### PR TITLE
feat: restore contrast warning via artisanpack-ui/accessibility

### DIFF
--- a/resources/js/visual-editor/editor/__tests__/contrast-warning.test.tsx
+++ b/resources/js/visual-editor/editor/__tests__/contrast-warning.test.tsx
@@ -253,6 +253,35 @@ describe('<ContrastWarning />', () => {
         );
     });
 
+    it('truncates the displayed ratio rather than rounding it up', async () => {
+        // #777777 on #ffffff produces a ratio of ~4.4781. The
+        // regression we're guarding against is `toFixed(2)` rounding
+        // failing ratios upward — here it would render "4.48", which
+        // is fine for this exact pair but telegraphs the rounding
+        // direction. Truncation locks the displayed value strictly
+        // below the actual ratio so no failing ratio can ever read
+        // ≥ 4.50:1 in the warning.
+        mockSettings = {
+            colors: [
+                { slug: 'fg', color: '#777777' },
+                { slug: 'bg', color: '#ffffff' },
+            ],
+        };
+
+        const { ContrastWarning } = await import('../contrast-warning');
+
+        render(
+            <ContrastWarning
+                attributes={{ textColor: 'fg', backgroundColor: 'bg' }}
+            />
+        );
+
+        const notice = screen.getByTestId('notice');
+        // Truncated value for ratio 4.4781 is 4.47, not 4.48.
+        expect(notice.textContent).toContain('4.47:1');
+        expect(notice.textContent).not.toContain('4.50:1');
+    });
+
     it('renders nothing when contrast passes', async () => {
         mockSettings = {
             colors: [

--- a/resources/js/visual-editor/editor/__tests__/contrast-warning.test.tsx
+++ b/resources/js/visual-editor/editor/__tests__/contrast-warning.test.tsx
@@ -1,0 +1,395 @@
+import { render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ComponentType } from 'react';
+
+const filters: Array<{
+    hook: string;
+    namespace: string;
+    callback: (component: unknown) => unknown;
+}> = [];
+
+vi.mock('@wordpress/hooks', () => ({
+    addFilter: (
+        hook: string,
+        namespace: string,
+        callback: (component: unknown) => unknown
+    ) => {
+        filters.push({ hook, namespace, callback });
+    },
+}));
+
+let mockSettings: Record<string, unknown> = {};
+
+vi.mock('@wordpress/data', () => ({
+    useSelect: (
+        mapSelect: (
+            select: (name: string) => Record<string, unknown> | undefined
+        ) => unknown
+    ) =>
+        mapSelect((name: string) => {
+            if (name === 'core/block-editor') {
+                return {
+                    getSettings: () => mockSettings,
+                };
+            }
+
+            return undefined;
+        }),
+}));
+
+const colorSupportRegistry = new Map<string, boolean>();
+
+vi.mock('@wordpress/blocks', () => ({
+    hasBlockSupport: (name: string, feature: string) =>
+        feature === 'color' ? colorSupportRegistry.get(name) === true : false,
+}));
+
+vi.mock('@wordpress/block-editor', () => ({
+    InspectorControls: ({
+        children,
+        group,
+    }: {
+        children: React.ReactNode;
+        group?: string;
+    }) => (
+        <div data-testid="inspector-controls" data-group={group}>
+            {children}
+        </div>
+    ),
+}));
+
+vi.mock('@wordpress/components', () => ({
+    Notice: ({
+        children,
+        status,
+    }: {
+        children: React.ReactNode;
+        status?: string;
+    }) => (
+        <div data-testid="notice" data-status={status} role="alert">
+            {children}
+        </div>
+    ),
+}));
+
+vi.mock('@wordpress/i18n', () => ({
+    __: (text: string) => text,
+    sprintf: (template: string, value: string) => template.replace('%s', value),
+}));
+
+const REGISTERED_KEY = Symbol.for(
+    'artisanpack-ui.visual-editor.contrast-warning.registered'
+);
+
+beforeEach(() => {
+    filters.length = 0;
+    mockSettings = {};
+    colorSupportRegistry.clear();
+    delete (globalThis as Record<symbol, unknown>)[REGISTERED_KEY];
+    vi.resetModules();
+});
+
+afterEach(() => {
+    delete (globalThis as Record<symbol, unknown>)[REGISTERED_KEY];
+    vi.resetModules();
+});
+
+describe('evaluateBlockContrast', () => {
+    it('returns null when no text or background color is set', async () => {
+        const { evaluateBlockContrast } = await import('../contrast-warning');
+
+        expect(
+            evaluateBlockContrast({ attributes: {}, palette: [] })
+        ).toBeNull();
+        expect(
+            evaluateBlockContrast({
+                attributes: { style: { color: { text: '#000000' } } },
+                palette: [],
+            })
+        ).toBeNull();
+        expect(
+            evaluateBlockContrast({
+                attributes: { style: { color: { background: '#ffffff' } } },
+                palette: [],
+            })
+        ).toBeNull();
+    });
+
+    it('passes high-contrast attribute pairs', async () => {
+        const { evaluateBlockContrast } = await import('../contrast-warning');
+
+        const result = evaluateBlockContrast({
+            attributes: {
+                style: {
+                    color: { text: '#000000', background: '#ffffff' },
+                },
+            },
+            palette: [],
+        });
+
+        expect(result).not.toBeNull();
+        expect(result?.passes).toBe(true);
+        expect(result?.ratio).toBeGreaterThanOrEqual(4.5);
+    });
+
+    it('flags low-contrast attribute pairs', async () => {
+        const { evaluateBlockContrast } = await import('../contrast-warning');
+
+        const result = evaluateBlockContrast({
+            attributes: {
+                style: {
+                    color: { text: '#cccccc', background: '#ffffff' },
+                },
+            },
+            palette: [],
+        });
+
+        expect(result?.passes).toBe(false);
+        expect(result?.ratio).toBeLessThan(4.5);
+    });
+
+    it('resolves textColor/backgroundColor slugs against the palette', async () => {
+        const { evaluateBlockContrast } = await import('../contrast-warning');
+
+        const palette = [
+            { slug: 'base-content', color: '#1f2937' },
+            { slug: 'primary', color: '#2563eb' },
+        ];
+
+        const result = evaluateBlockContrast({
+            attributes: {
+                textColor: 'base-content',
+                backgroundColor: 'primary',
+            },
+            palette,
+        });
+
+        expect(result?.foreground).toBe('#1f2937');
+        expect(result?.background).toBe('#2563eb');
+    });
+
+    it('resolves var:preset|color| references in style.color.*', async () => {
+        const { evaluateBlockContrast } = await import('../contrast-warning');
+
+        const palette = [{ slug: 'success', color: '#16a34a' }];
+
+        const result = evaluateBlockContrast({
+            attributes: {
+                style: {
+                    color: {
+                        text: 'var:preset|color|success',
+                        background: '#ffffff',
+                    },
+                },
+            },
+            palette,
+        });
+
+        expect(result?.foreground).toBe('#16a34a');
+        expect(result?.background).toBe('#ffffff');
+    });
+
+    it('returns null for unresolvable preset slugs', async () => {
+        const { evaluateBlockContrast } = await import('../contrast-warning');
+
+        const result = evaluateBlockContrast({
+            attributes: {
+                textColor: 'mystery-color',
+                backgroundColor: 'primary',
+            },
+            palette: [{ slug: 'primary', color: '#2563eb' }],
+        });
+
+        expect(result).toBeNull();
+    });
+
+    it('prefers slug attributes over style.color when both are set', async () => {
+        const { evaluateBlockContrast } = await import('../contrast-warning');
+
+        const palette = [{ slug: 'base-content', color: '#1f2937' }];
+
+        const result = evaluateBlockContrast({
+            attributes: {
+                textColor: 'base-content',
+                style: {
+                    color: { text: '#ff00ff', background: '#ffffff' },
+                },
+            },
+            palette,
+        });
+
+        // Slug wins → foreground resolves to the palette entry, not the
+        // raw hex in style.color.text.
+        expect(result?.foreground).toBe('#1f2937');
+    });
+});
+
+describe('<ContrastWarning />', () => {
+    it('renders a warning notice when contrast fails', async () => {
+        mockSettings = {
+            colors: [
+                { slug: 'base-content', color: '#cccccc' },
+                { slug: 'page', color: '#ffffff' },
+            ],
+        };
+
+        const { ContrastWarning } = await import('../contrast-warning');
+
+        render(
+            <ContrastWarning
+                attributes={{
+                    textColor: 'base-content',
+                    backgroundColor: 'page',
+                }}
+            />
+        );
+
+        const notice = screen.getByTestId('notice');
+        expect(notice).toHaveAttribute('data-status', 'warning');
+        expect(notice.textContent).toMatch(/contrast ratio/i);
+        expect(screen.getByTestId('inspector-controls')).toHaveAttribute(
+            'data-group',
+            'color'
+        );
+    });
+
+    it('renders nothing when contrast passes', async () => {
+        mockSettings = {
+            colors: [
+                { slug: 'base-content', color: '#000000' },
+                { slug: 'page', color: '#ffffff' },
+            ],
+        };
+
+        const { ContrastWarning } = await import('../contrast-warning');
+
+        const { container } = render(
+            <ContrastWarning
+                attributes={{
+                    textColor: 'base-content',
+                    backgroundColor: 'page',
+                }}
+            />
+        );
+
+        expect(container.firstChild).toBeNull();
+    });
+
+    it('renders nothing when text or background is missing', async () => {
+        const { ContrastWarning } = await import('../contrast-warning');
+
+        const { container: noBg } = render(
+            <ContrastWarning
+                attributes={{
+                    style: { color: { text: '#000000' } },
+                }}
+            />
+        );
+        expect(noBg.firstChild).toBeNull();
+
+        const { container: noFg } = render(
+            <ContrastWarning
+                attributes={{
+                    style: { color: { background: '#ffffff' } },
+                }}
+            />
+        );
+        expect(noFg.firstChild).toBeNull();
+    });
+
+    it('reads palette from __experimentalFeatures.color.palette.custom', async () => {
+        mockSettings = {
+            __experimentalFeatures: {
+                color: {
+                    palette: {
+                        custom: [{ slug: 'muted', color: '#cccccc' }],
+                    },
+                },
+            },
+        };
+
+        const { ContrastWarning } = await import('../contrast-warning');
+
+        render(
+            <ContrastWarning
+                attributes={{
+                    textColor: 'muted',
+                    style: { color: { background: '#ffffff' } },
+                }}
+            />
+        );
+
+        // #cccccc on #ffffff fails AA — warning should render.
+        expect(screen.getByTestId('notice')).toBeInTheDocument();
+    });
+});
+
+describe('registerContrastWarning', () => {
+    it('registers the editor.BlockEdit filter exactly once', async () => {
+        const mod = await import('../contrast-warning');
+
+        mod.registerContrastWarning();
+        mod.registerContrastWarning();
+        mod.registerContrastWarning();
+
+        expect(filters).toHaveLength(1);
+        expect(filters[0]?.hook).toBe('editor.BlockEdit');
+        expect(filters[0]?.namespace).toBe(
+            'artisanpack-ui/visual-editor/contrast-warning'
+        );
+    });
+
+    it('passes through blocks without color support unchanged', async () => {
+        const { withContrastWarning } = await import('../contrast-warning');
+
+        colorSupportRegistry.set('core/spacer', false);
+
+        const InnerEdit: ComponentType<{ name: string }> = ({ name }) => (
+            <div data-testid="inner">{String(name)}</div>
+        );
+
+        const Wrapped = withContrastWarning(
+            InnerEdit as unknown as Parameters<typeof withContrastWarning>[0]
+        );
+
+        render(<Wrapped name="core/spacer" attributes={{}} />);
+
+        expect(screen.getByTestId('inner')).toHaveTextContent('core/spacer');
+        expect(screen.queryByTestId('notice')).toBeNull();
+        expect(screen.queryByTestId('inspector-controls')).toBeNull();
+    });
+
+    it('renders the contrast warning alongside blocks that support color', async () => {
+        mockSettings = {
+            colors: [
+                { slug: 'base-content', color: '#cccccc' },
+                { slug: 'page', color: '#ffffff' },
+            ],
+        };
+
+        const { withContrastWarning } = await import('../contrast-warning');
+
+        colorSupportRegistry.set('core/paragraph', true);
+
+        const InnerEdit: ComponentType<{ name: string }> = ({ name }) => (
+            <div data-testid="inner">{String(name)}</div>
+        );
+
+        const Wrapped = withContrastWarning(
+            InnerEdit as unknown as Parameters<typeof withContrastWarning>[0]
+        );
+
+        render(
+            <Wrapped
+                name="core/paragraph"
+                attributes={{
+                    textColor: 'base-content',
+                    backgroundColor: 'page',
+                }}
+            />
+        );
+
+        expect(screen.getByTestId('inner')).toHaveTextContent('core/paragraph');
+        expect(screen.getByTestId('notice')).toBeInTheDocument();
+    });
+});

--- a/resources/js/visual-editor/editor/__tests__/wcag-contrast.test.ts
+++ b/resources/js/visual-editor/editor/__tests__/wcag-contrast.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    a11yCheckContrastColor,
+    a11yGetContrastColor,
+    getContrastRatio,
+    WCAG_AA_NORMAL_TEXT_RATIO,
+} from '../wcag-contrast';
+
+describe('getContrastRatio', () => {
+    it('returns 21 for black on white (the WCAG max)', () => {
+        const ratio = getContrastRatio('#000000', '#ffffff');
+        expect(ratio).not.toBeNull();
+        expect(ratio).toBeCloseTo(21, 1);
+    });
+
+    it('returns 1 for identical colors', () => {
+        expect(getContrastRatio('#3b82f6', '#3b82f6')).toBeCloseTo(1, 5);
+    });
+
+    it('returns null for unparseable hex', () => {
+        expect(getContrastRatio('not-a-color', '#ffffff')).toBeNull();
+        expect(getContrastRatio('#ffffff', 'rgb(0,0,0)')).toBeNull();
+    });
+
+    it('handles 3-digit shorthand hex', () => {
+        const expanded = getContrastRatio('#000', '#fff');
+        const long = getContrastRatio('#000000', '#ffffff');
+        expect(expanded).toBeCloseTo(long ?? 0, 5);
+    });
+});
+
+describe('a11yCheckContrastColor', () => {
+    it('passes for high-contrast pairs (≥ 4.5:1)', () => {
+        expect(a11yCheckContrastColor('#000000', '#ffffff')).toBe(true);
+        expect(a11yCheckContrastColor('#1f2937', '#ffffff')).toBe(true);
+    });
+
+    it('fails for low-contrast pairs (< 4.5:1)', () => {
+        // Light grey text on white — classic readability failure.
+        expect(a11yCheckContrastColor('#cccccc', '#ffffff')).toBe(false);
+        expect(a11yCheckContrastColor('#999999', '#aaaaaa')).toBe(false);
+    });
+
+    it('returns false for invalid hex input rather than throwing', () => {
+        expect(a11yCheckContrastColor('blue-500', '#ffffff')).toBe(false);
+        expect(a11yCheckContrastColor('#ffffff', '')).toBe(false);
+    });
+
+    it('uses 4.5:1 as the AA threshold', () => {
+        expect(WCAG_AA_NORMAL_TEXT_RATIO).toBe(4.5);
+    });
+});
+
+describe('a11yGetContrastColor', () => {
+    it('returns white for dark backgrounds', () => {
+        expect(a11yGetContrastColor('#000000')).toBe('#ffffff');
+        expect(a11yGetContrastColor('#1f2937')).toBe('#ffffff');
+    });
+
+    it('returns black for light backgrounds', () => {
+        expect(a11yGetContrastColor('#ffffff')).toBe('#000000');
+        expect(a11yGetContrastColor('#f3f4f6')).toBe('#000000');
+    });
+
+    it('falls back to black for unparseable input', () => {
+        expect(a11yGetContrastColor('garbage')).toBe('#000000');
+    });
+});

--- a/resources/js/visual-editor/editor/contrast-warning.css
+++ b/resources/js/visual-editor/editor/contrast-warning.css
@@ -1,0 +1,11 @@
+/*
+ * The contrast warning is rendered as a fill on
+ * `InspectorControls group="color"`, which lands inside Gutenberg's
+ * color `ToolsPanel`. That panel is a two-column CSS grid, so without
+ * an override the Notice would only span the first column. Telling the
+ * wrapper to occupy every column matches the upstream
+ * `.block-editor-contrast-checker` rule and keeps the warning legible.
+ */
+.ap-visual-editor-contrast-warning {
+    grid-column: 1 / -1;
+}

--- a/resources/js/visual-editor/editor/contrast-warning.tsx
+++ b/resources/js/visual-editor/editor/contrast-warning.tsx
@@ -231,13 +231,19 @@ export function ContrastWarning(props: ContrastWarningProps): JSX.Element | null
         return null;
     }
 
+    // `toFixed(2)` rounds half-up, so a failing ratio like 4.499 would
+    // render as "4.50:1" — visually equal to the 4.5:1 threshold quoted
+    // in the same sentence. Truncate toward zero instead so the
+    // displayed value is always strictly below the WCAG line for any
+    // ratio that actually failed the check.
+    const truncatedRatio = Math.floor(evaluation.ratio * 100) / 100;
     const message = sprintf(
         // translators: %s is the calculated contrast ratio (e.g. "3.21").
         __(
             'This color combination may be hard to read. Contrast ratio is %s:1; WCAG AA requires at least 4.5:1 for normal text.',
             TEXT_DOMAIN
         ),
-        evaluation.ratio.toFixed(2)
+        truncatedRatio.toFixed(2)
     );
 
     // The fill is dropped into Gutenberg's color `ToolsPanel`, which lays

--- a/resources/js/visual-editor/editor/contrast-warning.tsx
+++ b/resources/js/visual-editor/editor/contrast-warning.tsx
@@ -1,0 +1,297 @@
+/**
+ * Contrast warning fill.
+ *
+ * Replaces Gutenberg's built-in `BlockColorContrastChecker`, which we
+ * disabled in #343/A1 (see `disableContrastCheckerOnBlocks` in
+ * `editor-app.tsx`) because its deps-less `useLayoutEffect` +
+ * `requestAnimationFrame` chain triggered the color-picker drag crash.
+ *
+ * This implementation reads only block attributes — never computed
+ * styles — so the render loop that crashed the upstream component
+ * cannot reappear. The math comes from the
+ * `artisanpack-ui/accessibility` PHP package's WCAG helpers, ported to
+ * TypeScript in `wcag-contrast.ts`.
+ *
+ * Wiring: an `editor.BlockEdit` HOC wraps every block whose type has
+ * color support. The wrapper renders an `<InspectorControls
+ * group="color">` fill containing a warning `<Notice>` whenever the
+ * resolved foreground/background pair fails WCAG AA (≥ 4.5:1). The fill
+ * lands directly under the Color panel because `group="color"` targets
+ * Gutenberg's named color slot.
+ */
+
+import { hasBlockSupport } from '@wordpress/blocks';
+import { InspectorControls } from '@wordpress/block-editor';
+import { Notice } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { addFilter } from '@wordpress/hooks';
+import { __, sprintf } from '@wordpress/i18n';
+import { createElement, type ComponentType } from 'react';
+
+import { TEXT_DOMAIN } from '../vendor/i18n';
+
+import { getContrastRatio, WCAG_AA_NORMAL_TEXT_RATIO } from './wcag-contrast';
+
+import './contrast-warning.css';
+
+const FILTER_HOOK = 'editor.BlockEdit';
+const FILTER_NAMESPACE = 'artisanpack-ui/visual-editor/contrast-warning';
+
+// Page-global sentinel so the filter is registered once even when the
+// module is imported by multiple bundles (post + site editor entries
+// can both call `registerContrastWarning()`). Mirrors the pattern in
+// `synced-pattern-indicator.tsx`.
+const REGISTERED_KEY = Symbol.for(
+    'artisanpack-ui.visual-editor.contrast-warning.registered'
+);
+
+interface GlobalSentinelHost {
+    [REGISTERED_KEY]?: boolean;
+}
+
+export interface PaletteColor {
+    readonly name?: string;
+    readonly slug?: string;
+    readonly color?: string;
+}
+
+interface BlockEditAttributes {
+    readonly textColor?: string;
+    readonly backgroundColor?: string;
+    readonly style?: {
+        readonly color?: {
+            readonly text?: string;
+            readonly background?: string;
+        };
+    };
+}
+
+interface BlockEditProps {
+    readonly name: string;
+    readonly attributes?: BlockEditAttributes;
+    readonly [key: string]: unknown;
+}
+
+const PRESET_COLOR_PATTERN = /^var:preset\|color\|(.+)$/;
+
+function resolvePresetSlug(
+    slug: string | undefined,
+    palette: ReadonlyArray<PaletteColor>
+): string | undefined {
+    if (slug === undefined || slug === '') {
+        return undefined;
+    }
+
+    const match = palette.find((entry) => entry.slug === slug);
+
+    return match?.color;
+}
+
+/**
+ * Normalises an attribute color value (raw hex, CSS keyword, or
+ * `var:preset|color|{slug}` reference) into a hex string when possible.
+ * Returns `undefined` for empty values or unresolvable preset
+ * references — the caller treats that as "no color set" and hides the
+ * warning, matching the acceptance criteria.
+ */
+function resolveAttributeColor(
+    value: string | undefined,
+    palette: ReadonlyArray<PaletteColor>
+): string | undefined {
+    if (value === undefined || value === '') {
+        return undefined;
+    }
+
+    const presetMatch = PRESET_COLOR_PATTERN.exec(value);
+
+    if (presetMatch !== null) {
+        return resolvePresetSlug(presetMatch[1], palette);
+    }
+
+    return value;
+}
+
+export interface EvaluateBlockContrastArgs {
+    readonly attributes?: BlockEditAttributes;
+    readonly palette: ReadonlyArray<PaletteColor>;
+}
+
+export interface ContrastEvaluation {
+    readonly foreground: string;
+    readonly background: string;
+    readonly ratio: number;
+    readonly passes: boolean;
+}
+
+/**
+ * Pure helper that resolves the selected block's color attributes
+ * against the merged editor palette and returns the WCAG ratio. Split
+ * out of the component so the resolution + evaluation logic is unit
+ * testable without spinning up the React + `@wordpress/data` stack.
+ *
+ * Returns `null` when either color cannot be resolved — that maps to
+ * the "Hides when no text or no background is set" acceptance
+ * criterion in the calling component.
+ */
+export function evaluateBlockContrast(
+    args: EvaluateBlockContrastArgs
+): ContrastEvaluation | null {
+    const { attributes, palette } = args;
+
+    if (attributes === undefined || attributes === null) {
+        return null;
+    }
+
+    // Gutenberg writes preset slugs into `textColor`/`backgroundColor`
+    // and raw hex into `style.color.{text,background}` — the slug
+    // attribute wins when both are set, mirroring `attributesToStyle`
+    // in `@wordpress/block-editor/src/hooks/color.js`.
+    const foreground =
+        resolvePresetSlug(attributes.textColor, palette) ??
+        resolveAttributeColor(attributes.style?.color?.text, palette);
+    const background =
+        resolvePresetSlug(attributes.backgroundColor, palette) ??
+        resolveAttributeColor(attributes.style?.color?.background, palette);
+
+    if (foreground === undefined || background === undefined) {
+        return null;
+    }
+
+    const ratio = getContrastRatio(foreground, background);
+
+    if (ratio === null) {
+        return null;
+    }
+
+    return {
+        foreground,
+        background,
+        ratio,
+        passes: ratio >= WCAG_AA_NORMAL_TEXT_RATIO,
+    };
+}
+
+interface BlockEditorSettingsShape {
+    readonly colors?: ReadonlyArray<PaletteColor>;
+    readonly __experimentalFeatures?: {
+        readonly color?: {
+            readonly palette?: {
+                readonly custom?: ReadonlyArray<PaletteColor>;
+                readonly theme?: ReadonlyArray<PaletteColor>;
+                readonly default?: ReadonlyArray<PaletteColor>;
+            };
+        };
+    };
+}
+
+interface BlockEditorStore {
+    getSettings?: () => BlockEditorSettingsShape | undefined;
+}
+
+/**
+ * Merges every palette source the editor exposes into a single lookup
+ * list. `__experimentalFeatures.color.palette.custom` wins over theme
+ * and default — same priority Gutenberg uses internally — and the
+ * top-level `settings.colors` is appended last as the legacy fallback.
+ */
+function collectPalette(
+    settings: BlockEditorSettingsShape | undefined
+): ReadonlyArray<PaletteColor> {
+    if (settings === undefined || settings === null) {
+        return [];
+    }
+
+    const featurePalette = settings.__experimentalFeatures?.color?.palette;
+
+    return [
+        ...(featurePalette?.custom ?? []),
+        ...(featurePalette?.theme ?? []),
+        ...(featurePalette?.default ?? []),
+        ...(settings.colors ?? []),
+    ];
+}
+
+interface ContrastWarningProps {
+    readonly attributes?: BlockEditAttributes;
+}
+
+export function ContrastWarning(props: ContrastWarningProps): JSX.Element | null {
+    const palette = useSelect((select: (key: string) => unknown) => {
+        const store = select('core/block-editor') as BlockEditorStore | undefined;
+
+        return collectPalette(store?.getSettings?.());
+    }, []);
+
+    const evaluation = evaluateBlockContrast({
+        attributes: props.attributes,
+        palette,
+    });
+
+    if (evaluation === null || evaluation.passes) {
+        return null;
+    }
+
+    const message = sprintf(
+        // translators: %s is the calculated contrast ratio (e.g. "3.21").
+        __(
+            'This color combination may be hard to read. Contrast ratio is %s:1; WCAG AA requires at least 4.5:1 for normal text.',
+            TEXT_DOMAIN
+        ),
+        evaluation.ratio.toFixed(2)
+    );
+
+    // The fill is dropped into Gutenberg's color `ToolsPanel`, which lays
+    // its children out in a two-column grid. Without the wrapper the
+    // Notice would render at half-width — `grid-column: 1 / -1` on the
+    // wrapper restores full width, mirroring the upstream
+    // `.block-editor-contrast-checker` rule.
+    return (
+        <InspectorControls group="color">
+            <div className="ap-visual-editor-contrast-warning">
+                <Notice
+                    status="warning"
+                    isDismissible={false}
+                    spokenMessage={null}
+                >
+                    {message}
+                </Notice>
+            </div>
+        </InspectorControls>
+    );
+}
+
+/**
+ * `editor.BlockEdit` HOC. Wraps every block's edit component so the
+ * contrast warning fill renders alongside the inner edit only when the
+ * block type opts into color support — anything else short-circuits to
+ * the original `BlockEdit` unchanged.
+ */
+export function withContrastWarning(
+    BlockEdit: ComponentType<BlockEditProps>
+): ComponentType<BlockEditProps> {
+    return function ContrastWarningWrapper(props: BlockEditProps): JSX.Element {
+        const supportsColor = hasBlockSupport(props.name, 'color', false);
+
+        if (!supportsColor) {
+            return createElement(BlockEdit, props);
+        }
+
+        return (
+            <>
+                <ContrastWarning attributes={props.attributes} />
+                <BlockEdit {...props} />
+            </>
+        );
+    };
+}
+
+export function registerContrastWarning(): void {
+    const host = globalThis as unknown as GlobalSentinelHost;
+
+    if (host[REGISTERED_KEY] === true) {
+        return;
+    }
+
+    addFilter(FILTER_HOOK, FILTER_NAMESPACE, withContrastWarning);
+    host[REGISTERED_KEY] = true;
+}

--- a/resources/js/visual-editor/editor/editor-app.tsx
+++ b/resources/js/visual-editor/editor/editor-app.tsx
@@ -42,6 +42,7 @@ import {
 } from '../media-bridge';
 
 import { BlockLibrarySidebar } from './block-library-sidebar';
+import { registerContrastWarning } from './contrast-warning';
 import { ConvertToPatternControl } from './convert-to-pattern-control';
 import { discoverAndRegisterCustomBlocks } from './custom-blocks';
 import { registerSyncedPatternIndicator } from './synced-pattern-indicator';
@@ -151,6 +152,11 @@ function registerOnce(): void {
     // reaches every block as it registers. Doing it after would leave
     // already-registered blocks with the default (buggy) checker on.
     disableContrastCheckerOnBlocks();
+    // Replace the disabled upstream checker with our attribute-driven
+    // implementation (#348). Registers an `editor.BlockEdit` HOC, so it
+    // also belongs before `registerCoreBlocks` to wrap every block at
+    // first render rather than retroactively.
+    registerContrastWarning();
     // Register D5's synced-pattern indicator filter pre-`registerCoreBlocks`
     // for the same reason — the wrapper sees `core/block` once the
     // block registers and applies the badge from then on.

--- a/resources/js/visual-editor/editor/wcag-contrast.ts
+++ b/resources/js/visual-editor/editor/wcag-contrast.ts
@@ -1,0 +1,138 @@
+/**
+ * WCAG 2.0 contrast helpers.
+ *
+ * TypeScript port of the helpers exposed by the
+ * `artisanpack-ui/accessibility` PHP package (`a11yCheckContrastColor`,
+ * `a11yGetContrastColor`). The package itself is PHP-only — bundling its
+ * Composer build into the editor isn't viable — so the math lives here
+ * and the API names mirror the PHP side intentionally so anyone reading
+ * across both stacks recognises the contract. Algorithm is straight from
+ * https://www.w3.org/TR/WCAG20-TECHS/G18.html (relative luminance) and
+ * §1.4.3 (4.5:1 AA contrast ratio for normal text).
+ *
+ * Restoring this for #348 after #343/A1 disabled Gutenberg's built-in
+ * `BlockColorContrastChecker`. The upstream checker reads computed
+ * styles via a deps-less `useLayoutEffect` and triggered the
+ * color-picker drag crash; this implementation is attribute-driven so
+ * it cannot reintroduce that loop.
+ */
+export const WCAG_AA_NORMAL_TEXT_RATIO = 4.5;
+
+interface RGB {
+    readonly r: number;
+    readonly g: number;
+    readonly b: number;
+}
+
+const HEX_PATTERN = /^#([a-f0-9]{3}|[a-f0-9]{6})$/i;
+
+function expandShorthandHex(hex: string): string {
+    if (hex.length !== 3) {
+        return hex;
+    }
+
+    return hex
+        .split('')
+        .map((character) => character + character)
+        .join('');
+}
+
+function hexToRgb(hex: string): RGB | null {
+    if (typeof hex !== 'string') {
+        return null;
+    }
+
+    const trimmed = hex.trim();
+
+    if (!HEX_PATTERN.test(trimmed)) {
+        return null;
+    }
+
+    const expanded = expandShorthandHex(trimmed.replace(/^#/, ''));
+
+    return {
+        r: parseInt(expanded.substring(0, 2), 16),
+        g: parseInt(expanded.substring(2, 4), 16),
+        b: parseInt(expanded.substring(4, 6), 16),
+    };
+}
+
+function sRGBtoLinear(channel: number): number {
+    const normalised = channel / 255;
+
+    if (normalised <= 0.03928) {
+        return normalised / 12.92;
+    }
+
+    return Math.pow((normalised + 0.055) / 1.055, 2.4);
+}
+
+function relativeLuminance(rgb: RGB): number {
+    const r = sRGBtoLinear(rgb.r);
+    const g = sRGBtoLinear(rgb.g);
+    const b = sRGBtoLinear(rgb.b);
+
+    return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+/**
+ * Calculates the WCAG contrast ratio between two hex colors. Returns
+ * `null` when either color cannot be parsed so callers can distinguish
+ * "no warning to show" from "ratio is genuinely too low".
+ */
+export function getContrastRatio(
+    foreground: string,
+    background: string
+): number | null {
+    const fg = hexToRgb(foreground);
+    const bg = hexToRgb(background);
+
+    if (fg === null || bg === null) {
+        return null;
+    }
+
+    const l1 = relativeLuminance(fg);
+    const l2 = relativeLuminance(bg);
+    const lighter = Math.max(l1, l2);
+    const darker = Math.min(l1, l2);
+
+    return (lighter + 0.05) / (darker + 0.05);
+}
+
+/**
+ * Mirrors `A11y::a11yCheckContrastColor` in the PHP package. Returns
+ * `true` when the two hex colors meet WCAG AA for normal text
+ * (≥ 4.5:1). Invalid hex inputs are treated as failing checks — same as
+ * the PHP helper, which catches `InvalidArgumentException` and returns
+ * `false`.
+ */
+export function a11yCheckContrastColor(
+    foreground: string,
+    background: string
+): boolean {
+    const ratio = getContrastRatio(foreground, background);
+
+    if (ratio === null) {
+        return false;
+    }
+
+    return ratio >= WCAG_AA_NORMAL_TEXT_RATIO;
+}
+
+/**
+ * Mirrors `A11y::a11yGetContrastColor` in the PHP package. Returns
+ * `#000000` or `#ffffff` based on whichever has the higher contrast
+ * ratio against the supplied background. Falls back to `#000000` for
+ * unparseable input — matches the PHP behaviour of leaning on dark text
+ * when the algorithm can't decide.
+ */
+export function a11yGetContrastColor(background: string): '#000000' | '#ffffff' {
+    const blackRatio = getContrastRatio('#000000', background);
+    const whiteRatio = getContrastRatio('#ffffff', background);
+
+    if (blackRatio === null || whiteRatio === null) {
+        return '#000000';
+    }
+
+    return blackRatio >= whiteRatio ? '#000000' : '#ffffff';
+}


### PR DESCRIPTION
## Description

Reintroduce WCAG AA contrast warnings on blocks with color support after #343/A1 disabled Gutenberg's `BlockColorContrastChecker` to dodge the color-picker drag crash. The replacement reads only block attributes — never computed styles — so the upstream render loop cannot reappear.

**Closes:** #348

## Type of Change

- [x] Enhancement (improves existing functionality)

## Related Issue

**Issue:** #348

## Motivation and Context

A1 (#343) disabled the upstream `BlockColorContrastChecker` via a `blocks.registerBlockType` filter because its deps-less `useLayoutEffect` + double-`requestAnimationFrame` chain piled up during color-picker drags and crashed the block. The mitigation worked but cost us the WCAG warning surface. This PR puts the warning back without re-introducing the crash, using the contrast math from the `artisanpack-ui/accessibility` PHP package (ported to TypeScript since the package has no JS exports).

## Changes Made

- `wcag-contrast.ts` — TS port of `a11yCheckContrastColor` / `a11yGetContrastColor` from `artisanpack-ui/accessibility`. Same algorithm, same names so the contract reads the same across stacks.
- `contrast-warning.tsx` — `ContrastWarning` component + `withContrastWarning` HOC + `registerContrastWarning()`. Hooks `editor.BlockEdit` to wrap blocks with color support; resolves preset slugs against `__experimentalFeatures.color.palette.{custom,theme,default}` and the legacy `settings.colors`; renders a `<Notice status="warning">` inside `<InspectorControls group="color">` when contrast falls below 4.5:1.
- `contrast-warning.css` — `grid-column: 1 / -1` so the warning spans Gutenberg's two-column ToolsPanel grid (matches upstream `.block-editor-contrast-checker`).
- `editor-app.tsx` — calls `registerContrastWarning()` next to `disableContrastCheckerOnBlocks()`. The upstream-disable filter stays in place per the issue's acceptance criteria.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS
- Browser: Chrome (Laravel Herd dev app)
- PHP Version: 8.4
- Project Version: 1.0.0-spike

**Tests Performed:**
1. Inserted a Paragraph block, set text `#cccccc` on `#ffffff` background → warning appeared in the Color panel showing the calculated ratio.
2. Switched text to black → warning disappeared.
3. Verified the warning spans the full panel width after wrapping it in a grid-column override.
4. Ran the full JS test suite (917 passing, 1 pre-existing skipped) — no regressions.

## Accessibility Tests Run

- [x] Color contrast verified
- [x] ARIA labels checked (Notice carries the WP component's built-in role)

**Details:**
The Notice uses the upstream `<Notice status="warning">` component, which announces via aria-live by default. We pass `spokenMessage={null}` to suppress duplicate announcements during drag — matches the upstream `ContrastChecker` pattern.

## Tests Added

- [x] Unit tests added (`wcag-contrast.test.ts` — 11 tests for the math)
- [x] Component tests added (`contrast-warning.test.tsx` — 14 tests covering pass/fail, missing values, preset-slug resolution, slug-vs-style precedence, palette merging, no-color-support pass-through, and idempotent filter registration)
- [x] All tests passing

## Documentation

- [x] Inline code documentation added (file-level comments explain the why-not-the-what context, including the link back to #343/A1)

## Screenshots

_See manual test sequence above — warning renders under the Color panel for low-contrast pairs._

## Pre-Submission Checklist

- [x] Code passes all tests
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added WCAG AA contrast checking in the visual editor; non-dismissible warnings appear in the block inspector when text/background contrast is insufficient.

* **Tests**
  * Added thorough tests for contrast utilities and the editor warning behavior, covering ratio calculations and UI rendering.

* **Style**
  * Adjusted editor styling so contrast notices span the inspector layout for improved legibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->