### PR TITLE
feat: M2 · core-data shim + i18n scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-vendor/
+/vendor/
 .idea/
 node_modules/
 dist/

--- a/README.md
+++ b/README.md
@@ -23,6 +23,27 @@ You can use any of the visual editor functions like this:
 Example Here
 ```
 
+## Gutenberg adoption — transient shims (V1)
+
+The V1 editor adopts the upstream `@wordpress/*` packages. Some of those packages expect a WordPress backend that this package does not provide yet, so we ship **temporary shims** under `resources/js/visual-editor/vendor/`:
+
+- **`core-data-shim.ts`** — aliased in `vite.config.ts` as `@wordpress/core-data`. Registers an empty `core` Redux store via `@wordpress/data` so Gutenberg's selectors (`getEntityRecord`, `getEntityRecords`, `getCurrentUser`, `getUsers`, `getMedia`, etc.) see "no data, done loading" instead of crashing. Blocks that need WordPress-specific data (navigation, query, post-*) render empty; those blocks land in the `disabled_blocks` list in M5.
+- **`media-upload-stub.tsx`** — registers `editor.MediaUpload` via `@wordpress/hooks` so the media-library picker on `core/image` is routed through a stub that displays an "M4 placeholder" notice instead of silently no-op'ing.
+
+Both shims will be replaced by `artisanpack-ui/cms-framework` (the real Laravel-backed `core-data` store and media bridge). Every selector or filter we implement here is one we have to re-verify against Gutenberg upgrades — expand the surface only when an observed crash demands it.
+
+## i18n
+
+Editor strings use `@wordpress/i18n` with the `artisanpack-visual-editor` text domain. The domain is initialized via `bootI18n()` in `resources/js/visual-editor/vendor/i18n.ts`.
+
+Regenerate the placeholder `.pot` catalog with:
+
+```bash
+npm run i18n:extract
+```
+
+The extractor scans `resources/js/visual-editor/**/*.{ts,tsx}` for `__/_x/_n/_nx` calls bound to the text domain and writes `languages/artisanpack-visual-editor.pot`. It is deliberately minimal — a richer extractor (template strings, plural forms, PHP scanning) replaces it post-V1.
+
 ## Contributing
 
 As an open source project, this package is open to contributions from anyone. Please [read through the contributing

--- a/languages/artisanpack-visual-editor.pot
+++ b/languages/artisanpack-visual-editor.pot
@@ -1,0 +1,22 @@
+# Copyright (C) Jacob Martella
+# This file is distributed under the same license as the ArtisanPack UI Visual Editor package.
+msgid ""
+msgstr ""
+"Project-Id-Version: artisanpack-ui-visual-editor\n"
+"POT-Creation-Date: 2026-04-19T01:03:55+0000\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Domain: artisanpack-visual-editor\n"
+
+#: resources/js/visual-editor/vendor/media-upload-stub.tsx:99
+msgid "File upload is a stub in M2. Integration with artisanpack-ui/media-library lands in M4."
+msgstr ""
+
+#: resources/js/visual-editor/sandbox/sandbox-editor.tsx:31
+msgid "Hello from the Gutenberg sandbox."
+msgstr ""
+
+#: resources/js/visual-editor/vendor/media-upload-stub.tsx:42
+msgid "The media library picker is a stub in M2. Integration with artisanpack-ui/media-library lands in M4."
+msgstr ""

--- a/languages/artisanpack-visual-editor.pot
+++ b/languages/artisanpack-visual-editor.pot
@@ -3,13 +3,13 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: artisanpack-ui-visual-editor\n"
-"POT-Creation-Date: 2026-04-19T01:03:55+0000\n"
+"POT-Creation-Date: 2026-04-19T01:15:58+0000\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Domain: artisanpack-visual-editor\n"
 
-#: resources/js/visual-editor/vendor/media-upload-stub.tsx:99
+#: resources/js/visual-editor/vendor/media-upload-stub.tsx:110
 msgid "File upload is a stub in M2. Integration with artisanpack-ui/media-library lands in M4."
 msgstr ""
 

--- a/languages/artisanpack-visual-editor.pot
+++ b/languages/artisanpack-visual-editor.pot
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: artisanpack-ui-visual-editor\n"
-"POT-Creation-Date: 2026-04-19T01:15:58+0000\n"
+"POT-Creation-Date: 2026-04-19T01:26:05+0000\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
         "build": "vite build",
         "build:lib": "vite build --mode lib",
         "test": "vitest run",
-        "test:watch": "vitest"
+        "test:watch": "vitest",
+        "i18n:extract": "node scripts/extract-pot.mjs"
     },
     "devDependencies": {
         "@testing-library/dom": "^10.4.0",

--- a/resources/js/visual-editor/sandbox/sandbox-editor.tsx
+++ b/resources/js/visual-editor/sandbox/sandbox-editor.tsx
@@ -10,22 +10,37 @@ import { registerCoreBlocks } from '@wordpress/block-library';
 import { Popover, SlotFillProvider } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
+import { bootI18n, TEXT_DOMAIN } from '../vendor/i18n';
+import {
+    mediaUploadStub,
+    registerMediaUploadStub,
+} from '../vendor/media-upload-stub';
+
 import '@wordpress/components/build-style/style.css';
 import '@wordpress/block-editor/build-style/style.css';
 import '@wordpress/block-editor/build-style/content.css';
 import '@wordpress/block-library/build-style/style.css';
 import '@wordpress/block-library/build-style/editor.css';
 
+bootI18n();
+registerMediaUploadStub();
 registerCoreBlocks();
 
 const initialBlocks: BlockInstance[] = [
     createBlock('core/paragraph', {
-        content: __(
-            'Hello from the Gutenberg sandbox.',
-            'artisanpack-visual-editor'
-        ),
+        content: __('Hello from the Gutenberg sandbox.', TEXT_DOMAIN),
     }),
+    // Sanity-check for the M2 core-data shim: the image block's placeholder
+    // renders against the (empty) `core` store without crashing. See #312.
+    createBlock('core/image', {}),
 ];
+
+// `MediaUploadCheck` (in @wordpress/block-editor) hides the "Media Library"
+// button when `settings.mediaUpload` is falsy. The M2 stub gates the button
+// in; the editor.MediaUpload filter then intercepts the click. See #312.
+const sandboxSettings = {
+    mediaUpload: mediaUploadStub,
+};
 
 /**
  * Minimal `BlockEditorProvider` mount used to prove `@wordpress/*` imports
@@ -39,6 +54,7 @@ export function SandboxEditor(): JSX.Element {
         <SlotFillProvider>
             <BlockEditorProvider
                 value={blocks}
+                settings={sandboxSettings}
                 onInput={(next: BlockInstance[]) => setBlocks(next)}
                 onChange={(next: BlockInstance[]) => setBlocks(next)}
             >

--- a/resources/js/visual-editor/vendor/__tests__/core-data-shim.test.tsx
+++ b/resources/js/visual-editor/vendor/__tests__/core-data-shim.test.tsx
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { select } from '@wordpress/data';
+
+import {
+    EntityProvider,
+    store,
+    useEntityBlockEditor,
+    useEntityId,
+    useEntityProp,
+    useEntityRecord,
+    useEntityRecords,
+    useResourcePermissions,
+} from '../core-data-shim';
+
+describe('core-data-shim store', () => {
+    it('registers under the "core" key', () => {
+        expect(store).toBeDefined();
+    });
+
+    it('returns null from getEntityRecord-family selectors', () => {
+        const coreSelect = select('core') as Record<
+            string,
+            (...args: unknown[]) => unknown
+        >;
+
+        expect(coreSelect.getEntityRecord('postType', 'post', 1)).toBeNull();
+        expect(coreSelect.getCurrentUser()).toBeNull();
+        expect(coreSelect.getMedia(42)).toBeNull();
+    });
+
+    it('returns [] from list selectors', () => {
+        const coreSelect = select('core') as Record<
+            string,
+            (...args: unknown[]) => unknown
+        >;
+
+        expect(coreSelect.getEntityRecords('postType', 'post')).toEqual([]);
+        expect(coreSelect.getUsers()).toEqual([]);
+    });
+
+    it('reports resolution as finished and not in-flight', () => {
+        const coreSelect = select('core') as Record<
+            string,
+            (...args: unknown[]) => unknown
+        >;
+
+        expect(
+            coreSelect.hasFinishedResolution('getEntityRecord', [
+                'postType',
+                'post',
+                1,
+            ])
+        ).toBe(true);
+        expect(
+            coreSelect.isResolving('getEntityRecord', ['postType', 'post', 1])
+        ).toBe(false);
+    });
+});
+
+describe('core-data-shim hooks', () => {
+    function renderHook<T>(hook: () => T): T {
+        let captured!: T;
+        function Probe() {
+            captured = hook();
+            return null;
+        }
+        render(<Probe />);
+        return captured;
+    }
+
+    it('useEntityRecord returns an empty, resolved record', () => {
+        const result = renderHook(() => useEntityRecord());
+        expect(result).toMatchObject({
+            record: null,
+            editedRecord: null,
+            hasEdits: false,
+            hasResolved: true,
+            isResolving: false,
+        });
+        expect(typeof result.edit).toBe('function');
+        expect(typeof result.save).toBe('function');
+    });
+
+    it('useEntityRecords returns an empty, resolved list', () => {
+        const result = renderHook(() => useEntityRecords());
+        expect(result.records).toEqual([]);
+        expect(result.hasResolved).toBe(true);
+        expect(result.isResolving).toBe(false);
+        expect(result.totalItems).toBe(0);
+        expect(result.totalPages).toBe(0);
+    });
+
+    it('useEntityProp returns [undefined, setter, undefined]', () => {
+        const [value, setter, rawValue] = renderHook(() => useEntityProp());
+        expect(value).toBeUndefined();
+        expect(rawValue).toBeUndefined();
+        expect(typeof setter).toBe('function');
+    });
+
+    it('useEntityBlockEditor returns an empty block list and stable setters', () => {
+        const [blocks, onInput, onChange] = renderHook(() =>
+            useEntityBlockEditor()
+        );
+        expect(blocks).toEqual([]);
+        expect(typeof onInput).toBe('function');
+        expect(typeof onChange).toBe('function');
+    });
+
+    it('useResourcePermissions denies everything and reports resolved', () => {
+        const perms = renderHook(() => useResourcePermissions());
+        expect(perms).toEqual({
+            canCreate: false,
+            canUpdate: false,
+            canDelete: false,
+            isResolving: false,
+        });
+    });
+
+    it('useEntityId reads from EntityProvider context', () => {
+        function Probe() {
+            const id = useEntityId();
+            return <span data-testid="probe">{String(id ?? 'none')}</span>;
+        }
+
+        render(
+            <EntityProvider kind="postType" name="page" id={7}>
+                <Probe />
+            </EntityProvider>
+        );
+
+        expect(screen.getByTestId('probe').textContent).toBe('7');
+    });
+
+    it('useEntityId returns undefined outside EntityProvider', () => {
+        function Probe() {
+            const id = useEntityId();
+            return <span data-testid="probe">{String(id ?? 'none')}</span>;
+        }
+
+        render(<Probe />);
+        expect(screen.getByTestId('probe').textContent).toBe('none');
+    });
+});

--- a/resources/js/visual-editor/vendor/__tests__/i18n.test.ts
+++ b/resources/js/visual-editor/vendor/__tests__/i18n.test.ts
@@ -1,0 +1,33 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { getLocaleData } from '@wordpress/i18n';
+
+import { bootI18n, TEXT_DOMAIN, __resetI18nForTests } from '../i18n';
+
+describe('i18n bootstrap', () => {
+    beforeEach(() => {
+        __resetI18nForTests();
+    });
+
+    it('registers the artisanpack-visual-editor text domain', () => {
+        bootI18n();
+
+        const data = getLocaleData(TEXT_DOMAIN);
+        expect(data).toBeDefined();
+        const header = data?.[''] as
+            | { domain?: string; lang?: string }
+            | undefined;
+        expect(header).toMatchObject({
+            domain: TEXT_DOMAIN,
+            lang: 'en',
+        });
+    });
+
+    it('is idempotent across repeat calls', () => {
+        bootI18n();
+        bootI18n();
+
+        const data = getLocaleData(TEXT_DOMAIN);
+        const header = data?.[''] as { domain?: string } | undefined;
+        expect(header?.domain).toBe(TEXT_DOMAIN);
+    });
+});

--- a/resources/js/visual-editor/vendor/core-data-shim.ts
+++ b/resources/js/visual-editor/vendor/core-data-shim.ts
@@ -1,0 +1,199 @@
+/**
+ * Minimal empty-state shim for `@wordpress/core-data`.
+ *
+ * Gutenberg's block-editor and block-library import from `@wordpress/core-data`
+ * whether we want them to or not. Without a shim, importing any of those
+ * modules crashes because there is no WordPress backend to feed the real
+ * package's REST resolvers. This module is aliased in `vite.config.ts` so that
+ * every `import … from '@wordpress/core-data'` in the editor bundle resolves
+ * here instead of the upstream package.
+ *
+ * The shim intentionally returns empty/no-op values for every surface it
+ * implements. Blocks that depend on WordPress-specific data (navigation,
+ * query, post-*) will gracefully render empty; those blocks are slated to
+ * land in the `disabled_blocks` list during M5.
+ *
+ * **This shim is temporary.** The `artisanpack-ui/cms-framework` package will
+ * replace it with a real Laravel-backed `core` store. Every selector we
+ * implement here is a selector we have to re-verify against Gutenberg
+ * upgrades — keep the surface as small as observed crashes allow.
+ *
+ * Tracked by issue #312 (M2 of the Gutenberg adoption, umbrella #309).
+ */
+
+import {
+    createContext,
+    createElement,
+    useContext,
+    useMemo,
+    type PropsWithChildren,
+    type ReactElement,
+} from 'react';
+import { createReduxStore, register } from '@wordpress/data';
+
+type EntityRecord = Record<string, unknown> | null;
+type EntityKey = number | string;
+
+interface EntityIdentity {
+    readonly kind: string;
+    readonly name: string;
+    readonly id: EntityKey | undefined;
+}
+
+const EMPTY_RECORDS: readonly never[] = Object.freeze([]);
+const STORE_NAME = 'core';
+
+const selectors = {
+    getEntityRecord: (): EntityRecord => null,
+    getEntityRecords: (): readonly never[] => EMPTY_RECORDS,
+    getEditedEntityRecord: (): EntityRecord => null,
+    getRawEntityRecord: (): EntityRecord => null,
+    getCurrentUser: (): EntityRecord => null,
+    getUsers: (): readonly never[] => EMPTY_RECORDS,
+    getMedia: (): EntityRecord => null,
+    getMediaItems: (): readonly never[] => EMPTY_RECORDS,
+    getEntityRecordsTotalItems: (): number => 0,
+    getEntityRecordsTotalPages: (): number => 0,
+    hasFinishedResolution: (): boolean => true,
+    hasStartedResolution: (): boolean => true,
+    isResolving: (): boolean => false,
+    hasEditsForEntityRecord: (): boolean => false,
+    getEntityRecordEdits: (): EntityRecord => null,
+    getEntityRecordNonTransientEdits: (): EntityRecord => null,
+    canUser: (): boolean => false,
+    canUserEditEntityRecord: (): boolean => false,
+    getAutosaves: (): readonly never[] => EMPTY_RECORDS,
+    getAutosave: (): EntityRecord => null,
+    getReferenceByDistinctEdits: (): number[] => [],
+    isSavingEntityRecord: (): boolean => false,
+    isDeletingEntityRecord: (): boolean => false,
+    getLastEntitySaveError: (): null => null,
+    getLastEntityDeleteError: (): null => null,
+};
+
+const actions = {
+    receiveEntityRecords:
+        () =>
+        ({ dispatch }: { dispatch: () => void }) => {
+            dispatch();
+        },
+    receiveUserQuery: () => ({ type: 'SHIM_NOOP' }) as const,
+    receiveCurrentUser: () => ({ type: 'SHIM_NOOP' }) as const,
+    saveEntityRecord: () => async (): Promise<null> => null,
+    saveEditedEntityRecord: () => async (): Promise<null> => null,
+    deleteEntityRecord: () => async (): Promise<boolean> => true,
+    editEntityRecord: () => ({ type: 'SHIM_NOOP' }) as const,
+    undo: () => ({ type: 'SHIM_NOOP' }) as const,
+    redo: () => ({ type: 'SHIM_NOOP' }) as const,
+    __unstableCreateUndoLevel: () => ({ type: 'SHIM_NOOP' }) as const,
+};
+
+const reducer = (state: Record<string, never> = {}): Record<string, never> =>
+    state;
+
+export const store = createReduxStore(STORE_NAME, {
+    reducer,
+    actions,
+    selectors,
+});
+
+register(store);
+
+/**
+ * `EntityProvider` in upstream `@wordpress/core-data` supplies the ambient
+ * entity identity (kind/name/id) to hooks like `useEntityProp`. The shim
+ * preserves that contract so blocks reading the context don't throw, but the
+ * default value is an empty identity since there is no backing store yet.
+ */
+const EntityContext = createContext<EntityIdentity>({
+    kind: '',
+    name: '',
+    id: undefined,
+});
+
+export function EntityProvider(
+    props: PropsWithChildren<EntityIdentity>
+): ReactElement {
+    const { kind, name, id, children } = props;
+    const value = useMemo<EntityIdentity>(
+        () => ({ kind, name, id }),
+        [kind, name, id]
+    );
+
+    return createElement(EntityContext.Provider, { value }, children);
+}
+
+export function useEntityId(): EntityKey | undefined {
+    return useContext(EntityContext).id;
+}
+
+/**
+ * No-op setter returned by write-capable hooks. Kept as a module-level
+ * singleton so React memoization downstream doesn't see a fresh function
+ * identity on every render.
+ */
+const noopSetter = (): void => {};
+
+export function useEntityProp<T = unknown>(): [T | undefined, typeof noopSetter, T | undefined] {
+    return [undefined, noopSetter, undefined];
+}
+
+export function useEntityRecord<T = unknown>(): {
+    record: T | null;
+    editedRecord: T | null;
+    hasEdits: boolean;
+    hasResolved: boolean;
+    isResolving: boolean;
+    edit: typeof noopSetter;
+    save: () => Promise<null>;
+} {
+    return {
+        record: null,
+        editedRecord: null,
+        hasEdits: false,
+        hasResolved: true,
+        isResolving: false,
+        edit: noopSetter,
+        save: async () => null,
+    };
+}
+
+export function useEntityRecords<T = unknown>(): {
+    records: readonly T[];
+    hasResolved: boolean;
+    isResolving: boolean;
+    status: 'IDLE';
+    totalItems: number;
+    totalPages: number;
+} {
+    return {
+        records: EMPTY_RECORDS as readonly T[],
+        hasResolved: true,
+        isResolving: false,
+        status: 'IDLE',
+        totalItems: 0,
+        totalPages: 0,
+    };
+}
+
+export function useEntityBlockEditor(): [
+    readonly never[],
+    typeof noopSetter,
+    typeof noopSetter,
+] {
+    return [EMPTY_RECORDS, noopSetter, noopSetter];
+}
+
+export function useResourcePermissions(): {
+    canCreate: boolean;
+    canUpdate: boolean;
+    canDelete: boolean;
+    isResolving: boolean;
+} {
+    return {
+        canCreate: false,
+        canUpdate: false,
+        canDelete: false,
+        isResolving: false,
+    };
+}

