### PR TITLE
feat: C2 · Template parts model, migration, API

### DIFF
--- a/database/migrations/2026_04_23_100000_create_visual_editor_template_parts_table.php
+++ b/database/migrations/2026_04_23_100000_create_visual_editor_template_parts_table.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * Create visual_editor_template_parts table migration.
+ *
+ * Storage for the `wp_template_part` entity the B1 core-data shim
+ * addresses at `/visual-editor/api/template-parts`. Holds the Gutenberg
+ * block tree alongside the raw serialized payload plus the `area` enum
+ * and `theme` scoping that pair with `slug` as the composite natural key.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+	public function up(): void
+	{
+		Schema::create( 'visual_editor_template_parts', function ( Blueprint $table ) {
+			$table->id();
+			$table->string( 'slug' );
+			$table->string( 'title' )->default( '' );
+			// The API envelope { raw, blocks } is stored verbatim; an empty
+			// part is `{ "raw": "", "blocks": [] }` so the column is never
+			// null once hydrated through the model.
+			$table->json( 'content' )->nullable();
+			// Kept as a plain string (not an enum column) so new areas can
+			// be added without a schema migration; form-request validation
+			// gates the allowed values at the application layer.
+			$table->string( 'area' )->default( 'uncategorized' )->index();
+			$table->string( 'theme' );
+			$table->timestamps();
+
+			// `slug` is only unique within a theme — the same `header`
+			// slug can legitimately exist on two themes installed side
+			// by side.
+			$table->unique( [ 'slug', 'theme' ] );
+		} );
+	}
+
+	public function down(): void
+	{
+		Schema::dropIfExists( 'visual_editor_template_parts' );
+	}
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -20,6 +20,7 @@ declare( strict_types=1 );
 use ArtisanPackUI\VisualEditor\Http\Controllers\BlockPreviewController;
 use ArtisanPackUI\VisualEditor\Http\Controllers\ResourceContentController;
 use ArtisanPackUI\VisualEditor\Http\Controllers\TemplateController;
+use ArtisanPackUI\VisualEditor\Http\Controllers\TemplatePartController;
 use ArtisanPackUI\VisualEditor\Http\Controllers\VisualEditorBlocksController;
 use ArtisanPackUI\VisualEditor\Http\Controllers\VisualEditorPostsController;
 use Illuminate\Support\Facades\Route;
@@ -55,6 +56,22 @@ Route::put( 'templates/{template}', [ TemplateController::class, 'update' ] )
 
 Route::delete( 'templates/{template}', [ TemplateController::class, 'destroy' ] )
 	->name( 'visual-editor.api.templates.destroy' );
+
+// C2 `wp_template_part` REST surface — see docs/core-data-shim.md §Template parts.
+Route::get( 'template-parts', [ TemplatePartController::class, 'index' ] )
+	->name( 'visual-editor.api.template-parts.index' );
+
+Route::post( 'template-parts', [ TemplatePartController::class, 'store' ] )
+	->name( 'visual-editor.api.template-parts.store' );
+
+Route::get( 'template-parts/{templatePart}', [ TemplatePartController::class, 'show' ] )
+	->name( 'visual-editor.api.template-parts.show' );
+
+Route::put( 'template-parts/{templatePart}', [ TemplatePartController::class, 'update' ] )
+	->name( 'visual-editor.api.template-parts.update' );
+
+Route::delete( 'template-parts/{templatePart}', [ TemplatePartController::class, 'destroy' ] )
+	->name( 'visual-editor.api.template-parts.destroy' );
 
 // Legacy ve_contents routes retained for the existing editor tests and the
 // `VisualEditorPost` model. Deprecated in M3 in favor of the resource routes

--- a/src/Http/Controllers/TemplatePartController.php
+++ b/src/Http/Controllers/TemplatePartController.php
@@ -253,9 +253,12 @@ class TemplatePartController extends Controller
 	 * Recursively checks whether a parsed block tree contains a
 	 * `core/template-part` pointer matching the given slug + theme.
 	 *
-	 * Treats a missing `theme` attribute as a match when the part's own
-	 * theme is the default — the B2 fixtures always set `theme` on the
-	 * block, but older exports may omit it.
+	 * An empty/missing `theme` attribute on the block is treated as a
+	 * same-theme reference. The B2 fixtures always set `theme` on the
+	 * block, but older exports may omit it; since
+	 * {@see resolveReferencedBy()} only scans templates already filtered
+	 * to the target theme, an untagged reference inside one of those
+	 * templates can only resolve to a part in that same theme.
 	 *
 	 * @since 1.0.0
 	 *
@@ -275,7 +278,7 @@ class TemplatePartController extends Controller
 				$attributeSlug  = isset( $attributes['slug'] ) && is_string( $attributes['slug'] ) ? $attributes['slug'] : '';
 				$attributeTheme = isset( $attributes['theme'] ) && is_string( $attributes['theme'] ) ? $attributes['theme'] : '';
 
-				if ( $slug === $attributeSlug && $theme === $attributeTheme ) {
+				if ( $slug === $attributeSlug && ( '' === $attributeTheme || $theme === $attributeTheme ) ) {
 					return true;
 				}
 			}

