### PR TITLE
Rework template editor to full block editing experience (#162)

### DIFF
--- a/resources/lang/en/ve.php
+++ b/resources/lang/en/ve.php
@@ -209,6 +209,7 @@ return [
 	'toggle_sidebar'    => 'Toggle sidebar',
 	'save'              => 'Save',
 	'publish'           => 'Publish',
+	'drag_to_reorder'   => 'Drag to reorder',
 	'move_up'           => 'Move up',
 	'move_down'         => 'Move down',
 	'more_options'      => 'More options',
@@ -1094,4 +1095,43 @@ return [
 	'warning'                               => 'Warning',
 	'error'                                 => 'Error',
 	'info'                                  => 'Info',
+
+	// Template Editor
+	'template_editor'            => 'Template editor',
+	'template_untitled'          => 'Untitled Template',
+	'template_mode_switcher'     => 'Template mode switcher',
+	'template_editing_mode'      => 'Editing mode',
+	'template_mode_template'     => 'Template',
+	'template_mode_content'      => 'Content',
+	'template_mode_switched'     => 'Editing mode switched',
+	'template_preview'           => 'Template preview',
+	'template_preview_size'      => 'Preview size',
+
+	// Template Part Slots
+	'template_area_header'       => 'Header',
+	'template_area_footer'       => 'Footer',
+	'template_area_sidebar'      => 'Sidebar',
+	'template_area_custom'       => 'Custom',
+	'template_content_area'      => 'Content Area',
+	'template_edit_part'         => 'Edit Part',
+	'template_replace_part'      => 'Replace',
+	'template_clear_part'        => 'Remove',
+	'template_choose_part'       => 'Choose a :area template part',
+	'template_add_part'          => 'Add Template Part',
+	'template_select_part'       => 'Select a template part',
+	'template_no_parts_available' => 'No template parts available for this area.',
+	'template_part_assigned'     => 'Template part assigned',
+	'template_part_cleared'      => 'Template part removed',
+	'template_empty_slot'        => 'Empty',
+
+	// Template Switcher
+	'template_switcher'          => 'Template switcher',
+	'template_select'            => 'Select template',
+	'template_available_templates' => 'Available templates',
+	'template_no_templates'      => 'No templates available.',
+	'template_switched_to'       => 'Switched to :name template',
+
+	// Template Structure Panel
+	'template_structure'         => 'Template Structure',
+	'structure_tab'              => 'Structure',
 ];

--- a/resources/views/components/left-sidebar.blade.php
+++ b/resources/views/components/left-sidebar.blade.php
@@ -3,6 +3,7 @@
  *
  * Three-tab panel for Blocks, Patterns, and Layers.
  * Visibility is controlled by the editor store's showInserter property.
+ * Supports custom tabs via $customTabs prop.
  *
  * @package    ArtisanPack_UI
  * @subpackage VisualEditor\Views\Components
@@ -11,7 +12,7 @@
  --}}
 
 @php
-	$tabs = [
+	$tabs = ! empty( $customTabs ) ? $customTabs : [
 		[ 'slug' => 'blocks', 'label' => __( 'visual-editor::ve.blocks_tab' ) ],
 		[ 'slug' => 'patterns', 'label' => __( 'visual-editor::ve.patterns_tab' ) ],
 		[ 'slug' => 'layers', 'label' => __( 'visual-editor::ve.layers_tab' ) ],
@@ -96,5 +97,16 @@
 		aria-label="{{ __( 'visual-editor::ve.layers_tab' ) }}"
 	>
 		{{ $layersPanel ?? '' }}
+	</div>
+
+	{{-- Structure panel (used by template editor) --}}
+	<div
+		id="{{ $uuid }}-structure-panel"
+		x-show="'structure' === activeTab"
+		class="flex-1 overflow-y-auto"
+		role="tabpanel"
+		aria-label="{{ __( 'visual-editor::ve.template_structure' ) }}"
+	>
+		{{ $structurePanel ?? '' }}
 	</div>
 </div>

--- a/resources/views/components/template-editor.blade.php
+++ b/resources/views/components/template-editor.blade.php
@@ -1,0 +1,292 @@
+{{--
+ * Template Editor Component
+ *
+ * A full block editing experience for templates. Mirrors the Editor
+ * layout with template-specific features: template switcher in the
+ * toolbar, Structure tab in the left sidebar, and block-only inspector
+ * in the right sidebar (no Document tab).
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor\Views\Components
+ *
+ * @since      1.0.0
+ --}}
+
+{{-- Push editor styles (same CSS as the main editor) --}}
+@once
+@push( 'styles' )
+<style>
+	/* Contenteditable placeholder — show when block is empty and not focused */
+	[data-placeholder].ve-is-empty:not(:focus)::before {
+		content: attr(data-placeholder);
+		opacity: 0.4;
+		font-style: italic;
+		pointer-events: none;
+	}
+
+	/* Contenteditable placeholder for nested elements */
+	[contenteditable] > [data-placeholder].ve-is-empty::before {
+		content: attr(data-placeholder);
+		opacity: 0.4;
+		font-style: italic;
+		pointer-events: none;
+	}
+</style>
+@endpush
+@endonce
+
+{{-- State stores --}}
+<x-ve-editor-state
+	:initial-blocks="$initialBlocks"
+	:patterns="$patterns"
+	:block-transforms="$blockTransforms"
+	:block-variations="$blockVariations"
+	:autosave="$autosave"
+	:autosave-interval="$autosaveInterval"
+	document-status="draft"
+	:show-sidebar="$showSidebar"
+	:mode="$mode"
+	:default-inner-blocks-map="$defaultInnerBlocksMap"
+	:initial-meta="$initialMeta"
+/>
+<x-ve-selection-manager />
+<x-ve-aria-live-region />
+
+{{-- Keyboard shortcuts --}}
+<x-ve-keyboard-shortcuts :shortcuts="$editorShortcuts" :show-help-modal="false" />
+
+{{-- Pattern Modal (full-screen) --}}
+<x-ve-pattern-modal :patterns="$patternsWithPreviews" />
+
+{{-- Full-page editor layout --}}
+<div class="h-screen">
+	<x-ve-editor-layout sidebar-width="280px" left-sidebar-width="280px">
+
+		{{-- ============================================================ --}}
+		{{-- TOP TOOLBAR --}}
+		{{-- ============================================================ --}}
+		<x-slot:toolbar>
+			<x-ve-top-toolbar>
+				<x-slot:center>
+					<x-ve-template-switcher
+						:templates="$templates"
+						:current-slug="$currentTemplateSlug"
+					/>
+					{{ $toolbarCenter ?? '' }}
+				</x-slot:center>
+			</x-ve-top-toolbar>
+		</x-slot:toolbar>
+
+		{{-- ============================================================ --}}
+		{{-- LEFT SIDEBAR --}}
+		{{-- ============================================================ --}}
+		<x-slot:leftSidebar>
+			<x-ve-left-sidebar
+				:custom-tabs="[
+					[ 'slug' => 'blocks', 'label' => __( 'visual-editor::ve.blocks_tab' ) ],
+					[ 'slug' => 'patterns', 'label' => __( 'visual-editor::ve.patterns_tab' ) ],
+					[ 'slug' => 'structure', 'label' => __( 'visual-editor::ve.structure_tab' ) ],
+				]"
+				active-tab="blocks"
+			>
+				<x-slot:blocksPanel>
+					<x-ve-block-inserter :blocks="$inserterBlocks" :icon-renderer="$iconRenderer" />
+				</x-slot:blocksPanel>
+
+				<x-slot:patternsPanel>
+					<x-ve-pattern-browser :patterns="$patterns" />
+				</x-slot:patternsPanel>
+
+				<x-slot:structurePanel>
+					<x-ve-template-structure-panel :block-names="$blockNames" />
+				</x-slot:structurePanel>
+			</x-ve-left-sidebar>
+		</x-slot:leftSidebar>
+
+		{{-- ============================================================ --}}
+		{{-- CANVAS --}}
+		{{-- ============================================================ --}}
+		<x-slot:canvas>
+			{{-- Block toolbar - floats above selected block --}}
+			<x-ve-block-toolbar :show-move-controls="false">
+				{{-- Parent block navigation --}}
+				<template x-if="(() => {
+					if ( ! Alpine.store( 'selection' )?.focused || ! Alpine.store( 'editor' ) ) return false;
+					return !! Alpine.store( 'editor' ).getParentBlock( Alpine.store( 'selection' ).focused );
+				})()">
+					<div
+						x-data="{
+							parentBlockIcons: {{ Js::from( $toolbarBlockIcons ) }},
+							parentBlockNames: {{ Js::from( $blockNames ) }},
+
+							get parentBlock() {
+								const blockId = Alpine.store( 'selection' )?.focused;
+								if ( ! blockId || ! Alpine.store( 'editor' ) ) return null;
+								return Alpine.store( 'editor' ).getParentBlock( blockId );
+							},
+
+							selectParent() {
+								if ( this.parentBlock ) {
+									Alpine.store( 'selection' ).select( this.parentBlock.id );
+								}
+							},
+						}"
+						class="flex items-center"
+					>
+						<button
+							type="button"
+							class="btn btn-ghost btn-xs btn-square"
+							x-on:click="selectParent()"
+							:aria-label="'{{ __( 'visual-editor::ve.select_parent_block', [ 'name' => ':name' ] ) }}'.replace( ':name', parentBlockNames[ parentBlock?.type ] || parentBlock?.type || '' )"
+							:title="parentBlockNames[ parentBlock?.type ] || parentBlock?.type || ''"
+						>
+							<span class="w-4 h-4 flex items-center justify-center" x-html="parentBlockIcons[ parentBlock?.type ] || ''"></span>
+						</button>
+						<div class="w-px h-4 bg-base-300 mx-0.5" aria-hidden="true"></div>
+					</div>
+				</template>
+
+				{{-- Drag handle --}}
+				<button
+					type="button"
+					class="btn btn-ghost btn-xs btn-square cursor-grab active:cursor-grabbing"
+					aria-label="{{ __( 'visual-editor::ve.drag_to_reorder' ) }}"
+					draggable="true"
+				>
+					<svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" focusable="false">
+						<circle cx="9" cy="5" r="1.5" />
+						<circle cx="15" cy="5" r="1.5" />
+						<circle cx="9" cy="12" r="1.5" />
+						<circle cx="15" cy="12" r="1.5" />
+						<circle cx="9" cy="19" r="1.5" />
+						<circle cx="15" cy="19" r="1.5" />
+					</svg>
+				</button>
+
+				{{-- Move up / down --}}
+				<button
+					type="button"
+					class="btn btn-ghost btn-xs btn-square"
+					x-on:click="if ( Alpine.store( 'editor' ) && focusedBlockId ) { Alpine.store( 'editor' ).moveBlockUp( focusedBlockId ); }"
+					aria-label="{{ __( 'visual-editor::ve.move_up' ) }}"
+				>
+					<svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true" focusable="false">
+						<path stroke-linecap="round" stroke-linejoin="round" d="M4.5 15.75l7.5-7.5 7.5 7.5" />
+					</svg>
+				</button>
+				<button
+					type="button"
+					class="btn btn-ghost btn-xs btn-square"
+					x-on:click="if ( Alpine.store( 'editor' ) && focusedBlockId ) { Alpine.store( 'editor' ).moveBlockDown( focusedBlockId ); }"
+					aria-label="{{ __( 'visual-editor::ve.move_down' ) }}"
+				>
+					<svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true" focusable="false">
+						<path stroke-linecap="round" stroke-linejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
+					</svg>
+				</button>
+
+				<div class="w-px h-4 bg-base-300" aria-hidden="true"></div>
+
+				{{-- Block type icon + transform dropdown --}}
+				<div x-data="{
+					transformOpen: false,
+					blockIcons: {{ Js::from( $toolbarBlockIcons ) }},
+					blockNames: {{ Js::from( $transformableBlocks ) }},
+
+					get currentType() {
+						if ( ! Alpine.store( 'selection' )?.focused || ! Alpine.store( 'editor' ) ) return null;
+						const block = Alpine.store( 'editor' ).getBlock( Alpine.store( 'selection' ).focused );
+						return block?.type ?? null;
+					},
+
+					get availableTransforms() {
+						if ( ! this.currentType || ! Alpine.store( 'editor' ) ) return [];
+						return Alpine.store( 'editor' ).getTransformsForBlock( this.currentType );
+					},
+				}" class="relative">
+					<button
+						type="button"
+						class="btn btn-ghost btn-xs gap-1 px-1.5"
+						x-on:click="if ( availableTransforms.length > 0 ) { transformOpen = ! transformOpen; }"
+						:aria-expanded="transformOpen"
+						:disabled="availableTransforms.length === 0"
+						aria-label="{{ __( 'visual-editor::ve.transform_block' ) }}"
+					>
+						<span class="w-4 h-4 flex items-center justify-center" x-html="blockIcons[ currentType ] || blockIcons[ Object.keys( blockIcons )[ 0 ] ]"></span>
+						<svg x-show="availableTransforms.length > 0" class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
+							<path stroke-linecap="round" stroke-linejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
+						</svg>
+					</button>
+
+					<div
+						x-show="transformOpen && availableTransforms.length > 0"
+						x-on:click.outside="transformOpen = false"
+						x-transition
+						class="absolute left-0 top-full mt-1 w-48 rounded-lg border border-base-300 bg-base-100 shadow-lg py-1 z-50 max-h-64 overflow-y-auto"
+						role="menu"
+					>
+						<template x-for="targetType in availableTransforms" :key="targetType">
+							<button
+								type="button"
+								class="flex w-full items-center gap-2 px-3 py-1.5 text-sm hover:bg-base-200"
+								:class="targetType === currentType ? 'bg-primary/10 text-primary' : ''"
+								role="menuitem"
+								x-on:click="
+									Alpine.store( 'editor' ).transformBlock( Alpine.store( 'selection' ).focused, targetType );
+									transformOpen = false;
+								"
+							>
+								<span class="w-4 h-4 flex items-center justify-center shrink-0" x-html="blockIcons[ targetType ]"></span>
+								<span x-text="blockNames[ targetType ] || targetType"></span>
+							</button>
+						</template>
+					</div>
+				</div>
+
+				{{-- Custom toolbar HTML from blocks --}}
+				@foreach ( $customToolbarHtml as $toolbarType => $toolbarHtml )
+					<template x-if="(() => {
+						if ( ! Alpine.store( 'selection' )?.focused || ! Alpine.store( 'editor' ) ) return false;
+						const block = Alpine.store( 'editor' ).getBlock( Alpine.store( 'selection' ).focused );
+						return block?.type === {{ Js::from( $toolbarType ) }};
+					})()">
+						{!! $toolbarHtml !!}
+					</template>
+				@endforeach
+			</x-ve-block-toolbar>
+
+			{{-- Slash command inserter --}}
+			<x-ve-slash-command-inserter :blocks="$inserterBlocks" />
+
+			{{-- Dynamic canvas --}}
+			@include( 'visual-editor::components._editor-canvas-content' )
+		</x-slot:canvas>
+
+		{{-- ============================================================ --}}
+		{{-- RIGHT SIDEBAR (Block Inspector only, no Document tab) --}}
+		{{-- ============================================================ --}}
+		<x-slot:sidebar>
+			<x-ve-editor-sidebar :show-tabs="false">
+				<x-slot:settingsPanel>
+					@include( 'visual-editor::components._editor-inspector-settings' )
+				</x-slot:settingsPanel>
+
+				<x-slot:stylesPanel>
+					@include( 'visual-editor::components._editor-inspector-styles' )
+				</x-slot:stylesPanel>
+
+				<x-slot:documentPanel>
+					{{ $documentPanel ?? '' }}
+				</x-slot:documentPanel>
+			</x-ve-editor-sidebar>
+		</x-slot:sidebar>
+
+		<x-slot:statusbar>
+			<x-ve-status-bar />
+		</x-slot:statusbar>
+	</x-ve-editor-layout>
+</div>
+
+@if ( function_exists( 'doAction' ) )
+	@action('ap.visualEditor.templateEditor.rendered')
+@endif

