### PR TITLE
feat: Phase 0.6 — Tiptap setup and paragraph block edit module

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Visual Editor Spike</title>
+    </head>
+    <body>
+        <div id="editor-spike-root"></div>
+        <script type="module" src="/resources/js/editor-spike/main.tsx"></script>
+    </body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
             "name": "@artisanpack-ui/visual-editor",
             "version": "1.0.0-spike",
             "dependencies": {
+                "@tiptap/extension-link": "^3.22.3",
+                "@tiptap/react": "^3.22.3",
+                "@tiptap/starter-kit": "^3.22.3",
                 "react": "^19.0.0",
                 "react-dom": "^19.0.0"
             },
@@ -853,6 +856,23 @@
                 "node": ">=12"
             }
         },
+        "node_modules/@floating-ui/core": {
+            "version": "1.7.5",
+            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+            "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@floating-ui/utils": "^0.2.11"
+            }
+        },
+        "node_modules/@floating-ui/utils": {
+            "version": "0.2.11",
+            "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+            "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+            "license": "MIT",
+            "optional": true
+        },
         "node_modules/@jridgewell/gen-mapping": {
             "version": "0.3.13",
             "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -902,6 +922,12 @@
                 "@jridgewell/resolve-uri": "^3.1.0",
                 "@jridgewell/sourcemap-codec": "^1.4.14"
             }
+        },
+        "node_modules/@remirror/core-constants": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-3.0.0.tgz",
+            "integrity": "sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg==",
+            "license": "MIT"
         },
         "node_modules/@rolldown/pluginutils": {
             "version": "1.0.0-beta.27",
@@ -1336,6 +1362,444 @@
                 }
             }
         },
