### PR TITLE
feat: editor shell — EditorShell, Canvas, BlockList, BlockWrapper

### DIFF
--- a/resources/js/visual-editor/editor/components/BlockList.tsx
+++ b/resources/js/visual-editor/editor/components/BlockList.tsx
@@ -1,0 +1,34 @@
+import { useChildren } from '../store';
+import { useEditorStore, useInnerBlocksProps } from '../primitives';
+import { BlockWrapper } from './BlockWrapper';
+
+export interface BlockListProps {
+    className?: string;
+}
+
+export function BlockList({ className }: BlockListProps) {
+    const store = useEditorStore();
+    const topLevelBlocks = useChildren(store, null);
+    const { innerBlocksProps } = useInnerBlocksProps(null, {
+        className: ['ve-block-list', className].filter(Boolean).join(' '),
+    });
+    const {
+        ref,
+        className: mergedClassName,
+        'data-parent-client-id': parentClientId,
+        onClickCapture,
+    } = innerBlocksProps;
+
+    return (
+        <div
+            ref={ref}
+            className={mergedClassName}
+            data-parent-client-id={parentClientId}
+            onClickCapture={onClickCapture}
+        >
+            {topLevelBlocks.map((block) => (
+                <BlockWrapper key={block.clientId} block={block} />
+            ))}
+        </div>
+    );
+}

--- a/resources/js/visual-editor/editor/components/BlockWrapper.tsx
+++ b/resources/js/visual-editor/editor/components/BlockWrapper.tsx
@@ -1,0 +1,44 @@
+import { useState, type ReactNode } from 'react';
+import { useStore } from 'zustand';
+import type { Block } from '../store';
+import { RenderBlock, useEditorStore } from '../primitives';
+
+export interface BlockWrapperProps {
+    block: Block;
+    children?: ReactNode;
+}
+
+export function BlockWrapper({ block, children }: BlockWrapperProps) {
+    const store = useEditorStore();
+    const isSelected = useStore(
+        store,
+        (state) => state.selection.clientId === block.clientId
+    );
+    const [isHovered, setIsHovered] = useState(false);
+
+    const className = [
+        've-block',
+        isHovered ? 've-block--is-hovered' : null,
+        isSelected ? 've-block--is-selected' : null,
+    ]
+        .filter(Boolean)
+        .join(' ');
+
+    return (
+        <div
+            className={className}
+            data-ve-block-wrapper=""
+            data-ve-selected={isSelected || undefined}
+            data-ve-hovered={isHovered || undefined}
+            onMouseEnter={() => setIsHovered(true)}
+            onMouseLeave={() => setIsHovered(false)}
+        >
+            <div
+                className="ve-block__drag-handle"
+                data-ve-drag-handle-slot=""
+                aria-hidden="true"
+            />
+            {children ?? <RenderBlock block={block} />}
+        </div>
+    );
+}

--- a/resources/js/visual-editor/editor/components/Canvas.tsx
+++ b/resources/js/visual-editor/editor/components/Canvas.tsx
@@ -1,0 +1,19 @@
+import type { ReactNode } from 'react';
+
+export interface CanvasProps {
+    children: ReactNode;
+    className?: string;
+}
+
+export function Canvas({ children, className }: CanvasProps) {
+    return (
+        <div
+            className={['ve-canvas', className].filter(Boolean).join(' ')}
+            data-ve-canvas=""
+            role="region"
+            aria-label="Editor canvas"
+        >
+            {children}
+        </div>
+    );
+}