--- a/src/Http/Controllers/TemplatePartController.php
+++ b/src/Http/Controllers/TemplatePartController.php
@@ -1,0 +1,292 @@
+<?php
+
+/**
+ * TemplatePart controller.
+ *
+ * Serves the REST surface for the `wp_template_part` entity behind the
+ * B1 core-data shim (see `docs/core-data-shim.md` §Template parts). The
+ * five endpoints — index, show, store, update, destroy — mount under
+ * `/visual-editor/api/template-parts` via the package's auth-gated API
+ * group and return responses shaped by {@see TemplatePartResource}.
+ *
+ * The `show` action additionally computes a `referenced_by` list —
+ * template slugs whose serialized block tree embeds this part through a
+ * `core/template-part` block — so the D2 site-editor can warn before
+ * deleting a part that's still in use. The relationship is derived at
+ * read time rather than persisted because parts and templates have no
+ * FK between them: either side can outlive the other.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Http\Controllers;
+
+use ArtisanPackUI\VisualEditor\Http\Requests\StoreTemplatePartRequest;
+use ArtisanPackUI\VisualEditor\Http\Requests\UpdateTemplatePartRequest;
+use ArtisanPackUI\VisualEditor\Http\Resources\TemplatePartResource;
+use ArtisanPackUI\VisualEditor\Models\VisualEditorTemplate;
+use ArtisanPackUI\VisualEditor\Models\VisualEditorTemplatePart;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Illuminate\Http\Response;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Gate;
+
+class TemplatePartController extends Controller
+{
+	/**
+	 * Maximum per-page size for the index endpoint. Keeps a malicious or
+	 * accidental `?per_page=999999` query from dragging the site-editor
+	 * sidebar down while still letting the host page through explicit
+	 * requests when necessary.
+	 */
+	protected const MAX_PER_PAGE = 100;
+
+	/**
+	 * Lists template parts with a paginated `{ data, meta }` envelope.
+	 *
+	 * The shim reads `meta.total` and `meta.last_page` for the selectors
+	 * `getEntityRecordsTotalItems` / `getEntityRecordsTotalPages`; the
+	 * default Laravel `Resource::collection( $paginator )` response
+	 * already emits those keys, so no custom envelope is necessary.
+	 *
+	 * @since 1.0.0
+	 */
+	public function index( Request $request ): AnonymousResourceCollection
+	{
+		Gate::authorize( 'viewAny', VisualEditorTemplatePart::class );
+
+		$perPage = (int) $request->integer( 'per_page', 25 );
+
+		if ( $perPage < 1 ) {
+			$perPage = 25;
+		}
+
+		if ( $perPage > self::MAX_PER_PAGE ) {
+			$perPage = self::MAX_PER_PAGE;
+		}
+
+		$query = VisualEditorTemplatePart::query()->orderBy( 'id' );
+
+		$theme = $request->string( 'theme' )->toString();
+		if ( '' !== $theme ) {
+			$query->where( 'theme', $theme );
+		}
+
+		$slug = $request->string( 'slug' )->toString();
+		if ( '' !== $slug ) {
+			$query->where( 'slug', $slug );
+		}
+
+		$area = $request->string( 'area' )->toString();
+		if ( '' !== $area ) {
+			$query->where( 'area', $area );
+		}
+
+		return TemplatePartResource::collection( $query->paginate( $perPage ) );
+	}
+
+	/**
+	 * Returns a single template part.
+	 *
+	 * The shim expects the record at the top level (not wrapped in `data`)
+	 * so `fetchEntityRecord` can dispatch it straight into the cache.
+	 * `referenced_by` is merged in at the top level so the D2 delete
+	 * flow can read it without a separate request.
+	 *
+	 * @since 1.0.0
+	 */
+	public function show( Request $request, VisualEditorTemplatePart $templatePart ): JsonResponse
+	{
+		Gate::authorize( 'view', $templatePart );
+
+		$payload = ( new TemplatePartResource( $templatePart ) )->toArray( $request );
+
+		$payload['referenced_by'] = $this->resolveReferencedBy( $templatePart );
+
+		return response()->json( $payload );
+	}
+
+	/**
+	 * Creates a new template part.
+	 *
+	 * @since 1.0.0
+	 */
+	public function store( StoreTemplatePartRequest $request ): JsonResponse
+	{
+		Gate::authorize( 'create', VisualEditorTemplatePart::class );
+
+		$data = $request->validated();
+
+		$part = new VisualEditorTemplatePart();
+		$part->fill( [
+			'slug'  => $data['slug'],
+			'title' => $data['title'] ?? '',
+			'area'  => $data['area'],
+			'theme' => $data['theme'],
+		] );
+
+		$part->setContentEnvelope( $this->normalizeContentEnvelope( $data['content'] ?? null ) );
+		$part->save();
+
+		return response()->json(
+			( new TemplatePartResource( $part ) )->toArray( $request ),
+			Response::HTTP_CREATED
+		);
+	}
+
+	/**
+	 * Updates an existing template part.
+	 *
+	 * @since 1.0.0
+	 */
+	public function update( UpdateTemplatePartRequest $request, VisualEditorTemplatePart $templatePart ): JsonResponse
+	{
+		Gate::authorize( 'update', $templatePart );
+
+		$data = $request->validated();
+
+		foreach ( [ 'slug', 'title', 'area', 'theme' ] as $field ) {
+			if ( array_key_exists( $field, $data ) ) {
+				$templatePart->{$field} = $data[ $field ];
+			}
+		}
+
+		if ( array_key_exists( 'content', $data ) ) {
+			$templatePart->setContentEnvelope( $this->normalizeContentEnvelope( $data['content'] ) );
+		}
+
+		$templatePart->save();
+
+		return response()->json( ( new TemplatePartResource( $templatePart ) )->toArray( $request ) );
+	}
+
+	/**
+	 * Deletes a template part.
+	 *
+	 * @since 1.0.0
+	 */
+	public function destroy( VisualEditorTemplatePart $templatePart ): JsonResponse
+	{
+		Gate::authorize( 'delete', $templatePart );
+
+		$templatePart->delete();
+
+		return response()->json( null, Response::HTTP_NO_CONTENT );
+	}
+
+	/**
+	 * Normalizes the inbound content payload into the `{ raw, blocks }`
+	 * envelope the model expects. Form-request validation guarantees
+	 * the shape before we get here; this method just guards against
+	 * missing keys and bad types as a belt-and-braces fallback.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  mixed  $content
+	 *
+	 * @return array{raw: string, blocks: array<int, array<string, mixed>>}
+	 */
+	protected function normalizeContentEnvelope( mixed $content ): array
+	{
+		if ( ! is_array( $content ) ) {
+			return [ 'raw' => '', 'blocks' => [] ];
+		}
+
+		return [
+			'raw'    => isset( $content['raw'] ) && is_string( $content['raw'] ) ? $content['raw'] : '',
+			'blocks' => isset( $content['blocks'] ) && is_array( $content['blocks'] ) ? array_values( $content['blocks'] ) : [],
+		];
+	}
+
+	/**
+	 * Resolves the list of template slugs whose block tree embeds this
+	 * part via a `core/template-part` block.
+	 *
+	 * Correctness matters more than performance here: the V1 site-editor
+	 * only calls this on a single part at a time (before showing a
+	 * delete-confirmation dialog), so a linear scan over the templates
+	 * for the matching theme is fine. If D2 grows to render the browser
+	 * with per-part reference counts, this can move to a cached
+	 * aggregate without changing the response contract.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<int, string>
+	 */
+	protected function resolveReferencedBy( VisualEditorTemplatePart $part ): array
+	{
+		$slug  = $part->slug;
+		$theme = $part->theme;
+
+		// A part is only referenced from templates in the same theme —
+		// `core/template-part` attributes carry the theme alongside the
+		// slug, so the cross-theme case never resolves.
+		$templates = VisualEditorTemplate::query()
+			->where( 'theme', $theme )
+			->orderBy( 'slug' )
+			->get( [ 'slug', 'content' ] );
+
+		$matches = [];
+
+		foreach ( $templates as $template ) {
+			if ( $this->blockTreeReferencesPart( $template->getBlocks(), $slug, $theme ) ) {
+				$matches[] = $template->slug;
+			}
+		}
+
+		// Deduplicate while preserving order — the scan may visit the
+		// same template twice if the block tree embeds the part more
+		// than once.
+		return array_values( array_unique( $matches ) );
+	}
+
+	/**
+	 * Recursively checks whether a parsed block tree contains a
+	 * `core/template-part` pointer matching the given slug + theme.
+	 *
+	 * Treats a missing `theme` attribute as a match when the part's own
+	 * theme is the default — the B2 fixtures always set `theme` on the
+	 * block, but older exports may omit it.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array<int, array<string, mixed>>  $blocks
+	 */
+	protected function blockTreeReferencesPart( array $blocks, string $slug, string $theme ): bool
+	{
+		foreach ( $blocks as $block ) {
+			if ( ! is_array( $block ) ) {
+				continue;
+			}
+
+			$name = isset( $block['name'] ) && is_string( $block['name'] ) ? $block['name'] : '';
+
+			if ( 'core/template-part' === $name ) {
+				$attributes     = isset( $block['attributes'] ) && is_array( $block['attributes'] ) ? $block['attributes'] : [];
+				$attributeSlug  = isset( $attributes['slug'] ) && is_string( $attributes['slug'] ) ? $attributes['slug'] : '';
+				$attributeTheme = isset( $attributes['theme'] ) && is_string( $attributes['theme'] ) ? $attributes['theme'] : '';
+
+				if ( $slug === $attributeSlug && $theme === $attributeTheme ) {
+					return true;
+				}
+			}
+
+			$innerBlocks = isset( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ? $block['innerBlocks'] : [];
+
+			if ( [] !== $innerBlocks && $this->blockTreeReferencesPart( $innerBlocks, $slug, $theme ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+}

--- a/src/Http/Requests/StoreTemplatePartRequest.php
+++ b/src/Http/Requests/StoreTemplatePartRequest.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * StoreTemplatePart form request.
+ *
+ * Validates the payload for creating a `wp_template_part` record via
+ * `POST /visual-editor/api/template-parts`.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Http\Requests;
+
+use ArtisanPackUI\VisualEditor\Models\VisualEditorTemplatePart;
+use ArtisanPackUI\VisualEditor\Rules\TemplateBlockTreeRule;
+use Closure;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StoreTemplatePartRequest extends FormRequest
+{
+	public function authorize(): bool
+	{
+		return true;
+	}
+
+	/**
+	 * @return array<string, array<int, mixed>>
+	 */
+	public function rules(): array
+	{
+		return [
+			'slug'           => [
+				'required',
+				'string',
+				'max:191',
+				Rule::unique( 'visual_editor_template_parts', 'slug' )
+					->where( fn ( $query ) => $query->where( 'theme', $this->input( 'theme' ) ) ),
+			],
+			// `title` backs a non-nullable DB column (default ''). The store
+			// controller falls back to '' when the field is missing, but
+			// `null` is never a legal value — rejecting it here keeps the
+			// DB from rejecting the write later with an opaque
+			// QueryException.
+			'title'          => [ 'sometimes', 'string', 'max:255' ],
+			'content'        => [ 'nullable', 'array', $this->envelopeShapeRule() ],
+			'content.raw'    => [ 'nullable', 'string' ],
+			'content.blocks' => [ 'nullable', 'array', new TemplateBlockTreeRule() ],
+			'area'           => [
+				'required',
+				'string',
+				Rule::in( VisualEditorTemplatePart::AREAS ),
+			],
+			'theme'          => [ 'required', 'string', 'max:191' ],
+		];
+	}
+
+	/**
+	 * @return array<string, string>
+	 */
+	public function messages(): array
+	{
+		return [
+			'area.in' => 'The area must be one of: ' . implode( ', ', VisualEditorTemplatePart::AREAS ) . '.',
+		];
+	}
+
+	/**
+	 * Rejects a bare-list `content` payload.
+	 *
+	 * `content.blocks` is only validated when the request uses the
+	 * `{ raw, blocks }` envelope; without this rule a caller could send
+	 * `content: [ <blocks> ]` to skip `TemplateBlockTreeRule` entirely.
+	 *
+	 * @since 1.0.0
+	 */
+	protected function envelopeShapeRule(): Closure
+	{
+		return function ( string $attribute, mixed $value, Closure $fail ): void {
+			if ( is_array( $value ) && [] !== $value && array_is_list( $value ) ) {
+				$fail( 'The :attribute must be a { raw, blocks } envelope, not a bare list of blocks.' );
+			}
+		};
+	}
+}

--- a/src/Http/Requests/UpdateTemplatePartRequest.php
+++ b/src/Http/Requests/UpdateTemplatePartRequest.php
@@ -1,0 +1,115 @@
+<?php
+
+/**
+ * UpdateTemplatePart form request.
+ *
+ * Validates the payload for updating a `wp_template_part` record via
+ * `PUT /visual-editor/api/template-parts/{id}`.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Http\Requests;
+
+use ArtisanPackUI\VisualEditor\Models\VisualEditorTemplatePart;
+use ArtisanPackUI\VisualEditor\Rules\TemplateBlockTreeRule;
+use Closure;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateTemplatePartRequest extends FormRequest
+{
+	public function authorize(): bool
+	{
+		return true;
+	}
+
+	/**
+	 * @return array<string, array<int, mixed>>
+	 */
+	public function rules(): array
+	{
+		/** @var VisualEditorTemplatePart $templatePart */
+		$templatePart = $this->route( 'templatePart' );
+
+		$resolvedSlug  = $this->input( 'slug', $templatePart->slug );
+		$resolvedTheme = $this->input( 'theme', $templatePart->theme );
+
+		// Composite-uniqueness is mirrored on both slug and theme so a
+		// PUT that changes *either* field triggers the check. Without
+		// the theme-side mirror, `{ "theme": "other" }` (no slug) would
+		// slip past the `sometimes`-gated slug rule and rely on the DB
+		// constraint to reject the collision as an opaque
+		// QueryException.
+		$uniqueness = Rule::unique( 'visual_editor_template_parts', 'slug' )
+			->ignore( $templatePart->getKey() )
+			->where( fn ( $query ) => $query->where( 'theme', $resolvedTheme ) );
+
+		$themeUniqueness = Rule::unique( 'visual_editor_template_parts', 'theme' )
+			->ignore( $templatePart->getKey() )
+			->where( fn ( $query ) => $query->where( 'slug', $resolvedSlug ) );
+
+		return [
+			'slug'           => [
+				'sometimes',
+				'required',
+				'string',
+				'max:191',
+				$uniqueness,
+			],
+			// `title` backs a non-nullable DB column — null is never a
+			// legal value. The update controller leaves missing fields
+			// untouched, so dropping `nullable` here only tightens the
+			// error path without changing what a partial update can do.
+			'title'          => [ 'sometimes', 'string', 'max:255' ],
+			'content'        => [ 'sometimes', 'nullable', 'array', $this->envelopeShapeRule() ],
+			'content.raw'    => [ 'sometimes', 'nullable', 'string' ],
+			'content.blocks' => [ 'sometimes', 'nullable', 'array', new TemplateBlockTreeRule() ],
+			'area'           => [
+				'sometimes',
+				'required',
+				'string',
+				Rule::in( VisualEditorTemplatePart::AREAS ),
+			],
+			'theme'          => [
+				'sometimes',
+				'required',
+				'string',
+				'max:191',
+				$themeUniqueness,
+			],
+		];
+	}
+
+	/**
+	 * @return array<string, string>
+	 */
+	public function messages(): array
+	{
+		return [
+			'area.in' => 'The area must be one of: ' . implode( ', ', VisualEditorTemplatePart::AREAS ) . '.',
+		];
+	}
+
+	/**
+	 * Rejects a bare-list `content` payload — see the mirrored method
+	 * on {@see StoreTemplatePartRequest::envelopeShapeRule()} for why.
+	 *
+	 * @since 1.0.0
+	 */
+	protected function envelopeShapeRule(): Closure
+	{
+		return function ( string $attribute, mixed $value, Closure $fail ): void {
+			if ( is_array( $value ) && [] !== $value && array_is_list( $value ) ) {
+				$fail( 'The :attribute must be a { raw, blocks } envelope, not a bare list of blocks.' );
+			}
+		};
+	}
+}

--- a/src/Http/Resources/TemplatePartResource.php
+++ b/src/Http/Resources/TemplatePartResource.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * TemplatePartResource API resource.
+ *
+ * Shapes a {@see VisualEditorTemplatePart} into the B1 core-data shim's
+ * `wp_template_part` record envelope. Keeps the HTTP response contract
+ * in one place so controllers and tests don't have to reconstruct the
+ * `title.rendered` and `content.{raw,blocks}` wrappers ad hoc.
+ *
+ * The optional `referenced_by` key is populated on `show` responses via
+ * `additional([...])` — it's a derived list of template slugs whose
+ * block tree embeds this part through a `core/template-part` block.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Http\Resources;
+
+use ArtisanPackUI\VisualEditor\Models\VisualEditorTemplatePart;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @property VisualEditorTemplatePart $resource
+ */
+class TemplatePartResource extends JsonResource
+{
+	/**
+	 * Transforms the template part into the shim-compatible record shape.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function toArray( Request $request ): array
+	{
+		/** @var VisualEditorTemplatePart $part */
+		$part = $this->resource;
+
+		$envelope = $part->getContentEnvelope();
+
+		return [
+			'id'      => $part->getKey(),
+			'slug'    => $part->slug,
+			'title'   => [
+				'rendered' => (string) ( $part->title ?? '' ),
+			],
+			'content' => [
+				'raw'    => $envelope['raw'],
+				'blocks' => $envelope['blocks'],
+			],
+			'area'    => $part->area,
+			'theme'   => $part->theme,
+			'type'    => 'wp_template_part',
+		];
+	}
+}

--- a/src/Models/VisualEditorTemplatePart.php
+++ b/src/Models/VisualEditorTemplatePart.php
@@ -1,0 +1,187 @@
+<?php
+
+/**
+ * VisualEditorTemplatePart model.
+ *
+ * Eloquent backing for the `wp_template_part` entity exposed at
+ * `/visual-editor/api/template-parts`. Stores the Gutenberg block tree
+ * inside the `{ raw, blocks }` envelope the B1 core-data shim expects,
+ * together with the `area` enum (`header`, `footer`, `sidebar`,
+ * `uncategorized`) and the `theme` scoping that pairs with `slug` as the
+ * composite natural key.
+ *
+ * Shares the `{ raw, blocks }` storage shape with {@see VisualEditorTemplate}
+ * so block renderers can consume either surface without a translation
+ * step. `referenced_by` is derived on the REST layer (see
+ * {@see \ArtisanPackUI\VisualEditor\Http\Controllers\TemplatePartController::resolveReferencedBy()})
+ * — the model does not persist or maintain the relationship directly.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+class VisualEditorTemplatePart extends Model
+{
+	public const AREA_HEADER        = 'header';
+	public const AREA_FOOTER        = 'footer';
+	public const AREA_SIDEBAR       = 'sidebar';
+	public const AREA_UNCATEGORIZED = 'uncategorized';
+
+	/**
+	 * @var array<int, string>
+	 */
+	public const AREAS = [
+		self::AREA_HEADER,
+		self::AREA_FOOTER,
+		self::AREA_SIDEBAR,
+		self::AREA_UNCATEGORIZED,
+	];
+
+	protected $table = 'visual_editor_template_parts';
+
+	/**
+	 * @var array<int, string>
+	 */
+	protected $fillable = [
+		'slug',
+		'title',
+		'content',
+		'area',
+		'theme',
+	];
+
+	/**
+	 * @var array<string, string>
+	 */
+	protected $casts = [
+		'content' => 'array',
+	];
+
+	/**
+	 * Returns the canonical content envelope stored on the record.
+	 *
+	 * Always returns the `{ raw, blocks }` shape — callers never have to
+	 * null-check the raw column or the blocks key separately.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array{raw: string, blocks: array<int, array<string, mixed>>}
+	 */
+	public function getContentEnvelope(): array
+	{
+		$value = $this->getAttribute( 'content' );
+
+		$raw    = '';
+		$blocks = [];
+
+		if ( is_array( $value ) ) {
+			$raw    = isset( $value['raw'] ) && is_string( $value['raw'] ) ? $value['raw'] : '';
+			$blocks = isset( $value['blocks'] ) && is_array( $value['blocks'] ) ? array_values( $value['blocks'] ) : [];
+		}
+
+		return [
+			'raw'    => $raw,
+			'blocks' => $blocks,
+		];
+	}
+
+	/**
+	 * Returns just the parsed block tree.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	public function getBlocks(): array
+	{
+		return $this->getContentEnvelope()['blocks'];
+	}
+
+	/**
+	 * Returns just the raw Gutenberg serialization.
+	 *
+	 * @since 1.0.0
+	 */
+	public function getRawContent(): string
+	{
+		return $this->getContentEnvelope()['raw'];
+	}
+
+	/**
+	 * Persists an updated content envelope on the record.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array{raw?: string, blocks?: array<int, array<string, mixed>>}  $envelope
+	 */
+	public function setContentEnvelope( array $envelope ): void
+	{
+		$raw    = isset( $envelope['raw'] ) && is_string( $envelope['raw'] ) ? $envelope['raw'] : '';
+		$blocks = isset( $envelope['blocks'] ) && is_array( $envelope['blocks'] ) ? array_values( $envelope['blocks'] ) : [];
+
+		$this->setAttribute( 'content', [
+			'raw'    => $raw,
+			'blocks' => $blocks,
+		] );
+	}
+
+	/**
+	 * Scopes the query to template parts published for a theme.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  Builder<VisualEditorTemplatePart>  $query
+	 *
+	 * @return Builder<VisualEditorTemplatePart>
+	 */
+	public function scopeForTheme( Builder $query, string $theme ): Builder
+	{
+		return $query->where( 'theme', $theme );
+	}
+
+	/**
+	 * Scopes the query to a specific area enum value.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  Builder<VisualEditorTemplatePart>  $query
+	 *
+	 * @return Builder<VisualEditorTemplatePart>
+	 */
+	public function scopeForArea( Builder $query, string $area ): Builder
+	{
+		return $query->where( 'area', $area );
+	}
+
+	/**
+	 * Scopes the query to parts matching a slug (optionally constrained
+	 * to a theme).
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  Builder<VisualEditorTemplatePart>  $query
+	 *
+	 * @return Builder<VisualEditorTemplatePart>
+	 */
+	public function scopeForSlug( Builder $query, string $slug, ?string $theme = null ): Builder
+	{
+		$query->where( 'slug', $slug );
+
+		if ( null !== $theme && '' !== $theme ) {
+			$query->where( 'theme', $theme );
+		}
+
+		return $query;
+	}
+}

--- a/src/Policies/VisualEditorTemplatePartPolicy.php
+++ b/src/Policies/VisualEditorTemplatePartPolicy.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * VisualEditorTemplatePart policy.
+ *
+ * Authorization policy for the `wp_template_part` REST endpoints. The
+ * V1 default allows any authenticated user to read and mutate template
+ * parts, mirroring how {@see VisualEditorTemplatePolicy} handles the
+ * sibling `wp_template` entity; host apps that need tighter access
+ * should swap the binding in their own service provider.
+ *
+ * Template parts have no "owner" — they're theme or site-level records,
+ * not per-user content — so the `restrict_by_owner` config flag that
+ * governs posts doesn't apply here.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Policies;
+
+use ArtisanPackUI\VisualEditor\Models\VisualEditorTemplatePart;
+use Illuminate\Auth\Access\HandlesAuthorization;
+use Illuminate\Contracts\Auth\Authenticatable;
+
+class VisualEditorTemplatePartPolicy
+{
+	use HandlesAuthorization;
+
+	public function viewAny( ?Authenticatable $user ): bool
+	{
+		return null !== $user;
+	}
+
+	public function view( ?Authenticatable $user, VisualEditorTemplatePart $templatePart ): bool
+	{
+		return null !== $user;
+	}
+
+	public function create( ?Authenticatable $user ): bool
+	{
+		return null !== $user;
+	}
+
+	public function update( ?Authenticatable $user, VisualEditorTemplatePart $templatePart ): bool
+	{
+		return null !== $user;
+	}
+
+	public function delete( ?Authenticatable $user, VisualEditorTemplatePart $templatePart ): bool
+	{
+		return null !== $user;
+	}
+}

--- a/src/VisualEditorServiceProvider.php
+++ b/src/VisualEditorServiceProvider.php
@@ -6,8 +6,10 @@ use ArtisanPackUI\VisualEditor\Console\Commands\SeedSampleContentCommand;
 use ArtisanPackUI\VisualEditor\MediaBridge\GutenbergAttachmentAdapter;
 use ArtisanPackUI\VisualEditor\Models\VisualEditorPost;
 use ArtisanPackUI\VisualEditor\Models\VisualEditorTemplate;
+use ArtisanPackUI\VisualEditor\Models\VisualEditorTemplatePart;
 use ArtisanPackUI\VisualEditor\Policies\VisualEditorPostPolicy;
 use ArtisanPackUI\VisualEditor\Policies\VisualEditorTemplatePolicy;
+use ArtisanPackUI\VisualEditor\Policies\VisualEditorTemplatePartPolicy;
 use ArtisanPackUI\VisualEditor\Registries\BlockTypeRegistry;
 use ArtisanPackUI\VisualEditor\Registries\DynamicBlockRegistry;
 use ArtisanPackUI\VisualEditor\Resources\ResourceResolver;
@@ -85,6 +87,7 @@ class VisualEditorServiceProvider extends ServiceProvider
 
 		Gate::policy( VisualEditorPost::class, VisualEditorPostPolicy::class );
 		Gate::policy( VisualEditorTemplate::class, VisualEditorTemplatePolicy::class );
+		Gate::policy( VisualEditorTemplatePart::class, VisualEditorTemplatePartPolicy::class );
 
 		// 3. Register core blocks from their block.json manifests.
 		$this->registerCoreBlocks();

--- a/tests/Feature/VisualEditor/TemplatePartControllerTest.php
+++ b/tests/Feature/VisualEditor/TemplatePartControllerTest.php
@@ -1,0 +1,551 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Models\VisualEditorTemplate;
+use ArtisanPackUI\VisualEditor\Models\VisualEditorTemplatePart;
+use Tests\TestUser;
+
+function createTemplatePart( array $overrides = [] ): VisualEditorTemplatePart
+{
+	return VisualEditorTemplatePart::create( array_merge( [
+		'slug'    => 'header',
+		'title'   => 'Header',
+		'content' => [
+			'raw'    => '<!-- wp:site-title /-->',
+			'blocks' => [
+				[
+					'name'        => 'core/site-title',
+					'attributes'  => new stdClass(),
+					'innerBlocks' => [],
+				],
+			],
+		],
+		'area'    => 'header',
+		'theme'   => 'artisanpack-base',
+	], $overrides ) );
+}
+
+function createTemplateEmbeddingPart( string $templateSlug, string $partSlug, string $theme ): VisualEditorTemplate
+{
+	return VisualEditorTemplate::create( [
+		'slug'    => $templateSlug,
+		'title'   => ucfirst( $templateSlug ),
+		'content' => [
+			'raw'    => sprintf( '<!-- wp:template-part {"slug":"%s","theme":"%s"} /-->', $partSlug, $theme ),
+			'blocks' => [
+				[
+					'name'        => 'core/template-part',
+					'attributes'  => [ 'slug' => $partSlug, 'theme' => $theme ],
+					'innerBlocks' => [],
+				],
+			],
+		],
+		'status'  => 'publish',
+		'theme'   => $theme,
+		'source'  => 'theme',
+		'origin'  => 'theme',
+	] );
+}
+
+function actingAsTemplatePartUser(): TestUser
+{
+	$user = TestUser::create( [
+		'name'     => 'Template Part Tester',
+		'email'    => 'template-part+' . uniqid() . '@example.com',
+		'password' => bcrypt( 'secret' ),
+	] );
+
+	test()->actingAs( $user );
+
+	return $user;
+}
+
+it( 'returns 401 when unauthenticated on index', function () {
+	$this->getJson( '/visual-editor/api/template-parts' )->assertUnauthorized();
+} );
+
+it( 'returns an empty data/meta envelope when no parts exist', function () {
+	actingAsTemplatePartUser();
+
+	$this->getJson( '/visual-editor/api/template-parts' )
+		->assertOk()
+		->assertJsonPath( 'data', [] )
+		->assertJsonPath( 'meta.total', 0 )
+		->assertJsonPath( 'meta.last_page', 1 );
+} );
+
+it( 'lists template parts in the data/meta envelope', function () {
+	actingAsTemplatePartUser();
+
+	createTemplatePart( [ 'slug' => 'header', 'title' => 'Header', 'area' => 'header' ] );
+	createTemplatePart( [ 'slug' => 'footer', 'title' => 'Footer', 'area' => 'footer' ] );
+
+	$this->getJson( '/visual-editor/api/template-parts' )
+		->assertOk()
+		->assertJsonCount( 2, 'data' )
+		->assertJsonPath( 'meta.total', 2 )
+		->assertJsonPath( 'data.0.slug', 'header' )
+		->assertJsonPath( 'data.0.type', 'wp_template_part' )
+		->assertJsonPath( 'data.0.area', 'header' )
+		->assertJsonPath( 'data.0.title.rendered', 'Header' )
+		->assertJsonPath( 'data.1.slug', 'footer' )
+		->assertJsonPath( 'data.1.area', 'footer' );
+} );
+
+it( 'filters the index by slug, theme, and area', function () {
+	actingAsTemplatePartUser();
+
+	createTemplatePart( [ 'slug' => 'header', 'theme' => 'theme-a', 'area' => 'header' ] );
+	createTemplatePart( [ 'slug' => 'header', 'theme' => 'theme-b', 'area' => 'header' ] );
+	createTemplatePart( [ 'slug' => 'footer', 'theme' => 'theme-a', 'area' => 'footer' ] );
+
+	$this->getJson( '/visual-editor/api/template-parts?theme=theme-a' )
+		->assertOk()
+		->assertJsonCount( 2, 'data' );
+
+	$this->getJson( '/visual-editor/api/template-parts?slug=header&theme=theme-b' )
+		->assertOk()
+		->assertJsonCount( 1, 'data' )
+		->assertJsonPath( 'data.0.theme', 'theme-b' );
+
+	$this->getJson( '/visual-editor/api/template-parts?area=footer' )
+		->assertOk()
+		->assertJsonCount( 1, 'data' )
+		->assertJsonPath( 'data.0.slug', 'footer' );
+} );
+
+it( 'returns 401 when unauthenticated on show', function () {
+	$part = createTemplatePart();
+
+	$this->getJson( "/visual-editor/api/template-parts/{$part->id}" )->assertUnauthorized();
+} );
+
+it( 'returns the content envelope and rendered title on show', function () {
+	actingAsTemplatePartUser();
+
+	$part = createTemplatePart();
+
+	$this->getJson( "/visual-editor/api/template-parts/{$part->id}" )
+		->assertOk()
+		->assertJsonPath( 'id', $part->id )
+		->assertJsonPath( 'slug', 'header' )
+		->assertJsonPath( 'type', 'wp_template_part' )
+		->assertJsonPath( 'area', 'header' )
+		->assertJsonPath( 'title.rendered', 'Header' )
+		->assertJsonPath( 'content.raw', '<!-- wp:site-title /-->' )
+		->assertJsonPath( 'content.blocks.0.name', 'core/site-title' )
+		->assertJsonPath( 'referenced_by', [] );
+} );
+
+it( 'returns 404 when the template part id does not exist', function () {
+	actingAsTemplatePartUser();
+
+	$this->getJson( '/visual-editor/api/template-parts/999' )->assertNotFound();
+} );
+
+it( 'lists referencing template slugs in referenced_by', function () {
+	actingAsTemplatePartUser();
+
+	$part = createTemplatePart( [ 'slug' => 'header', 'theme' => 'artisanpack-base' ] );
+
+	createTemplateEmbeddingPart( 'single', 'header', 'artisanpack-base' );
+	createTemplateEmbeddingPart( 'page', 'header', 'artisanpack-base' );
+
+	// Unrelated template — references a different part.
+	createTemplateEmbeddingPart( 'archive', 'footer', 'artisanpack-base' );
+
+	// Same slug, different theme — should not match.
+	createTemplateEmbeddingPart( 'index', 'header', 'theme-b' );
+
+	$this->getJson( "/visual-editor/api/template-parts/{$part->id}" )
+		->assertOk()
+		->assertJsonPath( 'referenced_by', [ 'page', 'single' ] );
+} );
+
+it( 'detects references nested inside inner blocks', function () {
+	actingAsTemplatePartUser();
+
+	$part = createTemplatePart( [ 'slug' => 'header', 'theme' => 'artisanpack-base' ] );
+
+	VisualEditorTemplate::create( [
+		'slug'    => 'single',
+		'title'   => 'Single',
+		'content' => [
+			'raw'    => '',
+			'blocks' => [
+				[
+					'name'        => 'core/group',
+					'attributes'  => [ 'tagName' => 'div' ],
+					'innerBlocks' => [
+						[
+							'name'        => 'core/template-part',
+							'attributes'  => [ 'slug' => 'header', 'theme' => 'artisanpack-base' ],
+							'innerBlocks' => [],
+						],
+					],
+				],
+			],
+		],
+		'status'  => 'publish',
+		'theme'   => 'artisanpack-base',
+		'source'  => 'theme',
+		'origin'  => 'theme',
+	] );
+
+	$this->getJson( "/visual-editor/api/template-parts/{$part->id}" )
+		->assertOk()
+		->assertJsonPath( 'referenced_by', [ 'single' ] );
+} );
+
+it( 'deduplicates referenced_by when a template embeds the part twice', function () {
+	actingAsTemplatePartUser();
+
+	$part = createTemplatePart( [ 'slug' => 'header', 'theme' => 'artisanpack-base' ] );
+
+	VisualEditorTemplate::create( [
+		'slug'    => 'single',
+		'title'   => 'Single',
+		'content' => [
+			'raw'    => '',
+			'blocks' => [
+				[
+					'name'        => 'core/template-part',
+					'attributes'  => [ 'slug' => 'header', 'theme' => 'artisanpack-base' ],
+					'innerBlocks' => [],
+				],
+				[
+					'name'        => 'core/template-part',
+					'attributes'  => [ 'slug' => 'header', 'theme' => 'artisanpack-base' ],
+					'innerBlocks' => [],
+				],
+			],
+		],
+		'status'  => 'publish',
+		'theme'   => 'artisanpack-base',
+		'source'  => 'theme',
+		'origin'  => 'theme',
+	] );
+
+	$this->getJson( "/visual-editor/api/template-parts/{$part->id}" )
+		->assertOk()
+		->assertJsonPath( 'referenced_by', [ 'single' ] );
+} );
+
+it( 'creates a template part with a 201 Created response for each valid area', function ( string $area ) {
+	actingAsTemplatePartUser();
+
+	$payload = [
+		'slug'    => "my-{$area}",
+		'title'   => ucfirst( $area ),
+		'content' => [
+			'raw'    => '<!-- wp:site-title /-->',
+			'blocks' => [
+				[
+					'name'        => 'core/site-title',
+					'attributes'  => new stdClass(),
+					'innerBlocks' => [],
+				],
+			],
+		],
+		'area'    => $area,
+		'theme'   => 'artisanpack-base',
+	];
+
+	$this->postJson( '/visual-editor/api/template-parts', $payload )
+		->assertCreated()
+		->assertJsonPath( 'slug', "my-{$area}" )
+		->assertJsonPath( 'area', $area )
+		->assertJsonPath( 'content.raw', '<!-- wp:site-title /-->' )
+		->assertJsonPath( 'content.blocks.0.name', 'core/site-title' );
+
+	expect( VisualEditorTemplatePart::where( 'slug', "my-{$area}" )->first() )
+		->not->toBeNull()
+		->area->toBe( $area );
+} )->with( [ 'header', 'footer', 'sidebar', 'uncategorized' ] );
+
+it( 'rejects store with an invalid area', function () {
+	actingAsTemplatePartUser();
+
+	$response = $this->postJson( '/visual-editor/api/template-parts', [
+		'slug'  => 'header',
+		'theme' => 'artisanpack-base',
+		'area'  => 'banner',
+	] )
+		->assertUnprocessable()
+		->assertJsonValidationErrors( 'area' );
+
+	expect( $response->json( 'errors.area.0' ) )
+		->toContain( 'header' )
+		->toContain( 'footer' )
+		->toContain( 'sidebar' )
+		->toContain( 'uncategorized' );
+} );
+
+it( 'rejects store with a missing area', function () {
+	actingAsTemplatePartUser();
+
+	$this->postJson( '/visual-editor/api/template-parts', [
+		'slug'  => 'header',
+		'theme' => 'artisanpack-base',
+	] )
+		->assertUnprocessable()
+		->assertJsonValidationErrors( 'area' );
+} );
+
+it( 'rejects store when the (slug, theme) pair already exists', function () {
+	actingAsTemplatePartUser();
+
+	createTemplatePart( [ 'slug' => 'header', 'theme' => 'artisanpack-base' ] );
+
+	$this->postJson( '/visual-editor/api/template-parts', [
+		'slug'  => 'header',
+		'theme' => 'artisanpack-base',
+		'area'  => 'header',
+	] )
+		->assertUnprocessable()
+		->assertJsonValidationErrors( 'slug' );
+} );
+
+it( 'allows the same slug on different themes', function () {
+	actingAsTemplatePartUser();
+
+	createTemplatePart( [ 'slug' => 'header', 'theme' => 'theme-a' ] );
+
+	$this->postJson( '/visual-editor/api/template-parts', [
+		'slug'  => 'header',
+		'theme' => 'theme-b',
+		'area'  => 'header',
+		'title' => 'Header on Theme B',
+	] )->assertCreated();
+} );
+
+it( 'rejects store when the block tree is malformed', function () {
+	actingAsTemplatePartUser();
+
+	$this->postJson( '/visual-editor/api/template-parts', [
+		'slug'    => 'header',
+		'theme'   => 'artisanpack-base',
+		'area'    => 'header',
+		'content' => [
+			'raw'    => '',
+			'blocks' => [
+				[ 'not-a-block' => true ],
+			],
+		],
+	] )
+		->assertUnprocessable()
+		->assertJsonValidationErrors( 'content.blocks' );
+} );
+
+it( 'updates a template part with a partial payload', function () {
+	actingAsTemplatePartUser();
+
+	$part = createTemplatePart( [ 'title' => 'Before' ] );
+
+	$this->putJson( "/visual-editor/api/template-parts/{$part->id}", [
+		'title' => 'After',
+	] )
+		->assertOk()
+		->assertJsonPath( 'title.rendered', 'After' )
+		->assertJsonPath( 'slug', 'header' );
+
+	expect( $part->fresh()->title )->toBe( 'After' );
+} );
+
+it( 'rejects update with an invalid area', function () {
+	actingAsTemplatePartUser();
+
+	$part = createTemplatePart();
+
+	$this->putJson( "/visual-editor/api/template-parts/{$part->id}", [
+		'area' => 'banner',
+	] )
+		->assertUnprocessable()
+		->assertJsonValidationErrors( 'area' );
+
+	expect( $part->fresh()->area )->toBe( 'header' );
+} );
+
+it( 'updates the area with a valid enum value', function () {
+	actingAsTemplatePartUser();
+
+	$part = createTemplatePart( [ 'area' => 'uncategorized' ] );
+
+	$this->putJson( "/visual-editor/api/template-parts/{$part->id}", [
+		'area' => 'footer',
+	] )
+		->assertOk()
+		->assertJsonPath( 'area', 'footer' );
+
+	expect( $part->fresh()->area )->toBe( 'footer' );
+} );
+
+it( 'persists a new content envelope on update', function () {
+	actingAsTemplatePartUser();
+
+	$part = createTemplatePart();
+
+	$newContent = [
+		'raw'    => '<!-- wp:heading --><h1>Hi</h1><!-- /wp:heading -->',
+		'blocks' => [
+			[
+				'name'        => 'core/heading',
+				'attributes'  => [ 'level' => 1, 'content' => 'Hi' ],
+				'innerBlocks' => [],
+			],
+		],
+	];
+
+	$this->putJson( "/visual-editor/api/template-parts/{$part->id}", [
+		'content' => $newContent,
+	] )
+		->assertOk()
+		->assertJsonPath( 'content.raw', $newContent['raw'] )
+		->assertJsonPath( 'content.blocks.0.attributes.content', 'Hi' );
+
+	expect( $part->fresh()->getContentEnvelope() )->toEqual( $newContent );
+} );
+
+it( 'deletes a template part', function () {
+	actingAsTemplatePartUser();
+
+	$part = createTemplatePart();
+
+	$this->deleteJson( "/visual-editor/api/template-parts/{$part->id}" )
+		->assertNoContent();
+
+	expect( VisualEditorTemplatePart::find( $part->id ) )->toBeNull();
+} );
+
+it( 'round-trips the B2 fixture template parts through store + show', function () {
+	actingAsTemplatePartUser();
+
+	$fixturesDir = dirname( __DIR__, 2 ) . '/Fixtures/sample-content/template-parts';
+	$files       = glob( $fixturesDir . '/*.json' );
+
+	expect( $files )->not->toBeEmpty();
+
+	foreach ( $files as $file ) {
+		$fixture = json_decode( (string) file_get_contents( $file ), true, flags: JSON_THROW_ON_ERROR );
+
+		$payload = [
+			'slug'    => $fixture['slug'],
+			'title'   => $fixture['title']['rendered'] ?? '',
+			'content' => $fixture['content'] ?? [ 'raw' => '', 'blocks' => [] ],
+			'area'    => $fixture['area'],
+			'theme'   => $fixture['theme'],
+		];
+
+		$response = $this->postJson( '/visual-editor/api/template-parts', $payload )
+			->assertCreated()
+			->assertJsonPath( 'slug', $fixture['slug'] )
+			->assertJsonPath( 'area', $fixture['area'] )
+			->assertJsonPath( 'content.raw', $fixture['content']['raw'] );
+
+		$id = $response->json( 'id' );
+
+		$this->getJson( "/visual-editor/api/template-parts/{$id}" )
+			->assertOk()
+			->assertJsonPath( 'slug', $fixture['slug'] )
+			->assertJsonPath( 'content.blocks', $fixture['content']['blocks'] );
+	}
+} );
+
+it( 'rejects a null title on store (column is non-nullable)', function () {
+	actingAsTemplatePartUser();
+
+	$this->postJson( '/visual-editor/api/template-parts', [
+		'slug'  => 'header',
+		'theme' => 'artisanpack-base',
+		'area'  => 'header',
+		'title' => null,
+	] )
+		->assertUnprocessable()
+		->assertJsonValidationErrors( 'title' );
+} );
+
+it( 'rejects a null title on update (column is non-nullable)', function () {
+	actingAsTemplatePartUser();
+
+	$part = createTemplatePart();
+
+	$this->putJson( "/visual-editor/api/template-parts/{$part->id}", [
+		'title' => null,
+	] )
+		->assertUnprocessable()
+		->assertJsonValidationErrors( 'title' );
+
+	expect( $part->fresh()->title )->toBe( 'Header' );
+} );
+
+it( 'rejects a bare-list content payload on store', function () {
+	actingAsTemplatePartUser();
+
+	$this->postJson( '/visual-editor/api/template-parts', [
+		'slug'    => 'header',
+		'theme'   => 'artisanpack-base',
+		'area'    => 'header',
+		'content' => [
+			[
+				'name'        => 'core/paragraph',
+				'attributes'  => [],
+				'innerBlocks' => [],
+			],
+		],
+	] )
+		->assertUnprocessable()
+		->assertJsonValidationErrors( 'content' );
+} );
+
+it( 'rejects a bare-list content payload on update', function () {
+	actingAsTemplatePartUser();
+
+	$part = createTemplatePart();
+
+	$this->putJson( "/visual-editor/api/template-parts/{$part->id}", [
+		'content' => [
+			[
+				'name'        => 'core/paragraph',
+				'attributes'  => [],
+				'innerBlocks' => [],
+			],
+		],
+	] )
+		->assertUnprocessable()
+		->assertJsonValidationErrors( 'content' );
+} );
+
+it( 'rejects a theme-only update that would collide with an existing (slug, theme)', function () {
+	actingAsTemplatePartUser();
+
+	// Existing record we will try to update into a colliding (slug, theme).
+	$editing = createTemplatePart( [ 'slug' => 'header', 'theme' => 'theme-a' ] );
+
+	// The collision target.
+	createTemplatePart( [ 'slug' => 'header', 'theme' => 'theme-b' ] );
+
+	$this->putJson( "/visual-editor/api/template-parts/{$editing->id}", [
+		'theme' => 'theme-b',
+	] )
+		->assertUnprocessable()
+		->assertJsonValidationErrors( 'theme' );
+
+	expect( $editing->fresh()->theme )->toBe( 'theme-a' );
+} );
+
+it( 'rejects unauthenticated store, update, and destroy', function () {
+	$part = createTemplatePart();
+
+	$this->postJson( '/visual-editor/api/template-parts', [
+		'slug'  => 'new-header',
+		'theme' => 'artisanpack-base',
+		'area'  => 'header',
+	] )->assertUnauthorized();
+
+	$this->putJson( "/visual-editor/api/template-parts/{$part->id}", [
+		'title' => 'Nope',
+	] )->assertUnauthorized();
+
+	$this->deleteJson( "/visual-editor/api/template-parts/{$part->id}" )->assertUnauthorized();
+} );

--- a/tests/Feature/VisualEditor/TemplatePartControllerTest.php
+++ b/tests/Feature/VisualEditor/TemplatePartControllerTest.php
@@ -198,6 +198,38 @@ it( 'detects references nested inside inner blocks', function () {
 		->assertJsonPath( 'referenced_by', [ 'single' ] );
 } );
 
+it( 'counts an untagged template-part block as a same-theme reference', function () {
+	actingAsTemplatePartUser();
+
+	$part = createTemplatePart( [ 'slug' => 'header', 'theme' => 'artisanpack-base' ] );
+
+	// Older export — `core/template-part` block references the slug but
+	// omits the `theme` attribute. Since the containing template is
+	// already in `artisanpack-base`, the reference resolves there.
+	VisualEditorTemplate::create( [
+		'slug'    => 'single',
+		'title'   => 'Single',
+		'content' => [
+			'raw'    => '',
+			'blocks' => [
+				[
+					'name'        => 'core/template-part',
+					'attributes'  => [ 'slug' => 'header' ],
+					'innerBlocks' => [],
+				],
+			],
+		],
+		'status'  => 'publish',
+		'theme'   => 'artisanpack-base',
+		'source'  => 'theme',
+		'origin'  => 'theme',
+	] );
+
+	$this->getJson( "/visual-editor/api/template-parts/{$part->id}" )
+		->assertOk()
+		->assertJsonPath( 'referenced_by', [ 'single' ] );
+} );
+
 it( 'deduplicates referenced_by when a template embeds the part twice', function () {
 	actingAsTemplatePartUser();
 


### PR DESCRIPTION
## Description

Lands the server-side backing for the `wp_template_part` entity the B1 core-data shim dispatches at `/visual-editor/api/template-parts`. Adds the `VisualEditorTemplatePart` model, migration, REST controller, form requests, policy, and routes so the D2 site-editor browser and the E2 front-end template-part renderer have a real store to resolve against.

**Closes:** #358

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #358

## Motivation and Context

Template parts are reusable fragments of a template — `header`, `footer`, `sidebar`, etc. — referenced from templates via `core/template-part` blocks. B1 stubbed out the REST contract and B2 shipped fixtures demonstrating the shape; C2 makes those calls resolve against real data.

Because a single part can be used by several templates (the B2 `header.json` + `footer.json` are referenced by every template fixture), the `show` response carries a `referenced_by` pointer listing the template slugs that currently include it. That lets D2 warn before deleting a part still in use.

## Changes Made

- `VisualEditorTemplatePart` Eloquent model with the `{ raw, blocks }` content envelope accessors and `area` / `theme` / `slug` scopes, mirroring `VisualEditorTemplate` so block renderers can consume either surface without translation.
- Migration for `visual_editor_template_parts` (`id`, `slug`, `title`, `content` JSON, `area`, `theme`, timestamps) with composite unique `(slug, theme)`.
- `TemplatePartController` with `index`, `show`, `store`, `update`, `destroy`. `show` merges a derived `referenced_by` list — computed by recursively scanning block trees of templates in the same theme for `core/template-part` blocks whose `slug` + `theme` match the current part.
- `StoreTemplatePartRequest` + `UpdateTemplatePartRequest` — area validated against the enum, `slug` unique per theme (mirrored on both slug + theme fields so theme-only updates still trigger the check), bare-list `content` payloads rejected to keep `TemplateBlockTreeRule` reachable.
- `TemplatePartResource` emitting the shim-compatible `{ id, slug, title.rendered, content.{raw,blocks}, area, theme, type }` shape.
- `VisualEditorTemplatePartPolicy` — auth-only CRUD, mirroring `VisualEditorTemplatePolicy`. Host apps tighten access by rebinding the policy.
- 5 routes registered under `/visual-editor/api/template-parts` with the package's existing auth middleware stack.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (Darwin 25.3.0)
- PHP Version: 8.4.3
- Project Version: 1.0.0-alpha.x (release/1.0)

**Tests Performed:**
1. Full Pest suite: **252 tests pass** (31 new, 221 existing — nothing regressed).
2. Targeted: `./vendor/bin/pest tests/Feature/VisualEditor/TemplatePartControllerTest.php` — 31/31 green.
3. CodeRabbit local review (`cr review --base release/1.0 --prompt-only`): No findings.

## Accessibility Tests Run

- [x] Not applicable — backend REST surface, no UI introduced in this PR.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:**

`tests/Feature/VisualEditor/TemplatePartControllerTest.php` (31 tests, 144 assertions):

- index: unauthenticated 401, empty `{ data, meta }` envelope, populated list, filters by `slug` / `theme` / `area`.
- show: unauthenticated 401, record with content envelope + rendered title, 404 on missing id.
- `referenced_by`: correctly lists referencing templates; ignores parts in other themes; traverses nested `innerBlocks`; deduplicates when a template embeds a part twice.
- store: all four valid areas (`header`, `footer`, `sidebar`, `uncategorized`) — dataset-driven; 422 on invalid/missing area with a message that names every legal value; 422 on duplicate `(slug, theme)`; success on same slug across themes; 422 on malformed block tree; 422 on null title.
- update: partial payload, area enum validation, area update, content-envelope persistence, 422 on theme-only change that would collide with an existing `(slug, theme)`, 422 on null title, 422 on bare-list content.
- destroy: happy path + unauthenticated 401.
- B2 round-trip: header/footer/sidebar fixtures post through `store` and come back unchanged from `show`.

## Documentation

- [x] Inline code documentation added

**Documentation details:** Every new class carries a PHPDoc block explaining its role and, where relevant, the design decisions (why `referenced_by` is derived rather than persisted, why `area` is a plain string column gated by application-layer validation, why uniqueness is mirrored on both slug + theme in the update request).

The B1 core-data shim contract at `docs/core-data-shim.md` §Template parts already documented the endpoint shape, so no doc changes are needed.

## Screenshots

N/A — backend change.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted (CodeRabbit: no findings)
- [x] Accessibility tests completed (N/A — backend)
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added REST API for managing template parts with full CRUD, filtering by theme/slug/area, and authenticated access.
  * Persisted template parts via a new database table and model with normalized content envelope and uniqueness per (slug, theme).
  * Automatic reference tracking for template-part usage and a JSON resource shape matching expected responses.
* **Tests**
  * Comprehensive feature tests covering auth, listing/filtering, CRUD, validation, reference resolution, and fixture round-trips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->