+        "node_modules/@tiptap/core": {
+            "version": "3.22.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.22.3.tgz",
+            "integrity": "sha512-Dv9MKK5BDWCF0N2l6/Pxv3JNCce2kwuWf2cKMBc2bEetx0Pn6o7zlFmSxMvYK4UtG1Tw9Yg/ZHi6QOFWK0Zm9Q==",
+            "license": "MIT",
+            "peer": true,
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/ueberdosis"
+            },
+            "peerDependencies": {
+                "@tiptap/pm": "^3.22.3"
+            }
+        },
+        "node_modules/@tiptap/extension-blockquote": {
+            "version": "3.22.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-blockquote/-/extension-blockquote-3.22.3.tgz",
+            "integrity": "sha512-IaUx3zh7yLHXzIXKL+fw/jzFhsIImdhJyw0lMhe8FfYrefFqXJFYW/sey6+L/e8B3AWvTksPA6VBwefzbH77JA==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/ueberdosis"
+            },
+            "peerDependencies": {
+                "@tiptap/core": "^3.22.3"
+            }
+        },
+        "node_modules/@tiptap/extension-bold": {
+            "version": "3.22.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-bold/-/extension-bold-3.22.3.tgz",
+            "integrity": "sha512-tysipHla2zCWr8XNIWRaW9O+7i7/SoEqnRqSRUUi2ailcJjlia+RBy3RykhkgyThrQDStu5KGBS/UvrXwA+O1A==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/ueberdosis"
+            },
+            "peerDependencies": {
+                "@tiptap/core": "^3.22.3"
+            }
+        },
+        "node_modules/@tiptap/extension-bubble-menu": {
+            "version": "3.22.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-3.22.3.tgz",
+            "integrity": "sha512-Y6zQjh0ypDg32HWgICEvmPSKjGLr39k3aDxxt/H0uQEZSfw4smT0hxUyyyjVjx68C6t6MTnwdfz0hPI5lL68vQ==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@floating-ui/dom": "^1.0.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/ueberdosis"
+            },
+            "peerDependencies": {
+                "@tiptap/core": "^3.22.3",
+                "@tiptap/pm": "^3.22.3"
+            }
+        },
+        "node_modules/@tiptap/extension-bullet-list": {
+            "version": "3.22.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-bullet-list/-/extension-bullet-list-3.22.3.tgz",
+            "integrity": "sha512-xOmW/b1hgECIE6r3IeZvKn4VVlG3+dfTjCWE6lnnyLaqdNkNhKS1CwUmDZdYNLUS2ryIUtgz5ID1W/8A3PhbiA==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/ueberdosis"
+            },
+            "peerDependencies": {
+                "@tiptap/extension-list": "^3.22.3"
+            }
+        },
+        "node_modules/@tiptap/extension-code": {
+            "version": "3.22.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-code/-/extension-code-3.22.3.tgz",
+            "integrity": "sha512-wafWTDQOuMKtXpZEuk1PFQmzopabBciNLryL90MB9S03MNLaQQZYLnmYkDBlzAaLAbgF5QiC+2XZQEBQuTVjFQ==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/ueberdosis"
+            },
+            "peerDependencies": {
+                "@tiptap/core": "^3.22.3"
+            }
+        },
+        "node_modules/@tiptap/extension-code-block": {
+            "version": "3.22.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-3.22.3.tgz",
+            "integrity": "sha512-RiQtEjDAPrHpdo6sw6b7fOw/PijqgFIsozKKkGcSeBgWHQuFg7q9OxJTj+l0e60rVwSu/5gmKEEobzM9bX+t2Q==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/ueberdosis"
+            },
+            "peerDependencies": {
+                "@tiptap/core": "^3.22.3",
+                "@tiptap/pm": "^3.22.3"
+            }
+        },
+        "node_modules/@tiptap/extension-document": {
+            "version": "3.22.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-3.22.3.tgz",
+            "integrity": "sha512-MCSr1PFPtTd++lA3H1RNgqAczAE59XXJ5wUFIQf2F+/0DPY5q2SU4g5QsNJVxPPft5mrNT4C6ty8xBPrALFEdA==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/ueberdosis"
+            },
+            "peerDependencies": {
+                "@tiptap/core": "^3.22.3"
+            }
+        },
+        "node_modules/@tiptap/extension-dropcursor": {
+            "version": "3.22.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-dropcursor/-/extension-dropcursor-3.22.3.tgz",
+            "integrity": "sha512-taXq9Tl5aybdFbptJtFRHX9LFJzbXphAbPp4/vutFyTrBu5meXDxuS+B9pEmE+Or0XcolTlW2nDZB0Tqnr18JQ==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/ueberdosis"
+            },
+            "peerDependencies": {
+                "@tiptap/extensions": "^3.22.3"
+            }
+        },
+        "node_modules/@tiptap/extension-floating-menu": {
+            "version": "3.22.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-floating-menu/-/extension-floating-menu-3.22.3.tgz",
+            "integrity": "sha512-0f8b4KZ3XKai8GXWseIYJGdOfQr3evtFbBo3U08zy2aYzMMXWG0zEF7qe5/oiYp2aZ95edjjITnEceviTsZkIg==",
+            "license": "MIT",
+            "optional": true,
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/ueberdosis"
+            },
+            "peerDependencies": {
+                "@floating-ui/dom": "^1.0.0",
+                "@tiptap/core": "^3.22.3",
+                "@tiptap/pm": "^3.22.3"
+            }
+        },
+        "node_modules/@tiptap/extension-gapcursor": {
+            "version": "3.22.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-gapcursor/-/extension-gapcursor-3.22.3.tgz",
+            "integrity": "sha512-L/Px4UeQEVG/D9WIlcAOIej+4wyIBCMUSYicSR+hW68UsObe4rxVbUas1QgidQKm6DOhoT7U7D4KQHA/Gdg/7A==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/ueberdosis"
+            },
+            "peerDependencies": {
+                "@tiptap/extensions": "^3.22.3"
+            }
+        },
+        "node_modules/@tiptap/extension-hard-break": {
+            "version": "3.22.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-hard-break/-/extension-hard-break-3.22.3.tgz",
+            "integrity": "sha512-J0v8I99y9tbvVmgKYKzKP/JYNsWaZYS7avn4rzLft2OhnyTfwt3OoY8DtpHmmi6apSUaCtoWHWta/TmoEfK1nQ==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/ueberdosis"
+            },
+            "peerDependencies": {
+                "@tiptap/core": "^3.22.3"
+            }
+        },
+        "node_modules/@tiptap/extension-heading": {
+            "version": "3.22.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-heading/-/extension-heading-3.22.3.tgz",
+            "integrity": "sha512-XBHuhiEV2EEhZHpOLcplLqAmBIhJciU3I6AtwmqeEqDC0P114uMEfAO7JGlbBZdCYotNer26PKnu44TBTeNtkw==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/ueberdosis"
+            },
+            "peerDependencies": {
+                "@tiptap/core": "^3.22.3"
+            }
+        },
+        "node_modules/@tiptap/extension-horizontal-rule": {
+            "version": "3.22.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-3.22.3.tgz",
+            "integrity": "sha512-wI2bFzScs+KgWeBH/BtypcVKeYelCyqV0RG8nxsZMWtPrBhqixzNd0Oi3gEKtjSjKUqMQ/kjJAIRuESr5UzlHA==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/ueberdosis"
+            },
+            "peerDependencies": {
+                "@tiptap/core": "^3.22.3",
+                "@tiptap/pm": "^3.22.3"
+            }
+        },
+        "node_modules/@tiptap/extension-italic": {
+            "version": "3.22.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-italic/-/extension-italic-3.22.3.tgz",
+            "integrity": "sha512-LteA4cb4EGCiUtrK2JHvDF/Zg0/YqV4DUyHhAAho+oGEQDupZlsS6m0ia5wQcclkiTLzsoPrwcSNu6RDGQ16wQ==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/ueberdosis"
+            },
+            "peerDependencies": {
+                "@tiptap/core": "^3.22.3"
+            }
+        },
+        "node_modules/@tiptap/extension-link": {
+            "version": "3.22.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-3.22.3.tgz",
+            "integrity": "sha512-S8/P2o9pv6B3kqLjH2TRWwSAximGbciNc6R8/QcN6HWLYxp0N0JoqN3rZHl9VWIBAGRWc4zkt80dhqrl2xmgfQ==",
+            "license": "MIT",
+            "dependencies": {
+                "linkifyjs": "^4.3.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/ueberdosis"
+            },
+            "peerDependencies": {
+                "@tiptap/core": "^3.22.3",
+                "@tiptap/pm": "^3.22.3"
+            }
+        },
+        "node_modules/@tiptap/extension-list": {
+            "version": "3.22.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.22.3.tgz",
+            "integrity": "sha512-rqvv/dtqwbX+8KnPv0eMYp6PnBcuhPMol5cv1GlS8Nq/Cxt68EWGUHBuTFesw+hdnRQLmKwzoO1DlRn7PhxYRQ==",
+            "license": "MIT",
+            "peer": true,
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/ueberdosis"
+            },
+            "peerDependencies": {
+                "@tiptap/core": "^3.22.3",
+                "@tiptap/pm": "^3.22.3"
+            }
+        },
+        "node_modules/@tiptap/extension-list-item": {
+            "version": "3.22.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-list-item/-/extension-list-item-3.22.3.tgz",
+            "integrity": "sha512-80CNf4oO5y8+LdckT4CyMe1t01EyhpRrQC9H45JW20P7559Nrchp5my3vvMtIAJbpTPPZtcB7LwdzWGKsG5drg==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/ueberdosis"
+            },
+            "peerDependencies": {
+                "@tiptap/extension-list": "^3.22.3"
+            }
+        },
+        "node_modules/@tiptap/extension-list-keymap": {
+            "version": "3.22.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-list-keymap/-/extension-list-keymap-3.22.3.tgz",
+            "integrity": "sha512-pKuyj5llu35zd/s2u/H9aydKZjmPRAIK5P1q/YXULhhCNln2RnmuRfQ5NklAqTD3yGciQ2lxDwwf7J6iw3ergA==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/ueberdosis"
+            },
+            "peerDependencies": {
+                "@tiptap/extension-list": "^3.22.3"
+            }
+        },
+        "node_modules/@tiptap/extension-ordered-list": {
+            "version": "3.22.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-ordered-list/-/extension-ordered-list-3.22.3.tgz",
+            "integrity": "sha512-orAghtmd+K4Euu4BgI1hG+iZDXBYOyl5YTwiLBc2mQn+pqtZ9LqaH2us4ETwEwNP3/IWXGSAimUZ19nuL+eM2w==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/ueberdosis"
+            },
+            "peerDependencies": {
+                "@tiptap/extension-list": "^3.22.3"
+            }
+        },
+        "node_modules/@tiptap/extension-paragraph": {
+            "version": "3.22.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-3.22.3.tgz",
+            "integrity": "sha512-oO7rhfyhEuwm+50s9K3GZPjYyEEEvFAvm1wXopvZnhbkBLydIWImBfrZoC5IQh4/sRDlTIjosV2C+ji5y0tUSg==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/ueberdosis"
+            },
+            "peerDependencies": {
+                "@tiptap/core": "^3.22.3"
+            }
+        },
+        "node_modules/@tiptap/extension-strike": {
+            "version": "3.22.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-strike/-/extension-strike-3.22.3.tgz",
+            "integrity": "sha512-jY2InoUlKkuk5KHoIDGdML1OCA2n6PRHAtxwHNkAmiYh0Khf0zaVPGFpx4dgQrN7W5Q1WE6oBZnjrvy6qb7w0g==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/ueberdosis"
+            },
+            "peerDependencies": {
+                "@tiptap/core": "^3.22.3"
+            }
+        },
+        "node_modules/@tiptap/extension-text": {
+            "version": "3.22.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-3.22.3.tgz",
+            "integrity": "sha512-Q9R7JsTdomP5uUjtPjNKxHT1xoh/i9OJZnmgJLe7FcgZEaPOQ3bWxmKZoLZQfDfZjyB8BtH+Hc7nUvhCMOePxw==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/ueberdosis"
+            },
+            "peerDependencies": {
+                "@tiptap/core": "^3.22.3"
+            }
+        },
+        "node_modules/@tiptap/extension-underline": {
+            "version": "3.22.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-underline/-/extension-underline-3.22.3.tgz",
+            "integrity": "sha512-Ch6CBWRa5w90yYSPUW6x9Py9JdrXMqk3pZ9OIlMYD8A7BqyZGfiHerX7XDMYDS09KjyK3U9XH60/zxYOzXdDLA==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/ueberdosis"
+            },
+            "peerDependencies": {
+                "@tiptap/core": "^3.22.3"
+            }
+        },
+        "node_modules/@tiptap/extensions": {
+            "version": "3.22.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.22.3.tgz",
+            "integrity": "sha512-s5eiMq0m5N6N+W7dU6rd60KgZyyCD7FvtPNNswISfPr12EQwJBfbjWwTqd0UKNzA4fNrhQEERXnzORkykttPeA==",
+            "license": "MIT",
+            "peer": true,
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/ueberdosis"
+            },
+            "peerDependencies": {
+                "@tiptap/core": "^3.22.3",
+                "@tiptap/pm": "^3.22.3"
+            }
+        },
+        "node_modules/@tiptap/pm": {
+            "version": "3.22.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.22.3.tgz",
+            "integrity": "sha512-NjfWjZuvrqmpICT+GZWNIjtOdhPyqFKDMtQy7tsQ5rErM9L2ZQdy/+T/BKSO1JdTeBhdg9OP+0yfsqoYp2aT6A==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "prosemirror-changeset": "^2.3.0",
+                "prosemirror-collab": "^1.3.1",
+                "prosemirror-commands": "^1.6.2",
+                "prosemirror-dropcursor": "^1.8.1",
+                "prosemirror-gapcursor": "^1.3.2",
+                "prosemirror-history": "^1.4.1",
+                "prosemirror-inputrules": "^1.4.0",
+                "prosemirror-keymap": "^1.2.2",
+                "prosemirror-markdown": "^1.13.1",
+                "prosemirror-menu": "^1.2.4",
+                "prosemirror-model": "^1.24.1",
+                "prosemirror-schema-basic": "^1.2.3",
+                "prosemirror-schema-list": "^1.5.0",
+                "prosemirror-state": "^1.4.3",
+                "prosemirror-tables": "^1.6.4",
+                "prosemirror-trailing-node": "^3.0.0",
+                "prosemirror-transform": "^1.10.2",
+                "prosemirror-view": "^1.38.1"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/ueberdosis"
+            }
+        },
+        "node_modules/@tiptap/react": {
+            "version": "3.22.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/react/-/react-3.22.3.tgz",
+            "integrity": "sha512-6MNr6z0PxwfJFs+BKhHcvPNvY+UV1PXgqzTiTM4Z9guml84iVZxv7ZOCSj1dFYTr3Bf1MiOs4hT1yvBFlTfIaQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/use-sync-external-store": "^0.0.6",
+                "fast-equals": "^5.3.3",
+                "use-sync-external-store": "^1.4.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/ueberdosis"
+            },
+            "optionalDependencies": {
+                "@tiptap/extension-bubble-menu": "^3.22.3",
+                "@tiptap/extension-floating-menu": "^3.22.3"
+            },
+            "peerDependencies": {
+                "@tiptap/core": "^3.22.3",
+                "@tiptap/pm": "^3.22.3",
+                "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+                "@types/react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/@tiptap/starter-kit": {
+            "version": "3.22.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/starter-kit/-/starter-kit-3.22.3.tgz",
+            "integrity": "sha512-vdW/Oo1fdwTL1VOQ5YYbTov00ANeHLquBVEZyL/EkV7Xv5io9rXQsCysJfTSHhiQlyr2MtWFB4+CPGuwXjQWOQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@tiptap/core": "^3.22.3",
+                "@tiptap/extension-blockquote": "^3.22.3",
+                "@tiptap/extension-bold": "^3.22.3",
+                "@tiptap/extension-bullet-list": "^3.22.3",
+                "@tiptap/extension-code": "^3.22.3",
+                "@tiptap/extension-code-block": "^3.22.3",
+                "@tiptap/extension-document": "^3.22.3",
+                "@tiptap/extension-dropcursor": "^3.22.3",
+                "@tiptap/extension-gapcursor": "^3.22.3",
+                "@tiptap/extension-hard-break": "^3.22.3",
+                "@tiptap/extension-heading": "^3.22.3",
+                "@tiptap/extension-horizontal-rule": "^3.22.3",
+                "@tiptap/extension-italic": "^3.22.3",
+                "@tiptap/extension-link": "^3.22.3",
+                "@tiptap/extension-list": "^3.22.3",
+                "@tiptap/extension-list-item": "^3.22.3",
+                "@tiptap/extension-list-keymap": "^3.22.3",
+                "@tiptap/extension-ordered-list": "^3.22.3",
+                "@tiptap/extension-paragraph": "^3.22.3",
+                "@tiptap/extension-strike": "^3.22.3",
+                "@tiptap/extension-text": "^3.22.3",
+                "@tiptap/extension-underline": "^3.22.3",
+                "@tiptap/extensions": "^3.22.3",
+                "@tiptap/pm": "^3.22.3"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/ueberdosis"
+            }
+        },
         "node_modules/@types/aria-query": {
             "version": "5.0.4",
             "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
@@ -1395,11 +1859,32 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@types/linkify-it": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+            "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+            "license": "MIT"
+        },
+        "node_modules/@types/markdown-it": {
+            "version": "14.1.2",
+            "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+            "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/linkify-it": "^5",
+                "@types/mdurl": "^2"
+            }
+        },
+        "node_modules/@types/mdurl": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+            "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+            "license": "MIT"
+        },
         "node_modules/@types/react": {
             "version": "19.2.14",
             "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
             "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-            "dev": true,
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -1410,12 +1895,17 @@
             "version": "19.2.3",
             "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
             "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-            "dev": true,
             "license": "MIT",
             "peer": true,
             "peerDependencies": {
                 "@types/react": "^19.2.0"
             }
+        },
+        "node_modules/@types/use-sync-external-store": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+            "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+            "license": "MIT"
         },
         "node_modules/@vitejs/plugin-react": {
             "version": "4.7.0",
@@ -1584,6 +2074,12 @@
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
+        "node_modules/argparse": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+            "license": "Python-2.0"
+        },
         "node_modules/aria-query": {
             "version": "5.3.0",
             "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
@@ -1751,6 +2247,12 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/crelt": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+            "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+            "license": "MIT"
+        },
         "node_modules/css.escape": {
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
@@ -1783,7 +2285,6 @@
             "version": "3.2.3",
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
             "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/data-urls": {
@@ -2002,6 +2503,18 @@
                 "node": ">=6"
             }
         },
