### PR TITLE
feat: block.json architecture, registries, RichText & InnerBlocks primitives

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,15 @@
     "version": "1.0.0-spike",
     "private": true,
     "type": "module",
+    "exports": {
+        ".": {
+            "import": "./dist/lib/visual-editor.js"
+        }
+    },
     "scripts": {
         "dev": "vite",
         "build": "vite build",
+        "build:lib": "vite build --mode lib",
         "test": "vitest run",
         "test:watch": "vitest"
     },

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "type": "module",
     "exports": {
         ".": {
+            "types": "./dist/lib/visual-editor.d.ts",
             "import": "./dist/lib/visual-editor.js"
         }
     },

--- a/resources/js/visual-editor/editor/blocks/__tests__/code.test.tsx
+++ b/resources/js/visual-editor/editor/blocks/__tests__/code.test.tsx
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { EditorStoreProvider, RenderBlock } from '../../primitives';
+import { clearRegistry, getBlock } from '../../registry';
+import { createEditorStore, type Block, type EditorStore } from '../../store';
+import { registerCodeBlock, CODE_BLOCK_NAME, normalizeLanguage } from '../code';
+import { clearBlockEditors } from '../shared/blockEditorRegistry';
+
+function makeCode(clientId: string, content: string, language = 'plaintext'): Block {
+    return {
+        clientId,
+        name: CODE_BLOCK_NAME,
+        attributes: { content, language },
+        innerBlocks: [],
+    };
+}
+
+function renderBlock(store: EditorStore, block: Block) {
+    return render(
+        <EditorStoreProvider store={store}>
+            <RenderBlock block={block} />
+        </EditorStoreProvider>
+    );
+}
+
+beforeEach(() => {
+    clearRegistry();
+    clearBlockEditors();
+    registerCodeBlock();
+});
+
+afterEach(() => {
+    clearRegistry();
+    clearBlockEditors();
+});
+
+describe('code block registration', () => {
+    it('registers artisanpack/code in the block registry', () => {
+        expect(getBlock(CODE_BLOCK_NAME)).toBeDefined();
+    });
+});
+
+describe('normalizeLanguage', () => {
+    it('accepts supported languages and defaults unknown to plaintext', () => {
+        expect(normalizeLanguage('php')).toBe('php');
+        expect(normalizeLanguage('unknown')).toBe('plaintext');
+        expect(normalizeLanguage(undefined)).toBe('plaintext');
+    });
+});
+
+describe('code block edit', () => {
+    it('renders initial content in textarea', () => {
+        const block = makeCode('c1', 'const x = 1;');
+        const store = createEditorStore([block]);
+
+        renderBlock(store, block);
+
+        const textarea = screen.getByTestId('ve-code-textarea') as HTMLTextAreaElement;
+        expect(textarea.value).toBe('const x = 1;');
+    });
+
+    it('writes content changes to the store', () => {
+        const block = makeCode('c1', 'initial');
+        const store = createEditorStore([block]);
+
+        renderBlock(store, block);
+
+        const textarea = screen.getByTestId('ve-code-textarea') as HTMLTextAreaElement;
+        fireEvent.change(textarea, { target: { value: 'updated code' } });
+
+        expect(store.getState().blocks[0].attributes.content).toBe('updated code');
+    });
+
+    it('writes language changes to the store', () => {
+        const block = makeCode('c1', '', 'plaintext');
+        const store = createEditorStore([block]);
+
+        renderBlock(store, block);
+
+        const select = screen.getByTestId('ve-code-language') as HTMLSelectElement;
+        fireEvent.change(select, { target: { value: 'javascript' } });
+
+        expect(store.getState().blocks[0].attributes.language).toBe('javascript');
+    });
+});

--- a/resources/js/visual-editor/editor/blocks/__tests__/list.test.tsx
+++ b/resources/js/visual-editor/editor/blocks/__tests__/list.test.tsx
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { act, render } from '@testing-library/react';
+import { EditorStoreProvider, RenderBlock } from '../../primitives';
+import { clearRegistry, getBlock } from '../../registry';
+import { createEditorStore, type Block, type EditorStore } from '../../store';
+import {
+    registerListBlock,
+    LIST_BLOCK_NAME,
+    normalizeOrdered,
+} from '../list';
+import {
+    clearBlockEditors,
+    getBlockEditor,
+} from '../shared/blockEditorRegistry';
+
+function makeList(clientId: string, content: string, ordered = false): Block {
+    return {
+        clientId,
+        name: LIST_BLOCK_NAME,
+        attributes: { ordered, content },
+        innerBlocks: [],
+    };
+}
+
+function renderBlock(store: EditorStore, block: Block) {
+    return render(
+        <EditorStoreProvider store={store}>
+            <RenderBlock block={block} />
+        </EditorStoreProvider>
+    );
+}
+
+beforeEach(() => {
+    clearRegistry();
+    clearBlockEditors();
+    registerListBlock();
+});
+
+afterEach(() => {
+    clearRegistry();
+    clearBlockEditors();
+});
+
+describe('list block registration', () => {
+    it('registers artisanpack/list in the block registry', () => {
+        expect(getBlock(LIST_BLOCK_NAME)).toBeDefined();
+    });
+
+    it('has supports from block.json', () => {
+        const def = getBlock(LIST_BLOCK_NAME);
+        expect(def?.supports?.anchor).toBe(true);
+        expect(def?.supports?.className).toBe(true);
+    });
+});
+
+describe('normalizeOrdered', () => {
+    it('only returns true for strict true', () => {
+        expect(normalizeOrdered(true)).toBe(true);
+        expect(normalizeOrdered(false)).toBe(false);
+        expect(normalizeOrdered(undefined)).toBe(false);
+        expect(normalizeOrdered('true')).toBe(false);
+    });
+});
+
+describe('list block edit', () => {
+    it('mounts and seeds an empty bullet list', () => {
+        const block = makeList('l1', '');
+        const store = createEditorStore([block]);
+
+        renderBlock(store, block);
+
+        const editor = getBlockEditor('l1');
+        expect(editor).not.toBeNull();
+        expect(editor!.state.doc.firstChild?.type.name).toBe('bulletList');
+    });
+
+    it('writes content back to the store', async () => {
+        const block = makeList('l1', '<ul><li><p>first</p></li></ul>');
+        const store = createEditorStore([block]);
+
+        renderBlock(store, block);
+
+        const editor = getBlockEditor('l1');
+        expect(editor).not.toBeNull();
+
+        await act(async () => {
+            editor!.commands.focus('end');
+            editor!.commands.insertContent(' more');
+        });
+
+        const content = store.getState().blocks[0].attributes.content as string;
+        expect(content).toContain('first');
+        expect(content).toContain('more');
+    });
+
+    it('switches to ordered list when attribute changes', () => {
+        const block = makeList('l1', '<ul><li><p>item</p></li></ul>', false);
+        const store = createEditorStore([block]);
+
+        renderBlock(store, block);
+
+        const editor = getBlockEditor('l1');
+        expect(editor!.state.doc.firstChild?.type.name).toBe('bulletList');
+
+        act(() => {
+            store.getState().updateBlockAttributes('l1', { ordered: true });
+        });
+
+        expect(editor!.state.doc.firstChild?.type.name).toBe('orderedList');
+    });
+});

--- a/resources/js/visual-editor/editor/blocks/__tests__/preformatted.test.tsx
+++ b/resources/js/visual-editor/editor/blocks/__tests__/preformatted.test.tsx
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { act, render, screen } from '@testing-library/react';
+import { EditorStoreProvider, RenderBlock } from '../../primitives';
+import { clearRegistry, getBlock } from '../../registry';
+import { createEditorStore, type Block, type EditorStore } from '../../store';
+import { registerPreformattedBlock, PREFORMATTED_BLOCK_NAME } from '../preformatted';
+import { clearBlockEditors, getBlockEditor } from '../shared/blockEditorRegistry';
+
+function makePreformatted(clientId: string, content: string): Block {
+    return {
+        clientId,
+        name: PREFORMATTED_BLOCK_NAME,
+        attributes: { content },
+        innerBlocks: [],
+    };
+}
+
+function renderBlock(store: EditorStore, block: Block) {
+    return render(
+        <EditorStoreProvider store={store}>
+            <RenderBlock block={block} />
+        </EditorStoreProvider>
+    );
+}
+
+beforeEach(() => {
+    clearRegistry();
+    clearBlockEditors();
+    registerPreformattedBlock();
+});
+
+afterEach(() => {
+    clearRegistry();
+    clearBlockEditors();
+});
+
+describe('preformatted block registration', () => {
+    it('registers artisanpack/preformatted in the block registry', () => {
+        expect(getBlock(PREFORMATTED_BLOCK_NAME)).toBeDefined();
+    });
+});
+
+describe('preformatted block edit', () => {
+    it('renders initial pre content', () => {
+        const block = makePreformatted('pf1', '<pre>Hello world</pre>');
+        const store = createEditorStore([block]);
+
+        renderBlock(store, block);
+
+        expect(screen.getByText('Hello world')).toBeInTheDocument();
+    });
+
+    it('writes updated content back to the store', async () => {
+        const block = makePreformatted('pf1', '<pre>initial</pre>');
+        const store = createEditorStore([block]);
+
+        renderBlock(store, block);
+
+        const editor = getBlockEditor('pf1');
+        expect(editor).not.toBeNull();
+
+        await act(async () => {
+            editor!.commands.focus('end');
+            editor!.commands.insertContent(' more');
+        });
+
+        const content = store.getState().blocks[0].attributes.content as string;
+        expect(content).toMatch(/^<pre/);
+        expect(content).toContain('initial');
+        expect(content).toContain('more');
+    });
+
+    it('supports bold inline formatting', async () => {
+        const block = makePreformatted('pf1', '<pre>abc</pre>');
+        const store = createEditorStore([block]);
+
+        renderBlock(store, block);
+
+        const editor = getBlockEditor('pf1');
+        expect(editor).not.toBeNull();
+
+        await act(async () => {
+            editor!.commands.focus('start');
+            editor!.commands.selectAll();
+            editor!.commands.toggleBold();
+        });
+
+        const content = store.getState().blocks[0].attributes.content as string;
+        expect(content).toMatch(/^<pre/);
+        expect(content).toContain('<strong>');
+    });
+});

--- a/resources/js/visual-editor/editor/blocks/__tests__/quote.test.tsx
+++ b/resources/js/visual-editor/editor/blocks/__tests__/quote.test.tsx
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { EditorStoreProvider, RenderBlock } from '../../primitives';
+import { clearRegistry, getBlock } from '../../registry';
+import { createEditorStore, type Block, type EditorStore } from '../../store';
+import { registerQuoteBlock, QUOTE_BLOCK_NAME } from '../quote';
+import { clearBlockEditors, getBlockEditor } from '../shared/blockEditorRegistry';
+
+function makeQuote(clientId: string, content: string, citation = ''): Block {
+    return {
+        clientId,
+        name: QUOTE_BLOCK_NAME,
+        attributes: { content, citation },
+        innerBlocks: [],
+    };
+}
+
+function renderBlock(store: EditorStore, block: Block) {
+    return render(
+        <EditorStoreProvider store={store}>
+            <RenderBlock block={block} />
+        </EditorStoreProvider>
+    );
+}
+
+beforeEach(() => {
+    clearRegistry();
+    clearBlockEditors();
+    registerQuoteBlock();
+});
+
+afterEach(() => {
+    clearRegistry();
+    clearBlockEditors();
+});
+
+describe('quote block registration', () => {
+    it('registers artisanpack/quote in the block registry', () => {
+        expect(getBlock(QUOTE_BLOCK_NAME)).toBeDefined();
+    });
+});
+
+describe('quote block edit', () => {
+    it('renders the initial content', () => {
+        const block = makeQuote('q1', '<blockquote><p>Hello quote</p></blockquote>');
+        const store = createEditorStore([block]);
+
+        renderBlock(store, block);
+
+        expect(screen.getByText('Hello quote')).toBeInTheDocument();
+    });
+
+    it('writes content updates back to the store', async () => {
+        const block = makeQuote('q1', '<blockquote><p>initial</p></blockquote>');
+        const store = createEditorStore([block]);
+
+        renderBlock(store, block);
+
+        const editor = getBlockEditor('q1');
+        expect(editor).not.toBeNull();
+
+        await act(async () => {
+            editor!.commands.focus('end');
+            editor!.commands.insertContent(' more');
+        });
+
+        const content = store.getState().blocks[0].attributes.content as string;
+        expect(content).toContain('initial');
+        expect(content).toContain('more');
+    });
+
+    it('writes citation changes to the store', () => {
+        const block = makeQuote('q1', '<blockquote><p>body</p></blockquote>', '');
+        const store = createEditorStore([block]);
+
+        renderBlock(store, block);
+
+        const input = screen.getByTestId('ve-quote-citation') as HTMLInputElement;
+        fireEvent.change(input, { target: { value: 'Jane Doe' } });
+
+        expect(store.getState().blocks[0].attributes.citation).toBe('Jane Doe');
+    });
+});

--- a/resources/js/visual-editor/editor/blocks/__tests__/slashCommand.test.tsx
+++ b/resources/js/visual-editor/editor/blocks/__tests__/slashCommand.test.tsx
@@ -3,15 +3,12 @@ import { act, fireEvent, render, screen } from '@testing-library/react';
 import { EditorStoreProvider, RenderBlock } from '../../primitives';
 import { clearRegistry } from '../../registry';
 import { createEditorStore, type Block, type EditorStore } from '../../store';
-import { registerCoreBlocks, PARAGRAPH_BLOCK_NAME } from '../index';
+import { registerCoreBlocks, PARAGRAPH_BLOCK_NAME, HEADING_BLOCK_NAME } from '../index';
 import {
     clearBlockEditors,
     getBlockEditor,
 } from '../shared/blockEditorRegistry';
