### PR TITLE
feat: D2 · Template browser + editor integration

### DIFF
--- a/resources/js/visual-editor/site-editor/__tests__/api-client.test.ts
+++ b/resources/js/visual-editor/site-editor/__tests__/api-client.test.ts
@@ -1,0 +1,196 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+    SiteEditorApiError,
+    createEntity,
+    deleteEntity,
+    fetchEntity,
+    listEntities,
+    updateEntity,
+} from '../api-client';
+
+const API_BASE = '/visual-editor/api';
+
+function mockFetch(
+    response: Response | (() => Response)
+): ReturnType<typeof vi.fn> {
+    const fn = vi.fn(async (): Promise<Response> =>
+        typeof response === 'function' ? response() : response
+    );
+
+    vi.stubGlobal('fetch', fn);
+
+    return fn;
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+    return new Response(JSON.stringify(body), {
+        status,
+        headers: { 'Content-Type': 'application/json' },
+    });
+}
+
+beforeEach(() => {
+    // Clear any inherited CSRF meta between tests.
+    document.querySelectorAll('meta[name="csrf-token"]').forEach((node) => {
+        node.remove();
+    });
+});
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
+
+describe('listEntities', () => {
+    it('requests the paginated envelope and applies filters', async () => {
+        const body = {
+            data: [{ id: 1, slug: 'single', title: { rendered: 'Single' } }],
+            meta: { current_page: 1, last_page: 1, per_page: 25, total: 1 },
+        };
+        const fetchMock = mockFetch(jsonResponse(body));
+
+        const result = await listEntities(
+            { apiBase: API_BASE },
+            'template',
+            { perPage: 10, theme: 'my-theme', status: 'publish' }
+        );
+
+        expect(result.data).toHaveLength(1);
+        expect(result.meta.total).toBe(1);
+
+        const firstCall = fetchMock.mock.calls[0];
+        expect(firstCall).toBeDefined();
+
+        const url = firstCall![0] as string;
+        expect(url).toContain('/visual-editor/api/templates');
+        expect(url).toContain('per_page=10');
+        expect(url).toContain('theme=my-theme');
+        expect(url).toContain('status=publish');
+    });
+
+    it('hits the template-parts endpoint with an area filter', async () => {
+        const fetchMock = mockFetch(
+            jsonResponse({
+                data: [],
+                meta: { current_page: 1, last_page: 1, per_page: 25, total: 0 },
+            })
+        );
+
+        await listEntities(
+            { apiBase: API_BASE },
+            'template-part',
+            { area: 'header' }
+        );
+
+        const url = fetchMock.mock.calls[0]?.[0] as string;
+        expect(url).toContain('/visual-editor/api/template-parts');
+        expect(url).toContain('area=header');
+    });
+
+    it('raises SiteEditorApiError with the parsed body on non-2xx responses', async () => {
+        mockFetch(
+            jsonResponse({ message: 'Nope', errors: { slug: ['required'] } }, 422)
+        );
+
+        await expect(
+            listEntities({ apiBase: API_BASE }, 'template')
+        ).rejects.toBeInstanceOf(SiteEditorApiError);
+    });
+});
+
+describe('fetchEntity', () => {
+    it('returns the single-record response', async () => {
+        mockFetch(
+            jsonResponse({
+                id: 42,
+                slug: 'page',
+                title: { rendered: 'Page' },
+                content: { raw: '', blocks: [] },
+            })
+        );
+
+        const record = await fetchEntity({ apiBase: API_BASE }, 'template', 42);
+
+        expect(record.id).toBe(42);
+        expect(record.slug).toBe('page');
+    });
+});
+
+describe('createEntity', () => {
+    it('POSTs with the CSRF token and Content-Type headers', async () => {
+        const meta = document.createElement('meta');
+        meta.setAttribute('name', 'csrf-token');
+        meta.setAttribute('content', 'test-token');
+        document.head.appendChild(meta);
+
+        const fetchMock = mockFetch(
+            jsonResponse({ id: 1, slug: 'single', title: { rendered: '' } }, 201)
+        );
+
+        await createEntity({ apiBase: API_BASE }, 'template', {
+            slug: 'single',
+            theme: 'default',
+        });
+
+        const [, init] = fetchMock.mock.calls[0] ?? [];
+        expect(init?.method).toBe('POST');
+        const headers = init?.headers as Record<string, string>;
+        expect(headers['X-CSRF-TOKEN']).toBe('test-token');
+        expect(headers['Content-Type']).toBe('application/json');
+    });
+});
+
+describe('updateEntity', () => {
+    it('PUTs with the body payload', async () => {
+        const fetchMock = mockFetch(
+            jsonResponse({ id: 1, slug: 'single', title: { rendered: '' } })
+        );
+
+        await updateEntity({ apiBase: API_BASE }, 'template', 1, {
+            content: { raw: '', blocks: [{ name: 'core/paragraph' }] },
+        });
+
+        const [, init] = fetchMock.mock.calls[0] ?? [];
+        expect(init?.method).toBe('PUT');
+
+        const parsedBody = JSON.parse(init?.body as string) as {
+            content: { blocks: unknown[] };
+        };
+        expect(parsedBody.content.blocks).toHaveLength(1);
+    });
+
+    it('surfaces 422 validation errors on the error object', async () => {
+        mockFetch(
+            jsonResponse(
+                {
+                    message: 'The given data was invalid.',
+                    errors: { slug: ['Slug already in use.'] },
+                },
+                422
+            )
+        );
+
+        try {
+            await updateEntity({ apiBase: API_BASE }, 'template', 1, {});
+            expect.unreachable();
+        } catch (error: unknown) {
+            expect(error).toBeInstanceOf(SiteEditorApiError);
+            const typed = error as SiteEditorApiError;
+            expect(typed.status).toBe(422);
+            expect(typed.validationErrors?.slug?.[0]).toBe('Slug already in use.');
+        }
+    });
+});
+
+describe('deleteEntity', () => {
+    it('issues a DELETE and resolves on 204', async () => {
+        const fetchMock = mockFetch(
+            new Response(null, { status: 204 })
+        );
+
+        await deleteEntity({ apiBase: API_BASE }, 'template-part', 7);
+
+        const [, init] = fetchMock.mock.calls[0] ?? [];
+        expect(init?.method).toBe('DELETE');
+    });
+});

--- a/resources/js/visual-editor/site-editor/__tests__/create-entity-dialog.test.tsx
+++ b/resources/js/visual-editor/site-editor/__tests__/create-entity-dialog.test.tsx
@@ -1,0 +1,193 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const CREATE_MOCK = vi.fn();
+
+vi.mock('../api-client', async () => {
+    const actual = await vi.importActual<typeof import('../api-client')>(
+        '../api-client'
+    );
+
+    return {
+        ...actual,
+        createEntity: (...args: unknown[]) => CREATE_MOCK(...args),
+    };
+});
+
+import { TemplateCreateDialog } from '../templates-section';
+import { TemplatePartCreateDialog } from '../template-parts-section';
+
+const API_CONFIG = { apiBase: '/visual-editor/api' };
+
+beforeEach(() => {
+    CREATE_MOCK.mockReset();
+});
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
+
+describe('TemplateCreateDialog', () => {
+    it('renders the kind picker and fallback chain', () => {
+        render(
+            <TemplateCreateDialog
+                apiConfig={API_CONFIG}
+                defaultTheme="default"
+                onClose={() => undefined}
+                onCreated={() => undefined}
+            />
+        );
+
+        const select = screen.getByTestId(
+            'ap-site-editor-new-template-kind'
+        ) as HTMLSelectElement;
+
+        expect(select).toBeInTheDocument();
+        expect(
+            screen.getByTestId('ap-site-editor-new-template-chain')
+        ).toBeInTheDocument();
+    });
+
+    it('submits the chosen slug + title to the API', async () => {
+        CREATE_MOCK.mockResolvedValue({
+            id: 42,
+            slug: 'page',
+            title: { rendered: 'About' },
+        });
+
+        const onCreated = vi.fn();
+        const user = userEvent.setup();
+
+        render(
+            <TemplateCreateDialog
+                apiConfig={API_CONFIG}
+                defaultTheme="default"
+                onClose={() => undefined}
+                onCreated={onCreated}
+            />
+        );
+
+        await user.selectOptions(
+            screen.getByTestId('ap-site-editor-new-template-kind'),
+            'page'
+        );
+        await user.type(
+            screen.getByTestId('ap-site-editor-new-template-title'),
+            'About'
+        );
+        await user.click(
+            screen.getByTestId('ap-site-editor-create-dialog-submit-template')
+        );
+
+        await waitFor(() =>
+            expect(CREATE_MOCK).toHaveBeenCalledWith(
+                API_CONFIG,
+                'template',
+                expect.objectContaining({
+                    slug: 'page',
+                    title: 'About',
+                    theme: 'default',
+                })
+            )
+        );
+
+        expect(onCreated).toHaveBeenCalledWith(
+            expect.objectContaining({ id: 42 })
+        );
+    });
+
+    it('surfaces server-side validation errors inline', async () => {
+        const { SiteEditorApiError } = await vi.importActual<
+            typeof import('../api-client')
+        >('../api-client');
+
+        CREATE_MOCK.mockRejectedValueOnce(
+            new SiteEditorApiError('Invalid', 422, {
+                message: 'Invalid',
+                errors: { slug: ['Slug in use.'] },
+            })
+        );
+
+        const user = userEvent.setup();
+
+        render(
+            <TemplateCreateDialog
+                apiConfig={API_CONFIG}
+                defaultTheme="default"
+                onClose={() => undefined}
+                onCreated={() => undefined}
+            />
+        );
+
+        // Switch to custom slug so the slug error has a field to bind to.
+        await user.selectOptions(
+            screen.getByTestId('ap-site-editor-new-template-kind'),
+            '__custom__'
+        );
+        await user.type(
+            screen.getByTestId('ap-site-editor-new-template-slug'),
+            'existing-slug'
+        );
+        await user.click(
+            screen.getByTestId('ap-site-editor-create-dialog-submit-template')
+        );
+
+        await waitFor(() =>
+            expect(
+                screen.getByTestId('ap-site-editor-create-dialog-error-template')
+            ).toBeInTheDocument()
+        );
+
+        expect(screen.getByText('Slug in use.')).toBeInTheDocument();
+    });
+});
+
+describe('TemplatePartCreateDialog', () => {
+    it('submits with the chosen area', async () => {
+        CREATE_MOCK.mockResolvedValue({
+            id: 5,
+            slug: 'site-header',
+            area: 'header',
+            title: { rendered: '' },
+        });
+
+        const onCreated = vi.fn();
+        const user = userEvent.setup();
+
+        render(
+            <TemplatePartCreateDialog
+                apiConfig={API_CONFIG}
+                defaultTheme="default"
+                onClose={() => undefined}
+                onCreated={onCreated}
+            />
+        );
+
+        await user.type(
+            screen.getByTestId('ap-site-editor-new-part-slug'),
+            'site-header'
+        );
+        await user.selectOptions(
+            screen.getByTestId('ap-site-editor-new-part-area'),
+            'footer'
+        );
+        await user.click(
+            screen.getByTestId(
+                'ap-site-editor-create-dialog-submit-template-part'
+            )
+        );
+
+        await waitFor(() =>
+            expect(CREATE_MOCK).toHaveBeenCalledWith(
+                API_CONFIG,
+                'template-part',
+                expect.objectContaining({
+                    slug: 'site-header',
+                    area: 'footer',
+                    theme: 'default',
+                })
+            )
+        );
+    });
+});

--- a/resources/js/visual-editor/site-editor/__tests__/entity-browser.test.tsx
+++ b/resources/js/visual-editor/site-editor/__tests__/entity-browser.test.tsx
@@ -1,0 +1,302 @@
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { EntityBrowser } from '../entity-browser';
+
+const LIST_MOCK = vi.fn();
+
+vi.mock('../api-client', async () => {
+    const actual = await vi.importActual<typeof import('../api-client')>(
+        '../api-client'
+    );
+
+    return {
+        ...actual,
+        listEntities: (...args: unknown[]) => LIST_MOCK(...args),
+    };
+});
+
+const API_CONFIG = { apiBase: '/visual-editor/api' };
+
+beforeEach(() => {
+    LIST_MOCK.mockReset();
+});
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
+
+describe('EntityBrowser', () => {
+    it('shows a loading status then the rows returned by the API', async () => {
+        LIST_MOCK.mockResolvedValue({
+            data: [
+                {
+                    id: 1,
+                    slug: 'single',
+                    title: { rendered: 'Single post' },
+                    content: { raw: '', blocks: [] },
+                    status: 'publish',
+                    theme: 'default',
+                    type: 'wp_template',
+                    source: 'theme',
+                    origin: null,
+                },
+            ],
+            meta: { current_page: 1, last_page: 1, per_page: 25, total: 1 },
+        });
+
+        const onOpen = vi.fn();
+
+        render(
+            <EntityBrowser
+                apiConfig={API_CONFIG}
+                kind="template"
+                activeEntityId={null}
+                onOpen={onOpen}
+                onRequestCreate={() => undefined}
+                listLabel="Templates"
+                emptyTitle="No templates yet"
+                emptyBody="Create a template."
+                createLabel="Add new"
+                openAriaLabel={(entity) =>
+                    `template: ${entity.title.rendered || entity.slug}`
+                }
+                renderRow={(entity) => <span>{entity.slug}</span>}
+            />
+        );
+
+        expect(
+            screen.getByTestId('ap-site-editor-entity-browser-loading-template')
+        ).toBeInTheDocument();
+
+        await waitFor(() =>
+            expect(
+                screen.getByTestId(
+                    'ap-site-editor-entity-browser-list-template'
+                )
+            ).toBeInTheDocument()
+        );
+
+        const row = screen.getByTestId(
+            'ap-site-editor-entity-browser-row-template-1'
+        );
+        expect(row).toHaveTextContent('Single post');
+        expect(row).toHaveAttribute('aria-label', 'Open template: Single post');
+    });
+
+    it('calls onOpen with the row id when a row is activated', async () => {
+        LIST_MOCK.mockResolvedValue({
+            data: [
+                {
+                    id: 3,
+                    slug: 'page',
+                    title: { rendered: '' },
+                    content: { raw: '', blocks: [] },
+                    status: 'publish',
+                    theme: 'default',
+                    type: 'wp_template',
+                    source: 'custom',
+                    origin: null,
+                },
+            ],
+            meta: { current_page: 1, last_page: 1, per_page: 25, total: 1 },
+        });
+
+        const onOpen = vi.fn();
+        const user = userEvent.setup();
+
+        render(
+            <EntityBrowser
+                apiConfig={API_CONFIG}
+                kind="template"
+                activeEntityId={null}
+                onOpen={onOpen}
+                onRequestCreate={() => undefined}
+                listLabel="Templates"
+                emptyTitle="No templates yet"
+                emptyBody="Create a template."
+                createLabel="Add new"
+                openAriaLabel={(entity) => `template: ${entity.slug}`}
+                renderRow={(entity) => <span>{entity.slug}</span>}
+            />
+        );
+
+        const row = await screen.findByTestId(
+            'ap-site-editor-entity-browser-row-template-3'
+        );
+        await user.click(row);
+
+        expect(onOpen).toHaveBeenCalledWith('3');
+    });
+
+    it('shows the empty state when the API returns no rows', async () => {
+        LIST_MOCK.mockResolvedValue({
+            data: [],
+            meta: { current_page: 1, last_page: 1, per_page: 25, total: 0 },
+        });
+
+        render(
+            <EntityBrowser
+                apiConfig={API_CONFIG}
+                kind="template-part"
+                activeEntityId={null}
+                onOpen={() => undefined}
+                onRequestCreate={() => undefined}
+                listLabel="Template Parts"
+                emptyTitle="No template parts yet"
+                emptyBody="Create a template part."
+                createLabel="Add new"
+                openAriaLabel={() => 'part'}
+                renderRow={() => null}
+            />
+        );
+
+        await waitFor(() =>
+            expect(
+                screen.getByTestId(
+                    'ap-site-editor-entity-browser-empty-template-part'
+                )
+            ).toBeInTheDocument()
+        );
+
+        expect(screen.getByText('No template parts yet')).toBeInTheDocument();
+    });
+
+    it('renders an error + retry when the API fails', async () => {
+        LIST_MOCK.mockRejectedValueOnce(new Error('boom'));
+
+        render(
+            <EntityBrowser
+                apiConfig={API_CONFIG}
+                kind="template"
+                activeEntityId={null}
+                onOpen={() => undefined}
+                onRequestCreate={() => undefined}
+                listLabel="Templates"
+                emptyTitle="None"
+                emptyBody=""
+                createLabel="Add"
+                openAriaLabel={() => 'x'}
+                renderRow={() => null}
+            />
+        );
+
+        await waitFor(() =>
+            expect(
+                screen.getByTestId(
+                    'ap-site-editor-entity-browser-error-template'
+                )
+            ).toBeInTheDocument()
+        );
+    });
+
+    it('triggers onRequestCreate when the add-new button is clicked', async () => {
+        LIST_MOCK.mockResolvedValue({
+            data: [],
+            meta: { current_page: 1, last_page: 1, per_page: 25, total: 0 },
+        });
+
+        const onRequestCreate = vi.fn();
+        const user = userEvent.setup();
+
+        render(
+            <EntityBrowser
+                apiConfig={API_CONFIG}
+                kind="template"
+                activeEntityId={null}
+                onOpen={() => undefined}
+                onRequestCreate={onRequestCreate}
+                listLabel="Templates"
+                emptyTitle="No templates yet"
+                emptyBody="Create a template."
+                createLabel="Add new"
+                openAriaLabel={() => 'x'}
+                renderRow={() => null}
+            />
+        );
+
+        await user.click(
+            screen.getByTestId('ap-site-editor-entity-browser-create-template')
+        );
+
+        expect(onRequestCreate).toHaveBeenCalled();
+    });
+
+    it('filters via chips and re-fetches on chip change', async () => {
+        LIST_MOCK.mockImplementation(
+            async (_config, _kind, params: { status?: string }) => ({
+                data:
+                    params.status === 'draft'
+                        ? [
+                              {
+                                  id: 5,
+                                  slug: 'draft-page',
+                                  title: { rendered: 'Draft' },
+                                  content: { raw: '', blocks: [] },
+                                  status: 'draft',
+                                  theme: 'default',
+                                  type: 'wp_template',
+                                  source: 'custom',
+                                  origin: null,
+                              },
+                          ]
+                        : [],
+                meta: {
+                    current_page: 1,
+                    last_page: 1,
+                    per_page: 25,
+                    total: params.status === 'draft' ? 1 : 0,
+                },
+            })
+        );
+
+        const user = userEvent.setup();
+
+        render(
+            <EntityBrowser
+                apiConfig={API_CONFIG}
+                kind="template"
+                activeEntityId={null}
+                onOpen={() => undefined}
+                onRequestCreate={() => undefined}
+                chips={[
+                    { id: 'all', label: 'All', filter: {} },
+                    {
+                        id: 'draft',
+                        label: 'Drafts',
+                        filter: { status: 'draft' },
+                    },
+                ]}
+                listLabel="Templates"
+                emptyTitle="No templates"
+                emptyBody=""
+                createLabel="Add"
+                openAriaLabel={(entity) => `template: ${entity.slug}`}
+                renderRow={(entity) => <span>{entity.slug}</span>}
+            />
+        );
+
+        // Initial fetch — no status filter.
+        await waitFor(() => expect(LIST_MOCK).toHaveBeenCalledTimes(1));
+
+        await user.click(
+            screen.getByTestId(
+                'ap-site-editor-entity-browser-chip-template-draft'
+            )
+        );
+
+        await waitFor(() =>
+            expect(
+                within(
+                    screen.getByTestId(
+                        'ap-site-editor-entity-browser-list-template'
+                    )
+                ).getByTestId('ap-site-editor-entity-browser-row-template-5')
+            ).toBeInTheDocument()
+        );
+
+        const secondCall = LIST_MOCK.mock.calls[1];
+        expect(secondCall?.[2]?.status).toBe('draft');
+    });
+});

--- a/resources/js/visual-editor/site-editor/__tests__/entity-editor.test.tsx
+++ b/resources/js/visual-editor/site-editor/__tests__/entity-editor.test.tsx
@@ -1,0 +1,263 @@
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Stub `BlockCanvas`, `BlockEditorProvider`, `BlockInspector`, and the
+// `SlotFillProvider` / `Popover` pair so the hook's canvas/inspector
+// renders run under jsdom without reaching into the real Gutenberg
+// data store. The entity-editor's shell-side logic is what's under test
+// here; the actual block-rendering integration is covered by the
+// canvas-frame suite.
+vi.mock('@wordpress/block-editor', () => ({
+    BlockEditorProvider: ({
+        children,
+        onChange,
+    }: {
+        children?: ReactNode;
+        onChange?: (blocks: unknown[]) => void;
+    }): JSX.Element => (
+        <div data-testid="ap-stub-block-editor-provider">
+            <button
+                type="button"
+                data-testid="ap-stub-block-editor-fire-change"
+                onClick={() => onChange?.([{ name: 'core/paragraph' }])}
+            >
+                fire-change
+            </button>
+            {children}
+        </div>
+    ),
+    BlockInspector: (): JSX.Element => (
+        <div data-testid="ap-stub-block-inspector" />
+    ),
+    BlockList: (): JSX.Element => <div data-testid="ap-stub-block-list" />,
+    BlockTools: ({ children }: { children?: ReactNode }): JSX.Element => (
+        <div>{children}</div>
+    ),
+    ObserveTyping: ({ children }: { children?: ReactNode }): JSX.Element => (
+        <div>{children}</div>
+    ),
+    WritingFlow: ({ children }: { children?: ReactNode }): JSX.Element => (
+        <div>{children}</div>
+    ),
+}));
+
+vi.mock('@wordpress/blocks', () => ({
+    parse: (raw: string): unknown[] =>
+        raw === '' ? [] : [{ name: 'core/paragraph', clientId: 'stub' }],
+    serialize: (): string => '',
+}));
+
+vi.mock('@wordpress/format-library', () => ({}));
+
+vi.mock('@wordpress/components', () => {
+    const SlotFillProvider = ({ children }: { children?: ReactNode }): JSX.Element => (
+        <div>{children}</div>
+    );
+
+    function PopoverSlot(): null {
+        return null;
+    }
+
+    const Popover = Object.assign(() => null, { Slot: PopoverSlot });
+
+    return { SlotFillProvider, Popover };
+});
+
+vi.mock('@wordpress/data', () => ({
+    useSelect: () => false,
+}));
+
+const FETCH_MOCK = vi.fn();
+const UPDATE_MOCK = vi.fn();
+
+vi.mock('../api-client', async () => {
+    const actual = await vi.importActual<typeof import('../api-client')>(
+        '../api-client'
+    );
+
+    return {
+        ...actual,
+        fetchEntity: (...args: unknown[]) => FETCH_MOCK(...args),
+        updateEntity: (...args: unknown[]) => UPDATE_MOCK(...args),
+    };
+});
+
+import { useEntityEditorViews } from '../entity-editor';
+import type { EntityEditorState } from '../entity-editor';
+
+const API_CONFIG = { apiBase: '/visual-editor/api' };
+
+beforeEach(() => {
+    FETCH_MOCK.mockReset();
+    UPDATE_MOCK.mockReset();
+});
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
+
+function Harness(props: {
+    entityId: string | null;
+    onState: (state: EntityEditorState) => void;
+}): JSX.Element {
+    const { entityId, onState } = props;
+
+    const views = useEntityEditorViews({
+        apiConfig: API_CONFIG,
+        kind: 'template',
+        entityId,
+        onStateChange: onState,
+    });
+
+    return (
+        <div>
+            {views.canvas}
+            {views.inspector}
+        </div>
+    );
+}
+
+describe('useEntityEditorViews', () => {
+    it('renders the inactive empty state when no entityId is set', () => {
+        const onState = vi.fn();
+
+        render(<Harness entityId={null} onState={onState} />);
+
+        expect(
+            screen.getByTestId('ap-site-editor-entity-canvas-inactive')
+        ).toBeInTheDocument();
+    });
+
+    it('loads the entity, announces it, and renders the canvas', async () => {
+        FETCH_MOCK.mockResolvedValue({
+            id: 7,
+            slug: 'single',
+            title: { rendered: 'Single post' },
+            description: '',
+            content: { raw: '', blocks: [{ name: 'core/paragraph' }] },
+            status: 'publish',
+            theme: 'default',
+            type: 'wp_template',
+            source: 'custom',
+            origin: null,
+        });
+
+        const onState = vi.fn();
+
+        render(<Harness entityId="7" onState={onState} />);
+
+        await waitFor(() =>
+            expect(
+                screen.getByTestId('ap-site-editor-entity-canvas')
+            ).toBeInTheDocument()
+        );
+
+        expect(
+            screen.getByTestId('ap-site-editor-entity-canvas-announce')
+        ).toHaveTextContent('Editing Single post');
+
+        expect(
+            screen.getByTestId('ap-site-editor-entity-canvas-chain')
+        ).toBeInTheDocument();
+    });
+
+    it('flips the dirty flag through onStateChange when the canvas edits blocks', async () => {
+        FETCH_MOCK.mockResolvedValue({
+            id: 1,
+            slug: 'index',
+            title: { rendered: 'Index' },
+            description: '',
+            content: { raw: '', blocks: [] },
+            status: 'publish',
+            theme: 'default',
+            type: 'wp_template',
+            source: 'custom',
+            origin: null,
+        });
+
+        const states: EntityEditorState[] = [];
+        const onState = (state: EntityEditorState): void => {
+            states.push(state);
+        };
+
+        render(<Harness entityId="1" onState={onState} />);
+
+        await waitFor(() =>
+            expect(
+                screen.getByTestId('ap-site-editor-entity-canvas')
+            ).toBeInTheDocument()
+        );
+
+        const user = userEvent.setup();
+        await user.click(
+            screen.getByTestId('ap-stub-block-editor-fire-change')
+        );
+
+        await waitFor(() => expect(states.some((s) => s.isDirty)).toBe(true));
+
+        expect(
+            screen.getByTestId('ap-site-editor-entity-canvas-dirty')
+        ).toBeInTheDocument();
+    });
+
+    it('save() dispatches PUT and clears dirty on success', async () => {
+        FETCH_MOCK.mockResolvedValue({
+            id: 1,
+            slug: 'index',
+            title: { rendered: 'Index' },
+            description: '',
+            content: { raw: '', blocks: [] },
+            status: 'publish',
+            theme: 'default',
+            type: 'wp_template',
+            source: 'custom',
+            origin: null,
+        });
+
+        UPDATE_MOCK.mockImplementation(async (_c, _k, _id, payload) => ({
+            id: 1,
+            slug: 'index',
+            title: { rendered: 'Index' },
+            description: '',
+            content: payload.content,
+            status: 'publish',
+            theme: 'default',
+            type: 'wp_template',
+            source: 'custom',
+            origin: null,
+        }));
+
+        const latestRef: { value: EntityEditorState | null } = { value: null };
+        const onState = (state: EntityEditorState): void => {
+            latestRef.value = state;
+        };
+
+        render(<Harness entityId="1" onState={onState} />);
+
+        await waitFor(() =>
+            expect(
+                screen.getByTestId('ap-site-editor-entity-canvas')
+            ).toBeInTheDocument()
+        );
+
+        // Mutate and save.
+        const user = userEvent.setup();
+        await user.click(
+            screen.getByTestId('ap-stub-block-editor-fire-change')
+        );
+
+        await waitFor(() => expect(latestRef.value?.isDirty).toBe(true));
+
+        expect(latestRef.value?.save).not.toBeNull();
+
+        await act(async () => {
+            await latestRef.value?.save?.();
+        });
+
+        expect(UPDATE_MOCK).toHaveBeenCalledTimes(1);
+        await waitFor(() => expect(latestRef.value?.saveStatus).toBe('saved'));
+        expect(latestRef.value?.isDirty).toBe(false);
+    });
+});

