### PR TITLE
feat: H5 — site-editor resource filters (templates, parts, patterns, global-styles, navigation) (#407)

### DIFF
--- a/config/visual-editor.php
+++ b/config/visual-editor.php
@@ -309,4 +309,45 @@ return [
 		],
 	],
 
+	/*
+	|--------------------------------------------------------------------------
+	| Site editor (H5)
+	|--------------------------------------------------------------------------
+	|
+	| Static-config entry points for the five site-editor entity types. Each
+	| key is also a filter slug — packages like cms-framework register their
+	| entities at runtime through `addFilter('ap.visual-editor.{type}', ...)`.
+	|
+	| Static config wins on key collision: host-app entries listed here take
+	| precedence over filter-supplied entries with the same key.
+	|
+	| Standalone visual-editor installs (no cms-framework, no host
+	| registrations) leave these empty and the editor's site-editor surface
+	| boots cleanly with no entities. See plan 14 §4.4 for the full filter
+	| contract and the ResolvedX value-object shapes consumed by H6.
+	|
+	*/
+
+	'site-editor' => [
+		// array<string, array> keyed by template slug.
+		// Each entry: { slug, theme, title, status, source, content: { raw, blocks }, has_theme_file, is_custom, wp_id?, ... }
+		'templates' => [],
+
+		// array<string, array> keyed by template-part slug.
+		// Each entry adds: { area: 'header'|'footer'|'sidebar'|'general' }
+		'template-parts' => [],
+
+		// array<string, array> keyed by pattern slug.
+		// Each entry: { slug, title, source: 'theme'|'user', synced, content: { raw, blocks }, categories?, block_types? }
+		'patterns' => [],
+
+		// array<string, mixed>|null — singleton, not a map.
+		// { theme, settings, styles, variations? }
+		'global-styles' => null,
+
+		// array<string, array> keyed by theme-declared menu location.
+		// Each entry: { location, name, items: [...] }
+		'navigation' => [],
+	],
+
 ];

--- a/docs/plans/14-cms-framework-site-editor-integration.md
+++ b/docs/plans/14-cms-framework-site-editor-integration.md
@@ -194,6 +194,14 @@ Five new filters mirroring `ap.visual-editor.resources` from Phase G. Each takes
 - `ap.visual-editor.global-styles` → `?ResolvedGlobalStyles` (singleton).
 - `ap.visual-editor.navigation` → `array<string, ResolvedMenu>` keyed by location.
 
