### PR TITLE
C5 · Patterns: model, migration (synced + unsynced), API

### DIFF
--- a/database/migrations/2026_04_23_400000_create_visual_editor_patterns_table.php
+++ b/database/migrations/2026_04_23_400000_create_visual_editor_patterns_table.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * Create visual_editor_patterns table migration.
+ *
+ * Storage for the `wp_block` entity the B1 core-data shim addresses at
+ * `/visual-editor/api/patterns`. Holds the Gutenberg block tree along with
+ * the raw serialized payload, plus the `synced` flag that distinguishes
+ * reusable (synced) patterns from one-shot (unsynced) inserts. See
+ * `docs/core-data-shim.md` §Patterns for the REST record shape and
+ * `docs/plans/11-v1-expansion.md` §2.2 for the synced-vs-unsynced model.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+	public function up(): void
+	{
+		Schema::create( 'visual_editor_patterns', function ( Blueprint $table ) {
+			$table->id();
+			$table->string( 'slug' )->unique();
+			$table->string( 'title' )->default( '' );
+			// The API envelope { raw, blocks } is stored verbatim; an empty
+			// pattern is `{ "raw": "", "blocks": [] }` so the column is
+			// never null once hydrated through the model.
+			$table->json( 'content' )->nullable();
+			// `synced: true` records are referenced by id from every
+			// instance; `synced: false` records are copied into the target
+			// on insert. The backend stores the flag faithfully — the
+			// editor decides reference-vs-copy on insert (D5 / E3).
+			$table->boolean( 'synced' )->default( false )->index();
+			$table->string( 'status' )->default( 'publish' )->index();
+			$table->timestamps();
+		} );
+	}
+
+	public function down(): void
+	{
+		Schema::dropIfExists( 'visual_editor_patterns' );
+	}
+};

--- a/database/migrations/2026_04_23_500000_create_visual_editor_pattern_categories_table.php
+++ b/database/migrations/2026_04_23_500000_create_visual_editor_pattern_categories_table.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * Create visual_editor_pattern_categories table migration.
+ *
+ * Lookup table backing the many-to-many category relationship between
+ * patterns (`wp_block`) and their categories. Categories are addressed by
+ * slug in the REST payload (`categories: ["featured", "pricing"]`) and
+ * auto-created on first use from store / update requests, matching the
+ * B2 fixture shape.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+	public function up(): void
+	{
+		Schema::create( 'visual_editor_pattern_categories', function ( Blueprint $table ) {
+			$table->id();
+			$table->string( 'slug' )->unique();
+			$table->string( 'name' )->default( '' );
+			$table->timestamps();
+		} );
+	}
+
+	public function down(): void
+	{
+		Schema::dropIfExists( 'visual_editor_pattern_categories' );
+	}
+};

--- a/database/migrations/2026_04_23_600000_create_visual_editor_pattern_category_table.php
+++ b/database/migrations/2026_04_23_600000_create_visual_editor_pattern_category_table.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * Create visual_editor_pattern_category pivot table migration.
+ *
+ * Pivot joining `visual_editor_patterns` to `visual_editor_pattern_categories`.
+ * A composite primary key on `(pattern_id, pattern_category_id)` keeps each
+ * (pattern, category) pair to a single row, and `ON DELETE CASCADE` on both
+ * sides keeps the pivot from stranding orphan rows when either side is
+ * deleted.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+	public function up(): void
+	{
+		Schema::create( 'visual_editor_pattern_category', function ( Blueprint $table ) {
+			$table->foreignId( 'pattern_id' )
+				->constrained( 'visual_editor_patterns' )
+				->cascadeOnDelete();
+
+			$table->foreignId( 'pattern_category_id' )
+				->constrained( 'visual_editor_pattern_categories' )
+				->cascadeOnDelete();
+
+			$table->primary( [ 'pattern_id', 'pattern_category_id' ] );
+		} );
+	}
+
+	public function down(): void
+	{
+		Schema::dropIfExists( 'visual_editor_pattern_category' );
+	}
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -20,6 +20,7 @@ declare( strict_types=1 );
 use ArtisanPackUI\VisualEditor\Http\Controllers\BlockPreviewController;
 use ArtisanPackUI\VisualEditor\Http\Controllers\GlobalStylesController;
 use ArtisanPackUI\VisualEditor\Http\Controllers\NavigationController;
+use ArtisanPackUI\VisualEditor\Http\Controllers\PatternController;
 use ArtisanPackUI\VisualEditor\Http\Controllers\ResourceContentController;
 use ArtisanPackUI\VisualEditor\Http\Controllers\TemplateController;
 use ArtisanPackUI\VisualEditor\Http\Controllers\TemplatePartController;
