### PR TITLE
feat: REST API for posts GET/PUT and blocks GET (Phase 1.12)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,11 @@
   },
   "require-dev": {
     "pestphp/pest": "^3.8",
-    "pestphp/pest-plugin-laravel": "^3.1"
+    "pestphp/pest-plugin-laravel": "^3.1",
+    "orchestra/testbench": "^10.2"
+  },
+  "scripts": {
+    "test": "./vendor/bin/pest"
   },
   "config": {
     "allow-plugins": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f670570b29719f731f2a21a20902683b",
+    "content-hash": "e563946a0b19dfd7885beffa66ce3a6e",
     "packages": [
         {
             "name": "artisanpack-ui/core",
@@ -5977,6 +5977,83 @@
             "time": "2025-06-23T06:07:21+00:00"
         },
         {
+            "name": "composer/semver",
+            "version": "3.4.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/semver.git",
+                "reference": "198166618906cb2de69b95d7d47e5fa8aa1b2b95"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/semver/zipball/198166618906cb2de69b95d7d47e5fa8aa1b2b95",
+                "reference": "198166618906cb2de69b95d7d47e5fa8aa1b2b95",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.11",
+                "symfony/phpunit-bridge": "^3 || ^7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Semver\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nils Adermann",
+                    "email": "naderman@naderman.de",
+                    "homepage": "http://www.naderman.de"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                },
+                {
+                    "name": "Rob Bast",
+                    "email": "rob.bast@gmail.com",
+                    "homepage": "http://robbast.nl"
+                }
+            ],
+            "description": "Semver library that offers utilities, version constraint parsing and validation.",
+            "keywords": [
+                "semantic",
+                "semver",
+                "validation",
+                "versioning"
+            ],
+            "support": {
+                "irc": "ircs://irc.libera.chat:6697/composer",
+                "issues": "https://github.com/composer/semver/issues",
+                "source": "https://github.com/composer/semver/tree/3.4.4"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-08-20T19:15:30+00:00"
+        },
+        {
             "name": "doctrine/deprecations",
             "version": "1.1.5",
             "source": {
@@ -6023,6 +6100,69 @@
                 "source": "https://github.com/doctrine/deprecations/tree/1.1.5"
             },
             "time": "2025-04-07T20:06:18+00:00"
+        },
+        {
+            "name": "fakerphp/faker",
+            "version": "v1.24.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/FakerPHP/Faker.git",
+                "reference": "e0ee18eb1e6dc3cda3ce9fd97e5a0689a88a64b5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/FakerPHP/Faker/zipball/e0ee18eb1e6dc3cda3ce9fd97e5a0689a88a64b5",
+                "reference": "e0ee18eb1e6dc3cda3ce9fd97e5a0689a88a64b5",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0",
+                "psr/container": "^1.0 || ^2.0",
+                "symfony/deprecation-contracts": "^2.2 || ^3.0"
+            },
+            "conflict": {
+                "fzaninotto/faker": "*"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.4.1",
+                "doctrine/persistence": "^1.3 || ^2.0",
+                "ext-intl": "*",
+                "phpunit/phpunit": "^9.5.26",
+                "symfony/phpunit-bridge": "^5.4.16"
+            },
+            "suggest": {
+                "doctrine/orm": "Required to use Faker\\ORM\\Doctrine",
+                "ext-curl": "Required by Faker\\Provider\\Image to download images.",
+                "ext-dom": "Required by Faker\\Provider\\HtmlLorem for generating random HTML.",
+                "ext-iconv": "Required by Faker\\Provider\\ru_RU\\Text::realText() for generating real Russian text.",
+                "ext-mbstring": "Required for multibyte Unicode string functionality."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Faker\\": "src/Faker/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "François Zaninotto"
+                }
+            ],
+            "description": "Faker is a PHP library that generates fake data for you.",
+            "keywords": [
+                "data",
+                "faker",
+                "fixtures"
+            ],
+            "support": {
+                "issues": "https://github.com/FakerPHP/Faker/issues",
+                "source": "https://github.com/FakerPHP/Faker/tree/v1.24.1"
+            },
+            "time": "2024-11-21T13:46:39+00:00"
         },
         {
             "name": "fidry/cpu-core-counter",
@@ -6157,6 +6297,57 @@
             "time": "2025-08-08T12:00:00+00:00"
         },
         {
+            "name": "hamcrest/hamcrest-php",
+            "version": "v2.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/hamcrest/hamcrest-php.git",
+                "reference": "f8b1c0173b22fa6ec77a81fe63e5b01eba7e6487"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/hamcrest/hamcrest-php/zipball/f8b1c0173b22fa6ec77a81fe63e5b01eba7e6487",
+                "reference": "f8b1c0173b22fa6ec77a81fe63e5b01eba7e6487",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0"
+            },
+            "replace": {
+                "cordoval/hamcrest-php": "*",
+                "davedevelopment/hamcrest-php": "*",
+                "kodova/hamcrest-php": "*"
+            },
+            "require-dev": {
+                "phpunit/php-file-iterator": "^1.4 || ^2.0 || ^3.0",
+                "phpunit/phpunit": "^4.8.36 || ^5.7 || ^6.5 || ^7.0 || ^8.0 || ^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "hamcrest"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "This is the PHP port of Hamcrest Matchers",
+            "keywords": [
+                "test"
+            ],
+            "support": {
+                "issues": "https://github.com/hamcrest/hamcrest-php/issues",
+                "source": "https://github.com/hamcrest/hamcrest-php/tree/v2.1.1"
+            },
+            "time": "2025-04-30T06:54:44+00:00"
+        },
+        {
             "name": "jean85/pretty-package-versions",
             "version": "2.1.1",
             "source": {
@@ -6215,6 +6406,235 @@
                 "source": "https://github.com/Jean85/pretty-package-versions/tree/2.1.1"
             },
             "time": "2025-03-19T14:43:43+00:00"
+        },
+        {
+            "name": "laravel/pail",
+            "version": "v1.2.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/pail.git",
+                "reference": "aa71a01c309e7f66bc2ec4fb1a59291b82eb4abf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/pail/zipball/aa71a01c309e7f66bc2ec4fb1a59291b82eb4abf",
+                "reference": "aa71a01c309e7f66bc2ec4fb1a59291b82eb4abf",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "illuminate/console": "^10.24|^11.0|^12.0|^13.0",
+                "illuminate/contracts": "^10.24|^11.0|^12.0|^13.0",
+                "illuminate/log": "^10.24|^11.0|^12.0|^13.0",
+                "illuminate/process": "^10.24|^11.0|^12.0|^13.0",
+                "illuminate/support": "^10.24|^11.0|^12.0|^13.0",
+                "nunomaduro/termwind": "^1.15|^2.0",
+                "php": "^8.2",
+                "symfony/console": "^6.0|^7.0|^8.0"
+            },
+            "require-dev": {
+                "laravel/framework": "^10.24|^11.0|^12.0|^13.0",
+                "laravel/pint": "^1.13",
+                "orchestra/testbench-core": "^8.13|^9.17|^10.8|^11.0",
+                "pestphp/pest": "^2.20|^3.0|^4.0",
+                "pestphp/pest-plugin-type-coverage": "^2.3|^3.0|^4.0",
+                "phpstan/phpstan": "^1.12.27",
+                "symfony/var-dumper": "^6.3|^7.0|^8.0",
+                "symfony/yaml": "^6.3|^7.0|^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Laravel\\Pail\\PailServiceProvider"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-main": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\Pail\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                },
+                {
+                    "name": "Nuno Maduro",
+                    "email": "enunomaduro@gmail.com"
+                }
+            ],
+            "description": "Easily delve into your Laravel application's log files directly from the command line.",
+            "homepage": "https://github.com/laravel/pail",
+            "keywords": [
+                "dev",
+                "laravel",
+                "logs",
+                "php",
+                "tail"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/pail/issues",
+                "source": "https://github.com/laravel/pail"
+            },
+            "time": "2026-02-09T13:44:54+00:00"
+        },
+        {
+            "name": "laravel/tinker",
+            "version": "v2.11.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/tinker.git",
+                "reference": "c9f80cc835649b5c1842898fb043f8cc098dd741"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/tinker/zipball/c9f80cc835649b5c1842898fb043f8cc098dd741",
+                "reference": "c9f80cc835649b5c1842898fb043f8cc098dd741",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/console": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
+                "illuminate/contracts": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
+                "illuminate/support": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
+                "php": "^7.2.5|^8.0",
+                "psy/psysh": "^0.11.1|^0.12.0",
+                "symfony/var-dumper": "^4.3.4|^5.0|^6.0|^7.0|^8.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "~1.3.3|^1.4.2",
+                "phpstan/phpstan": "^1.10",
+                "phpunit/phpunit": "^8.5.8|^9.3.3|^10.0"
+            },
+            "suggest": {
+                "illuminate/database": "The Illuminate Database package (^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0)."
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Laravel\\Tinker\\TinkerServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\Tinker\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "Powerful REPL for the Laravel framework.",
+            "keywords": [
+                "REPL",
+                "Tinker",
+                "laravel",
+                "psysh"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/tinker/issues",
+                "source": "https://github.com/laravel/tinker/tree/v2.11.1"
+            },
+            "time": "2026-02-06T14:12:35+00:00"
+        },
+        {
+            "name": "mockery/mockery",
+            "version": "1.6.12",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mockery/mockery.git",
+                "reference": "1f4efdd7d3beafe9807b08156dfcb176d18f1699"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mockery/mockery/zipball/1f4efdd7d3beafe9807b08156dfcb176d18f1699",
+                "reference": "1f4efdd7d3beafe9807b08156dfcb176d18f1699",
+                "shasum": ""
+            },
+            "require": {
+                "hamcrest/hamcrest-php": "^2.0.1",
+                "lib-pcre": ">=7.0",
+                "php": ">=7.3"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.5 || ^9.6.17",
+                "symplify/easy-coding-standard": "^12.1.14"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "library/helpers.php",
+                    "library/Mockery.php"
+                ],
+                "psr-4": {
+                    "Mockery\\": "library/Mockery"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Pádraic Brady",
+                    "email": "padraic.brady@gmail.com",
+                    "homepage": "https://github.com/padraic",
+                    "role": "Author"
+                },
+                {
+                    "name": "Dave Marshall",
+                    "email": "dave.marshall@atstsolutions.co.uk",
+                    "homepage": "https://davedevelopment.co.uk",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Nathanael Esayeas",
+                    "email": "nathanael.esayeas@protonmail.com",
+                    "homepage": "https://github.com/ghostwriter",
+                    "role": "Lead Developer"
+                }
+            ],
+            "description": "Mockery is a simple yet flexible PHP mock object framework",
+            "homepage": "https://github.com/mockery/mockery",
+            "keywords": [
+                "BDD",
+                "TDD",
+                "library",
+                "mock",
+                "mock objects",
+                "mockery",
+                "stub",
+                "test",
+                "test double",
+                "testing"
+            ],
+            "support": {
+                "docs": "https://docs.mockery.io/",
+                "issues": "https://github.com/mockery/mockery/issues",
+                "rss": "https://github.com/mockery/mockery/releases.atom",
+                "security": "https://github.com/mockery/mockery/security/advisories",
+                "source": "https://github.com/mockery/mockery"
+            },
+            "time": "2024-05-16T03:13:13+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -6432,6 +6852,421 @@
                 }
             ],
             "time": "2025-06-25T02:12:12+00:00"