+        "node_modules/escape-string-regexp": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+            "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/estree-walker": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -2020,6 +2533,15 @@
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=12.0.0"
+            }
+        },
+        "node_modules/fast-equals": {
+            "version": "5.4.0",
+            "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.4.0.tgz",
+            "integrity": "sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.0.0"
             }
         },
         "node_modules/form-data": {
@@ -2314,6 +2836,21 @@
                 "node": ">=6"
             }
         },
+        "node_modules/linkify-it": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+            "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+            "license": "MIT",
+            "dependencies": {
+                "uc.micro": "^2.0.0"
+            }
+        },
+        "node_modules/linkifyjs": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.2.tgz",
+            "integrity": "sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA==",
+            "license": "MIT"
+        },
         "node_modules/loupe": {
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
@@ -2351,6 +2888,35 @@
                 "@jridgewell/sourcemap-codec": "^1.5.5"
             }
         },
+        "node_modules/markdown-it": {
+            "version": "14.1.1",
+            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+            "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+            "license": "MIT",
+            "dependencies": {
+                "argparse": "^2.0.1",
+                "entities": "^4.4.0",
+                "linkify-it": "^5.0.0",
+                "mdurl": "^2.0.0",
+                "punycode.js": "^2.3.1",
+                "uc.micro": "^2.1.0"
+            },
+            "bin": {
+                "markdown-it": "bin/markdown-it.mjs"
+            }
+        },
+        "node_modules/markdown-it/node_modules/entities": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+            "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
         "node_modules/math-intrinsics": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -2360,6 +2926,12 @@
             "engines": {
                 "node": ">= 0.4"
             }
