### PR TITLE
chore: rename V2 block-fork phases H{N} → I{N}

### DIFF
--- a/docs/plans/13-block-fork.md
+++ b/docs/plans/13-block-fork.md
@@ -138,7 +138,7 @@ Phase I — Block fork (V2)
            release.
 
   Ship
-    I8   v2.0.0-alpha.1 → v2.0.0-beta.1 → v2.0.0.
+    I8   v2.0.0-alpha.2 → v2.0.0-beta.1 → v2.0.0.
          Beta tag at end of I6 once all forks are landed but before
          cutover; GA after I7 has a soak window in the dev-app.
 ```

--- a/docs/plans/13-block-fork.md
+++ b/docs/plans/13-block-fork.md
@@ -75,12 +75,12 @@ The set of upstream blocks to fork is the union of (a) the current `enabled_bloc
 ## 3. Phase ordering
 
 ```
-Phase H — Block fork (V2)
+Phase I — Block fork (V2)
 
   Pilot (sequential)
-    H0   Paragraph pilot.
+    I0   Paragraph pilot.
          - Fork core/paragraph → artisanpack/paragraph end-to-end.
-         - Branch: feature/H0-paragraph-pilot off main (NOT release/2.0).
+         - Branch: feature/I0-paragraph-pilot off main (NOT release/2.0).
          - Validate block.json, edit, save, deprecations, i18n.
          - Identify shared primitives that need to be vendored
            alongside the block (icons, SCSS utilities, shared
@@ -91,20 +91,20 @@ Phase H — Block fork (V2)
          - Produce a real cost estimate in engineer-days for the
            remaining 41 blocks.
 
-  Cluster milestones (parallelizable after H0)
-    H1   Content cluster (8 blocks):
+  Cluster milestones (parallelizable after I0)
+    I1   Content cluster (8 blocks):
          heading, list, quote, code, preformatted, pullquote, verse, table.
-    H2   Media cluster (8 blocks):
+    I2   Media cluster (8 blocks):
          image, gallery, video, audio, file, embed, cover, media-text.
          Coordinates with the media-bridge contract (host-app
          MediaUpload registration). No bridge changes; the forks
          consume the same registered MediaUpload component.
-    H3   Layout cluster (8 logical blocks, 6 source units):
+    I3   Layout cluster (8 logical blocks, 6 source units):
          columns, group (+row, +stack variations), buttons,
          separator, spacer, details.
-    H4   Widgets cluster (2 blocks):
+    I4   Widgets cluster (2 blocks):
          search, latest-posts.
-    H5   Entity cluster (11 blocks): template-part, post-title,
+    I5   Entity cluster (11 blocks): template-part, post-title,
          post-content, post-excerpt, post-date, post-author,
          post-featured-image, site-title, site-tagline, site-logo,
          navigation.
@@ -113,14 +113,14 @@ Phase H — Block fork (V2)
          These forks read entity data through the same
          useEntityRecord / useEntityRecords surface the upstream
          blocks use — no API change required.
-    H6   Loop / feed cluster (5 blocks):
+    I6   Loop / feed cluster (5 blocks):
          archives, categories, tag-cloud, query, query-loop.
          Hard-couples to plan 12 G4b / G4c — does not start until
          cms-framework's term endpoints (G4b) and QueryRuntime
          service (G4c) are tagged in a cms-framework release.
 
   Cutover (sequential, after all clusters)
-    H7   - Drop registerCoreBlocks() from
+    I7   - Drop registerCoreBlocks() from
            resources/js/visual-editor/editor/editor-app.tsx
            and resources/js/visual-editor/site-editor/site-editor-app.tsx.
          - Replace with the artisanpack/* registration entrypoint.
@@ -138,14 +138,14 @@ Phase H — Block fork (V2)
            release.
 
   Ship
-    H8   v2.0.0-alpha.1 → v2.0.0-beta.1 → v2.0.0.
-         Beta tag at end of H6 once all forks are landed but before
-         cutover; GA after H7 has a soak window in the dev-app.
+    I8   v2.0.0-alpha.1 → v2.0.0-beta.1 → v2.0.0.
+         Beta tag at end of I6 once all forks are landed but before
+         cutover; GA after I7 has a soak window in the dev-app.
 ```
 
-**Critical path:** H0 → (any one cluster) → H6 → H7. H6 cannot start until cms-framework's V1.x release tagged with G4b/G4c is published.
+**Critical path:** I0 → (any one cluster) → I6 → I7. I6 cannot start until cms-framework's V1.x release tagged with G4b/G4c is published.
 
