### PR TITLE
feat: M13 · Livewire bridge docs + editor CustomEvent contract

### DIFF
--- a/docs/livewire.md
+++ b/docs/livewire.md
@@ -1,0 +1,109 @@
+# Livewire embedding recipe
+
+The visual editor ships as a self-contained React app, so Livewire can't
+render it directly. Instead, mount it inside `wire:ignore` and bridge
+editor activity back to the component with three browser events.
+
+## 1. Render the editor inside `wire:ignore`
+
+`wire:ignore` tells Livewire to leave the mount point alone during DOM
+diffs. Without it, Livewire's morph would wipe out the React tree on every
+`$wire` update.
+
+```blade
+<div>
+    <div
+        wire:ignore
+        @ve:editor:change.window="$wire.set('dirty', true)"
+        @ve:editor:autosave.window="$wire.handleAutosaved($event.detail)"
+        @ve:editor:save.window="$wire.handleSaved($event.detail)"
+    >
+        <x-visual-editor :model="$post" />
+    </div>
+
+    @if ($flash)
+        <div class="alert alert-success">{{ $flash }}</div>
+    @endif
+</div>
+```
+
+The `@ve:editor:*` attributes are Alpine listeners (Alpine ships with
+Livewire 3 by default). `.window` is required — the events are dispatched
+on `window`, not on the editor mount point.
+
+## 2. Receive the payload in the Livewire component
+
+```php
+use Livewire\Attributes\Locked;
+use Livewire\Component;
+
+class PostEditor extends Component
+{
+    #[Locked]
+    public int $postId;
+
+    public bool $dirty = false;
+
+    public ?string $lastSavedAt = null;
+
+    public ?string $flash = null;
+
+    /**
+     * @param  array{resource: string, id: string, blocks: array, updatedAt: ?string}  $detail
+     */
+    public function handleAutosaved(array $detail): void
+    {
+        $this->dirty = false;
+        $this->lastSavedAt = $detail['updatedAt'];
+    }
+
+    /**
+     * @param  array{resource: string, id: string, blocks: array, updatedAt: ?string}  $detail
+     */
+    public function handleSaved(array $detail): void
+    {
+        $this->dirty = false;
+        $this->lastSavedAt = $detail['updatedAt'];
+        $this->flash = __('Post saved at :time', ['time' => $detail['updatedAt']]);
+    }
+}
+```
+
+Each handler receives `$event.detail` — the typed `CustomEvent` payload
+documented below. Livewire serializes it as a PHP array, so type-hint with
+an array shape.
+
+## 3. Event contract
+
+Every event is dispatched on `window` as a `CustomEvent`. TypeScript hosts
+can `import { VE_EDITOR_SAVE, type VeEditorSaveDetail } from
+'@artisanpack-ui/visual-editor/editor'` to stay in sync.
+
+| Event | When it fires | `detail` shape |
+|-------|--------------|----------------|
+| `ve:editor:change` | Debounce window closes, right before the autosave request goes out. | `{ resource, id, blocks }` |
+| `ve:editor:autosave` | Debounce-triggered save returns `200`. | `{ resource, id, blocks, updatedAt }` |
+| `ve:editor:save` | Explicit save (⌘S / top-bar Save) returns `200`. | `{ resource, id, blocks, updatedAt }` |
+
+`resource` and `id` match the `data-resource` / `data-id` attributes the
+Blade component emits, so a single listener can disambiguate when multiple
+editors are mounted on the same page.
+
+## 4. Listening in plain JavaScript
+
+Outside Alpine — e.g. a vanilla Blade page with inline script:
+
+```html
+<script>
+    window.addEventListener('ve:editor:save', (event) => {
+        console.log('saved', event.detail.resource, event.detail.id, event.detail.updatedAt);
+    });
+</script>
+```
+
+## Working example
+
+The `artisanpack-ui` dev app ships a Volt component that wires all three
+events to live UI. See
+`resources/views/packages/visual-editor/m13-livewire-editor.blade.php`
+(route: `/packages/visual-editor/m13/livewire/post/{post}`).

