### PR TITLE
feat: add BlockContextProvider primitive

### DIFF
--- a/resources/js/editor-spike/__tests__/BlockContext.test.tsx
+++ b/resources/js/editor-spike/__tests__/BlockContext.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen } from '@testing-library/react';
+import {
+    BlockContextProvider,
+    useBlockContext,
+    useBlockContextValue,
+} from '../primitives/BlockContext';
+
+function Reader() {
+    const context = useBlockContext();
+    return <div data-testid="context">{JSON.stringify(context)}</div>;
+}
+
+function TypedReader() {
+    const postId = useBlockContextValue<number>('postId');
+    const missing = useBlockContextValue<string>('missing');
+    return (
+        <div>
+            <span data-testid="postId">{String(postId)}</span>
+            <span data-testid="missing">{String(missing)}</span>
+        </div>
+    );
+}
+
+describe('BlockContextProvider', () => {
+    it('exposes the provided value to descendants', () => {
+        render(
+            <BlockContextProvider value={{ postId: 1, postType: 'post' }}>
+                <Reader />
+            </BlockContextProvider>
+        );
+
+        expect(screen.getByTestId('context').textContent).toBe(
+            JSON.stringify({ postId: 1, postType: 'post' })
+        );
+    });
+
+    it('merges nested provider values with parent context', () => {
+        render(
+            <BlockContextProvider value={{ postId: 1, postType: 'post' }}>
+                <BlockContextProvider value={{ extra: 'data' }}>
+                    <Reader />
+                </BlockContextProvider>
+            </BlockContextProvider>
+        );
+
+        expect(screen.getByTestId('context').textContent).toBe(
+            JSON.stringify({ postId: 1, postType: 'post', extra: 'data' })
+        );
+    });
+
+    it('lets a nested provider override a parent key', () => {
+        render(
+            <BlockContextProvider value={{ postId: 1, postType: 'post' }}>
+                <BlockContextProvider value={{ postType: 'page' }}>
+                    <Reader />
+                </BlockContextProvider>
+            </BlockContextProvider>
+        );
+
+        expect(screen.getByTestId('context').textContent).toBe(
+            JSON.stringify({ postId: 1, postType: 'page' })
+        );
+    });
+
+    it('returns an empty object outside of any provider', () => {
+        render(<Reader />);
+
+        expect(screen.getByTestId('context').textContent).toBe('{}');
+    });
+
+    it('useBlockContextValue returns typed values and undefined for missing keys', () => {
+        render(
+            <BlockContextProvider value={{ postId: 42 }}>
+                <TypedReader />
+            </BlockContextProvider>
+        );
+
+        expect(screen.getByTestId('postId').textContent).toBe('42');
+        expect(screen.getByTestId('missing').textContent).toBe('undefined');
+    });
+});

--- a/resources/js/editor-spike/primitives/BlockContext.tsx
+++ b/resources/js/editor-spike/primitives/BlockContext.tsx
@@ -1,0 +1,29 @@
+import { createContext, useContext, useMemo, type ReactNode } from 'react';
+
+export type BlockContextValue = Record<string, unknown>;
+
+const Context = createContext<BlockContextValue>({});
+Context.displayName = 'BlockContext';
+
+export interface BlockContextProviderProps {
+    value: BlockContextValue;
+    children: ReactNode;
+}
+
+export function BlockContextProvider({ value, children }: BlockContextProviderProps) {
+    const parent = useContext(Context);
+    const merged = useMemo(() => ({ ...parent, ...value }), [parent, value]);
+
+    return <Context.Provider value={merged}>{children}</Context.Provider>;
+}
+
+export function useBlockContext(): BlockContextValue {
+    return useContext(Context);
+}
+
+export function useBlockContextValue<T>(key: string): T | undefined {
+    const context = useContext(Context);
+    return context[key] as T | undefined;
+}
+
+export default Context;


### PR DESCRIPTION
## Description

Builds the in-house `BlockContextProvider` React Context primitive for the editor spike (Phase 0.3). It scopes arbitrary `{key: value}` context (e.g. `postId`, `postType`) to a subtree of blocks, and nested providers compose by merging their value with parent context. Modeled on Gutenberg's `block-context` but reimplemented against our types with **zero `@wordpress/*` dependencies**.

**Closes:** #245

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #245

## Motivation and Context

Sub-issue of #236 (Phase 0 spike). Blocks need a way to read scoped context (like the current post ID/type) without prop drilling. This primitive is the foundation later sub-issues will hook real blocks into.

## Changes Made

- Add `resources/js/editor-spike/primitives/BlockContext.tsx` exporting `BlockContextProvider`, `useBlockContext()`, and a typed `useBlockContextValue<T>(key)` helper
- Provider merges its `value` prop with the parent context via `useMemo` so nested providers compose and child keys can override parent keys
- Add `resources/js/editor-spike/__tests__/BlockContext.test.tsx` with Vitest unit tests

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS
- Vitest: 2.1.9

**Tests Performed:**
1. `npm test` — all 10 tests passing across 3 files

## Accessibility Tests Run

- [x] N/A — pure React Context primitive with no rendered UI surface

## Tests Added

- [x] Unit tests added/updated
- [x] All tests passing

**Test details:**

5 new Vitest cases covering:
- Single provider exposes value to descendants
- Nested providers merge values with parent context
- Nested provider can override a parent key
- Reader outside any provider gets `{}` (default)
- `useBlockContextValue<T>` returns typed values and `undefined` for missing keys

## Documentation

- [x] Inline TypeScript types serve as the API contract

## Pre-Submission Checklist

- [x] Code passes all tests
- [x] Self-review completed
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added context management system enabling state sharing across component hierarchy
  * Introduced provider component with support for nested contexts and value merging
  * Added hooks for accessing full context and targeted values with type safety

* **Tests**
  * Added comprehensive test coverage for context provider and hook functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->