### PR TITLE
chore: ignore .vite build cache directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ vendor/
 .idea/
 node_modules/
 public/editor-spike/
+.vite/
 *.log


### PR DESCRIPTION
## Description

Adds \`.vite/\` to \`.gitignore\` so the local Vite build cache stops showing up as untracked after \`npm test\` / \`vite build\` runs.

**Closes:** N/A (housekeeping, no tracking issue)

## Type of Change

- [x] Chore / Maintenance

## Changes Made

- Added \`.vite/\` to \`.gitignore\` below \`public/editor-spike/\`

## How Has This Been Tested?

N/A — gitignore-only change. Verified locally that \`git status\` no longer reports \`.vite/\` as untracked.

## Pre-Submission Checklist

- [x] Self-review completed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `.gitignore` to exclude Vite build and cache directories from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->