@@ -90,6 +91,22 @@ Route::get( 'global-styles/{globalStyle}', [ GlobalStylesController::class, 'sho
 
 Route::put( 'global-styles/{globalStyle}', [ GlobalStylesController::class, 'update' ] )
 	->name( 'visual-editor.api.global-styles.update' );
+
+// C5 `wp_block` REST surface — see docs/core-data-shim.md §Patterns.
+Route::get( 'patterns', [ PatternController::class, 'index' ] )
+	->name( 'visual-editor.api.patterns.index' );
+
+Route::post( 'patterns', [ PatternController::class, 'store' ] )
+	->name( 'visual-editor.api.patterns.store' );
+
+Route::get( 'patterns/{pattern}', [ PatternController::class, 'show' ] )
+	->name( 'visual-editor.api.patterns.show' );
+
+Route::put( 'patterns/{pattern}', [ PatternController::class, 'update' ] )
+	->name( 'visual-editor.api.patterns.update' );
+
+Route::delete( 'patterns/{pattern}', [ PatternController::class, 'destroy' ] )
+	->name( 'visual-editor.api.patterns.destroy' );
 
 // C4 `wp_navigation` REST surface — see docs/core-data-shim.md §Navigation.
 Route::get( 'navigation', [ NavigationController::class, 'index' ] )

--- a/src/Http/Controllers/PatternController.php
+++ b/src/Http/Controllers/PatternController.php
@@ -1,0 +1,279 @@
+<?php
+
+/**
+ * Pattern controller.
+ *
+ * Serves the REST surface for the `wp_block` entity behind the B1
+ * core-data shim (see `docs/core-data-shim.md` §Patterns). The five
+ * endpoints — index, show, store, update, destroy — mount under
+ * `/visual-editor/api/patterns` via the package's auth-gated API group
+ * and return responses shaped by {@see PatternResource}.
+ *
+ * Categories are addressed by slug (`categories: ["featured"]`) on the
+ * way in and out; any slug missing from the `visual_editor_pattern_categories`
+ * lookup table is auto-created on first use, matching WordPress's UX
+ * and the B2 fixture shape.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Http\Controllers;
+
+use ArtisanPackUI\VisualEditor\Http\Requests\StorePatternRequest;
+use ArtisanPackUI\VisualEditor\Http\Requests\UpdatePatternRequest;
+use ArtisanPackUI\VisualEditor\Http\Resources\PatternResource;
+use ArtisanPackUI\VisualEditor\Models\VisualEditorPattern;
+use ArtisanPackUI\VisualEditor\Models\VisualEditorPatternCategory;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Illuminate\Http\Response;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Gate;
+
+class PatternController extends Controller
+{
+	/**
+	 * Maximum per-page size for the index endpoint. Keeps a malicious or
+	 * accidental `?per_page=999999` query from dragging the inserter
+	 * down while still letting the host page through explicit requests
+	 * when necessary.
+	 */
+	protected const MAX_PER_PAGE = 100;
+
+	/**
+	 * Lists patterns with a paginated `{ data, meta }` envelope.
+	 *
+	 * Supports filtering by slug, status, synced flag, and category slug
+	 * (one or many, OR semantics — `?categories=featured` or
+	 * `?categories[]=featured&categories[]=pricing`).
+	 *
+	 * @since 1.0.0
+	 */
+	public function index( Request $request ): AnonymousResourceCollection
+	{
+		Gate::authorize( 'viewAny', VisualEditorPattern::class );
+
+		$perPage = (int) $request->integer( 'per_page', 25 );
+
+		if ( $perPage < 1 ) {
+			$perPage = 25;
+		}
+
+		if ( $perPage > self::MAX_PER_PAGE ) {
+			$perPage = self::MAX_PER_PAGE;
+		}
+
+		$query = VisualEditorPattern::query()->with( 'categories' )->orderBy( 'id' );
+
+		$slug = $request->string( 'slug' )->toString();
+		if ( '' !== $slug ) {
+			$query->where( 'slug', $slug );
+		}
+
+		$status = $request->string( 'status' )->toString();
+		if ( '' !== $status ) {
+			$query->where( 'status', $status );
+		}
+
+		if ( $request->has( 'synced' ) ) {
+			$query->where( 'synced', $request->boolean( 'synced' ) );
+		}
+
+		$categories = $this->normalizeCategoryFilter( $request->input( 'categories' ) );
+		if ( [] !== $categories ) {
+			$query->withAnyCategory( $categories );
+		}
+
+		return PatternResource::collection( $query->paginate( $perPage ) );
+	}
+
+	/**
+	 * Returns a single pattern.
+	 *
+	 * The shim expects the record at the top level (not wrapped in `data`)
+	 * so `fetchEntityRecord` can dispatch it straight into the cache.
+	 *
+	 * @since 1.0.0
+	 */
+	public function show( Request $request, VisualEditorPattern $pattern ): JsonResponse
+	{
+		Gate::authorize( 'view', $pattern );
+
+		$pattern->loadMissing( 'categories' );
+
+		return response()->json( ( new PatternResource( $pattern ) )->toArray( $request ) );
+	}
+
+	/**
+	 * Creates a new pattern.
+	 *
+	 * @since 1.0.0
+	 */
+	public function store( StorePatternRequest $request ): JsonResponse
+	{
+		Gate::authorize( 'create', VisualEditorPattern::class );
+
+		$data = $request->validated();
+
+		$pattern = new VisualEditorPattern();
+		$pattern->fill( [
+			'slug'   => $data['slug'],
+			'title'  => $data['title'] ?? '',
+			'synced' => (bool) ( $data['synced'] ?? false ),
+			'status' => $data['status'] ?? VisualEditorPattern::STATUS_PUBLISH,
+		] );
+
+		$pattern->setContentEnvelope( $this->normalizeContentEnvelope( $data['content'] ?? null ) );
+		$pattern->save();
+
+		if ( array_key_exists( 'categories', $data ) ) {
+			$this->syncCategories( $pattern, $data['categories'] );
+		}
+
+		$pattern->load( 'categories' );
+
+		return response()->json(
+			( new PatternResource( $pattern ) )->toArray( $request ),
+			Response::HTTP_CREATED
+		);
+	}
+
+	/**
+	 * Updates an existing pattern.
+	 *
+	 * @since 1.0.0
+	 */
+	public function update( UpdatePatternRequest $request, VisualEditorPattern $pattern ): JsonResponse
+	{
+		Gate::authorize( 'update', $pattern );
+
+		$data = $request->validated();
+
+		foreach ( [ 'slug', 'title', 'status' ] as $field ) {
+			if ( array_key_exists( $field, $data ) ) {
+				$pattern->{$field} = $data[ $field ];
+			}
+		}
+
+		if ( array_key_exists( 'synced', $data ) ) {
+			$pattern->synced = (bool) $data['synced'];
+		}
+
+		if ( array_key_exists( 'content', $data ) ) {
+			$pattern->setContentEnvelope( $this->normalizeContentEnvelope( $data['content'] ) );
+		}
+
+		$pattern->save();
+
+		if ( array_key_exists( 'categories', $data ) ) {
+			$this->syncCategories( $pattern, $data['categories'] );
+		}
+
+		$pattern->load( 'categories' );
+
+		return response()->json( ( new PatternResource( $pattern ) )->toArray( $request ) );
+	}
+
+	/**
+	 * Deletes a pattern. The pivot rows are removed by the cascading
+	 * foreign key on `visual_editor_pattern_category`.
+	 *
+	 * @since 1.0.0
+	 */
+	public function destroy( VisualEditorPattern $pattern ): JsonResponse
+	{
+		Gate::authorize( 'delete', $pattern );
+
+		$pattern->delete();
+
+		return response()->json( null, Response::HTTP_NO_CONTENT );
+	}
+
+	/**
+	 * Normalizes the inbound content payload into the `{ raw, blocks }`
+	 * envelope the model expects. Form-request validation guarantees
+	 * the shape before we get here; this method just guards against
+	 * missing keys and bad types as a belt-and-braces fallback.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  mixed  $content
+	 *
+	 * @return array{raw: string, blocks: array<int, array<string, mixed>>}
+	 */
+	protected function normalizeContentEnvelope( mixed $content ): array
+	{
+		if ( ! is_array( $content ) ) {
+			return [ 'raw' => '', 'blocks' => [] ];
+		}
+
+		return [
+			'raw'    => isset( $content['raw'] ) && is_string( $content['raw'] ) ? $content['raw'] : '',
+			'blocks' => isset( $content['blocks'] ) && is_array( $content['blocks'] ) ? array_values( $content['blocks'] ) : [],
+		];
+	}
+
+	/**
+	 * Coerces the `?categories=` / `?categories[]=` query value into a
+	 * flat list of slug strings, dropping anything that isn't a non-empty
+	 * string.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  mixed  $value
+	 *
+	 * @return array<int, string>
+	 */
+	protected function normalizeCategoryFilter( mixed $value ): array
+	{
+		if ( is_string( $value ) ) {
+			$value = [ $value ];
+		}
+
+		if ( ! is_array( $value ) ) {
+			return [];
+		}
+
+		return array_values( array_filter(
+			$value,
+			fn ( $slug ) => is_string( $slug ) && '' !== $slug
+		) );
+	}
+
+	/**
+	 * Syncs the pattern's categories from an array of slugs, auto-creating
+	 * any slug that doesn't already exist in the lookup table.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array<int, mixed>  $slugs
+	 */
+	protected function syncCategories( VisualEditorPattern $pattern, array $slugs ): void
+	{
+		$normalized = array_values( array_unique( array_filter(
+			$slugs,
+			fn ( $slug ) => is_string( $slug ) && '' !== $slug
+		) ) );
+
+		$ids = [];
+
+		foreach ( $normalized as $slug ) {
+			$category = VisualEditorPatternCategory::firstOrCreate(
+				[ 'slug' => $slug ],
+				[ 'name' => $slug ]
+			);
+
+			$ids[] = $category->getKey();
+		}
+
+		$pattern->categories()->sync( $ids );
+	}
+}

--- a/src/Http/Requests/StorePatternRequest.php
+++ b/src/Http/Requests/StorePatternRequest.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * StorePattern form request.
+ *
+ * Validates the payload for creating a `wp_block` record via
+ * `POST /visual-editor/api/patterns`.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Http\Requests;
+
+use ArtisanPackUI\VisualEditor\Models\VisualEditorPattern;
+use ArtisanPackUI\VisualEditor\Rules\TemplateBlockTreeRule;
+use Closure;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StorePatternRequest extends FormRequest
+{
+	public function authorize(): bool
+	{
+		return true;
+	}
+
+	/**
+	 * @return array<string, array<int, mixed>>
+	 */
+	public function rules(): array
+	{
+		return [
+			'slug'           => [
+				'required',
+				'string',
+				'max:191',
+				Rule::unique( 'visual_editor_patterns', 'slug' ),
+			],
+			// `title` and `status` are backed by non-nullable DB columns
+			// (defaults: '', 'publish'). The store controller falls back
+			// to those defaults when the field is missing, but `null` is
+			// never a legal value — rejecting it here keeps the DB from
+			// rejecting the write later with an opaque QueryException.
+			'title'          => [ 'sometimes', 'string', 'max:255' ],
+			'content'        => [ 'nullable', 'array', $this->envelopeShapeRule() ],
+			'content.raw'    => [ 'nullable', 'string' ],
+			'content.blocks' => [ 'nullable', 'array', new TemplateBlockTreeRule() ],
+			'synced'         => [ 'sometimes', 'boolean' ],
+			'status'         => [
+				'sometimes',
+				'string',
+				Rule::in( [
+					VisualEditorPattern::STATUS_PUBLISH,
+					VisualEditorPattern::STATUS_DRAFT,
+					VisualEditorPattern::STATUS_PRIVATE,
+				] ),
+			],
+			'categories'     => [ 'sometimes', 'array' ],
+			'categories.*'   => [ 'string', 'max:191' ],
+		];
+	}
+
+	/**
+	 * Rejects a bare-list `content` payload.
+	 *
+	 * `content.blocks` is only validated when the request uses the
+	 * `{ raw, blocks }` envelope; without this rule a caller could send
+	 * `content: [ <blocks> ]` to skip `TemplateBlockTreeRule` entirely.
+	 *
+	 * @since 1.0.0
+	 */
+	protected function envelopeShapeRule(): Closure
+	{
+		return function ( string $attribute, mixed $value, Closure $fail ): void {
+			if ( is_array( $value ) && [] !== $value && array_is_list( $value ) ) {
+				$fail( 'The :attribute must be a { raw, blocks } envelope, not a bare list of blocks.' );
+			}
+		};
+	}
+}

--- a/src/Http/Requests/UpdatePatternRequest.php
+++ b/src/Http/Requests/UpdatePatternRequest.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * UpdatePattern form request.
+ *
+ * Validates the payload for updating a `wp_block` record via
+ * `PUT /visual-editor/api/patterns/{id}`.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Http\Requests;
+
+use ArtisanPackUI\VisualEditor\Models\VisualEditorPattern;
+use ArtisanPackUI\VisualEditor\Rules\TemplateBlockTreeRule;
+use Closure;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdatePatternRequest extends FormRequest
+{
+	public function authorize(): bool
+	{
+		return true;
+	}
+
+	/**
+	 * @return array<string, array<int, mixed>>
+	 */
+	public function rules(): array
+	{
+		/** @var VisualEditorPattern $pattern */
+		$pattern = $this->route( 'pattern' );
+
+		return [
+			'slug'            => [
+				'sometimes',
+				'required',
+				'string',
+				'max:191',
+				Rule::unique( 'visual_editor_patterns', 'slug' )->ignore( $pattern->getKey() ),
+			],
+			// `title` and `status` back non-nullable DB columns — null is
+			// never a legal value. The update controller leaves missing
+			// fields untouched, so dropping `nullable` here only tightens
+			// the error path without changing what a partial update can do.
+			'title'           => [ 'sometimes', 'string', 'max:255' ],
+			'content'         => [ 'sometimes', 'nullable', 'array', $this->envelopeShapeRule() ],
+			'content.raw'     => [ 'sometimes', 'nullable', 'string' ],
+			'content.blocks'  => [ 'sometimes', 'nullable', 'array', new TemplateBlockTreeRule() ],
+			'synced'          => [ 'sometimes', 'boolean' ],
+			'status'          => [
+				'sometimes',
+				'string',
+				Rule::in( [
+					VisualEditorPattern::STATUS_PUBLISH,
+					VisualEditorPattern::STATUS_DRAFT,
+					VisualEditorPattern::STATUS_PRIVATE,
+				] ),
+			],
+			'categories'      => [ 'sometimes', 'array' ],
+			'categories.*'    => [ 'string', 'max:191' ],
+		];
+	}
+
+	/**
+	 * Rejects a bare-list `content` payload — see the mirrored method on
+	 * {@see StorePatternRequest::envelopeShapeRule()} for why.
+	 *
+	 * @since 1.0.0
+	 */
+	protected function envelopeShapeRule(): Closure
+	{
+		return function ( string $attribute, mixed $value, Closure $fail ): void {
+			if ( is_array( $value ) && [] !== $value && array_is_list( $value ) ) {
+				$fail( 'The :attribute must be a { raw, blocks } envelope, not a bare list of blocks.' );
+			}
+		};
+	}
+}

--- a/src/Http/Resources/PatternResource.php
+++ b/src/Http/Resources/PatternResource.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * PatternResource API resource.
+ *
+ * Shapes a {@see VisualEditorPattern} into the B1 core-data shim's
+ * `wp_block` record envelope. Keeps the HTTP response contract in one
+ * place so controllers and tests don't have to reconstruct the
+ * `title.rendered`, `content.{raw,blocks}`, and `categories` wrappers
+ * ad hoc.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Http\Resources;
+
+use ArtisanPackUI\VisualEditor\Models\VisualEditorPattern;
+use ArtisanPackUI\VisualEditor\Models\VisualEditorPatternCategory;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @property VisualEditorPattern $resource
+ */
+class PatternResource extends JsonResource
+{
+	/**
+	 * Transforms the pattern into the shim-compatible record shape.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function toArray( Request $request ): array
+	{
+		/** @var VisualEditorPattern $pattern */
+		$pattern = $this->resource;
+
+		$envelope = $pattern->getContentEnvelope();
+
+		$categories = $pattern->relationLoaded( 'categories' )
+			? $pattern->categories
+			: $pattern->categories()->get();
+
+		return [
+			'id'         => $pattern->getKey(),
+			'slug'       => $pattern->slug,
+			'title'      => [
+				'rendered' => (string) ( $pattern->title ?? '' ),
+			],
+			'content'    => [
+				'raw'    => $envelope['raw'],
+				'blocks' => $envelope['blocks'],
+			],
+			'synced'     => (bool) $pattern->synced,
+			'categories' => $categories
+				->map( fn ( VisualEditorPatternCategory $category ) => $category->slug )
+				->values()
+				->all(),
+			'status'     => $pattern->status,
+			'type'       => 'wp_block',
+		];
+	}
+}

