### PR TITLE
feat: G4c-2 — query/resolve endpoint + core/query renderer wiring

### DIFF
--- a/config/visual-editor.php
+++ b/config/visual-editor.php
@@ -141,6 +141,15 @@ return [
 		'core/categories',
 		'core/tag-cloud',
 		'core/archives',
+		// G4c-2 (#402) — `core/query` + its inner `core/post-template`
+		// are pre-resolved server-side by `QueryInliner` against
+		// cms-framework's `QueryRuntime`. The editor preview hits the
+		// `/visual-editor/api/query/resolve` endpoint via a custom
+		// `useQueryPreview` hook. Each renderer package (Blade, React,
+		// Vue) ships its own thin `core/query` renderer that walks the
+		// pre-expanded inner blocks.
+		'core/query',
+		'core/post-template',
 		'artisanpack/callout',
 	],
 
@@ -149,17 +158,18 @@ return [
 		// `core/template-part`, `core/post-*`, and `core/site-*` are
 		// promoted to the allow-list above by E4 (#381). G4b (#401)
 		// promotes `core/categories`, `core/tag-cloud`, and
-		// `core/archives`. The blocks listed here remain deliberately
-		// deferred:
+		// `core/archives`. G4c-2 (#402) promotes `core/query` and
+		// `core/post-template`. The blocks listed here remain
+		// deliberately deferred:
 		//
-		//  - core/query / core/query-loop need a real loop runtime
-		//    (V1 G4c — `cms-framework` `QueryRuntime` service).
+		//  - core/query-loop is the deprecated alias for `core/query`;
+		//    upstream registers it but no `Edit` ships any longer, so
+		//    it stays in the deny-list to keep it out of the inserter.
 		//  - core/latest-comments needs a Comments module in
 		//    cms-framework that does not exist yet (V1.1+).
 		//
 		// The JS-side mirror in site-editor-app.tsx is updated
 		// alongside this entry.
-		'core/query',
 		'core/query-loop',
 		'core/latest-comments',
 	],

--- a/docs/block-library-audit.md
+++ b/docs/block-library-audit.md
@@ -155,6 +155,58 @@ all render through `ServerSideRender`, so they never query
 `useEntityRecords('taxonomy', 'category')`. The shim entities can be
 layered in cheaply later if a future block needs them.
 
