### PR TITLE
feat: C4 · Navigation: model, migration, API, menu locations

### DIFF
--- a/config/visual-editor.php
+++ b/config/visual-editor.php
@@ -212,4 +212,34 @@ return [
 		'base_path'      => null,
 	],
 
+	/*
+	|--------------------------------------------------------------------------
+	| Navigation
+	|--------------------------------------------------------------------------
+	|
+	| `locations` maps a theme-exposed menu-location slug to a navigation
+	| record id (by primary key) along with a human-readable label for the
+	| site editor UI. When `primary_id` is null or points at a missing
+	| record, the `MenuLocationResolver` falls back to the first published
+	| nav in `menu_order`. Menu-location admin CRUD is deferred to 1.1+;
+	| V1 is intentionally config-driven (see the V1 plan doc §8).
+	|
+	| Each entry:
+	|   - `slug`       (string)  Location identifier used by theme blocks.
+	|   - `label`      (string)  Human label shown in the site editor.
+	|   - `primary_id` (int|null) VisualEditorNavigation id, or null to
+	|                            always use the fallback.
+	|
+	*/
+
+	'navigation' => [
+		'locations' => [
+			// 'primary' => [
+			//     'slug'       => 'primary',
+			//     'label'      => 'Primary Menu',
+			//     'primary_id' => null,
+			// ],
+		],
+	],
+
 ];

--- a/database/migrations/2026_04_23_300000_create_visual_editor_navigations_table.php
+++ b/database/migrations/2026_04_23_300000_create_visual_editor_navigations_table.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * Create visual_editor_navigations table migration.
+ *
+ * Storage for the `wp_navigation` entity the B1 core-data shim addresses at
+ * `/visual-editor/api/navigation`. Holds the Gutenberg block tree plus the
+ * raw serialized payload for nav menus (primary, footer, etc.) along with
+ * the `status` and `menu_order` fields the fallback resolver walks over.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+	public function up(): void
+	{
+		Schema::create( 'visual_editor_navigations', function ( Blueprint $table ) {
+			$table->id();
+			$table->string( 'slug' )->unique();
+			$table->string( 'title' )->default( '' );
+			// The API envelope { raw, blocks } is stored verbatim; an empty
+			// navigation is `{ "raw": "", "blocks": [] }` so the column is
+			// never null once hydrated through the model.
+			$table->json( 'content' )->nullable();
+			$table->string( 'status' )->default( 'publish' )->index();
+			$table->unsignedInteger( 'menu_order' )->default( 0 )->index();
+			$table->timestamps();
+		} );
+	}
+
+	public function down(): void
+	{
+		Schema::dropIfExists( 'visual_editor_navigations' );
+	}
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -19,6 +19,7 @@ declare( strict_types=1 );
 
 use ArtisanPackUI\VisualEditor\Http\Controllers\BlockPreviewController;
 use ArtisanPackUI\VisualEditor\Http\Controllers\GlobalStylesController;
+use ArtisanPackUI\VisualEditor\Http\Controllers\NavigationController;
 use ArtisanPackUI\VisualEditor\Http\Controllers\ResourceContentController;
 use ArtisanPackUI\VisualEditor\Http\Controllers\TemplateController;
 use ArtisanPackUI\VisualEditor\Http\Controllers\TemplatePartController;