--- a/src/Models/VisualEditorPattern.php
+++ b/src/Models/VisualEditorPattern.php
@@ -1,0 +1,198 @@
+<?php
+
+/**
+ * VisualEditorPattern model.
+ *
+ * Eloquent backing for the `wp_block` entity exposed at
+ * `/visual-editor/api/patterns`. Stores the Gutenberg block tree inside
+ * the `{ raw, blocks }` envelope the B1 core-data shim expects, along
+ * with the `synced` flag and category relationships documented in
+ * `docs/core-data-shim.md` §Patterns and `docs/plans/11-v1-expansion.md`
+ * §2.2.
+ *
+ * A synced pattern (`synced: true`) is stored once and referenced by id
+ * from every instance; editing the pattern propagates everywhere. An
+ * unsynced pattern (`synced: false`) is a one-shot insert — the editor
+ * copies its block tree into the target on insert, and the two diverge
+ * from there. The backend stores the flag faithfully — the editor
+ * decides reference-vs-copy on insert.
+ *
+ * Categories are a many-to-many relationship used by both the
+ * post-editor inserter's category list and the site-editor's pattern
+ * library. Authoring with `categories: ["featured"]` auto-creates the
+ * category on the first use, matching the B2 fixture shape.
+ *
+ * The model intentionally does not use the `HasBlockContent` trait —
+ * patterns hold the raw serialized payload alongside the parsed block
+ * tree (same rationale as {@see VisualEditorTemplate}).
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+class VisualEditorPattern extends Model
+{
+	public const STATUS_PUBLISH = 'publish';
+	public const STATUS_DRAFT   = 'draft';
+	public const STATUS_PRIVATE = 'private';
+
+	protected $table = 'visual_editor_patterns';
+
+	/**
+	 * @var array<int, string>
+	 */
+	protected $fillable = [
+		'slug',
+		'title',
+		'content',
+		'synced',
+		'status',
+	];
+
+	/**
+	 * @var array<string, string>
+	 */
+	protected $casts = [
+		'content' => 'array',
+		'synced'  => 'boolean',
+	];
+
+	/**
+	 * The categories this pattern belongs to.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return BelongsToMany<VisualEditorPatternCategory>
+	 */
+	public function categories(): BelongsToMany
+	{
+		return $this->belongsToMany(
+			VisualEditorPatternCategory::class,
+			'visual_editor_pattern_category',
+			'pattern_id',
+			'pattern_category_id'
+		);
+	}
+
+	/**
+	 * Returns the canonical content envelope stored on the record.
+	 *
+	 * Always returns the `{ raw, blocks }` shape — callers never have to
+	 * null-check the raw column or the blocks key separately.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array{raw: string, blocks: array<int, array<string, mixed>>}
+	 */
+	public function getContentEnvelope(): array
+	{
+		$value = $this->getAttribute( 'content' );
+
+		$raw    = '';
+		$blocks = [];
+
+		if ( is_array( $value ) ) {
+			$raw    = isset( $value['raw'] ) && is_string( $value['raw'] ) ? $value['raw'] : '';
+			$blocks = isset( $value['blocks'] ) && is_array( $value['blocks'] ) ? array_values( $value['blocks'] ) : [];
+		}
+
+		return [
+			'raw'    => $raw,
+			'blocks' => $blocks,
+		];
+	}
+
+	/**
+	 * Returns just the parsed block tree.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	public function getBlocks(): array
+	{
+		return $this->getContentEnvelope()['blocks'];
+	}
+
+	/**
+	 * Returns just the raw Gutenberg serialization.
+	 *
+	 * @since 1.0.0
+	 */
+	public function getRawContent(): string
+	{
+		return $this->getContentEnvelope()['raw'];
+	}
+
+	/**
+	 * Persists an updated content envelope on the record.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array{raw?: string, blocks?: array<int, array<string, mixed>>}  $envelope
+	 */
+	public function setContentEnvelope( array $envelope ): void
+	{
+		$raw    = isset( $envelope['raw'] ) && is_string( $envelope['raw'] ) ? $envelope['raw'] : '';
+		$blocks = isset( $envelope['blocks'] ) && is_array( $envelope['blocks'] ) ? array_values( $envelope['blocks'] ) : [];
+
+		$this->setAttribute( 'content', [
+			'raw'    => $raw,
+			'blocks' => $blocks,
+		] );
+	}
+
+	/**
+	 * Scopes the query to patterns matching a slug.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  Builder<VisualEditorPattern>  $query
+	 *
+	 * @return Builder<VisualEditorPattern>
+	 */
+	public function scopeForSlug( Builder $query, string $slug ): Builder
+	{
+		return $query->where( 'slug', $slug );
+	}
+
+	/**
+	 * Scopes the query to patterns that have at least one of the given
+	 * category slugs (OR semantics).
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  Builder<VisualEditorPattern>  $query
+	 * @param  array<int, string>            $slugs
+	 *
+	 * @return Builder<VisualEditorPattern>
+	 */
+	public function scopeWithAnyCategory( Builder $query, array $slugs ): Builder
+	{
+		$normalized = array_values( array_filter(
+			$slugs,
+			fn ( $slug ) => is_string( $slug ) && '' !== $slug
+		) );
+
+		if ( [] === $normalized ) {
+			return $query;
+		}
+
+		return $query->whereHas(
+			'categories',
+			fn ( Builder $subQuery ) => $subQuery->whereIn( 'slug', $normalized )
+		);
+	}
+}

