### PR TITLE
feat: M11 · Vue renderer package

### DIFF
--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -12,9 +12,7 @@ sub-packages are meant to reach Packagist, because Packagist watches one
 | `./`                                    | `artisanpack-ui/visual-editor`                            | Packagist | published   |
 | `packages/visual-editor-renderer-blade` | `artisanpack-ui/visual-editor-renderer-blade`             | Packagist | unpublished |
 | `packages/visual-editor-renderer-react` | `@artisanpack-ui/visual-editor-renderer-react`            | npm       | unpublished |
-
-M11 (Vue renderer) will add one more sub-package under the same `packages/`
-directory.
+| `packages/visual-editor-renderer-vue`   | `@artisanpack-ui/visual-editor-renderer-vue`              | npm       | unpublished |
 
 ## Distribution strategy: subtree splits
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,12 +45,14 @@
                 "@types/react": "18.3.28",
                 "@types/react-dom": "18.3.7",
                 "@vitejs/plugin-react": "^4.3.1",
+                "@vue/test-utils": "^2.4.6",
                 "daisyui": "^5.0.48",
                 "jsdom": "^25.0.0",
                 "tailwindcss": "^4.1.11",
                 "typescript": "^5.5.0",
                 "vite": "^5.4.0",
-                "vitest": "^2.0.0"
+                "vitest": "^2.0.0",
+                "vue": "^3.5.0"
             },
             "peerDependencies": {
                 "daisyui": "^5.0.0",
@@ -1306,6 +1308,109 @@
                 "react": "^18.0.0 || ^19.0.0"
             }
         },
+        "node_modules/@isaacs/cliui": {
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+            "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "string-width": "^5.1.2",
+                "string-width-cjs": "npm:string-width@^4.2.0",
+                "strip-ansi": "^7.0.1",
+                "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+                "wrap-ansi": "^8.1.0",
+                "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+            "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+            }
+        },
+        "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+            "version": "6.2.3",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+            "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+            "version": "9.2.2",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+            "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@isaacs/cliui/node_modules/string-width": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+            "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "eastasianwidth": "^0.2.0",
+                "emoji-regex": "^9.2.2",
+                "strip-ansi": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+            "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^6.2.2"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+            }
+        },
+        "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+            "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^6.1.0",
+                "string-width": "^5.0.1",
+                "strip-ansi": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
         "node_modules/@jridgewell/gen-mapping": {
             "version": "0.3.13",
             "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1350,6 +1455,24 @@
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.1.0",
                 "@jridgewell/sourcemap-codec": "^1.4.14"
+            }
+        },
+        "node_modules/@one-ini/wasm": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/@one-ini/wasm/-/wasm-0.1.1.tgz",
+            "integrity": "sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@pkgjs/parseargs": {
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+            "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": ">=14"
             }
         },
         "node_modules/@preact/signals": {
@@ -3131,6 +3254,153 @@
                 "url": "https://opencollective.com/vitest"
             }
         },
+        "node_modules/@vue/compiler-core": {
+            "version": "3.5.32",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.32.tgz",
+            "integrity": "sha512-4x74Tbtqnda8s/NSD6e1Dr5p1c8HdMU5RWSjMSUzb8RTcUQqevDCxVAitcLBKT+ie3o0Dl9crc/S/opJM7qBGQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/parser": "^7.29.2",
+                "@vue/shared": "3.5.32",
+                "entities": "^7.0.1",
+                "estree-walker": "^2.0.2",
+                "source-map-js": "^1.2.1"
+            }
+        },
+        "node_modules/@vue/compiler-core/node_modules/entities": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+            "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
+        "node_modules/@vue/compiler-core/node_modules/estree-walker": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@vue/compiler-dom": {
+            "version": "3.5.32",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.32.tgz",
+            "integrity": "sha512-ybHAu70NtiEI1fvAUz3oXZqkUYEe5J98GjMDpTGl5iHb0T15wQYLR4wE3h9xfuTNA+Cm2f4czfe8B4s+CCH57Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vue/compiler-core": "3.5.32",
+                "@vue/shared": "3.5.32"
+            }
+        },
+        "node_modules/@vue/compiler-sfc": {
+            "version": "3.5.32",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.32.tgz",
+            "integrity": "sha512-8UYUYo71cP/0YHMO814TRZlPuUUw3oifHuMR7Wp9SNoRSrxRQnhMLNlCeaODNn6kNTJsjFoQ/kqIj4qGvya4Xg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/parser": "^7.29.2",
+                "@vue/compiler-core": "3.5.32",
+                "@vue/compiler-dom": "3.5.32",
+                "@vue/compiler-ssr": "3.5.32",
+                "@vue/shared": "3.5.32",
+                "estree-walker": "^2.0.2",
+                "magic-string": "^0.30.21",
+                "postcss": "^8.5.8",
+                "source-map-js": "^1.2.1"
+            }
+        },
+        "node_modules/@vue/compiler-sfc/node_modules/estree-walker": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@vue/compiler-ssr": {
+            "version": "3.5.32",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.32.tgz",
+            "integrity": "sha512-Gp4gTs22T3DgRotZ8aA/6m2jMR+GMztvBXUBEUOYOcST+giyGWJ4WvFd7QLHBkzTxkfOt8IELKNdpzITLbA2rw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vue/compiler-dom": "3.5.32",
+                "@vue/shared": "3.5.32"
+            }
+        },
+        "node_modules/@vue/reactivity": {
+            "version": "3.5.32",
+            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.32.tgz",
+            "integrity": "sha512-/ORasxSGvZ6MN5gc+uE364SxFdJ0+WqVG0CENXaGW58TOCdrAW76WWaplDtECeS1qphvtBZtR+3/o1g1zL4xPQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vue/shared": "3.5.32"
+            }
+        },
+        "node_modules/@vue/runtime-core": {
+            "version": "3.5.32",
+            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.32.tgz",
+            "integrity": "sha512-pDrXCejn4UpFDFmMd27AcJEbHaLemaE5o4pbb7sLk79SRIhc6/t34BQA7SGNgYtbMnvbF/HHOftYBgFJtUoJUQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vue/reactivity": "3.5.32",
+                "@vue/shared": "3.5.32"
+            }
+        },
+        "node_modules/@vue/runtime-dom": {
+            "version": "3.5.32",
+            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.32.tgz",
+            "integrity": "sha512-1CDVv7tv/IV13V8Nip1k/aaObVbWqRlVCVezTwx3K07p7Vxossp5JU1dcPNhJk3w347gonIUT9jQOGutyJrSVQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vue/reactivity": "3.5.32",
+                "@vue/runtime-core": "3.5.32",
+                "@vue/shared": "3.5.32",
+                "csstype": "^3.2.3"
+            }
+        },
+        "node_modules/@vue/server-renderer": {
+            "version": "3.5.32",
+            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.32.tgz",
+            "integrity": "sha512-IOjm2+JQwRFS7W28HNuJeXQle9KdZbODFY7hFGVtnnghF51ta20EWAZJHX+zLGtsHhaU6uC9BGPV52KVpYryMQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vue/compiler-ssr": "3.5.32",
+                "@vue/shared": "3.5.32"
+            },
+            "peerDependencies": {
+                "vue": "3.5.32"
+            }
+        },
+        "node_modules/@vue/shared": {
+            "version": "3.5.32",
+            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.32.tgz",
+            "integrity": "sha512-ksNyrmRQzWJJ8n3cRDuSF7zNNontuJg1YHnmWRJd2AMu8Ij2bqwiiri2lH5rHtYPZjj4STkNcgcmiQqlOjiYGg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@vue/test-utils": {
+            "version": "2.4.6",
+            "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-2.4.6.tgz",
+            "integrity": "sha512-FMxEjOpYNYiFe0GkaHsnJPXFHxQ6m4t8vI/ElPGpMWxZKpmRvQ33OIrvRXemy6yha03RxhOlQuy+gZMC3CQSow==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "js-beautify": "^1.14.9",
+                "vue-component-type-helpers": "^2.0.0"
+            }
+        },
         "node_modules/@wordpress/a11y": {
             "version": "4.44.0",
             "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.44.0.tgz",
@@ -4379,6 +4649,16 @@
                 "npm": ">=8.19.2"
             }
         },
+        "node_modules/abbrev": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
+            "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
         "node_modules/agent-base": {
             "version": "7.1.4",
             "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -4478,6 +4758,13 @@
                 "npm": ">=6"
             }
         },
+        "node_modules/balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/baseline-browser-mapping": {
             "version": "2.10.18",
             "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.18.tgz",
@@ -4489,6 +4776,16 @@
             },
             "engines": {
                 "node": ">=6.0.0"
+            }
+        },
+        "node_modules/brace-expansion": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+            "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
             }
         },
         "node_modules/browserslist": {
@@ -4744,10 +5041,31 @@
             "integrity": "sha512-ZMRGAYASYRdVfEoB7oxH8Nqu5Ay8I+YvAsQni+td0pYV9eww/PrtSFVyvc2JkNQyHXGDknCB4wJfxFYP6fuqZg==",
             "license": "MIT"
         },
+        "node_modules/commander": {
+            "version": "10.0.1",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+            "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14"
+            }
+        },
         "node_modules/computed-style": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/computed-style/-/computed-style-0.1.4.tgz",
             "integrity": "sha512-WpAmaKbMNmS3OProfHIdJiNleNJdgUrJfbKArXua28QF7+0CoZjlLn0lp6vlc+dl5r2/X9GQiQRQQU4BzSa69w=="
+        },
+        "node_modules/config-chain": {
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+            "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ini": "^1.3.4",
+                "proto-list": "~1.2.1"
+            }
         },
         "node_modules/constant-case": {
             "version": "3.0.4",
@@ -4788,6 +5106,21 @@
             "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
             "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
             "license": "MIT"
+        },
+        "node_modules/cross-spawn": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "path-key": "^3.1.0",
+                "shebang-command": "^2.0.0",
+                "which": "^2.0.1"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
         },
         "node_modules/css.escape": {
             "version": "1.5.1",
@@ -5048,6 +5381,45 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/eastasianwidth": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+            "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/editorconfig": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-1.0.7.tgz",
+            "integrity": "sha512-e0GOtq/aTQhVdNyDU9e02+wz9oDDM+SIOQxWME2QRjzRX5yyLAuHDE+0aE8vHb9XRC8XD37eO2u57+F09JqFhw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@one-ini/wasm": "0.1.1",
+                "commander": "^10.0.0",
+                "minimatch": "^9.0.1",
+                "semver": "^7.5.3"
+            },
+            "bin": {
+                "editorconfig": "bin/editorconfig"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/editorconfig/node_modules/semver": {
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+            "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/electron-to-chromium": {
             "version": "1.5.335",
             "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.335.tgz",
@@ -5274,6 +5646,23 @@
                 "node": ">=6"
             }
         },
+        "node_modules/foreground-child": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+            "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "cross-spawn": "^7.0.6",
+                "signal-exit": "^4.0.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
         "node_modules/form-data": {
             "version": "4.0.5",
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
@@ -5417,6 +5806,28 @@
             "dependencies": {
                 "encoding": "^0.1.12",
                 "safe-buffer": "^5.1.1"
+            }
+        },
+        "node_modules/glob": {
+            "version": "10.5.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+            "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "foreground-child": "^3.1.0",
+                "jackspeak": "^3.1.2",
+                "minimatch": "^9.0.4",
+                "minipass": "^7.1.2",
+                "package-json-from-dist": "^1.0.0",
+                "path-scurry": "^1.11.1"
+            },
+            "bin": {
+                "glob": "dist/esm/bin.mjs"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/gopd": {
@@ -5647,6 +6058,13 @@
                 "node": ">=8"
             }
         },
+        "node_modules/ini": {
+            "version": "1.3.8",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+            "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+            "dev": true,
+            "license": "ISC"
+        },
         "node_modules/inline-style-parser": {
             "version": "0.2.7",
             "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
@@ -5705,6 +6123,13 @@
             "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
             "license": "MIT"
         },
+        "node_modules/isexe": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+            "dev": true,
+            "license": "ISC"
+        },
         "node_modules/isomorphic.js": {
             "version": "0.2.5",
             "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
@@ -5713,6 +6138,54 @@
             "funding": {
                 "type": "GitHub Sponsors ❤",
                 "url": "https://github.com/sponsors/dmonad"
+            }
+        },
+        "node_modules/jackspeak": {
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+            "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "@isaacs/cliui": "^8.0.2"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            },
+            "optionalDependencies": {
+                "@pkgjs/parseargs": "^0.11.0"
+            }
+        },
+        "node_modules/js-beautify": {
+            "version": "1.15.4",
+            "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.15.4.tgz",
+            "integrity": "sha512-9/KXeZUKKJwqCXUdBxFJ3vPh467OCckSBmYDwSK/EtV090K+iMJ7zx2S3HLVDIWFQdqMIsZWbnaGiba18aWhaA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "config-chain": "^1.1.13",
+                "editorconfig": "^1.0.4",
+                "glob": "^10.4.2",
+                "js-cookie": "^3.0.5",
+                "nopt": "^7.2.1"
+            },
+            "bin": {
+                "css-beautify": "js/bin/css-beautify.js",
+                "html-beautify": "js/bin/html-beautify.js",
+                "js-beautify": "js/bin/js-beautify.js"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/js-cookie": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+            "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14"
             }
         },
         "node_modules/js-tokens": {
@@ -6003,6 +6476,32 @@
                 "node": ">=4"
             }
         },
+        "node_modules/minimatch": {
+            "version": "9.0.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.2"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/minipass": {
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+            "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            }
+        },
         "node_modules/moment": {
             "version": "2.30.1",
             "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
@@ -6086,6 +6585,22 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/nopt": {
+            "version": "7.2.1",
+            "resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.1.tgz",
+            "integrity": "sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "abbrev": "^2.0.0"
+            },
+            "bin": {
+                "nopt": "bin/nopt.js"
+            },
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
         "node_modules/normalize-wheel": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/normalize-wheel/-/normalize-wheel-1.0.1.tgz",
@@ -6149,6 +6664,13 @@
             "engines": {
                 "node": ">=6"
             }
+        },
+        "node_modules/package-json-from-dist": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+            "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+            "dev": true,
+            "license": "BlueOak-1.0.0"
         },
         "node_modules/param-case": {
             "version": "3.0.4",
@@ -6248,11 +6770,45 @@
                 "node": ">=4"
             }
         },
+        "node_modules/path-key": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+            "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/path-parse": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
             "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
             "license": "MIT"
+        },
+        "node_modules/path-scurry": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+            "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "lru-cache": "^10.2.0",
+                "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/path-scurry/node_modules/lru-cache": {
+            "version": "10.4.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/path-to-regexp": {
             "version": "6.3.0",
@@ -6588,6 +7144,13 @@
                 "prosemirror-state": "^1.0.0",
                 "prosemirror-transform": "^1.1.0"
             }
+        },
+        "node_modules/proto-list": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+            "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/punycode": {
             "version": "2.3.1",
@@ -7037,6 +7600,29 @@
             "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
             "license": "ISC"
         },