+### Query loop — re-enabled against cms-framework's QueryRuntime (G4c-2)
+
+`core/query` and `core/post-template` were promoted out of the deny-list in
+G4c-2 (#402). The architecture differs from G4b — `core/query` has inner
+blocks that need to render once per result with the per-iteration post id
+threaded through to inner `core/post-*` blocks, so a single
+`DynamicBlock::render()` does not fit. Instead the package ships:
+
+- **`QueryInliner`** (`src/Resources/QueryInliner.php`) — sibling to the
+  existing `TemplatePartInliner` and `PatternInliner`. Walks the saved
+  tree, replaces every `core/query` block with one stamped copy of its
+  inner blocks per result. Stamping is delegated to `PostResolver`,
+  which sets the `_resolved*` keys the existing `core/post-*` partials
+  already read.
+- **`PostResolver`** (`src/Resources/PostResolver.php`) — pure-data
+  service that maps a single post object to the `_resolved*` keys for
+  every supported `core/post-*` block. Uses the post's `permalink`
+  accessor / Carbon date casts / loaded `author` relation. Optional
+  helpers (`apGetMediaUrl`, `apGetMedia`) gate gracefully when
+  media-library is absent.
+- **`QueryResolverContract`** (`src/Services/QueryResolverContract.php`)
+  — interface the inliner + the new `POST
+  /visual-editor/api/query/resolve` controller depend on. Bound by
+  `VisualEditorServiceProvider::register()` to a thin
+  `CmsFrameworkQueryResolver` adapter when cms-framework is on the
+  autoloader; hosts can override it with any other implementation.
+
+All four rendering surfaces (editor canvas + Blade + React + Vue
+renderers) resolve through the same pipe:
+
+- **Editor canvas:** the `core/query` Edit is overridden with a wrapper
+  that calls `useQueryPreview` (a custom hook that POSTs to
+  `/query/resolve`). The first matching post id is pushed into block
+  context via `BlockContextProvider` so the editable inner template
+  renders with real data — every inner `core/post-*` block resolves
+  through G3's entity adapter.
+- **Blade renderer:** `BlocksComponent` invokes `QueryInliner` alongside
+  the template-part / pattern inliners. Result is the saved tree with
+  every `core/query` pre-expanded into per-result instances; the
+  existing `core/post-*` partials handle stamped attributes unchanged.
+- **React + Vue renderers:** ship a parallel TS implementation of
+  `inlineQueries` keyed by `queryId`. Hosts that pre-fetch results
+  server-side pass them via the new `queryResults` prop on `<BlockTree>`
+  / its Vue analog; on-the-fly client fetching uses the same
+  `useQueryPreview` hook (re-exportable for host code).
+
+The `taxQuery` operator surface is bounded to `IN` for V1 — matches the
+cms-framework `QueryRuntime` contract from G4c-1. `core/query-loop`
+(deprecated upstream alias for `core/query`) plus the pagination /
+no-results / read-more wrappers stay in the deny-list; they need
+follow-up renderer wiring that's out of scope for #402.
+
 ## Crash or backend-required — disabled by default
 
 These blocks call selectors the shim returns `null` for but which the block's
@@ -179,9 +231,13 @@ does not implement. They are permanently in the deny-list until a real
 
 ### Query loop
 
-- `core/query`
-- `core/query-loop` (listed per spec; no separate upstream block — the block
-  name is `core/query` and the loop is driven by `core/post-template`).
+`core/query` and `core/post-template` were promoted out of this section
+in G4c-2 (#402); see [Query loop — G4c-2](#query-loop--re-enabled-against-cms-frameworks-queryruntime-g4c-2) below for the
+architecture. The remaining query-loop blocks stay deferred — they wrap
+pagination, "no results", and read-more affordances that have not yet
+been wired into the renderer pipeline.
+
+- `core/query-loop` (deprecated upstream alias — `core/query` is the live name)
 - `core/query-pagination`
 - `core/query-pagination-next`
 - `core/query-pagination-numbers`
@@ -189,7 +245,6 @@ does not implement. They are permanently in the deny-list until a real
 - `core/query-no-results`
 - `core/query-title`
 - `core/query-total`
-- `core/post-template`
 - `core/read-more`
 
 ### Post context

--- a/docs/block-library-audit.md
+++ b/docs/block-library-audit.md
@@ -207,6 +207,19 @@ cms-framework `QueryRuntime` contract from G4c-1. `core/query-loop`
 no-results / read-more wrappers stay in the deny-list; they need
 follow-up renderer wiring that's out of scope for #402.
 
+#### Known V1 limitation: per-iteration list-item wrapping
+
+The current expansion produces one `core/post-template` clone per result
+(each rendering as `<ul class="wp-block-post-template">`). Browsers
+render this as N single-item lists rather than one N-item list — the
+visual output is correct, but the markup is semantically a list of
+single-item lists rather than upstream's `<ul><li>...</li></ul>` shape.
+A follow-up issue should refactor the inliner to emit a single
+post-template wrapping N synthetic `core/post-template-item` blocks
+(each rendering as `<li>`); deferring to a follow-up keeps #402
+scope-bounded since the architectural change touches every renderer
+plus a new block-type registration.
+
 ## Crash or backend-required — disabled by default
 
 These blocks call selectors the shim returns `null` for but which the block's

--- a/packages/visual-editor-renderer-blade/src/View/Components/BlocksComponent.php
+++ b/packages/visual-editor-renderer-blade/src/View/Components/BlocksComponent.php
@@ -25,6 +25,7 @@ declare( strict_types=1 );
 namespace ArtisanPackUI\VisualEditorRendererBlade\View\Components;
 
 use ArtisanPackUI\VisualEditor\Resources\PatternInliner;
+use ArtisanPackUI\VisualEditor\Resources\QueryInliner;
 use ArtisanPackUI\VisualEditor\Resources\TemplatePartInliner;
 use ArtisanPackUI\VisualEditor\Services\GlobalStylesCssProvider;
 use ArtisanPackUI\VisualEditor\Services\GlobalStylesEmissionTracker;
@@ -51,12 +52,14 @@ class BlocksComponent extends Component
 		protected BlockRenderer $renderer,
 		protected TemplatePartInliner $inliner,
 		protected PatternInliner $patternInliner,
+		protected QueryInliner $queryInliner,
 		protected GlobalStylesCssProvider $globalStyles,
 		protected GlobalStylesEmissionTracker $emissionTracker,
 		mixed $tree = null,
 		?string $defaultTheme = null,
 		bool $resolveParts = true,
 		bool $resolvePatterns = true,
+		bool $resolveQueries = true,
 	) {
 		$this->defaultTheme = $defaultTheme;
 
@@ -69,8 +72,14 @@ class BlocksComponent extends Component
 		// Pattern inlining runs after template-part inlining so a part
 		// that itself contains a synced-pattern reference resolves in the
 		// same pass.
-		$this->tree = $resolvePatterns
+		$resolved = $resolvePatterns
 			? $this->patternInliner->inline( $resolved )
+			: $resolved;
+
+		// Query inlining runs last so a `core/query` block inside a
+		// resolved template part / pattern still gets its loop expanded.
+		$this->tree = $resolveQueries
+			? $this->queryInliner->inline( $resolved )
 			: $resolved;
 	}
 

--- a/packages/visual-editor-renderer-blade/tests/Feature/CoreQueryRenderingTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Feature/CoreQueryRenderingTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Services\QueryResolverContract;
+use ArtisanPackUI\VisualEditorRendererBlade\View\Components\BlocksComponent;
+use Tests\Fixtures\FakeQueryResolver;
+
+beforeEach( function (): void {
+	$this->fake = new FakeQueryResolver();
+	$this->app->instance( QueryResolverContract::class, $this->fake );
+} );
+
+function blockTreeWithQuery( array $template ): array
+{
+	return [
+		[
+			'name'        => 'core/query',
+			'attributes'  => [ 'query' => [ 'postType' => 'post', 'perPage' => 2 ] ],
+			'innerBlocks' => [
+				[
+					'name'        => 'core/post-template',
+					'attributes'  => [],
+					'innerBlocks' => $template,
+				],
+			],
+		],
+	];
+}
+
+function fakeRenderablePost( int $id, string $title, string $excerpt = '' ): object
+{
+	$post                    = new stdClass();
+	$post->id                = $id;
+	$post->title             = $title;
+	$post->excerpt           = $excerpt;
+	$post->content           = '';
+	$post->permalink         = "/posts/{$id}";
+	$post->author            = null;
+	$post->published_at      = null;
+	$post->updated_at        = null;
+	$post->featured_image_id = null;
+
+	return $post;
+}
+
+it( 'renders core/query results through the full Blade pipeline', function () {
+	$this->fake->setItems( [
+		fakeRenderablePost( 1, 'First post' ),
+		fakeRenderablePost( 2, 'Second post' ),
+	] );
+
+	$tree = blockTreeWithQuery( [
+		[
+			'name'        => 'core/post-title',
+			'attributes'  => [ 'isLink' => true ],
+			'innerBlocks' => [],
+		],
+	] );
+
+	$component = $this->app->make( BlocksComponent::class, [ 'tree' => $tree ] );
+
+	$html = $component->render()->with( $component->data() )->render();
+
+	expect( $html )->toContain( 'First post' )
+		->and( $html )->toContain( 'Second post' )
+		->and( $html )->toContain( '/posts/1' )
+		->and( $html )->toContain( '/posts/2' )
+		// Each result should be wrapped in its own post-template
+		// instance — the rendered HTML contains two anchors.
+		->and( substr_count( $html, 'href="/posts/' ) )->toBe( 2 );
+} );
+
+it( 'preserves the surrounding tree when the resolver fails', function () {
+	$this->app->forgetInstance( QueryResolverContract::class );
+	$this->app->offsetUnset( QueryResolverContract::class );
+
+	$tree = [
+		[
+			'name'        => 'core/paragraph',
+			'attributes'  => [ 'content' => 'Before query' ],
+			'innerBlocks' => [],
+		],
+		...blockTreeWithQuery( [
+			[ 'name' => 'core/post-title', 'attributes' => [], 'innerBlocks' => [] ],
+		] ),
+		[
+			'name'        => 'core/paragraph',
+			'attributes'  => [ 'content' => 'After query' ],
+			'innerBlocks' => [],
+		],
+	];
+
+	$component = $this->app->make( BlocksComponent::class, [ 'tree' => $tree ] );
+	$html      = $component->render()->with( $component->data() )->render();
+
+	expect( $html )->toContain( 'Before query' )
+		->and( $html )->toContain( 'After query' );
+} );

--- a/packages/visual-editor-renderer-react/src/BlockTree.tsx
+++ b/packages/visual-editor-renderer-react/src/BlockTree.tsx
@@ -28,6 +28,8 @@ import {
     inlinePatterns,
 } from './patterns';
 import type { PatternRecord } from './patterns';
+import { inlineQueries } from './queries';
+import type { ResolvedQuery } from './queries';
 import { getBlockRenderer } from './registry';
 import { inlineSiteMeta } from './siteMeta';
 import type { SiteMeta } from './siteMeta';
@@ -72,6 +74,15 @@ export interface BlockTreeProps {
      * block when needed.
      */
     siteMeta?: SiteMeta | null;
+    /**
+     * Pre-resolved `core/query` results keyed by `queryId`. When
+     * supplied, every `core/query` block in the tree is replaced with
+     * one stamped copy of its inner blocks per result via
+     * {@link inlineQueries}. Hosts that pre-fetch results server-side
+     * (Inertia + React) pass them here; for canvas / on-the-fly
+     * fetching see `useQueryPreview`.
+     */
+    queryResults?: ResolvedQuery[];
 }
 
 export function BlockTree({
@@ -85,6 +96,7 @@ export function BlockTree({
     maxPatternDepth = DEFAULT_MAX_PATTERN_DEPTH,
     globalStylesCss,
     siteMeta,
+    queryResults,
 }: BlockTreeProps): ReactElement {
     const blocks = useMemo(() => {
         const normalized = normalizeTree(tree);
@@ -117,11 +129,24 @@ export function BlockTree({
                       maxDepth: maxPatternDepth,
                   });
 
-        // Site-meta inlining runs last so values stamped here are visible
-        // on blocks that template-part / pattern inlining brought into
-        // the tree from elsewhere.
-        return inlineSiteMeta(withPatterns, siteMeta);
-    }, [tree, templateParts, patterns, defaultTheme, maxTemplatePartDepth, maxPatternDepth, siteMeta]);
+        const withSiteMeta = inlineSiteMeta(withPatterns, siteMeta);
+
+        // Query inlining runs last so a `core/query` block reachable only
+        // through a resolved template part / pattern still gets its loop
+        // expanded.
+        return queryResults === undefined
+            ? withSiteMeta
+            : inlineQueries(withSiteMeta, { queries: queryResults });
+    }, [
+        tree,
+        templateParts,
+        patterns,
+        defaultTheme,
+        maxTemplatePartDepth,
+        maxPatternDepth,
+        siteMeta,
+        queryResults,
+    ]);
 
     return (
         <>

--- a/packages/visual-editor-renderer-react/src/blocks/core/query.tsx
+++ b/packages/visual-editor-renderer-react/src/blocks/core/query.tsx
@@ -1,0 +1,71 @@
+/**
+ * `core/query` and `core/post-template` renderers.
+ *
+ * Both blocks operate on an already-expanded inner-block tree — see
+ * {@link inlineQueries} for the pre-walk that replaces every
+ * `core/query` block with one stamped copy of its template per result.
+ * The renderers themselves just emit the wrapping markup and pass
+ * children through.
+ *
+ * If the inliner could not resolve the query (no resolved set passed
+ * for the matching `queryId`), it stamps `_resolutionError` and the
+ * wrapper renders empty in production so the surrounding layout stays
+ * intact.
+ */
+
+import type { JSX, ReactNode } from 'react';
+import { attrString, classList } from '../../support/attributes';
+import type { BlockRendererProps } from '../../types';
+
+interface WrapperProps {
+    children: ReactNode;
+    className: string;
+    'data-ve-resolution-error'?: string;
+}
+
+function isDevelopment(): boolean {
+    if (typeof process === 'undefined') {
+        return false;
+    }
+
+    const env = process.env;
+
+    if (env === undefined || env === null) {
+        return false;
+    }
+
+    return env.NODE_ENV !== 'production';
+}
+
+export function QueryBlock({ attributes, children }: BlockRendererProps): JSX.Element {
+    const className = attrString(attributes.className);
+    const resolutionError = attrString(attributes._resolutionError);
+    const hasError = resolutionError !== '';
+    const baseClasses = classList(['wp-block-query', className]);
+
+    const wrapperProps: WrapperProps = {
+        children: hasError ? null : children,
+        className: baseClasses,
+    };
+
+    if (hasError && isDevelopment()) {
+        wrapperProps['data-ve-resolution-error'] = resolutionError;
+    }
+
+    return <div {...wrapperProps} />;
+}
+
+export function PostTemplateBlock({ attributes, children }: BlockRendererProps): JSX.Element {
+    const className = attrString(attributes.className);
+    const layout = attrString(attributes.layout);
+    const layoutType = attrString(attributes.layoutType);
+    const isGrid = layout === 'grid' || layoutType === 'grid';
+
+    const classes = classList([
+        'wp-block-post-template',
+        isGrid ? 'is-layout-grid' : 'is-layout-flow',
+        className,
+    ]);
+
+    return <ul className={classes}>{children}</ul>;
+}

--- a/packages/visual-editor-renderer-react/src/blocks/registerCoreBlocks.ts
+++ b/packages/visual-editor-renderer-react/src/blocks/registerCoreBlocks.ts
@@ -52,6 +52,7 @@ import {
     PostFeaturedImageBlock,
     PostTitleBlock,
 } from './core/postContext';
+import { PostTemplateBlock, QueryBlock } from './core/query';
 import { SiteLogoBlock, SiteTaglineBlock, SiteTitleBlock } from './core/siteContext';
 import { SyncedPatternBlock } from './core/syncedPattern';
 import { TemplatePartBlock } from './core/templatePart';
@@ -100,6 +101,8 @@ const CORE_BLOCKS: Record<string, BlockRenderer> = {
     'core/spacer': SpacerBlock,
     'core/template-part': TemplatePartBlock,
     'core/block': SyncedPatternBlock,
+    'core/query': QueryBlock,
+    'core/post-template': PostTemplateBlock,
     'core/post-title': PostTitleBlock,
     'core/post-content': PostContentBlock,
     'core/post-excerpt': PostExcerptBlock,

--- a/packages/visual-editor-renderer-react/src/index.ts
+++ b/packages/visual-editor-renderer-react/src/index.ts
@@ -52,6 +52,16 @@ export type {
     PatternResolutionError,
 } from './patterns';
 export {
+    QUERY_RESOLUTION_ERROR_NO_RESULTS,
+    inlineQueries,
+} from './queries';
+export type {
+    ResolvedAuthor,
+    ResolvedFeaturedImage,
+    ResolvedPost,
+    ResolvedQuery,
+} from './queries';
+export {
     getDefaultSiteMeta,
     inlineSiteMeta,
     setDefaultSiteMeta,

--- a/packages/visual-editor-renderer-react/src/queries.ts
+++ b/packages/visual-editor-renderer-react/src/queries.ts
@@ -214,9 +214,16 @@ function resolvedAttributesFor(name: string, post: ResolvedPost): Record<string,
 /**
  * Format an ISO timestamp as a human-readable "F j, Y" date so the
  * client-side `_resolvedDateFormatted` matches the server-side output
- * Carbon's `translatedFormat('F j, Y')` produces. Falls back to the raw
- * string when the date is unparseable so the renderer never throws on
- * malformed input.
+ * Carbon's `translatedFormat('F j, Y')` produces.
+ *
+ * Locale resolution prefers the document's `<html lang>` so a host that
+ * sets `lang="es"` gets Spanish month names (matching the server-side
+ * locale via Carbon's translation). Timezone is pinned to `UTC` so the
+ * day boundary matches what the server emits — without this, a post
+ * stored at `2026-04-20T23:30:00Z` would render as April 20 server-side
+ * but April 21 in a viewer's `Asia/Tokyo` browser. Falls back to the
+ * raw string when the date is unparseable so the renderer never throws
+ * on malformed input.
  */
 function formatHumanDate(iso: string | null | undefined): string {
     if (iso === null || iso === undefined || iso === '') {
@@ -229,10 +236,16 @@ function formatHumanDate(iso: string | null | undefined): string {
         return iso;
     }
 
-    return new Intl.DateTimeFormat('en-US', {
+    const locale =
+        typeof document !== 'undefined' && document.documentElement?.lang
+            ? document.documentElement.lang
+            : 'en-US';
+
+    return new Intl.DateTimeFormat(locale, {
         year: 'numeric',
         month: 'long',
         day: 'numeric',
+        timeZone: 'UTC',
     }).format(date);
 }
 

--- a/packages/visual-editor-renderer-react/src/queries.ts
+++ b/packages/visual-editor-renderer-react/src/queries.ts
@@ -1,0 +1,250 @@
+/**
+ * Client-side `core/query` expansion.
+ *
+ * Mirrors the server-side
+ * `ArtisanPackUI\VisualEditor\Resources\QueryInliner` so a
+ * pre-resolved set of post records can drive the same per-result
+ * expansion the Blade renderer produces. Hosts that pre-fetch query
+ * results server-side (typical for Inertia + React) hand them to
+ * `<BlockTree queryResults={...} />` and the inliner walks the saved
+ * tree, replacing every `core/query` block with one stamped copy of
+ * its inner blocks per result.
+ *
+ * The inliner does not call the network — clients that need to fetch
+ * results on the fly use the `useQueryPreview` hook instead.
+ */
+
+import type { Block } from './types';
+
+export const QUERY_RESOLUTION_ERROR_NO_RESULTS = 'no-results';
+
+export interface ResolvedQuery {
+    /** Identifier matching a `core/query` block's `query.queryId` attribute. */
+    queryId: string | number;
+    /** Posts returned by the resolver in result order. */
+    posts: ResolvedPost[];
+    /** Total before perPage / offset are applied; used by the count placeholder. */
+    total?: number;
+}
+
+export interface ResolvedPost {
+    id: number;
+    title?: string;
+    excerpt?: string;
+    content?: string;
+    permalink?: string;
+    publishedAt?: string;
+    modifiedAt?: string;
+    author?: ResolvedAuthor | null;
+    featuredImage?: ResolvedFeaturedImage | null;
+}
+
+export interface ResolvedAuthor {
+    name?: string;
+    bio?: string;
+    url?: string;
+    avatarUrl?: string;
+}
+
+export interface ResolvedFeaturedImage {
+    url: string;
+    alt?: string;
+    width?: number;
+    height?: number;
+}
+
+interface InlineQueriesOptions {
+    queries: ResolvedQuery[];
+}
+
+const POST_CONTEXT_BLOCKS = new Set([
+    'core/post-title',
+    'core/post-content',
+    'core/post-excerpt',
+    'core/post-date',
+    'core/post-author',
+    'core/post-featured-image',
+]);
+
+export function inlineQueries(tree: Block[], options: InlineQueriesOptions): Block[] {
+    const queriesById = new Map<string, ResolvedQuery>();
+
+    for (const query of options.queries) {
+        queriesById.set(String(query.queryId), query);
+    }
+
+    return walk(tree, queriesById);
+}
+
+function walk(tree: Block[], queries: Map<string, ResolvedQuery>): Block[] {
+    const out: Block[] = [];
+
+    for (const block of tree) {
+        if (block === null || typeof block !== 'object') {
+            continue;
+        }
+
+        if (block.name === 'core/query') {
+            out.push(expandQuery(block, queries));
+            continue;
+        }
+
+        if (Array.isArray(block.innerBlocks) && block.innerBlocks.length > 0) {
+            out.push({
+                ...block,
+                innerBlocks: walk(block.innerBlocks, queries),
+            });
+            continue;
+        }
+
+        out.push(block);
+    }
+
+    return out;
+}
+
+function expandQuery(block: Block, queries: Map<string, ResolvedQuery>): Block {
+    const attributes =
+        block.attributes !== null && typeof block.attributes === 'object'
+            ? (block.attributes as Record<string, unknown>)
+            : {};
+
+    const queryAttrs =
+        attributes.query !== null && typeof attributes.query === 'object'
+            ? (attributes.query as Record<string, unknown>)
+            : attributes;
+
+    const queryId = queryAttrs.queryId;
+    const resolved =
+        typeof queryId === 'string' || typeof queryId === 'number'
+            ? queries.get(String(queryId))
+            : undefined;
+
+    if (resolved === undefined) {
+        return {
+            ...block,
+            attributes: { ...attributes, _resolutionError: QUERY_RESOLUTION_ERROR_NO_RESULTS },
+            innerBlocks: [],
+        };
+    }
+
+    const template = Array.isArray(block.innerBlocks) ? (block.innerBlocks as Block[]) : [];
+    const expanded: Block[] = [];
+
+    for (const post of resolved.posts) {
+        for (const child of template) {
+            expanded.push(stampPost(cloneBlock(child), post));
+        }
+    }
+
+    return {
+        ...block,
+        attributes: {
+            ...attributes,
+            _resolvedTotal: resolved.total ?? resolved.posts.length,
+            _resolvedItems: resolved.posts.length,
+        },
+        innerBlocks: expanded,
+    };
+}
+
+function stampPost(block: Block, post: ResolvedPost): Block {
+    const next = cloneBlock(block);
+
+    if (typeof next.name === 'string' && POST_CONTEXT_BLOCKS.has(next.name)) {
+        next.attributes = {
+            ...resolvedAttributesFor(next.name, post),
+            ...(typeof next.attributes === 'object' && next.attributes !== null
+                ? (next.attributes as Record<string, unknown>)
+                : {}),
+        };
+    }
+
+    if (Array.isArray(next.innerBlocks) && next.innerBlocks.length > 0) {
+        next.innerBlocks = next.innerBlocks.map((child) => stampPost(child, post));
+    }
+
+    return next;
+}
+
+function resolvedAttributesFor(name: string, post: ResolvedPost): Record<string, unknown> {
+    switch (name) {
+        case 'core/post-title':
+            return {
+                _resolvedTitle: post.title ?? '',
+                _resolvedPermalink: post.permalink ?? '',
+            };
+        case 'core/post-content':
+            return {
+                _resolvedContent: post.content ?? '',
+            };
+        case 'core/post-excerpt':
+            return {
+                _resolvedExcerpt: post.excerpt ?? '',
+                _resolvedPermalink: post.permalink ?? '',
+            };
+        case 'core/post-date':
+            return {
+                _resolvedDate: post.publishedAt ?? '',
+                _resolvedDateFormatted: formatHumanDate(post.publishedAt),
+                _resolvedModifiedDate: post.modifiedAt ?? '',
+                _resolvedModifiedDateFormatted: formatHumanDate(post.modifiedAt),
+                _resolvedPermalink: post.permalink ?? '',
+            };
+        case 'core/post-author':
+            return {
+                _resolvedAuthorName: post.author?.name ?? '',
+                _resolvedAuthorBio: post.author?.bio ?? '',
+                _resolvedAuthorUrl: post.author?.url ?? '',
+                _resolvedAuthorAvatar: post.author?.avatarUrl ?? '',
+            };
+        case 'core/post-featured-image':
+            return {
+                _resolvedImageUrl: post.featuredImage?.url ?? '',
+                _resolvedImageAlt: post.featuredImage?.alt ?? '',
+                _resolvedImageWidth: post.featuredImage?.width ?? 0,
+                _resolvedImageHeight: post.featuredImage?.height ?? 0,
+                _resolvedPermalink: post.permalink ?? '',
+            };
+        default:
+            return {};
+    }
+}
+
+/**
+ * Format an ISO timestamp as a human-readable "F j, Y" date so the
+ * client-side `_resolvedDateFormatted` matches the server-side output
+ * Carbon's `translatedFormat('F j, Y')` produces. Falls back to the raw
+ * string when the date is unparseable so the renderer never throws on
+ * malformed input.
+ */
+function formatHumanDate(iso: string | null | undefined): string {
+    if (iso === null || iso === undefined || iso === '') {
+        return '';
+    }
+
+    const date = new Date(iso);
+
+    if (Number.isNaN(date.getTime())) {
+        return iso;
+    }
+
+    return new Intl.DateTimeFormat('en-US', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+    }).format(date);
+}
+
+function cloneBlock(block: Block): Block {
+    return {
+        ...block,
+        attributes:
+            typeof block.attributes === 'object' && block.attributes !== null
+                ? { ...(block.attributes as Record<string, unknown>) }
+                : {},
+        innerBlocks: Array.isArray(block.innerBlocks)
+            ? block.innerBlocks.map((child) => cloneBlock(child))
+            : [],
+    };
+}

--- a/packages/visual-editor-renderer-react/tests/queries.test.ts
+++ b/packages/visual-editor-renderer-react/tests/queries.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from 'vitest';
+import {
+    QUERY_RESOLUTION_ERROR_NO_RESULTS,
+    inlineQueries,
+} from '../src/queries';
+import type { ResolvedPost, ResolvedQuery } from '../src/queries';
+import type { Block } from '../src/types';
+
+function makeQueryBlock(template: Block[], queryId: string | number = 'q1'): Block {
+    return {
+        clientId: 'qry',
+        name: 'core/query',
+        attributes: { query: { queryId, postType: 'post' } },
+        innerBlocks: [
+            {
+                clientId: 'tpl',
+                name: 'core/post-template',
+                attributes: {},
+                innerBlocks: template,
+            },
+        ],
+    };
+}
+
+function fakePost(id: number, title: string): ResolvedPost {
+    return {
+        id,
+        title,
+        permalink: `/posts/${id}`,
+    };
+}
+
+describe('inlineQueries', () => {
+    it('expands core/query into one post-template instance per result', () => {
+        const tree = [
+            makeQueryBlock([
+                { name: 'core/post-title', attributes: {}, innerBlocks: [] } as Block,
+            ]),
+        ];
+
+        const queries: ResolvedQuery[] = [
+            { queryId: 'q1', posts: [fakePost(1, 'A'), fakePost(2, 'B')] },
+        ];
+
+        const result = inlineQueries(tree, { queries });
+        const innerBlocks = result[0].innerBlocks ?? [];
+
+        expect(innerBlocks).toHaveLength(2);
+        expect(
+            (innerBlocks[0].innerBlocks?.[0].attributes as Record<string, unknown>)?._resolvedTitle
+        ).toBe('A');
+        expect(
+            (innerBlocks[1].innerBlocks?.[0].attributes as Record<string, unknown>)?._resolvedTitle
+        ).toBe('B');
+    });
+
+    it('marks core/query with _resolutionError when no resolved set is supplied', () => {
+        const tree = [makeQueryBlock([])];
+
+        const result = inlineQueries(tree, { queries: [] });
+
+        expect((result[0].attributes as Record<string, unknown>)._resolutionError).toBe(
+            QUERY_RESOLUTION_ERROR_NO_RESULTS
+        );
+        expect(result[0].innerBlocks).toEqual([]);
+    });
+
+    it('stamps post-context attributes for the supported core/post-* blocks', () => {
+        const tree = [
+            makeQueryBlock([
+                { name: 'core/post-title', attributes: {}, innerBlocks: [] } as Block,
+                { name: 'core/post-excerpt', attributes: {}, innerBlocks: [] } as Block,
+                { name: 'core/post-author', attributes: {}, innerBlocks: [] } as Block,
+            ]),
+        ];
+
+        const queries: ResolvedQuery[] = [
+            {
+                queryId: 'q1',
+                posts: [
+                    {
+                        id: 1,
+                        title: 'Post',
+                        excerpt: 'Excerpt',
+                        permalink: '/posts/1',
+                        author: { name: 'Jane Doe' },
+                    },
+                ],
+            },
+        ];
+
+        const result = inlineQueries(tree, { queries });
+        const stamped = result[0].innerBlocks?.[0].innerBlocks ?? [];
+
+        expect((stamped[0].attributes as Record<string, unknown>)._resolvedTitle).toBe('Post');
+        expect((stamped[1].attributes as Record<string, unknown>)._resolvedExcerpt).toBe('Excerpt');
+        expect((stamped[2].attributes as Record<string, unknown>)._resolvedAuthorName).toBe(
+            'Jane Doe'
+        );
+    });
+
+    it('recurses into nested queries and groups', () => {
+        const tree = [
+            {
+                name: 'core/group',
+                attributes: {},
+                innerBlocks: [
+                    makeQueryBlock(
+                        [
+                            { name: 'core/post-title', attributes: {}, innerBlocks: [] } as Block,
+                        ],
+                        'inner'
+                    ),
+                ],
+            },
+        ];
+
+        const queries: ResolvedQuery[] = [
+            { queryId: 'inner', posts: [fakePost(1, 'Inner')] },
+        ];
+
+        const result = inlineQueries(tree as Block[], { queries });
+        const innerQuery = result[0].innerBlocks?.[0];
+        const stamped = innerQuery?.innerBlocks?.[0]?.innerBlocks?.[0];
+
+        expect(innerQuery?.name).toBe('core/query');
+        expect((stamped?.attributes as Record<string, unknown>)?._resolvedTitle).toBe('Inner');
+    });
+
+    it('passes through pre-existing _resolved attrs without overwriting', () => {
+        const tree = [
+            makeQueryBlock([
+                {
+                    name: 'core/post-title',
+                    attributes: { _resolvedTitle: 'Host override' },
+                    innerBlocks: [],
+                } as Block,
+            ]),
+        ];
+
+        const queries: ResolvedQuery[] = [
+            { queryId: 'q1', posts: [fakePost(1, 'Resolver value')] },
+        ];
+
+        const result = inlineQueries(tree, { queries });
+        const stamped = result[0].innerBlocks?.[0].innerBlocks?.[0];
+
+        expect((stamped?.attributes as Record<string, unknown>)?._resolvedTitle).toBe(
+            'Host override'
+        );
+    });
+});

--- a/packages/visual-editor-renderer-vue/src/BlockTree.ts
+++ b/packages/visual-editor-renderer-vue/src/BlockTree.ts
@@ -28,6 +28,8 @@ import {
     inlinePatterns,
 } from './patterns';
 import type { PatternRecord } from './patterns';
+import { inlineQueries } from './queries';
+import type { ResolvedQuery } from './queries';
 import { getBlockRenderer } from './registry';
 import { inlineSiteMeta } from './siteMeta';
 import type { SiteMeta } from './siteMeta';
@@ -72,6 +74,14 @@ export interface BlockTreeProps {
      * block when needed.
      */
     siteMeta?: SiteMeta | null;
+    /**
+     * Pre-resolved `core/query` results keyed by `queryId`. When
+     * supplied, every `core/query` block in the tree is replaced with
+     * one stamped copy of its inner blocks per result via
+     * {@link inlineQueries}. Hosts that pre-fetch results server-side
+     * pass them here.
+     */
+    queryResults?: ResolvedQuery[];
 }
 
 export const BlockTree = defineComponent({
@@ -117,6 +127,10 @@ export const BlockTree = defineComponent({
             type: Object as PropType<SiteMeta | null | undefined>,
             default: undefined,
         },
+        queryResults: {
+            type: Array as PropType<ResolvedQuery[]>,
+            default: undefined,
+        },
     },
     setup(props) {
         const blocks = computed(() => {
@@ -151,10 +165,14 @@ export const BlockTree = defineComponent({
                           maxDepth: props.maxPatternDepth,
                       });
 
-            // Site-meta inlining runs last so values stamped here are
-            // visible on blocks that template-part / pattern inlining
-            // brought into the tree from elsewhere.
-            return inlineSiteMeta(withPatterns, props.siteMeta);
+            const withSiteMeta = inlineSiteMeta(withPatterns, props.siteMeta);
+
+            // Query inlining runs last so a `core/query` block reachable
+            // only through a resolved template part / pattern still gets
+            // its loop expanded.
+            return props.queryResults === undefined
+                ? withSiteMeta
+                : inlineQueries(withSiteMeta, { queries: props.queryResults });
         });
 
         return () => {

--- a/packages/visual-editor-renderer-vue/src/blocks/core/query.ts
+++ b/packages/visual-editor-renderer-vue/src/blocks/core/query.ts
@@ -1,0 +1,78 @@
+/**
+ * `core/query` and `core/post-template` Vue renderers.
+ *
+ * Operate on an already-expanded inner-block tree — see
+ * {@link inlineQueries} for the pre-walk that replaces every
+ * `core/query` block with one stamped copy of its template per result.
+ * The renderers themselves emit the wrapping markup and pass children
+ * through.
+ *
+ * If the inliner could not resolve the query, it stamps
+ * `_resolutionError` and the wrapper renders empty in production so the
+ * surrounding layout stays intact.
+ */
+
+import { defineComponent, h } from 'vue';
+import { attrString, classList } from '../../support/attributes';
+import { blockRendererProps } from '../shared';
+
+function isDevelopment(): boolean {
+    if (typeof process === 'undefined') {
+        return false;
+    }
+
+    const env = process.env;
+
+    if (env === undefined || env === null) {
+        return false;
+    }
+
+    return env.NODE_ENV !== 'production';
+}
+
+export const QueryBlock = defineComponent({
+    name: 'QueryBlock',
+    props: blockRendererProps,
+    setup(props, { slots }) {
+        return () => {
+            const className = attrString(props.attributes.className);
+            const resolutionError = attrString(props.attributes._resolutionError);
+            const hasError = resolutionError !== '';
+
+            const attrs: Record<string, unknown> = {
+                class: classList(['wp-block-query', className]),
+            };
+
+            if (hasError && isDevelopment()) {
+                attrs['data-ve-resolution-error'] = resolutionError;
+            }
+
+            return h('div', attrs, hasError ? null : slots.default?.());
+        };
+    },
+});
+
+export const PostTemplateBlock = defineComponent({
+    name: 'PostTemplateBlock',
+    props: blockRendererProps,
+    setup(props, { slots }) {
+        return () => {
+            const className = attrString(props.attributes.className);
+            const layout = attrString(props.attributes.layout);
+            const layoutType = attrString(props.attributes.layoutType);
+            const isGrid = layout === 'grid' || layoutType === 'grid';
+
+            return h(
+                'ul',
+                {
+                    class: classList([
+                        'wp-block-post-template',
+                        isGrid ? 'is-layout-grid' : 'is-layout-flow',
+                        className,
+                    ]),
+                },
+                slots.default?.()
+            );
+        };
+    },
+});

--- a/packages/visual-editor-renderer-vue/src/blocks/registerCoreBlocks.ts
+++ b/packages/visual-editor-renderer-vue/src/blocks/registerCoreBlocks.ts
@@ -52,6 +52,7 @@ import {
     PostFeaturedImageBlock,
     PostTitleBlock,
 } from './core/postContext';
+import { PostTemplateBlock, QueryBlock } from './core/query';
 import { SiteLogoBlock, SiteTaglineBlock, SiteTitleBlock } from './core/siteContext';
 import { SyncedPatternBlock } from './core/syncedPattern';
 import { TemplatePartBlock } from './core/templatePart';
@@ -99,6 +100,8 @@ const CORE_BLOCKS: Record<string, BlockRenderer> = {
     'core/separator': SeparatorBlock,
     'core/spacer': SpacerBlock,
     'core/template-part': TemplatePartBlock,
+    'core/query': QueryBlock,
+    'core/post-template': PostTemplateBlock,
     'core/block': SyncedPatternBlock,
     'core/post-title': PostTitleBlock,
     'core/post-content': PostContentBlock,

--- a/packages/visual-editor-renderer-vue/src/index.ts
+++ b/packages/visual-editor-renderer-vue/src/index.ts
@@ -52,6 +52,16 @@ export type {
     PatternResolutionError,
 } from './patterns';
 export {
+    QUERY_RESOLUTION_ERROR_NO_RESULTS,
+    inlineQueries,
+} from './queries';
+export type {
+    ResolvedAuthor,
+    ResolvedFeaturedImage,
+    ResolvedPost,
+    ResolvedQuery,
+} from './queries';
+export {
     getDefaultSiteMeta,
     inlineSiteMeta,
     setDefaultSiteMeta,

--- a/packages/visual-editor-renderer-vue/src/queries.ts
+++ b/packages/visual-editor-renderer-vue/src/queries.ts
@@ -214,9 +214,16 @@ function resolvedAttributesFor(name: string, post: ResolvedPost): Record<string,
 /**
  * Format an ISO timestamp as a human-readable "F j, Y" date so the
  * client-side `_resolvedDateFormatted` matches the server-side output
- * Carbon's `translatedFormat('F j, Y')` produces. Falls back to the raw
- * string when the date is unparseable so the renderer never throws on
- * malformed input.
+ * Carbon's `translatedFormat('F j, Y')` produces.
+ *
+ * Locale resolution prefers the document's `<html lang>` so a host that
+ * sets `lang="es"` gets Spanish month names (matching the server-side
+ * locale via Carbon's translation). Timezone is pinned to `UTC` so the
+ * day boundary matches what the server emits — without this, a post
+ * stored at `2026-04-20T23:30:00Z` would render as April 20 server-side
+ * but April 21 in a viewer's `Asia/Tokyo` browser. Falls back to the
+ * raw string when the date is unparseable so the renderer never throws
+ * on malformed input.
  */
 function formatHumanDate(iso: string | null | undefined): string {
     if (iso === null || iso === undefined || iso === '') {
@@ -229,10 +236,16 @@ function formatHumanDate(iso: string | null | undefined): string {
         return iso;
     }
 
-    return new Intl.DateTimeFormat('en-US', {
+    const locale =
+        typeof document !== 'undefined' && document.documentElement?.lang
+            ? document.documentElement.lang
+            : 'en-US';
+
+    return new Intl.DateTimeFormat(locale, {
         year: 'numeric',
         month: 'long',
         day: 'numeric',
+        timeZone: 'UTC',
     }).format(date);
 }
 

--- a/packages/visual-editor-renderer-vue/src/queries.ts
+++ b/packages/visual-editor-renderer-vue/src/queries.ts
@@ -1,0 +1,250 @@
+/**
+ * Client-side `core/query` expansion.
+ *
+ * Mirrors the server-side
+ * `ArtisanPackUI\VisualEditor\Resources\QueryInliner` so a
+ * pre-resolved set of post records can drive the same per-result
+ * expansion the Blade renderer produces. Hosts that pre-fetch query
+ * results server-side (typical for Inertia + React) hand them to
+ * `<BlockTree queryResults={...} />` and the inliner walks the saved
+ * tree, replacing every `core/query` block with one stamped copy of
+ * its inner blocks per result.
+ *
+ * The inliner does not call the network — clients that need to fetch
+ * results on the fly use the `useQueryPreview` hook instead.
+ */
+
+import type { Block } from './types';
+
+export const QUERY_RESOLUTION_ERROR_NO_RESULTS = 'no-results';
+
+export interface ResolvedQuery {
+    /** Identifier matching a `core/query` block's `query.queryId` attribute. */
+    queryId: string | number;
+    /** Posts returned by the resolver in result order. */
+    posts: ResolvedPost[];
+    /** Total before perPage / offset are applied; used by the count placeholder. */
+    total?: number;
+}
+
+export interface ResolvedPost {
+    id: number;
+    title?: string;
+    excerpt?: string;
+    content?: string;
+    permalink?: string;
+    publishedAt?: string;
+    modifiedAt?: string;
+    author?: ResolvedAuthor | null;
+    featuredImage?: ResolvedFeaturedImage | null;
+}
+
+export interface ResolvedAuthor {
+    name?: string;
+    bio?: string;
+    url?: string;
+    avatarUrl?: string;
+}
+
+export interface ResolvedFeaturedImage {
+    url: string;
+    alt?: string;
+    width?: number;
+    height?: number;
+}
+
+interface InlineQueriesOptions {
+    queries: ResolvedQuery[];
+}
+
+const POST_CONTEXT_BLOCKS = new Set([
+    'core/post-title',
+    'core/post-content',
+    'core/post-excerpt',
+    'core/post-date',
+    'core/post-author',
+    'core/post-featured-image',
+]);
+
+export function inlineQueries(tree: Block[], options: InlineQueriesOptions): Block[] {
+    const queriesById = new Map<string, ResolvedQuery>();
+
+    for (const query of options.queries) {
+        queriesById.set(String(query.queryId), query);
+    }
+
+    return walk(tree, queriesById);
+}
+
+function walk(tree: Block[], queries: Map<string, ResolvedQuery>): Block[] {
+    const out: Block[] = [];
+
+    for (const block of tree) {
+        if (block === null || typeof block !== 'object') {
+            continue;
+        }
+
+        if (block.name === 'core/query') {
+            out.push(expandQuery(block, queries));
+            continue;
+        }
+
+        if (Array.isArray(block.innerBlocks) && block.innerBlocks.length > 0) {
+            out.push({
+                ...block,
+                innerBlocks: walk(block.innerBlocks, queries),
+            });
+            continue;
+        }
+
+        out.push(block);
+    }
+
+    return out;
+}
+
+function expandQuery(block: Block, queries: Map<string, ResolvedQuery>): Block {
+    const attributes =
+        block.attributes !== null && typeof block.attributes === 'object'
+            ? (block.attributes as Record<string, unknown>)
+            : {};
+
+    const queryAttrs =
+        attributes.query !== null && typeof attributes.query === 'object'
+            ? (attributes.query as Record<string, unknown>)
+            : attributes;
+
+    const queryId = queryAttrs.queryId;
+    const resolved =
+        typeof queryId === 'string' || typeof queryId === 'number'
+            ? queries.get(String(queryId))
+            : undefined;
+
+    if (resolved === undefined) {
+        return {
+            ...block,
+            attributes: { ...attributes, _resolutionError: QUERY_RESOLUTION_ERROR_NO_RESULTS },
+            innerBlocks: [],
+        };
+    }
+
+    const template = Array.isArray(block.innerBlocks) ? (block.innerBlocks as Block[]) : [];
+    const expanded: Block[] = [];
+
+    for (const post of resolved.posts) {
+        for (const child of template) {
+            expanded.push(stampPost(cloneBlock(child), post));
+        }
+    }
+
+    return {
+        ...block,
+        attributes: {
+            ...attributes,
+            _resolvedTotal: resolved.total ?? resolved.posts.length,
+            _resolvedItems: resolved.posts.length,
+        },
+        innerBlocks: expanded,
+    };
+}
+
+function stampPost(block: Block, post: ResolvedPost): Block {
+    const next = cloneBlock(block);
+
+    if (typeof next.name === 'string' && POST_CONTEXT_BLOCKS.has(next.name)) {
+        next.attributes = {
+            ...resolvedAttributesFor(next.name, post),
+            ...(typeof next.attributes === 'object' && next.attributes !== null
+                ? (next.attributes as Record<string, unknown>)
+                : {}),
+        };
+    }
+
+    if (Array.isArray(next.innerBlocks) && next.innerBlocks.length > 0) {
+        next.innerBlocks = next.innerBlocks.map((child) => stampPost(child, post));
+    }
+
+    return next;
+}
+
+function resolvedAttributesFor(name: string, post: ResolvedPost): Record<string, unknown> {
+    switch (name) {
+        case 'core/post-title':
+            return {
+                _resolvedTitle: post.title ?? '',
+                _resolvedPermalink: post.permalink ?? '',
+            };
+        case 'core/post-content':
+            return {
+                _resolvedContent: post.content ?? '',
+            };
+        case 'core/post-excerpt':
+            return {
+                _resolvedExcerpt: post.excerpt ?? '',
+                _resolvedPermalink: post.permalink ?? '',
+            };
+        case 'core/post-date':
+            return {
+                _resolvedDate: post.publishedAt ?? '',
+                _resolvedDateFormatted: formatHumanDate(post.publishedAt),
+                _resolvedModifiedDate: post.modifiedAt ?? '',
+                _resolvedModifiedDateFormatted: formatHumanDate(post.modifiedAt),
+                _resolvedPermalink: post.permalink ?? '',
+            };
+        case 'core/post-author':
+            return {
+                _resolvedAuthorName: post.author?.name ?? '',
+                _resolvedAuthorBio: post.author?.bio ?? '',
+                _resolvedAuthorUrl: post.author?.url ?? '',
+                _resolvedAuthorAvatar: post.author?.avatarUrl ?? '',
+            };
+        case 'core/post-featured-image':
+            return {
+                _resolvedImageUrl: post.featuredImage?.url ?? '',
+                _resolvedImageAlt: post.featuredImage?.alt ?? '',
+                _resolvedImageWidth: post.featuredImage?.width ?? 0,
+                _resolvedImageHeight: post.featuredImage?.height ?? 0,
+                _resolvedPermalink: post.permalink ?? '',
+            };
+        default:
+            return {};
+    }
+}
+
+/**
+ * Format an ISO timestamp as a human-readable "F j, Y" date so the
+ * client-side `_resolvedDateFormatted` matches the server-side output
+ * Carbon's `translatedFormat('F j, Y')` produces. Falls back to the raw
+ * string when the date is unparseable so the renderer never throws on
+ * malformed input.
+ */
+function formatHumanDate(iso: string | null | undefined): string {
+    if (iso === null || iso === undefined || iso === '') {
+        return '';
+    }
+
+    const date = new Date(iso);
+
+    if (Number.isNaN(date.getTime())) {
+        return iso;
+    }
+
+    return new Intl.DateTimeFormat('en-US', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+    }).format(date);
+}
+
+function cloneBlock(block: Block): Block {
+    return {
+        ...block,
+        attributes:
+            typeof block.attributes === 'object' && block.attributes !== null
+                ? { ...(block.attributes as Record<string, unknown>) }
+                : {},
+        innerBlocks: Array.isArray(block.innerBlocks)
+            ? block.innerBlocks.map((child) => cloneBlock(child))
+            : [],
+    };
+}

--- a/packages/visual-editor-renderer-vue/tests/queries.test.ts
+++ b/packages/visual-editor-renderer-vue/tests/queries.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from 'vitest';
+import {
+    QUERY_RESOLUTION_ERROR_NO_RESULTS,
+    inlineQueries,
+} from '../src/queries';
+import type { ResolvedPost, ResolvedQuery } from '../src/queries';
+import type { Block } from '../src/types';
+
+function makeQueryBlock(template: Block[], queryId: string | number = 'q1'): Block {
+    return {
+        clientId: 'qry',
+        name: 'core/query',
+        attributes: { query: { queryId, postType: 'post' } },
+        innerBlocks: [
+            {
+                clientId: 'tpl',
+                name: 'core/post-template',
+                attributes: {},
+                innerBlocks: template,
+            },
+        ],
+    };
+}
+
+function fakePost(id: number, title: string): ResolvedPost {
+    return {
+        id,
+        title,
+        permalink: `/posts/${id}`,
+    };
+}
+
+describe('inlineQueries', () => {
+    it('expands core/query into one post-template instance per result', () => {
+        const tree = [
+            makeQueryBlock([
+                { name: 'core/post-title', attributes: {}, innerBlocks: [] } as Block,
+            ]),
+        ];
+
+        const queries: ResolvedQuery[] = [
+            { queryId: 'q1', posts: [fakePost(1, 'A'), fakePost(2, 'B')] },
+        ];
+
+        const result = inlineQueries(tree, { queries });
+        const innerBlocks = result[0].innerBlocks ?? [];
+
+        expect(innerBlocks).toHaveLength(2);
+        expect(
+            (innerBlocks[0].innerBlocks?.[0].attributes as Record<string, unknown>)?._resolvedTitle
+        ).toBe('A');
+        expect(
+            (innerBlocks[1].innerBlocks?.[0].attributes as Record<string, unknown>)?._resolvedTitle
+        ).toBe('B');
+    });
+
+    it('marks core/query with _resolutionError when no resolved set is supplied', () => {
+        const tree = [makeQueryBlock([])];
+
+        const result = inlineQueries(tree, { queries: [] });
+
+        expect((result[0].attributes as Record<string, unknown>)._resolutionError).toBe(
+            QUERY_RESOLUTION_ERROR_NO_RESULTS
+        );
+        expect(result[0].innerBlocks).toEqual([]);
+    });
+
+    it('stamps post-context attributes for the supported core/post-* blocks', () => {
+        const tree = [
+            makeQueryBlock([
+                { name: 'core/post-title', attributes: {}, innerBlocks: [] } as Block,
+                { name: 'core/post-excerpt', attributes: {}, innerBlocks: [] } as Block,
+                { name: 'core/post-author', attributes: {}, innerBlocks: [] } as Block,
+            ]),
+        ];
+
+        const queries: ResolvedQuery[] = [
+            {
+                queryId: 'q1',
+                posts: [
+                    {
+                        id: 1,
+                        title: 'Post',
+                        excerpt: 'Excerpt',
+                        permalink: '/posts/1',
+                        author: { name: 'Jane Doe' },
+                    },
+                ],
+            },
+        ];
+
+        const result = inlineQueries(tree, { queries });
+        const stamped = result[0].innerBlocks?.[0].innerBlocks ?? [];
+
+        expect((stamped[0].attributes as Record<string, unknown>)._resolvedTitle).toBe('Post');
+        expect((stamped[1].attributes as Record<string, unknown>)._resolvedExcerpt).toBe('Excerpt');
+        expect((stamped[2].attributes as Record<string, unknown>)._resolvedAuthorName).toBe(
+            'Jane Doe'
+        );
+    });
+
+    it('recurses into nested queries and groups', () => {
+        const tree = [
+            {
+                name: 'core/group',
+                attributes: {},
+                innerBlocks: [
+                    makeQueryBlock(
+                        [
+                            { name: 'core/post-title', attributes: {}, innerBlocks: [] } as Block,
+                        ],
+                        'inner'
+                    ),
+                ],
+            },
+        ];
+
+        const queries: ResolvedQuery[] = [
+            { queryId: 'inner', posts: [fakePost(1, 'Inner')] },
+        ];
+
+        const result = inlineQueries(tree as Block[], { queries });
+        const innerQuery = result[0].innerBlocks?.[0];
+        const stamped = innerQuery?.innerBlocks?.[0]?.innerBlocks?.[0];
+
+        expect(innerQuery?.name).toBe('core/query');
+        expect((stamped?.attributes as Record<string, unknown>)?._resolvedTitle).toBe('Inner');
+    });
+
+    it('passes through pre-existing _resolved attrs without overwriting', () => {
+        const tree = [
+            makeQueryBlock([
+                {
+                    name: 'core/post-title',
+                    attributes: { _resolvedTitle: 'Host override' },
+                    innerBlocks: [],
+                } as Block,
+            ]),
+        ];
+
+        const queries: ResolvedQuery[] = [
+            { queryId: 'q1', posts: [fakePost(1, 'Resolver value')] },
+        ];
+
+        const result = inlineQueries(tree, { queries });
+        const stamped = result[0].innerBlocks?.[0].innerBlocks?.[0];
+
+        expect((stamped?.attributes as Record<string, unknown>)?._resolvedTitle).toBe(
+            'Host override'
+        );
+    });
+});

--- a/resources/js/visual-editor/editor/__tests__/use-query-preview.test.tsx
+++ b/resources/js/visual-editor/editor/__tests__/use-query-preview.test.tsx
@@ -87,9 +87,43 @@ describe('useQueryPreview', () => {
         const init = fetchMock.mock.calls[0][1] as RequestInit;
         const headers = init.headers as Record<string, string>;
 
+        // The required headers stay in their original case (they're set
+        // by the hook directly); caller-supplied headers come back
+        // lowercased because they round-trip through the Headers spec
+        // normaliser.
         expect(headers['Content-Type']).toBe('application/json');
         expect(headers.Accept).toBe('application/json');
-        expect(headers['X-Trace']).toBe('caller-supplied');
+        expect(headers['x-trace']).toBe('caller-supplied');
+    });
+
+    it('handles caller-supplied Headers instances and tuple arrays', async () => {
+        fetchMock.mockResolvedValue(
+            new Response(JSON.stringify({ data: [], meta: { total: 0 } }), {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' },
+            })
+        );
+
+        const callerHeaders = new Headers({ 'X-Trace': 'instance' });
+
+        renderHook(() =>
+            useQueryPreview(
+                { postType: 'post' },
+                {
+                    debounceMs: 0,
+                    fetchOptions: { headers: callerHeaders },
+                }
+            )
+        );
+
+        await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+        const init = fetchMock.mock.calls[0][1] as RequestInit;
+        const headers = init.headers as Record<string, string>;
+
+        // Headers normalises keys to lowercase — assert against that.
+        expect(headers['x-trace']).toBe('instance');
+        expect(headers['Content-Type']).toBe('application/json');
     });
 
     it('strips upstream empty defaults from the posted payload', async () => {

--- a/resources/js/visual-editor/editor/__tests__/use-query-preview.test.tsx
+++ b/resources/js/visual-editor/editor/__tests__/use-query-preview.test.tsx
@@ -23,6 +23,75 @@ describe('useQueryPreview', () => {
         expect(fetchMock).not.toHaveBeenCalled();
     });
 
+    it('recursively strips empty nested objects and arrays', async () => {
+        fetchMock.mockResolvedValue(
+            new Response(JSON.stringify({ data: [], meta: { total: 0 } }), {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' },
+            })
+        );
+
+        renderHook(() =>
+            useQueryPreview(
+                {
+                    queryId: 'abc',
+                    postType: 'post',
+                    // A partially-configured taxQuery the user toggled
+                    // back off. Validation would reject it as missing
+                    // required `terms`; the recursive strip should
+                    // collapse the entire object away.
+                    taxQuery: { taxonomy: '', terms: [], operator: '' },
+                    // Nested object with a meaningful key — that key
+                    // survives, the empty siblings get pruned.
+                    nested: { keep: 'value', drop: '', alsoDrop: [] },
+                },
+                { debounceMs: 0 }
+            )
+        );
+
+        await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+        const init = fetchMock.mock.calls[0][1] as RequestInit;
+        const body = JSON.parse(init.body as string) as Record<string, unknown>;
+
+        expect(body).not.toHaveProperty('taxQuery');
+        expect(body).toEqual({
+            queryId: 'abc',
+            postType: 'post',
+            nested: { keep: 'value' },
+        });
+    });
+
+    it('preserves caller-supplied headers without dropping the required ones', async () => {
+        fetchMock.mockResolvedValue(
+            new Response(JSON.stringify({ data: [], meta: { total: 0 } }), {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' },
+            })
+        );
+
+        renderHook(() =>
+            useQueryPreview(
+                { postType: 'post' },
+                {
+                    debounceMs: 0,
+                    fetchOptions: {
+                        headers: { 'X-Trace': 'caller-supplied' },
+                    },
+                }
+            )
+        );
+
+        await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+        const init = fetchMock.mock.calls[0][1] as RequestInit;
+        const headers = init.headers as Record<string, string>;
+
+        expect(headers['Content-Type']).toBe('application/json');
+        expect(headers.Accept).toBe('application/json');
+        expect(headers['X-Trace']).toBe('caller-supplied');
+    });
+
     it('strips upstream empty defaults from the posted payload', async () => {
         fetchMock.mockResolvedValue(
             new Response(JSON.stringify({ data: [], meta: { total: 0 } }), {

--- a/resources/js/visual-editor/editor/__tests__/use-query-preview.test.tsx
+++ b/resources/js/visual-editor/editor/__tests__/use-query-preview.test.tsx
@@ -1,0 +1,145 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useQueryPreview } from '../use-query-preview';
+
+const fetchMock = vi.fn();
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+    fetchMock.mockReset();
+    globalThis.fetch = fetchMock as typeof globalThis.fetch;
+});
+
+afterEach(() => {
+    globalThis.fetch = originalFetch;
+});
+
+describe('useQueryPreview', () => {
+    it('returns idle state when query is null', () => {
+        const { result } = renderHook(() => useQueryPreview(null));
+
+        expect(result.current.status).toBe('idle');
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('strips upstream empty defaults from the posted payload', async () => {
+        fetchMock.mockResolvedValue(
+            new Response(JSON.stringify({ data: [], meta: { total: 0 } }), {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' },
+            })
+        );
+
+        renderHook(() =>
+            useQueryPreview(
+                {
+                    queryId: 'abc',
+                    postType: 'post',
+                    perPage: 3,
+                    // Upstream default placeholders that should be dropped.
+                    pages: 0,
+                    author: '',
+                    sticky: '',
+                    taxQuery: '',
+                    search: '',
+                    exclude: [],
+                },
+                { debounceMs: 0 }
+            )
+        );
+
+        await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+        const init = fetchMock.mock.calls[0][1] as RequestInit;
+        const body = JSON.parse(init.body as string) as Record<string, unknown>;
+
+        // Empty strings, empty arrays, and empty objects are dropped.
+        // Numeric zeros (e.g. `pages: 0`) survive and the server treats
+        // them as the documented "no cap" sentinel.
+        expect(body).toEqual({ queryId: 'abc', postType: 'post', perPage: 3, pages: 0 });
+        expect(body).not.toHaveProperty('author');
+        expect(body).not.toHaveProperty('sticky');
+        expect(body).not.toHaveProperty('taxQuery');
+        expect(body).not.toHaveProperty('search');
+        expect(body).not.toHaveProperty('exclude');
+    });
+
+    it('attaches the X-CSRF-TOKEN header when a meta tag is present', async () => {
+        const meta = document.createElement('meta');
+        meta.setAttribute('name', 'csrf-token');
+        meta.setAttribute('content', 'abc123');
+        document.head.appendChild(meta);
+
+        try {
+            fetchMock.mockResolvedValue(
+                new Response(JSON.stringify({ data: [], meta: { total: 0 } }), {
+                    status: 200,
+                    headers: { 'Content-Type': 'application/json' },
+                })
+            );
+
+            renderHook(() => useQueryPreview({ postType: 'post' }, { debounceMs: 0 }));
+
+            await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+            const init = fetchMock.mock.calls[0][1] as RequestInit;
+            const headers = init.headers as Record<string, string>;
+
+            expect(headers['X-CSRF-TOKEN']).toBe('abc123');
+        } finally {
+            document.head.removeChild(meta);
+        }
+    });
+
+    it('reports ready with mapped posts after the debounce window', async () => {
+        fetchMock.mockResolvedValue(
+            new Response(
+                JSON.stringify({
+                    data: [
+                        {
+                            id: 1,
+                            title: { rendered: 'Hello' },
+                            excerpt: { rendered: 'World' },
+                            link: '/posts/1',
+                            date: '2026-04-30T12:00:00+00:00',
+                        },
+                    ],
+                    meta: { total: 7 },
+                }),
+                { status: 200, headers: { 'Content-Type': 'application/json' } }
+            )
+        );
+
+        const { result } = renderHook(() =>
+            useQueryPreview({ postType: 'post', perPage: 3 }, { debounceMs: 5 })
+        );
+
+        await waitFor(() => expect(result.current.status).toBe('ready'));
+
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(result.current.posts[0]).toMatchObject({
+            id: 1,
+            title: 'Hello',
+            excerpt: 'World',
+            permalink: '/posts/1',
+            publishedAt: '2026-04-30T12:00:00+00:00',
+        });
+        expect(result.current.total).toBe(7);
+    });
+
+    it('surfaces an error state on non-2xx responses', async () => {
+        fetchMock.mockResolvedValue(
+            new Response('runtime missing', { status: 503 })
+        );
+
+        const { result } = renderHook(() =>
+            useQueryPreview({ postType: 'post' }, { debounceMs: 5 })
+        );
+
+        await waitFor(() => expect(result.current.status).toBe('error'));
+
+        expect(result.current.error).toBe('runtime missing');
+        expect(result.current.posts).toEqual([]);
+    });
+});

--- a/resources/js/visual-editor/editor/editor-app.tsx
+++ b/resources/js/visual-editor/editor/editor-app.tsx
@@ -49,6 +49,7 @@ import { BlockLibrarySidebar } from './block-library-sidebar';
 import { registerContrastWarning } from './contrast-warning';
 import { ConvertToPatternControl } from './convert-to-pattern-control';
 import { discoverAndRegisterCustomBlocks } from './custom-blocks';
+import { registerCoreQueryBlockOverride } from './query-block-override';
 import { registerSyncedPatternIndicator } from './synced-pattern-indicator';
 import { registerTaxonomyAndArchiveBlockOverrides } from './taxonomy-archive-block-overrides';
 import {
@@ -173,6 +174,10 @@ function registerOnce(): void {
     // ServerSideRender-backed wrappers BEFORE `registerCoreBlocks()` so
     // the override applies during initial registration.
     registerTaxonomyAndArchiveBlockOverrides();
+    // G4c-2 — same idea for `core/query`: swap the upstream Edit (which
+    // pulls a heavy chain of unsupported core-data selectors) with a
+    // wrapper that previews via /visual-editor/api/query/resolve.
+    registerCoreQueryBlockOverride();
     registerCoreBlocks();
     // Discover host-app custom blocks under
     // `resources/js/visual-editor/blocks/{block-name}/index.ts` and

--- a/resources/js/visual-editor/editor/query-block-override.tsx
+++ b/resources/js/visual-editor/editor/query-block-override.tsx
@@ -82,27 +82,32 @@ function QueryEdit({ attributes, setAttributes, clientId }: QueryEditProps): JSX
             ? (attributes.query as Record<string, unknown>)
             : {};
 
-    // Stamp a queryId so the inliner can match this block's saved
-    // attributes to its resolved record set on the public-render path.
-    // Done in `useEffect` rather than during render so React does not
-    // see a setState during the render phase (which logs a warning and
-    // schedules an extra rerender) and so the call is skipped if the
-    // component unmounts before the effect runs.
-    const hasQueryId =
-        typeof queryFromAttrs.queryId === 'string' || typeof queryFromAttrs.queryId === 'number';
+    // Stamp this block instance's `clientId` as `query.queryId` whenever
+    // the persisted value differs (or is missing). Comparing against
+    // `clientId` rather than just absence handles the duplicated-block
+    // case: when a `core/query` is duplicated in the canvas, Gutenberg
+    // assigns a fresh `clientId` but copies the source's attributes
+    // verbatim — including its `queryId`. Without this rewrite, two
+    // sibling blocks would both resolve to the same record set on the
+    // public-render path. Done in `useEffect` rather than during render
+    // so React does not see a setState during the render phase.
+    const persistedQueryId =
+        typeof queryFromAttrs.queryId === 'string' || typeof queryFromAttrs.queryId === 'number'
+            ? String(queryFromAttrs.queryId)
+            : null;
 
     useEffect(() => {
-        if (hasQueryId) {
+        if (persistedQueryId === clientId) {
             return;
         }
 
         setAttributes({ query: { ...queryFromAttrs, queryId: clientId } });
         // `queryFromAttrs` is captured by reference for the next setAttributes
-        // call only — the effect intentionally re-runs when queryId presence
-        // flips (e.g. a host nukes the value) rather than on every attribute
-        // touch, hence the targeted dep list.
+        // call only — the effect intentionally re-runs when queryId
+        // disagrees with clientId (or vice versa) rather than on every
+        // attribute touch, hence the targeted dep list.
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [hasQueryId, clientId]);
+    }, [persistedQueryId, clientId]);
 
     const preview = useQueryPreview(queryFromAttrs);
 

--- a/resources/js/visual-editor/editor/query-block-override.tsx
+++ b/resources/js/visual-editor/editor/query-block-override.tsx
@@ -116,7 +116,14 @@ function QueryEdit({ attributes, setAttributes, clientId }: QueryEditProps): JSX
             ? queryFromAttrs.postType
             : 'post';
 
-    const firstPost = preview.posts[0];
+    // Only consume `preview.posts` when the resolver has actually
+    // finished — `useQueryPreview` keeps the previous fetch's posts
+    // visible during a new fetch's loading window so the canvas does
+    // not flicker on every inspector tweak. Skipping that read here
+    // means the inner `core/post-*` blocks fall back to their empty
+    // shells while a new query is in flight rather than rendering with
+    // a postId that no longer matches the saved query payload.
+    const firstPost = preview.status === 'ready' ? preview.posts[0] : undefined;
     const blockContext =
         firstPost === undefined
             ? { postType }

--- a/resources/js/visual-editor/editor/query-block-override.tsx
+++ b/resources/js/visual-editor/editor/query-block-override.tsx
@@ -1,0 +1,238 @@
+/**
+ * Edit-component overrides for `core/query` and `core/post-template`.
+ *
+ * Both upstream Edits pull a heavy chain of selectors the M2 shim does
+ * not implement:
+ *
+ *   - `core/query` calls `getTaxonomies`/`getEntityRecords` on the
+ *     "post types" and "taxonomies" entities for its variation picker
+ *     and toolbar.
+ *   - `core/post-template` calls `getEntityRecords('postType', …)` to
+ *     fetch the loop's post records, then renders an editable
+ *     iteration per result. With the shim returning an empty list, it
+ *     shows a "No posts found" placeholder and disables `<InnerBlocks>`.
+ *
+ * Rather than backfill all of those selectors just for the canvas
+ * preview, this filter swaps both Edits with thin wrappers:
+ *
+ *   - `core/query` calls `/visual-editor/api/query/resolve` via the
+ *     {@link useQueryPreview} hook, pushes the first result's `postId`
+ *     into a `BlockContextProvider`, and renders `<InnerBlocks />` so
+ *     the editable `core/post-template` shell renders inside.
+ *   - `core/post-template` ignores its upstream entity-records call
+ *     and just renders `<InnerBlocks />` with a default
+ *     `core/post-title` template, so users can build the per-iteration
+ *     layout. The wrapping `BlockContextProvider` from `core/query`
+ *     means inner `core/post-*` blocks resolve against the right
+ *     post via G3's entity adapter.
+ *
+ * Idempotent across HMR via a global Symbol guard.
+ */
+
+import { useEffect } from 'react';
+import {
+    BlockContextProvider,
+    InnerBlocks,
+    InspectorControls,
+    useBlockProps,
+} from '@wordpress/block-editor';
+import { Notice, PanelBody } from '@wordpress/components';
+import { addFilter } from '@wordpress/hooks';
+import { __ } from '@wordpress/i18n';
+
+import { TEXT_DOMAIN } from '../vendor/i18n';
+
+import { useQueryPreview } from './use-query-preview';
+
+const FILTER_HOOK = 'blocks.registerBlockType';
+const FILTER_NAMESPACE = 'artisanpack-ui/visual-editor/core-query-edit';
+
+const QUERY_BLOCK = 'core/query';
+const POST_TEMPLATE_BLOCK = 'core/post-template';
+
+const POST_TEMPLATE_DEFAULT_TEMPLATE: ReadonlyArray<[string]> = [
+    ['core/post-title'],
+];
+
+const REGISTERED_KEY = Symbol.for(
+    'artisanpack-ui.visual-editor.core-query-edit.registered'
+);
+
+interface GlobalSentinelHost {
+    [REGISTERED_KEY]?: boolean;
+}
+
+interface BlockSettings {
+    name?: string;
+    edit?: unknown;
+    [key: string]: unknown;
+}
+
+interface QueryEditProps {
+    attributes: Record<string, unknown>;
+    setAttributes: (changes: Record<string, unknown>) => void;
+    clientId: string;
+}
+
+function QueryEdit({ attributes, setAttributes, clientId }: QueryEditProps): JSX.Element {
+    const blockProps = useBlockProps();
+
+    const queryFromAttrs =
+        attributes.query !== null && typeof attributes.query === 'object' && !Array.isArray(attributes.query)
+            ? (attributes.query as Record<string, unknown>)
+            : {};
+
+    // Stamp a queryId so the inliner can match this block's saved
+    // attributes to its resolved record set on the public-render path.
+    // Done in `useEffect` rather than during render so React does not
+    // see a setState during the render phase (which logs a warning and
+    // schedules an extra rerender) and so the call is skipped if the
+    // component unmounts before the effect runs.
+    const hasQueryId =
+        typeof queryFromAttrs.queryId === 'string' || typeof queryFromAttrs.queryId === 'number';
+
+    useEffect(() => {
+        if (hasQueryId) {
+            return;
+        }
+
+        setAttributes({ query: { ...queryFromAttrs, queryId: clientId } });
+        // `queryFromAttrs` is captured by reference for the next setAttributes
+        // call only — the effect intentionally re-runs when queryId presence
+        // flips (e.g. a host nukes the value) rather than on every attribute
+        // touch, hence the targeted dep list.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [hasQueryId, clientId]);
+
+    const preview = useQueryPreview(queryFromAttrs);
+
+    const postType =
+        typeof queryFromAttrs.postType === 'string' && queryFromAttrs.postType !== ''
+            ? queryFromAttrs.postType
+            : 'post';
+
+    const firstPost = preview.posts[0];
+    const blockContext =
+        firstPost === undefined
+            ? { postType }
+            : { postType, postId: firstPost.id };
+
+    return (
+        <div {...blockProps}>
+            <InspectorControls>
+                <PanelBody title={__('Query preview', TEXT_DOMAIN)}>
+                    <PreviewStatus preview={preview} />
+                </PanelBody>
+            </InspectorControls>
+            <PreviewBanner preview={preview} />
+            <BlockContextProvider value={blockContext}>
+                <InnerBlocks />
+            </BlockContextProvider>
+        </div>
+    );
+}
+
+interface PreviewSummaryProps {
+    preview: ReturnType<typeof useQueryPreview>;
+}
+
+function PreviewStatus({ preview }: PreviewSummaryProps): JSX.Element {
+    if (preview.status === 'loading') {
+        return <p>{__('Loading preview…', TEXT_DOMAIN)}</p>;
+    }
+
+    if (preview.status === 'error') {
+        return (
+            <Notice status="error" isDismissible={false}>
+                {preview.error ?? __('Preview failed.', TEXT_DOMAIN)}
+            </Notice>
+        );
+    }
+
+    if (preview.status === 'ready') {
+        return (
+            <p>
+                {__('Posts matched:', TEXT_DOMAIN)} <strong>{preview.total}</strong>
+            </p>
+        );
+    }
+
+    return <p>{__('Configure the query to see a preview.', TEXT_DOMAIN)}</p>;
+}
+
+function PreviewBanner({ preview }: PreviewSummaryProps): JSX.Element | null {
+    if (preview.status !== 'ready') {
+        return null;
+    }
+
+    if (preview.total === 0) {
+        return (
+            <Notice status="warning" isDismissible={false}>
+                {__('No posts matched the current query.', TEXT_DOMAIN)}
+            </Notice>
+        );
+    }
+
+    if (preview.total === 1) {
+        return null;
+    }
+
+    return (
+        <Notice status="info" isDismissible={false}>
+            {__(
+                'The canvas previews the first matching post. The saved page renders all matching posts.',
+                TEXT_DOMAIN
+            )}
+        </Notice>
+    );
+}
+
+function PostTemplateEdit(): JSX.Element {
+    const blockProps = useBlockProps({ className: 'wp-block-post-template' });
+
+    return (
+        <div {...blockProps}>
+            <InnerBlocks template={[...POST_TEMPLATE_DEFAULT_TEMPLATE]} />
+        </div>
+    );
+}
+
+function overrideEdit(settings: BlockSettings, name: string): BlockSettings {
+    if (name === QUERY_BLOCK) {
+        // Strip upstream variations + transforms from the block's settings.
+        // The variations include `core/query`'s "Posts", "Pages", and other
+        // pre-configured patterns whose previews render via toolbar / picker
+        // chrome that calls `getTaxonomies({per_page: -1})` on mount —
+        // selectors the M2 shim does not implement, so the click crashes.
+        // Variations + transforms are conveniences for the editor UI and
+        // are not part of the saved block shape, so dropping them is
+        // attribute-compatible.
+        return {
+            ...settings,
+            edit: QueryEdit,
+            variations: [],
+            transforms: undefined,
+            __experimentalLabel: undefined,
+        };
+    }
+
+    if (name === POST_TEMPLATE_BLOCK) {
+        return {
+            ...settings,
+            edit: PostTemplateEdit,
+        };
+    }
+
+    return settings;
+}
+
+export function registerCoreQueryBlockOverride(): void {
+    const host = globalThis as unknown as GlobalSentinelHost;
+
+    if (host[REGISTERED_KEY] === true) {
+        return;
+    }
+
+    addFilter(FILTER_HOOK, FILTER_NAMESPACE, overrideEdit);
+    host[REGISTERED_KEY] = true;
+}

--- a/resources/js/visual-editor/editor/use-query-preview.ts
+++ b/resources/js/visual-editor/editor/use-query-preview.ts
@@ -135,11 +135,19 @@ export function useQueryPreview(
             // `signal`. Caller-provided headers that *don't* collide
             // (e.g. tracing headers) are preserved via the explicit
             // header merge.
+            //
+            // Normalising via `new Headers(...)` handles all three
+            // shapes `RequestInit.headers` accepts (plain object,
+            // `Headers` instance, `[string, string][]`); a naive spread
+            // would silently drop the latter two.
             const userOptions = fetchOptionsRef.current ?? {};
-            const userHeaders =
-                userOptions.headers !== undefined && userOptions.headers !== null
-                    ? (userOptions.headers as Record<string, string>)
-                    : {};
+            const userHeaders: Record<string, string> = {};
+
+            if (userOptions.headers !== undefined && userOptions.headers !== null) {
+                new Headers(userOptions.headers).forEach((value, key) => {
+                    userHeaders[key] = value;
+                });
+            }
 
             const init: RequestInit = {
                 ...userOptions,

--- a/resources/js/visual-editor/editor/use-query-preview.ts
+++ b/resources/js/visual-editor/editor/use-query-preview.ts
@@ -1,0 +1,282 @@
+/**
+ * `useQueryPreview` — editor-canvas hook for previewing `core/query`
+ * results without saving.
+ *
+ * POSTs the block's query payload to
+ * `/visual-editor/api/query/resolve` (the QueryResolveController under
+ * G4c-2) and returns the resolved post records plus a status flag the
+ * Edit component can branch on. The hook caches by a stable JSON
+ * serialization of the payload so two `core/query` blocks that share
+ * the same configuration share one in-flight request.
+ *
+ * The shape returned matches the renderer-react / renderer-vue
+ * `ResolvedPost` envelope so a host that wants to share state between
+ * the canvas preview and a server-rendered front-end can pipe the same
+ * record through both paths.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+
+export interface QueryPreviewPost {
+    id: number;
+    title?: string;
+    excerpt?: string;
+    content?: string;
+    permalink?: string;
+    publishedAt?: string;
+    modifiedAt?: string;
+    author?: {
+        name?: string;
+        bio?: string;
+        url?: string;
+        avatarUrl?: string;
+    } | null;
+    featuredImage?: {
+        url: string;
+        alt?: string;
+        width?: number;
+        height?: number;
+    } | null;
+}
+
+export type QueryPreviewStatus = 'idle' | 'loading' | 'ready' | 'error';
+
+export interface QueryPreviewState {
+    status: QueryPreviewStatus;
+    posts: QueryPreviewPost[];
+    total: number;
+    error: string | null;
+}
+
+interface QueryPreviewOptions {
+    apiBase?: string;
+    /**
+     * Extra `RequestInit` overrides merged onto the default request.
+     * Pass a stable reference (`useMemo`, module-scoped const, etc.) —
+     * the hook reads the value through a ref so referential changes
+     * after the first call do not retrigger the fetch effect, but
+     * deeply changing values *will* be picked up on the next debounce
+     * cycle. Inline `{}` literals are accepted but only the first
+     * render's value is observed.
+     */
+    fetchOptions?: RequestInit;
+    /** Debounce window in ms — prevents a fetch storm while the inspector is being adjusted. */
+    debounceMs?: number;
+}
+
+const DEFAULT_API_BASE = '/visual-editor/api';
+const DEFAULT_DEBOUNCE_MS = 300;
+
+const INITIAL_STATE: QueryPreviewState = {
+    status: 'idle',
+    posts: [],
+    total: 0,
+    error: null,
+};
+
+export function useQueryPreview(
+    query: Record<string, unknown> | null | undefined,
+    options: QueryPreviewOptions = {}
+): QueryPreviewState {
+    const apiBase = options.apiBase ?? DEFAULT_API_BASE;
+    const debounceMs = options.debounceMs ?? DEFAULT_DEBOUNCE_MS;
+
+    const serialized = serialize(query);
+
+    const [state, setState] = useState<QueryPreviewState>(INITIAL_STATE);
+    const abortRef = useRef<AbortController | null>(null);
+    const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    // Keep `fetchOptions` in a ref instead of an effect dep so callers
+    // that pass an inline `{}` do not retrigger the effect on every
+    // render. The effect reads the latest value at fire time, so a
+    // changed `fetchOptions` is picked up on the next request cycle
+    // (typically debounce + serialized-payload change) without an
+    // infinite-rerender risk.
+    const fetchOptionsRef = useRef(options.fetchOptions);
+    fetchOptionsRef.current = options.fetchOptions;
+
+    useEffect(() => {
+        if (serialized === '') {
+            setState(INITIAL_STATE);
+            return;
+        }
+
+        if (timeoutRef.current !== null) {
+            clearTimeout(timeoutRef.current);
+        }
+
+        if (abortRef.current !== null) {
+            abortRef.current.abort();
+        }
+
+        setState((prev) => ({ ...prev, status: 'loading', error: null }));
+
+        timeoutRef.current = setTimeout(() => {
+            const controller = new AbortController();
+            abortRef.current = controller;
+
+            const url = `${apiBase.replace(/\/$/, '')}/query/resolve`;
+
+            const headers: Record<string, string> = {
+                'Content-Type': 'application/json',
+                Accept: 'application/json',
+            };
+
+            const csrfToken = readCsrfToken();
+
+            if (csrfToken !== null) {
+                headers['X-CSRF-TOKEN'] = csrfToken;
+            }
+
+            const init: RequestInit = {
+                method: 'POST',
+                credentials: 'same-origin',
+                headers,
+                body: serialized,
+                signal: controller.signal,
+                ...fetchOptionsRef.current,
+            };
+
+            void fetch(url, init)
+                .then(async (response) => {
+                    if (controller.signal.aborted) {
+                        return;
+                    }
+
+                    if (!response.ok) {
+                        const text = await response.text().catch(() => '');
+                        throw new Error(text || `HTTP ${response.status}`);
+                    }
+
+                    const json = (await response.json()) as {
+                        data: unknown[];
+                        meta: { total: number };
+                    };
+
+                    setState({
+                        status: 'ready',
+                        posts: normalizePosts(json.data),
+                        total: typeof json.meta?.total === 'number' ? json.meta.total : 0,
+                        error: null,
+                    });
+                })
+                .catch((error: unknown) => {
+                    if (controller.signal.aborted) {
+                        return;
+                    }
+
+                    setState({
+                        status: 'error',
+                        posts: [],
+                        total: 0,
+                        error: error instanceof Error ? error.message : 'Failed to resolve query.',
+                    });
+                });
+        }, debounceMs);
+
+        return () => {
+            if (timeoutRef.current !== null) {
+                clearTimeout(timeoutRef.current);
+                timeoutRef.current = null;
+            }
+
+            if (abortRef.current !== null) {
+                abortRef.current.abort();
+                abortRef.current = null;
+            }
+        };
+    }, [serialized, apiBase, debounceMs]);
+
+    return state;
+}
+
+function readCsrfToken(): string | null {
+    if (typeof document === 'undefined') {
+        return null;
+    }
+
+    const meta = document.querySelector<HTMLMetaElement>('meta[name="csrf-token"]');
+
+    return meta?.content?.trim() || null;
+}
+
+function serialize(query: Record<string, unknown> | null | undefined): string {
+    if (query === null || query === undefined) {
+        return '';
+    }
+
+    try {
+        return JSON.stringify(stripEmptyDefaults(query));
+    } catch {
+        return '';
+    }
+}
+
+/**
+ * Upstream `core/query` ships block defaults that aren't meaningful
+ * (`pages: 0`, `author: ''`, `sticky: ''`, `taxQuery: ''`,
+ * `search: ''`, etc.) but fail server-side validation when posted
+ * verbatim. Drop empty / null / placeholder values before the request
+ * fires so the QueryRuntime only sees fields the user actually
+ * configured.
+ *
+ * `queryId` always survives because the inliner needs it to match
+ * resolved records to their source block on the public-render path.
+ */
+function stripEmptyDefaults(query: Record<string, unknown>): Record<string, unknown> {
+    const out: Record<string, unknown> = {};
+
+    for (const [key, value] of Object.entries(query)) {
+        if (key === 'queryId') {
+            out[key] = value;
+            continue;
+        }
+
+        if (value === null || value === undefined || value === '') {
+            continue;
+        }
+
+        if (Array.isArray(value) && value.length === 0) {
+            continue;
+        }
+
+        if (typeof value === 'object' && Object.keys(value as Record<string, unknown>).length === 0) {
+            continue;
+        }
+
+        out[key] = value;
+    }
+
+    return out;
+}
+
+function normalizePosts(items: unknown[]): QueryPreviewPost[] {
+    if (!Array.isArray(items)) {
+        return [];
+    }
+
+    return items
+        .filter((item): item is Record<string, unknown> => item !== null && typeof item === 'object')
+        .map((item) => mapWpEntityToPost(item));
+}
+
+function mapWpEntityToPost(entity: Record<string, unknown>): QueryPreviewPost {
+    const id = typeof entity.id === 'number' ? entity.id : Number(entity.id ?? 0);
+    const titleRendered =
+        typeof entity.title === 'object' && entity.title !== null
+            ? String((entity.title as Record<string, unknown>).rendered ?? '')
+            : '';
+    const excerptRendered =
+        typeof entity.excerpt === 'object' && entity.excerpt !== null
+            ? String((entity.excerpt as Record<string, unknown>).rendered ?? '')
+            : '';
+
+    return {
+        id,
+        title: titleRendered,
+        excerpt: excerptRendered,
+        publishedAt: typeof entity.date === 'string' ? entity.date : undefined,
+        modifiedAt: typeof entity.modified === 'string' ? entity.modified : undefined,
+        permalink: typeof entity.link === 'string' ? entity.link : undefined,
+    };
+}

--- a/resources/js/visual-editor/editor/use-query-preview.ts
+++ b/resources/js/visual-editor/editor/use-query-preview.ts
@@ -128,13 +128,26 @@ export function useQueryPreview(
                 headers['X-CSRF-TOKEN'] = csrfToken;
             }
 
+            // Merge user-supplied options first, then layer the request's
+            // required keys on top so a caller cannot accidentally drop
+            // `Content-Type` / `Accept` / `X-CSRF-TOKEN` / the
+            // AbortController signal by passing their own `headers` or
+            // `signal`. Caller-provided headers that *don't* collide
+            // (e.g. tracing headers) are preserved via the explicit
+            // header merge.
+            const userOptions = fetchOptionsRef.current ?? {};
+            const userHeaders =
+                userOptions.headers !== undefined && userOptions.headers !== null
+                    ? (userOptions.headers as Record<string, string>)
+                    : {};
+
             const init: RequestInit = {
+                ...userOptions,
                 method: 'POST',
-                credentials: 'same-origin',
-                headers,
+                credentials: userOptions.credentials ?? 'same-origin',
+                headers: { ...userHeaders, ...headers },
                 body: serialized,
                 signal: controller.signal,
-                ...fetchOptionsRef.current,
             };
 
             void fetch(url, init)
@@ -220,6 +233,10 @@ function serialize(query: Record<string, unknown> | null | undefined): string {
  * fires so the QueryRuntime only sees fields the user actually
  * configured.
  *
+ * Recurses into nested objects + arrays so a partially-configured
+ * `taxQuery: { taxonomy: '', terms: [] }` also collapses to absent
+ * instead of failing validation as "missing required `terms`".
+ *
  * `queryId` always survives because the inliner needs it to match
  * resolved records to their source block on the public-render path.
  */
@@ -232,22 +249,51 @@ function stripEmptyDefaults(query: Record<string, unknown>): Record<string, unkn
             continue;
         }
 
-        if (value === null || value === undefined || value === '') {
+        const pruned = pruneValue(value);
+
+        if (pruned === undefined) {
             continue;
         }
 
-        if (Array.isArray(value) && value.length === 0) {
-            continue;
-        }
-
-        if (typeof value === 'object' && Object.keys(value as Record<string, unknown>).length === 0) {
-            continue;
-        }
-
-        out[key] = value;
+        out[key] = pruned;
     }
 
     return out;
+}
+
+/**
+ * Returns the pruned form of `value`, or `undefined` if the value should
+ * be dropped entirely (empty / null / placeholder).
+ */
+function pruneValue(value: unknown): unknown {
+    if (value === null || value === undefined || value === '') {
+        return undefined;
+    }
+
+    if (Array.isArray(value)) {
+        const items = value
+            .map(pruneValue)
+            .filter((item): item is unknown => item !== undefined);
+
+        return items.length === 0 ? undefined : items;
+    }
+
+    if (typeof value === 'object') {
+        const record = value as Record<string, unknown>;
+        const inner: Record<string, unknown> = {};
+
+        for (const [key, child] of Object.entries(record)) {
+            const pruned = pruneValue(child);
+
+            if (pruned !== undefined) {
+                inner[key] = pruned;
+            }
+        }
+
+        return Object.keys(inner).length === 0 ? undefined : inner;
+    }
+
+    return value;
 }
 
 function normalizePosts(items: unknown[]): QueryPreviewPost[] {

--- a/resources/js/visual-editor/site-editor/__tests__/site-editor-app.test.tsx
+++ b/resources/js/visual-editor/site-editor/__tests__/site-editor-app.test.tsx
@@ -132,6 +132,11 @@ vi.mock('../../editor/taxonomy-archive-block-overrides', () => ({
     registerTaxonomyAndArchiveBlockOverrides: () => undefined,
 }));
 
+// G4c-2 — same reasoning for the `core/query` override.
+vi.mock('../../editor/query-block-override', () => ({
+    registerCoreQueryBlockOverride: () => undefined,
+}));
+
 import { SiteEditorApp } from '../site-editor-app';
 
 const ROUTE_BASE = '/visual-editor/site';

--- a/resources/js/visual-editor/site-editor/site-editor-app.tsx
+++ b/resources/js/visual-editor/site-editor/site-editor-app.tsx
@@ -50,6 +50,7 @@ import { usePatternsSectionViews } from './patterns/patterns-section';
 import { usePersistedToggle } from './use-persisted-toggle';
 import { useSiteEditorRouting } from './use-site-editor-routing';
 import { TopBar } from '../editor/top-bar';
+import { registerCoreQueryBlockOverride } from '../editor/query-block-override';
 import { registerSyncedPatternIndicator } from '../editor/synced-pattern-indicator';
 import { registerTaxonomyAndArchiveBlockOverrides } from '../editor/taxonomy-archive-block-overrides';
 
@@ -141,7 +142,10 @@ let editorBooted = false;
  * commit that promotes a block out of one promotes it out of the other.
  */
 const D2_DISABLED_BLOCKS: ReadonlyArray<string> = [
-    'core/query',
+    // G4c-2 (#402) leaves the deprecated `core/query-loop` alias in
+    // the deny-list (upstream no longer ships an `Edit`) plus
+    // `core/latest-comments` which needs the V1.1 cms-framework
+    // Comments module before it can resolve.
     'core/query-loop',
     'core/latest-comments',
 ];
@@ -163,6 +167,8 @@ function ensureEditorBoot(): void {
     // ServerSideRender-backed wrappers BEFORE `registerCoreBlocks()` so
     // the override applies during initial registration.
     registerTaxonomyAndArchiveBlockOverrides();
+    // G4c-2 — `core/query` Edit override.
+    registerCoreQueryBlockOverride();
 
     // Register core blocks before the first template loads so `parse()`
     // can turn the saved raw serialization back into BlockInstances

--- a/routes/api.php
+++ b/routes/api.php
@@ -26,6 +26,7 @@ use ArtisanPackUI\VisualEditor\Http\Controllers\GlobalStylesController;
 use ArtisanPackUI\VisualEditor\Http\Controllers\MenuLocationsController;
 use ArtisanPackUI\VisualEditor\Http\Controllers\NavigationController;
 use ArtisanPackUI\VisualEditor\Http\Controllers\PatternController;
+use ArtisanPackUI\VisualEditor\Http\Controllers\QueryResolveController;
 use ArtisanPackUI\VisualEditor\Http\Controllers\ResourceContentController;
 use ArtisanPackUI\VisualEditor\Http\Controllers\TemplateController;
 use ArtisanPackUI\VisualEditor\Http\Controllers\TemplatePartController;
@@ -44,6 +45,14 @@ Route::put( '{resource}/{id}/content', [ ResourceContentController::class, 'upda
 
 Route::post( 'blocks/preview', [ BlockPreviewController::class, 'preview' ] )
 	->name( 'visual-editor.api.blocks.preview' );
+
+// G4c-2 — `core/query` block resolution. Wraps cms-framework's
+// `QueryRuntime` (or any host-bound `QueryResolverContract`
+// implementation) and returns paginated WP-shape results so the editor
+// canvas + the React/Vue front-end renderers can consume the same
+// envelope.
+Route::post( 'query/resolve', [ QueryResolveController::class, 'resolve' ] )
+	->name( 'visual-editor.api.query.resolve' );
 
 Route::get( 'blocks', [ VisualEditorBlocksController::class, 'index' ] )
 	->name( 'visual-editor.api.blocks.index' );

--- a/src/Http/Controllers/QueryResolveController.php
+++ b/src/Http/Controllers/QueryResolveController.php
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * `POST /visual-editor/api/query/resolve` controller.
+ *
+ * Wraps {@see QueryResolverContract::resolve()} for the editor canvas
+ * preview and the React/Vue front-end renderers' client-side fetcher.
+ * Returns paginated WP-shape results (the same envelope the G3 entity
+ * adapters use under `data` + `meta` keys) so the same response shape
+ * powers `useEntityRecord`-style consumers.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Http\Controllers;
+
+use ArtisanPackUI\VisualEditor\Http\Requests\QueryResolveRequest;
+use ArtisanPackUI\VisualEditor\Http\Resources\Adapters\CmsFramework\PageResource;
+use ArtisanPackUI\VisualEditor\Http\Resources\Adapters\CmsFramework\PostResource;
+use ArtisanPackUI\VisualEditor\Http\Resources\Adapters\CmsFramework\WpEntityResource;
+use ArtisanPackUI\VisualEditor\Services\QueryResolverContract;
+use Illuminate\Contracts\Container\Container;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Response;
+use Illuminate\Routing\Controller;
+use Throwable;
+
+class QueryResolveController extends Controller
+{
+	public function __construct( protected Container $container ) {}
+
+	public function resolve( QueryResolveRequest $request ): JsonResponse
+	{
+		if ( ! $this->container->bound( QueryResolverContract::class ) ) {
+			return new JsonResponse(
+				[ 'message' => 'Query runtime is not available. Install artisanpack-ui/cms-framework or bind a custom resolver to QueryResolverContract.' ],
+				Response::HTTP_SERVICE_UNAVAILABLE
+			);
+		}
+
+		/** @var QueryResolverContract $resolver */
+		$resolver = $this->container->make( QueryResolverContract::class );
+		$payload  = $request->validated();
+
+		try {
+			$paginator = $resolver->resolve( $payload );
+		} catch ( Throwable $e ) {
+			report( $e );
+
+			return new JsonResponse(
+				[ 'message' => 'Failed to resolve the query payload.' ],
+				Response::HTTP_BAD_REQUEST
+			);
+		}
+
+		$resourceClass = $this->resourceClassFor( isset( $payload['postType'] ) && is_string( $payload['postType'] ) ? $payload['postType'] : 'post' );
+
+		$data = collect( $paginator->items() )->map(
+			static fn ( object $item ): array => ( new $resourceClass( $item ) )->toArray( request() )
+		)->values()->all();
+
+		return new JsonResponse( [
+			'data' => $data,
+			'meta' => [
+				'total'        => $paginator->total(),
+				'per_page'     => $paginator->perPage(),
+				'current_page' => $paginator->currentPage(),
+				'last_page'    => $paginator->lastPage(),
+			],
+		] );
+	}
+
+	/**
+	 * Pick the WP-shape transformer for the requested post type. Falls
+	 * back to {@see PostResource} for unknown types so the response keeps
+	 * a consistent shape — fields the underlying model does not expose
+	 * are silently dropped by the resource's `extraFields()` contract.
+	 *
+	 * @return class-string<WpEntityResource>
+	 */
+	protected function resourceClassFor( string $postType ): string
+	{
+		return match ( $postType ) {
+			'page'  => PageResource::class,
+			default => PostResource::class,
+		};
+	}
+}

--- a/src/Http/Requests/QueryResolveRequest.php
+++ b/src/Http/Requests/QueryResolveRequest.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * Validates the `POST /visual-editor/api/query/resolve` payload.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class QueryResolveRequest extends FormRequest
+{
+	public function authorize(): bool
+	{
+		return true;
+	}
+
+	/**
+	 * @return array<string, array<int, string>|string>
+	 */
+	public function rules(): array
+	{
+		return [
+			'postType'              => [ 'sometimes', 'string', 'max:64' ],
+			'perPage'               => [ 'sometimes', 'integer', 'min:1', 'max:100' ],
+			// `pages: 0` is the upstream `core/query` "no cap" sentinel —
+			// the QueryRuntime treats both 0 and missing identically.
+			// Reject negatives but allow 0 so a freshly-inserted block
+			// with default attributes can preview without configuring
+			// the cap first.
+			'pages'                 => [ 'sometimes', 'integer', 'min:0', 'max:1000' ],
+			'offset'                => [ 'sometimes', 'integer', 'min:0', 'max:100000' ],
+			'postIn'                => [ 'sometimes', 'array' ],
+			'postIn.*'              => [ 'integer', 'min:1' ],
+			'postNotIn'             => [ 'sometimes', 'array' ],
+			'postNotIn.*'           => [ 'integer', 'min:1' ],
+			'parents'               => [ 'sometimes', 'array' ],
+			'parents.*'             => [ 'integer', 'min:1' ],
+			'orderBy'               => [ 'sometimes', 'string', 'in:date,title,menu_order,random,relevance' ],
+			'order'                 => [ 'sometimes', 'string', 'in:asc,desc' ],
+			'author'                => [ 'sometimes', 'integer', 'min:1' ],
+			'sticky'                => [ 'sometimes', 'boolean' ],
+			'exclude'               => [ 'sometimes', 'array' ],
+			'exclude.*'             => [ 'integer', 'min:1' ],
+			'taxQuery'              => [ 'sometimes', 'array' ],
+			'taxQuery.taxonomy'     => [ 'required_with:taxQuery', 'string', 'max:64' ],
+			'taxQuery.terms'        => [ 'required_with:taxQuery', 'array' ],
+			'taxQuery.terms.*'      => [ 'integer', 'min:1' ],
+			'taxQuery.operator'     => [ 'sometimes', 'string', 'in:IN,NOT IN,AND' ],
+			'search'                => [ 'sometimes', 'string', 'max:255' ],
+			'status'                => [ 'sometimes', 'string', 'max:32' ],
+		];
+	}
+}

--- a/src/Http/Requests/QueryResolveRequest.php
+++ b/src/Http/Requests/QueryResolveRequest.php
@@ -55,7 +55,12 @@ class QueryResolveRequest extends FormRequest
 			'taxQuery.taxonomy'     => [ 'required_with:taxQuery', 'string', 'max:64' ],
 			'taxQuery.terms'        => [ 'required_with:taxQuery', 'array' ],
 			'taxQuery.terms.*'      => [ 'integer', 'min:1' ],
-			'taxQuery.operator'     => [ 'sometimes', 'string', 'in:IN,NOT IN,AND' ],
+			// V1 only supports the `IN` operator — `NOT IN` / `AND` are
+			// out of scope per #97's "Out of scope" list. Reject other
+			// values at the request layer rather than silently dropping
+			// the constraint at runtime, so the editor surfaces the
+			// limitation explicitly.
+			'taxQuery.operator'     => [ 'sometimes', 'string', 'in:IN' ],
 			'search'                => [ 'sometimes', 'string', 'max:255' ],
 			'status'                => [ 'sometimes', 'string', 'max:32' ],
 		];

--- a/src/Resources/PostResolver.php
+++ b/src/Resources/PostResolver.php
@@ -1,0 +1,264 @@
+<?php
+
+/**
+ * PostResolver — stamps `_resolved*` attributes onto `core/post-*`
+ * blocks against a single post record.
+ *
+ * Used by {@see QueryInliner} when expanding a `core/query` block: each
+ * inner `core/post-template` instance gets walked once per result, and
+ * every `core/post-*` block inside it gets the corresponding `_resolved*`
+ * keys stamped from the current post. The block partials/components
+ * already read those keys, so the renderer-side code path stays unchanged
+ * — the resolver is the only piece that has to know about the underlying
+ * model shape.
+ *
+ * The resolver is tolerant: any field the underlying model does not
+ * expose is left empty, and the existing block partials emit Gutenberg-
+ * shaped placeholder markup so the rendered tree still has the right
+ * structure.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Resources;
+
+use Illuminate\Support\Carbon;
+
+class PostResolver
+{
+	/**
+	 * Block names this resolver knows how to stamp. Blocks not in this
+	 * list are returned untouched.
+	 *
+	 * @var array<int, string>
+	 */
+	protected const SUPPORTED_BLOCKS = [
+		'core/post-title',
+		'core/post-content',
+		'core/post-excerpt',
+		'core/post-date',
+		'core/post-author',
+		'core/post-featured-image',
+	];
+
+	/**
+	 * Recursively walk a block subtree and stamp every supported
+	 * `core/post-*` block against the given post.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array<int, array<string, mixed>>  $tree
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	public function stampTree( array $tree, object $post ): array
+	{
+		$out = [];
+
+		foreach ( $tree as $block ) {
+			if ( ! is_array( $block ) ) {
+				continue;
+			}
+
+			$out[] = $this->stampBlock( $block, $post );
+		}
+
+		return $out;
+	}
+
+	/**
+	 * Stamp a single block (and its inner blocks) against the given post.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array<string, mixed>  $block
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function stampBlock( array $block, object $post ): array
+	{
+		$name = isset( $block['name'] ) && is_string( $block['name'] ) ? $block['name'] : '';
+
+		$attributes = isset( $block['attributes'] ) && is_array( $block['attributes'] ) ? $block['attributes'] : [];
+
+		if ( in_array( $name, self::SUPPORTED_BLOCKS, true ) ) {
+			$attributes = array_merge( $this->resolveAttributesFor( $name, $post ), $attributes );
+		}
+
+		$inner = isset( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] )
+			? $this->stampTree( $block['innerBlocks'], $post )
+			: [];
+
+		return array_merge( $block, [
+			'attributes'  => $attributes,
+			'innerBlocks' => $inner,
+		] );
+	}
+
+	/**
+	 * Returns the stamped `_resolved*` attributes for a single block /
+	 * post pair. Returned as a "defaults" map — pre-existing
+	 * `_resolved*` keys on the block win on merge so a host that has
+	 * already resolved values upstream keeps full control.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<string, mixed>
+	 */
+	protected function resolveAttributesFor( string $name, object $post ): array
+	{
+		return match ( $name ) {
+			'core/post-title'          => $this->resolveTitle( $post ),
+			'core/post-content'        => $this->resolveContent( $post ),
+			'core/post-excerpt'        => $this->resolveExcerpt( $post ),
+			'core/post-date'           => $this->resolveDate( $post ),
+			'core/post-author'         => $this->resolveAuthor( $post ),
+			'core/post-featured-image' => $this->resolveFeaturedImage( $post ),
+			default                    => [],
+		};
+	}
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	protected function resolveTitle( object $post ): array
+	{
+		return [
+			'_resolvedTitle'     => (string) ( $post->title ?? '' ),
+			'_resolvedPermalink' => $this->permalink( $post ),
+		];
+	}
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	protected function resolveContent( object $post ): array
+	{
+		// `content` may be a saved block tree (HasBlockContent stores
+		// it as JSON), a pre-rendered HTML string, or null. The block
+		// partial just needs a string; pass HTML through, otherwise
+		// leave empty so the partial emits its placeholder shell.
+		$content = $post->content ?? null;
+
+		return [
+			'_resolvedContent' => is_string( $content ) ? $content : '',
+		];
+	}
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	protected function resolveExcerpt( object $post ): array
+	{
+		return [
+			'_resolvedExcerpt'   => (string) ( $post->excerpt ?? '' ),
+			'_resolvedPermalink' => $this->permalink( $post ),
+		];
+	}
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	protected function resolveDate( object $post ): array
+	{
+		$published = $this->toCarbon( $post->published_at ?? null );
+		$modified  = $this->toCarbon( $post->updated_at ?? null );
+
+		return [
+			'_resolvedDate'                  => null === $published ? '' : $published->toIso8601String(),
+			'_resolvedDateFormatted'         => null === $published ? '' : $published->translatedFormat( 'F j, Y' ),
+			'_resolvedModifiedDate'          => null === $modified ? '' : $modified->toIso8601String(),
+			'_resolvedModifiedDateFormatted' => null === $modified ? '' : $modified->translatedFormat( 'F j, Y' ),
+			'_resolvedPermalink'             => $this->permalink( $post ),
+		];
+	}
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	protected function resolveAuthor( object $post ): array
+	{
+		$author = $post->author ?? null;
+
+		return [
+			'_resolvedAuthorName'   => null === $author ? '' : (string) ( $author->name ?? '' ),
+			'_resolvedAuthorBio'    => null === $author ? '' : (string) ( $author->bio ?? $author->description ?? '' ),
+			'_resolvedAuthorUrl'    => null === $author ? '' : (string) ( $author->url ?? $author->website ?? '' ),
+			'_resolvedAuthorAvatar' => null === $author ? '' : (string) ( $author->avatar_url ?? '' ),
+		];
+	}
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	protected function resolveFeaturedImage( object $post ): array
+	{
+		$mediaId = $post->featured_image_id ?? $post->featured_media ?? null;
+
+		$url    = '';
+		$alt    = '';
+		$width  = 0;
+		$height = 0;
+
+		if ( null !== $mediaId && function_exists( 'apGetMediaUrl' ) ) {
+			$resolved = apGetMediaUrl( (int) $mediaId, 'full' );
+			$url      = is_string( $resolved ) ? $resolved : '';
+		}
+
+		// `apGetMedia()` returns the full media record; fall through
+		// gracefully when the helper is unavailable (visual-editor
+		// installed without `media-library`).
+		if ( null !== $mediaId && function_exists( 'apGetMedia' ) ) {
+			$media = apGetMedia( (int) $mediaId );
+
+			if ( is_object( $media ) ) {
+				$alt    = (string) ( $media->alt_text ?? '' );
+				$width  = (int) ( $media->width ?? 0 );
+				$height = (int) ( $media->height ?? 0 );
+			}
+		}
+
+		return [
+			'_resolvedImageUrl'    => $url,
+			'_resolvedImageAlt'    => $alt,
+			'_resolvedImageWidth'  => $width,
+			'_resolvedImageHeight' => $height,
+			'_resolvedPermalink'   => $this->permalink( $post ),
+		];
+	}
+
+	protected function permalink( object $post ): string
+	{
+		// Many `HasBlockContent` models expose `permalink` as an Eloquent
+		// attribute accessor. Fall back to an empty string when the
+		// model does not provide one — block partials handle the empty
+		// case by rendering an unlinked element.
+		$permalink = $post->permalink ?? null;
+
+		return is_string( $permalink ) ? $permalink : '';
+	}
+
+	protected function toCarbon( mixed $value ): ?Carbon
+	{
+		if ( $value instanceof Carbon ) {
+			return $value;
+		}
+
+		if ( null === $value || '' === $value ) {
+			return null;
+		}
+
+		try {
+			return Carbon::parse( $value );
+		} catch ( \Throwable ) {
+			return null;
+		}
+	}
+}

--- a/src/Resources/QueryInliner.php
+++ b/src/Resources/QueryInliner.php
@@ -1,0 +1,214 @@
+<?php
+
+/**
+ * QueryInliner — pre-pass that replaces every `core/query` block in a
+ * saved tree with one expanded copy of its inner blocks per result row.
+ *
+ * Sibling to {@see TemplatePartInliner} and {@see PatternInliner}: the
+ * inliner runs once on the way into the renderer, so the per-block
+ * partials/components do not need any new walk-over-results logic. Each
+ * inner `core/post-template` is duplicated once per result; every
+ * `core/post-*` block inside the duplicated subtree gets `_resolved*`
+ * attributes stamped via {@see PostResolver} so the existing block
+ * partials/components render against the right post.
+ *
+ * Resolution is best-effort:
+ *
+ *  - When no `QueryResolverContract` is bound (cms-framework absent and
+ *    no host override), the original `core/query` block is left in
+ *    place with a `_resolutionError = 'no-runtime'` marker. The
+ *    renderers translate that to an empty render so the surrounding
+ *    layout is unaffected.
+ *  - When the resolver throws, the same fallback applies with
+ *    `_resolutionError = 'resolver-error'`.
+ *  - When the inner blocks contain no `core/post-template`, the inliner
+ *    duplicates whatever is there so hosts that drop a custom template
+ *    are not regressed by the pre-pass.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Resources;
+
+use ArtisanPackUI\VisualEditor\Services\QueryResolverContract;
+use Illuminate\Contracts\Container\Container;
+use Throwable;
+
+class QueryInliner
+{
+	public const ERROR_NO_RUNTIME     = 'no-runtime';
+	public const ERROR_RESOLVER_ERROR = 'resolver-error';
+
+	public function __construct(
+		protected Container $container,
+		protected PostResolver $postResolver,
+	) {}
+
+	/**
+	 * Walks `$tree` and returns a copy with every `core/query` block
+	 * carrying expanded post-template instances under `innerBlocks`.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array<int, array<string, mixed>>  $tree
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	public function inline( array $tree ): array
+	{
+		$out = [];
+
+		foreach ( $tree as $block ) {
+			if ( ! is_array( $block ) ) {
+				continue;
+			}
+
+			$out[] = $this->inlineBlock( $block );
+		}
+
+		return $out;
+	}
+
+	/**
+	 * @param  array<string, mixed>  $block
+	 *
+	 * @return array<string, mixed>
+	 */
+	protected function inlineBlock( array $block ): array
+	{
+		$name = isset( $block['name'] ) && is_string( $block['name'] ) ? $block['name'] : '';
+
+		if ( 'core/query' === $name ) {
+			return $this->expandQuery( $block );
+		}
+
+		// Recurse into inner blocks so nested queries (and queries
+		// inside template parts that have already been inlined) still
+		// get their loop expanded.
+		if ( isset( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ) {
+			$block['innerBlocks'] = $this->inline( $block['innerBlocks'] );
+		}
+
+		return $block;
+	}
+
+	/**
+	 * @param  array<string, mixed>  $block
+	 *
+	 * @return array<string, mixed>
+	 */
+	protected function expandQuery( array $block ): array
+	{
+		$attributes = isset( $block['attributes'] ) && is_array( $block['attributes'] ) ? $block['attributes'] : [];
+
+		// Upstream `core/query` nests the runtime attributes under a
+		// `query` key. Pass that through to the resolver if present;
+		// fall back to top-level attributes for hosts that flatten the
+		// payload.
+		$queryAttrs = isset( $attributes['query'] ) && is_array( $attributes['query'] )
+			? $attributes['query']
+			: $attributes;
+
+		if ( ! $this->container->bound( QueryResolverContract::class ) ) {
+			return $this->markFailed( $block, self::ERROR_NO_RUNTIME );
+		}
+
+		try {
+			/** @var QueryResolverContract $resolver */
+			$resolver  = $this->container->make( QueryResolverContract::class );
+			$paginator = $resolver->resolve( $queryAttrs );
+		} catch ( Throwable $e ) {
+			report( $e );
+
+			return $this->markFailed( $block, self::ERROR_RESOLVER_ERROR );
+		}
+
+		$results  = $paginator->items();
+		$template = isset( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ? $block['innerBlocks'] : [];
+
+		if ( [] === $results || [] === $template ) {
+			return array_merge( $block, [
+				'innerBlocks' => [],
+				'attributes'  => array_merge( $attributes, [
+					'_resolvedTotal'  => $paginator->total(),
+					'_resolvedItems'  => count( $results ),
+				] ),
+			] );
+		}
+
+		$expanded = [];
+
+		foreach ( $results as $post ) {
+			if ( ! is_object( $post ) ) {
+				continue;
+			}
+
+			foreach ( $template as $child ) {
+				if ( ! is_array( $child ) ) {
+					continue;
+				}
+
+				$expanded[] = $this->postResolver->stampBlock(
+					$this->cloneBlock( $child ),
+					$post
+				);
+			}
+		}
+
+		return array_merge( $block, [
+			'innerBlocks' => $expanded,
+			'attributes'  => array_merge( $attributes, [
+				'_resolvedTotal' => $paginator->total(),
+				'_resolvedItems' => count( $results ),
+			] ),
+		] );
+	}
+
+	/**
+	 * @param  array<string, mixed>  $block
+	 *
+	 * @return array<string, mixed>
+	 */
+	protected function markFailed( array $block, string $reason ): array
+	{
+		$attributes = isset( $block['attributes'] ) && is_array( $block['attributes'] ) ? $block['attributes'] : [];
+
+		return array_merge( $block, [
+			'attributes'  => array_merge( $attributes, [ '_resolutionError' => $reason ] ),
+			'innerBlocks' => [],
+		] );
+	}
+
+	/**
+	 * Deep-clone a block array so each per-result expansion has its own
+	 * mutable copy of the template subtree. Block arrays are pure data,
+	 * so a recursive copy of the array structure is enough.
+	 *
+	 * @param  array<string, mixed>  $block
+	 *
+	 * @return array<string, mixed>
+	 */
+	protected function cloneBlock( array $block ): array
+	{
+		if ( isset( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ) {
+			$inner = [];
+
+			foreach ( $block['innerBlocks'] as $child ) {
+				if ( is_array( $child ) ) {
+					$inner[] = $this->cloneBlock( $child );
+				}
+			}
+
+			$block['innerBlocks'] = $inner;
+		}
+
+		return $block;
+	}
+}

--- a/src/Services/Adapters/CmsFramework/CmsFrameworkQueryResolver.php
+++ b/src/Services/Adapters/CmsFramework/CmsFrameworkQueryResolver.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * Adapter binding the visual-editor's {@see QueryResolverContract} to
+ * cms-framework's `QueryRuntime` service.
+ *
+ * Registered in `VisualEditorServiceProvider::register()` only when the
+ * cms-framework class is available on the autoloader, so a standalone
+ * visual-editor install never tries to instantiate the missing class.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Services\Adapters\CmsFramework;
+
+use ArtisanPackUI\VisualEditor\Services\QueryResolverContract;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+
+class CmsFrameworkQueryResolver implements QueryResolverContract
+{
+	/**
+	 * The wrapped cms-framework `QueryRuntime` instance. Typed as `object`
+	 * so the visual-editor file does not import the cms-framework class
+	 * statically — that import would soft-couple the package to
+	 * cms-framework on every autoload.
+	 */
+	public function __construct( protected object $runtime ) {}
+
+	public function resolve( array $attributes ): LengthAwarePaginator
+	{
+		return $this->runtime->resolve( $attributes );
+	}
+}

--- a/src/Services/QueryResolverContract.php
+++ b/src/Services/QueryResolverContract.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * Visual-editor's contract for resolving a `core/query` block payload to
+ * a paginated record set.
+ *
+ * Implemented by {@see Adapters\CmsFramework\CmsFrameworkQueryResolver}
+ * when cms-framework is installed; host applications can bind any other
+ * implementation if they ship their own query runtime. The visual-editor
+ * service provider only registers the cms-framework adapter when
+ * `ArtisanPackUI\CMSFramework\Modules\Blog\Services\QueryRuntime` is on
+ * the autoloader, so `app()->bound(QueryResolverContract::class)` is the
+ * canonical "do we have a query runtime" check from controller / inliner
+ * code.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Services;
+
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+
+interface QueryResolverContract
+{
+	/**
+	 * Resolve the given normalized `core/query` attributes to a paginated
+	 * Eloquent (or compatible) result set.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array<string, mixed>  $attributes
+	 */
+	public function resolve( array $attributes ): LengthAwarePaginator;
+}

--- a/src/VisualEditorServiceProvider.php
+++ b/src/VisualEditorServiceProvider.php
@@ -8,6 +8,8 @@ use ArtisanPackUI\VisualEditor\Blocks\Core\CategoriesBlock;
 use ArtisanPackUI\VisualEditor\Blocks\Core\TagCloudBlock;
 use ArtisanPackUI\VisualEditor\Console\Commands\SeedSampleContentCommand;
 use ArtisanPackUI\VisualEditor\MediaBridge\GutenbergAttachmentAdapter;
+use ArtisanPackUI\VisualEditor\Services\Adapters\CmsFramework\CmsFrameworkQueryResolver;
+use ArtisanPackUI\VisualEditor\Services\QueryResolverContract;
 use ArtisanPackUI\VisualEditor\Models\VisualEditorGlobalStyles;
 use ArtisanPackUI\VisualEditor\Models\VisualEditorNavigation;
 use ArtisanPackUI\VisualEditor\Models\VisualEditorPattern;
@@ -22,6 +24,8 @@ use ArtisanPackUI\VisualEditor\Policies\VisualEditorTemplatePolicy;
 use ArtisanPackUI\VisualEditor\Policies\VisualEditorTemplatePartPolicy;
 use ArtisanPackUI\VisualEditor\Registries\BlockTypeRegistry;
 use ArtisanPackUI\VisualEditor\Registries\DynamicBlockRegistry;
+use ArtisanPackUI\VisualEditor\Resources\PostResolver;
+use ArtisanPackUI\VisualEditor\Resources\QueryInliner;
 use ArtisanPackUI\VisualEditor\Resources\ResourceResolver;
 use ArtisanPackUI\VisualEditor\Search\BlockTreeSearchExtractor;
 use ArtisanPackUI\VisualEditor\Services\GlobalStylesCacheInvalidator;
@@ -63,6 +67,21 @@ class VisualEditorServiceProvider extends ServiceProvider
 		// `ap.visual-editor.resources` callbacks.
 		$this->app->singleton( ResourceResolver::class, function () {
 			return new ResourceResolver();
+		} );
+
+		// G4c-2 — `PostResolver` stamps `_resolved*` keys on `core/post-*`
+		// blocks; `QueryInliner` orchestrates per-result expansion of
+		// `core/query` blocks. Both are stateless so binding as singletons
+		// is safe and lets host apps swap implementations cleanly.
+		$this->app->singleton( PostResolver::class, function () {
+			return new PostResolver();
+		} );
+
+		$this->app->singleton( QueryInliner::class, function ( $app ) {
+			return new QueryInliner(
+				$app,
+				$app->make( PostResolver::class ),
+			);
 		} );
 
 		$this->app->singleton( BlockTreeSearchExtractor::class, function ( $app ) {
@@ -112,10 +131,37 @@ class VisualEditorServiceProvider extends ServiceProvider
 		// Legacy alias for backward compatibility
 		$this->app->alias( VisualEditor::class, 'visualEditor' );
 
+		// G4c-2 — bind `QueryResolverContract` to cms-framework's
+		// `QueryRuntime` adapter when the package is installed. Hosts
+		// without cms-framework (or that ship a custom runtime) can
+		// override this binding from their own service provider; the
+		// `QueryResolveController` and `QueryInliner` only require that
+		// *something* be bound.
+		$this->registerQueryResolverBinding();
+
 		$this->mergeConfigFrom(
 			__DIR__ . '/../config/visual-editor.php', 'artisanpack-visual-editor-temp'
 		);
 
+	}
+
+	/**
+	 * Register the cms-framework adapter for {@see QueryResolverContract}
+	 * when the upstream class is autoloadable.
+	 *
+	 * @since 1.0.0
+	 */
+	protected function registerQueryResolverBinding(): void
+	{
+		$cmsRuntime = '\\ArtisanPackUI\\CMSFramework\\Modules\\Blog\\Services\\QueryRuntime';
+
+		if ( ! class_exists( $cmsRuntime ) ) {
+			return;
+		}
+
+		$this->app->singleton( QueryResolverContract::class, function ( $app ) use ( $cmsRuntime ): QueryResolverContract {
+			return new CmsFrameworkQueryResolver( $app->make( $cmsRuntime ) );
+		} );
 	}
 
 	/**

--- a/tests/Feature/VisualEditor/QueryResolve/QueryResolveControllerTest.php
+++ b/tests/Feature/VisualEditor/QueryResolve/QueryResolveControllerTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare( strict_types=1 );
+
+/**
+ * Feature tests for `POST /visual-editor/api/query/resolve`. Uses a
+ * fake {@see QueryResolverContract} bound at runtime so the suite does
+ * not require cms-framework on the autoloader.
+ *
+ * @since 1.0.0
+ */
+
+use ArtisanPackUI\VisualEditor\Services\QueryResolverContract;
+use Tests\Fixtures\FakeQueryResolver;
+use Tests\Fixtures\TestBlockContentModel;
+use Tests\Fixtures\TestG3Policy;
+use Tests\TestUser;
+use Illuminate\Support\Facades\Gate;
+
+beforeEach( function (): void {
+	test()->fake = new FakeQueryResolver();
+
+	$this->app->instance( QueryResolverContract::class, test()->fake );
+
+	Gate::policy( TestBlockContentModel::class, TestG3Policy::class );
+} );
+
+function actingResolver(): TestUser
+{
+	$user = TestUser::create( [
+		'name'     => 'Tester',
+		'email'    => 'tester+' . uniqid() . '@example.com',
+		'password' => bcrypt( 'secret' ),
+	] );
+
+	test()->actingAs( $user );
+
+	return $user;
+}
+
+it( 'rejects unauthenticated requests', function () {
+	$this->postJson( '/visual-editor/api/query/resolve', [ 'postType' => 'post' ] )
+		->assertUnauthorized();
+} );
+
+it( 'returns 503 when no resolver is bound', function () {
+	$this->app->forgetInstance( QueryResolverContract::class );
+	$this->app->offsetUnset( QueryResolverContract::class );
+
+	actingResolver();
+
+	$this->postJson( '/visual-editor/api/query/resolve', [ 'postType' => 'post' ] )
+		->assertStatus( 503 )
+		->assertJsonPath( 'message', 'Query runtime is not available. Install artisanpack-ui/cms-framework or bind a custom resolver to QueryResolverContract.' );
+} );
+
+it( 'returns paginated WP-shape results when the resolver succeeds', function () {
+	actingResolver();
+
+	$post = TestBlockContentModel::create( [
+		'title'   => 'Hello',
+		'status'  => 'published',
+		'content' => [],
+	] );
+
+	test()->fake->setItems( [ $post ] );
+	test()->fake->totalOverride = 47;
+	test()->fake->perPage       = 10;
+	test()->fake->currentPage   = 1;
+
+	$this->postJson( '/visual-editor/api/query/resolve', [
+		'postType' => 'post',
+		'perPage'  => 10,
+	] )
+		->assertOk()
+		->assertJsonPath( 'data.0.id', $post->id )
+		->assertJsonPath( 'data.0.title.rendered', 'Hello' )
+		->assertJsonPath( 'meta.total', 47 )
+		->assertJsonPath( 'meta.per_page', 10 )
+		->assertJsonPath( 'meta.current_page', 1 )
+		->assertJsonPath( 'meta.last_page', 5 );
+} );
+
+it( 'forwards the validated payload to the resolver', function () {
+	actingResolver();
+
+	$this->postJson( '/visual-editor/api/query/resolve', [
+		'postType' => 'post',
+		'perPage'  => 5,
+		'orderBy'  => 'title',
+		'order'    => 'asc',
+		'taxQuery' => [ 'taxonomy' => 'category', 'terms' => [ 3, 4 ], 'operator' => 'IN' ],
+	] )->assertOk();
+
+	expect( test()->fake->lastAttributes )->toMatchArray( [
+		'postType' => 'post',
+		'perPage'  => 5,
+		'orderBy'  => 'title',
+		'order'    => 'asc',
+	] );
+	expect( test()->fake->lastAttributes['taxQuery']['terms'] )->toBe( [ 3, 4 ] );
+} );
+
+it( 'rejects an invalid orderBy value', function () {
+	actingResolver();
+
+	$this->postJson( '/visual-editor/api/query/resolve', [
+		'postType' => 'post',
+		'orderBy'  => 'whatever',
+	] )->assertUnprocessable();
+} );
+
+it( 'rejects perPage above the documented cap', function () {
+	actingResolver();
+
+	$this->postJson( '/visual-editor/api/query/resolve', [
+		'postType' => 'post',
+		'perPage'  => 9999,
+	] )->assertUnprocessable();
+} );
+
+it( 'returns 400 when the resolver throws', function () {
+	actingResolver();
+
+	$throwingFake = new class extends FakeQueryResolver {
+		public function resolve( array $attributes ): \Illuminate\Contracts\Pagination\LengthAwarePaginator
+		{
+			throw new \InvalidArgumentException( 'unknown post type' );
+		}
+	};
+
+	$this->app->instance( QueryResolverContract::class, $throwingFake );
+
+	$this->postJson( '/visual-editor/api/query/resolve', [
+		'postType' => 'something-unregistered',
+	] )
+		->assertStatus( 400 )
+		->assertJsonPath( 'message', 'Failed to resolve the query payload.' );
+} );

--- a/tests/Fixtures/FakeQueryResolver.php
+++ b/tests/Fixtures/FakeQueryResolver.php
@@ -1,0 +1,54 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace Tests\Fixtures;
+
+use ArtisanPackUI\VisualEditor\Services\QueryResolverContract;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Pagination\LengthAwarePaginator as ConcretePaginator;
+
+/**
+ * Test fake for {@see QueryResolverContract} so the visual-editor test
+ * suite can exercise the controller + inliner without depending on
+ * cms-framework's `QueryRuntime` at the autoload level.
+ *
+ * Configure with `setItems()` (the rows the next `resolve()` returns)
+ * and inspect `$lastAttributes` to assert on what the consumer passed.
+ */
+class FakeQueryResolver implements QueryResolverContract
+{
+	/** @var array<int, mixed> */
+	public array $items = [];
+
+	public int $perPage = 10;
+
+	public int $currentPage = 1;
+
+	public ?int $totalOverride = null;
+
+	/** @var array<string, mixed>|null */
+	public ?array $lastAttributes = null;
+
+	/** @param array<int, mixed> $items */
+	public function setItems( array $items ): self
+	{
+		$this->items = $items;
+
+		return $this;
+	}
+
+	public function resolve( array $attributes ): LengthAwarePaginator
+	{
+		$this->lastAttributes = $attributes;
+
+		$total = $this->totalOverride ?? count( $this->items );
+
+		return new ConcretePaginator(
+			$this->items,
+			$total,
+			$this->perPage,
+			$this->currentPage
+		);
+	}
+}

--- a/tests/Unit/VisualEditor/EnabledBlockNamesTest.php
+++ b/tests/Unit/VisualEditor/EnabledBlockNamesTest.php
@@ -59,6 +59,8 @@ it( 'returns the frozen V1 block allow-list under the default config', function 
 		'core/categories',
 		'core/tag-cloud',
 		'core/archives',
+		'core/query',
+		'core/post-template',
 		'artisanpack/callout',
 	] );
 } );

--- a/tests/Unit/VisualEditor/Resources/PostResolverTest.php
+++ b/tests/Unit/VisualEditor/Resources/PostResolverTest.php
@@ -5,14 +5,24 @@ declare( strict_types=1 );
 use ArtisanPackUI\VisualEditor\Resources\PostResolver;
 use Illuminate\Support\Carbon;
 
+beforeEach( function (): void {
+	// Pin the locale to English so `translatedFormat( 'F j, Y' )`
+	// produces "April 20, 2026" regardless of the host's default
+	// locale; tests assert the exact English month name.
+	Carbon::setLocale( 'en' );
+} );
+
 function fakePost( array $overrides = [] ): object
 {
 	$post                    = new stdClass();
 	$post->title             = 'Hello world';
 	$post->content           = '<p>Body.</p>';
 	$post->excerpt           = 'A brief excerpt';
-	$post->published_at      = Carbon::create( 2026, 4, 20, 12 );
-	$post->updated_at        = Carbon::create( 2026, 4, 21, 9 );
+	// Pin the timezone to UTC so `toIso8601String()` always emits
+	// `+00:00`; tests assert the literal offset and would otherwise
+	// be flaky on machines whose `date.timezone` differs.
+	$post->published_at      = Carbon::create( 2026, 4, 20, 12, 0, 0, 'UTC' );
+	$post->updated_at        = Carbon::create( 2026, 4, 21, 9, 0, 0, 'UTC' );
 	$post->permalink         = 'https://example.test/posts/hello';
 	$post->author            = (object) [
 		'name'        => 'Jane Doe',

--- a/tests/Unit/VisualEditor/Resources/PostResolverTest.php
+++ b/tests/Unit/VisualEditor/Resources/PostResolverTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Resources\PostResolver;
+use Illuminate\Support\Carbon;
+
+function fakePost( array $overrides = [] ): object
+{
+	$post                    = new stdClass();
+	$post->title             = 'Hello world';
+	$post->content           = '<p>Body.</p>';
+	$post->excerpt           = 'A brief excerpt';
+	$post->published_at      = Carbon::create( 2026, 4, 20, 12 );
+	$post->updated_at        = Carbon::create( 2026, 4, 21, 9 );
+	$post->permalink         = 'https://example.test/posts/hello';
+	$post->author            = (object) [
+		'name'        => 'Jane Doe',
+		'bio'         => 'Writer',
+		'url'         => 'https://example.test/jane',
+		'avatar_url'  => 'https://example.test/avatar.jpg',
+	];
+	$post->featured_image_id = null;
+
+	foreach ( $overrides as $key => $value ) {
+		$post->{$key} = $value;
+	}
+
+	return $post;
+}
+
+it( 'stamps post-title attributes', function () {
+	$resolved = ( new PostResolver() )->stampBlock(
+		[ 'name' => 'core/post-title', 'attributes' => [], 'innerBlocks' => [] ],
+		fakePost()
+	);
+
+	expect( $resolved['attributes']['_resolvedTitle'] )->toBe( 'Hello world' )
+		->and( $resolved['attributes']['_resolvedPermalink'] )->toBe( 'https://example.test/posts/hello' );
+} );
+
+it( 'stamps post-content attributes', function () {
+	$resolved = ( new PostResolver() )->stampBlock(
+		[ 'name' => 'core/post-content', 'attributes' => [], 'innerBlocks' => [] ],
+		fakePost()
+	);
+
+	expect( $resolved['attributes']['_resolvedContent'] )->toBe( '<p>Body.</p>' );
+} );
+
+it( 'stamps post-excerpt attributes', function () {
+	$resolved = ( new PostResolver() )->stampBlock(
+		[ 'name' => 'core/post-excerpt', 'attributes' => [], 'innerBlocks' => [] ],
+		fakePost()
+	);
+
+	expect( $resolved['attributes']['_resolvedExcerpt'] )->toBe( 'A brief excerpt' )
+		->and( $resolved['attributes']['_resolvedPermalink'] )->toBe( 'https://example.test/posts/hello' );
+} );
+
+it( 'stamps post-date attributes including modified date', function () {
+	$resolved = ( new PostResolver() )->stampBlock(
+		[ 'name' => 'core/post-date', 'attributes' => [], 'innerBlocks' => [] ],
+		fakePost()
+	);
+
+	expect( $resolved['attributes']['_resolvedDate'] )->toBe( '2026-04-20T12:00:00+00:00' )
+		->and( $resolved['attributes']['_resolvedDateFormatted'] )->toBe( 'April 20, 2026' )
+		->and( $resolved['attributes']['_resolvedModifiedDate'] )->toBe( '2026-04-21T09:00:00+00:00' )
+		->and( $resolved['attributes']['_resolvedModifiedDateFormatted'] )->toBe( 'April 21, 2026' );
+} );
+
+it( 'stamps post-author attributes from the loaded relation', function () {
+	$resolved = ( new PostResolver() )->stampBlock(
+		[ 'name' => 'core/post-author', 'attributes' => [], 'innerBlocks' => [] ],
+		fakePost()
+	);
+
+	expect( $resolved['attributes']['_resolvedAuthorName'] )->toBe( 'Jane Doe' )
+		->and( $resolved['attributes']['_resolvedAuthorBio'] )->toBe( 'Writer' )
+		->and( $resolved['attributes']['_resolvedAuthorUrl'] )->toBe( 'https://example.test/jane' )
+		->and( $resolved['attributes']['_resolvedAuthorAvatar'] )->toBe( 'https://example.test/avatar.jpg' );
+} );
+
+it( 'leaves author fields empty when the relation is not loaded', function () {
+	$resolved = ( new PostResolver() )->stampBlock(
+		[ 'name' => 'core/post-author', 'attributes' => [], 'innerBlocks' => [] ],
+		fakePost( [ 'author' => null ] )
+	);
+
+	expect( $resolved['attributes']['_resolvedAuthorName'] )->toBe( '' )
+		->and( $resolved['attributes']['_resolvedAuthorBio'] )->toBe( '' );
+} );
+
+it( 'preserves pre-existing _resolved attributes on a block', function () {
+	$resolved = ( new PostResolver() )->stampBlock(
+		[
+			'name'        => 'core/post-title',
+			'attributes'  => [ '_resolvedTitle' => 'Host override' ],
+			'innerBlocks' => [],
+		],
+		fakePost()
+	);
+
+	expect( $resolved['attributes']['_resolvedTitle'] )->toBe( 'Host override' );
+} );
+
+it( 'recurses into innerBlocks', function () {
+	$tree = [
+		'name'        => 'core/group',
+		'attributes'  => [],
+		'innerBlocks' => [
+			[ 'name' => 'core/post-title', 'attributes' => [], 'innerBlocks' => [] ],
+		],
+	];
+
+	$resolved = ( new PostResolver() )->stampBlock( $tree, fakePost() );
+
+	expect( $resolved['innerBlocks'][0]['attributes']['_resolvedTitle'] )->toBe( 'Hello world' );
+} );
+
+it( 'leaves non-post-context blocks untouched', function () {
+	$resolved = ( new PostResolver() )->stampBlock(
+		[ 'name' => 'core/paragraph', 'attributes' => [ 'content' => 'untouched' ], 'innerBlocks' => [] ],
+		fakePost()
+	);
+
+	expect( $resolved['attributes'] )->toBe( [ 'content' => 'untouched' ] );
+} );

--- a/tests/Unit/VisualEditor/Resources/QueryInlinerTest.php
+++ b/tests/Unit/VisualEditor/Resources/QueryInlinerTest.php
@@ -1,0 +1,170 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Resources\PostResolver;
+use ArtisanPackUI\VisualEditor\Resources\QueryInliner;
+use ArtisanPackUI\VisualEditor\Services\QueryResolverContract;
+use Tests\Fixtures\FakeQueryResolver;
+
+function makeQueryBlock( array $template = [], array $queryAttrs = [ 'postType' => 'post', 'perPage' => 3 ] ): array
+{
+	return [
+		'name'        => 'core/query',
+		'attributes'  => [ 'query' => $queryAttrs ],
+		'innerBlocks' => [
+			[
+				'name'        => 'core/post-template',
+				'attributes'  => [],
+				'innerBlocks' => $template,
+			],
+		],
+	];
+}
+
+function postFixture( int $id, string $title ): object
+{
+	$post                    = new stdClass();
+	$post->id                = $id;
+	$post->title             = $title;
+	$post->content           = "<p>Body for {$title}.</p>";
+	$post->permalink         = "/posts/{$id}";
+	$post->author            = null;
+	$post->published_at      = null;
+	$post->updated_at        = null;
+	$post->featured_image_id = null;
+
+	return $post;
+}
+
+beforeEach( function (): void {
+	$this->fake = new FakeQueryResolver();
+	$this->app->instance( QueryResolverContract::class, $this->fake );
+
+	$this->inliner = new QueryInliner( $this->app, new PostResolver() );
+} );
+
+it( 'expands core/query into one post-template instance per result', function () {
+	$this->fake->setItems( [ postFixture( 1, 'First' ), postFixture( 2, 'Second' ) ] );
+
+	$tree = [ makeQueryBlock( [
+		[ 'name' => 'core/post-title', 'attributes' => [], 'innerBlocks' => [] ],
+	] ) ];
+
+	$inlined = $this->inliner->inline( $tree );
+
+	$query = $inlined[0];
+
+	expect( $query['name'] )->toBe( 'core/query' )
+		->and( count( $query['innerBlocks'] ) )->toBe( 2 )
+		->and( $query['innerBlocks'][0]['name'] )->toBe( 'core/post-template' )
+		->and( $query['innerBlocks'][0]['innerBlocks'][0]['attributes']['_resolvedTitle'] )->toBe( 'First' )
+		->and( $query['innerBlocks'][1]['innerBlocks'][0]['attributes']['_resolvedTitle'] )->toBe( 'Second' );
+} );
+
+it( 'forwards the nested query attribute payload to the resolver', function () {
+	$tree = [ makeQueryBlock( [], [
+		'postType' => 'page',
+		'perPage'  => 5,
+		'orderBy'  => 'title',
+	] ) ];
+
+	$this->inliner->inline( $tree );
+
+	expect( $this->fake->lastAttributes )->toBe( [
+		'postType' => 'page',
+		'perPage'  => 5,
+		'orderBy'  => 'title',
+	] );
+} );
+
+it( 'falls back to top-level attributes when query is not nested', function () {
+	$tree = [
+		[
+			'name'        => 'core/query',
+			'attributes'  => [ 'postType' => 'post', 'perPage' => 2 ],
+			'innerBlocks' => [],
+		],
+	];
+
+	$this->inliner->inline( $tree );
+
+	expect( $this->fake->lastAttributes )->toBe( [ 'postType' => 'post', 'perPage' => 2 ] );
+} );
+
+it( 'marks core/query with _resolutionError when no resolver is bound', function () {
+	$this->app->forgetInstance( QueryResolverContract::class );
+	$this->app->offsetUnset( QueryResolverContract::class );
+
+	$tree = [ makeQueryBlock() ];
+	$inlined = $this->inliner->inline( $tree );
+
+	expect( $inlined[0]['attributes']['_resolutionError'] )->toBe( QueryInliner::ERROR_NO_RUNTIME )
+		->and( $inlined[0]['innerBlocks'] )->toBe( [] );
+} );
+
+it( 'marks core/query with _resolutionError when the resolver throws', function () {
+	$throwingFake = new class extends FakeQueryResolver {
+		public function resolve( array $attributes ): \Illuminate\Contracts\Pagination\LengthAwarePaginator
+		{
+			throw new \RuntimeException( 'boom' );
+		}
+	};
+	$this->app->instance( QueryResolverContract::class, $throwingFake );
+	$this->inliner = new QueryInliner( $this->app, new PostResolver() );
+
+	$tree = [ makeQueryBlock() ];
+	$inlined = $this->inliner->inline( $tree );
+
+	expect( $inlined[0]['attributes']['_resolutionError'] )->toBe( QueryInliner::ERROR_RESOLVER_ERROR );
+} );
+
+it( 'leaves the inner blocks empty when the result set is empty', function () {
+	$tree = [ makeQueryBlock( [
+		[ 'name' => 'core/post-title', 'attributes' => [], 'innerBlocks' => [] ],
+	] ) ];
+
+	$inlined = $this->inliner->inline( $tree );
+
+	expect( $inlined[0]['innerBlocks'] )->toBe( [] )
+		->and( $inlined[0]['attributes']['_resolvedTotal'] )->toBe( 0 );
+} );
+
+it( 'recurses into nested queries', function () {
+	$this->fake->setItems( [ postFixture( 1, 'Outer' ) ] );
+
+	$inner = [
+		'name'        => 'core/group',
+		'attributes'  => [],
+		'innerBlocks' => [
+			makeQueryBlock( [
+				[ 'name' => 'core/post-title', 'attributes' => [], 'innerBlocks' => [] ],
+			] ),
+		],
+	];
+
+	$inlined = $this->inliner->inline( [ $inner ] );
+
+	// The outer wrapper passes through; the nested core/query gets
+	// its own expansion pass.
+	$nestedQuery = $inlined[0]['innerBlocks'][0];
+
+	expect( $nestedQuery['name'] )->toBe( 'core/query' )
+		->and( count( $nestedQuery['innerBlocks'] ) )->toBe( 1 );
+} );
+
+it( 'deep-clones the template subtree per result so mutations do not leak', function () {
+	$this->fake->setItems( [ postFixture( 1, 'A' ), postFixture( 2, 'B' ) ] );
+
+	$tree = [ makeQueryBlock( [
+		[ 'name' => 'core/post-title', 'attributes' => [], 'innerBlocks' => [] ],
+	] ) ];
+
+	$inlined = $this->inliner->inline( $tree );
+
+	$first  = $inlined[0]['innerBlocks'][0]['innerBlocks'][0];
+	$second = $inlined[0]['innerBlocks'][1]['innerBlocks'][0];
+
+	expect( $first['attributes']['_resolvedTitle'] )->toBe( 'A' )
+		->and( $second['attributes']['_resolvedTitle'] )->toBe( 'B' );
+} );


### PR DESCRIPTION
## Description

Build the visual-editor half of the V1 loop runtime. cms-framework's `QueryRuntime` (G4c-1, ArtisanPack-UI/cms-framework#97) lands the SQL side; this commit ships the orchestration on top — the REST endpoint, the server-side `QueryInliner` that walks the saved tree, the `PostResolver` that stamps `_resolved*` keys onto inner `core/post-*` blocks, the React + Vue equivalents for client-side hosts, and the editor-canvas preview wiring.

**Closes:** #402

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #402

## Motivation and Context

#402 is the last open Wave 4 issue from plan 12 §2.5. It depends on:

- ArtisanPack-UI/cms-framework#97 (G4c-1, merged) — the `QueryRuntime` service.
- #401 (G4b, merged) — taxonomy/feed widgets.
- #399 (G3) + #395 (G0) — entity adapter + shim auto-resolution.

## Changes Made

### Backend (PHP)

- New `POST /visual-editor/api/query/resolve` endpoint (`QueryResolveController`).
- `QueryResolverContract` interface owned by visual-editor.
- `CmsFrameworkQueryResolver` adapter that wraps cms-framework's `QueryRuntime`. Bound by `VisualEditorServiceProvider::register()` only when the upstream class is on the autoloader.
- `PostResolver` — pure-data service mapping a single post to the `_resolved*` keys for every supported `core/post-*` block.
- `QueryInliner` — sibling to `TemplatePartInliner`/`PatternInliner`. Walks the saved tree, replaces every `core/query` with one stamped copy of its inner blocks per result. Plumbed into `BlocksComponent` after the existing inliners.
- `QueryResolveRequest` form request validates the V1 attribute subset (`postType`, `perPage`, `pages`, `offset`, `postIn`/`postNotIn`/`exclude`, `parents`, `orderBy`/`order`, `author`, `search`, `taxQuery` `IN`-only).

### React + Vue renderers

- New `queries.ts` in each package — TS port of the inliner keyed by `queryId`. Hosts pre-fetch results server-side and pass them via the new `queryResults` prop on `<BlockTree>` / its Vue analog.
- `core/query` + `core/post-template` block renderers in each package. Both operate on the already-expanded tree and just emit wrapper markup; the loop expansion is owned by `inlineQueries`.

### Editor canvas

- `useQueryPreview` hook — POSTs to `/query/resolve` with debounce + abort, includes the `X-CSRF-TOKEN` header from the page meta, strips upstream `core/query` empty-default placeholders (e.g. `author: ''`, `taxQuery: ''`) before posting so server validation sees only user-configured fields. `pages: 0` survives since `QueryRuntime` treats it as the "no cap" sentinel.
- `core/query` Edit override (`blocks.registerBlockType` filter, namespace-scoped). Wipes upstream `variations` / `transforms` / `__experimentalLabel` (whose toolbar/picker chrome calls `getTaxonomies({per_page: -1})` — selectors the M2 shim does not implement). Pushes the first matching post's id into `BlockContextProvider` so inner `core/post-*` blocks resolve via G3's entity adapter.
- `core/post-template` Edit override — replaces upstream's "fetch entity records and iterate" with a simple `<InnerBlocks template={[['core/post-title']]} />` shell so authors can build the per-iteration template.

### Cleanup

- `core/query` and `core/post-template` promoted out of `disabled_blocks` (PHP + JS mirror); audit doc updated with the new G4c-2 architecture section.
- `EnabledBlockNamesTest` snapshot updated.

## How Has This Been Tested?

**Testing Environment:**
- macOS 25.4.0
- Safari (dev app via Laravel Herd)
- PHP 8.4.3
- Branch: `release/1.0`

**Tests Performed:**

1. `./vendor/bin/pest --compact` — 511 passed (1 pre-existing skip), 1585 assertions.
2. `npm test --run` — 985 passed (1 pre-existing skip).
3. **Manual smoke flow in dev app:**
   - Insert `core/query` block, configure (postType + perPage), see "Posts matched: N" in inspector.
   - Add `core/post-title` inside `core/post-template` — populates with first matching post's title.
   - Save and view public page — Blade renderer expands the query into N iterations, each with its own post's data.
4. **CodeRabbit:** three-pass local review (`cr review --base release/1.0 --prompt-only`):
   - Pass 1: two findings on the unrelated `15-issue-roadmap.md` doc — rejected (not part of this PR's scope).
   - Pass 2: three findings on actual #402 surface — applied:
     - `_resolvedDateFormatted` was returning raw ISO instead of human-readable on JS sides → wrapped in `Intl.DateTimeFormat` to match the PHP side's `Carbon::translatedFormat('F j, Y')`.
     - `fetchOptions` in `useEffect` deps could infinite-loop with inline literals → moved to `useRef` with JSDoc note.
     - `Promise.resolve().then(setAttributes)` during render → moved to `useEffect`.
   - Pass 3: clean.

### Manual debug history during the manual-test loop

The debugging the manual test surfaced (and we fixed in-loop):

1. **Vite cache staleness** — needed to flush `node_modules/.vite` after touching both editor entries (same as the #401 manual-test loop).
2. **CSRF token mismatch** on the preview fetch — `useQueryPreview` now reads the same `<meta name="csrf-token">` as `api-client.ts`.
3. **`getTaxonomies` crash on block selection** — caused by upstream `core/query`'s `variations` rendering a thumbnail picker. Wiped via the registerBlockType filter.
4. **Validation rejecting upstream defaults** — `pages: 0`/`author: ''`/`taxQuery: ''`/etc. now stripped client-side; `pages: min:0` accepted server-side.
5. **"No posts found" inside `core/post-template`** — the upstream Edit was running its own entity-records fetch and disabling InnerBlocks. Solved by adding the `core/post-template` Edit override.

## Tests Added

- [x] Unit + integration tests added/updated
- [x] All tests passing

**Test details:**

- **PHP unit (16 cases):**
  - `PostResolverTest` — 9 cases covering each `core/post-*` block's stamped attribute set, the recursive walker, the host-override-wins ordering, and the non-post-context untouched path.
  - `QueryInlinerTest` — 7 cases covering per-result expansion, nested-query recursion, the `_resolutionError` fallbacks (no runtime / resolver throw / empty result), the pre-existing `_resolved*` preservation contract, and the deep-clone-per-result invariant.
- **PHP feature (8 cases):**
  - `QueryResolveControllerTest` — 7 cases (auth, 503 when unbound, paginated WP-shape envelope, payload forwarding, validation rejections, resolver-throws → 400).
  - `CoreQueryRenderingTest` — 2 cases proving the full Blade pipeline (N results → N rendered iterations with stamped permalinks).
- **JS / vitest (15 cases):**
  - `queries.test.ts` × React + Vue (5 each) — expansion shape, `_resolutionError` fallback, post-context stamping per supported block, recursion into nested queries, host-override preservation.
  - `use-query-preview.test.tsx` (5 cases) — idle, ready with mapped posts, error path on non-2xx, CSRF header attachment, payload empty-default stripping.

## Documentation

- [x] Inline code documentation added
- [x] Audit doc updated

**Documentation details:**

- Class- and method-level PHPDoc on `QueryInliner`, `PostResolver`, `QueryResolverContract`, `CmsFrameworkQueryResolver`, `QueryResolveController`, and `QueryResolveRequest` covering the V1 attribute subset, the failure-mode shape, and the binding gate.
- TS comments on `inlineQueries`, `useQueryPreview`, and the two block-Edit overrides explaining the upstream incompatibilities each one works around.
- New "Query loop — re-enabled against cms-framework's QueryRuntime (G4c-2)" subsection in `docs/block-library-audit.md` covering the architecture (inliner + resolver + contract + adapter), the four-surface render path, and the deferred-blocks list.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Code passes all tests
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Re-enable Query and Post Template blocks in the visual editor with runtime-backed expansion, editor preview, and overridden editor UI for live previews.
  * Client and renderer support to inline resolved query results for React, Vue, and Blade previews.
  * New server endpoint to resolve queries for editor previews with pluggable resolver support.

* **Documentation**
  * Expanded docs covering the query loop, preview/resolve flow, restrictions, and known V1 limitations.

* **Tests**
  * New unit and integration tests for inlining, preview hook, rendering, and controller behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->