### PR TITLE
feat: C1 · Templates model, migration, API, fallback chain

### DIFF
--- a/database/migrations/2026_04_23_000000_create_visual_editor_templates_table.php
+++ b/database/migrations/2026_04_23_000000_create_visual_editor_templates_table.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * Create visual_editor_templates table migration.
+ *
+ * Storage for the `wp_template` entity the B1 core-data shim addresses at
+ * `/visual-editor/api/templates`. Holds the Gutenberg block tree along with
+ * the raw serialized payload and the template-hierarchy metadata
+ * (`slug`, `theme`, `source`, `origin`) the fallback resolver walks over.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+	public function up(): void
+	{
+		Schema::create( 'visual_editor_templates', function ( Blueprint $table ) {
+			$table->id();
+			$table->string( 'slug' );
+			$table->string( 'title' )->default( '' );
+			$table->text( 'description' )->nullable();
+			// The API envelope { raw, blocks } is stored verbatim; an empty
+			// template is `{ "raw": "", "blocks": [] }` so the column is
+			// never null once hydrated through the model.
+			$table->json( 'content' )->nullable();
+			$table->string( 'status' )->default( 'publish' )->index();
+			$table->string( 'theme' );
+			$table->string( 'source' )->default( 'custom' );
+			$table->string( 'origin' )->nullable();
+			$table->timestamps();
+
+			// `slug` is only unique within a theme — the same `single` slug
+			// can legitimately exist on two themes installed side by side.
+			$table->unique( [ 'slug', 'theme' ] );
+		} );
+	}
+
+	public function down(): void
+	{
+		Schema::dropIfExists( 'visual_editor_templates' );
+	}
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -19,6 +19,7 @@ declare( strict_types=1 );
 
 use ArtisanPackUI\VisualEditor\Http\Controllers\BlockPreviewController;
 use ArtisanPackUI\VisualEditor\Http\Controllers\ResourceContentController;
+use ArtisanPackUI\VisualEditor\Http\Controllers\TemplateController;
 use ArtisanPackUI\VisualEditor\Http\Controllers\VisualEditorBlocksController;
 use ArtisanPackUI\VisualEditor\Http\Controllers\VisualEditorPostsController;
 use Illuminate\Support\Facades\Route;
@@ -38,6 +39,22 @@ Route::post( 'blocks/preview', [ BlockPreviewController::class, 'preview' ] )
 
 Route::get( 'blocks', [ VisualEditorBlocksController::class, 'index' ] )
 	->name( 'visual-editor.api.blocks.index' );
+
+// C1 `wp_template` REST surface — see docs/core-data-shim.md §Templates.
+Route::get( 'templates', [ TemplateController::class, 'index' ] )
+	->name( 'visual-editor.api.templates.index' );
+
+Route::post( 'templates', [ TemplateController::class, 'store' ] )
+	->name( 'visual-editor.api.templates.store' );
+
+Route::get( 'templates/{template}', [ TemplateController::class, 'show' ] )
+	->name( 'visual-editor.api.templates.show' );
+
+Route::put( 'templates/{template}', [ TemplateController::class, 'update' ] )
+	->name( 'visual-editor.api.templates.update' );
+
+Route::delete( 'templates/{template}', [ TemplateController::class, 'destroy' ] )
+	->name( 'visual-editor.api.templates.destroy' );
 
 // Legacy ve_contents routes retained for the existing editor tests and the
 // `VisualEditorPost` model. Deprecated in M3 in favor of the resource routes

--- a/src/Http/Controllers/TemplateController.php
+++ b/src/Http/Controllers/TemplateController.php
@@ -174,8 +174,9 @@ class TemplateController extends Controller
 
 	/**
 	 * Normalizes the inbound content payload into the `{ raw, blocks }`
-	 * envelope the model expects. Accepts an envelope, a bare blocks
-	 * array, or null.
+	 * envelope the model expects. Form-request validation guarantees
+	 * the shape before we get here; this method just guards against
+	 * missing keys and bad types as a belt-and-braces fallback.
 	 *
 	 * @since 1.0.0
 	 *
@@ -187,10 +188,6 @@ class TemplateController extends Controller
 	{
 		if ( ! is_array( $content ) ) {
 			return [ 'raw' => '', 'blocks' => [] ];
-		}
-
-		if ( array_is_list( $content ) ) {
-			return [ 'raw' => '', 'blocks' => $content ];
 		}
 
 		return [

--- a/src/Http/Controllers/TemplateController.php
+++ b/src/Http/Controllers/TemplateController.php
@@ -1,0 +1,201 @@
+<?php
+
+/**
+ * Template controller.
+ *
+ * Serves the REST surface for the `wp_template` entity behind the B1
+ * core-data shim (see `docs/core-data-shim.md` §Templates). The five
+ * endpoints — index, show, store, update, destroy — mount under
+ * `/visual-editor/api/templates` via the package's auth-gated API
+ * group and return responses shaped by {@see TemplateResource}.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Http\Controllers;
+
+use ArtisanPackUI\VisualEditor\Http\Requests\StoreTemplateRequest;
+use ArtisanPackUI\VisualEditor\Http\Requests\UpdateTemplateRequest;
+use ArtisanPackUI\VisualEditor\Http\Resources\TemplateResource;
+use ArtisanPackUI\VisualEditor\Models\VisualEditorTemplate;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Illuminate\Http\Response;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Gate;
+
+class TemplateController extends Controller
+{
+	/**
+	 * Maximum per-page size for the index endpoint. Keeps a malicious or
+	 * accidental `?per_page=999999` query from dragging the site-editor
+	 * sidebar down while still letting the host page through explicit
+	 * requests when necessary.
+	 */
+	protected const MAX_PER_PAGE = 100;
+
+	/**
+	 * Lists templates with a paginated `{ data, meta }` envelope.
+	 *
+	 * The shim reads `meta.total` and `meta.last_page` for the selectors
+	 * `getEntityRecordsTotalItems` / `getEntityRecordsTotalPages`; the
+	 * default Laravel `Resource::collection( $paginator )` response
+	 * already emits those keys, so no custom envelope is necessary.
+	 *
+	 * @since 1.0.0
+	 */
+	public function index( Request $request ): AnonymousResourceCollection
+	{
+		Gate::authorize( 'viewAny', VisualEditorTemplate::class );
+
+		$perPage = (int) $request->integer( 'per_page', 25 );
+
+		if ( $perPage < 1 ) {
+			$perPage = 25;
+		}
+
+		if ( $perPage > self::MAX_PER_PAGE ) {
+			$perPage = self::MAX_PER_PAGE;
+		}
+
+		$query = VisualEditorTemplate::query()->orderBy( 'id' );
+
+		$theme = $request->string( 'theme' )->toString();
+		if ( '' !== $theme ) {
+			$query->where( 'theme', $theme );
+		}
+
+		$slug = $request->string( 'slug' )->toString();
+		if ( '' !== $slug ) {
+			$query->where( 'slug', $slug );
+		}
+
+		$status = $request->string( 'status' )->toString();
+		if ( '' !== $status ) {
+			$query->where( 'status', $status );
+		}
+
+		return TemplateResource::collection( $query->paginate( $perPage ) );
+	}
+
+	/**
+	 * Returns a single template.
+	 *
+	 * The shim expects the record at the top level (not wrapped in `data`)
+	 * so `fetchEntityRecord` can dispatch it straight into the cache.
+	 *
+	 * @since 1.0.0
+	 */
+	public function show( Request $request, VisualEditorTemplate $template ): JsonResponse
+	{
+		Gate::authorize( 'view', $template );
+
+		return response()->json( ( new TemplateResource( $template ) )->toArray( $request ) );
+	}
+
+	/**
+	 * Creates a new template.
+	 *
+	 * @since 1.0.0
+	 */
+	public function store( StoreTemplateRequest $request ): JsonResponse
+	{
+		Gate::authorize( 'create', VisualEditorTemplate::class );
+
+		$data = $request->validated();
+
+		$template = new VisualEditorTemplate();
+		$template->fill( [
+			'slug'        => $data['slug'],
+			'title'       => $data['title'] ?? '',
+			'description' => $data['description'] ?? null,
+			'status'      => $data['status'] ?? VisualEditorTemplate::STATUS_PUBLISH,
+			'theme'       => $data['theme'],
+			'source'      => $data['source'] ?? VisualEditorTemplate::SOURCE_CUSTOM,
+			'origin'      => $data['origin'] ?? null,
+		] );
+
+		$template->setContentEnvelope( $this->normalizeContentEnvelope( $data['content'] ?? null ) );
+		$template->save();
+
+		return response()->json(
+			( new TemplateResource( $template ) )->toArray( $request ),
+			Response::HTTP_CREATED
+		);
+	}
+
+	/**
+	 * Updates an existing template.
+	 *
+	 * @since 1.0.0
+	 */
+	public function update( UpdateTemplateRequest $request, VisualEditorTemplate $template ): JsonResponse
+	{
+		Gate::authorize( 'update', $template );
+
+		$data = $request->validated();
+
+		foreach ( [ 'slug', 'title', 'description', 'status', 'theme', 'source', 'origin' ] as $field ) {
+			if ( array_key_exists( $field, $data ) ) {
+				$template->{$field} = $data[ $field ];
+			}
+		}
+
+		if ( array_key_exists( 'content', $data ) ) {
+			$template->setContentEnvelope( $this->normalizeContentEnvelope( $data['content'] ) );
+		}
+
+		$template->save();
+
+		return response()->json( ( new TemplateResource( $template ) )->toArray( $request ) );
+	}
+
+	/**
+	 * Deletes a template.
+	 *
+	 * @since 1.0.0
+	 */
+	public function destroy( VisualEditorTemplate $template ): JsonResponse
+	{
+		Gate::authorize( 'delete', $template );
+
+		$template->delete();
+
+		return response()->json( null, Response::HTTP_NO_CONTENT );
+	}
+
+	/**
+	 * Normalizes the inbound content payload into the `{ raw, blocks }`
+	 * envelope the model expects. Accepts an envelope, a bare blocks
+	 * array, or null.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  mixed  $content
+	 *
+	 * @return array{raw: string, blocks: array<int, array<string, mixed>>}
+	 */
+	protected function normalizeContentEnvelope( mixed $content ): array
+	{
+		if ( ! is_array( $content ) ) {
+			return [ 'raw' => '', 'blocks' => [] ];
+		}
+
+		if ( array_is_list( $content ) ) {
+			return [ 'raw' => '', 'blocks' => $content ];
+		}
+
+		return [
+			'raw'    => isset( $content['raw'] ) && is_string( $content['raw'] ) ? $content['raw'] : '',
+			'blocks' => isset( $content['blocks'] ) && is_array( $content['blocks'] ) ? array_values( $content['blocks'] ) : [],
+		];
+	}
+}