--- a/resources/views/components/template-editor.blade.php
+++ b/resources/views/components/template-editor.blade.php
@@ -25,7 +25,7 @@
 	}
 
 	/* Contenteditable placeholder for nested elements */
-	[contenteditable] > [data-placeholder].ve-is-empty::before {
+	[contenteditable] > [data-placeholder].ve-is-empty:not(:focus)::before {
 		content: attr(data-placeholder);
 		opacity: 0.4;
 		font-style: italic;

--- a/resources/views/components/template-part-slot.blade.php
+++ b/resources/views/components/template-part-slot.blade.php
@@ -1,0 +1,175 @@
+{{--
+ * Template Part Slot Component
+ *
+ * A visual placeholder in the template canvas representing a template
+ * part area. Shows the assigned part content with an edit overlay,
+ * or a picker when empty.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor\Views\Components
+ *
+ * @since      1.0.0
+ --}}
+
+<div
+	id="{{ $uuid }}"
+	x-data="{
+		showPicker: false,
+		hovered: false,
+	}"
+	{{ $attributes->merge( [ 'class' => 'relative group border-2 border-dashed transition-colors' ] ) }}
+	:class="{
+		'border-primary/50 bg-primary/5': hovered && ! {{ Js::from( $isEditing ) }},
+		'border-base-300': ! hovered && ! {{ Js::from( $isEditing ) }},
+		'border-primary bg-primary/10': {{ Js::from( $isEditing ) }},
+	}"
+	x-on:mouseenter="hovered = true"
+	x-on:mouseleave="hovered = false"
+	role="region"
+	aria-label="{{ $label ?? $areaLabel() }}"
+	data-template-area="{{ $area }}"
+>
+	{{-- Area Label Badge --}}
+	<div class="absolute top-0 left-3 -translate-y-1/2 z-10">
+		<span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-base-100 border border-base-300 text-base-content/70 shadow-sm">
+			<svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
+				@if ( 'header' === $area )
+					<path stroke-linecap="round" stroke-linejoin="round" d="M3 4.5h18" />
+					<path stroke-linecap="round" stroke-linejoin="round" d="M3 9h18" />
+				@elseif ( 'footer' === $area )
+					<path stroke-linecap="round" stroke-linejoin="round" d="M3 15h18" />
+					<path stroke-linecap="round" stroke-linejoin="round" d="M3 19.5h18" />
+				@elseif ( 'sidebar' === $area )
+					<path stroke-linecap="round" stroke-linejoin="round" d="M3.75 3.75v4.5m0-4.5h4.5m-4.5 0L9 9M3.75 20.25v-4.5m0 4.5h4.5m-4.5 0L9 15M20.25 3.75h-4.5m4.5 0v4.5m0-4.5L15 9m5.25 11.25h-4.5m4.5 0v-4.5m0 4.5L15 15" />
+				@else
+					<path stroke-linecap="round" stroke-linejoin="round" d="m21 7.5-9-5.25L3 7.5m18 0-9 5.25m9-5.25v9l-9 5.25M3 7.5l9 5.25M3 7.5v9l9 5.25m0-9v9" />
+				@endif
+			</svg>
+			{{ $areaLabel() }}
+		</span>
+	</div>
+
+	@if ( $hasAssignment() )
+		{{-- Assigned Part Content --}}
+		<div class="p-4 pt-5">
+			<div class="text-sm text-base-content/60 mb-2">
+				{{ $assignedName ?? $assignedSlug }}
+			</div>
+
+			{{-- Part content slot --}}
+			{{ $slot }}
+		</div>
+
+		{{-- Hover Overlay with Actions --}}
+		<div
+			class="absolute inset-0 flex items-center justify-center gap-2 bg-base-100/80 backdrop-blur-sm opacity-0 group-hover:opacity-100 transition-opacity rounded"
+			x-show="! {{ Js::from( $isEditing ) }}"
+		>
+			@if ( ! $isLocked )
+				<button
+					type="button"
+					class="btn btn-primary btn-sm"
+					x-on:click="$dispatch( 've-template-part-edit', { slug: {{ Js::from( $assignedSlug ) }} } )"
+					aria-label="{{ __( 'visual-editor::ve.template_edit_part' ) }}"
+				>
+					<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+						<path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10" />
+					</svg>
+					{{ __( 'visual-editor::ve.template_edit_part' ) }}
+				</button>
+			@endif
+
+			<button
+				type="button"
+				class="btn btn-ghost btn-sm"
+				x-on:click="showPicker = true"
+				aria-label="{{ __( 'visual-editor::ve.template_replace_part' ) }}"
+			>
+				<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+					<path stroke-linecap="round" stroke-linejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182" />
+				</svg>
+				{{ __( 'visual-editor::ve.template_replace_part' ) }}
+			</button>
+
+			@if ( ! $isLocked )
+				<button
+					type="button"
+					class="btn btn-ghost btn-sm text-error"
+					x-on:click="$dispatch( 've-template-part-cleared', { area: {{ Js::from( $area ) }} } )"
+					aria-label="{{ __( 'visual-editor::ve.template_clear_part' ) }}"
+				>
+					<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+						<path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" />
+					</svg>
+				</button>
+			@endif
+		</div>
+	@else
+		{{-- Empty Slot: Part Picker --}}
+		<div class="p-6 pt-7 flex flex-col items-center justify-center text-center min-h-[80px]">
+			<p class="text-sm text-base-content/50 mb-3">
+				{{ __( 'visual-editor::ve.template_choose_part', [ 'area' => $areaLabel() ] ) }}
+			</p>
+
+			<button
+				type="button"
+				class="btn btn-outline btn-sm"
+				x-on:click="showPicker = ! showPicker"
+				:aria-expanded="showPicker ? 'true' : 'false'"
+			>
+				<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
+					<path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
+				</svg>
+				{{ __( 'visual-editor::ve.template_add_part' ) }}
+			</button>
+		</div>
+	@endif
+
+	{{-- Part Picker Dropdown --}}
+	<div
+		x-show="showPicker"
+		x-transition:enter="transition ease-out duration-150"
+		x-transition:enter-start="opacity-0 scale-95"
+		x-transition:enter-end="opacity-100 scale-100"
+		x-transition:leave="transition ease-in duration-100"
+		x-transition:leave-start="opacity-100 scale-100"
+		x-transition:leave-end="opacity-0 scale-95"
+		x-on:click.outside="showPicker = false"
+		x-on:keydown.escape.window="showPicker = false"
+		class="absolute left-3 right-3 bottom-full mb-1 z-20 bg-base-100 border border-base-300 rounded-lg shadow-lg max-h-60 overflow-y-auto"
+		x-cloak
+		role="listbox"
+		aria-label="{{ __( 'visual-editor::ve.template_select_part' ) }}"
+	>
+		@if ( ! empty( $availableParts ) )
+			@foreach ( $availableParts as $part )
+				<button
+					type="button"
+					class="w-full text-left px-3 py-2 text-sm hover:bg-base-200 transition-colors flex items-center justify-between first:rounded-t-lg last:rounded-b-lg"
+					x-on:click="$dispatch( 've-template-part-assigned', { area: {{ Js::from( $area ) }}, slug: {{ Js::from( $part['slug'] ?? '' ) }} } ); showPicker = false;"
+					role="option"
+				>
+					<div>
+						<div class="font-medium">{{ $part['name'] ?? $part['slug'] ?? '' }}</div>
+						@if ( ! empty( $part['description'] ) )
+							<div class="text-xs text-base-content/50 mt-0.5">{{ $part['description'] }}</div>
+						@endif
+					</div>
+					@if ( ( $part['slug'] ?? '' ) === $assignedSlug )
+						<svg class="w-4 h-4 text-primary shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
+							<path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" />
+						</svg>
+					@endif
+				</button>
+			@endforeach
+		@else
+			<div class="px-3 py-4 text-sm text-base-content/50 text-center">
+				{{ __( 'visual-editor::ve.template_no_parts_available' ) }}
+			</div>
+		@endif
+	</div>
+
+	@if ( function_exists( 'doAction' ) )
+		@action('ap.visualEditor.templatePartSlot.rendered', $area)
+	@endif
+</div>