+        "node_modules/shebang-command": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+            "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "shebang-regex": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/shebang-regex": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+            "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/showdown": {
             "version": "1.9.1",
             "resolved": "https://registry.npmjs.org/showdown/-/showdown-1.9.1.tgz",
@@ -7055,6 +7641,19 @@
             "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
             "dev": true,
             "license": "ISC"
+        },
+        "node_modules/signal-exit": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+            "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
         },
         "node_modules/simple-html-tokenizer": {
             "version": "0.5.11",
@@ -7118,6 +7717,52 @@
                 "node": ">=6"
             }
         },
+        "node_modules/string-width-cjs": {
+            "name": "string-width",
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/string-width-cjs/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/string-width-cjs/node_modules/is-fullwidth-code-point": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/string-width-cjs/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/strip-ansi": {
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
@@ -7128,6 +7773,20 @@
             },
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/strip-ansi-cjs": {
+            "name": "strip-ansi",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/strip-ansi/node_modules/ansi-regex": {
@@ -7340,6 +7999,7 @@
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -7627,6 +8287,36 @@
                 }
             }
         },
+        "node_modules/vue": {
+            "version": "3.5.32",
+            "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.32.tgz",
+            "integrity": "sha512-vM4z4Q9tTafVfMAK7IVzmxg34rSzTFMyIe0UUEijUCkn9+23lj0WRfA83dg7eQZIUlgOSGrkViIaCfqSAUXsMw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@vue/compiler-dom": "3.5.32",
+                "@vue/compiler-sfc": "3.5.32",
+                "@vue/runtime-dom": "3.5.32",
+                "@vue/server-renderer": "3.5.32",
+                "@vue/shared": "3.5.32"
+            },
+            "peerDependencies": {
+                "typescript": "*"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/vue-component-type-helpers": {
+            "version": "2.2.12",
+            "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-2.2.12.tgz",
+            "integrity": "sha512-YbGqHZ5/eW4SnkPNR44mKVc6ZKQoRs/Rux1sxC6rdwXb4qpbOSYfDr9DsTHolOTGmIKgM9j141mZbBeg05R1pw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/w3c-keyname": {
             "version": "2.2.8",
             "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
@@ -7703,6 +8393,22 @@
                 "node": ">=18"
             }
         },
