### PR TITLE
fix(site-editor): bridge content.blocks ↔ menu_items so menu trees round-trip

### DIFF
--- a/src/Http/Controllers/SiteEditor/MenuController.php
+++ b/src/Http/Controllers/SiteEditor/MenuController.php
@@ -34,11 +34,13 @@ namespace ArtisanPackUI\VisualEditor\Http\Controllers\SiteEditor;
 
 use ArtisanPackUI\VisualEditor\Http\Requests\SiteEditor\StoreMenuRequest;
 use ArtisanPackUI\VisualEditor\Http\Requests\SiteEditor\UpdateMenuRequest;
+use ArtisanPackUI\VisualEditor\SiteEditor\MenuItemBlockBridge;
 use Illuminate\Database\QueryException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\DB;
 
 class MenuController extends Controller
 {
@@ -60,7 +62,10 @@ class MenuController extends Controller
 		}
 
 		$model = self::CMS_MENU_FQCN;
-		$query = $model::query()->orderBy( 'id' );
+		// Eager-load `items` — `menuToShape()` projects them into
+		// `content.blocks` (#440), and without the eager load the
+		// list endpoint would N+1 one items query per menu.
+		$query = $model::query()->with( 'items' )->orderBy( 'id' );
 
 		$theme = trim( (string) $request->query( 'theme', '' ) );
 		if ( '' !== $theme ) {
@@ -157,8 +162,22 @@ class MenuController extends Controller
 			return response()->json( [ 'message' => 'Menu not found.' ], Response::HTTP_NOT_FOUND );
 		}
 