--- a/src/Models/VisualEditorPatternCategory.php
+++ b/src/Models/VisualEditorPatternCategory.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * VisualEditorPatternCategory model.
+ *
+ * Lookup model for the many-to-many pattern categories relationship. A
+ * category is identified by its `slug` in the REST payload (the shape
+ * the B2 fixtures ship — `categories: ["featured"]`) and carries an
+ * optional human-readable `name` the site editor and inserter surfaces.
+ *
+ * Categories are auto-created on first use from the pattern store /
+ * update requests, matching WordPress's UX and the B2 fixture shape.
+ * Hosts that want a DBA-style lock-down can override the behavior in
+ * their own service provider.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+class VisualEditorPatternCategory extends Model
+{
+	protected $table = 'visual_editor_pattern_categories';
+
+	/**
+	 * @var array<int, string>
+	 */
+	protected $fillable = [
+		'slug',
+		'name',
+	];
+
+	/**
+	 * The patterns associated with this category.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return BelongsToMany<VisualEditorPattern>
+	 */
+	public function patterns(): BelongsToMany
+	{
+		return $this->belongsToMany(
+			VisualEditorPattern::class,
+			'visual_editor_pattern_category',
+			'pattern_category_id',
+			'pattern_id'
+		);
+	}
+}

--- a/src/Policies/VisualEditorPatternPolicy.php
+++ b/src/Policies/VisualEditorPatternPolicy.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * VisualEditorPattern policy.
+ *
+ * Authorization policy for the `wp_block` REST endpoints. The V1 default
+ * allows any authenticated user to read and mutate patterns, mirroring
+ * how the existing {@see VisualEditorTemplatePolicy} handles the
+ * site-level editor entities; host apps that need tighter access should
+ * swap the binding in their own service provider.
+ *
+ * Patterns have no "owner" — they're site-level content the editor and
+ * inserter surface to every author — so the `restrict_by_owner` config
+ * flag that governs posts doesn't apply here.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Policies;
+
+use ArtisanPackUI\VisualEditor\Models\VisualEditorPattern;
+use Illuminate\Auth\Access\HandlesAuthorization;
+use Illuminate\Contracts\Auth\Authenticatable;
+
+class VisualEditorPatternPolicy
+{
+	use HandlesAuthorization;
+
+	public function viewAny( ?Authenticatable $user ): bool
+	{
+		return null !== $user;
+	}
+
+	public function view( ?Authenticatable $user, VisualEditorPattern $pattern ): bool
+	{
+		return null !== $user;
+	}
+
+	public function create( ?Authenticatable $user ): bool
+	{
+		return null !== $user;
+	}
+
+	public function update( ?Authenticatable $user, VisualEditorPattern $pattern ): bool
+	{
+		return null !== $user;
+	}
+
+	public function delete( ?Authenticatable $user, VisualEditorPattern $pattern ): bool
+	{
+		return null !== $user;
+	}
+}

