### PR TITLE
feat: E2 · front-end template + template-part rendering (#379)

### DIFF
--- a/packages/visual-editor-renderer-blade/resources/views/blocks/core/template-part.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/core/template-part.blade.php
@@ -1,0 +1,32 @@
+@php
+	$slug  = isset( $attributes['slug'] ) && is_string( $attributes['slug'] ) ? $attributes['slug'] : '';
+	$theme = isset( $attributes['theme'] ) && is_string( $attributes['theme'] ) ? $attributes['theme'] : '';
+	$tag   = isset( $attributes['tagName'] ) && in_array( $attributes['tagName'], [ 'div', 'header', 'footer', 'aside', 'section', 'main', 'nav' ], true )
+		? $attributes['tagName']
+		: 'div';
+
+	$resolutionError = isset( $attributes['_resolutionError'] ) && is_string( $attributes['_resolutionError'] )
+		? $attributes['_resolutionError']
+		: null;
+
+	$classes = [ 'wp-block-template-part' ];
+
+	if ( '' !== $slug ) {
+		$classes[] = 'wp-block-template-part--' . preg_replace( '/[^a-z0-9_-]/i', '-', $slug );
+	}
+
+	if ( ! empty( $attributes['className'] ) && is_string( $attributes['className'] ) ) {
+		$classes[] = $attributes['className'];
+	}
+
+	$inDev = function_exists( 'app' ) ? ! app()->environment( 'production' ) : false;
+@endphp
+<{{ $tag }} class="{{ implode( ' ', $classes ) }}" data-ve-template-part="{{ $slug }}"@if( '' !== $theme ) data-ve-theme="{{ $theme }}"@endif>
+@if( null !== $resolutionError )
+@if( $inDev )
+<!-- visual-editor: template part "{{ $slug }}" failed to resolve ({{ $resolutionError }}) -->
+@endif
+@else
+{!! $innerBlocksHtml !!}
+@endif
+</{{ $tag }}>

--- a/packages/visual-editor-renderer-blade/resources/views/components/template.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/components/template.blade.php
@@ -1,0 +1,16 @@
+@php
+	$wrapperClasses = [ 'wp-site-blocks' ];
+
+	if ( null !== $matchedSlug ) {
+		$wrapperClasses[] = 'wp-site-blocks--' . preg_replace( '/[^a-z0-9_-]/i', '-', $matchedSlug );
+	}
+@endphp
+<div class="{{ implode( ' ', $wrapperClasses ) }}" data-ve-template="{{ $slug }}"@if( null !== $matchedSlug && $matchedSlug !== $slug ) data-ve-matched-template="{{ $matchedSlug }}"@endif>
+@if( null !== $resolutionError )
+@if( $inDev )
+<!-- visual-editor: template "{{ $slug }}" failed to resolve ({{ $resolutionError }}); fallback chain tried: {{ implode( ', ', $fallbackChain ) }} -->
+@endif
+@else
+{!! $html !!}
+@endif
+</div>

--- a/packages/visual-editor-renderer-blade/src/View/Components/BlocksComponent.php
+++ b/packages/visual-editor-renderer-blade/src/View/Components/BlocksComponent.php
@@ -5,6 +5,10 @@
  *
  * Renders a saved visual editor block tree into HTML using the
  * {@see \ArtisanPackUI\VisualEditorRendererBlade\BlockRenderer} engine.
+ * Resolves any `core/template-part` blocks in the tree inline (via the
+ * shared {@see TemplatePartInliner}) so a single render pass produces
+ * the final markup. Pass `:resolve-parts="false"` to opt out and render
+ * the raw tree.
  *
  * @package    ArtisanPack_UI
  * @subpackage VisualEditorRendererBlade
@@ -18,6 +22,7 @@ declare( strict_types=1 );
 
 namespace ArtisanPackUI\VisualEditorRendererBlade\View\Components;
 
+use ArtisanPackUI\VisualEditor\Resources\TemplatePartInliner;
 use ArtisanPackUI\VisualEditorRendererBlade\BlockRenderer;
 use Illuminate\Contracts\View\View;
 use Illuminate\View\Component;
@@ -33,9 +38,16 @@ class BlocksComponent extends Component
 
 	public function __construct(
 		protected BlockRenderer $renderer,
+		protected TemplatePartInliner $inliner,
 		mixed $tree = null,
+		?string $defaultTheme = null,
+		bool $resolveParts = true,
 	) {
-		$this->tree = $this->normalizeTree( $tree );
+		$normalized = $this->normalizeTree( $tree );
+
+		$this->tree = $resolveParts
+			? $this->inliner->inline( $normalized, $defaultTheme )
+			: $normalized;
 	}
 
 	public function render(): View

--- a/packages/visual-editor-renderer-blade/src/View/Components/TemplateComponent.php
+++ b/packages/visual-editor-renderer-blade/src/View/Components/TemplateComponent.php
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * `<x-ve-template :slug="..." :theme="...">` Blade component.
+ *
+ * Resolves the most-specific {@see VisualEditorTemplate} for the given
+ * slug (walking the WordPress-style fallback chain via
+ * {@see TemplateResolver}) and renders its block tree to HTML, inlining
+ * any `core/template-part` references along the way.
+ *
+ * Behaviour when no template matches:
+ * - In production the component renders an empty wrapper so the surrounding
+ *   layout stays intact.
+ * - In any non-production environment a visible HTML comment surfaces the
+ *   resolution failure so developers see the misconfiguration during a
+ *   browser refresh.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditorRendererBlade
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditorRendererBlade\View\Components;
+
+use ArtisanPackUI\VisualEditor\Resources\TemplatePartInliner;
+use ArtisanPackUI\VisualEditor\Resources\TemplateResolver;
+use ArtisanPackUI\VisualEditorRendererBlade\BlockRenderer;
+use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Contracts\View\View;
+use Illuminate\View\Component;
+
+class TemplateComponent extends Component
+{
+	public string $slug;
+
+	public ?string $theme;
+
+	/**
+	 * @var array<int, string>
+	 */
+	public array $fallbackChain;
+
+	public ?string $matchedSlug;
+
+	public ?string $resolutionError;
+
+	public string $html;
+
+	public function __construct(
+		protected BlockRenderer $renderer,
+		protected TemplateResolver $templates,
+		protected TemplatePartInliner $inliner,
+		protected Application $app,
+		string $slug,
+		?string $theme = null,
+	) {
+		$this->slug          = $slug;
+		$this->theme         = $theme;
+		$this->fallbackChain = $templates->fallbackChain( $slug );
+
+		$template = $templates->forSlug( $slug, $theme );
+
+		if ( null === $template ) {
+			$this->matchedSlug     = null;
+			$this->resolutionError = 'no-matching-template';
+			$this->html            = '';
+
+			return;
+		}
+
+		$this->matchedSlug     = $template->slug;
+		$this->resolutionError = null;
+
+		$inlined    = $this->inliner->inline( $template->getBlocks(), $theme ?? $template->theme );
+		$this->html = $renderer->render( $inlined );
+	}
+
+	public function render(): View
+	{
+		return view( 'visual-editor-renderer-blade::components.template', [
+			'slug'            => $this->slug,
+			'theme'           => $this->theme,
+			'matchedSlug'     => $this->matchedSlug,
+			'fallbackChain'   => $this->fallbackChain,
+			'resolutionError' => $this->resolutionError,
+			'inDev'           => ! $this->app->environment( 'production' ),
+			'html'            => $this->html,
+		] );
+	}
+}

--- a/packages/visual-editor-renderer-blade/src/VisualEditorRendererBladeServiceProvider.php
+++ b/packages/visual-editor-renderer-blade/src/VisualEditorRendererBladeServiceProvider.php
@@ -4,8 +4,8 @@
  * Service provider for the Blade renderer package.
  *
  * Wires the {@see BlockRenderer} singleton, registers the `<x-ve-blocks>`
- * Blade component, and publishes the partial views so host apps can override
- * any individual block's markup.
+ * and `<x-ve-template>` Blade components, and publishes the partial views
+ * so host apps can override any individual block's markup.
  *
  * @package    ArtisanPack_UI
  * @subpackage VisualEditorRendererBlade
@@ -20,7 +20,9 @@ declare( strict_types=1 );
 namespace ArtisanPackUI\VisualEditorRendererBlade;
 
 use ArtisanPackUI\VisualEditor\Registries\DynamicBlockRegistry;
+use ArtisanPackUI\VisualEditor\Resources\TemplatePartInliner;
 use ArtisanPackUI\VisualEditorRendererBlade\View\Components\BlocksComponent;
+use ArtisanPackUI\VisualEditorRendererBlade\View\Components\TemplateComponent;
 use Illuminate\Contracts\View\Factory as ViewFactory;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider;
@@ -35,6 +37,10 @@ class VisualEditorRendererBladeServiceProvider extends ServiceProvider
 				$app->make( DynamicBlockRegistry::class ),
 			);
 		} );
+
+		$this->app->singleton( TemplatePartInliner::class, function () {
+			return new TemplatePartInliner();
+		} );
 	}
 
 	public function boot(): void
@@ -42,6 +48,7 @@ class VisualEditorRendererBladeServiceProvider extends ServiceProvider
 		$this->loadViewsFrom( __DIR__ . '/../resources/views', 'visual-editor-renderer-blade' );
 
 		Blade::component( BlocksComponent::class, 've-blocks' );
