### PR TITLE
feat: D1 site-editor shell (routing, navigator, canvas frame, tabs)

### DIFF
--- a/docs/design/site-editor-ux.md
+++ b/docs/design/site-editor-ux.md
@@ -522,7 +522,7 @@ regions need a fixed home so the chrome doesn't drift section by section: the **
   zoom-out / preview affordance. Each toggle's `aria-pressed` reflects the panel's open state, mirroring the post
   editor's M7 conventions.
 
-```
+```text
 Edit mode (entity selected):
 ┌──────────────────────────────────────────────────────────────────────────┐
 │  Top Bar:  [☰] [+] [List] [Brand]  [Entity title]   [Save template]    │
@@ -538,7 +538,7 @@ Edit mode (entity selected):
 └────┴─────────────────┴─────────────────────────────┴─────────────────────┘
 ```
 
-```
+```text
 Browse mode (no entity selected):
 ┌──────────────────────────────────────────────────────────────────────────┐
 │  Top Bar:  [☰] [Brand]  [Section name]                                  │

--- a/docs/design/site-editor-ux.md
+++ b/docs/design/site-editor-ux.md
@@ -500,6 +500,66 @@ The shell has **four regions** and their responsibilities are fixed:
 Rationale: F10 (navigator depth), F11 (styles hierarchy), F13 (control dispersion) all stem from ambiguity about *which
 region owns what*. Locking these roles means controls have a single predictable home.
 
+#### 3.2.1 Editing-mode regions (block inserter, list view, pattern picker)
+
+D1 (#368) ships the four-region shell above. As D2–D5 wire entity editing into the canvas, three additional
+regions need a fixed home so the chrome doesn't drift section by section: the **block inserter**, the **list view**
+(block outline), and the **pattern picker**. Decision (recorded after D1 prototype review):
+
+- **Navigator stays visible.** When the user enters edit mode (selects an entity in the section list), the navigator
+  collapses to an **icon-only** rail (≈48px). It does not disappear. Section labels are revealed on hover / focus and
+  the active section keeps its accent. This preserves P5 ("navigator browses, canvas edits, inspector configures") and
+  the cross-section jump that motivates the persistent-shell IA in the first place — losing the navigator while
+  editing is one of the WP frictions (F11) we're explicitly designing out.
+- **Inserter + pattern picker live in a secondary left rail.** A second column opens *to the right of* the navigator
+  when toggled from the top bar's left button. It hosts the block inserter and pattern picker (synced/unsynced tabs
+  from §3.6) as a tabbed panel. The panel is roughly the same width as the post-editor's inserter (≈350px). When
+  closed, the rail collapses entirely; the canvas reclaims the space.
+- **List view rides in the inspector.** The right-rail inspector grows a third tab — **List view** — alongside Block
+  and Entity. This avoids competing with the inserter for left-rail space and keeps the inspector's charter intact:
+  it's the panel for *configuring what's on the canvas*, and the outline of the canvas is part of that.
+- **Top bar adds three editing-mode toggles.** Inserter (left-rail), list-view (right-rail tab focus), and a future
+  zoom-out / preview affordance. Each toggle's `aria-pressed` reflects the panel's open state, mirroring the post
+  editor's M7 conventions.
+
+```
+Edit mode (entity selected):
+┌──────────────────────────────────────────────────────────────────────────┐
+│  Top Bar:  [☰] [+] [List] [Brand]  [Entity title]   [Save template]    │
+├────┬─────────────────┬─────────────────────────────┬─────────────────────┤
+│    │                 │                             │                     │
+│ N  │  Inserter /     │  Canvas (iframe)            │  Inspector          │
+│ a  │  pattern        │                             │  ┌──────────────┐   │
+│ v  │  picker         │                             │  │ Block │ Doc  │   │
+│ (  │  (toggled,      │                             │  │ List view    │   │
+│ i  │  optional)      │                             │  └──────────────┘   │
+│ c  │                 │                             │                     │
+│ )  │                 │                             │                     │
+└────┴─────────────────┴─────────────────────────────┴─────────────────────┘
+```
+
+```
+Browse mode (no entity selected):
+┌──────────────────────────────────────────────────────────────────────────┐
+│  Top Bar:  [☰] [Brand]  [Section name]                                  │
+├──────────────────────┬───────────────────────────────┬───────────────────┤
+│                      │                               │                   │
+│  Navigator           │  Canvas (entity list/grid)    │  Inspector        │
+│  (full-width with    │                               │  (section-scoped) │
+│  section list)       │                               │                   │
+│                      │                               │                   │
+└──────────────────────┴───────────────────────────────┴───────────────────┘
+```
+
+Rationale: this is the "Pattern B" hybrid considered after D1's shell landed. Pattern A (swap left rail entirely
+with editing tools) loses the navigator at exactly the moment cross-section jumps are most useful. Pattern C
+(floating overlays) makes the pattern picker too cramped for the synced/unsynced + filter UI in §3.6. Pattern B
+preserves the four-region shell while giving editing tools dedicated space, at the cost of needing one extra
+column on small viewports — addressed by the inserter rail being collapsible.
+
+D2 implements the icon-only navigator collapse and the inserter rail. D3–D5 plug their per-section editor surfaces
+into the same chrome. Every D-issue's PR must reference this section when it lands editing-mode UI.
+
 ### 3.3 Section IA — overview
 
 Five sections, each with consistent region semantics:

--- a/resources/js/visual-editor/editor/__tests__/top-bar.test.tsx
+++ b/resources/js/visual-editor/editor/__tests__/top-bar.test.tsx
@@ -167,6 +167,54 @@ describe('TopBar', () => {
         ).toHaveTextContent('Network error');
     });
 
+    it('honors per-host overrides for the inserter and inspector aria labels', () => {
+        const { rerender } = render(
+            <TopBar
+                {...defaultProps({
+                    inserterToggleAriaLabel: {
+                        open: 'Open navigator',
+                        close: 'Close navigator',
+                    },
+                    inspectorToggleAriaLabel: {
+                        open: 'Open settings',
+                        close: 'Close settings',
+                    },
+                })}
+            />
+        );
+
+        expect(
+            screen.getByTestId('ap-visual-editor-top-bar-inserter')
+        ).toHaveAttribute('aria-label', 'Open navigator');
+        expect(
+            screen.getByTestId('ap-visual-editor-top-bar-inspector')
+        ).toHaveAttribute('aria-label', 'Open settings');
+
+        rerender(
+            <TopBar
+                {...defaultProps({
+                    isInserterOpen: true,
+                    isInspectorOpen: true,
+                    inserterToggleAriaLabel: {
+                        open: 'Open navigator',
+                        close: 'Close navigator',
+                    },
+                    inspectorToggleAriaLabel: {
+                        open: 'Open settings',
+                        close: 'Close settings',
+                    },
+                })}
+            />
+        );
+
+        expect(
+            screen.getByTestId('ap-visual-editor-top-bar-inserter')
+        ).toHaveAttribute('aria-label', 'Close navigator');
+        expect(
+            screen.getByTestId('ap-visual-editor-top-bar-inspector')
+        ).toHaveAttribute('aria-label', 'Close settings');
+    });
+
     it('renders a preview link when a URL is provided', () => {
         render(
             <TopBar

--- a/resources/js/visual-editor/editor/top-bar.tsx
+++ b/resources/js/visual-editor/editor/top-bar.tsx
@@ -59,6 +59,20 @@ export interface TopBarProps {
      * actions between the preview link and the more-options menu.
      */
     extraActions?: ReactNode;
+    /**
+     * Override the aria-label / accessible name of the left toggle button.
+     * The post editor uses this slot for the block inserter; the site
+     * editor (D1 · #368) reuses the same button for the navigator panel
+     * and supplies the matching label here. Defaults preserve the
+     * post-editor wording when omitted.
+     */
+    inserterToggleAriaLabel?: { open: string; close: string };
+    /**
+     * Override the aria-label / accessible name of the right (inspector)
+     * toggle button. The label varies between the post editor (the
+     * inspector panel) and the site editor (the section inspector).
+     */
+    inspectorToggleAriaLabel?: { open: string; close: string };
 }
 
 function saveStatusLabel(
@@ -145,7 +159,18 @@ export function TopBar(props: TopBarProps): JSX.Element {
         onPasteStyles,
         onShowKeyboardShortcuts,
         extraActions,
+        inserterToggleAriaLabel,
+        inspectorToggleAriaLabel,
     } = props;
+
+    const inserterOpenLabel =
+        inserterToggleAriaLabel?.open ?? __('Open block inserter', TEXT_DOMAIN);
+    const inserterCloseLabel =
+        inserterToggleAriaLabel?.close ?? __('Close block inserter', TEXT_DOMAIN);
+    const inspectorOpenLabel =
+        inspectorToggleAriaLabel?.open ?? __('Open inspector', TEXT_DOMAIN);
+    const inspectorCloseLabel =
+        inspectorToggleAriaLabel?.close ?? __('Close inspector', TEXT_DOMAIN);
 
     const menuId = useId();
     const menuTriggerRef = useRef<HTMLButtonElement | null>(null);
@@ -321,9 +346,7 @@ export function TopBar(props: TopBarProps): JSX.Element {
                     type="button"
                     className="ap-visual-editor-top-bar__icon-button"
                     aria-label={
-                        isInserterOpen
-                            ? __('Close block inserter', TEXT_DOMAIN)
-                            : __('Open block inserter', TEXT_DOMAIN)
+                        isInserterOpen ? inserterCloseLabel : inserterOpenLabel
                     }
                     aria-expanded={isInserterOpen}
                     aria-pressed={isInserterOpen}
@@ -413,9 +436,7 @@ export function TopBar(props: TopBarProps): JSX.Element {
                     type="button"
                     className="ap-visual-editor-top-bar__icon-button"
                     aria-label={
-                        isInspectorOpen
-                            ? __('Close inspector', TEXT_DOMAIN)
-                            : __('Open inspector', TEXT_DOMAIN)
+                        isInspectorOpen ? inspectorCloseLabel : inspectorOpenLabel
                     }
                     aria-expanded={isInspectorOpen}
                     aria-pressed={isInspectorOpen}

--- a/resources/js/visual-editor/site-editor/__tests__/canvas-frame.test.tsx
+++ b/resources/js/visual-editor/site-editor/__tests__/canvas-frame.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { ReactNode } from 'react';
+
+// Stub `BlockCanvas` and `BlockEditorProvider` from `@wordpress/block-editor`.
+// The real `BlockCanvas` mounts an iframe and pulls from a Gutenberg data
+// store, neither of which jsdom + the package's coreData shim produce
+// reliably. Stubbing keeps the test focused on the wrapper's behaviour:
+//   - render the canvas region;
+//   - render the empty state when `hasEntity={false}`;
+//   - swap to `children` when an entity is supplied.
+vi.mock('@wordpress/block-editor', () => ({
+    BlockCanvas: ({ children }: { children: ReactNode }): JSX.Element => (
+        <div data-testid="ap-stub-block-canvas">{children}</div>
+    ),
+    BlockEditorProvider: ({ children }: { children: ReactNode }): JSX.Element => (
+        <div data-testid="ap-stub-block-editor-provider">{children}</div>
+    ),
+}));
+
+vi.mock('@wordpress/components', () => {
+    const SlotFillProvider = ({ children }: { children: ReactNode }): JSX.Element => (
+        <div data-testid="ap-stub-slotfill-provider">{children}</div>
+    );
+
+    function PopoverSlot(): null {
+        return null;
+    }
+
+    const Popover = Object.assign(() => null, { Slot: PopoverSlot });
+
+    return { SlotFillProvider, Popover };
+});
+
+import { CanvasFrame } from '../canvas-frame';
+
+describe('CanvasFrame', () => {
+    it('renders the canvas wrapper and the empty state when no entity is selected', () => {
+        render(<CanvasFrame sectionLabel="Editing: Templates" />);
+
+        const canvas = screen.getByTestId('ap-site-editor-canvas');
+
+        expect(canvas).toBeInTheDocument();
+        expect(canvas).toHaveAttribute('data-has-entity', 'false');
+
+        const emptyState = screen.getByTestId('ap-site-editor-canvas-empty');
+
+        expect(emptyState).toHaveTextContent('Editing: Templates');
+        expect(emptyState).toHaveTextContent(
+            'Select an entity from the navigator to start editing.'
+        );
+    });
+
+    it('mounts the BlockCanvas and provider chain', () => {
+        render(<CanvasFrame sectionLabel="Editing: Styles" />);
+
+        expect(
+            screen.getByTestId('ap-stub-block-editor-provider')
+        ).toBeInTheDocument();
+        expect(
+            screen.getByTestId('ap-stub-block-canvas')
+        ).toBeInTheDocument();
+    });
+
+    it('renders supplied children inside the canvas when hasEntity is true', () => {
+        render(
+            <CanvasFrame sectionLabel="Editing: Patterns" hasEntity>
+                <div data-testid="ap-test-entity">My pattern</div>
+            </CanvasFrame>
+        );
+
+        expect(screen.getByTestId('ap-test-entity')).toBeInTheDocument();
+        expect(
+            screen.queryByTestId('ap-site-editor-canvas-empty')
+        ).not.toBeInTheDocument();
+        expect(screen.getByTestId('ap-site-editor-canvas')).toHaveAttribute(
+            'data-has-entity',
+            'true'
+        );
+    });
+});

--- a/resources/js/visual-editor/site-editor/__tests__/main.test.tsx
+++ b/resources/js/visual-editor/site-editor/__tests__/main.test.tsx
@@ -1,0 +1,96 @@
+import { act } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+// Stub the dynamic shell import so the boot test doesn't try to load
+// `@wordpress/block-editor` under jsdom.
+vi.mock('../site-editor-app', () => ({
+    SiteEditorApp: (): JSX.Element => (
+        <div data-testid="ap-site-editor-stub" />
+    ),
+}));
+
+import { bootSiteEditor, mountSiteEditor } from '../main';
+
+describe('bootSiteEditor', () => {
+    it('skips elements that are missing required data attributes', async () => {
+        const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {
+            // suppress test-log noise — the warning is the assertion target.
+        });
+
+        const root = document.createElement('div');
+        const incomplete = document.createElement('div');
+        incomplete.setAttribute('data-ap-site-editor', '');
+        // route-base + post-editor-url intentionally absent.
+        root.appendChild(incomplete);
+
+        await bootSiteEditor(root);
+
+        expect(errorSpy).toHaveBeenCalledWith(
+            expect.stringContaining('mount point is missing'),
+            incomplete
+        );
+
+        errorSpy.mockRestore();
+    });
+
+    it('mounts the React shell when a valid element is present', async () => {
+        const root = document.createElement('div');
+        const target = document.createElement('div');
+        target.setAttribute('data-ap-site-editor', '');
+        target.dataset.routeBase = '/visual-editor/site';
+        target.dataset.postEditorUrl = '/editor';
+        root.appendChild(target);
+        document.body.appendChild(root);
+
+        try {
+            // `act` flushes the React 18 concurrent-render commit that
+            // `createRoot().render()` only schedules for a future microtask;
+            // without it the assertion races the renderer.
+            await act(async () => {
+                await bootSiteEditor(root);
+            });
+
+            expect(target.querySelector('[data-testid="ap-site-editor-stub"]')).not.toBeNull();
+        } finally {
+            document.body.removeChild(root);
+        }
+    });
+});
+
+describe('mountSiteEditor', () => {
+    it('is idempotent — repeat mounts on the same node return the same root', async () => {
+        const target = document.createElement('div');
+        target.setAttribute('data-ap-site-editor', '');
+        document.body.appendChild(target);
+
+        try {
+            await act(async () => {
+                const first = mountSiteEditor(target, {
+                    routeBase: '/visual-editor/site',
+                    postEditorUrl: '/editor',
+                });
+                await first.ready;
+            });
+
+            const second = mountSiteEditor(target, {
+                routeBase: '/visual-editor/site',
+                postEditorUrl: '/editor',
+            });
+            await second.ready;
+
+            // The second call should have observed the existing root
+            // rather than mounting a duplicate React tree.
+            expect(
+                target.querySelectorAll('[data-testid="ap-site-editor-stub"]').length
+            ).toBe(1);
+
+            await act(async () => {
+                second.unmount();
+            });
+        } finally {
+            if (target.parentNode === document.body) {
+                document.body.removeChild(target);
+            }
+        }
+    });
+});

--- a/resources/js/visual-editor/site-editor/__tests__/main.test.tsx
+++ b/resources/js/visual-editor/site-editor/__tests__/main.test.tsx
@@ -58,6 +58,62 @@ describe('bootSiteEditor', () => {
 });
 
 describe('mountSiteEditor', () => {
+    it("a stale handle's unmount() is a no-op against a newer root", async () => {
+        const target = document.createElement('div');
+        target.setAttribute('data-ap-site-editor', '');
+        document.body.appendChild(target);
+
+        try {
+            // First mount → handleA. Tear it down, then re-mount the
+            // same node → handleB. Calling handleA.unmount() a second
+            // time must NOT touch handleB's root.
+            let handleA: ReturnType<typeof mountSiteEditor>;
+            let handleB: ReturnType<typeof mountSiteEditor>;
+
+            await act(async () => {
+                handleA = mountSiteEditor(target, {
+                    routeBase: '/visual-editor/site',
+                    postEditorUrl: '/editor',
+                });
+                await handleA.ready;
+            });
+
+            await act(async () => {
+                handleA.unmount();
+            });
+            expect(
+                target.querySelectorAll('[data-testid="ap-site-editor-stub"]').length
+            ).toBe(0);
+
+            await act(async () => {
+                handleB = mountSiteEditor(target, {
+                    routeBase: '/visual-editor/site',
+                    postEditorUrl: '/editor',
+                });
+                await handleB.ready;
+            });
+            expect(
+                target.querySelectorAll('[data-testid="ap-site-editor-stub"]').length
+            ).toBe(1);
+
+            // Stale unmount — must not affect handleB's root.
+            await act(async () => {
+                handleA.unmount();
+            });
+            expect(
+                target.querySelectorAll('[data-testid="ap-site-editor-stub"]').length
+            ).toBe(1);
+
+            await act(async () => {
+                handleB.unmount();
+            });
+        } finally {
+            if (target.parentNode === document.body) {
+                document.body.removeChild(target);
+            }
+        }
+    });
+
     it('is idempotent — repeat mounts on the same node return the same root', async () => {
         const target = document.createElement('div');
         target.setAttribute('data-ap-site-editor', '');

--- a/resources/js/visual-editor/site-editor/__tests__/navigator-sidebar.test.tsx
+++ b/resources/js/visual-editor/site-editor/__tests__/navigator-sidebar.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { NavigatorSidebar } from '../navigator-sidebar';
+
+describe('NavigatorSidebar', () => {
+    it('renders one tab per registered section', () => {
+        render(
+            <NavigatorSidebar
+                activeSection="templates"
+                onSelectSection={vi.fn()}
+            />
+        );
+
+        for (const slug of [
+            'templates',
+            'template-parts',
+            'patterns',
+            'styles',
+            'navigation',
+        ]) {
+            expect(
+                screen.getByTestId(`ap-site-editor-navigator-${slug}`)
+            ).toBeInTheDocument();
+        }
+    });
+
+    it('marks the active section with aria-selected', () => {
+        render(
+            <NavigatorSidebar
+                activeSection="patterns"
+                onSelectSection={vi.fn()}
+            />
+        );
+
+        const active = screen.getByTestId('ap-site-editor-navigator-patterns');
+        const inactive = screen.getByTestId(
+            'ap-site-editor-navigator-templates'
+        );
+
+        expect(active).toHaveAttribute('aria-selected', 'true');
+        expect(inactive).toHaveAttribute('aria-selected', 'false');
+    });
+
+    it('fires onSelectSection with the slug when a section is clicked', async () => {
+        const user = userEvent.setup();
+        const onSelectSection = vi.fn();
+
+        render(
+            <NavigatorSidebar
+                activeSection="templates"
+                onSelectSection={onSelectSection}
+            />
+        );
+
+        await user.click(screen.getByTestId('ap-site-editor-navigator-styles'));
+
+        expect(onSelectSection).toHaveBeenCalledWith('styles');
+    });
+
+    it('renders an outlet when children are provided', () => {
+        render(
+            <NavigatorSidebar
+                activeSection="templates"
+                onSelectSection={vi.fn()}
+            >
+                <p>extra</p>
+            </NavigatorSidebar>
+        );
+
+        expect(
+            screen.getByTestId('ap-site-editor-navigator-outlet')
+        ).toHaveTextContent('extra');
+    });
+
+    it('exposes a navigation landmark with an accessible name', () => {
+        render(
+            <NavigatorSidebar
+                activeSection="templates"
+                onSelectSection={vi.fn()}
+            />
+        );
+
+        expect(
+            screen.getByRole('navigation', { name: 'Site editor sections' })
+        ).toBeInTheDocument();
+        expect(screen.getByRole('tablist')).toHaveAttribute(
+            'aria-orientation',
+            'vertical'
+        );
+    });
+});

--- a/resources/js/visual-editor/site-editor/__tests__/navigator-sidebar.test.tsx
+++ b/resources/js/visual-editor/site-editor/__tests__/navigator-sidebar.test.tsx
@@ -1,8 +1,12 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 
-import { NavigatorSidebar } from '../navigator-sidebar';
+import {
+    NAVIGATOR_PANEL_ID,
+    NavigatorSidebar,
+    navigatorTabId,
+} from '../navigator-sidebar';
 
 describe('NavigatorSidebar', () => {
     it('renders one tab per registered section', () => {
@@ -89,5 +93,133 @@ describe('NavigatorSidebar', () => {
             'aria-orientation',
             'vertical'
         );
+    });
+
+    it('uses a roving tabindex — only the active tab is in the tab sequence', () => {
+        render(
+            <NavigatorSidebar
+                activeSection="patterns"
+                onSelectSection={vi.fn()}
+            />
+        );
+
+        const active = screen.getByTestId('ap-site-editor-navigator-patterns');
+        const inactive = [
+            'templates',
+            'template-parts',
+            'styles',
+            'navigation',
+        ].map((id) => screen.getByTestId(`ap-site-editor-navigator-${id}`));
+
+        expect(active).toHaveAttribute('tabindex', '0');
+        for (const tab of inactive) {
+            expect(tab).toHaveAttribute('tabindex', '-1');
+        }
+    });
+
+    it('emits a stable id per tab + exposes the panel id constant', () => {
+        render(
+            <NavigatorSidebar
+                activeSection="templates"
+                onSelectSection={vi.fn()}
+            />
+        );
+
+        expect(
+            screen.getByTestId('ap-site-editor-navigator-templates')
+        ).toHaveAttribute('id', navigatorTabId('templates'));
+        expect(
+            screen.getByTestId('ap-site-editor-navigator-templates')
+        ).toHaveAttribute('aria-controls', NAVIGATOR_PANEL_ID);
+    });
+
+    it('moves focus and selects on ArrowDown / ArrowUp', async () => {
+        const user = userEvent.setup();
+        const onSelectSection = vi.fn();
+
+        render(
+            <NavigatorSidebar
+                activeSection="templates"
+                onSelectSection={onSelectSection}
+            />
+        );
+
+        const templates = screen.getByTestId(
+            'ap-site-editor-navigator-templates'
+        );
+        templates.focus();
+
+        await user.keyboard('{ArrowDown}');
+
+        expect(
+            screen.getByTestId('ap-site-editor-navigator-template-parts')
+        ).toHaveFocus();
+        expect(onSelectSection).toHaveBeenLastCalledWith('template-parts');
+
+        await user.keyboard('{ArrowUp}');
+
+        expect(templates).toHaveFocus();
+        expect(onSelectSection).toHaveBeenLastCalledWith('templates');
+    });
+
+    it('wraps focus at the ends with ArrowDown / ArrowUp', () => {
+        const onSelectSection = vi.fn();
+
+        render(
+            <NavigatorSidebar
+                activeSection="navigation"
+                onSelectSection={onSelectSection}
+            />
+        );
+
+        const last = screen.getByTestId('ap-site-editor-navigator-navigation');
+        last.focus();
+
+        // `userEvent` doesn't always cooperate with the synchronous
+        // focus assertions when the listener is on a parent ul; fire a
+        // direct keydown so the bubbling target matches.
+        fireEvent.keyDown(last, { key: 'ArrowDown' });
+
+        expect(
+            screen.getByTestId('ap-site-editor-navigator-templates')
+        ).toHaveFocus();
+        expect(onSelectSection).toHaveBeenLastCalledWith('templates');
+
+        const first = screen.getByTestId('ap-site-editor-navigator-templates');
+        fireEvent.keyDown(first, { key: 'ArrowUp' });
+
+        expect(
+            screen.getByTestId('ap-site-editor-navigator-navigation')
+        ).toHaveFocus();
+        expect(onSelectSection).toHaveBeenLastCalledWith('navigation');
+    });
+
+    it('jumps to the ends with Home and End', async () => {
+        const user = userEvent.setup();
+        const onSelectSection = vi.fn();
+
+        render(
+            <NavigatorSidebar
+                activeSection="patterns"
+                onSelectSection={onSelectSection}
+            />
+        );
+
+        const patterns = screen.getByTestId('ap-site-editor-navigator-patterns');
+        patterns.focus();
+
+        await user.keyboard('{End}');
+
+        expect(
+            screen.getByTestId('ap-site-editor-navigator-navigation')
+        ).toHaveFocus();
+        expect(onSelectSection).toHaveBeenLastCalledWith('navigation');
+
+        await user.keyboard('{Home}');
+
+        expect(
+            screen.getByTestId('ap-site-editor-navigator-templates')
+        ).toHaveFocus();
+        expect(onSelectSection).toHaveBeenLastCalledWith('templates');
     });
 });

--- a/resources/js/visual-editor/site-editor/__tests__/site-editor-app.test.tsx
+++ b/resources/js/visual-editor/site-editor/__tests__/site-editor-app.test.tsx
@@ -1,0 +1,203 @@
+import { act, render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Stub the canvas frame to avoid mounting `BlockCanvas` (which needs a
+// real iframe + the @wordpress/block-editor data store) under jsdom.
+// The shell-level integration is what we're verifying here; the canvas
+// has its own focused test.
+vi.mock('../canvas-frame', () => ({
+    CanvasFrame: ({
+        sectionLabel,
+        hasEntity,
+    }: {
+        sectionLabel: string;
+        hasEntity?: boolean;
+    }): JSX.Element => (
+        <div
+            data-testid="ap-site-editor-canvas"
+            data-has-entity={hasEntity ?? false}
+        >
+            {sectionLabel}
+        </div>
+    ),
+}));
+
+import { SiteEditorApp } from '../site-editor-app';
+
+const ROUTE_BASE = '/visual-editor/site';
+
+function setPath(pathname: string): void {
+    window.history.replaceState(null, '', pathname);
+}
+
+beforeEach(() => {
+    setPath(ROUTE_BASE);
+    window.localStorage.clear();
+});
+
+afterEach(() => {
+    setPath('/');
+});
+
+function renderApp(): void {
+    render(
+        <SiteEditorApp
+            routeBase={ROUTE_BASE}
+            postEditorUrl="/editor"
+        />
+    );
+}
+
+describe('SiteEditorApp', () => {
+    it('renders the four shell regions', () => {
+        renderApp();
+
+        expect(screen.getByTestId('ap-site-editor-shell')).toBeInTheDocument();
+        expect(
+            screen.getByTestId('ap-visual-editor-top-bar')
+        ).toBeInTheDocument();
+        expect(
+            screen.getByTestId('ap-site-editor-navigator')
+        ).toBeInTheDocument();
+        expect(screen.getByTestId('ap-site-editor-canvas')).toBeInTheDocument();
+        expect(
+            screen.getByTestId('ap-site-editor-inspector')
+        ).toBeInTheDocument();
+    });
+
+    it('lands on Templates by default and reflects it in the mode indicator', () => {
+        renderApp();
+
+        const indicator = screen.getByTestId('ap-site-editor-mode-indicator');
+
+        expect(indicator).toHaveAttribute('data-section', 'templates');
+        expect(indicator).toHaveTextContent('Editing: Templates');
+        expect(screen.getByTestId('ap-site-editor-save')).toHaveTextContent(
+            'Save template'
+        );
+    });
+
+    it('switches sections when the user picks one in the navigator', async () => {
+        const user = userEvent.setup();
+        renderApp();
+
+        await user.click(screen.getByTestId('ap-site-editor-navigator-styles'));
+
+        expect(window.location.pathname).toBe(`${ROUTE_BASE}/styles`);
+        expect(
+            screen.getByTestId('ap-site-editor-mode-indicator')
+        ).toHaveTextContent('Editing: Global styles');
+        expect(screen.getByTestId('ap-site-editor-save')).toHaveTextContent(
+            'Save global styles'
+        );
+    });
+
+    it('reflects browser back/forward (popstate) in the active section', () => {
+        renderApp();
+
+        act(() => {
+            window.history.replaceState(
+                null,
+                '',
+                `${ROUTE_BASE}/navigation`
+            );
+            window.dispatchEvent(new PopStateEvent('popstate'));
+        });
+
+        expect(
+            screen.getByTestId('ap-site-editor-mode-indicator')
+        ).toHaveAttribute('data-section', 'navigation');
+        expect(screen.getByTestId('ap-site-editor-save')).toHaveTextContent(
+            'Save menu'
+        );
+    });
+
+    it('toggles the navigator sidebar from the top bar and persists the state', async () => {
+        const user = userEvent.setup();
+        renderApp();
+
+        const toggle = screen.getByTestId('ap-visual-editor-top-bar-inserter');
+
+        expect(toggle).toHaveAttribute('aria-pressed', 'true');
+        expect(toggle).toHaveAttribute('aria-label', 'Close navigator');
+        expect(
+            screen.getByTestId('ap-site-editor-navigator')
+        ).toBeInTheDocument();
+
+        await user.click(toggle);
+
+        expect(toggle).toHaveAttribute('aria-pressed', 'false');
+        expect(toggle).toHaveAttribute('aria-label', 'Open navigator');
+        expect(
+            screen.queryByTestId('ap-site-editor-navigator')
+        ).not.toBeInTheDocument();
+        expect(
+            window.localStorage.getItem('ap-site-editor:navigator-open')
+        ).toBe('false');
+    });
+
+    it('toggles the inspector and re-labels its trigger for the site editor', async () => {
+        const user = userEvent.setup();
+        renderApp();
+
+        const toggle = screen.getByTestId('ap-visual-editor-top-bar-inspector');
+
+        expect(toggle).toHaveAttribute('aria-pressed', 'true');
+        expect(toggle).toHaveAttribute('aria-label', 'Close inspector');
+
+        await user.click(toggle);
+
+        expect(toggle).toHaveAttribute('aria-pressed', 'false');
+        expect(
+            screen.queryByTestId('ap-site-editor-inspector')
+        ).not.toBeInTheDocument();
+    });
+
+    it('renders a back-to-post-editor link pointing at the post editor URL', () => {
+        renderApp();
+
+        const back = screen.getByTestId('ap-site-editor-back-to-post-editor');
+
+        expect(back).toHaveAttribute('href', '/editor');
+    });
+
+    it('keeps the save button disabled until a per-section panel wires it', () => {
+        renderApp();
+
+        expect(screen.getByTestId('ap-site-editor-save')).toBeDisabled();
+    });
+
+    it('mounts the section outlet placeholder inside the navigator', () => {
+        renderApp();
+
+        const outlet = screen.getByTestId(
+            'ap-site-editor-section-outlet-templates'
+        );
+
+        expect(outlet).toBeInTheDocument();
+        expect(outlet).toHaveTextContent(/Templates UI lands in D2\./);
+    });
+
+    it('updates document.title to identify the active scope', () => {
+        renderApp();
+
+        expect(document.title).toBe('Site Editor · Templates');
+    });
+
+    it('initializes from the URL when deep-linked into a section', () => {
+        setPath(`${ROUTE_BASE}/patterns`);
+
+        renderApp();
+
+        const outlet = within(screen.getByTestId('ap-site-editor-navigator'));
+
+        expect(outlet.getByTestId('ap-site-editor-navigator-patterns')).toHaveAttribute(
+            'aria-selected',
+            'true'
+        );
+        expect(
+            screen.getByTestId('ap-site-editor-mode-indicator')
+        ).toHaveAttribute('data-section', 'patterns');
+    });
+});

--- a/resources/js/visual-editor/site-editor/__tests__/site-editor-app.test.tsx
+++ b/resources/js/visual-editor/site-editor/__tests__/site-editor-app.test.tsx
@@ -200,4 +200,26 @@ describe('SiteEditorApp', () => {
             screen.getByTestId('ap-site-editor-mode-indicator')
         ).toHaveAttribute('data-section', 'patterns');
     });
+
+    it('marks the body region as the tabpanel and labels it by the active tab', async () => {
+        const user = userEvent.setup();
+        renderApp();
+
+        const panel = document.getElementById('ap-site-editor-section-outlet');
+
+        expect(panel).not.toBeNull();
+        expect(panel).toHaveAttribute('role', 'tabpanel');
+        expect(panel).toHaveAttribute(
+            'aria-labelledby',
+            'ap-site-editor-tab-templates'
+        );
+        expect(panel).toHaveAttribute('tabindex', '0');
+
+        await user.click(screen.getByTestId('ap-site-editor-navigator-styles'));
+
+        expect(panel).toHaveAttribute(
+            'aria-labelledby',
+            'ap-site-editor-tab-styles'
+        );
+    });
 });

--- a/resources/js/visual-editor/site-editor/__tests__/use-site-editor-routing.test.tsx
+++ b/resources/js/visual-editor/site-editor/__tests__/use-site-editor-routing.test.tsx
@@ -57,6 +57,30 @@ describe('parseSiteEditorPath', () => {
         });
     });
 
+    it('decodes percent-encoded entity ids (round-trips reserved chars)', () => {
+        expect(
+            parseSiteEditorPath(
+                `${ROUTE_BASE}/templates/${encodeURIComponent('hero / banner')}`,
+                ROUTE_BASE
+            )
+        ).toEqual({
+            section: 'templates',
+            entityId: 'hero / banner',
+        });
+    });
+
+    it('falls back to the raw segment when the entity id is malformed', () => {
+        // A lone `%` is not a valid escape sequence — `decodeURIComponent`
+        // throws on it, and the router should not bring the SPA down on
+        // a hand-typed URL.
+        expect(
+            parseSiteEditorPath(`${ROUTE_BASE}/templates/100%`, ROUTE_BASE)
+        ).toEqual({
+            section: 'templates',
+            entityId: '100%',
+        });
+    });
+
     it('falls back to the default section for unknown slugs', () => {
         expect(
             parseSiteEditorPath(`${ROUTE_BASE}/not-a-section`, ROUTE_BASE)
@@ -86,6 +110,20 @@ describe('buildSiteEditorPath', () => {
         expect(buildSiteEditorPath('/visual-editor/site/', 'styles')).toBe(
             '/visual-editor/site/styles'
         );
+    });
+
+    it('encodes reserved characters in the entity id', () => {
+        expect(
+            buildSiteEditorPath(ROUTE_BASE, 'templates', 'hero / banner')
+        ).toBe('/visual-editor/site/templates/hero%20%2F%20banner');
+    });
+
+    it('round-trips the entity id through parse + build', () => {
+        const original = 'hero / banner';
+        const built = buildSiteEditorPath(ROUTE_BASE, 'patterns', original);
+        const parsed = parseSiteEditorPath(built, ROUTE_BASE);
+
+        expect(parsed.entityId).toBe(original);
     });
 });
 

--- a/resources/js/visual-editor/site-editor/__tests__/use-site-editor-routing.test.tsx
+++ b/resources/js/visual-editor/site-editor/__tests__/use-site-editor-routing.test.tsx
@@ -1,0 +1,168 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+    buildSiteEditorPath,
+    parseSiteEditorPath,
+    useSiteEditorRouting,
+} from '../use-site-editor-routing';
+
+const ROUTE_BASE = '/visual-editor/site';
+
+function setPath(pathname: string): void {
+    window.history.replaceState(null, '', pathname);
+}
+
+describe('parseSiteEditorPath', () => {
+    it('returns the default section when the URL is the bare prefix', () => {
+        expect(parseSiteEditorPath(ROUTE_BASE, ROUTE_BASE)).toEqual({
+            section: 'templates',
+            entityId: null,
+        });
+
+        expect(parseSiteEditorPath(`${ROUTE_BASE}/`, ROUTE_BASE)).toEqual({
+            section: 'templates',
+            entityId: null,
+        });
+    });
+
+    it('resolves the five known section slugs', () => {
+        for (const slug of [
+            'templates',
+            'template-parts',
+            'patterns',
+            'styles',
+            'navigation',
+        ] as const) {
+            expect(parseSiteEditorPath(`${ROUTE_BASE}/${slug}`, ROUTE_BASE)).toEqual({
+                section: slug,
+                entityId: null,
+            });
+        }
+    });
+
+    it('parses an entity id from the trailing path segment', () => {
+        expect(
+            parseSiteEditorPath(`${ROUTE_BASE}/templates/42`, ROUTE_BASE)
+        ).toEqual({
+            section: 'templates',
+            entityId: '42',
+        });
+
+        expect(
+            parseSiteEditorPath(`${ROUTE_BASE}/patterns/a/b`, ROUTE_BASE)
+        ).toEqual({
+            section: 'patterns',
+            entityId: 'a/b',
+        });
+    });
+
+    it('falls back to the default section for unknown slugs', () => {
+        expect(
+            parseSiteEditorPath(`${ROUTE_BASE}/not-a-section`, ROUTE_BASE)
+        ).toEqual({ section: 'templates', entityId: null });
+    });
+
+    it('returns the default when the pathname is outside the route base', () => {
+        expect(parseSiteEditorPath('/somewhere/else', ROUTE_BASE)).toEqual({
+            section: 'templates',
+            entityId: null,
+        });
+    });
+});
+
+describe('buildSiteEditorPath', () => {
+    it('joins the section and entity id under the route base', () => {
+        expect(buildSiteEditorPath(ROUTE_BASE, 'templates')).toBe(
+            '/visual-editor/site/templates'
+        );
+
+        expect(buildSiteEditorPath(ROUTE_BASE, 'patterns', '7')).toBe(
+            '/visual-editor/site/patterns/7'
+        );
+    });
+
+    it('strips a trailing slash from the route base', () => {
+        expect(buildSiteEditorPath('/visual-editor/site/', 'styles')).toBe(
+            '/visual-editor/site/styles'
+        );
+    });
+});
+
+describe('useSiteEditorRouting', () => {
+    beforeEach(() => {
+        setPath(ROUTE_BASE);
+    });
+
+    afterEach(() => {
+        setPath('/');
+    });
+
+    it('initializes from the current pathname', () => {
+        setPath(`${ROUTE_BASE}/styles`);
+
+        const { result } = renderHook(() =>
+            useSiteEditorRouting({ routeBase: ROUTE_BASE })
+        );
+
+        expect(result.current.section).toBe('styles');
+        expect(result.current.entityId).toBeNull();
+    });
+
+    it('navigate() pushes a new history entry and updates state', () => {
+        const { result } = renderHook(() =>
+            useSiteEditorRouting({ routeBase: ROUTE_BASE })
+        );
+
+        expect(result.current.section).toBe('templates');
+
+        act(() => {
+            result.current.navigate('navigation');
+        });
+
+        expect(result.current.section).toBe('navigation');
+        expect(window.location.pathname).toBe(`${ROUTE_BASE}/navigation`);
+    });
+
+    it('responds to popstate (browser back/forward)', () => {
+        const { result } = renderHook(() =>
+            useSiteEditorRouting({ routeBase: ROUTE_BASE })
+        );
+
+        act(() => {
+            result.current.navigate('patterns');
+        });
+        act(() => {
+            result.current.navigate('styles');
+        });
+
+        // Simulate the back button: rewind history and dispatch popstate.
+        act(() => {
+            window.history.replaceState(
+                { section: 'patterns', entityId: null },
+                '',
+                `${ROUTE_BASE}/patterns`
+            );
+            window.dispatchEvent(new PopStateEvent('popstate'));
+        });
+
+        expect(result.current.section).toBe('patterns');
+    });
+
+    it('does not push duplicate entries when re-navigating to the active section', () => {
+        const { result } = renderHook(() =>
+            useSiteEditorRouting({ routeBase: ROUTE_BASE })
+        );
+
+        act(() => {
+            result.current.navigate('templates');
+        });
+        const lengthAfterFirst = window.history.length;
+
+        act(() => {
+            result.current.navigate('templates');
+        });
+
+        expect(window.history.length).toBe(lengthAfterFirst);
+    });
+});

--- a/resources/js/visual-editor/site-editor/canvas-frame.css
+++ b/resources/js/visual-editor/site-editor/canvas-frame.css
@@ -1,0 +1,52 @@
+/**
+ * Site-editor canvas frame styling.
+ *
+ * The block-editor `BlockCanvas` already paints its own background
+ * inside the iframe — we only need to govern the wrapping flex cell and
+ * the empty-state placeholder rendered until D2–D5 ship.
+ */
+
+.ap-site-editor__canvas {
+    flex: 1 1 auto;
+    min-width: 0;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    background: var(--ap-site-editor-canvas-background, var(--color-base-100, #ffffff));
+}
+
+.ap-site-editor__canvas-iframe {
+    flex: 1 1 auto;
+    width: 100%;
+    border: 0;
+    background: transparent;
+}
+
+.ap-site-editor__canvas-empty {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    padding: 48px 24px;
+    color: color-mix(
+        in oklch,
+        var(--color-base-content, #1f2937) 70%,
+        transparent
+    );
+    text-align: center;
+}
+
+.ap-site-editor__canvas-empty-title {
+    margin: 0;
+    font-size: 16px;
+    font-weight: 600;
+    color: var(--color-base-content, #1f2937);
+}
+
+.ap-site-editor__canvas-empty-body {
+    margin: 0;
+    font-size: 14px;
+    line-height: 1.5;
+}

--- a/resources/js/visual-editor/site-editor/canvas-frame.tsx
+++ b/resources/js/visual-editor/site-editor/canvas-frame.tsx
@@ -1,0 +1,99 @@
+/**
+ * Site-editor canvas frame.
+ *
+ * The shell-level wrapper around the iframe canvas D2–D5 will render
+ * entity content into. For D1 (#368) the canvas only needs to:
+ *   1. Mount a real `BlockEditorProvider` + `BlockCanvas` so the iframe
+ *      is created and isolates editor styles from admin chrome (per the
+ *      issue's acceptance criteria + macro brief §3.2);
+ *   2. Show an explicit empty state when no entity is selected so the
+ *      shell isn't a void of grey.
+ *
+ * The empty state copy is intentionally generic — D2–D5 replace this
+ * outlet entirely once they own real entity rendering.
+ */
+
+import type { ReactNode } from 'react';
+import { useMemo } from 'react';
+import {
+    BlockCanvas,
+    BlockEditorProvider,
+} from '@wordpress/block-editor';
+import { Popover, SlotFillProvider } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import type { BlockInstance } from '@wordpress/blocks';
+
+import { TEXT_DOMAIN } from '../vendor/i18n';
+
+import './canvas-frame.css';
+
+export interface CanvasFrameProps {
+    /**
+     * Caption shown in the empty state — typically the active section's
+     * mode label so the user immediately knows which scope they are in.
+     */
+    sectionLabel: string;
+    /**
+     * `true` once D2–D5 hand the shell an entity to edit. D1 always
+     * passes `false` so the empty state renders.
+     */
+    hasEntity?: boolean;
+    /**
+     * Optional override for the iframe contents. Reserved for D2–D5;
+     * when omitted, the shell draws its own empty-state placeholder
+     * inside the iframe.
+     */
+    children?: ReactNode;
+}
+
+const EMPTY_BLOCKS: BlockInstance[] = [];
+
+const EMPTY_SETTINGS = Object.freeze({});
+
+export function CanvasFrame(props: CanvasFrameProps): JSX.Element {
+    const { sectionLabel, hasEntity = false, children } = props;
+
+    const emptyState = useMemo(
+        () => (
+            <div
+                className="ap-site-editor__canvas-empty"
+                role="status"
+                aria-live="polite"
+                data-testid="ap-site-editor-canvas-empty"
+            >
+                <p className="ap-site-editor__canvas-empty-title">
+                    {sectionLabel}
+                </p>
+                <p className="ap-site-editor__canvas-empty-body">
+                    {__(
+                        'Select an entity from the navigator to start editing.',
+                        TEXT_DOMAIN
+                    )}
+                </p>
+            </div>
+        ),
+        [sectionLabel]
+    );
+
+    return (
+        <div
+            className="ap-site-editor__canvas"
+            data-has-entity={hasEntity}
+            data-testid="ap-site-editor-canvas"
+        >
+            <SlotFillProvider>
+                <BlockEditorProvider
+                    value={EMPTY_BLOCKS}
+                    settings={EMPTY_SETTINGS}
+                    onChange={() => undefined}
+                    onInput={() => undefined}
+                >
+                    <BlockCanvas height="100%">
+                        {hasEntity ? children : emptyState}
+                    </BlockCanvas>
+                    <Popover.Slot />
+                </BlockEditorProvider>
+            </SlotFillProvider>
+        </div>
+    );
+}

--- a/resources/js/visual-editor/site-editor/inspector-outlet.css
+++ b/resources/js/visual-editor/site-editor/inspector-outlet.css
@@ -1,0 +1,47 @@
+/**
+ * Site-editor inspector rail styling.
+ *
+ * Mirrors the layout of the post-editor inspector (`editor-app.css`) so
+ * a user moving between the two surfaces sees the same right-rail
+ * geometry.
+ */
+
+.ap-site-editor__inspector {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    min-height: 0;
+    overflow: hidden;
+    background: var(--ap-site-editor-sidebar-background, var(--color-base-100, #ffffff));
+    border-left: 1px solid var(--ap-site-editor-border, var(--color-base-300, #e5e7eb));
+}
+
+.ap-site-editor__inspector-header {
+    padding: 16px 16px 12px;
+    border-bottom: 1px solid var(--ap-site-editor-border, var(--color-base-300, #e5e7eb));
+}
+
+.ap-site-editor__inspector-title {
+    margin: 0;
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--color-base-content, #1f2937);
+}
+
+.ap-site-editor__inspector-body {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow-y: auto;
+    padding: 16px;
+}
+
+.ap-site-editor__inspector-placeholder {
+    margin: 0;
+    font-size: 13px;
+    line-height: 1.5;
+    color: color-mix(
+        in oklch,
+        var(--color-base-content, #1f2937) 65%,
+        transparent
+    );
+}

--- a/resources/js/visual-editor/site-editor/inspector-outlet.tsx
+++ b/resources/js/visual-editor/site-editor/inspector-outlet.tsx
@@ -1,0 +1,51 @@
+/**
+ * Site-editor inspector outlet.
+ *
+ * The right-rail mount point D2–D5 will plug their per-section inspector
+ * panels into. For D1 (#368) this only renders a placeholder identifying
+ * which section is active so the shell visibly fills the inspector
+ * region. The macro design brief (`docs/design/site-editor-ux.md` §3.9)
+ * dictates that the inspector is always present (collapsible, but never
+ * removed) so users have a single, predictable home for entity-level
+ * settings — that policy is enforced here by always rendering the rail.
+ */
+
+import { __, sprintf } from '@wordpress/i18n';
+
+import { TEXT_DOMAIN } from '../vendor/i18n';
+
+import './inspector-outlet.css';
+
+export interface InspectorOutletProps {
+    sectionLabel: string;
+}
+
+export function InspectorOutlet(props: InspectorOutletProps): JSX.Element {
+    const { sectionLabel } = props;
+
+    return (
+        <aside
+            className="ap-site-editor__inspector"
+            aria-label={__('Section inspector', TEXT_DOMAIN)}
+            data-testid="ap-site-editor-inspector"
+        >
+            <div className="ap-site-editor__inspector-header">
+                <h2 className="ap-site-editor__inspector-title">
+                    {sectionLabel}
+                </h2>
+            </div>
+            <div className="ap-site-editor__inspector-body">
+                <p className="ap-site-editor__inspector-placeholder">
+                    {sprintf(
+                        /* translators: %s: site-editor section label (e.g. "Templates"). */
+                        __(
+                            'Inspector controls for %s land in a follow-up phase.',
+                            TEXT_DOMAIN
+                        ),
+                        sectionLabel
+                    )}
+                </p>
+            </div>
+        </aside>
+    );
+}

--- a/resources/js/visual-editor/site-editor/main.tsx
+++ b/resources/js/visual-editor/site-editor/main.tsx
@@ -17,9 +17,18 @@ import { createRoot, type Root } from 'react-dom/client';
 
 const MOUNT_SELECTOR = '[data-ap-site-editor]';
 const ROOT_SYMBOL: unique symbol = Symbol('ap-site-editor-root');
+const READY_SYMBOL: unique symbol = Symbol('ap-site-editor-ready');
 
 type MountableElement = HTMLElement & {
     [ROOT_SYMBOL]?: Root;
+    /**
+     * Resolves once the dynamic shell module has loaded and the initial
+     * render has been scheduled. Stored on the host so a second call to
+     * {@link mountSiteEditor} on the same element waits for the first
+     * mount's render commit instead of resolving immediately and
+     * letting callers race the render.
+     */
+    [READY_SYMBOL]?: Promise<void>;
 };
 
 export interface SiteEditorMountConfig {
@@ -56,9 +65,17 @@ export function mountSiteEditor(
 ): MountedSiteEditor {
     const host = element as MountableElement;
 
-    if (host[ROOT_SYMBOL]) {
+    // Re-mount on an already-mounted host: hand back the in-flight
+    // readiness promise so the second caller sees the same render
+    // commit the first caller is waiting for. Falling back to
+    // `Promise.resolve()` here (the previous behaviour) lets the
+    // second caller race the dynamic import and observe a
+    // half-mounted DOM.
+    const existing = host[READY_SYMBOL];
+
+    if (host[ROOT_SYMBOL] && existing !== undefined) {
         return {
-            ready: Promise.resolve(),
+            ready: existing,
             unmount: () => unmountSiteEditor(host),
         };
     }
@@ -87,6 +104,8 @@ export function mountSiteEditor(
         }
     );
 
+    host[READY_SYMBOL] = ready;
+
     return {
         ready,
         unmount: () => unmountSiteEditor(host),
@@ -101,6 +120,7 @@ function unmountSiteEditor(element: MountableElement): void {
     }
 
     delete element[ROOT_SYMBOL];
+    delete element[READY_SYMBOL];
     root.unmount();
 }
 

--- a/resources/js/visual-editor/site-editor/main.tsx
+++ b/resources/js/visual-editor/site-editor/main.tsx
@@ -1,0 +1,141 @@
+/**
+ * Site-editor bootstrap entry.
+ *
+ * Scans the DOM for the `[data-ap-site-editor]` mount element rendered
+ * by `resources/views/site-editor/index.blade.php` and attaches the
+ * React shell to it. Mirrors the post-editor boot pattern in
+ * `editor/main.tsx` so host apps that already understand one entry
+ * understand the other.
+ *
+ * The Gutenberg packages are imported lazily through a dynamic
+ * `import('./site-editor-app')` so the `@wordpress/*` bundle lands in
+ * the shared `gutenberg` chunk (see `vite.config.ts`).
+ */
+
+import { createElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+const MOUNT_SELECTOR = '[data-ap-site-editor]';
+const ROOT_SYMBOL: unique symbol = Symbol('ap-site-editor-root');
+
+type MountableElement = HTMLElement & {
+    [ROOT_SYMBOL]?: Root;
+};
+
+export interface SiteEditorMountConfig {
+    routeBase: string;
+    postEditorUrl: string;
+}
+
+export interface MountedSiteEditor {
+    /**
+     * Tear down the React root and release the mount slot. Idempotent.
+     */
+    unmount(): void;
+    /**
+     * Resolves once the dynamic shell module has loaded and the initial
+     * render has been scheduled. Rejects if the bundle fails to load.
+     */
+    ready: Promise<void>;
+}
+
+function readMountConfig(element: HTMLElement): SiteEditorMountConfig | null {
+    const routeBase = element.dataset.routeBase?.trim();
+    const postEditorUrl = element.dataset.postEditorUrl?.trim();
+
+    if (!routeBase || !postEditorUrl) {
+        return null;
+    }
+
+    return { routeBase, postEditorUrl };
+}
+
+export function mountSiteEditor(
+    element: HTMLElement,
+    config: SiteEditorMountConfig
+): MountedSiteEditor {
+    const host = element as MountableElement;
+
+    if (host[ROOT_SYMBOL]) {
+        return {
+            ready: Promise.resolve(),
+            unmount: () => unmountSiteEditor(host),
+        };
+    }
+
+    const root = createRoot(host);
+    host[ROOT_SYMBOL] = root;
+
+    const ready = import('./site-editor-app').then(
+        ({ SiteEditorApp }) => {
+            // Bail if the host unmounted before the dynamic import
+            // resolved (HMR / rapid re-mount).
+            if (host[ROOT_SYMBOL] !== root) {
+                return;
+            }
+
+            // Same StrictMode caveat as the post editor — see
+            // `editor/main.tsx` for the rationale. Several
+            // `@wordpress/components` and block-editor color paths
+            // are not StrictMode-safe in the pinned package versions.
+            root.render(createElement(SiteEditorApp, config));
+        },
+        (error: unknown) => {
+            console.error('site-editor: failed to load shell.', error);
+            unmountSiteEditor(host);
+            throw error;
+        }
+    );
+
+    return {
+        ready,
+        unmount: () => unmountSiteEditor(host),
+    };
+}
+
+function unmountSiteEditor(element: MountableElement): void {
+    const root = element[ROOT_SYMBOL];
+
+    if (root === undefined) {
+        return;
+    }
+
+    delete element[ROOT_SYMBOL];
+    root.unmount();
+}
+
+async function mount(element: MountableElement): Promise<void> {
+    const config = readMountConfig(element);
+
+    if (config === null) {
+        console.error(
+            'site-editor: mount point is missing data-route-base or data-post-editor-url.',
+            element
+        );
+        return;
+    }
+
+    try {
+        await mountSiteEditor(element, config).ready;
+    } catch {
+        // `mountSiteEditor` already logged the failure and cleared the root.
+    }
+}
+
+export function bootSiteEditor(
+    scope: ParentNode = document
+): Promise<void[]> {
+    const elements = scope.querySelectorAll<HTMLElement>(MOUNT_SELECTOR);
+
+    return Promise.all(Array.from(elements).map((element) => mount(element)));
+}
+
+if (typeof document !== 'undefined') {
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', () => {
+            void bootSiteEditor();
+        });
+    } else {
+        void bootSiteEditor();
+    }
+}

