### PR TITLE
feat: D4 · Navigation editor screen + core/navigation enablement

### DIFF
--- a/config/visual-editor.php
+++ b/config/visual-editor.php
@@ -88,7 +88,11 @@ return [
 	],
 
 	'disabled_blocks' => [
-		'core/navigation',
+		// `core/navigation` is enabled by D4 — its editor experience is
+		// backed by the `wp_navigation` shim entity (B1) plus the C4
+		// REST surface, so the block's link-control picker and inner
+		// blocks both round-trip cleanly. The JS-side mirror in
+		// site-editor-app.tsx is updated alongside this entry.
 		'core/query',
 		'core/query-loop',
 		'core/post-content',

--- a/database/migrations/2026_04_24_000000_add_location_to_visual_editor_navigations_table.php
+++ b/database/migrations/2026_04_24_000000_add_location_to_visual_editor_navigations_table.php
@@ -10,9 +10,13 @@
  * consults before falling back to the config-driven `primary_id` /
  * first-published lookup chain.
  *
- * The column is nullable + indexed: most navs sit at no location until the
- * editor explicitly assigns one, and the resolver's `forLocation` lookup is
- * an indexed `where`.
+ * The column is nullable + uniquely indexed. Single-occupancy is the
+ * design contract — a location belongs to exactly one menu at a time —
+ * so enforcing it at the database layer closes the race window the
+ * application-level `releaseLocationFromOtherRecords()` shim leaves
+ * open. SQL `UNIQUE` allows multiple NULLs across all three target
+ * databases (MySQL / Postgres / SQLite), so unassigned menus
+ * (`location = NULL`) coexist freely.
  *
  * @package    ArtisanPack_UI
  * @subpackage VisualEditor
@@ -33,14 +37,14 @@ return new class extends Migration
 	public function up(): void
 	{
 		Schema::table( 'visual_editor_navigations', function ( Blueprint $table ) {
-			$table->string( 'location' )->nullable()->index();
+			$table->string( 'location' )->nullable()->unique();
 		} );
 	}
 
 	public function down(): void
 	{
 		Schema::table( 'visual_editor_navigations', function ( Blueprint $table ) {
-			$table->dropIndex( [ 'location' ] );
+			$table->dropUnique( [ 'location' ] );
 			$table->dropColumn( 'location' );
 		} );
 	}

--- a/database/migrations/2026_04_24_000000_add_location_to_visual_editor_navigations_table.php
+++ b/database/migrations/2026_04_24_000000_add_location_to_visual_editor_navigations_table.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * Add location column to visual_editor_navigations migration.
+ *
+ * Adds the menu-location assignment slot D4 writes to from the site editor's
+ * Navigation section. The slug names a location declared in
+ * `config/artisanpack.visual-editor.navigation.locations` and is the
+ * authoritative source the {@see \ArtisanPackUI\VisualEditor\Services\MenuLocationResolver}
+ * consults before falling back to the config-driven `primary_id` /
+ * first-published lookup chain.
+ *
+ * The column is nullable + indexed: most navs sit at no location until the
+ * editor explicitly assigns one, and the resolver's `forLocation` lookup is
+ * an indexed `where`.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+	public function up(): void
+	{
+		Schema::table( 'visual_editor_navigations', function ( Blueprint $table ) {
+			$table->string( 'location' )->nullable()->index();
+		} );
+	}
+
+	public function down(): void
+	{
+		Schema::table( 'visual_editor_navigations', function ( Blueprint $table ) {
+			$table->dropIndex( [ 'location' ] );
+			$table->dropColumn( 'location' );
+		} );
+	}
+};

--- a/resources/js/visual-editor/site-editor/navigation/__tests__/api-client.test.ts
+++ b/resources/js/visual-editor/site-editor/navigation/__tests__/api-client.test.ts
@@ -1,0 +1,261 @@
+/**
+ * Navigation REST client tests.
+ *
+ * Mirrors `../../__tests__/api-client.test.ts` patterns: stub
+ * `fetch`, assert on URL / method / body for each helper, and verify
+ * shape filtering for the locations + search endpoints.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+    createNavigation,
+    fetchMenuLocations,
+    fetchNavigation,
+    listNavigations,
+    searchEntities,
+    updateNavigation,
+} from '../api-client';
+
+const API_BASE = '/visual-editor/api';
+
+function mockFetch(
+    response: Response | (() => Response)
+): ReturnType<typeof vi.fn> {
+    const fn = vi.fn(async (): Promise<Response> =>
+        typeof response === 'function' ? response() : response
+    );
+
+    vi.stubGlobal('fetch', fn);
+
+    return fn;
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+    return new Response(JSON.stringify(body), {
+        status,
+        headers: { 'Content-Type': 'application/json' },
+    });
+}
+
+beforeEach(() => {
+    document.querySelectorAll('meta[name="csrf-token"]').forEach((node) => {
+        node.remove();
+    });
+});
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
+
+describe('listNavigations', () => {
+    it('returns the paginated envelope', async () => {
+        const fetchMock = mockFetch(
+            jsonResponse({
+                data: [
+                    {
+                        id: 5,
+                        slug: 'primary',
+                        title: { rendered: 'Primary' },
+                        content: { raw: '', blocks: [] },
+                        status: 'publish',
+                        menu_order: 0,
+                        location: 'primary',
+                        type: 'wp_navigation',
+                    },
+                ],
+                meta: {
+                    current_page: 1,
+                    last_page: 1,
+                    per_page: 25,
+                    total: 1,
+                },
+            })
+        );
+
+        const response = await listNavigations(
+            { apiBase: API_BASE },
+            { perPage: 25 }
+        );
+
+        expect(response.data).toHaveLength(1);
+        expect(response.meta.total).toBe(1);
+        expect(fetchMock.mock.calls[0]?.[0]).toContain(
+            '/visual-editor/api/navigation?per_page=25'
+        );
+    });
+});
+
+describe('fetchNavigation', () => {
+    it('GETs a single record by id', async () => {
+        const fetchMock = mockFetch(
+            jsonResponse({
+                id: 9,
+                slug: 'footer',
+                title: { rendered: 'Footer' },
+                content: { raw: '', blocks: [] },
+                status: 'publish',
+                menu_order: 0,
+                location: null,
+                type: 'wp_navigation',
+            })
+        );
+
+        const record = await fetchNavigation({ apiBase: API_BASE }, 9);
+
+        expect(record.slug).toBe('footer');
+        expect(fetchMock.mock.calls[0]?.[0]).toBe(
+            '/visual-editor/api/navigation/9'
+        );
+    });
+});
+
+describe('createNavigation + updateNavigation', () => {
+    it('POSTs a JSON body for create', async () => {
+        const fetchMock = mockFetch(
+            jsonResponse(
+                {
+                    id: 1,
+                    slug: 'primary',
+                    title: { rendered: 'Primary' },
+                    content: { raw: '', blocks: [] },
+                    status: 'publish',
+                    menu_order: 0,
+                    location: null,
+                    type: 'wp_navigation',
+                },
+                201
+            )
+        );
+
+        await createNavigation(
+            { apiBase: API_BASE },
+            { slug: 'primary', title: 'Primary' }
+        );
+
+        expect(fetchMock.mock.calls[0]?.[1]).toMatchObject({
+            method: 'POST',
+        });
+        const body = JSON.parse(
+            (fetchMock.mock.calls[0]?.[1] as { body: string }).body
+        );
+        expect(body).toEqual({ slug: 'primary', title: 'Primary' });
+    });
+
+    it('PUTs the update payload at /navigation/{id}', async () => {
+        const fetchMock = mockFetch(
+            jsonResponse({
+                id: 2,
+                slug: 'primary',
+                title: { rendered: 'Renamed' },
+                content: { raw: '', blocks: [] },
+                status: 'publish',
+                menu_order: 0,
+                location: 'primary',
+                type: 'wp_navigation',
+            })
+        );
+
+        await updateNavigation(
+            { apiBase: API_BASE },
+            2,
+            { title: 'Renamed', location: 'primary' }
+        );
+
+        expect(fetchMock.mock.calls[0]?.[0]).toBe(
+            '/visual-editor/api/navigation/2'
+        );
+        expect(fetchMock.mock.calls[0]?.[1]).toMatchObject({
+            method: 'PUT',
+        });
+    });
+});
+
+describe('fetchMenuLocations', () => {
+    it('returns the configured locations', async () => {
+        mockFetch(
+            jsonResponse({
+                data: [
+                    {
+                        slug: 'primary',
+                        label: 'Primary Menu',
+                        menu: { id: 1, slug: 'main', title: 'Main' },
+                        is_fallback: false,
+                    },
+                    {
+                        slug: 'footer',
+                        label: 'Footer',
+                        menu: null,
+                        is_fallback: false,
+                    },
+                ],
+            })
+        );
+
+        const result = await fetchMenuLocations({ apiBase: API_BASE });
+
+        expect(result).toHaveLength(2);
+        expect(result[0].slug).toBe('primary');
+        expect(result[1].menu).toBeNull();
+    });
+
+    it('drops malformed rows', async () => {
+        mockFetch(
+            jsonResponse({
+                data: [
+                    { slug: 'primary', label: 'Primary', is_fallback: false },
+                    { slug: 'broken' /* missing label */ },
+                    null,
+                ],
+            })
+        );
+
+        const result = await fetchMenuLocations({ apiBase: API_BASE });
+
+        expect(result).toHaveLength(1);
+        expect(result[0].slug).toBe('primary');
+    });
+});
+
+describe('searchEntities', () => {
+    it('passes the type + q params', async () => {
+        const fetchMock = mockFetch(
+            jsonResponse({
+                data: [
+                    { type: 'page', id: 1, title: 'About', url: '/about' },
+                ],
+            })
+        );
+
+        const results = await searchEntities(
+            { apiBase: API_BASE },
+            { type: 'page', q: 'about' }
+        );
+
+        expect(results).toHaveLength(1);
+        expect(fetchMock.mock.calls[0]?.[0]).toContain(
+            '/visual-editor/api/search?'
+        );
+        expect(fetchMock.mock.calls[0]?.[0]).toContain('type=page');
+        expect(fetchMock.mock.calls[0]?.[0]).toContain('q=about');
+    });
+
+    it('drops rows that are not search-result-shaped', async () => {
+        mockFetch(
+            jsonResponse({
+                data: [
+                    { type: 'page', id: 1, title: 'OK' },
+                    { id: 2 },
+                    null,
+                ],
+            })
+        );
+
+        const results = await searchEntities(
+            { apiBase: API_BASE },
+            { type: 'page', q: '' }
+        );
+
+        expect(results).toHaveLength(1);
+    });
+});

--- a/resources/js/visual-editor/site-editor/navigation/__tests__/link-picker.test.tsx
+++ b/resources/js/visual-editor/site-editor/navigation/__tests__/link-picker.test.tsx
@@ -71,6 +71,8 @@ describe('LinkPicker', () => {
             type: 'custom',
             targetId: null,
             url: null,
+            sourceKind: null,
+            sourceType: null,
         });
     });
 
@@ -115,6 +117,8 @@ describe('LinkPicker', () => {
                 targetId: 7,
                 autoLabel: 'About',
                 url: '/about',
+                sourceKind: null,
+                sourceType: null,
             })
         );
     });

