### PR TITLE
fix: render accessible icon-only submit button for core/search

### DIFF
--- a/packages/visual-editor-renderer-blade/resources/views/blocks/core/search.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/core/search.blade.php
@@ -5,7 +5,10 @@
 	$buttonText  = (string) ( $attributes['buttonText'] ?? 'Search' );
 	$useIcon     = ! empty( $attributes['buttonUseIcon'] );
 	$queryName   = (string) ( $attributes['query']['name'] ?? 's' );
-	$buttonLabel = $useIcon ? '' : $buttonText;
+
+	$ariaLabel = '' !== trim( $buttonText )
+		? $buttonText
+		: ( '' !== trim( $label ) ? $label : 'Search' );
 
 	$inputId = sprintf( 'wp-block-search-input-%s', substr( md5( $blockName . serialize( $attributes ) ), 0, 8 ) );
 
@@ -19,6 +22,12 @@
 		$classes[] = $attributes['className'];
 	}
 
+	$buttonClasses = [ 'wp-block-search__button' ];
+
+	if ( $useIcon ) {
+		$buttonClasses[] = 'has-icon';
+	}
+
 	$inputPlaceholder = '' !== $placeholder
 		? sprintf( ' placeholder="%s"', e( $placeholder ) )
 		: '';
@@ -29,6 +38,10 @@
 	@endif
 	<div class="wp-block-search__inside-wrapper">
 		<input id="{{ $inputId }}" type="search" class="wp-block-search__input" name="{{ $queryName }}"{!! $inputPlaceholder !!}/>
-		<button type="submit" class="wp-block-search__button">{{ $buttonLabel }}</button>
+		@if ( $useIcon )
+<button type="submit" class="{{ implode( ' ', $buttonClasses ) }}" aria-label="{{ $ariaLabel }}"><svg class="wp-block-search__button-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false"><path d="M13.5 6C10.5 6 8 8.5 8 11.5c0 1.1.3 2.1.9 3l-3.4 3 1 1.1 3.4-3c1 .9 2.2 1.4 3.6 1.4 3 0 5.5-2.5 5.5-5.5C19 8.5 16.5 6 13.5 6zm0 9.5c-2.2 0-4-1.8-4-4s1.8-4 4-4 4 1.8 4 4-1.8 4-4 4z"></path></svg></button>
+		@else
+			<button type="submit" class="{{ implode( ' ', $buttonClasses ) }}">{{ $buttonText }}</button>
+		@endif
 	</div>
 </form>

--- a/packages/visual-editor-renderer-blade/tests/Unit/BlockRendererTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Unit/BlockRendererTest.php
@@ -450,12 +450,23 @@ it( 'generates stable unique ids for multiple search blocks on the same page', f
 	expect( $m[1][0] )->not->toBe( $m[1][1] );
 } );
 
