### PR TITLE
E4 · Block re-enablement across Blade, React, Vue renderers

### DIFF
--- a/config/visual-editor.php
+++ b/config/visual-editor.php
@@ -84,27 +84,40 @@ return [
 		'core/details',
 		'core/search',
 		'core/latest-posts',
-		'artisanpack/callout',
-	],
-
-	'disabled_blocks' => [
-		// `core/navigation` is enabled by D4 — its editor experience is
-		// backed by the `wp_navigation` shim entity (B1) plus the C4
-		// REST surface, so the block's link-control picker and inner
-		// blocks both round-trip cleanly. The JS-side mirror in
-		// site-editor-app.tsx is updated alongside this entry.
-		'core/query',
-		'core/query-loop',
-		'core/post-content',
+		// E4 — re-enabled on the back of B1's expanded core-data shim
+		// and the C1–C5 REST surface. Each block has a renderer in
+		// every renderer package (Blade / React / Vue) and round-trips
+		// against the empty-state shim without crashing. See
+		// docs/block-library-audit.md for the per-block notes.
+		'core/template-part',
 		'core/post-title',
+		'core/post-content',
 		'core/post-excerpt',
 		'core/post-date',
 		'core/post-author',
 		'core/post-featured-image',
-		'core/site-logo',
 		'core/site-title',
 		'core/site-tagline',
-		'core/template-part',
+		'core/site-logo',
+		'core/navigation',
+		'artisanpack/callout',
+	],
+
+	'disabled_blocks' => [
+		// `core/navigation` was enabled by D4 and stays enabled in E4.
+		// `core/template-part`, `core/post-*`, and `core/site-*` are
+		// promoted to the allow-list above by E4 (#381). The blocks
+		// listed here remain deliberately deferred:
+		//
+		//  - core/query / core/query-loop need a real loop runtime
+		//    (V2 — `artisanpack-ui/cms-framework`).
+		//  - The taxonomy/feed widgets need term + comment endpoints
+		//    that the shim does not implement (V1.1+).
+		//
+		// The JS-side mirror in site-editor-app.tsx is updated
+		// alongside this entry.
+		'core/query',
+		'core/query-loop',
 		'core/latest-comments',
 		'core/archives',
 		'core/categories',

--- a/config/visual-editor.php
+++ b/config/visual-editor.php
@@ -47,12 +47,20 @@ return [
 	| always-applied deny-list. The deny-list wins when both are set. Use
 	| fully-qualified block names (e.g. `core/paragraph`, `core/query`).
 	|
-	| The frozen V1 defaults follow the M5 block-library audit
-	| (see docs/block-library-audit.md). Only blocks that render correctly
-	| against the empty-state @wordpress/core-data shim are enabled; every
-	| block that needs a real Laravel-backed core store — navigation, query,
-	| post-*, site-*, template-part, taxonomy widgets — is disabled until
-	| the artisanpack-ui/cms-framework package replaces the shim.
+	| The V1 defaults follow the M5 block-library audit
+	| (see docs/block-library-audit.md), updated by E4 (#381). The
+	| allow-list now includes the entity-scoped blocks that B1's expanded
+	| `core-data` shim plus the C1–C5 REST surface can round-trip:
+	| `core/template-part`, `core/post-*`, `core/site-*`, and
+	| `core/navigation`. The deny-list still removes the loop / feed
+	| widgets (`core/query`, `core/latest-comments`, `core/archives`,
+	| `core/categories`, `core/tag-cloud`) — they need a real loop runtime
+	| and term/comment endpoints that the shim does not implement, and
+	| stay deferred until V2 (`artisanpack-ui/cms-framework`) and V1.1+
+	| respectively. Keep the JS-side mirror in
+	| `resources/js/visual-editor/site-editor/site-editor-app.tsx`
+	| (`D2_DISABLED_BLOCKS`) in sync with the deny-list — the two lists
+	| want to agree.
 	|
 	*/
 

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/core/navigation-link.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/core/navigation-link.blade.php
@@ -1,0 +1,31 @@
+@php
+	use ArtisanPackUI\VisualEditorRendererBlade\Support\UrlSanitizer;
+
+	$label      = isset( $attributes['label'] ) && is_string( $attributes['label'] ) ? $attributes['label'] : '';
+	$url        = UrlSanitizer::safe( isset( $attributes['url'] ) && is_string( $attributes['url'] ) ? $attributes['url'] : '' );
+	$opensInNew = ! empty( $attributes['opensInNewTab'] );
+	$rel        = isset( $attributes['rel'] ) && is_string( $attributes['rel'] ) ? $attributes['rel'] : '';
+	$title      = isset( $attributes['title'] ) && is_string( $attributes['title'] ) ? $attributes['title'] : '';
+	$description = isset( $attributes['description'] ) && is_string( $attributes['description'] ) ? $attributes['description'] : '';
+
+	$classes = [ 'wp-block-navigation-item', 'wp-block-navigation-link' ];
+
+	if ( ! empty( $attributes['className'] ) && is_string( $attributes['className'] ) ) {
+		$classes[] = $attributes['className'];
+	}
+
+	$linkAttrs = '' !== $url ? sprintf( ' href="%s"', e( $url ) ) : '';
+
+	if ( $opensInNew ) {
+		$linkAttrs .= sprintf( ' target="_blank" rel="%s"', e( trim( 'noopener noreferrer ' . $rel ) ) );
+	} elseif ( '' !== $rel ) {
+		$linkAttrs .= sprintf( ' rel="%s"', e( $rel ) );
+	}
+
+	if ( '' !== $title ) {
+		$linkAttrs .= sprintf( ' title="%s"', e( $title ) );
+	}
+@endphp
+<li class="{{ implode( ' ', array_map( 'trim', $classes ) ) }}">
+	<a class="wp-block-navigation-item__content"{!! $linkAttrs !!}><span class="wp-block-navigation-item__label">{{ $label }}</span>@if ( '' !== $description )<span class="wp-block-navigation-item__description">{{ $description }}</span>@endif</a>
+</li>

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/core/navigation-submenu.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/core/navigation-submenu.blade.php
@@ -1,0 +1,26 @@
+@php
+	use ArtisanPackUI\VisualEditorRendererBlade\Support\UrlSanitizer;
+
+	$label      = isset( $attributes['label'] ) && is_string( $attributes['label'] ) ? $attributes['label'] : '';
+	$url        = UrlSanitizer::safe( isset( $attributes['url'] ) && is_string( $attributes['url'] ) ? $attributes['url'] : '' );
+	$opensInNew = ! empty( $attributes['opensInNewTab'] );
+	$rel        = isset( $attributes['rel'] ) && is_string( $attributes['rel'] ) ? $attributes['rel'] : '';
+
+	$classes = [ 'wp-block-navigation-item', 'wp-block-navigation-submenu', 'has-child' ];
+
+	if ( ! empty( $attributes['className'] ) && is_string( $attributes['className'] ) ) {
+		$classes[] = $attributes['className'];
+	}
+
+	$linkAttrs = '' !== $url ? sprintf( ' href="%s"', e( $url ) ) : '';
+
+	if ( $opensInNew ) {
+		$linkAttrs .= sprintf( ' target="_blank" rel="%s"', e( trim( 'noopener noreferrer ' . $rel ) ) );
+	} elseif ( '' !== $rel ) {
+		$linkAttrs .= sprintf( ' rel="%s"', e( $rel ) );
+	}
+@endphp
+<li class="{{ implode( ' ', array_map( 'trim', $classes ) ) }}">
+	<a class="wp-block-navigation-item__content"{!! $linkAttrs !!}><span class="wp-block-navigation-item__label">{{ $label }}</span></a>
+	<ul class="wp-block-navigation__submenu-container">{!! $innerBlocksHtml !!}</ul>
+</li>

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/core/navigation.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/core/navigation.blade.php
@@ -1,0 +1,36 @@
+@php
+	$overlayMenu  = isset( $attributes['overlayMenu'] ) && is_string( $attributes['overlayMenu'] ) ? $attributes['overlayMenu'] : 'mobile';
+	$orientation  = isset( $attributes['orientation'] ) && is_string( $attributes['orientation'] ) ? $attributes['orientation'] : 'horizontal';
+	$itemsJustify = isset( $attributes['itemsJustification'] ) && is_string( $attributes['itemsJustification'] ) ? $attributes['itemsJustification'] : '';
+
+	$ariaLabel = isset( $attributes['ariaLabel'] ) && is_string( $attributes['ariaLabel'] ) ? $attributes['ariaLabel'] : '';
+
+	$classes = [ 'wp-block-navigation' ];
+
+	if ( 'horizontal' === $orientation ) {
+		$classes[] = 'is-horizontal';
+	} elseif ( 'vertical' === $orientation ) {
+		$classes[] = 'is-vertical';
+	}
+
+	if ( '' !== $itemsJustify ) {
+		$classes[] = 'items-justified-' . $itemsJustify;
+	}
+
+	if ( 'never' !== $overlayMenu ) {
+		$classes[] = 'is-responsive';
+	}
+
+	if ( ! empty( $attributes['className'] ) && is_string( $attributes['className'] ) ) {
+		$classes[] = $attributes['className'];
+	}
+
+	$navAttrs = '';
+
+	if ( '' !== $ariaLabel ) {
+		$navAttrs .= sprintf( ' aria-label="%s"', e( $ariaLabel ) );
+	}
+@endphp
+<nav class="{{ implode( ' ', array_map( 'trim', $classes ) ) }}"{!! $navAttrs !!}>
+	<ul class="wp-block-navigation__container">{!! $innerBlocksHtml !!}</ul>
+</nav>

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/core/post-author.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/core/post-author.blade.php
@@ -1,0 +1,43 @@
+@php
+	use ArtisanPackUI\VisualEditorRendererBlade\Support\UrlSanitizer;
+
+	$align      = isset( $attributes['textAlign'] ) && is_string( $attributes['textAlign'] ) ? $attributes['textAlign'] : '';
+	$showAvatar = ! isset( $attributes['showAvatar'] ) || ! empty( $attributes['showAvatar'] );
+	$showBio    = ! empty( $attributes['showBio'] );
+	$avatarSize = isset( $attributes['avatarSize'] ) ? max( 1, (int) $attributes['avatarSize'] ) : 24;
+	$byline     = isset( $attributes['byline'] ) && is_string( $attributes['byline'] ) ? $attributes['byline'] : '';
+	$isLink     = ! empty( $attributes['isLink'] );
+
+	$name      = isset( $attributes['_resolvedAuthorName'] ) && is_string( $attributes['_resolvedAuthorName'] ) ? $attributes['_resolvedAuthorName'] : '';
+	$bio       = isset( $attributes['_resolvedAuthorBio'] ) && is_string( $attributes['_resolvedAuthorBio'] ) ? $attributes['_resolvedAuthorBio'] : '';
+	$authorUrl = UrlSanitizer::safe( isset( $attributes['_resolvedAuthorUrl'] ) && is_string( $attributes['_resolvedAuthorUrl'] ) ? $attributes['_resolvedAuthorUrl'] : '' );
+	$avatarUrl = UrlSanitizer::safe( isset( $attributes['_resolvedAuthorAvatar'] ) && is_string( $attributes['_resolvedAuthorAvatar'] ) ? $attributes['_resolvedAuthorAvatar'] : '' );
+
+	$classes = [ 'wp-block-post-author' ];
+
+	if ( '' !== $align ) {
+		$classes[] = 'has-text-align-' . $align;
+	}
+
+	if ( ! empty( $attributes['className'] ) && is_string( $attributes['className'] ) ) {
+		$classes[] = $attributes['className'];
+	}
+@endphp
+<div class="{{ implode( ' ', array_map( 'trim', $classes ) ) }}">
+	@if ( $showAvatar && '' !== $avatarUrl )
+		<div class="wp-block-post-author__avatar"><img alt="{{ $name }}" width="{{ $avatarSize }}" height="{{ $avatarSize }}" src="{{ $avatarUrl }}"/></div>
+	@endif
+	<div class="wp-block-post-author__content">
+		@if ( '' !== $byline )
+			<p class="wp-block-post-author__byline">{{ $byline }}</p>
+		@endif
+		@if ( $isLink && '' !== $authorUrl )
+			<p class="wp-block-post-author__name"><a href="{{ $authorUrl }}">{{ $name }}</a></p>
+		@else
+			<p class="wp-block-post-author__name">{{ $name }}</p>
+		@endif
+		@if ( $showBio && '' !== $bio )
+			<p class="wp-block-post-author__bio">{!! $bio !!}</p>
+		@endif
+	</div>
+</div>

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/core/post-content.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/core/post-content.blade.php
@@ -1,0 +1,16 @@
+@php
+	$align = isset( $attributes['textAlign'] ) && is_string( $attributes['textAlign'] ) ? $attributes['textAlign'] : '';
+
+	$classes = [ 'entry-content', 'wp-block-post-content' ];
+
+	if ( '' !== $align ) {
+		$classes[] = 'has-text-align-' . $align;
+	}
+
+	if ( ! empty( $attributes['className'] ) && is_string( $attributes['className'] ) ) {
+		$classes[] = $attributes['className'];
+	}
+
+	$content = isset( $attributes['_resolvedContent'] ) && is_string( $attributes['_resolvedContent'] ) ? $attributes['_resolvedContent'] : '';
+@endphp
+<div class="{{ implode( ' ', array_map( 'trim', $classes ) ) }}">{!! $content !!}</div>

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/core/post-date.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/core/post-date.blade.php
@@ -1,0 +1,27 @@
+@php
+	use ArtisanPackUI\VisualEditorRendererBlade\Support\UrlSanitizer;
+
+	$align       = isset( $attributes['textAlign'] ) && is_string( $attributes['textAlign'] ) ? $attributes['textAlign'] : '';
+	$displayType = isset( $attributes['displayType'] ) && 'modified' === $attributes['displayType'] ? 'modified' : 'date';
+	$isLink      = ! empty( $attributes['isLink'] );
+
+	$resolvedKey       = 'modified' === $displayType ? '_resolvedModifiedDate' : '_resolvedDate';
+	$resolvedFormatKey = 'modified' === $displayType ? '_resolvedModifiedDateFormatted' : '_resolvedDateFormatted';
+
+	$datetime  = isset( $attributes[ $resolvedKey ] ) && is_string( $attributes[ $resolvedKey ] ) ? $attributes[ $resolvedKey ] : '';
+	$formatted = isset( $attributes[ $resolvedFormatKey ] ) && is_string( $attributes[ $resolvedFormatKey ] ) ? $attributes[ $resolvedFormatKey ] : $datetime;
+	$permalink = UrlSanitizer::safe( isset( $attributes['_resolvedPermalink'] ) && is_string( $attributes['_resolvedPermalink'] ) ? $attributes['_resolvedPermalink'] : '' );
+
+	$classes = [ 'wp-block-post-date' ];
+
+	if ( '' !== $align ) {
+		$classes[] = 'has-text-align-' . $align;
+	}
+
+	if ( ! empty( $attributes['className'] ) && is_string( $attributes['className'] ) ) {
+		$classes[] = $attributes['className'];
+	}
+
+	$timeAttrs = '' !== $datetime ? sprintf( ' datetime="%s"', e( $datetime ) ) : '';
+@endphp
+<div class="{{ implode( ' ', array_map( 'trim', $classes ) ) }}">@if ( $isLink && '' !== $permalink )<a href="{{ $permalink }}"><time{!! $timeAttrs !!}>{{ $formatted }}</time></a>@else<time{!! $timeAttrs !!}>{{ $formatted }}</time>@endif</div>

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/core/post-excerpt.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/core/post-excerpt.blade.php
@@ -1,0 +1,41 @@
+@php
+	use ArtisanPackUI\VisualEditorRendererBlade\Support\UrlSanitizer;
+
+	$align    = isset( $attributes['textAlign'] ) && is_string( $attributes['textAlign'] ) ? $attributes['textAlign'] : '';
+	$moreText = isset( $attributes['moreText'] ) && is_string( $attributes['moreText'] ) ? $attributes['moreText'] : '';
+	$showMoreOnNewLine = ! isset( $attributes['showMoreOnNewLine'] ) || ! empty( $attributes['showMoreOnNewLine'] );
+
+	$excerpt   = isset( $attributes['_resolvedExcerpt'] ) && is_string( $attributes['_resolvedExcerpt'] ) ? $attributes['_resolvedExcerpt'] : '';
+	$permalink = UrlSanitizer::safe( isset( $attributes['_resolvedPermalink'] ) && is_string( $attributes['_resolvedPermalink'] ) ? $attributes['_resolvedPermalink'] : '' );
+
+	$classes = [ 'wp-block-post-excerpt' ];
+
+	if ( '' !== $align ) {
+		$classes[] = 'has-text-align-' . $align;
+	}
+
+	if ( ! empty( $attributes['className'] ) && is_string( $attributes['className'] ) ) {
+		$classes[] = $attributes['className'];
+	}
+
+	$moreLink = '';
+
+	if ( '' !== $moreText && '' !== $permalink ) {
+		$moreLink = sprintf(
+			'<a class="wp-block-post-excerpt__more-link" href="%s">%s</a>',
+			e( $permalink ),
+			e( $moreText )
+		);
+	} elseif ( '' !== $moreText ) {
+		$moreLink = sprintf(
+			'<span class="wp-block-post-excerpt__more-text">%s</span>',
+			e( $moreText )
+		);
+	}
+@endphp
+<div class="{{ implode( ' ', array_map( 'trim', $classes ) ) }}">
+	<p class="wp-block-post-excerpt__excerpt">{!! $excerpt !!}@if ( '' !== $moreLink && ! $showMoreOnNewLine ) {!! $moreLink !!}@endif</p>
+	@if ( '' !== $moreLink && $showMoreOnNewLine )
+		<p class="wp-block-post-excerpt__more-text">{!! $moreLink !!}</p>
+	@endif
+</div>

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/core/post-featured-image.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/core/post-featured-image.blade.php
@@ -1,0 +1,67 @@
+@php
+	use ArtisanPackUI\VisualEditorRendererBlade\Support\UrlSanitizer;
+
+	$isLink     = ! empty( $attributes['isLink'] );
+	$linkTarget = isset( $attributes['linkTarget'] ) && is_string( $attributes['linkTarget'] ) ? $attributes['linkTarget'] : '';
+	$rel        = isset( $attributes['rel'] ) && is_string( $attributes['rel'] ) ? $attributes['rel'] : '';
+	$aspect     = isset( $attributes['aspectRatio'] ) && is_string( $attributes['aspectRatio'] ) ? $attributes['aspectRatio'] : '';
+	$scale      = isset( $attributes['scale'] ) && is_string( $attributes['scale'] ) ? $attributes['scale'] : '';
+	$sizeSlug   = isset( $attributes['sizeSlug'] ) && is_string( $attributes['sizeSlug'] ) ? $attributes['sizeSlug'] : '';
+
+	$imageUrl  = UrlSanitizer::safe( isset( $attributes['_resolvedImageUrl'] ) && is_string( $attributes['_resolvedImageUrl'] ) ? $attributes['_resolvedImageUrl'] : '' );
+	$alt       = isset( $attributes['_resolvedImageAlt'] ) && is_string( $attributes['_resolvedImageAlt'] ) ? $attributes['_resolvedImageAlt'] : '';
+	$width     = isset( $attributes['_resolvedImageWidth'] ) ? (int) $attributes['_resolvedImageWidth'] : 0;
+	$height    = isset( $attributes['_resolvedImageHeight'] ) ? (int) $attributes['_resolvedImageHeight'] : 0;
+	$permalink = UrlSanitizer::safe( isset( $attributes['_resolvedPermalink'] ) && is_string( $attributes['_resolvedPermalink'] ) ? $attributes['_resolvedPermalink'] : '' );
+
+	$classes = [ 'wp-block-post-featured-image' ];
+
+	if ( '' !== $sizeSlug ) {
+		$classes[] = 'size-' . $sizeSlug;
+	}
+
+	if ( ! empty( $attributes['className'] ) && is_string( $attributes['className'] ) ) {
+		$classes[] = $attributes['className'];
+	}
+
+	$styleParts = [];
+
+	if ( '' !== $aspect ) {
+		$styleParts[] = 'aspect-ratio:' . $aspect;
+	}
+
+	if ( '' !== $scale ) {
+		$styleParts[] = 'object-fit:' . $scale;
+	}
+
+	$style = '' !== implode( '', $styleParts ) ? sprintf( ' style="%s"', e( implode( ';', $styleParts ) ) ) : '';
+
+	$imgAttrs = sprintf( ' src="%s" alt="%s"', e( $imageUrl ), e( $alt ) );
+
+	if ( $width > 0 ) {
+		$imgAttrs .= sprintf( ' width="%d"', $width );
+	}
+
+	if ( $height > 0 ) {
+		$imgAttrs .= sprintf( ' height="%d"', $height );
+	}
+
+	$imgAttrs .= $style;
+@endphp
+<figure class="{{ implode( ' ', array_map( 'trim', $classes ) ) }}">
+	@if ( '' !== $imageUrl )
+		@if ( $isLink && '' !== $permalink )
+			@php
+				$linkAttrs = sprintf( ' href="%s"', e( $permalink ) );
+				if ( '_blank' === $linkTarget ) {
+					$linkAttrs .= sprintf( ' target="_blank" rel="%s"', e( trim( 'noopener noreferrer ' . $rel ) ) );
+				} elseif ( '' !== $rel ) {
+					$linkAttrs .= sprintf( ' rel="%s"', e( $rel ) );
+				}
+			@endphp
+			<a{!! $linkAttrs !!}><img{!! $imgAttrs !!}/></a>
+		@else
+			<img{!! $imgAttrs !!}/>
+		@endif
+	@endif
+</figure>

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/core/post-title.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/core/post-title.blade.php
@@ -1,0 +1,42 @@
+@php
+	use ArtisanPackUI\VisualEditorRendererBlade\Support\UrlSanitizer;
+
+	$rawLevel = isset( $attributes['level'] ) ? (int) $attributes['level'] : 2;
+	$level    = max( 1, min( 6, $rawLevel ) );
+	$tag      = 'h' . $level;
+	$align    = isset( $attributes['textAlign'] ) && is_string( $attributes['textAlign'] ) ? $attributes['textAlign'] : '';
+	$isLink   = ! empty( $attributes['isLink'] );
+	$linkTarget = isset( $attributes['linkTarget'] ) && is_string( $attributes['linkTarget'] ) ? $attributes['linkTarget'] : '';
+	$rel        = isset( $attributes['rel'] ) && is_string( $attributes['rel'] ) ? $attributes['rel'] : '';
+	$linkClass  = isset( $attributes['linkClass'] ) && is_string( $attributes['linkClass'] ) ? $attributes['linkClass'] : '';
+
+	$title     = isset( $attributes['_resolvedTitle'] ) && is_string( $attributes['_resolvedTitle'] ) ? $attributes['_resolvedTitle'] : '';
+	$permalink = UrlSanitizer::safe( isset( $attributes['_resolvedPermalink'] ) && is_string( $attributes['_resolvedPermalink'] ) ? $attributes['_resolvedPermalink'] : '' );
+
+	$classes = [ 'wp-block-post-title' ];
+
+	if ( '' !== $align ) {
+		$classes[] = 'has-text-align-' . $align;
+	}
+
+	if ( ! empty( $attributes['className'] ) && is_string( $attributes['className'] ) ) {
+		$classes[] = $attributes['className'];
+	}
+
+	$linkAttrs = '';
+
+	if ( $isLink && '' !== $permalink ) {
+		$linkAttrs .= sprintf( ' href="%s"', e( $permalink ) );
+
+		if ( '' !== $linkClass ) {
+			$linkAttrs .= sprintf( ' class="%s"', e( $linkClass ) );
+		}
+
+		if ( '_blank' === $linkTarget ) {
+			$linkAttrs .= sprintf( ' target="_blank" rel="%s"', e( trim( 'noopener noreferrer ' . $rel ) ) );
+		} elseif ( '' !== $rel ) {
+			$linkAttrs .= sprintf( ' rel="%s"', e( $rel ) );
+		}
+	}
+@endphp
+<{{ $tag }} class="{{ implode( ' ', array_map( 'trim', $classes ) ) }}">@if ( $isLink && '' !== $permalink )<a{!! $linkAttrs !!}>{!! $title !!}</a>@else{!! $title !!}@endif</{{ $tag }}>

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/core/site-logo.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/core/site-logo.blade.php
@@ -1,0 +1,36 @@
+@php
+	use ArtisanPackUI\VisualEditorRendererBlade\Support\UrlSanitizer;
+
+	$width      = isset( $attributes['width'] ) ? (int) $attributes['width'] : 0;
+	$isLink     = ! isset( $attributes['isLink'] ) || ! empty( $attributes['isLink'] );
+	$linkTarget = isset( $attributes['linkTarget'] ) && is_string( $attributes['linkTarget'] ) ? $attributes['linkTarget'] : '_self';
+
+	$logoUrl = UrlSanitizer::safe( isset( $attributes['_resolvedLogoUrl'] ) && is_string( $attributes['_resolvedLogoUrl'] ) ? $attributes['_resolvedLogoUrl'] : '' );
+	$siteUrl = UrlSanitizer::safe( isset( $attributes['_resolvedSiteUrl'] ) && is_string( $attributes['_resolvedSiteUrl'] ) ? $attributes['_resolvedSiteUrl'] : '' );
+	$alt     = isset( $attributes['_resolvedSiteTitle'] ) && is_string( $attributes['_resolvedSiteTitle'] ) ? $attributes['_resolvedSiteTitle'] : '';
+
+	$classes = [ 'wp-block-site-logo' ];
+
+	if ( $width <= 0 ) {
+		$classes[] = 'is-default-size';
+	}
+
+	if ( ! empty( $attributes['className'] ) && is_string( $attributes['className'] ) ) {
+		$classes[] = $attributes['className'];
+	}
+
+	$imgAttrs = sprintf( ' src="%s" alt="%s" class="custom-logo"', e( $logoUrl ), e( $alt ) );
+
+	if ( $width > 0 ) {
+		$imgAttrs .= sprintf( ' width="%d"', $width );
+	}
+@endphp
+<div class="{{ implode( ' ', array_map( 'trim', $classes ) ) }}">
+	@if ( '' !== $logoUrl )
+		@if ( $isLink && '' !== $siteUrl )
+			<a href="{{ $siteUrl }}" target="{{ $linkTarget }}" rel="{{ '_blank' === $linkTarget ? 'noopener noreferrer' : 'home' }}" class="custom-logo-link"><img{!! $imgAttrs !!}/></a>
+		@else
+			<img{!! $imgAttrs !!}/>
+		@endif
+	@endif
+</div>

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/core/site-tagline.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/core/site-tagline.blade.php
@@ -1,0 +1,16 @@
+@php
+	$align = isset( $attributes['textAlign'] ) && is_string( $attributes['textAlign'] ) ? $attributes['textAlign'] : '';
+
+	$tagline = isset( $attributes['_resolvedSiteTagline'] ) && is_string( $attributes['_resolvedSiteTagline'] ) ? $attributes['_resolvedSiteTagline'] : '';
+
+	$classes = [ 'wp-block-site-tagline' ];
+
+	if ( '' !== $align ) {
+		$classes[] = 'has-text-align-' . $align;
+	}
+
+	if ( ! empty( $attributes['className'] ) && is_string( $attributes['className'] ) ) {
+		$classes[] = $attributes['className'];
+	}
+@endphp
+<p class="{{ implode( ' ', array_map( 'trim', $classes ) ) }}">{{ $tagline }}</p>

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/core/site-title.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/core/site-title.blade.php
@@ -1,0 +1,24 @@
+@php
+	use ArtisanPackUI\VisualEditorRendererBlade\Support\UrlSanitizer;
+
+	$rawLevel = isset( $attributes['level'] ) ? (int) $attributes['level'] : 1;
+	$level    = max( 0, min( 6, $rawLevel ) );
+	$tag      = 0 === $level ? 'p' : 'h' . $level;
+	$align    = isset( $attributes['textAlign'] ) && is_string( $attributes['textAlign'] ) ? $attributes['textAlign'] : '';
+	$isLink   = ! isset( $attributes['isLink'] ) || ! empty( $attributes['isLink'] );
+	$linkTarget = isset( $attributes['linkTarget'] ) && is_string( $attributes['linkTarget'] ) ? $attributes['linkTarget'] : '_self';
+
+	$title   = isset( $attributes['_resolvedSiteTitle'] ) && is_string( $attributes['_resolvedSiteTitle'] ) ? $attributes['_resolvedSiteTitle'] : '';
+	$siteUrl = UrlSanitizer::safe( isset( $attributes['_resolvedSiteUrl'] ) && is_string( $attributes['_resolvedSiteUrl'] ) ? $attributes['_resolvedSiteUrl'] : '' );
+
+	$classes = [ 'wp-block-site-title' ];
+
+	if ( '' !== $align ) {
+		$classes[] = 'has-text-align-' . $align;
+	}
+
+	if ( ! empty( $attributes['className'] ) && is_string( $attributes['className'] ) ) {
+		$classes[] = $attributes['className'];
+	}
+@endphp
+<{{ $tag }} class="{{ implode( ' ', array_map( 'trim', $classes ) ) }}">@if ( $isLink && '' !== $siteUrl )<a href="{{ $siteUrl }}" target="{{ $linkTarget }}" rel="{{ '_blank' === $linkTarget ? 'noopener noreferrer' : 'home' }}">{{ $title }}</a>@else{{ $title }}@endif</{{ $tag }}>

--- a/packages/visual-editor-renderer-blade/tests/Feature/PostAndSiteContextRenderingTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Feature/PostAndSiteContextRenderingTest.php
@@ -1,0 +1,270 @@
+<?php
+
+declare( strict_types=1 );
+
+use Illuminate\Support\Facades\Blade;
+
+function renderTree( array $tree ): string
+{
+	return Blade::render( '<x-ve-blocks :tree="$tree" />', [ 'tree' => $tree ] );
+}
+
+function blockNode( string $name, array $attributes = [], array $innerBlocks = [], string $clientId = 'cid' ): array
+{
+	return [
+		'clientId'    => $clientId,
+		'name'        => $name,
+		'attributes'  => $attributes,
+		'innerBlocks' => $innerBlocks,
+	];
+}
+
+it( 'renders a post-title block at the configured level', function () {
+	$tree = [
+		blockNode( 'core/post-title', [
+			'level'           => 3,
+			'_resolvedTitle'  => 'Hello World',
+		] ),
+	];
+
+	$rendered = $this->stripGlobalStyles( renderTree( $tree ) );
+
+	expect( $this->normalizeHtml( $rendered ) )->toContain( '<h3 class="wp-block-post-title">Hello World</h3>' );
+} );
+
+it( 'wraps the post-title in a permalink when isLink is true', function () {
+	$tree = [
+		blockNode( 'core/post-title', [
+			'isLink'              => true,
+			'_resolvedTitle'      => 'Linked Title',
+			'_resolvedPermalink'  => 'https://example.test/post',
+		] ),
+	];
+
+	$rendered = $this->stripGlobalStyles( renderTree( $tree ) );
+
+	expect( $rendered )->toContain( '<a href="https://example.test/post">Linked Title</a>' );
+} );
+
+it( 'renders post-content with the resolved HTML body', function () {
+	$tree = [
+		blockNode( 'core/post-content', [
+			'_resolvedContent' => '<p>Body</p>',
+		] ),
+	];
+
+	$rendered = $this->stripGlobalStyles( renderTree( $tree ) );
+
+	expect( $this->normalizeHtml( $rendered ) )->toContain( '<div class="entry-content wp-block-post-content"><p>Body</p></div>' );
+} );
+
+it( 'renders post-excerpt with a more-text link', function () {
+	$tree = [
+		blockNode( 'core/post-excerpt', [
+			'moreText'           => 'Read more',
+			'_resolvedExcerpt'   => 'A short excerpt',
+			'_resolvedPermalink' => 'https://example.test/post',
+		] ),
+	];
+
+	$rendered = $this->stripGlobalStyles( renderTree( $tree ) );
+
+	expect( $rendered )->toContain( 'wp-block-post-excerpt' );
+	expect( $rendered )->toContain( '<a class="wp-block-post-excerpt__more-link" href="https://example.test/post">Read more</a>' );
+} );
+
+it( 'renders a post-date with a datetime attribute and formatted text', function () {
+	$tree = [
+		blockNode( 'core/post-date', [
+			'_resolvedDate'           => '2026-04-20T12:00:00+00:00',
+			'_resolvedDateFormatted'  => 'April 20, 2026',
+		] ),
+	];
+
+	$rendered = $this->stripGlobalStyles( renderTree( $tree ) );
+
+	expect( $rendered )->toContain( 'datetime="2026-04-20T12:00:00+00:00"' );
+	expect( $rendered )->toContain( 'April 20, 2026' );
+} );
+
+it( 'renders post-author with name, avatar, and bio when shown', function () {
+	$tree = [
+		blockNode( 'core/post-author', [
+			'showAvatar'             => true,
+			'showBio'                => true,
+			'avatarSize'             => 48,
+			'byline'                 => 'Posted by',
+			'_resolvedAuthorName'    => 'Jane Doe',
+			'_resolvedAuthorBio'     => 'Writer.',
+			'_resolvedAuthorAvatar'  => 'https://example.test/avatar.jpg',
+		] ),
+	];
+
+	$rendered = $this->stripGlobalStyles( renderTree( $tree ) );
+
+	expect( $rendered )->toContain( 'wp-block-post-author' );
+	expect( $rendered )->toContain( 'Jane Doe' );
+	expect( $rendered )->toContain( 'Writer.' );
+	expect( $rendered )->toContain( 'src="https://example.test/avatar.jpg"' );
+	expect( $rendered )->toContain( 'Posted by' );
+} );
+
+it( 'renders post-featured-image with link wrapper when isLink is true', function () {
+	$tree = [
+		blockNode( 'core/post-featured-image', [
+			'isLink'                  => true,
+			'_resolvedImageUrl'       => 'https://example.test/featured.jpg',
+			'_resolvedImageAlt'       => 'Featured photo',
+			'_resolvedImageWidth'     => 800,
+			'_resolvedImageHeight'    => 600,
+			'_resolvedPermalink'      => 'https://example.test/post',
+		] ),
+	];
+
+	$rendered = $this->stripGlobalStyles( renderTree( $tree ) );
+
+	expect( $rendered )->toContain( '<figure class="wp-block-post-featured-image">' );
+	expect( $rendered )->toContain( '<a href="https://example.test/post">' );
+	expect( $rendered )->toContain( 'src="https://example.test/featured.jpg"' );
+	expect( $rendered )->toContain( 'alt="Featured photo"' );
+	expect( $rendered )->toContain( 'width="800"' );
+	expect( $rendered )->toContain( 'height="600"' );
+} );
+
+it( 'drops javascript: URLs from post-featured-image hrefs', function () {
+	$tree = [
+		blockNode( 'core/post-featured-image', [
+			'isLink'              => true,
+			'_resolvedImageUrl'   => 'https://example.test/safe.jpg',
+			'_resolvedPermalink'  => 'javascript:alert(1)',
+		] ),
+	];
+
+	$rendered = $this->stripGlobalStyles( renderTree( $tree ) );
+
+	expect( $rendered )->not()->toContain( 'javascript:' );
+	expect( $rendered )->not()->toContain( '<a ' );
+} );
+
+it( 'renders site-title with default link to site URL', function () {
+	$tree = [
+		blockNode( 'core/site-title', [
+			'level'                => 1,
+			'_resolvedSiteTitle'   => 'Acme',
+			'_resolvedSiteUrl'     => 'https://example.test',
+		] ),
+	];
+
+	$rendered = $this->stripGlobalStyles( renderTree( $tree ) );
+
+	expect( $rendered )->toContain( '<h1 class="wp-block-site-title">' );
+	expect( $rendered )->toContain( '<a href="https://example.test"' );
+	expect( $rendered )->toContain( 'rel="home"' );
+	expect( $rendered )->toContain( 'Acme' );
+} );
+
+it( 'renders site-title as a paragraph when level is 0', function () {
+	$tree = [
+		blockNode( 'core/site-title', [
+			'level'              => 0,
+			'isLink'             => false,
+			'_resolvedSiteTitle' => 'Acme',
+		] ),
+	];
+
+	$rendered = $this->stripGlobalStyles( renderTree( $tree ) );
+
+	expect( $this->normalizeHtml( $rendered ) )->toContain( '<p class="wp-block-site-title">Acme</p>' );
+} );
+
+it( 'renders site-tagline', function () {
+	$tree = [
+		blockNode( 'core/site-tagline', [
+			'_resolvedSiteTagline' => 'A small site',
+		] ),
+	];
+
+	$rendered = $this->stripGlobalStyles( renderTree( $tree ) );
+
+	expect( $this->normalizeHtml( $rendered ) )->toContain( '<p class="wp-block-site-tagline">A small site</p>' );
+} );
+
+it( 'renders site-logo with link wrapper and image', function () {
+	$tree = [
+		blockNode( 'core/site-logo', [
+			'width'              => 120,
+			'_resolvedLogoUrl'   => 'https://example.test/logo.svg',
+			'_resolvedSiteUrl'   => 'https://example.test',
+			'_resolvedSiteTitle' => 'Acme',
+		] ),
+	];
+
+	$rendered = $this->stripGlobalStyles( renderTree( $tree ) );
+
+	expect( $rendered )->toContain( 'wp-block-site-logo' );
+	expect( $rendered )->not()->toContain( 'is-default-size' );
+	expect( $rendered )->toContain( '<a href="https://example.test"' );
+	expect( $rendered )->toContain( 'class="custom-logo-link"' );
+	expect( $rendered )->toContain( 'src="https://example.test/logo.svg"' );
+	expect( $rendered )->toContain( 'width="120"' );
+} );
+
+it( 'adds is-default-size to site-logo when no width is set', function () {
+	$tree = [
+		blockNode( 'core/site-logo', [
+			'_resolvedLogoUrl'   => 'https://example.test/logo.svg',
+			'_resolvedSiteUrl'   => 'https://example.test',
+			'_resolvedSiteTitle' => 'Acme',
+		] ),
+	];
+
+	$rendered = $this->stripGlobalStyles( renderTree( $tree ) );
+
+	expect( $rendered )->toContain( 'is-default-size' );
+} );
+
+it( 'renders a navigation block with menu items', function () {
+	$tree = [
+		blockNode( 'core/navigation', [ 'ariaLabel' => 'Primary' ], [
+			blockNode( 'core/navigation-link', [
+				'label' => 'About',
+				'url'   => 'https://example.test/about',
+			], [], 'nl-1' ),
+			blockNode( 'core/navigation-submenu', [
+				'label' => 'More',
+				'url'   => 'https://example.test/more',
+			], [
+				blockNode( 'core/navigation-link', [
+					'label' => 'Sub',
+					'url'   => 'https://example.test/sub',
+				], [], 'nl-sub' ),
+			], 'sub-1' ),
+		] ),
+	];
+
+	$rendered = $this->stripGlobalStyles( renderTree( $tree ) );
+
+	expect( $rendered )->toContain( '<nav class="wp-block-navigation is-horizontal is-responsive"' );
+	expect( $rendered )->toContain( 'aria-label="Primary"' );
+	expect( $rendered )->toContain( '<ul class="wp-block-navigation__container">' );
+	expect( $rendered )->toContain( 'href="https://example.test/about"' );
+	expect( $rendered )->toContain( 'wp-block-navigation-submenu has-child' );
+	expect( $rendered )->toContain( 'href="https://example.test/sub"' );
+} );
+
+it( 'forces noopener when a navigation link opens in a new tab', function () {
+	$tree = [
+		blockNode( 'core/navigation', [], [
+			blockNode( 'core/navigation-link', [
+				'label'         => 'External',
+				'url'           => 'https://example.com',
+				'opensInNewTab' => true,
+			], [], 'nl-1' ),
+		] ),
+	];
+
+	$rendered = $this->stripGlobalStyles( renderTree( $tree ) );
+
+	expect( $rendered )->toContain( 'target="_blank"' );
+	expect( $rendered )->toContain( 'rel="noopener noreferrer"' );
+} );

--- a/packages/visual-editor-renderer-react/src/blocks/core/navigation.tsx
+++ b/packages/visual-editor-renderer-react/src/blocks/core/navigation.tsx
@@ -1,0 +1,115 @@
+/**
+ * `core/navigation`, `core/navigation-link`, and `core/navigation-submenu`
+ * renderers. The container block lays its inner blocks out as the menu
+ * `<ul>` so menu trees authored in the site editor render server- and
+ * client-side with the same structure.
+ */
+
+import { attrBoolean, attrString, classList } from '../../support/attributes';
+import { safeUrl } from '../../support/urlSanitizer';
+import type { BlockRendererProps } from '../../types';
+
+export function NavigationBlock({ attributes, children }: BlockRendererProps): JSX.Element {
+    const orientation = attrString(attributes.orientation, 'horizontal');
+    const itemsJustify = attrString(attributes.itemsJustification);
+    const overlayMenu = attrString(attributes.overlayMenu, 'mobile');
+    const ariaLabel = attrString(attributes.ariaLabel);
+    const className = attrString(attributes.className);
+
+    const classes = classList([
+        'wp-block-navigation',
+        orientation === 'vertical' ? 'is-vertical' : null,
+        orientation === 'horizontal' ? 'is-horizontal' : null,
+        itemsJustify !== '' ? `items-justified-${itemsJustify}` : null,
+        overlayMenu !== 'never' ? 'is-responsive' : null,
+        className,
+    ]);
+
+    const navProps: Record<string, string> = { className: classes };
+
+    if (ariaLabel !== '') {
+        navProps['aria-label'] = ariaLabel;
+    }
+
+    return (
+        <nav {...navProps}>
+            <ul className="wp-block-navigation__container">{children}</ul>
+        </nav>
+    );
+}
+
+function buildNavLinkProps(
+    url: string,
+    opensInNewTab: boolean,
+    rel: string
+): Record<string, string> {
+    const props: Record<string, string> = { className: 'wp-block-navigation-item__content' };
+
+    if (url !== '') {
+        props.href = url;
+    }
+
+    if (opensInNewTab) {
+        props.target = '_blank';
+        props.rel = `noopener noreferrer${rel === '' ? '' : ` ${rel}`}`.trim();
+    } else if (rel !== '') {
+        props.rel = rel;
+    }
+
+    return props;
+}
+
+export function NavigationLinkBlock({ attributes }: BlockRendererProps): JSX.Element {
+    const label = attrString(attributes.label);
+    const url = safeUrl(attrString(attributes.url));
+    const opensInNewTab = attrBoolean(attributes.opensInNewTab);
+    const rel = attrString(attributes.rel);
+    const title = attrString(attributes.title);
+    const description = attrString(attributes.description);
+    const className = attrString(attributes.className);
+
+    const classes = classList(['wp-block-navigation-item', 'wp-block-navigation-link', className]);
+
+    const linkProps = buildNavLinkProps(url, opensInNewTab, rel);
+
+    if (title !== '') {
+        linkProps.title = title;
+    }
+
+    return (
+        <li className={classes}>
+            <a {...linkProps}>
+                <span className="wp-block-navigation-item__label">{label}</span>
+                {description !== '' ? (
+                    <span className="wp-block-navigation-item__description">{description}</span>
+                ) : null}
+            </a>
+        </li>
+    );
+}
+
+export function NavigationSubmenuBlock({ attributes, children }: BlockRendererProps): JSX.Element {
+    const label = attrString(attributes.label);
+    const url = safeUrl(attrString(attributes.url));
+    const opensInNewTab = attrBoolean(attributes.opensInNewTab);
+    const rel = attrString(attributes.rel);
+    const className = attrString(attributes.className);
+
+    const classes = classList([
+        'wp-block-navigation-item',
+        'wp-block-navigation-submenu',
+        'has-child',
+        className,
+    ]);
+
+    const linkProps = buildNavLinkProps(url, opensInNewTab, rel);
+
+    return (
+        <li className={classes}>
+            <a {...linkProps}>
+                <span className="wp-block-navigation-item__label">{label}</span>
+            </a>
+            <ul className="wp-block-navigation__submenu-container">{children}</ul>
+        </li>
+    );
+}

--- a/packages/visual-editor-renderer-react/src/blocks/core/postContext.tsx
+++ b/packages/visual-editor-renderer-react/src/blocks/core/postContext.tsx
@@ -1,0 +1,275 @@
+/**
+ * Post-context core block renderers: post-title, post-content, post-excerpt,
+ * post-date, post-author, post-featured-image. Each block reads the actual
+ * post data from `_resolved*` attributes that a host-side resolver stamps
+ * onto the block tree before rendering — the renderer itself never reaches
+ * out to a data store, so it stays pure and identical to the Blade and Vue
+ * counterparts.
+ *
+ * When a `_resolved*` attribute is missing the block emits a Gutenberg-shaped
+ * empty shell (correct wrapper, classes, aria) so the editor preview and the
+ * front-end render structure agree even before a resolver is wired up.
+ */
+
+import { attrBoolean, attrInt, attrString, classList } from '../../support/attributes';
+import { safeUrl } from '../../support/urlSanitizer';
+import type { BlockRendererProps } from '../../types';
+
+function buildLinkProps(
+    href: string,
+    linkTarget: string,
+    rel: string,
+    linkClass = ''
+): Record<string, string> {
+    const props: Record<string, string> = { href };
+
+    if (linkClass !== '') {
+        props.className = linkClass;
+    }
+
+    if (linkTarget === '_blank') {
+        props.target = '_blank';
+        props.rel = `noopener noreferrer${rel === '' ? '' : ` ${rel}`}`.trim();
+    } else if (rel !== '') {
+        props.rel = rel;
+    }
+
+    return props;
+}
+
+export function PostTitleBlock({ attributes }: BlockRendererProps): JSX.Element {
+    const rawLevel = attrInt(attributes.level, 2);
+    const level = Math.max(1, Math.min(6, rawLevel));
+    const align = attrString(attributes.textAlign);
+    const isLink = attrBoolean(attributes.isLink);
+    const linkTarget = attrString(attributes.linkTarget);
+    const rel = attrString(attributes.rel);
+    const linkClass = attrString(attributes.linkClass);
+    const className = attrString(attributes.className);
+
+    const title = attrString(attributes._resolvedTitle);
+    const permalink = safeUrl(attrString(attributes._resolvedPermalink));
+
+    const Tag = `h${level}` as 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+
+    const classes = classList([
+        'wp-block-post-title',
+        align !== '' ? `has-text-align-${align}` : null,
+        className,
+    ]);
+
+    if (isLink && permalink !== '') {
+        const linkProps = buildLinkProps(permalink, linkTarget, rel, linkClass);
+
+        return (
+            <Tag className={classes}>
+                <a {...linkProps} dangerouslySetInnerHTML={{ __html: title }} />
+            </Tag>
+        );
+    }
+
+    return <Tag className={classes} dangerouslySetInnerHTML={{ __html: title }} />;
+}
+
+export function PostContentBlock({ attributes }: BlockRendererProps): JSX.Element {
+    const align = attrString(attributes.textAlign);
+    const className = attrString(attributes.className);
+    const content = attrString(attributes._resolvedContent);
+
+    const classes = classList([
+        'entry-content',
+        'wp-block-post-content',
+        align !== '' ? `has-text-align-${align}` : null,
+        className,
+    ]);
+
+    return <div className={classes} dangerouslySetInnerHTML={{ __html: content }} />;
+}
+
+export function PostExcerptBlock({ attributes }: BlockRendererProps): JSX.Element {
+    const align = attrString(attributes.textAlign);
+    const moreText = attrString(attributes.moreText);
+    const showMoreOnNewLine = attrBoolean(attributes.showMoreOnNewLine, true);
+    const className = attrString(attributes.className);
+
+    const excerpt = attrString(attributes._resolvedExcerpt);
+    const permalink = safeUrl(attrString(attributes._resolvedPermalink));
+
+    const classes = classList([
+        'wp-block-post-excerpt',
+        align !== '' ? `has-text-align-${align}` : null,
+        className,
+    ]);
+
+    const moreNode = (() => {
+        if (moreText === '') {
+            return null;
+        }
+
+        if (permalink !== '') {
+            return (
+                <a className="wp-block-post-excerpt__more-link" href={permalink}>
+                    {moreText}
+                </a>
+            );
+        }
+
+        return <span className="wp-block-post-excerpt__more-text">{moreText}</span>;
+    })();
+
+    return (
+        <div className={classes}>
+            <p className="wp-block-post-excerpt__excerpt">
+                <span dangerouslySetInnerHTML={{ __html: excerpt }} />
+                {moreNode !== null && !showMoreOnNewLine ? <> {moreNode}</> : null}
+            </p>
+            {moreNode !== null && showMoreOnNewLine ? (
+                <p className="wp-block-post-excerpt__more-text">{moreNode}</p>
+            ) : null}
+        </div>
+    );
+}
+
+export function PostDateBlock({ attributes }: BlockRendererProps): JSX.Element {
+    const align = attrString(attributes.textAlign);
+    const displayType = attrString(attributes.displayType, 'date') === 'modified' ? 'modified' : 'date';
+    const isLink = attrBoolean(attributes.isLink);
+    const className = attrString(attributes.className);
+
+    const datetime =
+        displayType === 'modified'
+            ? attrString(attributes._resolvedModifiedDate)
+            : attrString(attributes._resolvedDate);
+    const formatted =
+        displayType === 'modified'
+            ? attrString(attributes._resolvedModifiedDateFormatted, datetime)
+            : attrString(attributes._resolvedDateFormatted, datetime);
+    const permalink = safeUrl(attrString(attributes._resolvedPermalink));
+
+    const classes = classList([
+        'wp-block-post-date',
+        align !== '' ? `has-text-align-${align}` : null,
+        className,
+    ]);
+
+    const timeProps: Record<string, string> = {};
+
+    if (datetime !== '') {
+        timeProps.dateTime = datetime;
+    }
+
+    const timeNode = <time {...timeProps}>{formatted}</time>;
+
+    return (
+        <div className={classes}>
+            {isLink && permalink !== '' ? <a href={permalink}>{timeNode}</a> : timeNode}
+        </div>
+    );
+}
+
+export function PostAuthorBlock({ attributes }: BlockRendererProps): JSX.Element {
+    const align = attrString(attributes.textAlign);
+    const showAvatar = attrBoolean(attributes.showAvatar, true);
+    const showBio = attrBoolean(attributes.showBio);
+    const avatarSize = Math.max(1, attrInt(attributes.avatarSize, 24));
+    const byline = attrString(attributes.byline);
+    const isLink = attrBoolean(attributes.isLink);
+    const className = attrString(attributes.className);
+
+    const name = attrString(attributes._resolvedAuthorName);
+    const bio = attrString(attributes._resolvedAuthorBio);
+    const authorUrl = safeUrl(attrString(attributes._resolvedAuthorUrl));
+    const avatarUrl = safeUrl(attrString(attributes._resolvedAuthorAvatar));
+
+    const classes = classList([
+        'wp-block-post-author',
+        align !== '' ? `has-text-align-${align}` : null,
+        className,
+    ]);
+
+    return (
+        <div className={classes}>
+            {showAvatar && avatarUrl !== '' ? (
+                <div className="wp-block-post-author__avatar">
+                    <img alt={name} width={avatarSize} height={avatarSize} src={avatarUrl} />
+                </div>
+            ) : null}
+            <div className="wp-block-post-author__content">
+                {byline !== '' ? <p className="wp-block-post-author__byline">{byline}</p> : null}
+                <p className="wp-block-post-author__name">
+                    {isLink && authorUrl !== '' ? <a href={authorUrl}>{name}</a> : name}
+                </p>
+                {showBio && bio !== '' ? (
+                    <p
+                        className="wp-block-post-author__bio"
+                        dangerouslySetInnerHTML={{ __html: bio }}
+                    />
+                ) : null}
+            </div>
+        </div>
+    );
+}
+
+export function PostFeaturedImageBlock({ attributes }: BlockRendererProps): JSX.Element {
+    const isLink = attrBoolean(attributes.isLink);
+    const linkTarget = attrString(attributes.linkTarget);
+    const rel = attrString(attributes.rel);
+    const aspect = attrString(attributes.aspectRatio);
+    const scale = attrString(attributes.scale);
+    const sizeSlug = attrString(attributes.sizeSlug);
+    const className = attrString(attributes.className);
+
+    const imageUrl = safeUrl(attrString(attributes._resolvedImageUrl));
+    const alt = attrString(attributes._resolvedImageAlt);
+    const width = Math.max(0, attrInt(attributes._resolvedImageWidth));
+    const height = Math.max(0, attrInt(attributes._resolvedImageHeight));
+    const permalink = safeUrl(attrString(attributes._resolvedPermalink));
+
+    const classes = classList([
+        'wp-block-post-featured-image',
+        sizeSlug !== '' ? `size-${sizeSlug}` : null,
+        className,
+    ]);
+
+    if (imageUrl === '') {
+        return <figure className={classes} />;
+    }
+
+    const style: Record<string, string> = {};
+
+    if (aspect !== '') {
+        style.aspectRatio = aspect;
+    }
+
+    if (scale !== '') {
+        style.objectFit = scale;
+    }
+
+    const imgProps: Record<string, unknown> = {
+        src: imageUrl,
+        alt,
+        style: Object.keys(style).length > 0 ? style : undefined,
+    };
+
+    if (width > 0) {
+        imgProps.width = width;
+    }
+
+    if (height > 0) {
+        imgProps.height = height;
+    }
+
+    const img = <img {...(imgProps as JSX.IntrinsicElements['img'])} />;
+
+    if (isLink && permalink !== '') {
+        const linkProps = buildLinkProps(permalink, linkTarget, rel);
+
+        return (
+            <figure className={classes}>
+                <a {...linkProps}>{img}</a>
+            </figure>
+        );
+    }
+
+    return <figure className={classes}>{img}</figure>;
+}

--- a/packages/visual-editor-renderer-react/src/blocks/core/siteContext.tsx
+++ b/packages/visual-editor-renderer-react/src/blocks/core/siteContext.tsx
@@ -1,0 +1,124 @@
+/**
+ * Site-context core block renderers: site-title, site-tagline, site-logo.
+ *
+ * Each block reads the site-level values from `_resolved*` attributes a
+ * host-side resolver stamps onto the block tree. When a value is missing
+ * the renderer emits a Gutenberg-shaped empty shell so the editor preview
+ * and the front-end render structure agree even before a resolver is wired
+ * up.
+ */
+
+import { attrBoolean, attrInt, attrString, classList } from '../../support/attributes';
+import { safeUrl } from '../../support/urlSanitizer';
+import type { BlockRendererProps } from '../../types';
+
+const SITE_TITLE_LINK_REL = 'home';
+
+function siteLinkProps(href: string, linkTarget: string): Record<string, string> {
+    return {
+        href,
+        target: linkTarget === '_blank' ? '_blank' : '_self',
+        rel: linkTarget === '_blank' ? 'noopener noreferrer' : SITE_TITLE_LINK_REL,
+    };
+}
+
+export function SiteTitleBlock({ attributes }: BlockRendererProps): JSX.Element {
+    const rawLevel = attrInt(attributes.level, 1);
+    const level = Math.max(0, Math.min(6, rawLevel));
+    const align = attrString(attributes.textAlign);
+    const isLink = attrBoolean(attributes.isLink, true);
+    const linkTarget = attrString(attributes.linkTarget, '_self');
+    const className = attrString(attributes.className);
+
+    const title = attrString(attributes._resolvedSiteTitle);
+    const siteUrl = safeUrl(attrString(attributes._resolvedSiteUrl));
+
+    const Tag = (level === 0 ? 'p' : (`h${level}` as 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6')) as
+        | 'p'
+        | 'h1'
+        | 'h2'
+        | 'h3'
+        | 'h4'
+        | 'h5'
+        | 'h6';
+
+    const classes = classList([
+        'wp-block-site-title',
+        align !== '' ? `has-text-align-${align}` : null,
+        className,
+    ]);
+
+    if (isLink && siteUrl !== '') {
+        const linkProps = siteLinkProps(siteUrl, linkTarget);
+
+        return (
+            <Tag className={classes}>
+                <a {...linkProps}>{title}</a>
+            </Tag>
+        );
+    }
+
+    return <Tag className={classes}>{title}</Tag>;
+}
+
+export function SiteTaglineBlock({ attributes }: BlockRendererProps): JSX.Element {
+    const align = attrString(attributes.textAlign);
+    const className = attrString(attributes.className);
+
+    const tagline = attrString(attributes._resolvedSiteTagline);
+
+    const classes = classList([
+        'wp-block-site-tagline',
+        align !== '' ? `has-text-align-${align}` : null,
+        className,
+    ]);
+
+    return <p className={classes}>{tagline}</p>;
+}
+
+export function SiteLogoBlock({ attributes }: BlockRendererProps): JSX.Element {
+    const width = Math.max(0, attrInt(attributes.width));
+    const isLink = attrBoolean(attributes.isLink, true);
+    const linkTarget = attrString(attributes.linkTarget, '_self');
+    const className = attrString(attributes.className);
+
+    const logoUrl = safeUrl(attrString(attributes._resolvedLogoUrl));
+    const siteUrl = safeUrl(attrString(attributes._resolvedSiteUrl));
+    const alt = attrString(attributes._resolvedSiteTitle);
+
+    const classes = classList([
+        'wp-block-site-logo',
+        width <= 0 ? 'is-default-size' : null,
+        className,
+    ]);
+
+    if (logoUrl === '') {
+        return <div className={classes} />;
+    }
+
+    const imgProps: Record<string, unknown> = {
+        src: logoUrl,
+        alt,
+        className: 'custom-logo',
+    };
+
+    if (width > 0) {
+        imgProps.width = width;
+    }
+
+    const img = <img {...(imgProps as JSX.IntrinsicElements['img'])} />;
+
+    if (isLink && siteUrl !== '') {
+        const linkProps = siteLinkProps(siteUrl, linkTarget);
+
+        return (
+            <div className={classes}>
+                <a {...linkProps} className="custom-logo-link">
+                    {img}
+                </a>
+            </div>
+        );
+    }
+
+    return <div className={classes}>{img}</div>;
+}

--- a/packages/visual-editor-renderer-react/src/blocks/registerCoreBlocks.ts
+++ b/packages/visual-editor-renderer-react/src/blocks/registerCoreBlocks.ts
@@ -39,6 +39,20 @@ import {
     ImageBlock,
     VideoBlock,
 } from './core/media';
+import {
+    NavigationBlock,
+    NavigationLinkBlock,
+    NavigationSubmenuBlock,
+} from './core/navigation';
+import {
+    PostAuthorBlock,
+    PostContentBlock,
+    PostDateBlock,
+    PostExcerptBlock,
+    PostFeaturedImageBlock,
+    PostTitleBlock,
+} from './core/postContext';
+import { SiteLogoBlock, SiteTaglineBlock, SiteTitleBlock } from './core/siteContext';
 import { SyncedPatternBlock } from './core/syncedPattern';
 import { TemplatePartBlock } from './core/templatePart';
 import {
@@ -86,6 +100,18 @@ const CORE_BLOCKS: Record<string, BlockRenderer> = {
     'core/spacer': SpacerBlock,
     'core/template-part': TemplatePartBlock,
     'core/block': SyncedPatternBlock,
+    'core/post-title': PostTitleBlock,
+    'core/post-content': PostContentBlock,
+    'core/post-excerpt': PostExcerptBlock,
+    'core/post-date': PostDateBlock,
+    'core/post-author': PostAuthorBlock,
+    'core/post-featured-image': PostFeaturedImageBlock,
+    'core/site-title': SiteTitleBlock,
+    'core/site-tagline': SiteTaglineBlock,
+    'core/site-logo': SiteLogoBlock,
+    'core/navigation': NavigationBlock,
+    'core/navigation-link': NavigationLinkBlock,
+    'core/navigation-submenu': NavigationSubmenuBlock,
     'artisanpack/callout': CalloutBlock,
 };
 

--- a/packages/visual-editor-renderer-react/tests/PostAndSiteContextRendering.test.tsx
+++ b/packages/visual-editor-renderer-react/tests/PostAndSiteContextRendering.test.tsx
@@ -1,0 +1,321 @@
+import { render } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import '../src/index';
+import { BlockTree } from '../src/BlockTree';
+import { resetBlockRegistry } from '../src/registry';
+import { registerCoreBlocks } from '../src/blocks/registerCoreBlocks';
+import { makeBlock, normalizeHtml } from './helpers';
+
+function renderTree(tree: unknown): string {
+    const { container } = render(
+        <BlockTree tree={tree as Parameters<typeof BlockTree>[0]['tree']} />
+    );
+
+    return normalizeHtml(container.innerHTML);
+}
+
+afterEach(() => {
+    resetBlockRegistry();
+    registerCoreBlocks();
+});
+
+describe('Core post-context blocks', () => {
+    it('renders post-title at the configured level', () => {
+        const tree = [
+            makeBlock('core/post-title', { level: 3, _resolvedTitle: 'Hello World' }),
+        ];
+
+        expect(renderTree(tree)).toContain('<h3 class="wp-block-post-title">Hello World</h3>');
+    });
+
+    it('wraps post-title in a permalink when isLink is true', () => {
+        const tree = [
+            makeBlock('core/post-title', {
+                isLink: true,
+                _resolvedTitle: 'Linked',
+                _resolvedPermalink: 'https://example.test/post',
+            }),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('<a href="https://example.test/post">Linked</a>');
+    });
+
+    it('renders post-content with the resolved HTML body', () => {
+        const tree = [makeBlock('core/post-content', { _resolvedContent: '<p>Body</p>' })];
+
+        expect(renderTree(tree)).toBe(
+            '<div class="entry-content wp-block-post-content"><p>Body</p></div>'
+        );
+    });
+
+    it('renders post-excerpt with a more-text link', () => {
+        const tree = [
+            makeBlock('core/post-excerpt', {
+                moreText: 'Read more',
+                _resolvedExcerpt: 'A short excerpt',
+                _resolvedPermalink: 'https://example.test/post',
+            }),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('class="wp-block-post-excerpt"');
+        expect(html).toContain(
+            '<a class="wp-block-post-excerpt__more-link" href="https://example.test/post">Read more</a>'
+        );
+    });
+
+    it('renders post-date with datetime + formatted text', () => {
+        const tree = [
+            makeBlock('core/post-date', {
+                _resolvedDate: '2026-04-20T12:00:00+00:00',
+                _resolvedDateFormatted: 'April 20, 2026',
+            }),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('datetime="2026-04-20T12:00:00+00:00"');
+        expect(html).toContain('April 20, 2026');
+    });
+
+    it('uses the modified date when displayType=modified', () => {
+        const tree = [
+            makeBlock('core/post-date', {
+                displayType: 'modified',
+                _resolvedDate: '2026-01-01T00:00:00+00:00',
+                _resolvedModifiedDate: '2026-04-20T12:00:00+00:00',
+                _resolvedModifiedDateFormatted: 'Updated April 20',
+            }),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('datetime="2026-04-20T12:00:00+00:00"');
+        expect(html).toContain('Updated April 20');
+    });
+
+    it('renders post-author with avatar and bio', () => {
+        const tree = [
+            makeBlock('core/post-author', {
+                showAvatar: true,
+                showBio: true,
+                avatarSize: 48,
+                byline: 'Posted by',
+                _resolvedAuthorName: 'Jane Doe',
+                _resolvedAuthorBio: 'Writer.',
+                _resolvedAuthorAvatar: 'https://example.test/avatar.jpg',
+            }),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('Jane Doe');
+        expect(html).toContain('Writer.');
+        expect(html).toContain('src="https://example.test/avatar.jpg"');
+        expect(html).toContain('Posted by');
+    });
+
+    it('renders post-featured-image with link wrapper', () => {
+        const tree = [
+            makeBlock('core/post-featured-image', {
+                isLink: true,
+                _resolvedImageUrl: 'https://example.test/featured.jpg',
+                _resolvedImageAlt: 'Featured photo',
+                _resolvedImageWidth: 800,
+                _resolvedImageHeight: 600,
+                _resolvedPermalink: 'https://example.test/post',
+            }),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('<figure class="wp-block-post-featured-image">');
+        expect(html).toContain('href="https://example.test/post"');
+        expect(html).toContain('src="https://example.test/featured.jpg"');
+        expect(html).toContain('alt="Featured photo"');
+    });
+
+    it('drops javascript: hrefs from post-featured-image', () => {
+        const tree = [
+            makeBlock('core/post-featured-image', {
+                isLink: true,
+                _resolvedImageUrl: 'https://example.test/safe.jpg',
+                _resolvedPermalink: 'javascript:alert(1)',
+            }),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).not.toContain('javascript:');
+        expect(html).not.toContain('<a ');
+    });
+
+    it('renders an empty post-featured-image figure when no image is resolved', () => {
+        const tree = [makeBlock('core/post-featured-image', {})];
+
+        expect(renderTree(tree)).toBe('<figure class="wp-block-post-featured-image"></figure>');
+    });
+});
+
+describe('Core site-context blocks', () => {
+    it('renders site-title with default link to site URL', () => {
+        const tree = [
+            makeBlock('core/site-title', {
+                level: 1,
+                _resolvedSiteTitle: 'Acme',
+                _resolvedSiteUrl: 'https://example.test',
+            }),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('<h1 class="wp-block-site-title">');
+        expect(html).toContain('href="https://example.test"');
+        expect(html).toContain('rel="home"');
+        expect(html).toContain('Acme');
+    });
+
+    it('renders site-title as a paragraph when level is 0', () => {
+        const tree = [
+            makeBlock('core/site-title', {
+                level: 0,
+                isLink: false,
+                _resolvedSiteTitle: 'Acme',
+            }),
+        ];
+
+        expect(renderTree(tree)).toBe('<p class="wp-block-site-title">Acme</p>');
+    });
+
+    it('renders site-tagline', () => {
+        const tree = [
+            makeBlock('core/site-tagline', { _resolvedSiteTagline: 'A small site' }),
+        ];
+
+        expect(renderTree(tree)).toBe('<p class="wp-block-site-tagline">A small site</p>');
+    });
+
+    it('renders site-logo with link wrapper and width', () => {
+        const tree = [
+            makeBlock('core/site-logo', {
+                width: 120,
+                _resolvedLogoUrl: 'https://example.test/logo.svg',
+                _resolvedSiteUrl: 'https://example.test',
+                _resolvedSiteTitle: 'Acme',
+            }),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('class="wp-block-site-logo"');
+        expect(html).not.toContain('is-default-size');
+        expect(html).toContain('href="https://example.test"');
+        expect(html).toContain('class="custom-logo-link"');
+        expect(html).toContain('src="https://example.test/logo.svg"');
+        expect(html).toContain('width="120"');
+    });
+
+    it('adds is-default-size to site-logo when no width is set', () => {
+        const tree = [
+            makeBlock('core/site-logo', {
+                _resolvedLogoUrl: 'https://example.test/logo.svg',
+                _resolvedSiteUrl: 'https://example.test',
+            }),
+        ];
+
+        expect(renderTree(tree)).toContain('is-default-size');
+    });
+});
+
+describe('Core navigation blocks', () => {
+    it('renders a navigation block with menu items', () => {
+        const tree = [
+            makeBlock(
+                'core/navigation',
+                { ariaLabel: 'Primary' },
+                [
+                    makeBlock(
+                        'core/navigation-link',
+                        { label: 'About', url: 'https://example.test/about' },
+                        [],
+                        'nl-1'
+                    ),
+                    makeBlock(
+                        'core/navigation-submenu',
+                        { label: 'More', url: 'https://example.test/more' },
+                        [
+                            makeBlock(
+                                'core/navigation-link',
+                                { label: 'Sub', url: 'https://example.test/sub' },
+                                [],
+                                'nl-sub'
+                            ),
+                        ],
+                        'sub-1'
+                    ),
+                ]
+            ),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('class="wp-block-navigation is-horizontal is-responsive"');
+        expect(html).toContain('aria-label="Primary"');
+        expect(html).toContain('<ul class="wp-block-navigation__container">');
+        expect(html).toContain('href="https://example.test/about"');
+        expect(html).toContain('wp-block-navigation-submenu');
+        expect(html).toContain('href="https://example.test/sub"');
+    });
+
+    it('forces noopener when a navigation link opens in a new tab', () => {
+        const tree = [
+            makeBlock(
+                'core/navigation',
+                {},
+                [
+                    makeBlock(
+                        'core/navigation-link',
+                        {
+                            label: 'External',
+                            url: 'https://example.com',
+                            opensInNewTab: true,
+                        },
+                        [],
+                        'nl-1'
+                    ),
+                ]
+            ),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('target="_blank"');
+        expect(html).toContain('rel="noopener noreferrer"');
+    });
+
+    it('drops javascript: navigation link URLs', () => {
+        const tree = [
+            makeBlock(
+                'core/navigation',
+                {},
+                [
+                    makeBlock(
+                        'core/navigation-link',
+                        { label: 'Bad', url: 'javascript:alert(1)' },
+                        [],
+                        'nl-1'
+                    ),
+                ]
+            ),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).not.toContain('javascript:');
+        expect(html).not.toContain('href=');
+    });
+});

--- a/packages/visual-editor-renderer-react/tests/registry.test.ts
+++ b/packages/visual-editor-renderer-react/tests/registry.test.ts
@@ -49,6 +49,27 @@ describe('registerBlockRenderer', () => {
         expect(names).toContain('core/separator');
     });
 
+    it('registers every E4 post-, site-, and navigation block', () => {
+        const names = getRegisteredBlockNames();
+
+        for (const block of [
+            'core/post-title',
+            'core/post-content',
+            'core/post-excerpt',
+            'core/post-date',
+            'core/post-author',
+            'core/post-featured-image',
+            'core/site-title',
+            'core/site-tagline',
+            'core/site-logo',
+            'core/navigation',
+            'core/navigation-link',
+            'core/navigation-submenu',
+        ]) {
+            expect(names).toContain(block);
+        }
+    });
+
     it('allows unregistering a renderer', () => {
         registerBlockRenderer('acme/temp', () => null);
         expect(hasBlockRenderer('acme/temp')).toBe(true);

--- a/packages/visual-editor-renderer-vue/src/blocks/core/navigation.ts
+++ b/packages/visual-editor-renderer-vue/src/blocks/core/navigation.ts
@@ -1,0 +1,139 @@
+/**
+ * `core/navigation`, `core/navigation-link`, and `core/navigation-submenu`
+ * renderers. The container block lays its inner blocks out as the menu
+ * `<ul>` so menu trees authored in the site editor render server- and
+ * client-side with the same structure.
+ */
+
+import { defineComponent, h } from 'vue';
+import type { VNode } from 'vue';
+import { attrBoolean, attrString, classList } from '../../support/attributes';
+import { safeUrl } from '../../support/urlSanitizer';
+import { blockRendererProps } from '../shared';
+
+export const NavigationBlock = defineComponent({
+    name: 'NavigationBlock',
+    props: blockRendererProps,
+    setup(props, { slots }) {
+        return () => {
+            const orientation = attrString(props.attributes.orientation, 'horizontal');
+            const itemsJustify = attrString(props.attributes.itemsJustification);
+            const overlayMenu = attrString(props.attributes.overlayMenu, 'mobile');
+            const ariaLabel = attrString(props.attributes.ariaLabel);
+            const className = attrString(props.attributes.className);
+
+            const classes = classList([
+                'wp-block-navigation',
+                orientation === 'vertical' ? 'is-vertical' : null,
+                orientation === 'horizontal' ? 'is-horizontal' : null,
+                itemsJustify !== '' ? `items-justified-${itemsJustify}` : null,
+                overlayMenu !== 'never' ? 'is-responsive' : null,
+                className,
+            ]);
+
+            const navProps: Record<string, string> = { class: classes };
+
+            if (ariaLabel !== '') {
+                navProps['aria-label'] = ariaLabel;
+            }
+
+            const children: VNode[] = slots.default ? (slots.default() as VNode[]) : [];
+
+            return h('nav', navProps, [
+                h('ul', { class: 'wp-block-navigation__container' }, children),
+            ]);
+        };
+    },
+});
+
+function buildNavLinkProps(
+    url: string,
+    opensInNewTab: boolean,
+    rel: string
+): Record<string, string> {
+    const props: Record<string, string> = { class: 'wp-block-navigation-item__content' };
+
+    if (url !== '') {
+        props.href = url;
+    }
+
+    if (opensInNewTab) {
+        props.target = '_blank';
+        props.rel = `noopener noreferrer${rel === '' ? '' : ` ${rel}`}`.trim();
+    } else if (rel !== '') {
+        props.rel = rel;
+    }
+
+    return props;
+}
+
+export const NavigationLinkBlock = defineComponent({
+    name: 'NavigationLinkBlock',
+    props: blockRendererProps,
+    setup(props) {
+        return () => {
+            const label = attrString(props.attributes.label);
+            const url = safeUrl(props.attributes.url);
+            const opensInNewTab = attrBoolean(props.attributes.opensInNewTab);
+            const rel = attrString(props.attributes.rel);
+            const title = attrString(props.attributes.title);
+            const description = attrString(props.attributes.description);
+            const className = attrString(props.attributes.className);
+
+            const classes = classList([
+                'wp-block-navigation-item',
+                'wp-block-navigation-link',
+                className,
+            ]);
+
+            const linkProps = buildNavLinkProps(url, opensInNewTab, rel);
+
+            if (title !== '') {
+                linkProps.title = title;
+            }
+
+            const linkChildren: VNode[] = [
+                h('span', { class: 'wp-block-navigation-item__label' }, label),
+            ];
+
+            if (description !== '') {
+                linkChildren.push(
+                    h('span', { class: 'wp-block-navigation-item__description' }, description)
+                );
+            }
+
+            return h('li', { class: classes }, [h('a', linkProps, linkChildren)]);
+        };
+    },
+});
+
+export const NavigationSubmenuBlock = defineComponent({
+    name: 'NavigationSubmenuBlock',
+    props: blockRendererProps,
+    setup(props, { slots }) {
+        return () => {
+            const label = attrString(props.attributes.label);
+            const url = safeUrl(props.attributes.url);
+            const opensInNewTab = attrBoolean(props.attributes.opensInNewTab);
+            const rel = attrString(props.attributes.rel);
+            const className = attrString(props.attributes.className);
+
+            const classes = classList([
+                'wp-block-navigation-item',
+                'wp-block-navigation-submenu',
+                'has-child',
+                className,
+            ]);
+
+            const linkProps = buildNavLinkProps(url, opensInNewTab, rel);
+            const children: VNode[] = slots.default ? (slots.default() as VNode[]) : [];
+
+            return h('li', { class: classes }, [
+                h('a', linkProps, [
+                    h('span', { class: 'wp-block-navigation-item__label' }, label),
+                ]),
+                h('ul', { class: 'wp-block-navigation__submenu-container' }, children),
+            ]);
+        };
+    },
+});

--- a/packages/visual-editor-renderer-vue/src/blocks/core/postContext.ts
+++ b/packages/visual-editor-renderer-vue/src/blocks/core/postContext.ts
@@ -1,0 +1,327 @@
+/**
+ * Post-context core block renderers: post-title, post-content, post-excerpt,
+ * post-date, post-author, post-featured-image. Each block reads the actual
+ * post data from `_resolved*` attributes that a host-side resolver stamps
+ * onto the block tree before rendering — the renderer itself never reaches
+ * out to a data store, so it stays pure and identical to the Blade and React
+ * counterparts.
+ */
+
+import { defineComponent, h } from 'vue';
+import type { VNode } from 'vue';
+import { attrBoolean, attrInt, attrString, classList } from '../../support/attributes';
+import { safeUrl } from '../../support/urlSanitizer';
+import { blockRendererProps } from '../shared';
+
+function buildLinkProps(
+    href: string,
+    linkTarget: string,
+    rel: string,
+    linkClass = ''
+): Record<string, string> {
+    const props: Record<string, string> = { href };
+
+    if (linkClass !== '') {
+        props.class = linkClass;
+    }
+
+    if (linkTarget === '_blank') {
+        props.target = '_blank';
+        props.rel = `noopener noreferrer${rel === '' ? '' : ` ${rel}`}`.trim();
+    } else if (rel !== '') {
+        props.rel = rel;
+    }
+
+    return props;
+}
+
+export const PostTitleBlock = defineComponent({
+    name: 'PostTitleBlock',
+    props: blockRendererProps,
+    setup(props) {
+        return () => {
+            const rawLevel = attrInt(props.attributes.level, 2);
+            const level = Math.max(1, Math.min(6, rawLevel));
+            const align = attrString(props.attributes.textAlign);
+            const isLink = attrBoolean(props.attributes.isLink);
+            const linkTarget = attrString(props.attributes.linkTarget);
+            const rel = attrString(props.attributes.rel);
+            const linkClass = attrString(props.attributes.linkClass);
+            const className = attrString(props.attributes.className);
+
+            const title = attrString(props.attributes._resolvedTitle);
+            const permalink = safeUrl(props.attributes._resolvedPermalink);
+
+            const tag = `h${level}`;
+
+            const classes = classList([
+                'wp-block-post-title',
+                align !== '' ? `has-text-align-${align}` : null,
+                className,
+            ]);
+
+            if (isLink && permalink !== '') {
+                const linkProps = buildLinkProps(permalink, linkTarget, rel, linkClass);
+
+                return h(tag, { class: classes }, [h('a', { ...linkProps, innerHTML: title })]);
+            }
+
+            return h(tag, { class: classes, innerHTML: title });
+        };
+    },
+});
+
+export const PostContentBlock = defineComponent({
+    name: 'PostContentBlock',
+    props: blockRendererProps,
+    setup(props) {
+        return () => {
+            const align = attrString(props.attributes.textAlign);
+            const className = attrString(props.attributes.className);
+            const content = attrString(props.attributes._resolvedContent);
+
+            const classes = classList([
+                'entry-content',
+                'wp-block-post-content',
+                align !== '' ? `has-text-align-${align}` : null,
+                className,
+            ]);
+
+            return h('div', { class: classes, innerHTML: content });
+        };
+    },
+});
+
+export const PostExcerptBlock = defineComponent({
+    name: 'PostExcerptBlock',
+    props: blockRendererProps,
+    setup(props) {
+        return () => {
+            const align = attrString(props.attributes.textAlign);
+            const moreText = attrString(props.attributes.moreText);
+            const showMoreOnNewLine = attrBoolean(props.attributes.showMoreOnNewLine, true);
+            const className = attrString(props.attributes.className);
+
+            const excerpt = attrString(props.attributes._resolvedExcerpt);
+            const permalink = safeUrl(props.attributes._resolvedPermalink);
+
+            const classes = classList([
+                'wp-block-post-excerpt',
+                align !== '' ? `has-text-align-${align}` : null,
+                className,
+            ]);
+
+            const moreNode: VNode | null = (() => {
+                if (moreText === '') {
+                    return null;
+                }
+
+                if (permalink !== '') {
+                    return h(
+                        'a',
+                        { class: 'wp-block-post-excerpt__more-link', href: permalink },
+                        moreText
+                    );
+                }
+
+                return h('span', { class: 'wp-block-post-excerpt__more-text' }, moreText);
+            })();
+
+            const excerptParaChildren: Array<VNode | string> = [
+                h('span', { innerHTML: excerpt }),
+            ];
+
+            if (moreNode !== null && !showMoreOnNewLine) {
+                excerptParaChildren.push(' ', moreNode);
+            }
+
+            const children: VNode[] = [
+                h('p', { class: 'wp-block-post-excerpt__excerpt' }, excerptParaChildren),
+            ];
+
+            if (moreNode !== null && showMoreOnNewLine) {
+                children.push(h('p', { class: 'wp-block-post-excerpt__more-text' }, [moreNode]));
+            }
+
+            return h('div', { class: classes }, children);
+        };
+    },
+});
+
+export const PostDateBlock = defineComponent({
+    name: 'PostDateBlock',
+    props: blockRendererProps,
+    setup(props) {
+        return () => {
+            const align = attrString(props.attributes.textAlign);
+            const displayType =
+                attrString(props.attributes.displayType, 'date') === 'modified'
+                    ? 'modified'
+                    : 'date';
+            const isLink = attrBoolean(props.attributes.isLink);
+            const className = attrString(props.attributes.className);
+
+            const datetime =
+                displayType === 'modified'
+                    ? attrString(props.attributes._resolvedModifiedDate)
+                    : attrString(props.attributes._resolvedDate);
+            const formatted =
+                displayType === 'modified'
+                    ? attrString(props.attributes._resolvedModifiedDateFormatted, datetime)
+                    : attrString(props.attributes._resolvedDateFormatted, datetime);
+            const permalink = safeUrl(props.attributes._resolvedPermalink);
+
+            const classes = classList([
+                'wp-block-post-date',
+                align !== '' ? `has-text-align-${align}` : null,
+                className,
+            ]);
+
+            const timeProps: Record<string, string> = {};
+
+            if (datetime !== '') {
+                timeProps.datetime = datetime;
+            }
+
+            const timeNode = h('time', timeProps, formatted);
+
+            const inner =
+                isLink && permalink !== '' ? h('a', { href: permalink }, [timeNode]) : timeNode;
+
+            return h('div', { class: classes }, [inner]);
+        };
+    },
+});
+
+export const PostAuthorBlock = defineComponent({
+    name: 'PostAuthorBlock',
+    props: blockRendererProps,
+    setup(props) {
+        return () => {
+            const align = attrString(props.attributes.textAlign);
+            const showAvatar = attrBoolean(props.attributes.showAvatar, true);
+            const showBio = attrBoolean(props.attributes.showBio);
+            const avatarSize = Math.max(1, attrInt(props.attributes.avatarSize, 24));
+            const byline = attrString(props.attributes.byline);
+            const isLink = attrBoolean(props.attributes.isLink);
+            const className = attrString(props.attributes.className);
+
+            const name = attrString(props.attributes._resolvedAuthorName);
+            const bio = attrString(props.attributes._resolvedAuthorBio);
+            const authorUrl = safeUrl(props.attributes._resolvedAuthorUrl);
+            const avatarUrl = safeUrl(props.attributes._resolvedAuthorAvatar);
+
+            const classes = classList([
+                'wp-block-post-author',
+                align !== '' ? `has-text-align-${align}` : null,
+                className,
+            ]);
+
+            const children: VNode[] = [];
+
+            if (showAvatar && avatarUrl !== '') {
+                children.push(
+                    h('div', { class: 'wp-block-post-author__avatar' }, [
+                        h('img', {
+                            alt: name,
+                            width: avatarSize,
+                            height: avatarSize,
+                            src: avatarUrl,
+                        }),
+                    ])
+                );
+            }
+
+            const contentChildren: VNode[] = [];
+
+            if (byline !== '') {
+                contentChildren.push(
+                    h('p', { class: 'wp-block-post-author__byline' }, byline)
+                );
+            }
+
+            const nameNode =
+                isLink && authorUrl !== '' ? h('a', { href: authorUrl }, name) : name;
+
+            contentChildren.push(
+                h('p', { class: 'wp-block-post-author__name' }, [nameNode])
+            );
+
+            if (showBio && bio !== '') {
+                contentChildren.push(
+                    h('p', { class: 'wp-block-post-author__bio', innerHTML: bio })
+                );
+            }
+
+            children.push(h('div', { class: 'wp-block-post-author__content' }, contentChildren));
+
+            return h('div', { class: classes }, children);
+        };
+    },
+});
+
+export const PostFeaturedImageBlock = defineComponent({
+    name: 'PostFeaturedImageBlock',
+    props: blockRendererProps,
+    setup(props) {
+        return () => {
+            const isLink = attrBoolean(props.attributes.isLink);
+            const linkTarget = attrString(props.attributes.linkTarget);
+            const rel = attrString(props.attributes.rel);
+            const aspect = attrString(props.attributes.aspectRatio);
+            const scale = attrString(props.attributes.scale);
+            const sizeSlug = attrString(props.attributes.sizeSlug);
+            const className = attrString(props.attributes.className);
+
+            const imageUrl = safeUrl(props.attributes._resolvedImageUrl);
+            const alt = attrString(props.attributes._resolvedImageAlt);
+            const width = Math.max(0, attrInt(props.attributes._resolvedImageWidth));
+            const height = Math.max(0, attrInt(props.attributes._resolvedImageHeight));
+            const permalink = safeUrl(props.attributes._resolvedPermalink);
+
+            const classes = classList([
+                'wp-block-post-featured-image',
+                sizeSlug !== '' ? `size-${sizeSlug}` : null,
+                className,
+            ]);
+
+            if (imageUrl === '') {
+                return h('figure', { class: classes });
+            }
+
+            const style: Record<string, string> = {};
+
+            if (aspect !== '') {
+                style.aspectRatio = aspect;
+            }
+
+            if (scale !== '') {
+                style.objectFit = scale;
+            }
+
+            const imgProps: Record<string, unknown> = { src: imageUrl, alt };
+
+            if (Object.keys(style).length > 0) {
+                imgProps.style = style;
+            }
+
+            if (width > 0) {
+                imgProps.width = width;
+            }
+
+            if (height > 0) {
+                imgProps.height = height;
+            }
+
+            const img = h('img', imgProps);
+
+            if (isLink && permalink !== '') {
+                const linkProps = buildLinkProps(permalink, linkTarget, rel);
+
+                return h('figure', { class: classes }, [h('a', linkProps, [img])]);
+            }
+
+            return h('figure', { class: classes }, [img]);
+        };
+    },
+});

--- a/packages/visual-editor-renderer-vue/src/blocks/core/siteContext.ts
+++ b/packages/visual-editor-renderer-vue/src/blocks/core/siteContext.ts
@@ -1,0 +1,126 @@
+/**
+ * Site-context core block renderers: site-title, site-tagline, site-logo.
+ *
+ * Each block reads the site-level values from `_resolved*` attributes a
+ * host-side resolver stamps onto the block tree. Mirrors the React + Blade
+ * renderers exactly.
+ */
+
+import { defineComponent, h } from 'vue';
+import { attrBoolean, attrInt, attrString, classList } from '../../support/attributes';
+import { safeUrl } from '../../support/urlSanitizer';
+import { blockRendererProps } from '../shared';
+
+const SITE_TITLE_LINK_REL = 'home';
+
+function siteLinkProps(href: string, linkTarget: string): Record<string, string> {
+    return {
+        href,
+        target: linkTarget === '_blank' ? '_blank' : '_self',
+        rel: linkTarget === '_blank' ? 'noopener noreferrer' : SITE_TITLE_LINK_REL,
+    };
+}
+
+export const SiteTitleBlock = defineComponent({
+    name: 'SiteTitleBlock',
+    props: blockRendererProps,
+    setup(props) {
+        return () => {
+            const rawLevel = attrInt(props.attributes.level, 1);
+            const level = Math.max(0, Math.min(6, rawLevel));
+            const align = attrString(props.attributes.textAlign);
+            const isLink = attrBoolean(props.attributes.isLink, true);
+            const linkTarget = attrString(props.attributes.linkTarget, '_self');
+            const className = attrString(props.attributes.className);
+
+            const title = attrString(props.attributes._resolvedSiteTitle);
+            const siteUrl = safeUrl(props.attributes._resolvedSiteUrl);
+
+            const tag = level === 0 ? 'p' : `h${level}`;
+
+            const classes = classList([
+                'wp-block-site-title',
+                align !== '' ? `has-text-align-${align}` : null,
+                className,
+            ]);
+
+            if (isLink && siteUrl !== '') {
+                const linkProps = siteLinkProps(siteUrl, linkTarget);
+
+                return h(tag, { class: classes }, [h('a', linkProps, title)]);
+            }
+
+            return h(tag, { class: classes }, title);
+        };
+    },
+});
+
+export const SiteTaglineBlock = defineComponent({
+    name: 'SiteTaglineBlock',
+    props: blockRendererProps,
+    setup(props) {
+        return () => {
+            const align = attrString(props.attributes.textAlign);
+            const className = attrString(props.attributes.className);
+
+            const tagline = attrString(props.attributes._resolvedSiteTagline);
+
+            const classes = classList([
+                'wp-block-site-tagline',
+                align !== '' ? `has-text-align-${align}` : null,
+                className,
+            ]);
+
+            return h('p', { class: classes }, tagline);
+        };
+    },
+});
+
+export const SiteLogoBlock = defineComponent({
+    name: 'SiteLogoBlock',
+    props: blockRendererProps,
+    setup(props) {
+        return () => {
+            const width = Math.max(0, attrInt(props.attributes.width));
+            const isLink = attrBoolean(props.attributes.isLink, true);
+            const linkTarget = attrString(props.attributes.linkTarget, '_self');
+            const className = attrString(props.attributes.className);
+
+            const logoUrl = safeUrl(props.attributes._resolvedLogoUrl);
+            const siteUrl = safeUrl(props.attributes._resolvedSiteUrl);
+            const alt = attrString(props.attributes._resolvedSiteTitle);
+
+            const classes = classList([
+                'wp-block-site-logo',
+                width <= 0 ? 'is-default-size' : null,
+                className,
+            ]);
+
+            if (logoUrl === '') {
+                return h('div', { class: classes });
+            }
+
+            const imgProps: Record<string, unknown> = {
+                src: logoUrl,
+                alt,
+                class: 'custom-logo',
+            };
+
+            if (width > 0) {
+                imgProps.width = width;
+            }
+
+            const img = h('img', imgProps);
+
+            if (isLink && siteUrl !== '') {
+                const linkProps = siteLinkProps(siteUrl, linkTarget);
+
+                return h('div', { class: classes }, [
+                    h('a', { ...linkProps, class: 'custom-logo-link' }, [img]),
+                ]);
+            }
+
+            return h('div', { class: classes }, [img]);
+        };
+    },
+});

--- a/packages/visual-editor-renderer-vue/src/blocks/registerCoreBlocks.ts
+++ b/packages/visual-editor-renderer-vue/src/blocks/registerCoreBlocks.ts
@@ -39,6 +39,20 @@ import {
     ImageBlock,
     VideoBlock,
 } from './core/media';
+import {
+    NavigationBlock,
+    NavigationLinkBlock,
+    NavigationSubmenuBlock,
+} from './core/navigation';
+import {
+    PostAuthorBlock,
+    PostContentBlock,
+    PostDateBlock,
+    PostExcerptBlock,
+    PostFeaturedImageBlock,
+    PostTitleBlock,
+} from './core/postContext';
+import { SiteLogoBlock, SiteTaglineBlock, SiteTitleBlock } from './core/siteContext';
 import { SyncedPatternBlock } from './core/syncedPattern';
 import { TemplatePartBlock } from './core/templatePart';
 import {
@@ -86,6 +100,18 @@ const CORE_BLOCKS: Record<string, BlockRenderer> = {
     'core/spacer': SpacerBlock,
     'core/template-part': TemplatePartBlock,
     'core/block': SyncedPatternBlock,
+    'core/post-title': PostTitleBlock,
+    'core/post-content': PostContentBlock,
+    'core/post-excerpt': PostExcerptBlock,
+    'core/post-date': PostDateBlock,
+    'core/post-author': PostAuthorBlock,
+    'core/post-featured-image': PostFeaturedImageBlock,
+    'core/site-title': SiteTitleBlock,
+    'core/site-tagline': SiteTaglineBlock,
+    'core/site-logo': SiteLogoBlock,
+    'core/navigation': NavigationBlock,
+    'core/navigation-link': NavigationLinkBlock,
+    'core/navigation-submenu': NavigationSubmenuBlock,
     'artisanpack/callout': CalloutBlock,
 };
 

--- a/packages/visual-editor-renderer-vue/tests/PostAndSiteContextRendering.test.ts
+++ b/packages/visual-editor-renderer-vue/tests/PostAndSiteContextRendering.test.ts
@@ -1,0 +1,323 @@
+import { mount } from '@vue/test-utils';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import '../src/index';
+import { BlockTree } from '../src/BlockTree';
+import { resetBlockRegistry } from '../src/registry';
+import { registerCoreBlocks } from '../src/blocks/registerCoreBlocks';
+import { makeBlock, normalizeHtml } from './helpers';
+import type { Block } from '../src/types';
+
+function renderTree(tree: unknown): string {
+    const wrapper = mount(BlockTree, {
+        props: {
+            tree: tree as Block[] | string | null | undefined,
+        },
+    });
+
+    return normalizeHtml(wrapper.html());
+}
+
+afterEach(() => {
+    resetBlockRegistry();
+    registerCoreBlocks();
+});
+
+describe('Core post-context blocks (Vue)', () => {
+    it('renders post-title at the configured level', () => {
+        const tree = [makeBlock('core/post-title', { level: 3, _resolvedTitle: 'Hello World' })];
+
+        expect(renderTree(tree)).toContain('<h3 class="wp-block-post-title">Hello World</h3>');
+    });
+
+    it('wraps post-title in a permalink when isLink is true', () => {
+        const tree = [
+            makeBlock('core/post-title', {
+                isLink: true,
+                _resolvedTitle: 'Linked',
+                _resolvedPermalink: 'https://example.test/post',
+            }),
+        ];
+
+        expect(renderTree(tree)).toContain(
+            '<a href="https://example.test/post">Linked</a>'
+        );
+    });
+
+    it('renders post-content with the resolved HTML body', () => {
+        const tree = [makeBlock('core/post-content', { _resolvedContent: '<p>Body</p>' })];
+
+        expect(renderTree(tree)).toBe(
+            '<div class="entry-content wp-block-post-content"><p>Body</p></div>'
+        );
+    });
+
+    it('renders post-excerpt with a more-text link', () => {
+        const tree = [
+            makeBlock('core/post-excerpt', {
+                moreText: 'Read more',
+                _resolvedExcerpt: 'A short excerpt',
+                _resolvedPermalink: 'https://example.test/post',
+            }),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('class="wp-block-post-excerpt"');
+        expect(html).toContain(
+            'class="wp-block-post-excerpt__more-link" href="https://example.test/post"'
+        );
+        expect(html).toContain('Read more');
+    });
+
+    it('renders post-date with datetime + formatted text', () => {
+        const tree = [
+            makeBlock('core/post-date', {
+                _resolvedDate: '2026-04-20T12:00:00+00:00',
+                _resolvedDateFormatted: 'April 20, 2026',
+            }),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('datetime="2026-04-20T12:00:00+00:00"');
+        expect(html).toContain('April 20, 2026');
+    });
+
+    it('uses the modified date when displayType=modified', () => {
+        const tree = [
+            makeBlock('core/post-date', {
+                displayType: 'modified',
+                _resolvedDate: '2026-01-01T00:00:00+00:00',
+                _resolvedModifiedDate: '2026-04-20T12:00:00+00:00',
+                _resolvedModifiedDateFormatted: 'Updated April 20',
+            }),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('datetime="2026-04-20T12:00:00+00:00"');
+        expect(html).toContain('Updated April 20');
+    });
+
+    it('renders post-author with avatar and bio', () => {
+        const tree = [
+            makeBlock('core/post-author', {
+                showAvatar: true,
+                showBio: true,
+                avatarSize: 48,
+                byline: 'Posted by',
+                _resolvedAuthorName: 'Jane Doe',
+                _resolvedAuthorBio: 'Writer.',
+                _resolvedAuthorAvatar: 'https://example.test/avatar.jpg',
+            }),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('Jane Doe');
+        expect(html).toContain('Writer.');
+        expect(html).toContain('src="https://example.test/avatar.jpg"');
+        expect(html).toContain('Posted by');
+    });
+
+    it('renders post-featured-image with link wrapper', () => {
+        const tree = [
+            makeBlock('core/post-featured-image', {
+                isLink: true,
+                _resolvedImageUrl: 'https://example.test/featured.jpg',
+                _resolvedImageAlt: 'Featured photo',
+                _resolvedImageWidth: 800,
+                _resolvedImageHeight: 600,
+                _resolvedPermalink: 'https://example.test/post',
+            }),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('<figure class="wp-block-post-featured-image">');
+        expect(html).toContain('href="https://example.test/post"');
+        expect(html).toContain('src="https://example.test/featured.jpg"');
+        expect(html).toContain('alt="Featured photo"');
+    });
+
+    it('drops javascript: hrefs from post-featured-image', () => {
+        const tree = [
+            makeBlock('core/post-featured-image', {
+                isLink: true,
+                _resolvedImageUrl: 'https://example.test/safe.jpg',
+                _resolvedPermalink: 'javascript:alert(1)',
+            }),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).not.toContain('javascript:');
+        expect(html).not.toContain('<a ');
+    });
+
+    it('renders an empty post-featured-image figure when no image is resolved', () => {
+        const tree = [makeBlock('core/post-featured-image', {})];
+
+        expect(renderTree(tree)).toBe('<figure class="wp-block-post-featured-image"></figure>');
+    });
+});
+
+describe('Core site-context blocks (Vue)', () => {
+    it('renders site-title with default link to site URL', () => {
+        const tree = [
+            makeBlock('core/site-title', {
+                level: 1,
+                _resolvedSiteTitle: 'Acme',
+                _resolvedSiteUrl: 'https://example.test',
+            }),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('<h1 class="wp-block-site-title">');
+        expect(html).toContain('href="https://example.test"');
+        expect(html).toContain('rel="home"');
+        expect(html).toContain('Acme');
+    });
+
+    it('renders site-title as a paragraph when level is 0', () => {
+        const tree = [
+            makeBlock('core/site-title', {
+                level: 0,
+                isLink: false,
+                _resolvedSiteTitle: 'Acme',
+            }),
+        ];
+
+        expect(renderTree(tree)).toBe('<p class="wp-block-site-title">Acme</p>');
+    });
+
+    it('renders site-tagline', () => {
+        const tree = [makeBlock('core/site-tagline', { _resolvedSiteTagline: 'A small site' })];
+
+        expect(renderTree(tree)).toBe(
+            '<p class="wp-block-site-tagline">A small site</p>'
+        );
+    });
+
+    it('renders site-logo with link wrapper and width', () => {
+        const tree = [
+            makeBlock('core/site-logo', {
+                width: 120,
+                _resolvedLogoUrl: 'https://example.test/logo.svg',
+                _resolvedSiteUrl: 'https://example.test',
+                _resolvedSiteTitle: 'Acme',
+            }),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('class="wp-block-site-logo"');
+        expect(html).not.toContain('is-default-size');
+        expect(html).toContain('href="https://example.test"');
+        expect(html).toContain('class="custom-logo-link"');
+        expect(html).toContain('src="https://example.test/logo.svg"');
+        expect(html).toContain('width="120"');
+    });
+
+    it('adds is-default-size to site-logo when no width is set', () => {
+        const tree = [
+            makeBlock('core/site-logo', {
+                _resolvedLogoUrl: 'https://example.test/logo.svg',
+                _resolvedSiteUrl: 'https://example.test',
+            }),
+        ];
+
+        expect(renderTree(tree)).toContain('is-default-size');
+    });
+});
+
+describe('Core navigation blocks (Vue)', () => {
+    it('renders a navigation block with menu items', () => {
+        const tree = [
+            makeBlock(
+                'core/navigation',
+                { ariaLabel: 'Primary' },
+                [
+                    makeBlock(
+                        'core/navigation-link',
+                        { label: 'About', url: 'https://example.test/about' },
+                        [],
+                        'nl-1'
+                    ),
+                    makeBlock(
+                        'core/navigation-submenu',
+                        { label: 'More', url: 'https://example.test/more' },
+                        [
+                            makeBlock(
+                                'core/navigation-link',
+                                { label: 'Sub', url: 'https://example.test/sub' },
+                                [],
+                                'nl-sub'
+                            ),
+                        ],
+                        'sub-1'
+                    ),
+                ]
+            ),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('class="wp-block-navigation is-horizontal is-responsive"');
+        expect(html).toContain('aria-label="Primary"');
+        expect(html).toContain('<ul class="wp-block-navigation__container">');
+        expect(html).toContain('href="https://example.test/about"');
+        expect(html).toContain('wp-block-navigation-submenu');
+        expect(html).toContain('href="https://example.test/sub"');
+    });
+
+    it('forces noopener when a navigation link opens in a new tab', () => {
+        const tree = [
+            makeBlock(
+                'core/navigation',
+                {},
+                [
+                    makeBlock(
+                        'core/navigation-link',
+                        {
+                            label: 'External',
+                            url: 'https://example.com',
+                            opensInNewTab: true,
+                        },
+                        [],
+                        'nl-1'
+                    ),
+                ]
+            ),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('target="_blank"');
+        expect(html).toContain('rel="noopener noreferrer"');
+    });
+
+    it('drops javascript: navigation link URLs', () => {
+        const tree = [
+            makeBlock(
+                'core/navigation',
+                {},
+                [
+                    makeBlock(
+                        'core/navigation-link',
+                        { label: 'Bad', url: 'javascript:alert(1)' },
+                        [],
+                        'nl-1'
+                    ),
+                ]
+            ),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).not.toContain('javascript:');
+        expect(html).not.toContain('href=');
+    });
+});

--- a/packages/visual-editor-renderer-vue/tests/registry.test.ts
+++ b/packages/visual-editor-renderer-vue/tests/registry.test.ts
@@ -63,6 +63,27 @@ describe('registerBlockRenderer', () => {
         expect(names).toContain('core/separator');
     });
 
+    it('registers every E4 post-, site-, and navigation block', () => {
+        const names = getRegisteredBlockNames();
+
+        for (const block of [
+            'core/post-title',
+            'core/post-content',
+            'core/post-excerpt',
+            'core/post-date',
+            'core/post-author',
+            'core/post-featured-image',
+            'core/site-title',
+            'core/site-tagline',
+            'core/site-logo',
+            'core/navigation',
+            'core/navigation-link',
+            'core/navigation-submenu',
+        ]) {
+            expect(names).toContain(block);
+        }
+    });
+
     it('allows unregistering a renderer', () => {
         registerBlockRenderer('acme/temp', noopRenderer);
         expect(hasBlockRenderer('acme/temp')).toBe(true);

--- a/resources/js/visual-editor/site-editor/site-editor-app.tsx
+++ b/resources/js/visual-editor/site-editor/site-editor-app.tsx
@@ -120,33 +120,22 @@ export interface SiteEditorAppProps {
 let editorBooted = false;
 
 /**
- * Core blocks the site-editor deliberately leaves unregistered for D2.
- * Per issue #369's out-of-scope list, these entity-scoped blocks wait
- * until E4 — their `Edit` components depend on core-data selectors
- * (`getCurrentTheme`, `getEditedPostType`, etc.) that the B1 shim does
- * not yet implement, so rendering them under D2 trips the block-crash
- * boundary and leaves users staring at red error cards inside seeded
- * templates.
+ * Core blocks the site-editor deliberately leaves unregistered.
+ *
+ * D2 originally disabled the entity-scoped post-/site-/template-part
+ * blocks alongside the loop + feed widgets because their `Edit`
+ * components depended on core-data selectors the M2 shim did not
+ * implement. E4 re-enables every entity-scoped block on the back of
+ * B1's expanded shim plus the C1–C5 REST surface; the loop and feed
+ * widgets stay disabled because they still need a real loop runtime
+ * (V2) and term/comment endpoints (V1.1+) that the shim does not
+ * implement.
  *
  * Mirrors the PHP `disabled_blocks` list in
- * `config/visual-editor.php` — the two lists want to agree, and E4 will
- * be the single commit that removes blocks from both sides.
+ * `config/visual-editor.php` — the two lists want to agree, and the
+ * commit that promotes a block out of one promotes it out of the other.
  */
 const D2_DISABLED_BLOCKS: ReadonlyArray<string> = [
-    'core/template-part',
-    'core/post-content',
-    'core/post-title',
-    'core/post-excerpt',
-    'core/post-date',
-    'core/post-author',
-    'core/post-featured-image',
-    'core/site-logo',
-    'core/site-title',
-    'core/site-tagline',
-    // `core/navigation` is now D4-enabled. The block can render in the
-    // template canvas because B1's shim has `wp_navigation` and C4's
-    // REST surface round-trips its inner blocks. Keep it OUT of this
-    // list so the template editor's inserter exposes it.
     'core/query',
     'core/query-loop',
     'core/latest-comments',

--- a/resources/js/visual-editor/vendor/__tests__/core-data-shim.test.tsx
+++ b/resources/js/visual-editor/vendor/__tests__/core-data-shim.test.tsx
@@ -180,6 +180,28 @@ describe('core-data-shim record cache', () => {
         expect(coreSelect().getUsers()).toEqual([]);
     });
 
+    it('returns a synthetic theme record for getCurrentTheme', () => {
+        const theme = coreSelect().getCurrentTheme();
+
+        expect(theme).toMatchObject({
+            stylesheet: 'artisanpack-base',
+            template: 'artisanpack-base',
+            is_block_theme: true,
+        });
+    });
+
+    it('returns null from getPostType to keep post-* edit components quiet', () => {
+        expect(coreSelect().getPostType('post')).toBeNull();
+    });
+
+    it('returns an empty themeSupports object', () => {
+        expect(coreSelect().getThemeSupports()).toEqual({});
+    });
+
+    it('exposes getNavigationFallbackId as a no-op selector', () => {
+        expect(coreSelect().getNavigationFallbackId()).toBeUndefined();
+    });
+
     it('reports resolution as finished and not in-flight by default', () => {
         expect(
             coreSelect().hasFinishedResolution('getEntityRecord', [

--- a/resources/js/visual-editor/vendor/core-data-shim.ts
+++ b/resources/js/visual-editor/vendor/core-data-shim.ts
@@ -274,6 +274,15 @@ export function __resetCoreDataShimConfig(): void {
 const STORE_NAME = 'core';
 const EMPTY_RECORDS: readonly never[] = Object.freeze([]);
 
+const CURRENT_THEME_STUB: EntityRecord = Object.freeze({
+    stylesheet: 'artisanpack-base',
+    template: 'artisanpack-base',
+    name: 'ArtisanPack Base',
+    is_block_theme: true,
+});
+
+const EMPTY_THEME_SUPPORTS: EntityRecord = Object.freeze({});
+
 function entityKey(kind: EntityKind, name: EntityName): string {
     return `${kind}|${name}`;
 }
@@ -952,6 +961,30 @@ const selectors = {
     getAutosaves: (): readonly EntityRecord[] => EMPTY_RECORDS,
     getAutosave: (): EntityRecord | null => null,
     getReferenceByDistinctEdits: (): readonly number[] => EMPTY_RECORDS,
+
+    // E4 stubs — synthetic theme + post-type records returned to the
+    // template-part / post-* / site-* edit components so their
+    // `select(coreStore).getCurrentTheme()` / `getPostType()` calls
+    // don't throw against the empty-state shim. The theme value
+    // matches `config('artisanpack.visual-editor.global_styles.theme')`'s
+    // default ('artisanpack-base'); Phase C of cms-framework will
+    // replace these with a real backend that resolves the active
+    // theme and full post-type schema.
+    getCurrentTheme: (): EntityRecord => CURRENT_THEME_STUB,
+    getThemeSupports: (): EntityRecord => EMPTY_THEME_SUPPORTS,
+    getPostType: (): EntityRecord | null => null,
+
+    // Upstream `@wordpress/core-data` registers this as a private
+    // selector, so `core/navigation`'s edit reaches it through
+    // `unlock( useSelect( coreStore ) )`. `@wordpress/data` locks the
+    // store's selectors object with a merged public+private map; when
+    // we never register any private selectors that merged map is just
+    // the public selectors. Exposing it here lets the unlock call fall
+    // through to a no-op without us depending on `@wordpress/private-apis`
+    // (whose lock/unlock symbol identity is fragile across module
+    // copies in a mixed `node_modules` tree). Returning `undefined`
+    // routes the block to its uncontrolled-inner-blocks fallback path.
+    getNavigationFallbackId: (): EntityKey | undefined => undefined,
 };
 
 // ---------------------------------------------------------------------------

--- a/tests/Unit/VisualEditor/EnabledBlockNamesTest.php
+++ b/tests/Unit/VisualEditor/EnabledBlockNamesTest.php
@@ -7,11 +7,14 @@ use ArtisanPackUI\VisualEditor\VisualEditor;
 it( 'returns the frozen V1 block allow-list under the default config', function () {
 	$editor = app( VisualEditor::class );
 
-	// Snapshot of the M5-frozen default block set. Update this array only
-	// when intentionally changing the block-library audit (see
+	// Snapshot of the V1 default block set. Update this array only when
+	// intentionally changing the block-library audit (see
 	// docs/block-library-audit.md) and keep config/visual-editor.php in
-	// sync. The deny-list already removes every data-dependent block, so
-	// the output should be the allow-list verbatim, in config order.
+	// sync. The deny-list already removes every block that still needs a
+	// real loop runtime or term/comment endpoints, so the output should
+	// be the allow-list verbatim, in config order. E4 (#381) added the
+	// post-, site-, navigation, and template-part blocks on the back of
+	// B1's expanded core-data shim and the C-series REST surface.
 	expect( $editor->getEnabledBlockNames() )->toBe( [
 		'core/paragraph',
 		'core/heading',
@@ -40,6 +43,17 @@ it( 'returns the frozen V1 block allow-list under the default config', function 
 		'core/details',
 		'core/search',
 		'core/latest-posts',
+		'core/template-part',
+		'core/post-title',
+		'core/post-content',
+		'core/post-excerpt',
+		'core/post-date',
+		'core/post-author',
+		'core/post-featured-image',
+		'core/site-title',
+		'core/site-tagline',
+		'core/site-logo',
+		'core/navigation',
 		'artisanpack/callout',
 	] );
 } );


### PR DESCRIPTION
## Description

Promote the entity-scoped block set off the V1 deny-list now that B1's expanded `core-data` shim and the C1–C5 backends can round-trip them, and add Blade / React / Vue render implementations for each so server- and client-rendered output stay in lockstep.

**Closes:** #381

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #381

## Motivation and Context

`core-data` started as a stub that disabled 17 blocks needing entity resolution. B1 expanded the shim, C1–C5 landed the backends. E4 is where the visible payoff lands — the editor's full block palette becomes usable.

## Changes Made

**Blocks promoted to the V1 allow-list** (config/visual-editor.php + the JS-mirror in `site-editor-app.tsx`):

- `core/template-part`
- `core/post-title`, `core/post-content`, `core/post-excerpt`, `core/post-date`, `core/post-author`, `core/post-featured-image`
- `core/site-title`, `core/site-tagline`, `core/site-logo`
- `core/navigation` (+ `core/navigation-link`, `core/navigation-submenu` renderers)

**Renderers added in all three packages.** Each block reads the resolved post / site / author payload from a `_resolved*` attribute envelope a host-side resolver stamps onto the block tree (mirroring the template-part inliner pattern). When a value is missing the renderer emits a Gutenberg-shaped empty shell so the front-end markup matches the editor preview even before a resolver is wired up.

**Shim selectors added** so the newly-enabled `Edit` components don't crash against the empty-state core-data shim:

- `getCurrentTheme()` returns a synthetic `artisanpack-base` theme record (matches `config('artisanpack.visual-editor.global_styles.theme')`) so the template-part `enhanceTemplatePartVariations` filter and placeholder code can read `?.stylesheet` / `?.is_block_theme` without throwing.
- `getThemeSupports()` returns `{}`.
- `getPostType()` returns `null`.
- `getNavigationFallbackId()` is exposed as a public selector so block-library's `unlock( useSelect( coreStore ) )` falls through to it (returns `undefined` to opt the navigation block into its uncontrolled-inner-blocks fallback).

**Out of scope.** Loop / feed widgets (`core/query`, `core/latest-comments`, `core/archives`, `core/categories`, `core/tag-cloud`) stay disabled — they need a real loop runtime + term/comment endpoints that the shim does not implement (V2 + V1.1+).

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS 25.4
- Browser (if applicable): Safari (manual editor testing)
- PHP Version: 8.4.3
- Project Version: `release/1.0` HEAD

**Tests Performed:**
1. Full Pest suite — 443 tests / 1,379 assertions, all passing.
2. Full Vitest suite (renderer packages + shim) — 338 tests passing across 24 files.
3. Manual browser test in the dev app's site editor: insert each new block type, confirm no crashes, save + reload to confirm round-trip.
4. Three CodeRabbit review passes against `release/1.0` — final pass returned no findings (resolved 4 XSS-via-`rel` concatenation findings + 1 inverted-logic finding on the navigation `is-responsive` class along the way).

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:**

- Blade Pest feature test (`PostAndSiteContextRenderingTest.php`) covering all 11 newly-enabled blocks plus the navigation menu / submenu rendering matrix and URL-sanitisation safeguards on `_resolvedPermalink`.
- Vitest feature tests for the React and Vue renderers (`PostAndSiteContextRendering.test.{tsx,ts}`) — 18 tests each, mirroring the Blade matrix.
- Registry test additions in both JS renderer packages assert all 12 newly-registered block names (post-context × 6, site-context × 3, navigation × 3) are present after `registerCoreBlocks()`.
- `EnabledBlockNamesTest` snapshot updated to reflect the new V1 allow-list ordering.
- Three new shim tests cover `getCurrentTheme()`, `getPostType()`, `getThemeSupports()`, and `getNavigationFallbackId()`.

## Accessibility Tests Run

- [x] Keyboard navigation tested
- [ ] Screen reader tested
- [x] Color contrast verified
- [x] ARIA labels checked

**Details:**

The renderer output preserves Gutenberg core's wrapper semantics (correct heading levels for post/site title via `level` clamp, `<time datetime>` on post-date, `<figure>` on featured image, `<nav aria-label>` on navigation, `<ul>` menu containers for navigation children). No new interactive surfaces are introduced — all blocks render to static HTML. Tests assert `aria-label` propagation on the navigation block.

## Documentation

- [x] Inline code documentation added
- [ ] README updated
- [ ] Wiki updated
- [ ] API documentation updated

**Documentation details:**

Each new renderer file carries a top-of-file docblock explaining the `_resolved*` attribute envelope + parity goal with the other renderers. Inline comments in the shim explain why each new selector exists and what it returns. README / wiki updates can land alongside the resolver work that fills in the `_resolved*` attribute envelope (filed separately).

## Screenshots

Manual browser testing was performed in the site editor; no screenshot panel needed since the visible output is "blocks no longer crash on insert" and the rendered markup matches Gutenberg's wrapper semantics.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted (CodeRabbit clean)
- [x] Accessibility tests completed
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

---

## Follow-up issues opened during testing

Two pre-existing issues surfaced while exercising the new blocks. Filed separately so this PR can land without bundling shim or shell work:

- #394 — Site editor inspector sidebar reads block selection from the wrong registry (BlockEditorProvider sub-registry isolation)
- #395 — `core-data` shim's `useEntityRecords` / `getEntityRecords` should trigger REST resolution

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled rendering support for core post-context blocks (title, content, excerpt, date, author, featured image), site-context blocks (title, tagline, logo), and navigation (links, submenus) across Blade, React, and Vue renderers; updated editor config to re-enable these entity-scoped blocks.

* **Tests**
  * Added end-to-end and unit tests validating HTML structure, attributes, link target/rel behavior, security filtering of unsafe URLs, and registry registrations for post/site/navigation blocks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->