### PR TITLE
fix(site-editor): resolve id: 0 for file-only resources + harden store()/index()

### DIFF
--- a/resources/js/visual-editor/site-editor/navigation/api-client.ts
+++ b/resources/js/visual-editor/site-editor/navigation/api-client.ts
@@ -22,7 +22,12 @@ export interface NavigationRecord {
     id: number;
     slug: string;
     title: { rendered: string };
-    content: { raw: string; blocks: readonly unknown[] };
+    /**
+     * Optional because older controllers and partial-update responses
+     * may omit it; consumers should default to `{ raw: '', blocks: [] }`
+     * rather than crash on access (#438).
+     */
+    content?: { raw: string; blocks: readonly unknown[] };
     status: string;
     menu_order: number;
     /** `null` means no UI-driven location assignment. */

--- a/resources/js/visual-editor/site-editor/navigation/navigation-browser.tsx
+++ b/resources/js/visual-editor/site-editor/navigation/navigation-browser.tsx
@@ -122,7 +122,10 @@ export function NavigationBrowser(
     }, [locations]);
 
     const itemCountForRow = (row: NavigationRecord): number => {
-        return countNavigationLeaves(row.content.blocks);
+        // Defensive: older controllers and partial responses can omit
+        // `content`; treat as empty rather than crashing the whole tree
+        // with WSOD (#438).
+        return countNavigationLeaves(row.content?.blocks ?? []);
     };
 
     return (

--- a/src/Http/Controllers/SiteEditor/MenuController.php
+++ b/src/Http/Controllers/SiteEditor/MenuController.php
@@ -107,7 +107,7 @@ class MenuController extends Controller
 
 		$model = self::CMS_MENU_FQCN;
 
-		$attributes = $this->modelAttributesFromRequest( $request->validated() );
+		$attributes = $this->modelAttributesFromRequest( $request->validated(), forCreate: true );
 
 		if ( ! array_key_exists( 'theme', $attributes ) || '' === (string) $attributes['theme'] ) {
 			return response()->json( [
@@ -282,18 +282,26 @@ class MenuController extends Controller
 	/**
 	 * Translate the WP-shape validated input into cms-framework `Menu`
 	 * model attributes. Maps `title` (WP REST shape — what the editor's
-	 * create-menu dialog sends) onto `name` (model column), and falls
-	 * back to cms-framework's active theme when the payload doesn't
-	 * carry one. Mirrors the helpers in TemplateController and
+	 * create-menu dialog sends) onto `name` (model column). On create,
+	 * falls back to cms-framework's active theme when the payload
+	 * doesn't carry one. Mirrors the helpers in TemplateController and
 	 * TemplatePartController (#438).
+	 *
+	 * The active-theme fallback is create-only. On a partial `update()`
+	 * the payload routinely omits `theme` (e.g. a rename sends only
+	 * `title`); injecting the active theme there would silently
+	 * re-home the menu to a different theme. An explicit `theme` in the
+	 * payload still flows through on both paths — only the *inferred*
+	 * fallback is gated.
 	 *
 	 * @since 1.0.0
 	 *
 	 * @param  array<string, mixed>  $validated
+	 * @param  bool  $forCreate  True for store(), false for update().
 	 *
 	 * @return array<string, mixed>
 	 */
-	protected function modelAttributesFromRequest( array $validated ): array
+	protected function modelAttributesFromRequest( array $validated, bool $forCreate = false ): array
 	{
 		$attributes = [];
 
@@ -311,7 +319,9 @@ class MenuController extends Controller
 			$attributes['name'] = $validated['title'];
 		}
 
-		if ( ! array_key_exists( 'theme', $attributes ) || '' === (string) ( $attributes['theme'] ?? '' ) ) {
+		if ( $forCreate
+			&& ( ! array_key_exists( 'theme', $attributes ) || '' === (string) ( $attributes['theme'] ?? '' ) )
+		) {
 			$active = $this->activeThemeSlug();
 
 			if ( null !== $active ) {

--- a/src/Http/Controllers/SiteEditor/MenuController.php
+++ b/src/Http/Controllers/SiteEditor/MenuController.php
@@ -253,6 +253,16 @@ class MenuController extends Controller
 				'rendered' => $name,
 				'raw'      => $name,
 			],
+			// `content` mirrors the WP REST `wp_navigation` shape so the
+			// editor's NavigationBrowser can read `row.content.blocks`
+			// without crashing (#438). Items are surfaced through the
+			// separate /menu-items endpoint; for now this is an empty
+			// envelope, populated by a future H6 follow-up that converts
+			// menu items into a `core/navigation` block tree.
+			'content'        => [
+				'raw'    => '',
+				'blocks' => [],
+			],
 			'auto_add_pages' => (bool) ( $menu->auto_add_pages ?? false ),
 		];
 	}

--- a/src/Http/Controllers/SiteEditor/MenuController.php
+++ b/src/Http/Controllers/SiteEditor/MenuController.php
@@ -107,9 +107,25 @@ class MenuController extends Controller
 
 		$model = self::CMS_MENU_FQCN;
 
+		$attributes = $this->modelAttributesFromRequest( $request->validated() );
+
+		if ( ! array_key_exists( 'theme', $attributes ) || '' === (string) $attributes['theme'] ) {
+			return response()->json( [
+				'message' => 'A theme is required to create a menu.',
+				'errors'  => [ 'theme' => [ 'The theme field is required when no theme is active.' ] ],
+			], Response::HTTP_UNPROCESSABLE_ENTITY );
+		}
+
+		if ( ! array_key_exists( 'name', $attributes ) || '' === (string) $attributes['name'] ) {
+			return response()->json( [
+				'message' => 'A name is required to create a menu.',
+				'errors'  => [ 'name' => [ 'The name (or title) field is required.' ] ],
+			], Response::HTTP_UNPROCESSABLE_ENTITY );
+		}
+
 		try {
 			/** @var object $menu */
-			$menu = $model::create( $request->validated() );
+			$menu = $model::create( $attributes );
 		} catch ( QueryException $e ) {
 			if ( $this->isUniqueViolation( $e ) ) {
 				return response()->json( [
@@ -142,7 +158,7 @@ class MenuController extends Controller
 		}
 
 		try {
-			$menu->update( $request->validated() );
+			$menu->update( $this->modelAttributesFromRequest( $request->validated() ) );
 		} catch ( QueryException $e ) {
 			if ( $this->isUniqueViolation( $e ) ) {
 				return response()->json( [
@@ -251,6 +267,72 @@ class MenuController extends Controller
 		}
 
 		return app()->bound( self::CMS_RESOLVER_BINDING );
+	}
+
+	/**
+	 * Translate the WP-shape validated input into cms-framework `Menu`
+	 * model attributes. Maps `title` (WP REST shape — what the editor's
+	 * create-menu dialog sends) onto `name` (model column), and falls
+	 * back to cms-framework's active theme when the payload doesn't
+	 * carry one. Mirrors the helpers in TemplateController and
+	 * TemplatePartController (#438).
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array<string, mixed>  $validated
+	 *
+	 * @return array<string, mixed>
+	 */
+	protected function modelAttributesFromRequest( array $validated ): array
+	{
+		$attributes = [];
+
+		foreach ( [ 'theme', 'slug', 'name', 'description', 'auto_add_pages' ] as $field ) {
+			if ( array_key_exists( $field, $validated ) ) {
+				$attributes[ $field ] = $validated[ $field ];
+			}
+		}
+
+		// `title` (WP REST shape) wins over `name` (model shape) when
+		// both are present, since the editor consistently sends `title`
+		// and an explicit body `name` would only appear from a REST
+		// client choosing to use the model field directly.
+		if ( array_key_exists( 'title', $validated ) ) {
+			$attributes['name'] = $validated['title'];
+		}
+
+		if ( ! array_key_exists( 'theme', $attributes ) || '' === (string) ( $attributes['theme'] ?? '' ) ) {
+			$active = $this->activeThemeSlug();
+
+			if ( null !== $active ) {
+				$attributes['theme'] = $active;
+			}
+		}
+
+		return $attributes;
+	}
+
+	/**
+	 * Resolve the active theme slug through cms-framework's `ThemeManager`
+	 * when available. Mirrors {@see TemplateController::activeThemeSlug()}.
+	 *
+	 * @since 1.0.0
+	 */
+	protected function activeThemeSlug(): ?string
+	{
+		$themeManagerFqcn = 'ArtisanPackUI\\CMSFramework\\Modules\\Themes\\Managers\\ThemeManager';
+
+		if ( ! class_exists( $themeManagerFqcn ) || ! app()->bound( $themeManagerFqcn ) ) {
+			return null;
+		}
+
+		$theme = app( $themeManagerFqcn )->getActiveTheme();
+
+		if ( ! is_array( $theme ) || empty( $theme['slug'] ) || ! is_string( $theme['slug'] ) ) {
+			return null;
+		}
+
+		return $theme['slug'];
 	}
 
 	/**

--- a/src/Http/Controllers/SiteEditor/PatternController.php
+++ b/src/Http/Controllers/SiteEditor/PatternController.php
@@ -268,7 +268,10 @@ class PatternController extends Controller
 	 */
 	protected function findPatternByIdOrSlug( string $input ): ?ResolvedPattern
 	{
-		if ( ctype_digit( $input ) ) {
+		// `0` is the sentinel `wpId` for theme-source patterns — never a
+		// valid DB id. Treating it as one would silently match the first
+		// theme pattern, masking #438. Fall through to slug lookup.
+		if ( ctype_digit( $input ) && (int) $input > 0 ) {
 			$id = (int) $input;
 
 			foreach ( $this->resolver->all() as $candidate ) {
@@ -299,7 +302,9 @@ class PatternController extends Controller
 	{
 		$model = self::CMS_PATTERN_FQCN;
 
-		if ( ctype_digit( $input ) ) {
+		// `0` cannot match any real DB row; skip the lookup and fall
+		// through to slug resolution (#438).
+		if ( ctype_digit( $input ) && (int) $input > 0 ) {
 			/** @var object|null */
 			return $model::query()->find( (int) $input );
 		}

--- a/src/Http/Controllers/SiteEditor/PatternController.php
+++ b/src/Http/Controllers/SiteEditor/PatternController.php
@@ -143,10 +143,19 @@ class PatternController extends Controller
 
 		$resolved = $this->findPattern( (string) $pattern->slug );
 
+		// The row was created but the resolver can't see it — a
+		// server-side inconsistency, not a client error. Returning 201
+		// with this body would hand the editor a record with no `id`,
+		// which it then dereferences into `/patterns/undefined` (#438).
+		if ( ! $resolved instanceof ResolvedPattern ) {
+			return response()->json(
+				[ 'message' => 'Pattern created but could not be resolved.' ],
+				Response::HTTP_INTERNAL_SERVER_ERROR,
+			);
+		}
+
 		return response()->json(
-			$resolved instanceof ResolvedPattern
-				? ( new PatternAdapter() )->toArray( $resolved )
-				: [ 'message' => 'Pattern created but could not be resolved.' ],
+			( new PatternAdapter() )->toArray( $resolved ),
 			Response::HTTP_CREATED,
 		);
 	}

--- a/src/Http/Controllers/SiteEditor/TemplateController.php
+++ b/src/Http/Controllers/SiteEditor/TemplateController.php
@@ -78,13 +78,27 @@ class TemplateController extends Controller
 	 * active theme. Returns a flat list keyed in slug-iteration order; no
 	 * pagination wrapper, matching {@see TemplateAdapter::collection()}.
 	 *
+	 * Honors the `status` query param (the navigator's Published / Draft
+	 * filter chips). Without it the chips were cosmetic — every template
+	 * showed under every chip (#438). Mirrors the `source` / `synced`
+	 * filtering already in {@see PatternController::index()}.
+	 *
 	 * @since 1.0.0
 	 */
-	public function index(): JsonResponse
+	public function index( Request $request ): JsonResponse
 	{
-		$adapter = new TemplateAdapter();
+		$templates = $this->resolver->all();
 
-		return response()->json( $adapter->collection( $this->resolver->all() ) );
+		$status = trim( (string) $request->query( 'status', '' ) );
+
+		if ( '' !== $status ) {
+			$templates = array_filter(
+				$templates,
+				static fn ( ResolvedTemplate $template ): bool => $template->status === $status,
+			);
+		}
+
+		return response()->json( ( new TemplateAdapter() )->collection( $templates ) );
 	}
 
 	/**
@@ -131,11 +145,26 @@ class TemplateController extends Controller
 			return $this->cmsFrameworkUnavailable();
 		}
 
+		$validated = $request->validated();
+
+		// The site editor only ever resolves templates for the *active*
+		// theme — cms-framework's resolver scopes its DB query to it. A
+		// template created under any other theme is invisible to the
+		// navigator and to save/load, so prefer the active theme here.
+		// The request's `theme` (sourced from the mount point's stale
+		// `data-theme` attribute) is only a fallback for standalone
+		// installs with no ThemeManager bound. Mirrors the theme
+		// inference applied to update()/destroy() in #438.
+		//
+		// `StoreTemplateRequest` requires `theme`, so the fallback is
+		// always a non-empty string — no empty-theme guard needed.
+		$validated['theme'] = $this->activeThemeSlug() ?? $validated['theme'];
+
 		$model = self::CMS_TEMPLATE_FQCN;
 
 		try {
 			/** @var object $template */
-			$template = $model::create( $this->modelAttributesFromRequest( $request->validated() ) );
+			$template = $model::create( $this->modelAttributesFromRequest( $validated ) );
 		} catch ( QueryException $e ) {
 			if ( $this->isUniqueViolation( $e ) ) {
 				return response()->json( [
@@ -153,10 +182,19 @@ class TemplateController extends Controller
 
 		$resolved = $this->resolver->find( (string) $template->slug );
 
+		// The row was created but the resolver can't see it — a
+		// server-side inconsistency, not a client error. Returning 201
+		// with this body would hand the editor a record with no `id`,
+		// which it then dereferences into `/templates/undefined` (#438).
+		if ( ! $resolved instanceof ResolvedTemplate ) {
+			return response()->json(
+				[ 'message' => 'Template created but could not be resolved.' ],
+				Response::HTTP_INTERNAL_SERVER_ERROR,
+			);
+		}
+
 		return response()->json(
-			$resolved instanceof ResolvedTemplate
-				? ( new TemplateAdapter() )->toArray( $resolved )
-				: [ 'message' => 'Template created but could not be resolved.' ],
+			( new TemplateAdapter() )->toArray( $resolved ),
 			Response::HTTP_CREATED,
 		);
 	}

--- a/src/Http/Controllers/SiteEditor/TemplateController.php
+++ b/src/Http/Controllers/SiteEditor/TemplateController.php
@@ -181,8 +181,9 @@ class TemplateController extends Controller
 		// H7 (#432). Numeric URL parameter → look up the row directly
 		// by primary key (the row already knows its theme + slug). Slug
 		// path keeps the existing `(theme, slug)` upsert behavior so
-		// theme-only templates can be DB-overridden through a PUT.
-		if ( ctype_digit( $slug ) ) {
+		// theme-only templates can be DB-overridden through a PUT. `0`
+		// is the file-only sentinel and must fall through (#438).
+		if ( ctype_digit( $slug ) && (int) $slug > 0 ) {
 			$existing = $model::query()->find( (int) $slug );
 
 			if ( null === $existing ) {
@@ -220,11 +221,21 @@ class TemplateController extends Controller
 			$theme = (string) ( $validated['theme'] ?? '' );
 
 			if ( '' === $theme ) {
+				$theme = (string) ( $this->activeThemeSlug() ?? '' );
+			}
+
+			if ( '' === $theme ) {
 				return response()->json( [
 					'message' => 'A theme is required to identify the template.',
-					'errors'  => [ 'theme' => [ 'The theme field is required for site-editor updates.' ] ],
+					'errors'  => [ 'theme' => [ 'The theme field is required for site-editor updates when no theme is active.' ] ],
 				], Response::HTTP_UNPROCESSABLE_ENTITY );
 			}
+
+			// Persist the resolved theme back into `$validated` so
+			// `modelAttributesFromRequest()` carries it into the create
+			// payload. Without this, a fallback theme resolved from the
+			// active theme manager wouldn't reach the DB row.
+			$validated['theme'] = $theme;
 
 			$existing = $model::query()->where( 'theme', $theme )->where( 'slug', $slug )->first();
 
@@ -301,8 +312,9 @@ class TemplateController extends Controller
 		// H7 (#432). Numeric URL parameter → primary-key delete (row
 		// owns its theme already; no `?theme=` collision risk). Slug
 		// path keeps the `?theme=` requirement so a multi-theme
-		// override doesn't get collateral-deleted.
-		if ( ctype_digit( $slug ) ) {
+		// override doesn't get collateral-deleted. `0` is the file-only
+		// sentinel and must fall through (#438).
+		if ( ctype_digit( $slug ) && (int) $slug > 0 ) {
 			$existing = $model::query()->find( (int) $slug );
 
 			if ( null === $existing ) {
@@ -324,9 +336,13 @@ class TemplateController extends Controller
 		$theme = trim( (string) $request->query( 'theme', '' ) );
 
 		if ( '' === $theme ) {
+			$theme = (string) ( $this->activeThemeSlug() ?? '' );
+		}
+
+		if ( '' === $theme ) {
 			return response()->json( [
 				'message' => 'A theme is required to identify the template.',
-				'errors'  => [ 'theme' => [ 'The theme query parameter is required for site-editor deletes.' ] ],
+				'errors'  => [ 'theme' => [ 'The theme query parameter is required for site-editor deletes when no theme is active.' ] ],
 			], Response::HTTP_UNPROCESSABLE_ENTITY );
 		}
 
@@ -388,6 +404,34 @@ class TemplateController extends Controller
 		}
 
 		return app()->bound( self::CMS_RESOLVER_BINDING );
+	}
+
+	/**
+	 * Resolve the active theme slug through cms-framework's `ThemeManager`
+	 * when available. Used as the fallback for slug-branch upserts and
+	 * destroys when the request omits an explicit theme — matching the
+	 * single-active-theme invariant the site editor itself relies on.
+	 * Returns null when cms-framework isn't integrated, no theme is
+	 * active, or the manager is otherwise unbindable. Mirrors the same
+	 * helper in {@see GlobalStylesController::activeTheme()}.
+	 *
+	 * @since 1.0.0
+	 */
+	protected function activeThemeSlug(): ?string
+	{
+		$themeManagerFqcn = 'ArtisanPackUI\\CMSFramework\\Modules\\Themes\\Managers\\ThemeManager';
+
+		if ( ! class_exists( $themeManagerFqcn ) || ! app()->bound( $themeManagerFqcn ) ) {
+			return null;
+		}
+
+		$theme = app( $themeManagerFqcn )->getActiveTheme();
+
+		if ( ! is_array( $theme ) || empty( $theme['slug'] ) || ! is_string( $theme['slug'] ) ) {
+			return null;
+		}
+
+		return $theme['slug'];
 	}
 
 	/**

--- a/src/Http/Controllers/SiteEditor/TemplateController.php
+++ b/src/Http/Controllers/SiteEditor/TemplateController.php
@@ -240,8 +240,20 @@ class TemplateController extends Controller
 			$existing = $model::query()->where( 'theme', $theme )->where( 'slug', $slug )->first();
 
 			if ( null === $existing ) {
-				$attributes         = $this->modelAttributesFromRequest( $validated );
-				$attributes['slug'] = $slug;
+				// File→DB upsert: editor save payloads commonly omit
+				// every field except `content`. Seed defaults from the
+				// file-source resolved entity (title, description, etc.)
+				// before layering user-supplied changes on top, so
+				// NOT NULL columns like `title` always carry a value
+				// even when the editor only changed blocks (#438).
+				$fileDefaults = $this->fileSourceDefaults( $slug );
+
+				$attributes = array_merge(
+					$fileDefaults,
+					$this->modelAttributesFromRequest( $validated ),
+				);
+				$attributes['slug']  = $slug;
+				$attributes['theme'] = $theme;
 
 				try {
 					$existing = $model::create( $attributes );
@@ -404,6 +416,38 @@ class TemplateController extends Controller
 		}
 
 		return app()->bound( self::CMS_RESOLVER_BINDING );
+	}
+
+	/**
+	 * Seed model attributes for a brand-new file→DB upsert from the
+	 * file-source resolved template. Returns the subset of fields the
+	 * `templates` table requires (or strongly prefers) — `title`,
+	 * `description`, `status`, `is_custom` — so the editor can save
+	 * blocks-only payloads without 1364 NOT NULL violations on columns
+	 * it doesn't echo. Returns an empty array if the resolver can't
+	 * find the slug (e.g. a brand-new custom template the user is
+	 * creating from scratch through PUT — then required fields must
+	 * come from the request body, surfaced by the model's NOT NULL
+	 * column constraints if the client misses any).
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<string, mixed>
+	 */
+	protected function fileSourceDefaults( string $slug ): array
+	{
+		$resolved = $this->resolver->find( $slug );
+
+		if ( ! $resolved instanceof ResolvedTemplate ) {
+			return [];
+		}
+
+		return [
+			'title'       => $resolved->title,
+			'description' => $resolved->description,
+			'status'      => $resolved->status,
+			'is_custom'   => $resolved->isCustom,
+		];
 	}
 
 	/**

--- a/src/Http/Controllers/SiteEditor/TemplateController.php
+++ b/src/Http/Controllers/SiteEditor/TemplateController.php
@@ -361,7 +361,10 @@ class TemplateController extends Controller
 	 */
 	protected function findTemplateByIdOrSlug( string $input ): ?ResolvedTemplate
 	{
-		if ( ctype_digit( $input ) ) {
+		// `0` is the sentinel `wpId` for file-only templates — never a valid
+		// DB id. Treating it as one would silently match the first file-only
+		// candidate, masking #438. Fall through to slug lookup instead.
+		if ( ctype_digit( $input ) && (int) $input > 0 ) {
 			$id = (int) $input;
 
 			foreach ( $this->resolver->all() as $candidate ) {

--- a/src/Http/Controllers/SiteEditor/TemplatePartController.php
+++ b/src/Http/Controllers/SiteEditor/TemplatePartController.php
@@ -184,11 +184,20 @@ class TemplatePartController extends Controller
 			$theme = (string) ( $validated['theme'] ?? '' );
 
 			if ( '' === $theme ) {
+				$theme = (string) ( $this->activeThemeSlug() ?? '' );
+			}
+
+			if ( '' === $theme ) {
 				return response()->json( [
 					'message' => 'A theme is required to identify the template part.',
-					'errors'  => [ 'theme' => [ 'The theme field is required for site-editor updates.' ] ],
+					'errors'  => [ 'theme' => [ 'The theme field is required for site-editor updates when no theme is active.' ] ],
 				], Response::HTTP_UNPROCESSABLE_ENTITY );
 			}
+
+			// Persist the resolved theme back into `$validated` so
+			// `modelAttributesFromRequest()` carries it into the create
+			// payload. Mirrors the same fix in {@see TemplateController::update()}.
+			$validated['theme'] = $theme;
 
 			$existing = $model::query()->where( 'theme', $theme )->where( 'slug', $slug )->first();
 
@@ -196,8 +205,19 @@ class TemplatePartController extends Controller
 				$attributes         = $this->modelAttributesFromRequest( $validated );
 				$attributes['slug'] = $slug;
 
-				// Area is required to create a new part record; the existing
-				// row's area would otherwise survive the update branch.
+				// Area is required to create a new part record. When the
+				// editor upserts a file-only part it doesn't repeat the
+				// `area` field; fall back to the resolver's view of the
+				// existing file-source part (which infers area from the
+				// slug or `theme.json`) before bailing with 422 (#438).
+				if ( ! array_key_exists( 'area', $attributes ) ) {
+					$resolved = $this->resolver->find( $slug );
+
+					if ( $resolved instanceof ResolvedTemplatePart ) {
+						$attributes['area'] = $resolved->area;
+					}
+				}
+
 				if ( ! array_key_exists( 'area', $attributes ) ) {
 					return response()->json( [
 						'message' => 'An area is required to upsert a new template part.',
@@ -289,9 +309,13 @@ class TemplatePartController extends Controller
 		$theme = trim( (string) $request->query( 'theme', '' ) );
 
 		if ( '' === $theme ) {
+			$theme = (string) ( $this->activeThemeSlug() ?? '' );
+		}
+
+		if ( '' === $theme ) {
 			return response()->json( [
 				'message' => 'A theme is required to identify the template part.',
-				'errors'  => [ 'theme' => [ 'The theme query parameter is required for site-editor deletes.' ] ],
+				'errors'  => [ 'theme' => [ 'The theme query parameter is required for site-editor deletes when no theme is active.' ] ],
 			], Response::HTTP_UNPROCESSABLE_ENTITY );
 		}
 
@@ -347,6 +371,32 @@ class TemplatePartController extends Controller
 		}
 
 		return app()->bound( self::CMS_RESOLVER_BINDING );
+	}
+
+	/**
+	 * Resolve the active theme slug through cms-framework's `ThemeManager`
+	 * when available. Used as the fallback for slug-branch upserts and
+	 * destroys when the request omits an explicit theme. Mirrors
+	 * {@see TemplateController::activeThemeSlug()} and
+	 * {@see GlobalStylesController::activeTheme()}.
+	 *
+	 * @since 1.0.0
+	 */
+	protected function activeThemeSlug(): ?string
+	{
+		$themeManagerFqcn = 'ArtisanPackUI\\CMSFramework\\Modules\\Themes\\Managers\\ThemeManager';
+
+		if ( ! class_exists( $themeManagerFqcn ) || ! app()->bound( $themeManagerFqcn ) ) {
+			return null;
+		}
+
+		$theme = app( $themeManagerFqcn )->getActiveTheme();
+
+		if ( ! is_array( $theme ) || empty( $theme['slug'] ) || ! is_string( $theme['slug'] ) ) {
+			return null;
+		}
+
+		return $theme['slug'];
 	}
 
 	/**

--- a/src/Http/Controllers/SiteEditor/TemplatePartController.php
+++ b/src/Http/Controllers/SiteEditor/TemplatePartController.php
@@ -202,21 +202,20 @@ class TemplatePartController extends Controller
 			$existing = $model::query()->where( 'theme', $theme )->where( 'slug', $slug )->first();
 
 			if ( null === $existing ) {
-				$attributes         = $this->modelAttributesFromRequest( $validated );
-				$attributes['slug'] = $slug;
+				// File→DB upsert: editor save payloads commonly omit
+				// every field except `content`. Seed defaults from the
+				// file-source resolved part (title, description, area,
+				// etc.) before layering user-supplied changes on top,
+				// so NOT NULL columns like `title` and `area` always
+				// carry a value (#438).
+				$fileDefaults = $this->fileSourceDefaults( $slug );
 
-				// Area is required to create a new part record. When the
-				// editor upserts a file-only part it doesn't repeat the
-				// `area` field; fall back to the resolver's view of the
-				// existing file-source part (which infers area from the
-				// slug or `theme.json`) before bailing with 422 (#438).
-				if ( ! array_key_exists( 'area', $attributes ) ) {
-					$resolved = $this->resolver->find( $slug );
-
-					if ( $resolved instanceof ResolvedTemplatePart ) {
-						$attributes['area'] = $resolved->area;
-					}
-				}
+				$attributes = array_merge(
+					$fileDefaults,
+					$this->modelAttributesFromRequest( $validated ),
+				);
+				$attributes['slug']  = $slug;
+				$attributes['theme'] = $theme;
 
 				if ( ! array_key_exists( 'area', $attributes ) ) {
 					return response()->json( [
@@ -371,6 +370,33 @@ class TemplatePartController extends Controller
 		}
 
 		return app()->bound( self::CMS_RESOLVER_BINDING );
+	}
+
+	/**
+	 * Seed model attributes for a brand-new file→DB upsert from the
+	 * file-source resolved part. Mirrors
+	 * {@see TemplateController::fileSourceDefaults()} but additionally
+	 * carries the `area` enum since template parts require it.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<string, mixed>
+	 */
+	protected function fileSourceDefaults( string $slug ): array
+	{
+		$resolved = $this->resolver->find( $slug );
+
+		if ( ! $resolved instanceof ResolvedTemplatePart ) {
+			return [];
+		}
+
+		return [
+			'title'       => $resolved->title,
+			'description' => $resolved->description,
+			'status'      => $resolved->status,
+			'is_custom'   => $resolved->isCustom,
+			'area'        => $resolved->area,
+		];
 	}
 
 	/**

--- a/src/Http/Controllers/SiteEditor/TemplatePartController.php
+++ b/src/Http/Controllers/SiteEditor/TemplatePartController.php
@@ -56,13 +56,28 @@ class TemplatePartController extends Controller
 	/**
 	 * GET `/visual-editor/api/template-parts` — list parts for the active theme.
 	 *
+	 * Honors the `area` query param (the navigator's Header / Footer /
+	 * Sidebar / General filter chips). Without it the chips were
+	 * cosmetic — every part showed under every chip (#438). Mirrors the
+	 * `source` / `synced` filtering already in
+	 * {@see PatternController::index()}.
+	 *
 	 * @since 1.0.0
 	 */
-	public function index(): JsonResponse
+	public function index( Request $request ): JsonResponse
 	{
-		$adapter = new TemplatePartAdapter();
+		$parts = $this->resolver->all();
 
-		return response()->json( $adapter->collection( $this->resolver->all() ) );
+		$area = trim( (string) $request->query( 'area', '' ) );
+
+		if ( '' !== $area ) {
+			$parts = array_filter(
+				$parts,
+				static fn ( ResolvedTemplatePart $part ): bool => $part->area === $area,
+			);
+		}
+
+		return response()->json( ( new TemplatePartAdapter() )->collection( $parts ) );
 	}
 
 	/**
@@ -98,11 +113,26 @@ class TemplatePartController extends Controller
 			return $this->cmsFrameworkUnavailable();
 		}
 
+		$validated = $request->validated();
+
+		// The site editor only ever resolves parts for the *active*
+		// theme — cms-framework's resolver scopes its DB query to it. A
+		// part created under any other theme is invisible to the
+		// navigator and to save/load, so prefer the active theme here.
+		// The request's `theme` (sourced from the mount point's stale
+		// `data-theme` attribute) is only a fallback for standalone
+		// installs with no ThemeManager bound. Mirrors the theme
+		// inference applied to update()/destroy() in #438.
+		//
+		// `StoreTemplatePartRequest` requires `theme`, so the fallback
+		// is always a non-empty string — no empty-theme guard needed.
+		$validated['theme'] = $this->activeThemeSlug() ?? $validated['theme'];
+
 		$model = self::CMS_TEMPLATE_PART_FQCN;
 
 		try {
 			/** @var object $part */
-			$part = $model::create( $this->modelAttributesFromRequest( $request->validated() ) );
+			$part = $model::create( $this->modelAttributesFromRequest( $validated ) );
 		} catch ( QueryException $e ) {
 			if ( $this->isUniqueViolation( $e ) ) {
 				return response()->json( [
@@ -118,10 +148,20 @@ class TemplatePartController extends Controller
 
 		$resolved = $this->resolver->find( (string) $part->slug );
 
+		// The row was created but the resolver can't see it — a
+		// server-side inconsistency, not a client error. Returning 201
+		// with this body would hand the editor a record with no `id`,
+		// which it then dereferences into `/template-parts/undefined`
+		// (#438).
+		if ( ! $resolved instanceof ResolvedTemplatePart ) {
+			return response()->json(
+				[ 'message' => 'Template part created but could not be resolved.' ],
+				Response::HTTP_INTERNAL_SERVER_ERROR,
+			);
+		}
+
 		return response()->json(
-			$resolved instanceof ResolvedTemplatePart
-				? ( new TemplatePartAdapter() )->toArray( $resolved )
-				: [ 'message' => 'Template part created but could not be resolved.' ],
+			( new TemplatePartAdapter() )->toArray( $resolved ),
 			Response::HTTP_CREATED,
 		);
 	}

--- a/src/Http/Controllers/SiteEditor/TemplatePartController.php
+++ b/src/Http/Controllers/SiteEditor/TemplatePartController.php
@@ -144,8 +144,9 @@ class TemplatePartController extends Controller
 		// H7 (#432). Numeric URL parameter → primary-key update on
 		// the row that already knows its `(theme, slug, area)`. Slug
 		// path keeps the existing upsert behavior so a theme-only
-		// part can be DB-overridden through a PUT.
-		if ( ctype_digit( $slug ) ) {
+		// part can be DB-overridden through a PUT. `0` is the file-only
+		// sentinel and must fall through to the slug branch (#438).
+		if ( ctype_digit( $slug ) && (int) $slug > 0 ) {
 			$existing = $model::query()->find( (int) $slug );
 
 			if ( null === $existing ) {
@@ -265,8 +266,9 @@ class TemplatePartController extends Controller
 
 		// H7 (#432). Numeric URL parameter → primary-key delete; the
 		// row owns its theme so the `?theme=` collision risk doesn't
-		// apply. Slug path keeps the `?theme=` requirement.
-		if ( ctype_digit( $slug ) ) {
+		// apply. Slug path keeps the `?theme=` requirement. `0` is the
+		// file-only sentinel and must fall through (#438).
+		if ( ctype_digit( $slug ) && (int) $slug > 0 ) {
 			$existing = $model::query()->find( (int) $slug );
 
 			if ( null === $existing ) {
@@ -320,7 +322,8 @@ class TemplatePartController extends Controller
 	 */
 	protected function findTemplatePartByIdOrSlug( string $input ): ?ResolvedTemplatePart
 	{
-		if ( ctype_digit( $input ) ) {
+		// `0` is the file-only sentinel and must fall through (#438).
+		if ( ctype_digit( $input ) && (int) $input > 0 ) {
 			$id = (int) $input;
 
 			foreach ( $this->resolver->all() as $candidate ) {

--- a/src/Http/Requests/SiteEditor/StoreMenuRequest.php
+++ b/src/Http/Requests/SiteEditor/StoreMenuRequest.php
@@ -37,9 +37,18 @@ class StoreMenuRequest extends FormRequest
 	public function rules(): array
 	{
 		return [
-			'theme'          => [ 'required', 'string', 'max:191' ],
+			// `theme` is optional at the request layer and resolved
+			// server-side through cms-framework's active ThemeManager
+			// when omitted, matching the editor save flow that doesn't
+			// repeat the active theme on every payload (#438).
+			'theme'          => [ 'sometimes', 'string', 'max:191' ],
 			'slug'           => [ 'required', 'string', 'max:191' ],
-			'name'           => [ 'required', 'string', 'max:255' ],
+			// Accept either `name` (model-shape) or `title` (WP REST
+			// shape — what the editor's create-menu dialog sends).
+			// At least one must be present; the controller picks
+			// whichever it finds and maps to the model's `name` column.
+			'name'           => [ 'sometimes', 'string', 'max:255' ],
+			'title'          => [ 'sometimes', 'string', 'max:255' ],
 			'description'    => [ 'nullable', 'string' ],
 			'auto_add_pages' => [ 'sometimes', 'boolean' ],
 		];

--- a/src/Http/Requests/SiteEditor/UpdateMenuRequest.php
+++ b/src/Http/Requests/SiteEditor/UpdateMenuRequest.php
@@ -37,7 +37,11 @@ class UpdateMenuRequest extends FormRequest
 		return [
 			'theme'          => [ 'sometimes', 'string', 'max:191' ],
 			'slug'           => [ 'sometimes', 'string', 'max:191' ],
+			// Accept either `name` (model shape) or `title` (WP REST shape
+			// — what the editor's update flow sends). The controller maps
+			// `title` → `name` via `modelAttributesFromRequest`.
 			'name'           => [ 'sometimes', 'string', 'max:255' ],
+			'title'          => [ 'sometimes', 'string', 'max:255' ],
 			'description'    => [ 'nullable', 'string' ],
 			'auto_add_pages' => [ 'sometimes', 'boolean' ],
 		];

--- a/src/Http/Resources/Adapters/CmsFramework/SiteEditor/MenuAdapter.php
+++ b/src/Http/Resources/Adapters/CmsFramework/SiteEditor/MenuAdapter.php
@@ -47,7 +47,7 @@ class MenuAdapter
 	public function toArray( ResolvedMenu $menu ): array
 	{
 		return [
-			'id'     => $menu->wpId ?? $menu->location,
+			'id'     => $menu->wpId > 0 ? $menu->wpId : $menu->location,
 			'slug'   => $menu->location,
 			'type'   => 'wp_navigation',
 			'status' => 'publish',

--- a/src/Http/Resources/Adapters/CmsFramework/SiteEditor/PatternAdapter.php
+++ b/src/Http/Resources/Adapters/CmsFramework/SiteEditor/PatternAdapter.php
@@ -49,7 +49,7 @@ class PatternAdapter
 	public function toArray( ResolvedPattern $pattern ): array
 	{
 		return [
-			'id'          => $pattern->wpId ?? $pattern->slug,
+			'id'          => $pattern->wpId > 0 ? $pattern->wpId : $pattern->slug,
 			'slug'        => $pattern->slug,
 			'type'        => 'wp_block',
 			'status'      => 'publish',

--- a/src/Http/Resources/Adapters/CmsFramework/SiteEditor/TemplateAdapter.php
+++ b/src/Http/Resources/Adapters/CmsFramework/SiteEditor/TemplateAdapter.php
@@ -58,7 +58,7 @@ class TemplateAdapter
 	public function toArray( ResolvedTemplate $template ): array
 	{
 		return [
-			'id'             => $template->wpId ?? $template->slug,
+			'id'             => $template->wpId > 0 ? $template->wpId : $template->slug,
 			'slug'           => $template->slug,
 			'type'           => 'wp_template',
 			'source'         => $template->source,

--- a/tests/Feature/SiteEditor/MenuControllerTest.php
+++ b/tests/Feature/SiteEditor/MenuControllerTest.php
@@ -173,6 +173,27 @@ describe( 'PUT /visual-editor/api/menus/{id}', function (): void {
 		$this->putJson( '/visual-editor/api/menus/9999', [ 'name' => 'Nope' ] )->assertNotFound();
 	} );
 
+	it( 'leaves the theme untouched on a partial update that omits it (#438)', function (): void {
+		// The active-theme fallback in modelAttributesFromRequest() is
+		// create-only. A partial update — here a rename — must not
+		// silently re-home a menu belonging to a non-active theme onto
+		// the active one.
+		$menu = Menu::create( [
+			'theme' => 'other-theme',
+			'slug'  => 'primary',
+			'name'  => 'Primary',
+		] );
+
+		$this->putJson( "/visual-editor/api/menus/{$menu->id}", [
+			'name' => 'Primary Renamed',
+		] )
+			->assertOk()
+			->assertJsonPath( 'name', 'Primary Renamed' )
+			->assertJsonPath( 'theme', 'other-theme' );
+
+		expect( $menu->fresh()->theme )->toBe( 'other-theme' );
+	} );
+
 	it( 'returns 409 when the slug update would collide with another menu in the same theme', function (): void {
 		Menu::create( [ 'theme' => 'digital-shopfront', 'slug' => 'primary', 'name' => 'Primary' ] );
 		$secondary = Menu::create( [ 'theme' => 'digital-shopfront', 'slug' => 'secondary', 'name' => 'Secondary' ] );

--- a/tests/Feature/SiteEditor/MenuControllerTest.php
+++ b/tests/Feature/SiteEditor/MenuControllerTest.php
@@ -110,10 +110,39 @@ describe( 'POST /visual-editor/api/menus', function (): void {
 		] )->assertStatus( 409 );
 	} );
 
-	it( 'returns 422 with explicit validation errors when required fields are missing', function (): void {
-		$this->postJson( '/visual-editor/api/menus', [ 'name' => 'Missing theme + slug' ] )
+	it( 'returns 422 when slug is missing (theme falls back to active)', function (): void {
+		$this->postJson( '/visual-editor/api/menus', [ 'name' => 'Missing slug' ] )
 			->assertStatus( 422 )
-			->assertJsonValidationErrors( [ 'theme', 'slug' ] );
+			->assertJsonValidationErrors( 'slug' );
+	} );
+
+	// #438. The editor's create-menu dialog sends `title`, not `name`,
+	// and never sends `theme`. The controller maps `title` → `name`
+	// and falls back to ThemeManager's active theme.
+	it( 'accepts the WP-shape `title` field and falls back to the active theme (#438)', function (): void {
+		$this->postJson( '/visual-editor/api/menus', [
+			'slug'  => 'primary',
+			'title' => 'Primary Navigation',
+		] )
+			->assertCreated()
+			->assertJsonPath( 'theme', 'digital-shopfront' )
+			->assertJsonPath( 'name', 'Primary Navigation' );
+
+		expect( Menu::query()->where( 'theme', 'digital-shopfront' )->where( 'slug', 'primary' )->first()?->name )
+			->toBe( 'Primary Navigation' );
+	} );
+
+	it( 'returns 422 when theme is missing and no active theme is bound', function (): void {
+		$this->mock( \ArtisanPackUI\CMSFramework\Modules\Themes\Managers\ThemeManager::class, function ( $mock ): void {
+			$mock->shouldReceive( 'getActiveTheme' )->andReturn( null );
+		} );
+
+		$this->postJson( '/visual-editor/api/menus', [
+			'slug'  => 'primary',
+			'title' => 'Primary',
+		] )
+			->assertStatus( 422 )
+			->assertJsonValidationErrors( 'theme' );
 	} );
 } );
 

--- a/tests/Feature/SiteEditor/MenuControllerTest.php
+++ b/tests/Feature/SiteEditor/MenuControllerTest.php
@@ -78,7 +78,11 @@ describe( 'GET /visual-editor/api/menus/{id}', function (): void {
 			->assertJsonPath( 'name', 'Primary Navigation' )
 			->assertJsonPath( 'title.rendered', 'Primary Navigation' )
 			->assertJsonPath( 'type', 'wp_navigation' )
-			->assertJsonPath( 'auto_add_pages', true );
+			->assertJsonPath( 'auto_add_pages', true )
+			// #438. NavigationBrowser dereferences `row.content.blocks`
+			// — the shape must always include an envelope, even empty.
+			->assertJsonPath( 'content.raw', '' )
+			->assertJsonPath( 'content.blocks', [] );
 	} );
 
 	it( 'returns 404 when no menu matches the id', function (): void {

--- a/tests/Feature/SiteEditor/TemplateControllerTest.php
+++ b/tests/Feature/SiteEditor/TemplateControllerTest.php
@@ -78,6 +78,37 @@ describe( 'GET /visual-editor/api/templates', function (): void {
 			->assertJsonPath( '0.type', 'wp_template' )
 			->assertJsonPath( '0.title.rendered', 'Single' );
 	} );
+
+	it( 'filters the list by the status query param', function (): void {
+		foreach ( [ 'published-tpl' => 'publish', 'draft-tpl' => 'draft' ] as $slug => $status ) {
+			Template::create( [
+				'theme'         => 'digital-shopfront',
+				'slug'          => $slug,
+				'title'         => ucfirst( $slug ),
+				'description'   => '',
+				'status'        => $status,
+				'is_custom'     => false,
+				'block_content' => [],
+				'author_id'     => null,
+			] );
+		}
+
+		rebuildSiteEditorResolversForTest();
+
+		// Without the `status` filter the navigator's Published / Draft
+		// chips were cosmetic — every template showed under every chip
+		// (#438).
+		$this->getJson( '/visual-editor/api/templates?status=draft' )
+			->assertOk()
+			->assertJsonCount( 1 )
+			->assertJsonPath( '0.slug', 'draft-tpl' )
+			->assertJsonPath( '0.status', 'draft' );
+
+		// No `status` param → unfiltered, both templates surface.
+		$this->getJson( '/visual-editor/api/templates' )
+			->assertOk()
+			->assertJsonCount( 2 );
+	} );
 } );
 
 describe( 'GET /visual-editor/api/templates/{slug}', function (): void {
@@ -139,7 +170,7 @@ describe( 'POST /visual-editor/api/templates', function (): void {
 		// (per ResolvedEntity §raw docblock), so the response surfaces
 		// `content.blocks` from the resolver and `content.raw` stays
 		// empty for DB-stored entities. Asserts mirror that contract.
-		$this->postJson( '/visual-editor/api/templates', [
+		$response = $this->postJson( '/visual-editor/api/templates', [
 			'slug'    => 'archive',
 			'title'   => 'Archive',
 			'theme'   => 'digital-shopfront',
@@ -149,13 +180,43 @@ describe( 'POST /visual-editor/api/templates', function (): void {
 					[ 'name' => 'core/archives', 'attributes' => [ 'showLabel' => true ], 'innerBlocks' => [] ],
 				],
 			],
-		] )
+		] );
+
+		$response
 			->assertCreated()
 			->assertJsonPath( 'slug', 'archive' )
 			->assertJsonPath( 'title.raw', 'Archive' )
 			->assertJsonPath( 'content.blocks.0.name', 'core/archives' );
 
+		// The editor dereferences `entity.id` straight after create to
+		// navigate to the new template. A missing / zero id sends it to
+		// `/templates/undefined` (#438) — the response MUST carry a
+		// usable id.
+		$id = $response->json( 'id' );
+		expect( $id )->not->toBeNull()
+			->and( $id )->not->toBe( 0 );
+
 		expect( Template::query()->where( 'slug', 'archive' )->exists() )->toBeTrue();
+	} );
+
+	it( 'creates the template under the active theme, ignoring a stale request theme', function (): void {
+		// The site editor's mount point can carry a stale `data-theme`
+		// attribute, so the create payload's `theme` may not match the
+		// active theme. cms-framework's resolver only sees templates for
+		// the active theme — creating under any other theme yields an
+		// unresolvable template. store() must prefer the active theme (#438).
+		$response = $this->postJson( '/visual-editor/api/templates', [
+			'slug'  => 'search',
+			'title' => 'Search',
+			'theme' => 'some-stale-theme',
+		] );
+
+		$response->assertCreated()->assertJsonPath( 'slug', 'search' );
+
+		// Persisted under the active theme (mocked to digital-shopfront),
+		// not the stale value from the request body.
+		expect( Template::query()->where( 'slug', 'search' )->value( 'theme' ) )
+			->toBe( 'digital-shopfront' );
 	} );
 
 	it( 'returns 409 on a duplicate (theme, slug) write', function (): void {

--- a/tests/Feature/SiteEditor/TemplateControllerTest.php
+++ b/tests/Feature/SiteEditor/TemplateControllerTest.php
@@ -232,9 +232,28 @@ describe( 'PUT /visual-editor/api/templates/{slug}', function (): void {
 		] )->assertStatus( 422 );
 	} );
 
-	it( 'returns 422 when the theme is missing', function (): void {
+	// #438. When the body omits `theme`, the controller falls back to
+	// cms-framework's active theme via ThemeManager — the editor save
+	// payload doesn't carry `theme` and shouldn't have to.
+	it( 'falls back to the active theme when the body omits theme (#438)', function (): void {
+		$this->putJson( '/visual-editor/api/templates/falls-back', [ 'title' => 'Falls back' ] )
+			->assertOk()
+			->assertJsonPath( 'theme', 'digital-shopfront' );
+
+		expect( Template::query()->where( 'theme', 'digital-shopfront' )->where( 'slug', 'falls-back' )->exists() )
+			->toBeTrue();
+	} );
+
+	it( 'returns 422 when the body omits theme and no active theme is bound', function (): void {
+		// Re-bind ThemeManager to a no-active-theme stub so the fallback
+		// returns null and the 422 path actually fires.
+		$this->mock( ThemeManager::class, function ( $mock ): void {
+			$mock->shouldReceive( 'getActiveTheme' )->andReturn( null );
+		} );
+
 		$this->putJson( '/visual-editor/api/templates/single', [ 'title' => 'No theme' ] )
-			->assertStatus( 422 );
+			->assertStatus( 422 )
+			->assertJsonValidationErrors( 'theme' );
 	} );
 
 	// H7 (#432). With a numeric URL parameter the controller resolves
@@ -304,8 +323,34 @@ describe( 'DELETE /visual-editor/api/templates/{slug}', function (): void {
 			->and( Template::query()->where( 'theme', 'other-theme' )->where( 'slug', 'archive' )->exists() )->toBeTrue();
 	} );
 
-	it( 'returns 422 when the theme query parameter is missing', function (): void {
-		$this->deleteJson( '/visual-editor/api/templates/archive' )->assertStatus( 422 );
+	// #438. When the request omits `?theme=`, the controller falls back
+	// to cms-framework's active theme — the editor's revert action
+	// doesn't include the theme query param.
+	it( 'falls back to the active theme when ?theme= is omitted (#438)', function (): void {
+		Template::create( [
+			'theme'         => 'digital-shopfront',
+			'slug'          => 'archive',
+			'title'         => 'Archive',
+			'status'        => 'publish',
+			'is_custom'     => false,
+			'block_content' => [],
+			'author_id'     => null,
+		] );
+
+		$this->deleteJson( '/visual-editor/api/templates/archive' )->assertNoContent();
+
+		expect( Template::query()->where( 'theme', 'digital-shopfront' )->where( 'slug', 'archive' )->exists() )
+			->toBeFalse();
+	} );
+
+	it( 'returns 422 when ?theme= is omitted and no active theme is bound', function (): void {
+		$this->mock( ThemeManager::class, function ( $mock ): void {
+			$mock->shouldReceive( 'getActiveTheme' )->andReturn( null );
+		} );
+
+		$this->deleteJson( '/visual-editor/api/templates/archive' )
+			->assertStatus( 422 )
+			->assertJsonValidationErrors( 'theme' );
 	} );
 
 	it( 'returns 404 when no DB override matches the (theme, slug)', function (): void {

--- a/tests/Feature/SiteEditor/TemplatePartControllerTest.php
+++ b/tests/Feature/SiteEditor/TemplatePartControllerTest.php
@@ -306,7 +306,31 @@ describe( 'DELETE /visual-editor/api/template-parts/{slug}', function (): void {
 			->and( TemplatePart::query()->where( 'theme', 'other-theme' )->where( 'slug', 'header' )->exists() )->toBeTrue();
 	} );
 
-	it( 'returns 422 when the theme query parameter is missing', function (): void {
+	// #438. When the request omits `?theme=`, the controller falls back
+	// to cms-framework's active theme — the editor's revert action
+	// doesn't include the theme query param.
+	it( 'falls back to the active theme when ?theme= is omitted (#438)', function (): void {
+		TemplatePart::create( [
+			'theme'         => 'digital-shopfront',
+			'slug'          => 'header',
+			'area'          => 'header',
+			'title'         => 'Header',
+			'is_custom'     => false,
+			'block_content' => [],
+			'author_id'     => null,
+		] );
+
+		$this->deleteJson( '/visual-editor/api/template-parts/header' )->assertNoContent();
+
+		expect( TemplatePart::query()->where( 'theme', 'digital-shopfront' )->where( 'slug', 'header' )->exists() )
+			->toBeFalse();
+	} );
+
+	it( 'returns 422 when ?theme= is omitted and no active theme is bound', function (): void {
+		$this->mock( ThemeManager::class, function ( $mock ): void {
+			$mock->shouldReceive( 'getActiveTheme' )->andReturn( null );
+		} );
+
 		$this->deleteJson( '/visual-editor/api/template-parts/header' )
 			->assertStatus( 422 )
 			->assertJsonValidationErrors( 'theme' );

--- a/tests/Feature/SiteEditor/TemplatePartControllerTest.php
+++ b/tests/Feature/SiteEditor/TemplatePartControllerTest.php
@@ -71,6 +71,37 @@ describe( 'GET /visual-editor/api/template-parts', function (): void {
 			->assertJsonPath( '0.type', 'wp_template_part' )
 			->assertJsonPath( '0.area', 'header' );
 	} );
+
+	it( 'filters the list by the area query param', function (): void {
+		foreach ( [ 'site-header' => 'header', 'site-footer' => 'footer' ] as $slug => $area ) {
+			TemplatePart::create( [
+				'theme'         => 'digital-shopfront',
+				'slug'          => $slug,
+				'title'         => ucfirst( $area ),
+				'area'          => $area,
+				'status'        => 'publish',
+				'is_custom'     => false,
+				'block_content' => [],
+				'author_id'     => null,
+			] );
+		}
+
+		rebuildSiteEditorResolversForPartTest();
+
+		// Without the `area` filter the navigator's Header / Footer /
+		// Sidebar chips were cosmetic — every part showed under every
+		// chip (#438).
+		$this->getJson( '/visual-editor/api/template-parts?area=header' )
+			->assertOk()
+			->assertJsonCount( 1 )
+			->assertJsonPath( '0.slug', 'site-header' )
+			->assertJsonPath( '0.area', 'header' );
+
+		// No `area` param → unfiltered, both parts surface.
+		$this->getJson( '/visual-editor/api/template-parts' )
+			->assertOk()
+			->assertJsonCount( 2 );
+	} );
 } );
 
 describe( 'GET /visual-editor/api/template-parts/{slug}', function (): void {
@@ -127,7 +158,7 @@ describe( 'GET /visual-editor/api/template-parts/{slug}', function (): void {
 
 describe( 'POST /visual-editor/api/template-parts', function (): void {
 	it( 'creates a DB-stored part and returns the resolved record', function (): void {
-		$this->postJson( '/visual-editor/api/template-parts', [
+		$response = $this->postJson( '/visual-editor/api/template-parts', [
 			'slug'    => 'sidebar',
 			'title'   => 'Sidebar',
 			'area'    => 'sidebar',
@@ -136,13 +167,44 @@ describe( 'POST /visual-editor/api/template-parts', function (): void {
 				'raw'    => '',
 				'blocks' => [ [ 'name' => 'core/navigation', 'attributes' => [], 'innerBlocks' => [] ] ],
 			],
-		] )
+		] );
+
+		$response
 			->assertCreated()
 			->assertJsonPath( 'slug', 'sidebar' )
 			->assertJsonPath( 'area', 'sidebar' )
 			->assertJsonPath( 'content.blocks.0.name', 'core/navigation' );
 
+		// The editor dereferences `entity.id` straight after create to
+		// navigate to the new part. A missing / zero id sends it to
+		// `/template-parts/undefined` (#438) — the response MUST carry a
+		// usable id.
+		$id = $response->json( 'id' );
+		expect( $id )->not->toBeNull()
+			->and( $id )->not->toBe( 0 );
+
 		expect( TemplatePart::query()->where( 'slug', 'sidebar' )->exists() )->toBeTrue();
+	} );
+
+	it( 'creates the part under the active theme, ignoring a stale request theme', function (): void {
+		// The site editor's mount point can carry a stale `data-theme`
+		// attribute, so the create payload's `theme` may not match the
+		// active theme. cms-framework's resolver only sees parts for the
+		// active theme — creating under any other theme yields an
+		// unresolvable part. store() must prefer the active theme (#438).
+		$response = $this->postJson( '/visual-editor/api/template-parts', [
+			'slug'  => 'footer',
+			'title' => 'Footer',
+			'area'  => 'footer',
+			'theme' => 'some-stale-theme',
+		] );
+
+		$response->assertCreated()->assertJsonPath( 'slug', 'footer' );
+
+		// Persisted under the active theme (mocked to digital-shopfront),
+		// not the stale value from the request body.
+		expect( TemplatePart::query()->where( 'slug', 'footer' )->value( 'theme' ) )
+			->toBe( 'digital-shopfront' );
 	} );
 
 	it( 'rejects unknown areas at validation', function (): void {

--- a/tests/Unit/VisualEditor/SiteEditor/Adapters/MenuAdapterTest.php
+++ b/tests/Unit/VisualEditor/SiteEditor/Adapters/MenuAdapterTest.php
@@ -48,6 +48,12 @@ describe( 'single-record envelope', function (): void {
 			->and( $out['slug'] )->toBe( 'primary' );
 	} );
 
+	it( 'falls back from `wpId = 0` (no-record sentinel) to location for `id` (#438)', function (): void {
+		$out = ( new MenuAdapter() )->toArray( makeResolvedMenu( [ 'wpId' => 0 ] ) );
+
+		expect( $out['id'] )->toBe( 'primary' );
+	} );
+
 	it( 'forwards items as-is for the inspector to render without parse round-trip', function (): void {
 		$items = [
 			[ 'label' => 'Blog', 'url' => '/blog', 'type' => 'link', 'classes' => 'has-icon' ],

--- a/tests/Unit/VisualEditor/SiteEditor/Adapters/PatternAdapterTest.php
+++ b/tests/Unit/VisualEditor/SiteEditor/Adapters/PatternAdapterTest.php
@@ -68,6 +68,17 @@ describe( 'single-record envelope', function (): void {
 			->and( $out['synced'] )->toBeTrue();
 	} );
 
+	it( 'falls back from `wpId = 0` (theme-source sentinel) to slug for `id` (#438)', function (): void {
+		$pattern = makeResolvedPattern( [
+			'wpId' => 0,
+			'slug' => 'hero-banner',
+		] );
+
+		$out = ( new PatternAdapter() )->toArray( $pattern );
+
+		expect( $out['id'] )->toBe( 'hero-banner' );
+	} );
+
 	it( 'preserves empty category and block_type lists', function (): void {
 		$pattern = makeResolvedPattern( [ 'categories' => [], 'blockTypes' => [] ] );
 

--- a/tests/Unit/VisualEditor/SiteEditor/Adapters/TemplateAdapterTest.php
+++ b/tests/Unit/VisualEditor/SiteEditor/Adapters/TemplateAdapterTest.php
@@ -95,6 +95,17 @@ describe( 'single-record envelope', function (): void {
 			->and( $out['content']['blocks'] )->toHaveCount( 1 );
 	} );
 
+	it( 'falls back from `wpId = 0` (file-only sentinel) to slug for `id` (#438)', function (): void {
+		$template = makeResolvedTemplate( [
+			'wpId' => 0,
+			'slug' => 'page',
+		] );
+
+		$out = ( new TemplateAdapter() )->toArray( $template );
+
+		expect( $out['id'] )->toBe( 'page' );
+	} );
+
 	it( 'reports `origin` as null for custom templates with no theme backing', function (): void {
 		$template = makeResolvedTemplate( [
 			'isCustom'     => true,


### PR DESCRIPTION
## Description

Fixes the site-editor `id: 0` bug for file-only resources, plus two follow-ups surfaced while verifying the fix against a real CMS (Keystone) rather than the dev-app.

The first 5 commits are cherry-picked verbatim from the H8 branch (`feature/433-h8-sample-theme-docs`), which carried the original #438 fix because H8 couldn't be validated without it. Extracting them onto a dedicated branch decouples #438 from H8, exactly as the issue says it should ("the bug is independent and should be tracked here"). The 6th commit is the new follow-up work.

**Closes:** #438

## Type of Change

- [x] Bug fix (fixes an issue)

## Related Issue

**Issue:** #438

## Motivation and Context

File-only templates and template parts serialized with `id: 0` because three adapters used `??` (null coalescing) to fall back from `wpId` to `slug` — but `ResolvedEntity::wpId()` returns `0`, not `null`, when there's no backing DB row. Saving a file-only resource then sent `PUT /template-parts/0`, silently routing to the wrong resource or 404ing.

Manual verification against Keystone surfaced two more bugs the dev-app papered over: `store()` could return a record with no usable `id`, and the navigator's filter chips were cosmetic (the list endpoints ignored their query params).

## Changes Made

**Original #438 fix (commits 1–5, cherry-picked from the H8 branch):**
- `TemplateAdapter` / `PatternAdapter` / `MenuAdapter` — `??` → `wpId > 0 ? wpId : slug`, so file-only resources serialize `id: <slug>`
- `TemplateController::findTemplateByIdOrSlug()` + `update()` + `destroy()` — reject `0` as a numeric id, fall through to slug lookup
- `TemplateController` / `TemplatePartController` — infer `theme` from `ThemeManager::getActiveTheme()` and `area` from the resolver when the save payload omits them; seed title/description/status from the file-source entity so file→DB upserts don't hit NOT NULL violations
- `MenuController` + `StoreMenuRequest` / `UpdateMenuRequest` — accept WP-REST-shape payloads (`title`→`name`, active-theme fallback); include an empty content envelope in the menu shape so the NavigationBrowser doesn't WSOD on freshly-created menus

**Follow-ups (commit 6):**
- `store()` hardening (Template / TemplatePart / Pattern controllers): resolve `theme` via `activeThemeSlug()` with the request body as fallback — the site editor only resolves entities for the active theme, so a row created under any other theme is invisible. Return HTTP 500 instead of 201 when the created row can't be resolved (the old 201-with-`{message}`-body handed the editor `entity.id === undefined` → `GET /template-parts/undefined` → 404).
- `index()` filtering (Template / TemplatePart controllers): honor the `status` (templates) and `area` (parts) query params. Both previously ignored all query params, making the navigator's filter chips cosmetic. Mirrors the `source`/`synced` filtering already in `PatternController::index()`.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS
- PHP Version: 8.4
- Project Version: release/1.0

**Tests Performed:**
1. `./vendor/bin/pest` — 571 passed (1554 assertions); 4 new tests (id-presence on create, create-under-active-theme, area/status filtering)
2. Manual verification in a Keystone CMS instance running the site editor:
   - File-only `header` part from a theme serializes `id: header` (not `id: 0`), round-trips on edit/save
   - Creating a new template part shows it in the navigator with a usable id (no `/undefined` 404)
   - Navigator Header/Footer/Sidebar/General chips filter parts by area; Published/Draft chips filter templates by status
3. Local `coderabbit review` — the review service timed out / hung repeatedly today; skipped the local pre-pass. The automatic CodeRabbit review on this PR covers it.

## Accessibility Tests Run

- [x] N/A — backend-only change (PHP controllers + adapters). No UI surface modified; the frontend changes in the cherry-picked menu commit are defensive null-checks, no markup/interaction change.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:** 571 tests / 1554 assertions green. New cases: `id` presence on create responses (closes the coverage gap #438 itself flagged), "creates under active theme ignoring a stale request theme" for templates + parts, and "filters by area/status query param" for parts + templates.

## Documentation

- [x] Inline code documentation added — docblocks on the changed `store()` / `index()` methods explain the theme-inference and filter rationale.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [ ] CodeRabbit local pre-pass — review service was down today; deferring to the automatic PR review
- [x] Accessibility tests completed (N/A — backend only)
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

## Reviewer Notes

- The `store()` 500-on-unresolvable branch should be effectively unreachable now that theme inference is in place — it's a defensive guard against a server-side inconsistency, not an expected path. It exists specifically so the editor never again receives a 201 with no `id`.
- `store()` deliberately *prefers* the active theme over the request's `theme`. For the site editor this is correct — a new entity belongs to the theme being edited; the request's `theme` (sourced from the mount point's `data-theme` attribute) can be stale. This inverts the priority used in `update()`/`destroy()`, where the request theme identifies an *existing* row — that asymmetry is intentional.
- The H8 branch still contains these same 5 commits. Once this merges, H8 should be rebased onto the updated `release/1.0` to drop them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added filtering for templates by status and template parts by area.
  * Menu API accepts both title and name for compatibility.

* **Bug Fixes**
  * Always include empty content envelope in menu responses.
  * Defensive handling when content is missing to avoid crashes.
  * Prevent zero/invalid IDs from propagating as real IDs.
  * Stronger active-theme fallback and clearer error responses on create/update.

* **Tests**
  * Expanded integration and unit coverage for filtering, id fallbacks, field mapping, and theme fallback.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArtisanPack-UI/visual-editor/pull/444)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->