### PR TITLE
feat: B1 · core-data shim expansion (templates / template parts / navigation / patterns / global styles)

### DIFF
--- a/docs/core-data-shim.md
+++ b/docs/core-data-shim.md
@@ -1,0 +1,260 @@
+# core-data shim — surface and endpoint contract
+
+The visual editor aliases `@wordpress/core-data` to an in-repo shim
+(`resources/js/visual-editor/vendor/core-data-shim.ts`). The original
+shim (#312) returned empty/no-op for every selector — enough to keep
+the post-editor compiling while every data-backed core block lived on
+`disabled_blocks`. B1 (#353) expands the shim to real storage, edits,
+and mutation surfaces for the five entities the site editor (Phase C/D)
+and the post-editor block re-enablement (Phase E) depend on.
+
+This doc is the **contract Phase C codes against.** Every row in the
+table names a REST endpoint the shim expects to exist at
+`{apiBase}/...`, the HTTP method, and the request / response shape. B1
+implements all of the client-side wiring; C1–C5 build the endpoints.
+Until C lands, every resolver falls back silently to empty state.
+
+## Entities
+
+The shim registers these five entities by default via `addEntities()`:
+
+| Kind       | Name                | `baseURL`         | Key  | Notes                                   |
+| ---------- | ------------------- | ----------------- | ---- | --------------------------------------- |
+| `postType` | `wp_template`       | `/templates`      | `id` | Template tree root.                     |
+| `postType` | `wp_template_part`  | `/template-parts` | `id` | Header / footer / sidebar / etc.        |
+| `postType` | `wp_navigation`     | `/navigation`     | `id` | Nav menu (content + locations).         |
+| `postType` | `wp_block`          | `/patterns`       | `id` | Synced + unsynced patterns.             |
+| `root`     | `globalStyles`      | `/global-styles`  | `id` | Singleton theme.json-shaped record.     |
+
+Host applications can register additional entities at runtime with
+`dispatch('core').addEntities([...])`.
+
+The API base is configured at editor bootstrap with
+`configureCoreDataShim({ apiBase })`; defaults to `/visual-editor/api`.
+
+## Selectors
+
+All selectors read from the Redux store — they never trigger fetches
+themselves. Fetches are thunk actions (`fetchEntityRecord`,
+`fetchEntityRecords`) the editor calls imperatively (or that upstream
+block-editor components call via their own resolvers).
+
+| Selector                                        | Returns                                   | Purpose                                                   |
+| ----------------------------------------------- | ----------------------------------------- | --------------------------------------------------------- |
+| `getEntities()`                                 | `readonly EntityConfig[]`                 | Enumerate registered entities.                            |
+| `getEntityConfig(kind, name)`                   | `EntityConfig \| null`                    | Look up a registered entity config.                       |
+| `getEntityRecord(kind, name, id)`               | `EntityRecord \| null`                    | Cached single record.                                     |
+| `getRawEntityRecord(kind, name, id)`            | `EntityRecord \| null`                    | Raw (unsanitized) record — same as `getEntityRecord` in the shim. |
+| `getEntityRecords(kind, name, query?)`          | `readonly EntityRecord[]`                 | Cached record list. `undefined` query → all cached items. |
+| `getEntityRecordsTotalItems(kind, name, query?)`| `number`                                  | From `meta.total` on list response.                       |
+| `getEntityRecordsTotalPages(kind, name, query?)`| `number`                                  | From `meta.last_page` on list response.                   |
+| `getEditedEntityRecord(kind, name, id)`         | `EntityRecord \| null`                    | Base record merged with any pending edits.                |
+| `getEntityRecordEdits(kind, name, id)`          | `EntityRecord \| null`                    | The pending-edits bag for a record.                       |
+| `getEntityRecordNonTransientEdits(…)`           | `EntityRecord \| null`                    | Alias of the above — the shim has no transient edits.     |
+| `hasEditsForEntityRecord(kind, name, id)`       | `boolean`                                 | Whether any edits are staged for this record.             |
+| `isSavingEntityRecord(kind, name, id)`          | `boolean`                                 | Save in flight.                                           |
+| `isDeletingEntityRecord(kind, name, id)`        | `boolean`                                 | Delete in flight.                                         |
+| `getLastEntitySaveError(kind, name, id)`        | `unknown \| null`                         | Last save-error payload.                                  |
+| `getLastEntityDeleteError(kind, name, id)`      | `unknown \| null`                         | Last delete-error payload.                                |
+| `__experimentalGetCurrentGlobalStylesId()`      | `EntityKey \| null`                       | Singleton global-styles record id.                        |
+| `__experimentalGlobalStylesBaseStyles()`        | `Record<string, unknown> \| null`         | theme.json-shaped base styles (schema + defaults).        |
+
+### Back-compat stubs
+
+`getCurrentUser`, `getUsers`, `getMedia`, `getMediaItems`,
+`hasFinishedResolution`, `hasStartedResolution`, `isResolving`,
+`canUser`, `canUserEditEntityRecord`, `getAutosaves`, `getAutosave`,
+and `getReferenceByDistinctEdits` retain the M2 stub behavior (always
+null / empty / resolved). Site-editor features that need real values
+here should land them in a dedicated follow-up, not B1.
+
+## Actions + mutators
+
+Dispatched via `dispatch('core').<name>(...)` (or directly inside a
+thunk as `dispatch.<name>(...)`).
+
+### Reducer actions (synchronous)
+
+| Action                                                            | Effect                                                   |
+| ----------------------------------------------------------------- | -------------------------------------------------------- |
+| `addEntities(entities)`                                           | Registers additional entity configs.                     |
+| `receiveEntityRecords(kind, name, records, query?, total?, pages?)` | Caches records. When `query !== undefined`, also caches the query→ids mapping. |
+| `removeEntityRecord(kind, name, id)`                              | Evicts a record and its edits.                           |
+| `editEntityRecord(kind, name, id, edits)`                         | Merges edits into the record's edits bag.                |
+| `clearEntityRecordEdits(kind, name, id)`                          | Drops the edits bag.                                     |
+| `setEntitySaving(kind, name, id, saving, error?)`                 | Saving flag + last save error.                           |
+| `setEntityDeleting(kind, name, id, deleting, error?)`             | Deleting flag + last delete error.                       |
+| `receiveGlobalStylesBase(styles)`                                 | Sets `__experimentalGlobalStylesBaseStyles`.             |
+| `receiveCurrentGlobalStylesId(id)`                                | Sets `__experimentalGetCurrentGlobalStylesId`.           |
+| `reset()`                                                         | Resets the store (tests / HMR).                          |
+
+### Thunk actions (async)
+
+| Thunk                                                   | REST call                                      | Success behavior                                      | Failure behavior                                                    |
+| ------------------------------------------------------- | ---------------------------------------------- | ----------------------------------------------------- | ------------------------------------------------------------------- |
+| `fetchEntityRecord(kind, name, id)`                     | `GET {apiBase}{baseURL}/{id}`                  | `receiveEntityRecords(…, [record])`                   | Returns `null`; cache unchanged.                                    |
+| `fetchEntityRecords(kind, name, query?)`                | `GET {apiBase}{baseURL}?{query}`               | `receiveEntityRecords(…, records, query, total, pages)` | Caches an empty result at the query key; returns `[]`.            |
+| `saveEntityRecord(kind, name, record)`                  | `POST {apiBase}{baseURL}` (no key) or `PUT {apiBase}{baseURL}/{id}` | `receiveEntityRecords(…, [saved])`; returns `saved`.  | `setEntitySaving(…, false, error)`; returns `null`.                 |
+| `saveEditedEntityRecord(kind, name, id)`                | `PUT {apiBase}{baseURL}/{id}` with merged edits. | `clearEntityRecordEdits`; returns `saved`.            | Edits retained; `setEntitySaving(…, false, error)`; returns `null`. |
+| `deleteEntityRecord(kind, name, id)`                    | `DELETE {apiBase}{baseURL}/{id}`               | `removeEntityRecord`; returns `true`.                 | `setEntityDeleting(…, false, error)`; returns `false`.              |
+
+## Endpoint contract (for Phase C)
+
+All routes sit under the package's existing `/visual-editor/api/`
+prefix and use the auth middleware stack declared in
+`config/artisanpack/visual-editor.php`.
+
+### Templates — `wp_template`
+
+- `GET  /visual-editor/api/templates`
+- `GET  /visual-editor/api/templates/{id}`
+- `POST /visual-editor/api/templates`
+- `PUT  /visual-editor/api/templates/{id}`
+- `DELETE /visual-editor/api/templates/{id}`
+
+Single-record shape (to be finalized in C1):
+
+```json
+{
+  "id": 1,
+  "slug": "single-post",
+  "title": { "rendered": "Single Post" },
+  "description": "Fallback template for posts.",
+  "content": { "raw": "<!-- wp:post-content /-->", "blocks": [] },
+  "status": "publish",
+  "theme": "artisanpack-base",
+  "type": "wp_template",
+  "source": "theme|custom",
+  "origin": "theme|plugin|custom"
+}
+```
+
+List response accepts either a bare array or Laravel's `{ data, meta }`
+envelope (`meta.total` → `getEntityRecordsTotalItems`; `meta.last_page`
+→ `getEntityRecordsTotalPages`).
+
+### Template parts — `wp_template_part`
+
+- `GET    /visual-editor/api/template-parts`
+- `GET    /visual-editor/api/template-parts/{id}`
+- `POST   /visual-editor/api/template-parts`
+- `PUT    /visual-editor/api/template-parts/{id}`
+- `DELETE /visual-editor/api/template-parts/{id}`
+
+Single-record shape (finalized in C2):
+
+```json
+{
+  "id": 10,
+  "slug": "header",
+  "title": { "rendered": "Header" },
+  "content": { "raw": "<!-- wp:site-title /-->", "blocks": [] },
+  "area": "header|footer|sidebar|uncategorized",
+  "theme": "artisanpack-base",
+  "type": "wp_template_part"
+}
+```
+
+### Navigation — `wp_navigation`
+
+- `GET    /visual-editor/api/navigation`
+- `GET    /visual-editor/api/navigation/{id}`
+- `POST   /visual-editor/api/navigation`
+- `PUT    /visual-editor/api/navigation/{id}`
+- `DELETE /visual-editor/api/navigation/{id}`
+
+Single-record shape (finalized in C4):
+
+```json
+{
+  "id": 3,
+  "slug": "primary-nav",
+  "title": { "rendered": "Primary" },
+  "content": { "raw": "<!-- wp:navigation-link /-->", "blocks": [] },
+  "status": "publish",
+  "menu_order": 0
+}
+```
+
+Menu locations and fallback menus attach through a sibling endpoint
+(`/menu-locations`) — scope defer to C4 or D4.
+
+### Patterns — `wp_block`
+
+- `GET    /visual-editor/api/patterns`
+- `GET    /visual-editor/api/patterns/{id}`
+- `POST   /visual-editor/api/patterns`
+- `PUT    /visual-editor/api/patterns/{id}`
+- `DELETE /visual-editor/api/patterns/{id}`
+
+Single-record shape (finalized in C5). The `synced` flag distinguishes
+synced patterns (reusable blocks) from unsynced (one-shot inserts).
+
+```json
+{
+  "id": 42,
+  "slug": "hero",
+  "title": { "rendered": "Hero" },
+  "content": { "raw": "<!-- wp:cover /-->", "blocks": [] },
+  "synced": true,
+  "categories": ["featured"],
+  "status": "publish"
+}
+```
+
+### Global styles — `globalStyles`
+
+Global styles is a **singleton** per site. The `lookup` endpoint
+discovers the current id (which the shim dispatches to
+`receiveCurrentGlobalStylesId`); then read/write proceed through
+the normal record endpoints.
+
+- `GET  /visual-editor/api/global-styles/lookup` — resolves current id.
+- `GET  /visual-editor/api/global-styles/{id}`   — user record.
+- `PUT  /visual-editor/api/global-styles/{id}`   — user record.
+- `GET  /visual-editor/api/global-styles/base`   — theme defaults (dispatched to `receiveGlobalStylesBase`).
+
+Single-record shape (finalized in C3) mirrors theme.json:
+
+```json
+{
+  "id": 7,
+  "version": 3,
+  "settings": {
+    "color": { "palette": [ /* ... */ ] },
+    "typography": { "fontSizes": [ /* ... */ ] }
+  },
+  "styles": {
+    "color": { "background": "#ffffff" },
+    "elements": { "link": { "color": { "text": "#3b82f6" } } }
+  }
+}
+```
+
+The shim does not issue `GET /lookup` or `GET /base` itself — a
+site-editor bootstrap (Phase D3) will dispatch
+`receiveCurrentGlobalStylesId` and `receiveGlobalStylesBase` once the
+backend endpoints land.
+
+## CSRF + auth
+
+Mutating requests (`POST`, `PUT`, `DELETE`) include the Laravel CSRF
+token from `<meta name="csrf-token">` in an `X-CSRF-TOKEN` header, plus
+`credentials: 'same-origin'` so session cookies reach the server.
+
+## Testing
+
+`resources/js/visual-editor/vendor/__tests__/core-data-shim.test.tsx`
+covers:
+
+- entity-registry surface (default + `addEntities`)
+- record cache (receive, read, list + query keys)
+- edits pipeline (edit / clear / edited-record merging)
+- fetch → cache (single record, list with envelope, 404 fallback, unregistered entity)
+- save round-trip (POST create, PUT update, edits-cleared-on-success, edits-retained-on-failure)
+- delete + evict (204 success, 500 leaves cache in place)
+- global styles (base-styles + current-id selectors, user-styles PUT)
+- React hooks (provider context, stub return shapes)
+
+Unit tests inject a custom `fetcher` via `configureCoreDataShim({ fetcher })`,
+so no real HTTP is required.

--- a/docs/plans/11-v1-expansion.md
+++ b/docs/plans/11-v1-expansion.md
@@ -66,6 +66,7 @@ Phase A — Post-editor polish (parallelizable)
 Phase B — Foundation (sequential; gates Phase C)
   B1  core-data shim expansion: template, template-part, navigation,
       wp_block (patterns), global-styles entities
+      (surface + endpoint contract — see docs/core-data-shim.md)
   B2  Dev-app sample content for above
 
 Phase C — Site-editor backends (parallelizable after B)

--- a/resources/js/visual-editor/vendor/__tests__/core-data-shim.test.tsx
+++ b/resources/js/visual-editor/vendor/__tests__/core-data-shim.test.tsx
@@ -351,6 +351,89 @@ describe('core-data-shim fetch → cache', () => {
     });
 });
 
