### PR TITLE
feat: wire block tree into Laravel Scout (M12 · #322)

### DIFF
--- a/src/Blocks/DynamicBlock.php
+++ b/src/Blocks/DynamicBlock.php
@@ -55,9 +55,11 @@ abstract class DynamicBlock
 	/**
 	 * Extract searchable text from the block's attributes.
 	 *
-	 * The default implementation walks all string attribute values and joins
-	 * them with a single space. Override per-block when the block persists
-	 * IDs, slugs, or other non-display data that should not leak into search.
+	 * The default is an empty string: dynamic blocks often persist IDs,
+	 * slugs, or foreign-key references that would pollute search if they
+	 * leaked into the index. Override per-block to emit just the text the
+	 * rendered block will show — for example, a `LatestPostsBlock` might
+	 * resolve its referenced posts at index time and return their titles.
 	 *
 	 * @since 1.0.0
 	 *
@@ -65,19 +67,7 @@ abstract class DynamicBlock
 	 */
 	public function searchableText( array $attrs ): string
 	{
-		$collected = [];
-
-		array_walk_recursive( $attrs, static function ( $value ) use ( &$collected ): void {
-			if ( is_string( $value ) ) {
-				$trimmed = trim( $value );
-
-				if ( '' !== $trimmed ) {
-					$collected[] = $trimmed;
-				}
-			}
-		} );
-
-		return implode( ' ', $collected );
+		return '';
 	}
 
 	/**

--- a/src/Concerns/HasBlockContent.php
+++ b/src/Concerns/HasBlockContent.php
@@ -5,9 +5,10 @@
  *
  * Opt-in trait that marks an Eloquent model as editable by the visual editor.
  * Declares the column that stores the block tree JSON and an optional scope
- * that the editor's REST controller applies when resolving models. Includes a
- * Scout hook stub (real implementation in M12) so consuming apps can start
- * using the trait today without needing the full search pipeline.
+ * that the editor's REST controller applies when resolving models. Also
+ * exposes a Scout helper — {@see self::toBlockContentSearchableArray()} — that
+ * renders the block tree to plain text so a host model's `toSearchableArray()`
+ * can index editor content alongside its own fields.
  *
  * @package    ArtisanPack_UI
  * @subpackage VisualEditor
@@ -21,6 +22,7 @@ declare( strict_types=1 );
 
 namespace ArtisanPackUI\VisualEditor\Concerns;
 
+use ArtisanPackUI\VisualEditor\Search\BlockTreeSearchExtractor;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\Builder;
 use InvalidArgumentException;
@@ -162,18 +164,42 @@ trait HasBlockContent
 	/**
 	 * Returns the Scout-indexable payload for block content.
 	 *
-	 * Stub for M12. Consuming apps that use Laravel Scout can override
-	 * `toSearchableArray()` on their model and call this helper to include a
-	 * plain-text rendering of the block tree once the Scout indexer lands.
+	 * Walks the saved block tree, joins the extracted text from every static
+	 * and dynamic block into a single string, and returns it keyed by
+	 * `block_content`. Host models merge this into their own
+	 * `toSearchableArray()` so editor-authored copy lands in the index
+	 * alongside their native columns:
+	 *
+	 *     public function toSearchableArray(): array
+	 *     {
+	 *         return array_merge(
+	 *             $this->only( ['title', 'excerpt'] ),
+	 *             $this->toBlockContentSearchableArray()
+	 *         );
+	 *     }
 	 *
 	 * @since 1.0.0
 	 *
-	 * @return array<string, mixed>
+	 * @return array<string, string>
 	 */
 	public function toBlockContentSearchableArray(): array
 	{
 		return [
-			'block_content' => $this->getBlockContent(),
+			'block_content' => $this->blockContentSearchableText(),
 		];
+	}
+
+	/**
+	 * Return the plain-text rendering of this model's block tree.
+	 *
+	 * Use when you need the raw string (e.g. to combine with a custom
+	 * separator or to pipe into a separate search field) without the
+	 * `block_content` array wrapper.
+	 *
+	 * @since 1.0.0
+	 */
+	public function blockContentSearchableText(): string
+	{
+		return app( BlockTreeSearchExtractor::class )->extract( $this->getBlockContent() );
 	}
 }