--- a/resources/views/components/template-part-slot.blade.php
+++ b/resources/views/components/template-part-slot.blade.php
@@ -62,8 +62,14 @@
 
 		{{-- Hover Overlay with Actions --}}
 		<div
-			class="absolute inset-0 flex items-center justify-center gap-2 bg-base-100/80 backdrop-blur-sm opacity-0 group-hover:opacity-100 transition-opacity rounded"
-			x-show="! {{ Js::from( $isEditing ) }}"
+			class="absolute inset-0 flex items-center justify-center gap-2 bg-base-100/80 backdrop-blur-sm transition-opacity rounded"
+			x-show="hovered && ! {{ Js::from( $isEditing ) }}"
+			x-transition:enter="transition ease-out duration-150"
+			x-transition:enter-start="opacity-0"
+			x-transition:enter-end="opacity-100"
+			x-transition:leave="transition ease-in duration-100"
+			x-transition:leave-start="opacity-100"
+			x-transition:leave-end="opacity-0"
 		>
 			@if ( ! $isLocked )
 				<button
@@ -148,6 +154,7 @@
 					class="w-full text-left px-3 py-2 text-sm hover:bg-base-200 transition-colors flex items-center justify-between first:rounded-t-lg last:rounded-b-lg"
 					x-on:click="$dispatch( 've-template-part-assigned', { area: {{ Js::from( $area ) }}, slug: {{ Js::from( $part['slug'] ?? '' ) }} } ); showPicker = false;"
 					role="option"
+					aria-selected="{{ ( ( $part['slug'] ?? '' ) === $assignedSlug ) ? 'true' : 'false' }}"
 				>
 					<div>
 						<div class="font-medium">{{ $part['name'] ?? $part['slug'] ?? '' }}</div>

--- a/resources/views/components/template-structure-panel.blade.php
+++ b/resources/views/components/template-structure-panel.blade.php
@@ -1,0 +1,109 @@
+{{--
+ * Template Structure Panel Component
+ *
+ * Displays a hierarchical outline of the block tree in the
+ * left sidebar, reading blocks from the Alpine editor store.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor\Views\Components
+ *
+ * @since      1.0.0
+ --}}
+
+<div
+	id="{{ $uuid }}"
+	x-data="{
+		blockNames: {{ Js::from( $blockNames ) }},
+
+		get flatBlocks() {
+			const store = Alpine.store( 'editor' );
+			if ( ! store || ! store.blocks ) return [];
+			return this.flatten( store.blocks, 0 );
+		},
+
+		flatten( blocks, depth ) {
+			let result = [];
+			for ( const block of blocks ) {
+				const text = block.attributes?.text || block.attributes?.content || '';
+				const truncated = text.replace( /<[^>]*>/g, '' ).substring( 0, 40 );
+				result.push( {
+					id: block.id,
+					type: block.type,
+					depth: depth,
+					label: this.blockNames[ block.type ] || block.type,
+					preview: truncated,
+					hasChildren: block.innerBlocks && block.innerBlocks.length > 0,
+				} );
+				if ( block.innerBlocks && block.innerBlocks.length > 0 ) {
+					result = result.concat( this.flatten( block.innerBlocks, depth + 1 ) );
+				}
+			}
+			return result;
+		},
+
+		selectBlock( blockId ) {
+			if ( Alpine.store( 'selection' ) ) {
+				Alpine.store( 'selection' ).select( blockId );
+			}
+			const el = document.querySelector( '[data-block-id=\'' + CSS.escape( blockId ) + '\']' );
+			if ( el ) {
+				el.scrollIntoView( { behavior: 'smooth', block: 'center' } );
+			}
+		},
+
+		isSelected( blockId ) {
+			return Alpine.store( 'selection' )?.focused === blockId;
+		},
+	}"
+	{{ $attributes->merge( [ 'class' => 'flex flex-col h-full' ] ) }}
+	role="navigation"
+	aria-label="{{ $label ?? __( 'visual-editor::ve.template_structure' ) }}"
+>
+	{{-- Panel Header --}}
+	<div class="px-3 py-2 border-b border-base-300">
+		<h3 class="text-sm font-semibold text-base-content">
+			{{ __( 'visual-editor::ve.template_structure' ) }}
+		</h3>
+	</div>
+
+	{{-- Block Tree --}}
+	<div class="flex-1 overflow-y-auto py-1" role="tree" aria-label="{{ __( 'visual-editor::ve.template_structure' ) }}">
+		<template x-if="flatBlocks.length > 0">
+			<div>
+				<template x-for="item in flatBlocks" :key="item.id">
+					<button
+						type="button"
+						class="w-full flex items-center gap-2 px-3 py-1.5 text-sm hover:bg-base-200 transition-colors text-left"
+						:class="isSelected( item.id ) ? 'bg-primary/10 text-primary font-medium' : ''"
+						:style="{ paddingLeft: ( 12 + item.depth * 16 ) + 'px' }"
+						x-on:click="selectBlock( item.id )"
+						role="treeitem"
+						:aria-label="item.label"
+					>
+						<svg class="w-4 h-4 text-base-content/50 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+							<path stroke-linecap="round" stroke-linejoin="round" d="m21 7.5-9-5.25L3 7.5m18 0-9 5.25m9-5.25v9l-9 5.25M3 7.5l9 5.25M3 7.5v9l9 5.25m0-9v9" />
+						</svg>
+						<span class="flex-1 min-w-0">
+							<span class="block truncate" x-text="item.label"></span>
+							<span
+								x-show="item.preview"
+								class="block text-xs text-base-content/40 truncate"
+								x-text="item.preview"
+							></span>
+						</span>
+					</button>
+				</template>
+			</div>
+		</template>
+
+		<template x-if="flatBlocks.length === 0">
+			<div class="px-3 py-8 text-center text-sm text-base-content/40">
+				{{ __( 'visual-editor::ve.empty_canvas_description' ) }}
+			</div>
+		</template>
+	</div>
+
+	@if ( function_exists( 'doAction' ) )
+		@action('ap.visualEditor.templateStructurePanel.rendered')
+	@endif
+</div>

--- a/resources/views/components/template-switcher.blade.php
+++ b/resources/views/components/template-switcher.blade.php
@@ -1,0 +1,115 @@
+{{--
+ * Template Switcher Component
+ *
+ * Dropdown for selecting and switching between available templates
+ * in the editor toolbar.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor\Views\Components
+ *
+ * @since      1.0.0
+ --}}
+
+<div
+	id="{{ $uuid }}"
+	x-data="{
+		open: false,
+		currentSlug: {{ Js::from( $currentSlug ) }},
+		templates: {{ Js::from( $templates ) }},
+
+		get currentName() {
+			const tpl = this.templates.find( ( t ) => t.slug === this.currentSlug );
+			return tpl ? tpl.name : {{ Js::from( __( 'visual-editor::ve.template_select' ) ) }};
+		},
+
+		selectTemplate( slug ) {
+			this.currentSlug = slug;
+			this.open = false;
+			this.$dispatch( 've-template-switched', { slug: slug } );
+
+			if ( Alpine.store( 'announcer' ) ) {
+				const tpl = this.templates.find( ( t ) => t.slug === slug );
+				Alpine.store( 'announcer' ).announce(
+					{{ Js::from( __( 'visual-editor::ve.template_switched_to', [ 'name' => '__NAME__' ] ) ) }}.replace( '__NAME__', () => tpl ? tpl.name : slug )
+				);
+			}
+		},
+	}"
+	{{ $attributes->merge( [ 'class' => 'relative' ] ) }}
+>
+	{{-- Trigger Button --}}
+	<button
+		type="button"
+		class="btn btn-ghost btn-sm gap-1"
+		x-on:click="open = ! open"
+		:aria-expanded="open ? 'true' : 'false'"
+		aria-haspopup="listbox"
+		aria-label="{{ $label ?? __( 'visual-editor::ve.template_switcher' ) }}"
+	>
+		<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+			<path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6A2.25 2.25 0 0 1 6 3.75h2.25A2.25 2.25 0 0 1 10.5 6v2.25a2.25 2.25 0 0 1-2.25 2.25H6a2.25 2.25 0 0 1-2.25-2.25V6ZM3.75 15.75A2.25 2.25 0 0 1 6 13.5h2.25a2.25 2.25 0 0 1 2.25 2.25V18a2.25 2.25 0 0 1-2.25 2.25H6A2.25 2.25 0 0 1 3.75 18v-2.25ZM13.5 6a2.25 2.25 0 0 1 2.25-2.25H18A2.25 2.25 0 0 1 20.25 6v2.25A2.25 2.25 0 0 1 18 10.5h-2.25a2.25 2.25 0 0 1-2.25-2.25V6ZM13.5 15.75a2.25 2.25 0 0 1 2.25-2.25H18a2.25 2.25 0 0 1 2.25 2.25V18A2.25 2.25 0 0 1 18 20.25h-2.25a2.25 2.25 0 0 1-2.25-2.25v-2.25Z" />
+		</svg>
+		<span x-text="currentName" class="max-w-[150px] truncate"></span>
+		<svg class="w-3 h-3 transition-transform" :class="open ? 'rotate-180' : ''" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
+			<path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" />
+		</svg>
+	</button>
+
+	{{-- Dropdown List --}}
+	<div
+		x-show="open"
+		x-transition:enter="transition ease-out duration-150"
+		x-transition:enter-start="opacity-0 -translate-y-1"
+		x-transition:enter-end="opacity-100 translate-y-0"
+		x-transition:leave="transition ease-in duration-100"
+		x-transition:leave-start="opacity-100 translate-y-0"
+		x-transition:leave-end="opacity-0 -translate-y-1"
+		x-on:click.outside="open = false"
+		x-on:keydown.escape.window="open = false"
+		class="absolute top-full left-0 mt-1 z-50 w-64 bg-base-100 border border-base-300 rounded-lg shadow-lg max-h-72 overflow-y-auto"
+		x-cloak
+		role="listbox"
+		aria-label="{{ __( 'visual-editor::ve.template_available_templates' ) }}"
+	>
+		<template x-for="tpl in templates" :key="tpl.slug">
+			<button
+				type="button"
+				class="w-full text-left px-3 py-2 text-sm hover:bg-base-200 transition-colors flex items-center justify-between first:rounded-t-lg last:rounded-b-lg"
+				:class="tpl.slug === currentSlug ? 'bg-base-200' : ''"
+				x-on:click="selectTemplate( tpl.slug )"
+				role="option"
+				:aria-selected="tpl.slug === currentSlug ? 'true' : 'false'"
+			>
+				<div class="min-w-0">
+					<div class="font-medium truncate" x-text="tpl.name"></div>
+					<div
+						x-show="tpl.description"
+						class="text-xs text-base-content/50 mt-0.5 truncate"
+						x-text="tpl.description"
+					></div>
+				</div>
+				<svg
+					x-show="tpl.slug === currentSlug"
+					class="w-4 h-4 text-primary shrink-0 ml-2"
+					fill="none"
+					viewBox="0 0 24 24"
+					stroke="currentColor"
+					stroke-width="2"
+					aria-hidden="true"
+				>
+					<path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" />
+				</svg>
+			</button>
+		</template>
+
+		<template x-if="0 === templates.length">
+			<div class="px-3 py-4 text-sm text-base-content/50 text-center">
+				{{ __( 'visual-editor::ve.template_no_templates' ) }}
+			</div>
+		</template>
+	</div>
+
+	@if ( function_exists( 'doAction' ) )
+		@action('ap.visualEditor.templateSwitcher.rendered')
+	@endif
+</div>

--- a/resources/views/components/template-switcher.blade.php
+++ b/resources/views/components/template-switcher.blade.php
@@ -30,7 +30,7 @@
 			if ( Alpine.store( 'announcer' ) ) {
 				const tpl = this.templates.find( ( t ) => t.slug === slug );
 				Alpine.store( 'announcer' ).announce(
-					{{ Js::from( __( 'visual-editor::ve.template_switched_to', [ 'name' => '__NAME__' ] ) ) }}.replace( '__NAME__', () => tpl ? tpl.name : slug )
+					{{ Js::from( __( 'visual-editor::ve.template_switched_to', [ 'name' => '__NAME__' ] ) ) }}.replace( '__NAME__', tpl ? tpl.name : slug )
 				);
 			}
 		},