+		$validated = $request->validated();
+
 		try {
-			$menu->update( $this->modelAttributesFromRequest( $request->validated() ) );
+			DB::transaction( function () use ( $menu, $validated ): void {
+				$menu->update( $this->modelAttributesFromRequest( $validated ) );
+
+				// #440. When the editor sends a navigation tree, replace
+				// the menu's items wholesale. Gated on `content.blocks`
+				// being present so a partial update (rename, theme
+				// change, …) leaves items untouched. Inside the same
+				// transaction as the attribute update so a failed item
+				// rebuild rolls the whole save back.
+				if ( is_array( $validated['content']['blocks'] ?? null ) ) {
+					$this->replaceMenuItems( $menu, $validated['content']['blocks'] );
+				}
+			} );
 		} catch ( QueryException $e ) {
 			if ( $this->isUniqueViolation( $e ) ) {
 				return response()->json( [
@@ -171,6 +190,62 @@ class MenuController extends Controller
 		}
 
 		return response()->json( $this->menuToShape( $menu->fresh() ) );
+	}
+
+	/**
+	 * Replace a menu's items from a `core/navigation-*` block tree.
+	 *
+	 * The block wire shape carries no stable per-item id, so a precise
+	 * insert / update / delete diff against the existing rows isn't
+	 * possible — a delete-all + rebuild is the correct equivalent and
+	 * satisfies every round-trip the editor needs (add, remove,
+	 * reorder, re-nest). The caller runs this inside a transaction.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array<int, mixed>  $blocks
+	 */
+	protected function replaceMenuItems( object $menu, array $blocks ): void
+	{
+		// Bulk delete — `reorder()` strips the `items()` relation's
+		// `ORDER BY` so the DELETE is portable (SQLite rejects
+		// `DELETE … ORDER BY` without a LIMIT). Deleting every row for
+		// the menu in one query means no orphans regardless of the
+		// per-row `deleting` cascade.
+		$menu->items()->reorder()->delete();
+
+		$specs = ( new MenuItemBlockBridge() )->blocksToItemSpecs( $blocks );
+
+		$this->insertItemSpecs( $menu, $specs, null );
+	}
+
+	/**
+	 * Depth-first insert of the nested row specs produced by
+	 * {@see MenuItemBlockBridge::blocksToItemSpecs()}. `position` is the
+	 * sibling index within each parent; `parent_id` is the just-inserted
+	 * parent row's id.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array<int, array{attributes: array<string, mixed>, children: array<int, mixed>}>  $specs
+	 */
+	protected function insertItemSpecs( object $menu, array $specs, ?int $parentId ): void
+	{
+		$position = 0;
+
+		foreach ( $specs as $spec ) {
+			/** @var object $row */
+			$row = $menu->items()->create( array_merge( $spec['attributes'], [
+				'parent_id' => $parentId,
+				'position'  => $position,
+			] ) );
+
+			$position++;
+
+			if ( [] !== $spec['children'] ) {
+				$this->insertItemSpecs( $menu, $spec['children'], (int) $row->id );
+			}
+		}
 	}
 
 	/**
@@ -253,15 +328,18 @@ class MenuController extends Controller
 				'rendered' => $name,
 				'raw'      => $name,
 			],
-			// `content` mirrors the WP REST `wp_navigation` shape so the
-			// editor's NavigationBrowser can read `row.content.blocks`
-			// without crashing (#438). Items are surfaced through the
-			// separate /menu-items endpoint; for now this is an empty
-			// envelope, populated by a future H6 follow-up that converts
-			// menu items into a `core/navigation` block tree.
+			// `content` mirrors the WP REST `wp_navigation` shape. #440:
+			// the menu's `menu_items` rows are projected into a
+			// `core/navigation-link` / `core/navigation-submenu` block
+			// tree so the editor's NavigationBrowser reads the real
+			// tree (it was an empty envelope from #438 until this
+			// bridge landed). `raw` stays empty — the editor works off
+			// `blocks`, and the backend re-derives the tree from
+			// `menu_items` on every read. Items remain individually
+			// addressable through the separate /menu-items endpoint.
 			'content'        => [
 				'raw'    => '',
-				'blocks' => [],
+				'blocks' => ( new MenuItemBlockBridge() )->itemsToBlocks( $menu->items ),
 			],
 			'auto_add_pages' => (bool) ( $menu->auto_add_pages ?? false ),
 		];

--- a/src/Http/Requests/SiteEditor/UpdateMenuRequest.php
+++ b/src/Http/Requests/SiteEditor/UpdateMenuRequest.php
@@ -44,6 +44,14 @@ class UpdateMenuRequest extends FormRequest
 			'title'          => [ 'sometimes', 'string', 'max:255' ],
 			'description'    => [ 'nullable', 'string' ],
 			'auto_add_pages' => [ 'sometimes', 'boolean' ],
+			// #440. The site editor PUTs its navigation tree as a
+			// `core/navigation-*` block tree under `content.blocks`;
+			// the controller bridges it to / from cms-framework's
+			// relational `menu_items` rows. `content.raw` is accepted
+			// but ignored — the backend re-derives it from the tree.
+			'content'        => [ 'sometimes', 'array' ],
+			'content.raw'    => [ 'sometimes', 'nullable', 'string' ],
+			'content.blocks' => [ 'sometimes', 'array' ],
 		];
 	}
 }

--- a/src/SiteEditor/MenuItemBlockBridge.php
+++ b/src/SiteEditor/MenuItemBlockBridge.php
@@ -1,0 +1,277 @@
+<?php
+
+/**
+ * Menu-item ↔ navigation-block bridge — H6 site-editor (#440).
+ *
+ * The PHP mirror of `resources/js/visual-editor/site-editor/navigation/
+ * menu-tree.ts`. The site editor serializes its navigation tree into a
+ * `core/navigation-link` / `core/navigation-submenu` block tree and
+ * PUTs it as `content.blocks`; this class bridges that wire shape to
+ * and from cms-framework's relational `menu_items` rows.
+ *
+ * Read direction ({@see itemsToBlocks()}): a flat, pre-ordered list of
+ * `MenuItem` rows → a nested block tree. An item is emitted as
+ * `core/navigation-submenu` iff it has children, `core/navigation-link`
+ * otherwise — matching `menu-tree.ts`, which is purely children-driven
+ * (it collapses childless submenus to links). The stored `type` column
+ * is therefore advisory on read.
+ *
+ * Write direction ({@see blocksToItemSpecs()}): a block tree → a nested
+ * list of row-attribute specs. Blocks whose `name` is neither
+ * `core/navigation-link` nor `core/navigation-submenu` are dropped
+ * silently (same as `menu-tree.ts` — the native tree editor has no UI
+ * for block types it doesn't understand). `parent_id` / `position` are
+ * NOT in the specs: they're relational and only known once each row is
+ * inserted, so the controller assigns them while it walks the nested
+ * specs depth-first.
+ *
+ * Block ↔ column mapping:
+ *
+ *   | block                                  | column                        |
+ *   |----------------------------------------|-------------------------------|
+ *   | name (`-link` vs `-submenu`)           | `type` (`link` / `submenu`)   |
+ *   | `attributes.label`                     | `label`                       |
+ *   | `attributes.url`                       | `url`                         |
+ *   | `attributes.opensInNewTab` (bool)      | `target` (`_blank` / `_self`) |
+ *   | `attributes.rel`                       | `rel`                         |
+ *   | `attributes.className`                 | `classes`                     |
+ *   | `attributes.kind`                      | `kind`                        |
+ *   | `attributes.type`                      | `object_type`                 |
+ *   | `attributes.id`                        | `object_id`                   |
+ *   | `innerBlocks` (recursive)              | `parent_id` + sibling index   |
+ *
+ * `description` has no representation in the block wire shape, so it is
+ * neither read into nor written from blocks.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\SiteEditor;
+
+class MenuItemBlockBridge
+{
+	/**
+	 * @since 1.0.0
+	 */
+	public const NAV_LINK = 'core/navigation-link';
+
+	/**
+	 * @since 1.0.0
+	 */
+	public const NAV_SUBMENU = 'core/navigation-submenu';
+
+	/**
+	 * Read path — project a flat, pre-ordered list of `MenuItem` rows
+	 * into a nested `core/navigation-*` block tree.
+	 *
+	 * The rows must already be ordered `(parent_id, position, id)` —
+	 * cms-framework's `Menu::items()` relation does exactly that — so
+	 * this only has to bucket by `parent_id` and recurse.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  iterable<object>  $items  Flat, pre-ordered MenuItem rows.
+	 *
+	 * @return array<int, array<string, mixed>>  Nested block tree.
+	 */
+	public function itemsToBlocks( iterable $items ): array
+	{
+		$byParent = [];
+
+		foreach ( $items as $item ) {
+			$byParent[ (int) ( $item->parent_id ?? 0 ) ][] = $item;
+		}
+
+		return $this->buildBlockBranch( $byParent, 0 );
+	}
+
+	/**
+	 * Write path — parse a `core/navigation-*` block tree into a nested
+	 * list of row-attribute specs the controller inserts depth-first.
+	 *
+	 * Each spec is `{ attributes: array<string,mixed>, children: array }`.
+	 * `parent_id` / `position` are deliberately absent — they're
+	 * relational and assigned at insert time.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array<int, mixed>  $blocks
+	 *
+	 * @return array<int, array{attributes: array<string, mixed>, children: array<int, mixed>}>
+	 */
+	public function blocksToItemSpecs( array $blocks ): array
+	{
+		$specs = [];
+
+		foreach ( $blocks as $raw ) {
+			if ( ! is_array( $raw ) ) {
+				continue;
+			}
+
+			$name = $raw['name'] ?? null;
+
+			// Drop blocks we don't translate — matches `menu-tree.ts`:
+			// the native editor has no UI for them, and preserving
+			// opaque rows the user can't act on is worse than dropping.
+			if ( self::NAV_LINK !== $name && self::NAV_SUBMENU !== $name ) {
+				continue;
+			}
+
+			$attributes = is_array( $raw['attributes'] ?? null ) ? $raw['attributes'] : [];
+			$innerBlocks = is_array( $raw['innerBlocks'] ?? null ) ? $raw['innerBlocks'] : [];
+
+			$children = $this->blocksToItemSpecs( $innerBlocks );
+
+			$specs[] = [
+				'attributes' => $this->blockAttributesToRow( $attributes, [] !== $children ),
+				'children'   => $children,
+			];
+		}
+
+		return $specs;
+	}
+
+	/**
+	 * Recursive nesting helper for {@see itemsToBlocks()}.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array<int, array<int, object>>  $byParent
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	protected function buildBlockBranch( array $byParent, int $parentId ): array
+	{
+		$blocks = [];
+
+		foreach ( $byParent[ $parentId ] ?? [] as $item ) {
+			$children = $this->buildBlockBranch( $byParent, (int) $item->id );
+
+			$blocks[] = [
+				// Children-driven, matching `menu-tree.ts` — a childless
+				// `submenu`-typed row round-trips as a link.
+				'name'        => [] !== $children ? self::NAV_SUBMENU : self::NAV_LINK,
+				'attributes'  => $this->rowToBlockAttributes( $item ),
+				'innerBlocks' => $children,
+			];
+		}
+
+		return $blocks;
+	}
+
+	/**
+	 * Map a `MenuItem` row onto a navigation block's `attributes`. Only
+	 * non-empty values are emitted so the wire shape stays minimal and
+	 * round-trips cleanly against `menu-tree.ts`'s reader.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<string, mixed>
+	 */
+	protected function rowToBlockAttributes( object $item ): array
+	{
+		$attributes = [];
+
+		if ( null !== $item->kind && '' !== (string) $item->kind ) {
+			$attributes['kind'] = (string) $item->kind;
+		}
+
+		if ( null !== $item->object_type && '' !== (string) $item->object_type ) {
+			$attributes['type'] = (string) $item->object_type;
+		}
+
+		if ( null !== $item->object_id ) {
+			$attributes['id'] = (int) $item->object_id;
+		}
+
+		$attributes['label'] = (string) ( $item->label ?? '' );
+
+		if ( null !== $item->url && '' !== (string) $item->url ) {
+			$attributes['url'] = (string) $item->url;
+		}
+
+		if ( '_blank' === $item->target ) {
+			$attributes['opensInNewTab'] = true;
+		}
+
+		if ( null !== $item->classes && '' !== (string) $item->classes ) {
+			$attributes['className'] = (string) $item->classes;
+		}
+
+		if ( null !== $item->rel && '' !== (string) $item->rel ) {
+			$attributes['rel'] = (string) $item->rel;
+		}
+
+		return $attributes;
+	}
+
+	/**
+	 * Map a navigation block's `attributes` onto `MenuItem` column
+	 * values. `type` is derived from whether the block carries children
+	 * (children-driven, matching `menu-tree.ts`).
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array<string, mixed>  $attributes
+	 *
+	 * @return array<string, mixed>
+	 */
+	protected function blockAttributesToRow( array $attributes, bool $hasChildren ): array
+	{
+		return [
+			'type'        => $hasChildren ? 'submenu' : 'link',
+			'label'       => (string) ( $attributes['label'] ?? '' ),
+			'url'         => $this->nullableString( $attributes['url'] ?? null ),
+			'target'      => ( true === ( $attributes['opensInNewTab'] ?? false ) ) ? '_blank' : '_self',
+			'rel'         => $this->nullableString( $attributes['rel'] ?? null ),
+			'classes'     => $this->nullableString( $attributes['className'] ?? null ),
+			'kind'        => $this->nullableString( $attributes['kind'] ?? null ),
+			'object_type' => $this->nullableString( $attributes['type'] ?? null ),
+			'object_id'   => $this->nullableId( $attributes['id'] ?? null ),
+		];
+	}
+
+	/**
+	 * Coerce a wire value to a non-empty string or null.
+	 *
+	 * @since 1.0.0
+	 */
+	protected function nullableString( mixed $value ): ?string
+	{
+		if ( ! is_string( $value ) || '' === $value ) {
+			return null;
+		}
+
+		return $value;
+	}
+
+	/**
+	 * Coerce a wire value to a positive integer object id or null.
+	 * `menu-tree.ts` can emit `attributes.id` as a number or a string;
+	 * `menu_items.object_id` is an unsigned bigint, so only a numeric,
+	 * positive value maps — anything else (a slug, 0, garbage) is null.
+	 *
+	 * @since 1.0.0
+	 */
+	protected function nullableId( mixed $value ): ?int
+	{
+		if ( is_int( $value ) ) {
+			return $value > 0 ? $value : null;
+		}
+
+		if ( is_string( $value ) && ctype_digit( $value ) ) {
+			$id = (int) $value;
+
+			return $id > 0 ? $id : null;
+		}
+
+		return null;
+	}
+}

--- a/src/SiteEditor/MenuItemBlockBridge.php
+++ b/src/SiteEditor/MenuItemBlockBridge.php
@@ -68,16 +68,18 @@ class MenuItemBlockBridge
 	public const NAV_SUBMENU = 'core/navigation-submenu';
 
 	/**
-	 * Read path — project a flat, pre-ordered list of `MenuItem` rows
-	 * into a nested `core/navigation-*` block tree.
+	 * Read path — project a flat list of `MenuItem` rows into a nested
+	 * `core/navigation-*` block tree.
 	 *
-	 * The rows must already be ordered `(parent_id, position, id)` —
-	 * cms-framework's `Menu::items()` relation does exactly that — so
-	 * this only has to bucket by `parent_id` and recurse.
+	 * Sibling order is normalized here by `(position, id)` rather than
+	 * relying on the caller to pre-sort — that mirrors cms-framework's
+	 * `Menu::items()` relation ordering and keeps the projection
+	 * deterministic for any input (an `index()` eager-load, a lazy
+	 * relation read, a hand-built collection in a test, …).
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param  iterable<object>  $items  Flat, pre-ordered MenuItem rows.
+	 * @param  iterable<object>  $items  Flat MenuItem rows, any order.
 	 *
 	 * @return array<int, array<string, mixed>>  Nested block tree.
 	 */
@@ -89,7 +91,17 @@ class MenuItemBlockBridge
 			$byParent[ (int) ( $item->parent_id ?? 0 ) ][] = $item;
 		}
 