--- a/src/Search/BlockTreeSearchExtractor.php
+++ b/src/Search/BlockTreeSearchExtractor.php
@@ -1,0 +1,149 @@
+<?php
+
+/**
+ * Block tree searchable-text extractor.
+ *
+ * Walks a saved block tree and returns a single plain-text string suitable
+ * for indexing in Laravel Scout (or any other search engine). Static blocks
+ * contribute text from a fixed set of known attribute keys so URLs, IDs,
+ * and layout primitives never leak into the index. Dynamic blocks delegate
+ * to their own {@see DynamicBlock::searchableText()} implementation, which
+ * defaults to an empty string and must be overridden per block to opt in.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Search;
+
+use ArtisanPackUI\VisualEditor\Registries\DynamicBlockRegistry;
+
+class BlockTreeSearchExtractor
+{
+	/**
+	 * Attribute keys that hold human-readable text on static blocks.
+	 *
+	 * Deliberately narrow: restricting extraction to these keys keeps
+	 * class names, image URLs, element IDs, and other non-display strings
+	 * out of the search index without requiring each block to opt in.
+	 *
+	 * @var array<int, string>
+	 */
+	public const STATIC_TEXT_ATTRIBUTES = [ 'content', 'caption', 'alt', 'title' ];
+
+	public function __construct( protected DynamicBlockRegistry $registry ) {}
+
+	/**
+	 * Walk the given block tree and return a single space-separated string
+	 * of its extracted searchable text.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array<int, array<string, mixed>>  $blocks  The saved block tree.
+	 */
+	public function extract( array $blocks ): string
+	{
+		$parts = [];
+
+		$this->walk( $blocks, $parts );
+
+		return trim( implode( ' ', $parts ) );
+	}
+
+	/**
+	 * Recursively walk a block tree, appending each block's contribution to
+	 * the shared parts list.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array<int, mixed>  $blocks
+	 * @param  array<int, string>  $parts
+	 */
+	protected function walk( array $blocks, array &$parts ): void
+	{
+		foreach ( $blocks as $block ) {
+			if ( ! is_array( $block ) ) {
+				continue;
+			}
+
+			$name  = is_string( $block['name'] ?? null ) ? $block['name'] : '';
+			$attrs = is_array( $block['attributes'] ?? null ) ? $block['attributes'] : [];
+
+			if ( '' !== $name && $this->registry->has( $name ) ) {
+				$this->appendDynamic( $this->registry->get( $name ), $attrs, $parts );
+			} else {
+				$this->appendStatic( $attrs, $parts );
+			}
+
+			$inner = is_array( $block['innerBlocks'] ?? null ) ? $block['innerBlocks'] : [];
+
+			if ( [] !== $inner ) {
+				$this->walk( $inner, $parts );
+			}
+		}
+	}
+
+	/**
+	 * Append a dynamic block's contribution, catching exceptions so one
+	 * misbehaving block can't stop the entire model from being indexed.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  \ArtisanPackUI\VisualEditor\Blocks\DynamicBlock|null  $block
+	 * @param  array<string, mixed>  $attrs
+	 * @param  array<int, string>  $parts
+	 */
+	protected function appendDynamic( $block, array $attrs, array &$parts ): void
+	{
+		if ( null === $block ) {
+			return;
+		}
+
+		try {
+			$text = $block->searchableText( $attrs );
+		} catch ( \Throwable $e ) {
+			return;
+		}
+
+		$trimmed = trim( $text );
+
+		if ( '' !== $trimmed ) {
+			$parts[] = $trimmed;
+		}
+	}
+
+	/**
+	 * Append a static block's contribution by pulling known text attributes.
+	 *
+	 * Strips HTML tags so RichText-stored markup (e.g. a paragraph's
+	 * `<strong>` emphasis) contributes its text without dumping raw tags
+	 * into the search index.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array<string, mixed>  $attrs
+	 * @param  array<int, string>  $parts
+	 */
+	protected function appendStatic( array $attrs, array &$parts ): void
+	{
+		foreach ( self::STATIC_TEXT_ATTRIBUTES as $key ) {
+			$value = $attrs[ $key ] ?? null;
+
+			if ( ! is_string( $value ) ) {
+				continue;
+			}
+
+			$trimmed = trim( strip_tags( $value ) );
+
+			if ( '' !== $trimmed ) {
+				$parts[] = $trimmed;
+			}
+		}
+	}
+}