-**Rough duration:** the H0 pilot's cost estimate refines this. Provisional budget — 1 week pilot, 1.5–2 weeks per cluster (six clusters), 1 week cutover. ~10–12 engineer-weeks total assuming clusters parallelize across two people; ~16–18 weeks single-engineer. Lock the real number after H0.
+**Rough duration:** the I0 pilot's cost estimate refines this. Provisional budget — 1 week pilot, 1.5–2 weeks per cluster (six clusters), 1 week cutover. ~10–12 engineer-weeks total assuming clusters parallelize across two people; ~16–18 weeks single-engineer. Lock the real number after I0.
 
 ---
 
@@ -183,13 +183,13 @@ packages/visual-editor-renderer-vue/src/blocks/artisanpack/paragraph.ts
 Every fork ships a `transforms.ts` with both directions:
 
 - `from: { type: 'block', blocks: ['core/paragraph'] }` — converts a `core/paragraph` block instance to `artisanpack/paragraph` losslessly. Lets host apps with mid-V1 content (if any persisted before V2 ships) upgrade by pasting / re-inserting.
-- `to: { type: 'block', blocks: ['core/paragraph'] }` — round-trip, in case the user wants to drop back. Removed at H7 cutover when `core/paragraph` is no longer registered.
+- `to: { type: 'block', blocks: ['core/paragraph'] }` — round-trip, in case the user wants to drop back. Removed at I7 cutover when `core/paragraph` is no longer registered.
 
-The transforms cover the no-migration window's edge case: existing host-app content that may have hit `core/*` names. The Artisan command in §2.1 is the bulk-conversion fallback if the window closes before H7.
+The transforms cover the no-migration window's edge case: existing host-app content that may have hit `core/*` names. The Artisan command in §2.1 is the bulk-conversion fallback if the window closes before I7.
 
 ### 4.3 Upstream-diff workflow
 
-This is the maintenance commitment we take on at H7 — and the one most likely to rot if we don't bake a workflow at H0.
+This is the maintenance commitment we take on at I7 — and the one most likely to rot if we don't bake a workflow at I0.
 
 **Tooling:** a `scripts/upstream-diff.ts` CLI in this package that takes a block name and a target upstream `@wordpress/block-library` version. It:
 
@@ -207,18 +207,18 @@ This is the maintenance commitment we take on at H7 — and the one most likely 
 
 `upstream-state.json` keeps the per-block decision log — what we last reviewed, what we ported, what we skipped, what we superseded. When the next bump lands, the diff baseline is the recorded version, not the previous live `node_modules` version.
 
-**Documented in:** `docs/block-fork-workflow.md` (created in H0). Keeping the workflow doc in the package, not just in the team handbook, means it travels with the source.
+**Documented in:** `docs/block-fork-workflow.md` (created in I0). Keeping the workflow doc in the package, not just in the team handbook, means it travels with the source.
 
 ### 4.4 Vendored shared primitives
 
 `@wordpress/block-library` is not a flat directory of self-contained blocks. Many blocks `import` from `@wordpress/block-library/src/utils/`, `@wordpress/block-library/src/components/`, or sibling block folders (`core/list-item` imports from `core/list/utils.ts`, etc.). Forking a single block without those primitives produces broken imports.
 
-The H0 pilot enumerates the primitives `core/paragraph` actually imports, then we make a per-primitive call:
+The I0 pilot enumerates the primitives `core/paragraph` actually imports, then we make a per-primitive call:
 
 - **Vendor** — copy the primitive into `resources/js/visual-editor/blocks/_shared/` if it is genuinely block-library-private and not exported from a public `@wordpress/*` package.
 - **Re-import from public WP package** — if it is re-exported from `@wordpress/block-editor`, `@wordpress/components`, or `@wordpress/rich-text`, switch the import.
 
-By H6 we expect to have ~5–10 vendored primitives in `_shared/` covering the bulk of the entity blocks' bridge code. The pilot's deliverable includes the first iteration of this directory.
+By I6 we expect to have ~5–10 vendored primitives in `_shared/` covering the bulk of the entity blocks' bridge code. The pilot's deliverable includes the first iteration of this directory.
 
 ### 4.5 Block re-registration sequencing
 