--- a/resources/js/visual-editor/editor/components/EditorShell.tsx
+++ b/resources/js/visual-editor/editor/components/EditorShell.tsx
@@ -1,0 +1,96 @@
+import { useEffect } from 'react';
+import { useStore } from 'zustand';
+import type { EditorStore } from '../store';
+import { EditorStoreProvider, useEditorStore } from '../primitives';
+import { Canvas } from './Canvas';
+import { BlockList } from './BlockList';
+
+export interface EditorShellProps {
+    store: EditorStore;
+}
+
+export function EditorShell({ store }: EditorShellProps) {
+    return (
+        <EditorStoreProvider store={store}>
+            <EditorShellChrome />
+        </EditorStoreProvider>
+    );
+}
+
+function EditorShellChrome() {
+    return (
+        <div className="ve-editor-shell" data-ve-editor-shell="">
+            <Statusbar />
+            <KeyboardBindings />
+            <Canvas>
+                <BlockList />
+            </Canvas>
+        </div>
+    );
+}
+
+function Statusbar() {
+    const store = useEditorStore();
+    const isDirty = useStore(store, (state) => state.isDirty);
+    const selectedClientId = useStore(store, (state) => state.selection.clientId);
+
+    return (
+        <div className="ve-editor-shell__statusbar" role="status" aria-live="polite">
+            <span
+                className={[
+                    've-editor-shell__status',
+                    isDirty ? 've-editor-shell__status--dirty' : null,
+                ]
+                    .filter(Boolean)
+                    .join(' ')}
+                data-ve-dirty={isDirty || undefined}
+            >
+                {isDirty ? 'Unsaved changes' : 'Saved'}
+            </span>
+            <span
+                className="ve-editor-shell__status"
+                data-ve-selection={selectedClientId ?? undefined}
+            >
+                {selectedClientId ? `Selected: ${selectedClientId}` : 'No selection'}
+            </span>
+        </div>
+    );
+}
+
+function KeyboardBindings() {
+    const store = useEditorStore();
+
+    useEffect(() => {
+        function handleKeyDown(event: KeyboardEvent) {
+            if (!isUndoRedoKey(event)) {
+                return;
+            }
+
+            const isRedo = event.shiftKey || event.key.toLowerCase() === 'y';
+
+            event.preventDefault();
+
+            if (isRedo) {
+                store.getState().redo();
+            } else {
+                store.getState().undo();
+            }
+        }
+
+        window.addEventListener('keydown', handleKeyDown);
+
+        return () => window.removeEventListener('keydown', handleKeyDown);
+    }, [store]);
+
+    return null;
+}
+
+function isUndoRedoKey(event: KeyboardEvent): boolean {
+    if (!(event.metaKey || event.ctrlKey)) {
+        return false;
+    }
+
+    const key = event.key.toLowerCase();
+
+    return key === 'z' || key === 'y';
+}

--- a/resources/js/visual-editor/editor/components/__tests__/BlockList.test.tsx
+++ b/resources/js/visual-editor/editor/components/__tests__/BlockList.test.tsx
@@ -1,0 +1,91 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { BlockList } from '../BlockList';
+import { EditorStoreProvider } from '../../primitives';
+import {
+    clearRegistry,
+    registerBlock,
+    type BlockEditProps,
+} from '../../registry';
+import { createEditorStore, type Block, type EditorStore } from '../../store';
+
+function Paragraph({ attributes, clientId }: BlockEditProps) {
+    return <p data-client-id={clientId}>{String(attributes.content ?? '')}</p>;
+}
+
+function makeBlock(clientId: string, content: string): Block {
+    return {
+        clientId,
+        name: 've/paragraph',
+        attributes: { content },
+        innerBlocks: [],
+    };
+}
+
+function renderList(store: EditorStore) {
+    return render(
+        <EditorStoreProvider store={store}>
+            <BlockList />
+        </EditorStoreProvider>
+    );
+}
+
+beforeEach(() => {
+    clearRegistry();
+    registerBlock({ name: 've/paragraph', edit: Paragraph });
+});
+
+afterEach(() => {
+    clearRegistry();
+});
+
+describe('BlockList', () => {
+    it('renders a BlockWrapper for each top-level block', () => {
+        const store = createEditorStore([
+            makeBlock('a', 'alpha'),
+            makeBlock('b', 'beta'),
+        ]);
+
+        renderList(store);
+
+        expect(screen.getByText('alpha')).toBeInTheDocument();
+        expect(screen.getByText('beta')).toBeInTheDocument();
+        expect(document.querySelectorAll('[data-ve-block-wrapper]').length).toBe(2);
+    });
+
+    it('selects a block via the store when a child is clicked', () => {
+        const store = createEditorStore([
+            makeBlock('a', 'alpha'),
+            makeBlock('b', 'beta'),
+        ]);
+
+        renderList(store);
+
+        fireEvent.click(screen.getByText('beta'));
+
+        expect(store.getState().selection.clientId).toBe('b');
+    });
+
+    it('reactively renders blocks inserted into the store', () => {
+        const store = createEditorStore([makeBlock('a', 'alpha')]);
+        renderList(store);
+
+        act(() => {
+            store.getState().insertBlock(makeBlock('c', 'gamma'));
+        });
+
+        expect(screen.getByText('gamma')).toBeInTheDocument();
+    });
+
+    it('reflects store-driven selection in the wrapper state', () => {
+        const store = createEditorStore([makeBlock('a', 'alpha')]);
+        const { container } = renderList(store);
+
+        act(() => {
+            store.getState().select('a');
+        });
+
+        const wrapper = container.querySelector('[data-ve-block-wrapper]') as HTMLElement;
+        expect(wrapper.className).toContain('ve-block--is-selected');
+    });
+});

