### PR TITLE
feat: Zustand editor store — block tree, selection, dirty flag (#265)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
                 "@tiptap/react": "^3.22.3",
                 "@tiptap/starter-kit": "^3.22.3",
                 "react": "^19.0.0",
-                "react-dom": "^19.0.0"
+                "react-dom": "^19.0.0",
+                "zustand": "^5.0.12"
             },
             "devDependencies": {
                 "@testing-library/dom": "^10.4.0",
@@ -3315,7 +3316,6 @@
             "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
             "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -3938,6 +3938,35 @@
             "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
             "dev": true,
             "license": "ISC"
+        },
+        "node_modules/zustand": {
+            "version": "5.0.12",
+            "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.12.tgz",
+            "integrity": "sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.20.0"
+            },
+            "peerDependencies": {
+                "@types/react": ">=18.0.0",
+                "immer": ">=9.0.6",
+                "react": ">=18.0.0",
+                "use-sync-external-store": ">=1.2.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "immer": {
+                    "optional": true
+                },
+                "react": {
+                    "optional": true
+                },
+                "use-sync-external-store": {
+                    "optional": true
+                }
+            }
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
         "@tiptap/react": "^3.22.3",
         "@tiptap/starter-kit": "^3.22.3",
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "zustand": "^5.0.12"
     }
 }

--- a/resources/js/visual-editor/editor/store/__tests__/editorStore.test.ts
+++ b/resources/js/visual-editor/editor/store/__tests__/editorStore.test.ts
@@ -105,6 +105,17 @@ describe('insertBlock', () => {
         expect(next).not.toBe(original);
         expect(original).toHaveLength(1);
     });
+
+    it('is a no-op for an unknown parentClientId', () => {
+        const store = createEditorStore(nestedTree());
+        const beforeBlocks = store.getState().blocks;
+
+        store.getState().markClean();
+        store.getState().insertBlock(makeBlock('orphan'), { parentClientId: 'missing' });
+
+        expect(store.getState().blocks).toBe(beforeBlocks);
+        expect(store.getState().isDirty).toBe(false);
+    });
 });
 
 describe('updateBlockAttributes', () => {
@@ -201,6 +212,24 @@ describe('removeBlock', () => {
         store.getState().removeBlock('missing');
 
         expect(store.getState().isDirty).toBe(false);
+    });
+
+    it('clears the selection when a removed ancestor contained the selected block', () => {
+        const store = createEditorStore(nestedTree());
+
+        store.getState().select('para-1', 'end');
+        store.getState().removeBlock('ql-1');
+
+        expect(store.getState().selection).toEqual({ clientId: null });
+    });
+
+    it('preserves the selection when the selected block is in an untouched subtree', () => {
+        const store = createEditorStore(nestedTree());
+
+        store.getState().select('para-top');
+        store.getState().removeBlock('ql-1');
+
+        expect(store.getState().selection.clientId).toBe('para-top');
     });
 });
 

