### PR TITLE
feat: A3 · Media library integration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     "orchestra/testbench": "^10.2"
   },
   "suggest": {
-    "artisanpack-ui/media-library": "^1.2 — Default media library integration. Wire MediaModal + uploadMedia through registerArtisanpackMediaBridge() in the editor bootstrap to power Gutenberg's media picker and upload flows."
+    "artisanpack-ui/media-library": "Recommended ^1.2 — default media library integration. Wire MediaModal + uploadMedia through registerArtisanpackMediaBridge() in the editor bootstrap to power Gutenberg's media picker and upload flows. Not enforced by Composer; host apps are free to install a different library and register a custom bridge instead."
   },
   "scripts": {
     "test": "./vendor/bin/pest"

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,9 @@
     "pestphp/pest-plugin-laravel": "^3.1",
     "orchestra/testbench": "^10.2"
   },
+  "suggest": {
+    "artisanpack-ui/media-library": "^1.2 — Default media library integration. Wire MediaModal + uploadMedia through registerArtisanpackMediaBridge() in the editor bootstrap to power Gutenberg's media picker and upload flows."
+  },
   "scripts": {
     "test": "./vendor/bin/pest"
   },

--- a/config/visual-editor.php
+++ b/config/visual-editor.php
@@ -108,20 +108,32 @@ return [
 
 	/*
 	|--------------------------------------------------------------------------
-	| Media adapter
+	| Media bridge
 	|--------------------------------------------------------------------------
 	|
-	| Reserved for a future server-side adapter binding. The M4 media bridge
-	| (#314) wires `artisanpack-ui/media-library` into the editor entirely on
-	| the client: the host app calls `registerMediaBridge(...)` from
-	| `@artisanpack-ui/visual-editor` with `MediaModal` and `uploadMedia`
-	| before `bootVisualEditor()`. Leaving this key in place for apps that
-	| bind their own adapter via a container binding keyed on this value.
+	| The editor's media picker and upload plumbing route to whatever media
+	| library the host application provides. The default integration is
+	| `artisanpack-ui/media-library`: the host calls `registerMediaBridge`
+	| with `MediaModal` and `uploadMedia` before `bootVisualEditor`. Any
+	| library that exposes an equivalent picker component (props:
+	| `open`, `onClose`, `onSelect`, `multiSelect`, `allowedTypes`,
+	| `context`, `title`) and upload function (`(file, metadata?) =>
+	| Promise<{ data: Media } | Media>`) can be swapped in — the
+	| `media.bridge` key below records the active choice so server-side
+	| code (for example the Featured Image hydration path) can pick the
+	| matching PHP adapter from the container.
+	|
+	| Server-side record conversion is delegated to
+	| `ArtisanPackUI\VisualEditor\MediaBridge\GutenbergAttachmentAdapter`.
+	| Rebind that class in the container to override the Gutenberg shape
+	| emitted by `toGutenberg()`; the default implementation duck-types
+	| the `artisanpack-ui/media-library` Media model.
 	|
 	*/
 
 	'media' => [
-		'adapter' => 'null',
+		'bridge'  => 'artisanpack-ui/media-library',
+		'adapter' => \ArtisanPackUI\VisualEditor\MediaBridge\GutenbergAttachmentAdapter::class,
 	],
 
 	/*

--- a/docs/gutenberg-adoption.md
+++ b/docs/gutenberg-adoption.md
@@ -126,10 +126,23 @@ the published source tree, not a separate package.
 
 ### Swapping in a different media library
 
-Any picker component that accepts the bridge props — `open`, `onClose`,
-`onSelect(media, context)`, `multiSelect`, `allowedTypes`, `context`,
-`title` — can replace the default. Pair it with an `uploadMedia`
-function that resolves with `{ data: Media } | Media`:
+Any picker component that accepts the bridge props can replace the
+default. The exact contracts (defined in `media-bridge/types.ts`):
+
+- **Picker props** — `open: boolean`, `onClose: () => void`,
+  `onSelect: (media: Media[], context: string) => void`, optional
+  `multiSelect`, `allowedTypes`, `context`, `title`. `onSelect` always
+  receives an **array** regardless of `multiSelect`; the `multiSelect`
+  flag is a hint the picker uses to gate its own multi-select UI. The
+  editor's slot-fill (`MediaUploadBridge`) is responsible for
+  collapsing a single-element array into a scalar before handing off
+  to Gutenberg when the calling block is single-select.
+- **`uploadMedia`** — `(file: File, metadata?, onProgress?) =>
+  Promise<{ data: Media } | Media>`. Always per-file; the bridge
+  parallelises across multiple files via `Promise.all` when the user
+  drops several at once, so implementations only need to handle one
+  file per call. The wrapper accepts both the API-resource shape
+  (`{ data: Media }`) and a bare `Media` and unwraps accordingly.
 
 ```ts
 import { registerMediaBridge } from '@artisanpack-ui/visual-editor';

--- a/docs/gutenberg-adoption.md
+++ b/docs/gutenberg-adoption.md
@@ -95,6 +95,85 @@ rendering, admin chrome — is Laravel-native.
 | Livewire | Event-based opt-in; no Livewire-specific package code in V1 | Documented recipe |
 | Site editor | Deferred to Phase 3+ | V1 data model leaves room |
 
+## Media bridge
+
+Gutenberg core media blocks (`core/image`, `core/gallery`, `core/video`,
+`core/audio`, `core/file`, `core/cover`, `core/media-text`) render
+`<MediaUpload>` slot-fills and call the `settings.mediaUpload` callback
+for drag-and-drop uploads. The editor replaces both with a host-supplied
+bridge so picker UI and uploads route to the host's own media library.
+
+### Client wiring
+
+Most hosts pair the editor with `artisanpack-ui/media-library` and wire
+both halves in one call before booting the editor:
+
+```ts
+import {
+    bootVisualEditor,
+    registerArtisanpackMediaBridge,
+} from '@artisanpack-ui/visual-editor';
+import { MediaModal, uploadMedia } from './vendor/media-library';
+
+registerArtisanpackMediaBridge({ MediaModal, uploadMedia });
+bootVisualEditor();
+```
+
+Publish the React sources with
+`php artisan vendor:publish --tag=media-react` so they resolve inside the
+host bundle; the npm distribution for `artisanpack-ui/media-library` is
+the published source tree, not a separate package.
+
+### Swapping in a different media library
+
+Any picker component that accepts the bridge props — `open`, `onClose`,
+`onSelect(media, context)`, `multiSelect`, `allowedTypes`, `context`,
+`title` — can replace the default. Pair it with an `uploadMedia`
+function that resolves with `{ data: Media } | Media`:
+
+```ts
+import { registerMediaBridge } from '@artisanpack-ui/visual-editor';
+import { CustomPicker, customUploadMedia } from './vendor/my-media';
+
+registerMediaBridge({
+    MediaBridge: CustomPicker,
+    uploadMedia: customUploadMedia,
+});
+```
+
+Registration overrides any previous bridge — the last call wins — so
+hot-reload and feature-flag flips work without a page reload. Clicking
+the Media Library button before any bridge is registered surfaces an
+operator-facing alert instead of silently dropping the click.
+
+### Server-side adapter
+
+`ArtisanPackUI\VisualEditor\MediaBridge\GutenbergAttachmentAdapter` maps
+a media-library `Media` record (or any duck-typed record exposing the
+same fields) into the Gutenberg attachment shape core blocks consume:
+
+```php
+use ArtisanPackUI\VisualEditor\MediaBridge\GutenbergAttachmentAdapter;
+
+$attachment = app(GutenbergAttachmentAdapter::class)
+    ->toGutenberg($post->featured_image);
+// ['id' => …, 'url' => …, 'alt' => …, 'caption' => …,
+//  'mime' => …, 'media_type' => …, 'width' => …, 'height' => …,
+//  'filename' => …, 'sizes' => …]
+```
+
+Hydrate the `FeaturedImageValue` prop passed to `<x-visual-editor>`
+through this adapter so the Featured Image panel renders with the
+correct shape on first paint — no REST round-trip needed. Rebind the
+class in the container to customise the output (e.g. to append host-
+specific fields).
+
+The `config/visual-editor.php` key `media.adapter` records the adapter
+class name and `media.bridge` records the active JS bridge (defaults to
+`artisanpack-ui/media-library`). Both keys are informational — the
+active bridge is whichever component the host passes to
+`registerMediaBridge` / `registerArtisanpackMediaBridge`.
+
 ## Branching
 
 - **Integration branch**: `release/1.0`. Every M1–M15 feature branch cuts from here and opens a draft PR back into it.

--- a/resources/js/visual-editor/editor/main.tsx
+++ b/resources/js/visual-editor/editor/main.tsx
@@ -17,13 +17,17 @@ import type {
     FeaturedImageValue,
 } from './document-panels';
 
-export { registerMediaBridge } from '../media-bridge';
+export {
+    registerArtisanpackMediaBridge,
+    registerMediaBridge,
+} from '../media-bridge';
 export type {
     BridgeMedia,
     BridgeMediaType,
     MediaBridgeComponent,
     MediaBridgeComponentProps,
     MediaUploader,
+    RegisterArtisanpackMediaBridgeOptions,
     RegisterMediaBridgeOptions,
 } from '../media-bridge';
 

--- a/resources/js/visual-editor/media-bridge/__tests__/artisanpack-default.test.tsx
+++ b/resources/js/visual-editor/media-bridge/__tests__/artisanpack-default.test.tsx
@@ -1,0 +1,107 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { registerArtisanpackMediaBridge } from '../artisanpack-default';
+import { MediaUploadBridge } from '../media-upload';
+import { __resetMediaBridgeForTests, getMediaUploader } from '../state';
+import type {
+    BridgeMedia,
+    MediaBridgeComponent,
+    MediaBridgeComponentProps,
+    MediaUploader,
+} from '../types';
+
+function makeModal(
+    captured: MediaBridgeComponentProps[]
+): MediaBridgeComponent {
+    return (props: MediaBridgeComponentProps) => {
+        if (props.open) {
+            captured.push(props);
+            return <div data-testid="media-modal">open</div>;
+        }
+        return null;
+    };
+}
+
+const uploader: MediaUploader = vi.fn(() =>
+    Promise.resolve({
+        data: {
+            id: 1,
+            url: 'x',
+            mime_type: 'image/jpeg',
+        } as BridgeMedia,
+    })
+);
+
+afterEach(() => {
+    __resetMediaBridgeForTests();
+    vi.restoreAllMocks();
+});
+
+describe('registerArtisanpackMediaBridge', () => {
+    it('wires MediaModal into the bridge slot-fill component', async () => {
+        const captured: MediaBridgeComponentProps[] = [];
+        registerArtisanpackMediaBridge({
+            MediaModal: makeModal(captured),
+            uploadMedia: uploader,
+        });
+
+        const onSelect = vi.fn();
+
+        render(
+            <MediaUploadBridge
+                allowedTypes={['image']}
+                onSelect={onSelect}
+                render={({ open }) => (
+                    <button type="button" onClick={open}>
+                        Media Library
+                    </button>
+                )}
+            />
+        );
+
+        await userEvent.click(
+            screen.getByRole('button', { name: 'Media Library' })
+        );
+
+        expect(screen.getByTestId('media-modal')).toBeInTheDocument();
+        expect(captured).toHaveLength(1);
+        expect(captured[0]?.allowedTypes).toEqual(['image']);
+
+        act(() => {
+            captured[0]?.onSelect(
+                [
+                    {
+                        id: 7,
+                        url: 'https://cdn.example.test/a.jpg',
+                        mime_type: 'image/jpeg',
+                        alt_text: 'a',
+                        caption: 'b',
+                        is_image: true,
+                    },
+                ],
+                captured[0].context ?? ''
+            );
+        });
+
+        expect(onSelect).toHaveBeenCalledWith(
+            expect.objectContaining({
+                id: 7,
+                alt: 'a',
+                caption: 'b',
+                mime: 'image/jpeg',
+                media_type: 'image',
+            })
+        );
+    });
+
+    it('registers uploadMedia as the active uploader', () => {
+        registerArtisanpackMediaBridge({
+            MediaModal: makeModal([]),
+            uploadMedia: uploader,
+        });
+
+        expect(getMediaUploader()).toBe(uploader);
+    });
+});

--- a/resources/js/visual-editor/media-bridge/artisanpack-default.ts
+++ b/resources/js/visual-editor/media-bridge/artisanpack-default.ts
@@ -1,0 +1,68 @@
+/**
+ * `artisanpack-ui/media-library` wiring helper.
+ *
+ * The media bridge (`state.ts`) accepts any picker + uploader pair, but
+ * the default ArtisanPack UI integration pairs `MediaModal` with
+ * `uploadMedia`. This helper packages that wiring behind a single call so
+ * host bootstraps don't have to reach into `registerMediaBridge`'s generic
+ * signature — and, importantly, so the two symbols stay type-checked
+ * against the bridge contract.
+ *
+ * Usage from a host app (after publishing the media-library React sources
+ * via `php artisan vendor:publish --tag=media-react`):
+ *
+ * ```ts
+ * import { registerArtisanpackMediaBridge } from '@artisanpack-ui/visual-editor';
+ * import { MediaModal, uploadMedia } from './vendor/media-library';
+ *
+ * registerArtisanpackMediaBridge({ MediaModal, uploadMedia });
+ * ```
+ *
+ * Hosts using a different library register their own picker directly via
+ * `registerMediaBridge` (see `state.ts`). The two entry points share the
+ * same registration slot, so calling either overrides the previous
+ * registration.
+ */
+
+import { registerMediaBridge, type RegisterMediaBridgeOptions } from './state';
+import type { MediaBridgeComponent, MediaUploader } from './types';
+
+/**
+ * Options accepted by `registerArtisanpackMediaBridge`. Mirrors
+ * `RegisterMediaBridgeOptions` but renames `MediaBridge` → `MediaModal`
+ * and `uploadMedia` stays the same so the call site reads like a direct
+ * hand-off from the library's own exports.
+ */
+export interface RegisterArtisanpackMediaBridgeOptions {
+    /**
+     * `MediaModal` component from `artisanpack-ui/media-library`. Must
+     * accept the modal-picker props the bridge contract defines (open,
+     * onClose, onSelect, multiSelect, allowedTypes, context, title).
+     * `MediaModal`'s published props are a superset of this contract.
+     */
+    MediaModal: MediaBridgeComponent;
+
+    /**
+     * `uploadMedia` function from `artisanpack-ui/media-library`. Used by
+     * `settings.mediaUpload` for drag-and-drop and direct-upload flows.
+     */
+    uploadMedia: MediaUploader;
+}
+
+/**
+ * Register `artisanpack-ui/media-library` as the active media bridge.
+ *
+ * Equivalent to calling `registerMediaBridge({ MediaBridge: MediaModal,
+ * uploadMedia })` — kept as a distinct entry point so hosts can express
+ * intent at the call site and so the package surface documents the
+ * canonical integration path explicitly.
+ */
+export function registerArtisanpackMediaBridge(
+    options: RegisterArtisanpackMediaBridgeOptions
+): void {
+    const bridgeOptions: RegisterMediaBridgeOptions = {
+        MediaBridge: options.MediaModal,
+        uploadMedia: options.uploadMedia,
+    };
+    registerMediaBridge(bridgeOptions);
+}

--- a/resources/js/visual-editor/media-bridge/index.ts
+++ b/resources/js/visual-editor/media-bridge/index.ts
@@ -1,10 +1,15 @@
 /**
  * Media bridge public surface.
  *
- * Hosts wire `artisanpack-ui/media-library` into the editor by calling
- * `registerMediaBridge()` with the library's `MediaModal` component and
- * `uploadMedia` function. See `docs/gutenberg-adoption.md` and issue
- * #314 for background.
+ * Most hosts pair the editor with `artisanpack-ui/media-library` and
+ * should wire the bridge through `registerArtisanpackMediaBridge`, which
+ * takes the library's `MediaModal` component and `uploadMedia` function
+ * and registers both against the bridge in one call. Hosts using a
+ * different media library register their own picker component and
+ * uploader directly through `registerMediaBridge`.
+ *
+ * See `docs/gutenberg-adoption.md` for the end-to-end host wiring and
+ * issue #345 (supersedes the M4 stub from #314) for background.
  */
 
 export {
@@ -12,6 +17,8 @@ export {
     mediaListToGutenberg,
     mediaToGutenberg,
 } from './adapter';
+export { registerArtisanpackMediaBridge } from './artisanpack-default';
+export type { RegisterArtisanpackMediaBridgeOptions } from './artisanpack-default';
 export { MediaUploadBridge } from './media-upload';
 export { mediaUploadSetting } from './media-upload-setting';
 export {

--- a/resources/js/visual-editor/media-bridge/media-upload.tsx
+++ b/resources/js/visual-editor/media-bridge/media-upload.tsx
@@ -162,7 +162,7 @@ function notifyUnconfigured(): void {
     // eslint-disable-next-line no-alert -- intentional operator-facing fallback.
     window.alert(
         __(
-            'Media picker is not configured. Call registerMediaBridge() with MediaModal and uploadMedia from artisanpack-ui/media-library.',
+            'Media picker is not configured. Call registerArtisanpackMediaBridge() with MediaModal and uploadMedia from artisanpack-ui/media-library, or registerMediaBridge() with a custom picker.',
             TEXT_DOMAIN
         )
     );

--- a/src/MediaBridge/GutenbergAttachmentAdapter.php
+++ b/src/MediaBridge/GutenbergAttachmentAdapter.php
@@ -1,0 +1,296 @@
+<?php
+
+/**
+ * Gutenberg attachment adapter.
+ *
+ * Transforms an `artisanpack-ui/media-library` Media record (or any
+ * structurally-compatible media record) into the attachment shape
+ * Gutenberg core blocks expect: `{ id, url, alt, caption, mime, sizes,
+ * media_type, width, height, filename }`.
+ *
+ * Used server-side whenever the editor needs a Gutenberg-shaped media
+ * record without making a round-trip to the client — for example, when
+ * hydrating the Featured Image panel's initial value from a host model,
+ * or when a dynamic block render callback needs to emit an attachment
+ * fragment for a block's `innerHTML`.
+ *
+ * The adapter accepts any object or array that exposes the media-library
+ * field names (`id`, `url`, `mime_type`, `alt_text`, `caption`, `width`,
+ * `height`, `file_name`, `metadata`, `is_image`, `is_video`, `is_audio`,
+ * `is_document`). This keeps the visual-editor package from requiring
+ * `artisanpack-ui/media-library` as a hard dependency: hosts using a
+ * different library can pass a duck-typed record.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor\MediaBridge
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\MediaBridge;
+
+use Illuminate\Contracts\Support\Arrayable;
+
+class GutenbergAttachmentAdapter
+{
+	/**
+	 * Convert a single media record to the Gutenberg attachment shape.
+	 *
+	 * Null alt and caption collapse to empty strings so core blocks never
+	 * render literal `"null"` text. Width, height, filename, and sizes are
+	 * omitted when absent so the output JSON stays terse.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array<string, mixed>|Arrayable<string, mixed>|object  $media  Media record.
+	 *
+	 * @return array<string, mixed> Gutenberg-shaped attachment record.
+	 */
+	public function toGutenberg( array|object $media ): array
+	{
+		$source = $this->normalize( $media );
+
+		$result = [
+			'id'      => (int) ( $source['id'] ?? 0 ),
+			'url'     => (string) ( $source['url'] ?? '' ),
+			'alt'     => $this->stringOrEmpty( $source['alt_text'] ?? null ),
+			'caption' => $this->stringOrEmpty( $source['caption'] ?? null ),
+			'mime'    => (string) ( $source['mime_type'] ?? '' ),
+		];
+
+		$mediaType = $this->inferMediaType( $source );
+		if ( null !== $mediaType ) {
+			$result['media_type'] = $mediaType;
+		}
+
+		if ( $this->isPositiveInt( $source['width'] ?? null ) ) {
+			$result['width'] = (int) $source['width'];
+		}
+
+		if ( $this->isPositiveInt( $source['height'] ?? null ) ) {
+			$result['height'] = (int) $source['height'];
+		}
+
+		$filename = $source['file_name'] ?? null;
+		if ( is_string( $filename ) && '' !== $filename ) {
+			$result['filename'] = $filename;
+		}
+
+		$sizes = $this->extractSizes( $source );
+		if ( null !== $sizes ) {
+			$result['sizes'] = $sizes;
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Convert a collection of media records to Gutenberg attachment shapes.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  iterable<array<string, mixed>|Arrayable<string, mixed>|object>  $items  Media records.
+	 *
+	 * @return array<int, array<string, mixed>> Attachment array.
+	 */
+	public function toGutenbergList( iterable $items ): array
+	{
+		$out = [];
+		foreach ( $items as $item ) {
+			$out[] = $this->toGutenberg( $item );
+		}
+		return $out;
+	}
+
+	/**
+	 * Reduce any supported input into an associative array for uniform
+	 * field access. Objects exposing `toArray()` route through that path so
+	 * Eloquent models surface their appended accessors (including `url`).
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array<string, mixed>|Arrayable<string, mixed>|object  $media  Input record.
+	 *
+	 * @return array<string, mixed>
+	 */
+	protected function normalize( array|object $media ): array
+	{
+		if ( is_array( $media ) ) {
+			return $media;
+		}
+
+		if ( $media instanceof Arrayable ) {
+			return $media->toArray();
+		}
+
+		if ( method_exists( $media, 'toArray' ) ) {
+			$array = $media->toArray();
+			if ( is_array( $array ) ) {
+				return $array;
+			}
+		}
+
+		return get_object_vars( $media );
+	}
+
+	/**
+	 * Classify the record into one of Gutenberg's four media categories.
+	 *
+	 * The media-library model exposes `is_image`/`is_video`/`is_audio`/
+	 * `is_document` booleans; prefer those when present, then fall back to
+	 * the mime-type prefix so duck-typed records without the flags still
+	 * classify correctly.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array<string, mixed>  $source  Normalized media fields.
+	 *
+	 * @return string|null One of 'image', 'video', 'audio', 'file'; null when undetermined.
+	 */
+	protected function inferMediaType( array $source ): ?string
+	{
+		if ( true === ( $source['is_image'] ?? null ) ) {
+			return 'image';
+		}
+
+		if ( true === ( $source['is_video'] ?? null ) ) {
+			return 'video';
+		}
+
+		if ( true === ( $source['is_audio'] ?? null ) ) {
+			return 'audio';
+		}
+
+		if ( true === ( $source['is_document'] ?? null ) ) {
+			return 'file';
+		}
+
+		$mime = $source['mime_type'] ?? null;
+		if ( ! is_string( $mime ) || '' === $mime ) {
+			return null;
+		}
+
+		$prefix = strtolower( explode( '/', $mime, 2 )[0] );
+		switch ( $prefix ) {
+			case 'image':
+				return 'image';
+			case 'video':
+				return 'video';
+			case 'audio':
+				return 'audio';
+			case 'application':
+			case 'text':
+				return 'file';
+			default:
+				return null;
+		}
+	}
+
+	/**
+	 * Pull image sizes out of the record. Accepts three shapes the
+	 * media-library can emit:
+	 *
+	 *  - Top-level `image_sizes` (the Media model's `getImageSizes()`
+	 *    helper output: `[ size_name => url_string ]`).
+	 *  - `metadata.sizes` as `[ size_name => url_string ]`.
+	 *  - `metadata.sizes` as `[ size_name => [ url, width?, height? ] ]`
+	 *    (matches the JS adapter's richer shape).
+	 *
+	 * Returns null when no sizes are available so callers can omit the
+	 * key entirely.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array<string, mixed>  $source  Normalized media fields.
+	 *
+	 * @return array<string, array<string, mixed>>|null
+	 */
+	protected function extractSizes( array $source ): ?array
+	{
+		$candidates = [];
+
+		$topLevel = $source['image_sizes'] ?? null;
+		if ( is_array( $topLevel ) ) {
+			$candidates = $topLevel;
+		} else {
+			$metadata = $source['metadata'] ?? null;
+			if ( is_array( $metadata ) && isset( $metadata['sizes'] ) && is_array( $metadata['sizes'] ) ) {
+				$candidates = $metadata['sizes'];
+			}
+		}
+
+		if ( empty( $candidates ) ) {
+			return null;
+		}
+
+		$out = [];
+		foreach ( $candidates as $name => $value ) {
+			if ( ! is_string( $name ) || '' === $name ) {
+				continue;
+			}
+
+			if ( is_string( $value ) && '' !== $value ) {
+				$out[ $name ] = [ 'url' => $value ];
+				continue;
+			}
+
+			if ( ! is_array( $value ) || ! isset( $value['url'] ) || ! is_string( $value['url'] ) ) {
+				continue;
+			}
+
+			$entry = [ 'url' => $value['url'] ];
+			if ( $this->isPositiveInt( $value['width'] ?? null ) ) {
+				$entry['width'] = (int) $value['width'];
+			}
+			if ( $this->isPositiveInt( $value['height'] ?? null ) ) {
+				$entry['height'] = (int) $value['height'];
+			}
+			$out[ $name ] = $entry;
+		}
+
+		return empty( $out ) ? null : $out;
+	}
+
+	/**
+	 * Coerce null or non-string values into an empty string. Used for
+	 * attachment fields Gutenberg assumes are always strings.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  mixed  $value
+	 *
+	 * @return string
+	 */
+	protected function stringOrEmpty( $value ): string
+	{
+		return is_string( $value ) ? $value : '';
+	}
+
+	/**
+	 * True when `$value` is a positive integer (or a numeric string that
+	 * parses to one). Guards against media-library's nullable width/height
+	 * columns emitting `null` into the attachment shape.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  mixed  $value
+	 *
+	 * @return bool
+	 */
+	protected function isPositiveInt( $value ): bool
+	{
+		if ( is_int( $value ) ) {
+			return 0 < $value;
+		}
+
+		if ( is_string( $value ) && ctype_digit( $value ) ) {
+			return 0 < (int) $value;
+		}
+
+		return false;
+	}
+}

--- a/src/VisualEditorServiceProvider.php
+++ b/src/VisualEditorServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace ArtisanPackUI\VisualEditor;
 
+use ArtisanPackUI\VisualEditor\MediaBridge\GutenbergAttachmentAdapter;
 use ArtisanPackUI\VisualEditor\Models\VisualEditorPost;
 use ArtisanPackUI\VisualEditor\Policies\VisualEditorPostPolicy;
 use ArtisanPackUI\VisualEditor\Registries\BlockTypeRegistry;
@@ -42,6 +43,13 @@ class VisualEditorServiceProvider extends ServiceProvider
 			return new BlockTreeSearchExtractor(
 				$app->make( DynamicBlockRegistry::class )
 			);
+		} );
+
+		// The adapter is stateless and safe to share. Hosts that need a
+		// subclass (e.g. to append custom fields to the attachment shape)
+		// can rebind it via the container.
+		$this->app->singleton( GutenbergAttachmentAdapter::class, function () {
+			return new GutenbergAttachmentAdapter();
 		} );
 
 		// Legacy alias for backward compatibility

--- a/tests/Unit/VisualEditor/MediaBridge/GutenbergAttachmentAdapterTest.php
+++ b/tests/Unit/VisualEditor/MediaBridge/GutenbergAttachmentAdapterTest.php
@@ -1,0 +1,229 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\MediaBridge\GutenbergAttachmentAdapter;
+use Illuminate\Contracts\Support\Arrayable;
+
+function adapterFixture( array $overrides = [] ): array
+{
+	return array_merge( [
+		'id'           => 42,
+		'url'          => 'https://cdn.example.test/pic.jpg',
+		'mime_type'    => 'image/jpeg',
+		'alt_text'     => 'alt',
+		'caption'      => 'caption',
+		'width'        => 1024,
+		'height'       => 768,
+		'file_name'    => 'pic.jpg',
+		'is_image'     => true,
+		'is_video'     => false,
+		'is_audio'     => false,
+		'is_document'  => false,
+		'metadata'     => null,
+	], $overrides );
+}
+
+it( 'maps the core attachment fields', function () {
+	$adapter = new GutenbergAttachmentAdapter();
+
+	$result = $adapter->toGutenberg( adapterFixture() );
+
+	expect( $result )->toMatchArray( [
+		'id'         => 42,
+		'url'        => 'https://cdn.example.test/pic.jpg',
+		'alt'        => 'alt',
+		'caption'    => 'caption',
+		'mime'       => 'image/jpeg',
+		'media_type' => 'image',
+		'width'      => 1024,
+		'height'     => 768,
+		'filename'   => 'pic.jpg',
+	] );
+} );
+
+it( 'collapses null alt and caption to empty strings', function () {
+	$adapter = new GutenbergAttachmentAdapter();
+
+	$result = $adapter->toGutenberg( adapterFixture( [
+		'alt_text' => null,
+		'caption'  => null,
+	] ) );
+
+	expect( $result['alt'] )->toBe( '' )
+		->and( $result['caption'] )->toBe( '' );
+} );
+
+it( 'omits width, height, and filename when the source lacks them', function () {
+	$adapter = new GutenbergAttachmentAdapter();
+
+	$result = $adapter->toGutenberg( adapterFixture( [
+		'width'     => null,
+		'height'    => null,
+		'file_name' => '',
+	] ) );
+
+	expect( $result )->not->toHaveKey( 'width' )
+		->and( $result )->not->toHaveKey( 'height' )
+		->and( $result )->not->toHaveKey( 'filename' );
+} );
+
+it( 'infers media_type from the mime prefix when flags are missing', function () {
+	$adapter = new GutenbergAttachmentAdapter();
+
+	expect( $adapter->toGutenberg( [
+		'id'        => 1,
+		'url'       => 'x',
+		'mime_type' => 'video/mp4',
+	] )['media_type'] )->toBe( 'video' );
+
+	expect( $adapter->toGutenberg( [
+		'id'        => 2,
+		'url'       => 'x',
+		'mime_type' => 'audio/ogg',
+	] )['media_type'] )->toBe( 'audio' );
+
+	expect( $adapter->toGutenberg( [
+		'id'        => 3,
+		'url'       => 'x',
+		'mime_type' => 'application/pdf',
+	] )['media_type'] )->toBe( 'file' );
+
+	expect( $adapter->toGutenberg( [
+		'id'        => 4,
+		'url'       => 'x',
+		'mime_type' => 'text/csv',
+	] )['media_type'] )->toBe( 'file' );
+} );
+
+it( 'prefers explicit type flags over the mime prefix', function () {
+	$adapter = new GutenbergAttachmentAdapter();
+
+	$result = $adapter->toGutenberg( adapterFixture( [
+		'mime_type' => 'image/jpeg',
+		'is_image'  => false,
+		'is_video'  => true,
+	] ) );
+
+	expect( $result['media_type'] )->toBe( 'video' );
+} );
+
+it( 'pulls image sizes from the top-level image_sizes helper output', function () {
+	$adapter = new GutenbergAttachmentAdapter();
+
+	$result = $adapter->toGutenberg( adapterFixture( [
+		'image_sizes' => [
+			'thumbnail' => 'https://cdn.example.test/thumb.jpg',
+			'medium'    => 'https://cdn.example.test/medium.jpg',
+		],
+	] ) );
+
+	expect( $result['sizes'] )->toEqual( [
+		'thumbnail' => [ 'url' => 'https://cdn.example.test/thumb.jpg' ],
+		'medium'    => [ 'url' => 'https://cdn.example.test/medium.jpg' ],
+	] );
+} );
+
+it( 'accepts richer metadata.sizes entries with dimensions', function () {
+	$adapter = new GutenbergAttachmentAdapter();
+
+	$result = $adapter->toGutenberg( adapterFixture( [
+		'metadata' => [
+			'sizes' => [
+				'thumbnail' => [
+					'url'    => 'https://cdn.example.test/thumb.jpg',
+					'width'  => 150,
+					'height' => 150,
+				],
+				'medium' => 'https://cdn.example.test/medium.jpg',
+			],
+		],
+	] ) );
+
+	expect( $result['sizes'] )->toEqual( [
+		'thumbnail' => [
+			'url'    => 'https://cdn.example.test/thumb.jpg',
+			'width'  => 150,
+			'height' => 150,
+		],
+		'medium' => [ 'url' => 'https://cdn.example.test/medium.jpg' ],
+	] );
+} );
+
+it( 'drops malformed size entries instead of emitting a broken url', function () {
+	$adapter = new GutenbergAttachmentAdapter();
+
+	$result = $adapter->toGutenberg( adapterFixture( [
+		'metadata' => [
+			'sizes' => [
+				'missing' => [ 'width' => 10 ],
+				'broken'  => 123,
+				'good'    => [ 'url' => 'https://cdn.example.test/ok.jpg' ],
+			],
+		],
+	] ) );
+
+	expect( $result['sizes'] )->toEqual( [
+		'good' => [ 'url' => 'https://cdn.example.test/ok.jpg' ],
+	] );
+} );
+
+it( 'omits the sizes key when no sizes are available', function () {
+	$adapter = new GutenbergAttachmentAdapter();
+
+	$result = $adapter->toGutenberg( adapterFixture() );
+
+	expect( $result )->not->toHaveKey( 'sizes' );
+} );
+
+it( 'accepts an Arrayable record', function () {
+	$adapter = new GutenbergAttachmentAdapter();
+
+	$record = new class implements Arrayable {
+		public function toArray(): array
+		{
+			return adapterFixture( [ 'id' => 99 ] );
+		}
+	};
+
+	$result = $adapter->toGutenberg( $record );
+
+	expect( $result['id'] )->toBe( 99 );
+} );
+
+it( 'accepts a plain object with toArray()', function () {
+	$adapter = new GutenbergAttachmentAdapter();
+
+	$record = new class {
+		public function toArray(): array
+		{
+			return adapterFixture( [ 'id' => 77 ] );
+		}
+	};
+
+	$result = $adapter->toGutenberg( $record );
+
+	expect( $result['id'] )->toBe( 77 );
+} );
+
+it( 'maps a list of records without mutating the inputs', function () {
+	$adapter = new GutenbergAttachmentAdapter();
+
+	$inputs = [
+		adapterFixture( [ 'id' => 1 ] ),
+		adapterFixture( [ 'id' => 2, 'is_image' => false, 'is_video' => true, 'mime_type' => 'video/mp4' ] ),
+	];
+
+	$result = $adapter->toGutenbergList( $inputs );
+
+	expect( $result )->toHaveCount( 2 )
+		->and( $result[0]['id'] )->toBe( 1 )
+		->and( $result[1]['media_type'] )->toBe( 'video' )
+		->and( $inputs[0]['id'] )->toBe( 1 );
+} );
+
+it( 'is resolvable from the service container', function () {
+	$adapter = app( GutenbergAttachmentAdapter::class );
+
+	expect( $adapter )->toBeInstanceOf( GutenbergAttachmentAdapter::class );
+} );


### PR DESCRIPTION
## Description

Replace the M4 media-bridge stub with a real, host-pluggable integration for `artisanpack-ui/media-library`. Adds a server-side adapter mapping a Media record into Gutenberg's attachment shape, a JS convenience helper that names the canonical wiring, and documentation for the swappable extension point.

**Closes:** #345

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #345

## Motivation and Context

The M4 bridge (#314) shipped the adapter/slot-fill/uploader plumbing but left final wiring to the host. There was no PHP-side record conversion, no canonical helper naming the default integration, and the config file carried a `'null'` placeholder where the adapter class should live. A3 lands the missing pieces without locking the package into `artisanpack-ui/media-library` — hosts using a different library still have a first-class path.

## Changes Made

- Added `ArtisanPackUI\VisualEditor\MediaBridge\GutenbergAttachmentAdapter` — duck-typed transformer from a media-library `Media` record into the Gutenberg attachment shape (`{ id, url, alt, caption, mime, media_type, width, height, filename, sizes }`). Supports both the `image_sizes` helper output and the `metadata.sizes` shape.
- Registered the adapter as a container singleton so hosts can rebind it to customise the emitted shape.
- Added `registerArtisanpackMediaBridge({ MediaModal, uploadMedia })` — a thin helper over `registerMediaBridge` that names the canonical default wiring. Generic `registerMediaBridge()` remains for hosts using a different library.
- Replaced the `media.adapter = 'null'` placeholder with real keys: `media.bridge = 'artisanpack-ui/media-library'` and `media.adapter = GutenbergAttachmentAdapter::class`.
- Rewrote the config commentary and updated the unconfigured-picker alert to reference both entry points.
- Added `artisanpack-ui/media-library` to `composer.json` `suggest` per the issue's "documented host-provided dependency" option.
- New "Media bridge" section in `docs/gutenberg-adoption.md` covering client wiring, swapping in a different library, and the server-side adapter.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS 15 (Darwin 25.3.0)
- Browser: Safari / Chrome (Laravel Herd)
- PHP Version: 8.4.3
- Project Version: 1.0.0-alpha.1 (`release/1.0`)

**Tests Performed:**
1. `./vendor/bin/pest` — 165 tests passed (394 assertions), including 13 new adapter tests.
2. `npm test` — 500 JS tests passed, 1 skipped, including 2 new `registerArtisanpackMediaBridge` tests and the existing `core-blocks.test.tsx` block-integration coverage for all 7 core media blocks.
3. Browser verification in the dev app: inserted `core/image`, `core/gallery`, `core/video`, `core/audio`, `core/file`, and `core/cover`; confirmed the `MediaModal` picker opens, selections map to the Gutenberg shape, and the block renders correctly. Featured Image panel in the Document sidebar drives the same bridge. Drag-and-drop onto the canvas routes through `uploadMedia` and inserts an image block.

## Accessibility Tests Run

- [x] Keyboard navigation tested
- [x] Screen reader tested
- [x] Color contrast verified
- [x] ARIA labels checked

**Details:** The picker UI itself is rendered by `MediaModal` from `artisanpack-ui/media-library`, which owns its a11y story. This PR only wires it in — no new picker markup is introduced. The keyboard path to open the picker (the Media Library button rendered by `MediaUploadBridge`) already had focus + Enter/Space handling from M4 and is unchanged.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:**

- `tests/Unit/VisualEditor/MediaBridge/GutenbergAttachmentAdapterTest.php` — 13 scenarios covering core field mapping, null coercion, mime inference, flag priority, both size shapes, malformed entries, Arrayable/object inputs, list mapping, and container resolution.
- `resources/js/visual-editor/media-bridge/__tests__/artisanpack-default.test.tsx` — confirms `MediaModal` flows into the slot-fill via the new helper and `uploadMedia` registers as the active uploader.
- Existing `core-blocks.test.tsx` (7 blocks × correct `multiSelect` / `allowedTypes` / return shape) remains green.

## Documentation

- [x] Inline code documentation added
- [x] Wiki updated
- [ ] README updated
- [ ] API documentation updated

**Documentation details:** New "Media bridge" section in `docs/gutenberg-adoption.md` with client wiring, swappable-library instructions, and server-side adapter usage. Inline TSDoc and PHPDoc on every new symbol. The package README doesn't currently cover media wiring — left untouched; the gutenberg-adoption doc is the canonical reference.

## Screenshots

N/A — the user-facing picker UI is unchanged; it's the same `MediaModal` from `artisanpack-ui/media-library` that M4 already targeted.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [x] Accessibility tests completed
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Media bridge integration for Gutenberg media blocks and a simplified host registration API for picker+upload.
  * Server-side conversion of host media records into Gutenberg attachment shape for correct editor hydration.

* **Documentation**
  * New guide detailing bridge wiring, upload contract, runtime behavior, and configuration hints.

* **Tests**
  * Added comprehensive tests covering bridge registration, uploader behavior, and media-to-attachment conversions.

* **Chores**
  * Package suggestion added to recommend the companion media-library bridge.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->