### PR TITLE
B2 · Dev-app sample content for site-editor entities

### DIFF
--- a/config/visual-editor.php
+++ b/config/visual-editor.php
@@ -167,4 +167,26 @@ return [
 		'restrict_by_owner' => false,
 	],
 
+	/*
+	|--------------------------------------------------------------------------
+	| Sample content
+	|--------------------------------------------------------------------------
+	|
+	| The `visual-editor:seed-sample-content` Artisan command loads fixtures
+	| for the five B1 shim entities (templates, template parts, navigation,
+	| patterns, global styles) and writes them to a storage disk so the dev
+	| app has something to render against before Phase C endpoints land.
+	|
+	| `fixtures_path` is an absolute directory path. When null, the command
+	| falls back to the package's own `tests/Fixtures/sample-content/`
+	| directory (only available while the package is installed from source,
+	| e.g. a path repository or cloned checkout). Host apps that want to
+	| vendor their own fixtures should point this at their own directory.
+	|
+	*/
+
+	'sample_content' => [
+		'fixtures_path' => null,
+	],
+
 ];

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -30,7 +30,7 @@ disk (`storage/app/visual-editor/sample-content/…` on the `local`
 disk) so that Phase C seeders can pick up the payloads without a
 second fixtures round-trip:
 
-```
+```text
 storage/app/visual-editor/sample-content/
 ├── postType/
 │   ├── wp_template/{1,2,3,4}.json         # single, page, index, 404

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -1,0 +1,65 @@
+# Dev-app setup
+
+Short reference for anyone spinning up the visual editor against the
+ArtisanPack UI dev app (`~/Herd/artisanpack-ui`) or another host app
+running the package in-place.
+
+## Seeding sample content (B2)
+
+Phase B2 (`#354`) ships a set of fixtures that cover every entity the B1
+core-data shim (`#353`) knows how to read or write: templates, template
+parts, navigation menus, patterns (synced + unsynced), and the
+singleton global styles record. Seeding them once gives Phase C/D work
+something concrete to render against without hand-authoring JSON into
+the database for every new contributor.
+
+### Run
+
+```bash
+php artisan visual-editor:seed-sample-content
+```
+
+The command is idempotent — re-running it produces the same files on
+disk. Stale fixtures (entries removed from the fixtures directory
+between runs) are pruned.
+
+### What lands
+
+By default the command writes to the host app's default filesystem
+disk (`storage/app/visual-editor/sample-content/…` on the `local`
+disk) so that Phase C seeders can pick up the payloads without a
+second fixtures round-trip:
+
+```
+storage/app/visual-editor/sample-content/
+├── postType/
+│   ├── wp_template/{1,2,3,4}.json         # single, page, index, 404
+│   ├── wp_template_part/{10,11,12}.json   # header, footer, sidebar
+│   ├── wp_navigation/{20,21,22}.json      # primary, footer, nested
+│   └── wp_block/{30,31,32}.json           # hero (synced), pricing-row, call-out-pair
+└── root/
+    └── globalStyles/40.json               # theme.json singleton
+```
+
+The shapes match the contract in
+[`docs/core-data-shim.md`](./core-data-shim.md) — every record
+round-trips through `fetchEntityRecord` without munging.
+
+### Options
+
+- `--path=/absolute/path/to/fixtures` — point the seeder at a custom
+  fixtures directory with the same sub-folder layout (one folder per
+  REST URL fragment).
+- `--disk=public` — write to a non-default filesystem disk.
+
+Set `artisanpack.visual-editor.sample_content.fixtures_path` in
+`config/artisanpack/visual-editor.php` to persist a custom directory
+across runs.
+
+### Where the fixtures live
+
+Canonical fixtures ship under the package's
+`tests/Fixtures/sample-content/` directory (excluded from the
+distributed composer tarball via `.gitattributes`). Host apps that
+want to vendor their own can copy the tree into, for example,
+`database/seeders/fixtures/visual-editor/` and point `--path` at it.

--- a/resources/js/visual-editor/vendor/__tests__/sample-content-fixtures.test.ts
+++ b/resources/js/visual-editor/vendor/__tests__/sample-content-fixtures.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Verifies that the canonical B2 sample-content fixtures round-trip
+ * cleanly through the B1 core-data shim. If the JSON shape in
+ * `tests/Fixtures/sample-content/` drifts away from what the shim
+ * caches, this test is the first canary — Phase C/D will otherwise
+ * see silent type mismatches in the store.
+ */
+
+import { readFileSync, readdirSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { dispatch, select } from '@wordpress/data';
+
+import {
+    __resetCoreDataShimConfig,
+    configureCoreDataShim,
+    type EntityKey,
+    type EntityRecord,
+} from '../core-data-shim';
+
+type CoreSelect = Record<string, (...args: unknown[]) => unknown>;
+type CoreDispatch = Record<string, (...args: unknown[]) => unknown>;
+
+const coreSelect = (): CoreSelect => select('core') as CoreSelect;
+const coreDispatch = (): CoreDispatch => dispatch('core') as CoreDispatch;
+
+interface FixtureEntity {
+    readonly kind: string;
+    readonly name: string;
+    readonly directory: string;
+}
+
+const FIXTURE_ROOT = resolve(
+    __dirname,
+    '../../../../../tests/Fixtures/sample-content',
+);
+
+const FIXTURE_ENTITIES: readonly FixtureEntity[] = [
+    { kind: 'postType', name: 'wp_template', directory: 'templates' },
+    { kind: 'postType', name: 'wp_template_part', directory: 'template-parts' },
+    { kind: 'postType', name: 'wp_navigation', directory: 'navigation' },
+    { kind: 'postType', name: 'wp_block', directory: 'patterns' },
+    { kind: 'root', name: 'globalStyles', directory: 'global-styles' },
+];
+
+function loadFixtures(directory: string): readonly (EntityRecord & { id: EntityKey })[] {
+    const dir = resolve(FIXTURE_ROOT, directory);
+    const files = readdirSync(dir).filter((name) => name.endsWith('.json')).sort();
+
+    return files.map((file) => {
+        const record = JSON.parse(readFileSync(resolve(dir, file), 'utf-8')) as Record<
+            string,
+            unknown
+        >;
+
+        if (typeof record.id !== 'number' && typeof record.id !== 'string') {
+            throw new Error(`Fixture ${directory}/${file} is missing a primary key.`);
+        }
+
+        return record as EntityRecord & { id: EntityKey };
+    });
+}
+
+function mockFetcher(
+    impl: (input: string, init: RequestInit) => Promise<Response>,
+): typeof fetch {
+    return vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === 'string' ? input : String(input);
+
+        return impl(url, init ?? {});
+    }) as unknown as typeof fetch;
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+    return new Response(JSON.stringify(body), {
+        status,
+        headers: { 'Content-Type': 'application/json' },
+    });
+}
+
+beforeEach(() => {
+    coreDispatch().reset();
+    __resetCoreDataShimConfig();
+});
+
+afterEach(() => {
+    coreDispatch().reset();
+    __resetCoreDataShimConfig();
+});
+
+describe('B2 sample-content fixtures', () => {
+    it.each(FIXTURE_ENTITIES)(
+        'round-trips $name fixtures through fetchEntityRecord → getEntityRecord',
+        async ({ kind, name, directory }) => {
+            const fixtures = loadFixtures(directory);
+
+            expect(fixtures.length).toBeGreaterThan(0);
+
+            for (const record of fixtures) {
+                configureCoreDataShim({
+                    apiBase: '/visual-editor/api',
+                    fetcher: mockFetcher(async () => jsonResponse(record)),
+                });
+
+                const fetched = await coreDispatch().fetchEntityRecord(
+                    kind,
+                    name,
+                    record.id,
+                );
+
+                expect(fetched).toEqual(record);
+                expect(coreSelect().getEntityRecord(kind, name, record.id)).toEqual(record);
+            }
+        },
+    );
+
+    it('covers every B1 default entity at least once', () => {
+        const countsByFragment = FIXTURE_ENTITIES.map(({ directory }) => ({
+            directory,
+            count: loadFixtures(directory).length,
+        }));
+
+        // Acceptance criteria from #354: 3–4 templates, 3 template parts,
+        // 2–3 navigation records, 3+ patterns, 1 global styles record.
+        const byDirectory = Object.fromEntries(
+            countsByFragment.map(({ directory, count }) => [directory, count]),
+        );
+
+        expect(byDirectory.templates).toBeGreaterThanOrEqual(3);
+        expect(byDirectory['template-parts']).toBeGreaterThanOrEqual(3);
+        expect(byDirectory.navigation).toBeGreaterThanOrEqual(2);
+        expect(byDirectory.patterns).toBeGreaterThanOrEqual(3);
+        expect(byDirectory['global-styles']).toBe(1);
+    });
+
+    it('includes both synced and unsynced patterns so Phase D5 has a starting point', () => {
+        const patterns = loadFixtures('patterns');
+        const synced = patterns.filter((pattern) => pattern.synced === true);
+        const unsynced = patterns.filter((pattern) => pattern.synced === false);
+
+        expect(synced.length).toBeGreaterThan(0);
+        expect(unsynced.length).toBeGreaterThan(0);
+    });
+});