+        },
+        {
+            "name": "orchestra/canvas",
+            "version": "v10.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/orchestral/canvas.git",
+                "reference": "94f732350e5c6d7136ff7b0fd05a90079dd77deb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/orchestral/canvas/zipball/94f732350e5c6d7136ff7b0fd05a90079dd77deb",
+                "reference": "94f732350e5c6d7136ff7b0fd05a90079dd77deb",
+                "shasum": ""
+            },
+            "require": {
+                "composer-runtime-api": "^2.2",
+                "composer/semver": "^3.0",
+                "illuminate/console": "^12.3.0",
+                "illuminate/database": "^12.3.0",
+                "illuminate/filesystem": "^12.3.0",
+                "illuminate/support": "^12.3.0",
+                "orchestra/canvas-core": "^10.0.1",
+                "orchestra/sidekick": "^1.1.0",
+                "orchestra/testbench-core": "^10.1.0",
+                "php": "^8.2",
+                "symfony/polyfill-php83": "^1.31",
+                "symfony/yaml": "^7.2.0"
+            },
+            "require-dev": {
+                "laravel/framework": "^12.3.0",
+                "laravel/pint": "^1.21",
+                "mockery/mockery": "^1.6.12",
+                "phpstan/phpstan": "^2.1.8",
+                "phpunit/phpunit": "^11.5.13",
+                "spatie/laravel-ray": "^1.40.1"
+            },
+            "bin": [
+                "canvas"
+            ],
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Orchestra\\Canvas\\LaravelServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Orchestra\\Canvas\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                },
+                {
+                    "name": "Mior Muhammad Zaki",
+                    "email": "crynobone@gmail.com"
+                }
+            ],
+            "description": "Code Generators for Laravel Applications and Packages",
+            "support": {
+                "issues": "https://github.com/orchestral/canvas/issues",
+                "source": "https://github.com/orchestral/canvas/tree/v10.0.2"
+            },
+            "time": "2025-04-05T16:01:25+00:00"
+        },
+        {
+            "name": "orchestra/canvas-core",
+            "version": "v10.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/orchestral/canvas-core.git",
+                "reference": "6b5a2344ac94c6072bab2a20eec1ee9f6df0f634"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/orchestral/canvas-core/zipball/6b5a2344ac94c6072bab2a20eec1ee9f6df0f634",
+                "reference": "6b5a2344ac94c6072bab2a20eec1ee9f6df0f634",
+                "shasum": ""
+            },
+            "require": {
+                "composer-runtime-api": "^2.2",
+                "composer/semver": "^3.0",
+                "illuminate/console": "^12.8.0",
+                "illuminate/support": "^12.8.0",
+                "orchestra/sidekick": "^1.2.0",
+                "php": "^8.2",
+                "symfony/polyfill-php83": "^1.32"
+            },
+            "require-dev": {
+                "laravel/framework": "^12.0",
+                "laravel/pint": "^1.24",
+                "mockery/mockery": "^1.6.10",
+                "orchestra/testbench-core": "^10.6.1",
+                "phpstan/phpstan": "^2.1.14",
+                "phpunit/phpunit": "^11.5.12|^12.0.1",
+                "spatie/laravel-ray": "^1.40.2",
+                "symfony/yaml": "^7.2"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Orchestra\\Canvas\\Core\\LaravelServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Orchestra\\Canvas\\Core\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                },
+                {
+                    "name": "Mior Muhammad Zaki",
+                    "email": "crynobone@gmail.com"
+                }
+            ],
+            "description": "Code Generators Builder for Laravel Applications and Packages",
+            "support": {
+                "issues": "https://github.com/orchestral/canvas/issues",
+                "source": "https://github.com/orchestral/canvas-core/tree/v10.1.1"
+            },
+            "time": "2025-11-13T02:49:23+00:00"
+        },
+        {
+            "name": "orchestra/sidekick",
+            "version": "v1.2.20",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/orchestral/sidekick.git",
+                "reference": "267a71b56cb2fe1a634d69fc99889c671b77ff43"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/orchestral/sidekick/zipball/267a71b56cb2fe1a634d69fc99889c671b77ff43",
+                "reference": "267a71b56cb2fe1a634d69fc99889c671b77ff43",
+                "shasum": ""
+            },
+            "require": {
+                "composer-runtime-api": "^2.2",
+                "composer/semver": "^3.0",
+                "php": "^8.1",
+                "symfony/polyfill-php83": "^1.32"
+            },
+            "require-dev": {
+                "fakerphp/faker": "^1.21",
+                "laravel/framework": "^10.48.29|^11.44.7|^12.1.1|^13.0",
+                "laravel/pint": "^1.4",
+                "mockery/mockery": "^1.5.1",
+                "orchestra/testbench-core": "^8.37.0|^9.14.0|^10.2.0|^11.0",
+                "phpstan/phpstan": "^2.1.14",
+                "phpunit/phpunit": "^10.0|^11.0|^12.0",
+                "symfony/process": "^6.0|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/Eloquent/functions.php",
+                    "src/Filesystem/functions.php",
+                    "src/Http/functions.php",
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Orchestra\\Sidekick\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mior Muhammad Zaki",
+                    "email": "crynobone@gmail.com"
+                }
+            ],
+            "description": "Packages Toolkit Utilities and Helpers for Laravel",
+            "support": {
+                "issues": "https://github.com/orchestral/sidekick/issues",
+                "source": "https://github.com/orchestral/sidekick/tree/v1.2.20"
+            },
+            "time": "2026-01-12T11:09:33+00:00"
+        },
+        {
+            "name": "orchestra/testbench",
+            "version": "v10.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/orchestral/testbench.git",
+                "reference": "caf340bcc42dccd74f332d0cb1f2e017b6b8108b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/orchestral/testbench/zipball/caf340bcc42dccd74f332d0cb1f2e017b6b8108b",
+                "reference": "caf340bcc42dccd74f332d0cb1f2e017b6b8108b",
+                "shasum": ""
+            },
+            "require": {
+                "composer-runtime-api": "^2.2",
+                "fakerphp/faker": "^1.23",
+                "laravel/framework": "^12.28.0",
+                "mockery/mockery": "^1.6.10",
+                "orchestra/testbench-core": "^10.7.0",
+                "orchestra/workbench": "^10.0.6",
+                "php": "^8.2",
+                "phpunit/phpunit": "^11.5.3|^12.0.1",
+                "symfony/process": "^7.2",
+                "symfony/yaml": "^7.2",
+                "vlucas/phpdotenv": "^5.6.1"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mior Muhammad Zaki",
+                    "email": "crynobone@gmail.com",
+                    "homepage": "https://github.com/crynobone"
+                }
+            ],
+            "description": "Laravel Testing Helper for Packages Development",
+            "homepage": "https://packages.tools/testbench/",
+            "keywords": [
+                "BDD",
+                "TDD",
+                "dev",
+                "laravel",
+                "laravel-packages",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/orchestral/testbench/issues",
+                "source": "https://github.com/orchestral/testbench/tree/v10.7.0"
+            },
+            "time": "2025-10-16T11:43:54+00:00"
+        },
+        {
+            "name": "orchestra/testbench-core",
+            "version": "v10.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/orchestral/testbench-core.git",
+                "reference": "123ad189fcb1e49f95d87c3bc301b059e40edf05"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/orchestral/testbench-core/zipball/123ad189fcb1e49f95d87c3bc301b059e40edf05",
+                "reference": "123ad189fcb1e49f95d87c3bc301b059e40edf05",
+                "shasum": ""
+            },
+            "require": {
+                "composer-runtime-api": "^2.2",
+                "orchestra/sidekick": "~1.1.20|~1.2.17",
+                "php": "^8.2",
+                "symfony/deprecation-contracts": "^2.5|^3.0",
+                "symfony/polyfill-php83": "^1.32"
+            },
+            "conflict": {
+                "brianium/paratest": "<7.3.0|>=8.0.0",
+                "laravel/framework": "<12.28.0|>=13.0.0",
+                "laravel/serializable-closure": "<1.3.0|>=2.0.0 <2.0.3|>=3.0.0",
+                "nunomaduro/collision": "<8.0.0|>=9.0.0",
+                "phpunit/phpunit": "<10.5.35|>=11.0.0 <11.5.3|12.0.0|>=12.5.0"
+            },
+            "require-dev": {
+                "fakerphp/faker": "^1.24",
+                "laravel/framework": "^12.28.0",
+                "laravel/pint": "^1.24",
+                "laravel/serializable-closure": "^1.3|^2.0.4",
+                "mockery/mockery": "^1.6.10",
+                "phpstan/phpstan": "^2.1.19",
+                "phpunit/phpunit": "^10.5.35|^11.5.3|^12.0.1",
+                "spatie/laravel-ray": "^1.40.2",
+                "symfony/process": "^7.2.0",
+                "symfony/yaml": "^7.2.0",
+                "vlucas/phpdotenv": "^5.6.1"
+            },
+            "suggest": {
+                "brianium/paratest": "Allow using parallel testing (^7.3).",
+                "ext-pcntl": "Required to use all features of the console signal trapping.",
+                "fakerphp/faker": "Allow using Faker for testing (^1.23).",
+                "laravel/framework": "Required for testing (^12.28.0).",
+                "mockery/mockery": "Allow using Mockery for testing (^1.6).",
+                "nunomaduro/collision": "Allow using Laravel style tests output and parallel testing (^8.0).",
+                "orchestra/testbench-dusk": "Allow using Laravel Dusk for testing (^10.0).",
+                "phpunit/phpunit": "Allow using PHPUnit for testing (^10.5.35|^11.5.3|^12.0.1).",
+                "symfony/process": "Required to use Orchestra\\Testbench\\remote function (^7.2).",
+                "symfony/yaml": "Required for Testbench CLI (^7.2).",
+                "vlucas/phpdotenv": "Required for Testbench CLI (^5.6.1)."
+            },
+            "bin": [
+                "testbench"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Orchestra\\Testbench\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mior Muhammad Zaki",
+                    "email": "crynobone@gmail.com",
+                    "homepage": "https://github.com/crynobone"
+                }
+            ],
+            "description": "Testing Helper for Laravel Development",
+            "homepage": "https://packages.tools/testbench",
+            "keywords": [
+                "BDD",
+                "TDD",
+                "dev",
+                "laravel",
+                "laravel-packages",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/orchestral/testbench/issues",
+                "source": "https://github.com/orchestral/testbench-core"
+            },
+            "time": "2025-10-14T12:16:46+00:00"
+        },
+        {
+            "name": "orchestra/workbench",
+            "version": "v10.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/orchestral/workbench.git",
+                "reference": "4e8a5a68200971ddb9ce4abf26488838bf5c0812"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/orchestral/workbench/zipball/4e8a5a68200971ddb9ce4abf26488838bf5c0812",
+                "reference": "4e8a5a68200971ddb9ce4abf26488838bf5c0812",
+                "shasum": ""
+            },
+            "require": {
+                "composer-runtime-api": "^2.2",
+                "fakerphp/faker": "^1.23",
+                "laravel/framework": "^12.1.1",
+                "laravel/pail": "^1.2.2",
+                "laravel/tinker": "^2.10.1",
+                "nunomaduro/collision": "^8.6",
+                "orchestra/canvas": "^10.0.2",
+                "orchestra/sidekick": "^1.1.0",
+                "orchestra/testbench-core": "^10.2.1",
+                "php": "^8.2",
+                "symfony/polyfill-php83": "^1.31",
+                "symfony/process": "^7.2",
+                "symfony/yaml": "^7.2"
+            },
+            "require-dev": {
+                "laravel/pint": "^1.21.2",
+                "mockery/mockery": "^1.6.12",
+                "phpstan/phpstan": "^2.1.8",
+                "phpunit/phpunit": "^11.5.3|^12.0.1",
+                "spatie/laravel-ray": "^1.40.1"
+            },
+            "suggest": {
+                "ext-pcntl": "Required to use all features of the console signal trapping."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Orchestra\\Workbench\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mior Muhammad Zaki",
+                    "email": "crynobone@gmail.com"
+                }
+            ],
+            "description": "Workbench Companion for Laravel Packages Development",
+            "keywords": [
+                "dev",
+                "laravel",
+                "laravel-packages",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/orchestral/workbench/issues",
+                "source": "https://github.com/orchestral/workbench/tree/v10.0.6"
+            },
+            "time": "2025-04-13T01:07:44+00:00"
         },
         {
             "name": "pestphp/pest",
@@ -7616,6 +8451,85 @@
             "time": "2025-08-16T05:19:02+00:00"
         },
         {
+            "name": "psy/psysh",
+            "version": "v0.12.22",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/bobthecow/psysh.git",
+                "reference": "3be75d5b9244936dd4ac62ade2bfb004d13acf0f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/3be75d5b9244936dd4ac62ade2bfb004d13acf0f",
+                "reference": "3be75d5b9244936dd4ac62ade2bfb004d13acf0f",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "nikic/php-parser": "^5.0 || ^4.0",
+                "php": "^8.0 || ^7.4",
+                "symfony/console": "^8.0 || ^7.0 || ^6.0 || ^5.0 || ^4.0 || ^3.4",
+                "symfony/var-dumper": "^8.0 || ^7.0 || ^6.0 || ^5.0 || ^4.0 || ^3.4"
+            },
+            "conflict": {
+                "symfony/console": "4.4.37 || 5.3.14 || 5.3.15 || 5.4.3 || 5.4.4 || 6.0.3 || 6.0.4"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.2",
+                "composer/class-map-generator": "^1.6"
+            },
+            "suggest": {
+                "composer/class-map-generator": "Improved tab completion performance with better class discovery.",
+                "ext-pcntl": "Enabling the PCNTL extension makes PsySH a lot happier :)",
+                "ext-posix": "If you have PCNTL, you'll want the POSIX extension as well."
+            },
+            "bin": [
+                "bin/psysh"
+            ],
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": false,
+                    "forward-command": false
+                },
+                "branch-alias": {
+                    "dev-main": "0.12.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Psy\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Justin Hileman",
+                    "email": "justin@justinhileman.info"
+                }
+            ],
+            "description": "An interactive shell for modern PHP.",
+            "homepage": "https://psysh.org",
+            "keywords": [
+                "REPL",
+                "console",
+                "interactive",
+                "shell"
+            ],
+            "support": {
+                "issues": "https://github.com/bobthecow/psysh/issues",
+                "source": "https://github.com/bobthecow/psysh/tree/v0.12.22"
+            },
+            "time": "2026-03-22T23:03:24+00:00"
+        },
+        {
             "name": "sebastian/cli-parser",
             "version": "3.0.2",
             "source": {
@@ -8652,6 +9566,82 @@
                 }
             ],
             "time": "2024-10-20T05:08:20+00:00"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v7.4.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "c58fdf7b3d6c2995368264c49e4e8b05bcff2883"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/c58fdf7b3d6c2995368264c49e4e8b05bcff2883",