--- a/resources/js/visual-editor/editor/store/__tests__/editorStore.test.ts
+++ b/resources/js/visual-editor/editor/store/__tests__/editorStore.test.ts
@@ -1,0 +1,406 @@
+import { describe, expect, it } from 'vitest';
+import { createEditorStore } from '../editorStore';
+import type { Block } from '../types';
+
+function makeBlock(clientId: string, name = 've/paragraph', overrides: Partial<Block> = {}): Block {
+    return {
+        clientId,
+        name,
+        attributes: {},
+        innerBlocks: [],
+        ...overrides,
+    };
+}
+
+function nestedTree(): Block[] {
+    return [
+        makeBlock('ql-1', 've/query-loop', {
+            attributes: { postType: 'post', perPage: 5 },
+            innerBlocks: [
+                makeBlock('title-1', 've/post-title', { attributes: { level: 2 } }),
+                makeBlock('para-1', 've/paragraph', {
+                    attributes: { content: '<p>hello</p>' },
+                }),
+            ],
+        }),
+        makeBlock('para-top', 've/paragraph', {
+            attributes: { content: '<p>top-level</p>' },
+        }),
+    ];
+}
+
+describe('createEditorStore', () => {
+    it('initialises with defaults', () => {
+        const store = createEditorStore();
+        const state = store.getState();
+
+        expect(state.blocks).toEqual([]);
+        expect(state.selection).toEqual({ clientId: null });
+        expect(state.isDirty).toBe(false);
+    });
+
+    it('accepts an initial block tree', () => {
+        const tree = nestedTree();
+        const store = createEditorStore(tree);
+
+        expect(store.getState().blocks).toBe(tree);
+        expect(store.getState().isDirty).toBe(false);
+    });
+});
+
+describe('insertBlock', () => {
+    it('appends to the top level by default', () => {
+        const store = createEditorStore();
+
+        store.getState().insertBlock(makeBlock('p-1'));
+
+        const { blocks, isDirty } = store.getState();
+
+        expect(blocks).toHaveLength(1);
+        expect(blocks[0].clientId).toBe('p-1');
+        expect(isDirty).toBe(true);
+    });
+
+    it('inserts at an explicit top-level index', () => {
+        const store = createEditorStore([makeBlock('a'), makeBlock('c')]);
+
+        store.getState().insertBlock(makeBlock('b'), { index: 1 });
+
+        expect(store.getState().blocks.map((b) => b.clientId)).toEqual(['a', 'b', 'c']);
+    });
+
+    it('clamps an out-of-range index to the end', () => {
+        const store = createEditorStore([makeBlock('a')]);
+
+        store.getState().insertBlock(makeBlock('b'), { index: 99 });
+
+        expect(store.getState().blocks.map((b) => b.clientId)).toEqual(['a', 'b']);
+    });
+
+    it('inserts into a nested parent', () => {
+        const store = createEditorStore(nestedTree());
+
+        store.getState().insertBlock(makeBlock('new-child'), {
+            parentClientId: 'ql-1',
+            index: 1,
+        });
+
+        const queryLoop = store.getState().blocks[0];
+
+        expect(queryLoop.innerBlocks.map((b) => b.clientId)).toEqual([
+            'title-1',
+            'new-child',
+            'para-1',
+        ]);
+    });
+
+    it('produces a new blocks reference (immutable update)', () => {
+        const original = [makeBlock('a')];
+        const store = createEditorStore(original);
+
+        store.getState().insertBlock(makeBlock('b'));
+
+        const next = store.getState().blocks;
+
+        expect(next).not.toBe(original);
+        expect(original).toHaveLength(1);
+    });
+});
+
+describe('updateBlockAttributes', () => {
+    it('merges attributes on a top-level block', () => {
+        const store = createEditorStore([
+            makeBlock('p-1', 've/paragraph', { attributes: { content: 'hi', dropCap: false } }),
+        ]);
+
+        store.getState().updateBlockAttributes('p-1', { content: 'updated' });
+
+        expect(store.getState().blocks[0].attributes).toEqual({
+            content: 'updated',
+            dropCap: false,
+        });
+        expect(store.getState().isDirty).toBe(true);
+    });
+
+    it('updates a nested block', () => {
+        const store = createEditorStore(nestedTree());
+
+        store.getState().updateBlockAttributes('para-1', { content: '<p>changed</p>' });
+
+        const queryLoop = store.getState().blocks[0];
+        const para = queryLoop.innerBlocks.find((b) => b.clientId === 'para-1');
+
+        expect(para?.attributes.content).toBe('<p>changed</p>');
+    });
+
+    it('produces a new blocks reference and parent reference when nested', () => {
+        const original = nestedTree();
+        const store = createEditorStore(original);
+
+        store.getState().updateBlockAttributes('para-1', { content: 'x' });
+
+        const next = store.getState().blocks;
+
+        expect(next).not.toBe(original);
+        expect(next[0]).not.toBe(original[0]);
+        expect(next[1]).toBe(original[1]);
+    });
+
+    it('is a no-op for a missing clientId', () => {
+        const store = createEditorStore([makeBlock('a')]);
+
+        store.getState().markClean();
+        store.getState().updateBlockAttributes('missing', { x: 1 });
+
+        expect(store.getState().isDirty).toBe(false);
+    });
+});
+
+describe('removeBlock', () => {
+    it('removes a top-level block', () => {
+        const store = createEditorStore([makeBlock('a'), makeBlock('b')]);
+
+        store.getState().removeBlock('a');
+
+        expect(store.getState().blocks.map((b) => b.clientId)).toEqual(['b']);
+        expect(store.getState().isDirty).toBe(true);
+    });
+
+    it('removes a nested block', () => {
+        const store = createEditorStore(nestedTree());
+
+        store.getState().removeBlock('title-1');
+
+        const queryLoop = store.getState().blocks[0];
+
+        expect(queryLoop.innerBlocks.map((b) => b.clientId)).toEqual(['para-1']);
+    });
+
+    it('clears the selection if the removed block was selected', () => {
+        const store = createEditorStore([makeBlock('a')]);
+
+        store.getState().select('a', 'end');
+        store.getState().removeBlock('a');
+
+        expect(store.getState().selection).toEqual({ clientId: null });
+    });
+
+    it('leaves selection alone if another block was selected', () => {
+        const store = createEditorStore([makeBlock('a'), makeBlock('b')]);
+
+        store.getState().select('b');
+        store.getState().removeBlock('a');
+
+        expect(store.getState().selection.clientId).toBe('b');
+    });
+
+    it('is a no-op for a missing clientId', () => {
+        const store = createEditorStore([makeBlock('a')]);
+
+        store.getState().markClean();
+        store.getState().removeBlock('missing');
+
+        expect(store.getState().isDirty).toBe(false);
+    });
+});
+
+describe('moveBlock', () => {
+    it('moves a top-level block forward', () => {
+        const store = createEditorStore([makeBlock('a'), makeBlock('b'), makeBlock('c')]);
+
+        store.getState().moveBlock('a', { index: 2 });
+
+        expect(store.getState().blocks.map((b) => b.clientId)).toEqual(['b', 'c', 'a']);
+        expect(store.getState().isDirty).toBe(true);
+    });
+
+    it('moves a top-level block backward', () => {
+        const store = createEditorStore([makeBlock('a'), makeBlock('b'), makeBlock('c')]);
+
+        store.getState().moveBlock('c', { index: 0 });
+
+        expect(store.getState().blocks.map((b) => b.clientId)).toEqual(['c', 'a', 'b']);
+    });
+
+    it('clamps an out-of-range index', () => {
+        const store = createEditorStore([makeBlock('a'), makeBlock('b')]);
+
+        store.getState().moveBlock('a', { index: 99 });
+
+        expect(store.getState().blocks.map((b) => b.clientId)).toEqual(['b', 'a']);
+    });
+
+    it('is a no-op when a nested parentClientId is requested (Phase 1 scope)', () => {
+        const store = createEditorStore(nestedTree());
+
+        store.getState().markClean();
+        store.getState().moveBlock('title-1', { parentClientId: 'ql-1', index: 1 });
+
+        expect(store.getState().isDirty).toBe(false);
+        const queryLoop = store.getState().blocks[0];
+        expect(queryLoop.innerBlocks.map((b) => b.clientId)).toEqual(['title-1', 'para-1']);
+    });
+
+    it('is a no-op for a missing clientId', () => {
+        const store = createEditorStore([makeBlock('a')]);
+
+        store.getState().markClean();
+        store.getState().moveBlock('missing', { index: 0 });
+
+        expect(store.getState().isDirty).toBe(false);
+    });
+});
+
+describe('replaceBlocks', () => {
+    it('replaces the block tree and resets selection', () => {
+        const store = createEditorStore([makeBlock('a')]);
+
+        store.getState().select('a');
+        store.getState().replaceBlocks([makeBlock('x'), makeBlock('y')]);
+
+        const state = store.getState();
+
+        expect(state.blocks.map((b) => b.clientId)).toEqual(['x', 'y']);
+        expect(state.selection).toEqual({ clientId: null });
+        expect(state.isDirty).toBe(true);
+    });
+
+    it('accepts an empty array', () => {
+        const store = createEditorStore([makeBlock('a')]);
+
+        store.getState().replaceBlocks([]);
+
+        expect(store.getState().blocks).toEqual([]);
+    });
+});
+
+describe('selection', () => {
+    it('select() stores the clientId and edge', () => {
+        const store = createEditorStore([makeBlock('a')]);
+
+        store.getState().select('a', 'end');
+
+        expect(store.getState().selection).toEqual({ clientId: 'a', edge: 'end' });
+    });
+
+    it('select() without an edge leaves it undefined', () => {
+        const store = createEditorStore([makeBlock('a')]);
+
+        store.getState().select('a');
+
+        expect(store.getState().selection.clientId).toBe('a');
+        expect(store.getState().selection.edge).toBeUndefined();
+    });
+
+    it('clearSelection() resets the selection', () => {
+        const store = createEditorStore([makeBlock('a')]);
+
+        store.getState().select('a', 'start');
+        store.getState().clearSelection();
+
+        expect(store.getState().selection).toEqual({ clientId: null });
+    });
+
+    it('selection changes do not flip the dirty flag', () => {
+        const store = createEditorStore([makeBlock('a')]);
+
+        store.getState().select('a');
+        expect(store.getState().isDirty).toBe(false);
+
+        store.getState().clearSelection();
+        expect(store.getState().isDirty).toBe(false);
+    });
+});
+
+describe('dirty flag', () => {
+    it('starts clean', () => {
+        expect(createEditorStore().getState().isDirty).toBe(false);
+    });
+
+    it('flips on insertBlock', () => {
+        const store = createEditorStore();
+
+        store.getState().insertBlock(makeBlock('a'));
+
+        expect(store.getState().isDirty).toBe(true);
+    });
+
+    it('flips on updateBlockAttributes', () => {
+        const store = createEditorStore([makeBlock('a')]);
+
+        store.getState().updateBlockAttributes('a', { x: 1 });
+
+        expect(store.getState().isDirty).toBe(true);
+    });
+
+    it('flips on removeBlock', () => {
+        const store = createEditorStore([makeBlock('a')]);
+
+        store.getState().removeBlock('a');
+
+        expect(store.getState().isDirty).toBe(true);
+    });
+
+    it('flips on moveBlock', () => {
+        const store = createEditorStore([makeBlock('a'), makeBlock('b')]);
+
+        store.getState().moveBlock('a', { index: 1 });
+
+        expect(store.getState().isDirty).toBe(true);
+    });
+
+    it('flips on replaceBlocks', () => {
+        const store = createEditorStore();
+
+        store.getState().replaceBlocks([makeBlock('a')]);
+
+        expect(store.getState().isDirty).toBe(true);
+    });
+
+    it('markClean() only clears via explicit call', () => {
+        const store = createEditorStore();
+
+        store.getState().insertBlock(makeBlock('a'));
+        expect(store.getState().isDirty).toBe(true);
+
+        store.getState().markClean();
+        expect(store.getState().isDirty).toBe(false);
+
+        store.getState().updateBlockAttributes('a', { x: 1 });
+        expect(store.getState().isDirty).toBe(true);
+    });
+
+    it('markDirty() explicitly flips the flag', () => {
+        const store = createEditorStore();
+
+        store.getState().markDirty();
+
+        expect(store.getState().isDirty).toBe(true);
+    });
+});
+
+describe('round-trip nested tree', () => {
+    it('preserves structure through insert → update → remove', () => {
+        const store = createEditorStore(nestedTree());
+
+        store.getState().insertBlock(
+            makeBlock('footnote', 've/paragraph', {
+                attributes: { content: '<p>footnote</p>' },
+            }),
+            { parentClientId: 'ql-1' }
+        );
+
+        store.getState().updateBlockAttributes('footnote', { content: '<p>edited</p>' });
+
+        const ql = store.getState().blocks[0];
+        const footnote = ql.innerBlocks.find((b) => b.clientId === 'footnote');
+
+        expect(footnote?.attributes.content).toBe('<p>edited</p>');
+        expect(ql.innerBlocks.map((b) => b.clientId)).toEqual(['title-1', 'para-1', 'footnote']);
+
+        store.getState().removeBlock('footnote');
+
+        const qlAfter = store.getState().blocks[0];
+        expect(qlAfter.innerBlocks.map((b) => b.clientId)).toEqual(['title-1', 'para-1']);
+    });
+});

