### PR TITLE
enhancement: centralize sidebar/inserter state toggles via store methods

### DIFF
--- a/resources/views/components/_editor-canvas-content.blade.php
+++ b/resources/views/components/_editor-canvas-content.blade.php
@@ -2051,7 +2051,7 @@
 											<button
 												type="button"
 												class="w-full text-sm text-primary hover:text-primary-focus font-medium text-center py-1 rounded hover:bg-base-200 transition-colors"
-												x-on:click="inserterPopover.open = false; if ( Alpine.store( 'editor' ) ) { Alpine.store( 'editor' ).showInserter = true; }"
+												x-on:click="inserterPopover.open = false; if ( Alpine.store( 'editor' ) ) { Alpine.store( 'editor' ).openInserter(); }"
 											>
 												{{ __( 'Browse all' ) }}
 											</button>
@@ -2140,7 +2140,7 @@
 								<button
 									type="button"
 									class="w-full text-sm text-primary hover:text-primary-focus font-medium text-center py-1 rounded hover:bg-base-200 transition-colors"
-									x-on:click="innerInserterPopover.open = false; if ( Alpine.store( 'editor' ) ) { Alpine.store( 'editor' ).showInserter = true; }"
+									x-on:click="innerInserterPopover.open = false; if ( Alpine.store( 'editor' ) ) { Alpine.store( 'editor' ).openInserter(); }"
 								>
 									{{ __( 'Browse all' ) }}
 								</button>
@@ -2203,7 +2203,7 @@
 									<button
 										type="button"
 										class="w-full text-sm text-primary hover:text-primary-focus font-medium text-center py-1 rounded hover:bg-base-200 transition-colors"
-										x-on:click="inserterPopover.open = false; if ( Alpine.store( 'editor' ) ) { Alpine.store( 'editor' ).showInserter = true; }"
+										x-on:click="inserterPopover.open = false; if ( Alpine.store( 'editor' ) ) { Alpine.store( 'editor' ).openInserter(); }"
 									>
 										{{ __( 'Browse all' ) }}
 									</button>

--- a/resources/views/components/canvas-empty-state.blade.php
+++ b/resources/views/components/canvas-empty-state.blade.php
@@ -39,7 +39,7 @@
 	<button
 		type="button"
 		class="btn btn-primary btn-sm gap-2"
-		x-on:click="if ( Alpine.store( 'editor' ) ) { Alpine.store( 'editor' ).showInserter = true; }"
+		x-on:click="if ( Alpine.store( 'editor' ) ) { Alpine.store( 'editor' ).openInserter(); }"
 		aria-label="{{ $buttonLabel ?? __( 'visual-editor::ve.add_block' ) }}"
 	>
 		@if ( $icon )

--- a/resources/views/components/editor-state.blade.php
+++ b/resources/views/components/editor-state.blade.php
@@ -443,6 +443,24 @@
 					return this.blocks.length;
 				},
 
+				{{-- ── Sidebar / Inserter Toggles ────────────────────── --}}
+
+				toggleSidebar() {
+					this.showSidebar = ! this.showSidebar;
+				},
+
+				toggleInserter() {
+					this.showInserter = ! this.showInserter;
+				},
+
+				openInserter() {
+					this.showInserter = true;
+				},
+
+				closeInserter() {
+					this.showInserter = false;
+				},
+
 				{{-- ── Document Status ────────────────────────────────── --}}
 
 				setDocumentStatus( status ) {

--- a/resources/views/components/left-sidebar.blade.php
+++ b/resources/views/components/left-sidebar.blade.php
@@ -53,7 +53,7 @@
 		<button
 			type="button"
 			class="btn btn-ghost btn-sm btn-square mr-1"
-			x-on:click="if ( Alpine.store( 'editor' ) ) { Alpine.store( 'editor' ).showInserter = false; }"
+			x-on:click="if ( Alpine.store( 'editor' ) ) { Alpine.store( 'editor' ).closeInserter(); }"
 			:aria-label="{{ Js::from( __( 'visual-editor::ve.close_sidebar' ) ) }}"
 		>
 			<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" /></svg>

--- a/resources/views/components/top-toolbar.blade.php
+++ b/resources/views/components/top-toolbar.blade.php
@@ -29,7 +29,7 @@
 			<button
 				type="button"
 				class="btn btn-ghost btn-sm btn-square"
-				x-on:click="if ( Alpine.store( 'editor' ) ) { Alpine.store( 'editor' ).showInserter = ! Alpine.store( 'editor' ).showInserter; }"
+				x-on:click="if ( Alpine.store( 'editor' ) ) { Alpine.store( 'editor' ).toggleInserter(); }"
 				aria-label="{{ __( 'visual-editor::ve.toggle_inserter' ) }}"
 				:aria-pressed="Alpine.store( 'editor' ) ? Alpine.store( 'editor' ).showInserter : false"
 			>
@@ -99,7 +99,7 @@
 			<button
 				type="button"
 				class="btn btn-ghost btn-sm btn-square"
-				x-on:click="if ( Alpine.store( 'editor' ) ) { Alpine.store( 'editor' ).showSidebar = ! Alpine.store( 'editor' ).showSidebar; }"
+				x-on:click="if ( Alpine.store( 'editor' ) ) { Alpine.store( 'editor' ).toggleSidebar(); }"
 				aria-label="{{ __( 'visual-editor::ve.toggle_sidebar' ) }}"
 				:aria-pressed="Alpine.store( 'editor' ) ? Alpine.store( 'editor' ).showSidebar : false"
 			>

--- a/tests/Unit/Components/EditorStateTest.php
+++ b/tests/Unit/Components/EditorStateTest.php
@@ -251,6 +251,32 @@ test( 'editor state markSaved flushes pendingDirty to unsaved', function (): voi
 	$view->assertSee( 'if ( this._pendingDirty )', false );
 } );
 