--- a/src/Console/Commands/SeedSampleContentCommand.php
+++ b/src/Console/Commands/SeedSampleContentCommand.php
@@ -1,0 +1,98 @@
+<?php
+
+/**
+ * Artisan command that seeds sample site-editor content for the
+ * dev app (or any other host app that wants the shim-backed
+ * entities to render with non-empty data).
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Console\Commands;
+
+use ArtisanPackUI\VisualEditor\SampleContent\SampleContentRepository;
+use Illuminate\Console\Command;
+use InvalidArgumentException;
+use RuntimeException;
+use Throwable;
+
+class SeedSampleContentCommand extends Command
+{
+	protected $signature = 'visual-editor:seed-sample-content
+        {--path= : Absolute path to a sample-content fixtures directory.}
+        {--disk= : Storage disk name to write seeded records to (defaults to the app default disk).}';
+
+	protected $description = 'Seed templates, template parts, navigation, patterns, and global styles from the sample-content fixtures.';
+
+	public function handle( SampleContentRepository $repository ): int
+	{
+		$fixturesDir = $this->resolveFixturesDirectory();
+
+		if ( null === $fixturesDir ) {
+			$this->error(
+				'Unable to locate a sample-content fixtures directory. Pass --path or set '
+				. 'artisanpack.visual-editor.sample_content.fixtures_path in config.'
+			);
+
+			return self::FAILURE;
+		}
+
+		$disk = $this->option( 'disk' );
+
+		try {
+			$fixtures = $repository->loadFixtures( $fixturesDir );
+			$counts   = $repository->writeToDisk(
+				$repository->resolveDisk( is_string( $disk ) && '' !== $disk ? $disk : null ),
+				$fixtures
+			);
+		} catch ( InvalidArgumentException | RuntimeException $e ) {
+			$this->error( $e->getMessage() );
+
+			return self::FAILURE;
+		} catch ( Throwable $e ) {
+			$this->error(
+				sprintf( 'Sample-content seed failed: %s', $e->getMessage() )
+			);
+
+			return self::FAILURE;
+		}
+
+		$this->info( sprintf( 'Seeded sample content from %s', $fixturesDir ) );
+
+		foreach ( $counts as $fragment => $count ) {
+			$this->line( sprintf( '  - %-15s %d record(s)', $fragment, $count ) );
+		}
+
+		return self::SUCCESS;
+	}
+
+	protected function resolveFixturesDirectory(): ?string
+	{
+		$override = $this->option( 'path' );
+
+		if ( is_string( $override ) && '' !== $override ) {
+			return $override;
+		}
+
+		$configured = config( 'artisanpack.visual-editor.sample_content.fixtures_path' );
+
+		if ( is_string( $configured ) && '' !== $configured ) {
+			return $configured;
+		}
+
+		$packaged = dirname( __DIR__, 3 ) . '/tests/Fixtures/sample-content';
+
+		if ( is_dir( $packaged ) ) {
+			return $packaged;
+		}
+
+		return null;
+	}
+}

--- a/src/SampleContent/SampleContentRepository.php
+++ b/src/SampleContent/SampleContentRepository.php
@@ -1,0 +1,312 @@
+<?php
+
+/**
+ * Repository that reads dev-app sample-content fixtures and writes
+ * them to a storage disk for the B1 core-data shim to consume.
+ *
+ * The fixtures model the five site-editor entities that the shim
+ * registers by default — `wp_template`, `wp_template_part`,
+ * `wp_navigation`, `wp_block` (patterns), and `globalStyles`. Every
+ * file is a single-record JSON document laid out under
+ * `{fixturesDir}/{slug}/{name}.json`, where `slug` is the REST path
+ * fragment (e.g. `templates`, `template-parts`).
+ *
+ * Storing the loaded fixtures on a disk rather than a database table
+ * keeps Phase B2 decoupled from the Phase C migrations: each Phase C
+ * entity ticket can take over by pointing its seeder at the same
+ * fixtures directory and inserting rows into the real tables.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\SampleContent;
+
+use Illuminate\Contracts\Filesystem\Filesystem;
+use Illuminate\Support\Facades\Storage;
+use InvalidArgumentException;
+use JsonException;
+use RuntimeException;
+
+class SampleContentRepository
+{
+	/**
+	 * Map of REST URL fragment → (kind, name) that the B1 shim
+	 * registers by default. The REST fragment doubles as the
+	 * sub-directory under the fixtures root.
+	 *
+	 * @var array<string, array{kind: string, name: string}>
+	 */
+	public const ENTITY_MAP = [
+		'templates'      => [ 'kind' => 'postType', 'name' => 'wp_template' ],
+		'template-parts' => [ 'kind' => 'postType', 'name' => 'wp_template_part' ],
+		'navigation'     => [ 'kind' => 'postType', 'name' => 'wp_navigation' ],
+		'patterns'       => [ 'kind' => 'postType', 'name' => 'wp_block' ],
+		'global-styles'  => [ 'kind' => 'root', 'name' => 'globalStyles' ],
+	];
+
+	/**
+	 * Loads every fixture under `$fixturesDir` grouped by its REST
+	 * URL fragment.
+	 *
+	 * The directory layout mirrors the package's REST surface:
+	 *
+	 *     tests/Fixtures/sample-content/
+	 *     ├── templates/
+	 *     │   ├── index.json
+	 *     │   └── single.json
+	 *     ├── template-parts/
+	 *     │   └── header.json
+	 *     ├── navigation/…
+	 *     ├── patterns/…
+	 *     └── global-styles/default.json
+	 *
+	 * Subdirectories that do not match {@see ENTITY_MAP} are ignored
+	 * so host apps can park in-progress or draft fixtures alongside
+	 * the canonical set without breaking the seeder.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string  $fixturesDir  Absolute path to the fixtures root.
+	 *
+	 * @return array<string, array<string, array<string, mixed>>> Map
+	 *     of `urlFragment => [ basename => record ]`.
+	 *
+	 * @throws InvalidArgumentException If the directory is missing.
+	 * @throws RuntimeException         If a fixture file cannot be read or
+	 *                                  does not contain a JSON object.
+	 */
+	public function loadFixtures( string $fixturesDir ): array
+	{
+		if ( ! is_dir( $fixturesDir ) ) {
+			throw new InvalidArgumentException(
+				sprintf( 'Sample-content fixtures directory not found: %s', $fixturesDir )
+			);
+		}
+
+		$fixtures = [];
+
+		foreach ( array_keys( self::ENTITY_MAP ) as $fragment ) {
+			$entityDir = rtrim( $fixturesDir, DIRECTORY_SEPARATOR )
+				. DIRECTORY_SEPARATOR . $fragment;
+
+			if ( ! is_dir( $entityDir ) ) {
+				$fixtures[ $fragment ] = [];
+
+				continue;
+			}
+
+			$fixtures[ $fragment ] = $this->loadEntityDirectory( $entityDir );
+		}
+
+		return $fixtures;
+	}
+
+	/**
+	 * Writes every loaded fixture to the target disk, one JSON file
+	 * per record, under `visual-editor/sample-content/{kind}/{name}/{id}.json`.
+	 *
+	 * Re-running the method overwrites existing files with the same
+	 * payload, which keeps the seeder idempotent without needing a
+	 * hash-vs-hash diff — the target disk always reflects the fixtures
+	 * directory byte-for-byte.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  Filesystem                                                     $disk      Storage disk to write to.
+	 * @param  array<string, array<string, array<string, mixed>>>             $fixtures  Fixtures grouped by URL fragment.
+	 *
+	 * @return array<string, int> Map of `urlFragment => recordCount`.
+	 *
+	 * @throws RuntimeException If any fixture is missing a usable primary key.
+	 */
+	public function writeToDisk( Filesystem $disk, array $fixtures ): array
+	{
+		$root   = 'visual-editor/sample-content';
+		$counts = [];
+
+		foreach ( self::ENTITY_MAP as $fragment => $identity ) {
+			$records = $fixtures[ $fragment ] ?? [];
+			$counts[ $fragment ] = 0;
+
+			$entityPath = sprintf(
+				'%s/%s/%s',
+				$root,
+				$identity['kind'],
+				$identity['name']
+			);
+
+			// Reset the entity directory so removed fixtures do not
+			// linger on disk after a seed. `deleteDirectory` is defined
+			// on the `Filesystem` contract, so every driver the host
+			// app might configure (local, s3, memory, …) supports it.
+			if ( $disk->exists( $entityPath ) ) {
+				$disk->deleteDirectory( $entityPath );
+			}
+
+			foreach ( $records as $basename => $record ) {
+				$id = $this->recordIdFor( $fragment, (string) $basename, $record );
+
+				$disk->put(
+					sprintf( '%s/%s.json', $entityPath, $id ),
+					$this->encode( $record )
+				);
+
+				$counts[ $fragment ]++;
+			}
+		}
+
+		return $counts;
+	}
+
+	/**
+	 * Reads a single previously-seeded record back from the disk.
+	 * Exposed for feature tests and diagnostic tooling — the shim
+	 * itself pulls records through HTTP, not this path.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  Filesystem          $disk      Storage disk to read from.
+	 * @param  string              $fragment  REST URL fragment (e.g. `templates`).
+	 * @param  int|string          $id        Record primary key.
+	 *
+	 * @return array<string, mixed>|null The decoded record, or null if absent.
+	 *
+	 * @throws InvalidArgumentException If `$fragment` is not a known entity.
+	 * @throws RuntimeException         If the stored payload cannot be decoded.
+	 */
+	public function readRecord( Filesystem $disk, string $fragment, int | string $id ): ?array
+	{
+		if ( ! array_key_exists( $fragment, self::ENTITY_MAP ) ) {
+			throw new InvalidArgumentException(
+				sprintf( 'Unknown sample-content entity fragment: %s', $fragment )
+			);
+		}
+
+		$identity = self::ENTITY_MAP[ $fragment ];
+
+		$path = sprintf(
+			'visual-editor/sample-content/%s/%s/%s.json',
+			$identity['kind'],
+			$identity['name'],
+			$id
+		);
+
+		if ( ! $disk->exists( $path ) ) {
+			return null;
+		}
+
+		return $this->decode( $disk->get( $path ) ?? '', $path );
+	}
+
+	/**
+	 * Resolves the default storage disk the command should write to.
+	 * Prefers the host app's `local` disk when available so the seeded
+	 * files land under `storage/app/visual-editor/sample-content/`.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string|null  $name  Optional disk name override.
+	 */
+	public function resolveDisk( ?string $name = null ): Filesystem
+	{
+		if ( null !== $name ) {
+			return Storage::disk( $name );
+		}
+
+		return Storage::disk( config( 'filesystems.default', 'local' ) );
+	}
+
+	/**
+	 * @param  string  $directory  Absolute path to an entity-type fixture dir.
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
+	protected function loadEntityDirectory( string $directory ): array
+	{
+		$records = [];
+
+		$files = glob( rtrim( $directory, DIRECTORY_SEPARATOR ) . DIRECTORY_SEPARATOR . '*.json' ) ?: [];
+
+		sort( $files );
+
+		foreach ( $files as $file ) {
+			$basename = pathinfo( $file, PATHINFO_FILENAME );
+			$contents = file_get_contents( $file );
+
+			if ( false === $contents ) {
+				throw new RuntimeException( sprintf( 'Unable to read fixture: %s', $file ) );
+			}
+
+			$records[ $basename ] = $this->decode( $contents, $file );
+		}
+
+		return $records;
+	}
+
+	/**
+	 * @param  array<string, mixed>  $record
+	 */
+	protected function recordIdFor( string $fragment, string $basename, array $record ): int | string
+	{
+		$id = $record['id'] ?? null;
+
+		if ( is_int( $id ) || ( is_string( $id ) && '' !== $id ) ) {
+			return $id;
+		}
+
+		throw new RuntimeException(
+			sprintf(
+				'Sample-content fixture %s/%s.json is missing a primary key.',
+				$fragment,
+				$basename
+			)
+		);
+	}
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	protected function decode( string $payload, string $source ): array
+	{
+		try {
+			$decoded = json_decode( $payload, true, 512, JSON_THROW_ON_ERROR );
+		} catch ( JsonException $e ) {
+			throw new RuntimeException(
+				sprintf( 'Unable to decode sample-content fixture %s: %s', $source, $e->getMessage() ),
+				0,
+				$e
+			);
+		}
+
+		if ( ! is_array( $decoded ) ) {
+			throw new RuntimeException(
+				sprintf( 'Sample-content fixture %s must decode to a JSON object.', $source )
+			);
+		}
+
+		return $decoded;
+	}
+
+	protected function encode( array $record ): string
+	{
+		try {
+			return json_encode(
+				$record,
+				JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
+			) . "\n";
+		} catch ( JsonException $e ) {
+			throw new RuntimeException(
+				sprintf( 'Unable to encode sample-content fixture: %s', $e->getMessage() ),
+				0,
+				$e
+			);
+		}
+	}
+}