--- a/src/VisualEditorServiceProvider.php
+++ b/src/VisualEditorServiceProvider.php
@@ -6,11 +6,13 @@ use ArtisanPackUI\VisualEditor\Console\Commands\SeedSampleContentCommand;
 use ArtisanPackUI\VisualEditor\MediaBridge\GutenbergAttachmentAdapter;
 use ArtisanPackUI\VisualEditor\Models\VisualEditorGlobalStyles;
 use ArtisanPackUI\VisualEditor\Models\VisualEditorNavigation;
+use ArtisanPackUI\VisualEditor\Models\VisualEditorPattern;
 use ArtisanPackUI\VisualEditor\Models\VisualEditorPost;
 use ArtisanPackUI\VisualEditor\Models\VisualEditorTemplate;
 use ArtisanPackUI\VisualEditor\Models\VisualEditorTemplatePart;
 use ArtisanPackUI\VisualEditor\Policies\VisualEditorGlobalStylesPolicy;
 use ArtisanPackUI\VisualEditor\Policies\VisualEditorNavigationPolicy;
+use ArtisanPackUI\VisualEditor\Policies\VisualEditorPatternPolicy;
 use ArtisanPackUI\VisualEditor\Policies\VisualEditorPostPolicy;
 use ArtisanPackUI\VisualEditor\Policies\VisualEditorTemplatePolicy;
 use ArtisanPackUI\VisualEditor\Policies\VisualEditorTemplatePartPolicy;
@@ -99,6 +101,7 @@ class VisualEditorServiceProvider extends ServiceProvider
 		Gate::policy( VisualEditorTemplatePart::class, VisualEditorTemplatePartPolicy::class );
 		Gate::policy( VisualEditorGlobalStyles::class, VisualEditorGlobalStylesPolicy::class );
 		Gate::policy( VisualEditorNavigation::class, VisualEditorNavigationPolicy::class );
+		Gate::policy( VisualEditorPattern::class, VisualEditorPatternPolicy::class );
 
 		// 3. Register core blocks from their block.json manifests.
 		$this->registerCoreBlocks();