@@ -89,6 +90,22 @@ Route::get( 'global-styles/{globalStyle}', [ GlobalStylesController::class, 'sho
 
 Route::put( 'global-styles/{globalStyle}', [ GlobalStylesController::class, 'update' ] )
 	->name( 'visual-editor.api.global-styles.update' );
+
+// C4 `wp_navigation` REST surface — see docs/core-data-shim.md §Navigation.
+Route::get( 'navigation', [ NavigationController::class, 'index' ] )
+	->name( 'visual-editor.api.navigation.index' );
+
+Route::post( 'navigation', [ NavigationController::class, 'store' ] )
+	->name( 'visual-editor.api.navigation.store' );
+
+Route::get( 'navigation/{navigation}', [ NavigationController::class, 'show' ] )
+	->name( 'visual-editor.api.navigation.show' );
+
+Route::put( 'navigation/{navigation}', [ NavigationController::class, 'update' ] )
+	->name( 'visual-editor.api.navigation.update' );
+
+Route::delete( 'navigation/{navigation}', [ NavigationController::class, 'destroy' ] )
+	->name( 'visual-editor.api.navigation.destroy' );
 
 // Legacy ve_contents routes retained for the existing editor tests and the
 // `VisualEditorPost` model. Deprecated in M3 in favor of the resource routes

--- a/src/Http/Controllers/NavigationController.php
+++ b/src/Http/Controllers/NavigationController.php
@@ -1,0 +1,197 @@
+<?php
+
+/**
+ * Navigation controller.
+ *
+ * Serves the REST surface for the `wp_navigation` entity behind the B1
+ * core-data shim (see `docs/core-data-shim.md` §Navigation). The five
+ * endpoints — index, show, store, update, destroy — mount under
+ * `/visual-editor/api/navigation` via the package's auth-gated API
+ * group and return responses shaped by {@see NavigationResource}.
+ *
+ * Menu-location resolution is handled separately by
+ * {@see \ArtisanPackUI\VisualEditor\Services\MenuLocationResolver};
+ * V1 does not expose a REST surface for locations (reads go through
+ * the service, writes are config-only per §8 of the V1 plan doc).
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Http\Controllers;
+
+use ArtisanPackUI\VisualEditor\Http\Requests\StoreNavigationRequest;
+use ArtisanPackUI\VisualEditor\Http\Requests\UpdateNavigationRequest;
+use ArtisanPackUI\VisualEditor\Http\Resources\NavigationResource;
+use ArtisanPackUI\VisualEditor\Models\VisualEditorNavigation;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Illuminate\Http\Response;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Gate;
+
+class NavigationController extends Controller
+{
+	/**
+	 * Maximum per-page size for the index endpoint. Keeps a malicious or
+	 * accidental `?per_page=999999` query from dragging the editor's
+	 * nav-picker dropdown down while still letting the host page through
+	 * explicit requests when necessary.
+	 */
+	protected const MAX_PER_PAGE = 100;
+
+	/**
+	 * Lists navigation records with a paginated `{ data, meta }` envelope.
+	 *
+	 * The shim reads `meta.total` and `meta.last_page` for the selectors
+	 * `getEntityRecordsTotalItems` / `getEntityRecordsTotalPages`; the
+	 * default Laravel `Resource::collection( $paginator )` response
+	 * already emits those keys, so no custom envelope is necessary.
+	 *
+	 * @since 1.0.0
+	 */
+	public function index( Request $request ): AnonymousResourceCollection
+	{
+		Gate::authorize( 'viewAny', VisualEditorNavigation::class );
+
+		$perPage = (int) $request->integer( 'per_page', 25 );
+
+		if ( $perPage < 1 ) {
+			$perPage = 25;
+		}
+
+		if ( $perPage > self::MAX_PER_PAGE ) {
+			$perPage = self::MAX_PER_PAGE;
+		}
+
+		$query = VisualEditorNavigation::query()
+			->orderBy( 'menu_order' )
+			->orderBy( 'id' );
+
+		$slug = $request->string( 'slug' )->toString();
+		if ( '' !== $slug ) {
+			$query->where( 'slug', $slug );
+		}
+
+		$status = $request->string( 'status' )->toString();
+		if ( '' !== $status ) {
+			$query->where( 'status', $status );
+		}
+
+		return NavigationResource::collection( $query->paginate( $perPage ) );
+	}
+
+	/**
+	 * Returns a single navigation record.
+	 *
+	 * The shim expects the record at the top level (not wrapped in `data`)
+	 * so `fetchEntityRecord` can dispatch it straight into the cache.
+	 *
+	 * @since 1.0.0
+	 */
+	public function show( Request $request, VisualEditorNavigation $navigation ): JsonResponse
+	{
+		Gate::authorize( 'view', $navigation );
+
+		return response()->json( ( new NavigationResource( $navigation ) )->toArray( $request ) );
+	}
+
+	/**
+	 * Creates a new navigation record.
+	 *
+	 * @since 1.0.0
+	 */
+	public function store( StoreNavigationRequest $request ): JsonResponse
+	{
+		Gate::authorize( 'create', VisualEditorNavigation::class );
+
+		$data = $request->validated();
+
+		$navigation = new VisualEditorNavigation();
+		$navigation->fill( [
+			'slug'       => $data['slug'],
+			'title'      => $data['title'] ?? '',
+			'status'     => $data['status'] ?? VisualEditorNavigation::STATUS_PUBLISH,
+			'menu_order' => $data['menu_order'] ?? 0,
+		] );
+
+		$navigation->setContentEnvelope( $this->normalizeContentEnvelope( $data['content'] ?? null ) );
+		$navigation->save();
+
+		return response()->json(
+			( new NavigationResource( $navigation ) )->toArray( $request ),
+			Response::HTTP_CREATED
+		);
+	}
+
+	/**
+	 * Updates an existing navigation record.
+	 *
+	 * @since 1.0.0
+	 */
+	public function update( UpdateNavigationRequest $request, VisualEditorNavigation $navigation ): JsonResponse
+	{
+		Gate::authorize( 'update', $navigation );
+
+		$data = $request->validated();
+
+		foreach ( [ 'slug', 'title', 'status', 'menu_order' ] as $field ) {
+			if ( array_key_exists( $field, $data ) ) {
+				$navigation->{$field} = $data[ $field ];
+			}
+		}
+
+		if ( array_key_exists( 'content', $data ) ) {
+			$navigation->setContentEnvelope( $this->normalizeContentEnvelope( $data['content'] ) );
+		}
+
+		$navigation->save();
+
+		return response()->json( ( new NavigationResource( $navigation ) )->toArray( $request ) );
+	}
+
+	/**
+	 * Deletes a navigation record.
+	 *
+	 * @since 1.0.0
+	 */
+	public function destroy( VisualEditorNavigation $navigation ): JsonResponse
+	{
+		Gate::authorize( 'delete', $navigation );
+
+		$navigation->delete();
+
+		return response()->json( null, Response::HTTP_NO_CONTENT );
+	}
+
+	/**
+	 * Normalizes the inbound content payload into the `{ raw, blocks }`
+	 * envelope the model expects. Form-request validation guarantees
+	 * the shape before we get here; this method just guards against
+	 * missing keys and bad types as a belt-and-braces fallback.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  mixed  $content
+	 *
+	 * @return array{raw: string, blocks: array<int, array<string, mixed>>}
+	 */
+	protected function normalizeContentEnvelope( mixed $content ): array
+	{
+		if ( ! is_array( $content ) ) {
+			return [ 'raw' => '', 'blocks' => [] ];
+		}
+
+		return [
+			'raw'    => isset( $content['raw'] ) && is_string( $content['raw'] ) ? $content['raw'] : '',
+			'blocks' => isset( $content['blocks'] ) && is_array( $content['blocks'] ) ? array_values( $content['blocks'] ) : [],
+		];
+	}
+}

--- a/src/Http/Requests/StoreNavigationRequest.php
+++ b/src/Http/Requests/StoreNavigationRequest.php
@@ -1,0 +1,85 @@
+<?php
+
+/**
+ * StoreNavigation form request.
+ *
+ * Validates the payload for creating a `wp_navigation` record via
+ * `POST /visual-editor/api/navigation`.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Http\Requests;
+
+use ArtisanPackUI\VisualEditor\Models\VisualEditorNavigation;
+use ArtisanPackUI\VisualEditor\Rules\TemplateBlockTreeRule;
+use Closure;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StoreNavigationRequest extends FormRequest
+{
+	public function authorize(): bool
+	{
+		return true;
+	}
+
+	/**
+	 * @return array<string, array<int, mixed>>
+	 */
+	public function rules(): array
+	{
+		return [
+			'slug'           => [
+				'required',
+				'string',
+				'max:191',
+				Rule::unique( 'visual_editor_navigations', 'slug' ),
+			],
+			// `title` and `status` back non-nullable DB columns (defaults:
+			// '', 'publish'). The store controller falls back to those
+			// defaults when the field is missing, but `null` is never a
+			// legal value — rejecting it here keeps the DB from rejecting
+			// the write later with an opaque QueryException.
+			'title'          => [ 'sometimes', 'string', 'max:255' ],
+			'content'        => [ 'nullable', 'array', $this->envelopeShapeRule() ],
+			'content.raw'    => [ 'nullable', 'string' ],
+			'content.blocks' => [ 'nullable', 'array', new TemplateBlockTreeRule() ],
+			'status'         => [
+				'sometimes',
+				'string',
+				Rule::in( [
+					VisualEditorNavigation::STATUS_PUBLISH,
+					VisualEditorNavigation::STATUS_DRAFT,
+					VisualEditorNavigation::STATUS_PRIVATE,
+				] ),
+			],
+			'menu_order'     => [ 'sometimes', 'integer', 'min:0' ],
+		];
+	}
+
+	/**
+	 * Rejects a bare-list `content` payload.
+	 *
+	 * `content.blocks` is only validated when the request uses the
+	 * `{ raw, blocks }` envelope; without this rule a caller could send
+	 * `content: [ <blocks> ]` to skip `TemplateBlockTreeRule` entirely.
+	 *
+	 * @since 1.0.0
+	 */
+	protected function envelopeShapeRule(): Closure
+	{
+		return function ( string $attribute, mixed $value, Closure $fail ): void {
+			if ( is_array( $value ) && [] !== $value && array_is_list( $value ) ) {
+				$fail( 'The :attribute must be a { raw, blocks } envelope, not a bare list of blocks.' );
+			}
+		};
+	}
+}