+                "reference": "c58fdf7b3d6c2995368264c49e4e8b05bcff2883",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "symfony/console": "<6.4"
+            },
+            "require-dev": {
+                "symfony/console": "^6.4|^7.0|^8.0"
+            },
+            "bin": [
+                "Resources/bin/yaml-lint"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Loads and dumps YAML files",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/yaml/tree/v7.4.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-24T13:12:05+00:00"
         },
         {
             "name": "ta-tikoma/phpunit-architecture-test",

--- a/database/migrations/2026_04_14_000000_create_ve_contents_table.php
+++ b/database/migrations/2026_04_14_000000_create_ve_contents_table.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * Create ve_contents table migration.
+ *
+ * Stores block tree JSON for visual editor posts. Phase 1 minimum viable schema;
+ * additional columns (revisions, templates, SEO) land in later phases.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+	public function up(): void
+	{
+		Schema::create( 've_contents', function ( Blueprint $table ) {
+			$table->id();
+			$table->unsignedBigInteger( 'author_id' )->nullable()->index();
+			$table->string( 'title' )->default( '' );
+			$table->json( 'blocks' )->nullable();
+			$table->timestamps();
+		} );
+	}
+
+	public function down(): void
+	{
+		Schema::dropIfExists( 've_contents' );
+	}
+};

