### PR TITLE
feat: productionize spike primitives with store integration

### DIFF
--- a/resources/js/visual-editor/editor/primitives/BlockContext.tsx
+++ b/resources/js/visual-editor/editor/primitives/BlockContext.tsx
@@ -1,0 +1,62 @@
+import { createContext, useContext, useMemo, useRef, type ReactNode } from 'react';
+
+/**
+ * A runtime-agnostic block context map. Values are typed as `unknown` so that
+ * readers must narrow through a type guard — no `as T` escape hatches.
+ */
+export type BlockContextValue = Readonly<Record<string, unknown>>;
+
+export type BlockContextTypeGuard<T> = (value: unknown) => value is T;
+
+const EMPTY_CONTEXT: BlockContextValue = Object.freeze({});
+
+const UNSET_SENTINEL: unique symbol = Symbol('useBlockContextValue.unset');
+
+const Context = createContext<BlockContextValue>(EMPTY_CONTEXT);
+Context.displayName = 'BlockContext';
+
+export interface BlockContextProviderProps {
+    value: BlockContextValue;
+    children: ReactNode;
+}
+
+export function BlockContextProvider({ value, children }: BlockContextProviderProps) {
+    const parent = useContext(Context);
+    const merged = useMemo<BlockContextValue>(
+        () => Object.freeze({ ...parent, ...value }),
+        [parent, value]
+    );
+
+    return <Context.Provider value={merged}>{children}</Context.Provider>;
+}
+
+export function useBlockContext(): BlockContextValue {
+    return useContext(Context);
+}
+
+/**
+ * Read a typed value from the nearest BlockContextProvider, narrowing the value
+ * with a runtime type guard. When the key is missing or the guard rejects the
+ * value, returns `undefined`. The returned reference is stable across renders
+ * until the underlying context value changes, so memoized consumers stay
+ * memoized.
+ */
+export function useBlockContextValue<T>(
+    key: string,
+    guard: BlockContextTypeGuard<T>
+): T | undefined {
+    const context = useContext(Context);
+    const raw = context[key];
+
+    const lastRawRef = useRef<unknown>(UNSET_SENTINEL);
+    const lastResultRef = useRef<T | undefined>(undefined);
+
+    if (!Object.is(lastRawRef.current, raw)) {
+        lastRawRef.current = raw;
+        lastResultRef.current = guard(raw) ? raw : undefined;
+    }
+
+    return lastResultRef.current;
+}
+
+export default Context;

--- a/resources/js/visual-editor/editor/primitives/EditorStoreContext.tsx
+++ b/resources/js/visual-editor/editor/primitives/EditorStoreContext.tsx
@@ -1,0 +1,31 @@
+import { createContext, useContext, type ReactNode } from 'react';
+import type { EditorStore } from '../store';
+
+const Context = createContext<EditorStore | null>(null);
+Context.displayName = 'EditorStoreContext';
+
+export interface EditorStoreProviderProps {
+    store: EditorStore;
+    children: ReactNode;
+}
+
+export function EditorStoreProvider({ store, children }: EditorStoreProviderProps) {
+    return <Context.Provider value={store}>{children}</Context.Provider>;
+}
+
+export function useEditorStore(): EditorStore {
+    const store = useContext(Context);
+
+    if (store === null) {
+        throw new Error(
+            'useEditorStore must be used within an <EditorStoreProvider>. ' +
+                'Wrap your editor tree with <EditorStoreProvider store={store}> to provide a store instance.'
+        );
+    }
+
+    return store;
+}
+
+export function useOptionalEditorStore(): EditorStore | null {
+    return useContext(Context);
+}

--- a/resources/js/visual-editor/editor/primitives/ReadOnlyContext.tsx
+++ b/resources/js/visual-editor/editor/primitives/ReadOnlyContext.tsx
@@ -1,0 +1,19 @@
+import { createContext, useContext, type ReactNode } from 'react';
+
+const Context = createContext<boolean>(false);
+Context.displayName = 'ReadOnlyContext';
+
+export interface ReadOnlyProviderProps {
+    value: boolean;
+    children: ReactNode;
+}
+
+export function ReadOnlyProvider({ value, children }: ReadOnlyProviderProps) {
+    return <Context.Provider value={value}>{children}</Context.Provider>;
+}
+
+export function useReadOnly(): boolean {
+    return useContext(Context);
+}
+
+export default Context;