+**Implementation reference (H5 shipped):**
+
+- Resolvers + value objects: `src/SiteEditor/Resolution/{TemplateResolver, TemplatePartResolver, PatternResolver, GlobalStylesResolver, MenuResolver, ResolvedTemplate, ResolvedTemplatePart, ResolvedPattern, ResolvedGlobalStyles, ResolvedMenu}.php`
+- Lazy-validation exception: `src/SiteEditor/Exceptions/SiteEditorRegistrationException.php`
+- Filter wiring: `VisualEditorServiceProvider::registerSiteEditorResolvers()` (called from the `$this->app->booted(...)` callback alongside `registerResourceResolver()`).
+- Static config: `config/visual-editor.php` `site-editor.{templates, template-parts, patterns, global-styles, navigation}`. Static keys override filter-supplied keys on collision; for the singleton global-styles, a non-null static config wins outright.
+- Tests: `tests/Feature/VisualEditor/SiteEditorFiltersTest.php` covers empty/single-source/colliding/malformed filter-return scenarios.
+
 cms-framework registration site (H5):
 
 ```php

--- a/src/SiteEditor/Exceptions/SiteEditorRegistrationException.php
+++ b/src/SiteEditor/Exceptions/SiteEditorRegistrationException.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * Site-editor registration exception.
+ *
+ * Thrown lazily — on the first {@see TemplateResolver::all()} (or sibling
+ * resolver) call, never at boot — when an `ap.visual-editor.{templates,
+ * template-parts,patterns,global-styles,navigation}` filter returns a
+ * non-conforming shape or an entry is missing a required field.
+ *
+ * Lazy because `class_exists` registration sites in cms-framework register
+ * filter callbacks at boot. Validating eagerly would couple visual-editor's
+ * boot success to whatever shape every contributor happens to return that
+ * day; deferring validation until the editor's first request keeps a
+ * standalone visual-editor or cms-framework install booting cleanly even
+ * when a misconfigured contributor returns garbage.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\SiteEditor\Exceptions;
+
+use RuntimeException;
+
+class SiteEditorRegistrationException extends RuntimeException
+{
+	/**
+	 * The filter return value was not the expected map / array.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string  $filterName  The filter slug (e.g. `ap.visual-editor.templates`).
+	 * @param  string  $expected    A short description of the expected shape.
+	 * @param  string  $actual      A short description of the actual shape.
+	 */
+	public static function invalidFilterShape( string $filterName, string $expected, string $actual ): self
+	{
+		return new self( sprintf(
+			'Filter "%s" returned an invalid shape. Expected %s, got %s.',
+			$filterName,
+			$expected,
+			$actual,
+		) );
+	}
+
+	/**
+	 * An entry in a filter return map / object was missing a required field.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string  $filterName  The filter slug.
+	 * @param  string  $entryKey    The map key (or `'(singleton)'` for global-styles).
+	 * @param  string  $field       The missing required field.
+	 */
+	public static function missingRequiredField( string $filterName, string $entryKey, string $field ): self
+	{
+		return new self( sprintf(
+			'Filter "%s" entry "%s" is missing required field "%s".',
+			$filterName,
+			$entryKey,
+			$field,
+		) );
+	}
+
+	/**
+	 * A field was present but had the wrong type or value.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string  $filterName  The filter slug.
+	 * @param  string  $entryKey    The map key.
+	 * @param  string  $field       The field name.
+	 * @param  string  $expected    A short description of the expected type / value.
+	 */
+	public static function invalidField( string $filterName, string $entryKey, string $field, string $expected ): self
+	{
+		return new self( sprintf(
+			'Filter "%s" entry "%s" field "%s" is invalid: expected %s.',
+			$filterName,
+			$entryKey,
+			$field,
+			$expected,
+		) );
+	}
+}

--- a/src/SiteEditor/Resolution/AbstractMapResolver.php
+++ b/src/SiteEditor/Resolution/AbstractMapResolver.php
@@ -1,0 +1,165 @@
+<?php
+
+/**
+ * Abstract map-shaped site-editor resolver.
+ *
+ * Shared scaffolding for the four map-style resolvers (templates,
+ * template-parts, patterns, navigation). The fifth — global-styles —
+ * is a singleton, so it has its own resolver shape.
+ *
+ * Validation is deferred until first read so a misconfigured filter
+ * contributor surfaces an exception on the editor's first request, not
+ * at boot — letting standalone visual-editor or cms-framework installs
+ * boot cleanly even when contributors return garbage.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ *
+ * @template TValue of object
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\SiteEditor\Resolution;
+
+use ArtisanPackUI\VisualEditor\SiteEditor\Exceptions\SiteEditorRegistrationException;
+
+abstract class AbstractMapResolver
+{
+	/**
+	 * Raw filter input, deferred until first read.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var array<string, mixed>
+	 */
+	protected array $rawEntries;
+
+	/**
+	 * Cache of normalized typed value objects keyed by slug / location.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var array<string, TValue>|null
+	 */
+	protected ?array $cached = null;
+
+	/**
+	 * @since 1.0.0
+	 *
+	 * @param  array<string, mixed>  $entries  The merged filter result.
+	 */
+	public function __construct( array $entries = [] )
+	{
+		$this->rawEntries = $entries;
+	}
+
+	/**
+	 * Returns all resolved entries, normalizing on first call.
+	 *
+	 * Throws {@see SiteEditorRegistrationException} if any entry has the
+	 * wrong shape — surfaces invalid contributors at the first read instead
+	 * of at boot.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<string, TValue>
+	 */
+	public function all(): array
+	{
+		if ( null === $this->cached ) {
+			$this->cached = $this->normalizeEntries( $this->rawEntries );
+		}
+
+		return $this->cached;
+	}
+
+	/**
+	 * Returns a single entry by key, or null when absent. Forces normalization.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return TValue|null
+	 */
+	public function find( string $key ): ?object
+	{
+		return $this->all()[ $key ] ?? null;
+	}
+
+	/**
+	 * Returns the merged filter input verbatim. Useful for tests and for
+	 * resolvers that want to re-emit raw entries to downstream resolvers
+	 * without paying normalization.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function raw(): array
+	{
+		return $this->rawEntries;
+	}
+
+	/**
+	 * Walk the raw entries, validating each through the per-type
+	 * {@see static::normalizeEntry()} factory.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array<string, mixed>  $entries
+	 *
+	 * @return array<string, TValue>
+	 */
+	protected function normalizeEntries( array $entries ): array
+	{
+		$out = [];
+
+		foreach ( $entries as $key => $entry ) {
+			if ( ! is_string( $key ) || '' === $key ) {
+				throw SiteEditorRegistrationException::invalidFilterShape(
+					static::filterName(),
+					'a map keyed by non-empty string',
+					'numeric or empty keys',
+				);
+			}
+
+			if ( ! is_array( $entry ) ) {
+				throw SiteEditorRegistrationException::invalidFilterShape(
+					static::filterName(),
+					"an array entry for '{$key}'",
+					gettype( $entry ),
+				);
+			}
+
+			// Stamp the map key onto the entry under the type-specific key
+			// field so the value object can default to it when the entry
+			// omits the field. The per-type subclass picks the right field.
+			$out[ $key ] = static::normalizeEntry( $key, $entry );
+		}
+
+		return $out;
+	}
+
+	/**
+	 * The filter slug this resolver consumes — used in exceptions.
+	 *
+	 * @since 1.0.0
+	 */
+	abstract protected static function filterName(): string;
+
+	/**
+	 * Convert a single raw filter entry into the resolver's typed value object.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string  $key
+	 * @param  array<string, mixed>  $entry
+	 *
+	 * @return TValue
+	 */
+	abstract protected static function normalizeEntry( string $key, array $entry ): object;
+}

--- a/src/SiteEditor/Resolution/GlobalStylesResolver.php
+++ b/src/SiteEditor/Resolution/GlobalStylesResolver.php
@@ -1,0 +1,96 @@
+<?php
+
+/**
+ * Site-editor global-styles resolver.
+ *
+ * Singleton — one resolved object per active theme — distinct from the
+ * map-shaped sibling resolvers. cms-framework's H3 GlobalStylesResolver
+ * registers via `ap.visual-editor.global-styles`; H6 reads it through
+ * the `__unstableBase` REST adapter.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\SiteEditor\Resolution;
+
+class GlobalStylesResolver
+{
+	/**
+	 * @since 1.0.0
+	 */
+	protected const FILTER_NAME = 'ap.visual-editor.global-styles';
+
+	/**
+	 * Raw filter input, deferred until first read.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var array<string, mixed>|null
+	 */
+	protected ?array $rawEntry;
+
+	/**
+	 * Cache of the normalized typed value object, or null when none was
+	 * provided. We use {@see self::$resolved} instead of relying on
+	 * {@see self::$cached} being null because null is a valid resolved value
+	 * (the standalone-install case).
+	 *
+	 * @since 1.0.0
+	 */
+	protected ?ResolvedGlobalStyles $cached = null;
+
+	/**
+	 * @since 1.0.0
+	 */
+	protected bool $resolved = false;
+
+	/**
+	 * @since 1.0.0
+	 *
+	 * @param  array<string, mixed>|null  $entry  Merged filter result. `null`
+	 *                                            when no contributor registered
+	 *                                            and no static config is set.
+	 */
+	public function __construct( ?array $entry = null )
+	{
+		$this->rawEntry = $entry;
+	}
+
+	/**
+	 * Returns the resolved global-styles object, or null when none was
+	 * registered.
+	 *
+	 * @since 1.0.0
+	 */
+	public function get(): ?ResolvedGlobalStyles
+	{
+		if ( ! $this->resolved ) {
+			$this->cached   = ( null !== $this->rawEntry && [] !== $this->rawEntry )
+				? ResolvedGlobalStyles::fromArray( $this->rawEntry )
+				: null;
+			$this->resolved = true;
+		}
+
+		return $this->cached;
+	}
+
+	/**
+	 * Returns the raw merged filter input. Useful for tests and consumers
+	 * that want to forward the unparsed shape downstream.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<string, mixed>|null
+	 */
+	public function raw(): ?array
+	{
+		return $this->rawEntry;
+	}
+}

--- a/src/SiteEditor/Resolution/MenuResolver.php
+++ b/src/SiteEditor/Resolution/MenuResolver.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * Site-editor menu (navigation) resolver.
+ *
+ * Consumes the merged `ap.visual-editor.navigation` filter result, keyed by
+ * theme-declared menu location.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ *
+ * @extends AbstractMapResolver<ResolvedMenu>
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\SiteEditor\Resolution;
+
+class MenuResolver extends AbstractMapResolver
+{
+	/**
+	 * @since 1.0.0
+	 */
+	protected static function filterName(): string
+	{
+		return 'ap.visual-editor.navigation';
+	}
+
+	/**
+	 * @since 1.0.0
+	 *
+	 * @param  array<string, mixed>  $entry
+	 */
+	protected static function normalizeEntry( string $key, array $entry ): ResolvedMenu
+	{
+		// Default `location` to the map key if the contributor omitted it.
+		$entry['location'] = $entry['location'] ?? $key;
+
+		return ResolvedMenu::fromArray( $entry );
+	}
+}

--- a/src/SiteEditor/Resolution/PatternResolver.php
+++ b/src/SiteEditor/Resolution/PatternResolver.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * Site-editor pattern resolver.
+ *
+ * Consumes the merged `ap.visual-editor.patterns` filter result. Patterns
+ * cover both theme-shipped (`source: 'theme'`, read-only) and user-authored
+ * (`source: 'user'`, editable) entries — the value object's `synced` field
+ * distinguishes WP `wp_block` (synced) from `wp_block_pattern` (unsynced).
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ *
+ * @extends AbstractMapResolver<ResolvedPattern>
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\SiteEditor\Resolution;
+
+class PatternResolver extends AbstractMapResolver
+{
+	/**
+	 * @since 1.0.0
+	 */
+	protected static function filterName(): string
+	{
+		return 'ap.visual-editor.patterns';
+	}
+
+	/**
+	 * @since 1.0.0
+	 *
+	 * @param  array<string, mixed>  $entry
+	 */
+	protected static function normalizeEntry( string $key, array $entry ): ResolvedPattern
+	{
+		$entry['slug'] = $entry['slug'] ?? $key;
+
+		return ResolvedPattern::fromArray( $entry );
+	}
+}

--- a/src/SiteEditor/Resolution/ResolvedGlobalStyles.php
+++ b/src/SiteEditor/Resolution/ResolvedGlobalStyles.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * Resolved global-styles value object.
+ *
+ * Singleton (one per active theme): the merged `settings` + `styles` object
+ * H6's `__unstableBase` REST adapter consumes. Variations come from the
+ * theme's `theme.json` `styles.variations`.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\SiteEditor\Resolution;
+
+use ArtisanPackUI\VisualEditor\SiteEditor\Exceptions\SiteEditorRegistrationException;
+
+class ResolvedGlobalStyles
+{
+	/**
+	 * @since 1.0.0
+	 */
+	protected const FILTER_NAME = 'ap.visual-editor.global-styles';
+
+	/**
+	 * @since 1.0.0
+	 *
+	 * @param  string  $theme       Active theme slug.
+	 * @param  array<string, mixed>  $settings    `theme.json`-shape settings object.
+	 * @param  array<string, mixed>  $styles      `theme.json`-shape styles object.
+	 * @param  array<int, array<string, mixed>>  $variations  Style variations from
+	 *                                                        `theme.json` `styles.variations`.
+	 * @param  int|null  $wpId       DB row id; null when the theme defaults are
+	 *                               authoritative (no user customization yet).
+	 */
+	public function __construct(
+		public readonly string $theme,
+		public readonly array $settings,
+		public readonly array $styles,
+		public readonly array $variations,
+		public readonly ?int $wpId,
+	) {
+	}
+
+	/**
+	 * @since 1.0.0
+	 *
+	 * @param  array<string, mixed>  $data
+	 */
+	public static function fromArray( array $data ): self
+	{
+		if ( ! isset( $data['theme'] ) || ! is_string( $data['theme'] ) ) {
+			throw SiteEditorRegistrationException::missingRequiredField( self::FILTER_NAME, '(singleton)', 'theme' );
+		}
+
+		return new self(
+			theme      : $data['theme'],
+			settings   : is_array( $data['settings'] ?? null ) ? $data['settings'] : [],
+			styles     : is_array( $data['styles'] ?? null ) ? $data['styles'] : [],
+			variations : is_array( $data['variations'] ?? null ) ? $data['variations'] : [],
+			wpId       : isset( $data['wp_id'] ) ? (int) $data['wp_id'] : null,
+		);
+	}
+}

--- a/src/SiteEditor/Resolution/ResolvedMenu.php
+++ b/src/SiteEditor/Resolution/ResolvedMenu.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * Resolved menu value object.
+ *
+ * Maps a theme-declared location (`primary`, `footer`, etc.) to a menu
+ * record + its menu items. cms-framework's `MenuResolver` (H4) populates
+ * this through the `ap.visual-editor.navigation` filter; H6's
+ * `wp_navigation` REST adapter reads it.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\SiteEditor\Resolution;
+
+use ArtisanPackUI\VisualEditor\SiteEditor\Exceptions\SiteEditorRegistrationException;
+
+class ResolvedMenu
+{
+	/**
+	 * @since 1.0.0
+	 */
+	protected const FILTER_NAME = 'ap.visual-editor.navigation';
+
+	/**
+	 * @since 1.0.0
+	 *
+	 * @param  string  $location  Theme-declared menu location key.
+	 * @param  string  $name      Display name of the menu assigned to this location.
+	 * @param  array<int, array<string, mixed>>  $items  Menu items. Items follow
+	 *                                                   the upstream `core/navigation-link`
+	 *                                                   shape (label, url, type, ...) so
+	 *                                                   the navigation block consumes them
+	 *                                                   without translation.
+	 * @param  int|null  $wpId     DB row id of the menu record, or null when the
+	 *                             menu is theme-declared but has no user assignment yet.
+	 */
+	public function __construct(
+		public readonly string $location,
+		public readonly string $name,
+		public readonly array $items,
+		public readonly ?int $wpId,
+	) {
+	}
+
+	/**
+	 * @since 1.0.0
+	 *
+	 * @param  array<string, mixed>  $data
+	 */
+	public static function fromArray( array $data ): self
+	{
+		if ( ! isset( $data['location'] ) || ! is_string( $data['location'] ) ) {
+			throw SiteEditorRegistrationException::missingRequiredField(
+				self::FILTER_NAME,
+				$data['location'] ?? '(unknown)',
+				'location',
+			);
+		}
+
+		return new self(
+			location : $data['location'],
+			name     : (string) ( $data['name'] ?? '' ),
+			items    : is_array( $data['items'] ?? null ) ? $data['items'] : [],
+			wpId     : isset( $data['wp_id'] ) ? (int) $data['wp_id'] : null,
+		);
+	}
+}

--- a/src/SiteEditor/Resolution/ResolvedPattern.php
+++ b/src/SiteEditor/Resolution/ResolvedPattern.php
@@ -1,0 +1,114 @@
+<?php
+
+/**
+ * Resolved pattern value object.
+ *
+ * Site-editor patterns can be theme-shipped (`source: 'theme'`) or
+ * user-authored (`source: 'user'`). When `synced` is true, the pattern
+ * tracks edits — equivalent to `wp_block` in WP REST. When false, the
+ * pattern is a snapshot — equivalent to `wp_block_pattern`.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\SiteEditor\Resolution;
+
+use ArtisanPackUI\VisualEditor\SiteEditor\Exceptions\SiteEditorRegistrationException;
+
+class ResolvedPattern
+{
+	/**
+	 * @since 1.0.0
+	 */
+	protected const FILTER_NAME = 'ap.visual-editor.patterns';
+
+	/**
+	 * @since 1.0.0
+	 *
+	 * @param  string  $slug          Stable identifier; for user patterns this should
+	 *                                carry a `user/` prefix per plan 14 §5.6.
+	 * @param  string  $title         Display title.
+	 * @param  string  $rawContent    Serialized block markup.
+	 * @param  array<int, array<string, mixed>>  $blocks  Parsed block tree.
+	 * @param  string  $source        `'theme'` or `'user'`.
+	 * @param  bool    $synced        True for synced (live-edited) patterns.
+	 * @param  array<int, string>  $categories  Pattern category slugs.
+	 * @param  array<int, string>  $blockTypes  WP `blockTypes` hint for the inserter.
+	 * @param  int|null  $wpId        DB row id for user-source patterns; null otherwise.
+	 */
+	public function __construct(
+		public readonly string $slug,
+		public readonly string $title,
+		public readonly string $rawContent,
+		public readonly array $blocks,
+		public readonly string $source,
+		public readonly bool $synced,
+		public readonly array $categories,
+		public readonly array $blockTypes,
+		public readonly ?int $wpId,
+	) {
+	}
+
+	/**
+	 * @since 1.0.0
+	 *
+	 * @param  array<string, mixed>  $data
+	 */
+	public static function fromArray( array $data ): self
+	{
+		$slug   = self::requireString( $data, 'slug' );
+		$source = $data['source'] ?? 'theme';
+
+		if ( ! in_array( $source, [ 'theme', 'user' ], true ) ) {
+			throw SiteEditorRegistrationException::invalidField(
+				self::FILTER_NAME,
+				$slug,
+				'source',
+				"'theme' or 'user'",
+			);
+		}
+
+		return new self(
+			slug       : $slug,
+			title      : (string) ( $data['title'] ?? '' ),
+			rawContent : (string) ( $data['raw_content'] ?? $data['content']['raw'] ?? '' ),
+			blocks     : is_array( $data['blocks'] ?? null ) ? $data['blocks'] : ( $data['content']['blocks'] ?? [] ),
+			source     : (string) $source,
+			synced     : (bool) ( $data['synced'] ?? false ),
+			categories : array_values( array_filter(
+				is_array( $data['categories'] ?? null ) ? $data['categories'] : [],
+				'is_string',
+			) ),
+			blockTypes : array_values( array_filter(
+				is_array( $data['block_types'] ?? null ) ? $data['block_types'] : [],
+				'is_string',
+			) ),
+			wpId       : isset( $data['wp_id'] ) ? (int) $data['wp_id'] : null,
+		);
+	}
+
+	/**
+	 * @since 1.0.0
+	 *
+	 * @param  array<string, mixed>  $data
+	 */
+	protected static function requireString( array $data, string $field, string $entryKey = '(unknown)' ): string
+	{
+		if ( ! isset( $data[ $field ] ) ) {
+			throw SiteEditorRegistrationException::missingRequiredField( self::FILTER_NAME, $entryKey, $field );
+		}
+
+		if ( ! is_string( $data[ $field ] ) ) {
+			throw SiteEditorRegistrationException::invalidField( self::FILTER_NAME, $entryKey, $field, 'a string' );
+		}
+
+		return $data[ $field ];
+	}
+}

--- a/src/SiteEditor/Resolution/ResolvedPattern.php
+++ b/src/SiteEditor/Resolution/ResolvedPattern.php
@@ -92,8 +92,16 @@ class ResolvedPattern
 		// Mirror the same defensive pattern for `content.raw`. A string-shaped
 		// `$data['content']` would let `$data['content']['raw']` index into
 		// the string's offsets (PHP coerces 'raw' → int 0 → returns the first
-		// character), silently corrupting `rawContent` to a single byte.
-		$rawFromContent = ( is_array( $content ) && isset( $content['raw'] ) ) ? (string) $content['raw'] : '';
+		// character), silently corrupting `rawContent` to a single byte. The
+		// is_array guard above prevents that; coerceScalarString below
+		// additionally guards against a non-scalar `content.raw` (e.g. an
+		// array) stringifying to the literal `"Array"`.
+		$rawFromContent = self::coerceScalarString( $content['raw'] ?? null ) ?? '';
+
+		// Top-level `raw_content` may also arrive non-scalar from a
+		// misconfigured contributor; only adopt it when it cleanly coerces
+		// to a string, otherwise fall through to the nested fallback.
+		$rawContent = self::coerceScalarString( $data['raw_content'] ?? null ) ?? $rawFromContent;
 
 		return new self(
 			slug       : $slug,
@@ -103,7 +111,7 @@ class ResolvedPattern
 			// clear error on first read instead of silently shipping empty
 			// titles.
 			title      : self::requireString( $data, 'title', $slug ),
-			rawContent : (string) ( $data['raw_content'] ?? $rawFromContent ),
+			rawContent : $rawContent,
 			blocks     : $blocks,
 			source     : (string) $source,
 			synced     : (bool) ( $data['synced'] ?? false ),
@@ -135,5 +143,27 @@ class ResolvedPattern
 		}
 
 		return $data[ $field ];
+	}
+
+	/**
+	 * Mirror of {@see ResolvedTemplate::coerceScalarString()}. Returns the
+	 * value unchanged if it's already a string, casts other scalars
+	 * (int/float/bool) to string, and returns null for arrays / objects /
+	 * null. Without this guard, a non-scalar `content.raw` (e.g. an array)
+	 * would stringify to the literal `"Array"` and ship as `rawContent`.
+	 *
+	 * @since 1.0.0
+	 */
+	protected static function coerceScalarString( mixed $value ): ?string
+	{
+		if ( is_string( $value ) ) {
+			return $value;
+		}
+
+		if ( is_scalar( $value ) ) {
+			return (string) $value;
+		}
+
+		return null;
 	}
 }

--- a/src/SiteEditor/Resolution/ResolvedPattern.php
+++ b/src/SiteEditor/Resolution/ResolvedPattern.php
@@ -75,11 +75,28 @@ class ResolvedPattern
 			);
 		}
 
+		// Normalize the blocks fallback through an explicit is_array check on
+		// each candidate so a non-array value at any layer of the WP-shape
+		// envelope can't reach the typed `array $blocks` constructor param
+		// and raise a TypeError under strict_types.
+		if ( is_array( $data['blocks'] ?? null ) ) {
+			$blocks = $data['blocks'];
+		} elseif ( is_array( $data['content']['blocks'] ?? null ) ) {
+			$blocks = $data['content']['blocks'];
+		} else {
+			$blocks = [];
+		}
+
 		return new self(
 			slug       : $slug,
-			title      : (string) ( $data['title'] ?? '' ),
+			// Patterns require a title — WP REST `wp_block` enforces it and
+			// titleless patterns are unfindable in the inserter UI. Mirrors
+			// the slug check above so misconfigured contributors surface a
+			// clear error on first read instead of silently shipping empty
+			// titles.
+			title      : self::requireString( $data, 'title', $slug ),
 			rawContent : (string) ( $data['raw_content'] ?? $data['content']['raw'] ?? '' ),
-			blocks     : is_array( $data['blocks'] ?? null ) ? $data['blocks'] : ( $data['content']['blocks'] ?? [] ),
+			blocks     : $blocks,
 			source     : (string) $source,
 			synced     : (bool) ( $data['synced'] ?? false ),
 			categories : array_values( array_filter(

--- a/src/SiteEditor/Resolution/ResolvedPattern.php
+++ b/src/SiteEditor/Resolution/ResolvedPattern.php
@@ -79,13 +79,21 @@ class ResolvedPattern
 		// each candidate so a non-array value at any layer of the WP-shape
 		// envelope can't reach the typed `array $blocks` constructor param
 		// and raise a TypeError under strict_types.
+		$content = is_array( $data['content'] ?? null ) ? $data['content'] : [];
+
 		if ( is_array( $data['blocks'] ?? null ) ) {
 			$blocks = $data['blocks'];
-		} elseif ( is_array( $data['content']['blocks'] ?? null ) ) {
-			$blocks = $data['content']['blocks'];
+		} elseif ( is_array( $content['blocks'] ?? null ) ) {
+			$blocks = $content['blocks'];
 		} else {
 			$blocks = [];
 		}
+
+		// Mirror the same defensive pattern for `content.raw`. A string-shaped
+		// `$data['content']` would let `$data['content']['raw']` index into
+		// the string's offsets (PHP coerces 'raw' → int 0 → returns the first
+		// character), silently corrupting `rawContent` to a single byte.
+		$rawFromContent = ( is_array( $content ) && isset( $content['raw'] ) ) ? (string) $content['raw'] : '';
 
 		return new self(
 			slug       : $slug,
@@ -95,7 +103,7 @@ class ResolvedPattern
 			// clear error on first read instead of silently shipping empty
 			// titles.
 			title      : self::requireString( $data, 'title', $slug ),
-			rawContent : (string) ( $data['raw_content'] ?? $data['content']['raw'] ?? '' ),
+			rawContent : (string) ( $data['raw_content'] ?? $rawFromContent ),
 			blocks     : $blocks,
 			source     : (string) $source,
 			synced     : (bool) ( $data['synced'] ?? false ),

--- a/src/SiteEditor/Resolution/ResolvedTemplate.php
+++ b/src/SiteEditor/Resolution/ResolvedTemplate.php
@@ -93,8 +93,11 @@ class ResolvedTemplate
 		// non-numeric keys.
 		$content = is_array( $data['content'] ?? null ) ? $data['content'] : [];
 
-		$rawFallback     = isset( $content['raw'] ) ? (string) $content['raw'] : '';
-		$blocksFallback  = is_array( $content['blocks'] ?? null ) ? $content['blocks'] : [];
+		// Use coerceScalarString instead of an unconditional cast — a
+		// non-scalar `content.raw` (array/object) would otherwise stringify
+		// to the literal `"Array"` and ship as rawContent.
+		$rawFallback    = self::coerceScalarString( $content['raw'] ?? null ) ?? '';
+		$blocksFallback = is_array( $content['blocks'] ?? null ) ? $content['blocks'] : [];
 
 		return new self(
 			slug         : $slug,
@@ -147,6 +150,28 @@ class ResolvedTemplate
 		}
 
 		return is_string( $data[ $field ] ) ? $data[ $field ] : $default;
+	}
+
+	/**
+	 * Safely cast a filter-supplied value to a string when it is sensibly
+	 * stringable, returning null otherwise. Used at the contributor boundary
+	 * to guard against arrays or unsupported objects landing in string-typed
+	 * value-object fields — `(string) $array` would otherwise produce the
+	 * literal `"Array"` and silently corrupt `rawContent`.
+	 *
+	 * @since 1.0.0
+	 */
+	protected static function coerceScalarString( mixed $value ): ?string
+	{
+		if ( is_string( $value ) ) {
+			return $value;
+		}
+
+		if ( is_scalar( $value ) ) {
+			return (string) $value;
+		}
+
+		return null;
 	}
 
 	/**

--- a/src/SiteEditor/Resolution/ResolvedTemplate.php
+++ b/src/SiteEditor/Resolution/ResolvedTemplate.php
@@ -1,0 +1,173 @@
+<?php
+
+/**
+ * Resolved template value object.
+ *
+ * Carries the merged authoritative content for a single template slug, in
+ * the shape H6's WP-style REST adapters consume. Constructed lazily by
+ * {@see TemplateResolver} from raw filter arrays.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\SiteEditor\Resolution;
+
+use ArtisanPackUI\VisualEditor\SiteEditor\Exceptions\SiteEditorRegistrationException;
+
+class ResolvedTemplate
+{
+	/**
+	 * The filter slug that produced this entry — used in exceptions to point
+	 * back at the misconfigured contributor.
+	 *
+	 * @since 1.0.0
+	 */
+	protected const FILTER_NAME = 'ap.visual-editor.templates';
+
+	/**
+	 * @since 1.0.0
+	 *
+	 * @param  string  $slug          Stable identifier within the active theme.
+	 * @param  string  $theme         Active theme slug.
+	 * @param  string  $title         Display title.
+	 * @param  string  $description   Display description.
+	 * @param  string  $status        WP status (`'publish'` etc).
+	 * @param  string  $source        `'db'` or `'theme'`.
+	 * @param  string  $rawContent    The serialized block-markup string.
+	 *                                Empty for DB-stored entities (per the
+	 *                                cms-framework convention) and populated
+	 *                                for theme files.
+	 * @param  array<int, array<string, mixed>>  $blocks  The parsed block
+	 *                                tree. Populated for DB-stored entities;
+	 *                                empty for theme files.
+	 * @param  bool    $hasThemeFile  True when a theme file backs this slug.
+	 * @param  bool    $isCustom      True when the entity has no theme-file backing.
+	 * @param  int|null  $wpId        DB row id, or null when only a theme file backs.
+	 * @param  int|null  $authorId    Author user id, or null.
+	 * @param  string|null  $modifiedAt  ISO-8601 last-modified timestamp.
+	 */
+	public function __construct(
+		public readonly string $slug,
+		public readonly string $theme,
+		public readonly string $title,
+		public readonly string $description,
+		public readonly string $status,
+		public readonly string $source,
+		public readonly string $rawContent,
+		public readonly array $blocks,
+		public readonly bool $hasThemeFile,
+		public readonly bool $isCustom,
+		public readonly ?int $wpId,
+		public readonly ?int $authorId,
+		public readonly ?string $modifiedAt,
+	) {
+	}
+
+	/**
+	 * Build from a raw filter-array entry. Throws lazily on missing required
+	 * fields or invalid types so misconfigured filter contributors surface a
+	 * clear error on the editor's first request.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array<string, mixed>  $data
+	 */
+	public static function fromArray( array $data ): self
+	{
+		$slug = self::requireString( $data, 'slug' );
+
+		return new self(
+			slug         : $slug,
+			theme        : self::requireString( $data, 'theme', $slug ),
+			title        : self::optionalString( $data, 'title', '' ),
+			description  : self::optionalString( $data, 'description', '' ),
+			status       : self::optionalString( $data, 'status', 'publish' ),
+			source       : self::requireSourceEnum( $data, $slug ),
+			rawContent   : self::optionalString( $data, 'raw_content', $data['raw_content'] ?? $data['content']['raw'] ?? '' ),
+			blocks       : self::optionalArray( $data, 'blocks', $data['content']['blocks'] ?? [] ),
+			hasThemeFile : (bool) ( $data['has_theme_file'] ?? false ),
+			isCustom     : (bool) ( $data['is_custom'] ?? false ),
+			wpId         : isset( $data['wp_id'] ) ? (int) $data['wp_id'] : null,
+			authorId     : isset( $data['author_id'] ) ? (int) $data['author_id'] : null,
+			modifiedAt   : isset( $data['modified_at'] ) ? (string) $data['modified_at'] : null,
+		);
+	}
+
+	/**
+	 * @since 1.0.0
+	 *
+	 * @param  array<string, mixed>  $data
+	 */
+	protected static function requireString( array $data, string $field, string $entryKey = '(unknown)' ): string
+	{
+		if ( ! isset( $data[ $field ] ) ) {
+			throw SiteEditorRegistrationException::missingRequiredField( static::FILTER_NAME, $entryKey, $field );
+		}
+
+		if ( ! is_string( $data[ $field ] ) ) {
+			throw SiteEditorRegistrationException::invalidField( static::FILTER_NAME, $entryKey, $field, 'a string' );
+		}
+
+		return $data[ $field ];
+	}
+
+	/**
+	 * @since 1.0.0
+	 *
+	 * @param  array<string, mixed>  $data
+	 */
+	protected static function optionalString( array $data, string $field, string $default ): string
+	{
+		if ( ! array_key_exists( $field, $data ) ) {
+			return $default;
+		}
+
+		if ( null === $data[ $field ] ) {
+			return $default;
+		}
+
+		return is_string( $data[ $field ] ) ? $data[ $field ] : $default;
+	}
+
+	/**
+	 * @since 1.0.0
+	 *
+	 * @param  array<string, mixed>  $data
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	protected static function optionalArray( array $data, string $field, mixed $fallback ): array
+	{
+		$value = $data[ $field ] ?? $fallback;
+
+		return is_array( $value ) ? $value : [];
+	}
+
+	/**
+	 * @since 1.0.0
+	 *
+	 * @param  array<string, mixed>  $data
+	 */
+	protected static function requireSourceEnum( array $data, string $entryKey ): string
+	{
+		$source = $data['source'] ?? 'theme';
+
+		if ( ! in_array( $source, [ 'db', 'theme' ], true ) ) {
+			throw SiteEditorRegistrationException::invalidField(
+				static::FILTER_NAME,
+				$entryKey,
+				'source',
+				"'db' or 'theme'",
+			);
+		}
+
+		return (string) $source;
+	}
+}

--- a/src/SiteEditor/Resolution/ResolvedTemplate.php
+++ b/src/SiteEditor/Resolution/ResolvedTemplate.php
@@ -83,11 +83,18 @@ class ResolvedTemplate
 	{
 		$slug = self::requireString( $data, 'slug' );
 
-		// Coerce the nested `content.raw` fallback to a string before passing
-		// it through `optionalString`'s `string $default` parameter. Without
-		// the explicit cast a non-string nested value (e.g. an array or int)
-		// would raise a TypeError under strict_types at the call site.
-		$rawFallback = isset( $data['content']['raw'] ) ? (string) $data['content']['raw'] : '';
+		// Guard the nested `content.*` fallbacks with an is_array check on
+		// `content` itself before drilling in. `isset($str['raw'])` on a
+		// string would return true (PHP coerces 'raw' → int 0 → checks
+		// offset 0 of the string, which is set for any non-empty string),
+		// so without this guard a string-shaped `content` would silently
+		// corrupt `rawContent` to a single character. The guard also
+		// prevents the warning PHP emits on string-offset access with
+		// non-numeric keys.
+		$content = is_array( $data['content'] ?? null ) ? $data['content'] : [];
+
+		$rawFallback     = isset( $content['raw'] ) ? (string) $content['raw'] : '';
+		$blocksFallback  = is_array( $content['blocks'] ?? null ) ? $content['blocks'] : [];
 
 		return new self(
 			slug         : $slug,
@@ -97,7 +104,7 @@ class ResolvedTemplate
 			status       : self::optionalString( $data, 'status', 'publish' ),
 			source       : self::requireSourceEnum( $data, $slug ),
 			rawContent   : self::optionalString( $data, 'raw_content', $rawFallback ),
-			blocks       : self::optionalArray( $data, 'blocks', $data['content']['blocks'] ?? [] ),
+			blocks       : self::optionalArray( $data, 'blocks', $blocksFallback ),
 			hasThemeFile : (bool) ( $data['has_theme_file'] ?? false ),
 			isCustom     : (bool) ( $data['is_custom'] ?? false ),
 			wpId         : isset( $data['wp_id'] ) ? (int) $data['wp_id'] : null,

--- a/src/SiteEditor/Resolution/ResolvedTemplate.php
+++ b/src/SiteEditor/Resolution/ResolvedTemplate.php
@@ -83,6 +83,12 @@ class ResolvedTemplate
 	{
 		$slug = self::requireString( $data, 'slug' );
 
+		// Coerce the nested `content.raw` fallback to a string before passing
+		// it through `optionalString`'s `string $default` parameter. Without
+		// the explicit cast a non-string nested value (e.g. an array or int)
+		// would raise a TypeError under strict_types at the call site.
+		$rawFallback = isset( $data['content']['raw'] ) ? (string) $data['content']['raw'] : '';
+
 		return new self(
 			slug         : $slug,
 			theme        : self::requireString( $data, 'theme', $slug ),
@@ -90,7 +96,7 @@ class ResolvedTemplate
 			description  : self::optionalString( $data, 'description', '' ),
 			status       : self::optionalString( $data, 'status', 'publish' ),
 			source       : self::requireSourceEnum( $data, $slug ),
-			rawContent   : self::optionalString( $data, 'raw_content', $data['raw_content'] ?? $data['content']['raw'] ?? '' ),
+			rawContent   : self::optionalString( $data, 'raw_content', $rawFallback ),
 			blocks       : self::optionalArray( $data, 'blocks', $data['content']['blocks'] ?? [] ),
 			hasThemeFile : (bool) ( $data['has_theme_file'] ?? false ),
 			isCustom     : (bool) ( $data['is_custom'] ?? false ),

--- a/src/SiteEditor/Resolution/ResolvedTemplate.php
+++ b/src/SiteEditor/Resolution/ResolvedTemplate.php
@@ -99,6 +99,13 @@ class ResolvedTemplate
 		$rawFallback    = self::coerceScalarString( $content['raw'] ?? null ) ?? '';
 		$blocksFallback = is_array( $content['blocks'] ?? null ) ? $content['blocks'] : [];
 
+		// Route the top-level `raw_content` through coerceScalarString too —
+		// otherwise a non-string scalar (e.g. `42`, `true`) at the top level
+		// is silently dropped by `optionalString`'s is_string check while
+		// the same value at the nested `content.raw` slot is coerced to its
+		// string form. Matches ResolvedPattern's pattern.
+		$rawContent = self::coerceScalarString( $data['raw_content'] ?? null ) ?? $rawFallback;
+
 		return new self(
 			slug         : $slug,
 			theme        : self::requireString( $data, 'theme', $slug ),
@@ -106,7 +113,7 @@ class ResolvedTemplate
 			description  : self::optionalString( $data, 'description', '' ),
 			status       : self::optionalString( $data, 'status', 'publish' ),
 			source       : self::requireSourceEnum( $data, $slug ),
-			rawContent   : self::optionalString( $data, 'raw_content', $rawFallback ),
+			rawContent   : $rawContent,
 			blocks       : self::optionalArray( $data, 'blocks', $blocksFallback ),
 			hasThemeFile : (bool) ( $data['has_theme_file'] ?? false ),
 			isCustom     : (bool) ( $data['is_custom'] ?? false ),

--- a/src/SiteEditor/Resolution/ResolvedTemplatePart.php
+++ b/src/SiteEditor/Resolution/ResolvedTemplatePart.php
@@ -1,0 +1,113 @@
+<?php
+
+/**
+ * Resolved template-part value object.
+ *
+ * Adds an `area` field to the {@see ResolvedTemplate} shape. Areas are
+ * the closed list `header | footer | sidebar | general` for V1 — open-ended
+ * user-defined areas are deferred to V1.1 per plan 14 §8.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\SiteEditor\Resolution;
+
+use ArtisanPackUI\VisualEditor\SiteEditor\Exceptions\SiteEditorRegistrationException;
+
+class ResolvedTemplatePart extends ResolvedTemplate
+{
+	/**
+	 * @since 1.0.0
+	 */
+	protected const FILTER_NAME = 'ap.visual-editor.template-parts';
+
+	/**
+	 * V1 closed list of valid template-part areas. Mirrored from
+	 * cms-framework's `TemplatePart::AREAS`.
+	 *
+	 * @since 1.0.0
+	 */
+	public const AREAS = [ 'header', 'footer', 'sidebar', 'general' ];
+
+	/**
+	 * @since 1.0.0
+	 *
+	 * @param  string  $area  Template-part area; must be one of {@see self::AREAS}.
+	 */
+	public function __construct(
+		string $slug,
+		string $theme,
+		string $title,
+		string $description,
+		string $status,
+		string $source,
+		string $rawContent,
+		array $blocks,
+		bool $hasThemeFile,
+		bool $isCustom,
+		?int $wpId,
+		?int $authorId,
+		?string $modifiedAt,
+		public readonly string $area,
+	) {
+		parent::__construct(
+			slug         : $slug,
+			theme        : $theme,
+			title        : $title,
+			description  : $description,
+			status       : $status,
+			source       : $source,
+			rawContent   : $rawContent,
+			blocks       : $blocks,
+			hasThemeFile : $hasThemeFile,
+			isCustom     : $isCustom,
+			wpId         : $wpId,
+			authorId     : $authorId,
+			modifiedAt   : $modifiedAt,
+		);
+	}
+
+	/**
+	 * @since 1.0.0
+	 *
+	 * @param  array<string, mixed>  $data
+	 */
+	public static function fromArray( array $data ): self
+	{
+		$slug = self::requireString( $data, 'slug' );
+		$area = self::requireString( $data, 'area', $slug );
+
+		if ( ! in_array( $area, self::AREAS, true ) ) {
+			throw SiteEditorRegistrationException::invalidField(
+				static::FILTER_NAME,
+				$slug,
+				'area',
+				'one of: ' . implode( ', ', self::AREAS ),
+			);
+		}
+
+		return new self(
+			slug         : $slug,
+			theme        : self::requireString( $data, 'theme', $slug ),
+			title        : self::optionalString( $data, 'title', '' ),
+			description  : self::optionalString( $data, 'description', '' ),
+			status       : self::optionalString( $data, 'status', 'publish' ),
+			source       : self::requireSourceEnum( $data, $slug ),
+			rawContent   : self::optionalString( $data, 'raw_content', $data['raw_content'] ?? $data['content']['raw'] ?? '' ),
+			blocks       : self::optionalArray( $data, 'blocks', $data['content']['blocks'] ?? [] ),
+			hasThemeFile : (bool) ( $data['has_theme_file'] ?? false ),
+			isCustom     : (bool) ( $data['is_custom'] ?? false ),
+			wpId         : isset( $data['wp_id'] ) ? (int) $data['wp_id'] : null,
+			authorId     : isset( $data['author_id'] ) ? (int) $data['author_id'] : null,
+			modifiedAt   : isset( $data['modified_at'] ) ? (string) $data['modified_at'] : null,
+			area         : $area,
+		);
+	}
+}

--- a/src/SiteEditor/Resolution/ResolvedTemplatePart.php
+++ b/src/SiteEditor/Resolution/ResolvedTemplatePart.php
@@ -93,9 +93,14 @@ class ResolvedTemplatePart extends ResolvedTemplate
 			);
 		}
 
-		// Same strict_types-safe rawContent fallback as ResolvedTemplate —
-		// see the comment there for the rationale.
-		$rawFallback = isset( $data['content']['raw'] ) ? (string) $data['content']['raw'] : '';
+		// Same defensive `content.*` guards as ResolvedTemplate — see the
+		// comment there for the rationale (string-offset coercion silently
+		// corrupting `rawContent` to a single character if `content` is a
+		// string).
+		$content = is_array( $data['content'] ?? null ) ? $data['content'] : [];
+
+		$rawFallback    = isset( $content['raw'] ) ? (string) $content['raw'] : '';
+		$blocksFallback = is_array( $content['blocks'] ?? null ) ? $content['blocks'] : [];
 
 		return new self(
 			slug         : $slug,
@@ -105,7 +110,7 @@ class ResolvedTemplatePart extends ResolvedTemplate
 			status       : self::optionalString( $data, 'status', 'publish' ),
 			source       : self::requireSourceEnum( $data, $slug ),
 			rawContent   : self::optionalString( $data, 'raw_content', $rawFallback ),
-			blocks       : self::optionalArray( $data, 'blocks', $data['content']['blocks'] ?? [] ),
+			blocks       : self::optionalArray( $data, 'blocks', $blocksFallback ),
 			hasThemeFile : (bool) ( $data['has_theme_file'] ?? false ),
 			isCustom     : (bool) ( $data['is_custom'] ?? false ),
 			wpId         : isset( $data['wp_id'] ) ? (int) $data['wp_id'] : null,

--- a/src/SiteEditor/Resolution/ResolvedTemplatePart.php
+++ b/src/SiteEditor/Resolution/ResolvedTemplatePart.php
@@ -103,6 +103,11 @@ class ResolvedTemplatePart extends ResolvedTemplate
 		$rawFallback    = self::coerceScalarString( $content['raw'] ?? null ) ?? '';
 		$blocksFallback = is_array( $content['blocks'] ?? null ) ? $content['blocks'] : [];
 
+		// Mirror ResolvedTemplate's top-level coercion so a non-string
+		// scalar at the top level isn't silently dropped while the same
+		// value at `content.raw` is preserved.
+		$rawContent = self::coerceScalarString( $data['raw_content'] ?? null ) ?? $rawFallback;
+
 		return new self(
 			slug         : $slug,
 			theme        : self::requireString( $data, 'theme', $slug ),
@@ -110,7 +115,7 @@ class ResolvedTemplatePart extends ResolvedTemplate
 			description  : self::optionalString( $data, 'description', '' ),
 			status       : self::optionalString( $data, 'status', 'publish' ),
 			source       : self::requireSourceEnum( $data, $slug ),
-			rawContent   : self::optionalString( $data, 'raw_content', $rawFallback ),
+			rawContent   : $rawContent,
 			blocks       : self::optionalArray( $data, 'blocks', $blocksFallback ),
 			hasThemeFile : (bool) ( $data['has_theme_file'] ?? false ),
 			isCustom     : (bool) ( $data['is_custom'] ?? false ),

--- a/src/SiteEditor/Resolution/ResolvedTemplatePart.php
+++ b/src/SiteEditor/Resolution/ResolvedTemplatePart.php
@@ -93,6 +93,10 @@ class ResolvedTemplatePart extends ResolvedTemplate
 			);
 		}
 
+		// Same strict_types-safe rawContent fallback as ResolvedTemplate —
+		// see the comment there for the rationale.
+		$rawFallback = isset( $data['content']['raw'] ) ? (string) $data['content']['raw'] : '';
+
 		return new self(
 			slug         : $slug,
 			theme        : self::requireString( $data, 'theme', $slug ),
@@ -100,7 +104,7 @@ class ResolvedTemplatePart extends ResolvedTemplate
 			description  : self::optionalString( $data, 'description', '' ),
 			status       : self::optionalString( $data, 'status', 'publish' ),
 			source       : self::requireSourceEnum( $data, $slug ),
-			rawContent   : self::optionalString( $data, 'raw_content', $data['raw_content'] ?? $data['content']['raw'] ?? '' ),
+			rawContent   : self::optionalString( $data, 'raw_content', $rawFallback ),
 			blocks       : self::optionalArray( $data, 'blocks', $data['content']['blocks'] ?? [] ),
 			hasThemeFile : (bool) ( $data['has_theme_file'] ?? false ),
 			isCustom     : (bool) ( $data['is_custom'] ?? false ),

--- a/src/SiteEditor/Resolution/ResolvedTemplatePart.php
+++ b/src/SiteEditor/Resolution/ResolvedTemplatePart.php
@@ -94,12 +94,13 @@ class ResolvedTemplatePart extends ResolvedTemplate
 		}
 
 		// Same defensive `content.*` guards as ResolvedTemplate — see the
-		// comment there for the rationale (string-offset coercion silently
+		// comments there for the rationale (string-offset coercion silently
 		// corrupting `rawContent` to a single character if `content` is a
-		// string).
+		// string; `(string) $array` corrupting it to `"Array"` if a value
+		// is non-scalar).
 		$content = is_array( $data['content'] ?? null ) ? $data['content'] : [];
 
-		$rawFallback    = isset( $content['raw'] ) ? (string) $content['raw'] : '';
+		$rawFallback    = self::coerceScalarString( $content['raw'] ?? null ) ?? '';
 		$blocksFallback = is_array( $content['blocks'] ?? null ) ? $content['blocks'] : [];
 
 		return new self(

--- a/src/SiteEditor/Resolution/TemplatePartResolver.php
+++ b/src/SiteEditor/Resolution/TemplatePartResolver.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * Site-editor template-part resolver.
+ *
+ * Consumes the merged `ap.visual-editor.template-parts` filter result.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ *
+ * @extends AbstractMapResolver<ResolvedTemplatePart>
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\SiteEditor\Resolution;
+
+class TemplatePartResolver extends AbstractMapResolver
+{
+	/**
+	 * @since 1.0.0
+	 */
+	protected static function filterName(): string
+	{
+		return 'ap.visual-editor.template-parts';
+	}
+
+	/**
+	 * @since 1.0.0
+	 *
+	 * @param  array<string, mixed>  $entry
+	 */
+	protected static function normalizeEntry( string $key, array $entry ): ResolvedTemplatePart
+	{
+		$entry['slug'] = $entry['slug'] ?? $key;
+
+		return ResolvedTemplatePart::fromArray( $entry );
+	}
+}

--- a/src/SiteEditor/Resolution/TemplateResolver.php
+++ b/src/SiteEditor/Resolution/TemplateResolver.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * Site-editor template resolver.
+ *
+ * Consumes the merged `ap.visual-editor.templates` filter result and exposes
+ * a stable read surface to H6's WP-style REST adapters. Has no awareness of
+ * where the data came from — that's cms-framework's H1 resolution job.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ *
+ * @extends AbstractMapResolver<ResolvedTemplate>
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\SiteEditor\Resolution;
+
+class TemplateResolver extends AbstractMapResolver
+{
+	/**
+	 * @since 1.0.0
+	 */
+	protected static function filterName(): string
+	{
+		return 'ap.visual-editor.templates';
+	}
+
+	/**
+	 * @since 1.0.0
+	 *
+	 * @param  array<string, mixed>  $entry
+	 */
+	protected static function normalizeEntry( string $key, array $entry ): ResolvedTemplate
+	{
+		// Default `slug` to the map key if the contributor omitted it.
+		$entry['slug'] = $entry['slug'] ?? $key;
+
+		return ResolvedTemplate::fromArray( $entry );
+	}
+}

--- a/src/VisualEditorServiceProvider.php
+++ b/src/VisualEditorServiceProvider.php
@@ -28,6 +28,11 @@ use ArtisanPackUI\VisualEditor\Resources\PostResolver;
 use ArtisanPackUI\VisualEditor\Resources\QueryInliner;
 use ArtisanPackUI\VisualEditor\Resources\ResourceResolver;
 use ArtisanPackUI\VisualEditor\Search\BlockTreeSearchExtractor;
+use ArtisanPackUI\VisualEditor\SiteEditor\Resolution\GlobalStylesResolver as SiteEditorGlobalStylesResolver;
+use ArtisanPackUI\VisualEditor\SiteEditor\Resolution\MenuResolver as SiteEditorMenuResolver;
+use ArtisanPackUI\VisualEditor\SiteEditor\Resolution\PatternResolver as SiteEditorPatternResolver;
+use ArtisanPackUI\VisualEditor\SiteEditor\Resolution\TemplatePartResolver as SiteEditorTemplatePartResolver;
+use ArtisanPackUI\VisualEditor\SiteEditor\Resolution\TemplateResolver as SiteEditorTemplateResolver;
 use ArtisanPackUI\VisualEditor\Services\GlobalStylesCacheInvalidator;
 use ArtisanPackUI\VisualEditor\Services\GlobalStylesCompiler;
 use ArtisanPackUI\VisualEditor\Services\GlobalStylesCssProvider;
@@ -67,6 +72,31 @@ class VisualEditorServiceProvider extends ServiceProvider
 		// `ap.visual-editor.resources` callbacks.
 		$this->app->singleton( ResourceResolver::class, function () {
 			return new ResourceResolver();
+		} );
+
+		// H5 — site-editor resolvers. Same pattern as ResourceResolver
+		// above: empty placeholders here; boot() rebinds with the filter-
+		// merged data once all providers have registered their
+		// `ap.visual-editor.{templates,template-parts,patterns,
+		// global-styles,navigation}` callbacks.
+		$this->app->singleton( SiteEditorTemplateResolver::class, function () {
+			return new SiteEditorTemplateResolver();
+		} );
+
+		$this->app->singleton( SiteEditorTemplatePartResolver::class, function () {
+			return new SiteEditorTemplatePartResolver();
+		} );
+
+		$this->app->singleton( SiteEditorPatternResolver::class, function () {
+			return new SiteEditorPatternResolver();
+		} );
+
+		$this->app->singleton( SiteEditorGlobalStylesResolver::class, function () {
+			return new SiteEditorGlobalStylesResolver();
+		} );
+
+		$this->app->singleton( SiteEditorMenuResolver::class, function () {
+			return new SiteEditorMenuResolver();
 		} );
 
 		// G4c-2 — `PostResolver` stamps `_resolved*` keys on `core/post-*`
@@ -184,6 +214,7 @@ class VisualEditorServiceProvider extends ServiceProvider
 		//     filter contract.
 		$this->app->booted( function (): void {
 			$this->registerResourceResolver();
+			$this->registerSiteEditorResolvers();
 		} );
 
 		// 2. Load package views, routes, and migrations.
@@ -369,6 +400,86 @@ class VisualEditorServiceProvider extends ServiceProvider
 		$resources = array_merge( $filtered, $staticConfig );
 
 		$this->app->instance( ResourceResolver::class, new ResourceResolver( $resources ) );
+	}
+
+	/**
+	 * Builds the five site-editor resolvers from filter-merged data.
+	 *
+	 * Mirrors {@see self::registerResourceResolver()}: each filter receives the
+	 * static config, contributors (cms-framework H1–H4) merge their data in,
+	 * static config wins on key collision. Resolvers store the merged shape
+	 * verbatim — validation is deferred to first read so a misconfigured
+	 * contributor surfaces an exception on the editor's first request, not at
+	 * boot.
+	 *
+	 * Standalone visual-editor (no cms-framework, no host registrations) ends
+	 * up with empty resolvers — the editor's site-editor surface boots clean
+	 * and the editor renders with zero entities until something registers.
+	 *
+	 * Public so tests (and edge cases that mutate config or hook callbacks at
+	 * runtime) can re-trigger the rebind without going through reflection.
+	 *
+	 * @since 1.0.0
+	 */
+	public function registerSiteEditorResolvers(): void
+	{
+		// Templates ─ array<string, array> keyed by slug.
+		$templatesStatic = (array) config( 'artisanpack.visual-editor.site-editor.templates', [] );
+		$templatesMerged = applyFilters( 'ap.visual-editor.templates', $templatesStatic );
+		$templatesMerged = is_array( $templatesMerged ) ? $templatesMerged : [];
+		$templatesMerged = array_merge( $templatesMerged, $templatesStatic );
+
+		$this->app->instance(
+			SiteEditorTemplateResolver::class,
+			new SiteEditorTemplateResolver( $templatesMerged ),
+		);
+
+		// Template parts ─ array<string, array> keyed by slug.
+		$partsStatic = (array) config( 'artisanpack.visual-editor.site-editor.template-parts', [] );
+		$partsMerged = applyFilters( 'ap.visual-editor.template-parts', $partsStatic );
+		$partsMerged = is_array( $partsMerged ) ? $partsMerged : [];
+		$partsMerged = array_merge( $partsMerged, $partsStatic );
+
+		$this->app->instance(
+			SiteEditorTemplatePartResolver::class,
+			new SiteEditorTemplatePartResolver( $partsMerged ),
+		);
+
+		// Patterns ─ array<string, array> keyed by slug.
+		$patternsStatic = (array) config( 'artisanpack.visual-editor.site-editor.patterns', [] );
+		$patternsMerged = applyFilters( 'ap.visual-editor.patterns', $patternsStatic );
+		$patternsMerged = is_array( $patternsMerged ) ? $patternsMerged : [];
+		$patternsMerged = array_merge( $patternsMerged, $patternsStatic );
+
+		$this->app->instance(
+			SiteEditorPatternResolver::class,
+			new SiteEditorPatternResolver( $patternsMerged ),
+		);
+
+		// Global styles ─ singleton (?array). Static-config null-coalesces over
+		// filter return so a host that sets static config wins outright; with no
+		// static config, the filter result is authoritative.
+		$globalStylesStatic = config( 'artisanpack.visual-editor.site-editor.global-styles', null );
+		$globalStylesStatic = is_array( $globalStylesStatic ) ? $globalStylesStatic : null;
+		$globalStylesMerged = applyFilters( 'ap.visual-editor.global-styles', $globalStylesStatic );
+		$globalStylesMerged = is_array( $globalStylesMerged ) ? $globalStylesMerged : null;
+		$globalStylesMerged = $globalStylesStatic ?? $globalStylesMerged;
+
+		$this->app->instance(
+			SiteEditorGlobalStylesResolver::class,
+			new SiteEditorGlobalStylesResolver( $globalStylesMerged ),
+		);
+
+		// Navigation ─ array<string, array> keyed by location.
+		$menusStatic = (array) config( 'artisanpack.visual-editor.site-editor.navigation', [] );
+		$menusMerged = applyFilters( 'ap.visual-editor.navigation', $menusStatic );
+		$menusMerged = is_array( $menusMerged ) ? $menusMerged : [];
+		$menusMerged = array_merge( $menusMerged, $menusStatic );
+
+		$this->app->instance(
+			SiteEditorMenuResolver::class,
+			new SiteEditorMenuResolver( $menusMerged ),
+		);
 	}
 
 	/**

--- a/tests/Feature/VisualEditor/SiteEditorFiltersTest.php
+++ b/tests/Feature/VisualEditor/SiteEditorFiltersTest.php
@@ -316,6 +316,44 @@ describe( 'lazy validation on first read', function (): void {
 			->toThrow( SiteEditorRegistrationException::class, 'source' );
 	} );
 
+	it( 'throws when a pattern is missing the title field', function (): void {
+		addFilter( 'ap.visual-editor.patterns', function ( array $existing ): array {
+			return array_merge( [
+				'titleless' => [
+					'slug'   => 'titleless',
+					'source' => 'theme',
+				],
+			], $existing );
+		} );
+
+		rebuildSiteEditorResolvers();
+
+		expect( fn () => app( PatternResolver::class )->all() )
+			->toThrow( SiteEditorRegistrationException::class, 'title' );
+	} );
+
+	it( 'normalizes pattern blocks when content.blocks is not an array', function (): void {
+		// A misconfigured contributor passes a string in the nested
+		// content.blocks slot — should resolve to an empty blocks array
+		// instead of raising a TypeError on the typed constructor param.
+		addFilter( 'ap.visual-editor.patterns', function ( array $existing ): array {
+			return array_merge( [
+				'malformed' => [
+					'slug'    => 'malformed',
+					'title'   => 'Malformed',
+					'source'  => 'theme',
+					'content' => [ 'blocks' => 'not-an-array' ],
+				],
+			], $existing );
+		} );
+
+		rebuildSiteEditorResolvers();
+
+		$pattern = app( PatternResolver::class )->find( 'malformed' );
+
+		expect( $pattern->blocks )->toBe( [] );
+	} );
+
 	it( 'throws when global-styles is missing the theme field', function (): void {
 		addFilter( 'ap.visual-editor.global-styles', function ( $existing ) {
 			return $existing ?? [

--- a/tests/Feature/VisualEditor/SiteEditorFiltersTest.php
+++ b/tests/Feature/VisualEditor/SiteEditorFiltersTest.php
@@ -1,0 +1,364 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\SiteEditor\Exceptions\SiteEditorRegistrationException;
+use ArtisanPackUI\VisualEditor\SiteEditor\Resolution\GlobalStylesResolver;
+use ArtisanPackUI\VisualEditor\SiteEditor\Resolution\MenuResolver;
+use ArtisanPackUI\VisualEditor\SiteEditor\Resolution\PatternResolver;
+use ArtisanPackUI\VisualEditor\SiteEditor\Resolution\ResolvedGlobalStyles;
+use ArtisanPackUI\VisualEditor\SiteEditor\Resolution\ResolvedMenu;
+use ArtisanPackUI\VisualEditor\SiteEditor\Resolution\ResolvedPattern;
+use ArtisanPackUI\VisualEditor\SiteEditor\Resolution\ResolvedTemplate;
+use ArtisanPackUI\VisualEditor\SiteEditor\Resolution\ResolvedTemplatePart;
+use ArtisanPackUI\VisualEditor\SiteEditor\Resolution\TemplatePartResolver;
+use ArtisanPackUI\VisualEditor\SiteEditor\Resolution\TemplateResolver;
+use ArtisanPackUI\VisualEditor\VisualEditorServiceProvider;
+
+afterEach( function (): void {
+	foreach ( [
+		'ap.visual-editor.templates',
+		'ap.visual-editor.template-parts',
+		'ap.visual-editor.patterns',
+		'ap.visual-editor.global-styles',
+		'ap.visual-editor.navigation',
+	] as $filter ) {
+		removeAllFilters( $filter );
+	}
+
+	config()->set( 'artisanpack.visual-editor.site-editor', [
+		'templates'      => [],
+		'template-parts' => [],
+		'patterns'       => [],
+		'global-styles'  => null,
+		'navigation'     => [],
+	] );
+} );
+
+function rebuildSiteEditorResolvers(): void
+{
+	( new VisualEditorServiceProvider( app() ) )->registerSiteEditorResolvers();
+}
+
+describe( 'standalone install (no contributors, no static config)', function (): void {
+	it( 'boots cleanly with empty resolvers for every entity type', function (): void {
+		rebuildSiteEditorResolvers();
+
+		expect( app( TemplateResolver::class )->all() )->toBe( [] )
+			->and( app( TemplatePartResolver::class )->all() )->toBe( [] )
+			->and( app( PatternResolver::class )->all() )->toBe( [] )
+			->and( app( GlobalStylesResolver::class )->get() )->toBeNull()
+			->and( app( MenuResolver::class )->all() )->toBe( [] );
+	} );
+} );
+
+describe( 'single-source filter contribution', function (): void {
+	it( 'registers a template via the templates filter', function (): void {
+		addFilter( 'ap.visual-editor.templates', function ( array $existing ): array {
+			return array_merge( [
+				'page' => [
+					'slug'   => 'page',
+					'theme'  => 'digital-shopfront',
+					'title'  => 'Page',
+					'source' => 'theme',
+				],
+			], $existing );
+		} );
+
+		rebuildSiteEditorResolvers();
+
+		$template = app( TemplateResolver::class )->find( 'page' );
+
+		expect( $template )->toBeInstanceOf( ResolvedTemplate::class )
+			->and( $template->slug )->toBe( 'page' )
+			->and( $template->theme )->toBe( 'digital-shopfront' )
+			->and( $template->source )->toBe( 'theme' );
+	} );
+
+	it( 'registers a template-part with area', function (): void {
+		addFilter( 'ap.visual-editor.template-parts', function ( array $existing ): array {
+			return array_merge( [
+				'header' => [
+					'slug'   => 'header',
+					'theme'  => 'digital-shopfront',
+					'title'  => 'Header',
+					'area'   => 'header',
+					'source' => 'theme',
+				],
+			], $existing );
+		} );
+
+		rebuildSiteEditorResolvers();
+
+		$part = app( TemplatePartResolver::class )->find( 'header' );
+
+		expect( $part )->toBeInstanceOf( ResolvedTemplatePart::class )
+			->and( $part->area )->toBe( 'header' );
+	} );
+
+	it( 'registers a pattern with source flag', function (): void {
+		addFilter( 'ap.visual-editor.patterns', function ( array $existing ): array {
+			return array_merge( [
+				'cta' => [
+					'slug'   => 'cta',
+					'title'  => 'Call to Action',
+					'source' => 'theme',
+					'synced' => false,
+				],
+			], $existing );
+		} );
+
+		rebuildSiteEditorResolvers();
+
+		$pattern = app( PatternResolver::class )->find( 'cta' );
+
+		expect( $pattern )->toBeInstanceOf( ResolvedPattern::class )
+			->and( $pattern->source )->toBe( 'theme' )
+			->and( $pattern->synced )->toBeFalse();
+	} );
+
+	it( 'registers global-styles as a singleton', function (): void {
+		addFilter( 'ap.visual-editor.global-styles', function ( $existing ) {
+			return $existing ?? [
+				'theme'    => 'digital-shopfront',
+				'settings' => [ 'color' => [ 'palette' => [] ] ],
+				'styles'   => [],
+			];
+		} );
+
+		rebuildSiteEditorResolvers();
+
+		$globals = app( GlobalStylesResolver::class )->get();
+
+		expect( $globals )->toBeInstanceOf( ResolvedGlobalStyles::class )
+			->and( $globals->theme )->toBe( 'digital-shopfront' );
+	} );
+
+	it( 'registers a menu under its location', function (): void {
+		addFilter( 'ap.visual-editor.navigation', function ( array $existing ): array {
+			return array_merge( [
+				'primary' => [
+					'location' => 'primary',
+					'name'     => 'Primary Menu',
+					'items'    => [],
+				],
+			], $existing );
+		} );
+
+		rebuildSiteEditorResolvers();
+
+		$menu = app( MenuResolver::class )->find( 'primary' );
+
+		expect( $menu )->toBeInstanceOf( ResolvedMenu::class )
+			->and( $menu->location )->toBe( 'primary' )
+			->and( $menu->name )->toBe( 'Primary Menu' );
+	} );
+} );
+
+describe( 'static config wins on key collision', function (): void {
+	it( 'overrides a filter-contributed template when the same slug is in static config', function (): void {
+		config()->set( 'artisanpack.visual-editor.site-editor.templates', [
+			'page' => [
+				'slug'   => 'page',
+				'theme'  => 'host-theme',
+				'title'  => 'Host Page',
+				'source' => 'theme',
+			],
+		] );
+
+		addFilter( 'ap.visual-editor.templates', function ( array $existing ): array {
+			return array_merge( [
+				'page' => [
+					'slug'   => 'page',
+					'theme'  => 'cms-framework-theme',
+					'title'  => 'CMS Page',
+					'source' => 'theme',
+				],
+			], $existing );
+		} );
+
+		rebuildSiteEditorResolvers();
+
+		$template = app( TemplateResolver::class )->find( 'page' );
+
+		expect( $template->theme )->toBe( 'host-theme' )
+			->and( $template->title )->toBe( 'Host Page' );
+	} );
+
+	it( 'merges non-colliding static + filter entries', function (): void {
+		config()->set( 'artisanpack.visual-editor.site-editor.templates', [
+			'host-page' => [
+				'slug'   => 'host-page',
+				'theme'  => 'host-theme',
+				'title'  => 'Host Page',
+				'source' => 'theme',
+			],
+		] );
+
+		addFilter( 'ap.visual-editor.templates', function ( array $existing ): array {
+			return array_merge( [
+				'cms-page' => [
+					'slug'   => 'cms-page',
+					'theme'  => 'cms-theme',
+					'title'  => 'CMS Page',
+					'source' => 'theme',
+				],
+			], $existing );
+		} );
+
+		rebuildSiteEditorResolvers();
+
+		$resolver = app( TemplateResolver::class );
+
+		expect( $resolver->find( 'host-page' )->theme )->toBe( 'host-theme' )
+			->and( $resolver->find( 'cms-page' )->theme )->toBe( 'cms-theme' );
+	} );
+
+	it( 'static global-styles config wins outright over filter contribution', function (): void {
+		config()->set( 'artisanpack.visual-editor.site-editor.global-styles', [
+			'theme'    => 'host-theme',
+			'settings' => [ 'host' => true ],
+			'styles'   => [],
+		] );
+
+		addFilter( 'ap.visual-editor.global-styles', function ( $existing ) {
+			return $existing ?? [
+				'theme'    => 'cms-theme',
+				'settings' => [ 'cms' => true ],
+				'styles'   => [],
+			];
+		} );
+
+		rebuildSiteEditorResolvers();
+
+		$globals = app( GlobalStylesResolver::class )->get();
+
+		expect( $globals->theme )->toBe( 'host-theme' )
+			->and( $globals->settings )->toBe( [ 'host' => true ] );
+	} );
+} );
+
+describe( 'lazy validation on first read', function (): void {
+	it( 'does not throw at boot when a filter returns malformed entries', function (): void {
+		addFilter( 'ap.visual-editor.templates', function ( array $existing ): array {
+			return array_merge( [
+				'broken' => 'this-is-not-an-array',
+			], $existing );
+		} );
+
+		// Rebuild must succeed even with a malformed contribution.
+		rebuildSiteEditorResolvers();
+
+		expect( app( TemplateResolver::class ) )->toBeInstanceOf( TemplateResolver::class );
+	} );
+
+	it( 'throws SiteEditorRegistrationException on first all() with a malformed entry', function (): void {
+		addFilter( 'ap.visual-editor.templates', function ( array $existing ): array {
+			return array_merge( [
+				'broken' => 'this-is-not-an-array',
+			], $existing );
+		} );
+
+		rebuildSiteEditorResolvers();
+
+		expect( fn () => app( TemplateResolver::class )->all() )
+			->toThrow( SiteEditorRegistrationException::class );
+	} );
+
+	it( 'throws when a template entry is missing the required theme field', function (): void {
+		addFilter( 'ap.visual-editor.templates', function ( array $existing ): array {
+			return array_merge( [
+				'no-theme' => [
+					'slug'   => 'no-theme',
+					'title'  => 'No Theme',
+					'source' => 'theme',
+				],
+			], $existing );
+		} );
+
+		rebuildSiteEditorResolvers();
+
+		expect( fn () => app( TemplateResolver::class )->all() )
+			->toThrow( SiteEditorRegistrationException::class, 'theme' );
+	} );
+
+	it( 'throws when a template-part has an invalid area', function (): void {
+		addFilter( 'ap.visual-editor.template-parts', function ( array $existing ): array {
+			return array_merge( [
+				'banner' => [
+					'slug'   => 'banner',
+					'theme'  => 'test',
+					'area'   => 'invalid-area',
+					'source' => 'theme',
+				],
+			], $existing );
+		} );
+
+		rebuildSiteEditorResolvers();
+
+		expect( fn () => app( TemplatePartResolver::class )->all() )
+			->toThrow( SiteEditorRegistrationException::class, 'area' );
+	} );
+
+	it( 'throws when a pattern has an invalid source value', function (): void {
+		addFilter( 'ap.visual-editor.patterns', function ( array $existing ): array {
+			return array_merge( [
+				'bad' => [
+					'slug'   => 'bad',
+					'source' => 'wherever',
+				],
+			], $existing );
+		} );
+
+		rebuildSiteEditorResolvers();
+
+		expect( fn () => app( PatternResolver::class )->all() )
+			->toThrow( SiteEditorRegistrationException::class, 'source' );
+	} );
+
+	it( 'throws when global-styles is missing the theme field', function (): void {
+		addFilter( 'ap.visual-editor.global-styles', function ( $existing ) {
+			return $existing ?? [
+				'settings' => [],
+				'styles'   => [],
+			];
+		} );
+
+		rebuildSiteEditorResolvers();
+
+		expect( fn () => app( GlobalStylesResolver::class )->get() )
+			->toThrow( SiteEditorRegistrationException::class, 'theme' );
+	} );
+
+	it( 'auto-stamps the map key as location when a navigation entry omits the field', function (): void {
+		addFilter( 'ap.visual-editor.navigation', function ( array $existing ): array {
+			return array_merge( [
+				'primary' => [
+					'name' => 'Primary',
+					// Missing 'location' — the resolver should fill it from the map key.
+				],
+			], $existing );
+		} );
+
+		rebuildSiteEditorResolvers();
+
+		$menu = app( MenuResolver::class )->find( 'primary' );
+
+		expect( $menu->location )->toBe( 'primary' );
+	} );
+
+	it( 'throws when a non-array filter return value would corrupt the resolver', function (): void {
+		addFilter( 'ap.visual-editor.templates', function ( $existing ) {
+			// Pathological contributor: returns a string.
+			return 'oops';
+		} );
+
+		// The boot-side guard coerces non-array filter output back to an
+		// empty array, so the resolver itself never sees the bad value —
+		// this also means standalone install behavior is preserved when a
+		// host's filter callback misfires.
+		rebuildSiteEditorResolvers();
+
+		expect( app( TemplateResolver::class )->all() )->toBe( [] );
+	} );
+} );

--- a/tests/Feature/VisualEditor/SiteEditorFiltersTest.php
+++ b/tests/Feature/VisualEditor/SiteEditorFiltersTest.php
@@ -418,6 +418,74 @@ describe( 'lazy validation on first read', function (): void {
 			->and( $part->blocks )->toBe( [] );
 	} );
 
+	it( 'does not stringify a non-scalar raw_content to "Array" on patterns', function (): void {
+		// A contributor passes an array under `raw_content` (or under a
+		// nested `content.raw`). Without the is_scalar guard,
+		// `(string) $array` produces the literal `"Array"` and ships
+		// silently — the resolver should fall back to the empty default
+		// instead.
+		addFilter( 'ap.visual-editor.patterns', function ( array $existing ): array {
+			return array_merge( [
+				'array-raw' => [
+					'slug'        => 'array-raw',
+					'title'       => 'Array Raw',
+					'source'      => 'theme',
+					'raw_content' => [ 'unexpected' => 'array' ],
+				],
+			], $existing );
+		} );
+
+		rebuildSiteEditorResolvers();
+
+		$pattern = app( PatternResolver::class )->find( 'array-raw' );
+
+		expect( $pattern->rawContent )->toBe( '' )
+			->and( $pattern->rawContent )->not->toBe( 'Array' );
+	} );
+
+	it( 'does not stringify a non-scalar nested content.raw to "Array" on templates', function (): void {
+		addFilter( 'ap.visual-editor.templates', function ( array $existing ): array {
+			return array_merge( [
+				'array-content-raw' => [
+					'slug'    => 'array-content-raw',
+					'theme'   => 'host',
+					'source'  => 'theme',
+					'content' => [
+						'raw' => [ 'unexpected' => 'array' ],
+					],
+				],
+			], $existing );
+		} );
+
+		rebuildSiteEditorResolvers();
+
+		$template = app( TemplateResolver::class )->find( 'array-content-raw' );
+
+		expect( $template->rawContent )->toBe( '' );
+	} );
+
+	it( 'coerces scalar non-string raw_content (int/float/bool) to a string on patterns', function (): void {
+		// is_scalar accepts int, float, bool — these are sensibly stringable
+		// and shouldn't be rejected. Verifies the coercion path exposes the
+		// stringified value rather than dropping it.
+		addFilter( 'ap.visual-editor.patterns', function ( array $existing ): array {
+			return array_merge( [
+				'numeric-raw' => [
+					'slug'        => 'numeric-raw',
+					'title'       => 'Numeric Raw',
+					'source'      => 'theme',
+					'raw_content' => 42,
+				],
+			], $existing );
+		} );
+
+		rebuildSiteEditorResolvers();
+
+		$pattern = app( PatternResolver::class )->find( 'numeric-raw' );
+
+		expect( $pattern->rawContent )->toBe( '42' );
+	} );
+
 	it( 'throws when global-styles is missing the theme field', function (): void {
 		addFilter( 'ap.visual-editor.global-styles', function ( $existing ) {
 			return $existing ?? [

--- a/tests/Feature/VisualEditor/SiteEditorFiltersTest.php
+++ b/tests/Feature/VisualEditor/SiteEditorFiltersTest.php
@@ -486,6 +486,48 @@ describe( 'lazy validation on first read', function (): void {
 		expect( $pattern->rawContent )->toBe( '42' );
 	} );
 
+	it( 'coerces scalar non-string raw_content to a string on templates', function (): void {
+		// Top-level raw_content + nested content.raw should behave the same
+		// way: a non-string scalar (here, an int) coerces to its string form
+		// rather than being silently dropped.
+		addFilter( 'ap.visual-editor.templates', function ( array $existing ): array {
+			return array_merge( [
+				'numeric-template' => [
+					'slug'        => 'numeric-template',
+					'theme'       => 'host',
+					'source'      => 'theme',
+					'raw_content' => 42,
+				],
+			], $existing );
+		} );
+
+		rebuildSiteEditorResolvers();
+
+		$template = app( TemplateResolver::class )->find( 'numeric-template' );
+
+		expect( $template->rawContent )->toBe( '42' );
+	} );
+
+	it( 'coerces scalar non-string raw_content to a string on template parts', function (): void {
+		addFilter( 'ap.visual-editor.template-parts', function ( array $existing ): array {
+			return array_merge( [
+				'numeric-part' => [
+					'slug'        => 'numeric-part',
+					'theme'       => 'host',
+					'area'        => 'header',
+					'source'      => 'theme',
+					'raw_content' => 1.5,
+				],
+			], $existing );
+		} );
+
+		rebuildSiteEditorResolvers();
+
+		$part = app( TemplatePartResolver::class )->find( 'numeric-part' );
+
+		expect( $part->rawContent )->toBe( '1.5' );
+	} );
+
 	it( 'throws when global-styles is missing the theme field', function (): void {
 		addFilter( 'ap.visual-editor.global-styles', function ( $existing ) {
 			return $existing ?? [

--- a/tests/Feature/VisualEditor/SiteEditorFiltersTest.php
+++ b/tests/Feature/VisualEditor/SiteEditorFiltersTest.php
@@ -354,6 +354,70 @@ describe( 'lazy validation on first read', function (): void {
 		expect( $pattern->blocks )->toBe( [] );
 	} );
 
+	it( 'safely handles a scalar content envelope on patterns', function (): void {
+		// content is a string instead of an array. Without the defensive
+		// is_array guard, $data['content']['raw'] would index into the
+		// string and silently corrupt rawContent to its first character.
+		addFilter( 'ap.visual-editor.patterns', function ( array $existing ): array {
+			return array_merge( [
+				'scalar-content' => [
+					'slug'    => 'scalar-content',
+					'title'   => 'Scalar Content',
+					'source'  => 'theme',
+					'content' => 'this should be an array',
+				],
+			], $existing );
+		} );
+
+		rebuildSiteEditorResolvers();
+
+		$pattern = app( PatternResolver::class )->find( 'scalar-content' );
+
+		expect( $pattern->rawContent )->toBe( '' )
+			->and( $pattern->blocks )->toBe( [] );
+	} );
+
+	it( 'safely handles a scalar content envelope on templates', function (): void {
+		addFilter( 'ap.visual-editor.templates', function ( array $existing ): array {
+			return array_merge( [
+				'scalar-template' => [
+					'slug'    => 'scalar-template',
+					'theme'   => 'host',
+					'source'  => 'theme',
+					'content' => 'malformed string',
+				],
+			], $existing );
+		} );
+
+		rebuildSiteEditorResolvers();
+
+		$template = app( TemplateResolver::class )->find( 'scalar-template' );
+
+		expect( $template->rawContent )->toBe( '' )
+			->and( $template->blocks )->toBe( [] );
+	} );
+
+	it( 'safely handles a scalar content envelope on template parts', function (): void {
+		addFilter( 'ap.visual-editor.template-parts', function ( array $existing ): array {
+			return array_merge( [
+				'scalar-part' => [
+					'slug'    => 'scalar-part',
+					'theme'   => 'host',
+					'area'    => 'header',
+					'source'  => 'theme',
+					'content' => 'malformed string',
+				],
+			], $existing );
+		} );
+
+		rebuildSiteEditorResolvers();
+
+		$part = app( TemplatePartResolver::class )->find( 'scalar-part' );
+
+		expect( $part->rawContent )->toBe( '' )
+			->and( $part->blocks )->toBe( [] );
+	} );
+
 	it( 'throws when global-styles is missing the theme field', function (): void {
 		addFilter( 'ap.visual-editor.global-styles', function ( $existing ) {
 			return $existing ?? [


### PR DESCRIPTION
## Description

Implements **H5** of plan 14 (cms-framework site-editor integration). Adds five new filters that surface site-editor entity types from any registering host, plus the resolver scaffolding visual-editor's H6 (entity adapters + `addEntities`) will consume. cms-framework registers under `class_exists` guards as H1–H4 ship.

This is the visual-editor side of plan 14's bridge — equivalent in shape to Phase G's `ap.visual-editor.resources` filter (#397), one filter per site-editor entity type instead of one for everything.

**Closes:** #407

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #407

## Motivation and Context

Visual-editor's H6 (adapters + sidebars, not yet filed) needs a stable read surface for site-editor entities so it can populate `addEntities()` at editor bootstrap. cms-framework's H1–H4 backends produce the data; this PR is the visual-editor-side filter scaffolding that aggregates contributions.

Filter shape mirrors `ap.visual-editor.resources` from G1b: each filter receives the static config (typically empty), contributors merge their data in, static config wins on key collision. Validation is deferred until first read so a misconfigured contributor surfaces an exception on the editor's first request, not at boot — letting standalone visual-editor (no cms-framework) and standalone cms-framework (no visual-editor) both boot cleanly even when contributors return garbage.

## Changes Made

**New module: `src/SiteEditor/`**

- **Resolution layer** (10 files): five typed value objects (`ResolvedTemplate`, `ResolvedTemplatePart`, `ResolvedPattern`, `ResolvedGlobalStyles`, `ResolvedMenu`), an `AbstractMapResolver<TValue>` shared by the four map-style entity types, and the five concrete resolvers (`TemplateResolver`, `TemplatePartResolver`, `PatternResolver`, `GlobalStylesResolver`, `MenuResolver`). Each value object's `fromArray()` factory throws `SiteEditorRegistrationException` on missing required fields or invalid enum values.
- **Exception layer**: `SiteEditorRegistrationException` with three named factories (`invalidFilterShape`, `missingRequiredField`, `invalidField`) — the latter two carry the offending filter name + entry key + field name in the message so misconfigured contributors are easy to spot.

**`VisualEditorServiceProvider`**

- `register()` binds the five resolvers as singleton placeholders (so other providers' `register()` phases can typehint them).
- `boot()`'s existing `$this->app->booted(...)` callback now also calls a new `registerSiteEditorResolvers()` method that reads static config, applies each filter, merges (static wins on collision; for the singleton `global-styles`, non-null static config wins outright), and rebinds the resolver instance with the merged data.

**`config/visual-editor.php`**

- New `site-editor` section with five sub-keys (`templates`, `template-parts`, `patterns`, `global-styles`, `navigation`) for static-config entry points.

**`docs/plans/14-cms-framework-site-editor-integration.md`**

- §4.4 extended with an "Implementation reference (H5 shipped)" subsection pointing at the resolver/exception/provider/test files in the source tree.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS 15.4
- PHP Version: 8.4.3
- Project Version: visual-editor `release/1.0`

**Tests Performed:**
1. `./vendor/bin/pest tests/Feature/VisualEditor/SiteEditorFiltersTest.php --compact` → 17/17 pass.
2. `./vendor/bin/pest --compact` (full suite) → 528 passed, 1 skipped (pre-existing), 0 failures.
3. `coderabbit review --plain --base origin/release/1.0` — see review summary on this PR.

## Accessibility Tests Run

- [x] Not applicable — backend / filter-wiring work; no UI changes.

**Details:** Pure backend module. No UI surface affected; the consumer is visual-editor's H6 entity-adapter layer (filed at H6 kickoff) and ultimately the editor shell's `addEntities()` registration.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:**

`tests/Feature/VisualEditor/SiteEditorFiltersTest.php` — 17 tests organized into four describe blocks matching the issue's acceptance criteria:

1. **Standalone install** — boots cleanly with empty resolvers for all five entity types.
2. **Single-source filter contribution** — one test per entity type confirming the filter result reaches the resolver and constructs the right typed value object.
3. **Static config wins on key collision** — overrides for templates (map filter), merging non-colliding static + filter entries, and the singleton global-styles `null`-coalesce semantics.
4. **Lazy validation on first read** — boot survives a malformed filter contribution; `all()` / `get()` throws `SiteEditorRegistrationException` with the offending field named; missing `theme`, invalid `area` enum, invalid `source` enum, missing `theme` on global-styles; non-array filter return is coerced back to empty (boot-side guard); auto-stamp behavior for `location` from the map key.

## Documentation

- [x] Inline code documentation added
- [x] Plan doc cross-reference added (`docs/plans/14-cms-framework-site-editor-integration.md` §4.4)

**Documentation details:**

Each value object, resolver, and the exception class carry full PHPDoc explaining the filter contract, lazy-validation rationale, and where the type fits in the H5/H6 pipeline. The plan-14 doc now points at the implementation files so future readers don't have to grep the source tree.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests (528 pass, 1 pre-existing skip)
- [x] Code follows project style guide (tabs for indentation, matching existing files)
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Site-editor support for templates, template-parts, patterns, global-styles, and navigation via a new static config entry and merged dynamic contributions.

* **Bug Fixes / Reliability**
  * Static config now wins collisions; lazy resolver behavior lets installs boot empty and surfaces precise validation errors on first access.
  * Safer normalization for content, blocks, raw content coercion, and auto-defaulted navigation locations.

* **Documentation**
  * Expanded guide describing registration, merging, precedence, and error cases.

* **Tests**
  * Comprehensive feature tests covering empty installs, single-source, collisions, normalization, and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->