### PR TITLE
feat: M3 · persistence layer + Blade component

### DIFF
--- a/config/visual-editor.php
+++ b/config/visual-editor.php
@@ -1,2 +1,103 @@
 <?php
-return [];
+
+/**
+ * Visual editor package configuration.
+ *
+ * Merged into the host application's `artisanpack.visual-editor` key by
+ * VisualEditorServiceProvider. Applications override any of these values by
+ * publishing this file to `config/artisanpack/visual-editor.php`.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+return [
+
+	/*
+	|--------------------------------------------------------------------------
+	| Resources
+	|--------------------------------------------------------------------------
+	|
+	| Maps a URL-friendly slug to the Eloquent model class that backs it. The
+	| editor's REST routes resolve `/visual-editor/api/{resource}/{id}/content`
+	| through this map, so adding a new editable content type is a config
+	| change — no per-model controllers required. Every listed model must use
+	| the `HasBlockContent` trait.
+	|
+	*/
+
+	'resources' => [
+		// 'posts' => App\Models\Post::class,
+		// 'pages' => App\Models\Page::class,
+	],
+
+	/*
+	|--------------------------------------------------------------------------
+	| Block registry filters
+	|--------------------------------------------------------------------------
+	|
+	| `enabled_blocks` acts as an allow-list: when non-empty, only the listed
+	| block names are exposed to the inserter. `disabled_blocks` is an
+	| always-applied deny-list. The deny-list wins when both are set. Use
+	| fully-qualified block names (e.g. `core/paragraph`, `core/query`).
+	|
+	*/
+
+	'enabled_blocks' => [],
+
+	'disabled_blocks' => [],
+
+	/*
+	|--------------------------------------------------------------------------
+	| Media adapter
+	|--------------------------------------------------------------------------
+	|
+	| Identifier the editor uses to resolve the media-upload implementation.
+	| M3 only ships the `null` adapter (media insertion is unavailable); the
+	| real `artisanpack-ui/media-library` adapter lands in a later milestone.
+	| Consuming apps can bind their own adapter by registering a container
+	| binding on the same key and updating this value.
+	|
+	*/
+
+	'media' => [
+		'adapter' => 'null',
+	],
+
+	/*
+	|--------------------------------------------------------------------------
+	| API routes
+	|--------------------------------------------------------------------------
+	|
+	| Middleware stack applied to the auto-registered `/visual-editor/api/*`
+	| routes. The defaults cover a session-authenticated web app; API-only or
+	| stateless apps can swap in `auth:sanctum`, `auth:api`, etc.
+	|
+	*/
+
+	'api' => [
+		'middleware' => [ 'api', 'auth' ],
+	],
+
+	/*
+	|--------------------------------------------------------------------------
+	| Authorization
+	|--------------------------------------------------------------------------
+	|
+	| Controls how the default policy for the legacy VisualEditorPost model
+	| gates access. Resource models (via `HasBlockContent`) delegate to their
+	| own Laravel policies and ignore this flag.
+	|
+	*/
+
+	'authorization' => [
+		'restrict_by_owner' => false,
+	],
+
+];

--- a/database/migrations/testing/2026_04_19_000000_create_test_block_content_tables.php
+++ b/database/migrations/testing/2026_04_19_000000_create_test_block_content_tables.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * Creates the fixture tables used by M3 persistence-layer tests (testing only).
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+	public function up(): void
+	{
+		Schema::create( 'test_block_content_models', function ( Blueprint $table ) {
+			$table->id();
+			$table->unsignedBigInteger( 'author_id' )->nullable()->index();
+			$table->string( 'title' )->default( '' );
+			$table->string( 'status' )->default( 'draft' )->index();
+			$table->json( 'content' )->nullable();
+			$table->timestamps();
+		} );
+
+		Schema::create( 'test_block_content_pages', function ( Blueprint $table ) {
+			$table->id();
+			$table->unsignedBigInteger( 'author_id' )->nullable()->index();
+			$table->string( 'title' )->default( '' );
+			$table->json( 'body' )->nullable();
+			$table->timestamps();
+		} );
+	}
+
+	public function down(): void
+	{
+		Schema::dropIfExists( 'test_block_content_pages' );
+		Schema::dropIfExists( 'test_block_content_models' );
+	}
+};

--- a/resources/js/visual-editor/editor/__tests__/api-client.test.ts
+++ b/resources/js/visual-editor/editor/__tests__/api-client.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { ApiError, fetchContent, saveContent } from '../api-client';
+
+const CONFIG = {
+    apiBase: '/visual-editor/api',
+    resource: 'posts',
+    id: '42',
+} as const;
+
+function mockFetchResponse(body: unknown, init: ResponseInit = { status: 200 }): void {
+    vi.stubGlobal(
+        'fetch',
+        vi.fn(
+            async () =>
+                new Response(JSON.stringify(body), {
+                    status: init.status ?? 200,
+                    headers: { 'content-type': 'application/json' },
+                })
+        )
+    );
+}
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+    document.head.innerHTML = '';
+});
+
+describe('fetchContent', () => {
+    it('GETs the content endpoint and returns the parsed JSON body', async () => {
+        mockFetchResponse({
+            id: 42,
+            resource: 'posts',
+            blocks: [],
+            updated_at: null,
+        });
+
+        const response = await fetchContent(CONFIG);
+
+        expect(response.id).toBe(42);
+        expect(response.blocks).toEqual([]);
+        expect(fetch).toHaveBeenCalledWith(
+            '/visual-editor/api/posts/42/content',
+            expect.objectContaining({ method: 'GET', credentials: 'same-origin' })
+        );
+    });
+
+    it('throws ApiError with the parsed body on non-OK responses', async () => {
+        mockFetchResponse({ message: 'Unauthorized' }, { status: 401 });
+
+        await expect(fetchContent(CONFIG)).rejects.toMatchObject({
+            status: 401,
+            body: { message: 'Unauthorized' },
+        });
+
+        await expect(fetchContent(CONFIG)).rejects.toBeInstanceOf(ApiError);
+    });
+});
+
+describe('saveContent', () => {
+    it('PUTs a JSON body and forwards the CSRF token when present', async () => {
+        const meta = document.createElement('meta');
+        meta.name = 'csrf-token';
+        meta.content = 'token-123';
+        document.head.appendChild(meta);
+
+        mockFetchResponse({
+            id: 42,
+            resource: 'posts',
+            blocks: [{ clientId: 'a', name: 'core/paragraph', attributes: {}, innerBlocks: [] }],
+            updated_at: '2026-04-19T10:00:00Z',
+        });
+
+        const blocks = [
+            { clientId: 'a', name: 'core/paragraph', attributes: {}, innerBlocks: [] },
+        ];
+
+        const response = await saveContent(CONFIG, blocks);
+
+        expect(response.updated_at).toBe('2026-04-19T10:00:00Z');
+
+        const [, init] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+        expect(init.method).toBe('PUT');
+        expect(init.headers['X-CSRF-TOKEN']).toBe('token-123');
+        expect(init.body).toBe(JSON.stringify({ blocks }));
+    });
+
+    it('still succeeds when no CSRF meta tag is present', async () => {
+        mockFetchResponse({
+            id: 42,
+            resource: 'posts',
+            blocks: [],
+            updated_at: null,
+        });
+
+        const response = await saveContent(CONFIG, []);
+
+        expect(response.id).toBe(42);
+
+        const [, init] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+        expect(init.headers['X-CSRF-TOKEN']).toBeUndefined();
+    });
+});

--- a/resources/js/visual-editor/editor/__tests__/use-persistence.test.tsx
+++ b/resources/js/visual-editor/editor/__tests__/use-persistence.test.tsx
@@ -1,0 +1,188 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { usePersistence } from '../use-persistence';
+
+const CONFIG = {
+    apiBase: '/visual-editor/api',
+    resource: 'posts',
+    id: '42',
+    debounceMs: 20,
+};
+
+interface RecordedCall {
+    url: string;
+    method: string;
+    init: RequestInit | undefined;
+}
+
+type MockResponseFactory = (call: RecordedCall) => Response | Promise<Response>;
+
+function mockFetch(factory: MockResponseFactory): ReturnType<typeof vi.fn> {
+    const mock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === 'string' || input instanceof URL
+            ? String(input)
+            : input.url;
+        const method = (init?.method ?? 'GET').toUpperCase();
+        return factory({ url, method, init });
+    });
+    vi.stubGlobal('fetch', mock);
+    return mock;
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+    return new Response(JSON.stringify(body), {
+        status,
+        headers: { 'content-type': 'application/json' },
+    });
+}
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
+
+describe('usePersistence', () => {
+    it('loads initial content and marks the hook ready', async () => {
+        mockFetch(() =>
+            jsonResponse({
+                id: 42,
+                resource: 'posts',
+                blocks: [
+                    { clientId: 'a', name: 'core/paragraph', attributes: {}, innerBlocks: [] },
+                ],
+                updated_at: '2026-04-19T10:00:00Z',
+            })
+        );
+
+        const { result } = renderHook(() => usePersistence(CONFIG));
+
+        await waitFor(() => {
+            expect(result.current.loadStatus).toBe('ready');
+        });
+
+        expect(result.current.blocks).toHaveLength(1);
+        expect(result.current.lastSavedAt).toBe('2026-04-19T10:00:00Z');
+    });
+
+    it('exposes load errors so the editor can recover', async () => {
+        mockFetch(() => jsonResponse({ message: 'forbidden' }, 403));
+
+        const { result } = renderHook(() => usePersistence(CONFIG));
+
+        await waitFor(() => {
+            expect(result.current.loadStatus).toBe('error');
+        });
+
+        expect(result.current.loadError?.status).toBe(403);
+    });
+
+    it('debounces rapid edits into a single PUT and surfaces the saved timestamp', async () => {
+        const requests: RecordedCall[] = [];
+        mockFetch((call) => {
+            requests.push(call);
+            if (call.method === 'GET') {
+                return jsonResponse({ id: 42, resource: 'posts', blocks: [], updated_at: null });
+            }
+            return jsonResponse({
+                id: 42,
+                resource: 'posts',
+                blocks: [],
+                updated_at: '2026-04-19T10:10:00Z',
+            });
+        });
+
+        const { result } = renderHook(() => usePersistence(CONFIG));
+
+        await waitFor(() => {
+            expect(result.current.loadStatus).toBe('ready');
+        });
+
+        act(() => {
+            result.current.onBlocksChange([
+                { clientId: '1', name: 'core/paragraph', attributes: {}, innerBlocks: [] } as never,
+            ]);
+            result.current.onBlocksChange([
+                { clientId: '2', name: 'core/paragraph', attributes: {}, innerBlocks: [] } as never,
+            ]);
+            result.current.onBlocksChange([
+                { clientId: '3', name: 'core/paragraph', attributes: {}, innerBlocks: [] } as never,
+            ]);
+        });
+
+        await waitFor(() => {
+            expect(result.current.saveStatus).toBe('saved');
+        });
+
+        const putRequests = requests.filter((r) => r.method === 'PUT');
+        expect(putRequests).toHaveLength(1);
+        expect(putRequests[0]?.init?.body).toContain('"clientId":"3"');
+        expect(result.current.lastSavedAt).toBe('2026-04-19T10:10:00Z');
+    });
+
+    it('reports save errors without clobbering loaded content', async () => {
+        mockFetch((call) => {
+            if (call.method === 'GET') {
+                return jsonResponse({ id: 42, resource: 'posts', blocks: [], updated_at: null });
+            }
+            return jsonResponse({ message: 'validation failed' }, 422);
+        });
+
+        const { result } = renderHook(() => usePersistence(CONFIG));
+
+        await waitFor(() => {
+            expect(result.current.loadStatus).toBe('ready');
+        });
+
+        act(() => {
+            result.current.onBlocksChange([
+                { clientId: 'x', name: 'core/paragraph', attributes: {}, innerBlocks: [] } as never,
+            ]);
+        });
+
+        await waitFor(() => {
+            expect(result.current.saveStatus).toBe('error');
+        });
+
+        expect(result.current.saveError?.status).toBe(422);
+        expect(result.current.blocks).toHaveLength(1);
+    });
+
+    it('does not fire PUTs for edits before the initial load finishes', async () => {
+        let resolveLoad: (value: Response) => void = () => {};
+        const loadPromise = new Promise<Response>((resolve) => {
+            resolveLoad = resolve;
+        });
+
+        const mock = mockFetch((call) => {
+            if (call.method === 'GET') {
+                return loadPromise;
+            }
+            return jsonResponse({ id: 42, resource: 'posts', blocks: [], updated_at: null });
+        });
+
+        const { result } = renderHook(() => usePersistence(CONFIG));
+
+        act(() => {
+            result.current.onBlocksChange([
+                { clientId: 'early', name: 'core/paragraph', attributes: {}, innerBlocks: [] } as never,
+            ]);
+        });
+
+        // Let the debounce timer expire while load is still pending.
+        await new Promise((resolve) => setTimeout(resolve, CONFIG.debounceMs + 20));
+
+        expect(
+            mock.mock.calls.filter(([, init]) => (init as RequestInit | undefined)?.method === 'PUT')
+        ).toHaveLength(0);
+
+        act(() => {
+            resolveLoad(
+                jsonResponse({ id: 42, resource: 'posts', blocks: [], updated_at: null })
+            );
+        });
+
+        await waitFor(() => {
+            expect(result.current.loadStatus).toBe('ready');
+        });
+    });
+});

