### PR TITLE
feat: C3 · Global styles model, migration, API, schema pin

### DIFF
--- a/config/visual-editor.php
+++ b/config/visual-editor.php
@@ -189,4 +189,27 @@ return [
 		'fixtures_path' => null,
 	],
 
+	/*
+	|--------------------------------------------------------------------------
+	| Global styles
+	|--------------------------------------------------------------------------
+	|
+	| Configures the `globalStyles` entity the site editor customizes.
+	| `theme` scopes the singleton lookup — each installed theme gets its
+	| own global-styles record. `schema_version` pins the theme.json
+	| schema the package accepts on `PUT` requests; see
+	| `docs/global-styles.md` for the contract and how we handle future
+	| upgrades. `base_path` is an absolute path to the PHP file returning
+	| the default `base` payload (the theme.json defaults the site-editor
+	| compares user overrides against); leave null to use the package's
+	| bundled defaults.
+	|
+	*/
+
+	'global_styles' => [
+		'theme'          => 'artisanpack-base',
+		'schema_version' => 3,
+		'base_path'      => null,
+	],
+
 ];

--- a/database/migrations/2026_04_23_200000_create_visual_editor_global_styles_table.php
+++ b/database/migrations/2026_04_23_200000_create_visual_editor_global_styles_table.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * Create visual_editor_global_styles table migration.
+ *
+ * Storage for the `globalStyles` singleton the B1 core-data shim
+ * addresses at `/visual-editor/api/global-styles`. The record is a
+ * theme.json-shaped blob — `version`, `settings`, `styles` — scoped by
+ * `theme` so a host app swapping themes does not bleed one site's
+ * customizations into another. See `docs/global-styles.md` for the
+ * pinned schema version and `docs/core-data-shim.md` §Global styles for
+ * the API contract.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+	public function up(): void
+	{
+		Schema::create( 'visual_editor_global_styles', function ( Blueprint $table ) {
+			$table->id();
+			// Pinned theme.json schema version — a data value, not a code
+			// constant. The supported version is documented in
+			// `docs/global-styles.md` and enforced by the update
+			// form-request against the config value.
+			$table->unsignedSmallInteger( 'version' )->default( 3 );
+			// `settings` holds palettes, typography presets, layout sizes.
+			$table->json( 'settings' );
+			// `styles` holds resolved CSS values per element / per block.
+			$table->json( 'styles' );
+			// Multi-theme hook: each installed theme gets its own
+			// singleton. Uniqueness on `theme` enforces the singleton
+			// invariant at the DB level.
+			$table->string( 'theme' )->unique();
+			$table->timestamps();
+		} );
+	}
+
+	public function down(): void
+	{
+		Schema::dropIfExists( 'visual_editor_global_styles' );
+	}
+};