+test( 'editor state renders toggleSidebar method', function (): void {
+	$view = $this->blade( '<x-ve-editor-state>Content</x-ve-editor-state>' );
+
+	$view->assertSee( 'toggleSidebar()', false );
+	$view->assertSee( 'this.showSidebar = ! this.showSidebar', false );
+} );
+
+test( 'editor state renders toggleInserter method', function (): void {
+	$view = $this->blade( '<x-ve-editor-state>Content</x-ve-editor-state>' );
+
+	$view->assertSee( 'toggleInserter()', false );
+	$view->assertSee( 'this.showInserter = ! this.showInserter', false );
+} );
+
+test( 'editor state renders openInserter method', function (): void {
+	$view = $this->blade( '<x-ve-editor-state>Content</x-ve-editor-state>' );
+
+	$view->assertSee( 'openInserter()', false );
+} );
+
+test( 'editor state renders closeInserter method', function (): void {
+	$view = $this->blade( '<x-ve-editor-state>Content</x-ve-editor-state>' );
+
+	$view->assertSee( 'closeInserter()', false );
+} );
+
 test( 'editor state re-initialization resets pendingDirty', function (): void {
 	$view = $this->blade( '<x-ve-editor-state>Content</x-ve-editor-state>' );
 

--- a/tests/Unit/Components/LeftSidebarTest.php
+++ b/tests/Unit/Components/LeftSidebarTest.php
@@ -85,5 +85,5 @@ test( 'left sidebar renders layers panel slot', function (): void {
 
 test( 'left sidebar renders close button', function (): void {
 	$this->blade( '<x-ve-left-sidebar />' )
-		->assertSee( 'showInserter = false', false );
+		->assertSee( 'closeInserter()', false );
 } );


### PR DESCRIPTION
## Summary

Evaluates and addresses the relationship between `showSidebar` and `showInserter` in `EditorState`.

**Finding:** These two booleans control independent panels — `showSidebar` manages the right inspector sidebar and `showInserter` manages the left block inserter sidebar. All four state combinations are valid, so consolidation is unnecessary.

**Fix:** Adds `toggleSidebar()`, `toggleInserter()`, `openInserter()`, and `closeInserter()` methods to the Alpine editor store and updates all template call sites to use them instead of direct property manipulation. This centralizes the logic so any future constraints can be added in one place.

Closes #134

## Changes

- Added 4 store methods: `toggleSidebar()`, `toggleInserter()`, `openInserter()`, `closeInserter()`
- Updated `top-toolbar.blade.php` to use `toggleInserter()` and `toggleSidebar()`
- Updated `left-sidebar.blade.php` to use `closeInserter()`
- Updated `canvas-empty-state.blade.php` to use `openInserter()`
- Updated `_editor-canvas-content.blade.php` (3 occurrences) to use `openInserter()`
- Added 4 unit tests verifying the new store methods render correctly
- Updated left sidebar close button test assertion

## Testing

- 4 new unit tests for the store methods
- Updated 1 existing test for left sidebar close button
- All 53 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced editor control methods with dedicated actions for opening, closing, and toggling the inserter panel visibility.
  * Added dedicated toggle method for sidebar visibility control.

* **Tests**
  * Added test coverage validating new editor control methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->