--- a/resources/js/visual-editor/editor/primitives/__tests__/BlockContext.test.tsx
+++ b/resources/js/visual-editor/editor/primitives/__tests__/BlockContext.test.tsx
@@ -1,0 +1,143 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import {
+    BlockContextProvider,
+    useBlockContext,
+    useBlockContextValue,
+} from '../BlockContext';
+
+function isNumber(value: unknown): value is number {
+    return typeof value === 'number';
+}
+
+function isString(value: unknown): value is string {
+    return typeof value === 'string';
+}
+
+function Reader() {
+    const context = useBlockContext();
+    return <div data-testid="context">{JSON.stringify(context)}</div>;
+}
+
+function TypedReader() {
+    const postId = useBlockContextValue<number>('postId', isNumber);
+    const missing = useBlockContextValue<string>('missing', isString);
+    const wrongType = useBlockContextValue<number>('postType', isNumber);
+    return (
+        <div>
+            <span data-testid="postId">{String(postId)}</span>
+            <span data-testid="missing">{String(missing)}</span>
+            <span data-testid="wrongType">{String(wrongType)}</span>
+        </div>
+    );
+}
+
+describe('BlockContextProvider', () => {
+    it('exposes the provided value to descendants', () => {
+        render(
+            <BlockContextProvider value={{ postId: 1, postType: 'post' }}>
+                <Reader />
+            </BlockContextProvider>
+        );
+
+        expect(screen.getByTestId('context').textContent).toBe(
+            JSON.stringify({ postId: 1, postType: 'post' })
+        );
+    });
+
+    it('merges nested provider values with parent context', () => {
+        render(
+            <BlockContextProvider value={{ postId: 1, postType: 'post' }}>
+                <BlockContextProvider value={{ extra: 'data' }}>
+                    <Reader />
+                </BlockContextProvider>
+            </BlockContextProvider>
+        );
+
+        expect(screen.getByTestId('context').textContent).toBe(
+            JSON.stringify({ postId: 1, postType: 'post', extra: 'data' })
+        );
+    });
+
+    it('lets a nested provider override a parent key', () => {
+        render(
+            <BlockContextProvider value={{ postId: 1, postType: 'post' }}>
+                <BlockContextProvider value={{ postType: 'page' }}>
+                    <Reader />
+                </BlockContextProvider>
+            </BlockContextProvider>
+        );
+
+        expect(screen.getByTestId('context').textContent).toBe(
+            JSON.stringify({ postId: 1, postType: 'page' })
+        );
+    });
+
+    it('returns an empty frozen object outside of any provider', () => {
+        render(<Reader />);
+
+        expect(screen.getByTestId('context').textContent).toBe('{}');
+    });
+});
+
+describe('useBlockContextValue', () => {
+    it('returns typed values that pass the guard', () => {
+        render(
+            <BlockContextProvider value={{ postId: 42, postType: 'post' }}>
+                <TypedReader />
+            </BlockContextProvider>
+        );
+
+        expect(screen.getByTestId('postId').textContent).toBe('42');
+    });
+
+    it('returns undefined for missing keys', () => {
+        render(
+            <BlockContextProvider value={{ postId: 42 }}>
+                <TypedReader />
+            </BlockContextProvider>
+        );
+
+        expect(screen.getByTestId('missing').textContent).toBe('undefined');
+    });
+
+    it('returns undefined when the guard rejects the value', () => {
+        render(
+            <BlockContextProvider value={{ postId: 42, postType: 'post' }}>
+                <TypedReader />
+            </BlockContextProvider>
+        );
+
+        expect(screen.getByTestId('wrongType').textContent).toBe('undefined');
+    });
+
+    it('returns a stable reference across renders when raw value is unchanged', () => {
+        const captured: Array<{ value: { id: number } | undefined }> = [];
+
+        function Probe({ tick }: { tick: number }) {
+            const value = useBlockContextValue<{ id: number }>(
+                'obj',
+                (v): v is { id: number } =>
+                    typeof v === 'object' && v !== null && 'id' in v
+            );
+            captured.push({ value });
+            return <span>{tick}</span>;
+        }
+
+        const obj = { id: 1 };
+        const { rerender } = render(
+            <BlockContextProvider value={{ obj }}>
+                <Probe tick={1} />
+            </BlockContextProvider>
+        );
+
+        rerender(
+            <BlockContextProvider value={{ obj }}>
+                <Probe tick={2} />
+            </BlockContextProvider>
+        );
+
+        expect(captured.length).toBeGreaterThanOrEqual(2);
+        expect(captured[0].value).toBe(captured[captured.length - 1].value);
+    });
+});

--- a/resources/js/visual-editor/editor/primitives/__tests__/EditorStoreContext.test.tsx
+++ b/resources/js/visual-editor/editor/primitives/__tests__/EditorStoreContext.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { EditorStoreProvider, useEditorStore } from '../EditorStoreContext';
+import { createEditorStore } from '../../store';
+
+function StoreReader() {
+    const store = useEditorStore();
+    return <div data-testid="count">{store.getState().blocks.length}</div>;
+}
+
+describe('EditorStoreContext', () => {
+    it('exposes the provided store to descendants', () => {
+        const store = createEditorStore([
+            { clientId: 'a', name: 've/paragraph', attributes: {}, innerBlocks: [] },
+            { clientId: 'b', name: 've/paragraph', attributes: {}, innerBlocks: [] },
+        ]);
+
+        render(
+            <EditorStoreProvider store={store}>
+                <StoreReader />
+            </EditorStoreProvider>
+        );
+
+        expect(screen.getByTestId('count').textContent).toBe('2');
+    });
+
+    it('throws a helpful error when used outside of a provider', () => {
+        const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+        expect(() => render(<StoreReader />)).toThrow(
+            /useEditorStore must be used within an <EditorStoreProvider>/
+        );
+
+        consoleError.mockRestore();
+    });
+});