--- a/resources/js/visual-editor/editor/__tests__/editor-events.test.tsx
+++ b/resources/js/visual-editor/editor/__tests__/editor-events.test.tsx
@@ -1,0 +1,276 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+    VE_EDITOR_AUTOSAVE,
+    VE_EDITOR_CHANGE,
+    VE_EDITOR_SAVE,
+    type VeEditorAutosaveDetail,
+    type VeEditorChangeDetail,
+    type VeEditorSaveDetail,
+} from '../editor-events';
+import { usePersistence } from '../use-persistence';
+
+const CONFIG = {
+    apiBase: '/visual-editor/api',
+    resource: 'posts',
+    id: '42',
+    debounceMs: 20,
+};
+
+function mockFetch(saveTimestamp: string): ReturnType<typeof vi.fn> {
+    const mock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const method = (init?.method ?? 'GET').toUpperCase();
+
+        if (method === 'GET') {
+            return new Response(
+                JSON.stringify({
+                    id: 42,
+                    resource: 'posts',
+                    blocks: [],
+                    updated_at: null,
+                }),
+                { status: 200, headers: { 'content-type': 'application/json' } }
+            );
+        }
+
+        return new Response(
+            JSON.stringify({
+                id: 42,
+                resource: 'posts',
+                blocks: [],
+                updated_at: saveTimestamp,
+            }),
+            { status: 200, headers: { 'content-type': 'application/json' } }
+        );
+    });
+
+    vi.stubGlobal('fetch', mock);
+    return mock;
+}
+
+interface CapturedEvent<Detail> {
+    name: string;
+    detail: Detail;
+}
+
+function captureEvents(): {
+    change: CapturedEvent<VeEditorChangeDetail>[];
+    autosave: CapturedEvent<VeEditorAutosaveDetail>[];
+    save: CapturedEvent<VeEditorSaveDetail>[];
+    cleanup: () => void;
+} {
+    const change: CapturedEvent<VeEditorChangeDetail>[] = [];
+    const autosave: CapturedEvent<VeEditorAutosaveDetail>[] = [];
+    const save: CapturedEvent<VeEditorSaveDetail>[] = [];
+
+    const onChange = (event: Event): void => {
+        change.push({
+            name: event.type,
+            detail: (event as CustomEvent<VeEditorChangeDetail>).detail,
+        });
+    };
+    const onAutosave = (event: Event): void => {
+        autosave.push({
+            name: event.type,
+            detail: (event as CustomEvent<VeEditorAutosaveDetail>).detail,
+        });
+    };
+    const onSave = (event: Event): void => {
+        save.push({
+            name: event.type,
+            detail: (event as CustomEvent<VeEditorSaveDetail>).detail,
+        });
+    };
+
+    window.addEventListener(VE_EDITOR_CHANGE, onChange);
+    window.addEventListener(VE_EDITOR_AUTOSAVE, onAutosave);
+    window.addEventListener(VE_EDITOR_SAVE, onSave);
+
+    return {
+        change,
+        autosave,
+        save,
+        cleanup: () => {
+            window.removeEventListener(VE_EDITOR_CHANGE, onChange);
+            window.removeEventListener(VE_EDITOR_AUTOSAVE, onAutosave);
+            window.removeEventListener(VE_EDITOR_SAVE, onSave);
+        },
+    };
+}
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
+
+describe('editor CustomEvents', () => {
+    it('exposes stable event name constants', () => {
+        expect(VE_EDITOR_CHANGE).toBe('ve:editor:change');
+        expect(VE_EDITOR_AUTOSAVE).toBe('ve:editor:autosave');
+        expect(VE_EDITOR_SAVE).toBe('ve:editor:save');
+    });
+
+    it('fires ve:editor:change once per debounce window with the pending block tree', async () => {
+        mockFetch('2026-04-20T10:00:00Z');
+        const events = captureEvents();
+
+        try {
+            const { result } = renderHook(() => usePersistence(CONFIG));
+
+            await waitFor(() => {
+                expect(result.current.loadStatus).toBe('ready');
+            });
+
+            act(() => {
+                result.current.onBlocksChange([
+                    { clientId: 'a', name: 'core/paragraph', attributes: {}, innerBlocks: [] } as never,
+                ]);
+                result.current.onBlocksChange([
+                    { clientId: 'b', name: 'core/paragraph', attributes: {}, innerBlocks: [] } as never,
+                ]);
+                result.current.onBlocksChange([
+                    { clientId: 'c', name: 'core/paragraph', attributes: {}, innerBlocks: [] } as never,
+                ]);
+            });
+
+            await waitFor(() => {
+                expect(events.change).toHaveLength(1);
+            });
+
+            const [firstChange] = events.change;
+
+            expect(firstChange?.detail).toEqual({
+                resource: 'posts',
+                id: '42',
+                blocks: [
+                    expect.objectContaining({ clientId: 'c', name: 'core/paragraph' }),
+                ],
+            });
+        } finally {
+            events.cleanup();
+        }
+    });
+
+    it('fires ve:editor:autosave after a debounced save completes', async () => {
+        mockFetch('2026-04-20T11:00:00Z');
+        const events = captureEvents();
+
+        try {
+            const { result } = renderHook(() => usePersistence(CONFIG));
+
+            await waitFor(() => {
+                expect(result.current.loadStatus).toBe('ready');
+            });
+
+            act(() => {
+                result.current.onBlocksChange([
+                    { clientId: 'auto', name: 'core/paragraph', attributes: {}, innerBlocks: [] } as never,
+                ]);
+            });
+
+            await waitFor(() => {
+                expect(events.autosave).toHaveLength(1);
+            });
+
+            expect(events.save).toHaveLength(0);
+            expect(events.autosave[0]?.detail).toEqual({
+                resource: 'posts',
+                id: '42',
+                blocks: [
+                    expect.objectContaining({ clientId: 'auto', name: 'core/paragraph' }),
+                ],
+                updatedAt: '2026-04-20T11:00:00Z',
+            });
+        } finally {
+            events.cleanup();
+        }
+    });
+
+    it('fires ve:editor:save — not ve:editor:autosave — when flush() is the trigger', async () => {
+        mockFetch('2026-04-20T12:00:00Z');
+        const events = captureEvents();
+
+        try {
+            const { result } = renderHook(() =>
+                usePersistence({ ...CONFIG, debounceMs: 5000 })
+            );
+
+            await waitFor(() => {
+                expect(result.current.loadStatus).toBe('ready');
+            });
+
+            act(() => {
+                result.current.onBlocksChange([
+                    { clientId: 'manual', name: 'core/paragraph', attributes: {}, innerBlocks: [] } as never,
+                ]);
+            });
+
+            act(() => {
+                result.current.flush();
+            });
+
+            await waitFor(() => {
+                expect(events.save).toHaveLength(1);
+            });
+
+            expect(events.autosave).toHaveLength(0);
+            expect(events.save[0]?.detail).toEqual({
+                resource: 'posts',
+                id: '42',
+                blocks: [
+                    expect.objectContaining({ clientId: 'manual', name: 'core/paragraph' }),
+                ],
+                updatedAt: '2026-04-20T12:00:00Z',
+            });
+        } finally {
+            events.cleanup();
+        }
+    });
+
+    it('does not fire save events when the request fails', async () => {
+        const mock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+            const method = (init?.method ?? 'GET').toUpperCase();
+
+            if (method === 'GET') {
+                return new Response(
+                    JSON.stringify({ id: 42, resource: 'posts', blocks: [], updated_at: null }),
+                    { status: 200, headers: { 'content-type': 'application/json' } }
+                );
+            }
+
+            return new Response(JSON.stringify({ message: 'nope' }), {
+                status: 422,
+                headers: { 'content-type': 'application/json' },
+            });
+        });
+        vi.stubGlobal('fetch', mock);
+
+        const events = captureEvents();
+
+        try {
+            const { result } = renderHook(() => usePersistence(CONFIG));
+
+            await waitFor(() => {
+                expect(result.current.loadStatus).toBe('ready');
+            });
+
+            act(() => {
+                result.current.onBlocksChange([
+                    { clientId: 'fail', name: 'core/paragraph', attributes: {}, innerBlocks: [] } as never,
+                ]);
+            });
+
+            await waitFor(() => {
+                expect(result.current.saveStatus).toBe('error');
+            });
+
+            expect(events.autosave).toHaveLength(0);
+            expect(events.save).toHaveLength(0);
+            // Change events still fire — they describe editing activity, not
+            // persistence. Hosts should reconcile them against saveStatus.
+            expect(events.change).toHaveLength(1);
+        } finally {
+            events.cleanup();
+        }
+    });
+});

