### PR TITLE
M10 · React renderer package

### DIFF
--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -7,13 +7,14 @@ sub-packages are meant to reach Packagist, because Packagist watches one
 
 ## Sub-packages
 
-| Path                                    | Composer name                                       | Status      |
-|-----------------------------------------|-----------------------------------------------------|-------------|
-| `./`                                    | `artisanpack-ui/visual-editor`                      | published   |
-| `packages/visual-editor-renderer-blade` | `artisanpack-ui/visual-editor-renderer-blade`       | unpublished |
+| Path                                    | Package name                                              | Registry  | Status      |
+|-----------------------------------------|-----------------------------------------------------------|-----------|-------------|
+| `./`                                    | `artisanpack-ui/visual-editor`                            | Packagist | published   |
+| `packages/visual-editor-renderer-blade` | `artisanpack-ui/visual-editor-renderer-blade`             | Packagist | unpublished |
+| `packages/visual-editor-renderer-react` | `@artisanpack-ui/visual-editor-renderer-react`            | npm       | unpublished |
 
-M10 (React renderer) and M11 (Vue renderer) will add two more sub-packages
-under the same `packages/` directory.
+M11 (Vue renderer) will add one more sub-package under the same `packages/`
+directory.
 
 ## Distribution strategy: subtree splits
 

--- a/packages/visual-editor-renderer-react/README.md
+++ b/packages/visual-editor-renderer-react/README.md
@@ -1,0 +1,124 @@
+# @artisanpack-ui/visual-editor-renderer-react
+
+React renderer for the ArtisanPack UI visual editor.
+
+Takes a saved block tree (the JSON shape the editor persists to any
+`HasBlockContent` Eloquent model) and renders it to React elements using
+per-block components. Dynamic blocks — anything registered with the
+visual-editor's `DynamicBlockRegistry` — are fetched from the
+`/visual-editor/api/blocks/preview` endpoint on mount and spliced into the
+tree, with an unknown-block fallback for anything the server can't render.
+
+Built for Inertia+React apps. Ships zero styling — markup mirrors the server
+Blade renderer (`@artisanpack-ui/visual-editor-renderer-blade`) so the same
+theme styles apply on both sides.
+
+## Installation
+
+```sh
+npm install @artisanpack-ui/visual-editor-renderer-react
+```
+
+Peer dependencies: React 18 or 19.
+
+## Usage
+
+```tsx
+import { BlockTree } from '@artisanpack-ui/visual-editor-renderer-react';
+
+export default function Post({ post }) {
+    return (
+        <article className="prose">
+            <BlockTree tree={post.content} />
+        </article>
+    );
+}
+```
+
+`tree` accepts:
+
+- An array of blocks in the `{ clientId, name, attributes, innerBlocks }`
+  shape the visual editor persists.
+- A JSON-encoded string of that shape.
+- `null` / `undefined` (renders nothing).
+
+## Props
+
+| Prop | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `tree` | `Block[] \| string \| null` | — | Required. |
+| `dynamicBlockEndpoint` | `string` | `/visual-editor/api/blocks/preview` | Override if your app prefix is not `visual-editor`. |
+| `fetchOptions` | `RequestInit` | `{ credentials: 'same-origin' }` | Merged on top of the default request. Use for CSRF headers etc. |
+
+## Registering custom renderers
+
+The shared registry maps a block name to a React component. Register your own
+component to add support for a new block — or to override a core one:
+
+```tsx
+import {
+    registerBlockRenderer,
+    BlockTree,
+} from '@artisanpack-ui/visual-editor-renderer-react';
+
+registerBlockRenderer('acme/my-block', ({ attributes }) => (
+    <div className="my-block">{String(attributes.title ?? '')}</div>
+));
+```
+
+A custom renderer receives:
+
+```ts
+interface BlockRendererProps {
+    name: string;
+    attributes: Record<string, unknown>;
+    innerBlocks: Block[];
+    children?: React.ReactNode; // pre-rendered inner-block React elements
+}
+```
+
+Render `{children}` wherever the inner blocks should appear — BlockTree
+rendered them before invoking your component so you don't have to walk the
+tree yourself.
+
+## Dynamic blocks
+
+Any block name with no registered renderer is rendered via `<DynamicBlock>`,
+which POSTs `{ name, attributes }` to the preview endpoint and splices the
+returned HTML into the page with `dangerouslySetInnerHTML`. The HTML ships
+pre-escaped by the Laravel side (the same controller the editor calls for
+preview), so the only injection surface is the dynamic block's own `render()`
+method.
+
+If your app uses CSRF protection, pass the token through `fetchOptions`:
+
+```tsx
+<BlockTree
+    tree={post.content}
+    fetchOptions={{
+        headers: { 'X-CSRF-TOKEN': csrfToken },
+    }}
+/>
+```
+
+## Supported core blocks
+
+All blocks in the frozen V1 allow-list from the visual-editor package's M5
+audit ship with a React component:
+
+- Text: paragraph, heading, list, list-item, quote, code, preformatted,
+  pullquote, verse
+- Media: image, gallery, video, audio, file, embed
+- Design: cover, media-text, table, separator, spacer, details, search
+- Layout: columns, column, group, row, stack, buttons, button
+
+`core/latest-posts` and any other server-only dynamic block is intentionally
+not shipped as a client-side component — those hit the preview endpoint.
+
+## Status
+
+This package ships as part of the ArtisanPack UI visual editor V1 (epic
+`#309`, milestone M10). During the V1 cycle it lives inside the
+`visual-editor` monorepo under `packages/visual-editor-renderer-react/` and
+is distributed to npm via a subtree split — see `PACKAGING.md` at the
+monorepo root for the release workflow.

--- a/packages/visual-editor-renderer-react/package.json
+++ b/packages/visual-editor-renderer-react/package.json
@@ -1,0 +1,32 @@
+{
+    "name": "@artisanpack-ui/visual-editor-renderer-react",
+    "version": "1.0.0",
+    "description": "React renderer for ArtisanPack UI visual-editor block trees. Designed for Inertia+React apps.",
+    "license": "GPL-3.0-or-later",
+    "author": "Jacob Martella <me@jacobmartella.com>",
+    "type": "module",
+    "main": "./src/index.ts",
+    "types": "./src/index.ts",
+    "exports": {
+        ".": {
+            "types": "./src/index.ts",
+            "import": "./src/index.ts"
+        }
+    },
+    "files": [
+        "src",
+        "README.md"
+    ],
+    "keywords": [
+        "react",
+        "inertia",
+        "visual-editor",
+        "gutenberg",
+        "renderer",
+        "blocks"
+    ],
+    "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+    }
+}

--- a/packages/visual-editor-renderer-react/src/BlockTree.tsx
+++ b/packages/visual-editor-renderer-react/src/BlockTree.tsx
@@ -59,7 +59,7 @@ function renderBlock(
             ? (block.attributes as Record<string, unknown>)
             : {};
 
-    const innerBlocks = Array.isArray(block.innerBlocks) ? block.innerBlocks : [];
+    const innerBlocks = Array.isArray(block.innerBlocks) ? block.innerBlocks.filter(isBlock) : [];
     const key = typeof block.clientId === 'string' && block.clientId !== '' ? block.clientId : `${name}-${index}`;
 
     const renderedChildren =

--- a/packages/visual-editor-renderer-react/src/BlockTree.tsx
+++ b/packages/visual-editor-renderer-react/src/BlockTree.tsx
@@ -1,0 +1,125 @@
+/**
+ * Public React component for rendering a saved block tree.
+ *
+ * Walks a `{ clientId, name, attributes, innerBlocks }` block tree the visual
+ * editor persists and renders it to React elements. Each block name is looked
+ * up in the shared block registry; anything unregistered falls through to the
+ * {@link DynamicBlock} component, which fetches the server-rendered HTML from
+ * the visual-editor preview endpoint.
+ *
+ * `tree` accepts the array form the editor persists, a JSON-encoded string of
+ * that shape, or `null`/`undefined` for an empty render.
+ */
+
+import { Fragment } from 'react';
+import type { ReactElement, ReactNode } from 'react';
+import { DynamicBlock } from './DynamicBlock';
+import { UnknownBlock } from './blocks/unknownBlock';
+import { getBlockRenderer } from './registry';
+import type { Block } from './types';
+
+const DEFAULT_ENDPOINT = '/visual-editor/api/blocks/preview';
+
+export interface BlockTreeProps {
+    tree: Block[] | string | null | undefined;
+    dynamicBlockEndpoint?: string;
+    fetchOptions?: RequestInit;
+}
+
+export function BlockTree({
+    tree,
+    dynamicBlockEndpoint = DEFAULT_ENDPOINT,
+    fetchOptions,
+}: BlockTreeProps): ReactElement {
+    const blocks = normalizeTree(tree);
+
+    return (
+        <>
+            {blocks.map((block, index) =>
+                renderBlock(block, index, dynamicBlockEndpoint, fetchOptions)
+            )}
+        </>
+    );
+}
+
+function renderBlock(
+    block: Block,
+    index: number,
+    endpoint: string,
+    fetchOptions: RequestInit | undefined
+): ReactNode {
+    const name = typeof block.name === 'string' ? block.name.trim() : '';
+
+    if (name === '') {
+        return null;
+    }
+
+    const attributes =
+        block.attributes !== null && typeof block.attributes === 'object' && !Array.isArray(block.attributes)
+            ? (block.attributes as Record<string, unknown>)
+            : {};
+
+    const innerBlocks = Array.isArray(block.innerBlocks) ? block.innerBlocks : [];
+    const key = typeof block.clientId === 'string' && block.clientId !== '' ? block.clientId : `${name}-${index}`;
+
+    const renderedChildren =
+        innerBlocks.length === 0
+            ? null
+            : innerBlocks.map((child, childIndex) =>
+                  renderBlock(child, childIndex, endpoint, fetchOptions)
+              );
+
+    const Renderer = getBlockRenderer(name);
+
+    if (Renderer !== undefined) {
+        return (
+            <Renderer
+                key={key}
+                name={name}
+                attributes={attributes}
+                innerBlocks={innerBlocks}
+            >
+                {renderedChildren === null ? null : <Fragment>{renderedChildren}</Fragment>}
+            </Renderer>
+        );
+    }
+
+    return (
+        <DynamicBlock
+            key={key}
+            name={name}
+            attributes={attributes}
+            endpoint={endpoint}
+            fetchOptions={fetchOptions}
+        />
+    );
+}
+
+function normalizeTree(tree: Block[] | string | null | undefined): Block[] {
+    if (tree === null || tree === undefined) {
+        return [];
+    }
+
+    if (typeof tree === 'string') {
+        try {
+            const parsed = JSON.parse(tree);
+
+            return Array.isArray(parsed) ? parsed.filter(isBlock) : [];
+        } catch {
+            return [];
+        }
+    }
+
+    return Array.isArray(tree) ? tree.filter(isBlock) : [];
+}
+
+function isBlock(value: unknown): value is Block {
+    return (
+        value !== null &&
+        typeof value === 'object' &&
+        !Array.isArray(value) &&
+        typeof (value as { name?: unknown }).name === 'string'
+    );
+}
+
+export { UnknownBlock };

--- a/packages/visual-editor-renderer-react/src/DynamicBlock.tsx
+++ b/packages/visual-editor-renderer-react/src/DynamicBlock.tsx
@@ -1,0 +1,113 @@
+/**
+ * Dynamic block renderer.
+ *
+ * When a block has no client-side renderer registered, the renderer falls back
+ * to this component. On mount it POSTs `{ name, attributes }` to the
+ * visual-editor's `/visual-editor/api/blocks/preview` endpoint and mounts the
+ * HTML the server returns. If the request fails or the endpoint returns 404
+ * (no registered `DynamicBlock`), it renders the unknown-block marker so the
+ * page layout stays intact and the missing block is easy to spot.
+ *
+ * The endpoint is configurable via the `dynamicBlockEndpoint` prop on
+ * {@link BlockTree}, so hosts on a non-standard prefix can still use the
+ * renderer without patching it.
+ */
+
+import { useEffect, useMemo, useState } from 'react';
+import { UnknownBlock } from './blocks/unknownBlock';
+
+type FetchFn = typeof fetch;
+
+export interface DynamicBlockProps {
+    name: string;
+    attributes: Record<string, unknown>;
+    endpoint: string;
+    fetchOptions?: RequestInit;
+    fetchFn?: FetchFn;
+}
+
+interface DynamicBlockState {
+    status: 'loading' | 'ready' | 'error';
+    html: string;
+}
+
+export function DynamicBlock({
+    name,
+    attributes,
+    endpoint,
+    fetchOptions,
+    fetchFn,
+}: DynamicBlockProps): JSX.Element {
+    const [state, setState] = useState<DynamicBlockState>({
+        status: 'loading',
+        html: '',
+    });
+
+    const attributesJson = useMemo(() => JSON.stringify(attributes), [attributes]);
+
+    useEffect(() => {
+        const controller = new AbortController();
+        const doFetch = fetchFn ?? globalThis.fetch;
+
+        if (typeof doFetch !== 'function') {
+            setState({ status: 'error', html: '' });
+
+            return () => controller.abort();
+        }
+
+        const headers = new Headers(fetchOptions?.headers);
+
+        if (!headers.has('Accept')) {
+            headers.set('Accept', 'application/json');
+        }
+
+        if (!headers.has('Content-Type')) {
+            headers.set('Content-Type', 'application/json');
+        }
+
+        const request = doFetch(endpoint, {
+            method: 'POST',
+            credentials: 'same-origin',
+            ...fetchOptions,
+            headers,
+            body: `{"name":${JSON.stringify(name)},"attributes":${attributesJson}}`,
+            signal: controller.signal,
+        });
+
+        request
+            .then(async (response) => {
+                if (!response.ok) {
+                    throw new Error(`Preview request failed: ${response.status}`);
+                }
+
+                const data = (await response.json()) as { html?: unknown };
+                const html = typeof data.html === 'string' ? data.html : '';
+
+                setState({ status: 'ready', html });
+            })
+            .catch((error: unknown) => {
+                if ((error as { name?: string } | null)?.name === 'AbortError') {
+                    return;
+                }
+
+                setState({ status: 'error', html: '' });
+            });
+
+        return () => controller.abort();
+    }, [name, endpoint, fetchFn, fetchOptions, attributesJson]);
+
+    if (state.status === 'loading') {
+        return <div aria-busy="true" data-ve-dynamic-block={name} />;
+    }
+
+    if (state.status === 'error') {
+        return <UnknownBlock name={name} />;
+    }
+
+    return (
+        <div
+            data-ve-dynamic-block={name}
+            dangerouslySetInnerHTML={{ __html: state.html }}
+        />
+    );
+}

--- a/packages/visual-editor-renderer-react/src/blocks/core/design.tsx
+++ b/packages/visual-editor-renderer-react/src/blocks/core/design.tsx
@@ -6,7 +6,7 @@
  * server-side output.
  */
 
-import { useMemo } from 'react';
+import { useId } from 'react';
 import {
     attrArray,
     attrBoolean,
@@ -217,7 +217,7 @@ export function DetailsBlock({ attributes, children }: BlockRendererProps): JSX.
     );
 }
 