--- a/resources/js/visual-editor/editor/primitives/__tests__/EditorStoreContext.test.tsx
+++ b/resources/js/visual-editor/editor/primitives/__tests__/EditorStoreContext.test.tsx
@@ -27,10 +27,12 @@ describe('EditorStoreContext', () => {
     it('throws a helpful error when used outside of a provider', () => {
         const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
 
-        expect(() => render(<StoreReader />)).toThrow(
-            /useEditorStore must be used within an <EditorStoreProvider>/
-        );
-
-        consoleError.mockRestore();
+        try {
+            expect(() => render(<StoreReader />)).toThrow(
+                /useEditorStore must be used within an <EditorStoreProvider>/
+            );
+        } finally {
+            consoleError.mockRestore();
+        }
     });
 });

--- a/resources/js/visual-editor/editor/primitives/__tests__/useBlockPreview.test.tsx
+++ b/resources/js/visual-editor/editor/primitives/__tests__/useBlockPreview.test.tsx
@@ -1,0 +1,155 @@
+import { render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { BlockPreview, useBlockPreview } from '../useBlockPreview';
+import { InnerBlocks } from '../useInnerBlocksProps';
+import { useReadOnly } from '../ReadOnlyContext';
+import {
+    clearRegistry,
+    registerBlock,
+    type BlockEditProps,
+} from '../../registry';
+import type { Block } from '../../store';
+
+function Paragraph({ attributes, clientId }: BlockEditProps) {
+    const readOnly = useReadOnly();
+    const content = String(attributes.content ?? '');
+
+    if (readOnly) {
+        return (
+            <p data-client-id={clientId} data-read-only="true">
+                {content}
+            </p>
+        );
+    }
+
+    return (
+        <p
+            data-client-id={clientId}
+            contentEditable
+            suppressContentEditableWarning
+            onInput={() => {}}
+        >
+            {content}
+        </p>
+    );
+}
+
+function ClickButton({ clientId }: BlockEditProps) {
+    return (
+        <button
+            type="button"
+            data-client-id={clientId}
+            onClick={() => {
+                throw new Error('button handler should not fire inside a preview');
+            }}
+        >
+            click me
+        </button>
+    );
+}
+
+function Group({ block }: BlockEditProps) {
+    return <InnerBlocks parentClientId={block.clientId} />;
+}
+
+const tree: Block[] = [
+    {
+        clientId: 'p1',
+        name: 've/paragraph',
+        attributes: { content: 'Hello preview' },
+        innerBlocks: [],
+    },
+    {
+        clientId: 'group-root',
+        name: 've/group',
+        attributes: {},
+        innerBlocks: [
+            {
+                clientId: 'nested-p',
+                name: 've/paragraph',
+                attributes: { content: 'Nested line' },
+                innerBlocks: [],
+            },
+            {
+                clientId: 'nested-button',
+                name: 've/button',
+                attributes: {},
+                innerBlocks: [],
+            },
+        ],
+    },
+];
+
+beforeEach(() => {
+    clearRegistry();
+    registerBlock({ name: 've/paragraph', edit: Paragraph });
+    registerBlock({ name: 've/button', edit: ClickButton });
+    registerBlock({ name: 've/group', edit: Group });
+});
+
+afterEach(() => {
+    clearRegistry();
+});
+
+describe('BlockPreview', () => {
+    it('renders a paragraph block read-only (no contenteditable)', () => {
+        render(<BlockPreview blocks={[tree[0]]} />);
+
+        const paragraph = screen.getByText('Hello preview');
+        expect(paragraph.getAttribute('contenteditable')).toBeNull();
+        expect(paragraph.getAttribute('data-read-only')).toBe('true');
+    });
+
+    it('renders nested blocks via InnerBlocks inside the preview', () => {
+        render(<BlockPreview blocks={[tree[1]]} />);
+
+        expect(screen.getByText('Nested line')).toBeInTheDocument();
+        expect(screen.getByText('click me')).toBeInTheDocument();
+
+        const nested = screen.getByText('Nested line');
+        expect(nested.getAttribute('contenteditable')).toBeNull();
+        expect(nested.getAttribute('data-read-only')).toBe('true');
+    });
+
+    it('applies inert, aria-hidden, pointer-events:none, and user-select:none', () => {
+        const { container } = render(
+            <BlockPreview blocks={[tree[0]]} className="ve-preview" />
+        );
+
+        const wrapper = container.querySelector('[data-block-preview]') as HTMLElement | null;
+        expect(wrapper).not.toBeNull();
+        expect(wrapper!.classList.contains('ve-preview')).toBe(true);
+        expect(wrapper!.style.pointerEvents).toBe('none');
+        expect(wrapper!.style.userSelect).toBe('none');
+        expect(wrapper!.hasAttribute('inert')).toBe(true);
+        expect(wrapper!.getAttribute('aria-hidden')).toBe('true');
+    });
+
+    it('renders multiple root blocks', () => {
+        render(<BlockPreview blocks={tree} />);
+
+        expect(screen.getByText('Hello preview')).toBeInTheDocument();
+        expect(screen.getByText('Nested line')).toBeInTheDocument();
+    });
+});
+
+describe('useBlockPreview', () => {
+    it('returns previewProps spreadable onto a wrapper element', () => {
+        let captured: ReturnType<typeof useBlockPreview> | null = null;
+
+        function Probe() {
+            captured = useBlockPreview({ blocks: [tree[0]] });
+            return <div {...captured.previewProps} />;
+        }
+
+        const { container } = render(<Probe />);
+
+        expect(captured).not.toBeNull();
+        expect(captured!.previewProps['data-block-preview']).toBe(true);
+        expect(captured!.previewProps['aria-hidden']).toBe('true');
+        expect(captured!.previewProps.style.pointerEvents).toBe('none');
+        expect(captured!.previewProps.style.userSelect).toBe('none');
+        expect(captured!.previewProps.inert).toBe(true);
+        expect(container.querySelector('[data-block-preview]')).not.toBeNull();
+    });
+});

--- a/resources/js/visual-editor/editor/primitives/__tests__/useInnerBlocksProps.test.tsx
+++ b/resources/js/visual-editor/editor/primitives/__tests__/useInnerBlocksProps.test.tsx
@@ -1,0 +1,242 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+    InnerBlocks,
+    useInnerBlocksProps,
+} from '../useInnerBlocksProps';
+import { EditorStoreProvider } from '../EditorStoreContext';
+import { useBlockContextValue } from '../BlockContext';
+import {
+    clearRegistry,
+    registerBlock,
+    type BlockEditProps,
+} from '../../registry';
+import { createEditorStore, type Block, type EditorStore } from '../../store';
+
+function makeBlock(
+    clientId: string,
+    name = 've/paragraph',
+    overrides: Partial<Block> = {}
+): Block {
+    return {
+        clientId,
+        name,
+        attributes: {},
+        innerBlocks: [],
+        ...overrides,
+    };
+}
+
+function Paragraph({ attributes, clientId }: BlockEditProps) {
+    return <p data-client-id={clientId}>{String(attributes.content ?? '')}</p>;
+}
+
+function Group({ block }: BlockEditProps) {
+    return <InnerBlocks parentClientId={block.clientId} />;
+}
+
+function PostIdReader({ clientId }: BlockEditProps) {
+    const postId = useBlockContextValue<number>(
+        'postId',
+        (v): v is number => typeof v === 'number'
+    );
+    return <span data-client-id={clientId}>postId={String(postId)}</span>;
+}
+
+function makeTree(): Block[] {
+    return [
+        makeBlock('parent', 've/group', {
+            innerBlocks: [
+                makeBlock('child-1', 've/paragraph', {
+                    attributes: { content: 'First paragraph' },
+                }),
+                makeBlock('child-2', 've/paragraph', {
+                    attributes: { content: 'Second paragraph' },
+                }),
+            ],
+        }),
+        makeBlock('context-parent', 've/query-loop', {
+            attributes: { postId: 42 },
+            innerBlocks: [makeBlock('context-child', 've/post-id-reader')],
+        }),
+    ];
+}
+
+function renderWithStore(store: EditorStore, ui: React.ReactElement) {
+    return render(<EditorStoreProvider store={store}>{ui}</EditorStoreProvider>);
+}
+
+beforeEach(() => {
+    clearRegistry();
+    registerBlock({ name: 've/paragraph', edit: Paragraph });
+    registerBlock({ name: 've/group', edit: Group });
+    registerBlock({
+        name: 've/query-loop',
+        edit: Group,
+        providesContext: (attrs) => ({ postId: attrs.postId }),
+    });
+    registerBlock({ name: 've/post-id-reader', edit: PostIdReader });
+});
+
+afterEach(() => {
+    clearRegistry();
+});
+
+describe('InnerBlocks', () => {
+    it('renders each child block from the store', () => {
+        const store = createEditorStore(makeTree());
+        renderWithStore(store, <InnerBlocks parentClientId="parent" />);
+
+        expect(screen.getByText('First paragraph')).toBeInTheDocument();
+        expect(screen.getByText('Second paragraph')).toBeInTheDocument();
+    });
+
+    it('renders an empty wrapper when the parent has no children', () => {
+        const store = createEditorStore([makeBlock('lonely', 've/group')]);
+        renderWithStore(store, <InnerBlocks parentClientId="lonely" />);
+
+        const wrapper = document.querySelector('[data-parent-client-id="lonely"]');
+        expect(wrapper).not.toBeNull();
+        expect(wrapper?.children.length).toBe(0);
+    });
+
+    it('renders a fallback for unknown block types', () => {
+        const store = createEditorStore(makeTree());
+        clearRegistry();
+        registerBlock({ name: 've/group', edit: Group });
+        renderWithStore(store, <InnerBlocks parentClientId="parent" />);
+
+        const missing = document.querySelectorAll('[data-block-missing="ve/paragraph"]');
+        expect(missing.length).toBe(2);
+    });
+
+    it('passes providesContext values to descendants', () => {
+        const store = createEditorStore(makeTree());
+        renderWithStore(store, <InnerBlocks parentClientId={null} />);
+
+        expect(screen.getByText('postId=42')).toBeInTheDocument();
+    });
+
+    it('forwards className and parent id on the wrapper element', () => {
+        const store = createEditorStore(makeTree());
+        renderWithStore(
+            store,
+            <InnerBlocks parentClientId="parent" className="ve-inner-blocks" />
+        );
+
+        const wrapper = document.querySelector('[data-parent-client-id="parent"]');
+        expect(wrapper?.classList.contains('ve-inner-blocks')).toBe(true);
+    });
+
+    it('reactively re-renders when the store changes', () => {
+        const store = createEditorStore(makeTree());
+        renderWithStore(store, <InnerBlocks parentClientId="parent" />);
+
+        act(() => {
+            store.getState().updateBlockAttributes('child-1', { content: 'Updated' });
+        });
+
+        expect(screen.getByText('Updated')).toBeInTheDocument();
+    });
+});
+
+describe('useInnerBlocksProps', () => {
+    it('returns a stable innerBlocksProps object with the expected shape', () => {
+        const store = createEditorStore(makeTree());
+        let captured: ReturnType<typeof useInnerBlocksProps> | null = null;
+
+        function Probe() {
+            captured = useInnerBlocksProps('parent', { className: 'probe' });
+            return null;
+        }
+
+        renderWithStore(store, <Probe />);
+
+        expect(captured).not.toBeNull();
+        expect(captured!.innerBlocksProps['data-parent-client-id']).toBe('parent');
+        expect(captured!.innerBlocksProps.className).toBe('probe');
+        expect(captured!.innerBlocksProps.ref).toBeDefined();
+        expect(captured!.innerBlocksProps.children).toBeDefined();
+        expect(typeof captured!.appendBlock).toBe('function');
+        expect(typeof captured!.removeBlock).toBe('function');
+        expect(typeof captured!.moveBlock).toBe('function');
+    });
+
+    it('appendBlock inserts a block into the parent via the store', () => {
+        const store = createEditorStore(makeTree());
+        let captured: ReturnType<typeof useInnerBlocksProps> | null = null;
+
+        function Probe() {
+            captured = useInnerBlocksProps('parent');
+            return null;
+        }
+
+        renderWithStore(store, <Probe />);
+
+        act(() => {
+            captured!.appendBlock(
+                makeBlock('child-3', 've/paragraph', {
+                    attributes: { content: 'Third paragraph' },
+                })
+            );
+        });
+
+        const parent = store.getState().blocks.find((b) => b.clientId === 'parent');
+        expect(parent?.innerBlocks.map((b) => b.clientId)).toEqual([
+            'child-1',
+            'child-2',
+            'child-3',
+        ]);
+    });
+
+    it('removeBlock removes a child via the store', () => {
+        const store = createEditorStore(makeTree());
+        let captured: ReturnType<typeof useInnerBlocksProps> | null = null;
+
+        function Probe() {
+            captured = useInnerBlocksProps('parent');
+            return null;
+        }
+
+        renderWithStore(store, <Probe />);
+
+        act(() => {
+            captured!.removeBlock('child-1');
+        });
+
+        const parent = store.getState().blocks.find((b) => b.clientId === 'parent');
+        expect(parent?.innerBlocks.map((b) => b.clientId)).toEqual(['child-2']);
+    });
+
+    it('moveBlock reorders top-level blocks via the store', () => {
+        const store = createEditorStore([
+            makeBlock('a', 've/paragraph'),
+            makeBlock('b', 've/paragraph'),
+            makeBlock('c', 've/paragraph'),
+        ]);
+        let captured: ReturnType<typeof useInnerBlocksProps> | null = null;
+
+        function Probe() {
+            captured = useInnerBlocksProps(null);
+            return null;
+        }
+
+        renderWithStore(store, <Probe />);
+
+        act(() => {
+            captured!.moveBlock('a', 2);
+        });
+
+        expect(store.getState().blocks.map((b) => b.clientId)).toEqual(['b', 'c', 'a']);
+    });
+
+    it('selection propagates to the store when a child block is clicked', () => {
+        const store = createEditorStore(makeTree());
+        renderWithStore(store, <InnerBlocks parentClientId="parent" />);
+
+        const paragraph = screen.getByText('First paragraph');
+        fireEvent.click(paragraph);
+
+        expect(store.getState().selection.clientId).toBe('child-1');
+    });
+});