--- a/docs/global-styles.md
+++ b/docs/global-styles.md
@@ -1,0 +1,127 @@
+# Global styles — theme.json schema pin
+
+The visual editor's `globalStyles` singleton is the theme.json-shaped
+record the site editor reads and writes. C3 (#359) introduces the
+backend: a `VisualEditorGlobalStyles` model, migration, REST endpoints,
+validated write path, and policy. This document records the **schema
+version we pin the package to**, the constraints that follow from that
+decision, and how a future version bump is handled.
+
+## Pinned version
+
+The package pins to **theme.json schema version 3**. The value lives in
+config at `artisanpack.visual-editor.global_styles.schema_version` (not
+as a hard-coded constant in code) so host apps can override if they
+know what they are doing; the default is what the package is tested
+against.
+
+The pin tracks the `@wordpress/*` packages vendored into the editor
+bundle (see `package.json` — `@wordpress/block-editor`,
+`@wordpress/block-library`, `@wordpress/components`, etc.). These
+packages target a specific WordPress core release series; the
+corresponding theme.json schema version is the one the package treats
+as "compatible". Updating the pinned `@wordpress/*` versions without a
+conscious theme.json review is what §4.2 of the V1 plan calls out as
+silent drift — the pin is here to force the review.
+
+## Record shape
+
+The record stores a theme.json-shaped blob:
+
+```json
+{
+  "id": 7,
+  "version": 3,
+  "settings": {
+    "color":      { "palette": [ /* { slug, name, color } */ ] },
+    "typography": {
+      "fontFamilies": [ /* { slug, name, fontFamily } */ ],
+      "fontSizes":    [ /* { slug, name, size } */ ]
+    },
+    "layout":     { "contentSize": "720px", "wideSize": "1120px" }
+  },
+  "styles": {
+    "color":      { "background": "...", "text": "..." },
+    "typography": { "fontFamily": "...", "fontSize": "...", "lineHeight": "..." },
+    "elements":   { "link": { /* ... */ }, "heading": { /* ... */ } },
+    "blocks":     { "core/button": { /* ... */ } }
+  }
+}
+```
+
+The full reference payload lives at
+`resources/theme-json/default-base.php` and is returned by
+`GET /visual-editor/api/global-styles/base`.
+
+## Endpoints
+
+See `docs/core-data-shim.md` §Global styles for the REST contract the
+core-data shim addresses. C3 ships four endpoints:
+
+- `GET /visual-editor/api/global-styles/lookup` — resolves the active
+  theme's singleton id (creating the row on first access).
+- `GET /visual-editor/api/global-styles/{id}` — user record.
+- `PUT /visual-editor/api/global-styles/{id}` — write user record;
+  validated against the pinned schema version.
+- `GET /visual-editor/api/global-styles/base` — theme defaults; the
+  site-editor diffs the user record against this to show what has been
+  customized.
+
+## Validation
+
+`PUT` requests flow through
+`ArtisanPackUI\VisualEditor\Http\Requests\UpdateGlobalStylesRequest` which
+enforces:
+
+- `version` must equal the pinned `schema_version` — a schema bump is
+  explicit work, not a client-driven drift.
+- `settings` and `styles` are required arrays.
+- `settings.color.palette` entries must each carry `slug`, `name`,
+  `color`; slugs must be unique across the palette (duplicate slugs
+  collapse to a single CSS variable, masking a real bug).
+- `settings.typography.fontFamilies` and `settings.typography.fontSizes`
+  likewise require unique slugs.
+
+A 422 response with a `version`, `settings`, or
+`settings.color.palette` validation error is the signal that the
+payload does not match the pinned schema.
+
+## Multi-theme scoping
+
+The record carries a `theme` column so each installed theme gets its
+own singleton. The active theme is configured at
+`artisanpack.visual-editor.global_styles.theme` (default
+`artisanpack-base`). Switching themes gets a fresh singleton rather
+than inheriting the previous theme's customizations.
+
+## Handling a future schema bump
+
+When the `@wordpress/*` pins are upgraded and the upstream theme.json
+schema changes:
+
+1. Review the upstream changelog for schema-version bumps (theme.json
+   `version` field, new top-level keys, removed keys).
+2. If the bump is material, update
+   `artisanpack.visual-editor.global_styles.schema_version` to the new
+   version in the package's default config.
+3. Update `resources/theme-json/default-base.php` so the defaults match
+   the new schema.
+4. Ship a migration that either rewrites existing user records into the
+   new schema shape or documents an upgrade path for host apps that
+   have customized their global styles.
+5. Update this doc with the new pinned version and the WP core release
+   it tracks.
+
+The point of the pin is that each of these steps is a conscious
+decision — not a silent change that happens the next time `composer
+update` or `npm update` runs.
+
+## Out of scope for C3
+
+- CSS emission / frontend rendering — **E1** (front-end global-styles
+  CSS emission).
+- Site-editor global-styles UI (typography, colors, layout, blocks,
+  variations) — **D3**.
+- Style variations (theme-level presets) — deferred; §8 of the plan doc
+  tracks this as an open question for 1.1.
+- Revision history of global-styles edits.

--- a/resources/theme-json/default-base.php
+++ b/resources/theme-json/default-base.php
@@ -4,7 +4,7 @@
  * Default `base` global-styles payload.
  *
  * Returned by `GET /visual-editor/api/global-styles/base` when the host
- * app has not overridden `artisanpack.visual-editor.global_styles.base`
+ * app has not overridden `artisanpack.visual-editor.global_styles.base_path`
  * in config. The shape mirrors theme.json as of the pinned schema
  * version documented in `docs/global-styles.md`. The B2 global-styles
  * fixture (`tests/Fixtures/sample-content/global-styles/default.json`)

--- a/resources/theme-json/default-base.php
+++ b/resources/theme-json/default-base.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * Default `base` global-styles payload.
+ *
+ * Returned by `GET /visual-editor/api/global-styles/base` when the host
+ * app has not overridden `artisanpack.visual-editor.global_styles.base`
+ * in config. The shape mirrors theme.json as of the pinned schema
+ * version documented in `docs/global-styles.md`. The B2 global-styles
+ * fixture (`tests/Fixtures/sample-content/global-styles/default.json`)
+ * is kept in sync with this payload so shim round-trips exercise the
+ * real defaults.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+return [
+	'version'  => 3,
+	'settings' => [
+		'color'      => [
+			'palette' => [
+				[ 'slug' => 'primary', 'name' => 'Primary', 'color' => '#3b82f6' ],
+				[ 'slug' => 'secondary', 'name' => 'Secondary', 'color' => '#6366f1' ],
+				[ 'slug' => 'accent', 'name' => 'Accent', 'color' => '#10b981' ],
+				[ 'slug' => 'base', 'name' => 'Base', 'color' => '#ffffff' ],
+				[ 'slug' => 'contrast', 'name' => 'Contrast', 'color' => '#111827' ],
+			],
+		],
+		'typography' => [
+			'fontFamilies' => [
+				[
+					'slug'       => 'sans',
+					'name'       => 'Sans',
+					'fontFamily' => "'Inter', system-ui, sans-serif",
+				],
+				[
+					'slug'       => 'serif',
+					'name'       => 'Serif',
+					'fontFamily' => "'Source Serif 4', Georgia, serif",
+				],
+			],
+			'fontSizes'    => [
+				[ 'slug' => 'small', 'name' => 'Small', 'size' => '0.875rem' ],
+				[ 'slug' => 'medium', 'name' => 'Medium', 'size' => '1rem' ],
+				[ 'slug' => 'large', 'name' => 'Large', 'size' => '1.25rem' ],
+				[ 'slug' => 'x-large', 'name' => 'Extra Large', 'size' => '1.75rem' ],
+			],
+		],
+		'layout'     => [
+			'contentSize' => '720px',
+			'wideSize'    => '1120px',
+		],
+	],
+	'styles'   => [
+		'color'      => [
+			'background' => 'var(--wp--preset--color--base)',
+			'text'       => 'var(--wp--preset--color--contrast)',
+		],
+		'typography' => [
+			'fontFamily' => 'var(--wp--preset--font-family--sans)',
+			'fontSize'   => 'var(--wp--preset--font-size--medium)',
+			'lineHeight' => '1.6',
+		],
+		'elements'   => [
+			'link'    => [
+				'color' => [ 'text' => 'var(--wp--preset--color--primary)' ],
+			],
+			'heading' => [
+				'typography' => [
+					'fontFamily' => 'var(--wp--preset--font-family--serif)',
+					'fontWeight' => '600',
+				],
+			],
+		],
+		'blocks'     => [
+			'core/button' => [
+				'color'  => [
+					'background' => 'var(--wp--preset--color--primary)',
+					'text'       => 'var(--wp--preset--color--base)',
+				],
+				'border' => [ 'radius' => '0.5rem' ],
+			],
+		],
+	],
+];

--- a/routes/api.php
+++ b/routes/api.php
@@ -18,6 +18,7 @@
 declare( strict_types=1 );
 
 use ArtisanPackUI\VisualEditor\Http\Controllers\BlockPreviewController;
+use ArtisanPackUI\VisualEditor\Http\Controllers\GlobalStylesController;
 use ArtisanPackUI\VisualEditor\Http\Controllers\ResourceContentController;
 use ArtisanPackUI\VisualEditor\Http\Controllers\TemplateController;
 use ArtisanPackUI\VisualEditor\Http\Controllers\TemplatePartController;
@@ -72,6 +73,22 @@ Route::put( 'template-parts/{templatePart}', [ TemplatePartController::class, 'u
 
 Route::delete( 'template-parts/{templatePart}', [ TemplatePartController::class, 'destroy' ] )
 	->name( 'visual-editor.api.template-parts.destroy' );
+
+// C3 `globalStyles` REST surface — see docs/core-data-shim.md §Global styles.
+// Order matters: the static `lookup` and `base` routes must be declared
+// before `{globalStyle}` so they are not swallowed by the wildcard
+// model-binding segment.
+Route::get( 'global-styles/lookup', [ GlobalStylesController::class, 'lookup' ] )
+	->name( 'visual-editor.api.global-styles.lookup' );
+
+Route::get( 'global-styles/base', [ GlobalStylesController::class, 'base' ] )
+	->name( 'visual-editor.api.global-styles.base' );
+
+Route::get( 'global-styles/{globalStyle}', [ GlobalStylesController::class, 'show' ] )
+	->name( 'visual-editor.api.global-styles.show' );
+
+Route::put( 'global-styles/{globalStyle}', [ GlobalStylesController::class, 'update' ] )
+	->name( 'visual-editor.api.global-styles.update' );
 
 // Legacy ve_contents routes retained for the existing editor tests and the
 // `VisualEditorPost` model. Deprecated in M3 in favor of the resource routes

--- a/src/Http/Controllers/GlobalStylesController.php
+++ b/src/Http/Controllers/GlobalStylesController.php
@@ -1,0 +1,166 @@
+<?php
+
+/**
+ * GlobalStyles controller.
+ *
+ * Serves the REST surface for the `globalStyles` singleton behind the
+ * B1 core-data shim (see `docs/core-data-shim.md` §Global styles). Four
+ * endpoints — lookup, show, update, base — mount under
+ * `/visual-editor/api/global-styles` via the package's auth-gated API
+ * group.
+ *
+ * `lookup` resolves (or creates) the singleton record for the active
+ * theme and returns just its id; it is what the D3 site-editor
+ * bootstrap dispatches to `receiveCurrentGlobalStylesId`. `base`
+ * returns the theme's default theme.json-shaped payload so the
+ * site-editor can diff the user's record against it to highlight
+ * customizations. `show` and `update` round-trip the user record
+ * itself.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Http\Controllers;
+
+use ArtisanPackUI\VisualEditor\Http\Requests\UpdateGlobalStylesRequest;
+use ArtisanPackUI\VisualEditor\Http\Resources\GlobalStylesResource;
+use ArtisanPackUI\VisualEditor\Models\VisualEditorGlobalStyles;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Gate;
+
+class GlobalStylesController extends Controller
+{
+	/**
+	 * Returns `{ "id": <int> }` for the active theme's singleton record.
+	 *
+	 * The shim dispatches this once at bootstrap. If no record exists
+	 * yet, one is created lazily with the package's default base
+	 * payload — the site-editor can then start reading / writing
+	 * immediately without a manual seeder step.
+	 *
+	 * @since 1.0.0
+	 */
+	public function lookup( Request $request ): JsonResponse
+	{
+		Gate::authorize( 'viewAny', VisualEditorGlobalStyles::class );
+
+		$record = VisualEditorGlobalStyles::resolveSingleton(
+			$this->activeTheme(),
+			$this->basePayload()
+		);
+
+		return response()->json( [ 'id' => $record->getKey() ] );
+	}
+
+	/**
+	 * Returns the user record. The shim expects the payload at the top
+	 * level (not wrapped in `data`) so `fetchEntityRecord` can dispatch
+	 * it straight into the cache.
+	 *
+	 * @since 1.0.0
+	 */
+	public function show( Request $request, VisualEditorGlobalStyles $globalStyle ): JsonResponse
+	{
+		Gate::authorize( 'view', $globalStyle );
+
+		return response()->json(
+			( new GlobalStylesResource( $globalStyle ) )->toArray( $request )
+		);
+	}
+
+	/**
+	 * Updates the user record with a validated theme.json payload.
+	 *
+	 * @since 1.0.0
+	 */
+	public function update( UpdateGlobalStylesRequest $request, VisualEditorGlobalStyles $globalStyle ): JsonResponse
+	{
+		Gate::authorize( 'update', $globalStyle );
+
+		// Validation has already run (request is type-hinted). We pull
+		// settings / styles from the raw input rather than from
+		// validated() because theme.json is extensible and the
+		// form-request only declares shape constraints for the keys we
+		// care about enforcing — calling validated() would silently
+		// drop any preset families or top-level keys the schema adds in
+		// a minor revision (e.g. settings.layout, settings.spacing).
+		$settings = $request->input( 'settings', [] );
+		$styles   = $request->input( 'styles', [] );
+
+		$globalStyle->fill( [
+			'version'  => (int) $request->input( 'version' ),
+			'settings' => is_array( $settings ) ? $settings : [],
+			'styles'   => is_array( $styles ) ? $styles : [],
+		] );
+		$globalStyle->save();
+
+		return response()->json(
+			( new GlobalStylesResource( $globalStyle ) )->toArray( $request )
+		);
+	}
+
+	/**
+	 * Returns the theme's default (unmodified) theme.json payload.
+	 *
+	 * The site-editor style UI (D3) dispatches this to
+	 * `receiveGlobalStylesBase` and compares it against the user
+	 * record to show "what has been customized".
+	 *
+	 * @since 1.0.0
+	 */
+	public function base( Request $request ): JsonResponse
+	{
+		Gate::authorize( 'viewAny', VisualEditorGlobalStyles::class );
+
+		return response()->json( $this->basePayload() );
+	}
+
+	/**
+	 * Returns the active theme slug used to scope the singleton.
+	 *
+	 * @since 1.0.0
+	 */
+	protected function activeTheme(): string
+	{
+		$theme = config( 'artisanpack.visual-editor.global_styles.theme', 'artisanpack-base' );
+
+		return is_string( $theme ) && '' !== $theme ? $theme : 'artisanpack-base';
+	}
+
+	/**
+	 * Loads the default base payload — host-app override if configured,
+	 * otherwise the package's bundled defaults.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<string, mixed>
+	 */
+	protected function basePayload(): array
+	{
+		$configured = config( 'artisanpack.visual-editor.global_styles.base_path' );
+		$path       = is_string( $configured ) && '' !== $configured
+			? $configured
+			: __DIR__ . '/../../../resources/theme-json/default-base.php';
+
+		if ( ! is_file( $path ) ) {
+			return [
+				'version'  => (int) config( 'artisanpack.visual-editor.global_styles.schema_version', 3 ),
+				'settings' => [],
+				'styles'   => [],
+			];
+		}
+
+		$payload = require $path;
+
+		return is_array( $payload ) ? $payload : [];
+	}
+}

--- a/src/Http/Requests/UpdateGlobalStylesRequest.php
+++ b/src/Http/Requests/UpdateGlobalStylesRequest.php
@@ -46,15 +46,21 @@ class UpdateGlobalStylesRequest extends FormRequest
 		);
 
 		return [
-			'version'                          => [ 'required', 'integer', Rule::in( [ $schemaVersion ] ) ],
-			'settings'                         => [ 'required', 'array' ],
-			'settings.color.palette'           => [ 'sometimes', 'array', $this->uniqueSlugRule( 'palette' ) ],
-			'settings.color.palette.*.slug'    => [ 'required_with:settings.color.palette', 'string' ],
-			'settings.color.palette.*.name'    => [ 'required_with:settings.color.palette', 'string' ],
-			'settings.color.palette.*.color'   => [ 'required_with:settings.color.palette', 'string' ],
-			'settings.typography.fontFamilies' => [ 'sometimes', 'array', $this->uniqueSlugRule( 'fontFamilies' ) ],
-			'settings.typography.fontSizes'    => [ 'sometimes', 'array', $this->uniqueSlugRule( 'fontSizes' ) ],
-			'styles'                           => [ 'required', 'array' ],
+			'version'                                      => [ 'required', 'integer', Rule::in( [ $schemaVersion ] ) ],
+			'settings'                                     => [ 'required', 'array' ],
+			'settings.color.palette'                       => [ 'sometimes', 'array', $this->uniqueSlugRule( 'palette' ) ],
+			'settings.color.palette.*.slug'                => [ 'required_with:settings.color.palette', 'string' ],
+			'settings.color.palette.*.name'                => [ 'required_with:settings.color.palette', 'string' ],
+			'settings.color.palette.*.color'               => [ 'required_with:settings.color.palette', 'string' ],
+			'settings.typography.fontFamilies'             => [ 'sometimes', 'array', $this->uniqueSlugRule( 'fontFamilies' ) ],
+			'settings.typography.fontFamilies.*.slug'      => [ 'required_with:settings.typography.fontFamilies', 'string' ],
+			'settings.typography.fontFamilies.*.name'      => [ 'required_with:settings.typography.fontFamilies', 'string' ],
+			'settings.typography.fontFamilies.*.fontFamily' => [ 'required_with:settings.typography.fontFamilies', 'string' ],
+			'settings.typography.fontSizes'                => [ 'sometimes', 'array', $this->uniqueSlugRule( 'fontSizes' ) ],
+			'settings.typography.fontSizes.*.slug'         => [ 'required_with:settings.typography.fontSizes', 'string' ],
+			'settings.typography.fontSizes.*.name'         => [ 'required_with:settings.typography.fontSizes', 'string' ],
+			'settings.typography.fontSizes.*.size'         => [ 'required_with:settings.typography.fontSizes', 'string' ],
+			'styles'                                       => [ 'required', 'array' ],
 		];
 	}
 