--- a/resources/js/visual-editor/editor/store/__tests__/editorStoreSelectors.test.tsx
+++ b/resources/js/visual-editor/editor/store/__tests__/editorStoreSelectors.test.tsx
@@ -1,0 +1,147 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import {
+    createEditorStore,
+    useBlock,
+    useChildren,
+    useIsDirty,
+    useSelection,
+    type EditorStore,
+} from '../editorStore';
+import type { Block } from '../types';
+
+function makeBlock(clientId: string, name = 've/paragraph', overrides: Partial<Block> = {}): Block {
+    return {
+        clientId,
+        name,
+        attributes: {},
+        innerBlocks: [],
+        ...overrides,
+    };
+}
+
+function makeStore(): EditorStore {
+    return createEditorStore([
+        makeBlock('ql-1', 've/query-loop', {
+            attributes: { postType: 'post' },
+            innerBlocks: [
+                makeBlock('title-1', 've/post-title'),
+                makeBlock('para-1', 've/paragraph', { attributes: { content: 'hello' } }),
+            ],
+        }),
+        makeBlock('para-top', 've/paragraph'),
+    ]);
+}
+
+describe('useBlock', () => {
+    it('returns the block for a known top-level id', () => {
+        const store = makeStore();
+        const { result } = renderHook(() => useBlock(store, 'para-top'));
+
+        expect(result.current?.clientId).toBe('para-top');
+    });
+
+    it('returns a nested block by id', () => {
+        const store = makeStore();
+        const { result } = renderHook(() => useBlock(store, 'para-1'));
+
+        expect(result.current?.attributes.content).toBe('hello');
+    });
+
+    it('returns undefined for a missing id', () => {
+        const store = makeStore();
+        const { result } = renderHook(() => useBlock(store, 'nope'));
+
+        expect(result.current).toBeUndefined();
+    });
+
+    it('returns undefined when clientId is null', () => {
+        const store = makeStore();
+        const { result } = renderHook(() => useBlock(store, null));
+
+        expect(result.current).toBeUndefined();
+    });
+
+    it('reflects updated attributes after updateBlockAttributes', () => {
+        const store = makeStore();
+        const { result } = renderHook(() => useBlock(store, 'para-1'));
+
+        expect(result.current?.attributes.content).toBe('hello');
+
+        act(() => {
+            store.getState().updateBlockAttributes('para-1', { content: 'updated' });
+        });
+
+        expect(result.current?.attributes.content).toBe('updated');
+    });
+});
+
+describe('useChildren', () => {
+    it('returns top-level blocks when parentClientId is null', () => {
+        const store = makeStore();
+        const { result } = renderHook(() => useChildren(store, null));
+
+        expect(result.current.map((b) => b.clientId)).toEqual(['ql-1', 'para-top']);
+    });
+
+    it('returns children of a nested parent', () => {
+        const store = makeStore();
+        const { result } = renderHook(() => useChildren(store, 'ql-1'));
+
+        expect(result.current.map((b) => b.clientId)).toEqual(['title-1', 'para-1']);
+    });
+
+    it('returns an empty array for an unknown parent', () => {
+        const store = makeStore();
+        const { result } = renderHook(() => useChildren(store, 'missing'));
+
+        expect(result.current).toEqual([]);
+    });
+
+    it('reflects insertions into the parent', () => {
+        const store = makeStore();
+        const { result } = renderHook(() => useChildren(store, 'ql-1'));
+
+        act(() => {
+            store.getState().insertBlock(makeBlock('new'), { parentClientId: 'ql-1' });
+        });
+
+        expect(result.current.map((b) => b.clientId)).toEqual(['title-1', 'para-1', 'new']);
+    });
+});
+
+describe('useSelection', () => {
+    it('returns the current selection', () => {
+        const store = makeStore();
+        const { result } = renderHook(() => useSelection(store));
+
+        expect(result.current).toEqual({ clientId: null });
+
+        act(() => {
+            store.getState().select('para-top', 'end');
+        });
+
+        expect(result.current).toEqual({ clientId: 'para-top', edge: 'end' });
+    });
+});
+
+describe('useIsDirty', () => {
+    it('reflects the dirty flag reactively', () => {
+        const store = makeStore();
+        const { result } = renderHook(() => useIsDirty(store));
+
+        expect(result.current).toBe(false);
+
+        act(() => {
+            store.getState().insertBlock(makeBlock('new'));
+        });
+
+        expect(result.current).toBe(true);
+
+        act(() => {
+            store.getState().markClean();
+        });
+
+        expect(result.current).toBe(false);
+    });
+});