--- a/tests/Feature/VisualEditor/PatternControllerTest.php
+++ b/tests/Feature/VisualEditor/PatternControllerTest.php
@@ -1,0 +1,612 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Models\VisualEditorPattern;
+use ArtisanPackUI\VisualEditor\Models\VisualEditorPatternCategory;
+use Tests\TestUser;
+
+function createPattern( array $overrides = [], array $categories = [] ): VisualEditorPattern
+{
+	$attributes = array_merge( [
+		'slug'    => 'hero',
+		'title'   => 'Hero',
+		'content' => [
+			'raw'    => '<!-- wp:cover /-->',
+			'blocks' => [
+				[
+					'name'        => 'core/cover',
+					'attributes'  => new stdClass(),
+					'innerBlocks' => [],
+				],
+			],
+		],
+		'synced'  => true,
+		'status'  => 'publish',
+	], $overrides );
+
+	$pattern = VisualEditorPattern::create( $attributes );
+
+	if ( [] !== $categories ) {
+		$ids = [];
+		foreach ( $categories as $slug ) {
+			$category = VisualEditorPatternCategory::firstOrCreate(
+				[ 'slug' => $slug ],
+				[ 'name' => $slug ]
+			);
+			$ids[] = $category->getKey();
+		}
+
+		$pattern->categories()->sync( $ids );
+	}
+
+	return $pattern;
+}
+
+function actingAsPatternUser(): TestUser
+{
+	$user = TestUser::create( [
+		'name'     => 'Pattern Tester',
+		'email'    => 'pattern+' . uniqid() . '@example.com',
+		'password' => bcrypt( 'secret' ),
+	] );
+
+	test()->actingAs( $user );
+
+	return $user;
+}
+
+it( 'returns 401 when unauthenticated on index', function () {
+	$this->getJson( '/visual-editor/api/patterns' )->assertUnauthorized();
+} );
+
+it( 'returns an empty data/meta envelope when no patterns exist', function () {
+	actingAsPatternUser();
+
+	$this->getJson( '/visual-editor/api/patterns' )
+		->assertOk()
+		->assertJsonPath( 'data', [] )
+		->assertJsonPath( 'meta.total', 0 )
+		->assertJsonPath( 'meta.last_page', 1 );
+} );
+
+it( 'lists patterns in the data/meta envelope', function () {
+	actingAsPatternUser();
+
+	createPattern( [ 'slug' => 'hero', 'title' => 'Hero' ], [ 'featured' ] );
+	createPattern( [ 'slug' => 'pricing-row', 'title' => 'Pricing row', 'synced' => false ], [ 'pricing' ] );
+
+	$this->getJson( '/visual-editor/api/patterns' )
+		->assertOk()
+		->assertJsonCount( 2, 'data' )
+		->assertJsonPath( 'meta.total', 2 )
+		->assertJsonPath( 'data.0.slug', 'hero' )
+		->assertJsonPath( 'data.0.type', 'wp_block' )
+		->assertJsonPath( 'data.0.title.rendered', 'Hero' )
+		->assertJsonPath( 'data.0.synced', true )
+		->assertJsonPath( 'data.0.categories', [ 'featured' ] )
+		->assertJsonPath( 'data.1.slug', 'pricing-row' )
+		->assertJsonPath( 'data.1.synced', false )
+		->assertJsonPath( 'data.1.categories', [ 'pricing' ] );
+} );
+
+it( 'filters the index by a single category slug', function () {
+	actingAsPatternUser();
+
+	createPattern( [ 'slug' => 'hero' ], [ 'featured' ] );
+	createPattern( [ 'slug' => 'pricing-row', 'synced' => false ], [ 'pricing' ] );
+	createPattern( [ 'slug' => 'call-out-pair', 'synced' => false ], [ 'featured' ] );
+
+	$this->getJson( '/visual-editor/api/patterns?categories=featured' )
+		->assertOk()
+		->assertJsonCount( 2, 'data' )
+		->assertJsonPath( 'data.0.slug', 'hero' )
+		->assertJsonPath( 'data.1.slug', 'call-out-pair' );
+} );
+
+it( 'filters the index by multiple category slugs with OR semantics', function () {
+	actingAsPatternUser();
+
+	createPattern( [ 'slug' => 'hero' ], [ 'featured' ] );
+	createPattern( [ 'slug' => 'pricing-row', 'synced' => false ], [ 'pricing' ] );
+	createPattern( [ 'slug' => 'sidebar', 'synced' => false ], [ 'sidebars' ] );
+
+	$this->getJson( '/visual-editor/api/patterns?categories[]=featured&categories[]=pricing' )
+		->assertOk()
+		->assertJsonCount( 2, 'data' )
+		->assertJsonPath( 'data.0.slug', 'hero' )
+		->assertJsonPath( 'data.1.slug', 'pricing-row' );
+} );
+
+it( 'filters the index by slug, status, and synced flag', function () {
+	actingAsPatternUser();
+
+	createPattern( [ 'slug' => 'hero', 'synced' => true, 'status' => 'publish' ] );
+	createPattern( [ 'slug' => 'pricing-row', 'synced' => false, 'status' => 'publish' ] );
+	createPattern( [ 'slug' => 'draft-pattern', 'synced' => false, 'status' => 'draft' ] );
+
+	$this->getJson( '/visual-editor/api/patterns?slug=hero' )
+		->assertOk()
+		->assertJsonCount( 1, 'data' )
+		->assertJsonPath( 'data.0.slug', 'hero' );
+
+	$this->getJson( '/visual-editor/api/patterns?status=draft' )
+		->assertOk()
+		->assertJsonCount( 1, 'data' )
+		->assertJsonPath( 'data.0.status', 'draft' );
+
+	$this->getJson( '/visual-editor/api/patterns?synced=1' )
+		->assertOk()
+		->assertJsonCount( 1, 'data' )
+		->assertJsonPath( 'data.0.synced', true );
+
+	$this->getJson( '/visual-editor/api/patterns?synced=0' )
+		->assertOk()
+		->assertJsonCount( 2, 'data' );
+} );
+
+it( 'returns 401 when unauthenticated on show', function () {
+	$pattern = createPattern();
+
+	$this->getJson( "/visual-editor/api/patterns/{$pattern->id}" )->assertUnauthorized();
+} );
+
+it( 'returns the full record envelope on show', function () {
+	actingAsPatternUser();
+
+	$pattern = createPattern( [], [ 'featured' ] );
+
+	$this->getJson( "/visual-editor/api/patterns/{$pattern->id}" )
+		->assertOk()
+		->assertJsonPath( 'id', $pattern->id )
+		->assertJsonPath( 'slug', 'hero' )
+		->assertJsonPath( 'type', 'wp_block' )
+		->assertJsonPath( 'title.rendered', 'Hero' )
+		->assertJsonPath( 'synced', true )
+		->assertJsonPath( 'categories', [ 'featured' ] )
+		->assertJsonPath( 'content.raw', '<!-- wp:cover /-->' )
+		->assertJsonPath( 'content.blocks.0.name', 'core/cover' );
+} );
+
+it( 'returns 404 when the pattern id does not exist', function () {
+	actingAsPatternUser();
+
+	$this->getJson( '/visual-editor/api/patterns/999' )->assertNotFound();
+} );
+
+it( 'creates a synced pattern with a 201 Created response and auto-creates categories', function () {
+	actingAsPatternUser();
+
+	$payload = [
+		'slug'       => 'hero',
+		'title'      => 'Hero',
+		'content'    => [
+			'raw'    => '<!-- wp:cover /-->',
+			'blocks' => [
+				[
+					'name'        => 'core/cover',
+					'attributes'  => [ 'overlayColor' => 'primary' ],
+					'innerBlocks' => [],
+				],
+			],
+		],
+		'synced'     => true,
+		'status'     => 'publish',
+		'categories' => [ 'featured' ],
+	];
+
+	$this->postJson( '/visual-editor/api/patterns', $payload )
+		->assertCreated()
+		->assertJsonPath( 'slug', 'hero' )
+		->assertJsonPath( 'synced', true )
+		->assertJsonPath( 'categories', [ 'featured' ] )
+		->assertJsonPath( 'type', 'wp_block' )
+		->assertJsonPath( 'content.raw', '<!-- wp:cover /-->' )
+		->assertJsonPath( 'content.blocks.0.name', 'core/cover' );
+
+	expect( VisualEditorPattern::where( 'slug', 'hero' )->first() )
+		->not->toBeNull()
+		->getBlocks()->toEqual( [
+			[
+				'name'        => 'core/cover',
+				'attributes'  => [ 'overlayColor' => 'primary' ],
+				'innerBlocks' => [],
+			],
+		] );
+
+	expect( VisualEditorPatternCategory::where( 'slug', 'featured' )->first() )
+		->not->toBeNull();
+} );
+
+it( 'creates an unsynced pattern with a 201 Created response', function () {
+	actingAsPatternUser();
+
+	$payload = [
+		'slug'       => 'pricing-row',
+		'title'      => 'Pricing row',
+		'content'    => [
+			'raw'    => '<!-- wp:columns /-->',
+			'blocks' => [
+				[
+					'name'        => 'core/columns',
+					'attributes'  => [],
+					'innerBlocks' => [],
+				],
+			],
+		],
+		'synced'     => false,
+		'categories' => [ 'pricing' ],
+	];
+
+	$this->postJson( '/visual-editor/api/patterns', $payload )
+		->assertCreated()
+		->assertJsonPath( 'slug', 'pricing-row' )
+		->assertJsonPath( 'synced', false )
+		->assertJsonPath( 'categories', [ 'pricing' ] );
+} );
+
+it( 'defaults synced to false when the flag is omitted on store', function () {
+	actingAsPatternUser();
+
+	$this->postJson( '/visual-editor/api/patterns', [
+		'slug'  => 'some-pattern',
+		'title' => 'Some pattern',
+	] )
+		->assertCreated()
+		->assertJsonPath( 'synced', false );
+} );
+
+it( 'rejects store when the slug already exists', function () {
+	actingAsPatternUser();
+
+	createPattern( [ 'slug' => 'hero' ] );
+
+	$this->postJson( '/visual-editor/api/patterns', [
+		'slug'  => 'hero',
+		'title' => 'Duplicate',
+	] )
+		->assertUnprocessable()
+		->assertJsonValidationErrors( 'slug' );
+} );
+
+it( 'rejects store when the block tree is malformed', function () {
+	actingAsPatternUser();
+
+	$this->postJson( '/visual-editor/api/patterns', [
+		'slug'    => 'bad-blocks',
+		'content' => [
+			'raw'    => '',
+			'blocks' => [
+				[ 'not-a-block' => true ],
+			],
+		],
+	] )
+		->assertUnprocessable()
+		->assertJsonValidationErrors( 'content.blocks' );
+} );
+
+it( 'rejects a null title on store (column is non-nullable)', function () {
+	actingAsPatternUser();
+
+	$this->postJson( '/visual-editor/api/patterns', [
+		'slug'  => 'no-title',
+		'title' => null,
+	] )
+		->assertUnprocessable()
+		->assertJsonValidationErrors( 'title' );
+} );
+
+it( 'rejects a bare-list content payload on store', function () {
+	actingAsPatternUser();
+
+	$this->postJson( '/visual-editor/api/patterns', [
+		'slug'    => 'bare-list',
+		'content' => [
+			[
+				'name'        => 'core/paragraph',
+				'attributes'  => [],
+				'innerBlocks' => [],
+			],
+		],
+	] )
+		->assertUnprocessable()
+		->assertJsonValidationErrors( 'content' );
+} );
+
+it( 'updates a pattern with a partial payload', function () {
+	actingAsPatternUser();
+
+	$pattern = createPattern( [ 'title' => 'Before' ] );
+
+	$this->putJson( "/visual-editor/api/patterns/{$pattern->id}", [
+		'title' => 'After',
+	] )
+		->assertOk()
+		->assertJsonPath( 'title.rendered', 'After' )
+		->assertJsonPath( 'slug', 'hero' );
+
+	expect( $pattern->fresh()->title )->toBe( 'After' );
+} );
+
+it( 'persists a new content envelope on update', function () {
+	actingAsPatternUser();
+
+	$pattern = createPattern();
+
+	$newContent = [
+		'raw'    => '<!-- wp:paragraph --><p>Hello</p><!-- /wp:paragraph -->',
+		'blocks' => [
+			[
+				'name'        => 'core/paragraph',
+				'attributes'  => [ 'content' => 'Hello' ],
+				'innerBlocks' => [],
+			],
+		],
+	];
+
+	$this->putJson( "/visual-editor/api/patterns/{$pattern->id}", [
+		'content' => $newContent,
+	] )
+		->assertOk()
+		->assertJsonPath( 'content.raw', $newContent['raw'] )
+		->assertJsonPath( 'content.blocks.0.attributes.content', 'Hello' );
+
+	expect( $pattern->fresh()->getContentEnvelope() )->toEqual( $newContent );
+} );
+
+it( 'syncs categories on update (add, remove, replace)', function () {
+	actingAsPatternUser();
+
+	$pattern = createPattern( [], [ 'featured' ] );
+
+	// Replace the category list — `pricing` is new, `featured` should drop.
+	$this->putJson( "/visual-editor/api/patterns/{$pattern->id}", [
+		'categories' => [ 'pricing' ],
+	] )
+		->assertOk()
+		->assertJsonPath( 'categories', [ 'pricing' ] );
+
+	expect( $pattern->fresh()->categories->pluck( 'slug' )->all() )
+		->toEqual( [ 'pricing' ] );
+
+	// Drop all categories.
+	$this->putJson( "/visual-editor/api/patterns/{$pattern->id}", [
+		'categories' => [],
+	] )
+		->assertOk()
+		->assertJsonPath( 'categories', [] );
+
+	expect( $pattern->fresh()->categories )->toHaveCount( 0 );
+} );
+
+it( 'supports status transitions draft → publish → draft', function () {
+	actingAsPatternUser();
+
+	$pattern = createPattern( [ 'status' => 'draft' ] );
+
+	$this->putJson( "/visual-editor/api/patterns/{$pattern->id}", [
+		'status' => 'publish',
+	] )
+		->assertOk()
+		->assertJsonPath( 'status', 'publish' );
+
+	expect( $pattern->fresh()->status )->toBe( 'publish' );
+
+	$this->putJson( "/visual-editor/api/patterns/{$pattern->id}", [
+		'status' => 'draft',
+	] )
+		->assertOk()
+		->assertJsonPath( 'status', 'draft' );
+
+	expect( $pattern->fresh()->status )->toBe( 'draft' );
+} );
+
+it( 'rejects a null title on update (column is non-nullable)', function () {
+	actingAsPatternUser();
+
+	$pattern = createPattern();
+
+	$this->putJson( "/visual-editor/api/patterns/{$pattern->id}", [
+		'title' => null,
+	] )
+		->assertUnprocessable()
+		->assertJsonValidationErrors( 'title' );
+
+	expect( $pattern->fresh()->title )->toBe( 'Hero' );
+} );
+
+it( 'rejects a bare-list content payload on update', function () {
+	actingAsPatternUser();
+
+	$pattern = createPattern();
+
+	$this->putJson( "/visual-editor/api/patterns/{$pattern->id}", [
+		'content' => [
+			[
+				'name'        => 'core/paragraph',
+				'attributes'  => [],
+				'innerBlocks' => [],
+			],
+		],
+	] )
+		->assertUnprocessable()
+		->assertJsonValidationErrors( 'content' );
+} );
+
+it( 'rejects a slug update that would collide with an existing slug', function () {
+	actingAsPatternUser();
+
+	$editing = createPattern( [ 'slug' => 'editing' ] );
+	createPattern( [ 'slug' => 'collision' ] );
+
+	$this->putJson( "/visual-editor/api/patterns/{$editing->id}", [
+		'slug' => 'collision',
+	] )
+		->assertUnprocessable()
+		->assertJsonValidationErrors( 'slug' );
+
+	expect( $editing->fresh()->slug )->toBe( 'editing' );
+} );
+
+it( 'deletes a pattern and its pivot rows', function () {
+	actingAsPatternUser();
+
+	$pattern = createPattern( [], [ 'featured' ] );
+	$id      = $pattern->id;
+
+	$this->deleteJson( "/visual-editor/api/patterns/{$id}" )
+		->assertNoContent();
+
+	expect( VisualEditorPattern::find( $id ) )->toBeNull();
+
+	// The category record itself should survive the pattern delete.
+	expect( VisualEditorPatternCategory::where( 'slug', 'featured' )->first() )
+		->not->toBeNull();
+} );
+
+it( 'synced round-trip: storing a synced pattern and referencing it by id preserves the block tree', function () {
+	actingAsPatternUser();
+
+	$payload = [
+		'slug'       => 'hero',
+		'title'      => 'Hero',
+		'content'    => [
+			'raw'    => '<!-- wp:cover /-->',
+			'blocks' => [
+				[
+					'name'        => 'core/cover',
+					'attributes'  => [ 'overlayColor' => 'primary' ],
+					'innerBlocks' => [],
+				],
+			],
+		],
+		'synced'     => true,
+		'categories' => [ 'featured' ],
+	];
+
+	$created = $this->postJson( '/visual-editor/api/patterns', $payload )
+		->assertCreated()
+		->json();
+
+	$id = $created['id'];
+
+	// Reference the synced pattern by id twice and confirm both reads
+	// resolve to the same record and block tree.
+	$this->getJson( "/visual-editor/api/patterns/{$id}" )
+		->assertOk()
+		->assertJsonPath( 'synced', true )
+		->assertJsonPath( 'content.blocks.0.name', 'core/cover' )
+		->assertJsonPath( 'content.blocks.0.attributes.overlayColor', 'primary' );
+
+	$this->getJson( "/visual-editor/api/patterns/{$id}" )
+		->assertOk()
+		->assertJsonPath( 'synced', true )
+		->assertJsonPath( 'content.blocks.0.attributes.overlayColor', 'primary' );
+} );
+
+it( 'unsynced round-trip: editing an unsynced pattern does not mutate a previously-inserted copy', function () {
+	actingAsPatternUser();
+
+	// Store the unsynced pattern.
+	$payload = [
+		'slug'    => 'pricing-row',
+		'title'   => 'Pricing row',
+		'content' => [
+			'raw'    => '<!-- wp:columns /-->',
+			'blocks' => [
+				[
+					'name'        => 'core/columns',
+					'attributes'  => [ 'note' => 'original' ],
+					'innerBlocks' => [],
+				],
+			],
+		],
+		'synced'  => false,
+	];
+
+	$created = $this->postJson( '/visual-editor/api/patterns', $payload )
+		->assertCreated()
+		->json();
+
+	$id = $created['id'];
+
+	// Simulate the editor's insert-side copy: grab the current block tree
+	// and hold it independently of the stored record. (C5 only guarantees
+	// this round-trip shape — the actual copy-on-insert lives in D5/E3.)
+	$insertedCopy = $created['content']['blocks'];
+
+	// Mutate the stored pattern.
+	$this->putJson( "/visual-editor/api/patterns/{$id}", [
+		'content' => [
+			'raw'    => '<!-- wp:columns /-->',
+			'blocks' => [
+				[
+					'name'        => 'core/columns',
+					'attributes'  => [ 'note' => 'edited' ],
+					'innerBlocks' => [],
+				],
+			],
+		],
+	] )
+		->assertOk()
+		->assertJsonPath( 'content.blocks.0.attributes.note', 'edited' );
+
+	// The previously-inserted copy still carries the original attributes.
+	expect( $insertedCopy[0]['attributes']['note'] )->toBe( 'original' );
+
+	// And the stored record now carries the edited attributes.
+	$this->getJson( "/visual-editor/api/patterns/{$id}" )
+		->assertOk()
+		->assertJsonPath( 'content.blocks.0.attributes.note', 'edited' );
+} );
+
+it( 'round-trips the B2 pattern fixtures through store + show', function () {
+	actingAsPatternUser();
+
+	$fixturesDir = dirname( __DIR__, 2 ) . '/Fixtures/sample-content/patterns';
+	$files       = glob( $fixturesDir . '/*.json' );
+
+	expect( $files )->not->toBeEmpty();
+
+	foreach ( $files as $file ) {
+		$fixture = json_decode( (string) file_get_contents( $file ), true, flags: JSON_THROW_ON_ERROR );
+
+		$payload = [
+			'slug'       => $fixture['slug'],
+			'title'      => $fixture['title']['rendered'] ?? '',
+			'content'    => $fixture['content'] ?? [ 'raw' => '', 'blocks' => [] ],
+			'synced'     => (bool) ( $fixture['synced'] ?? false ),
+			'status'     => $fixture['status'] ?? 'publish',
+			'categories' => $fixture['categories'] ?? [],
+		];
+
+		$response = $this->postJson( '/visual-editor/api/patterns', $payload )
+			->assertCreated()
+			->assertJsonPath( 'slug', $fixture['slug'] )
+			->assertJsonPath( 'synced', (bool) ( $fixture['synced'] ?? false ) )
+			->assertJsonPath( 'content.raw', $fixture['content']['raw'] );
+
+		$id = $response->json( 'id' );
+
+		$this->getJson( "/visual-editor/api/patterns/{$id}" )
+			->assertOk()
+			->assertJsonPath( 'slug', $fixture['slug'] )
+			->assertJsonPath( 'categories', $fixture['categories'] ?? [] )
+			->assertJsonPath( 'content.blocks', $fixture['content']['blocks'] );
+	}
+} );
+
+it( 'rejects unauthenticated store, update, and destroy', function () {
+	$pattern = createPattern();
+
+	$this->postJson( '/visual-editor/api/patterns', [
+		'slug'  => 'new',
+		'title' => 'New',
+	] )->assertUnauthorized();
+
+	$this->putJson( "/visual-editor/api/patterns/{$pattern->id}", [
+		'title' => 'Nope',
+	] )->assertUnauthorized();
+
+	$this->deleteJson( "/visual-editor/api/patterns/{$pattern->id}" )->assertUnauthorized();
+} );


