### PR TITLE
feat: Phase 1.1 — production Vite config with dev server + externalized React

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,6 @@ vendor/
 .idea/
 node_modules/
 public/editor-spike/
+dist/
+.vite/
 *.log

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
     "scripts": {
         "dev": "vite",
         "build": "vite build",
+        "dev:editor": "vite --config vite.editor.config.ts",
+        "build:editor": "vite build --config vite.editor.config.ts",
         "test": "vitest run",
         "test:watch": "vitest"
     },

--- a/resources/js/visual-editor/editor/index.html
+++ b/resources/js/visual-editor/editor/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>ArtisanPack Visual Editor (dev)</title>
+    </head>
+    <body>
+        <div id="visual-editor-root"></div>
+        <script type="module" src="./main.tsx"></script>
+    </body>
+</html>

--- a/resources/js/visual-editor/editor/main.tsx
+++ b/resources/js/visual-editor/editor/main.tsx
@@ -1,0 +1,25 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+
+const MOUNT_ID = 'visual-editor-root';
+
+function EditorPlaceholder() {
+    return (
+        <div className="ve-editor-placeholder">
+            <h1>ArtisanPack Visual Editor</h1>
+            <p>Phase 1.1 placeholder. The real editor root lands in later issues.</p>
+        </div>
+    );
+}
+
+const container = document.getElementById(MOUNT_ID);
+
+if (!container) {
+    throw new Error(`visual-editor: missing #${MOUNT_ID} mount point`);
+}
+
+createRoot(container).render(
+    <StrictMode>
+        <EditorPlaceholder />
+    </StrictMode>
+);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,9 +19,13 @@
         "types": ["vitest/globals", "@testing-library/jest-dom"],
         "baseUrl": ".",
         "paths": {
-            "@spike/*": ["resources/js/editor-spike/*"]
+            "@spike/*": ["resources/js/editor-spike/*"],
+            "@editor/*": ["resources/js/visual-editor/editor/*"]
         }
     },
-    "include": ["resources/js/editor-spike/**/*"],
+    "include": [
+        "resources/js/editor-spike/**/*",
+        "resources/js/visual-editor/**/*"
+    ],
     "exclude": ["node_modules", "vendor", "public", "dist"]
 }

--- a/vite.editor.config.ts
+++ b/vite.editor.config.ts
@@ -1,0 +1,42 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import { resolve } from 'node:path';
+
+const editorRoot = resolve(__dirname, 'resources/js/visual-editor/editor');
+
+export default defineConfig(({ command }) => ({
+    plugins: [react()],
+    root: command === 'serve' ? editorRoot : __dirname,
+    resolve: {
+        alias: {
+            '@editor': editorRoot,
+        },
+    },
+    server: {
+        port: 5175,
+        strictPort: false,
+    },
+    build: {
+        target: 'esnext',
+        outDir: resolve(__dirname, 'dist/editor'),
+        emptyOutDir: true,
+        manifest: false,
+        sourcemap: true,
+        rollupOptions: {
+            input: resolve(editorRoot, 'main.tsx'),
+            external: [
+                'react',
+                'react/jsx-runtime',
+                'react/jsx-dev-runtime',
+                'react-dom',
+                'react-dom/client',
+            ],
+            output: {
+                format: 'es',
+                entryFileNames: 'main.js',
+                chunkFileNames: '[name].js',
+                assetFileNames: '[name][extname]',
+            },
+        },
+    },
+}));


### PR DESCRIPTION
## Description

Stands up a production-ready Vite pipeline for the new visual editor package alongside the existing Phase 0 spike build. Adds a placeholder entry point, a dedicated editor Vite config that externalizes React/ReactDOM/JSX runtime so host Laravel apps can dedupe, a dev HTML mount, and new npm scripts. The spike build at `public/editor-spike/` is untouched.

**Closes:** #263

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #263

## Motivation and Context

Phase 1.1 of the Alpine → React visual editor migration (sub-issue of #237). The Phase 0 spike config remains in place during the overlap period; this adds a parallel production build that targets `dist/editor/` for host app consumption.

## Changes Made

- New entry point: `resources/js/visual-editor/editor/main.tsx` (placeholder — real root lands in later issues)
- New dev HTML: `resources/js/visual-editor/editor/index.html` (mount point for dev server)
- New config: `vite.editor.config.ts` — root switches per command (dev serves the editor dir, build runs from package root), builds to `dist/editor/` with sourcemaps
- Externalizes `react`, `react/jsx-runtime`, `react/jsx-dev-runtime`, `react-dom`, `react-dom/client` via `rollupOptions.external` (ES format output)
- `tsconfig.json`: adds `@editor/*` path alias and `resources/js/visual-editor/**/*` include
- `package.json`: adds `build:editor` and `dev:editor` scripts alongside existing spike scripts
- `.gitignore`: ignores `dist/` and `.vite/` cache directories

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (Darwin 25.3.0)
- Browser: Chrome (dev server smoke test)
- Node: project-pinned
- Project Version: 1.0.0-spike

**Tests Performed:**
1. `npm run build:editor` → produces `dist/editor/main.js` (~0.54 kB) with all React imports externalized (verified via bundle inspection — only `import { jsx, jsxs } from "react/jsx-runtime"`, `import { StrictMode } from "react"`, `import { createRoot } from "react-dom/client"`)
2. `npm run dev:editor` → starts dev server on port 5175, mounts placeholder at `#visual-editor-root`, HMR works
3. `npm run build` (spike) → still produces `public/editor-spike/main.js` unchanged (570 kB non-externalized bundle)
4. `npm test` → 38/38 tests passing across 8 files
5. CodeRabbit CLI review against `add/phase-one` → no findings after cleanup pass

## Tests Added

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All tests passing

**Test details:** No new tests — the placeholder entry point has no logic to test. Existing 38 tests still pass. Real tests will land with the actual editor root in later Phase 1 issues.

## Documentation

- [x] Inline code documentation added

**Documentation details:** Placeholder entry includes a clarifying comment about what lands in later issues. Broader docs/wiki updates for the new build scripts will come alongside the final Phase 1 issue (spike deletion).

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [x] Code follows project style guide
- [x] Self-review completed
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added editor-specific npm scripts (`dev:editor`, `build:editor`) for development and builds.
  * Introduced new application entrypoint with placeholder interface.

* **Chores**
  * Expanded TypeScript configuration with new module alias and compilation scope.
  * Updated .gitignore to exclude build output directories.
  * Added alternative Vite build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->