+describe('core-data-shim list-cache invalidation', () => {
+    it('drops filter-query caches when a save-path receive fires', async () => {
+        coreDispatch().receiveEntityRecords(
+            'postType',
+            'wp_template',
+            [
+                { id: 1, slug: 'one' },
+                { id: 2, slug: 'two' },
+            ],
+            { status: 'publish' },
+            2,
+            1,
+        );
+
+        // Filter-query slot is populated.
+        expect(
+            coreSelect().getEntityRecords('postType', 'wp_template', {
+                status: 'publish',
+            }),
+        ).toHaveLength(2);
+
+        // A save-path receive (no query) lands.
+        coreDispatch().receiveEntityRecords('postType', 'wp_template', [
+            { id: 3, slug: 'three' },
+        ]);
+
+        // Filter-query slot is invalidated — next list render must
+        // refetch before showing a filtered view.
+        expect(
+            coreSelect().getEntityRecords('postType', 'wp_template', {
+                status: 'publish',
+            }),
+        ).toEqual([]);
+
+        // But `getEntityRecords(..., null)` still returns the live items
+        // (1, 2, 3) because the empty-slot falls back to `items`.
+        expect(
+            coreSelect().getEntityRecords('postType', 'wp_template', null),
+        ).toHaveLength(3);
+        expect(
+            coreSelect().getEntityRecordsTotalItems(
+                'postType',
+                'wp_template',
+                null,
+            ),
+        ).toBe(3);
+    });
+
+    it('drops query caches and refreshes totals after delete', async () => {
+        coreDispatch().receiveEntityRecords(
+            'postType',
+            'wp_block',
+            [
+                { id: 1, slug: 'one' },
+                { id: 2, slug: 'two' },
+            ],
+            null,
+            12,
+            3,
+        );
+
+        expect(
+            coreSelect().getEntityRecordsTotalItems('postType', 'wp_block', null),
+        ).toBe(12);
+
+        const { fetcher } = mockFetcher(
+            async () => new Response(null, { status: 204 }),
+        );
+
+        configureCoreDataShim({ apiBase: '/api', fetcher });
+
+        await coreDispatch().deleteEntityRecord('postType', 'wp_block', 1);
+
+        // Total is recomputed from live items — stale "12" no longer shown.
+        expect(
+            coreSelect().getEntityRecordsTotalItems('postType', 'wp_block', null),
+        ).toBe(1);
+        expect(
+            coreSelect().getEntityRecords('postType', 'wp_block', null),
+        ).toHaveLength(1);
+    });
+});
+
 describe('core-data-shim save round-trip', () => {
     it('POSTs a new record and caches the response', async () => {
         const { fetcher, calls } = mockFetcher(async (_url, init) => {
@@ -410,6 +493,34 @@ describe('core-data-shim save round-trip', () => {
         expect(
             coreSelect().getEntityRecord('postType', 'wp_template', 3),
         ).toEqual({ id: 3, slug: 'page', title: 'Updated' });
+    });
+
+    it('saveEditedEntityRecord PUTs even when no base record is cached', async () => {
+        // Stage edits for a record that was never fetched — covers the
+        // case where the UI is editing an id it knows by reference only.
+        coreDispatch().editEntityRecord('postType', 'wp_template', 8, {
+            title: 'Created from edits',
+        });
+
+        const { fetcher, calls } = mockFetcher(async (_url, init) => {
+            expect(init.method).toBe('PUT');
+            const body = JSON.parse(init.body as string) as EntityRecord;
+
+            expect(body).toEqual({ id: 8, title: 'Created from edits' });
+
+            return jsonResponse({ id: 8, title: 'Created from edits' });
+        });
+
+        configureCoreDataShim({ apiBase: '/api', fetcher });
+
+        const saved = await coreDispatch().saveEditedEntityRecord(
+            'postType',
+            'wp_template',
+            8,
+        );
+
+        expect(saved).not.toBeNull();
+        expect(calls[0]?.url).toBe('/api/templates/8');
     });
 
     it('retains edits when the save fails', async () => {

--- a/resources/js/visual-editor/vendor/__tests__/core-data-shim.test.tsx
+++ b/resources/js/visual-editor/vendor/__tests__/core-data-shim.test.tsx
@@ -1,9 +1,12 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { select } from '@wordpress/data';
+import { dispatch, select } from '@wordpress/data';
 
 import {
+    DEFAULT_ENTITIES,
     EntityProvider,
+    __resetCoreDataShimConfig,
+    configureCoreDataShim,
     store,
     useEntityBlockEditor,
     useEntityId,
@@ -11,50 +14,539 @@ import {
     useEntityRecord,
     useEntityRecords,
     useResourcePermissions,
+    type EntityConfig,
+    type EntityRecord,
 } from '../core-data-shim';
 
-describe('core-data-shim store', () => {
-    it('registers under the "core" key', () => {
-        expect(store).toBeDefined();
+type CoreSelect = Record<string, (...args: unknown[]) => unknown>;
+type CoreDispatch = Record<string, (...args: unknown[]) => unknown>;
+
+const coreSelect = (): CoreSelect => select('core') as CoreSelect;
+const coreDispatch = (): CoreDispatch => dispatch('core') as CoreDispatch;
+
+function resetStore(): void {
+    coreDispatch().reset();
+}
+
+function mockFetcher(
+    impl: (input: string, init: RequestInit) => Promise<Response>,
+): { fetcher: typeof fetch; calls: Array<{ url: string; init: RequestInit }> } {
+    const calls: Array<{ url: string; init: RequestInit }> = [];
+    const fetcher = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === 'string' ? input : String(input);
+        const normalized = init ?? {};
+
+        calls.push({ url, init: normalized });
+
+        return impl(url, normalized);
+    }) as unknown as typeof fetch;
+
+    return { fetcher, calls };
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+    return new Response(JSON.stringify(body), {
+        status,
+        headers: { 'Content-Type': 'application/json' },
+    });
+}
+
+beforeEach(() => {
+    resetStore();
+    __resetCoreDataShimConfig();
+});
+
+afterEach(() => {
+    resetStore();
+    __resetCoreDataShimConfig();
+});
+
+describe('core-data-shim entity registry', () => {
+    it('registers the five V1 entities by default', () => {
+        const names = DEFAULT_ENTITIES.map((entity) => `${entity.kind}|${entity.name}`);
+
+        expect(names).toEqual([
+            'postType|wp_template',
+            'postType|wp_template_part',
+            'postType|wp_navigation',
+            'postType|wp_block',
+            'root|globalStyles',
+        ]);
     });
 
-    it('returns null from getEntityRecord-family selectors', () => {
-        const coreSelect = select('core') as Record<
-            string,
-            (...args: unknown[]) => unknown
-        >;
+    it('exposes default entities via getEntities after reset', () => {
+        const entities = coreSelect().getEntities() as readonly EntityConfig[];
 
-        expect(coreSelect.getEntityRecord('postType', 'post', 1)).toBeNull();
-        expect(coreSelect.getCurrentUser()).toBeNull();
-        expect(coreSelect.getMedia(42)).toBeNull();
+        expect(entities.map((entity) => `${entity.kind}|${entity.name}`)).toEqual(
+            expect.arrayContaining([
+                'postType|wp_template',
+                'postType|wp_template_part',
+                'postType|wp_navigation',
+                'postType|wp_block',
+                'root|globalStyles',
+            ]),
+        );
     });
 
-    it('returns [] from list selectors', () => {
-        const coreSelect = select('core') as Record<
-            string,
-            (...args: unknown[]) => unknown
-        >;
+    it('addEntities registers custom entities alongside defaults', () => {
+        coreDispatch().addEntities([
+            {
+                kind: 'postType',
+                name: 'wp_menu_location',
+                baseURL: '/menu-locations',
+                key: 'slug',
+                label: 'Menu Location',
+            },
+        ]);
 
-        expect(coreSelect.getEntityRecords('postType', 'post')).toEqual([]);
-        expect(coreSelect.getUsers()).toEqual([]);
+        const config = coreSelect().getEntityConfig('postType', 'wp_menu_location');
+
+        expect(config).toMatchObject({
+            kind: 'postType',
+            name: 'wp_menu_location',
+            baseURL: '/menu-locations',
+            key: 'slug',
+        });
+
+        // Defaults are still present.
+        expect(
+            coreSelect().getEntityConfig('postType', 'wp_template'),
+        ).not.toBeNull();
+    });
+});
+
+describe('core-data-shim record cache', () => {
+    it('returns null from getEntityRecord for unregistered entities', () => {
+        expect(
+            coreSelect().getEntityRecord('postType', 'post', 1),
+        ).toBeNull();
     });
 
-    it('reports resolution as finished and not in-flight', () => {
-        const coreSelect = select('core') as Record<
-            string,
-            (...args: unknown[]) => unknown
-        >;
+    it('returns [] from getEntityRecords for unregistered entities', () => {
+        expect(coreSelect().getEntityRecords('postType', 'post')).toEqual([]);
+    });
+
+    it('caches records after receiveEntityRecords', () => {
+        const template: EntityRecord = {
+            id: 5,
+            slug: 'single-post',
+            title: 'Single Post',
+        };
+
+        coreDispatch().receiveEntityRecords('postType', 'wp_template', [template]);
 
         expect(
-            coreSelect.hasFinishedResolution('getEntityRecord', [
+            coreSelect().getEntityRecord('postType', 'wp_template', 5),
+        ).toEqual(template);
+    });
+
+    it('caches query→ids when a query is provided', () => {
+        const templates: readonly EntityRecord[] = [
+            { id: 1, slug: 'single' },
+            { id: 2, slug: 'archive' },
+        ];
+
+        coreDispatch().receiveEntityRecords(
+            'postType',
+            'wp_template',
+            templates,
+            null,
+            2,
+            1,
+        );
+
+        expect(
+            coreSelect().getEntityRecords('postType', 'wp_template', null),
+        ).toEqual(templates);
+        expect(
+            coreSelect().getEntityRecordsTotalItems(
                 'postType',
-                'post',
+                'wp_template',
+                null,
+            ),
+        ).toBe(2);
+        expect(
+            coreSelect().getEntityRecordsTotalPages(
+                'postType',
+                'wp_template',
+                null,
+            ),
+        ).toBe(1);
+    });
+
+    it('keeps stub selectors null for legacy surfaces', () => {
+        expect(coreSelect().getCurrentUser()).toBeNull();
+        expect(coreSelect().getMedia(42)).toBeNull();
+        expect(coreSelect().getUsers()).toEqual([]);
+    });
+
+    it('reports resolution as finished and not in-flight by default', () => {
+        expect(
+            coreSelect().hasFinishedResolution('getEntityRecord', [
+                'postType',
+                'wp_template',
                 1,
-            ])
+            ]),
         ).toBe(true);
         expect(
-            coreSelect.isResolving('getEntityRecord', ['postType', 'post', 1])
+            coreSelect().isResolving('getEntityRecord', [
+                'postType',
+                'wp_template',
+                1,
+            ]),
         ).toBe(false);
+    });
+});
+
+describe('core-data-shim edits pipeline', () => {
+    it('accumulates edits via editEntityRecord', () => {
+        coreDispatch().receiveEntityRecords('postType', 'wp_template', [
+            { id: 1, slug: 'page', title: 'Page', status: 'draft' },
+        ]);
+
+        coreDispatch().editEntityRecord('postType', 'wp_template', 1, {
+            title: 'New title',
+        });
+        coreDispatch().editEntityRecord('postType', 'wp_template', 1, {
+            status: 'publish',
+        });
+
+        expect(
+            coreSelect().hasEditsForEntityRecord('postType', 'wp_template', 1),
+        ).toBe(true);
+        expect(
+            coreSelect().getEntityRecordEdits('postType', 'wp_template', 1),
+        ).toEqual({ title: 'New title', status: 'publish' });
+        expect(
+            coreSelect().getEditedEntityRecord('postType', 'wp_template', 1),
+        ).toEqual({
+            id: 1,
+            slug: 'page',
+            title: 'New title',
+            status: 'publish',
+        });
+    });
+
+    it('clearEntityRecordEdits drops the edits bag', () => {
+        coreDispatch().editEntityRecord('postType', 'wp_template', 1, {
+            title: 'x',
+        });
+
+        expect(
+            coreSelect().hasEditsForEntityRecord('postType', 'wp_template', 1),
+        ).toBe(true);
+
+        coreDispatch().clearEntityRecordEdits('postType', 'wp_template', 1);
+
+        expect(
+            coreSelect().hasEditsForEntityRecord('postType', 'wp_template', 1),
+        ).toBe(false);
+    });
+});
+
+describe('core-data-shim fetch → cache', () => {
+    it('fetchEntityRecord GETs the configured URL and caches the response', async () => {
+        const { fetcher, calls } = mockFetcher(async () =>
+            jsonResponse({ id: 7, slug: 'home', title: 'Home' }),
+        );
+
+        configureCoreDataShim({ apiBase: '/api', fetcher });
+
+        const record = (await coreDispatch().fetchEntityRecord(
+            'postType',
+            'wp_template',
+            7,
+        )) as EntityRecord | null;
+
+        expect(record).toEqual({ id: 7, slug: 'home', title: 'Home' });
+        expect(calls[0]?.url).toBe('/api/templates/7');
+        expect(calls[0]?.init.method).toBe('GET');
+
+        expect(
+            coreSelect().getEntityRecord('postType', 'wp_template', 7),
+        ).toEqual({ id: 7, slug: 'home', title: 'Home' });
+    });
+
+    it('fetchEntityRecord swallows network errors and returns null', async () => {
+        const { fetcher } = mockFetcher(async () => jsonResponse({}, 500));
+
+        configureCoreDataShim({ apiBase: '/api', fetcher });
+
+        const record = await coreDispatch().fetchEntityRecord(
+            'postType',
+            'wp_template',
+            7,
+        );
+
+        expect(record).toBeNull();
+        expect(
+            coreSelect().getEntityRecord('postType', 'wp_template', 7),
+        ).toBeNull();
+    });
+
+    it('fetchEntityRecords accepts a Laravel { data, meta } envelope', async () => {
+        const { fetcher } = mockFetcher(async () =>
+            jsonResponse({
+                data: [
+                    { id: 1, slug: 'one' },
+                    { id: 2, slug: 'two' },
+                ],
+                meta: { total: 12, last_page: 3 },
+            }),
+        );
+
+        configureCoreDataShim({ apiBase: '/api', fetcher });
+
+        const records = (await coreDispatch().fetchEntityRecords(
+            'postType',
+            'wp_template',
+        )) as readonly EntityRecord[];
+
+        expect(records).toHaveLength(2);
+        expect(
+            coreSelect().getEntityRecords('postType', 'wp_template', null),
+        ).toHaveLength(2);
+        expect(
+            coreSelect().getEntityRecordsTotalItems(
+                'postType',
+                'wp_template',
+                null,
+            ),
+        ).toBe(12);
+        expect(
+            coreSelect().getEntityRecordsTotalPages(
+                'postType',
+                'wp_template',
+                null,
+            ),
+        ).toBe(3);
+    });
+
+    it('fetchEntityRecords returns [] when the endpoint is missing', async () => {
+        const { fetcher } = mockFetcher(async () => jsonResponse({}, 404));
+
+        configureCoreDataShim({ apiBase: '/api', fetcher });
+
+        const records = await coreDispatch().fetchEntityRecords(
+            'postType',
+            'wp_template',
+        );
+
+        expect(records).toEqual([]);
+    });
+
+    it('is a no-op for entity kinds that are not registered', async () => {
+        const { fetcher, calls } = mockFetcher(async () => jsonResponse({}));
+
+        configureCoreDataShim({ apiBase: '/api', fetcher });
+
+        const record = await coreDispatch().fetchEntityRecord(
+            'root',
+            'bogus',
+            1,
+        );
+
+        expect(record).toBeNull();
+        expect(calls).toHaveLength(0);
+    });
+});
+
+describe('core-data-shim save round-trip', () => {
+    it('POSTs a new record and caches the response', async () => {
+        const { fetcher, calls } = mockFetcher(async (_url, init) => {
+            expect(init.method).toBe('POST');
+            const body = init.body as string;
+
+            expect(JSON.parse(body)).toEqual({ slug: 'new', title: 'New' });
+
+            return jsonResponse({ id: 99, slug: 'new', title: 'New' });
+        });
+
+        configureCoreDataShim({ apiBase: '/api', fetcher });
+
+        const saved = (await coreDispatch().saveEntityRecord(
+            'postType',
+            'wp_template',
+            { slug: 'new', title: 'New' },
+        )) as EntityRecord | null;
+
+        expect(saved).toEqual({ id: 99, slug: 'new', title: 'New' });
+        expect(calls[0]?.url).toBe('/api/templates');
+        expect(
+            coreSelect().getEntityRecord('postType', 'wp_template', 99),
+        ).toEqual({ id: 99, slug: 'new', title: 'New' });
+    });
+
+    it('saveEditedEntityRecord PUTs merged record and clears edits', async () => {
+        coreDispatch().receiveEntityRecords('postType', 'wp_template', [
+            { id: 3, slug: 'page', title: 'Old' },
+        ]);
+        coreDispatch().editEntityRecord('postType', 'wp_template', 3, {
+            title: 'Updated',
+        });
+
+        const { fetcher, calls } = mockFetcher(async (_url, init) => {
+            expect(init.method).toBe('PUT');
+            const body = JSON.parse(init.body as string) as EntityRecord;
+
+            expect(body).toEqual({ id: 3, slug: 'page', title: 'Updated' });
+
+            return jsonResponse({ id: 3, slug: 'page', title: 'Updated' });
+        });
+
+        configureCoreDataShim({ apiBase: '/api', fetcher });
+
+        const saved = (await coreDispatch().saveEditedEntityRecord(
+            'postType',
+            'wp_template',
+            3,
+        )) as EntityRecord | null;
+
+        expect(saved).toEqual({ id: 3, slug: 'page', title: 'Updated' });
+        expect(calls[0]?.url).toBe('/api/templates/3');
+        expect(
+            coreSelect().hasEditsForEntityRecord('postType', 'wp_template', 3),
+        ).toBe(false);
+        expect(
+            coreSelect().getEntityRecord('postType', 'wp_template', 3),
+        ).toEqual({ id: 3, slug: 'page', title: 'Updated' });
+    });
+
+    it('retains edits when the save fails', async () => {
+        coreDispatch().receiveEntityRecords('postType', 'wp_template', [
+            { id: 3, slug: 'page', title: 'Old' },
+        ]);
+        coreDispatch().editEntityRecord('postType', 'wp_template', 3, {
+            title: 'Updated',
+        });
+
+        const { fetcher } = mockFetcher(async () => jsonResponse({}, 500));
+
+        configureCoreDataShim({ apiBase: '/api', fetcher });
+
+        const saved = await coreDispatch().saveEditedEntityRecord(
+            'postType',
+            'wp_template',
+            3,
+        );
+
+        expect(saved).toBeNull();
+        expect(
+            coreSelect().hasEditsForEntityRecord('postType', 'wp_template', 3),
+        ).toBe(true);
+        expect(
+            coreSelect().getLastEntitySaveError(
+                'postType',
+                'wp_template',
+                3,
+            ),
+        ).not.toBeNull();
+    });
+});
+
+describe('core-data-shim delete + evict', () => {
+    it('DELETEs and evicts the cached record on success', async () => {
+        coreDispatch().receiveEntityRecords('postType', 'wp_block', [
+            { id: 11, slug: 'hero', title: 'Hero' },
+        ]);
+
+        const { fetcher, calls } = mockFetcher(
+            async () => new Response(null, { status: 204 }),
+        );
+
+        configureCoreDataShim({ apiBase: '/api', fetcher });
+
+        const ok = await coreDispatch().deleteEntityRecord(
+            'postType',
+            'wp_block',
+            11,
+        );
+
+        expect(ok).toBe(true);
+        expect(calls[0]?.url).toBe('/api/patterns/11');
+        expect(calls[0]?.init.method).toBe('DELETE');
+        expect(
+            coreSelect().getEntityRecord('postType', 'wp_block', 11),
+        ).toBeNull();
+    });
+
+    it('leaves the record in place when the DELETE fails', async () => {
+        coreDispatch().receiveEntityRecords('postType', 'wp_block', [
+            { id: 11, slug: 'hero' },
+        ]);
+
+        const { fetcher } = mockFetcher(async () => jsonResponse({}, 500));
+
+        configureCoreDataShim({ apiBase: '/api', fetcher });
+
+        const ok = await coreDispatch().deleteEntityRecord(
+            'postType',
+            'wp_block',
+            11,
+        );
+
+        expect(ok).toBe(false);
+        expect(
+            coreSelect().getEntityRecord('postType', 'wp_block', 11),
+        ).not.toBeNull();
+        expect(
+            coreSelect().getLastEntityDeleteError(
+                'postType',
+                'wp_block',
+                11,
+            ),
+        ).not.toBeNull();
+    });
+});
+
+describe('core-data-shim global styles', () => {
+    it('stores and returns the base global-styles record', () => {
+        const base = {
+            version: 3,
+            settings: { color: { palette: [] } },
+        };
+
+        coreDispatch().receiveGlobalStylesBase(base);
+
+        expect(coreSelect().__experimentalGlobalStylesBaseStyles()).toEqual(base);
+    });
+
+    it('stores and returns the current global-styles record id', () => {
+        expect(coreSelect().__experimentalGetCurrentGlobalStylesId()).toBeNull();
+
+        coreDispatch().receiveCurrentGlobalStylesId(42);
+
+        expect(coreSelect().__experimentalGetCurrentGlobalStylesId()).toBe(42);
+    });
+
+    it('saves user global-styles edits as PUTs through the entity pipeline', async () => {
+        coreDispatch().receiveEntityRecords('root', 'globalStyles', [
+            { id: 1, settings: {}, styles: {} },
+        ]);
+        coreDispatch().editEntityRecord('root', 'globalStyles', 1, {
+            styles: { color: { background: '#fff' } },
+        });
+
+        const { fetcher, calls } = mockFetcher(async (_url, init) => {
+            expect(init.method).toBe('PUT');
+
+            return jsonResponse({
+                id: 1,
+                settings: {},
+                styles: { color: { background: '#fff' } },
+            });
+        });
+
+        configureCoreDataShim({ apiBase: '/api', fetcher });
+
+        const saved = (await coreDispatch().saveEditedEntityRecord(
+            'root',
+            'globalStyles',
+            1,
+        )) as EntityRecord | null;
+
+        expect(saved).not.toBeNull();
+        expect(calls[0]?.url).toBe('/api/global-styles/1');
     });
 });
 
@@ -100,7 +592,7 @@ describe('core-data-shim hooks', () => {
 
     it('useEntityBlockEditor returns an empty block list and stable setters', () => {
         const [blocks, onInput, onChange] = renderHook(() =>
-            useEntityBlockEditor()
+            useEntityBlockEditor(),
         );
         expect(blocks).toEqual([]);
         expect(typeof onInput).toBe('function');
@@ -126,7 +618,7 @@ describe('core-data-shim hooks', () => {
         render(
             <EntityProvider kind="postType" name="page" id={7}>
                 <Probe />
-            </EntityProvider>
+            </EntityProvider>,
         );
 
         expect(screen.getByTestId('probe').textContent).toBe('7');
@@ -140,5 +632,12 @@ describe('core-data-shim hooks', () => {
 
         render(<Probe />);
         expect(screen.getByTestId('probe').textContent).toBe('none');
+    });
+});
+
+describe('core-data-shim bootstrap', () => {
+    it('re-registers the shim store only once across imports', () => {
+        expect(store).toBeDefined();
+        expect(select('core')).toBeDefined();
     });
 });

--- a/resources/js/visual-editor/vendor/core-data-shim.ts
+++ b/resources/js/visual-editor/vendor/core-data-shim.ts
@@ -1,24 +1,44 @@
 /**
- * Minimal empty-state shim for `@wordpress/core-data`.
+ * Shim for `@wordpress/core-data`.
  *
  * Gutenberg's block-editor and block-library import from `@wordpress/core-data`
- * whether we want them to or not. Without a shim, importing any of those
- * modules crashes because there is no WordPress backend to feed the real
- * package's REST resolvers. This module is aliased in `vite.config.ts` so that
- * every `import … from '@wordpress/core-data'` in the editor bundle resolves
- * here instead of the upstream package.
+ * whether we want them to or not. This module is aliased in `vite.config.ts`
+ * (and `vitest.config.ts`) so that every `import … from '@wordpress/core-data'`
+ * in the editor bundle resolves here instead of the upstream package.
  *
- * The shim intentionally returns empty/no-op values for every surface it
- * implements. Blocks that depend on WordPress-specific data (navigation,
- * query, post-*) will gracefully render empty; those blocks are slated to
- * land in the `disabled_blocks` list during M5.
+ * ## Scope
  *
- * **This shim is temporary.** The `artisanpack-ui/cms-framework` package will
- * replace it with a real Laravel-backed `core` store. Every selector we
- * implement here is a selector we have to re-verify against Gutenberg
- * upgrades — keep the surface as small as observed crashes allow.
+ * The M2 shim (#312) returned empty/no-op for every selector; that was enough
+ * to keep the post-editor compiling while `disabled_blocks` hid every
+ * data-dependent core block. B1 (#353) expands the surface so the five
+ * entities that the site-editor UI (Phase C/D) and the post-editor's
+ * new-block enablement (Phase E) depend on can round-trip through the
+ * package's REST layer:
  *
- * Tracked by issue #312 (M2 of the Gutenberg adoption, umbrella #309).
+ * - `postType:wp_template`       — templates
+ * - `postType:wp_template_part`  — template parts
+ * - `postType:wp_navigation`     — navigation menus
+ * - `postType:wp_block`          — patterns (synced + unsynced)
+ * - `root:globalStyles`          — theme.json-shaped site configuration
+ *
+ * The REST endpoints (C1–C5) do not exist yet. When they're missing, every
+ * resolver falls back silently to empty state — `getEntityRecord` returns
+ * null, `getEntityRecords` returns [], no errors are raised. See
+ * `docs/core-data-shim.md` for the endpoint contract Phase C will implement.
+ *
+ * ## Out of scope for B1
+ *
+ * - Building the REST endpoints themselves (Phase C).
+ * - Enabling the `core/navigation`, `core/post-*`, `core/site-*`,
+ *   `core/template-part` blocks in `enabled_blocks` (Phase E4).
+ * - Replacing the shim with the real `artisanpack-ui/cms-framework` backend
+ *   (post-V1).
+ *
+ * This shim is temporary. Every selector it exposes is a selector we have to
+ * re-verify on Gutenberg upgrades — keep the surface as narrow as observed
+ * crashes allow.
+ *
+ * Tracked by: #312 (M2 original shim), #353 (B1 expansion), #309 (V1).
  */
 
 import {
@@ -31,75 +51,1235 @@ import {
 } from 'react';
 import { createReduxStore, register } from '@wordpress/data';
 
-type EntityRecord = Record<string, unknown> | null;
-type EntityKey = number | string;
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type EntityKind = string;
+export type EntityName = string;
+export type EntityKey = number | string;
+export type EntityRecord = Record<string, unknown>;
+
+export interface EntityConfig {
+    readonly kind: EntityKind;
+    readonly name: EntityName;
+    /** URL fragment appended to `apiBase` — e.g. `/templates`. */
+    readonly baseURL: string;
+    /** Primary-key field on the record payload. */
+    readonly key: string;
+    /** Human-readable label for error messages / diagnostics. */
+    readonly label: string;
+    /** Plural form for list-selector naming. */
+    readonly plural?: string;
+}
+
+export interface GlobalStylesRecord extends EntityRecord {
+    id: EntityKey;
+    settings?: Record<string, unknown>;
+    styles?: Record<string, unknown>;
+}
 
 interface EntityIdentity {
-    readonly kind: string;
-    readonly name: string;
+    readonly kind: EntityKind;
+    readonly name: EntityName;
     readonly id: EntityKey | undefined;
 }
 
-const EMPTY_RECORDS: readonly never[] = Object.freeze([]);
+interface EntityBag {
+    items: Record<string, EntityRecord>;
+    queries: Record<string, readonly EntityKey[]>;
+    queryMeta: Record<string, { totalItems: number; totalPages: number }>;
+}
+
+type EditsBag = Record<string, EntityRecord>;
+
+interface CoreDataState {
+    entities: Record<string, EntityConfig>;
+    records: Record<string, EntityBag>;
+    edits: Record<string, EditsBag>;
+    saving: Record<string, Record<string, boolean>>;
+    deleting: Record<string, Record<string, boolean>>;
+    saveErrors: Record<string, Record<string, unknown | null>>;
+    deleteErrors: Record<string, Record<string, unknown | null>>;
+    globalStylesBase: Record<string, unknown> | null;
+    currentGlobalStylesId: EntityKey | null;
+}
+
+type CoreDataAction =
+    | { type: 'ADD_ENTITIES'; entities: readonly EntityConfig[] }
+    | {
+          type: 'RECEIVE_ENTITY_RECORDS';
+          kind: EntityKind;
+          name: EntityName;
+          records: readonly EntityRecord[];
+          query?: Record<string, unknown> | null;
+          totalItems?: number;
+          totalPages?: number;
+      }
+    | {
+          type: 'REMOVE_ENTITY_RECORD';
+          kind: EntityKind;
+          name: EntityName;
+          id: EntityKey;
+      }
+    | {
+          type: 'EDIT_ENTITY_RECORD';
+          kind: EntityKind;
+          name: EntityName;
+          id: EntityKey;
+          edits: EntityRecord;
+      }
+    | {
+          type: 'CLEAR_ENTITY_RECORD_EDITS';
+          kind: EntityKind;
+          name: EntityName;
+          id: EntityKey;
+      }
+    | {
+          type: 'SET_SAVING';
+          kind: EntityKind;
+          name: EntityName;
+          id: EntityKey;
+          saving: boolean;
+          error: unknown | null;
+      }
+    | {
+          type: 'SET_DELETING';
+          kind: EntityKind;
+          name: EntityName;
+          id: EntityKey;
+          deleting: boolean;
+          error: unknown | null;
+      }
+    | {
+          type: 'RECEIVE_GLOBAL_STYLES_BASE';
+          styles: Record<string, unknown> | null;
+      }
+    | { type: 'RECEIVE_CURRENT_GLOBAL_STYLES_ID'; id: EntityKey | null }
+    | { type: 'SHIM_NOOP' }
+    | { type: 'SHIM_RESET' };
+
+// ---------------------------------------------------------------------------
+// Default entity registry
+// ---------------------------------------------------------------------------
+
+export const DEFAULT_ENTITIES: readonly EntityConfig[] = Object.freeze([
+    {
+        kind: 'postType',
+        name: 'wp_template',
+        baseURL: '/templates',
+        key: 'id',
+        label: 'Template',
+        plural: 'templates',
+    },
+    {
+        kind: 'postType',
+        name: 'wp_template_part',
+        baseURL: '/template-parts',
+        key: 'id',
+        label: 'Template Part',
+        plural: 'templateParts',
+    },
+    {
+        kind: 'postType',
+        name: 'wp_navigation',
+        baseURL: '/navigation',
+        key: 'id',
+        label: 'Navigation',
+        plural: 'navigations',
+    },
+    {
+        kind: 'postType',
+        name: 'wp_block',
+        baseURL: '/patterns',
+        key: 'id',
+        label: 'Pattern',
+        plural: 'patterns',
+    },
+    {
+        kind: 'root',
+        name: 'globalStyles',
+        baseURL: '/global-styles',
+        key: 'id',
+        label: 'Global Styles',
+        plural: 'globalStyles',
+    },
+]);
+
+// ---------------------------------------------------------------------------
+// Shim configuration
+// ---------------------------------------------------------------------------
+
+export interface ShimConfig {
+    /** URL prefix the package's REST endpoints live under. */
+    apiBase: string;
+    /** Custom fetch (for tests; defaults to the global `fetch`). */
+    fetcher: typeof fetch;
+}
+
+const DEFAULT_API_BASE = '/visual-editor/api';
+
+function defaultFetcher(): typeof fetch {
+    if (typeof fetch === 'function') {
+        return fetch.bind(globalThis);
+    }
+
+    return (() => {
+        throw new Error('core-data-shim: fetch is not available in this environment.');
+    }) as typeof fetch;
+}
+
+let shimConfig: ShimConfig = {
+    apiBase: DEFAULT_API_BASE,
+    fetcher: defaultFetcher(),
+};
+
+/**
+ * Updates the shim's runtime configuration. Call once at editor bootstrap
+ * before any block-editor / block-library code dispatches through the
+ * `core` store.
+ */
+export function configureCoreDataShim(
+    config: Partial<Readonly<ShimConfig>>,
+): void {
+    shimConfig = {
+        apiBase: config.apiBase ?? shimConfig.apiBase,
+        fetcher: config.fetcher ?? shimConfig.fetcher,
+    };
+}
+
+/**
+ * Resets the shim's runtime configuration to defaults. Intended for tests.
+ * @internal
+ */
+export function __resetCoreDataShimConfig(): void {
+    shimConfig = {
+        apiBase: DEFAULT_API_BASE,
+        fetcher: defaultFetcher(),
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Key helpers
+// ---------------------------------------------------------------------------
+
 const STORE_NAME = 'core';
+const EMPTY_RECORDS: readonly never[] = Object.freeze([]);
+
+function entityKey(kind: EntityKind, name: EntityName): string {
+    return `${kind}|${name}`;
+}
+
+function queryKey(query?: Record<string, unknown> | null): string {
+    if (!query) {
+        return '';
+    }
+
+    const entries = Object.entries(query);
+
+    if (entries.length === 0) {
+        return '';
+    }
+
+    return entries
+        .slice()
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([k, v]) => `${k}=${JSON.stringify(v)}`)
+        .join('&');
+}
+
+function recordIdOf(
+    record: EntityRecord,
+    config: EntityConfig,
+): EntityKey | null {
+    const raw = record[config.key];
+
+    if (typeof raw === 'string' || typeof raw === 'number') {
+        return raw;
+    }
+
+    return null;
+}
+
+function entityUrl(config: EntityConfig, id?: EntityKey): string {
+    const base = shimConfig.apiBase.replace(/\/$/, '');
+    const path = config.baseURL.startsWith('/')
+        ? config.baseURL
+        : `/${config.baseURL}`;
+
+    if (id === undefined) {
+        return `${base}${path}`;
+    }
+
+    return `${base}${path}/${encodeURIComponent(String(id))}`;
+}
+
+function queryString(query?: Record<string, unknown> | null): string {
+    if (!query) {
+        return '';
+    }
+
+    const params = new URLSearchParams();
+
+    for (const [key, value] of Object.entries(query)) {
+        if (value === undefined || value === null) {
+            continue;
+        }
+
+        if (Array.isArray(value)) {
+            for (const item of value) {
+                params.append(key, String(item));
+            }
+
+            continue;
+        }
+
+        params.append(key, String(value));
+    }
+
+    const serialized = params.toString();
+
+    return serialized.length > 0 ? `?${serialized}` : '';
+}
+
+function readCsrfToken(): string | null {
+    if (typeof document === 'undefined') {
+        return null;
+    }
+
+    const meta = document.querySelector<HTMLMetaElement>(
+        'meta[name="csrf-token"]',
+    );
+
+    return meta?.content?.trim() || null;
+}
+
+function buildHeaders(includeCsrf: boolean): Record<string, string> {
+    const headers: Record<string, string> = {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        'X-Requested-With': 'XMLHttpRequest',
+    };
+
+    if (includeCsrf) {
+        const token = readCsrfToken();
+
+        if (token) {
+            headers['X-CSRF-TOKEN'] = token;
+        }
+    }
+
+    return headers;
+}
+
+async function parseJson(response: Response): Promise<unknown> {
+    const text = await response.text();
+
+    if (text === '') {
+        return null;
+    }
+
+    try {
+        return JSON.parse(text);
+    } catch {
+        return text;
+    }
+}
+
+async function restRequest(
+    url: string,
+    init: RequestInit,
+): Promise<unknown> {
+    const response = await shimConfig.fetcher(url, {
+        credentials: 'same-origin',
+        ...init,
+    });
+
+    const body = await parseJson(response);
+
+    if (!response.ok) {
+        throw new Error(
+            `core-data-shim: ${init.method ?? 'GET'} ${url} failed with status ${response.status}`,
+        );
+    }
+
+    return body;
+}
+
+// ---------------------------------------------------------------------------
+// Reducer
+// ---------------------------------------------------------------------------
+
+function buildInitialEntities(): Record<string, EntityConfig> {
+    const entries: Record<string, EntityConfig> = {};
+
+    for (const config of DEFAULT_ENTITIES) {
+        entries[entityKey(config.kind, config.name)] = config;
+    }
+
+    return entries;
+}
+
+const INITIAL_STATE: CoreDataState = {
+    entities: buildInitialEntities(),
+    records: {},
+    edits: {},
+    saving: {},
+    deleting: {},
+    saveErrors: {},
+    deleteErrors: {},
+    globalStylesBase: null,
+    currentGlobalStylesId: null,
+};
+
+function reducer(
+    state: CoreDataState = INITIAL_STATE,
+    action: CoreDataAction,
+): CoreDataState {
+    switch (action.type) {
+        case 'ADD_ENTITIES': {
+            if (action.entities.length === 0) {
+                return state;
+            }
+
+            const next = { ...state.entities };
+
+            for (const config of action.entities) {
+                next[entityKey(config.kind, config.name)] = config;
+            }
+
+            return { ...state, entities: next };
+        }
+
+        case 'RECEIVE_ENTITY_RECORDS': {
+            const key = entityKey(action.kind, action.name);
+            const bag: EntityBag = state.records[key] ?? {
+                items: {},
+                queries: {},
+                queryMeta: {},
+            };
+            const config = state.entities[key];
+
+            const nextItems: Record<string, EntityRecord> = { ...bag.items };
+            const receivedIds: EntityKey[] = [];
+
+            for (const record of action.records) {
+                const id = config ? recordIdOf(record, config) : null;
+
+                if (id === null) {
+                    continue;
+                }
+
+                nextItems[String(id)] = record;
+                receivedIds.push(id);
+            }
+
+            const nextQueries = { ...bag.queries };
+            const nextQueryMeta = { ...bag.queryMeta };
+
+            // `query === undefined` means a single-record fetch just landed,
+            // so only the `items` map needs updating. `query === null` (or
+            // `{}`) is the callers' "I fetched the whole list" signal and
+            // caches under the empty-string slot; a real filter query
+            // caches under its stable signature.
+            if (action.query !== undefined) {
+                const qKey = queryKey(action.query);
+
+                nextQueries[qKey] = Object.freeze(receivedIds);
+                nextQueryMeta[qKey] = {
+                    totalItems: action.totalItems ?? receivedIds.length,
+                    totalPages: action.totalPages ?? 1,
+                };
+            }
+
+            return {
+                ...state,
+                records: {
+                    ...state.records,
+                    [key]: {
+                        items: nextItems,
+                        queries: nextQueries,
+                        queryMeta: nextQueryMeta,
+                    },
+                },
+            };
+        }
+
+        case 'REMOVE_ENTITY_RECORD': {
+            const key = entityKey(action.kind, action.name);
+            const bag = state.records[key];
+
+            if (!bag) {
+                return state;
+            }
+
+            const nextItems = { ...bag.items };
+            delete nextItems[String(action.id)];
+
+            const nextQueries: Record<string, readonly EntityKey[]> = {};
+
+            for (const [qKey, ids] of Object.entries(bag.queries)) {
+                nextQueries[qKey] = Object.freeze(
+                    ids.filter((existing) => String(existing) !== String(action.id)),
+                );
+            }
+
+            const nextEdits = { ...(state.edits[key] ?? {}) };
+            delete nextEdits[String(action.id)];
+
+            return {
+                ...state,
+                records: {
+                    ...state.records,
+                    [key]: {
+                        items: nextItems,
+                        queries: nextQueries,
+                        queryMeta: bag.queryMeta,
+                    },
+                },
+                edits: {
+                    ...state.edits,
+                    [key]: nextEdits,
+                },
+            };
+        }
+
+        case 'EDIT_ENTITY_RECORD': {
+            const key = entityKey(action.kind, action.name);
+            const existing = state.edits[key]?.[String(action.id)] ?? {};
+
+            return {
+                ...state,
+                edits: {
+                    ...state.edits,
+                    [key]: {
+                        ...(state.edits[key] ?? {}),
+                        [String(action.id)]: { ...existing, ...action.edits },
+                    },
+                },
+            };
+        }
+
+        case 'CLEAR_ENTITY_RECORD_EDITS': {
+            const key = entityKey(action.kind, action.name);
+            const bag = state.edits[key];
+
+            if (!bag || bag[String(action.id)] === undefined) {
+                return state;
+            }
+
+            const nextBag = { ...bag };
+            delete nextBag[String(action.id)];
+
+            return {
+                ...state,
+                edits: { ...state.edits, [key]: nextBag },
+            };
+        }
+
+        case 'SET_SAVING': {
+            const key = entityKey(action.kind, action.name);
+
+            return {
+                ...state,
+                saving: {
+                    ...state.saving,
+                    [key]: {
+                        ...(state.saving[key] ?? {}),
+                        [String(action.id)]: action.saving,
+                    },
+                },
+                saveErrors: {
+                    ...state.saveErrors,
+                    [key]: {
+                        ...(state.saveErrors[key] ?? {}),
+                        [String(action.id)]: action.error,
+                    },
+                },
+            };
+        }
+
+        case 'SET_DELETING': {
+            const key = entityKey(action.kind, action.name);
+
+            return {
+                ...state,
+                deleting: {
+                    ...state.deleting,
+                    [key]: {
+                        ...(state.deleting[key] ?? {}),
+                        [String(action.id)]: action.deleting,
+                    },
+                },
+                deleteErrors: {
+                    ...state.deleteErrors,
+                    [key]: {
+                        ...(state.deleteErrors[key] ?? {}),
+                        [String(action.id)]: action.error,
+                    },
+                },
+            };
+        }
+
+        case 'RECEIVE_GLOBAL_STYLES_BASE':
+            return { ...state, globalStylesBase: action.styles };
+
+        case 'RECEIVE_CURRENT_GLOBAL_STYLES_ID':
+            return { ...state, currentGlobalStylesId: action.id };
+
+        case 'SHIM_RESET':
+            return INITIAL_STATE;
+
+        default:
+            return state;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Selectors
+// ---------------------------------------------------------------------------
+
+function selectEntityConfig(
+    state: CoreDataState,
+    kind: EntityKind,
+    name: EntityName,
+): EntityConfig | null {
+    return state.entities[entityKey(kind, name)] ?? null;
+}
+
+function selectEntityRecord(
+    state: CoreDataState,
+    kind: EntityKind,
+    name: EntityName,
+    id: EntityKey,
+): EntityRecord | null {
+    return (
+        state.records[entityKey(kind, name)]?.items[String(id)] ?? null
+    );
+}
+
+function selectEntityRecords(
+    state: CoreDataState,
+    kind: EntityKind,
+    name: EntityName,
+    query?: Record<string, unknown> | null,
+): readonly EntityRecord[] {
+    const bag = state.records[entityKey(kind, name)];
+
+    if (!bag) {
+        return EMPTY_RECORDS;
+    }
+
+    const qKey = queryKey(query);
+
+    if (query === undefined) {
+        return Object.values(bag.items);
+    }
+
+    const ids = bag.queries[qKey];
+
+    if (!ids) {
+        return EMPTY_RECORDS;
+    }
+
+    const records: EntityRecord[] = [];
+
+    for (const id of ids) {
+        const record = bag.items[String(id)];
+
+        if (record !== undefined) {
+            records.push(record);
+        }
+    }
+
+    return records;
+}
+
+function selectEditsForRecord(
+    state: CoreDataState,
+    kind: EntityKind,
+    name: EntityName,
+    id: EntityKey,
+): EntityRecord | null {
+    const edits = state.edits[entityKey(kind, name)]?.[String(id)];
+
+    return edits ?? null;
+}
 
 const selectors = {
-    getEntityRecord: (): EntityRecord => null,
-    getEntityRecords: (): readonly never[] => EMPTY_RECORDS,
-    getEditedEntityRecord: (): EntityRecord => null,
-    getRawEntityRecord: (): EntityRecord => null,
-    getCurrentUser: (): EntityRecord => null,
-    getUsers: (): readonly never[] => EMPTY_RECORDS,
-    getMedia: (): EntityRecord => null,
-    getMediaItems: (): readonly never[] => EMPTY_RECORDS,
-    getEntityRecordsTotalItems: (): number => 0,
-    getEntityRecordsTotalPages: (): number => 0,
+    getEntities: (state: CoreDataState): readonly EntityConfig[] =>
+        Object.values(state.entities),
+
+    getEntityConfig: (
+        state: CoreDataState,
+        kind: EntityKind,
+        name: EntityName,
+    ): EntityConfig | null => selectEntityConfig(state, kind, name),
+
+    getEntityRecord: (
+        state: CoreDataState,
+        kind: EntityKind,
+        name: EntityName,
+        id: EntityKey,
+    ): EntityRecord | null => selectEntityRecord(state, kind, name, id),
+
+    getRawEntityRecord: (
+        state: CoreDataState,
+        kind: EntityKind,
+        name: EntityName,
+        id: EntityKey,
+    ): EntityRecord | null => selectEntityRecord(state, kind, name, id),
+
+    getEntityRecords: (
+        state: CoreDataState,
+        kind: EntityKind,
+        name: EntityName,
+        query?: Record<string, unknown> | null,
+    ): readonly EntityRecord[] =>
+        selectEntityRecords(state, kind, name, query),
+
+    getEntityRecordsTotalItems: (
+        state: CoreDataState,
+        kind: EntityKind,
+        name: EntityName,
+        query?: Record<string, unknown> | null,
+    ): number => {
+        const bag = state.records[entityKey(kind, name)];
+
+        return bag?.queryMeta[queryKey(query)]?.totalItems ?? 0;
+    },
+
+    getEntityRecordsTotalPages: (
+        state: CoreDataState,
+        kind: EntityKind,
+        name: EntityName,
+        query?: Record<string, unknown> | null,
+    ): number => {
+        const bag = state.records[entityKey(kind, name)];
+
+        return bag?.queryMeta[queryKey(query)]?.totalPages ?? 0;
+    },
+
+    getEditedEntityRecord: (
+        state: CoreDataState,
+        kind: EntityKind,
+        name: EntityName,
+        id: EntityKey,
+    ): EntityRecord | null => {
+        const base = selectEntityRecord(state, kind, name, id);
+        const edits = selectEditsForRecord(state, kind, name, id);
+
+        if (base === null && edits === null) {
+            return null;
+        }
+
+        return { ...(base ?? {}), ...(edits ?? {}) };
+    },
+
+    getEntityRecordEdits: (
+        state: CoreDataState,
+        kind: EntityKind,
+        name: EntityName,
+        id: EntityKey,
+    ): EntityRecord | null => selectEditsForRecord(state, kind, name, id),
+
+    getEntityRecordNonTransientEdits: (
+        state: CoreDataState,
+        kind: EntityKind,
+        name: EntityName,
+        id: EntityKey,
+    ): EntityRecord | null => selectEditsForRecord(state, kind, name, id),
+
+    hasEditsForEntityRecord: (
+        state: CoreDataState,
+        kind: EntityKind,
+        name: EntityName,
+        id: EntityKey,
+    ): boolean => {
+        const edits = selectEditsForRecord(state, kind, name, id);
+
+        return edits !== null && Object.keys(edits).length > 0;
+    },
+
+    isSavingEntityRecord: (
+        state: CoreDataState,
+        kind: EntityKind,
+        name: EntityName,
+        id: EntityKey,
+    ): boolean => state.saving[entityKey(kind, name)]?.[String(id)] === true,
+
+    isDeletingEntityRecord: (
+        state: CoreDataState,
+        kind: EntityKind,
+        name: EntityName,
+        id: EntityKey,
+    ): boolean =>
+        state.deleting[entityKey(kind, name)]?.[String(id)] === true,
+
+    getLastEntitySaveError: (
+        state: CoreDataState,
+        kind: EntityKind,
+        name: EntityName,
+        id: EntityKey,
+    ): unknown | null =>
+        state.saveErrors[entityKey(kind, name)]?.[String(id)] ?? null,
+
+    getLastEntityDeleteError: (
+        state: CoreDataState,
+        kind: EntityKind,
+        name: EntityName,
+        id: EntityKey,
+    ): unknown | null =>
+        state.deleteErrors[entityKey(kind, name)]?.[String(id)] ?? null,
+
+    __experimentalGetCurrentGlobalStylesId: (
+        state: CoreDataState,
+    ): EntityKey | null => state.currentGlobalStylesId,
+
+    __experimentalGlobalStylesBaseStyles: (
+        state: CoreDataState,
+    ): Record<string, unknown> | null => state.globalStylesBase,
+
+    // Stubs retained for back-compat with pre-B1 callsites.
+    getCurrentUser: (): EntityRecord | null => null,
+    getUsers: (): readonly EntityRecord[] => EMPTY_RECORDS,
+    getMedia: (): EntityRecord | null => null,
+    getMediaItems: (): readonly EntityRecord[] => EMPTY_RECORDS,
     hasFinishedResolution: (): boolean => true,
     hasStartedResolution: (): boolean => true,
     isResolving: (): boolean => false,
-    hasEditsForEntityRecord: (): boolean => false,
-    getEntityRecordEdits: (): EntityRecord => null,
-    getEntityRecordNonTransientEdits: (): EntityRecord => null,
     canUser: (): boolean => false,
     canUserEditEntityRecord: (): boolean => false,
-    getAutosaves: (): readonly never[] => EMPTY_RECORDS,
-    getAutosave: (): EntityRecord => null,
-    getReferenceByDistinctEdits: (): number[] => [],
-    isSavingEntityRecord: (): boolean => false,
-    isDeletingEntityRecord: (): boolean => false,
-    getLastEntitySaveError: (): null => null,
-    getLastEntityDeleteError: (): null => null,
+    getAutosaves: (): readonly EntityRecord[] => EMPTY_RECORDS,
+    getAutosave: (): EntityRecord | null => null,
+    getReferenceByDistinctEdits: (): readonly number[] => EMPTY_RECORDS,
 };
+
+// ---------------------------------------------------------------------------
+// Thunk-style actions
+// ---------------------------------------------------------------------------
+
+interface ThunkArgs {
+    dispatch: {
+        (action: CoreDataAction): CoreDataAction;
+        receiveEntityRecords: (
+            kind: EntityKind,
+            name: EntityName,
+            records: readonly EntityRecord[],
+            query?: Record<string, unknown> | null,
+            totalItems?: number,
+            totalPages?: number,
+        ) => CoreDataAction;
+        editEntityRecord: (
+            kind: EntityKind,
+            name: EntityName,
+            id: EntityKey,
+            edits: EntityRecord,
+        ) => CoreDataAction;
+        removeEntityRecord: (
+            kind: EntityKind,
+            name: EntityName,
+            id: EntityKey,
+        ) => CoreDataAction;
+        setEntitySaving: (
+            kind: EntityKind,
+            name: EntityName,
+            id: EntityKey,
+            saving: boolean,
+            error: unknown | null,
+        ) => CoreDataAction;
+        setEntityDeleting: (
+            kind: EntityKind,
+            name: EntityName,
+            id: EntityKey,
+            deleting: boolean,
+            error: unknown | null,
+        ) => CoreDataAction;
+        clearEntityRecordEdits: (
+            kind: EntityKind,
+            name: EntityName,
+            id: EntityKey,
+        ) => CoreDataAction;
+    };
+    select: {
+        getEntityConfig: (
+            kind: EntityKind,
+            name: EntityName,
+        ) => EntityConfig | null;
+        getEntityRecord: (
+            kind: EntityKind,
+            name: EntityName,
+            id: EntityKey,
+        ) => EntityRecord | null;
+        getEditedEntityRecord: (
+            kind: EntityKind,
+            name: EntityName,
+            id: EntityKey,
+        ) => EntityRecord | null;
+    };
+}
 
 const actions = {
-    receiveEntityRecords: () => ({ type: 'SHIM_NOOP' }) as const,
-    receiveUserQuery: () => ({ type: 'SHIM_NOOP' }) as const,
-    receiveCurrentUser: () => ({ type: 'SHIM_NOOP' }) as const,
-    saveEntityRecord: () => async (): Promise<null> => null,
-    saveEditedEntityRecord: () => async (): Promise<null> => null,
-    deleteEntityRecord: () => async (): Promise<boolean> => true,
-    editEntityRecord: () => ({ type: 'SHIM_NOOP' }) as const,
-    undo: () => ({ type: 'SHIM_NOOP' }) as const,
-    redo: () => ({ type: 'SHIM_NOOP' }) as const,
-    __unstableCreateUndoLevel: () => ({ type: 'SHIM_NOOP' }) as const,
+    addEntities: (entities: readonly EntityConfig[]): CoreDataAction => ({
+        type: 'ADD_ENTITIES',
+        entities,
+    }),
+
+    receiveEntityRecords: (
+        kind: EntityKind,
+        name: EntityName,
+        records: readonly EntityRecord[],
+        query?: Record<string, unknown> | null,
+        totalItems?: number,
+        totalPages?: number,
+    ): CoreDataAction => ({
+        type: 'RECEIVE_ENTITY_RECORDS',
+        kind,
+        name,
+        records,
+        query,
+        totalItems,
+        totalPages,
+    }),
+
+    removeEntityRecord: (
+        kind: EntityKind,
+        name: EntityName,
+        id: EntityKey,
+    ): CoreDataAction => ({
+        type: 'REMOVE_ENTITY_RECORD',
+        kind,
+        name,
+        id,
+    }),
+
+    editEntityRecord: (
+        kind: EntityKind,
+        name: EntityName,
+        id: EntityKey,
+        edits: EntityRecord,
+    ): CoreDataAction => ({
+        type: 'EDIT_ENTITY_RECORD',
+        kind,
+        name,
+        id,
+        edits,
+    }),
+
+    clearEntityRecordEdits: (
+        kind: EntityKind,
+        name: EntityName,
+        id: EntityKey,
+    ): CoreDataAction => ({
+        type: 'CLEAR_ENTITY_RECORD_EDITS',
+        kind,
+        name,
+        id,
+    }),
+
+    setEntitySaving: (
+        kind: EntityKind,
+        name: EntityName,
+        id: EntityKey,
+        saving: boolean,
+        error: unknown | null = null,
+    ): CoreDataAction => ({
+        type: 'SET_SAVING',
+        kind,
+        name,
+        id,
+        saving,
+        error,
+    }),
+
+    setEntityDeleting: (
+        kind: EntityKind,
+        name: EntityName,
+        id: EntityKey,
+        deleting: boolean,
+        error: unknown | null = null,
+    ): CoreDataAction => ({
+        type: 'SET_DELETING',
+        kind,
+        name,
+        id,
+        deleting,
+        error,
+    }),
+
+    receiveGlobalStylesBase: (
+        styles: Record<string, unknown> | null,
+    ): CoreDataAction => ({ type: 'RECEIVE_GLOBAL_STYLES_BASE', styles }),
+
+    receiveCurrentGlobalStylesId: (
+        id: EntityKey | null,
+    ): CoreDataAction => ({ type: 'RECEIVE_CURRENT_GLOBAL_STYLES_ID', id }),
+
+    /**
+     * Resets the store to its initial state. Tests and HMR wire this up
+     * between runs; the production editor never needs it.
+     * @internal
+     */
+    reset: (): CoreDataAction => ({ type: 'SHIM_RESET' }),
+
+    // Retained for back-compat.
+    receiveUserQuery: (): CoreDataAction => ({ type: 'SHIM_NOOP' }),
+    receiveCurrentUser: (): CoreDataAction => ({ type: 'SHIM_NOOP' }),
+    undo: (): CoreDataAction => ({ type: 'SHIM_NOOP' }),
+    redo: (): CoreDataAction => ({ type: 'SHIM_NOOP' }),
+    __unstableCreateUndoLevel: (): CoreDataAction => ({ type: 'SHIM_NOOP' }),
+
+    /**
+     * Fetches a single entity record from the REST API and caches it.
+     * Swallows network/endpoint failures so unregistered or not-yet-built
+     * endpoints degrade to an empty result instead of throwing.
+     */
+    fetchEntityRecord:
+        (kind: EntityKind, name: EntityName, id: EntityKey) =>
+        async ({ dispatch, select }: ThunkArgs): Promise<EntityRecord | null> => {
+            const config = select.getEntityConfig(kind, name);
+
+            if (!config) {
+                return null;
+            }
+
+            try {
+                const record = (await restRequest(entityUrl(config, id), {
+                    method: 'GET',
+                    headers: buildHeaders(false),
+                })) as EntityRecord | null;
+
+                if (record !== null) {
+                    dispatch.receiveEntityRecords(kind, name, [record]);
+                }
+
+                return record;
+            } catch {
+                return null;
+            }
+        },
+
+    /**
+     * Fetches a list of entity records, keyed by query signature.
+     * Swallows failures — returns [] when the endpoint is missing.
+     */
+    fetchEntityRecords:
+        (
+            kind: EntityKind,
+            name: EntityName,
+            query?: Record<string, unknown> | null,
+        ) =>
+        async ({
+            dispatch,
+            select,
+        }: ThunkArgs): Promise<readonly EntityRecord[]> => {
+            const config = select.getEntityConfig(kind, name);
+
+            if (!config) {
+                return EMPTY_RECORDS;
+            }
+
+            try {
+                const url = `${entityUrl(config)}${queryString(query)}`;
+                const body = (await restRequest(url, {
+                    method: 'GET',
+                    headers: buildHeaders(false),
+                })) as unknown;
+
+                const parsed = normalizeListResponse(body);
+
+                dispatch.receiveEntityRecords(
+                    kind,
+                    name,
+                    parsed.records,
+                    query ?? null,
+                    parsed.totalItems,
+                    parsed.totalPages,
+                );
+
+                return parsed.records;
+            } catch {
+                dispatch.receiveEntityRecords(
+                    kind,
+                    name,
+                    EMPTY_RECORDS,
+                    query ?? null,
+                    0,
+                    0,
+                );
+
+                return EMPTY_RECORDS;
+            }
+        },
+
+    /**
+     * Creates or updates an entity record in one shot.
+     *
+     * - Record without its key field → POST to the collection URL.
+     * - Record with its key field → PUT to the item URL.
+     */
+    saveEntityRecord:
+        (kind: EntityKind, name: EntityName, record: EntityRecord) =>
+        async ({ dispatch, select }: ThunkArgs): Promise<EntityRecord | null> => {
+            const config = select.getEntityConfig(kind, name);
+
+            if (!config) {
+                return null;
+            }
+
+            const existingId = recordIdOf(record, config);
+            const saveSlotId = existingId ?? '__new__';
+
+            dispatch.setEntitySaving(kind, name, saveSlotId, true, null);
+
+            try {
+                const url =
+                    existingId === null
+                        ? entityUrl(config)
+                        : entityUrl(config, existingId);
+                const method = existingId === null ? 'POST' : 'PUT';
+
+                const saved = (await restRequest(url, {
+                    method,
+                    headers: buildHeaders(true),
+                    body: JSON.stringify(record),
+                })) as EntityRecord | null;
+
+                if (saved !== null) {
+                    dispatch.receiveEntityRecords(kind, name, [saved]);
+                }
+
+                dispatch.setEntitySaving(kind, name, saveSlotId, false, null);
+
+                return saved;
+            } catch (error) {
+                dispatch.setEntitySaving(kind, name, saveSlotId, false, error);
+
+                return null;
+            }
+        },
+
+    /**
+     * PUTs the edited record (base + edits) back to the server, then
+     * clears the edits bag on success. Leaves the edits intact on failure
+     * so the UI can retry.
+     */
+    saveEditedEntityRecord:
+        (kind: EntityKind, name: EntityName, id: EntityKey) =>
+        async ({ dispatch, select }: ThunkArgs): Promise<EntityRecord | null> => {
+            const edited = select.getEditedEntityRecord(kind, name, id);
+
+            if (edited === null) {
+                return null;
+            }
+
+            const saved = await actions.saveEntityRecord(kind, name, edited)({
+                dispatch,
+                select,
+            });
+
+            if (saved !== null) {
+                dispatch.clearEntityRecordEdits(kind, name, id);
+            }
+
+            return saved;
+        },
+
+    /**
+     * DELETEs an entity record and evicts it from the store on success.
+     */
+    deleteEntityRecord:
+        (kind: EntityKind, name: EntityName, id: EntityKey) =>
+        async ({ dispatch, select }: ThunkArgs): Promise<boolean> => {
+            const config = select.getEntityConfig(kind, name);
+
+            if (!config) {
+                return false;
+            }
+
+            dispatch.setEntityDeleting(kind, name, id, true, null);
+
+            try {
+                await restRequest(entityUrl(config, id), {
+                    method: 'DELETE',
+                    headers: buildHeaders(true),
+                });
+
+                dispatch.removeEntityRecord(kind, name, id);
+                dispatch.setEntityDeleting(kind, name, id, false, null);
+
+                return true;
+            } catch (error) {
+                dispatch.setEntityDeleting(kind, name, id, false, error);
+
+                return false;
+            }
+        },
 };
 
-const reducer = (state: Record<string, never> = {}): Record<string, never> =>
-    state;
+interface NormalizedList {
+    records: readonly EntityRecord[];
+    totalItems: number;
+    totalPages: number;
+}
+
+/**
+ * Accepts either a bare array of records or a `{ data, meta }` envelope
+ * (Laravel's default pagination shape) and normalizes to the store's
+ * record-list shape.
+ */
+function normalizeListResponse(body: unknown): NormalizedList {
+    if (Array.isArray(body)) {
+        return {
+            records: body as readonly EntityRecord[],
+            totalItems: body.length,
+            totalPages: 1,
+        };
+    }
+
+    if (body && typeof body === 'object') {
+        const envelope = body as {
+            data?: unknown;
+            meta?: { total?: unknown; last_page?: unknown };
+        };
+        const data = Array.isArray(envelope.data)
+            ? (envelope.data as readonly EntityRecord[])
+            : EMPTY_RECORDS;
+        const meta = envelope.meta ?? {};
+        const totalItems =
+            typeof meta.total === 'number' ? meta.total : data.length;
+        const totalPages =
+            typeof meta.last_page === 'number' ? meta.last_page : 1;
+
+        return { records: data, totalItems, totalPages };
+    }
+
+    return { records: EMPTY_RECORDS, totalItems: 0, totalPages: 0 };
+}
+
+// ---------------------------------------------------------------------------
+// Store registration
+// ---------------------------------------------------------------------------
 
 export const store = createReduxStore(STORE_NAME, {
-    reducer,
-    actions,
-    selectors,
+    reducer: reducer as unknown as (
+        state: CoreDataState,
+        action: { type: string },
+    ) => CoreDataState,
+    actions: actions as unknown as Record<string, unknown>,
+    selectors: selectors as unknown as Record<string, unknown>,
 });
 
 register(store);
 
+// ---------------------------------------------------------------------------
+// React context + hooks
+// ---------------------------------------------------------------------------
+
 /**
  * `EntityProvider` in upstream `@wordpress/core-data` supplies the ambient
  * entity identity (kind/name/id) to hooks like `useEntityProp`. The shim
- * preserves that contract so blocks reading the context don't throw, but the
- * default value is an empty identity since there is no backing store yet.
+ * preserves that contract so blocks reading the context don't throw.
  */
 const EntityContext = createContext<EntityIdentity>({
     kind: '',
@@ -108,12 +1288,12 @@ const EntityContext = createContext<EntityIdentity>({
 });
 
 export function EntityProvider(
-    props: PropsWithChildren<EntityIdentity>
+    props: PropsWithChildren<EntityIdentity>,
 ): ReactElement {
     const { kind, name, id, children } = props;
     const value = useMemo<EntityIdentity>(
         () => ({ kind, name, id }),
-        [kind, name, id]
+        [kind, name, id],
     );
 
     return createElement(EntityContext.Provider, { value }, children);
@@ -130,7 +1310,11 @@ export function useEntityId(): EntityKey | undefined {
  */
 const noopSetter = (): void => {};
 
-export function useEntityProp<T = unknown>(): [T | undefined, typeof noopSetter, T | undefined] {
+export function useEntityProp<T = unknown>(): [
+    T | undefined,
+    typeof noopSetter,
+    T | undefined,
+] {
     return [undefined, noopSetter, undefined];
 }
 

--- a/resources/js/visual-editor/vendor/core-data-shim.ts
+++ b/resources/js/visual-editor/vendor/core-data-shim.ts
@@ -474,21 +474,39 @@ function reducer(
                 receivedIds.push(id);
             }
 
-            const nextQueries = { ...bag.queries };
-            const nextQueryMeta = { ...bag.queryMeta };
+            // `query === undefined` = save-path / single-record fetch.
+            // Drop every cached filter query for this entity: we can't
+            // know whether the new/updated record still matches any of
+            // those filters, so the safe move is to invalidate them and
+            // force a refetch on next list render. The live `items` bag
+            // is still authoritative for `getEntityRecords` with no
+            // query, so creates/updates show up immediately there.
+            //
+            // `query !== undefined` = list-fetch. Cache the received
+            // ids under the query's stable signature, and let sibling
+            // query caches stay untouched.
+            let nextQueries: Record<string, readonly EntityKey[]>;
+            let nextQueryMeta: Record<
+                string,
+                { totalItems: number; totalPages: number }
+            >;
 
-            // `query === undefined` means a single-record fetch just landed,
-            // so only the `items` map needs updating. `query === null` (or
-            // `{}`) is the callers' "I fetched the whole list" signal and
-            // caches under the empty-string slot; a real filter query
-            // caches under its stable signature.
-            if (action.query !== undefined) {
+            if (action.query === undefined) {
+                nextQueries = {};
+                nextQueryMeta = {};
+            } else {
                 const qKey = queryKey(action.query);
 
-                nextQueries[qKey] = Object.freeze(receivedIds);
-                nextQueryMeta[qKey] = {
-                    totalItems: action.totalItems ?? receivedIds.length,
-                    totalPages: action.totalPages ?? 1,
+                nextQueries = {
+                    ...bag.queries,
+                    [qKey]: Object.freeze(receivedIds),
+                };
+                nextQueryMeta = {
+                    ...bag.queryMeta,
+                    [qKey]: {
+                        totalItems: action.totalItems ?? receivedIds.length,
+                        totalPages: action.totalPages ?? 1,
+                    },
                 };
             }
 
@@ -516,14 +534,10 @@ function reducer(
             const nextItems = { ...bag.items };
             delete nextItems[String(action.id)];
 
-            const nextQueries: Record<string, readonly EntityKey[]> = {};
-
-            for (const [qKey, ids] of Object.entries(bag.queries)) {
-                nextQueries[qKey] = Object.freeze(
-                    ids.filter((existing) => String(existing) !== String(action.id)),
-                );
-            }
-
+            // A delete invalidates every cached filter query (the removed
+            // record might have filtered in or out of any of them) and
+            // their totals (`totalItems` would otherwise return a stale
+            // pre-delete count). Drop both.
             const nextEdits = { ...(state.edits[key] ?? {}) };
             delete nextEdits[String(action.id)];
 
@@ -533,8 +547,8 @@ function reducer(
                     ...state.records,
                     [key]: {
                         items: nextItems,
-                        queries: nextQueries,
-                        queryMeta: bag.queryMeta,
+                        queries: {},
+                        queryMeta: {},
                     },
                 },
                 edits: {
@@ -670,29 +684,35 @@ function selectEntityRecords(
         return EMPTY_RECORDS;
     }
 
-    const qKey = queryKey(query);
-
     if (query === undefined) {
         return Object.values(bag.items);
     }
 
+    const qKey = queryKey(query);
     const ids = bag.queries[qKey];
 
-    if (!ids) {
-        return EMPTY_RECORDS;
-    }
+    if (ids) {
+        const records: EntityRecord[] = [];
 
-    const records: EntityRecord[] = [];
+        for (const id of ids) {
+            const record = bag.items[String(id)];
 
-    for (const id of ids) {
-        const record = bag.items[String(id)];
-
-        if (record !== undefined) {
-            records.push(record);
+            if (record !== undefined) {
+                records.push(record);
+            }
         }
+
+        return records;
     }
 
-    return records;
+    // No cached filter query. For the "fetched everything" slot
+    // (`null`/`{}`) fall back to the live items map so UIs pick up
+    // cache-invalidating saves/deletes without needing a refetch.
+    if (qKey === '') {
+        return Object.values(bag.items);
+    }
+
+    return EMPTY_RECORDS;
 }
 
 function selectEditsForRecord(
@@ -746,7 +766,24 @@ const selectors = {
     ): number => {
         const bag = state.records[entityKey(kind, name)];
 
-        return bag?.queryMeta[queryKey(query)]?.totalItems ?? 0;
+        if (!bag) {
+            return 0;
+        }
+
+        const qKey = queryKey(query);
+        const meta = bag.queryMeta[qKey];
+
+        if (meta) {
+            return meta.totalItems;
+        }
+
+        // Fall back to the live items map for the "everything" slot so
+        // the count reflects saves/deletes after query caches are cleared.
+        if (qKey === '') {
+            return Object.keys(bag.items).length;
+        }
+
+        return 0;
     },
 
     getEntityRecordsTotalPages: (
@@ -757,7 +794,22 @@ const selectors = {
     ): number => {
         const bag = state.records[entityKey(kind, name)];
 
-        return bag?.queryMeta[queryKey(query)]?.totalPages ?? 0;
+        if (!bag) {
+            return 0;
+        }
+
+        const qKey = queryKey(query);
+        const meta = bag.queryMeta[qKey];
+
+        if (meta) {
+            return meta.totalPages;
+        }
+
+        if (qKey === '') {
+            return Object.keys(bag.items).length > 0 ? 1 : 0;
+        }
+
+        return 0;
     },
 
     getEditedEntityRecord: (
@@ -1163,6 +1215,11 @@ const actions = {
      * PUTs the edited record (base + edits) back to the server, then
      * clears the edits bag on success. Leaves the edits intact on failure
      * so the UI can retry.
+     *
+     * The key field is pinned onto the payload explicitly: edits staged
+     * before the base record was ever cached would otherwise produce a
+     * key-less payload, which `saveEntityRecord` would mis-route to
+     * `POST` (create) instead of `PUT` (update).
      */
     saveEditedEntityRecord:
         (kind: EntityKind, name: EntityName, id: EntityKey) =>
@@ -1173,7 +1230,12 @@ const actions = {
                 return null;
             }
 
-            const saved = await actions.saveEntityRecord(kind, name, edited)({
+            const config = select.getEntityConfig(kind, name);
+            const payload: EntityRecord = config
+                ? { ...edited, [config.key]: id }
+                : edited;
+
+            const saved = await actions.saveEntityRecord(kind, name, payload)({
                 dispatch,
                 select,
             });


### PR DESCRIPTION
## Description

Expand the `@wordpress/core-data` shim
(`resources/js/visual-editor/vendor/core-data-shim.ts`) from a no-op stub
to a real entity store covering the five V1 entities the site editor
(Phase C/D) and the post-editor block re-enablement (Phase E) depend on:

- `postType:wp_template`
- `postType:wp_template_part`
- `postType:wp_navigation`
- `postType:wp_block` (patterns — synced + unsynced)
- `root:globalStyles` (theme.json-shaped)

B1 is the serialization point for V1 — Phase C backends and Phase D UI
both depend on the surfaces landed here.

**Closes:** #353

## Type of Change

- [x] Enhancement (improves existing functionality)

## Related Issue

**Issue:** #353

## Motivation and Context

Gutenberg's `@wordpress/block-editor` and `@wordpress/block-library`
import from `@wordpress/core-data` unconditionally. The M2 shim (#312)
returned empty/no-op for every selector — that was enough to keep the
post-editor compiling while every data-backed core block lived on
`disabled_blocks`. B1 teaches the shim to **store, serve, edit, and
save** entity records so Phase C can implement the backend endpoints
against a concrete contract, Phase D can start building UI against a
working store, and Phase E4 can re-enable the 17 currently-disabled
core blocks.

## Changes Made

- Entity registration via `addEntities()` + a default registry of the
  five V1 entities.
- Real Redux reducer: entities config, per-entity record cache
  (items + query→ids), edits bag, saving / deleting flags, global-styles
  surface (`__experimentalGlobalStylesBaseStyles`,
  `__experimentalGetCurrentGlobalStylesId`).
- Typed selectors for every new surface — no `any` introduced.
- Thunk actions: `fetchEntityRecord`, `fetchEntityRecords`,
  `saveEntityRecord` (POST create / PUT update), `saveEditedEntityRecord`,
  `deleteEntityRecord`. All thunks fall back silently to empty state
  when the endpoint is missing (B1 is stub-only; Phase C builds the
  endpoints).
- REST client wired to the package's `/visual-editor/api/*` prefix with
  CSRF token + same-origin credentials.
- Optimistic cache invalidation via `receiveEntityRecords` after every
  save; `removeEntityRecord` evicts on delete.
- `configureCoreDataShim({ apiBase, fetcher })` for bootstrap + test
  injection.
- New `docs/core-data-shim.md` — the endpoint contract Phase C codes
  against (selector + mutator table, endpoint list + record shapes per
  entity).

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS 15
- Browser (if applicable): Safari / Chrome
- PHP Version: 8.4
- Project Version: `release/1.0` @ `dca7ef4`

**Tests Performed:**

1. `npm test` — 57 files / 536 tests pass, no regressions in any
   existing editor test (including `use-persistence`, `document-panels`,
   `inspector-sidebar`, `block-library-sidebar`).
2. `./vendor/bin/pest` — 176 PHP tests pass.
3. Manual: editor boots in the dev app without console errors; existing
   post-editor save/autosave flow unaffected; `wp.data.dispatch('core').addEntities([...])`
   + `wp.data.select('core').getEntityConfig(...)` round-trip confirmed
   in the browser console.

## Accessibility Tests Run

- [x] N/A — shim is internal editor plumbing with no visible UI surface
  (new blocks come online in Phase E4 and will be a11y-audited then).

## Tests Added

- [x] Unit tests added/updated — Vitest coverage expanded from 9 → 32
  assertions in
  `resources/js/visual-editor/vendor/__tests__/core-data-shim.test.tsx`.
- [x] All tests passing.

**Test details:**

New coverage:
- entity-registry surface (defaults + `addEntities`)
- record cache (receive, read, list + query keys)
- edits pipeline (edit / clear / edited-record merging)
- fetch → cache (single record, list with Laravel envelope, 404
  fallback, unregistered-entity no-op)
- save round-trip (POST create, PUT update, edits cleared on success,
  edits retained + error captured on failure)
- delete + evict (204 success, 500 leaves cache in place)
- global styles (base-styles + current-id selectors, user-styles PUT)
- React hooks (provider context, stub return shapes)

## Documentation

- [x] Inline code documentation added — every new selector / action has
  typed signatures and purpose in the shim file header.
- [x] Wiki updated — new `docs/core-data-shim.md` documents the complete
  surface + endpoint contract Phase C will build against.
- [x] `docs/plans/11-v1-expansion.md` — one-line pointer to the new doc
  in the Phase B line of the phase-ordering block.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [x] Accessibility tests completed
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive contract docs for the visual editor’s core-data surface and updated planning notes to reference the new contract.

* **New Features**
  * Visual editor now has an in-memory core-data shim enabling cached fetches, edit tracking, save/delete lifecycle handling, and global styles support.

* **Tests**
  * Large, behavior-driven test suite added to validate registration, caching, edit/save/delete flows, and global styles handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->