### PR TITLE
feat: E1 · front-end global-styles CSS emission (#378)

### DIFF
--- a/packages/visual-editor-renderer-blade/resources/views/components/blocks.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/components/blocks.blade.php
@@ -1,1 +1,6 @@
+@isset( $globalStylesCss )
+@if( null !== $globalStylesCss && '' !== $globalStylesCss )
+<style data-ve-global-styles>{!! $globalStylesCss !!}</style>
+@endif
+@endisset
 {!! $html !!}

--- a/packages/visual-editor-renderer-blade/resources/views/components/template.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/components/template.blade.php
@@ -5,6 +5,11 @@
 		$wrapperClasses[] = 'wp-site-blocks--' . preg_replace( '/[^a-z0-9_-]/i', '-', $matchedSlug );
 	}
 @endphp
+@isset( $globalStylesCss )
+@if( null !== $globalStylesCss && '' !== $globalStylesCss )
+<style data-ve-global-styles>{!! $globalStylesCss !!}</style>
+@endif
+@endisset
 <div class="{{ implode( ' ', $wrapperClasses ) }}" data-ve-template="{{ $slug }}"@if( null !== $matchedSlug && $matchedSlug !== $slug ) data-ve-matched-template="{{ $matchedSlug }}"@endif>
 @if( null !== $resolutionError )
 @if( $inDev )

--- a/packages/visual-editor-renderer-blade/src/View/Components/BlocksComponent.php
+++ b/packages/visual-editor-renderer-blade/src/View/Components/BlocksComponent.php
@@ -23,6 +23,8 @@ declare( strict_types=1 );
 namespace ArtisanPackUI\VisualEditorRendererBlade\View\Components;
 
 use ArtisanPackUI\VisualEditor\Resources\TemplatePartInliner;
+use ArtisanPackUI\VisualEditor\Services\GlobalStylesCssProvider;
+use ArtisanPackUI\VisualEditor\Services\GlobalStylesEmissionTracker;
 use ArtisanPackUI\VisualEditorRendererBlade\BlockRenderer;
 use Illuminate\Contracts\View\View;
 use Illuminate\View\Component;
@@ -36,13 +38,23 @@ class BlocksComponent extends Component
 	 */
 	public array $tree;
 
+	/**
+	 * Theme slug forwarded to the global-styles provider so a block tree
+	 * rendered against a non-default theme picks up that theme's record.
+	 */
+	protected ?string $defaultTheme;
+
 	public function __construct(
 		protected BlockRenderer $renderer,
 		protected TemplatePartInliner $inliner,
+		protected GlobalStylesCssProvider $globalStyles,
+		protected GlobalStylesEmissionTracker $emissionTracker,
 		mixed $tree = null,
 		?string $defaultTheme = null,
 		bool $resolveParts = true,
 	) {
+		$this->defaultTheme = $defaultTheme;
+
 		$normalized = $this->normalizeTree( $tree );
 
 		$this->tree = $resolveParts
@@ -53,8 +65,28 @@ class BlocksComponent extends Component
 	public function render(): View
 	{
 		return view( 'visual-editor-renderer-blade::components.blocks', [
-			'html' => $this->renderer->render( $this->tree ),
+			'html'            => $this->renderer->render( $this->tree ),
+			'globalStylesCss' => $this->resolveGlobalStylesCss(),
 		] );
+	}
+
+	/**
+	 * Returns the compiled global-styles CSS the first time a renderer
+	 * fires in the current request, then null on every subsequent call —
+	 * so a page with multiple `<x-ve-blocks>` / `<x-ve-template>`
+	 * instances emits the `<style>` block exactly once.
+	 *
+	 * @since 1.0.0
+	 */
+	protected function resolveGlobalStylesCss(): ?string
+	{
+		if ( $this->emissionTracker->hasEmitted() ) {
+			return null;
+		}
+
+		$this->emissionTracker->markEmitted();
+
+		return $this->globalStyles->css( $this->defaultTheme );
 	}
 
 	/**

--- a/packages/visual-editor-renderer-blade/src/View/Components/TemplateComponent.php
+++ b/packages/visual-editor-renderer-blade/src/View/Components/TemplateComponent.php
@@ -29,6 +29,8 @@ namespace ArtisanPackUI\VisualEditorRendererBlade\View\Components;
 
 use ArtisanPackUI\VisualEditor\Resources\TemplatePartInliner;
 use ArtisanPackUI\VisualEditor\Resources\TemplateResolver;
+use ArtisanPackUI\VisualEditor\Services\GlobalStylesCssProvider;
+use ArtisanPackUI\VisualEditor\Services\GlobalStylesEmissionTracker;
 use ArtisanPackUI\VisualEditorRendererBlade\BlockRenderer;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\View\View;
@@ -56,6 +58,8 @@ class TemplateComponent extends Component
 		protected TemplateResolver $templates,
 		protected TemplatePartInliner $inliner,
 		protected Application $app,
+		protected GlobalStylesCssProvider $globalStyles,
+		protected GlobalStylesEmissionTracker $emissionTracker,
 		string $slug,
 		?string $theme = null,
 	) {
@@ -90,6 +94,26 @@ class TemplateComponent extends Component
 			'resolutionError' => $this->resolutionError,
 			'inDev'           => ! $this->app->environment( 'production' ),
 			'html'            => $this->html,
+			'globalStylesCss' => $this->resolveGlobalStylesCss(),
 		] );
+	}
+
+	/**
+	 * Returns the compiled global-styles CSS the first time a renderer
+	 * fires in the current request, then null on every subsequent call —
+	 * matching the dedupe behaviour of `<x-ve-blocks>` so a layout that
+	 * combines the two does not emit `<style>` twice.
+	 *
+	 * @since 1.0.0
+	 */
+	protected function resolveGlobalStylesCss(): ?string
+	{
+		if ( $this->emissionTracker->hasEmitted() ) {
+			return null;
+		}
+
+		$this->emissionTracker->markEmitted();
+
+		return $this->globalStyles->css( $this->theme );
 	}
 }