--- a/database/migrations/testing/2026_04_14_000000_create_users_table.php
+++ b/database/migrations/testing/2026_04_14_000000_create_users_table.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * Create users table migration (testing only).
+ *
+ * This migration is for testing purposes only. Consuming applications
+ * are expected to provide their own users table.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+	public function up(): void
+	{
+		Schema::create( 'users', function ( Blueprint $table ) {
+			$table->id();
+			$table->string( 'name' );
+			$table->string( 'email' )->unique();
+			$table->timestamp( 'email_verified_at' )->nullable();
+			$table->string( 'password' );
+			$table->rememberToken();
+			$table->timestamps();
+		} );
+	}
+
+	public function down(): void
+	{
+		Schema::dropIfExists( 'users' );
+	}
+};

--- a/docs/phase-1-rest-api.md
+++ b/docs/phase-1-rest-api.md
@@ -1,6 +1,6 @@
 # Phase 1 — REST API
 
-Three JSON endpoints feed the React editor during Phase 1. All routes sit behind the `api` + `auth` middleware stack and are grouped under the `/visual-editor/api` prefix.
+Three JSON endpoints feed the React editor during Phase 1. All routes are grouped under the `/visual-editor/api` prefix. By default they sit behind the `api` + `auth` middleware stack; the stack can be overridden via `config('artisanpack.visual-editor.api.middleware')`.
 
 | Method | URI                               | Name                            | Purpose                                          |
 | ------ | --------------------------------- | ------------------------------- | ------------------------------------------------ |
@@ -8,7 +8,7 @@ Three JSON endpoints feed the React editor during Phase 1. All routes sit behind
 | PUT    | `/visual-editor/api/posts/{post}` | `visual-editor.api.posts.update`| Persist a new block tree for a post              |
 | GET    | `/visual-editor/api/blocks`       | `visual-editor.api.blocks.index`| Return the registered block type definitions    |
 
-The middleware stack is overridable via `config('artisanpack.visual-editor.api.middleware')` if a consuming app needs Sanctum, a different guard, etc.
+Override the middleware stack when a consuming app needs Sanctum, a different guard, etc.
 
 ## Authorization
 

--- a/docs/phase-1-rest-api.md
+++ b/docs/phase-1-rest-api.md
@@ -1,0 +1,105 @@
+# Phase 1 — REST API
+
+Three JSON endpoints feed the React editor during Phase 1. All routes sit behind the `api` + `auth` middleware stack and are grouped under the `/visual-editor/api` prefix.
+
+| Method | URI                               | Name                            | Purpose                                          |
+| ------ | --------------------------------- | ------------------------------- | ------------------------------------------------ |
+| GET    | `/visual-editor/api/posts/{post}` | `visual-editor.api.posts.show`  | Return the block tree JSON for a post            |
+| PUT    | `/visual-editor/api/posts/{post}` | `visual-editor.api.posts.update`| Persist a new block tree for a post              |
+| GET    | `/visual-editor/api/blocks`       | `visual-editor.api.blocks.index`| Return the registered block type definitions    |
+
+The middleware stack is overridable via `config('artisanpack.visual-editor.api.middleware')` if a consuming app needs Sanctum, a different guard, etc.
+
+## Authorization
+
+`VisualEditorPostPolicy` backs both post endpoints. Abilities:
+
+- `view` — requires an authenticated user; when `artisanpack.visual-editor.authorization.restrict_by_owner` is `true`, the authenticated user must match `ve_contents.author_id`.
+- `update` — same rules as `view`.
+
+Unauthenticated requests receive `401`. Authenticated requests without the needed ability receive `403`.
+
+## Block tree shape
+
+All blocks are objects of the following recursive shape:
+
+```json
+{
+  "clientId": "string (required, unique within the tree)",
+  "name": "string (required, e.g. \"core/paragraph\")",
+  "attributes": { },
+  "innerBlocks": []
+}
+```
+
+`UpdatePostBlocksRequest` runs the custom `BlockTreeRule` against the `blocks` key. The rule walks the tree and fails on the first block that is missing one of the four required keys or has the wrong type.
+
+## GET `/visual-editor/api/posts/{post}`
+
+Successful response (`200`):
+
+```json
+{
+  "id": 1,
+  "title": "Test Post",
+  "blocks": [
+    {
+      "clientId": "abc-123",
+      "name": "core/paragraph",
+      "attributes": { "content": "Hello" },
+      "innerBlocks": []
+    }
+  ],
+  "updated_at": "2026-04-14T12:34:56+00:00"
+}
+```
+
+## PUT `/visual-editor/api/posts/{post}`
+
+Request body:
+
+```json
+{
+  "blocks": [
+    {
+      "clientId": "heading-1",
+      "name": "core/heading",
+      "attributes": { "content": "Updated", "level": 2 },
+      "innerBlocks": []
+    }
+  ]
+}
+```
+
+Responses:
+
+- `200` — returns the same JSON shape as the `show` endpoint with the persisted tree.
+- `422` — `blocks` is missing, not an array, or fails the recursive shape check. The error bag reports the first invalid path in dot notation (for example `blocks.1.innerBlocks.0.attributes`).
+
+## GET `/visual-editor/api/blocks`
+
+Returns the list of registered block types from `BlockTypeRegistry`. Phase 1 ships with `core/paragraph` and `core/heading`; downstream packages extend the registry through the service container.
+
+```json
+{
+  "data": [
+    {
+      "name": "core/paragraph",
+      "title": "Paragraph",
+      "category": "text",
+      "attributes": {
+        "content": { "type": "string", "default": "" }
+      }
+    },
+    {
+      "name": "core/heading",
+      "title": "Heading",
+      "category": "text",
+      "attributes": {
+        "content": { "type": "string", "default": "" },
+        "level":   { "type": "integer", "default": 2 }
+      }
+    }
+  ]
+}
+```

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * Visual Editor API routes.
+ *
+ * JSON endpoints consumed by the React editor. Loaded by the service provider
+ * under the `/visual-editor/api` prefix with the `api` + `auth` middleware stack.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Http\Controllers\VisualEditorBlocksController;
+use ArtisanPackUI\VisualEditor\Http\Controllers\VisualEditorPostsController;
+use Illuminate\Support\Facades\Route;
+
+Route::get( 'posts/{post}', [VisualEditorPostsController::class, 'show'] )
+	->name( 'visual-editor.api.posts.show' );
+
+Route::put( 'posts/{post}', [VisualEditorPostsController::class, 'update'] )
+	->name( 'visual-editor.api.posts.update' );
+
+Route::get( 'blocks', [VisualEditorBlocksController::class, 'index'] )
+	->name( 'visual-editor.api.blocks.index' );

--- a/src/Http/Controllers/VisualEditorBlocksController.php
+++ b/src/Http/Controllers/VisualEditorBlocksController.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * VisualEditorBlocks controller.
+ *
+ * Serves the registry of available block types for the React editor.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Http\Controllers;
+
+use ArtisanPackUI\VisualEditor\Registries\BlockTypeRegistry;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Routing\Controller;
+
+class VisualEditorBlocksController extends Controller
+{
+	public function __construct( protected BlockTypeRegistry $registry )
+	{
+	}
+
+	/**
+	 * Returns the list of registered block types.
+	 *
+	 * @since 1.0.0
+	 */
+	public function index(): JsonResponse
+	{
+		return response()->json( [
+			'data' => $this->registry->all(),
+		] );
+	}
+}