+        },
+        "node_modules/mdurl": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+            "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+            "license": "MIT"
         },
         "node_modules/mime-db": {
             "version": "1.52.0",
@@ -2432,6 +3004,12 @@
             "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
             "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
             "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/orderedmap": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-2.1.1.tgz",
+            "integrity": "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==",
             "license": "MIT"
         },
         "node_modules/parse5": {
@@ -2515,11 +3093,218 @@
                 "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
             }
         },
+        "node_modules/prosemirror-changeset": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/prosemirror-changeset/-/prosemirror-changeset-2.4.0.tgz",
+            "integrity": "sha512-LvqH2v7Q2SF6yxatuPP2e8vSUKS/L+xAU7dPDC4RMyHMhZoGDfBC74mYuyYF4gLqOEG758wajtyhNnsTkuhvng==",
+            "license": "MIT",
+            "dependencies": {
+                "prosemirror-transform": "^1.0.0"
+            }
+        },
+        "node_modules/prosemirror-collab": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/prosemirror-collab/-/prosemirror-collab-1.3.1.tgz",
+            "integrity": "sha512-4SnynYR9TTYaQVXd/ieUvsVV4PDMBzrq2xPUWutHivDuOshZXqQ5rGbZM84HEaXKbLdItse7weMGOUdDVcLKEQ==",
+            "license": "MIT",
+            "dependencies": {
+                "prosemirror-state": "^1.0.0"
+            }
+        },
+        "node_modules/prosemirror-commands": {
+            "version": "1.7.1",
+            "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.7.1.tgz",
+            "integrity": "sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w==",
+            "license": "MIT",
+            "dependencies": {
+                "prosemirror-model": "^1.0.0",
+                "prosemirror-state": "^1.0.0",
+                "prosemirror-transform": "^1.10.2"
+            }
+        },
+        "node_modules/prosemirror-dropcursor": {
+            "version": "1.8.2",
+            "resolved": "https://registry.npmjs.org/prosemirror-dropcursor/-/prosemirror-dropcursor-1.8.2.tgz",
+            "integrity": "sha512-CCk6Gyx9+Tt2sbYk5NK0nB1ukHi2ryaRgadV/LvyNuO3ena1payM2z6Cg0vO1ebK8cxbzo41ku2DE5Axj1Zuiw==",
+            "license": "MIT",
+            "dependencies": {
+                "prosemirror-state": "^1.0.0",
+                "prosemirror-transform": "^1.1.0",
+                "prosemirror-view": "^1.1.0"
+            }
+        },
+        "node_modules/prosemirror-gapcursor": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.4.1.tgz",
+            "integrity": "sha512-pMdYaEnjNMSwl11yjEGtgTmLkR08m/Vl+Jj443167p9eB3HVQKhYCc4gmHVDsLPODfZfjr/MmirsdyZziXbQKw==",
+            "license": "MIT",
+            "dependencies": {
+                "prosemirror-keymap": "^1.0.0",
+                "prosemirror-model": "^1.0.0",
+                "prosemirror-state": "^1.0.0",
+                "prosemirror-view": "^1.0.0"
+            }
+        },
+        "node_modules/prosemirror-history": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.5.0.tgz",
+            "integrity": "sha512-zlzTiH01eKA55UAf1MEjtssJeHnGxO0j4K4Dpx+gnmX9n+SHNlDqI2oO1Kv1iPN5B1dm5fsljCfqKF9nFL6HRg==",
+            "license": "MIT",
+            "dependencies": {
+                "prosemirror-state": "^1.2.2",
+                "prosemirror-transform": "^1.0.0",
+                "prosemirror-view": "^1.31.0",
+                "rope-sequence": "^1.3.0"
+            }
+        },
+        "node_modules/prosemirror-inputrules": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.5.1.tgz",
+            "integrity": "sha512-7wj4uMjKaXWAQ1CDgxNzNtR9AlsuwzHfdFH1ygEHA2KHF2DOEaXl1CJfNPAKCg9qNEh4rum975QLaCiQPyY6Fw==",
+            "license": "MIT",
+            "dependencies": {
+                "prosemirror-state": "^1.0.0",
+                "prosemirror-transform": "^1.0.0"
+            }
+        },
+        "node_modules/prosemirror-keymap": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.2.3.tgz",
+            "integrity": "sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==",
+            "license": "MIT",
+            "dependencies": {
+                "prosemirror-state": "^1.0.0",
+                "w3c-keyname": "^2.2.0"
+            }
+        },
+        "node_modules/prosemirror-markdown": {
+            "version": "1.13.4",
+            "resolved": "https://registry.npmjs.org/prosemirror-markdown/-/prosemirror-markdown-1.13.4.tgz",
+            "integrity": "sha512-D98dm4cQ3Hs6EmjK500TdAOew4Z03EV71ajEFiWra3Upr7diytJsjF4mPV2dW+eK5uNectiRj0xFxYI9NLXDbw==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/markdown-it": "^14.0.0",
+                "markdown-it": "^14.0.0",
+                "prosemirror-model": "^1.25.0"
+            }
+        },
+        "node_modules/prosemirror-menu": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/prosemirror-menu/-/prosemirror-menu-1.3.0.tgz",
+            "integrity": "sha512-TImyPXCHPcDsSka2/lwJ6WjTASr4re/qWq1yoTTuLOqfXucwF6VcRa2LWCkM/EyTD1UO3CUwiH8qURJoWJRxwg==",
+            "license": "MIT",
+            "dependencies": {
+                "crelt": "^1.0.0",
+                "prosemirror-commands": "^1.0.0",
+                "prosemirror-history": "^1.0.0",
+                "prosemirror-state": "^1.0.0"
+            }
+        },
+        "node_modules/prosemirror-model": {
+            "version": "1.25.4",
+            "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
+            "integrity": "sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "orderedmap": "^2.0.0"
+            }
+        },
+        "node_modules/prosemirror-schema-basic": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/prosemirror-schema-basic/-/prosemirror-schema-basic-1.2.4.tgz",
+            "integrity": "sha512-ELxP4TlX3yr2v5rM7Sb70SqStq5NvI15c0j9j/gjsrO5vaw+fnnpovCLEGIcpeGfifkuqJwl4fon6b+KdrODYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "prosemirror-model": "^1.25.0"
+            }
+        },
+        "node_modules/prosemirror-schema-list": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/prosemirror-schema-list/-/prosemirror-schema-list-1.5.1.tgz",
+            "integrity": "sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q==",
+            "license": "MIT",
+            "dependencies": {
+                "prosemirror-model": "^1.0.0",
+                "prosemirror-state": "^1.0.0",
+                "prosemirror-transform": "^1.7.3"
+            }
+        },
+        "node_modules/prosemirror-state": {
+            "version": "1.4.4",
+            "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
+            "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "prosemirror-model": "^1.0.0",
+                "prosemirror-transform": "^1.0.0",
+                "prosemirror-view": "^1.27.0"
+            }
+        },
+        "node_modules/prosemirror-tables": {
+            "version": "1.8.5",
+            "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.8.5.tgz",
+            "integrity": "sha512-V/0cDCsHKHe/tfWkeCmthNUcEp1IVO3p6vwN8XtwE9PZQLAZJigbw3QoraAdfJPir4NKJtNvOB8oYGKRl+t0Dw==",
+            "license": "MIT",
+            "dependencies": {
+                "prosemirror-keymap": "^1.2.3",
+                "prosemirror-model": "^1.25.4",
+                "prosemirror-state": "^1.4.4",
+                "prosemirror-transform": "^1.10.5",
+                "prosemirror-view": "^1.41.4"
+            }
+        },
+        "node_modules/prosemirror-trailing-node": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/prosemirror-trailing-node/-/prosemirror-trailing-node-3.0.0.tgz",
+            "integrity": "sha512-xiun5/3q0w5eRnGYfNlW1uU9W6x5MoFKWwq/0TIRgt09lv7Hcser2QYV8t4muXbEr+Fwo0geYn79Xs4GKywrRQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@remirror/core-constants": "3.0.0",
+                "escape-string-regexp": "^4.0.0"
+            },
+            "peerDependencies": {
+                "prosemirror-model": "^1.22.1",
+                "prosemirror-state": "^1.4.2",
+                "prosemirror-view": "^1.33.8"
+            }
+        },
+        "node_modules/prosemirror-transform": {
+            "version": "1.12.0",
+            "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.12.0.tgz",
+            "integrity": "sha512-GxboyN4AMIsoHNtz5uf2r2Ru551i5hWeCMD6E2Ib4Eogqoub0NflniaBPVQ4MrGE5yZ8JV9tUHg9qcZTTrcN4w==",
+            "license": "MIT",
+            "dependencies": {
+                "prosemirror-model": "^1.21.0"
+            }
+        },
+        "node_modules/prosemirror-view": {
+            "version": "1.41.8",
+            "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.8.tgz",
+            "integrity": "sha512-TnKDdohEatgyZNGCDWIdccOHXhYloJwbwU+phw/a23KBvJIR9lWQWW7WHHK3vBdOLDNuF7TaX98GObUZOWkOnA==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "prosemirror-model": "^1.20.0",
+                "prosemirror-state": "^1.0.0",
+                "prosemirror-transform": "^1.1.0"
+            }
+        },
         "node_modules/punycode": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
             "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
             "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/punycode.js": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+            "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
             "license": "MIT",
             "engines": {
                 "node": ">=6"
@@ -2623,6 +3408,12 @@
                 "@rollup/rollup-win32-x64-msvc": "4.60.1",
                 "fsevents": "~2.3.2"
             }
