### PR TITLE
feat(site-editor): policy-contract install gate, deny by default

### DIFF
--- a/docs/site-editor-access-gate.md
+++ b/docs/site-editor-access-gate.md
@@ -1,0 +1,147 @@
+---
+title: Site Editor Access Gate
+---
+
+# Site Editor Access Gate
+
+The site-editor SPA at `/visual-editor/site/{path?}` is the package's most
+sensitive surface — it exposes templates, patterns, global styles, menus
+and template parts for the whole site. **The package does not assume it
+knows who should reach it.** Each consuming application decides.
+
+This document describes the contract a consumer implements to control
+that access, and the gates the package ships out of the box.
+
+## The contract
+
+```php
+namespace ArtisanPackUI\VisualEditor\SiteEditor\Gates;
+
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+interface SiteEditorAccessGate
+{
+    public function check( Request $request ): ?Response;
+}
+```
+
+- Return `null` to **allow** the request — the route renders the SPA
+  mount view.
+- Return a `Response` to **short-circuit** the request — the route
+  returns that response verbatim. This is the hook for install-gate
+  pages, login redirects, 403 / 503 templates, or anything else the
+  consumer wants to show in place of the editor.
+
+The package resolves whatever is bound to `SiteEditorAccessGate::class`
+from the container on each request to the site-editor route. To change
+the behaviour, bind your own implementation in a service provider.
+
+## Package default — fail closed
+
+If a consuming app does not bind a gate, the package binds
+`DenyByDefaultGate` automatically. That gate returns a 503 view on every
+request explaining the editor has not been configured. **A fresh
+install cannot expose the site editor by accident.**
+
+## Bundled `CmsFrameworkInstallGate`
+
+For the historical behaviour — allow when cms-framework's SiteEditor
+module is booted, render the install-instructions page otherwise — bind
+the bundled gate directly:
+
+```php
+// AppServiceProvider::register()
+use ArtisanPackUI\VisualEditor\SiteEditor\Gates\CmsFrameworkInstallGate;
+use ArtisanPackUI\VisualEditor\SiteEditor\Gates\SiteEditorAccessGate;
+
+$this->app->bind( SiteEditorAccessGate::class, CmsFrameworkInstallGate::class );
+```
+
+This is the right choice for dev / demo apps where any authenticated
+visitor should reach the editor as long as cms-framework is installed.
+
+## Composing your own gate
+
+Production CMS hosts almost always want at least two checks: an
+authorisation check (is this user an admin?) and an install check (is
+cms-framework actually on the classpath?). The recommended pattern is
+to wrap `CmsFrameworkInstallGate` and run it before your auth check, so
+an unauthorised visitor still sees the install instructions in a
+half-installed state rather than a 403 that leaks deployment state.
+
+```php
+namespace App\SiteEditor;
+
+use ArtisanPackUI\VisualEditor\SiteEditor\Gates\CmsFrameworkInstallGate;
+use ArtisanPackUI\VisualEditor\SiteEditor\Gates\SiteEditorAccessGate;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class MyAppSiteEditorGate implements SiteEditorAccessGate
+{
+    public function __construct(
+        protected CmsFrameworkInstallGate $installGate,
+    ) {}
+
+    public function check( Request $request ): ?Response
+    {
+        if ( $denial = $this->installGate->check( $request ) ) {
+            return $denial;
+        }
+
+        $user = $request->user();
+
+        if ( ! $user ) {
+            return redirect()->route( 'login' );
+        }
+
+        if ( ! $user->hasRole( 'admin' ) ) {
+            return response()->view( 'errors.403', status: Response::HTTP_FORBIDDEN );
+        }
+
+        return null;
+    }
+}
+```
+
+Bind it the same way:
+
+```php
+// AppServiceProvider::register()
+$this->app->bind( SiteEditorAccessGate::class, MyAppSiteEditorGate::class );
+```
+
+## Contract guarantees
+
+- The gate is resolved per-request, so it can depend on request-scoped
+  state (the authenticated user, the route, the session).
+- The gate runs inside the `web` middleware group, so session, CSRF
+  and auth state are available on the `Request`.
+- The package binds its default with `bindIf`, so a consumer-supplied
+  binding registered earlier in the boot order always wins.
+- Implementations **must not throw on the unauthenticated /
+  unauthorised path** — return a `Response` instead so the user sees a
+  useful page rather than a generic framework error.
+
+## Testing a custom gate
+
+Bind a stub in the test's `beforeEach` and assert the route's
+behaviour:
+
+```php
+beforeEach( function (): void {
+    $this->app->bind( SiteEditorAccessGate::class, function () {
+        return new class implements SiteEditorAccessGate
+        {
+            public function check( Request $request ): ?Response
+            {
+                return null; // allow
+            }
+        };
+    } );
+} );
+```
+
+See `tests/Feature/SiteEditor/SiteEditorAccessGateTest.php` for the
+full contract test set.

