### PR TITLE
feat: query-loop block with active/inactive post switching

### DIFF
--- a/resources/js/editor-spike/App.tsx
+++ b/resources/js/editor-spike/App.tsx
@@ -1,92 +1,31 @@
-import { useMemo, useState } from 'react';
-import type { Block } from './mocks/blockTree';
-import { BlockContextProvider } from './primitives/BlockContext';
+import { useState } from 'react';
+import { blockTree, type Block } from './mocks/blockTree';
 import { BlockTreeProvider } from './primitives/BlockTreeContext';
-import { BlockPreview } from './primitives/useBlockPreview';
 import { RenderBlock } from './primitives/useInnerBlocksProps';
-import { PARAGRAPH_BLOCK_NAME, registerParagraphBlock } from './blocks/paragraph';
-import { POST_TITLE_BLOCK_NAME, registerPostTitleBlock } from './blocks/post-title';
+import { registerParagraphBlock } from './blocks/paragraph';
+import { registerPostTitleBlock } from './blocks/post-title';
+import { registerQueryLoopBlock } from './blocks/query-loop';
 
 registerParagraphBlock();
 registerPostTitleBlock();
+registerQueryLoopBlock();
 
 export default function App() {
-    const [block] = useState<Block>(() => ({
-        clientId: 'spike-paragraph-1',
-        name: PARAGRAPH_BLOCK_NAME,
-        attributes: {
-            content: '<p>Edit me. Try <strong>Cmd+B</strong> for bold or <em>Cmd+I</em> for italic.</p>',
-        },
-        innerBlocks: [],
-    }));
-
-    const [postTitleA] = useState<Block>(() => ({
-        clientId: 'spike-post-title-a',
-        name: POST_TITLE_BLOCK_NAME,
-        attributes: { level: 2 },
-        innerBlocks: [],
-    }));
-
-    const [postTitleB] = useState<Block>(() => ({
-        clientId: 'spike-post-title-b',
-        name: POST_TITLE_BLOCK_NAME,
-        attributes: { level: 2 },
-        innerBlocks: [],
-    }));
-
-    const [postTitleOrphan] = useState<Block>(() => ({
-        clientId: 'spike-post-title-orphan',
-        name: POST_TITLE_BLOCK_NAME,
-        attributes: { level: 2 },
-        innerBlocks: [],
-    }));
-
-    const tree = useMemo(
-        () => [block, postTitleA, postTitleB, postTitleOrphan],
-        [block, postTitleA, postTitleB, postTitleOrphan]
-    );
+    const [tree] = useState<Block[]>(() => blockTree);
+    const root = tree[0];
 
     return (
         <main className="editor-spike">
             <h1>Visual Editor Spike</h1>
-            <p>Phase 0.7: post-title block consuming BlockContext.</p>
+            <p>
+                Phase 0.8: query-loop block with active/inactive post switching. Edit the active
+                post below; the same change should appear in every inactive preview because they
+                all share the same template.
+            </p>
 
-            <section>
-                <h2>Edit</h2>
-                <BlockTreeProvider blocks={tree}>
-                    <RenderBlock block={block} />
-                </BlockTreeProvider>
-            </section>
-
-            <section>
-                <h2>post-title with context (postId: 1)</h2>
-                <BlockTreeProvider blocks={tree}>
-                    <BlockContextProvider value={{ postId: 1, postType: 'post' }}>
-                        <RenderBlock block={postTitleA} />
-                    </BlockContextProvider>
-                </BlockTreeProvider>
-            </section>
-
-            <section>
-                <h2>post-title with context (postId: 2)</h2>
-                <BlockTreeProvider blocks={tree}>
-                    <BlockContextProvider value={{ postId: 2, postType: 'post' }}>
-                        <RenderBlock block={postTitleB} />
-                    </BlockContextProvider>
-                </BlockTreeProvider>
-            </section>
-
-            <section>
-                <h2>post-title without context (placeholder)</h2>
-                <BlockTreeProvider blocks={tree}>
-                    <RenderBlock block={postTitleOrphan} />
-                </BlockTreeProvider>
-            </section>
-
-            <section>
-                <h2>Preview (read-only)</h2>
-                <BlockPreview blocks={tree} />
-            </section>
+            <BlockTreeProvider blocks={tree}>
+                <RenderBlock block={root} />
+            </BlockTreeProvider>
         </main>
     );
 }