+        },
+        "node_modules/rope-sequence": {
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/rope-sequence/-/rope-sequence-1.3.4.tgz",
+            "integrity": "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==",
+            "license": "MIT"
         },
         "node_modules/rrweb-cssom": {
             "version": "0.7.1",
@@ -2822,6 +3613,12 @@
                 "node": ">=14.17"
             }
         },
+        "node_modules/uc.micro": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+            "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+            "license": "MIT"
+        },
         "node_modules/update-browserslist-db": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
@@ -2851,6 +3648,15 @@
             },
             "peerDependencies": {
                 "browserslist": ">= 4.21.0"
+            }
+        },
+        "node_modules/use-sync-external-store": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+            "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+            "license": "MIT",
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
             }
         },
         "node_modules/vite": {
@@ -3002,6 +3808,12 @@
                     "optional": true
                 }
             }
+        },
+        "node_modules/w3c-keyname": {
+            "version": "2.2.8",
+            "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+            "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+            "license": "MIT"
         },
         "node_modules/w3c-xmlserializer": {
             "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
         "vitest": "^2.0.0"
     },
     "dependencies": {
+        "@tiptap/extension-link": "^3.22.3",
+        "@tiptap/react": "^3.22.3",
+        "@tiptap/starter-kit": "^3.22.3",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
     }