-export function SearchBlock({ name, attributes }: BlockRendererProps): JSX.Element {
+export function SearchBlock({ attributes }: BlockRendererProps): JSX.Element {
     const label = attrString(attributes.label, 'Search');
     const showLabel = attributes.showLabel === undefined ? true : attrBoolean(attributes.showLabel);
     const placeholder = attrString(attributes.placeholder);
@@ -233,10 +233,7 @@ export function SearchBlock({ name, attributes }: BlockRendererProps): JSX.Eleme
         className,
     ]);
 
-    const inputId = useMemo(
-        () => `wp-block-search-input-${stableHash(`${name}|${JSON.stringify(attributes)}`)}`,
-        [name, attributes]
-    );
+    const inputId = `wp-block-search-input-${useId().replace(/[^a-zA-Z0-9_-]/g, '')}`;
 
     return (
         <form role="search" method="get" action="/" className={classes}>
@@ -261,21 +258,3 @@ export function SearchBlock({ name, attributes }: BlockRendererProps): JSX.Eleme
     );
 }
 
-function stableHash(value: string): string {
-    let h1 = 0xdeadbeef ^ value.length;
-    let h2 = 0x41c6ce57 ^ value.length;
-
-    for (let i = 0; i < value.length; i++) {
-        const code = value.charCodeAt(i);
-
-        h1 = Math.imul(h1 ^ code, 2654435761);
-        h2 = Math.imul(h2 ^ code, 1597334677);
-    }
-
-    h1 = Math.imul(h1 ^ (h1 >>> 16), 2246822507) ^ Math.imul(h2 ^ (h2 >>> 13), 3266489909);
-    h2 = Math.imul(h2 ^ (h2 >>> 16), 2246822507) ^ Math.imul(h1 ^ (h1 >>> 13), 3266489909);
-
-    const combined = (BigInt(h2 >>> 0) << 32n) | BigInt(h1 >>> 0);
-
-    return combined.toString(16).padStart(16, '0').slice(0, 8);
-}

--- a/packages/visual-editor-renderer-react/src/blocks/core/design.tsx
+++ b/packages/visual-editor-renderer-react/src/blocks/core/design.tsx
@@ -1,0 +1,281 @@
+/**
+ * Design-family core block renderers: separator, spacer, cover, media-text,
+ * table, details, search. Validates and clamps attributes the same way the
+ * Blade partials do — dimRatio 0-100, minHeightUnit allowlist, table cell
+ * alignment allowlist, group tag allowlist — to keep parity with the
+ * server-side output.
+ */
+
+import { useMemo } from 'react';
+import {
+    attrArray,
+    attrBoolean,
+    attrFloat,
+    attrInt,
+    attrRecord,
+    attrString,
+    classList,
+} from '../../support/attributes';
+import { safeUrl } from '../../support/urlSanitizer';
+import type { BlockRendererProps } from '../../types';
+
+const ALLOWED_MIN_HEIGHT_UNITS = ['px', 'em', 'rem', 'vh', 'vw', '%'] as const;
+const ALLOWED_CELL_ALIGN = ['left', 'center', 'right', 'justify'] as const;
+
+export function SeparatorBlock({ attributes }: BlockRendererProps): JSX.Element {
+    const style = attrString(attributes.style, 'default');
+    const className = attrString(attributes.className);
+
+    const classes = classList([
+        'wp-block-separator',
+        'has-alpha-channel-opacity',
+        style === 'wide' ? 'is-style-wide' : null,
+        style === 'dots' ? 'is-style-dots' : null,
+        className,
+    ]);
+
+    return <hr className={classes} />;
+}
+
+export function SpacerBlock({ attributes }: BlockRendererProps): JSX.Element {
+    const rawHeight = attributes.height ?? '100px';
+    const height =
+        typeof rawHeight === 'number'
+            ? `${rawHeight}px`
+            : typeof rawHeight === 'string' && /^\d+(\.\d+)?$/.test(rawHeight.trim())
+            ? `${rawHeight.trim()}px`
+            : attrString(rawHeight, '100px');
+
+    return <div aria-hidden="true" className="wp-block-spacer" style={{ height }} />;
+}
+
+export function CoverBlock({ attributes, children }: BlockRendererProps): JSX.Element {
+    const url = safeUrl(attributes.url);
+    const isDark = attributes.isDark === undefined ? true : attrBoolean(attributes.isDark);
+
+    const rawDim = attrInt(attributes.dimRatio, 50);
+    const dimRatio = Math.max(0, Math.min(100, rawDim));
+
+    const align = attrString(attributes.align);
+    const className = attrString(attributes.className);
+
+    const classes = classList([
+        'wp-block-cover',
+        isDark ? 'is-dark' : 'is-light',
+        align !== '' ? `align${align}` : null,
+        className,
+    ]);
+
+    let style: React.CSSProperties | undefined;
+
+    if (attributes.minHeight !== undefined && attributes.minHeight !== null) {
+        const minHeight = Math.max(0, attrFloat(attributes.minHeight));
+        const requestedUnit = attrString(attributes.minHeightUnit);
+        const unit = (ALLOWED_MIN_HEIGHT_UNITS as ReadonlyArray<string>).includes(requestedUnit)
+            ? requestedUnit
+            : 'px';
+
+        style = { minHeight: `${minHeight}${unit}` };
+    }
+
+    return (
+        <div className={classes} style={style}>
+            <span
+                aria-hidden="true"
+                className="wp-block-cover__background has-background-dim"
+                style={{ opacity: dimRatio / 100 }}
+            />
+            {url === '' ? null : (
+                <img className="wp-block-cover__image-background" alt="" src={url} />
+            )}
+            <div className="wp-block-cover__inner-container">{children}</div>
+        </div>
+    );
+}
+
+export function MediaTextBlock({ attributes, children }: BlockRendererProps): JSX.Element {
+    const mediaUrl = safeUrl(attributes.mediaUrl);
+    const mediaAlt = attrString(attributes.mediaAlt);
+    const mediaType = attrString(attributes.mediaType, 'image');
+    const mediaPosition = attrString(attributes.mediaPosition, 'left');
+    const mediaWidth = attrInt(attributes.mediaWidth, 50);
+    const className = attrString(attributes.className);
+    const isStackedOnMobile = attrBoolean(attributes.isStackedOnMobile);
+
+    const classes = classList([
+        'wp-block-media-text',
+        mediaPosition === 'right' ? 'has-media-on-the-right' : null,
+        isStackedOnMobile ? 'is-stacked-on-mobile' : null,
+        className,
+    ]);
+
+    let style: React.CSSProperties | undefined;
+
+    if (mediaWidth !== 50) {
+        const columns =
+            mediaPosition === 'left'
+                ? `${mediaWidth}% auto`
+                : `auto ${mediaWidth}%`;
+
+        style = { gridTemplateColumns: columns };
+    }
+
+    return (
+        <div className={classes} style={style}>
+            <figure className="wp-block-media-text__media">
+                {mediaUrl === '' ? null : mediaType === 'video' ? (
+                    <video controls src={mediaUrl} />
+                ) : (
+                    <img src={mediaUrl} alt={mediaAlt} />
+                )}
+            </figure>
+            <div className="wp-block-media-text__content">{children}</div>
+        </div>
+    );
+}
+
+export function TableBlock({ attributes }: BlockRendererProps): JSX.Element {
+    const className = attrString(attributes.className);
+    const hasFixedLayout = attrBoolean(attributes.hasFixedLayout);
+    const caption = attrString(attributes.caption);
+
+    const classes = classList([
+        'wp-block-table',
+        hasFixedLayout ? 'has-fixed-layout' : null,
+        className,
+    ]);
+
+    const sections = [
+        { key: 'head' as const, Tag: 'thead' as const, defaultTag: 'th' as const },
+        { key: 'body' as const, Tag: 'tbody' as const, defaultTag: 'td' as const },
+        { key: 'foot' as const, Tag: 'tfoot' as const, defaultTag: 'td' as const },
+    ];
+
+    return (
+        <figure className={classes}>
+            <table>
+                {sections.map(({ key, Tag, defaultTag }) => {
+                    const rows = attrArray(attributes[key]);
+
+                    if (rows.length === 0) {
+                        return null;
+                    }
+
+                    return (
+                        <Tag key={key}>
+                            {rows.map((row, rowIndex) => {
+                                const rowRecord = attrRecord(row);
+                                const cells = attrArray(rowRecord.cells);
+
+                                return (
+                                    <tr key={rowIndex}>
+                                        {cells.map((cell, cellIndex) => {
+                                            const cellRecord = attrRecord(cell);
+                                            const content = attrString(cellRecord.content);
+                                            const rawAlign = attrString(cellRecord.align).toLowerCase();
+                                            const align = (ALLOWED_CELL_ALIGN as ReadonlyArray<string>).includes(rawAlign)
+                                                ? rawAlign
+                                                : '';
+                                            const cellTagRaw = attrString(cellRecord.tag);
+                                            const CellTag: 'td' | 'th' =
+                                                cellTagRaw === 'td' || cellTagRaw === 'th' ? cellTagRaw : defaultTag;
+                                            const cellStyle = align === '' ? undefined : { textAlign: align as React.CSSProperties['textAlign'] };
+
+                                            return (
+                                                <CellTag
+                                                    key={cellIndex}
+                                                    style={cellStyle}
+                                                    dangerouslySetInnerHTML={{ __html: content }}
+                                                />
+                                            );
+                                        })}
+                                    </tr>
+                                );
+                            })}
+                        </Tag>
+                    );
+                })}
+            </table>
+            {caption.trim() !== '' ? (
+                <figcaption dangerouslySetInnerHTML={{ __html: caption }} />
+            ) : null}
+        </figure>
+    );
+}
+
+export function DetailsBlock({ attributes, children }: BlockRendererProps): JSX.Element {
+    const summary = attrString(attributes.summary);
+    const showContent = attrBoolean(attributes.showContent);
+    const className = attrString(attributes.className);
+    const classes = classList(['wp-block-details', className]);
+
+    return (
+        <details className={classes} open={showContent}>
+            <summary dangerouslySetInnerHTML={{ __html: summary }} />
+            {children}
+        </details>
+    );
+}
+
+export function SearchBlock({ name, attributes }: BlockRendererProps): JSX.Element {
+    const label = attrString(attributes.label, 'Search');
+    const showLabel = attributes.showLabel === undefined ? true : attrBoolean(attributes.showLabel);
+    const placeholder = attrString(attributes.placeholder);
+    const buttonText = attrString(attributes.buttonText, 'Search');
+    const useIcon = attrBoolean(attributes.buttonUseIcon);
+    const queryName = attrString(attrRecord(attributes.query).name, 's');
+    const buttonLabel = useIcon ? '' : buttonText;
+    const className = attrString(attributes.className);
+
+    const classes = classList([
+        'wp-block-search',
+        !showLabel ? 'wp-block-search__button-inside' : null,
+        className,
+    ]);
+
+    const inputId = useMemo(
+        () => `wp-block-search-input-${stableHash(`${name}|${JSON.stringify(attributes)}`)}`,
+        [name, attributes]
+    );
+
+    return (
+        <form role="search" method="get" action="/" className={classes}>
+            {showLabel ? (
+                <label className="wp-block-search__label" htmlFor={inputId}>
+                    {label}
+                </label>
+            ) : null}
+            <div className="wp-block-search__inside-wrapper">
+                <input
+                    id={inputId}
+                    type="search"
+                    className="wp-block-search__input"
+                    name={queryName}
+                    placeholder={placeholder === '' ? undefined : placeholder}
+                />
+                <button type="submit" className="wp-block-search__button">
+                    {buttonLabel}
+                </button>
+            </div>
+        </form>
+    );
+}
+
+function stableHash(value: string): string {
+    let h1 = 0xdeadbeef ^ value.length;
+    let h2 = 0x41c6ce57 ^ value.length;
+
+    for (let i = 0; i < value.length; i++) {
+        const code = value.charCodeAt(i);
+
+        h1 = Math.imul(h1 ^ code, 2654435761);
+        h2 = Math.imul(h2 ^ code, 1597334677);
+    }
+
+    h1 = Math.imul(h1 ^ (h1 >>> 16), 2246822507) ^ Math.imul(h2 ^ (h2 >>> 13), 3266489909);
+    h2 = Math.imul(h2 ^ (h2 >>> 16), 2246822507) ^ Math.imul(h1 ^ (h1 >>> 13), 3266489909);
+
+    const combined = (BigInt(h2 >>> 0) << 32n) | BigInt(h1 >>> 0);
+
+    return combined.toString(16).padStart(16, '0').slice(0, 8);
+}