--- a/resources/js/visual-editor/editor/primitives/index.ts
+++ b/resources/js/visual-editor/editor/primitives/index.ts
@@ -1,0 +1,24 @@
+export {
+    BlockContextProvider,
+    useBlockContext,
+    useBlockContextValue,
+    type BlockContextValue,
+    type BlockContextTypeGuard,
+} from './BlockContext';
+export { EditorStoreProvider, useEditorStore, useOptionalEditorStore } from './EditorStoreContext';
+export { ReadOnlyProvider, useReadOnly } from './ReadOnlyContext';
+export {
+    InnerBlocks,
+    RenderBlock,
+    useInnerBlocksProps,
+    type InnerBlocksElementProps,
+    type UseInnerBlocksPropsOptions,
+    type UseInnerBlocksPropsReturn,
+} from './useInnerBlocksProps';
+export {
+    BlockPreview,
+    useBlockPreview,
+    type BlockPreviewProps,
+    type UseBlockPreviewOptions,
+    type UseBlockPreviewReturn,
+} from './useBlockPreview';

--- a/resources/js/visual-editor/editor/primitives/useBlockPreview.tsx
+++ b/resources/js/visual-editor/editor/primitives/useBlockPreview.tsx
@@ -1,0 +1,63 @@
+import { useMemo, type CSSProperties, type ReactNode } from 'react';
+import { createEditorStore, type Block } from '../store';
+import { EditorStoreProvider } from './EditorStoreContext';
+import { ReadOnlyProvider } from './ReadOnlyContext';
+import { RenderBlock } from './useInnerBlocksProps';
+
+export interface UseBlockPreviewOptions {
+    blocks: readonly Block[];
+}
+
+export interface BlockPreviewProps {
+    children: ReactNode;
+    style: CSSProperties;
+    inert: true;
+    'aria-hidden': 'true';
+    'data-block-preview': true;
+}
+
+export interface UseBlockPreviewReturn {
+    previewProps: BlockPreviewProps;
+}
+
+const PREVIEW_STYLE: CSSProperties = Object.freeze({
+    pointerEvents: 'none',
+    userSelect: 'none',
+});
+
+export function useBlockPreview({ blocks }: UseBlockPreviewOptions): UseBlockPreviewReturn {
+    const children = useMemo<ReactNode>(() => {
+        const previewStore = createEditorStore(blocks.slice());
+
+        return (
+            <EditorStoreProvider store={previewStore}>
+                <ReadOnlyProvider value={true}>
+                    {blocks.map((block) => (
+                        <RenderBlock key={block.clientId} block={block} />
+                    ))}
+                </ReadOnlyProvider>
+            </EditorStoreProvider>
+        );
+    }, [blocks]);
+
+    return {
+        previewProps: {
+            children,
+            style: PREVIEW_STYLE,
+            inert: true,
+            'aria-hidden': 'true',
+            'data-block-preview': true,
+        },
+    };
+}
+
+export interface BlockPreviewComponentProps {
+    blocks: readonly Block[];
+    className?: string;
+}
+
+export function BlockPreview({ blocks, className }: BlockPreviewComponentProps) {
+    const { previewProps } = useBlockPreview({ blocks });
+
+    return <div className={className} {...previewProps} />;
+}

