### PR TITLE
H7 — Site-editor shell wiring + install gate (#432)

### DIFF
--- a/docs/plans/14-cms-framework-site-editor-integration.md
+++ b/docs/plans/14-cms-framework-site-editor-integration.md
@@ -3,7 +3,7 @@
 **Package:** `artisanpack-ui/visual-editor` (companion: `artisanpack-ui/cms-framework`)
 **Version Target:** visual-editor 1.0.0 / cms-framework 1.x
 **Created:** April 27, 2026
-**Status:** In rollout — H0–H6 shipped (#100, #108, #110, #112, #114, #407, #431); H7 + H8 pending
+**Status:** In rollout — H0–H7 shipped (#100, #108, #110, #112, #114, #407, #431, #432); H8 pending
 **Relates to:** #309 (umbrella), [`11-v1-expansion.md`](11-v1-expansion.md), [`12-cms-framework-integration.md`](12-cms-framework-integration.md).
 **Supersedes scope of:** [`11-v1-expansion.md`](11-v1-expansion.md) Phase C (templates / template-parts / patterns / global-styles / navigation backends) and the corresponding Phase D backend wiring — those phases assumed visual-editor first-party tables. This plan moves ownership of those entities into cms-framework. Phase D's UI work in visual-editor remains, retargeted at cms-framework endpoints.
 
@@ -287,6 +287,25 @@ The H6 surface ships across six commits on the `feature/431-site-editor-h6-adapt
 
 Plan 11 Phase D legacy code cleanup — `VisualEditor{Template,TemplatePart,Pattern,GlobalStyles,Navigation}` models + their migrations + factories + policies; the legacy `Resources/{TemplateResolver,TemplatePartInliner,PatternInliner}` classes; the `Services/GlobalStylesCssProvider` + `GlobalStylesCacheInvalidator` (cms-framework's `GlobalStylesEmitter` per §4.6 supersedes); `EntitySearchController` rewrite to consume cms-framework's resource map; `MenuLocationsController` rewrite to consume cms-framework's `MenuLocationAssignment`. These are still alive at the model layer because their consumers (search picker, location config endpoint, CSS emission) remain wired to the old DB; #434 spells out the per-system cutover order.
 
+#### 4.5.2 Implementation status — H7 shipped
+
+H7 (#432) layers two pieces on top of the H6 surface:
+
+| Sub-task | Files | Tests |
+|---|---|---|
+| Server-side install gate | `src/SiteEditor/CmsFrameworkIntegration.php`, `resources/views/site-editor/install-gate.blade.php`, `routes/web.php` | `tests/Feature/SiteEditor/InstallGateTest.php` (gate fires) + `InstallGateActiveTest.php` (gate falls through to SPA mount) |
+| Lazy-loaded section orchestrators | `resources/js/visual-editor/site-editor/section-portal.tsx`, default exports added to `styles/styles-section.tsx`, `navigation/navigation-section.tsx`, `patterns/patterns-section.tsx`; `site-editor-app.tsx` swaps the static hook calls for `React.lazy` + `Suspense` + portal slots | `tests/Feature/SiteEditorShellTest.php` (lazy boundary pinned at the source) + the existing site-editor-app shell test (updated mocks) |
+
+**Open questions resolved at H7 kickoff:**
+
+- **Install-gate copy** (deferred from H6) — final wording in `resources/views/site-editor/install-gate.blade.php`. Heading: *"Install cms-framework to enable the site editor"*. Body explains the dependency, shows a copy-pasteable `composer require` command, and links back to the post editor (which works standalone). The gate uses inline styles so it stays renderable when the Vite manifest isn't built.
+- **Entity-route lazy-loading** — three of the five section orchestrators (styles, navigation, patterns) ship as `React.lazy()` chunks; the shell exposes stable navigator/canvas/inspector/overlay portal slots and each lazy section portals its hook results into them. Templates and template-parts stay eager because they share `useEntityEditorViews` with the post-editor's already-warm bundle and they're the default landing path; making them lazy would pay a chunk-fetch cost on the most-trafficked nav.
+
+**Notable departures:**
+
+- **Coarse availability probe at the route** — `CmsFrameworkIntegration::isAvailable()` checks `class_exists` on cms-framework's `Template` model + `app()->bound()` on the `TemplateResolver` binding. Each H6 controller has its own per-entity probe; the route uses a single coarser check because cms-framework registers all four resolvers in one provider boot. Either signal alone would do — picking templates because H1 ships first.
+- **Slot-based portal architecture for the three lazy sections** — the navigator/canvas/inspector slots are conditional on whether the active section needs them, but they're at stable JSX positions so React reuses the same DOM elements across re-renders inside a section. The lazy section component receives the live slot state and renders a portal-or-null per slot — when the slot div isn't rendered (e.g., D4 with no entity loaded → falls back to `InspectorOutlet`), the slot state is null and the portal silently no-ops. This mirrors the existing shell's "show/hide the inspector based on entity load" behavior without forcing the section component to know about that gate.
+
 ### 4.6 CSS emission (H3)
 
 `GlobalStylesEmitter` service translates the resolved global-styles object into CSS custom properties + per-block class rules. Output is cached on a content hash; cache busts on any DB write to `global_styles` or theme switch.
@@ -376,6 +395,6 @@ Not blocking this plan, but worth naming so they don't surface mid-implementatio
 - **H2 user-pattern slug strategy** — `user/{slug}` prefix at storage (decision in §5.6) or separate `user_patterns` table? Leaning prefix for one model, one table.
 - **H3 variation registration** — theme-only (declared in `theme.json` `styles.variations`) or also runtime-registerable by apps? Leaning theme-only for V1.
 - **H4 menu-item link types** — `core/navigation-link` only, or also `core/navigation-submenu` and `core/page-list`? All three needed for parity; budget extra time at H4 kickoff.
-- **H6 install-gate copy** — exact wording for the "cms-framework required" page. Decide at H6 kickoff.
-- **H7 entity-route lazy-loading** — load all five entity-list views eagerly at site-editor boot (faster nav, larger initial bundle), or per-route lazy (smaller boot, per-nav cost)? Leaning lazy.
+- ~~**H6 install-gate copy** — exact wording for the "cms-framework required" page. Decide at H6 kickoff.~~ Resolved at H7 kickoff (deferred from H6 because the gate ships in H7) — see §4.5.2.
+- ~~**H7 entity-route lazy-loading** — load all five entity-list views eagerly at site-editor boot (faster nav, larger initial bundle), or per-route lazy (smaller boot, per-nav cost)? Leaning lazy.~~ Resolved: lazy on styles/navigation/patterns; eager on templates/template-parts. See §4.5.2.
 - **H8 sample theme name + scope** — fork cms-framework's `digital-shopfront` reference theme into the dev-app, or build a minimal `dev-sample` theme just for the smoke flow? Decide at H8 kickoff.

--- a/docs/plans/15-issue-roadmap.md
+++ b/docs/plans/15-issue-roadmap.md
@@ -86,15 +86,16 @@ After Wave 1. `#100` (H0) gates H1–H4. **H1–H4 in cms-framework and H6–H8 
 | Issue | Repo | Title | Priority | Effort | Depends on |
 |---|---|---|---|---|---|
 | `#406` | visual-editor | Plan 14 umbrella | High | High | — |
-| `#100` | cms-framework | H0 · `theme.json` schema extension | High | Medium | — |
-| *not filed* | cms-framework | H1 · Templates + template-parts module | — | — | `#100` |
-| *not filed* | cms-framework | H2 · Patterns module | — | — | `#100` |
-| *not filed* | cms-framework | H3 · Global styles + CSS emission | — | — | `#100` |
-| *not filed* | cms-framework | H4 · Menus module | — | — | `#100` |
-| `#407` | visual-editor | H5 · Site-editor resource filters | High | Medium | H1–H4 *(any one)* |
-| *not filed* | visual-editor | H6 · WP-shape adapters + `addEntities` + sidebars | — | — | `#407` |
-| *not filed* | visual-editor | H7 · Rescope plan 11 Phase D UI | — | — | H6 |
-| *not filed* | visual-editor | H8 · Dev-app sample theme + smoke flow | — | — | H7 |
+| ~~`#100`~~ | cms-framework | H0 · `theme.json` schema extension *(closed)* | High | Medium | — |
+| ~~`#108`~~ | cms-framework | H1 · Templates + template-parts module *(closed)* | High | High | `#100` |
+| ~~`#110`~~ | cms-framework | H2 · Patterns module *(closed)* | High | High | `#100` |
+| ~~`#112`~~ | cms-framework | H3 · Global styles + CSS emission *(closed)* | High | High | `#100` |
+| ~~`#114`~~ | cms-framework | H4 · Menus module *(closed)* | High | High | `#100` |
+| ~~`#407`~~ | visual-editor | H5 · Site-editor resource filters *(closed)* | High | Medium | H1–H4 *(any one)* |
+| ~~`#431`~~ | visual-editor | H6 · WP-shape adapters + `addEntities` + sidebars *(closed)* | High | High | `#407` |
+| ~~`#432`~~ | visual-editor | H7 · Site-editor shell wiring + install gate *(closed)* | High | Medium | H6 |
+| `#433` | visual-editor | H8 · Dev-app sample theme + smoke flow + version-pair docs | High | Medium | H7 |
+| `#434` | visual-editor | Follow-up · delete plan-11-Phase-D legacy site-editor code | Medium | Medium | H7 |
 
 ### Parallel polish track
 

--- a/resources/js/visual-editor/site-editor/__tests__/api-client.test.ts
+++ b/resources/js/visual-editor/site-editor/__tests__/api-client.test.ts
@@ -42,11 +42,10 @@ afterEach(() => {
 });
 
 describe('listEntities', () => {
-    it('requests the paginated envelope and applies filters', async () => {
-        const body = {
-            data: [{ id: 1, slug: 'single', title: { rendered: 'Single' } }],
-            meta: { current_page: 1, last_page: 1, per_page: 25, total: 1 },
-        };
+    it('returns the H6 flat-array response and applies filters', async () => {
+        // H7 (#432). H6's `TemplateController::index` returns a flat
+        // JSON array — no `{ data, meta }` envelope.
+        const body = [{ id: 1, slug: 'single', title: { rendered: 'Single' } }];
         const fetchMock = mockFetch(jsonResponse(body));
 
         const result = await listEntities(
@@ -55,8 +54,8 @@ describe('listEntities', () => {
             { perPage: 10, theme: 'my-theme', status: 'publish' }
         );
 
-        expect(result.data).toHaveLength(1);
-        expect(result.meta.total).toBe(1);
+        expect(result).toHaveLength(1);
+        expect(result[0]?.id).toBe(1);
 
         const firstCall = fetchMock.mock.calls[0];
         expect(firstCall).toBeDefined();
@@ -68,13 +67,21 @@ describe('listEntities', () => {
         expect(url).toContain('status=publish');
     });
 
-    it('hits the template-parts endpoint with an area filter', async () => {
-        const fetchMock = mockFetch(
-            jsonResponse({
-                data: [],
-                meta: { current_page: 1, last_page: 1, per_page: 25, total: 0 },
-            })
+    it('coerces non-array bodies to an empty list', async () => {
+        // Defensive — a malformed response should not crash the
+        // navigator with `items.length === undefined`.
+        mockFetch(jsonResponse({ message: 'oops' }));
+
+        const result = await listEntities(
+            { apiBase: API_BASE },
+            'template'
         );
+
+        expect(result).toEqual([]);
+    });
+
+    it('hits the template-parts endpoint with an area filter', async () => {
+        const fetchMock = mockFetch(jsonResponse([]));
 
         await listEntities(
             { apiBase: API_BASE },

--- a/resources/js/visual-editor/site-editor/__tests__/entity-browser.test.tsx
+++ b/resources/js/visual-editor/site-editor/__tests__/entity-browser.test.tsx
@@ -29,22 +29,20 @@ afterEach(() => {
 
 describe('EntityBrowser', () => {
     it('shows a loading status then the rows returned by the API', async () => {
-        LIST_MOCK.mockResolvedValue({
-            data: [
-                {
-                    id: 1,
-                    slug: 'single',
-                    title: { rendered: 'Single post' },
-                    content: { raw: '', blocks: [] },
-                    status: 'publish',
-                    theme: 'default',
-                    type: 'wp_template',
-                    source: 'theme',
-                    origin: null,
-                },
-            ],
-            meta: { current_page: 1, last_page: 1, per_page: 25, total: 1 },
-        });
+        // H7 (#432). H6's list endpoints return a flat array.
+        LIST_MOCK.mockResolvedValue([
+            {
+                id: 1,
+                slug: 'single',
+                title: { rendered: 'Single post' },
+                content: { raw: '', blocks: [] },
+                status: 'publish',
+                theme: 'default',
+                type: 'wp_template',
+                source: 'theme',
+                origin: null,
+            },
+        ]);
 
         const onOpen = vi.fn();
 
@@ -86,22 +84,19 @@ describe('EntityBrowser', () => {
     });
 
     it('calls onOpen with the row id when a row is activated', async () => {
-        LIST_MOCK.mockResolvedValue({
-            data: [
-                {
-                    id: 3,
-                    slug: 'page',
-                    title: { rendered: '' },
-                    content: { raw: '', blocks: [] },
-                    status: 'publish',
-                    theme: 'default',
-                    type: 'wp_template',
-                    source: 'custom',
-                    origin: null,
-                },
-            ],
-            meta: { current_page: 1, last_page: 1, per_page: 25, total: 1 },
-        });
+        LIST_MOCK.mockResolvedValue([
+            {
+                id: 3,
+                slug: 'page',
+                title: { rendered: '' },
+                content: { raw: '', blocks: [] },
+                status: 'publish',
+                theme: 'default',
+                type: 'wp_template',
+                source: 'custom',
+                origin: null,
+            },
+        ]);
 
         const onOpen = vi.fn();
         const user = userEvent.setup();
@@ -131,10 +126,7 @@ describe('EntityBrowser', () => {
     });
 
     it('shows the empty state when the API returns no rows', async () => {
-        LIST_MOCK.mockResolvedValue({
-            data: [],
-            meta: { current_page: 1, last_page: 1, per_page: 25, total: 0 },
-        });
+        LIST_MOCK.mockResolvedValue([]);
 
         render(
             <EntityBrowser
@@ -192,10 +184,7 @@ describe('EntityBrowser', () => {
     });
 
     it('triggers onRequestCreate when the add-new button is clicked', async () => {
-        LIST_MOCK.mockResolvedValue({
-            data: [],
-            meta: { current_page: 1, last_page: 1, per_page: 25, total: 0 },
-        });
+        LIST_MOCK.mockResolvedValue([]);
 
         const onRequestCreate = vi.fn();
         const user = userEvent.setup();
@@ -225,30 +214,22 @@ describe('EntityBrowser', () => {
 
     it('filters via chips and re-fetches on chip change', async () => {
         LIST_MOCK.mockImplementation(
-            async (_config, _kind, params: { status?: string }) => ({
-                data:
-                    params.status === 'draft'
-                        ? [
-                              {
-                                  id: 5,
-                                  slug: 'draft-page',
-                                  title: { rendered: 'Draft' },
-                                  content: { raw: '', blocks: [] },
-                                  status: 'draft',
-                                  theme: 'default',
-                                  type: 'wp_template',
-                                  source: 'custom',
-                                  origin: null,
-                              },
-                          ]
-                        : [],
-                meta: {
-                    current_page: 1,
-                    last_page: 1,
-                    per_page: 25,
-                    total: params.status === 'draft' ? 1 : 0,
-                },
-            })
+            async (_config, _kind, params: { status?: string }) =>
+                params.status === 'draft'
+                    ? [
+                          {
+                              id: 5,
+                              slug: 'draft-page',
+                              title: { rendered: 'Draft' },
+                              content: { raw: '', blocks: [] },
+                              status: 'draft',
+                              theme: 'default',
+                              type: 'wp_template',
+                              source: 'custom',
+                              origin: null,
+                          },
+                      ]
+                    : []
         );
 
         const user = userEvent.setup();

--- a/resources/js/visual-editor/site-editor/__tests__/site-editor-app.test.tsx
+++ b/resources/js/visual-editor/site-editor/__tests__/site-editor-app.test.tsx
@@ -66,60 +66,94 @@ vi.mock('../entity-editor', () => ({
 // D3 mounts the styles section inside the shell; the shell tests only
 // care that the navigator routes to it, not the global-styles fetch
 // chain. The styles-section test file exercises the hook end-to-end.
-vi.mock('../styles/styles-section', () => ({
-    useStylesSectionViews: (): {
-        navigator: JSX.Element;
-        canvas: JSX.Element;
-        inspector: JSX.Element;
-    } => ({
-        navigator: <div data-testid="ap-site-editor-stub-styles-navigator" />,
-        canvas: <div data-testid="ap-site-editor-stub-styles-canvas" />,
-        inspector: <div data-testid="ap-site-editor-stub-styles-inspector" />,
-    }),
-}));
+//
+// H7 (#432) — the shell now lazy-imports each section's default
+// export, so the mock has to expose one alongside the hook. The stub
+// component just renders the same three views inline (no portals);
+// the tests check stub existence by `data-testid`, not DOM position.
+vi.mock('../styles/styles-section', () => {
+    const navigator = (
+        <div data-testid="ap-site-editor-stub-styles-navigator" />
+    );
+    const canvas = <div data-testid="ap-site-editor-stub-styles-canvas" />;
+    const inspector = (
+        <div data-testid="ap-site-editor-stub-styles-inspector" />
+    );
+
+    return {
+        useStylesSectionViews: (): {
+            navigator: JSX.Element;
+            canvas: JSX.Element;
+            inspector: JSX.Element;
+        } => ({ navigator, canvas, inspector }),
+        default: (): JSX.Element => (
+            <>
+                {navigator}
+                {canvas}
+                {inspector}
+            </>
+        ),
+    };
+});
 
 // D5 mounts the patterns section. Stub the hook entry point so the
 // shell tests don't pull in the patterns canvas (and therefore
 // `@wordpress/block-editor`) at module-load time. The patterns-section
 // test file exercises the hook end-to-end.
-vi.mock('../patterns/patterns-section', () => ({
-    usePatternsSectionViews: (): {
-        navigator: JSX.Element;
-        canvas: JSX.Element;
-        inspector: JSX.Element;
-        overlay: null;
-    } => ({
-        navigator: (
-            <div data-testid="ap-site-editor-stub-patterns-navigator" />
+vi.mock('../patterns/patterns-section', () => {
+    const navigator = (
+        <div data-testid="ap-site-editor-stub-patterns-navigator" />
+    );
+    const canvas = <div data-testid="ap-site-editor-stub-patterns-canvas" />;
+    const inspector = (
+        <div data-testid="ap-site-editor-stub-patterns-inspector" />
+    );
+
+    return {
+        usePatternsSectionViews: (): {
+            navigator: JSX.Element;
+            canvas: JSX.Element;
+            inspector: JSX.Element;
+            overlay: null;
+        } => ({ navigator, canvas, inspector, overlay: null }),
+        default: (): JSX.Element => (
+            <>
+                {navigator}
+                {canvas}
+                {inspector}
+            </>
         ),
-        canvas: <div data-testid="ap-site-editor-stub-patterns-canvas" />,
-        inspector: (
-            <div data-testid="ap-site-editor-stub-patterns-inspector" />
-        ),
-        overlay: null,
-    }),
-}));
+    };
+});
 
 // Same reasoning for D4 — keep the navigation-section module out of
 // the shell test's import graph so its API client doesn't try to
 // fetch menu locations during the shell unit tests.
-vi.mock('../navigation/navigation-section', () => ({
-    useNavigationSectionViews: (): {
-        navigator: JSX.Element;
-        canvas: JSX.Element;
-        inspector: JSX.Element;
-        overlay: null;
-    } => ({
-        navigator: (
-            <div data-testid="ap-site-editor-stub-navigation-navigator" />
+vi.mock('../navigation/navigation-section', () => {
+    const navigator = (
+        <div data-testid="ap-site-editor-stub-navigation-navigator" />
+    );
+    const canvas = <div data-testid="ap-site-editor-stub-navigation-canvas" />;
+    const inspector = (
+        <div data-testid="ap-site-editor-stub-navigation-inspector" />
+    );
+
+    return {
+        useNavigationSectionViews: (): {
+            navigator: JSX.Element;
+            canvas: JSX.Element;
+            inspector: JSX.Element;
+            overlay: null;
+        } => ({ navigator, canvas, inspector, overlay: null }),
+        default: (): JSX.Element => (
+            <>
+                {navigator}
+                {canvas}
+                {inspector}
+            </>
         ),
-        canvas: <div data-testid="ap-site-editor-stub-navigation-canvas" />,
-        inspector: (
-            <div data-testid="ap-site-editor-stub-navigation-inspector" />
-        ),
-        overlay: null,
-    }),
-}));
+    };
+});
 
 vi.mock('../../editor/synced-pattern-indicator', () => ({
     registerSyncedPatternIndicator: () => undefined,

--- a/resources/js/visual-editor/site-editor/api-client.ts
+++ b/resources/js/visual-editor/site-editor/api-client.ts
@@ -60,15 +60,15 @@ export type EntityRecord<K extends EntityKind> = K extends 'template'
     ? TemplateRecord
     : TemplatePartRecord;
 
-export interface PaginatedResponse<T> {
-    data: readonly T[];
-    meta: {
-        current_page: number;
-        last_page: number;
-        per_page: number;
-        total: number;
-    };
-}
+/**
+ * H7 (#432). The H6 controllers return flat JSON arrays via
+ * {@see TemplateAdapter::collection()} — there's no pagination wrapper
+ * around the templates / parts list endpoints. The previous
+ * `PaginatedResponse<T>` envelope plan 11 Phase D shipped is
+ * superseded; the alias is kept as a flat array for any out-of-tree
+ * consumer that still imports the type.
+ */
+export type PaginatedResponse<T> = readonly T[];
 
 export interface ListParams {
     perPage?: number;
@@ -249,7 +249,7 @@ export async function listEntities<K extends EntityKind>(
     config: SiteEditorApiConfig,
     kind: K,
     params: ListParams = {}
-): Promise<PaginatedResponse<EntityRecord<K>>> {
+): Promise<readonly EntityRecord<K>[]> {
     try {
         const response = await fetch(
             buildUrl(config, kind, null, {
@@ -267,7 +267,17 @@ export async function listEntities<K extends EntityKind>(
             }
         );
 
-        return (await requireOk(response)) as PaginatedResponse<EntityRecord<K>>;
+        const body = await requireOk(response);
+
+        // H7 (#432). H6's `TemplateController::index` /
+        // `TemplatePartController::index` return a flat JSON array via
+        // their adapter's `collection()` method — no `{ data, meta }`
+        // wrapper. Coerce to an empty list if the body is missing or
+        // wrong-shaped so a malformed response doesn't crash the
+        // navigator with `items.length === undefined`.
+        return Array.isArray(body)
+            ? (body as readonly EntityRecord<K>[])
+            : [];
     } catch (error: unknown) {
         throw normalizeError(error, `Failed to load ${kind} list.`);
     }

--- a/resources/js/visual-editor/site-editor/navigation/__tests__/api-client.test.ts
+++ b/resources/js/visual-editor/site-editor/navigation/__tests__/api-client.test.ts
@@ -49,28 +49,23 @@ afterEach(() => {
 });
 
 describe('listNavigations', () => {
-    it('returns the paginated envelope', async () => {
+    it('returns the H6 flat-array response', async () => {
+        // H7 (#432). H6's `MenuController::index` returns a flat
+        // JSON array of `wp_navigation` records — no
+        // `{ data, meta }` wrapper.
         const fetchMock = mockFetch(
-            jsonResponse({
-                data: [
-                    {
-                        id: 5,
-                        slug: 'primary',
-                        title: { rendered: 'Primary' },
-                        content: { raw: '', blocks: [] },
-                        status: 'publish',
-                        menu_order: 0,
-                        location: 'primary',
-                        type: 'wp_navigation',
-                    },
-                ],
-                meta: {
-                    current_page: 1,
-                    last_page: 1,
-                    per_page: 25,
-                    total: 1,
+            jsonResponse([
+                {
+                    id: 5,
+                    slug: 'primary',
+                    title: { rendered: 'Primary' },
+                    content: { raw: '', blocks: [] },
+                    status: 'publish',
+                    menu_order: 0,
+                    location: 'primary',
+                    type: 'wp_navigation',
                 },
-            })
+            ])
         );
 
         const response = await listNavigations(
@@ -78,11 +73,19 @@ describe('listNavigations', () => {
             { perPage: 25 }
         );
 
-        expect(response.data).toHaveLength(1);
-        expect(response.meta.total).toBe(1);
+        expect(response).toHaveLength(1);
+        expect(response[0]?.id).toBe(5);
         expect(fetchMock.mock.calls[0]?.[0]).toContain(
-            '/visual-editor/api/navigation?per_page=25'
+            '/visual-editor/api/menus?per_page=25'
         );
+    });
+
+    it('coerces non-array bodies to an empty list', async () => {
+        mockFetch(jsonResponse({ message: 'oops' }));
+
+        const response = await listNavigations({ apiBase: API_BASE });
+
+        expect(response).toEqual([]);
     });
 });
 
@@ -105,7 +108,7 @@ describe('fetchNavigation', () => {
 
         expect(record.slug).toBe('footer');
         expect(fetchMock.mock.calls[0]?.[0]).toBe(
-            '/visual-editor/api/navigation/9'
+            '/visual-editor/api/menus/9'
         );
     });
 });
@@ -163,7 +166,7 @@ describe('createNavigation + updateNavigation', () => {
         );
 
         expect(fetchMock.mock.calls[0]?.[0]).toBe(
-            '/visual-editor/api/navigation/2'
+            '/visual-editor/api/menus/2'
         );
         expect(fetchMock.mock.calls[0]?.[1]).toMatchObject({
             method: 'PUT',

--- a/resources/js/visual-editor/site-editor/navigation/__tests__/navigation-section.test.tsx
+++ b/resources/js/visual-editor/site-editor/navigation/__tests__/navigation-section.test.tsx
@@ -116,27 +116,20 @@ const baseLocations: PendingResponse = {
     },
 };
 
+// H7 (#432). H6's `MenuController::index` returns a flat array.
 const baseList: PendingResponse = {
-    body: {
-        data: [
-            {
-                id: 1,
-                slug: 'main',
-                title: { rendered: 'Main' },
-                content: { raw: '', blocks: [] },
-                status: 'publish',
-                menu_order: 0,
-                location: 'primary',
-                type: 'wp_navigation',
-            },
-        ],
-        meta: {
-            current_page: 1,
-            last_page: 1,
-            per_page: 50,
-            total: 1,
+    body: [
+        {
+            id: 1,
+            slug: 'main',
+            title: { rendered: 'Main' },
+            content: { raw: '', blocks: [] },
+            status: 'publish',
+            menu_order: 0,
+            location: 'primary',
+            type: 'wp_navigation',
         },
-    },
+    ],
 };
 
 describe('navigation-section list + open', () => {
@@ -151,7 +144,7 @@ describe('navigation-section list + open', () => {
                 response: baseLocations,
             },
             {
-                matcher: /\/navigation\?per_page=50/,
+                matcher: /\/menus\?per_page=50/,
                 method: 'GET',
                 response: baseList,
             },
@@ -184,7 +177,7 @@ describe('navigation-section list + open', () => {
                 response: baseLocations,
             },
             {
-                matcher: /\/navigation\?per_page=50/,
+                matcher: /\/menus\?per_page=50/,
                 method: 'GET',
                 response: baseList,
             },
@@ -207,7 +200,7 @@ describe('navigation-section list + open', () => {
 });
 
 describe('navigation-section save pipeline', () => {
-    it('dispatches PUT /navigation/{id} when the entity-state save runs', async () => {
+    it('dispatches PUT /menus/{id} when the entity-state save runs', async () => {
         const stateRef: { current: EntityEditorState | null } = {
             current: null,
         };
@@ -222,12 +215,12 @@ describe('navigation-section save pipeline', () => {
                 response: baseLocations,
             },
             {
-                matcher: /\/navigation\?per_page=50/,
+                matcher: /\/menus\?per_page=50/,
                 method: 'GET',
                 response: baseList,
             },
             {
-                matcher: /\/navigation\/1$/,
+                matcher: /\/menus\/1$/,
                 method: 'GET',
                 response: {
                     body: {
@@ -243,7 +236,7 @@ describe('navigation-section save pipeline', () => {
                 },
             },
             {
-                matcher: /\/navigation\/1$/,
+                matcher: /\/menus\/1$/,
                 method: 'PUT',
                 response: {
                     body: {
@@ -278,7 +271,7 @@ describe('navigation-section save pipeline', () => {
         const putCall = calls.find(
             ([url, init]) =>
                 typeof url === 'string' &&
-                url.endsWith('/navigation/1') &&
+                url.endsWith('/menus/1') &&
                 (init as RequestInit | undefined)?.method === 'PUT'
         );
 

--- a/resources/js/visual-editor/site-editor/navigation/api-client.ts
+++ b/resources/js/visual-editor/site-editor/navigation/api-client.ts
@@ -30,17 +30,12 @@ export interface NavigationRecord {
     type: 'wp_navigation';
 }
 
-export interface NavigationListMeta {
-    current_page: number;
-    last_page: number;
-    per_page: number;
-    total: number;
-}
-
-export interface NavigationListResponse {
-    data: readonly NavigationRecord[];
-    meta: NavigationListMeta;
-}
+/**
+ * H7 (#432). H6's `MenuController::index` returns a flat JSON array of
+ * menus — no `{ data, meta }` wrapper. Type kept as a flat array for
+ * any downstream consumer that imports it.
+ */
+export type NavigationListResponse = readonly NavigationRecord[];
 
 export interface MenuLocation {
     slug: string;
@@ -195,8 +190,13 @@ function navigationUrl(
     suffix: string | number | null,
     query: Record<string, string | number | undefined> = {}
 ): string {
+    // H7 (#432). H6 mounted the navigation REST surface at
+    // `/visual-editor/api/menus` (per plan 14 §4.5 — `wp_navigation`
+    // entities), superseding plan 11 Phase D's `/navigation` path.
+    // The shim's `addEntities` registration also points at `/menus`,
+    // so the section client and the core-data shim stay aligned.
     const base = config.apiBase.replace(/\/+$/, '');
-    let url = `${base}/navigation`;
+    let url = `${base}/menus`;
 
     if (suffix !== null) {
         url += `/${encodeURIComponent(String(suffix))}`;
@@ -241,7 +241,9 @@ export async function listNavigations(
             }
         );
 
-        return (await requireOk(response)) as NavigationListResponse;
+        const body = await requireOk(response);
+
+        return Array.isArray(body) ? (body as NavigationListResponse) : [];
     } catch (error: unknown) {
         throw normalizeError(error, 'Failed to load navigation list.');
     }

--- a/resources/js/visual-editor/site-editor/navigation/menu-tree.ts
+++ b/resources/js/visual-editor/site-editor/navigation/menu-tree.ts
@@ -23,7 +23,7 @@
  *     `kind: 'post-type'` + `type` + `id`; `custom` → bare `url`/`label`.
  *
  * The `raw` half of the envelope is left empty; the backend regenerates
- * it from `blocks` on save (see `VisualEditorNavigation::setContentEnvelope`).
+ * it from `blocks` on save (see the H6 `MenuAdapter` — plan 14 §4.5).
  */
 
 export type MenuItemType = 'page' | 'post' | 'custom' | 'taxonomy';

--- a/resources/js/visual-editor/site-editor/navigation/navigation-browser.tsx
+++ b/resources/js/visual-editor/site-editor/navigation/navigation-browser.tsx
@@ -84,7 +84,7 @@ export function NavigationBrowser(
 
                 setState({
                     status: 'ready',
-                    rows: response.data,
+                    rows: response,
                     errorMessage: null,
                 });
             } catch (error: unknown) {

--- a/resources/js/visual-editor/site-editor/navigation/navigation-section.tsx
+++ b/resources/js/visual-editor/site-editor/navigation/navigation-section.tsx
@@ -195,9 +195,14 @@ export function useNavigationSectionViews(
             // the current owner and clear it.
             try {
                 if (navigationId === null) {
-                    // Find the current owner by slug. List response is
-                    // already paginated to 50 — V1 menus list is
-                    // small, no need to paginate further.
+                    // Find the current owner by location. H6's
+                    // `MenuController::index` returns the full menu
+                    // set as a flat array (no pagination), so a single
+                    // fetch sees every row — `perPage` is sent for
+                    // forward-compat with a future paginated surface
+                    // but the controller currently ignores it. If H6
+                    // adds pagination later, switch this to either a
+                    // location-filtered endpoint or a paginated walk.
                     const list = await listNavigations(apiConfig, {
                         perPage: 50,
                     });

--- a/resources/js/visual-editor/site-editor/navigation/navigation-section.tsx
+++ b/resources/js/visual-editor/site-editor/navigation/navigation-section.tsx
@@ -26,6 +26,7 @@ import type {
     SiteEditorApiConfig,
 } from '../api-client';
 import type { EntityEditorState } from '../entity-editor';
+import { SectionPortal } from '../section-portal';
 import {
     fetchMenuLocations,
     listNavigations,
@@ -200,7 +201,7 @@ export function useNavigationSectionViews(
                     const list = await listNavigations(apiConfig, {
                         perPage: 50,
                     });
-                    const current = list.data.find(
+                    const current = list.find(
                         (row) => row.location === locationSlug
                     );
 
@@ -341,4 +342,42 @@ export function useNavigationSectionViews(
     ) : null;
 
     return { navigator, canvas, inspector, overlay };
+}
+
+/**
+ * Lazy-mountable wrapper around `useNavigationSectionViews` — H7 (#432).
+ *
+ * Same role as `StylesSectionView` for D3: the shell `React.lazy()`-
+ * imports this default export so the navigation tree editor, browser,
+ * inspector, and create-menu dialog stay out of the initial site-
+ * editor boot chunk.
+ */
+export interface NavigationSectionViewProps
+    extends UseNavigationSectionViewsOptions {
+    navigatorSlot: HTMLElement | null;
+    canvasSlot: HTMLElement | null;
+    inspectorSlot: HTMLElement | null;
+    overlaySlot: HTMLElement | null;
+}
+
+export default function NavigationSectionView(
+    props: NavigationSectionViewProps
+): ReactElement {
+    const {
+        navigatorSlot,
+        canvasSlot,
+        inspectorSlot,
+        overlaySlot,
+        ...hookOptions
+    } = props;
+    const views = useNavigationSectionViews(hookOptions);
+
+    return (
+        <>
+            <SectionPortal slot={navigatorSlot}>{views.navigator}</SectionPortal>
+            <SectionPortal slot={canvasSlot}>{views.canvas}</SectionPortal>
+            <SectionPortal slot={inspectorSlot}>{views.inspector}</SectionPortal>
+            <SectionPortal slot={overlaySlot}>{views.overlay}</SectionPortal>
+        </>
+    );
 }

--- a/resources/js/visual-editor/site-editor/patterns/__tests__/delete-pattern-dialog.test.tsx
+++ b/resources/js/visual-editor/site-editor/patterns/__tests__/delete-pattern-dialog.test.tsx
@@ -64,44 +64,39 @@ afterEach(() => {
 
 describe('<DeletePatternDialog />', () => {
     it('shows a usage count derived from templates and parts for synced patterns', async () => {
+        // H7 (#432). H6's list endpoints return a flat array.
         LIST_ENTITIES_MOCK.mockImplementation((_config, kind) => {
             if (kind === 'template') {
-                return Promise.resolve({
-                    data: [
-                        {
-                            id: 1,
-                            slug: 'index',
-                            content: {
-                                raw: '',
-                                blocks: [
-                                    {
-                                        name: 'core/block',
-                                        attributes: { ref: 42 },
-                                        innerBlocks: [],
-                                    },
-                                    {
-                                        name: 'core/group',
-                                        attributes: {},
-                                        innerBlocks: [
-                                            {
-                                                name: 'core/block',
-                                                attributes: { ref: 42 },
-                                                innerBlocks: [],
-                                            },
-                                        ],
-                                    },
-                                ],
-                            },
+                return Promise.resolve([
+                    {
+                        id: 1,
+                        slug: 'index',
+                        content: {
+                            raw: '',
+                            blocks: [
+                                {
+                                    name: 'core/block',
+                                    attributes: { ref: 42 },
+                                    innerBlocks: [],
+                                },
+                                {
+                                    name: 'core/group',
+                                    attributes: {},
+                                    innerBlocks: [
+                                        {
+                                            name: 'core/block',
+                                            attributes: { ref: 42 },
+                                            innerBlocks: [],
+                                        },
+                                    ],
+                                },
+                            ],
                         },
-                    ],
-                    meta: { total: 1, current_page: 1, last_page: 1, per_page: 100 },
-                });
+                    },
+                ]);
             }
 
-            return Promise.resolve({
-                data: [],
-                meta: { total: 0, current_page: 1, last_page: 1, per_page: 100 },
-            });
+            return Promise.resolve([]);
         });
 
         render(
@@ -135,10 +130,7 @@ describe('<DeletePatternDialog />', () => {
 
     it('calls deletePattern when confirmed', async () => {
         DELETE_MOCK.mockResolvedValue(undefined);
-        LIST_ENTITIES_MOCK.mockResolvedValue({
-            data: [],
-            meta: { total: 0, current_page: 1, last_page: 1, per_page: 100 },
-        });
+        LIST_ENTITIES_MOCK.mockResolvedValue([]);
 
         const onDeleted = vi.fn();
         const user = userEvent.setup();

--- a/resources/js/visual-editor/site-editor/patterns/__tests__/pattern-grid.test.tsx
+++ b/resources/js/visual-editor/site-editor/patterns/__tests__/pattern-grid.test.tsx
@@ -43,18 +43,16 @@ afterEach(() => {
 
 describe('<PatternGrid />', () => {
     it('renders one card per pattern with a synced badge', async () => {
-        LIST_MOCK.mockResolvedValue({
-            data: [
-                makePattern({
-                    id: 7,
-                    slug: 'hero',
-                    title: { rendered: 'Hero' },
-                    synced: true,
-                    categories: ['featured', 'hero'],
-                }),
-            ],
-            meta: { current_page: 1, last_page: 1, per_page: 25, total: 1 },
-        });
+        // H7 (#432). H6's `PatternController::index` returns a flat array.
+        LIST_MOCK.mockResolvedValue([
+            makePattern({
+                id: 7,
+                slug: 'hero',
+                title: { rendered: 'Hero' },
+                synced: true,
+                categories: ['featured', 'hero'],
+            }),
+        ]);
 
         render(
             <PatternGrid
@@ -81,16 +79,13 @@ describe('<PatternGrid />', () => {
     });
 
     it('does not render the convert-to-unsynced button on unsynced cards', async () => {
-        LIST_MOCK.mockResolvedValue({
-            data: [
-                makePattern({
-                    id: 12,
-                    slug: 'plain',
-                    synced: false,
-                }),
-            ],
-            meta: { current_page: 1, last_page: 1, per_page: 25, total: 1 },
-        });
+        LIST_MOCK.mockResolvedValue([
+            makePattern({
+                id: 12,
+                slug: 'plain',
+                synced: false,
+            }),
+        ]);
 
         render(
             <PatternGrid
@@ -118,10 +113,9 @@ describe('<PatternGrid />', () => {
     it('triggers Edit when the edit action is activated', async () => {
         const onEdit = vi.fn();
 
-        LIST_MOCK.mockResolvedValue({
-            data: [makePattern({ id: 22, slug: 'banner', synced: true })],
-            meta: { current_page: 1, last_page: 1, per_page: 25, total: 1 },
-        });
+        LIST_MOCK.mockResolvedValue([
+            makePattern({ id: 22, slug: 'banner', synced: true }),
+        ]);
 
         const user = userEvent.setup();
 
@@ -147,10 +141,7 @@ describe('<PatternGrid />', () => {
     });
 
     it('renders an empty state when no patterns match the active sync flag', async () => {
-        LIST_MOCK.mockResolvedValue({
-            data: [],
-            meta: { current_page: 1, last_page: 1, per_page: 25, total: 0 },
-        });
+        LIST_MOCK.mockResolvedValue([]);
 
         render(
             <PatternGrid

--- a/resources/js/visual-editor/site-editor/patterns/__tests__/patterns-browser.test.tsx
+++ b/resources/js/visual-editor/site-editor/patterns/__tests__/patterns-browser.test.tsx
@@ -43,17 +43,15 @@ afterEach(() => {
 
 describe('<PatternsBrowser />', () => {
     it('renders Synced and Unsynced tabs and shows synced rows by default', async () => {
-        LIST_MOCK.mockResolvedValue({
-            data: [
-                makePattern({
-                    id: 5,
-                    slug: 'hero',
-                    title: { rendered: 'Hero pattern' },
-                    synced: true,
-                }),
-            ],
-            meta: { current_page: 1, last_page: 1, per_page: 25, total: 1 },
-        });
+        // H7 (#432). H6's `PatternController::index` returns a flat array.
+        LIST_MOCK.mockResolvedValue([
+            makePattern({
+                id: 5,
+                slug: 'hero',
+                title: { rendered: 'Hero pattern' },
+                synced: true,
+            }),
+        ]);
 
         render(
             <PatternsBrowser
@@ -89,10 +87,7 @@ describe('<PatternsBrowser />', () => {
     it('switches to the unsynced tab when the parent updates activeTab', async () => {
         const user = userEvent.setup();
 
-        LIST_MOCK.mockResolvedValue({
-            data: [],
-            meta: { current_page: 1, last_page: 1, per_page: 25, total: 0 },
-        });
+        LIST_MOCK.mockResolvedValue([]);
 
         const onSelectTab = vi.fn();
 
@@ -118,16 +113,13 @@ describe('<PatternsBrowser />', () => {
         const onOpen = vi.fn();
         const user = userEvent.setup();
 
-        LIST_MOCK.mockResolvedValue({
-            data: [
-                makePattern({
-                    id: 9,
-                    slug: 'cta',
-                    title: { rendered: 'Call to action' },
-                }),
-            ],
-            meta: { current_page: 1, last_page: 1, per_page: 25, total: 1 },
-        });
+        LIST_MOCK.mockResolvedValue([
+            makePattern({
+                id: 9,
+                slug: 'cta',
+                title: { rendered: 'Call to action' },
+            }),
+        ]);
 
         render(
             <PatternsBrowser
@@ -151,10 +143,7 @@ describe('<PatternsBrowser />', () => {
         const user = userEvent.setup();
         const onRequestCreate = vi.fn();
 
-        LIST_MOCK.mockResolvedValue({
-            data: [],
-            meta: { current_page: 1, last_page: 1, per_page: 25, total: 0 },
-        });
+        LIST_MOCK.mockResolvedValue([]);
 
         render(
             <PatternsBrowser
@@ -173,10 +162,7 @@ describe('<PatternsBrowser />', () => {
     });
 
     it('renders the empty state copy that names the active sync mode', async () => {
-        LIST_MOCK.mockResolvedValue({
-            data: [],
-            meta: { current_page: 1, last_page: 1, per_page: 25, total: 0 },
-        });
+        LIST_MOCK.mockResolvedValue([]);
 
         render(
             <PatternsBrowser

--- a/resources/js/visual-editor/site-editor/patterns/api-client.ts
+++ b/resources/js/visual-editor/site-editor/patterns/api-client.ts
@@ -12,7 +12,6 @@
 
 import {
     SiteEditorApiError,
-    type PaginatedResponse,
     type SiteEditorApiConfig,
     type ValidationErrors,
 } from '../api-client';
@@ -200,7 +199,7 @@ const READ_HEADERS: Readonly<Record<string, string>> = {
 export async function listPatterns(
     config: SiteEditorApiConfig,
     params: PatternListParams = {}
-): Promise<PaginatedResponse<PatternRecord>> {
+): Promise<readonly PatternRecord[]> {
     const url = buildUrl(config, null, {
         per_page: params.perPage,
         page: params.page,
@@ -234,7 +233,13 @@ export async function listPatterns(
             headers: READ_HEADERS,
         });
 
-        return (await requireOk(response)) as PaginatedResponse<PatternRecord>;
+        // H7 (#432). H6's `PatternController::index` returns a flat
+        // JSON array via `PatternAdapter::collection()` — no
+        // `{ data, meta }` wrapper. Coerce to `[]` if the response
+        // body is missing or wrong-shaped.
+        const body = await requireOk(response);
+
+        return Array.isArray(body) ? (body as readonly PatternRecord[]) : [];
     } catch (error: unknown) {
         throw normalizeError(error, 'Failed to load patterns.');
     }

--- a/resources/js/visual-editor/site-editor/patterns/patterns-section.tsx
+++ b/resources/js/visual-editor/site-editor/patterns/patterns-section.tsx
@@ -21,6 +21,7 @@ import { TEXT_DOMAIN } from '../../vendor/i18n';
 import type { SiteEditorApiConfig } from '../api-client';
 import { InspectorSidebar } from '../../editor/inspector-sidebar';
 import type { EntityEditorState } from '../entity-editor';
+import { SectionPortal } from '../section-portal';
 
 import {
     type PatternRecord,
@@ -348,4 +349,41 @@ export function usePatternsSectionViews(
     }
 
     return { navigator, canvas, inspector, overlay };
+}
+
+/**
+ * Lazy-mountable wrapper around `usePatternsSectionViews` — H7 (#432).
+ *
+ * Same role as `StylesSectionView` and `NavigationSectionView`: the
+ * shell `React.lazy()`-imports this default export so the patterns
+ * grid, canvas, inspector, and create / convert / delete dialogs stay
+ * out of the initial site-editor boot chunk.
+ */
+export interface PatternsSectionViewProps extends UsePatternsSectionViewsOptions {
+    navigatorSlot: HTMLElement | null;
+    canvasSlot: HTMLElement | null;
+    inspectorSlot: HTMLElement | null;
+    overlaySlot: HTMLElement | null;
+}
+
+export default function PatternsSectionView(
+    props: PatternsSectionViewProps
+): ReactElement {
+    const {
+        navigatorSlot,
+        canvasSlot,
+        inspectorSlot,
+        overlaySlot,
+        ...hookOptions
+    } = props;
+    const views = usePatternsSectionViews(hookOptions);
+
+    return (
+        <>
+            <SectionPortal slot={navigatorSlot}>{views.navigator}</SectionPortal>
+            <SectionPortal slot={canvasSlot}>{views.canvas}</SectionPortal>
+            <SectionPortal slot={inspectorSlot}>{views.inspector}</SectionPortal>
+            <SectionPortal slot={overlaySlot}>{views.overlay}</SectionPortal>
+        </>
+    );
 }

--- a/resources/js/visual-editor/site-editor/patterns/use-pattern-usage.ts
+++ b/resources/js/visual-editor/site-editor/patterns/use-pattern-usage.ts
@@ -203,57 +203,43 @@ export function usePatternUsage(
                 };
 
                 for (const kind of TARGET_KINDS) {
-                    // Walk every page so the count remains accurate on
-                    // sites with more templates / parts than the
-                    // per-page cap. The C1/C2 list endpoints expose
-                    // `meta.last_page`; we trust it over a "stop when
-                    // empty" probe so a single empty page doesn't
-                    // truncate the count if the next one happens to
-                    // re-populate.
-                    let page = 1;
-                    let lastPage = 1;
+                    // H7 (#432). H6's list endpoints return a flat
+                    // array — no pagination wrapper, so a single fetch
+                    // sees every record. If H6 grows pagination later
+                    // this loop reverts to walking pages.
+                    const list = await listEntities(apiConfig, kind, {
+                        perPage: 100,
+                    });
 
-                    do {
-                        const list = await listEntities(apiConfig, kind, {
-                            perPage: 100,
-                            page,
-                        });
+                    for (const summary of list) {
+                        let blocks = blocksFromRecord(summary);
 
-                        lastPage = list.meta.last_page;
+                        if (blocks.length === 0) {
+                            // Some H6 list responses omit content to
+                            // keep the payload small. Fall back to a
+                            // per-row fetch when we don't see any
+                            // blocks — the caller budget is small (a
+                            // few extra HTTPs at delete time) and
+                            // skipping would silently under-count the
+                            // usage figure.
+                            try {
+                                const detail = await fetchEntity(
+                                    apiConfig,
+                                    kind,
+                                    summary.id
+                                );
 
-                        for (const summary of list.data) {
-                            let blocks = blocksFromRecord(summary);
-
-                            if (blocks.length === 0) {
-                                // Some C1/C2 list endpoints omit
-                                // content from the list response to
-                                // keep the payload small. Fall back to
-                                // a per-row fetch when we don't see
-                                // any blocks — the caller budget is
-                                // small (a few extra HTTPs at delete
-                                // time) and skipping would silently
-                                // under-count the usage figure.
-                                try {
-                                    const detail = await fetchEntity(
-                                        apiConfig,
-                                        kind,
-                                        summary.id
-                                    );
-
-                                    blocks = blocksFromRecord(detail);
-                                } catch {
-                                    continue;
-                                }
+                                blocks = blocksFromRecord(detail);
+                            } catch {
+                                continue;
                             }
-
-                            breakdown.perKind[kind] += countReferences(
-                                blocks,
-                                patternId
-                            );
                         }
 
-                        page += 1;
-                    } while (page <= lastPage);
+                        breakdown.perKind[kind] += countReferences(
+                            blocks,
+                            patternId
+                        );
+                    }
                 }
 
                 breakdown.total =

--- a/resources/js/visual-editor/site-editor/patterns/use-patterns-list.ts
+++ b/resources/js/visual-editor/site-editor/patterns/use-patterns-list.ts
@@ -95,8 +95,12 @@ export function usePatternsList(
                 return;
             }
 
-            setItems(response.data);
-            setTotal(response.meta.total);
+            // H7 (#432). H6 returns a flat array; total now mirrors
+            // the loaded item count. The pattern grid uses `total`
+            // only for the "X patterns" badge, so this is a precise
+            // value at H6's no-pagination shape.
+            setItems(response);
+            setTotal(response.length);
             setStatus('ready');
         } catch (error: unknown) {
             if (requestCounterRef.current !== requestId) {

--- a/resources/js/visual-editor/site-editor/section-portal.tsx
+++ b/resources/js/visual-editor/site-editor/section-portal.tsx
@@ -1,0 +1,33 @@
+/**
+ * Section-portal helper — H7 (#432).
+ *
+ * Section orchestrators (styles, navigation, patterns) are loaded
+ * lazily via `React.lazy` so the heavy chunks stay out of the initial
+ * site-editor boot bundle. The shell exposes stable navigator / canvas
+ * / inspector / overlay mount points and the lazy section component
+ * portals its three views into those mount points instead of returning
+ * them as separate slot elements (a hook can't be lazy-loaded; a
+ * component can).
+ *
+ * `slot` is null on the first render before the shell's callback-ref
+ * has populated it. In that case we render nothing — once the ref
+ * populates and the section re-renders, the portal lights up.
+ */
+
+import { type ReactNode } from 'react';
+import { createPortal } from 'react-dom';
+
+export interface SectionPortalProps {
+    slot: HTMLElement | null;
+    children: ReactNode;
+}
+
+export function SectionPortal(props: SectionPortalProps): ReactNode {
+    const { slot, children } = props;
+
+    if (slot === null) {
+        return null;
+    }
+
+    return createPortal(children, slot);
+}

--- a/resources/js/visual-editor/site-editor/site-editor-app.tsx
+++ b/resources/js/visual-editor/site-editor/site-editor-app.tsx
@@ -15,7 +15,7 @@
  * slot when they ship.
  */
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Suspense, lazy, useCallback, useEffect, useMemo, useState } from 'react';
 import { getBlockType, getBlockTypes, unregisterBlockType } from '@wordpress/blocks';
 import { registerCoreBlocks } from '@wordpress/block-library';
 import { __, sprintf } from '@wordpress/i18n';
@@ -44,9 +44,6 @@ import {
     TemplatePartCreateDialog,
     TemplatePartsBrowser,
 } from './template-parts-section';
-import { useStylesSectionViews } from './styles/styles-section';
-import { useNavigationSectionViews } from './navigation/navigation-section';
-import { usePatternsSectionViews } from './patterns/patterns-section';
 import { usePersistedToggle } from './use-persisted-toggle';
 import { useSiteEditorRouting } from './use-site-editor-routing';
 import { TopBar } from '../editor/top-bar';
@@ -55,6 +52,24 @@ import { registerSyncedPatternIndicator } from '../editor/synced-pattern-indicat
 import { registerTaxonomyAndArchiveBlockOverrides } from '../editor/taxonomy-archive-block-overrides';
 
 import './site-editor-app.css';
+
+/**
+ * Lazy section orchestrators — H7 (#432).
+ *
+ * The styles, navigation, and patterns sections each carry a
+ * substantial dependency graph (style-book canvas, tree editor, link
+ * picker, pattern grid + dialogs). Loading them eagerly at boot pads
+ * the initial chunk for users who never leave the templates section.
+ * `React.lazy()` splits each into its own chunk; the active section's
+ * chunk is fetched on first nav. Templates and template-parts stay
+ * eager because they share `useEntityEditorViews` with the post
+ * editor's already-warm bundle and they're the default landing path.
+ */
+const StylesSectionView = lazy(() => import('./styles/styles-section'));
+const NavigationSectionView = lazy(
+    () => import('./navigation/navigation-section')
+);
+const PatternsSectionView = lazy(() => import('./patterns/patterns-section'));
 
 const NAVIGATOR_STORAGE_KEY = 'ap-site-editor:navigator-open';
 const INSPECTOR_STORAGE_KEY = 'ap-site-editor:inspector-open';
@@ -276,11 +291,19 @@ export function SiteEditorApp(props: SiteEditorAppProps): JSX.Element {
                 : handleEntityStateChange,
     });
 
-    const stylesViews = useStylesSectionViews({
-        apiConfig,
-        enabled: isD3Section,
-        onStateChange: isD3Section ? handleEntityStateChange : noopStateChange,
-    });
+    // H7 (#432). Lazy section orchestrators portal their views into
+    // these slots; the slots themselves are always present in the DOM
+    // (CSS controls navigator/inspector visibility) so the lazy
+    // section's portal targets remain stable across open/close
+    // toggles.
+    const [navigatorSlot, setNavigatorSlot] = useState<HTMLDivElement | null>(
+        null
+    );
+    const [canvasSlot, setCanvasSlot] = useState<HTMLDivElement | null>(null);
+    const [inspectorSlot, setInspectorSlot] = useState<HTMLDivElement | null>(
+        null
+    );
+    const [overlaySlot, setOverlaySlot] = useState<HTMLDivElement | null>(null);
 
     // Same shape as `handleOpenEntity` declared further down — duplicated
     // here so the navigation views hook can receive it without having to
@@ -295,14 +318,6 @@ export function SiteEditorApp(props: SiteEditorAppProps): JSX.Element {
         [activeSection.id, routing]
     );
 
-    const navigationViews = useNavigationSectionViews({
-        apiConfig,
-        enabled: isD4Section,
-        activeEntityId,
-        onOpenEntity: handleNavigationOpen,
-        onStateChange: isD4Section ? handleEntityStateChange : noopStateChange,
-    });
-
     const handlePatternsOpen = useCallback(
         (entityId: string): void => {
             routing.navigate(activeSection.id, entityId);
@@ -313,15 +328,6 @@ export function SiteEditorApp(props: SiteEditorAppProps): JSX.Element {
     const handlePatternsClose = useCallback((): void => {
         routing.navigate(activeSection.id, null);
     }, [activeSection.id, routing]);
-
-    const patternsViews = usePatternsSectionViews({
-        apiConfig,
-        enabled: isD5Section,
-        activeEntityId,
-        onOpenEntity: handlePatternsOpen,
-        onCloseEntity: handlePatternsClose,
-        onStateChange: isD5Section ? handleEntityStateChange : noopStateChange,
-    });
 
     const [dialogKind, setDialogKind] = useState<EntityKind | null>(null);
 
@@ -494,6 +500,8 @@ export function SiteEditorApp(props: SiteEditorAppProps): JSX.Element {
         </div>
     );
 
+    const isLazySection = isD3Section || isD4Section || isD5Section;
+
     let navigatorChildren: JSX.Element;
 
     if (activeSection.id === 'templates') {
@@ -516,12 +524,19 @@ export function SiteEditorApp(props: SiteEditorAppProps): JSX.Element {
                 refreshKey={partsRefreshKey}
             />
         );
-    } else if (isD3Section) {
-        navigatorChildren = stylesViews.navigator;
-    } else if (isD4Section) {
-        navigatorChildren = navigationViews.navigator;
-    } else if (isD5Section) {
-        navigatorChildren = patternsViews.navigator;
+    } else if (isLazySection) {
+        // H7 (#432). The lazy section orchestrator portals its
+        // navigator view into this slot once its dynamic chunk
+        // resolves. The wrapping div is the stable portal target;
+        // re-renders that move it to a different DOM position trigger
+        // the callback ref and the lazy section's portal updates.
+        navigatorChildren = (
+            <div
+                className="ap-site-editor__navigator-slot"
+                ref={setNavigatorSlot}
+                data-testid="ap-site-editor-navigator-slot"
+            />
+        );
     } else {
         navigatorChildren = (
             <SectionOutlet
@@ -593,29 +608,21 @@ export function SiteEditorApp(props: SiteEditorAppProps): JSX.Element {
                     >
                         {editorViews.canvas}
                     </div>
-                ) : isD3Section ? (
+                ) : isLazySection ? (
                     <div
                         className="ap-site-editor__canvas"
-                        data-has-entity="true"
+                        data-has-entity={
+                            isD3Section ||
+                            showNavigationEditor ||
+                            showPatternsEditor
+                        }
                         data-testid="ap-site-editor-canvas"
                     >
-                        {stylesViews.canvas}
-                    </div>
-                ) : isD4Section ? (
-                    <div
-                        className="ap-site-editor__canvas"
-                        data-has-entity={showNavigationEditor}
-                        data-testid="ap-site-editor-canvas"
-                    >
-                        {navigationViews.canvas}
-                    </div>
-                ) : isD5Section ? (
-                    <div
-                        className="ap-site-editor__canvas"
-                        data-has-entity={showPatternsEditor}
-                        data-testid="ap-site-editor-canvas"
-                    >
-                        {patternsViews.canvas}
+                        <div
+                            className="ap-site-editor__canvas-slot"
+                            ref={setCanvasSlot}
+                            data-testid="ap-site-editor-canvas-slot"
+                        />
                     </div>
                 ) : (
                     <CanvasFrame
@@ -627,12 +634,14 @@ export function SiteEditorApp(props: SiteEditorAppProps): JSX.Element {
                     <div className="ap-site-editor__sidebar ap-site-editor__sidebar--inspector">
                         {showEntityEditor ? (
                             editorViews.inspector
-                        ) : isD3Section ? (
-                            stylesViews.inspector
-                        ) : isD4Section && showNavigationEditor ? (
-                            navigationViews.inspector
-                        ) : isD5Section && showPatternsEditor ? (
-                            patternsViews.inspector
+                        ) : isD3Section ||
+                          (isD4Section && showNavigationEditor) ||
+                          (isD5Section && showPatternsEditor) ? (
+                            <div
+                                className="ap-site-editor__inspector-slot"
+                                ref={setInspectorSlot}
+                                data-testid="ap-site-editor-inspector-slot"
+                            />
                         ) : (
                             <InspectorOutlet sectionLabel={activeSection.label} />
                         )}
@@ -655,8 +664,59 @@ export function SiteEditorApp(props: SiteEditorAppProps): JSX.Element {
                     onCreated={(entity) => handleDialogCreated(entity.id)}
                 />
             ) : null}
-            {navigationViews.overlay}
-            {patternsViews.overlay}
+            {/* H7 (#432). Stable portal target for lazy section overlays
+              (CreateMenuDialog, CreatePatternDialog, etc.). Always
+              mounted so the portal can fire as soon as the lazy section
+              resolves. */}
+            <div
+                ref={setOverlaySlot}
+                data-testid="ap-site-editor-overlay-slot"
+            />
+            {/* H7 (#432). Lazy section orchestrators. Each portals its
+              navigator / canvas / inspector / overlay views into the
+              shell-controlled slots above. Suspense fallback is null —
+              brief blank flash on first nav into a section is
+              preferable to a layout-shifting spinner that competes
+              with the section's own loading states. */}
+            <Suspense fallback={null}>
+                {isD3Section ? (
+                    <StylesSectionView
+                        apiConfig={apiConfig}
+                        enabled={isD3Section}
+                        onStateChange={handleEntityStateChange}
+                        navigatorSlot={navigatorSlot}
+                        canvasSlot={canvasSlot}
+                        inspectorSlot={inspectorSlot}
+                    />
+                ) : null}
+                {isD4Section ? (
+                    <NavigationSectionView
+                        apiConfig={apiConfig}
+                        enabled={isD4Section}
+                        activeEntityId={activeEntityId}
+                        onOpenEntity={handleNavigationOpen}
+                        onStateChange={handleEntityStateChange}
+                        navigatorSlot={navigatorSlot}
+                        canvasSlot={canvasSlot}
+                        inspectorSlot={inspectorSlot}
+                        overlaySlot={overlaySlot}
+                    />
+                ) : null}
+                {isD5Section ? (
+                    <PatternsSectionView
+                        apiConfig={apiConfig}
+                        enabled={isD5Section}
+                        activeEntityId={activeEntityId}
+                        onOpenEntity={handlePatternsOpen}
+                        onCloseEntity={handlePatternsClose}
+                        onStateChange={handleEntityStateChange}
+                        navigatorSlot={navigatorSlot}
+                        canvasSlot={canvasSlot}
+                        inspectorSlot={inspectorSlot}
+                        overlaySlot={overlaySlot}
+                    />
+                ) : null}
+            </Suspense>
         </div>
     );
 }

--- a/resources/js/visual-editor/site-editor/styles/styles-section.tsx
+++ b/resources/js/visual-editor/site-editor/styles/styles-section.tsx
@@ -26,6 +26,7 @@ import {
 import { TEXT_DOMAIN } from '../../vendor/i18n';
 import type { SiteEditorApiConfig } from '../api-client';
 import type { EntityEditorState } from '../entity-editor';
+import { SectionPortal } from '../section-portal';
 import {
     StyleBookCanvas,
     type StyleVariation,
@@ -336,6 +337,37 @@ export function useStylesSectionViews(
     );
 
     return { navigator, canvas, inspector };
+}
+
+/**
+ * Lazy-mountable wrapper around `useStylesSectionViews` — H7 (#432).
+ *
+ * The shell `React.lazy()`-imports this file's default export so the
+ * styles bundle (style-book canvas, panels, navigator tree) stays out
+ * of the initial site-editor boot chunk. The component itself just
+ * runs the hook and portals the three views into shell-controlled
+ * mount points; lazy-loading the orchestrator is what actually splits
+ * the chunk.
+ */
+export interface StylesSectionViewProps extends UseStylesSectionViewsOptions {
+    navigatorSlot: HTMLElement | null;
+    canvasSlot: HTMLElement | null;
+    inspectorSlot: HTMLElement | null;
+}
+
+export default function StylesSectionView(
+    props: StylesSectionViewProps
+): ReactElement {
+    const { navigatorSlot, canvasSlot, inspectorSlot, ...hookOptions } = props;
+    const views = useStylesSectionViews(hookOptions);
+
+    return (
+        <>
+            <SectionPortal slot={navigatorSlot}>{views.navigator}</SectionPortal>
+            <SectionPortal slot={canvasSlot}>{views.canvas}</SectionPortal>
+            <SectionPortal slot={inspectorSlot}>{views.inspector}</SectionPortal>
+        </>
+    );
 }
 
 export { DEFAULT_NAVIGATOR_STATE } from './styles-navigator-tree';

--- a/resources/js/visual-editor/site-editor/template-parts-section.tsx
+++ b/resources/js/visual-editor/site-editor/template-parts-section.tsx
@@ -10,8 +10,8 @@
  * The create dialog requires an area selection up-front: a part with no
  * area can't be swapped into anything at render time, and the C2 request
  * validation rejects a blank area anyway. We surface the set from
- * {@link VisualEditorTemplatePart::AREAS} — adding a new area in PHP
- * means adding it here as well.
+ * cms-framework's `TemplatePart::AREAS` (plan 14 §4.2 / module H1) —
+ * adding a new area in PHP means adding it here as well.
  */
 
 import { __, sprintf } from '@wordpress/i18n';

--- a/resources/js/visual-editor/site-editor/use-entity-list.ts
+++ b/resources/js/visual-editor/site-editor/use-entity-list.ts
@@ -1,12 +1,16 @@
 /**
- * Paginated list hook for site-editor entities.
+ * List hook for site-editor entities.
  *
- * Handles the `{ data, meta }` envelope the C1/C2 REST endpoints return,
- * tracks load/error status, and exposes a `refresh` callback so callers
- * can force a re-fetch after a create/update/delete. The hook deliberately
- * does not cache across mounts — the site-editor browses one section at a
- * time and the relative cost of refetching a list on re-open is negligible
- * compared to the complexity of invalidation.
+ * H7 (#432) — H6's `TemplateController::index` /
+ * `TemplatePartController::index` return a flat JSON array via their
+ * adapter's `collection()` method, not the `{ data, meta }` envelope
+ * plan 11 Phase D shipped. This hook owns load/error status and a
+ * `refresh` callback so callers can force a re-fetch after a
+ * create/update/delete. It deliberately does not cache across mounts
+ * — the site-editor browses one section at a time and the cost of a
+ * refetch on re-open is negligible compared to invalidation
+ * complexity. Pagination state (`page` / `setPage`) is preserved as a
+ * no-op for callers; H6 doesn't paginate yet.
  */
 
 import { __ } from '@wordpress/i18n';
@@ -20,7 +24,6 @@ import {
     type EntityKind,
     type EntityRecord,
     type ListParams,
-    type PaginatedResponse,
     type SiteEditorApiConfig,
 } from './api-client';
 
@@ -46,7 +49,6 @@ export interface UseEntityListOptions<K extends EntityKind> extends ListParams {
 
 export interface UseEntityListResult<K extends EntityKind> {
     items: readonly EntityRecord<K>[];
-    meta: PaginatedResponse<EntityRecord<K>>['meta'] | null;
     status: EntityListStatus;
     errorMessage: string | null;
     /** Re-fetches the current page with the same filters. */
@@ -73,7 +75,6 @@ export function useEntityList<K extends EntityKind>(
     } = options;
 
     const [items, setItems] = useState<readonly EntityRecord<K>[]>([]);
-    const [meta, setMeta] = useState<PaginatedResponse<EntityRecord<K>>['meta'] | null>(null);
     const [status, setStatus] = useState<EntityListStatus>(enabled ? 'loading' : 'idle');
     const [errorMessage, setErrorMessage] = useState<string | null>(null);
     const [page, setPage] = useState<number>(initialPage);
@@ -106,8 +107,7 @@ export function useEntityList<K extends EntityKind>(
                 return;
             }
 
-            setItems(response.data);
-            setMeta(response.meta);
+            setItems(response);
             setStatus('ready');
         } catch (error: unknown) {
             if (requestCounterRef.current !== requestId) {
@@ -120,7 +120,6 @@ export function useEntityList<K extends EntityKind>(
                     : __('Failed to load entities.', TEXT_DOMAIN);
 
             setItems([]);
-            setMeta(null);
             setErrorMessage(message);
             setStatus('error');
         }
@@ -143,7 +142,6 @@ export function useEntityList<K extends EntityKind>(
 
     return {
         items,
-        meta,
         status,
         errorMessage,
         refresh: fetchList,

--- a/resources/views/site-editor/install-gate.blade.php
+++ b/resources/views/site-editor/install-gate.blade.php
@@ -1,0 +1,158 @@
+{{-- H7 (#432) install gate.
+
+	Rendered by the `/visual-editor/site/{path?}` route closure when
+	cms-framework's SiteEditor module is not booted. Per plan 14 §2.1
+	the site-editor surface is hard-coupled to cms-framework — without
+	it the H6 controllers all 404, which would cascade through the SPA
+	as a sea of error banners. This page short-circuits that, telling
+	the user how to get unstuck and pointing them back at the post
+	editor (which remains functional standalone).
+
+	Inline styles are deliberate: the SPA's CSS chunks aren't loaded
+	on this page (the gate is the alternative to mounting the SPA), so
+	the page must stand on its own without Vite's site-editor bundle. --}}
+<!DOCTYPE html>
+<html lang="{{ str_replace( '_', '-', app()->getLocale() ) }}">
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title>{{ __( 'Site editor unavailable — ArtisanPack Visual Editor' ) }}</title>
+	<style>
+		:root {
+			color-scheme: light dark;
+		}
+
+		body {
+			margin: 0;
+			min-height: 100vh;
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			padding: 2rem;
+			background: #f5f5f7;
+			color: #1d1d1f;
+			font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+			line-height: 1.5;
+		}
+
+		.ap-install-gate {
+			max-width: 36rem;
+			background: #fff;
+			border-radius: 0.75rem;
+			padding: 2.5rem;
+			box-shadow: 0 1px 2px rgba( 0, 0, 0, 0.05 ), 0 8px 24px rgba( 0, 0, 0, 0.08 );
+		}
+
+		.ap-install-gate__eyebrow {
+			text-transform: uppercase;
+			letter-spacing: 0.08em;
+			font-size: 0.75rem;
+			font-weight: 600;
+			color: #86868b;
+			margin: 0 0 0.75rem;
+		}
+
+		.ap-install-gate__title {
+			margin: 0 0 1rem;
+			font-size: 1.625rem;
+			font-weight: 700;
+			color: #1d1d1f;
+		}
+
+		.ap-install-gate__lede {
+			margin: 0 0 1.25rem;
+			font-size: 1rem;
+			color: #1d1d1f;
+		}
+
+		.ap-install-gate__lede code {
+			font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+			background: #f5f5f7;
+			border-radius: 0.25rem;
+			padding: 0.1rem 0.35rem;
+			font-size: 0.95em;
+		}
+
+		.ap-install-gate__command {
+			background: #1d1d1f;
+			color: #f5f5f7;
+			border-radius: 0.5rem;
+			padding: 1rem 1.25rem;
+			font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+			font-size: 0.9rem;
+			margin: 0 0 1.5rem;
+			overflow-x: auto;
+			white-space: pre;
+		}
+
+		.ap-install-gate__footer {
+			margin: 0;
+			font-size: 0.875rem;
+			color: #6e6e73;
+		}
+
+		.ap-install-gate__footer a {
+			color: #0066cc;
+			text-decoration: none;
+		}
+
+		.ap-install-gate__footer a:hover,
+		.ap-install-gate__footer a:focus {
+			text-decoration: underline;
+		}
+
+		@media ( prefers-color-scheme: dark ) {
+			body {
+				background: #1d1d1f;
+				color: #f5f5f7;
+			}
+
+			.ap-install-gate {
+				background: #2c2c2e;
+				box-shadow: 0 1px 2px rgba( 0, 0, 0, 0.4 ), 0 8px 24px rgba( 0, 0, 0, 0.6 );
+			}
+
+			.ap-install-gate__title {
+				color: #f5f5f7;
+			}
+
+			.ap-install-gate__lede {
+				color: #e5e5e7;
+			}
+
+			.ap-install-gate__lede code {
+				background: #1d1d1f;
+				color: #f5f5f7;
+			}
+
+			.ap-install-gate__command {
+				background: #000;
+				color: #f5f5f7;
+			}
+
+			.ap-install-gate__footer {
+				color: #a1a1a6;
+			}
+
+			.ap-install-gate__footer a {
+				color: #2997ff;
+			}
+		}
+	</style>
+</head>
+<body>
+	<main class="ap-install-gate" role="main" data-testid="ap-install-gate">
+		<p class="ap-install-gate__eyebrow">{{ __( 'Visual Editor' ) }}</p>
+		<h1 class="ap-install-gate__title">
+			{{ __( 'Install cms-framework to enable the site editor' ) }}
+		</h1>
+		<p class="ap-install-gate__lede">
+			{!! __( 'The visual-editor\'s site editor requires :package for templates, patterns, global styles, and menus. Install it, then reload this page:', [ 'package' => '<code>artisanpack-ui/cms-framework</code>' ] ) !!}
+		</p>
+		<pre class="ap-install-gate__command" aria-label="{{ __( 'Composer install command' ) }}"><code>composer require artisanpack-ui/cms-framework</code></pre>
+		<p class="ap-install-gate__footer">
+			{!! __( 'The post editor remains available at :link while you set this up.', [ 'link' => '<a href="' . e( $postEditorUrl ) . '" data-testid="ap-install-gate-post-editor-link">' . e( $postEditorUrl ) . '</a>' ] ) !!}
+		</p>
+	</main>
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use ArtisanPackUI\VisualEditor\SiteEditor\CmsFrameworkIntegration;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/editor', function () {
@@ -29,9 +30,21 @@ Route::get('/ve-sandbox', function () {
 // `csrf_token()` helper in the blade returns a token that isn't tied to
 // any session cookie — which makes the first REST mutation (CREATE,
 // PUT) fail with "CSRF token mismatch" (D2 #369).
+//
+// H7 (#432). The closure short-circuits to an install-gate view when
+// cms-framework's SiteEditor module is not booted. Without the gate the
+// SPA would mount and then receive a cascade of 404s from every H6
+// controller — a bad first-run experience that the gate replaces with a
+// single `composer require artisanpack-ui/cms-framework` instruction.
 Route::middleware('web')
     ->group(function (): void {
         Route::get('/visual-editor/site/{path?}', function () {
+            if (! CmsFrameworkIntegration::isAvailable()) {
+                return response()->view('visual-editor::site-editor.install-gate', [
+                    'postEditorUrl' => route('visual-editor.editor'),
+                ]);
+            }
+
             return view('visual-editor::site-editor.index');
         })
             ->where('path', '.*')

--- a/src/Http/Controllers/SiteEditor/PatternController.php
+++ b/src/Http/Controllers/SiteEditor/PatternController.php
@@ -84,15 +84,21 @@ class PatternController extends Controller
 	}
 
 	/**
-	 * GET `/visual-editor/api/patterns/{slug}` — single pattern. The
-	 * `{slug}` segment matches `.+` so user-source slugs carrying the
-	 * `user/` prefix can ride through unchanged.
+	 * GET `/visual-editor/api/patterns/{slug}` — single pattern.
+	 *
+	 * The route segment is named `{slug}` for parity with WP REST,
+	 * but H6 ({@see PatternAdapter::toArray()}) sets the response's
+	 * `id` to `wpId ?? slug`, and the editor's `addEntities` registers
+	 * `wp_block` with `key: 'id'`. So the URL parameter is whatever the
+	 * adapter put into `id` — a numeric DB id for user patterns, the
+	 * slug for theme patterns. {@see findPatternByIdOrSlug()} handles
+	 * both forms.
 	 *
 	 * @since 1.0.0
 	 */
 	public function show( string $slug ): JsonResponse
 	{
-		$resolved = $this->findPattern( $slug );
+		$resolved = $this->findPatternByIdOrSlug( $slug );
 
 		if ( ! $resolved instanceof ResolvedPattern ) {
 			return response()->json( [ 'message' => 'Pattern not found.' ], Response::HTTP_NOT_FOUND );
@@ -162,7 +168,13 @@ class PatternController extends Controller
 
 		$validated = $request->validated();
 
-		if ( array_key_exists( 'slug', $validated ) && $this->normalizeUserSlug( $validated['slug'] ) !== $this->normalizeUserSlug( $slug ) ) {
+		$existing = $this->findPatternModelByIdOrSlug( $slug );
+
+		if ( null === $existing ) {
+			return response()->json( [ 'message' => 'Pattern not found.' ], Response::HTTP_NOT_FOUND );
+		}
+
+		if ( array_key_exists( 'slug', $validated ) && $this->normalizeUserSlug( $validated['slug'] ) !== $this->normalizeUserSlug( (string) $existing->slug ) ) {
 			return response()->json( [
 				'message' => 'Body slug does not match URL slug.',
 				'errors'  => [ 'slug' => [ 'Slug in the request body must match the URL slug.' ] ],
@@ -171,20 +183,11 @@ class PatternController extends Controller
 
 		unset( $validated['slug'] );
 
-		$model      = self::CMS_PATTERN_FQCN;
-		$storedSlug = $this->ensureUserPrefix( $slug );
-
-		$existing = $model::query()->where( 'slug', $storedSlug )->first();
-
-		if ( null === $existing ) {
-			return response()->json( [ 'message' => 'Pattern not found.' ], Response::HTTP_NOT_FOUND );
-		}
-
 		$existing->update( $this->modelAttributesFromRequest( $validated ) );
 
 		$this->refreshResolver();
 
-		$resolved = $this->findPattern( $slug );
+		$resolved = $this->findPatternByIdOrSlug( $slug );
 
 		// The DB write succeeded; if the post-write resolver re-lookup
 		// can't find the record (stale filter contributor, slug-prefix
@@ -211,14 +214,13 @@ class PatternController extends Controller
 			return $this->cmsFrameworkUnavailable();
 		}
 
-		$model      = self::CMS_PATTERN_FQCN;
-		$storedSlug = $this->ensureUserPrefix( $slug );
+		$existing = $this->findPatternModelByIdOrSlug( $slug );
 
-		$deleted = (int) $model::query()->where( 'slug', $storedSlug )->delete();
-
-		if ( 0 === $deleted ) {
+		if ( null === $existing ) {
 			return response()->json( [ 'message' => 'Pattern not found.' ], Response::HTTP_NOT_FOUND );
 		}
+
+		$existing->delete();
 
 		$this->refreshResolver();
 
@@ -248,6 +250,64 @@ class PatternController extends Controller
 		$resolved = $this->resolver->find( $prefixed );
 
 		return $resolved instanceof ResolvedPattern ? $resolved : null;
+	}
+
+	/**
+	 * Resolve a pattern by either its DB id or its slug.
+	 *
+	 * H6's adapter stamps the response's `id` as `wpId ?? slug`, so the
+	 * URL parameter the editor sends back is one of:
+	 *   - a numeric DB id (user-source patterns), or
+	 *   - the slug (theme patterns whose `wpId` is null).
+	 *
+	 * Numeric ids dispatch through a single resolver scan keyed on
+	 * {@see ResolvedPattern::$wpId}; non-numeric input falls through to
+	 * {@see findPattern()} which already handles the user-prefix dance.
+	 *
+	 * @since 1.0.0
+	 */
+	protected function findPatternByIdOrSlug( string $input ): ?ResolvedPattern
+	{
+		if ( ctype_digit( $input ) ) {
+			$id = (int) $input;
+
+			foreach ( $this->resolver->all() as $candidate ) {
+				if ( $candidate instanceof ResolvedPattern && $candidate->wpId === $id ) {
+					return $candidate;
+				}
+			}
+
+			return null;
+		}
+
+		return $this->findPattern( $input );
+	}
+
+	/**
+	 * Resolve a pattern model row by either id or slug, for write
+	 * paths (update / destroy) that need the underlying Eloquent
+	 * record. Mirrors {@see findPatternByIdOrSlug()} but bypasses the
+	 * resolver because writes target the DB row directly.
+	 *
+	 * Returns null when the row doesn't exist or when cms-framework
+	 * isn't booted (callers gate on
+	 * {@see cmsFrameworkAvailable()} before invoking).
+	 *
+	 * @since 1.0.0
+	 */
+	protected function findPatternModelByIdOrSlug( string $input ): ?object
+	{
+		$model = self::CMS_PATTERN_FQCN;
+
+		if ( ctype_digit( $input ) ) {
+			/** @var object|null */
+			return $model::query()->find( (int) $input );
+		}
+
+		$storedSlug = $this->ensureUserPrefix( $input );
+
+		/** @var object|null */
+		return $model::query()->where( 'slug', $storedSlug )->first();
 	}
 
 	/**

--- a/src/Http/Controllers/SiteEditor/TemplateController.php
+++ b/src/Http/Controllers/SiteEditor/TemplateController.php
@@ -90,11 +90,19 @@ class TemplateController extends Controller
 	/**
 	 * GET `/visual-editor/api/templates/{slug}` — return a single template.
 	 *
+	 * The route segment is named `{slug}` for parity with WP REST, but
+	 * H6 ({@see TemplateAdapter::toArray()}) sets the response's `id`
+	 * to `wpId ?? slug`, and the editor's `addEntities` registers
+	 * `wp_template` with `key: 'id'`. So the URL parameter is whatever
+	 * the adapter put into `id` — a numeric DB id when the template
+	 * has a DB override, the slug for theme-only templates.
+	 * {@see findTemplateByIdOrSlug()} handles both forms.
+	 *
 	 * @since 1.0.0
 	 */
 	public function show( string $slug ): JsonResponse
 	{
-		$resolved = $this->resolver->find( $slug );
+		$resolved = $this->findTemplateByIdOrSlug( $slug );
 
 		if ( ! $resolved instanceof ResolvedTemplate ) {
 			return response()->json( [ 'message' => 'Template not found.' ], Response::HTTP_NOT_FOUND );
@@ -168,63 +176,97 @@ class TemplateController extends Controller
 
 		$validated = $request->validated();
 
-		if ( array_key_exists( 'slug', $validated ) && $validated['slug'] !== $slug ) {
-			return response()->json( [
-				'message' => 'Body slug does not match URL slug.',
-				'errors'  => [ 'slug' => [ 'Slug in the request body must match the URL slug.' ] ],
-			], Response::HTTP_UNPROCESSABLE_ENTITY );
-		}
-
-		unset( $validated['slug'] );
-
 		$model = self::CMS_TEMPLATE_FQCN;
-		$theme = (string) ( $validated['theme'] ?? '' );
 
-		if ( '' === $theme ) {
-			return response()->json( [
-				'message' => 'A theme is required to identify the template.',
-				'errors'  => [ 'theme' => [ 'The theme field is required for site-editor updates.' ] ],
-			], Response::HTTP_UNPROCESSABLE_ENTITY );
-		}
+		// H7 (#432). Numeric URL parameter → look up the row directly
+		// by primary key (the row already knows its theme + slug). Slug
+		// path keeps the existing `(theme, slug)` upsert behavior so
+		// theme-only templates can be DB-overridden through a PUT.
+		if ( ctype_digit( $slug ) ) {
+			$existing = $model::query()->find( (int) $slug );
 
-		$existing = $model::query()->where( 'theme', $theme )->where( 'slug', $slug )->first();
+			if ( null === $existing ) {
+				return response()->json(
+					[ 'message' => 'Template not found.' ],
+					Response::HTTP_NOT_FOUND,
+				);
+			}
 
-		if ( null === $existing ) {
-			$attributes         = $this->modelAttributesFromRequest( $validated );
-			$attributes['slug'] = $slug;
+			if (
+				array_key_exists( 'slug', $validated )
+				&& $validated['slug'] !== (string) $existing->slug
+			) {
+				return response()->json( [
+					'message' => 'Body slug does not match URL slug.',
+					'errors'  => [ 'slug' => [ 'Slug in the request body must match the URL slug.' ] ],
+				], Response::HTTP_UNPROCESSABLE_ENTITY );
+			}
 
-			try {
-				$existing = $model::create( $attributes );
-			} catch ( QueryException $e ) {
-				if ( ! $this->isUniqueViolation( $e ) ) {
-					throw $e;
+			unset( $validated['slug'] );
+
+			$existing->update( $this->modelAttributesFromRequest( $validated ) );
+
+			$resolverKey = (string) $existing->slug;
+		} else {
+			if ( array_key_exists( 'slug', $validated ) && $validated['slug'] !== $slug ) {
+				return response()->json( [
+					'message' => 'Body slug does not match URL slug.',
+					'errors'  => [ 'slug' => [ 'Slug in the request body must match the URL slug.' ] ],
+				], Response::HTTP_UNPROCESSABLE_ENTITY );
+			}
+
+			unset( $validated['slug'] );
+
+			$theme = (string) ( $validated['theme'] ?? '' );
+
+			if ( '' === $theme ) {
+				return response()->json( [
+					'message' => 'A theme is required to identify the template.',
+					'errors'  => [ 'theme' => [ 'The theme field is required for site-editor updates.' ] ],
+				], Response::HTTP_UNPROCESSABLE_ENTITY );
+			}
+
+			$existing = $model::query()->where( 'theme', $theme )->where( 'slug', $slug )->first();
+
+			if ( null === $existing ) {
+				$attributes         = $this->modelAttributesFromRequest( $validated );
+				$attributes['slug'] = $slug;
+
+				try {
+					$existing = $model::create( $attributes );
+				} catch ( QueryException $e ) {
+					if ( ! $this->isUniqueViolation( $e ) ) {
+						throw $e;
+					}
+
+					// Race recovery: another request inserted between the
+					// existence check and our create. Re-fetch the now-existing
+					// row and re-apply the edits. If the lookup still misses
+					// (genuine contradiction — unique violation said the row
+					// exists, but our scoped query can't find it; e.g. the
+					// other writer used a different theme), rethrow the
+					// original exception rather than masking it as 404.
+					$existing = $model::query()
+						->where( 'theme', $theme )
+						->where( 'slug', $slug )
+						->first();
+
+					if ( null === $existing ) {
+						throw $e;
+					}
+
+					$existing->update( $this->modelAttributesFromRequest( $validated ) );
 				}
-
-				// Race recovery: another request inserted between the
-				// existence check and our create. Re-fetch the now-existing
-				// row and re-apply the edits. If the lookup still misses
-				// (genuine contradiction — unique violation said the row
-				// exists, but our scoped query can't find it; e.g. the
-				// other writer used a different theme), rethrow the
-				// original exception rather than masking it as 404.
-				$existing = $model::query()
-					->where( 'theme', $theme )
-					->where( 'slug', $slug )
-					->first();
-
-				if ( null === $existing ) {
-					throw $e;
-				}
-
+			} else {
 				$existing->update( $this->modelAttributesFromRequest( $validated ) );
 			}
-		} else {
-			$existing->update( $this->modelAttributesFromRequest( $validated ) );
+
+			$resolverKey = $slug;
 		}
 
 		$this->refreshResolver();
 
-		$resolved = $this->resolver->find( $slug );
+		$resolved = $this->resolver->find( $resolverKey );
 
 		// The DB write succeeded; a post-write resolver miss shouldn't
 		// surface as 404 — that would imply the update failed. Return
@@ -254,6 +296,29 @@ class TemplateController extends Controller
 			return $this->cmsFrameworkUnavailable();
 		}
 
+		$model = self::CMS_TEMPLATE_FQCN;
+
+		// H7 (#432). Numeric URL parameter → primary-key delete (row
+		// owns its theme already; no `?theme=` collision risk). Slug
+		// path keeps the `?theme=` requirement so a multi-theme
+		// override doesn't get collateral-deleted.
+		if ( ctype_digit( $slug ) ) {
+			$existing = $model::query()->find( (int) $slug );
+
+			if ( null === $existing ) {
+				return response()->json(
+					[ 'message' => 'No template override to revert.' ],
+					Response::HTTP_NOT_FOUND,
+				);
+			}
+
+			$existing->delete();
+
+			$this->refreshResolver();
+
+			return response()->json( null, Response::HTTP_NO_CONTENT );
+		}
+
 		// Cast to string defensively — Laravel returns an array if the
 		// client sends `?theme[]=...`, which would error on `trim()`.
 		$theme = trim( (string) $request->query( 'theme', '' ) );
@@ -264,8 +329,6 @@ class TemplateController extends Controller
 				'errors'  => [ 'theme' => [ 'The theme query parameter is required for site-editor deletes.' ] ],
 			], Response::HTTP_UNPROCESSABLE_ENTITY );
 		}
-
-		$model = self::CMS_TEMPLATE_FQCN;
 
 		$deleted = (int) $model::query()
 			->where( 'theme', $theme )
@@ -288,6 +351,33 @@ class TemplateController extends Controller
 	 *
 	 * @since 1.0.0
 	 */
+	/**
+	 * Resolve a template through the H5 resolver by either DB id or
+	 * slug. Numeric inputs scan {@see TemplateResolver::all()} for an
+	 * entry whose `wpId` matches; non-numeric inputs fall through to
+	 * the resolver's slug-keyed lookup.
+	 *
+	 * @since 1.0.0
+	 */
+	protected function findTemplateByIdOrSlug( string $input ): ?ResolvedTemplate
+	{
+		if ( ctype_digit( $input ) ) {
+			$id = (int) $input;
+
+			foreach ( $this->resolver->all() as $candidate ) {
+				if ( $candidate instanceof ResolvedTemplate && $candidate->wpId === $id ) {
+					return $candidate;
+				}
+			}
+
+			return null;
+		}
+
+		$resolved = $this->resolver->find( $input );
+
+		return $resolved instanceof ResolvedTemplate ? $resolved : null;
+	}
+
 	protected function cmsFrameworkAvailable(): bool
 	{
 		if ( ! class_exists( self::CMS_TEMPLATE_FQCN ) ) {

--- a/src/Http/Controllers/SiteEditor/TemplatePartController.php
+++ b/src/Http/Controllers/SiteEditor/TemplatePartController.php
@@ -68,11 +68,17 @@ class TemplatePartController extends Controller
 	/**
 	 * GET `/visual-editor/api/template-parts/{slug}` — single part.
 	 *
+	 * H7 (#432). Same id-or-slug treatment as
+	 * {@see TemplateController::show()} — the editor's `addEntities`
+	 * registers `wp_template_part` with `key: 'id'` and the adapter
+	 * sets `id = wpId ?? slug`, so the URL parameter can be either
+	 * form. {@see findTemplatePartByIdOrSlug()} handles both.
+	 *
 	 * @since 1.0.0
 	 */
 	public function show( string $slug ): JsonResponse
 	{
-		$resolved = $this->resolver->find( $slug );
+		$resolved = $this->findTemplatePartByIdOrSlug( $slug );
 
 		if ( ! $resolved instanceof ResolvedTemplatePart ) {
 			return response()->json( [ 'message' => 'Template part not found.' ], Response::HTTP_NOT_FOUND );
@@ -133,68 +139,102 @@ class TemplatePartController extends Controller
 
 		$validated = $request->validated();
 
-		if ( array_key_exists( 'slug', $validated ) && $validated['slug'] !== $slug ) {
-			return response()->json( [
-				'message' => 'Body slug does not match URL slug.',
-				'errors'  => [ 'slug' => [ 'Slug in the request body must match the URL slug.' ] ],
-			], Response::HTTP_UNPROCESSABLE_ENTITY );
-		}
-
-		unset( $validated['slug'] );
-
 		$model = self::CMS_TEMPLATE_PART_FQCN;
-		$theme = (string) ( $validated['theme'] ?? '' );
 
-		if ( '' === $theme ) {
-			return response()->json( [
-				'message' => 'A theme is required to identify the template part.',
-				'errors'  => [ 'theme' => [ 'The theme field is required for site-editor updates.' ] ],
-			], Response::HTTP_UNPROCESSABLE_ENTITY );
-		}
+		// H7 (#432). Numeric URL parameter → primary-key update on
+		// the row that already knows its `(theme, slug, area)`. Slug
+		// path keeps the existing upsert behavior so a theme-only
+		// part can be DB-overridden through a PUT.
+		if ( ctype_digit( $slug ) ) {
+			$existing = $model::query()->find( (int) $slug );
 
-		$existing = $model::query()->where( 'theme', $theme )->where( 'slug', $slug )->first();
+			if ( null === $existing ) {
+				return response()->json(
+					[ 'message' => 'Template part not found.' ],
+					Response::HTTP_NOT_FOUND,
+				);
+			}
 
-		if ( null === $existing ) {
-			$attributes         = $this->modelAttributesFromRequest( $validated );
-			$attributes['slug'] = $slug;
-
-			// Area is required to create a new part record; the existing
-			// row's area would otherwise survive the update branch.
-			if ( ! array_key_exists( 'area', $attributes ) ) {
+			if (
+				array_key_exists( 'slug', $validated )
+				&& $validated['slug'] !== (string) $existing->slug
+			) {
 				return response()->json( [
-					'message' => 'An area is required to upsert a new template part.',
-					'errors'  => [ 'area' => [ 'The area field is required when creating a part.' ] ],
+					'message' => 'Body slug does not match URL slug.',
+					'errors'  => [ 'slug' => [ 'Slug in the request body must match the URL slug.' ] ],
 				], Response::HTTP_UNPROCESSABLE_ENTITY );
 			}
 
-			try {
-				$existing = $model::create( $attributes );
-			} catch ( QueryException $e ) {
-				if ( ! $this->isUniqueViolation( $e ) ) {
-					throw $e;
+			unset( $validated['slug'] );
+
+			$existing->update( $this->modelAttributesFromRequest( $validated ) );
+
+			$resolverKey = (string) $existing->slug;
+		} else {
+			if ( array_key_exists( 'slug', $validated ) && $validated['slug'] !== $slug ) {
+				return response()->json( [
+					'message' => 'Body slug does not match URL slug.',
+					'errors'  => [ 'slug' => [ 'Slug in the request body must match the URL slug.' ] ],
+				], Response::HTTP_UNPROCESSABLE_ENTITY );
+			}
+
+			unset( $validated['slug'] );
+
+			$theme = (string) ( $validated['theme'] ?? '' );
+
+			if ( '' === $theme ) {
+				return response()->json( [
+					'message' => 'A theme is required to identify the template part.',
+					'errors'  => [ 'theme' => [ 'The theme field is required for site-editor updates.' ] ],
+				], Response::HTTP_UNPROCESSABLE_ENTITY );
+			}
+
+			$existing = $model::query()->where( 'theme', $theme )->where( 'slug', $slug )->first();
+
+			if ( null === $existing ) {
+				$attributes         = $this->modelAttributesFromRequest( $validated );
+				$attributes['slug'] = $slug;
+
+				// Area is required to create a new part record; the existing
+				// row's area would otherwise survive the update branch.
+				if ( ! array_key_exists( 'area', $attributes ) ) {
+					return response()->json( [
+						'message' => 'An area is required to upsert a new template part.',
+						'errors'  => [ 'area' => [ 'The area field is required when creating a part.' ] ],
+					], Response::HTTP_UNPROCESSABLE_ENTITY );
 				}
 
-				// See {@see TemplateController::update()} for the race-recovery
-				// rationale. Rethrow the original exception when the
-				// post-violation lookup still misses, rather than 404.
-				$existing = $model::query()
-					->where( 'theme', $theme )
-					->where( 'slug', $slug )
-					->first();
+				try {
+					$existing = $model::create( $attributes );
+				} catch ( QueryException $e ) {
+					if ( ! $this->isUniqueViolation( $e ) ) {
+						throw $e;
+					}
 
-				if ( null === $existing ) {
-					throw $e;
+					// See {@see TemplateController::update()} for the race-recovery
+					// rationale. Rethrow the original exception when the
+					// post-violation lookup still misses, rather than 404.
+					$existing = $model::query()
+						->where( 'theme', $theme )
+						->where( 'slug', $slug )
+						->first();
+
+					if ( null === $existing ) {
+						throw $e;
+					}
+
+					$existing->update( $this->modelAttributesFromRequest( $validated ) );
 				}
-
+			} else {
 				$existing->update( $this->modelAttributesFromRequest( $validated ) );
 			}
-		} else {
-			$existing->update( $this->modelAttributesFromRequest( $validated ) );
+
+			$resolverKey = $slug;
 		}
 
 		$this->refreshResolver();
 
-		$resolved = $this->resolver->find( $slug );
+		$resolved = $this->resolver->find( $resolverKey );
 
 		// The DB write succeeded; a post-write resolver miss shouldn't
 		// surface as 404. See {@see TemplateController::update()} for
@@ -221,6 +261,28 @@ class TemplatePartController extends Controller
 			return $this->cmsFrameworkUnavailable();
 		}
 
+		$model = self::CMS_TEMPLATE_PART_FQCN;
+
+		// H7 (#432). Numeric URL parameter → primary-key delete; the
+		// row owns its theme so the `?theme=` collision risk doesn't
+		// apply. Slug path keeps the `?theme=` requirement.
+		if ( ctype_digit( $slug ) ) {
+			$existing = $model::query()->find( (int) $slug );
+
+			if ( null === $existing ) {
+				return response()->json(
+					[ 'message' => 'No template-part override to revert.' ],
+					Response::HTTP_NOT_FOUND,
+				);
+			}
+
+			$existing->delete();
+
+			$this->refreshResolver();
+
+			return response()->json( null, Response::HTTP_NO_CONTENT );
+		}
+
 		// Cast to string defensively — see {@see TemplateController::destroy()}.
 		$theme = trim( (string) $request->query( 'theme', '' ) );
 
@@ -230,8 +292,6 @@ class TemplatePartController extends Controller
 				'errors'  => [ 'theme' => [ 'The theme query parameter is required for site-editor deletes.' ] ],
 			], Response::HTTP_UNPROCESSABLE_ENTITY );
 		}
-
-		$model = self::CMS_TEMPLATE_PART_FQCN;
 
 		$deleted = (int) $model::query()
 			->where( 'theme', $theme )
@@ -250,6 +310,33 @@ class TemplatePartController extends Controller
 	/**
 	 * @since 1.0.0
 	 */
+	/**
+	 * Resolve a part through the H5 resolver by either DB id or slug.
+	 * Mirrors {@see TemplateController::findTemplateByIdOrSlug()};
+	 * numeric inputs scan the resolver's `all()` for a matching
+	 * `wpId`, slugs fall through to the slug-keyed lookup.
+	 *
+	 * @since 1.0.0
+	 */
+	protected function findTemplatePartByIdOrSlug( string $input ): ?ResolvedTemplatePart
+	{
+		if ( ctype_digit( $input ) ) {
+			$id = (int) $input;
+
+			foreach ( $this->resolver->all() as $candidate ) {
+				if ( $candidate instanceof ResolvedTemplatePart && $candidate->wpId === $id ) {
+					return $candidate;
+				}
+			}
+
+			return null;
+		}
+
+		$resolved = $this->resolver->find( $input );
+
+		return $resolved instanceof ResolvedTemplatePart ? $resolved : null;
+	}
+
 	protected function cmsFrameworkAvailable(): bool
 	{
 		if ( ! class_exists( self::CMS_TEMPLATE_PART_FQCN ) ) {

--- a/src/SiteEditor/CmsFrameworkIntegration.php
+++ b/src/SiteEditor/CmsFrameworkIntegration.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * cms-framework integration probe — H7 (#432).
+ *
+ * Centralizes the "is artisanpack-ui/cms-framework installed and its
+ * SiteEditor module booted?" check used by the H7 install-gate route
+ * closure. Per plan 14 §2.1 the site-editor surface is hard-coupled to
+ * cms-framework — the gate exists so a standalone visual-editor install
+ * lands on a clear "install cms-framework to enable the site editor"
+ * page instead of an SPA-shaped 404 cascade.
+ *
+ * The H6 controllers (`Http/Controllers/SiteEditor/*`) each carry their
+ * own per-entity `cmsFrameworkAvailable()` test against the entity's
+ * resolver binding. Those stay — the route gate is coarser (any one
+ * resolver binding bound is enough to say "the module is wired") and
+ * deliberately does not require all four resolvers since cms-framework
+ * registers them in a single provider boot.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\SiteEditor;
+
+class CmsFrameworkIntegration
+{
+	/**
+	 * Fully-qualified class name of cms-framework's `Template` model.
+	 *
+	 * Stored as a string so this file compiles without cms-framework on
+	 * the classpath. The H1 module ships this class first; its presence
+	 * is the canonical "cms-framework SiteEditor module is on the
+	 * classpath" signal.
+	 *
+	 * @since 1.0.0
+	 */
+	protected const CMS_TEMPLATE_FQCN = 'ArtisanPackUI\\CMSFramework\\Modules\\SiteEditor\\Models\\Template';
+
+	/**
+	 * Container binding cms-framework's SiteEditor provider declares for
+	 * the templates resolver. Its presence indicates the provider's
+	 * `boot()` has run — the same signal the H6 controllers use as the
+	 * "module is wired up" sentinel.
+	 *
+	 * Stored without a leading backslash so the string matches the
+	 * `$app->bound()` lookup key, which the container normalizes to the
+	 * bare FQCN.
+	 *
+	 * @since 1.0.0
+	 */
+	protected const CMS_RESOLVER_BINDING = 'ArtisanPackUI\\CMSFramework\\Modules\\SiteEditor\\Resolution\\TemplateResolver';
+
+	/**
+	 * True when cms-framework's SiteEditor module is on the classpath
+	 * AND its provider has booted. False otherwise — including the test
+	 * scenario where the class is autoloaded (because cms-framework is
+	 * in `require-dev`) but the provider hasn't been booted yet.
+	 *
+	 * @since 1.0.0
+	 */
+	public static function isAvailable(): bool
+	{
+		if ( ! class_exists( self::CMS_TEMPLATE_FQCN ) ) {
+			return false;
+		}
+
+		return app()->bound( self::CMS_RESOLVER_BINDING );
+	}
+}

--- a/tests/Feature/SiteEditor/InstallGateActiveTest.php
+++ b/tests/Feature/SiteEditor/InstallGateActiveTest.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * H7 (#432) install-gate companion — runs with cms-framework's
+ * SiteEditor provider booted and asserts the gate at
+ * `/visual-editor/site/{path?}` falls through to the SPA-mount blade.
+ * Pairs with {@see InstallGateTest} (no cms-framework) which asserts
+ * the gate fires.
+ *
+ * @since 1.0.0
+ */
+
+declare( strict_types=1 );
+
+use Tests\Concerns\WithCmsFramework;
+use Tests\TestCase;
+
+uses( TestCase::class, WithCmsFramework::class );
+
+test( 'site-editor route mounts the SPA when cms-framework is booted', function (): void {
+	// `withoutVite` swaps the Vite handler for an empty stub so the SPA
+	// mount blade doesn't fail looking for a built manifest under
+	// Testbench's public path. We're asserting the route picks the SPA
+	// view, not exercising Vite asset resolution.
+	$this->withoutVite();
+
+	$response = $this->get( '/visual-editor/site' );
+
+	$response->assertOk();
+	$response->assertViewIs( 'visual-editor::site-editor.index' );
+	$response->assertSee( 'data-ap-site-editor', false );
+} );
+
+test( 'site-editor sub-paths also reach the SPA mount when cms-framework is booted', function (): void {
+	$this->withoutVite();
+
+	$response = $this->get( '/visual-editor/site/templates/single' );
+
+	$response->assertOk();
+	$response->assertViewIs( 'visual-editor::site-editor.index' );
+} );

--- a/tests/Feature/SiteEditor/InstallGateTest.php
+++ b/tests/Feature/SiteEditor/InstallGateTest.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * H7 (#432) install-gate tests — exercises the standalone-install path
+ * where cms-framework is autoloaded (require-dev) but its SiteEditor
+ * provider has NOT been booted. Mirrors the per-controller standalone
+ * tests (e.g. {@see TemplateControllerStandaloneTest}) that prove the
+ * H6 surface 404s gracefully — H7 layers a route-level gate above
+ * those 404s so the user lands on a single install instruction page
+ * instead of a cascade of error banners from the SPA.
+ *
+ * The companion {@see InstallGateActiveTest} runs with cms-framework
+ * booted and asserts the gate falls through to the SPA mount.
+ *
+ * @since 1.0.0
+ */
+
+declare( strict_types=1 );
+
+use Tests\TestCase;
+
+uses( TestCase::class );
+
+test( 'site-editor route renders the install gate when cms-framework is missing', function (): void {
+	$response = $this->get( '/visual-editor/site' );
+
+	$response->assertOk();
+	$response->assertViewIs( 'visual-editor::site-editor.install-gate' );
+	$response->assertViewHas( 'postEditorUrl' );
+	$response->assertSee( 'Install cms-framework to enable the site editor' );
+	$response->assertSee( 'composer require artisanpack-ui/cms-framework', false );
+} );
+
+test( 'install gate renders for nested SPA paths too', function (): void {
+	// Sub-paths under /visual-editor/site (e.g. /styles/123) hit the
+	// same catch-all route — the gate should fire for all of them so
+	// users don't see the SPA mount with broken endpoints.
+	$response = $this->get( '/visual-editor/site/styles/global-styles' );
+
+	$response->assertOk();
+	$response->assertViewIs( 'visual-editor::site-editor.install-gate' );
+} );
+
+test( 'install gate links back to the post editor', function (): void {
+	$response = $this->get( '/visual-editor/site' );
+
+	$response->assertOk();
+	$response->assertSee( route( 'visual-editor.editor' ), false );
+} );

--- a/tests/Feature/SiteEditor/PatternControllerTest.php
+++ b/tests/Feature/SiteEditor/PatternControllerTest.php
@@ -180,6 +180,31 @@ describe( 'GET /visual-editor/api/patterns/{slug}', function (): void {
 
 		$this->getJson( '/visual-editor/api/patterns/missing' )->assertNotFound();
 	} );
+
+	// H7 (#432). The H6 adapter sets `id = wpId ?? slug`, and the
+	// editor's `addEntities` registers `wp_block` with `key: 'id'` —
+	// so after a user creates a DB-backed pattern the SPA fetches it
+	// at `/patterns/{numericId}`. The route matches `{slug}`; the
+	// controller resolves the numeric form by scanning for `wpId`.
+	it( 'resolves a pattern by its DB id (H6 adapter id field)', function (): void {
+		$pattern = BlockPattern::create( [
+			'slug'          => 'cta',
+			'title'         => 'CTA',
+			'source'        => 'user',
+			'synced'        => true,
+			'categories'    => [],
+			'block_types'   => [],
+			'block_content' => [],
+			'author_id'     => null,
+		] );
+
+		rebuildSiteEditorResolversForPatternTest();
+
+		$this->getJson( '/visual-editor/api/patterns/' . $pattern->id )
+			->assertOk()
+			->assertJsonPath( 'slug', 'user/cta' )
+			->assertJsonPath( 'id', $pattern->id );
+	} );
 } );
 
 describe( 'POST /visual-editor/api/patterns', function (): void {
@@ -256,6 +281,27 @@ describe( 'PUT /visual-editor/api/patterns/{slug}', function (): void {
 			'title' => 'Nope',
 		] )->assertNotFound();
 	} );
+
+	// H7 (#432). Same id-by-URL contract as the show endpoint.
+	it( 'updates by DB id (H6 adapter id field)', function (): void {
+		$pattern = BlockPattern::create( [
+			'slug'          => 'cta',
+			'title'         => 'CTA',
+			'source'        => 'user',
+			'synced'        => true,
+			'categories'    => [],
+			'block_types'   => [],
+			'block_content' => [],
+			'author_id'     => null,
+		] );
+
+		$this->putJson( '/visual-editor/api/patterns/' . $pattern->id, [
+			'title' => 'CTA Renamed',
+		] )
+			->assertOk()
+			->assertJsonPath( 'title.raw', 'CTA Renamed' )
+			->assertJsonPath( 'id', $pattern->id );
+	} );
 } );
 
 describe( 'DELETE /visual-editor/api/patterns/{slug}', function (): void {
@@ -295,5 +341,24 @@ describe( 'DELETE /visual-editor/api/patterns/{slug}', function (): void {
 
 	it( 'returns 404 when no pattern matches', function (): void {
 		$this->deleteJson( '/visual-editor/api/patterns/user/missing' )->assertNotFound();
+	} );
+
+	// H7 (#432). Same id-by-URL contract as show / update.
+	it( 'deletes by DB id (H6 adapter id field)', function (): void {
+		$pattern = BlockPattern::create( [
+			'slug'          => 'cta',
+			'title'         => 'CTA',
+			'source'        => 'user',
+			'synced'        => true,
+			'categories'    => [],
+			'block_types'   => [],
+			'block_content' => [],
+			'author_id'     => null,
+		] );
+
+		$this->deleteJson( '/visual-editor/api/patterns/' . $pattern->id )
+			->assertNoContent();
+
+		expect( BlockPattern::query()->whereKey( $pattern->id )->exists() )->toBeFalse();
 	} );
 } );

--- a/tests/Feature/SiteEditor/TemplateControllerTest.php
+++ b/tests/Feature/SiteEditor/TemplateControllerTest.php
@@ -106,6 +106,31 @@ describe( 'GET /visual-editor/api/templates/{slug}', function (): void {
 
 		$this->getJson( '/visual-editor/api/templates/missing' )->assertNotFound();
 	} );
+
+	// H7 (#432). The H6 adapter sets `id = wpId ?? slug`, so for
+	// DB-backed templates the SPA navigates by integer id. The route
+	// param is named `{slug}`; the controller dispatches on
+	// numeric-vs-non-numeric input and looks the row up by primary
+	// key in the numeric branch.
+	it( 'resolves a template by its DB id (H6 adapter id field)', function (): void {
+		$template = Template::create( [
+			'theme'         => 'digital-shopfront',
+			'slug'          => 'page',
+			'title'         => 'Page',
+			'description'   => 'Default page template.',
+			'status'        => 'publish',
+			'is_custom'     => false,
+			'block_content' => [],
+			'author_id'     => null,
+		] );
+
+		rebuildSiteEditorResolversForTest();
+
+		$this->getJson( '/visual-editor/api/templates/' . $template->id )
+			->assertOk()
+			->assertJsonPath( 'slug', 'page' )
+			->assertJsonPath( 'id', $template->id );
+	} );
 } );
 
 describe( 'POST /visual-editor/api/templates', function (): void {
@@ -211,6 +236,28 @@ describe( 'PUT /visual-editor/api/templates/{slug}', function (): void {
 		$this->putJson( '/visual-editor/api/templates/single', [ 'title' => 'No theme' ] )
 			->assertStatus( 422 );
 	} );
+
+	// H7 (#432). With a numeric URL parameter the controller resolves
+	// the template by primary key — the row already knows its theme,
+	// so the body's `theme` field becomes optional.
+	it( 'updates by DB id without requiring a theme in the body', function (): void {
+		$template = Template::create( [
+			'theme'         => 'digital-shopfront',
+			'slug'          => 'single',
+			'title'         => 'Single',
+			'status'        => 'publish',
+			'is_custom'     => false,
+			'block_content' => [],
+			'author_id'     => null,
+		] );
+
+		$this->putJson( '/visual-editor/api/templates/' . $template->id, [
+			'title' => 'Single Renamed',
+		] )
+			->assertOk()
+			->assertJsonPath( 'title.raw', 'Single Renamed' )
+			->assertJsonPath( 'id', $template->id );
+	} );
 } );
 
 describe( 'DELETE /visual-editor/api/templates/{slug}', function (): void {
@@ -263,5 +310,25 @@ describe( 'DELETE /visual-editor/api/templates/{slug}', function (): void {
 
 	it( 'returns 404 when no DB override matches the (theme, slug)', function (): void {
 		$this->deleteJson( '/visual-editor/api/templates/missing?theme=digital-shopfront' )->assertNotFound();
+	} );
+
+	// H7 (#432). Numeric URL parameter resolves the row by primary
+	// key — the row owns its theme, so `?theme=` is unnecessary in
+	// this branch.
+	it( 'deletes by DB id without requiring a theme query param', function (): void {
+		$template = Template::create( [
+			'theme'         => 'digital-shopfront',
+			'slug'          => 'archive',
+			'title'         => 'Archive',
+			'status'        => 'publish',
+			'is_custom'     => false,
+			'block_content' => [],
+			'author_id'     => null,
+		] );
+
+		$this->deleteJson( '/visual-editor/api/templates/' . $template->id )
+			->assertNoContent();
+
+		expect( Template::query()->whereKey( $template->id )->exists() )->toBeFalse();
 	} );
 } );

--- a/tests/Feature/SiteEditor/TemplatePartControllerTest.php
+++ b/tests/Feature/SiteEditor/TemplatePartControllerTest.php
@@ -95,6 +95,29 @@ describe( 'GET /visual-editor/api/template-parts/{slug}', function (): void {
 			->assertJsonPath( 'type', 'wp_template_part' );
 	} );
 
+	// H7 (#432). The H6 adapter sets `id = wpId ?? slug` and the
+	// editor's `addEntities` registers `wp_template_part` with
+	// `key: 'id'`, so the SPA fetches DB-backed parts by integer id.
+	it( 'resolves a template part by its DB id (H6 adapter id field)', function (): void {
+		$part = TemplatePart::create( [
+			'theme'         => 'digital-shopfront',
+			'slug'          => 'footer',
+			'title'         => 'Footer',
+			'area'          => 'footer',
+			'status'        => 'publish',
+			'is_custom'     => false,
+			'block_content' => [],
+			'author_id'     => null,
+		] );
+
+		rebuildSiteEditorResolversForPartTest();
+
+		$this->getJson( '/visual-editor/api/template-parts/' . $part->id )
+			->assertOk()
+			->assertJsonPath( 'slug', 'footer' )
+			->assertJsonPath( 'id', $part->id );
+	} );
+
 	it( 'returns 404 when the slug does not resolve', function (): void {
 		rebuildSiteEditorResolversForPartTest();
 
@@ -183,6 +206,29 @@ describe( 'PUT /visual-editor/api/template-parts/{slug}', function (): void {
 			->assertJsonValidationErrors( 'area' );
 	} );
 
+	// H7 (#432). Numeric URL parameter looks up by primary key — the
+	// row already knows its theme, so the body's `theme` becomes
+	// optional.
+	it( 'updates by DB id without requiring a theme in the body', function (): void {
+		$part = TemplatePart::create( [
+			'theme'         => 'digital-shopfront',
+			'slug'          => 'header',
+			'title'         => 'Header',
+			'area'          => 'header',
+			'status'        => 'publish',
+			'is_custom'     => false,
+			'block_content' => [],
+			'author_id'     => null,
+		] );
+
+		$this->putJson( '/visual-editor/api/template-parts/' . $part->id, [
+			'title' => 'Header Renamed',
+		] )
+			->assertOk()
+			->assertJsonPath( 'title.raw', 'Header Renamed' )
+			->assertJsonPath( 'id', $part->id );
+	} );
+
 	it( 'preserves existing block_content on a partial update that omits content.blocks', function (): void {
 		$existing = [ [ 'name' => 'core/site-title', 'attributes' => [], 'innerBlocks' => [] ] ];
 
@@ -268,5 +314,25 @@ describe( 'DELETE /visual-editor/api/template-parts/{slug}', function (): void {
 
 	it( 'returns 404 when no DB override matches the (theme, slug)', function (): void {
 		$this->deleteJson( '/visual-editor/api/template-parts/missing?theme=digital-shopfront' )->assertNotFound();
+	} );
+
+	// H7 (#432). Numeric URL parameter resolves by primary key; the
+	// `?theme=` query is unnecessary because the row owns its theme.
+	it( 'deletes by DB id without requiring a theme query param', function (): void {
+		$part = TemplatePart::create( [
+			'theme'         => 'digital-shopfront',
+			'slug'          => 'header',
+			'title'         => 'Header',
+			'area'          => 'header',
+			'status'        => 'publish',
+			'is_custom'     => false,
+			'block_content' => [],
+			'author_id'     => null,
+		] );
+
+		$this->deleteJson( '/visual-editor/api/template-parts/' . $part->id )
+			->assertNoContent();
+
+		expect( TemplatePart::query()->whereKey( $part->id )->exists() )->toBeFalse();
 	} );
 } );

--- a/tests/Feature/SiteEditorShellTest.php
+++ b/tests/Feature/SiteEditorShellTest.php
@@ -66,6 +66,30 @@ test('site-editor app composes the four shell regions', function () use ($appPat
     expect($contents)->toContain('inspectorToggleAriaLabel');
 });
 
+// H7 (#432). The styles, navigation, and patterns sections are loaded
+// via React.lazy so their chunks stay out of the initial site-editor
+// boot bundle. This test pins the lazy boundary at the source level —
+// a regression that statically imports any of those modules would
+// fold the chunk back into the main bundle.
+test('site-editor app lazy-loads the three heavy section orchestrators', function () use ($appPath) {
+    $contents = file_get_contents($appPath);
+
+    // Suspense boundary + the dynamic-import targets must all be
+    // present. Match on the import path alone, not the full
+    // `lazy(() => import(...))` literal — the navigation entry wraps
+    // across multiple lines because of its longer module path.
+    expect($contents)->toContain('Suspense');
+    expect($contents)->toContain("import('./styles/styles-section')");
+    expect($contents)->toContain("import('./navigation/navigation-section')");
+    expect($contents)->toContain("import('./patterns/patterns-section')");
+    expect($contents)->toMatch('/lazy\(\s*\(\)\s*=>\s*import\(/');
+    // The hooks must NOT be statically imported in the shell — the
+    // lazy default exports own their hook calls now.
+    expect($contents)->not->toContain('useStylesSectionViews');
+    expect($contents)->not->toContain('useNavigationSectionViews');
+    expect($contents)->not->toContain('usePatternsSectionViews');
+});
+
 test('section registry declares the five V1 site-editor sections', function () use ($sectionsPath) {
     $contents = file_get_contents($sectionsPath);
 


### PR DESCRIPTION
Closes #432.

## Summary

Layers two H7 deliverables on top of the H6 surface (#431):

1. **Server-side install gate** at \`/visual-editor/site/{path?}\` — renders \`install-gate.blade.php\` when cms-framework's SiteEditor module isn't booted, falls through to the SPA mount when it is. \`CmsFrameworkIntegration::isAvailable()\` centralizes the \`class_exists\` + container-binding probe (mirrors the per-controller checks the H6 controllers already do).
2. **Lazy-loaded section orchestrators** — styles, navigation, and patterns ship as \`React.lazy()\` chunks. Templates and template-parts stay eager because they share \`useEntityEditorViews\` with the post editor's already-warm bundle and they're the default landing path. The shell exposes navigator/canvas/inspector/overlay portal slots; each lazy section's default-export wrapper portals its hook results into the slots.

Plus a few bugs the H7 manual verification surfaced:

3. **SPA list consumers** (\`useEntityList\`, \`listPatterns\`, \`listNavigations\`, \`use-pattern-usage\`'s pagination loop) now read H6's flat-array response shape instead of the plan-11 \`{ data, meta }\` envelope. Each fetcher coerces non-array bodies to \`[]\` so a malformed response can't crash the navigator with \`items.length === undefined\`.
4. **Navigation API path** repointed from the legacy \`/visual-editor/api/navigation\` to H6's \`/visual-editor/api/menus\` (the shim's \`addEntities\` was already pointing there; the section client had drifted).
5. **Pattern / template / template-part controllers** now accept either a numeric DB id or a slug in the URL parameter. The H6 adapter sets \`id = wpId ?? slug\` and the editor's \`addEntities\` uses \`key: 'id'\`, so after a user creates a DB-backed entity the SPA navigates to e.g. \`/patterns/5\`. Without this, every show / update / delete on a DB-backed entity 404'd.

## Acceptance criteria — from #432

- [x] Plan 11 Phase D UI rescoped onto H6's \`/visual-editor/api/{entity}\` endpoints (data path was already there from H6; this PR cleans up the residual \`{ data, meta }\` consumers, the legacy \`/navigation\` path, and the id-vs-slug routing mismatch).
- [x] Site-editor entry-point checks \`class_exists\` on the cms-framework facade; renders an install-gate page when missing.
- [x] Entity-route loading: lazy on styles / navigation / patterns; eager on templates / template-parts. Decision recorded in plan 14 §4.5.2.

## Open questions resolved at H7 kickoff

- **Install-gate copy** (deferred from H6): see \`resources/views/site-editor/install-gate.blade.php\`.
- **Entity-route lazy-loading**: lazy on the three heavy sections; eager on the two default-landing sections that share \`useEntityEditorViews\` with the post editor.

## Tests

- **PHP**: 553 passing (1497 assertions). 9 new — \`InstallGateTest\` (3) + \`InstallGateActiveTest\` (2) + id-based show/update/destroy coverage in \`PatternControllerTest\`, \`TemplateControllerTest\`, \`TemplatePartControllerTest\` (1 each + a delete-by-id for patterns and templates).
- **JS**: 1009 passing (106 files). All section mocks updated for the new lazy default-export shape and the flat-array response. New assertion in \`SiteEditorShellTest\` pins the lazy boundary at the source level so a regression that statically imports a lazy section gets caught.
- **No new TypeScript errors** beyond the pre-existing \`@wordpress/*\` declaration-file noise.

## Manually verified

- Install gate renders when cms-framework provider is removed; SPA mounts when it's back.
- Three lazy sections each emit their own chunk — \`site-editor-app\`, \`styles-section\`, \`navigation-section\`, \`patterns-section\` are separate JS files in \`public/build/assets/\`.
- Created a user pattern end-to-end against the dev-app: list → create dialog → save → reload → entity opens via id-based URL.

## Known follow-ups

- **#436** — block-selection inspector reads from the wrong \`<BlockEditorProvider>\` scope. The \"Block\" tab of the right sidebar shows \"Click on a block to view its settings.\" even when a block is selected, because the inspector mounts as a sibling of the canvas (which owns the provider) rather than a descendant. Pre-existing structural issue from H6, surfaced during H7 manual testing. Plan 14 §4.5.2 always called out the block-selection inspector as a separate piece from H6's read-only document panels; the fix is a follow-up on its own ticket.
- **#434** — pre-existing follow-up to H6 for plan-11 Phase D model / service cleanup. Untouched by this PR; the legacy code is dead at the data path but still autoloads.

## Test plan

- [ ] Pull, run \`composer install\`, run \`./vendor/bin/pest\` and \`npm test\` — both should pass.
- [ ] In a host app without cms-framework: hit \`/visual-editor/site\`, see the install gate; \`composer require artisanpack-ui/cms-framework\`, reload, see the SPA.
- [ ] In a host app with cms-framework: navigate templates, template-parts, styles, navigation, patterns. The three lazy sections should fetch their chunks on first visit (visible in the network panel) and behave thereafter as before.
- [ ] Create a pattern. After save, the canvas opens at the new entity's id-based URL without a 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Install-gate page shown when cms-framework is unavailable
  - Sections (Styles/Navigation/Patterns) now lazy-load and render into stable portal slots
  - Patterns, templates, and template-parts endpoints accept numeric IDs or slugs

* **Bug Fixes**
  - API list endpoints now handle flat-array responses and tolerate non-array bodies
  - Navigation endpoints switched to new menu paths

* **Documentation**
  - Updated H0–H7 delivery status and implementation notes

* **Tests**
  - Added install-gate and numeric-ID endpoint coverage; updated mocks/tests for new API shape
<!-- end of auto-generated comment: release notes by coderabbit.ai -->