### PR TITLE
fix(site-editor): inline the canvas stylesheet so the canvas isn't browser-default serif

### DIFF
--- a/resources/js/visual-editor/site-editor/__tests__/canvas-frame.test.tsx
+++ b/resources/js/visual-editor/site-editor/__tests__/canvas-frame.test.tsx
@@ -35,7 +35,7 @@ vi.mock('@wordpress/components', () => {
 import { CanvasFrame } from '../canvas-frame';
 
 describe('CanvasFrame', () => {
-    it('renders the canvas wrapper and the empty state when no entity is selected', () => {
+    it('renders the empty state outside the BlockCanvas iframe when no entity is selected (#418)', () => {
         render(<CanvasFrame sectionLabel="Editing: Templates" />);
 
         const canvas = screen.getByTestId('ap-site-editor-canvas');
@@ -49,26 +49,30 @@ describe('CanvasFrame', () => {
         expect(emptyState).toHaveTextContent(
             'Select an entity from the navigator to start editing.'
         );
+
+        // #418: the placeholder must NOT render inside `BlockCanvas` —
+        // the iframe doesn't inherit `canvas-frame.css` or the SPA body
+        // font, so an iframed placeholder lost its centering and fell
+        // back to browser-default serif. No entity → no iframe.
+        expect(
+            screen.queryByTestId('ap-stub-block-canvas')
+        ).not.toBeInTheDocument();
+        expect(
+            screen.queryByTestId('ap-stub-block-editor-provider')
+        ).not.toBeInTheDocument();
     });
 
-    it('mounts the BlockCanvas and provider chain', () => {
-        render(<CanvasFrame sectionLabel="Editing: Styles" />);
-
-        expect(
-            screen.getByTestId('ap-stub-block-editor-provider')
-        ).toBeInTheDocument();
-        expect(
-            screen.getByTestId('ap-stub-block-canvas')
-        ).toBeInTheDocument();
-    });
-
-    it('renders supplied children inside the canvas when hasEntity is true', () => {
+    it('mounts the BlockCanvas + provider chain and renders children when hasEntity is true', () => {
         render(
             <CanvasFrame sectionLabel="Editing: Patterns" hasEntity>
                 <div data-testid="ap-test-entity">My pattern</div>
             </CanvasFrame>
         );
 
+        expect(
+            screen.getByTestId('ap-stub-block-editor-provider')
+        ).toBeInTheDocument();
+        expect(screen.getByTestId('ap-stub-block-canvas')).toBeInTheDocument();
         expect(screen.getByTestId('ap-test-entity')).toBeInTheDocument();
         expect(
             screen.queryByTestId('ap-site-editor-canvas-empty')

--- a/resources/js/visual-editor/site-editor/__tests__/entity-editor.test.tsx
+++ b/resources/js/visual-editor/site-editor/__tests__/entity-editor.test.tsx
@@ -189,6 +189,42 @@ describe('useEntityEditorViews', () => {
         ).toBeInTheDocument();
     });
 
+    it('inlines the default canvas stylesheet into the canvas surface (#418)', async () => {
+        FETCH_MOCK.mockResolvedValue({
+            id: 7,
+            slug: 'single',
+            title: { rendered: 'Single post' },
+            description: '',
+            content: { raw: '', blocks: [] },
+            status: 'publish',
+            theme: 'default',
+            type: 'wp_template',
+            source: 'custom',
+            origin: null,
+        });
+
+        render(<Harness entityId="7" onState={vi.fn()} />);
+
+        await waitFor(() =>
+            expect(
+                screen.getByTestId('ap-site-editor-entity-canvas')
+            ).toBeInTheDocument()
+        );
+
+        // Gutenberg's `settings.styles` only reaches an iframed canvas;
+        // this editor renders in-tree, so the stylesheet must be inlined
+        // into the `editor-styles-wrapper` surface — otherwise the
+        // canvas (and inlined core/template-part inner blocks) fall back
+        // to browser-default serif (#418).
+        const surface = document.querySelector(
+            '.ap-site-editor__entity-canvas-surface'
+        );
+        const style = surface?.querySelector('style');
+
+        expect(style).not.toBeNull();
+        expect(style?.textContent).toContain('.editor-styles-wrapper');
+    });
+
     it('flips the dirty flag through onStateChange when the canvas edits blocks', async () => {
         FETCH_MOCK.mockResolvedValue({
             id: 1,

--- a/resources/js/visual-editor/site-editor/canvas-frame.tsx
+++ b/resources/js/visual-editor/site-editor/canvas-frame.tsx
@@ -81,19 +81,31 @@ export function CanvasFrame(props: CanvasFrameProps): JSX.Element {
             data-has-entity={hasEntity}
             data-testid="ap-site-editor-canvas"
         >
-            <SlotFillProvider>
-                <BlockEditorProvider
-                    value={EMPTY_BLOCKS}
-                    settings={EMPTY_SETTINGS}
-                    onChange={() => undefined}
-                    onInput={() => undefined}
-                >
-                    <BlockCanvas height="100%">
-                        {hasEntity ? children : emptyState}
-                    </BlockCanvas>
-                    <Popover.Slot />
-                </BlockEditorProvider>
-            </SlotFillProvider>
+            {hasEntity ? (
+                <SlotFillProvider>
+                    <BlockEditorProvider
+                        value={EMPTY_BLOCKS}
+                        settings={EMPTY_SETTINGS}
+                        onChange={() => undefined}
+                        onInput={() => undefined}
+                    >
+                        <BlockCanvas height="100%">{children}</BlockCanvas>
+                        <Popover.Slot />
+                    </BlockEditorProvider>
+                </SlotFillProvider>
+            ) : (
+                /*
+                 * #418: the empty-state placeholder renders in the
+                 * parent document, NOT inside `BlockCanvas`'s iframe.
+                 * `canvas-frame.css` and the SPA body font live in the
+                 * parent doc and don't cross into the iframe — rendered
+                 * inside it the placeholder lost its centering and fell
+                 * back to browser-default serif. Iframing only earns
+                 * its keep when there's block content whose styles need
+                 * isolating; an empty-state message is just chrome.
+                 */
+                emptyState
+            )}
         </div>
     );
 }

--- a/resources/js/visual-editor/site-editor/entity-editor-canvas.tsx
+++ b/resources/js/visual-editor/site-editor/entity-editor-canvas.tsx
@@ -27,6 +27,7 @@ import {
 import { __, sprintf } from '@wordpress/i18n';
 import { useMemo, type ReactNode } from 'react';
 
+import { DEFAULT_CANVAS_STYLES } from '../editor-settings';
 import { TEXT_DOMAIN } from '../vendor/i18n';
 
 import './entity-editor-canvas.css';
@@ -102,6 +103,21 @@ export function EntityEditorCanvas(props: EntityEditorCanvasProps): JSX.Element 
             ) : null}
             <div className="ap-site-editor__entity-canvas-body">
                 <div className="editor-styles-wrapper ap-site-editor__entity-canvas-surface">
+                    {/*
+                     * #418: default canvas stylesheet rendered inline.
+                     * Gutenberg's `settings.styles` channel only injects
+                     * into the `<Iframe>` canvas; the site editor renders
+                     * the block list in the same DOM tree, so the rules
+                     * must be inlined here — exactly as the post editor
+                     * (`editor/editor-app.tsx`) does. Without it the
+                     * canvas (and any inlined `core/template-part` inner
+                     * blocks, which render in-tree under this wrapper)
+                     * fall back to browser-default serif. The CSS is
+                     * scoped under `.editor-styles-wrapper`, so a
+                     * theme.json stylesheet appended later wins on
+                     * cascade.
+                     */}
+                    <style>{DEFAULT_CANVAS_STYLES}</style>
                     <BlockTools>
                         <WritingFlow>
                             <ObserveTyping>

--- a/resources/js/visual-editor/site-editor/patterns/__tests__/pattern-canvas.test.tsx
+++ b/resources/js/visual-editor/site-editor/patterns/__tests__/pattern-canvas.test.tsx
@@ -1,0 +1,49 @@
+import { render } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+// `PatternCanvas` is a pure presentational shell post-#436 — the
+// `BlockEditorProvider` lives in `BlockEditorBoundary`, above the
+// canvas. Stub the block-editor primitives so the canvas renders under
+// jsdom without booting the real Gutenberg data store.
+vi.mock('@wordpress/block-editor', () => ({
+    BlockList: (): JSX.Element => <div data-testid="ap-stub-block-list" />,
+    BlockTools: ({ children }: { children?: ReactNode }): JSX.Element => (
+        <div>{children}</div>
+    ),
+    ObserveTyping: ({ children }: { children?: ReactNode }): JSX.Element => (
+        <div>{children}</div>
+    ),
+    WritingFlow: ({ children }: { children?: ReactNode }): JSX.Element => (
+        <div>{children}</div>
+    ),
+}));
+
+import { PatternCanvas } from '../pattern-canvas';
+
+describe('PatternCanvas', () => {
+    it('inlines the default canvas stylesheet into the canvas surface (#418)', () => {
+        render(<PatternCanvas title="Test pattern" synced={false} />);
+
+        // Gutenberg's `settings.styles` only reaches an iframed canvas;
+        // this editor renders in-tree, so the stylesheet must be inlined
+        // into the `editor-styles-wrapper` surface — otherwise the
+        // canvas falls back to browser-default serif (#418).
+        const surface = document.querySelector('.ap-pattern-canvas__surface');
+        const style = surface?.querySelector('style');
+
+        expect(style).not.toBeNull();
+        expect(style?.textContent).toContain('.editor-styles-wrapper');
+    });
+
+    it('renders the loading state without the canvas surface', () => {
+        render(<PatternCanvas title="Test pattern" synced={false} isLoading />);
+
+        expect(
+            document.querySelector('[data-testid="ap-pattern-canvas-loading"]')
+        ).not.toBeNull();
+        expect(
+            document.querySelector('.ap-pattern-canvas__surface')
+        ).toBeNull();
+    });
+});

--- a/resources/js/visual-editor/site-editor/patterns/pattern-canvas.tsx
+++ b/resources/js/visual-editor/site-editor/patterns/pattern-canvas.tsx
@@ -23,6 +23,7 @@ import {
 import { __, sprintf } from '@wordpress/i18n';
 import { useMemo, type ReactNode } from 'react';
 
+import { DEFAULT_CANVAS_STYLES } from '../../editor-settings';
 import { TEXT_DOMAIN } from '../../vendor/i18n';
 
 import './pattern-canvas.css';
@@ -102,6 +103,15 @@ export function PatternCanvas(props: PatternCanvasProps): JSX.Element {
             </div>
             <div className="ap-pattern-canvas__body">
                 <div className="editor-styles-wrapper ap-pattern-canvas__surface">
+                    {/*
+                     * #418: default canvas stylesheet rendered inline —
+                     * see the matching note in `entity-editor-canvas.tsx`.
+                     * Gutenberg's `settings.styles` only reaches the
+                     * `<Iframe>` canvas; this editor renders in-tree, so
+                     * the rules must be inlined or the canvas falls back
+                     * to browser-default serif.
+                     */}
+                    <style>{DEFAULT_CANVAS_STYLES}</style>
                     <BlockTools>
                         <WritingFlow>
                             <ObserveTyping>


### PR DESCRIPTION
## Description

The site-editor canvas rendered block content in browser-default serif instead of the editor's system-sans typography — the serif-vs-sans gap surfaced during the themes + site-editor arc's Slice 1 dogfooding. Two distinct gaps, both rooted in Gutenberg's `settings.styles` channel only reaching an *iframed* canvas.

**Closes:** #418

## Type of Change

- [x] Bug fix (fixes an issue)

## Related Issue

**Issue:** #418

## Motivation and Context

`editorSettings.styles` carries `DEFAULT_CANVAS_STYLES`, but Gutenberg only injects `settings.styles` into an `<Iframe>` canvas. The post editor (`editor/editor-app.tsx`) works around this by *also* inlining `<style>{DEFAULT_CANVAS_STYLES}</style>` directly in its in-tree canvas. The site-editor canvases never did — they were stripped to pure surface shells in #436 — so they fell back to serif.

## Changes Made

**1. Inline the canvas stylesheet in the site-editor canvases**
- `entity-editor-canvas.tsx` and `pattern-canvas.tsx` now inline `<style>{DEFAULT_CANVAS_STYLES}</style>` as the first child of their `editor-styles-wrapper` surface, mirroring `editor-app.tsx`. `DEFAULT_CANVAS_STYLES` is imported from the shared `editor-settings.ts`.
- Because the CSS is scoped under `.editor-styles-wrapper` and inlined `core/template-part` inner blocks render in-tree as descendants of that wrapper, this also fixes the unstyled-inlined-template-part case #418 was specifically filed for.

**2. Move `CanvasFrame`'s empty-state placeholder out of the iframe**
- The "Editing: … / Select an entity…" placeholder rendered *inside* `BlockCanvas` — the iframe. The iframe doesn't inherit `canvas-frame.css` or the SPA body font, so the placeholder lost its centering and fell back to serif.
- The placeholder is just chrome — no block content whose styles need isolating — so it now renders in the parent document. The `BlockCanvas` provider chain stays for the `hasEntity` branch.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS
- Browser: Safari
- PHP Version: 8.4
- Project Version: release/1.0

**Tests Performed:**
1. `npx vitest run` — 1019 passed, 1 skipped (pre-existing).
2. `npx tsc --noEmit` — no new type errors in touched files (pre-existing repo-wide `TS7016` `@wordpress/*` declaration errors unchanged).
3. Manual verification in a Keystone CMS site editor:
   - Editing a template part / template / pattern — canvas body text renders in the system-sans font (was browser-default serif); headings/paragraphs pick up the typographic baseline.
   - The no-entity placeholder ("Editing: Templates" / "Select an entity…") renders centered and sans-serif (was left-aligned serif).
4. Local `coderabbit review` — skipped at the maintainer's request; the CLI review service has hung repeatedly. Relying on this PR's automatic CodeRabbit review.

## Accessibility Tests Run

- [x] Keyboard navigation tested — n/a; no interactive surface changed (style injection + moving a non-interactive placeholder out of an iframe).
- [x] Screen reader tested — the empty-state placeholder keeps its `role="status"` / `aria-live="polite"`; moving it out of the iframe keeps it in the same accessibility tree as the rest of the shell chrome (arguably an improvement — it's no longer in a nested iframe document).
- [x] Color contrast verified — `DEFAULT_CANVAS_STYLES` is the same stylesheet the post editor already ships; no new colors.
- [x] ARIA labels checked — unchanged.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:**
- New `patterns/__tests__/pattern-canvas.test.tsx` — asserts `PatternCanvas` inlines the canvas stylesheet into its `editor-styles-wrapper` surface, plus a loading-state guard.
- `__tests__/entity-editor.test.tsx` — new case asserting `EntityEditorCanvas` inlines the stylesheet.
- `__tests__/canvas-frame.test.tsx` — updated: the no-entity placeholder no longer mounts the `BlockCanvas` provider chain (it renders outside the iframe); the `hasEntity` branch still mounts the chain.

## Documentation

- [x] Inline code documentation added — both canvas components and `CanvasFrame` carry comments explaining the `settings.styles`-only-reaches-iframes constraint and why the stylesheet is inlined / why the placeholder moved out of the iframe.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests (1019 JS tests)
- [x] Code has been linted
- [ ] CodeRabbit local pre-pass — skipped at maintainer request (CLI service unreliable this session); deferring to this PR's automatic review
- [x] Accessibility tests completed
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

## Additional Context

`CanvasFrame`'s `hasEntity` / `children` branch (the `BlockCanvas` provider chain) is now unreachable in practice — D2–D5 all render their own canvases (`EntityEditorCanvas`, `PatternCanvas`, lazy-section portals) and the shell only ever passes `hasEntity={false}` to `CanvasFrame`. It's left intact here (the docblock marks it "reserved") rather than expanding this bug-fix PR into a `CanvasFrame` refactor — a candidate for a follow-up cleanup.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected empty-state rendering in the visual editor when no entity is selected.
  * Enhanced canvas styling to ensure consistent typography and appearance across editor surfaces.

* **Tests**
  * Added comprehensive test coverage for canvas rendering, styling behavior, and pattern canvas functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArtisanPack-UI/visual-editor/pull/448)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->