--- a/src/Http/Controllers/VisualEditorPostsController.php
+++ b/src/Http/Controllers/VisualEditorPostsController.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * VisualEditorPosts controller.
+ *
+ * Serves GET/PUT JSON endpoints for the block-tree document backing a post.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Http\Controllers;
+
+use ArtisanPackUI\VisualEditor\Http\Requests\UpdatePostBlocksRequest;
+use ArtisanPackUI\VisualEditor\Models\VisualEditorPost;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Gate;
+
+class VisualEditorPostsController extends Controller
+{
+	/**
+	 * Returns the block tree for the given post.
+	 *
+	 * @since 1.0.0
+	 */
+	public function show( VisualEditorPost $post ): JsonResponse
+	{
+		Gate::authorize( 'view', $post );
+
+		return response()->json( $this->transform( $post ) );
+	}
+
+	/**
+	 * Persists an updated block tree for the given post.
+	 *
+	 * @since 1.0.0
+	 */
+	public function update( UpdatePostBlocksRequest $request, VisualEditorPost $post ): JsonResponse
+	{
+		Gate::authorize( 'update', $post );
+
+		$post->blocks = $request->validated( 'blocks' );
+		$post->save();
+
+		return response()->json( $this->transform( $post ) );
+	}
+
+	/**
+	 * Shapes a post for the JSON response.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<string, mixed>
+	 */
+	protected function transform( VisualEditorPost $post ): array
+	{
+		return [
+			'id'         => $post->id,
+			'title'      => $post->title,
+			'blocks'     => $post->blocks ?? [],
+			'updated_at' => $post->updated_at?->toIso8601String(),
+		];
+	}
+}

--- a/src/Http/Requests/UpdatePostBlocksRequest.php
+++ b/src/Http/Requests/UpdatePostBlocksRequest.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * UpdatePostBlocks form request.
+ *
+ * Validates the block tree payload sent to the PUT posts endpoint.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Http\Requests;
+
+use ArtisanPackUI\VisualEditor\Rules\BlockTreeRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdatePostBlocksRequest extends FormRequest
+{
+	public function authorize(): bool
+	{
+		return true;
+	}
+
+	/**
+	 * @return array<string, array<int, mixed>>
+	 */
+	public function rules(): array
+	{
+		return [
+			'blocks' => ['required', 'array', new BlockTreeRule()],
+		];
+	}
+}

--- a/src/Models/VisualEditorPost.php
+++ b/src/Models/VisualEditorPost.php
@@ -26,12 +26,9 @@ class VisualEditorPost extends Model
 	protected $guarded = [];
 
 	/**
-	 * @inheritDoc
+	 * @var array<string, string>
 	 */
-	protected function casts(): array
-	{
-		return [
-			'blocks' => 'array',
-		];
-	}
+	protected $casts = [
+		'blocks' => 'array',
+	];
 }

--- a/src/Models/VisualEditorPost.php
+++ b/src/Models/VisualEditorPost.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * VisualEditorPost model.
+ *
+ * Represents a single block-tree document stored in ve_contents.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class VisualEditorPost extends Model
+{
+	protected $table = 've_contents';
+
+	protected $guarded = [];
+
+	/**
+	 * @inheritDoc
+	 */
+	protected function casts(): array
+	{
+		return [
+			'blocks' => 'array',
+		];
+	}
+}