--- a/resources/js/visual-editor/site-editor/main.tsx
+++ b/resources/js/visual-editor/site-editor/main.tsx
@@ -99,7 +99,16 @@ export function mountSiteEditor(
         },
         (error: unknown) => {
             console.error('site-editor: failed to load shell.', error);
-            unmountSiteEditor(host);
+
+            // Same staleness guard as the success path above: if the
+            // host has been unmounted and re-mounted (HMR, rapid
+            // re-boot) while this import was in flight, the current
+            // root on the host belongs to that newer mount — leave it
+            // alone instead of tearing it down on a stale failure.
+            if (host[ROOT_SYMBOL] === root) {
+                unmountSiteEditor(host);
+            }
+
             throw error;
         }
     );

--- a/resources/js/visual-editor/site-editor/main.tsx
+++ b/resources/js/visual-editor/site-editor/main.tsx
@@ -72,11 +72,12 @@ export function mountSiteEditor(
     // second caller race the dynamic import and observe a
     // half-mounted DOM.
     const existing = host[READY_SYMBOL];
+    const existingRoot = host[ROOT_SYMBOL];
 
-    if (host[ROOT_SYMBOL] && existing !== undefined) {
+    if (existingRoot !== undefined && existing !== undefined) {
         return {
             ready: existing,
-            unmount: () => unmountSiteEditor(host),
+            unmount: makeBoundUnmount(host, existingRoot),
         };
     }
 
@@ -117,7 +118,7 @@ export function mountSiteEditor(
 
     return {
         ready,
-        unmount: () => unmountSiteEditor(host),
+        unmount: makeBoundUnmount(host, root),
     };
 }
 
@@ -131,6 +132,23 @@ function unmountSiteEditor(element: MountableElement): void {
     delete element[ROOT_SYMBOL];
     delete element[READY_SYMBOL];
     root.unmount();
+}
+
+/**
+ * Builds an unmount closure bound to the specific root the caller's
+ * {@link MountedSiteEditor} handle was created for. A handle that was
+ * already used to unmount (or that belongs to a mount that has since
+ * been replaced — HMR, rapid re-boot) becomes a no-op instead of
+ * tearing down whatever newer root happens to be on the host. Without
+ * this, a stale handle's `unmount()` would call `unmountSiteEditor`
+ * unconditionally and stomp the live mount.
+ */
+function makeBoundUnmount(host: MountableElement, ownRoot: Root): () => void {
+    return () => {
+        if (host[ROOT_SYMBOL] === ownRoot) {
+            unmountSiteEditor(host);
+        }
+    };
 }
 
 async function mount(element: MountableElement): Promise<void> {

--- a/resources/js/visual-editor/site-editor/navigator-sidebar.css
+++ b/resources/js/visual-editor/site-editor/navigator-sidebar.css
@@ -1,0 +1,92 @@
+/**
+ * Site-editor navigator sidebar styling.
+ *
+ * Layout-only — colour, border, and radius tokens cascade in from
+ * `.ap-site-editor__shell`. Keeping the visual tokens centralized lets
+ * D2–D5 add their own per-section panels under the section list without
+ * re-declaring the theme palette.
+ */
+
+.ap-site-editor__navigator {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    min-height: 0;
+    overflow: hidden;
+}
+
+.ap-site-editor__navigator-list {
+    list-style: none;
+    margin: 0;
+    padding: 12px 8px;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    border-bottom: 1px solid var(--ap-site-editor-border, var(--color-base-300, #e5e7eb));
+}
+
+.ap-site-editor__navigator-item {
+    margin: 0;
+}
+
+.ap-site-editor__navigator-link {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    width: 100%;
+    padding: 8px 10px;
+    background: transparent;
+    color: inherit;
+    border: 1px solid transparent;
+    border-radius: var(--rounded-btn, 0.375rem);
+    font: inherit;
+    font-size: 14px;
+    line-height: 1.4;
+    text-align: left;
+    cursor: pointer;
+}
+
+.ap-site-editor__navigator-link:hover,
+.ap-site-editor__navigator-link:focus-visible {
+    background: color-mix(
+        in oklch,
+        var(--color-primary, #2563eb) 10%,
+        transparent
+    );
+    outline: none;
+}
+
+.ap-site-editor__navigator-link:focus-visible {
+    border-color: var(--color-primary, #2563eb);
+}
+
+.ap-site-editor__navigator-link[data-active='true'] {
+    background: color-mix(
+        in oklch,
+        var(--color-primary, #2563eb) 16%,
+        transparent
+    );
+    color: var(--color-primary, #2563eb);
+    font-weight: 600;
+}
+
+.ap-site-editor__navigator-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 auto;
+    width: 18px;
+    height: 18px;
+}
+
+.ap-site-editor__navigator-label {
+    flex: 1 1 auto;
+    min-width: 0;
+}
+
+.ap-site-editor__navigator-outlet {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow-y: auto;
+    padding: 8px;
+}

--- a/resources/js/visual-editor/site-editor/navigator-sidebar.tsx
+++ b/resources/js/visual-editor/site-editor/navigator-sidebar.tsx
@@ -13,7 +13,8 @@
  * shell so the top-bar toggle and the sidebar's own chevron stay in sync.
  */
 
-import type { ReactNode } from 'react';
+import type { KeyboardEvent as ReactKeyboardEvent, ReactNode } from 'react';
+import { useCallback, useRef } from 'react';
 import { __ } from '@wordpress/i18n';
 
 import { TEXT_DOMAIN } from '../vendor/i18n';
@@ -24,6 +25,14 @@ import {
 } from './sections';
 
 import './navigator-sidebar.css';
+
+/** Stable id per tab — also consumed by the tabpanel's `aria-labelledby`. */
+export function navigatorTabId(section: SiteEditorSectionId): string {
+    return `ap-site-editor-tab-${section}`;
+}
+
+/** Id of the tabpanel the navigator's tabs control. */
+export const NAVIGATOR_PANEL_ID = 'ap-site-editor-section-outlet';
 
 export interface NavigatorSidebarProps {
     activeSection: SiteEditorSectionId;
@@ -39,6 +48,75 @@ export interface NavigatorSidebarProps {
 export function NavigatorSidebar(props: NavigatorSidebarProps): JSX.Element {
     const { activeSection, onSelectSection, children } = props;
     const sections = getSiteEditorSections();
+    const tablistRef = useRef<HTMLUListElement | null>(null);
+
+    // Roving-tabindex keyboard navigation per the WAI-ARIA APG `tabs`
+    // pattern (vertical orientation). Up / Down move focus, Home / End
+    // jump to the ends; selecting a tab also fires onSelectSection so
+    // arrow-key navigation immediately swaps the active section
+    // (automatic activation, the recommended default for tab content
+    // that is cheap to render — our shells are).
+    const handleKeyDown = useCallback(
+        (event: ReactKeyboardEvent<HTMLUListElement>): void => {
+            if (tablistRef.current === null) {
+                return;
+            }
+
+            const tabs = Array.from(
+                tablistRef.current.querySelectorAll<HTMLButtonElement>(
+                    '[role="tab"]'
+                )
+            );
+
+            if (tabs.length === 0) {
+                return;
+            }
+
+            const currentIndex = tabs.indexOf(
+                document.activeElement as HTMLButtonElement
+            );
+
+            let nextIndex: number | null = null;
+
+            if (event.key === 'ArrowDown') {
+                nextIndex =
+                    currentIndex === -1
+                        ? 0
+                        : (currentIndex + 1) % tabs.length;
+            } else if (event.key === 'ArrowUp') {
+                nextIndex =
+                    currentIndex === -1
+                        ? tabs.length - 1
+                        : (currentIndex - 1 + tabs.length) % tabs.length;
+            } else if (event.key === 'Home') {
+                nextIndex = 0;
+            } else if (event.key === 'End') {
+                nextIndex = tabs.length - 1;
+            }
+
+            if (nextIndex === null) {
+                return;
+            }
+
+            event.preventDefault();
+            const target = tabs[nextIndex];
+
+            if (target === undefined) {
+                return;
+            }
+
+            target.focus();
+
+            const sectionId = target.dataset.section as
+                | SiteEditorSectionId
+                | undefined;
+
+            if (sectionId !== undefined) {
+                onSelectSection(sectionId);
+            }
+        },
+        [onSelectSection]
+    );
 
     return (
         <nav
@@ -47,9 +125,11 @@ export function NavigatorSidebar(props: NavigatorSidebarProps): JSX.Element {
             data-testid="ap-site-editor-navigator"
         >
             <ul
+                ref={tablistRef}
                 className="ap-site-editor__navigator-list"
                 role="tablist"
                 aria-orientation="vertical"
+                onKeyDown={handleKeyDown}
             >
                 {sections.map((section) => {
                     const isActive = section.id === activeSection;
@@ -63,8 +143,9 @@ export function NavigatorSidebar(props: NavigatorSidebarProps): JSX.Element {
                             <button
                                 type="button"
                                 role="tab"
+                                id={navigatorTabId(section.id)}
                                 aria-selected={isActive}
-                                aria-controls="ap-site-editor-section-outlet"
+                                aria-controls={NAVIGATOR_PANEL_ID}
                                 tabIndex={isActive ? 0 : -1}
                                 className="ap-site-editor__navigator-link"
                                 data-active={isActive}

--- a/resources/js/visual-editor/site-editor/navigator-sidebar.tsx
+++ b/resources/js/visual-editor/site-editor/navigator-sidebar.tsx
@@ -1,0 +1,99 @@
+/**
+ * Site-editor navigator sidebar.
+ *
+ * Renders the section list (Templates / Template Parts / Patterns /
+ * Styles / Navigation) as the left-rail navigator. Per the macro design
+ * brief (`docs/design/site-editor-ux.md` §3.2, principle P5: navigator
+ * browses, canvas edits, inspector configures), this region only owns
+ * navigation between sections — D2–D5 plug per-section entity browsers
+ * inside each section's collapsible block underneath.
+ *
+ * The sidebar exposes a collapse affordance whose state is persisted
+ * (see {@link useSiteEditorChromeState}). The state lift up to the parent
+ * shell so the top-bar toggle and the sidebar's own chevron stay in sync.
+ */
+
+import type { ReactNode } from 'react';
+import { __ } from '@wordpress/i18n';
+
+import { TEXT_DOMAIN } from '../vendor/i18n';
+
+import {
+    getSiteEditorSections,
+    type SiteEditorSectionId,
+} from './sections';
+
+import './navigator-sidebar.css';
+
+export interface NavigatorSidebarProps {
+    activeSection: SiteEditorSectionId;
+    onSelectSection: (section: SiteEditorSectionId) => void;
+    /**
+     * Optional content rendered underneath the section list. D2–D5 use
+     * this slot to inject the per-section entity browser (template list,
+     * pattern list, etc.); D1 leaves it empty.
+     */
+    children?: ReactNode;
+}
+
+export function NavigatorSidebar(props: NavigatorSidebarProps): JSX.Element {
+    const { activeSection, onSelectSection, children } = props;
+    const sections = getSiteEditorSections();
+
+    return (
+        <nav
+            className="ap-site-editor__navigator"
+            aria-label={__('Site editor sections', TEXT_DOMAIN)}
+            data-testid="ap-site-editor-navigator"
+        >
+            <ul
+                className="ap-site-editor__navigator-list"
+                role="tablist"
+                aria-orientation="vertical"
+            >
+                {sections.map((section) => {
+                    const isActive = section.id === activeSection;
+
+                    return (
+                        <li
+                            key={section.id}
+                            className="ap-site-editor__navigator-item"
+                            role="presentation"
+                        >
+                            <button
+                                type="button"
+                                role="tab"
+                                aria-selected={isActive}
+                                aria-controls="ap-site-editor-section-outlet"
+                                tabIndex={isActive ? 0 : -1}
+                                className="ap-site-editor__navigator-link"
+                                data-active={isActive}
+                                data-section={section.id}
+                                data-testid={`ap-site-editor-navigator-${section.id}`}
+                                onClick={() => onSelectSection(section.id)}
+                            >
+                                <span
+                                    className="ap-site-editor__navigator-icon"
+                                    aria-hidden="true"
+                                >
+                                    {section.icon}
+                                </span>
+                                <span className="ap-site-editor__navigator-label">
+                                    {section.label}
+                                </span>
+                            </button>
+                        </li>
+                    );
+                })}
+            </ul>
+            {children !== undefined ? (
+                <div
+                    className="ap-site-editor__navigator-outlet"
+                    data-testid="ap-site-editor-navigator-outlet"
+                >
+                    {children}
+                </div>
+            ) : null}
+        </nav>
+    );
+}

--- a/resources/js/visual-editor/site-editor/section-outlet.tsx
+++ b/resources/js/visual-editor/site-editor/section-outlet.tsx
@@ -1,0 +1,48 @@
+/**
+ * Section-tab outlet placeholder.
+ *
+ * D2 (templates + parts), D3 (styles), D4 (navigation), and D5
+ * (patterns) each replace this placeholder for their section. Until
+ * those phases land, the canvas frame renders the empty state and the
+ * navigator-outlet slot below the section list shows this short
+ * "lands in {phase}" notice so the shell is informative rather than
+ * blank.
+ */
+
+import { __, sprintf } from '@wordpress/i18n';
+
+import { TEXT_DOMAIN } from '../vendor/i18n';
+
+import { type SiteEditorSectionId } from './sections';
+
+const SECTION_PHASE_NOTE: Record<SiteEditorSectionId, string> = {
+    templates: 'D2',
+    'template-parts': 'D2',
+    patterns: 'D5',
+    styles: 'D3',
+    navigation: 'D4',
+};
+
+export interface SectionOutletProps {
+    section: SiteEditorSectionId;
+    sectionLabel: string;
+}
+
+export function SectionOutlet(props: SectionOutletProps): JSX.Element {
+    const { section, sectionLabel } = props;
+    const phase = SECTION_PHASE_NOTE[section];
+
+    return (
+        <p
+            className="ap-site-editor__section-outlet"
+            data-testid={`ap-site-editor-section-outlet-${section}`}
+        >
+            {sprintf(
+                /* translators: 1: section label, 2: phase identifier (e.g. "D2"). */
+                __('%1$s UI lands in %2$s.', TEXT_DOMAIN),
+                sectionLabel,
+                phase
+            )}
+        </p>
+    );
+}

--- a/resources/js/visual-editor/site-editor/sections.tsx
+++ b/resources/js/visual-editor/site-editor/sections.tsx
@@ -1,0 +1,153 @@
+/**
+ * Site-editor section registry.
+ *
+ * Single source of truth for the five sections D2–D5 will plug into. Each
+ * entry binds a route slug to its label, save-scope label, and inline SVG
+ * icon used by the navigator. Order in the array also defines the order
+ * shown in the navigator.
+ *
+ * Per the macro design brief (`docs/design/site-editor-ux.md` §4.2), every
+ * Save action *names its scope*. The `saveLabel` here is consumed by the
+ * top bar; D2–D5 only need to wire the section-specific save handler.
+ */
+
+import { __ } from '@wordpress/i18n';
+import type { ReactElement } from 'react';
+
+import { TEXT_DOMAIN } from '../vendor/i18n';
+
+export type SiteEditorSectionId =
+    | 'templates'
+    | 'template-parts'
+    | 'patterns'
+    | 'styles'
+    | 'navigation';
+
+export interface SiteEditorSection {
+    id: SiteEditorSectionId;
+    /**
+     * Route slug used in the URL and the navigator anchors. Matches the
+     * `id` for the five V1 sections; kept separate so a future section
+     * could ship under an alias slug without breaking the registry key.
+     */
+    slug: SiteEditorSectionId;
+    /** Human-readable section title (e.g. "Templates"). */
+    label: string;
+    /** Mode-indicator wording (e.g. "Editing: Templates"). */
+    modeLabel: string;
+    /** Save button label per design brief §4.3 (e.g. "Save template"). */
+    saveLabel: string;
+    /**
+     * Inline SVG path. Kept inline to avoid a Blade-icons dependency in
+     * the package bundle (see project memory: package blades / JS must
+     * not depend on `<x-artisanpack-icon>`).
+     */
+    icon: ReactElement;
+}
+
+function svg(path: string): ReactElement {
+    return (
+        <svg
+            aria-hidden="true"
+            focusable="false"
+            viewBox="0 0 24 24"
+            width="18"
+            height="18"
+        >
+            <path fill="currentColor" d={path} />
+        </svg>
+    );
+}
+
+/**
+ * Returns the registry. A function (not a top-level constant) so the
+ * `__()` calls run after `bootI18n()` in the site-editor entry has
+ * initialized the text domain.
+ */
+export function getSiteEditorSections(): ReadonlyArray<SiteEditorSection> {
+    return [
+        {
+            id: 'templates',
+            slug: 'templates',
+            label: __('Templates', TEXT_DOMAIN),
+            modeLabel: __('Editing: Templates', TEXT_DOMAIN),
+            saveLabel: __('Save template', TEXT_DOMAIN),
+            icon: svg('M4 4h16v4H4V4zm0 6h7v10H4V10zm9 0h7v10h-7V10z'),
+        },
+        {
+            id: 'template-parts',
+            slug: 'template-parts',
+            label: __('Template Parts', TEXT_DOMAIN),
+            modeLabel: __('Editing: Template Parts', TEXT_DOMAIN),
+            saveLabel: __('Save template part', TEXT_DOMAIN),
+            icon: svg(
+                'M3 4h18v3H3V4zm0 6.5h18v3H3v-3zM3 17h18v3H3v-3z'
+            ),
+        },
+        {
+            id: 'patterns',
+            slug: 'patterns',
+            label: __('Patterns', TEXT_DOMAIN),
+            modeLabel: __('Editing: Patterns', TEXT_DOMAIN),
+            saveLabel: __('Save pattern', TEXT_DOMAIN),
+            icon: svg(
+                'M3 3h8v8H3V3zm10 0h8v8h-8V3zM3 13h8v8H3v-8zm10 0h8v8h-8v-8z'
+            ),
+        },
+        {
+            id: 'styles',
+            slug: 'styles',
+            label: __('Styles', TEXT_DOMAIN),
+            modeLabel: __('Editing: Global styles', TEXT_DOMAIN),
+            saveLabel: __('Save global styles', TEXT_DOMAIN),
+            icon: svg(
+                'M12 3a9 9 0 0 0 0 18c.83 0 1.5-.67 1.5-1.5 0-.39-.15-.74-.39-1.01-.23-.27-.36-.61-.36-.99 0-.83.67-1.5 1.5-1.5H16a5 5 0 0 0 5-5c0-4.42-4.03-8-9-8zm-5.5 9a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3zm3-4a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3zm5 0a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3zm3 4a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3z'
+            ),
+        },
+        {
+            id: 'navigation',
+            slug: 'navigation',
+            label: __('Navigation', TEXT_DOMAIN),
+            modeLabel: __('Editing: Navigation', TEXT_DOMAIN),
+            saveLabel: __('Save menu', TEXT_DOMAIN),
+            icon: svg(
+                'M3 6h18v2H3V6zm0 5h18v2H3v-2zm0 5h18v2H3v-2z'
+            ),
+        },
+    ];
+}
+
+/**
+ * Lookup helper that returns `null` for unknown slugs so callers can
+ * fall back to the default section instead of throwing.
+ */
+export function findSectionBySlug(
+    slug: string | null | undefined
+): SiteEditorSection | null {
+    if (slug === null || slug === undefined || slug === '') {
+        return null;
+    }
+
+    const sections = getSiteEditorSections();
+
+    return sections.find((section) => section.slug === slug) ?? null;
+}
+
+/**
+ * Resolve a known {@link SiteEditorSectionId} to its registry entry.
+ * The input is type-narrowed to one of the five known ids so the lookup
+ * cannot fail; throwing on a miss makes a future registry change loud
+ * instead of silently falling back to a wrong section.
+ */
+export function getSection(id: SiteEditorSectionId): SiteEditorSection {
+    const match = getSiteEditorSections().find((section) => section.id === id);
+
+    if (match === undefined) {
+        throw new Error(`Unknown site-editor section id: ${id}`);
+    }
+
+    return match;
+}
+
+/** Default landing section when the URL is just `/visual-editor/site`. */
+export const DEFAULT_SECTION_ID: SiteEditorSectionId = 'templates';

--- a/resources/js/visual-editor/site-editor/site-editor-app.css
+++ b/resources/js/visual-editor/site-editor/site-editor-app.css
@@ -9,7 +9,7 @@
  *     the inserter; the inspector keeps its right-rail position.
  */
 
-@import url('../editor/top-bar.css');
+@import '../editor/top-bar.css';
 
 .ap-visual-editor-site-editor-body {
     margin: 0;

--- a/resources/js/visual-editor/site-editor/site-editor-app.css
+++ b/resources/js/visual-editor/site-editor/site-editor-app.css
@@ -1,0 +1,143 @@
+/**
+ * Site-editor shell layout.
+ *
+ * Mirrors the post-editor shell (`editor/editor-app.css`) so the two
+ * editors feel like siblings (P3 in the macro design brief). Differences:
+ *   - Uses `--ap-site-editor-*` tokens namespaced separately so themes
+ *     can tune each surface independently.
+ *   - Renders the navigator on the left where the post editor renders
+ *     the inserter; the inspector keeps its right-rail position.
+ */
+
+@import url('../editor/top-bar.css');
+
+.ap-visual-editor-site-editor-body {
+    margin: 0;
+    background: var(--ap-site-editor-shell-background, var(--color-base-200, #f9fafb));
+    color: var(--ap-site-editor-shell-foreground, var(--color-base-content, #1f2937));
+    font-family: var(--ap-site-editor-font-family, system-ui, -apple-system, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif);
+}
+
+.ap-site-editor__shell {
+    --ap-site-editor-shell-background: var(--color-base-200, #f9fafb);
+    --ap-site-editor-shell-foreground: var(--color-base-content, #1f2937);
+    --ap-site-editor-border: var(--color-base-300, #e5e7eb);
+    --ap-site-editor-sidebar-background: var(--color-base-100, #ffffff);
+    --ap-site-editor-canvas-background: var(--color-base-100, #ffffff);
+    --ap-site-editor-navigator-width: 260px;
+    --ap-site-editor-inspector-width: 280px;
+
+    display: flex;
+    flex-direction: column;
+    background: var(--ap-site-editor-shell-background);
+    color: var(--ap-site-editor-shell-foreground);
+    height: 100dvh;
+    max-height: 100dvh;
+    overflow: hidden;
+}
+
+@supports not (height: 100dvh) {
+    .ap-site-editor__shell {
+        height: 100vh;
+        max-height: 100vh;
+    }
+}
+
+.ap-site-editor__body {
+    display: flex;
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow: hidden;
+}
+
+.ap-site-editor__sidebar {
+    background: var(--ap-site-editor-sidebar-background);
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    overflow: hidden;
+}
+
+.ap-site-editor__sidebar--navigator {
+    flex: 0 0 var(--ap-site-editor-navigator-width);
+    border-right: 1px solid var(--ap-site-editor-border);
+}
+
+.ap-site-editor__sidebar--inspector {
+    flex: 0 0 var(--ap-site-editor-inspector-width);
+}
+
+.ap-site-editor__top-bar-extras {
+    display: inline-flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.ap-site-editor__top-bar-back {
+    display: inline-flex;
+    align-items: center;
+    color: inherit;
+    text-decoration: none;
+    font-size: 13px;
+    padding: 4px 8px;
+    border-radius: var(--rounded-btn, 0.375rem);
+    border: 1px solid transparent;
+}
+
+.ap-site-editor__top-bar-back:hover,
+.ap-site-editor__top-bar-back:focus-visible {
+    background: color-mix(
+        in oklch,
+        var(--color-base-content, #1f2937) 8%,
+        transparent
+    );
+    outline: none;
+}
+
+.ap-site-editor__top-bar-back:focus-visible {
+    border-color: var(--color-primary, #2563eb);
+}
+
+.ap-site-editor__mode-indicator {
+    font-size: 13px;
+    font-weight: 600;
+    color: color-mix(
+        in oklch,
+        var(--color-base-content, #1f2937) 80%,
+        transparent
+    );
+    padding: 0 6px;
+    white-space: nowrap;
+}
+
+.ap-site-editor__top-bar-save {
+    display: inline-flex;
+    align-items: center;
+    padding: 6px 12px;
+    background: var(--color-primary, #2563eb);
+    color: var(--color-primary-content, #ffffff);
+    border: 0;
+    border-radius: var(--rounded-btn, 0.375rem);
+    font: inherit;
+    font-size: 13px;
+    font-weight: 600;
+    cursor: pointer;
+}
+
+.ap-site-editor__top-bar-save:disabled {
+    opacity: 0.55;
+    cursor: not-allowed;
+}
+
+.ap-site-editor__section-outlet {
+    margin: 0;
+    padding: 12px 4px;
+    font-size: 13px;
+    line-height: 1.5;
+    color: color-mix(
+        in oklch,
+        var(--color-base-content, #1f2937) 65%,
+        transparent
+    );
+}

--- a/resources/js/visual-editor/site-editor/site-editor-app.tsx
+++ b/resources/js/visual-editor/site-editor/site-editor-app.tsx
@@ -30,7 +30,11 @@ import { TEXT_DOMAIN, bootI18n } from '../vendor/i18n';
 
 import { CanvasFrame } from './canvas-frame';
 import { InspectorOutlet } from './inspector-outlet';
-import { NavigatorSidebar } from './navigator-sidebar';
+import {
+    NAVIGATOR_PANEL_ID,
+    NavigatorSidebar,
+    navigatorTabId,
+} from './navigator-sidebar';
 import { SectionOutlet } from './section-outlet';
 import { getSection } from './sections';
 import { usePersistedToggle } from './use-persisted-toggle';
@@ -190,7 +194,10 @@ export function SiteEditorApp(props: SiteEditorAppProps): JSX.Element {
             />
             <div
                 className="ap-site-editor__body"
-                id="ap-site-editor-section-outlet"
+                id={NAVIGATOR_PANEL_ID}
+                role="tabpanel"
+                aria-labelledby={navigatorTabId(activeSection.id)}
+                tabIndex={0}
             >
                 {navigatorOpen ? (
                     <div className="ap-site-editor__sidebar ap-site-editor__sidebar--navigator">

--- a/resources/js/visual-editor/site-editor/site-editor-app.tsx
+++ b/resources/js/visual-editor/site-editor/site-editor-app.tsx
@@ -1,0 +1,220 @@
+/**
+ * Site-editor SPA root.
+ *
+ * D1 (#368) — assembles the four shell regions defined in the macro
+ * design brief (`docs/design/site-editor-ux.md` §3.2):
+ *
+ *   ┌────────── Top bar ──────────┐
+ *   │ Navigator │  Canvas │ Inspector │
+ *   └─────────────────────────────────┘
+ *
+ * The top bar reuses the post-editor's {@link TopBar} so the chrome
+ * stays visually consistent (per issue: "Reuse the post-editor's
+ * top-bar implementation from M7 rather than forking it"). Site-editor-
+ * specific extras — back-to-post-editor, mode indicator, save-with-
+ * scope — ride in through the existing `extraActions` slot.
+ *
+ * D2–D5 plug into:
+ *   - The navigator's `children` slot for per-section entity browsers.
+ *   - The canvas-frame's `hasEntity` / `children` for live editing.
+ *   - The inspector outlet for per-entity settings.
+ *
+ * Until those phases land, the shell is intentionally informative
+ * (placeholders name the section + phase) rather than empty.
+ */
+
+import { useCallback, useEffect, useMemo } from 'react';
+import { __, sprintf } from '@wordpress/i18n';
+
+import { TEXT_DOMAIN, bootI18n } from '../vendor/i18n';
+
+import { CanvasFrame } from './canvas-frame';
+import { InspectorOutlet } from './inspector-outlet';
+import { NavigatorSidebar } from './navigator-sidebar';
+import { SectionOutlet } from './section-outlet';
+import { getSection } from './sections';
+import { usePersistedToggle } from './use-persisted-toggle';
+import { useSiteEditorRouting } from './use-site-editor-routing';
+import { TopBar } from '../editor/top-bar';
+
+import './site-editor-app.css';
+
+const NAVIGATOR_STORAGE_KEY = 'ap-site-editor:navigator-open';
+const INSPECTOR_STORAGE_KEY = 'ap-site-editor:inspector-open';
+
+export interface SiteEditorAppProps {
+    /** Pathname prefix the SPA owns (e.g. `/visual-editor/site`). */
+    routeBase: string;
+    /** URL to send the user back to when they leave the site editor. */
+    postEditorUrl: string;
+}
+
+let i18nBooted = false;
+
+function ensureI18n(): void {
+    if (i18nBooted) {
+        return;
+    }
+
+    bootI18n();
+    i18nBooted = true;
+}
+
+export function SiteEditorApp(props: SiteEditorAppProps): JSX.Element {
+    ensureI18n();
+
+    const { routeBase, postEditorUrl } = props;
+
+    const routing = useSiteEditorRouting({ routeBase });
+    const [navigatorOpen, setNavigatorOpen] = usePersistedToggle(
+        NAVIGATOR_STORAGE_KEY,
+        true
+    );
+    const [inspectorOpen, setInspectorOpen] = usePersistedToggle(
+        INSPECTOR_STORAGE_KEY,
+        true
+    );
+    const activeSection = useMemo(
+        () => getSection(routing.section),
+        [routing.section]
+    );
+
+    // Update the document title so deep-links and tab pickers identify
+    // the active scope without forcing the user to read the URL.
+    useEffect(() => {
+        if (typeof document === 'undefined') {
+            return;
+        }
+
+        document.title = sprintf(
+            /* translators: %s: active site-editor section label. */
+            __('Site Editor · %s', TEXT_DOMAIN),
+            activeSection.label
+        );
+    }, [activeSection.label]);
+
+    const handleSelectSection = useCallback(
+        (sectionId: typeof activeSection.id): void => {
+            routing.navigate(sectionId, null);
+        },
+        [routing]
+    );
+
+    const handleToggleNavigator = useCallback((): void => {
+        setNavigatorOpen((open) => !open);
+    }, [setNavigatorOpen]);
+
+    const handleToggleInspector = useCallback((): void => {
+        setInspectorOpen((open) => !open);
+    }, [setInspectorOpen]);
+
+    // The Cmd+S handler is intentionally a no-op for D1 so the
+    // shortcut doesn't bubble up as a browser "save page" dialog. D2–D5
+    // replace this with the real, scope-aware save dispatcher.
+    const handleSavePlaceholder = useCallback((): void => undefined, []);
+
+    const inserterToggleAriaLabel = useMemo(
+        () => ({
+            open: __('Open navigator', TEXT_DOMAIN),
+            close: __('Close navigator', TEXT_DOMAIN),
+        }),
+        []
+    );
+
+    const inspectorToggleAriaLabel = useMemo(
+        () => ({
+            open: __('Open inspector', TEXT_DOMAIN),
+            close: __('Close inspector', TEXT_DOMAIN),
+        }),
+        []
+    );
+
+    const extraActions = (
+        <div
+            className="ap-site-editor__top-bar-extras"
+            data-testid="ap-site-editor-top-bar-extras"
+        >
+            <a
+                className="ap-site-editor__top-bar-back"
+                href={postEditorUrl}
+                data-testid="ap-site-editor-back-to-post-editor"
+            >
+                {__('← Post editor', TEXT_DOMAIN)}
+            </a>
+            <span
+                className="ap-site-editor__mode-indicator"
+                role="status"
+                aria-live="polite"
+                data-testid="ap-site-editor-mode-indicator"
+                data-section={activeSection.id}
+            >
+                {activeSection.modeLabel}
+            </span>
+            <button
+                type="button"
+                className="ap-site-editor__top-bar-save"
+                disabled
+                aria-label={activeSection.saveLabel}
+                data-testid="ap-site-editor-save"
+            >
+                {activeSection.saveLabel}
+            </button>
+        </div>
+    );
+
+    return (
+        <div
+            className="ap-site-editor__shell"
+            data-navigator-open={navigatorOpen}
+            data-inspector-open={inspectorOpen}
+            data-active-section={activeSection.id}
+            data-testid="ap-site-editor-shell"
+        >
+            <TopBar
+                saveStatus="idle"
+                lastSavedAt={null}
+                saveErrorMessage={null}
+                canUndo={false}
+                canRedo={false}
+                onUndo={() => undefined}
+                onRedo={() => undefined}
+                isInserterOpen={navigatorOpen}
+                isInspectorOpen={inspectorOpen}
+                onToggleInserter={handleToggleNavigator}
+                onToggleInspector={handleToggleInspector}
+                previewUrl={null}
+                onSave={handleSavePlaceholder}
+                inserterToggleAriaLabel={inserterToggleAriaLabel}
+                inspectorToggleAriaLabel={inspectorToggleAriaLabel}
+                extraActions={extraActions}
+            />
+            <div
+                className="ap-site-editor__body"
+                id="ap-site-editor-section-outlet"
+            >
+                {navigatorOpen ? (
+                    <div className="ap-site-editor__sidebar ap-site-editor__sidebar--navigator">
+                        <NavigatorSidebar
+                            activeSection={activeSection.id}
+                            onSelectSection={handleSelectSection}
+                        >
+                            <SectionOutlet
+                                section={activeSection.id}
+                                sectionLabel={activeSection.label}
+                            />
+                        </NavigatorSidebar>
+                    </div>
+                ) : null}
+                <CanvasFrame
+                    sectionLabel={activeSection.modeLabel}
+                    hasEntity={false}
+                />
+                {inspectorOpen ? (
+                    <div className="ap-site-editor__sidebar ap-site-editor__sidebar--inspector">
+                        <InspectorOutlet sectionLabel={activeSection.label} />
+                    </div>
+                ) : null}
+            </div>
+        </div>
+    );
+}

--- a/resources/js/visual-editor/site-editor/use-persisted-toggle.ts
+++ b/resources/js/visual-editor/site-editor/use-persisted-toggle.ts
@@ -1,0 +1,73 @@
+/**
+ * Tiny localStorage-backed boolean toggle hook.
+ *
+ * Used by the site-editor shell to remember whether the navigator (and
+ * inspector) sidebar is collapsed across navigations and reloads — the
+ * issue's acceptance criteria require that "navigator sidebar is
+ * collapsible; state persists across navigations within the site
+ * editor." Falls back to in-memory state when storage isn't available
+ * (private browsing, SSR) so the hook never throws.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+function readStored(key: string, fallback: boolean): boolean {
+    if (typeof window === 'undefined' || window.localStorage === undefined) {
+        return fallback;
+    }
+
+    try {
+        const raw = window.localStorage.getItem(key);
+
+        if (raw === null) {
+            return fallback;
+        }
+
+        return raw === 'true';
+    } catch {
+        // Storage access can throw in private mode / sandboxed iframes.
+        return fallback;
+    }
+}
+
+export function usePersistedToggle(
+    storageKey: string,
+    defaultValue: boolean
+): [boolean, (next: boolean | ((prev: boolean) => boolean)) => void] {
+    const [value, setValue] = useState<boolean>(() =>
+        readStored(storageKey, defaultValue)
+    );
+
+    // Mirror the latest value in a ref so the persistence effect can
+    // write without depending on `value`, avoiding redundant writes
+    // when the consumer re-renders for unrelated reasons.
+    const lastWrittenRef = useRef<boolean>(value);
+
+    useEffect(() => {
+        if (typeof window === 'undefined' || window.localStorage === undefined) {
+            return;
+        }
+
+        if (lastWrittenRef.current === value) {
+            return;
+        }
+
+        try {
+            window.localStorage.setItem(storageKey, value ? 'true' : 'false');
+            lastWrittenRef.current = value;
+        } catch {
+            // Ignore quota / disabled-storage errors.
+        }
+    }, [storageKey, value]);
+
+    const update = useCallback(
+        (next: boolean | ((prev: boolean) => boolean)): void => {
+            setValue((prev) =>
+                typeof next === 'function' ? next(prev) : next
+            );
+        },
+        []
+    );
+
+    return [value, update];
+}

--- a/resources/js/visual-editor/site-editor/use-site-editor-routing.ts
+++ b/resources/js/visual-editor/site-editor/use-site-editor-routing.ts
@@ -1,0 +1,162 @@
+/**
+ * Site-editor routing hook.
+ *
+ * Owns the URL ↔ active-section mapping for the site-editor SPA. The
+ * Laravel route (`/visual-editor/site/{path?}`) is a single catch-all
+ * that hands control to the React shell; this hook reads the trailing
+ * path on mount, exposes the parsed `{section, entityId}`, and pushes
+ * to `window.history` when the user picks a different section in the
+ * navigator. `popstate` is wired so browser back/forward stay in sync.
+ *
+ * Kept separate from the React component tree so unit tests can drive
+ * navigation without rendering a full DOM.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import {
+    DEFAULT_SECTION_ID,
+    findSectionBySlug,
+    type SiteEditorSectionId,
+} from './sections';
+
+export interface SiteEditorLocation {
+    section: SiteEditorSectionId;
+    /** Entity id when a sub-path is present; `null` for list mode. */
+    entityId: string | null;
+}
+
+export interface SiteEditorRouting extends SiteEditorLocation {
+    /**
+     * Navigate to a different section (and optionally a specific entity)
+     * without a full page reload. Pushes a new history entry; falls back
+     * to direct state update when running outside a browser (SSR).
+     */
+    navigate: (section: SiteEditorSectionId, entityId?: string | null) => void;
+}
+
+interface UseSiteEditorRoutingOptions {
+    /** Path prefix the SPA owns (e.g. `/visual-editor/site`). */
+    routeBase: string;
+}
+
+/**
+ * Pure URL parser. Exported for tests so they can assert the mapping
+ * without running the hook.
+ */
+export function parseSiteEditorPath(
+    pathname: string,
+    routeBase: string
+): SiteEditorLocation {
+    const normalizedBase = routeBase.replace(/\/+$/, '');
+
+    if (
+        pathname !== normalizedBase &&
+        !pathname.startsWith(`${normalizedBase}/`)
+    ) {
+        return { section: DEFAULT_SECTION_ID, entityId: null };
+    }
+
+    const trailing = pathname
+        .slice(normalizedBase.length)
+        .replace(/^\/+/, '')
+        .replace(/\/+$/, '');
+
+    if (trailing === '') {
+        return { section: DEFAULT_SECTION_ID, entityId: null };
+    }
+
+    const [sectionSlug, ...rest] = trailing.split('/');
+    const section = findSectionBySlug(sectionSlug);
+
+    if (section === null) {
+        return { section: DEFAULT_SECTION_ID, entityId: null };
+    }
+
+    const entityId = rest.length > 0 ? rest.join('/') : null;
+
+    return { section: section.id, entityId };
+}
+
+/**
+ * Builds the canonical pathname for a (section, entityId) pair. Pure;
+ * exported for tests.
+ */
+export function buildSiteEditorPath(
+    routeBase: string,
+    section: SiteEditorSectionId,
+    entityId: string | null = null
+): string {
+    const normalizedBase = routeBase.replace(/\/+$/, '');
+    const tail = entityId === null ? section : `${section}/${entityId}`;
+
+    return `${normalizedBase}/${tail}`;
+}
+
+export function useSiteEditorRouting(
+    options: UseSiteEditorRoutingOptions
+): SiteEditorRouting {
+    const { routeBase } = options;
+
+    const [location, setLocation] = useState<SiteEditorLocation>(() => {
+        if (typeof window === 'undefined') {
+            return { section: DEFAULT_SECTION_ID, entityId: null };
+        }
+
+        return parseSiteEditorPath(window.location.pathname, routeBase);
+    });
+
+    useEffect(() => {
+        if (typeof window === 'undefined') {
+            return;
+        }
+
+        function handlePopState(): void {
+            setLocation(parseSiteEditorPath(window.location.pathname, routeBase));
+        }
+
+        window.addEventListener('popstate', handlePopState);
+
+        return () => {
+            window.removeEventListener('popstate', handlePopState);
+        };
+    }, [routeBase]);
+
+    const navigate = useCallback(
+        (section: SiteEditorSectionId, entityId: string | null = null): void => {
+            const next: SiteEditorLocation = { section, entityId };
+
+            setLocation((prev) => {
+                if (prev.section === section && prev.entityId === entityId) {
+                    return prev;
+                }
+
+                return next;
+            });
+
+            if (typeof window === 'undefined') {
+                return;
+            }
+
+            const target = buildSiteEditorPath(routeBase, section, entityId);
+
+            // Avoid pushing duplicate entries when the user clicks the
+            // already-active item.
+            if (window.location.pathname === target) {
+                return;
+            }
+
+            window.history.pushState({ section, entityId }, '', target);
+        },
+        [routeBase]
+    );
+
+    return useMemo(
+        () => ({
+            section: location.section,
+            entityId: location.entityId,
+            navigate,
+        }),
+        [location.entityId, location.section, navigate]
+    );
+}

--- a/resources/js/visual-editor/site-editor/use-site-editor-routing.ts
+++ b/resources/js/visual-editor/site-editor/use-site-editor-routing.ts
@@ -73,14 +73,29 @@ export function parseSiteEditorPath(
         return { section: DEFAULT_SECTION_ID, entityId: null };
     }
 
-    const entityId = rest.length > 0 ? rest.join('/') : null;
+    const entityId = rest.length > 0 ? decodePathSegment(rest.join('/')) : null;
 
     return { section: section.id, entityId };
 }
 
 /**
+ * `decodeURIComponent` throws on malformed escape sequences (e.g. a
+ * lone `%`). The router should never crash on a hand-typed URL — fall
+ * back to the raw string when the segment isn't decodable so the user
+ * still lands on the resolved section.
+ */
+function decodePathSegment(value: string): string {
+    try {
+        return decodeURIComponent(value);
+    } catch {
+        return value;
+    }
+}
+
+/**
  * Builds the canonical pathname for a (section, entityId) pair. Pure;
- * exported for tests.
+ * exported for tests. The entity id is `encodeURIComponent`-ed so
+ * reserved characters round-trip safely through `parseSiteEditorPath`.
  */
 export function buildSiteEditorPath(
     routeBase: string,
@@ -88,7 +103,10 @@ export function buildSiteEditorPath(
     entityId: string | null = null
 ): string {
     const normalizedBase = routeBase.replace(/\/+$/, '');
-    const tail = entityId === null ? section : `${section}/${entityId}`;
+    const tail =
+        entityId === null
+            ? section
+            : `${section}/${encodeURIComponent(entityId)}`;
 
     return `${normalizedBase}/${tail}`;
 }

--- a/resources/views/site-editor/index.blade.php
+++ b/resources/views/site-editor/index.blade.php
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title>ArtisanPack Visual Editor — Site Editor</title>
+	@viteReactRefresh
+	{{-- D1 (#368). Site-editor shell entry. Mounts the SPA into the
+	     `[data-ap-site-editor]` element below; the React app reads the
+	     current URL pathname under `data-route-base` to resolve the
+	     active section and entity. --}}
+	@vite(['resources/js/visual-editor/site-editor/main.tsx'])
+</head>
+<body class="ap-visual-editor-site-editor-body">
+	<div
+		id="ap-visual-editor-site-editor"
+		data-ap-site-editor
+		data-route-base="/visual-editor/site"
+		data-post-editor-url="{{ route('visual-editor.editor') }}"
+	></div>
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -18,3 +18,13 @@ Route::get('/editor', function () {
 Route::get('/ve-sandbox', function () {
     return view('visual-editor::sandbox.index');
 })->name('visual-editor.sandbox');
+
+// D1 (#368). Site-editor shell. A single catch-all entry mounts the SPA and
+// hands routing inside the shell to the React app via `history.pushState`.
+// Sub-paths the SPA recognises: `templates`, `template-parts`, `patterns`,
+// `styles`, `navigation` (each optionally followed by an entity id).
+Route::get('/visual-editor/site/{path?}', function () {
+    return view('visual-editor::site-editor.index');
+})
+    ->where('path', '.*')
+    ->name('visual-editor.site-editor');

--- a/tests/Feature/SiteEditorShellTest.php
+++ b/tests/Feature/SiteEditorShellTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+// D1 (#368). Site-editor shell wiring tests. The new /visual-editor/site
+// route mounts the SPA defined in resources/js/visual-editor/site-editor;
+// these checks confirm the static plumbing (blade view, route, vite
+// entry, mount attributes) is in place so the JS-side tests can assert
+// the SPA itself.
+
+$repoRoot = __DIR__.'/../..';
+$viewPath = $repoRoot.'/resources/views/site-editor/index.blade.php';
+$routesPath = $repoRoot.'/routes/web.php';
+$viteConfigPath = $repoRoot.'/vite.config.ts';
+$mainEntryPath = $repoRoot.'/resources/js/visual-editor/site-editor/main.tsx';
+$appPath = $repoRoot.'/resources/js/visual-editor/site-editor/site-editor-app.tsx';
+$sectionsPath = $repoRoot.'/resources/js/visual-editor/site-editor/sections.tsx';
+$navigatorPath = $repoRoot.'/resources/js/visual-editor/site-editor/navigator-sidebar.tsx';
+$canvasPath = $repoRoot.'/resources/js/visual-editor/site-editor/canvas-frame.tsx';
+
+test('site-editor blade view exists and exposes the SPA mount data attributes', function () use ($viewPath) {
+    expect(file_exists($viewPath))->toBeTrue();
+
+    $contents = file_get_contents($viewPath);
+
+    expect($contents)->toContain('data-ap-site-editor');
+    expect($contents)->toContain('data-route-base="/visual-editor/site"');
+    expect($contents)->toContain("data-post-editor-url=\"{{ route('visual-editor.editor') }}\"");
+    expect($contents)->toContain("@vite(['resources/js/visual-editor/site-editor/main.tsx'])");
+});
+
+test('package routes register the /visual-editor/site catch-all path', function () use ($routesPath) {
+    $contents = file_get_contents($routesPath);
+
+    expect($contents)->toContain("Route::get('/visual-editor/site/{path?}'");
+    expect($contents)->toContain('visual-editor::site-editor.index');
+    expect($contents)->toContain("->where('path', '.*')");
+    expect($contents)->toContain("->name('visual-editor.site-editor')");
+});
+
+test('vite config registers the site-editor entry alongside the post-editor entry', function () use ($viteConfigPath) {
+    $contents = file_get_contents($viteConfigPath);
+
+    expect($contents)->toContain("'site-editor': siteEditorEntry");
+    expect($contents)->toContain('site-editor/main.tsx');
+});
+
+test('site-editor main entry boots the SPA and reads the mount data attributes', function () use ($mainEntryPath) {
+    $contents = file_get_contents($mainEntryPath);
+
+    expect($contents)->toContain('data-ap-site-editor');
+    expect($contents)->toContain('routeBase');
+    expect($contents)->toContain('postEditorUrl');
+    expect($contents)->toContain("import('./site-editor-app')");
+});
+
+test('site-editor app composes the four shell regions', function () use ($appPath) {
+    $contents = file_get_contents($appPath);
+
+    expect($contents)->toContain('NavigatorSidebar');
+    expect($contents)->toContain('CanvasFrame');
+    expect($contents)->toContain('InspectorOutlet');
+    // Reuses the post-editor TopBar — must not fork it.
+    expect($contents)->toContain("from '../editor/top-bar'");
+    expect($contents)->toContain('inserterToggleAriaLabel');
+    expect($contents)->toContain('inspectorToggleAriaLabel');
+});
+
+test('section registry declares the five V1 site-editor sections', function () use ($sectionsPath) {
+    $contents = file_get_contents($sectionsPath);
+
+    foreach (['templates', 'template-parts', 'patterns', 'styles', 'navigation'] as $slug) {
+        expect($contents)->toContain("id: '{$slug}'");
+    }
+
+    // Save labels per design brief §4.3 must name their scope.
+    expect($contents)->toContain('Save template');
+    expect($contents)->toContain('Save template part');
+    expect($contents)->toContain('Save pattern');
+    expect($contents)->toContain('Save global styles');
+    expect($contents)->toContain('Save menu');
+});
+
+test('navigator sidebar exposes a navigation landmark and tablist semantics', function () use ($navigatorPath) {
+    $contents = file_get_contents($navigatorPath);
+
+    expect($contents)->toContain("aria-label={__('Site editor sections'");
+    expect($contents)->toContain("role=\"tablist\"");
+    expect($contents)->toContain("role=\"tab\"");
+    expect($contents)->toContain('aria-orientation="vertical"');
+});
+
+test('canvas frame wraps BlockCanvas in a BlockEditorProvider', function () use ($canvasPath) {
+    $contents = file_get_contents($canvasPath);
+
+    expect($contents)->toContain('BlockEditorProvider');
+    expect($contents)->toContain('BlockCanvas');
+    // The empty state must be present so D1 doesn't ship a blank canvas.
+    expect($contents)->toContain('ap-site-editor-canvas-empty');
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,6 +13,12 @@ const visualEditorEntry = resolve(
     __dirname,
     'resources/js/visual-editor/editor/main.tsx'
 );
+// D1 (#368). Site-editor shell entry — distinct boot bundle so the post
+// editor and site editor can ship independent chunks.
+const siteEditorEntry = resolve(
+    __dirname,
+    'resources/js/visual-editor/site-editor/main.tsx'
+);
 const coreDataShim = resolve(
     __dirname,
     'resources/js/visual-editor/vendor/core-data-shim.ts'
@@ -86,6 +92,7 @@ export default defineConfig(({ command, mode }) => {
                         editor: resolve(editorRoot, 'main.tsx'),
                         sandbox: sandboxEntry,
                         'visual-editor': visualEditorEntry,
+                        'site-editor': siteEditorEntry,
                     },
                     output: {
                         format: 'es',


### PR DESCRIPTION
## Description

D1 of the V1 site-editor expansion (#309). Mounts a dedicated site-editor SPA at `/visual-editor/site/{path?}` with the four-region shell defined in the macro design brief (`docs/design/site-editor-ux.md` §3.2): top bar, navigator (5 sections), iframe canvas, and inspector outlet. D2–D5 plug per-section UI into this shell — no section content lands in this PR.

**Closes:** #368

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #368

## Motivation and Context

Per the V1 plan §2.2, the site-editor shell is built in-house rather than depending on `@wordpress/edit-site`, to keep admin-chrome ownership inside the package and avoid coupling our upgrade cadence to WP-admin's REST/CPT assumptions. D1 is the chrome scaffolding that makes D2 (templates + parts), D3 (styles), D4 (navigation), and D5 (patterns) implementable in parallel.

Mid-review, we agreed on the editing-mode region model ("Pattern B" — persistent icon-only navigator + secondary inserter rail + list-view as inspector tab) so the chrome doesn't drift section-by-section as D2–D5 land. That decision is recorded in the brief as a new §3.2.1.

## Changes Made

- New Laravel route `Route::get('/visual-editor/site/{path?}')` (catch-all; SPA owns sub-paths).
- New Blade entry `resources/views/site-editor/index.blade.php` mounts a `[data-ap-site-editor]` element with `data-route-base` + `data-post-editor-url`.
- New Vite entry `site-editor` → `resources/js/visual-editor/site-editor/main.tsx` (auto-boots on the mount element; lazy-imports the shell so `@wordpress/*` lands in the existing `gutenberg` chunk).
- New SPA components under `resources/js/visual-editor/site-editor/`:
  - `site-editor-app.tsx` — root shell composition.
  - `sections.tsx` — single registry of the five sections (id, label, mode label, save label, icon). Save labels honor design brief §4.3 ("Save template", "Save template part", "Save pattern", "Save global styles", "Save menu").
  - `navigator-sidebar.tsx` — left-rail tablist, ARIA-labelled navigation landmark, `role="tab"` items, vertical orientation.
  - `canvas-frame.tsx` — `BlockEditorProvider` + `BlockCanvas` (iframe-isolated) with empty state when no entity is selected.
  - `inspector-outlet.tsx` — right-rail placeholder with section-scoped header.
  - `section-outlet.tsx` — small "Templates UI lands in D2" placeholder shown inside the navigator.
  - `use-site-editor-routing.ts` — pure path parser + `history.pushState` navigation + `popstate` listener for browser back/forward.
  - `use-persisted-toggle.ts` — localStorage-backed boolean for the navigator/inspector collapse state.
- `editor/top-bar.tsx` reused directly (no fork). Added two backward-compatible optional props — `inserterToggleAriaLabel` and `inspectorToggleAriaLabel` — so the same component can host the site editor with semantically correct toggle labels ("Open navigator" / "Open inspector").
- `docs/design/site-editor-ux.md` §3.2.1 records the editing-mode region decision (Pattern B) so D2–D5 inherit a fixed chrome.

## How Has This Been Tested?

**Tests Performed:**
1. JS suite via `npm test` — 580 tests pass (33 new for the shell across 5 files).
2. PHP suite via `./vendor/bin/pest` — 341 tests pass (8 new in `SiteEditorShellTest.php` covering route registration, blade contents, vite entry wiring, shell composition, and the section registry).
3. Manual browser walk-through against the dev app at `https://artisanpack-ui.test/visual-editor/site`: all five sections resolve via URL + navigator clicks, mode indicator + save label swap, navigator/inspector collapse persists across reloads, browser back/forward syncs, back-to-post-editor link routes correctly.

## Accessibility Tests Run

- [x] Keyboard navigation tested
- [x] ARIA labels checked
- [ ] Screen reader tested
- [ ] Color contrast verified

**Details:** Navigator is a `<nav>` landmark with an accessible name; section list is a `role="tablist"` with `aria-orientation="vertical"`, each entry `role="tab"` with `aria-selected` + roving `tabIndex`. Top-bar toggles use `aria-pressed`/`aria-expanded`/`aria-label` with site-editor-specific wording. Mode indicator is a `role="status"` `aria-live="polite"` region. Color contrast and screen-reader passes deferred to the per-section A11y reviews in D2–D5.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:**
- `use-site-editor-routing.test.tsx` — pure parser, hook init from URL, navigate/popstate, dedup of duplicate navigate.
- `navigator-sidebar.test.tsx` — section rendering, active selection, click handler, navigation landmark + tablist semantics.
- `canvas-frame.test.tsx` — empty state, BlockCanvas mount (mocked), `hasEntity` swap.
- `site-editor-app.test.tsx` — four-region render, default Templates landing, section switching updates URL + mode + save label, popstate sync, navigator/inspector toggles + persistence, back-link, default-disabled save, deep-link initialization, document.title sync.
- `main.test.tsx` — boot logs missing-attribute errors, mounts on valid element, idempotent re-mount.
- `top-bar.test.tsx` — new test for the optional aria-label override props.
- `tests/Feature/SiteEditorShellTest.php` — static wiring assertions (route, blade, vite entry, shell composition, sections registry, navigator landmarks, canvas BlockCanvas).

## Documentation

- [x] Inline code documentation added
- [x] Wiki updated *(via the design-brief amendment in `docs/design/site-editor-ux.md` §3.2.1)*

**Documentation details:** Every new file carries a header docblock describing its role and pointing back to #368 / the design brief. The brief's new §3.2.1 records the Pattern B editing-mode decision and notes that D2–D5 PRs must reference it when landing editing UI.

## Screenshots

_(Manual review captured in browser — empty-state canvas + navigator + mode indicator; will attach if requested.)_

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted *(no PHP-CS-Fixer in this package; PHP follows existing route conventions)*
- [x] Accessibility tests completed *(landmark + tablist + ARIA labels; section-level A11y deferred to D2–D5)*
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Launches Site Editor SPA: navigator, canvas frame, inspector rail, top-bar controls, persisted panel toggles, deep-link routing, mounting API, and section registry.
* **Accessibility**
  * Improved keyboard navigation, ARIA semantics, and configurable toggle aria-labels for screen readers.
* **UX / Documentation**
  * Added editing-mode UX spec describing layouts, panels, and top-bar state behaviors.
* **Tests**
  * Added comprehensive unit/integration tests covering routing, navigator, canvas, top-bar, and inspector.
* **Platform**
  * Added route and view to host the Site Editor entrypoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->