### PR TITLE
feat: blade mount view and boot script for React editor

### DIFF
--- a/resources/js/visual-editor/editor/index.html
+++ b/resources/js/visual-editor/editor/index.html
@@ -6,7 +6,12 @@
         <title>ArtisanPack Visual Editor (dev)</title>
     </head>
     <body>
-        <div id="visual-editor-root"></div>
+        <div
+            id="ve-root"
+            data-post-id="1"
+            data-post-type="page"
+            data-api-base="/api"
+        ></div>
         <script type="module" src="./main.tsx"></script>
     </body>
 </html>

--- a/resources/js/visual-editor/editor/main.tsx
+++ b/resources/js/visual-editor/editor/main.tsx
@@ -29,7 +29,9 @@ function EditorShell({ postId, postType, apiBase }: EditorShellProps) {
 }
 
 function readEditorConfig(container: HTMLElement): EditorConfig | null {
-    const { postId, postType, apiBase } = container.dataset;
+    const postId = container.dataset.postId?.trim();
+    const postType = container.dataset.postType?.trim();
+    const apiBase = container.dataset.apiBase?.trim();
 
     if (!postId || !postType || !apiBase) {
         return null;

--- a/resources/js/visual-editor/editor/main.tsx
+++ b/resources/js/visual-editor/editor/main.tsx
@@ -1,25 +1,67 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 
-const MOUNT_ID = 'visual-editor-root';
+const MOUNT_ID = 've-root';
 
-function EditorPlaceholder() {
+type EditorConfig = {
+    postId: string;
+    postType: string;
+    apiBase: string;
+};
+
+type EditorShellProps = EditorConfig;
+
+function EditorShell({ postId, postType, apiBase }: EditorShellProps) {
     return (
         <div className="ve-editor-placeholder">
             <h1>ArtisanPack Visual Editor</h1>
-            <p>Phase 1.1 placeholder. The real editor root lands in later issues.</p>
+            <p>Placeholder shell — the real editor lands in issue #270.</p>
+            <dl>
+                <dt>postId</dt>
+                <dd>{postId}</dd>
+                <dt>postType</dt>
+                <dd>{postType}</dd>
+                <dt>apiBase</dt>
+                <dd>{apiBase}</dd>
+            </dl>
         </div>
     );
 }
 
-const container = document.getElementById(MOUNT_ID);
+function readEditorConfig(container: HTMLElement): EditorConfig | null {
+    const { postId, postType, apiBase } = container.dataset;
 
-if (!container) {
-    throw new Error(`visual-editor: missing #${MOUNT_ID} mount point`);
+    if (!postId || !postType || !apiBase) {
+        return null;
+    }
+
+    return { postId, postType, apiBase };
 }
 
-createRoot(container).render(
-    <StrictMode>
-        <EditorPlaceholder />
-    </StrictMode>
-);
+function bootEditor(): void {
+    const container = document.getElementById(MOUNT_ID);
+
+    if (!container) {
+        console.error(
+            `visual-editor: missing #${MOUNT_ID} mount point. Include resources/views/editor/mount.blade.php or render a <div id="${MOUNT_ID}"> with data-post-id, data-post-type, and data-api-base.`
+        );
+        return;
+    }
+
+    const config = readEditorConfig(container);
+
+    if (!config) {
+        console.error(
+            `visual-editor: #${MOUNT_ID} is missing required data attributes. Expected data-post-id, data-post-type, and data-api-base.`
+        );
+        return;
+    }
+
+    createRoot(container).render(
+        <StrictMode>
+            <EditorShell {...config} />
+        </StrictMode>
+    );
+}
+
+bootEditor();

--- a/resources/views/editor/mount.blade.php
+++ b/resources/views/editor/mount.blade.php
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title>ArtisanPack Visual Editor</title>
+	@viteReactRefresh
+	@vite(['resources/js/visual-editor/editor/main.tsx'])
+</head>
+<body>
+	<div
+		id="ve-root"
+		data-post-id="{{ $postId }}"
+		data-post-type="{{ $postType }}"
+		data-api-base="{{ $apiBase }}"
+	></div>
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -7,3 +7,11 @@ use Illuminate\Support\Facades\Route;
 Route::get('/editor-spike', function () {
     return view('visual-editor::editor-spike');
 })->name('visual-editor.editor-spike');
+
+Route::get('/editor', function () {
+    return view('visual-editor::editor.mount', [
+        'postId' => '1',
+        'postType' => 'page',
+        'apiBase' => '/api',
+    ]);
+})->name('visual-editor.editor');

--- a/tests/Feature/EditorMountViewTest.php
+++ b/tests/Feature/EditorMountViewTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+$viewPath = __DIR__.'/../../resources/views/editor/mount.blade.php';
+$routesPath = __DIR__.'/../../routes/web.php';
+$bootPath = __DIR__.'/../../resources/js/visual-editor/editor/main.tsx';
+
+test('mount blade view exists', function () use ($viewPath) {
+    expect(file_exists($viewPath))->toBeTrue();
+});
+
+test('mount blade view renders the ve-root element with data attributes', function () use ($viewPath) {
+    $contents = file_get_contents($viewPath);
+
+    expect($contents)->toContain('id="ve-root"');
+    expect($contents)->toContain('data-post-id="{{ $postId }}"');
+    expect($contents)->toContain('data-post-type="{{ $postType }}"');
+    expect($contents)->toContain('data-api-base="{{ $apiBase }}"');
+});
+
+test('mount blade view pulls the editor entry through @vite', function () use ($viewPath) {
+    $contents = file_get_contents($viewPath);
+
+    expect($contents)->toContain("@vite(['resources/js/visual-editor/editor/main.tsx'])");
+});
+
+test('package routes register the /editor path next to /editor-spike', function () use ($routesPath) {
+    $contents = file_get_contents($routesPath);
+
+    expect($contents)->toContain("Route::get('/editor'");
+    expect($contents)->toContain('visual-editor::editor.mount');
+    expect($contents)->toContain("'postId'");
+    expect($contents)->toContain("'postType'");
+    expect($contents)->toContain("'apiBase'");
+    expect($contents)->toContain('/editor-spike');
+});
+
+test('boot script targets #ve-root and logs a clear error when missing', function () use ($bootPath) {
+    $contents = file_get_contents($bootPath);
+
+    expect($contents)->toContain("'ve-root'");
+    expect($contents)->toContain('console.error');
+    expect($contents)->toContain('data-post-id');
+    expect($contents)->toContain('data-post-type');
+    expect($contents)->toContain('data-api-base');
+});


### PR DESCRIPTION
## Description

Lands Phase 1.2 of the Alpine→React visual editor migration: the Blade mount view host apps include to render the editor, plus the boot script that reads config from `data-*` attributes and mounts the React root.

**Closes:** #264

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #264

## Motivation and Context

Host apps need a single include point to drop the React editor into any page without needing to know React internals. This PR provides that entry point, following directly on #263 (production Vite config + externalized React).

## Changes Made

- `resources/views/editor/mount.blade.php` — renders `<div id="ve-root" data-post-id data-post-type data-api-base>` and pulls the editor entry through `@viteReactRefresh` + `@vite`.
- `resources/js/visual-editor/editor/main.tsx` — finds `#ve-root`, types and reads the `data-*` attributes, mounts a placeholder `<EditorShell postId postType apiBase />`, and logs clear `console.error` messages (not silent failures) when the mount point or required attributes are missing.
- `resources/js/visual-editor/editor/index.html` — updated so the standalone Vite dev spike still boots against the new `#ve-root` contract.
- `routes/web.php` — registers a new `/editor` route rendering the mount view with sample props. `/editor-spike` stays in place until the final Phase 1 cleanup.
- `tests/Feature/EditorMountViewTest.php` — 5 tests locking in the view, route, and boot-script contract.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (Darwin 25.3.0)
- Browser: Safari
- PHP Version: 8.4
- Project Version: Phase 1.2

**Tests Performed:**
1. `./vendor/bin/pest` — 7 passed, 19 assertions.
2. Manually visited `/editor` in the dev app: the placeholder shell renders with `postId=1`, `postType=page`, `apiBase=/api` pulled from the data attributes.
3. Manually verified `/editor-spike` still works unchanged.
4. CodeRabbit review against `add/phase-one`: **No findings**.

> **Dev app wiring note:** making `/editor` resolve in the dev app also required a thin entry file at `resources/js/visual-editor/editor/main.tsx` in the host app that imports the symlinked package entry, plus adding that path to `vite.config.js` inputs. Those changes live in the dev app repo, not this PR.

## Accessibility Tests Run

- [ ] Keyboard navigation tested
- [ ] Screen reader tested
- [ ] Color contrast verified
- [ ] ARIA labels checked

**Details:** N/A for this PR — the rendered output is a throwaway placeholder that exists only to prove the mount/boot contract. Real accessibility work lands with the actual `EditorShell` in #270.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:** 5 new Feature tests in `tests/Feature/EditorMountViewTest.php` covering the mount view file, its data-attribute structure, the `@vite` wiring, the `/editor` route registration, and the boot script's `#ve-root` + `console.error` defensive path.

## Documentation

- [x] Inline code documentation added
- [ ] README updated
- [ ] Wiki updated
- [ ] API documentation updated

**Documentation details:** The boot script's error messages are the user-facing documentation for how to wire `#ve-root` correctly. Wiki updates will come with the real `EditorShell`.

## Screenshots

Placeholder shell rendering at `/editor` with the three data attributes surfaced.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [ ] Accessibility tests completed (N/A — placeholder)
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New Visual Editor available at /editor; frontend mounts into a consolidated root element and accepts runtime postId, postType and apiBase attributes for configuration.
  * Editor initializes via a configuration-driven boot flow and surfaces clear errors if required configuration is missing.

* **Tests**
  * Added tests for the mount view, route wiring, mount element, data attributes, and initialization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->