--- a/src/Http/Requests/UpdateNavigationRequest.php
+++ b/src/Http/Requests/UpdateNavigationRequest.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * UpdateNavigation form request.
+ *
+ * Validates the payload for updating a `wp_navigation` record via
+ * `PUT /visual-editor/api/navigation/{id}`.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Http\Requests;
+
+use ArtisanPackUI\VisualEditor\Models\VisualEditorNavigation;
+use ArtisanPackUI\VisualEditor\Rules\TemplateBlockTreeRule;
+use Closure;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateNavigationRequest extends FormRequest
+{
+	public function authorize(): bool
+	{
+		return true;
+	}
+
+	/**
+	 * @return array<string, array<int, mixed>>
+	 */
+	public function rules(): array
+	{
+		/** @var VisualEditorNavigation $navigation */
+		$navigation = $this->route( 'navigation' );
+
+		return [
+			'slug'           => [
+				'sometimes',
+				'required',
+				'string',
+				'max:191',
+				Rule::unique( 'visual_editor_navigations', 'slug' )
+					->ignore( $navigation->getKey() ),
+			],
+			// `title` and `status` back non-nullable DB columns — null is
+			// never a legal value. The update controller leaves missing
+			// fields untouched, so dropping `nullable` here only tightens
+			// the error path without changing what a partial update can
+			// do.
+			'title'          => [ 'sometimes', 'string', 'max:255' ],
+			'content'        => [ 'sometimes', 'nullable', 'array', $this->envelopeShapeRule() ],
+			'content.raw'    => [ 'sometimes', 'nullable', 'string' ],
+			'content.blocks' => [ 'sometimes', 'nullable', 'array', new TemplateBlockTreeRule() ],
+			'status'         => [
+				'sometimes',
+				'string',
+				Rule::in( [
+					VisualEditorNavigation::STATUS_PUBLISH,
+					VisualEditorNavigation::STATUS_DRAFT,
+					VisualEditorNavigation::STATUS_PRIVATE,
+				] ),
+			],
+			'menu_order'     => [ 'sometimes', 'integer', 'min:0' ],
+		];
+	}
+
+	/**
+	 * Rejects a bare-list `content` payload — see the mirrored method on
+	 * {@see StoreNavigationRequest::envelopeShapeRule()} for why.
+	 *
+	 * @since 1.0.0
+	 */
+	protected function envelopeShapeRule(): Closure
+	{
+		return function ( string $attribute, mixed $value, Closure $fail ): void {
+			if ( is_array( $value ) && [] !== $value && array_is_list( $value ) ) {
+				$fail( 'The :attribute must be a { raw, blocks } envelope, not a bare list of blocks.' );
+			}
+		};
+	}
+}

--- a/src/Http/Resources/NavigationResource.php
+++ b/src/Http/Resources/NavigationResource.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * NavigationResource API resource.
+ *
+ * Shapes a {@see VisualEditorNavigation} into the B1 core-data shim's
+ * `wp_navigation` record envelope. Keeps the HTTP response contract in
+ * one place so controllers and tests don't have to reconstruct the
+ * `title.rendered` and `content.{raw,blocks}` wrappers ad hoc.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Http\Resources;
+
+use ArtisanPackUI\VisualEditor\Models\VisualEditorNavigation;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @property VisualEditorNavigation $resource
+ */
+class NavigationResource extends JsonResource
+{
+	/**
+	 * Transforms the navigation into the shim-compatible record shape.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function toArray( Request $request ): array
+	{
+		/** @var VisualEditorNavigation $navigation */
+		$navigation = $this->resource;
+
+		$envelope = $navigation->getContentEnvelope();
+
+		return [
+			'id'         => $navigation->getKey(),
+			'slug'       => $navigation->slug,
+			'title'      => [
+				'rendered' => (string) ( $navigation->title ?? '' ),
+			],
+			'content'    => [
+				'raw'    => $envelope['raw'],
+				'blocks' => $envelope['blocks'],
+			],
+			'status'     => $navigation->status,
+			'menu_order' => (int) $navigation->menu_order,
+			'type'       => 'wp_navigation',
+		];
+	}
+}

--- a/src/Models/VisualEditorNavigation.php
+++ b/src/Models/VisualEditorNavigation.php
@@ -1,0 +1,158 @@
+<?php
+
+/**
+ * VisualEditorNavigation model.
+ *
+ * Eloquent backing for the `wp_navigation` entity exposed at
+ * `/visual-editor/api/navigation`. Stores the Gutenberg block tree inside
+ * the `{ raw, blocks }` envelope the B1 core-data shim expects. The tree
+ * carries `core/navigation-link` and `core/navigation-submenu` blocks
+ * (including nested submenus per B2's `nested.json` fixture); the model
+ * persists them verbatim so round-tripping through the REST surface
+ * preserves the exact shape the editor reads back.
+ *
+ * Records also carry a `status` + `menu_order` pair so the
+ * {@see \ArtisanPackUI\VisualEditor\Services\MenuLocationResolver} can
+ * fall back to the first published nav when a configured menu location
+ * has no assignment or points at a missing record.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+class VisualEditorNavigation extends Model
+{
+	public const STATUS_PUBLISH = 'publish';
+	public const STATUS_DRAFT   = 'draft';
+	public const STATUS_PRIVATE = 'private';
+
+	protected $table = 'visual_editor_navigations';
+
+	/**
+	 * @var array<int, string>
+	 */
+	protected $fillable = [
+		'slug',
+		'title',
+		'content',
+		'status',
+		'menu_order',
+	];
+
+	/**
+	 * @var array<string, string>
+	 */
+	protected $casts = [
+		'content'    => 'array',
+		'menu_order' => 'integer',
+	];
+
+	/**
+	 * Returns the canonical content envelope stored on the record.
+	 *
+	 * Always returns the `{ raw, blocks }` shape — callers never have to
+	 * null-check the raw column or the blocks key separately.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array{raw: string, blocks: array<int, array<string, mixed>>}
+	 */
+	public function getContentEnvelope(): array
+	{
+		$value = $this->getAttribute( 'content' );
+
+		$raw    = '';
+		$blocks = [];
+
+		if ( is_array( $value ) ) {
+			$raw    = isset( $value['raw'] ) && is_string( $value['raw'] ) ? $value['raw'] : '';
+			$blocks = isset( $value['blocks'] ) && is_array( $value['blocks'] ) ? array_values( $value['blocks'] ) : [];
+		}
+
+		return [
+			'raw'    => $raw,
+			'blocks' => $blocks,
+		];
+	}
+
+	/**
+	 * Returns just the parsed block tree.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	public function getBlocks(): array
+	{
+		return $this->getContentEnvelope()['blocks'];
+	}
+
+	/**
+	 * Returns just the raw Gutenberg serialization.
+	 *
+	 * @since 1.0.0
+	 */
+	public function getRawContent(): string
+	{
+		return $this->getContentEnvelope()['raw'];
+	}
+
+	/**
+	 * Persists an updated content envelope on the record.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array{raw?: string, blocks?: array<int, array<string, mixed>>}  $envelope
+	 */
+	public function setContentEnvelope( array $envelope ): void
+	{
+		$raw    = isset( $envelope['raw'] ) && is_string( $envelope['raw'] ) ? $envelope['raw'] : '';
+		$blocks = isset( $envelope['blocks'] ) && is_array( $envelope['blocks'] ) ? array_values( $envelope['blocks'] ) : [];
+
+		$this->setAttribute( 'content', [
+			'raw'    => $raw,
+			'blocks' => $blocks,
+		] );
+	}
+
+	/**
+	 * Whether the nav has any blocks in its content envelope.
+	 *
+	 * The fallback resolver treats an empty block tree the same as a
+	 * missing record, because a nav with nothing to render is no use to
+	 * the front end.
+	 *
+	 * @since 1.0.0
+	 */
+	public function isEmpty(): bool
+	{
+		return [] === $this->getBlocks();
+	}
+
+	/**
+	 * Scopes the query to published navs, ordered by `menu_order`.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  Builder<VisualEditorNavigation>  $query
+	 *
+	 * @return Builder<VisualEditorNavigation>
+	 */
+	public function scopePublished( Builder $query ): Builder
+	{
+		return $query->where( 'status', self::STATUS_PUBLISH )
+			->orderBy( 'menu_order' )
+			->orderBy( 'id' );
+	}
+}