-		return $this->buildBlockBranch( $byParent, 0 );
+		foreach ( $byParent as &$siblings ) {
+			usort(
+				$siblings,
+				static fn ( object $a, object $b ): int =>
+					[ (int) ( $a->position ?? 0 ), (int) ( $a->id ?? 0 ) ]
+					<=> [ (int) ( $b->position ?? 0 ), (int) ( $b->id ?? 0 ) ],
+			);
+		}
+		unset( $siblings );
+
+		return $this->buildBlockBranch( $byParent, 0, [] );
 	}
 
 	/**
@@ -141,18 +153,37 @@ class MenuItemBlockBridge
 	/**
 	 * Recursive nesting helper for {@see itemsToBlocks()}.
 	 *
+	 * `$visited` tracks the parent ids already on the current ancestor
+	 * path. A corrupt `parent_id` chain — reachable via the
+	 * `/menu-items` endpoint, which accepts an arbitrary `parent_id` —
+	 * would otherwise recurse forever; once a parent id repeats, its
+	 * branch is treated as empty. A non-positive `id` (0 / null) is
+	 * never recursed into for the same reason: `parent_id = 0` is the
+	 * root bucket key, so an item with `id = 0` would re-walk the root.
+	 *
 	 * @since 1.0.0
 	 *
 	 * @param  array<int, array<int, object>>  $byParent
+	 * @param  array<int, true>  $visited
 	 *
 	 * @return array<int, array<string, mixed>>
 	 */