--- a/resources/js/visual-editor/editor/store/editorStore.ts
+++ b/resources/js/visual-editor/editor/store/editorStore.ts
@@ -16,6 +16,14 @@ import {
     updateAttributesInTree,
 } from './treeUtils';
 
+function selectionExistsIn(blocks: Block[], clientId: string | null): boolean {
+    if (clientId === null) {
+        return true;
+    }
+
+    return findBlock(blocks, clientId) !== undefined;
+}
+
 export type EditorStore = StoreApi<EditorStoreState>;
 
 const initialSelection: Selection = { clientId: null };
@@ -27,15 +35,20 @@ export function createEditorStore(initialBlocks: Block[] = []): EditorStore {
         isDirty: false,
 
         insertBlock: (block: Block, location: InsertLocation = {}) => {
-            set((state) => ({
-                blocks: insertIntoTree(
+            set((state) => {
+                const nextBlocks = insertIntoTree(
                     state.blocks,
                     block,
                     location.parentClientId ?? null,
                     location.index
-                ),
-                isDirty: true,
-            }));
+                );
+
+                if (nextBlocks === state.blocks) {
+                    return state;
+                }
+
+                return { ...state, blocks: nextBlocks, isDirty: true };
+            });
         },
 
         updateBlockAttributes: (clientId: string, attrs: Record<string, unknown>) => {
@@ -58,8 +71,9 @@ export function createEditorStore(initialBlocks: Block[] = []): EditorStore {
                     return state;
                 }
 
-                const nextSelection =
-                    state.selection.clientId === clientId ? initialSelection : state.selection;
+                const nextSelection = selectionExistsIn(nextBlocks, state.selection.clientId)
+                    ? state.selection
+                    : initialSelection;
 
                 return {
                     ...state,

--- a/resources/js/visual-editor/editor/store/editorStore.ts
+++ b/resources/js/visual-editor/editor/store/editorStore.ts
@@ -1,0 +1,162 @@
+import { useMemo } from 'react';
+import { createStore, useStore, type StoreApi } from 'zustand';
+import type {
+    Block,
+    EditorStoreState,
+    InsertLocation,
+    MoveLocation,
+    Selection,
+    SelectionEdge,
+} from './types';
+import {
+    findBlock,
+    findChildren,
+    insertIntoTree,
+    removeFromTree,
+    updateAttributesInTree,
+} from './treeUtils';
+
+export type EditorStore = StoreApi<EditorStoreState>;
+
+const initialSelection: Selection = { clientId: null };
+
+export function createEditorStore(initialBlocks: Block[] = []): EditorStore {
+    return createStore<EditorStoreState>((set) => ({
+        blocks: initialBlocks,
+        selection: initialSelection,
+        isDirty: false,
+
+        insertBlock: (block: Block, location: InsertLocation = {}) => {
+            set((state) => ({
+                blocks: insertIntoTree(
+                    state.blocks,
+                    block,
+                    location.parentClientId ?? null,
+                    location.index
+                ),
+                isDirty: true,
+            }));
+        },
+
+        updateBlockAttributes: (clientId: string, attrs: Record<string, unknown>) => {
+            set((state) => {
+                const nextBlocks = updateAttributesInTree(state.blocks, clientId, attrs);
+
+                if (nextBlocks === state.blocks) {
+                    return state;
+                }
+
+                return { ...state, blocks: nextBlocks, isDirty: true };
+            });
+        },
+
+        removeBlock: (clientId: string) => {
+            set((state) => {
+                const nextBlocks = removeFromTree(state.blocks, clientId);
+
+                if (nextBlocks === state.blocks) {
+                    return state;
+                }
+
+                const nextSelection =
+                    state.selection.clientId === clientId ? initialSelection : state.selection;
+
+                return {
+                    ...state,
+                    blocks: nextBlocks,
+                    selection: nextSelection,
+                    isDirty: true,
+                };
+            });
+        },
+
+        moveBlock: (clientId: string, location: MoveLocation) => {
+            set((state) => {
+                const parentClientId = location.parentClientId ?? null;
+
+                if (parentClientId !== null) {
+                    return state;
+                }
+
+                const currentIndex = state.blocks.findIndex(
+                    (block) => block.clientId === clientId
+                );
+
+                if (currentIndex === -1) {
+                    return state;
+                }
+
+                const block = state.blocks[currentIndex];
+                const withoutBlock = state.blocks.slice();
+
+                withoutBlock.splice(currentIndex, 1);
+
+                const targetIndex =
+                    location.index < 0
+                        ? 0
+                        : location.index > withoutBlock.length
+                            ? withoutBlock.length
+                            : location.index;
+
+                withoutBlock.splice(targetIndex, 0, block);
+
+                if (targetIndex === currentIndex) {
+                    return state;
+                }
+
+                return { ...state, blocks: withoutBlock, isDirty: true };
+            });
+        },
+
+        replaceBlocks: (newBlocks: Block[]) => {
+            set((state) => ({
+                ...state,
+                blocks: newBlocks,
+                selection: initialSelection,
+                isDirty: true,
+            }));
+        },
+
+        select: (clientId: string, edge?: SelectionEdge) => {
+            set((state) => ({ ...state, selection: { clientId, edge } }));
+        },
+
+        clearSelection: () => {
+            set((state) => ({ ...state, selection: initialSelection }));
+        },
+
+        markDirty: () => {
+            set((state) => (state.isDirty ? state : { ...state, isDirty: true }));
+        },
+
+        markClean: () => {
+            set((state) => (state.isDirty ? { ...state, isDirty: false } : state));
+        },
+    }));
+}
+
+export function useBlock(store: EditorStore, clientId: string | null): Block | undefined {
+    const blocks = useStore(store, (state) => state.blocks);
+
+    return useMemo(() => {
+        if (clientId === null) {
+            return undefined;
+        }
+
+        return findBlock(blocks, clientId);
+    }, [blocks, clientId]);
+}
+
+export function useChildren(store: EditorStore, parentClientId: string | null): Block[] {
+    const blocks = useStore(store, (state) => state.blocks);
+
+    return useMemo(() => findChildren(blocks, parentClientId), [blocks, parentClientId]);
+}
+
+export function useSelection(store: EditorStore): Selection {
+    return useStore(store, (state) => state.selection);
+}
+
+export function useIsDirty(store: EditorStore): boolean {
+    return useStore(store, (state) => state.isDirty);
+}

--- a/resources/js/visual-editor/editor/store/index.ts
+++ b/resources/js/visual-editor/editor/store/index.ts
@@ -1,0 +1,26 @@
+export {
+    createEditorStore,
+    useBlock,
+    useChildren,
+    useSelection,
+    useIsDirty,
+    type EditorStore,
+} from './editorStore';
+export {
+    findBlock,
+    findChildren,
+    findParent,
+    insertIntoTree,
+    removeFromTree,
+    updateAttributesInTree,
+} from './treeUtils';
+export type {
+    Block,
+    EditorActions,
+    EditorState,
+    EditorStoreState,
+    InsertLocation,
+    MoveLocation,
+    Selection,
+    SelectionEdge,
+} from './types';

--- a/resources/js/visual-editor/editor/store/treeUtils.ts
+++ b/resources/js/visual-editor/editor/store/treeUtils.ts
@@ -64,11 +64,15 @@ export function insertIntoTree(
         return next;
     }
 
-    return blocks.map((current) => {
+    let changed = false;
+
+    const next = blocks.map((current) => {
         if (current.clientId === parentClientId) {
             const nextInner = current.innerBlocks.slice();
 
             nextInner.splice(clampIndex(current.innerBlocks.length, index), 0, block);
+
+            changed = true;
 
             return { ...current, innerBlocks: nextInner };
         }
@@ -83,8 +87,12 @@ export function insertIntoTree(
             return current;
         }
 
+        changed = true;
+
         return { ...current, innerBlocks: nextInner };
     });
+
+    return changed ? next : blocks;
 }
 
 export function removeFromTree(blocks: Block[], clientId: string): Block[] {

--- a/resources/js/visual-editor/editor/store/treeUtils.ts
+++ b/resources/js/visual-editor/editor/store/treeUtils.ts
@@ -1,0 +1,152 @@
+import type { Block } from './types';
+
+export function findBlock(blocks: Block[], clientId: string): Block | undefined {
+    for (const block of blocks) {
+        if (block.clientId === clientId) {
+            return block;
+        }
+
+        const nested = findBlock(block.innerBlocks, clientId);
+
+        if (nested) {
+            return nested;
+        }
+    }
+
+    return undefined;
+}
+
+export function findParent(blocks: Block[], clientId: string): Block | null {
+    for (const block of blocks) {
+        if (block.innerBlocks.some((child) => child.clientId === clientId)) {
+            return block;
+        }
+
+        const nested = findParent(block.innerBlocks, clientId);
+
+        if (nested) {
+            return nested;
+        }
+    }
+
+    return null;
+}
+
+export function findChildren(blocks: Block[], parentClientId: string | null): Block[] {
+    if (parentClientId === null) {
+        return blocks;
+    }
+
+    const parent = findBlock(blocks, parentClientId);
+
+    return parent ? parent.innerBlocks : [];
+}
+
+function clampIndex(length: number, index: number | undefined): number {
+    if (index === undefined || index < 0 || index > length) {
+        return length;
+    }
+
+    return index;
+}
+
+export function insertIntoTree(
+    blocks: Block[],
+    block: Block,
+    parentClientId: string | null | undefined,
+    index: number | undefined
+): Block[] {
+    if (parentClientId === null || parentClientId === undefined) {
+        const next = blocks.slice();
+
+        next.splice(clampIndex(blocks.length, index), 0, block);
+
+        return next;
+    }
+
+    return blocks.map((current) => {
+        if (current.clientId === parentClientId) {
+            const nextInner = current.innerBlocks.slice();
+
+            nextInner.splice(clampIndex(current.innerBlocks.length, index), 0, block);
+
+            return { ...current, innerBlocks: nextInner };
+        }
+
+        if (current.innerBlocks.length === 0) {
+            return current;
+        }
+
+        const nextInner = insertIntoTree(current.innerBlocks, block, parentClientId, index);
+
+        if (nextInner === current.innerBlocks) {
+            return current;
+        }
+
+        return { ...current, innerBlocks: nextInner };
+    });
+}
+
+export function removeFromTree(blocks: Block[], clientId: string): Block[] {
+    let changed = false;
+
+    const next = blocks
+        .filter((block) => {
+            if (block.clientId === clientId) {
+                changed = true;
+
+                return false;
+            }
+
+            return true;
+        })
+        .map((block) => {
+            if (block.innerBlocks.length === 0) {
+                return block;
+            }
+
+            const nextInner = removeFromTree(block.innerBlocks, clientId);
+
+            if (nextInner === block.innerBlocks) {
+                return block;
+            }
+
+            changed = true;
+
+            return { ...block, innerBlocks: nextInner };
+        });
+
+    return changed ? next : blocks;
+}
+
+export function updateAttributesInTree(
+    blocks: Block[],
+    clientId: string,
+    attrs: Record<string, unknown>
+): Block[] {
+    let changed = false;
+
+    const next = blocks.map((block) => {
+        if (block.clientId === clientId) {
+            changed = true;
+
+            return { ...block, attributes: { ...block.attributes, ...attrs } };
+        }
+
+        if (block.innerBlocks.length === 0) {
+            return block;
+        }
+
+        const nextInner = updateAttributesInTree(block.innerBlocks, clientId, attrs);
+
+        if (nextInner === block.innerBlocks) {
+            return block;
+        }
+
+        changed = true;
+
+        return { ...block, innerBlocks: nextInner };
+    });
+
+    return changed ? next : blocks;
+}

--- a/resources/js/visual-editor/editor/store/types.ts
+++ b/resources/js/visual-editor/editor/store/types.ts
@@ -1,0 +1,43 @@
+export type Block = {
+    clientId: string;
+    name: string;
+    attributes: Record<string, unknown>;
+    innerBlocks: Block[];
+};
+
+export type SelectionEdge = 'start' | 'end';
+
+export type Selection = {
+    clientId: string | null;
+    edge?: SelectionEdge;
+};
+
+export type InsertLocation = {
+    parentClientId?: string | null;
+    index?: number;
+};
+
+export type MoveLocation = {
+    parentClientId?: string | null;
+    index: number;
+};
+
+export type EditorState = {
+    blocks: Block[];
+    selection: Selection;
+    isDirty: boolean;
+};
+
+export type EditorActions = {
+    insertBlock: (block: Block, location?: InsertLocation) => void;
+    updateBlockAttributes: (clientId: string, attrs: Record<string, unknown>) => void;
+    removeBlock: (clientId: string) => void;
+    moveBlock: (clientId: string, location: MoveLocation) => void;
+    replaceBlocks: (newBlocks: Block[]) => void;
+    select: (clientId: string, edge?: SelectionEdge) => void;
+    clearSelection: () => void;
+    markDirty: () => void;
+    markClean: () => void;
+};
+
+export type EditorStoreState = EditorState & EditorActions;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,6 +13,9 @@ export default defineConfig({
         globals: true,
         environment: 'jsdom',
         setupFiles: ['./resources/js/editor-spike/test-setup.ts'],
-        include: ['resources/js/editor-spike/**/*.{test,spec}.{ts,tsx}'],
+        include: [
+            'resources/js/editor-spike/**/*.{test,spec}.{ts,tsx}',
+            'resources/js/visual-editor/**/*.{test,spec}.{ts,tsx}',
+        ],
     },
 });


### PR DESCRIPTION
## Description

Adds the Phase 1 state foundation for the React editor migration. Introduces a plain Zustand store (no middleware) that owns the block tree, selection, and dirty flag, replacing the Phase 0 spike's shared-mutable-state + \`__bumpTemplate\` pattern called out as finding #1 in \`PHASE-0-FINDINGS.md\`.

**Closes:** #265

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #265

## Motivation and Context

Phase 0 proved the React + Tiptap architecture works, but the spike leaned on a mutable block tree and a \`__bumpTemplate\` callback to force preview re-renders. Every other Phase 1 issue (REST load/save, inserter, undo/redo, Tiptap wiring) needs a real state layer to build on. This PR delivers that layer with immutable updates and memoized selectors, unblocking #266 (undo/redo), #274 (persistence), and the paragraph/heading blocks.

## Changes Made

- Added \`zustand\` as a runtime dependency (core only, no middleware)
- New \`resources/js/visual-editor/editor/store/\` module:
  - \`types.ts\` — \`Block\`, \`Selection\`, \`EditorState\`, \`EditorActions\`, \`EditorStoreState\`
  - \`treeUtils.ts\` — pure immutable tree helpers (\`findBlock\`, \`findChildren\`, \`findParent\`, \`insertIntoTree\`, \`removeFromTree\`, \`updateAttributesInTree\`)
  - \`editorStore.ts\` — \`createEditorStore()\` factory plus \`useBlock\` / \`useChildren\` / \`useSelection\` / \`useIsDirty\` React hooks
  - \`index.ts\` — barrel export
- Actions: \`insertBlock\`, \`updateBlockAttributes\`, \`removeBlock\`, \`moveBlock\` (top-level only per Phase 1 scope), \`replaceBlocks\`, \`select\`, \`clearSelection\`, \`markDirty\`, \`markClean\`
- Dirty flag flips on every mutation and clears only via \`markClean()\`; selection changes do not flip it
- \`vitest.config.ts\` include pattern extended to cover \`resources/js/visual-editor/**\`

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (Darwin 25.3.0)
- Node: project-pinned via package-lock
- Project Version: 1.0.0-spike

**Tests Performed:**
1. \`npm test\` — 85 tests passing (47 new, 38 existing spike tests untouched)
2. \`npx tsc --noEmit\` — clean
3. CodeRabbit review against \`add/phase-one\` — no findings

## Accessibility Tests Run

- [x] N/A — pure data layer, no UI surface yet (editor shell is still the placeholder from #270)

**Details:** This PR ships no rendered markup, so there is nothing to keyboard- or screen-reader-test. Accessibility work lives in the shell/canvas issues that consume this store.

## Tests Added

- [x] Unit tests added/updated
- [x] All tests passing

**Test details:**
- \`editorStore.test.ts\` (36 tests) — every action, immutability of updates, dirty-flag semantics, nested insert/update/remove, missing-clientId no-ops, round-trip nested tree
- \`editorStoreSelectors.test.tsx\` (11 tests) — \`useBlock\`/\`useChildren\`/\`useSelection\`/\`useIsDirty\` via \`@testing-library/react\` \`renderHook\`, including reactivity after mutations and nested lookups

## Documentation

- [x] Inline code documentation added

**Documentation details:** Types and action signatures are self-documenting via TypeScript. No wiki/README changes needed until the store is wired into UI in a later Phase 1 issue.

## Screenshots

N/A — pure data layer.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted (tsc clean, CodeRabbit clean)
- [x] Accessibility tests completed (N/A — data layer)
- [x] Code follows project style guide
- [x] Self-review completed
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an editor state system with block tree operations (insert, update attributes, remove, move, replace), selection handling, and dirty-state tracking.
  * Exposed reactive hooks for reading blocks, children, selection, and dirty state.

* **Tests**
  * Added comprehensive test suites covering store behavior and hook reactivity.

* **Chores**
  * Added Zustand dependency and expanded test discovery configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->