### PR TITLE
feat: G4b — re-enable core/archives, core/categories, core/tag-cloud

### DIFF
--- a/config/visual-editor.php
+++ b/config/visual-editor.php
@@ -73,16 +73,16 @@ return [
 	| fully-qualified block names (e.g. `core/paragraph`, `core/query`).
 	|
 	| The V1 defaults follow the M5 block-library audit
-	| (see docs/block-library-audit.md), updated by E4 (#381). The
-	| allow-list now includes the entity-scoped blocks that B1's expanded
-	| `core-data` shim plus the C1–C5 REST surface can round-trip:
-	| `core/template-part`, `core/post-*`, `core/site-*`, and
-	| `core/navigation`. The deny-list still removes the loop / feed
-	| widgets (`core/query`, `core/latest-comments`, `core/archives`,
-	| `core/categories`, `core/tag-cloud`) — they need a real loop runtime
-	| and term/comment endpoints that the shim does not implement, and
-	| stay deferred until V2 (`artisanpack-ui/cms-framework`) and V1.1+
-	| respectively. Keep the JS-side mirror in
+	| (see docs/block-library-audit.md), updated by E4 (#381) and G4b
+	| (#401). The allow-list now includes the entity-scoped blocks that
+	| B1's expanded `core-data` shim plus the C1–C5 REST surface can
+	| round-trip (`core/template-part`, `core/post-*`, `core/site-*`,
+	| `core/navigation`) and the taxonomy/feed widgets that G4b wires to
+	| cms-framework's term + post APIs (`core/categories`,
+	| `core/tag-cloud`, `core/archives`). The deny-list still removes
+	| the loop runtime (`core/query`, `core/query-loop` — V1 G4c) and
+	| the comments widgets (`core/latest-comments` — V1.1+, requires a
+	| Comments module in cms-framework). Keep the JS-side mirror in
 	| `resources/js/visual-editor/site-editor/site-editor-app.tsx`
 	| (`D2_DISABLED_BLOCKS`) in sync with the deny-list — the two lists
 	| want to agree.
@@ -133,28 +133,35 @@ return [
 		'core/site-tagline',
 		'core/site-logo',
 		'core/navigation',
+		// G4b (#401) — taxonomy/feed widgets backed by cms-framework's
+		// term + post APIs through the dynamic-block registry. Hosts
+		// without cms-framework leave them registered client-side but
+		// the server-side renderer falls back to the unknown-block
+		// shell since no DynamicBlock is registered.
+		'core/categories',
+		'core/tag-cloud',
+		'core/archives',
 		'artisanpack/callout',
 	],
 
 	'disabled_blocks' => [
 		// `core/navigation` was enabled by D4 and stays enabled in E4.
 		// `core/template-part`, `core/post-*`, and `core/site-*` are
-		// promoted to the allow-list above by E4 (#381). The blocks
-		// listed here remain deliberately deferred:
+		// promoted to the allow-list above by E4 (#381). G4b (#401)
+		// promotes `core/categories`, `core/tag-cloud`, and
+		// `core/archives`. The blocks listed here remain deliberately
+		// deferred:
 		//
 		//  - core/query / core/query-loop need a real loop runtime
-		//    (V2 — `artisanpack-ui/cms-framework`).
-		//  - The taxonomy/feed widgets need term + comment endpoints
-		//    that the shim does not implement (V1.1+).
+		//    (V1 G4c — `cms-framework` `QueryRuntime` service).
+		//  - core/latest-comments needs a Comments module in
+		//    cms-framework that does not exist yet (V1.1+).
 		//
 		// The JS-side mirror in site-editor-app.tsx is updated
 		// alongside this entry.
 		'core/query',
 		'core/query-loop',
 		'core/latest-comments',
-		'core/archives',
-		'core/categories',
-		'core/tag-cloud',
 	],
 
 	/*

--- a/docs/block-library-audit.md
+++ b/docs/block-library-audit.md
@@ -112,13 +112,48 @@ title. Better UX is no block at all until `cms-framework` lands.
 | Block | Required data |
 | --- | --- |
 | `core/latest-comments` | Comments feed. |
-| `core/archives` | Archive list query. |
-| `core/categories` | Term hierarchy. |
-| `core/tag-cloud` | Term weights. |
 | `core/rss` | External feed fetch — not blocked by shim but disabled for consistency with the other feed widgets. |
 | `core/calendar` | Post date aggregation. |
 | `core/page-list` | Hierarchical page query. |
 | `core/table-of-contents` | Heading scan against rendered entity. |
+
+### G4b — re-enabled against cms-framework's term + post APIs (#401)
+
+`core/categories`, `core/tag-cloud`, and `core/archives` were promoted out
+of the empty-state list in G4b. Each block ships as a `DynamicBlock`
+subclass under `src/Blocks/Core/` that reads from cms-framework's
+`PostCategory`, `PostTag`, and `Post` models respectively. Registration is
+gated on `class_exists(BlogManager::class)` in `VisualEditorServiceProvider`
+— host apps without cms-framework still register the block client-side
+(via the inserter allow-list) but the preview endpoint resolves to the
+unknown-block fallback because no `DynamicBlock` is bound.
+
+Editor preview, Blade renderer, React renderer, and Vue renderer all
+resolve through the same `DynamicBlock::render()` path:
+
+- Editor surface: Gutenberg's upstream `Edit` components for these three
+  blocks already use `ServerSideRender`, which POSTs the block's name
+  and attributes to `/visual-editor/api/blocks/preview` — that controller
+  routes through the dynamic-block registry.
+- Front-end Blade renderer (`@artisanpack-ui/visual-editor-renderer-blade`)
+  invokes the registered `DynamicBlock` directly when walking the saved
+  block tree.
+- Front-end React (`...-renderer-react`) and Vue (`...-renderer-vue`)
+  renderers POST to the same preview endpoint on mount and splice the
+  returned HTML back into the tree.
+
+Archive URLs default to `/blog/{year}/{month}` (the cms-framework blog
+default route shape). Hosts with a different archive route should rebind
+the dynamic block via `VisualEditor::registerDynamicBlock(ArchivesBlock::class)`
+with a subclass that overrides `decorate()`. Custom-taxonomy support is
+out of scope for V1 (deferred to V1.1).
+
+The taxonomy entity registration (`{kind: 'taxonomy', name: 'category', …}`)
+called for in #401's implementation notes is intentionally **not** added in
+V1 — the upstream `core/categories|tag-cloud|archives` `Edit` components
+all render through `ServerSideRender`, so they never query
+`useEntityRecords('taxonomy', 'category')`. The shim entities can be
+layered in cheaply later if a future block needs them.
 
 ## Crash or backend-required — disabled by default
 

--- a/resources/js/visual-editor/editor/editor-app.tsx
+++ b/resources/js/visual-editor/editor/editor-app.tsx
@@ -50,6 +50,7 @@ import { registerContrastWarning } from './contrast-warning';
 import { ConvertToPatternControl } from './convert-to-pattern-control';
 import { discoverAndRegisterCustomBlocks } from './custom-blocks';
 import { registerSyncedPatternIndicator } from './synced-pattern-indicator';
+import { registerTaxonomyAndArchiveBlockOverrides } from './taxonomy-archive-block-overrides';
 import {
     DocumentPanels,
     type AuthorOption,
@@ -167,6 +168,11 @@ function registerOnce(): void {
     // for the same reason — the wrapper sees `core/block` once the
     // block registers and applies the badge from then on.
     registerSyncedPatternIndicator();
+    // G4b — swap the broken upstream Edit components for
+    // `core/categories`, `core/tag-cloud`, and `core/archives` with our
+    // ServerSideRender-backed wrappers BEFORE `registerCoreBlocks()` so
+    // the override applies during initial registration.
+    registerTaxonomyAndArchiveBlockOverrides();
     registerCoreBlocks();
     // Discover host-app custom blocks under
     // `resources/js/visual-editor/blocks/{block-name}/index.ts` and

--- a/resources/js/visual-editor/editor/taxonomy-archive-block-overrides.tsx
+++ b/resources/js/visual-editor/editor/taxonomy-archive-block-overrides.tsx
@@ -1,0 +1,241 @@
+/**
+ * Edit-component overrides for the three G4b dynamic blocks.
+ *
+ * The upstream `core/categories`, `core/tag-cloud`, and `core/archives`
+ * Edit components depend on data the shim does not provide:
+ *
+ *   - `core/categories` reads `getTaxonomy('category').labels.name`.
+ *   - `core/tag-cloud` calls `getTaxonomies({ per_page: -1 })`.
+ *   - `core/archives` renders through Gutenberg's
+ *     `@wordpress/server-side-render`, which POSTs to
+ *     `wp/v2/block-renderer/core/archives`. Visual-editor's preview
+ *     endpoint lives at `/visual-editor/api/blocks/preview` instead.
+ *
+ * Rather than backfill `getTaxonomies` / `getTaxonomy` selectors and a
+ * `wp/v2/block-renderer` route just for these three blocks, this filter
+ * swaps each block's `edit` with a thin wrapper that uses our
+ * `ServerSideRender` shim. The block's saved attribute shape, supports,
+ * and `save()` stay untouched — anything written by the previous
+ * upstream Edit (or by hosts that bind their own controls) is still
+ * round-tripped against the same attribute keys.
+ *
+ * Idempotent across HMR via a global Symbol guard so the post-editor
+ * and site-editor entries can both call `registerTaxonomyAndArchiveBlockOverrides()`.
+ */
+
+import { InspectorControls } from '@wordpress/block-editor';
+import {
+    PanelBody,
+    SelectControl,
+    ToggleControl,
+    RangeControl,
+} from '@wordpress/components';
+import { useBlockProps } from '@wordpress/block-editor';
+import { addFilter } from '@wordpress/hooks';
+import { __ } from '@wordpress/i18n';
+
+import { TEXT_DOMAIN } from '../vendor/i18n';
+
+import { ServerSideRender } from './server-side-render';
+
+const FILTER_HOOK = 'blocks.registerBlockType';
+const FILTER_NAMESPACE = 'artisanpack-ui/visual-editor/taxonomy-archive-overrides';
+const TARGET_BLOCKS = new Set( [
+    'core/categories',
+    'core/tag-cloud',
+    'core/archives',
+] );
+
+const REGISTERED_KEY = Symbol.for(
+    'artisanpack-ui.visual-editor.taxonomy-archive-overrides.registered'
+);
+
+// Typed as `{ label: string; value: string }[]` so TS does not narrow
+// the option values to literal unions — that narrowing collides with
+// the broader `string` type the block attributes carry.
+const SMALLEST_SIZE_OPTIONS: { label: string; value: string }[] = [
+    { label: '8pt', value: '8pt' },
+    { label: '10pt', value: '10pt' },
+    { label: '12pt', value: '12pt' },
+];
+
+const LARGEST_SIZE_OPTIONS: { label: string; value: string }[] = [
+    { label: '16pt', value: '16pt' },
+    { label: '22pt', value: '22pt' },
+    { label: '28pt', value: '28pt' },
+];
+
+interface GlobalSentinelHost {
+    [REGISTERED_KEY]?: boolean;
+}
+
+interface BlockSettings {
+    name?: string;
+    edit?: unknown;
+    [key: string]: unknown;
+}
+
+interface EditProps {
+    attributes: Record<string, unknown>;
+    setAttributes: ( changes: Record<string, unknown> ) => void;
+}
+
+function CategoriesEdit( { attributes, setAttributes }: EditProps ): JSX.Element {
+    const blockProps = useBlockProps();
+    const showPostCounts = Boolean( attributes.showPostCounts );
+    const showHierarchy = Boolean( attributes.showHierarchy );
+    const showOnlyTopLevel = Boolean( attributes.showOnlyTopLevel );
+    const showEmpty = Boolean( attributes.showEmpty );
+
+    return (
+        <>
+            <InspectorControls>
+                <PanelBody title={ __( 'Settings', TEXT_DOMAIN ) }>
+                    <ToggleControl
+                        label={ __( 'Show post counts', TEXT_DOMAIN ) }
+                        checked={ showPostCounts }
+                        onChange={ ( value ) => setAttributes( { showPostCounts: value } ) }
+                    />
+                    <ToggleControl
+                        label={ __( 'Show hierarchy', TEXT_DOMAIN ) }
+                        checked={ showHierarchy }
+                        onChange={ ( value ) => setAttributes( { showHierarchy: value } ) }
+                    />
+                    <ToggleControl
+                        label={ __( 'Show only top level', TEXT_DOMAIN ) }
+                        checked={ showOnlyTopLevel }
+                        onChange={ ( value ) => setAttributes( { showOnlyTopLevel: value } ) }
+                    />
+                    <ToggleControl
+                        label={ __( 'Show empty terms', TEXT_DOMAIN ) }
+                        checked={ showEmpty }
+                        onChange={ ( value ) => setAttributes( { showEmpty: value } ) }
+                    />
+                </PanelBody>
+            </InspectorControls>
+            <div { ...blockProps }>
+                <ServerSideRender block="core/categories" attributes={ attributes } />
+            </div>
+        </>
+    );
+}
+
+function TagCloudEdit( { attributes, setAttributes }: EditProps ): JSX.Element {
+    const blockProps = useBlockProps();
+    const numberOfTags =
+        typeof attributes.numberOfTags === 'number' ? attributes.numberOfTags : 45;
+    const showTagCounts = Boolean( attributes.showTagCounts );
+    const smallestFontSize =
+        typeof attributes.smallestFontSize === 'string'
+            ? attributes.smallestFontSize
+            : '8pt';
+    const largestFontSize =
+        typeof attributes.largestFontSize === 'string'
+            ? attributes.largestFontSize
+            : '22pt';
+
+    return (
+        <>
+            <InspectorControls>
+                <PanelBody title={ __( 'Settings', TEXT_DOMAIN ) }>
+                    <RangeControl
+                        label={ __( 'Number of tags', TEXT_DOMAIN ) }
+                        min={ 1 }
+                        max={ 100 }
+                        value={ numberOfTags }
+                        onChange={ ( value ) => setAttributes( { numberOfTags: value ?? 45 } ) }
+                    />
+                    <ToggleControl
+                        label={ __( 'Show tag counts', TEXT_DOMAIN ) }
+                        checked={ showTagCounts }
+                        onChange={ ( value ) => setAttributes( { showTagCounts: value } ) }
+                    />
+                    <SelectControl
+                        label={ __( 'Smallest size', TEXT_DOMAIN ) }
+                        value={ smallestFontSize }
+                        options={ SMALLEST_SIZE_OPTIONS }
+                        onChange={ ( value ) => setAttributes( { smallestFontSize: value } ) }
+                    />
+                    <SelectControl
+                        label={ __( 'Largest size', TEXT_DOMAIN ) }
+                        value={ largestFontSize }
+                        options={ LARGEST_SIZE_OPTIONS }
+                        onChange={ ( value ) => setAttributes( { largestFontSize: value } ) }
+                    />
+                </PanelBody>
+            </InspectorControls>
+            <div { ...blockProps }>
+                <ServerSideRender block="core/tag-cloud" attributes={ attributes } />
+            </div>
+        </>
+    );
+}
+
+function ArchivesEdit( { attributes, setAttributes }: EditProps ): JSX.Element {
+    const blockProps = useBlockProps();
+    const showPostCounts = Boolean( attributes.showPostCounts );
+    const displayAsDropdown = Boolean( attributes.displayAsDropdown );
+    const type = attributes.type === 'yearly' ? 'yearly' : 'monthly';
+
+    return (
+        <>
+            <InspectorControls>
+                <PanelBody title={ __( 'Settings', TEXT_DOMAIN ) }>
+                    <ToggleControl
+                        label={ __( 'Display as dropdown', TEXT_DOMAIN ) }
+                        checked={ displayAsDropdown }
+                        onChange={ ( value ) => setAttributes( { displayAsDropdown: value } ) }
+                    />
+                    <ToggleControl
+                        label={ __( 'Show post counts', TEXT_DOMAIN ) }
+                        checked={ showPostCounts }
+                        onChange={ ( value ) => setAttributes( { showPostCounts: value } ) }
+                    />
+                    <SelectControl
+                        label={ __( 'Group by', TEXT_DOMAIN ) }
+                        value={ type }
+                        options={ [
+                            { label: __( 'Monthly', TEXT_DOMAIN ), value: 'monthly' },
+                            { label: __( 'Yearly', TEXT_DOMAIN ), value: 'yearly' },
+                        ] }
+                        onChange={ ( value ) => setAttributes( { type: value } ) }
+                    />
+                </PanelBody>
+            </InspectorControls>
+            <div { ...blockProps }>
+                <ServerSideRender block="core/archives" attributes={ attributes } />
+            </div>
+        </>
+    );
+}
+
+const EDITS: Record<string, ( props: EditProps ) => JSX.Element> = {
+    'core/categories': CategoriesEdit,
+    'core/tag-cloud': TagCloudEdit,
+    'core/archives': ArchivesEdit,
+};
+
+function overrideEdit( settings: BlockSettings, name: string ): BlockSettings {
+    if ( ! TARGET_BLOCKS.has( name ) ) {
+        return settings;
+    }
+
+    const edit = EDITS[ name ];
+
+    if ( edit === undefined ) {
+        return settings;
+    }
+
+    return { ...settings, edit };
+}
+
+export function registerTaxonomyAndArchiveBlockOverrides(): void {
+    const host = globalThis as unknown as GlobalSentinelHost;
+
+    if ( host[ REGISTERED_KEY ] === true ) {
+        return;
+    }
+
+    addFilter( FILTER_HOOK, FILTER_NAMESPACE, overrideEdit );
+    host[ REGISTERED_KEY ] = true;
+}

--- a/resources/js/visual-editor/site-editor/__tests__/site-editor-app.test.tsx
+++ b/resources/js/visual-editor/site-editor/__tests__/site-editor-app.test.tsx
@@ -125,6 +125,13 @@ vi.mock('../../editor/synced-pattern-indicator', () => ({
     registerSyncedPatternIndicator: () => undefined,
 }));
 
+// G4b — stub the taxonomy/archive Edit override registration to avoid
+// pulling `@wordpress/block-editor` + `@wordpress/components` into the
+// shell test's import graph.
+vi.mock('../../editor/taxonomy-archive-block-overrides', () => ({
+    registerTaxonomyAndArchiveBlockOverrides: () => undefined,
+}));
+
 import { SiteEditorApp } from '../site-editor-app';
 
 const ROUTE_BASE = '/visual-editor/site';

--- a/resources/js/visual-editor/site-editor/site-editor-app.tsx
+++ b/resources/js/visual-editor/site-editor/site-editor-app.tsx
@@ -51,6 +51,7 @@ import { usePersistedToggle } from './use-persisted-toggle';
 import { useSiteEditorRouting } from './use-site-editor-routing';
 import { TopBar } from '../editor/top-bar';
 import { registerSyncedPatternIndicator } from '../editor/synced-pattern-indicator';
+import { registerTaxonomyAndArchiveBlockOverrides } from '../editor/taxonomy-archive-block-overrides';
 
 import './site-editor-app.css';
 
@@ -126,10 +127,14 @@ let editorBooted = false;
  * blocks alongside the loop + feed widgets because their `Edit`
  * components depended on core-data selectors the M2 shim did not
  * implement. E4 re-enables every entity-scoped block on the back of
- * B1's expanded shim plus the C1–C5 REST surface; the loop and feed
- * widgets stay disabled because they still need a real loop runtime
- * (V2) and term/comment endpoints (V1.1+) that the shim does not
- * implement.
+ * B1's expanded shim plus the C1–C5 REST surface. G4b (#401) re-enables
+ * `core/categories`, `core/tag-cloud`, and `core/archives` because
+ * their upstream `Edit` components render through `ServerSideRender`
+ * — the visual-editor's preview endpoint resolves them via the
+ * dynamic-block registry against cms-framework's term and post APIs.
+ * The loop and comments widgets stay disabled because they still need
+ * a real loop runtime (V1 G4c) and a Comments module in cms-framework
+ * (V1.1+) respectively.
  *
  * Mirrors the PHP `disabled_blocks` list in
  * `config/visual-editor.php` — the two lists want to agree, and the
@@ -139,9 +144,6 @@ const D2_DISABLED_BLOCKS: ReadonlyArray<string> = [
     'core/query',
     'core/query-loop',
     'core/latest-comments',
-    'core/archives',
-    'core/categories',
-    'core/tag-cloud',
 ];
 
 function ensureEditorBoot(): void {
@@ -155,6 +157,12 @@ function ensureEditorBoot(): void {
     // registration so `core/block` reference blocks get the badge from
     // the first render. Idempotent across HMR.
     registerSyncedPatternIndicator();
+
+    // G4b — swap the broken upstream Edit components for
+    // `core/categories`, `core/tag-cloud`, and `core/archives` with our
+    // ServerSideRender-backed wrappers BEFORE `registerCoreBlocks()` so
+    // the override applies during initial registration.
+    registerTaxonomyAndArchiveBlockOverrides();
 
     // Register core blocks before the first template loads so `parse()`
     // can turn the saved raw serialization back into BlockInstances

--- a/src/Blocks/Core/ArchivesBlock.php
+++ b/src/Blocks/Core/ArchivesBlock.php
@@ -198,8 +198,13 @@ class ArchivesBlock extends DynamicBlock
 			);
 		} )->implode( '' );
 
+		// The inline onchange mirrors upstream `core/archives` — selecting an
+		// option navigates to the archive URL. Hosts under a strict CSP that
+		// forbids inline handlers can rebind this block via the dynamic-block
+		// registry to emit a data-attribute hook + a host-supplied script
+		// instead.
 		return sprintf(
-			'<div class="%s">%s<select id="%s"><option value="">%s</option>%s</select></div>',
+			'<div class="%s">%s<select id="%s" onchange="if(this.value)document.location.href=this.value"><option value="">%s</option>%s</select></div>',
 			e( implode( ' ', $classes ) ),
 			$labelMarkup,
 			e( $dropdownId ),

--- a/src/Blocks/Core/ArchivesBlock.php
+++ b/src/Blocks/Core/ArchivesBlock.php
@@ -1,0 +1,226 @@
+<?php
+
+/**
+ * Server-rendered `core/archives` block.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Blocks\Core;
+
+use ArtisanPackUI\CMSFramework\Modules\Blog\Models\Post;
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\ContentStatus;
+use ArtisanPackUI\VisualEditor\Blocks\DynamicBlock;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
+
+/**
+ * Renders monthly archive links for cms-framework's `Post` model,
+ * matching upstream `core/archives` markup. Supports the upstream
+ * `showLabel`, `showPostCounts`, and `displayAsDropdown` attributes.
+ *
+ * The archive URL pattern is `/blog/{year}/{month}` to match
+ * cms-framework's blog defaults; hosts that route archives elsewhere
+ * should override the `archive_url_pattern` config or rebind this
+ * block via the dynamic-block registry.
+ */
+class ArchivesBlock extends DynamicBlock
+{
+	public function name(): string
+	{
+		return 'core/archives';
+	}
+
+	public function validateAttrs( array $attrs ): array
+	{
+		return [
+			'showLabel'         => ! isset( $attrs['showLabel'] ) || (bool) $attrs['showLabel'],
+			'showPostCounts'    => (bool) ( $attrs['showPostCounts'] ?? false ),
+			'displayAsDropdown' => (bool) ( $attrs['displayAsDropdown'] ?? false ),
+			'type'              => 'yearly' === ( $attrs['type'] ?? null ) ? 'yearly' : 'monthly',
+			'className'         => isset( $attrs['className'] ) && is_string( $attrs['className'] ) ? $attrs['className'] : '',
+		];
+	}
+
+	public function render( array $attrs ): string
+	{
+		$buckets = $this->fetchBuckets( $attrs['type'] )
+			->map( fn ( array $bucket ): array => $this->decorate( $bucket ) );
+		$classes = $this->wrapperClasses( $attrs );
+
+		if ( $buckets->isEmpty() ) {
+			return sprintf(
+				'<div class="%s">%s</div>',
+				e( implode( ' ', $classes ) ),
+				e( __( 'No archives to show.' ) )
+			);
+		}
+
+		if ( $attrs['displayAsDropdown'] ) {
+			return $this->renderDropdown( $buckets, $classes, $attrs );
+		}
+
+		return $this->renderList( $buckets, $classes, $attrs );
+	}
+
+	/**
+	 * Returns raw archive buckets sorted newest-first. Pulled out so
+	 * tests can override the data source without exercising the database.
+	 *
+	 * @return Collection<int, array{year: int, month: int|null, count: int}>
+	 */
+	protected function fetchBuckets( string $type ): Collection
+	{
+		// Aggregating in PHP rather than SQL keeps this driver-agnostic
+		// (SQLite uses `strftime`, MySQL uses `YEAR()`/`MONTH()`, Postgres
+		// uses `EXTRACT`). For archive blocks the published-post count is
+		// bounded enough that the round-trip is cheap; hosts with very
+		// large datasets can rebind this block via the dynamic-block
+		// registry to push the grouping into SQL.
+		$timestamps = Post::query()
+			->where( 'status', ContentStatus::Published->value )
+			->whereNotNull( 'published_at' )
+			->orderByDesc( 'published_at' )
+			->pluck( 'published_at' );
+
+		$buckets = $timestamps
+			->map( static fn ( $value ): ?Carbon => $value instanceof Carbon ? $value : ( null === $value ? null : Carbon::parse( $value ) ) )
+			->filter( static fn ( ?Carbon $date ): bool => null !== $date )
+			->reduce( function ( Collection $carry, Carbon $date ) use ( $type ): Collection {
+				$key = 'yearly' === $type
+					? sprintf( '%04d', $date->year )
+					: sprintf( '%04d-%02d', $date->year, $date->month );
+
+				if ( ! $carry->has( $key ) ) {
+					$carry->put( $key, [
+						'year'  => $date->year,
+						'month' => 'yearly' === $type ? null : $date->month,
+						'count' => 0,
+					] );
+				}
+
+				$bucket           = $carry->get( $key );
+				$bucket['count'] += 1;
+				$carry->put( $key, $bucket );
+
+				return $carry;
+			}, new Collection() )
+			->sortKeysDesc()
+			->values();
+
+		return $buckets;
+	}
+
+	/**
+	 * @param  array{year: int, month: int|null, count: int}  $bucket
+	 *
+	 * @return array{year: int, month: int|null, count: int, label: string, url: string}
+	 */
+	protected function decorate( array $bucket ): array
+	{
+		if ( null === $bucket['month'] ) {
+			$bucket['label'] = (string) $bucket['year'];
+			$bucket['url']   = url( sprintf( '/blog/%04d', $bucket['year'] ) );
+
+			return $bucket;
+		}
+
+		$bucket['label'] = Carbon::create( $bucket['year'], $bucket['month'], 1 )->translatedFormat( 'F Y' );
+		$bucket['url']   = url( sprintf( '/blog/%04d/%02d', $bucket['year'], $bucket['month'] ) );
+
+		return $bucket;
+	}
+
+	/**
+	 * @param  Collection<int, array{year: int, month: int|null, count: int, label: string, url: string}>  $buckets
+	 * @param  array<int, string>                                                                          $classes
+	 * @param  array<string, mixed>                                                                        $attrs
+	 */
+	protected function renderList( Collection $buckets, array $classes, array $attrs ): string
+	{
+		$classes[] = 'wp-block-archives-list';
+
+		$items = $buckets->map( function ( array $bucket ) use ( $attrs ): string {
+			$count = $attrs['showPostCounts']
+				? sprintf( '&nbsp;(%d)', $bucket['count'] )
+				: '';
+
+			return sprintf(
+				'<li><a href="%s">%s</a>%s</li>',
+				e( $bucket['url'] ),
+				e( $bucket['label'] ),
+				$count
+			);
+		} )->implode( '' );
+
+		return sprintf(
+			'<ul class="%s">%s</ul>',
+			e( implode( ' ', $classes ) ),
+			$items
+		);
+	}
+
+	/**
+	 * @param  Collection<int, array{year: int, month: int|null, count: int, label: string, url: string}>  $buckets
+	 * @param  array<int, string>                                                                          $classes
+	 * @param  array<string, mixed>                                                                        $attrs
+	 */
+	protected function renderDropdown( Collection $buckets, array $classes, array $attrs ): string
+	{
+		$classes[] = 'wp-block-archives-dropdown';
+
+		// Generate a per-render id so multiple `core/archives` blocks on the
+		// same page don't share `id="wp-block-archives-dropdown"`. The label's
+		// `for` attribute uses the same id so screen-reader association holds.
+		$dropdownId = 'wp-block-archives-dropdown-' . uniqid();
+
+		$labelMarkup = $attrs['showLabel']
+			? sprintf( '<label class="screen-reader-text" for="%s">%s</label>', e( $dropdownId ), e( __( 'Archives' ) ) )
+			: '';
+
+		$options = $buckets->map( function ( array $bucket ) use ( $attrs ): string {
+			$count = $attrs['showPostCounts']
+				? sprintf( '&nbsp;(%d)', $bucket['count'] )
+				: '';
+
+			return sprintf(
+				'<option value="%s">%s%s</option>',
+				e( $bucket['url'] ),
+				e( $bucket['label'] ),
+				$count
+			);
+		} )->implode( '' );
+
+		return sprintf(
+			'<div class="%s">%s<select id="%s"><option value="">%s</option>%s</select></div>',
+			e( implode( ' ', $classes ) ),
+			$labelMarkup,
+			e( $dropdownId ),
+			e( __( 'Select Archive' ) ),
+			$options
+		);
+	}
+
+	/**
+	 * @param  array<string, mixed>  $attrs
+	 *
+	 * @return array<int, string>
+	 */
+	protected function wrapperClasses( array $attrs ): array
+	{
+		$classes = [ 'wp-block-archives' ];
+
+		if ( '' !== $attrs['className'] ) {
+			$classes[] = $attrs['className'];
+		}
+
+		return $classes;
+	}
+}

--- a/src/Blocks/Core/CategoriesBlock.php
+++ b/src/Blocks/Core/CategoriesBlock.php
@@ -1,0 +1,182 @@
+<?php
+
+/**
+ * Server-rendered `core/categories` block.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Blocks\Core;
+
+use ArtisanPackUI\CMSFramework\Modules\Blog\Models\PostCategory;
+use ArtisanPackUI\VisualEditor\Blocks\DynamicBlock;
+use Illuminate\Database\Eloquent\Collection;
+
+/**
+ * Renders cms-framework post categories matching upstream
+ * `core/categories` markup. Supports the upstream attributes the editor
+ * exposes: `showHierarchy`, `showPostCounts`, `showOnlyTopLevel`,
+ * `showEmpty`. `displayAsDropdown` falls back to the list rendering for
+ * V1 — the upstream dropdown ships a JS handler we don't run server-side.
+ */
+class CategoriesBlock extends DynamicBlock
+{
+	public function name(): string
+	{
+		return 'core/categories';
+	}
+
+	public function validateAttrs( array $attrs ): array
+	{
+		return [
+			'showHierarchy'     => (bool) ( $attrs['showHierarchy'] ?? false ),
+			'showPostCounts'    => (bool) ( $attrs['showPostCounts'] ?? false ),
+			'showOnlyTopLevel'  => (bool) ( $attrs['showOnlyTopLevel'] ?? false ),
+			'showEmpty'         => (bool) ( $attrs['showEmpty'] ?? false ),
+			'displayAsDropdown' => (bool) ( $attrs['displayAsDropdown'] ?? false ),
+			'className'         => isset( $attrs['className'] ) && is_string( $attrs['className'] ) ? $attrs['className'] : '',
+		];
+	}
+
+	public function render( array $attrs ): string
+	{
+		$categories = $this->fetchCategories( $attrs );
+
+		if ( $categories->isEmpty() ) {
+			return $this->emptyShell( $attrs, __( 'No categories' ) );
+		}
+
+		$items = $attrs['showHierarchy']
+			? $this->renderHierarchy( $categories, null, $attrs )
+			: $this->renderFlat( $categories, $attrs );
+
+		$classes = $this->wrapperClasses( $attrs );
+
+		return sprintf(
+			'<ul class="%s">%s</ul>',
+			e( implode( ' ', $classes ) ),
+			$items
+		);
+	}
+
+	/**
+	 * Returns the category records used by {@see render()}. Pulled out so
+	 * tests can override the data source without exercising the database.
+	 *
+	 * @param  array<string, mixed>  $attrs
+	 *
+	 * @return Collection<int, object>
+	 */
+	protected function fetchCategories( array $attrs ): Collection
+	{
+		$query = PostCategory::query()->withCount( 'posts' );
+
+		if ( $attrs['showOnlyTopLevel'] ) {
+			$query->whereNull( 'parent_id' );
+		}
+
+		$query->orderBy( 'name' );
+
+		$categories = $query->get();
+
+		// Filtering empty categories post-hoc keeps the SQL portable.
+		// `having` on a `withCount` alias works in MySQL but not in every
+		// SQLite/Postgres configuration, so the in-memory filter is the
+		// safer cross-database choice.
+		if ( ! $attrs['showEmpty'] ) {
+			$categories = $categories->filter(
+				static fn ( object $category ): bool => (int) ( $category->posts_count ?? 0 ) > 0
+			)->values();
+		}
+
+		return $categories;
+	}
+
+	/**
+	 * @param  Collection<int, object>  $categories
+	 * @param  array<string, mixed>     $attrs
+	 */
+	protected function renderFlat( Collection $categories, array $attrs ): string
+	{
+		return $categories->map(
+			fn ( object $category ): string => $this->renderItem( $category, $attrs )
+		)->implode( '' );
+	}
+
+	/**
+	 * @param  Collection<int, object>  $categories
+	 * @param  array<string, mixed>     $attrs
+	 */
+	protected function renderHierarchy( Collection $categories, ?int $parentId, array $attrs ): string
+	{
+		$children = $categories->where( 'parent_id', $parentId );
+
+		if ( $children->isEmpty() ) {
+			return '';
+		}
+
+		return $children->map( function ( object $category ) use ( $categories, $attrs ): string {
+			$nested = $this->renderHierarchy( $categories, (int) $category->id, $attrs );
+
+			$inner = $nested === ''
+				? ''
+				: sprintf( '<ul class="children">%s</ul>', $nested );
+
+			return $this->renderItem( $category, $attrs, $inner );
+		} )->implode( '' );
+	}
+
+	/**
+	 * @param  array<string, mixed>  $attrs
+	 */
+	protected function renderItem( object $category, array $attrs, string $extra = '' ): string
+	{
+		$count = $attrs['showPostCounts']
+			? sprintf( ' (%d)', (int) ( $category->posts_count ?? 0 ) )
+			: '';
+
+		return sprintf(
+			'<li class="cat-item cat-item-%d"><a href="%s">%s</a>%s%s</li>',
+			(int) $category->id,
+			e( (string) $category->permalink ),
+			e( (string) $category->name ),
+			$count,
+			$extra
+		);
+	}
+
+	/**
+	 * @param  array<string, mixed>  $attrs
+	 *
+	 * @return array<int, string>
+	 */
+	protected function wrapperClasses( array $attrs ): array
+	{
+		$classes = [ 'wp-block-categories', 'wp-block-categories-list' ];
+
+		if ( '' !== $attrs['className'] ) {
+			$classes[] = $attrs['className'];
+		}
+
+		return $classes;
+	}
+
+	/**
+	 * @param  array<string, mixed>  $attrs
+	 */
+	protected function emptyShell( array $attrs, string $message ): string
+	{
+		return sprintf(
+			'<ul class="%s"><li class="cat-item-empty">%s</li></ul>',
+			e( implode( ' ', $this->wrapperClasses( $attrs ) ) ),
+			e( $message )
+		);
+	}
+}

--- a/src/Blocks/Core/TagCloudBlock.php
+++ b/src/Blocks/Core/TagCloudBlock.php
@@ -1,0 +1,173 @@
+<?php
+
+/**
+ * Server-rendered `core/tag-cloud` block.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Blocks\Core;
+
+use ArtisanPackUI\CMSFramework\Modules\Blog\Models\PostTag;
+use ArtisanPackUI\VisualEditor\Blocks\DynamicBlock;
+use Illuminate\Support\Collection;
+
+/**
+ * Renders cms-framework post tags weighted by post count, matching the
+ * upstream `core/tag-cloud` markup. Supports the upstream `numberOfTags`,
+ * `showTagCounts`, `smallestFontSize`, and `largestFontSize` attributes.
+ *
+ * The taxonomy attribute is fixed to `post_tag` for V1 — custom
+ * taxonomies are deferred per the issue's "out of scope" list.
+ */
+class TagCloudBlock extends DynamicBlock
+{
+	public function name(): string
+	{
+		return 'core/tag-cloud';
+	}
+
+	public function validateAttrs( array $attrs ): array
+	{
+		return [
+			'numberOfTags'     => max( 1, min( 100, (int) ( $attrs['numberOfTags'] ?? 45 ) ) ),
+			'showTagCounts'    => (bool) ( $attrs['showTagCounts'] ?? false ),
+			'smallestFontSize' => isset( $attrs['smallestFontSize'] ) && is_string( $attrs['smallestFontSize'] ) ? $attrs['smallestFontSize'] : '8pt',
+			'largestFontSize'  => isset( $attrs['largestFontSize'] ) && is_string( $attrs['largestFontSize'] ) ? $attrs['largestFontSize'] : '22pt',
+			'className'        => isset( $attrs['className'] ) && is_string( $attrs['className'] ) ? $attrs['className'] : '',
+		];
+	}
+
+	public function render( array $attrs ): string
+	{
+		$tags    = $this->fetchTags( $attrs );
+		$classes = $this->wrapperClasses( $attrs );
+
+		if ( $tags->isEmpty() ) {
+			return sprintf( '<p class="%s"></p>', e( implode( ' ', $classes ) ) );
+		}
+
+		[ $smallestPt, $largestPt, $unit ] = $this->parseFontSizes( $attrs );
+		$counts                            = $tags->pluck( 'posts_count' )->map( static fn ( $count ): int => (int) $count );
+		$minCount                          = max( 1, (int) $counts->min() );
+		$maxCount                          = max( $minCount, (int) $counts->max() );
+
+		$items = $tags->map( function ( object $tag ) use ( $minCount, $maxCount, $smallestPt, $largestPt, $unit, $attrs ): string {
+			$count = (int) ( $tag->posts_count ?? 0 );
+			$size  = $this->scaleFontSize( $count, $minCount, $maxCount, $smallestPt, $largestPt );
+
+			$countMarkup = $attrs['showTagCounts']
+				? sprintf( ' <span class="tag-link-count">(%d)</span>', $count )
+				: '';
+
+			return sprintf(
+				'<a href="%s" class="tag-cloud-link" style="font-size: %s%s" data-wp-tag-count="%d">%s%s</a>',
+				e( (string) $tag->permalink ),
+				e( $this->formatSize( $size, $unit ) ),
+				e( $unit ),
+				$count,
+				e( (string) $tag->name ),
+				$countMarkup
+			);
+		} )->implode( '' );
+
+		return sprintf(
+			'<p class="%s">%s</p>',
+			e( implode( ' ', $classes ) ),
+			$items
+		);
+	}
+
+	/**
+	 * Returns the tag records used by {@see render()}. Pulled out so
+	 * tests can override the data source without exercising the database.
+	 *
+	 * @param  array<string, mixed>  $attrs
+	 *
+	 * @return Collection<int, object>
+	 */
+	protected function fetchTags( array $attrs ): Collection
+	{
+		return PostTag::query()
+			->withCount( 'posts' )
+			->orderByDesc( 'posts_count' )
+			->orderBy( 'name' )
+			->limit( $attrs['numberOfTags'] )
+			->get()
+			->filter(
+				static fn ( object $tag ): bool => (int) ( $tag->posts_count ?? 0 ) > 0
+			)
+			->values();
+	}
+
+	/**
+	 * @param  array<string, mixed>  $attrs
+	 *
+	 * @return array{0: float, 1: float, 2: string}
+	 */
+	protected function parseFontSizes( array $attrs ): array
+	{
+		$smallest = $this->parseSize( $attrs['smallestFontSize'], 8.0, 'pt' );
+		$largest  = $this->parseSize( $attrs['largestFontSize'], 22.0, $smallest[1] );
+
+		// Lock both ends to the same unit so the linear scale is meaningful.
+		return [ $smallest[0], $largest[0], $smallest[1] ];
+	}
+
+	/**
+	 * @return array{0: float, 1: string}
+	 */
+	protected function parseSize( string $value, float $default, string $defaultUnit ): array
+	{
+		if ( preg_match( '/^\s*([0-9]+(?:\.[0-9]+)?)\s*([a-z%]+)?\s*$/i', $value, $matches ) === 1 ) {
+			return [ (float) $matches[1], $matches[2] ?? $defaultUnit ];
+		}
+
+		return [ $default, $defaultUnit ];
+	}
+
+	protected function scaleFontSize( int $count, int $min, int $max, float $smallest, float $largest ): float
+	{
+		if ( $max === $min ) {
+			return $smallest;
+		}
+
+		$ratio = ( $count - $min ) / ( $max - $min );
+
+		return $smallest + ( $ratio * ( $largest - $smallest ) );
+	}
+
+	protected function formatSize( float $size, string $unit ): string
+	{
+		// Pixel-based units want integer values; pt/em/rem/% keep one
+		// decimal so the linear scale doesn't collapse for small ranges.
+		if ( in_array( strtolower( $unit ), [ 'px' ], true ) ) {
+			return (string) (int) round( $size );
+		}
+
+		return rtrim( rtrim( number_format( $size, 1, '.', '' ), '0' ), '.' );
+	}
+
+	/**
+	 * @param  array<string, mixed>  $attrs
+	 *
+	 * @return array<int, string>
+	 */
+	protected function wrapperClasses( array $attrs ): array
+	{
+		$classes = [ 'wp-block-tag-cloud' ];
+
+		if ( '' !== $attrs['className'] ) {
+			$classes[] = $attrs['className'];
+		}
+
+		return $classes;
+	}
+}

--- a/src/VisualEditorServiceProvider.php
+++ b/src/VisualEditorServiceProvider.php
@@ -2,6 +2,10 @@
 
 namespace ArtisanPackUI\VisualEditor;
 
+use ArtisanPackUI\CMSFramework\Modules\Blog\Managers\BlogManager;
+use ArtisanPackUI\VisualEditor\Blocks\Core\ArchivesBlock;
+use ArtisanPackUI\VisualEditor\Blocks\Core\CategoriesBlock;
+use ArtisanPackUI\VisualEditor\Blocks\Core\TagCloudBlock;
 use ArtisanPackUI\VisualEditor\Console\Commands\SeedSampleContentCommand;
 use ArtisanPackUI\VisualEditor\MediaBridge\GutenbergAttachmentAdapter;
 use ArtisanPackUI\VisualEditor\Models\VisualEditorGlobalStyles;
@@ -165,6 +169,13 @@ class VisualEditorServiceProvider extends ServiceProvider
 		//    category end-to-end.
 		$this->registerReferenceBlocks();
 
+		// 4a. G4b — register the three taxonomy/feed core blocks against
+		//     cms-framework's term + post APIs. Gated on the package's
+		//     presence so visual-editor still boots when cms-framework is
+		//     absent; without it these blocks stay deferred and the
+		//     deny-list keeps them out of the inserter.
+		$this->registerTaxonomyAndArchiveBlocks();
+
 		// 5. Tag the config file for the scaffold command.
 		if ( $this->app->runningInConsole() ) {
 			$this->publishes( [
@@ -236,6 +247,25 @@ class VisualEditorServiceProvider extends ServiceProvider
 				$editor->registerBlock( $blockJsonPath );
 			}
 		}
+	}
+
+	/**
+	 * Registers the G4b dynamic blocks (`core/categories`, `core/tag-cloud`,
+	 * `core/archives`) against cms-framework's term + post APIs.
+	 *
+	 * @since 1.0.0
+	 */
+	protected function registerTaxonomyAndArchiveBlocks(): void
+	{
+		if ( ! class_exists( BlogManager::class ) ) {
+			return;
+		}
+
+		$editor = $this->app->make( VisualEditor::class );
+
+		$editor->registerDynamicBlock( CategoriesBlock::class );
+		$editor->registerDynamicBlock( TagCloudBlock::class );
+		$editor->registerDynamicBlock( ArchivesBlock::class );
 	}
 
 	/**

--- a/tests/Unit/VisualEditor/Blocks/Core/ArchivesBlockTest.php
+++ b/tests/Unit/VisualEditor/Blocks/Core/ArchivesBlockTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Blocks\Core\ArchivesBlock;
+use Illuminate\Support\Collection;
+
+beforeEach( function (): void {
+	test()->block = new class extends ArchivesBlock {
+		/** @var Collection<int, array{year: int, month: int|null, count: int}> */
+		public Collection $buckets;
+
+		protected function fetchBuckets( string $type ): Collection
+		{
+			if ( 'yearly' === $type ) {
+				return $this->buckets
+					->groupBy( 'year' )
+					->map( static fn ( Collection $rows ): array => [
+						'year'  => (int) $rows->first()['year'],
+						'month' => null,
+						'count' => $rows->sum( 'count' ),
+					] )
+					->sortByDesc( 'year' )
+					->values();
+			}
+
+			return $this->buckets;
+		}
+	};
+
+	test()->block->buckets = new Collection();
+} );
+
+it( 'renders a list of monthly archive links', function () {
+	test()->block->buckets = new Collection( [
+		[ 'year' => 2026, 'month' => 4, 'count' => 5 ],
+		[ 'year' => 2026, 'month' => 3, 'count' => 7 ],
+	] );
+
+	$html = test()->block->render( test()->block->validateAttrs( [] ) );
+
+	expect( $html )->toContain( '<ul class="wp-block-archives wp-block-archives-list">' )
+		->and( $html )->toContain( 'href="' )
+		->and( $html )->toContain( '/blog/2026/04' )
+		->and( $html )->toContain( '/blog/2026/03' )
+		->and( $html )->toContain( 'April 2026' )
+		->and( $html )->toContain( 'March 2026' );
+} );
+
+it( 'shows post counts when showPostCounts is set', function () {
+	test()->block->buckets = new Collection( [
+		[ 'year' => 2026, 'month' => 4, 'count' => 5 ],
+	] );
+
+	$html = test()->block->render( test()->block->validateAttrs( [ 'showPostCounts' => true ] ) );
+
+	expect( $html )->toContain( '&nbsp;(5)' );
+} );
+
+it( 'collapses months into years when type is yearly', function () {
+	test()->block->buckets = new Collection( [
+		[ 'year' => 2026, 'month' => 4, 'count' => 5 ],
+		[ 'year' => 2026, 'month' => 3, 'count' => 7 ],
+		[ 'year' => 2025, 'month' => 12, 'count' => 2 ],
+	] );
+
+	$html = test()->block->render( test()->block->validateAttrs( [
+		'type'           => 'yearly',
+		'showPostCounts' => true,
+	] ) );
+
+	expect( $html )->toContain( '/blog/2026' )
+		->and( $html )->not->toContain( '/blog/2026/' )
+		->and( $html )->toContain( '&nbsp;(12)' )
+		->and( $html )->toContain( '&nbsp;(2)' );
+} );
+
+it( 'renders a dropdown when displayAsDropdown is set', function () {
+	test()->block->buckets = new Collection( [
+		[ 'year' => 2026, 'month' => 4, 'count' => 5 ],
+	] );
+
+	$html = test()->block->render( test()->block->validateAttrs( [ 'displayAsDropdown' => true ] ) );
+
+	expect( $html )->toMatch( '/<select id="wp-block-archives-dropdown-[a-f0-9.]+">/' )
+		->and( $html )->toContain( '<option value="' )
+		->and( $html )->toContain( '/blog/2026/04' )
+		->and( $html )->toContain( 'April 2026' );
+} );
+
+it( 'gives multiple dropdowns unique ids on the same render pass', function () {
+	test()->block->buckets = new Collection( [
+		[ 'year' => 2026, 'month' => 4, 'count' => 5 ],
+	] );
+
+	$first = test()->block->render( test()->block->validateAttrs( [ 'displayAsDropdown' => true ] ) );
+	$second = test()->block->render( test()->block->validateAttrs( [ 'displayAsDropdown' => true ] ) );
+
+	preg_match( '/id="(wp-block-archives-dropdown-[a-f0-9.]+)"/', $first, $firstMatch );
+	preg_match( '/id="(wp-block-archives-dropdown-[a-f0-9.]+)"/', $second, $secondMatch );
+
+	expect( $firstMatch[1] ?? null )->not->toBeNull()
+		->and( $secondMatch[1] ?? null )->not->toBeNull()
+		->and( $firstMatch[1] )->not->toBe( $secondMatch[1] );
+} );
+
+it( 'renders an empty-state notice when no buckets exist', function () {
+	$html = test()->block->render( test()->block->validateAttrs( [] ) );
+
+	expect( $html )->toContain( '<div class="wp-block-archives">' )
+		->and( $html )->toContain( 'No archives' );
+} );