--- a/src/SampleContent/SampleContentRepository.php
+++ b/src/SampleContent/SampleContentRepository.php
@@ -151,12 +151,18 @@ class SampleContentRepository
 			}
 
 			foreach ( $records as $basename => $record ) {
-				$id = $this->recordIdFor( $fragment, (string) $basename, $record );
+				$id     = $this->recordIdFor( $fragment, (string) $basename, $record );
+				$target = sprintf( '%s/%s.json', $entityPath, $id );
 
-				$disk->put(
-					sprintf( '%s/%s.json', $entityPath, $id ),
-					$this->encode( $record )
-				);
+				if ( ! $disk->put( $target, $this->encode( $record ) ) ) {
+					throw new RuntimeException(
+						sprintf(
+							'Failed to write sample-content fixture %s (entity id %s).',
+							$target,
+							$id
+						)
+					);
+				}
 
 				$counts[ $fragment ]++;
 			}
@@ -251,13 +257,35 @@ class SampleContentRepository
 	}
 
 	/**
+	 * Resolves the primary key for a fixture and guards against
+	 * filename-unsafe values. String IDs flow straight into the disk
+	 * path, so anything with a path separator or `..` segment could
+	 * escape `visual-editor/sample-content/{kind}/{name}/` — even
+	 * though the fixtures are dev-authored today, the `--path` option
+	 * lets host apps point the seeder at arbitrary directories.
+	 *
 	 * @param  array<string, mixed>  $record
 	 */
 	protected function recordIdFor( string $fragment, string $basename, array $record ): int | string
 	{
 		$id = $record['id'] ?? null;
 
-		if ( is_int( $id ) || ( is_string( $id ) && '' !== $id ) ) {
+		if ( is_int( $id ) ) {
+			return $id;
+		}
+
+		if ( is_string( $id ) && '' !== $id ) {
+			if ( 1 !== preg_match( '/^[A-Za-z0-9._-]+$/', $id ) || str_contains( $id, '..' ) ) {
+				throw new RuntimeException(
+					sprintf(
+						'Sample-content fixture %s/%s.json has an unsafe id %s — ids must contain only letters, digits, dot, underscore, or hyphen, and no path-traversal segments.',
+						$fragment,
+						$basename,
+						var_export( $id, true )
+					)
+				);
+			}
+
 			return $id;
 		}
 
@@ -285,7 +313,7 @@ class SampleContentRepository
 			);
 		}
 
-		if ( ! is_array( $decoded ) ) {
+		if ( ! is_array( $decoded ) || array_is_list( $decoded ) ) {
 			throw new RuntimeException(
 				sprintf( 'Sample-content fixture %s must decode to a JSON object.', $source )
 			);

--- a/src/SampleContent/SampleContentRepository.php
+++ b/src/SampleContent/SampleContentRepository.php
@@ -216,13 +216,15 @@ class SampleContentRepository
 			);
 		}
 