--- a/resources/js/visual-editor/editor/api-client.ts
+++ b/resources/js/visual-editor/editor/api-client.ts
@@ -80,19 +80,34 @@ async function requireOk(response: Response): Promise<unknown> {
     return body;
 }
 
+function normalizeError(error: unknown, fallbackMessage: string): ApiError {
+    if (error instanceof ApiError) {
+        return error;
+    }
+
+    const message =
+        error instanceof Error && error.message ? error.message : fallbackMessage;
+
+    return new ApiError(message, 0, error);
+}
+
 export async function fetchContent(
     config: ApiClientConfig
 ): Promise<ContentResponse> {
-    const response = await fetch(contentUrl(config), {
-        method: 'GET',
-        credentials: 'same-origin',
-        headers: {
-            Accept: 'application/json',
-            'X-Requested-With': 'XMLHttpRequest',
-        },
-    });
+    try {
+        const response = await fetch(contentUrl(config), {
+            method: 'GET',
+            credentials: 'same-origin',
+            headers: {
+                Accept: 'application/json',
+                'X-Requested-With': 'XMLHttpRequest',
+            },
+        });
 
-    return (await requireOk(response)) as ContentResponse;
+        return (await requireOk(response)) as ContentResponse;
+    } catch (error: unknown) {
+        throw normalizeError(error, 'Failed to load content.');
+    }
 }
 
 export async function saveContent(
@@ -110,12 +125,16 @@ export async function saveContent(
         headers['X-CSRF-TOKEN'] = csrfToken;
     }
 
-    const response = await fetch(contentUrl(config), {
-        method: 'PUT',
-        credentials: 'same-origin',
-        headers,
-        body: JSON.stringify({ blocks }),
-    });
+    try {
+        const response = await fetch(contentUrl(config), {
+            method: 'PUT',
+            credentials: 'same-origin',
+            headers,
+            body: JSON.stringify({ blocks }),
+        });
 
-    return (await requireOk(response)) as ContentResponse;
+        return (await requireOk(response)) as ContentResponse;
+    } catch (error: unknown) {
+        throw normalizeError(error, 'Failed to save content.');
+    }
 }

--- a/resources/js/visual-editor/editor/api-client.ts
+++ b/resources/js/visual-editor/editor/api-client.ts
@@ -1,0 +1,121 @@
+/**
+ * REST client for the visual editor's resource content endpoints.
+ *
+ * Thin wrapper over `fetch` that targets
+ * `{apiBase}/{resource}/{id}/content` and automatically sends the session
+ * CSRF token Laravel expects on mutating requests. Errors are surfaced as
+ * typed `ApiError` instances so the persistence loop can distinguish
+ * auth/validation/network failures.
+ */
+
+export interface ContentResponse {
+    id: number | string;
+    resource: string;
+    blocks: readonly unknown[];
+    updated_at: string | null;
+}
+
+export class ApiError extends Error {
+    public readonly status: number;
+
+    public readonly body: unknown;
+
+    public constructor(message: string, status: number, body: unknown) {
+        super(message);
+        this.name = 'ApiError';
+        this.status = status;
+        this.body = body;
+    }
+}
+
+export interface ApiClientConfig {
+    apiBase: string;
+    resource: string;
+    id: string;
+}
+
+function contentUrl(config: ApiClientConfig): string {
+    const base = config.apiBase.replace(/\/$/, '');
+
+    return `${base}/${encodeURIComponent(config.resource)}/${encodeURIComponent(
+        config.id
+    )}/content`;
+}
+
+function readCsrfToken(): string | null {
+    if (typeof document === 'undefined') {
+        return null;
+    }
+
+    const meta = document.querySelector<HTMLMetaElement>('meta[name="csrf-token"]');
+
+    return meta?.content?.trim() || null;
+}
+
+async function parseBody(response: Response): Promise<unknown> {
+    const text = await response.text();
+
+    if (text === '') {
+        return null;
+    }
+
+    try {
+        return JSON.parse(text);
+    } catch {
+        return text;
+    }
+}
+
+async function requireOk(response: Response): Promise<unknown> {
+    const body = await parseBody(response);
+
+    if (!response.ok) {
+        throw new ApiError(
+            `Visual editor request failed with status ${response.status}`,
+            response.status,
+            body
+        );
+    }
+
+    return body;
+}
+
+export async function fetchContent(
+    config: ApiClientConfig
+): Promise<ContentResponse> {
+    const response = await fetch(contentUrl(config), {
+        method: 'GET',
+        credentials: 'same-origin',
+        headers: {
+            Accept: 'application/json',
+            'X-Requested-With': 'XMLHttpRequest',
+        },
+    });
+
+    return (await requireOk(response)) as ContentResponse;
+}
+
+export async function saveContent(
+    config: ApiClientConfig,
+    blocks: readonly unknown[]
+): Promise<ContentResponse> {
+    const csrfToken = readCsrfToken();
+    const headers: Record<string, string> = {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        'X-Requested-With': 'XMLHttpRequest',
+    };
+
+    if (csrfToken) {
+        headers['X-CSRF-TOKEN'] = csrfToken;
+    }
+
+    const response = await fetch(contentUrl(config), {
+        method: 'PUT',
+        credentials: 'same-origin',
+        headers,
+        body: JSON.stringify({ blocks }),
+    });
+
+    return (await requireOk(response)) as ContentResponse;
+}

--- a/resources/js/visual-editor/editor/editor-app.tsx
+++ b/resources/js/visual-editor/editor/editor-app.tsx
@@ -1,0 +1,135 @@
+/**
+ * Visual editor React app.
+ *
+ * Mounts a `BlockEditorProvider` for a single resource+id pair and wires the
+ * persistence loop so keystrokes hit Laravel via debounced PUTs. This is the
+ * M3 entry point (#313) — a minimal shell sufficient to prove the end-to-end
+ * persistence path. The full editor chrome (three-panel layout, inserter,
+ * block toolbar) already exists in the sandbox and will consolidate with
+ * this app in a later milestone.
+ */
+
+import {
+    BlockEditorProvider,
+    BlockList,
+    BlockTools,
+    WritingFlow,
+} from '@wordpress/block-editor';
+import { registerCoreBlocks } from '@wordpress/block-library';
+import { Popover, SlotFillProvider } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import type { BlockInstance } from '@wordpress/blocks';
+
+import { bootI18n, TEXT_DOMAIN } from '../vendor/i18n';
+import {
+    mediaUploadStub,
+    registerMediaUploadStub,
+} from '../vendor/media-upload-stub';
+
+import { usePersistence } from './use-persistence';
+
+import '@wordpress/components/build-style/style.css';
+import '@wordpress/block-editor/build-style/style.css';
+import '@wordpress/block-editor/build-style/content.css';
+import '@wordpress/block-library/build-style/style.css';
+import '@wordpress/block-library/build-style/editor.css';
+
+let blocksRegistered = false;
+
+function registerOnce(): void {
+    if (blocksRegistered) {
+        return;
+    }
+
+    bootI18n();
+    registerMediaUploadStub();
+    registerCoreBlocks();
+    blocksRegistered = true;
+}
+
+const editorSettings = {
+    mediaUpload: mediaUploadStub,
+};
+
+export interface EditorAppProps {
+    apiBase: string;
+    resource: string;
+    id: string;
+}
+
+export function EditorApp(props: EditorAppProps): JSX.Element {
+    registerOnce();
+
+    const {
+        blocks,
+        loadStatus,
+        saveStatus,
+        loadError,
+        saveError,
+        onBlocksChange,
+    } = usePersistence(props);
+
+    if (loadStatus === 'loading') {
+        return (
+            <p className="ap-visual-editor__status ap-visual-editor__status--loading">
+                {__('Loading content…', TEXT_DOMAIN)}
+            </p>
+        );
+    }
+
+    if (loadStatus === 'error') {
+        return (
+            <p className="ap-visual-editor__status ap-visual-editor__status--error">
+                {loadError?.message ??
+                    __('Unable to load content.', TEXT_DOMAIN)}
+            </p>
+        );
+    }
+
+    return (
+        <SlotFillProvider>
+            <div className="ap-visual-editor__shell">
+                <BlockEditorProvider
+                    value={blocks}
+                    settings={editorSettings}
+                    onInput={(next: BlockInstance[]) => onBlocksChange(next)}
+                    onChange={(next: BlockInstance[]) => onBlocksChange(next)}
+                >
+                    <div className="editor-styles-wrapper">
+                        <BlockTools>
+                            <WritingFlow>
+                                <BlockList />
+                            </WritingFlow>
+                        </BlockTools>
+                    </div>
+                    <Popover.Slot />
+                </BlockEditorProvider>
+                <p
+                    className="ap-visual-editor__save-status"
+                    data-save-status={saveStatus}
+                    role="status"
+                    aria-live="polite"
+                >
+                    {saveStatusLabel(saveStatus, saveError?.message)}
+                </p>
+            </div>
+        </SlotFillProvider>
+    );
+}
+
+function saveStatusLabel(
+    status: 'idle' | 'saving' | 'saved' | 'error',
+    errorMessage?: string
+): string {
+    switch (status) {
+        case 'saving':
+            return __('Saving…', TEXT_DOMAIN);
+        case 'saved':
+            return __('All changes saved.', TEXT_DOMAIN);
+        case 'error':
+            return errorMessage ?? __('Save failed.', TEXT_DOMAIN);
+        case 'idle':
+        default:
+            return '';
+    }
+}

