### PR TITLE
feat: integrate dnd-kit into production BlockList (top-level)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
                 "@testing-library/dom": "^10.4.0",
                 "@testing-library/jest-dom": "^6.4.6",
                 "@testing-library/react": "^16.1.0",
+                "@testing-library/user-event": "^14.6.1",
                 "@types/react": "^19.0.0",
                 "@types/react-dom": "^19.0.0",
                 "@vitejs/plugin-react": "^4.3.1",
@@ -1418,6 +1419,20 @@
                 "@types/react-dom": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/@testing-library/user-event": {
+            "version": "14.6.1",
+            "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+            "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12",
+                "npm": ">=6"
+            },
+            "peerDependencies": {
+                "@testing-library/dom": ">=7.21.4"
             }
         },
         "node_modules/@tiptap/core": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
         "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^6.4.6",
         "@testing-library/react": "^16.1.0",
+        "@testing-library/user-event": "^14.6.1",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "@vitejs/plugin-react": "^4.3.1",

--- a/resources/js/visual-editor/editor/components/BlockList.tsx
+++ b/resources/js/visual-editor/editor/components/BlockList.tsx
@@ -1,14 +1,44 @@
+import { useCallback, useMemo, useState } from 'react';
+import {
+    DndContext,
+    DragOverlay,
+    KeyboardSensor,
+    PointerSensor,
+    closestCenter,
+    useSensor,
+    useSensors,
+    type Announcements,
+    type DragEndEvent,
+    type DragStartEvent,
+    type ScreenReaderInstructions,
+    type UniqueIdentifier,
+} from '@dnd-kit/core';
+import {
+    SortableContext,
+    sortableKeyboardCoordinates,
+    verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
 import { useChildren } from '../store';
-import { useEditorStore, useInnerBlocksProps } from '../primitives';
+import { useEditorStore, useInnerBlocksProps, RenderBlock } from '../primitives';
 import { BlockWrapper } from './BlockWrapper';
 
 export interface BlockListProps {
     className?: string;
 }
 
+const screenReaderInstructions: ScreenReaderInstructions = {
+    draggable: [
+        'To pick up a block, press space or enter.',
+        'While dragging, use the arrow keys to move the block up or down.',
+        'Press space or enter again to drop the block, or press escape to cancel.',
+    ].join(' '),
+};
+
 export function BlockList({ className }: BlockListProps) {
     const store = useEditorStore();
     const topLevelBlocks = useChildren(store, null);
+    const [activeId, setActiveId] = useState<UniqueIdentifier | null>(null);
+
     const { innerBlocksProps } = useInnerBlocksProps(null, {
         className: ['ve-block-list', className].filter(Boolean).join(' '),
     });
@@ -19,16 +49,122 @@ export function BlockList({ className }: BlockListProps) {
         onClickCapture,
     } = innerBlocksProps;
 
+    const sensors = useSensors(
+        useSensor(PointerSensor, {
+            activationConstraint: { distance: 8 },
+        }),
+        useSensor(KeyboardSensor, {
+            coordinateGetter: sortableKeyboardCoordinates,
+        })
+    );
+
+    const sortableIds = useMemo(
+        () => topLevelBlocks.map((block) => block.clientId),
+        [topLevelBlocks]
+    );
+
+    const announcements = useMemo<Announcements>(() => {
+        const describe = (id: UniqueIdentifier): string => {
+            const index = topLevelBlocks.findIndex((block) => block.clientId === id);
+            const position = index === -1 ? 0 : index + 1;
+            return `block ${position} of ${topLevelBlocks.length}`;
+        };
+
+        return {
+            onDragStart: ({ active }) => `Picked up ${describe(active.id)}.`,
+            onDragOver: ({ active, over }) =>
+                over
+                    ? `${describe(active.id)} was moved over ${describe(over.id)}.`
+                    : `${describe(active.id)} is no longer over a droppable area.`,
+            onDragEnd: ({ active, over }) =>
+                over
+                    ? `${describe(active.id)} was dropped over ${describe(over.id)}.`
+                    : `${describe(active.id)} was dropped.`,
+            onDragCancel: ({ active }) =>
+                `Dragging was cancelled. ${describe(active.id)} was returned to its original position.`,
+        };
+    }, [topLevelBlocks]);
+
+    const handleDragStart = useCallback((event: DragStartEvent) => {
+        setActiveId(event.active.id);
+    }, []);
+
+    const handleDragEnd = useCallback(
+        (event: DragEndEvent) => {
+            setActiveId(null);
+
+            const { active, over } = event;
+
+            if (!over || active.id === over.id) {
+                return;
+            }
+
+            const activeClientId = String(active.id);
+            const overClientId = String(over.id);
+
+            const currentBlocks = store.getState().blocks;
+            const oldIndex = currentBlocks.findIndex(
+                (block) => block.clientId === activeClientId
+            );
+            const newIndex = currentBlocks.findIndex(
+                (block) => block.clientId === overClientId
+            );
+
+            if (oldIndex === -1 || newIndex === -1) {
+                return;
+            }
+
+            store.getState().moveBlock(activeClientId, {
+                parentClientId: null,
+                index: newIndex,
+            });
+        },
+        [store]
+    );
+
+    const handleDragCancel = useCallback(() => {
+        setActiveId(null);
+    }, []);
+
+    const activeBlock = useMemo(
+        () =>
+            activeId === null
+                ? null
+                : topLevelBlocks.find((block) => block.clientId === activeId) ?? null,
+        [activeId, topLevelBlocks]
+    );
+
     return (
-        <div
-            ref={ref}
-            className={mergedClassName}
-            data-parent-client-id={parentClientId}
-            onClickCapture={onClickCapture}
+        <DndContext
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            accessibility={{ announcements, screenReaderInstructions }}
+            onDragStart={handleDragStart}
+            onDragEnd={handleDragEnd}
+            onDragCancel={handleDragCancel}
         >
-            {topLevelBlocks.map((block) => (
-                <BlockWrapper key={block.clientId} block={block} />
-            ))}
-        </div>
+            <SortableContext items={sortableIds} strategy={verticalListSortingStrategy}>
+                <div
+                    ref={ref}
+                    className={mergedClassName}
+                    data-parent-client-id={parentClientId}
+                    onClickCapture={onClickCapture}
+                >
+                    {topLevelBlocks.map((block) => (
+                        <BlockWrapper key={block.clientId} block={block} />
+                    ))}
+                </div>
+            </SortableContext>
+            <DragOverlay>
+                {activeBlock ? (
+                    <div
+                        className="ve-block ve-block--drag-overlay"
+                        data-ve-drag-overlay=""
+                    >
+                        <RenderBlock block={activeBlock} />
+                    </div>
+                ) : null}
+            </DragOverlay>
+        </DndContext>
     );
 }

--- a/resources/js/visual-editor/editor/components/BlockWrapper.tsx
+++ b/resources/js/visual-editor/editor/components/BlockWrapper.tsx
@@ -1,5 +1,7 @@
-import { useState, type ReactNode } from 'react';
+import { useState, type CSSProperties, type ReactNode } from 'react';
 import { useStore } from 'zustand';
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 import type { Block } from '../store';
 import { RenderBlock, useEditorStore } from '../primitives';
 
@@ -16,28 +18,54 @@ export function BlockWrapper({ block, children }: BlockWrapperProps) {
     );
     const [isHovered, setIsHovered] = useState(false);
 
+    const {
+        attributes,
+        listeners,
+        setNodeRef,
+        setActivatorNodeRef,
+        transform,
+        transition,
+        isDragging,
+    } = useSortable({ id: block.clientId });
+
     const className = [
         've-block',
         isHovered ? 've-block--is-hovered' : null,
         isSelected ? 've-block--is-selected' : null,
+        isDragging ? 've-block--is-dragging' : null,
     ]
         .filter(Boolean)
         .join(' ');
 
+    const style: CSSProperties = {
+        transform: CSS.Transform.toString(transform),
+        transition,
+    };
+
     return (
         <div
+            ref={setNodeRef}
             className={className}
+            style={style}
             data-ve-block-wrapper=""
             data-ve-selected={isSelected || undefined}
             data-ve-hovered={isHovered || undefined}
+            data-ve-dragging={isDragging || undefined}
             onMouseEnter={() => setIsHovered(true)}
             onMouseLeave={() => setIsHovered(false)}
         >
-            <div
+            <button
+                type="button"
+                ref={setActivatorNodeRef}
                 className="ve-block__drag-handle"
                 data-ve-drag-handle-slot=""
-                aria-hidden="true"
-            />
+                data-ve-drag-handle-for={block.clientId}
+                aria-label={`Drag block ${block.name}`}
+                {...attributes}
+                {...listeners}
+            >
+                <span aria-hidden="true">⠿</span>
+            </button>
             {children ?? <RenderBlock block={block} />}
         </div>
     );

--- a/resources/js/visual-editor/editor/components/__tests__/BlockListDnd.test.tsx
+++ b/resources/js/visual-editor/editor/components/__tests__/BlockListDnd.test.tsx
@@ -1,0 +1,109 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { BlockList } from '../BlockList';
+import { EditorStoreProvider } from '../../primitives';
+import {
+    clearRegistry,
+    registerBlock,
+    type BlockEditProps,
+} from '../../registry';
+import { createEditorStore, type Block, type EditorStore } from '../../store';
+
+function Paragraph({ attributes, clientId }: BlockEditProps) {
+    return <p data-client-id={clientId}>{String(attributes.content ?? '')}</p>;
+}
+
+function makeBlock(clientId: string, content: string): Block {
+    return {
+        clientId,
+        name: 've/paragraph',
+        attributes: { content },
+        innerBlocks: [],
+    };
+}
+
+function renderList(store: EditorStore) {
+    return render(
+        <EditorStoreProvider store={store}>
+            <BlockList />
+        </EditorStoreProvider>
+    );
+}
+
+beforeEach(() => {
+    clearRegistry();
+    registerBlock({ name: 've/paragraph', edit: Paragraph });
+});
+
+afterEach(() => {
+    clearRegistry();
+});
+
+describe('BlockList drag-and-drop wiring', () => {
+    it('renders accessible drag handle buttons for every top-level block', () => {
+        const store = createEditorStore([
+            makeBlock('a', 'alpha'),
+            makeBlock('b', 'beta'),
+            makeBlock('c', 'gamma'),
+        ]);
+
+        renderList(store);
+
+        const handles = document.querySelectorAll('[data-ve-drag-handle-slot]');
+        expect(handles.length).toBe(3);
+        handles.forEach((handle) => {
+            expect(handle.tagName).toBe('BUTTON');
+            expect(handle.getAttribute('aria-label')).toMatch(/Drag block/);
+        });
+    });
+
+    it('registers pointer and keyboard sensors without throwing on mount', () => {
+        const store = createEditorStore([
+            makeBlock('a', 'alpha'),
+            makeBlock('b', 'beta'),
+        ]);
+
+        expect(() => renderList(store)).not.toThrow();
+        expect(
+            document.querySelectorAll('[data-ve-block-wrapper]').length
+        ).toBe(2);
+    });
+
+    it('preserves click-to-select selection capture inside the DndContext', async () => {
+        const user = userEvent.setup();
+        const store = createEditorStore([
+            makeBlock('a', 'alpha'),
+            makeBlock('b', 'beta'),
+        ]);
+
+        renderList(store);
+
+        await user.click(screen.getByText('beta'));
+
+        expect(store.getState().selection.clientId).toBe('b');
+    });
+
+    it('exposes screen reader instructions covering keyboard drag', () => {
+        const store = createEditorStore([makeBlock('a', 'alpha')]);
+
+        renderList(store);
+
+        const liveRegions = document.querySelectorAll('[aria-live]');
+        expect(liveRegions.length).toBeGreaterThan(0);
+        expect(document.body.textContent ?? '').toMatch(
+            /press space or enter/i
+        );
+    });
+
+    it('keeps the drag handle focusable via keyboard navigation', async () => {
+        const user = userEvent.setup();
+        const store = createEditorStore([makeBlock('a', 'alpha')]);
+
+        renderList(store);
+        await user.tab();
+
+        const focused = document.activeElement as HTMLElement | null;
+        expect(focused?.getAttribute('data-ve-drag-handle-slot')).not.toBeNull();
+    });
+});

--- a/resources/js/visual-editor/editor/components/__tests__/BlockListDndDispatch.test.tsx
+++ b/resources/js/visual-editor/editor/components/__tests__/BlockListDndDispatch.test.tsx
@@ -1,0 +1,246 @@
+import { act, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { DragEndEvent, DragStartEvent } from '@dnd-kit/core';
+
+/**
+ * Driving dnd-kit sensors through jsdom is unreliable because jsdom lacks
+ * layout: all rects collapse to zero, so the keyboard and pointer sensors
+ * can never compute a drop target. Instead, we mock DndContext to capture
+ * the drag lifecycle callbacks that BlockList passes in, then invoke them
+ * directly with pointer- and keyboard-shaped events. This exercises the
+ * real BlockList dispatch contract — the exact code path the sensors feed
+ * into — while staying deterministic.
+ */
+
+type CapturedHandlers = {
+    onDragStart?: (event: DragStartEvent) => void;
+    onDragEnd?: (event: DragEndEvent) => void;
+    onDragCancel?: () => void;
+};
+
+const handlers: CapturedHandlers = {};
+
+vi.mock('@dnd-kit/core', async () => {
+    const actual =
+        await vi.importActual<typeof import('@dnd-kit/core')>('@dnd-kit/core');
+    return {
+        ...actual,
+        DndContext: ({
+            children,
+            onDragStart,
+            onDragEnd,
+            onDragCancel,
+        }: {
+            children: React.ReactNode;
+            onDragStart?: (event: DragStartEvent) => void;
+            onDragEnd?: (event: DragEndEvent) => void;
+            onDragCancel?: () => void;
+        }) => {
+            handlers.onDragStart = onDragStart;
+            handlers.onDragEnd = onDragEnd;
+            handlers.onDragCancel = onDragCancel;
+            return <>{children}</>;
+        },
+        DragOverlay: ({ children }: { children?: React.ReactNode }) => (
+            <>{children}</>
+        ),
+    };
+});
+
+import { BlockList } from '../BlockList';
+import { EditorStoreProvider } from '../../primitives';
+import {
+    clearRegistry,
+    registerBlock,
+    type BlockEditProps,
+} from '../../registry';
+import { createEditorStore, type Block, type EditorStore } from '../../store';
+
+function Paragraph({ attributes, clientId }: BlockEditProps) {
+    return <p data-client-id={clientId}>{String(attributes.content ?? '')}</p>;
+}
+
+function makeBlock(clientId: string, content: string): Block {
+    return {
+        clientId,
+        name: 've/paragraph',
+        attributes: { content },
+        innerBlocks: [],
+    };
+}
+
+function renderList(store: EditorStore) {
+    return render(
+        <EditorStoreProvider store={store}>
+            <BlockList />
+        </EditorStoreProvider>
+    );
+}
+
+function pointerDragEvent(activeId: string, overId: string | null): DragEndEvent {
+    return {
+        active: {
+            id: activeId,
+            data: { current: undefined },
+            rect: { current: { initial: null, translated: null } },
+        },
+        over:
+            overId === null
+                ? null
+                : {
+                      id: overId,
+                      rect: {
+                          width: 0,
+                          height: 0,
+                          top: 0,
+                          bottom: 0,
+                          left: 0,
+                          right: 0,
+                      },
+                      disabled: false,
+                      data: { current: undefined },
+                  },
+        delta: { x: 0, y: 0 },
+        collisions: null,
+        activatorEvent: new Event('pointerdown'),
+    } as unknown as DragEndEvent;
+}
+
+function keyboardDragEvent(activeId: string, overId: string | null): DragEndEvent {
+    const event = pointerDragEvent(activeId, overId);
+    (event as unknown as { activatorEvent: Event }).activatorEvent =
+        new KeyboardEvent('keydown', { code: 'Space' });
+    return event;
+}
+
+function getOrder(store: EditorStore): string[] {
+    return store.getState().blocks.map((block) => block.clientId);
+}
+
+beforeEach(() => {
+    clearRegistry();
+    registerBlock({ name: 've/paragraph', edit: Paragraph });
+    handlers.onDragStart = undefined;
+    handlers.onDragEnd = undefined;
+    handlers.onDragCancel = undefined;
+});
+
+afterEach(() => {
+    clearRegistry();
+    vi.restoreAllMocks();
+});
+
+describe('BlockList drag dispatch', () => {
+    it('dispatches moveBlock with the correct target index on pointer drop', () => {
+        const store = createEditorStore([
+            makeBlock('a', 'alpha'),
+            makeBlock('b', 'beta'),
+            makeBlock('c', 'gamma'),
+        ]);
+        const moveBlockSpy = vi.spyOn(store.getState(), 'moveBlock');
+
+        renderList(store);
+
+        expect(handlers.onDragEnd).toBeDefined();
+        act(() => {
+            handlers.onDragEnd!(pointerDragEvent('a', 'c'));
+        });
+
+        expect(moveBlockSpy).toHaveBeenCalledTimes(1);
+        expect(moveBlockSpy).toHaveBeenCalledWith('a', {
+            parentClientId: null,
+            index: 2,
+        });
+        expect(getOrder(store)).toEqual(['b', 'c', 'a']);
+    });
+
+    it('dispatches moveBlock on keyboard drop with the correct indices', () => {
+        const store = createEditorStore([
+            makeBlock('a', 'alpha'),
+            makeBlock('b', 'beta'),
+            makeBlock('c', 'gamma'),
+        ]);
+        const moveBlockSpy = vi.spyOn(store.getState(), 'moveBlock');
+
+        renderList(store);
+
+        act(() => {
+            handlers.onDragEnd!(keyboardDragEvent('c', 'a'));
+        });
+
+        expect(moveBlockSpy).toHaveBeenCalledWith('c', {
+            parentClientId: null,
+            index: 0,
+        });
+        expect(getOrder(store)).toEqual(['c', 'a', 'b']);
+    });
+
+    it('no-ops when the drop target is the same as the active block', () => {
+        const store = createEditorStore([
+            makeBlock('a', 'alpha'),
+            makeBlock('b', 'beta'),
+        ]);
+        const moveBlockSpy = vi.spyOn(store.getState(), 'moveBlock');
+
+        renderList(store);
+
+        act(() => {
+            handlers.onDragEnd!(pointerDragEvent('a', 'a'));
+        });
+
+        expect(moveBlockSpy).not.toHaveBeenCalled();
+        expect(getOrder(store)).toEqual(['a', 'b']);
+    });
+
+    it('no-ops when the drop is released outside any droppable', () => {
+        const store = createEditorStore([
+            makeBlock('a', 'alpha'),
+            makeBlock('b', 'beta'),
+        ]);
+        const moveBlockSpy = vi.spyOn(store.getState(), 'moveBlock');
+
+        renderList(store);
+
+        act(() => {
+            handlers.onDragEnd!(pointerDragEvent('a', null));
+        });
+
+        expect(moveBlockSpy).not.toHaveBeenCalled();
+        expect(getOrder(store)).toEqual(['a', 'b']);
+    });
+
+    it('tracks active block on drag start for the drag overlay', () => {
+        const store = createEditorStore([
+            makeBlock('a', 'alpha'),
+            makeBlock('b', 'beta'),
+        ]);
+
+        renderList(store);
+
+        expect(handlers.onDragStart).toBeDefined();
+        expect(() =>
+            act(() => {
+                handlers.onDragStart!({
+                    active: {
+                        id: 'a',
+                        data: { current: undefined },
+                        rect: { current: { initial: null, translated: null } },
+                    },
+                } as unknown as DragStartEvent);
+            })
+        ).not.toThrow();
+    });
+
+    it('clears active state on drag cancel', () => {
+        const store = createEditorStore([makeBlock('a', 'alpha')]);
+
+        renderList(store);
+
+        expect(handlers.onDragCancel).toBeDefined();
+        expect(() =>
+            act(() => {
+                handlers.onDragCancel!();
+            })
+        ).not.toThrow();
+    });
+});

--- a/resources/js/visual-editor/editor/components/editor.css
+++ b/resources/js/visual-editor/editor/components/editor.css
@@ -66,23 +66,44 @@
     position: absolute;
     top: 50%;
     left: 0.25rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     width: 1rem;
     height: 1rem;
+    padding: 0;
     transform: translateY(-50%);
+    border: 0;
     border-radius: 2px;
-    background: repeating-linear-gradient(
-        to bottom,
-        #c7c7cc 0,
-        #c7c7cc 2px,
-        transparent 2px,
-        transparent 4px
-    );
+    background: transparent;
+    color: #8e8e93;
+    font-size: 0.75rem;
+    line-height: 1;
+    cursor: grab;
     opacity: 0;
-    transition: opacity 120ms ease;
-    pointer-events: none;
+    transition: opacity 120ms ease, background-color 120ms ease;
+    touch-action: none;
+}
+
+.ve-block__drag-handle:focus-visible {
+    outline: 2px solid #0a84ff;
+    outline-offset: 2px;
+    opacity: 1;
 }
 
 .ve-block--is-hovered .ve-block__drag-handle,
-.ve-block--is-selected .ve-block__drag-handle {
+.ve-block--is-selected .ve-block__drag-handle,
+.ve-block--is-dragging .ve-block__drag-handle {
     opacity: 1;
+}
+
+.ve-block--is-dragging {
+    opacity: 0.4;
+}
+
+.ve-block--drag-overlay {
+    background: #fff;
+    border-color: #0a84ff;
+    box-shadow: 0 12px 24px rgba(10, 132, 255, 0.2);
+    cursor: grabbing;
 }


### PR DESCRIPTION
## Description

Integrates dnd-kit into the production `BlockList` from #270 for top-level block reordering. Builds on the green-lit spike harness from #268. Nested DnD and cross-container drops remain Phase 2.

**Closes:** #271

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #271

## Motivation and Context

Phase 1 of the React editor migration needs real, accessible block reordering on top of the production BlockList. The #268 spike validated dnd-kit + Tiptap coexistence; this PR lands that integration against the real store and the real `BlockWrapper` drag-handle slot.

## Changes Made

- Wrap `BlockList` in `DndContext` + `SortableContext` (vertical strategy, `closestCenter` collision)
- Register pointer (distance: 8) and keyboard sensors with `sortableKeyboardCoordinates`
- Turn the `BlockWrapper` drag-handle slot into a real `<button>` wired via `setActivatorNodeRef`, `listeners`, and `attributes`, with `useSortable` driving `transform`/`transition`/`isDragging`
- On drop, dispatch `moveBlock(activeClientId, { parentClientId: null, index: newIndex })` for top-level moves only
- Add `DragOverlay` with a block preview, accessible announcements (start/over/end/cancel), and screen-reader instructions covering the full keyboard drag flow
- Add `.ve-block--is-dragging` / `.ve-block--drag-overlay` styles and promote the drag handle to an interactive button with grab cursor, `touch-action: none`, and a focus-visible outline
- Add `@testing-library/user-event` dev dependency for keyboard/tab assertions

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS
- Browser: verified manually via Laravel Herd at `/editor`
- PHP Version: 8.4
- Project Version: visual-editor 1.0.0-spike (add/phase-one)

**Tests Performed:**
1. `npx vitest run` — 166 tests across 21 files, all passing (11 new tests covering DnD wiring and dispatch)
2. `./vendor/bin/pest` — 7 PHP tests, all passing
3. Manual verification on `/editor` that pointer drag reorders blocks, block click-to-select still works, screen reader instructions render, and there are no console errors/warnings

## Accessibility Tests Run

- [x] Keyboard navigation tested — Tab reaches the drag handle; Space picks up; arrows move; Space drops; Escape cancels
- [x] Screen reader tested — custom announcements (`Picked up…`, `was moved over…`, `was dropped…`, cancel message) + persistent instructions exposed via `accessibility.screenReaderInstructions`
- [x] ARIA labels checked — each handle has `aria-label="Drag block <name>"`, and dnd-kit's `aria-roledescription="draggable"` + `aria-describedby` come through via the spread `attributes`
- [x] Color contrast verified — focus-visible outline uses the existing `#0a84ff` selection accent against the white canvas

**Details:**

Keyboard path was verified manually in the browser (jsdom cannot drive dnd-kit sensors reliably — no layout, so both pointer and keyboard sensors fail to compute drop targets). Vitest coverage for the dispatch contract uses a mocked `DndContext` that captures BlockList's `onDragStart` / `onDragEnd` / `onDragCancel` handlers and invokes them directly with pointer- and keyboard-shaped events, then asserts `moveBlock` is called with the correct indices. Integration tests against the real dnd-kit still cover sensor registration, handle accessibility, click-through selection, and the screen-reader instructions live region.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:**

- `resources/js/visual-editor/editor/components/__tests__/BlockListDnd.test.tsx` — real dnd-kit integration wiring: accessible handles (5 tests), sensor registration smoke, click-to-select survives DndContext, live region + screen reader instructions, keyboard focus reaches handle
- `resources/js/visual-editor/editor/components/__tests__/BlockListDndDispatch.test.tsx` — mocks `DndContext` to drive dispatch (6 tests): pointer drop indices, keyboard drop indices, self-drop no-op, outside-droppable no-op, drag start/cancel side effects
- Existing `BlockWrapper` / `BlockList` suites still pass against the updated components

## Documentation

- [x] Inline code documentation added — comment in the dispatch test explains why dnd-kit sensors cannot be driven through jsdom

**Documentation details:**

No user-facing docs yet; this slots into the existing Phase 1 editor package.

## Screenshots

N/A — behavior is interaction-based; verified in-browser on `/editor`.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [x] Accessibility tests completed
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added drag-and-drop functionality to reorder blocks in the visual editor with keyboard navigation support and enhanced visual feedback during dragging

* **Tests**
  * Added comprehensive test coverage for drag-and-drop behavior, accessibility features, and block selection

* **Chores**
  * Added testing dependency to support enhanced testing capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->