--- a/src/Policies/VisualEditorNavigationPolicy.php
+++ b/src/Policies/VisualEditorNavigationPolicy.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * VisualEditorNavigation policy.
+ *
+ * Authorization policy for the `wp_navigation` REST endpoints. The V1
+ * default allows any authenticated user to read and mutate navigation
+ * records, mirroring how the existing `VisualEditorTemplatePolicy`
+ * handles its entity; host apps that need tighter access should swap
+ * the binding in their own service provider.
+ *
+ * Navigations have no "owner" — they're site-level records, not
+ * per-user content — so the `restrict_by_owner` config flag that
+ * governs posts doesn't apply here.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Policies;
+
+use ArtisanPackUI\VisualEditor\Models\VisualEditorNavigation;
+use Illuminate\Auth\Access\HandlesAuthorization;
+use Illuminate\Contracts\Auth\Authenticatable;
+
+class VisualEditorNavigationPolicy
+{
+	use HandlesAuthorization;
+
+	public function viewAny( ?Authenticatable $user ): bool
+	{
+		return null !== $user;
+	}
+
+	public function view( ?Authenticatable $user, VisualEditorNavigation $navigation ): bool
+	{
+		return null !== $user;
+	}
+
+	public function create( ?Authenticatable $user ): bool
+	{
+		return null !== $user;
+	}
+
+	public function update( ?Authenticatable $user, VisualEditorNavigation $navigation ): bool
+	{
+		return null !== $user;
+	}
+
+	public function delete( ?Authenticatable $user, VisualEditorNavigation $navigation ): bool
+	{
+		return null !== $user;
+	}
+}

--- a/src/Services/MenuLocationResolver.php
+++ b/src/Services/MenuLocationResolver.php
@@ -1,0 +1,142 @@
+<?php
+
+/**
+ * MenuLocationResolver service.
+ *
+ * Resolves theme-exposed menu-location slugs to a concrete
+ * {@see VisualEditorNavigation} record. The V1 commitment is
+ * configuration-driven menu locations (per §8 of the V1 plan doc):
+ * host apps declare the available slugs in
+ * `config/artisanpack/visual-editor.php` under `navigation.locations`,
+ * and each location optionally names the nav record (`primary_id`)
+ * the theme should render for that slot.
+ *
+ * When a location has no assignment, points at a missing record, or
+ * points at a record with an empty block tree, the resolver falls
+ * back to the first published nav ordered by `menu_order`. If no
+ * published nav exists at all, `forLocation` returns `null` so the
+ * `core/navigation` block can render an empty state instead of
+ * 500-ing the page.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Services;
+
+use ArtisanPackUI\VisualEditor\Models\VisualEditorNavigation;
+use Illuminate\Contracts\Config\Repository as ConfigRepository;
+
+class MenuLocationResolver
+{
+	public function __construct( protected ConfigRepository $config )
+	{
+	}
+
+	/**
+	 * Returns the configured menu-location entries.
+	 *
+	 * Each entry is shaped as
+	 * `{ slug: string, label: string, primary_id: ?int }` keyed by slug.
+	 * Entries with a non-string slug/label are filtered out so the site
+	 * editor UI always gets a sane list to render.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<string, array{slug: string, label: string, primary_id: ?int}>
+	 */
+	public function locations(): array
+	{
+		$raw = $this->config->get( 'artisanpack.visual-editor.navigation.locations', [] );
+
+		if ( ! is_array( $raw ) ) {
+			return [];
+		}
+
+		$locations = [];
+
+		foreach ( $raw as $key => $entry ) {
+			if ( ! is_array( $entry ) ) {
+				continue;
+			}
+
+			$slug  = isset( $entry['slug'] ) && is_string( $entry['slug'] ) ? $entry['slug'] : (string) $key;
+			$label = isset( $entry['label'] ) && is_string( $entry['label'] ) ? $entry['label'] : $slug;
+
+			if ( '' === $slug ) {
+				continue;
+			}
+
+			$primaryId = null;
+			if ( isset( $entry['primary_id'] ) && is_numeric( $entry['primary_id'] ) ) {
+				$primaryId = (int) $entry['primary_id'];
+			}
+
+			$locations[ $slug ] = [
+				'slug'       => $slug,
+				'label'      => $label,
+				'primary_id' => $primaryId,
+			];
+		}
+
+		return $locations;
+	}
+
+	/**
+	 * Resolves a menu-location slug to the navigation record the theme
+	 * should render for that slot.
+	 *
+	 * Resolution order:
+	 *   1. The configured `primary_id` (when present and the record
+	 *      exists and has a non-empty block tree).
+	 *   2. The first published nav ordered by `menu_order`.
+	 *   3. `null` when no published navs exist.
+	 *
+	 * An unknown slug still falls through to the published-nav fallback,
+	 * because a freshly-installed host app may have navs seeded before
+	 * it has declared any locations in config.
+	 *
+	 * @since 1.0.0
+	 */
+	public function forLocation( string $slug ): ?VisualEditorNavigation
+	{
+		$locations = $this->locations();
+
+		$primary = null;
+		if ( isset( $locations[ $slug ]['primary_id'] ) ) {
+			$primary = $locations[ $slug ]['primary_id'];
+		}
+
+		if ( null !== $primary ) {
+			$record = VisualEditorNavigation::query()->find( $primary );
+
+			if ( null !== $record && ! $record->isEmpty() ) {
+				return $record;
+			}
+		}
+
+		return $this->fallback();
+	}
+
+	/**
+	 * Returns the first published nav ordered by `menu_order`, or null
+	 * when the database has no published navs.
+	 *
+	 * Exposed separately so callers that already know the location is
+	 * unconfigured (for example, a front-end renderer handed a slug that
+	 * doesn't exist in config) can reach the fallback without paying for
+	 * the location lookup.
+	 *
+	 * @since 1.0.0
+	 */
+	public function fallback(): ?VisualEditorNavigation
+	{
+		return VisualEditorNavigation::query()->published()->first();
+	}
+}

--- a/src/VisualEditorServiceProvider.php
+++ b/src/VisualEditorServiceProvider.php
@@ -5,10 +5,12 @@ namespace ArtisanPackUI\VisualEditor;
 use ArtisanPackUI\VisualEditor\Console\Commands\SeedSampleContentCommand;
 use ArtisanPackUI\VisualEditor\MediaBridge\GutenbergAttachmentAdapter;
 use ArtisanPackUI\VisualEditor\Models\VisualEditorGlobalStyles;
+use ArtisanPackUI\VisualEditor\Models\VisualEditorNavigation;
 use ArtisanPackUI\VisualEditor\Models\VisualEditorPost;
 use ArtisanPackUI\VisualEditor\Models\VisualEditorTemplate;
 use ArtisanPackUI\VisualEditor\Models\VisualEditorTemplatePart;
 use ArtisanPackUI\VisualEditor\Policies\VisualEditorGlobalStylesPolicy;
