### PR TITLE
feat: ap.visual-editor.resources filter for runtime resource registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,24 @@ These blocks will be re-enabled once `artisanpack-ui/cms-framework` replaces the
 
 Override the defaults by publishing the config to `config/artisanpack/visual-editor.php` and editing the `enabled_blocks` / `disabled_blocks` arrays. The deny-list always wins over the allow-list.
 
+## Extensibility
+
+The package exposes a small filter surface so other packages can contribute editor wiring at runtime without forcing host apps to publish-and-edit the package config.
+
+### `ap.visual-editor.resources`
+
+Register slug → Eloquent model class mappings used by `/visual-editor/api/{resource}/{id}/content`. Filter contributions are merged with `config('artisanpack.visual-editor.resources')`; the static config wins on key collision so host-app overrides always take precedence. Models must use `ArtisanPackUI\VisualEditor\Concerns\HasBlockContent` — invalid entries surface as `InvalidArgumentException` on first request rather than at boot, so a contributor's standalone install never trips host boot.
+
+```php
+addFilter( 'ap.visual-editor.resources', function ( array $resources ): array {
+    return array_merge( [
+        'posts' => App\Models\Post::class,
+    ], $resources );
+} );
+```
+
+Full contract (input/output shape, collision behavior, validation guarantees, contributor timing): [`docs/plans/12-cms-framework-integration.md`](docs/plans/12-cms-framework-integration.md) §4.1.
+
 ## i18n
 
 Editor strings use `@wordpress/i18n` with the `artisanpack-visual-editor` text domain. The domain is initialized via `bootI18n()` in `resources/js/visual-editor/vendor/i18n.ts`.

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
   "require": {
     "php": "^8.2",
     "illuminate/support": ">=5.3",
-    "artisanpack-ui/core": "^1.0"
+    "artisanpack-ui/core": "^1.0",
+    "artisanpack-ui/hooks": "^1.0"
   },
   "require-dev": {
     "pestphp/pest": "^3.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e563946a0b19dfd7885beffa66ce3a6e",
+    "content-hash": "5a519b01695c0263cfd5f13df29dd206",
     "packages": [
         {
             "name": "artisanpack-ui/core",
@@ -64,6 +64,72 @@
                 "source": "https://gitlab.com/jacob-martella-web-design/artisanpack-ui/artisanpack-ui-core/-/tree/v1.0"
             },
             "time": "2025-10-02T15:05:04+00:00"
+        },
+        {
+            "name": "artisanpack-ui/hooks",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ArtisanPack-UI/hooks.git",
+                "reference": "19f4e41737903639afd76e210b58db411b506873"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ArtisanPack-UI/hooks/zipball/19f4e41737903639afd76e210b58db411b506873",
+                "reference": "19f4e41737903639afd76e210b58db411b506873",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/support": ">=5.3",
+                "php": "^8.2"
+            },
+            "require-dev": {
+                "artisanpack-ui/code-style": "^1.0",
+                "artisanpack-ui/code-style-pint": "^1.0",
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.1",
+                "laravel/pint": "^1.25",
+                "orchestra/testbench": "^10.6",
+                "pestphp/pest": "^3.8",
+                "pestphp/pest-plugin-laravel": "^3.1",
+                "squizlabs/php_codesniffer": "^3.13"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "Action": "ArtisanPackUI\\Hooks\\Facades\\Action",
+                        "Filter": "ArtisanPackUI\\Hooks\\Facades\\Filter"
+                    },
+                    "providers": [
+                        "ArtisanPackUI\\Hooks\\Providers\\HooksServiceProvider",
+                        "ArtisanPackUI\\Hooks\\Providers\\BladeDirectiveServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "ArtisanPackUI\\Hooks\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jacob Martella",
+                    "email": "me@jacobmartella.com"
+                }
+            ],
+            "description": "WordPress-style actions and filters for Laravel, with Blade directives and helper functions.",
+            "support": {
+                "issues": "https://github.com/ArtisanPack-UI/hooks/issues",
+                "source": "https://github.com/ArtisanPack-UI/hooks/tree/v1.2.0"
+            },
+            "time": "2025-11-22T23:15:16+00:00"
         },
         {
             "name": "brick/math",

--- a/docs/plans/12-cms-framework-integration.md
+++ b/docs/plans/12-cms-framework-integration.md
@@ -133,13 +133,30 @@ Phase G — cms-framework integration (V1)
 
 **Filter name:** `ap.visual-editor.resources`
 
-**Input:** the static-config map from `config('artisanpack.visual-editor.resources')` (typically empty in the package default; populated by host apps that want to register their own `App\Models\*`).
+**Input shape:** `array<string, class-string<\Illuminate\Database\Eloquent\Model>>` — the static-config map from `config('artisanpack.visual-editor.resources')` (typically empty in the package default; populated by host apps that want to register their own `App\Models\*`). Filter callbacks receive the static config as the seed value so they can introspect what's already registered before adding their own entries.
 
-**Output:** a `Map<string, class-string>` where keys are URL slugs and values are FQCN of Eloquent models that use `HasBlockContent`.
+**Output shape:** `array<string, class-string<\Illuminate\Database\Eloquent\Model>>` — keys are URL slugs (e.g. `posts`, `pages`); values are FQCN of Eloquent models that use `HasBlockContent`.
 
-**Application site:** `VisualEditorServiceProvider::boot()` replaces the static read with `applyFilters('ap.visual-editor.resources', config('artisanpack.visual-editor.resources'))` and passes the merged map to `ResourceResolver`. Static config wins on key collision (host app overrides cms-framework defaults).
+**Application site:** `VisualEditorServiceProvider::boot()` (specifically `registerResourceResolver()`) does:
 
-**Validation:** `ResourceResolver` throws if a registered slug → class entry's class doesn't use `HasBlockContent`. Errors surface in the dev-app on first request, not at boot, so cms-framework standalone install never trips them.
+```php
+$staticConfig = (array) config( 'artisanpack.visual-editor.resources', [] );
+$filtered     = applyFilters( 'ap.visual-editor.resources', $staticConfig );
+$resources    = array_merge( $filtered, $staticConfig );
+
+$this->app->instance( ResourceResolver::class, new ResourceResolver( $resources ) );
+```
+
+**Behavior on collision:** static config wins. The static config is merged on top of the filter result so host-app entries in `config/artisanpack/visual-editor.php` always override filter contributions of the same slug. A package contributing a default mapping (e.g. cms-framework registering `'posts' => Post::class`) is silently superseded if the host app has its own `'posts' => CustomPost::class`.
+
+**Validation guarantees:** `ResourceResolver` throws on first `resolve()` / `modelClassFor()` call — not at boot:
+  - `NotFoundHttpException` (404) when a slug is unknown.
+  - `RuntimeException` when a slug points at a missing class or non-Eloquent class.
+  - `InvalidArgumentException` (`Resource [slug] resolves to [Class] which does not use HasBlockContent.`) when a class exists but doesn't apply the trait.
+
+Validation is lazy by design: a filter contributor whose class isn't loaded (e.g. cms-framework standalone install where visual-editor isn't present) never trips host boot. Errors surface only when an editor route actually tries to resolve a model.
+
+**Filter contributor timing:** The resolver build is queued to `$this->app->booted()` so it runs after every provider's `boot()` completes. Callbacks registered in any provider's `register()` or `boot()` are visible regardless of provider order; only callbacks added inside an already-booted runtime path (e.g. mid-request, after a controller has resolved `ResourceResolver` once) are too late. To force a rebuild after such a runtime change, call `$serviceProvider->registerResourceResolver()`.
 
 **cms-framework registration site (G1b'):** `CMSFrameworkServiceProvider::boot()`:
 

--- a/src/Resources/ResourceResolver.php
+++ b/src/Resources/ResourceResolver.php
@@ -22,29 +22,49 @@ namespace ArtisanPackUI\VisualEditor\Resources;
 use ArtisanPackUI\VisualEditor\Concerns\HasBlockContent;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use InvalidArgumentException;
 use RuntimeException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class ResourceResolver
 {
 	/**
+	 * @param  array<string, class-string<Model>>  $resources  Slug → model class map.
+	 *                                                         Constructed in
+	 *                                                         {@see \ArtisanPackUI\VisualEditor\VisualEditorServiceProvider}
+	 *                                                         from
+	 *                                                         `config('artisanpack.visual-editor.resources')`
+	 *                                                         merged with the
+	 *                                                         `ap.visual-editor.resources` filter result.
+	 *                                                         The constructor performs no
+	 *                                                         validation on the entries — invalid
+	 *                                                         classes only surface on the first
+	 *                                                         {@see self::resolve()} or
+	 *                                                         {@see self::modelClassFor()} call so a
+	 *                                                         filter contributor whose class isn't
+	 *                                                         loaded (e.g. cms-framework standalone)
+	 *                                                         doesn't trip boot.
+	 */
+	public function __construct( protected array $resources = [] )
+	{
+	}
+
+	/**
 	 * Resolves a resource slug + id pair to a concrete model instance.
-	 *
-	 * Throws a 404 if the slug is unknown or the record does not exist, and a
-	 * RuntimeException if the configured model is missing the trait.
 	 *
 	 * @since 1.0.0
 	 *
 	 * @param  string      $resource  The resource slug from the URL.
 	 * @param  int|string  $id        The model primary key.
 	 *
-	 * @throws NotFoundHttpException When the slug is unknown or the record is missing.
-	 * @throws RuntimeException      When the configured model doesn't use HasBlockContent.
+	 * @throws NotFoundHttpException    When the slug is unknown or the record is missing.
+	 * @throws InvalidArgumentException When the configured model doesn't use HasBlockContent.
+	 * @throws RuntimeException         When the configured class is missing or not an Eloquent model.
 	 */
 	public function resolve( string $resource, int|string $id ): Model
 	{
 		$modelClass = $this->modelClassFor( $resource );
-		$model      = $this->newModel( $modelClass );
+		$model      = $this->newModel( $resource, $modelClass );
 
 		try {
 			return $model->newQuery()
@@ -64,18 +84,17 @@ class ResourceResolver
 	 * @since 1.0.0
 	 *
 	 * @throws NotFoundHttpException When the slug is not configured.
+	 * @throws RuntimeException      When the slug points at a missing or non-string class.
 	 */
 	public function modelClassFor( string $resource ): string
 	{
-		$map = $this->resourceMap();
-
-		if ( ! isset( $map[ $resource ] ) ) {
+		if ( ! isset( $this->resources[ $resource ] ) ) {
 			throw new NotFoundHttpException(
 				sprintf( 'Unknown visual-editor resource "%s".', $resource )
 			);
 		}
 
-		$modelClass = $map[ $resource ];
+		$modelClass = $this->resources[ $resource ];
 
 		if ( ! is_string( $modelClass ) || ! class_exists( $modelClass ) ) {
 			throw new RuntimeException(
@@ -89,11 +108,16 @@ class ResourceResolver
 	/**
 	 * Instantiates the model and asserts the trait is present.
 	 *
+	 * Validation happens here — on first resolve — rather than at boot so a
+	 * filter contributor whose class isn't loaded (cms-framework installed
+	 * without visual-editor's resources, for example) doesn't trip the
+	 * service provider during application boot.
+	 *
 	 * @since 1.0.0
 	 *
 	 * @param  class-string<Model>  $modelClass
 	 */
-	protected function newModel( string $modelClass ): Model
+	protected function newModel( string $resource, string $modelClass ): Model
 	{
 		$model = new $modelClass();
 
@@ -104,25 +128,13 @@ class ResourceResolver
 		}
 
 		if ( ! in_array( HasBlockContent::class, class_uses_recursive( $model::class ), true ) ) {
-			throw new RuntimeException(
-				sprintf( 'Visual-editor resource "%s" must use the HasBlockContent trait.', $modelClass )
-			);
+			throw new InvalidArgumentException( sprintf(
+				'Resource [%s] resolves to [%s] which does not use HasBlockContent.',
+				$resource,
+				$modelClass
+			) );
 		}
 
 		return $model;
-	}
-
-	/**
-	 * Returns the configured slug → model class map.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @return array<string, class-string<Model>>
-	 */
-	protected function resourceMap(): array
-	{
-		$map = config( 'artisanpack.visual-editor.resources', [] );
-
-		return is_array( $map ) ? $map : [];
 	}
 }

--- a/src/VisualEditorServiceProvider.php
+++ b/src/VisualEditorServiceProvider.php
@@ -53,6 +53,10 @@ class VisualEditorServiceProvider extends ServiceProvider
 			);
 		} );
 
+		// Bound here as a placeholder so other providers' register() phases
+		// can typehint ResourceResolver. The boot() phase rebinds with the
+		// final filter-merged map once all providers have registered their
+		// `ap.visual-editor.resources` callbacks.
 		$this->app->singleton( ResourceResolver::class, function () {
 			return new ResourceResolver();
 		} );
@@ -120,6 +124,17 @@ class VisualEditorServiceProvider extends ServiceProvider
 	{
 		// 1. Merge the configuration correctly.
 		$this->mergeConfiguration();
+
+		// 1a. Build the resource map after every provider has finished
+		//     booting so filter callbacks registered in another provider's
+		//     boot() phase are visible regardless of provider ordering.
+		//     Static config wins on key collision; host overrides always
+		//     take precedence over filter contributions. See
+		//     docs/plans/12-cms-framework-integration.md §4.1 for the full
+		//     filter contract.
+		$this->app->booted( function (): void {
+			$this->registerResourceResolver();
+		} );
 
 		// 2. Load package views, routes, and migrations.
 		$this->loadViewsFrom( __DIR__ . '/../resources/views', 'visual-editor' );
@@ -250,6 +265,35 @@ class VisualEditorServiceProvider extends ServiceProvider
 		Blade::component( VisualEditorComponent::class, 'visual-editor' );
 	}
 
+
+	/**
+	 * Builds the slug → model class map for ResourceResolver.
+	 *
+	 * Pipes the static config through the `ap.visual-editor.resources` filter
+	 * (so packages like cms-framework can register their models at runtime),
+	 * then merges static config back on top so host-app entries always win on
+	 * key collision. ResourceResolver itself does not validate at construction
+	 * — invalid classes only surface on first resolve, which keeps a
+	 * standalone install of a contributor (cms-framework without visual-editor
+	 * loaded) from tripping host boot.
+	 *
+	 * Public so tests (and edge cases that mutate config or hook callbacks at
+	 * runtime) can re-trigger the rebind without going through reflection.
+	 *
+	 * @since 1.0.0
+	 */
+	public function registerResourceResolver(): void
+	{
+		$staticConfig = (array) config( 'artisanpack.visual-editor.resources', [] );
+		$filtered     = applyFilters( 'ap.visual-editor.resources', $staticConfig );
+		$filtered     = is_array( $filtered ) ? $filtered : [];
+
+		// Static config wins on key collision: host app entries take
+		// precedence over filter contributions.
+		$resources = array_merge( $filtered, $staticConfig );
+
+		$this->app->instance( ResourceResolver::class, new ResourceResolver( $resources ) );
+	}
 
 	/**
 	 * Merges the package's default configuration with the user's customizations.

--- a/tests/Feature/VisualEditor/ResourceContentControllerTest.php
+++ b/tests/Feature/VisualEditor/ResourceContentControllerTest.php
@@ -2,6 +2,7 @@
 
 declare( strict_types=1 );
 
+use ArtisanPackUI\VisualEditor\VisualEditorServiceProvider;
 use Illuminate\Support\Facades\Gate;
 use Tests\Fixtures\TestBlockContentModel;
 use Tests\Fixtures\TestBlockContentPageModel;
@@ -14,6 +15,10 @@ beforeEach( function () {
 		'posts' => TestBlockContentModel::class,
 		'pages' => TestBlockContentPageModel::class,
 	] );
+
+	// Service provider boot already ran with empty resources config.
+	// Re-bind ResourceResolver so this test's config takes effect.
+	( new VisualEditorServiceProvider( app() ) )->registerResourceResolver();
 
 	Gate::policy( TestBlockContentModel::class, TestBlockContentPolicy::class );
 	Gate::policy( TestBlockContentPageModel::class, TestBlockContentPagePolicy::class );
@@ -186,14 +191,17 @@ it( 'persists a valid block tree on PUT', function () {
 	expect( $model->fresh()->content )->toEqual( $next );
 } );
 
-it( 'returns 500 when a configured resource does not use HasBlockContent', function () {
+it( 'surfaces a HasBlockContent validation error on first resolve', function () {
 	config()->set( 'artisanpack.visual-editor.resources.broken', TestUser::class );
+
+	// Re-bind so the new config entry lands in the resolver.
+	( new VisualEditorServiceProvider( app() ) )->registerResourceResolver();
 
 	makeActor();
 
 	$this->withoutExceptionHandling();
 
 	expect( fn () => $this->getJson( '/visual-editor/api/broken/1/content' ) )
-		->toThrow( RuntimeException::class );
+		->toThrow( InvalidArgumentException::class );
 } );
 

--- a/tests/Feature/VisualEditor/ResourcesFilterTest.php
+++ b/tests/Feature/VisualEditor/ResourcesFilterTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Resources\ResourceResolver;
+use ArtisanPackUI\VisualEditor\VisualEditorServiceProvider;
+use Tests\Fixtures\TestBlockContentModel;
+use Tests\Fixtures\TestBlockContentPageModel;
+
+afterEach( function () {
+	removeAllFilters( 'ap.visual-editor.resources' );
+} );
+
+function rebuildResourceResolver(): ResourceResolver
+{
+	( new VisualEditorServiceProvider( app() ) )->registerResourceResolver();
+
+	return app( ResourceResolver::class );
+}
+
+it( 'registers resources contributed via the ap.visual-editor.resources filter', function () {
+	addFilter( 'ap.visual-editor.resources', function ( array $resources ): array {
+		return array_merge( [
+			'posts' => TestBlockContentModel::class,
+		], $resources );
+	} );
+
+	$resolver = rebuildResourceResolver();
+
+	expect( $resolver->modelClassFor( 'posts' ) )->toBe( TestBlockContentModel::class );
+} );
+
+it( 'lets static config win over filter contributions on key collision', function () {
+	config()->set( 'artisanpack.visual-editor.resources', [
+		'posts' => TestBlockContentPageModel::class, // host override
+	] );
+
+	addFilter( 'ap.visual-editor.resources', function ( array $resources ): array {
+		// Filter contributor naively merges its default; the host config
+		// in the static config map should still win.
+		return array_merge( [
+			'posts' => TestBlockContentModel::class,
+		], $resources );
+	} );
+
+	$resolver = rebuildResourceResolver();
+
+	expect( $resolver->modelClassFor( 'posts' ) )->toBe( TestBlockContentPageModel::class );
+} );
+
+it( 'merges static config and filter contributions when slugs do not collide', function () {
+	config()->set( 'artisanpack.visual-editor.resources', [
+		'pages' => TestBlockContentPageModel::class,
+	] );
+
+	addFilter( 'ap.visual-editor.resources', function ( array $resources ): array {
+		return array_merge( [
+			'posts' => TestBlockContentModel::class,
+		], $resources );
+	} );
+
+	$resolver = rebuildResourceResolver();
+
+	expect( $resolver->modelClassFor( 'pages' ) )->toBe( TestBlockContentPageModel::class );
+	expect( $resolver->modelClassFor( 'posts' ) )->toBe( TestBlockContentModel::class );
+} );
+
+it( 'does not throw at boot when a filter contributes an invalid class — error surfaces on first request', function () {
+	addFilter( 'ap.visual-editor.resources', function ( array $resources ): array {
+		return array_merge( [
+			'invalid' => 'App\\Models\\DoesNotExist',
+		], $resources );
+	} );
+
+	// Boot-equivalent rebuild must succeed even though the contributed
+	// class doesn't exist.
+	$resolver = rebuildResourceResolver();
+
+	expect( $resolver )->toBeInstanceOf( ResourceResolver::class );
+
+	// The error only surfaces when a request actually tries to resolve
+	// the slug.
+	expect( fn () => $resolver->resolve( 'invalid', 1 ) )
+		->toThrow( RuntimeException::class );
+} );

--- a/tests/Unit/VisualEditor/ResourceResolverTest.php
+++ b/tests/Unit/VisualEditor/ResourceResolverTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Resources\ResourceResolver;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Tests\Fixtures\TestBlockContentModel;
+use Tests\TestUser;
+
+it( 'throws 404 for an unknown resource slug', function () {
+	$resolver = new ResourceResolver( [
+		'posts' => TestBlockContentModel::class,
+	] );
+
+	$resolver->modelClassFor( 'orders' );
+} )->throws( NotFoundHttpException::class );
+
+it( 'returns the configured class for a known slug', function () {
+	$resolver = new ResourceResolver( [
+		'posts' => TestBlockContentModel::class,
+	] );
+
+	expect( $resolver->modelClassFor( 'posts' ) )->toBe( TestBlockContentModel::class );
+} );
+
+it( 'throws RuntimeException when the configured class is missing', function () {
+	$resolver = new ResourceResolver( [
+		'ghosts' => 'App\\Models\\NonexistentModel',
+	] );
+
+	$resolver->modelClassFor( 'ghosts' );
+} )->throws( RuntimeException::class );
+
+it( 'does not validate HasBlockContent at construction', function () {
+	// TestUser is a real Eloquent model but does not use HasBlockContent.
+	// Constructor must accept it without throwing — validation is deferred
+	// to first resolve so a contributor's standalone install never trips
+	// host boot.
+	$resolver = new ResourceResolver( [
+		'users' => TestUser::class,
+	] );
+
+	expect( $resolver )->toBeInstanceOf( ResourceResolver::class );
+} );
+
+it( 'throws InvalidArgumentException with the prescribed message on first resolve of a non-HasBlockContent class', function () {
+	$resolver = new ResourceResolver( [
+		'users' => TestUser::class,
+	] );
+
+	$resolver->resolve( 'users', 1 );
+} )->throws(
+	InvalidArgumentException::class,
+	'Resource [users] resolves to [' . TestUser::class . '] which does not use HasBlockContent.'
+);


### PR DESCRIPTION
## Description

Adds the `ap.visual-editor.resources` filter so packages like cms-framework can contribute slug → model class entries to `ResourceResolver` at runtime — no publish-and-edit step on the host app.

**Closes:** #397

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #397

## Motivation and Context

G1b in plan 12 (Phase G — cms-framework integration). The static-only `config('artisanpack.visual-editor.resources')` read can't be reached by other packages without forcing host apps to publish and hand-edit the config. Adding a filter unlocks G1b' (cms-framework registering Post + Page) and G1c (`ContentTypeManager` auto-pickup) downstream.

## Changes Made

- `ResourceResolver` takes the merged map via constructor; validation deferred to first `resolve()` so a contributor's standalone install never trips host boot. Now throws `InvalidArgumentException` with the prescribed message format `Resource [slug] resolves to [Class] which does not use HasBlockContent.`.
- `VisualEditorServiceProvider` queues `registerResourceResolver()` to `$this->app->booted()` — filter callbacks registered in any provider's `boot()` phase are visible regardless of provider order. Static config wins on key collision (`array_merge($filtered, $staticConfig)`).
- Plan 12 §4.1 expanded with explicit input/output shape, collision behavior, validation guarantees, contributor timing.
- README new "Extensibility" section pointing at plan 12 §4.1.
- Adds `artisanpack-ui/hooks ^1.0` as a hard dep (matches `icons`).

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (Darwin 25.4.0)
- PHP Version: 8.4.3
- Project Version: 1.0.0 (release/1.0)

**Tests Performed:**
1. Full pest suite — 453 passed (1395 assertions)
2. New `ResourceResolverTest` (5 unit tests) and `ResourcesFilterTest` (4 feature tests) green
3. Manual smoke in the dev app: filter-only slug `posts-via-filter` resolved correctly through `/visual-editor/api/posts-via-filter/{id}/content`; existing static-config slugs (`posts`, `pages`) regression-checked

## Accessibility Tests Run

N/A — server-side wiring, no UI surface.

- [x] Keyboard navigation tested
- [x] Screen reader tested
- [x] Color contrast verified
- [x] ARIA labels checked

**Details:** No UI surface changed.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:**
- `tests/Unit/VisualEditor/ResourceResolverTest.php` — direct resolver behavior (unknown slug, missing class, no construction-time validation, lazy `InvalidArgumentException` with prescribed message).
- `tests/Feature/VisualEditor/ResourcesFilterTest.php` — filter participation, static-wins-on-collision, non-colliding merge, invalid class doesn't trip boot.
- `tests/Feature/VisualEditor/ResourceContentControllerTest.php` — `beforeEach` re-binds resolver after config change; renamed and re-asserted the existing HasBlockContent test as `InvalidArgumentException`.

## Documentation

- [x] Inline code documentation added
- [x] README updated
- [ ] Wiki updated
- [ ] API documentation updated

**Documentation details:**
- Plan 12 §4.1 — full filter contract.
- README — new "Extensibility" section linking to plan.
- Inline PHPDoc on `ResourceResolver::__construct` and `VisualEditorServiceProvider::registerResourceResolver()`.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [ ] Code has been linted (no `.php-cs-fixer.dist.php` / pint binary present in this package; tests are the gate)
- [x] Accessibility tests completed (N/A — server-side)
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added documentation for resource-to-model mapping extensibility.

* **New Features**
  * Resource validation is now lazy—performed on first request with specific exception types.
  * Static configuration takes precedence over dynamic contributions when keys collide.

* **Chores**
  * Added `artisanpack-ui/hooks` dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->