--- a/src/Http/Requests/StoreTemplateRequest.php
+++ b/src/Http/Requests/StoreTemplateRequest.php
@@ -20,6 +20,7 @@ namespace ArtisanPackUI\VisualEditor\Http\Requests;
 
 use ArtisanPackUI\VisualEditor\Models\VisualEditorTemplate;
 use ArtisanPackUI\VisualEditor\Rules\TemplateBlockTreeRule;
+use Closure;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
@@ -43,13 +44,19 @@ class StoreTemplateRequest extends FormRequest
 				Rule::unique( 'visual_editor_templates', 'slug' )
 					->where( fn ( $query ) => $query->where( 'theme', $this->input( 'theme' ) ) ),
 			],
-			'title'          => [ 'nullable', 'string', 'max:255' ],
+			// `title`, `status`, and `source` are backed by non-nullable
+			// DB columns (defaults: '', 'publish', 'custom'). The store
+			// controller falls back to those defaults when the field is
+			// missing, but `null` is never a legal value — rejecting it
+			// here keeps the DB from rejecting the write later with an
+			// opaque QueryException.
+			'title'          => [ 'sometimes', 'string', 'max:255' ],
 			'description'    => [ 'nullable', 'string' ],
-			'content'        => [ 'nullable', 'array' ],
+			'content'        => [ 'nullable', 'array', $this->envelopeShapeRule() ],
 			'content.raw'    => [ 'nullable', 'string' ],
 			'content.blocks' => [ 'nullable', 'array', new TemplateBlockTreeRule() ],
 			'status'         => [
-				'nullable',
+				'sometimes',
 				'string',
 				Rule::in( [
 					VisualEditorTemplate::STATUS_PUBLISH,
@@ -59,7 +66,7 @@ class StoreTemplateRequest extends FormRequest
 			],
 			'theme'          => [ 'required', 'string', 'max:191' ],
 			'source'         => [
-				'nullable',
+				'sometimes',
 				'string',
 				Rule::in( [
 					VisualEditorTemplate::SOURCE_THEME,
@@ -76,5 +83,23 @@ class StoreTemplateRequest extends FormRequest
 				] ),
 			],
 		];
+	}
+
+	/**
+	 * Rejects a bare-list `content` payload.
+	 *
+	 * `content.blocks` is only validated when the request uses the
+	 * `{ raw, blocks }` envelope; without this rule a caller could send
+	 * `content: [ <blocks> ]` to skip `TemplateBlockTreeRule` entirely.
+	 *
+	 * @since 1.0.0
+	 */
+	protected function envelopeShapeRule(): Closure
+	{
+		return function ( string $attribute, mixed $value, Closure $fail ): void {
+			if ( is_array( $value ) && [] !== $value && array_is_list( $value ) ) {
+				$fail( 'The :attribute must be a { raw, blocks } envelope, not a bare list of blocks.' );
+			}
+		};
 	}
 }

--- a/src/Http/Requests/StoreTemplateRequest.php
+++ b/src/Http/Requests/StoreTemplateRequest.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * StoreTemplate form request.
+ *
+ * Validates the payload for creating a `wp_template` record via
+ * `POST /visual-editor/api/templates`.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Http\Requests;
+
+use ArtisanPackUI\VisualEditor\Models\VisualEditorTemplate;
+use ArtisanPackUI\VisualEditor\Rules\TemplateBlockTreeRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StoreTemplateRequest extends FormRequest
+{
+	public function authorize(): bool
+	{
+		return true;
+	}
+
+	/**
+	 * @return array<string, array<int, mixed>>
+	 */
+	public function rules(): array
+	{
+		return [
+			'slug'           => [
+				'required',
+				'string',
+				'max:191',
+				Rule::unique( 'visual_editor_templates', 'slug' )
+					->where( fn ( $query ) => $query->where( 'theme', $this->input( 'theme' ) ) ),
+			],
+			'title'          => [ 'nullable', 'string', 'max:255' ],
+			'description'    => [ 'nullable', 'string' ],
+			'content'        => [ 'nullable', 'array' ],
+			'content.raw'    => [ 'nullable', 'string' ],
+			'content.blocks' => [ 'nullable', 'array', new TemplateBlockTreeRule() ],
+			'status'         => [
+				'nullable',
+				'string',
+				Rule::in( [
+					VisualEditorTemplate::STATUS_PUBLISH,
+					VisualEditorTemplate::STATUS_DRAFT,
+					VisualEditorTemplate::STATUS_PRIVATE,
+				] ),
+			],
+			'theme'          => [ 'required', 'string', 'max:191' ],
+			'source'         => [
+				'nullable',
+				'string',
+				Rule::in( [
+					VisualEditorTemplate::SOURCE_THEME,
+					VisualEditorTemplate::SOURCE_CUSTOM,
+				] ),
+			],
+			'origin'         => [
+				'nullable',
+				'string',
+				Rule::in( [
+					VisualEditorTemplate::ORIGIN_THEME,
+					VisualEditorTemplate::ORIGIN_PLUGIN,
+					VisualEditorTemplate::ORIGIN_CUSTOM,
+				] ),
+			],
+		];
+	}
+}

--- a/src/Http/Requests/UpdateTemplateRequest.php
+++ b/src/Http/Requests/UpdateTemplateRequest.php
@@ -20,6 +20,7 @@ namespace ArtisanPackUI\VisualEditor\Http\Requests;
 
 use ArtisanPackUI\VisualEditor\Models\VisualEditorTemplate;
 use ArtisanPackUI\VisualEditor\Rules\TemplateBlockTreeRule;