-import {
-    clearInserterRegistry,
-    registerBuiltinInserterBlocks,
-} from '../../inserter';
+import { clearInserterRegistry } from '../../inserter';
 
 function paragraph(clientId: string, content: string): Block {
     return {
@@ -35,7 +32,6 @@ beforeEach(() => {
     clearBlockEditors();
     clearInserterRegistry();
     registerCoreBlocks();
-    registerBuiltinInserterBlocks();
 });
 
 afterEach(() => {
@@ -60,8 +56,8 @@ describe('slash command', () => {
         });
 
         expect(screen.getByTestId('ve-slash-command-popover')).toBeInTheDocument();
-        expect(screen.getByTestId('ve-slash-command-item-ve/paragraph')).toBeInTheDocument();
-        expect(screen.getByTestId('ve-slash-command-item-ve/heading')).toBeInTheDocument();
+        expect(screen.getByTestId(`ve-slash-command-item-${PARAGRAPH_BLOCK_NAME}`)).toBeInTheDocument();
+        expect(screen.getByTestId(`ve-slash-command-item-${HEADING_BLOCK_NAME}`)).toBeInTheDocument();
     });
 
     it('filters the popover by the text after the slash', async () => {
@@ -76,8 +72,8 @@ describe('slash command', () => {
             editor!.commands.insertContent('/head');
         });
 
-        expect(screen.queryByTestId('ve-slash-command-item-ve/paragraph')).toBeNull();
-        expect(screen.getByTestId('ve-slash-command-item-ve/heading')).toBeInTheDocument();
+        expect(screen.queryByTestId(`ve-slash-command-item-${PARAGRAPH_BLOCK_NAME}`)).toBeNull();
+        expect(screen.getByTestId(`ve-slash-command-item-${HEADING_BLOCK_NAME}`)).toBeInTheDocument();
     });
 
     it('moves the selected index with ArrowDown / ArrowUp', async () => {
@@ -94,7 +90,7 @@ describe('slash command', () => {
 
         expect(
             screen
-                .getByTestId('ve-slash-command-item-ve/paragraph')
+                .getByTestId(`ve-slash-command-item-${PARAGRAPH_BLOCK_NAME}`)
                 .getAttribute('data-selected')
         ).toBe('true');
 
@@ -104,7 +100,7 @@ describe('slash command', () => {
 
         expect(
             screen
-                .getByTestId('ve-slash-command-item-ve/heading')
+                .getByTestId(`ve-slash-command-item-${HEADING_BLOCK_NAME}`)
                 .getAttribute('data-selected')
         ).toBe('true');
 
@@ -114,7 +110,7 @@ describe('slash command', () => {
 
         expect(
             screen
-                .getByTestId('ve-slash-command-item-ve/paragraph')
+                .getByTestId(`ve-slash-command-item-${PARAGRAPH_BLOCK_NAME}`)
                 .getAttribute('data-selected')
         ).toBe('true');
     });
@@ -142,7 +138,7 @@ describe('slash command', () => {
 
         const blocks = store.getState().blocks;
         expect(blocks).toHaveLength(1);
-        expect(blocks[0].name).toBe('ve/heading');
+        expect(blocks[0].name).toBe(HEADING_BLOCK_NAME);
     });
 
     it('closes the popover on Escape', async () => {
@@ -179,11 +175,11 @@ describe('slash command', () => {
         });
 
         await act(async () => {
-            fireEvent.mouseDown(screen.getByTestId('ve-slash-command-item-ve/heading'));
+            fireEvent.mouseDown(screen.getByTestId(`ve-slash-command-item-${HEADING_BLOCK_NAME}`));
         });
 
         const blocks = store.getState().blocks;
         expect(blocks).toHaveLength(1);
-        expect(blocks[0].name).toBe('ve/heading');
+        expect(blocks[0].name).toBe(HEADING_BLOCK_NAME);
     });
 });

--- a/resources/js/visual-editor/editor/blocks/code/block.json
+++ b/resources/js/visual-editor/editor/blocks/code/block.json
@@ -1,0 +1,42 @@
+{
+    "apiVersion": 1,
+    "name": "artisanpack/code",
+    "title": "Code",
+    "category": "text",
+    "description": "Display code snippets with monospaced formatting.",
+    "keywords": ["pre", "snippet", "syntax"],
+    "textdomain": "visual-editor",
+    "attributes": {
+        "content": {
+            "type": "string",
+            "default": ""
+        },
+        "language": {
+            "type": "string",
+            "default": "plaintext",
+            "enum": [
+                "plaintext", "html", "css", "javascript", "typescript",
+                "php", "python", "ruby", "go", "rust", "json", "yaml",
+                "bash", "sql", "markdown"
+            ]
+        }
+    },
+    "supports": {
+        "anchor": true,
+        "className": true,
+        "spacing": {
+            "margin": true,
+            "padding": true
+        },
+        "typography": {
+            "fontSize": true,
+            "lineHeight": true
+        },
+        "border": {
+            "color": true,
+            "radius": true,
+            "style": true,
+            "width": true
+        }
+    }
+}

--- a/resources/js/visual-editor/editor/blocks/code/edit.tsx
+++ b/resources/js/visual-editor/editor/blocks/code/edit.tsx
@@ -1,0 +1,123 @@
+import {
+    type ChangeEvent,
+    type KeyboardEvent,
+    useCallback,
+    useEffect,
+    useLayoutEffect,
+    useRef,
+} from 'react';
+import { useStore } from 'zustand';
+import type { BlockEditProps } from '../../registry';
+import { useEditorStore } from '../../primitives';
+
+import metadata from './block.json';
+
+export const CODE_BLOCK_NAME = metadata.name;
+
+export const CODE_LANGUAGES: readonly string[] =
+    (metadata.attributes?.language?.enum as string[] | undefined) ?? ['plaintext'];
+
+export function normalizeLanguage(value: unknown): string {
+    if (typeof value === 'string' && CODE_LANGUAGES.includes(value)) {
+        return value;
+    }
+    return 'plaintext';
+}
+
+export default function CodeEdit({ clientId, attributes }: BlockEditProps) {
+    const store = useEditorStore();
+    const content = typeof attributes.content === 'string' ? attributes.content : '';
+    const language = normalizeLanguage(attributes.language);
+    const textareaRef = useRef<HTMLTextAreaElement>(null);
+    const desiredCaretRef = useRef<number | null>(null);
+
+    const isSelected = useStore(
+        store,
+        (state) => state.selection.clientId === clientId
+    );
+
+    const onContentChange = useCallback(
+        (event: ChangeEvent<HTMLTextAreaElement>) => {
+            store
+                .getState()
+                .updateBlockAttributes(clientId, { content: event.target.value });
+        },
+        [store, clientId]
+    );
+
+    const onLanguageChange = useCallback(
+        (event: ChangeEvent<HTMLSelectElement>) => {
+            store
+                .getState()
+                .updateBlockAttributes(clientId, { language: event.target.value });
+        },
+        [store, clientId]
+    );
+
+    const onKeyDown = useCallback(
+        (event: KeyboardEvent<HTMLTextAreaElement>) => {
+            if (event.key !== 'Tab') {
+                return;
+            }
+            event.preventDefault();
+            const { selectionStart, selectionEnd, value } = event.currentTarget;
+            const nextValue =
+                value.slice(0, selectionStart) + '    ' + value.slice(selectionEnd);
+            desiredCaretRef.current = selectionStart + 4;
+            store.getState().updateBlockAttributes(clientId, { content: nextValue });
+        },
+        [store, clientId]
+    );
+
+    // Restore caret position after controlled value update from Tab indent
+    useLayoutEffect(() => {
+        if (desiredCaretRef.current === null || !textareaRef.current) {
+            return;
+        }
+        const pos = desiredCaretRef.current;
+        desiredCaretRef.current = null;
+        textareaRef.current.selectionStart = pos;
+        textareaRef.current.selectionEnd = pos;
+    }, [content]);
+
+    useEffect(() => {
+        if (!isSelected || !textareaRef.current) {
+            return;
+        }
+        if (document.activeElement === textareaRef.current) {
+            return;
+        }
+        textareaRef.current.focus();
+    }, [isSelected]);
+
+    return (
+        <div className="ve-block-code-wrapper" data-block-name={CODE_BLOCK_NAME}>
+            <label className="ve-block-code__language">
+                <span className="ve-sr-only">Language</span>
+                <select
+                    value={language}
+                    aria-label="Code language"
+                    data-testid="ve-code-language"
+                    onChange={onLanguageChange}
+                >
+                    {CODE_LANGUAGES.map((lang) => (
+                        <option key={lang} value={lang}>
+                            {lang}
+                        </option>
+                    ))}
+                </select>
+            </label>
+            <textarea
+                ref={textareaRef}
+                className="ve-block-code__textarea"
+                value={content}
+                spellCheck={false}
+                aria-label={`Code editor (${language})`}
+                data-testid="ve-code-textarea"
+                data-language={language}
+                onChange={onContentChange}
+                onKeyDown={onKeyDown}
+            />
+        </div>
+    );
+}

--- a/resources/js/visual-editor/editor/blocks/code/index.ts
+++ b/resources/js/visual-editor/editor/blocks/code/index.ts
@@ -1,0 +1,20 @@
+import { registerBlockType, type BlockJsonMetadata } from '../../registry';
+import rawMetadata from './block.json';
+import CodeEdit, { CODE_BLOCK_NAME } from './edit';
+
+const metadata = rawMetadata as unknown as BlockJsonMetadata;
+
+export function registerCodeBlock(): void {
+    registerBlockType(metadata, {
+        edit: CodeEdit,
+        factory: () => ({
+            name: CODE_BLOCK_NAME,
+            attributes: { content: '', language: 'plaintext' },
+            innerBlocks: [],
+        }),
+    });
+}
+
+export { CODE_BLOCK_NAME };
+export { CODE_LANGUAGES, normalizeLanguage } from './edit';
+export { default as CodeEdit } from './edit';

--- a/resources/js/visual-editor/editor/blocks/heading/block.json
+++ b/resources/js/visual-editor/editor/blocks/heading/block.json
@@ -1,0 +1,54 @@
+{
+    "apiVersion": 1,
+    "name": "artisanpack/heading",
+    "title": "Heading",
+    "category": "text",
+    "description": "Introduce new sections and organize content to help readers scan.",
+    "keywords": ["title", "subtitle", "h1", "h2", "h3", "h4", "h5", "h6"],
+    "textdomain": "visual-editor",
+    "attributes": {
+        "content": {
+            "type": "rich-text",
+            "source": "rich-text",
+            "selector": "h1,h2,h3,h4,h5,h6",
+            "role": "content",
+            "default": ""
+        },
+        "level": {
+            "type": "number",
+            "default": 2
+        }
+    },
+    "supports": {
+        "splitting": true,
+        "anchor": true,
+        "className": true,
+        "color": {
+            "background": true,
+            "text": true,
+            "gradients": true,
+            "link": true
+        },
+        "spacing": {
+            "margin": true,
+            "padding": true
+        },
+        "typography": {
+            "fontSize": true,
+            "lineHeight": true,
+            "textAlign": true,
+            "fontFamily": true,
+            "fontStyle": true,
+            "fontWeight": true,
+            "letterSpacing": true,
+            "textDecoration": true,
+            "textTransform": true
+        },
+        "border": {
+            "color": true,
+            "radius": true,
+            "style": true,
+            "width": true
+        }
+    }
+}

--- a/resources/js/visual-editor/editor/blocks/heading/edit.tsx
+++ b/resources/js/visual-editor/editor/blocks/heading/edit.tsx
@@ -1,14 +1,13 @@
-import { useCallback, useEffect, useMemo } from 'react';
-import { EditorContent } from '@tiptap/react';
-import { useStore } from 'zustand';
-import Heading, { type Level } from '@tiptap/extension-heading';
+import { useCallback } from 'react';
+import type { Level } from '@tiptap/extension-heading';
 import type { BlockEditProps } from '../../registry';
-import { useEditorStore } from '../../primitives';
-import { useBlockTiptap } from '../shared/useBlockTiptap';
+import { useEditorStore, RichText } from '../../primitives';
 import { handleBlockBackspace, handleBlockEnter } from '../shared/blockSplitMerge';
-import { takePendingCursor } from '../shared/blockEditorRegistry';
+import { getBlockEditor } from '../shared/blockEditorRegistry';
 
-export const HEADING_BLOCK_NAME = 've/heading';
+import metadata from './block.json';
+
+export const HEADING_BLOCK_NAME = metadata.name;
 export const HEADING_LEVELS: readonly Level[] = [1, 2, 3, 4, 5, 6];
 
 export function normalizeHeadingLevel(value: unknown): Level {
@@ -22,86 +21,39 @@ export default function HeadingEdit({ clientId, attributes }: BlockEditProps) {
     const store = useEditorStore();
     const content = typeof attributes.content === 'string' ? attributes.content : '';
     const level = normalizeHeadingLevel(attributes.level);
-    const isSelected = useStore(
-        store,
-        (state) => state.selection.clientId === clientId
-    );
-    const selectionEdge = useStore(
-        store,
-        (state) => (state.selection.clientId === clientId ? state.selection.edge : undefined)
-    );
 
-    const headingNode = useMemo(
-        () => Heading.configure({ levels: [...HEADING_LEVELS] }),
-        []
-    );
-
-    const onUpdate = useCallback(
+    const onChange = useCallback(
         (html: string) => {
             store.getState().updateBlockAttributes(clientId, { content: html });
         },
         [store, clientId]
     );
 
-    const editor = useBlockTiptap({
-        clientId,
-        content,
-        topLevelNode: headingNode,
-        docContentSpec: 'heading',
-        onUpdate,
-        onEnter: () => {
-            if (!editor) {
-                return false;
-            }
-            return handleBlockEnter(store, clientId, editor);
-        },
-        onBackspaceAtStart: () => {
-            if (!editor) {
-                return false;
-            }
-            return handleBlockBackspace(store, clientId, editor);
-        },
-    });
-
-    useEffect(() => {
-        if (!editor || !isSelected) {
-            return;
-        }
-
-        const pending = takePendingCursor(clientId);
-
-        if (pending !== undefined) {
-            editor.commands.focus(pending);
-            return;
-        }
-
-        if (editor.isFocused) {
-            return;
-        }
-
-        const position = selectionEdge === 'start' ? 'start' : 'end';
-        editor.commands.focus(position);
-    }, [editor, isSelected, selectionEdge, clientId]);
-
-    useEffect(() => {
+    const onEnter = useCallback((): boolean => {
+        const editor = getBlockEditor(clientId);
         if (!editor) {
-            return;
+            return false;
         }
+        return handleBlockEnter(store, clientId, editor);
+    }, [store, clientId]);
 
-        const first = editor.state.doc.firstChild;
-
-        if (!first || first.type.name !== 'heading' || first.attrs.level === level) {
-            return;
+    const onBackspaceAtStart = useCallback((): boolean => {
+        const editor = getBlockEditor(clientId);
+        if (!editor) {
+            return false;
         }
-
-        editor.chain().setNode('heading', { level }).run();
-    }, [editor, level]);
+        return handleBlockBackspace(store, clientId, editor);
+    }, [store, clientId]);
 
     return (
-        <EditorContent
-            editor={editor}
-            data-block-name={HEADING_BLOCK_NAME}
-            data-heading-level={level}
+        <RichText
+            clientId={clientId}
+            tagName={`h${level}`}
+            value={content}
+            onChange={onChange}
+            onEnter={onEnter}
+            onBackspaceAtStart={onBackspaceAtStart}
+            blockName={HEADING_BLOCK_NAME}
             className="ve-block-heading"
         />
     );

--- a/resources/js/visual-editor/editor/blocks/heading/index.ts
+++ b/resources/js/visual-editor/editor/blocks/heading/index.ts
@@ -1,16 +1,21 @@
-import { registerBlock } from '../../registry';
-import HeadingEdit, {
-    HEADING_BLOCK_NAME,
-    HEADING_LEVELS,
-    normalizeHeadingLevel,
-} from './edit';
+import { registerBlockType, type BlockJsonMetadata } from '../../registry';
+import rawMetadata from './block.json';
+import HeadingEdit, { HEADING_LEVELS, normalizeHeadingLevel } from './edit';
+
+const metadata = rawMetadata as unknown as BlockJsonMetadata;
+
+export const HEADING_BLOCK_NAME = metadata.name;
 
 export function registerHeadingBlock(): void {
-    registerBlock({
-        name: HEADING_BLOCK_NAME,
+    registerBlockType(metadata, {
         edit: HeadingEdit,
+        factory: () => ({
+            name: HEADING_BLOCK_NAME,
+            attributes: { level: 2, content: '<h2></h2>' },
+            innerBlocks: [],
+        }),
     });
 }
 
-export { HEADING_BLOCK_NAME, HEADING_LEVELS, normalizeHeadingLevel };
+export { HEADING_LEVELS, normalizeHeadingLevel };
 export { default as HeadingEdit } from './edit';

--- a/resources/js/visual-editor/editor/blocks/index.ts
+++ b/resources/js/visual-editor/editor/blocks/index.ts
@@ -1,5 +1,9 @@
 import { registerParagraphBlock } from './paragraph';
 import { registerHeadingBlock } from './heading';
+import { registerListBlock } from './list';
+import { registerQuoteBlock } from './quote';
+import { registerCodeBlock } from './code';
+import { registerPreformattedBlock } from './preformatted';
 
 export { registerParagraphBlock, PARAGRAPH_BLOCK_NAME, ParagraphEdit } from './paragraph';
 export {
@@ -9,8 +13,31 @@ export {
     HeadingEdit,
     normalizeHeadingLevel,
 } from './heading';
+export {
+    registerListBlock,
+    LIST_BLOCK_NAME,
+    ListEdit,
+    normalizeOrdered,
+} from './list';
+export { registerQuoteBlock, QUOTE_BLOCK_NAME, QuoteEdit } from './quote';
+export {
+    registerCodeBlock,
+    CODE_BLOCK_NAME,
+    CODE_LANGUAGES,
+    CodeEdit,
+    normalizeLanguage,
+} from './code';
+export {
+    registerPreformattedBlock,
+    PREFORMATTED_BLOCK_NAME,
+    PreformattedEdit,
+} from './preformatted';
 
 export function registerCoreBlocks(): void {
     registerParagraphBlock();
     registerHeadingBlock();
+    registerListBlock();
+    registerQuoteBlock();
+    registerCodeBlock();
+    registerPreformattedBlock();
 }

--- a/resources/js/visual-editor/editor/blocks/list/block.json
+++ b/resources/js/visual-editor/editor/blocks/list/block.json
@@ -1,0 +1,36 @@
+{
+    "apiVersion": 1,
+    "name": "artisanpack/list",
+    "title": "List",
+    "category": "text",
+    "description": "Create a bulleted or numbered list.",
+    "keywords": ["ul", "ol", "bullet", "numbered", "ordered", "unordered"],
+    "textdomain": "visual-editor",
+    "attributes": {
+        "ordered": {
+            "type": "boolean",
+            "default": false
+        },
+        "content": {
+            "type": "string",
+            "default": ""
+        }
+    },
+    "supports": {
+        "anchor": true,
+        "className": true,
+        "color": {
+            "background": true,
+            "text": true,
+            "link": true
+        },
+        "spacing": {
+            "margin": true,
+            "padding": true
+        },
+        "typography": {
+            "fontSize": true,
+            "lineHeight": true
+        }
+    }
+}

--- a/resources/js/visual-editor/editor/blocks/list/block.json
+++ b/resources/js/visual-editor/editor/blocks/list/block.json
@@ -12,7 +12,10 @@
             "default": false
         },
         "content": {
-            "type": "string",
+            "type": "rich-text",
+            "source": "rich-text",
+            "selector": "ul,ol",
+            "role": "content",
             "default": ""
         }
     },

--- a/resources/js/visual-editor/editor/blocks/list/edit.tsx
+++ b/resources/js/visual-editor/editor/blocks/list/edit.tsx
@@ -1,0 +1,179 @@
+import { useCallback, useEffect, useMemo } from 'react';
+import { EditorContent } from '@tiptap/react';
+import { useStore } from 'zustand';
+import Paragraph from '@tiptap/extension-paragraph';
+import BulletList from '@tiptap/extension-bullet-list';
+import OrderedList from '@tiptap/extension-ordered-list';
+import ListItem from '@tiptap/extension-list-item';
+import type { BlockEditProps } from '../../registry';
+import { useEditorStore } from '../../primitives';
+import { useBlockTiptap } from '../shared/useBlockTiptap';
+import { takePendingCursor, getBlockEditor } from '../shared/blockEditorRegistry';
+import { createClientId, type Block } from '../../store';
+import { PARAGRAPH_BLOCK_NAME } from '../paragraph';
+
+import metadata from './block.json';
+
+export const LIST_BLOCK_NAME = metadata.name;
+
+export function normalizeOrdered(value: unknown): boolean {
+    return value === true;
+}
+
+function wrapListContent(innerHtml: string, ordered: boolean): string {
+    const tag = ordered ? 'ol' : 'ul';
+    return `<${tag}>${innerHtml}</${tag}>`;
+}
+
+function extractListInner(html: string): string {
+    const match = html.match(/^<(?:ul|ol)[^>]*>([\s\S]*)<\/(?:ul|ol)>$/);
+    return match ? match[1] : html;
+}
+
+function ensureListContent(content: string, ordered: boolean): string {
+    const trimmed = content.trim();
+    if (trimmed.length === 0) {
+        return wrapListContent('<li><p></p></li>', ordered);
+    }
+    const inner = extractListInner(trimmed);
+    return wrapListContent(inner, ordered);
+}
+
+interface ResolvedPosLike {
+    depth: number;
+    node: (depth: number) => { type: { name: string }; textContent: string };
+}
+
+function findListItemDepth($pos: ResolvedPosLike): number | null {
+    for (let depth = $pos.depth; depth > 0; depth--) {
+        if ($pos.node(depth).type.name === 'listItem') {
+            return depth;
+        }
+    }
+    return null;
+}
+
+const LIST_EXTENSIONS = [OrderedList, ListItem, Paragraph];
+
+export default function ListEdit({ clientId, attributes }: BlockEditProps) {
+    const store = useEditorStore();
+    const ordered = normalizeOrdered(attributes.ordered);
+    const content = useMemo(
+        () => ensureListContent(
+            typeof attributes.content === 'string' ? attributes.content : '',
+            ordered
+        ),
+        [attributes.content, ordered]
+    );
+    const isSelected = useStore(
+        store,
+        (state) => state.selection.clientId === clientId
+    );
+    const selectionEdge = useStore(
+        store,
+        (state) => (state.selection.clientId === clientId ? state.selection.edge : undefined)
+    );
+
+    const onUpdate = useCallback(
+        (html: string) => {
+            store.getState().updateBlockAttributes(clientId, { content: html });
+        },
+        [store, clientId]
+    );
+
+    const onEnter = useCallback((): boolean => {
+        const activeEditor = getBlockEditor(clientId);
+        if (!activeEditor) {
+            return false;
+        }
+
+        const { $from } = activeEditor.state.selection;
+        const listItemDepth = findListItemDepth($from);
+
+        if (listItemDepth === null) {
+            return false;
+        }
+
+        const listItemNode = $from.node(listItemDepth);
+
+        if (listItemNode.textContent.length > 0) {
+            return false;
+        }
+
+        const state = store.getState();
+        const index = state.blocks.findIndex((b) => b.clientId === clientId);
+
+        if (index === -1) {
+            return false;
+        }
+
+        const newBlock: Block = {
+            clientId: createClientId(),
+            name: PARAGRAPH_BLOCK_NAME,
+            attributes: { content: '<p></p>' },
+            innerBlocks: [],
+        };
+
+        const nextBlocks = state.blocks.slice();
+        nextBlocks.splice(index + 1, 0, newBlock);
+        state.replaceBlocks(nextBlocks);
+        state.select(newBlock.clientId, 'start');
+
+        return true;
+    }, [store, clientId]);
+
+    const editor = useBlockTiptap({
+        clientId,
+        content,
+        topLevelNode: BulletList,
+        docContentSpec: 'bulletList | orderedList',
+        onUpdate,
+        onEnter,
+        onBackspaceAtStart: () => false,
+        extraExtensions: LIST_EXTENSIONS,
+    });
+
+    useEffect(() => {
+        if (!editor || !isSelected) {
+            return;
+        }
+
+        const pending = takePendingCursor(clientId);
+
+        if (pending !== undefined) {
+            editor.commands.focus(pending);
+            return;
+        }
+
+        if (editor.isFocused) {
+            return;
+        }
+
+        const position = selectionEdge === 'start' ? 'start' : 'end';
+        editor.commands.focus(position);
+    }, [editor, isSelected, selectionEdge, clientId]);
+
+    useEffect(() => {
+        if (!editor) {
+            return;
+        }
+
+        const first = editor.state.doc.firstChild;
+        const expectedType = ordered ? 'orderedList' : 'bulletList';
+
+        if (!first || first.type.name === expectedType) {
+            return;
+        }
+
+        editor.commands.toggleList(expectedType, 'listItem');
+    }, [editor, ordered]);
+
+    return (
+        <EditorContent
+            editor={editor}
+            data-block-name={LIST_BLOCK_NAME}
+            data-list-ordered={ordered ? 'true' : 'false'}
+            className="ve-block-list"
+        />
+    );
+}

--- a/resources/js/visual-editor/editor/blocks/list/edit.tsx
+++ b/resources/js/visual-editor/editor/blocks/list/edit.tsx
@@ -100,6 +100,17 @@ export default function ListEdit({ clientId, attributes }: BlockEditProps) {
             return false;
         }
 
+        // Delete the empty list item from the ProseMirror document before
+        // creating the new paragraph block below.
+        const listItemStart = $from.before(listItemDepth);
+        const listItemEnd = $from.after(listItemDepth);
+        const tr = activeEditor.state.tr.delete(listItemStart, listItemEnd);
+        activeEditor.view.dispatch(tr);
+
+        // Persist the trimmed list HTML back to the store attribute.
+        const updatedHtml = activeEditor.getHTML();
+        store.getState().updateBlockAttributes(clientId, { content: updatedHtml });
+
         const state = store.getState();
         const index = state.blocks.findIndex((b) => b.clientId === clientId);
 

--- a/resources/js/visual-editor/editor/blocks/list/index.ts
+++ b/resources/js/visual-editor/editor/blocks/list/index.ts
@@ -1,0 +1,20 @@
+import { registerBlockType, type BlockJsonMetadata } from '../../registry';
+import rawMetadata from './block.json';
+import ListEdit, { LIST_BLOCK_NAME } from './edit';
+
+const metadata = rawMetadata as unknown as BlockJsonMetadata;
+
+export function registerListBlock(): void {
+    registerBlockType(metadata, {
+        edit: ListEdit,
+        factory: () => ({
+            name: LIST_BLOCK_NAME,
+            attributes: { ordered: false, content: '<ul><li><p></p></li></ul>' },
+            innerBlocks: [],
+        }),
+    });
+}
+
+export { LIST_BLOCK_NAME };
+export { normalizeOrdered } from './edit';
+export { default as ListEdit } from './edit';

--- a/resources/js/visual-editor/editor/blocks/paragraph/block.json
+++ b/resources/js/visual-editor/editor/blocks/paragraph/block.json
@@ -1,0 +1,53 @@
+{
+    "apiVersion": 1,
+    "name": "artisanpack/paragraph",
+    "title": "Paragraph",
+    "category": "text",
+    "description": "Start with the basic building block of all narrative.",
+    "keywords": ["text", "body", "p"],
+    "textdomain": "visual-editor",
+    "attributes": {
+        "content": {
+            "type": "rich-text",
+            "source": "rich-text",
+            "selector": "p",
+            "role": "content",
+            "default": ""
+        }
+    },
+    "supports": {
+        "splitting": true,
+        "anchor": true,
+        "className": true,
+        "color": {
+            "background": true,
+            "text": true,
+            "gradients": true,
+            "link": true
+        },
+        "spacing": {
+            "margin": true,
+            "padding": true
+        },
+        "typography": {
+            "fontSize": true,
+            "lineHeight": true,
+            "textAlign": true,
+            "fontFamily": true,
+            "fontStyle": true,
+            "fontWeight": true,
+            "letterSpacing": true,
+            "textDecoration": true,
+            "textTransform": true
+        },
+        "border": {
+            "color": true,
+            "radius": true,
+            "style": true,
+            "width": true
+        }
+    },
+    "selectors": {
+        "root": "p"
+    }
+}

--- a/resources/js/visual-editor/editor/blocks/paragraph/edit.tsx
+++ b/resources/js/visual-editor/editor/blocks/paragraph/edit.tsx
@@ -6,14 +6,10 @@ import {
     useState,
     useSyncExternalStore,
 } from 'react';
-import { EditorContent } from '@tiptap/react';
-import { useStore } from 'zustand';
-import Paragraph from '@tiptap/extension-paragraph';
 import type { BlockEditProps } from '../../registry';
-import { useEditorStore } from '../../primitives';
-import { useBlockTiptap } from '../shared/useBlockTiptap';
+import { useEditorStore, RichText } from '../../primitives';
 import { handleBlockBackspace, handleBlockEnter } from '../shared/blockSplitMerge';
-import { takePendingCursor } from '../shared/blockEditorRegistry';
+import { getBlockEditor } from '../shared/blockEditorRegistry';
 import {
     filterInserterBlocks,
     getInserterBlocks,
@@ -23,7 +19,9 @@ import {
 } from '../../inserter';
 import { SlashCommandPopover } from '../../components/SlashCommandPopover';
 
-export const PARAGRAPH_BLOCK_NAME = 've/paragraph';
+import metadata from './block.json';
+
+export const PARAGRAPH_BLOCK_NAME = metadata.name;
 
 const SLASH_PLAINTEXT_REGEX = /^\/(.*)$/;
 
@@ -51,14 +49,6 @@ function detectSlashQuery(html: string): string | null {
 export default function ParagraphEdit({ clientId, attributes }: BlockEditProps) {
     const store = useEditorStore();
     const content = typeof attributes.content === 'string' ? attributes.content : '';
-    const isSelected = useStore(
-        store,
-        (state) => state.selection.clientId === clientId
-    );
-    const selectionEdge = useStore(
-        store,
-        (state) => (state.selection.clientId === clientId ? state.selection.edge : undefined)
-    );
 
     const [slashQuery, setSlashQuery] = useState<string | null>(null);
     const [slashIndex, setSlashIndex] = useState(0);
@@ -82,7 +72,7 @@ export default function ParagraphEdit({ clientId, attributes }: BlockEditProps) 
     filteredRef.current = filteredSlashBlocks;
     slashIndexRef.current = slashIndex;
 
-    const onUpdate = useCallback(
+    const onChange = useCallback(
         (html: string) => {
             store.getState().updateBlockAttributes(clientId, { content: html });
             setSlashQuery(detectSlashQuery(html));
@@ -108,54 +98,30 @@ export default function ParagraphEdit({ clientId, attributes }: BlockEditProps) 
         [selectSlashBlock]
     );
 
-    const editor = useBlockTiptap({
-        clientId,
-        content,
-        topLevelNode: Paragraph,
-        docContentSpec: 'paragraph',
-        onUpdate,
-        onEnter: () => {
-            if (slashActiveRef.current) {
-                if (filteredRef.current.length > 0) {
-                    selectSlashBlockAtIndex(slashIndexRef.current);
-                }
-                return true;
+    const onEnter = useCallback((): boolean => {
+        if (slashActiveRef.current) {
+            if (filteredRef.current.length > 0) {
+                selectSlashBlockAtIndex(slashIndexRef.current);
             }
-            if (!editor) {
-                return false;
-            }
-            return handleBlockEnter(store, clientId, editor);
-        },
-        onBackspaceAtStart: () => {
-            if (slashActiveRef.current) {
-                return false;
-            }
-            if (!editor) {
-                return false;
-            }
-            return handleBlockBackspace(store, clientId, editor);
-        },
-    });
-
-    useEffect(() => {
-        if (!editor || !isSelected) {
-            return;
+            return true;
         }
-
-        const pending = takePendingCursor(clientId);
-
-        if (pending !== undefined) {
-            editor.commands.focus(pending);
-            return;
+        const editor = getBlockEditor(clientId);
+        if (!editor) {
+            return false;
         }
+        return handleBlockEnter(store, clientId, editor);
+    }, [store, clientId, selectSlashBlockAtIndex]);
 
-        if (editor.isFocused) {
-            return;
+    const onBackspaceAtStart = useCallback((): boolean => {
+        if (slashActiveRef.current) {
+            return false;
         }
-
-        const position = selectionEdge === 'start' ? 'start' : 'end';
-        editor.commands.focus(position);
-    }, [editor, isSelected, selectionEdge, clientId]);
+        const editor = getBlockEditor(clientId);
+        if (!editor) {
+            return false;
+        }
+        return handleBlockBackspace(store, clientId, editor);
+    }, [store, clientId]);
 
     useEffect(() => {
         setSlashIndex((current) => {
@@ -167,6 +133,7 @@ export default function ParagraphEdit({ clientId, attributes }: BlockEditProps) 
     }, [filteredSlashBlocks]);
 
     useEffect(() => {
+        const editor = getBlockEditor(clientId);
         if (!editor) {
             return;
         }
@@ -180,7 +147,7 @@ export default function ParagraphEdit({ clientId, attributes }: BlockEditProps) 
         return () => {
             editor.off('blur', onBlur);
         };
-    }, [editor]);
+    }, [clientId]);
 
     useEffect(() => {
         if (slashQuery === null) {
@@ -219,9 +186,14 @@ export default function ParagraphEdit({ clientId, attributes }: BlockEditProps) 
 
     return (
         <div className="ve-block-paragraph-wrapper">
-            <EditorContent
-                editor={editor}
-                data-block-name={PARAGRAPH_BLOCK_NAME}
+            <RichText
+                clientId={clientId}
+                tagName="p"
+                value={content}
+                onChange={onChange}
+                onEnter={onEnter}
+                onBackspaceAtStart={onBackspaceAtStart}
+                blockName={PARAGRAPH_BLOCK_NAME}
                 className="ve-block-paragraph"
             />
             {slashQuery !== null ? (

--- a/resources/js/visual-editor/editor/blocks/paragraph/edit.tsx
+++ b/resources/js/visual-editor/editor/blocks/paragraph/edit.tsx
@@ -9,7 +9,7 @@ import {
 import type { BlockEditProps } from '../../registry';
 import { useEditorStore, RichText } from '../../primitives';
 import { handleBlockBackspace, handleBlockEnter } from '../shared/blockSplitMerge';
-import { getBlockEditor } from '../shared/blockEditorRegistry';
+import { getBlockEditor, subscribeBlockEditors } from '../shared/blockEditorRegistry';
 import {
     filterInserterBlocks,
     getInserterBlocks,
@@ -133,8 +133,13 @@ export default function ParagraphEdit({ clientId, attributes }: BlockEditProps) 
         });
     }, [filteredSlashBlocks]);
 
+    const editor = useSyncExternalStore(
+        subscribeBlockEditors,
+        () => getBlockEditor(clientId),
+        () => null
+    );
+
     useEffect(() => {
-        const editor = getBlockEditor(clientId);
         if (!editor) {
             return;
         }
@@ -148,7 +153,7 @@ export default function ParagraphEdit({ clientId, attributes }: BlockEditProps) 
         return () => {
             editor.off('blur', onBlur);
         };
-    }, [clientId]);
+    }, [editor]);
 
     useEffect(() => {
         if (slashQuery === null) {

--- a/resources/js/visual-editor/editor/blocks/paragraph/edit.tsx
+++ b/resources/js/visual-editor/editor/blocks/paragraph/edit.tsx
@@ -102,8 +102,9 @@ export default function ParagraphEdit({ clientId, attributes }: BlockEditProps) 
         if (slashActiveRef.current) {
             if (filteredRef.current.length > 0) {
                 selectSlashBlockAtIndex(slashIndexRef.current);
+                return true;
             }
-            return true;
+            return false;
         }
         const editor = getBlockEditor(clientId);
         if (!editor) {

--- a/resources/js/visual-editor/editor/blocks/paragraph/index.ts
+++ b/resources/js/visual-editor/editor/blocks/paragraph/index.ts
@@ -1,12 +1,20 @@
-import { registerBlock } from '../../registry';
-import ParagraphEdit, { PARAGRAPH_BLOCK_NAME } from './edit';
+import { registerBlockType, type BlockJsonMetadata } from '../../registry';
+import rawMetadata from './block.json';
+import ParagraphEdit from './edit';
+
+const metadata = rawMetadata as unknown as BlockJsonMetadata;
+
+export const PARAGRAPH_BLOCK_NAME = metadata.name;
 
 export function registerParagraphBlock(): void {
-    registerBlock({
-        name: PARAGRAPH_BLOCK_NAME,
+    registerBlockType(metadata, {
         edit: ParagraphEdit,
+        factory: () => ({
+            name: PARAGRAPH_BLOCK_NAME,
+            attributes: { content: '<p></p>' },
+            innerBlocks: [],
+        }),
     });
 }
 
-export { PARAGRAPH_BLOCK_NAME };
 export { default as ParagraphEdit } from './edit';

--- a/resources/js/visual-editor/editor/blocks/preformatted/block.json
+++ b/resources/js/visual-editor/editor/blocks/preformatted/block.json
@@ -1,0 +1,34 @@
+{
+    "apiVersion": 1,
+    "name": "artisanpack/preformatted",
+    "title": "Preformatted",
+    "category": "text",
+    "description": "Preserve whitespace and line breaks in a monospaced block.",
+    "keywords": ["pre", "ascii", "whitespace"],
+    "textdomain": "visual-editor",
+    "attributes": {
+        "content": {
+            "type": "rich-text",
+            "source": "rich-text",
+            "selector": "pre",
+            "role": "content",
+            "default": ""
+        }
+    },
+    "supports": {
+        "anchor": true,
+        "className": true,
+        "color": {
+            "background": true,
+            "text": true
+        },
+        "spacing": {
+            "margin": true,
+            "padding": true
+        },
+        "typography": {
+            "fontSize": true,
+            "lineHeight": true
+        }
+    }
+}

--- a/resources/js/visual-editor/editor/blocks/preformatted/edit.tsx
+++ b/resources/js/visual-editor/editor/blocks/preformatted/edit.tsx
@@ -1,0 +1,49 @@
+import { useCallback } from 'react';
+import { Node } from '@tiptap/core';
+import type { BlockEditProps } from '../../registry';
+import { useEditorStore, RichText } from '../../primitives';
+
+import metadata from './block.json';
+
+export const PREFORMATTED_BLOCK_NAME = metadata.name;
+
+export const PreformattedNode = Node.create({
+    name: 'preformatted',
+    group: 'block',
+    content: 'inline*',
+    marks: 'bold italic link',
+    defining: true,
+    code: true,
+    parseHTML() {
+        return [{ tag: 'pre' }];
+    },
+    renderHTML({ HTMLAttributes }) {
+        return ['pre', HTMLAttributes, 0];
+    },
+});
+
+const PRE_EXTENSIONS = [PreformattedNode];
+
+export default function PreformattedEdit({ clientId, attributes }: BlockEditProps) {
+    const store = useEditorStore();
+    const content = typeof attributes.content === 'string' ? attributes.content : '';
+
+    const onChange = useCallback(
+        (html: string) => {
+            store.getState().updateBlockAttributes(clientId, { content: html });
+        },
+        [store, clientId]
+    );
+
+    return (
+        <RichText
+            clientId={clientId}
+            tagName="preformatted"
+            value={content}
+            onChange={onChange}
+            blockName={PREFORMATTED_BLOCK_NAME}
+            className="ve-block-preformatted"
+            extraExtensions={PRE_EXTENSIONS}
+        />
+    );
+}

--- a/resources/js/visual-editor/editor/blocks/preformatted/index.ts
+++ b/resources/js/visual-editor/editor/blocks/preformatted/index.ts
@@ -1,0 +1,19 @@
+import { registerBlockType, type BlockJsonMetadata } from '../../registry';
+import rawMetadata from './block.json';
+import PreformattedEdit, { PREFORMATTED_BLOCK_NAME } from './edit';
+
+const metadata = rawMetadata as unknown as BlockJsonMetadata;
+
+export function registerPreformattedBlock(): void {
+    registerBlockType(metadata, {
+        edit: PreformattedEdit,
+        factory: () => ({
+            name: PREFORMATTED_BLOCK_NAME,
+            attributes: { content: '<pre></pre>' },
+            innerBlocks: [],
+        }),
+    });
+}
+
+export { PREFORMATTED_BLOCK_NAME };
+export { default as PreformattedEdit } from './edit';

--- a/resources/js/visual-editor/editor/blocks/quote/block.json
+++ b/resources/js/visual-editor/editor/blocks/quote/block.json
@@ -1,0 +1,49 @@
+{
+    "apiVersion": 1,
+    "name": "artisanpack/quote",
+    "title": "Quote",
+    "category": "text",
+    "description": "Give quoted text visual emphasis.",
+    "keywords": ["blockquote", "citation", "pullquote"],
+    "textdomain": "visual-editor",
+    "attributes": {
+        "content": {
+            "type": "rich-text",
+            "source": "rich-text",
+            "selector": "blockquote",
+            "role": "content",
+            "default": ""
+        },
+        "citation": {
+            "type": "string",
+            "default": ""
+        }
+    },
+    "supports": {
+        "anchor": true,
+        "className": true,
+        "color": {
+            "background": true,
+            "text": true,
+            "link": true
+        },
+        "spacing": {
+            "margin": true,
+            "padding": true
+        },
+        "typography": {
+            "fontSize": true,
+            "lineHeight": true
+        },
+        "border": {
+            "color": true,
+            "radius": true,
+            "style": true,
+            "width": true
+        }
+    },
+    "styles": [
+        { "name": "default", "label": "Default", "isDefault": true },
+        { "name": "plain", "label": "Plain" }
+    ]
+}

--- a/resources/js/visual-editor/editor/blocks/quote/edit.tsx
+++ b/resources/js/visual-editor/editor/blocks/quote/edit.tsx
@@ -1,0 +1,55 @@
+import { type ChangeEvent, useCallback } from 'react';
+import Blockquote from '@tiptap/extension-blockquote';
+import Paragraph from '@tiptap/extension-paragraph';
+import type { BlockEditProps } from '../../registry';
+import { useEditorStore, RichText } from '../../primitives';
+
+import metadata from './block.json';
+
+export const QUOTE_BLOCK_NAME = metadata.name;
+
+const QUOTE_EXTRA_EXTENSIONS = [Blockquote, Paragraph];
+
+export default function QuoteEdit({ clientId, attributes }: BlockEditProps) {
+    const store = useEditorStore();
+    const content = typeof attributes.content === 'string' ? attributes.content : '';
+    const citation = typeof attributes.citation === 'string' ? attributes.citation : '';
+
+    const onChange = useCallback(
+        (html: string) => {
+            store.getState().updateBlockAttributes(clientId, { content: html });
+        },
+        [store, clientId]
+    );
+
+    const onCitationChange = useCallback(
+        (event: ChangeEvent<HTMLInputElement>) => {
+            store
+                .getState()
+                .updateBlockAttributes(clientId, { citation: event.target.value });
+        },
+        [store, clientId]
+    );
+
+    return (
+        <div className="ve-block-quote-wrapper" data-block-name={QUOTE_BLOCK_NAME}>
+            <RichText
+                clientId={clientId}
+                tagName="blockquote"
+                value={content}
+                onChange={onChange}
+                className="ve-block-quote"
+                extraExtensions={QUOTE_EXTRA_EXTENSIONS}
+            />
+            <input
+                type="text"
+                className="ve-block-quote__citation"
+                value={citation}
+                placeholder="Add citation..."
+                aria-label="Citation"
+                data-testid="ve-quote-citation"
+                onChange={onCitationChange}
+            />
+        </div>
+    );
+}

--- a/resources/js/visual-editor/editor/blocks/quote/index.ts
+++ b/resources/js/visual-editor/editor/blocks/quote/index.ts
@@ -1,0 +1,19 @@
+import { registerBlockType, type BlockJsonMetadata } from '../../registry';
+import rawMetadata from './block.json';
+import QuoteEdit, { QUOTE_BLOCK_NAME } from './edit';
+
+const metadata = rawMetadata as unknown as BlockJsonMetadata;
+
+export function registerQuoteBlock(): void {
+    registerBlockType(metadata, {
+        edit: QuoteEdit,
+        factory: () => ({
+            name: QUOTE_BLOCK_NAME,
+            attributes: { content: '<blockquote><p></p></blockquote>', citation: '' },
+            innerBlocks: [],
+        }),
+    });
+}
+
+export { QUOTE_BLOCK_NAME };
+export { default as QuoteEdit } from './edit';

--- a/resources/js/visual-editor/editor/blocks/shared/blockSplitMerge.ts
+++ b/resources/js/visual-editor/editor/blocks/shared/blockSplitMerge.ts
@@ -3,8 +3,8 @@ import type { Block, EditorStore } from '../../store';
 import { createClientId } from '../../store';
 import { splitAtCursor, isCursorAtStart } from './splitContent';
 import { getBlockEditor, setPendingCursor } from './blockEditorRegistry';
-
-const TEXT_BLOCK_NAMES = new Set<string>(['ve/paragraph', 've/heading']);
+import { blockSupports } from '../../registry';
+import { PARAGRAPH_BLOCK_NAME } from '../paragraph';
 
 function findTopLevelIndex(blocks: Block[], clientId: string): number {
     return blocks.findIndex((block) => block.clientId === clientId);
@@ -33,7 +33,7 @@ export function handleBlockEnter(
 
     const newBlock: Block = {
         clientId: createClientId(),
-        name: 've/paragraph',
+        name: PARAGRAPH_BLOCK_NAME,
         attributes: { content: rightHtml },
         innerBlocks: [],
     };
@@ -78,7 +78,7 @@ export function handleBlockBackspace(
 
     const previousBlock = state.blocks[topLevelIndex - 1];
 
-    if (!TEXT_BLOCK_NAMES.has(previousBlock.name)) {
+    if (!blockSupports(previousBlock.name, 'splitting')) {
         return false;
     }
 

--- a/resources/js/visual-editor/editor/blocks/shared/blockSplitMerge.ts
+++ b/resources/js/visual-editor/editor/blocks/shared/blockSplitMerge.ts
@@ -4,7 +4,7 @@ import { createClientId } from '../../store';
 import { splitAtCursor, isCursorAtStart } from './splitContent';
 import { getBlockEditor, setPendingCursor } from './blockEditorRegistry';
 import { blockSupports } from '../../registry';
-import { PARAGRAPH_BLOCK_NAME } from '../paragraph';
+import paragraphMetadata from '../paragraph/block.json';
 
 function findTopLevelIndex(blocks: Block[], clientId: string): number {
     return blocks.findIndex((block) => block.clientId === clientId);
@@ -33,7 +33,7 @@ export function handleBlockEnter(
 
     const newBlock: Block = {
         clientId: createClientId(),
-        name: PARAGRAPH_BLOCK_NAME,
+        name: paragraphMetadata.name,
         attributes: { content: rightHtml },
         innerBlocks: [],
     };

--- a/resources/js/visual-editor/editor/components/RichTextToolbar.tsx
+++ b/resources/js/visual-editor/editor/components/RichTextToolbar.tsx
@@ -9,18 +9,24 @@ import {
 } from 'react';
 import { useStore } from 'zustand';
 import type { Editor } from '@tiptap/react';
-import { faBold, faItalic, faLink } from '@fortawesome/free-solid-svg-icons';
+import {
+    faBold,
+    faItalic,
+    faLink,
+    faListOl,
+    faListUl,
+} from '@fortawesome/free-solid-svg-icons';
 import { useEditorStore } from '../primitives';
 import {
     getBlockEditor,
     subscribeBlockEditors,
 } from '../blocks/shared/blockEditorRegistry';
+import { getBlock } from '../registry';
 import {
-    HEADING_BLOCK_NAME,
     HEADING_LEVELS,
     normalizeHeadingLevel,
 } from '../blocks/heading';
-import { PARAGRAPH_BLOCK_NAME } from '../blocks/paragraph';
+import { normalizeOrdered } from '../blocks/list';
 import { Icon } from './Icon';
 
 export interface RichTextToolbarProps {
@@ -47,11 +53,12 @@ export function RichTextToolbar({ className }: RichTextToolbarProps) {
         return null;
     }
 
-    if (block.name !== PARAGRAPH_BLOCK_NAME && block.name !== HEADING_BLOCK_NAME) {
-        return null;
-    }
+    // Show toolbar for any block that has a Tiptap editor registered
+    // (i.e. it's a rich-text block). No hardcoded block name checks.
 
-    const isHeading = block.name === HEADING_BLOCK_NAME;
+    const blockDefinition = getBlock(block.name);
+    const hasLevelAttribute = blockDefinition?.attributes?.level !== undefined;
+    const hasOrderedAttribute = blockDefinition?.attributes?.ordered !== undefined;
 
     return (
         <div
@@ -60,10 +67,16 @@ export function RichTextToolbar({ className }: RichTextToolbarProps) {
             aria-label="Text formatting"
             data-ve-rich-text-toolbar=""
         >
-            {isHeading ? (
+            {hasLevelAttribute ? (
                 <HeadingLevelSwitcher
                     clientId={block.clientId}
                     level={normalizeHeadingLevel(block.attributes.level)}
+                />
+            ) : null}
+            {hasOrderedAttribute ? (
+                <ListTypeSwitcher
+                    clientId={block.clientId}
+                    ordered={normalizeOrdered(block.attributes.ordered)}
                 />
             ) : null}
             <ToolbarButton
@@ -114,6 +127,40 @@ function HeadingLevelSwitcher({ clientId, level }: HeadingLevelSwitcherProps) {
                 ))}
             </select>
         </label>
+    );
+}
+
+interface ListTypeSwitcherProps {
+    clientId: string;
+    ordered: boolean;
+}
+
+function ListTypeSwitcher({ clientId, ordered }: ListTypeSwitcherProps) {
+    const store = useEditorStore();
+
+    return (
+        <div className="ve-rich-text-toolbar__list-type" role="group" aria-label="List type">
+            <ToolbarButton
+                label="Bulleted list"
+                isActive={!ordered}
+                onClick={() => {
+                    store.getState().updateBlockAttributes(clientId, { ordered: false });
+                }}
+                testId="ve-toolbar-list-unordered"
+            >
+                <Icon icon={faListUl} />
+            </ToolbarButton>
+            <ToolbarButton
+                label="Numbered list"
+                isActive={ordered}
+                onClick={() => {
+                    store.getState().updateBlockAttributes(clientId, { ordered: true });
+                }}
+                testId="ve-toolbar-list-ordered"
+            >
+                <Icon icon={faListOl} />
+            </ToolbarButton>
+        </div>
     );
 }
 

--- a/resources/js/visual-editor/editor/components/RichTextToolbar.tsx
+++ b/resources/js/visual-editor/editor/components/RichTextToolbar.tsx
@@ -57,8 +57,10 @@ export function RichTextToolbar({ className }: RichTextToolbarProps) {
     // (i.e. it's a rich-text block). No hardcoded block name checks.
 
     const blockDefinition = getBlock(block.name);
-    const hasLevelAttribute = blockDefinition?.attributes?.level !== undefined;
-    const hasOrderedAttribute = blockDefinition?.attributes?.ordered !== undefined;
+    const levelSchema = blockDefinition?.attributes?.level;
+    const orderedSchema = blockDefinition?.attributes?.ordered;
+    const hasLevelAttribute = levelSchema !== undefined && levelSchema.type === 'number';
+    const hasOrderedAttribute = orderedSchema !== undefined && orderedSchema.type === 'boolean';
 
     return (
         <div

--- a/resources/js/visual-editor/editor/components/__tests__/InserterPanel.test.tsx
+++ b/resources/js/visual-editor/editor/components/__tests__/InserterPanel.test.tsx
@@ -1,17 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import { EditorStoreProvider } from '../../primitives';
+import { clearRegistry } from '../../registry';
 import { createEditorStore, type Block, type EditorStore } from '../../store';
 import { InserterPanel } from '../InserterPanel';
-import {
-    clearInserterRegistry,
-    registerBuiltinInserterBlocks,
-} from '../../inserter';
+import { clearInserterRegistry } from '../../inserter';
+import { registerCoreBlocks, PARAGRAPH_BLOCK_NAME, HEADING_BLOCK_NAME } from '../../blocks';
 
 function paragraph(clientId: string, content: string): Block {
     return {
         clientId,
-        name: 've/paragraph',
+        name: PARAGRAPH_BLOCK_NAME,
         attributes: { content },
         innerBlocks: [],
     };
@@ -26,11 +25,13 @@ function renderPanel(store: EditorStore) {
 }
 
 beforeEach(() => {
+    clearRegistry();
     clearInserterRegistry();
-    registerBuiltinInserterBlocks();
+    registerCoreBlocks();
 });
 
 afterEach(() => {
+    clearRegistry();
     clearInserterRegistry();
 });
 
@@ -40,8 +41,8 @@ describe('InserterPanel', () => {
 
         renderPanel(store);
 
-        expect(screen.getByTestId('ve-inserter-item-ve/paragraph')).toBeInTheDocument();
-        expect(screen.getByTestId('ve-inserter-item-ve/heading')).toBeInTheDocument();
+        expect(screen.getByTestId(`ve-inserter-item-${PARAGRAPH_BLOCK_NAME}`)).toBeInTheDocument();
+        expect(screen.getByTestId(`ve-inserter-item-${HEADING_BLOCK_NAME}`)).toBeInTheDocument();
     });
 
     it('filters the list by the search query', () => {
@@ -55,8 +56,8 @@ describe('InserterPanel', () => {
             fireEvent.change(search, { target: { value: 'head' } });
         });
 
-        expect(screen.queryByTestId('ve-inserter-item-ve/paragraph')).toBeNull();
-        expect(screen.getByTestId('ve-inserter-item-ve/heading')).toBeInTheDocument();
+        expect(screen.queryByTestId(`ve-inserter-item-${PARAGRAPH_BLOCK_NAME}`)).toBeNull();
+        expect(screen.getByTestId(`ve-inserter-item-${HEADING_BLOCK_NAME}`)).toBeInTheDocument();
     });
 
     it('shows an empty state when the query matches nothing', () => {
@@ -80,12 +81,12 @@ describe('InserterPanel', () => {
         renderPanel(store);
 
         act(() => {
-            fireEvent.click(screen.getByTestId('ve-inserter-item-ve/heading'));
+            fireEvent.click(screen.getByTestId(`ve-inserter-item-${HEADING_BLOCK_NAME}`));
         });
 
         const blocks = store.getState().blocks;
         expect(blocks).toHaveLength(2);
-        expect(blocks[1].name).toBe('ve/heading');
+        expect(blocks[1].name).toBe(HEADING_BLOCK_NAME);
         expect(store.getState().selection.clientId).toBe(blocks[1].clientId);
     });
 
@@ -95,11 +96,11 @@ describe('InserterPanel', () => {
         renderPanel(store);
 
         act(() => {
-            fireEvent.click(screen.getByTestId('ve-inserter-item-ve/paragraph'));
+            fireEvent.click(screen.getByTestId(`ve-inserter-item-${PARAGRAPH_BLOCK_NAME}`));
         });
 
         const blocks = store.getState().blocks;
         expect(blocks).toHaveLength(2);
-        expect(blocks[1].name).toBe('ve/paragraph');
+        expect(blocks[1].name).toBe(PARAGRAPH_BLOCK_NAME);
     });
 });

--- a/resources/js/visual-editor/editor/index.ts
+++ b/resources/js/visual-editor/editor/index.ts
@@ -1,0 +1,117 @@
+/**
+ * Public API for the ArtisanPack UI Visual Editor.
+ *
+ * External packages import from this module to register custom blocks
+ * and use editor primitives:
+ *
+ * ```ts
+ * import {
+ *     registerBlockType,
+ *     RichText,
+ *     InnerBlocks,
+ *     blockSupports,
+ * } from '@artisanpack-ui/visual-editor';
+ * ```
+ */
+
+// ---------------------------------------------------------------------------
+// Registry — block type registration and query
+// ---------------------------------------------------------------------------
+
+export {
+    registerBlockType,
+    registerBlock,
+    getBlock,
+    getRegisteredBlocks,
+    getRegisteredBlockNames,
+    unregisterBlock,
+    clearRegistry,
+    subscribeRegistry,
+    blockSupports,
+    getBlockSupport,
+} from './registry';
+
+export type {
+    BlockDefinition,
+    BlockEditProps,
+    BlockFactory,
+    BlockTypeSettings,
+    BlockJsonMetadata,
+    BlockSupports,
+    BlockAttributeSchema,
+    BlockStyle,
+    BlockVariation,
+    BlockExample,
+    TypographySupports,
+    ColorSupports,
+    SpacingSupports,
+    DimensionsSupports,
+    BorderSupports,
+    LayoutSupports,
+} from './registry';
+
+// ---------------------------------------------------------------------------
+// Primitives — React components for building block edit UIs
+// ---------------------------------------------------------------------------
+
+export { RichText } from './primitives';
+export type { RichTextProps } from './primitives';
+
+export {
+    InnerBlocks,
+    RenderBlock,
+    useInnerBlocksProps,
+} from './primitives';
+export type {
+    InnerBlocksElementProps,
+    UseInnerBlocksPropsOptions,
+    UseInnerBlocksPropsReturn,
+} from './primitives';
+
+export { EditorStoreProvider, useEditorStore, useOptionalEditorStore } from './primitives';
+export { ReadOnlyProvider, useReadOnly } from './primitives';
+
+export {
+    BlockContextProvider,
+    useBlockContext,
+    useBlockContextValue,
+} from './primitives';
+export type {
+    BlockContextValue,
+    BlockContextTypeGuard,
+} from './primitives';
+
+// ---------------------------------------------------------------------------
+// Store types — for advanced consumers
+// ---------------------------------------------------------------------------
+
+export type {
+    Block,
+    EditorStore,
+    EditorState,
+    EditorStoreState,
+    Selection,
+    SelectionEdge,
+    InsertLocation,
+    MoveLocation,
+} from './store';
+
+export { createClientId } from './store';
+
+// ---------------------------------------------------------------------------
+// Block editor registry — for blocks that need cross-block editor access
+// ---------------------------------------------------------------------------
+
+export {
+    getBlockEditor,
+    subscribeBlockEditors,
+} from './blocks/shared/blockEditorRegistry';
+
+// ---------------------------------------------------------------------------
+// Split/merge utilities — for blocks with splitting support
+// ---------------------------------------------------------------------------
+
+export {
+    handleBlockEnter,
+    handleBlockBackspace,
+} from './blocks/shared/blockSplitMerge';

--- a/resources/js/visual-editor/editor/inserter/__tests__/insertBlockActions.test.ts
+++ b/resources/js/visual-editor/editor/inserter/__tests__/insertBlockActions.test.ts
@@ -1,27 +1,30 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { createEditorStore, type Block } from '../../store';
+import { clearRegistry } from '../../registry';
+import { registerCoreBlocks, PARAGRAPH_BLOCK_NAME, HEADING_BLOCK_NAME } from '../../blocks';
 import {
     clearInserterRegistry,
     insertBlockAtSelection,
-    registerBuiltinInserterBlocks,
     replaceBlockWithInserterBlock,
 } from '../index';
 
 function makeParagraph(clientId: string, content: string): Block {
     return {
         clientId,
-        name: 've/paragraph',
+        name: PARAGRAPH_BLOCK_NAME,
         attributes: { content },
         innerBlocks: [],
     };
 }
 
 beforeEach(() => {
+    clearRegistry();
     clearInserterRegistry();
-    registerBuiltinInserterBlocks();
+    registerCoreBlocks();
 });
 
 afterEach(() => {
+    clearRegistry();
     clearInserterRegistry();
 });
 
@@ -29,11 +32,11 @@ describe('insertBlockAtSelection', () => {
     it('appends a block when nothing is selected', () => {
         const store = createEditorStore([makeParagraph('p1', '<p>a</p>')]);
 
-        const inserted = insertBlockAtSelection(store, 've/heading');
+        const inserted = insertBlockAtSelection(store, HEADING_BLOCK_NAME);
 
         expect(inserted).not.toBeNull();
         expect(store.getState().blocks).toHaveLength(2);
-        expect(store.getState().blocks[1].name).toBe('ve/heading');
+        expect(store.getState().blocks[1].name).toBe(HEADING_BLOCK_NAME);
     });
 
     it('inserts after the selected block when the selection edge is end', () => {
@@ -43,12 +46,12 @@ describe('insertBlockAtSelection', () => {
         ]);
         store.getState().select('p1', 'end');
 
-        insertBlockAtSelection(store, 've/heading');
+        insertBlockAtSelection(store, HEADING_BLOCK_NAME);
 
         const blocks = store.getState().blocks;
         expect(blocks).toHaveLength(3);
         expect(blocks[0].clientId).toBe('p1');
-        expect(blocks[1].name).toBe('ve/heading');
+        expect(blocks[1].name).toBe(HEADING_BLOCK_NAME);
         expect(blocks[2].clientId).toBe('p2');
     });
 
@@ -59,19 +62,19 @@ describe('insertBlockAtSelection', () => {
         ]);
         store.getState().select('p2', 'start');
 
-        insertBlockAtSelection(store, 've/heading');
+        insertBlockAtSelection(store, HEADING_BLOCK_NAME);
 
         const blocks = store.getState().blocks;
         expect(blocks).toHaveLength(3);
         expect(blocks[0].clientId).toBe('p1');
-        expect(blocks[1].name).toBe('ve/heading');
+        expect(blocks[1].name).toBe(HEADING_BLOCK_NAME);
         expect(blocks[2].clientId).toBe('p2');
     });
 
     it('selects the newly inserted block', () => {
         const store = createEditorStore([makeParagraph('p1', '<p>a</p>')]);
 
-        const inserted = insertBlockAtSelection(store, 've/paragraph');
+        const inserted = insertBlockAtSelection(store, PARAGRAPH_BLOCK_NAME);
 
         expect(store.getState().selection.clientId).toBe(inserted!.clientId);
     });
@@ -79,7 +82,7 @@ describe('insertBlockAtSelection', () => {
     it('returns null when no factory is registered for the block', () => {
         const store = createEditorStore([makeParagraph('p1', '<p>a</p>')]);
 
-        const inserted = insertBlockAtSelection(store, 've/unknown');
+        const inserted = insertBlockAtSelection(store, 'unknown/block');
 
         expect(inserted).toBeNull();
         expect(store.getState().blocks).toHaveLength(1);
@@ -93,12 +96,12 @@ describe('replaceBlockWithInserterBlock', () => {
             makeParagraph('p2', '<p>/head</p>'),
         ]);
 
-        const replacement = replaceBlockWithInserterBlock(store, 'p2', 've/heading');
+        const replacement = replaceBlockWithInserterBlock(store, 'p2', HEADING_BLOCK_NAME);
 
         expect(replacement).not.toBeNull();
         const blocks = store.getState().blocks;
         expect(blocks).toHaveLength(2);
-        expect(blocks[1].name).toBe('ve/heading');
+        expect(blocks[1].name).toBe(HEADING_BLOCK_NAME);
         expect(blocks[1].clientId).toBe(replacement!.clientId);
         expect(store.getState().selection.clientId).toBe(replacement!.clientId);
     });
@@ -109,13 +112,13 @@ describe('replaceBlockWithInserterBlock', () => {
             makeParagraph('p2', '<p>/head</p>'),
         ]);
 
-        replaceBlockWithInserterBlock(store, 'p2', 've/heading');
+        replaceBlockWithInserterBlock(store, 'p2', HEADING_BLOCK_NAME);
 
         store.getState().undo();
 
         const blocks = store.getState().blocks;
         expect(blocks).toHaveLength(2);
         expect(blocks[1].clientId).toBe('p2');
-        expect(blocks[1].name).toBe('ve/paragraph');
+        expect(blocks[1].name).toBe(PARAGRAPH_BLOCK_NAME);
     });
 });

--- a/resources/js/visual-editor/editor/inserter/__tests__/inserterRegistry.test.ts
+++ b/resources/js/visual-editor/editor/inserter/__tests__/inserterRegistry.test.ts
@@ -1,66 +1,60 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { clearRegistry } from '../../registry';
+import { registerCoreBlocks, PARAGRAPH_BLOCK_NAME, HEADING_BLOCK_NAME } from '../../blocks';
 import {
     clearInserterRegistry,
     filterInserterBlocks,
     getInserterBlocks,
     loadInserterBlocks,
     registerBlockFactory,
-    registerBuiltinInserterBlocks,
     subscribeInserterBlocks,
     type InserterBlock,
 } from '../index';
 
 beforeEach(() => {
+    clearRegistry();
     clearInserterRegistry();
 });
 
 afterEach(() => {
+    clearRegistry();
     clearInserterRegistry();
 });
 
 describe('inserter registry', () => {
-    it('returns a stable snapshot reference until mutated', () => {
-        registerBuiltinInserterBlocks();
-        const a = getInserterBlocks();
-        const b = getInserterBlocks();
+    it('returns blocks registered via registerCoreBlocks', () => {
+        registerCoreBlocks();
+        const blocks = getInserterBlocks();
+        const names = blocks.map((b) => b.name);
 
-        expect(a).toBe(b);
-    });
-
-    it('produces a new snapshot when a block is registered', () => {
-        registerBuiltinInserterBlocks();
-        const first = getInserterBlocks();
-
-        registerBuiltinInserterBlocks();
-
-        const second = getInserterBlocks();
-        expect(second).not.toBe(first);
+        expect(names).toContain(PARAGRAPH_BLOCK_NAME);
+        expect(names).toContain(HEADING_BLOCK_NAME);
     });
 
     it('notifies subscribers when the registry changes', () => {
         const listener = vi.fn();
         const unsubscribe = subscribeInserterBlocks(listener);
 
-        registerBuiltinInserterBlocks();
+        registerCoreBlocks();
 
         expect(listener).toHaveBeenCalled();
 
         unsubscribe();
     });
 
-    it('seeds paragraph and heading via registerBuiltinInserterBlocks', () => {
-        registerBuiltinInserterBlocks();
+    it('seeds paragraph and heading via registerCoreBlocks', () => {
+        registerCoreBlocks();
         const blocks = getInserterBlocks();
 
-        expect(blocks.map((block) => block.name)).toContain('ve/paragraph');
-        expect(blocks.map((block) => block.name)).toContain('ve/heading');
+        expect(blocks.map((block) => block.name)).toContain(PARAGRAPH_BLOCK_NAME);
+        expect(blocks.map((block) => block.name)).toContain(HEADING_BLOCK_NAME);
     });
 });
 
 describe('filterInserterBlocks', () => {
     const blocks: InserterBlock[] = [
-        { name: 've/paragraph', title: 'Paragraph', keywords: ['text'] },
-        { name: 've/heading', title: 'Heading', description: 'Sections', keywords: ['h1', 'h2'] },
+        { name: PARAGRAPH_BLOCK_NAME, title: 'Paragraph', keywords: ['text'] },
+        { name: HEADING_BLOCK_NAME, title: 'Heading', description: 'Sections', keywords: ['h1', 'h2'] },
     ];
 
     it('returns a copy of the list for an empty query', () => {
@@ -91,16 +85,19 @@ describe('filterInserterBlocks', () => {
 });
 
 describe('loadInserterBlocks', () => {
-    it('registers the built-ins even without an API base', async () => {
+    it('includes core blocks even without an API base', async () => {
+        registerCoreBlocks();
         await loadInserterBlocks();
         const names = getInserterBlocks().map((block) => block.name);
-        expect(names).toContain('ve/paragraph');
-        expect(names).toContain('ve/heading');
+        expect(names).toContain(PARAGRAPH_BLOCK_NAME);
+        expect(names).toContain(HEADING_BLOCK_NAME);
     });
 
     it('merges API-returned blocks when a client factory is registered', async () => {
-        registerBlockFactory('ve/custom', () => ({
-            name: 've/custom',
+        registerCoreBlocks();
+
+        registerBlockFactory('custom/block', () => ({
+            name: 'custom/block',
             attributes: {},
             innerBlocks: [],
         }));
@@ -109,7 +106,7 @@ describe('loadInserterBlocks', () => {
             ok: true,
             json: async () => ({
                 blocks: [
-                    { name: 've/custom', title: 'Custom', description: 'A custom block' },
+                    { name: 'custom/block', title: 'Custom', description: 'A custom block' },
                 ],
             }),
         }) as unknown as typeof fetch;
@@ -117,16 +114,18 @@ describe('loadInserterBlocks', () => {
         await loadInserterBlocks({ apiBase: 'https://example.test/api', fetchImpl });
 
         const names = getInserterBlocks().map((block) => block.name);
-        expect(names).toContain('ve/custom');
-        expect(names).toContain('ve/paragraph');
+        expect(names).toContain('custom/block');
+        expect(names).toContain(PARAGRAPH_BLOCK_NAME);
     });
 
     it('skips API-returned blocks that have no client factory', async () => {
+        registerCoreBlocks();
+
         const fetchImpl = vi.fn().mockResolvedValue({
             ok: true,
             json: async () => ({
                 blocks: [
-                    { name: 've/unregistered', title: 'Unregistered' },
+                    { name: 'unknown/block', title: 'Unregistered' },
                 ],
             }),
         }) as unknown as typeof fetch;
@@ -134,12 +133,14 @@ describe('loadInserterBlocks', () => {
         await loadInserterBlocks({ apiBase: 'https://example.test/api', fetchImpl });
 
         const names = getInserterBlocks().map((block) => block.name);
-        expect(names).not.toContain('ve/unregistered');
+        expect(names).not.toContain('unknown/block');
     });
 
     it('ignores malformed payloads with non-string description or keyword entries', async () => {
-        registerBlockFactory('ve/custom', () => ({
-            name: 've/custom',
+        registerCoreBlocks();
+
+        registerBlockFactory('custom/block', () => ({
+            name: 'custom/block',
             attributes: {},
             innerBlocks: [],
         }));
@@ -149,7 +150,7 @@ describe('loadInserterBlocks', () => {
             json: async () => ({
                 blocks: [
                     {
-                        name: 've/custom',
+                        name: 'custom/block',
                         title: 'Custom',
                         description: 42,
                         keywords: ['valid', 7, null, 'more'],
@@ -160,13 +161,15 @@ describe('loadInserterBlocks', () => {
 
         await loadInserterBlocks({ apiBase: 'https://example.test/api', fetchImpl });
 
-        const custom = getInserterBlocks().find((block) => block.name === 've/custom');
+        const custom = getInserterBlocks().find((block) => block.name === 'custom/block');
         expect(custom).toBeDefined();
         expect(custom!.description).toBeUndefined();
         expect(custom!.keywords).toEqual(['valid', 'more']);
     });
 
-    it('falls back to built-ins when the API request fails', async () => {
+    it('falls back to core blocks when the API request fails', async () => {
+        registerCoreBlocks();
+
         const fetchImpl = vi
             .fn()
             .mockRejectedValue(new Error('network')) as unknown as typeof fetch;
@@ -174,11 +177,13 @@ describe('loadInserterBlocks', () => {
         await loadInserterBlocks({ apiBase: 'https://example.test/api', fetchImpl });
 
         const names = getInserterBlocks().map((block) => block.name);
-        expect(names).toContain('ve/paragraph');
-        expect(names).toContain('ve/heading');
+        expect(names).toContain(PARAGRAPH_BLOCK_NAME);
+        expect(names).toContain(HEADING_BLOCK_NAME);
     });
 
     it('ignores non-ok responses', async () => {
+        registerCoreBlocks();
+
         const fetchImpl = vi.fn().mockResolvedValue({
             ok: false,
             json: async () => ({ blocks: [] }),

--- a/resources/js/visual-editor/editor/inserter/builtinInserterBlocks.ts
+++ b/resources/js/visual-editor/editor/inserter/builtinInserterBlocks.ts
@@ -1,35 +1,12 @@
-import { HEADING_BLOCK_NAME } from '../blocks/heading';
-import { PARAGRAPH_BLOCK_NAME } from '../blocks/paragraph';
-import { registerBlockFactory, registerInserterBlock } from './inserterRegistry';
-
 /**
- * Register the inserter metadata and block factories for the two core text
- * block types shipped in Phase 1.10 (#272). These seeds guarantee the
- * inserter has something to show even when the REST API (#274) is not yet
- * available.
+ * No-op stub retained for backward compatibility.
+ *
+ * Block metadata and factories are now registered via `registerBlockType()`
+ * in each block's `index.ts` file. The inserter derives its list from the
+ * unified block registry. This function is called by `loadInserterBlocks()`
+ * but no longer needs to do anything — `registerCoreBlocks()` handles
+ * everything.
  */
 export function registerBuiltinInserterBlocks(): void {
-    registerInserterBlock({
-        name: PARAGRAPH_BLOCK_NAME,
-        title: 'Paragraph',
-        description: 'Start with the basic building block of all narrative.',
-        keywords: ['text', 'body', 'p'],
-    });
-    registerInserterBlock({
-        name: HEADING_BLOCK_NAME,
-        title: 'Heading',
-        description: 'Introduce new sections and organize content to help readers scan.',
-        keywords: ['title', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6'],
-    });
-
-    registerBlockFactory(PARAGRAPH_BLOCK_NAME, () => ({
-        name: PARAGRAPH_BLOCK_NAME,
-        attributes: { content: '<p></p>' },
-        innerBlocks: [],
-    }));
-    registerBlockFactory(HEADING_BLOCK_NAME, () => ({
-        name: HEADING_BLOCK_NAME,
-        attributes: { level: 2, content: '<h2></h2>' },
-        innerBlocks: [],
-    }));
+    // Intentionally empty — registration happens in registerCoreBlocks()
 }

--- a/resources/js/visual-editor/editor/inserter/index.ts
+++ b/resources/js/visual-editor/editor/inserter/index.ts
@@ -4,6 +4,7 @@ export {
     getInserterBlocks,
     getBlockFactory,
     clearInserterRegistry,
+    clearFactories,
     subscribeInserterBlocks,
     type InserterBlock,
     type BlockFactory,

--- a/resources/js/visual-editor/editor/inserter/inserterRegistry.ts
+++ b/resources/js/visual-editor/editor/inserter/inserterRegistry.ts
@@ -1,5 +1,15 @@
-import type { Block } from '../store';
+import {
+    getRegisteredBlocks,
+    subscribeRegistry,
+    getBlock,
+    type BlockDefinition,
+    type BlockFactory,
+} from '../registry';
 
+/**
+ * Lightweight inserter view-model derived from BlockDefinition.
+ * Used by the inserter panel, slash command, and filter logic.
+ */
 export interface InserterBlock {
     name: string;
     title: string;
@@ -7,45 +17,146 @@ export interface InserterBlock {
     keywords?: readonly string[];
 }
 
-export type BlockFactory = () => Omit<Block, 'clientId'>;
+// ---------------------------------------------------------------------------
+// Factory registry — kept separate since factories are an operational concern
+// (how to create a block instance) rather than a type-definition concern.
+// ---------------------------------------------------------------------------
 
-const inserterBlocks = new Map<string, InserterBlock>();
 const blockFactories = new Map<string, BlockFactory>();
-const listeners = new Set<() => void>();
 
-let cachedSnapshot: readonly InserterBlock[] = Object.freeze([]);
-
-function invalidateSnapshot(): void {
-    cachedSnapshot = Object.freeze(Array.from(inserterBlocks.values()));
-    listeners.forEach((listener) => listener());
-}
-
-export function registerInserterBlock(block: InserterBlock): void {
-    inserterBlocks.set(block.name, block);
-    invalidateSnapshot();
-}
+export { type BlockFactory };
 
 export function registerBlockFactory(name: string, factory: BlockFactory): void {
     blockFactories.set(name, factory);
 }
 
-export function getInserterBlocks(): readonly InserterBlock[] {
-    return cachedSnapshot;
-}
-
 export function getBlockFactory(name: string): BlockFactory | undefined {
-    return blockFactories.get(name);
+    // First check the factory map (explicit registrations)
+    const explicit = blockFactories.get(name);
+
+    if (explicit) {
+        return explicit;
+    }
+
+    // Fall back to the factory on the block definition (if registered via registerBlockType)
+    const definition = getBlock(name);
+    return definition?.factory;
 }
 
-export function clearInserterRegistry(): void {
-    inserterBlocks.clear();
+export function clearFactories(): void {
     blockFactories.clear();
-    invalidateSnapshot();
+}
+
+// ---------------------------------------------------------------------------
+// Inserter block list — derived from the unified block registry
+// ---------------------------------------------------------------------------
+
+const listeners = new Set<() => void>();
+let cachedInserterBlocks: readonly InserterBlock[] = Object.freeze([]);
+let unsubscribeRegistry: (() => void) | null = null;
+
+function definitionToInserterBlock(def: BlockDefinition): InserterBlock {
+    const block: InserterBlock = {
+        name: def.name,
+        title: def.title,
+    };
+
+    if (def.description) {
+        block.description = def.description;
+    }
+
+    if (def.keywords && def.keywords.length > 0) {
+        block.keywords = def.keywords;
+    }
+
+    return block;
+}
+
+function rebuildInserterSnapshot(): void {
+    const allBlocks = getRegisteredBlocks();
+    const inserterBlocks: InserterBlock[] = [];
+
+    for (const def of allBlocks) {
+        // Skip blocks that explicitly opt out of the inserter
+        if (def.supports?.inserter === false) {
+            continue;
+        }
+
+        // Skip blocks without a factory — the inserter can't create them
+        if (!def.factory && !blockFactories.has(def.name)) {
+            continue;
+        }
+
+        inserterBlocks.push(definitionToInserterBlock(def));
+    }
+
+    cachedInserterBlocks = Object.freeze(inserterBlocks);
+    listeners.forEach((listener) => listener());
+}
+
+function ensureRegistrySubscription(): void {
+    if (unsubscribeRegistry !== null) {
+        return;
+    }
+    unsubscribeRegistry = subscribeRegistry(() => {
+        rebuildInserterSnapshot();
+    });
+    // Build the initial snapshot from blocks already in the registry
+    rebuildInserterSnapshot();
+}
+
+/**
+ * @deprecated Use `registerBlockType(metadata, settings)` from the registry
+ * module instead. This function remains for backward compatibility during
+ * migration and for REST-API-loaded blocks that don't have a JS edit component.
+ */
+export function registerInserterBlock(block: InserterBlock): void {
+    // For blocks registered via REST API without a client-side definition,
+    // we don't have a full BlockDefinition. Keep these in a supplemental map.
+    if (!getBlock(block.name)) {
+        supplementalInserterBlocks.set(block.name, block);
+    }
+    rebuildInserterSnapshot();
+}
+
+const supplementalInserterBlocks = new Map<string, InserterBlock>();
+
+export function getInserterBlocks(): readonly InserterBlock[] {
+    ensureRegistrySubscription();
+
+    // Merge supplemental blocks (from REST API) with registry-derived blocks
+    if (supplementalInserterBlocks.size === 0) {
+        return cachedInserterBlocks;
+    }
+
+    // Build combined list — registry blocks take precedence
+    const registryNames = new Set(cachedInserterBlocks.map((b) => b.name));
+    const supplemental = Array.from(supplementalInserterBlocks.values()).filter(
+        (b) => !registryNames.has(b.name) && (blockFactories.has(b.name) || getBlock(b.name)?.factory)
+    );
+
+    if (supplemental.length === 0) {
+        return cachedInserterBlocks;
+    }
+
+    return Object.freeze([...cachedInserterBlocks, ...supplemental]);
 }
 
 export function subscribeInserterBlocks(listener: () => void): () => void {
+    ensureRegistrySubscription();
     listeners.add(listener);
     return () => {
         listeners.delete(listener);
     };
+}
+
+export function clearInserterRegistry(): void {
+    blockFactories.clear();
+    supplementalInserterBlocks.clear();
+    if (unsubscribeRegistry) {
+        unsubscribeRegistry();
+        unsubscribeRegistry = null;
+    }
+    cachedInserterBlocks = Object.freeze([]);
+    listeners.forEach((listener) => listener());
 }

--- a/resources/js/visual-editor/editor/inserter/inserterRegistry.ts
+++ b/resources/js/visual-editor/editor/inserter/inserterRegistry.ts
@@ -28,6 +28,7 @@ export { type BlockFactory };
 
 export function registerBlockFactory(name: string, factory: BlockFactory): void {
     blockFactories.set(name, factory);
+    rebuildInserterSnapshot();
 }
 
 export function getBlockFactory(name: string): BlockFactory | undefined {
@@ -45,6 +46,7 @@ export function getBlockFactory(name: string): BlockFactory | undefined {
 
 export function clearFactories(): void {
     blockFactories.clear();
+    rebuildInserterSnapshot();
 }
 
 // ---------------------------------------------------------------------------

--- a/resources/js/visual-editor/editor/primitives/RichText.tsx
+++ b/resources/js/visual-editor/editor/primitives/RichText.tsx
@@ -34,7 +34,11 @@ function resolveTopLevelNode(tagName: string, extraExtensions?: Extensions): {
     // For unknown tags, use paragraph as fallback — the extra extensions
     // should supply the actual top-level node.
     if (extraExtensions && extraExtensions.length > 0) {
-        return { node: extraExtensions[0], docContentSpec: tagName };
+        const ext = extraExtensions[0];
+        const extName = typeof ext === 'object' && ext !== null && 'name' in ext
+            ? (ext as { name: string }).name
+            : tagName;
+        return { node: ext, docContentSpec: extName };
     }
 
     return { node: Paragraph, docContentSpec: 'paragraph' };
@@ -98,7 +102,7 @@ export function RichText({
     tagName,
     value,
     onChange,
-    placeholder: _placeholder,
+    placeholder,
     className,
     blockName,
     onEnter,
@@ -182,6 +186,7 @@ export function RichText({
             editor={editor}
             className={className}
             data-block-name={blockName}
+            data-placeholder={placeholder}
         />
     );
 }

--- a/resources/js/visual-editor/editor/primitives/RichText.tsx
+++ b/resources/js/visual-editor/editor/primitives/RichText.tsx
@@ -1,0 +1,187 @@
+import { useEffect, useMemo } from 'react';
+import { EditorContent } from '@tiptap/react';
+import { useStore } from 'zustand';
+import type { Extensions } from '@tiptap/core';
+import Paragraph from '@tiptap/extension-paragraph';
+import Heading from '@tiptap/extension-heading';
+import { useBlockTiptap } from '../blocks/shared/useBlockTiptap';
+import { takePendingCursor } from '../blocks/shared/blockEditorRegistry';
+import { useEditorStore } from './EditorStoreContext';
+
+// ---------------------------------------------------------------------------
+// Tag → Tiptap node mapping
+// ---------------------------------------------------------------------------
+
+const HEADING_TAG_REGEX = /^h([1-6])$/i;
+
+function resolveTopLevelNode(tagName: string, extraExtensions?: Extensions): {
+    node: Extensions[number];
+    docContentSpec: string;
+} {
+    const headingMatch = tagName.match(HEADING_TAG_REGEX);
+
+    if (headingMatch) {
+        return {
+            node: Heading.configure({ levels: [1, 2, 3, 4, 5, 6] }),
+            docContentSpec: 'heading',
+        };
+    }
+
+    if (tagName === 'p' || tagName === 'paragraph') {
+        return { node: Paragraph, docContentSpec: 'paragraph' };
+    }
+
+    // For unknown tags, use paragraph as fallback — the extra extensions
+    // should supply the actual top-level node.
+    if (extraExtensions && extraExtensions.length > 0) {
+        return { node: extraExtensions[0], docContentSpec: tagName };
+    }
+
+    return { node: Paragraph, docContentSpec: 'paragraph' };
+}
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+export interface RichTextProps {
+    /** Block clientId — used for store selection tracking and editor registry. */
+    clientId: string;
+    /** HTML tag name that determines the Tiptap top-level node. */
+    tagName: string;
+    /** Current HTML content. */
+    value: string;
+    /** Fires when the editor content changes. */
+    onChange: (html: string) => void;
+    /** Placeholder text shown when the editor is empty. */
+    placeholder?: string;
+    /** CSS class applied to the wrapper element. */
+    className?: string;
+    /** data-block-name attribute for the wrapper. */
+    blockName?: string;
+    /**
+     * Called when Enter is pressed (without Shift). Return `true` to
+     * prevent default Tiptap behavior (e.g. for block splitting).
+     */
+    onEnter?: () => boolean;
+    /**
+     * Called when Backspace is pressed at the start of the content.
+     * Return `true` to prevent default behavior (e.g. for block merging).
+     */
+    onBackspaceAtStart?: () => boolean;
+    /** Additional Tiptap extensions beyond the base set. */
+    extraExtensions?: Extensions;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+/**
+ * `<RichText>` is the primary rich-text editing primitive for block edit
+ * components. It wraps a Tiptap editor instance, handles focus/selection
+ * sync with the Zustand store, and provides a clean API for block-level
+ * keyboard behaviors (Enter to split, Backspace to merge).
+ *
+ * @example
+ * ```tsx
+ * <RichText
+ *     clientId={clientId}
+ *     tagName="p"
+ *     value={content}
+ *     onChange={(html) => updateAttributes({ content: html })}
+ * />
+ * ```
+ */
+export function RichText({
+    clientId,
+    tagName,
+    value,
+    onChange,
+    placeholder: _placeholder,
+    className,
+    blockName,
+    onEnter,
+    onBackspaceAtStart,
+    extraExtensions,
+}: RichTextProps) {
+    const store = useEditorStore();
+
+    const isSelected = useStore(
+        store,
+        (state) => state.selection.clientId === clientId
+    );
+    const selectionEdge = useStore(
+        store,
+        (state) => (state.selection.clientId === clientId ? state.selection.edge : undefined)
+    );
+
+    const { node, docContentSpec } = useMemo(
+        () => resolveTopLevelNode(tagName, extraExtensions),
+        [tagName, extraExtensions]
+    );
+
+    const editor = useBlockTiptap({
+        clientId,
+        content: value,
+        topLevelNode: node,
+        docContentSpec,
+        onUpdate: onChange,
+        onEnter: onEnter ?? (() => false),
+        onBackspaceAtStart: onBackspaceAtStart ?? (() => false),
+        extraExtensions: extraExtensions?.slice(1),
+    });
+
+    // Heading level sync — when tagName changes (e.g. h2 → h4),
+    // update the Tiptap node type without recreating the editor.
+    useEffect(() => {
+        if (!editor) {
+            return;
+        }
+
+        const headingMatch = tagName.match(HEADING_TAG_REGEX);
+
+        if (!headingMatch) {
+            return;
+        }
+
+        const targetLevel = Number(headingMatch[1]);
+        const first = editor.state.doc.firstChild;
+
+        if (!first || first.type.name !== 'heading' || first.attrs.level === targetLevel) {
+            return;
+        }
+
+        editor.chain().setNode('heading', { level: targetLevel }).run();
+    }, [editor, tagName]);
+
+    // Focus management — centralized here so individual block edit
+    // components don't need to duplicate this logic.
+    useEffect(() => {
+        if (!editor || !isSelected) {
+            return;
+        }
+
+        const pending = takePendingCursor(clientId);
+
+        if (pending !== undefined) {
+            editor.commands.focus(pending);
+            return;
+        }
+
+        if (editor.isFocused) {
+            return;
+        }
+
+        const position = selectionEdge === 'start' ? 'start' : 'end';
+        editor.commands.focus(position);
+    }, [editor, isSelected, selectionEdge, clientId]);
+
+    return (
+        <EditorContent
+            editor={editor}
+            className={className}
+            data-block-name={blockName}
+        />
+    );
+}

--- a/resources/js/visual-editor/editor/primitives/index.ts
+++ b/resources/js/visual-editor/editor/primitives/index.ts
@@ -15,6 +15,7 @@ export {
     type UseInnerBlocksPropsOptions,
     type UseInnerBlocksPropsReturn,
 } from './useInnerBlocksProps';
+export { RichText, type RichTextProps } from './RichText';
 export {
     BlockPreview,
     useBlockPreview,

--- a/resources/js/visual-editor/editor/registry/blockRegistry.ts
+++ b/resources/js/visual-editor/editor/registry/blockRegistry.ts
@@ -1,6 +1,18 @@
 import type { ComponentType } from 'react';
 import type { Block } from '../store';
 import type { BlockContextValue } from '../primitives/BlockContext';
+import type {
+    BlockAttributeSchema,
+    BlockJsonMetadata,
+    BlockSupports,
+    BlockStyle,
+    BlockVariation,
+    BlockExample,
+} from './types';
+
+// ---------------------------------------------------------------------------
+// Block edit props — passed to every block's `edit` component
+// ---------------------------------------------------------------------------
 
 export interface BlockEditProps {
     clientId: string;
@@ -8,16 +20,150 @@ export interface BlockEditProps {
     block: Block;
 }
 
+// ---------------------------------------------------------------------------
+// Block factory — creates a new block instance with default attributes
+// ---------------------------------------------------------------------------
+
+export type BlockFactory = () => Omit<Block, 'clientId'>;
+
+// ---------------------------------------------------------------------------
+// Block definition — unified type merging block.json metadata + JS settings
+// ---------------------------------------------------------------------------
+
 export interface BlockDefinition {
+    // Required (from block.json)
     name: string;
+    title: string;
+
+    // Metadata (from block.json)
+    apiVersion?: number;
+    category?: string;
+    description?: string;
+    keywords?: string[];
+    icon?: string;
+    textdomain?: string;
+    version?: string;
+
+    // Nesting (from block.json)
+    parent?: string[];
+    ancestor?: string[];
+    allowedBlocks?: string[];
+
+    // Assets (from block.json)
+    editorScript?: string | string[];
+    editorStyle?: string | string[];
+    style?: string | string[];
+    viewScript?: string | string[];
+    render?: string;
+
+    // Configuration (from block.json)
+    attributes?: Record<string, BlockAttributeSchema>;
+    supports?: BlockSupports;
+    selectors?: Record<string, unknown>;
+    styles?: BlockStyle[];
+    variations?: BlockVariation[];
+    example?: BlockExample;
+
+    // JS-only settings (provided at registration time)
+    edit: ComponentType<BlockEditProps>;
+    factory?: BlockFactory;
+    providesContext?: (attributes: Record<string, unknown>, block: Block) => BlockContextValue;
+    usesContext?: readonly string[];
+}
+
+// ---------------------------------------------------------------------------
+// JS settings passed alongside block.json metadata to registerBlockType()
+// ---------------------------------------------------------------------------
+
+export interface BlockTypeSettings {
+    edit: ComponentType<BlockEditProps>;
+    factory?: BlockFactory;
+    providesContext?: (attributes: Record<string, unknown>, block: Block) => BlockContextValue;
+    usesContext?: readonly string[];
+}
+
+// ---------------------------------------------------------------------------
+// Registry state
+// ---------------------------------------------------------------------------
+
+const registry = new Map<string, BlockDefinition>();
+const listeners = new Set<() => void>();
+let cachedSnapshot: readonly BlockDefinition[] = Object.freeze([]);
+
+function invalidateSnapshot(): void {
+    cachedSnapshot = Object.freeze(Array.from(registry.values()));
+    listeners.forEach((listener) => listener());
+}
+
+// ---------------------------------------------------------------------------
+// Registration API
+// ---------------------------------------------------------------------------
+
+/**
+ * Registers a block type by merging block.json metadata with JS settings.
+ * This is the primary registration API — all blocks should use this.
+ *
+ * @example
+ * ```ts
+ * import metadata from './block.json';
+ * import MyEdit from './edit';
+ *
+ * registerBlockType(metadata, { edit: MyEdit });
+ * ```
+ */
+export function registerBlockType(
+    metadata: BlockJsonMetadata,
+    settings: BlockTypeSettings
+): void {
+    if (registry.has(metadata.name)) {
+        console.warn(
+            `[visual-editor] Block "${metadata.name}" is already registered; ignoring duplicate registration.`
+        );
+        return;
+    }
+
+    // Separate providesContext from block.json metadata — the block.json
+    // version is Record<string, string> (attribute name mapping), while the
+    // JS version is a function. We store the JS function; the block.json
+    // mapping is available via the metadata fields.
+    const {
+        providesContext: _jsonProvidesContext,
+        usesContext: _jsonUsesContext,
+        variations: rawVariations,
+        ...metadataRest
+    } = metadata;
+
+    const definition: BlockDefinition = {
+        ...metadataRest,
+        // Normalize variations from block.json (may be string ref; ignore non-array)
+        variations: Array.isArray(rawVariations) ? rawVariations : undefined,
+        // Preserve block.json usesContext if JS doesn't override
+        usesContext: settings.usesContext ?? (metadata.usesContext as readonly string[] | undefined),
+        // Merge JS settings (edit, factory, providesContext function)
+        ...settings,
+    };
+
+    registry.set(definition.name, definition);
+    invalidateSnapshot();
+}
+
+// ---------------------------------------------------------------------------
+// Legacy registration (deprecated)
+// ---------------------------------------------------------------------------
+
+export interface LegacyBlockDefinition {
+    name: string;
+    title?: string;
     edit: ComponentType<BlockEditProps>;
     providesContext?: (attributes: Record<string, unknown>, block: Block) => BlockContextValue;
     usesContext?: readonly string[];
 }
 
-const registry = new Map<string, BlockDefinition>();
-
-export function registerBlock(definition: BlockDefinition): void {
+/**
+ * @deprecated Use `registerBlockType(metadata, settings)` instead.
+ * Kept for backward compatibility during migration.
+ */
+export function registerBlock(definition: LegacyBlockDefinition): void {
     if (registry.has(definition.name)) {
         console.warn(
             `[visual-editor] Block "${definition.name}" is already registered; ignoring duplicate registration.`
@@ -25,21 +171,53 @@ export function registerBlock(definition: BlockDefinition): void {
         return;
     }
 
-    registry.set(definition.name, definition);
+    const full: BlockDefinition = {
+        title: definition.name,
+        ...definition,
+    };
+
+    registry.set(full.name, full);
+    invalidateSnapshot();
 }
+
+// ---------------------------------------------------------------------------
+// Query API
+// ---------------------------------------------------------------------------
 
 export function getBlock(name: string): BlockDefinition | undefined {
     return registry.get(name);
 }
 
-export function unregisterBlock(name: string): void {
-    registry.delete(name);
-}
-
-export function clearRegistry(): void {
-    registry.clear();
+export function getRegisteredBlocks(): readonly BlockDefinition[] {
+    return cachedSnapshot;
 }
 
 export function getRegisteredBlockNames(): string[] {
     return Array.from(registry.keys());
+}
+
+// ---------------------------------------------------------------------------
+// Mutation API
+// ---------------------------------------------------------------------------
+
+export function unregisterBlock(name: string): void {
+    if (registry.delete(name)) {
+        invalidateSnapshot();
+    }
+}
+
+export function clearRegistry(): void {
+    registry.clear();
+    invalidateSnapshot();
+}
+
+// ---------------------------------------------------------------------------
+// Observer API (for UI reactivity — inserter panel, slash command, etc.)
+// ---------------------------------------------------------------------------
+
+export function subscribeRegistry(listener: () => void): () => void {
+    listeners.add(listener);
+    return () => {
+        listeners.delete(listener);
+    };
 }

--- a/resources/js/visual-editor/editor/registry/blockSupports.ts
+++ b/resources/js/visual-editor/editor/registry/blockSupports.ts
@@ -1,0 +1,71 @@
+import { getBlock } from './blockRegistry';
+
+/**
+ * Queries a block's `supports` object by dot-path.
+ *
+ * Returns `true` when the resolved value is strictly `true`, a non-empty
+ * object, or a non-empty array. Returns `false` for `undefined`, `false`,
+ * or when the block/path doesn't exist.
+ *
+ * @example
+ * ```ts
+ * blockSupports('artisanpack/paragraph', 'splitting');      // true
+ * blockSupports('artisanpack/paragraph', 'typography.fontSize'); // true
+ * blockSupports('artisanpack/code', 'splitting');            // false
+ * ```
+ */
+export function blockSupports(blockName: string, feature: string): boolean {
+    const definition = getBlock(blockName);
+
+    if (!definition?.supports) {
+        return false;
+    }
+
+    const parts = feature.split('.');
+    let current: unknown = definition.supports;
+
+    for (const part of parts) {
+        if (current == null || typeof current !== 'object') {
+            return false;
+        }
+        current = (current as Record<string, unknown>)[part];
+    }
+
+    if (current === true) {
+        return true;
+    }
+
+    if (current !== null && typeof current === 'object') {
+        if (Array.isArray(current)) {
+            return current.length > 0;
+        }
+        return Object.keys(current).length > 0;
+    }
+
+    return false;
+}
+
+/**
+ * Returns the raw value at a dot-path in the block's supports object.
+ * Useful when you need the actual value (e.g. an array of align options)
+ * rather than a boolean check.
+ */
+export function getBlockSupport(blockName: string, feature: string): unknown {
+    const definition = getBlock(blockName);
+
+    if (!definition?.supports) {
+        return undefined;
+    }
+
+    const parts = feature.split('.');
+    let current: unknown = definition.supports;
+
+    for (const part of parts) {
+        if (current == null || typeof current !== 'object') {
+            return undefined;
+        }
+        current = (current as Record<string, unknown>)[part];
+    }
+
+    return current;
+}

--- a/resources/js/visual-editor/editor/registry/index.ts
+++ b/resources/js/visual-editor/editor/registry/index.ts
@@ -1,9 +1,31 @@
 export {
+    registerBlockType,
     registerBlock,
     getBlock,
+    getRegisteredBlocks,
+    getRegisteredBlockNames,
     unregisterBlock,
     clearRegistry,
-    getRegisteredBlockNames,
+    subscribeRegistry,
     type BlockDefinition,
     type BlockEditProps,
+    type BlockFactory,
+    type BlockTypeSettings,
 } from './blockRegistry';
+
+export { blockSupports, getBlockSupport } from './blockSupports';
+
+export type {
+    BlockJsonMetadata,
+    BlockSupports,
+    BlockAttributeSchema,
+    BlockStyle,
+    BlockVariation,
+    BlockExample,
+    TypographySupports,
+    ColorSupports,
+    SpacingSupports,
+    DimensionsSupports,
+    BorderSupports,
+    LayoutSupports,
+} from './types';

--- a/resources/js/visual-editor/editor/registry/types.ts
+++ b/resources/js/visual-editor/editor/registry/types.ts
@@ -1,0 +1,226 @@
+/**
+ * TypeScript types for the block.json manifest schema and block registration.
+ *
+ * Mirrors the WordPress Gutenberg block.json specification to ensure
+ * forward-compatibility and familiarity for developers coming from WordPress.
+ * Unknown keys in `supports` are stored but ignored — the schema is designed
+ * to be extended without breaking existing code.
+ */
+
+// ---------------------------------------------------------------------------
+// Attribute schema
+// ---------------------------------------------------------------------------
+
+export interface BlockAttributeSchema {
+    type?: string;
+    source?: 'attribute' | 'text' | 'html' | 'rich-text' | 'query' | 'meta';
+    selector?: string;
+    attribute?: string;
+    multiline?: string;
+    query?: Record<string, BlockAttributeSchema>;
+    default?: unknown;
+    enum?: readonly unknown[];
+    role?: 'content' | 'local';
+}
+
+// ---------------------------------------------------------------------------
+// Supports — WordPress-parity keys
+// ---------------------------------------------------------------------------
+
+export interface TypographySupports {
+    fontSize?: boolean;
+    lineHeight?: boolean;
+    textAlign?: boolean | string[];
+    textColumns?: boolean;
+    textIndent?: boolean;
+    fitText?: boolean;
+    fontFamily?: boolean;
+    fontStyle?: boolean;
+    fontWeight?: boolean;
+    letterSpacing?: boolean;
+    textDecoration?: boolean;
+    textTransform?: boolean;
+    writingMode?: boolean;
+    /** @internal Gutenberg experimental prefix retained for compat. */
+    __experimentalFontFamily?: boolean;
+    __experimentalFontStyle?: boolean;
+    __experimentalFontWeight?: boolean;
+    __experimentalLetterSpacing?: boolean;
+    __experimentalTextDecoration?: boolean;
+    __experimentalTextTransform?: boolean;
+    __experimentalWritingMode?: boolean;
+    __experimentalDefaultControls?: Record<string, boolean>;
+}
+
+export interface ColorSupports {
+    background?: boolean;
+    text?: boolean;
+    gradients?: boolean;
+    link?: boolean;
+    heading?: boolean;
+    button?: boolean;
+    enableContrastChecker?: boolean;
+    __experimentalDefaultControls?: Record<string, boolean>;
+}
+
+export interface SpacingSupports {
+    margin?: boolean | string[];
+    padding?: boolean | string[];
+    blockGap?: boolean | { __experimentalDefault?: string; sides?: string[] };
+    __experimentalDefaultControls?: Record<string, boolean>;
+}
+
+export interface DimensionsSupports {
+    width?: boolean;
+    height?: boolean;
+    minHeight?: boolean;
+    aspectRatio?: boolean;
+}
+
+export interface BorderSupports {
+    color?: boolean;
+    radius?: boolean;
+    style?: boolean;
+    width?: boolean;
+    __experimentalDefaultControls?: Record<string, boolean>;
+}
+
+export interface LayoutSupports {
+    default?: Record<string, unknown>;
+    allowSwitching?: boolean;
+    allowEditing?: boolean;
+    allowInheriting?: boolean;
+    allowSizingOnChildren?: boolean;
+    allowVerticalAlignment?: boolean;
+    allowJustification?: boolean;
+    allowOrientation?: boolean;
+    allowWrap?: boolean;
+    allowCustomContentAndWideSize?: boolean;
+}
+
+export interface BlockSupports {
+    // Layout & alignment
+    align?: boolean | string[];
+    alignWide?: boolean;
+    layout?: boolean | LayoutSupports;
+
+    // Typography, color, spacing, dimensions, border, shadow
+    typography?: boolean | TypographySupports;
+    color?: boolean | ColorSupports;
+    spacing?: boolean | SpacingSupports;
+    dimensions?: boolean | DimensionsSupports;
+    border?: boolean | BorderSupports;
+    shadow?: boolean | Record<string, unknown>;
+    background?: boolean | { backgroundImage?: boolean; backgroundSize?: boolean };
+
+    // Behavior
+    anchor?: boolean;
+    className?: boolean;
+    customClassName?: boolean;
+    html?: boolean;
+    inserter?: boolean;
+    multiple?: boolean;
+    reusable?: boolean;
+    lock?: boolean;
+    renaming?: boolean;
+    splitting?: boolean;
+
+    // Gutenberg experimental / unstable flags (kept for compat)
+    __experimentalBorder?: boolean | BorderSupports;
+    __experimentalSelector?: string;
+    __experimentalSlashInserter?: boolean;
+    __experimentalOnEnter?: boolean;
+    __experimentalOnMerge?: boolean;
+    __unstablePasteTextInline?: boolean;
+    interactivity?: boolean | { clientNavigation?: boolean; interactive?: boolean };
+
+    // Forward-compatible: unknown keys are stored but ignored
+    [key: string]: unknown;
+}
+
+// ---------------------------------------------------------------------------
+// Style variants
+// ---------------------------------------------------------------------------
+
+export interface BlockStyle {
+    name: string;
+    label: string;
+    isDefault?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Block variation
+// ---------------------------------------------------------------------------
+
+export interface BlockVariation {
+    name: string;
+    title: string;
+    description?: string;
+    category?: string;
+    icon?: string;
+    isDefault?: boolean;
+    attributes?: Record<string, unknown>;
+    innerBlocks?: unknown[];
+    example?: Record<string, unknown>;
+    scope?: Array<'block' | 'inserter' | 'transform'>;
+    keywords?: string[];
+    isActive?: string[] | ((blockAttributes: Record<string, unknown>, variationAttributes: Record<string, unknown>) => boolean);
+}
+
+// ---------------------------------------------------------------------------
+// Block example (preview data)
+// ---------------------------------------------------------------------------
+
+export interface BlockExample {
+    viewportWidth?: number;
+    attributes?: Record<string, unknown>;
+    innerBlocks?: unknown[];
+}
+
+// ---------------------------------------------------------------------------
+// block.json metadata
+// ---------------------------------------------------------------------------
+
+export interface BlockJsonMetadata {
+    // Required
+    apiVersion?: number;
+    name: string;
+    title: string;
+
+    // Metadata
+    category?: string;
+    description?: string;
+    keywords?: string[];
+    icon?: string;
+    textdomain?: string;
+    version?: string;
+
+    // Nesting
+    parent?: string[];
+    ancestor?: string[];
+    allowedBlocks?: string[];
+
+    // Assets
+    editorScript?: string | string[];
+    editorStyle?: string | string[];
+    script?: string | string[];
+    style?: string | string[];
+    viewScript?: string | string[];
+    viewScriptModule?: string | string[];
+    viewStyle?: string | string[];
+    render?: string;
+
+    // Configuration
+    attributes?: Record<string, BlockAttributeSchema>;
+    supports?: BlockSupports;
+    selectors?: Record<string, unknown>;
+    providesContext?: Record<string, string>;
+    usesContext?: string[];
+    styles?: BlockStyle[];
+    variations?: BlockVariation[] | string;
+    example?: BlockExample;
+    blockHooks?: Record<string, 'before' | 'after' | 'firstChild' | 'lastChild'>;
+
+    // Forward-compatible
+    [key: string]: unknown;
+}

--- a/src/Facades/VisualEditor.php
+++ b/src/Facades/VisualEditor.php
@@ -5,6 +5,10 @@ namespace ArtisanPackUI\VisualEditor\Facades;
 use Illuminate\Support\Facades\Facade;
 
 /**
+ * @method static void registerBlock(string $blockJsonPath)
+ * @method static void registerBlockType(string $name, array $definition)
+ * @method static \ArtisanPackUI\VisualEditor\Registries\BlockTypeRegistry getRegistry()
+ *
  * @see \ArtisanPackUI\VisualEditor\VisualEditor
  */
 class VisualEditor extends Facade
@@ -14,8 +18,8 @@ class VisualEditor extends Facade
 	 *
 	 * @return string
 	 */
-	protected static function getFacadeAccessor()
+	protected static function getFacadeAccessor(): string
 	{
-		return 'visualEditor';
+		return \ArtisanPackUI\VisualEditor\VisualEditor::class;
 	}
 }

--- a/src/Http/Controllers/VisualEditorBlocksController.php
+++ b/src/Http/Controllers/VisualEditorBlocksController.php
@@ -35,7 +35,7 @@ class VisualEditorBlocksController extends Controller
 	public function index(): JsonResponse
 	{
 		return response()->json( [
-			'data' => $this->registry->all(),
+			'blocks' => $this->registry->all(),
 		] );
 	}
 }

--- a/src/Registries/BlockTypeRegistry.php
+++ b/src/Registries/BlockTypeRegistry.php
@@ -3,8 +3,9 @@
 /**
  * BlockType registry.
  *
- * In-memory registry describing the block types the editor is aware of.
- * Packages and applications can extend this via the service container.
+ * In-memory registry storing block type definitions. Blocks are registered
+ * via their block.json metadata (read by VisualEditor::registerBlock()) or
+ * programmatically via VisualEditor::registerBlockType().
  *
  * @package    ArtisanPack_UI
  * @subpackage VisualEditor
@@ -24,7 +25,7 @@ class BlockTypeRegistry
 {
 	/**
 	 * Canonical block name pattern: `namespace/name` using lowercase
-	 * alphanumerics and hyphens (e.g. `core/paragraph`).
+	 * alphanumerics and hyphens (e.g. `artisanpack/paragraph`).
 	 */
 	protected const NAME_PATTERN = '/^[a-z][a-z0-9-]*\/[a-z][a-z0-9-]*$/';
 
@@ -33,33 +34,13 @@ class BlockTypeRegistry
 	 */
 	protected array $blocks = [];
 
-	public function __construct()
-	{
-		$this->register( 'core/paragraph', [
-			'title'      => 'Paragraph',
-			'category'   => 'text',
-			'attributes' => [
-				'content' => ['type' => 'string', 'default' => ''],
-			],
-		] );
-
-		$this->register( 'core/heading', [
-			'title'      => 'Heading',
-			'category'   => 'text',
-			'attributes' => [
-				'content' => ['type' => 'string', 'default' => ''],
-				'level'   => ['type' => 'integer', 'default' => 2],
-			],
-		] );
-	}
-
 	/**
 	 * Registers a block type by name.
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param  string                $name        The block name (e.g. `core/paragraph`).
-	 * @param  array<string, mixed>  $definition  Metadata describing the block.
+	 * @param  string                $name        The block name (e.g. `artisanpack/paragraph`).
+	 * @param  array<string, mixed>  $definition  Metadata describing the block (typically from block.json).
 	 */
 	public function register( string $name, array $definition ): void
 	{
@@ -77,6 +58,20 @@ class BlockTypeRegistry
 		}
 
 		$this->blocks[ $normalized ] = array_merge( ['name' => $normalized], $definition );
+	}
+
+	/**
+	 * Returns a single registered block type by name, or null if not found.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string  $name  The block name.
+	 *
+	 * @return array<string, mixed>|null
+	 */
+	public function get( string $name ): ?array
+	{
+		return $this->blocks[ trim( $name ) ] ?? null;
 	}
 
 	/**

--- a/src/VisualEditor.php
+++ b/src/VisualEditor.php
@@ -60,7 +60,7 @@ class VisualEditor
 
 		$metadata = json_decode( $json, true, 512, JSON_THROW_ON_ERROR );
 
-		if ( ! is_array( $metadata ) || ! isset( $metadata['name'] ) || ! is_string( $metadata['name'] ) ) {
+		if ( ! is_array( $metadata ) || ! isset( $metadata['name'] ) || ! is_string( $metadata['name'] ) || '' === trim( $metadata['name'] ) ) {
 			throw new InvalidArgumentException(
 				sprintf( 'block.json missing required "name" field: %s', $blockJsonPath )
 			);
@@ -79,7 +79,7 @@ class VisualEditor
 	 */
 	public function registerBlockType( string $name, array $definition ): void
 	{
-		$this->registry->register( $name, $definition );
+		$this->registry->register( $name, [ 'name' => $name ] + $definition );
 	}
 
 	/**

--- a/src/VisualEditor.php
+++ b/src/VisualEditor.php
@@ -1,7 +1,94 @@
 <?php
 
+/**
+ * Main VisualEditor class.
+ *
+ * Provides the public API for registering blocks and managing the visual
+ * editor. Packages and applications use this class (via the Facade or
+ * service container) to register their block types.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
 namespace ArtisanPackUI\VisualEditor;
+
+use ArtisanPackUI\VisualEditor\Registries\BlockTypeRegistry;
+use InvalidArgumentException;
+use JsonException;
+
 class VisualEditor
 {
+	public function __construct( protected BlockTypeRegistry $registry )
+	{
+	}
 
+	/**
+	 * Registers a block type from a block.json manifest file.
+	 *
+	 * Reads the JSON file, validates it has a `name` field, and stores
+	 * the full metadata in the block type registry.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string  $blockJsonPath  Absolute path to the block.json file.
+	 *
+	 * @throws InvalidArgumentException When the file doesn't exist or is invalid.
+	 * @throws JsonException            When the JSON cannot be parsed.
+	 */
+	public function registerBlock( string $blockJsonPath ): void
+	{
+		if ( ! file_exists( $blockJsonPath ) ) {
+			throw new InvalidArgumentException(
+				sprintf( 'block.json not found: %s', $blockJsonPath )
+			);
+		}
+
+		$json = file_get_contents( $blockJsonPath );
+
+		if ( false === $json ) {
+			throw new InvalidArgumentException(
+				sprintf( 'Unable to read block.json: %s', $blockJsonPath )
+			);
+		}
+
+		$metadata = json_decode( $json, true, 512, JSON_THROW_ON_ERROR );
+
+		if ( ! is_array( $metadata ) || ! isset( $metadata['name'] ) || ! is_string( $metadata['name'] ) ) {
+			throw new InvalidArgumentException(
+				sprintf( 'block.json missing required "name" field: %s', $blockJsonPath )
+			);
+		}
+
+		$this->registry->register( $metadata['name'], $metadata );
+	}
+
+	/**
+	 * Registers a block type programmatically without a block.json file.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string                $name        The block name (e.g. `artisanpack/paragraph`).
+	 * @param  array<string, mixed>  $definition  Block metadata matching the block.json schema.
+	 */
+	public function registerBlockType( string $name, array $definition ): void
+	{
+		$this->registry->register( $name, $definition );
+	}
+
+	/**
+	 * Returns the block type registry instance.
+	 *
+	 * @since 1.0.0
+	 */
+	public function getRegistry(): BlockTypeRegistry
+	{
+		return $this->registry;
+	}
 }

--- a/src/VisualEditorServiceProvider.php
+++ b/src/VisualEditorServiceProvider.php
@@ -14,13 +14,16 @@ class VisualEditorServiceProvider extends ServiceProvider
 
 	public function register(): void
 	{
-		$this->app->singleton( 'package', function ( $app ) {
-			return new VisualEditor();
-		} );
-
 		$this->app->singleton( BlockTypeRegistry::class, function () {
 			return new BlockTypeRegistry();
 		} );
+
+		$this->app->singleton( VisualEditor::class, function ( $app ) {
+			return new VisualEditor( $app->make( BlockTypeRegistry::class ) );
+		} );
+
+		// Legacy alias for backward compatibility
+		$this->app->alias( VisualEditor::class, 'visualEditor' );
 
 		$this->mergeConfigFrom(
 			__DIR__ . '/../config/visual-editor.php', 'artisanpack-visual-editor-temp'
@@ -48,11 +51,42 @@ class VisualEditorServiceProvider extends ServiceProvider
 
 		Gate::policy( VisualEditorPost::class, VisualEditorPostPolicy::class );
 
-		// 3. Tag the config file for the scaffold command.
+		// 3. Register core blocks from their block.json manifests.
+		$this->registerCoreBlocks();
+
+		// 4. Tag the config file for the scaffold command.
 		if ( $this->app->runningInConsole() ) {
 			$this->publishes( [
 								  __DIR__ . '/../config/visual-editor.php' => config_path( 'artisanpack/visual-editor.php' ),
 							  ], 'artisanpack-package-config' );
+		}
+	}
+
+	/**
+	 * Registers the core block types from their block.json manifest files.
+	 *
+	 * @since 1.0.0
+	 */
+	protected function registerCoreBlocks(): void
+	{
+		$editor    = $this->app->make( VisualEditor::class );
+		$blocksDir = __DIR__ . '/../resources/js/visual-editor/editor/blocks';
+
+		$coreBlocks = [
+			'paragraph',
+			'heading',
+			'list',
+			'quote',
+			'code',
+			'preformatted',
+		];
+
+		foreach ( $coreBlocks as $block ) {
+			$blockJsonPath = $blocksDir . '/' . $block . '/block.json';
+
+			if ( file_exists( $blockJsonPath ) ) {
+				$editor->registerBlock( $blockJsonPath );
+			}
 		}
 	}
 

--- a/tests/Feature/VisualEditor/BlocksControllerTest.php
+++ b/tests/Feature/VisualEditor/BlocksControllerTest.php
@@ -10,7 +10,7 @@ it( 'returns 401 for unauthenticated blocks requests', function () {
 	$response->assertUnauthorized();
 } );
 
-it( 'returns the registered block types', function () {
+it( 'returns the registered block types from block.json manifests', function () {
 	$user = TestUser::create( [
 		'name'     => 'Jane',
 		'email'    => 'jane@example.com',
@@ -23,12 +23,12 @@ it( 'returns the registered block types', function () {
 
 	$response->assertOk()
 		->assertJsonStructure( [
-			'data' => [
-				'*' => ['name', 'title', 'category', 'attributes'],
+			'blocks' => [
+				'*' => ['name', 'title'],
 			],
 		] );
 
-	$names = collect( $response->json( 'data' ) )->pluck( 'name' )->all();
+	$names = collect( $response->json( 'blocks' ) )->pluck( 'name' )->all();
 
-	expect( $names )->toContain( 'core/paragraph', 'core/heading' );
+	expect( $names )->toContain( 'artisanpack/paragraph', 'artisanpack/heading' );
 } );

--- a/tests/Feature/VisualEditor/PostsControllerTest.php
+++ b/tests/Feature/VisualEditor/PostsControllerTest.php
@@ -15,7 +15,7 @@ function createPost( array $overrides = [] ): VisualEditorPost
 		'blocks' => [
 			[
 				'clientId'    => 'abc-123',
-				'name'        => 'core/paragraph',
+				'name'        => 'artisanpack/paragraph',
 				'attributes'  => ['content' => 'Hello'],
 				'innerBlocks' => [],
 			],
@@ -84,7 +84,7 @@ it( 'returns 403 on PUT when ownership restriction blocks the user', function ()
 		'blocks' => [
 			[
 				'clientId'    => 'c-1',
-				'name'        => 'core/paragraph',
+				'name'        => 'artisanpack/paragraph',
 				'attributes'  => ['content' => 'Hello'],
 				'innerBlocks' => [],
 			],
@@ -96,7 +96,7 @@ it( 'returns 403 on PUT when ownership restriction blocks the user', function ()
 	expect( $post->fresh()->blocks )->toEqual( [
 		[
 			'clientId'    => 'abc-123',
-			'name'        => 'core/paragraph',
+			'name'        => 'artisanpack/paragraph',
 			'attributes'  => ['content' => 'Hello'],
 			'innerBlocks' => [],
 		],
@@ -113,7 +113,7 @@ it( 'returns the block tree for an authorized GET request', function () {
 		->assertJsonPath( 'id', $post->id )
 		->assertJsonPath( 'title', 'Test Post' )
 		->assertJsonPath( 'blocks.0.clientId', 'abc-123' )
-		->assertJsonPath( 'blocks.0.name', 'core/paragraph' )
+		->assertJsonPath( 'blocks.0.name', 'artisanpack/paragraph' )
 		->assertJsonPath( 'blocks.0.attributes.content', 'Hello' );
 } );
 
@@ -139,13 +139,13 @@ it( 'rejects duplicate clientIds within the tree', function () {
 		'blocks' => [
 			[
 				'clientId'    => 'dupe',
-				'name'        => 'core/paragraph',
+				'name'        => 'artisanpack/paragraph',
 				'attributes'  => ['content' => 'a'],
 				'innerBlocks' => [],
 			],
 			[
 				'clientId'    => 'dupe',
-				'name'        => 'core/paragraph',
+				'name'        => 'artisanpack/paragraph',
 				'attributes'  => ['content' => 'b'],
 				'innerBlocks' => [],
 			],
@@ -163,7 +163,7 @@ it( 'rejects block trees deeper than MAX_DEPTH', function () {
 	$build = function ( int $depth ) use ( &$build ): array {
 		$block = [
 			'clientId'    => "c-{$depth}",
-			'name'        => 'core/paragraph',
+			'name'        => 'artisanpack/paragraph',
 			'attributes'  => [],
 			'innerBlocks' => [],
 		];
@@ -192,7 +192,7 @@ it( 'rejects block trees with more than MAX_NODES blocks', function () {
 	for ( $i = 0; $i < $count; $i++ ) {
 		$blocks[] = [
 			'clientId'    => "c-{$i}",
-			'name'        => 'core/paragraph',
+			'name'        => 'artisanpack/paragraph',
 			'attributes'  => [],
 			'innerBlocks' => [],
 		];
@@ -223,18 +223,18 @@ it( 'persists a valid block tree on PUT', function () {
 	$newBlocks = [
 		[
 			'clientId'    => 'heading-1',
-			'name'        => 'core/heading',
+			'name'        => 'artisanpack/heading',
 			'attributes'  => ['content' => 'Updated', 'level' => 2],
 			'innerBlocks' => [],
 		],
 		[
 			'clientId'    => 'paragraph-1',
-			'name'        => 'core/paragraph',
+			'name'        => 'artisanpack/paragraph',
 			'attributes'  => ['content' => 'Body text'],
 			'innerBlocks' => [
 				[
 					'clientId'    => 'inner-1',
-					'name'        => 'core/paragraph',
+					'name'        => 'artisanpack/paragraph',
 					'attributes'  => ['content' => 'Nested'],
 					'innerBlocks' => [],
 				],

--- a/tests/Unit/VisualEditor/BlockTypeRegistryTest.php
+++ b/tests/Unit/VisualEditor/BlockTypeRegistryTest.php
@@ -4,12 +4,10 @@ declare( strict_types=1 );
 
 use ArtisanPackUI\VisualEditor\Registries\BlockTypeRegistry;
 
-it( 'seeds core/paragraph and core/heading by default', function () {
+it( 'starts empty with no seeded blocks', function () {
 	$registry = new BlockTypeRegistry();
 
-	$names = array_column( $registry->all(), 'name' );
-
-	expect( $names )->toContain( 'core/paragraph', 'core/heading' );
+	expect( $registry->all() )->toBeEmpty();
 } );
 
 it( 'registers a valid namespaced block name', function () {
@@ -20,6 +18,24 @@ it( 'registers a valid namespaced block name', function () {
 	$names = array_column( $registry->all(), 'name' );
 
 	expect( $names )->toContain( 'acme/callout' );
+} );
+
+it( 'retrieves a single block by name', function () {
+	$registry = new BlockTypeRegistry();
+
+	$registry->register( 'acme/callout', ['title' => 'Callout', 'category' => 'text'] );
+
+	$block = $registry->get( 'acme/callout' );
+
+	expect( $block )->not->toBeNull()
+		->and( $block['title'] )->toBe( 'Callout' )
+		->and( $block['category'] )->toBe( 'text' );
+} );
+
+it( 'returns null for unregistered block names', function () {
+	$registry = new BlockTypeRegistry();
+
+	expect( $registry->get( 'acme/missing' ) )->toBeNull();
 } );
 
 it( 'rejects empty block names', function () {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,32 +4,70 @@ import { resolve } from 'node:path';
 
 const editorRoot = resolve(__dirname, 'resources/js/visual-editor/editor');
 
-export default defineConfig(({ command }) => ({
-    plugins: [react()],
-    root: command === 'serve' ? editorRoot : __dirname,
-    resolve: {
-        alias: {
-            '@editor': editorRoot,
-        },
-    },
-    server: {
-        port: 5175,
-        strictPort: false,
-    },
-    build: {
-        target: 'esnext',
-        outDir: resolve(__dirname, 'dist/editor'),
-        emptyOutDir: true,
-        manifest: false,
-        sourcemap: true,
-        rollupOptions: {
-            input: resolve(editorRoot, 'main.tsx'),
-            output: {
-                format: 'es',
-                entryFileNames: 'main.js',
-                chunkFileNames: '[name].js',
-                assetFileNames: '[name][extname]',
+export default defineConfig(({ command, mode }) => {
+    const isLibraryBuild = mode === 'lib';
+
+    return {
+        plugins: [react()],
+        root: command === 'serve' ? editorRoot : __dirname,
+        resolve: {
+            alias: {
+                '@editor': editorRoot,
             },
         },
-    },
-}));
+        server: {
+            port: 5175,
+            strictPort: false,
+        },
+        build: isLibraryBuild
+            ? {
+                // Library build — produces an ES module that external packages
+                // can import from. React, ReactDOM, and Zustand are externalized
+                // so they come from the host application's node_modules.
+                target: 'esnext',
+                outDir: resolve(__dirname, 'dist/lib'),
+                emptyOutDir: true,
+                sourcemap: true,
+                lib: {
+                    entry: resolve(editorRoot, 'index.ts'),
+                    formats: ['es'],
+                    fileName: 'visual-editor',
+                },
+                rollupOptions: {
+                    external: [
+                        'react',
+                        'react-dom',
+                        'react/jsx-runtime',
+                        'zustand',
+                        '@tiptap/react',
+                        '@tiptap/core',
+                        '@tiptap/extension-paragraph',
+                        '@tiptap/extension-heading',
+                        '@tiptap/extension-bold',
+                        '@tiptap/extension-italic',
+                        '@tiptap/extension-link',
+                        '@tiptap/extension-text',
+                        '@tiptap/extension-document',
+                        '@tiptap/extension-hard-break',
+                    ],
+                },
+            }
+            : {
+                // App build — produces the full bundled editor application.
+                target: 'esnext',
+                outDir: resolve(__dirname, 'dist/editor'),
+                emptyOutDir: true,
+                manifest: false,
+                sourcemap: true,
+                rollupOptions: {
+                    input: resolve(editorRoot, 'main.tsx'),
+                    output: {
+                        format: 'es',
+                        entryFileNames: 'main.js',
+                        chunkFileNames: '[name].js',
+                        assetFileNames: '[name][extname]',
+                    },
+                },
+            },
+    };
+});


### PR DESCRIPTION
## Description

Rebuild the block registration and rendering architecture to follow a WordPress Gutenberg-inspired `block.json`-driven, SOLID-principled model. Replaces hardcoded block wiring with a fully extensible system that third-party Composer packages can plug into.

**Closes:** #302

## Type of Change

- [x] New feature (adds new functionality)
- [x] Enhancement (improves existing functionality)
- [x] Refactoring (code improvement, no behavior change)

## Related Issue

**Issue:** #302

## Motivation and Context

The previous block system hardcoded block names in shared code (toolbar visibility, split/merge logic) and wired blocks in `main.tsx`, making it impossible for third-party packages to add custom blocks. This overhaul follows WordPress's `block.json` pattern where blocks declare their capabilities via manifests, and the editor queries them dynamically via `blockSupports()`.

## Changes Made

### Architecture
- Created `registry/types.ts` with full WordPress-parity `BlockJsonMetadata`, `BlockSupports`, `BlockAttributeSchema` types
- Added `registerBlockType(metadata, settings)` as primary registration API
- Added `blockSupports()` and `getBlockSupport()` for dot-path feature queries
- Refactored `inserterRegistry` to derive its list from unified block registry
- Removed all hardcoded block name sets (`TEXT_BLOCK_NAMES`, toolbar name checks)
- Standardized block namespace from `ve/` to `artisanpack/`

### Primitives
- Created `<RichText>` component wrapping Tiptap with focus/selection sync
- Heading and paragraph edit components refactored to use `<RichText>`

### PHP
- `VisualEditor::registerBlock($path)` reads block.json and registers in `BlockTypeRegistry`
- Removed hardcoded seeds from `BlockTypeRegistry` constructor
- Service provider registers core blocks via block.json in `boot()`
- REST endpoint response key: `{ data }` → `{ blocks }`
- Facade updated to `VisualEditor::class` accessor

### ES Module Export
- Public API barrel `index.ts` exports registry, primitives, store types
- Vite library build (`npm run build:lib`) produces 18.69 kB ES module
- `package.json` exports field configured

### New Blocks (using new architecture)
- List, Quote, Code, Preformatted — all with `block.json`, `registerBlockType()`, `<RichText>`

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS
- PHP Version: 8.4.3
- Node: v22

**Tests Performed:**
1. Vitest suite: 215 JS tests passing (26 test files)
2. PHP Pest suite: 27 tests passing (76 assertions)
3. Manual: All 6 blocks insertable, editable, slash command works
4. Library build: `npm run build:lib` produces valid ES module

## Accessibility Tests Run

- [x] Keyboard navigation tested
- [ ] Screen reader tested
- [ ] Color contrast verified
- [x] ARIA labels checked

**Details:** Code textarea has aria-label, quote citation has aria-label, list type toolbar buttons have aria-labels, language select has aria-label.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:**
- 4 new block test files (list, quote, code, preformatted)
- Updated inserterRegistry, insertBlockActions, InserterPanel, slashCommand tests for new namespace
- Updated PHP BlockTypeRegistryTest and BlocksControllerTest for new architecture

## Documentation

- [ ] Inline code documentation added
- [ ] README updated
- [ ] Wiki updated
- [ ] API documentation updated

**Documentation details:** JSDoc added to key new APIs. Full documentation deferred to docs issue.

## Pre-Submission Checklist

- [x] Code passes all tests
- [x] Code follows project style guide
- [x] Self-review completed
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds Code, List (bulleted/numbered), Quote (with citation), Preformatted, Heading, and Paragraph blocks to the visual editor; introduces a shared rich-text editor primitive and a public editor API surface.
  * Toolbar now exposes list-type controls for quick toggling between bulleted/numbered lists.
  * Inserter panel now surfaces core blocks from manifests and respects registry-sourced blocks.

* **Tests**
  * Added comprehensive block-level tests covering registration, rendering, editing, and attribute persistence.

* **Chores**
  * Build tooling updated to produce a library bundle and expose the editor entry with TypeScript typings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->