--- a/packages/visual-editor-renderer-react/src/blocks/core/layout.tsx
+++ b/packages/visual-editor-renderer-react/src/blocks/core/layout.tsx
@@ -1,0 +1,168 @@
+/**
+ * Layout + button core block renderers: group, row, stack, columns, column,
+ * buttons, button. Containers render their already-rendered inner blocks as
+ * React children; buttons sanitize URL + target/rel tokens the same way the
+ * Blade partial does.
+ */
+
+import {
+    attrBoolean,
+    attrRecord,
+    attrString,
+    classList,
+    formatPercent,
+} from '../../support/attributes';
+import { safeUrl } from '../../support/urlSanitizer';
+import type { BlockRendererProps } from '../../types';
+
+const ALLOWED_GROUP_TAGS = ['div', 'section', 'article', 'aside', 'header', 'footer', 'main', 'nav'] as const;
+
+type GroupTag = (typeof ALLOWED_GROUP_TAGS)[number];
+
+export function GroupBlock({ attributes, children }: BlockRendererProps): JSX.Element {
+    const tagName = attrString(attributes.tagName);
+    const Tag: GroupTag = (ALLOWED_GROUP_TAGS as ReadonlyArray<string>).includes(tagName)
+        ? (tagName as GroupTag)
+        : 'div';
+
+    const layout = attrRecord(attributes.layout);
+    const layoutType = attrString(layout.type);
+    const layoutClass =
+        layoutType === 'constrained'
+            ? 'is-layout-constrained'
+            : layoutType === 'flex'
+            ? 'is-layout-flex'
+            : 'is-layout-flow';
+
+    const className = attrString(attributes.className);
+    const classes = classList(['wp-block-group', layoutClass, className]);
+
+    return <Tag className={classes}>{children}</Tag>;
+}
+
+export function RowBlock({ attributes, children }: BlockRendererProps): JSX.Element {
+    const className = attrString(attributes.className);
+    const classes = classList(['wp-block-group', 'is-layout-flex', 'is-horizontal', className]);
+
+    return <div className={classes}>{children}</div>;
+}
+
+export function StackBlock({ attributes, children }: BlockRendererProps): JSX.Element {
+    const className = attrString(attributes.className);
+    const classes = classList(['wp-block-group', 'is-layout-flex', 'is-vertical', className]);
+
+    return <div className={classes}>{children}</div>;
+}
+
+export function ColumnsBlock({ attributes, children }: BlockRendererProps): JSX.Element {
+    const className = attrString(attributes.className);
+    const isStacked =
+        attributes.isStackedOnMobile === undefined ? true : attrBoolean(attributes.isStackedOnMobile);
+    const verticalAlignment = attrString(attributes.verticalAlignment);
+
+    const classes = classList([
+        'wp-block-columns',
+        isStacked ? 'is-stacked-on-mobile' : null,
+        verticalAlignment !== '' ? `are-vertically-aligned-${verticalAlignment}` : null,
+        className,
+    ]);
+
+    return <div className={classes}>{children}</div>;
+}
+
+export function ColumnBlock({ attributes, children }: BlockRendererProps): JSX.Element {
+    const className = attrString(attributes.className);
+    const verticalAlignment = attrString(attributes.verticalAlignment);
+
+    const classes = classList([
+        'wp-block-column',
+        verticalAlignment !== '' ? `is-vertically-aligned-${verticalAlignment}` : null,
+        className,
+    ]);
+
+    const width = attributes.width;
+    let style: React.CSSProperties | undefined;
+
+    if (width !== undefined && width !== null && width !== '') {
+        let basis = '';
+
+        if (typeof width === 'number') {
+            basis = formatPercent(width);
+        } else if (typeof width === 'string' && width.trim() !== '') {
+            const numeric = Number.parseFloat(width);
+
+            basis = Number.isFinite(numeric) && String(numeric) === width.trim() ? formatPercent(numeric) : width;
+        }
+
+        if (basis !== '') {
+            style = { flexBasis: basis };
+        }
+    }
+
+    return (
+        <div className={classes} style={style}>
+            {children}
+        </div>
+    );
+}
+
+export function ButtonsBlock({ attributes, children }: BlockRendererProps): JSX.Element {
+    const layout = attrRecord(attributes.layout);
+    const justify = attrString(layout.justifyContent);
+    const className = attrString(attributes.className);
+
+    const classes = classList([
+        'wp-block-buttons',
+        'is-layout-flex',
+        justify !== '' ? `is-content-justification-${justify}` : 'is-content-justification-left',
+        className,
+    ]);
+
+    return <div className={classes}>{children}</div>;
+}
+
+export function ButtonBlock({ attributes }: BlockRendererProps): JSX.Element {
+    const text = attrString(attributes.text);
+    const url = safeUrl(attributes.url);
+    const linkTarget = attrString(attributes.linkTarget);
+    const title = attrString(attributes.title);
+    const className = attrString(attributes.className);
+
+    const wrapperClasses = classList(['wp-block-button', className]);
+    const linkClasses = 'wp-block-button__link wp-element-button';
+
+    let rel = attrString(attributes.rel);
+
+    if (linkTarget === '_blank') {
+        const tokens = rel.split(/\s+/).filter((t) => t !== '');
+
+        for (const required of ['noopener', 'noreferrer']) {
+            if (!tokens.includes(required)) {
+                tokens.push(required);
+            }
+        }
+
+        rel = tokens.join(' ');
+    }
+
+    return (
+        <div className={wrapperClasses}>
+            {url === '' ? (
+                <span
+                    className={linkClasses}
+                    title={title === '' ? undefined : title}
+                    dangerouslySetInnerHTML={{ __html: text }}
+                />
+            ) : (
+                <a
+                    className={linkClasses}
+                    href={url}
+                    target={linkTarget === '' ? undefined : linkTarget}
+                    rel={rel === '' ? undefined : rel}
+                    title={title === '' ? undefined : title}
+                    dangerouslySetInnerHTML={{ __html: text }}
+                />
+            )}
+        </div>
+    );
+}