+use Closure;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
@@ -38,24 +39,43 @@ class UpdateTemplateRequest extends FormRequest
 		/** @var VisualEditorTemplate $template */
 		$template = $this->route( 'template' );
 
+		$resolvedSlug  = $this->input( 'slug', $template->slug );
+		$resolvedTheme = $this->input( 'theme', $template->theme );
+
+		// Composite-uniqueness is mirrored on both slug and theme so a
+		// PUT that changes *either* field triggers the check. Without
+		// the theme-side mirror, `{ "theme": "other" }` (no slug) would
+		// slip past the `sometimes`-gated slug rule and rely on the DB
+		// constraint to reject the collision as an opaque
+		// QueryException.
+		$uniqueness = Rule::unique( 'visual_editor_templates', 'slug' )
+			->ignore( $template->getKey() )
+			->where( fn ( $query ) => $query->where( 'theme', $resolvedTheme ) );
+
+		$themeUniqueness = Rule::unique( 'visual_editor_templates', 'theme' )
+			->ignore( $template->getKey() )
+			->where( fn ( $query ) => $query->where( 'slug', $resolvedSlug ) );
+
 		return [
 			'slug'            => [
 				'sometimes',
 				'required',
 				'string',
 				'max:191',
-				Rule::unique( 'visual_editor_templates', 'slug' )
-					->ignore( $template->getKey() )
-					->where( fn ( $query ) => $query->where( 'theme', $this->input( 'theme', $template->theme ) ) ),
+				$uniqueness,
 			],
-			'title'           => [ 'sometimes', 'nullable', 'string', 'max:255' ],
+			// `title`, `status`, and `source` back non-nullable DB
+			// columns — null is never a legal value. The update
+			// controller leaves missing fields untouched, so dropping
+			// `nullable` here only tightens the error path without
+			// changing what a partial update can do.
+			'title'           => [ 'sometimes', 'string', 'max:255' ],
 			'description'     => [ 'sometimes', 'nullable', 'string' ],
-			'content'         => [ 'sometimes', 'nullable', 'array' ],
+			'content'         => [ 'sometimes', 'nullable', 'array', $this->envelopeShapeRule() ],
 			'content.raw'     => [ 'sometimes', 'nullable', 'string' ],
 			'content.blocks'  => [ 'sometimes', 'nullable', 'array', new TemplateBlockTreeRule() ],
 			'status'          => [
 				'sometimes',
-				'nullable',
 				'string',
 				Rule::in( [
 					VisualEditorTemplate::STATUS_PUBLISH,
@@ -63,10 +83,15 @@ class UpdateTemplateRequest extends FormRequest
 					VisualEditorTemplate::STATUS_PRIVATE,
 				] ),
 			],
-			'theme'           => [ 'sometimes', 'required', 'string', 'max:191' ],
+			'theme'           => [
+				'sometimes',
+				'required',
+				'string',
+				'max:191',
+				$themeUniqueness,
+			],
 			'source'          => [
 				'sometimes',
-				'nullable',
 				'string',
 				Rule::in( [
 					VisualEditorTemplate::SOURCE_THEME,
@@ -84,5 +109,20 @@ class UpdateTemplateRequest extends FormRequest
 				] ),
 			],
 		];
+	}
+
+	/**
+	 * Rejects a bare-list `content` payload — see the mirrored method
+	 * on {@see StoreTemplateRequest::envelopeShapeRule()} for why.
+	 *
+	 * @since 1.0.0
+	 */
+	protected function envelopeShapeRule(): Closure
+	{
+		return function ( string $attribute, mixed $value, Closure $fail ): void {
+			if ( is_array( $value ) && [] !== $value && array_is_list( $value ) ) {
+				$fail( 'The :attribute must be a { raw, blocks } envelope, not a bare list of blocks.' );
+			}
+		};
 	}
 }

--- a/src/Http/Requests/UpdateTemplateRequest.php
+++ b/src/Http/Requests/UpdateTemplateRequest.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * UpdateTemplate form request.
+ *
+ * Validates the payload for updating a `wp_template` record via
+ * `PUT /visual-editor/api/templates/{id}`.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Http\Requests;
+
+use ArtisanPackUI\VisualEditor\Models\VisualEditorTemplate;
+use ArtisanPackUI\VisualEditor\Rules\TemplateBlockTreeRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateTemplateRequest extends FormRequest
+{
+	public function authorize(): bool
+	{
+		return true;
+	}
+
+	/**
+	 * @return array<string, array<int, mixed>>
+	 */
+	public function rules(): array
+	{
+		/** @var VisualEditorTemplate $template */
+		$template = $this->route( 'template' );
+
+		return [
+			'slug'            => [
+				'sometimes',
+				'required',
+				'string',
+				'max:191',
+				Rule::unique( 'visual_editor_templates', 'slug' )
+					->ignore( $template->getKey() )
+					->where( fn ( $query ) => $query->where( 'theme', $this->input( 'theme', $template->theme ) ) ),
+			],
+			'title'           => [ 'sometimes', 'nullable', 'string', 'max:255' ],
+			'description'     => [ 'sometimes', 'nullable', 'string' ],
+			'content'         => [ 'sometimes', 'nullable', 'array' ],
+			'content.raw'     => [ 'sometimes', 'nullable', 'string' ],
+			'content.blocks'  => [ 'sometimes', 'nullable', 'array', new TemplateBlockTreeRule() ],
+			'status'          => [
+				'sometimes',
+				'nullable',
+				'string',
+				Rule::in( [
+					VisualEditorTemplate::STATUS_PUBLISH,
+					VisualEditorTemplate::STATUS_DRAFT,
+					VisualEditorTemplate::STATUS_PRIVATE,
+				] ),
+			],
+			'theme'           => [ 'sometimes', 'required', 'string', 'max:191' ],
+			'source'          => [
+				'sometimes',
+				'nullable',
+				'string',
+				Rule::in( [
+					VisualEditorTemplate::SOURCE_THEME,
+					VisualEditorTemplate::SOURCE_CUSTOM,
+				] ),
+			],
+			'origin'          => [
+				'sometimes',
+				'nullable',
+				'string',
+				Rule::in( [
+					VisualEditorTemplate::ORIGIN_THEME,
+					VisualEditorTemplate::ORIGIN_PLUGIN,
+					VisualEditorTemplate::ORIGIN_CUSTOM,
+				] ),
+			],
+		];
+	}
+}

--- a/src/Http/Resources/TemplateResource.php
+++ b/src/Http/Resources/TemplateResource.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * TemplateResource API resource.
+ *
+ * Shapes a {@see VisualEditorTemplate} into the B1 core-data shim's
+ * `wp_template` record envelope. Keeps the HTTP response contract in
+ * one place so controllers and tests don't have to reconstruct the
+ * `title.rendered` and `content.{raw,blocks}` wrappers ad hoc.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Http\Resources;
+
+use ArtisanPackUI\VisualEditor\Models\VisualEditorTemplate;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @property VisualEditorTemplate $resource
+ */
+class TemplateResource extends JsonResource
+{
+	/**
+	 * Transforms the template into the shim-compatible record shape.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function toArray( Request $request ): array
+	{
+		/** @var VisualEditorTemplate $template */
+		$template = $this->resource;
+
+		$envelope = $template->getContentEnvelope();
+
+		return [
+			'id'          => $template->getKey(),
+			'slug'        => $template->slug,
+			'title'       => [
+				'rendered' => (string) ( $template->title ?? '' ),
+			],
+			'description' => (string) ( $template->description ?? '' ),
+			'content'     => [
+				'raw'    => $envelope['raw'],
+				'blocks' => $envelope['blocks'],
+			],
+			'status'      => $template->status,
+			'theme'       => $template->theme,
+			'type'        => 'wp_template',
+			'source'      => $template->source,
+			'origin'      => $template->origin,
+		];
+	}
+}

