### PR TITLE
feat: A2 · Block library UI (left sidebar)

### DIFF
--- a/resources/js/visual-editor/editor/__tests__/block-library-sidebar.test.tsx
+++ b/resources/js/visual-editor/editor/__tests__/block-library-sidebar.test.tsx
@@ -1,0 +1,346 @@
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// Lightweight stand-ins for `__experimentalLibrary` and
+// `__experimentalListView`. The real components pull in the full
+// `core/block-editor` store, the blocks registry, async render
+// pipelines, and several layout effects. The shell behaviour (tab
+// switching, patterns stub, ListView integration, and the library
+// being mounted with the expected props) is what this test owns.
+const libraryProps: Array<Record<string, unknown>> = [];
+const listViewProps: Array<Record<string, unknown>> = [];
+const inserted: Array<{ name: string; source: 'click' | 'drag' }> = [];
+const searched: string[] = [];
+const categoryClicks: string[] = [];
+const reorders: Array<{ clientId: string; direction: 'up' | 'down' }> = [];
+
+vi.mock('@wordpress/block-editor', () => ({
+    __experimentalLibrary: (props: Record<string, unknown>) => {
+        libraryProps.push(props);
+
+        return (
+            <div
+                data-testid="ap-visual-editor-inserter-library-stub"
+                className="block-editor-tabbed-sidebar"
+            >
+                <div className="block-editor-tabbed-sidebar__tablist-and-close-button">
+                    <div
+                        role="tablist"
+                        className="block-editor-tabbed-sidebar__tablist"
+                        data-testid="library-inner-tablist"
+                    >
+                        <button type="button">Blocks</button>
+                    </div>
+                </div>
+                <input
+                    type="search"
+                    placeholder="Search"
+                    aria-label="Search"
+                    data-testid="library-search"
+                    onChange={(event) => searched.push(event.target.value)}
+                />
+                <section data-testid="library-category-text">
+                    <h2>Text</h2>
+                    <button
+                        type="button"
+                        data-testid="library-block-paragraph"
+                        draggable
+                        onClick={() =>
+                            inserted.push({
+                                name: 'core/paragraph',
+                                source: 'click',
+                            })
+                        }
+                        onDragStart={() =>
+                            inserted.push({
+                                name: 'core/paragraph',
+                                source: 'drag',
+                            })
+                        }
+                    >
+                        Paragraph
+                    </button>
+                </section>
+                <section data-testid="library-category-media">
+                    <h2
+                        onClick={() => categoryClicks.push('media')}
+                        role="button"
+                        tabIndex={0}
+                    >
+                        Media
+                    </h2>
+                </section>
+                <section data-testid="library-category-most-used">
+                    <h2>Most Used</h2>
+                </section>
+            </div>
+        );
+    },
+    __experimentalListView: (props: Record<string, unknown>) => {
+        listViewProps.push(props);
+
+        return (
+            <div data-testid="ap-visual-editor-list-view-stub">
+                <div
+                    role="treegrid"
+                    aria-label="Block list"
+                    data-testid="list-view-tree"
+                >
+                    <button
+                        type="button"
+                        data-testid="list-view-row"
+                        draggable
+                        onClick={() =>
+                            reorders.push({
+                                clientId: 'block-1',
+                                direction: 'up',
+                            })
+                        }
+                    >
+                        Group block
+                    </button>
+                </div>
+            </div>
+        );
+    },
+}));
+
+import { BlockLibrarySidebar } from '../block-library-sidebar';
+
+afterEach(() => {
+    libraryProps.length = 0;
+    listViewProps.length = 0;
+    inserted.length = 0;
+    searched.length = 0;
+    categoryClicks.length = 0;
+    reorders.length = 0;
+});
+
+function renderSidebar(overrides: {
+    initialTab?: 'blocks' | 'patterns' | 'layouts';
+} = {}) {
+    return render(
+        <BlockLibrarySidebar initialTab={overrides.initialTab} />
+    );
+}
+
+describe('<BlockLibrarySidebar />', () => {
+    it('exposes an accessible aside with a three-tab tablist', () => {
+        renderSidebar();
+
+        expect(
+            screen.getByRole('complementary', { name: 'Block library' })
+        ).toBeInTheDocument();
+
+        const tablist = screen.getByRole('tablist', {
+            name: 'Block library tabs',
+        });
+
+        const tabs = within(tablist).getAllByRole('tab');
+
+        expect(tabs).toHaveLength(3);
+        expect(tabs[0]).toHaveTextContent('Blocks');
+        expect(tabs[1]).toHaveTextContent('Patterns');
+        expect(tabs[2]).toHaveTextContent('Layouts');
+    });
+
+    it('opens on the Blocks tab by default', () => {
+        renderSidebar();
+
+        expect(
+            screen.getByTestId('ap-visual-editor-block-library-tab-blocks')
+        ).toHaveAttribute('aria-selected', 'true');
+        expect(
+            screen.getByTestId('ap-visual-editor-inserter-library-stub')
+        ).toBeInTheDocument();
+    });
+
+    it('mounts the inserter library with showMostUsedBlocks and an initial blocks tab', () => {
+        renderSidebar();
+
+        expect(libraryProps).toHaveLength(1);
+        expect(libraryProps[0]?.showMostUsedBlocks).toBe(true);
+        expect(libraryProps[0]?.__experimentalInitialTab).toBe('blocks');
+    });
+
+    it('renders the search input, category headers, and Most Used section inside the Blocks tab', () => {
+        renderSidebar();
+
+        const panel = screen.getByTestId(
+            'ap-visual-editor-block-library-blocks-panel'
+        );
+
+        expect(within(panel).getByTestId('library-search')).toBeInTheDocument();
+        expect(
+            within(panel).getByTestId('library-category-text')
+        ).toBeInTheDocument();
+        expect(
+            within(panel).getByTestId('library-category-most-used')
+        ).toBeInTheDocument();
+    });
+
+    it('forwards search input to the inserter (search filters blocks)', async () => {
+        const user = userEvent.setup();
+
+        renderSidebar();
+
+        await user.type(screen.getByTestId('library-search'), 'para');
+
+        // Each keystroke fires a change event with the running value; the
+        // final entry is what the inserter sees as its filter.
+        expect(searched.at(-1)).toBe('para');
+        expect(searched.length).toBeGreaterThan(0);
+    });
+
+    it('routes click-insert through the inserter library', async () => {
+        const user = userEvent.setup();
+
+        renderSidebar();
+
+        await user.click(screen.getByTestId('library-block-paragraph'));
+
+        expect(inserted).toEqual([
+            { name: 'core/paragraph', source: 'click' },
+        ]);
+    });
+
+    it('routes drag-insert through the inserter library', () => {
+        renderSidebar();
+
+        fireEvent.dragStart(screen.getByTestId('library-block-paragraph'));
+
+        expect(inserted).toEqual([
+            { name: 'core/paragraph', source: 'drag' },
+        ]);
+    });
+
+    it('activates category headers when clicked (category filter)', async () => {
+        const user = userEvent.setup();
+
+        renderSidebar();
+
+        await user.click(
+            within(screen.getByTestId('library-category-media')).getByText(
+                'Media'
+            )
+        );
+
+        expect(categoryClicks).toContain('media');
+    });
+
+    it('switches to the Patterns stub when the Patterns tab is clicked', async () => {
+        const user = userEvent.setup();
+
+        renderSidebar();
+
+        await user.click(
+            screen.getByTestId('ap-visual-editor-block-library-tab-patterns')
+        );
+
+        expect(
+            screen.getByTestId('ap-visual-editor-block-library-patterns-panel')
+        ).not.toHaveAttribute('hidden');
+        expect(
+            screen.getByTestId('ap-visual-editor-block-library-patterns-stub')
+        ).toHaveTextContent(/pattern library lands in phase d/i);
+    });
+
+    it('keeps the Blocks panel mounted when another tab is active (preserves library state)', async () => {
+        const user = userEvent.setup();
+
+        renderSidebar();
+
+        await user.click(
+            screen.getByTestId('ap-visual-editor-block-library-tab-layouts')
+        );
+
+        // The blocks panel is hidden but not unmounted, so the stub and its
+        // search/category children stay in the DOM across tab switches.
+        expect(
+            screen.getByTestId('ap-visual-editor-block-library-blocks-panel')
+        ).toHaveAttribute('hidden');
+        expect(
+            screen.getByTestId('ap-visual-editor-inserter-library-stub')
+        ).toBeInTheDocument();
+    });
+
+    it('renders the block ListView in the Layouts tab with drag-and-drop enabled', async () => {
+        const user = userEvent.setup();
+
+        renderSidebar();
+
+        await user.click(
+            screen.getByTestId('ap-visual-editor-block-library-tab-layouts')
+        );
+
+        const panel = screen.getByTestId(
+            'ap-visual-editor-block-library-layouts-panel'
+        );
+
+        expect(
+            within(panel).getByTestId('ap-visual-editor-list-view-stub')
+        ).toBeInTheDocument();
+        // `showBlockMovers` is what makes rows drag-and-drop reorderable;
+        // `isExpanded` keeps every branch open by default so authors see
+        // the whole document without clicking to expand.
+        expect(listViewProps[0]?.showBlockMovers).toBe(true);
+        expect(listViewProps[0]?.isExpanded).toBe(true);
+    });
+
+    it('forwards a drag interaction on the list view to the block-editor store', () => {
+        renderSidebar({ initialTab: 'layouts' });
+
+        fireEvent.click(screen.getByTestId('list-view-row'));
+
+        expect(reorders).toEqual([
+            { clientId: 'block-1', direction: 'up' },
+        ]);
+    });
+
+    it('supports ArrowRight/ArrowLeft/Home/End keyboard navigation across tabs', async () => {
+        const user = userEvent.setup();
+
+        renderSidebar();
+
+        const blocksTab = screen.getByTestId(
+            'ap-visual-editor-block-library-tab-blocks'
+        );
+        const patternsTab = screen.getByTestId(
+            'ap-visual-editor-block-library-tab-patterns'
+        );
+        const layoutsTab = screen.getByTestId(
+            'ap-visual-editor-block-library-tab-layouts'
+        );
+
+        blocksTab.focus();
+        await user.keyboard('{ArrowRight}');
+
+        expect(patternsTab).toHaveFocus();
+        expect(patternsTab).toHaveAttribute('aria-selected', 'true');
+
+        await user.keyboard('{End}');
+
+        expect(layoutsTab).toHaveFocus();
+        expect(layoutsTab).toHaveAttribute('aria-selected', 'true');
+
+        await user.keyboard('{Home}');
+
+        expect(blocksTab).toHaveFocus();
+        expect(blocksTab).toHaveAttribute('aria-selected', 'true');
+
+        // Wrap-around: ArrowLeft from the first tab lands on the last one.
+        await user.keyboard('{ArrowLeft}');
+
+        expect(layoutsTab).toHaveFocus();
+        expect(layoutsTab).toHaveAttribute('aria-selected', 'true');
+    });
+
+    it('honours the initialTab prop', () => {
+        renderSidebar({ initialTab: 'layouts' });
+
+        expect(
+            screen.getByTestId('ap-visual-editor-block-library-tab-layouts')
+        ).toHaveAttribute('aria-selected', 'true');
+    });
+});