--- a/resources/js/editor-spike/App.tsx
+++ b/resources/js/editor-spike/App.tsx
@@ -1,11 +1,40 @@
+import { useMemo, useState } from 'react';
+import type { Block } from './mocks/blockTree';
+import { BlockTreeProvider } from './primitives/BlockTreeContext';
+import { BlockPreview } from './primitives/useBlockPreview';
+import { RenderBlock } from './primitives/useInnerBlocksProps';
+import { PARAGRAPH_BLOCK_NAME, registerParagraphBlock } from './blocks/paragraph';
+
+registerParagraphBlock();
+
 export default function App() {
+    const [block] = useState<Block>(() => ({
+        clientId: 'spike-paragraph-1',
+        name: PARAGRAPH_BLOCK_NAME,
+        attributes: {
+            content: '<p>Edit me. Try <strong>Cmd+B</strong> for bold or <em>Cmd+I</em> for italic.</p>',
+        },
+        innerBlocks: [],
+    }));
+
+    const tree = useMemo(() => [block], [block]);
+
     return (
         <main className="editor-spike">
             <h1>Visual Editor Spike</h1>
-            <p>
-                Phase 0 scaffold. Sub-issues #244–#250 fill this in with the mock data layer,
-                primitives, and spike blocks.
-            </p>
+            <p>Phase 0.6: Tiptap + paragraph block edit module.</p>
+
+            <section>
+                <h2>Edit</h2>
+                <BlockTreeProvider blocks={tree}>
+                    <RenderBlock block={block} />
+                </BlockTreeProvider>
+            </section>
+
+            <section>
+                <h2>Preview (read-only)</h2>
+                <BlockPreview blocks={tree} />
+            </section>
         </main>
     );
 }