--- a/resources/js/visual-editor/editor/main.tsx
+++ b/resources/js/visual-editor/editor/main.tsx
@@ -1,0 +1,77 @@
+/**
+ * Visual editor bootstrap entry.
+ *
+ * Scans the DOM for every `[data-ap-visual-editor]` mount point rendered by
+ * the `<x-visual-editor>` Blade component and attaches a React root to each.
+ * Dynamically imports the editor app so the `@wordpress/*` bundle lands in a
+ * dedicated `gutenberg` chunk (see vite.config.ts) that only downloads when
+ * at least one editor is present on the page.
+ */
+
+import { StrictMode, createElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+const MOUNT_SELECTOR = '[data-ap-visual-editor]';
+const ROOT_SYMBOL: unique symbol = Symbol('ap-visual-editor-root');
+
+type MountableElement = HTMLElement & {
+    [ROOT_SYMBOL]?: Root;
+};
+
+interface MountConfig {
+    apiBase: string;
+    resource: string;
+    id: string;
+}
+
+function readMountConfig(element: HTMLElement): MountConfig | null {
+    const apiBase = element.dataset.apiBase?.trim();
+    const resource = element.dataset.resource?.trim();
+    const id = element.dataset.id?.trim();
+
+    if (!apiBase || !resource || !id) {
+        return null;
+    }
+
+    return { apiBase, resource, id };
+}
+
+async function mount(element: MountableElement): Promise<void> {
+    const config = readMountConfig(element);
+
+    if (config === null) {
+        console.error(
+            'visual-editor: mount point is missing data-api-base, data-resource, or data-id.',
+            element
+        );
+        return;
+    }
+
+    if (element[ROOT_SYMBOL]) {
+        return;
+    }
+
+    const { EditorApp } = await import('./editor-app');
+
+    const root = createRoot(element);
+    element[ROOT_SYMBOL] = root;
+    root.render(createElement(StrictMode, null, createElement(EditorApp, config)));
+}
+
+export function bootVisualEditor(
+    scope: ParentNode = document
+): Promise<void[]> {
+    const elements = scope.querySelectorAll<HTMLElement>(MOUNT_SELECTOR);
+
+    return Promise.all(Array.from(elements).map((element) => mount(element)));
+}
+
+if (typeof document !== 'undefined') {
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', () => {
+            void bootVisualEditor();
+        });
+    } else {
+        void bootVisualEditor();
+    }
+}

--- a/resources/js/visual-editor/editor/main.tsx
+++ b/resources/js/visual-editor/editor/main.tsx
@@ -51,11 +51,23 @@ async function mount(element: MountableElement): Promise<void> {
         return;
     }
 
-    const { EditorApp } = await import('./editor-app');
-
+    // Reserve the element synchronously so a second concurrent mount() call
+    // (e.g. a rapid bootVisualEditor() re-trigger) can't slip past the
+    // dedupe check while the dynamic import is still in flight.
     const root = createRoot(element);
     element[ROOT_SYMBOL] = root;
-    root.render(createElement(StrictMode, null, createElement(EditorApp, config)));
+
+    try {
+        const { EditorApp } = await import('./editor-app');
+
+        root.render(
+            createElement(StrictMode, null, createElement(EditorApp, config))
+        );
+    } catch (error: unknown) {
+        console.error('visual-editor: failed to load editor app.', error);
+        root.unmount();
+        delete element[ROOT_SYMBOL];
+    }
 }
 
 export function bootVisualEditor(

--- a/resources/js/visual-editor/editor/use-persistence.ts
+++ b/resources/js/visual-editor/editor/use-persistence.ts
@@ -1,0 +1,182 @@
+/**
+ * Persistence hook for the visual editor.
+ *
+ * Fetches the block tree for a resource on mount, exposes the initial state
+ * for `BlockEditorProvider`, and PUTs debounced changes back to the server.
+ * Dedupes concurrent saves so the React editor can fire `onChange` on every
+ * keystroke without overwhelming the Laravel endpoint.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { BlockInstance } from '@wordpress/blocks';
+
+import {
+    ApiError,
+    fetchContent,
+    saveContent,
+    type ApiClientConfig,
+} from './api-client';
+
+type LoadStatus = 'loading' | 'ready' | 'error';
+type SaveStatus = 'idle' | 'saving' | 'saved' | 'error';
+
+export interface PersistenceState {
+    blocks: BlockInstance[];
+    loadStatus: LoadStatus;
+    saveStatus: SaveStatus;
+    loadError: ApiError | null;
+    saveError: ApiError | null;
+    lastSavedAt: string | null;
+    onBlocksChange: (next: BlockInstance[]) => void;
+}
+
+export interface UsePersistenceOptions extends ApiClientConfig {
+    /**
+     * Delay in milliseconds between the last change and the triggered save.
+     * Defaults to 800ms so rapid edits coalesce into a single request.
+     */
+    debounceMs?: number;
+}
+
+const DEFAULT_DEBOUNCE_MS = 800;
+
+function toApiError(error: unknown, fallback: string): ApiError {
+    return error instanceof ApiError ? error : new ApiError(fallback, 0, error);
+}
+
+export function usePersistence(
+    options: UsePersistenceOptions
+): PersistenceState {
+    const { debounceMs = DEFAULT_DEBOUNCE_MS, apiBase, resource, id } = options;
+
+    const [blocks, setBlocks] = useState<BlockInstance[]>([]);
+    const [loadStatus, setLoadStatus] = useState<LoadStatus>('loading');
+    const [saveStatus, setSaveStatus] = useState<SaveStatus>('idle');
+    const [loadError, setLoadError] = useState<ApiError | null>(null);
+    const [saveError, setSaveError] = useState<ApiError | null>(null);
+    const [lastSavedAt, setLastSavedAt] = useState<string | null>(null);
+
+    const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const pendingRef = useRef<BlockInstance[] | null>(null);
+    const inFlightRef = useRef<boolean>(false);
+    const unmountedRef = useRef<boolean>(false);
+    const loadStatusRef = useRef<LoadStatus>('loading');
+
+    loadStatusRef.current = loadStatus;
+
+    useEffect(() => {
+        unmountedRef.current = false;
+        let cancelled = false;
+
+        setLoadStatus('loading');
+        setLoadError(null);
+
+        fetchContent({ apiBase, resource, id })
+            .then((response) => {
+                if (cancelled) {
+                    return;
+                }
+
+                setBlocks(response.blocks as BlockInstance[]);
+                setLastSavedAt(response.updated_at);
+                setLoadStatus('ready');
+            })
+            .catch((error: unknown) => {
+                if (cancelled) {
+                    return;
+                }
+
+                setLoadError(toApiError(error, 'Failed to load content.'));
+                setLoadStatus('error');
+            });
+
+        return () => {
+            cancelled = true;
+            unmountedRef.current = true;
+
+            if (timerRef.current !== null) {
+                clearTimeout(timerRef.current);
+                timerRef.current = null;
+            }
+        };
+    }, [apiBase, resource, id]);
+
+    const runFlush = useCallback(
+        async function runFlush(): Promise<void> {
+            if (inFlightRef.current || unmountedRef.current) {
+                return;
+            }
+
+            const next = pendingRef.current;
+
+            if (next === null) {
+                return;
+            }
+
+            pendingRef.current = null;
+            inFlightRef.current = true;
+            setSaveStatus('saving');
+            setSaveError(null);
+
+            try {
+                const response = await saveContent({ apiBase, resource, id }, next);
+
+                if (unmountedRef.current) {
+                    return;
+                }
+
+                setLastSavedAt(response.updated_at);
+                setSaveStatus('saved');
+            } catch (error: unknown) {
+                if (unmountedRef.current) {
+                    return;
+                }
+
+                setSaveError(toApiError(error, 'Failed to save content.'));
+                setSaveStatus('error');
+            } finally {
+                inFlightRef.current = false;
+            }
+
+            // A change landed while the save was in flight — drain the
+            // trailing edit now so we don't lose it.
+            if (pendingRef.current !== null && !unmountedRef.current) {
+                void runFlush();
+            }
+        },
+        [apiBase, resource, id]
+    );
+
+    const onBlocksChange = useCallback(
+        (next: BlockInstance[]): void => {
+            setBlocks(next);
+
+            if (loadStatusRef.current !== 'ready') {
+                return;
+            }
+
+            pendingRef.current = next;
+
+            if (timerRef.current !== null) {
+                clearTimeout(timerRef.current);
+            }
+
+            timerRef.current = setTimeout(() => {
+                timerRef.current = null;
+                void runFlush();
+            }, debounceMs);
+        },
+        [debounceMs, runFlush]
+    );
+
+    return {
+        blocks,
+        loadStatus,
+        saveStatus,
+        loadError,
+        saveError,
+        lastSavedAt,
+        onBlocksChange,
+    };
+}
+