--- a/src/Models/VisualEditorTemplate.php
+++ b/src/Models/VisualEditorTemplate.php
@@ -1,0 +1,173 @@
+<?php
+
+/**
+ * VisualEditorTemplate model.
+ *
+ * Eloquent backing for the `wp_template` entity exposed at
+ * `/visual-editor/api/templates`. Stores the Gutenberg block tree inside
+ * the `{ raw, blocks }` envelope the B1 core-data shim expects, together
+ * with the template-hierarchy metadata (`slug`, `theme`, `source`,
+ * `origin`) the fallback resolver cascades through.
+ *
+ * The model intentionally does not use the `HasBlockContent` trait
+ * because templates hold the raw serialized payload alongside the parsed
+ * block tree; the trait assumes the block column is the block array
+ * itself. The per-block shape stored under `content.blocks` still
+ * matches every other block-tree surface in the package (`name`,
+ * `attributes`, `innerBlocks`), so block renderers can consume it
+ * without a translation step.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+class VisualEditorTemplate extends Model
+{
+	public const SOURCE_THEME  = 'theme';
+	public const SOURCE_CUSTOM = 'custom';
+
+	public const ORIGIN_THEME  = 'theme';
+	public const ORIGIN_PLUGIN = 'plugin';
+	public const ORIGIN_CUSTOM = 'custom';
+
+	public const STATUS_PUBLISH = 'publish';
+	public const STATUS_DRAFT   = 'draft';
+	public const STATUS_PRIVATE = 'private';
+
+	protected $table = 'visual_editor_templates';
+
+	/**
+	 * @var array<int, string>
+	 */
+	protected $fillable = [
+		'slug',
+		'title',
+		'description',
+		'content',
+		'status',
+		'theme',
+		'source',
+		'origin',
+	];
+
+	/**
+	 * @var array<string, string>
+	 */
+	protected $casts = [
+		'content' => 'array',
+	];
+
+	/**
+	 * Returns the canonical content envelope stored on the record.
+	 *
+	 * Always returns the `{ raw, blocks }` shape — callers never have to
+	 * null-check the raw column or the blocks key separately.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array{raw: string, blocks: array<int, array<string, mixed>>}
+	 */
+	public function getContentEnvelope(): array
+	{
+		$value = $this->getAttribute( 'content' );
+
+		$raw    = '';
+		$blocks = [];
+
+		if ( is_array( $value ) ) {
+			$raw    = isset( $value['raw'] ) && is_string( $value['raw'] ) ? $value['raw'] : '';
+			$blocks = isset( $value['blocks'] ) && is_array( $value['blocks'] ) ? array_values( $value['blocks'] ) : [];
+		}
+
+		return [
+			'raw'    => $raw,
+			'blocks' => $blocks,
+		];
+	}
+
+	/**
+	 * Returns just the parsed block tree.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	public function getBlocks(): array
+	{
+		return $this->getContentEnvelope()['blocks'];
+	}
+
+	/**
+	 * Returns just the raw Gutenberg serialization.
+	 *
+	 * @since 1.0.0
+	 */
+	public function getRawContent(): string
+	{
+		return $this->getContentEnvelope()['raw'];
+	}
+
+	/**
+	 * Persists an updated content envelope on the record.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array{raw?: string, blocks?: array<int, array<string, mixed>>}  $envelope
+	 */
+	public function setContentEnvelope( array $envelope ): void
+	{
+		$raw    = isset( $envelope['raw'] ) && is_string( $envelope['raw'] ) ? $envelope['raw'] : '';
+		$blocks = isset( $envelope['blocks'] ) && is_array( $envelope['blocks'] ) ? array_values( $envelope['blocks'] ) : [];
+
+		$this->setAttribute( 'content', [
+			'raw'    => $raw,
+			'blocks' => $blocks,
+		] );
+	}
+
+	/**
+	 * Scopes the query to templates published for a theme.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  Builder<VisualEditorTemplate>  $query
+	 *
+	 * @return Builder<VisualEditorTemplate>
+	 */
+	public function scopeForTheme( Builder $query, string $theme ): Builder
+	{
+		return $query->where( 'theme', $theme );
+	}
+
+	/**
+	 * Scopes the query to templates matching a slug (optionally constrained
+	 * to a theme).
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  Builder<VisualEditorTemplate>  $query
+	 *
+	 * @return Builder<VisualEditorTemplate>
+	 */
+	public function scopeForSlug( Builder $query, string $slug, ?string $theme = null ): Builder
+	{
+		$query->where( 'slug', $slug );
+
+		if ( null !== $theme && '' !== $theme ) {
+			$query->where( 'theme', $theme );
+		}
+
+		return $query;
+	}
+}

--- a/src/Policies/VisualEditorTemplatePolicy.php
+++ b/src/Policies/VisualEditorTemplatePolicy.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * VisualEditorTemplate policy.
+ *
+ * Authorization policy for the `wp_template` REST endpoints. The V1
+ * default allows any authenticated user to read and mutate templates,
+ * mirroring how the existing `VisualEditorPostPolicy` handles the
+ * post-editor entity; host apps that need tighter access should swap
+ * the binding in their own service provider.
+ *
+ * Templates have no "owner" — they're theme or site-level records, not
+ * per-user content — so the `restrict_by_owner` config flag that
+ * governs posts doesn't apply here.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Policies;
+
+use ArtisanPackUI\VisualEditor\Models\VisualEditorTemplate;
+use Illuminate\Auth\Access\HandlesAuthorization;
+use Illuminate\Contracts\Auth\Authenticatable;
+
+class VisualEditorTemplatePolicy
+{
+	use HandlesAuthorization;
+
+	public function viewAny( ?Authenticatable $user ): bool
+	{
+		return null !== $user;
+	}
+
+	public function view( ?Authenticatable $user, VisualEditorTemplate $template ): bool
+	{
+		return null !== $user;
+	}
+
+	public function create( ?Authenticatable $user ): bool
+	{
+		return null !== $user;
+	}
+
+	public function update( ?Authenticatable $user, VisualEditorTemplate $template ): bool
+	{
+		return null !== $user;
+	}
+
+	public function delete( ?Authenticatable $user, VisualEditorTemplate $template ): bool
+	{
+		return null !== $user;
+	}
+}

