### PR TITLE
feat: E3 · front-end synced-pattern resolution (#380)

### DIFF
--- a/docs/core-data-shim.md
+++ b/docs/core-data-shim.md
@@ -202,6 +202,39 @@ synced patterns (reusable blocks) from unsynced (one-shot inserts).
 }
 ```
 
+#### Synced vs. unsynced rendering (E3)
+
+The two pattern types reach the saved block tree by different paths, so
+the front-end renderers (Blade, React, Vue) treat them differently:
+
+- **Synced patterns** (`synced: true`) — the editor inserts a
+  `core/block` reference, e.g. `{ "name": "core/block", "attributes":
+  { "ref": 42 } }`, into the saved tree. Editing the pattern record
+  propagates everywhere. At render time the renderers resolve the
+  reference against the pattern API (PHP: `PatternInliner` —
+  `src/Resources/PatternInliner.php`; JS: `inlinePatterns()` —
+  `packages/visual-editor-renderer-react/src/patterns.ts` and the Vue
+  twin). Resolution happens **before** the renderer walks the tree, so
+  a single recursive pass produces the final HTML. Missing patterns,
+  cycles, and depth-overflow conditions stamp a synthetic
+  `_resolutionError` attribute that the registered `core/block`
+  renderer surfaces as an empty wrapper in production and a
+  `data-ve-resolution-error` / HTML comment in development.
+- **Unsynced patterns** (`synced: false`) — the editor parses
+  `pattern.content.raw` at insert time and pastes the resulting block
+  list directly into the target (see
+  `inserter-patterns-panel.tsx::patternBlocks`). The two diverge from
+  that point on. Renderers never see a `core/block` reference for an
+  unsynced pattern — the tree they receive already carries the
+  pattern's blocks inline, so no runtime resolution is required.
+
+Hosts wire synced-pattern resolution by passing a `patterns` collection
+to `<x-ve-blocks>` (Blade resolves automatically through Eloquent),
+`<BlockTree patterns={patterns} />` / `<Template patterns={patterns} />`
+(React), or the same props on the Vue twins. Pattern inlining runs
+after template-part inlining so a part that itself references a synced
+pattern resolves in the same pass.
+
 ### Global styles — `globalStyles`
 
 Global styles is a **singleton** per site. The `lookup` endpoint

--- a/docs/plans/11-v1-expansion.md
+++ b/docs/plans/11-v1-expansion.md
@@ -165,4 +165,4 @@ Not blocking this plan, but worth naming:
 
 - **Global-styles**: do we surface "style variations" (theme-level presets) in V1 UI, or save for 1.1? Schema-compat means we *can*; UI cost is real.
 - **Nav menu locations**: config-driven (`config/visual-editor.php`) or database-driven (admin CRUD)? Leaning config for V1.
-- **Patterns**: do unsynced patterns support variables/bindings, or are they pure block-tree copies? Leaning pure copies for V1 — bindings are a whole separate system.
+- **Patterns**: do unsynced patterns support variables/bindings, or are they pure block-tree copies? **Closed (E3)** — pure block-tree copies for V1. The editor inlines unsynced patterns at insert time (`inserter-patterns-panel.tsx::patternBlocks`), so renderers only resolve `core/block` references for synced patterns. Bindings are deferred to V2.

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/core/block.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/core/block.blade.php
@@ -1,0 +1,25 @@
+@php
+	$ref = isset( $attributes['ref'] ) ? $attributes['ref'] : null;
+	$refString = is_int( $ref ) || ( is_string( $ref ) && '' !== $ref ) ? (string) $ref : '';
+
+	$resolutionError = isset( $attributes['_resolutionError'] ) && is_string( $attributes['_resolutionError'] )
+		? $attributes['_resolutionError']
+		: null;
+
+	$classes = [ 'wp-block-block' ];
+
+	if ( ! empty( $attributes['className'] ) && is_string( $attributes['className'] ) ) {
+		$classes[] = $attributes['className'];
+	}
+
+	$inDev = function_exists( 'app' ) ? ! app()->environment( 'production' ) : false;
+@endphp
+<div class="{{ implode( ' ', $classes ) }}"@if( '' !== $refString ) data-ve-pattern-ref="{{ $refString }}"@endif>
+@if( null !== $resolutionError )
+@if( $inDev )
+<!-- visual-editor: synced pattern{{ '' !== $refString ? ' "' . $refString . '"' : '' }} failed to resolve ({{ $resolutionError }}) -->
+@endif
+@else
+{!! $innerBlocksHtml !!}
+@endif
+</div>

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/core/block.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/core/block.blade.php
@@ -1,6 +1,7 @@
 @php
 	$ref = isset( $attributes['ref'] ) ? $attributes['ref'] : null;
-	$refString = is_int( $ref ) || ( is_string( $ref ) && '' !== $ref ) ? (string) $ref : '';
+	$trimmedRef = is_string( $ref ) ? trim( $ref ) : $ref;
+	$refString = is_int( $ref ) || ( is_string( $trimmedRef ) && '' !== $trimmedRef ) ? (string) $trimmedRef : '';
 
 	$resolutionError = isset( $attributes['_resolutionError'] ) && is_string( $attributes['_resolutionError'] )
 		? $attributes['_resolutionError']

--- a/packages/visual-editor-renderer-blade/src/View/Components/BlocksComponent.php
+++ b/packages/visual-editor-renderer-blade/src/View/Components/BlocksComponent.php
@@ -6,9 +6,11 @@
  * Renders a saved visual editor block tree into HTML using the
  * {@see \ArtisanPackUI\VisualEditorRendererBlade\BlockRenderer} engine.
  * Resolves any `core/template-part` blocks in the tree inline (via the
- * shared {@see TemplatePartInliner}) so a single render pass produces
- * the final markup. Pass `:resolve-parts="false"` to opt out and render
- * the raw tree.
+ * shared {@see TemplatePartInliner}) and any `core/block`
+ * (synced-pattern) references via {@see PatternInliner} so a single
+ * render pass produces the final markup. Pass `:resolve-parts="false"`
+ * or `:resolve-patterns="false"` to opt out of either resolution step
+ * and render the raw tree.
  *
  * @package    ArtisanPack_UI
  * @subpackage VisualEditorRendererBlade
@@ -22,6 +24,7 @@ declare( strict_types=1 );
 
 namespace ArtisanPackUI\VisualEditorRendererBlade\View\Components;
 
+use ArtisanPackUI\VisualEditor\Resources\PatternInliner;
 use ArtisanPackUI\VisualEditor\Resources\TemplatePartInliner;
 use ArtisanPackUI\VisualEditor\Services\GlobalStylesCssProvider;
 use ArtisanPackUI\VisualEditor\Services\GlobalStylesEmissionTracker;
@@ -47,19 +50,28 @@ class BlocksComponent extends Component
 	public function __construct(
 		protected BlockRenderer $renderer,
 		protected TemplatePartInliner $inliner,
+		protected PatternInliner $patternInliner,
 		protected GlobalStylesCssProvider $globalStyles,
 		protected GlobalStylesEmissionTracker $emissionTracker,
 		mixed $tree = null,
 		?string $defaultTheme = null,
 		bool $resolveParts = true,
+		bool $resolvePatterns = true,
 	) {
 		$this->defaultTheme = $defaultTheme;
 
 		$normalized = $this->normalizeTree( $tree );
 
-		$this->tree = $resolveParts
+		$resolved = $resolveParts
 			? $this->inliner->inline( $normalized, $defaultTheme )
 			: $normalized;
+
+		// Pattern inlining runs after template-part inlining so a part
+		// that itself contains a synced-pattern reference resolves in the
+		// same pass.
+		$this->tree = $resolvePatterns
+			? $this->patternInliner->inline( $resolved )
+			: $resolved;
 	}
 
 	public function render(): View

--- a/packages/visual-editor-renderer-blade/src/View/Components/TemplateComponent.php
+++ b/packages/visual-editor-renderer-blade/src/View/Components/TemplateComponent.php
@@ -27,6 +27,7 @@ declare( strict_types=1 );
 
 namespace ArtisanPackUI\VisualEditorRendererBlade\View\Components;
 
+use ArtisanPackUI\VisualEditor\Resources\PatternInliner;
 use ArtisanPackUI\VisualEditor\Resources\TemplatePartInliner;
 use ArtisanPackUI\VisualEditor\Resources\TemplateResolver;
 use ArtisanPackUI\VisualEditor\Services\GlobalStylesCssProvider;
@@ -57,6 +58,7 @@ class TemplateComponent extends Component
 		protected BlockRenderer $renderer,
 		protected TemplateResolver $templates,
 		protected TemplatePartInliner $inliner,
+		protected PatternInliner $patternInliner,
 		protected Application $app,
 		protected GlobalStylesCssProvider $globalStyles,
 		protected GlobalStylesEmissionTracker $emissionTracker,
@@ -80,8 +82,9 @@ class TemplateComponent extends Component
 		$this->matchedSlug     = $template->slug;
 		$this->resolutionError = null;
 
-		$inlined    = $this->inliner->inline( $template->getBlocks(), $theme ?? $template->theme );
-		$this->html = $renderer->render( $inlined );
+		$inlinedParts    = $this->inliner->inline( $template->getBlocks(), $theme ?? $template->theme );
+		$inlinedPatterns = $this->patternInliner->inline( $inlinedParts );
+		$this->html      = $renderer->render( $inlinedPatterns );
 	}
 
 	public function render(): View

--- a/packages/visual-editor-renderer-blade/tests/Feature/SyncedPatternRenderingTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Feature/SyncedPatternRenderingTest.php
@@ -134,6 +134,32 @@ it( 'renders a cycle marker without infinite recursion', function () {
 	expect( $rendered )->toContain( 'failed to resolve (cycle)' );
 } );
 
+it( 'omits data-ve-pattern-ref when the ref attribute is whitespace-only', function () {
+	// `:resolve-patterns="false"` lets the raw attributes flow straight to
+	// the partial — exercise the partial's own normalization to confirm a
+	// whitespace ref does not leak into the rendered data attribute. This
+	// matches the React/Vue `refString` helper, which trims before
+	// emptiness checks.
+	$tree = [
+		[
+			'clientId'    => 'pat-whitespace',
+			'name'        => 'core/block',
+			'attributes'  => [ 'ref' => '   ' ],
+			'innerBlocks' => [],
+		],
+	];
+
+	$rendered = Blade::render(
+		'<x-ve-blocks :tree="$tree" :resolve-patterns="false" />',
+		[ 'tree' => $tree ]
+	);
+
+	$normalized = $this->normalizeHtml( $rendered );
+
+	expect( $normalized )->toContain( '<div class="wp-block-block">' );
+	expect( $normalized )->not()->toContain( 'data-ve-pattern-ref' );
+} );
+
 it( 'unsynced patterns travel as inlined block trees, never as core/block references', function () {
 	// Sanity check on the synced/unsynced contract documented in
 	// `docs/plans/11-v1-expansion.md` §2.2 / §8: the editor only emits

--- a/packages/visual-editor-renderer-blade/tests/Feature/SyncedPatternRenderingTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Feature/SyncedPatternRenderingTest.php
@@ -1,0 +1,166 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Models\VisualEditorPattern;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Blade;
+
+uses( RefreshDatabase::class );
+
+function bladePatternFixture( string $slug, array $blocks, bool $synced = true ): VisualEditorPattern
+{
+	return VisualEditorPattern::create( [
+		'slug'    => $slug,
+		'title'   => ucfirst( $slug ),
+		'content' => [ 'raw' => '', 'blocks' => $blocks ],
+		'synced'  => $synced,
+		'status'  => 'publish',
+	] );
+}
+
+function bladePatternRef( int $ref, string $clientId = 'pat-cid' ): array
+{
+	return [
+		'clientId'    => $clientId,
+		'name'        => 'core/block',
+		'attributes'  => [ 'ref' => $ref ],
+		'innerBlocks' => [],
+	];
+}
+
+function bladePatternParagraph( string $text, string $clientId = 'p-cid' ): array
+{
+	return [
+		'clientId'    => $clientId,
+		'name'        => 'core/paragraph',
+		'attributes'  => [ 'content' => $text ],
+		'innerBlocks' => [],
+	];
+}
+
+it( 'inlines a core/block reference inside <x-ve-blocks>', function () {
+	$pattern = bladePatternFixture( 'hero', [ bladePatternParagraph( 'Hero copy' ) ] );
+
+	$tree = [ bladePatternRef( $pattern->id ) ];
+
+	$rendered = Blade::render( '<x-ve-blocks :tree="$tree" />', [ 'tree' => $tree ] );
+	$normalized = $this->normalizeHtml( $rendered );
+
+	expect( $normalized )->toContain( '<div class="wp-block-block"' );
+	expect( $normalized )->toContain( 'data-ve-pattern-ref="' . $pattern->id . '"' );
+	expect( $normalized )->toContain( '<p class="wp-block-paragraph">Hero copy</p>' );
+} );
+
+it( 'skips inlining when :resolve-patterns is false', function () {
+	$pattern = bladePatternFixture( 'hero', [ bladePatternParagraph( 'Hero copy' ) ] );
+
+	$tree = [ bladePatternRef( $pattern->id ) ];
+
+	$rendered = Blade::render(
+		'<x-ve-blocks :tree="$tree" :resolve-patterns="false" />',
+		[ 'tree' => $tree ]
+	);
+
+	expect( $this->normalizeHtml( $rendered ) )->not()->toContain( 'Hero copy' );
+} );
+
+it( 'renders an empty wrapper when the pattern is missing in production', function () {
+	$this->app['env'] = 'production';
+
+	$tree = [ bladePatternRef( 9999 ) ];
+
+	$rendered = Blade::render( '<x-ve-blocks :tree="$tree" />', [ 'tree' => $tree ] );
+	$normalized = $this->normalizeHtml( $rendered );
+
+	expect( $normalized )->toContain( 'wp-block-block' );
+	expect( $normalized )->not()->toContain( 'failed to resolve' );
+} );
+
+it( 'surfaces a comment warning when the pattern is missing in development', function () {
+	$this->app['env'] = 'local';
+
+	$tree = [ bladePatternRef( 9999 ) ];
+
+	$rendered = Blade::render( '<x-ve-blocks :tree="$tree" />', [ 'tree' => $tree ] );
+
+	expect( $rendered )->toContain( 'failed to resolve (not-found)' );
+} );
+
+it( 'flags a missing-ref marker when the ref attribute is absent', function () {
+	$this->app['env'] = 'local';
+
+	$tree = [
+		[
+			'clientId'    => 'pat-no-ref',
+			'name'        => 'core/block',
+			'attributes'  => [],
+			'innerBlocks' => [],
+		],
+	];
+
+	$rendered = Blade::render( '<x-ve-blocks :tree="$tree" />', [ 'tree' => $tree ] );
+
+	expect( $rendered )->toContain( 'failed to resolve (missing-ref)' );
+} );
+
+it( 'renders a cycle marker without infinite recursion', function () {
+	$this->app['env'] = 'local';
+
+	$patternA = bladePatternFixture( 'a', [] );
+	$patternB = bladePatternFixture( 'b', [] );
+
+	// Patch the pattern blocks now that we know the ids — pattern A
+	// references B and vice versa, which would loop forever without the
+	// cycle guard.
+	$patternA->setContentEnvelope( [
+		'raw'    => '',
+		'blocks' => [ bladePatternRef( $patternB->id, 'cycle-b' ) ],
+	] );
+	$patternA->save();
+
+	$patternB->setContentEnvelope( [
+		'raw'    => '',
+		'blocks' => [ bladePatternRef( $patternA->id, 'cycle-a' ) ],
+	] );
+	$patternB->save();
+
+	$tree = [ bladePatternRef( $patternA->id ) ];
+
+	$rendered = Blade::render( '<x-ve-blocks :tree="$tree" />', [ 'tree' => $tree ] );
+
+	expect( $rendered )->toContain( 'data-ve-pattern-ref="' . $patternA->id . '"' );
+	expect( $rendered )->toContain( 'data-ve-pattern-ref="' . $patternB->id . '"' );
+	expect( $rendered )->toContain( 'failed to resolve (cycle)' );
+} );
+
+it( 'unsynced patterns travel as inlined block trees, never as core/block references', function () {
+	// Sanity check on the synced/unsynced contract documented in
+	// `docs/plans/11-v1-expansion.md` §2.2 / §8: the editor only emits
+	// `core/block` references for synced patterns. Unsynced patterns are
+	// inlined into the saved tree at insert time (the editor calls
+	// Gutenberg's `parse()` on `pattern.content.raw` and pastes the
+	// resulting block list into the target — see
+	// `inserter-patterns-panel.tsx::patternBlocks`). The renderer never
+	// resolves an unsynced pattern at render time, so the tree it sees
+	// already carries the pattern's blocks directly.
+	$pattern = bladePatternFixture(
+		'hero-unsynced',
+		[ bladePatternParagraph( 'Unsynced copy' ) ],
+		false
+	);
+
+	expect( $pattern->synced )->toBeFalse();
+
+	// Simulate the post-insert state: the saved tree has the pattern's
+	// blocks inlined directly, with no `core/block` reference at all.
+	$treeAsSaved = $pattern->getBlocks();
+
+	$rendered = Blade::render( '<x-ve-blocks :tree="$tree" />', [ 'tree' => $treeAsSaved ] );
+
+	$normalized = $this->normalizeHtml( $rendered );
+
+	expect( $normalized )->toContain( 'Unsynced copy' );
+	expect( $normalized )->not()->toContain( 'wp-block-block' );
+	expect( $normalized )->not()->toContain( 'data-ve-pattern-ref' );
+} );

--- a/packages/visual-editor-renderer-react/src/BlockTree.tsx
+++ b/packages/visual-editor-renderer-react/src/BlockTree.tsx
@@ -23,6 +23,11 @@ import type { ReactElement, ReactNode } from 'react';
 import { DynamicBlock } from './DynamicBlock';
 import { GlobalStyles } from './GlobalStyles';
 import { UnknownBlock } from './blocks/unknownBlock';
+import {
+    DEFAULT_MAX_PATTERN_DEPTH,
+    inlinePatterns,
+} from './patterns';
+import type { PatternRecord } from './patterns';
 import { getBlockRenderer } from './registry';
 import {
     DEFAULT_MAX_TEMPLATE_PART_DEPTH,
@@ -38,8 +43,15 @@ export interface BlockTreeProps {
     dynamicBlockEndpoint?: string;
     fetchOptions?: RequestInit;
     templateParts?: TemplatePartRecord[];
+    /**
+     * Synced-pattern records keyed by id. When supplied, every
+     * `core/block` reference in the tree is replaced (pre-walk) with its
+     * referenced pattern's blocks via {@link inlinePatterns}.
+     */
+    patterns?: PatternRecord[];
     defaultTheme?: string;
     maxTemplatePartDepth?: number;
+    maxPatternDepth?: number;
     /**
      * Compiled global-styles CSS — same string the PHP
      * `GlobalStylesCssProvider` emits on Blade pages. When supplied,
@@ -54,8 +66,10 @@ export function BlockTree({
     dynamicBlockEndpoint = DEFAULT_ENDPOINT,
     fetchOptions,
     templateParts,
+    patterns,
     defaultTheme,
     maxTemplatePartDepth = DEFAULT_MAX_TEMPLATE_PART_DEPTH,
+    maxPatternDepth = DEFAULT_MAX_PATTERN_DEPTH,
     globalStylesCss,
 }: BlockTreeProps): ReactElement {
     const blocks = useMemo(() => {
@@ -66,16 +80,30 @@ export function BlockTree({
         // available," so any core/template-part references in the tree
         // should be flagged unresolved instead of silently rendering an
         // empty wrapper.
-        if (templateParts === undefined) {
-            return normalized;
+        const withParts =
+            templateParts === undefined
+                ? normalized
+                : inlineTemplateParts(normalized, {
+                      parts: templateParts,
+                      defaultTheme,
+                      maxDepth: maxTemplatePartDepth,
+                  });
+
+        // Same opt-in semantics as templateParts: an empty `patterns`
+        // array means "no synced patterns available," so any `core/block`
+        // references should resolve to an unresolved marker instead of
+        // falling through to the dynamic-block fallback. Pattern inlining
+        // runs after template-part inlining so a part that itself
+        // contains a synced-pattern reference resolves in the same pass.
+        if (patterns === undefined) {
+            return withParts;
         }
 
-        return inlineTemplateParts(normalized, {
-            parts: templateParts,
-            defaultTheme,
-            maxDepth: maxTemplatePartDepth,
+        return inlinePatterns(withParts, {
+            patterns,
+            maxDepth: maxPatternDepth,
         });
-    }, [tree, templateParts, defaultTheme, maxTemplatePartDepth]);
+    }, [tree, templateParts, patterns, defaultTheme, maxTemplatePartDepth, maxPatternDepth]);
 
     return (
         <>

--- a/packages/visual-editor-renderer-react/src/Template.tsx
+++ b/packages/visual-editor-renderer-react/src/Template.tsx
@@ -16,6 +16,8 @@ import { useMemo } from 'react';
 import type { ReactElement } from 'react';
 import { BlockTree } from './BlockTree';
 import { GlobalStyles } from './GlobalStyles';
+import { DEFAULT_MAX_PATTERN_DEPTH } from './patterns';
+import type { PatternRecord } from './patterns';
 import {
     DEFAULT_MAX_TEMPLATE_PART_DEPTH,
     resolveTemplate,
@@ -40,9 +42,11 @@ export interface TemplateProps {
     theme?: string;
     templates: TemplateRecord[];
     templateParts?: TemplatePartRecord[];
+    patterns?: PatternRecord[];
     dynamicBlockEndpoint?: string;
     fetchOptions?: RequestInit;
     maxTemplatePartDepth?: number;
+    maxPatternDepth?: number;
     /**
      * Compiled global-styles CSS — same string the PHP
      * `GlobalStylesCssProvider` emits on Blade pages. Hosts that mount
@@ -57,9 +61,11 @@ export function Template({
     theme,
     templates,
     templateParts = [],
+    patterns,
     dynamicBlockEndpoint,
     fetchOptions,
     maxTemplatePartDepth = DEFAULT_MAX_TEMPLATE_PART_DEPTH,
+    maxPatternDepth = DEFAULT_MAX_PATTERN_DEPTH,
     globalStylesCss,
 }: TemplateProps): ReactElement {
     const matched = useMemo(() => resolveTemplate(templates, slug, theme), [templates, slug, theme]);
@@ -100,10 +106,12 @@ export function Template({
                 <BlockTree
                     tree={matched.blocks}
                     templateParts={templateParts}
+                    patterns={patterns}
                     defaultTheme={theme ?? matched.theme}
                     dynamicBlockEndpoint={dynamicBlockEndpoint}
                     fetchOptions={fetchOptions}
                     maxTemplatePartDepth={maxTemplatePartDepth}
+                    maxPatternDepth={maxPatternDepth}
                 />
             </div>
         </>

--- a/packages/visual-editor-renderer-react/src/blocks/core/syncedPattern.tsx
+++ b/packages/visual-editor-renderer-react/src/blocks/core/syncedPattern.tsx
@@ -1,0 +1,67 @@
+/**
+ * `core/block` (synced-pattern reference) renderer.
+ *
+ * Operates on a tree where the synced-pattern reference already carries
+ * its resolved pattern's blocks under `innerBlocks` (see
+ * {@link inlinePatterns}). The renderer wraps the children in a
+ * `wp-block-block` div and stamps the pattern id onto a data attribute
+ * so client-side scripts can target the rendered region.
+ *
+ * If the inliner could not resolve the pattern, it stamps an
+ * `_resolutionError` attribute. In production this renderer emits an
+ * empty wrapper so the surrounding layout stays intact; in dev the
+ * wrapper carries a `data-ve-resolution-error` attribute the developer
+ * can spot in the inspector.
+ */
+
+import { attrString, classList } from '../../support/attributes';
+import type { BlockRendererProps } from '../../types';
+
+function isDevelopment(): boolean {
+    if (typeof process === 'undefined') {
+        return false;
+    }
+
+    const env = process.env?.NODE_ENV;
+
+    return env !== 'production';
+}
+
+function refString(value: unknown): string {
+    if (typeof value === 'number' && Number.isInteger(value)) {
+        return String(value);
+    }
+
+    if (typeof value === 'string') {
+        return value.trim();
+    }
+
+    return '';
+}
+
+export function SyncedPatternBlock({ attributes, children }: BlockRendererProps): JSX.Element {
+    const ref = refString(attributes.ref);
+    const resolutionError = attrString(attributes._resolutionError);
+    const className = attrString(attributes.className);
+    const classes = classList(['wp-block-block', className]);
+
+    const dataAttributes: Record<string, string> = {};
+
+    if (ref !== '') {
+        dataAttributes['data-ve-pattern-ref'] = ref;
+    }
+
+    if (resolutionError !== '' && isDevelopment()) {
+        dataAttributes['data-ve-resolution-error'] = resolutionError;
+    }
+
+    if (resolutionError !== '') {
+        return <div className={classes} {...dataAttributes} />;
+    }
+
+    return (
+        <div className={classes} {...dataAttributes}>
+            {children}
+        </div>
+    );
+}

--- a/packages/visual-editor-renderer-react/src/blocks/registerCoreBlocks.ts
+++ b/packages/visual-editor-renderer-react/src/blocks/registerCoreBlocks.ts
@@ -39,6 +39,7 @@ import {
     ImageBlock,
     VideoBlock,
 } from './core/media';
+import { SyncedPatternBlock } from './core/syncedPattern';
 import { TemplatePartBlock } from './core/templatePart';
 import {
     CodeBlock,
@@ -84,6 +85,7 @@ const CORE_BLOCKS: Record<string, BlockRenderer> = {
     'core/separator': SeparatorBlock,
     'core/spacer': SpacerBlock,
     'core/template-part': TemplatePartBlock,
+    'core/block': SyncedPatternBlock,
     'artisanpack/callout': CalloutBlock,
 };
 

--- a/packages/visual-editor-renderer-react/src/index.ts
+++ b/packages/visual-editor-renderer-react/src/index.ts
@@ -42,4 +42,13 @@ export type {
     TemplatePartResolutionError,
     TemplateRecord,
 } from './templateParts';
+export {
+    DEFAULT_MAX_PATTERN_DEPTH,
+    inlinePatterns,
+} from './patterns';
+export type {
+    InlinePatternsOptions,
+    PatternRecord,
+    PatternResolutionError,
+} from './patterns';
 export type { Block, BlockRenderer, BlockRendererProps } from './types';

--- a/packages/visual-editor-renderer-react/src/patterns.ts
+++ b/packages/visual-editor-renderer-react/src/patterns.ts
@@ -1,0 +1,165 @@
+/**
+ * Client-side synced-pattern resolution helpers.
+ *
+ * Mirrors the behaviour of the server-side
+ * `ArtisanPackUI\VisualEditor\Resources\PatternInliner` so the React
+ * renderer can produce the same inlined block tree without
+ * round-tripping to the server. Hosts pass a pre-fetched list of
+ * `patterns`; this module walks the tree and recursively splices each
+ * `core/block` reference's blocks into the output tree.
+ *
+ * Only synced patterns reach this resolver. Unsynced patterns are
+ * inlined into the target block tree at insert time by the editor and
+ * travel as plain block trees from that point on — they never appear in
+ * saved content as `core/block` references.
+ *
+ * Recursion guard: an in-flight stack of pattern-id keys catches cycles
+ * (pattern A → pattern B → pattern A) and a depth counter caps how deep
+ * the resolution chain can go (default 10). Either guard turns the
+ * offending block into a marker whose `attributes._resolutionError`
+ * records the reason — the registered `core/block` renderer translates
+ * that into a graceful empty render in production and a visible warning
+ * in dev.
+ */
+
+import type { Block } from './types';
+
+export const DEFAULT_MAX_PATTERN_DEPTH = 10;
+
+export type PatternResolutionError =
+    | 'missing-ref'
+    | 'not-found'
+    | 'cycle'
+    | 'depth-limit';
+
+export interface PatternRecord {
+    id: number;
+    blocks: Block[];
+}
+
+export interface InlinePatternsOptions {
+    patterns: PatternRecord[];
+    maxDepth?: number;
+}
+
+interface WalkContext {
+    patterns: PatternRecord[];
+    maxDepth: number;
+    stack: string[];
+    depth: number;
+}
+
+export function inlinePatterns(tree: Block[], options: InlinePatternsOptions): Block[] {
+    const context: WalkContext = {
+        patterns: options.patterns,
+        maxDepth: options.maxDepth ?? DEFAULT_MAX_PATTERN_DEPTH,
+        stack: [],
+        depth: 0,
+    };
+
+    return walk(tree, context);
+}
+
+function walk(tree: Block[], context: WalkContext): Block[] {
+    const out: Block[] = [];
+
+    for (const block of tree) {
+        if (block === null || typeof block !== 'object' || Array.isArray(block)) {
+            continue;
+        }
+
+        const name = typeof block.name === 'string' ? block.name : '';
+
+        if (name === 'core/block') {
+            out.push(resolvePattern(block, context));
+
+            continue;
+        }
+
+        const inner = Array.isArray(block.innerBlocks) ? block.innerBlocks : [];
+
+        out.push({
+            ...block,
+            innerBlocks: walk(inner, context),
+        });
+    }
+
+    return out;
+}
+
+function resolvePattern(block: Block, context: WalkContext): Block {
+    const attrs = block.attributes ?? {};
+    const ref = normalizeRef(attrs.ref);
+
+    if (ref === null) {
+        return markUnresolved(block, 'missing-ref');
+    }
+
+    if (context.depth >= context.maxDepth) {
+        return markUnresolved(block, 'depth-limit');
+    }
+
+    const key = String(ref);
+
+    if (context.stack.includes(key)) {
+        return markUnresolved(block, 'cycle');
+    }
+
+    const pattern = findPattern(context.patterns, ref);
+
+    if (pattern === undefined) {
+        return markUnresolved(block, 'not-found');
+    }
+
+    const childContext: WalkContext = {
+        ...context,
+        stack: [...context.stack, key],
+        depth: context.depth + 1,
+    };
+
+    return {
+        clientId: block.clientId,
+        name: 'core/block',
+        attributes: {
+            ...attrs,
+            ref,
+        },
+        innerBlocks: walk(Array.isArray(pattern.blocks) ? pattern.blocks : [], childContext),
+    };
+}
+
+function findPattern(patterns: PatternRecord[], ref: number): PatternRecord | undefined {
+    return patterns.find((pattern) => pattern.id === ref);
+}
+
+function normalizeRef(value: unknown): number | null {
+    if (typeof value === 'number') {
+        return Number.isInteger(value) && value > 0 ? value : null;
+    }
+
+    if (typeof value === 'string') {
+        const trimmed = value.trim();
+
+        if (trimmed === '' || !/^\d+$/.test(trimmed)) {
+            return null;
+        }
+
+        const parsed = Number.parseInt(trimmed, 10);
+
+        return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
+    }
+
+    return null;
+}
+
+function markUnresolved(block: Block, reason: PatternResolutionError): Block {
+    return {
+        clientId: block.clientId,
+        name: 'core/block',
+        attributes: {
+            ...(block.attributes ?? {}),
+            _resolutionError: reason,
+        },
+        innerBlocks: [],
+    };
+}

--- a/packages/visual-editor-renderer-react/tests/patterns.test.ts
+++ b/packages/visual-editor-renderer-react/tests/patterns.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    DEFAULT_MAX_PATTERN_DEPTH,
+    inlinePatterns,
+} from '../src/patterns';
+import type { PatternRecord } from '../src/patterns';
+import type { Block } from '../src/types';
+
+function paragraph(text: string, clientId = 'p-cid'): Block {
+    return {
+        clientId,
+        name: 'core/paragraph',
+        attributes: { content: text },
+        innerBlocks: [],
+    };
+}
+
+function patternRef(ref: number, clientId = 'pat-cid'): Block {
+    return {
+        clientId,
+        name: 'core/block',
+        attributes: { ref },
+        innerBlocks: [],
+    };
+}
+
+describe('inlinePatterns', () => {
+    it('inlines a referenced synced pattern', () => {
+        const patterns: PatternRecord[] = [{ id: 1, blocks: [paragraph('Hero')] }];
+        const tree = [patternRef(1)];
+
+        const inlined = inlinePatterns(tree, { patterns });
+
+        expect(inlined[0].name).toBe('core/block');
+        expect(inlined[0].innerBlocks?.[0].attributes?.content).toBe('Hero');
+    });
+
+    it('marks missing references with the not-found error', () => {
+        const tree = [patternRef(9999)];
+
+        const inlined = inlinePatterns(tree, { patterns: [] });
+
+        expect(inlined[0].attributes?._resolutionError).toBe('not-found');
+        expect(inlined[0].innerBlocks).toEqual([]);
+    });
+
+    it('marks missing ref with the missing-ref error', () => {
+        const tree: Block[] = [
+            { clientId: 'pat', name: 'core/block', attributes: {}, innerBlocks: [] },
+        ];
+
+        const inlined = inlinePatterns(tree, { patterns: [] });
+
+        expect(inlined[0].attributes?._resolutionError).toBe('missing-ref');
+    });
+
+    it('rejects non-numeric ref values with the missing-ref error', () => {
+        const tree: Block[] = [
+            { clientId: 'pat', name: 'core/block', attributes: { ref: 'not-a-number' }, innerBlocks: [] },
+        ];
+
+        const inlined = inlinePatterns(tree, { patterns: [] });
+
+        expect(inlined[0].attributes?._resolutionError).toBe('missing-ref');
+    });
+
+    it('normalizes numeric-string refs', () => {
+        const patterns: PatternRecord[] = [{ id: 7, blocks: [paragraph('Resolved')] }];
+        const tree: Block[] = [
+            { clientId: 'pat', name: 'core/block', attributes: { ref: '7' }, innerBlocks: [] },
+        ];
+
+        const inlined = inlinePatterns(tree, { patterns });
+
+        expect(inlined[0].attributes?._resolutionError).toBeUndefined();
+        expect(inlined[0].innerBlocks?.[0].attributes?.content).toBe('Resolved');
+    });
+
+    it('detects direct cycles (a → a)', () => {
+        const patterns: PatternRecord[] = [{ id: 1, blocks: [patternRef(1, 'self-ref')] }];
+        const tree = [patternRef(1, 'root')];
+
+        const inlined = inlinePatterns(tree, { patterns });
+
+        expect(inlined[0].innerBlocks?.[0].attributes?._resolutionError).toBe('cycle');
+    });
+
+    it('detects indirect cycles (a → b → a)', () => {
+        const patterns: PatternRecord[] = [
+            { id: 1, blocks: [patternRef(2, 'b-ref')] },
+            { id: 2, blocks: [patternRef(1, 'a-ref')] },
+        ];
+        const tree = [patternRef(1, 'a-root')];
+
+        const inlined = inlinePatterns(tree, { patterns });
+
+        const cycleNode = inlined[0].innerBlocks?.[0].innerBlocks?.[0];
+
+        expect(cycleNode?.attributes?._resolutionError).toBe('cycle');
+    });
+
+    it('enforces the depth limit', () => {
+        const patterns: PatternRecord[] = [
+            { id: 1, blocks: [patternRef(2, 'p2-ref')] },
+            { id: 2, blocks: [patternRef(3, 'p3-ref')] },
+            { id: 3, blocks: [patternRef(4, 'p4-ref')] },
+            { id: 4, blocks: [paragraph('end')] },
+        ];
+
+        const inlined = inlinePatterns([patternRef(1, 'p1-root')], { patterns, maxDepth: 2 });
+
+        // pattern 1 (depth 0) and pattern 2 (depth 1) resolve; pattern 3
+        // (depth 2) hits the cap.
+        const third = inlined[0].innerBlocks?.[0].innerBlocks?.[0];
+
+        expect(third?.attributes?._resolutionError).toBe('depth-limit');
+    });
+
+    it('preserves non-core/block blocks', () => {
+        const tree = [paragraph('only')];
+
+        expect(inlinePatterns(tree, { patterns: [] })).toEqual(tree);
+    });
+
+    it('descends into nested innerBlocks looking for synced patterns', () => {
+        const patterns: PatternRecord[] = [{ id: 5, blocks: [paragraph('Inside group')] }];
+        const tree = [
+            { clientId: 'g', name: 'core/group', attributes: {}, innerBlocks: [patternRef(5)] },
+        ];
+
+        const inlined = inlinePatterns(tree, { patterns });
+
+        expect(inlined[0].innerBlocks?.[0].innerBlocks?.[0].attributes?.content).toBe('Inside group');
+    });
+
+    it('exposes a default depth limit', () => {
+        expect(DEFAULT_MAX_PATTERN_DEPTH).toBe(10);
+    });
+
+    it('does not touch unsynced-style trees (block tree without core/block references)', () => {
+        // Sanity check on the synced/unsynced contract: unsynced patterns
+        // are inlined into the saved tree at insert time by the editor,
+        // so the inliner only ever sees `core/block` references for
+        // synced patterns. A tree composed of inlined unsynced-pattern
+        // blocks passes through untouched.
+        const tree = [paragraph('Inlined at insert time')];
+
+        expect(inlinePatterns(tree, { patterns: [] })).toEqual(tree);
+    });
+});

--- a/packages/visual-editor-renderer-react/tests/syncedPatternRendering.test.tsx
+++ b/packages/visual-editor-renderer-react/tests/syncedPatternRendering.test.tsx
@@ -1,0 +1,119 @@
+import { render } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import '../src/index';
+import { BlockTree } from '../src/BlockTree';
+import { Template } from '../src/Template';
+import { registerCoreBlocks } from '../src/blocks/registerCoreBlocks';
+import type { PatternRecord } from '../src/patterns';
+import { resetBlockRegistry } from '../src/registry';
+import type { TemplateRecord } from '../src/templateParts';
+import type { Block } from '../src/types';
+import { makeBlock, normalizeHtml } from './helpers';
+
+function paragraph(text: string, clientId = 'p-cid'): Block {
+    return makeBlock('core/paragraph', { content: text }, [], clientId);
+}
+
+function patternRef(ref: number, clientId = 'pat-cid'): Block {
+    return makeBlock('core/block', { ref }, [], clientId);
+}
+
+afterEach(() => {
+    resetBlockRegistry();
+    registerCoreBlocks();
+});
+
+describe('BlockTree synced-pattern inlining', () => {
+    it('renders a referenced pattern wrapped in a wp-block-block element', () => {
+        const patterns: PatternRecord[] = [
+            { id: 1, blocks: [paragraph('Hero copy', 'h-1')] },
+        ];
+        const tree = [patternRef(1)];
+
+        const { container } = render(<BlockTree tree={tree} patterns={patterns} />);
+        const html = normalizeHtml(container.innerHTML);
+
+        expect(html).toContain('<div class="wp-block-block"');
+        expect(html).toContain('data-ve-pattern-ref="1"');
+        expect(html).toContain('<p class="wp-block-paragraph">Hero copy</p>');
+    });
+
+    it('wraps a missing reference as an empty element with no children', () => {
+        const tree = [patternRef(9999)];
+
+        const { container } = render(<BlockTree tree={tree} patterns={[]} />);
+
+        const wrapper = container.querySelector('.wp-block-block');
+
+        expect(wrapper).not.toBeNull();
+        expect(wrapper?.children.length).toBe(0);
+    });
+
+    it('does not run the inliner when no patterns prop is supplied', () => {
+        const tree = [patternRef(1)];
+
+        const { container } = render(<BlockTree tree={tree} />);
+
+        // The synced-pattern block still renders; just empty (no inlined children).
+        const wrapper = container.querySelector('.wp-block-block');
+
+        expect(wrapper).not.toBeNull();
+        expect(wrapper?.children.length).toBe(0);
+    });
+
+    it('runs the inliner for an explicit empty patterns array so missing references are flagged', () => {
+        const tree = [patternRef(1)];
+
+        const { container } = render(<BlockTree tree={tree} patterns={[]} />);
+        const wrapper = container.querySelector('.wp-block-block');
+
+        expect(wrapper?.getAttribute('data-ve-resolution-error')).toBe('not-found');
+    });
+
+    it('detects cycles inside the inlined tree', () => {
+        const patterns: PatternRecord[] = [
+            { id: 1, blocks: [patternRef(2, 'b-ref')] },
+            { id: 2, blocks: [patternRef(1, 'a-ref')] },
+        ];
+        const tree = [patternRef(1, 'a-root')];
+
+        const { container } = render(<BlockTree tree={tree} patterns={patterns} />);
+
+        // Three nested wp-block-block wrappers (root → b → cycle marker on a).
+        const wrappers = container.querySelectorAll('.wp-block-block');
+
+        expect(wrappers.length).toBeGreaterThanOrEqual(3);
+        expect(container.querySelector('[data-ve-resolution-error="cycle"]')).not.toBeNull();
+    });
+});
+
+describe('Template component synced-pattern inlining', () => {
+    it('forwards the patterns prop to the inner BlockTree', () => {
+        const templates: TemplateRecord[] = [
+            {
+                slug: 'page-about',
+                theme: 'artisanpack-base',
+                blocks: [patternRef(1), paragraph('Body', 'b-1')],
+            },
+        ];
+        const patterns: PatternRecord[] = [
+            { id: 1, blocks: [paragraph('Hero', 'h-1')] },
+        ];
+
+        const { container } = render(
+            <Template
+                slug="page-about"
+                theme="artisanpack-base"
+                templates={templates}
+                templateParts={[]}
+                patterns={patterns}
+            />
+        );
+        const html = normalizeHtml(container.innerHTML);
+
+        expect(html).toContain('data-ve-pattern-ref="1"');
+        expect(html).toContain('<p class="wp-block-paragraph">Hero</p>');
+        expect(html).toContain('<p class="wp-block-paragraph">Body</p>');
+    });
+});

--- a/packages/visual-editor-renderer-vue/src/BlockTree.ts
+++ b/packages/visual-editor-renderer-vue/src/BlockTree.ts
@@ -23,6 +23,11 @@ import type { PropType, VNode } from 'vue';
 import { DynamicBlock } from './DynamicBlock';
 import { GlobalStyles } from './GlobalStyles';
 import { UnknownBlock } from './blocks/unknownBlock';
+import {
+    DEFAULT_MAX_PATTERN_DEPTH,
+    inlinePatterns,
+} from './patterns';
+import type { PatternRecord } from './patterns';
 import { getBlockRenderer } from './registry';
 import {
     DEFAULT_MAX_TEMPLATE_PART_DEPTH,
@@ -38,8 +43,15 @@ export interface BlockTreeProps {
     dynamicBlockEndpoint?: string;
     fetchOptions?: RequestInit;
     templateParts?: TemplatePartRecord[];
+    /**
+     * Synced-pattern records keyed by id. When supplied, every
+     * `core/block` reference in the tree is replaced (pre-walk) with its
+     * referenced pattern's blocks via {@link inlinePatterns}.
+     */
+    patterns?: PatternRecord[];
     defaultTheme?: string;
     maxTemplatePartDepth?: number;
+    maxPatternDepth?: number;
     /**
      * Compiled global-styles CSS — same string the PHP
      * `GlobalStylesCssProvider` emits on Blade pages. When supplied,
@@ -68,6 +80,10 @@ export const BlockTree = defineComponent({
             type: Array as PropType<TemplatePartRecord[]>,
             default: undefined,
         },
+        patterns: {
+            type: Array as PropType<PatternRecord[]>,
+            default: undefined,
+        },
         defaultTheme: {
             type: String,
             default: undefined,
@@ -75,6 +91,10 @@ export const BlockTree = defineComponent({
         maxTemplatePartDepth: {
             type: Number,
             default: DEFAULT_MAX_TEMPLATE_PART_DEPTH,
+        },
+        maxPatternDepth: {
+            type: Number,
+            default: DEFAULT_MAX_PATTERN_DEPTH,
         },
         globalStylesCss: {
             type: String as PropType<string | null | undefined>,
@@ -90,14 +110,29 @@ export const BlockTree = defineComponent({
             // "no parts available," so any core/template-part references
             // in the tree should be flagged unresolved instead of
             // silently rendering an empty wrapper.
-            if (props.templateParts === undefined) {
-                return normalized;
+            const withParts =
+                props.templateParts === undefined
+                    ? normalized
+                    : inlineTemplateParts(normalized, {
+                          parts: props.templateParts,
+                          defaultTheme: props.defaultTheme,
+                          maxDepth: props.maxTemplatePartDepth,
+                      });
+
+            // Same opt-in semantics as templateParts: an empty `patterns`
+            // array means "no synced patterns available," so any
+            // `core/block` references resolve to an unresolved marker
+            // instead of falling through to the dynamic-block fallback.
+            // Pattern inlining runs after template-part inlining so a
+            // part that itself contains a synced-pattern reference
+            // resolves in the same pass.
+            if (props.patterns === undefined) {
+                return withParts;
             }
 
-            return inlineTemplateParts(normalized, {
-                parts: props.templateParts,
-                defaultTheme: props.defaultTheme,
-                maxDepth: props.maxTemplatePartDepth,
+            return inlinePatterns(withParts, {
+                patterns: props.patterns,
+                maxDepth: props.maxPatternDepth,
             });
         });
 

--- a/packages/visual-editor-renderer-vue/src/Template.ts
+++ b/packages/visual-editor-renderer-vue/src/Template.ts
@@ -16,6 +16,8 @@ import { Fragment, computed, defineComponent, h } from 'vue';
 import type { PropType } from 'vue';
 import { BlockTree } from './BlockTree';
 import { GlobalStyles } from './GlobalStyles';
+import { DEFAULT_MAX_PATTERN_DEPTH } from './patterns';
+import type { PatternRecord } from './patterns';
 import {
     DEFAULT_MAX_TEMPLATE_PART_DEPTH,
     resolveTemplate,
@@ -40,9 +42,11 @@ export interface TemplateProps {
     theme?: string;
     templates: TemplateRecord[];
     templateParts?: TemplatePartRecord[];
+    patterns?: PatternRecord[];
     dynamicBlockEndpoint?: string;
     fetchOptions?: RequestInit;
     maxTemplatePartDepth?: number;
+    maxPatternDepth?: number;
     /**
      * Compiled global-styles CSS — same string the PHP
      * `GlobalStylesCssProvider` emits on Blade pages. Hosts that mount
@@ -71,6 +75,10 @@ export const Template = defineComponent({
             type: Array as PropType<TemplatePartRecord[]>,
             default: () => [],
         },
+        patterns: {
+            type: Array as PropType<PatternRecord[]>,
+            default: undefined,
+        },
         dynamicBlockEndpoint: {
             type: String,
             default: undefined,
@@ -82,6 +90,10 @@ export const Template = defineComponent({
         maxTemplatePartDepth: {
             type: Number,
             default: DEFAULT_MAX_TEMPLATE_PART_DEPTH,
+        },
+        maxPatternDepth: {
+            type: Number,
+            default: DEFAULT_MAX_PATTERN_DEPTH,
         },
         globalStylesCss: {
             type: String as PropType<string | null | undefined>,
@@ -127,10 +139,12 @@ export const Template = defineComponent({
                     h(BlockTree, {
                         tree: matched.value.blocks,
                         templateParts: props.templateParts,
+                        patterns: props.patterns,
                         defaultTheme: props.theme ?? matched.value.theme,
                         dynamicBlockEndpoint: props.dynamicBlockEndpoint,
                         fetchOptions: props.fetchOptions,
                         maxTemplatePartDepth: props.maxTemplatePartDepth,
+                        maxPatternDepth: props.maxPatternDepth,
                     }),
                 ]),
             ]);

--- a/packages/visual-editor-renderer-vue/src/blocks/core/syncedPattern.ts
+++ b/packages/visual-editor-renderer-vue/src/blocks/core/syncedPattern.ts
@@ -1,0 +1,70 @@
+/**
+ * `core/block` (synced-pattern reference) renderer.
+ *
+ * Operates on a tree where the synced-pattern reference already carries
+ * its resolved pattern's blocks under `innerBlocks` (see
+ * {@link inlinePatterns}). The renderer wraps the children in a
+ * `wp-block-block` div and stamps the pattern id onto a data attribute
+ * so client-side scripts can target the rendered region.
+ *
+ * If the inliner could not resolve the pattern, it stamps an
+ * `_resolutionError` attribute. In production this renderer emits an
+ * empty wrapper so the surrounding layout stays intact; in dev the
+ * wrapper carries a `data-ve-resolution-error` attribute the developer
+ * can spot in the inspector.
+ */
+
+import { defineComponent, h } from 'vue';
+import { attrString, classList } from '../../support/attributes';
+import { blockRendererProps } from '../shared';
+
+function isDevelopment(): boolean {
+    if (typeof process === 'undefined') {
+        return false;
+    }
+
+    const env = process.env?.NODE_ENV;
+
+    return env !== 'production';
+}
+
+function refString(value: unknown): string {
+    if (typeof value === 'number' && Number.isInteger(value)) {
+        return String(value);
+    }
+
+    if (typeof value === 'string') {
+        return value.trim();
+    }
+
+    return '';
+}
+
+export const SyncedPatternBlock = defineComponent({
+    name: 'SyncedPatternBlock',
+    props: blockRendererProps,
+    setup(props, { slots }) {
+        return () => {
+            const ref = refString(props.attributes.ref);
+            const resolutionError = attrString(props.attributes._resolutionError);
+            const className = attrString(props.attributes.className);
+            const classes = classList(['wp-block-block', className]);
+
+            const elementProps: Record<string, string> = {
+                class: classes,
+            };
+
+            if (ref !== '') {
+                elementProps['data-ve-pattern-ref'] = ref;
+            }
+
+            if (resolutionError !== '' && isDevelopment()) {
+                elementProps['data-ve-resolution-error'] = resolutionError;
+            }
+
+            const children = resolutionError !== '' ? [] : slots.default ? slots.default() : [];
+
+            return h('div', elementProps, children);
+        };
+    },
+});

--- a/packages/visual-editor-renderer-vue/src/blocks/registerCoreBlocks.ts
+++ b/packages/visual-editor-renderer-vue/src/blocks/registerCoreBlocks.ts
@@ -39,6 +39,7 @@ import {
     ImageBlock,
     VideoBlock,
 } from './core/media';
+import { SyncedPatternBlock } from './core/syncedPattern';
 import { TemplatePartBlock } from './core/templatePart';
 import {
     CodeBlock,
@@ -84,6 +85,7 @@ const CORE_BLOCKS: Record<string, BlockRenderer> = {
     'core/separator': SeparatorBlock,
     'core/spacer': SpacerBlock,
     'core/template-part': TemplatePartBlock,
+    'core/block': SyncedPatternBlock,
     'artisanpack/callout': CalloutBlock,
 };
 

--- a/packages/visual-editor-renderer-vue/src/index.ts
+++ b/packages/visual-editor-renderer-vue/src/index.ts
@@ -42,4 +42,13 @@ export type {
     TemplatePartResolutionError,
     TemplateRecord,
 } from './templateParts';
+export {
+    DEFAULT_MAX_PATTERN_DEPTH,
+    inlinePatterns,
+} from './patterns';
+export type {
+    InlinePatternsOptions,
+    PatternRecord,
+    PatternResolutionError,
+} from './patterns';
 export type { Block, BlockRenderer, BlockRendererProps } from './types';

--- a/packages/visual-editor-renderer-vue/src/patterns.ts
+++ b/packages/visual-editor-renderer-vue/src/patterns.ts
@@ -1,0 +1,165 @@
+/**
+ * Client-side synced-pattern resolution helpers.
+ *
+ * Mirrors the behaviour of the server-side
+ * `ArtisanPackUI\VisualEditor\Resources\PatternInliner` so the Vue
+ * renderer can produce the same inlined block tree without
+ * round-tripping to the server. Hosts pass a pre-fetched list of
+ * `patterns`; this module walks the tree and recursively splices each
+ * `core/block` reference's blocks into the output tree.
+ *
+ * Only synced patterns reach this resolver. Unsynced patterns are
+ * inlined into the target block tree at insert time by the editor and
+ * travel as plain block trees from that point on — they never appear in
+ * saved content as `core/block` references.
+ *
+ * Recursion guard: an in-flight stack of pattern-id keys catches cycles
+ * (pattern A → pattern B → pattern A) and a depth counter caps how deep
+ * the resolution chain can go (default 10). Either guard turns the
+ * offending block into a marker whose `attributes._resolutionError`
+ * records the reason — the registered `core/block` renderer translates
+ * that into a graceful empty render in production and a visible warning
+ * in dev.
+ */
+
+import type { Block } from './types';
+
+export const DEFAULT_MAX_PATTERN_DEPTH = 10;
+
+export type PatternResolutionError =
+    | 'missing-ref'
+    | 'not-found'
+    | 'cycle'
+    | 'depth-limit';
+
+export interface PatternRecord {
+    id: number;
+    blocks: Block[];
+}
+
+export interface InlinePatternsOptions {
+    patterns: PatternRecord[];
+    maxDepth?: number;
+}
+
+interface WalkContext {
+    patterns: PatternRecord[];
+    maxDepth: number;
+    stack: string[];
+    depth: number;
+}
+
+export function inlinePatterns(tree: Block[], options: InlinePatternsOptions): Block[] {
+    const context: WalkContext = {
+        patterns: options.patterns,
+        maxDepth: options.maxDepth ?? DEFAULT_MAX_PATTERN_DEPTH,
+        stack: [],
+        depth: 0,
+    };
+
+    return walk(tree, context);
+}
+
+function walk(tree: Block[], context: WalkContext): Block[] {
+    const out: Block[] = [];
+
+    for (const block of tree) {
+        if (block === null || typeof block !== 'object' || Array.isArray(block)) {
+            continue;
+        }
+
+        const name = typeof block.name === 'string' ? block.name : '';
+
+        if (name === 'core/block') {
+            out.push(resolvePattern(block, context));
+
+            continue;
+        }
+
+        const inner = Array.isArray(block.innerBlocks) ? block.innerBlocks : [];
+
+        out.push({
+            ...block,
+            innerBlocks: walk(inner, context),
+        });
+    }
+
+    return out;
+}
+
+function resolvePattern(block: Block, context: WalkContext): Block {
+    const attrs = block.attributes ?? {};
+    const ref = normalizeRef(attrs.ref);
+
+    if (ref === null) {
+        return markUnresolved(block, 'missing-ref');
+    }
+
+    if (context.depth >= context.maxDepth) {
+        return markUnresolved(block, 'depth-limit');
+    }
+
+    const key = String(ref);
+
+    if (context.stack.includes(key)) {
+        return markUnresolved(block, 'cycle');
+    }
+
+    const pattern = findPattern(context.patterns, ref);
+
+    if (pattern === undefined) {
+        return markUnresolved(block, 'not-found');
+    }
+
+    const childContext: WalkContext = {
+        ...context,
+        stack: [...context.stack, key],
+        depth: context.depth + 1,
+    };
+
+    return {
+        clientId: block.clientId,
+        name: 'core/block',
+        attributes: {
+            ...attrs,
+            ref,
+        },
+        innerBlocks: walk(Array.isArray(pattern.blocks) ? pattern.blocks : [], childContext),
+    };
+}
+
+function findPattern(patterns: PatternRecord[], ref: number): PatternRecord | undefined {
+    return patterns.find((pattern) => pattern.id === ref);
+}
+
+function normalizeRef(value: unknown): number | null {
+    if (typeof value === 'number') {
+        return Number.isInteger(value) && value > 0 ? value : null;
+    }
+
+    if (typeof value === 'string') {
+        const trimmed = value.trim();
+
+        if (trimmed === '' || !/^\d+$/.test(trimmed)) {
+            return null;
+        }
+
+        const parsed = Number.parseInt(trimmed, 10);
+
+        return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
+    }
+
+    return null;
+}
+
+function markUnresolved(block: Block, reason: PatternResolutionError): Block {
+    return {
+        clientId: block.clientId,
+        name: 'core/block',
+        attributes: {
+            ...(block.attributes ?? {}),
+            _resolutionError: reason,
+        },
+        innerBlocks: [],
+    };
+}

--- a/packages/visual-editor-renderer-vue/tests/patterns.test.ts
+++ b/packages/visual-editor-renderer-vue/tests/patterns.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    DEFAULT_MAX_PATTERN_DEPTH,
+    inlinePatterns,
+} from '../src/patterns';
+import type { PatternRecord } from '../src/patterns';
+import type { Block } from '../src/types';
+
+function paragraph(text: string, clientId = 'p-cid'): Block {
+    return {
+        clientId,
+        name: 'core/paragraph',
+        attributes: { content: text },
+        innerBlocks: [],
+    };
+}
+
+function patternRef(ref: number, clientId = 'pat-cid'): Block {
+    return {
+        clientId,
+        name: 'core/block',
+        attributes: { ref },
+        innerBlocks: [],
+    };
+}
+
+describe('inlinePatterns', () => {
+    it('inlines a referenced synced pattern', () => {
+        const patterns: PatternRecord[] = [{ id: 1, blocks: [paragraph('Hero')] }];
+        const tree = [patternRef(1)];
+
+        const inlined = inlinePatterns(tree, { patterns });
+
+        expect(inlined[0].name).toBe('core/block');
+        expect(inlined[0].innerBlocks?.[0].attributes?.content).toBe('Hero');
+    });
+
+    it('marks missing references with the not-found error', () => {
+        const tree = [patternRef(9999)];
+
+        const inlined = inlinePatterns(tree, { patterns: [] });
+
+        expect(inlined[0].attributes?._resolutionError).toBe('not-found');
+        expect(inlined[0].innerBlocks).toEqual([]);
+    });
+
+    it('marks missing ref with the missing-ref error', () => {
+        const tree: Block[] = [
+            { clientId: 'pat', name: 'core/block', attributes: {}, innerBlocks: [] },
+        ];
+
+        const inlined = inlinePatterns(tree, { patterns: [] });
+
+        expect(inlined[0].attributes?._resolutionError).toBe('missing-ref');
+    });
+
+    it('rejects non-numeric ref values with the missing-ref error', () => {
+        const tree: Block[] = [
+            { clientId: 'pat', name: 'core/block', attributes: { ref: 'not-a-number' }, innerBlocks: [] },
+        ];
+
+        const inlined = inlinePatterns(tree, { patterns: [] });
+
+        expect(inlined[0].attributes?._resolutionError).toBe('missing-ref');
+    });
+
+    it('normalizes numeric-string refs', () => {
+        const patterns: PatternRecord[] = [{ id: 7, blocks: [paragraph('Resolved')] }];
+        const tree: Block[] = [
+            { clientId: 'pat', name: 'core/block', attributes: { ref: '7' }, innerBlocks: [] },
+        ];
+
+        const inlined = inlinePatterns(tree, { patterns });
+
+        expect(inlined[0].attributes?._resolutionError).toBeUndefined();
+        expect(inlined[0].innerBlocks?.[0].attributes?.content).toBe('Resolved');
+    });
+
+    it('detects direct cycles (a → a)', () => {
+        const patterns: PatternRecord[] = [{ id: 1, blocks: [patternRef(1, 'self-ref')] }];
+        const tree = [patternRef(1, 'root')];
+
+        const inlined = inlinePatterns(tree, { patterns });
+
+        expect(inlined[0].innerBlocks?.[0].attributes?._resolutionError).toBe('cycle');
+    });
+
+    it('detects indirect cycles (a → b → a)', () => {
+        const patterns: PatternRecord[] = [
+            { id: 1, blocks: [patternRef(2, 'b-ref')] },
+            { id: 2, blocks: [patternRef(1, 'a-ref')] },
+        ];
+        const tree = [patternRef(1, 'a-root')];
+
+        const inlined = inlinePatterns(tree, { patterns });
+
+        const cycleNode = inlined[0].innerBlocks?.[0].innerBlocks?.[0];
+
+        expect(cycleNode?.attributes?._resolutionError).toBe('cycle');
+    });
+
+    it('enforces the depth limit', () => {
+        const patterns: PatternRecord[] = [
+            { id: 1, blocks: [patternRef(2, 'p2-ref')] },
+            { id: 2, blocks: [patternRef(3, 'p3-ref')] },
+            { id: 3, blocks: [patternRef(4, 'p4-ref')] },
+            { id: 4, blocks: [paragraph('end')] },
+        ];
+
+        const inlined = inlinePatterns([patternRef(1, 'p1-root')], { patterns, maxDepth: 2 });
+
+        // pattern 1 (depth 0) and pattern 2 (depth 1) resolve; pattern 3
+        // (depth 2) hits the cap.
+        const third = inlined[0].innerBlocks?.[0].innerBlocks?.[0];
+
+        expect(third?.attributes?._resolutionError).toBe('depth-limit');
+    });
+
+    it('preserves non-core/block blocks', () => {
+        const tree = [paragraph('only')];
+
+        expect(inlinePatterns(tree, { patterns: [] })).toEqual(tree);
+    });
+
+    it('descends into nested innerBlocks looking for synced patterns', () => {
+        const patterns: PatternRecord[] = [{ id: 5, blocks: [paragraph('Inside group')] }];
+        const tree = [
+            { clientId: 'g', name: 'core/group', attributes: {}, innerBlocks: [patternRef(5)] },
+        ];
+
+        const inlined = inlinePatterns(tree, { patterns });
+
+        expect(inlined[0].innerBlocks?.[0].innerBlocks?.[0].attributes?.content).toBe('Inside group');
+    });
+
+    it('exposes a default depth limit', () => {
+        expect(DEFAULT_MAX_PATTERN_DEPTH).toBe(10);
+    });
+
+    it('does not touch unsynced-style trees (block tree without core/block references)', () => {
+        // Sanity check on the synced/unsynced contract: unsynced patterns
+        // are inlined into the saved tree at insert time by the editor,
+        // so the inliner only ever sees `core/block` references for
+        // synced patterns.
+        const tree = [paragraph('Inlined at insert time')];
+
+        expect(inlinePatterns(tree, { patterns: [] })).toEqual(tree);
+    });
+});

--- a/packages/visual-editor-renderer-vue/tests/syncedPatternRendering.test.ts
+++ b/packages/visual-editor-renderer-vue/tests/syncedPatternRendering.test.ts
@@ -1,0 +1,120 @@
+import { mount } from '@vue/test-utils';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import '../src/index';
+import { BlockTree } from '../src/BlockTree';
+import { Template } from '../src/Template';
+import { registerCoreBlocks } from '../src/blocks/registerCoreBlocks';
+import type { PatternRecord } from '../src/patterns';
+import { resetBlockRegistry } from '../src/registry';
+import type { TemplateRecord } from '../src/templateParts';
+import type { Block } from '../src/types';
+import { makeBlock, normalizeHtml } from './helpers';
+
+function paragraph(text: string, clientId = 'p-cid'): Block {
+    return makeBlock('core/paragraph', { content: text }, [], clientId);
+}
+
+function patternRef(ref: number, clientId = 'pat-cid'): Block {
+    return makeBlock('core/block', { ref }, [], clientId);
+}
+
+afterEach(() => {
+    resetBlockRegistry();
+    registerCoreBlocks();
+});
+
+describe('BlockTree synced-pattern inlining', () => {
+    it('renders a referenced pattern wrapped in a wp-block-block element', () => {
+        const patterns: PatternRecord[] = [
+            { id: 1, blocks: [paragraph('Hero copy', 'h-1')] },
+        ];
+
+        const wrapper = mount(BlockTree, {
+            props: { tree: [patternRef(1)], patterns },
+        });
+        const html = normalizeHtml(wrapper.html());
+
+        expect(html).toContain('<div class="wp-block-block"');
+        expect(html).toContain('data-ve-pattern-ref="1"');
+        expect(html).toContain('<p class="wp-block-paragraph">Hero copy</p>');
+    });
+
+    it('wraps a missing reference as an empty element with no children', () => {
+        const wrapper = mount(BlockTree, {
+            props: { tree: [patternRef(9999)], patterns: [] as PatternRecord[] },
+        });
+
+        const el = wrapper.find('.wp-block-block');
+
+        expect(el.exists()).toBe(true);
+        expect(el.element.children.length).toBe(0);
+    });
+
+    it('does not run the inliner when no patterns prop is supplied', () => {
+        const wrapper = mount(BlockTree, {
+            props: { tree: [patternRef(1)] },
+        });
+
+        const el = wrapper.find('.wp-block-block');
+
+        expect(el.exists()).toBe(true);
+        expect(el.element.children.length).toBe(0);
+    });
+
+    it('runs the inliner for an explicit empty patterns array so missing references are flagged', () => {
+        const wrapper = mount(BlockTree, {
+            props: { tree: [patternRef(1)], patterns: [] as PatternRecord[] },
+        });
+
+        const el = wrapper.find('.wp-block-block');
+
+        expect(el.attributes('data-ve-resolution-error')).toBe('not-found');
+    });
+
+    it('detects cycles inside the inlined tree', () => {
+        const patterns: PatternRecord[] = [
+            { id: 1, blocks: [patternRef(2, 'b-ref')] },
+            { id: 2, blocks: [patternRef(1, 'a-ref')] },
+        ];
+
+        const wrapper = mount(BlockTree, {
+            props: { tree: [patternRef(1, 'a-root')], patterns },
+        });
+
+        const wrappers = wrapper.findAll('.wp-block-block');
+
+        expect(wrappers.length).toBeGreaterThanOrEqual(3);
+        expect(wrapper.find('[data-ve-resolution-error="cycle"]').exists()).toBe(true);
+    });
+});
+
+describe('Template component synced-pattern inlining', () => {
+    it('forwards the patterns prop to the inner BlockTree', () => {
+        const templates: TemplateRecord[] = [
+            {
+                slug: 'page-about',
+                theme: 'artisanpack-base',
+                blocks: [patternRef(1), paragraph('Body', 'b-1')],
+            },
+        ];
+        const patterns: PatternRecord[] = [
+            { id: 1, blocks: [paragraph('Hero', 'h-1')] },
+        ];
+
+        const wrapper = mount(Template, {
+            props: {
+                slug: 'page-about',
+                theme: 'artisanpack-base',
+                templates,
+                templateParts: [],
+                patterns,
+            },
+        });
+        const html = normalizeHtml(wrapper.html());
+
+        expect(html).toContain('data-ve-pattern-ref="1"');
+        expect(html).toContain('<p class="wp-block-paragraph">Hero</p>');
+        expect(html).toContain('<p class="wp-block-paragraph">Body</p>');
+    });
+});

--- a/src/Resources/PatternInliner.php
+++ b/src/Resources/PatternInliner.php
@@ -1,0 +1,234 @@
+<?php
+
+/**
+ * PatternInliner service.
+ *
+ * Walks a saved Gutenberg block tree and replaces every `core/block`
+ * (synced-pattern reference) with the same block carrying its resolved
+ * pattern's blocks as `innerBlocks`. Front-end renderers (Blade, React,
+ * Vue) consume the post-inlining tree so a single recursive renderer
+ * pass produces the final HTML — there is no per-renderer pattern
+ * lookup.
+ *
+ * Only synced patterns reach this resolver. Unsynced patterns
+ * (`synced: false`) are inlined into the target block tree at insert
+ * time by the editor (see `inserter-patterns-panel.tsx::patternBlocks`
+ * and the `parse()` call there) and travel as plain block trees from
+ * that point on — they never appear in saved content as `core/block`
+ * references. See `docs/plans/11-v1-expansion.md` §2.2 and §8.
+ *
+ * Recursion guard: an in-flight stack of pattern-id keys catches cycles
+ * (pattern A → pattern B → pattern A) and a depth counter caps how deep
+ * the resolution chain can go (default 10). Either guard converts the
+ * offending block into a marker whose `attributes._resolutionError`
+ * records the reason — the renderers translate that into a graceful
+ * empty render in production and a visible warning in dev.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Resources;
+
+use ArtisanPackUI\VisualEditor\Models\VisualEditorPattern;
+
+class PatternInliner
+{
+	/**
+	 * Default cap on how many levels deep the synced-pattern chain can
+	 * resolve before the renderer renders the fallback marker. Real
+	 * sites rarely nest synced patterns more than two or three deep;
+	 * ten leaves generous headroom while still terminating before PHP
+	 * exhausts its stack.
+	 */
+	public const DEFAULT_MAX_DEPTH = 10;
+
+	public const ERROR_MISSING_REF = 'missing-ref';
+	public const ERROR_NOT_FOUND   = 'not-found';
+	public const ERROR_CYCLE       = 'cycle';
+	public const ERROR_DEPTH_LIMIT = 'depth-limit';
+
+	public function __construct(
+		protected int $maxDepth = self::DEFAULT_MAX_DEPTH
+	) {
+	}
+
+	/**
+	 * Walks `$tree` and returns a copy with every `core/block` reference
+	 * carrying its resolved pattern's blocks under `innerBlocks`.
+	 *
+	 * The returned shape matches the input — the same `clientId`, `name`,
+	 * and `attributes` keys are preserved so existing renderers can render
+	 * the inlined tree without special-casing patterns. Blocks the
+	 * inliner cannot resolve (missing ref, missing pattern, cycle, depth
+	 * overflow) keep the `core/block` name and gain a synthetic
+	 * `_resolutionError` attribute the renderers detect.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array<int, array<string, mixed>>  $tree  Parsed block tree.
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	public function inline( array $tree ): array
+	{
+		return $this->walk( $tree, [], 0 );
+	}
+
+	/**
+	 * Recursive walker shared by the public entry point and inner-block
+	 * descent. Keeps the cycle stack and depth counter on the stack frame
+	 * (rather than instance state) so concurrent calls into the same
+	 * inliner instance don't leak resolution context across trees.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array<int, array<string, mixed>>  $tree
+	 * @param  array<int, string>                $stack
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	protected function walk( array $tree, array $stack, int $depth ): array
+	{
+		$out = [];
+
+		foreach ( $tree as $block ) {
+			if ( ! is_array( $block ) ) {
+				continue;
+			}
+
+			$name = isset( $block['name'] ) && is_string( $block['name'] ) ? $block['name'] : '';
+
+			if ( 'core/block' === $name ) {
+				$out[] = $this->resolvePattern( $block, $stack, $depth );
+
+				continue;
+			}
+
+			$innerBlocks          = isset( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ? $block['innerBlocks'] : [];
+			$block['innerBlocks'] = $this->walk( $innerBlocks, $stack, $depth );
+			$out[]                = $block;
+		}
+
+		return $out;
+	}
+
+	/**
+	 * Looks the pattern up by ref and returns the block with the resolved
+	 * pattern's blocks attached as `innerBlocks`.
+	 *
+	 * Resolution failures (missing ref, missing record, cycle, depth
+	 * overflow) return the original block stamped with a
+	 * `_resolutionError` attribute so the renderer can react without
+	 * hard-failing the whole template.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array<string, mixed>  $block
+	 * @param  array<int, string>    $stack
+	 *
+	 * @return array<string, mixed>
+	 */
+	protected function resolvePattern( array $block, array $stack, int $depth ): array
+	{
+		$attributes = isset( $block['attributes'] ) && is_array( $block['attributes'] ) ? $block['attributes'] : [];
+		$ref        = $this->normalizeRef( $attributes['ref'] ?? null );
+
+		if ( null === $ref ) {
+			return $this->markUnresolved( $block, self::ERROR_MISSING_REF );
+		}
+
+		if ( $depth >= $this->maxDepth ) {
+			return $this->markUnresolved( $block, self::ERROR_DEPTH_LIMIT );
+		}
+
+		$key = (string) $ref;
+
+		if ( in_array( $key, $stack, true ) ) {
+			return $this->markUnresolved( $block, self::ERROR_CYCLE );
+		}
+
+		$pattern = $this->findPattern( $ref );
+
+		if ( null === $pattern ) {
+			return $this->markUnresolved( $block, self::ERROR_NOT_FOUND );
+		}
+
+		$childStack       = $stack;
+		$childStack[]     = $key;
+		$resolvedChildren = $this->walk( $pattern->getBlocks(), $childStack, $depth + 1 );
+
+		return [
+			'clientId'    => $block['clientId'] ?? null,
+			'name'        => 'core/block',
+			'attributes'  => array_merge( $attributes, [
+				'ref' => $ref,
+			] ),
+			'innerBlocks' => $resolvedChildren,
+		];
+	}
+
+	/**
+	 * Coerces the `ref` attribute to a positive integer pattern id.
+	 *
+	 * The editor writes refs as integers (see `inserter-patterns-panel.tsx`),
+	 * but JSON round-trips and host-app authoring may surface them as
+	 * numeric strings — normalise both shapes and reject anything else.
+	 *
+	 * @since 1.0.0
+	 */
+	protected function normalizeRef( mixed $value ): ?int
+	{
+		if ( is_int( $value ) ) {
+			return $value > 0 ? $value : null;
+		}
+
+		if ( is_string( $value ) && '' !== trim( $value ) && ctype_digit( trim( $value ) ) ) {
+			$int = (int) trim( $value );
+
+			return $int > 0 ? $int : null;
+		}
+
+		return null;
+	}
+
+	/**
+	 * Looks the pattern up by id.
+	 *
+	 * @since 1.0.0
+	 */
+	protected function findPattern( int $ref ): ?VisualEditorPattern
+	{
+		return VisualEditorPattern::query()->find( $ref );
+	}
+
+	/**
+	 * Returns the block stamped with the resolution-failure reason so
+	 * downstream renderers can short-circuit to their fallback markup.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array<string, mixed>  $block
+	 *
+	 * @return array<string, mixed>
+	 */
+	protected function markUnresolved( array $block, string $reason ): array
+	{
+		$attributes = isset( $block['attributes'] ) && is_array( $block['attributes'] ) ? $block['attributes'] : [];
+
+		return [
+			'clientId'    => $block['clientId'] ?? null,
+			'name'        => 'core/block',
+			'attributes'  => array_merge( $attributes, [
+				'_resolutionError' => $reason,
+			] ),
+			'innerBlocks' => [],
+		];
+	}
+}

--- a/tests/Unit/VisualEditor/PatternInlinerTest.php
+++ b/tests/Unit/VisualEditor/PatternInlinerTest.php
@@ -1,0 +1,241 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Models\VisualEditorPattern;
+use ArtisanPackUI\VisualEditor\Resources\PatternInliner;
+
+function patternInlinerFixture( string $slug, array $blocks, bool $synced = true ): VisualEditorPattern
+{
+	return VisualEditorPattern::create( [
+		'slug'    => $slug,
+		'title'   => ucfirst( $slug ),
+		'content' => [ 'raw' => '', 'blocks' => $blocks ],
+		'synced'  => $synced,
+		'status'  => 'publish',
+	] );
+}
+
+function patternInlinerRef( int $ref, string $clientId = 'pat-cid' ): array
+{
+	return [
+		'clientId'    => $clientId,
+		'name'        => 'core/block',
+		'attributes'  => [ 'ref' => $ref ],
+		'innerBlocks' => [],
+	];
+}
+
+function patternInlinerParagraph( string $text, string $clientId = 'p-cid' ): array
+{
+	return [
+		'clientId'    => $clientId,
+		'name'        => 'core/paragraph',
+		'attributes'  => [ 'content' => $text ],
+		'innerBlocks' => [],
+	];
+}
+
+it( 'inlines a single core/block reference', function () {
+	$pattern = patternInlinerFixture( 'hero', [ patternInlinerParagraph( 'Hero copy' ) ] );
+
+	$tree = [ patternInlinerRef( $pattern->id ) ];
+
+	$resolved = ( new PatternInliner() )->inline( $tree );
+
+	expect( $resolved )->toHaveCount( 1 );
+	expect( $resolved[0]['name'] )->toBe( 'core/block' );
+	expect( $resolved[0]['innerBlocks'] )->toHaveCount( 1 );
+	expect( $resolved[0]['innerBlocks'][0]['attributes']['content'] )->toBe( 'Hero copy' );
+} );
+
+it( 'descends into nested innerBlocks looking for synced patterns', function () {
+	$pattern = patternInlinerFixture( 'inside', [ patternInlinerParagraph( 'Inside group' ) ] );
+
+	$tree = [
+		[
+			'clientId'    => 'g-1',
+			'name'        => 'core/group',
+			'attributes'  => [],
+			'innerBlocks' => [ patternInlinerRef( $pattern->id ) ],
+		],
+	];
+
+	$resolved = ( new PatternInliner() )->inline( $tree );
+
+	expect( $resolved[0]['innerBlocks'][0]['name'] )->toBe( 'core/block' );
+	expect( $resolved[0]['innerBlocks'][0]['innerBlocks'][0]['attributes']['content'] )->toBe( 'Inside group' );
+} );
+
+it( 'recurses through nested synced patterns', function () {
+	$inner = patternInlinerFixture( 'inner', [ patternInlinerParagraph( 'Innermost' ) ] );
+	$outer = patternInlinerFixture( 'outer', [ patternInlinerRef( $inner->id, 'inner-ref' ) ] );
+
+	$tree = [ patternInlinerRef( $outer->id, 'outer-root' ) ];
+
+	$resolved = ( new PatternInliner() )->inline( $tree );
+
+	expect( $resolved[0]['innerBlocks'][0]['name'] )->toBe( 'core/block' );
+	expect( $resolved[0]['innerBlocks'][0]['innerBlocks'][0]['attributes']['content'] )->toBe( 'Innermost' );
+} );
+
+it( 'marks a missing ref attribute with the missing-ref error', function () {
+	$tree = [
+		[
+			'clientId'    => 'pat-1',
+			'name'        => 'core/block',
+			'attributes'  => [],
+			'innerBlocks' => [],
+		],
+	];
+
+	$resolved = ( new PatternInliner() )->inline( $tree );
+
+	expect( $resolved[0]['attributes']['_resolutionError'] )->toBe( PatternInliner::ERROR_MISSING_REF );
+	expect( $resolved[0]['innerBlocks'] )->toBe( [] );
+} );
+
+it( 'marks a missing record with the not-found error', function () {
+	$tree = [ patternInlinerRef( 9999 ) ];
+
+	$resolved = ( new PatternInliner() )->inline( $tree );
+
+	expect( $resolved[0]['attributes']['_resolutionError'] )->toBe( PatternInliner::ERROR_NOT_FOUND );
+} );
+
+it( 'detects a direct cycle (a → a)', function () {
+	$pattern = patternInlinerFixture( 'looper', [] );
+
+	$pattern->setContentEnvelope( [
+		'raw'    => '',
+		'blocks' => [ patternInlinerRef( $pattern->id, 'self-ref' ) ],
+	] );
+	$pattern->save();
+
+	$tree = [ patternInlinerRef( $pattern->id, 'root' ) ];
+
+	$resolved = ( new PatternInliner() )->inline( $tree );
+
+	expect( $resolved[0]['attributes']['_resolutionError'] ?? null )->toBeNull();
+	expect( $resolved[0]['innerBlocks'][0]['attributes']['_resolutionError'] )
+		->toBe( PatternInliner::ERROR_CYCLE );
+} );
+
+it( 'detects an indirect cycle (a → b → a)', function () {
+	$patternA = patternInlinerFixture( 'a', [] );
+	$patternB = patternInlinerFixture( 'b', [] );
+
+	$patternA->setContentEnvelope( [
+		'raw'    => '',
+		'blocks' => [ patternInlinerRef( $patternB->id, 'b-ref' ) ],
+	] );
+	$patternA->save();
+
+	$patternB->setContentEnvelope( [
+		'raw'    => '',
+		'blocks' => [ patternInlinerRef( $patternA->id, 'a-ref' ) ],
+	] );
+	$patternB->save();
+
+	$tree = [ patternInlinerRef( $patternA->id, 'a-root' ) ];
+
+	$resolved = ( new PatternInliner() )->inline( $tree );
+
+	$cycleNode = $resolved[0]['innerBlocks'][0]['innerBlocks'][0];
+
+	expect( $cycleNode['name'] )->toBe( 'core/block' );
+	expect( $cycleNode['attributes']['_resolutionError'] )->toBe( PatternInliner::ERROR_CYCLE );
+} );
+
+it( 'enforces the depth limit', function () {
+	// Build a five-level chain: p0 → p1 → p2 → p3 → p4 (terminal).
+	$created = [];
+	for ( $i = 0; $i < 5; $i++ ) {
+		$created[ $i ] = patternInlinerFixture( 'p' . $i, [] );
+	}
+
+	for ( $i = 0; $i < 4; $i++ ) {
+		$created[ $i ]->setContentEnvelope( [
+			'raw'    => '',
+			'blocks' => [ patternInlinerRef( $created[ $i + 1 ]->id, 'p' . ( $i + 1 ) . '-ref' ) ],
+		] );
+		$created[ $i ]->save();
+	}
+
+	$tree = [ patternInlinerRef( $created[ 0 ]->id, 'p0-root' ) ];
+
+	$resolved = ( new PatternInliner( 2 ) )->inline( $tree );
+
+	$third = $resolved[0]['innerBlocks'][0]['innerBlocks'][0];
+
+	expect( $third['name'] )->toBe( 'core/block' );
+	expect( $third['attributes']['_resolutionError'] )->toBe( PatternInliner::ERROR_DEPTH_LIMIT );
+} );
+
+it( 'preserves non-core/block blocks untouched', function () {
+	$tree = [ patternInlinerParagraph( 'Just text', 'p-only' ) ];
+
+	$resolved = ( new PatternInliner() )->inline( $tree );
+
+	expect( $resolved )->toBe( $tree );
+} );
+
+it( 'returns an empty array when given non-array entries', function () {
+	$tree = [ 'not-a-block', null, 42 ];
+
+	$resolved = ( new PatternInliner() )->inline( $tree );
+
+	expect( $resolved )->toBe( [] );
+} );
+
+it( 'normalizes numeric-string refs to integers', function () {
+	$pattern = patternInlinerFixture( 'numeric-string', [ patternInlinerParagraph( 'Resolved' ) ] );
+
+	$tree = [
+		[
+			'clientId'    => 'pat-num-string',
+			'name'        => 'core/block',
+			'attributes'  => [ 'ref' => (string) $pattern->id ],
+			'innerBlocks' => [],
+		],
+	];
+
+	$resolved = ( new PatternInliner() )->inline( $tree );
+
+	expect( $resolved[0]['attributes']['_resolutionError'] ?? null )->toBeNull();
+	expect( $resolved[0]['innerBlocks'][0]['attributes']['content'] )->toBe( 'Resolved' );
+} );
+
+it( 'rejects non-numeric ref values with the missing-ref error', function () {
+	$tree = [
+		[
+			'clientId'    => 'pat-bad-ref',
+			'name'        => 'core/block',
+			'attributes'  => [ 'ref' => 'not-a-number' ],
+			'innerBlocks' => [],
+		],
+	];
+
+	$resolved = ( new PatternInliner() )->inline( $tree );
+
+	expect( $resolved[0]['attributes']['_resolutionError'] )->toBe( PatternInliner::ERROR_MISSING_REF );
+} );
+
+it( 'returns an empty resolved tree (no core/block references) when only unsynced patterns exist', function () {
+	// The synced/unsynced contract: unsynced patterns are inlined into
+	// the saved tree at insert time by the editor, so the inliner only
+	// ever sees `core/block` references for synced patterns. A tree
+	// composed of inlined unsynced-pattern blocks passes through
+	// untouched.
+	$pattern = patternInlinerFixture(
+		'unsynced',
+		[ patternInlinerParagraph( 'Inlined at insert time' ) ],
+		false
+	);
+
+	$treeAsSaved = $pattern->getBlocks();
+
+	$resolved = ( new PatternInliner() )->inline( $treeAsSaved );
+
+	expect( $resolved )->toBe( $treeAsSaved );
+} );


### PR DESCRIPTION
## Description

Resolves `core/block` (synced-pattern reference) blocks at render time across the Blade, React, and Vue renderer packages so a saved page that references a synced pattern renders the pattern's current content inline. Mirrors the existing template-part inliner: walk the tree, resolve each reference against the pattern record, attach the resolved blocks under `innerBlocks`, and let the recursive renderer pass produce the final HTML.

**Closes:** #380

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #380

## Motivation and Context

Phase E3 of the V1 expansion plan (`docs/plans/11-v1-expansion.md` §3). Without this, saved pages that reference a synced pattern fall through to the dynamic-block fallback (server preview round-trip on the JS side, unknown-block placeholder on the Blade side) instead of rendering the pattern's actual content. Locks in the synced/unsynced rendering contract: synced patterns resolve at render time (live, propagating), unsynced patterns are inlined at insert time (one-shot copies).

## Changes Made

- New `PatternInliner` service (`src/Resources/PatternInliner.php`) and `inlinePatterns` helpers (`patterns.ts` in renderer-react and renderer-vue).
- Recursion guard with depth limit (default 10) and cycle detection. Unresolvable references stamp a synthetic `_resolutionError` attribute (`missing-ref` / `not-found` / `cycle` / `depth-limit`).
- Wired the PHP service into both `<x-ve-blocks>` and `<x-ve-template>`; added `:resolve-patterns="false"` opt-out flag for parity with `:resolve-parts`.
- New `patterns` and `maxPatternDepth` props on React + Vue `<BlockTree>` and `<Template>`. Pattern inlining runs after template-part inlining so a part that itself contains a synced-pattern reference resolves in the same pass.
- New `core/block` renderer in each package wraps resolved children in `<div class="wp-block-block">` and surfaces the error reason in development (HTML comment for Blade, `data-ve-resolution-error` for React/Vue) while emitting an empty wrapper in production.
- Documents the synced/unsynced contract in `docs/core-data-shim.md` and closes the related open question in `docs/plans/11-v1-expansion.md` §8.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS Darwin 25.4.0
- Browser: Chrome (manual verification on the M9 Blade preview at `/m9/post/1`)
- PHP Version: 8.4.3
- Project Version: 1.0.0-alpha (release/1.0 branch)

**Tests Performed:**
1. Browser verification on `/m9/post/1` confirmed both unsynced patterns (inlined copies) and synced patterns (resolved from a single `core/block` reference) render with the live pattern content.
2. Editing the synced pattern propagated to the rendered page on refresh — confirmed live resolution rather than insert-time snapshot.
3. Full PHP pest suite: **427 / 427 passing**.
4. Full JS vitest suite: **849 passing** (1 pre-existing skip).

## Accessibility Tests Run

- [x] Keyboard navigation tested
- [x] Color contrast verified

**Details:** No new interactive UI surfaces — this is a render-time tree transformation. The `<div class="wp-block-block">` wrapper inherits the surrounding layout's keyboard semantics; resolution-error markers are non-visual debug attributes invisible to assistive tech in production.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:**
- `tests/Unit/VisualEditor/PatternInlinerTest.php` — 13 tests covering ref normalization (int + numeric string), missing ref, missing record, direct + indirect cycles, depth limit, nested innerBlocks descent, non-block entries, and the unsynced-tree pass-through contract.
- `packages/visual-editor-renderer-blade/tests/Feature/SyncedPatternRenderingTest.php` — 7 `<x-ve-blocks>` integration tests including dev/prod failure modes, the `:resolve-patterns="false"` opt-out, and the unsynced sanity check.
- `packages/visual-editor-renderer-react/tests/patterns.test.ts` (12) + `syncedPatternRendering.test.tsx` (6) — pure inliner + rendered-DOM integration including the `Template` forwarding.
- `packages/visual-editor-renderer-vue/tests/patterns.test.ts` (12) + `syncedPatternRendering.test.ts` (6) — same coverage as React.

Total: **56 new tests** added; 0 existing tests modified.

## Documentation

- [x] Inline code documentation added
- [x] Wiki updated

**Documentation details:**
- New "Synced vs. unsynced rendering (E3)" subsection under the Patterns API in `docs/core-data-shim.md` describing the runtime resolution path and the synced/unsynced contract.
- Closed the patterns open question in `docs/plans/11-v1-expansion.md` §8.
- Class-level docblocks on `PatternInliner.php`, file-level JSDoc on `patterns.ts` (React + Vue), and the new `core/block` renderer files in each package.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added synced-pattern support: resolved at render time and rendered wrappers include pattern tracking attributes.
  * Unsynced patterns are inlined at insertion so they render as regular blocks.

* **Bug Fixes**
  * Detects and surfaces missing refs, cycles, and depth limits with environment-aware error output (less noisy in production).

* **Documentation**
  * Updated pattern handling docs and V1 expansion plan.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->