### PR TITLE
feat: host-embed knobs and light-mode editor lock

### DIFF
--- a/resources/js/visual-editor/editor/document-panels.tsx
+++ b/resources/js/visual-editor/editor/document-panels.tsx
@@ -57,6 +57,21 @@ export interface AuthorOption {
 }
 
 export interface DocumentSupports {
+    /**
+     * Render the post-title block at the top of the canvas. Default `true`.
+     *
+     * Host apps that surface the title in their own form above the editor
+     * (so it isn't duplicated inside the canvas) should set this to `false`.
+     */
+    title?: boolean;
+    /**
+     * Render the Document tab in the inspector sidebar. Default `true`.
+     *
+     * Host apps that surface post meta (title/slug/status/excerpt/featured
+     * image/etc.) in their own form above the editor should set this to
+     * `false` — the inspector then collapses to a single "Block" pane.
+     */
+    document?: boolean;
     /** Show the Excerpt panel. Default `true`. */
     excerpt?: boolean;
     /** Show the Featured Image panel. Default `true`. */

--- a/resources/js/visual-editor/editor/editor-app.css
+++ b/resources/js/visual-editor/editor/editor-app.css
@@ -10,6 +10,30 @@
  */
 
 .ap-visual-editor__shell {
+    /*
+     * The editor is a self-contained light-mode surface — both the
+     * chrome (top bar + sidebars) and the canvas always render in
+     * light mode regardless of the host admin's theme. WP component
+     * primitives (`@wordpress/components`) hardcode light-mode
+     * foreground colors that we can't easily flip per WP minor
+     * release, so coexisting with a dark host means the editor
+     * stays light. Hosts that want a dark editor can override
+     * `--ap-visual-editor-shell-*` and the `--color-base-*` tokens
+     * scoped below in tandem.
+     */
+    color-scheme: light;
+
+    /*
+     * Token reset: force DaisyUI / Tailwind theme variables to
+     * light-mode values within the editor shell so block CSS that
+     * reads `--color-base-content`, etc., doesn't pick up dark
+     * values from `html[data-theme="dark"]` on the host.
+     */
+    --color-base-100: #ffffff;
+    --color-base-200: #f3f4f6;
+    --color-base-300: #e5e7eb;
+    --color-base-content: #1f2937;
+
     --ap-visual-editor-shell-background: var(--color-base-200, #f9fafb);
     --ap-visual-editor-shell-foreground: var(--color-base-content, #1f2937);
     --ap-visual-editor-shell-border: var(--color-base-300, #e5e7eb);
@@ -56,6 +80,21 @@
     min-width: 0;
     min-height: 0;
     overflow-y: auto;
+}
+
+/*
+ * Canvas surface renders against the front-end theme's background so
+ * authoring matches the rendered page. The shell scope already forces
+ * light-mode tokens; this rule just pins the canvas surface to white
+ * (separate from the `--color-base-200` shell background that surrounds
+ * the canvas). Hosts can override `--ap-editor-canvas-bg` /
+ * `--ap-editor-canvas-fg` per theme — once the theme.json reader lands
+ * it'll supply these from `settings.color.background`.
+ */
+.ap-visual-editor__canvas.editor-styles-wrapper,
+.editor-styles-wrapper.ap-visual-editor__canvas {
+    background-color: var(--ap-editor-canvas-bg, #ffffff);
+    color: var(--ap-editor-canvas-fg, #1f2937);
 }
 
 .ap-visual-editor__sidebar {

--- a/resources/js/visual-editor/editor/editor-app.tsx
+++ b/resources/js/visual-editor/editor/editor-app.tsx
@@ -219,6 +219,110 @@ const DEFAULT_FONT_SIZES = [
     { name: __('Huge', TEXT_DOMAIN), slug: 'huge', size: '36px' },
 ];
 
+/**
+ * Default canvas stylesheet. Injected via `settings.styles` so blocks have
+ * a sensible typographic baseline before a theme.json kicks in. Themes
+ * override these by emitting `styles.typography` / `styles.elements.*`
+ * blocks in theme.json — the theme's stylesheet ships later in the
+ * `styles` array and wins on cascade.
+ *
+ * Scoped under `.editor-styles-wrapper` because Gutenberg auto-prepends
+ * that selector to every style entry it isn't already scoped to,
+ * keeping these rules out of the editor chrome.
+ */
+const DEFAULT_CANVAS_STYLES = `
+.editor-styles-wrapper {
+    font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    font-size: 16px;
+    line-height: 1.6;
+    color: #1f2937;
+}
+
+.editor-styles-wrapper .block-editor-block-list__layout {
+    max-width: 720px;
+    margin-left: auto;
+    margin-right: auto;
+    padding: 48px 24px 96px;
+}
+
+.editor-styles-wrapper .wp-block[data-align="wide"] {
+    max-width: 1080px;
+    margin-left: auto;
+    margin-right: auto;
+}
+
+.editor-styles-wrapper .wp-block[data-align="full"] {
+    max-width: none;
+}
+
+.editor-styles-wrapper p {
+    margin: 0 0 1em;
+    font-size: 1rem;
+    line-height: 1.6;
+}
+
+.editor-styles-wrapper h1,
+.editor-styles-wrapper h2,
+.editor-styles-wrapper h3,
+.editor-styles-wrapper h4,
+.editor-styles-wrapper h5,
+.editor-styles-wrapper h6 {
+    font-family: inherit;
+    font-weight: 700;
+    line-height: 1.2;
+    margin: 1.4em 0 0.6em;
+    color: #111827;
+}
+
+.editor-styles-wrapper h1 { font-size: 2.5rem; }
+.editor-styles-wrapper h2 { font-size: 2rem; }
+.editor-styles-wrapper h3 { font-size: 1.5rem; }
+.editor-styles-wrapper h4 { font-size: 1.25rem; }
+.editor-styles-wrapper h5 { font-size: 1.125rem; }
+.editor-styles-wrapper h6 { font-size: 1rem; text-transform: uppercase; letter-spacing: 0.05em; }
+
+.editor-styles-wrapper a {
+    color: #2563eb;
+    text-decoration: underline;
+}
+
+.editor-styles-wrapper blockquote {
+    border-left: 4px solid #e5e7eb;
+    margin: 1.5em 0;
+    padding: 0 0 0 1em;
+    font-style: italic;
+    color: #4b5563;
+}
+
+.editor-styles-wrapper ul,
+.editor-styles-wrapper ol {
+    margin: 0 0 1em;
+    padding-left: 1.5em;
+}
+
+.editor-styles-wrapper code {
+    font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+    font-size: 0.9em;
+    background: #f3f4f6;
+    padding: 0.1em 0.35em;
+    border-radius: 4px;
+}
+
+.editor-styles-wrapper pre {
+    background: #f3f4f6;
+    padding: 1em;
+    border-radius: 6px;
+    overflow-x: auto;
+    margin: 0 0 1em;
+}
+
+.editor-styles-wrapper hr {
+    border: 0;
+    border-top: 1px solid #e5e7eb;
+    margin: 2em 0;
+}
+`;
+
 const DEFAULT_FONT_FAMILIES = [
     {
         name: __('System', TEXT_DOMAIN),
@@ -255,16 +359,28 @@ const DEFAULT_FONT_FAMILIES = [
 const editorSettings = {
     mediaUpload: mediaUploadSetting,
     alignWide: true,
+    /*
+     * Default canvas stylesheet (`{ css }`) gives blocks a typographic
+     * baseline so headings/paragraphs/links visually differentiate
+     * without a theme.json. Themes ship their own `{ css, baseURL }`
+     * entries via the theme.json bridge (planned) — they're appended to
+     * this array and win on cascade.
+     */
+    styles: [{ css: DEFAULT_CANVAS_STYLES }],
     // Top-level legacy keys are still read by some core blocks that
     // haven't migrated to `__experimentalFeatures`.
     colors: DEFAULT_PALETTE,
     fontSizes: DEFAULT_FONT_SIZES,
     // Minimal `__experimentalFeatures` — only the keys needed for the
     // Typography panel's font-family picker and the text-alignment
-    // toolbar. Turning on more keys (border, spacing, layout, duotone,
-    // default palettes) re-introduces the color-picker drag loop we're
-    // hunting; keep this config narrow until the upstream fix lands.
+    // toolbar. Turning on more keys (border, spacing, duotone, default
+    // palettes) re-introduces the color-picker drag loop we're hunting;
+    // keep this config narrow until the upstream fix lands.
     __experimentalFeatures: {
+        layout: {
+            contentSize: '720px',
+            wideSize: '1080px',
+        },
         color: {
             custom: true,
             text: true,
@@ -965,7 +1081,18 @@ function EditorAppShell(props: EditorAppProps): JSX.Element {
                 </div>
             ) : null}
             <div className="editor-styles-wrapper ap-visual-editor__canvas">
-                <PostTitle value={title} onChange={handleTitleChange} />
+                {/*
+                 * Default canvas stylesheet rendered inline. Gutenberg's
+                 * `settings.styles` channel only injects into the
+                 * `<Iframe>` canvas; our editor renders the block list
+                 * in the same DOM tree, so we inline the rules here.
+                 * Themes that ship a theme.json get their stylesheet
+                 * appended after this `<style>` and win on cascade.
+                 */}
+                <style>{DEFAULT_CANVAS_STYLES}</style>
+                {supports?.title !== false && (
+                    <PostTitle value={title} onChange={handleTitleChange} />
+                )}
                 <BlockTools>
                     <WritingFlow>
                         <ObserveTyping>
@@ -997,7 +1124,10 @@ function EditorAppShell(props: EditorAppProps): JSX.Element {
                     className="ap-visual-editor__sidebar ap-visual-editor__sidebar--inspector"
                     data-testid="ap-visual-editor-inspector-panel"
                 >
-                    <InspectorSidebar documentContent={documentPanels} />
+                    <InspectorSidebar
+                        documentContent={documentPanels}
+                        showDocumentTab={supports?.document !== false}
+                    />
                 </div>
             ) : null}
         </BlockEditorProvider>

--- a/resources/js/visual-editor/editor/inspector-sidebar.tsx
+++ b/resources/js/visual-editor/editor/inspector-sidebar.tsx
@@ -48,6 +48,12 @@ export type InspectorTab = 'block' | 'document';
 export interface InspectorSidebarProps {
     documentContent: ReactNode;
     /**
+     * Render the Document tab. When `false`, the tablist is suppressed and
+     * the inspector is a single-pane Block view — used when the host app
+     * surfaces post meta in its own form outside the editor.
+     */
+    showDocumentTab?: boolean;
+    /**
      * Override for the `@wordpress/data` selection lookup. Tests pass a
      * synchronous value so they don't need to stand up a block-editor
      * store; production code always omits this so the sidebar reflects
@@ -57,7 +63,11 @@ export interface InspectorSidebarProps {
 }
 
 export function InspectorSidebar(props: InspectorSidebarProps): JSX.Element {
-    const { documentContent, hasSelectedBlockOverride } = props;
+    const {
+        documentContent,
+        hasSelectedBlockOverride,
+        showDocumentTab = true,
+    } = props;
 
     const liveHasSelectedBlock = useSelect(
         (select) => {
@@ -84,7 +94,7 @@ export function InspectorSidebar(props: InspectorSidebarProps): JSX.Element {
     // selected (which is rare but possible when the host reopens a
     // previously-focused canvas).
     const [activeTab, setActiveTab] = useState<InspectorTab>(
-        hasSelectedBlock ? 'block' : 'document'
+        !showDocumentTab || hasSelectedBlock ? 'block' : 'document'
     );
 
     const blockTabId = useId();
@@ -175,42 +185,44 @@ export function InspectorSidebar(props: InspectorSidebarProps): JSX.Element {
             data-testid="ap-visual-editor-inspector-sidebar"
             data-active-tab={activeTab}
         >
-            <div
-                className="ap-visual-editor-inspector-sidebar__tablist"
-                role="tablist"
-                aria-label={__('Inspector tabs', TEXT_DOMAIN)}
-            >
-                <button
-                    ref={blockTabRef}
-                    type="button"
-                    role="tab"
-                    id={blockTabId}
-                    className="ap-visual-editor-inspector-sidebar__tab"
-                    aria-selected={activeTab === 'block'}
-                    aria-controls={blockPanelId}
-                    tabIndex={activeTab === 'block' ? 0 : -1}
-                    data-testid="ap-visual-editor-inspector-tab-block"
-                    onClick={() => handleSelectTab('block')}
-                    onKeyDown={handleTabKey}
+            {showDocumentTab && (
+                <div
+                    className="ap-visual-editor-inspector-sidebar__tablist"
+                    role="tablist"
+                    aria-label={__('Inspector tabs', TEXT_DOMAIN)}
                 >
-                    {__('Block', TEXT_DOMAIN)}
-                </button>
-                <button
-                    ref={documentTabRef}
-                    type="button"
-                    role="tab"
-                    id={documentTabId}
-                    className="ap-visual-editor-inspector-sidebar__tab"
-                    aria-selected={activeTab === 'document'}
-                    aria-controls={documentPanelId}
-                    tabIndex={activeTab === 'document' ? 0 : -1}
-                    data-testid="ap-visual-editor-inspector-tab-document"
-                    onClick={() => handleSelectTab('document')}
-                    onKeyDown={handleTabKey}
-                >
-                    {__('Document', TEXT_DOMAIN)}
-                </button>
-            </div>
+                    <button
+                        ref={blockTabRef}
+                        type="button"
+                        role="tab"
+                        id={blockTabId}
+                        className="ap-visual-editor-inspector-sidebar__tab"
+                        aria-selected={activeTab === 'block'}
+                        aria-controls={blockPanelId}
+                        tabIndex={activeTab === 'block' ? 0 : -1}
+                        data-testid="ap-visual-editor-inspector-tab-block"
+                        onClick={() => handleSelectTab('block')}
+                        onKeyDown={handleTabKey}
+                    >
+                        {__('Block', TEXT_DOMAIN)}
+                    </button>
+                    <button
+                        ref={documentTabRef}
+                        type="button"
+                        role="tab"
+                        id={documentTabId}
+                        className="ap-visual-editor-inspector-sidebar__tab"
+                        aria-selected={activeTab === 'document'}
+                        aria-controls={documentPanelId}
+                        tabIndex={activeTab === 'document' ? 0 : -1}
+                        data-testid="ap-visual-editor-inspector-tab-document"
+                        onClick={() => handleSelectTab('document')}
+                        onKeyDown={handleTabKey}
+                    >
+                        {__('Document', TEXT_DOMAIN)}
+                    </button>
+                </div>
+            )}
             {/*
              * Both tabpanels stay mounted so inner state survives tab
              * switches — `PanelBody` open/closed state, `TextareaControl`
@@ -242,16 +254,18 @@ export function InspectorSidebar(props: InspectorSidebarProps): JSX.Element {
                     </p>
                 )}
             </div>
-            <div
-                role="tabpanel"
-                id={documentPanelId}
-                aria-labelledby={documentTabId}
-                className="ap-visual-editor-inspector-sidebar__panel"
-                data-testid="ap-visual-editor-inspector-document-panel"
-                hidden={activeTab !== 'document'}
-            >
-                {documentContent}
-            </div>
+            {showDocumentTab && (
+                <div
+                    role="tabpanel"
+                    id={documentPanelId}
+                    aria-labelledby={documentTabId}
+                    className="ap-visual-editor-inspector-sidebar__panel"
+                    data-testid="ap-visual-editor-inspector-document-panel"
+                    hidden={activeTab !== 'document'}
+                >
+                    {documentContent}
+                </div>
+            )}
         </aside>
     );
 }

--- a/resources/js/visual-editor/editor/inspector-sidebar.tsx
+++ b/resources/js/visual-editor/editor/inspector-sidebar.tsx
@@ -125,12 +125,24 @@ export function InspectorSidebar(props: InspectorSidebarProps): JSX.Element {
         }
     }, [hasSelectedBlock]);
 
+    // Belt-and-suspenders: if a host flips `showDocumentTab` off while
+    // the Document panel is active, snap back to Block so we never leave
+    // the inspector stuck in a hidden tab with no tablist to recover
+    // from. The `activeTab` initializer already covers the mount case;
+    // this guards against runtime prop changes.
+    useEffect(() => {
+        if (!showDocumentTab && activeTab === 'document') {
+            setActiveTab('block');
+        }
+    }, [showDocumentTab, activeTab]);
+
     // Move focus to the active tab on first render so keyboard users who
     // just toggled the sidebar open land somewhere useful. Skip on
     // subsequent re-renders so typing inside a document control doesn't
-    // steal focus back to the tablist.
+    // steal focus back to the tablist. Also skip when there's no tablist
+    // to focus (single-pane mode via `showDocumentTab={false}`).
     useEffect(() => {
-        if (initialFocusRan.current) {
+        if (initialFocusRan.current || !showDocumentTab) {
             return;
         }
 
@@ -140,7 +152,7 @@ export function InspectorSidebar(props: InspectorSidebarProps): JSX.Element {
             activeTab === 'block' ? blockTabRef.current : documentTabRef.current;
 
         target?.focus({ preventScroll: true });
-    }, [activeTab]);
+    }, [activeTab, showDocumentTab]);
 
     const handleSelectTab = useCallback((tab: InspectorTab): void => {
         setActiveTab(tab);
@@ -233,12 +245,16 @@ export function InspectorSidebar(props: InspectorSidebarProps): JSX.Element {
              * readers and sighted users still see only the active one.
              */}
             <div
-                role="tabpanel"
-                id={blockPanelId}
-                aria-labelledby={blockTabId}
+                {...(showDocumentTab
+                    ? {
+                          role: 'tabpanel',
+                          id: blockPanelId,
+                          'aria-labelledby': blockTabId,
+                          hidden: activeTab !== 'block',
+                      }
+                    : { role: 'region', 'aria-label': __('Block', TEXT_DOMAIN) })}
                 className="ap-visual-editor-inspector-sidebar__panel"
                 data-testid="ap-visual-editor-inspector-block-panel"
-                hidden={activeTab !== 'block'}
             >
                 {hasSelectedBlock ? (
                     <BlockInspector />

--- a/resources/js/visual-editor/editor/visual-editor-theme.css
+++ b/resources/js/visual-editor/editor/visual-editor-theme.css
@@ -75,10 +75,11 @@
     --wp-admin-theme-color: var(--color-primary, #2563eb);
 
     /*
-     * Canvas typography inherits from `.ap-visual-editor__canvas` so the
-     * host app's dark-mode tokens (DaisyUI `--color-base-content`,
-     * Tailwind's text-base, etc.) can't bleed in — the canvas is always a
-     * light-mode surface regardless of admin chrome theme.
+     * Canvas typography reads the canvas-specific `--ap-editor-canvas-fg`
+     * token so host dark-mode tokens (DaisyUI `--color-base-content`,
+     * Tailwind's text-base, etc.) can't bleed in — the canvas is always
+     * a light-mode surface regardless of admin chrome theme. Hosts (or
+     * the theme.json bridge) can override the token per surface.
      */
-    color: inherit;
+    color: var(--ap-editor-canvas-fg, #1f2937);
 }

--- a/resources/js/visual-editor/editor/visual-editor-theme.css
+++ b/resources/js/visual-editor/editor/visual-editor-theme.css
@@ -74,5 +74,11 @@
 .ap-visual-editor__shell .editor-styles-wrapper {
     --wp-admin-theme-color: var(--color-primary, #2563eb);
 
-    color: var(--color-base-content, #1f2937);
+    /*
+     * Canvas typography inherits from `.ap-visual-editor__canvas` so the
+     * host app's dark-mode tokens (DaisyUI `--color-base-content`,
+     * Tailwind's text-base, etc.) can't bleed in — the canvas is always a
+     * light-mode surface regardless of admin chrome theme.
+     */
+    color: inherit;
 }


### PR DESCRIPTION
## Summary

Improvements that let host apps embed the editor as a sub-region of their own admin (vs. the full-page WP-style canvas), driven by integration work in Keystone CMS.

- **`supports.title`** and **`supports.document`** flags. When `false`, the in-canvas post-title and the inspector's Document tab are suppressed so hosts can surface those fields in their own form.
- **Light-mode editor lock.** The editor shell now sets `color-scheme: light` and resets the DaisyUI / Tailwind `--color-base-*` tokens within its scope, so a dark-mode host theme can no longer bleed into the editor chrome or canvas. `@wordpress/components` stays readable in any host theme — picking dark-mode chrome would require chasing every WP component token per release, which the editor isn't ready for yet.
- **Canvas surface pinned** to `var(--ap-editor-canvas-bg, #fff)` with light text, decoupled from the chrome's `--color-base-200` surround. Hosts can override the variable per theme; the future theme.json bridge will set it from `settings.color.background`.
- **Default canvas stylesheet.** System font, 16px/1.6 body, scaled h1–h6, link/blockquote/code styling, content width 720px (wide 1080px). Inlined as a `<style>` block inside the canvas div (Gutenberg's `settings.styles` only fires inside an `<Iframe>` wrapper, which this editor doesn't use). Themes that ship later via the theme.json bridge append after this entry and win on cascade.

## Changes

- `document-panels.tsx` — add `title?` and `document?` knobs to `DocumentSupports`.
- `inspector-sidebar.tsx` — `showDocumentTab` prop; when `false` the tablist disappears and the inspector is single-pane Block.
- `editor-app.tsx` — thread the new `supports` through, gate `<PostTitle>`, inline the default canvas stylesheet, add `__experimentalFeatures.layout = { contentSize, wideSize }`.
- `editor-app.css` — `color-scheme: light` on the shell, token reset, canvas surface variables.
- `visual-editor-theme.css` — canvas color inherits from the shell-scoped variables instead of reading `--color-base-content` directly.

## Testing

- `npm test` — all 1009 unit tests pass (1 pre-existing skip).
- Manually verified in Keystone CMS:
  - Canvas renders white with dark text even in `data-theme="dark"` host.
  - In-canvas title hides when `supports={{ title: false }}`.
  - Inspector collapses to single-pane Block when `supports={{ document: false }}`.
  - h1–h6 visually differentiate; paragraphs and lists have readable spacing.
  - Block list centered at 720px content width; wide-align breaks out to 1080px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added options to disable the post-title block and the Document tab for a block-only editor experience.
  * Sidebar can run in single-pane mode (Document tab hidden) with focus and tab behavior adjusted.

* **Style**
  * Editor shell now renders in light mode regardless of host theme.
  * Canvas styling pinned to consistent background/foreground tokens and includes a default canvas stylesheet to match front-end appearance.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArtisanPack-UI/visual-editor/pull/442)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->