### PR DESCRIPTION
## Description

Lands the server-side backing for the `wp_block` entity the B1 core-data shim dispatches at `/visual-editor/api/patterns`. Patterns ship with synced + unsynced semantics from day one per V1 plan §2.2 — the backend stores the `synced` flag faithfully and the editor decides reference-vs-copy on insert (D5 / E3 own the insert semantics).

Categories are many-to-many with auto-create on first use, matching the B2 fixture shape. The index endpoint filters by one or more category slugs with OR semantics.

**Closes:** #361

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #361

## Motivation and Context

Patterns are the most-used entity of the five once the site editor is live — authors reach for them constantly. This shim backs the B1 core-data selectors and unblocks D5 (pattern-library UI + inserter category) and E3 (front-end synced-pattern resolution).

## Changes Made

- `VisualEditorPattern` + `VisualEditorPatternCategory` Eloquent models with `{ raw, blocks }` envelope helpers and a `BelongsToMany` relationship.
- Three migrations: `visual_editor_patterns` (slug unique, synced flag, status index), `visual_editor_pattern_categories` (lookup), and `visual_editor_pattern_category` (pivot with cascading deletes and composite PK).
- `PatternController` — full CRUD at `/visual-editor/api/patterns`, with pagination (max 100), filtering by slug / status / synced / categories (single or multi with OR semantics), and auto-create-on-use for category slugs.
- `StorePatternRequest` + `UpdatePatternRequest` — envelope-shape validation, `TemplateBlockTreeRule` reused for block-tree validation, slug uniqueness, status enum, boolean `synced`.
- `PatternResource` — B1 shim envelope with `{ synced, categories, type: 'wp_block' }`.
- `VisualEditorPatternPolicy` — authenticated-user baseline, matching `VisualEditorTemplatePolicy`.
- Routes registered under the auth-gated API group.
- Policy bound in `VisualEditorServiceProvider::boot()`.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (Darwin 25.3.0)
- PHP Version: 8.4.3
- Project Version: 1.0.0 (release/1.0)