+		$safeId = $this->assertSafeId( $id );
+
 		$identity = self::ENTITY_MAP[ $fragment ];
 
 		$path = sprintf(
 			'visual-editor/sample-content/%s/%s/%s.json',
 			$identity['kind'],
 			$identity['name'],
-			$id
+			$safeId
 		);
 
 		if ( ! $disk->exists( $path ) ) {
@@ -296,7 +298,7 @@ class SampleContentRepository
 		}
 
 		if ( is_string( $id ) && '' !== $id ) {
-			if ( 1 !== preg_match( '/^[A-Za-z0-9._-]+$/', $id ) || str_contains( $id, '..' ) ) {
+			if ( ! $this->isSafeIdSegment( $id ) ) {
 				throw new RuntimeException(
 					sprintf(
 						'Sample-content fixture %s/%s.json has an unsafe id %s — ids must contain only letters, digits, dot, underscore, or hyphen, and no path-traversal segments.',
@@ -317,6 +319,42 @@ class SampleContentRepository
 				$basename
 			)
 		);
+	}
+
+	/**
+	 * Validates that `$id` is safe to use as a single path segment
+	 * and returns its string form. Non-integer string ids must match
+	 * the allowed character set and may not contain any `..` segment.
+	 *
+	 * @throws InvalidArgumentException If the id is blank or unsafe.
+	 */
+	protected function assertSafeId( int | string $id ): string
+	{
+		if ( is_int( $id ) ) {
+			return (string) $id;
+		}
+
+		if ( '' === $id || ! $this->isSafeIdSegment( $id ) ) {
+			throw new InvalidArgumentException(
+				sprintf(
+					'Unsafe sample-content id %s — ids must contain only letters, digits, dot, underscore, or hyphen, and no path-traversal segments.',
+					var_export( $id, true )
+				)
+			);
+		}
+
+		return $id;
+	}
+
+	/**
+	 * Whether `$id` is a single filename-safe path segment: ASCII
+	 * letters, digits, dot, underscore, hyphen; and no `..` anywhere
+	 * (which would otherwise satisfy the character class).
+	 */
+	protected function isSafeIdSegment( string $id ): bool
+	{
+		return 1 === preg_match( '/^[A-Za-z0-9._-]+$/', $id )
+			&& ! str_contains( $id, '..' );
 	}
 
 	/**

--- a/src/SampleContent/SampleContentRepository.php
+++ b/src/SampleContent/SampleContentRepository.php
@@ -129,8 +129,14 @@ class SampleContentRepository
 	public function writeToDisk( Filesystem $disk, array $fixtures ): array
 	{
 		$root   = 'visual-editor/sample-content';
+		$plan   = [];
 		$counts = [];
 
+		// Validate + encode every record first so a malformed fixture
+		// aborts the seed before any existing directory is deleted.
+		// Otherwise a bad fixture partway through the loop would wipe
+		// the previously-seeded sample content and leave nothing to
+		// read back.
 		foreach ( self::ENTITY_MAP as $fragment => $identity ) {
 			$records = $fixtures[ $fragment ] ?? [];
 			$counts[ $fragment ] = 0;
@@ -142,24 +148,39 @@ class SampleContentRepository
 				$identity['name']
 			);
 
-			// Reset the entity directory so removed fixtures do not
-			// linger on disk after a seed. `deleteDirectory` is defined
-			// on the `Filesystem` contract, so every driver the host
-			// app might configure (local, s3, memory, …) supports it.
-			if ( $disk->exists( $entityPath ) ) {
-				$disk->deleteDirectory( $entityPath );
-			}
+			$plan[ $fragment ] = [
+				'entityPath' => $entityPath,
+				'writes'     => [],
+			];
 
 			foreach ( $records as $basename => $record ) {
 				$id     = $this->recordIdFor( $fragment, (string) $basename, $record );
 				$target = sprintf( '%s/%s.json', $entityPath, $id );
 
-				if ( ! $disk->put( $target, $this->encode( $record ) ) ) {
+				$plan[ $fragment ]['writes'][] = [
+					'id'      => $id,
+					'target'  => $target,
+					'payload' => $this->encode( $record ),
+				];
+			}
+		}
+
+		// With every fixture validated, it's safe to reset the entity
+		// directories and commit the writes. `deleteDirectory` is
+		// defined on the `Filesystem` contract, so every driver the
+		// host app might configure (local, s3, memory, …) supports it.
+		foreach ( $plan as $fragment => $entry ) {
+			if ( $disk->exists( $entry['entityPath'] ) ) {
+				$disk->deleteDirectory( $entry['entityPath'] );
+			}
+
+			foreach ( $entry['writes'] as $write ) {
+				if ( ! $disk->put( $write['target'], $write['payload'] ) ) {
 					throw new RuntimeException(
 						sprintf(
 							'Failed to write sample-content fixture %s (entity id %s).',
-							$target,
-							$id
+							$write['target'],
+							$write['id']
 						)
 					);
 				}

--- a/src/VisualEditorServiceProvider.php
+++ b/src/VisualEditorServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace ArtisanPackUI\VisualEditor;
 
+use ArtisanPackUI\VisualEditor\Console\Commands\SeedSampleContentCommand;
 use ArtisanPackUI\VisualEditor\MediaBridge\GutenbergAttachmentAdapter;
 use ArtisanPackUI\VisualEditor\Models\VisualEditorPost;
 use ArtisanPackUI\VisualEditor\Policies\VisualEditorPostPolicy;
@@ -96,6 +97,10 @@ class VisualEditorServiceProvider extends ServiceProvider
 			$this->publishes( [
 								  __DIR__ . '/../config/visual-editor.php' => config_path( 'artisanpack/visual-editor.php' ),
 							  ], 'artisanpack-package-config' );
+
+			$this->commands( [
+				SeedSampleContentCommand::class,
+			] );
 		}
 	}
 

--- a/tests/Feature/VisualEditor/SeedSampleContentCommandTest.php
+++ b/tests/Feature/VisualEditor/SeedSampleContentCommandTest.php
@@ -1,0 +1,162 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\SampleContent\SampleContentRepository;
+use Illuminate\Support\Facades\Storage;
+
+beforeEach( function (): void {
+	Storage::fake( 'local' );
+} );
+
+it( 'seeds every B1-shim entity from the packaged fixtures directory', function (): void {
+	$this->artisan( 'visual-editor:seed-sample-content' )
+		->expectsOutputToContain( 'Seeded sample content from' )
+		->assertSuccessful();
+
+	$disk = Storage::disk( 'local' );
+
+	// One record per fixture file committed under tests/Fixtures/sample-content/.
+	expect( $disk->files( 'visual-editor/sample-content/postType/wp_template' ) )->toHaveCount( 4 );
+	expect( $disk->files( 'visual-editor/sample-content/postType/wp_template_part' ) )->toHaveCount( 3 );
+	expect( $disk->files( 'visual-editor/sample-content/postType/wp_navigation' ) )->toHaveCount( 3 );
+	expect( $disk->files( 'visual-editor/sample-content/postType/wp_block' ) )->toHaveCount( 3 );
+	expect( $disk->files( 'visual-editor/sample-content/root/globalStyles' ) )->toHaveCount( 1 );
+} );
+
+it( 'covers the acceptance criteria for each entity kind', function (): void {
+	$this->artisan( 'visual-editor:seed-sample-content' )->assertSuccessful();
+
+	$repository = app( SampleContentRepository::class );
+	$disk       = Storage::disk( 'local' );
+
+	// Templates — four of them, each with a non-empty block tree.
+	foreach ( [ 1, 2, 3, 4 ] as $id ) {
+		$record = $repository->readRecord( $disk, 'templates', $id );
+
+		expect( $record )->not->toBeNull();
+		expect( $record['type'] )->toBe( 'wp_template' );
+		expect( $record['content']['blocks'] )->not->toBeEmpty();
+	}
+
+	// Header template part is referenced by every template fixture.
+	$header = $repository->readRecord( $disk, 'template-parts', 10 );
+	expect( $header )->not->toBeNull();
+	expect( $header['area'] )->toBe( 'header' );
+
+	// Nested navigation exercises the submenu shape for Phase D4.
+	$nested = $repository->readRecord( $disk, 'navigation', 22 );
+	expect( $nested )->not->toBeNull();
+	$submenuBlocks = array_filter(
+		$nested['content']['blocks'],
+		static fn ( array $block ): bool => 'core/navigation-submenu' === ( $block['name'] ?? null )
+	);
+	expect( $submenuBlocks )->not->toBeEmpty();
+
+	// Patterns cover both synced and unsynced variants.
+	$synced   = $repository->readRecord( $disk, 'patterns', 30 );
+	$unsynced = $repository->readRecord( $disk, 'patterns', 31 );
+	expect( $synced['synced'] )->toBeTrue();
+	expect( $unsynced['synced'] )->toBeFalse();
+
+	// Global styles is the singleton theme.json record.
+	$globalStyles = $repository->readRecord( $disk, 'global-styles', 40 );
+	expect( $globalStyles )->not->toBeNull();
+	expect( $globalStyles['version'] )->toBe( 3 );
+	expect( $globalStyles['settings']['color']['palette'] )->not->toBeEmpty();
+	expect( $globalStyles['styles']['blocks']['core/button'] )->not->toBeEmpty();
+} );
+
+it( 'is idempotent across repeated runs', function (): void {
+	$this->artisan( 'visual-editor:seed-sample-content' )->assertSuccessful();
+
+	$disk           = Storage::disk( 'local' );
+	$firstSnapshot  = collect( $disk->allFiles( 'visual-editor/sample-content' ) )
+		->mapWithKeys( fn ( string $file ): array => [ $file => $disk->get( $file ) ] )
+		->all();
+
+	$this->artisan( 'visual-editor:seed-sample-content' )->assertSuccessful();
+
+	$secondSnapshot = collect( $disk->allFiles( 'visual-editor/sample-content' ) )
+		->mapWithKeys( fn ( string $file ): array => [ $file => $disk->get( $file ) ] )
+		->all();
+
+	expect( $secondSnapshot )->toEqual( $firstSnapshot );
+} );
+
+it( 'prunes records removed from the fixtures directory on re-seed', function (): void {
+	$fixturesDir = sys_get_temp_dir() . '/visual-editor-b2-fixtures-' . uniqid();
+	mkdir( $fixturesDir . '/templates', 0o777, true );
+
+	file_put_contents(
+		$fixturesDir . '/templates/temp.json',
+		json_encode( [ 'id' => 999, 'slug' => 'temp', 'type' => 'wp_template' ] )
+	);
+
+	$this->artisan( 'visual-editor:seed-sample-content', [ '--path' => $fixturesDir ] )
+		->assertSuccessful();
+
+	expect( Storage::disk( 'local' )->exists( 'visual-editor/sample-content/postType/wp_template/999.json' ) )
+		->toBeTrue();
+
+	unlink( $fixturesDir . '/templates/temp.json' );
+
+	$this->artisan( 'visual-editor:seed-sample-content', [ '--path' => $fixturesDir ] )
+		->assertSuccessful();
+
+	expect( Storage::disk( 'local' )->exists( 'visual-editor/sample-content/postType/wp_template/999.json' ) )
+		->toBeFalse();
+
+	rmdir( $fixturesDir . '/templates' );
+	rmdir( $fixturesDir );
+} );
+
+it( 'fails fast when the fixtures directory is missing', function (): void {
+	$this->artisan( 'visual-editor:seed-sample-content', [ '--path' => '/nonexistent/path' ] )
+		->expectsOutputToContain( 'Sample-content fixtures directory not found' )
+		->assertFailed();
+} );
+
+it( 'respects a custom fixtures path via the --path option', function (): void {
+	$fixturesDir = sys_get_temp_dir() . '/visual-editor-b2-fixtures-' . uniqid();
+	mkdir( $fixturesDir . '/patterns', 0o777, true );
+
+	file_put_contents(
+		$fixturesDir . '/patterns/custom.json',
+		json_encode( [
+			'id'      => 500,
+			'slug'    => 'custom',
+			'type'    => 'wp_block',
+			'synced'  => false,
+			'content' => [ 'raw' => '', 'blocks' => [] ],
+		] )
+	);
+
+	$this->artisan( 'visual-editor:seed-sample-content', [ '--path' => $fixturesDir ] )
+		->assertSuccessful();
+
+	expect( Storage::disk( 'local' )->exists( 'visual-editor/sample-content/postType/wp_block/500.json' ) )
+		->toBeTrue();
+
+	unlink( $fixturesDir . '/patterns/custom.json' );
+	rmdir( $fixturesDir . '/patterns' );
+	rmdir( $fixturesDir );
+} );
+
+it( 'rejects fixtures that are missing a primary key', function (): void {
+	$fixturesDir = sys_get_temp_dir() . '/visual-editor-b2-fixtures-' . uniqid();
+	mkdir( $fixturesDir . '/templates', 0o777, true );
+
+	file_put_contents(
+		$fixturesDir . '/templates/broken.json',
+		json_encode( [ 'slug' => 'broken', 'title' => [ 'rendered' => 'Broken' ] ] )
+	);
+
+	$this->artisan( 'visual-editor:seed-sample-content', [ '--path' => $fixturesDir ] )
+		->expectsOutputToContain( 'missing a primary key' )
+		->assertFailed();
+
+	unlink( $fixturesDir . '/templates/broken.json' );
+	rmdir( $fixturesDir . '/templates' );
+	rmdir( $fixturesDir );
+} );

--- a/tests/Feature/VisualEditor/SeedSampleContentCommandTest.php
+++ b/tests/Feature/VisualEditor/SeedSampleContentCommandTest.php
@@ -160,3 +160,39 @@ it( 'rejects fixtures that are missing a primary key', function (): void {
 	rmdir( $fixturesDir . '/templates' );
 	rmdir( $fixturesDir );
 } );
+
+it( 'rejects string ids that would escape the sample-content directory', function (): void {
+	$fixturesDir = sys_get_temp_dir() . '/visual-editor-b2-fixtures-' . uniqid();
+	mkdir( $fixturesDir . '/templates', 0o777, true );
+
+	file_put_contents(
+		$fixturesDir . '/templates/traversal.json',
+		json_encode( [ 'id' => '../evil', 'slug' => 'traversal' ] )
+	);
+
+	$this->artisan( 'visual-editor:seed-sample-content', [ '--path' => $fixturesDir ] )
+		->expectsOutputToContain( 'unsafe id' )
+		->assertFailed();
+
+	unlink( $fixturesDir . '/templates/traversal.json' );
+	rmdir( $fixturesDir . '/templates' );
+	rmdir( $fixturesDir );
+} );
+
+it( 'rejects fixture files whose top-level JSON is a list rather than an object', function (): void {
+	$fixturesDir = sys_get_temp_dir() . '/visual-editor-b2-fixtures-' . uniqid();
+	mkdir( $fixturesDir . '/templates', 0o777, true );
+
+	file_put_contents(
+		$fixturesDir . '/templates/list.json',
+		json_encode( [ [ 'id' => 1, 'slug' => 'wrapped' ] ] )
+	);
+
+	$this->artisan( 'visual-editor:seed-sample-content', [ '--path' => $fixturesDir ] )
+		->expectsOutputToContain( 'must decode to a JSON object' )
+		->assertFailed();
+
+	unlink( $fixturesDir . '/templates/list.json' );
+	rmdir( $fixturesDir . '/templates' );
+	rmdir( $fixturesDir );
+} );

--- a/tests/Feature/VisualEditor/SeedSampleContentCommandTest.php
+++ b/tests/Feature/VisualEditor/SeedSampleContentCommandTest.php
@@ -6,6 +6,11 @@ use ArtisanPackUI\VisualEditor\SampleContent\SampleContentRepository;
 use Illuminate\Support\Facades\Storage;
 
 beforeEach( function (): void {
+	// Pin the default disk so `Storage::fake('local')` is the disk
+	// the command resolves via `config('filesystems.default')`,
+	// regardless of what Testbench (or a future host app config)
+	// ships as its default.
+	config( [ 'filesystems.default' => 'local' ] );
 	Storage::fake( 'local' );
 } );
 
@@ -177,6 +182,53 @@ it( 'rejects string ids that would escape the sample-content directory', functio
 	unlink( $fixturesDir . '/templates/traversal.json' );
 	rmdir( $fixturesDir . '/templates' );
 	rmdir( $fixturesDir );
+} );
+
+it( 'preserves previously-seeded content when a later fixture fails validation', function (): void {
+	// First seed: a single valid fixture so the disk has known state.
+	$goodDir = sys_get_temp_dir() . '/visual-editor-b2-good-' . uniqid();
+	mkdir( $goodDir . '/templates', 0o777, true );
+	file_put_contents(
+		$goodDir . '/templates/valid.json',
+		json_encode( [ 'id' => 555, 'slug' => 'valid', 'type' => 'wp_template' ] )
+	);
+
+	$this->artisan( 'visual-editor:seed-sample-content', [ '--path' => $goodDir ] )
+		->assertSuccessful();
+
+	$targetPath = 'visual-editor/sample-content/postType/wp_template/555.json';
+	expect( Storage::disk( 'local' )->exists( $targetPath ) )->toBeTrue();
+
+	// Second seed: a new fixtures directory that mixes a valid
+	// record with one whose id would escape the sample-content root.
+	$mixedDir = sys_get_temp_dir() . '/visual-editor-b2-mixed-' . uniqid();
+	mkdir( $mixedDir . '/templates', 0o777, true );
+	file_put_contents(
+		$mixedDir . '/templates/fresh.json',
+		json_encode( [ 'id' => 777, 'slug' => 'fresh', 'type' => 'wp_template' ] )
+	);
+	file_put_contents(
+		$mixedDir . '/templates/broken.json',
+		json_encode( [ 'id' => '../escape', 'slug' => 'broken' ] )
+	);
+
+	$this->artisan( 'visual-editor:seed-sample-content', [ '--path' => $mixedDir ] )
+		->assertFailed();
+
+	// The previously-seeded record must still be on disk and the
+	// half-seeded "fresh" record must NOT have been written.
+	expect( Storage::disk( 'local' )->exists( $targetPath ) )->toBeTrue();
+	expect(
+		Storage::disk( 'local' )->exists( 'visual-editor/sample-content/postType/wp_template/777.json' )
+	)->toBeFalse();
+
+	unlink( $goodDir . '/templates/valid.json' );
+	rmdir( $goodDir . '/templates' );
+	rmdir( $goodDir );
+	unlink( $mixedDir . '/templates/fresh.json' );
+	unlink( $mixedDir . '/templates/broken.json' );
+	rmdir( $mixedDir . '/templates' );
+	rmdir( $mixedDir );
 } );
 
 it( 'rejects fixture files whose top-level JSON is a list rather than an object', function (): void {

--- a/tests/Feature/VisualEditor/SeedSampleContentCommandTest.php
+++ b/tests/Feature/VisualEditor/SeedSampleContentCommandTest.php
@@ -231,6 +231,19 @@ it( 'preserves previously-seeded content when a later fixture fails validation',
 	rmdir( $mixedDir );
 } );
 
+it( 'rejects unsafe ids passed directly to readRecord()', function (): void {
+	$this->artisan( 'visual-editor:seed-sample-content' )->assertSuccessful();
+
+	$repository = app( SampleContentRepository::class );
+	$disk       = Storage::disk( 'local' );
+
+	expect( fn () => $repository->readRecord( $disk, 'templates', '../escape' ) )
+		->toThrow( \InvalidArgumentException::class, 'Unsafe sample-content id' );
+
+	// Integer ids and safe strings still resolve normally.
+	expect( $repository->readRecord( $disk, 'templates', 1 ) )->not->toBeNull();
+} );
+
 it( 'rejects fixture files whose top-level JSON is a list rather than an object', function (): void {
 	$fixturesDir = sys_get_temp_dir() . '/visual-editor-b2-fixtures-' . uniqid();
 	mkdir( $fixturesDir . '/templates', 0o777, true );

--- a/tests/Fixtures/sample-content/global-styles/default.json
+++ b/tests/Fixtures/sample-content/global-styles/default.json
@@ -1,0 +1,70 @@
+{
+    "id": 40,
+    "version": 3,
+    "settings": {
+        "color": {
+            "palette": [
+                { "slug": "primary", "name": "Primary", "color": "#3b82f6" },
+                { "slug": "secondary", "name": "Secondary", "color": "#6366f1" },
+                { "slug": "accent", "name": "Accent", "color": "#10b981" },
+                { "slug": "base", "name": "Base", "color": "#ffffff" },
+                { "slug": "contrast", "name": "Contrast", "color": "#111827" }
+            ]
+        },
+        "typography": {
+            "fontFamilies": [
+                {
+                    "slug": "sans",
+                    "name": "Sans",
+                    "fontFamily": "'Inter', system-ui, sans-serif"
+                },
+                {
+                    "slug": "serif",
+                    "name": "Serif",
+                    "fontFamily": "'Source Serif 4', Georgia, serif"
+                }
+            ],
+            "fontSizes": [
+                { "slug": "small", "name": "Small", "size": "0.875rem" },
+                { "slug": "medium", "name": "Medium", "size": "1rem" },
+                { "slug": "large", "name": "Large", "size": "1.25rem" },
+                { "slug": "x-large", "name": "Extra Large", "size": "1.75rem" }
+            ]
+        },
+        "layout": {
+            "contentSize": "720px",
+            "wideSize": "1120px"
+        }
+    },
+    "styles": {
+        "color": {
+            "background": "var(--wp--preset--color--base)",
+            "text": "var(--wp--preset--color--contrast)"
+        },
+        "typography": {
+            "fontFamily": "var(--wp--preset--font-family--sans)",
+            "fontSize": "var(--wp--preset--font-size--medium)",
+            "lineHeight": "1.6"
+        },
+        "elements": {
+            "link": {
+                "color": { "text": "var(--wp--preset--color--primary)" }
+            },
+            "heading": {
+                "typography": {
+                    "fontFamily": "var(--wp--preset--font-family--serif)",
+                    "fontWeight": "600"
+                }
+            }
+        },
+        "blocks": {
+            "core/button": {
+                "color": {
+                    "background": "var(--wp--preset--color--primary)",
+                    "text": "var(--wp--preset--color--base)"
+                },
+                "border": { "radius": "0.5rem" }
+            }
+        }
+    }
+}

--- a/tests/Fixtures/sample-content/navigation/footer.json
+++ b/tests/Fixtures/sample-content/navigation/footer.json
@@ -1,0 +1,23 @@
+{
+    "id": 21,
+    "slug": "footer-nav",
+    "title": { "rendered": "Footer" },
+    "content": {
+        "raw": "<!-- wp:navigation-link {\"label\":\"Privacy\",\"url\":\"/privacy\"} /--><!-- wp:navigation-link {\"label\":\"Terms\",\"url\":\"/terms\"} /-->",
+        "blocks": [
+            {
+                "name": "core/navigation-link",
+                "attributes": { "label": "Privacy", "url": "/privacy" },
+                "innerBlocks": []
+            },
+            {
+                "name": "core/navigation-link",
+                "attributes": { "label": "Terms", "url": "/terms" },
+                "innerBlocks": []
+            }
+        ]
+    },
+    "status": "publish",
+    "menu_order": 1,
+    "type": "wp_navigation"
+}

--- a/tests/Fixtures/sample-content/navigation/nested.json
+++ b/tests/Fixtures/sample-content/navigation/nested.json
@@ -1,0 +1,45 @@
+{
+    "id": 22,
+    "slug": "nested-nav",
+    "title": { "rendered": "Nested" },
+    "content": {
+        "raw": "<!-- wp:navigation-link {\"label\":\"Home\",\"url\":\"/\"} /--><!-- wp:navigation-submenu {\"label\":\"Products\",\"url\":\"/products\"} --><!-- wp:navigation-link {\"label\":\"Featured\",\"url\":\"/products/featured\"} /--><!-- wp:navigation-link {\"label\":\"New\",\"url\":\"/products/new\"} /--><!-- /wp:navigation-submenu --><!-- wp:navigation-link {\"label\":\"Contact\",\"url\":\"/contact\"} /-->",
+        "blocks": [
+            {
+                "name": "core/navigation-link",
+                "attributes": { "label": "Home", "url": "/" },
+                "innerBlocks": []
+            },
+            {
+                "name": "core/navigation-submenu",
+                "attributes": { "label": "Products", "url": "/products" },
+                "innerBlocks": [
+                    {
+                        "name": "core/navigation-link",
+                        "attributes": {
+                            "label": "Featured",
+                            "url": "/products/featured"
+                        },
+                        "innerBlocks": []
+                    },
+                    {
+                        "name": "core/navigation-link",
+                        "attributes": {
+                            "label": "New",
+                            "url": "/products/new"
+                        },
+                        "innerBlocks": []
+                    }
+                ]
+            },
+            {
+                "name": "core/navigation-link",
+                "attributes": { "label": "Contact", "url": "/contact" },
+                "innerBlocks": []
+            }
+        ]
+    },
+    "status": "publish",
+    "menu_order": 2,
+    "type": "wp_navigation"
+}

--- a/tests/Fixtures/sample-content/navigation/primary.json
+++ b/tests/Fixtures/sample-content/navigation/primary.json
@@ -1,0 +1,28 @@
+{
+    "id": 20,
+    "slug": "primary-nav",
+    "title": { "rendered": "Primary" },
+    "content": {
+        "raw": "<!-- wp:navigation-link {\"label\":\"Home\",\"url\":\"/\"} /--><!-- wp:navigation-link {\"label\":\"About\",\"url\":\"/about\"} /--><!-- wp:navigation-link {\"label\":\"Contact\",\"url\":\"/contact\"} /-->",
+        "blocks": [
+            {
+                "name": "core/navigation-link",
+                "attributes": { "label": "Home", "url": "/" },
+                "innerBlocks": []
+            },
+            {
+                "name": "core/navigation-link",
+                "attributes": { "label": "About", "url": "/about" },
+                "innerBlocks": []
+            },
+            {
+                "name": "core/navigation-link",
+                "attributes": { "label": "Contact", "url": "/contact" },
+                "innerBlocks": []
+            }
+        ]
+    },
+    "status": "publish",
+    "menu_order": 0,
+    "type": "wp_navigation"
+}

--- a/tests/Fixtures/sample-content/patterns/call-out-pair.json
+++ b/tests/Fixtures/sample-content/patterns/call-out-pair.json
@@ -3,7 +3,7 @@
     "slug": "call-out-pair",
     "title": { "rendered": "Call-out pair" },
     "content": {
-        "raw": "<!-- wp:columns --><div class=\"wp-block-columns\"><!-- wp:column --><div class=\"wp-block-column\"><!-- wp:artisanpack/callout {\"tone\":\"info\"} --><div class=\"wp-block-artisanpack-callout\"><p>Section title</p><p>Body content here.</p></div><!-- /wp:artisanpack/callout --></div><!-- /wp:column --><!-- wp:column --><div class=\"wp-block-column\"><!-- wp:artisanpack/callout {\"tone\":\"success\"} --><div class=\"wp-block-artisanpack-callout\"><p>Section title</p><p>Body content here.</p></div><!-- /wp:artisanpack/callout --></div><!-- /wp:column --></div><!-- /wp:columns -->",
+        "raw": "<!-- wp:columns --><div class=\"wp-block-columns\"><!-- wp:column --><div class=\"wp-block-column\"><!-- wp:artisanpack/callout {\"tone\":\"info\",\"title\":\"Section title\",\"body\":\"Body content here.\"} --><div class=\"wp-block-artisanpack-callout\"><p>Section title</p><p>Body content here.</p></div><!-- /wp:artisanpack/callout --></div><!-- /wp:column --><!-- wp:column --><div class=\"wp-block-column\"><!-- wp:artisanpack/callout {\"tone\":\"success\",\"title\":\"Section title\",\"body\":\"Body content here.\"} --><div class=\"wp-block-artisanpack-callout\"><p>Section title</p><p>Body content here.</p></div><!-- /wp:artisanpack/callout --></div><!-- /wp:column --></div><!-- /wp:columns -->",
         "blocks": [
             {
                 "name": "core/columns",

--- a/tests/Fixtures/sample-content/patterns/call-out-pair.json
+++ b/tests/Fixtures/sample-content/patterns/call-out-pair.json
@@ -1,0 +1,50 @@
+{
+    "id": 32,
+    "slug": "call-out-pair",
+    "title": { "rendered": "Call-out pair" },
+    "content": {
+        "raw": "<!-- wp:columns --><div class=\"wp-block-columns\"><!-- wp:column --><div class=\"wp-block-column\"><!-- wp:artisanpack/callout {\"tone\":\"info\"} --><div class=\"wp-block-artisanpack-callout\"><p>Section title</p><p>Body content here.</p></div><!-- /wp:artisanpack/callout --></div><!-- /wp:column --><!-- wp:column --><div class=\"wp-block-column\"><!-- wp:artisanpack/callout {\"tone\":\"success\"} --><div class=\"wp-block-artisanpack-callout\"><p>Section title</p><p>Body content here.</p></div><!-- /wp:artisanpack/callout --></div><!-- /wp:column --></div><!-- /wp:columns -->",
+        "blocks": [
+            {
+                "name": "core/columns",
+                "attributes": {},
+                "innerBlocks": [
+                    {
+                        "name": "core/column",
+                        "attributes": {},
+                        "innerBlocks": [
+                            {
+                                "name": "artisanpack/callout",
+                                "attributes": {
+                                    "tone": "info",
+                                    "title": "Section title",
+                                    "body": "Body content here."
+                                },
+                                "innerBlocks": []
+                            }
+                        ]
+                    },
+                    {
+                        "name": "core/column",
+                        "attributes": {},
+                        "innerBlocks": [
+                            {
+                                "name": "artisanpack/callout",
+                                "attributes": {
+                                    "tone": "success",
+                                    "title": "Section title",
+                                    "body": "Body content here."
+                                },
+                                "innerBlocks": []
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    "synced": false,
+    "categories": ["featured"],
+    "status": "publish",
+    "type": "wp_block"
+}

--- a/tests/Fixtures/sample-content/patterns/hero.json
+++ b/tests/Fixtures/sample-content/patterns/hero.json
@@ -1,0 +1,56 @@
+{
+    "id": 30,
+    "slug": "hero",
+    "title": { "rendered": "Hero" },
+    "content": {
+        "raw": "<!-- wp:cover {\"overlayColor\":\"primary\"} --><div class=\"wp-block-cover\"><!-- wp:heading {\"level\":1,\"textAlign\":\"center\"} --><h1 class=\"has-text-align-center\">Section title</h1><!-- /wp:heading --><!-- wp:paragraph {\"align\":\"center\"} --><p class=\"has-text-align-center\">Body content here.</p><!-- /wp:paragraph --><!-- wp:buttons {\"layout\":{\"type\":\"flex\",\"justifyContent\":\"center\"}} --><div class=\"wp-block-buttons\"><!-- wp:button --><div class=\"wp-block-button\"><a class=\"wp-block-button__link\" href=\"#\">Primary action</a></div><!-- /wp:button --></div><!-- /wp:buttons --></div><!-- /wp:cover -->",
+        "blocks": [
+            {
+                "name": "core/cover",
+                "attributes": { "overlayColor": "primary" },
+                "innerBlocks": [
+                    {
+                        "name": "core/heading",
+                        "attributes": {
+                            "level": 1,
+                            "textAlign": "center",
+                            "content": "Section title"
+                        },
+                        "innerBlocks": []
+                    },
+                    {
+                        "name": "core/paragraph",
+                        "attributes": {
+                            "align": "center",
+                            "content": "Body content here."
+                        },
+                        "innerBlocks": []
+                    },
+                    {
+                        "name": "core/buttons",
+                        "attributes": {
+                            "layout": {
+                                "type": "flex",
+                                "justifyContent": "center"
+                            }
+                        },
+                        "innerBlocks": [
+                            {
+                                "name": "core/button",
+                                "attributes": {
+                                    "text": "Primary action",
+                                    "url": "#"
+                                },
+                                "innerBlocks": []
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    "synced": true,
+    "categories": ["featured"],
+    "status": "publish",
+    "type": "wp_block"
+}

--- a/tests/Fixtures/sample-content/patterns/pricing-row.json
+++ b/tests/Fixtures/sample-content/patterns/pricing-row.json
@@ -1,0 +1,68 @@
+{
+    "id": 31,
+    "slug": "pricing-row",
+    "title": { "rendered": "Pricing row" },
+    "content": {
+        "raw": "<!-- wp:columns --><div class=\"wp-block-columns\"><!-- wp:column --><div class=\"wp-block-column\"><!-- wp:heading {\"level\":3} --><h3>Starter</h3><!-- /wp:heading --><!-- wp:paragraph --><p>Price placeholder</p><!-- /wp:paragraph --></div><!-- /wp:column --><!-- wp:column --><div class=\"wp-block-column\"><!-- wp:heading {\"level\":3} --><h3>Pro</h3><!-- /wp:heading --><!-- wp:paragraph --><p>Price placeholder</p><!-- /wp:paragraph --></div><!-- /wp:column --><!-- wp:column --><div class=\"wp-block-column\"><!-- wp:heading {\"level\":3} --><h3>Team</h3><!-- /wp:heading --><!-- wp:paragraph --><p>Price placeholder</p><!-- /wp:paragraph --></div><!-- /wp:column --></div><!-- /wp:columns -->",
+        "blocks": [
+            {
+                "name": "core/columns",
+                "attributes": {},
+                "innerBlocks": [
+                    {
+                        "name": "core/column",
+                        "attributes": {},
+                        "innerBlocks": [
+                            {
+                                "name": "core/heading",
+                                "attributes": { "level": 3, "content": "Starter" },
+                                "innerBlocks": []
+                            },
+                            {
+                                "name": "core/paragraph",
+                                "attributes": { "content": "Price placeholder" },
+                                "innerBlocks": []
+                            }
+                        ]
+                    },
+                    {
+                        "name": "core/column",
+                        "attributes": {},
+                        "innerBlocks": [
+                            {
+                                "name": "core/heading",
+                                "attributes": { "level": 3, "content": "Pro" },
+                                "innerBlocks": []
+                            },
+                            {
+                                "name": "core/paragraph",
+                                "attributes": { "content": "Price placeholder" },
+                                "innerBlocks": []
+                            }
+                        ]
+                    },
+                    {
+                        "name": "core/column",
+                        "attributes": {},
+                        "innerBlocks": [
+                            {
+                                "name": "core/heading",
+                                "attributes": { "level": 3, "content": "Team" },
+                                "innerBlocks": []
+                            },
+                            {
+                                "name": "core/paragraph",
+                                "attributes": { "content": "Price placeholder" },
+                                "innerBlocks": []
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    "synced": false,
+    "categories": ["pricing"],
+    "status": "publish",
+    "type": "wp_block"
+}

--- a/tests/Fixtures/sample-content/template-parts/footer.json
+++ b/tests/Fixtures/sample-content/template-parts/footer.json
@@ -1,0 +1,32 @@
+{
+    "id": 11,
+    "slug": "footer",
+    "title": { "rendered": "Footer" },
+    "content": {
+        "raw": "<!-- wp:group {\"tagName\":\"footer\",\"layout\":{\"type\":\"constrained\"}} --><footer class=\"wp-block-group\"><!-- wp:paragraph --><p>Footer content here.</p><!-- /wp:paragraph --><!-- wp:navigation {\"ref\":21} /--></footer><!-- /wp:group -->",
+        "blocks": [
+            {
+                "name": "core/group",
+                "attributes": {
+                    "tagName": "footer",
+                    "layout": { "type": "constrained" }
+                },
+                "innerBlocks": [
+                    {
+                        "name": "core/paragraph",
+                        "attributes": { "content": "Footer content here." },
+                        "innerBlocks": []
+                    },
+                    {
+                        "name": "core/navigation",
+                        "attributes": { "ref": 21 },
+                        "innerBlocks": []
+                    }
+                ]
+            }
+        ]
+    },
+    "area": "footer",
+    "theme": "artisanpack-base",
+    "type": "wp_template_part"
+}

--- a/tests/Fixtures/sample-content/template-parts/header.json
+++ b/tests/Fixtures/sample-content/template-parts/header.json
@@ -1,0 +1,37 @@
+{
+    "id": 10,
+    "slug": "header",
+    "title": { "rendered": "Header" },
+    "content": {
+        "raw": "<!-- wp:group {\"tagName\":\"header\",\"layout\":{\"type\":\"constrained\"}} --><header class=\"wp-block-group\"><!-- wp:site-title /--><!-- wp:site-tagline /--><!-- wp:navigation {\"ref\":20} /--></header><!-- /wp:group -->",
+        "blocks": [
+            {
+                "name": "core/group",
+                "attributes": {
+                    "tagName": "header",
+                    "layout": { "type": "constrained" }
+                },
+                "innerBlocks": [
+                    {
+                        "name": "core/site-title",
+                        "attributes": {},
+                        "innerBlocks": []
+                    },
+                    {
+                        "name": "core/site-tagline",
+                        "attributes": {},
+                        "innerBlocks": []
+                    },
+                    {
+                        "name": "core/navigation",
+                        "attributes": { "ref": 20 },
+                        "innerBlocks": []
+                    }
+                ]
+            }
+        ]
+    },
+    "area": "header",
+    "theme": "artisanpack-base",
+    "type": "wp_template_part"
+}

--- a/tests/Fixtures/sample-content/template-parts/sidebar.json
+++ b/tests/Fixtures/sample-content/template-parts/sidebar.json
@@ -1,0 +1,32 @@
+{
+    "id": 12,
+    "slug": "sidebar",
+    "title": { "rendered": "Sidebar" },
+    "content": {
+        "raw": "<!-- wp:group {\"tagName\":\"aside\",\"layout\":{\"type\":\"constrained\"}} --><aside class=\"wp-block-group\"><!-- wp:heading {\"level\":2} --><h2>Section title</h2><!-- /wp:heading --><!-- wp:paragraph --><p>Body content here.</p><!-- /wp:paragraph --></aside><!-- /wp:group -->",
+        "blocks": [
+            {
+                "name": "core/group",
+                "attributes": {
+                    "tagName": "aside",
+                    "layout": { "type": "constrained" }
+                },
+                "innerBlocks": [
+                    {
+                        "name": "core/heading",
+                        "attributes": { "level": 2, "content": "Section title" },
+                        "innerBlocks": []
+                    },
+                    {
+                        "name": "core/paragraph",
+                        "attributes": { "content": "Body content here." },
+                        "innerBlocks": []
+                    }
+                ]
+            }
+        ]
+    },
+    "area": "sidebar",
+    "theme": "artisanpack-base",
+    "type": "wp_template_part"
+}

--- a/tests/Fixtures/sample-content/templates/404.json
+++ b/tests/Fixtures/sample-content/templates/404.json
@@ -1,0 +1,47 @@
+{
+    "id": 4,
+    "slug": "404",
+    "title": { "rendered": "404" },
+    "description": "Not-found template shown when the requested URL has no matching record.",
+    "content": {
+        "raw": "<!-- wp:template-part {\"slug\":\"header\",\"theme\":\"artisanpack-base\"} /--><!-- wp:group {\"tagName\":\"main\",\"layout\":{\"type\":\"constrained\"}} --><main class=\"wp-block-group\"><!-- wp:heading {\"level\":1} --><h1>Page not found</h1><!-- /wp:heading --><!-- wp:paragraph --><p>The page you requested could not be located.</p><!-- /wp:paragraph --></main><!-- /wp:group --><!-- wp:template-part {\"slug\":\"footer\",\"theme\":\"artisanpack-base\"} /-->",
+        "blocks": [
+            {
+                "name": "core/template-part",
+                "attributes": { "slug": "header", "theme": "artisanpack-base" },
+                "innerBlocks": []
+            },
+            {
+                "name": "core/group",
+                "attributes": {
+                    "tagName": "main",
+                    "layout": { "type": "constrained" }
+                },
+                "innerBlocks": [
+                    {
+                        "name": "core/heading",
+                        "attributes": { "level": 1, "content": "Page not found" },
+                        "innerBlocks": []
+                    },
+                    {
+                        "name": "core/paragraph",
+                        "attributes": {
+                            "content": "The page you requested could not be located."
+                        },
+                        "innerBlocks": []
+                    }
+                ]
+            },
+            {
+                "name": "core/template-part",
+                "attributes": { "slug": "footer", "theme": "artisanpack-base" },
+                "innerBlocks": []
+            }
+        ]
+    },
+    "status": "publish",
+    "theme": "artisanpack-base",
+    "type": "wp_template",
+    "source": "theme",
+    "origin": "theme"
+}

--- a/tests/Fixtures/sample-content/templates/index.json
+++ b/tests/Fixtures/sample-content/templates/index.json
@@ -1,0 +1,67 @@
+{
+    "id": 3,
+    "slug": "index",
+    "title": { "rendered": "Index" },
+    "description": "Root fallback template used when no more-specific template matches.",
+    "content": {
+        "raw": "<!-- wp:template-part {\"slug\":\"header\",\"theme\":\"artisanpack-base\"} /--><!-- wp:group {\"tagName\":\"main\",\"layout\":{\"type\":\"constrained\"}} --><main class=\"wp-block-group\"><!-- wp:heading {\"level\":1} --><h1>Section title</h1><!-- /wp:heading --><!-- wp:query --><!-- wp:post-template --><!-- wp:post-title {\"isLink\":true,\"level\":2} /--><!-- wp:post-excerpt /--><!-- wp:post-date /--><!-- /wp:post-template --><!-- /wp:query --></main><!-- /wp:group --><!-- wp:template-part {\"slug\":\"footer\",\"theme\":\"artisanpack-base\"} /-->",
+        "blocks": [
+            {
+                "name": "core/template-part",
+                "attributes": { "slug": "header", "theme": "artisanpack-base" },
+                "innerBlocks": []
+            },
+            {
+                "name": "core/group",
+                "attributes": {
+                    "tagName": "main",
+                    "layout": { "type": "constrained" }
+                },
+                "innerBlocks": [
+                    {
+                        "name": "core/heading",
+                        "attributes": { "level": 1, "content": "Section title" },
+                        "innerBlocks": []
+                    },
+                    {
+                        "name": "core/query",
+                        "attributes": {},
+                        "innerBlocks": [
+                            {
+                                "name": "core/post-template",
+                                "attributes": {},
+                                "innerBlocks": [
+                                    {
+                                        "name": "core/post-title",
+                                        "attributes": { "isLink": true, "level": 2 },
+                                        "innerBlocks": []
+                                    },
+                                    {
+                                        "name": "core/post-excerpt",
+                                        "attributes": {},
+                                        "innerBlocks": []
+                                    },
+                                    {
+                                        "name": "core/post-date",
+                                        "attributes": {},
+                                        "innerBlocks": []
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "name": "core/template-part",
+                "attributes": { "slug": "footer", "theme": "artisanpack-base" },
+                "innerBlocks": []
+            }
+        ]
+    },
+    "status": "publish",
+    "theme": "artisanpack-base",
+    "type": "wp_template",
+    "source": "theme",
+    "origin": "theme"
+}

--- a/tests/Fixtures/sample-content/templates/page.json
+++ b/tests/Fixtures/sample-content/templates/page.json
@@ -1,0 +1,45 @@
+{
+    "id": 2,
+    "slug": "page",
+    "title": { "rendered": "Page" },
+    "description": "Fallback template used for static pages.",
+    "content": {
+        "raw": "<!-- wp:template-part {\"slug\":\"header\",\"theme\":\"artisanpack-base\"} /--><!-- wp:group {\"tagName\":\"main\",\"layout\":{\"type\":\"constrained\"}} --><main class=\"wp-block-group\"><!-- wp:post-title {\"level\":1} /--><!-- wp:post-content /--></main><!-- /wp:group --><!-- wp:template-part {\"slug\":\"footer\",\"theme\":\"artisanpack-base\"} /-->",
+        "blocks": [
+            {
+                "name": "core/template-part",
+                "attributes": { "slug": "header", "theme": "artisanpack-base" },
+                "innerBlocks": []
+            },
+            {
+                "name": "core/group",
+                "attributes": {
+                    "tagName": "main",
+                    "layout": { "type": "constrained" }
+                },
+                "innerBlocks": [
+                    {
+                        "name": "core/post-title",
+                        "attributes": { "level": 1 },
+                        "innerBlocks": []
+                    },
+                    {
+                        "name": "core/post-content",
+                        "attributes": {},
+                        "innerBlocks": []
+                    }
+                ]
+            },
+            {
+                "name": "core/template-part",
+                "attributes": { "slug": "footer", "theme": "artisanpack-base" },
+                "innerBlocks": []
+            }
+        ]
+    },
+    "status": "publish",
+    "theme": "artisanpack-base",
+    "type": "wp_template",
+    "source": "theme",
+    "origin": "theme"
+}

--- a/tests/Fixtures/sample-content/templates/single.json
+++ b/tests/Fixtures/sample-content/templates/single.json
@@ -1,0 +1,50 @@
+{
+    "id": 1,
+    "slug": "single",
+    "title": { "rendered": "Single Post" },
+    "description": "Fallback template used for individual posts.",
+    "content": {
+        "raw": "<!-- wp:template-part {\"slug\":\"header\",\"theme\":\"artisanpack-base\"} /--><!-- wp:group {\"tagName\":\"main\",\"layout\":{\"type\":\"constrained\"}} --><main class=\"wp-block-group\"><!-- wp:post-title {\"level\":1} /--><!-- wp:post-featured-image /--><!-- wp:post-content /--></main><!-- /wp:group --><!-- wp:template-part {\"slug\":\"footer\",\"theme\":\"artisanpack-base\"} /-->",
+        "blocks": [
+            {
+                "name": "core/template-part",
+                "attributes": { "slug": "header", "theme": "artisanpack-base" },
+                "innerBlocks": []
+            },
+            {
+                "name": "core/group",
+                "attributes": {
+                    "tagName": "main",
+                    "layout": { "type": "constrained" }
+                },
+                "innerBlocks": [
+                    {
+                        "name": "core/post-title",
+                        "attributes": { "level": 1 },
+                        "innerBlocks": []
+                    },
+                    {
+                        "name": "core/post-featured-image",
+                        "attributes": {},
+                        "innerBlocks": []
+                    },
+                    {
+                        "name": "core/post-content",
+                        "attributes": {},
+                        "innerBlocks": []
+                    }
+                ]
+            },
+            {
+                "name": "core/template-part",
+                "attributes": { "slug": "footer", "theme": "artisanpack-base" },
+                "innerBlocks": []
+            }
+        ]
+    },
+    "status": "publish",
+    "theme": "artisanpack-base",
+    "type": "wp_template",
+    "source": "theme",
+    "origin": "theme"
+}


### PR DESCRIPTION
## Description

Adds fixture JSON for every entity the B1 core-data shim registers (templates, template parts, navigation menus, patterns, global styles) along with a `visual-editor:seed-sample-content` Artisan command that loads them onto a storage disk. This gives Phase C/D work something concrete to render against without each contributor hand-authoring JSON into the database.

**Closes:** #354

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #354

## Motivation and Context

The B1 core-data shim (#353) landed the client-side surface and endpoint contract for the five site-editor entity kinds, but the backend tables don't exist yet (Phase C). Without fixtures, the first contributor to open the site editor either sees an empty canvas or has to hand-author `wp_template`/`wp_navigation`/etc. payloads. B2 pays that cost once, in fixtures that match the shim contract byte-for-byte.

## Changes Made

- `tests/Fixtures/sample-content/` — canonical fixtures: 4 templates (single, page, index, 404) that reference shared header + footer template parts; 3 template parts; 3 navigation records including one with a `core/navigation-submenu`; 1 synced + 2 unsynced patterns; 1 theme.json-shaped global-styles singleton.
- `src/SampleContent/SampleContentRepository.php` — reads fixtures, validates primary keys, writes to `visual-editor/sample-content/{kind}/{name}/{id}.json` on the configured disk. Entity directories are reset on each run so stale records don't linger.
- `src/Console/Commands/SeedSampleContentCommand.php` — `visual-editor:seed-sample-content` with `--path=` and `--disk=` options, plus a config key `artisanpack.visual-editor.sample_content.fixtures_path` for persistent overrides.
- `docs/dev-setup.md` — covers how to run the seeder, what lands on disk, and how to point at a custom fixtures directory.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (darwin 25.3.0)
- PHP Version: 8.4.3
- Project Version: 1.0.0

**Tests Performed:**
1. `./vendor/bin/pest --compact` — 183 PHP tests passing (7 new).
2. `npx vitest run` — 546 JS tests passing (7 new).
3. Manual run of `php artisan visual-editor:seed-sample-content` in the dev app confirms idempotent writes to `storage/app/private/visual-editor/sample-content/`.

## Accessibility Tests Run

- [x] N/A — backend-only change, no UI surface.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:**

- `tests/Feature/VisualEditor/SeedSampleContentCommandTest.php` (7 tests) — exercises the full command: seeds every B1 entity from the packaged fixtures, covers acceptance-criteria counts/shape, idempotency across repeated runs, pruning of removed fixtures, `--path` override, missing-directory error, and rejection of fixtures without a primary key.
- `resources/js/visual-editor/vendor/__tests__/sample-content-fixtures.test.ts` (7 tests) — pipes every fixture through `configureCoreDataShim` + `fetchEntityRecord` → asserts `getEntityRecord` returns matching data, so JSON-shape drift is caught in CI.

## Documentation

- [x] Inline code documentation added
- [x] New `docs/dev-setup.md` describes the seeder

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Code passes all tests (183 PHP / 546 JS)
- [x] CodeRabbit CLI review clean against `release/1.0`
- [x] Code follows project style guide
- [x] Self-review completed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New Artisan command to seed visual-editor sample content (supports --path and --disk), configurable default fixtures path, and registered for console use.

* **Documentation**
  * Developer setup guide explaining the seeding workflow, CLI options, output layout, idempotency/pruning behavior, and canonical fixtures location.

* **Tests**
  * End-to-end tests and comprehensive sample-content fixtures covering templates, template parts, navigation, patterns, block post types, and global styles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->