--- a/resources/js/editor-spike/__tests__/paragraph.test.tsx
+++ b/resources/js/editor-spike/__tests__/paragraph.test.tsx
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { act, render, screen } from '@testing-library/react';
+import { getTiptapEditor } from '../richtext/useTiptap';
+import type { Block } from '../mocks/blockTree';
+import { BlockTreeProvider } from '../primitives/BlockTreeContext';
+import { ReadOnlyProvider } from '../primitives/ReadOnlyContext';
+import { clearRegistry, getBlock } from '../registry';
+import { RenderBlock } from '../primitives/useInnerBlocksProps';
+import { PARAGRAPH_BLOCK_NAME, registerParagraphBlock } from '../blocks/paragraph';
+
+function makeParagraph(content: string): Block {
+    return {
+        clientId: 'p-test',
+        name: PARAGRAPH_BLOCK_NAME,
+        attributes: { content },
+        innerBlocks: [],
+    };
+}
+
+beforeEach(() => {
+    clearRegistry();
+    registerParagraphBlock();
+});
+
+afterEach(() => {
+    clearRegistry();
+});
+
+describe('paragraph block registration', () => {
+    it('registers ve/paragraph in the block registry', () => {
+        expect(getBlock(PARAGRAPH_BLOCK_NAME)).toBeDefined();
+    });
+});
+
+describe('paragraph block edit', () => {
+    it('renders the initial content from attributes.content', () => {
+        const block = makeParagraph('<p>Hello Tiptap</p>');
+
+        render(
+            <BlockTreeProvider blocks={[block]}>
+                <RenderBlock block={block} />
+            </BlockTreeProvider>
+        );
+
+        expect(screen.getByText('Hello Tiptap')).toBeInTheDocument();
+    });
+
+    it('writes back to attributes.content when the editor updates', async () => {
+        const block = makeParagraph('<p>initial</p>');
+
+        render(
+            <BlockTreeProvider blocks={[block]}>
+                <RenderBlock block={block} />
+            </BlockTreeProvider>
+        );
+
+        const tiptap = document.querySelector<HTMLElement>('.ve-richtext.ProseMirror');
+        expect(tiptap).not.toBeNull();
+
+        const editor = getTiptapEditor(tiptap!);
+        expect(editor).not.toBeNull();
+
+        await act(async () => {
+            editor!.commands.insertContentAt(0, 'edited ');
+        });
+
+        expect(typeof block.attributes.content).toBe('string');
+        expect(block.attributes.content as string).toContain('edited');
+        expect(block.attributes.content as string).toContain('initial');
+    });
+
+    it('renders as static, non-editable HTML when read-only', () => {
+        const block = makeParagraph('<p>Preview only</p>');
+
+        render(
+            <BlockTreeProvider blocks={[block]}>
+                <ReadOnlyProvider value={true}>
+                    <RenderBlock block={block} />
+                </ReadOnlyProvider>
+            </BlockTreeProvider>
+        );
+
+        const wrapper = document.querySelector<HTMLElement>(
+            '[data-block-name="ve/paragraph"]'
+        );
+        expect(wrapper).not.toBeNull();
+        expect(wrapper!.getAttribute('data-read-only')).toBe('true');
+        expect(wrapper!.getAttribute('contenteditable')).toBeNull();
+        expect(screen.getByText('Preview only')).toBeInTheDocument();
+        expect(document.querySelector('.ProseMirror')).toBeNull();
+    });
+});

--- a/resources/js/editor-spike/blocks/paragraph/edit.tsx
+++ b/resources/js/editor-spike/blocks/paragraph/edit.tsx
@@ -1,0 +1,36 @@
+import { EditorContent } from '@tiptap/react';
+import type { BlockEditProps } from '../../registry';
+import { useReadOnly } from '../../primitives/ReadOnlyContext';
+import { useTiptap } from '../../richtext/useTiptap';
+
+export default function ParagraphEdit({ clientId, attributes, block }: BlockEditProps) {
+    const readOnly = useReadOnly();
+    const initialContent = typeof attributes.content === 'string' ? attributes.content : '';
+
+    const editor = useTiptap({
+        content: initialContent,
+        editable: !readOnly,
+        onUpdate: (html) => {
+            block.attributes.content = html;
+        },
+    });
+
+    if (readOnly) {
+        return (
+            <div
+                data-client-id={clientId}
+                data-block-name="ve/paragraph"
+                data-read-only="true"
+                dangerouslySetInnerHTML={{ __html: initialContent }}
+            />
+        );
+    }
+
+    return (
+        <EditorContent
+            editor={editor}
+            data-client-id={clientId}
+            data-block-name="ve/paragraph"
+        />
+    );
+}

--- a/resources/js/editor-spike/blocks/paragraph/index.ts
+++ b/resources/js/editor-spike/blocks/paragraph/index.ts
@@ -1,0 +1,13 @@
+import { registerBlock } from '../../registry';
+import ParagraphEdit from './edit';
+
+export const PARAGRAPH_BLOCK_NAME = 've/paragraph';
+
+export function registerParagraphBlock(): void {
+    registerBlock({
+        name: PARAGRAPH_BLOCK_NAME,
+        edit: ParagraphEdit,
+    });
+}
+
+export { default as ParagraphEdit } from './edit';

--- a/resources/js/editor-spike/richtext/useTiptap.ts
+++ b/resources/js/editor-spike/richtext/useTiptap.ts
@@ -1,0 +1,67 @@
+import { useEffect } from 'react';
+import { useEditor, type Editor } from '@tiptap/react';
+import StarterKit from '@tiptap/starter-kit';
+import Link from '@tiptap/extension-link';
+
+export interface UseTiptapOptions {
+    content: string;
+    editable?: boolean;
+    onUpdate?: (html: string, editor: Editor) => void;
+}
+
+const editorsByDom = new WeakMap<HTMLElement, Editor>();
+
+export function getTiptapEditor(domNode: HTMLElement): Editor | null {
+    return editorsByDom.get(domNode) ?? null;
+}
+
+export function useTiptap({
+    content,
+    editable = true,
+    onUpdate,
+}: UseTiptapOptions): Editor | null {
+    const editor = useEditor({
+        extensions: [
+            StarterKit.configure({
+                heading: false,
+                bulletList: false,
+                orderedList: false,
+                listItem: false,
+                blockquote: false,
+                codeBlock: false,
+                horizontalRule: false,
+                link: false,
+            }),
+            Link.configure({
+                openOnClick: false,
+                autolink: true,
+            }),
+        ],
+        content,
+        editable,
+        editorProps: {
+            attributes: {
+                class: 've-richtext',
+            },
+        },
+        onUpdate: ({ editor: activeEditor }) => {
+            onUpdate?.(activeEditor.getHTML(), activeEditor);
+        },
+        immediatelyRender: false,
+    });
+
+    useEffect(() => {
+        if (!editor) {
+            return;
+        }
+
+        const dom = editor.view.dom as HTMLElement;
+        editorsByDom.set(dom, editor);
+
+        return () => {
+            editorsByDom.delete(dom);
+        };
+    }, [editor]);
+
+    return editor;
+}