--- a/resources/js/visual-editor/editor/editor-events.ts
+++ b/resources/js/visual-editor/editor/editor-events.ts
@@ -1,0 +1,87 @@
+/**
+ * Browser CustomEvent contract for the visual editor.
+ *
+ * The editor is a self-contained React app, but it's embedded inside host
+ * frameworks (Blade, Livewire, Inertia) that need a side-channel for
+ * reacting to editor activity without cracking open the React tree. The
+ * three events below are the public bridge — they're dispatched on
+ * `window` with a namespaced name so multiple editors and listeners can
+ * coexist.
+ *
+ * Event names use the `ve:editor:*` prefix (browser CustomEvents allow
+ * colons in their names). Host integrations listen with
+ * `window.addEventListener('ve:editor:save', ...)`, or — inside Alpine —
+ * `@ve:editor:save.window="..."`.
+ */
+
+import type { BlockInstance } from '@wordpress/blocks';
+
+export const VE_EDITOR_CHANGE = 've:editor:change';
+export const VE_EDITOR_AUTOSAVE = 've:editor:autosave';
+export const VE_EDITOR_SAVE = 've:editor:save';
+
+export interface EditorEventTarget {
+    /** Resource slug from `config/visual-editor.php`. */
+    resource: string;
+    /** Host-model primary key as a string (matches the Blade data attribute). */
+    id: string;
+}
+
+/**
+ * Fires after the debounce window closes and the editor is about to persist
+ * a new block tree. Use this for "unsaved changes" indicators that should
+ * react immediately, without waiting on the network round-trip.
+ */
+export interface VeEditorChangeDetail extends EditorEventTarget {
+    /** Snapshot of the block tree that's about to be saved. */
+    blocks: readonly BlockInstance[];
+}
+
+/**
+ * Fires when a debounce-triggered save completes successfully. Use this for
+ * host UI that should only react to *persisted* autosaves (e.g. a Livewire
+ * parent that mirrors `updated_at`).
+ */
+export interface VeEditorAutosaveDetail extends EditorEventTarget {
+    /** Block tree that was just persisted. */
+    blocks: readonly BlockInstance[];
+    /** ISO 8601 timestamp returned by the API. */
+    updatedAt: string | null;
+}
+
+/**
+ * Fires when an explicit user save (⌘S / the top-bar Save button) completes
+ * successfully. Semantically stronger than autosave — host apps typically
+ * treat this as the signal to publish, navigate away, or flash a toast.
+ */
+export interface VeEditorSaveDetail extends EditorEventTarget {
+    /** Block tree that was just persisted. */
+    blocks: readonly BlockInstance[];
+    /** ISO 8601 timestamp returned by the API. */
+    updatedAt: string | null;
+}
+
+export type VeEditorChangeEvent = CustomEvent<VeEditorChangeDetail>;
+export type VeEditorAutosaveEvent = CustomEvent<VeEditorAutosaveDetail>;
+export type VeEditorSaveEvent = CustomEvent<VeEditorSaveDetail>;
+
+type EventMap = {
+    [VE_EDITOR_CHANGE]: VeEditorChangeDetail;
+    [VE_EDITOR_AUTOSAVE]: VeEditorAutosaveDetail;
+    [VE_EDITOR_SAVE]: VeEditorSaveDetail;
+};
+
+/**
+ * Dispatches a typed CustomEvent on `window`. No-op when the document is
+ * unavailable (e.g. SSR, Vitest environments that skip the jsdom setup).
+ */
+export function dispatchEditorEvent<Name extends keyof EventMap>(
+    name: Name,
+    detail: EventMap[Name],
+): void {
+    if (typeof window === 'undefined') {
+        return;
+    }
+
+    window.dispatchEvent(new CustomEvent(name, { detail }));
+}

