### PR TITLE
feat: D3 global styles UI (typography, colors, layout, blocks, elements, variations)

### DIFF
--- a/resources/js/visual-editor/site-editor/__tests__/site-editor-app.test.tsx
+++ b/resources/js/visual-editor/site-editor/__tests__/site-editor-app.test.tsx
@@ -63,6 +63,21 @@ vi.mock('../entity-editor', () => ({
     }),
 }));
 
+// D3 mounts the styles section inside the shell; the shell tests only
+// care that the navigator routes to it, not the global-styles fetch
+// chain. The styles-section test file exercises the hook end-to-end.
+vi.mock('../styles/styles-section', () => ({
+    useStylesSectionViews: (): {
+        navigator: JSX.Element;
+        canvas: JSX.Element;
+        inspector: JSX.Element;
+    } => ({
+        navigator: <div data-testid="ap-site-editor-stub-styles-navigator" />,
+        canvas: <div data-testid="ap-site-editor-stub-styles-canvas" />,
+        inspector: <div data-testid="ap-site-editor-stub-styles-inspector" />,
+    }),
+}));
+
 import { SiteEditorApp } from '../site-editor-app';
 
 const ROUTE_BASE = '/visual-editor/site';

--- a/resources/js/visual-editor/site-editor/site-editor-app.tsx
+++ b/resources/js/visual-editor/site-editor/site-editor-app.tsx
@@ -44,6 +44,7 @@ import {
     TemplatePartCreateDialog,
     TemplatePartsBrowser,
 } from './template-parts-section';
+import { useStylesSectionViews } from './styles/styles-section';
 import { usePersistedToggle } from './use-persisted-toggle';
 import { useSiteEditorRouting } from './use-site-editor-routing';
 import { TopBar } from '../editor/top-bar';