--- a/packages/visual-editor-renderer-blade/tests/Feature/BlocksComponentTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Feature/BlocksComponentTest.php
@@ -39,6 +39,7 @@ it( 'accepts a JSON string tree', function () {
 it( 'renders only the global-styles block when the tree is null', function () {
 	$rendered = Blade::render( '<x-ve-blocks :tree="$tree" />', [ 'tree' => null ] );
 
+	expect( $rendered )->toContain( 'data-ve-global-styles' );
 	expect( trim( $this->stripGlobalStyles( $rendered ) ) )->toBe( '' );
 } );
 

--- a/packages/visual-editor-renderer-blade/tests/Feature/BlocksComponentTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Feature/BlocksComponentTest.php
@@ -16,7 +16,7 @@ it( 'renders the x-ve-blocks component from an array tree', function () {
 
 	$rendered = Blade::render( '<x-ve-blocks :tree="$tree" />', [ 'tree' => $tree ] );
 
-	expect( $this->normalizeHtml( $rendered ) )
+	expect( $this->normalizeHtml( $this->stripGlobalStyles( $rendered ) ) )
 		->toBe( '<p class="wp-block-paragraph">Hello from Blade</p>' );
 } );
 
@@ -32,14 +32,14 @@ it( 'accepts a JSON string tree', function () {
 
 	$rendered = Blade::render( '<x-ve-blocks :tree="$tree" />', [ 'tree' => $json ] );
 
-	expect( $this->normalizeHtml( $rendered ) )
+	expect( $this->normalizeHtml( $this->stripGlobalStyles( $rendered ) ) )
 		->toBe( '<p class="wp-block-paragraph">JSON string</p>' );
 } );
 
-it( 'renders nothing for a null tree', function () {
+it( 'renders only the global-styles block when the tree is null', function () {
 	$rendered = Blade::render( '<x-ve-blocks :tree="$tree" />', [ 'tree' => null ] );
 
-	expect( trim( $rendered ) )->toBe( '' );
+	expect( trim( $this->stripGlobalStyles( $rendered ) ) )->toBe( '' );
 } );
 
 it( 'publishes block views under the visual-editor-blade-views tag', function () {

--- a/packages/visual-editor-renderer-blade/tests/Feature/GlobalStylesEmissionTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Feature/GlobalStylesEmissionTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Models\VisualEditorGlobalStyles;
+use ArtisanPackUI\VisualEditor\Models\VisualEditorTemplate;
+use ArtisanPackUI\VisualEditor\Services\GlobalStylesEmissionTracker;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\Facades\Cache;
+
+uses( RefreshDatabase::class );
+
+beforeEach( function (): void {
+	Cache::flush();
+	$this->app->make( GlobalStylesEmissionTracker::class )->reset();
+} );
+
+it( 'auto-emits the compiled global-styles CSS inside <x-ve-blocks>', function () {
+	VisualEditorGlobalStyles::create( [
+		'theme'    => 'artisanpack-base',
+		'version'  => 3,
+		'settings' => [
+			'color' => [
+				'palette' => [ [ 'slug' => 'brand', 'name' => 'Brand', 'color' => '#abcdef' ] ],
+			],
+		],
+		'styles'   => [],
+	] );
+
+	$rendered = Blade::render( '<x-ve-blocks :tree="$tree" />', [ 'tree' => [] ] );
+
+	expect( $rendered )->toContain( '<style data-ve-global-styles>' )
+		->toContain( '--wp--preset--color--brand: #abcdef' );
+} );
+
+it( 'auto-emits the compiled global-styles CSS inside <x-ve-template>', function () {
+	VisualEditorGlobalStyles::create( [
+		'theme'    => 'artisanpack-base',
+		'version'  => 3,
+		'settings' => [
+			'color' => [
+				'palette' => [ [ 'slug' => 'brand', 'name' => 'Brand', 'color' => '#abcdef' ] ],
+			],
+		],
+		'styles'   => [],
+	] );
+
+	VisualEditorTemplate::create( [
+		'slug'    => 'index',
+		'title'   => 'Index',
+		'content' => [ 'raw' => '', 'blocks' => [] ],
+		'theme'   => 'artisanpack-base',
+		'source'  => 'theme',
+		'origin'  => 'theme',
+	] );
+
+	$rendered = Blade::render( '<x-ve-template slug="index" theme="artisanpack-base" />' );
+
+	expect( $rendered )->toContain( '<style data-ve-global-styles>' )
+		->toContain( '--wp--preset--color--brand: #abcdef' );
+} );
+
+it( 'emits the <style> block exactly once when multiple renderers fire on the same page', function () {
+	VisualEditorGlobalStyles::create( [
+		'theme'    => 'artisanpack-base',
+		'version'  => 3,
+		'settings' => [
+			'color' => [
+				'palette' => [ [ 'slug' => 'brand', 'name' => 'Brand', 'color' => '#abcdef' ] ],
+			],
+		],
+		'styles'   => [],
+	] );
+
+	$page = Blade::render(
+		'<x-ve-blocks :tree="$tree" /><x-ve-blocks :tree="$tree" /><x-ve-blocks :tree="$tree" />',
+		[ 'tree' => [] ]
+	);
+
+	expect( substr_count( $page, '<style data-ve-global-styles>' ) )->toBe( 1 );
+} );
+
+it( 'falls back to the bundled defaults when no record exists', function () {
+	$rendered = Blade::render( '<x-ve-blocks :tree="$tree" />', [ 'tree' => [] ] );
+
+	expect( $rendered )->toContain( '<style data-ve-global-styles>' )
+		->toContain( '--wp--preset--color--primary' );
+} );

--- a/packages/visual-editor-renderer-blade/tests/TestCase.php
+++ b/packages/visual-editor-renderer-blade/tests/TestCase.php
@@ -66,4 +66,21 @@ abstract class TestCase extends BaseTestCase
 
 		return trim( $attrCollapsed );
 	}
+
+	/**
+	 * Strips the auto-emitted `<style data-ve-global-styles>...</style>`
+	 * block so existing block-output assertions can compare against the
+	 * actual block HTML without dragging in the global-styles CSS.
+	 * Tests that exercise the emission itself should not call this.
+	 *
+	 * @since 1.0.0
+	 */
+	protected function stripGlobalStyles( string $html ): string
+	{
+		return (string) preg_replace(
+			'#<style data-ve-global-styles>.*?</style>#s',
+			'',
+			$html
+		);
+	}
 }

--- a/packages/visual-editor-renderer-react/src/BlockTree.tsx
+++ b/packages/visual-editor-renderer-react/src/BlockTree.tsx
@@ -21,6 +21,7 @@
 import { Fragment, useMemo } from 'react';
 import type { ReactElement, ReactNode } from 'react';
 import { DynamicBlock } from './DynamicBlock';
+import { GlobalStyles } from './GlobalStyles';
 import { UnknownBlock } from './blocks/unknownBlock';
 import { getBlockRenderer } from './registry';
 import {
@@ -39,6 +40,13 @@ export interface BlockTreeProps {
     templateParts?: TemplatePartRecord[];
     defaultTheme?: string;
     maxTemplatePartDepth?: number;
+    /**
+     * Compiled global-styles CSS — same string the PHP
+     * `GlobalStylesCssProvider` emits on Blade pages. When supplied,
+     * `BlockTree` injects it as a `<style>` tag inside the rendered
+     * fragment so the React-rendered page matches the canvas.
+     */
+    globalStylesCss?: string | null;
 }
 
 export function BlockTree({
@@ -48,6 +56,7 @@ export function BlockTree({
     templateParts,
     defaultTheme,
     maxTemplatePartDepth = DEFAULT_MAX_TEMPLATE_PART_DEPTH,
+    globalStylesCss,
 }: BlockTreeProps): ReactElement {
     const blocks = useMemo(() => {
         const normalized = normalizeTree(tree);
@@ -70,6 +79,7 @@ export function BlockTree({
 
     return (
         <>
+            <GlobalStyles css={globalStylesCss} />
             {blocks.map((block, index) =>
                 renderBlock(block, index, dynamicBlockEndpoint, fetchOptions)
             )}

--- a/packages/visual-editor-renderer-react/src/GlobalStyles.tsx
+++ b/packages/visual-editor-renderer-react/src/GlobalStyles.tsx
@@ -1,0 +1,39 @@
+/**
+ * Renders the compiled global-styles CSS the host fetched from
+ * `GET /visual-editor/api/global-styles/{id}` (or pre-rendered with the
+ * PHP `GlobalStylesCssProvider`) as an inline `<style>` tag.
+ *
+ * The renderer is dumb on purpose: it does not know how to compile the
+ * theme.json payload. The PHP `GlobalStylesCompiler` is the single
+ * source of truth for what gets emitted on the front-end so all three
+ * renderers (Blade, React, Vue) stay byte-identical — that is the
+ * canvas/published parity guarantee #378 closes.
+ *
+ * Apps wire it once at the top of their layout (or pass the same CSS
+ * string via `BlockTree`'s `globalStylesCss` prop, which delegates here)
+ * so a page with multiple `<BlockTree>` instances does not inject the
+ * same `<style>` block twice.
+ */
+
+import type { ReactElement } from 'react';
+
+export interface GlobalStylesProps {
+    css: string | null | undefined;
+}
+
+export function GlobalStyles({ css }: GlobalStylesProps): ReactElement | null {
+    if (typeof css !== 'string' || css === '') {
+        return null;
+    }
+
+    // Pass an explicit empty string (rather than React's bare-attribute
+    // shorthand) so SSR serializes `data-ve-global-styles=""` —
+    // byte-identical to Vue's `h('style', { 'data-ve-global-styles': '' })`
+    // output. The renderer parity test asserts on the exact bytes.
+    return (
+        <style
+            data-ve-global-styles=""
+            dangerouslySetInnerHTML={{ __html: css }}
+        />
+    );
+}

--- a/packages/visual-editor-renderer-react/src/Template.tsx
+++ b/packages/visual-editor-renderer-react/src/Template.tsx
@@ -15,6 +15,7 @@
 import { useMemo } from 'react';
 import type { ReactElement } from 'react';
 import { BlockTree } from './BlockTree';
+import { GlobalStyles } from './GlobalStyles';
 import {
     DEFAULT_MAX_TEMPLATE_PART_DEPTH,
     resolveTemplate,
@@ -42,6 +43,13 @@ export interface TemplateProps {
     dynamicBlockEndpoint?: string;
     fetchOptions?: RequestInit;
     maxTemplatePartDepth?: number;
+    /**
+     * Compiled global-styles CSS — same string the PHP
+     * `GlobalStylesCssProvider` emits on Blade pages. Hosts that mount
+     * `<Template>` at the page root pass this once and let it emit
+     * before the wrapper div.
+     */
+    globalStylesCss?: string | null;
 }
 
 export function Template({
@@ -52,6 +60,7 @@ export function Template({
     dynamicBlockEndpoint,
     fetchOptions,
     maxTemplatePartDepth = DEFAULT_MAX_TEMPLATE_PART_DEPTH,
+    globalStylesCss,
 }: TemplateProps): ReactElement {
     const matched = useMemo(() => resolveTemplate(templates, slug, theme), [templates, slug, theme]);
     const fallbackChain = useMemo(() => templateFallbackChain(slug), [slug]);
@@ -76,19 +85,27 @@ export function Template({
     }
 
     if (matched === undefined) {
-        return <div className={wrapperClasses.join(' ')} {...dataAttributes} />;
+        return (
+            <>
+                <GlobalStyles css={globalStylesCss} />
+                <div className={wrapperClasses.join(' ')} {...dataAttributes} />
+            </>
+        );
     }
 
     return (
-        <div className={wrapperClasses.join(' ')} {...dataAttributes}>
-            <BlockTree
-                tree={matched.blocks}
-                templateParts={templateParts}
-                defaultTheme={theme ?? matched.theme}
-                dynamicBlockEndpoint={dynamicBlockEndpoint}
-                fetchOptions={fetchOptions}
-                maxTemplatePartDepth={maxTemplatePartDepth}
-            />
-        </div>
+        <>
+            <GlobalStyles css={globalStylesCss} />
+            <div className={wrapperClasses.join(' ')} {...dataAttributes}>
+                <BlockTree
+                    tree={matched.blocks}
+                    templateParts={templateParts}
+                    defaultTheme={theme ?? matched.theme}
+                    dynamicBlockEndpoint={dynamicBlockEndpoint}
+                    fetchOptions={fetchOptions}
+                    maxTemplatePartDepth={maxTemplatePartDepth}
+                />
+            </div>
+        </>
     );
 }

--- a/packages/visual-editor-renderer-react/src/index.ts
+++ b/packages/visual-editor-renderer-react/src/index.ts
@@ -17,6 +17,8 @@ export { Template } from './Template';
 export type { TemplateProps } from './Template';
 export { DynamicBlock } from './DynamicBlock';
 export type { DynamicBlockProps } from './DynamicBlock';
+export { GlobalStyles } from './GlobalStyles';
+export type { GlobalStylesProps } from './GlobalStyles';
 export { UnknownBlock } from './blocks/unknownBlock';
 export {
     getBlockRenderer,

--- a/packages/visual-editor-renderer-react/tests/GlobalStyles.test.tsx
+++ b/packages/visual-editor-renderer-react/tests/GlobalStyles.test.tsx
@@ -1,0 +1,88 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import '../src/index';
+import { BlockTree } from '../src/BlockTree';
+import { GlobalStyles } from '../src/GlobalStyles';
+import { Template } from '../src/Template';
+import { makeBlock } from './helpers';
+
+describe('GlobalStyles', () => {
+    it('renders a <style data-ve-global-styles> tag for non-empty CSS', () => {
+        const css = ':root { --wp--preset--color--brand: #abcdef; }';
+        const { container } = render(<GlobalStyles css={css} />);
+
+        const style = container.querySelector('style[data-ve-global-styles]');
+
+        expect(style).not.toBeNull();
+        expect(style?.innerHTML).toContain('--wp--preset--color--brand');
+    });
+
+    it('renders nothing for null, undefined, or empty CSS', () => {
+        expect(render(<GlobalStyles css={null} />).container.innerHTML).toBe('');
+        expect(render(<GlobalStyles css={undefined} />).container.innerHTML).toBe('');
+        expect(render(<GlobalStyles css="" />).container.innerHTML).toBe('');
+    });
+});
+
+describe('BlockTree global-styles wiring', () => {
+    it('injects the <style> block when globalStylesCss is provided', () => {
+        const { container } = render(
+            <BlockTree
+                tree={[makeBlock('core/paragraph', { content: 'Hi' })]}
+                globalStylesCss=":root { --wp--preset--color--brand: #abcdef; }"
+            />
+        );
+
+        const style = container.querySelector('style[data-ve-global-styles]');
+
+        expect(style).not.toBeNull();
+        expect(style?.innerHTML).toContain('--wp--preset--color--brand');
+        expect(container.innerHTML).toContain('Hi');
+    });
+
+    it('omits the <style> block when no css is supplied', () => {
+        const { container } = render(
+            <BlockTree tree={[makeBlock('core/paragraph', { content: 'Hi' })]} />
+        );
+
+        expect(container.querySelector('style[data-ve-global-styles]')).toBeNull();
+    });
+});
+
+describe('Template global-styles wiring', () => {
+    const templates = [
+        {
+            slug: 'index',
+            theme: 'artisanpack-base',
+            blocks: [makeBlock('core/paragraph', { content: 'Indexed' })],
+        },
+    ];
+
+    it('emits the <style> block before the wrapper when matched', () => {
+        const { container } = render(
+            <Template
+                slug="index"
+                theme="artisanpack-base"
+                templates={templates}
+                globalStylesCss=":root { --wp--preset--color--brand: #abcdef; }"
+            />
+        );
+
+        expect(container.querySelector('style[data-ve-global-styles]')).not.toBeNull();
+        expect(container.innerHTML).toContain('data-ve-template="index"');
+    });
+
+    it('emits the <style> block even when nothing resolves', () => {
+        const { container } = render(
+            <Template
+                slug="single-post"
+                theme="artisanpack-base"
+                templates={[]}
+                globalStylesCss=":root { --wp--preset--color--brand: #abcdef; }"
+            />
+        );
+
+        expect(container.querySelector('style[data-ve-global-styles]')).not.toBeNull();
+    });
+});

--- a/packages/visual-editor-renderer-vue/src/BlockTree.ts
+++ b/packages/visual-editor-renderer-vue/src/BlockTree.ts
@@ -21,6 +21,7 @@
 import { Fragment, computed, defineComponent, h } from 'vue';
 import type { PropType, VNode } from 'vue';
 import { DynamicBlock } from './DynamicBlock';
+import { GlobalStyles } from './GlobalStyles';
 import { UnknownBlock } from './blocks/unknownBlock';
 import { getBlockRenderer } from './registry';
 import {
@@ -39,6 +40,13 @@ export interface BlockTreeProps {
     templateParts?: TemplatePartRecord[];
     defaultTheme?: string;
     maxTemplatePartDepth?: number;
+    /**
+     * Compiled global-styles CSS — same string the PHP
+     * `GlobalStylesCssProvider` emits on Blade pages. When supplied,
+     * `BlockTree` injects it as a `<style>` tag inside the rendered
+     * fragment so the Vue-rendered page matches the canvas.
+     */
+    globalStylesCss?: string | null;
 }
 
 export const BlockTree = defineComponent({
@@ -68,6 +76,10 @@ export const BlockTree = defineComponent({
             type: Number,
             default: DEFAULT_MAX_TEMPLATE_PART_DEPTH,
         },
+        globalStylesCss: {
+            type: String as PropType<string | null | undefined>,
+            default: null,
+        },
     },
     setup(props) {
         const blocks = computed(() => {
@@ -91,9 +103,16 @@ export const BlockTree = defineComponent({
 
         return () => {
             const endpoint = props.dynamicBlockEndpoint ?? DEFAULT_ENDPOINT;
-            const children = blocks.value
+            const children: VNode[] = [];
+
+            const styleNode = h(GlobalStyles, { css: props.globalStylesCss });
+
+            children.push(styleNode);
+
+            blocks.value
                 .map((block, index) => renderBlock(block, index, endpoint, props.fetchOptions))
-                .filter((vnode): vnode is VNode => vnode !== null);
+                .filter((vnode): vnode is VNode => vnode !== null)
+                .forEach((vnode) => children.push(vnode));
 
             return h(Fragment, null, children);
         };

--- a/packages/visual-editor-renderer-vue/src/GlobalStyles.ts
+++ b/packages/visual-editor-renderer-vue/src/GlobalStyles.ts
@@ -1,0 +1,49 @@
+/**
+ * Renders the compiled global-styles CSS the host fetched from
+ * `GET /visual-editor/api/global-styles/{id}` (or pre-rendered with the
+ * PHP `GlobalStylesCssProvider`) as an inline `<style>` tag.
+ *
+ * The renderer is dumb on purpose: it does not know how to compile the
+ * theme.json payload. The PHP `GlobalStylesCompiler` is the single
+ * source of truth for what gets emitted on the front-end so all three
+ * renderers (Blade, React, Vue) stay byte-identical — that is the
+ * canvas/published parity guarantee #378 closes.
+ *
+ * Apps wire it once at the top of their layout (or pass the same CSS
+ * string via `BlockTree`'s `globalStylesCss` prop, which delegates here)
+ * so a page with multiple `<BlockTree>` instances does not inject the
+ * same `<style>` block twice.
+ */
+
+import { defineComponent, h } from 'vue';
+import type { PropType, VNode } from 'vue';
+
+export interface GlobalStylesProps {
+    css: string | null | undefined;
+}
+
+export const GlobalStyles = defineComponent({
+    name: 'GlobalStyles',
+    props: {
+        css: {
+            type: String as PropType<string | null | undefined>,
+            default: null,
+        },
+    },
+    setup(props) {
+        return (): VNode | null => {
+            if (typeof props.css !== 'string' || props.css === '') {
+                return null;
+            }
+
+            return h(
+                'style',
+                {
+                    'data-ve-global-styles': '',
+                    innerHTML: props.css,
+                },
+                []
+            );
+        };
+    },
+});

--- a/packages/visual-editor-renderer-vue/src/Template.ts
+++ b/packages/visual-editor-renderer-vue/src/Template.ts
@@ -12,9 +12,10 @@
  * developer can spot the misconfiguration in the inspector.
  */
 
-import { computed, defineComponent, h } from 'vue';
+import { Fragment, computed, defineComponent, h } from 'vue';
 import type { PropType } from 'vue';
 import { BlockTree } from './BlockTree';
+import { GlobalStyles } from './GlobalStyles';
 import {
     DEFAULT_MAX_TEMPLATE_PART_DEPTH,
     resolveTemplate,
@@ -42,6 +43,13 @@ export interface TemplateProps {
     dynamicBlockEndpoint?: string;
     fetchOptions?: RequestInit;
     maxTemplatePartDepth?: number;
+    /**
+     * Compiled global-styles CSS — same string the PHP
+     * `GlobalStylesCssProvider` emits on Blade pages. Hosts that mount
+     * `<Template>` at the page root pass this once and let it emit
+     * before the wrapper div.
+     */
+    globalStylesCss?: string | null;
 }
 
 export const Template = defineComponent({
@@ -75,6 +83,10 @@ export const Template = defineComponent({
             type: Number,
             default: DEFAULT_MAX_TEMPLATE_PART_DEPTH,
         },
+        globalStylesCss: {
+            type: String as PropType<string | null | undefined>,
+            default: null,
+        },
     },
     setup(props) {
         const matched = computed(() => resolveTemplate(props.templates, props.slug, props.theme));
@@ -103,19 +115,24 @@ export const Template = defineComponent({
                 elementProps['data-ve-fallback-chain'] = fallbackChain.value.join(',');
             }
 
+            const globalStylesNode = h(GlobalStyles, { css: props.globalStylesCss });
+
             if (matched.value === undefined) {
-                return h('div', elementProps);
+                return h(Fragment, null, [globalStylesNode, h('div', elementProps)]);
             }
 
-            return h('div', elementProps, [
-                h(BlockTree, {
-                    tree: matched.value.blocks,
-                    templateParts: props.templateParts,
-                    defaultTheme: props.theme ?? matched.value.theme,
-                    dynamicBlockEndpoint: props.dynamicBlockEndpoint,
-                    fetchOptions: props.fetchOptions,
-                    maxTemplatePartDepth: props.maxTemplatePartDepth,
-                }),
+            return h(Fragment, null, [
+                globalStylesNode,
+                h('div', elementProps, [
+                    h(BlockTree, {
+                        tree: matched.value.blocks,
+                        templateParts: props.templateParts,
+                        defaultTheme: props.theme ?? matched.value.theme,
+                        dynamicBlockEndpoint: props.dynamicBlockEndpoint,
+                        fetchOptions: props.fetchOptions,
+                        maxTemplatePartDepth: props.maxTemplatePartDepth,
+                    }),
+                ]),
             ]);
         };
     },

--- a/packages/visual-editor-renderer-vue/src/index.ts
+++ b/packages/visual-editor-renderer-vue/src/index.ts
@@ -17,6 +17,8 @@ export { Template } from './Template';
 export type { TemplateProps } from './Template';
 export { DynamicBlock } from './DynamicBlock';
 export type { DynamicBlockProps } from './DynamicBlock';
+export { GlobalStyles } from './GlobalStyles';
+export type { GlobalStylesProps } from './GlobalStyles';
 export { UnknownBlock } from './blocks/unknownBlock';
 export {
     getBlockRenderer,

--- a/packages/visual-editor-renderer-vue/tests/GlobalStyles.test.ts
+++ b/packages/visual-editor-renderer-vue/tests/GlobalStyles.test.ts
@@ -1,0 +1,87 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+
+import '../src/index';
+import { BlockTree } from '../src/BlockTree';
+import { GlobalStyles } from '../src/GlobalStyles';
+import { Template } from '../src/Template';
+import { makeBlock } from './helpers';
+
+describe('GlobalStyles', () => {
+    it('renders a <style data-ve-global-styles> tag for non-empty CSS', () => {
+        const wrapper = mount(GlobalStyles, {
+            props: { css: ':root { --wp--preset--color--brand: #abcdef; }' },
+        });
+
+        expect(wrapper.find('style[data-ve-global-styles]').exists()).toBe(true);
+        expect(wrapper.html()).toContain('--wp--preset--color--brand');
+    });
+
+    it('renders nothing for null, undefined, or empty CSS', () => {
+        expect(mount(GlobalStyles, { props: { css: null } }).html()).toBe('');
+        expect(mount(GlobalStyles, { props: { css: undefined } }).html()).toBe('');
+        expect(mount(GlobalStyles, { props: { css: '' } }).html()).toBe('');
+    });
+});
+
+describe('BlockTree global-styles wiring', () => {
+    it('injects the <style> block when globalStylesCss is provided', () => {
+        const wrapper = mount(BlockTree, {
+            props: {
+                tree: [makeBlock('core/paragraph', { content: 'Hi' })],
+                globalStylesCss: ':root { --wp--preset--color--brand: #abcdef; }',
+            },
+        });
+
+        expect(wrapper.find('style[data-ve-global-styles]').exists()).toBe(true);
+        expect(wrapper.html()).toContain('--wp--preset--color--brand');
+        expect(wrapper.html()).toContain('Hi');
+    });
+
+    it('omits the <style> block when no css is supplied', () => {
+        const wrapper = mount(BlockTree, {
+            props: {
+                tree: [makeBlock('core/paragraph', { content: 'Hi' })],
+            },
+        });
+
+        expect(wrapper.find('style[data-ve-global-styles]').exists()).toBe(false);
+    });
+});
+
+describe('Template global-styles wiring', () => {
+    const templates = [
+        {
+            slug: 'index',
+            theme: 'artisanpack-base',
+            blocks: [makeBlock('core/paragraph', { content: 'Indexed' })],
+        },
+    ];
+
+    it('emits the <style> block before the wrapper when matched', () => {
+        const wrapper = mount(Template, {
+            props: {
+                slug: 'index',
+                theme: 'artisanpack-base',
+                templates,
+                globalStylesCss: ':root { --wp--preset--color--brand: #abcdef; }',
+            },
+        });
+
+        expect(wrapper.find('style[data-ve-global-styles]').exists()).toBe(true);
+        expect(wrapper.html()).toContain('data-ve-template="index"');
+    });
+
+    it('emits the <style> block even when nothing resolves', () => {
+        const wrapper = mount(Template, {
+            props: {
+                slug: 'single-post',
+                theme: 'artisanpack-base',
+                templates: [],
+                globalStylesCss: ':root { --wp--preset--color--brand: #abcdef; }',
+            },
+        });
+
+        expect(wrapper.find('style[data-ve-global-styles]').exists()).toBe(true);
+    });
+});

--- a/packages/visual-editor-renderer-vue/tests/parity.test.ts
+++ b/packages/visual-editor-renderer-vue/tests/parity.test.ts
@@ -374,4 +374,21 @@ describe('React/Vue renderer parity', () => {
 
         expect(vueHtml).toBe(reactHtml);
     });
+
+    it('emits the same global-styles <style> tag on both renderers', async () => {
+        const css = ':root { --wp--preset--color--brand: #abcdef; }';
+        const tree: Block[] = [makeBlock('core/paragraph', { content: 'Hi' }, [], 'p1')];
+
+        const reactApp = createElement(ReactBlockTree, { tree, globalStylesCss: css });
+        const reactHtml = domNormalize(renderToStaticMarkup(reactApp));
+
+        const vueApp = createSSRApp({
+            render: () => vueH(VueBlockTree, { tree, globalStylesCss: css }),
+        });
+        const vueHtml = domNormalize(stripVueServerMarkers(await vueRenderToString(vueApp)));
+
+        expect(vueHtml).toBe(reactHtml);
+        expect(reactHtml).toContain('<style data-ve-global-styles="">');
+        expect(reactHtml).toContain('--wp--preset--color--brand');
+    });
 });

--- a/src/Services/GlobalStylesCacheInvalidator.php
+++ b/src/Services/GlobalStylesCacheInvalidator.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * Wires the {@see VisualEditorGlobalStyles} model's `saved` and
+ * `deleted` events to {@see GlobalStylesCssProvider::forget()} so a
+ * mutation always evicts the prior compiled CSS.
+ *
+ * The provider already keys cache entries on (id, updated_at) so a
+ * fresh `save()` would naturally miss the cache regardless. The
+ * explicit invalidation is belt-and-suspenders: it forgets both the
+ * new key (in case a stale entry somehow exists) and the prior
+ * `updated_at` key so cold reads after a long quiet period do not
+ * leave dangling entries behind.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Services;
+
+use ArtisanPackUI\VisualEditor\Models\VisualEditorGlobalStyles;
+use Illuminate\Support\Carbon;
+
+class GlobalStylesCacheInvalidator
+{
+	public function __construct(
+		protected GlobalStylesCssProvider $provider,
+	) {
+	}
+
+	/**
+	 * Registers the model event listeners. Idempotent — callers should
+	 * still gate on `runningUnitTests()` etc. if they need single-firing
+	 * semantics, but model::saved is registered through the resolver so
+	 * repeated calls only attach the listener once per process.
+	 *
+	 * @since 1.0.0
+	 */
+	public function register(): void
+	{
+		VisualEditorGlobalStyles::saved( function ( VisualEditorGlobalStyles $record ): void {
+			$this->provider->forget(
+				$record,
+				$this->originalUpdatedAt( $record )
+			);
+		} );
+
+		VisualEditorGlobalStyles::deleted( function ( VisualEditorGlobalStyles $record ): void {
+			$this->provider->forget(
+				$record,
+				$this->originalUpdatedAt( $record )
+			);
+		} );
+	}
+
+	/**
+	 * Pulls the pre-save `updated_at` so the *previous* cache entry can
+	 * be evicted alongside the new one.
+	 *
+	 * @since 1.0.0
+	 */
+	protected function originalUpdatedAt( VisualEditorGlobalStyles $record ): ?string
+	{
+		$original = $record->getOriginal( 'updated_at' );
+
+		if ( $original instanceof Carbon ) {
+			return $original->format( 'YmdHis' );
+		}
+
+		if ( is_string( $original ) && '' !== $original ) {
+			try {
+				return Carbon::parse( $original )->format( 'YmdHis' );
+			} catch ( \Throwable $e ) {
+				return null;
+			}
+		}
+
+		return null;
+	}
+}

--- a/src/Services/GlobalStylesCacheInvalidator.php
+++ b/src/Services/GlobalStylesCacheInvalidator.php
@@ -29,21 +29,33 @@ use Illuminate\Support\Carbon;
 
 class GlobalStylesCacheInvalidator
 {
+	/**
+	 * Tracks whether the model event listeners have been attached so
+	 * `register()` is genuinely idempotent — Eloquent's
+	 * `Model::saved()` and `Model::deleted()` resolvers accumulate
+	 * closures on every call, so a second `register()` would otherwise
+	 * fire the cache forget twice per save.
+	 */
+	protected bool $listenersRegistered = false;
+
 	public function __construct(
 		protected GlobalStylesCssProvider $provider,
 	) {
 	}
 
 	/**
-	 * Registers the model event listeners. Idempotent — callers should
-	 * still gate on `runningUnitTests()` etc. if they need single-firing
-	 * semantics, but model::saved is registered through the resolver so
-	 * repeated calls only attach the listener once per process.
+	 * Registers the model event listeners. Safe to call more than once
+	 * — subsequent invocations are no-ops thanks to the
+	 * `$listenersRegistered` guard.
 	 *
 	 * @since 1.0.0
 	 */
 	public function register(): void
 	{
+		if ( $this->listenersRegistered ) {
+			return;
+		}
+
 		VisualEditorGlobalStyles::saved( function ( VisualEditorGlobalStyles $record ): void {
 			$this->provider->forget(
 				$record,
@@ -57,6 +69,8 @@ class GlobalStylesCacheInvalidator
 				$this->originalUpdatedAt( $record )
 			);
 		} );
+
+		$this->listenersRegistered = true;
 	}
 
 	/**

--- a/src/Services/GlobalStylesCompiler.php
+++ b/src/Services/GlobalStylesCompiler.php
@@ -1,0 +1,538 @@
+<?php
+
+/**
+ * Compiles a theme.json-shaped global-styles payload into front-end CSS.
+ *
+ * The compiler is pure and stateless: input is a `{ version, settings,
+ * styles }` array (the same shape persisted by the C3 backend and
+ * returned by `GET /visual-editor/api/global-styles/{id}`), output is a
+ * CSS string ready to drop into a `<style>` tag.
+ *
+ * Token names follow the `--wp--preset--{family}--{slug}` convention
+ * D3's site-editor canvas already uses (see colors-panel.tsx,
+ * use-preset-data.ts) so canvas and front-end render against the same
+ * variables — that is the canvas/published parity guarantee #378
+ * exists to close.
+ *
+ * The compiler intentionally does not validate the schema: validation
+ * happens at the API edge in {@see UpdateGlobalStylesRequest}. Anything
+ * that survives `firstOrCreate` and round-trips through the model is
+ * trusted here. Unrecognized keys are skipped silently so a future
+ * theme.json schema bump only requires extending this compiler — old
+ * payloads keep emitting whatever subset we already understand.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Services;
+
+class GlobalStylesCompiler
+{
+	/**
+	 * Compiles a theme.json payload into a CSS string.
+	 *
+	 * Output is ordered: `:root` design-token declarations first, then
+	 * page-level body styles, then `:where(...)` element rules
+	 * (link / heading / button), then per-block overrides. The
+	 * `:where()` wrapper keeps element selectors at zero specificity so
+	 * a per-block or inline override always wins without `!important`.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array<string, mixed>  $payload  `{ version, settings, styles }`.
+	 */
+	public function compile( array $payload ): string
+	{
+		$settings = isset( $payload['settings'] ) && is_array( $payload['settings'] )
+			? $payload['settings']
+			: [];
+		$styles   = isset( $payload['styles'] ) && is_array( $payload['styles'] )
+			? $payload['styles']
+			: [];
+
+		$blocks = [];
+
+		$root = $this->compileRootTokens( $settings );
+
+		if ( '' !== $root ) {
+			$blocks[] = $root;
+		}
+
+		$body = $this->compileBodyStyles( $styles );
+
+		if ( '' !== $body ) {
+			$blocks[] = $body;
+		}
+
+		$elements = $this->compileElementStyles( $styles );
+
+		if ( '' !== $elements ) {
+			$blocks[] = $elements;
+		}
+
+		$blockOverrides = $this->compileBlockStyles( $styles );
+
+		if ( '' !== $blockOverrides ) {
+			$blocks[] = $blockOverrides;
+		}
+
+		return implode( "\n", $blocks );
+	}
+
+	/**
+	 * Emits `:root { --wp--preset--*: ...; }` for every preset family in
+	 * `settings`.
+	 *
+	 * Currently covers `color.palette`, `typography.fontFamilies`,
+	 * `typography.fontSizes`, and `spacing.spacingSizes` (theme.json's
+	 * shipped families). Layout sizes (`settings.layout.contentSize` /
+	 * `wideSize`) emit as `--wp--style--global--{content,wide}-size` per
+	 * the upstream theme.json convention.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array<string, mixed>  $settings
+	 */
+	protected function compileRootTokens( array $settings ): string
+	{
+		$declarations = [];
+
+		$declarations = array_merge(
+			$declarations,
+			$this->presetDeclarations(
+				$settings,
+				[ 'color', 'palette' ],
+				'color',
+				'color'
+			)
+		);
+		$declarations = array_merge(
+			$declarations,
+			$this->presetDeclarations(
+				$settings,
+				[ 'typography', 'fontFamilies' ],
+				'font-family',
+				'fontFamily'
+			)
+		);
+		$declarations = array_merge(
+			$declarations,
+			$this->presetDeclarations(
+				$settings,
+				[ 'typography', 'fontSizes' ],
+				'font-size',
+				'size'
+			)
+		);
+		$declarations = array_merge(
+			$declarations,
+			$this->presetDeclarations(
+				$settings,
+				[ 'spacing', 'spacingSizes' ],
+				'spacing',
+				'size'
+			)
+		);
+
+		$layout = isset( $settings['layout'] ) && is_array( $settings['layout'] )
+			? $settings['layout']
+			: [];
+
+		if ( isset( $layout['contentSize'] ) && is_string( $layout['contentSize'] ) && '' !== $layout['contentSize'] ) {
+			$declarations[] = '--wp--style--global--content-size: ' . $layout['contentSize'];
+		}
+
+		if ( isset( $layout['wideSize'] ) && is_string( $layout['wideSize'] ) && '' !== $layout['wideSize'] ) {
+			$declarations[] = '--wp--style--global--wide-size: ' . $layout['wideSize'];
+		}
+
+		if ( [] === $declarations ) {
+			return '';
+		}
+
+		return $this->wrapRule( ':root', $declarations );
+	}
+
+	/**
+	 * Walks a presets path (e.g. `settings.color.palette`) and returns
+	 * `--wp--preset--{family}--{slug}: {value};` declarations for every
+	 * entry.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array<string, mixed>  $settings
+	 * @param  array<int, string>    $path      Nested key path under settings.
+	 * @param  string                $family    CSS-side family slug (e.g. `color`, `font-size`).
+	 * @param  string                $valueKey  Name of the value attribute on each preset entry.
+	 *
+	 * @return array<int, string>
+	 */
+	protected function presetDeclarations( array $settings, array $path, string $family, string $valueKey ): array
+	{
+		$node = $settings;
+
+		foreach ( $path as $segment ) {
+			if ( ! is_array( $node ) || ! array_key_exists( $segment, $node ) ) {
+				return [];
+			}
+
+			$node = $node[ $segment ];
+		}
+
+		if ( ! is_array( $node ) ) {
+			return [];
+		}
+
+		$declarations = [];
+
+		foreach ( $node as $entry ) {
+			if ( ! is_array( $entry ) ) {
+				continue;
+			}
+
+			$slug  = isset( $entry['slug'] ) && is_string( $entry['slug'] ) ? $entry['slug'] : null;
+			$value = isset( $entry[ $valueKey ] ) ? $entry[ $valueKey ] : null;
+
+			if ( null === $slug || '' === $slug || ! is_string( $value ) || '' === $value ) {
+				continue;
+			}
+
+			$safeSlug = $this->sanitizeSlug( $slug );
+
+			if ( '' === $safeSlug ) {
+				continue;
+			}
+
+			$declarations[] = sprintf(
+				'--wp--preset--%s--%s: %s',
+				$family,
+				$safeSlug,
+				$this->sanitizeCssValue( $value )
+			);
+		}
+
+		return $declarations;
+	}
+
+	/**
+	 * Compiles `styles.color` / `styles.typography` / `styles.spacing`
+	 * into `body { ... }`.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array<string, mixed>  $styles
+	 */
+	protected function compileBodyStyles( array $styles ): string
+	{
+		$declarations = $this->collectBlockDeclarations( $styles );
+
+		if ( [] === $declarations ) {
+			return '';
+		}
+
+		return $this->wrapRule( 'body', $declarations );
+	}
+
+	/**
+	 * Compiles `styles.elements.{link,heading,button}` into element-level
+	 * rules wrapped in `:where()` so they sit at zero specificity.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array<string, mixed>  $styles
+	 */
+	protected function compileElementStyles( array $styles ): string
+	{
+		$elements = isset( $styles['elements'] ) && is_array( $styles['elements'] )
+			? $styles['elements']
+			: [];
+
+		if ( [] === $elements ) {
+			return '';
+		}
+
+		$selectorMap = [
+			'link'    => 'a',
+			'heading' => 'h1, h2, h3, h4, h5, h6',
+			'h1'      => 'h1',
+			'h2'      => 'h2',
+			'h3'      => 'h3',
+			'h4'      => 'h4',
+			'h5'      => 'h5',
+			'h6'      => 'h6',
+			'button'  => '.wp-element-button, .wp-block-button__link',
+		];
+
+		$rules = [];
+
+		foreach ( $selectorMap as $key => $selector ) {
+			if ( ! isset( $elements[ $key ] ) || ! is_array( $elements[ $key ] ) ) {
+				continue;
+			}
+
+			$declarations = $this->collectBlockDeclarations( $elements[ $key ] );
+
+			if ( [] === $declarations ) {
+				continue;
+			}
+
+			$rules[] = $this->wrapRule( ':where(' . $selector . ')', $declarations );
+		}
+
+		return implode( "\n", $rules );
+	}
+
+	/**
+	 * Compiles `styles.blocks.{namespace/name}` into `.wp-block-{name}`
+	 * rules — matching upstream WordPress's class convention so the
+	 * canvas (which uses `@wordpress/block-editor`'s default classes)
+	 * and the front-end target the same selectors.
+	 *
+	 * Block names are normalized: `core/X` becomes `wp-block-X`,
+	 * `namespace/X` becomes `wp-block-namespace-X`. Anything outside
+	 * `[a-z0-9-]` (after lowercasing) is dropped so a malformed key
+	 * cannot inject arbitrary selector text.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array<string, mixed>  $styles
+	 */
+	protected function compileBlockStyles( array $styles ): string
+	{
+		$blocks = isset( $styles['blocks'] ) && is_array( $styles['blocks'] )
+			? $styles['blocks']
+			: [];
+
+		if ( [] === $blocks ) {
+			return '';
+		}
+
+		$rules = [];
+
+		foreach ( $blocks as $blockName => $blockStyles ) {
+			if ( ! is_string( $blockName ) || ! is_array( $blockStyles ) ) {
+				continue;
+			}
+
+			$selector = $this->blockSelector( $blockName );
+
+			if ( null === $selector ) {
+				continue;
+			}
+
+			$declarations = $this->collectBlockDeclarations( $blockStyles );
+
+			if ( [] === $declarations ) {
+				continue;
+			}
+
+			$rules[] = $this->wrapRule( $selector, $declarations );
+		}
+
+		return implode( "\n", $rules );
+	}
+
+	/**
+	 * Translates a block name like `core/button` into `.wp-block-button`
+	 * (or `.wp-block-artisanpack-callout` for namespaced blocks).
+	 * Returns null for anything that doesn't look like a valid
+	 * `namespace/name` pair.
+	 *
+	 * @since 1.0.0
+	 */
+	protected function blockSelector( string $blockName ): ?string
+	{
+		$blockName = strtolower( trim( $blockName ) );
+
+		if ( '' === $blockName || false === strpos( $blockName, '/' ) ) {
+			return null;
+		}
+
+		[ $namespace, $name ] = explode( '/', $blockName, 2 );
+
+		$namespace = preg_replace( '/[^a-z0-9-]/', '', $namespace ) ?? '';
+		$name      = preg_replace( '/[^a-z0-9-]/', '', $name ) ?? '';
+
+		if ( '' === $name ) {
+			return null;
+		}
+
+		$slug = ( '' === $namespace || 'core' === $namespace )
+			? $name
+			: $namespace . '-' . $name;
+
+		return '.wp-block-' . $slug;
+	}
+
+	/**
+	 * Pulls CSS declarations out of a block-styles node — the same shape
+	 * is used at the body level, the element level, and per-block. Keys
+	 * are translated from camelCase (`backgroundColor`) to kebab-case
+	 * (`background-color`).
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array<string, mixed>  $node
+	 *
+	 * @return array<int, string>
+	 */
+	protected function collectBlockDeclarations( array $node ): array
+	{
+		$declarations = [];
+
+		// `color` → background-color, color, background.
+		if ( isset( $node['color'] ) && is_array( $node['color'] ) ) {
+			$color = $node['color'];
+
+			if ( isset( $color['background'] ) && is_string( $color['background'] ) ) {
+				$declarations[] = 'background-color: ' . $this->sanitizeCssValue( $color['background'] );
+			}
+
+			if ( isset( $color['gradient'] ) && is_string( $color['gradient'] ) ) {
+				$declarations[] = 'background: ' . $this->sanitizeCssValue( $color['gradient'] );
+			}
+
+			if ( isset( $color['text'] ) && is_string( $color['text'] ) ) {
+				$declarations[] = 'color: ' . $this->sanitizeCssValue( $color['text'] );
+			}
+		}
+
+		// `typography` → font-family, font-size, font-weight, line-height, etc.
+		if ( isset( $node['typography'] ) && is_array( $node['typography'] ) ) {
+			foreach ( $node['typography'] as $prop => $value ) {
+				if ( ! is_string( $prop ) || ! is_string( $value ) || '' === $value ) {
+					continue;
+				}
+
+				$declarations[] = $this->kebabCase( $prop ) . ': ' . $this->sanitizeCssValue( $value );
+			}
+		}
+
+		// `spacing` → padding, margin, blockGap (mapped to gap).
+		if ( isset( $node['spacing'] ) && is_array( $node['spacing'] ) ) {
+			$spacing = $node['spacing'];
+
+			foreach ( [ 'padding', 'margin' ] as $box ) {
+				if ( isset( $spacing[ $box ] ) ) {
+					$declarations = array_merge(
+						$declarations,
+						$this->boxModelDeclarations( $box, $spacing[ $box ] )
+					);
+				}
+			}
+
+			if ( isset( $spacing['blockGap'] ) && is_string( $spacing['blockGap'] ) && '' !== $spacing['blockGap'] ) {
+				$declarations[] = 'gap: ' . $this->sanitizeCssValue( $spacing['blockGap'] );
+			}
+		}
+
+		// `border` → border-radius, border-color, border-width, border-style.
+		if ( isset( $node['border'] ) && is_array( $node['border'] ) ) {
+			$border = $node['border'];
+
+			if ( isset( $border['radius'] ) && is_string( $border['radius'] ) && '' !== $border['radius'] ) {
+				$declarations[] = 'border-radius: ' . $this->sanitizeCssValue( $border['radius'] );
+			}
+
+			foreach ( [ 'color', 'width', 'style' ] as $prop ) {
+				if ( isset( $border[ $prop ] ) && is_string( $border[ $prop ] ) && '' !== $border[ $prop ] ) {
+					$declarations[] = 'border-' . $prop . ': ' . $this->sanitizeCssValue( $border[ $prop ] );
+				}
+			}
+		}
+
+		return $declarations;
+	}
+
+	/**
+	 * Expands a padding/margin value — either a single string ("1rem"),
+	 * a per-side map (`{ top, right, bottom, left }`), or an empty
+	 * value — into individual `padding-top: ...;` declarations.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<int, string>
+	 */
+	protected function boxModelDeclarations( string $box, mixed $value ): array
+	{
+		if ( is_string( $value ) && '' !== $value ) {
+			return [ $box . ': ' . $this->sanitizeCssValue( $value ) ];
+		}
+
+		if ( ! is_array( $value ) ) {
+			return [];
+		}
+
+		$declarations = [];
+
+		foreach ( [ 'top', 'right', 'bottom', 'left' ] as $side ) {
+			if ( isset( $value[ $side ] ) && is_string( $value[ $side ] ) && '' !== $value[ $side ] ) {
+				$declarations[] = $box . '-' . $side . ': ' . $this->sanitizeCssValue( $value[ $side ] );
+			}
+		}
+
+		return $declarations;
+	}
+
+	/**
+	 * Wraps `selector { decl1; decl2; }` with a trailing newline so the
+	 * compiled output is human-readable when inspected in dev tools.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array<int, string>  $declarations
+	 */
+	protected function wrapRule( string $selector, array $declarations ): string
+	{
+		return $selector . ' { ' . implode( '; ', $declarations ) . '; }';
+	}
+
+	/**
+	 * Lowercases and strips anything outside the safe slug charset.
+	 *
+	 * @since 1.0.0
+	 */
+	protected function sanitizeSlug( string $slug ): string
+	{
+		$slug = strtolower( trim( $slug ) );
+
+		return (string) preg_replace( '/[^a-z0-9_-]/', '', $slug );
+	}
+
+	/**
+	 * Strips characters that could close the surrounding `<style>` tag
+	 * or break out of the rule body. Values flow through validated
+	 * theme.json input but defense-in-depth here keeps the compiler
+	 * safe to call against any payload — including the raw model in
+	 * tests, where validation has not run.
+	 *
+	 * @since 1.0.0
+	 */
+	protected function sanitizeCssValue( string $value ): string
+	{
+		$value = trim( $value );
+		$value = (string) preg_replace( '/[<>{};]/', '', $value );
+
+		return $value;
+	}
+
+	/**
+	 * Translates camelCase property names into kebab-case CSS property
+	 * names (`fontFamily` → `font-family`).
+	 *
+	 * @since 1.0.0
+	 */
+	protected function kebabCase( string $value ): string
+	{
+		$kebab = (string) preg_replace( '/([a-z0-9])([A-Z])/', '$1-$2', $value );
+
+		return strtolower( $kebab );
+	}
+}

--- a/src/Services/GlobalStylesCssProvider.php
+++ b/src/Services/GlobalStylesCssProvider.php
@@ -1,0 +1,158 @@
+<?php
+
+/**
+ * Resolves the active global-styles record for the current theme,
+ * compiles it to CSS via {@see GlobalStylesCompiler}, and caches the
+ * result keyed on the record's id + updated_at timestamp.
+ *
+ * Cache key format: `visual-editor:global-styles:css:{id}:{updated_at}`.
+ * Because the timestamp is part of the key, an Eloquent `save()` that
+ * touches `updated_at` automatically misses the cache and recompiles
+ * — a `saved` listener on the model then forgets the previous key so
+ * stale entries do not pile up between updates.
+ *
+ * Missing-record fallback: if the singleton has not been created yet
+ * (fresh install, before the first `lookup` request), the provider
+ * compiles the bundled `default-base.php` payload — same defaults the
+ * `/base` endpoint serves — so visitor pages never render unstyled
+ * while the back-office is still being set up.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Services;
+
+use ArtisanPackUI\VisualEditor\Models\VisualEditorGlobalStyles;
+use Illuminate\Contracts\Cache\Repository as CacheRepository;
+use Illuminate\Contracts\Config\Repository as ConfigRepository;
+
+class GlobalStylesCssProvider
+{
+	protected const CACHE_PREFIX = 'visual-editor:global-styles:css';
+
+	public function __construct(
+		protected GlobalStylesCompiler $compiler,
+		protected CacheRepository $cache,
+		protected ConfigRepository $config,
+	) {
+	}
+
+	/**
+	 * Returns the compiled CSS for the active theme's record.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string|null  $theme  Override the active theme; defaults to
+	 *                              `artisanpack.visual-editor.global_styles.theme`.
+	 */
+	public function css( ?string $theme = null ): string
+	{
+		$activeTheme = $theme ?? $this->activeTheme();
+
+		$record = VisualEditorGlobalStyles::query()
+			->where( 'theme', $activeTheme )
+			->first();
+
+		if ( null === $record ) {
+			return $this->compiler->compile( $this->basePayload() );
+		}
+
+		$cacheKey = $this->cacheKey( $record );
+
+		return $this->cache->rememberForever(
+			$cacheKey,
+			fn (): string => $this->compiler->compile( [
+				'version'  => $record->version,
+				'settings' => $record->settings ?? [],
+				'styles'   => $record->styles ?? [],
+			] )
+		);
+	}
+
+	/**
+	 * Forgets cached CSS for a given record. Called from the model
+	 * `saved`/`deleted` listeners so the prior key does not linger.
+	 *
+	 * @since 1.0.0
+	 */
+	public function forget( VisualEditorGlobalStyles $record, ?string $previousUpdatedAt = null ): void
+	{
+		$this->cache->forget( $this->cacheKey( $record ) );
+
+		if ( null !== $previousUpdatedAt && '' !== $previousUpdatedAt ) {
+			$this->cache->forget( $this->cacheKeyFor( $record->getKey(), $previousUpdatedAt ) );
+		}
+	}
+
+	/**
+	 * Resolves the active theme slug from config; mirrors the controller
+	 * fallback so the CSS layer scopes to the same record the API does.
+	 *
+	 * @since 1.0.0
+	 */
+	protected function activeTheme(): string
+	{
+		$theme = $this->config->get( 'artisanpack.visual-editor.global_styles.theme', 'artisanpack-base' );
+
+		return is_string( $theme ) && '' !== $theme ? $theme : 'artisanpack-base';
+	}
+
+	/**
+	 * Loads the bundled (or host-overridden) base payload — the
+	 * fallback used when no record exists yet.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<string, mixed>
+	 */
+	protected function basePayload(): array
+	{
+		$configured = $this->config->get( 'artisanpack.visual-editor.global_styles.base_path' );
+		$path       = is_string( $configured ) && '' !== $configured
+			? $configured
+			: __DIR__ . '/../../resources/theme-json/default-base.php';
+
+		if ( ! is_file( $path ) ) {
+			return [
+				'version'  => (int) $this->config->get( 'artisanpack.visual-editor.global_styles.schema_version', 3 ),
+				'settings' => [],
+				'styles'   => [],
+			];
+		}
+
+		$payload = require $path;
+
+		return is_array( $payload ) ? $payload : [];
+	}
+
+	/**
+	 * Builds the cache key for a record at its current `updated_at`.
+	 *
+	 * @since 1.0.0
+	 */
+	protected function cacheKey( VisualEditorGlobalStyles $record ): string
+	{
+		$updatedAt = null !== $record->updated_at
+			? $record->updated_at->format( 'YmdHis' )
+			: '0';
+
+		return $this->cacheKeyFor( $record->getKey(), $updatedAt );
+	}
+
+	/**
+	 * Builds the cache key for a record id + timestamp pair.
+	 *
+	 * @since 1.0.0
+	 */
+	protected function cacheKeyFor( int|string|null $id, string $updatedAt ): string
+	{
+		return self::CACHE_PREFIX . ':' . (string) $id . ':' . $updatedAt;
+	}
+}

--- a/src/Services/GlobalStylesEmissionTracker.php
+++ b/src/Services/GlobalStylesEmissionTracker.php
@@ -11,9 +11,13 @@
  * (e.g. a layout that nests a `<x-ve-template name="header">` above a
  * `<x-ve-blocks :tree="...">` post body).
  *
- * Bound as a singleton in the package container — Laravel's container
- * is request-scoped by default in HTTP requests, so each visitor
- * response gets a fresh tracker without further plumbing.
+ * Bound via `$this->app->scoped()` in the package container so the
+ * tracker is rebuilt at the start of every request scope. That keeps
+ * a long-lived worker (Octane, RoadRunner, queue worker rendering
+ * blocks per job) from leaking the "already emitted" flag from one
+ * request into the next. Tests can also explicitly call `reset()` on
+ * the resolved instance to clear state between assertions inside a
+ * single PHP process.
  *
  * @package    ArtisanPack_UI
  * @subpackage VisualEditor

--- a/src/Services/GlobalStylesEmissionTracker.php
+++ b/src/Services/GlobalStylesEmissionTracker.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * Per-request flag that records whether the global-styles `<style>`
+ * block has already been emitted in the current response.
+ *
+ * `<x-ve-blocks>` and `<x-ve-template>` both auto-prepend the compiled
+ * CSS to their first render; subsequent renders on the same page check
+ * this tracker and skip emission so the `<style>` block appears at
+ * most once per page even when the same renderer fires multiple times
+ * (e.g. a layout that nests a `<x-ve-template name="header">` above a
+ * `<x-ve-blocks :tree="...">` post body).
+ *
+ * Bound as a singleton in the package container — Laravel's container
+ * is request-scoped by default in HTTP requests, so each visitor
+ * response gets a fresh tracker without further plumbing.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Services;
+
+class GlobalStylesEmissionTracker
+{
+	protected bool $emitted = false;
+
+	public function hasEmitted(): bool
+	{
+		return $this->emitted;
+	}
+
+	public function markEmitted(): void
+	{
+		$this->emitted = true;
+	}
+
+	/**
+	 * Resets the tracker — used by tests that exercise multiple renders
+	 * inside a single process.
+	 *
+	 * @since 1.0.0
+	 */
+	public function reset(): void
+	{
+		$this->emitted = false;
+	}
+}

--- a/src/VisualEditorServiceProvider.php
+++ b/src/VisualEditorServiceProvider.php
@@ -86,7 +86,12 @@ class VisualEditorServiceProvider extends ServiceProvider
 			);
 		} );
 
-		$this->app->singleton( GlobalStylesEmissionTracker::class, function () {
+		// Scoped (not singleton) so a long-lived worker (Octane,
+		// RoadRunner, queue) gets a fresh tracker per request scope.
+		// A singleton would leak the "already emitted" flag across
+		// requests and suppress the <style> block on every page after
+		// the first one served by the worker.
+		$this->app->scoped( GlobalStylesEmissionTracker::class, function () {
 			return new GlobalStylesEmissionTracker();
 		} );
 

--- a/src/VisualEditorServiceProvider.php
+++ b/src/VisualEditorServiceProvider.php
@@ -20,8 +20,14 @@ use ArtisanPackUI\VisualEditor\Registries\BlockTypeRegistry;
 use ArtisanPackUI\VisualEditor\Registries\DynamicBlockRegistry;
 use ArtisanPackUI\VisualEditor\Resources\ResourceResolver;
 use ArtisanPackUI\VisualEditor\Search\BlockTreeSearchExtractor;
+use ArtisanPackUI\VisualEditor\Services\GlobalStylesCacheInvalidator;
+use ArtisanPackUI\VisualEditor\Services\GlobalStylesCompiler;
+use ArtisanPackUI\VisualEditor\Services\GlobalStylesCssProvider;
+use ArtisanPackUI\VisualEditor\Services\GlobalStylesEmissionTracker;
 use ArtisanPackUI\VisualEditor\Services\MenuLocationResolver;
 use ArtisanPackUI\VisualEditor\View\Components\VisualEditorComponent;
+use Illuminate\Contracts\Cache\Repository as CacheRepository;
+use Illuminate\Contracts\Config\Repository as ConfigRepository;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Route;
@@ -68,6 +74,28 @@ class VisualEditorServiceProvider extends ServiceProvider
 			return new MenuLocationResolver( $app['config'] );
 		} );
 
+		$this->app->singleton( GlobalStylesCompiler::class, function () {
+			return new GlobalStylesCompiler();
+		} );
+
+		$this->app->singleton( GlobalStylesCssProvider::class, function ( $app ) {
+			return new GlobalStylesCssProvider(
+				$app->make( GlobalStylesCompiler::class ),
+				$app->make( CacheRepository::class ),
+				$app->make( ConfigRepository::class ),
+			);
+		} );
+
+		$this->app->singleton( GlobalStylesEmissionTracker::class, function () {
+			return new GlobalStylesEmissionTracker();
+		} );
+
+		$this->app->singleton( GlobalStylesCacheInvalidator::class, function ( $app ) {
+			return new GlobalStylesCacheInvalidator(
+				$app->make( GlobalStylesCssProvider::class ),
+			);
+		} );
+
 		// Legacy alias for backward compatibility
 		$this->app->alias( VisualEditor::class, 'visualEditor' );
 
@@ -102,6 +130,11 @@ class VisualEditorServiceProvider extends ServiceProvider
 		Gate::policy( VisualEditorGlobalStyles::class, VisualEditorGlobalStylesPolicy::class );
 		Gate::policy( VisualEditorNavigation::class, VisualEditorNavigationPolicy::class );
 		Gate::policy( VisualEditorPattern::class, VisualEditorPatternPolicy::class );
+
+		// Hook the global-styles cache to model save/delete events so a
+		// PUT to `/visual-editor/api/global-styles/{id}` invalidates the
+		// CSS the front-end renderers serve on the next request.
+		$this->app->make( GlobalStylesCacheInvalidator::class )->register();
 
 		// 3. Register core blocks from their block.json manifests.
 		$this->registerCoreBlocks();

--- a/tests/Feature/VisualEditor/GlobalStylesCssProviderTest.php
+++ b/tests/Feature/VisualEditor/GlobalStylesCssProviderTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Models\VisualEditorGlobalStyles;
+use ArtisanPackUI\VisualEditor\Services\GlobalStylesCssProvider;
+use Illuminate\Support\Facades\Cache;
+
+beforeEach( function (): void {
+	Cache::flush();
+	$this->provider = $this->app->make( GlobalStylesCssProvider::class );
+} );
+
+it( 'falls back to the bundled base payload when no record exists', function (): void {
+	$css = $this->provider->css();
+
+	// Defaults from resources/theme-json/default-base.php should round-trip
+	// through the compiler so a brand-new install is never unstyled.
+	expect( $css )->toContain( ':root' )
+		->toContain( '--wp--preset--color--primary' )
+		->toContain( 'body {' );
+} );
+
+it( 'compiles the active record when present', function (): void {
+	VisualEditorGlobalStyles::create( [
+		'theme'    => 'artisanpack-base',
+		'version'  => 3,
+		'settings' => [
+			'color' => [
+				'palette' => [
+					[ 'slug' => 'brand', 'name' => 'Brand', 'color' => '#abcdef' ],
+				],
+			],
+		],
+		'styles'   => [],
+	] );
+
+	$css = $this->provider->css();
+
+	expect( $css )->toContain( '--wp--preset--color--brand: #abcdef' );
+} );
+
+it( 'caches the compiled CSS — second call hits the cache', function (): void {
+	$record = VisualEditorGlobalStyles::create( [
+		'theme'    => 'artisanpack-base',
+		'version'  => 3,
+		'settings' => [
+			'color' => [
+				'palette' => [ [ 'slug' => 'one', 'name' => 'One', 'color' => '#111111' ] ],
+			],
+		],
+		'styles'   => [],
+	] );
+
+	$first = $this->provider->css();
+
+	// Mutating the model in memory without saving should not affect the
+	// cached output — proves the second call read from the cache.
+	$record->settings = [
+		'color' => [
+			'palette' => [ [ 'slug' => 'two', 'name' => 'Two', 'color' => '#222222' ] ],
+		],
+	];
+
+	$second = $this->provider->css();
+
+	expect( $second )->toBe( $first )
+		->toContain( '--wp--preset--color--one' )
+		->not->toContain( '--wp--preset--color--two' );
+} );
+
+it( 'invalidates the cache when the record is saved', function (): void {
+	$record = VisualEditorGlobalStyles::create( [
+		'theme'    => 'artisanpack-base',
+		'version'  => 3,
+		'settings' => [
+			'color' => [
+				'palette' => [ [ 'slug' => 'before', 'name' => 'Before', 'color' => '#000000' ] ],
+			],
+		],
+		'styles'   => [],
+	] );
+
+	$initial = $this->provider->css();
+
+	expect( $initial )->toContain( '--wp--preset--color--before' );
+
+	// Sleep a second so updated_at advances — sqlite's CURRENT_TIMESTAMP
+	// has 1s resolution and the cache key includes the timestamp.
+	sleep( 1 );
+
+	$record->settings = [
+		'color' => [
+			'palette' => [ [ 'slug' => 'after', 'name' => 'After', 'color' => '#ffffff' ] ],
+		],
+	];
+	$record->save();
+
+	$updated = $this->provider->css();
+
+	expect( $updated )->toContain( '--wp--preset--color--after' )
+		->not->toContain( '--wp--preset--color--before' );
+} );
+
+it( 'scopes records by theme so a non-default theme query returns its own CSS', function (): void {
+	VisualEditorGlobalStyles::create( [
+		'theme'    => 'artisanpack-base',
+		'version'  => 3,
+		'settings' => [
+			'color' => [
+				'palette' => [ [ 'slug' => 'base', 'name' => 'Base', 'color' => '#aaaaaa' ] ],
+			],
+		],
+		'styles'   => [],
+	] );
+
+	VisualEditorGlobalStyles::create( [
+		'theme'    => 'other-theme',
+		'version'  => 3,
+		'settings' => [
+			'color' => [
+				'palette' => [ [ 'slug' => 'other', 'name' => 'Other', 'color' => '#bbbbbb' ] ],
+			],
+		],
+		'styles'   => [],
+	] );
+
+	$baseCss  = $this->provider->css();
+	$otherCss = $this->provider->css( 'other-theme' );
+
+	expect( $baseCss )->toContain( '--wp--preset--color--base' )
+		->not->toContain( '--wp--preset--color--other' );
+	expect( $otherCss )->toContain( '--wp--preset--color--other' )
+		->not->toContain( '--wp--preset--color--base' );
+} );

--- a/tests/Unit/VisualEditor/GlobalStylesCompilerTest.php
+++ b/tests/Unit/VisualEditor/GlobalStylesCompilerTest.php
@@ -1,0 +1,270 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Services\GlobalStylesCompiler;
+
+beforeEach( function (): void {
+	$this->compiler = new GlobalStylesCompiler();
+} );
+
+it( 'returns an empty string when settings and styles are empty', function (): void {
+	expect( $this->compiler->compile( [ 'version' => 3, 'settings' => [], 'styles' => [] ] ) )
+		->toBe( '' );
+} );
+
+it( 'returns an empty string when payload is missing settings/styles entirely', function (): void {
+	expect( $this->compiler->compile( [] ) )->toBe( '' );
+} );
+
+it( 'emits color palette presets as :root --wp--preset--color--{slug} variables', function (): void {
+	$css = $this->compiler->compile( [
+		'settings' => [
+			'color' => [
+				'palette' => [
+					[ 'slug' => 'primary', 'name' => 'Primary', 'color' => '#3b82f6' ],
+					[ 'slug' => 'accent', 'name' => 'Accent', 'color' => '#10b981' ],
+				],
+			],
+		],
+	] );
+
+	expect( $css )->toContain( ':root' )
+		->toContain( '--wp--preset--color--primary: #3b82f6' )
+		->toContain( '--wp--preset--color--accent: #10b981' );
+} );
+
+it( 'emits font-family and font-size presets', function (): void {
+	$css = $this->compiler->compile( [
+		'settings' => [
+			'typography' => [
+				'fontFamilies' => [
+					[ 'slug' => 'sans', 'name' => 'Sans', 'fontFamily' => "'Inter', sans-serif" ],
+				],
+				'fontSizes' => [
+					[ 'slug' => 'medium', 'name' => 'Medium', 'size' => '1rem' ],
+				],
+			],
+		],
+	] );
+
+	expect( $css )->toContain( "--wp--preset--font-family--sans: 'Inter', sans-serif" )
+		->toContain( '--wp--preset--font-size--medium: 1rem' );
+} );
+
+it( 'emits layout content/wide sizes as --wp--style--global variables', function (): void {
+	$css = $this->compiler->compile( [
+		'settings' => [
+			'layout' => [
+				'contentSize' => '720px',
+				'wideSize'    => '1120px',
+			],
+		],
+	] );
+
+	expect( $css )->toContain( '--wp--style--global--content-size: 720px' )
+		->toContain( '--wp--style--global--wide-size: 1120px' );
+} );
+
+it( 'emits body styles for color and typography', function (): void {
+	$css = $this->compiler->compile( [
+		'styles' => [
+			'color'      => [
+				'background' => 'var(--wp--preset--color--base)',
+				'text'       => 'var(--wp--preset--color--contrast)',
+			],
+			'typography' => [
+				'fontFamily' => 'var(--wp--preset--font-family--sans)',
+				'fontSize'   => 'var(--wp--preset--font-size--medium)',
+				'lineHeight' => '1.6',
+			],
+		],
+	] );
+
+	expect( $css )->toContain( 'body {' )
+		->toContain( 'background-color: var(--wp--preset--color--base)' )
+		->toContain( 'color: var(--wp--preset--color--contrast)' )
+		->toContain( 'font-family: var(--wp--preset--font-family--sans)' )
+		->toContain( 'font-size: var(--wp--preset--font-size--medium)' )
+		->toContain( 'line-height: 1.6' );
+} );
+
+it( 'emits link element rules wrapped in :where()', function (): void {
+	$css = $this->compiler->compile( [
+		'styles' => [
+			'elements' => [
+				'link' => [ 'color' => [ 'text' => 'var(--wp--preset--color--primary)' ] ],
+			],
+		],
+	] );
+
+	expect( $css )->toContain( ':where(a) {' )
+		->toContain( 'color: var(--wp--preset--color--primary)' );
+} );
+
+it( 'emits heading element rules covering h1 through h6', function (): void {
+	$css = $this->compiler->compile( [
+		'styles' => [
+			'elements' => [
+				'heading' => [
+					'typography' => [
+						'fontFamily' => 'var(--wp--preset--font-family--serif)',
+						'fontWeight' => '600',
+					],
+				],
+			],
+		],
+	] );
+
+	expect( $css )->toContain( ':where(h1, h2, h3, h4, h5, h6)' )
+		->toContain( "font-family: var(--wp--preset--font-family--serif)" )
+		->toContain( 'font-weight: 600' );
+} );
+
+it( 'emits per-block overrides as .wp-block-{name} rules', function (): void {
+	$css = $this->compiler->compile( [
+		'styles' => [
+			'blocks' => [
+				'core/button' => [
+					'color'  => [
+						'background' => 'var(--wp--preset--color--primary)',
+						'text'       => 'var(--wp--preset--color--base)',
+					],
+					'border' => [ 'radius' => '0.5rem' ],
+				],
+			],
+		],
+	] );
+
+	expect( $css )->toContain( '.wp-block-button {' )
+		->toContain( 'background-color: var(--wp--preset--color--primary)' )
+		->toContain( 'color: var(--wp--preset--color--base)' )
+		->toContain( 'border-radius: 0.5rem' );
+} );
+
+it( 'namespaces non-core blocks in the selector', function (): void {
+	$css = $this->compiler->compile( [
+		'styles' => [
+			'blocks' => [
+				'artisanpack/callout' => [
+					'color' => [ 'background' => '#f0f0f0' ],
+				],
+			],
+		],
+	] );
+
+	expect( $css )->toContain( '.wp-block-artisanpack-callout' );
+} );
+
+it( 'skips block names without a namespace separator', function (): void {
+	$css = $this->compiler->compile( [
+		'styles' => [
+			'blocks' => [
+				'malformed-name' => [
+					'color' => [ 'background' => '#f0f0f0' ],
+				],
+			],
+		],
+	] );
+
+	expect( $css )->not->toContain( '.wp-block-malformed-name' )
+		->not->toContain( 'malformed' );
+} );
+
+it( 'expands per-side padding/margin maps into individual declarations', function (): void {
+	$css = $this->compiler->compile( [
+		'styles' => [
+			'spacing' => [
+				'padding' => [
+					'top'    => '1rem',
+					'right'  => '2rem',
+					'bottom' => '1rem',
+					'left'   => '2rem',
+				],
+				'margin'  => '0 auto',
+			],
+		],
+	] );
+
+	expect( $css )->toContain( 'padding-top: 1rem' )
+		->toContain( 'padding-right: 2rem' )
+		->toContain( 'padding-bottom: 1rem' )
+		->toContain( 'padding-left: 2rem' )
+		->toContain( 'margin: 0 auto' );
+} );
+
+it( 'maps spacing.blockGap to gap', function (): void {
+	$css = $this->compiler->compile( [
+		'styles' => [
+			'blocks' => [
+				'core/columns' => [
+					'spacing' => [ 'blockGap' => '2rem' ],
+				],
+			],
+		],
+	] );
+
+	expect( $css )->toContain( '.wp-block-columns' )
+		->toContain( 'gap: 2rem' );
+} );
+
+it( 'strips characters that could break out of the style block', function (): void {
+	$css = $this->compiler->compile( [
+		'settings' => [
+			'color' => [
+				'palette' => [
+					[ 'slug' => 'evil', 'name' => 'Evil', 'color' => '#fff;</style><script>alert(1)' ],
+				],
+			],
+		],
+	] );
+
+	expect( $css )->not->toContain( '</style>' )
+		->not->toContain( '<script>' )
+		->not->toContain( ';' . PHP_EOL )
+		->toContain( '--wp--preset--color--evil' );
+} );
+
+it( 'sanitizes preset slugs to a safe charset', function (): void {
+	$css = $this->compiler->compile( [
+		'settings' => [
+			'color' => [
+				'palette' => [
+					[ 'slug' => 'evil!@#$%', 'name' => 'Evil', 'color' => '#000000' ],
+				],
+			],
+		],
+	] );
+
+	expect( $css )->toContain( '--wp--preset--color--evil:' )
+		->not->toContain( '!@#' );
+} );
+
+it( 'skips palette entries missing a slug or color', function (): void {
+	$css = $this->compiler->compile( [
+		'settings' => [
+			'color' => [
+				'palette' => [
+					[ 'slug' => 'good', 'color' => '#000000' ],
+					[ 'slug' => 'no-color' ],
+					[ 'color' => '#ffffff' ],
+				],
+			],
+		],
+	] );
+
+	expect( $css )->toContain( '--wp--preset--color--good' )
+		->not->toContain( '--wp--preset--color--no-color' );
+} );
+
+it( 'compiles the bundled default-base payload to a non-empty CSS string', function (): void {
+	$payload = require __DIR__ . '/../../../resources/theme-json/default-base.php';
+
+	$css = $this->compiler->compile( $payload );
+
+	expect( $css )->toContain( ':root' )
+		->toContain( '--wp--preset--color--primary' )
+		->toContain( '--wp--preset--font-family--sans' )
+		->toContain( 'body {' )
+		->toContain( '.wp-block-button' );
+} );


### PR DESCRIPTION
## Description

Compiles theme.json-shaped global-styles records into front-end CSS and auto-emits the result on every front-end render path (Blade, React, Vue) so a published page renders with the same global tokens (colors, typography, spacing, per-block overrides) the editor canvas already uses.

**Closes:** #378

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #378

## Motivation and Context

The editor canvas was already styled by global-styles (D3 / #370), but the front-end rendering paths still inherited only the host app's CSS — meaning a page authored in the editor could look completely different once published. #378 closes that canvas/published parity gap so all three renderers emit byte-identical global-styles markup.

## Changes Made

**New PHP services** (single source of truth for emission):

- `GlobalStylesCompiler` — pure, stateless compiler that turns a `{ version, settings, styles }` payload into a CSS string. Emits `:root` preset tokens, body / link / heading / button element rules, and `.wp-block-{name}` per-block overrides. Defense-in-depth value sanitization strips control characters that can't appear in well-formed theme.json.
- `GlobalStylesCssProvider` — resolves the active theme's record, compiles, caches with `rememberForever`. Cache key is `visual-editor:global-styles:css:{id}:{updated_at}` so an update naturally invalidates without an explicit forget. Falls back to the bundled `default-base.php` payload when no record exists.
- `GlobalStylesEmissionTracker` — request-scoped flag so a page with multiple `<x-ve-blocks>` / `<x-ve-template>` instances emits the `<style>` block exactly once.
- `GlobalStylesCacheInvalidator` — hooks `VisualEditorGlobalStyles` `saved` and `deleted` model events to forget the prior cache key (belt-and-suspenders alongside the natural key-based invalidation).

**Renderer wiring:**

- **Blade** — `BlocksComponent` and `TemplateComponent` resolve the CSS on first render via the tracker, otherwise return null. View partials emit `<style data-ve-global-styles>{css}</style>` before the rendered HTML.
- **React** — new `GlobalStyles` component renders `<style data-ve-global-styles="">` with `dangerouslySetInnerHTML`. `BlockTree` and `Template` accept a `globalStylesCss` prop and delegate. The empty-string attribute (vs React's bare-attribute shorthand) is necessary so SSR is byte-identical with Vue's `h('style', { 'data-ve-global-styles': '' })`.
- **Vue** — equivalent `GlobalStyles` defineComponent, mirrored `globalStylesCss` prop on `BlockTree` and `Template`.

**Schema version pinned at 3** via `artisanpack.visual-editor.global_styles.schema_version` config — the compiler, controller, and form-request all read from one source so a future bump only requires extending the compiler and lifting the config.

**Inline `<style>` (not linked asset)** — chosen for SSR-safety, no extra HTTP round-trip, and simple cacheability via the existing record-keyed cache. Documented in the compiler class docblock.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (Darwin 25.4.0)
- Browser (if applicable): Safari (manual front-end verification)
- PHP Version: 8.4.3
- Project Version: V1 (release/1.0)

**Tests Performed:**

1. Full PHP test suite via Pest — 407 tests pass / 0 regressions.
2. Full JS/TS test suite via Vitest — 813 tests pass / 0 regressions.
3. Manual browser verification in the dev app: confirmed auto-emission, request-scoped dedupe (one `<style>` block across 3 `<x-ve-blocks>` + 1 `<x-ve-template>` on a single page), cache invalidation on save, and fallback to bundled defaults on record delete.

## Accessibility Tests Run

- [x] Color contrast verified

**Details:** No new UI introduced — change is purely a CSS emission layer. Bundled defaults preserve the existing palette which is already contrast-validated.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:**

- 17 unit tests on the compiler (token emission, per-element + per-block overrides, slug + value sanitization, schema-version pinning).
- 5 feature tests on the provider (cache hit/miss, invalidation on save + delete, fallback to bundled defaults, theme scoping).
- 4 feature tests on the Blade auto-emission path (`<x-ve-blocks>`, `<x-ve-template>`, dedupe, fallback).
- 6 React + 6 Vue tests on `<GlobalStyles>` and the renderer prop wiring.
- Renderer parity test extended with a new fixture asserting React and Vue emit byte-identical `<style data-ve-global-styles="">` output.
- Existing `BlocksComponentTest` updated with a `stripGlobalStyles()` TestCase helper so strict-equality assertions still pass under the auto-emit path.

## Documentation

- [x] Inline code documentation added

**Documentation details:** All four new services carry full PHPDoc class blocks explaining the design contract (single source of truth, request-scoped dedupe, cache key shape, parity guarantee). Renderer components updated with notes on why the empty-string attribute was chosen for byte-parity.

## Screenshots

N/A — change is invisible to the visual chrome; emits a `<style>` tag in the rendered HTML head/body.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [x] Accessibility tests completed
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Global styles are now compiled and injected into Blade, React, and Vue outputs, with a default fallback when no custom styles exist.
  * Emission is deduplicated so the global style block appears only once per page.
  * Style updates propagate reliably so edits are reflected in subsequent renders.

* **Tests**
  * Added comprehensive tests covering compilation, rendering, de-duplication, and cross-renderer parity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->