--- a/resources/js/editor-spike/test-setup.ts
+++ b/resources/js/editor-spike/test-setup.ts
@@ -1,1 +1,36 @@
 import '@testing-library/jest-dom/vitest';
+
+// jsdom does not implement Range.getBoundingClientRect or
+// Document.elementFromPoint, which ProseMirror needs for mouse/selection
+// handling. Stub just enough for Tiptap-driven tests to run.
+if (typeof document !== 'undefined') {
+    if (typeof document.elementFromPoint !== 'function') {
+        document.elementFromPoint = () => null;
+    }
+
+    if (typeof Range !== 'undefined' && !Range.prototype.getBoundingClientRect) {
+        Range.prototype.getBoundingClientRect = function () {
+            return {
+                x: 0,
+                y: 0,
+                top: 0,
+                left: 0,
+                right: 0,
+                bottom: 0,
+                width: 0,
+                height: 0,
+                toJSON: () => ({}),
+            } as DOMRect;
+        };
+    }
+
+    if (typeof Range !== 'undefined' && !Range.prototype.getClientRects) {
+        Range.prototype.getClientRects = function () {
+            return {
+                length: 0,
+                item: () => null,
+                [Symbol.iterator]: function* () {},
+            } as unknown as DOMRectList;
+        };
+    }
+}


### PR DESCRIPTION
## Description

Sets up Tiptap for the Phase 0 spike and builds the first block edit module around it — a `ve/paragraph` block whose edit surface is a Tiptap editor configured for inline-only content. Proves Tiptap works inside the spike's block component model (registry + `BlockTreeProvider` + `useReadOnly`).

**Closes:** #248

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #248 (sub-issue of #236)

## Motivation and Context

Phase 0 of the Alpine→React visual editor migration needs a concrete block that uses Tiptap so the other spike blocks have something to compose with. This PR lands the Tiptap wiring plus the paragraph block's edit module.

## Changes Made

- Add `@tiptap/react`, `@tiptap/starter-kit`, and `@tiptap/extension-link` dependencies.
- Add `resources/js/editor-spike/richtext/useTiptap.ts` — hook that wraps `useEditor` with inline-only StarterKit (headings, lists, blockquote, code-block, horizontal-rule disabled) plus the standalone Link extension. StarterKit's bundled link is disabled to avoid duplicate extensions. Exposes `getTiptapEditor(domNode)` so tests can drive updates through real ProseMirror transactions.
- Add `resources/js/editor-spike/blocks/paragraph/edit.tsx` — reads `attributes.content`, writes back on Tiptap update, and honors `useReadOnly()` by rendering static HTML instead of mounting an editor instance.
- Add `resources/js/editor-spike/blocks/paragraph/index.ts` — `registerParagraphBlock()` registers the block as `ve/paragraph`.
- Wire the paragraph block into the spike `App.tsx` with both an edit view and a read-only `BlockPreview` view.
- Add a standalone `index.html` at the package root so `npm run dev` serves the spike at Vite's dev server (separate from the published Laravel bundle).
- Stub `document.elementFromPoint` and `Range.prototype.getBoundingClientRect`/`getClientRects` in `test-setup.ts` so ProseMirror can mount under jsdom.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (Darwin 25.3.0)
- Browser: Safari / Chrome via `artisanpack-ui.test/editor-spike`
- PHP Version: 8.4.3
- Project Version: 1.0.0-spike

**Tests Performed:**
1. `npm test` — all 25 Vitest tests pass (6 test files).
2. `npm run build` — bundle builds cleanly, no TS errors.
3. `npx tsc --noEmit` — type-check clean.
4. Manual verification in the Laravel dev app (`artisanpack-ui.test/editor-spike`): paragraph renders with seed content, typing works, **Cmd+B**/**Cmd+I** toggle bold/italic via keyboard shortcuts, and the `BlockPreview` section below shows the same content non-interactively.

## Accessibility Tests Run

- [x] Keyboard navigation tested (Cmd+B / Cmd+I shortcuts confirmed)
- [ ] Screen reader tested
- [x] Color contrast verified (unstyled spike — relies on browser defaults)
- [ ] ARIA labels checked

**Details:**

Spike-level work — no chrome beyond Tiptap's built-in contenteditable surface. Full a11y pass will come in later phases when toolbars and menus land.

## Tests Added

- [x] Unit tests added/updated
- [x] All tests passing

**Test details:**

`resources/js/editor-spike/__tests__/paragraph.test.tsx` — 4 tests:
1. Registration: `ve/paragraph` is present in the block registry after `registerParagraphBlock()`.
2. Initial render: the edit view renders `attributes.content` into the Tiptap editor.
3. Write-back: calling `editor.commands.insertContentAt(0, 'edited ')` through the real ProseMirror transaction updates `block.attributes.content`.
4. Read-only: inside a `ReadOnlyProvider value={true}`, the block renders as static HTML with `data-read-only="true"` and no `.ProseMirror` instance.

## Documentation

- [x] Inline code documentation added (JSDoc-style types on public APIs)

**Documentation details:**

Spike code — user-facing documentation comes in a later phase when the public API surface is finalized.

## Screenshots

<!-- add if needed -->

## Pre-Submission Checklist

- [x] Code passes all tests (25/25)
- [x] Self-review completed
- [x] No new warnings generated (Tiptap duplicate-extension warning eliminated by disabling StarterKit's bundled link)

## Out of Scope

Per the issue: floating formatting toolbar (Phase 1), slash commands, block toolbar, anything beyond inline rich text in a single block.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a visual editor spike with paragraph editing and preview capabilities.
  * Added rich text editing with formatting and link support.
  * Paragraphs now support both edit and read-only preview modes for side-by-side comparison.

* **Tests**
  * Added comprehensive test suite for paragraph block functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->