--- a/resources/js/visual-editor/editor/primitives/useInnerBlocksProps.tsx
+++ b/resources/js/visual-editor/editor/primitives/useInnerBlocksProps.tsx
@@ -1,0 +1,211 @@
+import {
+    useCallback,
+    useMemo,
+    useRef,
+    type MouseEvent,
+    type ReactNode,
+    type RefObject,
+} from 'react';
+import { useStore } from 'zustand';
+import type { Block, EditorStore } from '../store';
+import { useChildren } from '../store';
+import { getBlock as getBlockDefinition, type BlockDefinition } from '../registry';
+import { BlockContextProvider } from './BlockContext';
+import { useEditorStore } from './EditorStoreContext';
+
+export interface InnerBlocksElementProps {
+    ref: RefObject<HTMLDivElement | null>;
+    children: ReactNode;
+    className?: string;
+    'data-parent-client-id': string;
+    onClickCapture: (event: MouseEvent<HTMLDivElement>) => void;
+}
+
+export interface UseInnerBlocksPropsOptions {
+    className?: string;
+}
+
+export interface UseInnerBlocksPropsReturn {
+    innerBlocksProps: InnerBlocksElementProps;
+    appendBlock: (block: Block, index?: number) => void;
+    removeBlock: (clientId: string) => void;
+    moveBlock: (clientId: string, index: number) => void;
+}
+
+const TOP_LEVEL_SENTINEL = '__ve_root__';
+
+export function useInnerBlocksProps(
+    parentClientId: string | null,
+    options: UseInnerBlocksPropsOptions = {}
+): UseInnerBlocksPropsReturn {
+    const ref = useRef<HTMLDivElement>(null);
+    const store = useEditorStore();
+    const childBlocks = useChildren(store, parentClientId);
+
+    const children = useMemo<ReactNode>(
+        () =>
+            childBlocks.map((block) => (
+                <RenderBlock key={block.clientId} block={block} />
+            )),
+        [childBlocks]
+    );
+
+    const appendBlock = useCallback(
+        (block: Block, index?: number) => {
+            store.getState().insertBlock(block, { parentClientId, index });
+        },
+        [store, parentClientId]
+    );
+
+    const removeBlock = useCallback(
+        (clientId: string) => {
+            store.getState().removeBlock(clientId);
+        },
+        [store]
+    );
+
+    const moveBlock = useCallback(
+        (clientId: string, index: number) => {
+            store.getState().moveBlock(clientId, { parentClientId, index });
+        },
+        [store, parentClientId]
+    );
+
+    const onClickCapture = useCallback(
+        (event: MouseEvent<HTMLDivElement>) => {
+            const childClientId = findNearestBlockClientId(
+                event.target as Element | null,
+                ref.current
+            );
+
+            if (childClientId === null || childClientId === parentClientId) {
+                return;
+            }
+
+            store.getState().select(childClientId);
+        },
+        [store, parentClientId]
+    );
+
+    return {
+        innerBlocksProps: {
+            ref,
+            children,
+            className: options.className,
+            'data-parent-client-id': parentClientId ?? TOP_LEVEL_SENTINEL,
+            onClickCapture,
+        },
+        appendBlock,
+        removeBlock,
+        moveBlock,
+    };
+}
+
+interface RenderBlockProps {
+    block: Block;
+}
+
+export function RenderBlock({ block }: RenderBlockProps) {
+    const definition = getBlockDefinition(block.name);
+
+    if (!definition) {
+        return (
+            <div data-block-missing={block.name} data-block-client-id={block.clientId}>
+                Unknown block: {block.name}
+            </div>
+        );
+    }
+
+    return <BlockEditHost definition={definition} block={block} />;
+}
+
+interface BlockEditHostProps {
+    definition: BlockDefinition;
+    block: Block;
+}
+
+function BlockEditHost({ definition, block }: BlockEditHostProps) {
+    const store = useEditorStore();
+    const liveBlock = useLiveBlock(store, block.clientId) ?? block;
+
+    const Edit = definition.edit;
+    const editElement = (
+        <Edit
+            clientId={liveBlock.clientId}
+            attributes={liveBlock.attributes}
+            block={liveBlock}
+        />
+    );
+
+    if (definition.providesContext) {
+        const contextValue = definition.providesContext(liveBlock.attributes, liveBlock);
+        return (
+            <div data-block-client-id={liveBlock.clientId}>
+                <BlockContextProvider value={contextValue}>{editElement}</BlockContextProvider>
+            </div>
+        );
+    }
+
+    return <div data-block-client-id={liveBlock.clientId}>{editElement}</div>;
+}
+
+function useLiveBlock(store: EditorStore, clientId: string): Block | undefined {
+    return useStore(store, (state) => findBlockInState(state.blocks, clientId));
+}
+
+function findBlockInState(blocks: Block[], clientId: string): Block | undefined {
+    for (const block of blocks) {
+        if (block.clientId === clientId) {
+            return block;
+        }
+
+        const found = findBlockInState(block.innerBlocks, clientId);
+
+        if (found !== undefined) {
+            return found;
+        }
+    }
+
+    return undefined;
+}
+
+function findNearestBlockClientId(
+    target: Element | null,
+    boundary: HTMLElement | null
+): string | null {
+    let current: Element | null = target;
+
+    while (current !== null) {
+        if (boundary !== null && current === boundary) {
+            return null;
+        }
+
+        if (current instanceof HTMLElement) {
+            const id = current.dataset.blockClientId;
+
+            if (typeof id === 'string' && id.length > 0) {
+                return id;
+            }
+        }
+
+        current = current.parentElement;
+    }
+
+    return null;
+}
+
+export interface InnerBlocksComponentProps {
+    parentClientId: string | null;
+    className?: string;
+}
+
+export function InnerBlocks({ parentClientId, className }: InnerBlocksComponentProps) {
+    const { innerBlocksProps } = useInnerBlocksProps(parentClientId, { className });
+    const { ref, children, ...rest } = innerBlocksProps;
+
+    return (
+        <div ref={ref} {...rest}>
+            {children}
+        </div>
+    );
+}

