### PR TITLE
G4a: verify core/post-* blocks fully wired against G3 entities

### DIFF
--- a/database/migrations/testing/2026_04_19_000000_create_test_block_content_tables.php
+++ b/database/migrations/testing/2026_04_19_000000_create_test_block_content_tables.php
@@ -25,11 +25,18 @@ return new class extends Migration
 			$table->id();
 			$table->unsignedBigInteger( 'author_id' )->nullable()->index();
 			$table->string( 'title' )->default( '' );
+			$table->string( 'slug' )->nullable();
+			$table->text( 'excerpt' )->nullable();
+			$table->unsignedBigInteger( 'featured_image_id' )->nullable();
 			$table->string( 'status' )->default( 'draft' )->index();
 			$table->json( 'content' )->nullable();
 			$table->timestamps();
 		} );
 
+		// Pages fixture is intentionally minimal — its PageResource test
+		// asserts that page-only fields (parent / menu_order / template)
+		// stay absent from the response when the model doesn't declare
+		// them. Don't add those columns here.
 		Schema::create( 'test_block_content_pages', function ( Blueprint $table ) {
 			$table->id();
 			$table->unsignedBigInteger( 'author_id' )->nullable()->index();

--- a/docs/block-library-audit.md
+++ b/docs/block-library-audit.md
@@ -4,10 +4,18 @@ Classification of every block registered by `@wordpress/block-library` (v9.44.0)
 against the current editor's empty-state `@wordpress/core-data` shim
 (`resources/js/visual-editor/vendor/core-data-shim.ts`).
 
-Each block falls into one of three buckets:
+Each block falls into one of four buckets:
 
 - **green** — inserts, renders, and edits without a backing WordPress data
   store. Safe to expose in the default `enabled_blocks` list.
+- **entity-wired** — enabled by default, but the saved markup only renders
+  meaningful content when an entity is in scope. The editor canvas resolves
+  these blocks via `core-data` hooks against `artisanpack-ui/cms-framework`
+  Post/Page (or any host model exposing the same WP-shape entity through
+  the `ap.visual-editor.resources` filter); the Blade / React / Vue
+  renderers consume `_resolved*` attributes that the host stamps onto the
+  block tree at render time. Without an entity context they degrade to
+  empty shells, not crashes.
 - **empty-state** — inserts and renders without crashing, but every data
   selector returns `null` or `[]`, so the block shows an empty shell. Shipped
   as **disabled-by-default** until the `artisanpack-ui/cms-framework` package
@@ -71,6 +79,30 @@ inserter out of the box.
 | `core/search` | Static form — posts target via host app. |
 | `core/latest-posts` | **Stubbed.** Renders an empty list against the core-data shim; flagged here so the UX expectation is explicit — the block is still usable as a placeholder authors can drop in before wiring a real data source. |
 
+## Entity-wired — enabled by default (G3)
+
+These blocks ship enabled and round-trip correctly when the editor canvas
+mounts against an entity (cms-framework Post/Page via the G3 entity adapter,
+or any host model registered through the `ap.visual-editor.resources`
+filter). The renderer packages read pre-stamped `_resolved*` attributes —
+the host application is responsible for resolving the entity and stamping
+those values onto the block tree before passing it to the renderer.
+
+When no entity is in scope (preview, fallback, missing host wiring) the
+block degrades to an empty Gutenberg-shaped shell so the front-end and
+editor-canvas DOMs stay in agreement.
+
+### Post context
+
+| Block | Resolved attribute(s) |
+| --- | --- |
+| `core/post-title` | `_resolvedTitle`, `_resolvedPermalink` |
+| `core/post-content` | `_resolvedContent` |
+| `core/post-excerpt` | `_resolvedExcerpt`, `_resolvedPermalink` |
+| `core/post-date` | `_resolvedDate`, `_resolvedDateFormatted`, `_resolvedModifiedDate`, `_resolvedModifiedDateFormatted`, `_resolvedPermalink` |
+| `core/post-author` | `_resolvedAuthorName`, `_resolvedAuthorBio`, `_resolvedAuthorUrl`, `_resolvedAuthorAvatar` |
+| `core/post-featured-image` | `_resolvedImageUrl`, `_resolvedImageAlt`, `_resolvedImageWidth`, `_resolvedImageHeight`, `_resolvedPermalink` |
+
 ## Empty-state — disabled by default
 
 These blocks do not crash, but the shim returns empty data for the selectors
@@ -127,14 +159,16 @@ does not implement. They are permanently in the deny-list until a real
 
 ### Post context
 
-- `core/post-title`
-- `core/post-content`
-- `core/post-excerpt`
-- `core/post-date`
-- `core/post-author`
+The six entity-wired post blocks (`core/post-title`, `core/post-content`,
+`core/post-excerpt`, `core/post-date`, `core/post-author`,
+`core/post-featured-image`) are enabled by default — see the
+[Entity-wired](#entity-wired--enabled-by-default-g3) section. The remaining
+post-context blocks below stay disabled because the underlying data
+(author bio, navigation, taxonomy, comments, time-to-read) is not yet
+exposed by the cms-framework adapter.
+
 - `core/post-author-name`
 - `core/post-author-biography`
-- `core/post-featured-image`
 - `core/post-navigation-link`
 - `core/post-terms`
 - `core/post-time-to-read`

--- a/resources/js/visual-editor/editor/api-client.ts
+++ b/resources/js/visual-editor/editor/api-client.ts
@@ -42,6 +42,14 @@ function contentUrl(config: ApiClientConfig): string {
     )}/content`;
 }
 
+function entityRecordUrl(config: ApiClientConfig): string {
+    const base = config.apiBase.replace(/\/$/, '');
+
+    return `${base}/${encodeURIComponent(config.resource)}/${encodeURIComponent(
+        config.id
+    )}`;
+}
+
 function readCsrfToken(): string | null {
     if (typeof document === 'undefined') {
         return null;
@@ -136,6 +144,48 @@ export async function saveContent(
         return (await requireOk(response)) as ContentResponse;
     } catch (error: unknown) {
         throw normalizeError(error, 'Failed to save content.');
+    }
+}
+
+/**
+ * Persists a partial WP-shape entity record to the G3 endpoint at
+ * `{apiBase}/{resource}/{id}`. Used to flush metadata edits (title,
+ * slug, status, excerpt, featured_media, author, categories, tags,
+ * parent, menu_order, template) staged through the core-data shim's
+ * `editEntityRecord` action — the legacy `/content` endpoint only
+ * accepts the block tree, so metadata persistence rides this separate
+ * channel. The server's `UpdatePostRequest` / `UpdatePageRequest`
+ * gate every field with `sometimes`, so a partial payload is the
+ * canonical shape.
+ *
+ * @since 1.0.0
+ */
+export async function saveEntityRecord(
+    config: ApiClientConfig,
+    edits: Record<string, unknown>
+): Promise<unknown> {
+    const csrfToken = readCsrfToken();
+    const headers: Record<string, string> = {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        'X-Requested-With': 'XMLHttpRequest',
+    };
+
+    if (csrfToken) {
+        headers['X-CSRF-TOKEN'] = csrfToken;
+    }
+
+    try {
+        const response = await fetch(entityRecordUrl(config), {
+            method: 'PUT',
+            credentials: 'same-origin',
+            headers,
+            body: JSON.stringify(edits),
+        });
+
+        return await requireOk(response);
+    } catch (error: unknown) {
+        throw normalizeError(error, 'Failed to save metadata.');
     }
 }
 

--- a/resources/js/visual-editor/editor/editor-app.tsx
+++ b/resources/js/visual-editor/editor/editor-app.tsx
@@ -10,12 +10,14 @@
 
 import {
     useCallback,
+    useEffect,
     useMemo,
     useRef,
     useState,
 } from 'react';
 import { Alert, ToastProvider } from '@artisanpack-ui/react/feedback';
 import {
+    BlockContextProvider,
     BlockEditorProvider,
     BlockList,
     BlockTools,
@@ -24,6 +26,7 @@ import {
 } from '@wordpress/block-editor';
 import { registerCoreBlocks } from '@wordpress/block-library';
 import { Popover, SlotFillProvider } from '@wordpress/components';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { EntityProvider } from '@wordpress/core-data';
 // Importing `@wordpress/format-library` is a side-effect — it registers
 // the core rich-text formats (bold, italic, link, inline code, etc.) so
@@ -381,6 +384,34 @@ function EditorAppShell(props: EditorAppProps): JSX.Element {
         [props.id]
     );
 
+    // G4a: thread the entity identity (kind/name/id) through the
+    // persistence layer so sidebar metadata edits and post-title block
+    // edits round-trip via the G3 entity endpoint after the block save.
+    // Bypasses for non-cms-framework resources (custom HasBlockContent
+    // models without a shim entity registration) — the persistence loop
+    // skips the metadata flush when `entity` is null.
+    const entityIdentity = useMemo(
+        () =>
+            documentType !== null && numericId !== null
+                ? { kind: 'postType', name: documentType, id: numericId }
+                : null,
+        [documentType, numericId]
+    );
+
+    // Memoized block context value. Stable reference across editor-app
+    // re-renders (e.g. on entity-edit dispatches) so `BlockContextProvider`
+    // doesn't fan out a new context object to every block on every render
+    // — the cascading `Edit` re-renders that follows clobbers the
+    // block-editor's selection state, leaving the inspector's "Block" tab
+    // stuck on its empty placeholder mid-edit.
+    const blockContextValue = useMemo(
+        () =>
+            documentType !== null && numericId !== null
+                ? { postType: documentType, postId: numericId }
+                : null,
+        [documentType, numericId]
+    );
+
     const {
         blocks,
         loadStatus,
@@ -390,8 +421,85 @@ function EditorAppShell(props: EditorAppProps): JSX.Element {
         lastSavedAt,
         onBlocksChange,
         queueBlocksForSave,
+        queueMetadataForSave,
         flush,
-    } = usePersistence(props);
+    } = usePersistence({ ...props, entity: entityIdentity });
+
+    const { editEntityRecord } = useDispatch('core') as {
+        editEntityRecord?: (
+            kind: string,
+            name: string,
+            id: number,
+            edits: Record<string, unknown>
+        ) => void;
+    };
+
+    /**
+     * Stages a metadata edit on the core-data entity record (when the
+     * editor is mounted against a cms-framework Post/Page) and schedules
+     * the debounced metadata flush. Sidebar handlers below call this
+     * alongside their `setLocalState` mirror so the canvas's
+     * `useEntityProp`-driven blocks (e.g. `core/post-title`) and the
+     * inspector share a single source of truth on save.
+     */
+    const stageEntityEdit = useCallback(
+        (field: string, value: unknown): void => {
+            if (entityIdentity === null || editEntityRecord === undefined) {
+                return;
+            }
+
+            editEntityRecord(
+                entityIdentity.kind,
+                entityIdentity.name,
+                entityIdentity.id,
+                { [field]: value }
+            );
+            queueMetadataForSave();
+        },
+        [entityIdentity, editEntityRecord, queueMetadataForSave]
+    );
+
+    // Watches the entity edits bag. Blocks rendered inside the canvas
+    // (e.g. `core/post-title` typing into a `PlainText`) call
+    // `editEntityRecord` directly through `useEntityProp`'s setter — they
+    // never reach `stageEntityEdit`. Subscribing here picks up those
+    // edits and re-arms the metadata-save debounce so block-level
+    // metadata edits round-trip on the same cycle as sidebar edits.
+    const stagedEntityEdits = useSelect(
+        (select) => {
+            if (entityIdentity === null) {
+                return null;
+            }
+
+            const store = select('core') as
+                | {
+                      getEntityRecordEdits?: (
+                          kind: string,
+                          name: string,
+                          id: number
+                      ) => Record<string, unknown> | null;
+                  }
+                | undefined;
+
+            return (
+                store?.getEntityRecordEdits?.(
+                    entityIdentity.kind,
+                    entityIdentity.name,
+                    entityIdentity.id
+                ) ?? null
+            );
+        },
+        [entityIdentity]
+    );
+
+    useEffect(() => {
+        if (
+            stagedEntityEdits !== null
+            && Object.keys(stagedEntityEdits).length > 0
+        ) {
+            queueMetadataForSave();
+        }
+    }, [stagedEntityEdits, queueMetadataForSave]);
 
     useSaveNotifications({
         saveStatus,
@@ -481,54 +589,73 @@ function EditorAppShell(props: EditorAppProps): JSX.Element {
         (value: string): void => {
             setTitle(value);
             emitMetadata({ title: value });
+            stageEntityEdit('title', value);
         },
-        [emitMetadata]
+        [emitMetadata, stageEntityEdit]
     );
 
     const handleSlugChange = useCallback(
         (value: string): void => {
             setSlug(value);
             emitMetadata({ slug: value });
+            stageEntityEdit('slug', value);
         },
-        [emitMetadata]
+        [emitMetadata, stageEntityEdit]
     );
 
     const handleStatusChange = useCallback(
         (value: PostStatus): void => {
             setStatus(value);
             emitMetadata({ status: value });
+            stageEntityEdit('status', value);
         },
-        [emitMetadata]
+        [emitMetadata, stageEntityEdit]
     );
 
     const handleExcerptChange = useCallback(
         (value: string): void => {
             setExcerpt(value);
             emitMetadata({ excerpt: value });
+            stageEntityEdit('excerpt', value);
         },
-        [emitMetadata]
+        [emitMetadata, stageEntityEdit]
     );
 
     const handleFeaturedImageChange = useCallback(
         (value: FeaturedImageValue | null): void => {
             setFeaturedImage(value);
             emitMetadata({ featuredImage: value });
+            // The G3 endpoint's WP-shape envelope expects
+            // `featured_media: <id|null>`, not the host's
+            // `{id, url, alt}` blob.
+            stageEntityEdit('featured_media', value === null ? null : value.id);
         },
-        [emitMetadata]
+        [emitMetadata, stageEntityEdit]
     );
 
     const handleAuthorChange = useCallback(
         (value: number | string | null): void => {
             setAuthorId(value);
             emitMetadata({ authorId: value });
+            // WP-shape entity field is `author`, scalar id.
+            stageEntityEdit(
+                'author',
+                typeof value === 'string' && value !== '' && /^\d+$/.test(value)
+                    ? Number.parseInt(value, 10)
+                    : (value as number | null)
+            );
         },
-        [emitMetadata]
+        [emitMetadata, stageEntityEdit]
     );
 
     const handleCommentsOpenChange = useCallback(
         (value: boolean): void => {
             setCommentsOpen(value);
             emitMetadata({ commentsOpen: value });
+            // `comments_open` isn't part of the V1 UpdatePostRequest
+            // surface, so we don't stage it on the entity record. Hosts
+            // that wire a comments column persist it through
+            // `onMetadataChange` until the entity adapter formalizes it.
         },
         [emitMetadata]
     );
@@ -537,40 +664,45 @@ function EditorAppShell(props: EditorAppProps): JSX.Element {
         (value: ReadonlyArray<number>): void => {
             setCategories(value);
             emitMetadata({ categories: value });
+            stageEntityEdit('categories', [...value]);
         },
-        [emitMetadata]
+        [emitMetadata, stageEntityEdit]
     );
 
     const handleTagsChange = useCallback(
         (value: ReadonlyArray<number>): void => {
             setTags(value);
             emitMetadata({ tags: value });
+            stageEntityEdit('tags', [...value]);
         },
-        [emitMetadata]
+        [emitMetadata, stageEntityEdit]
     );
 
     const handleParentChange = useCallback(
         (value: number | null): void => {
             setParent(value);
             emitMetadata({ parent: value });
+            stageEntityEdit('parent', value);
         },
-        [emitMetadata]
+        [emitMetadata, stageEntityEdit]
     );
 
     const handleMenuOrderChange = useCallback(
         (value: number): void => {
             setMenuOrder(value);
             emitMetadata({ menuOrder: value });
+            stageEntityEdit('menu_order', value);
         },
-        [emitMetadata]
+        [emitMetadata, stageEntityEdit]
     );
 
     const handleTemplateChange = useCallback(
         (value: string): void => {
             setTemplate(value);
             emitMetadata({ template: value });
+            stageEntityEdit('template', value);
         },
-        [emitMetadata]
+        [emitMetadata, stageEntityEdit]
     );
 
     const handleInput = useCallback(
@@ -826,7 +958,23 @@ function EditorAppShell(props: EditorAppProps): JSX.Element {
                 <BlockTools>
                     <WritingFlow>
                         <ObserveTyping>
-                            <BlockList />
+                            {/*
+                             * G4a: stamp `postType`/`postId` into block context
+                             * for cms-framework Post/Page edits so `core/post-*`
+                             * blocks (which declare `usesContext: ["postId",
+                             * "postType", "queryId"]`) see the active entity.
+                             * Outside an entity-mounted canvas the values stay
+                             * undefined and the blocks render their placeholder
+                             * shell — same behaviour as a query-loop descendant
+                             * with no parent providing the context.
+                             */}
+                            {documentType !== null && numericId !== null ? (
+                                <BlockContextProvider value={blockContextValue}>
+                                    <BlockList />
+                                </BlockContextProvider>
+                            ) : (
+                                <BlockList />
+                            )}
                         </ObserveTyping>
                     </WritingFlow>
                 </BlockTools>

--- a/resources/js/visual-editor/editor/use-persistence.ts
+++ b/resources/js/visual-editor/editor/use-persistence.ts
@@ -9,11 +9,13 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { BlockInstance } from '@wordpress/blocks';
+import { dispatch as wpDispatch, select as wpSelect } from '@wordpress/data';
 
 import {
     ApiError,
     fetchContent,
     saveContent,
+    saveEntityRecord,
     type ApiClientConfig,
 } from './api-client';
 import {
@@ -26,6 +28,20 @@ import {
 type LoadStatus = 'loading' | 'ready' | 'error';
 type SaveStatus = 'idle' | 'saving' | 'saved' | 'error';
 type SaveTrigger = 'autosave' | 'save';
+
+/**
+ * Identity tuple for a core-data entity edited by the canvas. When set,
+ * the persistence loop also flushes any staged
+ * `editEntityRecord(kind, name, id, ...)` edits to the G3 entity
+ * endpoint after the block save lands. cms-framework Post/Page edits
+ * thread their identity here so sidebar metadata edits and post-title
+ * block edits both round-trip through the same save cycle.
+ */
+export interface EntityIdentity {
+    kind: string;
+    name: string;
+    id: number;
+}
 
 export interface PersistenceState {
     blocks: BlockInstance[];
@@ -51,6 +67,14 @@ export interface PersistenceState {
      */
     queueBlocksForSave: (next: BlockInstance[]) => void;
     /**
+     * Schedule a debounced save for entity metadata edits already staged
+     * in the core-data shim's edits bag (via `editEntityRecord`). Sidebar
+     * handlers + the post-title block's `useEntityProp` setter both
+     * dispatch into the same bag; this hook drains it on the next
+     * scheduled flush.
+     */
+    queueMetadataForSave: () => void;
+    /**
      * Cancels the pending debounce timer and fires the save immediately.
      * Wired to the ⌘S shortcut in the top bar so explicit saves bypass the
      * 800ms coalescing window.
@@ -64,6 +88,13 @@ export interface UsePersistenceOptions extends ApiClientConfig {
      * Defaults to 800ms so rapid edits coalesce into a single request.
      */
     debounceMs?: number;
+    /**
+     * Optional core-data entity identity. Provide for resources that
+     * register a `postType:*` entity through the shim (cms-framework
+     * Post/Page) so metadata edits round-trip through the G3 endpoint
+     * alongside the block save.
+     */
+    entity?: EntityIdentity | null;
 }
 
 // 1.5s debounce — long enough to coalesce drag-bursts from the color
@@ -76,10 +107,62 @@ function toApiError(error: unknown, fallback: string): ApiError {
     return error instanceof ApiError ? error : new ApiError(fallback, 0, error);
 }
 
+function hasEntityEdits(kind: string, name: string, id: number): boolean {
+    const store = wpSelect('core') as
+        | {
+              hasEditsForEntityRecord?: (
+                  kind: string,
+                  name: string,
+                  id: number
+              ) => boolean;
+          }
+        | undefined;
+
+    return store?.hasEditsForEntityRecord?.(kind, name, id) ?? false;
+}
+
+function readEntityEdits(
+    kind: string,
+    name: string,
+    id: number
+): Record<string, unknown> | null {
+    const store = wpSelect('core') as
+        | {
+              getEntityRecordEdits?: (
+                  kind: string,
+                  name: string,
+                  id: number
+              ) => Record<string, unknown> | null;
+          }
+        | undefined;
+
+    return store?.getEntityRecordEdits?.(kind, name, id) ?? null;
+}
+
+function clearEntityEdits(kind: string, name: string, id: number): void {
+    const dispatcher = wpDispatch('core') as
+        | {
+              clearEntityRecordEdits?: (
+                  kind: string,
+                  name: string,
+                  id: number
+              ) => void;
+          }
+        | undefined;
+
+    dispatcher?.clearEntityRecordEdits?.(kind, name, id);
+}
+
 export function usePersistence(
     options: UsePersistenceOptions
 ): PersistenceState {
-    const { debounceMs = DEFAULT_DEBOUNCE_MS, apiBase, resource, id } = options;
+    const {
+        debounceMs = DEFAULT_DEBOUNCE_MS,
+        apiBase,
+        resource,
+        id,
+        entity = null,
+    } = options;
 
     const [blocks, setBlocks] = useState<BlockInstance[]>([]);
     const [loadStatus, setLoadStatus] = useState<LoadStatus>('loading');
@@ -97,6 +180,12 @@ export function usePersistence(
     // writing state or scheduling a trailing flush.
     const targetVersionRef = useRef<number>(0);
     const loadStatusRef = useRef<LoadStatus>('loading');
+    // Mirrors the entity tuple in a ref so the runFlush closure can read
+    // the latest identity without re-binding `runFlush` on every render
+    // (which would replace `queueBlocksForSave` / `queueMetadataForSave`
+    // identity and churn the consuming components downstream).
+    const entityRef = useRef<EntityIdentity | null>(entity);
+    entityRef.current = entity;
 
     loadStatusRef.current = loadStatus;
 
@@ -152,9 +241,12 @@ export function usePersistence(
                 return;
             }
 
-            const next = pendingRef.current;
+            const nextBlocks = pendingRef.current;
+            const ent = entityRef.current;
+            const hasMetadata =
+                ent !== null && hasEntityEdits(ent.kind, ent.name, ent.id);
 
-            if (next === null) {
+            if (nextBlocks === null && !hasMetadata) {
                 return;
             }
 
@@ -165,25 +257,64 @@ export function usePersistence(
             setSaveStatus('saving');
             setSaveError(null);
 
-            try {
-                const response = await saveContent({ apiBase, resource, id }, next);
+            let savedAt: string | null = null;
 
-                if (unmountedRef.current || version !== targetVersionRef.current) {
-                    return;
+            try {
+                if (nextBlocks !== null) {
+                    const response = await saveContent(
+                        { apiBase, resource, id },
+                        nextBlocks
+                    );
+
+                    if (unmountedRef.current || version !== targetVersionRef.current) {
+                        return;
+                    }
+
+                    savedAt = response.updated_at;
+
+                    dispatchEditorEvent(
+                        trigger === 'save' ? VE_EDITOR_SAVE : VE_EDITOR_AUTOSAVE,
+                        {
+                            resource,
+                            id,
+                            blocks: nextBlocks,
+                            updatedAt: response.updated_at,
+                        }
+                    );
                 }
 
-                setLastSavedAt(response.updated_at);
-                setSaveStatus('saved');
+                if (
+                    ent !== null
+                    && hasEntityEdits(ent.kind, ent.name, ent.id)
+                ) {
+                    const edits = readEntityEdits(ent.kind, ent.name, ent.id);
 
-                dispatchEditorEvent(
-                    trigger === 'save' ? VE_EDITOR_SAVE : VE_EDITOR_AUTOSAVE,
-                    {
-                        resource,
-                        id,
-                        blocks: next,
-                        updatedAt: response.updated_at,
+                    if (edits !== null && Object.keys(edits).length > 0) {
+                        // PUT only the staged edits — sending the merged
+                        // record would re-stamp the cached `content.blocks`
+                        // (potentially clobbering the just-saved block tree
+                        // when `nextBlocks` was non-null).
+                        await saveEntityRecord(
+                            { apiBase, resource, id },
+                            edits
+                        );
+
+                        if (
+                            unmountedRef.current
+                            || version !== targetVersionRef.current
+                        ) {
+                            return;
+                        }
+
+                        clearEntityEdits(ent.kind, ent.name, ent.id);
                     }
-                );
+                }
+
+                if (savedAt !== null) {
+                    setLastSavedAt(savedAt);
+                }
+
+                setSaveStatus('saved');
             } catch (error: unknown) {
                 if (unmountedRef.current || version !== targetVersionRef.current) {
                     return;
@@ -200,8 +331,17 @@ export function usePersistence(
             // count as autosaves: they're reacting to buffered edits, not a
             // fresh explicit Save press. Skip if the target changed during
             // the save.
+            const trailingEnt = entityRef.current;
+            const hasTrailingMetadata =
+                trailingEnt !== null
+                && hasEntityEdits(
+                    trailingEnt.kind,
+                    trailingEnt.name,
+                    trailingEnt.id
+                );
+
             if (
-                pendingRef.current !== null
+                (pendingRef.current !== null || hasTrailingMetadata)
                 && !unmountedRef.current
                 && version === targetVersionRef.current
             ) {
@@ -250,16 +390,43 @@ export function usePersistence(
         [queueBlocksForSave]
     );
 
+    const queueMetadataForSave = useCallback((): void => {
+        if (
+            loadStatusRef.current !== 'ready'
+            || entityRef.current === null
+        ) {
+            return;
+        }
+
+        // Mark dirty immediately so the top-bar indicator reflects the
+        // pending edit before the debounce window elapses.
+        setSaveStatus('idle');
+
+        if (timerRef.current !== null) {
+            clearTimeout(timerRef.current);
+        }
+
+        timerRef.current = setTimeout(() => {
+            timerRef.current = null;
+            void runFlush('autosave');
+        }, debounceMs);
+    }, [debounceMs, runFlush]);
+
     const flush = useCallback((): void => {
         if (timerRef.current !== null) {
             clearTimeout(timerRef.current);
             timerRef.current = null;
         }
 
-        if (
-            pendingRef.current === null
-            || loadStatusRef.current !== 'ready'
-        ) {
+        if (loadStatusRef.current !== 'ready') {
+            return;
+        }
+
+        const ent = entityRef.current;
+        const hasMetadata =
+            ent !== null && hasEntityEdits(ent.kind, ent.name, ent.id);
+
+        if (pendingRef.current === null && !hasMetadata) {
             return;
         }
 
@@ -275,6 +442,7 @@ export function usePersistence(
         lastSavedAt,
         onBlocksChange,
         queueBlocksForSave,
+        queueMetadataForSave,
         flush,
     };
 }

--- a/resources/js/visual-editor/vendor/__tests__/core-data-shim.test.tsx
+++ b/resources/js/visual-editor/vendor/__tests__/core-data-shim.test.tsx
@@ -104,6 +104,14 @@ describe('core-data-shim entity registry', () => {
             // resolve to null when cms-framework isn't installed.
             'postType|post',
             'postType|page',
+            // G4a — `core/post-featured-image` and `core/cover` resolve
+            // the saved `featured_media` id via
+            // `getEntityRecord('postType', 'attachment', id)`. The
+            // matching `/visual-editor/api/attachments/{id}` endpoint
+            // delegates to the host's media library through
+            // `apGetMedia()` and falls back to 404 when no media
+            // library is installed.
+            'postType|attachment',
         ]);
     });
 
@@ -1034,11 +1042,173 @@ describe('core-data-shim hooks', () => {
         expect(result.totalPages).toBe(0);
     });
 
-    it('useEntityProp returns [undefined, setter, undefined]', () => {
+    it('useEntityProp returns [undefined, noop setter, undefined] when args are missing', () => {
         const [value, setter, rawValue] = renderHook(() => useEntityProp());
         expect(value).toBeUndefined();
         expect(rawValue).toBeUndefined();
         expect(typeof setter).toBe('function');
+        // Calling the noop setter must not throw or dispatch — we don't
+        // know which entity/prop the caller meant to edit.
+        expect(() => setter(undefined as unknown as never)).not.toThrow();
+    });
+
+    it('useEntityProp reads the edited prop (flattened raw shape) and the full prop separately', () => {
+        coreDispatch().receiveEntityRecords('postType', 'post', [
+            {
+                id: 1,
+                title: { rendered: 'Hello World', raw: 'Hello World' },
+                status: 'publish',
+                type: 'post',
+            },
+        ]);
+
+        const [edited, setter, full] = renderHook(() =>
+            useEntityProp<string | { rendered: string; raw: string }>(
+                'postType',
+                'post',
+                'title',
+                1,
+            ),
+        );
+
+        expect(edited).toBe('Hello World');
+        expect(full).toEqual({ rendered: 'Hello World', raw: 'Hello World' });
+        expect(typeof setter).toBe('function');
+    });
+
+    it('useEntityProp setter dispatches editEntityRecord and surfaces the edit on next read', () => {
+        coreDispatch().receiveEntityRecords('postType', 'post', [
+            {
+                id: 1,
+                title: { rendered: 'Hello World', raw: 'Hello World' },
+                status: 'publish',
+                type: 'post',
+            },
+        ]);
+
+        const captured = renderHook(() =>
+            useEntityProp<string>('postType', 'post', 'title', 1),
+        );
+
+        act(() => {
+            captured[1]('Updated Title');
+        });
+
+        const [edited] = renderHook(() =>
+            useEntityProp<string>('postType', 'post', 'title', 1),
+        );
+
+        expect(edited).toBe('Updated Title');
+        expect(
+            coreSelect().getEntityRecordEdits('postType', 'post', 1),
+        ).toEqual({ title: 'Updated Title' });
+    });
+
+    it('useEntityProp re-renders the same consumer when the resolver populates the cache', async () => {
+        // The previous renderHook-based test mounted a fresh React tree
+        // after the fetch settled. Real consumers (e.g. core/post-title's
+        // Edit) mount once and rely on useSelect's subscription to surface
+        // the populated value on the next render. This test exercises the
+        // subscription path against a single mounted Probe.
+        const { fetcher } = mockFetcher(async () =>
+            jsonResponse({
+                id: 1,
+                slug: 'tinker-test',
+                title: { rendered: 'Tinker Test', raw: 'Tinker Test' },
+                status: 'publish',
+                type: 'post',
+            }),
+        );
+
+        configureCoreDataShim({ apiBase: '/visual-editor/api', fetcher });
+
+        let captured: [unknown, unknown, unknown] = [
+            undefined,
+            undefined,
+            undefined,
+        ];
+
+        function Probe(): null {
+            captured = useEntityProp<string>('postType', 'post', 'title', 1);
+            return null;
+        }
+
+        render(<Probe />);
+
+        expect(captured[0]).toBeUndefined();
+
+        await act(async () => {
+            await new Promise((resolve) => setTimeout(resolve, 20));
+        });
+
+        expect(captured[0]).toBe('Tinker Test');
+    });
+
+    it('useEntityProp resolves the entity through the REST resolver and surfaces the prop after fetch', async () => {
+        // Mirrors how `core/post-title` reads `title` from a cms-framework
+        // post in the editor canvas: nothing pre-populates the cache, so
+        // the hook has to trigger the `getEntityRecord` resolver, fetch
+        // the record, and re-render with the populated value.
+        const { fetcher, calls } = mockFetcher(async () =>
+            jsonResponse({
+                id: 1,
+                slug: 'tinker-test',
+                title: { rendered: 'Tinker Test', raw: 'Tinker Test' },
+                status: 'publish',
+                type: 'post',
+            }),
+        );
+
+        configureCoreDataShim({ apiBase: '/visual-editor/api', fetcher });
+
+        const initial = renderHook(() =>
+            useEntityProp<string>('postType', 'post', 'title', 1),
+        );
+
+        expect(initial[0]).toBeUndefined();
+
+        // Settle the resolver thunk + receive dispatch.
+        await act(async () => {
+            await new Promise((resolve) => setTimeout(resolve, 20));
+        });
+
+        const settled = renderHook(() =>
+            useEntityProp<string>('postType', 'post', 'title', 1),
+        );
+
+        expect(calls.length).toBeGreaterThanOrEqual(1);
+        expect(calls[0]?.url).toBe('/visual-editor/api/posts/1');
+        expect(settled[0]).toBe('Tinker Test');
+    });
+
+    it('useEntityProp falls back to ambient EntityProvider id when the id arg is omitted', () => {
+        coreDispatch().receiveEntityRecords('postType', 'post', [
+            {
+                id: 7,
+                title: { rendered: 'Ambient', raw: 'Ambient' },
+                status: 'publish',
+                type: 'post',
+            },
+        ]);
+
+        let captured: [unknown, unknown, unknown] = [
+            undefined,
+            undefined,
+            undefined,
+        ];
+
+        function Probe(): null {
+            captured = useEntityProp('postType', 'post', 'title');
+            return null;
+        }
+
+        render(
+            <EntityProvider kind="postType" name="post" id={7}>
+                <Probe />
+            </EntityProvider>,
+        );
+
+        expect(captured[0]).toBe('Ambient');
     });
 
     it('useEntityBlockEditor returns an empty block list and stable setters', () => {

--- a/resources/js/visual-editor/vendor/core-data-shim.ts
+++ b/resources/js/visual-editor/vendor/core-data-shim.ts
@@ -49,7 +49,7 @@ import {
     type PropsWithChildren,
     type ReactElement,
 } from 'react';
-import { createReduxStore, register, useSelect } from '@wordpress/data';
+import { createReduxStore, register, useDispatch, useSelect } from '@wordpress/data';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -232,6 +232,21 @@ export const DEFAULT_ENTITIES: readonly EntityConfig[] = Object.freeze([
         key: 'id',
         label: 'Page',
         plural: 'pages',
+    },
+    // G4a — `core/post-featured-image` and `core/cover` resolve the
+    // saved `featured_media` id via `getEntityRecord('postType',
+    // 'attachment', id)`. The matching endpoint
+    // (`/visual-editor/api/attachments/{id}`) emits the WP REST media
+    // shape by delegating to the host's media library through
+    // `apGetMedia()`. When the helper isn't available the endpoint
+    // 404s and the block falls back to its empty placeholder.
+    {
+        kind: 'postType',
+        name: 'attachment',
+        baseURL: '/attachments',
+        key: 'id',
+        label: 'Attachment',
+        plural: 'attachments',
     },
 ]);
 
@@ -1654,12 +1669,113 @@ export function useEntityId(): EntityKey | undefined {
  */
 const noopSetter = (): void => {};
 
-export function useEntityProp<T = unknown>(): [
-    T | undefined,
-    typeof noopSetter,
-    T | undefined,
-] {
-    return [undefined, noopSetter, undefined];
+/**
+ * Reads + edits a single property of an entity record. Mirrors upstream
+ * `@wordpress/core-data`'s `useEntityProp` so block-library Edit
+ * components (e.g. `core/post-title`) round-trip the prop through the
+ * shim's edits bag.
+ *
+ * Returns `[ editedValue, setValue, fullValue ]` where:
+ * - `editedValue` is the prop read from `getEditedEntityRecord`, which
+ *   already flattens `{raw, rendered}` shapes to their `raw` string and
+ *   layers any pending edits on top. Block edits (e.g. typing into a
+ *   `core/post-title`'s `PlainText`) read this value.
+ * - `setValue` dispatches `editEntityRecord(kind, name, id, { [prop]: value })`
+ *   so subsequent reads see the new value through the edits bag.
+ * - `fullValue` is the prop read from the original `getEntityRecord` —
+ *   the unflattened shape, used by upstream code that needs the
+ *   `{rendered}` form (e.g. the post-title block's read-only fallback
+ *   path).
+ *
+ * The `id` argument is optional; when omitted the hook reads the
+ * ambient entity from {@link EntityProvider} via {@link useEntityId}.
+ * That mirrors core-data's behaviour for blocks rendered in a context
+ * that already declared the current entity.
+ *
+ * Returns `[undefined, noop, undefined]` when any of `kind`, `name`,
+ * `prop`, or the resolved id are missing — same guarded shape callers
+ * already destructure with default values (`const [ rawTitle = '' ]`).
+ */
+export function useEntityProp<T = unknown>(
+    kind?: EntityKind,
+    name?: EntityName,
+    prop?: string,
+    id?: EntityKey | null,
+): [T | undefined, (value: T) => void, T | undefined] {
+    const ambientId = useEntityId();
+    const resolvedId = id !== undefined && id !== null ? id : ambientId;
+
+    const { editedValue, fullValue } = useSelect<{
+        editedValue: T | undefined;
+        fullValue: T | undefined;
+    }>(
+        (select) => {
+            if (
+                kind === undefined ||
+                name === undefined ||
+                prop === undefined ||
+                resolvedId === undefined ||
+                resolvedId === null
+            ) {
+                return { editedValue: undefined, fullValue: undefined };
+            }
+
+            const store = select(STORE_NAME) as
+                | {
+                      getEntityRecord?: (
+                          kind: EntityKind,
+                          name: EntityName,
+                          id: EntityKey,
+                      ) => EntityRecord | null;
+                      getEditedEntityRecord?: (
+                          kind: EntityKind,
+                          name: EntityName,
+                          id: EntityKey,
+                      ) => EntityRecord | null;
+                  }
+                | undefined;
+
+            const edited = store?.getEditedEntityRecord?.(kind, name, resolvedId) ?? null;
+            const full = store?.getEntityRecord?.(kind, name, resolvedId) ?? null;
+
+            return {
+                editedValue: (edited?.[prop] as T | undefined) ?? undefined,
+                fullValue: (full?.[prop] as T | undefined) ?? undefined,
+            };
+        },
+        [kind, name, prop, resolvedId],
+    );
+
+    const dispatchTuple = useDispatch(STORE_NAME) as
+        | {
+              editEntityRecord?: (
+                  kind: EntityKind,
+                  name: EntityName,
+                  id: EntityKey,
+                  edits: EntityRecord,
+              ) => void;
+          }
+        | undefined;
+
+    const setter = useMemo(() => {
+        if (
+            kind === undefined ||
+            name === undefined ||
+            prop === undefined ||
+            resolvedId === undefined ||
+            resolvedId === null
+        ) {
+            return noopSetter as (value: T) => void;
+        }
+
+        return (value: T): void => {
+            dispatchTuple?.editEntityRecord?.(kind, name, resolvedId, {
+                [prop]: value,
+            });
+        };
+    }, [dispatchTuple, kind, name, prop, resolvedId]);
+
+    return [editedValue, setter, fullValue];
 }
 
 /**

--- a/routes/api.php
+++ b/routes/api.php
@@ -19,6 +19,7 @@ declare( strict_types=1 );
 
 use ArtisanPackUI\VisualEditor\Http\Controllers\Adapters\CmsFramework\PageController;
 use ArtisanPackUI\VisualEditor\Http\Controllers\Adapters\CmsFramework\PostController;
+use ArtisanPackUI\VisualEditor\Http\Controllers\AttachmentController;
 use ArtisanPackUI\VisualEditor\Http\Controllers\BlockPreviewController;
 use ArtisanPackUI\VisualEditor\Http\Controllers\EntitySearchController;
 use ArtisanPackUI\VisualEditor\Http\Controllers\GlobalStylesController;
@@ -177,3 +178,13 @@ Route::put( 'pages/{id}', [ PageController::class, 'update' ] )
 
 Route::delete( 'pages/{id}', [ PageController::class, 'destroy' ] )
 	->name( 'visual-editor.api.pages.destroy' );
+
+// G4a — WP REST attachment shape for `core/post-featured-image` and
+// `core/cover` (featured-image option). Both blocks resolve the saved
+// `featured_media` id via `getEntityRecord('postType', 'attachment',
+// id)`, so the shim's attachment entity registration points here.
+// Read-only for V1; uploads still flow through the host's media-library
+// picker via the M4 media bridge.
+Route::get( 'attachments/{id}', [ AttachmentController::class, 'show' ] )
+	->where( 'id', '[0-9]+' )
+	->name( 'visual-editor.api.attachments.show' );

--- a/src/Http/Controllers/AttachmentController.php
+++ b/src/Http/Controllers/AttachmentController.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * Attachment controller.
+ *
+ * Serves the WP REST `/wp/v2/media/{id}` envelope that Gutenberg blocks
+ * (notably `core/post-featured-image` and `core/cover`'s featured-image
+ * option) resolve through `getEntityRecord('postType', 'attachment',
+ * id)`. Without this endpoint the core-data shim's `attachment` entity
+ * registration would 404 and those blocks would render the empty
+ * placeholder even when a `featured_media` id is present on the post.
+ *
+ * The controller delegates to the host's media library through the
+ * `apGetMedia()` helper exposed by `artisanpack-ui/media-library`. When
+ * the helper isn't available (no media library installed, or the host
+ * uses a different library) the endpoint 404s — block render falls
+ * back to the empty placeholder, matching the behaviour for any
+ * unresolved attachment id.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Http\Controllers;
+
+use ArtisanPackUI\VisualEditor\MediaBridge\GutenbergAttachmentAdapter;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Response;
+use Illuminate\Routing\Controller;
+
+class AttachmentController extends Controller
+{
+	public function __construct( protected GutenbergAttachmentAdapter $adapter )
+	{
+	}
+
+	/**
+	 * Returns a single media record in WP REST shape.
+	 *
+	 * @since 1.0.0
+	 */
+	public function show( int|string $id ): JsonResponse
+	{
+		if ( ! function_exists( 'apGetMedia' ) ) {
+			return response()->json( null, Response::HTTP_NOT_FOUND );
+		}
+
+		$media = apGetMedia( (int) $id );
+
+		if ( null === $media ) {
+			return response()->json( null, Response::HTTP_NOT_FOUND );
+		}
+
+		return response()->json( $this->adapter->toWpRestShape( $media ) );
+	}
+}

--- a/src/MediaBridge/GutenbergAttachmentAdapter.php
+++ b/src/MediaBridge/GutenbergAttachmentAdapter.php
@@ -107,6 +107,93 @@ class GutenbergAttachmentAdapter
 	}
 
 	/**
+	 * Convert a single media record to the WP REST attachment shape.
+	 *
+	 * Distinct from {@see self::toGutenberg()}: where that emits the
+	 * compact shape Gutenberg's `MediaUpload` component round-trips
+	 * (`{ id, url, alt, sizes, ... }`), this method emits the WP REST
+	 * `/wp/v2/media/{id}` envelope (`{ id, source_url, alt_text,
+	 * media_details: { width, height, sizes }, ... }`) used by blocks
+	 * that resolve attachments through `getEntityRecord('postType',
+	 * 'attachment', id)` — `core/post-featured-image`, `core/cover`'s
+	 * featured-image option, and any other block that reads the media
+	 * record from the core-data store.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array<string, mixed>|Arrayable<string, mixed>|object  $media  Media record.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function toWpRestShape( array|object $media ): array
+	{
+		$source = $this->normalize( $media );
+
+		$id = (int) ( $source['id'] ?? 0 );
+
+		$mediaDetails = [];
+		if ( $this->isPositiveInt( $source['width'] ?? null ) ) {
+			$mediaDetails['width'] = (int) $source['width'];
+		}
+		if ( $this->isPositiveInt( $source['height'] ?? null ) ) {
+			$mediaDetails['height'] = (int) $source['height'];
+		}
+
+		$sizes = $this->extractSizes( $source );
+		if ( null !== $sizes ) {
+			$mediaDetails['sizes'] = $this->sizesToWpShape( $sizes );
+		}
+
+		return [
+			'id'            => $id,
+			'source_url'    => (string) ( $source['url'] ?? '' ),
+			'alt_text'      => $this->stringOrEmpty( $source['alt_text'] ?? null ),
+			'caption'       => [ 'rendered' => $this->stringOrEmpty( $source['caption'] ?? null ) ],
+			'title'         => [ 'rendered' => $this->stringOrEmpty( $source['title'] ?? null ) ],
+			'mime_type'     => (string) ( $source['mime_type'] ?? '' ),
+			'media_type'    => $this->inferMediaType( $source ) ?? 'file',
+			'media_details' => $mediaDetails,
+		];
+	}
+
+	/**
+	 * Reshape Gutenberg-style sizes (`{ slug: { url, width, height } }`)
+	 * into the WP REST media-details sizes shape (`{ slug: { source_url,
+	 * width, height } }`). Keeps the V1 surface narrow — additional
+	 * fields (`mime_type`, `file`) are V1.1+ if and when consumers need
+	 * them.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array<string, array<string, mixed>>  $sizes
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
+	protected function sizesToWpShape( array $sizes ): array
+	{
+		$out = [];
+		foreach ( $sizes as $slug => $size ) {
+			if ( ! is_array( $size ) ) {
+				continue;
+			}
+			$reshaped = [];
+			if ( isset( $size['url'] ) && is_string( $size['url'] ) ) {
+				$reshaped['source_url'] = $size['url'];
+			}
+			if ( isset( $size['width'] ) && is_int( $size['width'] ) ) {
+				$reshaped['width'] = $size['width'];
+			}
+			if ( isset( $size['height'] ) && is_int( $size['height'] ) ) {
+				$reshaped['height'] = $size['height'];
+			}
+			if ( [] !== $reshaped ) {
+				$out[ (string) $slug ] = $reshaped;
+			}
+		}
+		return $out;
+	}
+
+	/**
 	 * Reduce any supported input into an associative array for uniform
 	 * field access. Objects exposing `toArray()` route through that path so
 	 * Eloquent models surface their appended accessors (including `url`).

--- a/tests/Feature/VisualEditor/Adapters/CmsFramework/PostControllerTest.php
+++ b/tests/Feature/VisualEditor/Adapters/CmsFramework/PostControllerTest.php
@@ -158,6 +158,30 @@ it( 'updates a post via PUT and round-trips the block tree', function () {
 	expect( $post->fresh()->getBlockContent() )->toEqual( $next );
 } );
 
+it( 'persists a partial metadata-only PUT (excerpt + featured_media)', function () {
+	actor();
+
+	$post = TestBlockContentModel::create( [
+		'title'   => 'Original',
+		'status'  => 'published',
+		'content' => [],
+	] );
+
+	// Mirror the shape that visual-editor's `saveEntityRecord` API
+	// client sends when only sidebar metadata edits are pending — no
+	// `content` envelope, just the staged fields.
+	$this->putJson( "/visual-editor/api/posts/{$post->id}", [
+		'excerpt'        => 'A brand-new excerpt',
+		'featured_media' => 42,
+	] )
+		->assertOk()
+		->assertJsonPath( 'excerpt.rendered', 'A brand-new excerpt' );
+
+	$fresh = $post->fresh();
+	expect( $fresh->getAttribute( 'excerpt' ) )->toBe( 'A brand-new excerpt' );
+	expect( (int) $fresh->getAttribute( 'featured_image_id' ) )->toBe( 42 );
+} );
+
 it( 'rejects a bare-list content payload with 422', function () {
 	actor();
 

--- a/tests/Unit/VisualEditor/MediaBridge/GutenbergAttachmentAdapterTest.php
+++ b/tests/Unit/VisualEditor/MediaBridge/GutenbergAttachmentAdapterTest.php
@@ -227,3 +227,63 @@ it( 'is resolvable from the service container', function () {
 
 	expect( $adapter )->toBeInstanceOf( GutenbergAttachmentAdapter::class );
 } );
+
+it( 'emits the WP REST media shape for getEntityRecord(attachment) consumers', function () {
+	$adapter = new GutenbergAttachmentAdapter();
+
+	$result = $adapter->toWpRestShape( adapterFixture() );
+
+	expect( $result )->toMatchArray( [
+		'id'         => 42,
+		'source_url' => 'https://cdn.example.test/pic.jpg',
+		'alt_text'   => 'alt',
+		'mime_type'  => 'image/jpeg',
+		'media_type' => 'image',
+		'caption'    => [ 'rendered' => 'caption' ],
+		'title'      => [ 'rendered' => '' ],
+	] );
+
+	expect( $result['media_details'] )->toMatchArray( [
+		'width'  => 1024,
+		'height' => 768,
+	] );
+} );
+
+it( 'reshapes Gutenberg-style sizes into WP REST media-details sizes', function () {
+	$adapter = new GutenbergAttachmentAdapter();
+
+	$result = $adapter->toWpRestShape( adapterFixture( [
+		'metadata' => [
+			'sizes' => [
+				'thumbnail' => [
+					'url'    => 'https://cdn.example.test/pic-thumb.jpg',
+					'width'  => 150,
+					'height' => 150,
+				],
+			],
+		],
+	] ) );
+
+	expect( $result['media_details']['sizes'] ?? null )->toMatchArray( [
+		'thumbnail' => [
+			'source_url' => 'https://cdn.example.test/pic-thumb.jpg',
+			'width'      => 150,
+			'height'     => 150,
+		],
+	] );
+} );
+
+it( 'collapses null caption to a rendered empty string', function () {
+	$adapter = new GutenbergAttachmentAdapter();
+
+	$result = $adapter->toWpRestShape( adapterFixture( [
+		'alt_text' => null,
+		'caption'  => null,
+	] ) );
+
+	expect( $result )
+		->toMatchArray( [
+			'alt_text' => '',
+			'caption'  => [ 'rendered' => '' ],
+		] );
+} );


### PR DESCRIPTION
## Description

Verification + cleanup pass for G4a (issue #400). Surfaced and closed three real gaps in the G3 entity adapter that prevented `core/post-*` blocks from actually round-tripping their content in the editor canvas.

**Closes:** #400

## Type of Change

- [x] Bug fix (fixes an issue)
- [x] Enhancement (improves existing functionality)
- [x] Documentation update

## Related Issue

**Issue:** #400

## Motivation and Context

Per the issue's acceptance criteria, each `core/post-*` block needs to render editable content in the editor against cms-framework Post and Page. Verification revealed three blockers in code that had shipped through G0/G3:

1. The core-data shim's `useEntityProp` was a no-op stub returning `[undefined, noop, undefined]`. Every block-library Edit component that reads via `useEntityProp` (post-title, post-content, post-excerpt, post-author, post-date, post-featured-image, cover) saw nothing.
2. The block-editor's `BlockContextProvider` was never wrapped around `<BlockList>`, so blocks declaring `usesContext: ["postId", "postType", "queryId"]` had `context.postType`/`context.postId` undefined and short-circuited to their placeholder shells.
3. The persistence loop only saved the block tree via the legacy `/content` endpoint. Sidebar metadata edits (excerpt, featured_media, author, etc.) accumulated in local React state and were dropped on reload because no save channel sent them anywhere.

A fourth gap surfaced once 1–3 landed: `core/post-featured-image` and `core/cover` resolve their `featured_media` id via `getEntityRecord('postType', 'attachment', id)`, which our shim had no entity registration or endpoint for.

## Changes Made

- **`useEntityProp` (`core-data-shim.ts`)** — replace the no-op with a real read+edit hook. Reads via `getEditedEntityRecord` (flattened) + `getEntityRecord` (full shape), returns a setter that dispatches `editEntityRecord`. Falls back to ambient `EntityProvider` id when the explicit id arg is omitted.
- **`<BlockContextProvider>`** wraps `<BlockList>` with a memoized `{postType, postId}` value when the editor mounts against a cms-framework Post/Page. Skipped for non-entity resources.
- **`usePersistence`** accepts an optional `entity: {kind, name, id}` identity. Save flow now flushes block tree first via the existing `/content` PUT, then drains any staged `editEntityRecord` edits to a new `saveEntityRecord` API client method that PUTs partial WP-shape data to `/visual-editor/api/{resource}/{id}`. Sidebar handlers dispatch `editEntityRecord` alongside their existing `setLocalState` mirror; a `useSelect` subscription on the entity edits bag re-arms the metadata-save debounce when block-level setters fire (e.g. `core/post-title` typing).
- **`AttachmentController` + WP REST attachment shape** — new `GET /visual-editor/api/attachments/{id}` endpoint emits the WP REST media envelope (`source_url`, `alt_text`, `media_details`) by delegating to `apGetMedia()`. `GutenbergAttachmentAdapter::toWpRestShape()` produces the new shape; the existing `toGutenberg()` (legacy `MediaUpload` shape) is unchanged. Shim's `DEFAULT_ENTITIES` adds an `attachment` postType entity pointing at the new endpoint.
- **`docs/block-library-audit.md`** — flips the six entity-wired post blocks out of the M5-era "Crash or backend-required" deny-list section into a new "Entity-wired" bucket documenting the resolved-attribute contract that the Blade/React/Vue renderer packages consume. Adds the bucket to the bucket-classification preamble.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS 25.4.0
- Browser: Safari 26.4
- PHP Version: 8.4.3
- Project Version: 1.0 (release/1.0 branch)

**Tests Performed:**

1. Automated: 463 PHP tests + 970 JS tests (1 skipped), all green.
2. Manual smoke test in the dev app (`/packages/visual-editor/m3/post/1`):
   - `core/post-title` block reads + edits the saved title and persists on reload.
   - Sidebar title field, excerpt, and featured-image picker all round-trip metadata edits to `/visual-editor/api/posts/1` and persist on reload.
   - `core/post-featured-image` block renders the saved image after the new `attachments` entity resolves.
   - Inspector "Block" tab continues to track the selected block during entity-edit cycles (the memoization fix on `BlockContextProvider`).
3. Two PUT requests fire on save when both blocks and metadata changed: `PUT /content` for the block tree and `PUT /` for the partial entity edits, in order.

## Accessibility Tests Run

- [ ] Keyboard navigation tested
- [ ] Screen reader tested
- [ ] Color contrast verified
- [ ] ARIA labels checked

**Details:** No new UI surfaces; the inspector panels, block toolbar, and canvas markup are unchanged. Existing accessibility coverage in upstream Gutenberg components applies. The new attachment endpoint is a JSON-only API — no a11y surface.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:**

- `core-data-shim.test.tsx`: 5 new `useEntityProp` cases covering missing-args early return, edited-prop read with `{raw, rendered}` flattening, full-shape return, setter dispatching `editEntityRecord` and surfacing on next read, ambient `EntityProvider` id fallback, REST resolver path with mocked fetcher, and same-component re-render after the resolver settles. Plus the `attachment` entity registration assertion.
- `GutenbergAttachmentAdapterTest.php`: 3 new cases for `toWpRestShape` covering core field mapping, sizes reshape into WP `{source_url, width, height}` shape, and null caption collapse to `{rendered: ''}`.
- `PostControllerTest.php`: 1 new feature test exercising the partial metadata-only PUT path (`{excerpt, featured_media}`) end-to-end against `TestBlockContentModel`.

## Documentation

- [x] Inline code documentation added
- [ ] README updated
- [ ] Wiki updated
- [ ] API documentation updated

**Documentation details:** `docs/block-library-audit.md` updated to reflect the Entity-wired bucket. Inline PHPDoc + JSDoc on the new methods (`useEntityProp`, `saveEntityRecord` API client, `AttachmentController::show`, `toWpRestShape`, `usePersistence` entity identity), and explanatory comments at each non-obvious wiring site (BlockContextProvider memoization rationale, entity-edits subscription, dual-flush ordering).

## Companion dev-app changes

To make the manual smoke test possible, the dev-app (`Herd/artisanpack-ui`) needs:

- A migration adding `slug, excerpt, featured_image_id` to `visual_editor_posts` and the page-only fields to `visual_editor_pages`.
- `App\Models\Post` / `App\Models\Page` `$fillable` updates to expose those columns.
- `VisualEditorTestController::resolveFeaturedImage()` and the `m3-editor.blade.php` template passing `data-excerpt` / `data-featured-image` / `data-author-id` so the sidebar's local state hydrates from the DB on reload.

These are tracked separately on the dev-app working tree and not part of this PR.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [x] Accessibility tests completed
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for persisting post metadata (slug, excerpt, featured image) alongside block content
  * Core post blocks are now enabled by default and render with proper entity context
  * Enhanced editing capabilities for featured image, author, and other post properties

* **Documentation**
  * Updated block library audit to clarify entity-context-dependent blocks that are enabled by default

<!-- end of auto-generated comment: release notes by coderabbit.ai -->