--- a/resources/js/visual-editor/editor/main.tsx
+++ b/resources/js/visual-editor/editor/main.tsx
@@ -454,6 +454,41 @@ export function bootVisualEditor(
     return Promise.all(Array.from(elements).map((element) => mount(element)));
 }
 
+// Expose the boot function on `window` so SPA hosts (Inertia, Livewire, etc.)
+// can call it after client-side navigation introduces new
+// `[data-ap-visual-editor]` markers. `mountEditor` already de-dupes via a
+// per-element symbol, so calling this on already-mounted markers is a no-op.
+//
+// `window.ApVisualEditor` mirrors the named ESM exports for hosts that
+// load this bundle as `<script type="module" src="…">` rather than
+// importing it. The bridge state lives in `media-bridge/state.ts` inside
+// this same module scope, so calls through the global flow into the same
+// registry as direct imports.
+import {
+    registerArtisanpackMediaBridge as registerArtisanpackMediaBridgeImpl,
+    registerMediaBridge as registerMediaBridgeImpl,
+} from '../media-bridge';
+
+declare global {
+    interface Window {
+        ApVisualEditorBoot?: (scope?: ParentNode) => Promise<void[]>;
+        ApVisualEditor?: {
+            boot: typeof bootVisualEditor;
+            registerArtisanpackMediaBridge: typeof registerArtisanpackMediaBridgeImpl;
+            registerMediaBridge: typeof registerMediaBridgeImpl;
+        };
+    }
+}
+
+if (typeof window !== 'undefined') {
+    window.ApVisualEditorBoot = bootVisualEditor;
+    window.ApVisualEditor = {
+        boot: bootVisualEditor,
+        registerArtisanpackMediaBridge: registerArtisanpackMediaBridgeImpl,
+        registerMediaBridge: registerMediaBridgeImpl,
+    };
+}
+
 if (typeof document !== 'undefined') {
     if (document.readyState === 'loading') {
         document.addEventListener('DOMContentLoaded', () => {

--- a/resources/views/site-editor/deny-by-default.blade.php
+++ b/resources/views/site-editor/deny-by-default.blade.php
@@ -1,0 +1,134 @@
+{{-- H7 (#432) deny-by-default gate page.
+
+	Rendered by {@see DenyByDefaultGate}, the package-default binding
+	for `SiteEditorAccessGate`. Reached when a consuming app has
+	installed the visual-editor package but has not yet bound an
+	access gate of its own — the package fails closed so the editor
+	cannot be exposed by accident.
+
+	Inline styles are deliberate: the SPA's CSS chunks aren't loaded
+	on this page (the gate is the alternative to mounting the SPA),
+	so the page must stand on its own without Vite's site-editor
+	bundle. --}}
+<!DOCTYPE html>
+<html lang="{{ str_replace( '_', '-', app()->getLocale() ) }}">
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title>{{ __( 'Site editor not configured — ArtisanPack Visual Editor' ) }}</title>
+	<style>
+		:root {
+			color-scheme: light dark;
+		}
+
+		body {
+			margin: 0;
+			min-height: 100vh;
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			padding: 2rem;
+			background: #f5f5f7;
+			color: #1d1d1f;
+			font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+			line-height: 1.5;
+		}
+
+		.ap-deny-gate {
+			max-width: 36rem;
+			background: #fff;
+			border-radius: 0.75rem;
+			padding: 2.5rem;
+			box-shadow: 0 1px 2px rgba( 0, 0, 0, 0.05 ), 0 8px 24px rgba( 0, 0, 0, 0.08 );
+		}
+
+		.ap-deny-gate__eyebrow {
+			text-transform: uppercase;
+			letter-spacing: 0.08em;
+			font-size: 0.75rem;
+			font-weight: 600;
+			color: #86868b;
+			margin: 0 0 0.75rem;
+		}
+
+		.ap-deny-gate__title {
+			margin: 0 0 1rem;
+			font-size: 1.625rem;
+			font-weight: 700;
+			color: #1d1d1f;
+		}
+
+		.ap-deny-gate__lede {
+			margin: 0 0 1.25rem;
+			font-size: 1rem;
+			color: #1d1d1f;
+		}
+
+		.ap-deny-gate__lede code {
+			font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+			background: #f5f5f7;
+			border-radius: 0.25rem;
+			padding: 0.1rem 0.35rem;
+			font-size: 0.95em;
+		}
+
+		.ap-deny-gate__footer {
+			margin: 0;
+			font-size: 0.875rem;
+			color: #6e6e73;
+		}
+
+		.ap-deny-gate__footer code {
+			font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+			background: #f5f5f7;
+			border-radius: 0.25rem;
+			padding: 0.1rem 0.35rem;
+			font-size: 0.95em;
+		}
+
+		@media ( prefers-color-scheme: dark ) {
+			body {
+				background: #1d1d1f;
+				color: #f5f5f7;
+			}
+
+			.ap-deny-gate {
+				background: #2c2c2e;
+				box-shadow: 0 1px 2px rgba( 0, 0, 0, 0.4 ), 0 8px 24px rgba( 0, 0, 0, 0.6 );
+			}
+
+			.ap-deny-gate__title {
+				color: #f5f5f7;
+			}
+
+			.ap-deny-gate__lede {
+				color: #e5e5e7;
+			}
+
+			.ap-deny-gate__lede code,
+			.ap-deny-gate__footer code {
+				background: #1d1d1f;
+				color: #f5f5f7;
+			}
+
+			.ap-deny-gate__footer {
+				color: #a1a1a6;
+			}
+		}
+	</style>
+</head>
+<body>
+	<main class="ap-deny-gate" role="main" data-testid="ap-deny-gate">
+		<p class="ap-deny-gate__eyebrow">{{ __( 'Visual Editor' ) }}</p>
+		<h1 class="ap-deny-gate__title">
+			{{ __( 'Site editor access has not been configured' ) }}
+		</h1>
+		<p class="ap-deny-gate__lede">
+			{!! __( 'This application has not bound an access gate for the visual-editor site editor. The package ships with a fail-closed default so the editor cannot be exposed by accident.' ) !!}
+		</p>
+		<p class="ap-deny-gate__footer">
+			{!! __( 'Application developers: bind an implementation of :contract in your service provider. See the access-gate docs that ship with the package for details.', [ 'contract' => '<code>ArtisanPackUI\\VisualEditor\\SiteEditor\\Gates\\SiteEditorAccessGate</code>' ] ) !!}
+		</p>
+	</main>
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,7 +2,8 @@
 
 declare(strict_types=1);
 
-use ArtisanPackUI\VisualEditor\SiteEditor\CmsFrameworkIntegration;
+use ArtisanPackUI\VisualEditor\SiteEditor\Gates\SiteEditorAccessGate;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/editor', function () {
@@ -31,18 +32,16 @@ Route::get('/ve-sandbox', function () {
 // any session cookie — which makes the first REST mutation (CREATE,
 // PUT) fail with "CSRF token mismatch" (D2 #369).
 //
-// H7 (#432). The closure short-circuits to an install-gate view when
-// cms-framework's SiteEditor module is not booted. Without the gate the
-// SPA would mount and then receive a cascade of 404s from every H6
-// controller — a bad first-run experience that the gate replaces with a
-// single `composer require artisanpack-ui/cms-framework` instruction.
+// H7 (#432). Access is decided by the bound `SiteEditorAccessGate`.
+// The package default fails closed (see `DenyByDefaultGate`); consumers
+// override the binding with `CmsFrameworkInstallGate` or their own
+// implementation that composes role / auth checks with the install
+// probe. See `docs/site-editor-access-gate.md`.
 Route::middleware('web')
     ->group(function (): void {
-        Route::get('/visual-editor/site/{path?}', function () {
-            if (! CmsFrameworkIntegration::isAvailable()) {
-                return response()->view('visual-editor::site-editor.install-gate', [
-                    'postEditorUrl' => route('visual-editor.editor'),
-                ]);
+        Route::get('/visual-editor/site/{path?}', function (Request $request, SiteEditorAccessGate $gate) {
+            if ($denial = $gate->check($request)) {
+                return $denial;
             }
 
             return view('visual-editor::site-editor.index');

--- a/src/SiteEditor/Gates/CmsFrameworkInstallGate.php
+++ b/src/SiteEditor/Gates/CmsFrameworkInstallGate.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * cms-framework install-gate — H7 (#432).
+ *
+ * Reusable {@see SiteEditorAccessGate} implementation consumers can
+ * bind (directly or via composition) when they want the historical
+ * behaviour: render the install-instructions page when cms-framework's
+ * SiteEditor module is not on the classpath / not booted, otherwise
+ * fall through to the SPA mount.
+ *
+ * Hosts that need an authorisation check on top — Keystone's admin-
+ * role check, for example — typically wrap this gate in their own
+ * implementation and run the install check first (so an unauthorised
+ * visitor still sees the install page rather than a 403, which leaks
+ * less about the deployment state).
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\SiteEditor\Gates;
+
+use ArtisanPackUI\VisualEditor\SiteEditor\CmsFrameworkIntegration;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class CmsFrameworkInstallGate implements SiteEditorAccessGate
+{
+	/**
+	 * Allow the request when cms-framework's SiteEditor module is
+	 * booted (the H6 resolver binding is bound). Otherwise short-
+	 * circuit with the install-instructions page so the user gets a
+	 * single actionable message instead of the SPA mounting and then
+	 * receiving a cascade of 404s from every H6 controller.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param Request $request The incoming site-editor request.
+	 *
+	 * @return Response|null Null when cms-framework is booted, the
+	 *                      install-gate view otherwise.
+	 */
+	public function check( Request $request ): ?Response
+	{
+		if ( CmsFrameworkIntegration::isAvailable() ) {
+			return null;
+		}
+
+		return response()->view(
+			'visual-editor::site-editor.install-gate',
+			[
+				'postEditorUrl' => route( 'visual-editor.editor' ),
+			]
+		);
+	}
+}

--- a/src/SiteEditor/Gates/DenyByDefaultGate.php
+++ b/src/SiteEditor/Gates/DenyByDefaultGate.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * Fail-closed default site-editor access gate — H7 (#432).
+ *
+ * Returns a 503 view on every request. Bound as the package default
+ * for {@see SiteEditorAccessGate} so a fresh install of the visual-
+ * editor package cannot expose the site editor without the consuming
+ * app explicitly opting in.
+ *
+ * Consumers replace the binding with one of the bundled gates
+ * ({@see CmsFrameworkInstallGate}) or their own implementation —
+ * see `docs/site-editor-access-gate.md`.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\SiteEditor\Gates;
+
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class DenyByDefaultGate implements SiteEditorAccessGate
+{
+	/**
+	 * Short-circuit with a 503 view explaining the gate has not been
+	 * configured. The status code is deliberate: this is a deployment
+	 * misconfiguration (no consumer-supplied gate is bound), not an
+	 * authorisation decision about a specific user.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param Request $request The incoming site-editor request.
+	 *
+	 * @return Response|null Always returns the 503 view response —
+	 *                      never null — but the signature is nullable
+	 *                      to satisfy {@see SiteEditorAccessGate}.
+	 */
+	public function check( Request $request ): ?Response
+	{
+		return response()->view(
+			'visual-editor::site-editor.deny-by-default',
+			[],
+			Response::HTTP_SERVICE_UNAVAILABLE
+		);
+	}
+}

--- a/src/SiteEditor/Gates/SiteEditorAccessGate.php
+++ b/src/SiteEditor/Gates/SiteEditorAccessGate.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * Site-editor access gate contract — H7 (#432).
+ *
+ * Consumers of the package implement this contract (and bind their
+ * implementation to {@see SiteEditorAccessGate::class} in the
+ * container) to control who reaches the `/visual-editor/site/{path?}`
+ * SPA mount and what unauthorised visitors see instead.
+ *
+ * The package ships {@see DenyByDefaultGate} as the default binding —
+ * a fail-closed gate that returns a 503 page on every request. A fresh
+ * install of the package cannot accidentally expose the site editor.
+ * Consumers MUST override the binding before the site editor is
+ * reachable.
+ *
+ * Consumers that just want the historical behaviour (allow when
+ * cms-framework's SiteEditor module is booted, render the install
+ * instructions otherwise) can bind {@see CmsFrameworkInstallGate}
+ * directly. CMS hosts that also need an authorisation check (e.g.
+ * Keystone's admin-role check) typically compose the install gate with
+ * their own role / capability check inside a thin app-side gate.
+ *
+ * See `docs/site-editor-access-gate.md` for the wiring guide.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\SiteEditor\Gates;
+
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+interface SiteEditorAccessGate
+{
+	/**
+	 * Decide whether the incoming request may reach the site-editor
+	 * SPA mount.
+	 *
+	 * Return `null` to allow the request through. The route closure
+	 * then renders the SPA mount view as normal.
+	 *
+	 * Return a {@see Response} to short-circuit the request — the
+	 * route closure returns the response verbatim. This is the hook
+	 * for install-gate pages, login redirects, 403 / 503 templates,
+	 * or anything else the consumer wants to show in place of the
+	 * editor.
+	 *
+	 * Implementations must not throw on the unauthenticated /
+	 * unauthorised path — short-circuit with a {@see Response}
+	 * instead so the user sees a useful page rather than a generic
+	 * framework error.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param Request $request The incoming site-editor request.
+	 *
+	 * @return Response|null Null to allow, Response to short-circuit.
+	 */
+	public function check( Request $request ): ?Response;
+}

--- a/src/VisualEditorServiceProvider.php
+++ b/src/VisualEditorServiceProvider.php
@@ -10,6 +10,8 @@ use ArtisanPackUI\VisualEditor\Console\Commands\SeedSampleContentCommand;
 use ArtisanPackUI\VisualEditor\MediaBridge\GutenbergAttachmentAdapter;
 use ArtisanPackUI\VisualEditor\Services\Adapters\CmsFramework\CmsFrameworkQueryResolver;
 use ArtisanPackUI\VisualEditor\Services\QueryResolverContract;
+use ArtisanPackUI\VisualEditor\SiteEditor\Gates\DenyByDefaultGate;
+use ArtisanPackUI\VisualEditor\SiteEditor\Gates\SiteEditorAccessGate;
 use ArtisanPackUI\VisualEditor\Models\VisualEditorGlobalStyles;
 use ArtisanPackUI\VisualEditor\Models\VisualEditorNavigation;
 use ArtisanPackUI\VisualEditor\Models\VisualEditorPattern;
@@ -168,6 +170,14 @@ class VisualEditorServiceProvider extends ServiceProvider
 		// `QueryResolveController` and `QueryInliner` only require that
 		// *something* be bound.
 		$this->registerQueryResolverBinding();
+
+		// H7 (#432) — bind the fail-closed default access gate for
+		// the site-editor shell route. `bindIf` is deliberate: a
+		// consuming app that binds its own `SiteEditorAccessGate`
+		// implementation (or one of the package-bundled gates such as
+		// `CmsFrameworkInstallGate`) earlier in the boot order wins.
+		// See `docs/site-editor-access-gate.md`.
+		$this->app->bindIf( SiteEditorAccessGate::class, DenyByDefaultGate::class );
 
 		$this->mergeConfigFrom(
 			__DIR__ . '/../config/visual-editor.php', 'artisanpack-visual-editor-temp'

--- a/tests/Feature/SiteEditor/InstallGateActiveTest.php
+++ b/tests/Feature/SiteEditor/InstallGateActiveTest.php
@@ -7,15 +7,27 @@
  * Pairs with {@see InstallGateTest} (no cms-framework) which asserts
  * the gate fires.
  *
+ * Both files explicitly bind {@see CmsFrameworkInstallGate} since the
+ * H7 policy-contract refactor: the package default is now fail-closed
+ * {@see DenyByDefaultGate}, and the install-gate behaviour is one of
+ * several gates a consumer can opt into. See
+ * {@see SiteEditorAccessGateTest} for default-binding coverage.
+ *
  * @since 1.0.0
  */
 
 declare( strict_types=1 );
 
+use ArtisanPackUI\VisualEditor\SiteEditor\Gates\CmsFrameworkInstallGate;
+use ArtisanPackUI\VisualEditor\SiteEditor\Gates\SiteEditorAccessGate;
 use Tests\Concerns\WithCmsFramework;
 use Tests\TestCase;
 
 uses( TestCase::class, WithCmsFramework::class );
+
+beforeEach( function (): void {
+	$this->app->bind( SiteEditorAccessGate::class, CmsFrameworkInstallGate::class );
+} );
 
 test( 'site-editor route mounts the SPA when cms-framework is booted', function (): void {
 	// `withoutVite` swaps the Vite handler for an empty stub so the SPA

--- a/tests/Feature/SiteEditor/InstallGateTest.php
+++ b/tests/Feature/SiteEditor/InstallGateTest.php
@@ -9,6 +9,11 @@
  * those 404s so the user lands on a single install instruction page
  * instead of a cascade of error banners from the SPA.
  *
+ * Since H7's policy-contract refactor the install gate is no longer
+ * the package default — these tests bind {@see CmsFrameworkInstallGate}
+ * explicitly to assert its behaviour. The deny-by-default behaviour is
+ * covered in {@see SiteEditorAccessGateTest}.
+ *
  * The companion {@see InstallGateActiveTest} runs with cms-framework
  * booted and asserts the gate falls through to the SPA mount.
  *
@@ -17,9 +22,15 @@
 
 declare( strict_types=1 );
 
+use ArtisanPackUI\VisualEditor\SiteEditor\Gates\CmsFrameworkInstallGate;
+use ArtisanPackUI\VisualEditor\SiteEditor\Gates\SiteEditorAccessGate;
 use Tests\TestCase;
 
 uses( TestCase::class );
+
+beforeEach( function (): void {
+	$this->app->bind( SiteEditorAccessGate::class, CmsFrameworkInstallGate::class );
+} );
 
 test( 'site-editor route renders the install gate when cms-framework is missing', function (): void {
 	$response = $this->get( '/visual-editor/site' );

--- a/tests/Feature/SiteEditor/SiteEditorAccessGateTest.php
+++ b/tests/Feature/SiteEditor/SiteEditorAccessGateTest.php
@@ -1,0 +1,105 @@
+<?php
+
+/**
+ * H7 (#432) site-editor access-gate contract tests.
+ *
+ * Covers the package-default fail-closed behaviour and the consumer-
+ * override contract: a host app binds its own
+ * {@see SiteEditorAccessGate} implementation in the container and the
+ * site-editor route uses it verbatim — allowing the request through
+ * (on null) or short-circuiting with the consumer's response.
+ *
+ * Paired with {@see InstallGateTest} / {@see InstallGateActiveTest},
+ * which cover the bundled {@see CmsFrameworkInstallGate} specifically.
+ *
+ * @since 1.0.0
+ */
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\SiteEditor\Gates\DenyByDefaultGate;
+use ArtisanPackUI\VisualEditor\SiteEditor\Gates\SiteEditorAccessGate;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Tests\TestCase;
+
+uses( TestCase::class );
+
+test( 'package default binding is the fail-closed deny gate', function (): void {
+	$resolved = $this->app->make( SiteEditorAccessGate::class );
+
+	expect( $resolved )->toBeInstanceOf( DenyByDefaultGate::class );
+} );
+
+test( 'site-editor route returns a 503 deny page with the default gate', function (): void {
+	$response = $this->get( '/visual-editor/site' );
+
+	$response->assertStatus( Response::HTTP_SERVICE_UNAVAILABLE );
+	$response->assertViewIs( 'visual-editor::site-editor.deny-by-default' );
+	$response->assertSee( 'Site editor access has not been configured' );
+} );
+
+test( 'deny-by-default gate fires for nested SPA paths too', function (): void {
+	$response = $this->get( '/visual-editor/site/templates/single' );
+
+	$response->assertStatus( Response::HTTP_SERVICE_UNAVAILABLE );
+	$response->assertViewIs( 'visual-editor::site-editor.deny-by-default' );
+} );
+
+test( 'a consumer-supplied gate returning null allows the request through', function (): void {
+	$this->app->bind( SiteEditorAccessGate::class, function () {
+		return new class implements SiteEditorAccessGate
+		{
+			public function check( Request $request ): ?Response
+			{
+				return null;
+			}
+		};
+	} );
+
+	$this->withoutVite();
+
+	$response = $this->get( '/visual-editor/site' );
+
+	$response->assertOk();
+	$response->assertViewIs( 'visual-editor::site-editor.index' );
+} );
+
+test( 'a consumer-supplied gate returning a response short-circuits the route', function (): void {
+	$this->app->bind( SiteEditorAccessGate::class, function () {
+		return new class implements SiteEditorAccessGate
+		{
+			public function check( Request $request ): ?Response
+			{
+				return response( 'consumer-denied', Response::HTTP_FORBIDDEN );
+			}
+		};
+	} );
+
+	$response = $this->get( '/visual-editor/site' );
+
+	$response->assertStatus( Response::HTTP_FORBIDDEN );
+	expect( $response->getContent() )->toBe( 'consumer-denied' );
+} );
+
+test( 'the gate receives the incoming request', function (): void {
+	$capturedPath = null;
+
+	$this->app->bind( SiteEditorAccessGate::class, function () use ( &$capturedPath ) {
+		return new class( $capturedPath ) implements SiteEditorAccessGate
+		{
+			public function __construct( public ?string &$captured ) {}
+
+			public function check( Request $request ): ?Response
+			{
+				$this->captured = $request->path();
+
+				return response( 'ok' );
+			}
+		};
+	} );
+
+	$this->get( '/visual-editor/site/templates/single' );
+
+	expect( $capturedPath )->toBe( 'visual-editor/site/templates/single' );
+} );

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,14 +24,50 @@ const coreDataShim = resolve(
     'resources/js/visual-editor/vendor/core-data-shim.ts'
 );
 
+// Several transitive `@wordpress/*` dependencies (e.g. `global-styles-engine`,
+// `server-side-render`) ship their own nested `node_modules/@wordpress/blocks`
+// copy. Without explicit aliases Rollup resolves each import chain to a
+// different on-disk file, then `manualChunks` collocates all three copies
+// into the single `gutenberg` chunk, where each copy re-registers Gutenberg's
+// `core/blocks` Redux store at module init — surfacing as the
+// `Store "core/blocks" is already registered.` error in consumer apps and
+// triggering a Vite HMR-overlay → `location.reload()` cascade in dev.
+//
+// Pin every `@wordpress/*` import to the package's top-level node_modules
+// copy so Rollup produces a single instance.
+const sharedWordpressSingletons = [
+    '@wordpress/blocks',
+    '@wordpress/block-editor',
+    '@wordpress/block-library',
+    '@wordpress/components',
+    '@wordpress/data',
+    '@wordpress/element',
+    '@wordpress/hooks',
+    '@wordpress/i18n',
+];
+const wordpressSingletonAliases = Object.fromEntries(
+    sharedWordpressSingletons.map((name) => [
+        name,
+        resolve(__dirname, 'node_modules', name),
+    ]),
+);
+
 export default defineConfig(({ command, mode }) => {
     const isLibraryBuild = mode === 'lib';
 
     return {
         plugins: [react()],
         root: command === 'serve' ? editorRoot : __dirname,
+        // The app-mode build is consumed by Keystone (and other host apps)
+        // by copying `dist/editor/*` to `public/visual-editor/`. The bundle
+        // emits relative `chunks/...` imports plus `__vitePreload` CSS deps
+        // that are resolved as `base + path`; without a base they resolve
+        // to `/assets/...` and 404. Pinning the base keeps the prebuilt
+        // self-contained at its hosted URL.
+        base: isLibraryBuild ? '/' : '/visual-editor/',
         resolve: {
             alias: {
+                ...wordpressSingletonAliases,
                 '@editor': editorRoot,
                 // M2 (#312): every `@wordpress/core-data` import in the
                 // editor bundle resolves to our in-repo empty-state shim.


### PR DESCRIPTION
## Description

Refactor the hard-coded install-gate check on `/visual-editor/site/{path?}` into a consumer-supplied policy contract. Each CMS using the package (Keystone, digital-shopfront-cms, future tenants) now decides for itself who reaches the site-editor SPA — the package no longer assumes any particular auth model.

Also ships two prerequisites for SPA-host mounting that the H7 work depends on (boot bridge + WordPress singleton aliases). See commit history for the split.

**Closes:** #432 (the install-gate / shell-wiring slice — see "Scope notes" below)

## Type of Change

- [x] New feature (adds new functionality)
- [x] Breaking change (breaks backward compatibility)

The package default behaviour changes from "allow when cms-framework is booted" to "deny by default with a 503 page." Consumers MUST bind a `SiteEditorAccessGate` to expose the site editor. Migration is one line in a service provider — see the docs.

## Related Issue

**Issue:** #432

## Motivation and Context

This is Slice 1 of the themes + site editor arc planned in the Keystone CMS repo (`plans/08-themes-site-editor-arc.md`). The user-facing decision driving the refactor:

> Install gates should be behind Keystone CMS specific gates, not via any artisanpack-ui packages — so developers using these packages for their own CMSs can decide for themselves who has access.

The previous design hard-coded "is cms-framework installed and booted?" as the gate. That answers a deployment question, not an authorisation question — a Keystone admin route needs both, and a different consumer might want neither. Making the gate a consumer-supplied policy lets every host wire its own combination.

Defaulting to deny (fail closed) means a fresh install can't accidentally expose the editor to the public if the consumer hasn't yet registered a gate.

## Changes Made

**New contract (`src/SiteEditor/Gates/`):**
- `SiteEditorAccessGate` — interface: `check(Request): ?Response`. `null` → allow, `Response` → short-circuit.
- `DenyByDefaultGate` — package default. Returns a 503 view explaining the editor has not been configured.
- `CmsFrameworkInstallGate` — bundled opt-in gate that preserves the historical behaviour (install-instructions page when cms-framework is missing).

**Wiring:**
- `routes/web.php` — resolves the bound gate per-request and uses its return value.
- `VisualEditorServiceProvider::register()` — `bindIf(SiteEditorAccessGate::class, DenyByDefaultGate::class)`. `bindIf` lets a consumer-supplied binding registered earlier in the boot order win.

**Views:**
- `resources/views/site-editor/deny-by-default.blade.php` — new 503 page, inline-styled to stand alone without the SPA's CSS bundle. Modelled on the existing install-gate page.

**Docs:**
- `docs/site-editor-access-gate.md` — full consumer wiring guide: contract, default behaviour, bundled gates, recommended composition pattern, testing example.

**SPA-host prerequisites** (separate commit, same branch):
- `resources/js/visual-editor/editor/main.tsx` — exposes `window.ApVisualEditor` / `window.ApVisualEditorBoot` so SPA hosts can re-mount after client-side navigation. `mountEditor` already de-dupes per element.
- `vite.config.ts` — pins every `@wordpress/*` import to the top-level `node_modules` copy so transitive deps don't ship duplicate `@wordpress/blocks` copies that re-register `core/blocks` at module init.

**Tests:**
- `tests/Feature/SiteEditor/SiteEditorAccessGateTest.php` — new. Covers default fail-closed binding, default-gate route response (503 + view + sub-paths), and the consumer-override contract (null → allow, Response → short-circuit, request passes through).
- `tests/Feature/SiteEditor/InstallGateTest.php` / `InstallGateActiveTest.php` — updated to bind `CmsFrameworkInstallGate` explicitly in `beforeEach`, since it's no longer the package default. Behaviour assertions unchanged.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS
- PHP Version: 8.4
- Project Version: release/1.0 (v1.0 milestone)

**Tests Performed:**
1. `./vendor/bin/pest tests/Feature/SiteEditor/` — 120 passed (306 assertions)
2. `./vendor/bin/pest tests/Feature/` — 264 passed (791 assertions) — full feature suite, no regressions
3. `coderabbit review --plain --base release/1.0` — no findings (after one round of docblock cleanup)

End-to-end UI testing (mounting the SPA inside Keystone's admin behind the admin-role gate) happens in Slice 1 Part 2, when Keystone consumes this contract.

## Accessibility Tests Run

- [x] Keyboard navigation tested — n/a (gate pages are static content with no interactive elements beyond the install-gate's link, which inherits browser defaults)
- [x] Screen reader tested — n/a (semantic `<main role="main">` + `<h1>` heading)
- [x] Color contrast verified — gate views use the same palette as the existing install-gate page, which already meets WCAG AA in both light and dark modes (`prefers-color-scheme` media query)
- [x] ARIA labels checked — the install-gate `<pre>` retains its `aria-label`; the deny page has no interactive elements requiring labels

**Details:** The deny-by-default page mirrors the existing install-gate page in markup and styling. No new interactive UI surfaces in this change.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:** 6 new tests in `SiteEditorAccessGateTest`; 2 existing test files updated to bind the cms-framework gate explicitly (4 tests preserved behaviour, no assertion changes). Full feature suite of 264 tests passes.

## Documentation

- [x] Inline code documentation added — full WordPress-style docblocks on all three new classes
- [x] Wiki updated — see `docs/site-editor-access-gate.md` (new file in the package's `docs/` tree)
- [x] API documentation updated — gate contract documented in the new doc file

**Documentation details:** `docs/site-editor-access-gate.md` covers the interface contract, package default behaviour, both bundled gate implementations, a recommended composition pattern for production hosts (wrap `CmsFrameworkInstallGate` in front of an auth check), and a testing example.

## Screenshots

n/a — the deny-by-default page mirrors the existing install-gate page in markup and styling. The two pages are visually distinct only in their copy ("install cms-framework" vs "no gate configured") and HTTP status (200 vs 503).

## Scope notes

The issue title is "shell wiring + install gate" with broad scope (D1–D5 retargeting onto H6 endpoints). The data-path retargeting was handled in #357–#361 and #367–#372; #432's remaining unique deliverable is the install-gate refactor, which this PR ships. The catch-all SPA route and shell views already exist on `release/1.0` from the prior #432 work that merged in PR #437 — this PR layers the policy contract on top.

The lazy-loading decision (plan 14 §8) is **not** decided here — leave it as a follow-up; the gate refactor is orthogonal to entity-route loading strategy.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests (264/264 feature tests)
- [x] Code has been linted
- [x] CodeRabbit review run locally — no findings
- [x] Accessibility tests completed (see above)
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented configurable access gating system for the site editor with fail-closed security defaults.
  * Visual editor now supports dynamic initialization via browser global APIs.

* **Improvements**
  * Enhanced build configuration for better WordPress package resolution.

* **Documentation**
  * Added comprehensive access gate contract documentation with configuration guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArtisanPack-UI/visual-editor/pull/443)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->