--- a/resources/js/visual-editor/editor/registry/blockRegistry.ts
+++ b/resources/js/visual-editor/editor/registry/blockRegistry.ts
@@ -1,0 +1,45 @@
+import type { ComponentType } from 'react';
+import type { Block } from '../store';
+import type { BlockContextValue } from '../primitives/BlockContext';
+
+export interface BlockEditProps {
+    clientId: string;
+    attributes: Record<string, unknown>;
+    block: Block;
+}
+
+export interface BlockDefinition {
+    name: string;
+    edit: ComponentType<BlockEditProps>;
+    providesContext?: (attributes: Record<string, unknown>, block: Block) => BlockContextValue;
+    usesContext?: readonly string[];
+}
+
+const registry = new Map<string, BlockDefinition>();
+
+export function registerBlock(definition: BlockDefinition): void {
+    if (registry.has(definition.name)) {
+        console.warn(
+            `[visual-editor] Block "${definition.name}" is already registered; ignoring duplicate registration.`
+        );
+        return;
+    }
+
+    registry.set(definition.name, definition);
+}
+
+export function getBlock(name: string): BlockDefinition | undefined {
+    return registry.get(name);
+}
+
+export function unregisterBlock(name: string): void {
+    registry.delete(name);
+}
+
+export function clearRegistry(): void {
+    registry.clear();
+}
+
+export function getRegisteredBlockNames(): string[] {
+    return Array.from(registry.keys());
+}