--- a/src/Http/Requests/UpdateGlobalStylesRequest.php
+++ b/src/Http/Requests/UpdateGlobalStylesRequest.php
@@ -1,0 +1,117 @@
+<?php
+
+/**
+ * UpdateGlobalStyles form request.
+ *
+ * Validates the payload for writing a user record through
+ * `PUT /visual-editor/api/global-styles/{id}`. The shape mirrors the
+ * pinned theme.json schema documented in `docs/global-styles.md` and
+ * enforced against `artisanpack.visual-editor.global_styles.schema_version`.
+ *
+ * The request rejects writes whose `version` does not match the pinned
+ * version — a schema bump is a conscious upgrade, not a silent drift on
+ * whatever value a client happened to send.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Http\Requests;
+
+use Closure;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateGlobalStylesRequest extends FormRequest
+{
+	public function authorize(): bool
+	{
+		return true;
+	}
+
+	/**
+	 * @return array<string, array<int, mixed>>
+	 */
+	public function rules(): array
+	{
+		$schemaVersion = (int) config(
+			'artisanpack.visual-editor.global_styles.schema_version',
+			3
+		);
+
+		return [
+			'version'                          => [ 'required', 'integer', Rule::in( [ $schemaVersion ] ) ],
+			'settings'                         => [ 'required', 'array' ],
+			'settings.color.palette'           => [ 'sometimes', 'array', $this->uniqueSlugRule( 'palette' ) ],
+			'settings.color.palette.*.slug'    => [ 'required_with:settings.color.palette', 'string' ],
+			'settings.color.palette.*.name'    => [ 'required_with:settings.color.palette', 'string' ],
+			'settings.color.palette.*.color'   => [ 'required_with:settings.color.palette', 'string' ],
+			'settings.typography.fontFamilies' => [ 'sometimes', 'array', $this->uniqueSlugRule( 'fontFamilies' ) ],
+			'settings.typography.fontSizes'    => [ 'sometimes', 'array', $this->uniqueSlugRule( 'fontSizes' ) ],
+			'styles'                           => [ 'required', 'array' ],
+		];
+	}
+
+	/**
+	 * @return array<string, string>
+	 */
+	public function messages(): array
+	{
+		$schemaVersion = (int) config(
+			'artisanpack.visual-editor.global_styles.schema_version',
+			3
+		);
+
+		return [
+			'version.in' => 'The version must match the pinned theme.json schema version (' . $schemaVersion . ').',
+		];
+	}
+
+	/**
+	 * Rejects a preset list whose entries share a `slug`.
+	 *
+	 * theme.json presets are addressed by slug (`var(--wp--preset--color--primary)`)
+	 * so two palette entries with the same slug would collapse into a
+	 * single CSS variable — the site-editor UI can't distinguish them.
+	 * We catch that here rather than letting the duplicate through and
+	 * surfacing a confusing downstream bug.
+	 *
+	 * @since 1.0.0
+	 */
+	protected function uniqueSlugRule( string $label ): Closure
+	{
+		return function ( string $attribute, mixed $value, Closure $fail ) use ( $label ): void {
+			if ( ! is_array( $value ) ) {
+				return;
+			}
+
+			$slugs = [];
+
+			foreach ( $value as $entry ) {
+				if ( ! is_array( $entry ) ) {
+					continue;
+				}
+
+				$slug = isset( $entry['slug'] ) && is_string( $entry['slug'] ) ? $entry['slug'] : null;
+
+				if ( null === $slug || '' === $slug ) {
+					continue;
+				}
+
+				if ( in_array( $slug, $slugs, true ) ) {
+					$fail( 'The ' . $label . ' presets must have unique slugs (duplicate: "' . $slug . '").' );
+
+					return;
+				}
+
+				$slugs[] = $slug;
+			}
+		};
+	}
+}