@@ -233,15 +233,15 @@ export function registerArtisanPackBlocks(): void {
 }
 ```
 
-Both editor bootstraps (`editor-app.tsx`, `site-editor-app.tsx`) call `registerArtisanPackBlocks()` instead of `registerCoreBlocks()` at H7. During the cluster phases (H1–H6), forked blocks register **alongside** their `core/*` counterparts so reviewers can A/B them in the dev-app — the inserter will show duplicates, gated behind a `?fork=on` query flag in the dev-app router. Production host apps continue to see `core/*` only until H7.
+Both editor bootstraps (`editor-app.tsx`, `site-editor-app.tsx`) call `registerArtisanPackBlocks()` instead of `registerCoreBlocks()` at I7. During the cluster phases (I1–I6), forked blocks register **alongside** their `core/*` counterparts so reviewers can A/B them in the dev-app — the inserter will show duplicates, gated behind a `?fork=on` query flag in the dev-app router. Production host apps continue to see `core/*` only until I7.
 
-### 4.6 Coordination with cms-framework (H5 / H6)
+### 4.6 Coordination with cms-framework (I5 / I6)
 
-**H5 — entity cluster.** The forked entity blocks (`artisanpack/post-*`, `artisanpack/site-*`, `artisanpack/template-part`, `artisanpack/navigation`) read entity records through the same `useEntityRecord` / `useEntityRecords` selectors the upstream blocks use. Plan 12 G0 (#395) plus G3 already wire those entities through `dispatch('core').addEntities(...)` — the forks inherit the wiring. No change to the cms-framework adapter.
+**I5 — entity cluster.** The forked entity blocks (`artisanpack/post-*`, `artisanpack/site-*`, `artisanpack/template-part`, `artisanpack/navigation`) read entity records through the same `useEntityRecord` / `useEntityRecords` selectors the upstream blocks use. Plan 12 G0 (#395) plus G3 already wire those entities through `dispatch('core').addEntities(...)` — the forks inherit the wiring. No change to the cms-framework adapter.
 
-**H6 — loop / feed cluster.** `artisanpack/query` and `artisanpack/query-loop` call into cms-framework's `QueryRuntime` (plan 12 G4c) via the same `POST /visual-editor/api/query/resolve` endpoint and Blade direct-call seam the upstream blocks use. The fork is contract-stable against G4c — no QueryRuntime API changes needed for the fork.
+**I6 — loop / feed cluster.** `artisanpack/query` and `artisanpack/query-loop` call into cms-framework's `QueryRuntime` (plan 12 G4c) via the same `POST /visual-editor/api/query/resolve` endpoint and Blade direct-call seam the upstream blocks use. The fork is contract-stable against G4c — no QueryRuntime API changes needed for the fork.
 
-**H6 — feed widgets.** `artisanpack/archives`, `artisanpack/categories`, `artisanpack/tag-cloud` consume cms-framework's existing term endpoints (`/api/post-categories`, `/api/post-tags`, `/api/page-categories`, `/api/page-tags`) per plan 12 G4b. Same contract; the fork inherits.
+**I6 — feed widgets.** `artisanpack/archives`, `artisanpack/categories`, `artisanpack/tag-cloud` consume cms-framework's existing term endpoints (`/api/post-categories`, `/api/post-tags`, `/api/page-categories`, `/api/page-tags`) per plan 12 G4b. Same contract; the fork inherits.
 
 The minimum-required cms-framework version for V2.0.0 is **the same** as for V1.0.0 plus whatever V1.x cms-framework release tags G4b and G4c. Document the version pair in V2.0.0 release notes per plan 12 §6.
 
@@ -251,7 +251,7 @@ The minimum-required cms-framework version for V2.0.0 is **the same** as for V1.
 
 ### 5.1 Maintenance debt compounds quietly
 
-41 forks × N upstream releases × M files per fork = a long tail of diff-and-port work. If the diff workflow rots — nobody triages the Renovate PR comments, `upstream-state.json` falls behind — the forks silently diverge from upstream a11y / security fixes. **Mitigation:** the H0 pilot ships the workflow doc *and* a CI job that fails the build if `upstream-state.json` is more than two minor versions behind the installed `@wordpress/block-library`. Forces the triage to happen on cadence.
+41 forks × N upstream releases × M files per fork = a long tail of diff-and-port work. If the diff workflow rots — nobody triages the Renovate PR comments, `upstream-state.json` falls behind — the forks silently diverge from upstream a11y / security fixes. **Mitigation:** the I0 pilot ships the workflow doc *and* a CI job that fails the build if `upstream-state.json` is more than two minor versions behind the installed `@wordpress/block-library`. Forces the triage to happen on cadence.
 
 ### 5.2 Block-library private API churn
 
@@ -267,11 +267,11 @@ The package ships three renderers — Blade, React, Vue. Each fork lands in all 
 
 ### 5.5 cms-framework version coupling tightens
 
-V1 already version-pairs visual-editor and cms-framework (plan 12 §5.5). V2 H6 hardens the pairing — if cms-framework's `QueryRuntime` API shifts post-G4c, the H6 forks break. **Mitigation:** the `QueryRuntime` PHP contract becomes a versioned interface (`ArtisanPackUI\CMSFramework\Contracts\QueryRuntime\V1`). cms-framework V2 introducing `V2` doesn't break our forks; we adopt `V2` as separate post-V2 work.
+V1 already version-pairs visual-editor and cms-framework (plan 12 §5.5). V2 I6 hardens the pairing — if cms-framework's `QueryRuntime` API shifts post-G4c, the I6 forks break. **Mitigation:** the `QueryRuntime` PHP contract becomes a versioned interface (`ArtisanPackUI\CMSFramework\Contracts\QueryRuntime\V1`). cms-framework V2 introducing `V2` doesn't break our forks; we adopt `V2` as separate post-V2 work.
 
 ### 5.6 No-migration window closes early
 
-§2.1 banks on V2 shipping within ~6 months of V1.0.0 GA. If V2 slips past that, host apps are persisting `core/*` block trees and our claim of "no stored content uses `core/*` names yet" no longer holds. **Mitigation:** the `wp:rename-blocks` Artisan command in §2.1 plus H7's cutover. Treated as an escape valve, not the primary plan.
+§2.1 banks on V2 shipping within ~6 months of V1.0.0 GA. If V2 slips past that, host apps are persisting `core/*` block trees and our claim of "no stored content uses `core/*` names yet" no longer holds. **Mitigation:** the `wp:rename-blocks` Artisan command in §2.1 plus I7's cutover. Treated as an escape valve, not the primary plan.
 
 ### 5.7 Diff fatigue across 41 blocks
 
@@ -281,28 +281,28 @@ Even with tooling, a human has to triage every Renovate-driven diff. With 41 for
 
 ## 6. Branching + release strategy
 
-- **Pilot branch:** `feature/H0-paragraph-pilot` cut from `main` per #331's pilot directive — V2 work does not gate on V1's `release/1.0` integration branch.
-- **Integration branch:** `release/2.0` cut from `main` once V1.0.0 is tagged. All H1–H7 work merges into `release/2.0`.
-- **Cluster branches:** `feature/H{n}-{cluster}` cut from + merged into `release/2.0`.
+- **Pilot branch:** `feature/I0-paragraph-pilot` cut from `main` per #331's pilot directive — V2 work does not gate on V1's `release/1.0` integration branch.
+- **Integration branch:** `release/2.0` cut from `main` once V1.0.0 is tagged. All I1–I7 work merges into `release/2.0`.
+- **Cluster branches:** `feature/I{n}-{cluster}` cut from + merged into `release/2.0`.
 - **Tags:**
-  - `v2.0.0-alpha.1` — at the end of H4 (content + media + layout + widgets clusters in).
-  - `v2.0.0-alpha.2` — at the end of H5 (entity cluster in).
-  - `v2.0.0-beta.1` — at the end of H6 (loop/feed cluster in; all forks landed; pre-cutover).
-  - `v2.0.0` — after H7 + dev-app soak.
+  - `v2.0.0-alpha.1` — at the end of I4 (content + media + layout + widgets clusters in).
+  - `v2.0.0-alpha.2` — at the end of I5 (entity cluster in).
+  - `v2.0.0-beta.1` — at the end of I6 (loop/feed cluster in; all forks landed; pre-cutover).
+  - `v2.0.0` — after I7 + dev-app soak.
 - `main` remains release-only; V2.0.0 merges back per existing workflow.
 
 ---
 
 ## 7. Issue tracking approach
 
-Following plan 11 §6 — create milestone-level tracking issues one phase at a time, as each phase kicks off. The cluster breakdown in §3 is provisional until the H0 pilot's cost estimate refines it; filing eight detailed cluster issues now produces stale tickets by the time H1 starts.
+Following plan 11 §6 — create milestone-level tracking issues one phase at a time, as each phase kicks off. The cluster breakdown in §3 is provisional until the I0 pilot's cost estimate refines it; filing eight detailed cluster issues now produces stale tickets by the time I1 starts.
 
-- **H0** — file as a single issue under #331 once V1.0.0 ships and the team commits to V2 kickoff.
-- **H1–H6** — one umbrella issue per cluster, filed at the start of each cluster's work. Each cluster issue spawns one child issue per block in the cluster as the cluster begins. Per-block issues have their own acceptance criteria covering edit/save parity, deprecations, transforms, three-renderer parity, and `__fixtures__` coverage.
-- **H7** — single cutover issue, filed at the start of H7.
+- **I0** — file as a single issue under #331 once V1.0.0 ships and the team commits to V2 kickoff.
+- **I1–I6** — one umbrella issue per cluster, filed at the start of each cluster's work. Each cluster issue spawns one child issue per block in the cluster as the cluster begins. Per-block issues have their own acceptance criteria covering edit/save parity, deprecations, transforms, three-renderer parity, and `__fixtures__` coverage.
+- **I7** — single cutover issue, filed at the start of I7.
 - **#331** stays open through the lifecycle; close only when v2.0.0 is tagged.
 
-`#338` (`core/search` `buttonUseIcon` a11y) is a V1 Phase F issue per plan 11 §6 and is unaffected by this plan — when `artisanpack/search` lands at H4, it inherits whatever fix V1 shipped.
+`#338` (`core/search` `buttonUseIcon` a11y) is a V1 Phase F issue per plan 11 §6 and is unaffected by this plan — when `artisanpack/search` lands at I4, it inherits whatever fix V1 shipped.
 
 ---
 
@@ -310,11 +310,11 @@ Following plan 11 §6 — create milestone-level tracking issues one phase at a 
 
 Not blocking this plan, but worth naming:
 
-- **H0 pilot location** — `feature/H0-paragraph-pilot` off `main` is per the issue body. Do we *also* land the pilot's `docs/block-fork-workflow.md` and `scripts/upstream-diff.ts` on `main` after H0 even if the rest of V2 stays on `release/2.0`? Leaning yes — the workflow doc is useful before V2 starts and not packaged into the published bundle.
-- **Vendored primitives directory naming** — `_shared/` (mirrors `_legacy/` precedent) vs `vendor/` (mirrors `core-data-shim` location at `resources/js/visual-editor/vendor/`). Settle at H0 once the actual primitives are visible.
+- **I0 pilot location** — `feature/I0-paragraph-pilot` off `main` is per the issue body. Do we *also* land the pilot's `docs/block-fork-workflow.md` and `scripts/upstream-diff.ts` on `main` after I0 even if the rest of V2 stays on `release/2.0`? Leaning yes — the workflow doc is useful before V2 starts and not packaged into the published bundle.
+- **Vendored primitives directory naming** — `_shared/` (mirrors `_legacy/` precedent) vs `vendor/` (mirrors `core-data-shim` location at `resources/js/visual-editor/vendor/`). Settle at I0 once the actual primitives are visible.
 - **Per-block customization budget** — at fork time, each block lands as byte-equivalent to upstream. When does post-fork customization (e.g. swapping `RichText` for Tiptap on `artisanpack/paragraph`) get scoped — alongside the fork or as a separate post-V2 backlog item per block? Leaning post-V2, scoped per block, so V2 itself stays a parity exercise.
-- **`@wordpress/block-library` final disposition** — devDependency for diff tooling, or removed entirely? The `scripts/upstream-diff.ts` workflow needs *some* path to upstream source. devDependency is the simpler answer; "remove and pull from a pinned tarball at CI time" is the smaller-attack-surface answer. Decide at H7.
-- **Style.scss / shared SCSS** — `@wordpress/block-library/src/style.scss` aggregates per-block styles and applies layout normalization. We'll need to fork the equivalent or rebuild. Cost surfaces at H0.
-- **i18n text-domain** — confirm `artisanpack-visual-editor` is the right text-domain for forked `__()` calls (vs reusing `default` or per-package domains). Settle at H0.
-- **Renderer parity manifest** — JSON file emitted by JS build, consumed by Blade (PHP) and Vue / React renderer build steps? Or a TS module that all three import? Decide at H4 once the cluster shape is concrete.
+- **`@wordpress/block-library` final disposition** — devDependency for diff tooling, or removed entirely? The `scripts/upstream-diff.ts` workflow needs *some* path to upstream source. devDependency is the simpler answer; "remove and pull from a pinned tarball at CI time" is the smaller-attack-surface answer. Decide at I7.
+- **Style.scss / shared SCSS** — `@wordpress/block-library/src/style.scss` aggregates per-block styles and applies layout normalization. We'll need to fork the equivalent or rebuild. Cost surfaces at I0.
+- **i18n text-domain** — confirm `artisanpack-visual-editor` is the right text-domain for forked `__()` calls (vs reusing `default` or per-package domains). Settle at I0.
+- **Renderer parity manifest** — JSON file emitted by JS build, consumed by Blade (PHP) and Vue / React renderer build steps? Or a TS module that all three import? Decide at I4 once the cluster shape is concrete.
 - **Block category labels** — upstream uses `text`, `media`, `design`, `widgets`, `theme`, `embed`. Do we keep those names under `artisanpack/*`, or rename to match the package's vocabulary? Leaning keep — host apps' inserter UI is built against the upstream category names and we don't want to invalidate that.

--- a/docs/plans/15-issue-roadmap.md
+++ b/docs/plans/15-issue-roadmap.md
@@ -1,0 +1,196 @@
+# Visual Editor — Issue Roadmap
+
+**Package:** `artisanpack-ui/visual-editor`
+**Created:** April 28, 2026
+**Status:** Active
+**Aggregates:** [`11-v1-expansion.md`](11-v1-expansion.md), [`12-cms-framework-integration.md`](12-cms-framework-integration.md), [`13-block-fork.md`](13-block-fork.md), [`14-cms-framework-site-editor-integration.md`](14-cms-framework-site-editor-integration.md)
+
+---
+
+## How to use this doc
+
+Single source of truth for issue ordering across V1 ship, V2 block fork, and 1.1+ deferred work. Pull this up before starting a new work session — the wave structure tells you what's safe to start now without re-deriving dependencies from the plan docs.
+
+When you say *"let's work on the next set of issues for the visual editor"*, read this file first, then verify with `gh issue view {number}` that the issue is still open (some may have closed since this doc was last edited).
+
+This doc captures **ordering**, not detailed acceptance criteria. Per-issue specifics live in each issue body and the source plan docs.
+
+---
+
+## 1. Critical-path summary
+
+```
+V1 ship (≈4–6 mo) ──→  V2 block fork (≈10–12 wk) ──→  1.1+ features
+   ▲
+   └── cms-framework V1.x (Phase G + Phase H backends, parallel)
+```
+
+V1 umbrella: [`#309`](https://github.com/ArtisanPack-UI/visual-editor/issues/309). V2 umbrella: [`#331`](https://github.com/ArtisanPack-UI/visual-editor/issues/331). Plan-14 site-editor umbrella: [`#406`](https://github.com/ArtisanPack-UI/visual-editor/issues/406).
+
+---
+
+## 2. Where to start right now
+
+If you opened this doc with no other context, start one of:
+
+1. **`#395`** (visual-editor) — G0 · core-data shim REST resolution. Unblocks the entire G-series.
+2. **`#94`** (cms-framework) — G1a · Adopt `HasBlockContent` on Post and Page. Same — unblocks G-series.
+
+These have no upstream dependencies and can run in parallel.
+
+---
+
+## 3. V1 ship — wave-by-wave
+
+### Wave 1 — Foundation
+
+| Issue | Repo | Title | Priority | Effort |
+|---|---|---|---|---|
+| `#395` | visual-editor | G0 · core-data shim REST resolution *(bug)* | High | Medium |
+| `#94` | cms-framework | G1a · Adopt `HasBlockContent` on Post and Page | High | Medium |
+
+### Wave 2 — Phase G resource bridge
+
+After Wave 1.
+
+| Issue | Repo | Title | Priority | Effort | Depends on |
+|---|---|---|---|---|---|
+| `#397` | visual-editor | G1b · `ap.visual-editor.resources` filter | High | Low | `#94` |
+| `#99` | cms-framework | G1b' · Register Post/Page into filter | High | Low | `#94`, `#397` |
+| `#95` | cms-framework | G1c · `ContentTypeManager` auto-register | Medium | Low | `#94` |
+| `#96` | cms-framework | G2a · `site.*` settings + REST | High | Medium | — |
+| `#398` | visual-editor | G2b · `core/site-*` block resolvers | High | Medium | `#96` |
+
+### Wave 3 — Phase G editor surface
+
+| Issue | Repo | Title | Priority | Effort | Depends on |
+|---|---|---|---|---|---|
+| `#399` | visual-editor | G3 · Editor entity adapter for Post/Page | High | High | `#395`, `#397`, `#99` |
+| `#98` | cms-framework | G5 · `visual_editor.*` permissions | Medium | Low | `#94` *(parallel)* |
+
+### Wave 4 — Phase G block re-enablement
+
+After G3.
+
+| Issue | Repo | Title | Priority | Effort | Depends on |
+|---|---|---|---|---|---|
+| `#400` | visual-editor | G4a · Verify `core/post-*` against G3 | Medium | Low | `#399` |
+| `#401` | visual-editor | G4b · Re-enable archives/categories/tag-cloud | Medium | Medium | `#399` |
+| `#97` | cms-framework | G4c-1 · `QueryRuntime` service | High | High | `#399` |
+| `#402` | visual-editor | G4c-2 · query/resolve endpoint | High | High | `#97`, `#401` |
+
+### Wave 5 — Phase H (cms-framework site-editor integration, plan 14)
+
+After Wave 1. `#100` (H0) gates H1–H4. **H1–H4 in cms-framework and H6–H8 in visual-editor are not yet filed**; per plan 11 §6, file at phase kickoff.
+
+| Issue | Repo | Title | Priority | Effort | Depends on |
+|---|---|---|---|---|---|
+| `#406` | visual-editor | Plan 14 umbrella | High | High | — |
+| `#100` | cms-framework | H0 · `theme.json` schema extension | High | Medium | — |
+| *not filed* | cms-framework | H1 · Templates + template-parts module | — | — | `#100` |
+| *not filed* | cms-framework | H2 · Patterns module | — | — | `#100` |
+| *not filed* | cms-framework | H3 · Global styles + CSS emission | — | — | `#100` |
+| *not filed* | cms-framework | H4 · Menus module | — | — | `#100` |
+| `#407` | visual-editor | H5 · Site-editor resource filters | High | Medium | H1–H4 *(any one)* |
+| *not filed* | visual-editor | H6 · WP-shape adapters + `addEntities` + sidebars | — | — | `#407` |
+| *not filed* | visual-editor | H7 · Rescope plan 11 Phase D UI | — | — | H6 |
+| *not filed* | visual-editor | H8 · Dev-app sample theme + smoke flow | — | — | H7 |
+
+### Parallel polish track
+
+Independent of Phase G / Phase H. Slot in between blocked waits.
+
+| Issue | Title | Priority | Effort | Notes |
+|---|---|---|---|---|
+| `#394` | Site editor inspector wrong registry *(bug)* | High | Low | Site-editor regression; do before `#382` |
+| `#347` | A1 · Iframe the editor canvas | High | Medium | Before `#382` (legacy reference may still help) |
+| `#348` | A1 · Restore contrast warning | Medium | Low | Defer if time-pressed; can ship in 1.0.1 |
+
+### Wave 6 — Cleanup + ship
+
+| Issue | Repo | Title | Priority | Effort | Depends on |
+|---|---|---|---|---|---|
+| `#403` | visual-editor | G6 · Integration docs + dev-app smoke flow | Medium | Low | All G work |
+| `#382` | visual-editor | F1 · Delete `_legacy/` | High | High | `#347` |
+| `#383` | visual-editor | F3 · Dev-app integration: surface site editor | High | High | H8, `#403` |
+| `#325` | visual-editor | M15 · Docs, website, release | High | High | Everything |
+| `#309` | visual-editor | V1 umbrella *(closes when 1.0.0 ships)* | Urgent | High | — |
+
+---
+
+## 4. V2 — Block fork (after V1.0.0 GA)
+
+Plan 13. I0 pilot branches off `main`, then `release/2.0` cuts from `main` once V1 tags. Per-block child issues spawn at each cluster's kickoff (per plan 13 §7).
+
+> **Naming note:** the V2 block-fork phases use the letter **I** (I0–I8) to avoid colliding with V1 plan 14's site-editor **H** phases (H0–H8). Plan 13 originally used H; renamed to I after H0 of plan 14 shipped against cms-framework. Issue titles use the `Block fork I{N}` prefix.
+
+| Issue | Title | Priority | Effort |
+|---|---|---|---|
+| `#331` | V2 umbrella · Port core blocks → `artisanpack/*` | High | High |
+| `#408` | I0 · Paragraph pilot *(gates I1–I6)* | High | Medium |
+| `#409` | I1 · Content cluster (8 blocks) | Medium | High |
+| `#410` | I2 · Media cluster (8 blocks) | Medium | High |
+| `#411` | I3 · Layout cluster (6 source units / 8 logical) | Medium | High |
+| `#412` | I4 · Widgets cluster (2 blocks) | Medium | Medium |
+| `#413` | I5 · Entity cluster (11 blocks) | Medium | High |
+| `#414` | I6 · Loop / feed cluster (5 blocks) | Medium | High |
+| `#415` | I7 · Cutover | High | Medium |
+| `#416` | I8 · Ship V2.0.0 | Medium | Low |
+
+**V1 → V2 dependencies:**
+
+- I5 reads through V1's `#399` (G3 entity adapter) + `#395` (G0 shim resolution).
+- I6 hard-couples to cms-framework V1.x release tagging G4b (`#401`) and G4c-1 (cms-framework `#97`).
+- `#338` carries forward into `artisanpack/search` at I4.
+
+---
+
+## 5. Deferred — 1.1+ (Awaiting Review milestone)
+
+All under `Awaiting Review` per plan 11 §7.
+
+| Issue | Title |
+|---|---|
+| `#384` | Block revisions / versioning |
+| `#385` | A/B testing for blocks and templates |
+| `#386` | AI assistant integration |
+| `#387` | Offline editing support |
+| `#388` | Fine-grained per-block permission locking |
+| `#389` | Pattern directory / remote pattern import |
+
+---
+
+## 6. Sequencing rationale (the *why*)
+
+Capture once so it doesn't have to be re-derived:
+
+- **`#395` first**: shim-layer bug. G4 series all assume REST-backed entities work through the shim. Fixing this after G4 means re-testing everything.
+- **G3 (`#399`) before G4***: G4 issues explicitly verify against G3 entities.
+- **`#347` before `#382`**: iframe canvas refactor is the kind of thing where having the legacy reference around is useful. Delete `_legacy/` only after the new shape is settled.
+- **`#383` last among features**: dev-app integration is a smoke test for everything else, so it consumes the finished surface.
+- **V2 `#408` (I0 pilot) does not start until V1 GA**: per plan 13 §1, V1's premise is to *adopt* upstream blocks. Inverting that during V1 splits reviewer attention. The pilot branches off `main`, not `release/2.0`.
+
+---
+
+## 7. Outstanding tactical decisions
+
+Documented so they're not re-litigated each session:
+
+- **File H1–H4 (cms-framework) + H6–H8 (visual-editor) stub issues now, or wait for phase kickoff?** Plan 11 §6 says wait. Counter-argument: matches V2 I-series treatment, gives full visibility. **Current call:** wait — file at each phase kickoff so acceptance criteria are fresh.
+- **Per-block V2 child issues filed at cluster kickoff, not preemptively** (plan 13 §7). 41 stale tickets in the backlog isn't worth the visibility.
+
+---
+
+## 8. Maintaining this doc
+
+Update when:
+
+- A wave completes (mark issues closed; trim wave from active section).
+- A plan doc changes (re-aggregate from the plans).
+- A new issue lands that doesn't fit the existing waves.
+- A dependency assumption breaks (rebuild affected wave).
+
+Don't update for:
+
+- Individual issue-state changes — query `gh issue list` for current state.
+- Per-issue detail edits — those live in the issue bodies.

--- a/docs/plans/15-issue-roadmap.md
+++ b/docs/plans/15-issue-roadmap.md
@@ -19,7 +19,7 @@ This doc captures **ordering**, not detailed acceptance criteria. Per-issue spec
 
 ## 1. Critical-path summary
 
-```
+```text
 V1 ship (≈4–6 mo) ──→  V2 block fork (≈10–12 wk) ──→  1.1+ features
    ▲
    └── cms-framework V1.x (Phase G + Phase H backends, parallel)


### PR DESCRIPTION
## Description

Renames the V2 plan-13 block-fork phases from H0–H8 to **I0–I8** to disambiguate from the V1 plan-14 site-editor H-series. Two H-series collided in this repo, making issue titles ambiguous (`#407` was just `H5 — ...` with no V1 marker; `#408–#416` were `Block fork H{N} — ...` reading ambiguously alongside the V1 H-series). V1 stays on H, V2 moves to I.

**Closes:** *(no issue — workflow cleanup)*

## Type of Change

- [x] Refactoring (code improvement, no behavior change)
- [x] Documentation update

## Related Issue

**Issue:** *(no issue — workflow cleanup; affects all of `#408–#416`)*

## Motivation and Context

After H0 of plan 14 (cms-framework theme.json schema, cms-framework #100) shipped, the H{N} naming collision between plan 13 (V2 block fork) and plan 14 (V1 site editor) became a source of confusion when checking what's next in Wave 5. Renaming V2 to I{N} preserves all the work already shipped under V1 H{N} naming and gives both series clean issue-title prefixes:

- V1 plan 14: `Site editor H{N} — ...` (prefix going forward)
- V2 plan 13: `Block fork I{N} — ...` (already prefix-disambiguated; just letter-renamed)

## Changes Made

- **`docs/plans/13-block-fork.md`** — Full H{N} → I{N} rewrite (plan is purely V2). 48 line edits. Includes `Phase H — Block fork` → `Phase I — Block fork`, branch placeholders `feature/H{n}-{cluster}` → `feature/I{n}-{cluster}`, all critical-path / phase-ordering / risks-of-record references.
- **`docs/plans/15-issue-roadmap.md`** — V2 section table + V1→V2 dependency list updated to I-series; V1 wave-5 H-refs left untouched (they're plan 14 references). Adds an explicit naming-note callout under section 4 explaining the rename. Also commits this file for the first time — it was local-only before this PR.
- **GitHub issues `#408–#416`** — Titles retitled from `Block fork H{N} — ...` to `Block fork I{N} — ...` via `gh issue edit`. Bodies updated to match (60 H{N} refs across the 9 issues, all renamed). Done outside the git history because issue bodies live on GitHub.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS 15.4
- PHP Version: N/A (docs-only)
- Project Version: visual-editor `release/1.0`

**Tests Performed:**
1. `grep -nE '\bH[0-9]\b' docs/plans/13-block-fork.md` → empty (no H{N} left in V2 plan).
2. `grep -nE '\bH[0-9]\b' docs/plans/15-issue-roadmap.md` → only V1 wave-5 references in the wave-5 table — preserved correctly. V2 section refs are now I{N}.
3. `gh issue view {408..416}` spot-check → all 9 titles show `Block fork I{N}`; body grep for stray H-refs returned only one ("all other H phases" in #408), now also fixed.
4. `coderabbit review --plain --base origin/release/1.0` → No findings.

## Accessibility Tests Run

- [x] Not applicable — docs-only.

**Details:** Pure docs + GitHub issue title/body changes. No UI surface affected.

## Tests Added

- [x] Not applicable — docs/workflow change with no executable behavior.

## Documentation

- [x] Plan 13 updated
- [x] Roadmap doc updated with naming note
- [x] Memory updated to reflect convention

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] CodeRabbit pre-PR pass: No findings
- [x] Code follows project style guide
- [x] Self-review completed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Renamed and renumbered phases in the V2 block-fork plan (H → I) and updated all related phase references, sequencing, cutover points, and release/branch timing.
  * Added a new Visual Editor Issue Roadmap covering V1 delivery waves, V2 execution phases, prioritized issue ordering, dependencies, deferred 1.1+ items, and maintenance rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->