--- a/resources/js/visual-editor/site-editor/__tests__/fallback-chain.test.ts
+++ b/resources/js/visual-editor/site-editor/__tests__/fallback-chain.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    fallbackChainForSlug,
+    getTemplateKindOptions,
+} from '../fallback-chain';
+
+describe('fallbackChainForSlug', () => {
+    it('puts the primary slug first and always ends at index', () => {
+        const chain = fallbackChainForSlug('front-page');
+
+        expect(chain[0]).toBe('front-page');
+        expect(chain[chain.length - 1]).toBe('index');
+    });
+
+    it('walks single-specific slugs to single → singular → index', () => {
+        const chain = fallbackChainForSlug('single-post');
+
+        expect(chain).toEqual(['single-post', 'single', 'singular', 'index']);
+    });
+
+    it('walks page-specific slugs to page → singular → index', () => {
+        const chain = fallbackChainForSlug('page-about');
+
+        expect(chain).toEqual(['page-about', 'page', 'singular', 'index']);
+    });
+
+    it('falls back from archive variants to archive → index', () => {
+        const chain = fallbackChainForSlug('archive-book');
+
+        expect(chain).toEqual(['archive-book', 'archive', 'index']);
+    });
+
+    it('treats custom slugs as falling back to index only', () => {
+        const chain = fallbackChainForSlug('my-custom-template');
+
+        expect(chain).toEqual(['my-custom-template', 'index']);
+    });
+
+    it('uses only index when the slug is empty', () => {
+        const chain = fallbackChainForSlug('');
+
+        expect(chain).toEqual(['index']);
+    });
+});
+
+describe('getTemplateKindOptions', () => {
+    it('exposes the known kinds in priority order', () => {
+        const options = getTemplateKindOptions();
+        const slugs = options.map((option) => option.slug);
+
+        expect(slugs).toContain('front-page');
+        expect(slugs).toContain('single');
+        expect(slugs).toContain('page');
+        expect(slugs).toContain('archive');
+        expect(slugs).toContain('index');
+        expect(slugs.indexOf('front-page')).toBeLessThan(slugs.indexOf('index'));
+    });
+});