--- a/src/Resources/TemplateResolver.php
+++ b/src/Resources/TemplateResolver.php
@@ -1,0 +1,106 @@
+<?php
+
+/**
+ * TemplateResolver service.
+ *
+ * Walks the WordPress-style template hierarchy (`single-{slug}` →
+ * `single` → `index`, `page-{slug}` → `page` → `index`, or an exact
+ * slug match → `index`) and returns the first `VisualEditorTemplate`
+ * record that matches. Callers treat a null result as the explicit
+ * "render the 404 template" signal — the resolver never returns the
+ * `404` record itself, because that's a rendering concern owned by the
+ * front-end renderer (E2) and the site-editor preview (D2).
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Resources;
+
+use ArtisanPackUI\VisualEditor\Models\VisualEditorTemplate;
+
+class TemplateResolver
+{
+	/**
+	 * Resolves the most specific template for a given slug, walking the
+	 * hierarchy fallback chain until a record matches.
+	 *
+	 * Example cascades:
+	 *
+	 *   forSlug( 'single-post' ) → single-post → single → index → null
+	 *   forSlug( 'single' )      → single → index → null
+	 *   forSlug( 'page-about' )  → page-about → page → index → null
+	 *   forSlug( 'page' )        → page → index → null
+	 *   forSlug( 'archive' )     → archive → index → null
+	 *   forSlug( 'index' )       → index → null
+	 *
+	 * Returning null at the end of the chain leaves `404` as the caller's
+	 * explicit fallback — see the service-level doc block for why.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string  $slug   The most-specific template slug to try first.
+	 * @param  ?string $theme  Optional theme scope; when null, the query
+	 *                         matches across themes (useful for host apps
+	 *                         that only install one theme at a time).
+	 */
+	public function forSlug( string $slug, ?string $theme = null ): ?VisualEditorTemplate
+	{
+		foreach ( $this->fallbackChain( $slug ) as $candidate ) {
+			$record = $this->findBySlug( $candidate, $theme );
+
+			if ( null !== $record ) {
+				return $record;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the ordered chain of slugs the resolver walks for a given
+	 * input slug — exposed so downstream code (renderer, diagnostics) can
+	 * introspect the hierarchy without re-running the query.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<int, string>
+	 */
+	public function fallbackChain( string $slug ): array
+	{
+		$chain = [ $slug ];
+
+		// Specific `single-*` and `page-*` slugs fall back to the bare
+		// `single` and `page` templates respectively. Other specific
+		// slugs (`archive-*`, `author-*`, …) fall straight to `index`.
+		if ( 'single' !== $slug && str_starts_with( $slug, 'single-' ) ) {
+			$chain[] = 'single';
+		} elseif ( 'page' !== $slug && str_starts_with( $slug, 'page-' ) ) {
+			$chain[] = 'page';
+		}
+
+		if ( 'index' !== $slug ) {
+			$chain[] = 'index';
+		}
+
+		return $chain;
+	}
+
+	/**
+	 * Performs a single slug lookup, optionally scoped to a theme.
+	 *
+	 * @since 1.0.0
+	 */
+	protected function findBySlug( string $slug, ?string $theme ): ?VisualEditorTemplate
+	{
+		return VisualEditorTemplate::query()
+			->forSlug( $slug, $theme )
+			->first();
+	}
+}

--- a/src/Rules/TemplateBlockTreeRule.php
+++ b/src/Rules/TemplateBlockTreeRule.php
@@ -1,0 +1,121 @@
+<?php
+
+/**
+ * TemplateBlockTree validation rule.
+ *
+ * Validates the parsed block tree stored on a `wp_template` record. The
+ * shape matches the post-editor's block tree — `{ name, attributes,
+ * innerBlocks }` — but without the editor-only `clientId` requirement,
+ * because theme-shipped templates are authored as flat JSON fixtures
+ * that don't carry ephemeral editor ids.
+ *
+ * Shares the depth / node bounds with {@see BlockTreeRule} so any tree
+ * that round-trips through the template endpoint can also round-trip
+ * through the post endpoint once a `clientId` is assigned.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Rules;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+
+class TemplateBlockTreeRule implements ValidationRule
+{
+	public const MAX_DEPTH = BlockTreeRule::MAX_DEPTH;
+
+	public const MAX_NODES = BlockTreeRule::MAX_NODES;
+
+	public function validate( string $attribute, mixed $value, Closure $fail ): void
+	{
+		if ( ! is_array( $value ) ) {
+			$fail( 'The :attribute must be an array of blocks.' );
+			return;
+		}
+
+		$nodeCount = 0;
+
+		$error = $this->validateBlocks( $value, $attribute, 0, $nodeCount );
+
+		if ( null !== $error ) {
+			$fail( $error );
+		}
+	}
+
+	/**
+	 * Recursively validates the block tree, returning the first error
+	 * path encountered or null when the tree is valid.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array<int, mixed>  $blocks
+	 */
+	protected function validateBlocks(
+		array $blocks,
+		string $path,
+		int $currentDepth,
+		int &$nodeCount
+	): ?string {
+		if ( $currentDepth >= self::MAX_DEPTH ) {
+			return sprintf(
+				'The %s exceeds the maximum block tree depth of %d.',
+				$path,
+				self::MAX_DEPTH
+			);
+		}
+
+		if ( ! array_is_list( $blocks ) ) {
+			return "The {$path} must be a list of blocks.";
+		}
+
+		foreach ( $blocks as $index => $block ) {
+			$blockPath = "{$path}.{$index}";
+
+			$nodeCount++;
+
+			if ( $nodeCount > self::MAX_NODES ) {
+				return sprintf(
+					'The block tree exceeds the maximum of %d nodes.',
+					self::MAX_NODES
+				);
+			}
+
+			if ( ! is_array( $block ) ) {
+				return "The {$blockPath} must be a block object.";
+			}
+
+			if ( ! isset( $block['name'] ) || ! is_string( $block['name'] ) || '' === $block['name'] ) {
+				return "The {$blockPath}.name is required and must be a string.";
+			}
+
+			if ( ! array_key_exists( 'attributes', $block ) || ! is_array( $block['attributes'] ) ) {
+				return "The {$blockPath}.attributes is required and must be an object.";
+			}
+
+			if ( ! array_key_exists( 'innerBlocks', $block ) || ! is_array( $block['innerBlocks'] ) ) {
+				return "The {$blockPath}.innerBlocks is required and must be an array.";
+			}
+
+			$childError = $this->validateBlocks(
+				$block['innerBlocks'],
+				"{$blockPath}.innerBlocks",
+				$currentDepth + 1,
+				$nodeCount
+			);
+
+			if ( null !== $childError ) {
+				return $childError;
+			}
+		}
+
+		return null;
+	}
+}

--- a/src/VisualEditorServiceProvider.php
+++ b/src/VisualEditorServiceProvider.php
@@ -5,7 +5,9 @@ namespace ArtisanPackUI\VisualEditor;
 use ArtisanPackUI\VisualEditor\Console\Commands\SeedSampleContentCommand;
 use ArtisanPackUI\VisualEditor\MediaBridge\GutenbergAttachmentAdapter;
 use ArtisanPackUI\VisualEditor\Models\VisualEditorPost;
+use ArtisanPackUI\VisualEditor\Models\VisualEditorTemplate;
 use ArtisanPackUI\VisualEditor\Policies\VisualEditorPostPolicy;
+use ArtisanPackUI\VisualEditor\Policies\VisualEditorTemplatePolicy;
 use ArtisanPackUI\VisualEditor\Registries\BlockTypeRegistry;
 use ArtisanPackUI\VisualEditor\Registries\DynamicBlockRegistry;
 use ArtisanPackUI\VisualEditor\Resources\ResourceResolver;
@@ -82,6 +84,7 @@ class VisualEditorServiceProvider extends ServiceProvider
 		$this->registerBladeComponents();
 
 		Gate::policy( VisualEditorPost::class, VisualEditorPostPolicy::class );
+		Gate::policy( VisualEditorTemplate::class, VisualEditorTemplatePolicy::class );
 
 		// 3. Register core blocks from their block.json manifests.
 		$this->registerCoreBlocks();

--- a/tests/Feature/VisualEditor/TemplateControllerTest.php
+++ b/tests/Feature/VisualEditor/TemplateControllerTest.php
@@ -1,0 +1,302 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Models\VisualEditorTemplate;
+use Tests\TestUser;
+
+function createTemplate( array $overrides = [] ): VisualEditorTemplate
+{
+	return VisualEditorTemplate::create( array_merge( [
+		'slug'        => 'single',
+		'title'       => 'Single',
+		'description' => 'Default single template.',
+		'content'     => [
+			'raw'    => '<!-- wp:post-content /-->',
+			'blocks' => [
+				[
+					'name'        => 'core/post-content',
+					'attributes'  => new stdClass(),
+					'innerBlocks' => [],
+				],
+			],
+		],
+		'status'      => 'publish',
+		'theme'       => 'artisanpack-base',
+		'source'      => 'theme',
+		'origin'      => 'theme',
+	], $overrides ) );
+}
+
+function actingAsTemplateUser(): TestUser
+{
+	$user = TestUser::create( [
+		'name'     => 'Template Tester',
+		'email'    => 'template+' . uniqid() . '@example.com',
+		'password' => bcrypt( 'secret' ),
+	] );
+
+	test()->actingAs( $user );
+
+	return $user;
+}
+
+it( 'returns 401 when unauthenticated on index', function () {
+	$this->getJson( '/visual-editor/api/templates' )->assertUnauthorized();
+} );
+
+it( 'returns an empty data/meta envelope when no templates exist', function () {
+	actingAsTemplateUser();
+
+	$this->getJson( '/visual-editor/api/templates' )
+		->assertOk()
+		->assertJsonPath( 'data', [] )
+		->assertJsonPath( 'meta.total', 0 )
+		->assertJsonPath( 'meta.last_page', 1 );
+} );
+
+it( 'lists templates in the data/meta envelope', function () {
+	actingAsTemplateUser();
+
+	createTemplate( [ 'slug' => 'index', 'title' => 'Index' ] );
+	createTemplate( [ 'slug' => 'single', 'title' => 'Single' ] );
+
+	$this->getJson( '/visual-editor/api/templates' )
+		->assertOk()
+		->assertJsonCount( 2, 'data' )
+		->assertJsonPath( 'meta.total', 2 )
+		->assertJsonPath( 'data.0.slug', 'index' )
+		->assertJsonPath( 'data.0.type', 'wp_template' )
+		->assertJsonPath( 'data.0.title.rendered', 'Index' )
+		->assertJsonPath( 'data.1.slug', 'single' );
+} );
+
+it( 'filters the index by slug and theme', function () {
+	actingAsTemplateUser();
+
+	createTemplate( [ 'slug' => 'index', 'theme' => 'theme-a' ] );
+	createTemplate( [ 'slug' => 'index', 'theme' => 'theme-b' ] );
+	createTemplate( [ 'slug' => 'single', 'theme' => 'theme-a' ] );
+
+	$this->getJson( '/visual-editor/api/templates?theme=theme-a' )
+		->assertOk()
+		->assertJsonCount( 2, 'data' );
+
+	$this->getJson( '/visual-editor/api/templates?slug=index&theme=theme-b' )
+		->assertOk()
+		->assertJsonCount( 1, 'data' )
+		->assertJsonPath( 'data.0.theme', 'theme-b' );
+} );
+
+it( 'returns 401 when unauthenticated on show', function () {
+	$template = createTemplate();
+
+	$this->getJson( "/visual-editor/api/templates/{$template->id}" )->assertUnauthorized();
+} );
+
+it( 'returns the content envelope and rendered title on show', function () {
+	actingAsTemplateUser();
+
+	$template = createTemplate();
+
+	$this->getJson( "/visual-editor/api/templates/{$template->id}" )
+		->assertOk()
+		->assertJsonPath( 'id', $template->id )
+		->assertJsonPath( 'slug', 'single' )
+		->assertJsonPath( 'type', 'wp_template' )
+		->assertJsonPath( 'title.rendered', 'Single' )
+		->assertJsonPath( 'content.raw', '<!-- wp:post-content /-->' )
+		->assertJsonPath( 'content.blocks.0.name', 'core/post-content' );
+} );
+
+it( 'returns 404 when the template id does not exist', function () {
+	actingAsTemplateUser();
+
+	$this->getJson( '/visual-editor/api/templates/999' )->assertNotFound();
+} );
+
+it( 'creates a template with a 201 Created response', function () {
+	actingAsTemplateUser();
+
+	$payload = [
+		'slug'        => 'page',
+		'title'       => 'Page',
+		'description' => 'Fallback page template.',
+		'content'     => [
+			'raw'    => '<!-- wp:post-title /-->',
+			'blocks' => [
+				[
+					'name'        => 'core/post-title',
+					'attributes'  => [ 'level' => 1 ],
+					'innerBlocks' => [],
+				],
+			],
+		],
+		'status'      => 'publish',
+		'theme'       => 'artisanpack-base',
+		'source'      => 'custom',
+		'origin'      => 'custom',
+	];
+
+	$this->postJson( '/visual-editor/api/templates', $payload )
+		->assertCreated()
+		->assertJsonPath( 'slug', 'page' )
+		->assertJsonPath( 'source', 'custom' )
+		->assertJsonPath( 'content.raw', '<!-- wp:post-title /-->' )
+		->assertJsonPath( 'content.blocks.0.name', 'core/post-title' );
+
+	expect( VisualEditorTemplate::where( 'slug', 'page' )->first() )
+		->not->toBeNull()
+		->getBlocks()->toEqual( [
+			[
+				'name'        => 'core/post-title',
+				'attributes'  => [ 'level' => 1 ],
+				'innerBlocks' => [],
+			],
+		] );
+} );
+
+it( 'rejects store when the (slug, theme) pair already exists', function () {
+	actingAsTemplateUser();
+
+	createTemplate( [ 'slug' => 'index', 'theme' => 'artisanpack-base' ] );
+
+	$this->postJson( '/visual-editor/api/templates', [
+		'slug'  => 'index',
+		'theme' => 'artisanpack-base',
+	] )
+		->assertUnprocessable()
+		->assertJsonValidationErrors( 'slug' );
+} );
+
+it( 'allows the same slug on different themes', function () {
+	actingAsTemplateUser();
+
+	createTemplate( [ 'slug' => 'index', 'theme' => 'theme-a' ] );
+
+	$this->postJson( '/visual-editor/api/templates', [
+		'slug'  => 'index',
+		'theme' => 'theme-b',
+		'title' => 'Index on Theme B',
+	] )->assertCreated();
+} );
+
+it( 'rejects store when the block tree is malformed', function () {
+	actingAsTemplateUser();
+
+	$this->postJson( '/visual-editor/api/templates', [
+		'slug'    => 'archive',
+		'theme'   => 'artisanpack-base',
+		'content' => [
+			'raw'    => '',
+			'blocks' => [
+				[ 'not-a-block' => true ],
+			],
+		],
+	] )
+		->assertUnprocessable()
+		->assertJsonValidationErrors( 'content.blocks' );
+} );
+
+it( 'updates a template with a partial payload', function () {
+	actingAsTemplateUser();
+
+	$template = createTemplate( [ 'title' => 'Before' ] );
+
+	$this->putJson( "/visual-editor/api/templates/{$template->id}", [
+		'title' => 'After',
+	] )
+		->assertOk()
+		->assertJsonPath( 'title.rendered', 'After' )
+		->assertJsonPath( 'slug', 'single' );
+
+	expect( $template->fresh()->title )->toBe( 'After' );
+} );
+
+it( 'persists a new content envelope on update', function () {
+	actingAsTemplateUser();
+
+	$template = createTemplate();
+
+	$newContent = [
+		'raw'    => '<!-- wp:heading --><h1>Hello</h1><!-- /wp:heading -->',
+		'blocks' => [
+			[
+				'name'        => 'core/heading',
+				'attributes'  => [ 'level' => 1, 'content' => 'Hello' ],
+				'innerBlocks' => [],
+			],
+		],
+	];
+
+	$this->putJson( "/visual-editor/api/templates/{$template->id}", [
+		'content' => $newContent,
+	] )
+		->assertOk()
+		->assertJsonPath( 'content.raw', $newContent['raw'] )
+		->assertJsonPath( 'content.blocks.0.attributes.content', 'Hello' );
+
+	expect( $template->fresh()->getContentEnvelope() )->toEqual( $newContent );
+} );
+
+it( 'deletes a template', function () {
+	actingAsTemplateUser();
+
+	$template = createTemplate();
+
+	$this->deleteJson( "/visual-editor/api/templates/{$template->id}" )
+		->assertNoContent();
+
+	expect( VisualEditorTemplate::find( $template->id ) )->toBeNull();
+} );
+
+it( 'round-trips the B2 fixture templates through store + show', function () {
+	actingAsTemplateUser();
+
+	$fixturesDir = dirname( __DIR__, 2 ) . '/Fixtures/sample-content/templates';
+	$files       = glob( $fixturesDir . '/*.json' );
+
+	expect( $files )->not->toBeEmpty();
+
+	foreach ( $files as $file ) {
+		$fixture = json_decode( (string) file_get_contents( $file ), true, flags: JSON_THROW_ON_ERROR );
+
+		$payload = [
+			'slug'        => $fixture['slug'],
+			'title'       => $fixture['title']['rendered'] ?? '',
+			'description' => $fixture['description'] ?? null,
+			'content'     => $fixture['content'] ?? [ 'raw' => '', 'blocks' => [] ],
+			'status'      => $fixture['status'] ?? 'publish',
+			'theme'       => $fixture['theme'],
+			'source'      => $fixture['source'] ?? 'theme',
+			'origin'      => $fixture['origin'] ?? 'theme',
+		];
+
+		$response = $this->postJson( '/visual-editor/api/templates', $payload )
+			->assertCreated()
+			->assertJsonPath( 'slug', $fixture['slug'] )
+			->assertJsonPath( 'content.raw', $fixture['content']['raw'] );
+
+		$id = $response->json( 'id' );
+
+		$this->getJson( "/visual-editor/api/templates/{$id}" )
+			->assertOk()
+			->assertJsonPath( 'slug', $fixture['slug'] )
+			->assertJsonPath( 'content.blocks', $fixture['content']['blocks'] );
+	}
+} );
+
+it( 'rejects unauthenticated store, update, and destroy', function () {
+	$template = createTemplate();
+
+	$this->postJson( '/visual-editor/api/templates', [
+		'slug'  => 'new',
+		'theme' => 'artisanpack-base',
+	] )->assertUnauthorized();
+
+	$this->putJson( "/visual-editor/api/templates/{$template->id}", [
+		'title' => 'Nope',
+	] )->assertUnauthorized();
+
+	$this->deleteJson( "/visual-editor/api/templates/{$template->id}" )->assertUnauthorized();
+} );

--- a/tests/Feature/VisualEditor/TemplateControllerTest.php
+++ b/tests/Feature/VisualEditor/TemplateControllerTest.php
@@ -286,6 +286,86 @@ it( 'round-trips the B2 fixture templates through store + show', function () {
 	}
 } );
 