--- a/resources/js/visual-editor/site-editor/navigation/__tests__/link-picker.test.tsx
+++ b/resources/js/visual-editor/site-editor/navigation/__tests__/link-picker.test.tsx
@@ -1,0 +1,121 @@
+/**
+ * Link-control picker tests.
+ *
+ * Covers the type switch (page/post/custom), debounced search, and
+ * the "select a result" path. The custom-URL branch is exercised
+ * separately so the search code-path is never reached for `custom`.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import { LinkPicker } from '../link-picker';
+import { makeMenuItem } from '../menu-tree';
+import type { MenuItem } from '../menu-tree';
+import type { SiteEditorApiConfig } from '../../api-client';
+
+const API: SiteEditorApiConfig = { apiBase: '/visual-editor/api' };
+
+beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+});
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+});
+
+function jsonResponse(body: unknown, status = 200): Response {
+    return new Response(JSON.stringify(body), {
+        status,
+        headers: { 'Content-Type': 'application/json' },
+    });
+}
+
+function renderPicker(item: MenuItem) {
+    const onChange = vi.fn();
+
+    const utils = render(
+        <LinkPicker apiConfig={API} item={item} onChange={onChange} />
+    );
+
+    return { ...utils, onChange };
+}
+
+describe('LinkPicker', () => {
+    it('shows a URL field when the type is custom', () => {
+        renderPicker(makeMenuItem({ type: 'custom', url: '/contact' }));
+
+        expect(screen.getByTestId('ap-nav-link-picker-url')).toBeInTheDocument();
+        expect(
+            screen.queryByTestId('ap-nav-link-picker-query')
+        ).not.toBeInTheDocument();
+    });
+
+    it('clears targetId when the user switches type away from a typed reference', () => {
+        const fetchMock = vi.fn(
+            async () => jsonResponse({ data: [] })
+        );
+        vi.stubGlobal('fetch', fetchMock);
+
+        const { onChange } = renderPicker(
+            makeMenuItem({ type: 'page', targetId: 12 })
+        );
+
+        fireEvent.change(screen.getByTestId('ap-nav-link-picker-type'), {
+            target: { value: 'custom' },
+        });
+
+        expect(onChange).toHaveBeenCalledWith({
+            type: 'custom',
+            targetId: null,
+            url: null,
+        });
+    });
+
+    it('debounces a search and renders results', async () => {
+        const fetchMock = vi.fn(async () =>
+            jsonResponse({
+                data: [
+                    {
+                        type: 'page',
+                        id: 7,
+                        title: 'About',
+                        url: '/about',
+                    },
+                ],
+            })
+        );
+        vi.stubGlobal('fetch', fetchMock);
+
+        const { onChange } = renderPicker(
+            makeMenuItem({ type: 'page', targetId: null })
+        );
+
+        fireEvent.change(screen.getByTestId('ap-nav-link-picker-query'), {
+            target: { value: 'abo' },
+        });
+
+        // Pre-debounce, no fetch yet.
+        expect(fetchMock).not.toHaveBeenCalled();
+
+        await vi.advanceTimersByTimeAsync(260);
+
+        await waitFor(() =>
+            expect(
+                screen.getByTestId('ap-nav-link-picker-result-7')
+            ).toBeInTheDocument()
+        );
+
+        fireEvent.click(screen.getByTestId('ap-nav-link-picker-result-7'));
+
+        expect(onChange).toHaveBeenCalledWith(
+            expect.objectContaining({
+                targetId: 7,
+                autoLabel: 'About',
+                url: '/about',
+            })
+        );
+    });
+});

--- a/resources/js/visual-editor/site-editor/navigation/__tests__/menu-tree.test.ts
+++ b/resources/js/visual-editor/site-editor/navigation/__tests__/menu-tree.test.ts
@@ -1,0 +1,502 @@
+/**
+ * Menu-tree round-trip + mutation helpers.
+ *
+ * The bridge between the persisted Gutenberg block tree and the
+ * in-memory MenuItem tree is the load-bearing piece of D4: it has to
+ * round-trip without losing data, and the helper mutators need to be
+ * pure so React state stays stable.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+    appendChild,
+    blocksToMenuTree,
+    buildTreeFromFlat,
+    commitProjection,
+    effectiveLabel,
+    findMenuItem,
+    flattenTree,
+    getDescendantIds,
+    makeMenuItem,
+    menuTreeToBlocks,
+    projectDrop,
+    removeMenuItem,
+    reorderTopLevel,
+    replaceMenuItem,
+    type MenuItem,
+} from '../menu-tree';
+
+describe('blocksToMenuTree', () => {
+    it('converts a navigation-link block into a typed page reference', () => {
+        const blocks = [
+            {
+                name: 'core/navigation-link',
+                attributes: {
+                    kind: 'post-type',
+                    type: 'page',
+                    id: 12,
+                    label: 'About',
+                    url: 'https://example.com/about',
+                    opensInNewTab: false,
+                },
+                innerBlocks: [],
+            },
+        ];
+
+        const tree = blocksToMenuTree(blocks);
+
+        expect(tree).toHaveLength(1);
+        expect(tree[0]).toMatchObject({
+            type: 'page',
+            targetId: 12,
+            url: 'https://example.com/about',
+            autoLabel: 'About',
+            children: [],
+        });
+    });
+
+    it('treats a bare URL block as the custom type', () => {
+        const blocks = [
+            {
+                name: 'core/navigation-link',
+                attributes: {
+                    label: 'Docs',
+                    url: 'https://docs.example.com',
+                },
+                innerBlocks: [],
+            },
+        ];
+
+        const tree = blocksToMenuTree(blocks);
+
+        expect(tree[0].type).toBe('custom');
+        expect(tree[0].targetId).toBeNull();
+        expect(tree[0].url).toBe('https://docs.example.com');
+    });
+
+    it('walks navigation-submenu inner blocks recursively', () => {
+        const blocks = [
+            {
+                name: 'core/navigation-submenu',
+                attributes: { label: 'Products', kind: 'custom' },
+                innerBlocks: [
+                    {
+                        name: 'core/navigation-link',
+                        attributes: { label: 'Pro', url: '/pro' },
+                        innerBlocks: [],
+                    },
+                ],
+            },
+        ];
+
+        const tree = blocksToMenuTree(blocks);
+
+        expect(tree[0].autoLabel).toBe('Products');
+        expect(tree[0].children).toHaveLength(1);
+        expect(tree[0].children[0].url).toBe('/pro');
+    });
+
+    it('drops blocks whose name is not a navigation block', () => {
+        const tree = blocksToMenuTree([
+            { name: 'core/paragraph', attributes: {}, innerBlocks: [] },
+            {
+                name: 'core/navigation-link',
+                attributes: { label: 'Home', url: '/' },
+                innerBlocks: [],
+            },
+        ]);
+
+        expect(tree).toHaveLength(1);
+        expect(tree[0].url).toBe('/');
+    });
+});
+
+describe('menuTreeToBlocks', () => {
+    it('serializes a leaf as a navigation-link block', () => {
+        const tree: MenuItem[] = [
+            makeMenuItem({
+                type: 'page',
+                targetId: 7,
+                autoLabel: 'About',
+                url: '/about',
+            }),
+        ];
+
+        const blocks = menuTreeToBlocks(tree) as Array<{
+            name: string;
+            attributes: Record<string, unknown>;
+        }>;
+
+        expect(blocks).toHaveLength(1);
+        expect(blocks[0].name).toBe('core/navigation-link');
+        expect(blocks[0].attributes).toMatchObject({
+            kind: 'post-type',
+            type: 'page',
+            id: 7,
+            label: 'About',
+            url: '/about',
+        });
+    });
+
+    it('serializes parents with children as navigation-submenu blocks', () => {
+        const tree: MenuItem[] = [
+            makeMenuItem({
+                type: 'custom',
+                autoLabel: 'Products',
+                children: [
+                    makeMenuItem({
+                        type: 'custom',
+                        autoLabel: 'Pro',
+                        url: '/pro',
+                    }),
+                ],
+            }),
+        ];
+
+        const blocks = menuTreeToBlocks(tree) as Array<{
+            name: string;
+            innerBlocks: unknown[];
+        }>;
+
+        expect(blocks[0].name).toBe('core/navigation-submenu');
+        expect(blocks[0].innerBlocks).toHaveLength(1);
+    });
+
+    it('round-trips a full tree without losing data', () => {
+        const original: MenuItem[] = [
+            makeMenuItem({
+                type: 'page',
+                targetId: 1,
+                autoLabel: 'Home',
+                url: '/',
+            }),
+            makeMenuItem({
+                type: 'custom',
+                autoLabel: 'Products',
+                children: [
+                    makeMenuItem({
+                        type: 'post',
+                        targetId: 5,
+                        autoLabel: 'Pro',
+                        url: '/pro',
+                    }),
+                ],
+            }),
+        ];
+
+        const blocks = menuTreeToBlocks(original);
+        const reparsed = blocksToMenuTree(blocks);
+
+        // Local IDs are unstable across regenerations — strip them
+        // before comparing.
+        const stripIds = (items: MenuItem[]): unknown[] =>
+            items.map(({ localId, children, ...rest }) => {
+                void localId;
+                return { ...rest, children: stripIds(children) };
+            });
+
+        expect(stripIds(reparsed)).toEqual(stripIds(original));
+    });
+});
+
+describe('mutations', () => {
+    it('replaceMenuItem updates a nested item without touching siblings', () => {
+        const child = makeMenuItem({ autoLabel: 'Child', url: '/child' });
+        const tree = [
+            makeMenuItem({
+                autoLabel: 'Parent',
+                children: [child],
+            }),
+            makeMenuItem({ autoLabel: 'Sibling' }),
+        ];
+
+        const next = replaceMenuItem(tree, child.localId, (item) => ({
+            ...item,
+            url: '/changed',
+        }));
+
+        expect(next[0].children[0].url).toBe('/changed');
+        expect(next[1].autoLabel).toBe('Sibling');
+        expect(next).not.toBe(tree);
+    });
+
+    it('removeMenuItem prunes a deeply-nested node', () => {
+        const grand = makeMenuItem({ autoLabel: 'Grand' });
+        const child = makeMenuItem({ autoLabel: 'Child', children: [grand] });
+        const tree = [
+            makeMenuItem({ autoLabel: 'Parent', children: [child] }),
+        ];
+
+        const next = removeMenuItem(tree, grand.localId);
+
+        expect(next[0].children[0].children).toHaveLength(0);
+    });
+
+    it('appendChild adds a fresh node under the right parent', () => {
+        const fresh = makeMenuItem({ autoLabel: 'New' });
+        const parent = makeMenuItem({ autoLabel: 'Parent' });
+        const tree = [parent];
+
+        const next = appendChild(tree, parent.localId, fresh);
+
+        expect(next[0].children).toHaveLength(1);
+        expect(next[0].children[0].autoLabel).toBe('New');
+    });
+
+    it('reorderTopLevel swaps two items', () => {
+        const a = makeMenuItem({ autoLabel: 'A' });
+        const b = makeMenuItem({ autoLabel: 'B' });
+        const c = makeMenuItem({ autoLabel: 'C' });
+
+        const next = reorderTopLevel([a, b, c], 0, 2);
+
+        expect(next.map((item) => item.autoLabel)).toEqual(['B', 'C', 'A']);
+    });
+
+    it('findMenuItem locates a deeply-nested node', () => {
+        const grand = makeMenuItem({ autoLabel: 'Grand' });
+        const child = makeMenuItem({ autoLabel: 'Child', children: [grand] });
+        const tree = [
+            makeMenuItem({ autoLabel: 'Parent', children: [child] }),
+        ];
+
+        const found = findMenuItem(tree, grand.localId);
+
+        expect(found?.autoLabel).toBe('Grand');
+    });
+});
+
+describe('flat-list bridge', () => {
+    function makeTree(): MenuItem[] {
+        return [
+            makeMenuItem({ autoLabel: 'Home' }),
+            makeMenuItem({
+                autoLabel: 'Products',
+                children: [
+                    makeMenuItem({ autoLabel: 'Pro' }),
+                    makeMenuItem({ autoLabel: 'Plus' }),
+                ],
+            }),
+            makeMenuItem({ autoLabel: 'About' }),
+        ];
+    }
+
+    it('flattenTree emits one row per node with depth + parent metadata', () => {
+        const tree = makeTree();
+        const flat = flattenTree(tree);
+
+        expect(flat).toHaveLength(5);
+        expect(flat.map((entry) => entry.depth)).toEqual([0, 0, 1, 1, 0]);
+        expect(flat[2].parentLocalId).toBe(tree[1].localId);
+        expect(flat[3].parentLocalId).toBe(tree[1].localId);
+        expect(flat[4].parentLocalId).toBeNull();
+    });
+
+    it('buildTreeFromFlat is the inverse of flattenTree', () => {
+        const tree = makeTree();
+        const reparsed = buildTreeFromFlat(flattenTree(tree));
+
+        const stripIds = (items: MenuItem[]): unknown[] =>
+            items.map(({ localId, children, ...rest }) => {
+                void localId;
+                return { ...rest, children: stripIds(children) };
+            });
+
+        expect(stripIds(reparsed)).toEqual(stripIds(tree));
+    });
+
+    it('buildTreeFromFlat handles a child appearing before its parent', () => {
+        const tree = makeTree();
+        const flat = flattenTree(tree);
+
+        // Swap the parent ("Products") with one of its children — the
+        // dnd-kit drag-end path can produce this layout when a single
+        // item array-moves across its own children.
+        const swapped = [...flat];
+        const productsIndex = swapped.findIndex(
+            (entry) => entry.item.autoLabel === 'Products'
+        );
+        const proIndex = swapped.findIndex(
+            (entry) => entry.item.autoLabel === 'Pro'
+        );
+
+        [swapped[productsIndex], swapped[proIndex]] = [
+            swapped[proIndex],
+            swapped[productsIndex],
+        ];
+
+        const rebuilt = buildTreeFromFlat(swapped);
+
+        const productsItem = rebuilt.find(
+            (item) => item.autoLabel === 'Products'
+        );
+
+        expect(productsItem?.children.map((c) => c.autoLabel)).toEqual([
+            'Pro',
+            'Plus',
+        ]);
+    });
+
+    it('getDescendantIds collects every transitive child', () => {
+        const grand = makeMenuItem({ autoLabel: 'Grand' });
+        const child = makeMenuItem({
+            autoLabel: 'Child',
+            children: [grand],
+        });
+        const parent = makeMenuItem({
+            autoLabel: 'Parent',
+            children: [child],
+        });
+
+        const descendants = getDescendantIds(
+            flattenTree([parent]),
+            parent.localId
+        );
+
+        expect(descendants.has(child.localId)).toBe(true);
+        expect(descendants.has(grand.localId)).toBe(true);
+        expect(descendants.has(parent.localId)).toBe(false);
+    });
+
+    it('projectDrop deepens when the drag offset clears one indent step', () => {
+        const tree = [
+            makeMenuItem({ autoLabel: 'A' }),
+            makeMenuItem({ autoLabel: 'B' }),
+        ];
+        const flat = flattenTree(tree);
+
+        const projection = projectDrop(
+            flat,
+            flat[1].item.localId,
+            flat[1].item.localId,
+            // Drag B 30 pixels right with INDENT_PX = 24 → projects to
+            // depth 1 (becomes a child of A).
+            30,
+            24
+        );
+
+        expect(projection?.depth).toBe(1);
+        expect(projection?.parentLocalId).toBe(flat[0].item.localId);
+    });
+
+    it('projectDrop clamps depth to maxDepth (previous sibling depth + 1)', () => {
+        const tree = [
+            makeMenuItem({ autoLabel: 'A' }),
+            makeMenuItem({ autoLabel: 'B' }),
+        ];
+        const flat = flattenTree(tree);
+
+        const projection = projectDrop(
+            flat,
+            flat[1].item.localId,
+            flat[1].item.localId,
+            // Far past the max depth; clamp to depth 1.
+            500,
+            24
+        );
+
+        expect(projection?.depth).toBe(1);
+    });
+
+    it('projectDrop pulls a nested item out to root with a left drag', () => {
+        const child = makeMenuItem({ autoLabel: 'Child' });
+        const parent = makeMenuItem({
+            autoLabel: 'Parent',
+            children: [child],
+        });
+
+        const flat = flattenTree([parent]);
+        const projection = projectDrop(
+            flat,
+            child.localId,
+            child.localId,
+            // 60px left → −2 indent steps → clamps to 0 (root).
+            -60,
+            24
+        );
+
+        expect(projection?.depth).toBe(0);
+        expect(projection?.parentLocalId).toBeNull();
+    });
+
+    it('commitProjection moves the active row and updates its depth + parent', () => {
+        const tree = [
+            makeMenuItem({ autoLabel: 'A' }),
+            makeMenuItem({ autoLabel: 'B' }),
+            makeMenuItem({ autoLabel: 'C' }),
+        ];
+        const flat = flattenTree(tree);
+        const projection = {
+            depth: 1,
+            maxDepth: 1,
+            minDepth: 0,
+            parentLocalId: flat[0].item.localId,
+        };
+
+        const updated = commitProjection(
+            flat,
+            flat[2].item.localId,
+            flat[1].item.localId,
+            projection
+        );
+
+        // C moves to index 1, becomes child of A.
+        expect(updated[1].item.localId).toBe(flat[2].item.localId);
+        expect(updated[1].depth).toBe(1);
+        expect(updated[1].parentLocalId).toBe(flat[0].item.localId);
+    });
+
+    it('round-trip: drag a child out to root rebuilds correctly', () => {
+        const child = makeMenuItem({ autoLabel: 'Child' });
+        const parent = makeMenuItem({
+            autoLabel: 'Parent',
+            children: [child],
+        });
+        const sibling = makeMenuItem({ autoLabel: 'Sibling' });
+
+        const flat = flattenTree([parent, sibling]);
+        const projection = {
+            depth: 0,
+            maxDepth: 0,
+            minDepth: 0,
+            parentLocalId: null,
+        };
+
+        // Move "Child" past "Sibling" at depth 0.
+        const updated = commitProjection(
+            flat,
+            child.localId,
+            sibling.localId,
+            projection
+        );
+        const rebuilt = buildTreeFromFlat(updated);
+
+        expect(rebuilt.map((item) => item.autoLabel)).toContain('Child');
+        const rebuiltParent = rebuilt.find(
+            (item) => item.autoLabel === 'Parent'
+        );
+        expect(rebuiltParent?.children).toHaveLength(0);
+    });
+});
+
+describe('effectiveLabel', () => {
+    it('prefers the override over the auto label', () => {
+        const item = makeMenuItem({
+            autoLabel: 'Auto',
+            labelOverride: 'Explicit',
+        });
+
+        expect(effectiveLabel(item)).toBe('Explicit');
+    });
+
+    it('falls back to URL when both labels are empty', () => {
+        const item = makeMenuItem({
+            autoLabel: '',
+            labelOverride: null,
+            url: '/contact',
+        });
+
+        expect(effectiveLabel(item)).toBe('/contact');
+    });
+});

--- a/resources/js/visual-editor/site-editor/navigation/__tests__/menu-tree.test.ts
+++ b/resources/js/visual-editor/site-editor/navigation/__tests__/menu-tree.test.ts
@@ -75,6 +75,38 @@ describe('blocksToMenuTree', () => {
         expect(tree[0].url).toBe('https://docs.example.com');
     });
 
+    it('preserves the source kind / type for non-IA wire shapes', () => {
+        const tree = blocksToMenuTree([
+            {
+                name: 'core/navigation-link',
+                attributes: {
+                    kind: 'post-type',
+                    type: 'book',
+                    id: 42,
+                    label: 'Catalog',
+                    url: '/books/42',
+                },
+                innerBlocks: [],
+            },
+        ]);
+
+        // The IA collapses non-{page,post,taxonomy} post types to
+        // 'custom' for the editor UI, but `sourceKind` / `sourceType`
+        // capture the wire-shape so the save path can re-emit it.
+        expect(tree[0].type).toBe('custom');
+        expect(tree[0].sourceKind).toBe('post-type');
+        expect(tree[0].sourceType).toBe('book');
+
+        const blocks = menuTreeToBlocks(tree) as Array<{
+            name: string;
+            attributes: Record<string, unknown>;
+        }>;
+
+        expect(blocks[0].attributes.kind).toBe('post-type');
+        expect(blocks[0].attributes.type).toBe('book');
+        expect(blocks[0].attributes.id).toBe(42);
+    });
+
     it('walks navigation-submenu inner blocks recursively', () => {
         const blocks = [
             {

--- a/resources/js/visual-editor/site-editor/navigation/__tests__/navigation-canvas.test.tsx
+++ b/resources/js/visual-editor/site-editor/navigation/__tests__/navigation-canvas.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * Navigation canvas (native tree editor) UI tests.
+ *
+ * The drag-sort behavior itself isn't unit-testable in jsdom (dnd-kit
+ * relies on real pointer events), so these tests cover the rest:
+ * empty state, add/select/delete, nested rows, and the
+ * confirm-delete two-step.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { NavigationCanvas } from '../navigation-canvas';
+import { makeMenuItem, type MenuItem } from '../menu-tree';
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+function renderCanvas(initial: MenuItem[]) {
+    let tree = initial;
+    let selected: string | null = null;
+    const onSelect = vi.fn((id: string | null) => {
+        selected = id;
+    });
+    const onTreeChange = vi.fn((next: readonly MenuItem[]) => {
+        tree = [...next];
+    });
+
+    const utils = render(
+        <NavigationCanvas
+            tree={tree}
+            selectedItemId={selected}
+            onSelectItem={onSelect}
+            onTreeChange={onTreeChange}
+        />
+    );
+
+    return { ...utils, onSelect, onTreeChange };
+}
+
+describe('NavigationCanvas', () => {
+    it('renders the empty state when the tree is empty', () => {
+        renderCanvas([]);
+
+        expect(
+            screen.getByTestId('ap-nav-canvas')
+        ).toHaveAttribute('data-empty', 'true');
+        expect(screen.getByTestId('ap-nav-canvas-add')).toBeInTheDocument();
+    });
+
+    it('emits an onTreeChange call when the user adds an item from empty', () => {
+        const { onTreeChange } = renderCanvas([]);
+
+        fireEvent.click(screen.getByTestId('ap-nav-canvas-add'));
+
+        expect(onTreeChange).toHaveBeenCalledOnce();
+        const next = onTreeChange.mock.calls[0]?.[0] as readonly MenuItem[];
+        expect(next).toHaveLength(1);
+        expect(next[0].type).toBe('custom');
+    });
+
+    it('selects an item when its row is clicked', () => {
+        const item = makeMenuItem({ autoLabel: 'Home', url: '/' });
+        const { onSelect } = renderCanvas([item]);
+
+        fireEvent.click(
+            screen.getByTestId(`ap-nav-canvas-row-${item.localId}`)
+        );
+
+        expect(onSelect).toHaveBeenCalledWith(item.localId);
+    });
+
+    it('requires a confirm click before deleting', () => {
+        const item = makeMenuItem({ autoLabel: 'Home', url: '/' });
+        const { onTreeChange } = renderCanvas([item]);
+
+        const deleteButton = screen.getByTestId(
+            `ap-nav-canvas-delete-${item.localId}`
+        );
+
+        fireEvent.click(deleteButton);
+        expect(onTreeChange).not.toHaveBeenCalled();
+        expect(deleteButton).toHaveAttribute('data-confirming', 'true');
+
+        fireEvent.click(deleteButton);
+        expect(onTreeChange).toHaveBeenCalledOnce();
+    });
+
+    it('appends a child when "Add child" is clicked', () => {
+        const parent = makeMenuItem({ autoLabel: 'Parent' });
+        const { onTreeChange } = renderCanvas([parent]);
+
+        fireEvent.click(
+            screen.getByTestId(`ap-nav-canvas-add-child-${parent.localId}`)
+        );
+
+        const next = onTreeChange.mock.calls[0]?.[0] as readonly MenuItem[];
+        expect(next[0].children).toHaveLength(1);
+    });
+
+    it('renders nested children under their parent row', () => {
+        const child = makeMenuItem({ autoLabel: 'Child' });
+        const parent = makeMenuItem({
+            autoLabel: 'Parent',
+            children: [child],
+        });
+
+        renderCanvas([parent]);
+
+        expect(
+            screen.getByTestId(`ap-nav-canvas-item-${child.localId}`)
+        ).toBeInTheDocument();
+    });
+});

--- a/resources/js/visual-editor/site-editor/navigation/__tests__/navigation-section.test.tsx
+++ b/resources/js/visual-editor/site-editor/navigation/__tests__/navigation-section.test.tsx
@@ -1,0 +1,287 @@
+/**
+ * Navigation section orchestrator integration tests.
+ *
+ * Covers the headline acceptance criteria:
+ *   - Section lists menus from C4's index endpoint.
+ *   - Opening a menu loads it into the canvas.
+ *   - Save dispatches a PUT.
+ *   - Locations panel renders + assignment writes.
+ *   - Create-new flow creates and opens the new menu.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+    act,
+    fireEvent,
+    render,
+    screen,
+    waitFor,
+} from '@testing-library/react';
+import { useEffect, useRef, useState } from 'react';
+
+import type { SiteEditorApiConfig } from '../../api-client';
+import type { EntityEditorState } from '../../entity-editor';
+import { useNavigationSectionViews } from '../navigation-section';
+
+const API: SiteEditorApiConfig = { apiBase: '/visual-editor/api' };
+
+interface PendingResponse {
+    body: unknown;
+    status?: number;
+}
+
+interface HarnessProps {
+    activeEntityId: string | null;
+    onOpenEntity: (id: string) => void;
+    onState: (state: EntityEditorState) => void;
+    saveButtonLabel?: string;
+}
+
+function Harness(props: HarnessProps): JSX.Element {
+    const { activeEntityId, onOpenEntity, onState } = props;
+    const views = useNavigationSectionViews({
+        apiConfig: API,
+        enabled: true,
+        activeEntityId,
+        onOpenEntity,
+        onStateChange: onState,
+    });
+
+    return (
+        <div>
+            <div data-testid="harness-navigator">{views.navigator}</div>
+            <div data-testid="harness-canvas">{views.canvas}</div>
+            <div data-testid="harness-inspector">{views.inspector}</div>
+            <div data-testid="harness-overlay">{views.overlay}</div>
+        </div>
+    );
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+    return new Response(JSON.stringify(body), {
+        status,
+        headers: { 'Content-Type': 'application/json' },
+    });
+}
+
+interface FetchRoute {
+    matcher: RegExp;
+    method: string;
+    response: PendingResponse | (() => PendingResponse);
+}
+
+function installFetch(routes: FetchRoute[]): ReturnType<typeof vi.fn> {
+    const fn = vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => {
+        const method = (init?.method ?? 'GET').toUpperCase();
+        const href = url.toString();
+
+        for (const route of routes) {
+            if (route.method === method && route.matcher.test(href)) {
+                const out =
+                    typeof route.response === 'function'
+                        ? route.response()
+                        : route.response;
+                return jsonResponse(out.body, out.status ?? 200);
+            }
+        }
+
+        return jsonResponse({ message: `unmatched ${method} ${href}` }, 404);
+    });
+
+    vi.stubGlobal('fetch', fn);
+    return fn;
+}
+
+beforeEach(() => {
+    document.querySelectorAll('meta[name="csrf-token"]').forEach((node) =>
+        node.remove()
+    );
+});
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+});
+
+const baseLocations: PendingResponse = {
+    body: {
+        data: [
+            {
+                slug: 'primary',
+                label: 'Primary Menu',
+                menu: { id: 1, slug: 'main', title: 'Main' },
+                is_fallback: false,
+            },
+        ],
+    },
+};
+
+const baseList: PendingResponse = {
+    body: {
+        data: [
+            {
+                id: 1,
+                slug: 'main',
+                title: { rendered: 'Main' },
+                content: { raw: '', blocks: [] },
+                status: 'publish',
+                menu_order: 0,
+                location: 'primary',
+                type: 'wp_navigation',
+            },
+        ],
+        meta: {
+            current_page: 1,
+            last_page: 1,
+            per_page: 50,
+            total: 1,
+        },
+    },
+};
+
+describe('navigation-section list + open', () => {
+    it('lists menus from the C4 index endpoint and opens one on click', async () => {
+        const onOpen = vi.fn();
+        const onState = vi.fn();
+
+        installFetch([
+            {
+                matcher: /\/menu-locations$/,
+                method: 'GET',
+                response: baseLocations,
+            },
+            {
+                matcher: /\/navigation\?per_page=50/,
+                method: 'GET',
+                response: baseList,
+            },
+        ]);
+
+        render(
+            <Harness
+                activeEntityId={null}
+                onOpenEntity={onOpen}
+                onState={onState}
+            />
+        );
+
+        await waitFor(() =>
+            expect(screen.getByTestId('ap-nav-browser-row-1')).toBeInTheDocument()
+        );
+
+        fireEvent.click(screen.getByTestId('ap-nav-browser-row-1'));
+        expect(onOpen).toHaveBeenCalledWith('1');
+    });
+
+    it('renders the locations panel from /menu-locations', async () => {
+        const onOpen = vi.fn();
+        const onState = vi.fn();
+
+        installFetch([
+            {
+                matcher: /\/menu-locations$/,
+                method: 'GET',
+                response: baseLocations,
+            },
+            {
+                matcher: /\/navigation\?per_page=50/,
+                method: 'GET',
+                response: baseList,
+            },
+        ]);
+
+        render(
+            <Harness
+                activeEntityId={null}
+                onOpenEntity={onOpen}
+                onState={onState}
+            />
+        );
+
+        await waitFor(() =>
+            expect(
+                screen.getByTestId('ap-locations-row-primary')
+            ).toBeInTheDocument()
+        );
+    });
+});
+
+describe('navigation-section save pipeline', () => {
+    it('dispatches PUT /navigation/{id} when the entity-state save runs', async () => {
+        const stateRef: { current: EntityEditorState | null } = {
+            current: null,
+        };
+        const onState = (state: EntityEditorState): void => {
+            stateRef.current = state;
+        };
+
+        const fetchMock = installFetch([
+            {
+                matcher: /\/menu-locations$/,
+                method: 'GET',
+                response: baseLocations,
+            },
+            {
+                matcher: /\/navigation\?per_page=50/,
+                method: 'GET',
+                response: baseList,
+            },
+            {
+                matcher: /\/navigation\/1$/,
+                method: 'GET',
+                response: {
+                    body: {
+                        id: 1,
+                        slug: 'main',
+                        title: { rendered: 'Main' },
+                        content: { raw: '', blocks: [] },
+                        status: 'publish',
+                        menu_order: 0,
+                        location: 'primary',
+                        type: 'wp_navigation',
+                    },
+                },
+            },
+            {
+                matcher: /\/navigation\/1$/,
+                method: 'PUT',
+                response: {
+                    body: {
+                        id: 1,
+                        slug: 'main',
+                        title: { rendered: 'Main' },
+                        content: { raw: '', blocks: [] },
+                        status: 'publish',
+                        menu_order: 0,
+                        location: 'primary',
+                        type: 'wp_navigation',
+                    },
+                },
+            },
+        ]);
+
+        render(
+            <Harness
+                activeEntityId="1"
+                onOpenEntity={vi.fn()}
+                onState={onState}
+            />
+        );
+
+        await waitFor(() => expect(stateRef.current?.save).not.toBeNull());
+
+        await act(async () => {
+            await stateRef.current?.save?.();
+        });
+
+        const calls = fetchMock.mock.calls;
+        const putCall = calls.find(
+            ([url, init]) =>
+                typeof url === 'string' &&
+                url.endsWith('/navigation/1') &&
+                (init as RequestInit | undefined)?.method === 'PUT'
+        );
+
+        expect(putCall).toBeDefined();
+    });
+});

--- a/resources/js/visual-editor/site-editor/navigation/api-client.ts
+++ b/resources/js/visual-editor/site-editor/navigation/api-client.ts
@@ -331,10 +331,35 @@ function isMenuLocation(value: unknown): value is MenuLocation {
 
     const row = value as Record<string, unknown>;
 
+    if (
+        typeof row.slug !== 'string' ||
+        typeof row.label !== 'string' ||
+        typeof row.is_fallback !== 'boolean'
+    ) {
+        return false;
+    }
+
+    // `menu` is `null` when nothing is currently resolved for the
+    // location, otherwise the matching record envelope. Reject
+    // anything else (string, number, malformed object) so a stray
+    // payload can't slip past the predicate's narrowing. `undefined`
+    // is allowed too so older API builds that omit the key entirely
+    // still pass — same lenient handling we use for `url` in
+    // `isSearchResult`.
+    if (row.menu === null || row.menu === undefined) {
+        return true;
+    }
+
+    if (typeof row.menu !== 'object') {
+        return false;
+    }
+
+    const menu = row.menu as Record<string, unknown>;
+
     return (
-        typeof row.slug === 'string' &&
-        typeof row.label === 'string' &&
-        typeof row.is_fallback === 'boolean'
+        typeof menu.id === 'number' &&
+        typeof menu.slug === 'string' &&
+        typeof menu.title === 'string'
     );
 }
 
@@ -378,10 +403,21 @@ function isSearchResult(value: unknown): value is SearchResult {
 
     const row = value as Record<string, unknown>;
 
+    if (
+        typeof row.type !== 'string' ||
+        (typeof row.id !== 'number' && typeof row.id !== 'string') ||
+        typeof row.title !== 'string'
+    ) {
+        return false;
+    }
+
+    // `url` is `string | null` per `SearchResult` — anything else is
+    // a malformed payload. Allow `undefined` too so older API
+    // builds that omit the key entirely still pass.
     return (
-        typeof row.type === 'string' &&
-        (typeof row.id === 'number' || typeof row.id === 'string') &&
-        typeof row.title === 'string'
+        row.url === null ||
+        row.url === undefined ||
+        typeof row.url === 'string'
     );
 }
 

--- a/resources/js/visual-editor/site-editor/navigation/api-client.ts
+++ b/resources/js/visual-editor/site-editor/navigation/api-client.ts
@@ -1,0 +1,388 @@
+/**
+ * Navigation REST client.
+ *
+ * Wraps the C4 `wp_navigation` surface and the D4-only menu-locations /
+ * entity-search endpoints. Kept separate from the templates / parts
+ * client (`../api-client.ts`) because the response shapes are different
+ * — navigation rows carry a `location` field, the locations endpoint
+ * returns its own `{ data: [{ slug, label, menu, is_fallback }] }`
+ * envelope, and search rows are unrelated to the C1/C2 entity types.
+ *
+ * Reuses the same CSRF + error-normalization conventions as the parent
+ * client so a host app's middleware setup applies uniformly.
+ */
+
+import {
+    SiteEditorApiError,
+    type SiteEditorApiConfig,
+    type ValidationErrors,
+} from '../api-client';
+
+export interface NavigationRecord {
+    id: number;
+    slug: string;
+    title: { rendered: string };
+    content: { raw: string; blocks: readonly unknown[] };
+    status: string;
+    menu_order: number;
+    /** `null` means no UI-driven location assignment. */
+    location: string | null;
+    type: 'wp_navigation';
+}
+
+export interface NavigationListMeta {
+    current_page: number;
+    last_page: number;
+    per_page: number;
+    total: number;
+}
+
+export interface NavigationListResponse {
+    data: readonly NavigationRecord[];
+    meta: NavigationListMeta;
+}
+
+export interface MenuLocation {
+    slug: string;
+    label: string;
+    /**
+     * The menu currently resolved for this slot. `null` when nothing is
+     * configured AND no published menus exist to fall back to.
+     */
+    menu: { id: number; slug: string; title: string } | null;
+    /**
+     * `true` when the resolved menu is a config / published-fallback —
+     * not a direct DB assignment from the editor. The locations panel
+     * uses this to render the "falling back to X" hint.
+     */
+    is_fallback: boolean;
+}
+
+export interface SearchResult {
+    type: string;
+    id: number | string;
+    title: string;
+    url: string | null;
+}
+
+interface NavigationCreatePayload {
+    slug: string;
+    title?: string;
+    status?: string;
+    menu_order?: number;
+    content?: { raw: string; blocks: readonly unknown[] };
+    location?: string | null;
+}
+
+export interface NavigationUpdatePayload {
+    slug?: string;
+    title?: string;
+    status?: string;
+    menu_order?: number;
+    content?: { raw: string; blocks: readonly unknown[] };
+    location?: string | null;
+}
+
+const READ_HEADERS: Readonly<Record<string, string>> = {
+    Accept: 'application/json',
+    'X-Requested-With': 'XMLHttpRequest',
+};
+
+function readCsrfToken(): string | null {
+    if (typeof document === 'undefined') {
+        return null;
+    }
+
+    const meta = document.querySelector<HTMLMetaElement>(
+        'meta[name="csrf-token"]'
+    );
+
+    return meta?.content?.trim() || null;
+}
+
+function mutatingHeaders(): Record<string, string> {
+    const headers: Record<string, string> = {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        'X-Requested-With': 'XMLHttpRequest',
+    };
+
+    const csrf = readCsrfToken();
+
+    if (csrf !== null) {
+        headers['X-CSRF-TOKEN'] = csrf;
+    }
+
+    return headers;
+}
+
+async function parseBody(response: Response): Promise<unknown> {
+    const text = await response.text();
+
+    if (text === '') {
+        return null;
+    }
+
+    try {
+        return JSON.parse(text);
+    } catch {
+        return text;
+    }
+}
+
+function extractValidationErrors(body: unknown): ValidationErrors | null {
+    if (
+        body === null ||
+        typeof body !== 'object' ||
+        !('errors' in body) ||
+        typeof (body as { errors: unknown }).errors !== 'object' ||
+        (body as { errors: unknown }).errors === null
+    ) {
+        return null;
+    }
+
+    const raw = (body as { errors: Record<string, unknown> }).errors;
+    const result: ValidationErrors = {};
+
+    for (const [field, value] of Object.entries(raw)) {
+        if (Array.isArray(value)) {
+            result[field] = value.filter(
+                (entry): entry is string => typeof entry === 'string'
+            );
+        }
+    }
+
+    return result;
+}
+
+async function requireOk(response: Response): Promise<unknown> {
+    const body = await parseBody(response);
+
+    if (!response.ok) {
+        const baseMessage = `Navigation request failed with status ${response.status}`;
+        const message =
+            body !== null &&
+            typeof body === 'object' &&
+            'message' in body &&
+            typeof (body as { message: unknown }).message === 'string'
+                ? (body as { message: string }).message || baseMessage
+                : baseMessage;
+
+        throw new SiteEditorApiError(message, response.status, body);
+    }
+
+    return body;
+}
+
+function normalizeError(
+    error: unknown,
+    fallbackMessage: string
+): SiteEditorApiError {
+    if (error instanceof SiteEditorApiError) {
+        return error;
+    }
+
+    const message =
+        error instanceof Error && error.message
+            ? error.message
+            : fallbackMessage;
+
+    return new SiteEditorApiError(message, 0, error);
+}
+
+function navigationUrl(
+    config: SiteEditorApiConfig,
+    suffix: string | number | null,
+    query: Record<string, string | number | undefined> = {}
+): string {
+    const base = config.apiBase.replace(/\/+$/, '');
+    let url = `${base}/navigation`;
+
+    if (suffix !== null) {
+        url += `/${encodeURIComponent(String(suffix))}`;
+    }
+
+    const params = new URLSearchParams();
+
+    for (const [key, value] of Object.entries(query)) {
+        if (value === undefined || value === '') {
+            continue;
+        }
+
+        params.set(key, String(value));
+    }
+
+    const qs = params.toString();
+
+    return qs === '' ? url : `${url}?${qs}`;
+}
+
+export interface ListNavigationParams {
+    perPage?: number;
+    page?: number;
+    status?: string;
+}
+
+export async function listNavigations(
+    config: SiteEditorApiConfig,
+    params: ListNavigationParams = {}
+): Promise<NavigationListResponse> {
+    try {
+        const response = await fetch(
+            navigationUrl(config, null, {
+                per_page: params.perPage,
+                page: params.page,
+                status: params.status,
+            }),
+            {
+                method: 'GET',
+                credentials: 'same-origin',
+                headers: READ_HEADERS,
+            }
+        );
+
+        return (await requireOk(response)) as NavigationListResponse;
+    } catch (error: unknown) {
+        throw normalizeError(error, 'Failed to load navigation list.');
+    }
+}
+
+export async function fetchNavigation(
+    config: SiteEditorApiConfig,
+    id: number | string
+): Promise<NavigationRecord> {
+    try {
+        const response = await fetch(navigationUrl(config, id), {
+            method: 'GET',
+            credentials: 'same-origin',
+            headers: READ_HEADERS,
+        });
+
+        return (await requireOk(response)) as NavigationRecord;
+    } catch (error: unknown) {
+        throw normalizeError(error, 'Failed to load navigation.');
+    }
+}
+
+export async function createNavigation(
+    config: SiteEditorApiConfig,
+    payload: NavigationCreatePayload
+): Promise<NavigationRecord> {
+    try {
+        const response = await fetch(navigationUrl(config, null), {
+            method: 'POST',
+            credentials: 'same-origin',
+            headers: mutatingHeaders(),
+            body: JSON.stringify(payload),
+        });
+
+        return (await requireOk(response)) as NavigationRecord;
+    } catch (error: unknown) {
+        throw normalizeError(error, 'Failed to create navigation.');
+    }
+}
+
+export async function updateNavigation(
+    config: SiteEditorApiConfig,
+    id: number | string,
+    payload: NavigationUpdatePayload
+): Promise<NavigationRecord> {
+    try {
+        const response = await fetch(navigationUrl(config, id), {
+            method: 'PUT',
+            credentials: 'same-origin',
+            headers: mutatingHeaders(),
+            body: JSON.stringify(payload),
+        });
+
+        return (await requireOk(response)) as NavigationRecord;
+    } catch (error: unknown) {
+        throw normalizeError(error, 'Failed to save navigation.');
+    }
+}
+
+export async function fetchMenuLocations(
+    config: SiteEditorApiConfig
+): Promise<readonly MenuLocation[]> {
+    try {
+        const base = config.apiBase.replace(/\/+$/, '');
+        const response = await fetch(`${base}/menu-locations`, {
+            method: 'GET',
+            credentials: 'same-origin',
+            headers: READ_HEADERS,
+        });
+
+        const body = (await requireOk(response)) as { data?: unknown };
+
+        if (!Array.isArray(body.data)) {
+            return [];
+        }
+
+        return body.data.filter(isMenuLocation);
+    } catch (error: unknown) {
+        throw normalizeError(error, 'Failed to load menu locations.');
+    }
+}
+
+function isMenuLocation(value: unknown): value is MenuLocation {
+    if (value === null || typeof value !== 'object') {
+        return false;
+    }
+
+    const row = value as Record<string, unknown>;
+
+    return (
+        typeof row.slug === 'string' &&
+        typeof row.label === 'string' &&
+        typeof row.is_fallback === 'boolean'
+    );
+}
+
+export interface SearchEntitiesParams {
+    type: string;
+    q: string;
+}
+
+export async function searchEntities(
+    config: SiteEditorApiConfig,
+    params: SearchEntitiesParams
+): Promise<readonly SearchResult[]> {
+    try {
+        const base = config.apiBase.replace(/\/+$/, '');
+        const search = new URLSearchParams({
+            type: params.type,
+            q: params.q,
+        });
+        const response = await fetch(`${base}/search?${search.toString()}`, {
+            method: 'GET',
+            credentials: 'same-origin',
+            headers: READ_HEADERS,
+        });
+
+        const body = (await requireOk(response)) as { data?: unknown };
+
+        if (!Array.isArray(body.data)) {
+            return [];
+        }
+
+        return body.data.filter(isSearchResult);
+    } catch (error: unknown) {
+        throw normalizeError(error, 'Failed to search entities.');
+    }
+}
+
+function isSearchResult(value: unknown): value is SearchResult {
+    if (value === null || typeof value !== 'object') {
+        return false;
+    }
+
+    const row = value as Record<string, unknown>;
+
+    return (
+        typeof row.type === 'string' &&
+        (typeof row.id === 'number' || typeof row.id === 'string') &&
+        typeof row.title === 'string'
+    );
+}
+
+export { extractValidationErrors };