--- a/resources/js/visual-editor/editor/main.tsx
+++ b/resources/js/visual-editor/editor/main.tsx
@@ -21,6 +21,21 @@ export type {
     RegisterMediaBridgeOptions,
 } from '../media-bridge';
 
+export {
+    VE_EDITOR_AUTOSAVE,
+    VE_EDITOR_CHANGE,
+    VE_EDITOR_SAVE,
+} from './editor-events';
+export type {
+    EditorEventTarget,
+    VeEditorAutosaveDetail,
+    VeEditorAutosaveEvent,
+    VeEditorChangeDetail,
+    VeEditorChangeEvent,
+    VeEditorSaveDetail,
+    VeEditorSaveEvent,
+} from './editor-events';
+
 const MOUNT_SELECTOR = '[data-ap-visual-editor]';
 const ROOT_SYMBOL: unique symbol = Symbol('ap-visual-editor-root');
 

--- a/resources/js/visual-editor/editor/use-persistence.ts
+++ b/resources/js/visual-editor/editor/use-persistence.ts
@@ -16,9 +16,16 @@ import {
     saveContent,
     type ApiClientConfig,
 } from './api-client';
+import {
+    VE_EDITOR_AUTOSAVE,
+    VE_EDITOR_CHANGE,
+    VE_EDITOR_SAVE,
+    dispatchEditorEvent,
+} from './editor-events';
 
 type LoadStatus = 'loading' | 'ready' | 'error';
 type SaveStatus = 'idle' | 'saving' | 'saved' | 'error';