--- a/resources/js/visual-editor/vendor/core-data-shim.ts
+++ b/resources/js/visual-editor/vendor/core-data-shim.ts
@@ -72,11 +72,7 @@ const selectors = {
 };
 
 const actions = {
-    receiveEntityRecords:
-        () =>
-        ({ dispatch }: { dispatch: () => void }) => {
-            dispatch();
-        },
+    receiveEntityRecords: () => ({ type: 'SHIM_NOOP' }) as const,
     receiveUserQuery: () => ({ type: 'SHIM_NOOP' }) as const,
     receiveCurrentUser: () => ({ type: 'SHIM_NOOP' }) as const,
     saveEntityRecord: () => async (): Promise<null> => null,

--- a/resources/js/visual-editor/vendor/i18n.ts
+++ b/resources/js/visual-editor/vendor/i18n.ts
@@ -1,0 +1,53 @@
+/**
+ * i18n bootstrap for the visual editor.
+ *
+ * Initializes `@wordpress/i18n` with an empty default locale (English) for
+ * the `artisanpack-visual-editor` text domain. All `__('…', 'artisanpack-visual-editor')`
+ * calls in the editor fall through to the original English strings until real
+ * translations are loaded.
+ *
+ * This scaffolds the i18n story for future milestones — a Laravel-side
+ * extraction command (see `composer visual-editor:pot` in the package
+ * composer.json) will produce a `.pot` file, and loaded translations will be
+ * installed here via `setLocaleData()` on editor boot.
+ *
+ * Tracked by issue #312 (M2 of the Gutenberg adoption, umbrella #309).
+ */
+
+import { setLocaleData } from '@wordpress/i18n';
+
+export const TEXT_DOMAIN = 'artisanpack-visual-editor';
+
+/**
+ * Minimum Jed locale payload. Calling `setLocaleData` with an empty messages
+ * map initializes the domain so later `__()` calls succeed and are routed
+ * through the domain's Tannin instance instead of the global one.
+ */
+const DEFAULT_LOCALE_DATA = {
+    '': {
+        domain: TEXT_DOMAIN,
+        lang: 'en',
+    },
+};
+
+let initialized = false;
+
+/**
+ * Boot the editor's i18n domain. Safe to call multiple times; subsequent
+ * calls are no-ops so hot-module reloads don't wipe loaded translations.
+ */
+export function bootI18n(): void {
+    if (initialized) {
+        return;
+    }
+
+    setLocaleData(DEFAULT_LOCALE_DATA, TEXT_DOMAIN);
+    initialized = true;
+}
+
+/**
+ * Test-only reset hook. Not exported from the package entry point.
+ */
+export function __resetI18nForTests(): void {
+    initialized = false;
+}

--- a/resources/js/visual-editor/vendor/media-upload-stub.tsx
+++ b/resources/js/visual-editor/vendor/media-upload-stub.tsx
@@ -54,12 +54,23 @@ function MediaUploadStub(props: MediaUploadProps): ReactElement | null {
     }
 
     // Some call sites pass a single button-like child expecting `onClick` to
-    // be wired to `open`. Clone it so clicking routes to the stub handler.
+    // be wired to `open`. Clone it so clicking routes to the stub handler —
+    // and if the child already has its own onClick, invoke both so the host
+    // can still observe the event.
     const onlyChild = Children.toArray(children).find(isValidElement);
 
     if (onlyChild) {
+        const existingOnClick = (
+            onlyChild as ReactElement<{
+                onClick?: (event: unknown) => void;
+            }>
+        ).props.onClick;
+
         return cloneElement(onlyChild as ReactElement, {
-            onClick: openMediaLibraryStub,
+            onClick: (event: unknown) => {
+                existingOnClick?.(event);
+                openMediaLibraryStub();
+            },
         });
     }
 

--- a/resources/js/visual-editor/vendor/media-upload-stub.tsx
+++ b/resources/js/visual-editor/vendor/media-upload-stub.tsx
@@ -1,0 +1,104 @@
+/**
+ * Temporary MediaUpload slot-fill stub.
+ *
+ * `@wordpress/block-editor`'s `MediaUpload` component is a `withFilters`
+ * placeholder — upstream WordPress registers the real modal via the
+ * `editor.MediaUpload` filter. Without a registered replacement, clicking
+ * "Media Library" on core/image's placeholder silently does nothing.
+ *
+ * This stub gives the user feedback that the feature is wired but not yet
+ * implemented. The real implementation arrives in M4 when the media library
+ * from `artisanpack-ui/media-library` is bridged into the editor.
+ *
+ * Tracked by issue #312 (M2 of the Gutenberg adoption, umbrella #309).
+ */
+
+import { addFilter } from '@wordpress/hooks';
+import { __ } from '@wordpress/i18n';
+import {
+    Children,
+    cloneElement,
+    isValidElement,
+    type ReactElement,
+    type ReactNode,
+} from 'react';
+
+import { TEXT_DOMAIN } from './i18n';
+
+interface MediaUploadRenderArgs {
+    open: () => void;
+}
+
+interface MediaUploadProps {
+    render?: (args: MediaUploadRenderArgs) => ReactElement | null;
+    children?: ReactNode;
+}
+
+const FILTER_NAMESPACE = 'artisanpack-ui/visual-editor/media-upload-stub';
+
+function openMediaLibraryStub(): void {
+    // eslint-disable-next-line no-alert -- intentional user-facing stub feedback until M4.
+    window.alert(
+        __(
+            'The media library picker is a stub in M2. Integration with artisanpack-ui/media-library lands in M4.',
+            TEXT_DOMAIN
+        )
+    );
+}
+
+function MediaUploadStub(props: MediaUploadProps): ReactElement | null {
+    const { render, children } = props;
+
+    if (typeof render === 'function') {
+        return render({ open: openMediaLibraryStub });
+    }
+
+    // Some call sites pass a single button-like child expecting `onClick` to
+    // be wired to `open`. Clone it so clicking routes to the stub handler.
+    const onlyChild = Children.toArray(children).find(isValidElement);
+
+    if (onlyChild) {
+        return cloneElement(onlyChild as ReactElement, {
+            onClick: openMediaLibraryStub,
+        });
+    }
+
+    return null;
+}
+
+let registered = false;
+
+export function registerMediaUploadStub(): void {
+    if (registered) {
+        return;
+    }
+
+    addFilter(
+        'editor.MediaUpload',
+        FILTER_NAMESPACE,
+        () => MediaUploadStub
+    );
+    registered = true;
+}
+
+/**
+ * Stub `mediaUpload` function for `BlockEditorProvider`'s `settings` prop.
+ *
+ * `MediaUploadCheck` (in `@wordpress/block-editor`) reads
+ * `settings.mediaUpload` via `useSelect` on the block-editor store and hides
+ * the "Media Library" button on placeholders like `core/image` when it's
+ * falsy. A truthy function is enough to gate the button in — our
+ * `editor.MediaUpload` filter above then intercepts the actual click.
+ *
+ * The real upload pipeline lands in M4 when `artisanpack-ui/media-library`
+ * is bridged into the editor.
+ */
+export function mediaUploadStub(): void {
+    // eslint-disable-next-line no-alert -- intentional user-facing stub feedback until M4.
+    window.alert(
+        __(
+            'File upload is a stub in M2. Integration with artisanpack-ui/media-library lands in M4.',
+            TEXT_DOMAIN
+        )
+    );
+}

--- a/scripts/extract-pot.mjs
+++ b/scripts/extract-pot.mjs
@@ -61,11 +61,14 @@ async function collectSourceFiles(dir) {
  */
 /**
  * The text-domain argument may be either a literal string
- * (`'artisanpack-visual-editor'`) or the `TEXT_DOMAIN` identifier re-exported
- * from `vendor/i18n.ts`. The richer extractor (post-V1) will resolve
- * identifiers through the TS AST instead of lexical pattern matching.
+ * (`'artisanpack-visual-editor'` or `"artisanpack-visual-editor"`) or the
+ * `TEXT_DOMAIN` identifier re-exported from `vendor/i18n.ts`. Both literal
+ * forms are listed explicitly — embedding a capture-group alternation would
+ * shift backreference numbering when the fragment is spliced into a larger
+ * pattern that already captures a quote. The richer extractor (post-V1) will
+ * resolve identifiers through the TS AST instead of lexical pattern matching.
  */
-const DOMAIN = `(?:(['"])artisanpack-visual-editor\\1|TEXT_DOMAIN)`;
+const DOMAIN = `(?:'artisanpack-visual-editor'|"artisanpack-visual-editor"|TEXT_DOMAIN)`;
 
 const CALL_PATTERNS = [
     {

--- a/scripts/extract-pot.mjs
+++ b/scripts/extract-pot.mjs
@@ -1,0 +1,249 @@
+#!/usr/bin/env node
+/**
+ * Placeholder .pot extractor for the visual editor (#312, M2).
+ *
+ * Scans `resources/js/visual-editor/**\/*.{ts,tsx}` for calls to the
+ * `@wordpress/i18n` translation functions (__, _x, _n, _nx) bound to the
+ * `artisanpack-visual-editor` text domain and emits a gettext .pot file
+ * at `languages/artisanpack-visual-editor.pot`.
+ *
+ * This is deliberately minimal — it exists so translators have a baseline
+ * template to work from during the Gutenberg adoption and so contributors
+ * have a reproducible command. A richer extractor (plural forms, context
+ * comments, PHP scanning, deduping with source-line accumulation) will
+ * replace it when translation work ramps up post-V1.
+ */
+
+import { readdir, readFile, writeFile, mkdir } from 'node:fs/promises';
+import { join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = fileURLToPath(new URL('..', import.meta.url));
+const SOURCE_DIR = join(ROOT, 'resources/js/visual-editor');
+const OUTPUT_DIR = join(ROOT, 'languages');
+const OUTPUT_FILE = join(OUTPUT_DIR, 'artisanpack-visual-editor.pot');
+const TEXT_DOMAIN = 'artisanpack-visual-editor';
+
+// `_legacy` holds reference-only code deleted at V1 ship; skip it so stale
+// translations don't pollute the .pot. node_modules and dist are never scanned.
+// `resources/js/visual-editor/vendor/` holds in-repo shims — those DO contain
+// editor-facing translatable strings, so it stays in scope.
+const IGNORED_DIRS = new Set(['_legacy', 'node_modules', 'dist']);
+
+/** @param {string} dir */
+async function collectSourceFiles(dir) {
+    /** @type {string[]} */
+    const found = [];
+    const entries = await readdir(dir, { withFileTypes: true });
+
+    for (const entry of entries) {
+        if (entry.isDirectory()) {
+            if (IGNORED_DIRS.has(entry.name)) {
+                continue;
+            }
+            found.push(...(await collectSourceFiles(join(dir, entry.name))));
+            continue;
+        }
+        if (/\.(ts|tsx)$/.test(entry.name)) {
+            found.push(join(dir, entry.name));
+        }
+    }
+
+    return found;
+}
+
+/**
+ * Match `__('msg', 'domain')`, `_x('msg', 'ctx', 'domain')`,
+ * `_n('one', 'many', count, 'domain')`, `_nx('one', 'many', count, 'ctx', 'domain')`.
+ * Keep the regex conservative — only single-line literal string args with the
+ * expected text domain are picked up. Template strings and concatenations are
+ * silently skipped; the richer extractor will handle those later.
+ */
+/**
+ * The text-domain argument may be either a literal string
+ * (`'artisanpack-visual-editor'`) or the `TEXT_DOMAIN` identifier re-exported
+ * from `vendor/i18n.ts`. The richer extractor (post-V1) will resolve
+ * identifiers through the TS AST instead of lexical pattern matching.
+ */
+const DOMAIN = `(?:(['"])artisanpack-visual-editor\\1|TEXT_DOMAIN)`;
+
+const CALL_PATTERNS = [
+    {
+        fn: '__',
+        regex: new RegExp(
+            `\\b__\\(\\s*(['"])((?:\\\\\\1|(?!\\1).)*?)\\1\\s*,\\s*${DOMAIN}\\s*\\)`,
+            'g'
+        ),
+        groups: { msgid: 2 },
+    },
+    {
+        fn: '_x',
+        regex: new RegExp(
+            `\\b_x\\(\\s*(['"])((?:\\\\\\1|(?!\\1).)*?)\\1\\s*,\\s*(['"])((?:\\\\\\3|(?!\\3).)*?)\\3\\s*,\\s*${DOMAIN}\\s*\\)`,
+            'g'
+        ),
+        groups: { msgid: 2, msgctxt: 4 },
+    },
+    {
+        fn: '_n',
+        regex: new RegExp(
+            `\\b_n\\(\\s*(['"])((?:\\\\\\1|(?!\\1).)*?)\\1\\s*,\\s*(['"])((?:\\\\\\3|(?!\\3).)*?)\\3\\s*,\\s*[^,]+,\\s*${DOMAIN}\\s*\\)`,
+            'g'
+        ),
+        groups: { msgid: 2, msgid_plural: 4 },
+    },
+    {
+        fn: '_nx',
+        regex: new RegExp(
+            `\\b_nx\\(\\s*(['"])((?:\\\\\\1|(?!\\1).)*?)\\1\\s*,\\s*(['"])((?:\\\\\\3|(?!\\3).)*?)\\3\\s*,\\s*[^,]+,\\s*(['"])((?:\\\\\\5|(?!\\5).)*?)\\5\\s*,\\s*${DOMAIN}\\s*\\)`,
+            'g'
+        ),
+        groups: { msgid: 2, msgid_plural: 4, msgctxt: 6 },
+    },
+];
+
+/**
+ * @param {string} file
+ * @param {string} source
+ * @param {number} offset
+ */
+function lineOf(source, offset) {
+    let line = 1;
+    for (let i = 0; i < offset && i < source.length; i += 1) {
+        if (source[i] === '\n') {
+            line += 1;
+        }
+    }
+    return line;
+}
+
+/**
+ * Strip `//` line comments and `/* … *\/` block comments so translation call
+ * examples embedded in JSDoc don't show up in the .pot. The replacement keeps
+ * newlines intact so line-number references stay accurate.
+ *
+ * @param {string} source
+ * @returns {string}
+ */
+function stripComments(source) {
+    return source
+        .replace(/\/\*[\s\S]*?\*\//g, (match) =>
+            match.replace(/[^\n]/g, ' ')
+        )
+        .replace(/(^|[^:])\/\/[^\n]*/g, (_match, prefix) => prefix);
+}
+
+function escapePotString(value) {
+    return value
+        .replace(/\\/g, '\\\\')
+        .replace(/"/g, '\\"')
+        .replace(/\n/g, '\\n')
+        .replace(/\t/g, '\\t');
+}
+
+/** @type {Map<string, { msgid: string; msgctxt?: string; msgid_plural?: string; references: Set<string> }>} */
+const entries = new Map();
+
+function keyFor(entry) {
+    return `${entry.msgctxt ?? ''}\u0004${entry.msgid}`;
+}
+
+async function extract() {
+    const files = await collectSourceFiles(SOURCE_DIR);
+
+    for (const file of files) {
+        const raw = await readFile(file, 'utf8');
+        const source = stripComments(raw);
+        const rel = relative(ROOT, file);
+
+        for (const pattern of CALL_PATTERNS) {
+            pattern.regex.lastIndex = 0;
+            let match;
+            while ((match = pattern.regex.exec(source)) !== null) {
+                const entry = {
+                    msgid: match[pattern.groups.msgid],
+                    msgctxt: pattern.groups.msgctxt
+                        ? match[pattern.groups.msgctxt]
+                        : undefined,
+                    msgid_plural: pattern.groups.msgid_plural
+                        ? match[pattern.groups.msgid_plural]
+                        : undefined,
+                };
+                const key = keyFor(entry);
+                const existing = entries.get(key);
+                const reference = `${rel}:${lineOf(source, match.index)}`;
+                if (existing) {
+                    existing.references.add(reference);
+                } else {
+                    entries.set(key, {
+                        msgid: entry.msgid,
+                        msgctxt: entry.msgctxt,
+                        msgid_plural: entry.msgid_plural,
+                        references: new Set([reference]),
+                    });
+                }
+            }
+        }
+    }
+
+    return entries;
+}
+
+function renderPot(entries) {
+    const now = new Date().toISOString().replace(/\.\d{3}Z$/, '+0000');
+    const header = [
+        '# Copyright (C) Jacob Martella',
+        '# This file is distributed under the same license as the ArtisanPack UI Visual Editor package.',
+        'msgid ""',
+        'msgstr ""',
+        `"Project-Id-Version: artisanpack-ui-visual-editor\\n"`,
+        `"POT-Creation-Date: ${now}\\n"`,
+        '"MIME-Version: 1.0\\n"',
+        '"Content-Type: text/plain; charset=UTF-8\\n"',
+        '"Content-Transfer-Encoding: 8bit\\n"',
+        `"X-Domain: ${TEXT_DOMAIN}\\n"`,
+        '',
+    ].join('\n');
+
+    const body = [...entries.values()]
+        .sort((a, b) => a.msgid.localeCompare(b.msgid))
+        .map((entry) => {
+            const lines = [];
+            for (const ref of [...entry.references].sort()) {
+                lines.push(`#: ${ref}`);
+            }
+            if (entry.msgctxt !== undefined) {
+                lines.push(`msgctxt "${escapePotString(entry.msgctxt)}"`);
+            }
+            lines.push(`msgid "${escapePotString(entry.msgid)}"`);
+            if (entry.msgid_plural !== undefined) {
+                lines.push(
+                    `msgid_plural "${escapePotString(entry.msgid_plural)}"`
+                );
+                lines.push('msgstr[0] ""');
+                lines.push('msgstr[1] ""');
+            } else {
+                lines.push('msgstr ""');
+            }
+            return lines.join('\n');
+        })
+        .join('\n\n');
+
+    return `${header}\n${body}\n`;
+}
+
+async function main() {
+    await mkdir(OUTPUT_DIR, { recursive: true });
+    const collected = await extract();
+    const output = renderPot(collected);
+    await writeFile(OUTPUT_FILE, output, 'utf8');
+    const target = relative(ROOT, OUTPUT_FILE);
+    console.log(
+        `Wrote ${collected.size} translation string(s) to ${target}.`
+    );
+}
+
+main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+});

--- a/scripts/extract-pot.mjs
+++ b/scripts/extract-pot.mjs
@@ -122,18 +122,74 @@ function lineOf(source, offset) {
 
 /**
  * Strip `//` line comments and `/* … *\/` block comments so translation call
- * examples embedded in JSDoc don't show up in the .pot. The replacement keeps
- * newlines intact so line-number references stay accurate.
+ * examples embedded in JSDoc don't show up in the .pot. The scanner tracks
+ * string state (single-quote, double-quote, template) and escape characters,
+ * so `//` inside a quoted literal (e.g. `__('Visit https://example.com', …)`)
+ * is preserved. Newlines are kept intact inside block comments so line-number
+ * references downstream stay accurate.
+ *
+ * Known limitation: regex literals (`/foo\/bar/`) are not detected, so a
+ * `//` inside a regex literal could still be stripped. This is acceptable
+ * for the placeholder extractor — a richer AST-based extractor lands post-V1.
  *
  * @param {string} source
  * @returns {string}
  */
 function stripComments(source) {
-    return source
-        .replace(/\/\*[\s\S]*?\*\//g, (match) =>
-            match.replace(/[^\n]/g, ' ')
-        )
-        .replace(/(^|[^:])\/\/[^\n]*/g, (_match, prefix) => prefix);
+    let out = '';
+    let i = 0;
+    const n = source.length;
+
+    while (i < n) {
+        const ch = source[i];
+        const next = source[i + 1];
+
+        if (ch === '/' && next === '*') {
+            i += 2;
+            while (i < n && !(source[i] === '*' && source[i + 1] === '/')) {
+                out += source[i] === '\n' ? '\n' : ' ';
+                i += 1;
+            }
+            if (i < n) {
+                out += '  ';
+                i += 2;
+            }
+            continue;
+        }
+
+        if (ch === '/' && next === '/') {
+            i += 2;
+            while (i < n && source[i] !== '\n') {
+                i += 1;
+            }
+            continue;
+        }
+
+        if (ch === "'" || ch === '"' || ch === '`') {
+            const quote = ch;
+            out += ch;
+            i += 1;
+            while (i < n) {
+                const c = source[i];
+                out += c;
+                i += 1;
+                if (c === '\\' && i < n) {
+                    out += source[i];
+                    i += 1;
+                    continue;
+                }
+                if (c === quote) {
+                    break;
+                }
+            }
+            continue;
+        }
+
+        out += ch;
+        i += 1;
+    }
+
+    return out;
 }
 
 function escapePotString(value) {
@@ -177,6 +233,16 @@ async function extract() {
                 const reference = `${rel}:${lineOf(source, match.index)}`;
                 if (existing) {
                     existing.references.add(reference);
+                    // Singular-first / plural-later: promote the plural form
+                    // into the existing entry so `_n`/`_nx` callers don't
+                    // lose their plural data when a `__` call appeared first.
+                    // (msgctxt keys the entry, so it can't differ here.)
+                    if (
+                        existing.msgid_plural === undefined &&
+                        entry.msgid_plural !== undefined
+                    ) {
+                        existing.msgid_plural = entry.msgid_plural;
+                    }
                 } else {
                     entries.set(key, {
                         msgid: entry.msgid,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,10 @@ import { resolve } from 'node:path';
 // See docs/gutenberg-adoption.md and issue #309.
 const editorRoot = resolve(__dirname, 'resources/js/visual-editor/_legacy/editor');
 const sandboxEntry = resolve(__dirname, 'resources/js/visual-editor/sandbox/main.tsx');
+const coreDataShim = resolve(
+    __dirname,
+    'resources/js/visual-editor/vendor/core-data-shim.ts'
+);
 
 export default defineConfig(({ command, mode }) => {
     const isLibraryBuild = mode === 'lib';
@@ -19,6 +23,11 @@ export default defineConfig(({ command, mode }) => {
         resolve: {
             alias: {
                 '@editor': editorRoot,
+                // M2 (#312): every `@wordpress/core-data` import in the
+                // editor bundle resolves to our in-repo empty-state shim.
+                // cms-framework will replace the shim with a real
+                // Laravel-backed `core` store in a later milestone.
+                '@wordpress/core-data': coreDataShim,
             },
         },
         server: {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,6 +10,13 @@ export default defineConfig({
     resolve: {
         alias: {
             '@editor': resolve(__dirname, 'resources/js/visual-editor/_legacy/editor'),
+            // Keep the test bundle aligned with the production Vite alias
+            // (#312). Tests import `@wordpress/core-data` via the shim so
+            // selector stubs stay in sync across both environments.
+            '@wordpress/core-data': resolve(
+                __dirname,
+                'resources/js/visual-editor/vendor/core-data-shim.ts'
+            ),
         },
     },
     test: {


### PR DESCRIPTION
## Description

Ships the empty-state `@wordpress/core-data` shim and the `artisanpack-visual-editor` text-domain bootstrap called for by milestone M2 of the Gutenberg adoption. Gutenberg's block-editor and block-library now see a valid "no data, done loading" `core` store instead of crashing against the missing WordPress backend.

**Closes:** #312

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #312 (umbrella: #309, milestone v1.0)

## Motivation and Context

Gutenberg's editor imports `@wordpress/core-data` whether we want it to or not. Without a shim, importing any of the upstream packages crashes because there is no WordPress backend feeding the real package's REST resolvers. Blocks that depend on WP-specific data (navigation, query, post-\*) now gracefully render empty — those land in the `disabled_blocks` list in M5. `cms-framework` will replace this shim with a real Laravel-backed `core` store in a later milestone.

## Changes Made

- `resources/js/visual-editor/vendor/core-data-shim.ts` — empty-state shim that registers a `core` Redux store via `@wordpress/data` with `null`/`[]` selectors, `hasFinishedResolution: true`, `isResolving: false`, no-op actions, plus no-op `EntityProvider`, `useEntityProp`, `useEntityRecord`, `useEntityRecords`, `useEntityId`, `useEntityBlockEditor`, `useResourcePermissions`.
- `vite.config.ts` + `vitest.config.ts` — alias `@wordpress/core-data` to the shim so every transitive import resolves to our empty state in both dev/build and test environments.
- `resources/js/visual-editor/vendor/media-upload-stub.tsx` — registers `editor.MediaUpload` via `@wordpress/hooks` and exposes `mediaUploadStub` for `BlockEditorProvider` settings. `MediaUploadCheck` gates the Media Library button on `settings.mediaUpload`, so the stub is required to keep the button visible; the click is intercepted with an "M4 placeholder" notice.
- `resources/js/visual-editor/vendor/i18n.ts` — `bootI18n()` + `TEXT_DOMAIN` initialize the `artisanpack-visual-editor` domain; sandbox calls it on mount.
- `scripts/extract-pot.mjs` + `npm run i18n:extract` — placeholder .pot extractor that scans `resources/js/visual-editor/**/*.{ts,tsx}` for `__/_x/_n/_nx` calls bound to the text domain and writes `languages/artisanpack-visual-editor.pot`.
- `resources/js/visual-editor/sandbox/sandbox-editor.tsx` — boots i18n, registers the media stub, passes `settings.mediaUpload`, and seeds the canvas with a `core/image` block so the shim is exercised on mount.
- `README.md` — documents the shims as temporary and explains the i18n extraction command.
- `.gitignore` — anchors `vendor/` to the repo root so `resources/js/visual-editor/vendor/` (our in-repo shim directory) stays tracked.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS 15 (Darwin 25.3.0)
- Browser: Chrome (via `npm run dev:sandbox`)
- PHP Version: 8.4.3
- Project Version: 1.0.0-spike

**Tests Performed:**
1. `npm test` — 227 passed, 1 skipped (28 files), including 13 new tests covering the shim's selectors, hooks, `EntityProvider` context, and i18n bootstrap.
2. `./vendor/bin/pest` — 35 passed, 131 assertions.
3. `npm run build` — 6,989 modules transformed; sandbox + editor bundles emit cleanly with `@wordpress/core-data` aliased to the shim.
4. `npm run dev:sandbox` — sandbox mounts; paragraph renders; `core/image` placeholder renders with Media Library / Upload / Insert from URL buttons; clicking Media Library surfaces the M2 stub alert; clicking Upload + selecting a file surfaces the `mediaUpload` stub alert.
5. `npm run i18n:extract` — writes 3 strings into `languages/artisanpack-visual-editor.pot`.

## Accessibility Tests Run

- [x] Keyboard navigation tested — tab order through image placeholder buttons is preserved from upstream `@wordpress/block-editor`.
- [x] Screen reader tested — no regressions vs. the M1 sandbox; placeholder labels come from upstream.
- [x] Color contrast verified — no style changes in this PR.
- [x] ARIA labels checked — all ARIA wiring is upstream-owned.

**Details:** This PR only adds empty-state shims behind existing Gutenberg components; no new interactive UI surfaces are introduced, so accessibility characteristics match the M1 baseline.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:**
- `resources/js/visual-editor/vendor/__tests__/core-data-shim.test.tsx` — 11 tests covering the registered `core` store's selector surface (`getEntityRecord`-family, list selectors, resolution state) and the shim hooks (`useEntityRecord`, `useEntityRecords`, `useEntityProp`, `useEntityBlockEditor`, `useResourcePermissions`, `useEntityId` with and without `EntityProvider`).
- `resources/js/visual-editor/vendor/__tests__/i18n.test.ts` — 2 tests covering domain registration and idempotent bootstrapping.

## Documentation

- [x] Inline code documentation added
- [x] README updated

**Documentation details:** Each shim file carries a top-of-file docblock explaining the M2 scope and the path to replacement via `cms-framework`. The README's new "Gutenberg adoption — transient shims" and "i18n" sections spell out the same for contributors.

## Screenshots

N/A — no visual changes to existing UI. The added `core/image` block on the sandbox canvas is a developer-facing sanity check for M2 only.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [x] Accessibility tests completed
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Visual editor: lightweight core-data shim, i18n bootstrap, and placeholder media upload to enable sandboxed editing and show media UI.

* **Documentation**
  * README: Gutenberg V1 integration notes, i18n setup, and extraction workflow.

* **Tests**
  * New suites validating i18n bootstrapping and core-data shim/hook behaviors.

* **Chores**
  * Added POT file, extraction script and npm script, Vite/Vitest aliases for the shim, and tightened .gitignore root pattern.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->