-it( 'uses an empty button label when buttonUseIcon is true', function () {
+it( 'renders an icon-only submit button with accessible name when buttonUseIcon is true', function () {
 	$tree = [ makeBlock( 'core/search', [ 'buttonText' => 'Go', 'buttonUseIcon' => true ] ) ];
 
 	$html = makeRenderer()->render( $tree );
 
-	expect( $html )->toContain( '<button type="submit" class="wp-block-search__button"></button>' );
+	expect( $html )->toContain( 'class="wp-block-search__button has-icon"' )
+		->toContain( 'aria-label="Go"' )
+		->toContain( '<svg class="wp-block-search__button-icon"' )
+		->not->toContain( '<button type="submit" class="wp-block-search__button"></button>' );
+} );
+
+it( 'falls back to label when buttonText is empty and buttonUseIcon is true', function () {
+	$tree = [ makeBlock( 'core/search', [ 'label' => 'Find stuff', 'buttonText' => '', 'buttonUseIcon' => true ] ) ];
+
+	$html = makeRenderer()->render( $tree );
+
+	expect( $html )->toContain( 'aria-label="Find stuff"' );
 } );
 
 it( 'preserves fractional column widths', function () {

--- a/packages/visual-editor-renderer-react/src/blocks/core/design.tsx
+++ b/packages/visual-editor-renderer-react/src/blocks/core/design.tsx
@@ -224,13 +224,24 @@ export function SearchBlock({ attributes }: BlockRendererProps): JSX.Element {
     const buttonText = attrString(attributes.buttonText, 'Search');
     const useIcon = attrBoolean(attributes.buttonUseIcon);
     const queryName = attrString(attrRecord(attributes.query).name, 's');
-    const buttonLabel = useIcon ? '' : buttonText;
     const className = attrString(attributes.className);
+
+    const ariaLabel =
+        buttonText.trim() !== ''
+            ? buttonText
+            : label.trim() !== ''
+            ? label
+            : 'Search';
 
     const classes = classList([
         'wp-block-search',
         !showLabel ? 'wp-block-search__button-inside' : null,
         className,
+    ]);
+
+    const buttonClasses = classList([
+        'wp-block-search__button',
+        useIcon ? 'has-icon' : null,
     ]);
 
     const inputId = `wp-block-search-input-${useId().replace(/[^a-zA-Z0-9_-]/g, '')}`;
@@ -250,9 +261,25 @@ export function SearchBlock({ attributes }: BlockRendererProps): JSX.Element {
                     name={queryName}
                     placeholder={placeholder === '' ? undefined : placeholder}
                 />
-                <button type="submit" className="wp-block-search__button">
-                    {buttonLabel}
-                </button>
+                {useIcon ? (
+                    <button type="submit" className={buttonClasses} aria-label={ariaLabel}>
+                        <svg
+                            className="wp-block-search__button-icon"
+                            xmlns="http://www.w3.org/2000/svg"
+                            viewBox="0 0 24 24"
+                            width="24"
+                            height="24"
+                            aria-hidden="true"
+                            focusable="false"
+                        >
+                            <path d="M13.5 6C10.5 6 8 8.5 8 11.5c0 1.1.3 2.1.9 3l-3.4 3 1 1.1 3.4-3c1 .9 2.2 1.4 3.6 1.4 3 0 5.5-2.5 5.5-5.5C19 8.5 16.5 6 13.5 6zm0 9.5c-2.2 0-4-1.8-4-4s1.8-4 4-4 4 1.8 4 4-1.8 4-4 4z"></path>
+                        </svg>
+                    </button>
+                ) : (
+                    <button type="submit" className={buttonClasses}>
+                        {buttonText}
+                    </button>
+                )}
             </div>
         </form>
     );

--- a/packages/visual-editor-renderer-react/tests/BlockTree.test.tsx
+++ b/packages/visual-editor-renderer-react/tests/BlockTree.test.tsx
@@ -551,10 +551,27 @@ describe('Core design blocks', () => {
         expect(ids[0]).not.toBe(ids[1]);
     });
 
-    it('uses an empty button label when buttonUseIcon is true', () => {
+    it('renders an icon-only submit button with accessible name when buttonUseIcon is true', () => {
         const tree = [makeBlock('core/search', { buttonText: 'Go', buttonUseIcon: true })];
 
-        expect(renderTree(tree)).toContain('<button type="submit" class="wp-block-search__button"></button>');
+        const html = renderTree(tree);
+
+        expect(html).toContain('class="wp-block-search__button has-icon"');
+        expect(html).toContain('aria-label="Go"');
+        expect(html).toContain('<svg class="wp-block-search__button-icon"');
+        expect(html).not.toContain('<button type="submit" class="wp-block-search__button"></button>');
+    });
+
+    it('falls back to label when buttonText is empty and buttonUseIcon is true', () => {
+        const tree = [
+            makeBlock('core/search', {
+                label: 'Find stuff',
+                buttonText: '',
+                buttonUseIcon: true,
+            }),
+        ];
+
+        expect(renderTree(tree)).toContain('aria-label="Find stuff"');
     });
 
     it('renders the artisanpack/callout reference block', () => {


### PR DESCRIPTION
## Description

When a `core/search` block has `buttonUseIcon: true`, both renderers were emitting an empty, unlabeled submit button (`<button type="submit" class="wp-block-search__button"></button>`). That fails WCAG 4.1.2 (no accessible name) and doesn't match WordPress's own frontend output.

Both the Blade and React renderers now emit the matched WordPress markup: a button with `wp-block-search__button has-icon`, an `aria-label`, and the canonical magnifier `<svg>`. The accessible name resolves to `buttonText`, falling back to the block `label`, then the literal `'Search'`.

**Closes:** #338

## Type of Change

- [x] Bug fix (fixes an issue)

## Related Issue

**Issue:** #338

## Motivation and Context

Surfaced by CodeRabbit during the #320 review and intentionally deferred to keep the two renderers output-matched. This PR is the matched fix so they stay in lockstep — fixing only one would have introduced server/client divergence.

## Changes Made

- `packages/visual-editor-renderer-blade/resources/views/blocks/core/search.blade.php`: branch on `buttonUseIcon` to render a `has-icon` button with `aria-label` and the magnifier SVG, or the original text button otherwise.
- `packages/visual-editor-renderer-react/src/blocks/core/design.tsx`: same branching in `SearchBlock`, output kept byte-aligned with the Blade partial.
- `packages/visual-editor-renderer-blade/tests/Unit/BlockRendererTest.php`: replaced the empty-button assertion with assertions for `has-icon`, `aria-label`, and the SVG; added a fallback test for empty `buttonText`.
- `packages/visual-editor-renderer-react/tests/BlockTree.test.tsx`: same assertions on the React side.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (Darwin 25.4.0)
- Browser (if applicable): Chrome (manual verification)
- PHP Version: 8.4.3
- Project Version: 1.0.0-spike (`release/1.0`)

**Tests Performed:**
1. Updated Pest tests for the Blade renderer pass (full Blade suite: 444 passed).
2. Updated vitest tests for the React renderer pass (full vitest suite: 892 passed).
3. Manually rendered a `core/search` block with `buttonUseIcon: true` through both `<x-ve-blocks>` and `<BlockTree>`; confirmed the icon-only button shows `has-icon`, `aria-label`, and the magnifier SVG, and that toggling `buttonUseIcon` off restores the original text-button output.

## Accessibility Tests Run

- [x] Keyboard navigation tested
- [ ] Screen reader tested
- [ ] Color contrast verified
- [x] ARIA labels checked

**Details:** Verified the icon-only submit button now exposes an accessible name via `aria-label`, resolving the WCAG 4.1.2 failure called out in the issue. Markup matches the WordPress canonical output (`has-icon` class + `wp-block-search__button-icon` SVG).

## Tests Added

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All tests passing

**Test details:** Replaced the existing "empty button label" assertions in `BlockRendererTest.php` and `BlockTree.test.tsx` with positive assertions for the `has-icon` class, `aria-label`, and `<svg class="wp-block-search__button-icon">` child. Added a second test in each renderer that exercises the `buttonText: ''` → `label` fallback path.

## Documentation

- [ ] Inline code documentation added
- [ ] README updated
- [ ] Wiki updated
- [ ] API documentation updated

**Documentation details:** No documentation changes — the `buttonUseIcon` attribute is unchanged from a consumer perspective; only the rendered markup is fixed.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [x] Accessibility tests completed
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Enhancements**
  * Search button now conditionally renders as an icon or text based on configuration settings.
  * Enhanced accessibility with automatic ARIA labels for screen readers on icon-only buttons.
  * Improved button styling with dynamic CSS classes for better visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->