--- a/resources/js/visual-editor/editor/components/__tests__/BlockWrapper.test.tsx
+++ b/resources/js/visual-editor/editor/components/__tests__/BlockWrapper.test.tsx
@@ -1,0 +1,85 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { BlockWrapper } from '../BlockWrapper';
+import { EditorStoreProvider } from '../../primitives';
+import {
+    clearRegistry,
+    registerBlock,
+    type BlockEditProps,
+} from '../../registry';
+import { createEditorStore, type Block, type EditorStore } from '../../store';
+
+function Paragraph({ attributes, clientId }: BlockEditProps) {
+    return <p data-client-id={clientId}>{String(attributes.content ?? '')}</p>;
+}
+
+function makeBlock(clientId: string): Block {
+    return {
+        clientId,
+        name: 've/paragraph',
+        attributes: { content: `content-${clientId}` },
+        innerBlocks: [],
+    };
+}
+
+function renderWithStore(store: EditorStore, block: Block) {
+    return render(
+        <EditorStoreProvider store={store}>
+            <BlockWrapper block={block} />
+        </EditorStoreProvider>
+    );
+}
+
+beforeEach(() => {
+    clearRegistry();
+    registerBlock({ name: 've/paragraph', edit: Paragraph });
+});
+
+afterEach(() => {
+    clearRegistry();
+});
+
+describe('BlockWrapper', () => {
+    it('renders the block via RenderBlock inside the wrapper', () => {
+        const store = createEditorStore([makeBlock('a')]);
+        renderWithStore(store, makeBlock('a'));
+
+        expect(screen.getByText('content-a')).toBeInTheDocument();
+        expect(document.querySelector('[data-ve-block-wrapper]')).not.toBeNull();
+    });
+
+    it('exposes a drag-handle slot element', () => {
+        const store = createEditorStore([makeBlock('a')]);
+        renderWithStore(store, makeBlock('a'));
+
+        expect(document.querySelector('[data-ve-drag-handle-slot]')).not.toBeNull();
+    });
+
+    it('applies the selected class when the store selection matches', () => {
+        const store = createEditorStore([makeBlock('a')]);
+        const { container } = renderWithStore(store, makeBlock('a'));
+
+        const wrapper = container.querySelector('[data-ve-block-wrapper]') as HTMLElement;
+        expect(wrapper.className).not.toContain('ve-block--is-selected');
+
+        act(() => {
+            store.getState().select('a');
+        });
+
+        expect(wrapper.className).toContain('ve-block--is-selected');
+        expect(wrapper.dataset.veSelected).toBe('true');
+    });
+
+    it('toggles the hovered class on mouse enter and leave', () => {
+        const store = createEditorStore([makeBlock('a')]);
+        const { container } = renderWithStore(store, makeBlock('a'));
+
+        const wrapper = container.querySelector('[data-ve-block-wrapper]') as HTMLElement;
+
+        fireEvent.mouseEnter(wrapper);
+        expect(wrapper.className).toContain('ve-block--is-hovered');
+
+        fireEvent.mouseLeave(wrapper);
+        expect(wrapper.className).not.toContain('ve-block--is-hovered');
+    });
+});

