### PR TITLE
feat: M14 · Vue admin embed wrapper

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,13 @@
     },
     "peerDependencies": {
         "daisyui": "^5.0.0",
-        "tailwindcss": "^4.0.0"
+        "tailwindcss": "^4.0.0",
+        "vue": "^3.3.0"
+    },
+    "peerDependenciesMeta": {
+        "vue": {
+            "optional": true
+        }
     },
     "dependencies": {
         "@artisanpack-ui/react": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
         ".": {
             "types": "./dist/lib/visual-editor.d.ts",
             "import": "./dist/lib/visual-editor.js"
+        },
+        "./vue": {
+            "types": "./resources/js/visual-editor/editor/vue.ts",
+            "import": "./resources/js/visual-editor/editor/vue.ts"
         }
     },
     "scripts": {

--- a/resources/js/visual-editor/editor/__tests__/vue.test.ts
+++ b/resources/js/visual-editor/editor/__tests__/vue.test.ts
@@ -1,0 +1,222 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushPromises, mount as vueMount } from '@vue/test-utils';
+
+import {
+    VE_EDITOR_AUTOSAVE,
+    VE_EDITOR_CHANGE,
+    VE_EDITOR_SAVE,
+    type VeEditorAutosaveDetail,
+    type VeEditorChangeDetail,
+    type VeEditorSaveDetail,
+} from '../editor-events';
+
+// The Gutenberg-using editor bundle pulls in `@wordpress/block-editor` etc.,
+// which is heavy and not under test here. Mock `editor-app` so `mountEditor`
+// resolves its dynamic import to a trivial React component and the wrapper's
+// lifecycle becomes the only thing under test.
+vi.mock('../editor-app', () => ({
+    EditorApp: (): null => null,
+}));
+
+import { VisualEditor } from '../vue';
+
+function dispatchChange(detail: VeEditorChangeDetail): void {
+    window.dispatchEvent(new CustomEvent(VE_EDITOR_CHANGE, { detail }));
+}
+
+function dispatchAutosave(detail: VeEditorAutosaveDetail): void {
+    window.dispatchEvent(new CustomEvent(VE_EDITOR_AUTOSAVE, { detail }));
+}
+
+function dispatchSave(detail: VeEditorSaveDetail): void {
+    window.dispatchEvent(new CustomEvent(VE_EDITOR_SAVE, { detail }));
+}
+
+const BASE_PROPS = {
+    model: { id: 42, title: 'Hello', slug: 'hello', status: 'draft' as const },
+    apiBase: '/visual-editor/api',
+    resource: 'posts',
+};
+
+describe('<VisualEditor /> Vue wrapper', () => {
+    let addSpy: ReturnType<typeof vi.spyOn>;
+    let removeSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+        addSpy = vi.spyOn(window, 'addEventListener');
+        removeSpy = vi.spyOn(window, 'removeEventListener');
+    });
+
+    afterEach(() => {
+        addSpy.mockRestore();
+        removeSpy.mockRestore();
+    });
+
+    it('mounts a host element into the DOM', async () => {
+        const wrapper = vueMount(VisualEditor, { props: BASE_PROPS });
+
+        await flushPromises();
+
+        expect(wrapper.element).toBeInstanceOf(HTMLDivElement);
+        expect(wrapper.element.classList.contains('ap-visual-editor')).toBe(true);
+
+        wrapper.unmount();
+    });
+
+    it('registers ve:editor:* listeners on mount and removes them on unmount', async () => {
+        const wrapper = vueMount(VisualEditor, { props: BASE_PROPS });
+
+        await flushPromises();
+
+        const registered = addSpy.mock.calls
+            .map(([name]) => name)
+            .filter((name): name is string => typeof name === 'string');
+
+        expect(registered).toContain(VE_EDITOR_CHANGE);
+        expect(registered).toContain(VE_EDITOR_AUTOSAVE);
+        expect(registered).toContain(VE_EDITOR_SAVE);
+
+        wrapper.unmount();
+
+        const removed = removeSpy.mock.calls
+            .map(([name]) => name)
+            .filter((name): name is string => typeof name === 'string');
+
+        expect(removed).toContain(VE_EDITOR_CHANGE);
+        expect(removed).toContain(VE_EDITOR_AUTOSAVE);
+        expect(removed).toContain(VE_EDITOR_SAVE);
+    });
+
+    it('re-emits ve:editor:change as @changed with the detail payload', async () => {
+        const wrapper = vueMount(VisualEditor, { props: BASE_PROPS });
+
+        await flushPromises();
+
+        const detail: VeEditorChangeDetail = {
+            resource: 'posts',
+            id: '42',
+            blocks: [],
+        };
+
+        dispatchChange(detail);
+
+        const emitted = wrapper.emitted('changed');
+        expect(emitted).toBeDefined();
+        expect(emitted?.[0]).toEqual([detail]);
+
+        wrapper.unmount();
+    });
+
+    it('re-emits ve:editor:autosave as @autosaved with the detail payload', async () => {
+        const wrapper = vueMount(VisualEditor, { props: BASE_PROPS });
+
+        await flushPromises();
+
+        const detail: VeEditorAutosaveDetail = {
+            resource: 'posts',
+            id: '42',
+            blocks: [],
+            updatedAt: '2026-04-20T12:00:00Z',
+        };
+
+        dispatchAutosave(detail);
+
+        expect(wrapper.emitted('autosaved')?.[0]).toEqual([detail]);
+
+        wrapper.unmount();
+    });
+
+    it('re-emits ve:editor:save as @saved with the detail payload', async () => {
+        const wrapper = vueMount(VisualEditor, { props: BASE_PROPS });
+
+        await flushPromises();
+
+        const detail: VeEditorSaveDetail = {
+            resource: 'posts',
+            id: '42',
+            blocks: [],
+            updatedAt: '2026-04-20T13:00:00Z',
+        };
+
+        dispatchSave(detail);
+
+        expect(wrapper.emitted('saved')?.[0]).toEqual([detail]);
+
+        wrapper.unmount();
+    });
+
+    it('ignores events targeting a different resource or id', async () => {
+        const wrapper = vueMount(VisualEditor, { props: BASE_PROPS });
+
+        await flushPromises();
+
+        // Different resource — should be ignored.
+        dispatchSave({
+            resource: 'pages',
+            id: '42',
+            blocks: [],
+            updatedAt: '2026-04-20T13:00:00Z',
+        });
+
+        // Different id — should be ignored.
+        dispatchSave({
+            resource: 'posts',
+            id: '99',
+            blocks: [],
+            updatedAt: '2026-04-20T13:00:00Z',
+        });
+
+        expect(wrapper.emitted('saved')).toBeUndefined();
+
+        // Matching target — should be emitted.
+        const detail: VeEditorSaveDetail = {
+            resource: 'posts',
+            id: '42',
+            blocks: [],
+            updatedAt: '2026-04-20T13:00:00Z',
+        };
+
+        dispatchSave(detail);
+
+        expect(wrapper.emitted('saved')?.[0]).toEqual([detail]);
+
+        wrapper.unmount();
+    });
+
+    it('stops emitting after the component unmounts', async () => {
+        const wrapper = vueMount(VisualEditor, { props: BASE_PROPS });
+
+        await flushPromises();
+        wrapper.unmount();
+
+        dispatchSave({
+            resource: 'posts',
+            id: '42',
+            blocks: [],
+            updatedAt: '2026-04-20T14:00:00Z',
+        });
+
+        expect(wrapper.emitted('saved')).toBeUndefined();
+    });
+
+    it('accepts string ids on the model and matches string event targets', async () => {
+        const wrapper = vueMount(VisualEditor, {
+            props: { ...BASE_PROPS, model: { id: 'abc-123' } },
+        });
+
+        await flushPromises();
+
+        const detail: VeEditorSaveDetail = {
+            resource: 'posts',
+            id: 'abc-123',
+            blocks: [],
+            updatedAt: null,
+        };
+
+        dispatchSave(detail);
+
+        expect(wrapper.emitted('saved')?.[0]).toEqual([detail]);
+
+        wrapper.unmount();
+    });
+});