+		Blade::component( TemplateComponent::class, 've-template' );
 
 		if ( $this->app->runningInConsole() ) {
 			$this->publishes( [

--- a/packages/visual-editor-renderer-blade/tests/Feature/TemplateComponentTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Feature/TemplateComponentTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Models\VisualEditorTemplate;
+use ArtisanPackUI\VisualEditor\Models\VisualEditorTemplatePart;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Blade;
+
+uses( RefreshDatabase::class );
+
+function bladeTemplateFixture( string $slug, array $blocks, string $theme = 'artisanpack-base' ): VisualEditorTemplate
+{
+	return VisualEditorTemplate::create( [
+		'slug'    => $slug,
+		'title'   => ucfirst( $slug ),
+		'content' => [ 'raw' => '', 'blocks' => $blocks ],
+		'theme'   => $theme,
+		'source'  => 'theme',
+		'origin'  => 'theme',
+	] );
+}
+
+function bladeTemplatePartFixture( string $slug, array $blocks, string $theme = 'artisanpack-base' ): VisualEditorTemplatePart
+{
+	return VisualEditorTemplatePart::create( [
+		'slug'    => $slug,
+		'title'   => ucfirst( $slug ),
+		'content' => [ 'raw' => '', 'blocks' => $blocks ],
+		'area'    => 'uncategorized',
+		'theme'   => $theme,
+	] );
+}
+
+function bladeTplParagraph( string $text, string $clientId = 'p-cid' ): array
+{
+	return [
+		'clientId'    => $clientId,
+		'name'        => 'core/paragraph',
+		'attributes'  => [ 'content' => $text ],
+		'innerBlocks' => [],
+	];
+}
+
+function bladeTplPartRef( string $slug, string $theme = 'artisanpack-base', string $clientId = 'tp-cid' ): array
+{
+	return [
+		'clientId'    => $clientId,
+		'name'        => 'core/template-part',
+		'attributes'  => [ 'slug' => $slug, 'theme' => $theme ],
+		'innerBlocks' => [],
+	];
+}
+
+it( 'renders the matched template with template-parts inlined', function () {
+	bladeTemplatePartFixture( 'header', [ bladeTplParagraph( 'Header content', 'p-h' ) ] );
+	bladeTemplateFixture( 'page-about', [ bladeTplPartRef( 'header' ), bladeTplParagraph( 'About body', 'p-b' ) ] );
+
+	$rendered = Blade::render( '<x-ve-template slug="page-about" theme="artisanpack-base" />' );
+	$normalized = $this->normalizeHtml( $rendered );
+
+	expect( $normalized )->toContain( 'data-ve-template="page-about"' );
+	expect( $normalized )->toContain( 'wp-block-template-part--header' );
+	expect( $normalized )->toContain( '<p class="wp-block-paragraph">Header content</p>' );
+	expect( $normalized )->toContain( '<p class="wp-block-paragraph">About body</p>' );
+} );
+
+it( 'walks the fallback chain (page-about → page → index)', function () {
+	bladeTemplateFixture( 'page', [ bladeTplParagraph( 'Default page' ) ] );
+	bladeTemplateFixture( 'index', [ bladeTplParagraph( 'Catch-all index' ) ] );
+
+	$rendered = Blade::render( '<x-ve-template slug="page-about" theme="artisanpack-base" />' );
+	$normalized = $this->normalizeHtml( $rendered );
+
+	expect( $normalized )->toContain( 'data-ve-matched-template="page"' );
+	expect( $normalized )->toContain( '<p class="wp-block-paragraph">Default page</p>' );
+	expect( $normalized )->not()->toContain( 'Catch-all index' );
+} );
+
+it( 'falls back to index when nothing more specific exists', function () {
+	bladeTemplateFixture( 'index', [ bladeTplParagraph( 'Catch-all index' ) ] );
+
+	$rendered = Blade::render( '<x-ve-template slug="archive" theme="artisanpack-base" />' );
+
+	expect( $this->normalizeHtml( $rendered ) )->toContain( '<p class="wp-block-paragraph">Catch-all index</p>' );
+} );
+
+it( 'renders an empty wrapper in production when nothing resolves', function () {
+	$this->app['env'] = 'production';
+
+	$rendered = Blade::render( '<x-ve-template slug="single-post" theme="artisanpack-base" />' );
+	$normalized = $this->normalizeHtml( $rendered );
+
+	expect( $normalized )->toContain( 'data-ve-template="single-post"' );
+	expect( $normalized )->not()->toContain( 'failed to resolve' );
+} );
+
+it( 'surfaces the failure as an HTML comment in development', function () {
+	$this->app['env'] = 'local';
+
+	$rendered = Blade::render( '<x-ve-template slug="single-post" theme="artisanpack-base" />' );
+
+	expect( $rendered )->toContain( 'failed to resolve (no-matching-template)' );
+	expect( $rendered )->toContain( 'fallback chain tried: single-post, single, index' );
+} );
+
+it( 'matches templates by slug only when no theme is provided', function () {
+	bladeTemplateFixture( 'index', [ bladeTplParagraph( 'Single-theme index' ) ], 'theme-x' );
+
+	$rendered = Blade::render( '<x-ve-template slug="archive" />' );
+
+	expect( $this->normalizeHtml( $rendered ) )->toContain( 'Single-theme index' );
+} );

--- a/packages/visual-editor-renderer-blade/tests/Feature/TemplatePartRenderingTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Feature/TemplatePartRenderingTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Models\VisualEditorTemplatePart;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Blade;
+
+uses( RefreshDatabase::class );
+
+function bladePartFixture( string $slug, array $blocks, string $theme = 'artisanpack-base', string $area = 'uncategorized' ): VisualEditorTemplatePart
+{
+	return VisualEditorTemplatePart::create( [
+		'slug'    => $slug,
+		'title'   => ucfirst( $slug ),
+		'content' => [ 'raw' => '', 'blocks' => $blocks ],
+		'area'    => $area,
+		'theme'   => $theme,
+	] );
+}
+
+function bladePartRef( string $slug, string $theme = 'artisanpack-base' ): array
+{
+	return [
+		'clientId'    => 'tp-' . $slug,
+		'name'        => 'core/template-part',
+		'attributes'  => [ 'slug' => $slug, 'theme' => $theme ],
+		'innerBlocks' => [],
+	];
+}
+
+function bladeParagraph( string $text, string $clientId = 'p-cid' ): array
+{
+	return [
+		'clientId'    => $clientId,
+		'name'        => 'core/paragraph',
+		'attributes'  => [ 'content' => $text ],
+		'innerBlocks' => [],
+	];
+}
+
+it( 'inlines a core/template-part reference inside <x-ve-blocks>', function () {
+	bladePartFixture( 'header', [ bladeParagraph( 'Header text' ) ] );
+
+	$tree = [ bladePartRef( 'header' ) ];
+
+	$rendered = Blade::render( '<x-ve-blocks :tree="$tree" />', [ 'tree' => $tree ] );
+	$normalized = $this->normalizeHtml( $rendered );
+
+	expect( $normalized )->toContain( '<div class="wp-block-template-part wp-block-template-part--header"' );
+	expect( $normalized )->toContain( 'data-ve-template-part="header"' );
+	expect( $normalized )->toContain( '<p class="wp-block-paragraph">Header text</p>' );
+} );
+
+it( 'skips inlining when :resolve-parts is false', function () {
+	bladePartFixture( 'header', [ bladeParagraph( 'Header text' ) ] );
+
+	$tree = [ bladePartRef( 'header' ) ];
+
+	$rendered = Blade::render(
+		'<x-ve-blocks :tree="$tree" :resolve-parts="false" />',
+		[ 'tree' => $tree ]
+	);
+
+	expect( $this->normalizeHtml( $rendered ) )->not()->toContain( 'Header text' );
+} );
+
+it( 'falls back to default-theme when the reference omits theme', function () {
+	bladePartFixture( 'header', [ bladeParagraph( 'Themed header' ) ], 'artisanpack-base' );
+
+	$tree = [
+		[
+			'clientId'    => 'tp-1',
+			'name'        => 'core/template-part',
+			'attributes'  => [ 'slug' => 'header' ],
+			'innerBlocks' => [],
+		],
+	];
+
+	$rendered = Blade::render(
+		'<x-ve-blocks :tree="$tree" default-theme="artisanpack-base" />',
+		[ 'tree' => $tree ]
+	);
+
+	expect( $this->normalizeHtml( $rendered ) )->toContain( 'Themed header' );
+} );
+
+it( 'renders an empty wrapper when the part is missing in production', function () {
+	$this->app['env'] = 'production';
+
+	$tree = [ bladePartRef( 'never-created' ) ];
+
+	$rendered = Blade::render( '<x-ve-blocks :tree="$tree" />', [ 'tree' => $tree ] );
+	$normalized = $this->normalizeHtml( $rendered );
+
+	expect( $normalized )->toContain( 'wp-block-template-part' );
+	expect( $normalized )->not()->toContain( 'failed to resolve' );
+} );
+
+it( 'surfaces a comment warning when the part is missing in development', function () {
+	$this->app['env'] = 'local';
+
+	$tree = [ bladePartRef( 'never-created' ) ];
+
+	$rendered = Blade::render( '<x-ve-blocks :tree="$tree" />', [ 'tree' => $tree ] );
+
+	expect( $rendered )->toContain( 'failed to resolve (not-found)' );
+} );
+
+it( 'renders a cycle marker without infinite recursion', function () {
+	$this->app['env'] = 'local';
+
+	bladePartFixture( 'a', [ bladePartRef( 'b' ) ] );
+	bladePartFixture( 'b', [ bladePartRef( 'a' ) ] );
+
+	$tree = [ bladePartRef( 'a' ) ];
+
+	$rendered = Blade::render( '<x-ve-blocks :tree="$tree" />', [ 'tree' => $tree ] );
+
+	// The two wrappers prove the resolver returned (no infinite recursion);
+	// the dev-mode comment proves the cycle guard was the reason the chain
+	// terminated rather than a part lookup that happened to fail.
+	expect( $rendered )->toContain( 'wp-block-template-part--a' );
+	expect( $rendered )->toContain( 'wp-block-template-part--b' );
+	expect( $rendered )->toContain( 'failed to resolve (cycle)' );
+} );

--- a/packages/visual-editor-renderer-blade/tests/TestCase.php
+++ b/packages/visual-editor-renderer-blade/tests/TestCase.php
@@ -39,6 +39,18 @@ abstract class TestCase extends BaseTestCase
 	}
 
 	/**
+	 * Loads the host package's migrations so tests that touch the
+	 * `visual_editor_*` tables (template-part inlining, template
+	 * resolution) can persist fixtures via Eloquent.
+	 *
+	 * @since 1.0.0
+	 */
+	protected function defineDatabaseMigrations(): void
+	{
+		$this->loadMigrationsFrom( __DIR__ . '/../../../database/migrations' );
+	}
+
+	/**
 	 * Collapse insignificant whitespace so snapshot comparisons aren't brittle.
 	 *
 	 * Only strips whitespace directly between tags (e.g. "</p>\n\t<p>" → "</p><p>")

--- a/packages/visual-editor-renderer-react/src/BlockTree.tsx
+++ b/packages/visual-editor-renderer-react/src/BlockTree.tsx
@@ -9,13 +9,25 @@
  *
  * `tree` accepts the array form the editor persists, a JSON-encoded string of
  * that shape, or `null`/`undefined` for an empty render.
+ *
+ * Optionally accepts a `templateParts` map. When provided, every
+ * `core/template-part` block in the tree is replaced (pre-walk) with
+ * its referenced part's blocks via {@link inlineTemplateParts}. The
+ * registered `core/template-part` renderer wraps the resolved blocks in
+ * a semantic element so the surrounding layout still gets the part's
+ * regions.
  */
 
-import { Fragment } from 'react';
+import { Fragment, useMemo } from 'react';
 import type { ReactElement, ReactNode } from 'react';
 import { DynamicBlock } from './DynamicBlock';
 import { UnknownBlock } from './blocks/unknownBlock';
 import { getBlockRenderer } from './registry';
+import {
+    DEFAULT_MAX_TEMPLATE_PART_DEPTH,
+    inlineTemplateParts,
+} from './templateParts';
+import type { TemplatePartRecord } from './templateParts';
 import type { Block } from './types';
 
 const DEFAULT_ENDPOINT = '/visual-editor/api/blocks/preview';
@@ -24,14 +36,32 @@ export interface BlockTreeProps {
     tree: Block[] | string | null | undefined;
     dynamicBlockEndpoint?: string;
     fetchOptions?: RequestInit;
+    templateParts?: TemplatePartRecord[];
+    defaultTheme?: string;
+    maxTemplatePartDepth?: number;
 }
 
 export function BlockTree({
     tree,
     dynamicBlockEndpoint = DEFAULT_ENDPOINT,
     fetchOptions,
+    templateParts,
+    defaultTheme,
+    maxTemplatePartDepth = DEFAULT_MAX_TEMPLATE_PART_DEPTH,
 }: BlockTreeProps): ReactElement {
-    const blocks = normalizeTree(tree);
+    const blocks = useMemo(() => {
+        const normalized = normalizeTree(tree);
+
+        if (templateParts === undefined || templateParts.length === 0) {
+            return normalized;
+        }
+
+        return inlineTemplateParts(normalized, {
+            parts: templateParts,
+            defaultTheme,
+            maxDepth: maxTemplatePartDepth,
+        });
+    }, [tree, templateParts, defaultTheme, maxTemplatePartDepth]);
 
     return (
         <>

--- a/packages/visual-editor-renderer-react/src/BlockTree.tsx
+++ b/packages/visual-editor-renderer-react/src/BlockTree.tsx
@@ -52,7 +52,12 @@ export function BlockTree({
     const blocks = useMemo(() => {
         const normalized = normalizeTree(tree);
 
-        if (templateParts === undefined || templateParts.length === 0) {
+        // Run the inliner whenever templateParts is supplied at all, even
+        // when it's an empty array — the host explicitly told us "no parts
+        // available," so any core/template-part references in the tree
+        // should be flagged unresolved instead of silently rendering an
+        // empty wrapper.
+        if (templateParts === undefined) {
             return normalized;
         }
 

--- a/packages/visual-editor-renderer-react/src/Template.tsx
+++ b/packages/visual-editor-renderer-react/src/Template.tsx
@@ -1,0 +1,94 @@
+/**
+ * Public React component for rendering a template by slug.
+ *
+ * Walks the WordPress-style fallback chain (`single-{slug}` → `single`
+ * → `index`, `page-{slug}` → `page` → `index`, etc.) over the supplied
+ * `templates` list, and renders the first match's block tree via
+ * {@link BlockTree}. Template-part references inside the matched
+ * template are inlined via the supplied `templateParts` collection.
+ *
+ * Resolution failures render an empty wrapper in production; in dev the
+ * wrapper carries a `data-ve-resolution-error` attribute so the
+ * developer can spot the misconfiguration in the inspector.
+ */
+
+import { useMemo } from 'react';
+import type { ReactElement } from 'react';
+import { BlockTree } from './BlockTree';
+import {
+    DEFAULT_MAX_TEMPLATE_PART_DEPTH,
+    resolveTemplate,
+    templateFallbackChain,
+} from './templateParts';
+import type { TemplatePartRecord, TemplateRecord } from './templateParts';
+
+const SLUG_CLASS_PATTERN = /[^a-zA-Z0-9_-]/g;
+
+function isDevelopment(): boolean {
+    if (typeof process === 'undefined') {
+        return false;
+    }
+
+    const env = process.env?.NODE_ENV;
+
+    return env !== 'production';
+}
+
+export interface TemplateProps {
+    slug: string;
+    theme?: string;
+    templates: TemplateRecord[];
+    templateParts?: TemplatePartRecord[];
+    dynamicBlockEndpoint?: string;
+    fetchOptions?: RequestInit;
+    maxTemplatePartDepth?: number;
+}
+
+export function Template({
+    slug,
+    theme,
+    templates,
+    templateParts = [],
+    dynamicBlockEndpoint,
+    fetchOptions,
+    maxTemplatePartDepth = DEFAULT_MAX_TEMPLATE_PART_DEPTH,
+}: TemplateProps): ReactElement {
+    const matched = useMemo(() => resolveTemplate(templates, slug, theme), [templates, slug, theme]);
+    const fallbackChain = useMemo(() => templateFallbackChain(slug), [slug]);
+
+    const wrapperClasses = ['wp-site-blocks'];
+
+    if (matched !== undefined) {
+        wrapperClasses.push(`wp-site-blocks--${matched.slug.replace(SLUG_CLASS_PATTERN, '-')}`);
+    }
+
+    const dataAttributes: Record<string, string> = {
+        'data-ve-template': slug,
+    };
+
+    if (matched !== undefined && matched.slug !== slug) {
+        dataAttributes['data-ve-matched-template'] = matched.slug;
+    }
+
+    if (matched === undefined && isDevelopment()) {
+        dataAttributes['data-ve-resolution-error'] = 'no-matching-template';
+        dataAttributes['data-ve-fallback-chain'] = fallbackChain.join(',');
+    }
+
+    if (matched === undefined) {
+        return <div className={wrapperClasses.join(' ')} {...dataAttributes} />;
+    }
+
+    return (
+        <div className={wrapperClasses.join(' ')} {...dataAttributes}>
+            <BlockTree
+                tree={matched.blocks}
+                templateParts={templateParts}
+                defaultTheme={theme ?? matched.theme}
+                dynamicBlockEndpoint={dynamicBlockEndpoint}
+                fetchOptions={fetchOptions}
+                maxTemplatePartDepth={maxTemplatePartDepth}
+            />
+        </div>
+    );
+}

--- a/packages/visual-editor-renderer-react/src/blocks/core/templatePart.tsx
+++ b/packages/visual-editor-renderer-react/src/blocks/core/templatePart.tsx
@@ -1,0 +1,72 @@
+/**
+ * `core/template-part` renderer.
+ *
+ * Operates on a tree where the template-part block already carries its
+ * resolved part's blocks under `innerBlocks` (see
+ * {@link inlineTemplateParts}). The renderer wraps the children in a
+ * semantic element matching the part's `tagName` attribute (default
+ * `div`) and stamps the slug + theme onto data attributes so
+ * client-side scripts can target the rendered region.
+ *
+ * If the inliner could not resolve the part, it stamps an
+ * `_resolutionError` attribute. In production this renderer emits an
+ * empty wrapper so the surrounding layout stays intact; in dev the
+ * wrapper carries a `data-ve-resolution-error` attribute the developer
+ * can spot in the inspector.
+ */
+
+import { attrString, classList } from '../../support/attributes';
+import type { BlockRendererProps } from '../../types';
+
+const ALLOWED_PART_TAGS = ['div', 'header', 'footer', 'aside', 'section', 'main', 'nav'] as const;
+
+type PartTag = (typeof ALLOWED_PART_TAGS)[number];
+
+const SLUG_CLASS_PATTERN = /[^a-zA-Z0-9_-]/g;
+
+function isDevelopment(): boolean {
+    if (typeof process === 'undefined') {
+        return false;
+    }
+
+    const env = process.env?.NODE_ENV;
+
+    return env !== 'production';
+}
+
+export function TemplatePartBlock({ attributes, children }: BlockRendererProps): JSX.Element {
+    const slug = attrString(attributes.slug);
+    const theme = attrString(attributes.theme);
+    const tagName = attrString(attributes.tagName);
+    const resolutionError = attrString(attributes._resolutionError);
+
+    const Tag: PartTag = (ALLOWED_PART_TAGS as ReadonlyArray<string>).includes(tagName)
+        ? (tagName as PartTag)
+        : 'div';
+
+    const slugClass = slug === '' ? '' : `wp-block-template-part--${slug.replace(SLUG_CLASS_PATTERN, '-')}`;
+    const className = attrString(attributes.className);
+    const classes = classList(['wp-block-template-part', slugClass, className]);
+
+    const dataAttributes: Record<string, string> = {
+        'data-ve-template-part': slug,
+    };
+
+    if (theme !== '') {
+        dataAttributes['data-ve-theme'] = theme;
+    }
+
+    if (resolutionError !== '' && isDevelopment()) {
+        dataAttributes['data-ve-resolution-error'] = resolutionError;
+    }
+
+    if (resolutionError !== '') {
+        return <Tag className={classes} {...dataAttributes} />;
+    }
+
+    return (
+        <Tag className={classes} {...dataAttributes}>
+            {children}
+        </Tag>
+    );
+}

--- a/packages/visual-editor-renderer-react/src/blocks/registerCoreBlocks.ts
+++ b/packages/visual-editor-renderer-react/src/blocks/registerCoreBlocks.ts
@@ -39,6 +39,7 @@ import {
     ImageBlock,
     VideoBlock,
 } from './core/media';
+import { TemplatePartBlock } from './core/templatePart';
 import {
     CodeBlock,
     HeadingBlock,
@@ -82,6 +83,7 @@ const CORE_BLOCKS: Record<string, BlockRenderer> = {
     'core/search': SearchBlock,
     'core/separator': SeparatorBlock,
     'core/spacer': SpacerBlock,
+    'core/template-part': TemplatePartBlock,
     'artisanpack/callout': CalloutBlock,
 };
 

--- a/packages/visual-editor-renderer-react/src/index.ts
+++ b/packages/visual-editor-renderer-react/src/index.ts
@@ -13,6 +13,8 @@ registerCoreBlocks();
 
 export { BlockTree } from './BlockTree';
 export type { BlockTreeProps } from './BlockTree';
+export { Template } from './Template';
+export type { TemplateProps } from './Template';
 export { DynamicBlock } from './DynamicBlock';
 export type { DynamicBlockProps } from './DynamicBlock';
 export { UnknownBlock } from './blocks/unknownBlock';
@@ -25,4 +27,17 @@ export {
     unregisterBlockRenderer,
 } from './registry';
 export { registerCoreBlocks } from './blocks/registerCoreBlocks';
+export {
+    DEFAULT_MAX_TEMPLATE_PART_DEPTH,
+    findTemplate,
+    inlineTemplateParts,
+    resolveTemplate,
+    templateFallbackChain,
+} from './templateParts';
+export type {
+    InlineTemplatePartsOptions,
+    TemplatePartRecord,
+    TemplatePartResolutionError,
+    TemplateRecord,
+} from './templateParts';
 export type { Block, BlockRenderer, BlockRendererProps } from './types';

--- a/packages/visual-editor-renderer-react/src/templateParts.ts
+++ b/packages/visual-editor-renderer-react/src/templateParts.ts
@@ -81,17 +81,25 @@ export function findTemplate(
     slug: string,
     theme?: string
 ): TemplateRecord | undefined {
-    return templates.find((template) => {
-        if (template.slug !== slug) {
-            return false;
-        }
+    if (theme === undefined || theme === '') {
+        return templates.find((template) => template.slug === slug);
+    }
 
-        if (theme === undefined || theme === '') {
-            return true;
-        }
+    // Two-pass lookup: prefer an exact theme match, then fall back to an
+    // unthemed record. Single-pass matching would let array order pick the
+    // unthemed record over a more-specific themed one for the same slug.
+    const exact = templates.find(
+        (template) => template.slug === slug && template.theme === theme
+    );
 
-        return template.theme === undefined || template.theme === '' || template.theme === theme;
-    });
+    if (exact !== undefined) {
+        return exact;
+    }
+
+    return templates.find(
+        (template) =>
+            template.slug === slug && (template.theme === undefined || template.theme === '')
+    );
 }
 
 export function resolveTemplate(
@@ -202,17 +210,22 @@ function findPart(
     slug: string,
     theme: string
 ): TemplatePartRecord | undefined {
-    return parts.find((part) => {
-        if (part.slug !== slug) {
-            return false;
-        }
+    if (theme === '') {
+        return parts.find((part) => part.slug === slug);
+    }
 
-        if (theme === '') {
-            return true;
-        }
+    // Two-pass lookup matching findTemplate's contract: prefer an exact
+    // theme match, then fall back to an unthemed record. Single-pass would
+    // let array order pick the wrong part for the slug.
+    const exact = parts.find((part) => part.slug === slug && part.theme === theme);
 
-        return part.theme === undefined || part.theme === '' || part.theme === theme;
-    });
+    if (exact !== undefined) {
+        return exact;
+    }
+
+    return parts.find(
+        (part) => part.slug === slug && (part.theme === undefined || part.theme === '')
+    );
 }
 
 function markUnresolved(

--- a/packages/visual-editor-renderer-react/src/templateParts.ts
+++ b/packages/visual-editor-renderer-react/src/templateParts.ts
@@ -1,0 +1,235 @@
+/**
+ * Client-side template + template-part resolution helpers.
+ *
+ * Mirrors the behaviour of the server-side
+ * `ArtisanPackUI\VisualEditor\Resources\TemplatePartInliner` and
+ * `TemplateResolver` services so the React renderer can produce the same
+ * inlined block tree without round-tripping to the server. Hosts pass a
+ * pre-fetched list of `templates` and `templateParts`; this module walks
+ * the WordPress-style fallback chain and recursively splices each
+ * `core/template-part` reference's blocks into the output tree.
+ *
+ * Recursion guard: an in-flight stack of `theme/slug` keys catches
+ * cycles (header → nav → header) and a depth counter caps how deep the
+ * resolution chain can go (default 10). Either guard turns the offending
+ * block into a marker whose `attributes._resolutionError` records the
+ * reason — the registered `core/template-part` renderer translates that
+ * into a graceful empty render in production and a visible warning in
+ * dev.
+ */
+
+import type { Block } from './types';
+
+export const DEFAULT_MAX_TEMPLATE_PART_DEPTH = 10;
+
+export type TemplatePartResolutionError =
+    | 'missing-slug'
+    | 'not-found'
+    | 'cycle'
+    | 'depth-limit';
+
+export interface TemplatePartRecord {
+    slug: string;
+    theme?: string;
+    blocks: Block[];
+}
+
+export interface TemplateRecord {
+    slug: string;
+    theme?: string;
+    blocks: Block[];
+}
+
+export interface InlineTemplatePartsOptions {
+    parts: TemplatePartRecord[];
+    defaultTheme?: string;
+    maxDepth?: number;
+}
+
+interface WalkContext {
+    parts: TemplatePartRecord[];
+    defaultTheme: string | undefined;
+    maxDepth: number;
+    stack: string[];
+    depth: number;
+}
+
+/**
+ * Returns the ordered chain of slugs the resolver walks for a given
+ * input slug. Mirrors `TemplateResolver::fallbackChain()` on the PHP
+ * side so renderers see the same fallback order their host app's saved
+ * pages would resolve to.
+ */
+export function templateFallbackChain(slug: string): string[] {
+    const chain = [slug];
+
+    if (slug !== 'single' && slug.startsWith('single-')) {
+        chain.push('single');
+    } else if (slug !== 'page' && slug.startsWith('page-')) {
+        chain.push('page');
+    }
+
+    if (slug !== 'index') {
+        chain.push('index');
+    }
+
+    return chain;
+}
+
+export function findTemplate(
+    templates: TemplateRecord[],
+    slug: string,
+    theme?: string
+): TemplateRecord | undefined {
+    return templates.find((template) => {
+        if (template.slug !== slug) {
+            return false;
+        }
+
+        if (theme === undefined || theme === '') {
+            return true;
+        }
+
+        return template.theme === undefined || template.theme === '' || template.theme === theme;
+    });
+}
+
+export function resolveTemplate(
+    templates: TemplateRecord[],
+    slug: string,
+    theme?: string
+): TemplateRecord | undefined {
+    for (const candidate of templateFallbackChain(slug)) {
+        const match = findTemplate(templates, candidate, theme);
+
+        if (match !== undefined) {
+            return match;
+        }
+    }
+
+    return undefined;
+}
+
+export function inlineTemplateParts(tree: Block[], options: InlineTemplatePartsOptions): Block[] {
+    const context: WalkContext = {
+        parts: options.parts,
+        defaultTheme: options.defaultTheme,
+        maxDepth: options.maxDepth ?? DEFAULT_MAX_TEMPLATE_PART_DEPTH,
+        stack: [],
+        depth: 0,
+    };
+
+    return walk(tree, context);
+}
+
+function walk(tree: Block[], context: WalkContext): Block[] {
+    const out: Block[] = [];
+
+    for (const block of tree) {
+        if (block === null || typeof block !== 'object' || Array.isArray(block)) {
+            continue;
+        }
+
+        const name = typeof block.name === 'string' ? block.name : '';
+
+        if (name === 'core/template-part') {
+            out.push(resolvePart(block, context));
+
+            continue;
+        }
+
+        const inner = Array.isArray(block.innerBlocks) ? block.innerBlocks : [];
+
+        out.push({
+            ...block,
+            innerBlocks: walk(inner, context),
+        });
+    }
+
+    return out;
+}
+
+function resolvePart(block: Block, context: WalkContext): Block {
+    const attrs = block.attributes ?? {};
+    const slug = typeof attrs.slug === 'string' ? attrs.slug.trim() : '';
+    let theme = typeof attrs.theme === 'string' ? attrs.theme.trim() : '';
+
+    if (theme === '' && context.defaultTheme !== undefined) {
+        theme = context.defaultTheme;
+    }
+
+    if (slug === '') {
+        return markUnresolved(block, 'missing-slug', slug, theme);
+    }
+
+    if (context.depth >= context.maxDepth) {
+        return markUnresolved(block, 'depth-limit', slug, theme);
+    }
+
+    const key = `${theme}/${slug}`;
+
+    if (context.stack.includes(key)) {
+        return markUnresolved(block, 'cycle', slug, theme);
+    }
+
+    const part = findPart(context.parts, slug, theme);
+
+    if (part === undefined) {
+        return markUnresolved(block, 'not-found', slug, theme);
+    }
+
+    const childContext: WalkContext = {
+        ...context,
+        defaultTheme: theme !== '' ? theme : context.defaultTheme,
+        stack: [...context.stack, key],
+        depth: context.depth + 1,
+    };
+
+    return {
+        clientId: block.clientId,
+        name: 'core/template-part',
+        attributes: {
+            ...attrs,
+            slug,
+            theme,
+        },
+        innerBlocks: walk(Array.isArray(part.blocks) ? part.blocks : [], childContext),
+    };
+}
+
+function findPart(
+    parts: TemplatePartRecord[],
+    slug: string,
+    theme: string
+): TemplatePartRecord | undefined {
+    return parts.find((part) => {
+        if (part.slug !== slug) {
+            return false;
+        }
+
+        if (theme === '') {
+            return true;
+        }
+
+        return part.theme === undefined || part.theme === '' || part.theme === theme;
+    });
+}
+
+function markUnresolved(
+    block: Block,
+    reason: TemplatePartResolutionError,
+    slug: string,
+    theme: string
+): Block {
+    return {
+        clientId: block.clientId,
+        name: 'core/template-part',
+        attributes: {
+            ...(block.attributes ?? {}),
+            slug,
+            theme,
+            _resolutionError: reason,
+        },
+        innerBlocks: [],
+    };
+}

--- a/packages/visual-editor-renderer-react/tests/Template.test.tsx
+++ b/packages/visual-editor-renderer-react/tests/Template.test.tsx
@@ -60,6 +60,19 @@ describe('BlockTree template-part inlining', () => {
         expect(wrapper).not.toBeNull();
         expect(wrapper?.children.length).toBe(0);
     });
+
+    it('runs the inliner for an explicit empty templateParts array so missing references are flagged', () => {
+        const tree = [partRef('header')];
+
+        const { container } = render(<BlockTree tree={tree} templateParts={[]} />);
+        const wrapper = container.querySelector('[data-ve-template-part="header"]');
+
+        // Empty array means "no parts supplied" — the inliner should mark
+        // the reference unresolved so dev diagnostics surface, rather than
+        // silently rendering an empty wrapper indistinguishable from
+        // "templateParts not configured at all."
+        expect(wrapper?.getAttribute('data-ve-resolution-error')).toBe('not-found');
+    });
 });
 
 describe('Template component', () => {

--- a/packages/visual-editor-renderer-react/tests/Template.test.tsx
+++ b/packages/visual-editor-renderer-react/tests/Template.test.tsx
@@ -1,0 +1,138 @@
+import { render } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import '../src/index';
+import { BlockTree } from '../src/BlockTree';
+import { Template } from '../src/Template';
+import { resetBlockRegistry } from '../src/registry';
+import { registerCoreBlocks } from '../src/blocks/registerCoreBlocks';
+import type { TemplatePartRecord, TemplateRecord } from '../src/templateParts';
+import type { Block } from '../src/types';
+import { makeBlock, normalizeHtml } from './helpers';
+
+function paragraph(text: string, clientId = 'p-cid'): Block {
+    return makeBlock('core/paragraph', { content: text }, [], clientId);
+}
+
+function partRef(slug: string, theme = 'artisanpack-base', clientId = 'tp-cid'): Block {
+    return makeBlock('core/template-part', { slug, theme }, [], clientId);
+}
+
+afterEach(() => {
+    resetBlockRegistry();
+    registerCoreBlocks();
+});
+
+describe('BlockTree template-part inlining', () => {
+    it('renders a referenced part wrapped in a wp-block-template-part element', () => {
+        const parts: TemplatePartRecord[] = [
+            { slug: 'header', theme: 'artisanpack-base', blocks: [paragraph('Header text', 'h-1')] },
+        ];
+        const tree = [partRef('header')];
+
+        const { container } = render(<BlockTree tree={tree} templateParts={parts} />);
+        const html = normalizeHtml(container.innerHTML);
+
+        expect(html).toContain('<div class="wp-block-template-part wp-block-template-part--header"');
+        expect(html).toContain('data-ve-template-part="header"');
+        expect(html).toContain('<p class="wp-block-paragraph">Header text</p>');
+    });
+
+    it('wraps a missing reference as an empty element with no children', () => {
+        const tree = [partRef('never-created')];
+
+        const { container } = render(<BlockTree tree={tree} templateParts={[]} />);
+
+        const wrapper = container.querySelector('[data-ve-template-part="never-created"]');
+
+        expect(wrapper).not.toBeNull();
+        expect(wrapper?.children.length).toBe(0);
+    });
+
+    it('does not run the inliner when no parts are supplied', () => {
+        const tree = [partRef('header')];
+
+        const { container } = render(<BlockTree tree={tree} />);
+
+        // The template-part block still renders; just empty (no inlined children).
+        const wrapper = container.querySelector('[data-ve-template-part="header"]');
+
+        expect(wrapper).not.toBeNull();
+        expect(wrapper?.children.length).toBe(0);
+    });
+});
+
+describe('Template component', () => {
+    const parts: TemplatePartRecord[] = [
+        { slug: 'header', theme: 'artisanpack-base', blocks: [paragraph('Header content', 'h-1')] },
+    ];
+
+    it('renders the matched template with parts inlined', () => {
+        const templates: TemplateRecord[] = [
+            {
+                slug: 'page-about',
+                theme: 'artisanpack-base',
+                blocks: [partRef('header'), paragraph('Body', 'b-1')],
+            },
+        ];
+
+        const { container } = render(
+            <Template
+                slug="page-about"
+                theme="artisanpack-base"
+                templates={templates}
+                templateParts={parts}
+            />
+        );
+        const html = normalizeHtml(container.innerHTML);
+
+        expect(html).toContain('data-ve-template="page-about"');
+        expect(html).toContain('<p class="wp-block-paragraph">Header content</p>');
+        expect(html).toContain('<p class="wp-block-paragraph">Body</p>');
+    });
+
+    it('walks the fallback chain (page-about → page → index)', () => {
+        const templates: TemplateRecord[] = [
+            { slug: 'page', theme: 'artisanpack-base', blocks: [paragraph('Default page', 'p-1')] },
+            { slug: 'index', theme: 'artisanpack-base', blocks: [paragraph('Catch-all', 'i-1')] },
+        ];
+
+        const { container } = render(
+            <Template
+                slug="page-about"
+                theme="artisanpack-base"
+                templates={templates}
+                templateParts={parts}
+            />
+        );
+        const html = normalizeHtml(container.innerHTML);
+
+        expect(html).toContain('data-ve-matched-template="page"');
+        expect(html).toContain('Default page');
+        expect(html).not.toContain('Catch-all');
+    });
+
+    it('renders an empty wrapper when nothing in the chain matches', () => {
+        const { container } = render(
+            <Template slug="single-post" theme="artisanpack-base" templates={[]} templateParts={[]} />
+        );
+
+        const wrapper = container.querySelector('[data-ve-template="single-post"]');
+
+        expect(wrapper).not.toBeNull();
+        expect(wrapper?.children.length).toBe(0);
+    });
+
+    it('exposes the fallback chain via a data attribute in development', () => {
+        const { container } = render(
+            <Template slug="single-post" theme="artisanpack-base" templates={[]} templateParts={[]} />
+        );
+
+        const wrapper = container.querySelector('[data-ve-template="single-post"]');
+
+        // jsdom defaults NODE_ENV to 'test', which our isDevelopment() helper
+        // treats as non-production — so the dev-only diagnostics are rendered.
+        expect(wrapper?.getAttribute('data-ve-resolution-error')).toBe('no-matching-template');
+        expect(wrapper?.getAttribute('data-ve-fallback-chain')).toBe('single-post,single,index');
+    });
+});

--- a/packages/visual-editor-renderer-react/tests/templateParts.test.ts
+++ b/packages/visual-editor-renderer-react/tests/templateParts.test.ts
@@ -73,6 +73,26 @@ describe('findTemplate / resolveTemplate', () => {
     it('returns templates regardless of theme when no theme is supplied', () => {
         expect(findTemplate(templates, 'index')?.slug).toBe('index');
     });
+
+    it('prefers an exact-theme match over an unthemed record regardless of array order', () => {
+        const mixed = [
+            // Unthemed record listed first; the themed record should still win
+            // because findTemplate runs an exact-theme pass before the fallback.
+            { slug: 'index', theme: '', blocks: [paragraph('Unthemed')] },
+            { slug: 'index', theme: 'artisanpack-base', blocks: [paragraph('Themed')] },
+        ];
+
+        expect(findTemplate(mixed, 'index', 'artisanpack-base')?.blocks[0].attributes?.content).toBe('Themed');
+    });
+
+    it('falls back to an unthemed record only when no exact-theme match exists', () => {
+        const mixed = [
+            { slug: 'index', theme: '', blocks: [paragraph('Unthemed')] },
+            { slug: 'index', theme: 'other-theme', blocks: [paragraph('Other')] },
+        ];
+
+        expect(findTemplate(mixed, 'index', 'artisanpack-base')?.blocks[0].attributes?.content).toBe('Unthemed');
+    });
 });
 
 describe('inlineTemplateParts', () => {
@@ -173,5 +193,17 @@ describe('inlineTemplateParts', () => {
 
     it('exposes a default depth limit', () => {
         expect(DEFAULT_MAX_TEMPLATE_PART_DEPTH).toBe(10);
+    });
+
+    it('prefers an exact-theme part over an unthemed part regardless of array order', () => {
+        const parts = [
+            { slug: 'header', theme: '', blocks: [paragraph('Unthemed')] },
+            { slug: 'header', theme: 'artisanpack-base', blocks: [paragraph('Themed')] },
+        ];
+        const tree = [partRef('header', 'artisanpack-base')];
+
+        const inlined = inlineTemplateParts(tree, { parts });
+
+        expect(inlined[0].innerBlocks?.[0].attributes?.content).toBe('Themed');
     });
 });

--- a/packages/visual-editor-renderer-react/tests/templateParts.test.ts
+++ b/packages/visual-editor-renderer-react/tests/templateParts.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    DEFAULT_MAX_TEMPLATE_PART_DEPTH,
+    findTemplate,
+    inlineTemplateParts,
+    resolveTemplate,
+    templateFallbackChain,
+} from '../src/templateParts';
+import type { Block } from '../src/types';
+
+function paragraph(text: string, clientId = 'p-cid'): Block {
+    return {
+        clientId,
+        name: 'core/paragraph',
+        attributes: { content: text },
+        innerBlocks: [],
+    };
+}
+
+function partRef(slug: string, theme = 'artisanpack-base', clientId = 'tp-cid'): Block {
+    return {
+        clientId,
+        name: 'core/template-part',
+        attributes: { slug, theme },
+        innerBlocks: [],
+    };
+}
+
+describe('templateFallbackChain', () => {
+    it('expands single-{slug} → single → index', () => {
+        expect(templateFallbackChain('single-post')).toEqual(['single-post', 'single', 'index']);
+    });
+
+    it('expands page-{slug} → page → index', () => {
+        expect(templateFallbackChain('page-about')).toEqual(['page-about', 'page', 'index']);
+    });
+
+    it('falls straight to index for unspecialized slugs', () => {
+        expect(templateFallbackChain('archive')).toEqual(['archive', 'index']);
+    });
+
+    it('returns just [index] for index itself', () => {
+        expect(templateFallbackChain('index')).toEqual(['index']);
+    });
+});
+
+describe('findTemplate / resolveTemplate', () => {
+    const templates = [
+        { slug: 'index', theme: 'artisanpack-base', blocks: [paragraph('Index')] },
+        { slug: 'page', theme: 'artisanpack-base', blocks: [paragraph('Page')] },
+        { slug: 'page-about', theme: 'artisanpack-base', blocks: [paragraph('About')] },
+    ];
+
+    it('returns the exact match when present', () => {
+        expect(resolveTemplate(templates, 'page-about', 'artisanpack-base')?.slug).toBe('page-about');
+    });
+
+    it('falls back to page when page-{slug} is missing', () => {
+        expect(resolveTemplate(templates, 'page-contact', 'artisanpack-base')?.slug).toBe('page');
+    });
+
+    it('falls back to index when page is missing too', () => {
+        const subset = [{ slug: 'index', blocks: [paragraph('idx')] }];
+
+        expect(resolveTemplate(subset, 'page-about')?.slug).toBe('index');
+    });
+
+    it('returns undefined when nothing matches', () => {
+        expect(resolveTemplate([], 'archive')).toBeUndefined();
+    });
+
+    it('returns templates regardless of theme when no theme is supplied', () => {
+        expect(findTemplate(templates, 'index')?.slug).toBe('index');
+    });
+});
+
+describe('inlineTemplateParts', () => {
+    it('inlines a referenced part', () => {
+        const parts = [{ slug: 'header', theme: 'artisanpack-base', blocks: [paragraph('H')] }];
+        const tree = [partRef('header')];
+
+        const inlined = inlineTemplateParts(tree, { parts });
+
+        expect(inlined[0].name).toBe('core/template-part');
+        expect(inlined[0].innerBlocks?.[0].attributes?.content).toBe('H');
+    });
+
+    it('uses defaultTheme when the reference omits theme', () => {
+        const parts = [{ slug: 'header', theme: 'artisanpack-base', blocks: [paragraph('H')] }];
+        const tree = [
+            { clientId: 'tp', name: 'core/template-part', attributes: { slug: 'header' }, innerBlocks: [] },
+        ];
+
+        const inlined = inlineTemplateParts(tree, { parts, defaultTheme: 'artisanpack-base' });
+
+        expect(inlined[0].innerBlocks?.[0].attributes?.content).toBe('H');
+    });
+
+    it('marks missing references with the not-found error', () => {
+        const tree = [partRef('never-created')];
+
+        const inlined = inlineTemplateParts(tree, { parts: [] });
+
+        expect(inlined[0].attributes?._resolutionError).toBe('not-found');
+    });
+
+    it('marks missing slug with the missing-slug error', () => {
+        const tree: Block[] = [
+            { clientId: 'tp', name: 'core/template-part', attributes: {}, innerBlocks: [] },
+        ];
+
+        const inlined = inlineTemplateParts(tree, { parts: [] });
+
+        expect(inlined[0].attributes?._resolutionError).toBe('missing-slug');
+    });
+
+    it('detects direct cycles', () => {
+        const parts = [{ slug: 'looper', theme: 'artisanpack-base', blocks: [partRef('looper')] }];
+        const tree = [partRef('looper')];
+
+        const inlined = inlineTemplateParts(tree, { parts });
+
+        expect(inlined[0].innerBlocks?.[0].attributes?._resolutionError).toBe('cycle');
+    });
+
+    it('detects indirect cycles (a → b → a)', () => {
+        const parts = [
+            { slug: 'a', theme: 'artisanpack-base', blocks: [partRef('b')] },
+            { slug: 'b', theme: 'artisanpack-base', blocks: [partRef('a')] },
+        ];
+        const tree = [partRef('a')];
+
+        const inlined = inlineTemplateParts(tree, { parts });
+
+        const cycleNode = inlined[0].innerBlocks?.[0].innerBlocks?.[0];
+
+        expect(cycleNode?.attributes?._resolutionError).toBe('cycle');
+    });
+
+    it('enforces the depth limit', () => {
+        const parts = [
+            { slug: 'p0', theme: 'artisanpack-base', blocks: [partRef('p1')] },
+            { slug: 'p1', theme: 'artisanpack-base', blocks: [partRef('p2')] },
+            { slug: 'p2', theme: 'artisanpack-base', blocks: [partRef('p3')] },
+            { slug: 'p3', theme: 'artisanpack-base', blocks: [paragraph('end')] },
+        ];
+
+        const inlined = inlineTemplateParts([partRef('p0')], { parts, maxDepth: 2 });
+
+        // p0 (depth 0) and p1 (depth 1) resolve; p2 (depth 2) hits the cap.
+        const third = inlined[0].innerBlocks?.[0].innerBlocks?.[0];
+
+        expect(third?.attributes?._resolutionError).toBe('depth-limit');
+    });
+
+    it('preserves non-template-part blocks', () => {
+        const tree = [paragraph('only')];
+
+        expect(inlineTemplateParts(tree, { parts: [] })).toEqual(tree);
+    });
+
+    it('descends into nested innerBlocks looking for parts', () => {
+        const parts = [{ slug: 'header', theme: 'artisanpack-base', blocks: [paragraph('H')] }];
+        const tree = [
+            { clientId: 'g', name: 'core/group', attributes: {}, innerBlocks: [partRef('header')] },
+        ];
+
+        const inlined = inlineTemplateParts(tree, { parts });
+
+        expect(inlined[0].innerBlocks?.[0].innerBlocks?.[0].attributes?.content).toBe('H');
+    });
+
+    it('exposes a default depth limit', () => {
+        expect(DEFAULT_MAX_TEMPLATE_PART_DEPTH).toBe(10);
+    });
+});

--- a/packages/visual-editor-renderer-vue/src/BlockTree.ts
+++ b/packages/visual-editor-renderer-vue/src/BlockTree.ts
@@ -73,7 +73,12 @@ export const BlockTree = defineComponent({
         const blocks = computed(() => {
             const normalized = normalizeTree(props.tree);
 
-            if (props.templateParts === undefined || props.templateParts.length === 0) {
+            // Run the inliner whenever templateParts is supplied at all,
+            // even when it's an empty array — the host explicitly told us
+            // "no parts available," so any core/template-part references
+            // in the tree should be flagged unresolved instead of
+            // silently rendering an empty wrapper.
+            if (props.templateParts === undefined) {
                 return normalized;
             }
 

--- a/packages/visual-editor-renderer-vue/src/BlockTree.ts
+++ b/packages/visual-editor-renderer-vue/src/BlockTree.ts
@@ -9,13 +9,25 @@
  *
  * `tree` accepts the array form the editor persists, a JSON-encoded string of
  * that shape, or `null`/`undefined` for an empty render.
+ *
+ * Optionally accepts a `templateParts` map. When provided, every
+ * `core/template-part` block in the tree is replaced (pre-walk) with
+ * its referenced part's blocks via {@link inlineTemplateParts}. The
+ * registered `core/template-part` renderer wraps the resolved blocks in
+ * a semantic element so the surrounding layout still gets the part's
+ * regions.
  */
 
-import { Fragment, defineComponent, h } from 'vue';
+import { Fragment, computed, defineComponent, h } from 'vue';
 import type { PropType, VNode } from 'vue';
 import { DynamicBlock } from './DynamicBlock';
 import { UnknownBlock } from './blocks/unknownBlock';
 import { getBlockRenderer } from './registry';
+import {
+    DEFAULT_MAX_TEMPLATE_PART_DEPTH,
+    inlineTemplateParts,
+} from './templateParts';
+import type { TemplatePartRecord } from './templateParts';
 import type { Block } from './types';
 
 const DEFAULT_ENDPOINT = '/visual-editor/api/blocks/preview';
@@ -24,6 +36,9 @@ export interface BlockTreeProps {
     tree: Block[] | string | null | undefined;
     dynamicBlockEndpoint?: string;
     fetchOptions?: RequestInit;
+    templateParts?: TemplatePartRecord[];
+    defaultTheme?: string;
+    maxTemplatePartDepth?: number;
 }
 
 export const BlockTree = defineComponent({
@@ -41,12 +56,37 @@ export const BlockTree = defineComponent({
             type: Object as PropType<RequestInit>,
             default: undefined,
         },
+        templateParts: {
+            type: Array as PropType<TemplatePartRecord[]>,
+            default: undefined,
+        },
+        defaultTheme: {
+            type: String,
+            default: undefined,
+        },
+        maxTemplatePartDepth: {
+            type: Number,
+            default: DEFAULT_MAX_TEMPLATE_PART_DEPTH,
+        },
     },
     setup(props) {
+        const blocks = computed(() => {
+            const normalized = normalizeTree(props.tree);
+
+            if (props.templateParts === undefined || props.templateParts.length === 0) {
+                return normalized;
+            }
+
+            return inlineTemplateParts(normalized, {
+                parts: props.templateParts,
+                defaultTheme: props.defaultTheme,
+                maxDepth: props.maxTemplatePartDepth,
+            });
+        });
+
         return () => {
-            const blocks = normalizeTree(props.tree);
             const endpoint = props.dynamicBlockEndpoint ?? DEFAULT_ENDPOINT;
-            const children = blocks
+            const children = blocks.value
                 .map((block, index) => renderBlock(block, index, endpoint, props.fetchOptions))
                 .filter((vnode): vnode is VNode => vnode !== null);
 

--- a/packages/visual-editor-renderer-vue/src/Template.ts
+++ b/packages/visual-editor-renderer-vue/src/Template.ts
@@ -1,0 +1,122 @@
+/**
+ * Public Vue component for rendering a template by slug.
+ *
+ * Walks the WordPress-style fallback chain (`single-{slug}` → `single`
+ * → `index`, `page-{slug}` → `page` → `index`, etc.) over the supplied
+ * `templates` list, and renders the first match's block tree via
+ * {@link BlockTree}. Template-part references inside the matched
+ * template are inlined via the supplied `templateParts` collection.
+ *
+ * Resolution failures render an empty wrapper in production; in dev the
+ * wrapper carries a `data-ve-resolution-error` attribute so the
+ * developer can spot the misconfiguration in the inspector.
+ */
+
+import { computed, defineComponent, h } from 'vue';
+import type { PropType } from 'vue';
+import { BlockTree } from './BlockTree';
+import {
+    DEFAULT_MAX_TEMPLATE_PART_DEPTH,
+    resolveTemplate,
+    templateFallbackChain,
+} from './templateParts';
+import type { TemplatePartRecord, TemplateRecord } from './templateParts';
+
+const SLUG_CLASS_PATTERN = /[^a-zA-Z0-9_-]/g;
+
+function isDevelopment(): boolean {
+    if (typeof process === 'undefined') {
+        return false;
+    }
+
+    const env = process.env?.NODE_ENV;
+
+    return env !== 'production';
+}
+
+export interface TemplateProps {
+    slug: string;
+    theme?: string;
+    templates: TemplateRecord[];
+    templateParts?: TemplatePartRecord[];
+    dynamicBlockEndpoint?: string;
+    fetchOptions?: RequestInit;
+    maxTemplatePartDepth?: number;
+}
+
+export const Template = defineComponent({
+    name: 'Template',
+    props: {
+        slug: {
+            type: String,
+            required: true as const,
+        },
+        theme: {
+            type: String,
+            default: undefined,
+        },
+        templates: {
+            type: Array as PropType<TemplateRecord[]>,
+            required: true as const,
+        },
+        templateParts: {
+            type: Array as PropType<TemplatePartRecord[]>,
+            default: () => [],
+        },
+        dynamicBlockEndpoint: {
+            type: String,
+            default: undefined,
+        },
+        fetchOptions: {
+            type: Object as PropType<RequestInit>,
+            default: undefined,
+        },
+        maxTemplatePartDepth: {
+            type: Number,
+            default: DEFAULT_MAX_TEMPLATE_PART_DEPTH,
+        },
+    },
+    setup(props) {
+        const matched = computed(() => resolveTemplate(props.templates, props.slug, props.theme));
+        const fallbackChain = computed(() => templateFallbackChain(props.slug));
+
+        return () => {
+            const wrapperClasses = ['wp-site-blocks'];
+
+            if (matched.value !== undefined) {
+                wrapperClasses.push(
+                    `wp-site-blocks--${matched.value.slug.replace(SLUG_CLASS_PATTERN, '-')}`
+                );
+            }
+
+            const elementProps: Record<string, string> = {
+                class: wrapperClasses.join(' '),
+                'data-ve-template': props.slug,
+            };
+
+            if (matched.value !== undefined && matched.value.slug !== props.slug) {
+                elementProps['data-ve-matched-template'] = matched.value.slug;
+            }
+
+            if (matched.value === undefined && isDevelopment()) {
+                elementProps['data-ve-resolution-error'] = 'no-matching-template';
+                elementProps['data-ve-fallback-chain'] = fallbackChain.value.join(',');
+            }
+
+            if (matched.value === undefined) {
+                return h('div', elementProps);
+            }
+
+            return h('div', elementProps, [
+                h(BlockTree, {
+                    tree: matched.value.blocks,
+                    templateParts: props.templateParts,
+                    defaultTheme: props.theme ?? matched.value.theme,
+                    dynamicBlockEndpoint: props.dynamicBlockEndpoint,
+                    fetchOptions: props.fetchOptions,
+                    maxTemplatePartDepth: props.maxTemplatePartDepth,
+                }),
+            ]);
+        };
+    },
+});

--- a/packages/visual-editor-renderer-vue/src/blocks/core/templatePart.ts
+++ b/packages/visual-editor-renderer-vue/src/blocks/core/templatePart.ts
@@ -1,0 +1,74 @@
+/**
+ * `core/template-part` renderer.
+ *
+ * Operates on a tree where the template-part block already carries its
+ * resolved part's blocks under `innerBlocks` (see
+ * {@link inlineTemplateParts}). The renderer wraps the children in a
+ * semantic element matching the part's `tagName` attribute (default
+ * `div`) and stamps the slug + theme onto data attributes so
+ * client-side scripts can target the rendered region.
+ *
+ * If the inliner could not resolve the part, it stamps an
+ * `_resolutionError` attribute. In production this renderer emits an
+ * empty wrapper so the surrounding layout stays intact; in dev the
+ * wrapper carries a `data-ve-resolution-error` attribute the developer
+ * can spot in the inspector.
+ */
+
+import { defineComponent, h } from 'vue';
+import { attrString, classList } from '../../support/attributes';
+import { blockRendererProps } from '../shared';
+
+const ALLOWED_PART_TAGS = ['div', 'header', 'footer', 'aside', 'section', 'main', 'nav'] as const;
+
+type PartTag = (typeof ALLOWED_PART_TAGS)[number];
+
+const SLUG_CLASS_PATTERN = /[^a-zA-Z0-9_-]/g;
+
+function isDevelopment(): boolean {
+    if (typeof process === 'undefined') {
+        return false;
+    }
+
+    const env = process.env?.NODE_ENV;
+
+    return env !== 'production';
+}
+
+export const TemplatePartBlock = defineComponent({
+    name: 'TemplatePartBlock',
+    props: blockRendererProps,
+    setup(props, { slots }) {
+        return () => {
+            const slug = attrString(props.attributes.slug);
+            const theme = attrString(props.attributes.theme);
+            const tagName = attrString(props.attributes.tagName);
+            const resolutionError = attrString(props.attributes._resolutionError);
+
+            const tag: PartTag = (ALLOWED_PART_TAGS as ReadonlyArray<string>).includes(tagName)
+                ? (tagName as PartTag)
+                : 'div';
+
+            const slugClass = slug === '' ? '' : `wp-block-template-part--${slug.replace(SLUG_CLASS_PATTERN, '-')}`;
+            const className = attrString(props.attributes.className);
+            const classes = classList(['wp-block-template-part', slugClass, className]);
+
+            const elementProps: Record<string, string> = {
+                class: classes,
+                'data-ve-template-part': slug,
+            };
+
+            if (theme !== '') {
+                elementProps['data-ve-theme'] = theme;
+            }
+
+            if (resolutionError !== '' && isDevelopment()) {
+                elementProps['data-ve-resolution-error'] = resolutionError;
+            }
+
+            const children = resolutionError !== '' ? [] : slots.default ? slots.default() : [];
+
+            return h(tag, elementProps, children);
+        };
+    },
+});

--- a/packages/visual-editor-renderer-vue/src/blocks/registerCoreBlocks.ts
+++ b/packages/visual-editor-renderer-vue/src/blocks/registerCoreBlocks.ts
@@ -39,6 +39,7 @@ import {
     ImageBlock,
     VideoBlock,
 } from './core/media';
+import { TemplatePartBlock } from './core/templatePart';
 import {
     CodeBlock,
     HeadingBlock,
@@ -82,6 +83,7 @@ const CORE_BLOCKS: Record<string, BlockRenderer> = {
     'core/search': SearchBlock,
     'core/separator': SeparatorBlock,
     'core/spacer': SpacerBlock,
+    'core/template-part': TemplatePartBlock,
     'artisanpack/callout': CalloutBlock,
 };
 

--- a/packages/visual-editor-renderer-vue/src/index.ts
+++ b/packages/visual-editor-renderer-vue/src/index.ts
@@ -13,6 +13,8 @@ registerCoreBlocks();
 
 export { BlockTree } from './BlockTree';
 export type { BlockTreeProps } from './BlockTree';
+export { Template } from './Template';
+export type { TemplateProps } from './Template';
 export { DynamicBlock } from './DynamicBlock';
 export type { DynamicBlockProps } from './DynamicBlock';
 export { UnknownBlock } from './blocks/unknownBlock';
@@ -25,4 +27,17 @@ export {
     unregisterBlockRenderer,
 } from './registry';
 export { registerCoreBlocks } from './blocks/registerCoreBlocks';
+export {
+    DEFAULT_MAX_TEMPLATE_PART_DEPTH,
+    findTemplate,
+    inlineTemplateParts,
+    resolveTemplate,
+    templateFallbackChain,
+} from './templateParts';
+export type {
+    InlineTemplatePartsOptions,
+    TemplatePartRecord,
+    TemplatePartResolutionError,
+    TemplateRecord,
+} from './templateParts';
 export type { Block, BlockRenderer, BlockRendererProps } from './types';

--- a/packages/visual-editor-renderer-vue/src/templateParts.ts
+++ b/packages/visual-editor-renderer-vue/src/templateParts.ts
@@ -81,17 +81,25 @@ export function findTemplate(
     slug: string,
     theme?: string
 ): TemplateRecord | undefined {
-    return templates.find((template) => {
-        if (template.slug !== slug) {
-            return false;
-        }
+    if (theme === undefined || theme === '') {
+        return templates.find((template) => template.slug === slug);
+    }
 
-        if (theme === undefined || theme === '') {
-            return true;
-        }
+    // Two-pass lookup: prefer an exact theme match, then fall back to an
+    // unthemed record. Single-pass matching would let array order pick the
+    // unthemed record over a more-specific themed one for the same slug.
+    const exact = templates.find(
+        (template) => template.slug === slug && template.theme === theme
+    );
 
-        return template.theme === undefined || template.theme === '' || template.theme === theme;
-    });
+    if (exact !== undefined) {
+        return exact;
+    }
+
+    return templates.find(
+        (template) =>
+            template.slug === slug && (template.theme === undefined || template.theme === '')
+    );
 }
 
 export function resolveTemplate(
@@ -202,17 +210,22 @@ function findPart(
     slug: string,
     theme: string
 ): TemplatePartRecord | undefined {
-    return parts.find((part) => {
-        if (part.slug !== slug) {
-            return false;
-        }
+    if (theme === '') {
+        return parts.find((part) => part.slug === slug);
+    }
 
-        if (theme === '') {
-            return true;
-        }
+    // Two-pass lookup matching findTemplate's contract: prefer an exact
+    // theme match, then fall back to an unthemed record. Single-pass would
+    // let array order pick the wrong part for the slug.
+    const exact = parts.find((part) => part.slug === slug && part.theme === theme);
 
-        return part.theme === undefined || part.theme === '' || part.theme === theme;
-    });
+    if (exact !== undefined) {
+        return exact;
+    }
+
+    return parts.find(
+        (part) => part.slug === slug && (part.theme === undefined || part.theme === '')
+    );
 }
 
 function markUnresolved(

--- a/packages/visual-editor-renderer-vue/src/templateParts.ts
+++ b/packages/visual-editor-renderer-vue/src/templateParts.ts
@@ -1,0 +1,235 @@
+/**
+ * Client-side template + template-part resolution helpers.
+ *
+ * Mirrors the behaviour of the server-side
+ * `ArtisanPackUI\VisualEditor\Resources\TemplatePartInliner` and
+ * `TemplateResolver` services so the Vue renderer can produce the same
+ * inlined block tree without round-tripping to the server. Hosts pass a
+ * pre-fetched list of `templates` and `templateParts`; this module walks
+ * the WordPress-style fallback chain and recursively splices each
+ * `core/template-part` reference's blocks into the output tree.
+ *
+ * Recursion guard: an in-flight stack of `theme/slug` keys catches
+ * cycles (header → nav → header) and a depth counter caps how deep the
+ * resolution chain can go (default 10). Either guard turns the offending
+ * block into a marker whose `attributes._resolutionError` records the
+ * reason — the registered `core/template-part` renderer translates that
+ * into a graceful empty render in production and a visible warning in
+ * dev.
+ */
+
+import type { Block } from './types';
+
+export const DEFAULT_MAX_TEMPLATE_PART_DEPTH = 10;
+
+export type TemplatePartResolutionError =
+    | 'missing-slug'
+    | 'not-found'
+    | 'cycle'
+    | 'depth-limit';
+
+export interface TemplatePartRecord {
+    slug: string;
+    theme?: string;
+    blocks: Block[];
+}
+
+export interface TemplateRecord {
+    slug: string;
+    theme?: string;
+    blocks: Block[];
+}
+
+export interface InlineTemplatePartsOptions {
+    parts: TemplatePartRecord[];
+    defaultTheme?: string;
+    maxDepth?: number;
+}
+
+interface WalkContext {
+    parts: TemplatePartRecord[];
+    defaultTheme: string | undefined;
+    maxDepth: number;
+    stack: string[];
+    depth: number;
+}
+
+/**
+ * Returns the ordered chain of slugs the resolver walks for a given
+ * input slug. Mirrors `TemplateResolver::fallbackChain()` on the PHP
+ * side so renderers see the same fallback order their host app's saved
+ * pages would resolve to.
+ */
+export function templateFallbackChain(slug: string): string[] {
+    const chain = [slug];
+
+    if (slug !== 'single' && slug.startsWith('single-')) {
+        chain.push('single');
+    } else if (slug !== 'page' && slug.startsWith('page-')) {
+        chain.push('page');
+    }
+
+    if (slug !== 'index') {
+        chain.push('index');
+    }
+
+    return chain;
+}
+
+export function findTemplate(
+    templates: TemplateRecord[],
+    slug: string,
+    theme?: string
+): TemplateRecord | undefined {
+    return templates.find((template) => {
+        if (template.slug !== slug) {
+            return false;
+        }
+
+        if (theme === undefined || theme === '') {
+            return true;
+        }
+
+        return template.theme === undefined || template.theme === '' || template.theme === theme;
+    });
+}
+
+export function resolveTemplate(
+    templates: TemplateRecord[],
+    slug: string,
+    theme?: string
+): TemplateRecord | undefined {
+    for (const candidate of templateFallbackChain(slug)) {
+        const match = findTemplate(templates, candidate, theme);
+
+        if (match !== undefined) {
+            return match;
+        }
+    }
+
+    return undefined;
+}
+
+export function inlineTemplateParts(tree: Block[], options: InlineTemplatePartsOptions): Block[] {
+    const context: WalkContext = {
+        parts: options.parts,
+        defaultTheme: options.defaultTheme,
+        maxDepth: options.maxDepth ?? DEFAULT_MAX_TEMPLATE_PART_DEPTH,
+        stack: [],
+        depth: 0,
+    };
+
+    return walk(tree, context);
+}
+
+function walk(tree: Block[], context: WalkContext): Block[] {
+    const out: Block[] = [];
+
+    for (const block of tree) {
+        if (block === null || typeof block !== 'object' || Array.isArray(block)) {
+            continue;
+        }
+
+        const name = typeof block.name === 'string' ? block.name : '';
+
+        if (name === 'core/template-part') {
+            out.push(resolvePart(block, context));
+
+            continue;
+        }
+
+        const inner = Array.isArray(block.innerBlocks) ? block.innerBlocks : [];
+
+        out.push({
+            ...block,
+            innerBlocks: walk(inner, context),
+        });
+    }
+
+    return out;
+}
+
+function resolvePart(block: Block, context: WalkContext): Block {
+    const attrs = block.attributes ?? {};
+    const slug = typeof attrs.slug === 'string' ? attrs.slug.trim() : '';
+    let theme = typeof attrs.theme === 'string' ? attrs.theme.trim() : '';
+
+    if (theme === '' && context.defaultTheme !== undefined) {
+        theme = context.defaultTheme;
+    }
+
+    if (slug === '') {
+        return markUnresolved(block, 'missing-slug', slug, theme);
+    }
+
+    if (context.depth >= context.maxDepth) {
+        return markUnresolved(block, 'depth-limit', slug, theme);
+    }
+
+    const key = `${theme}/${slug}`;
+
+    if (context.stack.includes(key)) {
+        return markUnresolved(block, 'cycle', slug, theme);
+    }
+
+    const part = findPart(context.parts, slug, theme);
+
+    if (part === undefined) {
+        return markUnresolved(block, 'not-found', slug, theme);
+    }
+
+    const childContext: WalkContext = {
+        ...context,
+        defaultTheme: theme !== '' ? theme : context.defaultTheme,
+        stack: [...context.stack, key],
+        depth: context.depth + 1,
+    };
+
+    return {
+        clientId: block.clientId,
+        name: 'core/template-part',
+        attributes: {
+            ...attrs,
+            slug,
+            theme,
+        },
+        innerBlocks: walk(Array.isArray(part.blocks) ? part.blocks : [], childContext),
+    };
+}
+
+function findPart(
+    parts: TemplatePartRecord[],
+    slug: string,
+    theme: string
+): TemplatePartRecord | undefined {
+    return parts.find((part) => {
+        if (part.slug !== slug) {
+            return false;
+        }
+
+        if (theme === '') {
+            return true;
+        }
+
+        return part.theme === undefined || part.theme === '' || part.theme === theme;
+    });
+}
+
+function markUnresolved(
+    block: Block,
+    reason: TemplatePartResolutionError,
+    slug: string,
+    theme: string
+): Block {
+    return {
+        clientId: block.clientId,
+        name: 'core/template-part',
+        attributes: {
+            ...(block.attributes ?? {}),
+            slug,
+            theme,
+            _resolutionError: reason,
+        },
+        innerBlocks: [],
+    };
+}

--- a/packages/visual-editor-renderer-vue/tests/Template.test.ts
+++ b/packages/visual-editor-renderer-vue/tests/Template.test.ts
@@ -60,6 +60,20 @@ describe('BlockTree template-part inlining', () => {
         expect(el.exists()).toBe(true);
         expect(el.element.children.length).toBe(0);
     });
+
+    it('runs the inliner for an explicit empty templateParts array so missing references are flagged', () => {
+        const wrapper = mount(BlockTree, {
+            props: { tree: [partRef('header')], templateParts: [] as TemplatePartRecord[] },
+        });
+
+        const el = wrapper.find('[data-ve-template-part="header"]');
+
+        // Empty array means "no parts supplied" — the inliner should mark
+        // the reference unresolved so dev diagnostics surface, rather than
+        // silently rendering an empty wrapper indistinguishable from
+        // "templateParts not configured at all."
+        expect(el.attributes('data-ve-resolution-error')).toBe('not-found');
+    });
 });
 
 describe('Template component', () => {

--- a/packages/visual-editor-renderer-vue/tests/Template.test.ts
+++ b/packages/visual-editor-renderer-vue/tests/Template.test.ts
@@ -1,0 +1,131 @@
+import { mount } from '@vue/test-utils';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import '../src/index';
+import { BlockTree } from '../src/BlockTree';
+import { Template } from '../src/Template';
+import { resetBlockRegistry } from '../src/registry';
+import { registerCoreBlocks } from '../src/blocks/registerCoreBlocks';
+import type { TemplatePartRecord, TemplateRecord } from '../src/templateParts';
+import type { Block } from '../src/types';
+import { makeBlock, normalizeHtml } from './helpers';
+
+function paragraph(text: string, clientId = 'p-cid'): Block {
+    return makeBlock('core/paragraph', { content: text }, [], clientId);
+}
+
+function partRef(slug: string, theme = 'artisanpack-base', clientId = 'tp-cid'): Block {
+    return makeBlock('core/template-part', { slug, theme }, [], clientId);
+}
+
+afterEach(() => {
+    resetBlockRegistry();
+    registerCoreBlocks();
+});
+
+describe('BlockTree template-part inlining', () => {
+    it('renders a referenced part wrapped in a wp-block-template-part element', () => {
+        const parts: TemplatePartRecord[] = [
+            { slug: 'header', theme: 'artisanpack-base', blocks: [paragraph('Header text', 'h-1')] },
+        ];
+
+        const wrapper = mount(BlockTree, {
+            props: { tree: [partRef('header')], templateParts: parts },
+        });
+        const html = normalizeHtml(wrapper.html());
+
+        expect(html).toContain('<div class="wp-block-template-part wp-block-template-part--header"');
+        expect(html).toContain('data-ve-template-part="header"');
+        expect(html).toContain('<p class="wp-block-paragraph">Header text</p>');
+    });
+
+    it('wraps a missing reference as an empty element with no children', () => {
+        const wrapper = mount(BlockTree, {
+            props: { tree: [partRef('never-created')], templateParts: [] as TemplatePartRecord[] },
+        });
+
+        const el = wrapper.find('[data-ve-template-part="never-created"]');
+
+        expect(el.exists()).toBe(true);
+        expect(el.element.children.length).toBe(0);
+    });
+
+    it('does not run the inliner when no parts are supplied', () => {
+        const wrapper = mount(BlockTree, {
+            props: { tree: [partRef('header')] },
+        });
+
+        const el = wrapper.find('[data-ve-template-part="header"]');
+
+        expect(el.exists()).toBe(true);
+        expect(el.element.children.length).toBe(0);
+    });
+});
+
+describe('Template component', () => {
+    const parts: TemplatePartRecord[] = [
+        { slug: 'header', theme: 'artisanpack-base', blocks: [paragraph('Header content', 'h-1')] },
+    ];
+
+    it('renders the matched template with parts inlined', () => {
+        const templates: TemplateRecord[] = [
+            {
+                slug: 'page-about',
+                theme: 'artisanpack-base',
+                blocks: [partRef('header'), paragraph('Body', 'b-1')],
+            },
+        ];
+
+        const wrapper = mount(Template, {
+            props: {
+                slug: 'page-about',
+                theme: 'artisanpack-base',
+                templates,
+                templateParts: parts,
+            },
+        });
+        const html = normalizeHtml(wrapper.html());
+
+        expect(html).toContain('data-ve-template="page-about"');
+        expect(html).toContain('<p class="wp-block-paragraph">Header content</p>');
+        expect(html).toContain('<p class="wp-block-paragraph">Body</p>');
+    });
+
+    it('walks the fallback chain (page-about → page → index)', () => {
+        const templates: TemplateRecord[] = [
+            { slug: 'page', theme: 'artisanpack-base', blocks: [paragraph('Default page', 'p-1')] },
+            { slug: 'index', theme: 'artisanpack-base', blocks: [paragraph('Catch-all', 'i-1')] },
+        ];
+
+        const wrapper = mount(Template, {
+            props: { slug: 'page-about', theme: 'artisanpack-base', templates, templateParts: parts },
+        });
+        const html = normalizeHtml(wrapper.html());
+
+        expect(html).toContain('data-ve-matched-template="page"');
+        expect(html).toContain('Default page');
+        expect(html).not.toContain('Catch-all');
+    });
+
+    it('renders an empty wrapper when nothing in the chain matches', () => {
+        const wrapper = mount(Template, {
+            props: { slug: 'single-post', theme: 'artisanpack-base', templates: [], templateParts: [] },
+        });
+
+        const el = wrapper.find('[data-ve-template="single-post"]');
+
+        expect(el.exists()).toBe(true);
+        expect(el.element.children.length).toBe(0);
+    });
+
+    it('exposes the fallback chain via a data attribute in development', () => {
+        const wrapper = mount(Template, {
+            props: { slug: 'single-post', theme: 'artisanpack-base', templates: [], templateParts: [] },
+        });
+
+        const el = wrapper.find('[data-ve-template="single-post"]');
+
+        expect(el.attributes('data-ve-resolution-error')).toBe('no-matching-template');
+        expect(el.attributes('data-ve-fallback-chain')).toBe('single-post,single,index');
+    });
+});

--- a/packages/visual-editor-renderer-vue/tests/parity.test.ts
+++ b/packages/visual-editor-renderer-vue/tests/parity.test.ts
@@ -354,6 +354,17 @@ const FIXTURES: Array<{ name: string; tree: Block[] }> = [
             ),
         ],
     },
+    {
+        name: 'template-part wrapper with inlined inner block',
+        tree: [
+            makeBlock(
+                'core/template-part',
+                { slug: 'header', theme: 'artisanpack-base' },
+                [makeBlock('core/paragraph', { content: 'Inlined header' }, [], 'p-h')],
+                'tp-1'
+            ),
+        ],
+    },
 ];
 
 describe('React/Vue renderer parity', () => {

--- a/packages/visual-editor-renderer-vue/tests/templateParts.test.ts
+++ b/packages/visual-editor-renderer-vue/tests/templateParts.test.ts
@@ -73,6 +73,24 @@ describe('findTemplate / resolveTemplate', () => {
     it('returns templates regardless of theme when no theme is supplied', () => {
         expect(findTemplate(templates, 'index')?.slug).toBe('index');
     });
+
+    it('prefers an exact-theme match over an unthemed record regardless of array order', () => {
+        const mixed = [
+            { slug: 'index', theme: '', blocks: [paragraph('Unthemed')] },
+            { slug: 'index', theme: 'artisanpack-base', blocks: [paragraph('Themed')] },
+        ];
+
+        expect(findTemplate(mixed, 'index', 'artisanpack-base')?.blocks[0].attributes?.content).toBe('Themed');
+    });
+
+    it('falls back to an unthemed record only when no exact-theme match exists', () => {
+        const mixed = [
+            { slug: 'index', theme: '', blocks: [paragraph('Unthemed')] },
+            { slug: 'index', theme: 'other-theme', blocks: [paragraph('Other')] },
+        ];
+
+        expect(findTemplate(mixed, 'index', 'artisanpack-base')?.blocks[0].attributes?.content).toBe('Unthemed');
+    });
 });
 
 describe('inlineTemplateParts', () => {
@@ -172,5 +190,17 @@ describe('inlineTemplateParts', () => {
 
     it('exposes a default depth limit', () => {
         expect(DEFAULT_MAX_TEMPLATE_PART_DEPTH).toBe(10);
+    });
+
+    it('prefers an exact-theme part over an unthemed part regardless of array order', () => {
+        const parts = [
+            { slug: 'header', theme: '', blocks: [paragraph('Unthemed')] },
+            { slug: 'header', theme: 'artisanpack-base', blocks: [paragraph('Themed')] },
+        ];
+        const tree = [partRef('header', 'artisanpack-base')];
+
+        const inlined = inlineTemplateParts(tree, { parts });
+
+        expect(inlined[0].innerBlocks?.[0].attributes?.content).toBe('Themed');
     });
 });

--- a/packages/visual-editor-renderer-vue/tests/templateParts.test.ts
+++ b/packages/visual-editor-renderer-vue/tests/templateParts.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    DEFAULT_MAX_TEMPLATE_PART_DEPTH,
+    findTemplate,
+    inlineTemplateParts,
+    resolveTemplate,
+    templateFallbackChain,
+} from '../src/templateParts';
+import type { Block } from '../src/types';
+
+function paragraph(text: string, clientId = 'p-cid'): Block {
+    return {
+        clientId,
+        name: 'core/paragraph',
+        attributes: { content: text },
+        innerBlocks: [],
+    };
+}
+
+function partRef(slug: string, theme = 'artisanpack-base', clientId = 'tp-cid'): Block {
+    return {
+        clientId,
+        name: 'core/template-part',
+        attributes: { slug, theme },
+        innerBlocks: [],
+    };
+}
+
+describe('templateFallbackChain', () => {
+    it('expands single-{slug} → single → index', () => {
+        expect(templateFallbackChain('single-post')).toEqual(['single-post', 'single', 'index']);
+    });
+
+    it('expands page-{slug} → page → index', () => {
+        expect(templateFallbackChain('page-about')).toEqual(['page-about', 'page', 'index']);
+    });
+
+    it('falls straight to index for unspecialized slugs', () => {
+        expect(templateFallbackChain('archive')).toEqual(['archive', 'index']);
+    });
+
+    it('returns just [index] for index itself', () => {
+        expect(templateFallbackChain('index')).toEqual(['index']);
+    });
+});
+
+describe('findTemplate / resolveTemplate', () => {
+    const templates = [
+        { slug: 'index', theme: 'artisanpack-base', blocks: [paragraph('Index')] },
+        { slug: 'page', theme: 'artisanpack-base', blocks: [paragraph('Page')] },
+        { slug: 'page-about', theme: 'artisanpack-base', blocks: [paragraph('About')] },
+    ];
+
+    it('returns the exact match when present', () => {
+        expect(resolveTemplate(templates, 'page-about', 'artisanpack-base')?.slug).toBe('page-about');
+    });
+
+    it('falls back to page when page-{slug} is missing', () => {
+        expect(resolveTemplate(templates, 'page-contact', 'artisanpack-base')?.slug).toBe('page');
+    });
+
+    it('falls back to index when page is missing too', () => {
+        const subset = [{ slug: 'index', blocks: [paragraph('idx')] }];
+
+        expect(resolveTemplate(subset, 'page-about')?.slug).toBe('index');
+    });
+
+    it('returns undefined when nothing matches', () => {
+        expect(resolveTemplate([], 'archive')).toBeUndefined();
+    });
+
+    it('returns templates regardless of theme when no theme is supplied', () => {
+        expect(findTemplate(templates, 'index')?.slug).toBe('index');
+    });
+});
+
+describe('inlineTemplateParts', () => {
+    it('inlines a referenced part', () => {
+        const parts = [{ slug: 'header', theme: 'artisanpack-base', blocks: [paragraph('H')] }];
+        const tree = [partRef('header')];
+
+        const inlined = inlineTemplateParts(tree, { parts });
+
+        expect(inlined[0].name).toBe('core/template-part');
+        expect(inlined[0].innerBlocks?.[0].attributes?.content).toBe('H');
+    });
+
+    it('uses defaultTheme when the reference omits theme', () => {
+        const parts = [{ slug: 'header', theme: 'artisanpack-base', blocks: [paragraph('H')] }];
+        const tree = [
+            { clientId: 'tp', name: 'core/template-part', attributes: { slug: 'header' }, innerBlocks: [] },
+        ];
+
+        const inlined = inlineTemplateParts(tree, { parts, defaultTheme: 'artisanpack-base' });
+
+        expect(inlined[0].innerBlocks?.[0].attributes?.content).toBe('H');
+    });
+
+    it('marks missing references with the not-found error', () => {
+        const tree = [partRef('never-created')];
+
+        const inlined = inlineTemplateParts(tree, { parts: [] });
+
+        expect(inlined[0].attributes?._resolutionError).toBe('not-found');
+    });
+
+    it('marks missing slug with the missing-slug error', () => {
+        const tree: Block[] = [
+            { clientId: 'tp', name: 'core/template-part', attributes: {}, innerBlocks: [] },
+        ];
+
+        const inlined = inlineTemplateParts(tree, { parts: [] });
+
+        expect(inlined[0].attributes?._resolutionError).toBe('missing-slug');
+    });
+
+    it('detects direct cycles', () => {
+        const parts = [{ slug: 'looper', theme: 'artisanpack-base', blocks: [partRef('looper')] }];
+        const tree = [partRef('looper')];
+
+        const inlined = inlineTemplateParts(tree, { parts });
+
+        expect(inlined[0].innerBlocks?.[0].attributes?._resolutionError).toBe('cycle');
+    });
+
+    it('detects indirect cycles (a → b → a)', () => {
+        const parts = [
+            { slug: 'a', theme: 'artisanpack-base', blocks: [partRef('b')] },
+            { slug: 'b', theme: 'artisanpack-base', blocks: [partRef('a')] },
+        ];
+        const tree = [partRef('a')];
+
+        const inlined = inlineTemplateParts(tree, { parts });
+
+        const cycleNode = inlined[0].innerBlocks?.[0].innerBlocks?.[0];
+
+        expect(cycleNode?.attributes?._resolutionError).toBe('cycle');
+    });
+
+    it('enforces the depth limit', () => {
+        const parts = [
+            { slug: 'p0', theme: 'artisanpack-base', blocks: [partRef('p1')] },
+            { slug: 'p1', theme: 'artisanpack-base', blocks: [partRef('p2')] },
+            { slug: 'p2', theme: 'artisanpack-base', blocks: [partRef('p3')] },
+            { slug: 'p3', theme: 'artisanpack-base', blocks: [paragraph('end')] },
+        ];
+
+        const inlined = inlineTemplateParts([partRef('p0')], { parts, maxDepth: 2 });
+
+        const third = inlined[0].innerBlocks?.[0].innerBlocks?.[0];
+
+        expect(third?.attributes?._resolutionError).toBe('depth-limit');
+    });
+
+    it('preserves non-template-part blocks', () => {
+        const tree = [paragraph('only')];
+
+        expect(inlineTemplateParts(tree, { parts: [] })).toEqual(tree);
+    });
+
+    it('descends into nested innerBlocks looking for parts', () => {
+        const parts = [{ slug: 'header', theme: 'artisanpack-base', blocks: [paragraph('H')] }];
+        const tree = [
+            { clientId: 'g', name: 'core/group', attributes: {}, innerBlocks: [partRef('header')] },
+        ];
+
+        const inlined = inlineTemplateParts(tree, { parts });
+
+        expect(inlined[0].innerBlocks?.[0].innerBlocks?.[0].attributes?.content).toBe('H');
+    });
+
+    it('exposes a default depth limit', () => {
+        expect(DEFAULT_MAX_TEMPLATE_PART_DEPTH).toBe(10);
+    });
+});

--- a/src/Resources/TemplatePartInliner.php
+++ b/src/Resources/TemplatePartInliner.php
@@ -1,0 +1,217 @@
+<?php
+
+/**
+ * TemplatePartInliner service.
+ *
+ * Walks a saved Gutenberg block tree and replaces every `core/template-part`
+ * block with the same block carrying its resolved part's blocks as
+ * `innerBlocks`. Front-end renderers (Blade, React, Vue) consume the
+ * post-inlining tree so a single recursive renderer pass produces the
+ * final HTML — there is no per-renderer template-part lookup.
+ *
+ * Recursion guard: an in-flight stack of `theme/slug` keys catches cycles
+ * (header → nav → header) and a depth counter caps how deep the resolution
+ * chain can go (default 10). Either guard converts the offending block
+ * into a marker whose `attributes._resolutionError` records the reason —
+ * the renderers translate that into a graceful empty render in production
+ * and a visible warning in dev.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Resources;
+
+use ArtisanPackUI\VisualEditor\Models\VisualEditorTemplatePart;
+
+class TemplatePartInliner
+{
+	/**
+	 * Default cap on how many levels deep the template-part chain can
+	 * resolve before the renderer renders the fallback marker. Real
+	 * sites rarely nest parts more than two or three deep; ten leaves
+	 * generous headroom while still terminating before PHP exhausts
+	 * its stack.
+	 */
+	public const DEFAULT_MAX_DEPTH = 10;
+
+	public const ERROR_MISSING_SLUG  = 'missing-slug';
+	public const ERROR_NOT_FOUND     = 'not-found';
+	public const ERROR_CYCLE         = 'cycle';
+	public const ERROR_DEPTH_LIMIT   = 'depth-limit';
+
+	public function __construct(
+		protected int $maxDepth = self::DEFAULT_MAX_DEPTH
+	) {
+	}
+
+	/**
+	 * Walks `$tree` and returns a copy with every `core/template-part`
+	 * block carrying its resolved part's blocks under `innerBlocks`.
+	 *
+	 * The returned shape matches the input — the same `clientId`, `name`,
+	 * and `attributes` keys are preserved so existing renderers can render
+	 * the inlined tree without special-casing template parts. Blocks the
+	 * inliner cannot resolve (missing slug, missing part, cycle, depth
+	 * overflow) keep the `core/template-part` name and gain a synthetic
+	 * `_resolutionError` attribute the renderers detect.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array<int, array<string, mixed>>  $tree            Parsed block tree.
+	 * @param  ?string                           $defaultTheme    Theme to assume when a `core/template-part` block omits the `theme` attribute.
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	public function inline( array $tree, ?string $defaultTheme = null ): array
+	{
+		return $this->walk( $tree, $defaultTheme, [], 0 );
+	}
+
+	/**
+	 * Recursive walker shared by the public entry point and inner-block
+	 * descent. Keeps the cycle stack and depth counter on the stack frame
+	 * (rather than instance state) so concurrent calls into the same
+	 * inliner instance don't leak resolution context across trees.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array<int, array<string, mixed>>  $tree
+	 * @param  array<int, string>                $stack
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	protected function walk( array $tree, ?string $defaultTheme, array $stack, int $depth ): array
+	{
+		$out = [];
+
+		foreach ( $tree as $block ) {
+			if ( ! is_array( $block ) ) {
+				continue;
+			}
+
+			$name = isset( $block['name'] ) && is_string( $block['name'] ) ? $block['name'] : '';
+
+			if ( 'core/template-part' === $name ) {
+				$out[] = $this->resolvePart( $block, $defaultTheme, $stack, $depth );
+
+				continue;
+			}
+
+			$innerBlocks          = isset( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ? $block['innerBlocks'] : [];
+			$block['innerBlocks'] = $this->walk( $innerBlocks, $defaultTheme, $stack, $depth );
+			$out[]                = $block;
+		}
+
+		return $out;
+	}
+
+	/**
+	 * Looks the part up by slug + theme and returns the block with the
+	 * resolved blocks attached as `innerBlocks`.
+	 *
+	 * Resolution failures (missing slug, missing record, cycle, depth
+	 * overflow) return the original block stamped with a
+	 * `_resolutionError` attribute so the renderer can react without
+	 * hard-failing the whole template.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array<string, mixed>  $block
+	 * @param  array<int, string>    $stack
+	 *
+	 * @return array<string, mixed>
+	 */
+	protected function resolvePart( array $block, ?string $defaultTheme, array $stack, int $depth ): array
+	{
+		$attributes = isset( $block['attributes'] ) && is_array( $block['attributes'] ) ? $block['attributes'] : [];
+		$slug       = isset( $attributes['slug'] ) && is_string( $attributes['slug'] ) ? trim( $attributes['slug'] ) : '';
+		$theme      = isset( $attributes['theme'] ) && is_string( $attributes['theme'] ) ? trim( $attributes['theme'] ) : '';
+
+		if ( '' === $theme && null !== $defaultTheme ) {
+			$theme = $defaultTheme;
+		}
+
+		if ( '' === $slug ) {
+			return $this->markUnresolved( $block, self::ERROR_MISSING_SLUG, $slug, $theme );
+		}
+
+		if ( $depth >= $this->maxDepth ) {
+			return $this->markUnresolved( $block, self::ERROR_DEPTH_LIMIT, $slug, $theme );
+		}
+
+		$key = $theme . '/' . $slug;
+
+		if ( in_array( $key, $stack, true ) ) {
+			return $this->markUnresolved( $block, self::ERROR_CYCLE, $slug, $theme );
+		}
+
+		$part = $this->findPart( $slug, $theme );
+
+		if ( null === $part ) {
+			return $this->markUnresolved( $block, self::ERROR_NOT_FOUND, $slug, $theme );
+		}
+
+		$childStack       = $stack;
+		$childStack[]     = $key;
+		$resolvedChildren = $this->walk( $part->getBlocks(), '' !== $theme ? $theme : $defaultTheme, $childStack, $depth + 1 );
+
+		return [
+			'clientId'    => $block['clientId'] ?? null,
+			'name'        => 'core/template-part',
+			'attributes'  => array_merge( $attributes, [
+				'slug'  => $slug,
+				'theme' => $theme,
+			] ),
+			'innerBlocks' => $resolvedChildren,
+		];
+	}
+
+	/**
+	 * Looks the part up by slug, optionally constrained to a theme.
+	 *
+	 * @since 1.0.0
+	 */
+	protected function findPart( string $slug, string $theme ): ?VisualEditorTemplatePart
+	{
+		$query = VisualEditorTemplatePart::query()->where( 'slug', $slug );
+
+		if ( '' !== $theme ) {
+			$query->where( 'theme', $theme );
+		}
+
+		return $query->first();
+	}
+
+	/**
+	 * Returns the block stamped with the resolution-failure reason so
+	 * downstream renderers can short-circuit to their fallback markup.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array<string, mixed>  $block
+	 *
+	 * @return array<string, mixed>
+	 */
+	protected function markUnresolved( array $block, string $reason, string $slug, string $theme ): array
+	{
+		$attributes = isset( $block['attributes'] ) && is_array( $block['attributes'] ) ? $block['attributes'] : [];
+
+		return [
+			'clientId'    => $block['clientId'] ?? null,
+			'name'        => 'core/template-part',
+			'attributes'  => array_merge( $attributes, [
+				'slug'              => $slug,
+				'theme'             => $theme,
+				'_resolutionError' => $reason,
+			] ),
+			'innerBlocks' => [],
+		];
+	}
+}

--- a/src/Resources/TemplatePartInliner.php
+++ b/src/Resources/TemplatePartInliner.php
@@ -176,17 +176,18 @@ class TemplatePartInliner
 	/**
 	 * Looks the part up by slug, optionally constrained to a theme.
 	 *
+	 * Delegates to {@see VisualEditorTemplatePart::scopeForSlug()} so the
+	 * empty-string-vs-null theme handling stays in one place — passing
+	 * an empty string here is treated as "no theme filter" the same way
+	 * the scope does.
+	 *
 	 * @since 1.0.0
 	 */
 	protected function findPart( string $slug, string $theme ): ?VisualEditorTemplatePart
 	{
-		$query = VisualEditorTemplatePart::query()->where( 'slug', $slug );
-
-		if ( '' !== $theme ) {
-			$query->where( 'theme', $theme );
-		}
-
-		return $query->first();
+		return VisualEditorTemplatePart::query()
+			->forSlug( $slug, '' === $theme ? null : $theme )
+			->first();
 	}
 
 	/**

--- a/tests/Unit/VisualEditor/TemplatePartInlinerTest.php
+++ b/tests/Unit/VisualEditor/TemplatePartInlinerTest.php
@@ -1,0 +1,180 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Models\VisualEditorTemplatePart;
+use ArtisanPackUI\VisualEditor\Resources\TemplatePartInliner;
+
+function inlinerMakePart( string $slug, array $blocks, string $theme = 'artisanpack-base', string $area = 'uncategorized' ): VisualEditorTemplatePart
+{
+	return VisualEditorTemplatePart::create( [
+		'slug'    => $slug,
+		'title'   => ucfirst( $slug ),
+		'content' => [ 'raw' => '', 'blocks' => $blocks ],
+		'area'    => $area,
+		'theme'   => $theme,
+	] );
+}
+
+function inlinerPartRef( string $slug, ?string $theme = null, string $clientId = 'tp-cid' ): array
+{
+	$attributes = [ 'slug' => $slug ];
+
+	if ( null !== $theme ) {
+		$attributes['theme'] = $theme;
+	}
+
+	return [
+		'clientId'    => $clientId,
+		'name'        => 'core/template-part',
+		'attributes'  => $attributes,
+		'innerBlocks' => [],
+	];
+}
+
+function inlinerParagraph( string $text, string $clientId = 'p-cid' ): array
+{
+	return [
+		'clientId'    => $clientId,
+		'name'        => 'core/paragraph',
+		'attributes'  => [ 'content' => $text ],
+		'innerBlocks' => [],
+	];
+}
+
+it( 'inlines a single template-part reference', function () {
+	inlinerMakePart( 'header', [ inlinerParagraph( 'Header content', 'p-1' ) ] );
+
+	$tree = [ inlinerPartRef( 'header', 'artisanpack-base' ) ];
+
+	$resolved = ( new TemplatePartInliner() )->inline( $tree );
+
+	expect( $resolved )->toHaveCount( 1 );
+	expect( $resolved[0]['name'] )->toBe( 'core/template-part' );
+	expect( $resolved[0]['innerBlocks'] )->toHaveCount( 1 );
+	expect( $resolved[0]['innerBlocks'][0]['attributes']['content'] )->toBe( 'Header content' );
+} );
+
+it( 'falls back to defaultTheme when the reference omits its theme attribute', function () {
+	inlinerMakePart( 'header', [ inlinerParagraph( 'Default theme header' ) ], 'artisanpack-base' );
+
+	$tree = [ inlinerPartRef( 'header' ) ];
+
+	$resolved = ( new TemplatePartInliner() )->inline( $tree, 'artisanpack-base' );
+
+	expect( $resolved[0]['innerBlocks'][0]['attributes']['content'] )->toBe( 'Default theme header' );
+} );
+
+it( 'descends into nested innerBlocks looking for template parts', function () {
+	inlinerMakePart( 'header', [ inlinerParagraph( 'Inside group' ) ] );
+
+	$tree = [
+		[
+			'clientId'    => 'g-1',
+			'name'        => 'core/group',
+			'attributes'  => [],
+			'innerBlocks' => [ inlinerPartRef( 'header', 'artisanpack-base' ) ],
+		],
+	];
+
+	$resolved = ( new TemplatePartInliner() )->inline( $tree );
+
+	expect( $resolved[0]['innerBlocks'][0]['name'] )->toBe( 'core/template-part' );
+	expect( $resolved[0]['innerBlocks'][0]['innerBlocks'][0]['attributes']['content'] )->toBe( 'Inside group' );
+} );
+
+it( 'recurses through nested template parts', function () {
+	inlinerMakePart( 'inner', [ inlinerParagraph( 'Innermost' ) ] );
+	inlinerMakePart( 'outer', [ inlinerPartRef( 'inner', 'artisanpack-base' ) ] );
+
+	$tree = [ inlinerPartRef( 'outer', 'artisanpack-base' ) ];
+
+	$resolved = ( new TemplatePartInliner() )->inline( $tree );
+
+	expect( $resolved[0]['innerBlocks'][0]['name'] )->toBe( 'core/template-part' );
+	expect( $resolved[0]['innerBlocks'][0]['innerBlocks'][0]['attributes']['content'] )->toBe( 'Innermost' );
+} );
+
+it( 'marks a missing slug attribute with the missing-slug error', function () {
+	$tree = [
+		[
+			'clientId'    => 'tp-1',
+			'name'        => 'core/template-part',
+			'attributes'  => [ 'theme' => 'artisanpack-base' ],
+			'innerBlocks' => [],
+		],
+	];
+
+	$resolved = ( new TemplatePartInliner() )->inline( $tree );
+
+	expect( $resolved[0]['attributes']['_resolutionError'] )->toBe( TemplatePartInliner::ERROR_MISSING_SLUG );
+	expect( $resolved[0]['innerBlocks'] )->toBe( [] );
+} );
+
+it( 'marks a missing record with the not-found error', function () {
+	$tree = [ inlinerPartRef( 'never-created', 'artisanpack-base' ) ];
+
+	$resolved = ( new TemplatePartInliner() )->inline( $tree );
+
+	expect( $resolved[0]['attributes']['_resolutionError'] )->toBe( TemplatePartInliner::ERROR_NOT_FOUND );
+} );
+
+it( 'detects a direct cycle (a → a)', function () {
+	inlinerMakePart( 'looper', [ inlinerPartRef( 'looper', 'artisanpack-base' ) ] );
+
+	$tree = [ inlinerPartRef( 'looper', 'artisanpack-base' ) ];
+
+	$resolved = ( new TemplatePartInliner() )->inline( $tree );
+
+	expect( $resolved[0]['attributes']['_resolutionError'] ?? null )->toBeNull();
+	expect( $resolved[0]['innerBlocks'][0]['attributes']['_resolutionError'] )
+		->toBe( TemplatePartInliner::ERROR_CYCLE );
+} );
+
+it( 'detects an indirect cycle (a → b → a)', function () {
+	inlinerMakePart( 'a', [ inlinerPartRef( 'b', 'artisanpack-base', 'b-ref' ) ] );
+	inlinerMakePart( 'b', [ inlinerPartRef( 'a', 'artisanpack-base', 'a-ref' ) ] );
+
+	$tree = [ inlinerPartRef( 'a', 'artisanpack-base', 'a-root' ) ];
+
+	$resolved = ( new TemplatePartInliner() )->inline( $tree );
+
+	$cycleNode = $resolved[0]['innerBlocks'][0]['innerBlocks'][0];
+
+	expect( $cycleNode['name'] )->toBe( 'core/template-part' );
+	expect( $cycleNode['attributes']['_resolutionError'] )->toBe( TemplatePartInliner::ERROR_CYCLE );
+} );
+
+it( 'enforces the depth limit', function () {
+	for ( $i = 0; $i < 5; $i++ ) {
+		$nextRef = $i === 4 ? [] : [ inlinerPartRef( 'p' . ( $i + 1 ), 'artisanpack-base', 'p' . ( $i + 1 ) . '-ref' ) ];
+		inlinerMakePart( 'p' . $i, $nextRef );
+	}
+
+	$tree = [ inlinerPartRef( 'p0', 'artisanpack-base', 'p0-root' ) ];
+
+	$resolved = ( new TemplatePartInliner( 2 ) )->inline( $tree );
+
+	$third = $resolved[0]['innerBlocks'][0]['innerBlocks'][0];
+
+	expect( $third['name'] )->toBe( 'core/template-part' );
+	expect( $third['attributes']['_resolutionError'] )->toBe( TemplatePartInliner::ERROR_DEPTH_LIMIT );
+} );
+
+it( 'preserves non-template-part blocks untouched', function () {
+	$tree = [
+		inlinerParagraph( 'Just text', 'p-only' ),
+	];
+
+	$resolved = ( new TemplatePartInliner() )->inline( $tree );
+
+	expect( $resolved )->toBe( $tree );
+} );
+
+it( 'returns an empty array when given non-array entries', function () {
+	$tree = [ 'not-a-block', null, 42 ];
+
+	$resolved = ( new TemplatePartInliner() )->inline( $tree );
+
+	expect( $resolved )->toBe( [] );
+} );

--- a/tests/Unit/VisualEditor/TemplatePartInlinerTest.php
+++ b/tests/Unit/VisualEditor/TemplatePartInlinerTest.php
@@ -178,3 +178,33 @@ it( 'returns an empty array when given non-array entries', function () {
 
 	expect( $resolved )->toBe( [] );
 } );
+
+it( 'matches across themes when neither the block nor defaultTheme supplies one', function () {
+	// Same slug seeded under two themes. With no theme attribute on the
+	// block and no defaultTheme passed in, findPart degrades to a
+	// slug-only lookup (matching VisualEditorTemplatePart::scopeForSlug),
+	// so the first record wins. The point of this test is to lock in
+	// "the inliner doesn't crash and doesn't silently mark unresolved" —
+	// host apps that need deterministic cross-theme behavior should pass
+	// a defaultTheme.
+	inlinerMakePart( 'header', [ inlinerParagraph( 'Theme A' ) ], 'theme-a' );
+	inlinerMakePart( 'header', [ inlinerParagraph( 'Theme B' ) ], 'theme-b' );
+
+	$tree = [ inlinerPartRef( 'header' ) ];
+
+	$resolved = ( new TemplatePartInliner() )->inline( $tree );
+
+	expect( $resolved[0]['attributes']['_resolutionError'] ?? null )->toBeNull();
+	expect( $resolved[0]['innerBlocks'] )->toHaveCount( 1 );
+} );
+
+it( 'scopes to the defaultTheme when one is supplied alongside an untyped reference', function () {
+	inlinerMakePart( 'header', [ inlinerParagraph( 'Theme A' ) ], 'theme-a' );
+	inlinerMakePart( 'header', [ inlinerParagraph( 'Theme B' ) ], 'theme-b' );
+
+	$tree = [ inlinerPartRef( 'header' ) ];
+
+	$resolved = ( new TemplatePartInliner() )->inline( $tree, 'theme-b' );
+
+	expect( $resolved[0]['innerBlocks'][0]['attributes']['content'] )->toBe( 'Theme B' );
+} );


### PR DESCRIPTION
## Description

Adds the V1 front-end render path for templates and template parts so host apps can publish pages whose output matches the site editor's canvas preview. The work spans the core PHP package and all three renderer packages (Blade, React, Vue) with shared semantics for the WordPress-style fallback chain and template-part recursion guard.

**Closes:** #379

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #379

## Motivation and Context

Templates and template parts are the structural backbone of the site editor — without front-end rendering, none of the C1/C2/D2 work is visible to a host app's visitors. This PR closes the gap so the published site reflects what the editor canvas previews.

## Changes Made

**PHP (core `visual-editor` package)**
- `src/Resources/TemplatePartInliner.php` — walks a saved block tree, replaces every `core/template-part` reference with its part's blocks under `innerBlocks`. Cycle detection via stack of `theme/slug` keys; depth cap (default 10). Resolution failures stamp `_resolutionError` on the block.
- `TemplateResolver` (existing from C1 #357) drives the fallback chain (`single-{slug}` → `single` → `index`, `page-{slug}` → `page` → `index`, anything else → `index`).

**Blade renderer (`packages/visual-editor-renderer-blade/`)**
- `<x-ve-blocks>` auto-inlines `core/template-part` references via the inliner; new `:default-theme` and `:resolve-parts` props.
- New `<x-ve-template :slug :theme>` component resolves a template through the fallback chain and renders it with parts inlined.
- New `core/template-part` Blade partial wraps inlined children in a semantic element with `wp-block-template-part--{slug}` class + `data-ve-template-part` / `data-ve-theme` data attributes. Production renders an empty wrapper on resolution failure; dev renders an HTML comment listing the reason.

**React renderer (`packages/visual-editor-renderer-react/`)**
- New `templateParts.ts` module mirrors the PHP inliner + resolver so the same fallback chain runs client-side with no server round-trip.
- `<BlockTree>` accepts `templateParts`, `defaultTheme`, `maxTemplatePartDepth` props; runs the inliner before walking the tree.
- New `<Template>` component (`slug`, `theme`, `templates`, `templateParts`) resolves and renders the matched template.
- New `core/template-part` block renderer registered.

**Vue renderer (`packages/visual-editor-renderer-vue/`)**
- Same surface ported to Vue (`templateParts.ts`, `<BlockTree>` props, `<Template>` component, `core/template-part` renderer).
- Cross-renderer parity test extended with a template-part fixture so React + Vue continue to produce byte-identical HTML.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS 25.4.0
- Browser (if applicable): Chrome (dev-app smoke test)
- PHP Version: 8.4.3
- Project Version: 1.0.0-dev (`release/1.0`)

**Tests Performed:**
1. `./vendor/bin/pest --compact` — 379 PHP tests / 1226 assertions passing.
2. `npm test` — 191 renderer JS tests passing across both React + Vue (plus the cross-renderer parity test extended for `core/template-part`).
3. Browser smoke test in the host dev app: `<x-ve-template slug="index" theme="artisanpack-base" />` correctly renders the seeded `index` template with `header` + `footer` parts inlined; `slug="page-about"` correctly cascades to `page` (`data-ve-matched-template="page"` on the wrapper).

## Accessibility Tests Run

- [x] Keyboard navigation tested
- [x] Screen reader tested
- [ ] Color contrast verified
- [ ] ARIA labels checked

**Details:** Rendered output is plain semantic HTML (the template-part wrapper defaults to `<div>` but accepts `header` / `footer` / `aside` / `nav` / `main` / `section` via the `tagName` attribute). No interactive controls introduced — keyboard / screen-reader behaviour is whatever the underlying block renderers provide. No new color tokens, no new ARIA.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:**
- `tests/Unit/VisualEditor/TemplatePartInlinerTest.php` — 11 unit tests covering inlining, default-theme fallback, nested descent, recursive parts, missing-slug + missing-record errors, direct + indirect cycle detection, depth limit, non-template-part passthrough.
- `packages/visual-editor-renderer-blade/tests/Feature/TemplatePartRenderingTest.php` — 6 tests covering `<x-ve-blocks>` inlining, opt-out via `:resolve-parts="false"`, default-theme fallback, prod vs. dev resolution-failure render, cycle marker.
- `packages/visual-editor-renderer-blade/tests/Feature/TemplateComponentTest.php` — 6 tests covering `<x-ve-template>` exact match, fallback chain (page-about → page), deepest fallback (→ index), prod vs. dev no-match render, cross-theme lookup.
- React: 19 `templateParts` unit tests + 7 `<BlockTree>`/`<Template>` integration tests.
- Vue: 19 `templateParts` unit tests + 7 `<BlockTree>`/`<Template>` integration tests + 1 added template-part fixture in the React/Vue parity test.

## Documentation

- [x] Inline code documentation added
- [ ] README updated
- [ ] Wiki updated
- [ ] API documentation updated

**Documentation details:** Each new class / module / component carries a docblock explaining the contract, the recursion guard, and the prod-vs-dev failure semantics. The renderer package READMEs and the `docs/plans/05-template-system.md` doc were not updated in this PR — that's deferred to the F3 dev-app integration / #325 release prep work that was called out in the issue's "out-of-scope" section.

## Screenshots

(Browser smoke test image attached to the work-issue thread — `<x-ve-template>` on `/packages/visual-editor/e2/templates` renders the `index` template's seeded `header` + `footer` parts inlined.)

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [x] Accessibility tests completed
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Template rendering with WordPress-style fallback chains (e.g., page-about → page → index).
  * Template part inlining that replaces references with resolved content, honoring theme/default theme.
  * Exposed Template component and template-part utilities across renderers (React, Vue, Blade).
  * Cycle detection and recursion depth limits to prevent infinite inlining.
  * Development-mode diagnostics showing resolution errors and fallback chains.

* **Tests**
  * New comprehensive unit and feature tests validating resolution, inlining, fallbacks, error cases, and parity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->