@@ -42,7 +42,7 @@
 		type="button"
 		class="btn btn-ghost btn-sm gap-1"
 		x-on:click="open = ! open"
-		:aria-expanded="open ? 'true' : 'false'"
+		:aria-expanded="open"
 		aria-haspopup="listbox"
 		aria-label="{{ $label ?? __( 'visual-editor::ve.template_switcher' ) }}"
 	>

--- a/src/View/Components/Concerns/BuildsBlockRegistryData.php
+++ b/src/View/Components/Concerns/BuildsBlockRegistryData.php
@@ -315,6 +315,7 @@ trait BuildsBlockRegistryData
 			}
 		}
 
+		// External transforms override registry-defined ones (intentional).
 		$this->blockTransforms = array_merge( $registryTransforms, $this->blockTransforms );
 	}
 

--- a/src/View/Components/Concerns/BuildsBlockRegistryData.php
+++ b/src/View/Components/Concerns/BuildsBlockRegistryData.php
@@ -1,0 +1,348 @@
+<?php
+
+/**
+ * Builds Block Registry Data Trait.
+ *
+ * Extracts shared block registry initialization logic used by both
+ * the Editor and TemplateEditor components. Each method populates
+ * public properties on the consuming class from the BlockRegistry.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor\View\Components\Concerns
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\View\Components\Concerns;
+
+use ArtisanPackUI\VisualEditor\Blocks\BlockRegistry;
+use ArtisanPackUI\VisualEditor\View\Components\Icon;
+use Closure;
+
+/**
+ * Trait for building block registry data arrays.
+ *
+ * Classes using this trait must declare the following public properties:
+ * - $initialBlocks, $patterns, $blockTransforms, $blockVariations
+ * - $iconRenderer (Closure)
+ * - $inserterBlocks, $renderedBlocks, $defaultBlockTemplates, $blockMetadata
+ * - $inspectorBlockNames, $inspectorBlockDescriptions, $inspectorBlockTypes
+ * - $toolbarBlockIcons, $transformableBlocks, $blockNames, $blockAlignSupports
+ * - $customToolbarHtml, $editorShortcuts, $patternsWithPreviews
+ * - $defaultInnerBlocksMap
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor\View\Components\Concerns
+ *
+ * @since      1.0.0
+ */
+trait BuildsBlockRegistryData
+{
+	/**
+	 * Create the default icon renderer.
+	 *
+	 * Uses inline SVGs to avoid dependency on livewire-ui-components
+	 * in the package views (which causes test failures).
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return Closure
+	 */
+	protected function defaultIconRenderer(): Closure
+	{
+		return function ( string $iconName ): string {
+			$fallback = '<svg class="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="m21 7.5-9-5.25L3 7.5m18 0-9 5.25m9-5.25v9l-9 5.25M3 7.5l9 5.25M3 7.5v9l9 5.25m0-9v9" /></svg>';
+
+			if ( '_default' === $iconName ) {
+				return $fallback;
+			}
+
+			if ( 'heading' === $iconName ) {
+				return '<svg class="w-5 h-5" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><text x="50%" y="50%" dominant-baseline="central" text-anchor="middle" font-size="16" font-weight="700" font-family="system-ui, sans-serif">H</text></svg>';
+			}
+
+			$svgMap = Icon::getSvgMap();
+
+			if ( isset( $svgMap[ $iconName ] ) ) {
+				return str_replace( '<svg ', '<svg class="w-5 h-5" ', $svgMap[ $iconName ] );
+			}
+
+			// Try without common prefixes (o-, s-, fa-).
+			$stripped = (string) preg_replace( '/^(o-|s-|fa-)/', '', $iconName );
+			if ( $stripped !== $iconName && isset( $svgMap[ $stripped ] ) ) {
+				return str_replace( '<svg ', '<svg class="w-5 h-5" ', $svgMap[ $stripped ] );
+			}
+
+			return $fallback;
+		};
+	}
+
+	/**
+	 * Build the inserter blocks from the registry.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param BlockRegistry $registry The block registry instance.
+	 *
+	 * @return void
+	 */
+	protected function buildInserterBlocks( BlockRegistry $registry ): void
+	{
+		$this->inserterBlocks = collect( $registry->all() )
+			->filter( fn ( $block ) => $block->isPublic() )
+			->map( fn ( $block ) => [
+				'name'               => $block->getType(),
+				'label'              => $block->getName(),
+				'icon'               => $block->getIcon(),
+				'category'           => $block->getCategory(),
+				'description'        => $block->getDescription(),
+				'keywords'           => $block->getKeywords(),
+				'defaultInnerBlocks' => $block->getDefaultInnerBlocks(),
+			] )
+			->values()
+			->all();
+
+		$this->defaultInnerBlocksMap = collect( $registry->all() )
+			->filter( fn ( $block ) => [] !== $block->getDefaultInnerBlocks() )
+			->mapWithKeys( fn ( $block ) => [ $block->getType() => $block->getDefaultInnerBlocks() ] )
+			->all();
+	}
+
+	/**
+	 * Pre-render initial blocks for the canvas.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param BlockRegistry $registry The block registry instance.
+	 *
+	 * @return void
+	 */
+	protected function buildRenderedBlocks( BlockRegistry $registry ): void
+	{
+		$this->renderedBlocks = [];
+
+		foreach ( $this->initialBlocks as $block ) {
+			if ( ! is_array( $block ) || ! isset( $block['id'], $block['type'] ) || ! is_string( $block['id'] ) || ! is_string( $block['type'] ) ) {
+				continue;
+			}
+
+			$blockType = $registry->get( $block['type'] );
+			if ( $blockType ) {
+				$this->renderedBlocks[ $block['id'] ] = $blockType->renderEditor(
+					$block['attributes'] ?? [],
+					$block['styles'] ?? [],
+				);
+			}
+		}
+	}
+
+	/**
+	 * Pre-render default block templates for each registered type.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param BlockRegistry $registry The block registry instance.
+	 *
+	 * @return void
+	 */
+	protected function buildDefaultBlockTemplates( BlockRegistry $registry ): void
+	{
+		$this->defaultBlockTemplates = [];
+
+		foreach ( $registry->all() as $type => $block ) {
+			$defaultContent = [];
+			foreach ( $block->getContentSchema() as $key => $field ) {
+				$defaultContent[ $key ] = $field['default'] ?? '';
+			}
+
+			$this->defaultBlockTemplates[ $type ] = $block->renderEditor( $defaultContent, [] );
+		}
+	}
+
+	/**
+	 * Build block metadata for the JavaScript renderer registry.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param BlockRegistry $registry The block registry instance.
+	 *
+	 * @return void
+	 */
+	protected function buildBlockMetadata( BlockRegistry $registry ): void
+	{
+		$this->blockMetadata = $registry->toArray();
+	}
+
+	/**
+	 * Build inspector data (block names, descriptions, types).
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param BlockRegistry $registry The block registry instance.
+	 *
+	 * @return void
+	 */
+	protected function buildInspectorData( BlockRegistry $registry ): void
+	{
+		$this->inspectorBlockNames        = [];
+		$this->inspectorBlockDescriptions = [];
+		$this->inspectorBlockTypes        = [];
+
+		foreach ( $registry->all() as $type => $block ) {
+			$this->inspectorBlockNames[ $type ]        = $block->getName();
+			$this->inspectorBlockDescriptions[ $type ] = $block->getDescription();
+			$this->inspectorBlockTypes[]               = $type;
+		}
+	}
+
+	/**
+	 * Build toolbar icons and transformable block data.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param BlockRegistry $registry The block registry instance.
+	 *
+	 * @return void
+	 */
+	protected function buildToolbarData( BlockRegistry $registry ): void
+	{
+		$this->toolbarBlockIcons   = [];
+		$this->transformableBlocks = [];
+		$this->blockNames          = [];
+		$iconRenderer              = $this->iconRenderer;
+
+		foreach ( $registry->all() as $type => $block ) {
+			$this->toolbarBlockIcons[ $type ] = $iconRenderer( $block->getIcon() );
+			$this->blockNames[ $type ]        = $block->getName();
+
+			if ( $block->isPublic() ) {
+				$this->transformableBlocks[ $type ] = $block->getName();
+			}
+		}
+	}
+
+	/**
+	 * Build block alignment support data.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param BlockRegistry $registry The block registry instance.
+	 *
+	 * @return void
+	 */
+	protected function buildAlignmentData( BlockRegistry $registry ): void
+	{
+		$this->blockAlignSupports = [];
+
+		foreach ( $registry->all() as $type => $block ) {
+			$alignments = $block->getSupportedAlignments();
+			if ( ! empty( $alignments ) ) {
+				$this->blockAlignSupports[ $type ] = $alignments;
+			}
+		}
+	}
+
+	/**
+	 * Build custom toolbar HTML from blocks.
+	 *
+	 * Custom inspector HTML is rendered directly by the inspector-controls
+	 * component via renderInspector(), so it does not need pre-rendering here.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param BlockRegistry $registry The block registry instance.
+	 *
+	 * @return void
+	 */
+	protected function buildCustomPanels( BlockRegistry $registry ): void
+	{
+		$this->customToolbarHtml = [];
+
+		foreach ( $registry->all() as $type => $block ) {
+			if ( $block->hasCustomToolbar() ) {
+				$this->customToolbarHtml[ $type ] = $block->renderToolbar();
+			}
+		}
+	}
+
+	/**
+	 * Build the default keyboard shortcuts.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	protected function buildEditorShortcuts(): void
+	{
+		$this->editorShortcuts = [
+			[ 'name' => 'undo', 'keys' => 'mod+z', 'description' => __( 'visual-editor::ve.undo_action' ), 'category' => 'global' ],
+			[ 'name' => 'redo', 'keys' => 'mod+shift+z', 'description' => __( 'visual-editor::ve.redo_action' ), 'category' => 'global' ],
+			[ 'name' => 'save', 'keys' => 'mod+s', 'description' => __( 'visual-editor::ve.save' ), 'category' => 'global' ],
+			[ 'name' => 'delete-block', 'keys' => 'mod+shift+d', 'description' => __( 'visual-editor::ve.delete_block' ), 'category' => 'block' ],
+			[ 'name' => 'duplicate-block', 'keys' => 'mod+d', 'description' => __( 'visual-editor::ve.duplicate_block' ), 'category' => 'block' ],
+			[ 'name' => 'move-up', 'keys' => 'mod+shift+up', 'description' => __( 'visual-editor::ve.move_up' ), 'category' => 'block' ],
+			[ 'name' => 'move-down', 'keys' => 'mod+shift+down', 'description' => __( 'visual-editor::ve.move_down' ), 'category' => 'block' ],
+			[ 'name' => 'select-all', 'keys' => 'mod+a', 'description' => __( 'visual-editor::ve.select_all' ), 'category' => 'selection' ],
+			[ 'name' => 'deselect', 'keys' => 'escape', 'description' => __( 'visual-editor::ve.deselect' ), 'category' => 'selection' ],
+			[ 'name' => 'toggle-inserter', 'keys' => 'mod+/', 'description' => __( 'visual-editor::ve.toggle_inserter' ), 'category' => 'navigation' ],
+		];
+	}
+
+	/**
+	 * Build block transforms from the registry.
+	 *
+	 * Collects transform mappings defined by each block's getTransforms()
+	 * method and merges them with any externally provided transforms.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param BlockRegistry $registry The block registry instance.
+	 *
+	 * @return void
+	 */
+	protected function buildBlockTransforms( BlockRegistry $registry ): void
+	{
+		$registryTransforms = [];
+
+		foreach ( $registry->all() as $type => $block ) {
+			$transforms = $block->getTransforms();
+			if ( ! empty( $transforms ) ) {
+				$registryTransforms[ $type ] = $transforms;
+			}
+		}
+
+		$this->blockTransforms = array_merge( $registryTransforms, $this->blockTransforms );
+	}
+
+	/**
+	 * Build patterns with preview images.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	protected function buildPatternsWithPreviews(): void
+	{
+		$this->patternsWithPreviews = array_map( function ( $pattern ): array {
+			if ( ! is_array( $pattern ) ) {
+				return [];
+			}
+
+			if ( ! isset( $pattern['preview'] ) ) {
+				$name               = e( $pattern['name'] ?? '' );
+				$pattern['preview'] = 'data:image/svg+xml,' . rawurlencode(
+					'<svg xmlns="http://www.w3.org/2000/svg" width="400" height="200">'
+					. '<rect width="400" height="200" fill="#e2e8f0"/>'
+					. '<text x="200" y="105" text-anchor="middle" font-family="system-ui,sans-serif" font-size="16" fill="#64748b">' . $name . '</text>'
+					. '</svg>',
+				);
+			}
+
+			return $pattern;
+		}, $this->patterns );
+	}
+}

--- a/src/View/Components/EditorState.php
+++ b/src/View/Components/EditorState.php
@@ -43,6 +43,7 @@ class EditorState extends Component
 	public const MODES = [
 		'visual',
 		'code',
+		'template',
 	];
 
 	/**

--- a/src/View/Components/LeftSidebar.php
+++ b/src/View/Components/LeftSidebar.php
@@ -60,21 +60,28 @@ class LeftSidebar extends Component
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param string|null $id        Optional custom ID.
-	 * @param string|null $label     Accessible label. Defaults to translation.
-	 * @param string      $activeTab Initially active tab: blocks, patterns, or layers.
-	 * @param string      $width     CSS width for the sidebar.
+	 * @param string|null                        $id         Optional custom ID.
+	 * @param string|null                        $label      Accessible label. Defaults to translation.
+	 * @param string                             $activeTab  Initially active tab: blocks, patterns, or layers.
+	 * @param string                             $width      CSS width for the sidebar.
+	 * @param array<int, array<string, string>>  $customTabs Custom tab definitions to replace the defaults.
 	 */
 	public function __construct(
 		public ?string $id = null,
 		public ?string $label = null,
 		public string $activeTab = 'blocks',
 		public string $width = '280px',
+		public array $customTabs = [],
 	) {
 		$this->uuid = 've-' . Str::random( 8 ) . ( $id ? '-' . $id : '' );
 
-		if ( ! in_array( $this->activeTab, self::TABS, true ) ) {
-			$this->activeTab = 'blocks';
+		// Validate activeTab against default tabs or custom tab slugs.
+		$validSlugs = ! empty( $this->customTabs )
+			? array_column( $this->customTabs, 'slug' )
+			: self::TABS;
+
+		if ( ! in_array( $this->activeTab, $validSlugs, true ) ) {
+			$this->activeTab = $validSlugs[0] ?? 'blocks';
 		}
 	}
 

--- a/src/View/Components/TemplateEditor.php
+++ b/src/View/Components/TemplateEditor.php
@@ -219,6 +219,7 @@ class TemplateEditor extends Component
 	 * @param bool          $showSidebar         Show sidebar by default.
 	 * @param string        $mode                Editor mode (visual/code).
 	 * @param Closure|null  $customIconRenderer  Optional custom icon renderer.
+	 * @param string        $featuredImageUrl    Optional featured image URL for the Cover block placeholder.
 	 * @param array<string, mixed> $initialMeta  Initial meta key-value pairs.
 	 * @param array<int, array<string, string>> $templates  Available templates for the switcher.
 	 * @param string        $currentTemplateSlug The currently active template slug.
@@ -234,11 +235,17 @@ class TemplateEditor extends Component
 		public bool $showSidebar = true,
 		public string $mode = 'visual',
 		?Closure $customIconRenderer = null,
+		public string $featuredImageUrl = '',
 		public array $initialMeta = [],
 		public array $templates = [],
 		public string $currentTemplateSlug = '',
 	) {
 		$this->uuid = 've-tpl-editor-' . Str::random( 8 ) . ( $id ? '-' . $id : '' );
+
+		// Resolve featured image URL via hook if not explicitly provided.
+		if ( '' === $this->featuredImageUrl ) {
+			$this->featuredImageUrl = (string) veApplyFilters( 've.editor.featured_image_url', '' );
+		}
 
 		/** @var BlockRegistry $registry */
 		$registry = app( 'visual-editor.blocks' );

--- a/src/View/Components/TemplateEditor.php
+++ b/src/View/Components/TemplateEditor.php
@@ -1,12 +1,12 @@
 <?php
 
 /**
- * Editor Component.
+ * Template Editor Component.
  *
- * The high-level orchestration component that assembles the complete
- * visual editor experience. Composes all sub-components (layout, canvas,
- * sidebar, toolbar, inserter, inspector, layers) and wires them together
- * with block rendering, drag-and-drop, and the block renderer registry.
+ * Provides a full block editing experience for templates. Reuses the
+ * same sub-components as the Editor (canvas, sidebar, toolbar, inserter,
+ * inspector, layers) but is tailored for template editing with a
+ * template switcher and structure panel.
  *
  * @package    ArtisanPack_UI
  * @subpackage VisualEditor\View\Components
@@ -28,15 +28,18 @@ use Illuminate\Support\Str;
 use Illuminate\View\Component;
 
 /**
- * Editor component providing the complete visual editor UI.
+ * Template Editor component for full block-based template editing.
+ *
+ * Mirrors the Editor component layout but with template-specific
+ * features: a template switcher in the toolbar, a Structure tab
+ * in the left sidebar (instead of Layers), and no Document tab
+ * in the right sidebar.
  *
  * Usage:
- *   <x-ve-editor
+ *   <x-ve-template-editor
  *       :initial-blocks="$blocks"
- *       :patterns="$patterns"
- *       :autosave="true"
- *       :autosave-interval="30"
- *       document-status="draft"
+ *       :templates="$templates"
+ *       current-template-slug="default-page"
  *   />
  *
  * @package    ArtisanPack_UI
@@ -44,7 +47,7 @@ use Illuminate\View\Component;
  *
  * @since      1.0.0
  */
-class Editor extends Component
+class TemplateEditor extends Component
 {
 	use BuildsBlockRegistryData;
 
@@ -186,9 +189,6 @@ class Editor extends Component
 	/**
 	 * Default inner blocks keyed by block type.
 	 *
-	 * Allows the editor store to auto-populate inner blocks
-	 * when a block is added from any insertion path.
-	 *
 	 * @since 1.0.0
 	 *
 	 * @var array<string, array<int, array<string, mixed>>>
@@ -209,19 +209,19 @@ class Editor extends Component
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param string|null  $id               Optional custom ID.
-	 * @param array<mixed> $initialBlocks    Block data to populate the editor.
-	 * @param array<mixed> $patterns         Pattern definitions for the pattern browser.
-	 * @param array<mixed> $blockTransforms  Transform mappings between block types.
-	 * @param array<mixed> $blockVariations  Variation definitions for blocks.
-	 * @param bool         $autosave         Enable autosave.
-	 * @param int          $autosaveInterval Autosave interval in seconds.
-	 * @param string       $documentStatus   Initial document status.
-	 * @param bool         $showSidebar      Show sidebar by default.
-	 * @param string       $mode             Editor mode (visual/code).
-	 * @param Closure|null $customIconRenderer  Optional custom icon renderer.
-	 * @param string       $featuredImageUrl    Optional featured image URL for the Cover block placeholder.
-	 * @param array<string, mixed> $initialMeta Initial meta key-value pairs for document panel fields.
+	 * @param string|null   $id                  Optional custom ID.
+	 * @param array<mixed>  $initialBlocks       Block data to populate the editor.
+	 * @param array<mixed>  $patterns            Pattern definitions for the pattern browser.
+	 * @param array<mixed>  $blockTransforms     Transform mappings between block types.
+	 * @param array<mixed>  $blockVariations     Variation definitions for blocks.
+	 * @param bool          $autosave            Enable autosave.
+	 * @param int           $autosaveInterval    Autosave interval in seconds.
+	 * @param bool          $showSidebar         Show sidebar by default.
+	 * @param string        $mode                Editor mode (visual/code).
+	 * @param Closure|null  $customIconRenderer  Optional custom icon renderer.
+	 * @param array<string, mixed> $initialMeta  Initial meta key-value pairs.
+	 * @param array<int, array<string, string>> $templates  Available templates for the switcher.
+	 * @param string        $currentTemplateSlug The currently active template slug.
 	 */
 	public function __construct(
 		public ?string $id = null,
@@ -231,19 +231,14 @@ class Editor extends Component
 		public array $blockVariations = [],
 		public bool $autosave = false,
 		public int $autosaveInterval = 60,
-		public string $documentStatus = 'draft',
 		public bool $showSidebar = true,
 		public string $mode = 'visual',
 		?Closure $customIconRenderer = null,
-		public string $featuredImageUrl = '',
 		public array $initialMeta = [],
+		public array $templates = [],
+		public string $currentTemplateSlug = '',
 	) {
-		$this->uuid = 've-editor-' . Str::random( 8 ) . ( $id ? '-' . $id : '' );
-
-		// Resolve featured image URL via hook if not explicitly provided.
-		if ( '' === $this->featuredImageUrl ) {
-			$this->featuredImageUrl = (string) veApplyFilters( 've.editor.featured_image_url', '' );
-		}
+		$this->uuid = 've-tpl-editor-' . Str::random( 8 ) . ( $id ? '-' . $id : '' );
 
 		/** @var BlockRegistry $registry */
 		$registry = app( 'visual-editor.blocks' );
@@ -272,6 +267,6 @@ class Editor extends Component
 	 */
 	public function render(): View|Closure|string
 	{
-		return view( 'visual-editor::components.editor' );
+		return view( 'visual-editor::components.template-editor' );
 	}
 }

--- a/src/View/Components/TemplatePartSlot.php
+++ b/src/View/Components/TemplatePartSlot.php
@@ -1,0 +1,133 @@
+<?php
+
+/**
+ * Template Part Slot Component.
+ *
+ * A visual placeholder in the template canvas representing a template
+ * part area (header, footer, sidebar, custom). Shows the assigned part
+ * content and provides an overlay for selecting or editing the part.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor\View\Components
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\View\Components;
+
+use ArtisanPackUI\VisualEditor\Models\TemplatePart;
+use Closure;
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Str;
+use Illuminate\View\Component;
+
+/**
+ * Template Part Slot component for template part area placeholders.
+ *
+ * Renders a bordered region in the template canvas that represents
+ * where a template part (header, footer, sidebar) is placed. When
+ * empty, shows a picker to select a part. When filled, shows the
+ * part content with an "Edit Part" overlay button.
+ *
+ * Usage:
+ *   <x-ve-template-part-slot
+ *       area="header"
+ *       :assigned-slug="$headerSlug"
+ *       :available-parts="$headerParts"
+ *   />
+ *
+ * @deprecated Will be replaced by a template-part block type in a future release.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor\View\Components
+ *
+ * @since      1.0.0
+ */
+class TemplatePartSlot extends Component
+{
+	/**
+	 * Unique identifier for this component instance.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var string
+	 */
+	public string $uuid;
+
+	/**
+	 * Create a new component instance.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string|null $id             Optional custom ID.
+	 * @param string|null $label          Accessible label. Defaults to area name.
+	 * @param string      $area           The template part area: header, footer, sidebar, or custom.
+	 * @param string|null $assignedSlug   The slug of the currently assigned template part.
+	 * @param string|null $assignedName   The display name of the currently assigned template part.
+	 * @param array<int, array<string, mixed>> $availableParts Available template parts for this area.
+	 * @param bool        $isEditing      Whether this slot is currently being inline-edited.
+	 * @param bool        $isLocked       Whether the assigned part is locked from editing.
+	 */
+	public function __construct(
+		public ?string $id = null,
+		public ?string $label = null,
+		public string $area = 'custom',
+		public ?string $assignedSlug = null,
+		public ?string $assignedName = null,
+		public array $availableParts = [],
+		public bool $isEditing = false,
+		public bool $isLocked = false,
+	) {
+		$this->uuid = 've-' . Str::random( 8 ) . ( $id ? '-' . $id : '' );
+
+		$validAreas = TemplatePart::AREAS;
+		if ( ! in_array( $this->area, $validAreas, true ) ) {
+			$this->area = 'custom';
+		}
+	}
+
+	/**
+	 * Check if a template part is assigned to this slot.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return bool
+	 */
+	public function hasAssignment(): bool
+	{
+		return null !== $this->assignedSlug && '' !== $this->assignedSlug;
+	}
+
+	/**
+	 * Get the display label for this slot's area.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return string
+	 */
+	public function areaLabel(): string
+	{
+		return match ( $this->area ) {
+			'header'  => __( 'visual-editor::ve.template_area_header' ),
+			'footer'  => __( 'visual-editor::ve.template_area_footer' ),
+			'sidebar' => __( 'visual-editor::ve.template_area_sidebar' ),
+			default   => __( 'visual-editor::ve.template_area_custom' ),
+		};
+	}
+
+	/**
+	 * Get the view that represents the component.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return Closure|string|View
+	 */
+	public function render(): View|Closure|string
+	{
+		return view( 'visual-editor::components.template-part-slot' );
+	}
+}

--- a/src/View/Components/TemplateStructurePanel.php
+++ b/src/View/Components/TemplateStructurePanel.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * Template Structure Panel Component.
+ *
+ * Displays a hierarchical outline of the block tree in the
+ * left sidebar, allowing users to navigate blocks in the
+ * template editor by clicking to select them.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor\View\Components
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\View\Components;
+
+use Closure;
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Str;
+use Illuminate\View\Component;
+
+/**
+ * Template Structure Panel component for the left sidebar.
+ *
+ * Renders a tree-style outline showing the template's block
+ * structure. Reads blocks from the Alpine editor store and
+ * flattens them with depth info for indentation. Clicking
+ * an item selects that block in the canvas.
+ *
+ * Usage:
+ *   <x-ve-template-structure-panel :block-names="$blockNames" />
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor\View\Components
+ *
+ * @since      1.0.0
+ */
+class TemplateStructurePanel extends Component
+{
+	/**
+	 * Unique identifier for this component instance.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var string
+	 */
+	public string $uuid;
+
+	/**
+	 * Create a new component instance.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string|null             $id         Optional custom ID.
+	 * @param string|null             $label      Accessible label. Defaults to translation.
+	 * @param array<string, string>   $blockNames Block type display names keyed by type.
+	 */
+	public function __construct(
+		public ?string $id = null,
+		public ?string $label = null,
+		public array $blockNames = [],
+	) {
+		$this->uuid = 've-' . Str::random( 8 ) . ( $id ? '-' . $id : '' );
+	}
+
+	/**
+	 * Get the view that represents the component.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return Closure|string|View
+	 */
+	public function render(): View|Closure|string
+	{
+		return view( 'visual-editor::components.template-structure-panel' );
+	}
+}

--- a/src/View/Components/TemplateSwitcher.php
+++ b/src/View/Components/TemplateSwitcher.php
@@ -1,0 +1,116 @@
+<?php
+
+/**
+ * Template Switcher Component.
+ *
+ * A dropdown in the toolbar for selecting and switching between
+ * available templates. Displays the current template name and
+ * provides a list of alternatives.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor\View\Components
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\View\Components;
+
+use Closure;
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Str;
+use Illuminate\View\Component;
+
+/**
+ * Template Switcher component for the editor toolbar.
+ *
+ * Renders a dropdown that shows the currently active template
+ * and allows switching to other available templates.
+ *
+ * Usage:
+ *   <x-ve-template-switcher
+ *       :templates="$templates"
+ *       :current-slug="$currentSlug"
+ *   />
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor\View\Components
+ *
+ * @since      1.0.0
+ */
+class TemplateSwitcher extends Component
+{
+	/**
+	 * Unique identifier for this component instance.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var string
+	 */
+	public string $uuid;
+
+	/**
+	 * Create a new component instance.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string|null $id          Optional custom ID.
+	 * @param string|null $label       Accessible label. Defaults to translation.
+	 * @param array<int, array<string, mixed>> $templates Available templates (each with name, slug, description).
+	 * @param string|null $currentSlug The slug of the currently active template.
+	 */
+	public function __construct(
+		public ?string $id = null,
+		public ?string $label = null,
+		public array $templates = [],
+		public ?string $currentSlug = null,
+	) {
+		$this->uuid = 've-' . Str::random( 8 ) . ( $id ? '-' . $id : '' );
+	}
+
+	/**
+	 * Get the display name of the currently active template.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return string
+	 */
+	public function currentTemplateName(): string
+	{
+		foreach ( $this->templates as $template ) {
+			$slug = $template['slug'] ?? '';
+			if ( $slug === $this->currentSlug ) {
+				return $template['name'] ?? $slug;
+			}
+		}
+
+		return __( 'visual-editor::ve.template_select' );
+	}
+
+	/**
+	 * Check if a template is currently selected.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return bool
+	 */
+	public function hasSelection(): bool
+	{
+		return null !== $this->currentSlug && '' !== $this->currentSlug;
+	}
+
+	/**
+	 * Get the view that represents the component.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return Closure|string|View
+	 */
+	public function render(): View|Closure|string
+	{
+		return view( 'visual-editor::components.template-switcher' );
+	}
+}

--- a/src/VisualEditorServiceProvider.php
+++ b/src/VisualEditorServiceProvider.php
@@ -131,7 +131,7 @@ class VisualEditorServiceProvider extends ServiceProvider
 		// Phase 8: Block Placeholder
 		'block-placeholder' => Components\BlockPlaceholder::class,
 
-		// Phase 7: Template Editor
+		// Phase 10: Template Editor
 		'template-editor'          => Components\TemplateEditor::class,
 		'template-part-slot'       => Components\TemplatePartSlot::class,
 		'template-switcher'        => Components\TemplateSwitcher::class,

--- a/src/VisualEditorServiceProvider.php
+++ b/src/VisualEditorServiceProvider.php
@@ -131,6 +131,12 @@ class VisualEditorServiceProvider extends ServiceProvider
 		// Phase 8: Block Placeholder
 		'block-placeholder' => Components\BlockPlaceholder::class,
 
+		// Phase 7: Template Editor
+		'template-editor'          => Components\TemplateEditor::class,
+		'template-part-slot'       => Components\TemplatePartSlot::class,
+		'template-switcher'        => Components\TemplateSwitcher::class,
+		'template-structure-panel' => Components\TemplateStructurePanel::class,
+
 		// Phase 9: Editor Assembly
 		'icon'   => Components\Icon::class,
 		'editor' => Components\Editor::class,

--- a/tests/Unit/Components/Concerns/BuildsBlockRegistryDataTest.php
+++ b/tests/Unit/Components/Concerns/BuildsBlockRegistryDataTest.php
@@ -180,6 +180,62 @@ test( 'trait builds empty block transforms from empty registry', function (): vo
 	expect( $consumer->blockTransforms )->toBeArray()->toBeEmpty();
 } );
 
+test( 'trait builds empty alignment data from empty registry', function (): void {
+	$consumer = new TestTraitConsumer();
+	$registry = new BlockRegistry();
+	$consumer->buildAlignmentData( $registry );
+
+	expect( $consumer->blockAlignSupports )->toBeArray()->toBeEmpty();
+} );
+
+test( 'trait builds populated data from real registry', function (): void {
+	// Use the real registry with core blocks (service provider boots automatically).
+	$registry = app( 'visual-editor.blocks' );
+	$consumer = new TestTraitConsumer();
+
+	$consumer->buildInserterBlocks( $registry );
+	expect( $consumer->inserterBlocks )->toBeArray()->not->toBeEmpty();
+	expect( $consumer->inserterBlocks[0] )->toHaveKeys( [ 'name', 'label', 'icon', 'category' ] );
+
+	$consumer->buildBlockMetadata( $registry );
+	expect( $consumer->blockMetadata )->toBeArray()->not->toBeEmpty();
+	expect( $consumer->blockMetadata )->toHaveKey( 'paragraph' );
+
+	$consumer->buildInspectorData( $registry );
+	expect( $consumer->inspectorBlockNames )->toBeArray()->not->toBeEmpty();
+	expect( $consumer->inspectorBlockNames )->toHaveKey( 'paragraph' );
+	expect( $consumer->inspectorBlockDescriptions )->toBeArray()->not->toBeEmpty();
+	expect( $consumer->inspectorBlockTypes )->toBeArray()->not->toBeEmpty();
+	expect( $consumer->inspectorBlockTypes )->toContain( 'paragraph' );
+
+	$consumer->buildToolbarData( $registry );
+	expect( $consumer->toolbarBlockIcons )->toBeArray()->not->toBeEmpty();
+	expect( $consumer->toolbarBlockIcons )->toHaveKey( 'paragraph' );
+	expect( $consumer->blockNames )->toBeArray()->not->toBeEmpty();
+	expect( $consumer->blockNames )->toHaveKey( 'paragraph' );
+	expect( $consumer->transformableBlocks )->toBeArray()->not->toBeEmpty();
+
+	$consumer->buildDefaultBlockTemplates( $registry );
+	expect( $consumer->defaultBlockTemplates )->toBeArray()->not->toBeEmpty();
+	expect( $consumer->defaultBlockTemplates )->toHaveKey( 'paragraph' );
+} );
+
+test( 'trait builds rendered blocks from real registry with initial blocks', function (): void {
+	$registry                = app( 'visual-editor.blocks' );
+	$consumer                = new TestTraitConsumer();
+	$consumer->initialBlocks = [
+		[ 'id' => 'b1', 'type' => 'paragraph', 'attributes' => [ 'text' => 'Hello' ] ],
+		[ 'id' => 'b2', 'type' => 'heading', 'attributes' => [ 'text' => 'Title', 'level' => 'h2' ] ],
+	];
+
+	$consumer->buildRenderedBlocks( $registry );
+
+	expect( $consumer->renderedBlocks )->toBeArray()->not->toBeEmpty();
+	expect( $consumer->renderedBlocks )->toHaveKey( 'b1' );
+	expect( $consumer->renderedBlocks )->toHaveKey( 'b2' );
+	expect( $consumer->renderedBlocks['b1'] )->toContain( 'Hello' );
+} );
+
 test( 'trait default icon renderer returns svg for heading', function (): void {
 	$consumer = new TestTraitConsumer();
 	$result   = ( $consumer->iconRenderer )( 'heading' );

--- a/tests/Unit/Components/Concerns/BuildsBlockRegistryDataTest.php
+++ b/tests/Unit/Components/Concerns/BuildsBlockRegistryDataTest.php
@@ -1,0 +1,189 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Blocks\BlockRegistry;
+use ArtisanPackUI\VisualEditor\View\Components\Concerns\BuildsBlockRegistryData;
+
+/**
+ * Concrete test class that uses the trait.
+ */
+class TestTraitConsumer
+{
+	use BuildsBlockRegistryData {
+		defaultIconRenderer as public;
+		buildInserterBlocks as public;
+		buildRenderedBlocks as public;
+		buildDefaultBlockTemplates as public;
+		buildBlockMetadata as public;
+		buildInspectorData as public;
+		buildToolbarData as public;
+		buildAlignmentData as public;
+		buildCustomPanels as public;
+		buildEditorShortcuts as public;
+		buildBlockTransforms as public;
+		buildPatternsWithPreviews as public;
+	}
+
+	public array $initialBlocks = [];
+
+	public array $patterns = [];
+
+	public array $blockTransforms = [];
+
+	public array $blockVariations = [];
+
+	public Closure $iconRenderer;
+
+	public array $inserterBlocks = [];
+
+	public array $renderedBlocks = [];
+
+	public array $defaultBlockTemplates = [];
+
+	public array $blockMetadata = [];
+
+	public array $inspectorBlockNames = [];
+
+	public array $inspectorBlockDescriptions = [];
+
+	public array $inspectorBlockTypes = [];
+
+	public array $toolbarBlockIcons = [];
+
+	public array $transformableBlocks = [];
+
+	public array $blockNames = [];
+
+	public array $blockAlignSupports = [];
+
+	public array $customToolbarHtml = [];
+
+	public array $editorShortcuts = [];
+
+	public array $patternsWithPreviews = [];
+
+	public array $defaultInnerBlocksMap = [];
+
+	public function __construct()
+	{
+		$this->iconRenderer = $this->defaultIconRenderer();
+	}
+}
+
+test( 'trait provides default icon renderer', function (): void {
+	$consumer = new TestTraitConsumer();
+
+	expect( $consumer->iconRenderer )->toBeCallable();
+
+	$result = ( $consumer->iconRenderer )( '_default' );
+	expect( $result )->toContain( 'svg' );
+} );
+
+test( 'trait builds editor shortcuts', function (): void {
+	$consumer = new TestTraitConsumer();
+	$consumer->buildEditorShortcuts();
+
+	expect( $consumer->editorShortcuts )->toBeArray();
+	expect( count( $consumer->editorShortcuts ) )->toBeGreaterThan( 0 );
+	expect( $consumer->editorShortcuts[0] )->toHaveKeys( [ 'name', 'keys', 'description', 'category' ] );
+} );
+
+test( 'trait builds empty inserter blocks from empty registry', function (): void {
+	$consumer = new TestTraitConsumer();
+	$registry = new BlockRegistry();
+	$consumer->buildInserterBlocks( $registry );
+
+	expect( $consumer->inserterBlocks )->toBeArray()->toBeEmpty();
+	expect( $consumer->defaultInnerBlocksMap )->toBeArray()->toBeEmpty();
+} );
+
+test( 'trait builds empty rendered blocks when no initial blocks', function (): void {
+	$consumer = new TestTraitConsumer();
+	$registry = new BlockRegistry();
+	$consumer->buildRenderedBlocks( $registry );
+
+	expect( $consumer->renderedBlocks )->toBeArray()->toBeEmpty();
+} );
+
+test( 'trait skips malformed initial blocks', function (): void {
+	$consumer                = new TestTraitConsumer();
+	$consumer->initialBlocks = [
+		'not-an-array',
+		[ 'id'   => 'no-type' ],
+		[ 'type' => 'no-id' ],
+	];
+
+	$registry = new BlockRegistry();
+	$consumer->buildRenderedBlocks( $registry );
+
+	expect( $consumer->renderedBlocks )->toBeArray()->toBeEmpty();
+} );
+
+test( 'trait builds empty block metadata from empty registry', function (): void {
+	$consumer = new TestTraitConsumer();
+	$registry = new BlockRegistry();
+	$consumer->buildBlockMetadata( $registry );
+
+	expect( $consumer->blockMetadata )->toBeArray()->toBeEmpty();
+} );
+
+test( 'trait builds empty inspector data from empty registry', function (): void {
+	$consumer = new TestTraitConsumer();
+	$registry = new BlockRegistry();
+	$consumer->buildInspectorData( $registry );
+
+	expect( $consumer->inspectorBlockNames )->toBeArray()->toBeEmpty();
+	expect( $consumer->inspectorBlockDescriptions )->toBeArray()->toBeEmpty();
+	expect( $consumer->inspectorBlockTypes )->toBeArray()->toBeEmpty();
+} );
+
+test( 'trait builds empty toolbar data from empty registry', function (): void {
+	$consumer = new TestTraitConsumer();
+	$registry = new BlockRegistry();
+	$consumer->buildToolbarData( $registry );
+
+	expect( $consumer->toolbarBlockIcons )->toBeArray()->toBeEmpty();
+	expect( $consumer->transformableBlocks )->toBeArray()->toBeEmpty();
+	expect( $consumer->blockNames )->toBeArray()->toBeEmpty();
+} );
+
+test( 'trait builds patterns with previews', function (): void {
+	$consumer           = new TestTraitConsumer();
+	$consumer->patterns = [
+		[ 'name' => 'test-pattern', 'title' => 'Test' ],
+	];
+	$consumer->buildPatternsWithPreviews();
+
+	expect( $consumer->patternsWithPreviews )->toHaveCount( 1 );
+	expect( $consumer->patternsWithPreviews[0] )->toHaveKey( 'preview' );
+} );
+
+test( 'trait handles non-array patterns gracefully', function (): void {
+	$consumer           = new TestTraitConsumer();
+	$consumer->patterns = [
+		'not-an-array',
+		[ 'name' => 'valid', 'title' => 'Valid' ],
+	];
+	$consumer->buildPatternsWithPreviews();
+
+	expect( $consumer->patternsWithPreviews )->toHaveCount( 2 );
+	expect( $consumer->patternsWithPreviews[0] )->toBe( [] );
+	expect( $consumer->patternsWithPreviews[1] )->toHaveKey( 'preview' );
+} );
+
+test( 'trait builds empty block transforms from empty registry', function (): void {
+	$consumer = new TestTraitConsumer();
+	$registry = new BlockRegistry();
+	$consumer->buildBlockTransforms( $registry );
+
+	expect( $consumer->blockTransforms )->toBeArray()->toBeEmpty();
+} );
+
+test( 'trait default icon renderer returns svg for heading', function (): void {
+	$consumer = new TestTraitConsumer();
+	$result   = ( $consumer->iconRenderer )( 'heading' );
+
+	expect( $result )->toContain( 'svg' );
+	expect( $result )->toContain( 'H' );
+} );

--- a/tests/Unit/Components/TemplateEditorTest.php
+++ b/tests/Unit/Components/TemplateEditorTest.php
@@ -1,0 +1,157 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Blocks\BlockRegistry;
+use ArtisanPackUI\VisualEditor\View\Components\TemplateEditor;
+
+test( 'template editor can be instantiated with defaults', function (): void {
+	$this->app->singleton( 'visual-editor.blocks', function () {
+		return new BlockRegistry();
+	} );
+
+	$component = new TemplateEditor();
+
+	expect( $component->uuid )->toStartWith( 've-tpl-editor-' );
+	expect( $component->id )->toBeNull();
+	expect( $component->initialBlocks )->toBe( [] );
+	expect( $component->patterns )->toBe( [] );
+	expect( $component->blockTransforms )->toBe( [] );
+	expect( $component->blockVariations )->toBe( [] );
+	expect( $component->autosave )->toBeFalse();
+	expect( $component->autosaveInterval )->toBe( 60 );
+	expect( $component->showSidebar )->toBeTrue();
+	expect( $component->mode )->toBe( 'visual' );
+	expect( $component->initialMeta )->toBe( [] );
+	expect( $component->templates )->toBe( [] );
+	expect( $component->currentTemplateSlug )->toBe( '' );
+} );
+
+test( 'template editor accepts custom props', function (): void {
+	$this->app->singleton( 'visual-editor.blocks', function () {
+		return new BlockRegistry();
+	} );
+
+	$templates = [
+		[ 'name' => 'Default Page', 'slug' => 'default-page' ],
+		[ 'name' => 'Full Width', 'slug' => 'full-width' ],
+	];
+
+	$component = new TemplateEditor(
+		id: 'tpl-editor',
+		autosave: true,
+		autosaveInterval: 30,
+		showSidebar: false,
+		templates: $templates,
+		currentTemplateSlug: 'default-page',
+	);
+
+	expect( $component->uuid )->toContain( 'tpl-editor' );
+	expect( $component->autosave )->toBeTrue();
+	expect( $component->autosaveInterval )->toBe( 30 );
+	expect( $component->showSidebar )->toBeFalse();
+	expect( $component->templates )->toBe( $templates );
+	expect( $component->currentTemplateSlug )->toBe( 'default-page' );
+} );
+
+test( 'template editor builds empty data when registry is empty', function (): void {
+	$this->app->singleton( 'visual-editor.blocks', function () {
+		return new BlockRegistry();
+	} );
+
+	$component = new TemplateEditor();
+
+	expect( $component->inserterBlocks )->toBeArray()->toBeEmpty();
+	expect( $component->renderedBlocks )->toBeArray()->toBeEmpty();
+	expect( $component->defaultBlockTemplates )->toBeArray()->toBeEmpty();
+	expect( $component->blockMetadata )->toBeArray()->toBeEmpty();
+	expect( $component->inspectorBlockNames )->toBeArray()->toBeEmpty();
+	expect( $component->inspectorBlockDescriptions )->toBeArray()->toBeEmpty();
+	expect( $component->inspectorBlockTypes )->toBeArray()->toBeEmpty();
+	expect( $component->toolbarBlockIcons )->toBeArray()->toBeEmpty();
+	expect( $component->blockNames )->toBeArray()->toBeEmpty();
+	expect( $component->transformableBlocks )->toBeArray()->toBeEmpty();
+	expect( $component->blockAlignSupports )->toBeArray()->toBeEmpty();
+	expect( $component->customToolbarHtml )->toBeArray()->toBeEmpty();
+} );
+
+test( 'template editor builds editor shortcuts', function (): void {
+	$this->app->singleton( 'visual-editor.blocks', function () {
+		return new BlockRegistry();
+	} );
+
+	$component = new TemplateEditor();
+
+	expect( $component->editorShortcuts )->toBeArray();
+	expect( count( $component->editorShortcuts ) )->toBeGreaterThan( 0 );
+
+	$first = $component->editorShortcuts[0];
+	expect( $first )->toHaveKeys( [ 'name', 'keys', 'description', 'category' ] );
+} );
+
+test( 'template editor icon renderer uses default when none provided', function (): void {
+	$this->app->singleton( 'visual-editor.blocks', function () {
+		return new BlockRegistry();
+	} );
+
+	$component = new TemplateEditor();
+
+	expect( $component->iconRenderer )->toBeCallable();
+
+	$result = ( $component->iconRenderer )( 'paragraph' );
+	expect( $result )->toBeString();
+	expect( $result )->toContain( 'svg' );
+} );
+
+test( 'template editor icon renderer uses custom when provided', function (): void {
+	$this->app->singleton( 'visual-editor.blocks', function () {
+		return new BlockRegistry();
+	} );
+
+	$custom = function ( string $icon ): string {
+		return '<i class="icon-' . $icon . '"></i>';
+	};
+
+	$component = new TemplateEditor( customIconRenderer: $custom );
+
+	expect( $component->iconRenderer )->toBe( $custom );
+	expect( ( $component->iconRenderer )( 'paragraph' ) )->toBe( '<i class="icon-paragraph"></i>' );
+} );
+
+test( 'template editor builds patterns with previews', function (): void {
+	$this->app->singleton( 'visual-editor.blocks', function () {
+		return new BlockRegistry();
+	} );
+
+	$patterns = [
+		[
+			'name'   => 'test-pattern',
+			'title'  => 'Test Pattern',
+			'blocks' => [],
+		],
+	];
+
+	$component = new TemplateEditor( patterns: $patterns );
+
+	expect( $component->patternsWithPreviews )->toBeArray();
+	expect( $component->patternsWithPreviews )->toHaveCount( 1 );
+	expect( $component->patternsWithPreviews[0] )->toHaveKey( 'preview' );
+} );
+
+test( 'template editor renders view name', function (): void {
+	$this->app->singleton( 'visual-editor.blocks', function () {
+		return new BlockRegistry();
+	} );
+
+	$component = new TemplateEditor();
+	$view      = $component->render();
+
+	expect( $view->name() )->toBe( 'visual-editor::components.template-editor' );
+} );
+
+test( 'template editor auto-populates blockTransforms from registry', function (): void {
+	$component = new TemplateEditor();
+
+	expect( $component->blockTransforms )->toBeArray();
+	expect( $component->blockTransforms )->toHaveKey( 'paragraph' );
+} );

--- a/tests/Unit/Components/TemplateEditorTest.php
+++ b/tests/Unit/Components/TemplateEditorTest.php
@@ -150,6 +150,8 @@ test( 'template editor renders view name', function (): void {
 } );
 
 test( 'template editor auto-populates blockTransforms from registry', function (): void {
+	// Use the real registry with all core blocks registered
+	// (the service provider registers core blocks on boot).
 	$component = new TemplateEditor();
 
 	expect( $component->blockTransforms )->toBeArray();

--- a/tests/Unit/Components/TemplatePartSlotTest.php
+++ b/tests/Unit/Components/TemplatePartSlotTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\View\Components\TemplatePartSlot;
+
+test( 'template part slot can be instantiated with defaults', function (): void {
+	$component = new TemplatePartSlot();
+
+	expect( $component->uuid )->toStartWith( 've-' );
+	expect( $component->id )->toBeNull();
+	expect( $component->label )->toBeNull();
+	expect( $component->area )->toBe( 'custom' );
+	expect( $component->assignedSlug )->toBeNull();
+	expect( $component->assignedName )->toBeNull();
+	expect( $component->availableParts )->toBe( [] );
+	expect( $component->isEditing )->toBeFalse();
+	expect( $component->isLocked )->toBeFalse();
+} );
+
+test( 'template part slot accepts custom props', function (): void {
+	$component = new TemplatePartSlot(
+		id: 'header-slot',
+		area: 'header',
+		assignedSlug: 'main-header',
+		assignedName: 'Main Header',
+		isEditing: true,
+		isLocked: false,
+	);
+
+	expect( $component->uuid )->toContain( 'header-slot' );
+	expect( $component->area )->toBe( 'header' );
+	expect( $component->assignedSlug )->toBe( 'main-header' );
+	expect( $component->assignedName )->toBe( 'Main Header' );
+	expect( $component->isEditing )->toBeTrue();
+} );
+
+test( 'template part slot falls back to custom for invalid area', function (): void {
+	$component = new TemplatePartSlot( area: 'invalid-area' );
+
+	expect( $component->area )->toBe( 'custom' );
+} );
+
+test( 'template part slot accepts all valid areas', function (): void {
+	foreach ( [ 'header', 'footer', 'sidebar', 'custom' ] as $area ) {
+		$component = new TemplatePartSlot( area: $area );
+		expect( $component->area )->toBe( $area );
+	}
+} );
+
+test( 'template part slot hasAssignment returns true when slug assigned', function (): void {
+	$component = new TemplatePartSlot( assignedSlug: 'main-header' );
+
+	expect( $component->hasAssignment() )->toBeTrue();
+} );
+
+test( 'template part slot hasAssignment returns false when null', function (): void {
+	$component = new TemplatePartSlot( assignedSlug: null );
+
+	expect( $component->hasAssignment() )->toBeFalse();
+} );
+
+test( 'template part slot hasAssignment returns false when empty string', function (): void {
+	$component = new TemplatePartSlot( assignedSlug: '' );
+
+	expect( $component->hasAssignment() )->toBeFalse();
+} );
+
+test( 'template part slot areaLabel returns translated string for each area', function (): void {
+	foreach ( [ 'header', 'footer', 'sidebar', 'custom' ] as $area ) {
+		$component = new TemplatePartSlot( area: $area );
+		expect( $component->areaLabel() )->toBeString();
+		expect( $component->areaLabel() )->not->toBeEmpty();
+	}
+} );
+
+test( 'template part slot renders', function (): void {
+	$view = $this->blade( '<x-ve-template-part-slot area="header" />' );
+	expect( $view )->not->toBeNull();
+} );
+
+test( 'template part slot renders area label badge', function (): void {
+	$this->blade( '<x-ve-template-part-slot area="header" />' )
+		->assertSee( 'Header' );
+} );
+
+test( 'template part slot renders empty state when no assignment', function (): void {
+	$this->blade( '<x-ve-template-part-slot area="footer" />' )
+		->assertSee( 'Add Template Part' );
+} );
+
+test( 'template part slot renders data attribute for area', function (): void {
+	$this->blade( '<x-ve-template-part-slot area="sidebar" />' )
+		->assertSee( 'data-template-area="sidebar"', false );
+} );
+
+test( 'template part slot renders assigned part name', function (): void {
+	$this->blade( '<x-ve-template-part-slot area="header" assigned-slug="main-header" assigned-name="Main Header" />' )
+		->assertSee( 'Main Header' );
+} );
+
+test( 'template part slot renders edit button for assigned part', function (): void {
+	$this->blade( '<x-ve-template-part-slot area="header" assigned-slug="main-header" />' )
+		->assertSee( 'Edit Part' );
+} );
+
+test( 'template part slot hides edit button when locked', function (): void {
+	$this->blade( '<x-ve-template-part-slot area="header" assigned-slug="main-header" :is-locked="true" />' )
+		->assertDontSee( 'Edit Part' );
+} );

--- a/tests/Unit/Components/TemplateStructurePanelTest.php
+++ b/tests/Unit/Components/TemplateStructurePanelTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\View\Components\TemplateStructurePanel;
+
+test( 'template structure panel can be instantiated with defaults', function (): void {
+	$component = new TemplateStructurePanel();
+
+	expect( $component->uuid )->toStartWith( 've-' );
+	expect( $component->id )->toBeNull();
+	expect( $component->label )->toBeNull();
+	expect( $component->blockNames )->toBe( [] );
+} );
+
+test( 'template structure panel accepts custom props', function (): void {
+	$blockNames = [
+		'paragraph' => 'Paragraph',
+		'heading'   => 'Heading',
+		'image'     => 'Image',
+	];
+
+	$component = new TemplateStructurePanel(
+		id: 'structure',
+		blockNames: $blockNames,
+	);
+
+	expect( $component->uuid )->toContain( 'structure' );
+	expect( $component->blockNames )->toBe( $blockNames );
+	expect( $component->blockNames )->toHaveCount( 3 );
+} );
+
+test( 'template structure panel renders', function (): void {
+	$view = $this->blade( '<x-ve-template-structure-panel />' );
+	expect( $view )->not->toBeNull();
+} );
+
+test( 'template structure panel renders navigation role', function (): void {
+	$this->blade( '<x-ve-template-structure-panel />' )
+		->assertSee( 'role="navigation"', false );
+} );
+
+test( 'template structure panel renders header', function (): void {
+	$this->blade( '<x-ve-template-structure-panel />' )
+		->assertSee( 'Template Structure' );
+} );
+
+test( 'template structure panel renders tree role', function (): void {
+	$this->blade( '<x-ve-template-structure-panel />' )
+		->assertSee( 'role="tree"', false );
+} );
+
+test( 'template structure panel passes block names to alpine', function (): void {
+	$this->blade(
+		'<x-ve-template-structure-panel :block-names="[\'paragraph\' => \'Paragraph\']" />',
+	)->assertSee( 'Paragraph', false );
+} );

--- a/tests/Unit/Components/TemplateSwitcherTest.php
+++ b/tests/Unit/Components/TemplateSwitcherTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\View\Components\TemplateSwitcher;
+
+test( 'template switcher can be instantiated with defaults', function (): void {
+	$component = new TemplateSwitcher();
+
+	expect( $component->uuid )->toStartWith( 've-' );
+	expect( $component->id )->toBeNull();
+	expect( $component->label )->toBeNull();
+	expect( $component->templates )->toBe( [] );
+	expect( $component->currentSlug )->toBeNull();
+} );
+
+test( 'template switcher accepts custom props', function (): void {
+	$templates = [
+		[ 'name' => 'Blank', 'slug' => 'blank' ],
+		[ 'name' => 'Full Width', 'slug' => 'full-width' ],
+	];
+
+	$component = new TemplateSwitcher(
+		id: 'tpl-switch',
+		templates: $templates,
+		currentSlug: 'blank',
+	);
+
+	expect( $component->uuid )->toContain( 'tpl-switch' );
+	expect( $component->templates )->toHaveCount( 2 );
+	expect( $component->currentSlug )->toBe( 'blank' );
+} );
+
+test( 'template switcher returns current template name', function (): void {
+	$component = new TemplateSwitcher(
+		templates: [
+			[ 'name' => 'Blank', 'slug' => 'blank' ],
+			[ 'name' => 'Full Width', 'slug' => 'full-width' ],
+		],
+		currentSlug: 'full-width',
+	);
+
+	expect( $component->currentTemplateName() )->toBe( 'Full Width' );
+} );
+
+test( 'template switcher returns fallback name when no selection', function (): void {
+	$component = new TemplateSwitcher();
+
+	expect( $component->currentTemplateName() )->toBeString();
+	expect( $component->currentTemplateName() )->not->toBeEmpty();
+} );
+
+test( 'template switcher returns fallback name when slug not in templates', function (): void {
+	$component = new TemplateSwitcher(
+		templates: [ [ 'name' => 'Blank', 'slug' => 'blank' ] ],
+		currentSlug: 'nonexistent',
+	);
+
+	expect( $component->currentTemplateName() )->toBeString();
+} );
+
+test( 'template switcher hasSelection returns true when slug set', function (): void {
+	$component = new TemplateSwitcher( currentSlug: 'blank' );
+
+	expect( $component->hasSelection() )->toBeTrue();
+} );
+
+test( 'template switcher hasSelection returns false when null', function (): void {
+	$component = new TemplateSwitcher( currentSlug: null );
+
+	expect( $component->hasSelection() )->toBeFalse();
+} );
+
+test( 'template switcher hasSelection returns false when empty string', function (): void {
+	$component = new TemplateSwitcher( currentSlug: '' );
+
+	expect( $component->hasSelection() )->toBeFalse();
+} );
+
+test( 'template switcher renders', function (): void {
+	$view = $this->blade( '<x-ve-template-switcher />' );
+	expect( $view )->not->toBeNull();
+} );
+
+test( 'template switcher renders trigger button', function (): void {
+	$this->blade( '<x-ve-template-switcher />' )
+		->assertSee( 'aria-haspopup="listbox"', false );
+} );
+
+test( 'template switcher renders listbox dropdown', function (): void {
+	$this->blade( '<x-ve-template-switcher />' )
+		->assertSee( 'role="listbox"', false );
+} );


### PR DESCRIPTION
## Summary

- Extract shared block registry initialization logic into a `BuildsBlockRegistryData` trait used by both `Editor` and `TemplateEditor` to eliminate code duplication
- Rework `TemplateEditor` from slot-based template parts UI to a full block editing experience with inserter, canvas, inspector, and keyboard shortcuts
- Add `customTabs` prop to `LeftSidebar` and a new `structurePanel` slot; template editor uses Blocks/Patterns/Structure tabs instead of Blocks/Patterns/Layers
- Rework `TemplateStructurePanel` to display an Alpine-driven block tree (read from editor store) instead of the old template-area outline
- Add template switcher to template editor toolbar, fix switcher z-index (z-30 → z-50), deprecate `TemplatePartSlot`
- Add `structure_tab` and `drag_to_reorder` translation keys; fix aria-label strings to use package namespace

## Test plan

- [x] `./vendor/bin/pest tests/Unit/Components/EditorTest.php` — 15 tests pass (trait extraction didn't break existing editor)
- [x] `./vendor/bin/pest tests/Unit/Components/TemplateEditorTest.php` — 9 tests pass (new constructor, props, registry builds)
- [x] `./vendor/bin/pest tests/Unit/Components/TemplateStructurePanelTest.php` — 7 tests pass (new block-tree-based panel)
- [x] `./vendor/bin/pest tests/Unit/Components/Concerns/BuildsBlockRegistryDataTest.php` — 12 tests pass (trait methods)
- [x] `./vendor/bin/pest tests/Unit/Components/LeftSidebarTest.php` — 11 tests pass (customTabs + validation)
- [x] `./vendor/bin/pest tests/Unit/Components/TemplateSwitcherTest.php` — unchanged, passes
- [x] `./vendor/bin/pest tests/Unit/Components/TemplatePartSlotTest.php` — unchanged, passes
- [x] Full suite: 1433 tests, 4334 assertions — all passing
- [ ] Manual: visit `/packages/visual-editor/template-editor` — block inserter, canvas, inspector, structure tab, template switcher all functional

Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full-page Template Editor with toolbar, sidebars, canvas, template switcher, part slots, and structure panel.
  * Template switcher dropdown for selecting templates.
  * Template part slots for header/footer/sidebar/custom areas.
  * Structure panel to navigate block hierarchy.
  * New "template" editor mode.

* **Localization**
  * Added comprehensive template-editor translations (including drag-to-reorder and UI strings).

* **Tests**
  * Added unit tests covering editor components and registry builders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->