--- a/src/VisualEditorServiceProvider.php
+++ b/src/VisualEditorServiceProvider.php
@@ -7,6 +7,7 @@ use ArtisanPackUI\VisualEditor\Policies\VisualEditorPostPolicy;
 use ArtisanPackUI\VisualEditor\Registries\BlockTypeRegistry;
 use ArtisanPackUI\VisualEditor\Registries\DynamicBlockRegistry;
 use ArtisanPackUI\VisualEditor\Resources\ResourceResolver;
+use ArtisanPackUI\VisualEditor\Search\BlockTreeSearchExtractor;
 use ArtisanPackUI\VisualEditor\View\Components\VisualEditorComponent;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Gate;
@@ -35,6 +36,12 @@ class VisualEditorServiceProvider extends ServiceProvider
 
 		$this->app->singleton( ResourceResolver::class, function () {
 			return new ResourceResolver();
+		} );
+
+		$this->app->singleton( BlockTreeSearchExtractor::class, function ( $app ) {
+			return new BlockTreeSearchExtractor(
+				$app->make( DynamicBlockRegistry::class )
+			);
 		} );
 
 		// Legacy alias for backward compatibility

--- a/tests/Feature/VisualEditor/ScoutIntegrationTest.php
+++ b/tests/Feature/VisualEditor/ScoutIntegrationTest.php
@@ -1,0 +1,182 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Blocks\DynamicBlock;
+use ArtisanPackUI\VisualEditor\Facades\VisualEditor;
+use Tests\Fixtures\TestBlockContentModel;
+
+it( 'merges block content text with a model\'s own searchable fields', function () {
+	$searchable = new class extends TestBlockContentModel {
+		protected $table = 'test_block_content_models';
+
+		/**
+		 * Mirrors the pattern a Scout-backed model would use: merge
+		 * HasBlockContent's plain-text output with the model's native
+		 * columns so both are indexed under a single record.
+		 *
+		 * @return array<string, mixed>
+		 */
+		public function toSearchableArray(): array
+		{
+			return array_merge(
+				[ 'title' => $this->title ],
+				$this->toBlockContentSearchableArray()
+			);
+		}
+	};
+
+	$model = $searchable::create( [
+		'title'   => 'Release Notes',
+		'status'  => 'published',
+		'content' => [
+			[
+				'clientId'    => 'h',
+				'name'        => 'core/heading',
+				'attributes'  => [ 'content' => 'Whats new in 1.0' ],
+				'innerBlocks' => [],
+			],
+			[
+				'clientId'    => 'p',
+				'name'        => 'core/paragraph',
+				'attributes'  => [ 'content' => 'Ships search extraction today.' ],
+				'innerBlocks' => [],
+			],
+		],
+	] );
+
+	expect( $model->toSearchableArray() )->toBe( [
+		'title'         => 'Release Notes',
+		'block_content' => 'Whats new in 1.0 Ships search extraction today.',
+	] );
+} );
+
+it( 'resolves dynamic block data at index time', function () {
+	$products = [
+		1 => 'Eloquent T-Shirt',
+		2 => 'Blade Coffee Mug',
+		3 => 'Livewire Notebook',
+	];
+
+	$block = new class ( $products ) extends DynamicBlock {
+		/**
+		 * @param  array<int, string>  $catalog
+		 */
+		public function __construct( protected array $catalog ) {}
+
+		public function name(): string
+		{
+			return 'acme/latest-products';
+		}
+
+		public function render( array $attrs ): string
+		{
+			return '';
+		}
+
+		public function searchableText( array $attrs ): string
+		{
+			$ids   = is_array( $attrs['productIds'] ?? null ) ? $attrs['productIds'] : [];
+			$names = [];
+
+			foreach ( $ids as $id ) {
+				if ( isset( $this->catalog[ $id ] ) ) {
+					$names[] = $this->catalog[ $id ];
+				}
+			}
+
+			return implode( ' ', $names );
+		}
+	};
+
+	VisualEditor::registerDynamicBlock( $block );
+
+	$model = TestBlockContentModel::create( [
+		'title'   => 'Store Front',
+		'status'  => 'published',
+		'content' => [
+			[
+				'clientId'    => 'intro',
+				'name'        => 'core/paragraph',
+				'attributes'  => [ 'content' => 'Our current picks:' ],
+				'innerBlocks' => [],
+			],
+			[
+				'clientId'    => 'latest',
+				'name'        => 'acme/latest-products',
+				'attributes'  => [ 'productIds' => [ 1, 3 ] ],
+				'innerBlocks' => [],
+			],
+		],
+	] );
+
+	$text = $model->blockContentSearchableText();
+
+	expect( $text )->toBe( 'Our current picks: Eloquent T-Shirt Livewire Notebook' )
+		->and( $text )->toContain( 'Eloquent T-Shirt' )
+		->and( $text )->toContain( 'Livewire Notebook' )
+		->and( $text )->not->toContain( 'Blade Coffee Mug' );
+} );
+
+it( 'reflects updated dynamic data on the next index call', function () {
+	$products = [
+		1 => 'Original Name',
+	];
+
+	$block = new class ( $products ) extends DynamicBlock {
+		/**
+		 * @param  array<int, string>  $catalog
+		 */
+		public function __construct( protected array $catalog ) {}
+
+		public function name(): string
+		{
+			return 'acme/latest-products';
+		}
+
+		public function render( array $attrs ): string
+		{
+			return '';
+		}
+
+		public function updateCatalog( int $id, string $name ): void
+		{
+			$this->catalog[ $id ] = $name;
+		}
+
+		public function searchableText( array $attrs ): string
+		{
+			$ids   = is_array( $attrs['productIds'] ?? null ) ? $attrs['productIds'] : [];
+			$names = [];
+
+			foreach ( $ids as $id ) {
+				if ( isset( $this->catalog[ $id ] ) ) {
+					$names[] = $this->catalog[ $id ];
+				}
+			}
+
+			return implode( ' ', $names );
+		}
+	};
+
+	VisualEditor::registerDynamicBlock( $block );
+
+	$model = TestBlockContentModel::create( [
+		'title'   => 'Rename Demo',
+		'status'  => 'published',
+		'content' => [
+			[
+				'clientId'    => 'latest',
+				'name'        => 'acme/latest-products',
+				'attributes'  => [ 'productIds' => [ 1 ] ],
+				'innerBlocks' => [],
+			],
+		],
+	] );
+
+	expect( $model->blockContentSearchableText() )->toBe( 'Original Name' );
+
+	$block->updateCatalog( 1, 'Renamed Product' );
+
+	expect( $model->blockContentSearchableText() )->toBe( 'Renamed Product' );
+} );

