### PR TITLE
fix: wire core-data shim resolvers + composite-id reads (#395)

### DIFF
--- a/docs/core-data-shim.md
+++ b/docs/core-data-shim.md
@@ -69,14 +69,35 @@ callers that need to refresh a tuple outside the resolver lifecycle
 | `__experimentalGetCurrentGlobalStylesId()`      | `EntityKey \| null`                       | Singleton global-styles record id.                        |
 | `__experimentalGlobalStylesBaseStyles()`        | `Record<string, unknown> \| null`         | theme.json-shaped base styles (schema + defaults).        |
 
+### Resolution-tracking selectors
+
+`hasFinishedResolution(selectorName, args)`, `hasStartedResolution`, and
+`isResolving(selectorName, args)` are auto-supplied by `@wordpress/data`
+once resolvers are registered (G0 / #395). For `getEntityRecord` /
+`getEntityRecords` / `getEditedEntityRecord` they reflect real fetch
+lifecycle state — first read flips `isResolving` to `true`, the
+resolver fetches, then `hasFinishedResolution` flips to `true` and the
+cache is populated. Selectors without a registered resolver
+(`getCurrentTheme`, `canUser`, etc.) report `hasFinishedResolution =
+false` indefinitely; callers that need a real "resolved" signal for
+those should not gate on it.
+
+### Permissions stubs
+
+`canUser(action, resource)` and `canUserEditEntityRecord` return
+`true` in the shim — the editor route is already gated by the
+package's auth middleware, so any user with editor access is treated
+as having full CRUD on the entities the editor manages. Real
+fine-grained permissions land in G5 (cms-framework #98); until then,
+do not use these selectors as a security boundary.
+
 ### Back-compat stubs
 
 `getCurrentUser`, `getUsers`, `getMedia`, `getMediaItems`,
-`hasFinishedResolution`, `hasStartedResolution`, `isResolving`,
-`canUser`, `canUserEditEntityRecord`, `getAutosaves`, `getAutosave`,
-and `getReferenceByDistinctEdits` retain the M2 stub behavior (always
-null / empty / resolved). Site-editor features that need real values
-here should land them in a dedicated follow-up, not B1.
+`getAutosaves`, `getAutosave`, and `getReferenceByDistinctEdits`
+retain the M2 stub behavior (always null / empty). Site-editor
+features that need real values here should land them in a dedicated
+follow-up.
 
 ## Actions + mutators
 

--- a/docs/core-data-shim.md
+++ b/docs/core-data-shim.md
@@ -34,10 +34,20 @@ The API base is configured at editor bootstrap with
 
 ## Selectors
 
-All selectors read from the Redux store — they never trigger fetches
-themselves. Fetches are thunk actions (`fetchEntityRecord`,
-`fetchEntityRecords`) the editor calls imperatively (or that upstream
-block-editor components call via their own resolvers).
+`getEntityRecord` and `getEntityRecords` are wired to resolvers that
+dispatch `fetchEntityRecord` / `fetchEntityRecords` on first read for
+each `(kind, name, id|query)` tuple (G0 / #395). Subsequent reads hit
+the cache. Resolution metadata is exposed via `@wordpress/data`'s
+auto-supplied `hasFinishedResolution(selectorName, args)` /
+`isResolving(selectorName, args)` selectors so consumers (the
+template-part placeholder picker, archives inserters, `core/post-*`
+edit components, etc.) can render real loading states.
+
+Other selectors read from the Redux store directly — they never
+trigger fetches. Imperative fetches via the thunk actions
+(`fetchEntityRecord`, `fetchEntityRecords`) remain available for
+callers that need to refresh a tuple outside the resolver lifecycle
+(saves, list invalidation, etc.).
 
 | Selector                                        | Returns                                   | Purpose                                                   |
 | ----------------------------------------------- | ----------------------------------------- | --------------------------------------------------------- |

--- a/resources/js/visual-editor/vendor/__tests__/core-data-shim.test.tsx
+++ b/resources/js/visual-editor/vendor/__tests__/core-data-shim.test.tsx
@@ -581,6 +581,79 @@ describe('core-data-shim resolver auto-resolution', () => {
             ]),
         ).toBe(true);
     });
+
+    it('does not double-count composite-aliased records in list selectors', () => {
+        // Records with theme+slug are mirrored under a `<theme>//<slug>`
+        // alias for upstream lookups, but the alias must not show up as
+        // a separate item in `getEntityRecords` / totals — otherwise
+        // pickers would render duplicates.
+        coreDispatch().receiveEntityRecords('postType', 'wp_template_part', [
+            {
+                id: 1,
+                slug: 'footer',
+                theme: 'artisanpack-base',
+                title: { rendered: 'Footer' },
+            },
+            {
+                id: 2,
+                slug: 'header',
+                theme: 'artisanpack-base',
+                title: { rendered: 'Header' },
+            },
+        ]);
+
+        // Composite lookups still resolve.
+        expect(
+            coreSelect().getEntityRecord(
+                'postType',
+                'wp_template_part',
+                'artisanpack-base//footer',
+            ),
+        ).toMatchObject({ id: 1, slug: 'footer' });
+
+        // List + total reflect only primaries.
+        expect(
+            coreSelect().getEntityRecords('postType', 'wp_template_part'),
+        ).toHaveLength(2);
+        expect(
+            coreSelect().getEntityRecordsTotalItems(
+                'postType',
+                'wp_template_part',
+            ),
+        ).toBe(2);
+    });
+
+    it('drops composite aliases when the primary record is removed', () => {
+        coreDispatch().receiveEntityRecords('postType', 'wp_template_part', [
+            {
+                id: 1,
+                slug: 'footer',
+                theme: 'artisanpack-base',
+                title: { rendered: 'Footer' },
+            },
+        ]);
+
+        expect(
+            coreSelect().getEntityRecord(
+                'postType',
+                'wp_template_part',
+                'artisanpack-base//footer',
+            ),
+        ).toMatchObject({ id: 1 });
+
+        coreDispatch().removeEntityRecord('postType', 'wp_template_part', 1);
+
+        expect(
+            coreSelect().getEntityRecord('postType', 'wp_template_part', 1),
+        ).toBeNull();
+        expect(
+            coreSelect().getEntityRecord(
+                'postType',
+                'wp_template_part',
+                'artisanpack-base//footer',
+            ),
+        ).toBeNull();
+    });
 });
 
 describe('core-data-shim list-cache invalidation', () => {
@@ -1105,6 +1178,46 @@ describe('core-data-shim hooks', () => {
         expect(settled.records).toHaveLength(2);
         expect(settled.hasResolved).toBe(true);
         expect(settled.totalItems).toBe(2);
+    });
+
+    it('useEntityRecord exposes staged edits via editedRecord + hasEdits', () => {
+        // `useEntityRecord` returns the canonical cached record on
+        // `record` and the cached + staged-edits merge on
+        // `editedRecord`. Block-library reads `editedRecord` to render
+        // optimistic UI before saves land; if the hook ignored edits
+        // the canvas would flicker between the typed value and the
+        // server's stale copy.
+        coreDispatch().receiveEntityRecords('postType', 'wp_template', [
+            { id: 5, slug: 'index', title: 'Index' },
+        ]);
+
+        const initial = renderHook(() =>
+            useEntityRecord('postType', 'wp_template', 5),
+        ) as {
+            record: { title?: string } | null;
+            editedRecord: { title?: string } | null;
+            hasEdits: boolean;
+        };
+
+        expect(initial.record?.title).toBe('Index');
+        expect(initial.editedRecord?.title).toBe('Index');
+        expect(initial.hasEdits).toBe(false);
+
+        coreDispatch().editEntityRecord('postType', 'wp_template', 5, {
+            title: 'New Title',
+        });
+
+        const edited = renderHook(() =>
+            useEntityRecord('postType', 'wp_template', 5),
+        ) as {
+            record: { title?: string } | null;
+            editedRecord: { title?: string } | null;
+            hasEdits: boolean;
+        };
+
+        expect(edited.record?.title).toBe('Index');
+        expect(edited.editedRecord?.title).toBe('New Title');
+        expect(edited.hasEdits).toBe(true);
     });
 
     it('useEntityRecord starts unresolved when it has to fetch a missing record', () => {

--- a/resources/js/visual-editor/vendor/__tests__/core-data-shim.test.tsx
+++ b/resources/js/visual-editor/vendor/__tests__/core-data-shim.test.tsx
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
-import { dispatch, select } from '@wordpress/data';
+import { act, render, screen } from '@testing-library/react';
+import { dispatch, resolveSelect, select } from '@wordpress/data';
 
 import {
     DEFAULT_ENTITIES,
@@ -23,9 +23,36 @@ type CoreDispatch = Record<string, (...args: unknown[]) => unknown>;
 
 const coreSelect = (): CoreSelect => select('core') as CoreSelect;
 const coreDispatch = (): CoreDispatch => dispatch('core') as CoreDispatch;
+const coreResolveSelect = (): Record<
+    string,
+    (...args: unknown[]) => Promise<unknown>
+> =>
+    resolveSelect('core') as Record<
+        string,
+        (...args: unknown[]) => Promise<unknown>
+    >;
 
-function resetStore(): void {
+async function resetStore(): Promise<void> {
+    // Drain in-flight resolvers from the previous test so their
+    // pending `receiveEntityRecords` dispatches don't land mid-reset.
+    // Replacing the fetcher with a fast-fail responder forces any
+    // outstanding `restRequest` awaits to resolve immediately; the
+    // 50ms macrotask wait then settles the resolver thunks (which
+    // chain through several microtasks) before we wipe state and
+    // resolution metadata.
+    configureCoreDataShim({
+        apiBase: '/_drain_',
+        fetcher: async () =>
+            new Response(null, {
+                status: 503,
+                headers: { 'Content-Type': 'application/json' },
+            }),
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
     coreDispatch().reset();
+    coreDispatch().invalidateResolutionForStore();
 }
 
 function mockFetcher(
@@ -51,13 +78,13 @@ function jsonResponse(body: unknown, status = 200): Response {
     });
 }
 
-beforeEach(() => {
-    resetStore();
+beforeEach(async () => {
+    await resetStore();
     __resetCoreDataShimConfig();
 });
 
-afterEach(() => {
-    resetStore();
+afterEach(async () => {
+    await resetStore();
     __resetCoreDataShimConfig();
 });
 
@@ -202,14 +229,17 @@ describe('core-data-shim record cache', () => {
         expect(coreSelect().getNavigationFallbackId()).toBeUndefined();
     });
 
-    it('reports resolution as finished and not in-flight by default', () => {
+    it('reports resolution as not-yet-started for an unread entity tuple', () => {
+        // G0 (#395) wires resolvers for `getEntityRecord` /
+        // `getEntityRecords`. Before a tuple has been read, no
+        // resolver has fired, so `hasFinishedResolution` is false.
         expect(
             coreSelect().hasFinishedResolution('getEntityRecord', [
                 'postType',
                 'wp_template',
                 1,
             ]),
-        ).toBe(true);
+        ).toBe(false);
         expect(
             coreSelect().isResolving('getEntityRecord', [
                 'postType',
@@ -370,6 +400,186 @@ describe('core-data-shim fetch → cache', () => {
 
         expect(record).toBeNull();
         expect(calls).toHaveLength(0);
+    });
+});
+
+describe('core-data-shim resolver auto-resolution', () => {
+    it('resolves getEntityRecord by triggering fetchEntityRecord on first read', async () => {
+        const { fetcher, calls } = mockFetcher(async () =>
+            jsonResponse({ id: 9, slug: 'home' }),
+        );
+
+        configureCoreDataShim({ apiBase: '/api', fetcher });
+
+        const record = await coreResolveSelect().getEntityRecord(
+            'postType',
+            'wp_template',
+            9,
+        );
+
+        expect(record).toEqual({ id: 9, slug: 'home' });
+        expect(calls).toHaveLength(1);
+        expect(calls[0]?.url).toBe('/api/templates/9');
+        expect(
+            coreSelect().hasFinishedResolution('getEntityRecord', [
+                'postType',
+                'wp_template',
+                9,
+            ]),
+        ).toBe(true);
+    });
+
+    it('resolves getEntityRecords by triggering fetchEntityRecords on first read', async () => {
+        const { fetcher, calls } = mockFetcher(async () =>
+            jsonResponse([
+                { id: 1, slug: 'header' },
+                { id: 2, slug: 'footer' },
+            ]),
+        );
+
+        configureCoreDataShim({ apiBase: '/api', fetcher });
+
+        const records = await coreResolveSelect().getEntityRecords(
+            'postType',
+            'wp_template_part',
+            null,
+        );
+
+        expect(records).toHaveLength(2);
+        expect(calls).toHaveLength(1);
+        expect(calls[0]?.url).toBe('/api/template-parts');
+        expect(
+            coreSelect().hasFinishedResolution('getEntityRecords', [
+                'postType',
+                'wp_template_part',
+                null,
+            ]),
+        ).toBe(true);
+    });
+
+    it('does not refetch a resolved tuple on subsequent reads', async () => {
+        const { fetcher, calls } = mockFetcher(async () =>
+            jsonResponse({ id: 11, slug: 'page' }),
+        );
+
+        configureCoreDataShim({ apiBase: '/api', fetcher });
+
+        await coreResolveSelect().getEntityRecord(
+            'postType',
+            'wp_template',
+            11,
+        );
+        await coreResolveSelect().getEntityRecord(
+            'postType',
+            'wp_template',
+            11,
+        );
+
+        expect(calls).toHaveLength(1);
+    });
+
+    it('keeps an empty cache when the resolver hits a 404', async () => {
+        const { fetcher } = mockFetcher(async () => jsonResponse({}, 404));
+
+        configureCoreDataShim({ apiBase: '/api', fetcher });
+
+        const records = await coreResolveSelect().getEntityRecords(
+            'postType',
+            'wp_navigation',
+            null,
+        );
+
+        expect(records).toEqual([]);
+        expect(
+            coreSelect().hasFinishedResolution('getEntityRecords', [
+                'postType',
+                'wp_navigation',
+                null,
+            ]),
+        ).toBe(true);
+    });
+
+    it('resolves a composite <theme>//<slug> id via the index endpoint', async () => {
+        // Block-library reads `getEntityRecord(kind, 'wp_template_part',
+        // '<theme>//<slug>')` for saved template-part references. Our
+        // REST `show` route only accepts numeric ids, so the resolver
+        // falls back to listing the index filtered by theme+slug.
+        const { fetcher, calls } = mockFetcher(async () =>
+            jsonResponse({
+                data: [
+                    {
+                        id: 1,
+                        slug: 'footer',
+                        theme: 'artisanpack-base',
+                        title: { rendered: 'Footer' },
+                        content: { raw: '<!-- wp:paragraph -->', blocks: [] },
+                    },
+                ],
+                meta: { total: 1, last_page: 1 },
+            }),
+        );
+
+        configureCoreDataShim({ apiBase: '/api', fetcher });
+
+        const record = await coreResolveSelect().getEntityRecord(
+            'postType',
+            'wp_template_part',
+            'artisanpack-base//footer',
+        );
+
+        expect(record).toMatchObject({ id: 1, slug: 'footer' });
+        expect(calls).toHaveLength(1);
+        expect(calls[0]?.url).toBe(
+            '/api/template-parts?theme=artisanpack-base&slug=footer',
+        );
+        // Both the numeric id and the composite key resolve to the
+        // same record so subsequent reads hit the cache regardless of
+        // which form the caller uses.
+        expect(
+            coreSelect().getEntityRecord('postType', 'wp_template_part', 1),
+        ).toMatchObject({ id: 1, slug: 'footer' });
+        expect(
+            coreSelect().getEntityRecord(
+                'postType',
+                'wp_template_part',
+                'artisanpack-base//footer',
+            ),
+        ).toMatchObject({ id: 1, slug: 'footer' });
+    });
+
+    it('resolves getEditedEntityRecord through the same fetch path', async () => {
+        const { fetcher, calls } = mockFetcher(async () =>
+            jsonResponse({
+                data: [
+                    {
+                        id: 2,
+                        slug: 'header',
+                        theme: 'artisanpack-base',
+                        title: { rendered: 'Header' },
+                        content: { raw: '<!-- wp:site-title /-->', blocks: [] },
+                    },
+                ],
+                meta: { total: 1, last_page: 1 },
+            }),
+        );
+
+        configureCoreDataShim({ apiBase: '/api', fetcher });
+
+        const record = await coreResolveSelect().getEditedEntityRecord(
+            'postType',
+            'wp_template_part',
+            'artisanpack-base//header',
+        );
+
+        expect(record).toMatchObject({ id: 2, slug: 'header' });
+        expect(calls).toHaveLength(1);
+        expect(
+            coreSelect().hasFinishedResolution('getEditedEntityRecord', [
+                'postType',
+                'wp_template_part',
+                'artisanpack-base//header',
+            ]),
+        ).toBe(true);
     });
 });
 
@@ -780,6 +990,56 @@ describe('core-data-shim hooks', () => {
         expect(blocks[0]).toMatchObject({ name: 'core/paragraph' });
     });
 
+    it('useEntityBlockEditor decorates server blocks with clientId / isValid', () => {
+        // Block-editor's `useInnerBlocksProps` rejects blocks that
+        // lack a `clientId`; the shim's REST envelope ships only
+        // `{name, attributes, innerBlocks}` so the hook must decorate
+        // each block before handing them off (#395).
+        coreDispatch().receiveEntityRecords('postType', 'wp_template_part', [
+            {
+                id: 1,
+                slug: 'footer',
+                theme: 'artisanpack-base',
+                content: {
+                    raw: '<!-- wp:group -->',
+                    blocks: [
+                        {
+                            name: 'core/group',
+                            attributes: { tagName: 'footer' },
+                            innerBlocks: [
+                                {
+                                    name: 'core/paragraph',
+                                    attributes: { content: 'Hi' },
+                                    innerBlocks: [],
+                                },
+                            ],
+                        },
+                    ],
+                },
+            },
+        ]);
+
+        const [blocks] = renderHook(() =>
+            useEntityBlockEditor('postType', 'wp_template_part', { id: 1 }),
+        ) as readonly Array<{
+            name: string;
+            clientId: string;
+            isValid: true;
+            attributes: Record<string, unknown>;
+            innerBlocks: ReadonlyArray<{ name: string; clientId: string }>;
+        }>;
+
+        expect(blocks).toHaveLength(1);
+        expect(blocks[0].name).toBe('core/group');
+        expect(blocks[0].isValid).toBe(true);
+        expect(typeof blocks[0].clientId).toBe('string');
+        expect(blocks[0].clientId.length).toBeGreaterThan(0);
+        expect(blocks[0].attributes).toEqual({ tagName: 'footer' });
+        expect(blocks[0].innerBlocks).toHaveLength(1);
+        expect(blocks[0].innerBlocks[0].name).toBe('core/paragraph');
+        expect(typeof blocks[0].innerBlocks[0].clientId).toBe('string');
+    });
+
     it('flattens {raw, rendered} fields on getRawEntityRecord and getEditedEntityRecord', () => {
         coreDispatch().receiveEntityRecords('postType', 'wp_block', [
             {
@@ -812,6 +1072,39 @@ describe('core-data-shim hooks', () => {
         ) as { title?: unknown };
 
         expect(edited.title).toBe('Flatten Me');
+    });
+
+    it('useEntityRecords surfaces the list-cache and resolves through fetchEntityRecords', async () => {
+        const { fetcher, calls } = mockFetcher(async () =>
+            jsonResponse([
+                { id: 1, slug: 'header', title: 'Header' },
+                { id: 2, slug: 'footer', title: 'Footer' },
+            ]),
+        );
+
+        configureCoreDataShim({ apiBase: '/api', fetcher });
+
+        const initial = renderHook(() =>
+            useEntityRecords('postType', 'wp_template_part', null),
+        );
+
+        expect(initial.records).toEqual([]);
+        expect(initial.hasResolved).toBe(false);
+
+        // Wait for the resolver thunk + receive dispatch to settle.
+        await act(async () => {
+            await new Promise((resolve) => setTimeout(resolve, 20));
+        });
+
+        const settled = renderHook(() =>
+            useEntityRecords('postType', 'wp_template_part', null),
+        );
+
+        expect(calls).toHaveLength(1);
+        expect(calls[0]?.url).toBe('/api/template-parts');
+        expect(settled.records).toHaveLength(2);
+        expect(settled.hasResolved).toBe(true);
+        expect(settled.totalItems).toBe(2);
     });
 
     it('useEntityRecord starts unresolved when it has to fetch a missing record', () => {

--- a/resources/js/visual-editor/vendor/core-data-shim.ts
+++ b/resources/js/visual-editor/vendor/core-data-shim.ts
@@ -45,19 +45,11 @@ import {
     createContext,
     createElement,
     useContext,
-    useEffect,
     useMemo,
-    useRef,
-    useState,
     type PropsWithChildren,
     type ReactElement,
 } from 'react';
-import {
-    createReduxStore,
-    register,
-    useDispatch,
-    useSelect,
-} from '@wordpress/data';
+import { createReduxStore, register, useSelect } from '@wordpress/data';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -318,6 +310,49 @@ function recordIdOf(
     return null;
 }
 
+/**
+ * Returns the upstream `<theme>//<slug>` composite key for a record, or
+ * `null` if the record can't form one. Used to mirror template-part /
+ * template records under the lookup id the block-library expects without
+ * changing the REST contract.
+ */
+function compositeRecordKey(record: EntityRecord): string | null {
+    const theme = record.theme;
+    const slug = record.slug;
+
+    if (typeof theme !== 'string' || typeof slug !== 'string') {
+        return null;
+    }
+
+    if (theme === '' || slug === '') {
+        return null;
+    }
+
+    return `${theme}//${slug}`;
+}
+
+/**
+ * Splits a `<theme>//<slug>` composite id into its parts, or returns
+ * `null` if the value isn't in that shape. The separator is a literal
+ * `//` rather than a regex so slugs that legitimately contain `/`
+ * round-trip without ambiguity.
+ */
+function splitCompositeId(
+    id: string,
+): { theme: string; slug: string } | null {
+    const separator = '//';
+    const idx = id.indexOf(separator);
+
+    if (idx <= 0 || idx === id.length - separator.length) {
+        return null;
+    }
+
+    return {
+        theme: id.slice(0, idx),
+        slug: id.slice(idx + separator.length),
+    };
+}
+
 function entityUrl(config: EntityConfig, id?: EntityKey): string {
     const base = shimConfig.apiBase.replace(/\/$/, '');
     const path = config.baseURL.startsWith('/')
@@ -489,6 +524,18 @@ function reducer(
 
                 nextItems[String(id)] = record;
                 receivedIds.push(id);
+
+                // Upstream `@wordpress/block-library` looks up template parts
+                // (and templates) by a composite `<theme>//<slug>` id while
+                // our REST endpoints return numeric ids. Mirror the record
+                // under the composite key so `getEntityRecord(kind, name,
+                // "<theme>//<slug>")` and `getEditedEntityRecord(...)` find
+                // it without a backend contract change. See #395.
+                const compositeKey = compositeRecordKey(record);
+
+                if (compositeKey !== null) {
+                    nextItems[compositeKey] = record;
+                }
             }
 
             // `query === undefined` = save-path / single-record fetch.
@@ -692,25 +739,34 @@ function selectEntityRecord(
 /**
  * WordPress's `getRawEntityRecord` flattens any `{raw, rendered}`
  * shaped property to its `raw` string. Block-library code (e.g.
- * `core/block`'s `__experimentalLabel`) relies on this — it passes
- * `entity.title` straight to `decodeEntities()`, which coerces the
- * structured object to `[object Object]` if the shim returns the
- * REST shape verbatim. The flattener mirrors core-data's behaviour
- * so synced patterns surface their human-readable title in the
+ * `core/block`'s `__experimentalLabel`, `core/template-part`'s
+ * label) relies on this — it passes `entity.title` straight to
+ * `decodeEntities()`, which coerces the structured object to
+ * `[object Object]` if the shim returns the REST shape verbatim.
+ * The flattener mirrors core-data's behaviour so synced patterns
+ * and template parts surface their human-readable title in the
  * canvas + inspector.
+ *
+ * When `raw` is absent, falls back to `rendered` — our REST
+ * resources currently emit only `{rendered}` for `title`, and
+ * upstream flattens to whichever string-typed key is present.
  */
 function flattenRawProperties(record: EntityRecord): EntityRecord {
     const out: EntityRecord = {};
 
     for (const [key, value] of Object.entries(record)) {
-        if (
-            value !== null &&
-            typeof value === 'object' &&
-            'raw' in value &&
-            typeof (value as { raw?: unknown }).raw === 'string'
-        ) {
-            out[key] = (value as { raw: string }).raw;
-            continue;
+        if (value !== null && typeof value === 'object') {
+            const shape = value as { raw?: unknown; rendered?: unknown };
+
+            if (typeof shape.raw === 'string') {
+                out[key] = shape.raw;
+                continue;
+            }
+
+            if (typeof shape.rendered === 'string') {
+                out[key] = shape.rendered;
+                continue;
+            }
         }
 
         out[key] = value;
@@ -949,15 +1005,30 @@ const selectors = {
     ): Record<string, unknown> | null => state.globalStylesBase,
 
     // Stubs retained for back-compat with pre-B1 callsites.
+    //
+    // `hasFinishedResolution` / `hasStartedResolution` / `isResolving` were
+    // manual `true`/`false` stubs in the M2 shim. G0 (#395) registers
+    // resolvers for `getEntityRecord` / `getEntityRecords`, so
+    // `@wordpress/data` now auto-supplies the resolution-tracking
+    // selectors and the manual stubs would shadow them. Stubs removed
+    // here; selectors without a registered resolver (canUser, etc.)
+    // still fall through to wp-data's default `true`.
     getCurrentUser: (): EntityRecord | null => null,
     getUsers: (): readonly EntityRecord[] => EMPTY_RECORDS,
     getMedia: (): EntityRecord | null => null,
     getMediaItems: (): readonly EntityRecord[] => EMPTY_RECORDS,
-    hasFinishedResolution: (): boolean => true,
-    hasStartedResolution: (): boolean => true,
-    isResolving: (): boolean => false,
-    canUser: (): boolean => false,
-    canUserEditEntityRecord: (): boolean => false,
+    // Pre-G0 (#395) these returned `false`, which was harmless when no
+    // entity reads ever resolved — the block-library code never reached
+    // the `canUser` gates because the placeholder/spinner short-circuited
+    // first. Now that the resolvers populate entity records, the
+    // `wp_template_part` (and post-* / site-*) edit components reach
+    // their `canUser('read', …)` / `canUser('update', …)` checks and
+    // refuse to render anything when both come back `false`. Until G5
+    // (#98) wires real permissions through `visual_editor.*` policies,
+    // assume any user with editor access has full CRUD — the editor
+    // surface is already gated by the package's auth middleware.
+    canUser: (): boolean => true,
+    canUserEditEntityRecord: (): boolean => true,
     getAutosaves: (): readonly EntityRecord[] => EMPTY_RECORDS,
     getAutosave: (): EntityRecord | null => null,
     getReferenceByDistinctEdits: (): readonly number[] => EMPTY_RECORDS,
@@ -1165,6 +1236,12 @@ const actions = {
      * Fetches a single entity record from the REST API and caches it.
      * Swallows network/endpoint failures so unregistered or not-yet-built
      * endpoints degrade to an empty result instead of throwing.
+     *
+     * Composite (`<theme>//<slug>`) ids fall back to the index endpoint
+     * filtered by `theme` + `slug`. Block-library looks template parts
+     * up by the composite form even though the REST `show` route only
+     * accepts the numeric primary key, so the shim bridges by listing
+     * one and picking the single match.
      */
     fetchEntityRecord:
         (kind: EntityKind, name: EntityName, id: EntityKey) =>
@@ -1175,7 +1252,30 @@ const actions = {
                 return null;
             }
 
+            const compositeParts =
+                typeof id === 'string' ? splitCompositeId(id) : null;
+
             try {
+                if (compositeParts !== null) {
+                    const url = `${entityUrl(config)}${queryString({
+                        theme: compositeParts.theme,
+                        slug: compositeParts.slug,
+                    })}`;
+                    const body = (await restRequest(url, {
+                        method: 'GET',
+                        headers: buildHeaders(false),
+                    })) as unknown;
+
+                    const parsed = normalizeListResponse(body);
+                    const record = parsed.records[0] ?? null;
+
+                    if (record !== null) {
+                        dispatch.receiveEntityRecords(kind, name, [record]);
+                    }
+
+                    return record;
+                }
+
                 const record = (await restRequest(entityUrl(config, id), {
                     method: 'GET',
                     headers: buildHeaders(false),
@@ -1400,6 +1500,40 @@ function normalizeListResponse(body: unknown): NormalizedList {
 }
 
 // ---------------------------------------------------------------------------
+// Resolvers
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolvers for `getEntityRecord` / `getEntityRecords` /
+ * `getEditedEntityRecord`.
+ *
+ * Pre-G0 (#395) the shim cache only populated through manual
+ * `dispatch.fetchEntityRecord(...)` / `fetchEntityRecords(...)` or
+ * `receiveEntityRecords(...)` calls; reading via selectors alone
+ * (e.g. block-library's `useEntityRecords`) returned the empty cache
+ * forever. Wiring the resolvers here lets `@wordpress/data` fire the
+ * existing fetch thunks the first time each `(kind, name, id|query)`
+ * tuple is read, populate the cache, and surface real
+ * `isResolving` / `hasFinishedResolution` flags.
+ *
+ * `getEditedEntityRecord` forwards to the same fetch — mirroring
+ * upstream `@wordpress/core-data`'s `forwardResolver('getEntityRecord')`
+ * — so the template-part `edit` component (which gates on
+ * `hasFinishedResolution('getEditedEntityRecord', …)`) sees the
+ * record settle and stops spinning.
+ *
+ * The thunks already swallow network failures (see their bodies), so
+ * unregistered or not-yet-built endpoints degrade to empty state
+ * without throwing — preserving the empty-state contract documented
+ * in `docs/core-data-shim.md`.
+ */
+const resolvers = {
+    getEntityRecord: actions.fetchEntityRecord,
+    getEntityRecords: actions.fetchEntityRecords,
+    getEditedEntityRecord: actions.fetchEntityRecord,
+};
+
+// ---------------------------------------------------------------------------
 // Store registration
 // ---------------------------------------------------------------------------
 
@@ -1410,6 +1544,7 @@ export const store = createReduxStore(STORE_NAME, {
     ) => CoreDataState,
     actions: actions as unknown as Record<string, unknown>,
     selectors: selectors as unknown as Record<string, unknown>,
+    resolvers: resolvers as unknown as Record<string, () => unknown>,
 });
 
 register(store);
@@ -1461,26 +1596,26 @@ export function useEntityProp<T = unknown>(): [
 }
 
 /**
- * Returns the cached entity record. The B1 shim originally returned a
- * null record stub; D5 (#372) needs a real read so `core/block`'s
- * `isMissing` check passes for synced patterns. Two paths populate the
- * cache:
+ * Returns the cached entity record, triggering a single REST resolution
+ * the first time each `(kind, name, id)` tuple is read.
  *
- *   1. The patterns inserter primes records via
- *      `receiveEntityRecords` at fetch time, so the very first synced
- *      insertion resolves without a round-trip.
- *   2. When `core/block` mounts on page reload (before any inserter
- *      ran), the saved post tree carries `core/block` references for
- *      already-synced patterns. The cache is empty for those, so the
- *      hook fires `fetchEntityRecord` once per missing tuple and
- *      reports `hasResolved=false` until the fetch settles. Without
- *      this branch, every saved synced reference would render "Block
- *      has been deleted or is unavailable." after a reload — the same
- *      crash D5 #372 was filed to fix.
+ * Pre-G0 (#395) this hook ran a manual `useEffect`/`useState` lifecycle
+ * to fire `fetchEntityRecord` on cache miss because the shim store had
+ * no resolvers wired. With resolvers now registered for
+ * `getEntityRecord`, `@wordpress/data` handles the fetch + tracking
+ * automatically; the hook just reads the selector and the auto-supplied
+ * `isResolving` / `hasFinishedResolution` metadata.
+ *
+ * `hasResolved` falls back to `record !== null` so callers that
+ * pre-populate the cache via `dispatch.receiveEntityRecords(...)`
+ * (e.g. the patterns inserter priming D5 synced refs) report resolved
+ * even though no resolver fired. Without this OR the inserter-primed
+ * `core/block` mount would see `hasResolved: false` for one render and
+ * flash the "deleted" placeholder.
  *
  * Edits are still no-ops — callers wanting to write through must use
- * the section's dedicated editor (D2 templates, D5 patterns, …)
- * rather than `editEntityRecord` from the inline edit path.
+ * the section's dedicated editor (D2 templates, D5 patterns, …) rather
+ * than `editEntityRecord` from the inline edit path.
  */
 export function useEntityRecord<T = unknown>(
     kind?: EntityKind,
@@ -1495,7 +1630,7 @@ export function useEntityRecord<T = unknown>(
     edit: typeof noopSetter;
     save: () => Promise<null>;
 } {
-    const record = useSelect(
+    return useSelect(
         (select) => {
             if (
                 kind === undefined ||
@@ -1503,7 +1638,15 @@ export function useEntityRecord<T = unknown>(
                 id === undefined ||
                 id === null
             ) {
-                return null;
+                return {
+                    record: null as T | null,
+                    editedRecord: null as T | null,
+                    hasEdits: false,
+                    hasResolved: true,
+                    isResolving: false,
+                    edit: noopSetter,
+                    save: async () => null,
+                };
             }
 
             const store = select(STORE_NAME) as
@@ -1511,167 +1654,152 @@ export function useEntityRecord<T = unknown>(
                       getEntityRecord?: (
                           kind: EntityKind,
                           name: EntityName,
-                          id: EntityKey
+                          id: EntityKey,
                       ) => EntityRecord | null;
+                      hasFinishedResolution?: (
+                          selectorName: string,
+                          args: readonly unknown[],
+                      ) => boolean;
+                      isResolving?: (
+                          selectorName: string,
+                          args: readonly unknown[],
+                      ) => boolean;
                   }
                 | undefined;
 
-            return store?.getEntityRecord?.(kind, name, id) ?? null;
+            const args: readonly unknown[] = [kind, name, id];
+            const record = (store?.getEntityRecord?.(kind, name, id) ??
+                null) as T | null;
+
+            return {
+                record,
+                editedRecord: record,
+                hasEdits: false,
+                hasResolved:
+                    record !== null ||
+                    (store?.hasFinishedResolution?.('getEntityRecord', args) ??
+                        false),
+                isResolving:
+                    store?.isResolving?.('getEntityRecord', args) ?? false,
+                edit: noopSetter,
+                save: async () => null,
+            };
         },
-        [kind, name, id]
+        [kind, name, id],
     );
-
-    const dispatchActions = useDispatch(STORE_NAME) as
-        | {
-              fetchEntityRecord?: (
-                  kind: EntityKind,
-                  name: EntityName,
-                  id: EntityKey
-              ) => Promise<EntityRecord | null>;
-          }
-        | null
-        | undefined;
-
-    const tupleKey =
-        kind !== undefined &&
-        name !== undefined &&
-        id !== undefined &&
-        id !== null
-            ? `${kind}|${name}|${id}`
-            : null;
-
-    const [resolutionState, setResolutionState] = useState<{
-        key: string | null;
-        hasResolved: boolean;
-        isResolving: boolean;
-    }>({
-        key: tupleKey,
-        // No id, or already in cache → resolution is trivially "done"
-        // on first render so consumers don't see a spinner that
-        // never had work to do.
-        hasResolved: tupleKey === null || record !== null,
-        isResolving: false,
-    });
-
-    // Snapshot the latest dispatch + record without forcing the
-    // resolution effect to re-fire when their identities churn.
-    const fetcherRef = useRef(dispatchActions?.fetchEntityRecord);
-    fetcherRef.current = dispatchActions?.fetchEntityRecord;
-
-    const recordRef = useRef(record);
-    recordRef.current = record;
-
-    useEffect(() => {
-        if (tupleKey === null) {
-            setResolutionState({
-                key: null,
-                hasResolved: true,
-                isResolving: false,
-            });
-
-            return undefined;
-        }
-
-        // Already cached. Mark resolved without a round-trip.
-        if (recordRef.current !== null) {
-            setResolutionState({
-                key: tupleKey,
-                hasResolved: true,
-                isResolving: false,
-            });
-
-            return undefined;
-        }
-
-        const fetcher = fetcherRef.current;
-
-        if (typeof fetcher !== 'function') {
-            // No fetcher available — degrade gracefully so consumers
-            // don't get stuck on a perpetual spinner. Treat the
-            // resolution as finished even though the cache is empty;
-            // `core/block` will then surface the "deleted" placeholder
-            // (which is correct — there's no way to reach the record).
-            setResolutionState({
-                key: tupleKey,
-                hasResolved: true,
-                isResolving: false,
-            });
-
-            return undefined;
-        }
-
-        let cancelled = false;
-
-        setResolutionState({
-            key: tupleKey,
-            hasResolved: false,
-            isResolving: true,
-        });
-
-        void Promise.resolve(
-            fetcher(kind as EntityKind, name as EntityName, id as EntityKey)
-        ).finally(() => {
-            if (cancelled) {
-                return;
-            }
-
-            setResolutionState((prev) =>
-                prev.key === tupleKey
-                    ? { key: tupleKey, hasResolved: true, isResolving: false }
-                    : prev
-            );
-        });
-
-        return () => {
-            cancelled = true;
-        };
-    }, [tupleKey, kind, name, id]);
-
-    const hasResolved =
-        resolutionState.key === tupleKey ? resolutionState.hasResolved : false;
-    const isResolving =
-        resolutionState.key === tupleKey ? resolutionState.isResolving : false;
-
-    return {
-        record: (record as T | null) ?? null,
-        editedRecord: (record as T | null) ?? null,
-        hasEdits: false,
-        hasResolved,
-        isResolving,
-        edit: noopSetter,
-        save: async () => null,
-    };
 }
 
-export function useEntityRecords<T = unknown>(): {
+/**
+ * Returns the cached list of entity records for `(kind, name, query)`,
+ * triggering a single REST resolution the first time the tuple is read.
+ *
+ * Pre-G0 (#395) this hook returned `EMPTY_RECORDS` regardless of cache
+ * or query. With the `getEntityRecords` resolver wired, the first read
+ * dispatches `fetchEntityRecords`; subsequent reads hit the cache.
+ * `isResolving` / `hasResolved` come from `@wordpress/data`'s
+ * resolution tracking so consumers (e.g. the `core/template-part`
+ * placeholder picker, archives inserters) can render real loading
+ * states.
+ *
+ * Errors are still swallowed inside the fetch thunk — endpoints that
+ * 404 or are not yet built degrade to an empty list, matching the
+ * empty-state contract documented in `docs/core-data-shim.md`.
+ */
+export function useEntityRecords<T = unknown>(
+    kind?: EntityKind,
+    name?: EntityName,
+    query?: Record<string, unknown> | null,
+): {
     records: readonly T[];
     hasResolved: boolean;
     isResolving: boolean;
-    status: 'IDLE';
+    status: 'IDLE' | 'RESOLVING' | 'SUCCESS';
     totalItems: number;
     totalPages: number;
 } {
-    return {
-        records: EMPTY_RECORDS as readonly T[],
-        hasResolved: true,
-        isResolving: false,
-        status: 'IDLE',
-        totalItems: 0,
-        totalPages: 0,
-    };
+    return useSelect(
+        (select) => {
+            if (kind === undefined || name === undefined) {
+                return {
+                    records: EMPTY_RECORDS as readonly T[],
+                    hasResolved: true,
+                    isResolving: false,
+                    status: 'IDLE' as const,
+                    totalItems: 0,
+                    totalPages: 0,
+                };
+            }
+
+            const store = select(STORE_NAME) as
+                | {
+                      getEntityRecords?: (
+                          kind: EntityKind,
+                          name: EntityName,
+                          query?: Record<string, unknown> | null,
+                      ) => readonly EntityRecord[];
+                      getEntityRecordsTotalItems?: (
+                          kind: EntityKind,
+                          name: EntityName,
+                          query?: Record<string, unknown> | null,
+                      ) => number;
+                      getEntityRecordsTotalPages?: (
+                          kind: EntityKind,
+                          name: EntityName,
+                          query?: Record<string, unknown> | null,
+                      ) => number;
+                      hasFinishedResolution?: (
+                          selectorName: string,
+                          args: readonly unknown[],
+                      ) => boolean;
+                      isResolving?: (
+                          selectorName: string,
+                          args: readonly unknown[],
+                      ) => boolean;
+                  }
+                | undefined;
+
+            const args: readonly unknown[] = [kind, name, query];
+            const records = (store?.getEntityRecords?.(kind, name, query) ??
+                EMPTY_RECORDS) as readonly T[];
+            const hasResolved =
+                store?.hasFinishedResolution?.('getEntityRecords', args) ??
+                false;
+            const isResolving =
+                store?.isResolving?.('getEntityRecords', args) ?? false;
+
+            return {
+                records,
+                hasResolved,
+                isResolving,
+                status: isResolving
+                    ? ('RESOLVING' as const)
+                    : hasResolved
+                      ? ('SUCCESS' as const)
+                      : ('IDLE' as const),
+                totalItems:
+                    store?.getEntityRecordsTotalItems?.(kind, name, query) ?? 0,
+                totalPages:
+                    store?.getEntityRecordsTotalPages?.(kind, name, query) ?? 0,
+            };
+        },
+        [kind, name, query],
+    );
 }
 
 /**
  * Resolves the inner block tree for an entity record.
  *
- * `core/block` (the synced-pattern reference block) calls this with
- * `('postType', 'wp_block', { id: ref })` to load the pattern's saved
- * blocks. The B1 shim originally returned an empty array which made
- * the block render "Block has been deleted or is unavailable" even
- * when the wp_block record was cached. D5 (#372) needed real reads,
- * so the implementation now pulls the cached record, prefers the
- * already-parsed `content.blocks` payload, and falls back to parsing
- * the raw HTML when `blocks` is missing.
+ * `core/block` (synced patterns) and `core/template-part` call this
+ * with `(kind, name, { id })` to load saved inner blocks. Our REST
+ * endpoints ship `content.blocks` already parsed server-side, but in
+ * the upstream client-shape the block editor expects each block also
+ * needs a stable `clientId` and an `isValid` flag — without them,
+ * `useInnerBlocksProps` flags the tree as "unexpected or invalid
+ * content" (#395 follow-up).
+ *
+ * `decorateServerBlocks` walks the server tree, fills in the missing
+ * fields, and caches the result by `(kind, name, id, raw)` so render
+ * loops don't reissue fresh `clientId`s on every selector read.
  *
  * Edits are still no-ops — saving a synced pattern goes through the
  * dedicated patterns canvas in the site editor (D5), not via this
@@ -1721,26 +1849,122 @@ export function useEntityBlockEditor(
                 return EMPTY_RECORDS as readonly unknown[];
             }
 
-            // The patterns C5 endpoint (and the templates / parts
-            // endpoints alongside it) always ship `content.blocks`
-            // alongside `content.raw`, so we trust the parsed array
-            // and skip the `parse(raw)` fallback. Adding `parseBlocks`
-            // here would force `@wordpress/blocks` into every test
-            // that ever imports the shim — vitest can't resolve that
-            // package's strict-ESM JSON import without per-test
-            // mocks, and the fallback never fires in production.
-            const parsed = (content as { blocks?: unknown }).blocks;
+            const serverBlocks = (content as { blocks?: unknown }).blocks;
 
-            if (Array.isArray(parsed)) {
-                return parsed as readonly unknown[];
+            if (!Array.isArray(serverBlocks)) {
+                return EMPTY_RECORDS as readonly unknown[];
             }
 
-            return EMPTY_RECORDS as readonly unknown[];
+            return getDecoratedBlocks(
+                kind,
+                name,
+                id,
+                serverBlocks as readonly unknown[],
+            );
         },
         [kind, name, id]
     );
 
     return [blocks, noopSetter, noopSetter];
+}
+
+interface ServerBlock {
+    name: string;
+    attributes?: Record<string, unknown>;
+    innerBlocks?: readonly ServerBlock[];
+}
+
+interface DecoratedBlock {
+    name: string;
+    clientId: string;
+    isValid: true;
+    attributes: Record<string, unknown>;
+    innerBlocks: readonly DecoratedBlock[];
+}
+
+const decoratedBlocksCache = new Map<
+    string,
+    { source: readonly unknown[]; decorated: readonly DecoratedBlock[] }
+>();
+
+/**
+ * Returns the server's pre-parsed block tree decorated with the
+ * `clientId` / `isValid` fields the block editor needs, memoized
+ * per `(kind, name, id)` so successive selector reads return the
+ * same array reference and the editor doesn't see "new" blocks
+ * on every render.
+ */
+function getDecoratedBlocks(
+    kind: EntityKind,
+    name: EntityName,
+    id: EntityKey,
+    serverBlocks: readonly unknown[],
+): readonly DecoratedBlock[] {
+    const cacheKey = `${kind}|${name}|${id}`;
+    const cached = decoratedBlocksCache.get(cacheKey);
+
+    if (cached && cached.source === serverBlocks) {
+        return cached.decorated;
+    }
+
+    const decorated = decorateBlockList(serverBlocks);
+    decoratedBlocksCache.set(cacheKey, { source: serverBlocks, decorated });
+
+    return decorated;
+}
+
+function decorateBlockList(
+    blocks: readonly unknown[],
+): readonly DecoratedBlock[] {
+    const out: DecoratedBlock[] = [];
+
+    for (const block of blocks) {
+        const decorated = decorateBlock(block);
+
+        if (decorated !== null) {
+            out.push(decorated);
+        }
+    }
+
+    return out;
+}
+
+function decorateBlock(block: unknown): DecoratedBlock | null {
+    if (
+        block === null ||
+        typeof block !== 'object' ||
+        typeof (block as ServerBlock).name !== 'string'
+    ) {
+        return null;
+    }
+
+    const server = block as ServerBlock;
+    const innerBlocks = Array.isArray(server.innerBlocks)
+        ? decorateBlockList(server.innerBlocks)
+        : EMPTY_RECORDS;
+
+    return {
+        name: server.name,
+        clientId: createClientId(),
+        isValid: true,
+        attributes: server.attributes ?? {},
+        innerBlocks,
+    };
+}
+
+let clientIdCounter = 0;
+
+function createClientId(): string {
+    if (
+        typeof globalThis.crypto !== 'undefined' &&
+        typeof globalThis.crypto.randomUUID === 'function'
+    ) {
+        return globalThis.crypto.randomUUID();
+    }
+
+    clientIdCounter += 1;
+
+    return `shim-${Date.now().toString(36)}-${clientIdCounter.toString(36)}`;
 }
 
 export function useResourcePermissions(): {

--- a/resources/js/visual-editor/vendor/core-data-shim.ts
+++ b/resources/js/visual-editor/vendor/core-data-shim.ts
@@ -87,6 +87,13 @@ interface EntityIdentity {
 
 interface EntityBag {
     items: Record<string, EntityRecord>;
+    /**
+     * Read-only alias map (e.g. `<theme>//<slug>` → numeric primary key)
+     * for upstream-shape lookups. Never iterated as records and never
+     * counted by `getEntityRecordsTotalItems` — only used to redirect
+     * `getEntityRecord(kind, name, alias)` to the real item.
+     */
+    aliases: Record<string, string>;
     queries: Record<string, readonly EntityKey[]>;
     queryMeta: Record<string, { totalItems: number; totalPages: number }>;
 }
@@ -507,12 +514,14 @@ function reducer(
             const key = entityKey(action.kind, action.name);
             const bag: EntityBag = state.records[key] ?? {
                 items: {},
+                aliases: {},
                 queries: {},
                 queryMeta: {},
             };
             const config = state.entities[key];
 
             const nextItems: Record<string, EntityRecord> = { ...bag.items };
+            const nextAliases: Record<string, string> = { ...bag.aliases };
             const receivedIds: EntityKey[] = [];
 
             for (const record of action.records) {
@@ -522,19 +531,21 @@ function reducer(
                     continue;
                 }
 
-                nextItems[String(id)] = record;
+                const primaryKey = String(id);
+                nextItems[primaryKey] = record;
                 receivedIds.push(id);
 
                 // Upstream `@wordpress/block-library` looks up template parts
                 // (and templates) by a composite `<theme>//<slug>` id while
-                // our REST endpoints return numeric ids. Mirror the record
-                // under the composite key so `getEntityRecord(kind, name,
-                // "<theme>//<slug>")` and `getEditedEntityRecord(...)` find
-                // it without a backend contract change. See #395.
+                // our REST endpoints return numeric ids. Track the composite
+                // form in a separate alias map keyed `composite → primary`
+                // so `getEntityRecord(kind, name, "<theme>//<slug>")` resolves
+                // to the same record without double-counting it in
+                // `getEntityRecords` / `getEntityRecordsTotalItems`. See #395.
                 const compositeKey = compositeRecordKey(record);
 
-                if (compositeKey !== null) {
-                    nextItems[compositeKey] = record;
+                if (compositeKey !== null && compositeKey !== primaryKey) {
+                    nextAliases[compositeKey] = primaryKey;
                 }
             }
 
@@ -580,6 +591,7 @@ function reducer(
                     ...state.records,
                     [key]: {
                         items: nextItems,
+                        aliases: nextAliases,
                         queries: nextQueries,
                         queryMeta: nextQueryMeta,
                     },
@@ -595,15 +607,27 @@ function reducer(
                 return state;
             }
 
+            const primaryKey = String(action.id);
             const nextItems = { ...bag.items };
-            delete nextItems[String(action.id)];
+            delete nextItems[primaryKey];
+
+            // Drop any composite alias that pointed at the removed primary
+            // so subsequent `getEntityRecord(kind, name, "<theme>//<slug>")`
+            // calls return null rather than redirecting to an evicted item.
+            const nextAliases = { ...bag.aliases };
+
+            for (const [alias, target] of Object.entries(nextAliases)) {
+                if (target === primaryKey) {
+                    delete nextAliases[alias];
+                }
+            }
 
             // A delete invalidates every cached filter query (the removed
             // record might have filtered in or out of any of them) and
             // their totals (`totalItems` would otherwise return a stale
             // pre-delete count). Drop both.
             const nextEdits = { ...(state.edits[key] ?? {}) };
-            delete nextEdits[String(action.id)];
+            delete nextEdits[primaryKey];
 
             return {
                 ...state,
@@ -611,6 +635,7 @@ function reducer(
                     ...state.records,
                     [key]: {
                         items: nextItems,
+                        aliases: nextAliases,
                         queries: {},
                         queryMeta: {},
                     },
@@ -731,9 +756,29 @@ function selectEntityRecord(
     name: EntityName,
     id: EntityKey,
 ): EntityRecord | null {
-    return (
-        state.records[entityKey(kind, name)]?.items[String(id)] ?? null
-    );
+    const bag = state.records[entityKey(kind, name)];
+
+    if (!bag) {
+        return null;
+    }
+
+    const primary = String(id);
+    const direct = bag.items[primary];
+
+    if (direct !== undefined) {
+        return direct;
+    }
+
+    // Fall through to the composite alias map so upstream-shape lookups
+    // like `getEntityRecord('postType', 'wp_template_part', '<theme>//<slug>')`
+    // resolve to the same record stored under the numeric primary key.
+    const aliasTarget = bag.aliases[primary];
+
+    if (aliasTarget !== undefined) {
+        return bag.items[aliasTarget] ?? null;
+    }
+
+    return null;
 }
 
 /**
@@ -1613,9 +1658,10 @@ export function useEntityProp<T = unknown>(): [
  * `core/block` mount would see `hasResolved: false` for one render and
  * flash the "deleted" placeholder.
  *
- * Edits are still no-ops — callers wanting to write through must use
- * the section's dedicated editor (D2 templates, D5 patterns, …) rather
- * than `editEntityRecord` from the inline edit path.
+ * `editedRecord` and `hasEdits` reflect the store's edits bag — staged
+ * `editEntityRecord(...)` writes appear immediately. The `edit` and
+ * `save` callbacks remain no-ops since this hook is the read-side
+ * surface; the visual editor saves through dedicated paths.
  */
 export function useEntityRecord<T = unknown>(
     kind?: EntityKind,
@@ -1656,6 +1702,16 @@ export function useEntityRecord<T = unknown>(
                           name: EntityName,
                           id: EntityKey,
                       ) => EntityRecord | null;
+                      getEditedEntityRecord?: (
+                          kind: EntityKind,
+                          name: EntityName,
+                          id: EntityKey,
+                      ) => EntityRecord | null;
+                      hasEditsForEntityRecord?: (
+                          kind: EntityKind,
+                          name: EntityName,
+                          id: EntityKey,
+                      ) => boolean;
                       hasFinishedResolution?: (
                           selectorName: string,
                           args: readonly unknown[],
@@ -1670,11 +1726,18 @@ export function useEntityRecord<T = unknown>(
             const args: readonly unknown[] = [kind, name, id];
             const record = (store?.getEntityRecord?.(kind, name, id) ??
                 null) as T | null;
+            const editedRecord = (store?.getEditedEntityRecord?.(
+                kind,
+                name,
+                id,
+            ) ?? record) as T | null;
+            const hasEdits =
+                store?.hasEditsForEntityRecord?.(kind, name, id) ?? false;
 
             return {
                 record,
-                editedRecord: record,
-                hasEdits: false,
+                editedRecord,
+                hasEdits,
                 hasResolved:
                     record !== null ||
                     (store?.hasFinishedResolution?.('getEntityRecord', args) ??


### PR DESCRIPTION
## Description

Wires resolvers into the in-repo \`@wordpress/core-data\` shim so reading entity records via the \`core\` store actually fetches them. Pre-G0 the shim's \`useEntityRecords\` returned an empty cache forever and \`useEntityRecord\` ran a manual \`useEffect\`/\`useState\` lifecycle to dispatch fetches; with E4 (#381) re-enabling the entity-backed core blocks (\`core/template-part\`, \`core/post-*\`, \`core/site-*\`, \`core/navigation\`) the gap was user-visible — the template-part placeholder showed an empty picker and saved template-part references rendered "deleted or unavailable" instead of inlining.

This is **Wave 1, G0** of the visual-editor V1 issue roadmap (\`docs/plans/15-issue-roadmap.md\`). It unblocks G3 (\`#399\` — entity adapter for Post/Page) and the rest of Phase G.

**Closes:** #395

## Type of Change

- [x] Bug fix (fixes an issue)

## Related Issue

**Issue:** #395

## Motivation and Context

Phase G needs entity reads through the WP-shape REST adapter to actually populate the cache so the entity-backed core blocks have data to render. The B1 audit (\`docs/core-data-shim.md\`) deferred auto-resolution to a later phase — this is that phase.

Most of the change is mechanical resolver wiring. Three additional adaptations were needed to make the saved-template-part case actually inline correctly without a backend contract change:

1. **Composite \`<theme>//<slug>\` lookups.** Block-library reads template parts by composite id while our REST returns numeric ids. The reducer now mirrors records with \`theme\` + \`slug\` under both keys, and \`fetchEntityRecord\` falls back to \`?theme=…&slug=…\` filters on the index endpoint when the id is composite.
2. **Server-parsed block decoration.** Our REST ships \`content.blocks\` server-parsed, missing \`clientId\` / \`isValid\`. \`useEntityBlockEditor\` now decorates the tree (memoized per tuple) so \`useInnerBlocksProps\` accepts it.
3. **\`canUser\` flip.** Pre-resolver these stubs were unreachable; now block-library's read/update gates would refuse to render anything if both came back \`false\`. Until G5 (\`#98\`) wires real \`visual_editor.*\` policies, assume any user with editor access has CRUD — the editor surface is already auth-gated at the route level.

## Changes Made

### Resolvers
- Register \`getEntityRecord\` / \`getEntityRecords\` resolvers that dispatch the existing fetch thunks. First read for each \`(kind, name, id|query)\` tuple fetches; subsequent reads hit the cache.
- Forward-resolver \`getEditedEntityRecord\` to the same fetch (mirrors upstream's \`forwardResolver\`).
- Drop manual \`hasFinishedResolution\` / \`hasStartedResolution\` / \`isResolving\` stubs so wp-data's auto-supplied resolution selectors take over.

### Hooks
- \`useEntityRecord\` now reads selector + auto-supplied resolution state. Removed ~80 lines of bespoke \`useEffect\`/\`useState\`/\`useRef\` machinery.
- \`useEntityRecords\` now takes \`(kind?, name?, query?)\` and surfaces real \`isResolving\` / \`hasResolved\` / \`totalItems\` / \`totalPages\`.
- \`useEntityBlockEditor\` decorates server-parsed \`content.blocks\` with \`clientId\` + \`isValid\`, memoized per \`(kind, name, id)\` so render loops don't churn fresh ids.

### Composite-id bridge
- Reducer's \`RECEIVE_ENTITY_RECORDS\` mirrors records with \`theme\` + \`slug\` under \`<theme>//<slug>\` in addition to their numeric key.
- \`fetchEntityRecord\` detects composite ids and falls back to the index endpoint with theme/slug filters.

### Misc
- \`flattenRawProperties\` falls back to \`rendered\` when \`raw\` is absent (so \`title: {rendered: 'Footer'}\` flattens to \`'Footer'\` instead of staying as an object that decodes to \`[object Object]\`).
- \`canUser\` / \`canUserEditEntityRecord\` flipped \`false\` → \`true\` with a note pointing at G5.
- \`docs/core-data-shim.md\` updated to document the resolver wiring.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS
- Browser: Safari
- PHP Version: 8.4.3
- Project Version: \`release/1.0\` HEAD

**Tests Performed:**
1. \`npx vitest run resources/js/visual-editor/vendor/__tests__/core-data-shim.test.tsx\` — 51 shim tests pass.
2. \`npm test\` — full vitest suite: 926 passed, 1 skipped.
3. \`./vendor/bin/pest --compact\` — 444 PHP tests pass.
4. \`npx tsc --noEmit\` — no new TypeScript errors (pre-existing baseline unchanged).
5. **Manual test in dev app**:
   - Inserted a fresh \`core/template-part\` block — the placeholder picker now shows the seeded parts (footer, header, sidebar, test-template-part) filtered by area.
   - Loaded a template that references saved \`core/template-part\` blocks (footer, header) — they inline correctly with their parsed inner blocks.
   - Network tab shows \`GET /visual-editor/api/template-parts?theme=artisanpack-base&slug=footer\` firing on canvas mount.

## Accessibility Tests Run

- [x] N/A — data-resolution change with no new UI surface. Loading-state semantics now reflect real fetch lifecycle (was hardcoded \`hasResolved=true\` previously), which improves screen-reader feedback for upstream block placeholders.

## Tests Added

- [x] Unit tests added
- [x] All tests passing

**Test details:** 7 new shim tests covering:
1. Single-record resolver fire on first read.
2. List resolver fire on first read.
3. No-refetch on subsequent resolved reads.
4. 404 → empty cache (resolver completes silently).
5. Composite \`<theme>//<slug>\` resolution via index endpoint with theme/slug filter.
6. \`getEditedEntityRecord\` forward-resolver completes through the same fetch.
7. \`useEntityBlockEditor\` decorates server-parsed blocks with \`clientId\` / \`isValid\` (recursive into \`innerBlocks\`).

\`useEntityRecords\` hook lifecycle test added separately — initial unresolved → resolver fires → settled with cache populated.

## Documentation

- [x] Inline code documentation added (resolver block-comment, decorate helpers, composite-id docstrings)
- [x] \`docs/core-data-shim.md\` "Selectors" section updated to document the resolver wiring

## Screenshots

N/A — visual change is "saved \`core/template-part\` references render their content instead of a deleted-warning placeholder."

## Pre-Submission Checklist

- [x] Code passes all tests
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code (composite-id bridge, decoration cache, resolver wiring)
- [x] No new warnings generated

## Follow-ups (out of scope)

Two issues surfaced during manual testing that are being filed separately rather than expanded into this PR:

1. **Editor-canvas styling for inlined template parts.** When viewed via the post editor, inlined parts render content but no theme CSS — the dedicated site-editor canvas does load it. Phase D / canvas-styling concern, not data resolution.
2. **\`core/navigation\` errors when its referenced record is missing.** Same shape will hit \`core/post-content\` / \`core/post-featured-image\` if their refs are unseeded. Block-library's edit components don't degrade gracefully on null records.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Entity records now auto-fetch and cache on first read; template/template-part composite IDs are resolved transparently.

* **Improvements**
  * Resolution status exposed for loading states (including edited-record/has-edits indicators).
  * Block editor now decorates server blocks with clientId and validity, improving client-side editing.
  * Better fallback handling for template properties.

* **Documentation**
  * Clarified lazy-fetch behavior, resolution metadata, and permission-stub expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->