@@ -70,6 +71,14 @@ const IDLE_ENTITY_STATE: EntityEditorState = {
 const D2_SECTIONS: ReadonlySet<SiteEditorSectionId> = new Set([
     'templates',
     'template-parts',
+]);
+
+/**
+ * Section ids D3 (#370) ships — the Styles section mounts the
+ * global-styles UI instead of the placeholder outlet.
+ */
+const D3_SECTIONS: ReadonlySet<SiteEditorSectionId> = new Set<SiteEditorSectionId>([
+    'styles',
 ]);
 
 export interface SiteEditorAppProps {
@@ -191,6 +200,7 @@ export function SiteEditorApp(props: SiteEditorAppProps): JSX.Element {
 
     const activeEntityId = routing.entityId;
     const isD2Section = D2_SECTIONS.has(activeSection.id);
+    const isD3Section = D3_SECTIONS.has(activeSection.id);
     const activeKind = sectionKind(activeSection.id);
 
     // Effective kind passed to the editor hook — always a real value so
@@ -209,11 +219,26 @@ export function SiteEditorApp(props: SiteEditorAppProps): JSX.Element {
         []
     );
 
+    // Swap in a no-op receiver for the hook that isn't driving the shell
+    // on this render so the active hook has sole ownership of the entity-
+    // state slot. Without this both hooks would fight over the slot and
+    // one would keep resetting it to idle.
+    const noopStateChange = useCallback(
+        (_state: EntityEditorState): void => undefined,
+        []
+    );
+
     const editorViews = useEntityEditorViews({
         apiConfig,
         kind: editorKind,
         entityId: editorEntityId,
-        onStateChange: handleEntityStateChange,
+        onStateChange: isD3Section ? noopStateChange : handleEntityStateChange,
+    });
+
+    const stylesViews = useStylesSectionViews({
+        apiConfig,
+        enabled: isD3Section,
+        onStateChange: isD3Section ? handleEntityStateChange : noopStateChange,
     });
 
     const [dialogKind, setDialogKind] = useState<EntityKind | null>(null);
@@ -237,17 +262,14 @@ export function SiteEditorApp(props: SiteEditorAppProps): JSX.Element {
         );
     }, [activeSection.label]);
 
-    // Reset cached entity state when leaving a D2 section so a
-    // subsequent re-entry doesn't surface stale save-status chrome.
-    // Switches between D2 sections (templates ↔ template-parts) are
-    // handled by the entity-editor hook itself: when its `entityId`
-    // resets to `null`, it dispatches an idle `onStateChange` that
-    // clears our cached state through the normal path.
+    // Reset cached entity state whenever the active section changes so
+    // a previous section's save-status chrome never lingers in the top
+    // bar. Each section's hook then dispatches its own fresh state on
+    // the next render — D2's entity-editor when an entity loads, D3's
+    // global-styles hook when `/lookup` resolves.
     useEffect(() => {
-        if (!isD2Section) {
-            setEntityState(IDLE_ENTITY_STATE);
-        }
-    }, [isD2Section]);
+        setEntityState(IDLE_ENTITY_STATE);
+    }, [activeSection.id]);
 
     const handleSelectSection = useCallback(
         (sectionId: typeof activeSection.id): void => {
@@ -412,6 +434,8 @@ export function SiteEditorApp(props: SiteEditorAppProps): JSX.Element {
                 refreshKey={partsRefreshKey}
             />
         );
+    } else if (isD3Section) {
+        navigatorChildren = stylesViews.navigator;
     } else {
         navigatorChildren = (
             <SectionOutlet
@@ -429,7 +453,7 @@ export function SiteEditorApp(props: SiteEditorAppProps): JSX.Element {
             data-navigator-open={navigatorOpen}
             data-inspector-open={inspectorOpen}
             data-active-section={activeSection.id}
-            data-has-entity={showEntityEditor}
+            data-has-entity={showEntityEditor || isD3Section}
             data-testid="ap-site-editor-shell"
         >
             <TopBar
@@ -479,6 +503,14 @@ export function SiteEditorApp(props: SiteEditorAppProps): JSX.Element {
                     >
                         {editorViews.canvas}
                     </div>
+                ) : isD3Section ? (
+                    <div
+                        className="ap-site-editor__canvas"
+                        data-has-entity="true"
+                        data-testid="ap-site-editor-canvas"
+                    >
+                        {stylesViews.canvas}
+                    </div>
                 ) : (
                     <CanvasFrame
                         sectionLabel={activeSection.modeLabel}
@@ -489,6 +521,8 @@ export function SiteEditorApp(props: SiteEditorAppProps): JSX.Element {
                     <div className="ap-site-editor__sidebar ap-site-editor__sidebar--inspector">
                         {showEntityEditor ? (
                             editorViews.inspector
+                        ) : isD3Section ? (
+                            stylesViews.inspector
                         ) : (
                             <InspectorOutlet sectionLabel={activeSection.label} />
                         )}

--- a/resources/js/visual-editor/site-editor/styles/__tests__/styles-section.test.tsx
+++ b/resources/js/visual-editor/site-editor/styles/__tests__/styles-section.test.tsx
@@ -1,0 +1,757 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {
+    afterEach,
+    beforeEach,
+    describe,
+    expect,
+    it,
+    vi,
+} from 'vitest';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { dispatch, select } from '@wordpress/data';
+
+// Force the core-data shim to load + register its `core` store. In the
+// real runtime Gutenberg's block-editor bundle imports `@wordpress/core-data`
+// (aliased to the shim) and that side-effect runs on module load; the
+// styles tests mock Gutenberg out so the shim needs an explicit import
+// to register before `dispatch('core')` returns a functioning store.
+import '@wordpress/core-data';
+
+import type { SiteEditorApiConfig } from '../../api-client';
+import type { EntityEditorState } from '../../entity-editor';
+import { useStylesSectionViews } from '../styles-section';
+
+type CoreSelect = Record<string, (...args: unknown[]) => unknown>;
+type CoreDispatch = Record<string, (...args: unknown[]) => unknown>;
+
+const coreSelect = (): CoreSelect => select('core') as CoreSelect;
+const coreDispatch = (): CoreDispatch => dispatch('core') as CoreDispatch;
+
+const API: SiteEditorApiConfig = { apiBase: '/visual-editor/api' };
+
+const DEFAULT_BASE = {
+    version: 3,
+    settings: {
+        color: {
+            palette: [
+                { slug: 'primary', name: 'Primary', color: '#3b82f6' },
+                { slug: 'contrast', name: 'Contrast', color: '#111827' },
+            ],
+        },
+        typography: {
+            fontFamilies: [
+                {
+                    slug: 'sans',
+                    name: 'Sans',
+                    fontFamily: "'Inter', sans-serif",
+                },
+                {
+                    slug: 'serif',
+                    name: 'Serif',
+                    fontFamily: "'Source Serif 4', Georgia, serif",
+                },
+            ],
+            fontSizes: [
+                { slug: 'medium', name: 'Medium', size: '1rem' },
+            ],
+        },
+        layout: { contentSize: '720px', wideSize: '1120px' },
+    },
+    styles: {
+        color: {
+            background: 'var(--wp--preset--color--contrast)',
+            text: 'var(--wp--preset--color--primary)',
+        },
+        typography: {
+            fontFamily: 'var(--wp--preset--font-family--sans)',
+            fontSize: 'var(--wp--preset--font-size--medium)',
+            lineHeight: '1.6',
+        },
+        elements: {
+            link: {
+                color: {
+                    text: 'var(--wp--preset--color--primary)',
+                },
+            },
+        },
+        blocks: {
+            'core/button': {
+                color: {
+                    background: 'var(--wp--preset--color--primary)',
+                },
+                border: { radius: '0.5rem' },
+            },
+        },
+    },
+    variations: [
+        {
+            slug: 'light',
+            title: 'Light',
+            settings: {},
+            styles: { color: { background: '#ffffff' } },
+        },
+        {
+            slug: 'dark',
+            title: 'Dark',
+            settings: {},
+            styles: { color: { background: '#000000' } },
+        },
+    ],
+};
+
+const DEFAULT_RECORD = {
+    id: 7,
+    version: 3,
+    settings: DEFAULT_BASE.settings,
+    styles: DEFAULT_BASE.styles,
+};
+
+const BLOCKS_RESPONSE = {
+    blocks: [
+        { name: 'core/button', title: 'Button' },
+        { name: 'core/heading', title: 'Heading' },
+    ],
+};
+
+interface CallRecord {
+    url: string;
+    method: string;
+    body: unknown;
+}
+
+type ResponseFactory = (body: CallRecord['body']) => Response;
+
+interface HarnessHandlers {
+    onUpdate?: (payload: unknown) => Response;
+}
+
+function installFetchStub(
+    handlers: HarnessHandlers = {}
+): { calls: CallRecord[]; restore: () => void } {
+    const calls: CallRecord[] = [];
+    const jsonResponse: ResponseFactory = () =>
+        new Response(JSON.stringify(DEFAULT_RECORD), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+        });
+
+    const fetcher = vi.fn(
+        async (input: RequestInfo | URL, init?: RequestInit) => {
+            const url =
+                typeof input === 'string' ? input : input.toString();
+            const method =
+                init?.method?.toUpperCase() ??
+                (typeof input === 'object' &&
+                'method' in input &&
+                typeof input.method === 'string'
+                    ? input.method.toUpperCase()
+                    : 'GET');
+            let parsedBody: unknown = null;
+            const rawBody = init?.body;
+
+            if (typeof rawBody === 'string' && rawBody !== '') {
+                try {
+                    parsedBody = JSON.parse(rawBody);
+                } catch {
+                    parsedBody = rawBody;
+                }
+            }
+
+            calls.push({ url, method, body: parsedBody });
+
+            if (url.includes('/global-styles/lookup')) {
+                return new Response(JSON.stringify({ id: 7 }), {
+                    status: 200,
+                    headers: { 'Content-Type': 'application/json' },
+                });
+            }
+
+            if (url.includes('/global-styles/base')) {
+                return new Response(JSON.stringify(DEFAULT_BASE), {
+                    status: 200,
+                    headers: { 'Content-Type': 'application/json' },
+                });
+            }
+
+            if (url.includes('/global-styles/7') && method === 'PUT') {
+                return (
+                    handlers.onUpdate?.(parsedBody) ??
+                    new Response(JSON.stringify(DEFAULT_RECORD), {
+                        status: 200,
+                        headers: { 'Content-Type': 'application/json' },
+                    })
+                );
+            }
+
+            if (url.includes('/global-styles/')) {
+                return jsonResponse(parsedBody);
+            }
+
+            if (url.endsWith('/blocks')) {
+                return new Response(JSON.stringify(BLOCKS_RESPONSE), {
+                    status: 200,
+                    headers: { 'Content-Type': 'application/json' },
+                });
+            }
+
+            return new Response('not found', { status: 404 });
+        }
+    );
+
+    const original = global.fetch;
+    global.fetch = fetcher as unknown as typeof fetch;
+
+    return {
+        calls,
+        restore: () => {
+            global.fetch = original;
+        },
+    };
+}
+
+interface HarnessProps {
+    enabled?: boolean;
+    onState?: (state: EntityEditorState) => void;
+}
+
+function Harness(props: HarnessProps): JSX.Element {
+    const { enabled = true, onState } = props;
+    const [state, setState] = useState<EntityEditorState | null>(null);
+
+    // Stash the observer in a ref so we can pass a stable onStateChange
+    // down into the hook — otherwise every Harness render creates a new
+    // callback identity, the hook's own onStateChange-watching effect
+    // re-fires, setState, re-render, infinite loop.
+    const onStateRef = useRef<HarnessProps['onState']>(onState);
+    onStateRef.current = onState;
+
+    const handleStateChange = useCallback(
+        (next: EntityEditorState): void => {
+            setState(next);
+            onStateRef.current?.(next);
+        },
+        []
+    );
+
+    const { navigator, canvas, inspector } = useStylesSectionViews({
+        apiConfig: API,
+        enabled,
+        onStateChange: handleStateChange,
+    });
+
+    useEffect(() => {
+        // Render latest entity state as an attribute so tests can read it
+        // without reaching into the top-bar chrome.
+        if (state !== null) {
+            document.body.setAttribute(
+                'data-entity-state',
+                JSON.stringify({
+                    isDirty: state.isDirty,
+                    saveStatus: state.saveStatus,
+                    entityId: state.entityId,
+                })
+            );
+        }
+    }, [state]);
+
+    return (
+        <div data-testid="styles-harness">
+            <aside data-testid="harness-navigator">{navigator}</aside>
+            <main data-testid="harness-canvas">{canvas}</main>
+            <aside data-testid="harness-inspector">{inspector}</aside>
+        </div>
+    );
+}
+
+let fetchStub: ReturnType<typeof installFetchStub>;
+
+beforeEach(() => {
+    coreDispatch().reset();
+    fetchStub = installFetchStub();
+});
+
+afterEach(() => {
+    fetchStub.restore();
+    coreDispatch().reset();
+    document.body.removeAttribute('data-entity-state');
+});
+
+describe('useStylesSectionViews — bootstrap', () => {
+    it('dispatches receiveCurrentGlobalStylesId and receiveGlobalStylesBase on mount', async () => {
+        render(<Harness />);
+
+        await waitFor(() => {
+            expect(
+                coreSelect().__experimentalGetCurrentGlobalStylesId()
+            ).toBe(7);
+        });
+
+        expect(
+            coreSelect().__experimentalGlobalStylesBaseStyles()
+        ).toMatchObject({
+            version: 3,
+            settings: expect.anything(),
+            styles: expect.anything(),
+        });
+    });
+
+    it('renders the six panel-root nodes in the navigator', async () => {
+        render(<Harness />);
+
+        await waitFor(() =>
+            expect(
+                screen.getByTestId('ap-site-editor-styles-nav-typography')
+            ).toBeInTheDocument()
+        );
+
+        expect(
+            screen.getByTestId('ap-site-editor-styles-nav-typography')
+        ).toBeInTheDocument();
+        expect(
+            screen.getByTestId('ap-site-editor-styles-nav-colors')
+        ).toBeInTheDocument();
+        expect(
+            screen.getByTestId('ap-site-editor-styles-nav-layout')
+        ).toBeInTheDocument();
+        expect(
+            screen.getByTestId('ap-site-editor-styles-nav-blocks')
+        ).toBeInTheDocument();
+        expect(
+            screen.getByTestId('ap-site-editor-styles-nav-elements')
+        ).toBeInTheDocument();
+        expect(
+            screen.getByTestId('ap-site-editor-styles-nav-variations')
+        ).toBeInTheDocument();
+    });
+
+    it('skips fetching when enabled is false', async () => {
+        render(<Harness enabled={false} />);
+
+        // Allow micro-tasks to flush; fetch should remain idle.
+        await new Promise((resolve) => setTimeout(resolve, 10));
+
+        expect(fetchStub.calls.length).toBe(0);
+    });
+});
+
+describe('useStylesSectionViews — panels', () => {
+    it('mounts the typography panel by default', async () => {
+        render(<Harness />);
+
+        await waitFor(() =>
+            expect(
+                screen.getByTestId(
+                    'ap-site-editor-style-panel-typography'
+                )
+            ).toBeInTheDocument()
+        );
+    });
+
+    it('edits font family and marks the state dirty', async () => {
+        const onState = vi.fn();
+        const user = userEvent.setup();
+        render(<Harness onState={onState} />);
+
+        const select = (await screen.findByTestId(
+            'ap-site-editor-style-field-select-font-family'
+        )) as HTMLSelectElement;
+
+        // The default record ships font-family set to the "sans" preset;
+        // switching to "serif" writes a new CSS var ref and marks the
+        // editor dirty.
+        await user.selectOptions(
+            select,
+            'var(--wp--preset--font-family--serif)'
+        );
+
+        await waitFor(() => {
+            const last = onState.mock.calls.at(-1)?.[0] as EntityEditorState;
+            expect(last?.isDirty).toBe(true);
+        });
+    });
+
+    it('resets a customized value back to the base default', async () => {
+        const user = userEvent.setup();
+        render(<Harness />);
+
+        const select = (await screen.findByTestId(
+            'ap-site-editor-style-field-select-font-family'
+        )) as HTMLSelectElement;
+
+        await user.selectOptions(
+            select,
+            'var(--wp--preset--font-family--serif)'
+        );
+
+        const reset = await screen.findByTestId(
+            'ap-site-editor-style-field-reset-font-family'
+        );
+
+        await user.click(reset);
+
+        await waitFor(() =>
+            expect(select.value).toBe(
+                'var(--wp--preset--font-family--sans)'
+            )
+        );
+    });
+
+    it('switches to the Colors panel and adds a palette entry', async () => {
+        const user = userEvent.setup();
+        render(<Harness />);
+
+        await screen.findByTestId(
+            'ap-site-editor-style-panel-typography'
+        );
+
+        await user.click(
+            screen.getByTestId('ap-site-editor-styles-nav-colors')
+        );
+
+        await screen.findByTestId('ap-site-editor-style-panel-colors');
+
+        const before = screen.getAllByTestId(/ap-site-editor-style-palette-row-/);
+
+        await user.click(
+            screen.getByTestId('ap-site-editor-style-palette-add')
+        );
+
+        await waitFor(() => {
+            const rows = screen.getAllByTestId(
+                /ap-site-editor-style-palette-row-/
+            );
+            expect(rows.length).toBe(before.length + 1);
+        });
+    });
+
+    it('surfaces a duplicate-slug error when two palette entries share a slug', async () => {
+        const user = userEvent.setup();
+        render(<Harness />);
+
+        await user.click(
+            screen.getByTestId('ap-site-editor-styles-nav-colors')
+        );
+
+        const otherSlug = await screen.findByTestId(
+            'ap-site-editor-style-palette-slug-1'
+        );
+
+        // Force a duplicate of the first seeded palette slug ("primary").
+        // `fireEvent.change` replaces the value in one step — avoids the
+        // per-keystroke flicker through intermediate non-duplicate values
+        // that `user.type` causes on a controlled input.
+        fireEvent.change(otherSlug, { target: { value: 'primary' } });
+
+        await waitFor(() =>
+            expect(
+                screen.getByTestId('ap-site-editor-style-palette-error')
+            ).toBeInTheDocument()
+        );
+    });
+
+    it('switches to the Blocks panel and drills into a block detail', async () => {
+        const user = userEvent.setup();
+        render(<Harness />);
+
+        await user.click(
+            screen.getByTestId('ap-site-editor-styles-nav-blocks')
+        );
+
+        await waitFor(() =>
+            expect(
+                screen.getByTestId(
+                    'ap-site-editor-style-panel-blocks-index'
+                )
+            ).toBeInTheDocument()
+        );
+
+        const buttonEntry = await screen.findByTestId(
+            'ap-site-editor-styles-nav-block-core/button'
+        );
+
+        await user.click(buttonEntry);
+
+        await waitFor(() =>
+            expect(
+                screen.getByTestId(
+                    'ap-site-editor-style-panel-block-detail'
+                )
+            ).toBeInTheDocument()
+        );
+
+        expect(
+            screen
+                .getByTestId('ap-site-editor-styles-breadcrumb')
+                .textContent
+        ).toContain('Button');
+    });
+
+    it('switches to the Elements panel and drills into the Link element', async () => {
+        const user = userEvent.setup();
+        render(<Harness />);
+
+        await user.click(
+            screen.getByTestId('ap-site-editor-styles-nav-elements')
+        );
+
+        await screen.findByTestId(
+            'ap-site-editor-style-panel-elements-index'
+        );
+
+        await user.click(
+            screen.getByTestId('ap-site-editor-styles-nav-element-link')
+        );
+
+        await waitFor(() =>
+            expect(
+                screen.getByTestId(
+                    'ap-site-editor-style-panel-element-detail'
+                )
+            ).toBeInTheDocument()
+        );
+
+        expect(
+            screen
+                .getByTestId('ap-site-editor-styles-breadcrumb')
+                .textContent
+        ).toContain('Link');
+    });
+});
+
+describe('useStylesSectionViews — variations', () => {
+    it('lists theme variations on the canvas and applies one on click', async () => {
+        const user = userEvent.setup();
+        const onState = vi.fn();
+        render(<Harness onState={onState} />);
+
+        const lightVariation = await screen.findByTestId(
+            'ap-site-editor-style-book-variation-light'
+        );
+
+        await user.click(lightVariation);
+
+        await waitFor(() => {
+            const last = onState.mock.calls.at(-1)?.[0] as EntityEditorState;
+            expect(last?.isDirty).toBe(true);
+        });
+    });
+
+    it('shows an empty state when the base payload ships no variations', async () => {
+        // Swap the fetcher mid-test to return a base without variations.
+        fetchStub.restore();
+        const newStub = installFetchStub();
+        const originalFetch = global.fetch as unknown as typeof fetch;
+
+        global.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+            const url =
+                typeof input === 'string' ? input : input.toString();
+
+            if (url.includes('/global-styles/base')) {
+                const { variations: _variations, ...rest } = DEFAULT_BASE;
+
+                return new Response(JSON.stringify(rest), {
+                    status: 200,
+                    headers: { 'Content-Type': 'application/json' },
+                });
+            }
+
+            return originalFetch(input, init);
+        }) as unknown as typeof fetch;
+
+        fetchStub = newStub;
+
+        render(<Harness />);
+
+        await waitFor(() =>
+            expect(
+                screen.getByTestId(
+                    'ap-site-editor-style-book-no-variations'
+                )
+            ).toBeInTheDocument()
+        );
+    });
+});
+
+describe('useStylesSectionViews — save pipeline', () => {
+    it('issues a PUT and exits the dirty state on success', async () => {
+        const onState = vi.fn();
+        const user = userEvent.setup();
+        render(<Harness onState={onState} />);
+
+        const select = await screen.findByTestId(
+            'ap-site-editor-style-field-select-font-family'
+        );
+
+        await user.selectOptions(
+            select,
+            'var(--wp--preset--font-family--serif)'
+        );
+
+        // Trigger save via the hook state — our harness stashes it on the
+        // last onState call.
+        await waitFor(() => {
+            const last = onState.mock.calls.at(-1)?.[0] as EntityEditorState;
+            expect(last?.save).not.toBeNull();
+        });
+
+        const last = onState.mock.calls.at(-1)?.[0] as EntityEditorState;
+
+        await act(async () => {
+            await last.save?.();
+        });
+
+        await waitFor(() => {
+            const now = onState.mock.calls.at(-1)?.[0] as EntityEditorState;
+            expect(now?.saveStatus).toBe('saved');
+            expect(now?.isDirty).toBe(false);
+        });
+
+        const putCall = fetchStub.calls.find((call) => call.method === 'PUT');
+
+        expect(putCall).toBeDefined();
+        expect(putCall?.url).toContain('/global-styles/7');
+    });
+
+    it('renders a 422 validation error inline', async () => {
+        fetchStub.restore();
+        fetchStub = installFetchStub({
+            onUpdate: () =>
+                new Response(
+                    JSON.stringify({
+                        message:
+                            'The given data was invalid.',
+                        errors: {
+                            'styles.typography.fontFamily': [
+                                'Must be a CSS value.',
+                            ],
+                        },
+                    }),
+                    {
+                        status: 422,
+                        headers: { 'Content-Type': 'application/json' },
+                    }
+                ),
+        });
+
+        const onState = vi.fn();
+        const user = userEvent.setup();
+        render(<Harness onState={onState} />);
+
+        const select = await screen.findByTestId(
+            'ap-site-editor-style-field-select-font-family'
+        );
+
+        await user.selectOptions(
+            select,
+            'var(--wp--preset--font-family--serif)'
+        );
+
+        await waitFor(() => {
+            const last = onState.mock.calls.at(-1)?.[0] as EntityEditorState;
+            expect(last?.save).not.toBeNull();
+        });
+
+        const last = onState.mock.calls.at(-1)?.[0] as EntityEditorState;
+
+        await act(async () => {
+            await last.save?.();
+        });
+
+        await waitFor(() =>
+            expect(
+                screen.getByTestId(
+                    'ap-site-editor-style-field-error-font-family'
+                )
+            ).toBeInTheDocument()
+        );
+
+        expect(
+            screen.getByTestId('ap-site-editor-styles-save-error')
+        ).toBeInTheDocument();
+    });
+});
+
+describe('useStylesSectionViews — breadcrumb + accessibility', () => {
+    it('reflects the current scope in the breadcrumb', async () => {
+        const user = userEvent.setup();
+        render(<Harness />);
+
+        const crumb = await screen.findByTestId(
+            'ap-site-editor-styles-breadcrumb'
+        );
+
+        expect(crumb.textContent).toContain('Styles');
+        expect(crumb.textContent).toContain('Typography');
+
+        await user.click(
+            screen.getByTestId('ap-site-editor-styles-nav-colors')
+        );
+
+        await waitFor(() =>
+            expect(
+                screen.getByTestId('ap-site-editor-styles-breadcrumb')
+                    .textContent
+            ).toContain('Colors')
+        );
+    });
+
+    it('labels the navigator and variation picker for screen readers', async () => {
+        render(<Harness />);
+
+        const navigator = await screen.findByTestId(
+            'ap-site-editor-styles-navigator'
+        );
+        const variations = await screen.findByTestId(
+            'ap-site-editor-style-book-variations'
+        );
+
+        expect(navigator).toHaveAttribute('aria-label');
+        expect(variations).toHaveAttribute('role', 'radiogroup');
+        expect(variations).toHaveAttribute('aria-label');
+    });
+});
+
+describe('useStylesSectionViews — error handling', () => {
+    it('surfaces a load error when the lookup request fails', async () => {
+        fetchStub.restore();
+        const failingFetch = vi.fn(async (input: RequestInfo | URL) => {
+            const url = typeof input === 'string' ? input : input.toString();
+
+            if (url.includes('/global-styles/lookup')) {
+                return new Response('Server error', { status: 500 });
+            }
+
+            if (url.includes('/global-styles/base')) {
+                return new Response(JSON.stringify(DEFAULT_BASE), {
+                    status: 200,
+                    headers: { 'Content-Type': 'application/json' },
+                });
+            }
+
+            if (url.endsWith('/blocks')) {
+                return new Response(JSON.stringify(BLOCKS_RESPONSE), {
+                    status: 200,
+                    headers: { 'Content-Type': 'application/json' },
+                });
+            }
+
+            return new Response('not found', { status: 404 });
+        }) as unknown as typeof fetch;
+
+        const original = global.fetch;
+        global.fetch = failingFetch;
+        fetchStub = { calls: [], restore: () => (global.fetch = original) } as unknown as ReturnType<
+            typeof installFetchStub
+        >;
+
+        render(<Harness />);
+
+        await waitFor(() =>
+            expect(
+                screen.getByTestId('ap-site-editor-styles-load-error')
+            ).toBeInTheDocument()
+        );
+    });
+});
+

--- a/resources/js/visual-editor/site-editor/styles/__tests__/styles-section.test.tsx
+++ b/resources/js/visual-editor/site-editor/styles/__tests__/styles-section.test.tsx
@@ -539,9 +539,12 @@ describe('useStylesSectionViews — variations', () => {
 
     it('shows an empty state when the base payload ships no variations', async () => {
         // Swap the fetcher mid-test to return a base without variations.
+        // Capture the delegate fetcher first (the one the new stub just
+        // installed), then override `global.fetch` with a proxy that
+        // intercepts /global-styles/base and delegates everything else.
         fetchStub.restore();
-        const newStub = installFetchStub();
-        const originalFetch = global.fetch as unknown as typeof fetch;
+        fetchStub = installFetchStub();
+        const stubbedFetch = global.fetch as unknown as typeof fetch;
 
         global.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
             const url =
@@ -556,10 +559,8 @@ describe('useStylesSectionViews — variations', () => {
                 });
             }
 
-            return originalFetch(input, init);
+            return stubbedFetch(input, init);
         }) as unknown as typeof fetch;
-
-        fetchStub = newStub;
 
         render(<Harness />);
 

--- a/resources/js/visual-editor/site-editor/styles/__tests__/theme-json-paths.test.ts
+++ b/resources/js/visual-editor/site-editor/styles/__tests__/theme-json-paths.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    isCustomized,
+    readPath,
+    unsetPath,
+    writePath,
+} from '../theme-json-paths';
+
+describe('readPath', () => {
+    it('returns undefined for any miss along the path', () => {
+        expect(readPath(undefined, ['a'])).toBeUndefined();
+        expect(readPath({}, ['a'])).toBeUndefined();
+        expect(readPath({ a: {} }, ['a', 'b'])).toBeUndefined();
+        expect(readPath({ a: { b: null } }, ['a', 'b', 'c'])).toBeUndefined();
+    });
+
+    it('reads deep values', () => {
+        expect(readPath({ a: { b: { c: 42 } } }, ['a', 'b', 'c'])).toBe(42);
+    });
+});
+
+describe('writePath', () => {
+    it('writes a value without mutating the source', () => {
+        const source = { a: 1 };
+        const next = writePath(source, ['b'], 2);
+
+        expect(next).toEqual({ a: 1, b: 2 });
+        expect(source).toEqual({ a: 1 });
+    });
+
+    it('creates intermediate objects on demand', () => {
+        const next = writePath({}, ['a', 'b', 'c'], 'x');
+
+        expect(next).toEqual({ a: { b: { c: 'x' } } });
+    });
+
+    it('preserves sibling branches', () => {
+        const next = writePath(
+            { a: { b: 1, c: 2 } },
+            ['a', 'b'],
+            'updated'
+        );
+
+        expect(next).toEqual({ a: { b: 'updated', c: 2 } });
+    });
+});
+
+describe('unsetPath', () => {
+    it('removes the leaf and prunes empty ancestors', () => {
+        const next = unsetPath(
+            { a: { b: { c: 1 } } },
+            ['a', 'b', 'c']
+        );
+
+        expect(next).toEqual({});
+    });
+
+    it('keeps siblings untouched', () => {
+        const next = unsetPath(
+            { a: { b: 1, c: 2 } },
+            ['a', 'b']
+        );
+
+        expect(next).toEqual({ a: { c: 2 } });
+    });
+
+    it('is a no-op when the path is missing', () => {
+        const next = unsetPath({ a: 1 }, ['b', 'c']);
+
+        expect(next).toEqual({ a: 1 });
+    });
+});
+
+describe('isCustomized', () => {
+    it('returns false when the user value is undefined', () => {
+        expect(isCustomized(undefined, 'base')).toBe(false);
+    });
+
+    it('returns true when the user value differs from base', () => {
+        expect(isCustomized('user', 'base')).toBe(true);
+        expect(isCustomized(['a', 'b'], ['a'])).toBe(true);
+    });
+
+    it('returns false when the user value equals base', () => {
+        expect(isCustomized('same', 'same')).toBe(false);
+        expect(isCustomized({ a: 1 }, { a: 1 })).toBe(false);
+    });
+});

--- a/resources/js/visual-editor/site-editor/styles/global-styles-api.ts
+++ b/resources/js/visual-editor/site-editor/styles/global-styles-api.ts
@@ -1,0 +1,239 @@
+/**
+ * Global-styles REST client.
+ *
+ * The site-editor talks to the C3 REST surface exposed under
+ * `/visual-editor/api/global-styles` (see
+ * `src/Http/Controllers/GlobalStylesController.php`). This client wraps the
+ * four endpoints — lookup / base / show / update — behind typed helpers so
+ * the D3 styles UI doesn't have to rebuild URLs, CSRF handling, or error
+ * shapes ad hoc.
+ *
+ * Kept alongside the `site-editor/api-client.ts` pattern but in its own
+ * file because global-styles uses a singleton record shape (no pagination,
+ * one-record-per-theme) rather than the post-type envelope templates and
+ * template parts ride on.
+ */
+import {
+    SiteEditorApiError,
+    type SiteEditorApiConfig,
+    type ValidationErrors,
+} from '../api-client';
+
+export interface GlobalStylesRecord {
+    id: number;
+    version: number;
+    settings: Record<string, unknown>;
+    styles: Record<string, unknown>;
+}
+
+export type GlobalStylesBase = Pick<
+    GlobalStylesRecord,
+    'version' | 'settings' | 'styles'
+>;
+
+export interface GlobalStylesUpdatePayload {
+    version: number;
+    settings: Record<string, unknown>;
+    styles: Record<string, unknown>;
+}
+
+const READ_HEADERS: Readonly<Record<string, string>> = {
+    Accept: 'application/json',
+    'X-Requested-With': 'XMLHttpRequest',
+};
+
+function readCsrfToken(): string | null {
+    if (typeof document === 'undefined') {
+        return null;
+    }
+
+    const meta = document.querySelector<HTMLMetaElement>(
+        'meta[name="csrf-token"]'
+    );
+
+    return meta?.content?.trim() || null;
+}
+
+function mutatingHeaders(): Record<string, string> {
+    const headers: Record<string, string> = {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        'X-Requested-With': 'XMLHttpRequest',
+    };
+
+    const csrf = readCsrfToken();
+
+    if (csrf) {
+        headers['X-CSRF-TOKEN'] = csrf;
+    }
+
+    return headers;
+}
+
+async function parseBody(response: Response): Promise<unknown> {
+    const text = await response.text();
+
+    if (text === '') {
+        return null;
+    }
+
+    try {
+        return JSON.parse(text);
+    } catch {
+        return text;
+    }
+}
+
+function extractValidationErrors(body: unknown): ValidationErrors | null {
+    if (
+        body === null ||
+        typeof body !== 'object' ||
+        !('errors' in body) ||
+        typeof (body as { errors: unknown }).errors !== 'object' ||
+        (body as { errors: unknown }).errors === null
+    ) {
+        return null;
+    }
+
+    const raw = (body as { errors: Record<string, unknown> }).errors;
+    const result: ValidationErrors = {};
+
+    for (const [field, value] of Object.entries(raw)) {
+        if (Array.isArray(value)) {
+            result[field] = value.filter(
+                (entry): entry is string => typeof entry === 'string'
+            );
+        }
+    }
+
+    return result;
+}
+
+async function requireOk(response: Response): Promise<unknown> {
+    const body = await parseBody(response);
+
+    if (!response.ok) {
+        const baseMessage = `Global-styles request failed with status ${response.status}`;
+        const message =
+            body !== null &&
+            typeof body === 'object' &&
+            'message' in body &&
+            typeof (body as { message: unknown }).message === 'string'
+                ? (body as { message: string }).message || baseMessage
+                : baseMessage;
+
+        // Reuse the shell's `SiteEditorApiError` so 422 handling flows
+        // through the same extraction path the D2 editor already uses —
+        // the inspector renders field-level errors the same way.
+        throw new SiteEditorApiError(message, response.status, body);
+    }
+
+    return body;
+}
+
+function buildUrl(
+    config: SiteEditorApiConfig,
+    suffix: string | number | null = null
+): string {
+    const base = config.apiBase.replace(/\/+$/, '');
+
+    if (suffix === null) {
+        return `${base}/global-styles`;
+    }
+
+    return `${base}/global-styles/${encodeURIComponent(String(suffix))}`;
+}
+
+function normalizeError(
+    error: unknown,
+    fallback: string
+): SiteEditorApiError {
+    if (error instanceof SiteEditorApiError) {
+        return error;
+    }
+
+    const message =
+        error instanceof Error && error.message ? error.message : fallback;
+
+    return new SiteEditorApiError(message, 0, error);
+}
+
+/**
+ * Returns the active-theme's singleton id. The D3 bootstrap dispatches
+ * this to `receiveCurrentGlobalStylesId` so downstream selectors
+ * (`__experimentalGetCurrentGlobalStylesId`) resolve without a network
+ * call.
+ */
+export async function lookupGlobalStyles(
+    config: SiteEditorApiConfig
+): Promise<{ id: number }> {
+    try {
+        const response = await fetch(buildUrl(config, 'lookup'), {
+            method: 'GET',
+            credentials: 'same-origin',
+            headers: READ_HEADERS,
+        });
+
+        return (await requireOk(response)) as { id: number };
+    } catch (error: unknown) {
+        throw normalizeError(error, 'Failed to look up global styles.');
+    }
+}
+
+/**
+ * Returns the theme's unmodified theme.json payload — the baseline the
+ * inspector panels diff against when highlighting customized values.
+ */
+export async function fetchGlobalStylesBase(
+    config: SiteEditorApiConfig
+): Promise<GlobalStylesBase> {
+    try {
+        const response = await fetch(buildUrl(config, 'base'), {
+            method: 'GET',
+            credentials: 'same-origin',
+            headers: READ_HEADERS,
+        });
+
+        return (await requireOk(response)) as GlobalStylesBase;
+    } catch (error: unknown) {
+        throw normalizeError(error, 'Failed to load global-styles base.');
+    }
+}
+
+export async function fetchGlobalStyles(
+    config: SiteEditorApiConfig,
+    id: number | string
+): Promise<GlobalStylesRecord> {
+    try {
+        const response = await fetch(buildUrl(config, id), {
+            method: 'GET',
+            credentials: 'same-origin',
+            headers: READ_HEADERS,
+        });
+
+        return (await requireOk(response)) as GlobalStylesRecord;
+    } catch (error: unknown) {
+        throw normalizeError(error, 'Failed to load global styles.');
+    }
+}
+
+export async function updateGlobalStyles(
+    config: SiteEditorApiConfig,
+    id: number | string,
+    payload: GlobalStylesUpdatePayload
+): Promise<GlobalStylesRecord> {
+    try {
+        const response = await fetch(buildUrl(config, id), {
+            method: 'PUT',
+            credentials: 'same-origin',
+            headers: mutatingHeaders(),
+            body: JSON.stringify(payload),
+        });
+
+        return (await requireOk(response)) as GlobalStylesRecord;
+    } catch (error: unknown) {
+        throw normalizeError(error, 'Failed to save global styles.');
+    }
+}
+
+export { extractValidationErrors };

--- a/resources/js/visual-editor/site-editor/styles/panels/blocks-panel.tsx
+++ b/resources/js/visual-editor/site-editor/styles/panels/blocks-panel.tsx
@@ -35,37 +35,59 @@ interface BlockField extends StyleFieldDescriptor {
     key: readonly string[];
 }
 
-const BLOCK_FIELDS: readonly BlockField[] = [
-    {
-        label: 'Background color',
-        key: ['color', 'background'],
-        testId: 'block-color-background',
-        kind: 'color',
-    },
-    {
-        label: 'Text color',
-        key: ['color', 'text'],
-        testId: 'block-color-text',
-        kind: 'color',
-    },
-    {
-        label: 'Font family',
-        key: ['typography', 'fontFamily'],
-        testId: 'block-font-family',
-        kind: 'font-family',
-    },
-    {
-        label: 'Font size',
-        key: ['typography', 'fontSize'],
-        testId: 'block-font-size',
-        kind: 'font-size',
-    },
-    {
-        label: 'Border radius',
-        key: ['border', 'radius'],
-        testId: 'block-border-radius',
-        kind: 'size',
-    },
+/**
+ * Returns the block-detail field descriptors. A function (not a
+ * top-level constant) so `__()` resolves at call time — mirrors the
+ * `getSiteEditorSections` pattern and matches how the codebase handles
+ * every other static label list that needs to be translator-extractable
+ * without freezing to English at module load.
+ */
+function getBlockFields(): readonly BlockField[] {
+    return [
+        {
+            label: __('Background color', TEXT_DOMAIN),
+            key: ['color', 'background'],
+            testId: 'block-color-background',
+            kind: 'color',
+        },
+        {
+            label: __('Text color', TEXT_DOMAIN),
+            key: ['color', 'text'],
+            testId: 'block-color-text',
+            kind: 'color',
+        },
+        {
+            label: __('Font family', TEXT_DOMAIN),
+            key: ['typography', 'fontFamily'],
+            testId: 'block-font-family',
+            kind: 'font-family',
+        },
+        {
+            label: __('Font size', TEXT_DOMAIN),
+            key: ['typography', 'fontSize'],
+            testId: 'block-font-size',
+            kind: 'font-size',
+        },
+        {
+            label: __('Border radius', TEXT_DOMAIN),
+            key: ['border', 'radius'],
+            testId: 'block-border-radius',
+            kind: 'size',
+        },
+    ];
+}
+
+/**
+ * Stable key list used for iteration in `customizedCount` detection —
+ * derived once from a single cached descriptor set so the render path
+ * doesn't re-translate on every isPathCustomized check.
+ */
+const BLOCK_FIELD_KEYS: readonly (readonly string[])[] = [
+    ['color', 'background'],
+    ['color', 'text'],
+    ['typography', 'fontFamily'],
+    ['typography', 'fontSize'],
+    ['border', 'radius'],
 ];
 
 export function BlocksIndexPanel(
@@ -188,14 +210,16 @@ export function BlockDetailPanel(
         [blocks, selectedBlockName]
     );
 
+    const fields = useMemo(() => getBlockFields(), []);
+
     const customizedCount = useMemo(
         () =>
-            BLOCK_FIELDS.filter((field) =>
+            BLOCK_FIELD_KEYS.filter((key) =>
                 editor.isPathCustomized([
                     'styles',
                     'blocks',
                     selectedBlockName,
-                    ...field.key,
+                    ...key,
                 ])
             ).length,
         [editor, selectedBlockName]
@@ -234,7 +258,7 @@ export function BlockDetailPanel(
                     ])
                 }
             >
-                {BLOCK_FIELDS.map((field) =>
+                {fields.map((field) =>
                     renderStyleField({
                         editor,
                         validationErrors,

--- a/resources/js/visual-editor/site-editor/styles/panels/blocks-panel.tsx
+++ b/resources/js/visual-editor/site-editor/styles/panels/blocks-panel.tsx
@@ -1,0 +1,258 @@
+/**
+ * Blocks panels.
+ *
+ * The "Blocks" navigator node exposes two distinct panels — an index
+ * that lists the registered block types, and a per-block detail panel
+ * the user opens by picking a block. Only blocks registered through the
+ * package's BlockTypeRegistry are shown (per issue #370's out-of-scope
+ * note: we don't surface every core block if it's disabled).
+ */
+
+import { Button, PanelRow } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import { useMemo } from 'react';
+
+import { TEXT_DOMAIN } from '../../../vendor/i18n';
+import type { ValidationErrors } from '../../api-client';
+import type { StyleBlock } from '../styles-navigator';
+import type { UseGlobalStylesEditorResult } from '../use-global-styles-editor';
+import { StylePanelSection } from './panel-controls';
+import {
+    renderStyleField,
+    type StyleFieldDescriptor,
+} from './styles-fields';
+import { useStylePresets } from './use-preset-data';
+
+export interface BlocksPanelProps {
+    editor: UseGlobalStylesEditorResult;
+    validationErrors: ValidationErrors | null;
+    blocks: readonly StyleBlock[];
+    selectedBlockName: string | null;
+    onSelectBlock: (blockName: string | null) => void;
+}
+
+interface BlockField extends StyleFieldDescriptor {
+    key: readonly string[];
+}
+
+const BLOCK_FIELDS: readonly BlockField[] = [
+    {
+        label: 'Background color',
+        key: ['color', 'background'],
+        testId: 'block-color-background',
+        kind: 'color',
+    },
+    {
+        label: 'Text color',
+        key: ['color', 'text'],
+        testId: 'block-color-text',
+        kind: 'color',
+    },
+    {
+        label: 'Font family',
+        key: ['typography', 'fontFamily'],
+        testId: 'block-font-family',
+        kind: 'font-family',
+    },
+    {
+        label: 'Font size',
+        key: ['typography', 'fontSize'],
+        testId: 'block-font-size',
+        kind: 'font-size',
+    },
+    {
+        label: 'Border radius',
+        key: ['border', 'radius'],
+        testId: 'block-border-radius',
+        kind: 'size',
+    },
+];
+
+export function BlocksIndexPanel(
+    props: BlocksPanelProps
+): JSX.Element {
+    const { editor, blocks, onSelectBlock } = props;
+
+    const customizedBlockNames = useMemo(() => {
+        const customized: string[] = [];
+
+        for (const block of blocks) {
+            if (
+                editor.isPathCustomized([
+                    'styles',
+                    'blocks',
+                    block.name,
+                ])
+            ) {
+                customized.push(block.name);
+            }
+        }
+
+        return customized;
+    }, [blocks, editor]);
+
+    return (
+        <StylePanelSection
+            testId="ap-site-editor-style-panel-blocks-index"
+            title={__('Blocks', TEXT_DOMAIN)}
+            customizedCount={customizedBlockNames.length}
+            onResetSection={() => editor.resetPath(['styles', 'blocks'])}
+            description={__(
+                'Override styles per block. Pick a block from the navigator to edit its overrides.',
+                TEXT_DOMAIN
+            )}
+        >
+            <PanelRow>
+                <div
+                    className="ap-site-editor__style-listing"
+                    data-testid={
+                        blocks.length === 0
+                            ? 'ap-site-editor-style-panel-blocks-empty'
+                            : 'ap-site-editor-style-panel-blocks-list'
+                    }
+                >
+                    {blocks.length === 0 ? (
+                        <p className="ap-site-editor__style-panel-description">
+                            {__(
+                                'No blocks are registered through the package registry.',
+                                TEXT_DOMAIN
+                            )}
+                        </p>
+                    ) : (
+                        <ul className="ap-site-editor__style-listing-list">
+                            {blocks.map((block) => {
+                                const isCustomized = customizedBlockNames.includes(
+                                    block.name
+                                );
+                                const label = block.title ?? block.name;
+
+                                return (
+                                    <li
+                                        key={block.name}
+                                        className="ap-site-editor__style-listing-item"
+                                    >
+                                        <Button
+                                            variant="tertiary"
+                                            className="ap-site-editor__style-listing-link"
+                                            data-customized={isCustomized}
+                                            data-testid={`ap-site-editor-style-panel-block-${block.name}`}
+                                            onClick={() =>
+                                                onSelectBlock(block.name)
+                                            }
+                                        >
+                                            <span className="ap-site-editor__style-listing-label">
+                                                {label}
+                                            </span>
+                                            <code className="ap-site-editor__style-listing-code">
+                                                {block.name}
+                                            </code>
+                                            {isCustomized ? (
+                                                <span className="ap-site-editor__style-panel-customized">
+                                                    {__(
+                                                        'Customized',
+                                                        TEXT_DOMAIN
+                                                    )}
+                                                </span>
+                                            ) : null}
+                                        </Button>
+                                    </li>
+                                );
+                            })}
+                        </ul>
+                    )}
+                </div>
+            </PanelRow>
+        </StylePanelSection>
+    );
+}
+
+export interface BlockDetailPanelProps
+    extends Omit<BlocksPanelProps, 'selectedBlockName'> {
+    selectedBlockName: string;
+}
+
+export function BlockDetailPanel(
+    props: BlockDetailPanelProps
+): JSX.Element {
+    const {
+        editor,
+        validationErrors,
+        blocks,
+        selectedBlockName,
+        onSelectBlock,
+    } = props;
+    const presets = useStylePresets(editor);
+
+    const block = useMemo(
+        () => blocks.find((entry) => entry.name === selectedBlockName),
+        [blocks, selectedBlockName]
+    );
+
+    const customizedCount = useMemo(
+        () =>
+            BLOCK_FIELDS.filter((field) =>
+                editor.isPathCustomized([
+                    'styles',
+                    'blocks',
+                    selectedBlockName,
+                    ...field.key,
+                ])
+            ).length,
+        [editor, selectedBlockName]
+    );
+
+    const label = block?.title ?? selectedBlockName;
+
+    return (
+        <div
+            className="ap-site-editor__style-panel-wrapper"
+            data-testid="ap-site-editor-style-panel-block-detail"
+            data-block={selectedBlockName}
+        >
+            <PanelRow>
+                <Button
+                    variant="tertiary"
+                    size="small"
+                    data-testid="ap-site-editor-style-panel-block-back"
+                    onClick={() => onSelectBlock(null)}
+                >
+                    {__('← Back to blocks list', TEXT_DOMAIN)}
+                </Button>
+            </PanelRow>
+            <StylePanelSection
+                title={sprintf(
+                    /* translators: %s: block title or name. */
+                    __('Block: %s', TEXT_DOMAIN),
+                    label
+                )}
+                customizedCount={customizedCount}
+                onResetSection={() =>
+                    editor.resetPath([
+                        'styles',
+                        'blocks',
+                        selectedBlockName,
+                    ])
+                }
+            >
+                {BLOCK_FIELDS.map((field) =>
+                    renderStyleField({
+                        editor,
+                        validationErrors,
+                        presets,
+                        descriptor: field,
+                        path: [
+                            'styles',
+                            'blocks',
+                            selectedBlockName,
+                            ...field.key,
+                        ],
+                    })
+                )}
+            </StylePanelSection>
+        </div>
+    );
+}
+
+// Not every panel uses the index's index-only props; re-export so the
+// `styles-index` panel keeps a single prop shape.
+export type { BlocksPanelProps as BlocksIndexPanelProps };

--- a/resources/js/visual-editor/site-editor/styles/panels/colors-panel.tsx
+++ b/resources/js/visual-editor/site-editor/styles/panels/colors-panel.tsx
@@ -1,0 +1,472 @@
+/**
+ * Colors panel.
+ *
+ * The palette editor uses Gutenberg's `TextControl` for slug/name fields
+ * and its native `ColorPicker` for the value; site-level color defaults
+ * (background, text, link) use `ColorPalette` so the user picks from
+ * the theme's registered colors the same way they do inside any block's
+ * color settings.
+ */
+
+import {
+    Button,
+    ColorIndicator,
+    ColorPalette,
+    ColorPicker,
+    Dropdown,
+    PanelRow,
+    TextControl,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useMemo } from 'react';
+
+import { TEXT_DOMAIN } from '../../../vendor/i18n';
+import type { ValidationErrors } from '../../api-client';
+import type { UseGlobalStylesEditorResult } from '../use-global-styles-editor';
+import {
+    StyleControlRow,
+    StylePanelSection,
+} from './panel-controls';
+import { useStylePresets } from './use-preset-data';
+
+export interface ColorsPanelProps {
+    editor: UseGlobalStylesEditorResult;
+    validationErrors: ValidationErrors | null;
+}
+
+interface PaletteEntry {
+    slug: string;
+    name: string;
+    color: string;
+}
+
+const PALETTE_PATH: readonly string[] = ['settings', 'color', 'palette'];
+const PRESET_VAR_PATTERN = /^var\(--wp--preset--color--([a-z0-9-]+)\)$/i;
+
+function stringOrEmpty(value: unknown): string {
+    return typeof value === 'string' ? value : '';
+}
+
+function readPalette(editor: UseGlobalStylesEditorResult): PaletteEntry[] {
+    const raw = editor.readValue(PALETTE_PATH);
+
+    if (!Array.isArray(raw)) {
+        return [];
+    }
+
+    return raw
+        .map((entry): PaletteEntry | null => {
+            if (entry === null || typeof entry !== 'object') {
+                return null;
+            }
+
+            const row = entry as Record<string, unknown>;
+
+            return {
+                slug: typeof row.slug === 'string' ? row.slug : '',
+                name: typeof row.name === 'string' ? row.name : '',
+                color: typeof row.color === 'string' ? row.color : '#000000',
+            };
+        })
+        .filter((entry): entry is PaletteEntry => entry !== null);
+}
+
+function slugify(value: string, existing: readonly string[]): string {
+    const base =
+        value
+            .toLowerCase()
+            .normalize('NFKD')
+            .replace(/[^a-z0-9-]+/g, '-')
+            .replace(/-+/g, '-')
+            .replace(/^-|-$/g, '') || 'color';
+
+    if (!existing.includes(base)) {
+        return base;
+    }
+
+    let counter = 2;
+
+    while (existing.includes(`${base}-${counter}`)) {
+        counter += 1;
+    }
+
+    return `${base}-${counter}`;
+}
+
+function detectDuplicateSlug(
+    palette: readonly PaletteEntry[]
+): string | null {
+    const seen: string[] = [];
+
+    for (const entry of palette) {
+        if (entry.slug === '') {
+            continue;
+        }
+
+        if (seen.includes(entry.slug)) {
+            return entry.slug;
+        }
+
+        seen.push(entry.slug);
+    }
+
+    return null;
+}
+
+function resolveValueForPalette(
+    value: string,
+    palette: ReadonlyArray<{ slug: string; color: string }>
+): string | undefined {
+    const match = PRESET_VAR_PATTERN.exec(value);
+
+    if (match !== null) {
+        const slug = match[1] ?? '';
+        const entry = palette.find((swatch) => swatch.slug === slug);
+
+        if (entry !== undefined) {
+            return entry.color;
+        }
+    }
+
+    return value !== '' ? value : undefined;
+}
+
+function paletteRefFromColor(
+    color: string,
+    palette: ReadonlyArray<{ slug: string; color: string }>
+): string {
+    const match = palette.find(
+        (entry) => entry.color.toLowerCase() === color.toLowerCase()
+    );
+
+    if (match !== undefined) {
+        return `var(--wp--preset--color--${match.slug})`;
+    }
+
+    return color;
+}
+
+const STYLE_FIELDS: ReadonlyArray<{
+    label: string;
+    path: readonly string[];
+    testId: string;
+}> = [
+    {
+        label: 'Background color',
+        path: ['styles', 'color', 'background'],
+        testId: 'color-background',
+    },
+    {
+        label: 'Text color',
+        path: ['styles', 'color', 'text'],
+        testId: 'color-text',
+    },
+    {
+        label: 'Default link color',
+        path: ['styles', 'elements', 'link', 'color', 'text'],
+        testId: 'link-color',
+    },
+];
+
+export function ColorsPanel(props: ColorsPanelProps): JSX.Element {
+    const { editor, validationErrors } = props;
+
+    const palette = useMemo(() => readPalette(editor), [editor]);
+    const duplicateSlug = useMemo(
+        () => detectDuplicateSlug(palette),
+        [palette]
+    );
+    const presets = useStylePresets(editor);
+
+    const paletteCustomized = editor.isPathCustomized(PALETTE_PATH);
+
+    const customizedStyleCount = useMemo(
+        () =>
+            STYLE_FIELDS.filter((field) =>
+                editor.isPathCustomized(field.path)
+            ).length,
+        [editor]
+    );
+    const customizedCount =
+        customizedStyleCount + (paletteCustomized ? 1 : 0);
+
+    const persistPalette = (next: PaletteEntry[]): void => {
+        // `setValue` takes `unknown` — declare the array shape explicitly
+        // instead of double-casting through `unknown`.
+        editor.setValue(PALETTE_PATH, next as readonly PaletteEntry[]);
+    };
+
+    const addSwatch = (): void => {
+        const slug = slugify(
+            'new-color',
+            palette.map((entry) => entry.slug)
+        );
+
+        persistPalette([
+            ...palette,
+            { slug, name: __('New Color', TEXT_DOMAIN), color: '#000000' },
+        ]);
+    };
+
+    const removeSwatch = (index: number): void => {
+        if (index < 0 || index >= palette.length) {
+            return;
+        }
+
+        persistPalette(palette.filter((_, idx) => idx !== index));
+    };
+
+    const moveSwatch = (index: number, delta: number): void => {
+        const target = index + delta;
+
+        if (target < 0 || target >= palette.length) {
+            return;
+        }
+
+        const copy = palette.slice();
+        const [removed] = copy.splice(index, 1);
+
+        if (removed !== undefined) {
+            copy.splice(target, 0, removed);
+        }
+
+        persistPalette(copy);
+    };
+
+    const updateSwatch = (
+        index: number,
+        key: keyof PaletteEntry,
+        value: string
+    ): void => {
+        const copy = palette.slice();
+        const existing = copy[index];
+
+        if (existing === undefined) {
+            return;
+        }
+
+        copy[index] = { ...existing, [key]: value };
+        persistPalette(copy);
+    };
+
+    const paletteError =
+        validationErrors?.['settings.color.palette']?.[0] ??
+        (duplicateSlug !== null
+            ? __('Palette slugs must be unique.', TEXT_DOMAIN)
+            : null);
+
+    const paletteOptions = useMemo(
+        () =>
+            presets.palette.map((entry) => ({
+                name: entry.name,
+                color: entry.color,
+                slug: entry.slug,
+            })),
+        [presets.palette]
+    );
+
+    return (
+        <StylePanelSection
+            testId="ap-site-editor-style-panel-colors"
+            title={__('Colors', TEXT_DOMAIN)}
+            customizedCount={customizedCount}
+            onResetSection={() => {
+                editor.resetPath(PALETTE_PATH);
+                STYLE_FIELDS.forEach((field) => editor.resetPath(field.path));
+            }}
+            description={__(
+                'Palette entries are exposed as CSS variables (var(--wp--preset--color--{slug})).',
+                TEXT_DOMAIN
+            )}
+        >
+            <PanelRow>
+                <div
+                    className="ap-site-editor__style-palette"
+                    data-testid="ap-site-editor-style-panel-palette"
+                >
+                    <div className="ap-site-editor__style-palette-header">
+                        <h4 className="ap-site-editor__style-panel-presets-title">
+                            {__('Palette', TEXT_DOMAIN)}
+                        </h4>
+                        <Button
+                            variant="secondary"
+                            size="small"
+                            data-testid="ap-site-editor-style-palette-add"
+                            onClick={addSwatch}
+                        >
+                            {__('Add color', TEXT_DOMAIN)}
+                        </Button>
+                    </div>
+                    {paletteError !== null ? (
+                        <p
+                            role="alert"
+                            className="ap-site-editor__style-control-row-error"
+                            data-testid="ap-site-editor-style-palette-error"
+                        >
+                            {paletteError}
+                        </p>
+                    ) : null}
+                    {palette.length === 0 ? (
+                        <p className="ap-site-editor__style-panel-description">
+                            {__(
+                                'No palette entries — add one to expose it as a CSS variable.',
+                                TEXT_DOMAIN
+                            )}
+                        </p>
+                    ) : null}
+                    <ul
+                        className="ap-site-editor__style-palette-list"
+                        aria-label={__('Color palette', TEXT_DOMAIN)}
+                    >
+                        {palette.map((entry, index) => (
+                            <li
+                                key={`${entry.slug}-${index}`}
+                                className="ap-site-editor__style-palette-row"
+                                data-testid={`ap-site-editor-style-palette-row-${index}`}
+                            >
+                                <Dropdown
+                                    popoverProps={{ placement: 'bottom-start' }}
+                                    renderToggle={({ isOpen, onToggle }) => (
+                                        <Button
+                                            variant="tertiary"
+                                            className="ap-site-editor__style-palette-color-trigger"
+                                            aria-expanded={isOpen}
+                                            aria-label={__(
+                                                'Color value',
+                                                TEXT_DOMAIN
+                                            )}
+                                            data-testid={`ap-site-editor-style-palette-color-${index}`}
+                                            onClick={onToggle}
+                                        >
+                                            <ColorIndicator
+                                                colorValue={entry.color}
+                                            />
+                                        </Button>
+                                    )}
+                                    renderContent={() => (
+                                        <ColorPicker
+                                            color={entry.color}
+                                            enableAlpha={false}
+                                            onChange={(next) =>
+                                                updateSwatch(
+                                                    index,
+                                                    'color',
+                                                    next
+                                                )
+                                            }
+                                        />
+                                    )}
+                                />
+                                <TextControl
+                                    label={__('Color name', TEXT_DOMAIN)}
+                                    hideLabelFromVision={true}
+                                    value={entry.name}
+                                    placeholder={__('Name', TEXT_DOMAIN)}
+                                    data-testid={`ap-site-editor-style-palette-name-${index}`}
+                                    __nextHasNoMarginBottom={true}
+                                    __next40pxDefaultSize={true}
+                                    onChange={(next) =>
+                                        updateSwatch(index, 'name', next)
+                                    }
+                                />
+                                <TextControl
+                                    label={__('Color slug', TEXT_DOMAIN)}
+                                    hideLabelFromVision={true}
+                                    value={entry.slug}
+                                    placeholder={__('slug', TEXT_DOMAIN)}
+                                    data-testid={`ap-site-editor-style-palette-slug-${index}`}
+                                    __nextHasNoMarginBottom={true}
+                                    __next40pxDefaultSize={true}
+                                    onChange={(next) =>
+                                        updateSwatch(index, 'slug', next)
+                                    }
+                                />
+                                <div className="ap-site-editor__style-palette-row-actions">
+                                    <Button
+                                        variant="tertiary"
+                                        size="small"
+                                        aria-label={__('Move up', TEXT_DOMAIN)}
+                                        data-testid={`ap-site-editor-style-palette-up-${index}`}
+                                        disabled={index === 0}
+                                        onClick={() => moveSwatch(index, -1)}
+                                    >
+                                        {__('↑', TEXT_DOMAIN)}
+                                    </Button>
+                                    <Button
+                                        variant="tertiary"
+                                        size="small"
+                                        aria-label={__('Move down', TEXT_DOMAIN)}
+                                        data-testid={`ap-site-editor-style-palette-down-${index}`}
+                                        disabled={
+                                            index === palette.length - 1
+                                        }
+                                        onClick={() => moveSwatch(index, 1)}
+                                    >
+                                        {__('↓', TEXT_DOMAIN)}
+                                    </Button>
+                                    <Button
+                                        variant="tertiary"
+                                        size="small"
+                                        isDestructive={true}
+                                        data-testid={`ap-site-editor-style-palette-remove-${index}`}
+                                        onClick={() => removeSwatch(index)}
+                                    >
+                                        {__('Remove', TEXT_DOMAIN)}
+                                    </Button>
+                                </div>
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+            </PanelRow>
+
+            {STYLE_FIELDS.map((field) => {
+                const value = stringOrEmpty(editor.readValue(field.path));
+                const baseValue = stringOrEmpty(
+                    editor.readBaseValue(field.path)
+                );
+                const error =
+                    validationErrors?.[field.path.join('.')]?.[0] ?? null;
+                const resolved = resolveValueForPalette(value, paletteOptions);
+
+                return (
+                    <StyleControlRow
+                        key={field.testId}
+                        testId={field.testId}
+                        isCustomized={editor.isPathCustomized(field.path)}
+                        onReset={() => editor.resetPath(field.path)}
+                        baseValue={baseValue === '' ? undefined : baseValue}
+                        error={error}
+                    >
+                        <div
+                            className="ap-site-editor__style-color-field"
+                            data-testid={`ap-site-editor-style-swatches-${field.testId}`}
+                        >
+                            <span className="ap-site-editor__style-color-field-label">
+                                {__(field.label, TEXT_DOMAIN)}
+                            </span>
+                            <ColorPalette
+                                colors={paletteOptions}
+                                value={resolved}
+                                disableCustomColors={false}
+                                clearable={true}
+                                enableAlpha={false}
+                                onChange={(next?: string) => {
+                                    if (next === undefined || next === '') {
+                                        editor.resetPath(field.path);
+                                        return;
+                                    }
+
+                                    editor.setValue(
+                                        field.path,
+                                        paletteRefFromColor(next, paletteOptions)
+                                    );
+                                }}
+                            />
+                        </div>
+                    </StyleControlRow>
+                );
+            })}
+        </StylePanelSection>
+    );
+}

--- a/resources/js/visual-editor/site-editor/styles/panels/colors-panel.tsx
+++ b/resources/js/visual-editor/site-editor/styles/panels/colors-panel.tsx
@@ -71,14 +71,29 @@ function readPalette(editor: UseGlobalStylesEditorResult): PaletteEntry[] {
         .filter((entry): entry is PaletteEntry => entry !== null);
 }
 
-function slugify(value: string, existing: readonly string[]): string {
-    const base =
-        value
-            .toLowerCase()
-            .normalize('NFKD')
-            .replace(/[^a-z0-9-]+/g, '-')
-            .replace(/-+/g, '-')
-            .replace(/^-|-$/g, '') || 'color';
+/**
+ * Normalizes an arbitrary string into a theme.json-safe slug: lowercase,
+ * alphanumerics + hyphen only, collapsed hyphens. No collision-avoidance
+ * suffix so the user keeps control of the identifier they're typing —
+ * duplicates are surfaced by `detectDuplicateSlug` as inline feedback
+ * the user resolves themselves.
+ */
+function normalizeSlugChars(value: string): string {
+    return value
+        .toLowerCase()
+        .normalize('NFKD')
+        .replace(/[^a-z0-9-]+/g, '-')
+        .replace(/-+/g, '-')
+        .replace(/^-|-$/g, '');
+}
+
+/**
+ * Picks a fresh unique slug for a newly-added swatch. Uses the stricter
+ * normalization above + appends a `-N` suffix if the candidate collides
+ * with an existing slug.
+ */
+function slugifyNew(seed: string, existing: readonly string[]): string {
+    const base = normalizeSlugChars(seed) || 'color';
 
     if (!existing.includes(base)) {
         return base;
@@ -197,7 +212,7 @@ export function ColorsPanel(props: ColorsPanelProps): JSX.Element {
     };
 
     const addSwatch = (): void => {
-        const slug = slugify(
+        const slug = slugifyNew(
             'new-color',
             palette.map((entry) => entry.slug)
         );
@@ -245,7 +260,16 @@ export function ColorsPanel(props: ColorsPanelProps): JSX.Element {
             return;
         }
 
-        copy[index] = { ...existing, [key]: value };
+        // Slug edits go through the char-normalizer so whatever lands in
+        // the record is always safe for the `var(--wp--preset--color--{slug})`
+        // CSS variable name. Duplicate detection stays with
+        // `detectDuplicateSlug` — we don't auto-append `-N` here because
+        // collisions happen mid-typing ("prim" → "prima" → "primary") and
+        // should surface as inline errors the user clears themselves.
+        const normalizedValue =
+            key === 'slug' ? normalizeSlugChars(value) : value;
+
+        copy[index] = { ...existing, [key]: normalizedValue };
         persistPalette(copy);
     };
 
@@ -254,6 +278,49 @@ export function ColorsPanel(props: ColorsPanelProps): JSX.Element {
         (duplicateSlug !== null
             ? __('Palette slugs must be unique.', TEXT_DOMAIN)
             : null);
+
+    /**
+     * Per-row validation errors extracted from keys like
+     * `settings.color.palette.2.slug`. Laravel's validator emits one
+     * key per offending attribute — we bucket them by index so the row
+     * renderer can show the message next to the offending field.
+     */
+    const paletteRowErrors = useMemo((): ReadonlyArray<
+        Partial<Record<keyof PaletteEntry, string>>
+    > => {
+        const rows: Array<Partial<Record<keyof PaletteEntry, string>>> =
+            palette.map(() => ({}));
+
+        if (validationErrors === null) {
+            return rows;
+        }
+
+        for (const [key, messages] of Object.entries(validationErrors)) {
+            const match = /^settings\.color\.palette\.(\d+)\.(slug|name|color)$/.exec(
+                key
+            );
+
+            if (match === null) {
+                continue;
+            }
+
+            const index = Number(match[1]);
+            const field = match[2] as keyof PaletteEntry;
+            const message = messages[0];
+
+            if (message === undefined) {
+                continue;
+            }
+
+            const bucket = rows[index];
+
+            if (bucket !== undefined) {
+                bucket[field] = message;
+            }
+        }
+
+        return rows;
+    }, [palette, validationErrors]);
 
     const paletteOptions = useMemo(
         () =>
@@ -318,104 +385,137 @@ export function ColorsPanel(props: ColorsPanelProps): JSX.Element {
                         className="ap-site-editor__style-palette-list"
                         aria-label={__('Color palette', TEXT_DOMAIN)}
                     >
-                        {palette.map((entry, index) => (
-                            <li
-                                key={`${entry.slug}-${index}`}
-                                className="ap-site-editor__style-palette-row"
-                                data-testid={`ap-site-editor-style-palette-row-${index}`}
-                            >
-                                <Dropdown
-                                    popoverProps={{ placement: 'bottom-start' }}
-                                    renderToggle={({ isOpen, onToggle }) => (
+                        {palette.map((entry, index) => {
+                            const rowErrors =
+                                paletteRowErrors[index] ?? {};
+
+                            return (
+                                <li
+                                    key={`${entry.slug}-${index}`}
+                                    className="ap-site-editor__style-palette-row"
+                                    data-testid={`ap-site-editor-style-palette-row-${index}`}
+                                >
+                                    <Dropdown
+                                        popoverProps={{
+                                            placement: 'bottom-start',
+                                        }}
+                                        renderToggle={({ isOpen, onToggle }) => (
+                                            <Button
+                                                variant="tertiary"
+                                                className="ap-site-editor__style-palette-color-trigger"
+                                                aria-expanded={isOpen}
+                                                aria-label={__(
+                                                    'Color value',
+                                                    TEXT_DOMAIN
+                                                )}
+                                                data-testid={`ap-site-editor-style-palette-color-${index}`}
+                                                onClick={onToggle}
+                                            >
+                                                <ColorIndicator
+                                                    colorValue={entry.color}
+                                                />
+                                            </Button>
+                                        )}
+                                        renderContent={() => (
+                                            <ColorPicker
+                                                color={entry.color}
+                                                enableAlpha={false}
+                                                onChange={(next) =>
+                                                    updateSwatch(
+                                                        index,
+                                                        'color',
+                                                        next
+                                                    )
+                                                }
+                                            />
+                                        )}
+                                    />
+                                    <TextControl
+                                        label={__('Color name', TEXT_DOMAIN)}
+                                        hideLabelFromVision={true}
+                                        value={entry.name}
+                                        placeholder={__('Name', TEXT_DOMAIN)}
+                                        data-testid={`ap-site-editor-style-palette-name-${index}`}
+                                        __nextHasNoMarginBottom={true}
+                                        __next40pxDefaultSize={true}
+                                        onChange={(next) =>
+                                            updateSwatch(index, 'name', next)
+                                        }
+                                    />
+                                    <TextControl
+                                        label={__('Color slug', TEXT_DOMAIN)}
+                                        hideLabelFromVision={true}
+                                        value={entry.slug}
+                                        placeholder={__('slug', TEXT_DOMAIN)}
+                                        data-testid={`ap-site-editor-style-palette-slug-${index}`}
+                                        __nextHasNoMarginBottom={true}
+                                        __next40pxDefaultSize={true}
+                                        onChange={(next) =>
+                                            updateSwatch(index, 'slug', next)
+                                        }
+                                    />
+                                    <div className="ap-site-editor__style-palette-row-actions">
                                         <Button
                                             variant="tertiary"
-                                            className="ap-site-editor__style-palette-color-trigger"
-                                            aria-expanded={isOpen}
+                                            size="small"
                                             aria-label={__(
-                                                'Color value',
+                                                'Move up',
                                                 TEXT_DOMAIN
                                             )}
-                                            data-testid={`ap-site-editor-style-palette-color-${index}`}
-                                            onClick={onToggle}
+                                            data-testid={`ap-site-editor-style-palette-up-${index}`}
+                                            disabled={index === 0}
+                                            onClick={() => moveSwatch(index, -1)}
                                         >
-                                            <ColorIndicator
-                                                colorValue={entry.color}
-                                            />
+                                            {__('↑', TEXT_DOMAIN)}
                                         </Button>
-                                    )}
-                                    renderContent={() => (
-                                        <ColorPicker
-                                            color={entry.color}
-                                            enableAlpha={false}
-                                            onChange={(next) =>
-                                                updateSwatch(
-                                                    index,
-                                                    'color',
-                                                    next
-                                                )
+                                        <Button
+                                            variant="tertiary"
+                                            size="small"
+                                            aria-label={__(
+                                                'Move down',
+                                                TEXT_DOMAIN
+                                            )}
+                                            data-testid={`ap-site-editor-style-palette-down-${index}`}
+                                            disabled={
+                                                index === palette.length - 1
                                             }
-                                        />
-                                    )}
-                                />
-                                <TextControl
-                                    label={__('Color name', TEXT_DOMAIN)}
-                                    hideLabelFromVision={true}
-                                    value={entry.name}
-                                    placeholder={__('Name', TEXT_DOMAIN)}
-                                    data-testid={`ap-site-editor-style-palette-name-${index}`}
-                                    __nextHasNoMarginBottom={true}
-                                    __next40pxDefaultSize={true}
-                                    onChange={(next) =>
-                                        updateSwatch(index, 'name', next)
-                                    }
-                                />
-                                <TextControl
-                                    label={__('Color slug', TEXT_DOMAIN)}
-                                    hideLabelFromVision={true}
-                                    value={entry.slug}
-                                    placeholder={__('slug', TEXT_DOMAIN)}
-                                    data-testid={`ap-site-editor-style-palette-slug-${index}`}
-                                    __nextHasNoMarginBottom={true}
-                                    __next40pxDefaultSize={true}
-                                    onChange={(next) =>
-                                        updateSwatch(index, 'slug', next)
-                                    }
-                                />
-                                <div className="ap-site-editor__style-palette-row-actions">
-                                    <Button
-                                        variant="tertiary"
-                                        size="small"
-                                        aria-label={__('Move up', TEXT_DOMAIN)}
-                                        data-testid={`ap-site-editor-style-palette-up-${index}`}
-                                        disabled={index === 0}
-                                        onClick={() => moveSwatch(index, -1)}
-                                    >
-                                        {__('↑', TEXT_DOMAIN)}
-                                    </Button>
-                                    <Button
-                                        variant="tertiary"
-                                        size="small"
-                                        aria-label={__('Move down', TEXT_DOMAIN)}
-                                        data-testid={`ap-site-editor-style-palette-down-${index}`}
-                                        disabled={
-                                            index === palette.length - 1
+                                            onClick={() => moveSwatch(index, 1)}
+                                        >
+                                            {__('↓', TEXT_DOMAIN)}
+                                        </Button>
+                                        <Button
+                                            variant="tertiary"
+                                            size="small"
+                                            isDestructive={true}
+                                            data-testid={`ap-site-editor-style-palette-remove-${index}`}
+                                            onClick={() => removeSwatch(index)}
+                                        >
+                                            {__('Remove', TEXT_DOMAIN)}
+                                        </Button>
+                                    </div>
+                                    {(['color', 'name', 'slug'] as const).map(
+                                        (field) => {
+                                            const message = rowErrors[field];
+
+                                            if (message === undefined) {
+                                                return null;
+                                            }
+
+                                            return (
+                                                <p
+                                                    key={field}
+                                                    role="alert"
+                                                    className="ap-site-editor__style-palette-row-error"
+                                                    data-testid={`ap-site-editor-style-palette-error-${index}-${field}`}
+                                                >
+                                                    {message}
+                                                </p>
+                                            );
                                         }
-                                        onClick={() => moveSwatch(index, 1)}
-                                    >
-                                        {__('↓', TEXT_DOMAIN)}
-                                    </Button>
-                                    <Button
-                                        variant="tertiary"
-                                        size="small"
-                                        isDestructive={true}
-                                        data-testid={`ap-site-editor-style-palette-remove-${index}`}
-                                        onClick={() => removeSwatch(index)}
-                                    >
-                                        {__('Remove', TEXT_DOMAIN)}
-                                    </Button>
-                                </div>
-                            </li>
-                        ))}
+                                    )}
+                                </li>
+                            );
+                        })}
                     </ul>
                 </div>
             </PanelRow>

--- a/resources/js/visual-editor/site-editor/styles/panels/elements-panel.tsx
+++ b/resources/js/visual-editor/site-editor/styles/panels/elements-panel.tsx
@@ -1,0 +1,216 @@
+/**
+ * Elements panels.
+ *
+ * Schema v3's `styles.elements.*` key contains per-element overrides
+ * (link, button, heading, h1–h6, caption). The navigator lists each
+ * scope; picking one opens a detail panel scoped to that element's
+ * color / typography leaves rendered through the same Gutenberg
+ * primitives the rest of the editor uses.
+ */
+
+import { Button, PanelRow } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import { useMemo } from 'react';
+
+import { TEXT_DOMAIN } from '../../../vendor/i18n';
+import type { ValidationErrors } from '../../api-client';
+import {
+    ELEMENT_ORDER,
+    getElementLabel,
+    type ElementScope,
+} from '../styles-navigator-tree';
+import type { UseGlobalStylesEditorResult } from '../use-global-styles-editor';
+import { StylePanelSection } from './panel-controls';
+import {
+    renderStyleField,
+    type StyleFieldDescriptor,
+} from './styles-fields';
+import { useStylePresets } from './use-preset-data';
+
+export interface ElementsIndexPanelProps {
+    editor: UseGlobalStylesEditorResult;
+    onSelectElement: (element: ElementScope) => void;
+}
+
+interface ElementField extends StyleFieldDescriptor {
+    key: readonly string[];
+}
+
+const ELEMENT_FIELDS: readonly ElementField[] = [
+    {
+        label: 'Text color',
+        key: ['color', 'text'],
+        testId: 'element-color-text',
+        kind: 'color',
+    },
+    {
+        label: 'Background color',
+        key: ['color', 'background'],
+        testId: 'element-color-background',
+        kind: 'color',
+    },
+    {
+        label: 'Font family',
+        key: ['typography', 'fontFamily'],
+        testId: 'element-font-family',
+        kind: 'font-family',
+    },
+    {
+        label: 'Font size',
+        key: ['typography', 'fontSize'],
+        testId: 'element-font-size',
+        kind: 'font-size',
+    },
+    {
+        label: 'Font weight',
+        key: ['typography', 'fontWeight'],
+        testId: 'element-font-weight',
+        kind: 'font-weight',
+    },
+];
+
+export function ElementsIndexPanel(
+    props: ElementsIndexPanelProps
+): JSX.Element {
+    const { editor, onSelectElement } = props;
+
+    const customizedScopes = useMemo(() => {
+        const customized: ElementScope[] = [];
+
+        for (const element of ELEMENT_ORDER) {
+            if (
+                editor.isPathCustomized([
+                    'styles',
+                    'elements',
+                    element,
+                ])
+            ) {
+                customized.push(element);
+            }
+        }
+
+        return customized;
+    }, [editor]);
+
+    return (
+        <StylePanelSection
+            testId="ap-site-editor-style-panel-elements-index"
+            title={__('Elements', TEXT_DOMAIN)}
+            customizedCount={customizedScopes.length}
+            onResetSection={() => editor.resetPath(['styles', 'elements'])}
+            description={__(
+                'Override typography and color for the built-in HTML elements — links, buttons, headings, captions.',
+                TEXT_DOMAIN
+            )}
+        >
+            <PanelRow>
+                <ul
+                    className="ap-site-editor__style-listing-list"
+                    data-testid="ap-site-editor-style-panel-elements-list"
+                >
+                    {ELEMENT_ORDER.map((element) => {
+                        const isCustomized = customizedScopes.includes(
+                            element
+                        );
+
+                        return (
+                            <li
+                                key={element}
+                                className="ap-site-editor__style-listing-item"
+                            >
+                                <Button
+                                    variant="tertiary"
+                                    className="ap-site-editor__style-listing-link"
+                                    data-customized={isCustomized}
+                                    data-testid={`ap-site-editor-style-panel-element-${element}`}
+                                    onClick={() => onSelectElement(element)}
+                                >
+                                    <span className="ap-site-editor__style-listing-label">
+                                        {getElementLabel(element)}
+                                    </span>
+                                    {isCustomized ? (
+                                        <span className="ap-site-editor__style-panel-customized">
+                                            {__('Customized', TEXT_DOMAIN)}
+                                        </span>
+                                    ) : null}
+                                </Button>
+                            </li>
+                        );
+                    })}
+                </ul>
+            </PanelRow>
+        </StylePanelSection>
+    );
+}
+
+export interface ElementDetailPanelProps {
+    editor: UseGlobalStylesEditorResult;
+    validationErrors: ValidationErrors | null;
+    element: ElementScope;
+    onBack: () => void;
+}
+
+export function ElementDetailPanel(
+    props: ElementDetailPanelProps
+): JSX.Element {
+    const { editor, validationErrors, element, onBack } = props;
+    const presets = useStylePresets(editor);
+
+    const customizedCount = useMemo(
+        () =>
+            ELEMENT_FIELDS.filter((field) =>
+                editor.isPathCustomized([
+                    'styles',
+                    'elements',
+                    element,
+                    ...field.key,
+                ])
+            ).length,
+        [editor, element]
+    );
+
+    return (
+        <div
+            className="ap-site-editor__style-panel-wrapper"
+            data-testid="ap-site-editor-style-panel-element-detail"
+            data-element={element}
+        >
+            <PanelRow>
+                <Button
+                    variant="tertiary"
+                    size="small"
+                    data-testid="ap-site-editor-style-panel-element-back"
+                    onClick={onBack}
+                >
+                    {__('← Back to elements list', TEXT_DOMAIN)}
+                </Button>
+            </PanelRow>
+            <StylePanelSection
+                title={sprintf(
+                    /* translators: %s: element label (e.g. "Link"). */
+                    __('Element: %s', TEXT_DOMAIN),
+                    getElementLabel(element)
+                )}
+                customizedCount={customizedCount}
+                onResetSection={() =>
+                    editor.resetPath(['styles', 'elements', element])
+                }
+            >
+                {ELEMENT_FIELDS.map((field) =>
+                    renderStyleField({
+                        editor,
+                        validationErrors,
+                        presets,
+                        descriptor: field,
+                        path: [
+                            'styles',
+                            'elements',
+                            element,
+                            ...field.key,
+                        ],
+                    })
+                )}
+            </StylePanelSection>
+        </div>
+    );
+}

--- a/resources/js/visual-editor/site-editor/styles/panels/elements-panel.tsx
+++ b/resources/js/visual-editor/site-editor/styles/panels/elements-panel.tsx
@@ -36,37 +36,59 @@ interface ElementField extends StyleFieldDescriptor {
     key: readonly string[];
 }
 
-const ELEMENT_FIELDS: readonly ElementField[] = [
-    {
-        label: 'Text color',
-        key: ['color', 'text'],
-        testId: 'element-color-text',
-        kind: 'color',
-    },
-    {
-        label: 'Background color',
-        key: ['color', 'background'],
-        testId: 'element-color-background',
-        kind: 'color',
-    },
-    {
-        label: 'Font family',
-        key: ['typography', 'fontFamily'],
-        testId: 'element-font-family',
-        kind: 'font-family',
-    },
-    {
-        label: 'Font size',
-        key: ['typography', 'fontSize'],
-        testId: 'element-font-size',
-        kind: 'font-size',
-    },
-    {
-        label: 'Font weight',
-        key: ['typography', 'fontWeight'],
-        testId: 'element-font-weight',
-        kind: 'font-weight',
-    },
+/**
+ * Returns the element-detail field descriptors. A function (not a
+ * top-level constant) so `__()` resolves at call time — mirrors the
+ * `getSiteEditorSections` pattern and matches how the codebase handles
+ * every other static label list that needs to be translator-extractable
+ * without freezing to English at module load.
+ */
+function getElementFields(): readonly ElementField[] {
+    return [
+        {
+            label: __('Text color', TEXT_DOMAIN),
+            key: ['color', 'text'],
+            testId: 'element-color-text',
+            kind: 'color',
+        },
+        {
+            label: __('Background color', TEXT_DOMAIN),
+            key: ['color', 'background'],
+            testId: 'element-color-background',
+            kind: 'color',
+        },
+        {
+            label: __('Font family', TEXT_DOMAIN),
+            key: ['typography', 'fontFamily'],
+            testId: 'element-font-family',
+            kind: 'font-family',
+        },
+        {
+            label: __('Font size', TEXT_DOMAIN),
+            key: ['typography', 'fontSize'],
+            testId: 'element-font-size',
+            kind: 'font-size',
+        },
+        {
+            label: __('Font weight', TEXT_DOMAIN),
+            key: ['typography', 'fontWeight'],
+            testId: 'element-font-weight',
+            kind: 'font-weight',
+        },
+    ];
+}
+
+/**
+ * Stable key list used for iteration in `customizedCount` detection —
+ * derived once so the render path doesn't re-translate on every
+ * isPathCustomized check.
+ */
+const ELEMENT_FIELD_KEYS: readonly (readonly string[])[] = [
+    ['color', 'text'],
+    ['color', 'background'],
+    ['typography', 'fontFamily'],
+    ['typography', 'fontSize'],
+    ['typography', 'fontWeight'],
 ];
 
 export function ElementsIndexPanel(
@@ -156,14 +178,16 @@ export function ElementDetailPanel(
     const { editor, validationErrors, element, onBack } = props;
     const presets = useStylePresets(editor);
 
+    const fields = useMemo(() => getElementFields(), []);
+
     const customizedCount = useMemo(
         () =>
-            ELEMENT_FIELDS.filter((field) =>
+            ELEMENT_FIELD_KEYS.filter((key) =>
                 editor.isPathCustomized([
                     'styles',
                     'elements',
                     element,
-                    ...field.key,
+                    ...key,
                 ])
             ).length,
         [editor, element]
@@ -196,7 +220,7 @@ export function ElementDetailPanel(
                     editor.resetPath(['styles', 'elements', element])
                 }
             >
-                {ELEMENT_FIELDS.map((field) =>
+                {fields.map((field) =>
                     renderStyleField({
                         editor,
                         validationErrors,

--- a/resources/js/visual-editor/site-editor/styles/panels/layout-panel.tsx
+++ b/resources/js/visual-editor/site-editor/styles/panels/layout-panel.tsx
@@ -1,0 +1,124 @@
+/**
+ * Layout panel.
+ *
+ * Schema v3 layout covers content / wide widths (`settings.layout.contentSize`,
+ * `wideSize`) and the default block gap. All three render through
+ * Gutenberg's `__experimentalUnitControl` so the number-and-unit
+ * interaction matches every other editor surface.
+ */
+
+// `UnitControl` is still marked experimental upstream — its export name,
+// props, and emitted value shape may shift between Gutenberg releases.
+// Keep the alias centralized so the inevitable rename is a single diff.
+import { __experimentalUnitControl as UnitControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useMemo } from 'react';
+
+import { TEXT_DOMAIN } from '../../../vendor/i18n';
+import type { ValidationErrors } from '../../api-client';
+import type { UseGlobalStylesEditorResult } from '../use-global-styles-editor';
+import { StyleControlRow, StylePanelSection } from './panel-controls';
+
+export interface LayoutPanelProps {
+    editor: UseGlobalStylesEditorResult;
+    validationErrors: ValidationErrors | null;
+}
+
+interface LayoutField {
+    label: string;
+    path: readonly string[];
+    testId: string;
+    help?: string;
+}
+
+const LAYOUT_FIELDS: readonly LayoutField[] = [
+    {
+        label: 'Content size',
+        path: ['settings', 'layout', 'contentSize'],
+        testId: 'content-size',
+        help: 'Default width for alignable blocks.',
+    },
+    {
+        label: 'Wide size',
+        path: ['settings', 'layout', 'wideSize'],
+        testId: 'wide-size',
+        help: 'Width used for wide-aligned blocks.',
+    },
+    {
+        label: 'Block spacing',
+        path: ['styles', 'spacing', 'blockGap'],
+        testId: 'block-gap',
+    },
+];
+
+const LAYOUT_UNITS = [
+    { value: 'px', label: 'px', default: 16 },
+    { value: 'rem', label: 'rem', default: 1 },
+    { value: 'em', label: 'em', default: 1 },
+    { value: '%', label: '%', default: 100 },
+    { value: 'vw', label: 'vw', default: 50 },
+    { value: 'vh', label: 'vh', default: 50 },
+];
+
+function stringOrEmpty(value: unknown): string {
+    return typeof value === 'string' ? value : '';
+}
+
+export function LayoutPanel(props: LayoutPanelProps): JSX.Element {
+    const { editor, validationErrors } = props;
+
+    const customizedCount = useMemo(
+        () =>
+            LAYOUT_FIELDS.filter((field) =>
+                editor.isPathCustomized(field.path)
+            ).length,
+        [editor]
+    );
+
+    return (
+        <StylePanelSection
+            testId="ap-site-editor-style-panel-layout"
+            title={__('Layout', TEXT_DOMAIN)}
+            customizedCount={customizedCount}
+            onResetSection={() =>
+                LAYOUT_FIELDS.forEach((field) => editor.resetPath(field.path))
+            }
+        >
+            {LAYOUT_FIELDS.map((field) => {
+                const value = stringOrEmpty(editor.readValue(field.path));
+                const baseValue = stringOrEmpty(
+                    editor.readBaseValue(field.path)
+                );
+                const error =
+                    validationErrors?.[field.path.join('.')]?.[0] ?? null;
+
+                return (
+                    <StyleControlRow
+                        key={field.testId}
+                        testId={field.testId}
+                        isCustomized={editor.isPathCustomized(field.path)}
+                        onReset={() => editor.resetPath(field.path)}
+                        baseValue={baseValue === '' ? undefined : baseValue}
+                        error={error}
+                    >
+                        <UnitControl
+                            label={__(field.label, TEXT_DOMAIN)}
+                            help={
+                                field.help !== undefined
+                                    ? __(field.help, TEXT_DOMAIN)
+                                    : undefined
+                            }
+                            value={value}
+                            units={LAYOUT_UNITS}
+                            data-testid={`ap-site-editor-style-field-input-${field.testId}`}
+                            __nextHasNoMarginBottom={true}
+                            onChange={(next) =>
+                                editor.setValue(field.path, next ?? '')
+                            }
+                        />
+                    </StyleControlRow>
+                );
+            })}
+        </StylePanelSection>
+    );
+}

--- a/resources/js/visual-editor/site-editor/styles/panels/panel-controls.css
+++ b/resources/js/visual-editor/site-editor/styles/panels/panel-controls.css
@@ -79,12 +79,10 @@
     margin: 0;
     opacity: 0.75;
     overflow-wrap: anywhere;
-    word-break: break-word;
 }
 
 .ap-site-editor__style-control-row-base > code {
     overflow-wrap: anywhere;
-    word-break: break-word;
 }
 
 .ap-site-editor__style-control-row-error {
@@ -126,7 +124,7 @@
 .ap-site-editor__styles-inspector
     .components-panel__row
     + .components-panel__row {
-    border-top: 1px solid color-mix(in srgb, currentColor 8%, transparent);
+    border-top: 1px solid color-mix(in srgb, currentcolor 8%, transparent);
 }
 
 .ap-site-editor__styles-inspector .components-color-palette {

--- a/resources/js/visual-editor/site-editor/styles/panels/panel-controls.css
+++ b/resources/js/visual-editor/site-editor/styles/panels/panel-controls.css
@@ -1,0 +1,134 @@
+/*
+ * Styles panels — Gutenberg primitives with per-row customization chrome.
+ *
+ * The inner controls (TextControl / SelectControl / ColorPalette /
+ * UnitControl) inherit their visual language from `@wordpress/components`.
+ * This stylesheet only wires the Styles-specific decorations (customized
+ * highlight, reset affordance, theme-default hint) onto each row.
+ */
+
+.ap-site-editor__style-panel-wrapper {
+    min-width: 0;
+}
+
+.ap-site-editor__style-panel-meta {
+    align-items: center;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    justify-content: flex-start;
+    margin-bottom: 0.5rem;
+}
+
+.ap-site-editor__style-panel-customized {
+    background: color-mix(in srgb, #f59e0b 15%, transparent);
+    border-radius: 0.25rem;
+    color: #b45309;
+    font-size: 0.75rem;
+    font-weight: 600;
+    padding: 0.125rem 0.375rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.ap-site-editor__style-panel-description {
+    font-size: 0.8125rem;
+    margin: 0;
+    opacity: 0.75;
+}
+
+.ap-site-editor__style-control-row {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    min-width: 0;
+    padding-block: 0.375rem;
+    width: 100%;
+}
+
+.ap-site-editor__style-control-row[data-customized='true'] {
+    background: color-mix(in srgb, #f59e0b 6%, transparent);
+    border-left: 2px solid color-mix(in srgb, #f59e0b 40%, transparent);
+    margin-inline: -0.75rem;
+    padding: 0.5rem 0.5rem;
+}
+
+.ap-site-editor__style-control-row-control {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    min-width: 0;
+    width: 100%;
+}
+
+.ap-site-editor__style-control-row-control > * {
+    width: 100%;
+}
+
+.ap-site-editor__style-control-row-aside {
+    align-items: center;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25rem 0.5rem;
+    justify-content: flex-start;
+    min-width: 0;
+}
+
+.ap-site-editor__style-control-row-base {
+    font-size: 0.75rem;
+    margin: 0;
+    opacity: 0.75;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+}
+
+.ap-site-editor__style-control-row-base > code {
+    overflow-wrap: anywhere;
+    word-break: break-word;
+}
+
+.ap-site-editor__style-control-row-error {
+    color: #b91c1c;
+    font-size: 0.75rem;
+    margin: 0;
+}
+
+/* Make sure the Gutenberg wrappers don't overflow the narrow inspector. */
+
+.ap-site-editor__styles-inspector .components-base-control,
+.ap-site-editor__styles-inspector .components-panel__body,
+.ap-site-editor__styles-inspector .components-panel__row,
+.ap-site-editor__styles-inspector .components-input-control__container {
+    min-width: 0;
+    max-width: 100%;
+}
+
+.ap-site-editor__styles-inspector .components-panel__body {
+    padding: 0.75rem 1rem;
+}
+
+/*
+ * The base PanelRow clamps children to a 32px min-height and arranges
+ * them in a horizontal flex row. The Styles panels need vertical
+ * stacking so labels, controls, and reset affordances layer top-to-
+ * bottom — we keep PanelRow for the semantic grouping + rhythm, but
+ * override the flex direction + add visible separation between rows
+ * inside the same PanelBody.
+ */
+.ap-site-editor__styles-inspector .components-panel__row {
+    align-items: stretch;
+    flex-direction: column;
+    margin: 0;
+    min-height: 0;
+    padding-block: 0.5rem;
+}
+
+.ap-site-editor__styles-inspector
+    .components-panel__row
+    + .components-panel__row {
+    border-top: 1px solid color-mix(in srgb, currentColor 8%, transparent);
+}
+
+.ap-site-editor__styles-inspector .components-color-palette {
+    min-width: 0;
+}

--- a/resources/js/visual-editor/site-editor/styles/panels/panel-controls.tsx
+++ b/resources/js/visual-editor/site-editor/styles/panels/panel-controls.tsx
@@ -1,0 +1,157 @@
+/**
+ * Shared panel primitives built on `@wordpress/components`.
+ *
+ * Every style inspector panel renders its controls through Gutenberg's
+ * own primitives — the same `PanelBody` + `TextControl` + `SelectControl`
+ * + `ColorPalette` + `__experimentalUnitControl` set the block
+ * inspector uses — so the Styles section feels like a first-class piece
+ * of the editor chrome rather than a bespoke form. Customization
+ * tracking and reset-to-default affordances layer on top; anything the
+ * user has overridden is decorated + one click away from reverting to
+ * the theme base.
+ */
+
+import {
+    Button,
+    PanelBody,
+    PanelRow,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { type ReactNode } from 'react';
+
+import { TEXT_DOMAIN } from '../../../vendor/i18n';
+
+import './panel-controls.css';
+
+export interface StylePanelSectionProps {
+    title: string;
+    customizedCount: number;
+    onResetSection: () => void;
+    description?: ReactNode;
+    /** Stable test hook so panel tests can target this section directly. */
+    testId?: string;
+    children: ReactNode;
+}
+
+/**
+ * Top-level section wrapper for each styles panel. Wraps Gutenberg's
+ * {@link PanelBody} so the collapse affordance, focus behaviour, and
+ * keyboard handling mirror the rest of the editor. The "Customized"
+ * chip + "Reset all" action live in the header so the user always has
+ * a single click to compare against / revert to the theme defaults.
+ */
+export function StylePanelSection(
+    props: StylePanelSectionProps
+): JSX.Element {
+    const {
+        title,
+        customizedCount,
+        onResetSection,
+        description,
+        testId,
+        children,
+    } = props;
+
+    return (
+        <div
+            className="ap-site-editor__style-panel-wrapper"
+            data-testid={testId}
+        >
+            <PanelBody title={title} initialOpen={true}>
+                <div className="ap-site-editor__style-panel-meta">
+                    {customizedCount > 0 ? (
+                        <span
+                            className="ap-site-editor__style-panel-customized"
+                            data-testid="ap-site-editor-style-panel-customized"
+                        >
+                            {__('Customized', TEXT_DOMAIN)}
+                        </span>
+                    ) : null}
+                    {customizedCount > 0 ? (
+                        <Button
+                            variant="tertiary"
+                            size="small"
+                            data-testid="ap-site-editor-style-panel-reset"
+                            onClick={onResetSection}
+                        >
+                            {__('Reset all', TEXT_DOMAIN)}
+                        </Button>
+                    ) : null}
+                </div>
+                {description !== undefined ? (
+                    <PanelRow>
+                        <p className="ap-site-editor__style-panel-description">
+                            {description}
+                        </p>
+                    </PanelRow>
+                ) : null}
+                {children}
+            </PanelBody>
+        </div>
+    );
+}
+
+export interface StyleControlRowProps {
+    /** data-testid prefix, applied to the reset button + base-default hint. */
+    testId: string;
+    isCustomized: boolean;
+    onReset: () => void;
+    baseValue?: string;
+    error?: string | null;
+    children: ReactNode;
+}
+
+/**
+ * Wraps a Gutenberg control with the Styles-panel chrome the bare
+ * control doesn't know about: customization highlight, per-row "Reset"
+ * button, "Theme default:" hint, inline validation error. Keep this
+ * purely presentational so the control inside stays a vanilla
+ * `TextControl` / `SelectControl` / etc.
+ */
+export function StyleControlRow(props: StyleControlRowProps): JSX.Element {
+    const { testId, isCustomized, onReset, baseValue, error, children } = props;
+
+    return (
+        <PanelRow>
+            <div
+                className="ap-site-editor__style-control-row"
+                data-customized={isCustomized}
+                data-testid={`ap-site-editor-style-field-${testId}`}
+            >
+                <div className="ap-site-editor__style-control-row-control">
+                    {children}
+                </div>
+                {isCustomized ? (
+                    <div className="ap-site-editor__style-control-row-aside">
+                        <Button
+                            variant="tertiary"
+                            size="small"
+                            data-testid={`ap-site-editor-style-field-reset-${testId}`}
+                            onClick={onReset}
+                        >
+                            {__('Reset', TEXT_DOMAIN)}
+                        </Button>
+                        {baseValue !== undefined && baseValue !== '' ? (
+                            <p
+                                className="ap-site-editor__style-control-row-base"
+                                data-testid={`ap-site-editor-style-field-base-${testId}`}
+                            >
+                                {__('Theme default:', TEXT_DOMAIN)}{' '}
+                                <code>{baseValue}</code>
+                            </p>
+                        ) : null}
+                    </div>
+                ) : null}
+                {error !== null && error !== undefined ? (
+                    <p
+                        role="alert"
+                        className="ap-site-editor__style-control-row-error"
+                        data-testid={`ap-site-editor-style-field-error-${testId}`}
+                    >
+                        {error}
+                    </p>
+                ) : null}
+            </div>
+        </PanelRow>
+    );
+}

--- a/resources/js/visual-editor/site-editor/styles/panels/styles-fields.tsx
+++ b/resources/js/visual-editor/site-editor/styles/panels/styles-fields.tsx
@@ -44,13 +44,32 @@ export interface StyleFieldDescriptor {
 const CUSTOM_SENTINEL = '__custom__';
 const PRESET_VAR_PATTERN = /^var\(--wp--preset--color--([a-z0-9-]+)\)$/i;
 
-const FONT_WEIGHT_PRESETS = [
-    { value: '300', label: 'Light · 300' },
-    { value: '400', label: 'Regular · 400' },
-    { value: '500', label: 'Medium · 500' },
-    { value: '600', label: 'Semibold · 600' },
-    { value: '700', label: 'Bold · 700' },
+/**
+ * Stable value list — used for match detection so the "Custom…" escape
+ * hatch triggers only when the draft's weight isn't in the preset set.
+ * Labels live in {@link fontWeightPresetOptions} so their `__()` calls
+ * run at render time (after `bootI18n`), not at module load.
+ */
+const FONT_WEIGHT_PRESET_VALUES: ReadonlyArray<string> = [
+    '300',
+    '400',
+    '500',
+    '600',
+    '700',
 ];
+
+function fontWeightPresetOptions(): ReadonlyArray<{
+    value: string;
+    label: string;
+}> {
+    return [
+        { value: '300', label: __('Light · 300', TEXT_DOMAIN) },
+        { value: '400', label: __('Regular · 400', TEXT_DOMAIN) },
+        { value: '500', label: __('Medium · 500', TEXT_DOMAIN) },
+        { value: '600', label: __('Semibold · 600', TEXT_DOMAIN) },
+        { value: '700', label: __('Bold · 700', TEXT_DOMAIN) },
+    ];
+}
 
 const SIZE_UNITS = [
     { value: 'px', label: 'px', default: 0 },
@@ -231,12 +250,10 @@ export function renderStyleField(
 
     if (descriptor.kind === 'font-weight') {
         const options = [
-            ...FONT_WEIGHT_PRESETS,
+            ...fontWeightPresetOptions(),
             { value: CUSTOM_SENTINEL, label: __('Custom…', TEXT_DOMAIN) },
         ];
-        const matches = FONT_WEIGHT_PRESETS.some(
-            (preset) => preset.value === value
-        );
+        const matches = FONT_WEIGHT_PRESET_VALUES.includes(value);
         const selectValue = matches ? value : CUSTOM_SENTINEL;
 
         return (

--- a/resources/js/visual-editor/site-editor/styles/panels/styles-fields.tsx
+++ b/resources/js/visual-editor/site-editor/styles/panels/styles-fields.tsx
@@ -155,7 +155,7 @@ export function renderStyleField(
                     data-testid={`ap-site-editor-style-swatches-${descriptor.testId}`}
                 >
                     <span className="ap-site-editor__style-color-field-label">
-                        {__(descriptor.label, TEXT_DOMAIN)}
+                        {descriptor.label}
                     </span>
                     <ColorPalette
                         colors={paletteOptions}
@@ -199,7 +199,7 @@ export function renderStyleField(
         return (
             <StyleControlRow key={descriptor.testId} {...rowProps}>
                 <SelectControl
-                    label={__(descriptor.label, TEXT_DOMAIN)}
+                    label={descriptor.label}
                     value={selectValue}
                     options={options}
                     data-testid={selectTestId}
@@ -259,7 +259,7 @@ export function renderStyleField(
         return (
             <StyleControlRow key={descriptor.testId} {...rowProps}>
                 <SelectControl
-                    label={__(descriptor.label, TEXT_DOMAIN)}
+                    label={descriptor.label}
                     value={selectValue}
                     options={options}
                     data-testid={`ap-site-editor-style-field-select-${descriptor.testId}`}
@@ -293,7 +293,7 @@ export function renderStyleField(
     return (
         <StyleControlRow key={descriptor.testId} {...rowProps}>
             <UnitControl
-                label={__(descriptor.label, TEXT_DOMAIN)}
+                label={descriptor.label}
                 value={value}
                 units={SIZE_UNITS}
                 data-testid={`ap-site-editor-style-field-input-${descriptor.testId}`}

--- a/resources/js/visual-editor/site-editor/styles/panels/styles-fields.tsx
+++ b/resources/js/visual-editor/site-editor/styles/panels/styles-fields.tsx
@@ -188,7 +188,11 @@ export function renderStyleField(
                     __next40pxDefaultSize={true}
                     onChange={(next) => {
                         if (next === CUSTOM_SENTINEL) {
-                            editor.setValue(path, value);
+                            // Clear the value so the select sticks on
+                            // "Custom…" and the custom input renders —
+                            // re-writing the preset value would snap it
+                            // back to the preset row.
+                            editor.setValue(path, '');
                             return;
                         }
 
@@ -246,7 +250,7 @@ export function renderStyleField(
                     __next40pxDefaultSize={true}
                     onChange={(next) => {
                         if (next === CUSTOM_SENTINEL) {
-                            editor.setValue(path, value);
+                            editor.setValue(path, '');
                             return;
                         }
 

--- a/resources/js/visual-editor/site-editor/styles/panels/styles-fields.tsx
+++ b/resources/js/visual-editor/site-editor/styles/panels/styles-fields.tsx
@@ -1,0 +1,284 @@
+/**
+ * Shared styles-panel field renderers.
+ *
+ * Blocks-detail and Elements-detail both render the same core set of
+ * property controls — color (palette + custom picker), font family /
+ * size (preset dropdown + custom escape-hatch), size (number + unit).
+ * Centralizing them here keeps the two panels focused on their
+ * scope-specific wiring and guarantees the WP-component primitives they
+ * render stay identical.
+ */
+
+import {
+    ColorPalette,
+    SelectControl,
+    TextControl,
+    // `UnitControl` is still marked experimental upstream — its export
+    // name, props, and emitted value shape may shift between Gutenberg
+    // releases. Keep the alias centralized here so a rename is a single
+    // diff.
+    __experimentalUnitControl as UnitControl,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { type ReactElement } from 'react';
+
+import { TEXT_DOMAIN } from '../../../vendor/i18n';
+import type { ValidationErrors } from '../../api-client';
+import type { UseGlobalStylesEditorResult } from '../use-global-styles-editor';
+import { StyleControlRow } from './panel-controls';
+import type { StylePresets } from './use-preset-data';
+
+export type StyleFieldKind =
+    | 'color'
+    | 'font-family'
+    | 'font-size'
+    | 'font-weight'
+    | 'size';
+
+export interface StyleFieldDescriptor {
+    label: string;
+    testId: string;
+    kind: StyleFieldKind;
+}
+
+const CUSTOM_SENTINEL = '__custom__';
+const PRESET_VAR_PATTERN = /^var\(--wp--preset--color--([a-z0-9-]+)\)$/i;
+
+const FONT_WEIGHT_PRESETS = [
+    { value: '300', label: 'Light · 300' },
+    { value: '400', label: 'Regular · 400' },
+    { value: '500', label: 'Medium · 500' },
+    { value: '600', label: 'Semibold · 600' },
+    { value: '700', label: 'Bold · 700' },
+];
+
+const SIZE_UNITS = [
+    { value: 'px', label: 'px', default: 0 },
+    { value: 'rem', label: 'rem', default: 0 },
+    { value: 'em', label: 'em', default: 0 },
+    { value: '%', label: '%', default: 0 },
+];
+
+function stringOrEmpty(value: unknown): string {
+    return typeof value === 'string' ? value : '';
+}
+
+function resolveColorForPalette(
+    value: string,
+    palette: ReadonlyArray<{ slug: string; color: string }>
+): string | undefined {
+    const match = PRESET_VAR_PATTERN.exec(value);
+
+    if (match !== null) {
+        const slug = match[1] ?? '';
+        const entry = palette.find((swatch) => swatch.slug === slug);
+
+        if (entry !== undefined) {
+            return entry.color;
+        }
+    }
+
+    return value !== '' ? value : undefined;
+}
+
+function paletteRefFromColor(
+    color: string,
+    palette: ReadonlyArray<{ slug: string; color: string }>
+): string {
+    const match = palette.find(
+        (entry) => entry.color.toLowerCase() === color.toLowerCase()
+    );
+
+    if (match !== undefined) {
+        return `var(--wp--preset--color--${match.slug})`;
+    }
+
+    return color;
+}
+
+export interface RenderFieldOptions {
+    editor: UseGlobalStylesEditorResult;
+    validationErrors: ValidationErrors | null;
+    presets: StylePresets;
+    descriptor: StyleFieldDescriptor;
+    path: readonly string[];
+}
+
+export function renderStyleField(
+    options: RenderFieldOptions
+): ReactElement {
+    const { editor, validationErrors, presets, descriptor, path } = options;
+    const value = stringOrEmpty(editor.readValue(path));
+    const baseValue = stringOrEmpty(editor.readBaseValue(path));
+    const error = validationErrors?.[path.join('.')]?.[0] ?? null;
+    const isCustomized = editor.isPathCustomized(path);
+
+    const rowProps = {
+        testId: descriptor.testId,
+        isCustomized,
+        onReset: (): void => editor.resetPath(path),
+        baseValue: baseValue === '' ? undefined : baseValue,
+        error,
+    };
+
+    if (descriptor.kind === 'color') {
+        const paletteOptions = presets.palette.map((entry) => ({
+            slug: entry.slug,
+            name: entry.name,
+            color: entry.color,
+        }));
+        const resolved = resolveColorForPalette(value, paletteOptions);
+
+        return (
+            <StyleControlRow key={descriptor.testId} {...rowProps}>
+                <div
+                    className="ap-site-editor__style-color-field"
+                    data-testid={`ap-site-editor-style-swatches-${descriptor.testId}`}
+                >
+                    <span className="ap-site-editor__style-color-field-label">
+                        {__(descriptor.label, TEXT_DOMAIN)}
+                    </span>
+                    <ColorPalette
+                        colors={paletteOptions}
+                        value={resolved}
+                        clearable={true}
+                        enableAlpha={false}
+                        onChange={(next?: string) => {
+                            if (next === undefined || next === '') {
+                                editor.resetPath(path);
+                                return;
+                            }
+
+                            editor.setValue(
+                                path,
+                                paletteRefFromColor(next, paletteOptions)
+                            );
+                        }}
+                    />
+                </div>
+            </StyleControlRow>
+        );
+    }
+
+    if (descriptor.kind === 'font-family' || descriptor.kind === 'font-size') {
+        const presetList =
+            descriptor.kind === 'font-family'
+                ? presets.fontFamilies
+                : presets.fontSizes;
+        const options = [
+            ...presetList.map((preset) => ({
+                value: preset.value,
+                label: preset.label,
+            })),
+            { value: CUSTOM_SENTINEL, label: __('Custom…', TEXT_DOMAIN) },
+        ];
+        const matches = presetList.some((preset) => preset.value === value);
+        const selectValue = matches ? value : CUSTOM_SENTINEL;
+        const isFamily = descriptor.kind === 'font-family';
+        const selectTestId = `ap-site-editor-style-field-select-${descriptor.testId}`;
+
+        return (
+            <StyleControlRow key={descriptor.testId} {...rowProps}>
+                <SelectControl
+                    label={__(descriptor.label, TEXT_DOMAIN)}
+                    value={selectValue}
+                    options={options}
+                    data-testid={selectTestId}
+                    __nextHasNoMarginBottom={true}
+                    __next40pxDefaultSize={true}
+                    onChange={(next) => {
+                        if (next === CUSTOM_SENTINEL) {
+                            editor.setValue(path, value);
+                            return;
+                        }
+
+                        editor.setValue(path, next);
+                    }}
+                />
+                {selectValue === CUSTOM_SENTINEL ? (
+                    isFamily ? (
+                        <TextControl
+                            label={__('Custom value', TEXT_DOMAIN)}
+                            hideLabelFromVision={true}
+                            value={value}
+                            placeholder="system-ui, sans-serif"
+                            data-testid={`ap-site-editor-style-field-custom-${descriptor.testId}`}
+                            __nextHasNoMarginBottom={true}
+                            __next40pxDefaultSize={true}
+                            onChange={(next) => editor.setValue(path, next)}
+                        />
+                    ) : (
+                        <UnitControl
+                            label={__('Custom value', TEXT_DOMAIN)}
+                            hideLabelFromVision={true}
+                            value={value}
+                            units={SIZE_UNITS}
+                            data-testid={`ap-site-editor-style-field-custom-${descriptor.testId}`}
+                            __nextHasNoMarginBottom={true}
+                            onChange={(next) =>
+                                editor.setValue(path, next ?? '')
+                            }
+                        />
+                    )
+                ) : null}
+            </StyleControlRow>
+        );
+    }
+
+    if (descriptor.kind === 'font-weight') {
+        const options = [
+            ...FONT_WEIGHT_PRESETS,
+            { value: CUSTOM_SENTINEL, label: __('Custom…', TEXT_DOMAIN) },
+        ];
+        const matches = FONT_WEIGHT_PRESETS.some(
+            (preset) => preset.value === value
+        );
+        const selectValue = matches ? value : CUSTOM_SENTINEL;
+
+        return (
+            <StyleControlRow key={descriptor.testId} {...rowProps}>
+                <SelectControl
+                    label={__(descriptor.label, TEXT_DOMAIN)}
+                    value={selectValue}
+                    options={options}
+                    data-testid={`ap-site-editor-style-field-select-${descriptor.testId}`}
+                    __nextHasNoMarginBottom={true}
+                    __next40pxDefaultSize={true}
+                    onChange={(next) => {
+                        if (next === CUSTOM_SENTINEL) {
+                            editor.setValue(path, value);
+                            return;
+                        }
+
+                        editor.setValue(path, next);
+                    }}
+                />
+                {selectValue === CUSTOM_SENTINEL ? (
+                    <TextControl
+                        label={__('Custom weight', TEXT_DOMAIN)}
+                        hideLabelFromVision={true}
+                        value={value}
+                        placeholder="500"
+                        data-testid={`ap-site-editor-style-field-custom-${descriptor.testId}`}
+                        __nextHasNoMarginBottom={true}
+                        __next40pxDefaultSize={true}
+                        onChange={(next) => editor.setValue(path, next)}
+                    />
+                ) : null}
+            </StyleControlRow>
+        );
+    }
+
+    return (
+        <StyleControlRow key={descriptor.testId} {...rowProps}>
+            <UnitControl
+                label={__(descriptor.label, TEXT_DOMAIN)}
+                value={value}
+                units={SIZE_UNITS}
+                data-testid={`ap-site-editor-style-field-input-${descriptor.testId}`}
+                __nextHasNoMarginBottom={true}
+                onChange={(next) => editor.setValue(path, next ?? '')}
+            />
+        </StyleControlRow>
+    );
+}

--- a/resources/js/visual-editor/site-editor/styles/panels/typography-panel.tsx
+++ b/resources/js/visual-editor/site-editor/styles/panels/typography-panel.tsx
@@ -1,0 +1,261 @@
+/**
+ * Typography panel.
+ *
+ * Exposes the schema-v3 typography surface: `styles.typography.fontFamily`,
+ * `.fontSize`, `.lineHeight`, and `.letterSpacing`. Controls are the
+ * same Gutenberg primitives (`SelectControl`, `TextControl`,
+ * `__experimentalUnitControl`) the block inspector uses, wrapped in the
+ * Styles-panel customization chrome.
+ */
+
+import {
+    SelectControl,
+    TextControl,
+    // `UnitControl` is still marked experimental upstream — its export name,
+    // props, and emitted value shape may shift between Gutenberg releases.
+    // Keep the alias centralized so the inevitable rename is a single diff.
+    __experimentalUnitControl as UnitControl,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useMemo } from 'react';
+
+import { TEXT_DOMAIN } from '../../../vendor/i18n';
+import type { ValidationErrors } from '../../api-client';
+import type { UseGlobalStylesEditorResult } from '../use-global-styles-editor';
+import { StyleControlRow, StylePanelSection } from './panel-controls';
+import { useStylePresets } from './use-preset-data';
+
+export interface TypographyPanelProps {
+    editor: UseGlobalStylesEditorResult;
+    validationErrors: ValidationErrors | null;
+}
+
+const FONT_FAMILY_PATH = ['styles', 'typography', 'fontFamily'] as const;
+const FONT_SIZE_PATH = ['styles', 'typography', 'fontSize'] as const;
+const LINE_HEIGHT_PATH = ['styles', 'typography', 'lineHeight'] as const;
+const LETTER_SPACING_PATH = ['styles', 'typography', 'letterSpacing'] as const;
+
+const WATCHED_PATHS = [
+    FONT_FAMILY_PATH,
+    FONT_SIZE_PATH,
+    LINE_HEIGHT_PATH,
+    LETTER_SPACING_PATH,
+];
+
+const CUSTOM_SENTINEL = '__custom__';
+
+function stringOrEmpty(value: unknown): string {
+    return typeof value === 'string' ? value : '';
+}
+
+function errorFor(
+    errors: ValidationErrors | null,
+    path: readonly string[]
+): string | null {
+    return errors?.[path.join('.')]?.[0] ?? null;
+}
+
+export function TypographyPanel(props: TypographyPanelProps): JSX.Element {
+    const { editor, validationErrors } = props;
+    const presets = useStylePresets(editor);
+
+    const customizedCount = useMemo(
+        () =>
+            WATCHED_PATHS.filter((path) =>
+                editor.isPathCustomized(path)
+            ).length,
+        [editor]
+    );
+
+    const fontFamilyValue = stringOrEmpty(editor.readValue(FONT_FAMILY_PATH));
+    const fontFamilyOptions = useMemo(
+        () => [
+            ...presets.fontFamilies.map((preset) => ({
+                value: preset.value,
+                label: preset.label,
+            })),
+            { value: CUSTOM_SENTINEL, label: __('Custom…', TEXT_DOMAIN) },
+        ],
+        [presets.fontFamilies]
+    );
+    const fontFamilyMatches = presets.fontFamilies.some(
+        (preset) => preset.value === fontFamilyValue
+    );
+    const fontFamilySelectValue = fontFamilyMatches
+        ? fontFamilyValue
+        : CUSTOM_SENTINEL;
+
+    const fontSizeValue = stringOrEmpty(editor.readValue(FONT_SIZE_PATH));
+    const fontSizeOptions = useMemo(
+        () => [
+            ...presets.fontSizes.map((preset) => ({
+                value: preset.value,
+                label: preset.label,
+            })),
+            { value: CUSTOM_SENTINEL, label: __('Custom…', TEXT_DOMAIN) },
+        ],
+        [presets.fontSizes]
+    );
+    const fontSizeMatches = presets.fontSizes.some(
+        (preset) => preset.value === fontSizeValue
+    );
+    const fontSizeSelectValue = fontSizeMatches
+        ? fontSizeValue
+        : CUSTOM_SENTINEL;
+
+    return (
+        <StylePanelSection
+            testId="ap-site-editor-style-panel-typography"
+            title={__('Typography', TEXT_DOMAIN)}
+            customizedCount={customizedCount}
+            onResetSection={() =>
+                WATCHED_PATHS.forEach((path) => editor.resetPath(path))
+            }
+            description={__(
+                'Typography defaults apply site-wide. Override per element under "Elements" and per block under "Blocks".',
+                TEXT_DOMAIN
+            )}
+        >
+            <StyleControlRow
+                testId="font-family"
+                isCustomized={editor.isPathCustomized(FONT_FAMILY_PATH)}
+                onReset={() => editor.resetPath(FONT_FAMILY_PATH)}
+                baseValue={stringOrEmpty(
+                    editor.readBaseValue(FONT_FAMILY_PATH)
+                )}
+                error={errorFor(validationErrors, FONT_FAMILY_PATH)}
+            >
+                <SelectControl
+                    label={__('Font family', TEXT_DOMAIN)}
+                    value={fontFamilySelectValue}
+                    options={fontFamilyOptions}
+                    data-testid="ap-site-editor-style-field-select-font-family"
+                    __nextHasNoMarginBottom={true}
+                    __next40pxDefaultSize={true}
+                    onChange={(next) => {
+                        if (next === CUSTOM_SENTINEL) {
+                            // Seed the custom input with the current draft
+                            // value so the user tweaks rather than retypes.
+                            editor.setValue(FONT_FAMILY_PATH, fontFamilyValue);
+                            return;
+                        }
+
+                        editor.setValue(FONT_FAMILY_PATH, next);
+                    }}
+                />
+                {fontFamilySelectValue === CUSTOM_SENTINEL ? (
+                    <TextControl
+                        label={__('Custom font family', TEXT_DOMAIN)}
+                        hideLabelFromVision={true}
+                        value={fontFamilyValue}
+                        placeholder="system-ui, sans-serif"
+                        data-testid="ap-site-editor-style-field-custom-font-family"
+                        __nextHasNoMarginBottom={true}
+                        __next40pxDefaultSize={true}
+                        onChange={(next) =>
+                            editor.setValue(FONT_FAMILY_PATH, next)
+                        }
+                    />
+                ) : null}
+            </StyleControlRow>
+
+            <StyleControlRow
+                testId="font-size"
+                isCustomized={editor.isPathCustomized(FONT_SIZE_PATH)}
+                onReset={() => editor.resetPath(FONT_SIZE_PATH)}
+                baseValue={stringOrEmpty(
+                    editor.readBaseValue(FONT_SIZE_PATH)
+                )}
+                error={errorFor(validationErrors, FONT_SIZE_PATH)}
+            >
+                <SelectControl
+                    label={__('Font size', TEXT_DOMAIN)}
+                    value={fontSizeSelectValue}
+                    options={fontSizeOptions}
+                    data-testid="ap-site-editor-style-field-select-font-size"
+                    __nextHasNoMarginBottom={true}
+                    __next40pxDefaultSize={true}
+                    onChange={(next) => {
+                        if (next === CUSTOM_SENTINEL) {
+                            editor.setValue(FONT_SIZE_PATH, fontSizeValue);
+                            return;
+                        }
+
+                        editor.setValue(FONT_SIZE_PATH, next);
+                    }}
+                />
+                {fontSizeSelectValue === CUSTOM_SENTINEL ? (
+                    <UnitControl
+                        label={__('Custom font size', TEXT_DOMAIN)}
+                        hideLabelFromVision={true}
+                        value={fontSizeValue}
+                        units={[
+                            { value: 'px', label: 'px', default: 16 },
+                            { value: 'rem', label: 'rem', default: 1 },
+                            { value: 'em', label: 'em', default: 1 },
+                            { value: '%', label: '%', default: 100 },
+                        ]}
+                        data-testid="ap-site-editor-style-field-custom-font-size"
+                        __nextHasNoMarginBottom={true}
+                        onChange={(next) =>
+                            editor.setValue(FONT_SIZE_PATH, next ?? '')
+                        }
+                    />
+                ) : null}
+            </StyleControlRow>
+
+            <StyleControlRow
+                testId="line-height"
+                isCustomized={editor.isPathCustomized(LINE_HEIGHT_PATH)}
+                onReset={() => editor.resetPath(LINE_HEIGHT_PATH)}
+                baseValue={stringOrEmpty(
+                    editor.readBaseValue(LINE_HEIGHT_PATH)
+                )}
+                error={errorFor(validationErrors, LINE_HEIGHT_PATH)}
+            >
+                <TextControl
+                    label={__('Line height', TEXT_DOMAIN)}
+                    type="number"
+                    value={stringOrEmpty(
+                        editor.readValue(LINE_HEIGHT_PATH)
+                    )}
+                    step="0.1"
+                    min="0"
+                    data-testid="ap-site-editor-style-field-input-line-height"
+                    __nextHasNoMarginBottom={true}
+                    __next40pxDefaultSize={true}
+                    onChange={(next) =>
+                        editor.setValue(LINE_HEIGHT_PATH, next)
+                    }
+                />
+            </StyleControlRow>
+
+            <StyleControlRow
+                testId="letter-spacing"
+                isCustomized={editor.isPathCustomized(LETTER_SPACING_PATH)}
+                onReset={() => editor.resetPath(LETTER_SPACING_PATH)}
+                baseValue={stringOrEmpty(
+                    editor.readBaseValue(LETTER_SPACING_PATH)
+                )}
+                error={errorFor(validationErrors, LETTER_SPACING_PATH)}
+            >
+                <UnitControl
+                    label={__('Letter spacing', TEXT_DOMAIN)}
+                    value={stringOrEmpty(
+                        editor.readValue(LETTER_SPACING_PATH)
+                    )}
+                    units={[
+                        { value: 'px', label: 'px', default: 0 },
+                        { value: 'em', label: 'em', default: 0 },
+                        { value: 'rem', label: 'rem', default: 0 },
+                    ]}
+                    data-testid="ap-site-editor-style-field-input-letter-spacing"
+                    __nextHasNoMarginBottom={true}
+                    onChange={(next) =>
+                        editor.setValue(LETTER_SPACING_PATH, next ?? '')
+                    }
+                />
+            </StyleControlRow>
+        </StylePanelSection>
+    );
+}

--- a/resources/js/visual-editor/site-editor/styles/panels/typography-panel.tsx
+++ b/resources/js/visual-editor/site-editor/styles/panels/typography-panel.tsx
@@ -134,9 +134,11 @@ export function TypographyPanel(props: TypographyPanelProps): JSX.Element {
                     __next40pxDefaultSize={true}
                     onChange={(next) => {
                         if (next === CUSTOM_SENTINEL) {
-                            // Seed the custom input with the current draft
-                            // value so the user tweaks rather than retypes.
-                            editor.setValue(FONT_FAMILY_PATH, fontFamilyValue);
+                            // Clear the value so `fontFamilyMatches` flips
+                            // to false and the Custom input renders —
+                            // otherwise re-writing the current preset value
+                            // would snap the select straight back.
+                            editor.setValue(FONT_FAMILY_PATH, '');
                             return;
                         }
 
@@ -177,7 +179,7 @@ export function TypographyPanel(props: TypographyPanelProps): JSX.Element {
                     __next40pxDefaultSize={true}
                     onChange={(next) => {
                         if (next === CUSTOM_SENTINEL) {
-                            editor.setValue(FONT_SIZE_PATH, fontSizeValue);
+                            editor.setValue(FONT_SIZE_PATH, '');
                             return;
                         }
 

--- a/resources/js/visual-editor/site-editor/styles/panels/use-preset-data.ts
+++ b/resources/js/visual-editor/site-editor/styles/panels/use-preset-data.ts
@@ -1,0 +1,158 @@
+/**
+ * Preset data hook.
+ *
+ * Reads the current palette / font-family / font-size preset lists off
+ * the editor draft so each panel can seed its WP-style picker controls
+ * without re-implementing the same shape-mapping over and over.
+ *
+ * Kept as a hook (not a util) so the memoization can key on the editor
+ * draft identity — panel renders see stable preset arrays when nothing
+ * about the registered presets has changed.
+ */
+
+import { useMemo } from 'react';
+
+import type { UseGlobalStylesEditorResult } from '../use-global-styles-editor';
+import type { PaletteSwatch } from './color-value-field';
+import type { PresetOption } from './preset-select-field';
+
+export interface StylePresets {
+    palette: readonly PaletteSwatch[];
+    fontFamilies: readonly PresetOption[];
+    fontSizes: readonly PresetOption[];
+}
+
+function readPaletteEntries(
+    editor: UseGlobalStylesEditorResult
+): readonly PaletteSwatch[] {
+    const raw = editor.readValue(['settings', 'color', 'palette']);
+
+    if (!Array.isArray(raw)) {
+        return [];
+    }
+
+    const result: PaletteSwatch[] = [];
+
+    for (const entry of raw) {
+        if (entry === null || typeof entry !== 'object') {
+            continue;
+        }
+
+        const row = entry as Record<string, unknown>;
+        const slug = typeof row.slug === 'string' ? row.slug : null;
+        const name =
+            typeof row.name === 'string' ? row.name : slug ?? null;
+        const color = typeof row.color === 'string' ? row.color : null;
+
+        if (slug === null || name === null || color === null) {
+            continue;
+        }
+
+        result.push({ slug, name, color });
+    }
+
+    return result;
+}
+
+function readFontFamilyPresets(
+    editor: UseGlobalStylesEditorResult
+): readonly PresetOption[] {
+    const raw = editor.readValue([
+        'settings',
+        'typography',
+        'fontFamilies',
+    ]);
+
+    if (!Array.isArray(raw)) {
+        return [];
+    }
+
+    const result: PresetOption[] = [];
+
+    for (const entry of raw) {
+        if (entry === null || typeof entry !== 'object') {
+            continue;
+        }
+
+        const row = entry as Record<string, unknown>;
+        const slug = typeof row.slug === 'string' ? row.slug : null;
+        const name =
+            typeof row.name === 'string' ? row.name : slug ?? null;
+
+        if (slug === null || name === null) {
+            continue;
+        }
+
+        result.push({
+            slug,
+            label: name,
+            value: `var(--wp--preset--font-family--${slug})`,
+        });
+    }
+
+    return result;
+}
+
+function readFontSizePresets(
+    editor: UseGlobalStylesEditorResult
+): readonly PresetOption[] {
+    const raw = editor.readValue([
+        'settings',
+        'typography',
+        'fontSizes',
+    ]);
+
+    if (!Array.isArray(raw)) {
+        return [];
+    }
+
+    const result: PresetOption[] = [];
+
+    for (const entry of raw) {
+        if (entry === null || typeof entry !== 'object') {
+            continue;
+        }
+
+        const row = entry as Record<string, unknown>;
+        const slug = typeof row.slug === 'string' ? row.slug : null;
+        const name =
+            typeof row.name === 'string' ? row.name : slug ?? null;
+        const size =
+            typeof row.size === 'string' ? (row.size as string) : null;
+
+        if (slug === null || name === null) {
+            continue;
+        }
+
+        const labelParts: string[] = [name];
+
+        if (size !== null) {
+            labelParts.push(`· ${size}`);
+        }
+
+        result.push({
+            slug,
+            label: labelParts.join(' '),
+            value: `var(--wp--preset--font-size--${slug})`,
+        });
+    }
+
+    return result;
+}
+
+export function useStylePresets(
+    editor: UseGlobalStylesEditorResult
+): StylePresets {
+    // Key memos on the editor draft identity — every edit rebuilds the
+    // draft reference so panel-side memos see a fresh list, but idle
+    // renders reuse the previous arrays.
+    return useMemo(
+        () => ({
+            palette: readPaletteEntries(editor),
+            fontFamilies: readFontFamilyPresets(editor),
+            fontSizes: readFontSizePresets(editor),
+        }),
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        [editor.draft]
+    );
+}

--- a/resources/js/visual-editor/site-editor/styles/panels/variations-panel.tsx
+++ b/resources/js/visual-editor/site-editor/styles/panels/variations-panel.tsx
@@ -1,0 +1,104 @@
+/**
+ * Variations panel.
+ *
+ * Themes can ship named style variations (theme.json
+ * `styles.variations`) — bundled presets the site owner swaps in via a
+ * picker. Per plan §8 and the design brief, V1 ships the picker UI;
+ * full authoring (create a new variation from scratch) is 1.1. Users
+ * can, however, "duplicate + tweak" an applied variation because each
+ * picker entry just writes its `settings` / `styles` into the user
+ * record — subsequent panel edits layer on top as normal.
+ */
+
+import { Button, PanelRow } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useMemo } from 'react';
+
+import { TEXT_DOMAIN } from '../../../vendor/i18n';
+import type { UseGlobalStylesEditorResult } from '../use-global-styles-editor';
+import type { StyleVariation } from '../style-book-canvas';
+import { StylePanelSection } from './panel-controls';
+
+export interface VariationsPanelProps {
+    editor: UseGlobalStylesEditorResult;
+    variations: readonly StyleVariation[];
+    activeVariationSlug: string | null;
+    onApplyVariation: (slug: string) => void;
+}
+
+export function VariationsPanel(
+    props: VariationsPanelProps
+): JSX.Element {
+    const { editor, variations, activeVariationSlug, onApplyVariation } =
+        props;
+
+    const hasCustomizations = useMemo(() => editor.isDirty, [editor.isDirty]);
+
+    return (
+        <StylePanelSection
+            testId="ap-site-editor-style-panel-variations"
+            title={__('Style variations', TEXT_DOMAIN)}
+            customizedCount={hasCustomizations ? 1 : 0}
+            onResetSection={() => editor.resetAll()}
+            description={__(
+                'Switch between theme-provided style presets. Applying a variation overwrites the current user record with the preset\'s settings and styles — your in-flight edits are discarded.',
+                TEXT_DOMAIN
+            )}
+        >
+            <PanelRow>
+                {variations.length === 0 ? (
+                    <p
+                        className="ap-site-editor__style-panel-description"
+                        data-testid="ap-site-editor-style-panel-variations-empty"
+                    >
+                        {__(
+                            'The active theme does not provide style variations.',
+                            TEXT_DOMAIN
+                        )}
+                    </p>
+                ) : (
+                    <ul
+                        className="ap-site-editor__style-listing-list"
+                        data-testid="ap-site-editor-style-panel-variations-list"
+                    >
+                        {variations.map((variation) => {
+                            const isActive =
+                                activeVariationSlug === variation.slug;
+
+                            return (
+                                <li
+                                    key={variation.slug}
+                                    className="ap-site-editor__style-listing-item"
+                                >
+                                    <Button
+                                        variant={
+                                            isActive ? 'primary' : 'tertiary'
+                                        }
+                                        className="ap-site-editor__style-listing-link"
+                                        data-active={isActive}
+                                        data-testid={`ap-site-editor-style-panel-variation-${variation.slug}`}
+                                        onClick={() =>
+                                            onApplyVariation(variation.slug)
+                                        }
+                                    >
+                                        <span className="ap-site-editor__style-listing-label">
+                                            {variation.title}
+                                        </span>
+                                        {isActive ? (
+                                            <span
+                                                className="ap-site-editor__style-panel-customized"
+                                                data-testid={`ap-site-editor-style-panel-variation-active-${variation.slug}`}
+                                            >
+                                                {__('Applied', TEXT_DOMAIN)}
+                                            </span>
+                                        ) : null}
+                                    </Button>
+                                </li>
+                            );
+                        })}
+                    </ul>
+                )}
+            </PanelRow>
+        </StylePanelSection>
+    );
+}

--- a/resources/js/visual-editor/site-editor/styles/style-book-canvas.css
+++ b/resources/js/visual-editor/site-editor/styles/style-book-canvas.css
@@ -1,0 +1,101 @@
+/*
+ * Style-book canvas styles.
+ */
+
+.ap-site-editor__style-book {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    height: 100%;
+    overflow: auto;
+    padding: 1rem;
+}
+
+.ap-site-editor__style-book-variations {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    padding: 0.5rem 0;
+}
+
+.ap-site-editor__style-book-variation {
+    appearance: none;
+    background: transparent;
+    border: 1px solid color-mix(in srgb, currentColor 25%, transparent);
+    border-radius: 0.375rem;
+    color: inherit;
+    cursor: pointer;
+    font: inherit;
+    min-width: 8rem;
+    padding: 0.5rem 0.75rem;
+}
+
+.ap-site-editor__style-book-variation[data-active='true'] {
+    background: color-mix(in srgb, currentColor 10%, transparent);
+    border-color: color-mix(in srgb, currentColor 40%, transparent);
+    font-weight: 600;
+}
+
+.ap-site-editor__style-book-note,
+.ap-site-editor__style-book-error {
+    font-size: 0.8125rem;
+    margin: 0;
+}
+
+.ap-site-editor__style-book-error {
+    color: #b91c1c;
+}
+
+.ap-site-editor__style-book-body {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.ap-site-editor__style-book-section {
+    background: color-mix(in srgb, currentColor 4%, transparent);
+    border: 1px solid color-mix(in srgb, currentColor 8%, transparent);
+    border-radius: 0.5rem;
+    padding: 1rem;
+}
+
+.ap-site-editor__style-book-h {
+    font-size: 1rem;
+    font-weight: 600;
+    margin: 0 0 0.5rem 0;
+}
+
+.ap-site-editor__style-book-swatches {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.ap-site-editor__style-book-swatch {
+    align-items: center;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    text-align: center;
+}
+
+.ap-site-editor__style-book-swatch-chip {
+    border: 1px solid color-mix(in srgb, currentColor 18%, transparent);
+    border-radius: 0.25rem;
+    display: block;
+    height: 2.5rem;
+    width: 3rem;
+}
+
+.ap-site-editor__style-book-swatch-name {
+    font-size: 0.8125rem;
+    font-weight: 500;
+}
+
+.ap-site-editor__style-book-swatch-value {
+    font-size: 0.75rem;
+    opacity: 0.75;
+}

--- a/resources/js/visual-editor/site-editor/styles/style-book-canvas.css
+++ b/resources/js/visual-editor/site-editor/styles/style-book-canvas.css
@@ -21,7 +21,7 @@
 .ap-site-editor__style-book-variation {
     appearance: none;
     background: transparent;
-    border: 1px solid color-mix(in srgb, currentColor 25%, transparent);
+    border: 1px solid color-mix(in srgb, currentcolor 25%, transparent);
     border-radius: 0.375rem;
     color: inherit;
     cursor: pointer;
@@ -31,8 +31,8 @@
 }
 
 .ap-site-editor__style-book-variation[data-active='true'] {
-    background: color-mix(in srgb, currentColor 10%, transparent);
-    border-color: color-mix(in srgb, currentColor 40%, transparent);
+    background: color-mix(in srgb, currentcolor 10%, transparent);
+    border-color: color-mix(in srgb, currentcolor 40%, transparent);
     font-weight: 600;
 }
 
@@ -53,8 +53,8 @@
 }
 
 .ap-site-editor__style-book-section {
-    background: color-mix(in srgb, currentColor 4%, transparent);
-    border: 1px solid color-mix(in srgb, currentColor 8%, transparent);
+    background: color-mix(in srgb, currentcolor 4%, transparent);
+    border: 1px solid color-mix(in srgb, currentcolor 8%, transparent);
     border-radius: 0.5rem;
     padding: 1rem;
 }
@@ -83,7 +83,7 @@
 }
 
 .ap-site-editor__style-book-swatch-chip {
-    border: 1px solid color-mix(in srgb, currentColor 18%, transparent);
+    border: 1px solid color-mix(in srgb, currentcolor 18%, transparent);
     border-radius: 0.25rem;
     display: block;
     height: 2.5rem;

--- a/resources/js/visual-editor/site-editor/styles/style-book-canvas.tsx
+++ b/resources/js/visual-editor/site-editor/styles/style-book-canvas.tsx
@@ -1,0 +1,294 @@
+/**
+ * Style Book canvas.
+ *
+ * Per design brief §3.7, the Styles section's canvas is a Style Book —
+ * a gallery of block examples rendered against the current style state —
+ * and it stays on-screen both when browsing the navigator and when
+ * editing an inspector panel. That "live preview as you edit" loop is
+ * the single-biggest demo moment per the issue.
+ *
+ * For V1 we ship a lightweight preview that reflects the key
+ * customizable primitives (typography, colors, element styles, a
+ * sampler of blocks) rather than WP's full preview-every-block panel
+ * (issue notes: WP's "style book" panel is NOT in scope). The preview
+ * reads directly from the merged draft so every user edit surfaces
+ * immediately, which is enough to validate the inspector is doing the
+ * right thing.
+ *
+ * The variation-picker strip sits above the preview per brief §3.7 —
+ * horizontal cards, one per theme-provided variation, clicking one
+ * overwrites the user record with the preset's values (the V1 scope;
+ * authoring new variations is deferred to 1.1 per plan §8).
+ */
+
+import { __, sprintf } from '@wordpress/i18n';
+import { type CSSProperties, useMemo } from 'react';
+
+import { TEXT_DOMAIN } from '../../vendor/i18n';
+
+import type { GlobalStylesDraft } from './use-global-styles-editor';
+
+import './style-book-canvas.css';
+
+export interface StyleVariation {
+    slug: string;
+    title: string;
+    settings?: Record<string, unknown>;
+    styles?: Record<string, unknown>;
+}
+
+export interface StyleBookCanvasProps {
+    draft: GlobalStylesDraft | null;
+    variations: readonly StyleVariation[];
+    activeVariationSlug: string | null;
+    onSelectVariation: (slug: string) => void;
+    loadError: string | null;
+}
+
+interface Swatch {
+    slug: string;
+    name: string;
+    color: string;
+}
+
+function readPalette(draft: GlobalStylesDraft | null): readonly Swatch[] {
+    if (draft === null) {
+        return [];
+    }
+
+    const palette = (draft.settings as Record<string, Record<string, unknown>>)
+        ?.color?.palette;
+
+    if (!Array.isArray(palette)) {
+        return [];
+    }
+
+    const swatches: Swatch[] = [];
+
+    for (const entry of palette) {
+        if (entry === null || typeof entry !== 'object') {
+            continue;
+        }
+
+        const row = entry as Record<string, unknown>;
+        const slug = typeof row.slug === 'string' ? row.slug : null;
+        const name = typeof row.name === 'string' ? row.name : null;
+        const color = typeof row.color === 'string' ? row.color : null;
+
+        if (slug === null || name === null || color === null) {
+            continue;
+        }
+
+        swatches.push({ slug, name, color });
+    }
+
+    return swatches;
+}
+
+function readTypographyPreview(
+    draft: GlobalStylesDraft | null
+): { family: string | null; size: string | null } {
+    if (draft === null) {
+        return { family: null, size: null };
+    }
+
+    const typography = (
+        draft.styles as Record<string, Record<string, unknown>>
+    )?.typography;
+
+    const family =
+        typeof typography?.fontFamily === 'string'
+            ? (typography.fontFamily as string)
+            : null;
+    const size =
+        typeof typography?.fontSize === 'string'
+            ? (typography.fontSize as string)
+            : null;
+
+    return { family, size };
+}
+
+function readLayoutPreview(
+    draft: GlobalStylesDraft | null
+): { contentSize: string | null; wideSize: string | null } {
+    if (draft === null) {
+        return { contentSize: null, wideSize: null };
+    }
+
+    const layout = (draft.settings as Record<string, Record<string, unknown>>)
+        ?.layout;
+
+    const contentSize =
+        typeof layout?.contentSize === 'string'
+            ? (layout.contentSize as string)
+            : null;
+    const wideSize =
+        typeof layout?.wideSize === 'string'
+            ? (layout.wideSize as string)
+            : null;
+
+    return { contentSize, wideSize };
+}
+
+function presetVarOrLiteral(value: string | null): string | undefined {
+    if (value === null) {
+        return undefined;
+    }
+
+    return value;
+}
+
+export function StyleBookCanvas(props: StyleBookCanvasProps): JSX.Element {
+    const { draft, variations, activeVariationSlug, onSelectVariation, loadError } =
+        props;
+    const palette = useMemo(() => readPalette(draft), [draft]);
+    const typography = useMemo(() => readTypographyPreview(draft), [draft]);
+    const layout = useMemo(() => readLayoutPreview(draft), [draft]);
+
+    const bodyStyle: CSSProperties = useMemo(() => {
+        return {
+            fontFamily: presetVarOrLiteral(typography.family),
+            fontSize: presetVarOrLiteral(typography.size),
+        };
+    }, [typography.family, typography.size]);
+
+    return (
+        <div
+            className="ap-site-editor__style-book"
+            data-testid="ap-site-editor-style-book"
+        >
+            <div
+                className="ap-site-editor__style-book-variations"
+                role="radiogroup"
+                aria-label={__('Style variations', TEXT_DOMAIN)}
+                data-testid="ap-site-editor-style-book-variations"
+            >
+                {variations.length === 0 ? (
+                    <p
+                        className="ap-site-editor__style-book-note"
+                        data-testid="ap-site-editor-style-book-no-variations"
+                    >
+                        {__(
+                            'The active theme does not provide style variations.',
+                            TEXT_DOMAIN
+                        )}
+                    </p>
+                ) : null}
+                {variations.map((variation, index) => {
+                    const isActive =
+                        activeVariationSlug === variation.slug;
+                    // Roving-tabindex per the WAI-ARIA APG `radiogroup`
+                    // pattern: only the selected (or the first, when
+                    // nothing is selected yet) radio is tab-reachable;
+                    // the rest step through with arrow keys.
+                    const isTabStop =
+                        isActive ||
+                        (activeVariationSlug === null && index === 0);
+
+                    return (
+                        <button
+                            key={variation.slug}
+                            type="button"
+                            role="radio"
+                            aria-checked={isActive}
+                            tabIndex={isTabStop ? 0 : -1}
+                            className="ap-site-editor__style-book-variation"
+                            data-active={isActive}
+                            data-testid={`ap-site-editor-style-book-variation-${variation.slug}`}
+                            onClick={() => onSelectVariation(variation.slug)}
+                        >
+                            <span className="ap-site-editor__style-book-variation-title">
+                                {variation.title}
+                            </span>
+                        </button>
+                    );
+                })}
+            </div>
+
+            {loadError !== null ? (
+                <p
+                    role="alert"
+                    className="ap-site-editor__style-book-error"
+                    data-testid="ap-site-editor-style-book-error"
+                >
+                    {loadError}
+                </p>
+            ) : null}
+
+            <div
+                className="ap-site-editor__style-book-body"
+                style={bodyStyle}
+                data-testid="ap-site-editor-style-book-body"
+            >
+                <section
+                    className="ap-site-editor__style-book-section"
+                    aria-label={__('Typography sample', TEXT_DOMAIN)}
+                >
+                    <h2 className="ap-site-editor__style-book-h">
+                        {__('Headline sample', TEXT_DOMAIN)}
+                    </h2>
+                    <p>
+                        {__(
+                            'The quick brown fox jumps over the lazy dog.',
+                            TEXT_DOMAIN
+                        )}
+                    </p>
+                </section>
+                <section
+                    className="ap-site-editor__style-book-section"
+                    aria-label={__('Color palette', TEXT_DOMAIN)}
+                >
+                    <h2 className="ap-site-editor__style-book-h">
+                        {__('Palette', TEXT_DOMAIN)}
+                    </h2>
+                    <ul
+                        className="ap-site-editor__style-book-swatches"
+                        data-testid="ap-site-editor-style-book-swatches"
+                    >
+                        {palette.map((swatch, index) => (
+                            <li
+                                key={`${swatch.slug}-${index}`}
+                                className="ap-site-editor__style-book-swatch"
+                                data-testid={`ap-site-editor-style-book-swatch-${swatch.slug}`}
+                            >
+                                <span
+                                    className="ap-site-editor__style-book-swatch-chip"
+                                    style={{ background: swatch.color }}
+                                    aria-hidden="true"
+                                />
+                                <span className="ap-site-editor__style-book-swatch-name">
+                                    {swatch.name}
+                                </span>
+                                <code className="ap-site-editor__style-book-swatch-value">
+                                    {swatch.color}
+                                </code>
+                            </li>
+                        ))}
+                    </ul>
+                </section>
+                <section
+                    className="ap-site-editor__style-book-section"
+                    aria-label={__('Layout preview', TEXT_DOMAIN)}
+                >
+                    <h2 className="ap-site-editor__style-book-h">
+                        {__('Layout', TEXT_DOMAIN)}
+                    </h2>
+                    <p data-testid="ap-site-editor-style-book-content-width">
+                        {sprintf(
+                            /* translators: %s: content-size value (e.g. "720px"). */
+                            __('Content width: %s', TEXT_DOMAIN),
+                            layout.contentSize ?? __('default', TEXT_DOMAIN)
+                        )}
+                    </p>
+                    <p data-testid="ap-site-editor-style-book-wide-width">
+                        {sprintf(
+                            /* translators: %s: wide-size value. */
+                            __('Wide width: %s', TEXT_DOMAIN),
+                            layout.wideSize ?? __('default', TEXT_DOMAIN)
+                        )}
+                    </p>
+                </section>
+            </div>
+        </div>
+    );
+}

--- a/resources/js/visual-editor/site-editor/styles/style-book-canvas.tsx
+++ b/resources/js/visual-editor/site-editor/styles/style-book-canvas.tsx
@@ -22,7 +22,13 @@
  */
 
 import { __, sprintf } from '@wordpress/i18n';
-import { type CSSProperties, useMemo } from 'react';
+import {
+    useCallback,
+    useMemo,
+    useRef,
+    type CSSProperties,
+    type KeyboardEvent as ReactKeyboardEvent,
+} from 'react';
 
 import { TEXT_DOMAIN } from '../../vendor/i18n';
 
@@ -152,6 +158,54 @@ export function StyleBookCanvas(props: StyleBookCanvasProps): JSX.Element {
         };
     }, [typography.family, typography.size]);
 
+    const variationButtonsRef = useRef<Array<HTMLButtonElement | null>>([]);
+
+    // WAI-ARIA APG `radiogroup` keyboard behavior: arrow keys cycle
+    // through the radios (with wrap-around), Home / End jump to the
+    // ends, and moving focus also selects — matching the roving-tabindex
+    // we render above.
+    const handleVariationKeyDown = useCallback(
+        (event: ReactKeyboardEvent<HTMLDivElement>): void => {
+            if (variations.length === 0) {
+                return;
+            }
+
+            const currentIndex = variations.findIndex(
+                (variation) => variation.slug === activeVariationSlug
+            );
+            const effectiveIndex = currentIndex === -1 ? 0 : currentIndex;
+
+            let nextIndex: number | null = null;
+
+            if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
+                nextIndex = (effectiveIndex + 1) % variations.length;
+            } else if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
+                nextIndex =
+                    (effectiveIndex - 1 + variations.length) %
+                    variations.length;
+            } else if (event.key === 'Home') {
+                nextIndex = 0;
+            } else if (event.key === 'End') {
+                nextIndex = variations.length - 1;
+            }
+
+            if (nextIndex === null) {
+                return;
+            }
+
+            event.preventDefault();
+            const nextVariation = variations[nextIndex];
+
+            if (nextVariation === undefined) {
+                return;
+            }
+
+            onSelectVariation(nextVariation.slug);
+            variationButtonsRef.current[nextIndex]?.focus();
+        },
+        [activeVariationSlug, onSelectVariation, variations]
+    );
+
     return (
         <div
             className="ap-site-editor__style-book"
@@ -162,6 +216,7 @@ export function StyleBookCanvas(props: StyleBookCanvasProps): JSX.Element {
                 role="radiogroup"
                 aria-label={__('Style variations', TEXT_DOMAIN)}
                 data-testid="ap-site-editor-style-book-variations"
+                onKeyDown={handleVariationKeyDown}
             >
                 {variations.length === 0 ? (
                     <p
@@ -187,6 +242,9 @@ export function StyleBookCanvas(props: StyleBookCanvasProps): JSX.Element {
 
                     return (
                         <button
+                            ref={(element) => {
+                                variationButtonsRef.current[index] = element;
+                            }}
                             key={variation.slug}
                             type="button"
                             role="radio"

--- a/resources/js/visual-editor/site-editor/styles/styles-inspector.css
+++ b/resources/js/visual-editor/site-editor/styles/styles-inspector.css
@@ -88,7 +88,7 @@
     gap: 0.25rem 0.5rem;
     min-width: 0;
     padding: 0.5rem;
-    border: 1px solid color-mix(in srgb, currentColor 8%, transparent);
+    border: 1px solid color-mix(in srgb, currentcolor 8%, transparent);
     border-radius: 0.375rem;
 }
 
@@ -98,7 +98,7 @@
 }
 
 .ap-site-editor__style-palette-color-trigger {
-    border: 1px solid color-mix(in srgb, currentColor 18%, transparent) !important;
+    border: 1px solid color-mix(in srgb, currentcolor 18%, transparent) !important;
     height: 2rem !important;
     min-width: 2rem !important;
     padding: 0.25rem !important;
@@ -129,6 +129,13 @@
     gap: 0.25rem;
     justify-content: flex-end;
     min-width: 0;
+}
+
+.ap-site-editor__style-palette-row-error {
+    color: #b91c1c;
+    font-size: 0.75rem;
+    grid-column: 1 / -1;
+    margin: 0;
 }
 
 /* Listing panels (Blocks / Elements / Variations) ------------------------- */
@@ -170,14 +177,12 @@
     font-weight: 500;
     min-width: 0;
     overflow-wrap: anywhere;
-    word-break: break-word;
 }
 
 .ap-site-editor__style-listing-code {
     font-size: 0.75rem;
     opacity: 0.75;
     overflow-wrap: anywhere;
-    word-break: break-word;
 }
 
 /* Color-palette field label ---------------------------------------------- */

--- a/resources/js/visual-editor/site-editor/styles/styles-inspector.css
+++ b/resources/js/visual-editor/site-editor/styles/styles-inspector.css
@@ -1,0 +1,196 @@
+/*
+ * Styles-section inspector chrome.
+ *
+ * The panels inside use Gutenberg's `@wordpress/components` primitives
+ * (PanelBody, TextControl, SelectControl, ColorPalette, UnitControl) so
+ * they look and behave like every other editor surface. This stylesheet
+ * only handles the Styles-specific layout around those primitives: the
+ * breadcrumb header, palette editor list, and per-listing navigation
+ * buttons used by the Blocks / Elements / Variations panels.
+ */
+
+.ap-site-editor__styles-inspector {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    overflow: hidden;
+}
+
+.ap-site-editor__styles-inspector .ap-site-editor__inspector-body {
+    flex: 1;
+    min-height: 0;
+    overflow-x: hidden;
+    overflow-y: auto;
+}
+
+.ap-site-editor__styles-breadcrumb-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.125rem;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.ap-site-editor__styles-breadcrumb-item {
+    color: inherit;
+    font-size: 0.8125rem;
+}
+
+.ap-site-editor__styles-breadcrumb-item[aria-current='page'] {
+    font-weight: 600;
+}
+
+.ap-site-editor__styles-inspector-error {
+    color: #b91c1c;
+    font-size: 0.8125rem;
+    margin: 0.5rem 0;
+}
+
+/* Palette editor ---------------------------------------------------------- */
+
+.ap-site-editor__style-palette {
+    min-width: 0;
+    width: 100%;
+}
+
+.ap-site-editor__style-palette-header {
+    align-items: center;
+    display: flex;
+    gap: 0.5rem;
+    justify-content: space-between;
+    margin-bottom: 0.5rem;
+}
+
+.ap-site-editor__style-panel-presets-title {
+    font-size: 0.8125rem;
+    font-weight: 600;
+    margin: 0;
+}
+
+.ap-site-editor__style-palette-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.375rem;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.ap-site-editor__style-palette-row {
+    align-items: center;
+    display: grid;
+    grid-template-columns: 2rem 1fr;
+    grid-template-areas:
+        'swatch name'
+        'swatch slug'
+        'actions actions';
+    gap: 0.25rem 0.5rem;
+    min-width: 0;
+    padding: 0.5rem;
+    border: 1px solid color-mix(in srgb, currentColor 8%, transparent);
+    border-radius: 0.375rem;
+}
+
+.ap-site-editor__style-palette-row > .components-dropdown {
+    grid-area: swatch;
+    justify-self: start;
+}
+
+.ap-site-editor__style-palette-color-trigger {
+    border: 1px solid color-mix(in srgb, currentColor 18%, transparent) !important;
+    height: 2rem !important;
+    min-width: 2rem !important;
+    padding: 0.25rem !important;
+    width: 2rem !important;
+}
+
+.ap-site-editor__style-palette-color-trigger .components-color-indicator {
+    height: 1.25rem;
+    width: 1.25rem;
+}
+
+.ap-site-editor__style-palette-row > .components-base-control:nth-of-type(1) {
+    grid-area: name;
+    min-width: 0;
+    width: 100%;
+}
+
+.ap-site-editor__style-palette-row > .components-base-control:nth-of-type(2) {
+    grid-area: slug;
+    min-width: 0;
+    width: 100%;
+}
+
+.ap-site-editor__style-palette-row-actions {
+    grid-area: actions;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+    justify-content: flex-end;
+    min-width: 0;
+}
+
+/* Listing panels (Blocks / Elements / Variations) ------------------------- */
+
+.ap-site-editor__style-listing {
+    min-width: 0;
+    width: 100%;
+}
+
+.ap-site-editor__style-listing-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    width: 100%;
+}
+
+.ap-site-editor__style-listing-item {
+    min-width: 0;
+    width: 100%;
+}
+
+.ap-site-editor__style-listing-link {
+    align-items: center;
+    display: flex !important;
+    flex-wrap: wrap;
+    gap: 0.25rem 0.5rem;
+    justify-content: flex-start !important;
+    min-width: 0;
+    padding: 0.5rem 0.75rem !important;
+    text-align: left;
+    width: 100%;
+}
+
+.ap-site-editor__style-listing-label {
+    flex: 1;
+    font-weight: 500;
+    min-width: 0;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+}
+
+.ap-site-editor__style-listing-code {
+    font-size: 0.75rem;
+    opacity: 0.75;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+}
+
+/* Color-palette field label ---------------------------------------------- */
+
+.ap-site-editor__style-color-field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.375rem;
+    min-width: 0;
+    width: 100%;
+}
+
+.ap-site-editor__style-color-field-label {
+    font-size: 0.8125rem;
+    font-weight: 500;
+}

--- a/resources/js/visual-editor/site-editor/styles/styles-inspector.tsx
+++ b/resources/js/visual-editor/site-editor/styles/styles-inspector.tsx
@@ -1,0 +1,320 @@
+/**
+ * Styles-section inspector.
+ *
+ * Renders the right-rail breadcrumb ("Styles ▸ Blocks ▸ Button"), the
+ * active panel for the current navigator scope, and the dirty /
+ * save-status chrome the brief's P1 calls out (Save always names its
+ * scope, plus an error surface when the PUT comes back 422).
+ *
+ * Kept in its own file so the shell can drop the inspector independent
+ * of the navigator + canvas panes and the panel switch stays testable
+ * on its own.
+ */
+
+import { __ } from '@wordpress/i18n';
+import type { ReactElement } from 'react';
+
+import { TEXT_DOMAIN } from '../../vendor/i18n';
+import type { ValidationErrors } from '../api-client';
+import type { SaveStatus } from '../use-entity-editor';
+import {
+    BlockDetailPanel,
+    BlocksIndexPanel,
+} from './panels/blocks-panel';
+import { ColorsPanel } from './panels/colors-panel';
+import {
+    ElementDetailPanel,
+    ElementsIndexPanel,
+} from './panels/elements-panel';
+import { LayoutPanel } from './panels/layout-panel';
+import { TypographyPanel } from './panels/typography-panel';
+import { VariationsPanel } from './panels/variations-panel';
+import type { StyleBlock } from './styles-navigator';
+import {
+    getElementLabel,
+    getPanelLabel,
+    type StylesNavigatorState,
+} from './styles-navigator-tree';
+import type { StyleVariation } from './style-book-canvas';
+import type { UseGlobalStylesEditorResult } from './use-global-styles-editor';
+
+import './styles-inspector.css';
+
+export interface StylesInspectorProps {
+    editor: UseGlobalStylesEditorResult;
+    state: StylesNavigatorState;
+    onNavigatorChange: (next: StylesNavigatorState) => void;
+
+    /** Validation errors from the most recent save attempt. */
+    validationErrors: ValidationErrors | null;
+
+    blocks: readonly StyleBlock[];
+    variations: readonly StyleVariation[];
+    activeVariationSlug: string | null;
+    onApplyVariation: (slug: string) => void;
+
+    saveStatus: SaveStatus;
+    saveErrorMessage: string | null;
+}
+
+function buildBreadcrumbSegments(
+    state: StylesNavigatorState,
+    blocks: readonly StyleBlock[]
+): readonly string[] {
+    const root = __('Styles', TEXT_DOMAIN);
+    const panelLabel = getPanelLabel(state.panel);
+
+    if (state.panel === 'blocks' && state.blockName !== null) {
+        const block = blocks.find(
+            (entry) => entry.name === state.blockName
+        );
+        const label = block?.title ?? state.blockName;
+
+        return [root, panelLabel, label];
+    }
+
+    if (state.panel === 'elements' && state.elementName !== null) {
+        return [root, panelLabel, getElementLabel(state.elementName)];
+    }
+
+    return [root, panelLabel];
+}
+
+function renderActivePanel(
+    editor: UseGlobalStylesEditorResult,
+    state: StylesNavigatorState,
+    validationErrors: ValidationErrors | null,
+    blocks: readonly StyleBlock[],
+    variations: readonly StyleVariation[],
+    activeVariationSlug: string | null,
+    onNavigatorChange: (next: StylesNavigatorState) => void,
+    onApplyVariation: (slug: string) => void
+): ReactElement {
+    if (state.panel === 'typography') {
+        return (
+            <TypographyPanel
+                editor={editor}
+                validationErrors={validationErrors}
+            />
+        );
+    }
+
+    if (state.panel === 'colors') {
+        return (
+            <ColorsPanel
+                editor={editor}
+                validationErrors={validationErrors}
+            />
+        );
+    }
+
+    if (state.panel === 'layout') {
+        return (
+            <LayoutPanel
+                editor={editor}
+                validationErrors={validationErrors}
+            />
+        );
+    }
+
+    if (state.panel === 'blocks') {
+        if (state.blockName !== null) {
+            return (
+                <BlockDetailPanel
+                    editor={editor}
+                    validationErrors={validationErrors}
+                    blocks={blocks}
+                    selectedBlockName={state.blockName}
+                    onSelectBlock={(blockName) =>
+                        onNavigatorChange({
+                            panel: 'blocks',
+                            blockName,
+                            elementName: null,
+                        })
+                    }
+                />
+            );
+        }
+
+        return (
+            <BlocksIndexPanel
+                editor={editor}
+                validationErrors={validationErrors}
+                blocks={blocks}
+                selectedBlockName={null}
+                onSelectBlock={(blockName) =>
+                    onNavigatorChange({
+                        panel: 'blocks',
+                        blockName,
+                        elementName: null,
+                    })
+                }
+            />
+        );
+    }
+
+    if (state.panel === 'elements') {
+        if (state.elementName !== null) {
+            return (
+                <ElementDetailPanel
+                    editor={editor}
+                    validationErrors={validationErrors}
+                    element={state.elementName}
+                    onBack={() =>
+                        onNavigatorChange({
+                            panel: 'elements',
+                            blockName: null,
+                            elementName: null,
+                        })
+                    }
+                />
+            );
+        }
+
+        return (
+            <ElementsIndexPanel
+                editor={editor}
+                onSelectElement={(element) =>
+                    onNavigatorChange({
+                        panel: 'elements',
+                        blockName: null,
+                        elementName: element,
+                    })
+                }
+            />
+        );
+    }
+
+    return (
+        <VariationsPanel
+            editor={editor}
+            variations={variations}
+            activeVariationSlug={activeVariationSlug}
+            onApplyVariation={onApplyVariation}
+        />
+    );
+}
+
+export function StylesInspector(
+    props: StylesInspectorProps
+): JSX.Element {
+    const {
+        editor,
+        state,
+        onNavigatorChange,
+        validationErrors,
+        blocks,
+        variations,
+        activeVariationSlug,
+        onApplyVariation,
+        saveStatus,
+        saveErrorMessage,
+    } = props;
+
+    const crumbs = buildBreadcrumbSegments(state, blocks);
+
+    return (
+        <aside
+            className="ap-site-editor__inspector ap-site-editor__styles-inspector"
+            aria-label={__('Global styles inspector', TEXT_DOMAIN)}
+            data-testid="ap-site-editor-styles-inspector"
+        >
+            <div className="ap-site-editor__inspector-header">
+                <nav
+                    aria-label={__('Styles scope', TEXT_DOMAIN)}
+                    data-testid="ap-site-editor-styles-breadcrumb"
+                    className="ap-site-editor__styles-breadcrumb"
+                >
+                    <ol className="ap-site-editor__styles-breadcrumb-list">
+                        {crumbs.map((crumb, index) => (
+                            <li
+                                key={`${crumb}-${index}`}
+                                className="ap-site-editor__styles-breadcrumb-item"
+                                aria-current={
+                                    index === crumbs.length - 1
+                                        ? 'page'
+                                        : undefined
+                                }
+                            >
+                                {crumb}
+                                {index < crumbs.length - 1 ? (
+                                    <span
+                                        aria-hidden="true"
+                                        className="ap-site-editor__styles-breadcrumb-sep"
+                                    >
+                                        {' ▸ '}
+                                    </span>
+                                ) : null}
+                            </li>
+                        ))}
+                    </ol>
+                </nav>
+                {editor.isDirty ? (
+                    <span
+                        className="ap-site-editor__dirty-indicator"
+                        role="status"
+                        data-testid="ap-site-editor-styles-dirty"
+                    >
+                        {__('Unsaved changes', TEXT_DOMAIN)}
+                    </span>
+                ) : null}
+                {saveStatus === 'saved' && !editor.isDirty ? (
+                    <span
+                        className="ap-site-editor__save-indicator"
+                        role="status"
+                        data-testid="ap-site-editor-styles-saved"
+                    >
+                        {__('Saved', TEXT_DOMAIN)}
+                    </span>
+                ) : null}
+                {saveStatus === 'error' && saveErrorMessage !== null ? (
+                    <p
+                        role="alert"
+                        className="ap-site-editor__styles-inspector-error"
+                        data-testid="ap-site-editor-styles-save-error"
+                    >
+                        {saveErrorMessage}
+                    </p>
+                ) : null}
+            </div>
+            <div
+                className="ap-site-editor__inspector-body"
+                data-testid="ap-site-editor-styles-inspector-body"
+            >
+                {editor.loadStatus === 'error' ? (
+                    <p
+                        role="alert"
+                        className="ap-site-editor__styles-inspector-error"
+                        data-testid="ap-site-editor-styles-load-error"
+                    >
+                        {editor.loadErrorMessage ??
+                            __(
+                                'Failed to load global styles.',
+                                TEXT_DOMAIN
+                            )}
+                    </p>
+                ) : null}
+                {editor.loadStatus === 'loading' ? (
+                    <p
+                        className="ap-site-editor__inspector-placeholder"
+                        data-testid="ap-site-editor-styles-loading"
+                    >
+                        {__('Loading global styles…', TEXT_DOMAIN)}
+                    </p>
+                ) : null}
+                {editor.loadStatus === 'ready'
+                    ? renderActivePanel(
+                          editor,
+                          state,
+                          validationErrors,
+                          blocks,
+                          variations,
+                          activeVariationSlug,
+                          onNavigatorChange,
+                          onApplyVariation
+                      )
+                    : null}
+            </div>
+        </aside>
+    );
+}

--- a/resources/js/visual-editor/site-editor/styles/styles-navigator-tree.ts
+++ b/resources/js/visual-editor/site-editor/styles/styles-navigator-tree.ts
@@ -1,0 +1,122 @@
+/**
+ * Shape + labels for the Styles-section navigator tree.
+ *
+ * Per design brief §3.7, the navigator mirrors theme.json's structure:
+ * Typography / Colors / Layout / Blocks / Elements / Variations. Issue
+ * #370 pulls Elements up to a sibling of Blocks (rather than nested
+ * under Typography / Colors as the brief describes) so the breadcrumb
+ * pattern "Styles ▸ Elements ▸ Link" mirrors "Styles ▸ Blocks ▸ Button" —
+ * same depth, same mental model, one panel per node.
+ *
+ * Blocks' children are populated dynamically from the block-type
+ * registry (GET /visual-editor/api/blocks) so the per-block tree
+ * reflects only the blocks registered through the shim (per the issue's
+ * out-of-scope note: don't list every Gutenberg block if it's disabled).
+ */
+
+import { __ } from '@wordpress/i18n';
+
+import { TEXT_DOMAIN } from '../../vendor/i18n';
+
+export type StylesNavigatorPanelId =
+    | 'typography'
+    | 'colors'
+    | 'layout'
+    | 'blocks'
+    | 'elements'
+    | 'variations';
+
+export type StylesNavigatorNode =
+    | { kind: 'panel'; id: StylesNavigatorPanelId; label: string }
+    | { kind: 'block'; id: string; label: string };
+
+export interface StylesNavigatorState {
+    panel: StylesNavigatorPanelId;
+    /** When `panel === 'blocks'`, the specific block the user drilled into. */
+    blockName: string | null;
+    /** When `panel === 'elements'`, the specific element scope. */
+    elementName: ElementScope | null;
+}
+
+export type ElementScope =
+    | 'link'
+    | 'button'
+    | 'heading'
+    | 'h1'
+    | 'h2'
+    | 'h3'
+    | 'h4'
+    | 'h5'
+    | 'h6'
+    | 'caption';
+
+export const DEFAULT_NAVIGATOR_STATE: Readonly<StylesNavigatorState> =
+    Object.freeze({
+        panel: 'typography',
+        blockName: null,
+        elementName: null,
+    });
+
+export function getPanelLabel(panel: StylesNavigatorPanelId): string {
+    switch (panel) {
+        case 'typography':
+            return __('Typography', TEXT_DOMAIN);
+        case 'colors':
+            return __('Colors', TEXT_DOMAIN);
+        case 'layout':
+            return __('Layout', TEXT_DOMAIN);
+        case 'blocks':
+            return __('Blocks', TEXT_DOMAIN);
+        case 'elements':
+            return __('Elements', TEXT_DOMAIN);
+        case 'variations':
+            return __('Variations', TEXT_DOMAIN);
+    }
+}
+
+export function getElementLabel(element: ElementScope): string {
+    switch (element) {
+        case 'link':
+            return __('Link', TEXT_DOMAIN);
+        case 'button':
+            return __('Button', TEXT_DOMAIN);
+        case 'heading':
+            return __('Headings', TEXT_DOMAIN);
+        case 'h1':
+            return __('Heading 1', TEXT_DOMAIN);
+        case 'h2':
+            return __('Heading 2', TEXT_DOMAIN);
+        case 'h3':
+            return __('Heading 3', TEXT_DOMAIN);
+        case 'h4':
+            return __('Heading 4', TEXT_DOMAIN);
+        case 'h5':
+            return __('Heading 5', TEXT_DOMAIN);
+        case 'h6':
+            return __('Heading 6', TEXT_DOMAIN);
+        case 'caption':
+            return __('Caption', TEXT_DOMAIN);
+    }
+}
+
+export const ELEMENT_ORDER: readonly ElementScope[] = Object.freeze([
+    'link',
+    'button',
+    'heading',
+    'h1',
+    'h2',
+    'h3',
+    'h4',
+    'h5',
+    'h6',
+    'caption',
+]);
+
+export const PANEL_ORDER: readonly StylesNavigatorPanelId[] = Object.freeze([
+    'typography',
+    'colors',
+    'layout',
+    'blocks',
+    'elements',
+    'variations',
+]);

--- a/resources/js/visual-editor/site-editor/styles/styles-navigator.css
+++ b/resources/js/visual-editor/site-editor/styles/styles-navigator.css
@@ -1,0 +1,96 @@
+/*
+ * Styles-section navigator styles.
+ *
+ * Reuses the same sidebar tokens as `navigator-sidebar.css` so the two
+ * trees feel visually consistent; the outer nav list (sections) and the
+ * inner tree (styles scopes) share typography and spacing.
+ */
+
+.ap-site-editor__styles-navigator {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    padding: 0.5rem 0.25rem;
+}
+
+.ap-site-editor__styles-navigator-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.125rem;
+}
+
+.ap-site-editor__styles-navigator-item {
+    display: flex;
+    flex-direction: column;
+}
+
+.ap-site-editor__styles-navigator-link {
+    appearance: none;
+    background: transparent;
+    border: none;
+    border-radius: 0.25rem;
+    color: inherit;
+    cursor: pointer;
+    font: inherit;
+    padding: 0.375rem 0.5rem;
+    text-align: left;
+}
+
+.ap-site-editor__styles-navigator-link:hover {
+    background: color-mix(in srgb, currentColor 6%, transparent);
+}
+
+.ap-site-editor__styles-navigator-item[data-active='true']
+    > .ap-site-editor__styles-navigator-link {
+    background: color-mix(in srgb, currentColor 10%, transparent);
+    font-weight: 600;
+}
+
+.ap-site-editor__styles-navigator-children {
+    list-style: none;
+    margin: 0.125rem 0 0.25rem 0.75rem;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.125rem;
+    border-left: 1px solid color-mix(in srgb, currentColor 12%, transparent);
+    padding-left: 0.5rem;
+}
+
+.ap-site-editor__styles-navigator-child-link {
+    appearance: none;
+    background: transparent;
+    border: none;
+    border-radius: 0.25rem;
+    color: inherit;
+    cursor: pointer;
+    font: inherit;
+    font-size: 0.875rem;
+    padding: 0.25rem 0.5rem;
+    text-align: left;
+    width: 100%;
+}
+
+.ap-site-editor__styles-navigator-child-link:hover {
+    background: color-mix(in srgb, currentColor 6%, transparent);
+}
+
+.ap-site-editor__styles-navigator-child-link[data-active='true'] {
+    background: color-mix(in srgb, currentColor 10%, transparent);
+    font-weight: 600;
+}
+
+.ap-site-editor__styles-navigator-note,
+.ap-site-editor__styles-navigator-error {
+    font-size: 0.8125rem;
+    opacity: 0.75;
+    padding: 0.25rem 0.5rem;
+}
+
+.ap-site-editor__styles-navigator-error {
+    color: #b91c1c;
+    opacity: 1;
+}

--- a/resources/js/visual-editor/site-editor/styles/styles-navigator.css
+++ b/resources/js/visual-editor/site-editor/styles/styles-navigator.css
@@ -40,12 +40,12 @@
 }
 
 .ap-site-editor__styles-navigator-link:hover {
-    background: color-mix(in srgb, currentColor 6%, transparent);
+    background: color-mix(in srgb, currentcolor 6%, transparent);
 }
 
 .ap-site-editor__styles-navigator-item[data-active='true']
     > .ap-site-editor__styles-navigator-link {
-    background: color-mix(in srgb, currentColor 10%, transparent);
+    background: color-mix(in srgb, currentcolor 10%, transparent);
     font-weight: 600;
 }
 
@@ -56,7 +56,7 @@
     display: flex;
     flex-direction: column;
     gap: 0.125rem;
-    border-left: 1px solid color-mix(in srgb, currentColor 12%, transparent);
+    border-left: 1px solid color-mix(in srgb, currentcolor 12%, transparent);
     padding-left: 0.5rem;
 }
 
@@ -75,11 +75,11 @@
 }
 
 .ap-site-editor__styles-navigator-child-link:hover {
-    background: color-mix(in srgb, currentColor 6%, transparent);
+    background: color-mix(in srgb, currentcolor 6%, transparent);
 }
 
 .ap-site-editor__styles-navigator-child-link[data-active='true'] {
-    background: color-mix(in srgb, currentColor 10%, transparent);
+    background: color-mix(in srgb, currentcolor 10%, transparent);
     font-weight: 600;
 }
 

--- a/resources/js/visual-editor/site-editor/styles/styles-navigator.tsx
+++ b/resources/js/visual-editor/site-editor/styles/styles-navigator.tsx
@@ -1,0 +1,244 @@
+/**
+ * Styles-section navigator panel.
+ *
+ * Renders the left-rail tree of style scopes: Typography / Colors /
+ * Layout / Blocks / Elements / Variations. Picking a node updates the
+ * inspector breadcrumb + panel scope through the shared
+ * `StylesNavigatorState`; the canvas continues to show the same Style
+ * Book so the user sees changes live.
+ *
+ * Kept intentionally lightweight (no Gutenberg-components dep) so the
+ * styles test suite can mount it inside jsdom without pulling in the
+ * full block-editor runtime.
+ */
+
+import { __ } from '@wordpress/i18n';
+import { useMemo } from 'react';
+
+import { TEXT_DOMAIN } from '../../vendor/i18n';
+import {
+    ELEMENT_ORDER,
+    PANEL_ORDER,
+    getElementLabel,
+    getPanelLabel,
+    type ElementScope,
+    type StylesNavigatorPanelId,
+    type StylesNavigatorState,
+} from './styles-navigator-tree';
+
+import './styles-navigator.css';
+
+export interface StyleBlock {
+    name: string;
+    title?: string;
+}
+
+export interface StylesNavigatorProps {
+    state: StylesNavigatorState;
+    onSelect: (next: StylesNavigatorState) => void;
+    /** Registered blocks from `/visual-editor/api/blocks` (B1 / shim). */
+    blocks: readonly StyleBlock[];
+    /** Error hint when the blocks fetch failed; shows under the Blocks panel. */
+    blocksError?: string | null;
+    isLoadingBlocks?: boolean;
+}
+
+function topLevelActive(
+    state: StylesNavigatorState,
+    panel: StylesNavigatorPanelId
+): boolean {
+    if (state.panel !== panel) {
+        return false;
+    }
+
+    // The root node is "selected" when no child is drilled into.
+    if (panel === 'blocks') {
+        return state.blockName === null;
+    }
+
+    if (panel === 'elements') {
+        return state.elementName === null;
+    }
+
+    return true;
+}
+
+export function StylesNavigator(
+    props: StylesNavigatorProps
+): JSX.Element {
+    const { state, onSelect, blocks, blocksError, isLoadingBlocks } = props;
+
+    const blockChildren = useMemo(() => {
+        const copy = blocks.slice();
+
+        copy.sort((a, b) => {
+            const aLabel = (a.title ?? a.name).toLowerCase();
+            const bLabel = (b.title ?? b.name).toLowerCase();
+
+            return aLabel.localeCompare(bLabel);
+        });
+
+        return copy;
+    }, [blocks]);
+
+    return (
+        <nav
+            className="ap-site-editor__styles-navigator"
+            aria-label={__('Styles scopes', TEXT_DOMAIN)}
+            data-testid="ap-site-editor-styles-navigator"
+        >
+            <ul
+                role="tree"
+                aria-label={__('Styles scopes', TEXT_DOMAIN)}
+                className="ap-site-editor__styles-navigator-list"
+            >
+                {PANEL_ORDER.map((panel) => {
+                    const isOpen = state.panel === panel;
+                    const isSelected = topLevelActive(state, panel);
+                    const label = getPanelLabel(panel);
+
+                    return (
+                        <li
+                            key={panel}
+                            role="treeitem"
+                            aria-expanded={
+                                panel === 'blocks' || panel === 'elements'
+                                    ? isOpen
+                                    : undefined
+                            }
+                            aria-selected={isSelected}
+                            className="ap-site-editor__styles-navigator-item"
+                            data-panel={panel}
+                            data-active={isSelected}
+                        >
+                            <button
+                                type="button"
+                                className="ap-site-editor__styles-navigator-link"
+                                data-testid={`ap-site-editor-styles-nav-${panel}`}
+                                aria-current={isSelected ? 'page' : undefined}
+                                onClick={() =>
+                                    onSelect({
+                                        panel,
+                                        blockName: null,
+                                        elementName: null,
+                                    })
+                                }
+                            >
+                                {label}
+                            </button>
+
+                            {panel === 'blocks' && isOpen ? (
+                                <ul
+                                    role="group"
+                                    className="ap-site-editor__styles-navigator-children"
+                                    data-testid="ap-site-editor-styles-nav-blocks-children"
+                                >
+                                    {blockChildren.length === 0 &&
+                                    isLoadingBlocks ? (
+                                        <li className="ap-site-editor__styles-navigator-note">
+                                            {__('Loading blocks…', TEXT_DOMAIN)}
+                                        </li>
+                                    ) : null}
+                                    {blockChildren.length === 0 &&
+                                    !isLoadingBlocks &&
+                                    blocksError !== null &&
+                                    blocksError !== undefined ? (
+                                        <li
+                                            role="alert"
+                                            className="ap-site-editor__styles-navigator-error"
+                                            data-testid="ap-site-editor-styles-nav-blocks-error"
+                                        >
+                                            {blocksError}
+                                        </li>
+                                    ) : null}
+                                    {blockChildren.length === 0 &&
+                                    !isLoadingBlocks &&
+                                    (blocksError === null ||
+                                        blocksError === undefined) ? (
+                                        <li className="ap-site-editor__styles-navigator-note">
+                                            {__(
+                                                'No blocks registered.',
+                                                TEXT_DOMAIN
+                                            )}
+                                        </li>
+                                    ) : null}
+                                    {blockChildren.map((block) => {
+                                        const isBlockSelected =
+                                            state.blockName === block.name;
+                                        const displayLabel =
+                                            block.title ?? block.name;
+
+                                        return (
+                                            <li
+                                                key={block.name}
+                                                role="treeitem"
+                                                aria-selected={isBlockSelected}
+                                                className="ap-site-editor__styles-navigator-child"
+                                            >
+                                                <button
+                                                    type="button"
+                                                    className="ap-site-editor__styles-navigator-child-link"
+                                                    data-active={isBlockSelected}
+                                                    data-testid={`ap-site-editor-styles-nav-block-${block.name}`}
+                                                    onClick={() =>
+                                                        onSelect({
+                                                            panel: 'blocks',
+                                                            blockName: block.name,
+                                                            elementName: null,
+                                                        })
+                                                    }
+                                                >
+                                                    {displayLabel}
+                                                </button>
+                                            </li>
+                                        );
+                                    })}
+                                </ul>
+                            ) : null}
+
+                            {panel === 'elements' && isOpen ? (
+                                <ul
+                                    role="group"
+                                    className="ap-site-editor__styles-navigator-children"
+                                    data-testid="ap-site-editor-styles-nav-elements-children"
+                                >
+                                    {ELEMENT_ORDER.map(
+                                        (element: ElementScope) => {
+                                            const isElementSelected =
+                                                state.elementName === element;
+
+                                            return (
+                                                <li
+                                                    key={element}
+                                                    role="treeitem"
+                                                    aria-selected={isElementSelected}
+                                                    className="ap-site-editor__styles-navigator-child"
+                                                >
+                                                    <button
+                                                        type="button"
+                                                        className="ap-site-editor__styles-navigator-child-link"
+                                                        data-active={isElementSelected}
+                                                        data-testid={`ap-site-editor-styles-nav-element-${element}`}
+                                                        onClick={() =>
+                                                            onSelect({
+                                                                panel: 'elements',
+                                                                blockName: null,
+                                                                elementName: element,
+                                                            })
+                                                        }
+                                                    >
+                                                        {getElementLabel(element)}
+                                                    </button>
+                                                </li>
+                                            );
+                                        }
+                                    )}
+                                </ul>
+                            ) : null}
+                        </li>
+                    );
+                })}
+            </ul>
+        </nav>
+    );
+}

--- a/resources/js/visual-editor/site-editor/styles/styles-navigator.tsx
+++ b/resources/js/visual-editor/site-editor/styles/styles-navigator.tsx
@@ -88,8 +88,7 @@ export function StylesNavigator(
             data-testid="ap-site-editor-styles-navigator"
         >
             <ul
-                role="tree"
-                aria-label={__('Styles scopes', TEXT_DOMAIN)}
+                role="list"
                 className="ap-site-editor__styles-navigator-list"
             >
                 {PANEL_ORDER.map((panel) => {
@@ -100,13 +99,7 @@ export function StylesNavigator(
                     return (
                         <li
                             key={panel}
-                            role="treeitem"
-                            aria-expanded={
-                                panel === 'blocks' || panel === 'elements'
-                                    ? isOpen
-                                    : undefined
-                            }
-                            aria-selected={isSelected}
+                            role="listitem"
                             className="ap-site-editor__styles-navigator-item"
                             data-panel={panel}
                             data-active={isSelected}
@@ -129,7 +122,7 @@ export function StylesNavigator(
 
                             {panel === 'blocks' && isOpen ? (
                                 <ul
-                                    role="group"
+                                    role="list"
                                     className="ap-site-editor__styles-navigator-children"
                                     data-testid="ap-site-editor-styles-nav-blocks-children"
                                 >
@@ -171,8 +164,7 @@ export function StylesNavigator(
                                         return (
                                             <li
                                                 key={block.name}
-                                                role="treeitem"
-                                                aria-selected={isBlockSelected}
+                                                role="listitem"
                                                 className="ap-site-editor__styles-navigator-child"
                                             >
                                                 <button
@@ -180,6 +172,11 @@ export function StylesNavigator(
                                                     className="ap-site-editor__styles-navigator-child-link"
                                                     data-active={isBlockSelected}
                                                     data-testid={`ap-site-editor-styles-nav-block-${block.name}`}
+                                                    aria-current={
+                                                        isBlockSelected
+                                                            ? 'page'
+                                                            : undefined
+                                                    }
                                                     onClick={() =>
                                                         onSelect({
                                                             panel: 'blocks',
@@ -198,7 +195,7 @@ export function StylesNavigator(
 
                             {panel === 'elements' && isOpen ? (
                                 <ul
-                                    role="group"
+                                    role="list"
                                     className="ap-site-editor__styles-navigator-children"
                                     data-testid="ap-site-editor-styles-nav-elements-children"
                                 >
@@ -210,8 +207,7 @@ export function StylesNavigator(
                                             return (
                                                 <li
                                                     key={element}
-                                                    role="treeitem"
-                                                    aria-selected={isElementSelected}
+                                                    role="listitem"
                                                     className="ap-site-editor__styles-navigator-child"
                                                 >
                                                     <button
@@ -219,6 +215,11 @@ export function StylesNavigator(
                                                         className="ap-site-editor__styles-navigator-child-link"
                                                         data-active={isElementSelected}
                                                         data-testid={`ap-site-editor-styles-nav-element-${element}`}
+                                                        aria-current={
+                                                            isElementSelected
+                                                                ? 'page'
+                                                                : undefined
+                                                        }
                                                         onClick={() =>
                                                             onSelect({
                                                                 panel: 'elements',

--- a/resources/js/visual-editor/site-editor/styles/styles-section.tsx
+++ b/resources/js/visual-editor/site-editor/styles/styles-section.tsx
@@ -1,0 +1,319 @@
+/**
+ * Styles section orchestrator.
+ *
+ * Parallel to D2's `useEntityEditorViews` but shaped around global
+ * styles' singleton record. The site-editor shell plugs the navigator /
+ * canvas / inspector outputs into its existing slots — the shell
+ * doesn't need to know the Styles section is special; it gets the same
+ * `{ canvas, inspector }` contract D2's editor hook returns plus the
+ * navigator tree the left rail renders.
+ *
+ * The hook also pushes status into the shell's `entityState` slot so the
+ * top-bar Save button wires to the global-styles save without any
+ * special-casing — the shell already knows how to render "Save global
+ * styles" for the Styles section (see `sections.tsx`).
+ */
+
+import { __ } from '@wordpress/i18n';
+import {
+    useCallback,
+    useEffect,
+    useMemo,
+    useState,
+    type ReactElement,
+} from 'react';
+
+import { TEXT_DOMAIN } from '../../vendor/i18n';
+import type { SiteEditorApiConfig } from '../api-client';
+import type { EntityEditorState } from '../entity-editor';
+import {
+    StyleBookCanvas,
+    type StyleVariation,
+} from './style-book-canvas';
+import { StylesInspector } from './styles-inspector';
+import {
+    StylesNavigator,
+    type StyleBlock,
+} from './styles-navigator';
+import {
+    DEFAULT_NAVIGATOR_STATE,
+    type StylesNavigatorState,
+} from './styles-navigator-tree';
+import {
+    useGlobalStylesEditor,
+    type UseGlobalStylesEditorResult,
+} from './use-global-styles-editor';
+import { useRegisteredBlocks } from './use-registered-blocks';
+
+export interface UseStylesSectionViewsOptions {
+    apiConfig: SiteEditorApiConfig;
+    enabled: boolean;
+    onStateChange: (state: EntityEditorState) => void;
+}
+
+export interface StylesSectionViews {
+    navigator: ReactElement;
+    canvas: ReactElement;
+    inspector: ReactElement;
+}
+
+function readVariations(
+    base: Record<string, unknown> | null
+): readonly StyleVariation[] {
+    if (base === null) {
+        return [];
+    }
+
+    const candidates: unknown[] = [];
+
+    const direct = (base as Record<string, unknown>)['variations'];
+
+    if (Array.isArray(direct)) {
+        candidates.push(...direct);
+    }
+
+    const styles = (base as Record<string, unknown>)['styles'];
+
+    if (styles !== null && typeof styles === 'object') {
+        const nested = (styles as Record<string, unknown>)['variations'];
+
+        if (Array.isArray(nested)) {
+            candidates.push(...nested);
+        }
+    }
+
+    const results: StyleVariation[] = [];
+
+    for (const entry of candidates) {
+        if (entry === null || typeof entry !== 'object') {
+            continue;
+        }
+
+        const row = entry as Record<string, unknown>;
+        const slug = typeof row.slug === 'string' ? row.slug : null;
+        const title = typeof row.title === 'string' ? row.title : slug;
+
+        if (slug === null || title === null) {
+            continue;
+        }
+
+        const settings =
+            row.settings !== null && typeof row.settings === 'object'
+                ? (row.settings as Record<string, unknown>)
+                : undefined;
+        const styles =
+            row.styles !== null && typeof row.styles === 'object'
+                ? (row.styles as Record<string, unknown>)
+                : undefined;
+
+        results.push({ slug, title, settings, styles });
+    }
+
+    return results;
+}
+
+/**
+ * Deterministic serializer — recursively sorts object keys before
+ * stringifying so two semantically equal payloads compare equal
+ * regardless of whichever order PHP's `json_encode` + theme-json
+ * fixtures happened to emit their keys. Falls back to raw
+ * `JSON.stringify` for non-objects (numbers / strings / null / arrays).
+ */
+function stableStringify(value: unknown): string {
+    if (value === null || typeof value !== 'object') {
+        return JSON.stringify(value);
+    }
+
+    if (Array.isArray(value)) {
+        return `[${value.map((entry) => stableStringify(entry)).join(',')}]`;
+    }
+
+    const entries = Object.entries(value as Record<string, unknown>).sort(
+        ([a], [b]) => a.localeCompare(b)
+    );
+
+    return `{${entries
+        .map(([k, v]) => `${JSON.stringify(k)}:${stableStringify(v)}`)
+        .join(',')}}`;
+}
+
+function selectActiveVariation(
+    editor: UseGlobalStylesEditorResult,
+    variations: readonly StyleVariation[],
+    activeSlug: string | null
+): string | null {
+    // The user explicitly applied a variation in this session.
+    if (activeSlug !== null) {
+        return activeSlug;
+    }
+
+    // If the user record's settings/styles match a variation wholesale,
+    // surface that variation as the "applied" one. For V1 we detect a
+    // strict match by deterministic (key-sorted) stringify so picker
+    // state is predictable regardless of the order PHP serialized the
+    // payload — any manual edit (which won't exactly equal a preset)
+    // flips back to "customized / no variation selected".
+    if (editor.record === null || variations.length === 0) {
+        return null;
+    }
+
+    const userSignature = stableStringify({
+        settings: editor.record.settings ?? {},
+        styles: editor.record.styles ?? {},
+    });
+
+    for (const variation of variations) {
+        const signature = stableStringify({
+            settings: variation.settings ?? {},
+            styles: variation.styles ?? {},
+        });
+
+        if (signature === userSignature) {
+            return variation.slug;
+        }
+    }
+
+    return null;
+}
+
+export function useStylesSectionViews(
+    options: UseStylesSectionViewsOptions
+): StylesSectionViews {
+    const { apiConfig, enabled, onStateChange } = options;
+
+    const editor = useGlobalStylesEditor({ apiConfig, enabled });
+    const blocksState = useRegisteredBlocks(apiConfig, enabled);
+
+    const [navigatorState, setNavigatorState] = useState<StylesNavigatorState>(
+        { ...DEFAULT_NAVIGATOR_STATE }
+    );
+    const [activeVariationSlug, setActiveVariationSlug] = useState<
+        string | null
+    >(null);
+
+    const variations = useMemo(
+        () =>
+            readVariations(
+                (editor.base as unknown as Record<string, unknown> | null)
+            ),
+        [editor.base]
+    );
+
+    const effectiveVariationSlug = useMemo(
+        () =>
+            selectActiveVariation(editor, variations, activeVariationSlug),
+        [activeVariationSlug, editor, variations]
+    );
+
+    // Wrap `editor.save` so the `EntityEditorState` slot receives a
+    // Promise<void>-returning callback (the shell doesn't care about
+    // the saved record). Depend only on the `editor.save` primitive —
+    // `editor` itself is a fresh object each render, so including it
+    // as a dep would remake this callback every render and cascade
+    // through the onStateChange useEffect as an update-every-tick loop.
+    const save = useCallback(async (): Promise<void> => {
+        await editor.save();
+    }, [editor.save]);
+
+    // Mirror the state contract D2's entity-editor hook uses so the shell
+    // top bar can wire Save / dirty / error uniformly.
+    useEffect(() => {
+        if (!enabled) {
+            onStateChange({
+                entityId: null,
+                entityTitle: '',
+                isDirty: false,
+                saveStatus: 'idle',
+                saveErrorMessage: null,
+                lastSavedAt: null,
+                save: null,
+            });
+            return;
+        }
+
+        onStateChange({
+            entityId: editor.id === null ? null : String(editor.id),
+            entityTitle: __('Global styles', TEXT_DOMAIN),
+            isDirty: editor.isDirty,
+            saveStatus: editor.saveStatus,
+            saveErrorMessage: editor.saveErrorMessage,
+            lastSavedAt: editor.lastSavedAt,
+            save: editor.id === null ? null : save,
+        });
+    }, [
+        editor.id,
+        editor.isDirty,
+        editor.lastSavedAt,
+        editor.saveErrorMessage,
+        editor.saveStatus,
+        enabled,
+        onStateChange,
+        save,
+    ]);
+
+    const handleApplyVariation = useCallback(
+        (slug: string): void => {
+            const variation = variations.find(
+                (entry) => entry.slug === slug
+            );
+
+            if (variation === undefined) {
+                return;
+            }
+
+            editor.replaceSubtree(
+                'settings',
+                [],
+                variation.settings ?? {}
+            );
+            editor.replaceSubtree('styles', [], variation.styles ?? {});
+            setActiveVariationSlug(slug);
+        },
+        [editor, variations]
+    );
+
+    const navigator = (
+        <StylesNavigator
+            state={navigatorState}
+            onSelect={setNavigatorState}
+            blocks={blocksState.blocks}
+            blocksError={blocksState.error}
+            isLoadingBlocks={blocksState.isLoading}
+        />
+    );
+
+    const canvas = (
+        <StyleBookCanvas
+            draft={editor.draft}
+            variations={variations}
+            activeVariationSlug={effectiveVariationSlug}
+            onSelectVariation={handleApplyVariation}
+            loadError={
+                editor.loadStatus === 'error'
+                    ? editor.loadErrorMessage ??
+                      __('Failed to load global styles.', TEXT_DOMAIN)
+                    : null
+            }
+        />
+    );
+
+    const inspector = (
+        <StylesInspector
+            editor={editor}
+            state={navigatorState}
+            onNavigatorChange={setNavigatorState}
+            validationErrors={editor.validationErrors}
+            blocks={blocksState.blocks}
+            variations={variations}
+            activeVariationSlug={effectiveVariationSlug}
+            onApplyVariation={handleApplyVariation}
+            saveStatus={editor.saveStatus}
+            saveErrorMessage={editor.saveErrorMessage}
+        />
+    );
+
+    return { navigator, canvas, inspector };
+}
+
+export { DEFAULT_NAVIGATOR_STATE } from './styles-navigator-tree';
+export type { StyleBlock };

--- a/resources/js/visual-editor/site-editor/styles/styles-section.tsx
+++ b/resources/js/visual-editor/site-editor/styles/styles-section.tsx
@@ -137,38 +137,61 @@ function stableStringify(value: unknown): string {
         .join(',')}}`;
 }
 
+function variationMatchesDraft(
+    variation: StyleVariation,
+    editor: UseGlobalStylesEditorResult
+): boolean {
+    if (editor.draft === null) {
+        return false;
+    }
+
+    const variationSignature = stableStringify({
+        settings: variation.settings ?? {},
+        styles: variation.styles ?? {},
+    });
+    const draftSignature = stableStringify({
+        settings: editor.draft.settings ?? {},
+        styles: editor.draft.styles ?? {},
+    });
+
+    return variationSignature === draftSignature;
+}
+
 function selectActiveVariation(
     editor: UseGlobalStylesEditorResult,
     variations: readonly StyleVariation[],
     activeSlug: string | null
 ): string | null {
-    // The user explicitly applied a variation in this session.
-    if (activeSlug !== null) {
-        return activeSlug;
-    }
-
-    // If the user record's settings/styles match a variation wholesale,
-    // surface that variation as the "applied" one. For V1 we detect a
-    // strict match by deterministic (key-sorted) stringify so picker
-    // state is predictable regardless of the order PHP serialized the
-    // payload — any manual edit (which won't exactly equal a preset)
-    // flips back to "customized / no variation selected".
-    if (editor.record === null || variations.length === 0) {
+    if (variations.length === 0) {
         return null;
     }
 
-    const userSignature = stableStringify({
-        settings: editor.record.settings ?? {},
-        styles: editor.record.styles ?? {},
-    });
+    // An explicit click-to-apply only stays authoritative while the
+    // current draft still matches the variation's payload — a
+    // subsequent manual edit breaks the match and flips us back to
+    // "customized / no variation selected" so the picker doesn't
+    // falsely advertise a preset the user has already diverged from.
+    if (activeSlug !== null) {
+        const explicit = variations.find(
+            (variation) => variation.slug === activeSlug
+        );
 
+        if (
+            explicit !== undefined &&
+            variationMatchesDraft(explicit, editor)
+        ) {
+            return activeSlug;
+        }
+
+        return null;
+    }
+
+    // No explicit selection this session: fall back to auto-detecting a
+    // match against whatever the user saved previously. Same
+    // deterministic (key-sorted) stringify so ordering in PHP JSON
+    // output doesn't produce false negatives.
     for (const variation of variations) {
-        const signature = stableStringify({
-            settings: variation.settings ?? {},
-            styles: variation.styles ?? {},
-        });
-
-        if (signature === userSignature) {
+        if (variationMatchesDraft(variation, editor)) {
             return variation.slug;
         }
     }

--- a/resources/js/visual-editor/site-editor/styles/theme-json-paths.ts
+++ b/resources/js/visual-editor/site-editor/styles/theme-json-paths.ts
@@ -1,0 +1,187 @@
+/**
+ * theme.json helpers.
+ *
+ * The global-styles payload is a deeply-nested theme.json-shaped object
+ * (`settings.color.palette`, `styles.elements.link.color.text`, …).
+ * Panels poke at individual leaves without wanting to rebuild the whole
+ * object tree by hand — these helpers do the lens-style set / get /
+ * unset work in one place so each panel stays focused on UX rather than
+ * deep-object plumbing.
+ *
+ * Per plan §4.2 the schema is pinned (version 3); the helpers only
+ * enforce shape at the leaf they touch and leave higher-level keys
+ * alone, so a schema bump that adds a new top-level key (e.g.
+ * `settings.spacing`) doesn't need to cascade through these utilities.
+ */
+
+export type ThemeJsonPath = ReadonlyArray<string>;
+
+export type JsonShape = Record<string, unknown>;
+
+function isPlainObject(value: unknown): value is JsonShape {
+    return (
+        value !== null &&
+        typeof value === 'object' &&
+        !Array.isArray(value) &&
+        Object.prototype.toString.call(value) === '[object Object]'
+    );
+}
+
+/**
+ * Safe deep read. Returns `undefined` for any miss along the path —
+ * panels use the base payload as a fallback when the user record hasn't
+ * overridden a given key.
+ */
+export function readPath(source: unknown, path: ThemeJsonPath): unknown {
+    let cursor: unknown = source;
+
+    for (const segment of path) {
+        if (!isPlainObject(cursor)) {
+            return undefined;
+        }
+
+        cursor = cursor[segment];
+    }
+
+    return cursor;
+}
+
+/**
+ * Returns a shallow-cloned object with the value at `path` set to `value`.
+ * Creates intermediate objects as needed. Never mutates the input.
+ */
+export function writePath(
+    source: unknown,
+    path: ThemeJsonPath,
+    value: unknown
+): JsonShape {
+    const root: JsonShape = isPlainObject(source) ? { ...source } : {};
+
+    if (path.length === 0) {
+        return root;
+    }
+
+    let cursor: JsonShape = root;
+
+    for (let index = 0; index < path.length - 1; index += 1) {
+        const segment = path[index];
+
+        if (segment === undefined) {
+            continue;
+        }
+
+        const existing = cursor[segment];
+        const next: JsonShape = isPlainObject(existing) ? { ...existing } : {};
+        cursor[segment] = next;
+        cursor = next;
+    }
+
+    const tail = path[path.length - 1];
+
+    if (tail !== undefined) {
+        cursor[tail] = value;
+    }
+
+    return root;
+}
+
+/**
+ * Deletes the key at `path`; prunes newly-empty ancestor objects on the
+ * way back so a user record doesn't accumulate empty `{ color: {} }`-style
+ * husks as they reset customizations. Never mutates the input.
+ */
+export function unsetPath(source: unknown, path: ThemeJsonPath): JsonShape {
+    const root: JsonShape = isPlainObject(source) ? { ...source } : {};
+
+    if (path.length === 0) {
+        return root;
+    }
+
+    // Walk down cloning each node we touch so the mutation is isolated.
+    const stack: JsonShape[] = [root];
+    let cursor: JsonShape = root;
+
+    for (let index = 0; index < path.length - 1; index += 1) {
+        const segment = path[index];
+
+        if (segment === undefined) {
+            continue;
+        }
+
+        const existing = cursor[segment];
+
+        if (!isPlainObject(existing)) {
+            return root;
+        }
+
+        const next: JsonShape = { ...existing };
+        cursor[segment] = next;
+        stack.push(next);
+        cursor = next;
+    }
+
+    const tail = path[path.length - 1];
+
+    if (tail === undefined) {
+        return root;
+    }
+
+    if (tail in cursor) {
+        delete cursor[tail];
+    }
+
+    // Prune empty ancestors. Leave the root object in place even when
+    // empty so `settings` / `styles` keys are always present on the
+    // envelope.
+    for (let index = stack.length - 1; index > 0; index -= 1) {
+        const node = stack[index];
+        const parent = stack[index - 1];
+
+        if (
+            node !== undefined &&
+            parent !== undefined &&
+            Object.keys(node).length === 0
+        ) {
+            const parentKey = path[index - 1];
+
+            if (parentKey !== undefined) {
+                delete parent[parentKey];
+            }
+        } else {
+            break;
+        }
+    }
+
+    return root;
+}
+
+/**
+ * True when `userValue` differs from `baseValue`. Strings / numbers /
+ * booleans compare directly; objects and arrays compare by JSON round-trip
+ * so palette-entry reorders and value changes both register as dirty.
+ *
+ * `undefined` user values are not customized — they fall through to the
+ * theme default.
+ */
+export function isCustomized(userValue: unknown, baseValue: unknown): boolean {
+    if (userValue === undefined) {
+        return false;
+    }
+
+    if (userValue === baseValue) {
+        return false;
+    }
+
+    if (
+        (userValue === null || typeof userValue !== 'object') &&
+        (baseValue === null || typeof baseValue !== 'object')
+    ) {
+        return userValue !== baseValue;
+    }
+
+    try {
+        return JSON.stringify(userValue) !== JSON.stringify(baseValue);
+    } catch {
+        return userValue !== baseValue;
+    }
+}

--- a/resources/js/visual-editor/site-editor/styles/use-global-styles-editor.ts
+++ b/resources/js/visual-editor/site-editor/styles/use-global-styles-editor.ts
@@ -1,0 +1,525 @@
+/**
+ * Global-styles editor state hook.
+ *
+ * Owns the D3 styles section's in-memory draft — the pending edits the
+ * user makes in any of the six panels (typography, colors, layout,
+ * blocks, elements, variations) before they hit Save. Parallel to the
+ * D2 `useEntityEditor`, but shaped around global styles' singleton
+ * record instead of the per-entity template flow:
+ *
+ *   - One record per theme, so no `entityId` navigation. The id comes
+ *     from the `lookup` dispatch at bootstrap.
+ *   - Edits are sparse leaf patches (one property at a time) rather
+ *     than block-tree mutations. `patch(path, value)` writes a deep
+ *     key; `reset(path)` clears it.
+ *   - Save PUTs the merged (`base + edits`) record; 422 responses
+ *     surface under `validationErrors` so panels can render inline.
+ *
+ * The hook is kept headless so each panel gets the same dirty /
+ * customized / save primitives and the section wrapper can hand the
+ * shell top-bar a single save callback.
+ */
+
+import { dispatch as wpDispatch } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { TEXT_DOMAIN } from '../../vendor/i18n';
+import {
+    SiteEditorApiError,
+    type SiteEditorApiConfig,
+    type ValidationErrors,
+} from '../api-client';
+import type { SaveStatus } from '../use-entity-editor';
+
+import {
+    fetchGlobalStyles,
+    fetchGlobalStylesBase,
+    lookupGlobalStyles,
+    updateGlobalStyles,
+    type GlobalStylesBase,
+    type GlobalStylesRecord,
+} from './global-styles-api';
+import {
+    isCustomized,
+    readPath,
+    unsetPath,
+    writePath,
+    type ThemeJsonPath,
+} from './theme-json-paths';
+
+export interface UseGlobalStylesEditorOptions {
+    apiConfig: SiteEditorApiConfig;
+    /**
+     * When `false` the hook short-circuits into idle — nothing fetched,
+     * no state updates, safe to mount on sections that aren't styles.
+     */
+    enabled: boolean;
+}
+
+export interface GlobalStylesDraft {
+    version: number;
+    settings: Record<string, unknown>;
+    styles: Record<string, unknown>;
+}
+
+export type LoadStatus = 'idle' | 'loading' | 'ready' | 'error';
+
+export interface UseGlobalStylesEditorResult {
+    id: number | null;
+    base: GlobalStylesBase | null;
+    record: GlobalStylesRecord | null;
+    /** Merged (record + pending edits) shape — what panels should render. */
+    draft: GlobalStylesDraft | null;
+
+    loadStatus: LoadStatus;
+    loadErrorMessage: string | null;
+
+    isDirty: boolean;
+
+    saveStatus: SaveStatus;
+    saveErrorMessage: string | null;
+    validationErrors: ValidationErrors | null;
+    lastSavedAt: Date | null;
+
+    /** Value at `path`, preferring the user draft then falling back to base. */
+    readValue: (path: ThemeJsonPath) => unknown;
+    /** Base-payload value at `path` (no user overlay applied). */
+    readBaseValue: (path: ThemeJsonPath) => unknown;
+    /**
+     * `true` when the user has overridden the value at `path`. Panels
+     * use this to decorate customized fields + expose a "reset" affordance.
+     */
+    isPathCustomized: (path: ThemeJsonPath) => boolean;
+
+    /** Writes a leaf edit; marks the record dirty. */
+    setValue: (path: ThemeJsonPath, value: unknown) => void;
+    /**
+     * Replaces the settings or styles subtree wholesale. Used by the
+     * variation picker (which bulk-applies a preset's values) and the
+     * panel-scoped "reset section" affordance. The variation picker
+     * also passes a nested reset (`['color', 'palette']`) to blow away a
+     * specific subtree without touching sibling subtrees.
+     */
+    replaceSubtree: (scope: 'settings' | 'styles', path: ThemeJsonPath, value: unknown) => void;
+    /** Clears the user override at `path`, reverting to base. */
+    resetPath: (path: ThemeJsonPath) => void;
+    /** Clears every pending edit — full revert to the last saved record. */
+    resetAll: () => void;
+
+    save: () => Promise<GlobalStylesRecord | null>;
+}
+
+const EMPTY_EDITS: Readonly<GlobalStylesDraft> = Object.freeze({
+    version: 0,
+    settings: {},
+    styles: {},
+});
+
+function schemaVersionFrom(
+    record: GlobalStylesRecord | null,
+    base: GlobalStylesBase | null
+): number {
+    if (record !== null && typeof record.version === 'number') {
+        return record.version;
+    }
+
+    if (base !== null && typeof base.version === 'number') {
+        return base.version;
+    }
+
+    // The C3 backend pins schema v3 when no override is configured. The
+    // fallback matches `config/visual-editor.php` so a PUT from a
+    // brand-new app that hasn't yet received a lookup/base response
+    // still submits a value the backend will accept.
+    return 3;
+}
+
+function hasAnyEdits(edits: GlobalStylesDraft | null): boolean {
+    if (edits === null) {
+        return false;
+    }
+
+    return (
+        Object.keys(edits.settings).length > 0 ||
+        Object.keys(edits.styles).length > 0
+    );
+}
+
+/**
+ * Merges the base record, server record, and pending edits into a
+ * single object panels can read from.
+ */
+function buildDraft(
+    record: GlobalStylesRecord | null,
+    edits: GlobalStylesDraft,
+    base: GlobalStylesBase | null
+): GlobalStylesDraft | null {
+    if (record === null && base === null) {
+        return null;
+    }
+
+    const recordSettings =
+        record !== null && typeof record.settings === 'object' && record.settings !== null
+            ? record.settings
+            : {};
+    const recordStyles =
+        record !== null && typeof record.styles === 'object' && record.styles !== null
+            ? record.styles
+            : {};
+    const baseSettings = base?.settings ?? {};
+    const baseStyles = base?.styles ?? {};
+
+    const settings = mergeDeep(
+        mergeDeep(baseSettings, recordSettings),
+        edits.settings
+    );
+    const styles = mergeDeep(
+        mergeDeep(baseStyles, recordStyles),
+        edits.styles
+    );
+
+    return {
+        version: schemaVersionFrom(record, base),
+        settings,
+        styles,
+    };
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+    return (
+        value !== null &&
+        typeof value === 'object' &&
+        !Array.isArray(value) &&
+        Object.prototype.toString.call(value) === '[object Object]'
+    );
+}
+
+function mergeDeep(
+    base: Record<string, unknown>,
+    overlay: Record<string, unknown>
+): Record<string, unknown> {
+    if (Object.keys(overlay).length === 0) {
+        return { ...base };
+    }
+
+    const result: Record<string, unknown> = { ...base };
+
+    for (const [key, overlayValue] of Object.entries(overlay)) {
+        const baseValue = base[key];
+
+        if (isPlainObject(baseValue) && isPlainObject(overlayValue)) {
+            result[key] = mergeDeep(baseValue, overlayValue);
+            continue;
+        }
+
+        result[key] = overlayValue;
+    }
+
+    return result;
+}
+
+export function useGlobalStylesEditor(
+    options: UseGlobalStylesEditorOptions
+): UseGlobalStylesEditorResult {
+    const { apiConfig, enabled } = options;
+
+    const [id, setId] = useState<number | null>(null);
+    const [base, setBase] = useState<GlobalStylesBase | null>(null);
+    const [record, setRecord] = useState<GlobalStylesRecord | null>(null);
+    const [edits, setEdits] = useState<GlobalStylesDraft>({
+        ...EMPTY_EDITS,
+    });
+
+    const [loadStatus, setLoadStatus] = useState<LoadStatus>('idle');
+    const [loadErrorMessage, setLoadErrorMessage] = useState<string | null>(
+        null
+    );
+
+    const [saveStatus, setSaveStatus] = useState<SaveStatus>('idle');
+    const [saveErrorMessage, setSaveErrorMessage] = useState<string | null>(
+        null
+    );
+    const [validationErrors, setValidationErrors] =
+        useState<ValidationErrors | null>(null);
+    const [lastSavedAt, setLastSavedAt] = useState<Date | null>(null);
+
+    // Bumped on every local edit or save so in-flight fetches that
+    // started before a subsequent edit/unmount can't hydrate over the
+    // user's fresher state.
+    const requestCounterRef = useRef(0);
+
+    useEffect(() => {
+        if (!enabled) {
+            setLoadStatus('idle');
+            return;
+        }
+
+        const requestId = ++requestCounterRef.current;
+
+        setLoadStatus('loading');
+        setLoadErrorMessage(null);
+
+        void (async () => {
+            try {
+                const [lookup, baseRecord] = await Promise.all([
+                    lookupGlobalStyles(apiConfig),
+                    fetchGlobalStylesBase(apiConfig),
+                ]);
+
+                if (requestCounterRef.current !== requestId) {
+                    return;
+                }
+
+                // Dispatch into the core-data store so Gutenberg's
+                // globalStyles selectors (__experimentalGetCurrentGlobalStylesId
+                // etc.) resolve for any block-editor surface that asks —
+                // the hook also tracks its own copy for the panels'
+                // deep-leaf edits.
+                const coreDispatch = wpDispatch('core') as unknown as {
+                    receiveCurrentGlobalStylesId?: (id: number) => unknown;
+                    receiveGlobalStylesBase?: (
+                        payload: Record<string, unknown>
+                    ) => unknown;
+                };
+                coreDispatch.receiveCurrentGlobalStylesId?.(lookup.id);
+                coreDispatch.receiveGlobalStylesBase?.(
+                    baseRecord as unknown as Record<string, unknown>
+                );
+
+                setId(lookup.id);
+                setBase(baseRecord);
+
+                const fetched = await fetchGlobalStyles(
+                    apiConfig,
+                    lookup.id
+                );
+
+                if (requestCounterRef.current !== requestId) {
+                    return;
+                }
+
+                setRecord(fetched);
+                setEdits({ ...EMPTY_EDITS });
+                setLoadStatus('ready');
+            } catch (error: unknown) {
+                if (requestCounterRef.current !== requestId) {
+                    return;
+                }
+
+                const message =
+                    error instanceof SiteEditorApiError
+                        ? error.message
+                        : __(
+                              'Failed to load global styles.',
+                              TEXT_DOMAIN
+                          );
+
+                setLoadStatus('error');
+                setLoadErrorMessage(message);
+            }
+        })();
+    }, [apiConfig, enabled]);
+
+    const draft = useMemo(
+        () => buildDraft(record, edits, base),
+        [base, edits, record]
+    );
+
+    const readValue = useCallback(
+        (path: ThemeJsonPath): unknown => {
+            if (draft === null) {
+                return undefined;
+            }
+
+            return readPath(draft, path);
+        },
+        [draft]
+    );
+
+    const readBaseValue = useCallback(
+        (path: ThemeJsonPath): unknown => {
+            if (base === null) {
+                return undefined;
+            }
+
+            return readPath(base, path);
+        },
+        [base]
+    );
+
+    const isPathCustomized = useCallback(
+        (path: ThemeJsonPath): boolean => {
+            if (base === null) {
+                return false;
+            }
+
+            const draftValue = readPath(draft, path);
+            const baseValue = readPath(base, path);
+
+            return isCustomized(draftValue, baseValue);
+        },
+        [base, draft]
+    );
+
+    const mutate = useCallback(
+        (
+            mutator: (edits: GlobalStylesDraft) => GlobalStylesDraft
+        ): void => {
+            requestCounterRef.current += 1;
+            setEdits((prev) => mutator(prev));
+            setSaveStatus('idle');
+            setSaveErrorMessage(null);
+            setValidationErrors(null);
+        },
+        []
+    );
+
+    const setValue = useCallback(
+        (path: ThemeJsonPath, value: unknown): void => {
+            if (path.length === 0) {
+                return;
+            }
+
+            const [scope, ...rest] = path;
+
+            if (scope !== 'settings' && scope !== 'styles') {
+                return;
+            }
+
+            mutate((prev) => ({
+                ...prev,
+                [scope]: writePath(prev[scope], rest, value) as Record<
+                    string,
+                    unknown
+                >,
+            }));
+        },
+        [mutate]
+    );
+
+    const replaceSubtree = useCallback(
+        (
+            scope: 'settings' | 'styles',
+            path: ThemeJsonPath,
+            value: unknown
+        ): void => {
+            mutate((prev) => ({
+                ...prev,
+                [scope]:
+                    path.length === 0
+                        ? ((value as Record<string, unknown>) ?? {})
+                        : (writePath(prev[scope], path, value) as Record<
+                              string,
+                              unknown
+                          >),
+            }));
+        },
+        [mutate]
+    );
+
+    const resetPath = useCallback(
+        (path: ThemeJsonPath): void => {
+            if (path.length === 0) {
+                return;
+            }
+
+            const [scope, ...rest] = path;
+
+            if (scope !== 'settings' && scope !== 'styles') {
+                return;
+            }
+
+            mutate((prev) => ({
+                ...prev,
+                [scope]: unsetPath(prev[scope], rest) as Record<
+                    string,
+                    unknown
+                >,
+            }));
+        },
+        [mutate]
+    );
+
+    const resetAll = useCallback((): void => {
+        mutate(() => ({ ...EMPTY_EDITS }));
+    }, [mutate]);
+
+    const isDirty = useMemo(() => hasAnyEdits(edits), [edits]);
+
+    const save = useCallback(async (): Promise<GlobalStylesRecord | null> => {
+        if (id === null) {
+            return null;
+        }
+
+        if (draft === null) {
+            return null;
+        }
+
+        const requestId = ++requestCounterRef.current;
+        const isStale = (): boolean =>
+            requestCounterRef.current !== requestId;
+
+        setSaveStatus('saving');
+        setSaveErrorMessage(null);
+        setValidationErrors(null);
+
+        try {
+            const saved = await updateGlobalStyles(apiConfig, id, {
+                version: draft.version,
+                settings: draft.settings,
+                styles: draft.styles,
+            });
+
+            if (isStale()) {
+                return saved;
+            }
+
+            setRecord(saved);
+            setEdits({ ...EMPTY_EDITS });
+            setSaveStatus('saved');
+            setLastSavedAt(new Date());
+
+            return saved;
+        } catch (error: unknown) {
+            if (isStale()) {
+                return null;
+            }
+
+            if (error instanceof SiteEditorApiError) {
+                setSaveStatus('error');
+                setSaveErrorMessage(error.message);
+                setValidationErrors(error.validationErrors);
+            } else {
+                setSaveStatus('error');
+                setSaveErrorMessage(
+                    __('Failed to save global styles.', TEXT_DOMAIN)
+                );
+            }
+
+            return null;
+        }
+    }, [apiConfig, draft, id]);
+
+    return {
+        id,
+        base,
+        record,
+        draft,
+        loadStatus,
+        loadErrorMessage,
+        isDirty,
+        saveStatus,
+        saveErrorMessage,
+        validationErrors,
+        lastSavedAt,
+        readValue,
+        readBaseValue,
+        isPathCustomized,
+        setValue,
+        replaceSubtree,
+        resetPath,
+        resetAll,
+        save,
+    };
+}

--- a/resources/js/visual-editor/site-editor/styles/use-global-styles-editor.ts
+++ b/resources/js/visual-editor/site-editor/styles/use-global-styles-editor.ts
@@ -11,9 +11,11 @@
  *     from the `lookup` dispatch at bootstrap.
  *   - Edits are sparse leaf patches (one property at a time) rather
  *     than block-tree mutations. `patch(path, value)` writes a deep
- *     key; `reset(path)` clears it.
- *   - Save PUTs the merged (`base + edits`) record; 422 responses
- *     surface under `validationErrors` so panels can render inline.
+ *     key; `resetPath(path)` reverts to base (including stripping a
+ *     previously-persisted override from the record on save).
+ *   - Save PUTs the user-owned payload (record + overlay, minus reset
+ *     paths); 422 responses surface under `validationErrors` so panels
+ *     can render inline.
  *
  * The hook is kept headless so each panel gets the same dirty /
  * customized / save primitives and the section wrapper can hand the
@@ -69,7 +71,7 @@ export interface UseGlobalStylesEditorResult {
     id: number | null;
     base: GlobalStylesBase | null;
     record: GlobalStylesRecord | null;
-    /** Merged (record + pending edits) shape — what panels should render. */
+    /** Merged (base + record + overlay) shape — what panels should render. */
     draft: GlobalStylesDraft | null;
 
     loadStatus: LoadStatus;
@@ -102,18 +104,39 @@ export interface UseGlobalStylesEditorResult {
      * specific subtree without touching sibling subtrees.
      */
     replaceSubtree: (scope: 'settings' | 'styles', path: ThemeJsonPath, value: unknown) => void;
-    /** Clears the user override at `path`, reverting to base. */
+    /**
+     * Reverts the value at `path` back to the theme default. Clears
+     * both pending overlay edits *and* any persisted override on the
+     * saved record so the user genuinely sees the theme default (not a
+     * stale value they saved days ago).
+     */
     resetPath: (path: ThemeJsonPath) => void;
-    /** Clears every pending edit — full revert to the last saved record. */
+    /**
+     * Wipes every user customization — pending edits + persisted
+     * overrides — so the editor shows the theme base wholesale.
+     */
     resetAll: () => void;
 
     save: () => Promise<GlobalStylesRecord | null>;
 }
 
-const EMPTY_EDITS: Readonly<GlobalStylesDraft> = Object.freeze({
-    version: 0,
+interface EditsState {
+    settings: Record<string, unknown>;
+    styles: Record<string, unknown>;
+    /**
+     * Paths (relative to the draft root, e.g. `['settings','color','palette']`)
+     * the user has explicitly reset. Applied as a pre-merge strip on
+     * the record — so a previously-persisted override doesn't survive a
+     * reset, and the save payload omits the value so the next fetch
+     * returns the base default.
+     */
+    removedPaths: ThemeJsonPath[];
+}
+
+const EMPTY_EDITS: Readonly<EditsState> = Object.freeze({
     settings: {},
     styles: {},
+    removedPaths: [],
 });
 
 function schemaVersionFrom(
@@ -135,55 +158,12 @@ function schemaVersionFrom(
     return 3;
 }
 
-function hasAnyEdits(edits: GlobalStylesDraft | null): boolean {
-    if (edits === null) {
-        return false;
-    }
-
+function hasAnyEdits(edits: EditsState): boolean {
     return (
         Object.keys(edits.settings).length > 0 ||
-        Object.keys(edits.styles).length > 0
+        Object.keys(edits.styles).length > 0 ||
+        edits.removedPaths.length > 0
     );
-}
-
-/**
- * Merges the base record, server record, and pending edits into a
- * single object panels can read from.
- */
-function buildDraft(
-    record: GlobalStylesRecord | null,
-    edits: GlobalStylesDraft,
-    base: GlobalStylesBase | null
-): GlobalStylesDraft | null {
-    if (record === null && base === null) {
-        return null;
-    }
-
-    const recordSettings =
-        record !== null && typeof record.settings === 'object' && record.settings !== null
-            ? record.settings
-            : {};
-    const recordStyles =
-        record !== null && typeof record.styles === 'object' && record.styles !== null
-            ? record.styles
-            : {};
-    const baseSettings = base?.settings ?? {};
-    const baseStyles = base?.styles ?? {};
-
-    const settings = mergeDeep(
-        mergeDeep(baseSettings, recordSettings),
-        edits.settings
-    );
-    const styles = mergeDeep(
-        mergeDeep(baseStyles, recordStyles),
-        edits.styles
-    );
-
-    return {
-        version: schemaVersionFrom(record, base),
-        settings,
-        styles,
-    };
 }
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
@@ -219,6 +199,116 @@ function mergeDeep(
     return result;
 }
 
+/**
+ * Applies every removed path as an `unset` against the record so the
+ * strip survives into both the draft render and the save payload.
+ */
+function stripRemovedPaths(
+    recordSettings: Record<string, unknown>,
+    recordStyles: Record<string, unknown>,
+    removedPaths: readonly ThemeJsonPath[]
+): { settings: Record<string, unknown>; styles: Record<string, unknown> } {
+    let settings = { ...recordSettings };
+    let styles = { ...recordStyles };
+
+    for (const path of removedPaths) {
+        const [scope, ...rest] = path;
+
+        if (scope === 'settings') {
+            settings =
+                rest.length === 0
+                    ? {}
+                    : (unsetPath(settings, rest) as Record<string, unknown>);
+        } else if (scope === 'styles') {
+            styles =
+                rest.length === 0
+                    ? {}
+                    : (unsetPath(styles, rest) as Record<string, unknown>);
+        }
+    }
+
+    return { settings, styles };
+}
+
+/**
+ * Merges the base record, server record (with resets applied), and
+ * pending overlay edits into a single object panels can read from.
+ */
+function buildDraft(
+    record: GlobalStylesRecord | null,
+    edits: EditsState,
+    base: GlobalStylesBase | null
+): GlobalStylesDraft | null {
+    if (record === null && base === null) {
+        return null;
+    }
+
+    const recordSettings =
+        record !== null && isPlainObject(record.settings)
+            ? record.settings
+            : {};
+    const recordStyles =
+        record !== null && isPlainObject(record.styles)
+            ? record.styles
+            : {};
+    const baseSettings = isPlainObject(base?.settings) ? base.settings : {};
+    const baseStyles = isPlainObject(base?.styles) ? base.styles : {};
+
+    const stripped = stripRemovedPaths(
+        recordSettings,
+        recordStyles,
+        edits.removedPaths
+    );
+
+    const settings = mergeDeep(
+        mergeDeep(baseSettings, stripped.settings),
+        edits.settings
+    );
+    const styles = mergeDeep(
+        mergeDeep(baseStyles, stripped.styles),
+        edits.styles
+    );
+
+    return {
+        version: schemaVersionFrom(record, base),
+        settings,
+        styles,
+    };
+}
+
+/**
+ * Computes the payload for `PUT /global-styles/{id}` — the user's own
+ * record + pending overlay, with reset paths stripped. Does NOT include
+ * base defaults, so subsequent fetches return a lean record that the
+ * next reset can actually bring back to base.
+ */
+function buildSavePayload(
+    record: GlobalStylesRecord | null,
+    edits: EditsState,
+    version: number
+): { version: number; settings: Record<string, unknown>; styles: Record<string, unknown> } {
+    const recordSettings =
+        record !== null && isPlainObject(record.settings)
+            ? record.settings
+            : {};
+    const recordStyles =
+        record !== null && isPlainObject(record.styles)
+            ? record.styles
+            : {};
+
+    const stripped = stripRemovedPaths(
+        recordSettings,
+        recordStyles,
+        edits.removedPaths
+    );
+
+    return {
+        version,
+        settings: mergeDeep(stripped.settings, edits.settings),
+        styles: mergeDeep(stripped.styles, edits.styles),
+    };
+}
+
 export function useGlobalStylesEditor(
     options: UseGlobalStylesEditorOptions
 ): UseGlobalStylesEditorResult {
@@ -227,9 +317,7 @@ export function useGlobalStylesEditor(
     const [id, setId] = useState<number | null>(null);
     const [base, setBase] = useState<GlobalStylesBase | null>(null);
     const [record, setRecord] = useState<GlobalStylesRecord | null>(null);
-    const [edits, setEdits] = useState<GlobalStylesDraft>({
-        ...EMPTY_EDITS,
-    });
+    const [edits, setEdits] = useState<EditsState>({ ...EMPTY_EDITS });
 
     const [loadStatus, setLoadStatus] = useState<LoadStatus>('idle');
     const [loadErrorMessage, setLoadErrorMessage] = useState<string | null>(
@@ -251,7 +339,19 @@ export function useGlobalStylesEditor(
 
     useEffect(() => {
         if (!enabled) {
+            // Invalidate any in-flight fetches started while this
+            // section was active and clear the cached state so a
+            // subsequent re-enable doesn't surface stale styles.
+            requestCounterRef.current += 1;
+            setId(null);
+            setBase(null);
+            setRecord(null);
+            setEdits({ ...EMPTY_EDITS });
             setLoadStatus('idle');
+            setLoadErrorMessage(null);
+            setSaveStatus('idle');
+            setSaveErrorMessage(null);
+            setValidationErrors(null);
             return;
         }
 
@@ -363,9 +463,7 @@ export function useGlobalStylesEditor(
     );
 
     const mutate = useCallback(
-        (
-            mutator: (edits: GlobalStylesDraft) => GlobalStylesDraft
-        ): void => {
+        (mutator: (edits: EditsState) => EditsState): void => {
             requestCounterRef.current += 1;
             setEdits((prev) => mutator(prev));
             setSaveStatus('idle');
@@ -393,6 +491,14 @@ export function useGlobalStylesEditor(
                     string,
                     unknown
                 >,
+                // A new value at this path implicitly un-resets it — the
+                // user is explicitly re-customizing, so the previous
+                // "strip from record on save" marker is stale.
+                removedPaths: prev.removedPaths.filter(
+                    (removed) =>
+                        removed.length !== path.length ||
+                        removed.some((segment, index) => segment !== path[index])
+                ),
             }));
         },
         [mutate]
@@ -404,16 +510,32 @@ export function useGlobalStylesEditor(
             path: ThemeJsonPath,
             value: unknown
         ): void => {
-            mutate((prev) => ({
-                ...prev,
-                [scope]:
+            mutate((prev) => {
+                const nextScope =
                     path.length === 0
                         ? ((value as Record<string, unknown>) ?? {})
                         : (writePath(prev[scope], path, value) as Record<
                               string,
                               unknown
-                          >),
-            }));
+                          >);
+
+                // A root replace (applying a variation) means "this is
+                // now the whole scope" — any stale removed-path for
+                // this scope is now absorbed by the explicit overlay,
+                // so drop them.
+                const nextRemoved =
+                    path.length === 0
+                        ? prev.removedPaths.filter(
+                              (removed) => removed[0] !== scope
+                          )
+                        : prev.removedPaths;
+
+                return {
+                    ...prev,
+                    [scope]: nextScope,
+                    removedPaths: nextRemoved,
+                };
+            });
         },
         [mutate]
     );
@@ -430,19 +552,54 @@ export function useGlobalStylesEditor(
                 return;
             }
 
-            mutate((prev) => ({
-                ...prev,
-                [scope]: unsetPath(prev[scope], rest) as Record<
-                    string,
-                    unknown
-                >,
-            }));
+            mutate((prev) => {
+                // Drop any overlay entry at or under this path so the
+                // display + save payload don't re-apply the value we're
+                // trying to reset.
+                const nextScope =
+                    rest.length === 0
+                        ? {}
+                        : (unsetPath(prev[scope], rest) as Record<
+                              string,
+                              unknown
+                          >);
+
+                // Record the reset so buildDraft strips record + the
+                // save payload omits the value. De-dupe against any
+                // ancestor path already marked — the broader reset
+                // already covers this one.
+                const alreadyCovered = prev.removedPaths.some((removed) => {
+                    if (removed.length > path.length) {
+                        return false;
+                    }
+
+                    return removed.every(
+                        (segment, index) => segment === path[index]
+                    );
+                });
+
+                const nextRemoved = alreadyCovered
+                    ? prev.removedPaths
+                    : [...prev.removedPaths, path];
+
+                return {
+                    ...prev,
+                    [scope]: nextScope,
+                    removedPaths: nextRemoved,
+                };
+            });
         },
         [mutate]
     );
 
     const resetAll = useCallback((): void => {
-        mutate(() => ({ ...EMPTY_EDITS }));
+        // Blow away both scopes entirely: pending overlay + persisted
+        // record get stripped so the user sees pure base defaults.
+        mutate(() => ({
+            settings: {},
+            styles: {},
+            removedPaths: [['settings'], ['styles']],
+        }));
     }, [mutate]);
 
     const isDirty = useMemo(() => hasAnyEdits(edits), [edits]);
@@ -465,11 +622,11 @@ export function useGlobalStylesEditor(
         setValidationErrors(null);
 
         try {
-            const saved = await updateGlobalStyles(apiConfig, id, {
-                version: draft.version,
-                settings: draft.settings,
-                styles: draft.styles,
-            });
+            const saved = await updateGlobalStyles(
+                apiConfig,
+                id,
+                buildSavePayload(record, edits, draft.version)
+            );
 
             if (isStale()) {
                 return saved;
@@ -499,7 +656,7 @@ export function useGlobalStylesEditor(
 
             return null;
         }
-    }, [apiConfig, draft, id]);
+    }, [apiConfig, draft, edits, id, record]);
 
     return {
         id,

--- a/resources/js/visual-editor/site-editor/styles/use-registered-blocks.ts
+++ b/resources/js/visual-editor/site-editor/styles/use-registered-blocks.ts
@@ -1,0 +1,153 @@
+/**
+ * Registered-blocks hook.
+ *
+ * Fetches the block-type registry exposed at `GET /visual-editor/api/blocks`.
+ * The Styles → Blocks navigator node renders only these blocks — per
+ * issue #370's out-of-scope note, we do not list every Gutenberg core
+ * block if it's been disabled via the `disabled_blocks` config (same
+ * principle the site-editor shell's `D2_DISABLED_BLOCKS` enforces on
+ * the JS side).
+ */
+
+import { __ } from '@wordpress/i18n';
+import { useEffect, useRef, useState } from 'react';
+
+import { TEXT_DOMAIN } from '../../vendor/i18n';
+import {
+    SiteEditorApiError,
+    type SiteEditorApiConfig,
+} from '../api-client';
+import type { StyleBlock } from './styles-navigator';
+
+export interface UseRegisteredBlocksResult {
+    blocks: readonly StyleBlock[];
+    isLoading: boolean;
+    error: string | null;
+}
+
+interface BlocksEnvelope {
+    blocks: ReadonlyArray<Record<string, unknown>>;
+}
+
+const READ_HEADERS: Readonly<Record<string, string>> = {
+    Accept: 'application/json',
+    'X-Requested-With': 'XMLHttpRequest',
+};
+
+function buildUrl(config: SiteEditorApiConfig): string {
+    const base = config.apiBase.replace(/\/+$/, '');
+
+    return `${base}/blocks`;
+}
+
+async function parseBody(response: Response): Promise<unknown> {
+    const text = await response.text();
+
+    if (text === '') {
+        return null;
+    }
+
+    try {
+        return JSON.parse(text);
+    } catch {
+        return text;
+    }
+}
+
+function normalizeBlocks(envelope: unknown): readonly StyleBlock[] {
+    if (envelope === null || typeof envelope !== 'object') {
+        return [];
+    }
+
+    const maybe = (envelope as BlocksEnvelope).blocks;
+
+    if (!Array.isArray(maybe)) {
+        return [];
+    }
+
+    const result: StyleBlock[] = [];
+
+    for (const entry of maybe) {
+        if (entry === null || typeof entry !== 'object') {
+            continue;
+        }
+
+        const row = entry as Record<string, unknown>;
+        const name = typeof row.name === 'string' ? row.name : null;
+
+        if (name === null) {
+            continue;
+        }
+
+        const title = typeof row.title === 'string' ? row.title : undefined;
+
+        result.push(title !== undefined ? { name, title } : { name });
+    }
+
+    return result;
+}
+
+export function useRegisteredBlocks(
+    apiConfig: SiteEditorApiConfig,
+    enabled: boolean
+): UseRegisteredBlocksResult {
+    const [blocks, setBlocks] = useState<readonly StyleBlock[]>([]);
+    const [isLoading, setIsLoading] = useState<boolean>(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const requestCounterRef = useRef(0);
+
+    useEffect(() => {
+        if (!enabled) {
+            return;
+        }
+
+        const requestId = ++requestCounterRef.current;
+        setIsLoading(true);
+        setError(null);
+
+        void (async () => {
+            try {
+                const response = await fetch(buildUrl(apiConfig), {
+                    method: 'GET',
+                    credentials: 'same-origin',
+                    headers: READ_HEADERS,
+                });
+
+                const body = await parseBody(response);
+
+                if (requestCounterRef.current !== requestId) {
+                    return;
+                }
+
+                if (!response.ok) {
+                    throw new SiteEditorApiError(
+                        `Block registry request failed with status ${response.status}`,
+                        response.status,
+                        body
+                    );
+                }
+
+                setBlocks(normalizeBlocks(body));
+                setIsLoading(false);
+            } catch (err: unknown) {
+                if (requestCounterRef.current !== requestId) {
+                    return;
+                }
+
+                const message =
+                    err instanceof Error && err.message !== ''
+                        ? err.message
+                        : __(
+                              'Failed to load registered blocks.',
+                              TEXT_DOMAIN
+                          );
+
+                setError(message);
+                setIsLoading(false);
+            }
+        })();
+    }, [apiConfig, enabled]);
+
+    return { blocks, isLoading, error };
+}

--- a/resources/js/visual-editor/site-editor/styles/use-registered-blocks.ts
+++ b/resources/js/visual-editor/site-editor/styles/use-registered-blocks.ts
@@ -99,6 +99,13 @@ export function useRegisteredBlocks(
 
     useEffect(() => {
         if (!enabled) {
+            // Invalidate any in-flight fetch and clear cached state so
+            // a stale response can't slip past the counter guard and a
+            // re-enable starts from a known blank slate.
+            requestCounterRef.current += 1;
+            setBlocks([]);
+            setError(null);
+            setIsLoading(false);
             return;
         }
 


### PR DESCRIPTION
## Description

Builds the D3 Global Styles UI inside the D1 site-editor shell. Authors can now customize theme.json-shaped presets and styles — typography, colors, layout, per-block overrides, per-element overrides, and theme variations — and write them back through C3's `PUT /global-styles/{id}` endpoint. The section mounts inside the shell's navigator / canvas / inspector slots using the same entity-state slot templates and template parts use, so the top-bar Save button ("Save global styles") wires up with no shell special-casing.

**Closes:** #370

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #370

## Motivation and Context

Global styles is flagged in D0 as a known WP pain point (discoverability, unclear scope, buried Style Book). D3 implements D0's brief: Style Book is the default canvas, the navigator mirrors theme.json hierarchy, the inspector always shows scope breadcrumbs, and the variation picker lands in V1. Without D3, the Styles section shows only a placeholder; E1 (front-end CSS emission) is also blocked on this landing.

## Changes Made

- **Bootstrap**: `/lookup` + `/base` dispatch into the core-data shim on mount (`receiveCurrentGlobalStylesId`, `receiveGlobalStylesBase`)
- **Navigator tree**: Typography / Colors / Layout / Blocks / Elements / Variations with drill-downs for blocks + elements; Blocks children come from `/visual-editor/api/blocks` so only registered block types appear
- **Canvas**: Style Book preview (palette swatches, typography sample, layout summary) + horizontal variation-picker strip
- **Inspector**: breadcrumb (`Styles ▸ Blocks ▸ Button`), dirty / saved / 422 chrome, and the six panels built entirely on `@wordpress/components` primitives (`PanelBody`, `PanelRow`, `SelectControl`, `TextControl`, `ColorPalette`, `ColorPicker` + `ColorIndicator` + `Dropdown`, `__experimentalUnitControl`) so the Styles UI matches the block-inspector look & feel
- **Save pipeline**: the shell's existing `entityState` slot drives the top-bar Save button with label "Save global styles"; 422 responses surface field-level errors inline
- **Palette editor**: add / remove / reorder / rename / recolor; duplicate-slug detection inline before the PUT
- **Variation picker**: apply-only per V1 plan §8; duplicate-and-tweak happens organically via subsequent panel edits
- **Tests**: 28 new tests covering bootstrap dispatch, panel mount, each panel's interactions, reset-to-default, variation apply, save pipeline, 422 handling, breadcrumb rendering, a11y

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS
- Browser: Safari (local Herd)
- PHP Version: 8.4.3
- Project Version: 1.0.0-alpha.1 (release/1.0 branch)

**Tests Performed:**
1. Navigate to \`/visual-editor/site/styles\`, confirm the six panels + breadcrumb render and the canvas shows a live Style Book
2. Edit typography / color / layout / block / element values and verify the "Customized" chip appears, the Reset affordance reverts to base, and the top-bar Save persists via PUT
3. Apply a style variation from the picker, confirm it overwrites the user record and marks the session dirty
4. Force a 422 (duplicate palette slug) and confirm field-level + top-level error display
5. Confirm the palette swatch click opens Gutenberg's `ColorPicker` popover (not the native OS picker)

## Accessibility Tests Run

- [x] Keyboard navigation tested
- [x] Screen reader tested
- [x] Color contrast verified
- [x] ARIA labels checked

**Details:** navigator uses `role=\"tree\"` with proper aria-expanded / aria-selected per node; inspector breadcrumb uses `<nav>` + `aria-current=\"page\"`; variation picker uses `role=\"radiogroup\"` with roving tabindex so only the active (or first) radio is tab-reachable; every color / text control inherits Gutenberg's own focus + announcement behavior.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:** 28 new tests across `styles/__tests__/styles-section.test.tsx` + `styles/__tests__/theme-json-paths.test.ts`. Updated `site-editor-app.test.tsx` to stub the styles hook so shell tests don't reach the new REST endpoints. Full suite: 660 JS tests + 341 PHP tests passing.

## Documentation

- [x] Inline code documentation added

**Documentation details:** Every module carries a header docblock explaining its role in the D1 shell + references to the design brief / plan sections it implements. Non-obvious choices (deterministic variation signature, `__experimentalUnitControl` API risk, dual D2/D3 entity-state ownership) have inline comments.

## Screenshots

_Added manually during manual-test review; palette editor now uses Gutenberg's `ColorPicker` popover; all rows inside a panel have visible separation via the `PanelBody` row dividers._

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [x] Accessibility tests completed
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full Global Styles editor: Typography, Colors, Layout, Blocks, Elements, Variations panels; style-book preview with keyboard-accessible variation picker; palette/preset/unit editors with add/remove/reorder and per-field reset.

* **Improvements**
  * More robust section routing and state handling to avoid stale save-status UI; consistent reset/save lifecycle and clearer validation/error feedback in the UI.

* **Tests**
  * Broad Vitest coverage for styles UI flows, theme.json path utilities, API client behavior, and save/validation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->