--- a/tests/Unit/VisualEditor/HasBlockContentTest.php
+++ b/tests/Unit/VisualEditor/HasBlockContentTest.php
@@ -153,7 +153,7 @@ it( 'throws when the configured scope method does not exist on the model', funct
 		->toThrow( InvalidArgumentException::class );
 } );
 
-it( 'emits a searchable array stub for Scout integration', function () {
+it( 'emits extracted searchable text in the Scout integration array', function () {
 	$model = TestBlockContentModel::create( [
 		'title'   => 'Searchable',
 		'status'  => 'published',
@@ -163,8 +163,6 @@ it( 'emits a searchable array stub for Scout integration', function () {
 	] );
 
 	expect( $model->toBlockContentSearchableArray() )->toEqual( [
-		'block_content' => [
-			[ 'clientId' => 'x', 'name' => 'core/paragraph', 'attributes' => ['content' => 'Hello'], 'innerBlocks' => [] ],
-		],
+		'block_content' => 'Hello',
 	] );
 } );

--- a/tests/Unit/VisualEditor/RegisterDynamicBlockTest.php
+++ b/tests/Unit/VisualEditor/RegisterDynamicBlockTest.php
@@ -87,7 +87,7 @@ it( 'rejects a class that does not extend DynamicBlock', function () {
 	VisualEditor::registerDynamicBlock( \stdClass::class );
 } )->throws( InvalidArgumentException::class, 'must extend' );
 
-it( 'walks attrs to build default searchable text', function () {
+it( 'returns an empty string from the default searchableText()', function () {
 	$block = new class extends DynamicBlock {
 		public function name(): string
 		{
@@ -105,5 +105,5 @@ it( 'walks attrs to build default searchable text', function () {
 		'nested' => [ 'line' => 'World', 'ignored' => 42 ],
 	] );
 
-	expect( $text )->toBe( 'Hello World' );
+	expect( $text )->toBe( '' );
 } );

--- a/tests/Unit/VisualEditor/Search/BlockTreeSearchExtractorTest.php
+++ b/tests/Unit/VisualEditor/Search/BlockTreeSearchExtractorTest.php
@@ -1,0 +1,269 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Blocks\DynamicBlock;
+use ArtisanPackUI\VisualEditor\Facades\VisualEditor;
+use ArtisanPackUI\VisualEditor\Search\BlockTreeSearchExtractor;
+
+it( 'extracts text from known static attribute keys only', function () {
+	$tree = [
+		[
+			'clientId'    => 'a',
+			'name'        => 'core/paragraph',
+			'attributes'  => [
+				'content'    => 'Hello world',
+				'dropCap'    => true,
+				'className'  => 'my-class',
+				'anchor'     => 'section-1',
+			],
+			'innerBlocks' => [],
+		],
+	];
+
+	$extracted = app( BlockTreeSearchExtractor::class )->extract( $tree );
+
+	expect( $extracted )->toBe( 'Hello world' );
+} );
+
+it( 'extracts caption, alt, and title on an image block', function () {
+	$tree = [
+		[
+			'clientId'    => 'img',
+			'name'        => 'core/image',
+			'attributes'  => [
+				'url'     => 'https://example.test/cat.jpg',
+				'alt'     => 'A sleeping cat',
+				'caption' => 'Our cat Felix napping',
+				'title'   => 'Felix',
+			],
+			'innerBlocks' => [],
+		],
+	];
+
+	$extracted = app( BlockTreeSearchExtractor::class )->extract( $tree );
+
+	expect( $extracted )->toBe( 'Our cat Felix napping A sleeping cat Felix' );
+} );
+
+it( 'strips HTML tags from RichText content', function () {
+	$tree = [
+		[
+			'clientId'    => 'p',
+			'name'        => 'core/paragraph',
+			'attributes'  => [ 'content' => 'Hello <strong>brave</strong> <em>world</em>' ],
+			'innerBlocks' => [],
+		],
+	];
+
+	$extracted = app( BlockTreeSearchExtractor::class )->extract( $tree );
+
+	expect( $extracted )->toBe( 'Hello brave world' );
+} );
+
+it( 'recurses into innerBlocks', function () {
+	$tree = [
+		[
+			'clientId'    => 'group',
+			'name'        => 'core/group',
+			'attributes'  => [],
+			'innerBlocks' => [
+				[
+					'clientId'    => 'heading',
+					'name'        => 'core/heading',
+					'attributes'  => [ 'content' => 'A Heading' ],
+					'innerBlocks' => [],
+				],
+				[
+					'clientId'    => 'paragraph',
+					'name'        => 'core/paragraph',
+					'attributes'  => [ 'content' => 'A paragraph.' ],
+					'innerBlocks' => [],
+				],
+			],
+		],
+	];
+
+	$extracted = app( BlockTreeSearchExtractor::class )->extract( $tree );
+
+	expect( $extracted )->toBe( 'A Heading A paragraph.' );
+} );
+
+it( 'delegates to DynamicBlock::searchableText() for registered dynamic blocks', function () {
+	$block = new class extends DynamicBlock {
+		public function name(): string
+		{
+			return 'acme/latest-products';
+		}
+
+		public function render( array $attrs ): string
+		{
+			return '';
+		}
+
+		public function searchableText( array $attrs ): string
+		{
+			return 'Product Alpha Product Beta';
+		}
+	};
+
+	VisualEditor::registerDynamicBlock( $block );
+
+	$tree = [
+		[
+			'clientId'    => 'latest',
+			'name'        => 'acme/latest-products',
+			'attributes'  => [ 'productIds' => [ 1, 2, 3 ] ],
+			'innerBlocks' => [],
+		],
+	];
+
+	$extracted = app( BlockTreeSearchExtractor::class )->extract( $tree );
+
+	expect( $extracted )->toBe( 'Product Alpha Product Beta' );
+} );
+
+it( 'returns empty string for a dynamic block that has not overridden searchableText()', function () {
+	$block = new class extends DynamicBlock {
+		public function name(): string
+		{
+			return 'acme/silent';
+		}
+
+		public function render( array $attrs ): string
+		{
+			return '';
+		}
+	};
+
+	VisualEditor::registerDynamicBlock( $block );
+
+	$tree = [
+		[
+			'clientId'    => 's',
+			'name'        => 'acme/silent',
+			'attributes'  => [ 'content' => 'This should not leak' ],
+			'innerBlocks' => [],
+		],
+	];
+
+	$extracted = app( BlockTreeSearchExtractor::class )->extract( $tree );
+
+	expect( $extracted )->toBe( '' );
+} );
+
+it( 'combines static and dynamic block contributions in tree order', function () {
+	VisualEditor::registerDynamicBlock( 'acme/shoutout', [
+		'render'         => static fn ( array $attrs ): string => '',
+		'searchableText' => static fn ( array $attrs ): string => 'Partner spotlight',
+	] );
+
+	$tree = [
+		[
+			'clientId'    => 'p1',
+			'name'        => 'core/paragraph',
+			'attributes'  => [ 'content' => 'Intro copy.' ],
+			'innerBlocks' => [],
+		],
+		[
+			'clientId'    => 'shout',
+			'name'        => 'acme/shoutout',
+			'attributes'  => [ 'partnerId' => 42 ],
+			'innerBlocks' => [],
+		],
+		[
+			'clientId'    => 'p2',
+			'name'        => 'core/paragraph',
+			'attributes'  => [ 'content' => 'Outro copy.' ],
+			'innerBlocks' => [],
+		],
+	];
+
+	$extracted = app( BlockTreeSearchExtractor::class )->extract( $tree );
+
+	expect( $extracted )->toBe( 'Intro copy. Partner spotlight Outro copy.' );
+} );
+
+it( 'walks innerBlocks even when the parent is a dynamic block', function () {
+	VisualEditor::registerDynamicBlock( 'acme/wrapper', [
+		'render'         => static fn ( array $attrs ): string => '',
+		'searchableText' => static fn ( array $attrs ): string => 'Wrapper label',
+	] );
+
+	$tree = [
+		[
+			'clientId'    => 'wrap',
+			'name'        => 'acme/wrapper',
+			'attributes'  => [],
+			'innerBlocks' => [
+				[
+					'clientId'    => 'inner',
+					'name'        => 'core/paragraph',
+					'attributes'  => [ 'content' => 'Inner paragraph text.' ],
+					'innerBlocks' => [],
+				],
+			],
+		],
+	];
+
+	$extracted = app( BlockTreeSearchExtractor::class )->extract( $tree );
+
+	expect( $extracted )->toBe( 'Wrapper label Inner paragraph text.' );
+} );
+
+it( 'returns an empty string for an empty tree', function () {
+	$extracted = app( BlockTreeSearchExtractor::class )->extract( [] );
+
+	expect( $extracted )->toBe( '' );
+} );
+
+it( 'skips malformed entries instead of throwing', function () {
+	$tree = [
+		'not-an-array',
+		[
+			'clientId'    => 'p',
+			'name'        => 'core/paragraph',
+			'attributes'  => [ 'content' => 'Valid text.' ],
+			'innerBlocks' => [],
+		],
+		[ 'name' => 'core/paragraph' ],
+	];
+
+	$extracted = app( BlockTreeSearchExtractor::class )->extract( $tree );
+
+	expect( $extracted )->toBe( 'Valid text.' );
+} );
+
+it( 'swallows exceptions thrown by a dynamic block extractor', function () {
+	VisualEditor::registerDynamicBlock( 'acme/broken', [
+		'render'         => static fn ( array $attrs ): string => '',
+		'searchableText' => static function ( array $attrs ): string {
+			throw new RuntimeException( 'boom' );
+		},
+	] );
+
+	$tree = [
+		[
+			'clientId'    => 'ok',
+			'name'        => 'core/paragraph',
+			'attributes'  => [ 'content' => 'Before' ],
+			'innerBlocks' => [],
+		],
+		[
+			'clientId'    => 'bad',
+			'name'        => 'acme/broken',
+			'attributes'  => [],
+			'innerBlocks' => [],
+		],
+		[
+			'clientId'    => 'ok2',
+			'name'        => 'core/paragraph',
+			'attributes'  => [ 'content' => 'After' ],
+			'innerBlocks' => [],
+		],
+	];
+
+	$extracted = app( BlockTreeSearchExtractor::class )->extract( $tree );
+
+	expect( $extracted )->toBe( 'Before After' );
+} );


### PR DESCRIPTION
## Description

Implements M12 of the Gutenberg adoption roadmap: searchable-text extraction from the block tree, wired up so host apps using Laravel Scout get editor-authored content indexed alongside their native columns.

**Closes:** #322

## Type of Change

- [x] New feature (adds new functionality)
- [ ] Breaking change (breaks backward compatibility) — see caveat below

## Related Issue

**Issue:** #322

## Motivation and Context

Search is a V1 blocker — without this, published content is invisible to the host app's search engine. Scout is the integration point; the driver (Meilisearch, Typesense, Algolia, database) is the host app's choice.

## Changes Made

- **New `BlockTreeSearchExtractor`** (`src/Search/`) — walks a saved block tree (including `innerBlocks`), extracts text from static blocks via a fixed allowlist (`content`, `caption`, `alt`, `title`) with HTML tags stripped, and delegates dynamic blocks to their `searchableText()` method. Exceptions from a single dynamic block are caught so a bad block can't block indexing of the entire model.
- **`DynamicBlock::searchableText()` default is now `''`** — subclasses must opt in. Previously the default walked every string attribute, which leaked foreign-key IDs and slugs.
- **`HasBlockContent::toBlockContentSearchableArray()`** now returns `['block_content' => <plain text>]` (was raw tree). Docblock documents the `array_merge()` pattern host models use inside their own `toSearchableArray()`.
- **New `blockContentSearchableText()`** helper returns just the string for callers that want to combine with custom separators or a distinct search field.
- Service provider registers `BlockTreeSearchExtractor` as a container singleton.

Scout's own `ModelObserver` (via the `Searchable` trait) handles reindex-on-save automatically — no additional observer in this package.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS 15
- PHP Version: 8.4.3
- Project Version: release/1.0

**Tests Performed:**
1. Full package test suite: 150 passed / 340 assertions (was 136; +14 new).
2. Walker correctness across static/dynamic/mixed trees with `innerBlocks` recursion.
3. End-to-end integration test showing a dynamic block resolving live data at index time and reflecting updates on the next call.

## Accessibility Tests Run

- [x] N/A — backend-only change; no UI.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:**
- `tests/Unit/VisualEditor/Search/BlockTreeSearchExtractorTest.php` — 11 cases covering allowlist filtering, HTML stripping, innerBlocks recursion, dynamic delegation, empty-override behavior, tree-order combination, empty trees, malformed entries, and exception safety.
- `tests/Feature/VisualEditor/ScoutIntegrationTest.php` — 3 cases covering the `toSearchableArray()` merge pattern, live dynamic-data resolution, and re-index freshness after underlying data changes.
- Updated `HasBlockContentTest` and `RegisterDynamicBlockTest` expectations to match the new Scout array shape and empty-default.

## Documentation

- [x] Inline code documentation added (class, method, and trait docblocks)
- [ ] README updated — deferred; the M15 docs pass (`#325`) covers public-facing copy.

## Caveats for review

- **Behavior change**: `DynamicBlock::searchableText()` default changed from "walk every string attribute" to `''`. Existing consumers that relied on the walking behavior need to override `searchableText()` explicitly — this is the deliberate opt-in model called out in the issue's acceptance criteria.
- **Shape change**: `toBlockContentSearchableArray()` now returns `['block_content' => string]` instead of `['block_content' => array]`. Any caller that was treating the old stub as-is will need to adjust, though the old stub was explicitly documented as a placeholder for M12.

## Pre-Submission Checklist

- [x] Code passes all tests
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced search indexing for visual editor blocks to extract searchable text from block content.
  * Search indexes now capture text from common block attributes (content, captions, titles, alt text).
  * Dynamic blocks contribute only explicitly defined searchable content to search results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->