--- a/resources/js/editor-spike/App.tsx
+++ b/resources/js/editor-spike/App.tsx
@@ -10,8 +10,16 @@ registerParagraphBlock();
 registerPostTitleBlock();
 registerQueryLoopBlock();
 
+function cloneBlocks(blocks: Block[]): Block[] {
+    return blocks.map((block) => ({
+        ...block,
+        attributes: { ...block.attributes },
+        innerBlocks: cloneBlocks(block.innerBlocks),
+    }));
+}
+
 export default function App() {
-    const [tree] = useState<Block[]>(() => blockTree);
+    const [tree] = useState<Block[]>(() => cloneBlocks(blockTree));
     const root = tree[0];
 
     return (

--- a/resources/js/editor-spike/__tests__/queryLoop.test.tsx
+++ b/resources/js/editor-spike/__tests__/queryLoop.test.tsx
@@ -1,0 +1,176 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { act, fireEvent, render, screen, within } from '@testing-library/react';
+import type { Block } from '../mocks/blockTree';
+import { BlockTreeProvider } from '../primitives/BlockTreeContext';
+import { RenderBlock } from '../primitives/useInnerBlocksProps';
+import { clearRegistry, getBlock } from '../registry';
+import { PARAGRAPH_BLOCK_NAME, registerParagraphBlock } from '../blocks/paragraph';
+import { POST_TITLE_BLOCK_NAME, registerPostTitleBlock } from '../blocks/post-title';
+import { QUERY_LOOP_BLOCK_NAME, registerQueryLoopBlock } from '../blocks/query-loop';
+import { getTiptapEditor } from '../richtext/useTiptap';
+
+function makeQueryLoopTree(): Block[] {
+    return [
+        {
+            clientId: 'ql-1',
+            name: QUERY_LOOP_BLOCK_NAME,
+            attributes: { postType: 'post', perPage: 5 },
+            innerBlocks: [
+                {
+                    clientId: 'ql-1-title',
+                    name: POST_TITLE_BLOCK_NAME,
+                    attributes: { level: 2 },
+                    innerBlocks: [],
+                },
+                {
+                    clientId: 'ql-1-paragraph',
+                    name: PARAGRAPH_BLOCK_NAME,
+                    attributes: { content: '<p>Shared template body.</p>' },
+                    innerBlocks: [],
+                },
+            ],
+        },
+    ];
+}
+
+beforeEach(() => {
+    clearRegistry();
+    registerParagraphBlock();
+    registerPostTitleBlock();
+    registerQueryLoopBlock();
+});
+
+afterEach(() => {
+    clearRegistry();
+});
+
+describe('query-loop block registration', () => {
+    it('registers ve/query-loop in the block registry', () => {
+        expect(getBlock(QUERY_LOOP_BLOCK_NAME)).toBeDefined();
+    });
+});
+
+describe('query-loop block edit', () => {
+    it('renders one post article per mock post returned by the query', () => {
+        const tree = makeQueryLoopTree();
+
+        render(
+            <BlockTreeProvider blocks={tree}>
+                <RenderBlock block={tree[0]} />
+            </BlockTreeProvider>
+        );
+
+        const articles = document.querySelectorAll('[data-post-id]');
+        expect(articles).toHaveLength(5);
+    });
+
+    it('renders the correct per-post title via BlockContext (not all the same)', () => {
+        const tree = makeQueryLoopTree();
+
+        render(
+            <BlockTreeProvider blocks={tree}>
+                <RenderBlock block={tree[0]} />
+            </BlockTreeProvider>
+        );
+
+        expect(screen.getByText('Lorem ipsum dolor sit amet')).toBeInTheDocument();
+        expect(screen.getByText('Sed do eiusmod tempor incididunt')).toBeInTheDocument();
+        expect(screen.getByText('Duis aute irure dolor in reprehenderit')).toBeInTheDocument();
+        expect(screen.getByText('Curabitur pretium tincidunt lacus')).toBeInTheDocument();
+        expect(
+            screen.getByText('Praesent dapibus, neque id cursus faucibus')
+        ).toBeInTheDocument();
+    });
+
+    it('marks the first post as active by default and all others as inactive', () => {
+        const tree = makeQueryLoopTree();
+
+        render(
+            <BlockTreeProvider blocks={tree}>
+                <RenderBlock block={tree[0]} />
+            </BlockTreeProvider>
+        );
+
+        const activePosts = document.querySelectorAll('[data-active="true"]');
+        const inactivePosts = document.querySelectorAll('[data-active="false"]');
+        expect(activePosts).toHaveLength(1);
+        expect(inactivePosts).toHaveLength(4);
+        expect(activePosts[0].getAttribute('data-post-id')).toBe('1');
+    });
+
+    it('renders a live Tiptap editor inside the active post only', () => {
+        const tree = makeQueryLoopTree();
+
+        render(
+            <BlockTreeProvider blocks={tree}>
+                <RenderBlock block={tree[0]} />
+            </BlockTreeProvider>
+        );
+
+        const tiptapEditors = document.querySelectorAll('.ve-richtext.ProseMirror');
+        expect(tiptapEditors).toHaveLength(1);
+
+        const activePost = document.querySelector<HTMLElement>('[data-active="true"]');
+        expect(activePost).not.toBeNull();
+        expect(activePost!.querySelector('.ve-richtext.ProseMirror')).not.toBeNull();
+    });
+
+    it('activates a previously-inactive post when its Edit button is clicked', () => {
+        const tree = makeQueryLoopTree();
+
+        render(
+            <BlockTreeProvider blocks={tree}>
+                <RenderBlock block={tree[0]} />
+            </BlockTreeProvider>
+        );
+
+        const thirdPost = document.querySelector<HTMLElement>('[data-post-id="3"]');
+        expect(thirdPost).not.toBeNull();
+        const activateButton = within(thirdPost!).getByRole('button', { name: /edit this post/i });
+
+        fireEvent.click(activateButton);
+
+        expect(
+            document.querySelector('[data-post-id="3"]')!.getAttribute('data-active')
+        ).toBe('true');
+        expect(
+            document.querySelector('[data-post-id="1"]')!.getAttribute('data-active')
+        ).toBe('false');
+
+        // Only the newly active post has a Tiptap editor.
+        const tiptapEditors = document.querySelectorAll('.ve-richtext.ProseMirror');
+        expect(tiptapEditors).toHaveLength(1);
+        expect(
+            document.querySelector('[data-post-id="3"]')!.querySelector('.ve-richtext.ProseMirror')
+        ).not.toBeNull();
+    });
+
+    it('propagates edits in the active post to every inactive preview (shared template)', async () => {
+        const tree = makeQueryLoopTree();
+
+        render(
+            <BlockTreeProvider blocks={tree}>
+                <RenderBlock block={tree[0]} />
+            </BlockTreeProvider>
+        );
+
+        const tiptap = document.querySelector<HTMLElement>('.ve-richtext.ProseMirror');
+        expect(tiptap).not.toBeNull();
+
+        const editor = getTiptapEditor(tiptap!);
+        expect(editor).not.toBeNull();
+
+        await act(async () => {
+            editor!.commands.insertContentAt(0, 'SYNCED ');
+        });
+
+        // All four inactive previews should now show the edited text.
+        const previews = document.querySelectorAll(
+            '[data-active="false"] [data-block-name="ve/paragraph"]'
+        );
+        expect(previews).toHaveLength(4);
+        previews.forEach((preview) => {
+            expect(preview.textContent).toContain('SYNCED');
+        });
+    });
+});

--- a/resources/js/editor-spike/blocks/paragraph/edit.tsx
+++ b/resources/js/editor-spike/blocks/paragraph/edit.tsx
@@ -1,10 +1,12 @@
 import { EditorContent } from '@tiptap/react';
 import type { BlockEditProps } from '../../registry';
+import { useBlockContextValue } from '../../primitives/BlockContext';
 import { useReadOnly } from '../../primitives/ReadOnlyContext';
 import { useTiptap } from '../../richtext/useTiptap';
 
 export default function ParagraphEdit({ clientId, attributes, block }: BlockEditProps) {
     const readOnly = useReadOnly();
+    const bumpTemplate = useBlockContextValue<() => void>('__bumpTemplate');
     const initialContent = typeof attributes.content === 'string' ? attributes.content : '';
 
     const editor = useTiptap({
@@ -12,6 +14,7 @@ export default function ParagraphEdit({ clientId, attributes, block }: BlockEdit
         editable: !readOnly,
         onUpdate: (html) => {
             block.attributes.content = html;
+            bumpTemplate?.();
         },
     });
 

--- a/resources/js/editor-spike/blocks/query-loop/edit.tsx
+++ b/resources/js/editor-spike/blocks/query-loop/edit.tsx
@@ -1,0 +1,84 @@
+import { useCallback, useMemo, useState } from 'react';
+import type { BlockEditProps } from '../../registry';
+import { BlockContextProvider } from '../../primitives/BlockContext';
+import { BlockPreview } from '../../primitives/useBlockPreview';
+import { InnerBlocks } from '../../primitives/useInnerBlocksProps';
+import { fetchQueryResults, type Query } from '../../mocks/mockApi';
+
+const DEFAULT_QUERY: Query = { postType: 'post', perPage: 5 };
+
+function readQuery(attributes: Record<string, unknown>): Query {
+    const postType =
+        typeof attributes.postType === 'string' ? attributes.postType : DEFAULT_QUERY.postType;
+    const perPage =
+        typeof attributes.perPage === 'number' ? attributes.perPage : DEFAULT_QUERY.perPage;
+
+    return { postType, perPage };
+}
+
+export default function QueryLoopEdit({ clientId, attributes, block }: BlockEditProps) {
+    const query = useMemo(() => readQuery(attributes), [attributes]);
+    const posts = useMemo(() => fetchQueryResults(query), [query]);
+
+    const [activePostId, setActivePostId] = useState<number | null>(
+        () => posts[0]?.id ?? null
+    );
+    const [templateVersion, setTemplateVersion] = useState(0);
+
+    const bumpTemplate = useCallback(() => {
+        setTemplateVersion((v) => v + 1);
+    }, []);
+
+    return (
+        <div
+            data-client-id={clientId}
+            data-block-name="ve/query-loop"
+            className="ve-query-loop"
+        >
+            {posts.map((post) => {
+                const isActive = post.id === activePostId;
+
+                return (
+                    <BlockContextProvider
+                        key={post.id}
+                        value={{
+                            postId: post.id,
+                            postType: post.type,
+                            __bumpTemplate: bumpTemplate,
+                        }}
+                    >
+                        <article
+                            className={`ve-query-loop__post${
+                                isActive ? ' ve-query-loop__post--active' : ''
+                            }`}
+                            data-post-id={post.id}
+                            data-active={isActive ? 'true' : 'false'}
+                        >
+                            {isActive ? (
+                                <InnerBlocks
+                                    parentClientId={clientId}
+                                    className="ve-query-loop__content"
+                                />
+                            ) : (
+                                <>
+                                    <BlockPreview
+                                        key={templateVersion}
+                                        blocks={block.innerBlocks}
+                                        className="ve-query-loop__content ve-query-loop__content--preview"
+                                    />
+                                    <button
+                                        type="button"
+                                        className="ve-query-loop__activate"
+                                        onClick={() => setActivePostId(post.id)}
+                                    >
+                                        Edit this post
+                                    </button>
+                                </>
+                            )}
+                        </article>
+                    </BlockContextProvider>
+                );
+            })}
+        </div>
+    );
+}

--- a/resources/js/editor-spike/blocks/query-loop/edit.tsx
+++ b/resources/js/editor-spike/blocks/query-loop/edit.tsx
@@ -10,8 +10,12 @@ const DEFAULT_QUERY: Query = { postType: 'post', perPage: 5 };
 function readQuery(attributes: Record<string, unknown>): Query {
     const postType =
         typeof attributes.postType === 'string' ? attributes.postType : DEFAULT_QUERY.postType;
+
+    const rawPerPage = attributes.perPage;
     const perPage =
-        typeof attributes.perPage === 'number' ? attributes.perPage : DEFAULT_QUERY.perPage;
+        typeof rawPerPage === 'number' && Number.isFinite(rawPerPage) && rawPerPage > 0
+            ? Math.floor(rawPerPage)
+            : DEFAULT_QUERY.perPage;
 
     return { postType, perPage };
 }

--- a/resources/js/editor-spike/blocks/query-loop/index.ts
+++ b/resources/js/editor-spike/blocks/query-loop/index.ts
@@ -1,0 +1,13 @@
+import { registerBlock } from '../../registry';
+import QueryLoopEdit from './edit';
+
+export const QUERY_LOOP_BLOCK_NAME = 've/query-loop';
+
+export function registerQueryLoopBlock(): void {
+    registerBlock({
+        name: QUERY_LOOP_BLOCK_NAME,
+        edit: QueryLoopEdit,
+    });
+}
+
+export { default as QueryLoopEdit } from './edit';

--- a/resources/js/editor-spike/index.css
+++ b/resources/js/editor-spike/index.css
@@ -26,3 +26,57 @@ body {
     margin-top: 0;
     font-size: 1.75rem;
 }
+
+.ve-query-loop {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    margin-top: 2rem;
+}
+
+.ve-query-loop__post {
+    position: relative;
+    padding: 1.25rem 1.5rem;
+    border: 1px solid #e2e8f0;
+    border-radius: 8px;
+    background: #ffffff;
+    transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+.ve-query-loop__post--active {
+    border-color: #2563eb;
+    background: #eff6ff;
+    box-shadow: 0 0 0 1px #2563eb inset;
+}
+
+.ve-query-loop__content {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.ve-query-loop__content--preview {
+    opacity: 0.85;
+}
+
+.ve-query-loop__activate {
+    margin-top: 0.75rem;
+    padding: 0.375rem 0.875rem;
+    font-size: 0.8125rem;
+    font-weight: 500;
+    color: #1d4ed8;
+    background: transparent;
+    border: 1px solid #93c5fd;
+    border-radius: 6px;
+    cursor: pointer;
+}
+
+.ve-query-loop__activate:hover {
+    background: #dbeafe;
+}
+
+.ve-query-loop__activate:focus-visible {
+    background: #dbeafe;
+    outline: 2px solid #2563eb;
+    outline-offset: 2px;
+}

--- a/resources/js/editor-spike/mocks/blockTree.ts
+++ b/resources/js/editor-spike/mocks/blockTree.ts
@@ -26,7 +26,7 @@ export const blockTree: Block[] = [
                 clientId: 'block-paragraph-1',
                 name: 've/paragraph',
                 attributes: {
-                    field: 'excerpt',
+                    content: '<p>Edit me. This template is shared across every post in the loop.</p>',
                 },
                 innerBlocks: [],
             },


### PR DESCRIPTION
## Description

Implements the Phase 0 spike deliverable that ties the spike together: a `query-loop` block that fetches N posts via `mockApi`, renders each inside its own `BlockContextProvider`, keeps one post active (editable `InnerBlocks`) and the rest as read-only `BlockPreview`s, and propagates template edits from the active post to every inactive preview.

**Closes:** #250

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #250

## Motivation and Context

Phase 0's decision gate. If the query-loop spike works end-to-end with shared-template propagation, the React/Tiptap/BlockContext architecture is sound and Phase 1 can proceed.

## Changes Made

- Add `resources/js/editor-spike/blocks/query-loop/{edit.tsx,index.ts}` — the new block
- `paragraph/edit.tsx` now reads `__bumpTemplate` from block context and calls it from Tiptap's `onUpdate`, so shared-template previews re-render when the active post is edited
- `mocks/blockTree.ts` paragraph attribute switches from `field: 'excerpt'` to an editable `content` so it can serve as the shared template
- `App.tsx` now renders the single `query-loop` root from `blockTree.ts` (replaces the previous per-block playground)
- `index.css` adds query-loop layout, active-post highlight (blue border + background), and an accessible focus ring on the activate button
- `__tests__/queryLoop.test.tsx` — 7 new tests covering all 5 Phase 0 acceptance criteria

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS
- Browser: Chrome (Vite dev server)

**Tests Performed:**
1. `npm test` — **38 passed** (31 prior + 7 new query-loop tests)
2. Manual verification in the spike app: 5 posts render, each shows its own title via context, post 1 is active by default with a live Tiptap editor, clicking "Edit this post" on any inactive post activates it, and typing in the active paragraph updates all four inactive previews in real time

## Accessibility Tests Run

- [x] Keyboard navigation tested
- [x] Color contrast verified (focus ring)

**Details:** Activate button has a visible `outline: 2px solid #2563eb` focus ring via `:focus-visible` (surfaced by the CodeRabbit review).

## Tests Added

- [x] Unit tests added/updated
- [x] All tests passing

**Test details:** `queryLoop.test.tsx` asserts: block registration, 5 posts render, per-post titles differ via `BlockContext`, post 1 is active by default, only the active post has a live Tiptap `.ProseMirror`, clicking activate swaps the active post, and Tiptap edits propagate to every inactive preview.

## Pre-Submission Checklist

- [x] Code passes all tests
- [x] Self-review completed
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Query Loop block shows multiple posts as a vertical list; click "Edit this post" to activate and edit a single post with a live editor while others show previews.
  * Shared template editing updates preview content across all inactive posts.

* **Style**
  * New styles for list layout, post cards, active state, previews, and activate button.

* **Tests**
  * Added tests covering rendering, activation switching, editor presence, and template-propagation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->