--- a/resources/js/visual-editor/editor/main.tsx
+++ b/resources/js/visual-editor/editor/main.tsx
@@ -12,6 +12,7 @@ import { StrictMode, createElement } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 
 export { registerMediaBridge } from '../media-bridge';
+export type { MountConfig, MountedEditor };
 export type {
     BridgeMedia,
     BridgeMediaType,
@@ -43,7 +44,7 @@ type MountableElement = HTMLElement & {
     [ROOT_SYMBOL]?: Root;
 };
 
-interface MountConfig {
+export interface MountConfig {
     apiBase: string;
     resource: string;
     id: string;
@@ -51,6 +52,20 @@ interface MountConfig {
     initialSlug?: string;
     initialStatus?: string;
     previewUrl?: string | null;
+}
+
+export interface MountedEditor {
+    /**
+     * Unmounts the React root and releases the mount slot. Safe to call
+     * multiple times — subsequent calls are no-ops.
+     */
+    unmount(): void;
+    /**
+     * Resolves once the dynamic editor bundle has been loaded and the
+     * initial React render has been scheduled. Rejects if the bundle
+     * fails to load.
+     */
+    ready: Promise<void>;
 }
 
 function readMountConfig(element: HTMLElement): MountConfig | null {
@@ -78,6 +93,70 @@ function readMountConfig(element: HTMLElement): MountConfig | null {
     };
 }
 
+/**
+ * Mounts the React editor into an arbitrary host element with an explicit
+ * config object. Intended for host-framework wrappers (Vue, Svelte, etc.)
+ * that can't rely on the `[data-ap-visual-editor]` attribute bootstrap.
+ *
+ * Returns a {@link MountedEditor} with an `unmount()` method the host
+ * should call from its component-unmount hook to tear down the React root.
+ */
+export function mountEditor(
+    element: HTMLElement,
+    config: MountConfig,
+): MountedEditor {
+    const host = element as MountableElement;
+
+    if (host[ROOT_SYMBOL]) {
+        return {
+            ready: Promise.resolve(),
+            unmount: () => unmountEditor(host),
+        };
+    }
+
+    // Reserve the element synchronously so a second concurrent mount call
+    // (e.g. a rapid bootVisualEditor() re-trigger or a dev-server HMR
+    // double-mount) can't slip past the dedupe check while the dynamic
+    // import is still in flight.
+    const root = createRoot(host);
+    host[ROOT_SYMBOL] = root;
+
+    const ready = import('./editor-app').then(
+        ({ EditorApp }) => {
+            // If the host unmounted before the dynamic import resolved,
+            // `ROOT_SYMBOL` will have been cleared — skip the render.
+            if (host[ROOT_SYMBOL] !== root) {
+                return;
+            }
+
+            root.render(
+                createElement(StrictMode, null, createElement(EditorApp, config)),
+            );
+        },
+        (error: unknown) => {
+            console.error('visual-editor: failed to load editor app.', error);
+            unmountEditor(host);
+            throw error;
+        },
+    );
+
+    return {
+        ready,
+        unmount: () => unmountEditor(host),
+    };
+}
+
+function unmountEditor(element: MountableElement): void {
+    const root = element[ROOT_SYMBOL];
+
+    if (root === undefined) {
+        return;
+    }
+
+    delete element[ROOT_SYMBOL];
+    root.unmount();
+}
+
 async function mount(element: MountableElement): Promise<void> {
     const config = readMountConfig(element);
 
@@ -89,26 +168,10 @@ async function mount(element: MountableElement): Promise<void> {
         return;
     }
 
-    if (element[ROOT_SYMBOL]) {
-        return;
-    }
-
-    // Reserve the element synchronously so a second concurrent mount() call
-    // (e.g. a rapid bootVisualEditor() re-trigger) can't slip past the
-    // dedupe check while the dynamic import is still in flight.
-    const root = createRoot(element);
-    element[ROOT_SYMBOL] = root;
-
     try {
-        const { EditorApp } = await import('./editor-app');
-
-        root.render(
-            createElement(StrictMode, null, createElement(EditorApp, config))
-        );
-    } catch (error: unknown) {
-        console.error('visual-editor: failed to load editor app.', error);
-        root.unmount();
-        delete element[ROOT_SYMBOL];
+        await mountEditor(element, config).ready;
+    } catch {
+        // `mountEditor` already logged the failure and cleared the root.
     }
 }
 

--- a/resources/js/visual-editor/editor/vue.ts
+++ b/resources/js/visual-editor/editor/vue.ts
@@ -1,0 +1,184 @@
+/**
+ * Vue wrapper for the React visual editor.
+ *
+ * Mounts the `@artisanpack-ui/visual-editor` React editor inside a Vue
+ * component lifecycle so Inertia+Vue admin apps can embed the editor
+ * directly without touching `[data-ap-visual-editor]` data attributes.
+ *
+ * The wrapper subscribes to the `ve:editor:*` CustomEvents the editor
+ * dispatches on `window`, filters them by `resource + id` so multiple
+ * editors on the same page stay isolated, and re-emits them as Vue
+ * events (`@changed`, `@autosaved`, `@saved`).
+ *
+ * HMR and StrictMode double-mounts are handled by the shared
+ * {@link mountEditor} helper, which guards the host element against
+ * double roots.
+ */
+
+import {
+    defineComponent,
+    h,
+    onBeforeUnmount,
+    onMounted,
+    ref,
+    watch,
+} from 'vue';
+import type { PropType } from 'vue';
+
+import {
+    VE_EDITOR_AUTOSAVE,
+    VE_EDITOR_CHANGE,
+    VE_EDITOR_SAVE,
+    type VeEditorAutosaveDetail,
+    type VeEditorChangeDetail,
+    type VeEditorSaveDetail,
+} from './editor-events';
+import {
+    mountEditor,
+    type MountConfig,
+    type MountedEditor,
+} from './main';
+
+type PostStatus = 'draft' | 'pending' | 'scheduled' | 'published' | 'private';
+
+export interface VisualEditorModel {
+    id: number | string;
+    title?: string;
+    slug?: string;
+    status?: PostStatus | string;
+}
+
+export interface VisualEditorProps {
+    model: VisualEditorModel;
+    apiBase: string;
+    resource: string;
+    previewUrl?: string | null;
+}
+
+function buildMountConfig(props: VisualEditorProps): MountConfig {
+    return {
+        apiBase: props.apiBase,
+        resource: props.resource,
+        id: String(props.model.id),
+        ...(props.model.title !== undefined ? { initialTitle: props.model.title } : {}),
+        ...(props.model.slug !== undefined ? { initialSlug: props.model.slug } : {}),
+        ...(props.model.status !== undefined ? { initialStatus: String(props.model.status) } : {}),
+        previewUrl: props.previewUrl ?? null,
+    };
+}
+
+export const VisualEditor = defineComponent({
+    name: 'VisualEditor',
+    props: {
+        model: {
+            type: Object as PropType<VisualEditorModel>,
+            required: true,
+        },
+        apiBase: {
+            type: String,
+            required: true,
+        },
+        resource: {
+            type: String,
+            required: true,
+        },
+        previewUrl: {
+            type: String as PropType<string | null>,
+            default: null,
+        },
+    },
+    emits: {
+        changed: (_detail: VeEditorChangeDetail): boolean => true,
+        autosaved: (_detail: VeEditorAutosaveDetail): boolean => true,
+        saved: (_detail: VeEditorSaveDetail): boolean => true,
+    },
+    setup(props, { emit }) {
+        const rootEl = ref<HTMLDivElement | null>(null);
+        let mounted: MountedEditor | null = null;
+
+        const expectedResource = (): string => props.resource;
+        const expectedId = (): string => String(props.model.id);
+
+        const isSelf = (target: { resource: string; id: string }): boolean =>
+            target.resource === expectedResource() && target.id === expectedId();
+
+        const onChange = (event: Event): void => {
+            const detail = (event as CustomEvent<VeEditorChangeDetail>).detail;
+
+            if (detail !== undefined && isSelf(detail)) {
+                emit('changed', detail);
+            }
+        };
+
+        const onAutosave = (event: Event): void => {
+            const detail = (event as CustomEvent<VeEditorAutosaveDetail>).detail;
+
+            if (detail !== undefined && isSelf(detail)) {
+                emit('autosaved', detail);
+            }
+        };
+
+        const onSave = (event: Event): void => {
+            const detail = (event as CustomEvent<VeEditorSaveDetail>).detail;
+
+            if (detail !== undefined && isSelf(detail)) {
+                emit('saved', detail);
+            }
+        };
+
+        onMounted(() => {
+            if (rootEl.value === null) {
+                return;
+            }
+
+            mounted = mountEditor(rootEl.value, buildMountConfig(props));
+
+            window.addEventListener(VE_EDITOR_CHANGE, onChange);
+            window.addEventListener(VE_EDITOR_AUTOSAVE, onAutosave);
+            window.addEventListener(VE_EDITOR_SAVE, onSave);
+        });
+
+        // If the caller swaps the underlying model (e.g. Inertia navigation
+        // to a different post), tear the React root down and remount against
+        // the new config. The editor reads its mount config once at React
+        // mount time, so prop changes need a full remount to propagate.
+        watch(
+            () => [props.resource, String(props.model.id), props.apiBase],
+            ([nextResource, nextId, nextApiBase], [prevResource, prevId, prevApiBase]) => {
+                if (
+                    nextResource === prevResource &&
+                    nextId === prevId &&
+                    nextApiBase === prevApiBase
+                ) {
+                    return;
+                }
+
+                if (mounted !== null) {
+                    mounted.unmount();
+                    mounted = null;
+                }
+
+                if (rootEl.value !== null) {
+                    mounted = mountEditor(rootEl.value, buildMountConfig(props));
+                }
+            },
+        );
+
+        onBeforeUnmount(() => {
+            window.removeEventListener(VE_EDITOR_CHANGE, onChange);
+            window.removeEventListener(VE_EDITOR_AUTOSAVE, onAutosave);
+            window.removeEventListener(VE_EDITOR_SAVE, onSave);
+
+            if (mounted !== null) {
+                mounted.unmount();
+                mounted = null;
+            }
+        });
+
+        return () =>
+            h('div', {
+                ref: rootEl,
+                class: 'ap-visual-editor',
+            });
+    },
+});

--- a/resources/js/visual-editor/editor/vue.ts
+++ b/resources/js/visual-editor/editor/vue.ts
@@ -126,12 +126,25 @@ export const VisualEditor = defineComponent({
             }
         };
 
+        // `mountEditor().ready` rejects when the dynamic editor-app import
+        // fails. The failure is already logged inside `mountEditor`; attach
+        // a no-op catch here so the rejection doesn't bubble up as an
+        // unhandled promise warning in the host app's console.
+        const swallowReadyRejection = (mount: MountedEditor): MountedEditor => {
+            mount.ready.catch(() => {
+                // Already logged by mountEditor.
+            });
+            return mount;
+        };
+
         onMounted(() => {
             if (rootEl.value === null) {
                 return;
             }
 
-            mounted = mountEditor(rootEl.value, buildMountConfig(props));
+            mounted = swallowReadyRejection(
+                mountEditor(rootEl.value, buildMountConfig(props)),
+            );
 
             window.addEventListener(VE_EDITOR_CHANGE, onChange);
             window.addEventListener(VE_EDITOR_AUTOSAVE, onAutosave);
@@ -159,7 +172,9 @@ export const VisualEditor = defineComponent({
                 }
 
                 if (rootEl.value !== null) {
-                    mounted = mountEditor(rootEl.value, buildMountConfig(props));
+                    mounted = swallowReadyRejection(
+                        mountEditor(rootEl.value, buildMountConfig(props)),
+                    );
                 }
             },
         );


### PR DESCRIPTION
## Description

Ships a `<VisualEditor>` Vue component in the core `@artisanpack-ui/visual-editor` package so Inertia+Vue admin apps can embed the React editor inside a Vue component lifecycle without touching `[data-ap-visual-editor]` data attributes.

**Closes:** #324

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #324

## Motivation and Context

Laravel dev ecosystem has strong Vue presence (Inertia+Vue). Without a Vue wrapper, Vue-first shops can't embed the editor in their admin surfaces — they'd have to drop down to raw DOM and wire the data attributes by hand. This wrapper gives them a first-class Vue SFC-equivalent with typed props and emits.

## Changes Made

- Extract `mountEditor(element, config)` + `MountConfig` / `MountedEditor` from the `main.tsx` bootstrap as public host-framework entry points. Returns `{ ready, unmount }` so Vue/Svelte/etc. wrappers can tear down the React root from their own unmount hooks. Existing `[data-ap-visual-editor]` DOM scan and HMR/StrictMode double-mount guards are preserved.
- Add `resources/js/visual-editor/editor/vue.ts` — a `defineComponent` that takes `:model`, `:resource`, `:api-base`, `:preview-url` and emits `@changed`, `@autosaved`, `@saved` from the `ve:editor:*` window CustomEvents. Filters by `resource + id` so multiple editors on the same page stay isolated, remounts on prop change, cleans up listeners + React root on unmount.
- Declare `vue` as an optional peer dep so React-only consumers aren't forced to install it.
- Add Vitest suite covering the wrapper's lifecycle and event propagation.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (Darwin 25.3.0)
- Browser: Arc / Chrome
- PHP Version: 8.4.3
- Project Version: release/1.0

**Tests Performed:**
1. `npm test` — full Vitest suite (443 passing, 1 skipped, 49 files)
2. `./vendor/bin/pest` — full PHP test suite (150 passing, 340 assertions)
3. Manual browser verification against a dev-app Inertia+Vue page at `/packages/visual-editor/m14/vue/post/{id}`:
   - Editor mounts inside the Vue component; top bar + canvas render.
   - Typing flips a `Dirty: yes` indicator via `@changed`.
   - Debounced autosave increments the autosave counter and flips dirty back via `@autosaved`.
   - ⌘S fires the green flash via `@saved`.
   - Navigating away and back preserves content.

## Accessibility Tests Run

- [x] Keyboard navigation tested (editor's existing a11y preserved — the wrapper is a transparent shell)
- [ ] Screen reader tested
- [x] Color contrast verified (wrapper adds no UI chrome)
- [x] ARIA labels checked (no new UI elements introduced by the wrapper)

**Details:** The Vue wrapper renders a single `<div class="ap-visual-editor">` host element. All interactive UI comes from the unchanged React editor, so existing accessibility characteristics carry over unchanged.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:** `resources/js/visual-editor/editor/__tests__/vue.test.ts` — 8 tests covering: host DOM shape, `ve:editor:*` listener attach/detach on mount/unmount, event re-emission for all three events (`@changed`, `@autosaved`, `@saved`), cross-resource and cross-id event filtering, post-unmount silence, and string-id models.

## Documentation

- [x] Inline code documentation added
- [ ] README updated
- [ ] Wiki updated
- [ ] API documentation updated

**Documentation details:** Public entry points (`mountEditor`, `MountConfig`, `MountedEditor`, `VisualEditor`) have JSDoc blocks explaining intent and lifecycle semantics. Wiki/README updates can follow in the M15 docs milestone alongside the Livewire recipe in `docs/livewire.md`.

## Screenshots

_Manual verification performed in the dev app against `/packages/visual-editor/m14/vue/post/1`._

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted (no PHP changes; JS/TS follow project conventions)
- [x] Accessibility tests completed
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New Vue 3.3+ wrapper component for the visual editor.
  * Programmatic mounting API returning a mount handle with ready/unmount control.
* **Tests**
  * Added comprehensive tests for the Vue wrapper covering mount/unmount, event wiring, filtering, and lifecycle.
* **Chores**
  * Added a dedicated Vue package export subpath and declared Vue as an optional peer dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->