--- a/resources/js/visual-editor/editor/use-persistence.ts
+++ b/resources/js/visual-editor/editor/use-persistence.ts
@@ -60,20 +60,33 @@ export function usePersistence(
     const pendingRef = useRef<BlockInstance[] | null>(null);
     const inFlightRef = useRef<boolean>(false);
     const unmountedRef = useRef<boolean>(false);
+    // Incremented on every target change so in-flight saves for the previous
+    // (apiBase, resource, id) tuple can detect they've been superseded before
+    // writing state or scheduling a trailing flush.
+    const targetVersionRef = useRef<number>(0);
     const loadStatusRef = useRef<LoadStatus>('loading');
 
     loadStatusRef.current = loadStatus;
 
     useEffect(() => {
         unmountedRef.current = false;
-        let cancelled = false;
+        const version = ++targetVersionRef.current;
+        pendingRef.current = null;
+        inFlightRef.current = false;
+
+        if (timerRef.current !== null) {
+            clearTimeout(timerRef.current);
+            timerRef.current = null;
+        }
 
         setLoadStatus('loading');
         setLoadError(null);
+        setSaveStatus('idle');
+        setSaveError(null);
 
         fetchContent({ apiBase, resource, id })
             .then((response) => {
-                if (cancelled) {
+                if (version !== targetVersionRef.current) {
                     return;
                 }
 
@@ -82,7 +95,7 @@ export function usePersistence(
                 setLoadStatus('ready');
             })
             .catch((error: unknown) => {
-                if (cancelled) {
+                if (version !== targetVersionRef.current) {
                     return;
                 }
 
@@ -91,8 +104,8 @@ export function usePersistence(
             });
 
         return () => {
-            cancelled = true;
             unmountedRef.current = true;
+            pendingRef.current = null;
 
             if (timerRef.current !== null) {
                 clearTimeout(timerRef.current);
@@ -113,6 +126,8 @@ export function usePersistence(
                 return;
             }
 
+            const version = targetVersionRef.current;
+
             pendingRef.current = null;
             inFlightRef.current = true;
             setSaveStatus('saving');
@@ -121,14 +136,14 @@ export function usePersistence(
             try {
                 const response = await saveContent({ apiBase, resource, id }, next);
 
-                if (unmountedRef.current) {
+                if (unmountedRef.current || version !== targetVersionRef.current) {
                     return;
                 }
 
                 setLastSavedAt(response.updated_at);
                 setSaveStatus('saved');
             } catch (error: unknown) {
-                if (unmountedRef.current) {
+                if (unmountedRef.current || version !== targetVersionRef.current) {
                     return;
                 }
 
@@ -139,8 +154,13 @@ export function usePersistence(
             }
 
             // A change landed while the save was in flight — drain the
-            // trailing edit now so we don't lose it.
-            if (pendingRef.current !== null && !unmountedRef.current) {
+            // trailing edit now so we don't lose it. Skip if the target
+            // changed during the save.
+            if (
+                pendingRef.current !== null
+                && !unmountedRef.current
+                && version === targetVersionRef.current
+            ) {
                 void runFlush();
             }
         },

--- a/resources/views/components/editor.blade.php
+++ b/resources/views/components/editor.blade.php
@@ -1,0 +1,7 @@
+<div
+	{{ $attributes->merge(['class' => 'ap-visual-editor']) }}
+	data-ap-visual-editor
+	data-resource="{{ $resource }}"
+	data-id="{{ $modelId }}"
+	data-api-base="{{ $apiBase }}"
+></div>

--- a/routes/api.php
+++ b/routes/api.php
@@ -4,7 +4,8 @@
  * Visual Editor API routes.
  *
  * JSON endpoints consumed by the React editor. Loaded by the service provider
- * under the `/visual-editor/api` prefix with the `api` + `auth` middleware stack.
+ * under the `/visual-editor/api` prefix with the middleware stack configured
+ * at `artisanpack.visual-editor.api.middleware`.
  *
  * @package    ArtisanPack_UI
  * @subpackage VisualEditor
@@ -16,15 +17,33 @@
 
 declare( strict_types=1 );
 
+use ArtisanPackUI\VisualEditor\Http\Controllers\BlockPreviewController;
+use ArtisanPackUI\VisualEditor\Http\Controllers\ResourceContentController;
 use ArtisanPackUI\VisualEditor\Http\Controllers\VisualEditorBlocksController;
 use ArtisanPackUI\VisualEditor\Http\Controllers\VisualEditorPostsController;
 use Illuminate\Support\Facades\Route;
 
-Route::get( 'posts/{post}', [VisualEditorPostsController::class, 'show'] )
+// Generic resource content endpoints (M3). Any model registered in
+// `artisanpack.visual-editor.resources` is editable through these routes.
+Route::get( '{resource}/{id}/content', [ ResourceContentController::class, 'show' ] )
+	->where( 'resource', '[A-Za-z0-9_-]+' )
+	->name( 'visual-editor.api.resources.content.show' );
+
+Route::put( '{resource}/{id}/content', [ ResourceContentController::class, 'update' ] )
+	->where( 'resource', '[A-Za-z0-9_-]+' )
+	->name( 'visual-editor.api.resources.content.update' );
+
+Route::post( 'blocks/preview', [ BlockPreviewController::class, 'preview' ] )
+	->name( 'visual-editor.api.blocks.preview' );
+
+Route::get( 'blocks', [ VisualEditorBlocksController::class, 'index' ] )
+	->name( 'visual-editor.api.blocks.index' );
+
+// Legacy ve_contents routes retained for the existing editor tests and the
+// `VisualEditorPost` model. Deprecated in M3 in favor of the resource routes
+// above; removed once the dev app migrates off the seeded post fixture.
+Route::get( 'posts/{post}', [ VisualEditorPostsController::class, 'show' ] )
 	->name( 'visual-editor.api.posts.show' );
 
-Route::put( 'posts/{post}', [VisualEditorPostsController::class, 'update'] )
+Route::put( 'posts/{post}', [ VisualEditorPostsController::class, 'update' ] )
 	->name( 'visual-editor.api.posts.update' );
-
-Route::get( 'blocks', [VisualEditorBlocksController::class, 'index'] )
-	->name( 'visual-editor.api.blocks.index' );

--- a/src/Concerns/HasBlockContent.php
+++ b/src/Concerns/HasBlockContent.php
@@ -22,6 +22,7 @@ declare( strict_types=1 );
 namespace ArtisanPackUI\VisualEditor\Concerns;
 
 use Illuminate\Database\Eloquent\Builder;
+use InvalidArgumentException;
 
 /**
  * @mixin \Illuminate\Database\Eloquent\Model
@@ -101,15 +102,17 @@ trait HasBlockContent
 	/**
 	 * Scopes the query to models the editor can resolve.
 	 *
-	 * Applies the optional `$blockContentScope` if it matches a local scope on
-	 * the model. Unknown scope names are ignored so a misconfigured scope
-	 * can't silently hide content.
+	 * Applies the optional `$blockContentScope` if it's configured. Missing
+	 * scope methods throw loudly — silently ignoring a typo'd scope would
+	 * leak otherwise-hidden content (e.g. drafts) through the editor API.
 	 *
 	 * @since 1.0.0
 	 *
 	 * @param  Builder<\Illuminate\Database\Eloquent\Model>  $query
 	 *
 	 * @return Builder<\Illuminate\Database\Eloquent\Model>
+	 *
+	 * @throws InvalidArgumentException When the configured scope method doesn't exist on the model.
 	 */
 	public function scopeForVisualEditor( Builder $query ): Builder
 	{
@@ -121,9 +124,16 @@ trait HasBlockContent
 
 		$method = 'scope' . ucfirst( $scope );
 
-		if ( method_exists( $this, $method ) ) {
-			$query->{$scope}();
+		if ( ! method_exists( $this, $method ) ) {
+			throw new InvalidArgumentException( sprintf(
+				'HasBlockContent: scope "%s" (expected method %s::%s) is not defined on the model.',
+				$scope,
+				static::class,
+				$method
+			) );
 		}
+
+		$query->{$scope}();
 
 		return $query;
 	}

--- a/src/Concerns/HasBlockContent.php
+++ b/src/Concerns/HasBlockContent.php
@@ -1,0 +1,148 @@
+<?php
+
+/**
+ * HasBlockContent trait.
+ *
+ * Opt-in trait that marks an Eloquent model as editable by the visual editor.
+ * Declares the column that stores the block tree JSON and an optional scope
+ * that the editor's REST controller applies when resolving models. Includes a
+ * Scout hook stub (real implementation in M12) so consuming apps can start
+ * using the trait today without needing the full search pipeline.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Concerns;
+
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * @mixin \Illuminate\Database\Eloquent\Model
+ */
+trait HasBlockContent
+{
+	/**
+	 * Initializes the trait on each model instance by registering an `array`
+	 * cast for the block content column if the model hasn't declared one.
+	 *
+	 * @since 1.0.0
+	 */
+	public function initializeHasBlockContent(): void
+	{
+		$column = $this->getBlockContentColumn();
+
+		if ( ! array_key_exists( $column, $this->getCasts() ) ) {
+			$this->mergeCasts( [ $column => 'array' ] );
+		}
+	}
+
+	/**
+	 * Returns the column that stores the block tree JSON.
+	 *
+	 * Override by setting `protected $blockContentColumn = 'body';` on the model.
+	 *
+	 * @since 1.0.0
+	 */
+	public function getBlockContentColumn(): string
+	{
+		return property_exists( $this, 'blockContentColumn' ) && is_string( $this->blockContentColumn )
+			? $this->blockContentColumn
+			: 'content';
+	}
+
+	/**
+	 * Returns the optional query scope applied when resolving models for the editor.
+	 *
+	 * Override by setting `protected $blockContentScope = 'published';` on the
+	 * model. Returns null when no scope is configured.
+	 *
+	 * @since 1.0.0
+	 */
+	public function getBlockContentScope(): ?string
+	{
+		return property_exists( $this, 'blockContentScope' ) && is_string( $this->blockContentScope )
+			? $this->blockContentScope
+			: null;
+	}
+
+	/**
+	 * Returns the current block tree for the model.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	public function getBlockContent(): array
+	{
+		$value = $this->getAttribute( $this->getBlockContentColumn() );
+
+		return is_array( $value ) ? $value : [];
+	}
+
+	/**
+	 * Persists a new block tree for the model.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array<int, array<string, mixed>>  $blocks  The block tree to store.
+	 */
+	public function setBlockContent( array $blocks ): void
+	{
+		$this->setAttribute( $this->getBlockContentColumn(), $blocks );
+	}
+
+	/**
+	 * Scopes the query to models the editor can resolve.
+	 *
+	 * Applies the optional `$blockContentScope` if it matches a local scope on
+	 * the model. Unknown scope names are ignored so a misconfigured scope
+	 * can't silently hide content.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  Builder<\Illuminate\Database\Eloquent\Model>  $query
+	 *
+	 * @return Builder<\Illuminate\Database\Eloquent\Model>
+	 */
+	public function scopeForVisualEditor( Builder $query ): Builder
+	{
+		$scope = $this->getBlockContentScope();
+
+		if ( null === $scope ) {
+			return $query;
+		}
+
+		$method = 'scope' . ucfirst( $scope );
+
+		if ( method_exists( $this, $method ) ) {
+			$query->{$scope}();
+		}
+
+		return $query;
+	}
+
+	/**
+	 * Returns the Scout-indexable payload for block content.
+	 *
+	 * Stub for M12. Consuming apps that use Laravel Scout can override
+	 * `toSearchableArray()` on their model and call this helper to include a
+	 * plain-text rendering of the block tree once the Scout indexer lands.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function toBlockContentSearchableArray(): array
+	{
+		return [
+			'block_content' => $this->getBlockContent(),
+		];
+	}
+}

--- a/src/Concerns/HasBlockContent.php
+++ b/src/Concerns/HasBlockContent.php
@@ -21,8 +21,10 @@ declare( strict_types=1 );
 
 namespace ArtisanPackUI\VisualEditor\Concerns;
 
+use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\Builder;
 use InvalidArgumentException;
+use Traversable;
 
 /**
  * @mixin \Illuminate\Database\Eloquent\Model
@@ -48,12 +50,14 @@ trait HasBlockContent
 	 * Returns the column that stores the block tree JSON.
 	 *
 	 * Override by setting `protected $blockContentColumn = 'body';` on the model.
+	 * Uses `isset()` rather than `property_exists()` so an uninitialized typed
+	 * property falls back to the default instead of throwing.
 	 *
 	 * @since 1.0.0
 	 */
 	public function getBlockContentColumn(): string
 	{
-		return property_exists( $this, 'blockContentColumn' ) && is_string( $this->blockContentColumn )
+		return isset( $this->blockContentColumn ) && is_string( $this->blockContentColumn )
 			? $this->blockContentColumn
 			: 'content';
 	}
@@ -62,19 +66,24 @@ trait HasBlockContent
 	 * Returns the optional query scope applied when resolving models for the editor.
 	 *
 	 * Override by setting `protected $blockContentScope = 'published';` on the
-	 * model. Returns null when no scope is configured.
+	 * model. Returns null when no scope is configured. Uses `isset()` so
+	 * uninitialized typed properties fall back to null rather than throwing.
 	 *
 	 * @since 1.0.0
 	 */
 	public function getBlockContentScope(): ?string
 	{
-		return property_exists( $this, 'blockContentScope' ) && is_string( $this->blockContentScope )
+		return isset( $this->blockContentScope ) && is_string( $this->blockContentScope )
 			? $this->blockContentScope
 			: null;
 	}
 
 	/**
 	 * Returns the current block tree for the model.
+	 *
+	 * Accepts native arrays, `Arrayable` (e.g. Collection / `AsCollection`
+	 * casts), and `Traversable` so a consumer's custom cast on the block
+	 * content column is preserved on read instead of collapsing to `[]`.
 	 *
 	 * @since 1.0.0
 	 *
@@ -84,7 +93,19 @@ trait HasBlockContent
 	{
 		$value = $this->getAttribute( $this->getBlockContentColumn() );
 
-		return is_array( $value ) ? $value : [];
+		if ( is_array( $value ) ) {
+			return $value;
+		}
+
+		if ( $value instanceof Arrayable ) {
+			return $value->toArray();
+		}
+
+		if ( $value instanceof Traversable ) {
+			return iterator_to_array( $value );
+		}
+
+		return [];
 	}
 
 	/**

--- a/src/Http/Controllers/BlockPreviewController.php
+++ b/src/Http/Controllers/BlockPreviewController.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * BlockPreview controller.
+ *
+ * Stub POST endpoint that will server-render a block tree preview once M6
+ * lands. Until then it validates the payload shape and echoes it back so the
+ * React client can wire up the round-trip ahead of the real renderer.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Http\Controllers;
+
+use ArtisanPackUI\VisualEditor\Http\Requests\UpdateResourceContentRequest;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Routing\Controller;
+
+class BlockPreviewController extends Controller
+{
+	/**
+	 * Returns a pass-through preview of the submitted block tree.
+	 *
+	 * Reuses UpdateResourceContentRequest so the stub enforces the same
+	 * BlockTreeRule validation the real renderer will need.
+	 *
+	 * @since 1.0.0
+	 */
+	public function preview( UpdateResourceContentRequest $request ): JsonResponse
+	{
+		/** @var array<int, array<string, mixed>> $blocks */
+		$blocks = $request->validated( 'blocks' );
+
+		return response()->json( [
+			'status' => 'stub',
+			'blocks' => $blocks,
+			'html'   => null,
+		] );
+	}
+}

--- a/src/Http/Controllers/ResourceContentController.php
+++ b/src/Http/Controllers/ResourceContentController.php
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ * ResourceContent controller.
+ *
+ * Serves GET/PUT JSON endpoints for the block tree of any model registered in
+ * `config('artisanpack.visual-editor.resources')`. Authorization is delegated
+ * to the model's Laravel policy — this controller never checks ownership or
+ * role on its own.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Http\Controllers;
+
+use ArtisanPackUI\VisualEditor\Http\Requests\UpdateResourceContentRequest;
+use ArtisanPackUI\VisualEditor\Resources\ResourceResolver;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Gate;
+
+class ResourceContentController extends Controller
+{
+	public function __construct( protected ResourceResolver $resolver )
+	{
+	}
+
+	/**
+	 * Returns the block tree for the given resource.
+	 *
+	 * @since 1.0.0
+	 */
+	public function show( string $resource, int|string $id ): JsonResponse
+	{
+		$model = $this->resolver->resolve( $resource, $id );
+
+		Gate::authorize( 'view', $model );
+
+		return response()->json( $this->transform( $resource, $model ) );
+	}
+
+	/**
+	 * Persists an updated block tree for the given resource.
+	 *
+	 * @since 1.0.0
+	 */
+	public function update(
+		UpdateResourceContentRequest $request,
+		string $resource,
+		int|string $id
+	): JsonResponse {
+		$model = $this->resolver->resolve( $resource, $id );
+
+		Gate::authorize( 'update', $model );
+
+		/** @var array<int, array<string, mixed>> $blocks */
+		$blocks = $request->validated( 'blocks' );
+
+		$model->setBlockContent( $blocks );
+		$model->save();
+
+		return response()->json( $this->transform( $resource, $model ) );
+	}
+
+	/**
+	 * Shapes a model for the JSON response.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<string, mixed>
+	 */
+	protected function transform( string $resource, Model $model ): array
+	{
+		return [
+			'id'         => $model->getKey(),
+			'resource'   => $resource,
+			'blocks'     => $model->getBlockContent(),
+			'updated_at' => $model->updated_at?->toIso8601String(),
+		];
+	}
+}

--- a/src/Http/Requests/UpdateResourceContentRequest.php
+++ b/src/Http/Requests/UpdateResourceContentRequest.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * UpdateResourceContent form request.
+ *
+ * Validates the block tree payload sent to the generic resource PUT endpoint.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Http\Requests;
+
+use ArtisanPackUI\VisualEditor\Rules\BlockTreeRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateResourceContentRequest extends FormRequest
+{
+	public function authorize(): bool
+	{
+		return true;
+	}
+
+	/**
+	 * @return array<string, array<int, mixed>>
+	 */
+	public function rules(): array
+	{
+		return [
+			'blocks' => [ 'required', 'array', new BlockTreeRule() ],
+		];
+	}
+}

--- a/src/Resources/ResourceResolver.php
+++ b/src/Resources/ResourceResolver.php
@@ -1,0 +1,148 @@
+<?php
+
+/**
+ * Resource resolver.
+ *
+ * Maps a URL-friendly resource slug to the Eloquent model that backs it.
+ * Reads the `resources` map from `config('artisanpack.visual-editor.resources')`
+ * and enforces that the resolved model uses the `HasBlockContent` trait.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Resources;
+
+use ArtisanPackUI\VisualEditor\Concerns\HasBlockContent;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use RuntimeException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+class ResourceResolver
+{
+	/**
+	 * Resolves a resource slug + id pair to a concrete model instance.
+	 *
+	 * Throws a 404 if the slug is unknown or the record does not exist, and a
+	 * RuntimeException if the configured model is missing the trait.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string      $resource  The resource slug from the URL.
+	 * @param  int|string  $id        The model primary key.
+	 *
+	 * @throws NotFoundHttpException When the slug is unknown or the record is missing.
+	 * @throws RuntimeException      When the configured model doesn't use HasBlockContent.
+	 */
+	public function resolve( string $resource, int|string $id ): Model
+	{
+		$modelClass = $this->modelClassFor( $resource );
+		$model      = $this->newModel( $modelClass );
+
+		try {
+			return $model->newQuery()
+				->forVisualEditor()
+				->findOrFail( $id );
+		} catch ( ModelNotFoundException $exception ) {
+			throw new NotFoundHttpException(
+				sprintf( 'No %s with id %s.', $resource, (string) $id ),
+				$exception
+			);
+		}
+	}
+
+	/**
+	 * Returns the model class bound to a resource slug.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @throws NotFoundHttpException When the slug is not configured.
+	 */
+	public function modelClassFor( string $resource ): string
+	{
+		$map = $this->resourceMap();
+
+		if ( ! isset( $map[ $resource ] ) ) {
+			throw new NotFoundHttpException(
+				sprintf( 'Unknown visual-editor resource "%s".', $resource )
+			);
+		}
+
+		$modelClass = $map[ $resource ];
+
+		if ( ! is_string( $modelClass ) || ! class_exists( $modelClass ) ) {
+			throw new RuntimeException(
+				sprintf( 'Visual-editor resource "%s" must point to a valid model class.', $resource )
+			);
+		}
+
+		return $modelClass;
+	}
+
+	/**
+	 * Instantiates the model and asserts the trait is present.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  class-string<Model>  $modelClass
+	 */
+	protected function newModel( string $modelClass ): Model
+	{
+		$model = new $modelClass();
+
+		if ( ! $model instanceof Model ) {
+			throw new RuntimeException(
+				sprintf( 'Visual-editor resource "%s" must extend Eloquent Model.', $modelClass )
+			);
+		}
+
+		if ( ! in_array( HasBlockContent::class, $this->usedTraits( $model ), true ) ) {
+			throw new RuntimeException(
+				sprintf( 'Visual-editor resource "%s" must use the HasBlockContent trait.', $modelClass )
+			);
+		}
+
+		return $model;
+	}
+
+	/**
+	 * Returns the recursive list of traits used by a model.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<int, string>
+	 */
+	protected function usedTraits( Model $model ): array
+	{
+		$traits = [];
+		$class  = $model::class;
+
+		do {
+			$traits = array_merge( $traits, class_uses( $class ) ?: [] );
+			$class  = get_parent_class( $class );
+		} while ( false !== $class );
+
+		return array_values( array_unique( $traits ) );
+	}
+
+	/**
+	 * Returns the configured slug → model class map.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<string, class-string<Model>>
+	 */
+	protected function resourceMap(): array
+	{
+		$map = config( 'artisanpack.visual-editor.resources', [] );
+
+		return is_array( $map ) ? $map : [];
+	}
+}

--- a/src/Resources/ResourceResolver.php
+++ b/src/Resources/ResourceResolver.php
@@ -103,33 +103,13 @@ class ResourceResolver
 			);
 		}
 
-		if ( ! in_array( HasBlockContent::class, $this->usedTraits( $model ), true ) ) {
+		if ( ! in_array( HasBlockContent::class, class_uses_recursive( $model::class ), true ) ) {
 			throw new RuntimeException(
 				sprintf( 'Visual-editor resource "%s" must use the HasBlockContent trait.', $modelClass )
 			);
 		}
 
 		return $model;
-	}
-
-	/**
-	 * Returns the recursive list of traits used by a model.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @return array<int, string>
-	 */
-	protected function usedTraits( Model $model ): array
-	{
-		$traits = [];
-		$class  = $model::class;
-
-		do {
-			$traits = array_merge( $traits, class_uses( $class ) ?: [] );
-			$class  = get_parent_class( $class );
-		} while ( false !== $class );
-
-		return array_values( array_unique( $traits ) );
 	}
 
 	/**

--- a/src/View/Components/VisualEditorComponent.php
+++ b/src/View/Components/VisualEditorComponent.php
@@ -38,8 +38,17 @@ class VisualEditorComponent extends Component
 		?string $resource = null,
 		?string $apiBase = null,
 	) {
+		$key = $model->getKey();
+
+		if ( ! $model->exists || null === $key || '' === (string) $key ) {
+			throw new RuntimeException( sprintf(
+				'Visual editor cannot mount against an unsaved %s. Persist the model before rendering <x-visual-editor>.',
+				$model::class
+			) );
+		}
+
 		$this->resource = $resource ?? $this->resolveResourceSlug( $model );
-		$this->modelId  = (string) $model->getKey();
+		$this->modelId  = (string) $key;
 		$this->apiBase  = $apiBase ?? $this->defaultApiBase();
 	}
 

--- a/src/View/Components/VisualEditorComponent.php
+++ b/src/View/Components/VisualEditorComponent.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * VisualEditor Blade component.
+ *
+ * Renders the mount point for the React editor bound to a specific Eloquent
+ * model. Reverse-resolves the model's class to a resource slug via the
+ * `artisanpack.visual-editor.resources` map and emits the `data-resource`,
+ * `data-id`, and `data-api-base` attributes the React bootstrap consumes.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\View\Components;
+
+use Illuminate\Contracts\View\View;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\View\Component;
+use RuntimeException;
+
+class VisualEditorComponent extends Component
+{
+	public string $resource;
+
+	public string $modelId;
+
+	public string $apiBase;
+
+	public function __construct(
+		public Model $model,
+		?string $resource = null,
+		?string $apiBase = null,
+	) {
+		$this->resource = $resource ?? $this->resolveResourceSlug( $model );
+		$this->modelId  = (string) $model->getKey();
+		$this->apiBase  = $apiBase ?? $this->defaultApiBase();
+	}
+
+	public function render(): View
+	{
+		return view( 'visual-editor::components.editor' );
+	}
+
+	/**
+	 * Looks up the resource slug for the given model class.
+	 *
+	 * @since 1.0.0
+	 */
+	protected function resolveResourceSlug( Model $model ): string
+	{
+		$map   = (array) config( 'artisanpack.visual-editor.resources', [] );
+		$class = $model::class;
+
+		foreach ( $map as $slug => $modelClass ) {
+			if ( is_string( $slug ) && $modelClass === $class ) {
+				return $slug;
+			}
+		}
+
+		throw new RuntimeException( sprintf(
+			'Model %s is not registered in config("artisanpack.visual-editor.resources"). '
+			. 'Add it to the resources map or pass an explicit :resource="..." prop.',
+			$class
+		) );
+	}
+
+	/**
+	 * Returns the default API base path for the editor.
+	 *
+	 * @since 1.0.0
+	 */
+	protected function defaultApiBase(): string
+	{
+		return (string) config( 'artisanpack.visual-editor.api.base', '/visual-editor/api' );
+	}
+}

--- a/src/VisualEditorServiceProvider.php
+++ b/src/VisualEditorServiceProvider.php
@@ -5,6 +5,9 @@ namespace ArtisanPackUI\VisualEditor;
 use ArtisanPackUI\VisualEditor\Models\VisualEditorPost;
 use ArtisanPackUI\VisualEditor\Policies\VisualEditorPostPolicy;
 use ArtisanPackUI\VisualEditor\Registries\BlockTypeRegistry;
+use ArtisanPackUI\VisualEditor\Resources\ResourceResolver;
+use ArtisanPackUI\VisualEditor\View\Components\VisualEditorComponent;
+use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
@@ -20,6 +23,10 @@ class VisualEditorServiceProvider extends ServiceProvider
 
 		$this->app->singleton( VisualEditor::class, function ( $app ) {
 			return new VisualEditor( $app->make( BlockTypeRegistry::class ) );
+		} );
+
+		$this->app->singleton( ResourceResolver::class, function () {
+			return new ResourceResolver();
 		} );
 
 		// Legacy alias for backward compatibility
@@ -48,6 +55,7 @@ class VisualEditorServiceProvider extends ServiceProvider
 		$this->loadMigrationsFrom( __DIR__ . '/../database/migrations' );
 
 		$this->registerApiRoutes();
+		$this->registerBladeComponents();
 
 		Gate::policy( VisualEditorPost::class, VisualEditorPostPolicy::class );
 
@@ -108,6 +116,16 @@ class VisualEditorServiceProvider extends ServiceProvider
 		Route::middleware( $middleware )
 			->prefix( 'visual-editor/api' )
 			->group( __DIR__ . '/../routes/api.php' );
+	}
+
+	/**
+	 * Registers package Blade components.
+	 *
+	 * @since 1.0.0
+	 */
+	protected function registerBladeComponents(): void
+	{
+		Blade::component( VisualEditorComponent::class, 'visual-editor' );
 	}
 
 

--- a/tests/Feature/VisualEditor/ResourceContentControllerTest.php
+++ b/tests/Feature/VisualEditor/ResourceContentControllerTest.php
@@ -1,0 +1,216 @@
+<?php
+
+declare( strict_types=1 );
+
+use Illuminate\Support\Facades\Gate;
+use Tests\Fixtures\TestBlockContentModel;
+use Tests\Fixtures\TestBlockContentPageModel;
+use Tests\Fixtures\TestBlockContentPagePolicy;
+use Tests\Fixtures\TestBlockContentPolicy;
+use Tests\TestUser;
+
+beforeEach( function () {
+	config()->set( 'artisanpack.visual-editor.resources', [
+		'posts' => TestBlockContentModel::class,
+		'pages' => TestBlockContentPageModel::class,
+	] );
+
+	Gate::policy( TestBlockContentModel::class, TestBlockContentPolicy::class );
+	Gate::policy( TestBlockContentPageModel::class, TestBlockContentPagePolicy::class );
+} );
+
+function makeActor(): TestUser
+{
+	$user = TestUser::create( [
+		'name'     => 'Tester',
+		'email'    => 'tester+' . uniqid() . '@example.com',
+		'password' => bcrypt( 'secret' ),
+	] );
+
+	test()->actingAs( $user );
+
+	return $user;
+}
+
+function validBlockTree(): array
+{
+	return [
+		[
+			'clientId'    => 'abc',
+			'name'        => 'core/paragraph',
+			'attributes'  => [ 'content' => 'Hello world' ],
+			'innerBlocks' => [],
+		],
+	];
+}
+
+it( 'returns 401 for unauthenticated GET', function () {
+	$model = TestBlockContentModel::create( [
+		'title'   => 'Unauthed',
+		'status'  => 'published',
+		'content' => validBlockTree(),
+	] );
+
+	$this->getJson( "/visual-editor/api/posts/{$model->id}/content" )
+		->assertUnauthorized();
+} );
+
+it( 'returns 404 for an unregistered resource slug', function () {
+	makeActor();
+
+	$this->getJson( '/visual-editor/api/orders/1/content' )->assertNotFound();
+} );
+
+it( 'returns 404 when the record does not exist', function () {
+	makeActor();
+
+	$this->getJson( '/visual-editor/api/posts/999/content' )->assertNotFound();
+} );
+
+it( 'returns the block tree for an authorized GET', function () {
+	makeActor();
+
+	$model = TestBlockContentModel::create( [
+		'title'   => 'Hello',
+		'status'  => 'published',
+		'content' => validBlockTree(),
+	] );
+
+	$this->getJson( "/visual-editor/api/posts/{$model->id}/content" )
+		->assertOk()
+		->assertJsonPath( 'id', $model->id )
+		->assertJsonPath( 'resource', 'posts' )
+		->assertJsonPath( 'blocks.0.clientId', 'abc' )
+		->assertJsonPath( 'blocks.0.name', 'core/paragraph' );
+} );
+
+it( 'applies the configured query scope when resolving resources', function () {
+	makeActor();
+
+	$draft = TestBlockContentModel::create( [
+		'title'   => 'Draft',
+		'status'  => 'draft',
+		'content' => validBlockTree(),
+	] );
+
+	$this->getJson( "/visual-editor/api/posts/{$draft->id}/content" )
+		->assertNotFound();
+} );
+
+it( 'honors the custom block content column on PUT', function () {
+	$user = makeActor();
+
+	$page = TestBlockContentPageModel::create( [
+		'title'     => 'Page',
+		'author_id' => $user->id,
+		'body'      => [],
+	] );
+
+	$blocks = validBlockTree();
+
+	$this->putJson( "/visual-editor/api/pages/{$page->id}/content", [ 'blocks' => $blocks ] )
+		->assertOk()
+		->assertJsonPath( 'resource', 'pages' )
+		->assertJsonPath( 'blocks.0.clientId', 'abc' );
+
+	expect( $page->fresh()->body )->toEqual( $blocks );
+} );
+
+it( 'forbids PUT when the policy denies update', function () {
+	$owner = TestUser::create( [
+		'name'     => 'Owner',
+		'email'    => 'owner@example.com',
+		'password' => bcrypt( 'secret' ),
+	] );
+
+	$page = TestBlockContentPageModel::create( [
+		'title'     => 'Restricted',
+		'author_id' => $owner->id,
+		'body'      => [],
+	] );
+
+	makeActor();
+
+	$this->putJson( "/visual-editor/api/pages/{$page->id}/content", [ 'blocks' => validBlockTree() ] )
+		->assertForbidden();
+
+	expect( $page->fresh()->body )->toEqual( [] );
+} );
+
+it( 'validates the block tree shape on PUT', function () {
+	makeActor();
+
+	$model = TestBlockContentModel::create( [
+		'title'   => 'Validate',
+		'status'  => 'published',
+		'content' => [],
+	] );
+
+	$this->putJson( "/visual-editor/api/posts/{$model->id}/content", [
+		'blocks' => [ [ 'clientId' => 'only-id' ] ],
+	] )
+		->assertUnprocessable()
+		->assertJsonValidationErrors( 'blocks' );
+} );
+
+it( 'persists a valid block tree on PUT', function () {
+	makeActor();
+
+	$model = TestBlockContentModel::create( [
+		'title'   => 'Persist',
+		'status'  => 'published',
+		'content' => [],
+	] );
+
+	$next = [
+		[
+			'clientId'    => 'h1',
+			'name'        => 'core/heading',
+			'attributes'  => [ 'content' => 'Updated', 'level' => 2 ],
+			'innerBlocks' => [
+				[
+					'clientId'    => 'p1',
+					'name'        => 'core/paragraph',
+					'attributes'  => [ 'content' => 'Nested' ],
+					'innerBlocks' => [],
+				],
+			],
+		],
+	];
+
+	$this->putJson( "/visual-editor/api/posts/{$model->id}/content", [ 'blocks' => $next ] )
+		->assertOk()
+		->assertJsonPath( 'blocks.0.clientId', 'h1' )
+		->assertJsonPath( 'blocks.0.innerBlocks.0.clientId', 'p1' );
+
+	expect( $model->fresh()->content )->toEqual( $next );
+} );
+
+it( 'returns 500 when a configured resource does not use HasBlockContent', function () {
+	config()->set( 'artisanpack.visual-editor.resources.broken', TestUser::class );
+
+	makeActor();
+
+	$this->withoutExceptionHandling();
+
+	expect( fn () => $this->getJson( '/visual-editor/api/broken/1/content' ) )
+		->toThrow( RuntimeException::class );
+} );
+
+it( 'returns a preview stub from the blocks/preview endpoint', function () {
+	makeActor();
+
+	$this->postJson( '/visual-editor/api/blocks/preview', [ 'blocks' => validBlockTree() ] )
+		->assertOk()
+		->assertJsonPath( 'status', 'stub' )
+		->assertJsonPath( 'blocks.0.clientId', 'abc' )
+		->assertJsonPath( 'html', null );
+} );
+
+it( 'validates the block tree shape on the preview endpoint', function () {
+	makeActor();
+
+	$this->postJson( '/visual-editor/api/blocks/preview', [ 'blocks' => [ [ 'clientId' => 'only-id' ] ] ] )
+		->assertUnprocessable()
+		->assertJsonValidationErrors( 'blocks' );
+} );

--- a/tests/Feature/VisualEditor/VisualEditorComponentTest.php
+++ b/tests/Feature/VisualEditor/VisualEditorComponentTest.php
@@ -83,6 +83,28 @@ it( 'honors an explicit resource override prop', function () {
 	expect( $html )->toContain( 'data-resource="custom-slug"' );
 } );
 
+it( 'throws when mounted against an unsaved model', function () {
+	$model = new TestBlockContentModel( [
+		'title'   => 'Unsaved',
+		'status'  => 'published',
+		'content' => [],
+	] );
+
+	try {
+		Blade::render( '<x-visual-editor :model="$model" />', [ 'model' => $model ] );
+		test()->fail( 'Expected a RuntimeException to be thrown.' );
+	} catch ( \Throwable $e ) {
+		$root = $e;
+
+		while ( $root->getPrevious() && ! $root instanceof RuntimeException ) {
+			$root = $root->getPrevious();
+		}
+
+		expect( $root )->toBeInstanceOf( RuntimeException::class )
+			->and( $root->getMessage() )->toContain( 'unsaved' );
+	}
+} );
+
 it( 'honors an explicit api-base override prop', function () {
 	$model = TestBlockContentModel::create( [
 		'title'   => 'Api override',

--- a/tests/Feature/VisualEditor/VisualEditorComponentTest.php
+++ b/tests/Feature/VisualEditor/VisualEditorComponentTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare( strict_types=1 );
+
+use Illuminate\Support\Facades\Blade;
+use Tests\Fixtures\TestBlockContentModel;
+use Tests\Fixtures\TestBlockContentPageModel;
+
+beforeEach( function () {
+	config()->set( 'artisanpack.visual-editor.resources', [
+		'posts' => TestBlockContentModel::class,
+		'pages' => TestBlockContentPageModel::class,
+	] );
+} );
+
+it( 'renders the data attributes the React bootstrap needs', function () {
+	$model = TestBlockContentModel::create( [
+		'title'   => 'Rendered',
+		'status'  => 'published',
+		'content' => [],
+	] );
+
+	$html = Blade::render(
+		'<x-visual-editor :model="$model" />',
+		[ 'model' => $model ]
+	);
+
+	expect( $html )->toContain( 'data-ap-visual-editor' )
+		->and( $html )->toContain( 'data-resource="posts"' )
+		->and( $html )->toContain( 'data-id="' . $model->id . '"' )
+		->and( $html )->toContain( 'data-api-base="/visual-editor/api"' );
+} );
+
+it( 'infers the resource slug from the page fixture', function () {
+	$page = TestBlockContentPageModel::create( [
+		'title' => 'A page',
+		'body'  => [],
+	] );
+
+	$html = Blade::render(
+		'<x-visual-editor :model="$model" />',
+		[ 'model' => $page ]
+	);
+
+	expect( $html )->toContain( 'data-resource="pages"' );
+} );
+
+it( 'throws when the model is not registered as a resource', function () {
+	config()->set( 'artisanpack.visual-editor.resources', [] );
+
+	$model = TestBlockContentModel::create( [
+		'title'   => 'Orphan',
+		'status'  => 'published',
+		'content' => [],
+	] );
+
+	try {
+		Blade::render( '<x-visual-editor :model="$model" />', [ 'model' => $model ] );
+		test()->fail( 'Expected a RuntimeException to be thrown.' );
+	} catch ( \Throwable $e ) {
+		$root = $e;
+
+		while ( $root->getPrevious() && ! $root instanceof RuntimeException ) {
+			$root = $root->getPrevious();
+		}
+
+		expect( $root )->toBeInstanceOf( RuntimeException::class );
+	}
+} );
+
+it( 'honors an explicit resource override prop', function () {
+	$model = TestBlockContentModel::create( [
+		'title'   => 'Override',
+		'status'  => 'published',
+		'content' => [],
+	] );
+
+	$html = Blade::render(
+		'<x-visual-editor :model="$model" resource="custom-slug" />',
+		[ 'model' => $model ]
+	);
+
+	expect( $html )->toContain( 'data-resource="custom-slug"' );
+} );
+
+it( 'honors an explicit api-base override prop', function () {
+	$model = TestBlockContentModel::create( [
+		'title'   => 'Api override',
+		'status'  => 'published',
+		'content' => [],
+	] );
+
+	$html = Blade::render(
+		'<x-visual-editor :model="$model" api-base="/custom/api" />',
+		[ 'model' => $model ]
+	);
+
+	expect( $html )->toContain( 'data-api-base="/custom/api"' );
+} );

--- a/tests/Fixtures/TestBlockContentModel.php
+++ b/tests/Fixtures/TestBlockContentModel.php
@@ -1,0 +1,32 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace Tests\Fixtures;
+
+use ArtisanPackUI\VisualEditor\Concerns\HasBlockContent;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @property int $id
+ * @property string $title
+ * @property string $status
+ * @property int|null $author_id
+ * @property array<int, array<string, mixed>>|null $content
+ */
+class TestBlockContentModel extends Model
+{
+	use HasBlockContent;
+
+	protected $table = 'test_block_content_models';
+
+	protected $guarded = [];
+
+	protected string $blockContentScope = 'published';
+
+	public function scopePublished( Builder $query ): Builder
+	{
+		return $query->where( 'status', 'published' );
+	}
+}

--- a/tests/Fixtures/TestBlockContentPageModel.php
+++ b/tests/Fixtures/TestBlockContentPageModel.php
@@ -1,0 +1,28 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace Tests\Fixtures;
+
+use ArtisanPackUI\VisualEditor\Concerns\HasBlockContent;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Fixture that stores content under a non-default column to exercise the
+ * `$blockContentColumn` override on the trait.
+ *
+ * @property int $id
+ * @property string $title
+ * @property int|null $author_id
+ * @property array<int, array<string, mixed>>|null $body
+ */
+class TestBlockContentPageModel extends Model
+{
+	use HasBlockContent;
+
+	protected $table = 'test_block_content_pages';
+
+	protected $guarded = [];
+
+	protected string $blockContentColumn = 'body';
+}

--- a/tests/Fixtures/TestBlockContentPagePolicy.php
+++ b/tests/Fixtures/TestBlockContentPagePolicy.php
@@ -1,0 +1,25 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace Tests\Fixtures;
+
+use Illuminate\Contracts\Auth\Authenticatable;
+
+class TestBlockContentPagePolicy
+{
+	public function view( ?Authenticatable $user, TestBlockContentPageModel $page ): bool
+	{
+		return null !== $user;
+	}
+
+	public function update( ?Authenticatable $user, TestBlockContentPageModel $page ): bool
+	{
+		if ( null === $user ) {
+			return false;
+		}
+
+		return null === $page->author_id
+			|| (int) $page->author_id === (int) $user->getAuthIdentifier();
+	}
+}

--- a/tests/Fixtures/TestBlockContentPolicy.php
+++ b/tests/Fixtures/TestBlockContentPolicy.php
@@ -1,0 +1,25 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace Tests\Fixtures;
+
+use Illuminate\Contracts\Auth\Authenticatable;
+
+class TestBlockContentPolicy
+{
+	public function view( ?Authenticatable $user, TestBlockContentModel $model ): bool
+	{
+		return null !== $user;
+	}
+
+	public function update( ?Authenticatable $user, TestBlockContentModel $model ): bool
+	{
+		if ( null === $user ) {
+			return false;
+		}
+
+		return null === $model->author_id
+			|| (int) $model->author_id === (int) $user->getAuthIdentifier();
+	}
+}

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -15,6 +15,10 @@ pest()->extend(Tests\TestCase::class)
     ->use(Illuminate\Foundation\Testing\RefreshDatabase::class)
     ->in('Feature/VisualEditor');
 
+pest()->extend(Tests\TestCase::class)
+    ->use(Illuminate\Foundation\Testing\RefreshDatabase::class)
+    ->in('Unit/VisualEditor');
+
 /*
 |--------------------------------------------------------------------------
 | Expectations

--- a/tests/Unit/VisualEditor/HasBlockContentTest.php
+++ b/tests/Unit/VisualEditor/HasBlockContentTest.php
@@ -93,6 +93,51 @@ it( 'leaves the query untouched when no scope is configured', function () {
 	expect( $results )->toHaveCount( 2 );
 } );
 
+it( 'falls back to defaults when override properties are declared but uninitialized', function () {
+	$model = new class extends \Illuminate\Database\Eloquent\Model {
+		use \ArtisanPackUI\VisualEditor\Concerns\HasBlockContent;
+
+		protected $table = 'test_block_content_models';
+
+		protected $guarded = [];
+
+		protected string $blockContentColumn;
+
+		protected string $blockContentScope;
+	};
+
+	expect( $model->getBlockContentColumn() )->toBe( 'content' )
+		->and( $model->getBlockContentScope() )->toBeNull();
+} );
+
+it( 'preserves Arrayable casts on read (e.g. AsCollection)', function () {
+	$model = new class extends \Illuminate\Database\Eloquent\Model {
+		use \ArtisanPackUI\VisualEditor\Concerns\HasBlockContent;
+
+		protected $table = 'test_block_content_models';
+
+		protected $guarded = [];
+
+		protected function casts(): array
+		{
+			return [ 'content' => \Illuminate\Database\Eloquent\Casts\AsCollection::class ];
+		}
+	};
+
+	$model->setRawAttributes( [
+		'id'      => 1,
+		'content' => json_encode( [
+			[ 'clientId' => 'c', 'name' => 'core/paragraph', 'attributes' => [], 'innerBlocks' => [] ],
+		] ),
+	] );
+
+	$result = $model->getBlockContent();
+
+	expect( $result )->toBeArray()
+		->and( $result )->toHaveCount( 1 )
+		->and( $result[0]['clientId'] )->toBe( 'c' );
+} );
+
 it( 'throws when the configured scope method does not exist on the model', function () {
 	$model = new class extends \Illuminate\Database\Eloquent\Model {
 		use \ArtisanPackUI\VisualEditor\Concerns\HasBlockContent;

--- a/tests/Unit/VisualEditor/HasBlockContentTest.php
+++ b/tests/Unit/VisualEditor/HasBlockContentTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare( strict_types=1 );
+
+use Tests\Fixtures\TestBlockContentModel;
+use Tests\Fixtures\TestBlockContentPageModel;
+
+it( 'defaults the block content column to "content"', function () {
+	$model = new TestBlockContentModel();
+
+	expect( $model->getBlockContentColumn() )->toBe( 'content' );
+} );
+
+it( 'honors a custom block content column override', function () {
+	$model = new TestBlockContentPageModel();
+
+	expect( $model->getBlockContentColumn() )->toBe( 'body' );
+} );
+
+it( 'returns null scope when none is configured', function () {
+	$model = new TestBlockContentPageModel();
+
+	expect( $model->getBlockContentScope() )->toBeNull();
+} );
+
+it( 'exposes the configured block content scope', function () {
+	$model = new TestBlockContentModel();
+
+	expect( $model->getBlockContentScope() )->toBe( 'published' );
+} );
+
+it( 'reads and writes block content through the trait', function () {
+	$model = TestBlockContentModel::create( [
+		'title'   => 'Draft Post',
+		'status'  => 'published',
+		'content' => [
+			[ 'clientId' => 'a', 'name' => 'core/paragraph', 'attributes' => [], 'innerBlocks' => [] ],
+		],
+	] );
+
+	expect( $model->getBlockContent() )->toEqual( [
+		[ 'clientId' => 'a', 'name' => 'core/paragraph', 'attributes' => [], 'innerBlocks' => [] ],
+	] );
+
+	$model->setBlockContent( [
+		[ 'clientId' => 'b', 'name' => 'core/heading', 'attributes' => ['content' => 'Hi'], 'innerBlocks' => [] ],
+	] );
+	$model->save();
+
+	expect( $model->fresh()->getBlockContent() )->toEqual( [
+		[ 'clientId' => 'b', 'name' => 'core/heading', 'attributes' => ['content' => 'Hi'], 'innerBlocks' => [] ],
+	] );
+} );
+
+it( 'casts the content column to array on retrieval', function () {
+	$model = TestBlockContentModel::create( [
+		'title'   => 'Cast Check',
+		'status'  => 'published',
+		'content' => [ [ 'clientId' => 'c1', 'name' => 'core/paragraph', 'attributes' => [], 'innerBlocks' => [] ] ],
+	] );
+
+	$fetched = TestBlockContentModel::query()->find( $model->id );
+
+	expect( $fetched->content )->toBeArray();
+} );
+
+it( 'returns empty array when block content column is null', function () {
+	$model = TestBlockContentModel::create( [
+		'title'   => 'Empty',
+		'status'  => 'published',
+		'content' => null,
+	] );
+
+	expect( $model->getBlockContent() )->toBe( [] );
+} );
+
+it( 'applies the configured scope in forVisualEditor()', function () {
+	TestBlockContentModel::create( [ 'title' => 'Draft',     'status' => 'draft' ] );
+	TestBlockContentModel::create( [ 'title' => 'Live Post', 'status' => 'published' ] );
+
+	$results = TestBlockContentModel::query()->forVisualEditor()->get();
+
+	expect( $results )->toHaveCount( 1 )
+		->and( $results->first()->title )->toBe( 'Live Post' );
+} );
+
+it( 'leaves the query untouched when no scope is configured', function () {
+	TestBlockContentPageModel::create( [ 'title' => 'A', 'body' => [] ] );
+	TestBlockContentPageModel::create( [ 'title' => 'B', 'body' => [] ] );
+
+	$results = TestBlockContentPageModel::query()->forVisualEditor()->get();
+
+	expect( $results )->toHaveCount( 2 );
+} );
+
+it( 'emits a searchable array stub for Scout integration', function () {
+	$model = TestBlockContentModel::create( [
+		'title'   => 'Searchable',
+		'status'  => 'published',
+		'content' => [
+			[ 'clientId' => 'x', 'name' => 'core/paragraph', 'attributes' => ['content' => 'Hello'], 'innerBlocks' => [] ],
+		],
+	] );
+
+	expect( $model->toBlockContentSearchableArray() )->toEqual( [
+		'block_content' => [
+			[ 'clientId' => 'x', 'name' => 'core/paragraph', 'attributes' => ['content' => 'Hello'], 'innerBlocks' => [] ],
+		],
+	] );
+} );

--- a/tests/Unit/VisualEditor/HasBlockContentTest.php
+++ b/tests/Unit/VisualEditor/HasBlockContentTest.php
@@ -93,6 +93,21 @@ it( 'leaves the query untouched when no scope is configured', function () {
 	expect( $results )->toHaveCount( 2 );
 } );
 
+it( 'throws when the configured scope method does not exist on the model', function () {
+	$model = new class extends \Illuminate\Database\Eloquent\Model {
+		use \ArtisanPackUI\VisualEditor\Concerns\HasBlockContent;
+
+		protected $table = 'test_block_content_models';
+
+		protected $guarded = [];
+
+		protected string $blockContentScope = 'nonexistent';
+	};
+
+	expect( fn () => $model->newQuery()->forVisualEditor() )
+		->toThrow( InvalidArgumentException::class );
+} );
+
 it( 'emits a searchable array stub for Scout integration', function () {
 	$model = TestBlockContentModel::create( [
 		'title'   => 'Searchable',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,10 @@ import { resolve } from 'node:path';
 // See docs/gutenberg-adoption.md and issue #309.
 const editorRoot = resolve(__dirname, 'resources/js/visual-editor/_legacy/editor');
 const sandboxEntry = resolve(__dirname, 'resources/js/visual-editor/sandbox/main.tsx');
+const visualEditorEntry = resolve(
+    __dirname,
+    'resources/js/visual-editor/editor/main.tsx'
+);
 const coreDataShim = resolve(
     __dirname,
     'resources/js/visual-editor/vendor/core-data-shim.ts'
@@ -81,6 +85,7 @@ export default defineConfig(({ command, mode }) => {
                     input: {
                         editor: resolve(editorRoot, 'main.tsx'),
                         sandbox: sandboxEntry,
+                        'visual-editor': visualEditorEntry,
                     },
                     output: {
                         format: 'es',


### PR DESCRIPTION
## Description

M3 of the Gutenberg adoption (umbrella #309). Ships the content-agnostic persistence layer so any Eloquent model can opt in to the visual editor through a trait, auto-registered REST routes, and a one-line Blade component. Once this lands, phases C/D/E can proceed in parallel.

**Closes:** #313

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #313

## Motivation and Context

The `resources` map + Laravel policy is the load-bearing abstraction for the whole editor. Slug-to-model resolution happens centrally so adding a new content type is only a config line — no per-model controllers or routes.

## Changes Made

- `HasBlockContent` trait with `$blockContentColumn` (default `content`, overridable) and `$blockContentScope` (optional local scope); registers the JSON cast via `initializeHasBlockContent()` and ships a `toBlockContentSearchableArray()` Scout hook stub (real implementation lands in M12).
- `config/visual-editor.php`: `resources` slug→model map, `enabled_blocks` / `disabled_blocks` allow/deny lists, `media.adapter` identifier.
- `ResourceResolver` + `ResourceContentController` serve `GET|PUT /visual-editor/api/{resource}/{id}/content`. Authorization is delegated to the model's Laravel policy via `Gate::authorize('view', $model)` / `Gate::authorize('update', $model)`.
- `BlockPreviewController` ships the `POST /visual-editor/api/blocks/preview` stub (will server-render in M6). Reuses `BlockTreeRule` validation now.
- `<x-visual-editor :model="$model" />` Blade component reverse-resolves the slug, mounts a React root, and emits `data-resource` / `data-id` / `data-api-base` attributes. Supports `resource=""` / `api-base=""` override props.
- React bootstrap in `resources/js/visual-editor/editor/`: `main.tsx` scans for mount points and dynamically imports `editor-app.tsx` (so `@wordpress/*` stays in the `gutenberg` chunk). `use-persistence.ts` handles fetch → load → debounced PUT → save-status reporting, deduping concurrent saves and draining trailing edits.
- Auto-registered routes added alongside the existing `posts/{post}` + `blocks` endpoints (legacy routes retained until dev-app migrates off the `VisualEditorPost` fixture).

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS 26.3
- Browser: Safari 26.3 (manual smoke test)
- PHP Version: 8.4.19
- Laravel: 12.56

**Tests Performed:**
1. Pest: 62 passed (181 assertions) — `HasBlockContentTest`, `ResourceContentControllerTest`, `VisualEditorComponentTest`, plus the existing suite.
2. Vitest: 236 passed — `api-client.test.ts` covers GET/PUT + CSRF + error handling; `use-persistence.test.tsx` covers load state, debounce coalescing, save-error surfacing, and suppression of early PUTs.
3. Manual smoke test in the dev app: created Post + Page records (using `visual_editor_posts` / `visual_editor_pages` tables to avoid a collision with `cms-framework`), typed into the Gutenberg canvas, confirmed the ''All changes saved.'' indicator flipped, and verified content persisted across a hard reload.

## Accessibility Tests Run

- [x] Keyboard navigation tested (Gutenberg's `WritingFlow` handles this)
- [ ] Screen reader tested
- [x] Color contrast verified (save-status text uses default theme tokens)
- [x] ARIA labels checked (save-status uses `role="status"` + `aria-live="polite"`)

**Details:**

Save status announces changes via `aria-live="polite"` so screen readers pick up ''Saving…'' / ''All changes saved.'' transitions without stealing focus.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:**

- `tests/Unit/VisualEditor/HasBlockContentTest.php` — 10 tests covering column/scope defaults + overrides, cast registration, scope application, empty-content handling, and the Scout stub shape.
- `tests/Feature/VisualEditor/ResourceContentControllerTest.php` — 12 tests covering 401/404/403, scope-driven resolution, custom column PUT, validation, persistence, the broken-config guard, and the preview stub.
- `tests/Feature/VisualEditor/VisualEditorComponentTest.php` — 5 tests covering data-attribute output, slug inference, unregistered-model error, and explicit resource/api-base overrides.
- `resources/js/visual-editor/editor/__tests__/api-client.test.ts` + `use-persistence.test.tsx` — 9 frontend tests covering the fetch wrapper, CSRF handling, debounce coalescing, save-error state, and load-race protection.

## Documentation

- [x] Inline code documentation added
- [ ] README updated
- [ ] Wiki updated
- [ ] API documentation updated

**Documentation details:**

Every new class carries a file-level docblock explaining its role in M3 and how it composes with the rest of the editor; no README/Wiki updates yet because M3 is an integration-branch milestone and the public docs update will come with the release PR into `main`.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [x] Accessibility tests completed
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Visual block editor with autosave, status reporting, CSRF-aware saves, and a Blade component for embedding.
  * Client-side bootstrapping and React entrypoint to mount editors on matching DOM elements.

* **API**
  * JSON endpoints to fetch, update, and preview block content; resource resolution and authorization enforced server-side.

* **Configuration**
  * New configurable visual-editor settings (resources, block allow/deny lists, media adapter, API middleware, ownership toggle).

* **Tests**
  * Extensive unit & feature tests plus testing migrations and fixture models covering persistence, API, component, and hook behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->