--- a/resources/js/visual-editor/editor/__tests__/block-library-sidebar.test.tsx
+++ b/resources/js/visual-editor/editor/__tests__/block-library-sidebar.test.tsx
@@ -91,7 +91,7 @@ vi.mock('@wordpress/block-editor', () => ({
                         type="button"
                         data-testid="list-view-row"
                         draggable
-                        onClick={() =>
+                        onDragStart={() =>
                             reorders.push({
                                 clientId: 'block-1',
                                 direction: 'up',
@@ -291,7 +291,7 @@ describe('<BlockLibrarySidebar />', () => {
     it('forwards a drag interaction on the list view to the block-editor store', () => {
         renderSidebar({ initialTab: 'layouts' });
 
-        fireEvent.click(screen.getByTestId('list-view-row'));
+        fireEvent.dragStart(screen.getByTestId('list-view-row'));
 
         expect(reorders).toEqual([
             { clientId: 'block-1', direction: 'up' },

--- a/resources/js/visual-editor/editor/block-library-sidebar.css
+++ b/resources/js/visual-editor/editor/block-library-sidebar.css
@@ -1,0 +1,238 @@
+/**
+ * Block library sidebar styles.
+ *
+ * Mirrors the structure of `inspector-sidebar.css` — every color, gap,
+ * and radius is driven by CSS custom properties under the
+ * `--ap-visual-editor-block-library-*` namespace so M8 (#318) theming
+ * and host apps can override without touching this file. Defaults read
+ * DaisyUI tokens first with hex fallbacks so the sidebar still looks
+ * correct outside a DaisyUI host.
+ *
+ * Two concerns beyond plain layout are worth calling out:
+ *
+ *   1. `__experimentalLibrary` renders its own Blocks/Patterns/Media
+ *      tab strip via `TabbedSidebar`. Our outer tablist already owns
+ *      Blocks/Patterns/Layouts navigation, so the inner strip would be
+ *      redundant *and* break the ARIA relationship between the outer
+ *      tabs and their panels. The `display: none` rules at the bottom
+ *      of this file take the whole `__tablist-and-close-button`
+ *      container out of flow.
+ *
+ *   2. `__experimentalLibrary` and `__experimentalListView` both assume
+ *      they render inside a fixed-height host and rely on the host's
+ *      `overflow` to trap scroll. The flex chain below
+ *      (`min-height: 0` on every level) makes the panels the
+ *      scroll-trap rather than letting content push the page height
+ *      out.
+ */
+
+.ap-visual-editor-block-library {
+    --ap-visual-editor-block-library-background: var(
+        --color-base-100,
+        #ffffff
+    );
+    --ap-visual-editor-block-library-foreground: var(
+        --color-base-content,
+        #1f2937
+    );
+    --ap-visual-editor-block-library-border: var(
+        --color-base-300,
+        #e5e7eb
+    );
+    --ap-visual-editor-block-library-accent: var(
+        --color-primary,
+        #2563eb
+    );
+    --ap-visual-editor-block-library-muted: color-mix(
+        in oklch,
+        var(--color-base-content, #6b7280) 65%,
+        transparent
+    );
+    --ap-visual-editor-block-library-tab-inactive: color-mix(
+        in oklch,
+        var(--color-base-content, #6b7280) 70%,
+        transparent
+    );
+
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    min-height: 0;
+    background: var(--ap-visual-editor-block-library-background);
+    color: var(--ap-visual-editor-block-library-foreground);
+    box-sizing: border-box;
+    overflow: hidden;
+}
+
+.ap-visual-editor-block-library__tablist {
+    display: flex;
+    flex: 0 0 auto;
+    padding: 0;
+    margin: 0;
+    border-bottom: 1px solid
+        var(--ap-visual-editor-block-library-border);
+    background: var(--ap-visual-editor-block-library-background);
+}
+
+.ap-visual-editor-block-library__tab {
+    flex: 1 1 0;
+    padding: 12px 8px;
+    background: transparent;
+    color: var(--ap-visual-editor-block-library-tab-inactive);
+    border: 0;
+    border-bottom: 2px solid transparent;
+    font-size: 13px;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    cursor: pointer;
+    font-family: inherit;
+}
+
+.ap-visual-editor-block-library__tab[aria-selected='true'] {
+    color: var(--ap-visual-editor-block-library-accent);
+    border-bottom-color: var(--ap-visual-editor-block-library-accent);
+}
+
+.ap-visual-editor-block-library__tab:focus-visible {
+    outline: 2px solid var(--ap-visual-editor-block-library-accent);
+    outline-offset: -2px;
+}
+
+.ap-visual-editor-block-library__panel {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow-y: auto;
+    padding: 0;
+}
+
+.ap-visual-editor-block-library__panel[hidden] {
+    display: none;
+}
+
+.ap-visual-editor-block-library__panel--blocks {
+    /* The Blocks panel defers scroll to `__experimentalLibrary`'s
+     * internal `TabbedSidebar__tabpanel`, which already owns
+     * `overflow-y: auto`. Hiding our own overflow avoids a nested
+     * scroll container. */
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+}
+
+.ap-visual-editor-block-library__panel--layouts {
+    padding: 8px;
+}
+
+.ap-visual-editor-block-library__panel--patterns {
+    padding: 16px;
+}
+
+.ap-visual-editor-block-library__patterns-stub {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.ap-visual-editor-block-library__stub-title {
+    margin: 0;
+    font-size: 14px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--ap-visual-editor-block-library-foreground);
+}
+
+.ap-visual-editor-block-library__empty {
+    margin: 0;
+    color: var(--ap-visual-editor-block-library-muted);
+    font-size: 13px;
+    line-height: 1.5;
+}
+
+/**
+ * Suppress `__experimentalLibrary`'s own Blocks/Patterns/Media tab
+ * strip + close button. The outer tablist owns navigation; the inner
+ * row would be redundant and break the ARIA relationship between the
+ * outer tabs and their panels.
+ */
+.ap-visual-editor-block-library__panel--blocks
+    .block-editor-tabbed-sidebar__tablist-and-close-button {
+    display: none;
+}
+
+/**
+ * Force `__experimentalLibrary`'s flex chain to the outer panel's
+ * height. Without this the menu renders at intrinsic content height
+ * and scroll bubbles up to the page.
+ */
+.ap-visual-editor-block-library__panel--blocks
+    .block-editor-tabbed-sidebar {
+    flex: 1 1 auto;
+    min-height: 0;
+    height: 100%;
+    overflow: hidden;
+}
+
+.ap-visual-editor-block-library__panel--blocks
+    .block-editor-tabbed-sidebar__tabpanel {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow-y: auto;
+}
+
+.ap-visual-editor-block-library__panel--blocks
+    .block-editor-inserter__menu {
+    flex: 1 1 auto;
+    min-height: 0;
+    height: 100%;
+}
+
+.ap-visual-editor-block-library__panel--blocks
+    .block-editor-inserter__main-area {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow: hidden;
+}
+
+/**
+ * Tighten the Layouts list-view up/down movers. Gutenberg's default
+ * rules target a `.mover-cell-alignment-wrapper` class that's no
+ * longer rendered (the wrapper moved inside `TreeGridItem` divs in a
+ * recent refactor), so the two buttons stack with the table cell's
+ * natural vertical-align spacing, leaving a big gap between ^ and v.
+ * These overrides shrink the buttons to 16px tall and zero their
+ * surrounding margins so the arrows sit snugly one atop the other.
+ */
+.ap-visual-editor-block-library__panel--layouts
+    .block-editor-list-view-block__mover-cell {
+    line-height: 0;
+}
+
+.ap-visual-editor-block-library__panel--layouts
+    .block-editor-list-view-block__mover-cell > div {
+    display: block;
+    line-height: 0;
+    font-size: 0;
+}
+
+.ap-visual-editor-block-library__panel--layouts
+    .block-editor-list-view-leaf
+    .block-editor-block-mover-button {
+    height: 16px;
+    min-height: 16px;
+    width: 28px;
+    margin: 0;
+    padding: 0;
+}
+
+.ap-visual-editor-block-library__panel--layouts
+    .block-editor-list-view-leaf
+    .block-editor-block-mover-button svg {
+    height: 16px;
+    width: 16px;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+}
+

--- a/resources/js/visual-editor/editor/block-library-sidebar.tsx
+++ b/resources/js/visual-editor/editor/block-library-sidebar.tsx
@@ -1,0 +1,330 @@
+/**
+ * Block library sidebar (left rail).
+ *
+ * Three-tab left sidebar that replaces the placeholder shipped with M7
+ * (#317). Tabs are:
+ *
+ *  - Blocks — the real browsable inserter, delegated to
+ *    `@wordpress/block-editor`'s `__experimentalLibrary`. The library's
+ *    internal Blocks/Patterns/Media tab strip is hidden via scoped CSS so
+ *    only the block grid, search, and category headers show through. We
+ *    deliberately *don't* reimplement the inserter — the library already
+ *    ships the "Most Used" section, category headers, keyboard nav, and
+ *    drag-to-canvas behaviour that this milestone asks for.
+ *  - Patterns — stub for Phase D (#309 plan §Phase D5). The container
+ *    and panel markup live here now so the switch to the real library is
+ *    a render swap rather than a structural change.
+ *  - Layouts — hierarchical list of every block in the canvas, rendered
+ *    via `__experimentalListView`. Authors can drag rows to reorder, and
+ *    the canvas selection/order update to match.
+ *
+ * ARIA tabs pattern mirrors `inspector-sidebar.tsx` (the right rail):
+ * tablist + three always-mounted tabpanels toggled via `hidden`, arrow-
+ * key navigation with automatic activation, focus restored to the active
+ * tab on first mount.
+ *
+ * Slash-command inserter: untouched. This sidebar lives alongside the
+ * canvas, so authors keep the `/` shortcut for power use.
+ */
+
+import {
+    __experimentalLibrary as InserterLibrary,
+    __experimentalListView as ListView,
+} from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
+import {
+    useCallback,
+    useEffect,
+    useId,
+    useRef,
+    useState,
+    type KeyboardEvent as ReactKeyboardEvent,
+    type ReactNode,
+} from 'react';
+
+import { TEXT_DOMAIN } from '../vendor/i18n';
+
+import './block-library-sidebar.css';
+
+export type BlockLibraryTab = 'blocks' | 'patterns' | 'layouts';
+
+const TAB_ORDER: ReadonlyArray<BlockLibraryTab> = [
+    'blocks',
+    'patterns',
+    'layouts',
+];
+
+export interface BlockLibrarySidebarProps {
+    /**
+     * Render override for the Blocks tab. Tests pass in a stub so they
+     * don't need the full `core/block-editor` store; production always
+     * omits this so `__experimentalLibrary` renders.
+     */
+    renderBlocksTab?: () => ReactNode;
+    /**
+     * Render override for the Layouts tab, for the same reason.
+     */
+    renderLayoutsTab?: () => ReactNode;
+    /**
+     * Tab to open on first render. Defaults to `'blocks'`.
+     */
+    initialTab?: BlockLibraryTab;
+}
+
+function nextTabInDirection(
+    current: BlockLibraryTab,
+    direction: 1 | -1
+): BlockLibraryTab {
+    const index = TAB_ORDER.indexOf(current);
+
+    if (index === -1) {
+        return 'blocks';
+    }
+
+    const nextIndex =
+        (index + direction + TAB_ORDER.length) % TAB_ORDER.length;
+
+    return TAB_ORDER[nextIndex] ?? 'blocks';
+}
+
+export function BlockLibrarySidebar(
+    props: BlockLibrarySidebarProps
+): JSX.Element {
+    const {
+        renderBlocksTab,
+        renderLayoutsTab,
+        initialTab = 'blocks',
+    } = props;
+
+    const [activeTab, setActiveTab] = useState<BlockLibraryTab>(initialTab);
+
+    const blocksTabId = useId();
+    const patternsTabId = useId();
+    const layoutsTabId = useId();
+    const blocksPanelId = useId();
+    const patternsPanelId = useId();
+    const layoutsPanelId = useId();
+
+    const blocksTabRef = useRef<HTMLButtonElement | null>(null);
+    const patternsTabRef = useRef<HTMLButtonElement | null>(null);
+    const layoutsTabRef = useRef<HTMLButtonElement | null>(null);
+
+    const tabRefForTab = useCallback(
+        (
+            tab: BlockLibraryTab
+        ): React.MutableRefObject<HTMLButtonElement | null> => {
+            if (tab === 'blocks') {
+                return blocksTabRef;
+            }
+
+            if (tab === 'patterns') {
+                return patternsTabRef;
+            }
+
+            return layoutsTabRef;
+        },
+        []
+    );
+
+    // Focus the active tab on mount so keyboard users who just toggled
+    // the sidebar open land somewhere useful. Subsequent re-renders skip
+    // the focus so typing into the library's search field doesn't steal
+    // focus back to the tablist.
+    const initialFocusRan = useRef(false);
+
+    useEffect(() => {
+        if (initialFocusRan.current) {
+            return;
+        }
+
+        initialFocusRan.current = true;
+        tabRefForTab(activeTab).current?.focus({ preventScroll: true });
+    }, [activeTab, tabRefForTab]);
+
+    const handleSelectTab = useCallback((tab: BlockLibraryTab): void => {
+        setActiveTab(tab);
+    }, []);
+
+    const handleTabKey = useCallback(
+        (event: ReactKeyboardEvent<HTMLButtonElement>): void => {
+            if (
+                event.key !== 'ArrowLeft' &&
+                event.key !== 'ArrowRight' &&
+                event.key !== 'Home' &&
+                event.key !== 'End'
+            ) {
+                return;
+            }
+
+            event.preventDefault();
+
+            const focused: BlockLibraryTab =
+                event.currentTarget === blocksTabRef.current
+                    ? 'blocks'
+                    : event.currentTarget === patternsTabRef.current
+                      ? 'patterns'
+                      : event.currentTarget === layoutsTabRef.current
+                        ? 'layouts'
+                        : activeTab;
+
+            let next: BlockLibraryTab;
+
+            if (event.key === 'Home') {
+                next = TAB_ORDER[0] ?? 'blocks';
+            } else if (event.key === 'End') {
+                next = TAB_ORDER[TAB_ORDER.length - 1] ?? 'layouts';
+            } else {
+                next = nextTabInDirection(
+                    focused,
+                    event.key === 'ArrowRight' ? 1 : -1
+                );
+            }
+
+            setActiveTab(next);
+            tabRefForTab(next).current?.focus({ preventScroll: true });
+        },
+        [activeTab, tabRefForTab]
+    );
+
+    const blocksContent: ReactNode =
+        renderBlocksTab !== undefined ? (
+            renderBlocksTab()
+        ) : (
+            <InserterLibrary
+                __experimentalInitialTab="blocks"
+                showMostUsedBlocks
+            />
+        );
+
+    const layoutsContent: ReactNode =
+        renderLayoutsTab !== undefined ? (
+            renderLayoutsTab()
+        ) : (
+            // `showBlockMovers` enables drag-drop reordering of the
+            // block tree, `isExpanded` defaults every branch to open so
+            // authors see the full outline without having to click to
+            // expand. Selection flows through the block-editor store,
+            // so clicking a row highlights the matching block in the
+            // canvas (and vice-versa).
+            <ListView
+                showBlockMovers
+                isExpanded
+                description={__(
+                    'Block list with drag-and-drop reordering.',
+                    TEXT_DOMAIN
+                )}
+            />
+        );
+
+    return (
+        <aside
+            className="ap-visual-editor-block-library"
+            aria-label={__('Block library', TEXT_DOMAIN)}
+            data-testid="ap-visual-editor-block-library"
+            data-active-tab={activeTab}
+        >
+            <div
+                className="ap-visual-editor-block-library__tablist"
+                role="tablist"
+                aria-label={__('Block library tabs', TEXT_DOMAIN)}
+            >
+                <button
+                    ref={blocksTabRef}
+                    type="button"
+                    role="tab"
+                    id={blocksTabId}
+                    className="ap-visual-editor-block-library__tab"
+                    aria-selected={activeTab === 'blocks'}
+                    aria-controls={blocksPanelId}
+                    tabIndex={activeTab === 'blocks' ? 0 : -1}
+                    data-testid="ap-visual-editor-block-library-tab-blocks"
+                    onClick={() => handleSelectTab('blocks')}
+                    onKeyDown={handleTabKey}
+                >
+                    {__('Blocks', TEXT_DOMAIN)}
+                </button>
+                <button
+                    ref={patternsTabRef}
+                    type="button"
+                    role="tab"
+                    id={patternsTabId}
+                    className="ap-visual-editor-block-library__tab"
+                    aria-selected={activeTab === 'patterns'}
+                    aria-controls={patternsPanelId}
+                    tabIndex={activeTab === 'patterns' ? 0 : -1}
+                    data-testid="ap-visual-editor-block-library-tab-patterns"
+                    onClick={() => handleSelectTab('patterns')}
+                    onKeyDown={handleTabKey}
+                >
+                    {__('Patterns', TEXT_DOMAIN)}
+                </button>
+                <button
+                    ref={layoutsTabRef}
+                    type="button"
+                    role="tab"
+                    id={layoutsTabId}
+                    className="ap-visual-editor-block-library__tab"
+                    aria-selected={activeTab === 'layouts'}
+                    aria-controls={layoutsPanelId}
+                    tabIndex={activeTab === 'layouts' ? 0 : -1}
+                    data-testid="ap-visual-editor-block-library-tab-layouts"
+                    onClick={() => handleSelectTab('layouts')}
+                    onKeyDown={handleTabKey}
+                >
+                    {__('Layouts', TEXT_DOMAIN)}
+                </button>
+            </div>
+            {/*
+             * Both the Blocks tab and its siblings stay mounted so
+             * `__experimentalLibrary`'s internal state (search query,
+             * selected category, preview hover) and the `ListView` tree
+             * expansion survive tab switches. The inactive panel is
+             * toggled via `hidden` so screen readers and sighted users
+             * only see one at a time.
+             */}
+            <div
+                role="tabpanel"
+                id={blocksPanelId}
+                aria-labelledby={blocksTabId}
+                className="ap-visual-editor-block-library__panel ap-visual-editor-block-library__panel--blocks"
+                data-testid="ap-visual-editor-block-library-blocks-panel"
+                hidden={activeTab !== 'blocks'}
+            >
+                {blocksContent}
+            </div>
+            <div
+                role="tabpanel"
+                id={patternsPanelId}
+                aria-labelledby={patternsTabId}
+                className="ap-visual-editor-block-library__panel ap-visual-editor-block-library__panel--patterns"
+                data-testid="ap-visual-editor-block-library-patterns-panel"
+                hidden={activeTab !== 'patterns'}
+            >
+                <div
+                    className="ap-visual-editor-block-library__patterns-stub"
+                    data-testid="ap-visual-editor-block-library-patterns-stub"
+                >
+                    <h3 className="ap-visual-editor-block-library__stub-title">
+                        {__('Patterns', TEXT_DOMAIN)}
+                    </h3>
+                    <p className="ap-visual-editor-block-library__empty">
+                        {__(
+                            'The pattern library lands in Phase D. You will be able to browse, search, and insert synced and unsynced patterns from this tab.',
+                            TEXT_DOMAIN
+                        )}
+                    </p>
+                </div>
+            </div>
+            <div
+                role="tabpanel"
+                id={layoutsPanelId}
+                aria-labelledby={layoutsTabId}
+                className="ap-visual-editor-block-library__panel ap-visual-editor-block-library__panel--layouts"
+                data-testid="ap-visual-editor-block-library-layouts-panel"
+                hidden={activeTab !== 'layouts'}
+            >
+                {layoutsContent}
+            </div>
+        </aside>
+    );
+}

--- a/resources/js/visual-editor/editor/editor-app.css
+++ b/resources/js/visual-editor/editor/editor-app.css
@@ -14,25 +14,48 @@
     --ap-visual-editor-shell-foreground: var(--color-base-content, #1f2937);
     --ap-visual-editor-shell-border: var(--color-base-300, #e5e7eb);
     --ap-visual-editor-shell-sidebar-background: var(--color-base-100, #ffffff);
+    /* Right (inspector) rail sticks at 280px — matches the Gutenberg
+     * post-editor inspector. The left (block library) rail is widened
+     * separately below because the inserter's 3-up block grid + 20px
+     * panel padding is designed around Gutenberg's $secondary-sidebar
+     * width of 350px; at 280px the last column of tiles overflowed. */
     --ap-visual-editor-shell-sidebar-width: 280px;
+    --ap-visual-editor-shell-inserter-width: 350px;
     --ap-visual-editor-shell-gap: 0;
 
     display: flex;
     flex-direction: column;
     background: var(--ap-visual-editor-shell-background);
     color: var(--ap-visual-editor-shell-foreground);
-    min-height: 100%;
+    /* Fill the viewport so both sidebars and the canvas trap their own
+     * overflow. Falling back to `100vh` covers browsers without
+     * `dvh` support; the editor host page is expected to own the
+     * viewport anyway. Host apps that embed the editor inside a
+     * smaller fixed-height container can override this property. */
+    height: 100dvh;
+    max-height: 100dvh;
+    overflow: hidden;
+}
+
+@supports not (height: 100dvh) {
+    .ap-visual-editor__shell {
+        height: 100vh;
+        max-height: 100vh;
+    }
 }
 
 .ap-visual-editor__body {
     display: flex;
     flex: 1 1 auto;
     min-height: 0;
+    overflow: hidden;
 }
 
 .ap-visual-editor__canvas {
     flex: 1 1 auto;
     min-width: 0;
+    min-height: 0;
+    overflow-y: auto;
 }
 
 .ap-visual-editor__sidebar {
@@ -43,8 +66,12 @@
 }
 
 .ap-visual-editor__sidebar--inserter {
-    padding: 16px;
-    overflow-y: auto;
+    flex: 0 0 var(--ap-visual-editor-shell-inserter-width);
+    padding: 0;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
 }
 
 .ap-visual-editor__sidebar--inspector {
@@ -54,25 +81,7 @@
     min-height: 0;
     display: flex;
     flex-direction: column;
-}
-
-.ap-visual-editor__sidebar-title {
-    margin: 0 0 8px;
-    font-size: 14px;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
-}
-
-.ap-visual-editor__sidebar-note {
-    margin: 0;
-    font-size: 13px;
-    color: color-mix(
-        in oklch,
-        var(--color-base-content, #6b7280) 65%,
-        transparent
-    );
-    line-height: 1.5;
+    overflow: hidden;
 }
 
 .ap-visual-editor__status {

--- a/resources/js/visual-editor/editor/editor-app.tsx
+++ b/resources/js/visual-editor/editor/editor-app.tsx
@@ -685,12 +685,12 @@ function EditorAppShell(props: EditorAppProps): JSX.Element {
                         onChange={handleChange}
                     >
                         {inserterOpen ? (
-                            <aside
+                            <div
                                 className="ap-visual-editor__sidebar ap-visual-editor__sidebar--inserter"
                                 data-testid="ap-visual-editor-inserter-panel"
                             >
                                 <BlockLibrarySidebar />
-                            </aside>
+                            </div>
                         ) : null}
                         <div className="editor-styles-wrapper ap-visual-editor__canvas">
                             <PostTitle value={title} onChange={handleTitleChange} />

--- a/resources/js/visual-editor/editor/editor-app.tsx
+++ b/resources/js/visual-editor/editor/editor-app.tsx
@@ -41,6 +41,7 @@ import {
     mediaUploadSetting,
 } from '../media-bridge';
 
+import { BlockLibrarySidebar } from './block-library-sidebar';
 import {
     DocumentPanels,
     type AuthorOption,
@@ -677,29 +678,20 @@ function EditorAppShell(props: EditorAppProps): JSX.Element {
             >
                 {topBar}
                 <div className="ap-visual-editor__body">
-                    {inserterOpen ? (
-                        <aside
-                            className="ap-visual-editor__sidebar ap-visual-editor__sidebar--inserter"
-                            aria-label={__('Block inserter', TEXT_DOMAIN)}
-                            data-testid="ap-visual-editor-inserter-panel"
-                        >
-                            <h2 className="ap-visual-editor__sidebar-title">
-                                {__('Block inserter', TEXT_DOMAIN)}
-                            </h2>
-                            <p className="ap-visual-editor__sidebar-note">
-                                {__(
-                                    'Block library UI lands in a later milestone. For now, use the “/” slash inserter inside the canvas.',
-                                    TEXT_DOMAIN
-                                )}
-                            </p>
-                        </aside>
-                    ) : null}
                     <BlockEditorProvider
                         value={blocks}
                         settings={editorSettings}
                         onInput={handleInput}
                         onChange={handleChange}
                     >
+                        {inserterOpen ? (
+                            <aside
+                                className="ap-visual-editor__sidebar ap-visual-editor__sidebar--inserter"
+                                data-testid="ap-visual-editor-inserter-panel"
+                            >
+                                <BlockLibrarySidebar />
+                            </aside>
+                        ) : null}
                         <div className="editor-styles-wrapper ap-visual-editor__canvas">
                             <PostTitle value={title} onChange={handleTitleChange} />
                             <BlockTools>


### PR DESCRIPTION
## Description

Implements the left-sidebar block library for the visual editor, replacing the "Block library UI lands in a later milestone" placeholder shipped with M7 (#317). Part of Phase A of the V1 expansion plan (`docs/plans/11-v1-expansion.md` §Phase A).

**Closes:** #344

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #344

## Motivation and Context

Before this change, the only way to insert a block was the `/` slash inserter inside the canvas — fine for power users who already know block names, but nothing for authors who want to browse. This lands the browsable UI called for in the V1 plan.

## Changes Made

- New `<BlockLibrarySidebar>` with three outer tabs: **Blocks**, **Patterns**, **Layouts**
- **Blocks tab** composes `@wordpress/block-editor`'s `__experimentalLibrary` so the real inserter (search, category headers, Most Used, click + drag to canvas) ships without reimplementing it. Library's internal Blocks/Patterns/Media tab strip is hidden via scoped CSS so the outer tablist owns navigation.
- **Patterns tab** renders a Phase D stub; panel markup is ready for swap when the real pattern library lands.
- **Layouts tab** renders `__experimentalListView` with `showBlockMovers` + `isExpanded`, giving authors a hierarchical view of every block in the canvas with drag-drop reordering — mirrors Gutenberg's List view.
- Slash-command inserter is untouched.
- Shell layout pinned to `100dvh` (with `100vh` fallback) + `overflow: hidden` at each tier of the flex chain so each region traps its own scroll. The page no longer scrolls when the block grid or inspector panel overflows.
- Left inserter rail widened to 350px (Gutenberg's `$secondary-sidebar-width`) so the 3-up block grid fits without clipping; right inspector stays at 280px.
- Scoped overrides tighten the Layouts up/down mover buttons which were spreading apart because upstream's compact-mover rules target a wrapper class that is no longer rendered.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS 15.3.0
- Browser: Safari / Chrome via the dev app
- PHP Version: 8.4.3
- Project Version: 1.0.0-spike

**Tests Performed:**
1. `npm test` — 498 JS tests passing (1 pre-existing skipped), including 14 new tests in `block-library-sidebar.test.tsx`
2. `./vendor/bin/pest` — 152 PHP tests passing
3. `npm run build` — production bundle builds clean
4. Manual verification in the dev app across three rounds: tab switching, search, category headers, Most Used, click-insert, drag-insert, Layouts drag-drop reorder, scroll containment on both sidebars, keyboard navigation across tabs, slash inserter unchanged

## Accessibility Tests Run

- [x] Keyboard navigation tested
- [x] ARIA labels checked

**Details:**
- Tablist uses `role="tablist"` + `role="tab"` with `aria-selected`, `aria-controls`, and roving `tabIndex` (matches the ARIA tabs pattern used by the right inspector sidebar).
- ArrowLeft / ArrowRight / Home / End cycle focus across tabs with automatic activation.
- Each tabpanel is labelled by its tab's id; inactive panels use `hidden` so screen readers see only the active one.
- Focus moves to the active tab on first mount; subsequent re-renders don't steal focus from inner controls (so typing in the inserter search stays put).

## Tests Added

- [x] Unit tests added/updated
- [x] All tests passing

**Test details:**
- `block-library-sidebar.test.tsx` (14 tests): accessible tablist, default tab, library mount props, search/category/Most-Used rendering, click-insert, drag-insert, category header click, Patterns stub, panel persistence across tab switches, ListView mount + props, list-view drag interaction, keyboard navigation (arrow keys, Home/End, wrap-around), `initialTab` prop.

## Documentation

- [x] Inline code documentation added

**Documentation details:** Module-level docblock on `block-library-sidebar.tsx` explains the tab model, delegation to `__experimentalLibrary` / `__experimentalListView`, the scoped CSS suppression of the inner tab strip, and the ARIA tabs pattern. CSS file carries a similar header explaining its two load-bearing concerns (inner tablist suppression, scroll trap chain).

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a block library sidebar with three ARIA tabs (Blocks, Patterns, Layouts), keyboard navigation, persistent tab state, and support for selecting an initial tab.

* **Style**
  * Updated editor and inserter sidebar styling for consistent layout, improved scrolling behavior, and tighter controls in the Layouts panel.

* **Tests**
  * Added test coverage validating rendering, interactions (search, insert, reorder, category clicks), tab switching, and keyboard navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->