-	protected function buildBlockBranch( array $byParent, int $parentId ): array
+	protected function buildBlockBranch( array $byParent, int $parentId, array $visited ): array
 	{
+		if ( isset( $visited[ $parentId ] ) ) {
+			return [];
+		}
+
+		$visited[ $parentId ] = true;
+
 		$blocks = [];
 
 		foreach ( $byParent[ $parentId ] ?? [] as $item ) {
-			$children = $this->buildBlockBranch( $byParent, (int) $item->id );
+			$itemId = (int) ( $item->id ?? 0 );
+
+			$children = $itemId > 0
+				? $this->buildBlockBranch( $byParent, $itemId, $visited )
+				: [];
 
 			$blocks[] = [
 				// Children-driven, matching `menu-tree.ts` — a childless

--- a/tests/Feature/SiteEditor/MenuControllerTest.php
+++ b/tests/Feature/SiteEditor/MenuControllerTest.php
@@ -9,10 +9,41 @@
 declare( strict_types=1 );
 
 use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models\Menu;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models\MenuItem;
 use ArtisanPackUI\CMSFramework\Modules\Themes\Managers\ThemeManager;
 use Tests\Concerns\WithCmsFramework;
 use Tests\TestCase;
 use Tests\TestUser;
+
+/**
+ * Builds a `core/navigation-link` block — the leaf shape the site
+ * editor's `menuTreeToBlocks` emits.
+ *
+ * @param  array<string, mixed>  $attributes
+ */
+function navLink( array $attributes ): array
+{
+	return [
+		'name'        => 'core/navigation-link',
+		'attributes'  => $attributes,
+		'innerBlocks' => [],
+	];
+}
+
+/**
+ * Builds a `core/navigation-submenu` block wrapping the given children.
+ *
+ * @param  array<string, mixed>  $attributes
+ * @param  array<int, mixed>  $innerBlocks
+ */
+function navSubmenu( array $attributes, array $innerBlocks ): array
+{
+	return [
+		'name'        => 'core/navigation-submenu',
+		'attributes'  => $attributes,
+		'innerBlocks' => $innerBlocks,
+	];
+}
 
 uses( TestCase::class, WithCmsFramework::class );
 
@@ -215,5 +246,172 @@ describe( 'DELETE /visual-editor/api/menus/{id}', function (): void {
 
 	it( 'returns 404 when no menu matches', function (): void {
 		$this->deleteJson( '/visual-editor/api/menus/9999' )->assertNotFound();
+	} );
+} );
+
+describe( 'navigation tree round-trip — content.blocks ↔ menu_items (#440)', function (): void {
+	it( 'persists a PUT content.blocks tree to menu_items with correct parent_id + position', function (): void {
+		$menu = Menu::create( [ 'theme' => 'digital-shopfront', 'slug' => 'primary', 'name' => 'Primary' ] );
+
+		// 2 top-level items + 1 nested under the second.
+		$this->putJson( "/visual-editor/api/menus/{$menu->id}", [
+			'content' => [
+				'raw'    => '',
+				'blocks' => [
+					navLink( [ 'label' => 'Home', 'url' => '/' ] ),
+					navSubmenu(
+						[ 'label' => 'About', 'url' => '/about' ],
+						[ navLink( [ 'label' => 'Team', 'url' => '/about/team' ] ) ],
+					),
+				],
+			],
+		] )->assertOk();
+
+		$rows = MenuItem::query()->where( 'menu_id', $menu->id )
+			->orderByRaw( 'COALESCE(parent_id, 0)' )->orderBy( 'position' )->orderBy( 'id' )->get();
+
+		expect( $rows )->toHaveCount( 3 );
+
+		// Two roots, in order.
+		$roots = $rows->whereNull( 'parent_id' )->values();
+		expect( $roots )->toHaveCount( 2 )
+			->and( $roots[0]->label )->toBe( 'Home' )
+			->and( $roots[0]->type )->toBe( 'link' )
+			->and( $roots[0]->position )->toBe( 0 )
+			->and( $roots[1]->label )->toBe( 'About' )
+			->and( $roots[1]->type )->toBe( 'submenu' )
+			->and( $roots[1]->position )->toBe( 1 );
+
+		// The nested child points at the "About" submenu, position 0.
+		$child = $rows->whereNotNull( 'parent_id' )->first();
+		expect( $child->label )->toBe( 'Team' )
+			->and( $child->parent_id )->toBe( $roots[1]->id )
+			->and( $child->position )->toBe( 0 );
+	} );
+
+	it( 'round-trips the same tree back through GET after a PUT', function (): void {
+		$menu = Menu::create( [ 'theme' => 'digital-shopfront', 'slug' => 'primary', 'name' => 'Primary' ] );
+
+		$tree = [
+			navLink( [ 'label' => 'Home', 'url' => '/' ] ),
+			navSubmenu(
+				[ 'label' => 'About', 'url' => '/about' ],
+				[ navLink( [ 'label' => 'Team', 'url' => '/about/team' ] ) ],
+			),
+		];
+
+		// The PUT response and a fresh GET must both project the items
+		// back into the same block tree — the editor rebuilds its tree
+		// from the response without a re-fetch.
+		$putResponse = $this->putJson( "/visual-editor/api/menus/{$menu->id}", [
+			'content' => [ 'raw' => '', 'blocks' => $tree ],
+		] )->assertOk();
+
+		foreach ( [ $putResponse->json( 'content.blocks' ), $this->getJson( "/visual-editor/api/menus/{$menu->id}" )->json( 'content.blocks' ) ] as $blocks ) {
+			expect( $blocks )->toHaveCount( 2 )
+				->and( $blocks[0]['name'] )->toBe( 'core/navigation-link' )
+				->and( $blocks[0]['attributes']['label'] )->toBe( 'Home' )
+				->and( $blocks[1]['name'] )->toBe( 'core/navigation-submenu' )
+				->and( $blocks[1]['attributes']['label'] )->toBe( 'About' )
+				->and( $blocks[1]['innerBlocks'] )->toHaveCount( 1 )
+				->and( $blocks[1]['innerBlocks'][0]['name'] )->toBe( 'core/navigation-link' )
+				->and( $blocks[1]['innerBlocks'][0]['attributes']['label'] )->toBe( 'Team' );
+		}
+	} );
+
+	it( 'maps typed-reference and target attributes onto the menu_items columns', function (): void {
+		$menu = Menu::create( [ 'theme' => 'digital-shopfront', 'slug' => 'primary', 'name' => 'Primary' ] );
+
+		$this->putJson( "/visual-editor/api/menus/{$menu->id}", [
+			'content' => [
+				'raw'    => '',
+				'blocks' => [
+					navLink( [
+						'label'         => 'Blog',
+						'url'           => '/blog',
+						'kind'          => 'post-type',
+						'type'          => 'page',
+						'id'            => 42,
+						'opensInNewTab' => true,
+						'rel'           => 'noopener',
+						'className'     => 'is-highlighted',
+					] ),
+				],
+			],
+		] )->assertOk();
+
+		$row = MenuItem::query()->where( 'menu_id', $menu->id )->firstOrFail();
+		expect( $row->kind )->toBe( 'post-type' )
+			->and( $row->object_type )->toBe( 'page' )
+			->and( $row->object_id )->toBe( 42 )
+			->and( $row->target )->toBe( '_blank' )
+			->and( $row->rel )->toBe( 'noopener' )
+			->and( $row->classes )->toBe( 'is-highlighted' );
+
+		// …and they round-trip back out as block attributes.
+		$attrs = $this->getJson( "/visual-editor/api/menus/{$menu->id}" )->json( 'content.blocks.0.attributes' );
+		expect( $attrs['kind'] )->toBe( 'post-type' )
+			->and( $attrs['type'] )->toBe( 'page' )
+			->and( $attrs['id'] )->toBe( 42 )
+			->and( $attrs['opensInNewTab'] )->toBeTrue();
+	} );
+
+	it( 'deletes rows the new tree no longer references', function (): void {
+		$menu = Menu::create( [ 'theme' => 'digital-shopfront', 'slug' => 'primary', 'name' => 'Primary' ] );
+
+		$this->putJson( "/visual-editor/api/menus/{$menu->id}", [
+			'content' => [ 'raw' => '', 'blocks' => [
+				navLink( [ 'label' => 'Home', 'url' => '/' ] ),
+				navLink( [ 'label' => 'Contact', 'url' => '/contact' ] ),
+			] ],
+		] )->assertOk();
+		expect( MenuItem::query()->where( 'menu_id', $menu->id )->count() )->toBe( 2 );
+
+		// Re-save with only the first item — the dropped row is gone.
+		$this->putJson( "/visual-editor/api/menus/{$menu->id}", [
+			'content' => [ 'raw' => '', 'blocks' => [
+				navLink( [ 'label' => 'Home', 'url' => '/' ] ),
+			] ],
+		] )->assertOk();
+
+		$rows = MenuItem::query()->where( 'menu_id', $menu->id )->get();
+		expect( $rows )->toHaveCount( 1 )
+			->and( $rows->first()->label )->toBe( 'Home' );
+	} );
+
+	it( 'reorders siblings — positions reflect the new tree order', function (): void {
+		$menu = Menu::create( [ 'theme' => 'digital-shopfront', 'slug' => 'primary', 'name' => 'Primary' ] );
+
+		$this->putJson( "/visual-editor/api/menus/{$menu->id}", [
+			'content' => [ 'raw' => '', 'blocks' => [
+				navLink( [ 'label' => 'First', 'url' => '/1' ] ),
+				navLink( [ 'label' => 'Second', 'url' => '/2' ] ),
+			] ],
+		] )->assertOk();
+
+		// Swap the order.
+		$this->putJson( "/visual-editor/api/menus/{$menu->id}", [
+			'content' => [ 'raw' => '', 'blocks' => [
+				navLink( [ 'label' => 'Second', 'url' => '/2' ] ),
+				navLink( [ 'label' => 'First', 'url' => '/1' ] ),
+			] ],
+		] )->assertOk();
+
+		$byLabel = MenuItem::query()->where( 'menu_id', $menu->id )->get()->keyBy( 'label' );
+		expect( $byLabel['Second']->position )->toBe( 0 )
+			->and( $byLabel['First']->position )->toBe( 1 );
+	} );
+
+	it( 'leaves existing items untouched on a partial update that omits content', function (): void {
+		$menu = Menu::create( [ 'theme' => 'digital-shopfront', 'slug' => 'primary', 'name' => 'Primary' ] );
+
+		$this->putJson( "/visual-editor/api/menus/{$menu->id}", [
+			'content' => [ 'raw' => '', 'blocks' => [ navLink( [ 'label' => 'Home', 'url' => '/' ] ) ] ],
+		] )->assertOk();
+
+		// A rename with no `content` key must not wipe the items.
+		$this->putJson( "/visual-editor/api/menus/{$menu->id}", [ 'name' => 'Renamed' ] )->assertOk();
+
+		expect( MenuItem::query()->where( 'menu_id', $menu->id )->count() )->toBe( 1 );
 	} );
 } );

--- a/tests/Feature/SiteEditorShellTest.php
+++ b/tests/Feature/SiteEditorShellTest.php
@@ -25,7 +25,10 @@ test('site-editor blade view exists and exposes the SPA mount data attributes', 
 
     expect($contents)->toContain('data-ap-site-editor');
     expect($contents)->toContain('data-route-base="/visual-editor/site"');
-    expect($contents)->toContain("data-post-editor-url=\"{{ route('visual-editor.editor') }}\"");
+    // #446 renamed the exit-link attributes from `data-post-editor-url`
+    // to the consumer-configurable `data-exit-url` / `data-exit-label`.
+    expect($contents)->toContain("data-exit-url=\"{{ route('visual-editor.editor') }}\"");
+    expect($contents)->toContain("data-exit-label=\"{{ __('← Post editor') }}\"");
     expect($contents)->toContain("@vite(['resources/js/visual-editor/site-editor/main.tsx'])");
 });
 

--- a/tests/Unit/VisualEditor/SiteEditor/MenuItemBlockBridgeTest.php
+++ b/tests/Unit/VisualEditor/SiteEditor/MenuItemBlockBridgeTest.php
@@ -1,0 +1,189 @@
+<?php
+
+/**
+ * Unit tests for {@see MenuItemBlockBridge} — the PHP mirror of
+ * `menu-tree.ts`. Pure converter, no DB: `itemsToBlocks()` is fed
+ * plain row-shaped objects, `blocksToItemSpecs()` plain arrays.
+ *
+ * @since 1.0.0
+ */
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\SiteEditor\MenuItemBlockBridge;
+
+/**
+ * Build a `menu_items`-row-shaped object for the read-path tests.
+ *
+ * @param  array<string, mixed>  $overrides
+ */
+function menuItemRow( array $overrides = [] ): object
+{
+	return (object) array_merge( [
+		'id'          => 1,
+		'parent_id'   => null,
+		'position'    => 0,
+		'type'        => 'link',
+		'label'       => 'Item',
+		'url'         => null,
+		'target'      => '_self',
+		'rel'         => null,
+		'classes'     => null,
+		'kind'        => null,
+		'object_type' => null,
+		'object_id'   => null,
+	], $overrides );
+}
+
+describe( 'itemsToBlocks() — read path', function (): void {
+	it( 'emits a childless row as core/navigation-link', function (): void {
+		$blocks = ( new MenuItemBlockBridge() )->itemsToBlocks( [
+			menuItemRow( [ 'id' => 1, 'label' => 'Home', 'url' => '/' ] ),
+		] );
+
+		expect( $blocks )->toHaveCount( 1 )
+			->and( $blocks[0]['name'] )->toBe( 'core/navigation-link' )
+			->and( $blocks[0]['attributes']['label'] )->toBe( 'Home' )
+			->and( $blocks[0]['attributes']['url'] )->toBe( '/' )
+			->and( $blocks[0]['innerBlocks'] )->toBe( [] );
+	} );
+
+	it( 'emits a row with children as core/navigation-submenu, nesting recursively', function (): void {
+		$blocks = ( new MenuItemBlockBridge() )->itemsToBlocks( [
+			menuItemRow( [ 'id' => 1, 'parent_id' => null, 'label' => 'About' ] ),
+			menuItemRow( [ 'id' => 2, 'parent_id' => 1, 'label' => 'Team' ] ),
+		] );
+
+		expect( $blocks )->toHaveCount( 1 )
+			->and( $blocks[0]['name'] )->toBe( 'core/navigation-submenu' )
+			->and( $blocks[0]['attributes']['label'] )->toBe( 'About' )
+			->and( $blocks[0]['innerBlocks'] )->toHaveCount( 1 )
+			->and( $blocks[0]['innerBlocks'][0]['name'] )->toBe( 'core/navigation-link' )
+			->and( $blocks[0]['innerBlocks'][0]['attributes']['label'] )->toBe( 'Team' );
+	} );
+
+	it( 'is children-driven — a childless submenu-typed row still emits a link', function (): void {
+		// Matches `menu-tree.ts`, which collapses childless submenus to
+		// links so the round-trip is stable.
+		$blocks = ( new MenuItemBlockBridge() )->itemsToBlocks( [
+			menuItemRow( [ 'id' => 1, 'type' => 'submenu', 'label' => 'Empty' ] ),
+		] );
+
+		expect( $blocks[0]['name'] )->toBe( 'core/navigation-link' );
+	} );
+
+	it( 'maps the typed-reference + target columns onto block attributes', function (): void {
+		$blocks = ( new MenuItemBlockBridge() )->itemsToBlocks( [
+			menuItemRow( [
+				'id'          => 1,
+				'label'       => 'Blog',
+				'url'         => '/blog',
+				'target'      => '_blank',
+				'rel'         => 'noopener',
+				'classes'     => 'is-cta',
+				'kind'        => 'post-type',
+				'object_type' => 'page',
+				'object_id'   => 42,
+			] ),
+		] );
+
+		$attrs = $blocks[0]['attributes'];
+		expect( $attrs['kind'] )->toBe( 'post-type' )
+			->and( $attrs['type'] )->toBe( 'page' )
+			->and( $attrs['id'] )->toBe( 42 )
+			->and( $attrs['opensInNewTab'] )->toBeTrue()
+			->and( $attrs['rel'] )->toBe( 'noopener' )
+			->and( $attrs['className'] )->toBe( 'is-cta' );
+	} );
+
+	it( 'omits empty optional attributes — only label is always present', function (): void {
+		$blocks = ( new MenuItemBlockBridge() )->itemsToBlocks( [
+			menuItemRow( [ 'id' => 1, 'label' => 'Bare', 'target' => '_self' ] ),
+		] );
+
+		expect( $blocks[0]['attributes'] )->toBe( [ 'label' => 'Bare' ] );
+	} );
+} );
+
+describe( 'blocksToItemSpecs() — write path', function (): void {
+	it( 'parses a link block into a row spec', function (): void {
+		$specs = ( new MenuItemBlockBridge() )->blocksToItemSpecs( [
+			[
+				'name'        => 'core/navigation-link',
+				'attributes'  => [ 'label' => 'Home', 'url' => '/' ],
+				'innerBlocks' => [],
+			],
+		] );
+
+		expect( $specs )->toHaveCount( 1 )
+			->and( $specs[0]['attributes']['type'] )->toBe( 'link' )
+			->and( $specs[0]['attributes']['label'] )->toBe( 'Home' )
+			->and( $specs[0]['attributes']['url'] )->toBe( '/' )
+			->and( $specs[0]['attributes']['target'] )->toBe( '_self' )
+			->and( $specs[0]['children'] )->toBe( [] );
+	} );
+
+	it( 'parses a submenu block, marking type=submenu and nesting children', function (): void {
+		$specs = ( new MenuItemBlockBridge() )->blocksToItemSpecs( [
+			[
+				'name'        => 'core/navigation-submenu',
+				'attributes'  => [ 'label' => 'About' ],
+				'innerBlocks' => [
+					[ 'name' => 'core/navigation-link', 'attributes' => [ 'label' => 'Team' ], 'innerBlocks' => [] ],
+				],
+			],
+		] );
+
+		expect( $specs[0]['attributes']['type'] )->toBe( 'submenu' )
+			->and( $specs[0]['children'] )->toHaveCount( 1 )
+			->and( $specs[0]['children'][0]['attributes']['type'] )->toBe( 'link' )
+			->and( $specs[0]['children'][0]['attributes']['label'] )->toBe( 'Team' );
+	} );
+
+	it( 'drops blocks it does not translate', function (): void {
+		// Matches `menu-tree.ts` — the native tree editor has no UI for
+		// block types it doesn't understand.
+		$specs = ( new MenuItemBlockBridge() )->blocksToItemSpecs( [
+			[ 'name' => 'core/paragraph', 'attributes' => [ 'content' => 'nope' ], 'innerBlocks' => [] ],
+			[ 'name' => 'core/navigation-link', 'attributes' => [ 'label' => 'Kept' ], 'innerBlocks' => [] ],
+			'not-an-array',
+		] );
+
+		expect( $specs )->toHaveCount( 1 )
+			->and( $specs[0]['attributes']['label'] )->toBe( 'Kept' );
+	} );
+
+	it( 'maps opensInNewTab + typed-reference attributes onto columns', function (): void {
+		$specs = ( new MenuItemBlockBridge() )->blocksToItemSpecs( [
+			[
+				'name'        => 'core/navigation-link',
+				'attributes'  => [
+					'label'         => 'Blog',
+					'kind'          => 'post-type',
+					'type'          => 'page',
+					'id'            => 42,
+					'opensInNewTab' => true,
+					'className'     => 'is-cta',
+				],
+				'innerBlocks' => [],
+			],
+		] );
+
+		$attrs = $specs[0]['attributes'];
+		expect( $attrs['target'] )->toBe( '_blank' )
+			->and( $attrs['kind'] )->toBe( 'post-type' )
+			->and( $attrs['object_type'] )->toBe( 'page' )
+			->and( $attrs['object_id'] )->toBe( 42 )
+			->and( $attrs['classes'] )->toBe( 'is-cta' );
+	} );
+
+	it( 'normalizes a non-numeric attributes.id to a null object_id', function (): void {
+		// `menu-tree.ts` can emit `id` as a slug string; `object_id` is
+		// an unsigned bigint, so only a numeric positive value maps.
+		$specs = ( new MenuItemBlockBridge() )->blocksToItemSpecs( [
+			[ 'name' => 'core/navigation-link', 'attributes' => [ 'label' => 'X', 'id' => 'a-slug' ], 'innerBlocks' => [] ],
+		] );
+
+		expect( $specs[0]['attributes']['object_id'] )->toBeNull();
+	} );
+} );

--- a/tests/Unit/VisualEditor/SiteEditor/MenuItemBlockBridgeTest.php
+++ b/tests/Unit/VisualEditor/SiteEditor/MenuItemBlockBridgeTest.php
@@ -103,6 +103,34 @@ describe( 'itemsToBlocks() — read path', function (): void {
 
 		expect( $blocks[0]['attributes'] )->toBe( [ 'label' => 'Bare' ] );
 	} );
+
+	it( 'normalizes sibling order by (position, id) regardless of input order', function (): void {
+		// The bridge no longer depends on the caller pre-sorting — it
+		// orders each parent bucket itself. Feed the rows shuffled.
+		$blocks = ( new MenuItemBlockBridge() )->itemsToBlocks( [
+			menuItemRow( [ 'id' => 9, 'position' => 2, 'label' => 'Third' ] ),
+			menuItemRow( [ 'id' => 3, 'position' => 0, 'label' => 'First' ] ),
+			menuItemRow( [ 'id' => 7, 'position' => 1, 'label' => 'Second' ] ),
+		] );
+
+		expect( array_column( array_column( $blocks, 'attributes' ), 'label' ) )
+			->toBe( [ 'First', 'Second', 'Third' ] );
+	} );
+
+	it( 'does not infinite-loop on a cyclic parent_id chain', function (): void {
+		// Corrupt data — reachable via the /menu-items endpoint, which
+		// accepts an arbitrary parent_id. Item 1's parent is 2 and
+		// item 2's parent is 1. The cycle guard must bottom out.
+		$blocks = ( new MenuItemBlockBridge() )->itemsToBlocks( [
+			menuItemRow( [ 'id' => 1, 'parent_id' => 2, 'label' => 'A' ] ),
+			menuItemRow( [ 'id' => 2, 'parent_id' => 1, 'label' => 'B' ] ),
+		] );
+
+		// Neither item is reachable from the root (both have a non-zero
+		// parent), so the projection is simply empty — and crucially,
+		// it returns rather than recursing forever.
+		expect( $blocks )->toBe( [] );
+	} );
 } );
 
 describe( 'blocksToItemSpecs() — write path', function (): void {


### PR DESCRIPTION
## Description

The site editor serializes its navigation tree into a `core/navigation-link` / `core/navigation-submenu` block tree and PUTs it as `content.blocks` to `/visual-editor/api/menus/{id}`. `MenuController` had no bridge to cms-framework's relational `menu_items` table — `update()` silently dropped `content`, and `menuToShape()` always returned an empty `content.blocks` envelope (the #438 defensive stub). Every menu item vanished on save.

**Closes:** #440

## Type of Change

- [x] Bug fix (fixes an issue)

## Related Issue

**Issue:** #440 — surfaced during the H8 (#433) smoke flow.

## Changes Made

**New `src/SiteEditor/MenuItemBlockBridge.php`** — the PHP mirror of `resources/js/visual-editor/site-editor/navigation/menu-tree.ts`:
- `itemsToBlocks()` — a flat, pre-ordered list of `MenuItem` rows → a nested `core/navigation-*` block tree. Children-driven: a row emits `core/navigation-submenu` iff it has children, `core/navigation-link` otherwise — matching `menu-tree.ts`, which collapses childless submenus to links so the round-trip stays stable.
- `blocksToItemSpecs()` — a block tree → a nested list of row-attribute specs; drops blocks whose `name` isn't a nav-link/nav-submenu, same as the JS reader. `parent_id` / `position` are deliberately absent — they're relational and assigned at insert time.

**`MenuController`:**
- `menuToShape()` projects `$menu->items` into `content.blocks`.
- `index()` eager-loads `items` to avoid an N+1.
- `update()` rebuilds `menu_items` from `content.blocks` inside the same transaction as the attribute update — gated on `content.blocks` being present so a partial update (rename, theme change) leaves items untouched. The block wire shape carries **no stable per-item id**, so a precise insert/update/delete diff isn't possible; a transactional delete-all + depth-first rebuild is the correct equivalent and satisfies every round-trip the editor needs (add, remove, reorder, re-nest). `parent_id` / `position` are assigned as the nested specs are walked.

**`UpdateMenuRequest`** accepts `content` / `content.raw` / `content.blocks`.

**Block ↔ column mapping** (per the issue's table, faithful to `menu-tree.ts`):

| block | column |
|---|---|
| name (`-link` vs `-submenu`) | `type` (`link` / `submenu`) |
| `attributes.label` | `label` |
| `attributes.url` | `url` |
| `attributes.opensInNewTab` | `target` (`_blank` / `_self`) |
| `attributes.rel` | `rel` |
| `attributes.className` | `classes` |
| `attributes.kind` | `kind` |
| `attributes.type` | `object_type` |
| `attributes.id` | `object_id` |
| `innerBlocks` (recursive) | `parent_id` + sibling index |

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS
- PHP Version: 8.4
- Project Version: release/1.0

**Tests Performed:**
1. `./vendor/bin/pest` — 588 passed (1648 assertions).
2. Manual verification in a Keystone CMS site editor (Navigation section): adding 2 top-level + 1 nested item and saving persists them; reload shows the same tree; removing an item deletes the row; reordering siblings holds; nesting survives the round-trip.
3. Local `coderabbit review` — skipped at the maintainer's request (the CLI service has been unreliable this session); relying on this PR's automatic CodeRabbit review.

## Accessibility Tests Run

- [x] N/A — backend-only change (PHP controller + converter + form request). No UI surface modified; the navigation editor frontend already round-trips through `menu-tree.ts` and was simply receiving an empty `content.blocks` before this.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:**
- `tests/Feature/SiteEditor/MenuControllerTest.php` — 6 round-trip integration tests: PUT a 2-level tree persists to `menu_items` with correct `parent_id` / `position`; GET-after-PUT projects the same tree (the editor rebuilds without a re-fetch); typed-reference + target attributes map onto the columns and back; re-saving without a dropped item deletes its row; reordering siblings updates `position`; a partial update that omits `content` leaves items untouched. Plus `navLink()` / `navSubmenu()` block-builder helpers.
- `tests/Unit/VisualEditor/SiteEditor/MenuItemBlockBridgeTest.php` — 11 unit tests for the converter in isolation (childless→link, children→submenu, children-driven type, attribute mapping both directions, unknown blocks dropped, non-numeric `id` → null `object_id`, empty optional attributes omitted).
- `tests/Feature/SiteEditorShellTest.php` — fixed a stale assertion: #446 renamed the dev-app blade's `data-post-editor-url` → `data-exit-url` / `data-exit-label` but didn't update this shell test, leaving it red on `release/1.0`. Corrected here so the suite is green.

## Documentation

- [x] Inline code documentation added — `MenuItemBlockBridge` carries a full docblock with the mapping table and the children-driven / drop-unknown rationale; `MenuController::replaceMenuItems()` documents why a delete-all rebuild (not a diff) is the right approach given the wire shape.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests (588)
- [x] Code has been linted — the package ships no PHP linter (`composer.json` has only a `test` script, no `pint`/`phpcs` binary); matched the existing tab-indented house style by hand
- [ ] CodeRabbit local pre-pass — skipped at maintainer request (CLI unreliable this session); deferring to this PR's automatic review
- [x] Accessibility tests completed (N/A — backend only)
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

## Reviewer Notes

- **Why delete-all + rebuild, not a diff:** the `core/navigation-*` block wire shape carries no stable `menu_items.id` (`attributes.id` is the *object* reference — `object_id` — not the row id). A precise insert/update/delete diff would need a stable per-item id the editor doesn't send. The transactional delete-all + depth-first rebuild produces the correct end state for every acceptance criterion. The trade-off — row ids churn each save — is invisible to the whole-tree save flow (the wire shape doesn't expose ids), and the separate `/menu-items` incremental-edit endpoints are a different flow.
- **`description` column** has no representation in the navigation block wire shape, so it's neither read into nor written from `content.blocks` — consistent with `menu-tree.ts`.
- The pre-existing `MenuAdapter` class is unused dead code (no references anywhere) — left untouched; not in scope here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Editor now round-trips block-based navigation trees: menus render as navigation blocks and can be saved back into menu structure.

* **Improvements**
  * Menu listing loads items eagerly to reduce queries.
  * Menu updates apply within a single transaction when block content is provided.
  * Request validation accepts optional content/blocks payload for editor saves.

* **Tests**
  * Integration and unit tests added to verify block-to-menu and menu-to-block conversions, ordering, deletion, and edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArtisanPack-UI/visual-editor/pull/449)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->