+it( 'rejects a null title on store (column is non-nullable)', function () {
+	actingAsTemplateUser();
+
+	$this->postJson( '/visual-editor/api/templates', [
+		'slug'  => 'archive',
+		'theme' => 'artisanpack-base',
+		'title' => null,
+	] )
+		->assertUnprocessable()
+		->assertJsonValidationErrors( 'title' );
+} );
+
+it( 'rejects a null title on update (column is non-nullable)', function () {
+	actingAsTemplateUser();
+
+	$template = createTemplate();
+
+	$this->putJson( "/visual-editor/api/templates/{$template->id}", [
+		'title' => null,
+	] )
+		->assertUnprocessable()
+		->assertJsonValidationErrors( 'title' );
+
+	expect( $template->fresh()->title )->toBe( 'Single' );
+} );
+
+it( 'rejects a bare-list content payload on store', function () {
+	actingAsTemplateUser();
+
+	$this->postJson( '/visual-editor/api/templates', [
+		'slug'    => 'archive',
+		'theme'   => 'artisanpack-base',
+		'content' => [
+			[
+				'name'        => 'core/paragraph',
+				'attributes'  => [],
+				'innerBlocks' => [],
+			],
+		],
+	] )
+		->assertUnprocessable()
+		->assertJsonValidationErrors( 'content' );
+} );
+
+it( 'rejects a bare-list content payload on update', function () {
+	actingAsTemplateUser();
+
+	$template = createTemplate();
+
+	$this->putJson( "/visual-editor/api/templates/{$template->id}", [
+		'content' => [
+			[
+				'name'        => 'core/paragraph',
+				'attributes'  => [],
+				'innerBlocks' => [],
+			],
+		],
+	] )
+		->assertUnprocessable()
+		->assertJsonValidationErrors( 'content' );
+} );
+
+it( 'rejects a theme-only update that would collide with an existing (slug, theme)', function () {
+	actingAsTemplateUser();
+
+	// Existing record we will try to update into a colliding (slug, theme).
+	$editing = createTemplate( [ 'slug' => 'index', 'theme' => 'theme-a' ] );
+
+	// The collision target.
+	createTemplate( [ 'slug' => 'index', 'theme' => 'theme-b' ] );
+
+	$this->putJson( "/visual-editor/api/templates/{$editing->id}", [
+		'theme' => 'theme-b',
+	] )
+		->assertUnprocessable()
+		->assertJsonValidationErrors( 'theme' );
+
+	expect( $editing->fresh()->theme )->toBe( 'theme-a' );
+} );
+
 it( 'rejects unauthenticated store, update, and destroy', function () {
 	$template = createTemplate();
 

--- a/tests/Unit/VisualEditor/TemplateResolverTest.php
+++ b/tests/Unit/VisualEditor/TemplateResolverTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Models\VisualEditorTemplate;
+use ArtisanPackUI\VisualEditor\Resources\TemplateResolver;
+
+function makeTemplate( string $slug, string $theme = 'artisanpack-base' ): VisualEditorTemplate
+{
+	return VisualEditorTemplate::create( [
+		'slug'    => $slug,
+		'title'   => ucfirst( $slug ),
+		'content' => [ 'raw' => '', 'blocks' => [] ],
+		'theme'   => $theme,
+		'source'  => 'theme',
+		'origin'  => 'theme',
+	] );
+}
+
+it( 'returns null when the table is empty', function () {
+	$resolver = new TemplateResolver();
+
+	expect( $resolver->forSlug( 'single-post' ) )->toBeNull();
+} );
+
+it( 'returns the exact slug match when present', function () {
+	$resolver = new TemplateResolver();
+
+	$target = makeTemplate( 'single-post' );
+	makeTemplate( 'single' );
+	makeTemplate( 'index' );
+
+	expect( $resolver->forSlug( 'single-post' )->id )->toBe( $target->id );
+} );
+
+it( 'falls back to single when single-{slug} is missing', function () {
+	$resolver = new TemplateResolver();
+
+	$single = makeTemplate( 'single' );
+	makeTemplate( 'index' );
+
+	expect( $resolver->forSlug( 'single-post' )->id )->toBe( $single->id );
+} );
+
+it( 'falls back to page when page-{slug} is missing', function () {
+	$resolver = new TemplateResolver();
+
+	$page = makeTemplate( 'page' );
+	makeTemplate( 'index' );
+
+	expect( $resolver->forSlug( 'page-about' )->id )->toBe( $page->id );
+} );
+
+it( 'falls back to index when single and page are missing', function () {
+	$resolver = new TemplateResolver();
+
+	$index = makeTemplate( 'index' );
+
+	expect( $resolver->forSlug( 'single-post' )->id )->toBe( $index->id );
+	expect( $resolver->forSlug( 'page-about' )->id )->toBe( $index->id );
+	expect( $resolver->forSlug( 'archive' )->id )->toBe( $index->id );
+} );
+
+it( 'returns null when even index is missing', function () {
+	$resolver = new TemplateResolver();
+
+	makeTemplate( 'single' );
+
+	// No page, no index. single-post → single exists → OK.
+	expect( $resolver->forSlug( 'single-post' )->slug )->toBe( 'single' );
+	// But page-about has no fallback candidates in the DB.
+	expect( $resolver->forSlug( 'page-about' ) )->toBeNull();
+	// An unrelated slug also misses.
+	expect( $resolver->forSlug( 'archive' ) )->toBeNull();
+} );
+
+it( 'scopes lookups to a theme when provided', function () {
+	$resolver = new TemplateResolver();
+
+	makeTemplate( 'index', 'theme-a' );
+	$themeBIndex = makeTemplate( 'index', 'theme-b' );
+
+	expect( $resolver->forSlug( 'single-post', 'theme-b' )->id )
+		->toBe( $themeBIndex->id );
+
+	// theme-c has nothing — cascade terminates.
+	expect( $resolver->forSlug( 'single-post', 'theme-c' ) )->toBeNull();
+} );
+
+it( 'exposes the fallback chain for introspection', function () {
+	$resolver = new TemplateResolver();
+
+	expect( $resolver->fallbackChain( 'single-post' ) )->toBe( [ 'single-post', 'single', 'index' ] );
+	expect( $resolver->fallbackChain( 'page-about' ) )->toBe( [ 'page-about', 'page', 'index' ] );
+	expect( $resolver->fallbackChain( 'single' ) )->toBe( [ 'single', 'index' ] );
+	expect( $resolver->fallbackChain( 'page' ) )->toBe( [ 'page', 'index' ] );
+	expect( $resolver->fallbackChain( 'archive' ) )->toBe( [ 'archive', 'index' ] );
+	expect( $resolver->fallbackChain( 'index' ) )->toBe( [ 'index' ] );
+} );

--- a/tests/Unit/VisualEditor/VisualEditorTemplateTest.php
+++ b/tests/Unit/VisualEditor/VisualEditorTemplateTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Models\VisualEditorTemplate;
+
+it( 'round-trips the content envelope through the model', function () {
+	$template = VisualEditorTemplate::create( [
+		'slug'    => 'single',
+		'title'   => 'Single',
+		'content' => [
+			'raw'    => '<!-- wp:post-content /-->',
+			'blocks' => [
+				[
+					'name'        => 'core/post-content',
+					'attributes'  => [],
+					'innerBlocks' => [],
+				],
+			],
+		],
+		'theme'   => 'artisanpack-base',
+	] );
+
+	$envelope = $template->fresh()->getContentEnvelope();
+
+	expect( $envelope['raw'] )->toBe( '<!-- wp:post-content /-->' );
+	expect( $envelope['blocks'] )->toHaveCount( 1 );
+	expect( $envelope['blocks'][0]['name'] )->toBe( 'core/post-content' );
+} );
+
+it( 'returns an empty envelope when content is null', function () {
+	$template = new VisualEditorTemplate( [
+		'slug'  => 'empty',
+		'theme' => 'artisanpack-base',
+	] );
+
+	expect( $template->getContentEnvelope() )->toBe( [
+		'raw'    => '',
+		'blocks' => [],
+	] );
+
+	expect( $template->getBlocks() )->toBe( [] );
+	expect( $template->getRawContent() )->toBe( '' );
+} );
+
+it( 'setContentEnvelope normalizes missing keys', function () {
+	$template = new VisualEditorTemplate( [
+		'slug'  => 'foo',
+		'theme' => 'artisanpack-base',
+	] );
+
+	$template->setContentEnvelope( [ 'blocks' => [
+		[ 'name' => 'core/paragraph', 'attributes' => [], 'innerBlocks' => [] ],
+	] ] );
+
+	expect( $template->getContentEnvelope() )->toBe( [
+		'raw'    => '',
+		'blocks' => [
+			[ 'name' => 'core/paragraph', 'attributes' => [], 'innerBlocks' => [] ],
+		],
+	] );
+} );
+
+it( 'enforces the (slug, theme) unique constraint', function () {
+	VisualEditorTemplate::create( [
+		'slug'  => 'index',
+		'title' => 'Index',
+		'theme' => 'artisanpack-base',
+	] );
+
+	expect( function () {
+		VisualEditorTemplate::create( [
+			'slug'  => 'index',
+			'title' => 'Index Clone',
+			'theme' => 'artisanpack-base',
+		] );
+	} )->toThrow( Illuminate\Database\QueryException::class );
+} );
+
+it( 'allows the same slug on a different theme', function () {
+	VisualEditorTemplate::create( [
+		'slug'  => 'index',
+		'title' => 'Theme A',
+		'theme' => 'theme-a',
+	] );
+
+	$themeB = VisualEditorTemplate::create( [
+		'slug'  => 'index',
+		'title' => 'Theme B',
+		'theme' => 'theme-b',
+	] );
+
+	expect( $themeB->exists )->toBeTrue();
+} );


### PR DESCRIPTION
## Description

Lands the server-side backing for the `wp_template` entity the B1 core-data shim (#353) already talks to. The shim was dispatching `GET|POST|PUT|DELETE /visual-editor/api/templates[/:id]` into the void; this PR makes those calls resolve against real Eloquent records, wires a `TemplateResolver` that walks the WordPress-style `single-{slug}` → `single` → `index` (and `page-{slug}` → `page` → `index`) fallback cascade, and rounds the B2 fixture templates (#354) through the endpoints verbatim.

**Closes:** #357

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #357

## Motivation and Context

C1 unblocks D2 (site-editor template browser UI) and is a hard dependency for E2 (front-end template rendering). The endpoint contract was locked upstream in `docs/core-data-shim.md` §Templates, and the B2 fixtures defined the record shape on disk — this PR is what makes both resolve against real data instead of silently falling back to empty state.

## Changes Made

- **Migration** `create_visual_editor_templates_table` — `id`, `slug`, `title`, `description`, `content` (JSON envelope), `status` (indexed), `theme`, `source`, `origin`, timestamps, and a `(slug, theme)` unique constraint so the same slug can coexist across themes.
- **`VisualEditorTemplate` model** — canonical `getContentEnvelope()` / `setContentEnvelope()` accessor and mutator that always round-trip the `{ raw, blocks }` shape. Exposes `forSlug` and `forTheme` query scopes and source/origin/status constants.
- **`TemplateResolver` service** — `forSlug(slug, theme?)` walks the fallback chain until a record matches and returns `null` at the terminus so callers (E2 renderer, D2 preview) own the explicit 404 render. `fallbackChain()` is exposed for diagnostics.
- **`TemplateController`** — `index` returns the paginated `{ data, meta }` envelope the shim's `getEntityRecordsTotalItems` / `getEntityRecordsTotalPages` selectors need. `show`, `store`, and `update` return the bare record (no `data` wrap) so `fetchEntityRecord` can dispatch it straight into the cache. `per_page` is clamped to 100; `index` supports `theme`, `slug`, and `status` filters.
- **`TemplateResource`** — emits the B1-documented shape: `{ id, slug, title: { rendered }, description, content: { raw, blocks }, status, theme, type: 'wp_template', source, origin }`.
- **Form requests** — `StoreTemplateRequest` and `UpdateTemplateRequest` validate the full record, enforce the `(slug, theme)` uniqueness at the HTTP boundary, and delegate block-tree shape validation to a new `TemplateBlockTreeRule`.
- **`TemplateBlockTreeRule`** — shape validator that requires `name` / `attributes` / `innerBlocks` but doesn't require the editor-only `clientId` (theme-shipped fixtures don't carry it). Shares `MAX_DEPTH` / `MAX_NODES` with the existing post-editor `BlockTreeRule`.
- **`VisualEditorTemplatePolicy`** — gates the five endpoints to authenticated users (matches the post-policy default). Templates are site-level records with no owner, so the `restrict_by_owner` flag doesn't apply.
- **Service provider + routes** — registers the policy binding and mounts the five REST endpoints under the existing `/visual-editor/api` group.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS 26.3.0
- PHP Version: 8.4.3
- Project Version: 1.0.0 (release/1.0)

**Tests Performed:**

1. `./vendor/bin/pest --compact` — full package suite: **216 passed, 587 assertions** (includes 29 new tests for this PR).
2. Feature-tested the REST surface end-to-end: empty index, populated index with `theme`/`slug` filters, show hit + 404, store with `(slug, theme)` uniqueness collision, cross-theme slug reuse, block-tree validation rejection, partial title update, content-envelope replacement, destroy (204), unauthenticated 401 on all mutating verbs.
3. Resolver tested for the whole cascade: exact hit, `single-{slug}` → `single`, `page-{slug}` → `page`, fall-through to `index`, null terminus when `index` is missing, theme scoping, and `fallbackChain()` introspection.
4. Round-tripped all four B2 fixture templates (`single`, `page`, `index`, `404`) through `POST → GET` and asserted the stored `content.raw` + `content.blocks` match the fixture byte-for-byte.

## Accessibility Tests Run

- [ ] Keyboard navigation tested
- [ ] Screen reader tested
- [ ] Color contrast verified
- [ ] ARIA labels checked

**Details:** Backend-only change; no UI surface. D2 (site-editor template browser) is where a11y testing enters the picture.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:**

- `tests/Feature/VisualEditor/TemplateControllerTest.php` — 16 cases covering the REST surface, validation paths, auth, and the B2 fixture round-trip.
- `tests/Unit/VisualEditor/TemplateResolverTest.php` — 8 cases covering the whole `single-* → single → index` / `page-* → page → index` cascade, empty-DB terminus, theme scoping, and `fallbackChain()`.
- `tests/Unit/VisualEditor/VisualEditorTemplateTest.php` — 5 cases covering content-envelope round-trip, null-content defaults, mutator normalization, and the `(slug, theme)` uniqueness constraint at the model layer.

## Documentation

- [x] Inline code documentation added
- [ ] README updated
- [ ] Wiki updated
- [ ] API documentation updated

**Documentation details:** All new classes carry the standard package docblock header + `@since` / parameter annotations. `core-data-shim.md` already documents the endpoint contract this PR implements — no doc change needed. API reference / wiki updates (if any) ride along with the umbrella #309 site-editor docs pass.

## Screenshots

N/A — backend-only.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [x] Accessibility tests completed
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * REST API for managing visual editor templates (list, create, retrieve, update, delete)
  * Templates support theme scoping, per-theme unique slugs, status/source/origin metadata, and block-based content envelopes
  * Template resolver with fallback chain for flexible lookup

* **Tests**
  * Comprehensive feature and unit tests covering API behavior, validation, resolver logic, and content persistence
<!-- end of auto-generated comment: release notes by coderabbit.ai -->