--- a/src/Policies/VisualEditorPostPolicy.php
+++ b/src/Policies/VisualEditorPostPolicy.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * VisualEditorPost policy.
+ *
+ * Authorization policy for block-tree post view/update operations.
+ * Default behavior requires an authenticated user and, when ownership
+ * restriction is enabled, matches the author id against the user id.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Policies;
+
+use ArtisanPackUI\VisualEditor\Models\VisualEditorPost;
+use Illuminate\Auth\Access\HandlesAuthorization;
+use Illuminate\Contracts\Auth\Authenticatable;
+
+class VisualEditorPostPolicy
+{
+	use HandlesAuthorization;
+
+	/**
+	 * Determines whether the user can view the post.
+	 *
+	 * @since 1.0.0
+	 */
+	public function view( ?Authenticatable $user, VisualEditorPost $post ): bool
+	{
+		if ( null === $user ) {
+			return false;
+		}
+
+		if ( $this->isOwnershipRestricted() ) {
+			return $this->isOwnerOrAdmin( $user, $post );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Determines whether the user can update the post.
+	 *
+	 * @since 1.0.0
+	 */
+	public function update( ?Authenticatable $user, VisualEditorPost $post ): bool
+	{
+		if ( null === $user ) {
+			return false;
+		}
+
+		if ( $this->isOwnershipRestricted() ) {
+			return $this->isOwnerOrAdmin( $user, $post );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Checks whether ownership-based access control is enabled.
+	 *
+	 * @since 1.0.0
+	 */
+	protected function isOwnershipRestricted(): bool
+	{
+		return (bool) config( 'artisanpack.visual-editor.authorization.restrict_by_owner', false );
+	}
+
+	/**
+	 * Checks whether the user is the post owner.
+	 *
+	 * Posts without an author are accessible to all authenticated users so
+	 * legacy or package-seeded content remains editable.
+	 *
+	 * @since 1.0.0
+	 */
+	protected function isOwnerOrAdmin( Authenticatable $user, VisualEditorPost $post ): bool
+	{
+		if ( null === $post->author_id ) {
+			return true;
+		}
+
+		return (int) $post->author_id === (int) $user->getAuthIdentifier();
+	}
+}

--- a/src/Registries/BlockTypeRegistry.php
+++ b/src/Registries/BlockTypeRegistry.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * BlockType registry.
+ *
+ * In-memory registry describing the block types the editor is aware of.
+ * Packages and applications can extend this via the service container.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Registries;
+
+class BlockTypeRegistry
+{
+	/**
+	 * @var array<string, array<string, mixed>>
+	 */
+	protected array $blocks = [];
+
+	public function __construct()
+	{
+		$this->register( 'core/paragraph', [
+			'title'      => 'Paragraph',
+			'category'   => 'text',
+			'attributes' => [
+				'content' => ['type' => 'string', 'default' => ''],
+			],
+		] );
+
+		$this->register( 'core/heading', [
+			'title'      => 'Heading',
+			'category'   => 'text',
+			'attributes' => [
+				'content' => ['type' => 'string', 'default' => ''],
+				'level'   => ['type' => 'integer', 'default' => 2],
+			],
+		] );
+	}
+
+	/**
+	 * Registers a block type by name.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string                $name        The block name (e.g. `core/paragraph`).
+	 * @param  array<string, mixed>  $definition  Metadata describing the block.
+	 */
+	public function register( string $name, array $definition ): void
+	{
+		$this->blocks[ $name ] = array_merge( ['name' => $name], $definition );
+	}
+
+	/**
+	 * Removes a block type from the registry.
+	 *
+	 * @since 1.0.0
+	 */
+	public function unregister( string $name ): void
+	{
+		unset( $this->blocks[ $name ] );
+	}
+
+	/**
+	 * Returns all registered block types as a list.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	public function all(): array
+	{
+		return array_values( $this->blocks );
+	}
+}

--- a/src/Registries/BlockTypeRegistry.php
+++ b/src/Registries/BlockTypeRegistry.php
@@ -18,8 +18,16 @@ declare( strict_types=1 );
 
 namespace ArtisanPackUI\VisualEditor\Registries;
 
+use InvalidArgumentException;
+
 class BlockTypeRegistry
 {
+	/**
+	 * Canonical block name pattern: `namespace/name` using lowercase
+	 * alphanumerics and hyphens (e.g. `core/paragraph`).
+	 */
+	protected const NAME_PATTERN = '/^[a-z][a-z0-9-]*\/[a-z][a-z0-9-]*$/';
+
 	/**
 	 * @var array<string, array<string, mixed>>
 	 */
@@ -55,7 +63,20 @@ class BlockTypeRegistry
 	 */
 	public function register( string $name, array $definition ): void
 	{
-		$this->blocks[ $name ] = array_merge( ['name' => $name], $definition );
+		$normalized = trim( $name );
+
+		if ( '' === $normalized ) {
+			throw new InvalidArgumentException( 'Block type name cannot be empty.' );
+		}
+
+		if ( 1 !== preg_match( self::NAME_PATTERN, $normalized ) ) {
+			throw new InvalidArgumentException( sprintf(
+				'Block type name "%s" is invalid. Expected format: "namespace/name" using lowercase letters, numbers, and hyphens.',
+				$name
+			) );
+		}
+
+		$this->blocks[ $normalized ] = array_merge( ['name' => $normalized], $definition );
 	}
 
 	/**

--- a/src/Rules/BlockTreeRule.php
+++ b/src/Rules/BlockTreeRule.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * BlockTree validation rule.
+ *
+ * Recursively validates that a value is an array of blocks shaped as
+ * `{ clientId: string, name: string, attributes: object, innerBlocks: Block[] }`.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Rules;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+
+class BlockTreeRule implements ValidationRule
+{
+	public function validate( string $attribute, mixed $value, Closure $fail ): void
+	{
+		if ( ! is_array( $value ) ) {
+			$fail( 'The :attribute must be an array of blocks.' );
+			return;
+		}
+
+		$error = $this->validateBlocks( $value, $attribute );
+
+		if ( null !== $error ) {
+			$fail( $error );
+		}
+	}
+
+	/**
+	 * Validates an array of blocks, returning the first error path encountered.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array<int, mixed>  $blocks  The block array to validate.
+	 * @param  string             $path    Dot-notated path for error reporting.
+	 *
+	 * @return string|null Error message when invalid, null when valid.
+	 */
+	protected function validateBlocks( array $blocks, string $path ): ?string
+	{
+		if ( ! array_is_list( $blocks ) ) {
+			return "The {$path} must be a list of blocks.";
+		}
+
+		foreach ( $blocks as $index => $block ) {
+			$blockPath = "{$path}.{$index}";
+
+			if ( ! is_array( $block ) ) {
+				return "The {$blockPath} must be a block object.";
+			}
+
+			if ( ! isset( $block['clientId'] ) || ! is_string( $block['clientId'] ) || '' === $block['clientId'] ) {
+				return "The {$blockPath}.clientId is required and must be a string.";
+			}
+
+			if ( ! isset( $block['name'] ) || ! is_string( $block['name'] ) || '' === $block['name'] ) {
+				return "The {$blockPath}.name is required and must be a string.";
+			}
+
+			if ( ! array_key_exists( 'attributes', $block ) || ! is_array( $block['attributes'] ) ) {
+				return "The {$blockPath}.attributes is required and must be an object.";
+			}
+
+			if ( ! array_key_exists( 'innerBlocks', $block ) || ! is_array( $block['innerBlocks'] ) ) {
+				return "The {$blockPath}.innerBlocks is required and must be an array.";
+			}
+
+			$childError = $this->validateBlocks( $block['innerBlocks'], "{$blockPath}.innerBlocks" );
+
+			if ( null !== $childError ) {
+				return $childError;
+			}
+		}
+
+		return null;
+	}
+}

--- a/src/Rules/BlockTreeRule.php
+++ b/src/Rules/BlockTreeRule.php
@@ -5,6 +5,8 @@
  *
  * Recursively validates that a value is an array of blocks shaped as
  * `{ clientId: string, name: string, attributes: object, innerBlocks: Block[] }`.
+ * Enforces `clientId` uniqueness within the tree and bounds on depth and total
+ * node count to keep validation cost predictable.
  *
  * @package    ArtisanPack_UI
  * @subpackage VisualEditor
@@ -23,6 +25,16 @@ use Illuminate\Contracts\Validation\ValidationRule;
 
 class BlockTreeRule implements ValidationRule
 {
+	/**
+	 * Maximum allowed depth of the block tree.
+	 */
+	public const MAX_DEPTH = 10;
+
+	/**
+	 * Maximum allowed total block nodes in the tree.
+	 */
+	public const MAX_NODES = 1000;
+
 	public function validate( string $attribute, mixed $value, Closure $fail ): void
 	{
 		if ( ! is_array( $value ) ) {
@@ -30,7 +42,10 @@ class BlockTreeRule implements ValidationRule
 			return;
 		}
 
-		$error = $this->validateBlocks( $value, $attribute );
+		$nodeCount   = 0;
+		$seenClients = [];
+
+		$error = $this->validateBlocks( $value, $attribute, 0, $nodeCount, $seenClients );
 
 		if ( null !== $error ) {
 			$fail( $error );
@@ -42,19 +57,44 @@ class BlockTreeRule implements ValidationRule
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param  array<int, mixed>  $blocks  The block array to validate.
-	 * @param  string             $path    Dot-notated path for error reporting.
+	 * @param  array<int, mixed>   $blocks        The block array to validate.
+	 * @param  string              $path          Dot-notated path for error reporting.
+	 * @param  int                 $currentDepth  Current recursion depth (0 at the root).
+	 * @param  int                 $nodeCount     Running total of nodes visited (by reference).
+	 * @param  array<string, bool> $seenClients   Set of clientIds already encountered (by reference).
 	 *
 	 * @return string|null Error message when invalid, null when valid.
 	 */
-	protected function validateBlocks( array $blocks, string $path ): ?string
-	{
+	protected function validateBlocks(
+		array $blocks,
+		string $path,
+		int $currentDepth,
+		int &$nodeCount,
+		array &$seenClients
+	): ?string {
+		if ( $currentDepth >= self::MAX_DEPTH ) {
+			return sprintf(
+				'The %s exceeds the maximum block tree depth of %d.',
+				$path,
+				self::MAX_DEPTH
+			);
+		}
+
 		if ( ! array_is_list( $blocks ) ) {
 			return "The {$path} must be a list of blocks.";
 		}
 
 		foreach ( $blocks as $index => $block ) {
 			$blockPath = "{$path}.{$index}";
+
+			$nodeCount++;
+
+			if ( $nodeCount > self::MAX_NODES ) {
+				return sprintf(
+					'The block tree exceeds the maximum of %d nodes.',
+					self::MAX_NODES
+				);
+			}
 
 			if ( ! is_array( $block ) ) {
 				return "The {$blockPath} must be a block object.";
@@ -63,6 +103,12 @@ class BlockTreeRule implements ValidationRule
 			if ( ! isset( $block['clientId'] ) || ! is_string( $block['clientId'] ) || '' === $block['clientId'] ) {
 				return "The {$blockPath}.clientId is required and must be a string.";
 			}
+
+			if ( isset( $seenClients[ $block['clientId'] ] ) ) {
+				return "The {$blockPath}.clientId \"{$block['clientId']}\" is duplicated within the block tree.";
+			}
+
+			$seenClients[ $block['clientId'] ] = true;
 
 			if ( ! isset( $block['name'] ) || ! is_string( $block['name'] ) || '' === $block['name'] ) {
 				return "The {$blockPath}.name is required and must be a string.";
@@ -76,7 +122,13 @@ class BlockTreeRule implements ValidationRule
 				return "The {$blockPath}.innerBlocks is required and must be an array.";
 			}
 
-			$childError = $this->validateBlocks( $block['innerBlocks'], "{$blockPath}.innerBlocks" );
+			$childError = $this->validateBlocks(
+				$block['innerBlocks'],
+				"{$blockPath}.innerBlocks",
+				$currentDepth + 1,
+				$nodeCount,
+				$seenClients
+			);
 
 			if ( null !== $childError ) {
 				return $childError;

--- a/src/VisualEditorServiceProvider.php
+++ b/src/VisualEditorServiceProvider.php
@@ -2,6 +2,11 @@
 
 namespace ArtisanPackUI\VisualEditor;
 
+use ArtisanPackUI\VisualEditor\Models\VisualEditorPost;
+use ArtisanPackUI\VisualEditor\Policies\VisualEditorPostPolicy;
+use ArtisanPackUI\VisualEditor\Registries\BlockTypeRegistry;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
 
 class VisualEditorServiceProvider extends ServiceProvider
@@ -11,6 +16,10 @@ class VisualEditorServiceProvider extends ServiceProvider
 	{
 		$this->app->singleton( 'package', function ( $app ) {
 			return new VisualEditor();
+		} );
+
+		$this->app->singleton( BlockTypeRegistry::class, function () {
+			return new BlockTypeRegistry();
 		} );
 
 		$this->mergeConfigFrom(
@@ -30,9 +39,14 @@ class VisualEditorServiceProvider extends ServiceProvider
 		// 1. Merge the configuration correctly.
 		$this->mergeConfiguration();
 
-		// 2. Load package views and routes for the Phase 0 spike.
+		// 2. Load package views, routes, and migrations.
 		$this->loadViewsFrom( __DIR__ . '/../resources/views', 'visual-editor' );
 		$this->loadRoutesFrom( __DIR__ . '/../routes/web.php' );
+		$this->loadMigrationsFrom( __DIR__ . '/../database/migrations' );
+
+		$this->registerApiRoutes();
+
+		Gate::policy( VisualEditorPost::class, VisualEditorPostPolicy::class );
 
 		// 3. Tag the config file for the scaffold command.
 		if ( $this->app->runningInConsole() ) {
@@ -44,6 +58,23 @@ class VisualEditorServiceProvider extends ServiceProvider
 								  __DIR__ . '/../public/editor-spike' => public_path( 'vendor/visual-editor/editor-spike' ),
 							  ], 'visual-editor-spike-assets' );
 		}
+	}
+
+	/**
+	 * Registers the package API routes under the `/visual-editor/api` prefix.
+	 *
+	 * @since 1.0.0
+	 */
+	protected function registerApiRoutes(): void
+	{
+		$middleware = (array) config(
+			'artisanpack.visual-editor.api.middleware',
+			['api', 'auth']
+		);
+
+		Route::middleware( $middleware )
+			->prefix( 'visual-editor/api' )
+			->group( __DIR__ . '/../routes/api.php' );
 	}
 
 

--- a/tests/Feature/VisualEditor/BlocksControllerTest.php
+++ b/tests/Feature/VisualEditor/BlocksControllerTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare( strict_types=1 );
+
+use Tests\TestUser;
+
+it( 'returns 401 for unauthenticated blocks requests', function () {
+	$response = $this->getJson( '/visual-editor/api/blocks' );
+
+	$response->assertUnauthorized();
+} );
+
+it( 'returns the registered block types', function () {
+	$user = TestUser::create( [
+		'name'     => 'Jane',
+		'email'    => 'jane@example.com',
+		'password' => bcrypt( 'secret' ),
+	] );
+
+	$this->actingAs( $user );
+
+	$response = $this->getJson( '/visual-editor/api/blocks' );
+
+	$response->assertOk()
+		->assertJsonStructure( [
+			'data' => [
+				'*' => ['name', 'title', 'category', 'attributes'],
+			],
+		] );
+
+	$names = collect( $response->json( 'data' ) )->pluck( 'name' )->all();
+
+	expect( $names )->toContain( 'core/paragraph', 'core/heading' );
+} );

--- a/tests/Feature/VisualEditor/PostsControllerTest.php
+++ b/tests/Feature/VisualEditor/PostsControllerTest.php
@@ -86,6 +86,81 @@ it( 'validates the block tree shape on PUT', function () {
 		->assertJsonValidationErrors( 'blocks' );
 } );
 
+it( 'rejects duplicate clientIds within the tree', function () {
+	actingAsUser();
+	$post = createPost();
+
+	$response = $this->putJson( "/visual-editor/api/posts/{$post->id}", [
+		'blocks' => [
+			[
+				'clientId'    => 'dupe',
+				'name'        => 'core/paragraph',
+				'attributes'  => ['content' => 'a'],
+				'innerBlocks' => [],
+			],
+			[
+				'clientId'    => 'dupe',
+				'name'        => 'core/paragraph',
+				'attributes'  => ['content' => 'b'],
+				'innerBlocks' => [],
+			],
+		],
+	] );
+
+	$response->assertUnprocessable()
+		->assertJsonValidationErrors( 'blocks' );
+} );
+
+it( 'rejects block trees deeper than MAX_DEPTH', function () {
+	actingAsUser();
+	$post = createPost();
+
+	$build = function ( int $depth ) use ( &$build ): array {
+		$block = [
+			'clientId'    => "c-{$depth}",
+			'name'        => 'core/paragraph',
+			'attributes'  => [],
+			'innerBlocks' => [],
+		];
+
+		if ( $depth > 0 ) {
+			$block['innerBlocks'] = [$build( $depth - 1 )];
+		}
+
+		return $block;
+	};
+
+	$response = $this->putJson( "/visual-editor/api/posts/{$post->id}", [
+		'blocks' => [$build( \ArtisanPackUI\VisualEditor\Rules\BlockTreeRule::MAX_DEPTH )],
+	] );
+
+	$response->assertUnprocessable()
+		->assertJsonValidationErrors( 'blocks' );
+} );
+
+it( 'rejects block trees with more than MAX_NODES blocks', function () {
+	actingAsUser();
+	$post = createPost();
+
+	$count  = \ArtisanPackUI\VisualEditor\Rules\BlockTreeRule::MAX_NODES + 1;
+	$blocks = [];
+	for ( $i = 0; $i < $count; $i++ ) {
+		$blocks[] = [
+			'clientId'    => "c-{$i}",
+			'name'        => 'core/paragraph',
+			'attributes'  => [],
+			'innerBlocks' => [],
+		];
+	}
+
+	$response = $this->putJson( "/visual-editor/api/posts/{$post->id}", [
+		'blocks' => $blocks,
+	] );
+
+	$response->assertUnprocessable()
+		->assertJsonValidationErrors( 'blocks' );
+} );
+
 it( 'requires the blocks key on PUT', function () {
 	actingAsUser();
 	$post = createPost();

--- a/tests/Feature/VisualEditor/PostsControllerTest.php
+++ b/tests/Feature/VisualEditor/PostsControllerTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Models\VisualEditorPost;
+use Tests\TestUser;
+
+function createPost( array $overrides = [] ): VisualEditorPost
+{
+	return VisualEditorPost::create( array_merge( [
+		'title'  => 'Test Post',
+		'blocks' => [
+			[
+				'clientId'    => 'abc-123',
+				'name'        => 'core/paragraph',
+				'attributes'  => ['content' => 'Hello'],
+				'innerBlocks' => [],
+			],
+		],
+	], $overrides ) );
+}
+
+function actingAsUser(): TestUser
+{
+	$user = TestUser::create( [
+		'name'     => 'Jane Doe',
+		'email'    => 'jane@example.com',
+		'password' => bcrypt( 'secret' ),
+	] );
+
+	test()->actingAs( $user );
+
+	return $user;
+}
+
+it( 'returns 401 for unauthenticated GET requests', function () {
+	$post = createPost();
+
+	$response = $this->getJson( "/visual-editor/api/posts/{$post->id}" );
+
+	$response->assertUnauthorized();
+} );
+
+it( 'returns 403 when ownership restriction blocks the user', function () {
+	config()->set( 'artisanpack.visual-editor.authorization.restrict_by_owner', true );
+
+	$owner = TestUser::create( [
+		'name'     => 'Owner',
+		'email'    => 'owner@example.com',
+		'password' => bcrypt( 'secret' ),
+	] );
+	$post = createPost( ['author_id' => $owner->id] );
+
+	actingAsUser();
+
+	$response = $this->getJson( "/visual-editor/api/posts/{$post->id}" );
+
+	$response->assertForbidden();
+} );
+
+it( 'returns the block tree for an authorized GET request', function () {
+	actingAsUser();
+	$post = createPost();
+
+	$response = $this->getJson( "/visual-editor/api/posts/{$post->id}" );
+
+	$response->assertOk()
+		->assertJsonPath( 'id', $post->id )
+		->assertJsonPath( 'title', 'Test Post' )
+		->assertJsonPath( 'blocks.0.clientId', 'abc-123' )
+		->assertJsonPath( 'blocks.0.name', 'core/paragraph' )
+		->assertJsonPath( 'blocks.0.attributes.content', 'Hello' );
+} );
+
+it( 'validates the block tree shape on PUT', function () {
+	actingAsUser();
+	$post = createPost();
+
+	$response = $this->putJson( "/visual-editor/api/posts/{$post->id}", [
+		'blocks' => [
+			['clientId' => 'only-id'],
+		],
+	] );
+
+	$response->assertUnprocessable()
+		->assertJsonValidationErrors( 'blocks' );
+} );
+
+it( 'requires the blocks key on PUT', function () {
+	actingAsUser();
+	$post = createPost();
+
+	$response = $this->putJson( "/visual-editor/api/posts/{$post->id}", [] );
+
+	$response->assertUnprocessable()
+		->assertJsonValidationErrors( 'blocks' );
+} );
+
+it( 'persists a valid block tree on PUT', function () {
+	actingAsUser();
+	$post = createPost();
+
+	$newBlocks = [
+		[
+			'clientId'    => 'heading-1',
+			'name'        => 'core/heading',
+			'attributes'  => ['content' => 'Updated', 'level' => 2],
+			'innerBlocks' => [],
+		],
+		[
+			'clientId'    => 'paragraph-1',
+			'name'        => 'core/paragraph',
+			'attributes'  => ['content' => 'Body text'],
+			'innerBlocks' => [
+				[
+					'clientId'    => 'inner-1',
+					'name'        => 'core/paragraph',
+					'attributes'  => ['content' => 'Nested'],
+					'innerBlocks' => [],
+				],
+			],
+		],
+	];
+
+	$response = $this->putJson( "/visual-editor/api/posts/{$post->id}", [
+		'blocks' => $newBlocks,
+	] );
+
+	$response->assertOk()
+		->assertJsonPath( 'blocks.0.clientId', 'heading-1' )
+		->assertJsonPath( 'blocks.1.innerBlocks.0.clientId', 'inner-1' );
+
+	expect( $post->fresh()->blocks )->toEqual( $newBlocks );
+} );
+
+it( 'returns 401 for unauthenticated PUT requests', function () {
+	$post = createPost();
+
+	$response = $this->putJson( "/visual-editor/api/posts/{$post->id}", [
+		'blocks' => [],
+	] );
+
+	$response->assertUnauthorized();
+} );

--- a/tests/Feature/VisualEditor/PostsControllerTest.php
+++ b/tests/Feature/VisualEditor/PostsControllerTest.php
@@ -58,6 +58,41 @@ it( 'returns 403 when ownership restriction blocks the user', function () {
 	$response->assertForbidden();
 } );
 
+it( 'returns 403 on PUT when ownership restriction blocks the user', function () {
+	config()->set( 'artisanpack.visual-editor.authorization.restrict_by_owner', true );
+
+	$owner = TestUser::create( [
+		'name'     => 'Owner',
+		'email'    => 'owner@example.com',
+		'password' => bcrypt( 'secret' ),
+	] );
+	$post = createPost( ['author_id' => $owner->id] );
+
+	actingAsUser();
+
+	$response = $this->putJson( "/visual-editor/api/posts/{$post->id}", [
+		'blocks' => [
+			[
+				'clientId'    => 'c-1',
+				'name'        => 'core/paragraph',
+				'attributes'  => ['content' => 'Hello'],
+				'innerBlocks' => [],
+			],
+		],
+	] );
+
+	$response->assertForbidden();
+
+	expect( $post->fresh()->blocks )->toEqual( [
+		[
+			'clientId'    => 'abc-123',
+			'name'        => 'core/paragraph',
+			'attributes'  => ['content' => 'Hello'],
+			'innerBlocks' => [],
+		],
+	] );
+} );
+
 it( 'returns the block tree for an authorized GET request', function () {
 	actingAsUser();
 	$post = createPost();

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -11,9 +11,9 @@
 |
 */
 
-// pest()->extend(Tests\TestCase::class)
-//     ->use(Illuminate\Foundation\Testing\RefreshDatabase::class)
-//     ->in('Feature');
+pest()->extend(Tests\TestCase::class)
+    ->use(Illuminate\Foundation\Testing\RefreshDatabase::class)
+    ->in('Feature/VisualEditor');
 
 /*
 |--------------------------------------------------------------------------

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,10 +1,55 @@
 <?php
 
+declare( strict_types=1 );
+
 namespace Tests;
 
-use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+use ArtisanPackUI\VisualEditor\VisualEditorServiceProvider;
+use Orchestra\Testbench\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {
-    //
+	/**
+	 * @param  \Illuminate\Foundation\Application  $app
+	 *
+	 * @return array<int, class-string>
+	 */
+	protected function getPackageProviders( $app ): array
+	{
+		return [
+			VisualEditorServiceProvider::class,
+		];
+	}
+
+	/**
+	 * @param  \Illuminate\Foundation\Application  $app
+	 */
+	protected function defineEnvironment( $app ): void
+	{
+		$app['config']->set( 'app.key', 'base64:' . base64_encode( random_bytes( 32 ) ) );
+
+		$app['config']->set( 'database.default', 'testbench' );
+		$app['config']->set( 'database.connections.testbench', [
+			'driver'                  => 'sqlite',
+			'database'                => ':memory:',
+			'prefix'                  => '',
+			'foreign_key_constraints' => true,
+		] );
+
+		$app['config']->set( 'auth.providers.users.model', TestUser::class );
+	}
+
+	protected function defineDatabaseMigrations(): void
+	{
+		$this->loadMigrationsFrom( __DIR__ . '/../database/migrations/testing' );
+		$this->loadMigrationsFrom( __DIR__ . '/../database/migrations' );
+	}
+
+	/**
+	 * @param  \Illuminate\Routing\Router  $router
+	 */
+	protected function defineRoutes( $router ): void
+	{
+		$router->get( '/login', fn () => 'Login' )->name( 'login' );
+	}
 }

--- a/tests/TestUser.php
+++ b/tests/TestUser.php
@@ -1,0 +1,16 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace Tests;
+
+use Illuminate\Foundation\Auth\User as Authenticatable;
+
+class TestUser extends Authenticatable
+{
+	protected $table = 'users';
+
+	protected $guarded = [];
+
+	public $timestamps = true;
+}

--- a/tests/Unit/VisualEditor/BlockTypeRegistryTest.php
+++ b/tests/Unit/VisualEditor/BlockTypeRegistryTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Registries\BlockTypeRegistry;
+
+it( 'seeds core/paragraph and core/heading by default', function () {
+	$registry = new BlockTypeRegistry();
+
+	$names = array_column( $registry->all(), 'name' );
+
+	expect( $names )->toContain( 'core/paragraph', 'core/heading' );
+} );
+
+it( 'registers a valid namespaced block name', function () {
+	$registry = new BlockTypeRegistry();
+
+	$registry->register( 'acme/callout', ['title' => 'Callout'] );
+
+	$names = array_column( $registry->all(), 'name' );
+
+	expect( $names )->toContain( 'acme/callout' );
+} );
+
+it( 'rejects empty block names', function () {
+	$registry = new BlockTypeRegistry();
+
+	$registry->register( '   ', [] );
+} )->throws( InvalidArgumentException::class );
+
+it( 'rejects malformed block names', function () {
+	$registry = new BlockTypeRegistry();
+
+	$registry->register( 'Bad Name!', [] );
+} )->throws( InvalidArgumentException::class );
+
+it( 'rejects block names missing a namespace', function () {
+	$registry = new BlockTypeRegistry();
+
+	$registry->register( 'paragraph', [] );
+} )->throws( InvalidArgumentException::class );


### PR DESCRIPTION
## Description

Adds the Phase 1.12 REST API — three JSON endpoints the React editor consumes, plus the policy, form request, block-tree validation rule, and block type registry that back them.

**Closes:** #274

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #274

## Motivation and Context

Phase 1 of the React-editor migration needs a server contract the frontend can talk to. This PR delivers the full server side independent of the frontend work so Phase 1 blocks (Tiptap, dnd-kit, etc.) can integrate against a real API.

## Changes Made

- `VisualEditorPostsController` with `show` / `update` actions gated via `Gate::authorize('view'|'update', $post)`
- `VisualEditorBlocksController` returning the registered block types from a new `BlockTypeRegistry` singleton (seeded with `core/paragraph` + `core/heading`)
- `routes/api.php` registered under the `/visual-editor/api` prefix with a configurable `api` + `auth` middleware stack
- `VisualEditorPost` Eloquent model + `ve_contents` migration (minimal Phase 1 schema: `id`, `author_id`, `title`, `blocks`, timestamps)
- `VisualEditorPostPolicy` with `view` / `update` abilities and an optional owner restriction via `artisanpack.visual-editor.authorization.restrict_by_owner`
- `UpdatePostBlocksRequest` backed by a recursive `BlockTreeRule` that validates the `{ clientId, name, attributes, innerBlocks }` shape and reports the first invalid path in dot notation
- Service provider registers the registry singleton, loads migrations, loads API routes, and binds the policy via `Gate::policy()`
- Orchestra Testbench bootstrapped for package feature tests (isolated to `tests/Feature/VisualEditor` so the existing file-inspection tests continue to run)
- `docs/phase-1-rest-api.md` documenting the routes, auth model, and JSON shapes

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (Darwin 25.3.0)
- Browser (if applicable): N/A (JSON API)
- PHP Version: 8.4.3
- Project Version: visual-editor @ add/phase-one

**Tests Performed:**
1. `./vendor/bin/pest` — full suite: 16 passed (52 assertions)
2. `./vendor/bin/pest tests/Feature/VisualEditor` — 9 passed (33 assertions)
3. Exercised auth (401), policy rejection (403), happy-path GET (200), missing `blocks` key (422), malformed block (422), nested happy-path PUT with persistence assertion, and the blocks index endpoint

## Accessibility Tests Run

- [x] Keyboard navigation tested — N/A (JSON API, no UI)
- [x] Screen reader tested — N/A
- [x] Color contrast verified — N/A
- [x] ARIA labels checked — N/A

**Details:** This PR adds only backend JSON endpoints. No user-facing UI is introduced.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:**

`tests/Feature/VisualEditor/PostsControllerTest.php` covers:
- GET unauthenticated → 401
- GET ownership-restricted non-owner → 403
- GET happy path returns the block tree
- PUT with malformed block → 422 (validation errors on `blocks`)
- PUT with missing `blocks` key → 422
- PUT happy path persists a nested block tree and returns the updated payload
- PUT unauthenticated → 401

`tests/Feature/VisualEditor/BlocksControllerTest.php` covers:
- GET unauthenticated → 401
- GET authenticated returns `core/paragraph` and `core/heading` with the expected structure

## Documentation

- [x] Inline code documentation added
- [x] API documentation updated

**Documentation details:** `docs/phase-1-rest-api.md` documents all three endpoints, authorization, and the recursive block tree shape with request/response examples.

## Pre-Submission Checklist

- [x] Code passes all tests (16 passed)
- [x] Self-review completed
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Visual Editor API (endpoints to fetch/update posts and list block types), block-based content persistence, built-in paragraph/heading types, ownership-aware authorization, and server-side block-tree validation.

* **Documentation**
  * Phase 1 REST API spec describing endpoints, request/response shapes, block tree schema, and auth behavior.

* **Tests**
  * Comprehensive feature and unit tests plus test harness configuration to exercise API, validation, and registry behavior.

* **Chores**
  * Added test runner dev dependency and a test script.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->