### PR TITLE
chore: standardize block support declarations

### DIFF
--- a/src/Blocks/Layout/Columns/block.json
+++ b/src/Blocks/Layout/Columns/block.json
@@ -52,21 +52,7 @@
 	},
 	"supports": {
 		"align": ["wide", "full"],
-		"color": {
-			"text": false,
-			"background": false
-		},
-		"typography": {
-			"fontSize": false,
-			"fontFamily": false
-		},
-		"spacing": {
-			"margin": false,
-			"padding": false
-		},
-		"border": false,
 		"dimensions": {
-			"aspectRatio": false,
 			"minHeight": true
 		},
 		"background": {

--- a/src/Blocks/Layout/Grid/block.json
+++ b/src/Blocks/Layout/Grid/block.json
@@ -58,21 +58,7 @@
 	},
 	"supports": {
 		"align": ["wide", "full"],
-		"color": {
-			"text": false,
-			"background": false
-		},
-		"typography": {
-			"fontSize": false,
-			"fontFamily": false
-		},
-		"spacing": {
-			"margin": false,
-			"padding": false
-		},
-		"border": false,
 		"dimensions": {
-			"aspectRatio": false,
 			"minHeight": true
 		},
 		"background": {

--- a/src/Blocks/Layout/Group/block.json
+++ b/src/Blocks/Layout/Group/block.json
@@ -163,10 +163,6 @@
 			"text": true,
 			"background": true
 		},
-		"typography": {
-			"fontSize": false,
-			"fontFamily": false
-		},
 		"spacing": {
 			"margin": true,
 			"padding": true,
@@ -175,7 +171,6 @@
 		"border": true,
 		"shadow": true,
 		"dimensions": {
-			"aspectRatio": false,
 			"minHeight": true
 		},
 		"background": {

--- a/src/Blocks/Layout/Spacer/block.json
+++ b/src/Blocks/Layout/Spacer/block.json
@@ -24,7 +24,6 @@
 	},
 	"supports": {
 		"dimensions": {
-			"aspectRatio": false,
 			"minHeight": true
 		},
 		"anchor": true,

--- a/src/Blocks/Media/Gallery/block.json
+++ b/src/Blocks/Media/Gallery/block.json
@@ -74,19 +74,6 @@
 			"wide",
 			"full"
 		],
-		"color": {
-			"text": false,
-			"background": false
-		},
-		"typography": {
-			"fontSize": false,
-			"fontFamily": false
-		},
-		"spacing": {
-			"margin": false,
-			"padding": false
-		},
-		"border": false,
 		"htmlId": true,
 		"anchor": true,
 		"className": true

--- a/src/Blocks/Media/Image/block.json
+++ b/src/Blocks/Media/Image/block.json
@@ -89,23 +89,9 @@
 	},
 	"supports": {
 		"align": true,
-		"color": {
-			"text": false,
-			"background": false
-		},
-		"typography": {
-			"fontSize": false,
-			"fontFamily": false
-		},
-		"spacing": {
-			"margin": false,
-			"padding": false
-		},
-		"border": false,
 		"shadow": true,
 		"dimensions": {
-			"aspectRatio": true,
-			"minHeight": false
+			"aspectRatio": true
 		},
 		"htmlId": true,
 		"anchor": true,

--- a/src/Blocks/Media/Video/block.json
+++ b/src/Blocks/Media/Video/block.json
@@ -64,19 +64,6 @@
 	},
 	"supports": {
 		"align": ["wide", "full"],
-		"color": {
-			"text": false,
-			"background": false
-		},
-		"typography": {
-			"fontSize": false,
-			"fontFamily": false
-		},
-		"spacing": {
-			"margin": false,
-			"padding": false
-		},
-		"border": false,
 		"dimensions": {
 			"aspectRatio": true,
 			"minHeight": true

--- a/src/Blocks/Text/Heading/block.json
+++ b/src/Blocks/Text/Heading/block.json
@@ -80,8 +80,7 @@
 			"background": true
 		},
 		"typography": {
-			"fontSize": true,
-			"fontFamily": false
+			"fontSize": true
 		},
 		"spacing": {
 			"margin": true,


### PR DESCRIPTION
## Summary

Standardizes block support declarations across all 18 `block.json` files to use a consistent **opt-in only** convention. Since all defaults in `HasBlockSupports::getDefaultSupports()` are already `false`, blocks now only declare supports they explicitly enable — removing 77 lines of redundant `false` declarations.

Closes #133

## Changes

- **Heading** — removed redundant `typography.fontFamily: false`
- **Spacer** — removed redundant `dimensions.aspectRatio: false`
- **Columns** — removed redundant `false` values from `color`, `typography`, `spacing`, `border`, `dimensions`
- **Grid** — removed redundant `false` values from `color`, `typography`, `spacing`, `border`, `dimensions`
- **Group** — removed redundant `false` values from `typography`, `dimensions`
- **Gallery** — removed redundant `false` values from `color`, `typography`, `spacing`, `border`
- **Image** — removed redundant `false` values from `color`, `typography`, `spacing`, `border`, `dimensions`
- **Video** — removed redundant `false` values from `color`, `typography`, `spacing`, `border`

Blocks that were already following the opt-in convention (paragraph, list, quote, divider, column, grid-item, audio, file, code, button) required no changes.

## Testing

- All 811 existing tests pass (including block support tests that verify merged defaults)
- CodeRabbit review: no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified styling control options across multiple blocks (Columns, Grid, Group, Spacer, Gallery, Image, Video, and Heading).
  * Removed color, typography, spacing, and border styling controls from layout and media blocks.
  * Removed aspect ratio and dimension controls from several blocks.
  * Restricted font family configuration on Heading blocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->