### PR TITLE
feat: A4 · Custom block scaffolding + reference block

### DIFF
--- a/config/visual-editor.php
+++ b/config/visual-editor.php
@@ -84,6 +84,7 @@ return [
 		'core/details',
 		'core/search',
 		'core/latest-posts',
+		'artisanpack/callout',
 	],
 
 	'disabled_blocks' => [

--- a/docs/custom-blocks.md
+++ b/docs/custom-blocks.md
@@ -1,0 +1,327 @@
+# Custom blocks
+
+**Status:** V1 · shipped via issue #346 (A4)
+**Reference block:** [`artisanpack/callout`](../resources/js/visual-editor/blocks/callout)
+
+Host apps and packages register their own blocks under the `artisanpack/*`
+namespace (or any other custom namespace) by dropping files into a
+conventional directory and calling one of three PHP registration methods.
+The package does the rest: auto-discovery on the JS side, allow-list
+filtering on the PHP side, and rendering on the public frontend through
+the three renderer packages (Blade, React, Vue).
+
+This document is the authoring pattern. Forking core blocks is *not*
+covered here — that's tracked separately under issue #331 and lands in V2.
+
+---
+
+## 1. Directory layout
+
+Custom blocks live under
+`resources/js/visual-editor/blocks/{block-name}/` with this layout:
+
+```
+resources/js/visual-editor/blocks/
+└── callout/
+    ├── block.json          ← metadata (Gutenberg schema)
+    ├── edit.tsx            ← editor-side React component
+    ├── save.tsx            ← (static blocks) persisted markup
+    ├── index.ts            ← re-exports { metadata, edit, save }
+    └── callout.css         ← optional editor styles
+```
+
+The auto-discovery glob keys off `index.ts`, so every block folder
+**must** expose that entrypoint. Vite picks up any `import` statements in
+`index.ts` — CSS, asset references, or additional helpers — as normal.
+
+Dynamic blocks (server-rendered) may omit `save.tsx`; the PHP render
+callback produces the public markup instead. See §4.
+
+---
+
+## 2. `block.json` schema
+
+Every block is described by a Gutenberg-compatible `block.json`. The
+editor calls `@wordpress/blocks.registerBlockType(name, settings)`
+under the hood, so anything valid in the [WordPress block.json reference](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/)
+is valid here.
+
+Minimum fields for the ArtisanPack pipeline:
+
+| Field        | Purpose                                                                   |
+|--------------|---------------------------------------------------------------------------|
+| `name`       | `namespace/name` — lowercase, hyphens only (e.g. `artisanpack/callout`)   |
+| `category`   | `artisanpack` for bundled/reference blocks; free choice for host apps     |
+| `title`      | User-facing label shown in the inserter                                   |
+| `attributes` | Block attributes (optionally typed/enumerated with `default` values)      |
+| `supports`   | Which Gutenberg block supports to enable (alignment, color, spacing, …)   |
+
+Example (abridged) from `artisanpack/callout`:
+
+```json
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "artisanpack/callout",
+    "title": "Callout",
+    "category": "artisanpack",
+    "attributes": {
+        "severity": {
+            "type": "string",
+            "enum": ["info", "success", "warning", "error"],
+            "default": "info"
+        },
+        "content": {
+            "type": "rich-text",
+            "source": "rich-text",
+            "selector": "div.ap-callout__body",
+            "default": ""
+        }
+    },
+    "supports": {
+        "anchor": true,
+        "className": true,
+        "spacing": { "margin": true, "padding": true }
+    }
+}
+```
+
+The `artisanpack` category is registered automatically by the editor; any
+block whose `category` matches that slug shows up in the block library
+sidebar under the ArtisanPack heading.
+
+---
+
+## 3. PHP registration
+
+The PHP `VisualEditor::registerBlock()` method accepts any of three input
+shapes. Pick whichever one matches where your metadata lives.
+
+### 3.1 From a `block.json` path
+
+```php
+use ArtisanPackUI\VisualEditor\Facades\VisualEditor;
+
+public function boot(): void
+{
+    VisualEditor::registerBlock(
+        resource_path('js/visual-editor/blocks/callout/block.json')
+    );
+}
+```
+
+This is the canonical form — the same file powers both the JS auto-
+registration and the PHP allow-list.
+
+### 3.2 From a class
+
+Implement `ProvidesBlockMetadata` to expose a static `blockMetadata()`
+method returning the metadata array. Useful when the metadata is built
+from config, enum definitions, or other PHP-side state:
+
+```php
+use ArtisanPackUI\VisualEditor\Blocks\ProvidesBlockMetadata;
+use ArtisanPackUI\VisualEditor\Facades\VisualEditor;
+
+class CalloutBlock implements ProvidesBlockMetadata
+{
+    public static function blockMetadata(): array
+    {
+        return [
+            'name'       => 'artisanpack/callout',
+            'title'      => __('Callout'),
+            'category'   => 'artisanpack',
+            'attributes' => config('callouts.attributes'),
+        ];
+    }
+}
+
+VisualEditor::registerBlock(CalloutBlock::class);
+```
+
+### 3.3 From a closure
+
+The most flexible form — handy for quick iteration in a service provider
+or for blocks assembled at boot time:
+
+```php
+VisualEditor::registerBlock(fn (): array => [
+    'name'     => 'acme/notice',
+    'title'    => __('Notice'),
+    'category' => 'artisanpack',
+]);
+```
+
+The closure must return an array; a non-array return throws
+`InvalidArgumentException`.
+
+### 3.4 Enabling the block
+
+Registering a block makes it known to the PHP registry; whether the
+editor exposes it in the inserter depends on the allow-list. Add the
+fully-qualified block name to `config/artisanpack/visual-editor.php`:
+
+```php
+'enabled_blocks' => [
+    // … core blocks …
+    'artisanpack/callout',
+    'acme/notice',
+],
+```
+
+The bundled `artisanpack/callout` is already in the default allow-list.
+
+---
+
+## 4. Static vs dynamic — which do I need?
+
+### Static blocks
+
+The `edit.tsx` + `save.tsx` pair persists serialized HTML inside the
+post content. Every renderer (Blade, React, Vue) either outputs that
+HTML verbatim (when passing through raw) or rebuilds the same markup from
+attributes. Static blocks are the right default:
+
+- The output is deterministic from the attributes alone.
+- No request-time data is required to render.
+- The markup does not change based on the viewing user.
+
+The callout is a static block. Its `save.tsx` returns the final HTML;
+`save`/`edit` parity is validated by Gutenberg on load.
+
+### Dynamic blocks
+
+Dynamic blocks render server-side. Register the implementation via
+`VisualEditor::registerDynamicBlock()` and omit `save.tsx` entirely — the
+editor uses the preview endpoint while authoring, and the Blade/React/Vue
+renderers call the PHP render callback at request time.
+
+```php
+use ArtisanPackUI\VisualEditor\Blocks\DynamicBlock;
+
+class LatestPostsBlock extends DynamicBlock
+{
+    public function name(): string
+    {
+        return 'artisanpack/latest-posts';
+    }
+
+    public function render(array $attrs)
+    {
+        return view('blocks.latest-posts', [
+            'posts' => Post::latest()->take($attrs['limit'] ?? 5)->get(),
+        ]);
+    }
+}
+
+VisualEditor::registerDynamicBlock(LatestPostsBlock::class);
+```
+
+Use a dynamic block when:
+
+- Output depends on the current request (authenticated user, request
+  time, query parameters).
+- Output depends on database state that can change between save and
+  render (latest posts, cart totals, stock levels).
+- The block needs to run Laravel authorization before exposing data.
+
+---
+
+## 5. Rendering on the public frontend
+
+The visual editor ships three renderer packages. Each one looks up a
+per-block partial/component by name and falls back to a "no renderer
+registered" placeholder otherwise. A custom static block needs a
+matching partial in every renderer you plan to use.
+
+### 5.1 Blade renderer
+
+`artisanpack-ui/visual-editor-renderer-blade` resolves the view name
+`visual-editor-renderer-blade::blocks.{namespace}.{block}`. Add a
+partial at:
+
+```
+packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/callout.blade.php
+```
+
+The partial receives the block attributes in `$attributes` plus
+`$innerBlocksHtml` (pre-rendered children). Mirror the `save.tsx` markup:
+
+```blade
+@php
+    $severity = (string) ( $attributes['severity'] ?? 'info' );
+    $content  = (string) ( $attributes['content'] ?? '' );
+@endphp
+<div class="ap-callout ap-callout--{{ $severity }}" data-severity="{{ $severity }}">
+    <div class="ap-callout__body">{!! $content !!}</div>
+</div>
+```
+
+Host apps can override any core or custom partial by publishing
+`visual-editor-blade-views` and editing the file under
+`resources/views/vendor/visual-editor-renderer-blade/blocks/…`.
+
+### 5.2 React renderer
+
+`artisanpack-ui/visual-editor-renderer-react` holds a module-level
+registry keyed by block name. Create a renderer component:
+
+```
+packages/visual-editor-renderer-react/src/blocks/artisanpack/callout.tsx
+```
+
+Then register it from `registerCoreBlocks.ts` (or from the host app's
+own bootstrap):
+
+```ts
+import { registerBlockRenderer } from './registry';
+import { CalloutBlock } from './blocks/artisanpack/callout';
+
+registerBlockRenderer('artisanpack/callout', CalloutBlock);
+```
+
+The React component receives `{ attributes, innerBlocks, children }`.
+Reuse the `attrString` / `classList` helpers in `support/attributes.ts`
+for safe coercion.
+
+### 5.3 Vue renderer
+
+Identical pattern to React, using `defineComponent` and
+`blockRendererProps`:
+
+```
+packages/visual-editor-renderer-vue/src/blocks/artisanpack/callout.ts
+```
+
+Register via the same `registerBlockRenderer(name, component)` API.
+
+### 5.4 Dynamic blocks and renderers
+
+Dynamic blocks do **not** need per-renderer partials. The Blade renderer
+invokes the registered `DynamicBlock::render()` directly; the React and
+Vue renderers fall back to `<DynamicBlock>` which fetches the server-
+rendered HTML from the preview endpoint.
+
+---
+
+## 6. Authoring checklist
+
+For every new static block:
+
+- [ ] Directory created under `resources/js/visual-editor/blocks/{name}/`
+- [ ] `block.json` with a namespaced `name`, category, attributes, supports
+- [ ] `edit.tsx` with `useBlockProps` and any `InspectorControls`
+- [ ] `save.tsx` producing byte-identical markup for the `edit` output
+- [ ] `index.ts` re-exporting `{ metadata, edit, save }`
+- [ ] PHP registration (`VisualEditor::registerBlock(...)` in a boot hook)
+- [ ] Added to `enabled_blocks` in `config/artisanpack/visual-editor.php`
+- [ ] Blade partial in `visual-editor-renderer-blade`
+- [ ] React renderer in `visual-editor-renderer-react` + registered
+- [ ] Vue renderer in `visual-editor-renderer-vue` + registered
+- [ ] Tests:
+    - PHP: registry covers at least one of path / class / closure
+    - JS: `registerCustomBlocks` + edit/save round-trip
+    - Renderer-Blade / Renderer-React / Renderer-Vue: per-block render test
+
+For dynamic blocks, swap `save.tsx` for a `DynamicBlock` subclass and
+skip the per-renderer partials.

--- a/docs/custom-blocks.md
+++ b/docs/custom-blocks.md
@@ -20,7 +20,7 @@ covered here — that's tracked separately under issue #331 and lands in V2.
 Custom blocks live under
 `resources/js/visual-editor/blocks/{block-name}/` with this layout:
 
-```
+```text
 resources/js/visual-editor/blocks/
 └── callout/
     ├── block.json          ← metadata (Gutenberg schema)
@@ -240,7 +240,7 @@ matching partial in every renderer you plan to use.
 `visual-editor-renderer-blade::blocks.{namespace}.{block}`. Add a
 partial at:
 
-```
+```text
 packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/callout.blade.php
 ```
 
@@ -266,7 +266,7 @@ Host apps can override any core or custom partial by publishing
 `artisanpack-ui/visual-editor-renderer-react` holds a module-level
 registry keyed by block name. Create a renderer component:
 
-```
+```text
 packages/visual-editor-renderer-react/src/blocks/artisanpack/callout.tsx
 ```
 
@@ -289,7 +289,7 @@ for safe coercion.
 Identical pattern to React, using `defineComponent` and
 `blockRendererProps`:
 
-```
+```text
 packages/visual-editor-renderer-vue/src/blocks/artisanpack/callout.ts
 ```
 

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/callout.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/callout.blade.php
@@ -1,0 +1,43 @@
+@php
+	$validSeverities = [ 'info', 'success', 'warning', 'error' ];
+	$validIcons      = [ 'info', 'check', 'warning', 'error', 'lightbulb' ];
+
+	$severity = (string) ( $attributes['severity'] ?? 'info' );
+
+	if ( ! in_array( $severity, $validSeverities, true ) ) {
+		$severity = 'info';
+	}
+
+	$icon = (string) ( $attributes['icon'] ?? 'info' );
+
+	if ( ! in_array( $icon, $validIcons, true ) ) {
+		$icon = 'info';
+	}
+
+	$content = (string) ( $attributes['content'] ?? '' );
+
+	$iconPaths = [
+		'info'      => 'M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2Zm1 15h-2v-6h2Zm0-8h-2V7h2Z',
+		'check'     => 'M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2Zm-1.5 14.5-4-4 1.4-1.4 2.6 2.6 6.6-6.6L17.5 8.5Z',
+		'warning'   => 'M12 2 1 21h22Zm1 15h-2v-2h2Zm0-4h-2V9h2Z',
+		'error'     => 'M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2Zm5 13.6L15.6 17 12 13.4 8.4 17 7 15.6 10.6 12 7 8.4 8.4 7 12 10.6 15.6 7 17 8.4 13.4 12Z',
+		'lightbulb' => 'M9 21h6v-1H9Zm3-19a7 7 0 0 0-4 12.74V17h8v-2.26A7 7 0 0 0 12 2Zm1 12h-2v-2h2Z',
+	];
+
+	$classes = [
+		'ap-callout',
+		'ap-callout--' . $severity,
+	];
+
+	if ( ! empty( $attributes['className'] ) ) {
+		$classes[] = $attributes['className'];
+	}
+@endphp
+<div class="{{ implode( ' ', array_map( 'trim', $classes ) ) }}" data-severity="{{ $severity }}">
+	<span class="ap-callout__icon" aria-hidden="true">
+		<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+			<path d="{{ $iconPaths[ $icon ] }}"></path>
+		</svg>
+	</span>
+	<div class="ap-callout__body">{!! $content !!}</div>
+</div>

--- a/packages/visual-editor-renderer-blade/tests/Unit/BlockRendererTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Unit/BlockRendererTest.php
@@ -471,3 +471,35 @@ it( 'preserves fractional column widths', function () {
 
 	expect( $html )->toContain( 'flex-basis: 33.33%;' );
 } );
+
+it( 'renders the artisanpack/callout reference block with severity and icon', function () {
+	$tree = [
+		makeBlock( 'artisanpack/callout', [
+			'severity' => 'warning',
+			'icon'     => 'warning',
+			'content'  => 'Check this out.',
+		] ),
+	];
+
+	$html = makeRenderer()->render( $tree );
+
+	expect( $html )->toContain( 'ap-callout ap-callout--warning' )
+		->and( $html )->toContain( 'data-severity="warning"' )
+		->and( $html )->toContain( '<div class="ap-callout__body">Check this out.</div>' )
+		->and( $html )->toContain( '<svg' );
+} );
+
+it( 'falls back to safe defaults when callout severity or icon is invalid', function () {
+	$tree = [
+		makeBlock( 'artisanpack/callout', [
+			'severity' => 'catastrophic',
+			'icon'     => 'rocket',
+			'content'  => 'fallback',
+		] ),
+	];
+
+	$html = makeRenderer()->render( $tree );
+
+	expect( $html )->toContain( 'ap-callout--info' )
+		->and( $html )->toContain( 'data-severity="info"' );
+} );

--- a/packages/visual-editor-renderer-react/src/blocks/artisanpack/callout.tsx
+++ b/packages/visual-editor-renderer-react/src/blocks/artisanpack/callout.tsx
@@ -1,0 +1,84 @@
+/**
+ * React renderer for the `artisanpack/callout` reference block.
+ *
+ * Mirrors the Blade partial in
+ * `packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/callout.blade.php`
+ * and the edit/save components in
+ * `resources/js/visual-editor/blocks/callout/` so every renderer ships
+ * identical markup.
+ */
+
+import { attrString, classList } from '../../support/attributes';
+import type { BlockRendererProps } from '../../types';
+
+type CalloutSeverity = 'info' | 'success' | 'warning' | 'error';
+type CalloutIconName = 'info' | 'check' | 'warning' | 'error' | 'lightbulb';
+
+const VALID_SEVERITIES: ReadonlyArray<CalloutSeverity> = [
+    'info',
+    'success',
+    'warning',
+    'error',
+];
+
+const VALID_ICONS: ReadonlyArray<CalloutIconName> = [
+    'info',
+    'check',
+    'warning',
+    'error',
+    'lightbulb',
+];
+
+const ICON_PATHS: Readonly<Record<CalloutIconName, string>> = {
+    info: 'M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2Zm1 15h-2v-6h2Zm0-8h-2V7h2Z',
+    check: 'M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2Zm-1.5 14.5-4-4 1.4-1.4 2.6 2.6 6.6-6.6L17.5 8.5Z',
+    warning: 'M12 2 1 21h22Zm1 15h-2v-2h2Zm0-4h-2V9h2Z',
+    error: 'M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2Zm5 13.6L15.6 17 12 13.4 8.4 17 7 15.6 10.6 12 7 8.4 8.4 7 12 10.6 15.6 7 17 8.4 13.4 12Z',
+    lightbulb: 'M9 21h6v-1H9Zm3-19a7 7 0 0 0-4 12.74V17h8v-2.26A7 7 0 0 0 12 2Zm1 12h-2v-2h2Z',
+};
+
+function normalizeSeverity(value: unknown): CalloutSeverity {
+    const raw = attrString(value, 'info');
+    return (VALID_SEVERITIES as ReadonlyArray<string>).includes(raw)
+        ? (raw as CalloutSeverity)
+        : 'info';
+}
+
+function normalizeIcon(value: unknown): CalloutIconName {
+    const raw = attrString(value, 'info');
+    return (VALID_ICONS as ReadonlyArray<string>).includes(raw)
+        ? (raw as CalloutIconName)
+        : 'info';
+}
+
+export function CalloutBlock({ attributes }: BlockRendererProps): JSX.Element {
+    const severity = normalizeSeverity(attributes.severity);
+    const icon = normalizeIcon(attributes.icon);
+    const content = attrString(attributes.content);
+    const className = attrString(attributes.className);
+
+    const classes = classList([
+        'ap-callout',
+        `ap-callout--${severity}`,
+        className,
+    ]);
+
+    return (
+        <div className={classes} data-severity={severity}>
+            <span className="ap-callout__icon" aria-hidden="true">
+                <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 24 24"
+                    aria-hidden="true"
+                    focusable="false"
+                >
+                    <path d={ICON_PATHS[icon]} />
+                </svg>
+            </span>
+            <div
+                className="ap-callout__body"
+                dangerouslySetInnerHTML={{ __html: content }}
+            />
+        </div>
+    );
+}

--- a/packages/visual-editor-renderer-react/src/blocks/registerCoreBlocks.ts
+++ b/packages/visual-editor-renderer-react/src/blocks/registerCoreBlocks.ts
@@ -12,6 +12,7 @@
  */
 
 import { registerBlockRenderer } from '../registry';
+import { CalloutBlock } from './artisanpack/callout';
 import {
     CoverBlock,
     DetailsBlock,
@@ -81,6 +82,7 @@ const CORE_BLOCKS: Record<string, BlockRenderer> = {
     'core/search': SearchBlock,
     'core/separator': SeparatorBlock,
     'core/spacer': SpacerBlock,
+    'artisanpack/callout': CalloutBlock,
 };
 
 export function registerCoreBlocks(): void {

--- a/packages/visual-editor-renderer-react/tests/BlockTree.test.tsx
+++ b/packages/visual-editor-renderer-react/tests/BlockTree.test.tsx
@@ -556,6 +556,38 @@ describe('Core design blocks', () => {
 
         expect(renderTree(tree)).toContain('<button type="submit" class="wp-block-search__button"></button>');
     });
+
+    it('renders the artisanpack/callout reference block', () => {
+        const tree = [
+            makeBlock('artisanpack/callout', {
+                severity: 'success',
+                icon: 'check',
+                content: 'Nice work.',
+            }),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('class="ap-callout ap-callout--success"');
+        expect(html).toContain('data-severity="success"');
+        expect(html).toContain('<div class="ap-callout__body">Nice work.</div>');
+        expect(html).toContain('<svg');
+    });
+
+    it('normalizes invalid callout severity and icon to safe defaults', () => {
+        const tree = [
+            makeBlock('artisanpack/callout', {
+                severity: 'galactic',
+                icon: 'rocket',
+                content: 'fallback',
+            }),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('ap-callout--info');
+        expect(html).toContain('data-severity="info"');
+    });
 });
 
 describe('Registry + dynamic fallback', () => {

--- a/packages/visual-editor-renderer-vue/src/blocks/artisanpack/callout.ts
+++ b/packages/visual-editor-renderer-vue/src/blocks/artisanpack/callout.ts
@@ -1,0 +1,93 @@
+/**
+ * Vue renderer for the `artisanpack/callout` reference block.
+ *
+ * Mirrors the Blade partial and the React renderer so every rendering
+ * environment emits identical markup for the same saved block tree.
+ */
+
+import { defineComponent, h } from 'vue';
+
+import { attrString, classList } from '../../support/attributes';
+import { blockRendererProps } from '../shared';
+
+type CalloutSeverity = 'info' | 'success' | 'warning' | 'error';
+type CalloutIconName = 'info' | 'check' | 'warning' | 'error' | 'lightbulb';
+
+const VALID_SEVERITIES: ReadonlyArray<CalloutSeverity> = [
+    'info',
+    'success',
+    'warning',
+    'error',
+];
+
+const VALID_ICONS: ReadonlyArray<CalloutIconName> = [
+    'info',
+    'check',
+    'warning',
+    'error',
+    'lightbulb',
+];
+
+const ICON_PATHS: Readonly<Record<CalloutIconName, string>> = {
+    info: 'M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2Zm1 15h-2v-6h2Zm0-8h-2V7h2Z',
+    check: 'M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2Zm-1.5 14.5-4-4 1.4-1.4 2.6 2.6 6.6-6.6L17.5 8.5Z',
+    warning: 'M12 2 1 21h22Zm1 15h-2v-2h2Zm0-4h-2V9h2Z',
+    error: 'M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2Zm5 13.6L15.6 17 12 13.4 8.4 17 7 15.6 10.6 12 7 8.4 8.4 7 12 10.6 15.6 7 17 8.4 13.4 12Z',
+    lightbulb: 'M9 21h6v-1H9Zm3-19a7 7 0 0 0-4 12.74V17h8v-2.26A7 7 0 0 0 12 2Zm1 12h-2v-2h2Z',
+};
+
+function normalizeSeverity(value: unknown): CalloutSeverity {
+    const raw = attrString(value, 'info');
+    return (VALID_SEVERITIES as ReadonlyArray<string>).includes(raw)
+        ? (raw as CalloutSeverity)
+        : 'info';
+}
+
+function normalizeIcon(value: unknown): CalloutIconName {
+    const raw = attrString(value, 'info');
+    return (VALID_ICONS as ReadonlyArray<string>).includes(raw)
+        ? (raw as CalloutIconName)
+        : 'info';
+}
+
+export const CalloutBlock = defineComponent({
+    name: 'CalloutBlock',
+    props: blockRendererProps,
+    setup(props) {
+        return () => {
+            const severity = normalizeSeverity(props.attributes.severity);
+            const icon = normalizeIcon(props.attributes.icon);
+            const content = attrString(props.attributes.content);
+            const className = attrString(props.attributes.className);
+
+            const classes = classList([
+                'ap-callout',
+                `ap-callout--${severity}`,
+                className,
+            ]);
+
+            return h(
+                'div',
+                { class: classes, 'data-severity': severity },
+                [
+                    h('span', { class: 'ap-callout__icon', 'aria-hidden': 'true' }, [
+                        h(
+                            'svg',
+                            {
+                                xmlns: 'http://www.w3.org/2000/svg',
+                                viewBox: '0 0 24 24',
+                                'aria-hidden': 'true',
+                                focusable: 'false',
+                            },
+                            [h('path', { d: ICON_PATHS[icon] })],
+                        ),
+                    ]),
+                    h('div', {
+                        class: 'ap-callout__body',
+                        innerHTML: content,
+                    }),
+                ],
+            );
+        };
+    },
+});

--- a/packages/visual-editor-renderer-vue/src/blocks/registerCoreBlocks.ts
+++ b/packages/visual-editor-renderer-vue/src/blocks/registerCoreBlocks.ts
@@ -12,6 +12,7 @@
  */
 
 import { registerBlockRenderer } from '../registry';
+import { CalloutBlock } from './artisanpack/callout';
 import {
     CoverBlock,
     DetailsBlock,
@@ -81,6 +82,7 @@ const CORE_BLOCKS: Record<string, BlockRenderer> = {
     'core/search': SearchBlock,
     'core/separator': SeparatorBlock,
     'core/spacer': SpacerBlock,
+    'artisanpack/callout': CalloutBlock,
 };
 
 export function registerCoreBlocks(): void {

--- a/packages/visual-editor-renderer-vue/tests/BlockTree.test.ts
+++ b/packages/visual-editor-renderer-vue/tests/BlockTree.test.ts
@@ -559,6 +559,38 @@ describe('Core design blocks', () => {
 
         expect(renderTree(tree)).toContain('<button type="submit" class="wp-block-search__button"></button>');
     });
+
+    it('renders the artisanpack/callout reference block', () => {
+        const tree = [
+            makeBlock('artisanpack/callout', {
+                severity: 'success',
+                icon: 'check',
+                content: 'Nice work.',
+            }),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('class="ap-callout ap-callout--success"');
+        expect(html).toContain('data-severity="success"');
+        expect(html).toContain('<div class="ap-callout__body">Nice work.</div>');
+        expect(html).toContain('<svg');
+    });
+
+    it('normalizes invalid callout severity and icon to safe defaults', () => {
+        const tree = [
+            makeBlock('artisanpack/callout', {
+                severity: 'galactic',
+                icon: 'rocket',
+                content: 'fallback',
+            }),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('ap-callout--info');
+        expect(html).toContain('data-severity="info"');
+    });
 });
 
 describe('Registry + dynamic fallback', () => {

--- a/resources/js/visual-editor/blocks/callout/block.json
+++ b/resources/js/visual-editor/blocks/callout/block.json
@@ -26,12 +26,7 @@
         }
     },
     "supports": {
-        "anchor": true,
         "className": true,
-        "html": false,
-        "spacing": {
-            "margin": true,
-            "padding": true
-        }
+        "html": false
     }
 }

--- a/resources/js/visual-editor/blocks/callout/block.json
+++ b/resources/js/visual-editor/blocks/callout/block.json
@@ -1,0 +1,37 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "artisanpack/callout",
+    "title": "Callout",
+    "category": "artisanpack",
+    "description": "Highlight a short message with a severity badge and icon.",
+    "keywords": ["callout", "notice", "alert", "tip"],
+    "textdomain": "visual-editor",
+    "attributes": {
+        "severity": {
+            "type": "string",
+            "enum": ["info", "success", "warning", "error"],
+            "default": "info"
+        },
+        "icon": {
+            "type": "string",
+            "enum": ["info", "check", "warning", "error", "lightbulb"],
+            "default": "info"
+        },
+        "content": {
+            "type": "rich-text",
+            "source": "rich-text",
+            "selector": "div.ap-callout__body",
+            "default": ""
+        }
+    },
+    "supports": {
+        "anchor": true,
+        "className": true,
+        "html": false,
+        "spacing": {
+            "margin": true,
+            "padding": true
+        }
+    }
+}

--- a/resources/js/visual-editor/blocks/callout/callout.css
+++ b/resources/js/visual-editor/blocks/callout/callout.css
@@ -1,0 +1,59 @@
+/**
+ * Callout block styles.
+ *
+ * Loaded in the editor via `blocks/callout/index.ts` so authors see the
+ * block chromed; host apps are expected to reuse these rules (or a
+ * compatible override) on the public frontend. Values use CSS variables
+ * so DaisyUI themes and host-app theming can swap colors without
+ * patching the block.
+ */
+
+.ap-callout {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.75rem;
+    padding: 1rem 1.25rem;
+    border-radius: 0.5rem;
+    border-left: 4px solid var(--ap-callout-accent, #3b82f6);
+    background: var(--ap-callout-surface, rgba(59, 130, 246, 0.08));
+    color: var(--ap-callout-color, inherit);
+}
+
+.ap-callout--info {
+    --ap-callout-accent: #3b82f6;
+    --ap-callout-surface: rgba(59, 130, 246, 0.08);
+}
+
+.ap-callout--success {
+    --ap-callout-accent: #16a34a;
+    --ap-callout-surface: rgba(22, 163, 74, 0.08);
+}
+
+.ap-callout--warning {
+    --ap-callout-accent: #d97706;
+    --ap-callout-surface: rgba(217, 119, 6, 0.08);
+}
+
+.ap-callout--error {
+    --ap-callout-accent: #dc2626;
+    --ap-callout-surface: rgba(220, 38, 38, 0.08);
+}
+
+.ap-callout__icon {
+    flex: 0 0 auto;
+    width: 1.5rem;
+    height: 1.5rem;
+    color: var(--ap-callout-accent, currentColor);
+}
+
+.ap-callout__icon svg {
+    width: 100%;
+    height: 100%;
+    fill: currentColor;
+}
+
+.ap-callout__body {
+    flex: 1 1 auto;
+    min-width: 0;
+    line-height: 1.5;
+}

--- a/resources/js/visual-editor/blocks/callout/callout.css
+++ b/resources/js/visual-editor/blocks/callout/callout.css
@@ -43,13 +43,13 @@
     flex: 0 0 auto;
     width: 1.5rem;
     height: 1.5rem;
-    color: var(--ap-callout-accent, currentColor);
+    color: var(--ap-callout-accent, currentcolor);
 }
 
 .ap-callout__icon svg {
     width: 100%;
     height: 100%;
-    fill: currentColor;
+    fill: currentcolor;
 }
 
 .ap-callout__body {

--- a/resources/js/visual-editor/blocks/callout/edit.tsx
+++ b/resources/js/visual-editor/blocks/callout/edit.tsx
@@ -1,0 +1,107 @@
+/**
+ * Callout — editor-side render.
+ *
+ * The edit component mirrors the static `save.tsx` output so authors see
+ * exactly what the frontend renders, and wires the severity + icon
+ * attributes into the InspectorControls sidebar so they can be changed
+ * without leaving the canvas. `RichText` drives the body; Gutenberg's
+ * `source: 'rich-text'` attribute wiring handles serialization for us.
+ */
+
+import type { ReactElement } from 'react';
+import {
+    InspectorControls,
+    RichText,
+    useBlockProps,
+} from '@wordpress/block-editor';
+import { PanelBody, SelectControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+import { TEXT_DOMAIN } from '../../vendor/i18n';
+
+import { CalloutIcon, type CalloutIconName } from './icons';
+
+export type CalloutSeverity = 'info' | 'success' | 'warning' | 'error';
+
+interface CalloutAttributes {
+    readonly severity: CalloutSeverity;
+    readonly icon: CalloutIconName;
+    readonly content: string;
+}
+
+interface CalloutEditProps {
+    readonly attributes: CalloutAttributes;
+    readonly setAttributes: (next: Partial<CalloutAttributes>) => void;
+}
+
+const SEVERITY_OPTIONS: ReadonlyArray<{ readonly label: string; readonly value: CalloutSeverity }> = [
+    { label: 'Info', value: 'info' },
+    { label: 'Success', value: 'success' },
+    { label: 'Warning', value: 'warning' },
+    { label: 'Error', value: 'error' },
+];
+
+const ICON_OPTIONS: ReadonlyArray<{ readonly label: string; readonly value: CalloutIconName }> = [
+    { label: 'Info', value: 'info' },
+    { label: 'Check', value: 'check' },
+    { label: 'Warning', value: 'warning' },
+    { label: 'Error', value: 'error' },
+    { label: 'Lightbulb', value: 'lightbulb' },
+];
+
+export default function CalloutEdit({
+    attributes,
+    setAttributes,
+}: CalloutEditProps): ReactElement {
+    const { severity, icon, content } = attributes;
+
+    const blockProps = useBlockProps({
+        className: `ap-callout ap-callout--${severity}`,
+        'data-severity': severity,
+    });
+
+    return (
+        <>
+            <InspectorControls>
+                <PanelBody title={__('Callout settings', TEXT_DOMAIN)} initialOpen>
+                    <SelectControl
+                        label={__('Severity', TEXT_DOMAIN)}
+                        value={severity}
+                        options={SEVERITY_OPTIONS.map((option) => ({
+                            label: __(option.label, TEXT_DOMAIN),
+                            value: option.value,
+                        }))}
+                        onChange={(value) =>
+                            setAttributes({ severity: value as CalloutSeverity })
+                        }
+                        __nextHasNoMarginBottom
+                    />
+                    <SelectControl
+                        label={__('Icon', TEXT_DOMAIN)}
+                        value={icon}
+                        options={ICON_OPTIONS.map((option) => ({
+                            label: __(option.label, TEXT_DOMAIN),
+                            value: option.value,
+                        }))}
+                        onChange={(value) =>
+                            setAttributes({ icon: value as CalloutIconName })
+                        }
+                        __nextHasNoMarginBottom
+                    />
+                </PanelBody>
+            </InspectorControls>
+            <div {...blockProps}>
+                <span className="ap-callout__icon" aria-hidden="true">
+                    <CalloutIcon name={icon} />
+                </span>
+                <RichText
+                    tagName="div"
+                    className="ap-callout__body"
+                    value={content}
+                    onChange={(next: string) => setAttributes({ content: next })}
+                    placeholder={__('Write a callout…', TEXT_DOMAIN)}
+                />
+            </div>
+        </>
+    );
+}

--- a/resources/js/visual-editor/blocks/callout/icons.tsx
+++ b/resources/js/visual-editor/blocks/callout/icons.tsx
@@ -1,0 +1,102 @@
+/**
+ * Inline SVG icons shared between the callout `edit.tsx` and `save.tsx`.
+ *
+ * Inlining here (rather than pulling @wordpress/icons) guarantees the
+ * save output is byte-identical across environments — critical because
+ * Gutenberg validates saved markup on load and throws a recovery modal
+ * when the editor's render doesn't match what was persisted.
+ */
+
+import type { ReactElement } from 'react';
+
+export type CalloutIconName =
+    | 'info'
+    | 'check'
+    | 'warning'
+    | 'error'
+    | 'lightbulb';
+
+interface CalloutIconProps {
+    readonly name: CalloutIconName;
+}
+
+function InfoIcon(): ReactElement {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+            focusable="false"
+        >
+            <path d="M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2Zm1 15h-2v-6h2Zm0-8h-2V7h2Z" />
+        </svg>
+    );
+}
+
+function CheckIcon(): ReactElement {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+            focusable="false"
+        >
+            <path d="M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2Zm-1.5 14.5-4-4 1.4-1.4 2.6 2.6 6.6-6.6L17.5 8.5Z" />
+        </svg>
+    );
+}
+
+function WarningIcon(): ReactElement {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+            focusable="false"
+        >
+            <path d="M12 2 1 21h22Zm1 15h-2v-2h2Zm0-4h-2V9h2Z" />
+        </svg>
+    );
+}
+
+function ErrorIcon(): ReactElement {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+            focusable="false"
+        >
+            <path d="M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2Zm5 13.6L15.6 17 12 13.4 8.4 17 7 15.6 10.6 12 7 8.4 8.4 7 12 10.6 15.6 7 17 8.4 13.4 12Z" />
+        </svg>
+    );
+}
+
+function LightbulbIcon(): ReactElement {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+            focusable="false"
+        >
+            <path d="M9 21h6v-1H9Zm3-19a7 7 0 0 0-4 12.74V17h8v-2.26A7 7 0 0 0 12 2Zm1 12h-2v-2h2Z" />
+        </svg>
+    );
+}
+
+const REGISTRY: Readonly<Record<CalloutIconName, () => ReactElement>> = {
+    info: InfoIcon,
+    check: CheckIcon,
+    warning: WarningIcon,
+    error: ErrorIcon,
+    lightbulb: LightbulbIcon,
+};
+
+export function CalloutIcon({ name }: CalloutIconProps): ReactElement {
+    const Renderer = REGISTRY[name] ?? InfoIcon;
+    return <Renderer />;
+}
+
+export const CALLOUT_ICON_NAMES: ReadonlyArray<CalloutIconName> =
+    Object.keys(REGISTRY) as ReadonlyArray<CalloutIconName>;

--- a/resources/js/visual-editor/blocks/callout/index.ts
+++ b/resources/js/visual-editor/blocks/callout/index.ts
@@ -1,0 +1,29 @@
+/**
+ * Callout block entrypoint.
+ *
+ * Re-exports `edit`, `save`, and `metadata` so the host JS bundle (via the
+ * custom block auto-discovery glob — see `../../editor/custom-blocks.ts`)
+ * can register the block with `@wordpress/blocks.registerBlockType`.
+ *
+ * Also exports an `icon` SVG for the block-library inserter. The editor
+ * does not bundle `dashicons.css`, so a dashicon-slug icon in `block.json`
+ * would render as a blank square. Providing the inline SVG here bypasses
+ * the Dashicon pipeline entirely.
+ */
+
+import metadata from './block.json';
+import edit from './edit';
+import save from './save';
+import icon from './inserter-icon';
+
+import './callout.css';
+
+export { edit, save, metadata, icon };
+
+export default {
+    name: metadata.name,
+    metadata,
+    edit,
+    save,
+    icon,
+};

--- a/resources/js/visual-editor/blocks/callout/inserter-icon.tsx
+++ b/resources/js/visual-editor/blocks/callout/inserter-icon.tsx
@@ -1,0 +1,24 @@
+/**
+ * Inline SVG icon used by the block-library inserter.
+ *
+ * Mirrors the lightbulb glyph rather than the severity glyph — the
+ * inserter icon should communicate "tip / highlight," not a specific
+ * severity state the author hasn't chosen yet.
+ */
+
+import type { ReactElement } from 'react';
+
+export default function CalloutInserterIcon(): ReactElement {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            width="24"
+            height="24"
+            aria-hidden="true"
+            focusable="false"
+        >
+            <path d="M9 21h6v-1H9Zm3-19a7 7 0 0 0-4 12.74V17h8v-2.26A7 7 0 0 0 12 2Zm1 12h-2v-2h2Z" />
+        </svg>
+    );
+}

--- a/resources/js/visual-editor/blocks/callout/save.tsx
+++ b/resources/js/visual-editor/blocks/callout/save.tsx
@@ -1,0 +1,50 @@
+/**
+ * Callout — saved markup.
+ *
+ * Persists the same DOM shape the edit component renders so Gutenberg's
+ * save-vs-edit validation passes on reload. The frontend renderers
+ * (Blade, React, Vue) output the serialized HTML verbatim; the host
+ * application is responsible for shipping the matching `.ap-callout`
+ * stylesheet.
+ */
+
+import type { ReactElement } from 'react';
+import { RichText, useBlockProps } from '@wordpress/block-editor';
+
+import { CalloutIcon, type CalloutIconName } from './icons';
+
+type CalloutSeverity = 'info' | 'success' | 'warning' | 'error';
+
+interface CalloutAttributes {
+    readonly severity: CalloutSeverity;
+    readonly icon: CalloutIconName;
+    readonly content: string;
+}
+
+interface CalloutSaveProps {
+    readonly attributes: CalloutAttributes;
+}
+
+export default function CalloutSave({
+    attributes,
+}: CalloutSaveProps): ReactElement {
+    const { severity, icon, content } = attributes;
+
+    const blockProps = useBlockProps.save({
+        className: `ap-callout ap-callout--${severity}`,
+        'data-severity': severity,
+    });
+
+    return (
+        <div {...blockProps}>
+            <span className="ap-callout__icon" aria-hidden="true">
+                <CalloutIcon name={icon} />
+            </span>
+            <RichText.Content
+                tagName="div"
+                className="ap-callout__body"
+                value={content}
+            />
+        </div>
+    );
+}

--- a/resources/js/visual-editor/editor/__tests__/custom-blocks.test.tsx
+++ b/resources/js/visual-editor/editor/__tests__/custom-blocks.test.tsx
@@ -1,0 +1,301 @@
+/**
+ * Tests for the custom block discovery/registration pipeline and the
+ * bundled `artisanpack/callout` reference block.
+ *
+ * `@wordpress/blocks` is fully mocked so Node's strict JSON import
+ * semantics don't trip over the package's internal
+ * `i18n-block.json` import — we only need the mock to prove the
+ * orchestration layer calls the right WP APIs.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render } from '@testing-library/react';
+
+const categoriesState: Array<{ slug: string; title: string }> = [];
+const registeredTypes = new Map<string, unknown>();
+
+vi.mock('@wordpress/blocks', () => ({
+    getCategories: () => [...categoriesState],
+    setCategories: (next: Array<{ slug: string; title: string }>) => {
+        categoriesState.length = 0;
+        categoriesState.push(...next);
+    },
+    registerBlockType: (name: string, settings: unknown) => {
+        if (registeredTypes.has(name)) {
+            throw new Error(`Block ${name} already registered`);
+        }
+        registeredTypes.set(name, settings);
+        return settings;
+    },
+    getBlockType: (name: string) => registeredTypes.get(name),
+    unregisterBlockType: (name: string) => {
+        registeredTypes.delete(name);
+    },
+    getBlockTypes: () =>
+        Array.from(registeredTypes.entries()).map(([name, settings]) => ({
+            name,
+            ...(settings as Record<string, unknown>),
+        })),
+}));
+
+vi.mock('@wordpress/block-editor', () => ({
+    InspectorControls: ({ children }: { children: React.ReactNode }) => (
+        <div data-testid="inspector">{children}</div>
+    ),
+    RichText: Object.assign(
+        function RichText(props: { value?: string; className?: string }) {
+            return (
+                <div
+                    data-testid="richtext"
+                    className={props.className}
+                    dangerouslySetInnerHTML={{ __html: props.value ?? '' }}
+                />
+            );
+        },
+        {
+            Content: function RichTextContent(props: {
+                value?: string;
+                className?: string;
+            }) {
+                return (
+                    <div
+                        data-testid="richtext-content"
+                        className={props.className}
+                        dangerouslySetInnerHTML={{ __html: props.value ?? '' }}
+                    />
+                );
+            },
+        }
+    ),
+    useBlockProps: Object.assign(
+        (props?: Record<string, unknown>) => ({ ...props }),
+        { save: (props?: Record<string, unknown>) => ({ ...props }) }
+    ),
+}));
+
+vi.mock('@wordpress/components', () => ({
+    PanelBody: ({
+        title,
+        children,
+    }: {
+        title: string;
+        children: React.ReactNode;
+    }) => (
+        <div data-testid="panel-body" data-title={title}>
+            {children}
+        </div>
+    ),
+    SelectControl: ({
+        label,
+        value,
+        options,
+        onChange,
+    }: {
+        label: string;
+        value: string;
+        options: ReadonlyArray<{ label: string; value: string }>;
+        onChange: (value: string) => void;
+    }) => (
+        <label>
+            {label}
+            <select
+                value={value}
+                onChange={(event) => onChange(event.target.value)}
+                data-testid={`select-${label}`}
+            >
+                {options.map((option) => (
+                    <option key={option.value} value={option.value}>
+                        {option.label}
+                    </option>
+                ))}
+            </select>
+        </label>
+    ),
+}));
+
+vi.mock('@wordpress/i18n', () => ({
+    __: (text: string) => text,
+}));
+
+import {
+    ARTISANPACK_CATEGORY_SLUG,
+    __resetCustomBlockRegistrationCache,
+    ensureArtisanpackCategory,
+    registerCustomBlocks,
+} from '../custom-blocks';
+
+import calloutEdit from '../../blocks/callout/edit';
+import calloutSave from '../../blocks/callout/save';
+import calloutIcon from '../../blocks/callout/inserter-icon';
+import calloutMetadata from '../../blocks/callout/block.json';
+
+beforeEach(() => {
+    categoriesState.length = 0;
+    categoriesState.push(
+        { slug: 'text', title: 'Text' },
+        { slug: 'media', title: 'Media' }
+    );
+    registeredTypes.clear();
+    __resetCustomBlockRegistrationCache();
+});
+
+describe('ensureArtisanpackCategory', () => {
+    it('adds the artisanpack category when missing', () => {
+        ensureArtisanpackCategory('ArtisanPack');
+
+        expect(categoriesState.map((cat) => cat.slug)).toContain(
+            ARTISANPACK_CATEGORY_SLUG
+        );
+    });
+
+    it('does not duplicate the category on repeat calls', () => {
+        ensureArtisanpackCategory();
+        ensureArtisanpackCategory();
+
+        const matches = categoriesState.filter(
+            (cat) => cat.slug === ARTISANPACK_CATEGORY_SLUG
+        );
+        expect(matches).toHaveLength(1);
+    });
+
+    it('preserves pre-existing categories', () => {
+        ensureArtisanpackCategory();
+
+        const slugs = categoriesState.map((cat) => cat.slug);
+        expect(slugs).toContain('text');
+        expect(slugs).toContain('media');
+    });
+});
+
+describe('registerCustomBlocks', () => {
+    it('registers a module with metadata, edit, and save', () => {
+        const names = registerCustomBlocks([
+            {
+                metadata: calloutMetadata,
+                edit: calloutEdit,
+                save: calloutSave,
+            },
+        ]);
+
+        expect(names).toContain('artisanpack/callout');
+        expect(registeredTypes.has('artisanpack/callout')).toBe(true);
+    });
+
+    it('skips modules missing a metadata name', () => {
+        const names = registerCustomBlocks([
+            {
+                metadata: { title: 'Nameless' } as unknown as {
+                    name: string;
+                },
+                edit: calloutEdit,
+            },
+        ]);
+
+        expect(names).toHaveLength(0);
+    });
+
+    it('is idempotent on repeat calls for the same block', () => {
+        registerCustomBlocks([
+            { metadata: calloutMetadata, edit: calloutEdit, save: calloutSave },
+        ]);
+        const second = registerCustomBlocks([
+            { metadata: calloutMetadata, edit: calloutEdit, save: calloutSave },
+        ]);
+
+        expect(second).toEqual(['artisanpack/callout']);
+        expect(registeredTypes.size).toBe(1);
+    });
+
+    it('passes edit and save through to registerBlockType settings', () => {
+        registerCustomBlocks([
+            { metadata: calloutMetadata, edit: calloutEdit, save: calloutSave },
+        ]);
+
+        const settings = registeredTypes.get('artisanpack/callout') as {
+            edit?: unknown;
+            save?: unknown;
+            category?: string;
+        };
+
+        expect(settings.edit).toBe(calloutEdit);
+        expect(settings.save).toBe(calloutSave);
+        expect(settings.category).toBe(ARTISANPACK_CATEGORY_SLUG);
+    });
+
+    it('forwards an icon override to registerBlockType settings', () => {
+        registerCustomBlocks([
+            {
+                metadata: calloutMetadata,
+                edit: calloutEdit,
+                save: calloutSave,
+                icon: calloutIcon,
+            },
+        ]);
+
+        const settings = registeredTypes.get('artisanpack/callout') as {
+            icon?: unknown;
+        };
+
+        expect(settings.icon).toBe(calloutIcon);
+    });
+});
+
+describe('artisanpack/callout block.json', () => {
+    it('declares severity + icon attributes with enum defaults', () => {
+        expect(calloutMetadata.name).toBe('artisanpack/callout');
+        expect(calloutMetadata.category).toBe(ARTISANPACK_CATEGORY_SLUG);
+        expect(calloutMetadata.attributes.severity.default).toBe('info');
+        expect(calloutMetadata.attributes.icon.default).toBe('info');
+        expect(calloutMetadata.attributes.severity.enum).toContain('warning');
+        expect(calloutMetadata.attributes.icon.enum).toContain('lightbulb');
+    });
+});
+
+describe('artisanpack/callout save', () => {
+    it('renders with the severity class and icon SVG', () => {
+        const { container } = render(
+            calloutSave({
+                attributes: {
+                    severity: 'success',
+                    icon: 'check',
+                    content: '<strong>Saved!</strong>',
+                },
+            } as Parameters<typeof calloutSave>[0])
+        );
+
+        const root = container.querySelector('.ap-callout');
+        expect(root).not.toBeNull();
+        expect(root?.classList.contains('ap-callout--success')).toBe(true);
+        expect(root?.getAttribute('data-severity')).toBe('success');
+        expect(container.querySelector('svg')).not.toBeNull();
+        expect(container.querySelector('.ap-callout__body')?.innerHTML).toBe(
+            '<strong>Saved!</strong>'
+        );
+    });
+});
+
+describe('artisanpack/callout edit', () => {
+    it('renders inspector controls for severity and icon and fires setAttributes on change', () => {
+        const setAttributes = vi.fn();
+        const { getByTestId } = render(
+            calloutEdit({
+                attributes: {
+                    severity: 'info',
+                    icon: 'info',
+                    content: 'Body text',
+                },
+                setAttributes,
+            } as Parameters<typeof calloutEdit>[0])
+        );
+
+        const severitySelect = getByTestId('select-Severity') as HTMLSelectElement;
+        severitySelect.value = 'warning';
+        severitySelect.dispatchEvent(new Event('change', { bubbles: true }));
+        expect(setAttributes).toHaveBeenCalledWith({ severity: 'warning' });
+
+        const iconSelect = getByTestId('select-Icon') as HTMLSelectElement;
+        iconSelect.value = 'lightbulb';
+        iconSelect.dispatchEvent(new Event('change', { bubbles: true }));
+        expect(setAttributes).toHaveBeenCalledWith({ icon: 'lightbulb' });
+    });
+});

--- a/resources/js/visual-editor/editor/custom-blocks.ts
+++ b/resources/js/visual-editor/editor/custom-blocks.ts
@@ -1,0 +1,221 @@
+/**
+ * Custom block auto-discovery.
+ *
+ * Host apps drop a block into
+ * `resources/js/visual-editor/blocks/{block-name}/` with the conventional
+ * `block.json`, `edit.tsx`, and (for static blocks) `save.tsx` files. The
+ * Vite build picks them up via `import.meta.glob` and this module hands
+ * the normalized modules to `registerBlockType` once per session.
+ *
+ * Keeping the discovery glob here — rather than inline in `editor-app.tsx`
+ * — makes it straightforward to unit-test via the exported
+ * `registerCustomBlocks(modules)` helper.
+ */
+
+/// <reference types="vite/client" />
+
+import { getCategories, registerBlockType, setCategories } from '@wordpress/blocks';
+import type { BlockConfiguration } from '@wordpress/blocks';
+
+export const ARTISANPACK_CATEGORY_SLUG = 'artisanpack';
+
+export interface CustomBlockModule {
+    /**
+     * Parsed `block.json` metadata. Must include a namespaced `name`.
+     */
+    readonly metadata: { readonly name: string } & Record<string, unknown>;
+    /**
+     * Editor-side React component for the block.
+     */
+    readonly edit: BlockConfiguration['edit'];
+    /**
+     * Save-side React component. Optional for server-rendered (dynamic)
+     * blocks that resolve on the PHP side.
+     */
+    readonly save?: BlockConfiguration['save'];
+    /**
+     * Optional block-library icon override. Accepts the same shapes
+     * `@wordpress/blocks` does — a Dashicon slug, an SVG React element,
+     * or the `{ src, background, foreground }` object form. Host apps
+     * use this when they want an inline SVG rather than the Dashicon
+     * string declared in `block.json`, which requires `dashicons.css`
+     * to be loaded.
+     */
+    readonly icon?: BlockConfiguration['icon'];
+}
+
+/**
+ * Register the `artisanpack` block category on the first call.
+ *
+ * `setCategories` replaces the full list, so we append to whatever the
+ * host (or `@wordpress/block-library`) has already seeded. Subsequent
+ * calls are no-ops.
+ */
+export function ensureArtisanpackCategory(
+    title: string = 'ArtisanPack'
+): void {
+    const categories = getCategories() as ReadonlyArray<{ slug: string }>;
+
+    if (categories.some((category) => category.slug === ARTISANPACK_CATEGORY_SLUG)) {
+        return;
+    }
+
+    setCategories([
+        ...categories,
+        { slug: ARTISANPACK_CATEGORY_SLUG, title },
+    ]);
+}
+
+const registered = new Set<string>();
+
+/**
+ * Register a batch of custom block modules with `@wordpress/blocks`.
+ *
+ * Each module must expose a `metadata` object (from `block.json`) and an
+ * `edit` component. `save` is optional — dynamic blocks omit it and rely
+ * on the PHP render callback. Re-registering the same block is a no-op so
+ * HMR reloads don't warn "Block X is already registered."
+ */
+export function registerCustomBlocks(
+    modules: ReadonlyArray<CustomBlockModule>
+): ReadonlyArray<string> {
+    ensureArtisanpackCategory();
+
+    const names: string[] = [];
+
+    for (const module of modules) {
+        const name = module.metadata?.name;
+
+        if (typeof name !== 'string' || name === '') {
+            console.warn(
+                'visual-editor: skipping custom block with missing metadata.name.',
+                module
+            );
+            continue;
+        }
+
+        if (registered.has(name)) {
+            names.push(name);
+            continue;
+        }
+
+        const { metadata, edit, save, icon } = module;
+        const { name: _metadataName, ...rest } = metadata;
+
+        const settings: BlockConfiguration = {
+            ...(rest as Partial<BlockConfiguration>),
+            edit,
+            ...(save !== undefined ? { save } : {}),
+            ...(icon !== undefined ? { icon } : {}),
+        } as BlockConfiguration;
+
+        try {
+            registerBlockType(name, settings);
+            registered.add(name);
+            names.push(name);
+        } catch (error) {
+            console.error(
+                `visual-editor: failed to register custom block "${name}".`,
+                error
+            );
+        }
+    }
+
+    return names;
+}
+
+interface GlobbedModule {
+    readonly default?: unknown;
+    readonly edit?: unknown;
+    readonly save?: unknown;
+    readonly metadata?: unknown;
+    readonly icon?: unknown;
+}
+
+/**
+ * Discover and register every custom block under
+ * `resources/js/visual-editor/blocks/{block-name}/index.ts` via Vite's
+ * eager `import.meta.glob`. The glob pattern is deliberately restricted
+ * to the conventional `index.ts` entrypoint so the filesystem layout is
+ * predictable.
+ *
+ * Returns the registered block names for diagnostic logging.
+ */
+export function discoverAndRegisterCustomBlocks(): ReadonlyArray<string> {
+    // `import.meta.glob` is a Vite-specific API that Vite transforms at
+    // build time — the string literal + options object MUST appear
+    // inline, otherwise Vite leaves the call in place and the runtime
+    // blows up with "undefined is not a function". The `vite/client`
+    // triple-slash reference at the top of this file gives TypeScript
+    // the matching declaration.
+    const modules = import.meta.glob<GlobbedModule>(
+        '../blocks/*/index.ts',
+        { eager: true }
+    );
+
+    const discovered: CustomBlockModule[] = [];
+
+    for (const module of Object.values(modules)) {
+        const resolved = resolveCustomBlockModule(module);
+
+        if (resolved !== null) {
+            discovered.push(resolved);
+        }
+    }
+
+    return registerCustomBlocks(discovered);
+}
+
+function resolveCustomBlockModule(module: GlobbedModule): CustomBlockModule | null {
+    const candidate =
+        module.default !== undefined &&
+        module.default !== null &&
+        typeof module.default === 'object'
+            ? (module.default as GlobbedModule)
+            : module;
+
+    const metadata = candidate.metadata;
+
+    if (
+        metadata === null ||
+        metadata === undefined ||
+        typeof metadata !== 'object'
+    ) {
+        return null;
+    }
+
+    const name = (metadata as { name?: unknown }).name;
+
+    if (typeof name !== 'string' || name === '') {
+        return null;
+    }
+
+    const edit = candidate.edit;
+
+    if (typeof edit !== 'function') {
+        return null;
+    }
+
+    const save = candidate.save;
+    const icon = candidate.icon;
+
+    return {
+        metadata: metadata as CustomBlockModule['metadata'],
+        edit: edit as CustomBlockModule['edit'],
+        ...(typeof save === 'function'
+            ? { save: save as CustomBlockModule['save'] }
+            : {}),
+        ...(icon !== undefined
+            ? { icon: icon as CustomBlockModule['icon'] }
+            : {}),
+    };
+}
+
+/**
+ * Test-only: reset the dedupe cache so a fresh registration pass can run.
+ *
+ * @internal
+ */
+export function __resetCustomBlockRegistrationCache(): void {
+    registered.clear();
+}

--- a/resources/js/visual-editor/editor/custom-blocks.ts
+++ b/resources/js/visual-editor/editor/custom-blocks.ts
@@ -166,13 +166,32 @@ export function discoverAndRegisterCustomBlocks(): ReadonlyArray<string> {
     return registerCustomBlocks(discovered);
 }
 
+function hasBlockShape(value: unknown): value is GlobbedModule {
+    if (value === null || value === undefined || typeof value !== 'object') {
+        return false;
+    }
+
+    const candidate = value as GlobbedModule;
+    const metadata = candidate.metadata;
+
+    return (
+        metadata !== null &&
+        metadata !== undefined &&
+        typeof metadata === 'object' &&
+        typeof (metadata as { name?: unknown }).name === 'string' &&
+        typeof candidate.edit === 'function'
+    );
+}
+
 function resolveCustomBlockModule(module: GlobbedModule): CustomBlockModule | null {
-    const candidate =
-        module.default !== undefined &&
-        module.default !== null &&
-        typeof module.default === 'object'
-            ? (module.default as GlobbedModule)
-            : module;
+    // Prefer the `default` export only when it actually looks like a
+    // block module (has the metadata + edit shape). Otherwise fall back
+    // to the named exports on `module` itself — a default export that's
+    // unrelated (e.g. a helper object) shouldn't shadow valid named
+    // exports.
+    const candidate: GlobbedModule = hasBlockShape(module.default)
+        ? (module.default as GlobbedModule)
+        : module;
 
     const metadata = candidate.metadata;
 

--- a/resources/js/visual-editor/editor/editor-app.tsx
+++ b/resources/js/visual-editor/editor/editor-app.tsx
@@ -42,6 +42,7 @@ import {
 } from '../media-bridge';
 
 import { BlockLibrarySidebar } from './block-library-sidebar';
+import { discoverAndRegisterCustomBlocks } from './custom-blocks';
 import {
     DocumentPanels,
     type AuthorOption,
@@ -149,6 +150,12 @@ function registerOnce(): void {
     // already-registered blocks with the default (buggy) checker on.
     disableContrastCheckerOnBlocks();
     registerCoreBlocks();
+    // Discover host-app custom blocks under
+    // `resources/js/visual-editor/blocks/{block-name}/index.ts` and
+    // register them plus the `artisanpack` category. Runs after
+    // `registerCoreBlocks` so custom-block category registration sees
+    // the full core category list.
+    discoverAndRegisterCustomBlocks();
     blocksRegistered = true;
 }
 

--- a/src/Blocks/ProvidesBlockMetadata.php
+++ b/src/Blocks/ProvidesBlockMetadata.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * Marker interface for block classes that expose block.json-compatible metadata.
+ *
+ * Host apps and packages can register a block by passing the implementing class
+ * name to {@see \ArtisanPackUI\VisualEditor\VisualEditor::registerBlock()}. The
+ * returned array must match the block.json schema (at minimum a namespaced
+ * `name` field).
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Blocks;
+
+interface ProvidesBlockMetadata
+{
+	/**
+	 * Return the block's metadata array.
+	 *
+	 * The shape mirrors block.json: at least a namespaced `name` plus the
+	 * keys the editor consumes (`title`, `category`, `attributes`, etc.).
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<string, mixed>
+	 */
+	public static function blockMetadata(): array;
+}

--- a/src/Facades/VisualEditor.php
+++ b/src/Facades/VisualEditor.php
@@ -5,7 +5,7 @@ namespace ArtisanPackUI\VisualEditor\Facades;
 use Illuminate\Support\Facades\Facade;
 
 /**
- * @method static void registerBlock(string $blockJsonPath)
+ * @method static void registerBlock(string|\Closure $source)
  * @method static void registerBlockType(string $name, array $definition)
  * @method static \ArtisanPackUI\VisualEditor\Blocks\DynamicBlock registerDynamicBlock(\ArtisanPackUI\VisualEditor\Blocks\DynamicBlock|string $blockOrName, ?array $config = null)
  * @method static \ArtisanPackUI\VisualEditor\Registries\BlockTypeRegistry getRegistry()

--- a/src/VisualEditor.php
+++ b/src/VisualEditor.php
@@ -21,6 +21,7 @@ namespace ArtisanPackUI\VisualEditor;
 
 use ArtisanPackUI\VisualEditor\Blocks\ClosureDynamicBlock;
 use ArtisanPackUI\VisualEditor\Blocks\DynamicBlock;
+use ArtisanPackUI\VisualEditor\Blocks\ProvidesBlockMetadata;
 use ArtisanPackUI\VisualEditor\Registries\BlockTypeRegistry;
 use ArtisanPackUI\VisualEditor\Registries\DynamicBlockRegistry;
 use Closure;
@@ -36,19 +37,113 @@ class VisualEditor
 	}
 
 	/**
-	 * Registers a block type from a block.json manifest file.
+	 * Registers a block type from one of three sources.
 	 *
-	 * Reads the JSON file, validates it has a `name` field, and stores
-	 * the full metadata in the block type registry.
+	 *   1. **Path string** — an absolute path to a `block.json` manifest.
+	 *      The file is read and parsed, and the full metadata is stored
+	 *      in the block type registry.
+	 *
+	 *      `VisualEditor::registerBlock(__DIR__ . '/callout/block.json');`
+	 *
+	 *   2. **Class name** — a string that resolves to a class implementing
+	 *      {@see ProvidesBlockMetadata}. The static `blockMetadata()` method
+	 *      is invoked to obtain the metadata array.
+	 *
+	 *      `VisualEditor::registerBlock(CalloutBlock::class);`
+	 *
+	 *   3. **Closure** — any callable that returns a metadata array. Useful
+	 *      when the metadata is computed at registration time (e.g. pulling
+	 *      attribute defaults from config).
+	 *
+	 *      `VisualEditor::registerBlock(fn () => ['name' => 'acme/callout', ...]);`
+	 *
+	 * In all three cases the returned metadata must contain a non-empty
+	 * `name` field in `namespace/name` format.
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param  string  $blockJsonPath  Absolute path to the block.json file.
+	 * @param  string|Closure  $source  Path to block.json, a class name that implements
+	 *                                  {@see ProvidesBlockMetadata}, or a closure that
+	 *                                  returns a metadata array.
 	 *
-	 * @throws InvalidArgumentException When the file doesn't exist or is invalid.
-	 * @throws JsonException            When the JSON cannot be parsed.
+	 * @throws InvalidArgumentException When the source is invalid or the resulting
+	 *                                  metadata is missing a `name` field.
+	 * @throws JsonException            When a block.json file cannot be parsed.
 	 */
-	public function registerBlock( string $blockJsonPath ): void
+	public function registerBlock( $source ): void
+	{
+		$metadata = $this->resolveBlockMetadata( $source );
+
+		if ( ! isset( $metadata['name'] ) || ! is_string( $metadata['name'] ) || '' === trim( $metadata['name'] ) ) {
+			throw new InvalidArgumentException(
+				'Block metadata is missing a non-empty "name" field.'
+			);
+		}
+
+		$this->registry->register( $metadata['name'], $metadata );
+	}
+
+	/**
+	 * Resolve the block metadata array from the registration source.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string|Closure  $source
+	 *
+	 * @return array<string, mixed>
+	 */
+	protected function resolveBlockMetadata( $source ): array
+	{
+		if ( $source instanceof Closure ) {
+			$value = ( $source )();
+
+			if ( ! is_array( $value ) ) {
+				throw new InvalidArgumentException(
+					'Block registration closure must return an array of metadata.'
+				);
+			}
+
+			return $value;
+		}
+
+		if ( ! is_string( $source ) || '' === trim( $source ) ) {
+			throw new InvalidArgumentException(
+				'Block registration requires a block.json path, a class name, or a closure.'
+			);
+		}
+
+		if ( class_exists( $source ) ) {
+			if ( ! is_subclass_of( $source, ProvidesBlockMetadata::class ) && ! in_array( ProvidesBlockMetadata::class, class_implements( $source ) ?: [], true ) ) {
+				throw new InvalidArgumentException( sprintf(
+					'Block class "%s" must implement %s.',
+					$source,
+					ProvidesBlockMetadata::class
+				) );
+			}
+
+			$value = $source::blockMetadata();
+
+			if ( ! is_array( $value ) ) {
+				throw new InvalidArgumentException( sprintf(
+					'%s::blockMetadata() must return an array.',
+					$source
+				) );
+			}
+
+			return $value;
+		}
+
+		return $this->loadBlockJsonMetadata( $source );
+	}
+
+	/**
+	 * Read and decode a `block.json` manifest file into a metadata array.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<string, mixed>
+	 */
+	protected function loadBlockJsonMetadata( string $blockJsonPath ): array
 	{
 		if ( ! file_exists( $blockJsonPath ) ) {
 			throw new InvalidArgumentException(
@@ -66,13 +161,13 @@ class VisualEditor
 
 		$metadata = json_decode( $json, true, 512, JSON_THROW_ON_ERROR );
 
-		if ( ! is_array( $metadata ) || ! isset( $metadata['name'] ) || ! is_string( $metadata['name'] ) || '' === trim( $metadata['name'] ) ) {
+		if ( ! is_array( $metadata ) ) {
 			throw new InvalidArgumentException(
-				sprintf( 'block.json missing required "name" field: %s', $blockJsonPath )
+				sprintf( 'block.json did not decode to an object: %s', $blockJsonPath )
 			);
 		}
 
-		$this->registry->register( $metadata['name'], $metadata );
+		return $metadata;
 	}
 
 	/**

--- a/src/VisualEditor.php
+++ b/src/VisualEditor.php
@@ -74,13 +74,28 @@ class VisualEditor
 	{
 		$metadata = $this->resolveBlockMetadata( $source );
 
-		if ( ! isset( $metadata['name'] ) || ! is_string( $metadata['name'] ) || '' === trim( $metadata['name'] ) ) {
+		if ( ! isset( $metadata['name'] ) || ! is_string( $metadata['name'] ) ) {
 			throw new InvalidArgumentException(
 				'Block metadata is missing a non-empty "name" field.'
 			);
 		}
 
-		$this->registry->register( $metadata['name'], $metadata );
+		$normalizedName = trim( $metadata['name'] );
+
+		if ( '' === $normalizedName ) {
+			throw new InvalidArgumentException(
+				'Block metadata is missing a non-empty "name" field.'
+			);
+		}
+
+		// Store the trimmed name back into the metadata array so the
+		// registry ends up with a canonical value in both the key and
+		// the definition's own `name` field. Format validation
+		// (namespace/name, lowercase, hyphens) is enforced by
+		// {@see BlockTypeRegistry::register()}.
+		$metadata['name'] = $normalizedName;
+
+		$this->registry->register( $normalizedName, $metadata );
 	}
 
 	/**

--- a/src/VisualEditorServiceProvider.php
+++ b/src/VisualEditorServiceProvider.php
@@ -85,7 +85,13 @@ class VisualEditorServiceProvider extends ServiceProvider
 		// 3. Register core blocks from their block.json manifests.
 		$this->registerCoreBlocks();
 
-		// 4. Tag the config file for the scaffold command.
+		// 4. Register the bundled reference custom block
+		//    (`artisanpack/callout`). Demonstrates the auto-discovered
+		//    block pattern for host apps and exercises the `artisanpack`
+		//    category end-to-end.
+		$this->registerReferenceBlocks();
+
+		// 5. Tag the config file for the scaffold command.
 		if ( $this->app->runningInConsole() ) {
 			$this->publishes( [
 								  __DIR__ . '/../config/visual-editor.php' => config_path( 'artisanpack/visual-editor.php' ),
@@ -116,6 +122,36 @@ class VisualEditorServiceProvider extends ServiceProvider
 		];
 
 		foreach ( $coreBlocks as $block ) {
+			$blockJsonPath = $blocksDir . '/' . $block . '/block.json';
+
+			if ( file_exists( $blockJsonPath ) ) {
+				$editor->registerBlock( $blockJsonPath );
+			}
+		}
+	}
+
+	/**
+	 * Registers the bundled reference blocks from the
+	 * `resources/js/visual-editor/blocks/` directory.
+	 *
+	 * Keeping the path discovery in PHP (rather than trusting the JS
+	 * auto-discovery glob alone) means the server-side registry knows
+	 * about the block — its metadata flows into `getEnabledBlockNames()`
+	 * and into anything that reads the registry — even before the editor
+	 * bundle loads.
+	 *
+	 * @since 1.0.0
+	 */
+	protected function registerReferenceBlocks(): void
+	{
+		$editor    = $this->app->make( VisualEditor::class );
+		$blocksDir = __DIR__ . '/../resources/js/visual-editor/blocks';
+
+		$referenceBlocks = [
+			'callout',
+		];
+
+		foreach ( $referenceBlocks as $block ) {
 			$blockJsonPath = $blocksDir . '/' . $block . '/block.json';
 
 			if ( file_exists( $blockJsonPath ) ) {

--- a/tests/Fixtures/TestBlockMetadata.php
+++ b/tests/Fixtures/TestBlockMetadata.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace Tests\Fixtures;
+
+use ArtisanPackUI\VisualEditor\Blocks\ProvidesBlockMetadata;
+
+class TestBlockMetadata implements ProvidesBlockMetadata
+{
+	public static function blockMetadata(): array
+	{
+		return [
+			'name'        => 'tests/metadata-block',
+			'title'       => 'Metadata Block',
+			'category'    => 'artisanpack',
+			'description' => 'Fixture block registered via a class.',
+			'attributes'  => [
+				'label' => [
+					'type'    => 'string',
+					'default' => '',
+				],
+			],
+		];
+	}
+}

--- a/tests/Unit/VisualEditor/EnabledBlockNamesTest.php
+++ b/tests/Unit/VisualEditor/EnabledBlockNamesTest.php
@@ -40,6 +40,7 @@ it( 'returns the frozen V1 block allow-list under the default config', function 
 		'core/details',
 		'core/search',
 		'core/latest-posts',
+		'artisanpack/callout',
 	] );
 } );
 

--- a/tests/Unit/VisualEditor/RegisterBlockTest.php
+++ b/tests/Unit/VisualEditor/RegisterBlockTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Facades\VisualEditor;
+use ArtisanPackUI\VisualEditor\Registries\BlockTypeRegistry;
+use Tests\Fixtures\TestBlockMetadata;
+
+beforeEach( function () {
+	$this->tempDir = sys_get_temp_dir() . '/visual-editor-register-block-' . bin2hex( random_bytes( 4 ) );
+	mkdir( $this->tempDir );
+} );
+
+afterEach( function () {
+	if ( isset( $this->tempDir ) && is_dir( $this->tempDir ) ) {
+		array_map( 'unlink', glob( $this->tempDir . '/*' ) ?: [] );
+		rmdir( $this->tempDir );
+	}
+} );
+
+it( 'registers a block from a block.json path', function () {
+	$path = $this->tempDir . '/block.json';
+	file_put_contents( $path, json_encode( [
+		'name'     => 'tests/path-block',
+		'title'    => 'Path Block',
+		'category' => 'artisanpack',
+	] ) );
+
+	VisualEditor::registerBlock( $path );
+
+	$block = app( BlockTypeRegistry::class )->get( 'tests/path-block' );
+
+	expect( $block )->not->toBeNull()
+		->and( $block['name'] )->toBe( 'tests/path-block' )
+		->and( $block['title'] )->toBe( 'Path Block' );
+} );
+
+it( 'registers a block from a class implementing ProvidesBlockMetadata', function () {
+	VisualEditor::registerBlock( TestBlockMetadata::class );
+
+	$block = app( BlockTypeRegistry::class )->get( 'tests/metadata-block' );
+
+	expect( $block )->not->toBeNull()
+		->and( $block['title'] )->toBe( 'Metadata Block' )
+		->and( $block['category'] )->toBe( 'artisanpack' )
+		->and( $block['attributes'] )->toBe( [
+			'label' => [ 'type' => 'string', 'default' => '' ],
+		] );
+} );
+
+it( 'registers a block from a closure returning metadata', function () {
+	VisualEditor::registerBlock( static fn (): array => [
+		'name'     => 'tests/closure-block',
+		'title'    => 'Closure Block',
+		'category' => 'artisanpack',
+	] );
+
+	$block = app( BlockTypeRegistry::class )->get( 'tests/closure-block' );
+
+	expect( $block )->not->toBeNull()
+		->and( $block['title'] )->toBe( 'Closure Block' );
+} );
+
+it( 'throws when the block.json file is missing', function () {
+	VisualEditor::registerBlock( $this->tempDir . '/missing.json' );
+} )->throws( InvalidArgumentException::class, 'block.json not found' );
+
+it( 'throws when the class does not implement ProvidesBlockMetadata', function () {
+	VisualEditor::registerBlock( \stdClass::class );
+} )->throws( InvalidArgumentException::class, 'must implement' );
+
+it( 'throws when the closure does not return an array', function () {
+	VisualEditor::registerBlock( static fn () => 'not-an-array' );
+} )->throws( InvalidArgumentException::class, 'must return an array' );
+
+it( 'throws when metadata is missing a name', function () {
+	VisualEditor::registerBlock( static fn (): array => [ 'title' => 'Nameless' ] );
+} )->throws( InvalidArgumentException::class, 'name' );
+
+it( 'registers the bundled callout reference block by default', function () {
+	$block = app( BlockTypeRegistry::class )->get( 'artisanpack/callout' );
+
+	expect( $block )->not->toBeNull()
+		->and( $block['category'] )->toBe( 'artisanpack' )
+		->and( $block['attributes'] )->toHaveKey( 'severity' )
+		->and( $block['attributes'] )->toHaveKey( 'icon' )
+		->and( $block['attributes'] )->toHaveKey( 'content' );
+} );
+
+it( 'includes artisanpack/callout in the enabled blocks allow-list', function () {
+	$enabled = config( 'artisanpack.visual-editor.enabled_blocks', [] );
+
+	expect( $enabled )->toContain( 'artisanpack/callout' );
+} );


### PR DESCRIPTION
## Description

Ships the documented pattern + tooling for host apps to register custom blocks under the `artisanpack/*` namespace, plus one reference block (`artisanpack/callout`) that exercises the pattern end to end. V2 block forking (#331) is **not** in scope here.

**Closes:** #346

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #346

## Motivation and Context

Pre-PR, zero ArtisanPack custom blocks existed. `DynamicBlock` / `ClosureDynamicBlock` supported server-rendered blocks, but there was no edit-side authoring pattern or reference static block and no `artisanpack` category in the inserter. A4 closes that gap.

## Changes Made

**PHP**
- Widen `VisualEditor::registerBlock()` to accept three input shapes: a `block.json` path, a class implementing the new `ProvidesBlockMetadata` interface, or a closure returning the metadata array.
- Register the bundled callout via `registerReferenceBlocks()` in `VisualEditorServiceProvider`; add `artisanpack/callout` to the default `enabled_blocks` allow-list.

**JS**
- New `editor/custom-blocks.ts`: eager `import.meta.glob` auto-discovery over `resources/js/visual-editor/blocks/*/index.ts`, `artisanpack` block-category registration, and an optional inline-SVG `icon` override (the editor does not bundle `dashicons.css`, so dashicon-slug icons render blank).
- Wired `discoverAndRegisterCustomBlocks()` into `registerOnce()` in `editor-app.tsx`.

**Reference block**
- `blocks/callout/`: `block.json` with severity + icon enum attributes, `edit.tsx` (`InspectorControls` + `RichText`), matching `save.tsx`, scoped CSS, and an inline-SVG inserter icon.

**Renderers (Blade / React / Vue)**
- Each renderer package now ships an `artisanpack/callout` partial/component that mirrors the `save.tsx` markup so server-rendered and client-rendered pages emit identical HTML.

**Docs**
- `docs/custom-blocks.md`: authoring pattern, directory structure, block.json schema, dynamic vs static guidance, per-renderer partial pattern, and a per-block checklist. Feeds into #325 M15.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (Darwin 25.3.0)
- Browser (if applicable): tested in the dev app via Laravel Herd
- PHP Version: 8.4.3
- Project Version: 1.0.0

**Tests Performed:**
1. Automated: full Pest suite + full Vitest suite.
2. Manual: opened the editor in the dev app, confirmed the ArtisanPack category shows up in the block library, inserted a Callout, swapped severity + icon through InspectorControls, verified the canvas re-rendered with the matching class / SVG, and confirmed edit/save round-trips on reload.

## Accessibility Tests Run

- [x] Keyboard navigation tested — InspectorControls `SelectControl` components use the standard Gutenberg focus pattern, inserter entries remain keyboard-navigable.
- [ ] Screen reader tested
- [x] Color contrast verified — severity variants use the same token palette already in the editor theme.
- [x] ARIA labels checked — inserter icon, block icon, and RichText placeholder are all tagged `aria-hidden="true"` on decorative elements; the RichText body carries the implicit role.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:**
- PHP: `tests/Unit/VisualEditor/RegisterBlockTest.php` covers all three registration forms + error paths; `BlockRendererTest` gains Blade renderer cases for the callout.
- JS: `resources/js/visual-editor/editor/__tests__/custom-blocks.test.tsx` covers category registration, the `registerCustomBlocks` pipeline (dedupe + icon override + skip-missing-name), and the callout edit/save round-trip; React and Vue renderer `BlockTree.test` files gain callout cases.
- Totals: **176 PHP tests / 515 JS tests passing.**

## Documentation

- [x] Inline code documentation added
- [x] API documentation updated

**Documentation details:**
`docs/custom-blocks.md` is the new authoring guide — registration mechanics, schema notes, dynamic vs static, renderer wiring, and an authoring checklist.

## Screenshots

_(available on request; manually verified in the dev app — ArtisanPack category + Callout inserter icon + severity/icon InspectorControls all render as expected.)_

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted (no lint config in this package; `npx tsc --noEmit` surfaces only pre-existing `@wordpress/*` missing-types warnings)
- [x] Accessibility tests completed
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code (glob transform + Dashicon CSS notes inline in `custom-blocks.ts`)
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Callout" block to the visual editor (Info/Success/Warning/Error) with selectable icons, editor controls, saved markup, and inserter availability.

* **Documentation**
  * Added a comprehensive guide for authoring custom visual editor blocks (layout, metadata, registration, rendering, checklist).

* **Tests**
  * Added unit and integration tests covering callout rendering, normalization/fallbacks, and custom-block registration/discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->