--- a/src/Http/Resources/GlobalStylesResource.php
+++ b/src/Http/Resources/GlobalStylesResource.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * GlobalStylesResource API resource.
+ *
+ * Shapes a {@see VisualEditorGlobalStyles} record into the B1 core-data
+ * shim's `globalStyles` envelope — `{ id, version, settings, styles }`.
+ * Keeps the HTTP response shape in one place so the controller's
+ * `show` and `update` paths do not reconstruct it by hand.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Http\Resources;
+
+use ArtisanPackUI\VisualEditor\Models\VisualEditorGlobalStyles;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @property VisualEditorGlobalStyles $resource
+ */
+class GlobalStylesResource extends JsonResource
+{
+	/**
+	 * Transforms the record into the shim-compatible envelope.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function toArray( Request $request ): array
+	{
+		/** @var VisualEditorGlobalStyles $record */
+		$record = $this->resource;
+
+		$settings = $record->settings;
+		$styles   = $record->styles;
+
+		return [
+			'id'       => $record->getKey(),
+			'version'  => (int) $record->version,
+			'settings' => is_array( $settings ) ? $settings : [],
+			'styles'   => is_array( $styles ) ? $styles : [],
+		];
+	}
+}

--- a/src/Models/VisualEditorGlobalStyles.php
+++ b/src/Models/VisualEditorGlobalStyles.php
@@ -1,0 +1,85 @@
+<?php
+
+/**
+ * VisualEditorGlobalStyles model.
+ *
+ * Singleton backing for the `globalStyles` entity exposed at
+ * `/visual-editor/api/global-styles`. Stores a theme.json-shaped
+ * `{ version, settings, styles }` blob — `settings` is the palette /
+ * typography / layout presets, `styles` is the resolved CSS values
+ * (page-level plus per-element and per-block overrides). The record is
+ * scoped by `theme` so the singleton invariant is per-theme, not
+ * per-site: a host app switching themes gets a separate record rather
+ * than silently inheriting a different theme's customizations.
+ *
+ * The `resolveSingleton()` helper is the single source of truth for
+ * "which record does `GET /lookup` return" — it reads the active theme
+ * from config, finds the matching row, and creates one seeded with the
+ * default `base` payload if it does not yet exist. This keeps the
+ * `lookup` endpoint idempotent without a manual seeder.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class VisualEditorGlobalStyles extends Model
+{
+	protected $table = 'visual_editor_global_styles';
+
+	/**
+	 * @var array<int, string>
+	 */
+	protected $fillable = [
+		'version',
+		'settings',
+		'styles',
+		'theme',
+	];
+
+	/**
+	 * @var array<string, string>
+	 */
+	protected $casts = [
+		'version'  => 'int',
+		'settings' => 'array',
+		'styles'   => 'array',
+	];
+
+	/**
+	 * Resolves (or creates) the singleton record for the given theme.
+	 *
+	 * The record is lazily created the first time it is requested so a
+	 * fresh install, a freshly migrated test database, or a new theme
+	 * all land on an endpoint that returns a real id instead of 404ing
+	 * into the site-editor bootstrap. The seed payload comes from the
+	 * package's default base (or the host app's override) so a brand
+	 * new site starts with the same defaults the `/base` endpoint
+	 * returns.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array<string, mixed>  $defaults  Seed payload for first-time creation.
+	 *                                          Must carry `version`, `settings`, `styles`.
+	 */
+	public static function resolveSingleton( string $theme, array $defaults ): self
+	{
+		return self::firstOrCreate(
+			[ 'theme' => $theme ],
+			[
+				'version'  => isset( $defaults['version'] ) ? (int) $defaults['version'] : 3,
+				'settings' => isset( $defaults['settings'] ) && is_array( $defaults['settings'] ) ? $defaults['settings'] : [],
+				'styles'   => isset( $defaults['styles'] ) && is_array( $defaults['styles'] ) ? $defaults['styles'] : [],
+			]
+		);
+	}
+}