+use ArtisanPackUI\VisualEditor\Policies\VisualEditorNavigationPolicy;
 use ArtisanPackUI\VisualEditor\Policies\VisualEditorPostPolicy;
 use ArtisanPackUI\VisualEditor\Policies\VisualEditorTemplatePolicy;
 use ArtisanPackUI\VisualEditor\Policies\VisualEditorTemplatePartPolicy;
@@ -16,6 +18,7 @@ use ArtisanPackUI\VisualEditor\Registries\BlockTypeRegistry;
 use ArtisanPackUI\VisualEditor\Registries\DynamicBlockRegistry;
 use ArtisanPackUI\VisualEditor\Resources\ResourceResolver;
 use ArtisanPackUI\VisualEditor\Search\BlockTreeSearchExtractor;
+use ArtisanPackUI\VisualEditor\Services\MenuLocationResolver;
 use ArtisanPackUI\VisualEditor\View\Components\VisualEditorComponent;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Gate;
@@ -59,6 +62,10 @@ class VisualEditorServiceProvider extends ServiceProvider
 			return new GutenbergAttachmentAdapter();
 		} );
 
+		$this->app->singleton( MenuLocationResolver::class, function ( $app ) {
+			return new MenuLocationResolver( $app['config'] );
+		} );
+
 		// Legacy alias for backward compatibility
 		$this->app->alias( VisualEditor::class, 'visualEditor' );
 
@@ -91,6 +98,7 @@ class VisualEditorServiceProvider extends ServiceProvider
 		Gate::policy( VisualEditorTemplate::class, VisualEditorTemplatePolicy::class );
 		Gate::policy( VisualEditorTemplatePart::class, VisualEditorTemplatePartPolicy::class );
 		Gate::policy( VisualEditorGlobalStyles::class, VisualEditorGlobalStylesPolicy::class );
+		Gate::policy( VisualEditorNavigation::class, VisualEditorNavigationPolicy::class );
 
 		// 3. Register core blocks from their block.json manifests.
 		$this->registerCoreBlocks();

--- a/tests/Feature/VisualEditor/MenuLocationResolverTest.php
+++ b/tests/Feature/VisualEditor/MenuLocationResolverTest.php
@@ -1,0 +1,202 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Models\VisualEditorNavigation;
+use ArtisanPackUI\VisualEditor\Services\MenuLocationResolver;
+
+function makeNavigation( array $overrides = [] ): VisualEditorNavigation
+{
+	return VisualEditorNavigation::create( array_merge( [
+		'slug'       => 'primary-nav',
+		'title'      => 'Primary',
+		'content'    => [
+			'raw'    => '',
+			'blocks' => [
+				[
+					'name'        => 'core/navigation-link',
+					'attributes'  => [ 'label' => 'Home', 'url' => '/' ],
+					'innerBlocks' => [],
+				],
+			],
+		],
+		'status'     => 'publish',
+		'menu_order' => 0,
+	], $overrides ) );
+}
+
+function setLocations( array $locations ): void
+{
+	config( [ 'artisanpack.visual-editor.navigation.locations' => $locations ] );
+}
+
+it( 'returns the configured primary nav when the location has an assignment', function () {
+	$primary = makeNavigation( [ 'slug' => 'primary-nav', 'menu_order' => 5 ] );
+	$footer  = makeNavigation( [ 'slug' => 'footer-nav', 'menu_order' => 10 ] );
+
+	setLocations( [
+		'primary' => [
+			'slug'       => 'primary',
+			'label'      => 'Primary Menu',
+			'primary_id' => $primary->id,
+		],
+	] );
+
+	$resolver = app( MenuLocationResolver::class );
+
+	expect( $resolver->forLocation( 'primary' ) )->not->toBeNull()
+		->and( $resolver->forLocation( 'primary' )->id )->toBe( $primary->id );
+} );
+
+it( 'falls back to the first published nav when the location has no assignment', function () {
+	$first  = makeNavigation( [ 'slug' => 'primary-nav', 'menu_order' => 0 ] );
+	$second = makeNavigation( [ 'slug' => 'footer-nav', 'menu_order' => 5 ] );
+
+	setLocations( [
+		'primary' => [
+			'slug'       => 'primary',
+			'label'      => 'Primary Menu',
+			'primary_id' => null,
+		],
+	] );
+
+	$resolver = app( MenuLocationResolver::class );
+
+	expect( $resolver->forLocation( 'primary' ) )->not->toBeNull()
+		->and( $resolver->forLocation( 'primary' )->id )->toBe( $first->id );
+} );
+
+it( 'falls back when the configured primary id points at a missing record', function () {
+	$nav = makeNavigation( [ 'slug' => 'primary-nav' ] );
+
+	setLocations( [
+		'primary' => [
+			'slug'       => 'primary',
+			'label'      => 'Primary Menu',
+			'primary_id' => 9999,
+		],
+	] );
+
+	$resolver = app( MenuLocationResolver::class );
+
+	expect( $resolver->forLocation( 'primary' ) )->not->toBeNull()
+		->and( $resolver->forLocation( 'primary' )->id )->toBe( $nav->id );
+} );
+
+it( 'falls back when the configured primary id points at an empty record', function () {
+	// `$other` has the lower menu_order so it wins the fallback ordering;
+	// `$empty` is what the location points at and what we expect to be
+	// bypassed because its block tree is empty.
+	$other = makeNavigation( [ 'slug' => 'primary-nav', 'menu_order' => 0 ] );
+	$empty = makeNavigation( [
+		'slug'       => 'empty-nav',
+		'content'    => [ 'raw' => '', 'blocks' => [] ],
+		'menu_order' => 5,
+	] );
+
+	setLocations( [
+		'primary' => [
+			'slug'       => 'primary',
+			'label'      => 'Primary Menu',
+			'primary_id' => $empty->id,
+		],
+	] );
+
+	$resolver = app( MenuLocationResolver::class );
+
+	expect( $resolver->forLocation( 'primary' ) )->not->toBeNull()
+		->and( $resolver->forLocation( 'primary' )->id )->toBe( $other->id );
+} );
+
+it( 'returns null when the database has no published navs', function () {
+	setLocations( [
+		'primary' => [
+			'slug'       => 'primary',
+			'label'      => 'Primary Menu',
+			'primary_id' => null,
+		],
+	] );
+
+	$resolver = app( MenuLocationResolver::class );
+
+	expect( $resolver->forLocation( 'primary' ) )->toBeNull();
+} );
+
+it( 'ignores draft navs when falling back', function () {
+	makeNavigation( [ 'slug' => 'draft-nav', 'status' => 'draft', 'menu_order' => 0 ] );
+	$published = makeNavigation( [ 'slug' => 'primary-nav', 'status' => 'publish', 'menu_order' => 5 ] );
+
+	setLocations( [
+		'primary' => [
+			'slug'       => 'primary',
+			'label'      => 'Primary Menu',
+			'primary_id' => null,
+		],
+	] );
+
+	$resolver = app( MenuLocationResolver::class );
+
+	expect( $resolver->forLocation( 'primary' ) )->not->toBeNull()
+		->and( $resolver->forLocation( 'primary' )->id )->toBe( $published->id );
+} );
+
+it( 'returns the fallback for an unknown location slug', function () {
+	$nav = makeNavigation( [ 'slug' => 'primary-nav' ] );
+
+	setLocations( [] );
+
+	$resolver = app( MenuLocationResolver::class );
+
+	expect( $resolver->forLocation( 'does-not-exist' ) )->not->toBeNull()
+		->and( $resolver->forLocation( 'does-not-exist' )->id )->toBe( $nav->id );
+} );
+
+it( 'exposes locations() as a keyed map with normalized entries', function () {
+	setLocations( [
+		'primary' => [
+			'slug'       => 'primary',
+			'label'      => 'Primary Menu',
+			'primary_id' => 42,
+		],
+		'footer'  => [
+			'slug'       => 'footer',
+			'label'      => 'Footer Menu',
+			'primary_id' => null,
+		],
+	] );
+
+	$resolver  = app( MenuLocationResolver::class );
+	$locations = $resolver->locations();
+
+	expect( $locations )
+		->toHaveKey( 'primary' )
+		->toHaveKey( 'footer' )
+		->and( $locations['primary'] )->toEqual( [
+			'slug'       => 'primary',
+			'label'      => 'Primary Menu',
+			'primary_id' => 42,
+		] )
+		->and( $locations['footer']['primary_id'] )->toBeNull();
+} );
+
+it( 'drops malformed location entries silently', function () {
+	setLocations( [
+		'primary' => [
+			'slug'       => 'primary',
+			'label'      => 'Primary Menu',
+			'primary_id' => 1,
+		],
+		'broken'  => 'not-an-array',
+		''        => [
+			'slug'  => '',
+			'label' => 'Empty slug',
+		],
+	] );
+
+	$resolver  = app( MenuLocationResolver::class );
+	$locations = $resolver->locations();
+
+	expect( $locations )
+		->toHaveCount( 1 )
+		->toHaveKey( 'primary' );
+} );