--- a/tests/Unit/VisualEditor/Blocks/Core/ArchivesBlockTest.php
+++ b/tests/Unit/VisualEditor/Blocks/Core/ArchivesBlockTest.php
@@ -82,10 +82,20 @@ it( 'renders a dropdown when displayAsDropdown is set', function () {
 
 	$html = test()->block->render( test()->block->validateAttrs( [ 'displayAsDropdown' => true ] ) );
 
-	expect( $html )->toMatch( '/<select id="wp-block-archives-dropdown-[a-f0-9.]+">/' )
+	expect( $html )->toMatch( '/<select id="wp-block-archives-dropdown-[a-f0-9.]+" onchange="[^"]+">/' )
 		->and( $html )->toContain( '<option value="' )
 		->and( $html )->toContain( '/blog/2026/04' )
 		->and( $html )->toContain( 'April 2026' );
+} );
+
+it( 'attaches an inline onchange handler so the dropdown navigates on select', function () {
+	test()->block->buckets = new Collection( [
+		[ 'year' => 2026, 'month' => 4, 'count' => 5 ],
+	] );
+
+	$html = test()->block->render( test()->block->validateAttrs( [ 'displayAsDropdown' => true ] ) );
+
+	expect( $html )->toContain( 'onchange="if(this.value)document.location.href=this.value"' );
 } );
 
 it( 'gives multiple dropdowns unique ids on the same render pass', function () {

--- a/tests/Unit/VisualEditor/Blocks/Core/CategoriesBlockTest.php
+++ b/tests/Unit/VisualEditor/Blocks/Core/CategoriesBlockTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Blocks\Core\CategoriesBlock;
+use Illuminate\Database\Eloquent\Collection;
+
+function fakeCategory( int $id, string $name, string $slug, int $count, ?int $parent = null ): object
+{
+	$category               = new stdClass();
+	$category->id           = $id;
+	$category->name         = $name;
+	$category->slug         = $slug;
+	$category->parent_id    = $parent;
+	$category->posts_count  = $count;
+	$category->permalink    = '/blog/category/' . $slug;
+
+	return $category;
+}
+
+beforeEach( function (): void {
+	test()->block = new class extends CategoriesBlock {
+		/** @var Collection<int, object> */
+		public Collection $categories;
+
+		protected function fetchCategories( array $attrs ): Collection
+		{
+			$collection = $this->categories;
+
+			if ( $attrs['showOnlyTopLevel'] ) {
+				$collection = $collection->filter( static fn ( object $c ): bool => null === $c->parent_id )->values();
+			}
+
+			if ( ! $attrs['showEmpty'] ) {
+				$collection = $collection->filter( static fn ( object $c ): bool => (int) $c->posts_count > 0 )->values();
+			}
+
+			return $collection;
+		}
+	};
+
+	test()->block->categories = new Collection();
+} );
+
+it( 'renders a flat list with post counts', function () {
+	test()->block->categories = new Collection( [
+		fakeCategory( 1, 'Laravel', 'laravel', 7 ),
+		fakeCategory( 2, 'PHP', 'php', 3 ),
+	] );
+
+	$html = test()->block->render( test()->block->validateAttrs( [
+		'showPostCounts' => true,
+		'showEmpty'      => true,
+	] ) );
+
+	expect( $html )->toContain( '<ul class="wp-block-categories wp-block-categories-list">' )
+		->and( $html )->toContain( '<li class="cat-item cat-item-1"><a href="/blog/category/laravel">Laravel</a> (7)</li>' )
+		->and( $html )->toContain( '<li class="cat-item cat-item-2"><a href="/blog/category/php">PHP</a> (3)</li>' );
+} );
+
+it( 'omits post counts by default', function () {
+	test()->block->categories = new Collection( [
+		fakeCategory( 1, 'Laravel', 'laravel', 7 ),
+	] );
+
+	$html = test()->block->render( test()->block->validateAttrs( [] ) );
+
+	expect( $html )->toContain( '<a href="/blog/category/laravel">Laravel</a></li>' )
+		->and( $html )->not->toContain( '(7)' );
+} );
+
+it( 'filters empty categories unless showEmpty is true', function () {
+	test()->block->categories = new Collection( [
+		fakeCategory( 1, 'Laravel', 'laravel', 7 ),
+		fakeCategory( 2, 'Empty', 'empty', 0 ),
+	] );
+
+	$default = test()->block->render( test()->block->validateAttrs( [] ) );
+
+	expect( $default )->toContain( 'cat-item-1' )
+		->and( $default )->not->toContain( 'cat-item-2' );
+
+	$withEmpty = test()->block->render( test()->block->validateAttrs( [ 'showEmpty' => true ] ) );
+
+	expect( $withEmpty )->toContain( 'cat-item-1' )
+		->and( $withEmpty )->toContain( 'cat-item-2' );
+} );
+
+it( 'restricts to top-level categories when showOnlyTopLevel is set', function () {
+	test()->block->categories = new Collection( [
+		fakeCategory( 1, 'Frameworks', 'frameworks', 5 ),
+		fakeCategory( 2, 'Laravel', 'laravel', 3, 1 ),
+	] );
+
+	$html = test()->block->render( test()->block->validateAttrs( [ 'showOnlyTopLevel' => true ] ) );
+
+	expect( $html )->toContain( 'cat-item-1' )
+		->and( $html )->not->toContain( 'cat-item-2' );
+} );
+
+it( 'nests children when showHierarchy is set', function () {
+	test()->block->categories = new Collection( [
+		fakeCategory( 1, 'Frameworks', 'frameworks', 5 ),
+		fakeCategory( 2, 'Laravel', 'laravel', 3, 1 ),
+	] );
+
+	$html = test()->block->render( test()->block->validateAttrs( [ 'showHierarchy' => true ] ) );
+
+	expect( $html )->toContain( 'cat-item-1' )
+		->and( $html )->toContain( 'cat-item-2' )
+		->and( $html )->toContain( '<ul class="children">' );
+} );
+
+it( 'renders an empty shell when no categories survive filters', function () {
+	test()->block->categories = new Collection( [
+		fakeCategory( 2, 'Empty', 'empty', 0 ),
+	] );
+
+	$html = test()->block->render( test()->block->validateAttrs( [] ) );
+
+	expect( $html )->toContain( 'cat-item-empty' );
+} );
+
+it( 'escapes attacker-controlled name and permalink', function () {
+	test()->block->categories = new Collection( [
+		fakeCategory( 9, '<img src=x onerror=alert(1)>', 'evil', 1 ),
+	] );
+
+	$html = test()->block->render( test()->block->validateAttrs( [] ) );
+
+	expect( $html )->not->toContain( '<img src=x' )
+		->and( $html )->toContain( '&lt;img' );
+} );

--- a/tests/Unit/VisualEditor/Blocks/Core/TagCloudBlockTest.php
+++ b/tests/Unit/VisualEditor/Blocks/Core/TagCloudBlockTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Blocks\Core\TagCloudBlock;
+use Illuminate\Support\Collection;
+
+function fakeTag( int $id, string $name, string $slug, int $count ): object
+{
+	$tag              = new stdClass();
+	$tag->id          = $id;
+	$tag->name        = $name;
+	$tag->slug        = $slug;
+	$tag->posts_count = $count;
+	$tag->permalink   = '/blog/tag/' . $slug;
+
+	return $tag;
+}
+
+beforeEach( function (): void {
+	test()->block = new class extends TagCloudBlock {
+		/** @var Collection<int, object> */
+		public Collection $tags;
+
+		protected function fetchTags( array $attrs ): Collection
+		{
+			return $this->tags
+				->take( $attrs['numberOfTags'] )
+				->filter( static fn ( object $tag ): bool => (int) $tag->posts_count > 0 )
+				->values();
+		}
+	};
+
+	test()->block->tags = new Collection();
+} );
+
+it( 'renders a paragraph with tag links', function () {
+	test()->block->tags = new Collection( [
+		fakeTag( 1, 'Laravel', 'laravel', 10 ),
+		fakeTag( 2, 'PHP', 'php', 5 ),
+	] );
+
+	$html = test()->block->render( test()->block->validateAttrs( [] ) );
+
+	expect( $html )->toStartWith( '<p class="wp-block-tag-cloud">' )
+		->and( $html )->toContain( 'href="/blog/tag/laravel"' )
+		->and( $html )->toContain( '>Laravel</a>' )
+		->and( $html )->toContain( 'data-wp-tag-count="10"' );
+} );
+
+it( 'scales font sizes between smallest and largest', function () {
+	test()->block->tags = new Collection( [
+		fakeTag( 1, 'Big', 'big', 100 ),
+		fakeTag( 2, 'Small', 'small', 1 ),
+	] );
+
+	$html = test()->block->render( test()->block->validateAttrs( [
+		'smallestFontSize' => '10pt',
+		'largestFontSize'  => '20pt',
+	] ) );
+
+	// Tag with the highest count gets the largest size; lowest gets smallest.
+	expect( $html )->toContain( 'style="font-size: 20pt"' )
+		->and( $html )->toContain( 'style="font-size: 10pt"' );
+} );
+
+it( 'collapses to smallest size when all tags have the same count', function () {
+	test()->block->tags = new Collection( [
+		fakeTag( 1, 'A', 'a', 5 ),
+		fakeTag( 2, 'B', 'b', 5 ),
+	] );
+
+	$html = test()->block->render( test()->block->validateAttrs( [
+		'smallestFontSize' => '8pt',
+		'largestFontSize'  => '22pt',
+	] ) );
+
+	// Both tags should hit the smallest size; the largest size should not appear.
+	expect( $html )->toContain( 'font-size: 8pt' )
+		->and( $html )->not->toContain( 'font-size: 22pt' );
+} );
+
+it( 'omits empty tags', function () {
+	test()->block->tags = new Collection( [
+		fakeTag( 1, 'A', 'a', 5 ),
+		fakeTag( 2, 'Empty', 'empty', 0 ),
+	] );
+
+	$html = test()->block->render( test()->block->validateAttrs( [] ) );
+
+	expect( $html )->toContain( '>A</a>' )
+		->and( $html )->not->toContain( '>Empty</a>' );
+} );
+
+it( 'shows tag counts when showTagCounts is set', function () {
+	test()->block->tags = new Collection( [
+		fakeTag( 1, 'Laravel', 'laravel', 7 ),
+	] );
+
+	$html = test()->block->render( test()->block->validateAttrs( [ 'showTagCounts' => true ] ) );
+
+	expect( $html )->toContain( '<span class="tag-link-count">(7)</span>' );
+} );
+
+it( 'caps numberOfTags between 1 and 100', function () {
+	$normalised = test()->block->validateAttrs( [ 'numberOfTags' => 1000 ] );
+	expect( $normalised['numberOfTags'] )->toBe( 100 );
+
+	$normalised = test()->block->validateAttrs( [ 'numberOfTags' => -5 ] );
+	expect( $normalised['numberOfTags'] )->toBe( 1 );
+} );
+
+it( 'renders an empty paragraph when no tags exist', function () {
+	$html = test()->block->render( test()->block->validateAttrs( [] ) );
+
+	expect( $html )->toBe( '<p class="wp-block-tag-cloud"></p>' );
+} );
+
+it( 'escapes attacker-controlled tag names', function () {
+	test()->block->tags = new Collection( [
+		fakeTag( 1, '<script>alert(1)</script>', 'evil', 3 ),
+	] );
+
+	$html = test()->block->render( test()->block->validateAttrs( [] ) );
+
+	expect( $html )->not->toContain( '<script>alert(1)</script>' )
+		->and( $html )->toContain( '&lt;script&gt;' );
+} );

--- a/tests/Unit/VisualEditor/EnabledBlockNamesTest.php
+++ b/tests/Unit/VisualEditor/EnabledBlockNamesTest.php
@@ -14,7 +14,9 @@ it( 'returns the frozen V1 block allow-list under the default config', function 
 	// real loop runtime or term/comment endpoints, so the output should
 	// be the allow-list verbatim, in config order. E4 (#381) added the
 	// post-, site-, navigation, and template-part blocks on the back of
-	// B1's expanded core-data shim and the C-series REST surface.
+	// B1's expanded core-data shim and the C-series REST surface. G4b
+	// (#401) added the taxonomy/feed widgets that the cms-framework
+	// term + post APIs back through the dynamic-block registry.
 	expect( $editor->getEnabledBlockNames() )->toBe( [
 		'core/paragraph',
 		'core/heading',
@@ -54,6 +56,9 @@ it( 'returns the frozen V1 block allow-list under the default config', function 
 		'core/site-tagline',
 		'core/site-logo',
 		'core/navigation',
+		'core/categories',
+		'core/tag-cloud',
+		'core/archives',
 		'artisanpack/callout',
 	] );
 } );


### PR DESCRIPTION
## Description

Re-enable the three taxonomy/feed widgets the M5 audit deferred to "empty-state — disabled by default" until cms-framework landed. Each block ships as a `DynamicBlock` subclass under `src/Blocks/Core/` that reads from cms-framework's `PostCategory`, `PostTag`, and `Post` models respectively. Registration is gated on `class_exists(BlogManager::class)` so the package still boots standalone — without cms-framework the blocks stay deferred and the deny-list keeps them out of the inserter.

**Closes:** #401

## Type of Change

- [x] Enhancement (improves existing functionality)

## Related Issue

**Issue:** #401

## Motivation and Context

#401 is Wave 4 of the V1 ship plan (plan 12 §2.5). G4a verified `core/post-*` against G3 entities; this is the matching wire-up for the three taxonomy/feed widgets the audit had been holding in the deny-list.

## Changes Made

- Three `DynamicBlock` subclasses (`src/Blocks/Core/{Categories,TagCloud,Archives}Block.php`). Each isolates the data fetch in a `protected function fetch*()` method so tests can override the data source without exercising the database.
- Service provider registers them under `class_exists(BlogManager::class)` in a new `registerTaxonomyAndArchiveBlocks()` boot step.
- `config/visual-editor.php`: moved the three blocks from `disabled_blocks` to `enabled_blocks`; updated the explanatory comment.
- `D2_DISABLED_BLOCKS` in `site-editor-app.tsx` mirrors the PHP change.
- `EnabledBlockNamesTest` snapshot updated.

### Editor surface

The upstream `core/categories`, `core/tag-cloud`, and `core/archives` Edit components depend on shim surface that does not exist in V1 (`getTaxonomies`, `getTaxonomy('category').labels`, and the `wp/v2/block-renderer/{name}` route). A new `taxonomy-archive-block-overrides.tsx` module registers a `blocks.registerBlockType` filter (BEFORE `registerCoreBlocks()`) that swaps each block's `edit` with a thin wrapper using the existing `ServerSideRender` shim, plus a minimal `InspectorControls` panel for the toggles each block actually persists. Block save() shape stays untouched so attribute round-trip is unaffected.

Wired into both `editor-app.tsx` (post editor) and `site-editor-app.tsx` (site editor); idempotent across HMR via a global Symbol guard.

### Renderer integration

Editor preview, Blade renderer, React renderer, and Vue renderer all resolve through the same `DynamicBlock::render()` path. Renderers post to `/visual-editor/api/blocks/preview`, the controller routes through the dynamic-block registry, and the registered block emits HTML. One implementation, all four surfaces.

### Documented deviation

The taxonomy entity registration called for in #401's implementation notes (`{kind: 'taxonomy', name: 'category', baseURL: '/post-categories', …}`) is intentionally **not** added in V1. The upstream Edit components all render through `ServerSideRender` (and our overrides do the same), so they never query `useEntityRecords('taxonomy', 'category')`. Adding entities pointing at non-existent endpoints would be dead code in V1; `PostCategory`/`PostTag` are not `HasBlockContent` models so they do not fit `WpEntityController` either. The audit doc captures this — entities can be layered in cheaply later if a future block needs them.

## How Has This Been Tested?

**Testing Environment:**
- macOS 25.4.0
- Safari (dev app via Laravel Herd)
- PHP 8.4.3
- Branch: `release/1.0`

**Tests Performed:**
1. Full PHP suite (`./vendor/bin/pest`): 484 passed (1 pre-existing skip), 1519 assertions.
2. Full JS suite (`npm test`): 970 passed (1 pre-existing skip).
3. Manual smoke flow in dev app:
   - Insert each of the three blocks in the post editor.
   - Flip the InspectorControls toggles (post counts, hierarchy, dropdown, etc.) and verify the preview re-renders.
   - Save the post and view the rendered output via the front-end Blade renderer — same HTML as the editor preview.

**CodeRabbit:** two-pass local review (`cr review --base release/1.0 --prompt-only`) — flagged a hardcoded `id="wp-block-archives-dropdown"` collision risk, fixed in `ArchivesBlock::renderDropdown()` with a `uniqid()` suffix shared between the `<select>` and the label's `for=`. Second pass: no findings.

## Accessibility Tests Run

- [x] ARIA labels checked
- [x] Keyboard navigation tested (manual smoke in Safari)
- [ ] Screen reader tested
- [ ] Color contrast verified

**Details:**
- The dropdown variant of `core/archives` uses `<label class="screen-reader-text" for="wp-block-archives-dropdown-{uniqid}">` paired to a matching `<select id=...>`. The CodeRabbit-flagged hardcoded id was replaced so multiple `core/archives` blocks on a page do not collide on the same `for`/`id` pair.
- All emitted HTML escapes user-controlled term names, slugs, and labels via `e()` (Laravel's `htmlspecialchars` wrapper). XSS escape is asserted in CategoriesBlockTest + TagCloudBlockTest.

## Tests Added

- [x] Unit tests added/updated
- [x] All tests passing

**Test details:**

- `CategoriesBlockTest` (7 cases): flat list, hierarchy, post counts, empty-term filter, top-level filter, empty shell, XSS escape.
- `TagCloudBlockTest` (8 cases): link rendering, font scaling, equal-count collapse, empty-tag filter, count display, `numberOfTags` clamp, empty paragraph, XSS escape.
- `ArchivesBlockTest` (6 cases): monthly list, post counts, yearly grouping, dropdown markup, unique dropdown ids per render, empty-state notice.
- `EnabledBlockNamesTest`: snapshot updated for the three new entries; comment notes G4b promotion.

Tests use anonymous-class subclasses that override the fetch methods to inject synthetic data, so the suite proves the rendering pipeline without coupling to cms-framework's models or pulling cms-framework into the dev deps.

## Documentation

- [x] Inline code documentation added
- [x] Audit doc updated

**Documentation details:**

- `docs/block-library-audit.md` removes the three blocks from the empty-state-deferred table and adds a new "G4b — re-enabled" subsection covering the architecture (DynamicBlock pathway, four-surface render, archive URL pattern, host-override path, deferred-entities deviation).
- Inline PHPDoc + comments on each new block class explaining the supported attributes and the divergence from upstream behavior.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Code passes all tests
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Re-enabled Categories, Tag Cloud, and Archives blocks with server-rendered previews and editor controls.
  * Added editor controls for Archives (list/dropdown, post counts, labels), Categories (hierarchy, post counts, top-level filtering), and Tag Cloud (font sizing, tag limits, post counts).

* **Documentation**
  * Updated block-library docs to reflect taxonomy/feed widget availability and behavior.

* **Tests**
  * Added unit tests for Archives, Categories, and Tag Cloud; updated enabled-blocks snapshot.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->