--- a/src/Models/VisualEditorGlobalStyles.php
+++ b/src/Models/VisualEditorGlobalStyles.php
@@ -80,10 +80,15 @@ class VisualEditorGlobalStyles extends Model
 	 */
 	public static function resolveSingleton( string $theme, array $defaults ): self
 	{
+		// Fallback reads the pinned schema version from config so the
+		// model, controller, and form-request share a single source of
+		// truth — see `artisanpack.visual-editor.global_styles.schema_version`.
+		$schemaVersion = (int) config( 'artisanpack.visual-editor.global_styles.schema_version', 3 );
+
 		return self::firstOrCreate(
 			[ 'theme' => $theme ],
 			[
-				'version'  => isset( $defaults['version'] ) ? (int) $defaults['version'] : 3,
+				'version'  => isset( $defaults['version'] ) ? (int) $defaults['version'] : $schemaVersion,
 				'settings' => isset( $defaults['settings'] ) && is_array( $defaults['settings'] ) ? $defaults['settings'] : [],
 				'styles'   => isset( $defaults['styles'] ) && is_array( $defaults['styles'] ) ? $defaults['styles'] : [],
 			]

--- a/src/Models/VisualEditorGlobalStyles.php
+++ b/src/Models/VisualEditorGlobalStyles.php
@@ -66,6 +66,13 @@ class VisualEditorGlobalStyles extends Model
 	 * new site starts with the same defaults the `/base` endpoint
 	 * returns.
 	 *
+	 * The write path relies on Laravel's race-safe `firstOrCreate`
+	 * (which catches `UniqueConstraintViolationException` and re-queries
+	 * on conflict) plus the unique index on `theme` at the DB level. Two
+	 * concurrent cold-start `lookup` requests cannot both succeed with
+	 * different ids for the same theme — the loser's insert is converted
+	 * back into a read of the winner's row.
+	 *
 	 * @since 1.0.0
 	 *
 	 * @param  array<string, mixed>  $defaults  Seed payload for first-time creation.

--- a/src/Policies/VisualEditorGlobalStylesPolicy.php
+++ b/src/Policies/VisualEditorGlobalStylesPolicy.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * VisualEditorGlobalStyles policy.
+ *
+ * Authorization policy for the `globalStyles` REST endpoints. The V1
+ * default allows any authenticated user to read the singleton and
+ * write updates to it, mirroring how {@see VisualEditorTemplatePolicy}
+ * and {@see VisualEditorTemplatePartPolicy} gate the sibling entities;
+ * host apps that need tighter access (for example: restrict writes to
+ * site admins) should swap the binding in their own service provider.
+ *
+ * `globalStyles` is a singleton — there is no `create` or `delete`
+ * surface to gate. `viewAny` covers the instance-less endpoints
+ * (`lookup`, `base`); `view` covers `show`; `update` covers `PUT`.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Policies;
+
+use ArtisanPackUI\VisualEditor\Models\VisualEditorGlobalStyles;
+use Illuminate\Auth\Access\HandlesAuthorization;
+use Illuminate\Contracts\Auth\Authenticatable;
+
+class VisualEditorGlobalStylesPolicy
+{
+	use HandlesAuthorization;
+
+	public function viewAny( ?Authenticatable $user ): bool
+	{
+		return null !== $user;
+	}
+
+	public function view( ?Authenticatable $user, VisualEditorGlobalStyles $globalStyle ): bool
+	{
+		return null !== $user;
+	}
+
+	public function update( ?Authenticatable $user, VisualEditorGlobalStyles $globalStyle ): bool
+	{
+		return null !== $user;
+	}
+}

--- a/src/VisualEditorServiceProvider.php
+++ b/src/VisualEditorServiceProvider.php
@@ -4,9 +4,11 @@ namespace ArtisanPackUI\VisualEditor;
 
 use ArtisanPackUI\VisualEditor\Console\Commands\SeedSampleContentCommand;
 use ArtisanPackUI\VisualEditor\MediaBridge\GutenbergAttachmentAdapter;
+use ArtisanPackUI\VisualEditor\Models\VisualEditorGlobalStyles;
 use ArtisanPackUI\VisualEditor\Models\VisualEditorPost;
 use ArtisanPackUI\VisualEditor\Models\VisualEditorTemplate;
 use ArtisanPackUI\VisualEditor\Models\VisualEditorTemplatePart;
+use ArtisanPackUI\VisualEditor\Policies\VisualEditorGlobalStylesPolicy;
 use ArtisanPackUI\VisualEditor\Policies\VisualEditorPostPolicy;
 use ArtisanPackUI\VisualEditor\Policies\VisualEditorTemplatePolicy;
 use ArtisanPackUI\VisualEditor\Policies\VisualEditorTemplatePartPolicy;
@@ -88,6 +90,7 @@ class VisualEditorServiceProvider extends ServiceProvider
 		Gate::policy( VisualEditorPost::class, VisualEditorPostPolicy::class );
 		Gate::policy( VisualEditorTemplate::class, VisualEditorTemplatePolicy::class );
 		Gate::policy( VisualEditorTemplatePart::class, VisualEditorTemplatePartPolicy::class );
+		Gate::policy( VisualEditorGlobalStyles::class, VisualEditorGlobalStylesPolicy::class );
 
 		// 3. Register core blocks from their block.json manifests.
 		$this->registerCoreBlocks();

--- a/tests/Feature/VisualEditor/GlobalStylesControllerTest.php
+++ b/tests/Feature/VisualEditor/GlobalStylesControllerTest.php
@@ -1,0 +1,304 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Models\VisualEditorGlobalStyles;
+use Tests\TestUser;
+
+function validGlobalStylesPayload( array $overrides = [] ): array
+{
+	return array_replace_recursive( [
+		'version'  => 3,
+		'settings' => [
+			'color'      => [
+				'palette' => [
+					[ 'slug' => 'primary', 'name' => 'Primary', 'color' => '#3b82f6' ],
+					[ 'slug' => 'secondary', 'name' => 'Secondary', 'color' => '#6366f1' ],
+				],
+			],
+			'typography' => [
+				'fontSizes' => [
+					[ 'slug' => 'small', 'name' => 'Small', 'size' => '0.875rem' ],
+					[ 'slug' => 'medium', 'name' => 'Medium', 'size' => '1rem' ],
+				],
+			],
+		],
+		'styles'   => [
+			'color' => [ 'background' => '#ffffff' ],
+		],
+	], $overrides );
+}
+
+function actingAsGlobalStylesUser(): TestUser
+{
+	$user = TestUser::create( [
+		'name'     => 'Global Styles Tester',
+		'email'    => 'global-styles+' . uniqid() . '@example.com',
+		'password' => bcrypt( 'secret' ),
+	] );
+
+	test()->actingAs( $user );
+
+	return $user;
+}
+
+it( 'returns 401 when unauthenticated on lookup', function () {
+	$this->getJson( '/visual-editor/api/global-styles/lookup' )->assertUnauthorized();
+} );
+
+it( 'lookup resolves (or creates) the singleton and returns its id', function () {
+	actingAsGlobalStylesUser();
+
+	expect( VisualEditorGlobalStyles::count() )->toBe( 0 );
+
+	$response = $this->getJson( '/visual-editor/api/global-styles/lookup' )
+		->assertOk();
+
+	$id = $response->json( 'id' );
+
+	expect( $id )->toBeInt()
+		->and( VisualEditorGlobalStyles::count() )->toBe( 1 )
+		->and( VisualEditorGlobalStyles::find( $id )->theme )->toBe( 'artisanpack-base' );
+} );
+
+it( 'lookup is idempotent — repeat calls return the same id', function () {
+	actingAsGlobalStylesUser();
+
+	$first  = $this->getJson( '/visual-editor/api/global-styles/lookup' )->assertOk()->json( 'id' );
+	$second = $this->getJson( '/visual-editor/api/global-styles/lookup' )->assertOk()->json( 'id' );
+
+	expect( $first )->toBe( $second )
+		->and( VisualEditorGlobalStyles::count() )->toBe( 1 );
+} );
+
+it( 'lookup respects the configured active theme', function () {
+	actingAsGlobalStylesUser();
+
+	config()->set( 'artisanpack.visual-editor.global_styles.theme', 'custom-theme' );
+
+	$id = $this->getJson( '/visual-editor/api/global-styles/lookup' )->assertOk()->json( 'id' );
+
+	expect( VisualEditorGlobalStyles::find( $id )->theme )->toBe( 'custom-theme' );
+} );
+
+it( 'returns 401 when unauthenticated on show', function () {
+	$record = VisualEditorGlobalStyles::resolveSingleton( 'artisanpack-base', [
+		'version'  => 3,
+		'settings' => [],
+		'styles'   => [],
+	] );
+
+	$this->getJson( "/visual-editor/api/global-styles/{$record->id}" )->assertUnauthorized();
+} );
+
+it( 'returns the full record shape on show', function () {
+	actingAsGlobalStylesUser();
+
+	$record = VisualEditorGlobalStyles::resolveSingleton( 'artisanpack-base', [
+		'version'  => 3,
+		'settings' => [ 'color' => [ 'palette' => [ [ 'slug' => 'x', 'name' => 'X', 'color' => '#000' ] ] ] ],
+		'styles'   => [ 'color' => [ 'background' => '#fff' ] ],
+	] );
+
+	$this->getJson( "/visual-editor/api/global-styles/{$record->id}" )
+		->assertOk()
+		->assertJsonPath( 'id', $record->id )
+		->assertJsonPath( 'version', 3 )
+		->assertJsonPath( 'settings.color.palette.0.slug', 'x' )
+		->assertJsonPath( 'styles.color.background', '#fff' );
+} );
+
+it( 'returns 404 when the id does not exist on show', function () {
+	actingAsGlobalStylesUser();
+
+	$this->getJson( '/visual-editor/api/global-styles/999' )->assertNotFound();
+} );
+
+it( 'updates the record with a valid payload', function () {
+	actingAsGlobalStylesUser();
+
+	$id = $this->getJson( '/visual-editor/api/global-styles/lookup' )->json( 'id' );
+
+	$payload = validGlobalStylesPayload( [
+		'styles' => [ 'color' => [ 'background' => '#111111' ] ],
+	] );
+
+	$this->putJson( "/visual-editor/api/global-styles/{$id}", $payload )
+		->assertOk()
+		->assertJsonPath( 'id', $id )
+		->assertJsonPath( 'styles.color.background', '#111111' )
+		->assertJsonPath( 'settings.color.palette.0.slug', 'primary' );
+
+	expect( VisualEditorGlobalStyles::find( $id )->styles['color']['background'] )->toBe( '#111111' );
+} );
+
+it( 'rejects an update whose version does not match the pinned schema', function () {
+	actingAsGlobalStylesUser();
+
+	$id = $this->getJson( '/visual-editor/api/global-styles/lookup' )->json( 'id' );
+
+	$this->putJson( "/visual-editor/api/global-styles/{$id}", validGlobalStylesPayload( [ 'version' => 2 ] ) )
+		->assertUnprocessable()
+		->assertJsonValidationErrors( 'version' );
+} );
+
+it( 'rejects an update with a missing version', function () {
+	actingAsGlobalStylesUser();
+
+	$id      = $this->getJson( '/visual-editor/api/global-styles/lookup' )->json( 'id' );
+	$payload = validGlobalStylesPayload();
+	unset( $payload['version'] );
+
+	$this->putJson( "/visual-editor/api/global-styles/{$id}", $payload )
+		->assertUnprocessable()
+		->assertJsonValidationErrors( 'version' );
+} );
+
+it( 'rejects an update with missing settings or styles', function () {
+	actingAsGlobalStylesUser();
+
+	$id = $this->getJson( '/visual-editor/api/global-styles/lookup' )->json( 'id' );
+
+	$this->putJson( "/visual-editor/api/global-styles/{$id}", [
+		'version' => 3,
+		'styles'  => [],
+	] )
+		->assertUnprocessable()
+		->assertJsonValidationErrors( 'settings' );
+
+	$this->putJson( "/visual-editor/api/global-styles/{$id}", [
+		'version'  => 3,
+		'settings' => [],
+	] )
+		->assertUnprocessable()
+		->assertJsonValidationErrors( 'styles' );
+} );
+
+it( 'rejects an update with duplicate palette slugs', function () {
+	actingAsGlobalStylesUser();
+
+	$id = $this->getJson( '/visual-editor/api/global-styles/lookup' )->json( 'id' );
+
+	$payload = validGlobalStylesPayload( [
+		'settings' => [
+			'color' => [
+				'palette' => [
+					[ 'slug' => 'primary', 'name' => 'Primary', 'color' => '#3b82f6' ],
+					[ 'slug' => 'primary', 'name' => 'Primary Dup', 'color' => '#2563eb' ],
+				],
+			],
+		],
+	] );
+
+	$this->putJson( "/visual-editor/api/global-styles/{$id}", $payload )
+		->assertUnprocessable()
+		->assertJsonValidationErrors( 'settings.color.palette' );
+} );
+
+it( 'rejects an update with a malformed palette entry', function () {
+	actingAsGlobalStylesUser();
+
+	$id = $this->getJson( '/visual-editor/api/global-styles/lookup' )->json( 'id' );
+
+	// Build the payload from scratch — array_replace_recursive would
+	// merge the default palette entries' `color` key back onto the
+	// override, hiding the missing-field case we're trying to test.
+	$payload = [
+		'version'  => 3,
+		'settings' => [
+			'color' => [
+				'palette' => [
+					[ 'slug' => 'primary', 'name' => 'Primary' ],
+				],
+			],
+		],
+		'styles'   => [],
+	];
+
+	$this->putJson( "/visual-editor/api/global-styles/{$id}", $payload )
+		->assertUnprocessable()
+		->assertJsonValidationErrors( 'settings.color.palette.0.color' );
+} );
+
+it( 'returns 401 when unauthenticated on update', function () {
+	$record = VisualEditorGlobalStyles::resolveSingleton( 'artisanpack-base', [
+		'version'  => 3,
+		'settings' => [],
+		'styles'   => [],
+	] );
+
+	$this->putJson( "/visual-editor/api/global-styles/{$record->id}", validGlobalStylesPayload() )
+		->assertUnauthorized();
+} );
+
+it( 'returns 401 when unauthenticated on base', function () {
+	$this->getJson( '/visual-editor/api/global-styles/base' )->assertUnauthorized();
+} );
+
+it( 'returns a theme.json-shaped default payload on base', function () {
+	actingAsGlobalStylesUser();
+
+	$this->getJson( '/visual-editor/api/global-styles/base' )
+		->assertOk()
+		->assertJsonPath( 'version', 3 )
+		->assertJsonStructure( [
+			'version',
+			'settings' => [
+				'color'      => [ 'palette' ],
+				'typography' => [ 'fontFamilies', 'fontSizes' ],
+				'layout'     => [ 'contentSize', 'wideSize' ],
+			],
+			'styles'   => [ 'color', 'typography', 'elements', 'blocks' ],
+		] );
+} );
+
+it( 'base respects the base_path config override', function () {
+	actingAsGlobalStylesUser();
+
+	$override = tempnam( sys_get_temp_dir(), 'base-' ) . '.php';
+	file_put_contents( $override, '<?php return [ "version" => 3, "settings" => [ "custom" => true ], "styles" => [ "custom" => true ] ];' );
+
+	try {
+		config()->set( 'artisanpack.visual-editor.global_styles.base_path', $override );
+
+		$this->getJson( '/visual-editor/api/global-styles/base' )
+			->assertOk()
+			->assertJsonPath( 'settings.custom', true )
+			->assertJsonPath( 'styles.custom', true );
+	} finally {
+		@unlink( $override );
+	}
+} );
+
+it( 'round-trips the B2 global-styles fixture through show and update', function () {
+	actingAsGlobalStylesUser();
+
+	$fixturePath = dirname( __DIR__, 2 ) . '/Fixtures/sample-content/global-styles/default.json';
+	$fixture     = json_decode( (string) file_get_contents( $fixturePath ), true, flags: JSON_THROW_ON_ERROR );
+
+	expect( $fixture )->toBeArray();
+
+	$id = $this->getJson( '/visual-editor/api/global-styles/lookup' )->json( 'id' );
+
+	$payload = [
+		'version'  => $fixture['version'],
+		'settings' => $fixture['settings'],
+		'styles'   => $fixture['styles'],
+	];
+
+	// Use toEqual (value equality) rather than assertJsonPath, which
+	// uses assertSame and requires identical array key ordering — the
+	// shim treats settings/styles as opaque JSON blobs, so ordering is
+	// incidental to the contract.
+	$updateResponse = $this->putJson( "/visual-editor/api/global-styles/{$id}", $payload )
+		->assertOk()
+		->assertJsonPath( 'version', $fixture['version'] );
+
+	expect( $updateResponse->json( 'settings' ) )->toEqual( $fixture['settings'] )
+		->and( $updateResponse->json( 'styles' ) )->toEqual( $fixture['styles'] );
+
+	$showResponse = $this->getJson( "/visual-editor/api/global-styles/{$id}" )->assertOk();
+
+	expect( $showResponse->json( 'settings' ) )->toEqual( $fixture['settings'] )
+		->and( $showResponse->json( 'styles' ) )->toEqual( $fixture['styles'] );
+} );

--- a/tests/Feature/VisualEditor/GlobalStylesControllerTest.php
+++ b/tests/Feature/VisualEditor/GlobalStylesControllerTest.php
@@ -195,6 +195,50 @@ it( 'rejects an update with duplicate palette slugs', function () {
 		->assertJsonValidationErrors( 'settings.color.palette' );
 } );
 
+it( 'rejects an update with a malformed fontFamilies entry', function () {
+	actingAsGlobalStylesUser();
+
+	$id = $this->getJson( '/visual-editor/api/global-styles/lookup' )->json( 'id' );
+
+	$payload = [
+		'version'  => 3,
+		'settings' => [
+			'typography' => [
+				'fontFamilies' => [
+					[ 'slug' => 'sans', 'name' => 'Sans' ], // missing fontFamily
+				],
+			],
+		],
+		'styles'   => [],
+	];
+
+	$this->putJson( "/visual-editor/api/global-styles/{$id}", $payload )
+		->assertUnprocessable()
+		->assertJsonValidationErrors( 'settings.typography.fontFamilies.0.fontFamily' );
+} );
+
+it( 'rejects an update with a malformed fontSizes entry', function () {
+	actingAsGlobalStylesUser();
+
+	$id = $this->getJson( '/visual-editor/api/global-styles/lookup' )->json( 'id' );
+
+	$payload = [
+		'version'  => 3,
+		'settings' => [
+			'typography' => [
+				'fontSizes' => [
+					[ 'slug' => 'medium', 'name' => 'Medium' ], // missing size
+				],
+			],
+		],
+		'styles'   => [],
+	];
+
+	$this->putJson( "/visual-editor/api/global-styles/{$id}", $payload )
+		->assertUnprocessable()
+		->assertJsonValidationErrors( 'settings.typography.fontSizes.0.size' );
+} );
+
 it( 'rejects an update with a malformed palette entry', function () {
 	actingAsGlobalStylesUser();
 
@@ -255,7 +299,11 @@ it( 'returns a theme.json-shaped default payload on base', function () {
 it( 'base respects the base_path config override', function () {
 	actingAsGlobalStylesUser();
 
-	$override = tempnam( sys_get_temp_dir(), 'base-' ) . '.php';
+	// tempnam() creates the file at the path it returns; writing to
+	// that same path (no extension append) keeps us from leaking the
+	// stub file when the finally block runs. `require` in the
+	// controller does not care about the extension.
+	$override = tempnam( sys_get_temp_dir(), 'base-' );
 	file_put_contents( $override, '<?php return [ "version" => 3, "settings" => [ "custom" => true ], "styles" => [ "custom" => true ] ];' );
 
 	try {


### PR DESCRIPTION
## Description

Lands the server-side backing for the `globalStyles` singleton the B1 core-data shim (#353) addresses at `/visual-editor/api/global-styles`. The record is a theme.json-shaped `{ version, settings, styles }` blob, scoped by theme to support future multi-theme hosting. Four endpoints — `lookup`, `show`, `update`, `base` — unblock the D3 site-editor style UI and E1 front-end CSS emission.

**Closes:** #359

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #359

## Motivation and Context

The B1 core-data shim dispatches three endpoint patterns against `globalStyles` — `lookup`, CRUD on the singleton, and a separate `base` endpoint for the theme defaults the site-editor style UI diffs against. Phase C is the backend work that makes each entity's endpoints return real payloads; C3 is the global-styles slice.

Per §4.2 of the V1 plan doc, the theme.json schema is pinned to a specific version so upstream `@wordpress/*` bumps do not silently drift the schema. The pin is recorded as configurable data (`artisanpack.visual-editor.global_styles.schema_version`, default `3`) and enforced by the `PUT` form-request, not a hard-coded constant.

## Changes Made

- Migration `visual_editor_global_styles` (`version`, `settings`, `styles`, `theme` unique).
- `VisualEditorGlobalStyles` model with a `resolveSingleton($theme, $defaults)` helper that lazily seeds the singleton row on first lookup — no manual seeder needed.
- `GlobalStylesController` with `lookup`, `show`, `update`, `base` actions; routes declared so static segments (`lookup`, `base`) win over the wildcard model-binding segment.
- `UpdateGlobalStylesRequest` validates: pinned-version match, required `settings`/`styles`, palette entry shape, unique preset slugs across color/typography families.
- Controller persists the full `settings`/`styles` blob verbatim via `$request->input()` — using `validated()` would silently strip extensible theme.json keys (`layout`, `spacing`, etc.) that the form-request doesn't enforce shape on.
- Default base payload bundled at `resources/theme-json/default-base.php`; host apps can override via `artisanpack.visual-editor.global_styles.base_path`.
- `VisualEditorGlobalStylesPolicy` gates access (auth required on every endpoint).
- `docs/global-styles.md` documents the pinned v3 schema, what "compatible" means, and the steps for a future schema bump.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (Darwin 25.3.0)
- PHP Version: 8.4.3
- Project Version: `release/1.0`

**Tests Performed:**
1. Full Pest suite: `./vendor/bin/pest --compact` → **271 passed (822 assertions)**.
2. New test file: `./vendor/bin/pest tests/Feature/VisualEditor/GlobalStylesControllerTest.php` → **18 passed (72 assertions)**.
3. Manual verification by the issue author in the dev app (backend-only work — no visual surface yet; D3 wires the UI).

## Accessibility Tests Run

- [ ] Keyboard navigation tested
- [ ] Screen reader tested
- [ ] Color contrast verified
- [ ] ARIA labels checked

**Details:** Not applicable — backend REST endpoints, no UI surface. D3 (site-editor global-styles UI) will cover accessibility testing for the consumer of these endpoints.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:** 18 new Pest feature tests covering:
- `lookup` auth gate, idempotency, theme scoping
- `show` auth gate, full record shape, 404
- `update` auth gate, happy path, 422 on schema-version mismatch, missing `version`, missing `settings`/`styles`, duplicate palette slugs, malformed palette entry
- `base` auth gate, shape assertion, `base_path` config override
- B2 global-styles fixture (`tests/Fixtures/sample-content/global-styles/default.json`) round-trips through `PUT` + `GET` without reshaping

## Documentation

- [x] Inline code documentation added
- [x] API documentation updated

**Documentation details:** New `docs/global-styles.md` records the pinned schema version, the relationship to the vendored `@wordpress/*` packages, the validation constraints, the multi-theme scoping model, and an explicit upgrade checklist for future schema bumps. File-level and method-level PHPDoc blocks follow the same convention as the C1 / C2 siblings.

## Screenshots

Not applicable — backend-only work.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted (house style hand-verified against C2 patterns; package has no local linter wired up)
- [x] Accessibility tests completed (n/a, backend only)
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Global theme styles management with REST endpoints for lookup, retrieval, update, and base defaults; per-theme singleton persistence and pinned schema versioning.
  * Auth-guarded APIs and standardized JSON responses for global styles; configurable base payload source.

* **Documentation**
  * New guide describing payload shape, endpoints, validation rules, theme scoping, and schema-bump process.
  * Added default base theme.json-styled payload.

* **Tests**
  * Comprehensive feature tests covering auth, lookup/show/update flows, validation, base-path override, and end-to-end persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->