--- a/tests/Feature/VisualEditor/NavigationControllerTest.php
+++ b/tests/Feature/VisualEditor/NavigationControllerTest.php
@@ -1,0 +1,411 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Models\VisualEditorNavigation;
+use Tests\TestUser;
+
+function createNavigation( array $overrides = [] ): VisualEditorNavigation
+{
+	return VisualEditorNavigation::create( array_merge( [
+		'slug'       => 'primary-nav',
+		'title'      => 'Primary',
+		'content'    => [
+			'raw'    => '<!-- wp:navigation-link {"label":"Home","url":"/"} /-->',
+			'blocks' => [
+				[
+					'name'        => 'core/navigation-link',
+					'attributes'  => [ 'label' => 'Home', 'url' => '/' ],
+					'innerBlocks' => [],
+				],
+			],
+		],
+		'status'     => 'publish',
+		'menu_order' => 0,
+	], $overrides ) );
+}
+
+function actingAsNavigationUser(): TestUser
+{
+	$user = TestUser::create( [
+		'name'     => 'Navigation Tester',
+		'email'    => 'navigation+' . uniqid() . '@example.com',
+		'password' => bcrypt( 'secret' ),
+	] );
+
+	test()->actingAs( $user );
+
+	return $user;
+}
+
+it( 'returns 401 when unauthenticated on index', function () {
+	$this->getJson( '/visual-editor/api/navigation' )->assertUnauthorized();
+} );
+
+it( 'returns an empty data/meta envelope when no navigations exist', function () {
+	actingAsNavigationUser();
+
+	$this->getJson( '/visual-editor/api/navigation' )
+		->assertOk()
+		->assertJsonPath( 'data', [] )
+		->assertJsonPath( 'meta.total', 0 )
+		->assertJsonPath( 'meta.last_page', 1 );
+} );
+
+it( 'lists navigations ordered by menu_order', function () {
+	actingAsNavigationUser();
+
+	createNavigation( [ 'slug' => 'footer-nav', 'title' => 'Footer', 'menu_order' => 5 ] );
+	createNavigation( [ 'slug' => 'primary-nav', 'title' => 'Primary', 'menu_order' => 0 ] );
+
+	$this->getJson( '/visual-editor/api/navigation' )
+		->assertOk()
+		->assertJsonCount( 2, 'data' )
+		->assertJsonPath( 'meta.total', 2 )
+		->assertJsonPath( 'data.0.slug', 'primary-nav' )
+		->assertJsonPath( 'data.0.type', 'wp_navigation' )
+		->assertJsonPath( 'data.0.title.rendered', 'Primary' )
+		->assertJsonPath( 'data.0.menu_order', 0 )
+		->assertJsonPath( 'data.1.slug', 'footer-nav' )
+		->assertJsonPath( 'data.1.menu_order', 5 );
+} );
+
+it( 'filters the index by slug and status', function () {
+	actingAsNavigationUser();
+
+	createNavigation( [ 'slug' => 'primary-nav', 'status' => 'publish' ] );
+	createNavigation( [ 'slug' => 'footer-nav', 'status' => 'draft' ] );
+	createNavigation( [ 'slug' => 'secondary-nav', 'status' => 'publish' ] );
+
+	$this->getJson( '/visual-editor/api/navigation?status=publish' )
+		->assertOk()
+		->assertJsonCount( 2, 'data' );
+
+	$this->getJson( '/visual-editor/api/navigation?slug=footer-nav' )
+		->assertOk()
+		->assertJsonCount( 1, 'data' )
+		->assertJsonPath( 'data.0.slug', 'footer-nav' );
+} );
+
+it( 'returns 401 when unauthenticated on show', function () {
+	$navigation = createNavigation();
+
+	$this->getJson( "/visual-editor/api/navigation/{$navigation->id}" )->assertUnauthorized();
+} );
+
+it( 'returns the content envelope and rendered title on show', function () {
+	actingAsNavigationUser();
+
+	$navigation = createNavigation();
+
+	$this->getJson( "/visual-editor/api/navigation/{$navigation->id}" )
+		->assertOk()
+		->assertJsonPath( 'id', $navigation->id )
+		->assertJsonPath( 'slug', 'primary-nav' )
+		->assertJsonPath( 'type', 'wp_navigation' )
+		->assertJsonPath( 'title.rendered', 'Primary' )
+		->assertJsonPath( 'content.raw', '<!-- wp:navigation-link {"label":"Home","url":"/"} /-->' )
+		->assertJsonPath( 'content.blocks.0.name', 'core/navigation-link' )
+		->assertJsonPath( 'status', 'publish' )
+		->assertJsonPath( 'menu_order', 0 );
+} );
+
+it( 'returns 404 when the navigation id does not exist', function () {
+	actingAsNavigationUser();
+
+	$this->getJson( '/visual-editor/api/navigation/999' )->assertNotFound();
+} );
+
+it( 'creates a navigation with a 201 Created response', function () {
+	actingAsNavigationUser();
+
+	$payload = [
+		'slug'       => 'footer-nav',
+		'title'      => 'Footer',
+		'content'    => [
+			'raw'    => '<!-- wp:navigation-link {"label":"Privacy","url":"/privacy"} /-->',
+			'blocks' => [
+				[
+					'name'        => 'core/navigation-link',
+					'attributes'  => [ 'label' => 'Privacy', 'url' => '/privacy' ],
+					'innerBlocks' => [],
+				],
+			],
+		],
+		'status'     => 'publish',
+		'menu_order' => 2,
+	];
+
+	$this->postJson( '/visual-editor/api/navigation', $payload )
+		->assertCreated()
+		->assertJsonPath( 'slug', 'footer-nav' )
+		->assertJsonPath( 'menu_order', 2 )
+		->assertJsonPath( 'content.raw', '<!-- wp:navigation-link {"label":"Privacy","url":"/privacy"} /-->' )
+		->assertJsonPath( 'content.blocks.0.name', 'core/navigation-link' );
+
+	expect( VisualEditorNavigation::where( 'slug', 'footer-nav' )->first() )
+		->not->toBeNull()
+		->getBlocks()->toEqual( [
+			[
+				'name'        => 'core/navigation-link',
+				'attributes'  => [ 'label' => 'Privacy', 'url' => '/privacy' ],
+				'innerBlocks' => [],
+			],
+		] );
+} );
+
+it( 'rejects store when the slug already exists', function () {
+	actingAsNavigationUser();
+
+	createNavigation( [ 'slug' => 'primary-nav' ] );
+
+	$this->postJson( '/visual-editor/api/navigation', [
+		'slug' => 'primary-nav',
+	] )
+		->assertUnprocessable()
+		->assertJsonValidationErrors( 'slug' );
+} );
+
+it( 'rejects store when the block tree is malformed', function () {
+	actingAsNavigationUser();
+
+	$this->postJson( '/visual-editor/api/navigation', [
+		'slug'    => 'broken-nav',
+		'content' => [
+			'raw'    => '',
+			'blocks' => [
+				[ 'not-a-block' => true ],
+			],
+		],
+	] )
+		->assertUnprocessable()
+		->assertJsonValidationErrors( 'content.blocks' );
+} );
+
+it( 'rejects store when status is outside the enum', function () {
+	actingAsNavigationUser();
+
+	$this->postJson( '/visual-editor/api/navigation', [
+		'slug'   => 'maybe-nav',
+		'status' => 'trashed',
+	] )
+		->assertUnprocessable()
+		->assertJsonValidationErrors( 'status' );
+} );
+
+it( 'updates a navigation with a partial payload', function () {
+	actingAsNavigationUser();
+
+	$navigation = createNavigation( [ 'title' => 'Before' ] );
+
+	$this->putJson( "/visual-editor/api/navigation/{$navigation->id}", [
+		'title' => 'After',
+	] )
+		->assertOk()
+		->assertJsonPath( 'title.rendered', 'After' )
+		->assertJsonPath( 'slug', 'primary-nav' );
+
+	expect( $navigation->fresh()->title )->toBe( 'After' );
+} );
+
+it( 'persists a new content envelope on update', function () {
+	actingAsNavigationUser();
+
+	$navigation = createNavigation();
+
+	$newContent = [
+		'raw'    => '<!-- wp:navigation-link {"label":"About","url":"/about"} /-->',
+		'blocks' => [
+			[
+				'name'        => 'core/navigation-link',
+				'attributes'  => [ 'label' => 'About', 'url' => '/about' ],
+				'innerBlocks' => [],
+			],
+		],
+	];
+
+	$this->putJson( "/visual-editor/api/navigation/{$navigation->id}", [
+		'content' => $newContent,
+	] )
+		->assertOk()
+		->assertJsonPath( 'content.raw', $newContent['raw'] )
+		->assertJsonPath( 'content.blocks.0.attributes.label', 'About' );
+
+	expect( $navigation->fresh()->getContentEnvelope() )->toEqual( $newContent );
+} );
+
+it( 'deletes a navigation', function () {
+	actingAsNavigationUser();
+
+	$navigation = createNavigation();
+
+	$this->deleteJson( "/visual-editor/api/navigation/{$navigation->id}" )
+		->assertNoContent();
+
+	expect( VisualEditorNavigation::find( $navigation->id ) )->toBeNull();
+} );
+
+it( 'round-trips the nested.json fixture without reshaping the submenu', function () {
+	actingAsNavigationUser();
+
+	$fixturePath = dirname( __DIR__, 2 ) . '/Fixtures/sample-content/navigation/nested.json';
+	$fixture     = json_decode( (string) file_get_contents( $fixturePath ), true, flags: JSON_THROW_ON_ERROR );
+
+	$payload = [
+		'slug'       => $fixture['slug'],
+		'title'      => $fixture['title']['rendered'] ?? '',
+		'content'    => $fixture['content'],
+		'status'     => $fixture['status'],
+		'menu_order' => $fixture['menu_order'],
+	];
+
+	$response = $this->postJson( '/visual-editor/api/navigation', $payload )
+		->assertCreated()
+		->assertJsonPath( 'slug', $fixture['slug'] )
+		->assertJsonPath( 'content.raw', $fixture['content']['raw'] )
+		->assertJsonPath( 'content.blocks', $fixture['content']['blocks'] );
+
+	$id = $response->json( 'id' );
+
+	$this->getJson( "/visual-editor/api/navigation/{$id}" )
+		->assertOk()
+		->assertJsonPath( 'content.blocks', $fixture['content']['blocks'] )
+		->assertJsonPath( 'content.blocks.1.name', 'core/navigation-submenu' )
+		->assertJsonPath( 'content.blocks.1.innerBlocks.0.name', 'core/navigation-link' )
+		->assertJsonPath( 'content.blocks.1.innerBlocks.0.attributes.label', 'Featured' );
+} );
+
+it( 'round-trips all B2 navigation fixtures through store + show', function () {
+	actingAsNavigationUser();
+
+	$fixturesDir = dirname( __DIR__, 2 ) . '/Fixtures/sample-content/navigation';
+	$files       = glob( $fixturesDir . '/*.json' );
+
+	expect( $files )->not->toBeEmpty();
+
+	foreach ( $files as $file ) {
+		$fixture = json_decode( (string) file_get_contents( $file ), true, flags: JSON_THROW_ON_ERROR );
+
+		$payload = [
+			'slug'       => $fixture['slug'],
+			'title'      => $fixture['title']['rendered'] ?? '',
+			'content'    => $fixture['content'] ?? [ 'raw' => '', 'blocks' => [] ],
+			'status'     => $fixture['status'] ?? 'publish',
+			'menu_order' => $fixture['menu_order'] ?? 0,
+		];
+
+		$response = $this->postJson( '/visual-editor/api/navigation', $payload )
+			->assertCreated()
+			->assertJsonPath( 'slug', $fixture['slug'] );
+
+		$id = $response->json( 'id' );
+
+		$this->getJson( "/visual-editor/api/navigation/{$id}" )
+			->assertOk()
+			->assertJsonPath( 'slug', $fixture['slug'] )
+			->assertJsonPath( 'content.blocks', $fixture['content']['blocks'] );
+	}
+} );
+
+it( 'rejects a null title on store (column is non-nullable)', function () {
+	actingAsNavigationUser();
+
+	$this->postJson( '/visual-editor/api/navigation', [
+		'slug'  => 'broken-nav',
+		'title' => null,
+	] )
+		->assertUnprocessable()
+		->assertJsonValidationErrors( 'title' );
+} );
+
+it( 'rejects a null title on update (column is non-nullable)', function () {
+	actingAsNavigationUser();
+
+	$navigation = createNavigation();
+
+	$this->putJson( "/visual-editor/api/navigation/{$navigation->id}", [
+		'title' => null,
+	] )
+		->assertUnprocessable()
+		->assertJsonValidationErrors( 'title' );
+
+	expect( $navigation->fresh()->title )->toBe( 'Primary' );
+} );
+
+it( 'rejects a bare-list content payload on store', function () {
+	actingAsNavigationUser();
+
+	$this->postJson( '/visual-editor/api/navigation', [
+		'slug'    => 'broken-nav',
+		'content' => [
+			[
+				'name'        => 'core/navigation-link',
+				'attributes'  => [],
+				'innerBlocks' => [],
+			],
+		],
+	] )
+		->assertUnprocessable()
+		->assertJsonValidationErrors( 'content' );
+} );
+
+it( 'rejects a bare-list content payload on update', function () {
+	actingAsNavigationUser();
+
+	$navigation = createNavigation();
+
+	$this->putJson( "/visual-editor/api/navigation/{$navigation->id}", [
+		'content' => [
+			[
+				'name'        => 'core/navigation-link',
+				'attributes'  => [],
+				'innerBlocks' => [],
+			],
+		],
+	] )
+		->assertUnprocessable()
+		->assertJsonValidationErrors( 'content' );
+} );
+
+it( 'rejects a slug-only update that would collide with an existing slug', function () {
+	actingAsNavigationUser();
+
+	$editing = createNavigation( [ 'slug' => 'primary-nav' ] );
+	createNavigation( [ 'slug' => 'footer-nav' ] );
+
+	$this->putJson( "/visual-editor/api/navigation/{$editing->id}", [
+		'slug' => 'footer-nav',
+	] )
+		->assertUnprocessable()
+		->assertJsonValidationErrors( 'slug' );
+
+	expect( $editing->fresh()->slug )->toBe( 'primary-nav' );
+} );
+
+it( 'allows updating a record without changing its slug', function () {
+	actingAsNavigationUser();
+
+	$navigation = createNavigation( [ 'slug' => 'primary-nav' ] );
+
+	$this->putJson( "/visual-editor/api/navigation/{$navigation->id}", [
+		'slug'  => 'primary-nav',
+		'title' => 'Renamed',
+	] )
+		->assertOk()
+		->assertJsonPath( 'slug', 'primary-nav' )
+		->assertJsonPath( 'title.rendered', 'Renamed' );
+} );
+
+it( 'rejects unauthenticated store, update, and destroy', function () {
+	$navigation = createNavigation();
+
+	$this->postJson( '/visual-editor/api/navigation', [
+		'slug' => 'new-nav',
+	] )->assertUnauthorized();
+
+	$this->putJson( "/visual-editor/api/navigation/{$navigation->id}", [
+		'title' => 'Nope',
+	] )->assertUnauthorized();
+
+	$this->deleteJson( "/visual-editor/api/navigation/{$navigation->id}" )->assertUnauthorized();
+} );