**Tests Performed:**
1. `./vendor/bin/pest --filter=PatternControllerTest` — 28 tests, 151 assertions, all passing.
2. `./vendor/bin/pest` (full suite) — 333 tests, 1103 assertions, all passing.
3. CodeRabbit CLI review against `release/1.0` — no findings.

## Accessibility Tests Run

N/A — this is a backend-only change (REST API + Eloquent models). No UI surface introduced.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details (28 new Pest feature tests):**

- Auth gating on every method (401 on index/show/store/update/destroy when unauthenticated).
- CRUD happy paths: empty + populated index, show hit + 404, store (synced + unsynced + default-synced), update (partial, full content envelope replace), delete.
- Category filtering: single slug, multiple slugs with OR semantics, combined with slug / status / synced filters.
- Synced round-trip: reference a synced pattern by id and confirm the block tree resolves.
- Unsynced round-trip: edit the stored pattern and confirm the previously-inserted copy diverges (backend does not mutate the copy).
- Status transitions: `draft` → `publish` → `draft`.
- Category sync on update (add, replace, clear to empty).
- B2 fixture round-trip: `hero.json`, `pricing-row.json`, `call-out-pair.json` all POST-then-GET cleanly.
- Validation errors: slug uniqueness, null title (non-nullable column), bare-list content payload, malformed block tree.
- Delete preserves category lookup rows (only the pivot cascades).

## Documentation

- [x] Inline code documentation added

**Documentation details:** All new classes carry full PHPDoc blocks matching the existing `VisualEditorTemplate` / `TemplateController` style (class-level purpose, `@since`, method-level purpose with `@param` / `@return`). The endpoint contract is already locked in `docs/core-data-shim.md` §Patterns; no doc changes needed there.

## Screenshots

N/A — backend-only change.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [ ] Code has been linted (no `php-cs-fixer` / `pint` installed in this package; code follows existing ArtisanPack UI conventions — tabs, WP-style spacing, Yoda conditionals, aligned assignments — matching sibling controllers)
- [x] Accessibility tests completed (N/A for backend)
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visual editor pattern management system with full create, read, update, and delete capabilities
  * Patterns now support categorization, content blocks, and publication statuses (draft/publish/private)
  * Enabled pattern synchronization tracking

* **Tests**
  * Added comprehensive test suite for pattern operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->