### PR TITLE
feat: add useBlockPreview primitive for read-only block rendering

### DIFF
--- a/resources/js/editor-spike/__tests__/useBlockPreview.test.tsx
+++ b/resources/js/editor-spike/__tests__/useBlockPreview.test.tsx
@@ -103,7 +103,7 @@ describe('BlockPreview', () => {
         expect(screen.getByText('click me')).toBeInTheDocument();
     });
 
-    it('applies pointer-events:none and user-select:none to the wrapper', () => {
+    it('applies pointer-events:none, user-select:none, and inert to the wrapper', () => {
         const { container } = render(<BlockPreview blocks={[tree[0]]} className="ve-preview" />);
 
         const wrapper = container.querySelector('[data-block-preview]') as HTMLElement | null;
@@ -111,6 +111,7 @@ describe('BlockPreview', () => {
         expect(wrapper!.classList.contains('ve-preview')).toBe(true);
         expect(wrapper!.style.pointerEvents).toBe('none');
         expect(wrapper!.style.userSelect).toBe('none');
+        expect(wrapper!.hasAttribute('inert')).toBe(true);
     });
 
     it('renders multiple root blocks', () => {
@@ -136,6 +137,7 @@ describe('useBlockPreview', () => {
         expect(captured!.previewProps['data-block-preview']).toBe(true);
         expect(captured!.previewProps.style.pointerEvents).toBe('none');
         expect(captured!.previewProps.style.userSelect).toBe('none');
+        expect(captured!.previewProps.inert).toBe(true);
         expect(container.querySelector('[data-block-preview]')).not.toBeNull();
     });
 });

--- a/resources/js/editor-spike/__tests__/useBlockPreview.test.tsx
+++ b/resources/js/editor-spike/__tests__/useBlockPreview.test.tsx
@@ -1,0 +1,141 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { Block } from '../mocks/blockTree';
+import { clearRegistry, registerBlock, type BlockEditProps } from '../registry';
+import { useReadOnly } from '../primitives/ReadOnlyContext';
+import { BlockPreview, useBlockPreview } from '../primitives/useBlockPreview';
+import { InnerBlocks } from '../primitives/useInnerBlocksProps';
+
+function Paragraph({ attributes, clientId }: BlockEditProps) {
+    const readOnly = useReadOnly();
+    const content = String(attributes.content ?? '');
+
+    if (readOnly) {
+        return (
+            <p data-client-id={clientId} data-read-only="true">
+                {content}
+            </p>
+        );
+    }
+
+    return (
+        <p
+            data-client-id={clientId}
+            contentEditable
+            suppressContentEditableWarning
+            onInput={() => {}}
+        >
+            {content}
+        </p>
+    );
+}
+
+function ClickButton({ clientId }: BlockEditProps) {
+    return (
+        <button
+            type="button"
+            data-client-id={clientId}
+            onClick={() => {
+                throw new Error('button handler should not fire inside a preview');
+            }}
+        >
+            click me
+        </button>
+    );
+}
+
+const tree: Block[] = [
+    {
+        clientId: 'p1',
+        name: 've/paragraph',
+        attributes: { content: 'Hello preview' },
+        innerBlocks: [],
+    },
+    {
+        clientId: 'group-root',
+        name: 've/group',
+        attributes: {},
+        innerBlocks: [
+            {
+                clientId: 'nested-p',
+                name: 've/paragraph',
+                attributes: { content: 'Nested line' },
+                innerBlocks: [],
+            },
+            {
+                clientId: 'nested-button',
+                name: 've/button',
+                attributes: {},
+                innerBlocks: [],
+            },
+        ],
+    },
+];
+
+beforeEach(() => {
+    clearRegistry();
+    registerBlock({ name: 've/paragraph', edit: Paragraph });
+    registerBlock({ name: 've/button', edit: ClickButton });
+    registerBlock({
+        name: 've/group',
+        edit: ({ block }) => <InnerBlocks parentClientId={block.clientId} />,
+    });
+});
+
+afterEach(() => {
+    clearRegistry();
+});
+
+describe('BlockPreview', () => {
+    it('renders a paragraph block with no contenteditable in read-only mode', () => {
+        render(<BlockPreview blocks={[tree[0]]} />);
+
+        const paragraph = screen.getByText('Hello preview');
+        expect(paragraph.getAttribute('contenteditable')).toBeNull();
+        expect(paragraph.getAttribute('data-read-only')).toBe('true');
+    });
+
+    it('renders nested blocks via InnerBlocks inside the preview', () => {
+        render(<BlockPreview blocks={[tree[1]]} />);
+
+        const nested = screen.getByText('Nested line');
+        expect(nested.getAttribute('contenteditable')).toBeNull();
+        expect(screen.getByText('click me')).toBeInTheDocument();
+    });
+
+    it('applies pointer-events:none and user-select:none to the wrapper', () => {
+        const { container } = render(<BlockPreview blocks={[tree[0]]} className="ve-preview" />);
+
+        const wrapper = container.querySelector('[data-block-preview]') as HTMLElement | null;
+        expect(wrapper).not.toBeNull();
+        expect(wrapper!.classList.contains('ve-preview')).toBe(true);
+        expect(wrapper!.style.pointerEvents).toBe('none');
+        expect(wrapper!.style.userSelect).toBe('none');
+    });
+
+    it('renders multiple root blocks', () => {
+        render(<BlockPreview blocks={tree} />);
+
+        expect(screen.getByText('Hello preview')).toBeInTheDocument();
+        expect(screen.getByText('Nested line')).toBeInTheDocument();
+    });
+});
+
+describe('useBlockPreview', () => {
+    it('returns previewProps spreadable onto a wrapper element', () => {
+        let captured: ReturnType<typeof useBlockPreview> | null = null;
+
+        function Probe() {
+            captured = useBlockPreview({ blocks: [tree[0]] });
+            return <div {...captured.previewProps} />;
+        }
+
+        const { container } = render(<Probe />);
+
+        expect(captured).not.toBeNull();
+        expect(captured!.previewProps['data-block-preview']).toBe(true);
+        expect(captured!.previewProps.style.pointerEvents).toBe('none');
+        expect(captured!.previewProps.style.userSelect).toBe('none');
+        expect(container.querySelector('[data-block-preview]')).not.toBeNull();
+    });
+});

--- a/resources/js/editor-spike/primitives/ReadOnlyContext.tsx
+++ b/resources/js/editor-spike/primitives/ReadOnlyContext.tsx
@@ -1,0 +1,19 @@
+import { createContext, useContext, type ReactNode } from 'react';
+
+const Context = createContext<boolean>(false);
+Context.displayName = 'ReadOnlyContext';
+
+export interface ReadOnlyProviderProps {
+    value: boolean;
+    children: ReactNode;
+}
+
+export function ReadOnlyProvider({ value, children }: ReadOnlyProviderProps) {
+    return <Context.Provider value={value}>{children}</Context.Provider>;
+}
+
+export function useReadOnly(): boolean {
+    return useContext(Context);
+}
+
+export default Context;

--- a/resources/js/editor-spike/primitives/useBlockPreview.tsx
+++ b/resources/js/editor-spike/primitives/useBlockPreview.tsx
@@ -12,6 +12,7 @@ export interface UseBlockPreviewOptions {
 export interface BlockPreviewProps {
     children: ReactNode;
     style: CSSProperties;
+    inert: boolean;
     'data-block-preview': true;
 }
 
@@ -42,6 +43,7 @@ export function useBlockPreview({ blocks }: UseBlockPreviewOptions): UseBlockPre
         previewProps: {
             children,
             style: previewStyle,
+            inert: true,
             'data-block-preview': true,
         },
     };

--- a/resources/js/editor-spike/primitives/useBlockPreview.tsx
+++ b/resources/js/editor-spike/primitives/useBlockPreview.tsx
@@ -1,0 +1,60 @@
+import { useMemo, type CSSProperties, type ReactNode } from 'react';
+import type { Block } from '../mocks/blockTree';
+import { BlockTreeProvider } from './BlockTreeContext';
+import { ReadOnlyProvider } from './ReadOnlyContext';
+import { RenderBlock } from './useInnerBlocksProps';
+
+export interface UseBlockPreviewOptions {
+    blocks: Block[];
+    viewportWidth?: number;
+}
+
+export interface BlockPreviewProps {
+    children: ReactNode;
+    style: CSSProperties;
+    'data-block-preview': true;
+}
+
+export interface UseBlockPreviewReturn {
+    previewProps: BlockPreviewProps;
+}
+
+const previewStyle: CSSProperties = {
+    pointerEvents: 'none',
+    userSelect: 'none',
+};
+
+export function useBlockPreview({ blocks }: UseBlockPreviewOptions): UseBlockPreviewReturn {
+    const children = useMemo<ReactNode>(
+        () => (
+            <BlockTreeProvider blocks={blocks}>
+                <ReadOnlyProvider value={true}>
+                    {blocks.map((block) => (
+                        <RenderBlock key={block.clientId} block={block} />
+                    ))}
+                </ReadOnlyProvider>
+            </BlockTreeProvider>
+        ),
+        [blocks]
+    );
+
+    return {
+        previewProps: {
+            children,
+            style: previewStyle,
+            'data-block-preview': true,
+        },
+    };
+}
+
+export interface BlockPreviewComponentProps {
+    blocks: Block[];
+    viewportWidth?: number;
+    className?: string;
+}
+
+export function BlockPreview({ blocks, viewportWidth, className }: BlockPreviewComponentProps) {
+    const { previewProps } = useBlockPreview({ blocks, viewportWidth });
+
+    return <div className={className} {...previewProps} />;
+}

--- a/resources/js/editor-spike/primitives/useInnerBlocksProps.tsx
+++ b/resources/js/editor-spike/primitives/useInnerBlocksProps.tsx
@@ -39,7 +39,7 @@ interface RenderBlockProps {
     block: Block;
 }
 
-function RenderBlock({ block }: RenderBlockProps) {
+export function RenderBlock({ block }: RenderBlockProps) {
     const definition = getBlock(block.name);
 
     if (!definition) {


### PR DESCRIPTION
## Description

Builds the in-house `useBlockPreview` primitive for Phase 0 — renders a block tree as a non-interactive, read-only preview, modeled on Gutenberg's `useBlockPreview` but with zero `@wordpress/*` dependencies. This is the preview primitive used for inactive posts in the query loop.

**Closes:** #247

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #247

## Motivation and Context

Part of the Alpine→React editor migration (Phase 0.5 spike, sub-issue of #236). The preview primitive is required so block edit components can render a non-interactive variant when displayed outside the active editing context — clicks pass through to the parent so activate-on-click (#8) can handle them.

## Changes Made

- Added `primitives/ReadOnlyContext.tsx` with `ReadOnlyProvider` + `useReadOnly()` hook (default `false`)
- Added `primitives/useBlockPreview.tsx` exposing `useBlockPreview({ blocks, viewportWidth? })` and a `<BlockPreview>` convenience component; wrapper carries `pointer-events: none` + `user-select: none` + `data-block-preview`
- Exported `RenderBlock` from `primitives/useInnerBlocksProps.tsx` so the preview can reuse the existing render path
- Added 5 Vitest cases covering the read-only paragraph case (no `contenteditable`), nested `InnerBlocks`, wrapper styles, multi-root trees, and the hook return shape

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (Darwin 25.3.0)
- Browser (if applicable): n/a (Vitest + jsdom)
- PHP Version: n/a
- Project Version: 1.0.0-spike

**Tests Performed:**
1. `npm test` — 21/21 passing (5 new in `useBlockPreview.test.tsx`)
2. `npx tsc --noEmit` — clean

## Accessibility Tests Run

- [ ] Keyboard navigation tested
- [ ] Screen reader tested
- [ ] Color contrast verified
- [ ] ARIA labels checked

**Details:** Not applicable — this is a headless primitive with no rendered UI surface of its own. Accessibility of the edit components that consume `useReadOnly()` will be covered in their individual issues.

## Tests Added

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All tests passing

**Test details:** `resources/js/editor-spike/__tests__/useBlockPreview.test.tsx` — 5 cases for `BlockPreview` + `useBlockPreview`.

## Documentation

- [ ] Inline code documentation added
- [ ] README updated
- [ ] Wiki updated
- [ ] API documentation updated

**Documentation details:** Phase 0 spike; docs land with the full React migration.

## Pre-Submission Checklist

- [x] Code passes all tests
- [x] Self-review completed
- [x] No new warnings generated

## Out of Scope

Per the issue: memoization optimization, viewport scaling, and isolated style scope are deferred to Phase 3 polish. `viewportWidth` is accepted in the API but not yet applied.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added block preview functionality supporting read-only rendering, disabling editing and pointer interactions (inert, no selection), preserving styling/className, and correctly rendering nested and multiple root blocks.
  * Introduced a read-only context to control block interaction state.

* **Tests**
  * Added tests validating preview rendering, nested block handling, inert/interaction behavior, and spreadable preview props.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->