### PR DESCRIPTION
## Description

Lands the server-side backing for the `wp_navigation` entity the B1 core-data shim dispatches to `/visual-editor/api/navigation`. Adds the model, migration, CRUD REST controller, form-request validation, resource, policy, and the config-driven menu-locations surface `core/navigation` will read in D4/E4.

**Closes:** #360

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #360

## Motivation and Context

Per §4.3 of the V1 plan doc, navigation is the single biggest risk area in the expansion — `core/navigation` pulls a disproportionate share of the core-data surface with it. B1 (#353) absorbed the client-side shim work and B2 (#354) shipped the fixtures; C4 lands the backend contract so D4 (nav editor UI) can re-enable `core/navigation`.

Menu locations for V1 are configuration-driven per §8 of the plan doc — a `navigation.locations` array in `config/artisanpack/visual-editor.php` names the slugs the theme exposes and maps each to a nav record (or the fallback). No admin CRUD for locations in V1; that's 1.1+.

## Changes Made

- `VisualEditorNavigation` Eloquent model backing `wp_navigation` with `{raw, blocks}` envelope helpers, `published()` scope, and `isEmpty()` check.
- Migration for `visual_editor_navigations` (id, unique slug, title, content JSON, status indexed, menu_order indexed, timestamps).
- `NavigationController` with the five shim-compatible endpoints mounted under `/visual-editor/api/navigation[/:id]`.
- `StoreNavigationRequest` / `UpdateNavigationRequest` — status enum, `{raw, blocks}` envelope shape, `TemplateBlockTreeRule` for the block tree, unique slug (ignore-self on update).
- `NavigationResource` shaping records into the B1 `wp_navigation` envelope (`title.rendered`, `content.{raw,blocks}`, `menu_order`, `type: wp_navigation`).
- `VisualEditorNavigationPolicy` — auth-gated CRUD matching the Template policy default.
- `navigation.locations` config section with a documented `{slug, label, primary_id?}` shape.
- `MenuLocationResolver::forLocation($slug)` service — returns configured primary when assigned + non-empty, else falls back to the first published nav by `menu_order`, else null.
- Policy + resolver wired into the service provider; routes mounted in `routes/api.php` alongside the rest of the C-phase surface.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (Darwin 25.3.0)
- PHP Version: 8.4.3
- Project Version: release/1.0

**Tests Performed:**
1. Full pest suite — 305 passed (952 assertions), no regressions.
2. Navigation-specific suite — 32 new tests covering index / show (hit + 404) / store / update / destroy, validation, policy gating, nested.json round-trip, all B2 fixtures round-trip, and every `MenuLocationResolver` branch (configured hit, null primary_id, missing id, empty record, no published navs, unknown slug, malformed config).
3. CodeRabbit CLI review against `release/1.0` — no findings.

## Accessibility Tests Run

- [x] N/A — backend-only change (no user-facing UI)

**Details:** Backend-only PR. No templates, views, or frontend code shipped.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:**
- `tests/Feature/VisualEditor/NavigationControllerTest.php` — 22 tests covering the full REST surface plus bare-list rejection, null-title rejection, slug-collision updates, and the B2 fixture round-trip.
- `tests/Feature/VisualEditor/MenuLocationResolverTest.php` — 10 tests covering configured-hit, fallback-hit for null/missing/empty primary, empty-DB null, draft exclusion, unknown-slug fallback, locations() normalization, malformed entry filtering.

## Documentation

- [x] Inline code documentation added

**Documentation details:** PHPDoc blocks on every new class and public method. The `navigation.locations` config block is documented inline in `config/visual-editor.php`. No separate docs file needed — `docs/core-data-shim.md` §Navigation already locks the record shape.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests (305/305)
- [x] Code has been linted (no lint tooling configured in this package; follows existing Template/Global-Styles patterns)
- [x] Accessibility tests completed (N/A — backend-only)
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added REST API endpoints for managing visual editor navigations with create, read, update, delete, and list operations.
  * Added support for storing navigation content with draft and published status options.
  * Added configurable menu location mapping to integrate theme menus with stored navigations.

* **Tests**
  * Added comprehensive test coverage for navigation API functionality and menu location resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->