### PR TITLE
feat: post-title spike block consuming BlockContext

### DIFF
--- a/resources/js/editor-spike/App.tsx
+++ b/resources/js/editor-spike/App.tsx
@@ -1,11 +1,14 @@
 import { useMemo, useState } from 'react';
 import type { Block } from './mocks/blockTree';
+import { BlockContextProvider } from './primitives/BlockContext';
 import { BlockTreeProvider } from './primitives/BlockTreeContext';
 import { BlockPreview } from './primitives/useBlockPreview';
 import { RenderBlock } from './primitives/useInnerBlocksProps';
 import { PARAGRAPH_BLOCK_NAME, registerParagraphBlock } from './blocks/paragraph';
+import { POST_TITLE_BLOCK_NAME, registerPostTitleBlock } from './blocks/post-title';
 
 registerParagraphBlock();
+registerPostTitleBlock();
 
 export default function App() {
     const [block] = useState<Block>(() => ({
@@ -17,17 +20,66 @@ export default function App() {
         innerBlocks: [],
     }));
 
-    const tree = useMemo(() => [block], [block]);
+    const [postTitleA] = useState<Block>(() => ({
+        clientId: 'spike-post-title-a',
+        name: POST_TITLE_BLOCK_NAME,
+        attributes: { level: 2 },
+        innerBlocks: [],
+    }));
+
+    const [postTitleB] = useState<Block>(() => ({
+        clientId: 'spike-post-title-b',
+        name: POST_TITLE_BLOCK_NAME,
+        attributes: { level: 2 },
+        innerBlocks: [],
+    }));
+
+    const [postTitleOrphan] = useState<Block>(() => ({
+        clientId: 'spike-post-title-orphan',
+        name: POST_TITLE_BLOCK_NAME,
+        attributes: { level: 2 },
+        innerBlocks: [],
+    }));
+
+    const tree = useMemo(
+        () => [block, postTitleA, postTitleB, postTitleOrphan],
+        [block, postTitleA, postTitleB, postTitleOrphan]
+    );
 
     return (
         <main className="editor-spike">
             <h1>Visual Editor Spike</h1>
-            <p>Phase 0.6: Tiptap + paragraph block edit module.</p>
+            <p>Phase 0.7: post-title block consuming BlockContext.</p>
 
             <section>
                 <h2>Edit</h2>
                 <BlockTreeProvider blocks={tree}>
                     <RenderBlock block={block} />
+                </BlockTreeProvider>
+            </section>
+
+            <section>
+                <h2>post-title with context (postId: 1)</h2>
+                <BlockTreeProvider blocks={tree}>
+                    <BlockContextProvider value={{ postId: 1, postType: 'post' }}>
+                        <RenderBlock block={postTitleA} />
+                    </BlockContextProvider>
+                </BlockTreeProvider>
+            </section>
+
+            <section>
+                <h2>post-title with context (postId: 2)</h2>
+                <BlockTreeProvider blocks={tree}>
+                    <BlockContextProvider value={{ postId: 2, postType: 'post' }}>
+                        <RenderBlock block={postTitleB} />
+                    </BlockContextProvider>
+                </BlockTreeProvider>
+            </section>
+
+            <section>
+                <h2>post-title without context (placeholder)</h2>
+                <BlockTreeProvider blocks={tree}>
+                    <RenderBlock block={postTitleOrphan} />
                 </BlockTreeProvider>
             </section>
 

--- a/resources/js/editor-spike/__tests__/postTitle.test.tsx
+++ b/resources/js/editor-spike/__tests__/postTitle.test.tsx
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { Block } from '../mocks/blockTree';
+import { BlockContextProvider } from '../primitives/BlockContext';
+import { BlockTreeProvider } from '../primitives/BlockTreeContext';
+import { RenderBlock } from '../primitives/useInnerBlocksProps';
+import { clearRegistry, getBlock } from '../registry';
+import {
+    POST_TITLE_BLOCK_NAME,
+    registerPostTitleBlock,
+} from '../blocks/post-title';
+
+function makePostTitle(clientId = 'pt-test'): Block {
+    return {
+        clientId,
+        name: POST_TITLE_BLOCK_NAME,
+        attributes: { level: 2 },
+        innerBlocks: [],
+    };
+}
+
+beforeEach(() => {
+    clearRegistry();
+    registerPostTitleBlock();
+});
+
+afterEach(() => {
+    clearRegistry();
+});
+
+describe('post-title block registration', () => {
+    it('registers ve/post-title in the block registry', () => {
+        expect(getBlock(POST_TITLE_BLOCK_NAME)).toBeDefined();
+    });
+
+    it('declares usesContext for postId and postType', () => {
+        const definition = getBlock(POST_TITLE_BLOCK_NAME);
+        expect(definition?.usesContext).toEqual(['postId', 'postType']);
+    });
+});
+
+describe('post-title block edit', () => {
+    it('renders the post title from the context post', () => {
+        const block = makePostTitle();
+
+        render(
+            <BlockTreeProvider blocks={[block]}>
+                <BlockContextProvider value={{ postId: 1, postType: 'post' }}>
+                    <RenderBlock block={block} />
+                </BlockContextProvider>
+            </BlockTreeProvider>
+        );
+
+        expect(screen.getByText('Lorem ipsum dolor sit amet')).toBeInTheDocument();
+    });
+
+    it('renders a placeholder when no postId is in context', () => {
+        const block = makePostTitle();
+
+        render(
+            <BlockTreeProvider blocks={[block]}>
+                <RenderBlock block={block} />
+            </BlockTreeProvider>
+        );
+
+        const heading = screen.getByText('[post title]');
+        expect(heading).toBeInTheDocument();
+        expect(heading.getAttribute('data-placeholder')).toBe('true');
+    });
+
+    it('shows different titles when wrapped in different BlockContextProviders', () => {
+        const blockA = makePostTitle('pt-a');
+        const blockB = makePostTitle('pt-b');
+
+        render(
+            <BlockTreeProvider blocks={[blockA, blockB]}>
+                <BlockContextProvider value={{ postId: 1, postType: 'post' }}>
+                    <RenderBlock block={blockA} />
+                </BlockContextProvider>
+                <BlockContextProvider value={{ postId: 2, postType: 'post' }}>
+                    <RenderBlock block={blockB} />
+                </BlockContextProvider>
+            </BlockTreeProvider>
+        );
+
+        expect(screen.getByText('Lorem ipsum dolor sit amet')).toBeInTheDocument();
+        expect(screen.getByText('Sed do eiusmod tempor incididunt')).toBeInTheDocument();
+    });
+});

--- a/resources/js/editor-spike/__tests__/postTitle.test.tsx
+++ b/resources/js/editor-spike/__tests__/postTitle.test.tsx
@@ -68,6 +68,22 @@ describe('post-title block edit', () => {
         expect(heading.getAttribute('data-placeholder')).toBe('true');
     });
 
+    it('renders the placeholder when the context post cannot be resolved', () => {
+        const block = makePostTitle();
+
+        render(
+            <BlockTreeProvider blocks={[block]}>
+                <BlockContextProvider value={{ postId: 9999, postType: 'post' }}>
+                    <RenderBlock block={block} />
+                </BlockContextProvider>
+            </BlockTreeProvider>
+        );
+
+        const heading = screen.getByText('[post title]');
+        expect(heading).toBeInTheDocument();
+        expect(heading.getAttribute('data-placeholder')).toBe('true');
+    });
+
     it('shows different titles when wrapped in different BlockContextProviders', () => {
         const blockA = makePostTitle('pt-a');
         const blockB = makePostTitle('pt-b');

--- a/resources/js/editor-spike/blocks/post-title/edit.tsx
+++ b/resources/js/editor-spike/blocks/post-title/edit.tsx
@@ -1,0 +1,28 @@
+import type { BlockEditProps } from '../../registry';
+import { useBlockContextValue } from '../../primitives/BlockContext';
+import { fetchPostField } from '../../mocks/mockApi';
+
+export default function PostTitleEdit({ clientId }: BlockEditProps) {
+    const postId = useBlockContextValue<number>('postId');
+    const postType = useBlockContextValue<string>('postType');
+
+    if (typeof postId !== 'number' || typeof postType !== 'string') {
+        return (
+            <h2
+                data-client-id={clientId}
+                data-block-name="ve/post-title"
+                data-placeholder="true"
+            >
+                [post title]
+            </h2>
+        );
+    }
+
+    const title = fetchPostField(postType, postId, 'title');
+
+    return (
+        <h2 data-client-id={clientId} data-block-name="ve/post-title">
+            {title}
+        </h2>
+    );
+}

--- a/resources/js/editor-spike/blocks/post-title/edit.tsx
+++ b/resources/js/editor-spike/blocks/post-title/edit.tsx
@@ -6,7 +6,12 @@ export default function PostTitleEdit({ clientId }: BlockEditProps) {
     const postId = useBlockContextValue<number>('postId');
     const postType = useBlockContextValue<string>('postType');
 
-    if (typeof postId !== 'number' || typeof postType !== 'string') {
+    const title =
+        typeof postId === 'number' && typeof postType === 'string'
+            ? fetchPostField(postType, postId, 'title')
+            : '';
+
+    if (title === '') {
         return (
             <h2
                 data-client-id={clientId}
@@ -17,8 +22,6 @@ export default function PostTitleEdit({ clientId }: BlockEditProps) {
             </h2>
         );
     }
-
-    const title = fetchPostField(postType, postId, 'title');
 
     return (
         <h2 data-client-id={clientId} data-block-name="ve/post-title">

--- a/resources/js/editor-spike/blocks/post-title/index.ts
+++ b/resources/js/editor-spike/blocks/post-title/index.ts
@@ -1,0 +1,14 @@
+import { registerBlock } from '../../registry';
+import PostTitleEdit from './edit';
+
+export const POST_TITLE_BLOCK_NAME = 've/post-title';
+
+export function registerPostTitleBlock(): void {
+    registerBlock({
+        name: POST_TITLE_BLOCK_NAME,
+        edit: PostTitleEdit,
+        usesContext: ['postId', 'postType'],
+    });
+}
+
+export { default as PostTitleEdit } from './edit';

--- a/resources/js/editor-spike/registry.ts
+++ b/resources/js/editor-spike/registry.ts
@@ -12,6 +12,7 @@ export interface BlockDefinition {
     name: string;
     edit: ComponentType<BlockEditProps>;
     providesContext?: (attributes: Record<string, unknown>, block: Block) => BlockContextValue;
+    usesContext?: string[];
 }
 
 const registry = new Map<string, BlockDefinition>();


### PR DESCRIPTION
## Description

Implements the `post-title` edit module for the Phase 0 React spike (sub-issue of #236). This is the litmus test block — the proof that `BlockContextProvider` actually does what Alpine couldn't: the same block definition renders different data depending on which context wraps it.

**Closes:** #249

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #249

## Motivation and Context

The Phase 0 spike exists to validate that React Context can carry dynamic per-instance data (post id, post type, etc.) down through the block tree in a way Alpine could not. The `post-title` block is the specific block chosen for that validation because its rendered output is entirely derived from context — there is no inline block content. Two instances wrapped in different `BlockContextProvider`s must show different titles for the hypothesis to hold.

## Changes Made

- Added `resources/js/editor-spike/blocks/post-title/edit.tsx` — reads `postId` / `postType` via `useBlockContextValue`, calls `mockApi.fetchPostField()`, renders the resolved title as an `<h2>`, falls back to a `[post title]` placeholder when either context key is missing.
- Added `resources/js/editor-spike/blocks/post-title/index.ts` — registers `ve/post-title` with `usesContext: ['postId', 'postType']`.
- Extended `BlockDefinition` in `resources/js/editor-spike/registry.ts` with an optional `usesContext?: string[]` declarative field (spike descriptor — no `block.json` yet).
- Wired three demo instances into `resources/js/editor-spike/App.tsx`: two wrapped in different `BlockContextProvider`s and one orphan to exercise the placeholder path.

## How Has This Been Tested?

**Tests Performed:**
1. `npm test` — all 30 Vitest tests pass (5 new for post-title).
2. Manual visual test via `npm run dev` — verified two `post-title` instances under different `BlockContextProvider`s render different titles ("Lorem ipsum dolor sit amet" vs. "Sed do eiusmod tempor incididunt") and the unwrapped instance renders `[post title]`.

## Tests Added

- [x] Unit tests added/updated
- [x] All tests passing

**Test details:**

`resources/js/editor-spike/__tests__/postTitle.test.tsx` covers:
- Registration of `ve/post-title` in the block registry
- `usesContext` declaration of `['postId', 'postType']`
- Rendering a resolved title from `BlockContextProvider`-wrapped context
- Placeholder fallback when no context is present
- **The litmus test**: two blocks under different `BlockContextProvider`s show different titles

## Pre-Submission Checklist

- [x] Code passes all tests
- [x] Self-review completed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a post-title block that displays a post's title when context is provided and shows a placeholder otherwise.
  * UI demo updated (Phase 0.7) with three sections illustrating post-title behavior with different context conditions.

* **Tests**
  * Added tests covering registration and rendering of the post-title block across context scenarios.

* **Refactor**
  * Registry enhanced to support blocks declaring context usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->