--- a/resources/js/visual-editor/editor/components/__tests__/EditorShell.test.tsx
+++ b/resources/js/visual-editor/editor/components/__tests__/EditorShell.test.tsx
@@ -1,0 +1,160 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { EditorShell } from '../EditorShell';
+import {
+    clearRegistry,
+    registerBlock,
+    type BlockEditProps,
+} from '../../registry';
+import { createEditorStore, type Block } from '../../store';
+
+function Paragraph({ attributes, clientId }: BlockEditProps) {
+    return <p data-client-id={clientId}>{String(attributes.content ?? '')}</p>;
+}
+
+function makeBlock(clientId: string, content: string): Block {
+    return {
+        clientId,
+        name: 've/paragraph',
+        attributes: { content },
+        innerBlocks: [],
+    };
+}
+
+beforeEach(() => {
+    clearRegistry();
+    registerBlock({ name: 've/paragraph', edit: Paragraph });
+});
+
+afterEach(() => {
+    clearRegistry();
+});
+
+describe('EditorShell', () => {
+    it('mounts the Canvas and BlockList from the store', () => {
+        const store = createEditorStore([
+            makeBlock('a', 'alpha'),
+            makeBlock('b', 'beta'),
+        ]);
+
+        render(<EditorShell store={store} />);
+
+        expect(document.querySelector('[data-ve-editor-shell]')).not.toBeNull();
+        expect(document.querySelector('[data-ve-canvas]')).not.toBeNull();
+        expect(screen.getByText('alpha')).toBeInTheDocument();
+        expect(screen.getByText('beta')).toBeInTheDocument();
+    });
+
+    it('shows "Saved" in the statusbar and switches to "Unsaved changes" on mutation', () => {
+        const store = createEditorStore([makeBlock('a', 'alpha')]);
+        render(<EditorShell store={store} />);
+
+        expect(screen.getByText('Saved')).toBeInTheDocument();
+
+        act(() => {
+            store.getState().insertBlock(makeBlock('b', 'beta'));
+        });
+
+        expect(screen.getByText('Unsaved changes')).toBeInTheDocument();
+    });
+
+    it('shows the currently selected block client id', () => {
+        const store = createEditorStore([makeBlock('a', 'alpha')]);
+        render(<EditorShell store={store} />);
+
+        expect(screen.getByText('No selection')).toBeInTheDocument();
+
+        act(() => {
+            store.getState().select('a');
+        });
+
+        expect(screen.getByText('Selected: a')).toBeInTheDocument();
+    });
+
+    it('undoes the last mutation when Cmd+Z is pressed', () => {
+        const store = createEditorStore([makeBlock('a', 'alpha')]);
+        render(<EditorShell store={store} />);
+
+        act(() => {
+            store.getState().insertBlock(makeBlock('b', 'beta'));
+        });
+
+        expect(store.getState().blocks.map((b) => b.clientId)).toEqual(['a', 'b']);
+
+        act(() => {
+            fireEvent.keyDown(window, { key: 'z', metaKey: true });
+        });
+
+        expect(store.getState().blocks.map((b) => b.clientId)).toEqual(['a']);
+    });
+
+    it('undoes the last mutation when Ctrl+Z is pressed', () => {
+        const store = createEditorStore([makeBlock('a', 'alpha')]);
+        render(<EditorShell store={store} />);
+
+        act(() => {
+            store.getState().insertBlock(makeBlock('b', 'beta'));
+        });
+
+        act(() => {
+            fireEvent.keyDown(window, { key: 'z', ctrlKey: true });
+        });
+
+        expect(store.getState().blocks.map((b) => b.clientId)).toEqual(['a']);
+    });
+
+    it('redoes when Cmd+Shift+Z is pressed', () => {
+        const store = createEditorStore([makeBlock('a', 'alpha')]);
+        render(<EditorShell store={store} />);
+
+        act(() => {
+            store.getState().insertBlock(makeBlock('b', 'beta'));
+        });
+
+        act(() => {
+            store.getState().undo();
+        });
+
+        expect(store.getState().blocks.map((b) => b.clientId)).toEqual(['a']);
+
+        act(() => {
+            fireEvent.keyDown(window, { key: 'z', metaKey: true, shiftKey: true });
+        });
+
+        expect(store.getState().blocks.map((b) => b.clientId)).toEqual(['a', 'b']);
+    });
+
+    it('redoes when Ctrl+Y is pressed', () => {
+        const store = createEditorStore([makeBlock('a', 'alpha')]);
+        render(<EditorShell store={store} />);
+
+        act(() => {
+            store.getState().insertBlock(makeBlock('b', 'beta'));
+        });
+
+        act(() => {
+            store.getState().undo();
+        });
+
+        act(() => {
+            fireEvent.keyDown(window, { key: 'y', ctrlKey: true });
+        });
+
+        expect(store.getState().blocks.map((b) => b.clientId)).toEqual(['a', 'b']);
+    });
+
+    it('ignores keydowns without meta or ctrl modifiers', () => {
+        const store = createEditorStore([makeBlock('a', 'alpha')]);
+        render(<EditorShell store={store} />);
+
+        act(() => {
+            store.getState().insertBlock(makeBlock('b', 'beta'));
+        });
+
+        act(() => {
+            fireEvent.keyDown(window, { key: 'z' });
+        });
+
+        expect(store.getState().blocks.map((b) => b.clientId)).toEqual(['a', 'b']);
+    });
+});