--- a/resources/js/visual-editor/site-editor/navigation/create-menu-dialog.tsx
+++ b/resources/js/visual-editor/site-editor/navigation/create-menu-dialog.tsx
@@ -1,0 +1,309 @@
+/**
+ * "Add new menu" dialog.
+ *
+ * Captures slug + name + (optional) location at create time and
+ * dispatches the C4 store endpoint. Shares the
+ * `.ap-site-editor__dialog-*` chrome with the templates / parts
+ * create dialog so the dialog widgets render identically — only the
+ * inner form is nav-specific.
+ */
+
+import { __ } from '@wordpress/i18n';
+import {
+    useCallback,
+    useEffect,
+    useId,
+    useMemo,
+    useRef,
+    useState,
+    type FormEvent,
+} from 'react';
+
+import { TEXT_DOMAIN } from '../../vendor/i18n';
+import { SiteEditorApiError, type SiteEditorApiConfig } from '../api-client';
+import { normalizeSlugInput } from '../slug';
+import {
+    createNavigation,
+    type MenuLocation,
+    type NavigationRecord,
+} from './api-client';
+import {
+    extractValidationErrors,
+} from './api-client';
+
+export interface CreateMenuDialogProps {
+    apiConfig: SiteEditorApiConfig;
+    locations: readonly MenuLocation[];
+    onClose: () => void;
+    onCreated: (entity: NavigationRecord) => void;
+}
+
+export function CreateMenuDialog(props: CreateMenuDialogProps): JSX.Element {
+    const { apiConfig, locations, onClose, onCreated } = props;
+
+    const slugId = useId();
+    const titleId = useId();
+    const locationId = useId();
+
+    const [slug, setSlug] = useState('');
+    const [title, setTitle] = useState('');
+    const [location, setLocation] = useState<string>('');
+    const [submitting, setSubmitting] = useState(false);
+    const [generalError, setGeneralError] = useState<string | null>(null);
+    const [errors, setErrors] = useState<Record<string, string>>({});
+
+    const titleRef = useRef<HTMLInputElement>(null);
+
+    useEffect(() => {
+        titleRef.current?.focus();
+    }, []);
+
+    const handleClose = useCallback((): void => {
+        if (submitting) {
+            return;
+        }
+
+        onClose();
+    }, [onClose, submitting]);
+
+    useEffect(() => {
+        const handleKey = (event: KeyboardEvent): void => {
+            if (event.key === 'Escape') {
+                handleClose();
+            }
+        };
+
+        window.addEventListener('keydown', handleKey);
+
+        return () => window.removeEventListener('keydown', handleKey);
+    }, [handleClose]);
+
+    const handleSubmit = async (event: FormEvent): Promise<void> => {
+        event.preventDefault();
+
+        const trimmedSlug = slug.trim();
+        const trimmedTitle = title.trim();
+
+        if (trimmedSlug === '') {
+            setErrors({
+                slug: __('Slug is required.', TEXT_DOMAIN),
+            });
+            return;
+        }
+
+        setSubmitting(true);
+        setGeneralError(null);
+        setErrors({});
+
+        try {
+            const created = await createNavigation(apiConfig, {
+                slug: trimmedSlug,
+                title: trimmedTitle,
+                location: location === '' ? null : location,
+                content: { raw: '', blocks: [] },
+            });
+
+            onCreated(created);
+        } catch (error: unknown) {
+            if (error instanceof SiteEditorApiError) {
+                const validation = extractValidationErrors(error.body);
+
+                if (validation !== null) {
+                    const flat: Record<string, string> = {};
+
+                    for (const [field, messages] of Object.entries(validation)) {
+                        const first = messages[0];
+
+                        if (first !== undefined) {
+                            flat[field] = first;
+                        }
+                    }
+
+                    setErrors(flat);
+                } else {
+                    setGeneralError(error.message);
+                }
+            } else if (error instanceof Error) {
+                setGeneralError(error.message);
+            } else {
+                setGeneralError(__('Failed to create menu.', TEXT_DOMAIN));
+            }
+        } finally {
+            setSubmitting(false);
+        }
+    };
+
+    const titleLabel = useMemo(
+        () => __('Menu name', TEXT_DOMAIN),
+        []
+    );
+
+    return (
+        <div
+            className="ap-site-editor__dialog-scrim"
+            data-testid="ap-create-menu-backdrop"
+            onClick={(event) => {
+                if (event.target === event.currentTarget) {
+                    handleClose();
+                }
+            }}
+        >
+            <div
+                className="ap-site-editor__dialog"
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby={titleId}
+            >
+                <header className="ap-site-editor__dialog-header">
+                    <h2 id={titleId} className="ap-site-editor__dialog-title">
+                        {__('Add new menu', TEXT_DOMAIN)}
+                    </h2>
+                    <button
+                        type="button"
+                        className="ap-site-editor__dialog-close"
+                        onClick={handleClose}
+                        aria-label={__('Close', TEXT_DOMAIN)}
+                        data-testid="ap-create-menu-close"
+                    >
+                        {'×'}
+                    </button>
+                </header>
+
+                <form
+                    onSubmit={(event) => void handleSubmit(event)}
+                    className="ap-site-editor__dialog-form"
+                >
+                    <div className="ap-site-editor__dialog-body">
+                        <div className="ap-site-editor__dialog-field">
+                            <label
+                                className="ap-site-editor__dialog-label"
+                                htmlFor={`${titleId}-input`}
+                            >
+                                {titleLabel}
+                            </label>
+                            <input
+                                ref={titleRef}
+                                id={`${titleId}-input`}
+                                type="text"
+                                className="ap-site-editor__dialog-input"
+                                value={title}
+                                onChange={(event) =>
+                                    setTitle(event.target.value)
+                                }
+                                data-testid="ap-create-menu-title"
+                            />
+                            {errors.title !== undefined ? (
+                                <p
+                                    className="ap-site-editor__dialog-field-error"
+                                    role="alert"
+                                >
+                                    {errors.title}
+                                </p>
+                            ) : null}
+                        </div>
+
+                        <div className="ap-site-editor__dialog-field">
+                            <label
+                                className="ap-site-editor__dialog-label"
+                                htmlFor={slugId}
+                            >
+                                {__('Slug', TEXT_DOMAIN)}
+                            </label>
+                            <input
+                                id={slugId}
+                                type="text"
+                                className="ap-site-editor__dialog-input"
+                                value={slug}
+                                onChange={(event) =>
+                                    setSlug(
+                                        normalizeSlugInput(event.target.value)
+                                    )
+                                }
+                                placeholder={__('e.g. primary', TEXT_DOMAIN)}
+                                data-testid="ap-create-menu-slug"
+                            />
+                            {errors.slug !== undefined ? (
+                                <p
+                                    className="ap-site-editor__dialog-field-error"
+                                    role="alert"
+                                >
+                                    {errors.slug}
+                                </p>
+                            ) : null}
+                        </div>
+
+                        <div className="ap-site-editor__dialog-field">
+                            <label
+                                className="ap-site-editor__dialog-label"
+                                htmlFor={locationId}
+                            >
+                                {__('Location (optional)', TEXT_DOMAIN)}
+                            </label>
+                            <select
+                                id={locationId}
+                                className="ap-site-editor__dialog-select"
+                                value={location}
+                                onChange={(event) =>
+                                    setLocation(event.target.value)
+                                }
+                                data-testid="ap-create-menu-location"
+                            >
+                                <option value="">
+                                    {__('— No location —', TEXT_DOMAIN)}
+                                </option>
+                                {locations.map((entry) => (
+                                    <option
+                                        key={entry.slug}
+                                        value={entry.slug}
+                                    >
+                                        {entry.label}
+                                    </option>
+                                ))}
+                            </select>
+                            {errors.location !== undefined ? (
+                                <p
+                                    className="ap-site-editor__dialog-field-error"
+                                    role="alert"
+                                >
+                                    {errors.location}
+                                </p>
+                            ) : null}
+                        </div>
+
+                        {generalError !== null ? (
+                            <p
+                                className="ap-site-editor__dialog-error"
+                                role="alert"
+                                data-testid="ap-create-menu-error"
+                            >
+                                {generalError}
+                            </p>
+                        ) : null}
+                    </div>
+
+                    <footer className="ap-site-editor__dialog-footer">
+                        <button
+                            type="button"
+                            onClick={handleClose}
+                            className="ap-site-editor__dialog-cancel"
+                            disabled={submitting}
+                            data-testid="ap-create-menu-cancel"
+                        >
+                            {__('Cancel', TEXT_DOMAIN)}
+                        </button>
+                        <button
+                            type="submit"
+                            className="ap-site-editor__dialog-submit"
+                            disabled={submitting}
+                            data-testid="ap-create-menu-submit"
+                        >
+                            {submitting
+                                ? __('Creating…', TEXT_DOMAIN)
+                                : __('Create menu', TEXT_DOMAIN)}
+                        </button>
+                    </footer>
+                </form>
+            </div>
+        </div>
+    );
+}

--- a/resources/js/visual-editor/site-editor/navigation/link-picker.tsx
+++ b/resources/js/visual-editor/site-editor/navigation/link-picker.tsx
@@ -1,0 +1,263 @@
+/**
+ * Link-control menu picker.
+ *
+ * Drives the "what does this menu item point to?" UI. The user picks a
+ * type (Page / Post / Custom URL / Taxonomy term) and either searches
+ * the host app's entities (page / post / taxonomy / template) or types
+ * a URL (custom). Powered by the D4-only `/visual-editor/api/search`
+ * endpoint — see EntitySearchController.
+ *
+ * Type list is fixed: V1 supports the four IA types from design brief
+ * §3.8. A host app that registers extra `resources` won't see them in
+ * the picker (intentional — the picker is for menu IA, not arbitrary
+ * data sources). 1.1+ may make the type list extensible.
+ *
+ * Form fields use the shared `.ap-site-editor__dialog-*` classes so
+ * the type select / search field render identically to the templates
+ * inspector.
+ */
+
+import { __ } from '@wordpress/i18n';
+import { useEffect, useId, useMemo, useRef, useState } from 'react';
+
+import { TEXT_DOMAIN } from '../../vendor/i18n';
+
+import type { SiteEditorApiConfig } from '../api-client';
+import { searchEntities, type SearchResult } from './api-client';
+import type { MenuItem, MenuItemType } from './menu-tree';
+
+export interface LinkPickerProps {
+    apiConfig: SiteEditorApiConfig;
+    item: MenuItem;
+    onChange: (patch: Partial<MenuItem>) => void;
+}
+
+interface TypeOption {
+    value: MenuItemType;
+    label: string;
+    /**
+     * `null` = no entity-search step (custom URL takes the URL field
+     * directly). Otherwise the slug we send to /search.
+     */
+    searchType: string | null;
+}
+
+function getTypeOptions(): readonly TypeOption[] {
+    return [
+        { value: 'page', label: __('Page', TEXT_DOMAIN), searchType: 'page' },
+        { value: 'post', label: __('Post', TEXT_DOMAIN), searchType: 'post' },
+        {
+            value: 'taxonomy',
+            label: __('Taxonomy term', TEXT_DOMAIN),
+            searchType: 'taxonomy',
+        },
+        {
+            value: 'custom',
+            label: __('Custom URL', TEXT_DOMAIN),
+            searchType: null,
+        },
+    ];
+}
+
+export function LinkPicker(props: LinkPickerProps): JSX.Element {
+    const { apiConfig, item, onChange } = props;
+    const typeId = useId();
+    const queryId = useId();
+    const urlId = useId();
+
+    const typeOptions = useMemo(() => getTypeOptions(), []);
+    const activeType = typeOptions.find((option) => option.value === item.type);
+
+    const [query, setQuery] = useState('');
+    const [results, setResults] = useState<readonly SearchResult[]>([]);
+    const [isSearching, setIsSearching] = useState(false);
+    const [searchError, setSearchError] = useState<string | null>(null);
+
+    const requestEpoch = useRef(0);
+
+    useEffect(() => {
+        if (activeType === undefined || activeType.searchType === null) {
+            setResults([]);
+            setIsSearching(false);
+            setSearchError(null);
+            return undefined;
+        }
+
+        // Debounce: 250ms is the same cadence the templates `slug`
+        // input uses elsewhere in the editor for "stop typing first".
+        const handle = window.setTimeout(() => {
+            requestEpoch.current += 1;
+            const epoch = requestEpoch.current;
+
+            setIsSearching(true);
+            setSearchError(null);
+
+            (async () => {
+                try {
+                    const data = await searchEntities(apiConfig, {
+                        type: activeType.searchType ?? '',
+                        q: query,
+                    });
+
+                    if (epoch !== requestEpoch.current) {
+                        return;
+                    }
+
+                    setResults(data);
+                } catch (error: unknown) {
+                    if (epoch !== requestEpoch.current) {
+                        return;
+                    }
+
+                    setSearchError(
+                        error instanceof Error
+                            ? error.message
+                            : __('Search failed.', TEXT_DOMAIN)
+                    );
+                    setResults([]);
+                } finally {
+                    if (epoch === requestEpoch.current) {
+                        setIsSearching(false);
+                    }
+                }
+            })();
+        }, 250);
+
+        return () => window.clearTimeout(handle);
+    }, [activeType, apiConfig, query]);
+
+    return (
+        <div
+            className="ap-nav-inspector__link-picker"
+            data-testid="ap-nav-link-picker"
+        >
+            <div className="ap-site-editor__dialog-field">
+                <label
+                    className="ap-site-editor__dialog-label"
+                    htmlFor={typeId}
+                >
+                    {__('Link type', TEXT_DOMAIN)}
+                </label>
+                <select
+                    id={typeId}
+                    className="ap-site-editor__dialog-select"
+                    value={item.type}
+                    onChange={(event) => {
+                        const next = event.target.value as MenuItemType;
+                        // Switching type clears `targetId` + `url` so the
+                        // user can't accidentally save a stale typed
+                        // reference under the wrong wire shape.
+                        onChange({
+                            type: next,
+                            targetId: null,
+                            url: next === 'custom' ? item.url : null,
+                        });
+                    }}
+                    data-testid="ap-nav-link-picker-type"
+                >
+                    {typeOptions.map((option) => (
+                        <option key={option.value} value={option.value}>
+                            {option.label}
+                        </option>
+                    ))}
+                </select>
+            </div>
+
+            {activeType !== undefined && activeType.searchType !== null ? (
+                <>
+                    <div className="ap-site-editor__dialog-field">
+                        <label
+                            className="ap-site-editor__dialog-label"
+                            htmlFor={queryId}
+                        >
+                            {__('Search', TEXT_DOMAIN)}
+                        </label>
+                        <input
+                            id={queryId}
+                            type="search"
+                            className="ap-site-editor__dialog-input"
+                            value={query}
+                            onChange={(event) => setQuery(event.target.value)}
+                            placeholder={__('Type to search…', TEXT_DOMAIN)}
+                            data-testid="ap-nav-link-picker-query"
+                        />
+                    </div>
+
+                    {searchError !== null ? (
+                        <p
+                            className="ap-site-editor__dialog-field-error"
+                            role="alert"
+                        >
+                            {searchError}
+                        </p>
+                    ) : null}
+
+                    <ul
+                        className="ap-nav-inspector__results"
+                        role="listbox"
+                        aria-label={__('Search results', TEXT_DOMAIN)}
+                        aria-busy={isSearching}
+                        data-testid="ap-nav-link-picker-results"
+                    >
+                        {results.length === 0 && !isSearching ? (
+                            <li className="ap-nav-inspector__result-empty">
+                                {__('No results.', TEXT_DOMAIN)}
+                            </li>
+                        ) : null}
+                        {results.map((result) => {
+                            const selected =
+                                item.targetId !== null &&
+                                String(item.targetId) === String(result.id);
+
+                            return (
+                                <li
+                                    key={`${result.type}-${result.id}`}
+                                    className="ap-nav-inspector__result"
+                                    role="option"
+                                    aria-selected={selected}
+                                >
+                                    <button
+                                        type="button"
+                                        className="ap-nav-inspector__result-button"
+                                        data-selected={selected}
+                                        onClick={() => {
+                                            onChange({
+                                                targetId: result.id,
+                                                autoLabel: result.title,
+                                                url:
+                                                    result.url ?? item.url,
+                                            });
+                                        }}
+                                        data-testid={`ap-nav-link-picker-result-${result.id}`}
+                                    >
+                                        {result.title}
+                                    </button>
+                                </li>
+                            );
+                        })}
+                    </ul>
+                </>
+            ) : (
+                <div className="ap-site-editor__dialog-field">
+                    <label
+                        className="ap-site-editor__dialog-label"
+                        htmlFor={urlId}
+                    >
+                        {__('URL', TEXT_DOMAIN)}
+                    </label>
+                    <input
+                        id={urlId}
+                        type="url"
+                        className="ap-site-editor__dialog-input"
+                        value={item.url ?? ''}
+                        onChange={(event) =>
+                            onChange({ url: event.target.value })
+                        }
+                        placeholder="https://example.com"
+                        data-testid="ap-nav-link-picker-url"
+                    />
+                </div>
+            )}
+        </div>
+    );
+}

--- a/resources/js/visual-editor/site-editor/navigation/link-picker.tsx
+++ b/resources/js/visual-editor/site-editor/navigation/link-picker.tsx
@@ -146,11 +146,18 @@ export function LinkPicker(props: LinkPickerProps): JSX.Element {
                         const next = event.target.value as MenuItemType;
                         // Switching type clears `targetId` + `url` so the
                         // user can't accidentally save a stale typed
-                        // reference under the wrong wire shape.
+                        // reference under the wrong wire shape. Also
+                        // clear `sourceKind` / `sourceType` so the new
+                        // IA selection drives serialization — without
+                        // that, a CPT-sourced item the user retypes as
+                        // `Page` would still emit the original CPT
+                        // wire shape.
                         onChange({
                             type: next,
                             targetId: null,
                             url: next === 'custom' ? item.url : null,
+                            sourceKind: null,
+                            sourceType: null,
                         });
                     }}
                     data-testid="ap-nav-link-picker-type"
@@ -226,6 +233,13 @@ export function LinkPicker(props: LinkPickerProps): JSX.Element {
                                                 autoLabel: result.title,
                                                 url:
                                                     result.url ?? item.url,
+                                                // Picking a result is an
+                                                // explicit re-typing — the
+                                                // wire-source attributes
+                                                // from the original block
+                                                // no longer apply.
+                                                sourceKind: null,
+                                                sourceType: null,
                                             });
                                         }}
                                         data-testid={`ap-nav-link-picker-result-${result.id}`}

--- a/resources/js/visual-editor/site-editor/navigation/locations-panel.tsx
+++ b/resources/js/visual-editor/site-editor/navigation/locations-panel.tsx
@@ -1,0 +1,184 @@
+/**
+ * Menu locations panel.
+ *
+ * Renders the configured menu locations and the menu currently
+ * resolved for each (per `MenuLocationsController::index`). Each row
+ * lets the user pick a different menu — that selection writes the
+ * `location` field on the chosen menu's record (single-occupant
+ * semantics — the controller releases the slug from any prior owner).
+ *
+ * Sits in the navigator outlet alongside the menu list. The panel is
+ * read-mostly: assignments rarely change, but when they do the user
+ * shouldn't have to navigate into a specific menu's inspector to make
+ * the change.
+ */
+
+import { __, sprintf } from '@wordpress/i18n';
+import { useState } from 'react';
+
+import { TEXT_DOMAIN } from '../../vendor/i18n';
+
+import type {
+    MenuLocation,
+    NavigationRecord,
+} from './api-client';
+
+export interface LocationsPanelProps {
+    locations: readonly MenuLocation[];
+    isLoading: boolean;
+    errorMessage: string | null;
+    navigations: readonly NavigationRecord[];
+    onAssign: (
+        locationSlug: string,
+        navigationId: number | null
+    ) => Promise<void>;
+}
+
+export function LocationsPanel(props: LocationsPanelProps): JSX.Element {
+    const { locations, isLoading, errorMessage, navigations, onAssign } =
+        props;
+
+    const [pendingSlug, setPendingSlug] = useState<string | null>(null);
+
+    if (errorMessage !== null) {
+        return (
+            <section
+                className="ap-locations-panel"
+                data-testid="ap-locations-panel"
+                aria-label={__('Menu locations', TEXT_DOMAIN)}
+            >
+                <h3 className="ap-locations-panel__title">
+                    {__('Locations', TEXT_DOMAIN)}
+                </h3>
+                <p className="ap-locations-panel__hint" role="alert">
+                    {errorMessage}
+                </p>
+            </section>
+        );
+    }
+
+    if (isLoading) {
+        return (
+            <section
+                className="ap-locations-panel"
+                data-testid="ap-locations-panel"
+                aria-label={__('Menu locations', TEXT_DOMAIN)}
+                aria-busy="true"
+            >
+                <h3 className="ap-locations-panel__title">
+                    {__('Locations', TEXT_DOMAIN)}
+                </h3>
+                <p className="ap-locations-panel__hint">
+                    {__('Loading locations…', TEXT_DOMAIN)}
+                </p>
+            </section>
+        );
+    }
+
+    if (locations.length === 0) {
+        return (
+            <section
+                className="ap-locations-panel"
+                data-testid="ap-locations-panel"
+                aria-label={__('Menu locations', TEXT_DOMAIN)}
+            >
+                <h3 className="ap-locations-panel__title">
+                    {__('Locations', TEXT_DOMAIN)}
+                </h3>
+                <p className="ap-locations-panel__empty">
+                    {__(
+                        'No menu locations configured. Declare them in `config/artisanpack/visual-editor.php` under `navigation.locations`.',
+                        TEXT_DOMAIN
+                    )}
+                </p>
+            </section>
+        );
+    }
+
+    const handleSelectChange = async (
+        locationSlug: string,
+        rawValue: string
+    ): Promise<void> => {
+        const next = rawValue === '' ? null : Number(rawValue);
+
+        setPendingSlug(locationSlug);
+
+        try {
+            await onAssign(locationSlug, Number.isFinite(next) ? next : null);
+        } finally {
+            setPendingSlug(null);
+        }
+    };
+
+    return (
+        <section
+            className="ap-locations-panel"
+            data-testid="ap-locations-panel"
+            aria-label={__('Menu locations', TEXT_DOMAIN)}
+        >
+            <h3 className="ap-locations-panel__title">
+                {__('Locations', TEXT_DOMAIN)}
+            </h3>
+            {locations.map((location) => {
+                const selectedId = location.menu?.id ?? '';
+
+                return (
+                    <div
+                        key={location.slug}
+                        className="ap-locations-panel__row"
+                        data-testid={`ap-locations-row-${location.slug}`}
+                    >
+                        <span className="ap-locations-panel__label">
+                            {location.label}
+                        </span>
+                        <select
+                            className="ap-locations-panel__select"
+                            value={selectedId}
+                            onChange={(event) =>
+                                void handleSelectChange(
+                                    location.slug,
+                                    event.target.value
+                                )
+                            }
+                            disabled={pendingSlug === location.slug}
+                            data-testid={`ap-locations-select-${location.slug}`}
+                            aria-label={sprintf(
+                                /* translators: %s: location label. */
+                                __('Menu for %s', TEXT_DOMAIN),
+                                location.label
+                            )}
+                        >
+                            <option value="">
+                                {__('— None —', TEXT_DOMAIN)}
+                            </option>
+                            {navigations.map((row) => (
+                                <option key={row.id} value={row.id}>
+                                    {row.title.rendered === ''
+                                        ? row.slug
+                                        : row.title.rendered}
+                                </option>
+                            ))}
+                        </select>
+                        {location.is_fallback && location.menu !== null ? (
+                            <p
+                                className="ap-locations-panel__hint"
+                                data-testid={`ap-locations-fallback-${location.slug}`}
+                            >
+                                {sprintf(
+                                    /* translators: %s: menu title. */
+                                    __(
+                                        'Falling back to "%s" because no menu is assigned.',
+                                        TEXT_DOMAIN
+                                    ),
+                                    location.menu.title === ''
+                                        ? location.menu.slug
+                                        : location.menu.title
+                                )}
+                            </p>
+                        ) : null}
+                    </div>
+                );
+            })}
+        </section>
+    );
+}