--- a/packages/visual-editor-renderer-react/src/blocks/core/media.tsx
+++ b/packages/visual-editor-renderer-react/src/blocks/core/media.tsx
@@ -1,0 +1,205 @@
+/**
+ * Media-family core block renderers: image, gallery, video, audio, file,
+ * embed. Each matches the HTML shape of the corresponding Blade partial so
+ * rendered output is interchangeable with the server-side renderer.
+ */
+
+import { attrBoolean, attrInt, attrString, classList } from '../../support/attributes';
+import { safeUrl } from '../../support/urlSanitizer';
+import type { BlockRendererProps } from '../../types';
+
+export function ImageBlock({ attributes }: BlockRendererProps): JSX.Element {
+    const url = safeUrl(attributes.url);
+    const alt = attrString(attributes.alt);
+    const caption = attrString(attributes.caption);
+    const href = safeUrl(attributes.href);
+    const id = attrInt(attributes.id);
+    const hasDimension = (key: 'width' | 'height'): boolean =>
+        attributes[key] !== undefined && attributes[key] !== null && attributes[key] !== '';
+    const width = hasDimension('width') ? attrInt(attributes.width) : undefined;
+    const height = hasDimension('height') ? attrInt(attributes.height) : undefined;
+
+    const align = attrString(attributes.align);
+    const sizeSlug = attrString(attributes.sizeSlug);
+    const className = attrString(attributes.className);
+
+    const figureClasses = classList([
+        'wp-block-image',
+        align !== '' ? `align${align}` : null,
+        sizeSlug !== '' ? `size-${sizeSlug}` : null,
+        className,
+    ]);
+
+    const imgClass = id > 0 ? `wp-image-${id}` : undefined;
+    const img =
+        url === '' ? null : (
+            <img
+                src={url}
+                alt={alt}
+                className={imgClass}
+                width={width}
+                height={height}
+            />
+        );
+
+    return (
+        <figure className={figureClasses}>
+            {img !== null && href !== '' ? <a href={href}>{img}</a> : img}
+            {caption.trim() !== '' ? (
+                <figcaption dangerouslySetInnerHTML={{ __html: caption }} />
+            ) : null}
+        </figure>
+    );
+}
+
+export function GalleryBlock({ attributes, children }: BlockRendererProps): JSX.Element {
+    const columns = attrInt(attributes.columns);
+    const imageCrop = attrBoolean(attributes.imageCrop);
+    const className = attrString(attributes.className);
+    const caption = attrString(attributes.caption);
+
+    const classes = classList([
+        'wp-block-gallery',
+        'has-nested-images',
+        columns > 0 ? `columns-${columns}` : null,
+        imageCrop ? 'is-cropped' : null,
+        className,
+    ]);
+
+    return (
+        <figure className={classes}>
+            {children}
+            {caption.trim() !== '' ? (
+                <figcaption
+                    className="blocks-gallery-caption"
+                    dangerouslySetInnerHTML={{ __html: caption }}
+                />
+            ) : null}
+        </figure>
+    );
+}
+
+export function VideoBlock({ attributes }: BlockRendererProps): JSX.Element {
+    const src = safeUrl(attributes.src);
+    const caption = attrString(attributes.caption);
+    const align = attrString(attributes.align);
+    const className = attrString(attributes.className);
+    const poster = safeUrl(attributes.poster);
+    const preload = attrString(attributes.preload, 'metadata');
+
+    const controls = attributes.controls === undefined ? true : attrBoolean(attributes.controls);
+
+    const classes = classList([
+        'wp-block-video',
+        align !== '' ? `align${align}` : null,
+        className,
+    ]);
+
+    return (
+        <figure className={classes}>
+            {src === '' ? null : (
+                <video
+                    src={src}
+                    preload={preload}
+                    controls={controls}
+                    autoPlay={attrBoolean(attributes.autoplay)}
+                    loop={attrBoolean(attributes.loop)}
+                    muted={attrBoolean(attributes.muted)}
+                    playsInline={attrBoolean(attributes.playsInline)}
+                    poster={poster === '' ? undefined : poster}
+                />
+            )}
+            {caption.trim() !== '' ? (
+                <figcaption dangerouslySetInnerHTML={{ __html: caption }} />
+            ) : null}
+        </figure>
+    );
+}
+
+export function AudioBlock({ attributes }: BlockRendererProps): JSX.Element {
+    const src = safeUrl(attributes.src);
+    const caption = attrString(attributes.caption);
+    const align = attrString(attributes.align);
+    const className = attrString(attributes.className);
+    const preload = attrString(attributes.preload, 'none');
+
+    const classes = classList([
+        'wp-block-audio',
+        align !== '' ? `align${align}` : null,
+        className,
+    ]);
+
+    return (
+        <figure className={classes}>
+            {src === '' ? null : (
+                <audio
+                    controls
+                    src={src}
+                    preload={preload}
+                    autoPlay={attrBoolean(attributes.autoplay)}
+                    loop={attrBoolean(attributes.loop)}
+                />
+            )}
+            {caption.trim() !== '' ? (
+                <figcaption dangerouslySetInnerHTML={{ __html: caption }} />
+            ) : null}
+        </figure>
+    );
+}
+
+export function FileBlock({ attributes }: BlockRendererProps): JSX.Element {
+    const href = safeUrl(attributes.href);
+    const fileName = attrString(attributes.fileName);
+    const textLinkHrefRaw = attrString(attributes.textLinkHref);
+    const textLinkHref = safeUrl(textLinkHrefRaw === '' ? attributes.href : textLinkHrefRaw);
+    const download = attrString(attributes.downloadButtonText, 'Download');
+    const showDownload =
+        attributes.showDownloadButton === undefined ? true : attrBoolean(attributes.showDownloadButton);
+    const className = attrString(attributes.className);
+
+    const classes = classList(['wp-block-file', className]);
+    const linkLabel = fileName !== '' ? fileName : href;
+
+    if (href === '') {
+        return <div className={classes} />;
+    }
+
+    return (
+        <div className={classes}>
+            <a href={textLinkHref !== '' ? textLinkHref : href}>{linkLabel}</a>
+            {showDownload ? (
+                <a href={href} className="wp-block-file__button" download>
+                    {download}
+                </a>
+            ) : null}
+        </div>
+    );
+}
+
+export function EmbedBlock({ attributes }: BlockRendererProps): JSX.Element {
+    const url = attrString(attributes.url);
+    const provider = attrString(attributes.providerNameSlug).toLowerCase();
+    const caption = attrString(attributes.caption);
+    const ratio = attrString(attributes.aspectRatio);
+    const type = attrString(attributes.type);
+
+    const sanitizedProvider = provider.replace(/[^a-z0-9-]/g, '-');
+
+    const classes = classList([
+        'wp-block-embed',
+        sanitizedProvider !== '' ? `is-provider-${sanitizedProvider}` : null,
+        sanitizedProvider !== '' ? `wp-block-embed-${sanitizedProvider}` : null,
+        type !== '' ? `is-type-${type}` : null,
+        ratio !== '' ? `wp-embed-aspect-${ratio.replace(/\//g, '-')}` : null,
+        ratio !== '' ? 'wp-has-aspect-ratio' : null,
+    ]);
+
+    return (
+        <figure className={classes}>
+            <div className="wp-block-embed__wrapper">{url === '' ? null : url}</div>
+            {caption.trim() !== '' ? (
+                <figcaption dangerouslySetInnerHTML={{ __html: caption }} />
+            ) : null}
+        </figure>
+    );
+}

--- a/packages/visual-editor-renderer-react/src/blocks/core/text.tsx
+++ b/packages/visual-editor-renderer-react/src/blocks/core/text.tsx
@@ -1,0 +1,154 @@
+/**
+ * Text-family core block renderers: paragraph, heading, list, list-item,
+ * quote, code, preformatted, verse, and pullquote. Each one mirrors the
+ * output of the matching Blade partial in
+ * `artisanpack-ui/visual-editor-renderer-blade` so server-rendered and
+ * React-rendered pages ship identical markup.
+ */
+
+import { attrBoolean, attrInt, attrString, classList } from '../../support/attributes';
+import type { BlockRendererProps } from '../../types';
+
+export function ParagraphBlock({ attributes }: BlockRendererProps): JSX.Element {
+    const align = attrString(attributes.align);
+    const className = attrString(attributes.className);
+    const content = attrString(attributes.content);
+
+    const classes = classList([
+        'wp-block-paragraph',
+        align !== '' ? `has-text-align-${align}` : null,
+        className,
+    ]);
+
+    return <p className={classes} dangerouslySetInnerHTML={{ __html: content }} />;
+}
+
+export function HeadingBlock({ attributes }: BlockRendererProps): JSX.Element {
+    const rawLevel = attrInt(attributes.level, 2);
+    const level = Math.max(1, Math.min(6, rawLevel));
+    const textAlign = attrString(attributes.textAlign);
+    const className = attrString(attributes.className);
+    const content = attrString(attributes.content);
+
+    const classes = classList([
+        'wp-block-heading',
+        textAlign !== '' ? `has-text-align-${textAlign}` : null,
+        className,
+    ]);
+
+    const Tag = `h${level}` as 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+
+    return <Tag className={classes} dangerouslySetInnerHTML={{ __html: content }} />;
+}
+
+export function ListBlock({ attributes, children }: BlockRendererProps): JSX.Element {
+    const ordered = attrBoolean(attributes.ordered);
+    const className = attrString(attributes.className);
+    const legacyValues = attrString(attributes.values);
+    const classes = classList(['wp-block-list', className]);
+
+    const commonProps: Record<string, unknown> = { className: classes };
+
+    if (ordered) {
+        if (attributes.start !== undefined && attributes.start !== null) {
+            commonProps.start = attrInt(attributes.start);
+        }
+
+        if (attrBoolean(attributes.reversed)) {
+            commonProps.reversed = true;
+        }
+    }
+
+    const hasChildren = children !== null && children !== undefined;
+
+    if (hasChildren) {
+        return ordered ? <ol {...commonProps}>{children}</ol> : <ul {...commonProps}>{children}</ul>;
+    }
+
+    if (legacyValues === '') {
+        return ordered ? <ol {...commonProps} /> : <ul {...commonProps} />;
+    }
+
+    const htmlProps = { ...commonProps, dangerouslySetInnerHTML: { __html: legacyValues } };
+
+    return ordered ? <ol {...htmlProps} /> : <ul {...htmlProps} />;
+}
+
+export function ListItemBlock({ attributes, children }: BlockRendererProps): JSX.Element {
+    const content = attrString(attributes.content);
+
+    if (children === null || children === undefined) {
+        return <li dangerouslySetInnerHTML={{ __html: content }} />;
+    }
+
+    return (
+        <li>
+            <span dangerouslySetInnerHTML={{ __html: content }} />
+            {children}
+        </li>
+    );
+}
+
+export function QuoteBlock({ attributes, children }: BlockRendererProps): JSX.Element {
+    const className = attrString(attributes.className);
+    const citation = attrString(attributes.citation);
+    const classes = classList(['wp-block-quote', className]);
+
+    return (
+        <blockquote className={classes}>
+            {children}
+            {citation.trim() !== '' ? (
+                <cite dangerouslySetInnerHTML={{ __html: citation }} />
+            ) : null}
+        </blockquote>
+    );
+}
+
+export function CodeBlock({ attributes }: BlockRendererProps): JSX.Element {
+    const content = attrString(attributes.content);
+
+    return (
+        <pre className="wp-block-code">
+            <code dangerouslySetInnerHTML={{ __html: content }} />
+        </pre>
+    );
+}
+
+export function PreformattedBlock({ attributes }: BlockRendererProps): JSX.Element {
+    const content = attrString(attributes.content);
+
+    return (
+        <pre className="wp-block-preformatted" dangerouslySetInnerHTML={{ __html: content }} />
+    );
+}
+
+export function VerseBlock({ attributes }: BlockRendererProps): JSX.Element {
+    const content = attrString(attributes.content);
+    const textAlign = attrString(attributes.textAlign);
+    const classes = classList([
+        'wp-block-verse',
+        textAlign !== '' ? `has-text-align-${textAlign}` : null,
+    ]);
+
+    return <pre className={classes} dangerouslySetInnerHTML={{ __html: content }} />;
+}
+
+export function PullquoteBlock({ attributes }: BlockRendererProps): JSX.Element {
+    const className = attrString(attributes.className);
+    const value = attrString(attributes.value);
+    const citation = attrString(attributes.citation);
+    const classes = classList(['wp-block-pullquote', className]);
+
+    return (
+        <figure className={classes}>
+            <blockquote>
+                {value.trim() !== '' ? (
+                    <span dangerouslySetInnerHTML={{ __html: value }} />
+                ) : null}
+                {citation.trim() !== '' ? (
+                    <cite dangerouslySetInnerHTML={{ __html: citation }} />
+                ) : null}
+            </blockquote>
+        </figure>
+    );
+}