+type SaveTrigger = 'autosave' | 'save';
 
 export interface PersistenceState {
     blocks: BlockInstance[];
@@ -121,7 +128,7 @@ export function usePersistence(
     }, [apiBase, resource, id]);
 
     const runFlush = useCallback(
-        async function runFlush(): Promise<void> {
+        async function runFlush(trigger: SaveTrigger): Promise<void> {
             if (inFlightRef.current || unmountedRef.current) {
                 return;
             }
@@ -148,6 +155,16 @@ export function usePersistence(
 
                 setLastSavedAt(response.updated_at);
                 setSaveStatus('saved');
+
+                dispatchEditorEvent(
+                    trigger === 'save' ? VE_EDITOR_SAVE : VE_EDITOR_AUTOSAVE,
+                    {
+                        resource,
+                        id,
+                        blocks: next,
+                        updatedAt: response.updated_at,
+                    }
+                );
             } catch (error: unknown) {
                 if (unmountedRef.current || version !== targetVersionRef.current) {
                     return;
@@ -160,14 +177,16 @@ export function usePersistence(
             }
 
             // A change landed while the save was in flight — drain the
-            // trailing edit now so we don't lose it. Skip if the target
-            // changed during the save.
+            // trailing edit now so we don't lose it. Trailing drains always
+            // count as autosaves: they're reacting to buffered edits, not a
+            // fresh explicit Save press. Skip if the target changed during
+            // the save.
             if (
                 pendingRef.current !== null
                 && !unmountedRef.current
                 && version === targetVersionRef.current
             ) {
-                void runFlush();
+                void runFlush('autosave');
             }
         },
         [apiBase, resource, id]
@@ -189,10 +208,18 @@ export function usePersistence(
 
             timerRef.current = setTimeout(() => {
                 timerRef.current = null;
-                void runFlush();
+                // The change event is debounced: host listeners see one
+                // event per coalesced edit burst, timed with the autosave
+                // they're about to observe.
+                dispatchEditorEvent(VE_EDITOR_CHANGE, {
+                    resource,
+                    id,
+                    blocks: next,
+                });
+                void runFlush('autosave');
             }, debounceMs);
         },
-        [debounceMs, runFlush]
+        [debounceMs, id, resource, runFlush]
     );
 
     const flush = useCallback((): void => {
@@ -208,7 +235,7 @@ export function usePersistence(
             return;
         }
 
-        void runFlush();
+        void runFlush('save');
     }, [runFlush]);
 
     return {


### PR DESCRIPTION
## Description

Wire the visual editor to dispatch three typed browser CustomEvents so Livewire — and any other host framework — can react to editor activity without cracking open the React tree. Ship a copy-pasteable `docs/livewire.md` recipe around those events plus a working demo in the dev app.

**Closes:** #323

## Type of Change

- [x] New feature (adds new functionality)
- [x] Documentation update

## Related Issue

**Issue:** #323 (M13 of the Gutenberg adoption umbrella, #309)

## Motivation and Context

Livewire users are a first-class audience for the editor even though the package ships zero Livewire-specific code. The bridge is a DOM event contract on `window`: React fires it, Alpine listens, Livewire handles it. M13 documents that contract and proves it end-to-end.

## Changes Made

- **New `editor-events.ts`** module exporting `VE_EDITOR_CHANGE` / `VE_EDITOR_AUTOSAVE` / `VE_EDITOR_SAVE` constants, typed `detail` interfaces (`VeEditorChangeDetail`, `VeEditorAutosaveDetail`, `VeEditorSaveDetail`), matching `CustomEvent` type aliases, and a `dispatchEditorEvent()` helper that no-ops on SSR.
- **`use-persistence.ts`** now tags each save with a `SaveTrigger` (`'autosave' | 'save'`), dispatches `ve:editor:change` when the debounce window closes, and fires `ve:editor:autosave` or `ve:editor:save` after the API returns 200 based on whether the trigger was the debounce timer or an explicit `flush()`. Trailing drains (edits that land during an in-flight save) always emit as autosaves.
- **`main.tsx`** re-exports the event constants and detail types so host apps can `import { VE_EDITOR_SAVE, type VeEditorSaveDetail } from '@artisanpack-ui/visual-editor/editor'`.
- **`docs/livewire.md`** — copy-pasteable recipe: `wire:ignore` around `<x-visual-editor>`, Alpine `.window` listeners, Volt handler example, event contract table, plain-JS fallback.
- **Dev-app demo** — a Volt component + route at `/packages/visual-editor/m13/livewire/post/{post}` that subscribes to all three events and reflects dirty / autosave / explicit-save counters live on the page. Dev-app changes are in the `artisanpack-ui` sandbox repo, not this PR.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (Darwin 25.3.0)
- Browser: Chrome/Safari via Laravel Herd
- PHP Version: 8.4.3
- Project Version: `release/1.0`

**Tests Performed:**
1. Full Vitest run: **435 passed, 1 skipped (48 files)**.
2. Full Pest run: **150 passed (340 assertions)**.
3. Manual browser test in the dev app: edited a block and watched the Livewire panel flip to `Dirty: yes` via `ve:editor:change`, then back to `Dirty: no` with the autosave counter incrementing via `ve:editor:autosave`. Pressed ⌘S and saw the explicit-save counter increment plus a success flash driven by `ve:editor:save`. Verified the payload shape from the DevTools console.

## Accessibility Tests Run

- [x] Keyboard navigation tested — ⌘S still flushes and fires `ve:editor:save`; no new focus traps.
- [ ] Screen reader tested — not applicable; no new UI chrome in the editor.
- [ ] Color contrast verified — not applicable.
- [ ] ARIA labels checked — not applicable.

**Details:** This change adds an invisible event bus; no new editor UI was introduced. The demo page in the dev app is for illustration only.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:** New `editor-events.test.tsx` covers: constant names, debounced `ve:editor:change` payload shape, autosave-vs-save branching based on trigger, and no-event-on-failure (change still fires, save/autosave do not).

## Documentation

- [x] Inline code documentation added
- [ ] README updated
- [ ] Wiki updated
- [ ] API documentation updated

**Documentation details:** New `docs/livewire.md` with the wire:ignore + Alpine + Volt recipe, event contract table, and pointer to the dev-app demo. TSDoc on the `editor-events.ts` exports.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [x] Accessibility tests completed (N/A noted above)
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The visual editor now broadcasts custom events when content changes, autosaves, or is explicitly saved.

* **Documentation**
  * Added integration guide for embedding the visual editor within Livewire/Blade applications with event listener examples.

* **Tests**
  * Added test suite covering editor event emission, behavior, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->