--- a/resources/js/visual-editor/editor/registry/index.ts
+++ b/resources/js/visual-editor/editor/registry/index.ts
@@ -1,0 +1,9 @@
+export {
+    registerBlock,
+    getBlock,
+    unregisterBlock,
+    clearRegistry,
+    getRegisteredBlockNames,
+    type BlockDefinition,
+    type BlockEditProps,
+} from './blockRegistry';


### PR DESCRIPTION
## Description

Port the three primitives from the Phase 0 spike (`resources/js/editor-spike/primitives/`) into the production editor tree at `resources/js/visual-editor/editor/primitives/`, strengthening them with strict TypeScript types, Zustand store integration, and production-grade Vitest coverage.

**Closes:** #269

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #269

## Motivation and Context

Phase 1.7 of the React migration. Moves the spike primitives into the production tree so subsequent Phase 1 issues (block wrapper, paragraph/heading blocks, etc.) can build on them. Per `PHASE-0-FINDINGS.md`, the spike copies stay in place until the final Phase 1 cleanup issue.

## Changes Made

- **BlockContext** (`primitives/BlockContext.tsx`): frozen `Record<string, unknown>` context value, `useBlockContextValue<T>(key, guard)` selector hook with runtime type guard (no `as T` escape hatches), stable refs across renders using a unique sentinel.
- **EditorStoreContext** (`primitives/EditorStoreContext.tsx`): new React context that exposes the editor store to primitives; throws a helpful error if used outside a provider.
- **useInnerBlocksProps** (`primitives/useInnerBlocksProps.tsx`): reads children from the Zustand store (#265) via `useChildren`, exposes `appendBlock` / `removeBlock` / `moveBlock` on the return value, and propagates clicks on child blocks to store selection via `onClickCapture`. Returns `innerBlocksProps` separately from mutation APIs to keep element spreading clean.
- **useBlockPreview** (`primitives/useBlockPreview.tsx`): renders an inert, `aria-hidden="true"`, `pointer-events: none`, `user-select: none` preview backed by an ephemeral store + `ReadOnlyProvider`, with strict types on `previewProps`.
- **Block registry** (`registry/blockRegistry.ts`): ported from the spike into the production tree so primitives can resolve block definitions.

## How Has This Been Tested?

**Testing Environment:**
- OS: macOS (Darwin 25.3.0)
- Node: Vitest 2.1.9

**Tests Performed:**
1. `npx vitest run resources/js/visual-editor` — all 101 tests in the production tree pass.
2. `npx vitest run` — full suite of 139 tests (production + spike + dnd-kit spike) all pass.
3. `npx tsc --noEmit` — clean.
4. `cr review --base add/phase-one --prompt-only` — 2 passes; second pass returns no findings.

## Accessibility Tests Run

- [x] ARIA labels checked

**Details:** `BlockPreview` wraps previews with `inert`, `aria-hidden="true"`, `pointer-events: none`, and `user-select: none`. Unit tests verify each attribute is present on the rendered wrapper.

## Tests Added

- [x] Unit tests added/updated
- [x] All tests passing

**Test details:**

- `primitives/__tests__/BlockContext.test.tsx` — 8 tests: merge, nested overrides, typed guard happy/missing/wrong-type paths, stable-ref behavior across renders.
- `primitives/__tests__/EditorStoreContext.test.tsx` — 2 tests: exposes store, throws outside provider.
- `primitives/__tests__/useInnerBlocksProps.test.tsx` — 11 tests: store-backed child rendering, empty wrappers, unknown block fallback, `providesContext` propagation, className forwarding, reactive updates, `appendBlock` / `removeBlock` / `moveBlock` (top-level), click-to-select propagation.
- `primitives/__tests__/useBlockPreview.test.tsx` — 5 tests: read-only paragraph rendering, nested `InnerBlocks` inside a preview, inert + aria-hidden + pointer-events + user-select, multi-root rendering, spreadable `previewProps`.

## Documentation

- [x] Inline code documentation added

**Documentation details:** JSDoc on `BlockContextValue` and `useBlockContextValue` explaining the strict-types contract and stable-ref behavior.

## Pre-Submission Checklist

- [x] Code passes all tests
- [x] Code has been linted (tsc clean)
- [x] Self-review completed
- [x] No new warnings generated

## Out of Scope

- Keyboard merge/split on inner blocks (lands with paragraph/heading in #272)
- Drag-and-drop on inner blocks — top-level only for Phase 1
- Selection UI affordances (land with `BlockWrapper` in the editor shell issue)
- Deleting the Phase 0 spike copies (final Phase 1 cleanup issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Block preview: render read-only previews with proper accessibility and inert behavior.
  * Block registration: register custom block types for the editor.
  * Block-level context: share typed context values between block boundaries.
  * Nested blocks: support inner/nested blocks with selection and block-manipulation APIs.
  * Public primitives entrypoint: unified exports for primitives and preview utilities.

* **Tests**
  * Added comprehensive tests covering block context, store context, preview, inner blocks, and registry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->