--- a/packages/visual-editor-renderer-react/src/blocks/registerCoreBlocks.ts
+++ b/packages/visual-editor-renderer-react/src/blocks/registerCoreBlocks.ts
@@ -1,0 +1,92 @@
+/**
+ * Core block registration entry point.
+ *
+ * Calling {@link registerCoreBlocks} populates the shared registry with every
+ * `core/*` renderer this package ships. Host apps that want to override a
+ * core renderer should call `registerCoreBlocks()` first, then register their
+ * own component under the same name.
+ *
+ * The visual-editor block allow-list (from the package's M5 audit) is frozen
+ * for V1, so the map below is exhaustive for every block type the editor can
+ * persist.
+ */
+
+import { registerBlockRenderer } from '../registry';
+import {
+    CoverBlock,
+    DetailsBlock,
+    MediaTextBlock,
+    SearchBlock,
+    SeparatorBlock,
+    SpacerBlock,
+    TableBlock,
+} from './core/design';
+import {
+    ButtonBlock,
+    ButtonsBlock,
+    ColumnBlock,
+    ColumnsBlock,
+    GroupBlock,
+    RowBlock,
+    StackBlock,
+} from './core/layout';
+import {
+    AudioBlock,
+    EmbedBlock,
+    FileBlock,
+    GalleryBlock,
+    ImageBlock,
+    VideoBlock,
+} from './core/media';
+import {
+    CodeBlock,
+    HeadingBlock,
+    ListBlock,
+    ListItemBlock,
+    ParagraphBlock,
+    PreformattedBlock,
+    PullquoteBlock,
+    QuoteBlock,
+    VerseBlock,
+} from './core/text';
+import type { BlockRenderer } from '../types';
+
+const CORE_BLOCKS: Record<string, BlockRenderer> = {
+    'core/paragraph': ParagraphBlock,
+    'core/heading': HeadingBlock,
+    'core/list': ListBlock,
+    'core/list-item': ListItemBlock,
+    'core/quote': QuoteBlock,
+    'core/code': CodeBlock,
+    'core/preformatted': PreformattedBlock,
+    'core/verse': VerseBlock,
+    'core/pullquote': PullquoteBlock,
+    'core/image': ImageBlock,
+    'core/gallery': GalleryBlock,
+    'core/video': VideoBlock,
+    'core/audio': AudioBlock,
+    'core/file': FileBlock,
+    'core/embed': EmbedBlock,
+    'core/group': GroupBlock,
+    'core/row': RowBlock,
+    'core/stack': StackBlock,
+    'core/columns': ColumnsBlock,
+    'core/column': ColumnBlock,
+    'core/buttons': ButtonsBlock,
+    'core/button': ButtonBlock,
+    'core/cover': CoverBlock,
+    'core/media-text': MediaTextBlock,
+    'core/table': TableBlock,
+    'core/details': DetailsBlock,
+    'core/search': SearchBlock,
+    'core/separator': SeparatorBlock,
+    'core/spacer': SpacerBlock,
+};
+
+export function registerCoreBlocks(): void {
+    for (const [name, component] of Object.entries(CORE_BLOCKS)) {
+        registerBlockRenderer(name, component);
+    }
+}
+
+export { CORE_BLOCKS };

--- a/packages/visual-editor-renderer-react/src/blocks/unknownBlock.tsx
+++ b/packages/visual-editor-renderer-react/src/blocks/unknownBlock.tsx
@@ -1,0 +1,21 @@
+/**
+ * Fallback markup for blocks that have no registered React renderer and that
+ * the dynamic-block endpoint does not recognize either. Mirrors the
+ * `<!-- visual-editor: no partial for ... -->` comment + `<div>` wrapper the
+ * Blade renderer emits.
+ */
+
+import type { ReactNode } from 'react';
+
+export interface UnknownBlockProps {
+    name: string;
+    children?: ReactNode;
+}
+
+export function UnknownBlock({ name, children }: UnknownBlockProps): JSX.Element {
+    return (
+        <div data-ve-unknown-block={name}>
+            {children}
+        </div>
+    );
+}

--- a/packages/visual-editor-renderer-react/src/index.ts
+++ b/packages/visual-editor-renderer-react/src/index.ts
@@ -1,0 +1,28 @@
+/**
+ * Public API for `@artisanpack-ui/visual-editor-renderer-react`.
+ *
+ * Auto-registers every core block renderer at import time so the simplest
+ * consumer only has to render `<BlockTree tree={post.content} />`. Apps that
+ * need to override a core block or ship their own can call
+ * {@link registerBlockRenderer} after this import.
+ */
+
+import { registerCoreBlocks } from './blocks/registerCoreBlocks';
+
+registerCoreBlocks();
+
+export { BlockTree } from './BlockTree';
+export type { BlockTreeProps } from './BlockTree';
+export { DynamicBlock } from './DynamicBlock';
+export type { DynamicBlockProps } from './DynamicBlock';
+export { UnknownBlock } from './blocks/unknownBlock';
+export {
+    getBlockRenderer,
+    getRegisteredBlockNames,
+    hasBlockRenderer,
+    registerBlockRenderer,
+    resetBlockRegistry,
+    unregisterBlockRenderer,
+} from './registry';
+export { registerCoreBlocks } from './blocks/registerCoreBlocks';
+export type { Block, BlockRenderer, BlockRendererProps } from './types';

--- a/packages/visual-editor-renderer-react/src/registry.ts
+++ b/packages/visual-editor-renderer-react/src/registry.ts
@@ -1,0 +1,46 @@
+/**
+ * Block renderer registry.
+ *
+ * The registry maps a block name (e.g. `core/paragraph`, `acme/my-block`) to
+ * a React component. Every renderer receives the same
+ * {@link BlockRendererProps} contract: parsed `attributes`, the raw
+ * `innerBlocks` array, and already-rendered inner-block children.
+ *
+ * Core blocks register themselves at import time from `coreBlocks.ts`. Host
+ * apps and third-party packages register custom renderers via
+ * {@link registerBlockRenderer}, which also lets them override a core block.
+ */
+
+import type { BlockRenderer } from './types';
+
+const registry = new Map<string, BlockRenderer>();
+
+export function registerBlockRenderer(name: string, renderer: BlockRenderer): void {
+    const trimmed = name.trim();
+
+    if (trimmed === '') {
+        throw new Error('registerBlockRenderer: block name cannot be empty.');
+    }
+
+    registry.set(trimmed, renderer);
+}
+
+export function unregisterBlockRenderer(name: string): void {
+    registry.delete(name.trim());
+}
+
+export function getBlockRenderer(name: string): BlockRenderer | undefined {
+    return registry.get(name.trim());
+}
+
+export function hasBlockRenderer(name: string): boolean {
+    return registry.has(name.trim());
+}
+
+export function getRegisteredBlockNames(): string[] {
+    return Array.from(registry.keys()).sort();
+}
+
+export function resetBlockRegistry(): void {
+    registry.clear();
+}