--- a/resources/js/visual-editor/editor/components/editor.css
+++ b/resources/js/visual-editor/editor/components/editor.css
@@ -1,0 +1,88 @@
+.ve-editor-shell {
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+    background: #f5f5f7;
+    color: #1d1d1f;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+
+.ve-editor-shell__statusbar {
+    display: flex;
+    gap: 1rem;
+    padding: 0.5rem 1rem;
+    border-bottom: 1px solid #e5e5ea;
+    background: #fff;
+    font-size: 0.75rem;
+}
+
+.ve-editor-shell__status {
+    color: #6e6e73;
+}
+
+.ve-editor-shell__status--dirty {
+    color: #bf5af2;
+}
+
+.ve-canvas {
+    flex: 1 1 auto;
+    padding: 2rem;
+    background: #fff;
+    max-width: 960px;
+    margin: 0 auto;
+    width: 100%;
+    box-sizing: border-box;
+}
+
+.ve-block-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.ve-block {
+    position: relative;
+    padding: 0.25rem 0.5rem 0.25rem 1.75rem;
+    border: 1px solid transparent;
+    border-radius: 4px;
+    transition: border-color 120ms ease, background-color 120ms ease;
+}
+
+.ve-block--is-hovered {
+    border-color: #c7c7cc;
+    background: #fafafa;
+}
+
+.ve-block--is-selected {
+    border-color: #0a84ff;
+    background: #f0f7ff;
+}
+
+.ve-block--is-selected.ve-block--is-hovered {
+    border-color: #0a84ff;
+}
+
+.ve-block__drag-handle {
+    position: absolute;
+    top: 50%;
+    left: 0.25rem;
+    width: 1rem;
+    height: 1rem;
+    transform: translateY(-50%);
+    border-radius: 2px;
+    background: repeating-linear-gradient(
+        to bottom,
+        #c7c7cc 0,
+        #c7c7cc 2px,
+        transparent 2px,
+        transparent 4px
+    );
+    opacity: 0;
+    transition: opacity 120ms ease;
+    pointer-events: none;
+}
+
+.ve-block--is-hovered .ve-block__drag-handle,
+.ve-block--is-selected .ve-block__drag-handle {
+    opacity: 1;
+}

--- a/resources/js/visual-editor/editor/components/index.ts
+++ b/resources/js/visual-editor/editor/components/index.ts
@@ -1,0 +1,4 @@
+export { EditorShell, type EditorShellProps } from './EditorShell';
+export { Canvas, type CanvasProps } from './Canvas';
+export { BlockList, type BlockListProps } from './BlockList';
+export { BlockWrapper, type BlockWrapperProps } from './BlockWrapper';

--- a/resources/js/visual-editor/editor/main.tsx
+++ b/resources/js/visual-editor/editor/main.tsx
@@ -1,5 +1,9 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
+import { EditorShell } from './components';
+import './components/editor.css';
+import { registerBlock, type BlockEditProps } from './registry';
+import { createEditorStore, type Block, type EditorStore } from './store';
 
 const MOUNT_ID = 've-root';
 
@@ -8,25 +12,6 @@ type EditorConfig = {
     postType: string;
     apiBase: string;
 };
-
-type EditorShellProps = EditorConfig;
-
-function EditorShell({ postId, postType, apiBase }: EditorShellProps) {
-    return (
-        <div className="ve-editor-placeholder">
-            <h1>ArtisanPack Visual Editor</h1>
-            <p>Placeholder shell — the real editor lands in issue #270.</p>
-            <dl>
-                <dt>postId</dt>
-                <dd>{postId}</dd>
-                <dt>postType</dt>
-                <dd>{postType}</dd>
-                <dt>apiBase</dt>
-                <dd>{apiBase}</dd>
-            </dl>
-        </div>
-    );
-}
 
 function readEditorConfig(container: HTMLElement): EditorConfig | null {
     const postId = container.dataset.postId?.trim();
@@ -38,6 +23,36 @@ function readEditorConfig(container: HTMLElement): EditorConfig | null {
     }
 
     return { postId, postType, apiBase };
+}
+
+function PlaceholderEdit({ attributes }: BlockEditProps) {
+    const label =
+        typeof attributes.label === 'string' ? attributes.label : 'Placeholder block';
+
+    return <p className="ve-placeholder-block">{label}</p>;
+}
+
+function registerPlaceholderBlock(): void {
+    registerBlock({ name: 've/placeholder', edit: PlaceholderEdit });
+}
+
+function createPlaceholderStore(): EditorStore {
+    const placeholders: Block[] = [
+        {
+            clientId: 'placeholder-1',
+            name: 've/placeholder',
+            attributes: { label: 'First placeholder block' },
+            innerBlocks: [],
+        },
+        {
+            clientId: 'placeholder-2',
+            name: 've/placeholder',
+            attributes: { label: 'Second placeholder block' },
+            innerBlocks: [],
+        },
+    ];
+
+    return createEditorStore(placeholders);
 }
 
 function bootEditor(): void {
@@ -59,11 +74,18 @@ function bootEditor(): void {
         return;
     }
 
+    registerPlaceholderBlock();
+
+    const store = createPlaceholderStore();
+
     createRoot(container).render(
         <StrictMode>
-            <EditorShell {...config} />
+            <EditorShell store={store} />
         </StrictMode>
     );
+
+    // Config is read for future wiring (post loader, API client) but unused for now.
+    void config;
 }
 
 bootEditor();


### PR DESCRIPTION
## Description

Phase 1.8 of the React migration. Builds the React component skeleton that frames the editor: `EditorShell`, `Canvas`, `BlockList`, and `BlockWrapper`. No block-type-specific code — just the layout, the canvas that holds the tree, the block list that iterates the store, and the block wrapper that handles selection, hover, and a drag-handle slot for every block type.

**Closes:** #270

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #270

## Motivation and Context

Stands up the editor shell that subsequent Phase 1 issues plug into (#271 fills the drag handle, #272 ships real block types, #273 adds the inserter UI). Everything interactive beyond selection is explicitly out of scope per the issue.

## Changes Made

- **`EditorShell.tsx`** — top-level layout, wraps the tree in `EditorStoreProvider` (from #269), installs a global `keydown` listener for `⌘Z`/`Ctrl+Z` (undo) and `⌘⇧Z` / `Ctrl+Y` (redo) routed through the store's history actions (#266), and renders a dirty/selection statusbar backed by Zustand selectors.
- **`Canvas.tsx`** — editable area wrapper with chrome CSS and `role="region"` / `aria-label`.
- **`BlockList.tsx`** — reads top-level blocks via `useChildren`, uses the productionized `useInnerBlocksProps(null)` from #269 for the ref/element props/`onClickCapture`/mutation APIs, and maps the top-level blocks to `<BlockWrapper>` children.
- **`BlockWrapper.tsx`** — hover outline, selection outline (driven by a store selector), drag-handle slot (`[data-ve-drag-handle-slot]`) that #271 fills in, and delegates block rendering to `RenderBlock` from the primitives. Click-to-select is handled at the `BlockList` level via `onClickCapture` so the wrapper stays purely presentational.
- **`editor.css`** — minimal styles for block boundaries, hover/selected states, and the drag-handle affordance.
- **`main.tsx`** — creates a real editor store seeded with two placeholder blocks and renders `<EditorShell store={store} />`; registers a `ve/placeholder` block so the dev harness has something to show.

## How Has This Been Tested?

**Testing Environment:**
- OS: macOS (Darwin 25.3.0)
- Node: Vitest 2.1.9

**Tests Performed:**
1. `npx vitest run resources/js/visual-editor/editor/components` — 16/16 new tests pass.
2. `npx vitest run` — full suite of 155 tests passes.
3. `npx tsc --noEmit` — clean.
4. `cr review --base add/phase-one --prompt-only` — no findings on first pass.
5. Manual browser smoke test against the dev harness — shell renders, click-to-select works, statusbar reflects dirty/selection state, drag-handle affordance appears on hover/selection.

## Accessibility Tests Run

- [x] Keyboard navigation tested
- [x] ARIA labels checked

**Details:** Canvas is a labelled region. Statusbar uses `role="status"` + `aria-live="polite"`. Drag-handle slot is marked `aria-hidden="true"` since #271 will replace it with a real keyboard-navigable handle. Global `⌘Z` / `Ctrl+Z` / `⌘⇧Z` / `Ctrl+Y` keybindings verified via keyboard events in Vitest.

## Tests Added

- [x] Unit tests added/updated
- [x] All tests passing

**Test details:**

- `components/__tests__/BlockWrapper.test.tsx` — 4 tests: renders via `RenderBlock`, exposes the drag-handle slot, applies the selected class from store selection, toggles the hovered class on mouse enter/leave.
- `components/__tests__/BlockList.test.tsx` — 4 tests: renders a `BlockWrapper` per top-level block, store-level selection on child click, reactively picks up inserted blocks, reflects store-driven selection into the wrapper class.
- `components/__tests__/EditorShell.test.tsx` — 8 tests: mounts Canvas + BlockList from the store, dirty-state statusbar, selection statusbar, `⌘Z` undo, `Ctrl+Z` undo, `⌘⇧Z` redo, `Ctrl+Y` redo, ignores unmodified `z` keydowns.

## Documentation

- [x] Inline code documentation added

**Documentation details:** Types on every public component prop. Component responsibilities are clear from file names and small surface area.

## Pre-Submission Checklist

- [x] Code passes all tests
- [x] Code has been linted (tsc clean)
- [x] Self-review completed
- [x] No new warnings generated

## Out of Scope (per issue)

- Real dnd-kit drag handles (#271) — the slot is a visual placeholder only.
- Block inserter UI (#273).
- Any block-type-specific edit code (#272) — the placeholder block is render-only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added visual editor interface with block editing canvas
  * Added selection and hover states for blocks with visual feedback
  * Added keyboard shortcuts: Ctrl/Cmd+Z for undo and Ctrl/Cmd+Y or Ctrl/Cmd+Shift+Z for redo

* **Tests**
  * Added comprehensive test coverage for editor components and keyboard functionality

* **Style**
  * Added styling for editor UI, canvas, blocks, and drag handles

<!-- end of auto-generated comment: release notes by coderabbit.ai -->