--- a/resources/js/visual-editor/site-editor/__tests__/main.test.tsx
+++ b/resources/js/visual-editor/site-editor/__tests__/main.test.tsx
@@ -39,6 +39,7 @@ describe('bootSiteEditor', () => {
         target.setAttribute('data-ap-site-editor', '');
         target.dataset.routeBase = '/visual-editor/site';
         target.dataset.postEditorUrl = '/editor';
+        target.dataset.apiBase = '/visual-editor/api';
         root.appendChild(target);
         document.body.appendChild(root);
 
@@ -74,6 +75,7 @@ describe('mountSiteEditor', () => {
                 handleA = mountSiteEditor(target, {
                     routeBase: '/visual-editor/site',
                     postEditorUrl: '/editor',
+                    apiBase: '/visual-editor/api',
                 });
                 await handleA.ready;
             });
@@ -89,6 +91,7 @@ describe('mountSiteEditor', () => {
                 handleB = mountSiteEditor(target, {
                     routeBase: '/visual-editor/site',
                     postEditorUrl: '/editor',
+                    apiBase: '/visual-editor/api',
                 });
                 await handleB.ready;
             });
@@ -124,6 +127,7 @@ describe('mountSiteEditor', () => {
                 const first = mountSiteEditor(target, {
                     routeBase: '/visual-editor/site',
                     postEditorUrl: '/editor',
+                    apiBase: '/visual-editor/api',
                 });
                 await first.ready;
             });
@@ -131,6 +135,7 @@ describe('mountSiteEditor', () => {
             const second = mountSiteEditor(target, {
                 routeBase: '/visual-editor/site',
                 postEditorUrl: '/editor',
+                apiBase: '/visual-editor/api',
             });
             await second.ready;
 

--- a/resources/js/visual-editor/site-editor/__tests__/site-editor-app.test.tsx
+++ b/resources/js/visual-editor/site-editor/__tests__/site-editor-app.test.tsx
@@ -7,7 +7,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 // JSON-attribute ESM rules. The shell tests don't exercise block
 // rendering; they only care that the shell wires regions correctly.
 vi.mock('@wordpress/blocks', () => ({
+    getBlockType: (): undefined => undefined,
     getBlockTypes: (): never[] => [],
+    unregisterBlockType: (): void => undefined,
 }));
 
 vi.mock('@wordpress/block-library', () => ({

--- a/resources/js/visual-editor/site-editor/__tests__/site-editor-app.test.tsx
+++ b/resources/js/visual-editor/site-editor/__tests__/site-editor-app.test.tsx
@@ -2,6 +2,18 @@ import { act, render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+// Stub the Gutenberg block-library registration pathway: loading it
+// under jsdom pulls in the full block catalog which fails on strict
+// JSON-attribute ESM rules. The shell tests don't exercise block
+// rendering; they only care that the shell wires regions correctly.
+vi.mock('@wordpress/blocks', () => ({
+    getBlockTypes: (): never[] => [],
+}));
+
+vi.mock('@wordpress/block-library', () => ({
+    registerCoreBlocks: (): void => undefined,
+}));
+
 // Stub the canvas frame to avoid mounting `BlockCanvas` (which needs a
 // real iframe + the @wordpress/block-editor data store) under jsdom.
 // The shell-level integration is what we're verifying here; the canvas
@@ -21,6 +33,32 @@ vi.mock('../canvas-frame', () => ({
             {sectionLabel}
         </div>
     ),
+}));
+
+// D2 mounts real browsers into the templates/parts sections; the shell
+// tests only care that the navigator wires them through, so stub them
+// with simple placeholders that opt out of the REST fetch chain.
+vi.mock('../templates-section', () => ({
+    TemplatesBrowser: (): JSX.Element => (
+        <div data-testid="ap-site-editor-stub-templates-browser" />
+    ),
+    TemplateCreateDialog: (): null => null,
+    TemplateDocumentPanel: (): null => null,
+}));
+
+vi.mock('../template-parts-section', () => ({
+    TemplatePartsBrowser: (): JSX.Element => (
+        <div data-testid="ap-site-editor-stub-parts-browser" />
+    ),
+    TemplatePartCreateDialog: (): null => null,
+    TemplatePartDocumentPanel: (): null => null,
+}));
+
+vi.mock('../entity-editor', () => ({
+    useEntityEditorViews: (): { canvas: JSX.Element; inspector: JSX.Element } => ({
+        canvas: <div data-testid="ap-site-editor-stub-entity-canvas" />,
+        inspector: <div data-testid="ap-site-editor-stub-entity-inspector" />,
+    }),
 }));
 
 import { SiteEditorApp } from '../site-editor-app';
@@ -45,6 +83,7 @@ function renderApp(): void {
         <SiteEditorApp
             routeBase={ROUTE_BASE}
             postEditorUrl="/editor"
+            apiBase="/visual-editor/api"
         />
     );
 }
@@ -168,15 +207,26 @@ describe('SiteEditorApp', () => {
         expect(screen.getByTestId('ap-site-editor-save')).toBeDisabled();
     });
 
-    it('mounts the section outlet placeholder inside the navigator', () => {
+    it('mounts the D2 templates browser inside the navigator', () => {
         renderApp();
 
+        expect(
+            screen.getByTestId('ap-site-editor-stub-templates-browser')
+        ).toBeInTheDocument();
+    });
+
+    it('falls back to the section-outlet placeholder for phase-not-yet sections', async () => {
+        const user = userEvent.setup();
+        renderApp();
+
+        await user.click(screen.getByTestId('ap-site-editor-navigator-patterns'));
+
         const outlet = screen.getByTestId(
-            'ap-site-editor-section-outlet-templates'
+            'ap-site-editor-section-outlet-patterns'
         );
 
         expect(outlet).toBeInTheDocument();
-        expect(outlet).toHaveTextContent(/Templates UI lands in D2\./);
+        expect(outlet).toHaveTextContent(/Patterns UI lands in D5\./);
     });
 
     it('updates document.title to identify the active scope', () => {

--- a/resources/js/visual-editor/site-editor/__tests__/use-entity-editor.test.tsx
+++ b/resources/js/visual-editor/site-editor/__tests__/use-entity-editor.test.tsx
@@ -163,6 +163,80 @@ describe('useEntityEditor', () => {
         expect(result.current.validationErrors?.slug?.[0]).toBe('Slug required.');
     });
 
+    it('merges pending patch into the exposed entity so inputs reflect typed-in values', async () => {
+        FETCH_MOCK.mockResolvedValue(makeTemplate({ description: 'Old desc' }));
+
+        const { result } = renderHook(() =>
+            useEntityEditor({
+                apiConfig: API_CONFIG,
+                kind: 'template',
+                entityId: '1',
+            })
+        );
+
+        await waitFor(() => expect(result.current.loadStatus).toBe('ready'));
+
+        act(() => {
+            result.current.patch({ title: 'Edited', description: 'New desc' });
+        });
+
+        expect(result.current.entity?.title.rendered).toBe('Edited');
+        expect(
+            (result.current.entity as unknown as { description: string } | null)
+                ?.description
+        ).toBe('New desc');
+        expect(result.current.isDirty).toBe(true);
+    });
+
+    it('ignores a save response once the user navigates to a different entity', async () => {
+        FETCH_MOCK.mockImplementation(async (_config, _kind, id) =>
+            makeTemplate({ id: Number(id), slug: `slug-${id}` })
+        );
+
+        let releaseUpdate: (value: Record<string, unknown>) => void = () => {};
+        UPDATE_MOCK.mockImplementationOnce(
+            () =>
+                new Promise<Record<string, unknown>>((resolve) => {
+                    releaseUpdate = resolve;
+                })
+        );
+
+        const { result, rerender } = renderHook(
+            ({ id }: { id: string }) =>
+                useEntityEditor({
+                    apiConfig: API_CONFIG,
+                    kind: 'template',
+                    entityId: id,
+                }),
+            { initialProps: { id: '1' } }
+        );
+
+        await waitFor(() => expect(result.current.loadStatus).toBe('ready'));
+        expect(result.current.entity?.slug).toBe('slug-1');
+
+        let savePromise: Promise<unknown> = Promise.resolve();
+        act(() => {
+            savePromise = result.current.save();
+        });
+
+        expect(result.current.saveStatus).toBe('saving');
+
+        rerender({ id: '2' });
+
+        await waitFor(() => expect(result.current.entity?.slug).toBe('slug-2'));
+
+        await act(async () => {
+            releaseUpdate(makeTemplate({ id: 1, slug: 'slug-1-stale' }));
+            await savePromise;
+        });
+
+        // The in-flight save resolved with entity 1's shape, but the user
+        // is now on entity 2 — hydrating would overwrite the visible
+        // record with the wrong one. Editor should still show entity 2.
+        expect(result.current.entity?.slug).toBe('slug-2');
+        expect(result.current.saveStatus).not.toBe('saved');
+    });
+
     it('switches to idle state when entityId becomes null', async () => {
         FETCH_MOCK.mockResolvedValue(makeTemplate());
 

--- a/resources/js/visual-editor/site-editor/__tests__/use-entity-editor.test.tsx
+++ b/resources/js/visual-editor/site-editor/__tests__/use-entity-editor.test.tsx
@@ -237,6 +237,62 @@ describe('useEntityEditor', () => {
         expect(result.current.saveStatus).not.toBe('saved');
     });
 
+    it('drops a concurrent save response that resolves after a newer save started', async () => {
+        FETCH_MOCK.mockResolvedValue(makeTemplate());
+
+        let releaseFirst: (value: Record<string, unknown>) => void = () => {};
+        let releaseSecond: (value: Record<string, unknown>) => void = () => {};
+
+        UPDATE_MOCK
+            .mockImplementationOnce(
+                () =>
+                    new Promise<Record<string, unknown>>((resolve) => {
+                        releaseFirst = resolve;
+                    })
+            )
+            .mockImplementationOnce(
+                () =>
+                    new Promise<Record<string, unknown>>((resolve) => {
+                        releaseSecond = resolve;
+                    })
+            );
+
+        const { result } = renderHook(() =>
+            useEntityEditor({
+                apiConfig: API_CONFIG,
+                kind: 'template',
+                entityId: '1',
+            })
+        );
+
+        await waitFor(() => expect(result.current.loadStatus).toBe('ready'));
+
+        let firstSave: Promise<unknown> = Promise.resolve();
+        let secondSave: Promise<unknown> = Promise.resolve();
+
+        act(() => {
+            firstSave = result.current.save();
+            secondSave = result.current.save();
+        });
+
+        // Resolve the second (newer) save first, then the first. The
+        // later-started save is authoritative — the earlier one's
+        // response must not overwrite it.
+        await act(async () => {
+            releaseSecond(makeTemplate({ slug: 'winner' }));
+            await secondSave;
+        });
+
+        expect(result.current.entity?.slug).toBe('winner');
+
+        await act(async () => {
+            releaseFirst(makeTemplate({ slug: 'stale' }));
+            await firstSave;
+        });
+
+        expect(result.current.entity?.slug).toBe('winner');
+    });
+
     it('ignores a save response that resolves after the editor was closed', async () => {
         FETCH_MOCK.mockResolvedValue(makeTemplate());
 

--- a/resources/js/visual-editor/site-editor/__tests__/use-entity-editor.test.tsx
+++ b/resources/js/visual-editor/site-editor/__tests__/use-entity-editor.test.tsx
@@ -1,0 +1,187 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Stub `@wordpress/blocks` so the hook's `parse` / `serialize` calls run
+// without loading the real package. The tests exercise the dirty +
+// save-status flow, not the underlying block-tree parsing; `parse`
+// returns the input content's parsed `blocks` array directly, and
+// `serialize` returns an empty string (exercises both branches of
+// `hydrateBlocks`).
+vi.mock('@wordpress/blocks', () => ({
+    parse: (raw: string): unknown[] =>
+        raw === '' ? [] : [{ name: 'core/paragraph', clientId: 'stub' }],
+    serialize: (): string => '',
+}));
+
+import { useEntityEditor } from '../use-entity-editor';
+
+const FETCH_MOCK = vi.fn();
+const UPDATE_MOCK = vi.fn();
+
+vi.mock('../api-client', async () => {
+    const actual = await vi.importActual<typeof import('../api-client')>(
+        '../api-client'
+    );
+
+    return {
+        ...actual,
+        fetchEntity: (...args: unknown[]) => FETCH_MOCK(...args),
+        updateEntity: (...args: unknown[]) => UPDATE_MOCK(...args),
+    };
+});
+
+const API_CONFIG = { apiBase: '/visual-editor/api' };
+
+beforeEach(() => {
+    FETCH_MOCK.mockReset();
+    UPDATE_MOCK.mockReset();
+});
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
+
+function makeTemplate(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+    return {
+        id: 1,
+        slug: 'single',
+        title: { rendered: 'Single' },
+        description: '',
+        content: { raw: '', blocks: [{ name: 'core/paragraph', attributes: {} }] },
+        status: 'publish',
+        theme: 'default',
+        type: 'wp_template',
+        source: 'custom',
+        origin: null,
+        ...overrides,
+    };
+}
+
+describe('useEntityEditor', () => {
+    it('loads the entity and hydrates the block list', async () => {
+        FETCH_MOCK.mockResolvedValue(makeTemplate());
+
+        const { result } = renderHook(() =>
+            useEntityEditor({
+                apiConfig: API_CONFIG,
+                kind: 'template',
+                entityId: '1',
+            })
+        );
+
+        await waitFor(() => expect(result.current.loadStatus).toBe('ready'));
+
+        expect(result.current.entity?.slug).toBe('single');
+        expect(result.current.blocks).toHaveLength(1);
+        expect(result.current.isDirty).toBe(false);
+    });
+
+    it('flags the editor dirty when blocks change', async () => {
+        FETCH_MOCK.mockResolvedValue(makeTemplate());
+
+        const { result } = renderHook(() =>
+            useEntityEditor({
+                apiConfig: API_CONFIG,
+                kind: 'template',
+                entityId: '1',
+            })
+        );
+
+        await waitFor(() => expect(result.current.loadStatus).toBe('ready'));
+
+        act(() => {
+            result.current.setBlocks([
+                { name: 'core/paragraph', attributes: { content: 'New text' } },
+            ]);
+        });
+
+        expect(result.current.isDirty).toBe(true);
+    });
+
+    it('resets dirty state after a successful save', async () => {
+        FETCH_MOCK.mockResolvedValue(makeTemplate());
+        UPDATE_MOCK.mockImplementation(async (_config, _kind, _id, payload) =>
+            makeTemplate({ content: payload.content })
+        );
+
+        const { result } = renderHook(() =>
+            useEntityEditor({
+                apiConfig: API_CONFIG,
+                kind: 'template',
+                entityId: '1',
+            })
+        );
+
+        await waitFor(() => expect(result.current.loadStatus).toBe('ready'));
+
+        act(() => {
+            result.current.setBlocks([
+                { name: 'core/heading', attributes: { content: 'Hi' } },
+            ]);
+        });
+
+        expect(result.current.isDirty).toBe(true);
+
+        await act(async () => {
+            await result.current.save();
+        });
+
+        expect(UPDATE_MOCK).toHaveBeenCalledTimes(1);
+        expect(result.current.saveStatus).toBe('saved');
+        expect(result.current.isDirty).toBe(false);
+    });
+
+    it('surfaces validation errors on 422', async () => {
+        FETCH_MOCK.mockResolvedValue(makeTemplate());
+
+        const { SiteEditorApiError } = await vi.importActual<
+            typeof import('../api-client')
+        >('../api-client');
+
+        UPDATE_MOCK.mockRejectedValueOnce(
+            new SiteEditorApiError('Invalid.', 422, {
+                message: 'Invalid.',
+                errors: { slug: ['Slug required.'] },
+            })
+        );
+
+        const { result } = renderHook(() =>
+            useEntityEditor({
+                apiConfig: API_CONFIG,
+                kind: 'template',
+                entityId: '1',
+            })
+        );
+
+        await waitFor(() => expect(result.current.loadStatus).toBe('ready'));
+
+        await act(async () => {
+            await result.current.save();
+        });
+
+        expect(result.current.saveStatus).toBe('error');
+        expect(result.current.validationErrors?.slug?.[0]).toBe('Slug required.');
+    });
+
+    it('switches to idle state when entityId becomes null', async () => {
+        FETCH_MOCK.mockResolvedValue(makeTemplate());
+
+        const { result, rerender } = renderHook(
+            ({ id }: { id: string | null }) =>
+                useEntityEditor({
+                    apiConfig: API_CONFIG,
+                    kind: 'template',
+                    entityId: id,
+                }),
+            { initialProps: { id: '1' } as { id: string | null } }
+        );
+
+        await waitFor(() => expect(result.current.loadStatus).toBe('ready'));
+
+        rerender({ id: null });
+
+        expect(result.current.loadStatus).toBe('idle');
+        expect(result.current.entity).toBeNull();
+        expect(result.current.blocks).toHaveLength(0);
+    });
+});

--- a/resources/js/visual-editor/site-editor/__tests__/use-entity-editor.test.tsx
+++ b/resources/js/visual-editor/site-editor/__tests__/use-entity-editor.test.tsx
@@ -237,6 +237,51 @@ describe('useEntityEditor', () => {
         expect(result.current.saveStatus).not.toBe('saved');
     });
 
+    it('ignores a save response that resolves after the editor was closed', async () => {
+        FETCH_MOCK.mockResolvedValue(makeTemplate());
+
+        let releaseUpdate: (value: Record<string, unknown>) => void = () => {};
+        UPDATE_MOCK.mockImplementationOnce(
+            () =>
+                new Promise<Record<string, unknown>>((resolve) => {
+                    releaseUpdate = resolve;
+                })
+        );
+
+        const { result, rerender } = renderHook(
+            ({ id }: { id: string | null }) =>
+                useEntityEditor({
+                    apiConfig: API_CONFIG,
+                    kind: 'template',
+                    entityId: id,
+                }),
+            { initialProps: { id: '1' } as { id: string | null } }
+        );
+
+        await waitFor(() => expect(result.current.loadStatus).toBe('ready'));
+
+        let savePromise: Promise<unknown> = Promise.resolve();
+        act(() => {
+            savePromise = result.current.save();
+        });
+
+        rerender({ id: null });
+
+        expect(result.current.entity).toBeNull();
+        expect(result.current.loadStatus).toBe('idle');
+
+        await act(async () => {
+            releaseUpdate(makeTemplate({ slug: 'should-not-appear' }));
+            await savePromise;
+        });
+
+        // Closing while a save was in-flight should leave the editor
+        // idle — the late response can't re-populate the cleared state.
+        expect(result.current.entity).toBeNull();
+        expect(result.current.loadStatus).toBe('idle');
+        expect(result.current.saveStatus).not.toBe('saved');
+    });
+
     it('switches to idle state when entityId becomes null', async () => {
         FETCH_MOCK.mockResolvedValue(makeTemplate());
 

--- a/resources/js/visual-editor/site-editor/__tests__/use-entity-editor.test.tsx
+++ b/resources/js/visual-editor/site-editor/__tests__/use-entity-editor.test.tsx
@@ -237,6 +237,115 @@ describe('useEntityEditor', () => {
         expect(result.current.saveStatus).not.toBe('saved');
     });
 
+    it('preserves in-flight edits when a save response arrives after the user kept typing', async () => {
+        FETCH_MOCK.mockResolvedValue(
+            makeTemplate({ title: { rendered: 'Original' } })
+        );
+
+        let releaseUpdate: (value: Record<string, unknown>) => void = () => {};
+        UPDATE_MOCK.mockImplementationOnce(
+            () =>
+                new Promise<Record<string, unknown>>((resolve) => {
+                    releaseUpdate = resolve;
+                })
+        );
+
+        const { result } = renderHook(() =>
+            useEntityEditor({
+                apiConfig: API_CONFIG,
+                kind: 'template',
+                entityId: '1',
+            })
+        );
+
+        await waitFor(() => expect(result.current.loadStatus).toBe('ready'));
+
+        act(() => {
+            result.current.patch({ title: 'Saved snapshot' });
+        });
+
+        let savePromise: Promise<unknown> = Promise.resolve();
+        act(() => {
+            savePromise = result.current.save();
+        });
+
+        // User keeps typing while the PUT is still in-flight.
+        act(() => {
+            result.current.patch({ title: 'Newer edit' });
+        });
+
+        await act(async () => {
+            releaseUpdate(
+                makeTemplate({ title: { rendered: 'Saved snapshot' } })
+            );
+            await savePromise;
+        });
+
+        // Save confirmed (status + timestamp advance) but the user's
+        // post-save edit survives and the dirty flag stays up so they
+        // know there's still pending state to push.
+        expect(result.current.saveStatus).toBe('saved');
+        expect(result.current.lastSavedAt).not.toBeNull();
+        expect(result.current.entity?.title.rendered).toBe('Newer edit');
+        expect(result.current.isDirty).toBe(true);
+    });
+
+    it('clears entity A save metadata when switching to entity B', async () => {
+        FETCH_MOCK.mockImplementation(async (_config, _kind, id) =>
+            makeTemplate({ id: Number(id), slug: `slug-${id}` })
+        );
+        UPDATE_MOCK.mockImplementation(async (_config, _kind, id) =>
+            makeTemplate({ id: Number(id), slug: `slug-${id}` })
+        );
+
+        const { result, rerender } = renderHook(
+            ({ id }: { id: string }) =>
+                useEntityEditor({
+                    apiConfig: API_CONFIG,
+                    kind: 'template',
+                    entityId: id,
+                }),
+            { initialProps: { id: '1' } }
+        );
+
+        await waitFor(() => expect(result.current.loadStatus).toBe('ready'));
+
+        await act(async () => {
+            await result.current.save();
+        });
+
+        expect(result.current.saveStatus).toBe('saved');
+        expect(result.current.lastSavedAt).not.toBeNull();
+
+        // Hold entity 2's fetch open so we can observe the in-between
+        // "loading B" window and confirm A's save metadata isn't bleeding
+        // into it.
+        let releaseFetch: (value: Record<string, unknown>) => void = () => {};
+        FETCH_MOCK.mockImplementationOnce(
+            () =>
+                new Promise<Record<string, unknown>>((resolve) => {
+                    releaseFetch = resolve;
+                })
+        );
+
+        rerender({ id: '2' });
+
+        expect(result.current.loadStatus).toBe('loading');
+        expect(result.current.saveStatus).toBe('idle');
+        expect(result.current.lastSavedAt).toBeNull();
+        expect(result.current.saveErrorMessage).toBeNull();
+        expect(result.current.validationErrors).toBeNull();
+        expect(result.current.isDirty).toBe(false);
+        expect(result.current.entity).toBeNull();
+
+        await act(async () => {
+            releaseFetch(makeTemplate({ id: 2, slug: 'slug-2' }));
+        });
+
+        await waitFor(() => expect(result.current.loadStatus).toBe('ready'));
+        expect(result.current.entity?.slug).toBe('slug-2');
+    });
+
     it('drops a concurrent save response that resolves after a newer save started', async () => {
         FETCH_MOCK.mockResolvedValue(makeTemplate());
 

--- a/resources/js/visual-editor/site-editor/api-client.ts
+++ b/resources/js/visual-editor/site-editor/api-client.ts
@@ -1,0 +1,384 @@
+/**
+ * Site-editor REST client for template and template-part entities.
+ *
+ * The site-editor talks to the C1/C2 REST surface exposed by the package
+ * under `/visual-editor/api/templates` and `/visual-editor/api/template-parts`.
+ * This client wraps the five endpoints per entity behind typed helpers so
+ * D2's browsers and editors don't have to reconstruct URLs, CSRF handling,
+ * or error shapes ad hoc.
+ *
+ * The client is intentionally separate from `editor/api-client.ts` (which
+ * targets the generic `/resources/{type}/{id}/content` surface used by
+ * posts and pages). Templates and parts have their own routes because the
+ * core-data shim expects the WordPress `wp_template` / `wp_template_part`
+ * record shape — not the `{ blocks }` envelope the post editor sends.
+ */
+
+export type EntityKind = 'template' | 'template-part';
+
+/**
+ * The common fields every list row / detail response carries. Kept loose
+ * because the two entity kinds share 80% of their shape — the `area` field
+ * on template parts and the `source`/`origin`/`description`/`status`
+ * fields on templates are the only divergences.
+ */
+export interface EntityTitle {
+    rendered: string;
+}
+
+export interface EntityContent {
+    raw: string;
+    blocks: readonly unknown[];
+}
+
+export interface TemplateRecord {
+    id: number;
+    slug: string;
+    title: EntityTitle;
+    description: string;
+    content: EntityContent;
+    status: string;
+    theme: string;
+    type: 'wp_template';
+    source: string;
+    origin: string | null;
+}
+
+export interface TemplatePartRecord {
+    id: number;
+    slug: string;
+    title: EntityTitle;
+    content: EntityContent;
+    area: string;
+    theme: string;
+    type: 'wp_template_part';
+    /** Populated only on `show` responses. */
+    referenced_by?: readonly string[];
+}
+
+export type EntityRecord<K extends EntityKind> = K extends 'template'
+    ? TemplateRecord
+    : TemplatePartRecord;
+
+export interface PaginatedResponse<T> {
+    data: readonly T[];
+    meta: {
+        current_page: number;
+        last_page: number;
+        per_page: number;
+        total: number;
+    };
+}
+
+export interface ListParams {
+    perPage?: number;
+    page?: number;
+    theme?: string;
+    slug?: string;
+    /** Templates only. */
+    status?: string;
+    /** Template parts only. */
+    area?: string;
+}
+
+export interface ValidationErrors {
+    [field: string]: readonly string[];
+}
+
+/**
+ * Typed error raised for every non-2xx response so callers can inline a
+ * validation summary (status 422 carries `{ errors: {...} }`) or a generic
+ * failure banner (other statuses).
+ */
+export class SiteEditorApiError extends Error {
+    public readonly status: number;
+
+    public readonly body: unknown;
+
+    public readonly validationErrors: ValidationErrors | null;
+
+    public constructor(message: string, status: number, body: unknown) {
+        super(message);
+        this.name = 'SiteEditorApiError';
+        this.status = status;
+        this.body = body;
+        this.validationErrors = extractValidationErrors(body);
+    }
+}
+
+export interface SiteEditorApiConfig {
+    /** Absolute base URL for the site-editor API (e.g. `/visual-editor/api`). */
+    apiBase: string;
+}
+
+const RESOURCE_PATH: Record<EntityKind, string> = {
+    template: 'templates',
+    'template-part': 'template-parts',
+};
+
+function buildUrl(
+    config: SiteEditorApiConfig,
+    kind: EntityKind,
+    idOrSuffix: string | number | null = null,
+    query: Record<string, string | number | undefined> = {}
+): string {
+    const base = config.apiBase.replace(/\/+$/, '');
+    let url = `${base}/${RESOURCE_PATH[kind]}`;
+
+    if (idOrSuffix !== null) {
+        url += `/${encodeURIComponent(String(idOrSuffix))}`;
+    }
+
+    const params = new URLSearchParams();
+
+    for (const [key, value] of Object.entries(query)) {
+        if (value === undefined || value === '') {
+            continue;
+        }
+
+        params.set(key, String(value));
+    }
+
+    const qs = params.toString();
+
+    return qs === '' ? url : `${url}?${qs}`;
+}
+
+function readCsrfToken(): string | null {
+    if (typeof document === 'undefined') {
+        return null;
+    }
+
+    const meta = document.querySelector<HTMLMetaElement>(
+        'meta[name="csrf-token"]'
+    );
+
+    return meta?.content?.trim() || null;
+}
+
+async function parseBody(response: Response): Promise<unknown> {
+    const text = await response.text();
+
+    if (text === '') {
+        return null;
+    }
+
+    try {
+        return JSON.parse(text);
+    } catch {
+        return text;
+    }
+}
+
+function extractValidationErrors(body: unknown): ValidationErrors | null {
+    if (
+        body === null ||
+        typeof body !== 'object' ||
+        !('errors' in body) ||
+        typeof (body as { errors: unknown }).errors !== 'object' ||
+        (body as { errors: unknown }).errors === null
+    ) {
+        return null;
+    }
+
+    const raw = (body as { errors: Record<string, unknown> }).errors;
+    const result: ValidationErrors = {};
+
+    for (const [field, value] of Object.entries(raw)) {
+        if (Array.isArray(value)) {
+            result[field] = value
+                .filter((entry): entry is string => typeof entry === 'string');
+        }
+    }
+
+    return result;
+}
+
+async function requireOk(response: Response): Promise<unknown> {
+    const body = await parseBody(response);
+
+    if (!response.ok) {
+        const baseMessage = `Site-editor request failed with status ${response.status}`;
+        const message =
+            body !== null &&
+            typeof body === 'object' &&
+            'message' in body &&
+            typeof (body as { message: unknown }).message === 'string'
+                ? ((body as { message: string }).message || baseMessage)
+                : baseMessage;
+
+        throw new SiteEditorApiError(message, response.status, body);
+    }
+
+    return body;
+}
+
+function normalizeError(error: unknown, fallbackMessage: string): SiteEditorApiError {
+    if (error instanceof SiteEditorApiError) {
+        return error;
+    }
+
+    const message =
+        error instanceof Error && error.message ? error.message : fallbackMessage;
+
+    return new SiteEditorApiError(message, 0, error);
+}
+
+function mutatingHeaders(): Record<string, string> {
+    const headers: Record<string, string> = {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        'X-Requested-With': 'XMLHttpRequest',
+    };
+
+    const csrf = readCsrfToken();
+
+    if (csrf) {
+        headers['X-CSRF-TOKEN'] = csrf;
+    }
+
+    return headers;
+}
+
+const READ_HEADERS: Readonly<Record<string, string>> = {
+    Accept: 'application/json',
+    'X-Requested-With': 'XMLHttpRequest',
+};
+
+export async function listEntities<K extends EntityKind>(
+    config: SiteEditorApiConfig,
+    kind: K,
+    params: ListParams = {}
+): Promise<PaginatedResponse<EntityRecord<K>>> {
+    try {
+        const response = await fetch(
+            buildUrl(config, kind, null, {
+                per_page: params.perPage,
+                page: params.page,
+                theme: params.theme,
+                slug: params.slug,
+                status: params.status,
+                area: params.area,
+            }),
+            {
+                method: 'GET',
+                credentials: 'same-origin',
+                headers: READ_HEADERS,
+            }
+        );
+
+        return (await requireOk(response)) as PaginatedResponse<EntityRecord<K>>;
+    } catch (error: unknown) {
+        throw normalizeError(error, `Failed to load ${kind} list.`);
+    }
+}
+
+export async function fetchEntity<K extends EntityKind>(
+    config: SiteEditorApiConfig,
+    kind: K,
+    id: number | string
+): Promise<EntityRecord<K>> {
+    try {
+        const response = await fetch(buildUrl(config, kind, id), {
+            method: 'GET',
+            credentials: 'same-origin',
+            headers: READ_HEADERS,
+        });
+
+        return (await requireOk(response)) as EntityRecord<K>;
+    } catch (error: unknown) {
+        throw normalizeError(error, `Failed to load ${kind}.`);
+    }
+}
+
+export interface TemplateCreatePayload {
+    slug: string;
+    title?: string;
+    description?: string | null;
+    theme: string;
+    status?: string;
+    source?: string;
+    origin?: string | null;
+    content?: EntityContent;
+}
+
+export interface TemplatePartCreatePayload {
+    slug: string;
+    title?: string;
+    area: string;
+    theme: string;
+    content?: EntityContent;
+}
+
+export type CreatePayload<K extends EntityKind> = K extends 'template'
+    ? TemplateCreatePayload
+    : TemplatePartCreatePayload;
+
+export async function createEntity<K extends EntityKind>(
+    config: SiteEditorApiConfig,
+    kind: K,
+    payload: CreatePayload<K>
+): Promise<EntityRecord<K>> {
+    try {
+        const response = await fetch(buildUrl(config, kind), {
+            method: 'POST',
+            credentials: 'same-origin',
+            headers: mutatingHeaders(),
+            body: JSON.stringify(payload),
+        });
+
+        return (await requireOk(response)) as EntityRecord<K>;
+    } catch (error: unknown) {
+        throw normalizeError(error, `Failed to create ${kind}.`);
+    }
+}
+
+export interface UpdatePayload {
+    content?: EntityContent;
+    title?: string;
+    slug?: string;
+    description?: string | null;
+    status?: string;
+    source?: string;
+    origin?: string | null;
+    area?: string;
+    theme?: string;
+}
+
+export async function updateEntity<K extends EntityKind>(
+    config: SiteEditorApiConfig,
+    kind: K,
+    id: number | string,
+    payload: UpdatePayload
+): Promise<EntityRecord<K>> {
+    try {
+        const response = await fetch(buildUrl(config, kind, id), {
+            method: 'PUT',
+            credentials: 'same-origin',
+            headers: mutatingHeaders(),
+            body: JSON.stringify(payload),
+        });
+
+        return (await requireOk(response)) as EntityRecord<K>;
+    } catch (error: unknown) {
+        throw normalizeError(error, `Failed to save ${kind}.`);
+    }
+}
+
+export async function deleteEntity(
+    config: SiteEditorApiConfig,
+    kind: EntityKind,
+    id: number | string
+): Promise<void> {
+    try {
+        const response = await fetch(buildUrl(config, kind, id), {
+            method: 'DELETE',
+            credentials: 'same-origin',
+            headers: mutatingHeaders(),
+        });
+
+        await requireOk(response);
+    } catch (error: unknown) {
+        throw normalizeError(error, `Failed to delete ${kind}.`);
+    }
+}

--- a/resources/js/visual-editor/site-editor/create-entity-dialog.css
+++ b/resources/js/visual-editor/site-editor/create-entity-dialog.css
@@ -1,0 +1,196 @@
+.ap-site-editor__dialog-scrim {
+    position: fixed;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.45);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+    padding: 16px;
+}
+
+.ap-site-editor__dialog {
+    background: #fff;
+    border-radius: 8px;
+    max-width: 520px;
+    width: 100%;
+    max-height: calc(100vh - 32px);
+    display: flex;
+    flex-direction: column;
+    box-shadow: 0 20px 60px rgba(15, 23, 42, 0.25);
+}
+
+.ap-site-editor__dialog-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 16px 20px;
+    border-bottom: 1px solid var(--ap-site-editor-border, #e5e7eb);
+}
+
+.ap-site-editor__dialog-title {
+    margin: 0;
+    font-size: 16px;
+    font-weight: 600;
+}
+
+.ap-site-editor__dialog-close {
+    appearance: none;
+    background: transparent;
+    border: 0;
+    font-size: 20px;
+    line-height: 1;
+    cursor: pointer;
+    color: inherit;
+    padding: 4px 8px;
+}
+
+.ap-site-editor__dialog-form {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
+}
+
+.ap-site-editor__dialog-body {
+    padding: 16px 20px;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.ap-site-editor__dialog-footer {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    padding: 12px 20px;
+    border-top: 1px solid var(--ap-site-editor-border, #e5e7eb);
+}
+
+.ap-site-editor__dialog-cancel,
+.ap-site-editor__dialog-submit {
+    appearance: none;
+    border-radius: 4px;
+    padding: 6px 14px;
+    font-size: 13px;
+    font-weight: 600;
+    cursor: pointer;
+    border: 1px solid transparent;
+}
+
+.ap-site-editor__dialog-cancel {
+    background: transparent;
+    border-color: var(--ap-site-editor-border, #d1d5db);
+    color: inherit;
+}
+
+.ap-site-editor__dialog-submit {
+    background: var(--ap-site-editor-accent, #1d4ed8);
+    color: #fff;
+}
+
+.ap-site-editor__dialog-submit:disabled,
+.ap-site-editor__dialog-cancel:disabled {
+    opacity: 0.55;
+    cursor: not-allowed;
+}
+
+.ap-site-editor__dialog-error {
+    background: var(--ap-site-editor-error-bg, #fef2f2);
+    border: 1px solid var(--ap-site-editor-error-border, #fecaca);
+    color: var(--ap-site-editor-error-fg, #991b1b);
+    padding: 8px 10px;
+    border-radius: 4px;
+    margin: 0;
+    font-size: 13px;
+}
+
+.ap-site-editor__dialog-field {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.ap-site-editor__dialog-label {
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--ap-site-editor-muted, #4b5563);
+    line-height: 1;
+}
+
+.ap-site-editor__dialog-input,
+.ap-site-editor__dialog-select,
+.ap-site-editor__dialog-textarea {
+    font: inherit;
+    font-size: 13px;
+    line-height: 1.4;
+    padding: 8px 10px;
+    border: 1px solid var(--ap-site-editor-border, #d1d5db);
+    border-radius: 4px;
+    background: #fff;
+    color: inherit;
+}
+
+/* Native <select> runs through the browser's widget renderer, which
+   overrides `padding` in ways even `!important` can't beat on most
+   platforms. `appearance: none` strips the renderer so CSS takes
+   full control — at the cost of the browser's default chevron, which
+   we redraw via the inline-SVG background below. */
+.ap-site-editor__dialog-select {
+    appearance: none;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    padding: 10px 32px 10px 10px;
+    min-height: 38px;
+    background-color: #fff;
+    background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 8'><path fill='none' stroke='%234b5563' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round' d='M1 1.5l5 5 5-5'/></svg>");
+    background-repeat: no-repeat;
+    background-position: right 12px center;
+    background-size: 12px 8px;
+    cursor: pointer;
+}
+
+.ap-site-editor__dialog-select::-ms-expand {
+    display: none;
+}
+
+.ap-site-editor__dialog-input:focus,
+.ap-site-editor__dialog-select:focus,
+.ap-site-editor__dialog-textarea:focus {
+    outline: 2px solid var(--ap-site-editor-accent, #1d4ed8);
+    outline-offset: -1px;
+    border-color: transparent;
+}
+
+.ap-site-editor__dialog-field-help {
+    font-size: 12px;
+    color: var(--ap-site-editor-muted, #6b7280);
+    margin: 0;
+}
+
+.ap-site-editor__dialog-field-error {
+    font-size: 12px;
+    color: var(--ap-site-editor-error-fg, #991b1b);
+    margin: 0;
+}
+
+.ap-site-editor__fallback-chain {
+    display: flex;
+    gap: 6px;
+    flex-wrap: wrap;
+    font-size: 12px;
+    color: var(--ap-site-editor-muted, #4b5563);
+}
+
+.ap-site-editor__fallback-chain-item {
+    padding: 2px 6px;
+    background: var(--ap-site-editor-chip-active, #eef2ff);
+    border-radius: 4px;
+}
+
+.ap-site-editor__fallback-chain-sep {
+    align-self: center;
+}

--- a/resources/js/visual-editor/site-editor/create-entity-dialog.tsx
+++ b/resources/js/visual-editor/site-editor/create-entity-dialog.tsx
@@ -1,0 +1,255 @@
+/**
+ * Create-new dialog for templates and template parts.
+ *
+ * Implements the D0 §3.4 / §3.5 create-new flow: for templates, a slug
+ * picker gated by the fallback chain (P7 — fallback chains are visible
+ * to users); for parts, an area selector. Same dialog shell either way —
+ * the caller supplies kind-specific fields via the `fields` prop.
+ *
+ * Focus-traps inside the dialog while open per WAI-ARIA dialog pattern:
+ *   - Esc closes.
+ *   - Initial focus goes to the first interactive control.
+ *   - Tab/Shift+Tab wrap within the dialog.
+ */
+
+import { __ } from '@wordpress/i18n';
+import {
+    useCallback,
+    useEffect,
+    useId,
+    useRef,
+    useState,
+    type FormEvent,
+    type KeyboardEvent as ReactKeyboardEvent,
+    type ReactNode,
+} from 'react';
+
+import { TEXT_DOMAIN } from '../vendor/i18n';
+
+import {
+    createEntity,
+    SiteEditorApiError,
+    type CreatePayload,
+    type EntityKind,
+    type EntityRecord,
+    type SiteEditorApiConfig,
+    type ValidationErrors,
+} from './api-client';
+
+import './create-entity-dialog.css';
+
+export interface CreateEntityDialogProps<K extends EntityKind> {
+    apiConfig: SiteEditorApiConfig;
+    kind: K;
+    title: string;
+    /** Fields rendered between the title field and the footer actions. */
+    renderFields: (api: {
+        validationErrors: ValidationErrors | null;
+    }) => ReactNode;
+    /**
+     * Builds the create payload from the dialog form state. Called at
+     * submit time. Returning `null` blocks submission (e.g. the caller
+     * surfaces its own validation error to the user).
+     */
+    buildPayload: () => CreatePayload<K> | null;
+    onClose: () => void;
+    onCreated: (entity: EntityRecord<K>) => void;
+}
+
+function makeFocusables(container: HTMLElement): HTMLElement[] {
+    return Array.from(
+        container.querySelectorAll<HTMLElement>(
+            'button,[href],input,select,textarea,[tabindex]:not([tabindex="-1"])'
+        )
+    ).filter((element) => !element.hasAttribute('disabled'));
+}
+
+export function CreateEntityDialog<K extends EntityKind>(
+    props: CreateEntityDialogProps<K>
+): JSX.Element {
+    const { apiConfig, kind, title, renderFields, buildPayload, onClose, onCreated } =
+        props;
+
+    const dialogRef = useRef<HTMLDivElement | null>(null);
+    const previousFocusRef = useRef<HTMLElement | null>(null);
+    const titleId = useId();
+
+    const [submitting, setSubmitting] = useState(false);
+    const [submitError, setSubmitError] = useState<string | null>(null);
+    const [validationErrors, setValidationErrors] = useState<ValidationErrors | null>(
+        null
+    );
+
+    useEffect(() => {
+        if (typeof document === 'undefined') {
+            return;
+        }
+
+        previousFocusRef.current =
+            document.activeElement instanceof HTMLElement
+                ? document.activeElement
+                : null;
+
+        const dialog = dialogRef.current;
+
+        if (dialog !== null) {
+            const focusables = makeFocusables(dialog);
+            focusables[0]?.focus();
+        }
+
+        return () => {
+            previousFocusRef.current?.focus();
+        };
+    }, []);
+
+    const handleKeyDown = useCallback(
+        (event: ReactKeyboardEvent<HTMLDivElement>): void => {
+            if (event.key === 'Escape') {
+                event.preventDefault();
+                onClose();
+                return;
+            }
+
+            if (event.key !== 'Tab') {
+                return;
+            }
+
+            const dialog = dialogRef.current;
+
+            if (dialog === null) {
+                return;
+            }
+
+            const focusables = makeFocusables(dialog);
+
+            if (focusables.length === 0) {
+                return;
+            }
+
+            const first = focusables[0];
+            const last = focusables[focusables.length - 1];
+
+            if (first === undefined || last === undefined) {
+                return;
+            }
+
+            if (event.shiftKey && document.activeElement === first) {
+                event.preventDefault();
+                last.focus();
+            } else if (!event.shiftKey && document.activeElement === last) {
+                event.preventDefault();
+                first.focus();
+            }
+        },
+        [onClose]
+    );
+
+    const handleSubmit = useCallback(
+        async (event: FormEvent<HTMLFormElement>): Promise<void> => {
+            event.preventDefault();
+
+            if (submitting) {
+                return;
+            }
+
+            const payload = buildPayload();
+
+            if (payload === null) {
+                return;
+            }
+
+            setSubmitting(true);
+            setSubmitError(null);
+            setValidationErrors(null);
+
+            try {
+                const entity = await createEntity(apiConfig, kind, payload);
+
+                onCreated(entity);
+            } catch (error: unknown) {
+                if (error instanceof SiteEditorApiError) {
+                    setSubmitError(error.message);
+                    setValidationErrors(error.validationErrors);
+                } else {
+                    setSubmitError(__('Failed to create.', TEXT_DOMAIN));
+                }
+            } finally {
+                setSubmitting(false);
+            }
+        },
+        [apiConfig, buildPayload, kind, onCreated, submitting]
+    );
+
+    return (
+        <div
+            className="ap-site-editor__dialog-scrim"
+            data-testid={`ap-site-editor-create-dialog-${kind}`}
+            onClick={(event) => {
+                if (event.target === event.currentTarget) {
+                    onClose();
+                }
+            }}
+        >
+            <div
+                ref={dialogRef}
+                className="ap-site-editor__dialog"
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby={titleId}
+                onKeyDown={handleKeyDown}
+            >
+                <header className="ap-site-editor__dialog-header">
+                    <h2 id={titleId} className="ap-site-editor__dialog-title">
+                        {title}
+                    </h2>
+                    <button
+                        type="button"
+                        className="ap-site-editor__dialog-close"
+                        aria-label={__('Close dialog', TEXT_DOMAIN)}
+                        onClick={onClose}
+                        data-testid={`ap-site-editor-create-dialog-close-${kind}`}
+                    >
+                        {'×'}
+                    </button>
+                </header>
+                <form
+                    className="ap-site-editor__dialog-form"
+                    onSubmit={(event) => void handleSubmit(event)}
+                >
+                    <div className="ap-site-editor__dialog-body">
+                        {renderFields({ validationErrors })}
+                        {submitError !== null ? (
+                            <p
+                                className="ap-site-editor__dialog-error"
+                                role="alert"
+                                data-testid={`ap-site-editor-create-dialog-error-${kind}`}
+                            >
+                                {submitError}
+                            </p>
+                        ) : null}
+                    </div>
+                    <footer className="ap-site-editor__dialog-footer">
+                        <button
+                            type="button"
+                            className="ap-site-editor__dialog-cancel"
+                            onClick={onClose}
+                            disabled={submitting}
+                        >
+                            {__('Cancel', TEXT_DOMAIN)}
+                        </button>
+                        <button
+                            type="submit"
+                            className="ap-site-editor__dialog-submit"
+                            disabled={submitting}
+                            data-testid={`ap-site-editor-create-dialog-submit-${kind}`}
+                        >
+                            {submitting
+                                ? __('Creating…', TEXT_DOMAIN)
+                                : __('Create', TEXT_DOMAIN)}
+                        </button>
+                    </footer>
+                </form>
+            </div>
+        </div>
+    );
+}

--- a/resources/js/visual-editor/site-editor/entity-browser.css
+++ b/resources/js/visual-editor/site-editor/entity-browser.css
@@ -1,0 +1,174 @@
+.ap-site-editor__entity-browser {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 8px 0 0;
+}
+
+.ap-site-editor__entity-browser-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    padding: 0 12px;
+}
+
+.ap-site-editor__entity-browser-title {
+    font-size: 13px;
+    font-weight: 600;
+    margin: 0;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--ap-site-editor-muted, #666);
+}
+
+.ap-site-editor__entity-browser-create {
+    appearance: none;
+    background: var(--ap-site-editor-accent, #1d4ed8);
+    color: #fff;
+    border: 0;
+    border-radius: 4px;
+    padding: 4px 10px;
+    font-size: 12px;
+    font-weight: 600;
+    cursor: pointer;
+}
+
+.ap-site-editor__entity-browser-create:hover {
+    background: var(--ap-site-editor-accent-hover, #1e40af);
+}
+
+.ap-site-editor__entity-browser-create:focus-visible {
+    background: var(--ap-site-editor-accent-hover, #1e40af);
+    outline: 2px solid var(--ap-site-editor-accent, #1d4ed8);
+    outline-offset: 2px;
+}
+
+.ap-site-editor__entity-browser-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    padding: 0 12px;
+}
+
+.ap-site-editor__entity-browser-chip {
+    appearance: none;
+    background: transparent;
+    border: 1px solid var(--ap-site-editor-border, #d1d5db);
+    border-radius: 999px;
+    padding: 2px 10px;
+    font-size: 12px;
+    cursor: pointer;
+    color: inherit;
+}
+
+.ap-site-editor__entity-browser-chip[aria-pressed='true'] {
+    background: var(--ap-site-editor-chip-active, #dbeafe);
+    border-color: var(--ap-site-editor-accent, #1d4ed8);
+    color: var(--ap-site-editor-accent, #1d4ed8);
+}
+
+.ap-site-editor__entity-browser-chip:focus-visible {
+    outline: 2px solid var(--ap-site-editor-accent, #1d4ed8);
+    outline-offset: 2px;
+}
+
+.ap-site-editor__entity-browser-status,
+.ap-site-editor__entity-browser-error,
+.ap-site-editor__entity-browser-empty {
+    padding: 8px 12px;
+    font-size: 13px;
+    color: var(--ap-site-editor-muted, #666);
+    margin: 0;
+}
+
+.ap-site-editor__entity-browser-error {
+    background: var(--ap-site-editor-error-bg, #fef2f2);
+    border-top: 1px solid var(--ap-site-editor-error-border, #fecaca);
+    border-bottom: 1px solid var(--ap-site-editor-error-border, #fecaca);
+    color: var(--ap-site-editor-error-fg, #991b1b);
+}
+
+.ap-site-editor__entity-browser-retry {
+    margin-top: 4px;
+    appearance: none;
+    background: transparent;
+    border: 1px solid currentColor;
+    border-radius: 4px;
+    padding: 2px 8px;
+    cursor: pointer;
+    color: inherit;
+    font-size: 12px;
+}
+
+.ap-site-editor__entity-browser-retry:focus-visible {
+    outline: 2px solid currentColor;
+    outline-offset: 2px;
+}
+
+.ap-site-editor__entity-browser-empty-title {
+    font-weight: 600;
+    color: inherit;
+    margin: 0 0 4px;
+}
+
+.ap-site-editor__entity-browser-empty-body {
+    margin: 0;
+    font-size: 12px;
+}
+
+.ap-site-editor__entity-browser-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+}
+
+.ap-site-editor__entity-browser-item {
+    margin: 0;
+}
+
+.ap-site-editor__entity-browser-row {
+    appearance: none;
+    background: transparent;
+    border: 0;
+    width: 100%;
+    text-align: left;
+    padding: 8px 12px;
+    cursor: pointer;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    color: inherit;
+    font: inherit;
+    border-left: 2px solid transparent;
+}
+
+.ap-site-editor__entity-browser-row:hover {
+    background: var(--ap-site-editor-row-hover, #f3f4f6);
+}
+
+.ap-site-editor__entity-browser-row:focus-visible {
+    outline: 2px solid var(--ap-site-editor-accent, #1d4ed8);
+    outline-offset: -2px;
+}
+
+.ap-site-editor__entity-browser-row[data-active='true'] {
+    background: var(--ap-site-editor-row-active, #eff6ff);
+    border-left-color: var(--ap-site-editor-accent, #1d4ed8);
+}
+
+.ap-site-editor__entity-browser-row-title {
+    font-weight: 600;
+    font-size: 13px;
+}
+
+.ap-site-editor__entity-browser-row-meta {
+    font-size: 11px;
+    color: var(--ap-site-editor-muted, #666);
+    display: flex;
+    gap: 6px;
+    align-items: center;
+    flex-wrap: wrap;
+}

--- a/resources/js/visual-editor/site-editor/entity-browser.css
+++ b/resources/js/visual-editor/site-editor/entity-browser.css
@@ -93,7 +93,7 @@
     margin-top: 4px;
     appearance: none;
     background: transparent;
-    border: 1px solid currentColor;
+    border: 1px solid currentcolor;
     border-radius: 4px;
     padding: 2px 8px;
     cursor: pointer;
@@ -102,7 +102,7 @@
 }
 
 .ap-site-editor__entity-browser-retry:focus-visible {
-    outline: 2px solid currentColor;
+    outline: 2px solid currentcolor;
     outline-offset: 2px;
 }
 

--- a/resources/js/visual-editor/site-editor/entity-browser.tsx
+++ b/resources/js/visual-editor/site-editor/entity-browser.tsx
@@ -1,0 +1,326 @@
+/**
+ * Shared browser component for template + template-part sections.
+ *
+ * Mounted inside the navigator-outlet slot per D0 §3.4 / §3.5, this is
+ * the list surface users scan to pick an entity to open in the canvas.
+ * Templates and parts share 80% of the interaction model — filter chips,
+ * grouped list, row click opens-in-canvas, create-new button — so D2
+ * parameterises the component by `kind` + a pluggable chip set and row
+ * renderer rather than shipping two near-identical implementations.
+ *
+ * Deliberately list-only, no card grid: the issue's in-scope copy calls
+ * for the navigator sub-panel list as the entry surface; the card-grid
+ * canvas (D0 §3.4) is polish for post-V1 when thumbnails are available.
+ */
+
+import { __, sprintf } from '@wordpress/i18n';
+import {
+    useCallback,
+    useMemo,
+    useState,
+    type KeyboardEvent as ReactKeyboardEvent,
+    type ReactNode,
+} from 'react';
+
+import { TEXT_DOMAIN } from '../vendor/i18n';
+
+import {
+    type EntityKind,
+    type EntityRecord,
+    type SiteEditorApiConfig,
+} from './api-client';
+import { useEntityList } from './use-entity-list';
+
+import './entity-browser.css';
+
+export interface FilterChip {
+    id: string;
+    label: string;
+    /** Passed to the list endpoint as the relevant filter query param. */
+    filter?: { status?: string; area?: string; source?: string };
+}
+
+export interface EntityBrowserProps<K extends EntityKind> {
+    apiConfig: SiteEditorApiConfig;
+    kind: K;
+    /** Active entity id from the URL, or `null` in list mode. */
+    activeEntityId: string | null;
+    /** Opens an entity in the canvas. */
+    onOpen: (entityId: string) => void;
+    /** Opens the create-new dialog. */
+    onRequestCreate: () => void;
+    /** Optional filter chips (rendered above the list). */
+    chips?: readonly FilterChip[];
+    /** Label for the list region (screen readers). */
+    listLabel: string;
+    /** Empty-state heading. */
+    emptyTitle: string;
+    /** Empty-state body copy. */
+    emptyBody: string;
+    /** "Add new" button label. */
+    createLabel: string;
+    /** Label describing a single row for "open" aria context. */
+    openAriaLabel: (entity: EntityRecord<K>) => string;
+    /** Renders the row contents (title, meta, badges). */
+    renderRow: (entity: EntityRecord<K>) => ReactNode;
+    /**
+     * Force a re-fetch when the parent creates or deletes a record.
+     * Unused for in-browser filter changes — those already re-fetch via
+     * the chip handler.
+     */
+    refreshKey?: number;
+}
+
+const DEFAULT_PER_PAGE = 25;
+
+function extractTitle(entity: { title?: { rendered?: string }; slug?: string }): string {
+    const rendered = entity.title?.rendered?.trim();
+
+    if (rendered !== undefined && rendered !== '') {
+        return rendered;
+    }
+
+    return entity.slug ?? '';
+}
+
+export function EntityBrowser<K extends EntityKind>(
+    props: EntityBrowserProps<K>
+): JSX.Element {
+    const {
+        apiConfig,
+        kind,
+        activeEntityId,
+        onOpen,
+        onRequestCreate,
+        chips,
+        listLabel,
+        emptyTitle,
+        emptyBody,
+        createLabel,
+        openAriaLabel,
+        renderRow,
+        refreshKey,
+    } = props;
+
+    const [activeChipId, setActiveChipId] = useState<string | null>(
+        chips !== undefined && chips.length > 0 ? (chips[0]?.id ?? null) : null
+    );
+
+    const activeChip = useMemo(
+        () =>
+            chips !== undefined
+                ? (chips.find((chip) => chip.id === activeChipId) ?? null)
+                : null,
+        [activeChipId, chips]
+    );
+
+    const { items, status, errorMessage, refresh } = useEntityList({
+        apiConfig,
+        kind,
+        perPage: DEFAULT_PER_PAGE,
+        status: activeChip?.filter?.status,
+        area: activeChip?.filter?.area,
+        refreshKey,
+    });
+
+    // Keyboard navigation across the row buttons — Up/Down walks the
+    // list, Home/End jumps to the ends. Roving tabindex keeps keyboard
+    // users from tabbing through every row when they just want to scan.
+    const handleRowKeyDown = useCallback(
+        (event: ReactKeyboardEvent<HTMLElement>): void => {
+            const list = event.currentTarget.closest(
+                '[data-ap-site-editor-entity-list]'
+            );
+
+            if (list === null) {
+                return;
+            }
+
+            const buttons = Array.from(
+                list.querySelectorAll<HTMLButtonElement>(
+                    'button[data-ap-site-editor-entity-row]'
+                )
+            );
+
+            if (buttons.length === 0) {
+                return;
+            }
+
+            const activeElement = document.activeElement;
+            const activeButton =
+                activeElement instanceof HTMLButtonElement ? activeElement : null;
+            const currentIndex = activeButton === null ? -1 : buttons.indexOf(activeButton);
+
+            let nextIndex: number | null = null;
+
+            if (event.key === 'ArrowDown') {
+                nextIndex =
+                    currentIndex === -1 ? 0 : (currentIndex + 1) % buttons.length;
+            } else if (event.key === 'ArrowUp') {
+                nextIndex =
+                    currentIndex === -1
+                        ? buttons.length - 1
+                        : (currentIndex - 1 + buttons.length) % buttons.length;
+            } else if (event.key === 'Home') {
+                nextIndex = 0;
+            } else if (event.key === 'End') {
+                nextIndex = buttons.length - 1;
+            }
+
+            if (nextIndex === null) {
+                return;
+            }
+
+            event.preventDefault();
+            buttons[nextIndex]?.focus();
+        },
+        []
+    );
+
+    const isLoading = status === 'loading' || status === 'idle';
+    const isError = status === 'error';
+    const isEmpty = status === 'ready' && items.length === 0;
+
+    return (
+        <div
+            className="ap-site-editor__entity-browser"
+            data-testid={`ap-site-editor-entity-browser-${kind}`}
+        >
+            <div className="ap-site-editor__entity-browser-head">
+                <h3 className="ap-site-editor__entity-browser-title">{listLabel}</h3>
+                <button
+                    type="button"
+                    className="ap-site-editor__entity-browser-create"
+                    data-testid={`ap-site-editor-entity-browser-create-${kind}`}
+                    onClick={onRequestCreate}
+                >
+                    {createLabel}
+                </button>
+            </div>
+
+            {chips !== undefined && chips.length > 0 ? (
+                <div
+                    className="ap-site-editor__entity-browser-chips"
+                    role="group"
+                    aria-label={__('Filters', TEXT_DOMAIN)}
+                >
+                    {chips.map((chip) => {
+                        const isActive = chip.id === activeChipId;
+
+                        return (
+                            <button
+                                key={chip.id}
+                                type="button"
+                                className="ap-site-editor__entity-browser-chip"
+                                data-testid={`ap-site-editor-entity-browser-chip-${kind}-${chip.id}`}
+                                aria-pressed={isActive}
+                                onClick={() => setActiveChipId(chip.id)}
+                            >
+                                {chip.label}
+                            </button>
+                        );
+                    })}
+                </div>
+            ) : null}
+
+            {isLoading ? (
+                <p
+                    className="ap-site-editor__entity-browser-status"
+                    role="status"
+                    aria-live="polite"
+                    data-testid={`ap-site-editor-entity-browser-loading-${kind}`}
+                >
+                    {__('Loading…', TEXT_DOMAIN)}
+                </p>
+            ) : null}
+
+            {isError ? (
+                <div
+                    className="ap-site-editor__entity-browser-error"
+                    role="alert"
+                    data-testid={`ap-site-editor-entity-browser-error-${kind}`}
+                >
+                    <p>
+                        {errorMessage ??
+                            __('Failed to load the list.', TEXT_DOMAIN)}
+                    </p>
+                    <button
+                        type="button"
+                        className="ap-site-editor__entity-browser-retry"
+                        onClick={() => void refresh()}
+                    >
+                        {__('Retry', TEXT_DOMAIN)}
+                    </button>
+                </div>
+            ) : null}
+
+            {isEmpty ? (
+                <div
+                    className="ap-site-editor__entity-browser-empty"
+                    data-testid={`ap-site-editor-entity-browser-empty-${kind}`}
+                >
+                    <p className="ap-site-editor__entity-browser-empty-title">
+                        {emptyTitle}
+                    </p>
+                    <p className="ap-site-editor__entity-browser-empty-body">
+                        {emptyBody}
+                    </p>
+                </div>
+            ) : null}
+
+            {status === 'ready' && items.length > 0 ? (
+                <ul
+                    className="ap-site-editor__entity-browser-list"
+                    data-ap-site-editor-entity-list=""
+                    data-testid={`ap-site-editor-entity-browser-list-${kind}`}
+                    aria-label={listLabel}
+                >
+                    {items.map((entity, index) => {
+                        const entityId = String(entity.id);
+                        const isActive = activeEntityId === entityId;
+                        const hasActive = items.some(
+                            (candidate) => String(candidate.id) === activeEntityId
+                        );
+                        // Roving tabindex: one row must always be tab-reachable.
+                        // Prefer the active entity; fall back to the first row
+                        // when nothing is active so the list is reachable from
+                        // the keyboard out of the box.
+                        const isTabStop = hasActive ? isActive : index === 0;
+                        const title = extractTitle(entity);
+
+                        return (
+                            <li
+                                key={entityId}
+                                className="ap-site-editor__entity-browser-item"
+                            >
+                                <button
+                                    type="button"
+                                    className="ap-site-editor__entity-browser-row"
+                                    data-ap-site-editor-entity-row=""
+                                    data-active={isActive}
+                                    data-testid={`ap-site-editor-entity-browser-row-${kind}-${entityId}`}
+                                    aria-current={isActive ? 'true' : undefined}
+                                    aria-label={sprintf(
+                                        /* translators: %s: row description (e.g. "Open template: Single post"). */
+                                        __('Open %s', TEXT_DOMAIN),
+                                        openAriaLabel(entity)
+                                    )}
+                                    tabIndex={isTabStop ? 0 : -1}
+                                    onClick={() => onOpen(entityId)}
+                                    onKeyDown={handleRowKeyDown}
+                                >
+                                    <span className="ap-site-editor__entity-browser-row-title">
+                                        {title || entity.slug}
+                                    </span>
+                                    <span className="ap-site-editor__entity-browser-row-meta">
+                                        {renderRow(entity)}
+                                    </span>
+                                </button>
+                            </li>
+                        );
+                    })}
+                </ul>
+            ) : null}
+        </div>
+    );
+}

--- a/resources/js/visual-editor/site-editor/entity-browser.tsx
+++ b/resources/js/visual-editor/site-editor/entity-browser.tsx
@@ -16,6 +16,7 @@
 import { __, sprintf } from '@wordpress/i18n';
 import {
     useCallback,
+    useEffect,
     useMemo,
     useState,
     type KeyboardEvent as ReactKeyboardEvent,
@@ -114,7 +115,7 @@ export function EntityBrowser<K extends EntityKind>(
         [activeChipId, chips]
     );
 
-    const { items, status, errorMessage, refresh } = useEntityList({
+    const { items, status, errorMessage, refresh, setPage } = useEntityList({
         apiConfig,
         kind,
         perPage: DEFAULT_PER_PAGE,
@@ -122,6 +123,14 @@ export function EntityBrowser<K extends EntityKind>(
         area: activeChip?.filter?.area,
         refreshKey,
     });
+
+    // Reset to page 1 whenever the user picks a new filter chip so a
+    // short list doesn't inherit a deep-page cursor from the previous
+    // filter. Skips the mount-time run because `useEntityList` is
+    // already initialized at page 1.
+    useEffect(() => {
+        setPage(1);
+    }, [activeChipId, setPage]);
 
     // Keyboard navigation across the row buttons — Up/Down walks the
     // list, Home/End jumps to the ends. Roving tabindex keeps keyboard

--- a/resources/js/visual-editor/site-editor/entity-editor-canvas.css
+++ b/resources/js/visual-editor/site-editor/entity-editor-canvas.css
@@ -65,7 +65,7 @@
     padding: 0;
     margin: -1px;
     overflow: hidden;
-    clip: rect(0, 0, 0, 0);
+    clip-path: inset(50%);
     white-space: nowrap;
     border: 0;
 }
@@ -93,7 +93,7 @@
     width: 8px;
     height: 8px;
     border-radius: 50%;
-    background: currentColor;
+    background: currentcolor;
 }
 
 .ap-site-editor__save-indicator {

--- a/resources/js/visual-editor/site-editor/entity-editor-canvas.css
+++ b/resources/js/visual-editor/site-editor/entity-editor-canvas.css
@@ -1,0 +1,140 @@
+.ap-site-editor__entity-canvas {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    overflow: hidden;
+}
+
+.ap-site-editor__entity-canvas--loading,
+.ap-site-editor__entity-canvas--error {
+    padding: 24px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    font-size: 14px;
+    color: var(--ap-site-editor-muted, #4b5563);
+}
+
+.ap-site-editor__entity-canvas--error {
+    color: var(--ap-site-editor-error-fg, #991b1b);
+}
+
+.ap-site-editor__entity-canvas-header {
+    /* Matches the inspector tablist height (tab padding 12px top+bottom,
+       13px text ≈ 20px line, 2px underline + 1px tablist border = 47px)
+       so the horizontal divider between canvas and inspector runs in a
+       single line across the shell. */
+    min-height: 47px;
+    padding: 10px 20px;
+    border-bottom: 1px solid var(--ap-site-editor-border, #e5e7eb);
+    box-sizing: border-box;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+    font-size: 13px;
+}
+
+.ap-site-editor__entity-canvas-body {
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    overflow: auto;
+}
+
+.ap-site-editor__entity-canvas-surface {
+    flex: 1;
+    padding: 24px;
+    background: #fff;
+    min-height: 100%;
+}
+
+/* Clickable empty area: when a template has no blocks yet, the default
+   inserter placeholder is tiny — give the surface a visible min-height
+   so users have a target to click the appender. */
+.ap-site-editor__entity-canvas-surface .block-editor-block-list__layout {
+    min-height: 300px;
+}
+
+.ap-site-editor__sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+.ap-site-editor__fallback-chain-header {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 12px;
+    color: var(--ap-site-editor-muted, #4b5563);
+}
+
+.ap-site-editor__dirty-indicator {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 12px;
+    color: var(--ap-site-editor-accent, #1d4ed8);
+    font-weight: 600;
+}
+
+.ap-site-editor__dirty-indicator::before {
+    content: '';
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: currentColor;
+}
+
+.ap-site-editor__save-indicator {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 12px;
+    color: var(--ap-site-editor-success, #047857);
+    font-weight: 600;
+}
+
+.ap-site-editor__save-indicator::before {
+    content: '✓';
+    font-weight: 700;
+}
+
+.ap-site-editor__inspector-slug {
+    display: inline-block;
+    padding: 2px 6px;
+    background: var(--ap-site-editor-chip-active, #eef2ff);
+    border-radius: 4px;
+    font-size: 12px;
+}
+
+.ap-site-editor__inspector-refs {
+    list-style: disc;
+    padding-left: 20px;
+    margin: 0;
+    font-size: 13px;
+}
+
+.ap-site-editor__inspector-empty {
+    padding: 12px;
+    font-size: 13px;
+    color: var(--ap-site-editor-muted, #4b5563);
+    margin: 0;
+}
+
+.ap-site-editor__inspector-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    padding: 16px 20px;
+}

--- a/resources/js/visual-editor/site-editor/entity-editor-canvas.tsx
+++ b/resources/js/visual-editor/site-editor/entity-editor-canvas.tsx
@@ -1,0 +1,153 @@
+/**
+ * Entity-editing canvas for the site-editor.
+ *
+ * Renders the active entity's block tree inside a `BlockEditorProvider`
+ * + `BlockTools` / `WritingFlow` / `BlockList` stack so the user gets the
+ * same Gutenberg editor surface they'd see in the post editor. Mirrors
+ * the sandbox (`sandbox/sandbox-editor.tsx`) and post editor
+ * (`editor/editor-app.tsx`) composition rather than using `BlockCanvas`
+ * (iframe) — the site-editor shell renders directly into the main
+ * content area, so the iframe is unnecessary and added a frame jump
+ * when switching between list and edit views.
+ *
+ * Core blocks are registered on first mount via `ensureBlocksRegistered()`
+ * so deep-linking into a template or part lights up the block renderers
+ * before the block tree is walked. Registration is idempotent — we flip
+ * a module flag to avoid the "already registered" console noise when the
+ * shell hot-reloads during dev.
+ */
+
+import {
+    BlockEditorProvider,
+    BlockList,
+    BlockTools,
+    ObserveTyping,
+    WritingFlow,
+} from '@wordpress/block-editor';
+import { Popover, SlotFillProvider } from '@wordpress/components';
+// `@wordpress/format-library` is a side-effect import: it registers the
+// core rich-text formats (bold, italic, link, …) so the block toolbar's
+// inline formatting controls work inside RichText blocks.
+import '@wordpress/format-library';
+import { __, sprintf } from '@wordpress/i18n';
+import { useMemo, type ReactNode } from 'react';
+
+import { TEXT_DOMAIN } from '../vendor/i18n';
+
+import '@wordpress/components/build-style/style.css';
+import '@wordpress/block-editor/build-style/style.css';
+import '@wordpress/block-editor/build-style/content.css';
+import '@wordpress/block-library/build-style/style.css';
+import '@wordpress/block-library/build-style/editor.css';
+
+import './entity-editor-canvas.css';
+
+export interface EntityEditorCanvasProps {
+    /** Identifier for the active entity (used in a11y announcements). */
+    entityTitle: string;
+    /** Parsed block tree loaded from the REST response. */
+    blocks: readonly unknown[];
+    onChange: (blocks: readonly unknown[]) => void;
+    onInput: (blocks: readonly unknown[]) => void;
+    /**
+     * Renders any entity-scoped chrome above the canvas. D2 uses this to
+     * plug in the template fallback-chain breadcrumb and the dirty-state
+     * indicator the design brief calls out.
+     */
+    header?: ReactNode;
+    /** Optional status line rendered in place of the canvas while loading. */
+    isLoading?: boolean;
+    /** Optional error copy rendered in place of the canvas. */
+    errorMessage?: string | null;
+}
+
+/**
+ * Minimal block-editor settings — enough for the stock blocks to render
+ * without crashing on missing presets. D3 (global styles) wires the real
+ * palette / font sizes / layout defaults; for D2 the canvas needs to
+ * boot with the defaults most core blocks expect.
+ */
+const EDITOR_SETTINGS = {
+    alignWide: true,
+    hasFixedToolbar: false,
+};
+
+export function EntityEditorCanvas(props: EntityEditorCanvasProps): JSX.Element {
+    const { entityTitle, blocks, onChange, onInput, header, isLoading, errorMessage } =
+        props;
+
+    const announcement = useMemo(
+        () =>
+            sprintf(
+                /* translators: %s: entity title being edited. */
+                __('Editing %s', TEXT_DOMAIN),
+                entityTitle
+            ),
+        [entityTitle]
+    );
+
+    if (isLoading === true) {
+        return (
+            <div
+                className="ap-site-editor__entity-canvas ap-site-editor__entity-canvas--loading"
+                role="status"
+                aria-live="polite"
+                data-testid="ap-site-editor-entity-canvas-loading"
+            >
+                {__('Loading entity…', TEXT_DOMAIN)}
+            </div>
+        );
+    }
+
+    if (errorMessage !== null && errorMessage !== undefined) {
+        return (
+            <div
+                className="ap-site-editor__entity-canvas ap-site-editor__entity-canvas--error"
+                role="alert"
+                data-testid="ap-site-editor-entity-canvas-error"
+            >
+                {errorMessage}
+            </div>
+        );
+    }
+
+    return (
+        <div
+            className="ap-site-editor__entity-canvas"
+            data-testid="ap-site-editor-entity-canvas"
+        >
+            <span
+                role="status"
+                aria-live="polite"
+                className="ap-site-editor__sr-only"
+                data-testid="ap-site-editor-entity-canvas-announce"
+            >
+                {announcement}
+            </span>
+            {header !== undefined ? (
+                <div className="ap-site-editor__entity-canvas-header">{header}</div>
+            ) : null}
+            <div className="ap-site-editor__entity-canvas-body">
+                <SlotFillProvider>
+                    <BlockEditorProvider
+                        value={blocks}
+                        settings={EDITOR_SETTINGS}
+                        onChange={onChange}
+                        onInput={onInput}
+                    >
+                        <div className="editor-styles-wrapper ap-site-editor__entity-canvas-surface">
+                            <BlockTools>
+                                <WritingFlow>
+                                    <ObserveTyping>
+                                        <BlockList />
+                                    </ObserveTyping>
+                                </WritingFlow>
+                            </BlockTools>
+                        </div>
+                        <Popover.Slot />
+                    </BlockEditorProvider>
+                </SlotFillProvider>
+            </div>
+        </div>
+    );
+}

--- a/resources/js/visual-editor/site-editor/entity-editor.tsx
+++ b/resources/js/visual-editor/site-editor/entity-editor.tsx
@@ -1,0 +1,261 @@
+/**
+ * Entity-editor orchestrator.
+ *
+ * Stitches together the canvas, the A1 inspector sidebar, and the kind-
+ * specific document panel once the user opens a template or part. Also
+ * owns the handoff of save status / dirty flag up to the shell top bar:
+ * the parent passes an `onStateChange` callback and a `saveHandlerRef`
+ * (a slot for the top-bar button to invoke), so the top bar stays in
+ * sync with whichever editor is mounted without reaching into React
+ * context.
+ */
+
+import { __ } from '@wordpress/i18n';
+import { useCallback, useEffect, useMemo, type ReactNode } from 'react';
+
+import { TEXT_DOMAIN } from '../vendor/i18n';
+
+import {
+    type EntityKind,
+    type EntityRecord,
+    type SiteEditorApiConfig,
+    type UpdatePayload,
+} from './api-client';
+import { EntityEditorCanvas } from './entity-editor-canvas';
+import { fallbackChainForSlug } from './fallback-chain';
+import { useEntityEditor, type SaveStatus } from './use-entity-editor';
+import { InspectorSidebar } from '../editor/inspector-sidebar';
+import {
+    TemplateDocumentPanel,
+} from './templates-section';
+import {
+    TemplatePartDocumentPanel,
+} from './template-parts-section';
+
+export interface EntityEditorState {
+    entityId: string | null;
+    entityTitle: string;
+    isDirty: boolean;
+    saveStatus: SaveStatus;
+    saveErrorMessage: string | null;
+    lastSavedAt: Date | null;
+    /**
+     * Dispatcher the top-bar Save button invokes. `null` when no entity
+     * is loaded (the top bar disables its Save in that case).
+     */
+    save: (() => Promise<void>) | null;
+}
+
+export interface EntityEditorOptions<K extends EntityKind> {
+    apiConfig: SiteEditorApiConfig;
+    kind: K;
+    entityId: string | null;
+    onStateChange: (state: EntityEditorState) => void;
+}
+
+export interface EntityEditorViews {
+    canvas: JSX.Element;
+    inspector: JSX.Element;
+}
+
+function resolveTitle(entity: EntityRecord<EntityKind> | null): string {
+    if (entity === null) {
+        return '';
+    }
+
+    const rendered = entity.title?.rendered?.trim();
+
+    if (rendered !== undefined && rendered !== '') {
+        return rendered;
+    }
+
+    return entity.slug;
+}
+
+export function useEntityEditorViews<K extends EntityKind>(
+    options: EntityEditorOptions<K>
+): EntityEditorViews {
+    const { apiConfig, kind, entityId, onStateChange } = options;
+
+    const editor = useEntityEditor({ apiConfig, kind, entityId });
+    const {
+        entity,
+        loadStatus,
+        loadErrorMessage,
+        blocks,
+        setBlocks,
+        isDirty,
+        saveStatus,
+        saveErrorMessage,
+        lastSavedAt,
+        save,
+        patch,
+    } = editor;
+
+    const entityTitle = useMemo(() => resolveTitle(entity), [entity]);
+
+    // Memoize the top-bar save dispatcher so `onStateChange` receives a
+    // stable reference between renders — otherwise the shell's
+    // `entityState` re-equality check sees a new `save` closure every
+    // render and re-runs its own state update loop.
+    const memoizedSave = useCallback(async (): Promise<void> => {
+        await save();
+    }, [save]);
+
+    const savePayload = entityId === null ? null : memoizedSave;
+
+    useEffect(() => {
+        onStateChange({
+            entityId,
+            entityTitle,
+            isDirty,
+            saveStatus,
+            saveErrorMessage,
+            lastSavedAt,
+            save: savePayload,
+        });
+    }, [
+        entityId,
+        entityTitle,
+        isDirty,
+        saveStatus,
+        saveErrorMessage,
+        lastSavedAt,
+        savePayload,
+        onStateChange,
+    ]);
+
+    const headerContent = useMemo((): ReactNode => {
+        if (entity === null) {
+            return null;
+        }
+
+        const rows: ReactNode[] = [];
+
+        if (kind === 'template') {
+            const chain = fallbackChainForSlug(entity.slug);
+
+            rows.push(
+                <span
+                    key="chain"
+                    className="ap-site-editor__fallback-chain-header"
+                    data-testid="ap-site-editor-entity-canvas-chain"
+                >
+                    {chain.map((slug, index) => (
+                        <span key={slug}>
+                            <code>{slug}</code>
+                            {index < chain.length - 1 ? (
+                                <span aria-hidden="true">{' ▸ '}</span>
+                            ) : null}
+                        </span>
+                    ))}
+                </span>
+            );
+        }
+
+        if (isDirty) {
+            rows.push(
+                <span
+                    key="dirty"
+                    className="ap-site-editor__dirty-indicator"
+                    role="status"
+                    aria-live="polite"
+                    data-testid="ap-site-editor-entity-canvas-dirty"
+                >
+                    {__('Unsaved changes', TEXT_DOMAIN)}
+                </span>
+            );
+        }
+
+        if (saveStatus === 'saved' && !isDirty) {
+            rows.push(
+                <span
+                    key="saved"
+                    className="ap-site-editor__save-indicator"
+                    role="status"
+                    data-testid="ap-site-editor-entity-canvas-saved"
+                >
+                    {__('Saved', TEXT_DOMAIN)}
+                </span>
+            );
+        }
+
+        if (saveStatus === 'error' && saveErrorMessage !== null) {
+            rows.push(
+                <span
+                    key="save-error"
+                    role="alert"
+                    className="ap-site-editor__entity-canvas--error"
+                    data-testid="ap-site-editor-entity-canvas-save-error"
+                >
+                    {saveErrorMessage}
+                </span>
+            );
+        }
+
+        return rows.length > 0 ? rows : null;
+    }, [entity, isDirty, kind, saveErrorMessage, saveStatus]);
+
+    const canvas = useMemo((): JSX.Element => {
+        if (entityId === null) {
+            return (
+                <div
+                    className="ap-site-editor__entity-canvas ap-site-editor__entity-canvas--loading"
+                    data-testid="ap-site-editor-entity-canvas-inactive"
+                >
+                    {__('Select an entity to edit.', TEXT_DOMAIN)}
+                </div>
+            );
+        }
+
+        return (
+            <EntityEditorCanvas
+                entityTitle={entityTitle !== '' ? entityTitle : kind}
+                blocks={blocks}
+                onChange={setBlocks}
+                onInput={setBlocks}
+                header={headerContent}
+                isLoading={loadStatus === 'loading'}
+                errorMessage={loadStatus === 'error' ? loadErrorMessage : null}
+            />
+        );
+    }, [
+        blocks,
+        entityId,
+        entityTitle,
+        headerContent,
+        kind,
+        loadErrorMessage,
+        loadStatus,
+        setBlocks,
+    ]);
+
+    const documentPanel = useMemo((): ReactNode => {
+        const handlePatch = (overrides: UpdatePayload): void => {
+            patch(overrides);
+        };
+
+        if (kind === 'template') {
+            return (
+                <TemplateDocumentPanel
+                    entity={entity as EntityRecord<'template'> | null}
+                    onPatch={handlePatch}
+                />
+            );
+        }
+
+        return (
+            <TemplatePartDocumentPanel
+                entity={entity as EntityRecord<'template-part'> | null}
+                onPatch={handlePatch}
+            />
+        );
+    }, [entity, kind, patch]);
+
+    const inspector = useMemo(
+        (): JSX.Element => <InspectorSidebar documentContent={documentPanel} />,
+        [documentPanel]
+    );
+
+    return { canvas, inspector };
+}

--- a/resources/js/visual-editor/site-editor/fallback-chain.ts
+++ b/resources/js/visual-editor/site-editor/fallback-chain.ts
@@ -66,8 +66,12 @@ export function fallbackChainForSlug(slug: string): readonly string[] {
 /**
  * Known template kinds the create-new picker surfaces. The design brief
  * (§3.4, §5.1) calls out "Front page, Home, Single post, Single page,
- * Archive, 404, Search, Custom" — kept in this order so the picker reads
- * left-to-right from most specific to most generic.
+ * Archive, 404, Search, Custom" — kept in this order so the picker
+ * reads left-to-right from most specific to most generic. The "Custom"
+ * option is NOT in this list on purpose: the create dialog renders it
+ * as a dedicated sentinel (`__custom__`) that swaps the fixed slug for
+ * a free-text input, so mixing it into the kind-options array would
+ * double up the affordance.
  */
 export interface TemplateKindOption {
     slug: string;

--- a/resources/js/visual-editor/site-editor/fallback-chain.ts
+++ b/resources/js/visual-editor/site-editor/fallback-chain.ts
@@ -1,0 +1,121 @@
+/**
+ * Template fallback-chain helper.
+ *
+ * Mirrors the PHP `TemplateResolver::fallbackChain()` so the inspector's
+ * Template tab can surface "Single post ▸ Single ▸ Index" (design brief
+ * P7: template fallback chains are visible to users) without an extra
+ * round-trip. The chain is a pure function of the slug, so duplicating it
+ * client-side is safe — if the backend hierarchy ever changes, both
+ * sides move together and the shared test coverage catches the drift.
+ */
+
+const GENERIC_FALLBACKS: readonly string[] = ['index'];
+const SINGULAR_FALLBACKS: readonly string[] = ['singular', ...GENERIC_FALLBACKS];
+
+/**
+ * Returns the ordered fallback chain for the given template slug. The
+ * first entry is the slug itself; the remainder is the list the backend
+ * resolver walks if the primary template is missing. Entries are unique
+ * and preserve order.
+ */
+export function fallbackChainForSlug(slug: string): readonly string[] {
+    const primary = slug.trim();
+
+    if (primary === '') {
+        return GENERIC_FALLBACKS;
+    }
+
+    const chain: string[] = [primary];
+    const append = (candidate: string): void => {
+        if (candidate !== primary && !chain.includes(candidate)) {
+            chain.push(candidate);
+        }
+    };
+
+    // Specific-slug variants — e.g. `page-about` → `page` → `singular` → `index`.
+    if (/^(page|single|singular)-[^-]+/.test(primary)) {
+        const kind = primary.split('-', 1)[0];
+
+        if (kind !== undefined) {
+            append(kind);
+        }
+
+        SINGULAR_FALLBACKS.forEach(append);
+    } else if (primary === 'page' || primary === 'single' || primary === 'singular') {
+        SINGULAR_FALLBACKS.forEach(append);
+    } else if (
+        primary === 'front-page' ||
+        primary === 'home' ||
+        primary === '404' ||
+        primary === 'search' ||
+        primary === 'archive'
+    ) {
+        GENERIC_FALLBACKS.forEach(append);
+    } else if (/^archive-[^-]+/.test(primary)) {
+        append('archive');
+        GENERIC_FALLBACKS.forEach(append);
+    } else {
+        // Custom templates fall back straight to `index` — themes can
+        // override by shipping a more specific template.
+        GENERIC_FALLBACKS.forEach(append);
+    }
+
+    return chain;
+}
+
+/**
+ * Known template kinds the create-new picker surfaces. The design brief
+ * (§3.4, §5.1) calls out "Front page, Home, Single post, Single page,
+ * Archive, 404, Search, Custom" — kept in this order so the picker reads
+ * left-to-right from most specific to most generic.
+ */
+export interface TemplateKindOption {
+    slug: string;
+    label: string;
+    description: string;
+}
+
+export function getTemplateKindOptions(): readonly TemplateKindOption[] {
+    return [
+        {
+            slug: 'front-page',
+            label: 'Front page',
+            description: 'The site homepage when a static front page is assigned.',
+        },
+        {
+            slug: 'home',
+            label: 'Blog home',
+            description: 'The posts archive when not used as the front page.',
+        },
+        {
+            slug: 'single',
+            label: 'Single post',
+            description: 'The default layout for individual posts.',
+        },
+        {
+            slug: 'page',
+            label: 'Single page',
+            description: 'The default layout for individual pages.',
+        },
+        {
+            slug: 'archive',
+            label: 'Archive',
+            description: 'Listings for categories, tags, and custom taxonomies.',
+        },
+        {
+            slug: 'search',
+            label: 'Search results',
+            description: 'The search results page.',
+        },
+        {
+            slug: '404',
+            label: '404 (not found)',
+            description: 'Shown when no other template matches the request.',
+        },
+        {
+            slug: 'index',
+            label: 'Index (fallback)',
+            description: 'The last-resort fallback used when no other template matches.',
+        },
+    ];
+}

--- a/resources/js/visual-editor/site-editor/main.tsx
+++ b/resources/js/visual-editor/site-editor/main.tsx
@@ -34,6 +34,8 @@ type MountableElement = HTMLElement & {
 export interface SiteEditorMountConfig {
     routeBase: string;
     postEditorUrl: string;
+    apiBase: string;
+    theme?: string;
 }
 
 export interface MountedSiteEditor {
@@ -51,12 +53,19 @@ export interface MountedSiteEditor {
 function readMountConfig(element: HTMLElement): SiteEditorMountConfig | null {
     const routeBase = element.dataset.routeBase?.trim();
     const postEditorUrl = element.dataset.postEditorUrl?.trim();
+    const apiBase = element.dataset.apiBase?.trim();
+    const theme = element.dataset.theme?.trim();
 
-    if (!routeBase || !postEditorUrl) {
+    if (!routeBase || !postEditorUrl || !apiBase) {
         return null;
     }
 
-    return { routeBase, postEditorUrl };
+    return {
+        routeBase,
+        postEditorUrl,
+        apiBase,
+        ...(theme !== undefined && theme !== '' ? { theme } : {}),
+    };
 }
 
 export function mountSiteEditor(
@@ -156,7 +165,7 @@ async function mount(element: MountableElement): Promise<void> {
 
     if (config === null) {
         console.error(
-            'site-editor: mount point is missing data-route-base or data-post-editor-url.',
+            'site-editor: mount point is missing data-route-base, data-post-editor-url, or data-api-base.',
             element
         );
         return;

--- a/resources/js/visual-editor/site-editor/site-editor-app.css
+++ b/resources/js/visual-editor/site-editor/site-editor-app.css
@@ -66,6 +66,9 @@
 
 .ap-site-editor__sidebar--inspector {
     flex: 0 0 var(--ap-site-editor-inspector-width);
+    /* Match the navigator's separator on the left side so both rails
+       frame the canvas symmetrically. */
+    border-left: 1px solid var(--ap-site-editor-border);
 }
 
 .ap-site-editor__top-bar-extras {

--- a/resources/js/visual-editor/site-editor/site-editor-app.tsx
+++ b/resources/js/visual-editor/site-editor/site-editor-app.tsx
@@ -16,7 +16,7 @@
  */
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { getBlockTypes, unregisterBlockType } from '@wordpress/blocks';
+import { getBlockType, getBlockTypes, unregisterBlockType } from '@wordpress/blocks';
 import { registerCoreBlocks } from '@wordpress/block-library';
 import { __, sprintf } from '@wordpress/i18n';
 
@@ -127,9 +127,12 @@ function ensureEditorBoot(): void {
 
     // Register core blocks before the first template loads so `parse()`
     // can turn the saved raw serialization back into BlockInstances
-    // Gutenberg can render. Skip if another mount (HMR, shared bundle)
-    // already registered the core set.
-    if (getBlockTypes().length === 0) {
+    // Gutenberg can render. Probe for `core/paragraph` specifically —
+    // a length > 0 registry isn't enough, since a host app may have
+    // registered an unrelated block before this boot runs and we'd
+    // silently skip the core set. Paragraph is the canonical "is core
+    // loaded?" sentinel.
+    if (getBlockType('core/paragraph') === undefined) {
         registerCoreBlocks();
     }
 

--- a/resources/js/visual-editor/site-editor/site-editor-app.tsx
+++ b/resources/js/visual-editor/site-editor/site-editor-app.tsx
@@ -1,34 +1,33 @@
 /**
  * Site-editor SPA root.
  *
- * D1 (#368) — assembles the four shell regions defined in the macro
- * design brief (`docs/design/site-editor-ux.md` §3.2):
+ * D1 (#368) built the four shell regions (top bar / navigator / canvas /
+ * inspector). D2 (#369) plugs in the Templates and Template Parts
+ * sections: the navigator-outlet hosts the entity browser, the canvas
+ * swaps its empty state for the block editor when an entity id appears
+ * in the URL, and the inspector outlet renders the reused A1
+ * `InspectorSidebar` with a kind-specific Document panel.
  *
- *   ┌────────── Top bar ──────────┐
- *   │ Navigator │  Canvas │ Inspector │
- *   └─────────────────────────────────┘
- *
- * The top bar reuses the post-editor's {@link TopBar} so the chrome
- * stays visually consistent (per issue: "Reuse the post-editor's
- * top-bar implementation from M7 rather than forking it"). Site-editor-
- * specific extras — back-to-post-editor, mode indicator, save-with-
- * scope — ride in through the existing `extraActions` slot.
- *
- * D2–D5 plug into:
- *   - The navigator's `children` slot for per-section entity browsers.
- *   - The canvas-frame's `hasEntity` / `children` for live editing.
- *   - The inspector outlet for per-entity settings.
- *
- * Until those phases land, the shell is intentionally informative
- * (placeholders name the section + phase) rather than empty.
+ * The top-bar Save button is wired to whatever entity editor is mounted
+ * via an `entityState` hand-off — the site editor tracks one entity at a
+ * time, so the shell owns a single save slot rather than a per-section
+ * context tree. D3–D5 will hook their own `entityState` into the same
+ * slot when they ship.
  */
 
-import { useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { getBlockTypes, unregisterBlockType } from '@wordpress/blocks';
+import { registerCoreBlocks } from '@wordpress/block-library';
 import { __, sprintf } from '@wordpress/i18n';
 
 import { TEXT_DOMAIN, bootI18n } from '../vendor/i18n';
 
+import type { EntityKind, SiteEditorApiConfig } from './api-client';
 import { CanvasFrame } from './canvas-frame';
+import {
+    useEntityEditorViews,
+    type EntityEditorState,
+} from './entity-editor';
 import { InspectorOutlet } from './inspector-outlet';
 import {
     NAVIGATOR_PANEL_ID,
@@ -36,7 +35,15 @@ import {
     navigatorTabId,
 } from './navigator-sidebar';
 import { SectionOutlet } from './section-outlet';
-import { getSection } from './sections';
+import { getSection, type SiteEditorSectionId } from './sections';
+import {
+    TemplateCreateDialog,
+    TemplatesBrowser,
+} from './templates-section';
+import {
+    TemplatePartCreateDialog,
+    TemplatePartsBrowser,
+} from './template-parts-section';
 import { usePersistedToggle } from './use-persisted-toggle';
 import { useSiteEditorRouting } from './use-site-editor-routing';
 import { TopBar } from '../editor/top-bar';
@@ -46,28 +53,124 @@ import './site-editor-app.css';
 const NAVIGATOR_STORAGE_KEY = 'ap-site-editor:navigator-open';
 const INSPECTOR_STORAGE_KEY = 'ap-site-editor:inspector-open';
 
+const IDLE_ENTITY_STATE: EntityEditorState = {
+    entityId: null,
+    entityTitle: '',
+    isDirty: false,
+    saveStatus: 'idle',
+    saveErrorMessage: null,
+    lastSavedAt: null,
+    save: null,
+};
+
+/**
+ * Section ids whose content D2 ships. Others still render the D1
+ * placeholder.
+ */
+const D2_SECTIONS: ReadonlySet<SiteEditorSectionId> = new Set([
+    'templates',
+    'template-parts',
+]);
+
 export interface SiteEditorAppProps {
     /** Pathname prefix the SPA owns (e.g. `/visual-editor/site`). */
     routeBase: string;
     /** URL to send the user back to when they leave the site editor. */
     postEditorUrl: string;
+    /** Base URL for the site-editor REST surface (e.g. `/visual-editor/api`). */
+    apiBase: string;
+    /** Theme slug used when creating new templates / parts. */
+    theme?: string;
 }
 
-let i18nBooted = false;
+let editorBooted = false;
 
-function ensureI18n(): void {
-    if (i18nBooted) {
+/**
+ * Core blocks the site-editor deliberately leaves unregistered for D2.
+ * Per issue #369's out-of-scope list, these entity-scoped blocks wait
+ * until E4 — their `Edit` components depend on core-data selectors
+ * (`getCurrentTheme`, `getEditedPostType`, etc.) that the B1 shim does
+ * not yet implement, so rendering them under D2 trips the block-crash
+ * boundary and leaves users staring at red error cards inside seeded
+ * templates.
+ *
+ * Mirrors the PHP `disabled_blocks` list in
+ * `config/visual-editor.php` — the two lists want to agree, and E4 will
+ * be the single commit that removes blocks from both sides.
+ */
+const D2_DISABLED_BLOCKS: ReadonlyArray<string> = [
+    'core/template-part',
+    'core/post-content',
+    'core/post-title',
+    'core/post-excerpt',
+    'core/post-date',
+    'core/post-author',
+    'core/post-featured-image',
+    'core/site-logo',
+    'core/site-title',
+    'core/site-tagline',
+    'core/navigation',
+    'core/query',
+    'core/query-loop',
+    'core/latest-comments',
+    'core/archives',
+    'core/categories',
+    'core/tag-cloud',
+];
+
+function ensureEditorBoot(): void {
+    if (editorBooted) {
         return;
     }
 
     bootI18n();
-    i18nBooted = true;
+
+    // Register core blocks before the first template loads so `parse()`
+    // can turn the saved raw serialization back into BlockInstances
+    // Gutenberg can render. Skip if another mount (HMR, shared bundle)
+    // already registered the core set.
+    if (getBlockTypes().length === 0) {
+        registerCoreBlocks();
+    }
+
+    // Strip out the out-of-scope blocks. `unregisterBlockType` throws a
+    // console warning when the target was never registered (e.g. a
+    // narrower `registerCoreBlocks` build) — check the registry first so
+    // host apps that ship a trimmed core don't see spurious noise.
+    const registered = new Set(
+        getBlockTypes().map((type: { name: string }) => type.name)
+    );
+
+    for (const name of D2_DISABLED_BLOCKS) {
+        if (registered.has(name)) {
+            unregisterBlockType(name);
+        }
+    }
+
+    editorBooted = true;
+}
+
+function sectionKind(section: SiteEditorSectionId): EntityKind | null {
+    if (section === 'templates') {
+        return 'template';
+    }
+
+    if (section === 'template-parts') {
+        return 'template-part';
+    }
+
+    return null;
 }
 
 export function SiteEditorApp(props: SiteEditorAppProps): JSX.Element {
-    ensureI18n();
+    ensureEditorBoot();
 
-    const { routeBase, postEditorUrl } = props;
+    const { routeBase, postEditorUrl, apiBase, theme = 'default' } = props;
+
+    const apiConfig = useMemo<SiteEditorApiConfig>(
+        () => ({ apiBase }),
+        [apiBase]
+    );
 
     const routing = useSiteEditorRouting({ routeBase });
     const [navigatorOpen, setNavigatorOpen] = usePersistedToggle(
@@ -83,8 +186,42 @@ export function SiteEditorApp(props: SiteEditorAppProps): JSX.Element {
         [routing.section]
     );
 
-    // Update the document title so deep-links and tab pickers identify
-    // the active scope without forcing the user to read the URL.
+    const activeEntityId = routing.entityId;
+    const isD2Section = D2_SECTIONS.has(activeSection.id);
+    const activeKind = sectionKind(activeSection.id);
+
+    // Effective kind passed to the editor hook — always a real value so
+    // the hook is called unconditionally. Non-D2 sections get
+    // `entityId: null`, which short-circuits the hook into idle state.
+    const editorKind: EntityKind = activeKind ?? 'template';
+    const editorEntityId = isD2Section ? activeEntityId : null;
+
+    const [entityState, setEntityState] =
+        useState<EntityEditorState>(IDLE_ENTITY_STATE);
+
+    const handleEntityStateChange = useCallback(
+        (state: EntityEditorState): void => {
+            setEntityState(state);
+        },
+        []
+    );
+
+    const editorViews = useEntityEditorViews({
+        apiConfig,
+        kind: editorKind,
+        entityId: editorEntityId,
+        onStateChange: handleEntityStateChange,
+    });
+
+    const [dialogKind, setDialogKind] = useState<EntityKind | null>(null);
+
+    // Browser-list refresh signal. Bumped after a successful create so the
+    // navigator list re-fetches and the new row appears without a full
+    // page reload. Each section tracks its own counter so touching one
+    // section never invalidates the other.
+    const [templatesRefreshKey, setTemplatesRefreshKey] = useState(0);
+    const [partsRefreshKey, setPartsRefreshKey] = useState(0);
+
     useEffect(() => {
         if (typeof document === 'undefined') {
             return;
@@ -96,6 +233,14 @@ export function SiteEditorApp(props: SiteEditorAppProps): JSX.Element {
             activeSection.label
         );
     }, [activeSection.label]);
+
+    // Reset cached entity state when leaving a D2 section so a
+    // subsequent re-entry doesn't surface stale save-status chrome.
+    useEffect(() => {
+        if (!isD2Section) {
+            setEntityState(IDLE_ENTITY_STATE);
+        }
+    }, [isD2Section, activeSection.id]);
 
     const handleSelectSection = useCallback(
         (sectionId: typeof activeSection.id): void => {
@@ -112,10 +257,51 @@ export function SiteEditorApp(props: SiteEditorAppProps): JSX.Element {
         setInspectorOpen((open) => !open);
     }, [setInspectorOpen]);
 
-    // The Cmd+S handler is intentionally a no-op for D1 so the
-    // shortcut doesn't bubble up as a browser "save page" dialog. D2–D5
-    // replace this with the real, scope-aware save dispatcher.
-    const handleSavePlaceholder = useCallback((): void => undefined, []);
+    const handleOpenEntity = useCallback(
+        (entityId: string): void => {
+            routing.navigate(activeSection.id, entityId);
+        },
+        [activeSection.id, routing]
+    );
+
+    const handleRequestCreate = useCallback((): void => {
+        if (activeKind === null) {
+            return;
+        }
+
+        setDialogKind(activeKind);
+    }, [activeKind]);
+
+    const handleCloseDialog = useCallback((): void => {
+        setDialogKind(null);
+    }, []);
+
+    const handleDialogCreated = useCallback(
+        (entityId: number | string): void => {
+            setDialogKind(null);
+
+            // Bump the section's refresh counter so the navigator list
+            // re-fetches and the new record appears alongside its siblings.
+            // Only the active section's counter moves — the sibling list
+            // stays cached until the user explicitly visits it.
+            if (activeSection.id === 'templates') {
+                setTemplatesRefreshKey((v) => v + 1);
+            } else if (activeSection.id === 'template-parts') {
+                setPartsRefreshKey((v) => v + 1);
+            }
+
+            routing.navigate(activeSection.id, String(entityId));
+        },
+        [activeSection.id, routing]
+    );
+
+    const handleSave = useCallback((): void => {
+        if (entityState.save === null) {
+            return;
+        }
+
+        void entityState.save();
+    }, [entityState.save]);
 
     const inserterToggleAriaLabel = useMemo(
         () => ({
@@ -132,6 +318,19 @@ export function SiteEditorApp(props: SiteEditorAppProps): JSX.Element {
         }),
         []
     );
+
+    const saveLabel = useMemo(() => {
+        if (entityState.entityTitle !== '' && entityState.entityId !== null) {
+            return sprintf(
+                /* translators: 1: entity title, 2: section save label (e.g. "Save template"). */
+                __('%1$s — %2$s', TEXT_DOMAIN),
+                entityState.entityTitle,
+                activeSection.saveLabel
+            );
+        }
+
+        return activeSection.saveLabel;
+    }, [activeSection.saveLabel, entityState.entityId, entityState.entityTitle]);
 
     const extraActions = (
         <div
@@ -152,19 +351,70 @@ export function SiteEditorApp(props: SiteEditorAppProps): JSX.Element {
                 data-testid="ap-site-editor-mode-indicator"
                 data-section={activeSection.id}
             >
-                {activeSection.modeLabel}
+                {entityState.entityId !== null
+                    ? sprintf(
+                          /* translators: %s: entity title being edited. */
+                          __('Editing: %s', TEXT_DOMAIN),
+                          entityState.entityTitle || activeSection.label
+                      )
+                    : activeSection.modeLabel}
             </span>
+            {entityState.isDirty ? (
+                <span
+                    className="ap-site-editor__dirty-indicator"
+                    role="status"
+                    data-testid="ap-site-editor-top-bar-dirty"
+                >
+                    {__('Unsaved', TEXT_DOMAIN)}
+                </span>
+            ) : null}
             <button
                 type="button"
                 className="ap-site-editor__top-bar-save"
-                disabled
-                aria-label={activeSection.saveLabel}
+                disabled={entityState.save === null || entityState.saveStatus === 'saving'}
+                aria-label={saveLabel}
                 data-testid="ap-site-editor-save"
+                onClick={handleSave}
             >
-                {activeSection.saveLabel}
+                {entityState.saveStatus === 'saving'
+                    ? __('Saving…', TEXT_DOMAIN)
+                    : activeSection.saveLabel}
             </button>
         </div>
     );
+
+    let navigatorChildren: JSX.Element;
+
+    if (activeSection.id === 'templates') {
+        navigatorChildren = (
+            <TemplatesBrowser
+                apiConfig={apiConfig}
+                activeEntityId={activeEntityId}
+                onOpen={handleOpenEntity}
+                onRequestCreate={handleRequestCreate}
+                refreshKey={templatesRefreshKey}
+            />
+        );
+    } else if (activeSection.id === 'template-parts') {
+        navigatorChildren = (
+            <TemplatePartsBrowser
+                apiConfig={apiConfig}
+                activeEntityId={activeEntityId}
+                onOpen={handleOpenEntity}
+                onRequestCreate={handleRequestCreate}
+                refreshKey={partsRefreshKey}
+            />
+        );
+    } else {
+        navigatorChildren = (
+            <SectionOutlet
+                section={activeSection.id}
+                sectionLabel={activeSection.label}
+            />
+        );
+    }
+
+    const showEntityEditor = isD2Section && activeEntityId !== null;
 
     return (
         <div
@@ -172,12 +422,17 @@ export function SiteEditorApp(props: SiteEditorAppProps): JSX.Element {
             data-navigator-open={navigatorOpen}
             data-inspector-open={inspectorOpen}
             data-active-section={activeSection.id}
+            data-has-entity={showEntityEditor}
             data-testid="ap-site-editor-shell"
         >
             <TopBar
-                saveStatus="idle"
-                lastSavedAt={null}
-                saveErrorMessage={null}
+                saveStatus={entityState.saveStatus}
+                lastSavedAt={
+                    entityState.lastSavedAt !== null
+                        ? entityState.lastSavedAt.toISOString()
+                        : null
+                }
+                saveErrorMessage={entityState.saveErrorMessage}
                 canUndo={false}
                 canRedo={false}
                 onUndo={() => undefined}
@@ -187,7 +442,7 @@ export function SiteEditorApp(props: SiteEditorAppProps): JSX.Element {
                 onToggleInserter={handleToggleNavigator}
                 onToggleInspector={handleToggleInspector}
                 previewUrl={null}
-                onSave={handleSavePlaceholder}
+                onSave={handleSave}
                 inserterToggleAriaLabel={inserterToggleAriaLabel}
                 inspectorToggleAriaLabel={inspectorToggleAriaLabel}
                 extraActions={extraActions}
@@ -205,23 +460,50 @@ export function SiteEditorApp(props: SiteEditorAppProps): JSX.Element {
                             activeSection={activeSection.id}
                             onSelectSection={handleSelectSection}
                         >
-                            <SectionOutlet
-                                section={activeSection.id}
-                                sectionLabel={activeSection.label}
-                            />
+                            {navigatorChildren}
                         </NavigatorSidebar>
                     </div>
                 ) : null}
-                <CanvasFrame
-                    sectionLabel={activeSection.modeLabel}
-                    hasEntity={false}
-                />
+                {showEntityEditor ? (
+                    <div
+                        className="ap-site-editor__canvas"
+                        data-has-entity="true"
+                        data-testid="ap-site-editor-canvas"
+                    >
+                        {editorViews.canvas}
+                    </div>
+                ) : (
+                    <CanvasFrame
+                        sectionLabel={activeSection.modeLabel}
+                        hasEntity={false}
+                    />
+                )}
                 {inspectorOpen ? (
                     <div className="ap-site-editor__sidebar ap-site-editor__sidebar--inspector">
-                        <InspectorOutlet sectionLabel={activeSection.label} />
+                        {showEntityEditor ? (
+                            editorViews.inspector
+                        ) : (
+                            <InspectorOutlet sectionLabel={activeSection.label} />
+                        )}
                     </div>
                 ) : null}
             </div>
+            {dialogKind === 'template' ? (
+                <TemplateCreateDialog
+                    apiConfig={apiConfig}
+                    defaultTheme={theme}
+                    onClose={handleCloseDialog}
+                    onCreated={(entity) => handleDialogCreated(entity.id)}
+                />
+            ) : null}
+            {dialogKind === 'template-part' ? (
+                <TemplatePartCreateDialog
+                    apiConfig={apiConfig}
+                    defaultTheme={theme}
+                    onClose={handleCloseDialog}
+                    onCreated={(entity) => handleDialogCreated(entity.id)}
+                />
+            ) : null}
         </div>
     );
 }

--- a/resources/js/visual-editor/site-editor/site-editor-app.tsx
+++ b/resources/js/visual-editor/site-editor/site-editor-app.tsx
@@ -236,11 +236,15 @@ export function SiteEditorApp(props: SiteEditorAppProps): JSX.Element {
 
     // Reset cached entity state when leaving a D2 section so a
     // subsequent re-entry doesn't surface stale save-status chrome.
+    // Switches between D2 sections (templates ↔ template-parts) are
+    // handled by the entity-editor hook itself: when its `entityId`
+    // resets to `null`, it dispatches an idle `onStateChange` that
+    // clears our cached state through the normal path.
     useEffect(() => {
         if (!isD2Section) {
             setEntityState(IDLE_ENTITY_STATE);
         }
-    }, [isD2Section, activeSection.id]);
+    }, [isD2Section]);
 
     const handleSelectSection = useCallback(
         (sectionId: typeof activeSection.id): void => {

--- a/resources/js/visual-editor/site-editor/slug.ts
+++ b/resources/js/visual-editor/site-editor/slug.ts
@@ -1,0 +1,12 @@
+/**
+ * Slug input normalizer.
+ *
+ * Run on every keystroke in the new-template / new-template-part slug
+ * fields so the live value always matches what the backend stores: all
+ * lowercase, with whitespace runs collapsed to a single dash. Keeps
+ * punctuation untouched — an invalid character triggers the backend
+ * validation rather than silently disappearing under the user's cursor.
+ */
+export function normalizeSlugInput(value: string): string {
+    return value.toLowerCase().replace(/\s+/g, '-');
+}

--- a/resources/js/visual-editor/site-editor/slug.ts
+++ b/resources/js/visual-editor/site-editor/slug.ts
@@ -8,5 +8,5 @@
  * validation rather than silently disappearing under the user's cursor.
  */
 export function normalizeSlugInput(value: string): string {
-    return value.toLowerCase().replace(/\s+/g, '-');
+    return value.trim().toLowerCase().replace(/\s+/g, '-');
 }

--- a/resources/js/visual-editor/site-editor/template-parts-section.tsx
+++ b/resources/js/visual-editor/site-editor/template-parts-section.tsx
@@ -1,0 +1,359 @@
+/**
+ * Template-parts section wiring.
+ *
+ * Mirror of `templates-section.tsx` scoped to `wp_template_part`. The
+ * browser surfaces area (header / footer / sidebar / uncategorized) as
+ * both a filter chip and a per-row meta badge — design brief §3.5 calls
+ * out typed areas as a first-class concept so the UX needs to make them
+ * visible at both the filter and the row levels.
+ *
+ * The create dialog requires an area selection up-front: a part with no
+ * area can't be swapped into anything at render time, and the C2 request
+ * validation rejects a blank area anyway. We surface the set from
+ * {@link VisualEditorTemplatePart::AREAS} — adding a new area in PHP
+ * means adding it here as well.
+ */
+
+import { __, sprintf } from '@wordpress/i18n';
+import { useCallback, useMemo, useState, type ChangeEvent } from 'react';
+
+import { TEXT_DOMAIN } from '../vendor/i18n';
+
+import { CreateEntityDialog } from './create-entity-dialog';
+import { EntityBrowser, type FilterChip } from './entity-browser';
+import {
+    type EntityRecord,
+    type SiteEditorApiConfig,
+    type TemplatePartCreatePayload,
+    type TemplatePartRecord,
+    type ValidationErrors,
+} from './api-client';
+import { normalizeSlugInput } from './slug';
+
+export interface TemplatePartArea {
+    slug: string;
+    label: string;
+}
+
+/**
+ * Returns the template-part area options for the area picker / filter
+ * chips. A function (not a top-level constant) so the `__()` calls run
+ * after `bootI18n()` has initialized the text domain — matches the
+ * same pattern as the section registry in `sections.tsx`.
+ */
+export function getTemplatePartAreas(): readonly TemplatePartArea[] {
+    return [
+        { slug: 'header', label: __('Header', TEXT_DOMAIN) },
+        { slug: 'footer', label: __('Footer', TEXT_DOMAIN) },
+        { slug: 'sidebar', label: __('Sidebar', TEXT_DOMAIN) },
+        { slug: 'uncategorized', label: __('Uncategorized', TEXT_DOMAIN) },
+    ];
+}
+
+export interface TemplatePartsBrowserProps {
+    apiConfig: SiteEditorApiConfig;
+    activeEntityId: string | null;
+    onOpen: (entityId: string) => void;
+    onRequestCreate: () => void;
+    refreshKey?: number;
+}
+
+function buildPartChips(): readonly FilterChip[] {
+    return [
+        { id: 'all', label: __('All areas', TEXT_DOMAIN), filter: {} },
+        ...getTemplatePartAreas().map((area) => ({
+            id: area.slug,
+            label: area.label,
+            filter: { area: area.slug },
+        })),
+    ];
+}
+
+export function TemplatePartsBrowser(
+    props: TemplatePartsBrowserProps
+): JSX.Element {
+    const { apiConfig, activeEntityId, onOpen, onRequestCreate, refreshKey } = props;
+    const chips = useMemo(() => buildPartChips(), []);
+
+    const renderRow = useCallback(
+        (entity: EntityRecord<'template-part'>): JSX.Element => (
+            <>
+                <code>{entity.slug}</code>
+                <span data-testid={`ap-site-editor-template-part-area-${entity.id}`}>
+                    {entity.area}
+                </span>
+            </>
+        ),
+        []
+    );
+
+    const openAriaLabel = useCallback(
+        (entity: EntityRecord<'template-part'>): string => {
+            const title = entity.title?.rendered?.trim();
+            const label = title !== undefined && title !== '' ? title : entity.slug;
+
+            return sprintf(
+                /* translators: %s: template-part title or slug. */
+                __('template part: %s', TEXT_DOMAIN),
+                label
+            );
+        },
+        []
+    );
+
+    return (
+        <EntityBrowser
+            apiConfig={apiConfig}
+            kind="template-part"
+            activeEntityId={activeEntityId}
+            onOpen={onOpen}
+            onRequestCreate={onRequestCreate}
+            chips={chips}
+            listLabel={__('Template Parts', TEXT_DOMAIN)}
+            emptyTitle={__('No template parts yet', TEXT_DOMAIN)}
+            emptyBody={__(
+                'Create a header, footer, sidebar, or other reusable region.',
+                TEXT_DOMAIN
+            )}
+            createLabel={__('Add new', TEXT_DOMAIN)}
+            openAriaLabel={openAriaLabel}
+            renderRow={renderRow}
+            refreshKey={refreshKey}
+        />
+    );
+}
+
+export interface TemplatePartDocumentPanelProps {
+    entity: TemplatePartRecord | null;
+    onPatch: (overrides: { slug?: string; title?: string; area?: string }) => void;
+}
+
+export function TemplatePartDocumentPanel(
+    props: TemplatePartDocumentPanelProps
+): JSX.Element {
+    const { entity, onPatch } = props;
+
+    if (entity === null) {
+        return (
+            <p
+                className="ap-site-editor__inspector-empty"
+                data-testid="ap-site-editor-template-part-inspector-empty"
+            >
+                {__('Open a template part to edit its settings.', TEXT_DOMAIN)}
+            </p>
+        );
+    }
+
+    return (
+        <div
+            className="ap-site-editor__inspector-panel"
+            data-testid="ap-site-editor-template-part-inspector-panel"
+        >
+            <div className="ap-site-editor__dialog-field">
+                <label
+                    className="ap-site-editor__dialog-label"
+                    htmlFor="ap-site-editor-template-part-title"
+                >
+                    {__('Title', TEXT_DOMAIN)}
+                </label>
+                <input
+                    id="ap-site-editor-template-part-title"
+                    type="text"
+                    className="ap-site-editor__dialog-input"
+                    value={entity.title.rendered}
+                    onChange={(event) => onPatch({ title: event.target.value })}
+                    data-testid="ap-site-editor-template-part-inspector-title"
+                />
+            </div>
+
+            <div className="ap-site-editor__dialog-field">
+                <span className="ap-site-editor__dialog-label">
+                    {__('Slug', TEXT_DOMAIN)}
+                </span>
+                <code className="ap-site-editor__inspector-slug">
+                    {entity.slug}
+                </code>
+            </div>
+
+            <div className="ap-site-editor__dialog-field">
+                <label
+                    className="ap-site-editor__dialog-label"
+                    htmlFor="ap-site-editor-template-part-area"
+                >
+                    {__('Area', TEXT_DOMAIN)}
+                </label>
+                <select
+                    id="ap-site-editor-template-part-area"
+                    className="ap-site-editor__dialog-select"
+                    value={entity.area}
+                    onChange={(event) => onPatch({ area: event.target.value })}
+                    data-testid="ap-site-editor-template-part-inspector-area"
+                >
+                    {getTemplatePartAreas().map((area) => (
+                        <option key={area.slug} value={area.slug}>
+                            {area.label}
+                        </option>
+                    ))}
+                </select>
+                <p className="ap-site-editor__dialog-field-help">
+                    {__(
+                        'Determines which template slots this part can fill.',
+                        TEXT_DOMAIN
+                    )}
+                </p>
+            </div>
+
+            {entity.referenced_by !== undefined && entity.referenced_by.length > 0 ? (
+                <div className="ap-site-editor__dialog-field">
+                    <span className="ap-site-editor__dialog-label">
+                        {__('Used by', TEXT_DOMAIN)}
+                    </span>
+                    <ul
+                        className="ap-site-editor__inspector-refs"
+                        data-testid="ap-site-editor-template-part-inspector-refs"
+                    >
+                        {entity.referenced_by.map((slug) => (
+                            <li key={slug}>
+                                <code>{slug}</code>
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+            ) : null}
+        </div>
+    );
+}
+
+export interface TemplatePartCreateDialogProps {
+    apiConfig: SiteEditorApiConfig;
+    defaultTheme: string;
+    onClose: () => void;
+    onCreated: (entity: TemplatePartRecord) => void;
+}
+
+export function TemplatePartCreateDialog(
+    props: TemplatePartCreateDialogProps
+): JSX.Element {
+    const { apiConfig, defaultTheme, onClose, onCreated } = props;
+
+    const areaOptions = useMemo(() => getTemplatePartAreas(), []);
+    const [slug, setSlug] = useState<string>('');
+    const [title, setTitle] = useState<string>('');
+    const [area, setArea] = useState<string>(areaOptions[0]?.slug ?? 'header');
+
+    const buildPayload = useCallback((): TemplatePartCreatePayload | null => {
+        if (slug.trim() === '') {
+            return null;
+        }
+
+        return {
+            slug: slug.trim(),
+            title: title.trim(),
+            area,
+            theme: defaultTheme,
+            content: { raw: '', blocks: [] },
+        };
+    }, [area, defaultTheme, slug, title]);
+
+    const renderFields = useCallback(
+        (api: { validationErrors: ValidationErrors | null }): JSX.Element => {
+            const slugError = api.validationErrors?.slug?.[0] ?? null;
+            const areaError = api.validationErrors?.area?.[0] ?? null;
+
+            return (
+                <>
+                    <div className="ap-site-editor__dialog-field">
+                        <label
+                            className="ap-site-editor__dialog-label"
+                            htmlFor="ap-site-editor-new-part-slug"
+                        >
+                            {__('Slug', TEXT_DOMAIN)}
+                        </label>
+                        <input
+                            id="ap-site-editor-new-part-slug"
+                            type="text"
+                            className="ap-site-editor__dialog-input"
+                            value={slug}
+                            onChange={(event) =>
+                                setSlug(normalizeSlugInput(event.target.value))
+                            }
+                            placeholder={__('e.g. site-header', TEXT_DOMAIN)}
+                            data-testid="ap-site-editor-new-part-slug"
+                            required
+                        />
+                        {slugError !== null ? (
+                            <p
+                                className="ap-site-editor__dialog-field-error"
+                                role="alert"
+                            >
+                                {slugError}
+                            </p>
+                        ) : null}
+                    </div>
+
+                    <div className="ap-site-editor__dialog-field">
+                        <label
+                            className="ap-site-editor__dialog-label"
+                            htmlFor="ap-site-editor-new-part-title"
+                        >
+                            {__('Title', TEXT_DOMAIN)}
+                        </label>
+                        <input
+                            id="ap-site-editor-new-part-title"
+                            type="text"
+                            className="ap-site-editor__dialog-input"
+                            value={title}
+                            onChange={(event) => setTitle(event.target.value)}
+                            data-testid="ap-site-editor-new-part-title"
+                        />
+                    </div>
+
+                    <div className="ap-site-editor__dialog-field">
+                        <label
+                            className="ap-site-editor__dialog-label"
+                            htmlFor="ap-site-editor-new-part-area"
+                        >
+                            {__('Area', TEXT_DOMAIN)}
+                        </label>
+                        <select
+                            id="ap-site-editor-new-part-area"
+                            className="ap-site-editor__dialog-select"
+                            value={area}
+                            onChange={(event: ChangeEvent<HTMLSelectElement>) =>
+                                setArea(event.target.value)
+                            }
+                            data-testid="ap-site-editor-new-part-area"
+                        >
+                            {areaOptions.map((option) => (
+                                <option key={option.slug} value={option.slug}>
+                                    {option.label}
+                                </option>
+                            ))}
+                        </select>
+                        {areaError !== null ? (
+                            <p
+                                className="ap-site-editor__dialog-field-error"
+                                role="alert"
+                            >
+                                {areaError}
+                            </p>
+                        ) : null}
+                    </div>
+                </>
+            );
+        },
+        [area, areaOptions, slug, title]
+    );
+
+    return (
+        <CreateEntityDialog
+            apiConfig={apiConfig}
+            kind="template-part"
+            title={__('Add new template part', TEXT_DOMAIN)}
+            renderFields={renderFields}
+            buildPayload={buildPayload}
+            onClose={onClose}
+            onCreated={onCreated}
+        />
+    );
+}

--- a/resources/js/visual-editor/site-editor/template-parts-section.tsx
+++ b/resources/js/visual-editor/site-editor/template-parts-section.tsx
@@ -75,16 +75,28 @@ export function TemplatePartsBrowser(
     const { apiConfig, activeEntityId, onOpen, onRequestCreate, refreshKey } = props;
     const chips = useMemo(() => buildPartChips(), []);
 
+    // Index areas by slug so the row renderer can swap the raw machine
+    // slug for its localized label without walking the list on every
+    // render.
+    const areaLabelBySlug = useMemo(() => {
+        const map: Record<string, string> = {};
+        for (const area of getTemplatePartAreas()) {
+            map[area.slug] = area.label;
+        }
+
+        return map;
+    }, []);
+
     const renderRow = useCallback(
         (entity: EntityRecord<'template-part'>): JSX.Element => (
             <>
                 <code>{entity.slug}</code>
                 <span data-testid={`ap-site-editor-template-part-area-${entity.id}`}>
-                    {entity.area}
+                    {areaLabelBySlug[entity.area] ?? entity.area}
                 </span>
             </>
         ),
-        []
+        [areaLabelBySlug]
     );
 
     const openAriaLabel = useCallback(

--- a/resources/js/visual-editor/site-editor/templates-section.tsx
+++ b/resources/js/visual-editor/site-editor/templates-section.tsx
@@ -1,0 +1,434 @@
+/**
+ * Templates section wiring.
+ *
+ * Assembles the templates-specific pieces the shell plugs together at
+ * runtime:
+ *   - `TemplatesBrowser` — the navigator sub-panel list, with `All /
+ *     Theme / Custom` filter chips per design brief §3.4.
+ *   - `TemplateDocumentPanel` — the Document tab that drops into the
+ *     reused A1 `InspectorSidebar`.
+ *   - `TemplateCreateDialog` — slug picker with fallback-chain preview
+ *     per P7 (template fallback chains are visible to users).
+ *
+ * Kept in one file so the shell only imports a single surface; the
+ * symmetrical template-parts-section.tsx follows the same shape.
+ */
+
+import { __, sprintf } from '@wordpress/i18n';
+import { useCallback, useId, useMemo, useState, type ChangeEvent } from 'react';
+
+import { TEXT_DOMAIN } from '../vendor/i18n';
+
+import { CreateEntityDialog } from './create-entity-dialog';
+import { EntityBrowser, type FilterChip } from './entity-browser';
+import {
+    fallbackChainForSlug,
+    getTemplateKindOptions,
+} from './fallback-chain';
+import {
+    type EntityRecord,
+    type SiteEditorApiConfig,
+    type TemplateCreatePayload,
+    type TemplateRecord,
+    type ValidationErrors,
+} from './api-client';
+import { normalizeSlugInput } from './slug';
+
+const CUSTOM_KIND_VALUE = '__custom__';
+
+export interface TemplatesBrowserProps {
+    apiConfig: SiteEditorApiConfig;
+    activeEntityId: string | null;
+    onOpen: (entityId: string) => void;
+    onRequestCreate: () => void;
+    refreshKey?: number;
+}
+
+function buildTemplateChips(): readonly FilterChip[] {
+    return [
+        { id: 'all', label: __('All', TEXT_DOMAIN), filter: {} },
+        {
+            id: 'publish',
+            label: __('Published', TEXT_DOMAIN),
+            filter: { status: 'publish' },
+        },
+        {
+            id: 'draft',
+            label: __('Drafts', TEXT_DOMAIN),
+            filter: { status: 'draft' },
+        },
+    ];
+}
+
+export function TemplatesBrowser(props: TemplatesBrowserProps): JSX.Element {
+    const { apiConfig, activeEntityId, onOpen, onRequestCreate, refreshKey } = props;
+    const chips = useMemo(() => buildTemplateChips(), []);
+
+    const renderRow = useCallback((entity: EntityRecord<'template'>): JSX.Element => {
+        return (
+            <>
+                <code>{entity.slug}</code>
+                <span>{entity.source === 'theme' ? __('Theme', TEXT_DOMAIN) : __('Custom', TEXT_DOMAIN)}</span>
+                <span>{entity.status}</span>
+            </>
+        );
+    }, []);
+
+    const openAriaLabel = useCallback((entity: EntityRecord<'template'>): string => {
+        const title = entity.title?.rendered?.trim();
+        const label = title !== undefined && title !== '' ? title : entity.slug;
+
+        return sprintf(
+            /* translators: %s: template title or slug. */
+            __('template: %s', TEXT_DOMAIN),
+            label
+        );
+    }, []);
+
+    return (
+        <EntityBrowser
+            apiConfig={apiConfig}
+            kind="template"
+            activeEntityId={activeEntityId}
+            onOpen={onOpen}
+            onRequestCreate={onRequestCreate}
+            chips={chips}
+            listLabel={__('Templates', TEXT_DOMAIN)}
+            emptyTitle={__('No templates yet', TEXT_DOMAIN)}
+            emptyBody={__(
+                'Create a template to control how a URL or kind of content renders.',
+                TEXT_DOMAIN
+            )}
+            createLabel={__('Add new', TEXT_DOMAIN)}
+            openAriaLabel={openAriaLabel}
+            renderRow={renderRow}
+            refreshKey={refreshKey}
+        />
+    );
+}
+
+export interface TemplateDocumentPanelProps {
+    entity: TemplateRecord | null;
+    onPatch: (overrides: { slug?: string; title?: string; description?: string }) => void;
+}
+
+export function TemplateDocumentPanel(
+    props: TemplateDocumentPanelProps
+): JSX.Element {
+    const { entity, onPatch } = props;
+    const titleId = useId();
+    const descriptionId = useId();
+
+    if (entity === null) {
+        return (
+            <p
+                className="ap-site-editor__inspector-empty"
+                data-testid="ap-site-editor-template-inspector-empty"
+            >
+                {__('Open a template to edit its settings.', TEXT_DOMAIN)}
+            </p>
+        );
+    }
+
+    const chain = fallbackChainForSlug(entity.slug);
+
+    return (
+        <div
+            className="ap-site-editor__inspector-panel"
+            data-testid="ap-site-editor-template-inspector-panel"
+        >
+            <div className="ap-site-editor__dialog-field">
+                <label
+                    className="ap-site-editor__dialog-label"
+                    htmlFor={titleId}
+                >
+                    {__('Title', TEXT_DOMAIN)}
+                </label>
+                <input
+                    id={titleId}
+                    type="text"
+                    className="ap-site-editor__dialog-input"
+                    value={entity.title.rendered}
+                    onChange={(event) => onPatch({ title: event.target.value })}
+                    data-testid="ap-site-editor-template-inspector-title"
+                />
+            </div>
+
+            <div className="ap-site-editor__dialog-field">
+                <span className="ap-site-editor__dialog-label">
+                    {__('Slug', TEXT_DOMAIN)}
+                </span>
+                <code className="ap-site-editor__inspector-slug">
+                    {entity.slug}
+                </code>
+            </div>
+
+            <div className="ap-site-editor__dialog-field">
+                <label
+                    className="ap-site-editor__dialog-label"
+                    htmlFor={descriptionId}
+                >
+                    {__('Description', TEXT_DOMAIN)}
+                </label>
+                <textarea
+                    id={descriptionId}
+                    className="ap-site-editor__dialog-textarea"
+                    rows={3}
+                    value={entity.description}
+                    onChange={(event) => onPatch({ description: event.target.value })}
+                    data-testid="ap-site-editor-template-inspector-description"
+                />
+            </div>
+
+            <div className="ap-site-editor__dialog-field">
+                <span className="ap-site-editor__dialog-label">
+                    {__('Fallback chain', TEXT_DOMAIN)}
+                </span>
+                <div
+                    className="ap-site-editor__fallback-chain"
+                    aria-label={__('Fallback chain', TEXT_DOMAIN)}
+                    data-testid="ap-site-editor-template-inspector-chain"
+                >
+                    {chain.map((slug, index) => (
+                        <span
+                            key={slug}
+                            className="ap-site-editor__fallback-chain-item"
+                        >
+                            {slug}
+                            {index < chain.length - 1 ? (
+                                <span
+                                    className="ap-site-editor__fallback-chain-sep"
+                                    aria-hidden="true"
+                                >
+                                    {' ▸'}
+                                </span>
+                            ) : null}
+                        </span>
+                    ))}
+                </div>
+                <p className="ap-site-editor__dialog-field-help">
+                    {__(
+                        'If this template is empty, the next slug in the chain is rendered instead.',
+                        TEXT_DOMAIN
+                    )}
+                </p>
+            </div>
+
+            <div className="ap-site-editor__dialog-field">
+                <span className="ap-site-editor__dialog-label">
+                    {__('Source', TEXT_DOMAIN)}
+                </span>
+                <span>
+                    {entity.source === 'theme'
+                        ? __('Theme', TEXT_DOMAIN)
+                        : __('Custom', TEXT_DOMAIN)}
+                </span>
+            </div>
+        </div>
+    );
+}
+
+export interface TemplateCreateDialogProps {
+    apiConfig: SiteEditorApiConfig;
+    defaultTheme: string;
+    onClose: () => void;
+    onCreated: (entity: TemplateRecord) => void;
+}
+
+export function TemplateCreateDialog(
+    props: TemplateCreateDialogProps
+): JSX.Element {
+    const { apiConfig, defaultTheme, onClose, onCreated } = props;
+    const kindOptions = useMemo(() => getTemplateKindOptions(), []);
+
+    const [kind, setKind] = useState<string>(kindOptions[0]?.slug ?? 'index');
+    const [customSlug, setCustomSlug] = useState<string>('');
+    const [title, setTitle] = useState<string>('');
+    const [description, setDescription] = useState<string>('');
+    const [theme] = useState<string>(defaultTheme);
+
+    const activeSlug = kind === CUSTOM_KIND_VALUE ? customSlug.trim() : kind;
+    const chain = useMemo(
+        () => fallbackChainForSlug(activeSlug),
+        [activeSlug]
+    );
+
+    const buildPayload = useCallback((): TemplateCreatePayload | null => {
+        if (activeSlug === '') {
+            return null;
+        }
+
+        return {
+            slug: activeSlug,
+            title: title.trim(),
+            description: description.trim() === '' ? null : description.trim(),
+            theme,
+            status: 'publish',
+            source: 'custom',
+            content: { raw: '', blocks: [] },
+        };
+    }, [activeSlug, description, theme, title]);
+
+    const renderFields = useCallback(
+        (api: { validationErrors: ValidationErrors | null }): JSX.Element => {
+            const slugError = api.validationErrors?.slug?.[0] ?? null;
+            const titleError = api.validationErrors?.title?.[0] ?? null;
+
+            return (
+                <>
+                    <div className="ap-site-editor__dialog-field">
+                        <label
+                            className="ap-site-editor__dialog-label"
+                            htmlFor="ap-site-editor-new-template-kind"
+                        >
+                            {__('Template kind', TEXT_DOMAIN)}
+                        </label>
+                        <select
+                            id="ap-site-editor-new-template-kind"
+                            className="ap-site-editor__dialog-select"
+                            value={kind}
+                            onChange={(event: ChangeEvent<HTMLSelectElement>) =>
+                                setKind(event.target.value)
+                            }
+                            data-testid="ap-site-editor-new-template-kind"
+                        >
+                            {kindOptions.map((option) => (
+                                <option key={option.slug} value={option.slug}>
+                                    {option.label}
+                                </option>
+                            ))}
+                            <option value={CUSTOM_KIND_VALUE}>
+                                {__('Custom slug…', TEXT_DOMAIN)}
+                            </option>
+                        </select>
+                    </div>
+
+                    {kind === CUSTOM_KIND_VALUE ? (
+                        <div className="ap-site-editor__dialog-field">
+                            <label
+                                className="ap-site-editor__dialog-label"
+                                htmlFor="ap-site-editor-new-template-slug"
+                            >
+                                {__('Custom slug', TEXT_DOMAIN)}
+                            </label>
+                            <input
+                                id="ap-site-editor-new-template-slug"
+                                type="text"
+                                className="ap-site-editor__dialog-input"
+                                value={customSlug}
+                                onChange={(event) =>
+                                    setCustomSlug(normalizeSlugInput(event.target.value))
+                                }
+                                placeholder={__('e.g. single-book', TEXT_DOMAIN)}
+                                data-testid="ap-site-editor-new-template-slug"
+                            />
+                        </div>
+                    ) : null}
+
+                    {/*
+                      Render slug validation errors unconditionally —
+                      backend may reject a predefined kind (e.g. the
+                      slug already exists for this theme) and the user
+                      needs to see the error whether or not they
+                      switched to the custom-slug input.
+                    */}
+                    {slugError !== null ? (
+                        <p
+                            className="ap-site-editor__dialog-field-error"
+                            role="alert"
+                        >
+                            {slugError}
+                        </p>
+                    ) : null}
+
+                    <div className="ap-site-editor__dialog-field">
+                        <span className="ap-site-editor__dialog-label">
+                            {__('Fallback chain', TEXT_DOMAIN)}
+                        </span>
+                        <div
+                            className="ap-site-editor__fallback-chain"
+                            data-testid="ap-site-editor-new-template-chain"
+                        >
+                            {chain.map((slug, index) => (
+                                <span
+                                    key={slug}
+                                    className="ap-site-editor__fallback-chain-item"
+                                >
+                                    {slug}
+                                    {index < chain.length - 1 ? (
+                                        <span
+                                            aria-hidden="true"
+                                            className="ap-site-editor__fallback-chain-sep"
+                                        >
+                                            {' ▸'}
+                                        </span>
+                                    ) : null}
+                                </span>
+                            ))}
+                        </div>
+                        <p className="ap-site-editor__dialog-field-help">
+                            {__(
+                                'When the template above is empty, the next slug in the chain is rendered.',
+                                TEXT_DOMAIN
+                            )}
+                        </p>
+                    </div>
+
+                    <div className="ap-site-editor__dialog-field">
+                        <label
+                            className="ap-site-editor__dialog-label"
+                            htmlFor="ap-site-editor-new-template-title"
+                        >
+                            {__('Title', TEXT_DOMAIN)}
+                        </label>
+                        <input
+                            id="ap-site-editor-new-template-title"
+                            type="text"
+                            className="ap-site-editor__dialog-input"
+                            value={title}
+                            onChange={(event) => setTitle(event.target.value)}
+                            data-testid="ap-site-editor-new-template-title"
+                        />
+                        {titleError !== null ? (
+                            <p
+                                className="ap-site-editor__dialog-field-error"
+                                role="alert"
+                            >
+                                {titleError}
+                            </p>
+                        ) : null}
+                    </div>
+
+                    <div className="ap-site-editor__dialog-field">
+                        <label
+                            className="ap-site-editor__dialog-label"
+                            htmlFor="ap-site-editor-new-template-description"
+                        >
+                            {__('Description (optional)', TEXT_DOMAIN)}
+                        </label>
+                        <textarea
+                            id="ap-site-editor-new-template-description"
+                            className="ap-site-editor__dialog-textarea"
+                            rows={2}
+                            value={description}
+                            onChange={(event) => setDescription(event.target.value)}
+                        />
+                    </div>
+                </>
+            );
+        },
+        [chain, customSlug, description, kind, kindOptions, title]
+    );
+
+    return (
+        <CreateEntityDialog
+            apiConfig={apiConfig}
+            kind="template"
+            title={__('Add new template', TEXT_DOMAIN)}
+            renderFields={renderFields}
+            buildPayload={buildPayload}
+            onClose={onClose}
+            onCreated={onCreated}
+        />
+    );
+}

--- a/resources/js/visual-editor/site-editor/templates-section.tsx
+++ b/resources/js/visual-editor/site-editor/templates-section.tsx
@@ -246,6 +246,7 @@ export function TemplateCreateDialog(
     const [title, setTitle] = useState<string>('');
     const [description, setDescription] = useState<string>('');
     const [theme] = useState<string>(defaultTheme);
+    const [localSlugError, setLocalSlugError] = useState<string | null>(null);
 
     const activeSlug = kind === CUSTOM_KIND_VALUE ? customSlug.trim() : kind;
     const chain = useMemo(
@@ -255,8 +256,17 @@ export function TemplateCreateDialog(
 
     const buildPayload = useCallback((): TemplateCreatePayload | null => {
         if (activeSlug === '') {
+            // The dialog form suppresses submission when this returns
+            // null — surface an inline error so the user understands
+            // why nothing happened instead of silently no-op'ing.
+            setLocalSlugError(
+                __('Enter a slug to continue.', TEXT_DOMAIN)
+            );
+
             return null;
         }
+
+        setLocalSlugError(null);
 
         return {
             slug: activeSlug,
@@ -271,7 +281,8 @@ export function TemplateCreateDialog(
 
     const renderFields = useCallback(
         (api: { validationErrors: ValidationErrors | null }): JSX.Element => {
-            const slugError = api.validationErrors?.slug?.[0] ?? null;
+            const slugError =
+                localSlugError ?? api.validationErrors?.slug?.[0] ?? null;
             const titleError = api.validationErrors?.title?.[0] ?? null;
 
             return (
@@ -316,9 +327,12 @@ export function TemplateCreateDialog(
                                 type="text"
                                 className="ap-site-editor__dialog-input"
                                 value={customSlug}
-                                onChange={(event) =>
-                                    setCustomSlug(normalizeSlugInput(event.target.value))
-                                }
+                                onChange={(event) => {
+                                    setCustomSlug(
+                                        normalizeSlugInput(event.target.value)
+                                    );
+                                    setLocalSlugError(null);
+                                }}
                                 placeholder={__('e.g. single-book', TEXT_DOMAIN)}
                                 data-testid="ap-site-editor-new-template-slug"
                             />
@@ -417,7 +431,7 @@ export function TemplateCreateDialog(
                 </>
             );
         },
-        [chain, customSlug, description, kind, kindOptions, title]
+        [chain, customSlug, description, kind, kindOptions, localSlugError, title]
     );
 
     return (

--- a/resources/js/visual-editor/site-editor/use-entity-editor.ts
+++ b/resources/js/visual-editor/site-editor/use-entity-editor.ts
@@ -134,6 +134,24 @@ export function useEntityEditor<K extends EntityKind>(
     // typed then undid" from "user typed" without comparing trees.
     const committedBlocksRef = useRef<readonly unknown[]>([]);
 
+    // Bumped on every local edit (setBlocks, patch, reset). A save
+    // snapshots this at start; if the value has moved by the time the
+    // response arrives, the user kept typing during the save and we
+    // must NOT overwrite their newer edits with the server snapshot.
+    const editVersionRef = useRef(0);
+
+    const resetEditorState = useCallback((): void => {
+        committedBlocksRef.current = [];
+        setEntity(null);
+        setBlocksState([]);
+        setPendingPatch({});
+        setIsDirty(false);
+        setSaveStatus('idle');
+        setSaveErrorMessage(null);
+        setValidationErrors(null);
+        setLastSavedAt(null);
+    }, []);
+
     const hydrateFromRecord = useCallback((record: EntityRecord<K>): void => {
         const nextBlocks = isEntityContent(record.content)
             ? hydrateBlocks(record.content)
@@ -154,22 +172,19 @@ export function useEntityEditor<K extends EntityKind>(
             // slip past the stale-request guard and re-populate the
             // cleared state.
             requestCounterRef.current += 1;
-            committedBlocksRef.current = [];
-            setEntity(null);
-            setBlocksState([]);
-            setPendingPatch({});
-            setIsDirty(false);
+            resetEditorState();
             setLoadStatus('idle');
             setLoadErrorMessage(null);
-            setSaveStatus('idle');
-            setSaveErrorMessage(null);
-            setValidationErrors(null);
-            setLastSavedAt(null);
             return;
         }
 
         const requestId = ++requestCounterRef.current;
 
+        // Clear every field that belonged to the previous entity before
+        // kicking off the fetch — otherwise entity A's `saveStatus`,
+        // `lastSavedAt`, validation errors, and dirty flag stay visible
+        // in the top bar / inspector until entity B finishes loading.
+        resetEditorState();
         setLoadStatus('loading');
         setLoadErrorMessage(null);
 
@@ -199,7 +214,7 @@ export function useEntityEditor<K extends EntityKind>(
                 setLoadErrorMessage(message);
             }
         })();
-    }, [apiConfig, kind, entityId, hydrateFromRecord]);
+    }, [apiConfig, kind, entityId, hydrateFromRecord, resetEditorState]);
 
     // Read the latest `pendingPatch` from inside `setBlocks` without
     // re-creating the callback on every keystroke — reading from state
@@ -217,6 +232,8 @@ export function useEntityEditor<K extends EntityKind>(
                 return prev;
             }
 
+            editVersionRef.current += 1;
+
             if (next === committedBlocksRef.current) {
                 // User undid every block edit back to the saved tree —
                 // clear the dirty flag unless a pending field override
@@ -233,11 +250,13 @@ export function useEntityEditor<K extends EntityKind>(
     }, []);
 
     const patch = useCallback((overrides: UpdatePayload): void => {
+        editVersionRef.current += 1;
         setPendingPatch((prev) => ({ ...prev, ...overrides }));
         setIsDirty(true);
     }, []);
 
     const reset = useCallback((): void => {
+        editVersionRef.current += 1;
         setBlocksState(committedBlocksRef.current);
         setPendingPatch({});
         setIsDirty(false);
@@ -323,6 +342,13 @@ export function useEntityEditor<K extends EntityKind>(
             const requestId = ++requestCounterRef.current;
             const isStale = (): boolean => requestCounterRef.current !== requestId;
 
+            // Snapshot the edit-version so we can detect typing that
+            // happened after the payload was captured. On a slow network
+            // the user can keep editing while the PUT is in-flight;
+            // hydrating the response on top of those fresh edits would
+            // silently discard them.
+            const draftVersion = editVersionRef.current;
+
             setSaveStatus('saving');
             setSaveErrorMessage(null);
             setValidationErrors(null);
@@ -334,9 +360,18 @@ export function useEntityEditor<K extends EntityKind>(
                     return updated;
                 }
 
-                hydrateFromRecord(updated);
+                // The save itself succeeded either way, so confirm it to
+                // the user. Only re-sync the canvas + pending patch from
+                // the server when no new edits happened during the
+                // request — otherwise preserve the user's in-flight
+                // edits and leave `isDirty` true so they know there's
+                // still newer state to push.
                 setSaveStatus('saved');
                 setLastSavedAt(new Date());
+
+                if (editVersionRef.current === draftVersion) {
+                    hydrateFromRecord(updated);
+                }
 
                 return updated;
             } catch (error: unknown) {

--- a/resources/js/visual-editor/site-editor/use-entity-editor.ts
+++ b/resources/js/visual-editor/site-editor/use-entity-editor.ts
@@ -149,6 +149,11 @@ export function useEntityEditor<K extends EntityKind>(
 
     useEffect(() => {
         if (entityId === null) {
+            // Bump the counter alongside the state reset so a load or
+            // save that resolves after the user closed the editor can't
+            // slip past the stale-request guard and re-populate the
+            // cleared state.
+            requestCounterRef.current += 1;
             committedBlocksRef.current = [];
             setEntity(null);
             setBlocksState([]);

--- a/resources/js/visual-editor/site-editor/use-entity-editor.ts
+++ b/resources/js/visual-editor/site-editor/use-entity-editor.ts
@@ -314,11 +314,13 @@ export function useEntityEditor<K extends EntityKind>(
                 },
             };
 
-            // Snapshot the request counter so a save that resolves after
-            // the user navigated to a different entity (counter was bumped
-            // by the load effect) or triggered a manual reload doesn't
-            // hydrate the editor with a stale record.
-            const requestId = requestCounterRef.current;
+            // Allocate a unique request id for this save so a later save
+            // (or a navigate/close) always invalidates us. Snapshotting
+            // without incrementing would let two concurrent saves share
+            // an id — the slower one's stale response could then
+            // hydrate the editor with outdated fields on top of the
+            // faster one's authoritative result.
+            const requestId = ++requestCounterRef.current;
             const isStale = (): boolean => requestCounterRef.current !== requestId;
 
             setSaveStatus('saving');

--- a/resources/js/visual-editor/site-editor/use-entity-editor.ts
+++ b/resources/js/visual-editor/site-editor/use-entity-editor.ts
@@ -13,7 +13,10 @@
  */
 
 import { parse, serialize, type BlockInstance } from '@wordpress/blocks';
+import { __ } from '@wordpress/i18n';
 import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { TEXT_DOMAIN } from '../vendor/i18n';
 
 import {
     fetchEntity,
@@ -183,7 +186,7 @@ export function useEntityEditor<K extends EntityKind>(
                 const message =
                     error instanceof SiteEditorApiError
                         ? error.message
-                        : 'Failed to load entity.';
+                        : __('Failed to load entity.', TEXT_DOMAIN);
 
                 setEntity(null);
                 setBlocksState([]);
@@ -277,7 +280,7 @@ export function useEntityEditor<K extends EntityKind>(
                     setValidationErrors(error.validationErrors);
                 } else {
                     setSaveStatus('error');
-                    setSaveErrorMessage('Failed to save.');
+                    setSaveErrorMessage(__('Failed to save.', TEXT_DOMAIN));
                 }
 
                 return null;

--- a/resources/js/visual-editor/site-editor/use-entity-editor.ts
+++ b/resources/js/visual-editor/site-editor/use-entity-editor.ts
@@ -14,7 +14,7 @@
 
 import { parse, serialize, type BlockInstance } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { TEXT_DOMAIN } from '../vendor/i18n';
 
@@ -239,6 +239,54 @@ export function useEntityEditor<K extends EntityKind>(
         setValidationErrors(null);
     }, []);
 
+    // Merge pending field overrides back into the loaded record so the
+    // inspector inputs bound to `entity.title.rendered`, `entity.slug`,
+    // etc. reflect what the user typed. Without this, each keystroke
+    // updates `pendingPatch` but the bound input re-renders with the
+    // committed record — keystrokes vanish from the UI even though the
+    // dirty flag is set correctly.
+    const draftEntity = useMemo<EntityRecord<K> | null>(() => {
+        if (entity === null) {
+            return null;
+        }
+
+        if (Object.keys(pendingPatch).length === 0) {
+            return entity;
+        }
+
+        const merged = { ...entity } as EntityRecord<K> & Record<string, unknown>;
+
+        if (pendingPatch.slug !== undefined) {
+            merged.slug = pendingPatch.slug;
+        }
+
+        if (pendingPatch.title !== undefined) {
+            merged.title = { ...entity.title, rendered: pendingPatch.title };
+        }
+
+        if (pendingPatch.description !== undefined && 'description' in entity) {
+            merged.description = pendingPatch.description ?? '';
+        }
+
+        if (pendingPatch.area !== undefined && 'area' in entity) {
+            merged.area = pendingPatch.area;
+        }
+
+        if (pendingPatch.status !== undefined && 'status' in entity) {
+            merged.status = pendingPatch.status;
+        }
+
+        if (pendingPatch.source !== undefined && 'source' in entity) {
+            merged.source = pendingPatch.source;
+        }
+
+        if (pendingPatch.theme !== undefined && 'theme' in entity) {
+            merged.theme = pendingPatch.theme;
+        }
+
+        return merged as EntityRecord<K>;
+    }, [entity, pendingPatch]);
+
     const save = useCallback(
         async (overrides: UpdatePayload = {}): Promise<EntityRecord<K> | null> => {
             if (entityId === null) {
@@ -261,6 +309,13 @@ export function useEntityEditor<K extends EntityKind>(
                 },
             };
 
+            // Snapshot the request counter so a save that resolves after
+            // the user navigated to a different entity (counter was bumped
+            // by the load effect) or triggered a manual reload doesn't
+            // hydrate the editor with a stale record.
+            const requestId = requestCounterRef.current;
+            const isStale = (): boolean => requestCounterRef.current !== requestId;
+
             setSaveStatus('saving');
             setSaveErrorMessage(null);
             setValidationErrors(null);
@@ -268,12 +323,20 @@ export function useEntityEditor<K extends EntityKind>(
             try {
                 const updated = await updateEntity(apiConfig, kind, entityId, payload);
 
+                if (isStale()) {
+                    return updated;
+                }
+
                 hydrateFromRecord(updated);
                 setSaveStatus('saved');
                 setLastSavedAt(new Date());
 
                 return updated;
             } catch (error: unknown) {
+                if (isStale()) {
+                    return null;
+                }
+
                 if (error instanceof SiteEditorApiError) {
                     setSaveStatus('error');
                     setSaveErrorMessage(error.message);
@@ -290,7 +353,7 @@ export function useEntityEditor<K extends EntityKind>(
     );
 
     return {
-        entity,
+        entity: draftEntity,
         loadStatus,
         loadErrorMessage,
         blocks,

--- a/resources/js/visual-editor/site-editor/use-entity-editor.ts
+++ b/resources/js/visual-editor/site-editor/use-entity-editor.ts
@@ -1,0 +1,304 @@
+/**
+ * Single-entity editor state hook.
+ *
+ * Loads the currently-open template or template part, exposes its content
+ * envelope for the `BlockEditorProvider`, and carries the dirty flag +
+ * save status the top bar needs to render "Save template" / "Saving…" /
+ * "Saved" (design brief §4.3: Save affects just this one entity, and the
+ * top bar always names the scope).
+ *
+ * Decoupled from the canvas so the shell can lift status into the top
+ * bar and expose a single `save()` callback — which the top-bar button
+ * calls — without the canvas having to render the button itself.
+ */
+
+import { parse, serialize, type BlockInstance } from '@wordpress/blocks';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import {
+    fetchEntity,
+    SiteEditorApiError,
+    updateEntity,
+    type EntityKind,
+    type EntityRecord,
+    type SiteEditorApiConfig,
+    type UpdatePayload,
+    type ValidationErrors,
+} from './api-client';
+
+export type SaveStatus = 'idle' | 'saving' | 'saved' | 'error';
+
+export type EntityLoadStatus = 'idle' | 'loading' | 'ready' | 'error';
+
+export interface UseEntityEditorOptions<K extends EntityKind> {
+    apiConfig: SiteEditorApiConfig;
+    kind: K;
+    /**
+     * Entity id from the URL. `null` switches the hook into "no entity"
+     * state — useful when the URL maps to the section list rather than a
+     * specific entity.
+     */
+    entityId: string | null;
+}
+
+export interface UseEntityEditorResult<K extends EntityKind> {
+    entity: EntityRecord<K> | null;
+    loadStatus: EntityLoadStatus;
+    loadErrorMessage: string | null;
+
+    blocks: readonly unknown[];
+    /** Notifies the hook of a block-tree mutation from the canvas. */
+    setBlocks: (blocks: readonly unknown[]) => void;
+
+    isDirty: boolean;
+
+    saveStatus: SaveStatus;
+    saveErrorMessage: string | null;
+    validationErrors: ValidationErrors | null;
+    lastSavedAt: Date | null;
+    /**
+     * Persists the current blocks + any pending field overrides to the
+     * backend. Returns the updated entity on success, `null` on error.
+     */
+    save: (overrides?: UpdatePayload) => Promise<EntityRecord<K> | null>;
+
+    /**
+     * Merges partial field updates (slug, title, area, …) into the
+     * working copy and marks the entity dirty. Block-tree changes should
+     * go through `setBlocks` instead.
+     */
+    patch: (overrides: UpdatePayload) => void;
+
+    /** Hard reset of the in-memory working copy to the last saved state. */
+    reset: () => void;
+}
+
+interface LoadedContent {
+    raw: string;
+    blocks: readonly unknown[];
+}
+
+function isEntityContent(value: unknown): value is LoadedContent {
+    return (
+        typeof value === 'object' &&
+        value !== null &&
+        'blocks' in value &&
+        Array.isArray((value as { blocks: unknown }).blocks)
+    );
+}
+
+/**
+ * Hydrate a raw-serialized block tree into BlockInstances Gutenberg can
+ * render. Prefers `content.raw` (the canonical Gutenberg HTML form —
+ * guarantees fresh `clientId`s) and only falls back to the parsed
+ * `blocks` array when raw is empty. This matches what the legacy
+ * post-editor's `use-persistence` does for its response shape.
+ */
+function hydrateBlocks(content: LoadedContent): BlockInstance[] {
+    const raw = typeof content.raw === 'string' ? content.raw.trim() : '';
+
+    if (raw !== '') {
+        return parse(raw);
+    }
+
+    // No raw serialization — trust the parsed array. `parse()` cannot run
+    // against an already-parsed tree, so cast through `BlockInstance` and
+    // let Gutenberg regenerate missing metadata when it renders.
+    return content.blocks as BlockInstance[];
+}
+
+export function useEntityEditor<K extends EntityKind>(
+    options: UseEntityEditorOptions<K>
+): UseEntityEditorResult<K> {
+    const { apiConfig, kind, entityId } = options;
+
+    const [entity, setEntity] = useState<EntityRecord<K> | null>(null);
+    const [loadStatus, setLoadStatus] = useState<EntityLoadStatus>('idle');
+    const [loadErrorMessage, setLoadErrorMessage] = useState<string | null>(null);
+
+    const [blocks, setBlocksState] = useState<readonly unknown[]>([]);
+    const [pendingPatch, setPendingPatch] = useState<UpdatePayload>({});
+    const [isDirty, setIsDirty] = useState<boolean>(false);
+
+    const [saveStatus, setSaveStatus] = useState<SaveStatus>('idle');
+    const [saveErrorMessage, setSaveErrorMessage] = useState<string | null>(null);
+    const [validationErrors, setValidationErrors] = useState<ValidationErrors | null>(null);
+    const [lastSavedAt, setLastSavedAt] = useState<Date | null>(null);
+
+    const requestCounterRef = useRef(0);
+
+    // Snapshot of the last committed blocks so we can distinguish "user
+    // typed then undid" from "user typed" without comparing trees.
+    const committedBlocksRef = useRef<readonly unknown[]>([]);
+
+    const hydrateFromRecord = useCallback((record: EntityRecord<K>): void => {
+        const nextBlocks = isEntityContent(record.content)
+            ? hydrateBlocks(record.content)
+            : [];
+
+        committedBlocksRef.current = nextBlocks;
+        setEntity(record);
+        setBlocksState(nextBlocks);
+        setPendingPatch({});
+        setIsDirty(false);
+        setValidationErrors(null);
+    }, []);
+
+    useEffect(() => {
+        if (entityId === null) {
+            committedBlocksRef.current = [];
+            setEntity(null);
+            setBlocksState([]);
+            setPendingPatch({});
+            setIsDirty(false);
+            setLoadStatus('idle');
+            setLoadErrorMessage(null);
+            setSaveStatus('idle');
+            setSaveErrorMessage(null);
+            setValidationErrors(null);
+            setLastSavedAt(null);
+            return;
+        }
+
+        const requestId = ++requestCounterRef.current;
+
+        setLoadStatus('loading');
+        setLoadErrorMessage(null);
+
+        void (async () => {
+            try {
+                const record = await fetchEntity(apiConfig, kind, entityId);
+
+                if (requestCounterRef.current !== requestId) {
+                    return;
+                }
+
+                hydrateFromRecord(record);
+                setLoadStatus('ready');
+            } catch (error: unknown) {
+                if (requestCounterRef.current !== requestId) {
+                    return;
+                }
+
+                const message =
+                    error instanceof SiteEditorApiError
+                        ? error.message
+                        : 'Failed to load entity.';
+
+                setEntity(null);
+                setBlocksState([]);
+                setLoadStatus('error');
+                setLoadErrorMessage(message);
+            }
+        })();
+    }, [apiConfig, kind, entityId, hydrateFromRecord]);
+
+    // Read the latest `pendingPatch` from inside `setBlocks` without
+    // re-creating the callback on every keystroke — reading from state
+    // directly would force a new `setBlocks` identity each render and
+    // thrash BlockEditorProvider's memoized handlers.
+    const pendingPatchRef = useRef<UpdatePayload>({});
+    pendingPatchRef.current = pendingPatch;
+
+    const setBlocks = useCallback((next: readonly unknown[]): void => {
+        setBlocksState((prev) => {
+            // BlockEditorProvider calls `onInput` / `onChange` with the
+            // same reference when nothing changed; short-circuit to avoid
+            // flipping the dirty flag on every mouse move.
+            if (prev === next) {
+                return prev;
+            }
+
+            if (next === committedBlocksRef.current) {
+                // User undid every block edit back to the saved tree —
+                // clear the dirty flag unless a pending field override
+                // (slug / title / area / …) is still outstanding.
+                if (Object.keys(pendingPatchRef.current).length === 0) {
+                    setIsDirty(false);
+                }
+            } else {
+                setIsDirty(true);
+            }
+
+            return next;
+        });
+    }, []);
+
+    const patch = useCallback((overrides: UpdatePayload): void => {
+        setPendingPatch((prev) => ({ ...prev, ...overrides }));
+        setIsDirty(true);
+    }, []);
+
+    const reset = useCallback((): void => {
+        setBlocksState(committedBlocksRef.current);
+        setPendingPatch({});
+        setIsDirty(false);
+        setValidationErrors(null);
+    }, []);
+
+    const save = useCallback(
+        async (overrides: UpdatePayload = {}): Promise<EntityRecord<K> | null> => {
+            if (entityId === null) {
+                return null;
+            }
+
+            // Serialize the in-memory `BlockInstance` tree back to the raw
+            // Gutenberg string so the backend and the canonical re-hydration
+            // stay aligned. `blocks` stays alongside raw for consumers that
+            // want the parsed form without re-running `parse()`.
+            const blockInstances = blocks as BlockInstance[];
+            const raw = serialize(blockInstances);
+
+            const payload: UpdatePayload = {
+                ...pendingPatch,
+                ...overrides,
+                content: {
+                    raw,
+                    blocks,
+                },
+            };
+
+            setSaveStatus('saving');
+            setSaveErrorMessage(null);
+            setValidationErrors(null);
+
+            try {
+                const updated = await updateEntity(apiConfig, kind, entityId, payload);
+
+                hydrateFromRecord(updated);
+                setSaveStatus('saved');
+                setLastSavedAt(new Date());
+
+                return updated;
+            } catch (error: unknown) {
+                if (error instanceof SiteEditorApiError) {
+                    setSaveStatus('error');
+                    setSaveErrorMessage(error.message);
+                    setValidationErrors(error.validationErrors);
+                } else {
+                    setSaveStatus('error');
+                    setSaveErrorMessage('Failed to save.');
+                }
+
+                return null;
+            }
+        },
+        [apiConfig, blocks, entityId, hydrateFromRecord, kind, pendingPatch]
+    );
+
+    return {
+        entity,
+        loadStatus,
+        loadErrorMessage,
+        blocks,
+        setBlocks,
+        isDirty,
+        saveStatus,
+        saveErrorMessage,
+        validationErrors,
+        lastSavedAt,
+        save,
+        patch,
+        reset,
+    };
+}

--- a/resources/js/visual-editor/site-editor/use-entity-list.ts
+++ b/resources/js/visual-editor/site-editor/use-entity-list.ts
@@ -1,0 +1,153 @@
+/**
+ * Paginated list hook for site-editor entities.
+ *
+ * Handles the `{ data, meta }` envelope the C1/C2 REST endpoints return,
+ * tracks load/error status, and exposes a `refresh` callback so callers
+ * can force a re-fetch after a create/update/delete. The hook deliberately
+ * does not cache across mounts — the site-editor browses one section at a
+ * time and the relative cost of refetching a list on re-open is negligible
+ * compared to the complexity of invalidation.
+ */
+
+import { __ } from '@wordpress/i18n';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { TEXT_DOMAIN } from '../vendor/i18n';
+
+import {
+    listEntities,
+    SiteEditorApiError,
+    type EntityKind,
+    type EntityRecord,
+    type ListParams,
+    type PaginatedResponse,
+    type SiteEditorApiConfig,
+} from './api-client';
+
+export type EntityListStatus = 'idle' | 'loading' | 'ready' | 'error';
+
+export interface UseEntityListOptions<K extends EntityKind> extends ListParams {
+    apiConfig: SiteEditorApiConfig;
+    kind: K;
+    /**
+     * When `false`, the hook skips its initial fetch. Callers flip this
+     * to `true` once prerequisites (e.g. apiBase being wired) are ready.
+     * Defaults to `true` so the common path stays ergonomic.
+     */
+    enabled?: boolean;
+    /**
+     * Bump to force a re-fetch (e.g. after a sibling creates or deletes
+     * a record). Any change to this value re-runs the list query with
+     * the current filters. Omit when the hook's own filter state is the
+     * only re-fetch trigger.
+     */
+    refreshKey?: number;
+}
+
+export interface UseEntityListResult<K extends EntityKind> {
+    items: readonly EntityRecord<K>[];
+    meta: PaginatedResponse<EntityRecord<K>>['meta'] | null;
+    status: EntityListStatus;
+    errorMessage: string | null;
+    /** Re-fetches the current page with the same filters. */
+    refresh: () => Promise<void>;
+    /** Swaps the active page and triggers a fetch. */
+    setPage: (page: number) => void;
+    page: number;
+}
+
+export function useEntityList<K extends EntityKind>(
+    options: UseEntityListOptions<K>
+): UseEntityListResult<K> {
+    const {
+        apiConfig,
+        kind,
+        enabled = true,
+        perPage,
+        theme,
+        slug,
+        status: statusFilter,
+        area,
+        page: initialPage = 1,
+        refreshKey = 0,
+    } = options;
+
+    const [items, setItems] = useState<readonly EntityRecord<K>[]>([]);
+    const [meta, setMeta] = useState<PaginatedResponse<EntityRecord<K>>['meta'] | null>(null);
+    const [status, setStatus] = useState<EntityListStatus>(enabled ? 'loading' : 'idle');
+    const [errorMessage, setErrorMessage] = useState<string | null>(null);
+    const [page, setPage] = useState<number>(initialPage);
+
+    // Track the most recent request so late-arriving responses can't
+    // overwrite newer state (e.g. user types fast in a filter field).
+    const requestCounterRef = useRef(0);
+
+    const fetchList = useCallback(async (): Promise<void> => {
+        if (!enabled) {
+            return;
+        }
+
+        const requestId = ++requestCounterRef.current;
+
+        setStatus('loading');
+        setErrorMessage(null);
+
+        try {
+            const response = await listEntities(apiConfig, kind, {
+                perPage,
+                theme,
+                slug,
+                status: statusFilter,
+                area,
+                page,
+            });
+
+            if (requestCounterRef.current !== requestId) {
+                return;
+            }
+
+            setItems(response.data);
+            setMeta(response.meta);
+            setStatus('ready');
+        } catch (error: unknown) {
+            if (requestCounterRef.current !== requestId) {
+                return;
+            }
+
+            const message =
+                error instanceof SiteEditorApiError
+                    ? error.message
+                    : __('Failed to load entities.', TEXT_DOMAIN);
+
+            setItems([]);
+            setMeta(null);
+            setErrorMessage(message);
+            setStatus('error');
+        }
+    }, [
+        apiConfig,
+        enabled,
+        kind,
+        perPage,
+        theme,
+        slug,
+        statusFilter,
+        area,
+        page,
+        refreshKey,
+    ]);
+
+    useEffect(() => {
+        void fetchList();
+    }, [fetchList]);
+
+    return {
+        items,
+        meta,
+        status,
+        errorMessage,
+        refresh: fetchList,
+        setPage,
+        page,
+    };
+}

--- a/resources/views/site-editor/index.blade.php
+++ b/resources/views/site-editor/index.blade.php
@@ -3,6 +3,10 @@
 <head>
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	{{-- CSRF token for the site-editor's mutating REST requests; the
+	     React client reads this meta tag and forwards it as the
+	     `X-CSRF-TOKEN` header on POST/PUT/DELETE calls. --}}
+	<meta name="csrf-token" content="{{ csrf_token() }}">
 	<title>ArtisanPack Visual Editor — Site Editor</title>
 	@viteReactRefresh
 	{{-- D1 (#368). Site-editor shell entry. Mounts the SPA into the
@@ -17,6 +21,8 @@
 		data-ap-site-editor
 		data-route-base="/visual-editor/site"
 		data-post-editor-url="{{ route('visual-editor.editor') }}"
+		data-api-base="/visual-editor/api"
+		data-theme="{{ config('artisanpack.visual-editor.global_styles.theme', 'default') }}"
 	></div>
 </body>
 </html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -23,8 +23,17 @@ Route::get('/ve-sandbox', function () {
 // hands routing inside the shell to the React app via `history.pushState`.
 // Sub-paths the SPA recognises: `templates`, `template-parts`, `patterns`,
 // `styles`, `navigation` (each optionally followed by an entity id).
-Route::get('/visual-editor/site/{path?}', function () {
-    return view('visual-editor::site-editor.index');
-})
-    ->where('path', '.*')
-    ->name('visual-editor.site-editor');
+//
+// `web` middleware is applied explicitly: `loadRoutesFrom()` does not
+// attach it by default, and without a session on the SPA page load the
+// `csrf_token()` helper in the blade returns a token that isn't tied to
+// any session cookie — which makes the first REST mutation (CREATE,
+// PUT) fail with "CSRF token mismatch" (D2 #369).
+Route::middleware('web')
+    ->group(function (): void {
+        Route::get('/visual-editor/site/{path?}', function () {
+            return view('visual-editor::site-editor.index');
+        })
+            ->where('path', '.*')
+            ->name('visual-editor.site-editor');
+    });


### PR DESCRIPTION
## Description

Wires the Templates and Template Parts sections into the D1 site-editor shell: list views in the navigator-outlet, open-in-canvas editing, save via the C1/C2 REST endpoints, and a reused A1 inspector with kind-specific Document panels. Implements design brief §3.4, §3.5, §5.1, §5.5 and principles P7 (visible fallback chains) + P9 (destructive confirmations).

**Closes:** #369

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #369

## Motivation and Context

C1 (#357) and C2 (#358) landed the REST endpoints. D1 (#368) landed the shell. D2 is the surface users actually touch — without it, templates and parts exist on disk but can't be edited.

## Changes Made

**Frontend — `resources/js/visual-editor/site-editor/`:**
- `api-client.ts` — typed REST client for templates + parts, handling CSRF, 422 validation-error extraction, and the paginated list envelope
- `use-entity-list.ts` / `use-entity-editor.ts` — list + single-entity hooks with dirty tracking, save/load status, and refresh signals
- `entity-browser.tsx` — shared navigator-sub-panel list with filter chips and row-level keyboard navigation (roving tabindex)
- `entity-editor-canvas.tsx` — `BlockList` / `WritingFlow` / `BlockTools` editor surface with screen-reader announcement
- `entity-editor.tsx` — stitches canvas + inspector, bubbles save state to the top bar
- `templates-section.tsx` / `template-parts-section.tsx` — kind-specific browsers, Document panels, and create-new dialogs (slug picker with fallback-chain preview for templates, area selector for parts)
- `create-entity-dialog.tsx` — focus-trapping dialog shell with accessible form controls + custom-styled native select
- `fallback-chain.ts` — pure client-side mirror of the PHP resolver
- `slug.ts` — live input normalizer (lowercase + space→dash)

**Shell wiring (`site-editor-app.tsx`):**
- Registers core blocks on boot, then unregisters the D2 out-of-scope entity blocks (`core/template-part`, `core/post-*`, `core/site-*`, `core/query`, `core/navigation`, etc.) so seeded templates that embed them don't trip the block-crash boundary. E4 re-enables them with real core-data selectors.
- Threads `apiBase` / `theme` from the blade through the React mount.
- Lifts per-section refresh counters so the navigator list refetches after a successful create.
- Owns the top-bar Save handler and dirty indicator, bound to whichever entity editor is mounted.

**Backend:**
- `routes/web.php` — wraps the SPA mount in the `web` middleware group so Laravel starts a session and the CSRF token in the blade matches the session when the API mutation requests land.
- `resources/views/site-editor/index.blade.php` — passes `data-api-base`, `data-theme`, and a `<meta name="csrf-token">` tag to the SPA.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (darwin 25.3.0)
- Browser: Safari (via Laravel Herd)
- PHP Version: 8.4.3
- Project Version: 1.0.0-spike

**Tests Performed:**
1. Opened each of the 4 seeded templates (404, index, page, single) — blocks render correctly; embedded `core/template-part` blocks render as "block not registered" placeholders (expected for D2).
2. Edited block content → dirty indicator appears in the top bar and canvas header; Save PUT fires against `/visual-editor/api/templates/{id}`; status cycles saving → saved; dirty clears.
3. Created new templates (both predefined kinds and custom slugs) — POST fires, new record appears in the navigator list without a page reload, URL updates and the new template opens in the canvas.
4. Repeated the flow for Template Parts: 3 seeded parts list with their area badges; area filter chips refetch the list; create-new dialog enforces slug + area up front.
5. Validation errors: intentionally collided with an existing slug → 422 response surfaces inline; slug errors now render regardless of the selected kind.
6. Slug normalization: typing "My Slug!" in the custom-slug field lands as `my-slug!` in real time.

## Accessibility Tests Run

- [x] Keyboard navigation tested
- [x] ARIA labels checked
- [ ] Screen reader tested (spot-checked `aria-live` announcements in code; not run in a real screen reader)
- [ ] Color contrast verified (default palette inherits DaisyUI tokens; no custom colors introduced)

**Details:**
- Navigator tablist and row list both implement roving-tabindex keyboard navigation (Up/Down/Home/End).
- Create-new dialog implements WAI-ARIA dialog pattern: focus trap, Esc closes, initial focus lands on first control.
- Entity canvas emits an `aria-live="polite"` "Editing {title}" announcement on open.
- Filter chips, create button, and retry button all have `:focus-visible` focus rings.
- All inputs/selects/textareas in the dialog and inspector share a consistent focus outline.

## Tests Added

- [x] Unit tests added/updated
- [x] All tests passing

**Test details:**
79 site-editor JS tests total (up from 51 pre-D2):
- `api-client.test.ts` — list/fetch/create/update/delete + CSRF + 422 extraction (8 tests)
- `use-entity-editor.test.tsx` — load, dirty tracking, save success + validation error, idle-on-null (5 tests)
- `entity-browser.test.tsx` — loading/ready/empty/error states, row open, chip filter refetch (6 tests)
- `entity-editor.test.tsx` — inactive state, load + announcement, dirty flag, save clears dirty (4 tests)
- `create-entity-dialog.test.tsx` — template and template-part dialog submit paths + validation error display (4 tests)
- `fallback-chain.test.ts` — PHP resolver parity (7 tests)
- Updated `main.test.tsx` + `site-editor-app.test.tsx` for the new required `apiBase` prop and D2 module stubs.

All 626 JS tests pass (`npm test`); all 341 PHP tests pass (`vendor/bin/pest`); `npm run build` succeeds.

## Documentation

- [x] Inline code documentation added
- [ ] README updated (no user-facing API changes yet; will be covered by the rescoped docs ticket #325)
- [ ] Wiki updated
- [ ] API documentation updated

**Documentation details:**
Every new module has a file-level docblock explaining its role and how it connects to the D0 design brief / D1 shell. Non-obvious decisions (e.g., `appearance: none` on the select, `!important` on WordPress-overridden resets, the deliberate `D2_DISABLED_BLOCKS` list mirroring the PHP config) are commented inline.

## Screenshots

N/A — the UX matches the design brief's navigator-sub-panel list + canvas-edit + right-rail inspector layout.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted (CodeRabbit CLI run against `release/1.0`, 3 passes)
- [x] Accessibility tests completed
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full site editor: create/list/edit templates and template-parts with canvas, inspector, create dialogs, fallback-chain preview, slug normalization, area selection, and keyboard-accessible entity browser. Top-bar save reflects dirty/saving/saved states.

* **Bug Fixes**
  * Client receives CSRF token and API base via page metadata; routing/middleware adjusted to ensure valid session/CSRF for REST mutations.

* **Tests**
  * Extensive test coverage added for API, dialogs, browsers, hooks, and editor behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->