--- a/packages/visual-editor-renderer-react/src/support/attributes.ts
+++ b/packages/visual-editor-renderer-react/src/support/attributes.ts
@@ -28,7 +28,9 @@ export function attrBoolean(value: unknown, fallback = false): boolean {
     }
 
     if (typeof value === 'string') {
-        return value.trim() !== '' && value !== 'false' && value !== '0';
+        const normalized = value.trim().toLowerCase();
+
+        return normalized !== '' && normalized !== 'false' && normalized !== '0';
     }
 
     if (typeof value === 'number') {

--- a/packages/visual-editor-renderer-react/src/support/attributes.ts
+++ b/packages/visual-editor-renderer-react/src/support/attributes.ts
@@ -1,0 +1,101 @@
+/**
+ * Attribute coercion helpers.
+ *
+ * Block attributes come off a JSON payload, so every value is `unknown` at
+ * runtime. These helpers coerce individual attributes to the shapes the
+ * per-block renderers expect while keeping every renderer terse.
+ */
+
+export function attrString(value: unknown, fallback = ''): string {
+    if (typeof value === 'string') {
+        return value;
+    }
+
+    if (typeof value === 'number' || typeof value === 'boolean') {
+        return String(value);
+    }
+
+    return fallback;
+}
+
+export function attrBoolean(value: unknown, fallback = false): boolean {
+    if (typeof value === 'boolean') {
+        return value;
+    }
+
+    if (value === null || value === undefined) {
+        return fallback;
+    }
+
+    if (typeof value === 'string') {
+        return value.trim() !== '' && value !== 'false' && value !== '0';
+    }
+
+    if (typeof value === 'number') {
+        return value !== 0;
+    }
+
+    return Boolean(value);
+}
+
+export function attrInt(value: unknown, fallback = 0): number {
+    if (typeof value === 'number' && Number.isFinite(value)) {
+        return Math.trunc(value);
+    }
+
+    if (typeof value === 'string' && value.trim() !== '') {
+        const parsed = Number.parseInt(value, 10);
+
+        if (Number.isFinite(parsed)) {
+            return parsed;
+        }
+    }
+
+    return fallback;
+}
+
+export function attrFloat(value: unknown, fallback = 0): number {
+    if (typeof value === 'number' && Number.isFinite(value)) {
+        return value;
+    }
+
+    if (typeof value === 'string' && value.trim() !== '') {
+        const parsed = Number.parseFloat(value);
+
+        if (Number.isFinite(parsed)) {
+            return parsed;
+        }
+    }
+
+    return fallback;
+}
+
+export function attrRecord(value: unknown): Record<string, unknown> {
+    if (value === null || value === undefined || typeof value !== 'object') {
+        return {};
+    }
+
+    if (Array.isArray(value)) {
+        return {};
+    }
+
+    return value as Record<string, unknown>;
+}
+
+export function attrArray(value: unknown): unknown[] {
+    return Array.isArray(value) ? value : [];
+}
+
+export function classList(classes: Array<string | false | null | undefined>): string {
+    return classes
+        .filter((c): c is string => typeof c === 'string' && c.trim() !== '')
+        .map((c) => c.trim())
+        .join(' ');
+}
+
+export function formatPercent(value: number): string {
+    const fixed = value.toFixed(6);
+    const trimmed = fixed.replace(/0+$/, '').replace(/\.$/, '');
+
+    return (trimmed === '' ? '0' : trimmed) + '%';
+}

--- a/packages/visual-editor-renderer-react/src/support/urlSanitizer.ts
+++ b/packages/visual-editor-renderer-react/src/support/urlSanitizer.ts
@@ -1,0 +1,39 @@
+/**
+ * URL sanitization helpers.
+ *
+ * Mirrors the PHP `UrlSanitizer::safe()` used by the Blade renderer: relative
+ * URLs pass through, absolute URLs must use one of the safe schemes, and
+ * anything else (e.g. `javascript:`, `data:`, `vbscript:`) is dropped so a
+ * stored block tree can't smuggle script execution into the rendered page.
+ */
+
+const SAFE_SCHEMES: ReadonlyArray<string> = [
+    'http',
+    'https',
+    'mailto',
+    'tel',
+    'ftp',
+    'sms',
+];
+
+const SCHEME_PATTERN = /^([a-z][a-z0-9+\-.]*):/i;
+
+export function safeUrl(url: unknown): string {
+    if (typeof url !== 'string') {
+        return '';
+    }
+
+    const trimmed = url.trim();
+
+    if (trimmed === '') {
+        return '';
+    }
+
+    const match = SCHEME_PATTERN.exec(trimmed);
+
+    if (match === null) {
+        return trimmed;
+    }
+
+    return SAFE_SCHEMES.includes(match[1].toLowerCase()) ? trimmed : '';
+}

--- a/packages/visual-editor-renderer-react/src/types.ts
+++ b/packages/visual-editor-renderer-react/src/types.ts
@@ -1,0 +1,27 @@
+/**
+ * Shared types for the React block renderer.
+ *
+ * A {@link Block} matches the shape the visual editor persists to any
+ * `HasBlockContent` model: `{ clientId, name, attributes, innerBlocks }`.
+ * Block renderer components receive their own parsed attributes plus the
+ * already-rendered inner blocks (as React children) so containers can splice
+ * children into place without re-walking the tree.
+ */
+
+import type { ComponentType, ReactNode } from 'react';
+
+export interface Block {
+    clientId?: string;
+    name: string;
+    attributes?: Record<string, unknown>;
+    innerBlocks?: Block[];
+}
+
+export interface BlockRendererProps {
+    name: string;
+    attributes: Record<string, unknown>;
+    innerBlocks: Block[];
+    children?: ReactNode;
+}
+
+export type BlockRenderer = ComponentType<BlockRendererProps>;

--- a/packages/visual-editor-renderer-react/tests/BlockTree.test.tsx
+++ b/packages/visual-editor-renderer-react/tests/BlockTree.test.tsx
@@ -1,0 +1,558 @@
+import { render, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import '../src/index';
+import { BlockTree } from '../src/BlockTree';
+import {
+    registerBlockRenderer,
+    resetBlockRegistry,
+    unregisterBlockRenderer,
+} from '../src/registry';
+import { registerCoreBlocks } from '../src/blocks/registerCoreBlocks';
+import { makeBlock, normalizeHtml } from './helpers';
+
+function renderTree(tree: unknown): string {
+    const { container } = render(
+        <BlockTree tree={tree as Parameters<typeof BlockTree>[0]['tree']} />
+    );
+
+    return normalizeHtml(container.innerHTML);
+}
+
+afterEach(() => {
+    resetBlockRegistry();
+    registerCoreBlocks();
+});
+
+describe('BlockTree normalization', () => {
+    it('renders nothing for an empty tree', () => {
+        expect(renderTree([])).toBe('');
+    });
+
+    it('renders nothing for null or undefined', () => {
+        expect(renderTree(null)).toBe('');
+        expect(renderTree(undefined)).toBe('');
+    });
+
+    it('parses a JSON-encoded string tree', () => {
+        const json = JSON.stringify([makeBlock('core/paragraph', { content: 'Hi' })]);
+
+        expect(renderTree(json)).toBe('<p class="wp-block-paragraph">Hi</p>');
+    });
+
+    it('skips entries that are not block-shaped objects', () => {
+        const tree = [
+            'not-a-block',
+            null,
+            42,
+            makeBlock('core/paragraph', { content: 'Good' }),
+        ];
+
+        expect(renderTree(tree)).toContain('Good');
+    });
+
+    it('skips blocks with missing or empty names', () => {
+        const tree = [
+            { clientId: 'a', name: '', attributes: {}, innerBlocks: [] },
+            { clientId: 'b', attributes: {}, innerBlocks: [] } as unknown,
+        ];
+
+        expect(renderTree(tree)).toBe('');
+    });
+});
+
+describe('Core text blocks', () => {
+    it('renders a paragraph block', () => {
+        const tree = [makeBlock('core/paragraph', { content: 'Hello <strong>world</strong>' })];
+
+        expect(renderTree(tree)).toBe('<p class="wp-block-paragraph">Hello <strong>world</strong></p>');
+    });
+
+    it('renders a heading at the configured level', () => {
+        const tree = [makeBlock('core/heading', { level: 3, content: 'Section' })];
+
+        expect(renderTree(tree)).toBe('<h3 class="wp-block-heading">Section</h3>');
+    });
+
+    it('clamps invalid heading levels to the allowed range', () => {
+        expect(renderTree([makeBlock('core/heading', { level: 99, content: 'X' })])).toContain('<h6');
+        expect(renderTree([makeBlock('core/heading', { level: 0, content: 'Y' })])).toContain('<h1');
+    });
+
+    it('renders a quote with citation', () => {
+        const tree = [
+            makeBlock('core/quote', { citation: 'Someone Famous' }, [
+                makeBlock('core/paragraph', { content: 'Quoted text' }, [], 'p1'),
+            ]),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('<blockquote class="wp-block-quote">');
+        expect(html).toContain('<p class="wp-block-paragraph">Quoted text</p>');
+        expect(html).toContain('<cite>Someone Famous</cite>');
+    });
+
+    it('renders a code block', () => {
+        const tree = [makeBlock('core/code', { content: 'echo 1;' })];
+
+        expect(renderTree(tree)).toBe('<pre class="wp-block-code"><code>echo 1;</code></pre>');
+    });
+
+    it('renders a preformatted block preserving whitespace', () => {
+        const tree = [makeBlock('core/preformatted', { content: 'line 1\nline 2' })];
+
+        const html = render(
+            <BlockTree tree={tree} />
+        ).container.innerHTML;
+
+        expect(html).toContain('<pre class="wp-block-preformatted">');
+        expect(html).toContain('line 1\nline 2');
+    });
+
+    it('renders a verse block', () => {
+        const tree = [makeBlock('core/verse', { content: 'Roses are red' })];
+
+        expect(renderTree(tree)).toContain('<pre class="wp-block-verse">Roses are red</pre>');
+    });
+
+    it('renders a pullquote with value and citation', () => {
+        const tree = [
+            makeBlock('core/pullquote', {
+                value: 'Be bold',
+                citation: 'Editor',
+            }),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('<figure class="wp-block-pullquote">');
+        expect(html).toContain('Be bold');
+        expect(html).toContain('<cite>Editor</cite>');
+    });
+
+    it('renders an unordered list with list items', () => {
+        const tree = [
+            makeBlock('core/list', { ordered: false }, [
+                makeBlock('core/list-item', { content: 'One' }, [], 'li-1'),
+                makeBlock('core/list-item', { content: 'Two' }, [], 'li-2'),
+            ]),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('<ul class="wp-block-list">');
+        expect(html).toContain('<li>One</li>');
+        expect(html).toContain('<li>Two</li>');
+        expect(html).toContain('</ul>');
+    });
+
+    it('renders an ordered list with start + reversed attributes', () => {
+        const tree = [
+            makeBlock('core/list', { ordered: true, start: 5, reversed: true }, [
+                makeBlock('core/list-item', { content: 'A' }, [], 'li-1'),
+            ]),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('<ol ');
+        expect(html).toContain('start="5"');
+        expect(html).toContain('reversed');
+    });
+});
+
+describe('Core media blocks', () => {
+    it('renders an image block with caption and link', () => {
+        const tree = [
+            makeBlock('core/image', {
+                url: 'https://example.test/image.jpg',
+                alt: 'An image',
+                caption: 'A <em>caption</em>',
+                href: 'https://example.test/full.jpg',
+                id: 42,
+            }),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('<figure class="wp-block-image">');
+        expect(html).toContain('src="https://example.test/image.jpg"');
+        expect(html).toContain('alt="An image"');
+        expect(html).toContain('class="wp-image-42"');
+        expect(html).toContain('href="https://example.test/full.jpg"');
+        expect(html).toContain('<figcaption>A <em>caption</em></figcaption>');
+    });
+
+    it('drops unsafe URL schemes from image hrefs', () => {
+        const tree = [
+            makeBlock('core/image', {
+                url: 'https://example.test/safe.jpg',
+                href: 'javascript:void(0)',
+                alt: 'safe',
+            }),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).not.toContain('javascript:');
+        expect(html).toContain('src="https://example.test/safe.jpg"');
+        expect(html).not.toContain('<a ');
+    });
+
+    it('renders a video block with controls + poster', () => {
+        const tree = [
+            makeBlock('core/video', {
+                src: 'https://example.test/movie.mp4',
+                poster: 'https://example.test/poster.jpg',
+                controls: true,
+                loop: true,
+                muted: true,
+            }),
+        ];
+
+        const { container } = render(<BlockTree tree={tree} />);
+        const video = container.querySelector('video');
+
+        expect(video).not.toBeNull();
+        expect(video?.getAttribute('src')).toBe('https://example.test/movie.mp4');
+        expect(video?.getAttribute('poster')).toBe('https://example.test/poster.jpg');
+        expect(video?.controls).toBe(true);
+        expect(video?.loop).toBe(true);
+        expect(video?.muted).toBe(true);
+    });
+
+    it('renders an audio block', () => {
+        const tree = [
+            makeBlock('core/audio', {
+                src: 'https://example.test/track.mp3',
+                preload: 'metadata',
+            }),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('<figure class="wp-block-audio">');
+        expect(html).toContain('src="https://example.test/track.mp3"');
+        expect(html).toContain('preload="metadata"');
+    });
+
+    it('renders a file block with download button', () => {
+        const tree = [
+            makeBlock('core/file', {
+                href: 'https://example.test/doc.pdf',
+                fileName: 'doc.pdf',
+                downloadButtonText: 'Download PDF',
+            }),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('<div class="wp-block-file">');
+        expect(html).toContain('<a href="https://example.test/doc.pdf">doc.pdf</a>');
+        expect(html).toContain('class="wp-block-file__button"');
+        expect(html).toContain('Download PDF');
+    });
+
+    it('renders a gallery with columns class and nested images', () => {
+        const tree = [
+            makeBlock(
+                'core/gallery',
+                { columns: 3, imageCrop: true },
+                [
+                    makeBlock(
+                        'core/image',
+                        { url: 'https://example.test/a.jpg', alt: 'a' },
+                        [],
+                        'img-a'
+                    ),
+                    makeBlock(
+                        'core/image',
+                        { url: 'https://example.test/b.jpg', alt: 'b' },
+                        [],
+                        'img-b'
+                    ),
+                ]
+            ),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('<figure class="wp-block-gallery has-nested-images columns-3 is-cropped">');
+        expect(html).toContain('src="https://example.test/a.jpg"');
+        expect(html).toContain('src="https://example.test/b.jpg"');
+    });
+
+    it('renders an embed block with provider and aspect classes', () => {
+        const tree = [
+            makeBlock('core/embed', {
+                url: 'https://youtu.be/abc123',
+                providerNameSlug: 'youtube',
+                aspectRatio: '16/9',
+                type: 'video',
+            }),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('is-provider-youtube');
+        expect(html).toContain('wp-block-embed-youtube');
+        expect(html).toContain('is-type-video');
+        expect(html).toContain('wp-embed-aspect-16-9');
+        expect(html).toContain('wp-has-aspect-ratio');
+    });
+});
+
+describe('Core layout blocks', () => {
+    it('renders nested inner blocks for a group', () => {
+        const tree = [
+            makeBlock('core/group', {}, [
+                makeBlock('core/paragraph', { content: 'Inner' }, [], 'inner-1'),
+            ]),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('<div class="wp-block-group is-layout-flow">');
+        expect(html).toContain('<p class="wp-block-paragraph">Inner</p>');
+    });
+
+    it('renders a row with is-horizontal class', () => {
+        const tree = [makeBlock('core/row', {}, [makeBlock('core/paragraph', { content: 'Row' }, [], 'r1')])];
+
+        expect(renderTree(tree)).toContain('<div class="wp-block-group is-layout-flex is-horizontal">');
+    });
+
+    it('renders a stack with is-vertical class', () => {
+        const tree = [makeBlock('core/stack', {}, [makeBlock('core/paragraph', { content: 'Stacked' }, [], 's1')])];
+
+        expect(renderTree(tree)).toContain('<div class="wp-block-group is-layout-flex is-vertical">');
+    });
+
+    it('renders columns with column widths', () => {
+        const tree = [
+            makeBlock('core/columns', {}, [
+                makeBlock(
+                    'core/column',
+                    { width: 60 },
+                    [makeBlock('core/paragraph', { content: 'Left' }, [], 'l-1')],
+                    'col-1'
+                ),
+                makeBlock(
+                    'core/column',
+                    {},
+                    [makeBlock('core/paragraph', { content: 'Right' }, [], 'r-1')],
+                    'col-2'
+                ),
+            ]),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('wp-block-columns');
+        expect(html).toContain('flex-basis: 60%');
+        expect(html).toContain('<p class="wp-block-paragraph">Left</p>');
+        expect(html).toContain('<p class="wp-block-paragraph">Right</p>');
+    });
+
+    it('renders a button with safe URL and forces noopener on _blank', () => {
+        const tree = [
+            makeBlock('core/button', {
+                text: 'External',
+                url: 'https://example.com',
+                linkTarget: '_blank',
+            }),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('target="_blank"');
+        expect(html).toContain('rel="noopener noreferrer"');
+    });
+
+    it('renders a span fallback when a button URL is unsafe', () => {
+        const tree = [
+            makeBlock('core/button', { text: 'Click', url: 'javascript:alert(1)' }),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).not.toContain('javascript:');
+        expect(html).not.toContain('<a ');
+        expect(html).toContain('<span class="wp-block-button__link');
+    });
+
+    it('renders buttons wrapper with justify class', () => {
+        const tree = [
+            makeBlock(
+                'core/buttons',
+                { layout: { justifyContent: 'center' } },
+                [
+                    makeBlock(
+                        'core/button',
+                        { text: 'Go', url: 'https://example.com' },
+                        [],
+                        'b1'
+                    ),
+                ]
+            ),
+        ];
+
+        expect(renderTree(tree)).toContain('is-content-justification-center');
+    });
+});
+
+describe('Core design blocks', () => {
+    it('renders a separator block with style class', () => {
+        const tree = [makeBlock('core/separator', { style: 'wide' })];
+
+        expect(renderTree(tree)).toBe('<hr class="wp-block-separator has-alpha-channel-opacity is-style-wide">');
+    });
+
+    it('renders a spacer with numeric height as px', () => {
+        const tree = [makeBlock('core/spacer', { height: 48 })];
+
+        expect(renderTree(tree)).toContain('height: 48px');
+    });
+
+    it('drops unsafe cover background URLs', () => {
+        const tree = [
+            makeBlock('core/cover', {
+                url: 'javascript:alert(1)',
+            }),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).not.toContain('javascript:');
+        expect(html).not.toContain('<img');
+    });
+
+    it('clamps cover dimRatio and whitelists minHeightUnit', () => {
+        const tree = [
+            makeBlock('core/cover', {
+                dimRatio: 250,
+                minHeight: 40,
+                minHeightUnit: 'javascript:alert(1)',
+            }),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('opacity: 1');
+        expect(html).toContain('min-height: 40px');
+        expect(html).not.toContain('javascript:');
+    });
+
+    it('validates table cell alignment against an allowlist', () => {
+        const tree = [
+            makeBlock('core/table', {
+                body: [
+                    {
+                        cells: [
+                            { content: 'A', tag: 'td', align: 'center' },
+                            { content: 'B', tag: 'td', align: 'expression(alert(1))' },
+                        ],
+                    },
+                ],
+            }),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('text-align: center');
+        expect(html).not.toContain('expression');
+    });
+
+    it('renders media-text with right-side grid template', () => {
+        const tree = [
+            makeBlock('core/media-text', {
+                mediaUrl: 'https://example.test/photo.jpg',
+                mediaPosition: 'right',
+                mediaWidth: 30,
+            }),
+        ];
+
+        expect(renderTree(tree)).toContain('grid-template-columns: auto 30%');
+    });
+
+    it('drops unsafe media-text mediaUrl schemes', () => {
+        const tree = [
+            makeBlock('core/media-text', {
+                mediaUrl: 'javascript:alert(1)',
+                mediaType: 'image',
+                mediaAlt: 'x',
+            }),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).not.toContain('javascript:');
+        expect(html).not.toContain('<img');
+    });
+
+    it('renders a details block with showContent=true open', () => {
+        const tree = [
+            makeBlock('core/details', { summary: 'Click me', showContent: true }, [
+                makeBlock('core/paragraph', { content: 'Hidden' }, [], 'p1'),
+            ]),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toMatch(/<details class="wp-block-details" open(="")?>/);
+        expect(html).toContain('<summary>Click me</summary>');
+        expect(html).toContain('Hidden');
+    });
+
+    it('generates stable unique ids for multiple search blocks on the same page', () => {
+        const tree = [
+            makeBlock('core/search', { label: 'First', buttonText: 'Go' }, [], 's-1'),
+            makeBlock('core/search', { label: 'Second', buttonText: 'Find' }, [], 's-2'),
+        ];
+
+        const html = renderTree(tree);
+        const ids = Array.from(html.matchAll(/id="(wp-block-search-input-[a-f0-9]+)"/g)).map((m) => m[1]);
+
+        expect(ids).toHaveLength(2);
+        expect(ids[0]).not.toBe(ids[1]);
+    });
+
+    it('uses an empty button label when buttonUseIcon is true', () => {
+        const tree = [makeBlock('core/search', { buttonText: 'Go', buttonUseIcon: true })];
+
+        expect(renderTree(tree)).toContain('<button type="submit" class="wp-block-search__button"></button>');
+    });
+});
+
+describe('Registry + dynamic fallback', () => {
+    it('invokes a custom registered renderer instead of the default', () => {
+        registerBlockRenderer('acme/sticker', ({ attributes }) => (
+            <span data-sticker="yes">{(attributes.label as string) ?? ''}</span>
+        ));
+
+        const tree = [makeBlock('acme/sticker', { label: 'Ship it' })];
+
+        expect(renderTree(tree)).toBe('<span data-sticker="yes">Ship it</span>');
+
+        unregisterBlockRenderer('acme/sticker');
+    });
+
+    it('falls back to DynamicBlock when no renderer is registered', async () => {
+        const fetchFn = vi.fn().mockRejectedValue(new TypeError('offline'));
+        vi.stubGlobal('fetch', fetchFn);
+
+        try {
+            const tree = [makeBlock('acme/unregistered', { label: 'test' })];
+            const { container } = render(<BlockTree tree={tree} />);
+
+            expect(container.innerHTML).toContain('data-ve-dynamic-block="acme/unregistered"');
+
+            await waitFor(() => {
+                expect(container.innerHTML).toContain('data-ve-unknown-block="acme/unregistered"');
+            });
+        } finally {
+            vi.unstubAllGlobals();
+        }
+    });
+});

--- a/packages/visual-editor-renderer-react/tests/BlockTree.test.tsx
+++ b/packages/visual-editor-renderer-react/tests/BlockTree.test.tsx
@@ -59,6 +59,25 @@ describe('BlockTree normalization', () => {
 
         expect(renderTree(tree)).toBe('');
     });
+
+    it('filters non-block entries out of innerBlocks before recursion', () => {
+        const tree = [
+            makeBlock(
+                'core/group',
+                {},
+                [
+                    makeBlock('core/paragraph', { content: 'Real' }, [], 'p-1'),
+                    'not-a-block' as unknown as never,
+                    null as unknown as never,
+                    { clientId: 'x', name: '', attributes: {}, innerBlocks: [] },
+                ]
+            ),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('<p class="wp-block-paragraph">Real</p>');
+    });
 });
 
 describe('Core text blocks', () => {
@@ -505,14 +524,28 @@ describe('Core design blocks', () => {
         expect(html).toContain('Hidden');
     });
 
-    it('generates stable unique ids for multiple search blocks on the same page', () => {
+    it('generates unique ids for multiple search blocks on the same page', () => {
         const tree = [
             makeBlock('core/search', { label: 'First', buttonText: 'Go' }, [], 's-1'),
             makeBlock('core/search', { label: 'Second', buttonText: 'Find' }, [], 's-2'),
         ];
 
         const html = renderTree(tree);
-        const ids = Array.from(html.matchAll(/id="(wp-block-search-input-[a-f0-9]+)"/g)).map((m) => m[1]);
+        const ids = Array.from(html.matchAll(/id="(wp-block-search-input-[\w-]+)"/g)).map((m) => m[1]);
+
+        expect(ids).toHaveLength(2);
+        expect(ids[0]).not.toBe(ids[1]);
+    });
+
+    it('gives two search blocks with identical attributes different ids', () => {
+        const identicalAttrs = { label: 'Same', buttonText: 'Go' };
+        const tree = [
+            makeBlock('core/search', identicalAttrs, [], 'a'),
+            makeBlock('core/search', identicalAttrs, [], 'b'),
+        ];
+
+        const html = renderTree(tree);
+        const ids = Array.from(html.matchAll(/id="(wp-block-search-input-[\w-]+)"/g)).map((m) => m[1]);
 
         expect(ids).toHaveLength(2);
         expect(ids[0]).not.toBe(ids[1]);

--- a/packages/visual-editor-renderer-react/tests/DynamicBlock.test.tsx
+++ b/packages/visual-editor-renderer-react/tests/DynamicBlock.test.tsx
@@ -1,0 +1,74 @@
+import { render, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { DynamicBlock } from '../src/DynamicBlock';
+
+function jsonResponse(body: unknown, status = 200): Response {
+    return new Response(JSON.stringify(body), {
+        status,
+        headers: { 'Content-Type': 'application/json' },
+    });
+}
+
+describe('DynamicBlock', () => {
+    it('renders HTML returned by the preview endpoint', async () => {
+        const fetchFn = vi
+            .fn()
+            .mockResolvedValue(jsonResponse({ name: 'acme/live', html: '<aside>Live!</aside>' }));
+
+        const { container } = render(
+            <DynamicBlock
+                name="acme/live"
+                attributes={{ title: 'Hi' }}
+                endpoint="/visual-editor/api/blocks/preview"
+                fetchFn={fetchFn as unknown as typeof fetch}
+            />
+        );
+
+        await waitFor(() => {
+            expect(container.innerHTML).toContain('<aside>Live!</aside>');
+        });
+
+        expect(fetchFn).toHaveBeenCalledOnce();
+        const [url, init] = fetchFn.mock.calls[0];
+        expect(url).toBe('/visual-editor/api/blocks/preview');
+        expect(init?.method).toBe('POST');
+        expect(init?.body).toBe(JSON.stringify({ name: 'acme/live', attributes: { title: 'Hi' } }));
+    });
+
+    it('renders the unknown-block marker when the endpoint 404s', async () => {
+        const fetchFn = vi
+            .fn()
+            .mockResolvedValue(jsonResponse({ error: 'block_not_registered' }, 404));
+
+        const { container } = render(
+            <DynamicBlock
+                name="acme/missing"
+                attributes={{}}
+                endpoint="/visual-editor/api/blocks/preview"
+                fetchFn={fetchFn as unknown as typeof fetch}
+            />
+        );
+
+        await waitFor(() => {
+            expect(container.innerHTML).toContain('data-ve-unknown-block="acme/missing"');
+        });
+    });
+
+    it('renders the unknown-block marker when the fetch rejects', async () => {
+        const fetchFn = vi.fn().mockRejectedValue(new TypeError('network error'));
+
+        const { container } = render(
+            <DynamicBlock
+                name="acme/broken"
+                attributes={{}}
+                endpoint="/visual-editor/api/blocks/preview"
+                fetchFn={fetchFn as unknown as typeof fetch}
+            />
+        );
+
+        await waitFor(() => {
+            expect(container.innerHTML).toContain('data-ve-unknown-block="acme/broken"');
+        });
+    });
+});

--- a/packages/visual-editor-renderer-react/tests/helpers.ts
+++ b/packages/visual-editor-renderer-react/tests/helpers.ts
@@ -1,0 +1,19 @@
+import type { Block } from '../src/types';
+
+export function makeBlock(
+    name: string,
+    attributes: Record<string, unknown> = {},
+    innerBlocks: Block[] = [],
+    clientId?: string
+): Block {
+    return {
+        clientId: clientId ?? `cid-${Math.random().toString(36).slice(2, 10)}`,
+        name,
+        attributes,
+        innerBlocks,
+    };
+}
+
+export function normalizeHtml(html: string): string {
+    return html.replace(/>\s+</g, '><').replace(/\s+/g, ' ').trim();
+}

--- a/packages/visual-editor-renderer-react/tests/registry.test.ts
+++ b/packages/visual-editor-renderer-react/tests/registry.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+    getBlockRenderer,
+    getRegisteredBlockNames,
+    hasBlockRenderer,
+    registerBlockRenderer,
+    resetBlockRegistry,
+    unregisterBlockRenderer,
+} from '../src/registry';
+import { registerCoreBlocks } from '../src/blocks/registerCoreBlocks';
+
+afterEach(() => {
+    resetBlockRegistry();
+    registerCoreBlocks();
+});
+
+describe('registerBlockRenderer', () => {
+    it('rejects empty block names', () => {
+        expect(() => registerBlockRenderer('   ', () => null)).toThrow(/name cannot be empty/);
+    });
+
+    it('trims whitespace in block names', () => {
+        const renderer = () => null;
+
+        registerBlockRenderer('  acme/trimmed  ', renderer);
+
+        expect(getBlockRenderer('acme/trimmed')).toBe(renderer);
+        expect(hasBlockRenderer('acme/trimmed')).toBe(true);
+    });
+
+    it('overrides an existing renderer registration', () => {
+        const first = () => null;
+        const second = () => null;
+
+        registerBlockRenderer('acme/replace', first);
+        registerBlockRenderer('acme/replace', second);
+
+        expect(getBlockRenderer('acme/replace')).toBe(second);
+    });
+
+    it('includes every core block after registerCoreBlocks', () => {
+        const names = getRegisteredBlockNames();
+
+        expect(names).toContain('core/paragraph');
+        expect(names).toContain('core/heading');
+        expect(names).toContain('core/image');
+        expect(names).toContain('core/button');
+        expect(names).toContain('core/cover');
+        expect(names).toContain('core/separator');
+    });
+
+    it('allows unregistering a renderer', () => {
+        registerBlockRenderer('acme/temp', () => null);
+        expect(hasBlockRenderer('acme/temp')).toBe(true);
+
+        unregisterBlockRenderer('acme/temp');
+        expect(hasBlockRenderer('acme/temp')).toBe(false);
+    });
+});

--- a/packages/visual-editor-renderer-react/tests/urlSanitizer.test.ts
+++ b/packages/visual-editor-renderer-react/tests/urlSanitizer.test.ts
@@ -25,6 +25,8 @@ describe('safeUrl', () => {
         expect(safeUrl('http://example.test')).toBe('http://example.test');
         expect(safeUrl('mailto:me@example.test')).toBe('mailto:me@example.test');
         expect(safeUrl('tel:+15555551212')).toBe('tel:+15555551212');
+        expect(safeUrl('ftp://example.test/file.zip')).toBe('ftp://example.test/file.zip');
+        expect(safeUrl('sms:+15555551212')).toBe('sms:+15555551212');
     });
 
     it('drops javascript, data, and vbscript schemes', () => {

--- a/packages/visual-editor-renderer-react/tests/urlSanitizer.test.ts
+++ b/packages/visual-editor-renderer-react/tests/urlSanitizer.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { safeUrl } from '../src/support/urlSanitizer';
+
+describe('safeUrl', () => {
+    it('returns an empty string for non-string input', () => {
+        expect(safeUrl(42)).toBe('');
+        expect(safeUrl(null)).toBe('');
+        expect(safeUrl(undefined)).toBe('');
+        expect(safeUrl({})).toBe('');
+    });
+
+    it('returns an empty string for blank input', () => {
+        expect(safeUrl('')).toBe('');
+        expect(safeUrl('   ')).toBe('');
+    });
+
+    it('passes relative URLs through unchanged', () => {
+        expect(safeUrl('/page')).toBe('/page');
+        expect(safeUrl('foo/bar')).toBe('foo/bar');
+        expect(safeUrl('#anchor')).toBe('#anchor');
+    });
+
+    it('allows http, https, mailto, tel, ftp, and sms schemes', () => {
+        expect(safeUrl('https://example.test')).toBe('https://example.test');
+        expect(safeUrl('http://example.test')).toBe('http://example.test');
+        expect(safeUrl('mailto:me@example.test')).toBe('mailto:me@example.test');
+        expect(safeUrl('tel:+15555551212')).toBe('tel:+15555551212');
+    });
+
+    it('drops javascript, data, and vbscript schemes', () => {
+        expect(safeUrl('javascript:alert(1)')).toBe('');
+        expect(safeUrl('JAVASCRIPT:alert(1)')).toBe('');
+        expect(safeUrl('data:text/html,abc')).toBe('');
+        expect(safeUrl('vbscript:msgbox')).toBe('');
+    });
+});

--- a/packages/visual-editor-renderer-react/tsconfig.json
+++ b/packages/visual-editor-renderer-react/tsconfig.json
@@ -1,0 +1,15 @@
+{
+    "extends": "../../tsconfig.json",
+    "compilerOptions": {
+        "baseUrl": ".",
+        "paths": {}
+    },
+    "include": [
+        "src/**/*",
+        "tests/**/*"
+    ],
+    "exclude": [
+        "node_modules",
+        "dist"
+    ]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -25,6 +25,7 @@ export default defineConfig({
         setupFiles: ['./resources/js/visual-editor/_legacy/editor/test-setup.ts'],
         include: [
             'resources/js/visual-editor/**/*.{test,spec}.{ts,tsx}',
+            'packages/**/tests/**/*.{test,spec}.{ts,tsx}',
         ],
     },
 });


### PR DESCRIPTION
## Description

Ships the `@artisanpack-ui/visual-editor-renderer-react` npm package: a React
component that takes a block tree the visual editor persists and renders it
to React elements. Designed for Inertia+React apps. Markup mirrors the M9
Blade renderer one-to-one — same classes, attribute allow-lists, and URL
sanitization — so server- and client-rendered pages stay interchangeable.

**Closes:** #320

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #320

## Motivation and Context

Required for users running Inertia+React. Lives in its own npm package so
apps that don't need React on the frontend don't ship it. Shares the
registry + attribute-adapter pattern with the upcoming Vue renderer (M11).

## Changes Made

- **New sub-package** at `packages/visual-editor-renderer-react/`, distributed
  to npm via the same subtree-split workflow as the Blade renderer.
- `<BlockTree tree={...} />` walks the persisted tree and mounts each block
  through an overridable React-component registry.
- 29 core block renderers across text / media / layout / design families —
  exactly the V1 allow-list from the M5 audit.
- `registerBlockRenderer(name, component)` lets hosts add custom blocks or
  override core ones. `unregister`, `reset`, `has`, `get` round out the API.
- `<DynamicBlock>` fetches `/visual-editor/api/blocks/preview` on mount for
  any block without a client-side renderer, falls back to the unknown-block
  marker on error. Endpoint + fetch options are prop-configurable.
- URL sanitizer + attribute coercion helpers ported from the PHP side —
  `javascript:`, `data:`, `vbscript:` dropped on every URL-shaped attribute
  (image `src`/`href`, button `url`, video `src`/`poster`, audio `src`,
  file `href`/`textLinkHref`, media-text `mediaUrl`, cover `url`).
- `vitest.config.ts` picks up package tests alongside the legacy suite.
- `PACKAGING.md` registers the new sub-package in the subtree-split table.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS
- Browser: Safari 26.3.1
- PHP Version: 8.4.3
- Project Version: 1.0.0-spike

**Tests Performed:**
1. `npm test` — 350 vitest tests passing, 1 skipped.
2. `./vendor/bin/pest` — 136 PHP tests passing (unchanged).
3. Manually verified the demo route at
   `/packages/visual-editor/m10/post/{id}` in the dev app: Inertia+React
   page renders the saved post's 4 paragraphs + 1 image through `<BlockTree>`.

## Tests Added

- [x] Unit tests added/updated
- [x] All tests passing

**Test details:**

54 new vitest tests under `packages/visual-editor-renderer-react/tests/`:

- `BlockTree.test.tsx` — every core block rendered from fixtures, normalization
  of null/undefined/JSON-string/array trees, custom renderer override, dynamic
  fallback, URL sanitization on image / button / cover / media-text, allow-lists
  for cover dim ratio / table cell align.
- `DynamicBlock.test.tsx` — fetch HTML from the preview endpoint, 404 and
  rejected fetch both fall back to the unknown-block marker.
- `registry.test.ts` — registration, override, unregister, reset, empty-name
  rejection, core block coverage.
- `urlSanitizer.test.ts` — safe schemes pass through, unsafe schemes get dropped.

## Documentation

- [x] Inline code documentation added
- [x] README updated

**Documentation details:**

- Every module gets a short purpose docblock.
- `packages/visual-editor-renderer-react/README.md` covers install, props,
  custom renderer API, dynamic-block fetch, and the core-block allow-list.
- `PACKAGING.md` sub-package table updated with the new npm package.

## Pre-Submission Checklist

- [x] Code passes all tests
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New React package @artisanpack-ui/visual-editor-renderer-react: renders saved block trees, registers core block renderers, supports dynamic server-rendered previews, and exposes a registry API for custom renderers.

* **Documentation**
  * Comprehensive README added with installation, API, props, and usage guidance.

* **Tests**
  * Extensive test suites covering rendering, dynamic previews, registry behavior, and URL sanitization.

* **Chores**
  * Packaging metadata and test discovery config updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->