--- a/resources/js/visual-editor/site-editor/navigation/menu-tree.ts
+++ b/resources/js/visual-editor/site-editor/navigation/menu-tree.ts
@@ -34,6 +34,19 @@ export interface MenuItem {
     type: MenuItemType;
     /** When the item points at an entity, this is the typed reference. */
     targetId: number | string | null;
+    /**
+     * The original `kind` attribute from the source block when it
+     * didn't map cleanly to one of the four IA `MenuItemType`
+     * values (e.g. a custom post type or a specific taxonomy slug).
+     * Preserved verbatim so the save path can re-emit it and host
+     * apps that seed nav menus with CPT / taxonomy references don't
+     * lose those identifiers across the editor's read → write cycle.
+     * `null` after the user explicitly changes the type / target in
+     * the editor — the new IA selection then drives serialization.
+     */
+    sourceKind: string | null;
+    /** Original `type` attribute from the source block — see {@link sourceKind}. */
+    sourceType: string | null;
     /** Optional human override; falsy → render the auto-derived label. */
     labelOverride: string | null;
     /**
@@ -146,6 +159,34 @@ function menuItemTypeToAttributes(
 }
 
 /**
+ * Prefer the source `kind` / `type` attributes from the original
+ * block when present so custom post types (e.g. `kind: 'post-type',
+ * type: 'book'`) and specific taxonomies (e.g. `kind: 'taxonomy',
+ * type: 'category'`) round-trip through the editor without losing
+ * their wire identifiers. The IA-derived attributes only kick in
+ * when the user explicitly creates / changes a menu item — the link
+ * picker clears `sourceKind` + `sourceType` on every type / target
+ * mutation so the new IA selection takes precedence.
+ */
+function sourceAwareTypeAttributes(
+    item: MenuItem
+): { kind: string; type?: string } {
+    if (item.sourceKind !== null && item.sourceKind !== '') {
+        const out: { kind: string; type?: string } = {
+            kind: item.sourceKind,
+        };
+
+        if (item.sourceType !== null && item.sourceType !== '') {
+            out.type = item.sourceType;
+        }
+
+        return out;
+    }
+
+    return menuItemTypeToAttributes(item.type);
+}
+
+/**
  * Walks a block tree and returns the corresponding MenuItem tree.
  * Drops blocks whose `name` we don't know how to translate.
  */
@@ -173,10 +214,27 @@ export function blocksToMenuTree(blocks: readonly unknown[]): MenuItem[] {
             ? (block.innerBlocks as readonly unknown[])
             : [];
 
+        const derivedType = blockAttributesToType(attributes);
+        const wireKind = readMaybeString(attributes.kind);
+        const wireType = readMaybeString(attributes.type);
+
+        // Only preserve `kind` / `type` as source overrides when they
+        // diverge from what the IA would re-emit on save — otherwise
+        // round-tripping a `kind: 'post-type', type: 'page'` block
+        // through a freshly-created MenuItem would write source* on
+        // read and skip them on write, breaking bit-equivalence.
+        const iaShape = menuItemTypeToAttributes(derivedType);
+        const matchesIaShape =
+            wireKind === iaShape.kind &&
+            ((iaShape.type === undefined && wireType === null) ||
+                wireType === (iaShape.type ?? null));
+
         const item: MenuItem = {
             localId: nextLocalId(),
-            type: blockAttributesToType(attributes),
+            type: derivedType,
             targetId: readMaybeIdentifier(attributes.id),
+            sourceKind: matchesIaShape ? null : wireKind,
+            sourceType: matchesIaShape ? null : wireType,
             // The wire format has a single `label` attribute — there is
             // no signal whether it originated as an auto-derived label
             // or a user override. Treat it as the auto label on read;
@@ -211,7 +269,7 @@ export function menuTreeToBlocks(items: readonly MenuItem[]): unknown[] {
 
 function menuItemToBlock(item: MenuItem): Record<string, unknown> {
     const attributes: Record<string, unknown> = {
-        ...menuItemTypeToAttributes(item.type),
+        ...sourceAwareTypeAttributes(item),
         label:
             item.labelOverride !== null && item.labelOverride !== ''
                 ? item.labelOverride
@@ -258,6 +316,8 @@ export function makeMenuItem(overrides: Partial<MenuItem> = {}): MenuItem {
         localId: overrides.localId ?? nextLocalId(),
         type: overrides.type ?? 'custom',
         targetId: overrides.targetId ?? null,
+        sourceKind: overrides.sourceKind ?? null,
+        sourceType: overrides.sourceType ?? null,
         labelOverride: overrides.labelOverride ?? null,
         autoLabel: overrides.autoLabel ?? '',
         url: overrides.url ?? null,

--- a/resources/js/visual-editor/site-editor/navigation/menu-tree.ts
+++ b/resources/js/visual-editor/site-editor/navigation/menu-tree.ts
@@ -1,0 +1,693 @@
+/**
+ * Menu-tree ↔ Gutenberg block-tree bridge.
+ *
+ * The C4 backend persists navigations as Gutenberg block trees inside
+ * the `{ raw, blocks }` envelope (see `docs/core-data-shim.md` §Navigation).
+ * The D4 editor, however, is a NATIVE TREE EDITOR per design brief §3.8 —
+ * users drag-sort typed-reference items, not blocks. This module is the
+ * translation layer between the two.
+ *
+ * Read direction (block tree → MenuItem tree):
+ *   - `core/navigation-link`     → `{ type: page|post|custom, target_id, label_override?, url? }`
+ *   - `core/navigation-submenu`  → same fields + `children`, walked recursively
+ *   - Anything else is dropped silently. The native editor has no UI for
+ *     block types it doesn't understand, and the alternative (preserving
+ *     opaque "unknown" rows the user can't act on) is worse than losing
+ *     them.
+ *
+ * Write direction (MenuItem tree → block tree):
+ *   - Items with no children round-trip as `core/navigation-link`.
+ *   - Items with children round-trip as `core/navigation-submenu`,
+ *     children rendered recursively as `innerBlocks`.
+ *   - Type → block-attribute kind mapping mirrors WP's: `page`/`post` →
+ *     `kind: 'post-type'` + `type` + `id`; `custom` → bare `url`/`label`.
+ *
+ * The `raw` half of the envelope is left empty; the backend regenerates
+ * it from `blocks` on save (see `VisualEditorNavigation::setContentEnvelope`).
+ */
+
+export type MenuItemType = 'page' | 'post' | 'custom' | 'taxonomy';
+
+export interface MenuItem {
+    /** Locally stable id used by react keys + dnd-kit; not persisted. */
+    localId: string;
+    type: MenuItemType;
+    /** When the item points at an entity, this is the typed reference. */
+    targetId: number | string | null;
+    /** Optional human override; falsy → render the auto-derived label. */
+    labelOverride: string | null;
+    /**
+     * Auto-derived label from the target entity at read-time. Useful for
+     * rendering the tree without a separate fetch. The save path doesn't
+     * persist this — the backend re-resolves on next read.
+     */
+    autoLabel: string;
+    /** Custom-URL items hold their URL here. */
+    url: string | null;
+    /** Open in new tab. */
+    opensInNewTab: boolean;
+    /** Free-form CSS classes. */
+    className: string | null;
+    /** Free-form rel attribute. */
+    rel: string | null;
+    children: MenuItem[];
+}
+
+interface UnknownBlock {
+    name?: unknown;
+    attributes?: unknown;
+    innerBlocks?: unknown;
+    [key: string]: unknown;
+}
+
+const NAV_LINK = 'core/navigation-link';
+const NAV_SUBMENU = 'core/navigation-submenu';
+
+/**
+ * Generates a stable-enough local id for tree-editor react keys. The id
+ * never round-trips to the backend — it lives only on the in-memory
+ * MenuItem tree to back drag-sort and edits.
+ */
+let counter = 0;
+export function nextLocalId(): string {
+    counter += 1;
+
+    return `menu-item-${counter}-${Date.now().toString(36)}`;
+}
+
+function readString(value: unknown, fallback = ''): string {
+    return typeof value === 'string' ? value : fallback;
+}
+
+function readMaybeString(value: unknown): string | null {
+    if (typeof value !== 'string') {
+        return null;
+    }
+
+    return value === '' ? null : value;
+}
+
+function readBool(value: unknown): boolean {
+    return value === true;
+}
+
+function readMaybeIdentifier(value: unknown): number | string | null {
+    if (typeof value === 'number' && Number.isFinite(value)) {
+        return value;
+    }
+
+    if (typeof value === 'string' && value !== '') {
+        return value;
+    }
+
+    return null;
+}
+
+/**
+ * Maps a `core/navigation-link` / `core/navigation-submenu` block's
+ * `{ kind, type }` attributes onto our flat `MenuItemType`.
+ */
+function blockAttributesToType(
+    attributes: Record<string, unknown>
+): MenuItemType {
+    const kind = readString(attributes.kind);
+    const type = readString(attributes.type);
+
+    if (kind === 'post-type') {
+        if (type === 'page') {
+            return 'page';
+        }
+        if (type === 'post') {
+            return 'post';
+        }
+    }
+
+    if (kind === 'taxonomy') {
+        return 'taxonomy';
+    }
+
+    // Bare URL items have neither `kind` nor `type` set in WP's wire
+    // shape — we treat them as the catch-all custom URL.
+    return 'custom';
+}
+
+function menuItemTypeToAttributes(
+    type: MenuItemType
+): { kind: string; type?: string } {
+    if (type === 'page' || type === 'post') {
+        return { kind: 'post-type', type };
+    }
+
+    if (type === 'taxonomy') {
+        return { kind: 'taxonomy' };
+    }
+
+    return { kind: 'custom' };
+}
+
+/**
+ * Walks a block tree and returns the corresponding MenuItem tree.
+ * Drops blocks whose `name` we don't know how to translate.
+ */
+export function blocksToMenuTree(blocks: readonly unknown[]): MenuItem[] {
+    const items: MenuItem[] = [];
+
+    for (const raw of blocks) {
+        if (raw === null || typeof raw !== 'object') {
+            continue;
+        }
+
+        const block = raw as UnknownBlock;
+        const name = readString(block.name);
+
+        if (name !== NAV_LINK && name !== NAV_SUBMENU) {
+            continue;
+        }
+
+        const attributes =
+            block.attributes !== null && typeof block.attributes === 'object'
+                ? (block.attributes as Record<string, unknown>)
+                : {};
+
+        const innerBlocks = Array.isArray(block.innerBlocks)
+            ? (block.innerBlocks as readonly unknown[])
+            : [];
+
+        const item: MenuItem = {
+            localId: nextLocalId(),
+            type: blockAttributesToType(attributes),
+            targetId: readMaybeIdentifier(attributes.id),
+            // The wire format has a single `label` attribute — there is
+            // no signal whether it originated as an auto-derived label
+            // or a user override. Treat it as the auto label on read;
+            // the user re-asserts an override the next time they edit
+            // the field. `effectiveLabel` returns the same string
+            // either way, so the visible behavior is unchanged.
+            labelOverride: null,
+            autoLabel: readString(attributes.label),
+            url: readMaybeString(attributes.url),
+            opensInNewTab: readBool(attributes.opensInNewTab),
+            className: readMaybeString(attributes.className),
+            rel: readMaybeString(attributes.rel),
+            children:
+                name === NAV_SUBMENU ? blocksToMenuTree(innerBlocks) : [],
+        };
+
+        items.push(item);
+    }
+
+    return items;
+}
+
+/**
+ * Walks a MenuItem tree and emits the matching block tree. Submenus
+ * win against bare links whenever an item has children — this is what
+ * Gutenberg's `core/navigation` editor expects, and matches the
+ * backend's parse pipeline.
+ */
+export function menuTreeToBlocks(items: readonly MenuItem[]): unknown[] {
+    return items.map((item) => menuItemToBlock(item));
+}
+
+function menuItemToBlock(item: MenuItem): Record<string, unknown> {
+    const attributes: Record<string, unknown> = {
+        ...menuItemTypeToAttributes(item.type),
+        label:
+            item.labelOverride !== null && item.labelOverride !== ''
+                ? item.labelOverride
+                : item.autoLabel,
+    };
+
+    if (item.targetId !== null) {
+        attributes.id = item.targetId;
+    }
+
+    if (item.url !== null) {
+        attributes.url = item.url;
+    }
+
+    if (item.opensInNewTab) {
+        attributes.opensInNewTab = true;
+    }
+
+    if (item.className !== null) {
+        attributes.className = item.className;
+    }
+
+    if (item.rel !== null) {
+        attributes.rel = item.rel;
+    }
+
+    if (item.children.length === 0) {
+        return {
+            name: NAV_LINK,
+            attributes,
+            innerBlocks: [],
+        };
+    }
+
+    return {
+        name: NAV_SUBMENU,
+        attributes,
+        innerBlocks: menuTreeToBlocks(item.children),
+    };
+}
+
+export function makeMenuItem(overrides: Partial<MenuItem> = {}): MenuItem {
+    return {
+        localId: overrides.localId ?? nextLocalId(),
+        type: overrides.type ?? 'custom',
+        targetId: overrides.targetId ?? null,
+        labelOverride: overrides.labelOverride ?? null,
+        autoLabel: overrides.autoLabel ?? '',
+        url: overrides.url ?? null,
+        opensInNewTab: overrides.opensInNewTab ?? false,
+        className: overrides.className ?? null,
+        rel: overrides.rel ?? null,
+        children: overrides.children ?? [],
+    };
+}
+
+/** Returns the visible label — override wins, falls back to auto. */
+export function effectiveLabel(item: MenuItem): string {
+    if (item.labelOverride !== null && item.labelOverride !== '') {
+        return item.labelOverride;
+    }
+
+    if (item.autoLabel !== '') {
+        return item.autoLabel;
+    }
+
+    if (item.url !== null && item.url !== '') {
+        return item.url;
+    }
+
+    return '';
+}
+
+/**
+ * Recursively replaces an item by `localId`. Returns a new tree (no
+ * mutation) so React state updates are safe.
+ */
+export function replaceMenuItem(
+    tree: readonly MenuItem[],
+    localId: string,
+    update: (item: MenuItem) => MenuItem
+): MenuItem[] {
+    return tree.map((item) => {
+        if (item.localId === localId) {
+            return update(item);
+        }
+
+        if (item.children.length === 0) {
+            return item;
+        }
+
+        return {
+            ...item,
+            children: replaceMenuItem(item.children, localId, update),
+        };
+    });
+}
+
+export function removeMenuItem(
+    tree: readonly MenuItem[],
+    localId: string
+): MenuItem[] {
+    const filtered: MenuItem[] = [];
+
+    for (const item of tree) {
+        if (item.localId === localId) {
+            continue;
+        }
+
+        filtered.push({
+            ...item,
+            children: removeMenuItem(item.children, localId),
+        });
+    }
+
+    return filtered;
+}
+
+export function appendChild(
+    tree: readonly MenuItem[],
+    parentLocalId: string,
+    child: MenuItem
+): MenuItem[] {
+    return tree.map((item) => {
+        if (item.localId === parentLocalId) {
+            return {
+                ...item,
+                children: [...item.children, child],
+            };
+        }
+
+        if (item.children.length === 0) {
+            return item;
+        }
+
+        return {
+            ...item,
+            children: appendChild(item.children, parentLocalId, child),
+        };
+    });
+}
+
+/** Locate an item in the tree by `localId`. Returns `null` on miss. */
+export function findMenuItem(
+    tree: readonly MenuItem[],
+    localId: string
+): MenuItem | null {
+    for (const item of tree) {
+        if (item.localId === localId) {
+            return item;
+        }
+
+        const child = findMenuItem(item.children, localId);
+
+        if (child !== null) {
+            return child;
+        }
+    }
+
+    return null;
+}
+
+/**
+ * Reorders `tree[fromIndex]` to `toIndex` at the top level.
+ * Out-of-range indices return the tree unchanged.
+ */
+export function reorderTopLevel(
+    tree: readonly MenuItem[],
+    fromIndex: number,
+    toIndex: number
+): MenuItem[] {
+    if (
+        fromIndex < 0 ||
+        fromIndex >= tree.length ||
+        toIndex < 0 ||
+        toIndex >= tree.length ||
+        fromIndex === toIndex
+    ) {
+        return tree.slice();
+    }
+
+    const next = tree.slice();
+    const [moved] = next.splice(fromIndex, 1);
+    next.splice(toIndex, 0, moved);
+
+    return next;
+}
+
+// ---------------------------------------------------------------------------
+// Flat-list bridge — used by the dnd-kit "tree" pattern in
+// `navigation-canvas.tsx`. Drag-and-drop wants a single flat sortable
+// list, so we render from a flattened view and rebuild the nested
+// MenuItem tree on commit.
+// ---------------------------------------------------------------------------
+
+/**
+ * One row in the flat view of a MenuItem tree. `depth` is 0 at the
+ * root and increases by 1 per generation. `parentLocalId` is the
+ * direct parent's `localId`, or `null` at the root.
+ */
+export interface FlatMenuItem {
+    item: MenuItem;
+    depth: number;
+    parentLocalId: string | null;
+    /** True when the item carries its own children. */
+    hasChildren: boolean;
+}
+
+/**
+ * Walk the tree depth-first and emit one `FlatMenuItem` per node so
+ * the canvas can hand a single sortable list to dnd-kit.
+ */
+export function flattenTree(
+    tree: readonly MenuItem[],
+    parentLocalId: string | null = null,
+    depth = 0
+): FlatMenuItem[] {
+    const out: FlatMenuItem[] = [];
+
+    for (const item of tree) {
+        out.push({
+            item,
+            depth,
+            parentLocalId,
+            hasChildren: item.children.length > 0,
+        });
+
+        if (item.children.length > 0) {
+            out.push(
+                ...flattenTree(item.children, item.localId, depth + 1)
+            );
+        }
+    }
+
+    return out;
+}
+
+/**
+ * Inverse of `flattenTree`. Rebuilds a nested `MenuItem[]` from a
+ * flat list, using each row's `parentLocalId` as the authoritative
+ * link (depth is rendering metadata only — it can't disambiguate
+ * sibling subtrees that happen to sit at the same level).
+ *
+ * The implementation is order-independent: the dnd-kit drag-end path
+ * arrayMoves a single row without resorting the flat list, so a
+ * child can appear before its parent. Two passes — first materialize
+ * every item, then attach in flat-list order — keep that behavior
+ * stable. Children of the same parent stay in their flat-list order
+ * so user-perceived sibling order survives the round trip.
+ */
+export function buildTreeFromFlat(
+    flat: readonly FlatMenuItem[]
+): MenuItem[] {
+    const itemsById = new Map<string, MenuItem>();
+
+    for (const flatItem of flat) {
+        // Reset `children` — we re-derive parent/child wiring from
+        // the flat list itself, not whatever was nested on input.
+        itemsById.set(flatItem.item.localId, {
+            ...flatItem.item,
+            children: [],
+        });
+    }
+
+    const root: MenuItem[] = [];
+
+    for (const flatItem of flat) {
+        const rebuilt = itemsById.get(flatItem.item.localId);
+
+        if (rebuilt === undefined) {
+            continue;
+        }
+
+        if (flatItem.parentLocalId === null) {
+            root.push(rebuilt);
+            continue;
+        }
+
+        const parent = itemsById.get(flatItem.parentLocalId);
+
+        if (parent === undefined) {
+            // Orphan with a non-null parent — re-root so the item
+            // doesn't disappear. This shouldn't happen with a
+            // well-formed flat list but guards the round-trip.
+            root.push(rebuilt);
+            continue;
+        }
+
+        parent.children.push(rebuilt);
+    }
+
+    return root;
+}
+
+/**
+ * Returns the localIds of the descendant items beneath the given
+ * ancestor. Used by the canvas to "lift" a subtree out of the flat
+ * list while it's being dragged so the dragged item doesn't pretend
+ * to drop INTO its own children.
+ *
+ * Order-independent: builds a parent → children map and runs a BFS
+ * from the ancestor, so the result is stable regardless of whether
+ * children appear before or after their parent in the flat list
+ * (the drag-end commit path can produce an unsorted layout).
+ */
+export function getDescendantIds(
+    flat: readonly FlatMenuItem[],
+    ancestorLocalId: string
+): Set<string> {
+    const childrenByParent = new Map<string, string[]>();
+
+    for (const flatItem of flat) {
+        if (flatItem.parentLocalId === null) {
+            continue;
+        }
+
+        const bucket = childrenByParent.get(flatItem.parentLocalId);
+
+        if (bucket === undefined) {
+            childrenByParent.set(flatItem.parentLocalId, [
+                flatItem.item.localId,
+            ]);
+        } else {
+            bucket.push(flatItem.item.localId);
+        }
+    }
+
+    const descendants = new Set<string>();
+    const queue: string[] = [ancestorLocalId];
+
+    while (queue.length > 0) {
+        const current = queue.shift() as string;
+        const children = childrenByParent.get(current);
+
+        if (children === undefined) {
+            continue;
+        }
+
+        for (const childId of children) {
+            if (descendants.has(childId)) {
+                continue;
+            }
+
+            descendants.add(childId);
+            queue.push(childId);
+        }
+    }
+
+    return descendants;
+}
+
+export interface ProjectionResult {
+    depth: number;
+    maxDepth: number;
+    minDepth: number;
+    parentLocalId: string | null;
+}
+
+/**
+ * Computes the projected depth + parent for the dragged item given:
+ *
+ *   - the current ordered flat list (with the dragged item still at
+ *     its original index),
+ *   - the active and over ids,
+ *   - the cumulative drag X-offset (positive = right, deepens),
+ *   - the indent width in pixels.
+ *
+ * Returns the depth the canvas should render the dragged row at while
+ * a drag is in flight (visual feedback) and that the commit step
+ * should snap to on drop.
+ *
+ * Mirrors the standard dnd-kit "tree" recipe — see
+ * https://github.com/clauderic/dnd-kit/blob/master/stories/3%20-%20Examples/Tree/utilities.ts.
+ */
+export function projectDrop(
+    flat: readonly FlatMenuItem[],
+    activeId: string,
+    overId: string,
+    dragOffsetX: number,
+    indentWidth: number
+): ProjectionResult | null {
+    const overIndex = flat.findIndex(
+        (entry) => entry.item.localId === overId
+    );
+    const activeIndex = flat.findIndex(
+        (entry) => entry.item.localId === activeId
+    );
+
+    if (overIndex === -1 || activeIndex === -1) {
+        return null;
+    }
+
+    const activeItem = flat[activeIndex];
+
+    // `arrayMove` semantics — pretend the dragged item has already
+    // moved to the over-index so the previous / next neighbors reflect
+    // the post-drop layout.
+    const reordered = flat.slice();
+    const [moved] = reordered.splice(activeIndex, 1);
+    reordered.splice(overIndex, 0, moved);
+
+    const previousItem = reordered[overIndex - 1];
+    const nextItem = reordered[overIndex + 1];
+    const dragDepth = Math.round(dragOffsetX / indentWidth);
+    const projectedDepth = activeItem.depth + dragDepth;
+
+    const maxDepth =
+        previousItem === undefined ? 0 : previousItem.depth + 1;
+    const minDepth = nextItem === undefined ? 0 : nextItem.depth;
+
+    let depth = projectedDepth;
+
+    if (depth >= maxDepth) {
+        depth = maxDepth;
+    } else if (depth < minDepth) {
+        depth = minDepth;
+    }
+
+    let parentLocalId: string | null = null;
+
+    if (depth > 0 && previousItem !== undefined) {
+        if (depth === previousItem.depth) {
+            parentLocalId = previousItem.parentLocalId;
+        } else if (depth > previousItem.depth) {
+            parentLocalId = previousItem.item.localId;
+        } else {
+            // Walk back through the reordered list to find an ancestor
+            // that sits at the projected depth and inherit ITS parent.
+            const ancestor = reordered
+                .slice(0, overIndex)
+                .reverse()
+                .find((entry) => entry.depth === depth);
+
+            parentLocalId = ancestor?.parentLocalId ?? null;
+        }
+    }
+
+    return { depth, maxDepth, minDepth, parentLocalId };
+}
+
+/**
+ * Commit the active row's projected depth + parent into the flat
+ * list, then array-move it from its old index to the over-row's
+ * index. Mirrors the dnd-kit "tree" recipe: only the active row
+ * moves, its descendants stay in place and re-attach via
+ * `parentLocalId` when `buildTreeFromFlat` runs.
+ *
+ * Returns the new flat list, or the original list when the indices
+ * couldn't be resolved (a defensive no-op).
+ */
+export function commitProjection(
+    flat: readonly FlatMenuItem[],
+    activeId: string,
+    overId: string,
+    projection: ProjectionResult
+): FlatMenuItem[] {
+    const activeIndex = flat.findIndex(
+        (entry) => entry.item.localId === activeId
+    );
+    const overIndex = flat.findIndex(
+        (entry) => entry.item.localId === overId
+    );
+
+    if (activeIndex === -1 || overIndex === -1) {
+        return flat.slice();
+    }
+
+    const updated = flat.slice();
+    updated[activeIndex] = {
+        ...updated[activeIndex],
+        depth: projection.depth,
+        parentLocalId: projection.parentLocalId,
+    };
+
+    const [moved] = updated.splice(activeIndex, 1);
+    updated.splice(overIndex, 0, moved);
+
+    return updated;
+}

--- a/resources/js/visual-editor/site-editor/navigation/navigation-browser.css
+++ b/resources/js/visual-editor/site-editor/navigation/navigation-browser.css
@@ -1,0 +1,132 @@
+/*
+ * Navigation browser — left-rail menu list + locations panel.
+ */
+
+.ap-nav-browser {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+	padding: 12px;
+	height: 100%;
+	overflow: auto;
+}
+
+.ap-nav-browser__header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 8px;
+}
+
+.ap-nav-browser__title {
+	font-size: 13px;
+	font-weight: 600;
+	margin: 0;
+}
+
+.ap-nav-browser__create {
+	font-size: 12px;
+	padding: 4px 8px;
+	background: var(--ap-site-editor-accent, #2271b1);
+	color: #fff;
+	border: 0;
+	border-radius: 3px;
+	cursor: pointer;
+}
+
+.ap-nav-browser__list {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+
+.ap-nav-browser__row[data-active='true'] .ap-nav-browser__row-button {
+	border-color: var(--ap-site-editor-accent, #2271b1);
+	background: rgba(34, 113, 177, 0.05);
+}
+
+.ap-nav-browser__row-button {
+	width: 100%;
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	text-align: left;
+	background: #fff;
+	border: 1px solid var(--ap-site-editor-border, #ddd);
+	border-radius: 3px;
+	padding: 8px;
+	cursor: pointer;
+}
+
+.ap-nav-browser__row-title {
+	font-weight: 500;
+	font-size: 12px;
+	color: var(--ap-site-editor-fg, #1d2327);
+}
+
+.ap-nav-browser__row-meta {
+	font-size: 11px;
+	color: var(--ap-site-editor-muted, #555);
+}
+
+.ap-nav-browser__status,
+.ap-nav-browser__empty {
+	margin: 0;
+	font-size: 12px;
+	color: var(--ap-site-editor-muted, #555);
+}
+
+.ap-locations-panel {
+	margin-top: 12px;
+	padding-top: 12px;
+	border-top: 1px solid var(--ap-site-editor-border, #ddd);
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+
+.ap-locations-panel__title {
+	font-size: 11px;
+	font-weight: 600;
+	letter-spacing: 0.04em;
+	text-transform: uppercase;
+	color: var(--ap-site-editor-muted, #555);
+	margin: 0;
+}
+
+.ap-locations-panel__row {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+	padding: 6px;
+	background: #fff;
+	border: 1px solid var(--ap-site-editor-border, #ddd);
+	border-radius: 3px;
+}
+
+.ap-locations-panel__label {
+	font-size: 12px;
+	font-weight: 500;
+}
+
+.ap-locations-panel__select {
+	font-size: 11px;
+	padding: 4px;
+	border: 1px solid var(--ap-site-editor-border, #ddd);
+	border-radius: 3px;
+}
+
+.ap-locations-panel__hint {
+	font-size: 11px;
+	color: var(--ap-site-editor-muted, #555);
+	margin: 0;
+}
+
+.ap-locations-panel__empty {
+	font-size: 11px;
+	color: var(--ap-site-editor-muted, #555);
+	margin: 0;
+}

--- a/resources/js/visual-editor/site-editor/navigation/navigation-browser.tsx
+++ b/resources/js/visual-editor/site-editor/navigation/navigation-browser.tsx
@@ -1,0 +1,278 @@
+/**
+ * Navigation browser — the left rail's menu list.
+ *
+ * Lists `wp_navigation` records via the C4 index endpoint. Mirrors the
+ * `EntityBrowser` ergonomics (list rows, "Add new" button, selection
+ * state) without depending on it: nav rows show extra columns
+ * (location, item count) that don't fit the templates browser shape.
+ */
+
+import { __, sprintf } from '@wordpress/i18n';
+import { useEffect, useMemo, useState } from 'react';
+
+import { TEXT_DOMAIN } from '../../vendor/i18n';
+
+import type { SiteEditorApiConfig } from '../api-client';
+import {
+    listNavigations,
+    type NavigationRecord,
+} from './api-client';
+import { LocationsPanel } from './locations-panel';
+import type { MenuLocation } from './api-client';
+
+import './navigation-browser.css';
+
+export interface NavigationBrowserProps {
+    apiConfig: SiteEditorApiConfig;
+    activeEntityId: string | null;
+    onOpen: (entityId: string) => void;
+    onRequestCreate: () => void;
+    /** Bumped after a successful create / save to refresh the list. */
+    refreshKey?: number;
+    locations: readonly MenuLocation[];
+    isLocationsLoading: boolean;
+    locationsError: string | null;
+    onAssignLocation: (
+        locationSlug: string,
+        navigationId: number | null
+    ) => Promise<void>;
+}
+
+interface ListState {
+    status: 'idle' | 'loading' | 'ready' | 'error';
+    rows: readonly NavigationRecord[];
+    errorMessage: string | null;
+}
+
+const INITIAL_LIST: ListState = {
+    status: 'idle',
+    rows: [],
+    errorMessage: null,
+};
+
+export function NavigationBrowser(
+    props: NavigationBrowserProps
+): JSX.Element {
+    const {
+        apiConfig,
+        activeEntityId,
+        onOpen,
+        onRequestCreate,
+        refreshKey = 0,
+        locations,
+        isLocationsLoading,
+        locationsError,
+        onAssignLocation,
+    } = props;
+
+    const [state, setState] = useState<ListState>(INITIAL_LIST);
+
+    useEffect(() => {
+        let cancelled = false;
+
+        setState({ status: 'loading', rows: [], errorMessage: null });
+
+        (async () => {
+            try {
+                const response = await listNavigations(apiConfig, {
+                    perPage: 50,
+                });
+
+                if (cancelled) {
+                    return;
+                }
+
+                setState({
+                    status: 'ready',
+                    rows: response.data,
+                    errorMessage: null,
+                });
+            } catch (error: unknown) {
+                if (cancelled) {
+                    return;
+                }
+
+                setState({
+                    status: 'error',
+                    rows: [],
+                    errorMessage:
+                        error instanceof Error
+                            ? error.message
+                            : __(
+                                  'Failed to load navigation menus.',
+                                  TEXT_DOMAIN
+                              ),
+                });
+            }
+        })();
+
+        return () => {
+            cancelled = true;
+        };
+    }, [apiConfig, refreshKey]);
+
+    const locationLabelBySlug = useMemo(() => {
+        const map = new Map<string, string>();
+
+        for (const location of locations) {
+            map.set(location.slug, location.label);
+        }
+
+        return map;
+    }, [locations]);
+
+    const itemCountForRow = (row: NavigationRecord): number => {
+        return countNavigationLeaves(row.content.blocks);
+    };
+
+    return (
+        <div
+            className="ap-nav-browser"
+            data-testid="ap-nav-browser"
+        >
+            <header className="ap-nav-browser__header">
+                <h2 className="ap-nav-browser__title">
+                    {__('Menus', TEXT_DOMAIN)}
+                </h2>
+                <button
+                    type="button"
+                    className="ap-nav-browser__create"
+                    onClick={onRequestCreate}
+                    data-testid="ap-nav-browser-create"
+                >
+                    {__('Add new', TEXT_DOMAIN)}
+                </button>
+            </header>
+
+            {state.status === 'loading' ? (
+                <p className="ap-nav-browser__status" role="status">
+                    {__('Loading menus…', TEXT_DOMAIN)}
+                </p>
+            ) : null}
+
+            {state.status === 'error' ? (
+                <p className="ap-nav-browser__status" role="alert">
+                    {state.errorMessage}
+                </p>
+            ) : null}
+
+            {state.status === 'ready' && state.rows.length === 0 ? (
+                <p className="ap-nav-browser__empty">
+                    {__(
+                        'No menus yet. Create one to get started.',
+                        TEXT_DOMAIN
+                    )}
+                </p>
+            ) : null}
+
+            {state.status === 'ready' && state.rows.length > 0 ? (
+                <ul
+                    className="ap-nav-browser__list"
+                    aria-label={__('Navigation menus', TEXT_DOMAIN)}
+                >
+                    {state.rows.map((row) => {
+                        const isActive =
+                            activeEntityId !== null &&
+                            String(row.id) === activeEntityId;
+
+                        const locationLabel =
+                            row.location !== null
+                                ? locationLabelBySlug.get(row.location) ??
+                                  row.location
+                                : null;
+
+                        return (
+                            <li
+                                key={row.id}
+                                className="ap-nav-browser__row"
+                                data-active={isActive}
+                            >
+                                <button
+                                    type="button"
+                                    className="ap-nav-browser__row-button"
+                                    onClick={() => onOpen(String(row.id))}
+                                    aria-label={sprintf(
+                                        /* translators: %s: menu title or slug. */
+                                        __('Open menu: %s', TEXT_DOMAIN),
+                                        row.title.rendered === ''
+                                            ? row.slug
+                                            : row.title.rendered
+                                    )}
+                                    data-testid={`ap-nav-browser-row-${row.id}`}
+                                >
+                                    <span className="ap-nav-browser__row-title">
+                                        {row.title.rendered === ''
+                                            ? row.slug
+                                            : row.title.rendered}
+                                    </span>
+                                    <span className="ap-nav-browser__row-meta">
+                                        {locationLabel !== null
+                                            ? sprintf(
+                                                  /* translators: %s: location label. */
+                                                  __(
+                                                      'Location: %s',
+                                                      TEXT_DOMAIN
+                                                  ),
+                                                  locationLabel
+                                              )
+                                            : __(
+                                                  'No location',
+                                                  TEXT_DOMAIN
+                                              )}
+                                        {' · '}
+                                        {sprintf(
+                                            /* translators: %d: number of items. */
+                                            __('%d items', TEXT_DOMAIN),
+                                            itemCountForRow(row)
+                                        )}
+                                    </span>
+                                </button>
+                            </li>
+                        );
+                    })}
+                </ul>
+            ) : null}
+
+            <LocationsPanel
+                locations={locations}
+                isLoading={isLocationsLoading}
+                errorMessage={locationsError}
+                navigations={state.rows}
+                onAssign={onAssignLocation}
+            />
+        </div>
+    );
+}
+
+/**
+ * Recursively counts `core/navigation-link` and
+ * `core/navigation-submenu` blocks anywhere in the tree. Used as a
+ * cheap "items" stat — exact figure isn't load-bearing, just a hint.
+ */
+function countNavigationLeaves(blocks: readonly unknown[]): number {
+    let count = 0;
+
+    for (const raw of blocks) {
+        if (raw === null || typeof raw !== 'object') {
+            continue;
+        }
+
+        const block = raw as { name?: unknown; innerBlocks?: unknown };
+
+        if (block.name === 'core/navigation-link') {
+            count += 1;
+        }
+
+        if (block.name === 'core/navigation-submenu') {
+            count += 1;
+
+            if (Array.isArray(block.innerBlocks)) {
+                count += countNavigationLeaves(
+                    block.innerBlocks as readonly unknown[]
+                );
+            }
+        }
+    }
+
+    return count;
+}

--- a/resources/js/visual-editor/site-editor/navigation/navigation-canvas.css
+++ b/resources/js/visual-editor/site-editor/navigation/navigation-canvas.css
@@ -1,0 +1,188 @@
+/*
+ * Navigation canvas — native tree editor styles.
+ *
+ * Rows render in a flat <ul> (the dnd-kit "tree" recipe is depth-by-
+ * padding, not depth-by-nesting). Indentation is applied inline via
+ * `padding-left` on `.ap-nav-canvas__row` so the projected drop depth
+ * during a drag can animate without rebuilding the DOM.
+ */
+
+.ap-nav-canvas {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+	padding: 16px 20px;
+	height: 100%;
+	overflow: auto;
+	background: var(--ap-site-editor-canvas-bg, #f5f7fa);
+}
+
+.ap-nav-canvas[data-empty='true'] {
+	align-items: center;
+	justify-content: center;
+	text-align: center;
+}
+
+.ap-nav-canvas__empty {
+	max-width: 340px;
+	color: var(--ap-site-editor-muted, #4b5563);
+	margin: 0;
+}
+
+.ap-nav-canvas__tree {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+
+.ap-nav-canvas__item {
+	list-style: none;
+}
+
+/* The dragged source row carries a soft shadow + accent border so the
+ * user has clear feedback as it follows the cursor. The simpler
+ * sortable pattern (no DragOverlay) means the source row IS the
+ * visual — keeping it fully opaque is intentional. `position: relative`
+ * on the row below activates the `z-index` so the dragged row stacks
+ * above its in-place neighbors. */
+.ap-nav-canvas__item[data-dragging='true'] .ap-nav-canvas__row {
+	box-shadow: 0 8px 24px rgba(15, 23, 42, 0.18);
+	border-color: var(--ap-site-editor-accent, #1d4ed8);
+	z-index: 1;
+}
+
+.ap-nav-canvas__row {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 6px 8px;
+	background: #fff;
+	border: 1px solid var(--ap-site-editor-border, #d1d5db);
+	border-radius: 4px;
+	position: relative;
+	transition: border-color 120ms, padding-left 120ms;
+}
+
+.ap-nav-canvas__row[data-selected='true'] {
+	border-color: var(--ap-site-editor-accent, #1d4ed8);
+	box-shadow: 0 0 0 1px var(--ap-site-editor-accent, #1d4ed8);
+}
+
+.ap-nav-canvas__drag-handle {
+	cursor: grab;
+	background: transparent;
+	border: 0;
+	color: var(--ap-site-editor-muted, #4b5563);
+	font-size: 14px;
+	padding: 4px;
+	border-radius: 2px;
+}
+
+.ap-nav-canvas__drag-handle:active {
+	cursor: grabbing;
+}
+
+.ap-nav-canvas__drag-handle:focus-visible {
+	outline: 2px solid var(--ap-site-editor-accent, #1d4ed8);
+}
+
+.ap-nav-canvas__row-main {
+	flex: 1;
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	background: transparent;
+	border: 0;
+	padding: 4px;
+	cursor: pointer;
+	text-align: left;
+	min-width: 0;
+	border-radius: 3px;
+}
+
+.ap-nav-canvas__row-main:focus-visible {
+	outline: 2px solid var(--ap-site-editor-accent, #1d4ed8);
+	outline-offset: 2px;
+}
+
+.ap-nav-canvas__type {
+	font-size: 16px;
+	width: 20px;
+	text-align: center;
+	color: var(--ap-site-editor-muted, #4b5563);
+}
+
+.ap-nav-canvas__label {
+	font-weight: 500;
+	color: inherit;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	flex: 1;
+}
+
+.ap-nav-canvas__type-label {
+	font-size: 11px;
+	text-transform: uppercase;
+	color: var(--ap-site-editor-muted, #4b5563);
+	letter-spacing: 0.04em;
+}
+
+.ap-nav-canvas__row-actions {
+	display: flex;
+	gap: 4px;
+}
+
+.ap-nav-canvas__row-action {
+	font-size: 12px;
+	padding: 4px 8px;
+	background: transparent;
+	border: 1px solid transparent;
+	border-radius: 3px;
+	color: inherit;
+	cursor: pointer;
+}
+
+.ap-nav-canvas__row-action:hover {
+	border-color: var(--ap-site-editor-border, #d1d5db);
+}
+
+.ap-nav-canvas__row-action:focus-visible {
+	outline: 2px solid var(--ap-site-editor-accent, #1d4ed8);
+	outline-offset: 1px;
+	border-color: var(--ap-site-editor-border, #d1d5db);
+}
+
+.ap-nav-canvas__row-action--danger[data-confirming='true'] {
+	background: var(--ap-site-editor-error-fg, #991b1b);
+	color: #fff;
+	border-color: var(--ap-site-editor-error-fg, #991b1b);
+}
+
+.ap-nav-canvas__row-action--danger:focus-visible {
+	outline-color: var(--ap-site-editor-error-fg, #991b1b);
+	border-color: var(--ap-site-editor-error-fg, #991b1b);
+}
+
+.ap-nav-canvas__add {
+	align-self: flex-start;
+	font-size: 13px;
+	padding: 6px 12px;
+	background: var(--ap-site-editor-accent, #1d4ed8);
+	color: #fff;
+	border: 0;
+	border-radius: 4px;
+	cursor: pointer;
+}
+
+.ap-nav-canvas__add:hover {
+	filter: brightness(1.05);
+}
+
+.ap-nav-canvas__add:focus-visible {
+	outline: 2px solid var(--ap-site-editor-accent, #1d4ed8);
+	outline-offset: 2px;
+}

--- a/resources/js/visual-editor/site-editor/navigation/navigation-canvas.tsx
+++ b/resources/js/visual-editor/site-editor/navigation/navigation-canvas.tsx
@@ -1,0 +1,515 @@
+/**
+ * Navigation canvas — the native tree editor.
+ *
+ * Per design brief §3.8 the Navigation section is the one site-editor
+ * surface that ISN'T a block-editor iframe canvas: nav trees are
+ * structural data, not block trees, so a tree editor with drag-sort
+ * and a typed-target picker is the correct UI.
+ *
+ * Drag-and-drop uses the dnd-kit "tree" recipe: the nested MenuItem
+ * tree is flattened into a single sortable list, and the dragged row's
+ * horizontal offset is mapped to a projected depth so the user can
+ * drag items INTO and OUT OF submenus by dragging right / left. On
+ * commit, the active row's `depth` + `parentLocalId` are updated and
+ * then array-moved into place; descendants re-attach via their
+ * `parentLocalId` when `buildTreeFromFlat` rebuilds the nested tree.
+ */
+
+import { __, sprintf } from '@wordpress/i18n';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+    DndContext,
+    type DragEndEvent,
+    type DragMoveEvent,
+    type DragOverEvent,
+    type DragStartEvent,
+    KeyboardSensor,
+    MouseSensor,
+    TouchSensor,
+    useSensor,
+    useSensors,
+} from '@dnd-kit/core';
+import {
+    SortableContext,
+    sortableKeyboardCoordinates,
+    useSortable,
+    verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+
+import { TEXT_DOMAIN } from '../../vendor/i18n';
+import {
+    appendChild,
+    buildTreeFromFlat,
+    commitProjection,
+    effectiveLabel,
+    flattenTree,
+    getDescendantIds,
+    makeMenuItem,
+    projectDrop,
+    removeMenuItem,
+    type FlatMenuItem,
+    type MenuItem,
+    type ProjectionResult,
+} from './menu-tree';
+
+import './navigation-canvas.css';
+
+const INDENT_PX = 24;
+
+export interface NavigationCanvasProps {
+    tree: readonly MenuItem[];
+    selectedItemId: string | null;
+    onSelectItem: (localId: string | null) => void;
+    onTreeChange: (next: readonly MenuItem[]) => void;
+    /** Render an empty-state message when the menu has no items yet. */
+    emptyStateMessage?: string;
+}
+
+export function NavigationCanvas(props: NavigationCanvasProps): JSX.Element {
+    const {
+        tree,
+        selectedItemId,
+        onSelectItem,
+        onTreeChange,
+        emptyStateMessage,
+    } = props;
+
+    const sensors = useSensors(
+        useSensor(MouseSensor, { activationConstraint: { distance: 4 } }),
+        useSensor(TouchSensor),
+        useSensor(KeyboardSensor, {
+            coordinateGetter: sortableKeyboardCoordinates,
+        })
+    );
+
+    const flatTree = useMemo(() => flattenTree(tree), [tree]);
+
+    const [activeId, setActiveId] = useState<string | null>(null);
+    const [overId, setOverId] = useState<string | null>(null);
+    const [dragOffsetX, setDragOffsetX] = useState(0);
+
+    // While dragging, hide the active item's descendants from the
+    // sortable list so the dragged subtree visibly travels as a unit
+    // (the children re-attach via parentLocalId on commit). This
+    // matches the standard dnd-kit tree recipe.
+    const visibleFlat = useMemo(() => {
+        if (activeId === null) {
+            return flatTree;
+        }
+
+        const descendants = getDescendantIds(flatTree, activeId);
+
+        return flatTree.filter(
+            (entry) => !descendants.has(entry.item.localId)
+        );
+    }, [activeId, flatTree]);
+
+    const projection: ProjectionResult | null = useMemo(() => {
+        if (activeId === null || overId === null) {
+            return null;
+        }
+
+        return projectDrop(
+            visibleFlat,
+            activeId,
+            overId,
+            dragOffsetX,
+            INDENT_PX
+        );
+    }, [activeId, dragOffsetX, overId, visibleFlat]);
+
+    const sortedIds = useMemo(
+        () => visibleFlat.map((entry) => entry.item.localId),
+        [visibleFlat]
+    );
+
+    const handleDragStart = useCallback((event: DragStartEvent): void => {
+        setActiveId(String(event.active.id));
+        setOverId(String(event.active.id));
+        setDragOffsetX(0);
+    }, []);
+
+    const handleDragMove = useCallback((event: DragMoveEvent): void => {
+        setDragOffsetX(event.delta.x);
+    }, []);
+
+    const handleDragOver = useCallback((event: DragOverEvent): void => {
+        setOverId(event.over === null ? null : String(event.over.id));
+    }, []);
+
+    const reset = useCallback((): void => {
+        setActiveId(null);
+        setOverId(null);
+        setDragOffsetX(0);
+    }, []);
+
+    const handleDragEnd = useCallback(
+        (event: DragEndEvent): void => {
+            const active = String(event.active.id);
+            const over = event.over === null ? null : String(event.over.id);
+
+            reset();
+
+            if (over === null || projection === null) {
+                return;
+            }
+
+            const updated = commitProjection(
+                flatTree,
+                active,
+                over,
+                projection
+            );
+
+            onTreeChange(buildTreeFromFlat(updated));
+        },
+        [flatTree, onTreeChange, projection, reset]
+    );
+
+    const handleDragCancel = useCallback((): void => {
+        reset();
+    }, [reset]);
+
+    const handleAddItem = useCallback((): void => {
+        const fresh = makeMenuItem({
+            type: 'custom',
+            url: '',
+            autoLabel: __('New menu item', TEXT_DOMAIN),
+        });
+
+        onTreeChange([...tree, fresh]);
+        onSelectItem(fresh.localId);
+    }, [onSelectItem, onTreeChange, tree]);
+
+    const handleAddChild = useCallback(
+        (parentId: string): void => {
+            const fresh = makeMenuItem({
+                type: 'custom',
+                url: '',
+                autoLabel: __('New menu item', TEXT_DOMAIN),
+            });
+
+            onTreeChange(appendChild(tree, parentId, fresh));
+            onSelectItem(fresh.localId);
+        },
+        [onSelectItem, onTreeChange, tree]
+    );
+
+    const handleDelete = useCallback(
+        (localId: string): void => {
+            onTreeChange(removeMenuItem(tree, localId));
+
+            if (selectedItemId === localId) {
+                onSelectItem(null);
+            }
+        },
+        [onSelectItem, onTreeChange, selectedItemId, tree]
+    );
+
+    if (tree.length === 0) {
+        return (
+            <div
+                className="ap-nav-canvas"
+                data-testid="ap-nav-canvas"
+                data-empty="true"
+            >
+                <p className="ap-nav-canvas__empty">
+                    {emptyStateMessage ??
+                        __(
+                            'This menu is empty. Add the first link to get started.',
+                            TEXT_DOMAIN
+                        )}
+                </p>
+                <button
+                    type="button"
+                    className="ap-nav-canvas__add"
+                    onClick={handleAddItem}
+                    data-testid="ap-nav-canvas-add"
+                >
+                    {__('Add menu item', TEXT_DOMAIN)}
+                </button>
+            </div>
+        );
+    }
+
+    return (
+        <div
+            className="ap-nav-canvas"
+            data-testid="ap-nav-canvas"
+            data-empty="false"
+        >
+            <DndContext
+                sensors={sensors}
+                onDragStart={handleDragStart}
+                onDragMove={handleDragMove}
+                onDragOver={handleDragOver}
+                onDragEnd={handleDragEnd}
+                onDragCancel={handleDragCancel}
+            >
+                <SortableContext
+                    items={sortedIds}
+                    strategy={verticalListSortingStrategy}
+                >
+                    <ul
+                        className="ap-nav-canvas__tree"
+                        role="tree"
+                        aria-label={__('Menu items', TEXT_DOMAIN)}
+                    >
+                        {visibleFlat.map((entry) => (
+                            <SortableMenuItemRow
+                                key={entry.item.localId}
+                                flat={entry}
+                                projection={
+                                    activeId === entry.item.localId
+                                        ? projection
+                                        : null
+                                }
+                                indentPx={INDENT_PX}
+                                selectedItemId={selectedItemId}
+                                onSelect={onSelectItem}
+                                onAddChild={handleAddChild}
+                                onDelete={handleDelete}
+                            />
+                        ))}
+                    </ul>
+                </SortableContext>
+            </DndContext>
+
+            <button
+                type="button"
+                className="ap-nav-canvas__add"
+                onClick={handleAddItem}
+                data-testid="ap-nav-canvas-add"
+            >
+                {__('Add menu item', TEXT_DOMAIN)}
+            </button>
+        </div>
+    );
+}
+
+interface SortableMenuItemRowProps {
+    flat: FlatMenuItem;
+    projection: ProjectionResult | null;
+    indentPx: number;
+    selectedItemId: string | null;
+    onSelect: (localId: string | null) => void;
+    onAddChild: (parentId: string) => void;
+    onDelete: (localId: string) => void;
+}
+
+function SortableMenuItemRow(props: SortableMenuItemRowProps): JSX.Element {
+    const {
+        flat,
+        projection,
+        indentPx,
+        selectedItemId,
+        onSelect,
+        onAddChild,
+        onDelete,
+    } = props;
+
+    const sortable = useSortable({ id: flat.item.localId });
+
+    const style = {
+        transform: CSS.Translate.toString(sortable.transform),
+        transition: sortable.transition,
+    };
+
+    // Live depth follows the projection while a drag is in progress
+    // so the user sees the row indent / outdent under the cursor.
+    const renderDepth =
+        sortable.isDragging && projection !== null
+            ? projection.depth
+            : flat.depth;
+
+    const renderFlat: FlatMenuItem = {
+        ...flat,
+        depth: renderDepth,
+    };
+
+    return (
+        <li
+            ref={sortable.setNodeRef}
+            style={style}
+            className="ap-nav-canvas__item"
+            role="treeitem"
+            aria-level={renderDepth + 1}
+            aria-selected={selectedItemId === flat.item.localId}
+            data-testid={`ap-nav-canvas-item-${flat.item.localId}`}
+            data-dragging={sortable.isDragging}
+        >
+            <MenuItemRowBody
+                flat={renderFlat}
+                indentPx={indentPx}
+                selectedItemId={selectedItemId}
+                onSelect={onSelect}
+                onAddChild={onAddChild}
+                onDelete={onDelete}
+                dragHandleProps={{
+                    ...sortable.attributes,
+                    ...sortable.listeners,
+                }}
+            />
+        </li>
+    );
+}
+
+interface RowBodyProps {
+    flat: FlatMenuItem;
+    indentPx: number;
+    selectedItemId: string | null;
+    onSelect: (localId: string | null) => void;
+    onAddChild: (parentId: string) => void;
+    onDelete: (localId: string) => void;
+    dragHandleProps?: Record<string, unknown>;
+}
+
+function MenuItemRowBody(props: RowBodyProps): JSX.Element {
+    const {
+        flat,
+        indentPx,
+        selectedItemId,
+        onSelect,
+        onAddChild,
+        onDelete,
+        dragHandleProps,
+    } = props;
+
+    const item = flat.item;
+    const [confirmingDelete, setConfirmingDelete] = useState(false);
+
+    // Auto-revert the confirm state after a short window. Without this
+    // a user who clicks Delete once and walks away would find the row
+    // armed for a one-click destruction whenever they came back.
+    useEffect(() => {
+        if (!confirmingDelete) {
+            return undefined;
+        }
+
+        const handle = window.setTimeout(() => {
+            setConfirmingDelete(false);
+        }, 4000);
+
+        return () => window.clearTimeout(handle);
+    }, [confirmingDelete]);
+
+    const isSelected = selectedItemId === item.localId;
+    const label = effectiveLabel(item);
+    const visibleLabel =
+        label === '' ? __('(Untitled item)', TEXT_DOMAIN) : label;
+
+    const handleDeleteClick = useCallback((): void => {
+        if (!confirmingDelete) {
+            setConfirmingDelete(true);
+            return;
+        }
+
+        onDelete(item.localId);
+    }, [confirmingDelete, item.localId, onDelete]);
+
+    const handleSelect = useCallback((): void => {
+        onSelect(item.localId);
+    }, [item.localId, onSelect]);
+
+    const targetIcon = typeIcon(item.type);
+
+    return (
+        <div
+            className="ap-nav-canvas__row"
+            data-selected={isSelected}
+            data-depth={flat.depth}
+            style={{ paddingLeft: flat.depth * indentPx }}
+        >
+            {dragHandleProps !== undefined ? (
+                <button
+                    type="button"
+                    className="ap-nav-canvas__drag-handle"
+                    aria-label={sprintf(
+                        /* translators: %s: menu item label. */
+                        __('Drag to reorder %s', TEXT_DOMAIN),
+                        visibleLabel
+                    )}
+                    data-testid={`ap-nav-canvas-drag-${item.localId}`}
+                    {...dragHandleProps}
+                >
+                    {'⋮⋮'}
+                </button>
+            ) : null}
+            <button
+                type="button"
+                className="ap-nav-canvas__row-main"
+                onClick={handleSelect}
+                aria-pressed={isSelected}
+                data-testid={`ap-nav-canvas-row-${item.localId}`}
+            >
+                <span className="ap-nav-canvas__type" aria-hidden="true">
+                    {targetIcon}
+                </span>
+                <span className="ap-nav-canvas__label">{visibleLabel}</span>
+                <span className="ap-nav-canvas__type-label">
+                    {typeLabel(item.type)}
+                </span>
+            </button>
+            <span className="ap-nav-canvas__row-actions">
+                <button
+                    type="button"
+                    className="ap-nav-canvas__row-action"
+                    onClick={() => onAddChild(item.localId)}
+                    aria-label={sprintf(
+                        /* translators: %s: parent label. */
+                        __('Add child of %s', TEXT_DOMAIN),
+                        visibleLabel
+                    )}
+                    data-testid={`ap-nav-canvas-add-child-${item.localId}`}
+                >
+                    {__('Add child', TEXT_DOMAIN)}
+                </button>
+                <button
+                    type="button"
+                    className="ap-nav-canvas__row-action ap-nav-canvas__row-action--danger"
+                    onClick={handleDeleteClick}
+                    aria-label={sprintf(
+                        /* translators: %s: menu item label. */
+                        __('Delete %s', TEXT_DOMAIN),
+                        visibleLabel
+                    )}
+                    data-confirming={confirmingDelete}
+                    data-testid={`ap-nav-canvas-delete-${item.localId}`}
+                >
+                    {confirmingDelete
+                        ? __('Confirm delete', TEXT_DOMAIN)
+                        : __('Delete', TEXT_DOMAIN)}
+                </button>
+            </span>
+        </div>
+    );
+}
+
+function typeIcon(type: MenuItem['type']): string {
+    if (type === 'page') {
+        return '▤';
+    }
+    if (type === 'post') {
+        return '✎';
+    }
+    if (type === 'taxonomy') {
+        return '🏷';
+    }
+
+    return '↗';
+}
+
+function typeLabel(type: MenuItem['type']): string {
+    if (type === 'page') {
+        return __('Page', TEXT_DOMAIN);
+    }
+    if (type === 'post') {
+        return __('Post', TEXT_DOMAIN);
+    }
+    if (type === 'taxonomy') {
+        return __('Taxonomy', TEXT_DOMAIN);
+    }
+
+    return __('Custom URL', TEXT_DOMAIN);
+}

--- a/resources/js/visual-editor/site-editor/navigation/navigation-inspector.css
+++ b/resources/js/visual-editor/site-editor/navigation/navigation-inspector.css
@@ -1,0 +1,113 @@
+/*
+ * Navigation inspector — nav-specific layout only.
+ *
+ * Form fields (input, select, textarea, label, error, help) reuse the
+ * shared `.ap-site-editor__dialog-*` classes from
+ * `create-entity-dialog.css` so the templates / parts inspector and
+ * the navigation inspector render identical controls. This file only
+ * holds the bits that are nav-specific: the scope header, the
+ * link-picker results list, and the advanced details disclosure.
+ */
+
+.ap-nav-inspector {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+	padding: 16px;
+	height: 100%;
+	overflow: auto;
+	background: var(--ap-site-editor-sidebar-bg, #fff);
+}
+
+.ap-nav-inspector__header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 8px;
+	padding-bottom: 8px;
+	border-bottom: 1px solid var(--ap-site-editor-border, #e5e7eb);
+}
+
+.ap-nav-inspector__scope {
+	font-size: 11px;
+	font-weight: 600;
+	letter-spacing: 0.06em;
+	text-transform: uppercase;
+	color: var(--ap-site-editor-muted, #4b5563);
+}
+
+.ap-nav-inspector__back {
+	background: transparent;
+	border: 0;
+	color: var(--ap-site-editor-accent, #1d4ed8);
+	cursor: pointer;
+	font-size: 12px;
+	padding: 2px 4px;
+}
+
+.ap-nav-inspector__field-checkbox {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	font-size: 13px;
+}
+
+.ap-nav-inspector__results {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	max-height: 240px;
+	overflow: auto;
+	border: 1px solid var(--ap-site-editor-border, #d1d5db);
+	border-radius: 4px;
+}
+
+.ap-nav-inspector__result {
+	border-bottom: 1px solid var(--ap-site-editor-border, #e5e7eb);
+}
+
+.ap-nav-inspector__result:last-child {
+	border-bottom: 0;
+}
+
+.ap-nav-inspector__result-button {
+	width: 100%;
+	text-align: left;
+	background: transparent;
+	border: 0;
+	padding: 8px 10px;
+	font-size: 13px;
+	cursor: pointer;
+}
+
+.ap-nav-inspector__result-button:hover {
+	background: var(--ap-site-editor-canvas-bg, #f5f7fa);
+}
+
+.ap-nav-inspector__result-button[data-selected='true'] {
+	background: var(--ap-site-editor-accent, #1d4ed8);
+	color: #fff;
+}
+
+.ap-nav-inspector__result-empty {
+	padding: 8px 10px;
+	font-size: 12px;
+	color: var(--ap-site-editor-muted, #6b7280);
+}
+
+.ap-nav-inspector__advanced summary {
+	font-size: 13px;
+	cursor: pointer;
+	padding: 4px 0;
+	color: var(--ap-site-editor-muted, #4b5563);
+}
+
+.ap-nav-inspector__advanced[open] summary {
+	color: inherit;
+}
+
+.ap-nav-inspector__advanced[open] {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+}

--- a/resources/js/visual-editor/site-editor/navigation/navigation-inspector.tsx
+++ b/resources/js/visual-editor/site-editor/navigation/navigation-inspector.tsx
@@ -1,0 +1,410 @@
+/**
+ * Navigation inspector.
+ *
+ * Two scopes per design brief §3.9:
+ *   - Entity panel: name, slug, location assignment dropdown.
+ *   - Item panel: link picker (type + entity / URL), label override,
+ *     advanced (CSS class, rel, open in new tab).
+ *
+ * The shell hands us the active selection — `selectedItemId === null`
+ * means the entity panel is active; otherwise we render the item panel
+ * for the matching MenuItem. A separate "Locations" panel (rendered by
+ * `LocationsPanel`) lives in the navigator outlet for cross-menu views.
+ *
+ * Field markup uses the shared `.ap-site-editor__dialog-*` classes so
+ * inputs / selects / textareas match the templates and template-parts
+ * inspector exactly. Nav-specific layout (the scope header, the
+ * link-picker results list) lives in `navigation-inspector.css`.
+ */
+
+import { __, sprintf } from '@wordpress/i18n';
+import { useId, useMemo } from 'react';
+
+import { TEXT_DOMAIN } from '../../vendor/i18n';
+
+import type { SiteEditorApiConfig, ValidationErrors } from '../api-client';
+import { LinkPicker } from './link-picker';
+import {
+    findMenuItem,
+    replaceMenuItem,
+    type MenuItem,
+} from './menu-tree';
+import type { MenuLocation } from './api-client';
+import type { NavigationEntityFields } from './use-navigation-editor';
+
+import './navigation-inspector.css';
+
+export interface NavigationInspectorProps {
+    apiConfig: SiteEditorApiConfig;
+    fields: NavigationEntityFields;
+    onFieldsChange: (
+        update: Partial<NavigationEntityFields>
+    ) => void;
+    tree: readonly MenuItem[];
+    onTreeChange: (next: readonly MenuItem[]) => void;
+    selectedItemId: string | null;
+    onSelectItem: (localId: string | null) => void;
+    locations: readonly MenuLocation[];
+    isLocationsLoading: boolean;
+    locationsError: string | null;
+    validationErrors: ValidationErrors | null;
+    saveStatus: 'idle' | 'saving' | 'saved' | 'error';
+    saveErrorMessage: string | null;
+}
+
+export function NavigationInspector(
+    props: NavigationInspectorProps
+): JSX.Element {
+    const {
+        apiConfig,
+        fields,
+        onFieldsChange,
+        tree,
+        onTreeChange,
+        selectedItemId,
+        onSelectItem,
+        locations,
+        isLocationsLoading,
+        locationsError,
+        validationErrors,
+        saveErrorMessage,
+        saveStatus,
+    } = props;
+
+    const selectedItem = useMemo(
+        () =>
+            selectedItemId === null ? null : findMenuItem(tree, selectedItemId),
+        [selectedItemId, tree]
+    );
+
+    const handleItemPatch = (patch: Partial<MenuItem>): void => {
+        if (selectedItem === null) {
+            return;
+        }
+
+        onTreeChange(
+            replaceMenuItem(tree, selectedItem.localId, (item) => ({
+                ...item,
+                ...patch,
+            }))
+        );
+    };
+
+    return (
+        <aside
+            className="ap-nav-inspector"
+            data-testid="ap-nav-inspector"
+            data-scope={selectedItem === null ? 'entity' : 'item'}
+            aria-label={__('Navigation inspector', TEXT_DOMAIN)}
+        >
+            <header className="ap-nav-inspector__header">
+                <span className="ap-nav-inspector__scope">
+                    {selectedItem === null
+                        ? __('Menu', TEXT_DOMAIN)
+                        : __('Menu item', TEXT_DOMAIN)}
+                </span>
+                {selectedItem !== null ? (
+                    <button
+                        type="button"
+                        className="ap-nav-inspector__back"
+                        onClick={() => onSelectItem(null)}
+                        data-testid="ap-nav-inspector-back"
+                    >
+                        {__('← Menu settings', TEXT_DOMAIN)}
+                    </button>
+                ) : null}
+            </header>
+
+            {saveStatus === 'error' && saveErrorMessage !== null ? (
+                <p
+                    className="ap-site-editor__dialog-error"
+                    role="alert"
+                >
+                    {saveErrorMessage}
+                </p>
+            ) : null}
+
+            {selectedItem === null ? (
+                <EntityPanel
+                    fields={fields}
+                    onFieldsChange={onFieldsChange}
+                    locations={locations}
+                    isLocationsLoading={isLocationsLoading}
+                    locationsError={locationsError}
+                    validationErrors={validationErrors}
+                />
+            ) : (
+                <ItemPanel
+                    apiConfig={apiConfig}
+                    item={selectedItem}
+                    onPatch={handleItemPatch}
+                />
+            )}
+        </aside>
+    );
+}
+
+interface EntityPanelProps {
+    fields: NavigationEntityFields;
+    onFieldsChange: (update: Partial<NavigationEntityFields>) => void;
+    locations: readonly MenuLocation[];
+    isLocationsLoading: boolean;
+    locationsError: string | null;
+    validationErrors: ValidationErrors | null;
+}
+
+function EntityPanel(props: EntityPanelProps): JSX.Element {
+    const {
+        fields,
+        onFieldsChange,
+        locations,
+        isLocationsLoading,
+        locationsError,
+        validationErrors,
+    } = props;
+
+    const titleId = useId();
+    const slugId = useId();
+    const locationId = useId();
+
+    const titleError = validationErrors?.title?.[0];
+    const slugError = validationErrors?.slug?.[0];
+    const locationError = validationErrors?.location?.[0];
+
+    return (
+        <div className="ap-site-editor__inspector-panel">
+            <div className="ap-site-editor__dialog-field">
+                <label
+                    className="ap-site-editor__dialog-label"
+                    htmlFor={titleId}
+                >
+                    {__('Name', TEXT_DOMAIN)}
+                </label>
+                <input
+                    id={titleId}
+                    type="text"
+                    className="ap-site-editor__dialog-input"
+                    value={fields.title}
+                    onChange={(event) =>
+                        onFieldsChange({ title: event.target.value })
+                    }
+                    data-testid="ap-nav-inspector-title"
+                />
+                {titleError !== undefined ? (
+                    <p
+                        className="ap-site-editor__dialog-field-error"
+                        role="alert"
+                    >
+                        {titleError}
+                    </p>
+                ) : null}
+            </div>
+
+            <div className="ap-site-editor__dialog-field">
+                <label
+                    className="ap-site-editor__dialog-label"
+                    htmlFor={slugId}
+                >
+                    {__('Slug', TEXT_DOMAIN)}
+                </label>
+                <input
+                    id={slugId}
+                    type="text"
+                    className="ap-site-editor__dialog-input"
+                    value={fields.slug}
+                    onChange={(event) =>
+                        onFieldsChange({ slug: event.target.value })
+                    }
+                    data-testid="ap-nav-inspector-slug"
+                />
+                {slugError !== undefined ? (
+                    <p
+                        className="ap-site-editor__dialog-field-error"
+                        role="alert"
+                    >
+                        {slugError}
+                    </p>
+                ) : null}
+            </div>
+
+            <div className="ap-site-editor__dialog-field">
+                <label
+                    className="ap-site-editor__dialog-label"
+                    htmlFor={locationId}
+                >
+                    {__('Location', TEXT_DOMAIN)}
+                </label>
+                <select
+                    id={locationId}
+                    className="ap-site-editor__dialog-select"
+                    value={fields.location ?? ''}
+                    onChange={(event) =>
+                        onFieldsChange({
+                            location:
+                                event.target.value === ''
+                                    ? null
+                                    : event.target.value,
+                        })
+                    }
+                    disabled={isLocationsLoading}
+                    data-testid="ap-nav-inspector-location"
+                >
+                    <option value="">
+                        {__('— No location —', TEXT_DOMAIN)}
+                    </option>
+                    {locations.map((location) => (
+                        <option
+                            key={location.slug}
+                            value={location.slug}
+                        >
+                            {location.label}
+                        </option>
+                    ))}
+                </select>
+                {locationsError !== null ? (
+                    <p
+                        className="ap-site-editor__dialog-field-error"
+                        role="alert"
+                    >
+                        {locationsError}
+                    </p>
+                ) : null}
+                {locationError !== undefined ? (
+                    <p
+                        className="ap-site-editor__dialog-field-error"
+                        role="alert"
+                    >
+                        {locationError}
+                    </p>
+                ) : null}
+                <p className="ap-site-editor__dialog-field-help">
+                    {__(
+                        'Locations are declared in `config/artisanpack/visual-editor.php`. Assigning here writes to this menu only.',
+                        TEXT_DOMAIN
+                    )}
+                </p>
+            </div>
+        </div>
+    );
+}
+
+interface ItemPanelProps {
+    apiConfig: SiteEditorApiConfig;
+    item: MenuItem;
+    onPatch: (patch: Partial<MenuItem>) => void;
+}
+
+function ItemPanel(props: ItemPanelProps): JSX.Element {
+    const { apiConfig, item, onPatch } = props;
+    const labelId = useId();
+    const classId = useId();
+    const relId = useId();
+    const newTabId = useId();
+
+    const placeholderHelp = sprintf(
+        /* translators: %s: auto-derived label. */
+        __('Defaults to: %s', TEXT_DOMAIN),
+        item.autoLabel === '' ? __('(no label)', TEXT_DOMAIN) : item.autoLabel
+    );
+
+    return (
+        <div className="ap-site-editor__inspector-panel">
+            <LinkPicker apiConfig={apiConfig} item={item} onChange={onPatch} />
+
+            <div className="ap-site-editor__dialog-field">
+                <label
+                    className="ap-site-editor__dialog-label"
+                    htmlFor={labelId}
+                >
+                    {__('Label', TEXT_DOMAIN)}
+                </label>
+                <input
+                    id={labelId}
+                    type="text"
+                    className="ap-site-editor__dialog-input"
+                    value={item.labelOverride ?? ''}
+                    placeholder={item.autoLabel}
+                    onChange={(event) =>
+                        onPatch({
+                            labelOverride:
+                                event.target.value === ''
+                                    ? null
+                                    : event.target.value,
+                        })
+                    }
+                    data-testid="ap-nav-inspector-label"
+                />
+                <p className="ap-site-editor__dialog-field-help">
+                    {placeholderHelp}
+                </p>
+            </div>
+
+            <div className="ap-site-editor__dialog-field">
+                <label className="ap-nav-inspector__field-checkbox">
+                    <input
+                        id={newTabId}
+                        type="checkbox"
+                        checked={item.opensInNewTab}
+                        onChange={(event) =>
+                            onPatch({ opensInNewTab: event.target.checked })
+                        }
+                        data-testid="ap-nav-inspector-new-tab"
+                    />
+                    {__('Open in new tab', TEXT_DOMAIN)}
+                </label>
+            </div>
+
+            <details className="ap-nav-inspector__advanced">
+                <summary>{__('Advanced', TEXT_DOMAIN)}</summary>
+
+                <div className="ap-site-editor__dialog-field">
+                    <label
+                        className="ap-site-editor__dialog-label"
+                        htmlFor={classId}
+                    >
+                        {__('CSS class', TEXT_DOMAIN)}
+                    </label>
+                    <input
+                        id={classId}
+                        type="text"
+                        className="ap-site-editor__dialog-input"
+                        value={item.className ?? ''}
+                        onChange={(event) =>
+                            onPatch({
+                                className:
+                                    event.target.value === ''
+                                        ? null
+                                        : event.target.value,
+                            })
+                        }
+                        data-testid="ap-nav-inspector-class"
+                    />
+                </div>
+
+                <div className="ap-site-editor__dialog-field">
+                    <label
+                        className="ap-site-editor__dialog-label"
+                        htmlFor={relId}
+                    >
+                        {__('Rel', TEXT_DOMAIN)}
+                    </label>
+                    <input
+                        id={relId}
+                        type="text"
+                        className="ap-site-editor__dialog-input"
+                        value={item.rel ?? ''}
+                        onChange={(event) =>
+                            onPatch({
+                                rel:
+                                    event.target.value === ''
+                                        ? null
+                                        : event.target.value,
+                            })
+                        }
+                        data-testid="ap-nav-inspector-rel"
+                    />
+                </div>
+            </details>
+        </div>
+    );
+}

--- a/resources/js/visual-editor/site-editor/navigation/navigation-section.tsx
+++ b/resources/js/visual-editor/site-editor/navigation/navigation-section.tsx
@@ -1,0 +1,344 @@
+/**
+ * Navigation section orchestrator.
+ *
+ * Parallel to `useStylesSectionViews` but for the D4 menu editor.
+ * Combines:
+ *   - the menu list + locations panel (navigator outlet)
+ *   - the native tree editor (canvas outlet)
+ *   - the inspector (entity OR item panel)
+ *
+ * Surfaces the entity-state contract the shell's top-bar Save button
+ * already knows how to render, so wiring D4 in is just the same
+ * `useNavigationSectionViews({ ... })` shape D3 uses.
+ */
+
+import { __ } from '@wordpress/i18n';
+import {
+    useCallback,
+    useEffect,
+    useMemo,
+    useState,
+    type ReactElement,
+} from 'react';
+
+import { TEXT_DOMAIN } from '../../vendor/i18n';
+import type {
+    SiteEditorApiConfig,
+} from '../api-client';
+import type { EntityEditorState } from '../entity-editor';
+import {
+    fetchMenuLocations,
+    listNavigations,
+    updateNavigation,
+    type MenuLocation,
+    type NavigationRecord,
+} from './api-client';
+import { CreateMenuDialog } from './create-menu-dialog';
+import { NavigationBrowser } from './navigation-browser';
+import { NavigationCanvas } from './navigation-canvas';
+import { NavigationInspector } from './navigation-inspector';
+import { useNavigationEditor } from './use-navigation-editor';
+
+export interface UseNavigationSectionViewsOptions {
+    apiConfig: SiteEditorApiConfig;
+    enabled: boolean;
+    activeEntityId: string | null;
+    onOpenEntity: (entityId: string) => void;
+    onStateChange: (state: EntityEditorState) => void;
+}
+
+export interface NavigationSectionViews {
+    navigator: ReactElement;
+    canvas: ReactElement;
+    inspector: ReactElement;
+    /** Modal layer the shell renders alongside the existing dialogs. */
+    overlay: ReactElement | null;
+}
+
+export function useNavigationSectionViews(
+    options: UseNavigationSectionViewsOptions
+): NavigationSectionViews {
+    const {
+        apiConfig,
+        enabled,
+        activeEntityId,
+        onOpenEntity,
+        onStateChange,
+    } = options;
+
+    const [locations, setLocations] = useState<readonly MenuLocation[]>([]);
+    const [isLocationsLoading, setIsLocationsLoading] = useState(false);
+    const [locationsError, setLocationsError] = useState<string | null>(null);
+    const [browserRefreshKey, setBrowserRefreshKey] = useState(0);
+    const [locationsRefreshKey, setLocationsRefreshKey] = useState(0);
+    const [showCreateDialog, setShowCreateDialog] = useState(false);
+    const [selectedItemId, setSelectedItemId] = useState<string | null>(null);
+
+    useEffect(() => {
+        if (!enabled) {
+            return undefined;
+        }
+
+        let cancelled = false;
+        setIsLocationsLoading(true);
+        setLocationsError(null);
+
+        (async () => {
+            try {
+                const data = await fetchMenuLocations(apiConfig);
+
+                if (cancelled) {
+                    return;
+                }
+
+                setLocations(data);
+            } catch (error: unknown) {
+                if (cancelled) {
+                    return;
+                }
+
+                setLocationsError(
+                    error instanceof Error
+                        ? error.message
+                        : __('Failed to load menu locations.', TEXT_DOMAIN)
+                );
+            } finally {
+                if (!cancelled) {
+                    setIsLocationsLoading(false);
+                }
+            }
+        })();
+
+        return () => {
+            cancelled = true;
+        };
+    }, [apiConfig, enabled, locationsRefreshKey]);
+
+    const editor = useNavigationEditor({
+        apiConfig,
+        entityId: enabled ? activeEntityId : null,
+    });
+
+    // Reset selected item whenever the user opens a different menu so
+    // the inspector doesn't keep highlighting an id that's no longer in
+    // the tree.
+    useEffect(() => {
+        setSelectedItemId(null);
+    }, [activeEntityId]);
+
+    // Push state into the shell's slot. Same shape D3's hook uses so
+    // the top bar's "Save menu" button hits our save dispatcher
+    // without any conditional branching.
+    useEffect(() => {
+        if (!enabled) {
+            onStateChange({
+                entityId: null,
+                entityTitle: '',
+                isDirty: false,
+                saveStatus: 'idle',
+                saveErrorMessage: null,
+                lastSavedAt: null,
+                save: null,
+            });
+            return;
+        }
+
+        onStateChange({
+            entityId:
+                editor.entity === null ? null : String(editor.entity.id),
+            entityTitle:
+                editor.fields.title === ''
+                    ? editor.fields.slug
+                    : editor.fields.title,
+            isDirty: editor.isDirty,
+            saveStatus: editor.saveStatus,
+            saveErrorMessage: editor.saveErrorMessage,
+            lastSavedAt: editor.lastSavedAt,
+            save:
+                editor.entity === null
+                    ? null
+                    : async (): Promise<void> => {
+                          const updated = await editor.save();
+
+                          if (updated !== null) {
+                              // Bump both refresh keys so the navigator
+                              // list reflects renames / location moves
+                              // and the locations panel updates the
+                              // assignment chip.
+                              setBrowserRefreshKey((value) => value + 1);
+                              setLocationsRefreshKey((value) => value + 1);
+                          }
+                      },
+        });
+    }, [
+        editor.entity,
+        editor.fields.slug,
+        editor.fields.title,
+        editor.isDirty,
+        editor.lastSavedAt,
+        editor.save,
+        editor.saveErrorMessage,
+        editor.saveStatus,
+        enabled,
+        onStateChange,
+    ]);
+
+    const handleAssignLocation = useCallback(
+        async (
+            locationSlug: string,
+            navigationId: number | null
+        ): Promise<void> => {
+            // Two-step write semantics: the chosen menu gets the new
+            // slug; whoever already had the slug is released by the
+            // backend. If the user picked "None" we still need to find
+            // the current owner and clear it.
+            try {
+                if (navigationId === null) {
+                    // Find the current owner by slug. List response is
+                    // already paginated to 50 — V1 menus list is
+                    // small, no need to paginate further.
+                    const list = await listNavigations(apiConfig, {
+                        perPage: 50,
+                    });
+                    const current = list.data.find(
+                        (row) => row.location === locationSlug
+                    );
+
+                    if (current !== undefined) {
+                        await updateNavigation(apiConfig, current.id, {
+                            location: null,
+                        });
+                    }
+                } else {
+                    await updateNavigation(apiConfig, navigationId, {
+                        location: locationSlug,
+                    });
+                }
+
+                setBrowserRefreshKey((value) => value + 1);
+                setLocationsRefreshKey((value) => value + 1);
+            } catch (error: unknown) {
+                setLocationsError(
+                    error instanceof Error
+                        ? error.message
+                        : __(
+                              'Failed to update menu location.',
+                              TEXT_DOMAIN
+                          )
+                );
+            }
+        },
+        [apiConfig]
+    );
+
+    const navigator = (
+        <NavigationBrowser
+            apiConfig={apiConfig}
+            activeEntityId={activeEntityId}
+            onOpen={onOpenEntity}
+            onRequestCreate={() => setShowCreateDialog(true)}
+            refreshKey={browserRefreshKey}
+            locations={locations}
+            isLocationsLoading={isLocationsLoading}
+            locationsError={locationsError}
+            onAssignLocation={handleAssignLocation}
+        />
+    );
+
+    const canvas = useMemo(() => {
+        if (activeEntityId === null) {
+            return (
+                <div
+                    className="ap-nav-canvas ap-nav-canvas--empty-shell"
+                    data-empty="true"
+                    data-testid="ap-nav-canvas-empty-shell"
+                >
+                    <p className="ap-nav-canvas__empty">
+                        {__(
+                            'Open a menu from the list to start editing.',
+                            TEXT_DOMAIN
+                        )}
+                    </p>
+                </div>
+            );
+        }
+
+        if (editor.loadStatus === 'loading') {
+            return (
+                <div
+                    className="ap-nav-canvas"
+                    data-testid="ap-nav-canvas-loading"
+                >
+                    <p className="ap-nav-canvas__empty">
+                        {__('Loading menu…', TEXT_DOMAIN)}
+                    </p>
+                </div>
+            );
+        }
+
+        if (editor.loadStatus === 'error') {
+            return (
+                <div
+                    className="ap-nav-canvas"
+                    role="alert"
+                    data-testid="ap-nav-canvas-error"
+                >
+                    <p className="ap-nav-canvas__empty">
+                        {editor.loadErrorMessage ??
+                            __('Failed to load menu.', TEXT_DOMAIN)}
+                    </p>
+                </div>
+            );
+        }
+
+        return (
+            <NavigationCanvas
+                tree={editor.tree}
+                selectedItemId={selectedItemId}
+                onSelectItem={setSelectedItemId}
+                onTreeChange={editor.setTree}
+            />
+        );
+    }, [
+        activeEntityId,
+        editor.loadErrorMessage,
+        editor.loadStatus,
+        editor.setTree,
+        editor.tree,
+        selectedItemId,
+    ]);
+
+    const inspector = (
+        <NavigationInspector
+            apiConfig={apiConfig}
+            fields={editor.fields}
+            onFieldsChange={editor.setFields}
+            tree={editor.tree}
+            onTreeChange={editor.setTree}
+            selectedItemId={selectedItemId}
+            onSelectItem={setSelectedItemId}
+            locations={locations}
+            isLocationsLoading={isLocationsLoading}
+            locationsError={locationsError}
+            validationErrors={editor.validationErrors}
+            saveStatus={editor.saveStatus}
+            saveErrorMessage={editor.saveErrorMessage}
+        />
+    );
+
+    const overlay = showCreateDialog ? (
+        <CreateMenuDialog
+            apiConfig={apiConfig}
+            locations={locations}
+            onClose={() => setShowCreateDialog(false)}
+            onCreated={(record) => {
+                setShowCreateDialog(false);
+                setBrowserRefreshKey((value) => value + 1);
+                setLocationsRefreshKey((value) => value + 1);
+                onOpenEntity(String(record.id));
+            }}
+        />
+    ) : null;
+
+    return { navigator, canvas, inspector, overlay };
+}

--- a/resources/js/visual-editor/site-editor/navigation/use-navigation-editor.ts
+++ b/resources/js/visual-editor/site-editor/navigation/use-navigation-editor.ts
@@ -1,0 +1,332 @@
+/**
+ * Navigation editor state hook.
+ *
+ * Parallel to `useEntityEditor` (templates / parts) but shaped around
+ * the native MenuItem tree the D4 canvas works with rather than a
+ * Gutenberg block tree. The hook handles loading, dirty-state
+ * tracking, and saving — the canvas component owns the tree
+ * mutations and dispatches them through `setTree`.
+ */
+
+import { __ } from '@wordpress/i18n';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { TEXT_DOMAIN } from '../../vendor/i18n';
+import { SiteEditorApiError } from '../api-client';
+import type {
+    NavigationRecord,
+    NavigationUpdatePayload,
+} from './api-client';
+import { fetchNavigation, updateNavigation } from './api-client';
+import {
+    blocksToMenuTree,
+    menuTreeToBlocks,
+    type MenuItem,
+} from './menu-tree';
+
+import type { SiteEditorApiConfig } from '../api-client';
+import type { ValidationErrors } from '../api-client';
+
+export type SaveStatus = 'idle' | 'saving' | 'saved' | 'error';
+export type LoadStatus = 'idle' | 'loading' | 'ready' | 'error';
+
+export interface UseNavigationEditorOptions {
+    apiConfig: SiteEditorApiConfig;
+    /** `null` = no menu open — hook stays idle. */
+    entityId: string | null;
+}
+
+export interface NavigationEntityFields {
+    title: string;
+    slug: string;
+    location: string | null;
+}
+
+export interface UseNavigationEditorResult {
+    entity: NavigationRecord | null;
+    loadStatus: LoadStatus;
+    loadErrorMessage: string | null;
+
+    tree: readonly MenuItem[];
+    setTree: (tree: readonly MenuItem[]) => void;
+
+    fields: NavigationEntityFields;
+    setFields: (
+        update: Partial<NavigationEntityFields>
+    ) => void;
+
+    isDirty: boolean;
+
+    saveStatus: SaveStatus;
+    saveErrorMessage: string | null;
+    validationErrors: ValidationErrors | null;
+    lastSavedAt: Date | null;
+
+    save: () => Promise<NavigationRecord | null>;
+    reset: () => void;
+}
+
+const EMPTY_FIELDS: NavigationEntityFields = {
+    title: '',
+    slug: '',
+    location: null,
+};
+
+export function useNavigationEditor(
+    options: UseNavigationEditorOptions
+): UseNavigationEditorResult {
+    const { apiConfig, entityId } = options;
+
+    const [entity, setEntity] = useState<NavigationRecord | null>(null);
+    const [loadStatus, setLoadStatus] = useState<LoadStatus>('idle');
+    const [loadErrorMessage, setLoadErrorMessage] = useState<string | null>(
+        null
+    );
+    const [tree, setTreeState] = useState<readonly MenuItem[]>([]);
+    const [fields, setFieldsState] =
+        useState<NavigationEntityFields>(EMPTY_FIELDS);
+    const [savedTreeKey, setSavedTreeKey] = useState<string>('[]');
+    const [savedFields, setSavedFields] =
+        useState<NavigationEntityFields>(EMPTY_FIELDS);
+
+    const [saveStatus, setSaveStatus] = useState<SaveStatus>('idle');
+    const [saveErrorMessage, setSaveErrorMessage] = useState<string | null>(
+        null
+    );
+    const [validationErrors, setValidationErrors] =
+        useState<ValidationErrors | null>(null);
+    const [lastSavedAt, setLastSavedAt] = useState<Date | null>(null);
+
+    // Tracks the most recent load — abort flag prevents a slow earlier
+    // request from clobbering state when the user opens a different
+    // menu mid-fetch.
+    const loadEpoch = useRef(0);
+    // Same idea for saves; a stale save mid-flight when the user closes
+    // the menu must not flip status back to 'saved'.
+    const saveEpoch = useRef(0);
+
+    const treeKey = useMemo(() => stringifyTree(tree), [tree]);
+    const fieldsKey = useMemo(() => stringifyFields(fields), [fields]);
+    const savedFieldsKey = useMemo(
+        () => stringifyFields(savedFields),
+        [savedFields]
+    );
+
+    const isDirty =
+        treeKey !== savedTreeKey || fieldsKey !== savedFieldsKey;
+
+    useEffect(() => {
+        if (entityId === null) {
+            loadEpoch.current += 1;
+            setEntity(null);
+            setLoadStatus('idle');
+            setLoadErrorMessage(null);
+            setTreeState([]);
+            setFieldsState(EMPTY_FIELDS);
+            setSavedFields(EMPTY_FIELDS);
+            setSavedTreeKey('[]');
+            setSaveStatus('idle');
+            setSaveErrorMessage(null);
+            setValidationErrors(null);
+            setLastSavedAt(null);
+
+            return undefined;
+        }
+
+        loadEpoch.current += 1;
+        const epoch = loadEpoch.current;
+
+        setLoadStatus('loading');
+        setLoadErrorMessage(null);
+        setSaveStatus('idle');
+        setSaveErrorMessage(null);
+        setValidationErrors(null);
+
+        let cancelled = false;
+
+        (async () => {
+            try {
+                const record = await fetchNavigation(apiConfig, entityId);
+
+                if (cancelled || epoch !== loadEpoch.current) {
+                    return;
+                }
+
+                const initialTree = blocksToMenuTree(record.content.blocks);
+                const initialFields: NavigationEntityFields = {
+                    title: record.title.rendered,
+                    slug: record.slug,
+                    location: record.location,
+                };
+
+                setEntity(record);
+                setLoadStatus('ready');
+                setTreeState(initialTree);
+                setFieldsState(initialFields);
+                setSavedFields(initialFields);
+                setSavedTreeKey(stringifyTree(initialTree));
+                setLastSavedAt(null);
+            } catch (error: unknown) {
+                if (cancelled || epoch !== loadEpoch.current) {
+                    return;
+                }
+
+                setLoadStatus('error');
+                setLoadErrorMessage(extractErrorMessage(error));
+            }
+        })();
+
+        return () => {
+            cancelled = true;
+        };
+    }, [apiConfig, entityId]);
+
+    const setTree = useCallback((next: readonly MenuItem[]): void => {
+        setTreeState(next);
+    }, []);
+
+    const setFields = useCallback(
+        (update: Partial<NavigationEntityFields>): void => {
+            setFieldsState((current) => ({ ...current, ...update }));
+        },
+        []
+    );
+
+    const save = useCallback(async (): Promise<NavigationRecord | null> => {
+        if (entity === null) {
+            return null;
+        }
+
+        saveEpoch.current += 1;
+        const epoch = saveEpoch.current;
+
+        setSaveStatus('saving');
+        setSaveErrorMessage(null);
+        setValidationErrors(null);
+
+        const blocks = menuTreeToBlocks(tree);
+        const payload: NavigationUpdatePayload = {
+            content: { raw: '', blocks },
+            title: fields.title,
+            slug: fields.slug,
+            location: fields.location,
+        };
+
+        try {
+            const updated = await updateNavigation(
+                apiConfig,
+                entity.id,
+                payload
+            );
+
+            if (epoch !== saveEpoch.current) {
+                return null;
+            }
+
+            const updatedTree = blocksToMenuTree(updated.content.blocks);
+            const updatedFields: NavigationEntityFields = {
+                title: updated.title.rendered,
+                slug: updated.slug,
+                location: updated.location,
+            };
+
+            setEntity(updated);
+            setTreeState(updatedTree);
+            setFieldsState(updatedFields);
+            setSavedFields(updatedFields);
+            setSavedTreeKey(stringifyTree(updatedTree));
+            setSaveStatus('saved');
+            setLastSavedAt(new Date());
+
+            return updated;
+        } catch (error: unknown) {
+            if (epoch !== saveEpoch.current) {
+                return null;
+            }
+
+            setSaveStatus('error');
+            setSaveErrorMessage(extractErrorMessage(error));
+
+            if (error instanceof SiteEditorApiError) {
+                setValidationErrors(error.validationErrors);
+            }
+
+            return null;
+        }
+    }, [apiConfig, entity, fields, tree]);
+
+    const reset = useCallback((): void => {
+        if (entity === null) {
+            return;
+        }
+
+        const initialTree = blocksToMenuTree(entity.content.blocks);
+        const initialFields: NavigationEntityFields = {
+            title: entity.title.rendered,
+            slug: entity.slug,
+            location: entity.location,
+        };
+
+        setTreeState(initialTree);
+        setFieldsState(initialFields);
+        setSavedFields(initialFields);
+        setSavedTreeKey(stringifyTree(initialTree));
+        setSaveStatus('idle');
+        setSaveErrorMessage(null);
+        setValidationErrors(null);
+    }, [entity]);
+
+    return {
+        entity,
+        loadStatus,
+        loadErrorMessage,
+        tree,
+        setTree,
+        fields,
+        setFields,
+        isDirty,
+        saveStatus,
+        saveErrorMessage,
+        validationErrors,
+        lastSavedAt,
+        save,
+        reset,
+    };
+}
+
+function stringifyTree(tree: readonly MenuItem[]): string {
+    // Strip `localId` before signing — id only lives in memory and
+    // gets regenerated each load, so including it would always show
+    // dirty after a refetch.
+    return JSON.stringify(tree.map(stripLocalIds));
+}
+
+function stripLocalIds(
+    item: MenuItem
+): Omit<MenuItem, 'localId' | 'children'> & {
+    children: ReturnType<typeof stripLocalIds>[];
+} {
+    const { localId, children, ...rest } = item;
+    void localId;
+
+    return {
+        ...rest,
+        children: children.map(stripLocalIds),
+    };
+}
+
+function stringifyFields(fields: NavigationEntityFields): string {
+    return JSON.stringify(fields);
+}
+
+function extractErrorMessage(error: unknown): string {
+    if (error instanceof SiteEditorApiError) {
+        return error.message;
+    }
+
+    if (error instanceof Error) {
+        return error.message;
+    }
+
+    return __('Unknown error.', TEXT_DOMAIN);
+}

--- a/resources/js/visual-editor/site-editor/site-editor-app.tsx
+++ b/resources/js/visual-editor/site-editor/site-editor-app.tsx
@@ -45,6 +45,7 @@ import {
     TemplatePartsBrowser,
 } from './template-parts-section';
 import { useStylesSectionViews } from './styles/styles-section';
+import { useNavigationSectionViews } from './navigation/navigation-section';
 import { usePersistedToggle } from './use-persisted-toggle';
 import { useSiteEditorRouting } from './use-site-editor-routing';
 import { TopBar } from '../editor/top-bar';
@@ -79,6 +80,18 @@ const D2_SECTIONS: ReadonlySet<SiteEditorSectionId> = new Set([
  */
 const D3_SECTIONS: ReadonlySet<SiteEditorSectionId> = new Set<SiteEditorSectionId>([
     'styles',
+]);
+
+/**
+ * Section ids D4 (#371) ships — the Navigation section mounts the
+ * native tree editor (per design brief §3.8) instead of the
+ * block-canvas placeholder. The shell still treats it as an
+ * "entity-driven" section: the tree editor only renders once the URL
+ * carries a navigation id, with the empty list / locations panel
+ * showing in the navigator outlet beforehand.
+ */
+const D4_SECTIONS: ReadonlySet<SiteEditorSectionId> = new Set<SiteEditorSectionId>([
+    'navigation',
 ]);
 
 export interface SiteEditorAppProps {
@@ -118,7 +131,10 @@ const D2_DISABLED_BLOCKS: ReadonlyArray<string> = [
     'core/site-logo',
     'core/site-title',
     'core/site-tagline',
-    'core/navigation',
+    // `core/navigation` is now D4-enabled. The block can render in the
+    // template canvas because B1's shim has `wp_navigation` and C4's
+    // REST surface round-trips its inner blocks. Keep it OUT of this
+    // list so the template editor's inserter exposes it.
     'core/query',
     'core/query-loop',
     'core/latest-comments',
@@ -201,6 +217,7 @@ export function SiteEditorApp(props: SiteEditorAppProps): JSX.Element {
     const activeEntityId = routing.entityId;
     const isD2Section = D2_SECTIONS.has(activeSection.id);
     const isD3Section = D3_SECTIONS.has(activeSection.id);
+    const isD4Section = D4_SECTIONS.has(activeSection.id);
     const activeKind = sectionKind(activeSection.id);
 
     // Effective kind passed to the editor hook — always a real value so
@@ -232,13 +249,37 @@ export function SiteEditorApp(props: SiteEditorAppProps): JSX.Element {
         apiConfig,
         kind: editorKind,
         entityId: editorEntityId,
-        onStateChange: isD3Section ? noopStateChange : handleEntityStateChange,
+        onStateChange:
+            isD3Section || isD4Section
+                ? noopStateChange
+                : handleEntityStateChange,
     });
 
     const stylesViews = useStylesSectionViews({
         apiConfig,
         enabled: isD3Section,
         onStateChange: isD3Section ? handleEntityStateChange : noopStateChange,
+    });
+
+    // Same shape as `handleOpenEntity` declared further down — duplicated
+    // here so the navigation views hook can receive it without having to
+    // hoist the original above the hook calls (the down-stream
+    // `handleOpenEntity` would otherwise be a TDZ reference). Both
+    // callbacks dispatch through the same routing instance, so no state
+    // diverges.
+    const handleNavigationOpen = useCallback(
+        (entityId: string): void => {
+            routing.navigate(activeSection.id, entityId);
+        },
+        [activeSection.id, routing]
+    );
+
+    const navigationViews = useNavigationSectionViews({
+        apiConfig,
+        enabled: isD4Section,
+        activeEntityId,
+        onOpenEntity: handleNavigationOpen,
+        onStateChange: isD4Section ? handleEntityStateChange : noopStateChange,
     });
 
     const [dialogKind, setDialogKind] = useState<EntityKind | null>(null);
@@ -436,6 +477,8 @@ export function SiteEditorApp(props: SiteEditorAppProps): JSX.Element {
         );
     } else if (isD3Section) {
         navigatorChildren = stylesViews.navigator;
+    } else if (isD4Section) {
+        navigatorChildren = navigationViews.navigator;
     } else {
         navigatorChildren = (
             <SectionOutlet
@@ -446,6 +489,7 @@ export function SiteEditorApp(props: SiteEditorAppProps): JSX.Element {
     }
 
     const showEntityEditor = isD2Section && activeEntityId !== null;
+    const showNavigationEditor = isD4Section && activeEntityId !== null;
 
     return (
         <div
@@ -453,7 +497,7 @@ export function SiteEditorApp(props: SiteEditorAppProps): JSX.Element {
             data-navigator-open={navigatorOpen}
             data-inspector-open={inspectorOpen}
             data-active-section={activeSection.id}
-            data-has-entity={showEntityEditor || isD3Section}
+            data-has-entity={showEntityEditor || isD3Section || isD4Section}
             data-testid="ap-site-editor-shell"
         >
             <TopBar
@@ -511,6 +555,14 @@ export function SiteEditorApp(props: SiteEditorAppProps): JSX.Element {
                     >
                         {stylesViews.canvas}
                     </div>
+                ) : isD4Section ? (
+                    <div
+                        className="ap-site-editor__canvas"
+                        data-has-entity={showNavigationEditor}
+                        data-testid="ap-site-editor-canvas"
+                    >
+                        {navigationViews.canvas}
+                    </div>
                 ) : (
                     <CanvasFrame
                         sectionLabel={activeSection.modeLabel}
@@ -523,6 +575,8 @@ export function SiteEditorApp(props: SiteEditorAppProps): JSX.Element {
                             editorViews.inspector
                         ) : isD3Section ? (
                             stylesViews.inspector
+                        ) : isD4Section && showNavigationEditor ? (
+                            navigationViews.inspector
                         ) : (
                             <InspectorOutlet sectionLabel={activeSection.label} />
                         )}
@@ -545,6 +599,7 @@ export function SiteEditorApp(props: SiteEditorAppProps): JSX.Element {
                     onCreated={(entity) => handleDialogCreated(entity.id)}
                 />
             ) : null}
+            {navigationViews.overlay}
         </div>
     );
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -18,7 +18,9 @@
 declare( strict_types=1 );
 
 use ArtisanPackUI\VisualEditor\Http\Controllers\BlockPreviewController;
+use ArtisanPackUI\VisualEditor\Http\Controllers\EntitySearchController;
 use ArtisanPackUI\VisualEditor\Http\Controllers\GlobalStylesController;
+use ArtisanPackUI\VisualEditor\Http\Controllers\MenuLocationsController;
 use ArtisanPackUI\VisualEditor\Http\Controllers\NavigationController;
 use ArtisanPackUI\VisualEditor\Http\Controllers\PatternController;
 use ArtisanPackUI\VisualEditor\Http\Controllers\ResourceContentController;
@@ -123,6 +125,18 @@ Route::put( 'navigation/{navigation}', [ NavigationController::class, 'update' ]
 
 Route::delete( 'navigation/{navigation}', [ NavigationController::class, 'destroy' ] )
 	->name( 'visual-editor.api.navigation.destroy' );
+
+// D4 menu-location read surface — locations are config-driven (V1 plan §8) so
+// the editor only reads them; assignment writes live on the navigation
+// record's `location` field via the regular `PUT /navigation/{id}` route.
+Route::get( 'menu-locations', [ MenuLocationsController::class, 'index' ] )
+	->name( 'visual-editor.api.menu-locations.index' );
+
+// D4 entity search — backs the link-control picker in the menu tree
+// editor. Sources: registered `resources` config + templates +
+// template parts. Read-only.
+Route::get( 'search', [ EntitySearchController::class, 'index' ] )
+	->name( 'visual-editor.api.search.index' );
 
 // Legacy ve_contents routes retained for the existing editor tests and the
 // `VisualEditorPost` model. Deprecated in M3 in favor of the resource routes

--- a/src/Http/Controllers/EntitySearchController.php
+++ b/src/Http/Controllers/EntitySearchController.php
@@ -1,0 +1,243 @@
+<?php
+
+/**
+ * Entity search controller.
+ *
+ * Powers the link-control menu picker D4 ships with: when a user adds a
+ * menu item and chooses Page / Post / Template / Custom URL, the picker
+ * hits this endpoint with `?type=…&q=…` and gets back a flat list of
+ * `{ type, id, title, url }` rows it can drop straight into the menu
+ * tree as a typed reference.
+ *
+ * Sources:
+ *
+ *   - `page` / `post` / any other slug declared in
+ *     `artisanpack.visual-editor.resources` map to that entry's
+ *     Eloquent model. The model must expose a `title` column for the
+ *     query to bite.
+ *   - `template` / `template-part` map to the C1/C2 entities so the
+ *     picker can drop a template URL into a menu item.
+ *
+ * The endpoint is intentionally READ-only and small: a more elaborate
+ * search surface (Scout, faceting) is out of V1 scope. Hard caps live
+ * in the per-type `MAX_RESULTS` constant.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Http\Controllers;
+
+use ArtisanPackUI\VisualEditor\Models\VisualEditorTemplate;
+use ArtisanPackUI\VisualEditor\Models\VisualEditorTemplatePart;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Schema;
+
+class EntitySearchController extends Controller
+{
+	/**
+	 * Hard cap on rows returned per request — keeps the picker
+	 * responsive even when a host app has 50,000 pages.
+	 */
+	protected const MAX_RESULTS = 20;
+
+	/**
+	 * Built-in search sources mapped to their model + URL strategy.
+	 * Resource-config sources (pages, posts) are layered on at request
+	 * time so a host app's published `resources` map drives the
+	 * picker's available types without controller edits.
+	 *
+	 * @return array<string, array{model: class-string<Model>, url: callable(Model): ?string}>
+	 */
+	protected function builtInSources(): array
+	{
+		return [
+			'template'      => [
+				'model' => VisualEditorTemplate::class,
+				'url'   => fn ( Model $template ): ?string => null,
+			],
+			'template-part' => [
+				'model' => VisualEditorTemplatePart::class,
+				'url'   => fn ( Model $part ): ?string => null,
+			],
+		];
+	}
+
+	/**
+	 * Performs the search and returns a flat row list.
+	 *
+	 * @since 1.0.0
+	 */
+	public function index( Request $request ): JsonResponse
+	{
+		$type = trim( (string) $request->query( 'type', '' ) );
+		$q    = trim( (string) $request->query( 'q', '' ) );
+
+		if ( '' === $type ) {
+			return response()->json( [ 'data' => [] ] );
+		}
+
+		$source = $this->resolveSource( $type );
+
+		if ( null === $source ) {
+			return response()->json( [ 'data' => [] ] );
+		}
+
+		/** @var class-string<Model> $modelClass */
+		$modelClass = $source['model'];
+
+		// `title` is the canonical search column — every entity in the
+		// allowlist exposes it, so we only have to dispatch one column
+		// name. A model whose schema has neither column gets skipped
+		// instead of 500-ing the picker.
+		$searchColumn = $this->resolveSearchColumn( $modelClass );
+
+		if ( null === $searchColumn ) {
+			return response()->json( [ 'data' => [] ] );
+		}
+
+		$query = $modelClass::query();
+
+		if ( '' !== $q ) {
+			// `|` is the explicit ESCAPE character — neutral across
+			// MySQL / Postgres / SQLite and avoids the
+			// backslash-double-escape pitfall the default Laravel
+			// LIKE binding has on Postgres + SQLite. Escape `|`, `%`,
+			// and `_` in the user's input so the pattern matches the
+			// literal characters they typed.
+			$escaped = str_replace(
+				[ '|', '%', '_' ],
+				[ '||', '|%', '|_' ],
+				$q
+			);
+
+			$query->whereRaw(
+				$searchColumn . " LIKE ? ESCAPE '|'",
+				[ '%' . $escaped . '%' ]
+			);
+		}
+
+		$rows = $query
+			->orderBy( $searchColumn )
+			->limit( self::MAX_RESULTS )
+			->get();
+
+		$urlResolver = $source['url'];
+
+		$data = $rows->map( function ( Model $row ) use ( $type, $searchColumn, $urlResolver ): array {
+			return [
+				'type'  => $type,
+				'id'    => $row->getKey(),
+				'title' => (string) ( $row->{$searchColumn} ?? '' ),
+				'url'   => $urlResolver( $row ),
+			];
+		} )->all();
+
+		return response()->json( [ 'data' => $data ] );
+	}
+
+	/**
+	 * Resolves the requested type slug to a model + URL strategy.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array{model: class-string<Model>, url: callable(Model): ?string}|null
+	 */
+	protected function resolveSource( string $type ): ?array
+	{
+		$builtIns = $this->builtInSources();
+
+		if ( isset( $builtIns[ $type ] ) ) {
+			return $builtIns[ $type ];
+		}
+
+		// Resource-config sources. The map's keys are URL slugs (`pages`,
+		// `posts`); the picker accepts the singular form (`page`,
+		// `post`) for ergonomics, so both are checked.
+		$resources = config( 'artisanpack.visual-editor.resources', [] );
+
+		if ( ! is_array( $resources ) ) {
+			return null;
+		}
+
+		$candidates = [ $type, $type . 's' ];
+
+		foreach ( $candidates as $candidate ) {
+			if ( ! array_key_exists( $candidate, $resources ) ) {
+				continue;
+			}
+
+			$modelClass = $resources[ $candidate ];
+
+			if ( ! is_string( $modelClass ) || ! class_exists( $modelClass ) ) {
+				continue;
+			}
+
+			if ( ! is_subclass_of( $modelClass, Model::class ) ) {
+				continue;
+			}
+
+			return [
+				'model' => $modelClass,
+				'url'   => fn ( Model $row ): ?string => $this->resolveResourceUrl( $row ),
+			];
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the first column the model declares that the picker can
+	 * search on. `title` is the canonical name; an `a11y` resource that
+	 * uses `name` is supported as a fallback so host apps don't have to
+	 * rename columns to wire into the picker.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  class-string<Model>  $modelClass
+	 */
+	protected function resolveSearchColumn( string $modelClass ): ?string
+	{
+		/** @var Model $instance */
+		$instance = new $modelClass();
+
+		foreach ( [ 'title', 'name' ] as $candidate ) {
+			if ( Schema::connection( $instance->getConnectionName() )->hasColumn( $instance->getTable(), $candidate ) ) {
+				return $candidate;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Best-effort URL extraction for a resource model. A `route_to_url`
+	 * accessor wins, then a `url` attribute, then null. Custom URL menu
+	 * items are the escape hatch for resources without a public URL —
+	 * the picker still resolves the typed reference, the host app just
+	 * has to render its own URL at the front end.
+	 *
+	 * @since 1.0.0
+	 */
+	protected function resolveResourceUrl( Model $row ): ?string
+	{
+		foreach ( [ 'permalink', 'url' ] as $attribute ) {
+			$value = $row->getAttribute( $attribute );
+
+			if ( is_string( $value ) && '' !== $value ) {
+				return $value;
+			}
+		}
+
+		return null;
+	}
+}

--- a/src/Http/Controllers/MenuLocationsController.php
+++ b/src/Http/Controllers/MenuLocationsController.php
@@ -1,0 +1,101 @@
+<?php
+
+/**
+ * Menu locations controller.
+ *
+ * Read-only surface for the configured menu-location slugs, paired with
+ * the navigation record currently assigned to each. The site editor's
+ * Navigation section calls `index` once when the section mounts to
+ * render its locations panel; subsequent assignment writes go through
+ * the regular `PUT /navigation/{id}` surface (the `location` field on
+ * the navigation record is the source of truth).
+ *
+ * Locations themselves are config-only for V1 per plan §8 — there is
+ * no create / update / destroy here on purpose. 1.1+ may revisit.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Http\Controllers;
+
+use ArtisanPackUI\VisualEditor\Models\VisualEditorNavigation;
+use ArtisanPackUI\VisualEditor\Services\MenuLocationResolver;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Gate;
+
+class MenuLocationsController extends Controller
+{
+	public function __construct( protected MenuLocationResolver $resolver ) {}
+
+	/**
+	 * Returns the configured menu locations, the menu currently
+	 * resolved for each, and whether that menu was resolved through a
+	 * direct DB assignment (the editor's UI-driven path) or via the
+	 * config-driven fallback chain.
+	 *
+	 * Response shape:
+	 *
+	 *   ```
+	 *   {
+	 *     "data": [
+	 *       {
+	 *         "slug": "primary",
+	 *         "label": "Primary Menu",
+	 *         "menu": { "id": 12, "title": "…", "slug": "main" } | null,
+	 *         "is_fallback": true | false
+	 *       }
+	 *     ]
+	 *   }
+	 *   ```
+	 *
+	 * `is_fallback: true` tells the panel to render the "no direct
+	 * assignment — falling back to X" hint instead of treating the
+	 * resolved menu as authoritative.
+	 *
+	 * @since 1.0.0
+	 */
+	public function index(): JsonResponse
+	{
+		Gate::authorize( 'viewAny', VisualEditorNavigation::class );
+
+		$locations = $this->resolver->locations();
+		$rows      = [];
+
+		foreach ( $locations as $entry ) {
+			$slug = $entry['slug'];
+
+			// Direct assignment — a published nav whose `location`
+			// column matches the slug. The same query the resolver
+			// runs first, but we also need to know whether it
+			// matched so the UI can flag fallback assignments.
+			$assigned = VisualEditorNavigation::query()
+				->forLocation( $slug )
+				->first();
+
+			$resolved = null !== $assigned && ! $assigned->isEmpty()
+				? $assigned
+				: $this->resolver->forLocation( $slug );
+
+			$rows[] = [
+				'slug'        => $slug,
+				'label'       => $entry['label'],
+				'menu'        => null === $resolved ? null : [
+					'id'    => $resolved->getKey(),
+					'slug'  => (string) $resolved->slug,
+					'title' => (string) ( $resolved->title ?? '' ),
+				],
+				'is_fallback' => null !== $resolved && ( null === $assigned || $assigned->isEmpty() ),
+			];
+		}
+
+		return response()->json( [ 'data' => $rows ] );
+	}
+}

--- a/src/Http/Controllers/NavigationController.php
+++ b/src/Http/Controllers/NavigationController.php
@@ -120,9 +120,15 @@ class NavigationController extends Controller
 			'title'      => $data['title'] ?? '',
 			'status'     => $data['status'] ?? VisualEditorNavigation::STATUS_PUBLISH,
 			'menu_order' => $data['menu_order'] ?? 0,
+			'location'   => array_key_exists( 'location', $data ) ? $this->normalizeLocation( $data['location'] ) : null,
 		] );
 
 		$navigation->setContentEnvelope( $this->normalizeContentEnvelope( $data['content'] ?? null ) );
+
+		if ( null !== $navigation->location && '' !== $navigation->location ) {
+			$this->releaseLocationFromOtherRecords( $navigation );
+		}
+
 		$navigation->save();
 
 		return response()->json(
@@ -150,6 +156,20 @@ class NavigationController extends Controller
 
 		if ( array_key_exists( 'content', $data ) ) {
 			$navigation->setContentEnvelope( $this->normalizeContentEnvelope( $data['content'] ) );
+		}
+
+		if ( array_key_exists( 'location', $data ) ) {
+			$navigation->location = $this->normalizeLocation( $data['location'] );
+
+			// A location is single-occupant: assigning it to one menu
+			// implicitly releases it from any other record that already
+			// claims the same slug. Without this an admin who reassigns
+			// would briefly have two records claiming `primary` and the
+			// resolver's `forLocation` would resolve to whichever sorts
+			// lowest by menu_order — surprising behavior.
+			if ( null !== $navigation->location && '' !== $navigation->location ) {
+				$this->releaseLocationFromOtherRecords( $navigation );
+			}
 		}
 
 		$navigation->save();
@@ -193,5 +213,43 @@ class NavigationController extends Controller
 			'raw'    => isset( $content['raw'] ) && is_string( $content['raw'] ) ? $content['raw'] : '',
 			'blocks' => isset( $content['blocks'] ) && is_array( $content['blocks'] ) ? array_values( $content['blocks'] ) : [],
 		];
+	}
+
+	/**
+	 * Coerces an empty `location` string into `null` so the database
+	 * stores a uniform "unassigned" sentinel and the resolver's
+	 * `forLocation` short-circuits.
+	 *
+	 * @since 1.0.0
+	 */
+	protected function normalizeLocation( mixed $location ): ?string
+	{
+		if ( null === $location ) {
+			return null;
+		}
+
+		if ( ! is_string( $location ) ) {
+			return null;
+		}
+
+		$trimmed = trim( $location );
+
+		return '' === $trimmed ? null : $trimmed;
+	}
+
+	/**
+	 * Clears the location slug on every other record that already claims
+	 * it so the location is single-occupant by construction.
+	 *
+	 * @since 1.0.0
+	 */
+	protected function releaseLocationFromOtherRecords( VisualEditorNavigation $navigation ): void
+	{
+		VisualEditorNavigation::query()
+			->where( 'location', $navigation->location )
+			->when( null !== $navigation->getKey(), function ( $query ) use ( $navigation ) {
+				$query->where( $navigation->getKeyName(), '!=', $navigation->getKey() );
+			} )
+			->update( [ 'location' => null ] );
 	}
 }

--- a/src/Http/Controllers/NavigationController.php
+++ b/src/Http/Controllers/NavigationController.php
@@ -35,6 +35,7 @@ use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Gate;
 
 class NavigationController extends Controller
@@ -125,11 +126,17 @@ class NavigationController extends Controller
 
 		$navigation->setContentEnvelope( $this->normalizeContentEnvelope( $data['content'] ?? null ) );
 
-		if ( null !== $navigation->location && '' !== $navigation->location ) {
-			$this->releaseLocationFromOtherRecords( $navigation );
-		}
+		// Wrap the release + save in a transaction so the table's
+		// `UNIQUE(location)` constraint can't trap us in a half-applied
+		// state — if the save fails for any reason the previous owner
+		// keeps the slug.
+		DB::transaction( function () use ( $navigation ) {
+			if ( null !== $navigation->location && '' !== $navigation->location ) {
+				$this->releaseLocationFromOtherRecords( $navigation );
+			}
 
-		$navigation->save();
+			$navigation->save();
+		} );
 
 		return response()->json(
 			( new NavigationResource( $navigation ) )->toArray( $request ),
@@ -160,19 +167,21 @@ class NavigationController extends Controller
 
 		if ( array_key_exists( 'location', $data ) ) {
 			$navigation->location = $this->normalizeLocation( $data['location'] );
+		}
 
-			// A location is single-occupant: assigning it to one menu
-			// implicitly releases it from any other record that already
-			// claims the same slug. Without this an admin who reassigns
-			// would briefly have two records claiming `primary` and the
-			// resolver's `forLocation` would resolve to whichever sorts
-			// lowest by menu_order — surprising behavior.
+		// A location is single-occupant: assigning it to one menu
+		// implicitly releases it from any other record that already
+		// claims the same slug. The release + save run in one
+		// transaction so the table's `UNIQUE(location)` constraint
+		// can't see the intermediate two-claimant state and the save
+		// rolls back cleanly on any failure.
+		DB::transaction( function () use ( $navigation ) {
 			if ( null !== $navigation->location && '' !== $navigation->location ) {
 				$this->releaseLocationFromOtherRecords( $navigation );
 			}
-		}
 
-		$navigation->save();
+			$navigation->save();
+		} );
 
 		return response()->json( ( new NavigationResource( $navigation ) )->toArray( $request ) );
 	}

--- a/src/Http/Requests/StoreNavigationRequest.php
+++ b/src/Http/Requests/StoreNavigationRequest.php
@@ -20,6 +20,7 @@ namespace ArtisanPackUI\VisualEditor\Http\Requests;
 
 use ArtisanPackUI\VisualEditor\Models\VisualEditorNavigation;
 use ArtisanPackUI\VisualEditor\Rules\TemplateBlockTreeRule;
+use ArtisanPackUI\VisualEditor\Services\MenuLocationResolver;
 use Closure;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
@@ -62,6 +63,12 @@ class StoreNavigationRequest extends FormRequest
 				] ),
 			],
 			'menu_order'     => [ 'sometimes', 'integer', 'min:0' ],
+			// `location` is nullable (most menus sit unassigned). When
+			// present it must name a slug declared in
+			// `artisanpack.visual-editor.navigation.locations` so the
+			// editor can never write an assignment to a slot the front
+			// end has no theme hook for.
+			'location'       => [ 'sometimes', 'nullable', 'string', 'max:191', $this->locationSlugRule() ],
 		];
 	}
 
@@ -79,6 +86,37 @@ class StoreNavigationRequest extends FormRequest
 		return function ( string $attribute, mixed $value, Closure $fail ): void {
 			if ( is_array( $value ) && [] !== $value && array_is_list( $value ) ) {
 				$fail( 'The :attribute must be a { raw, blocks } envelope, not a bare list of blocks.' );
+			}
+		};
+	}
+
+	/**
+	 * Restricts the `location` slug to one of the declared
+	 * configuration entries.
+	 *
+	 * Resolves the resolver lazily through the container so request
+	 * tests that don't bootstrap the package config don't trip the
+	 * binding.
+	 *
+	 * @since 1.0.0
+	 */
+	protected function locationSlugRule(): Closure
+	{
+		return function ( string $attribute, mixed $value, Closure $fail ): void {
+			if ( null === $value || '' === $value ) {
+				return;
+			}
+
+			if ( ! is_string( $value ) ) {
+				return;
+			}
+
+			/** @var MenuLocationResolver $resolver */
+			$resolver = $this->container->make( MenuLocationResolver::class );
+			$slugs    = array_keys( $resolver->locations() );
+
+			if ( ! in_array( $value, $slugs, true ) ) {
+				$fail( 'The :attribute is not a configured menu location.' );
 			}
 		};
 	}

--- a/src/Http/Requests/UpdateNavigationRequest.php
+++ b/src/Http/Requests/UpdateNavigationRequest.php
@@ -20,6 +20,7 @@ namespace ArtisanPackUI\VisualEditor\Http\Requests;
 
 use ArtisanPackUI\VisualEditor\Models\VisualEditorNavigation;
 use ArtisanPackUI\VisualEditor\Rules\TemplateBlockTreeRule;
+use ArtisanPackUI\VisualEditor\Services\MenuLocationResolver;
 use Closure;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
@@ -67,6 +68,10 @@ class UpdateNavigationRequest extends FormRequest
 				] ),
 			],
 			'menu_order'     => [ 'sometimes', 'integer', 'min:0' ],
+			// Mirrors `StoreNavigationRequest::rules()['location']`. Null
+			// clears the assignment, a configured slug writes one;
+			// anything else 422s before it can poison the resolver.
+			'location'       => [ 'sometimes', 'nullable', 'string', 'max:191', $this->locationSlugRule() ],
 		];
 	}
 
@@ -81,6 +86,34 @@ class UpdateNavigationRequest extends FormRequest
 		return function ( string $attribute, mixed $value, Closure $fail ): void {
 			if ( is_array( $value ) && [] !== $value && array_is_list( $value ) ) {
 				$fail( 'The :attribute must be a { raw, blocks } envelope, not a bare list of blocks.' );
+			}
+		};
+	}
+
+	/**
+	 * Mirrors {@see StoreNavigationRequest::locationSlugRule()} so the
+	 * `location` field accepts only slugs declared in the package
+	 * configuration.
+	 *
+	 * @since 1.0.0
+	 */
+	protected function locationSlugRule(): Closure
+	{
+		return function ( string $attribute, mixed $value, Closure $fail ): void {
+			if ( null === $value || '' === $value ) {
+				return;
+			}
+
+			if ( ! is_string( $value ) ) {
+				return;
+			}
+
+			/** @var MenuLocationResolver $resolver */
+			$resolver = $this->container->make( MenuLocationResolver::class );
+			$slugs    = array_keys( $resolver->locations() );
+
+			if ( ! in_array( $value, $slugs, true ) ) {
+				$fail( 'The :attribute is not a configured menu location.' );
 			}
 		};
 	}

--- a/src/Http/Resources/NavigationResource.php
+++ b/src/Http/Resources/NavigationResource.php
@@ -55,6 +55,9 @@ class NavigationResource extends JsonResource
 			],
 			'status'     => $navigation->status,
 			'menu_order' => (int) $navigation->menu_order,
+			// `null` is the wire signal "no location assigned" — the
+			// site editor's locations panel keys off this directly.
+			'location'   => null === $navigation->location || '' === $navigation->location ? null : (string) $navigation->location,
 			'type'       => 'wp_navigation',
 		];
 	}

--- a/src/Models/VisualEditorNavigation.php
+++ b/src/Models/VisualEditorNavigation.php
@@ -48,6 +48,7 @@ class VisualEditorNavigation extends Model
 		'content',
 		'status',
 		'menu_order',
+		'location',
 	];
 
 	/**
@@ -152,6 +153,27 @@ class VisualEditorNavigation extends Model
 	public function scopePublished( Builder $query ): Builder
 	{
 		return $query->where( 'status', self::STATUS_PUBLISH )
+			->orderBy( 'menu_order' )
+			->orderBy( 'id' );
+	}
+
+	/**
+	 * Scopes the query to navs published to the given location slug,
+	 * ordered by `menu_order`. Used by the
+	 * {@see \ArtisanPackUI\VisualEditor\Services\MenuLocationResolver}
+	 * as the authoritative lookup before it falls back to the
+	 * config-driven `primary_id` chain.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  Builder<VisualEditorNavigation>  $query
+	 *
+	 * @return Builder<VisualEditorNavigation>
+	 */
+	public function scopeForLocation( Builder $query, string $location ): Builder
+	{
+		return $query->where( 'location', $location )
+			->where( 'status', self::STATUS_PUBLISH )
 			->orderBy( 'menu_order' )
 			->orderBy( 'id' );
 	}

--- a/src/Services/MenuLocationResolver.php
+++ b/src/Services/MenuLocationResolver.php
@@ -93,10 +93,15 @@ class MenuLocationResolver
 	 * should render for that slot.
 	 *
 	 * Resolution order:
-	 *   1. The configured `primary_id` (when present and the record
-	 *      exists and has a non-empty block tree).
-	 *   2. The first published nav ordered by `menu_order`.
-	 *   3. `null` when no published navs exist.
+	 *   1. The first published nav with `location = $slug` ordered by
+	 *      `menu_order`. This is what the D4 site editor writes to;
+	 *      always preferred over config so an admin's UI assignment
+	 *      wins against a stale config entry.
+	 *   2. The configured `primary_id` (when present and the record
+	 *      exists and has a non-empty block tree). Lets a host app
+	 *      pin a location without exposing it to the editor.
+	 *   3. The first published nav ordered by `menu_order`.
+	 *   4. `null` when no published navs exist.
 	 *
 	 * An unknown slug still falls through to the published-nav fallback,
 	 * because a freshly-installed host app may have navs seeded before
@@ -106,6 +111,14 @@ class MenuLocationResolver
 	 */
 	public function forLocation( string $slug ): ?VisualEditorNavigation
 	{
+		if ( '' !== $slug ) {
+			$assigned = VisualEditorNavigation::query()->forLocation( $slug )->first();
+
+			if ( null !== $assigned && ! $assigned->isEmpty() ) {
+				return $assigned;
+			}
+		}
+
 		$locations = $this->locations();
 
 		$primary = null;
@@ -122,6 +135,31 @@ class MenuLocationResolver
 		}
 
 		return $this->fallback();
+	}
+
+	/**
+	 * Returns the navigation record currently assigned to each
+	 * configured location via the database `location` column.
+	 *
+	 * The site editor's locations panel uses this to render which menu
+	 * is "effective" for each slot per D0's "what does this affect"
+	 * principle. A location with no DB assignment AND no config
+	 * `primary_id` resolves to `null` so the UI can render the
+	 * fallback-chain note instead of a fictitious assignment.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<string, ?VisualEditorNavigation>  Keyed by location slug.
+	 */
+	public function effectiveAssignments(): array
+	{
+		$assignments = [];
+
+		foreach ( array_keys( $this->locations() ) as $slug ) {
+			$assignments[ $slug ] = $this->forLocation( $slug );
+		}
+
+		return $assignments;
 	}
 
 	/**

--- a/src/Services/MenuLocationResolver.php
+++ b/src/Services/MenuLocationResolver.php
@@ -138,14 +138,18 @@ class MenuLocationResolver
 	}
 
 	/**
-	 * Returns the navigation record currently assigned to each
-	 * configured location via the database `location` column.
+	 * Returns the navigation record currently effective for each
+	 * configured location, keyed by location slug.
 	 *
-	 * The site editor's locations panel uses this to render which menu
-	 * is "effective" for each slot per D0's "what does this affect"
-	 * principle. A location with no DB assignment AND no config
-	 * `primary_id` resolves to `null` so the UI can render the
-	 * fallback-chain note instead of a fictitious assignment.
+	 * Each entry is the result of `forLocation($slug)` — see that
+	 * method for the resolution chain (DB assignment → configured
+	 * `primary_id` → first-published fallback → `null`). A null entry
+	 * therefore means "no DB assignment, no config primary_id, AND no
+	 * published nav exists at all" — not the narrower "no direct
+	 * assignment" condition the locations-panel UI uses to render its
+	 * fallback hint. The panel reads `is_fallback` from
+	 * {@see \ArtisanPackUI\VisualEditor\Http\Controllers\MenuLocationsController::index()}
+	 * for that distinction.
 	 *
 	 * @since 1.0.0
 	 *

--- a/tests/Feature/VisualEditor/EntitySearchControllerTest.php
+++ b/tests/Feature/VisualEditor/EntitySearchControllerTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Models\VisualEditorTemplate;
+use Tests\TestUser;
+
+function actingAsSearchUser(): TestUser
+{
+	$user = TestUser::create( [
+		'name'     => 'Search Tester',
+		'email'    => 'search+' . uniqid() . '@example.com',
+		'password' => bcrypt( 'secret' ),
+	] );
+
+	test()->actingAs( $user );
+
+	return $user;
+}
+
+it( 'returns an empty data array when type is missing', function () {
+	actingAsSearchUser();
+
+	$this->getJson( '/visual-editor/api/search' )
+		->assertOk()
+		->assertJsonPath( 'data', [] );
+} );
+
+it( 'returns an empty data array for an unknown type slug', function () {
+	actingAsSearchUser();
+
+	$this->getJson( '/visual-editor/api/search?type=mystery&q=anything' )
+		->assertOk()
+		->assertJsonPath( 'data', [] );
+} );
+
+it( 'searches the visual_editor_templates table for type=template', function () {
+	actingAsSearchUser();
+
+	VisualEditorTemplate::create( [
+		'slug'    => 'single-book',
+		'title'   => 'Single Book Layout',
+		'content' => [ 'raw' => '', 'blocks' => [] ],
+		'theme'   => 'default',
+		'status'  => 'publish',
+		'source'  => 'custom',
+	] );
+
+	VisualEditorTemplate::create( [
+		'slug'    => 'archive-book',
+		'title'   => 'Archive Book Page',
+		'content' => [ 'raw' => '', 'blocks' => [] ],
+		'theme'   => 'default',
+		'status'  => 'publish',
+		'source'  => 'custom',
+	] );
+
+	VisualEditorTemplate::create( [
+		'slug'    => 'index',
+		'title'   => 'Default Index',
+		'content' => [ 'raw' => '', 'blocks' => [] ],
+		'theme'   => 'default',
+		'status'  => 'publish',
+		'source'  => 'custom',
+	] );
+
+	$response = $this->getJson( '/visual-editor/api/search?type=template&q=Book' )
+		->assertOk();
+
+	$rows = $response->json( 'data' );
+
+	expect( $rows )->toHaveCount( 2 );
+	expect( collect( $rows )->pluck( 'type' )->all() )->each->toBe( 'template' );
+} );
+
+it( 'caps the result list at MAX_RESULTS', function () {
+	actingAsSearchUser();
+
+	for ( $i = 0; $i < 25; $i++ ) {
+		VisualEditorTemplate::create( [
+			'slug'    => "page-{$i}",
+			'title'   => "Page {$i}",
+			'content' => [ 'raw' => '', 'blocks' => [] ],
+			'theme'   => 'default',
+			'status'  => 'publish',
+			'source'  => 'custom',
+		] );
+	}
+
+	$response = $this->getJson( '/visual-editor/api/search?type=template' )->assertOk();
+
+	expect( $response->json( 'data' ) )->toHaveCount( 20 );
+} );

--- a/tests/Feature/VisualEditor/MenuLocationResolverTest.php
+++ b/tests/Feature/VisualEditor/MenuLocationResolverTest.php
@@ -200,3 +200,63 @@ it( 'drops malformed location entries silently', function () {
 		->toHaveCount( 1 )
 		->toHaveKey( 'primary' );
 } );
+
+it( 'prefers a DB-assigned navigation over the configured primary_id', function () {
+	$dbAssigned = makeNavigation( [ 'slug' => 'editor-pick', 'location' => 'primary', 'menu_order' => 99 ] );
+	$configPick = makeNavigation( [ 'slug' => 'config-pick', 'menu_order' => 0 ] );
+
+	setLocations( [
+		'primary' => [
+			'slug'       => 'primary',
+			'label'      => 'Primary Menu',
+			'primary_id' => $configPick->id,
+		],
+	] );
+
+	$resolver = app( MenuLocationResolver::class );
+
+	expect( $resolver->forLocation( 'primary' ) )
+		->not->toBeNull()
+		->and( $resolver->forLocation( 'primary' )->id )->toBe( $dbAssigned->id );
+} );
+
+it( 'falls through to the config primary_id when no DB assignment matches', function () {
+	$configPick = makeNavigation( [ 'slug' => 'config-pick' ] );
+	makeNavigation( [ 'slug' => 'unrelated', 'location' => 'footer' ] );
+
+	setLocations( [
+		'primary' => [
+			'slug'       => 'primary',
+			'label'      => 'Primary Menu',
+			'primary_id' => $configPick->id,
+		],
+	] );
+
+	$resolver = app( MenuLocationResolver::class );
+
+	expect( $resolver->forLocation( 'primary' )->id )->toBe( $configPick->id );
+} );
+
+it( 'effectiveAssignments() reports each configured location once', function () {
+	$primary = makeNavigation( [ 'slug' => 'primary-pick', 'location' => 'primary' ] );
+	makeNavigation( [ 'slug' => 'fallback' ] );
+
+	setLocations( [
+		'primary' => [
+			'slug'       => 'primary',
+			'label'      => 'Primary',
+			'primary_id' => null,
+		],
+		'footer'  => [
+			'slug'       => 'footer',
+			'label'      => 'Footer',
+			'primary_id' => null,
+		],
+	] );
+
+	$resolver    = app( MenuLocationResolver::class );
+	$assignments = $resolver->effectiveAssignments();
+
+	expect( $assignments )->toHaveKey( 'primary' )
+		->and( $assignments['primary']->id )->toBe( $primary->id );
+} );

--- a/tests/Feature/VisualEditor/MenuLocationsControllerTest.php
+++ b/tests/Feature/VisualEditor/MenuLocationsControllerTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Models\VisualEditorNavigation;
+use Tests\TestUser;
+
+function makeMenuLocationNavigation( array $overrides = [] ): VisualEditorNavigation
+{
+	return VisualEditorNavigation::create( array_merge( [
+		'slug'       => 'primary-nav',
+		'title'      => 'Primary',
+		'content'    => [
+			'raw'    => '',
+			'blocks' => [
+				[
+					'name'        => 'core/navigation-link',
+					'attributes'  => [ 'label' => 'Home', 'url' => '/' ],
+					'innerBlocks' => [],
+				],
+			],
+		],
+		'status'     => 'publish',
+		'menu_order' => 0,
+	], $overrides ) );
+}
+
+function actingAsMenuLocationUser(): TestUser
+{
+	$user = TestUser::create( [
+		'name'     => 'Locations Tester',
+		'email'    => 'locations+' . uniqid() . '@example.com',
+		'password' => bcrypt( 'secret' ),
+	] );
+
+	test()->actingAs( $user );
+
+	return $user;
+}
+
+beforeEach( function () {
+	config( [
+		'artisanpack.visual-editor.navigation.locations' => [
+			'primary' => [
+				'slug'       => 'primary',
+				'label'      => 'Primary Menu',
+				'primary_id' => null,
+			],
+			'footer'  => [
+				'slug'       => 'footer',
+				'label'      => 'Footer',
+				'primary_id' => null,
+			],
+		],
+	] );
+} );
+
+it( 'returns 401 when unauthenticated', function () {
+	$this->getJson( '/visual-editor/api/menu-locations' )->assertUnauthorized();
+} );
+
+it( 'returns the configured locations with no menu when nothing is published', function () {
+	actingAsMenuLocationUser();
+
+	$this->getJson( '/visual-editor/api/menu-locations' )
+		->assertOk()
+		->assertJsonCount( 2, 'data' )
+		->assertJsonPath( 'data.0.slug', 'primary' )
+		->assertJsonPath( 'data.0.menu', null )
+		->assertJsonPath( 'data.1.slug', 'footer' )
+		->assertJsonPath( 'data.1.menu', null );
+} );
+
+it( 'flags the resolved menu as a fallback when no DB assignment exists', function () {
+	actingAsMenuLocationUser();
+
+	makeMenuLocationNavigation( [ 'slug' => 'primary-nav', 'location' => null ] );
+
+	$this->getJson( '/visual-editor/api/menu-locations' )
+		->assertOk()
+		->assertJsonPath( 'data.0.menu.slug', 'primary-nav' )
+		->assertJsonPath( 'data.0.is_fallback', true );
+} );
+
+it( 'reports a direct assignment as not-fallback', function () {
+	actingAsMenuLocationUser();
+
+	$assigned = makeMenuLocationNavigation( [
+		'slug'     => 'primary-nav',
+		'location' => 'primary',
+	] );
+
+	$this->getJson( '/visual-editor/api/menu-locations' )
+		->assertOk()
+		->assertJsonPath( 'data.0.menu.id', $assigned->id )
+		->assertJsonPath( 'data.0.is_fallback', false );
+} );

--- a/tests/Feature/VisualEditor/NavigationControllerTest.php
+++ b/tests/Feature/VisualEditor/NavigationControllerTest.php
@@ -409,3 +409,99 @@ it( 'rejects unauthenticated store, update, and destroy', function () {
 
 	$this->deleteJson( "/visual-editor/api/navigation/{$navigation->id}" )->assertUnauthorized();
 } );
+
+it( 'persists a configured location on store and exposes it in the response', function () {
+	actingAsNavigationUser();
+
+	config( [
+		'artisanpack.visual-editor.navigation.locations' => [
+			'primary' => [
+				'slug'       => 'primary',
+				'label'      => 'Primary Menu',
+				'primary_id' => null,
+			],
+		],
+	] );
+
+	$this->postJson( '/visual-editor/api/navigation', [
+		'slug'     => 'main-menu',
+		'title'    => 'Main',
+		'location' => 'primary',
+	] )
+		->assertCreated()
+		->assertJsonPath( 'location', 'primary' );
+
+	expect( VisualEditorNavigation::where( 'slug', 'main-menu' )->first()->location )
+		->toBe( 'primary' );
+} );
+
+it( 'rejects an unknown location slug as a 422', function () {
+	actingAsNavigationUser();
+
+	config( [
+		'artisanpack.visual-editor.navigation.locations' => [
+			'primary' => [
+				'slug'       => 'primary',
+				'label'      => 'Primary',
+				'primary_id' => null,
+			],
+		],
+	] );
+
+	$this->postJson( '/visual-editor/api/navigation', [
+		'slug'     => 'main-menu',
+		'location' => 'sidebar',
+	] )
+		->assertUnprocessable()
+		->assertJsonValidationErrors( 'location' );
+} );
+
+it( 'releases an existing location assignment when reassigning to another menu', function () {
+	actingAsNavigationUser();
+
+	config( [
+		'artisanpack.visual-editor.navigation.locations' => [
+			'primary' => [
+				'slug'       => 'primary',
+				'label'      => 'Primary',
+				'primary_id' => null,
+			],
+		],
+	] );
+
+	$first  = createNavigation( [ 'slug' => 'first-nav', 'location' => 'primary' ] );
+	$second = createNavigation( [ 'slug' => 'second-nav', 'location' => null ] );
+
+	$this->putJson( "/visual-editor/api/navigation/{$second->id}", [
+		'location' => 'primary',
+	] )
+		->assertOk()
+		->assertJsonPath( 'location', 'primary' );
+
+	expect( $first->fresh()->location )->toBeNull();
+	expect( $second->fresh()->location )->toBe( 'primary' );
+} );
+
+it( 'clears the location when null is sent on update', function () {
+	actingAsNavigationUser();
+
+	config( [
+		'artisanpack.visual-editor.navigation.locations' => [
+			'primary' => [
+				'slug'       => 'primary',
+				'label'      => 'Primary',
+				'primary_id' => null,
+			],
+		],
+	] );
+
+	$navigation = createNavigation( [ 'slug' => 'primary-nav', 'location' => 'primary' ] );
+
+	$this->putJson( "/visual-editor/api/navigation/{$navigation->id}", [
+		'location' => null,
+	] )
+		->assertOk()
+		->assertJsonPath( 'location', null );
+
+	expect( $navigation->fresh()->location )->toBeNull();
+} );


### PR DESCRIPTION
## Description

Builds the Navigation editor screen inside the D1 site-editor shell per design brief §3.8 and enables the `core/navigation` block in the template canvas. The navigation section is the one site-editor surface that deliberately ISN'T a block-editor iframe — nav trees are structural data, not block trees, so this ships a native tree editor with drag-sort + nested re-parenting + a typed-target picker.

**Closes:** #371

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #371

## Motivation and Context

Navigation is called out in V1 plan §4.3 as "the hardest single piece" of Phase D — `core/navigation`'s editor experience depends on a substantial `core-data` shim surface (the `wp_navigation` entity, the link-control menu picker, fallback resolution). C4 (#360) landed the backend; B1 (#353) locked the shim. D4 is the UI surface that depends on both, and the section that actually lets users build menus.

## Changes Made

**Backend**
- New nullable + indexed `location` column on `visual_editor_navigations` so the editor can write menu-location assignments (single-occupant: assigning a location to one menu releases it from any prior owner)
- `MenuLocationsController` — GET `/menu-locations`, returning the configured slugs paired with the menu currently resolved for each + an `is_fallback` flag so the UI can render the "falling back to X" hint
- `EntitySearchController` — GET `/search?type=…&q=…`, the link-picker's source for pages / posts / templates / template-parts. Searches use a portable `LIKE … ESCAPE '|'` pattern and cap at 20 results per request
- `MenuLocationResolver` now prefers DB assignments over the config `primary_id` chain, with a new `effectiveAssignments()` helper for cross-location reads
- Form-request validation rejects unknown location slugs as 422 so the editor can never write to a slot the front-end has no theme hook for

**Frontend** (`resources/js/visual-editor/site-editor/navigation/`)
- `menu-tree.ts` — pure functions for the Gutenberg-block ↔ typed-MenuItem-tree bridge and the flat-list / projection helpers powering DnD (`flattenTree`, `buildTreeFromFlat`, `getDescendantIds`, `projectDrop`, `commitProjection`)
- `navigation-canvas.tsx` — the native tree editor. Single sortable list with depth-by-padding; drag X-offset projects target depth (clamped to `previous-sibling-depth + 1` and `next-sibling-depth`) so users drag right to nest into a submenu and left to outdent back to root. Subtrees move with their parent
- `navigation-inspector.tsx` + `link-picker.tsx` — entity panel (name, slug, location dropdown) and item panel (typed link picker, label override, advanced rel/class/new-tab). All form fields use the shared `.ap-site-editor__dialog-*` classes so they match the templates / parts inspector
- `navigation-browser.tsx` + `locations-panel.tsx` — left-rail menu list + locations assignment panel
- `create-menu-dialog.tsx` — slug + name + optional location, also using the shared dialog chrome
- `navigation-section.tsx` — orchestrator that returns `{ navigator, canvas, inspector, overlay }` to the shell
- `core/navigation` block enabled (removed from `disabled_blocks` config and the JS shell mirror)

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS Darwin 25.4.0
- Browser: tested in Chrome via Laravel Herd dev app
- PHP Version: 8.4.3
- Project Version: 1.0.0

**Tests Performed:**
1. Created a menu via "Add new", added page / post / custom-URL items, edited each in the inspector, saved — round-tripped cleanly through `PUT /navigation/{id}`
2. Drag-sorted top-level items, dragged a top-level item right onto another to nest, dragged a nested item left to outdent, dragged a parent with children (subtree moved as a unit)
3. Assigned a menu to a location via the inspector dropdown — assignment persisted, locations panel rendered the new resolution
4. Reassigned the same location to another menu — first menu's `location` cleared (single-occupant)
5. Switched to the Templates section and confirmed `core/navigation` is now in the inserter

## Accessibility Tests Run

- [x] Keyboard navigation tested
- [x] ARIA labels checked
- [ ] Screen reader tested (deferred — not in V1 scope per design brief)
- [ ] Color contrast verified (uses existing site-editor design tokens)

**Details:** All interactive elements (drag handle, row main, action buttons, picker results) are buttons with descriptive `aria-label`s; the tree uses `role="tree"` / `role="treeitem"` with `aria-level` and `aria-selected`; focus-visible outlines are explicit on the row main + action buttons.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:**
- 22 new menu-tree tests (block round-trip, mutation helpers, flatten / build, projection clamping, drag-out-to-root commit)
- 13 new component / API tests across `navigation-canvas`, `navigation-section`, `link-picker`, and `api-client`
- 2 new PHP test files (`MenuLocationsControllerTest`, `EntitySearchControllerTest`) plus extensions to `MenuLocationResolverTest` (DB-priority + `effectiveAssignments`) and `NavigationControllerTest` (location persistence, slug validation, single-occupant reassignment, null-clears)
- All 1059 tests pass: 356 PHP + 703 JS (1 pre-existing skip)

## Documentation

- [x] Inline code documentation added
- [ ] README updated (no API surface changes for end users)
- [ ] Wiki updated (deferred to F4 / #325)

**Documentation details:** Each new file carries a header docblock with rationale; the menu-tree → block bridge and the DnD projection helpers carry inline comments naming the standard dnd-kit "tree" recipe they implement.

## Out of scope (called out in plan / #371 but deferred)

- **Auto-generate menu from page tree** — design brief §3.8 mentions this as an opt-in at create time. Requires a page-tree-source API B1 didn't deliver; defer to a follow-up issue rather than expand B1 mid-stream
- **`core/navigation` block link picker** — when the block is placed in a template, its own LinkControl uses WordPress's `/wp/v2/search` endpoint, which the B1 shim doesn't expose. Block placement + render works; richer in-block link picking is a B1-shim follow-up

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted (TypeScript clean for new code; pre-existing project errors unchanged)
- [x] Accessibility tests completed
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Comprehensive navigation menu editor (drag‑and‑drop, inspector, browser, create dialog, link picker, locations panel) and integration into the site editor UI
  * Searchable entity picker for linking menu items

* **API**
  * Added read-only endpoints for menu locations and entity search

* **Database**
  * Migration to track menu location assignments

* **Tests**
  * Extensive test coverage across editor UI, API client, search, and location resolution
<!-- end of auto-generated comment: release notes by coderabbit.ai -->