+        "node_modules/which": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "isexe": "^2.0.0"
+            },
+            "bin": {
+                "node-which": "bin/node-which"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
         "node_modules/which-module": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
@@ -7738,6 +8444,106 @@
             },
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/wrap-ansi-cjs": {
+            "name": "wrap-ansi",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/wrap-ansi-cjs/node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/wrap-ansi-cjs/node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/wrap-ansi-cjs/node_modules/is-fullwidth-code-point": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/wrap-ansi/node_modules/ansi-styles": {

--- a/package.json
+++ b/package.json
@@ -26,12 +26,14 @@
         "@types/react": "18.3.28",
         "@types/react-dom": "18.3.7",
         "@vitejs/plugin-react": "^4.3.1",
+        "@vue/test-utils": "^2.4.6",
         "daisyui": "^5.0.48",
         "jsdom": "^25.0.0",
         "tailwindcss": "^4.1.11",
         "typescript": "^5.5.0",
         "vite": "^5.4.0",
-        "vitest": "^2.0.0"
+        "vitest": "^2.0.0",
+        "vue": "^3.5.0"
     },
     "peerDependencies": {
         "daisyui": "^5.0.0",

--- a/packages/visual-editor-renderer-vue/README.md
+++ b/packages/visual-editor-renderer-vue/README.md
@@ -49,7 +49,7 @@ defineProps<{ post: { content: unknown } }>();
 
 | Prop | Type | Default | Notes |
 | --- | --- | --- | --- |
-| `tree` | `Block[] \| string \| null` | — | Required. |
+| `tree` | `Block[] \| string \| null` | `null` | Optional. `null`/`undefined` renders nothing. |
 | `dynamicBlockEndpoint` | `string` | `/visual-editor/api/blocks/preview` | Override if your app prefix is not `visual-editor`. |
 | `fetchOptions` | `RequestInit` | `{ credentials: 'same-origin' }` | Merged on top of the default request. Use for CSRF headers etc. |
 

--- a/packages/visual-editor-renderer-vue/README.md
+++ b/packages/visual-editor-renderer-vue/README.md
@@ -1,0 +1,142 @@
+# @artisanpack-ui/visual-editor-renderer-vue
+
+Vue renderer for the ArtisanPack UI visual editor.
+
+Takes a saved block tree (the JSON shape the editor persists to any
+`HasBlockContent` Eloquent model) and renders it to Vue VNodes using
+per-block components. Dynamic blocks — anything registered with the
+visual-editor's `DynamicBlockRegistry` — are fetched from the
+`/visual-editor/api/blocks/preview` endpoint on mount and spliced into the
+tree, with an unknown-block fallback for anything the server can't render.
+
+Built for Inertia+Vue apps. Ships zero styling — markup mirrors the server
+Blade renderer (`@artisanpack-ui/visual-editor-renderer-blade`) and the
+React renderer (`@artisanpack-ui/visual-editor-renderer-react`) so the same
+theme styles apply across all three.
+
+## Installation
+
+```sh
+npm install @artisanpack-ui/visual-editor-renderer-vue
+```
+
+Peer dependencies: Vue 3.3 or later.
+
+## Usage
+
+```vue
+<script setup lang="ts">
+import { BlockTree } from '@artisanpack-ui/visual-editor-renderer-vue';
+
+defineProps<{ post: { content: unknown } }>();
+</script>
+
+<template>
+    <article class="prose">
+        <BlockTree :tree="post.content" />
+    </article>
+</template>
+```
+
+`tree` accepts:
+
+- An array of blocks in the `{ clientId, name, attributes, innerBlocks }`
+  shape the visual editor persists.
+- A JSON-encoded string of that shape.
+- `null` / `undefined` (renders nothing).
+
+## Props
+
+| Prop | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `tree` | `Block[] \| string \| null` | — | Required. |
+| `dynamicBlockEndpoint` | `string` | `/visual-editor/api/blocks/preview` | Override if your app prefix is not `visual-editor`. |
+| `fetchOptions` | `RequestInit` | `{ credentials: 'same-origin' }` | Merged on top of the default request. Use for CSRF headers etc. |
+
+## Registering custom renderers
+
+The shared registry maps a block name to a Vue component. Register your own
+component to add support for a new block — or to override a core one:
+
+```ts
+import { defineComponent, h } from 'vue';
+import {
+    registerBlockRenderer,
+    BlockTree,
+} from '@artisanpack-ui/visual-editor-renderer-vue';
+
+const StickerBlock = defineComponent({
+    props: {
+        name: { type: String, required: true },
+        attributes: { type: Object, required: true },
+        innerBlocks: { type: Array, required: true },
+    },
+    setup(props) {
+        return () => h('div', { class: 'my-block' }, String(props.attributes.title ?? ''));
+    },
+});
+
+registerBlockRenderer('acme/my-block', StickerBlock);
+```
+
+A custom renderer receives the standard `BlockRendererProps`:
+
+```ts
+interface BlockRendererProps {
+    name: string;
+    attributes: Record<string, unknown>;
+    innerBlocks: Block[];
+}
+```
+
+Inner blocks are passed through the default slot, already rendered as Vue
+VNodes — render `<slot />` wherever inner blocks should appear so you don't
+have to walk the tree yourself.
+
+## Dynamic blocks
+
+Any block name with no registered renderer is rendered via `<DynamicBlock>`,
+which POSTs `{ name, attributes }` to the preview endpoint and splices the
+returned HTML into the page via `innerHTML`. The HTML ships pre-escaped by
+the Laravel side (the same controller the editor calls for preview), so the
+only injection surface is the dynamic block's own `render()` method.
+
+If your app uses CSRF protection, pass the token through `fetchOptions`:
+
+```vue
+<BlockTree
+    :tree="post.content"
+    :fetch-options="{ headers: { 'X-CSRF-TOKEN': csrfToken } }"
+/>
+```
+
+## Supported core blocks
+
+All blocks in the frozen V1 allow-list from the visual-editor package's M5
+audit ship with a Vue component:
+
+- Text: paragraph, heading, list, list-item, quote, code, preformatted,
+  pullquote, verse
+- Media: image, gallery, video, audio, file, embed
+- Design: cover, media-text, table, separator, spacer, details, search
+- Layout: columns, column, group, row, stack, buttons, button
+
+`core/latest-posts` and any other server-only dynamic block is intentionally
+not shipped as a client-side component — those hit the preview endpoint.
+
+## Parity with the React renderer
+
+The Vue renderer is a straight port of the React renderer's behavior and is
+tested against it: every core block has a parity test that renders the same
+fixture through both frameworks and asserts byte-identical HTML (after
+normalizing framework-level serialization differences). When behavior
+diverges, that's a bug in one of the two renderers — fix the renderer, not
+the test.
+
+## Status
+
+This package ships as part of the ArtisanPack UI visual editor V1 (epic
+`#309`, milestone M11). During the V1 cycle it lives inside the
+`visual-editor` monorepo under `packages/visual-editor-renderer-vue/` and
+is distributed to npm via a subtree split — see `PACKAGING.md` at the
+monorepo root for the release workflow.

--- a/packages/visual-editor-renderer-vue/package.json
+++ b/packages/visual-editor-renderer-vue/package.json
@@ -1,0 +1,31 @@
+{
+    "name": "@artisanpack-ui/visual-editor-renderer-vue",
+    "version": "1.0.0",
+    "description": "Vue renderer for ArtisanPack UI visual-editor block trees. Designed for Inertia+Vue apps.",
+    "license": "GPL-3.0-or-later",
+    "author": "Jacob Martella <me@jacobmartella.com>",
+    "type": "module",
+    "main": "./src/index.ts",
+    "types": "./src/index.ts",
+    "exports": {
+        ".": {
+            "types": "./src/index.ts",
+            "import": "./src/index.ts"
+        }
+    },
+    "files": [
+        "src",
+        "README.md"
+    ],
+    "keywords": [
+        "vue",
+        "inertia",
+        "visual-editor",
+        "gutenberg",
+        "renderer",
+        "blocks"
+    ],
+    "peerDependencies": {
+        "vue": "^3.3.0"
+    }
+}

--- a/packages/visual-editor-renderer-vue/src/BlockTree.ts
+++ b/packages/visual-editor-renderer-vue/src/BlockTree.ts
@@ -1,0 +1,138 @@
+/**
+ * Public Vue component for rendering a saved block tree.
+ *
+ * Walks a `{ clientId, name, attributes, innerBlocks }` block tree the visual
+ * editor persists and renders it to Vue VNodes. Each block name is looked up
+ * in the shared block registry; anything unregistered falls through to the
+ * {@link DynamicBlock} component, which fetches the server-rendered HTML from
+ * the visual-editor preview endpoint.
+ *
+ * `tree` accepts the array form the editor persists, a JSON-encoded string of
+ * that shape, or `null`/`undefined` for an empty render.
+ */
+
+import { Fragment, defineComponent, h } from 'vue';
+import type { PropType, VNode } from 'vue';
+import { DynamicBlock } from './DynamicBlock';
+import { UnknownBlock } from './blocks/unknownBlock';
+import { getBlockRenderer } from './registry';
+import type { Block } from './types';
+
+const DEFAULT_ENDPOINT = '/visual-editor/api/blocks/preview';
+
+export interface BlockTreeProps {
+    tree: Block[] | string | null | undefined;
+    dynamicBlockEndpoint?: string;
+    fetchOptions?: RequestInit;
+}
+
+export const BlockTree = defineComponent({
+    name: 'BlockTree',
+    props: {
+        tree: {
+            type: [Array, String, null] as unknown as PropType<Block[] | string | null | undefined>,
+            default: null,
+        },
+        dynamicBlockEndpoint: {
+            type: String,
+            default: DEFAULT_ENDPOINT,
+        },
+        fetchOptions: {
+            type: Object as PropType<RequestInit>,
+            default: undefined,
+        },
+    },
+    setup(props) {
+        return () => {
+            const blocks = normalizeTree(props.tree);
+            const endpoint = props.dynamicBlockEndpoint ?? DEFAULT_ENDPOINT;
+            const children = blocks
+                .map((block, index) => renderBlock(block, index, endpoint, props.fetchOptions))
+                .filter((vnode): vnode is VNode => vnode !== null);
+
+            return h(Fragment, null, children);
+        };
+    },
+});
+
+function renderBlock(
+    block: Block,
+    index: number,
+    endpoint: string,
+    fetchOptions: RequestInit | undefined
+): VNode | null {
+    const name = typeof block.name === 'string' ? block.name.trim() : '';
+
+    if (name === '') {
+        return null;
+    }
+
+    const attributes =
+        block.attributes !== null && typeof block.attributes === 'object' && !Array.isArray(block.attributes)
+            ? (block.attributes as Record<string, unknown>)
+            : {};
+
+    const innerBlocks = Array.isArray(block.innerBlocks) ? block.innerBlocks.filter(isBlock) : [];
+    const key = typeof block.clientId === 'string' && block.clientId !== '' ? block.clientId : `${name}-${index}`;
+
+    const renderedChildren = innerBlocks
+        .map((child, childIndex) => renderBlock(child, childIndex, endpoint, fetchOptions))
+        .filter((vnode): vnode is VNode => vnode !== null);
+
+    const renderer = getBlockRenderer(name);
+
+    if (renderer !== undefined) {
+        const slots =
+            renderedChildren.length === 0
+                ? undefined
+                : { default: () => renderedChildren };
+
+        return h(
+            renderer,
+            {
+                key,
+                name,
+                attributes,
+                innerBlocks,
+            },
+            slots
+        );
+    }
+
+    return h(DynamicBlock, {
+        key,
+        name,
+        attributes,
+        endpoint,
+        fetchOptions,
+    });
+}
+
+function normalizeTree(tree: Block[] | string | null | undefined): Block[] {
+    if (tree === null || tree === undefined) {
+        return [];
+    }
+
+    if (typeof tree === 'string') {
+        try {
+            const parsed = JSON.parse(tree);
+
+            return Array.isArray(parsed) ? parsed.filter(isBlock) : [];
+        } catch {
+            return [];
+        }
+    }
+
+    return Array.isArray(tree) ? tree.filter(isBlock) : [];
+}
+
+function isBlock(value: unknown): value is Block {
+    return (
+        value !== null &&
+        typeof value === 'object' &&
+        !Array.isArray(value) &&
+        typeof (value as { name?: unknown }).name === 'string'
+    );
+}
+
+export { UnknownBlock };

--- a/packages/visual-editor-renderer-vue/src/DynamicBlock.ts
+++ b/packages/visual-editor-renderer-vue/src/DynamicBlock.ts
@@ -1,0 +1,132 @@
+/**
+ * Dynamic block renderer.
+ *
+ * When a block has no client-side renderer registered, the renderer falls back
+ * to this component. On mount it POSTs `{ name, attributes }` to the
+ * visual-editor's `/visual-editor/api/blocks/preview` endpoint and mounts the
+ * HTML the server returns. If the request fails or the endpoint returns 404
+ * (no registered `DynamicBlock`), it renders the unknown-block marker so the
+ * page layout stays intact and the missing block is easy to spot.
+ *
+ * The endpoint is configurable via the `dynamicBlockEndpoint` prop on
+ * {@link BlockTree}, so hosts on a non-standard prefix can still use the
+ * renderer without patching it.
+ */
+
+import { defineComponent, h, onBeforeUnmount, onMounted, ref } from 'vue';
+import type { PropType } from 'vue';
+import { UnknownBlock } from './blocks/unknownBlock';
+
+type FetchFn = typeof fetch;
+
+type DynamicBlockStatus = 'loading' | 'ready' | 'error';
+
+export interface DynamicBlockProps {
+    name: string;
+    attributes: Record<string, unknown>;
+    endpoint: string;
+    fetchOptions?: RequestInit;
+    fetchFn?: FetchFn;
+}
+
+export const DynamicBlock = defineComponent({
+    name: 'DynamicBlock',
+    props: {
+        name: {
+            type: String,
+            required: true,
+        },
+        attributes: {
+            type: Object as PropType<Record<string, unknown>>,
+            required: true,
+        },
+        endpoint: {
+            type: String,
+            required: true,
+        },
+        fetchOptions: {
+            type: Object as PropType<RequestInit>,
+            default: undefined,
+        },
+        fetchFn: {
+            type: Function as PropType<FetchFn>,
+            default: undefined,
+        },
+    },
+    setup(props) {
+        const status = ref<DynamicBlockStatus>('loading');
+        const html = ref('');
+        const controller = new AbortController();
+
+        onMounted(() => {
+            const doFetch = props.fetchFn ?? globalThis.fetch;
+
+            if (typeof doFetch !== 'function') {
+                status.value = 'error';
+
+                return;
+            }
+
+            const headers = new Headers(props.fetchOptions?.headers);
+
+            if (!headers.has('Accept')) {
+                headers.set('Accept', 'application/json');
+            }
+
+            if (!headers.has('Content-Type')) {
+                headers.set('Content-Type', 'application/json');
+            }
+
+            const body = `{"name":${JSON.stringify(props.name)},"attributes":${JSON.stringify(props.attributes)}}`;
+
+            doFetch(props.endpoint, {
+                method: 'POST',
+                credentials: 'same-origin',
+                ...props.fetchOptions,
+                headers,
+                body,
+                signal: controller.signal,
+            })
+                .then(async (response) => {
+                    if (!response.ok) {
+                        throw new Error(`Preview request failed: ${response.status}`);
+                    }
+
+                    const data = (await response.json()) as { html?: unknown };
+                    const rendered = typeof data.html === 'string' ? data.html : '';
+
+                    html.value = rendered;
+                    status.value = 'ready';
+                })
+                .catch((error: unknown) => {
+                    if ((error as { name?: string } | null)?.name === 'AbortError') {
+                        return;
+                    }
+
+                    status.value = 'error';
+                });
+        });
+
+        onBeforeUnmount(() => {
+            controller.abort();
+        });
+
+        return () => {
+            if (status.value === 'loading') {
+                return h('div', {
+                    'aria-busy': 'true',
+                    'data-ve-dynamic-block': props.name,
+                });
+            }
+
+            if (status.value === 'error') {
+                return h(UnknownBlock, { name: props.name });
+            }
+
+            return h('div', {
+                'data-ve-dynamic-block': props.name,
+                innerHTML: html.value,
+            });
+        };
+    },
+});

--- a/packages/visual-editor-renderer-vue/src/blocks/core/design.ts
+++ b/packages/visual-editor-renderer-vue/src/blocks/core/design.ts
@@ -1,0 +1,348 @@
+/**
+ * Design-family core block renderers: separator, spacer, cover, media-text,
+ * table, details, search. Validates and clamps attributes the same way the
+ * Blade partials do — dimRatio 0-100, minHeightUnit allowlist, table cell
+ * alignment allowlist, group tag allowlist — to keep parity with the
+ * server-side output.
+ */
+
+import { defineComponent, h, useId } from 'vue';
+import type { VNode } from 'vue';
+import {
+    attrArray,
+    attrBoolean,
+    attrFloat,
+    attrInt,
+    attrRecord,
+    attrString,
+    classList,
+} from '../../support/attributes';
+import { safeUrl } from '../../support/urlSanitizer';
+import { blockRendererProps } from '../shared';
+
+const ALLOWED_MIN_HEIGHT_UNITS = ['px', 'em', 'rem', 'vh', 'vw', '%'] as const;
+const ALLOWED_CELL_ALIGN = ['left', 'center', 'right', 'justify'] as const;
+
+export const SeparatorBlock = defineComponent({
+    name: 'SeparatorBlock',
+    props: blockRendererProps,
+    setup(props) {
+        return () => {
+            const style = attrString(props.attributes.style, 'default');
+            const className = attrString(props.attributes.className);
+
+            const classes = classList([
+                'wp-block-separator',
+                'has-alpha-channel-opacity',
+                style === 'wide' ? 'is-style-wide' : null,
+                style === 'dots' ? 'is-style-dots' : null,
+                className,
+            ]);
+
+            return h('hr', { class: classes });
+        };
+    },
+});
+
+export const SpacerBlock = defineComponent({
+    name: 'SpacerBlock',
+    props: blockRendererProps,
+    setup(props) {
+        return () => {
+            const rawHeight = props.attributes.height ?? '100px';
+            const height =
+                typeof rawHeight === 'number'
+                    ? `${rawHeight}px`
+                    : typeof rawHeight === 'string' && /^\d+(\.\d+)?$/.test(rawHeight.trim())
+                    ? `${rawHeight.trim()}px`
+                    : attrString(rawHeight, '100px');
+
+            return h('div', {
+                'aria-hidden': 'true',
+                class: 'wp-block-spacer',
+                style: { height },
+            });
+        };
+    },
+});
+
+export const CoverBlock = defineComponent({
+    name: 'CoverBlock',
+    props: blockRendererProps,
+    setup(props, { slots }) {
+        return () => {
+            const url = safeUrl(props.attributes.url);
+            const isDark = props.attributes.isDark === undefined ? true : attrBoolean(props.attributes.isDark);
+
+            const rawDim = attrInt(props.attributes.dimRatio, 50);
+            const dimRatio = Math.max(0, Math.min(100, rawDim));
+
+            const align = attrString(props.attributes.align);
+            const className = attrString(props.attributes.className);
+
+            const classes = classList([
+                'wp-block-cover',
+                isDark ? 'is-dark' : 'is-light',
+                align !== '' ? `align${align}` : null,
+                className,
+            ]);
+
+            let outerStyle: Record<string, string> | undefined;
+
+            if (props.attributes.minHeight !== undefined && props.attributes.minHeight !== null) {
+                const minHeight = Math.max(0, attrFloat(props.attributes.minHeight));
+                const requestedUnit = attrString(props.attributes.minHeightUnit);
+                const unit = (ALLOWED_MIN_HEIGHT_UNITS as ReadonlyArray<string>).includes(requestedUnit)
+                    ? requestedUnit
+                    : 'px';
+
+                outerStyle = { 'min-height': `${minHeight}${unit}` };
+            }
+
+            const children: VNode[] = [
+                h('span', {
+                    'aria-hidden': 'true',
+                    class: 'wp-block-cover__background has-background-dim',
+                    style: { opacity: String(dimRatio / 100) },
+                }),
+            ];
+
+            if (url !== '') {
+                children.push(
+                    h('img', {
+                        class: 'wp-block-cover__image-background',
+                        alt: '',
+                        src: url,
+                    })
+                );
+            }
+
+            children.push(
+                h(
+                    'div',
+                    { class: 'wp-block-cover__inner-container' },
+                    slots.default ? slots.default() : []
+                )
+            );
+
+            const coverProps: Record<string, unknown> = { class: classes };
+
+            if (outerStyle !== undefined) {
+                coverProps.style = outerStyle;
+            }
+
+            return h('div', coverProps, children);
+        };
+    },
+});
+
+export const MediaTextBlock = defineComponent({
+    name: 'MediaTextBlock',
+    props: blockRendererProps,
+    setup(props, { slots }) {
+        return () => {
+            const mediaUrl = safeUrl(props.attributes.mediaUrl);
+            const mediaAlt = attrString(props.attributes.mediaAlt);
+            const mediaType = attrString(props.attributes.mediaType, 'image');
+            const mediaPosition = attrString(props.attributes.mediaPosition, 'left');
+            const mediaWidth = attrInt(props.attributes.mediaWidth, 50);
+            const className = attrString(props.attributes.className);
+            const isStackedOnMobile = attrBoolean(props.attributes.isStackedOnMobile);
+
+            const classes = classList([
+                'wp-block-media-text',
+                mediaPosition === 'right' ? 'has-media-on-the-right' : null,
+                isStackedOnMobile ? 'is-stacked-on-mobile' : null,
+                className,
+            ]);
+
+            let style: Record<string, string> | undefined;
+
+            if (mediaWidth !== 50) {
+                const columns =
+                    mediaPosition === 'left' ? `${mediaWidth}% auto` : `auto ${mediaWidth}%`;
+
+                style = { 'grid-template-columns': columns };
+            }
+
+            let mediaChild: VNode | null = null;
+
+            if (mediaUrl !== '') {
+                mediaChild =
+                    mediaType === 'video'
+                        ? h('video', { controls: true, src: mediaUrl })
+                        : h('img', { src: mediaUrl, alt: mediaAlt });
+            }
+
+            const wrapperProps: Record<string, unknown> = { class: classes };
+
+            if (style !== undefined) {
+                wrapperProps.style = style;
+            }
+
+            return h('div', wrapperProps, [
+                h(
+                    'figure',
+                    { class: 'wp-block-media-text__media' },
+                    mediaChild === null ? [] : [mediaChild]
+                ),
+                h(
+                    'div',
+                    { class: 'wp-block-media-text__content' },
+                    slots.default ? slots.default() : []
+                ),
+            ]);
+        };
+    },
+});
+
+export const TableBlock = defineComponent({
+    name: 'TableBlock',
+    props: blockRendererProps,
+    setup(props) {
+        return () => {
+            const className = attrString(props.attributes.className);
+            const hasFixedLayout = attrBoolean(props.attributes.hasFixedLayout);
+            const caption = attrString(props.attributes.caption);
+
+            const classes = classList([
+                'wp-block-table',
+                hasFixedLayout ? 'has-fixed-layout' : null,
+                className,
+            ]);
+
+            const sections = [
+                { key: 'head' as const, Tag: 'thead' as const, defaultTag: 'th' as const },
+                { key: 'body' as const, Tag: 'tbody' as const, defaultTag: 'td' as const },
+                { key: 'foot' as const, Tag: 'tfoot' as const, defaultTag: 'td' as const },
+            ];
+
+            const tableChildren: VNode[] = [];
+
+            for (const { key, Tag, defaultTag } of sections) {
+                const rows = attrArray(props.attributes[key]);
+
+                if (rows.length === 0) {
+                    continue;
+                }
+
+                const rowNodes = rows.map((row, rowIndex) => {
+                    const rowRecord = attrRecord(row);
+                    const cells = attrArray(rowRecord.cells);
+                    const cellNodes = cells.map((cell, cellIndex) => {
+                        const cellRecord = attrRecord(cell);
+                        const content = attrString(cellRecord.content);
+                        const rawAlign = attrString(cellRecord.align).toLowerCase();
+                        const align = (ALLOWED_CELL_ALIGN as ReadonlyArray<string>).includes(rawAlign)
+                            ? rawAlign
+                            : '';
+                        const cellTagRaw = attrString(cellRecord.tag);
+                        const cellTag: 'td' | 'th' =
+                            cellTagRaw === 'td' || cellTagRaw === 'th' ? cellTagRaw : defaultTag;
+                        const cellStyle = align === '' ? undefined : { 'text-align': align };
+
+                        return h(cellTag, {
+                            key: cellIndex,
+                            style: cellStyle,
+                            innerHTML: content,
+                        });
+                    });
+
+                    return h('tr', { key: rowIndex }, cellNodes);
+                });
+
+                tableChildren.push(h(Tag, { key }, rowNodes));
+            }
+
+            const figureChildren: VNode[] = [h('table', null, tableChildren)];
+
+            if (caption.trim() !== '') {
+                figureChildren.push(h('figcaption', { innerHTML: caption }));
+            }
+
+            return h('figure', { class: classes }, figureChildren);
+        };
+    },
+});
+
+export const DetailsBlock = defineComponent({
+    name: 'DetailsBlock',
+    props: blockRendererProps,
+    setup(props, { slots }) {
+        return () => {
+            const summary = attrString(props.attributes.summary);
+            const showContent = attrBoolean(props.attributes.showContent);
+            const className = attrString(props.attributes.className);
+            const classes = classList(['wp-block-details', className]);
+
+            const children: VNode[] = [h('summary', { innerHTML: summary })];
+
+            if (slots.default) {
+                children.push(...(slots.default() as VNode[]));
+            }
+
+            return h('details', { class: classes, open: showContent }, children);
+        };
+    },
+});
+
+export const SearchBlock = defineComponent({
+    name: 'SearchBlock',
+    props: blockRendererProps,
+    setup(props) {
+        const inputId = `wp-block-search-input-${useId().replace(/[^a-zA-Z0-9_-]/g, '')}`;
+
+        return () => {
+            const label = attrString(props.attributes.label, 'Search');
+            const showLabel =
+                props.attributes.showLabel === undefined ? true : attrBoolean(props.attributes.showLabel);
+            const placeholder = attrString(props.attributes.placeholder);
+            const buttonText = attrString(props.attributes.buttonText, 'Search');
+            const useIcon = attrBoolean(props.attributes.buttonUseIcon);
+            const queryName = attrString(attrRecord(props.attributes.query).name, 's');
+            const buttonLabel = useIcon ? '' : buttonText;
+            const className = attrString(props.attributes.className);
+
+            const classes = classList([
+                'wp-block-search',
+                !showLabel ? 'wp-block-search__button-inside' : null,
+                className,
+            ]);
+
+            const children: VNode[] = [];
+
+            if (showLabel) {
+                children.push(
+                    h(
+                        'label',
+                        { class: 'wp-block-search__label', for: inputId },
+                        label
+                    )
+                );
+            }
+
+            children.push(
+                h('div', { class: 'wp-block-search__inside-wrapper' }, [
+                    h('input', {
+                        id: inputId,
+                        type: 'search',
+                        class: 'wp-block-search__input',
+                        name: queryName,
+                        placeholder: placeholder === '' ? undefined : placeholder,
+                    }),
+                    h(
+                        'button',
+                        { type: 'submit', class: 'wp-block-search__button' },
+                        buttonLabel
+                    ),
+                ])
+            );
+
+            return h(
+                'form',
+                { role: 'search', method: 'get', action: '/', class: classes },
+                children
+            );
+        };
+    },
+});

--- a/packages/visual-editor-renderer-vue/src/blocks/core/layout.ts
+++ b/packages/visual-editor-renderer-vue/src/blocks/core/layout.ts
@@ -1,0 +1,222 @@
+/**
+ * Layout + button core block renderers: group, row, stack, columns, column,
+ * buttons, button. Containers render their already-rendered inner blocks via
+ * the default slot; buttons sanitize URL + target/rel tokens the same way
+ * the Blade partial does.
+ */
+
+import { defineComponent, h } from 'vue';
+import {
+    attrBoolean,
+    attrRecord,
+    attrString,
+    classList,
+    formatPercent,
+} from '../../support/attributes';
+import { safeUrl } from '../../support/urlSanitizer';
+import { blockRendererProps } from '../shared';
+
+const ALLOWED_GROUP_TAGS = ['div', 'section', 'article', 'aside', 'header', 'footer', 'main', 'nav'] as const;
+
+type GroupTag = (typeof ALLOWED_GROUP_TAGS)[number];
+
+export const GroupBlock = defineComponent({
+    name: 'GroupBlock',
+    props: blockRendererProps,
+    setup(props, { slots }) {
+        return () => {
+            const tagName = attrString(props.attributes.tagName);
+            const tag: GroupTag = (ALLOWED_GROUP_TAGS as ReadonlyArray<string>).includes(tagName)
+                ? (tagName as GroupTag)
+                : 'div';
+
+            const layout = attrRecord(props.attributes.layout);
+            const layoutType = attrString(layout.type);
+            const layoutClass =
+                layoutType === 'constrained'
+                    ? 'is-layout-constrained'
+                    : layoutType === 'flex'
+                    ? 'is-layout-flex'
+                    : 'is-layout-flow';
+
+            const className = attrString(props.attributes.className);
+            const classes = classList(['wp-block-group', layoutClass, className]);
+
+            return h(tag, { class: classes }, slots.default ? slots.default() : []);
+        };
+    },
+});
+
+export const RowBlock = defineComponent({
+    name: 'RowBlock',
+    props: blockRendererProps,
+    setup(props, { slots }) {
+        return () => {
+            const className = attrString(props.attributes.className);
+            const classes = classList(['wp-block-group', 'is-layout-flex', 'is-horizontal', className]);
+
+            return h('div', { class: classes }, slots.default ? slots.default() : []);
+        };
+    },
+});
+
+export const StackBlock = defineComponent({
+    name: 'StackBlock',
+    props: blockRendererProps,
+    setup(props, { slots }) {
+        return () => {
+            const className = attrString(props.attributes.className);
+            const classes = classList(['wp-block-group', 'is-layout-flex', 'is-vertical', className]);
+
+            return h('div', { class: classes }, slots.default ? slots.default() : []);
+        };
+    },
+});
+
+export const ColumnsBlock = defineComponent({
+    name: 'ColumnsBlock',
+    props: blockRendererProps,
+    setup(props, { slots }) {
+        return () => {
+            const className = attrString(props.attributes.className);
+            const isStacked =
+                props.attributes.isStackedOnMobile === undefined
+                    ? true
+                    : attrBoolean(props.attributes.isStackedOnMobile);
+            const verticalAlignment = attrString(props.attributes.verticalAlignment);
+
+            const classes = classList([
+                'wp-block-columns',
+                isStacked ? 'is-stacked-on-mobile' : null,
+                verticalAlignment !== '' ? `are-vertically-aligned-${verticalAlignment}` : null,
+                className,
+            ]);
+
+            return h('div', { class: classes }, slots.default ? slots.default() : []);
+        };
+    },
+});
+
+export const ColumnBlock = defineComponent({
+    name: 'ColumnBlock',
+    props: blockRendererProps,
+    setup(props, { slots }) {
+        return () => {
+            const className = attrString(props.attributes.className);
+            const verticalAlignment = attrString(props.attributes.verticalAlignment);
+
+            const classes = classList([
+                'wp-block-column',
+                verticalAlignment !== '' ? `is-vertically-aligned-${verticalAlignment}` : null,
+                className,
+            ]);
+
+            const width = props.attributes.width;
+            let style: Record<string, string> | undefined;
+
+            if (width !== undefined && width !== null && width !== '') {
+                let basis = '';
+
+                if (typeof width === 'number') {
+                    basis = formatPercent(width);
+                } else if (typeof width === 'string' && width.trim() !== '') {
+                    const numeric = Number.parseFloat(width);
+
+                    basis =
+                        Number.isFinite(numeric) && String(numeric) === width.trim()
+                            ? formatPercent(numeric)
+                            : width;
+                }
+
+                if (basis !== '') {
+                    style = { 'flex-basis': basis };
+                }
+            }
+
+            const divProps: Record<string, unknown> = { class: classes };
+
+            if (style !== undefined) {
+                divProps.style = style;
+            }
+
+            return h('div', divProps, slots.default ? slots.default() : []);
+        };
+    },
+});
+
+export const ButtonsBlock = defineComponent({
+    name: 'ButtonsBlock',
+    props: blockRendererProps,
+    setup(props, { slots }) {
+        return () => {
+            const layout = attrRecord(props.attributes.layout);
+            const justify = attrString(layout.justifyContent);
+            const className = attrString(props.attributes.className);
+
+            const classes = classList([
+                'wp-block-buttons',
+                'is-layout-flex',
+                justify !== '' ? `is-content-justification-${justify}` : 'is-content-justification-left',
+                className,
+            ]);
+
+            return h('div', { class: classes }, slots.default ? slots.default() : []);
+        };
+    },
+});
+
+export const ButtonBlock = defineComponent({
+    name: 'ButtonBlock',
+    props: blockRendererProps,
+    setup(props) {
+        return () => {
+            const text = attrString(props.attributes.text);
+            const url = safeUrl(props.attributes.url);
+            const linkTarget = attrString(props.attributes.linkTarget);
+            const title = attrString(props.attributes.title);
+            const className = attrString(props.attributes.className);
+
+            const wrapperClasses = classList(['wp-block-button', className]);
+            const linkClasses = 'wp-block-button__link wp-element-button';
+
+            let rel = attrString(props.attributes.rel);
+
+            if (linkTarget === '_blank') {
+                const tokens = rel.split(/\s+/).filter((t) => t !== '');
+
+                for (const required of ['noopener', 'noreferrer']) {
+                    if (!tokens.includes(required)) {
+                        tokens.push(required);
+                    }
+                }
+
+                rel = tokens.join(' ');
+            }
+
+            if (url === '') {
+                return h(
+                    'div',
+                    { class: wrapperClasses },
+                    h('span', {
+                        class: linkClasses,
+                        title: title === '' ? undefined : title,
+                        innerHTML: text,
+                    })
+                );
+            }
+
+            return h(
+                'div',
+                { class: wrapperClasses },
+                h('a', {
+                    class: linkClasses,
+                    href: url,
+                    target: linkTarget === '' ? undefined : linkTarget,
+                    rel: rel === '' ? undefined : rel,
+                    title: title === '' ? undefined : title,
+                    innerHTML: text,
+                })
+            );
+        };
+    },
+});

--- a/packages/visual-editor-renderer-vue/src/blocks/core/media.ts
+++ b/packages/visual-editor-renderer-vue/src/blocks/core/media.ts
@@ -1,0 +1,275 @@
+/**
+ * Media-family core block renderers: image, gallery, video, audio, file,
+ * embed. Each matches the HTML shape of the corresponding Blade partial so
+ * rendered output is interchangeable with the server-side renderer.
+ */
+
+import { defineComponent, h } from 'vue';
+import type { VNode } from 'vue';
+import { attrBoolean, attrInt, attrString, classList } from '../../support/attributes';
+import { safeUrl } from '../../support/urlSanitizer';
+import { blockRendererProps } from '../shared';
+
+export const ImageBlock = defineComponent({
+    name: 'ImageBlock',
+    props: blockRendererProps,
+    setup(props) {
+        return () => {
+            const url = safeUrl(props.attributes.url);
+            const alt = attrString(props.attributes.alt);
+            const caption = attrString(props.attributes.caption);
+            const href = safeUrl(props.attributes.href);
+            const id = attrInt(props.attributes.id);
+            const hasDimension = (key: 'width' | 'height'): boolean =>
+                props.attributes[key] !== undefined &&
+                props.attributes[key] !== null &&
+                props.attributes[key] !== '';
+            const width = hasDimension('width') ? attrInt(props.attributes.width) : undefined;
+            const height = hasDimension('height') ? attrInt(props.attributes.height) : undefined;
+
+            const align = attrString(props.attributes.align);
+            const sizeSlug = attrString(props.attributes.sizeSlug);
+            const className = attrString(props.attributes.className);
+
+            const figureClasses = classList([
+                'wp-block-image',
+                align !== '' ? `align${align}` : null,
+                sizeSlug !== '' ? `size-${sizeSlug}` : null,
+                className,
+            ]);
+
+            const imgProps: Record<string, unknown> = { src: url, alt };
+
+            if (id > 0) {
+                imgProps.class = `wp-image-${id}`;
+            }
+
+            if (width !== undefined) {
+                imgProps.width = width;
+            }
+
+            if (height !== undefined) {
+                imgProps.height = height;
+            }
+
+            const img: VNode | null = url === '' ? null : h('img', imgProps);
+
+            const children: VNode[] = [];
+
+            if (img !== null) {
+                children.push(href !== '' ? h('a', { href }, [img]) : img);
+            }
+
+            if (caption.trim() !== '') {
+                children.push(h('figcaption', { innerHTML: caption }));
+            }
+
+            return h('figure', { class: figureClasses }, children);
+        };
+    },
+});
+
+export const GalleryBlock = defineComponent({
+    name: 'GalleryBlock',
+    props: blockRendererProps,
+    setup(props, { slots }) {
+        return () => {
+            const columns = attrInt(props.attributes.columns);
+            const imageCrop = attrBoolean(props.attributes.imageCrop);
+            const className = attrString(props.attributes.className);
+            const caption = attrString(props.attributes.caption);
+
+            const classes = classList([
+                'wp-block-gallery',
+                'has-nested-images',
+                columns > 0 ? `columns-${columns}` : null,
+                imageCrop ? 'is-cropped' : null,
+                className,
+            ]);
+
+            const children: VNode[] = [];
+            const inner = slots.default ? slots.default() : [];
+
+            children.push(...(inner as VNode[]));
+
+            if (caption.trim() !== '') {
+                children.push(
+                    h('figcaption', {
+                        class: 'blocks-gallery-caption',
+                        innerHTML: caption,
+                    })
+                );
+            }
+
+            return h('figure', { class: classes }, children);
+        };
+    },
+});
+
+export const VideoBlock = defineComponent({
+    name: 'VideoBlock',
+    props: blockRendererProps,
+    setup(props) {
+        return () => {
+            const src = safeUrl(props.attributes.src);
+            const caption = attrString(props.attributes.caption);
+            const align = attrString(props.attributes.align);
+            const className = attrString(props.attributes.className);
+            const poster = safeUrl(props.attributes.poster);
+            const preload = attrString(props.attributes.preload, 'metadata');
+
+            const controls =
+                props.attributes.controls === undefined ? true : attrBoolean(props.attributes.controls);
+
+            const classes = classList([
+                'wp-block-video',
+                align !== '' ? `align${align}` : null,
+                className,
+            ]);
+
+            const children: VNode[] = [];
+
+            if (src !== '') {
+                children.push(
+                    h('video', {
+                        src,
+                        preload,
+                        controls,
+                        autoplay: attrBoolean(props.attributes.autoplay),
+                        loop: attrBoolean(props.attributes.loop),
+                        muted: attrBoolean(props.attributes.muted),
+                        playsinline: attrBoolean(props.attributes.playsInline),
+                        poster: poster === '' ? undefined : poster,
+                    })
+                );
+            }
+
+            if (caption.trim() !== '') {
+                children.push(h('figcaption', { innerHTML: caption }));
+            }
+
+            return h('figure', { class: classes }, children);
+        };
+    },
+});
+
+export const AudioBlock = defineComponent({
+    name: 'AudioBlock',
+    props: blockRendererProps,
+    setup(props) {
+        return () => {
+            const src = safeUrl(props.attributes.src);
+            const caption = attrString(props.attributes.caption);
+            const align = attrString(props.attributes.align);
+            const className = attrString(props.attributes.className);
+            const preload = attrString(props.attributes.preload, 'none');
+
+            const classes = classList([
+                'wp-block-audio',
+                align !== '' ? `align${align}` : null,
+                className,
+            ]);
+
+            const children: VNode[] = [];
+
+            if (src !== '') {
+                children.push(
+                    h('audio', {
+                        controls: true,
+                        src,
+                        preload,
+                        autoplay: attrBoolean(props.attributes.autoplay),
+                        loop: attrBoolean(props.attributes.loop),
+                    })
+                );
+            }
+
+            if (caption.trim() !== '') {
+                children.push(h('figcaption', { innerHTML: caption }));
+            }
+
+            return h('figure', { class: classes }, children);
+        };
+    },
+});
+
+export const FileBlock = defineComponent({
+    name: 'FileBlock',
+    props: blockRendererProps,
+    setup(props) {
+        return () => {
+            const href = safeUrl(props.attributes.href);
+            const fileName = attrString(props.attributes.fileName);
+            const textLinkHrefRaw = attrString(props.attributes.textLinkHref);
+            const textLinkHref = safeUrl(textLinkHrefRaw === '' ? props.attributes.href : textLinkHrefRaw);
+            const download = attrString(props.attributes.downloadButtonText, 'Download');
+            const showDownload =
+                props.attributes.showDownloadButton === undefined
+                    ? true
+                    : attrBoolean(props.attributes.showDownloadButton);
+            const className = attrString(props.attributes.className);
+
+            const classes = classList(['wp-block-file', className]);
+            const linkLabel = fileName !== '' ? fileName : href;
+
+            if (href === '') {
+                return h('div', { class: classes });
+            }
+
+            const children: VNode[] = [
+                h('a', { href: textLinkHref !== '' ? textLinkHref : href }, linkLabel),
+            ];
+
+            if (showDownload) {
+                children.push(
+                    h(
+                        'a',
+                        {
+                            href,
+                            class: 'wp-block-file__button',
+                            download: '',
+                        },
+                        download
+                    )
+                );
+            }
+
+            return h('div', { class: classes }, children);
+        };
+    },
+});
+
+export const EmbedBlock = defineComponent({
+    name: 'EmbedBlock',
+    props: blockRendererProps,
+    setup(props) {
+        return () => {
+            const url = attrString(props.attributes.url);
+            const provider = attrString(props.attributes.providerNameSlug).toLowerCase();
+            const caption = attrString(props.attributes.caption);
+            const ratio = attrString(props.attributes.aspectRatio);
+            const type = attrString(props.attributes.type);
+
+            const sanitizedProvider = provider.replace(/[^a-z0-9-]/g, '-');
+
+            const classes = classList([
+                'wp-block-embed',
+                sanitizedProvider !== '' ? `is-provider-${sanitizedProvider}` : null,
+                sanitizedProvider !== '' ? `wp-block-embed-${sanitizedProvider}` : null,
+                type !== '' ? `is-type-${type}` : null,
+                ratio !== '' ? `wp-embed-aspect-${ratio.replace(/\//g, '-')}` : null,
+                ratio !== '' ? 'wp-has-aspect-ratio' : null,
+            ]);
+
+            const children: VNode[] = [
+                h('div', { class: 'wp-block-embed__wrapper' }, url === '' ? undefined : url),
+            ];
+
+            if (caption.trim() !== '') {
+                children.push(h('figcaption', { innerHTML: caption }));
+            }
+
+            return h('figure', { class: classes }, children);
+        };
+    },
+});

--- a/packages/visual-editor-renderer-vue/src/blocks/core/text.ts
+++ b/packages/visual-editor-renderer-vue/src/blocks/core/text.ts
@@ -1,0 +1,193 @@
+/**
+ * Text-family core block renderers: paragraph, heading, list, list-item,
+ * quote, code, preformatted, verse, and pullquote. Each one mirrors the
+ * output of the matching Blade partial in
+ * `artisanpack-ui/visual-editor-renderer-blade` so server-rendered and
+ * Vue-rendered pages ship identical markup.
+ */
+
+import { defineComponent, h } from 'vue';
+import { attrBoolean, attrInt, attrString, classList } from '../../support/attributes';
+import { blockRendererProps } from '../shared';
+
+export const ParagraphBlock = defineComponent({
+    name: 'ParagraphBlock',
+    props: blockRendererProps,
+    setup(props) {
+        return () => {
+            const align = attrString(props.attributes.align);
+            const className = attrString(props.attributes.className);
+            const content = attrString(props.attributes.content);
+
+            const classes = classList([
+                'wp-block-paragraph',
+                align !== '' ? `has-text-align-${align}` : null,
+                className,
+            ]);
+
+            return h('p', { class: classes, innerHTML: content });
+        };
+    },
+});
+
+export const HeadingBlock = defineComponent({
+    name: 'HeadingBlock',
+    props: blockRendererProps,
+    setup(props) {
+        return () => {
+            const rawLevel = attrInt(props.attributes.level, 2);
+            const level = Math.max(1, Math.min(6, rawLevel));
+            const textAlign = attrString(props.attributes.textAlign);
+            const className = attrString(props.attributes.className);
+            const content = attrString(props.attributes.content);
+
+            const classes = classList([
+                'wp-block-heading',
+                textAlign !== '' ? `has-text-align-${textAlign}` : null,
+                className,
+            ]);
+
+            return h(`h${level}`, { class: classes, innerHTML: content });
+        };
+    },
+});
+
+export const ListBlock = defineComponent({
+    name: 'ListBlock',
+    props: blockRendererProps,
+    setup(props, { slots }) {
+        return () => {
+            const ordered = attrBoolean(props.attributes.ordered);
+            const className = attrString(props.attributes.className);
+            const legacyValues = attrString(props.attributes.values);
+            const classes = classList(['wp-block-list', className]);
+
+            const tag = ordered ? 'ol' : 'ul';
+            const commonProps: Record<string, unknown> = { class: classes };
+
+            if (ordered) {
+                if (props.attributes.start !== undefined && props.attributes.start !== null) {
+                    commonProps.start = attrInt(props.attributes.start);
+                }
+
+                if (attrBoolean(props.attributes.reversed)) {
+                    commonProps.reversed = true;
+                }
+            }
+
+            const children = slots.default ? slots.default() : [];
+
+            if (children.length > 0) {
+                return h(tag, commonProps, children);
+            }
+
+            if (legacyValues === '') {
+                return h(tag, commonProps);
+            }
+
+            return h(tag, { ...commonProps, innerHTML: legacyValues });
+        };
+    },
+});
+
+export const ListItemBlock = defineComponent({
+    name: 'ListItemBlock',
+    props: blockRendererProps,
+    setup(props, { slots }) {
+        return () => {
+            const content = attrString(props.attributes.content);
+            const children = slots.default ? slots.default() : [];
+
+            if (children.length === 0) {
+                return h('li', { innerHTML: content });
+            }
+
+            return h('li', null, [h('span', { innerHTML: content }), ...children]);
+        };
+    },
+});
+
+export const QuoteBlock = defineComponent({
+    name: 'QuoteBlock',
+    props: blockRendererProps,
+    setup(props, { slots }) {
+        return () => {
+            const className = attrString(props.attributes.className);
+            const citation = attrString(props.attributes.citation);
+            const classes = classList(['wp-block-quote', className]);
+            const children = slots.default ? slots.default() : [];
+            const nodes = [...children];
+
+            if (citation.trim() !== '') {
+                nodes.push(h('cite', { innerHTML: citation }));
+            }
+
+            return h('blockquote', { class: classes }, nodes);
+        };
+    },
+});
+
+export const CodeBlock = defineComponent({
+    name: 'CodeBlock',
+    props: blockRendererProps,
+    setup(props) {
+        return () => {
+            const content = attrString(props.attributes.content);
+
+            return h('pre', { class: 'wp-block-code' }, h('code', { innerHTML: content }));
+        };
+    },
+});
+
+export const PreformattedBlock = defineComponent({
+    name: 'PreformattedBlock',
+    props: blockRendererProps,
+    setup(props) {
+        return () => {
+            const content = attrString(props.attributes.content);
+
+            return h('pre', { class: 'wp-block-preformatted', innerHTML: content });
+        };
+    },
+});
+
+export const VerseBlock = defineComponent({
+    name: 'VerseBlock',
+    props: blockRendererProps,
+    setup(props) {
+        return () => {
+            const content = attrString(props.attributes.content);
+            const textAlign = attrString(props.attributes.textAlign);
+            const classes = classList([
+                'wp-block-verse',
+                textAlign !== '' ? `has-text-align-${textAlign}` : null,
+            ]);
+
+            return h('pre', { class: classes, innerHTML: content });
+        };
+    },
+});
+
+export const PullquoteBlock = defineComponent({
+    name: 'PullquoteBlock',
+    props: blockRendererProps,
+    setup(props) {
+        return () => {
+            const className = attrString(props.attributes.className);
+            const value = attrString(props.attributes.value);
+            const citation = attrString(props.attributes.citation);
+            const classes = classList(['wp-block-pullquote', className]);
+            const quoteChildren = [];
+
+            if (value.trim() !== '') {
+                quoteChildren.push(h('span', { innerHTML: value }));
+            }
+
+            if (citation.trim() !== '') {
+                quoteChildren.push(h('cite', { innerHTML: citation }));
+            }
+
+            return h('figure', { class: classes }, h('blockquote', null, quoteChildren));
+        };
+    },
+});

--- a/packages/visual-editor-renderer-vue/src/blocks/registerCoreBlocks.ts
+++ b/packages/visual-editor-renderer-vue/src/blocks/registerCoreBlocks.ts
@@ -1,0 +1,92 @@
+/**
+ * Core block registration entry point.
+ *
+ * Calling {@link registerCoreBlocks} populates the shared registry with every
+ * `core/*` renderer this package ships. Host apps that want to override a
+ * core renderer should call `registerCoreBlocks()` first, then register their
+ * own component under the same name.
+ *
+ * The visual-editor block allow-list (from the package's M5 audit) is frozen
+ * for V1, so the map below is exhaustive for every block type the editor can
+ * persist.
+ */
+
+import { registerBlockRenderer } from '../registry';
+import {
+    CoverBlock,
+    DetailsBlock,
+    MediaTextBlock,
+    SearchBlock,
+    SeparatorBlock,
+    SpacerBlock,
+    TableBlock,
+} from './core/design';
+import {
+    ButtonBlock,
+    ButtonsBlock,
+    ColumnBlock,
+    ColumnsBlock,
+    GroupBlock,
+    RowBlock,
+    StackBlock,
+} from './core/layout';
+import {
+    AudioBlock,
+    EmbedBlock,
+    FileBlock,
+    GalleryBlock,
+    ImageBlock,
+    VideoBlock,
+} from './core/media';
+import {
+    CodeBlock,
+    HeadingBlock,
+    ListBlock,
+    ListItemBlock,
+    ParagraphBlock,
+    PreformattedBlock,
+    PullquoteBlock,
+    QuoteBlock,
+    VerseBlock,
+} from './core/text';
+import type { BlockRenderer } from '../types';
+
+const CORE_BLOCKS: Record<string, BlockRenderer> = {
+    'core/paragraph': ParagraphBlock,
+    'core/heading': HeadingBlock,
+    'core/list': ListBlock,
+    'core/list-item': ListItemBlock,
+    'core/quote': QuoteBlock,
+    'core/code': CodeBlock,
+    'core/preformatted': PreformattedBlock,
+    'core/verse': VerseBlock,
+    'core/pullquote': PullquoteBlock,
+    'core/image': ImageBlock,
+    'core/gallery': GalleryBlock,
+    'core/video': VideoBlock,
+    'core/audio': AudioBlock,
+    'core/file': FileBlock,
+    'core/embed': EmbedBlock,
+    'core/group': GroupBlock,
+    'core/row': RowBlock,
+    'core/stack': StackBlock,
+    'core/columns': ColumnsBlock,
+    'core/column': ColumnBlock,
+    'core/buttons': ButtonsBlock,
+    'core/button': ButtonBlock,
+    'core/cover': CoverBlock,
+    'core/media-text': MediaTextBlock,
+    'core/table': TableBlock,
+    'core/details': DetailsBlock,
+    'core/search': SearchBlock,
+    'core/separator': SeparatorBlock,
+    'core/spacer': SpacerBlock,
+};
+
+export function registerCoreBlocks(): void {
+    for (const [name, component] of Object.entries(CORE_BLOCKS)) {
+        registerBlockRenderer(name, component);
+    }
+}
+
+export { CORE_BLOCKS };

--- a/packages/visual-editor-renderer-vue/src/blocks/shared.ts
+++ b/packages/visual-editor-renderer-vue/src/blocks/shared.ts
@@ -1,0 +1,25 @@
+/**
+ * Shared prop definitions for every core block renderer.
+ *
+ * Every block component accepts the same `{ name, attributes, innerBlocks }`
+ * contract so the {@link BlockTree} walker can hand off rendering by name
+ * without knowing which renderer will actually run.
+ */
+
+import type { PropType } from 'vue';
+import type { Block } from '../types';
+
+export const blockRendererProps = {
+    name: {
+        type: String,
+        required: true as const,
+    },
+    attributes: {
+        type: Object as PropType<Record<string, unknown>>,
+        required: true as const,
+    },
+    innerBlocks: {
+        type: Array as PropType<Block[]>,
+        required: true as const,
+    },
+};

--- a/packages/visual-editor-renderer-vue/src/blocks/unknownBlock.ts
+++ b/packages/visual-editor-renderer-vue/src/blocks/unknownBlock.ts
@@ -1,0 +1,26 @@
+/**
+ * Fallback markup for blocks that have no registered Vue renderer and that
+ * the dynamic-block endpoint does not recognize either. Mirrors the
+ * `<!-- visual-editor: no partial for ... -->` comment + `<div>` wrapper the
+ * Blade renderer emits and the React renderer's unknown-block output.
+ */
+
+import { defineComponent, h } from 'vue';
+
+export const UnknownBlock = defineComponent({
+    name: 'UnknownBlock',
+    props: {
+        name: {
+            type: String,
+            required: true,
+        },
+    },
+    setup(props, { slots }) {
+        return () =>
+            h(
+                'div',
+                { 'data-ve-unknown-block': props.name },
+                slots.default ? slots.default() : undefined
+            );
+    },
+});

--- a/packages/visual-editor-renderer-vue/src/index.ts
+++ b/packages/visual-editor-renderer-vue/src/index.ts
@@ -1,0 +1,28 @@
+/**
+ * Public API for `@artisanpack-ui/visual-editor-renderer-vue`.
+ *
+ * Auto-registers every core block renderer at import time so the simplest
+ * consumer only has to render `<BlockTree :tree="post.content" />`. Apps that
+ * need to override a core block or ship their own can call
+ * {@link registerBlockRenderer} after this import.
+ */
+
+import { registerCoreBlocks } from './blocks/registerCoreBlocks';
+
+registerCoreBlocks();
+
+export { BlockTree } from './BlockTree';
+export type { BlockTreeProps } from './BlockTree';
+export { DynamicBlock } from './DynamicBlock';
+export type { DynamicBlockProps } from './DynamicBlock';
+export { UnknownBlock } from './blocks/unknownBlock';
+export {
+    getBlockRenderer,
+    getRegisteredBlockNames,
+    hasBlockRenderer,
+    registerBlockRenderer,
+    resetBlockRegistry,
+    unregisterBlockRenderer,
+} from './registry';
+export { registerCoreBlocks } from './blocks/registerCoreBlocks';
+export type { Block, BlockRenderer, BlockRendererProps } from './types';

--- a/packages/visual-editor-renderer-vue/src/registry.ts
+++ b/packages/visual-editor-renderer-vue/src/registry.ts
@@ -1,0 +1,47 @@
+/**
+ * Block renderer registry.
+ *
+ * The registry maps a block name (e.g. `core/paragraph`, `acme/my-block`) to
+ * a Vue component. Every renderer receives the same
+ * {@link BlockRendererProps} contract: parsed `attributes`, the raw
+ * `innerBlocks` array, plus already-rendered inner-block children via the
+ * default slot.
+ *
+ * Core blocks register themselves at import time from `registerCoreBlocks.ts`.
+ * Host apps and third-party packages register custom renderers via
+ * {@link registerBlockRenderer}, which also lets them override a core block.
+ */
+
+import type { BlockRenderer } from './types';
+
+const registry = new Map<string, BlockRenderer>();
+
+export function registerBlockRenderer(name: string, renderer: BlockRenderer): void {
+    const trimmed = name.trim();
+
+    if (trimmed === '') {
+        throw new Error('registerBlockRenderer: block name cannot be empty.');
+    }
+
+    registry.set(trimmed, renderer);
+}
+
+export function unregisterBlockRenderer(name: string): void {
+    registry.delete(name.trim());
+}
+
+export function getBlockRenderer(name: string): BlockRenderer | undefined {
+    return registry.get(name.trim());
+}
+
+export function hasBlockRenderer(name: string): boolean {
+    return registry.has(name.trim());
+}
+
+export function getRegisteredBlockNames(): string[] {
+    return Array.from(registry.keys()).sort();
+}
+
+export function resetBlockRegistry(): void {
+    registry.clear();
+}

--- a/packages/visual-editor-renderer-vue/src/support/attributes.ts
+++ b/packages/visual-editor-renderer-vue/src/support/attributes.ts
@@ -1,0 +1,103 @@
+/**
+ * Attribute coercion helpers.
+ *
+ * Block attributes come off a JSON payload, so every value is `unknown` at
+ * runtime. These helpers coerce individual attributes to the shapes the
+ * per-block renderers expect while keeping every renderer terse.
+ */
+
+export function attrString(value: unknown, fallback = ''): string {
+    if (typeof value === 'string') {
+        return value;
+    }
+
+    if (typeof value === 'number' || typeof value === 'boolean') {
+        return String(value);
+    }
+
+    return fallback;
+}
+
+export function attrBoolean(value: unknown, fallback = false): boolean {
+    if (typeof value === 'boolean') {
+        return value;
+    }
+
+    if (value === null || value === undefined) {
+        return fallback;
+    }
+
+    if (typeof value === 'string') {
+        const normalized = value.trim().toLowerCase();
+
+        return normalized !== '' && normalized !== 'false' && normalized !== '0';
+    }
+
+    if (typeof value === 'number') {
+        return value !== 0;
+    }
+
+    return Boolean(value);
+}
+
+export function attrInt(value: unknown, fallback = 0): number {
+    if (typeof value === 'number' && Number.isFinite(value)) {
+        return Math.trunc(value);
+    }
+
+    if (typeof value === 'string' && value.trim() !== '') {
+        const parsed = Number.parseInt(value, 10);
+
+        if (Number.isFinite(parsed)) {
+            return parsed;
+        }
+    }
+
+    return fallback;
+}
+
+export function attrFloat(value: unknown, fallback = 0): number {
+    if (typeof value === 'number' && Number.isFinite(value)) {
+        return value;
+    }
+
+    if (typeof value === 'string' && value.trim() !== '') {
+        const parsed = Number.parseFloat(value);
+
+        if (Number.isFinite(parsed)) {
+            return parsed;
+        }
+    }
+
+    return fallback;
+}
+
+export function attrRecord(value: unknown): Record<string, unknown> {
+    if (value === null || value === undefined || typeof value !== 'object') {
+        return {};
+    }
+
+    if (Array.isArray(value)) {
+        return {};
+    }
+
+    return value as Record<string, unknown>;
+}
+
+export function attrArray(value: unknown): unknown[] {
+    return Array.isArray(value) ? value : [];
+}
+
+export function classList(classes: Array<string | false | null | undefined>): string {
+    return classes
+        .filter((c): c is string => typeof c === 'string' && c.trim() !== '')
+        .map((c) => c.trim())
+        .join(' ');
+}
+
+export function formatPercent(value: number): string {
+    const fixed = value.toFixed(6);
+    const trimmed = fixed.replace(/0+$/, '').replace(/\.$/, '');
+
+    return (trimmed === '' ? '0' : trimmed) + '%';
+}

--- a/packages/visual-editor-renderer-vue/src/support/urlSanitizer.ts
+++ b/packages/visual-editor-renderer-vue/src/support/urlSanitizer.ts
@@ -1,0 +1,39 @@
+/**
+ * URL sanitization helpers.
+ *
+ * Mirrors the PHP `UrlSanitizer::safe()` used by the Blade renderer: relative
+ * URLs pass through, absolute URLs must use one of the safe schemes, and
+ * anything else (e.g. `javascript:`, `data:`, `vbscript:`) is dropped so a
+ * stored block tree can't smuggle script execution into the rendered page.
+ */
+
+const SAFE_SCHEMES: ReadonlyArray<string> = [
+    'http',
+    'https',
+    'mailto',
+    'tel',
+    'ftp',
+    'sms',
+];
+
+const SCHEME_PATTERN = /^([a-z][a-z0-9+\-.]*):/i;
+
+export function safeUrl(url: unknown): string {
+    if (typeof url !== 'string') {
+        return '';
+    }
+
+    const trimmed = url.trim();
+
+    if (trimmed === '') {
+        return '';
+    }
+
+    const match = SCHEME_PATTERN.exec(trimmed);
+
+    if (match === null) {
+        return trimmed;
+    }
+
+    return SAFE_SCHEMES.includes(match[1].toLowerCase()) ? trimmed : '';
+}

--- a/packages/visual-editor-renderer-vue/src/types.ts
+++ b/packages/visual-editor-renderer-vue/src/types.ts
@@ -1,0 +1,26 @@
+/**
+ * Shared types for the Vue block renderer.
+ *
+ * A {@link Block} matches the shape the visual editor persists to any
+ * `HasBlockContent` model: `{ clientId, name, attributes, innerBlocks }`.
+ * Block renderer components receive their own parsed attributes via props and
+ * the already-rendered inner blocks via the default slot, so containers can
+ * splice children into place without re-walking the tree.
+ */
+
+import type { Component } from 'vue';
+
+export interface Block {
+    clientId?: string;
+    name: string;
+    attributes?: Record<string, unknown>;
+    innerBlocks?: Block[];
+}
+
+export interface BlockRendererProps {
+    name: string;
+    attributes: Record<string, unknown>;
+    innerBlocks: Block[];
+}
+
+export type BlockRenderer = Component<BlockRendererProps>;

--- a/packages/visual-editor-renderer-vue/tests/BlockTree.test.ts
+++ b/packages/visual-editor-renderer-vue/tests/BlockTree.test.ts
@@ -1,0 +1,608 @@
+import { defineComponent, h } from 'vue';
+import { mount, flushPromises } from '@vue/test-utils';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import '../src/index';
+import { BlockTree } from '../src/BlockTree';
+import {
+    registerBlockRenderer,
+    resetBlockRegistry,
+    unregisterBlockRenderer,
+} from '../src/registry';
+import { registerCoreBlocks } from '../src/blocks/registerCoreBlocks';
+import { makeBlock, normalizeHtml } from './helpers';
+import type { Block } from '../src/types';
+
+function renderTree(tree: unknown): string {
+    const wrapper = mount(BlockTree, {
+        props: {
+            tree: tree as Block[] | string | null | undefined,
+        },
+    });
+
+    return normalizeHtml(wrapper.html());
+}
+
+afterEach(() => {
+    resetBlockRegistry();
+    registerCoreBlocks();
+});
+
+describe('BlockTree normalization', () => {
+    it('renders nothing for an empty tree', () => {
+        expect(renderTree([])).toBe('');
+    });
+
+    it('renders nothing for null or undefined', () => {
+        expect(renderTree(null)).toBe('');
+        expect(renderTree(undefined)).toBe('');
+    });
+
+    it('parses a JSON-encoded string tree', () => {
+        const json = JSON.stringify([makeBlock('core/paragraph', { content: 'Hi' })]);
+
+        expect(renderTree(json)).toBe('<p class="wp-block-paragraph">Hi</p>');
+    });
+
+    it('skips entries that are not block-shaped objects', () => {
+        const tree = [
+            'not-a-block',
+            null,
+            42,
+            makeBlock('core/paragraph', { content: 'Good' }),
+        ];
+
+        expect(renderTree(tree)).toContain('Good');
+    });
+
+    it('skips blocks with missing or empty names', () => {
+        const tree = [
+            { clientId: 'a', name: '', attributes: {}, innerBlocks: [] },
+            { clientId: 'b', attributes: {}, innerBlocks: [] } as unknown,
+        ];
+
+        expect(renderTree(tree)).toBe('');
+    });
+
+    it('filters non-block entries out of innerBlocks before recursion', () => {
+        const tree = [
+            makeBlock(
+                'core/group',
+                {},
+                [
+                    makeBlock('core/paragraph', { content: 'Real' }, [], 'p-1'),
+                    'not-a-block' as unknown as never,
+                    null as unknown as never,
+                    { clientId: 'x', name: '', attributes: {}, innerBlocks: [] },
+                ]
+            ),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('<p class="wp-block-paragraph">Real</p>');
+    });
+});
+
+describe('Core text blocks', () => {
+    it('renders a paragraph block', () => {
+        const tree = [makeBlock('core/paragraph', { content: 'Hello <strong>world</strong>' })];
+
+        expect(renderTree(tree)).toBe('<p class="wp-block-paragraph">Hello <strong>world</strong></p>');
+    });
+
+    it('renders a heading at the configured level', () => {
+        const tree = [makeBlock('core/heading', { level: 3, content: 'Section' })];
+
+        expect(renderTree(tree)).toBe('<h3 class="wp-block-heading">Section</h3>');
+    });
+
+    it('clamps invalid heading levels to the allowed range', () => {
+        expect(renderTree([makeBlock('core/heading', { level: 99, content: 'X' })])).toContain('<h6');
+        expect(renderTree([makeBlock('core/heading', { level: 0, content: 'Y' })])).toContain('<h1');
+    });
+
+    it('renders a quote with citation', () => {
+        const tree = [
+            makeBlock('core/quote', { citation: 'Someone Famous' }, [
+                makeBlock('core/paragraph', { content: 'Quoted text' }, [], 'p1'),
+            ]),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('<blockquote class="wp-block-quote">');
+        expect(html).toContain('<p class="wp-block-paragraph">Quoted text</p>');
+        expect(html).toContain('<cite>Someone Famous</cite>');
+    });
+
+    it('renders a code block', () => {
+        const tree = [makeBlock('core/code', { content: 'echo 1;' })];
+
+        expect(renderTree(tree)).toBe('<pre class="wp-block-code"><code>echo 1;</code></pre>');
+    });
+
+    it('renders a preformatted block preserving whitespace', () => {
+        const tree = [makeBlock('core/preformatted', { content: 'line 1\nline 2' })];
+
+        const wrapper = mount(BlockTree, { props: { tree } });
+        const html = wrapper.html();
+
+        expect(html).toContain('<pre class="wp-block-preformatted">');
+        expect(html).toContain('line 1\nline 2');
+    });
+
+    it('renders a verse block', () => {
+        const tree = [makeBlock('core/verse', { content: 'Roses are red' })];
+
+        expect(renderTree(tree)).toContain('<pre class="wp-block-verse">Roses are red</pre>');
+    });
+
+    it('renders a pullquote with value and citation', () => {
+        const tree = [
+            makeBlock('core/pullquote', {
+                value: 'Be bold',
+                citation: 'Editor',
+            }),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('<figure class="wp-block-pullquote">');
+        expect(html).toContain('Be bold');
+        expect(html).toContain('<cite>Editor</cite>');
+    });
+
+    it('renders an unordered list with list items', () => {
+        const tree = [
+            makeBlock('core/list', { ordered: false }, [
+                makeBlock('core/list-item', { content: 'One' }, [], 'li-1'),
+                makeBlock('core/list-item', { content: 'Two' }, [], 'li-2'),
+            ]),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('<ul class="wp-block-list">');
+        expect(html).toContain('<li>One</li>');
+        expect(html).toContain('<li>Two</li>');
+        expect(html).toContain('</ul>');
+    });
+
+    it('renders an ordered list with start + reversed attributes', () => {
+        const tree = [
+            makeBlock('core/list', { ordered: true, start: 5, reversed: true }, [
+                makeBlock('core/list-item', { content: 'A' }, [], 'li-1'),
+            ]),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('<ol ');
+        expect(html).toContain('start="5"');
+        expect(html).toContain('reversed');
+    });
+});
+
+describe('Core media blocks', () => {
+    it('renders an image block with caption and link', () => {
+        const tree = [
+            makeBlock('core/image', {
+                url: 'https://example.test/image.jpg',
+                alt: 'An image',
+                caption: 'A <em>caption</em>',
+                href: 'https://example.test/full.jpg',
+                id: 42,
+            }),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('<figure class="wp-block-image">');
+        expect(html).toContain('src="https://example.test/image.jpg"');
+        expect(html).toContain('alt="An image"');
+        expect(html).toContain('class="wp-image-42"');
+        expect(html).toContain('href="https://example.test/full.jpg"');
+        expect(html).toContain('<figcaption>A <em>caption</em></figcaption>');
+    });
+
+    it('drops unsafe URL schemes from image hrefs', () => {
+        const tree = [
+            makeBlock('core/image', {
+                url: 'https://example.test/safe.jpg',
+                href: 'javascript:void(0)',
+                alt: 'safe',
+            }),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).not.toContain('javascript:');
+        expect(html).toContain('src="https://example.test/safe.jpg"');
+        expect(html).not.toContain('<a ');
+    });
+
+    it('renders a video block with controls + poster', () => {
+        const tree = [
+            makeBlock('core/video', {
+                src: 'https://example.test/movie.mp4',
+                poster: 'https://example.test/poster.jpg',
+                controls: true,
+                loop: true,
+                muted: true,
+            }),
+        ];
+
+        const wrapper = mount(BlockTree, { props: { tree } });
+        const video = wrapper.element.querySelector('video');
+
+        expect(video).not.toBeNull();
+        expect(video?.getAttribute('src')).toBe('https://example.test/movie.mp4');
+        expect(video?.getAttribute('poster')).toBe('https://example.test/poster.jpg');
+        expect(video?.controls).toBe(true);
+        expect(video?.loop).toBe(true);
+        expect(video?.muted).toBe(true);
+    });
+
+    it('renders an audio block', () => {
+        const tree = [
+            makeBlock('core/audio', {
+                src: 'https://example.test/track.mp3',
+                preload: 'metadata',
+            }),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('<figure class="wp-block-audio">');
+        expect(html).toContain('src="https://example.test/track.mp3"');
+        expect(html).toContain('preload="metadata"');
+    });
+
+    it('renders a file block with download button', () => {
+        const tree = [
+            makeBlock('core/file', {
+                href: 'https://example.test/doc.pdf',
+                fileName: 'doc.pdf',
+                downloadButtonText: 'Download PDF',
+            }),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('<div class="wp-block-file">');
+        expect(html).toContain('<a href="https://example.test/doc.pdf">doc.pdf</a>');
+        expect(html).toContain('class="wp-block-file__button"');
+        expect(html).toContain('Download PDF');
+    });
+
+    it('renders a gallery with columns class and nested images', () => {
+        const tree = [
+            makeBlock(
+                'core/gallery',
+                { columns: 3, imageCrop: true },
+                [
+                    makeBlock(
+                        'core/image',
+                        { url: 'https://example.test/a.jpg', alt: 'a' },
+                        [],
+                        'img-a'
+                    ),
+                    makeBlock(
+                        'core/image',
+                        { url: 'https://example.test/b.jpg', alt: 'b' },
+                        [],
+                        'img-b'
+                    ),
+                ]
+            ),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('<figure class="wp-block-gallery has-nested-images columns-3 is-cropped">');
+        expect(html).toContain('src="https://example.test/a.jpg"');
+        expect(html).toContain('src="https://example.test/b.jpg"');
+    });
+
+    it('renders an embed block with provider and aspect classes', () => {
+        const tree = [
+            makeBlock('core/embed', {
+                url: 'https://youtu.be/abc123',
+                providerNameSlug: 'youtube',
+                aspectRatio: '16/9',
+                type: 'video',
+            }),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('is-provider-youtube');
+        expect(html).toContain('wp-block-embed-youtube');
+        expect(html).toContain('is-type-video');
+        expect(html).toContain('wp-embed-aspect-16-9');
+        expect(html).toContain('wp-has-aspect-ratio');
+    });
+});
+
+describe('Core layout blocks', () => {
+    it('renders nested inner blocks for a group', () => {
+        const tree = [
+            makeBlock('core/group', {}, [
+                makeBlock('core/paragraph', { content: 'Inner' }, [], 'inner-1'),
+            ]),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('<div class="wp-block-group is-layout-flow">');
+        expect(html).toContain('<p class="wp-block-paragraph">Inner</p>');
+    });
+
+    it('renders a row with is-horizontal class', () => {
+        const tree = [makeBlock('core/row', {}, [makeBlock('core/paragraph', { content: 'Row' }, [], 'r1')])];
+
+        expect(renderTree(tree)).toContain('<div class="wp-block-group is-layout-flex is-horizontal">');
+    });
+
+    it('renders a stack with is-vertical class', () => {
+        const tree = [makeBlock('core/stack', {}, [makeBlock('core/paragraph', { content: 'Stacked' }, [], 's1')])];
+
+        expect(renderTree(tree)).toContain('<div class="wp-block-group is-layout-flex is-vertical">');
+    });
+
+    it('renders columns with column widths', () => {
+        const tree = [
+            makeBlock('core/columns', {}, [
+                makeBlock(
+                    'core/column',
+                    { width: 60 },
+                    [makeBlock('core/paragraph', { content: 'Left' }, [], 'l-1')],
+                    'col-1'
+                ),
+                makeBlock(
+                    'core/column',
+                    {},
+                    [makeBlock('core/paragraph', { content: 'Right' }, [], 'r-1')],
+                    'col-2'
+                ),
+            ]),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('wp-block-columns');
+        expect(html).toContain('flex-basis: 60%');
+        expect(html).toContain('<p class="wp-block-paragraph">Left</p>');
+        expect(html).toContain('<p class="wp-block-paragraph">Right</p>');
+    });
+
+    it('renders a button with safe URL and forces noopener on _blank', () => {
+        const tree = [
+            makeBlock('core/button', {
+                text: 'External',
+                url: 'https://example.com',
+                linkTarget: '_blank',
+            }),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('target="_blank"');
+        expect(html).toContain('rel="noopener noreferrer"');
+    });
+
+    it('renders a span fallback when a button URL is unsafe', () => {
+        const tree = [
+            makeBlock('core/button', { text: 'Click', url: 'javascript:alert(1)' }),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).not.toContain('javascript:');
+        expect(html).not.toContain('<a ');
+        expect(html).toContain('<span class="wp-block-button__link');
+    });
+
+    it('renders buttons wrapper with justify class', () => {
+        const tree = [
+            makeBlock(
+                'core/buttons',
+                { layout: { justifyContent: 'center' } },
+                [
+                    makeBlock(
+                        'core/button',
+                        { text: 'Go', url: 'https://example.com' },
+                        [],
+                        'b1'
+                    ),
+                ]
+            ),
+        ];
+
+        expect(renderTree(tree)).toContain('is-content-justification-center');
+    });
+});
+
+describe('Core design blocks', () => {
+    it('renders a separator block with style class', () => {
+        const tree = [makeBlock('core/separator', { style: 'wide' })];
+
+        expect(renderTree(tree)).toBe('<hr class="wp-block-separator has-alpha-channel-opacity is-style-wide">');
+    });
+
+    it('renders a spacer with numeric height as px', () => {
+        const tree = [makeBlock('core/spacer', { height: 48 })];
+
+        expect(renderTree(tree)).toContain('height: 48px');
+    });
+
+    it('drops unsafe cover background URLs', () => {
+        const tree = [
+            makeBlock('core/cover', {
+                url: 'javascript:alert(1)',
+            }),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).not.toContain('javascript:');
+        expect(html).not.toContain('<img');
+    });
+
+    it('clamps cover dimRatio and whitelists minHeightUnit', () => {
+        const tree = [
+            makeBlock('core/cover', {
+                dimRatio: 250,
+                minHeight: 40,
+                minHeightUnit: 'javascript:alert(1)',
+            }),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('opacity: 1');
+        expect(html).toContain('min-height: 40px');
+        expect(html).not.toContain('javascript:');
+    });
+
+    it('validates table cell alignment against an allowlist', () => {
+        const tree = [
+            makeBlock('core/table', {
+                body: [
+                    {
+                        cells: [
+                            { content: 'A', tag: 'td', align: 'center' },
+                            { content: 'B', tag: 'td', align: 'expression(alert(1))' },
+                        ],
+                    },
+                ],
+            }),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('text-align: center');
+        expect(html).not.toContain('expression');
+    });
+
+    it('renders media-text with right-side grid template', () => {
+        const tree = [
+            makeBlock('core/media-text', {
+                mediaUrl: 'https://example.test/photo.jpg',
+                mediaPosition: 'right',
+                mediaWidth: 30,
+            }),
+        ];
+
+        expect(renderTree(tree)).toContain('grid-template-columns: auto 30%');
+    });
+
+    it('drops unsafe media-text mediaUrl schemes', () => {
+        const tree = [
+            makeBlock('core/media-text', {
+                mediaUrl: 'javascript:alert(1)',
+                mediaType: 'image',
+                mediaAlt: 'x',
+            }),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).not.toContain('javascript:');
+        expect(html).not.toContain('<img');
+    });
+
+    it('renders a details block with showContent=true open', () => {
+        const tree = [
+            makeBlock('core/details', { summary: 'Click me', showContent: true }, [
+                makeBlock('core/paragraph', { content: 'Hidden' }, [], 'p1'),
+            ]),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toMatch(/<details class="wp-block-details" open(="")?>/);
+        expect(html).toContain('<summary>Click me</summary>');
+        expect(html).toContain('Hidden');
+    });
+
+    it('generates unique ids for multiple search blocks on the same page', () => {
+        const tree = [
+            makeBlock('core/search', { label: 'First', buttonText: 'Go' }, [], 's-1'),
+            makeBlock('core/search', { label: 'Second', buttonText: 'Find' }, [], 's-2'),
+        ];
+
+        const html = renderTree(tree);
+        const ids = Array.from(html.matchAll(/id="(wp-block-search-input-[\w-]+)"/g)).map((m) => m[1]);
+
+        expect(ids).toHaveLength(2);
+        expect(ids[0]).not.toBe(ids[1]);
+    });
+
+    it('gives two search blocks with identical attributes different ids', () => {
+        const identicalAttrs = { label: 'Same', buttonText: 'Go' };
+        const tree = [
+            makeBlock('core/search', identicalAttrs, [], 'a'),
+            makeBlock('core/search', identicalAttrs, [], 'b'),
+        ];
+
+        const html = renderTree(tree);
+        const ids = Array.from(html.matchAll(/id="(wp-block-search-input-[\w-]+)"/g)).map((m) => m[1]);
+
+        expect(ids).toHaveLength(2);
+        expect(ids[0]).not.toBe(ids[1]);
+    });
+
+    it('uses an empty button label when buttonUseIcon is true', () => {
+        const tree = [makeBlock('core/search', { buttonText: 'Go', buttonUseIcon: true })];
+
+        expect(renderTree(tree)).toContain('<button type="submit" class="wp-block-search__button"></button>');
+    });
+});
+
+describe('Registry + dynamic fallback', () => {
+    it('invokes a custom registered renderer instead of the default', () => {
+        const stickerRenderer = defineComponent({
+            props: {
+                name: { type: String, required: true },
+                attributes: { type: Object, required: true },
+                innerBlocks: { type: Array, required: true },
+            },
+            setup(props) {
+                return () =>
+                    h(
+                        'span',
+                        { 'data-sticker': 'yes' },
+                        (props.attributes.label as string) ?? ''
+                    );
+            },
+        });
+
+        registerBlockRenderer('acme/sticker', stickerRenderer);
+
+        const tree = [makeBlock('acme/sticker', { label: 'Ship it' })];
+
+        expect(renderTree(tree)).toBe('<span data-sticker="yes">Ship it</span>');
+
+        unregisterBlockRenderer('acme/sticker');
+    });
+
+    it('falls back to DynamicBlock when no renderer is registered', async () => {
+        const fetchFn = vi.fn().mockRejectedValue(new TypeError('offline'));
+        vi.stubGlobal('fetch', fetchFn);
+
+        try {
+            const tree = [makeBlock('acme/unregistered', { label: 'test' })];
+            const wrapper = mount(BlockTree, { props: { tree } });
+
+            expect(wrapper.html()).toContain('data-ve-dynamic-block="acme/unregistered"');
+
+            await flushPromises();
+
+            expect(wrapper.html()).toContain('data-ve-unknown-block="acme/unregistered"');
+        } finally {
+            vi.unstubAllGlobals();
+        }
+    });
+});

--- a/packages/visual-editor-renderer-vue/tests/DynamicBlock.test.ts
+++ b/packages/visual-editor-renderer-vue/tests/DynamicBlock.test.ts
@@ -1,0 +1,72 @@
+import { mount, flushPromises } from '@vue/test-utils';
+import { describe, expect, it, vi } from 'vitest';
+import { DynamicBlock } from '../src/DynamicBlock';
+
+function jsonResponse(body: unknown, status = 200): Response {
+    return new Response(JSON.stringify(body), {
+        status,
+        headers: { 'Content-Type': 'application/json' },
+    });
+}
+
+describe('DynamicBlock', () => {
+    it('renders HTML returned by the preview endpoint', async () => {
+        const fetchFn = vi
+            .fn()
+            .mockResolvedValue(jsonResponse({ name: 'acme/live', html: '<aside>Live!</aside>' }));
+
+        const wrapper = mount(DynamicBlock, {
+            props: {
+                name: 'acme/live',
+                attributes: { title: 'Hi' },
+                endpoint: '/visual-editor/api/blocks/preview',
+                fetchFn: fetchFn as unknown as typeof fetch,
+            },
+        });
+
+        await flushPromises();
+
+        expect(wrapper.html()).toContain('<aside>Live!</aside>');
+        expect(fetchFn).toHaveBeenCalledOnce();
+        const [url, init] = fetchFn.mock.calls[0];
+        expect(url).toBe('/visual-editor/api/blocks/preview');
+        expect(init?.method).toBe('POST');
+        expect(init?.body).toBe(JSON.stringify({ name: 'acme/live', attributes: { title: 'Hi' } }));
+    });
+
+    it('renders the unknown-block marker when the endpoint 404s', async () => {
+        const fetchFn = vi
+            .fn()
+            .mockResolvedValue(jsonResponse({ error: 'block_not_registered' }, 404));
+
+        const wrapper = mount(DynamicBlock, {
+            props: {
+                name: 'acme/missing',
+                attributes: {},
+                endpoint: '/visual-editor/api/blocks/preview',
+                fetchFn: fetchFn as unknown as typeof fetch,
+            },
+        });
+
+        await flushPromises();
+
+        expect(wrapper.html()).toContain('data-ve-unknown-block="acme/missing"');
+    });
+
+    it('renders the unknown-block marker when the fetch rejects', async () => {
+        const fetchFn = vi.fn().mockRejectedValue(new TypeError('network error'));
+
+        const wrapper = mount(DynamicBlock, {
+            props: {
+                name: 'acme/broken',
+                attributes: {},
+                endpoint: '/visual-editor/api/blocks/preview',
+                fetchFn: fetchFn as unknown as typeof fetch,
+            },
+        });
+
+        await flushPromises();
+
+        expect(wrapper.html()).toContain('data-ve-unknown-block="acme/broken"');
+    });
+});

--- a/packages/visual-editor-renderer-vue/tests/helpers.ts
+++ b/packages/visual-editor-renderer-vue/tests/helpers.ts
@@ -1,0 +1,19 @@
+import type { Block } from '../src/types';
+
+export function makeBlock(
+    name: string,
+    attributes: Record<string, unknown> = {},
+    innerBlocks: Block[] = [],
+    clientId?: string
+): Block {
+    return {
+        clientId: clientId ?? `cid-${Math.random().toString(36).slice(2, 10)}`,
+        name,
+        attributes,
+        innerBlocks,
+    };
+}
+
+export function normalizeHtml(html: string): string {
+    return html.replace(/>\s+</g, '><').replace(/\s+/g, ' ').trim();
+}

--- a/packages/visual-editor-renderer-vue/tests/parity.test.ts
+++ b/packages/visual-editor-renderer-vue/tests/parity.test.ts
@@ -1,0 +1,366 @@
+/**
+ * React/Vue renderer parity test.
+ *
+ * Renders the same fixture block trees through the React and Vue renderers
+ * using each framework's SSR entry point, then asserts the HTML output is
+ * byte-for-byte identical after normalization. When this test fails, one of
+ * the two renderers has drifted from the shared Blade partial contract —
+ * that's a bug in the renderer that diverged, not in the test.
+ */
+
+import { createSSRApp, h as vueH } from 'vue';
+import { renderToString as vueRenderToString } from '@vue/server-renderer';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import '../src/index';
+import { BlockTree as VueBlockTree } from '../src/BlockTree';
+import { BlockTree as ReactBlockTree } from '../../visual-editor-renderer-react/src/BlockTree';
+import '../../visual-editor-renderer-react/src/index';
+import type { Block } from '../src/types';
+import { makeBlock, normalizeHtml } from './helpers';
+
+async function renderVue(tree: Block[]): Promise<string> {
+    const app = createSSRApp({
+        render: () => vueH(VueBlockTree, { tree }),
+    });
+
+    const html = await vueRenderToString(app);
+
+    return domNormalize(stripVueServerMarkers(html));
+}
+
+function renderReact(tree: Block[]): string {
+    return domNormalize(renderToStaticMarkup(createElement(ReactBlockTree, { tree })));
+}
+
+function stripVueServerMarkers(html: string): string {
+    return html.replace(/<!--\[-->|<!--\]-->|<!---->/g, '');
+}
+
+/**
+ * Re-parses `html` through the DOM and serializes it back out, then
+ * normalizes whitespace + collapses framework-level style serialization
+ * differences. Vue's server renderer emits a trailing `;` after the last
+ * style declaration (`style="height:48px;"`) while React omits it; both
+ * serialize to identical CSS, so we strip the trailing `;` before
+ * comparing.
+ */
+function domNormalize(html: string): string {
+    const wrapper = document.createElement('div');
+
+    wrapper.innerHTML = html;
+
+    return normalizeHtml(wrapper.innerHTML).replace(
+        /(style="[^"]*?);"/g,
+        '$1"'
+    );
+}
+
+const FIXTURES: Array<{ name: string; tree: Block[] }> = [
+    {
+        name: 'paragraph',
+        tree: [makeBlock('core/paragraph', { content: 'Hello <strong>world</strong>' }, [], 'p1')],
+    },
+    {
+        name: 'heading with alignment',
+        tree: [
+            makeBlock(
+                'core/heading',
+                { level: 3, textAlign: 'center', content: 'Section' },
+                [],
+                'h1'
+            ),
+        ],
+    },
+    {
+        name: 'code + preformatted + verse',
+        tree: [
+            makeBlock('core/code', { content: 'echo 1;' }, [], 'c1'),
+            makeBlock('core/preformatted', { content: 'line 1\nline 2' }, [], 'pre1'),
+            makeBlock('core/verse', { content: 'Roses are red', textAlign: 'right' }, [], 'v1'),
+        ],
+    },
+    {
+        name: 'quote with citation',
+        tree: [
+            makeBlock(
+                'core/quote',
+                { citation: 'Someone' },
+                [makeBlock('core/paragraph', { content: 'Quoted' }, [], 'p1')],
+                'q1'
+            ),
+        ],
+    },
+    {
+        name: 'pullquote',
+        tree: [
+            makeBlock(
+                'core/pullquote',
+                { value: 'Be bold', citation: 'Editor' },
+                [],
+                'pq1'
+            ),
+        ],
+    },
+    {
+        name: 'unordered list',
+        tree: [
+            makeBlock(
+                'core/list',
+                { ordered: false },
+                [
+                    makeBlock('core/list-item', { content: 'One' }, [], 'li-1'),
+                    makeBlock('core/list-item', { content: 'Two' }, [], 'li-2'),
+                ],
+                'list-1'
+            ),
+        ],
+    },
+    {
+        name: 'ordered list with start + reversed',
+        tree: [
+            makeBlock(
+                'core/list',
+                { ordered: true, start: 5, reversed: true },
+                [makeBlock('core/list-item', { content: 'A' }, [], 'li-1')],
+                'list-2'
+            ),
+        ],
+    },
+    {
+        name: 'image with caption + link',
+        tree: [
+            makeBlock(
+                'core/image',
+                {
+                    url: 'https://example.test/image.jpg',
+                    alt: 'An image',
+                    caption: 'A <em>caption</em>',
+                    href: 'https://example.test/full.jpg',
+                    id: 42,
+                    width: 800,
+                    height: 600,
+                },
+                [],
+                'img-1'
+            ),
+        ],
+    },
+    {
+        name: 'gallery',
+        tree: [
+            makeBlock(
+                'core/gallery',
+                { columns: 3, imageCrop: true },
+                [
+                    makeBlock(
+                        'core/image',
+                        { url: 'https://example.test/a.jpg', alt: 'a' },
+                        [],
+                        'img-a'
+                    ),
+                    makeBlock(
+                        'core/image',
+                        { url: 'https://example.test/b.jpg', alt: 'b' },
+                        [],
+                        'img-b'
+                    ),
+                ],
+                'gal-1'
+            ),
+        ],
+    },
+    {
+        name: 'embed',
+        tree: [
+            makeBlock(
+                'core/embed',
+                {
+                    url: 'https://youtu.be/abc123',
+                    providerNameSlug: 'youtube',
+                    aspectRatio: '16/9',
+                    type: 'video',
+                },
+                [],
+                'emb-1'
+            ),
+        ],
+    },
+    {
+        name: 'file',
+        tree: [
+            makeBlock(
+                'core/file',
+                {
+                    href: 'https://example.test/doc.pdf',
+                    fileName: 'doc.pdf',
+                    downloadButtonText: 'Download PDF',
+                },
+                [],
+                'file-1'
+            ),
+        ],
+    },
+    {
+        name: 'group with inner paragraph',
+        tree: [
+            makeBlock(
+                'core/group',
+                {},
+                [makeBlock('core/paragraph', { content: 'Inner' }, [], 'p1')],
+                'g1'
+            ),
+        ],
+    },
+    {
+        name: 'row / stack containers',
+        tree: [
+            makeBlock(
+                'core/row',
+                {},
+                [makeBlock('core/paragraph', { content: 'Row' }, [], 'rp')],
+                'r1'
+            ),
+            makeBlock(
+                'core/stack',
+                {},
+                [makeBlock('core/paragraph', { content: 'Stacked' }, [], 'sp')],
+                's1'
+            ),
+        ],
+    },
+    {
+        name: 'columns with widths',
+        tree: [
+            makeBlock(
+                'core/columns',
+                {},
+                [
+                    makeBlock(
+                        'core/column',
+                        { width: 60 },
+                        [makeBlock('core/paragraph', { content: 'Left' }, [], 'lp')],
+                        'col-1'
+                    ),
+                    makeBlock(
+                        'core/column',
+                        {},
+                        [makeBlock('core/paragraph', { content: 'Right' }, [], 'rp')],
+                        'col-2'
+                    ),
+                ],
+                'cols-1'
+            ),
+        ],
+    },
+    {
+        name: 'buttons + button (safe URL)',
+        tree: [
+            makeBlock(
+                'core/buttons',
+                { layout: { justifyContent: 'center' } },
+                [
+                    makeBlock(
+                        'core/button',
+                        {
+                            text: 'Go',
+                            url: 'https://example.com',
+                            linkTarget: '_blank',
+                        },
+                        [],
+                        'b1'
+                    ),
+                ],
+                'btns-1'
+            ),
+        ],
+    },
+    {
+        name: 'button with unsafe URL',
+        tree: [
+            makeBlock(
+                'core/button',
+                { text: 'Click', url: 'javascript:alert(1)' },
+                [],
+                'b-evil'
+            ),
+        ],
+    },
+    {
+        name: 'separator',
+        tree: [makeBlock('core/separator', { style: 'wide' }, [], 'sep-1')],
+    },
+    {
+        name: 'spacer',
+        tree: [makeBlock('core/spacer', { height: 48 }, [], 'sp-1')],
+    },
+    {
+        name: 'cover with clamp + inner container',
+        tree: [
+            makeBlock(
+                'core/cover',
+                {
+                    url: 'https://example.test/bg.jpg',
+                    dimRatio: 60,
+                    minHeight: 40,
+                    minHeightUnit: 'vh',
+                },
+                [makeBlock('core/paragraph', { content: 'Hero' }, [], 'hp')],
+                'cov-1'
+            ),
+        ],
+    },
+    {
+        name: 'media-text',
+        tree: [
+            makeBlock(
+                'core/media-text',
+                {
+                    mediaUrl: 'https://example.test/photo.jpg',
+                    mediaAlt: 'Photo',
+                    mediaPosition: 'right',
+                    mediaWidth: 30,
+                },
+                [makeBlock('core/paragraph', { content: 'Caption' }, [], 'cp')],
+                'mt-1'
+            ),
+        ],
+    },
+    {
+        name: 'details',
+        tree: [
+            makeBlock(
+                'core/details',
+                { summary: 'Click me', showContent: true },
+                [makeBlock('core/paragraph', { content: 'Hidden' }, [], 'p1')],
+                'det-1'
+            ),
+        ],
+    },
+    {
+        name: 'table with head + body',
+        tree: [
+            makeBlock(
+                'core/table',
+                {
+                    caption: 'Data',
+                    head: [{ cells: [{ content: 'Name', tag: 'th', align: 'left' }] }],
+                    body: [{ cells: [{ content: 'Alice', tag: 'td', align: 'center' }] }],
+                },
+                [],
+                'tbl-1'
+            ),
+        ],
+    },
+];
+
+describe('React/Vue renderer parity', () => {
+    it.each(FIXTURES)('produces identical HTML for $name', async ({ tree }) => {
+        const reactHtml = renderReact(tree);
+        const vueHtml = await renderVue(tree);
+
+        expect(vueHtml).toBe(reactHtml);
+    });
+});

--- a/packages/visual-editor-renderer-vue/tests/registry.test.ts
+++ b/packages/visual-editor-renderer-vue/tests/registry.test.ts
@@ -1,0 +1,73 @@
+import { defineComponent, h } from 'vue';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+    getBlockRenderer,
+    getRegisteredBlockNames,
+    hasBlockRenderer,
+    registerBlockRenderer,
+    resetBlockRegistry,
+    unregisterBlockRenderer,
+} from '../src/registry';
+import { registerCoreBlocks } from '../src/blocks/registerCoreBlocks';
+
+const noopRenderer = defineComponent({
+    name: 'NoopRenderer',
+    setup() {
+        return () => h('div');
+    },
+});
+
+afterEach(() => {
+    resetBlockRegistry();
+    registerCoreBlocks();
+});
+
+describe('registerBlockRenderer', () => {
+    it('rejects empty block names', () => {
+        expect(() => registerBlockRenderer('   ', noopRenderer)).toThrow(/name cannot be empty/);
+    });
+
+    it('trims whitespace in block names', () => {
+        registerBlockRenderer('  acme/trimmed  ', noopRenderer);
+
+        expect(getBlockRenderer('acme/trimmed')).toBe(noopRenderer);
+        expect(hasBlockRenderer('acme/trimmed')).toBe(true);
+    });
+
+    it('overrides an existing renderer registration', () => {
+        const first = defineComponent({
+            setup() {
+                return () => h('div');
+            },
+        });
+        const second = defineComponent({
+            setup() {
+                return () => h('div');
+            },
+        });
+
+        registerBlockRenderer('acme/replace', first);
+        registerBlockRenderer('acme/replace', second);
+
+        expect(getBlockRenderer('acme/replace')).toBe(second);
+    });
+
+    it('includes every core block after registerCoreBlocks', () => {
+        const names = getRegisteredBlockNames();
+
+        expect(names).toContain('core/paragraph');
+        expect(names).toContain('core/heading');
+        expect(names).toContain('core/image');
+        expect(names).toContain('core/button');
+        expect(names).toContain('core/cover');
+        expect(names).toContain('core/separator');
+    });
+
+    it('allows unregistering a renderer', () => {
+        registerBlockRenderer('acme/temp', noopRenderer);
+        expect(hasBlockRenderer('acme/temp')).toBe(true);
+
+        unregisterBlockRenderer('acme/temp');
+        expect(hasBlockRenderer('acme/temp')).toBe(false);
+    });
+});

--- a/packages/visual-editor-renderer-vue/tests/urlSanitizer.test.ts
+++ b/packages/visual-editor-renderer-vue/tests/urlSanitizer.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { safeUrl } from '../src/support/urlSanitizer';
+
+describe('safeUrl', () => {
+    it('returns an empty string for non-string input', () => {
+        expect(safeUrl(42)).toBe('');
+        expect(safeUrl(null)).toBe('');
+        expect(safeUrl(undefined)).toBe('');
+        expect(safeUrl({})).toBe('');
+    });
+
+    it('returns an empty string for blank input', () => {
+        expect(safeUrl('')).toBe('');
+        expect(safeUrl('   ')).toBe('');
+    });
+
+    it('passes relative URLs through unchanged', () => {
+        expect(safeUrl('/page')).toBe('/page');
+        expect(safeUrl('foo/bar')).toBe('foo/bar');
+        expect(safeUrl('#anchor')).toBe('#anchor');
+    });
+
+    it('allows http, https, mailto, tel, ftp, and sms schemes', () => {
+        expect(safeUrl('https://example.test')).toBe('https://example.test');
+        expect(safeUrl('http://example.test')).toBe('http://example.test');
+        expect(safeUrl('mailto:me@example.test')).toBe('mailto:me@example.test');
+        expect(safeUrl('tel:+15555551212')).toBe('tel:+15555551212');
+        expect(safeUrl('ftp://example.test/file.zip')).toBe('ftp://example.test/file.zip');
+        expect(safeUrl('sms:+15555551212')).toBe('sms:+15555551212');
+    });
+
+    it('drops javascript, data, and vbscript schemes', () => {
+        expect(safeUrl('javascript:alert(1)')).toBe('');
+        expect(safeUrl('JAVASCRIPT:alert(1)')).toBe('');
+        expect(safeUrl('data:text/html,abc')).toBe('');
+        expect(safeUrl('vbscript:msgbox')).toBe('');
+    });
+});

--- a/packages/visual-editor-renderer-vue/tsconfig.json
+++ b/packages/visual-editor-renderer-vue/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "extends": "../../tsconfig.json",
+    "compilerOptions": {
+        "baseUrl": ".",
+        "jsx": "preserve",
+        "paths": {}
+    },
+    "include": [
+        "src/**/*",
+        "tests/**/*"
+    ],
+    "exclude": [
+        "node_modules",
+        "dist"
+    ]
+}


### PR DESCRIPTION
## Description

Ships `@artisanpack-ui/visual-editor-renderer-vue`, the Inertia+Vue counterpart to the M10 React renderer. `<BlockTree :tree="..." />` walks a saved block tree and renders it through per-core-block Vue components, with a `DynamicBlock` fallback that fetches server-rendered HTML from the preview endpoint for unregistered blocks. All 29 core blocks from the frozen V1 allow-list ship with a Vue component; consumers can register custom renderers or override core ones via the shared registry.

**Closes:** #321

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #321

## Motivation and Context

Required for users running Inertia+Vue. Mirrors the React renderer's API one-to-one so an app migrating between the two frameworks doesn't have to rewrite its renderer integration. Completes the trio of M9 (Blade), M10 (React), M11 (Vue) so Laravel apps on any of the three front-end stacks can render a persisted block tree.

## Changes Made

- New package at `packages/visual-editor-renderer-vue/` (scoped `@artisanpack-ui/visual-editor-renderer-vue`, Vue 3.3+ peer dep).
- `BlockTree`, `DynamicBlock`, `UnknownBlock` components + shared registry mirroring the React API.
- 29 core-block renderers across text / media / layout / design families, all matching the Blade and React output.
- URL sanitizer + attribute coercion helpers identical to the React renderer.
- Auto-registration of core blocks at package import time (consumers only have to import and render).
- Dev-app demo at `/packages/visual-editor/m11/post/{id}` rendering a saved post via Inertia+Vue (added `@inertiajs/vue3` as a dev dep, wired `main.ts` entry in `vite.config.js`, new `m11VuePreview` controller method + named route).
- README with usage + custom-renderer registration examples.
- `PACKAGING.md` sub-package table updated.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (Darwin 25.3.0)
- PHP Version: 8.4.3
- Project Version: visual-editor `release/1.0`

**Tests Performed:**
1. `npm test` — 430 tests pass, 1 skipped.
2. Vue package suite — 78 tests pass (43 `BlockTree` + 3 `DynamicBlock` + 5 registry + 5 urlSanitizer + **22 parity tests against the React renderer**).
3. `./vendor/bin/pest` — 136 passing, 322 assertions.
4. `npm run build` — dev-app bundle compiles cleanly with the new Vue demo entry point.
5. Manual verification of `/packages/visual-editor/m11/post/{id}` against the existing M9 Blade and M10 React preview pages — confirmed identical rendering.

## Accessibility Tests Run

- [ ] Keyboard navigation tested
- [ ] Screen reader tested
- [ ] Color contrast verified
- [ ] ARIA labels checked

**Details:**

Not applicable — this package emits zero styling and mirrors the Blade partial HTML contract byte-for-byte, so accessibility is inherited from the shared markup. The editor itself (M3–M8) owns the editing a11y story.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:**

- `tests/BlockTree.test.ts` — normalization, 29 core blocks, registry/dynamic fallback.
- `tests/DynamicBlock.test.ts` — happy path, 404 fallback, network error fallback.
- `tests/registry.test.ts` — validation + override behavior.
- `tests/urlSanitizer.test.ts` — scheme allow-list parity with the Blade `UrlSanitizer`.
- `tests/parity.test.ts` — **22 parity assertions** that render the same fixture through both `renderToStaticMarkup` (React) and `renderToString` (Vue SSR), normalize framework-level serialization differences, and assert byte-identical HTML. This is the "output verified identical to React renderer" acceptance criterion from the issue.

## Documentation

- [x] Inline code documentation added
- [x] README updated
- [ ] Wiki updated
- [ ] API documentation updated

**Documentation details:**

- `packages/visual-editor-renderer-vue/README.md` — installation, usage, custom-renderer registration, dynamic-block behavior, supported-core-blocks list, parity statement with the React renderer.
- `PACKAGING.md` — Vue sub-package row added to the table.

## Screenshots

N/A — markup mirrors the existing M9/M10 preview pages.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [ ] Accessibility tests completed
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Vue 3.3+ visual-editor renderer package with core text/media/layout/design block support, dynamic preview loading, block registry/registration API, and parity with the React renderer.

* **Documentation**
  * Added package README and updated sub-packages listing to include the Vue renderer.

* **Tests**
  * Added comprehensive tests covering rendering, dynamic loading, registry behavior, URL sanitization, and HTML parity with React.

* **Chores**
  * Added Vue testing dev-dependencies and package TypeScript config.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->