### PR TITLE
Iframe the post-editor canvas via BlockCanvas (#347)

### DIFF
--- a/resources/js/visual-editor/editor/__tests__/canvas-styles.test.ts
+++ b/resources/js/visual-editor/editor/__tests__/canvas-styles.test.ts
@@ -1,0 +1,40 @@
+/**
+ * `canvas-styles.ts` assembles the stylesheet bundle handed to
+ * `BlockCanvas`'s `styles` prop so the iframe canvas isn't styled by
+ * browser defaults (#347).
+ *
+ * The individual `@wordpress/*` sheets are resolved by Vite's `?inline`
+ * transform at build/dev time; under vitest (`css: false`) those
+ * imports collapse to empty strings, so this suite asserts the bundle's
+ * *structure and ordering* rather than re-checking Gutenberg's CSS
+ * text. `DEFAULT_CANVAS_STYLES` is a real TypeScript constant, so the
+ * cascade-order anchor is still verifiable here.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { DEFAULT_CANVAS_STYLES } from '../../editor-settings';
+import { canvasStyles } from '../canvas-styles';
+
+describe('canvasStyles', () => {
+    it('exposes every sheet as a `{ css: string }` entry — the shape BlockCanvas injects', () => {
+        expect(canvasStyles.length).toBeGreaterThan(0);
+
+        for (const entry of canvasStyles) {
+            expect(Object.keys(entry)).toEqual(['css']);
+            expect(typeof entry.css).toBe('string');
+        }
+    });
+
+    it('bundles the theme token bridge, the three @wordpress sheet groups, and the canvas baseline', () => {
+        // token bridge + components + block-editor (style + content)
+        // + block-library (style + editor) + DEFAULT_CANVAS_STYLES.
+        expect(canvasStyles).toHaveLength(7);
+    });
+
+    it('ends with DEFAULT_CANVAS_STYLES so the package typographic baseline wins the cascade', () => {
+        expect(canvasStyles[canvasStyles.length - 1]?.css).toBe(
+            DEFAULT_CANVAS_STYLES
+        );
+    });
+});

--- a/resources/js/visual-editor/editor/__tests__/editor-canvas.test.tsx
+++ b/resources/js/visual-editor/editor/__tests__/editor-canvas.test.tsx
@@ -1,0 +1,176 @@
+/**
+ * `EditorCanvas` mounts the post title above the iframed `BlockCanvas`
+ * (#347). The real `BlockCanvas` mounts an iframe and pulls from a
+ * Gutenberg data store — neither of which jsdom reproduces reliably —
+ * so `@wordpress/block-editor` is stubbed here (the same approach
+ * `site-editor/__tests__/canvas-frame.test.tsx` takes). The stubs let
+ * the suite focus on this component's wiring:
+ *   - the canvas renders inside a `BlockCanvas` (iframe mount intent);
+ *   - `BlockCanvas` receives the assembled `canvasStyles` bundle (style
+ *     injection into the iframe);
+ *   - `PostTitle` renders above `BlockCanvas`, and only when supported;
+ *   - cms-framework entities get a `BlockContextProvider` wrap.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { ReactNode } from 'react';
+
+const blockCanvasProps = vi.fn();
+
+vi.mock('@wordpress/block-editor', () => ({
+    BlockCanvas: (props: { children: ReactNode; styles: unknown; height: string }): JSX.Element => {
+        blockCanvasProps(props);
+
+        return <div data-testid="ap-stub-block-canvas">{props.children}</div>;
+    },
+    BlockContextProvider: ({
+        children,
+        value,
+    }: {
+        children: ReactNode;
+        value: unknown;
+    }): JSX.Element => (
+        <div
+            data-testid="ap-stub-block-context-provider"
+            data-context={JSON.stringify(value)}
+        >
+            {children}
+        </div>
+    ),
+    BlockList: (): JSX.Element => <div data-testid="ap-stub-block-list" />,
+    ObserveTyping: ({ children }: { children: ReactNode }): JSX.Element => (
+        <div data-testid="ap-stub-observe-typing">{children}</div>
+    ),
+}));
+
+vi.mock('../post-title', () => ({
+    PostTitle: ({
+        value,
+        onChange,
+    }: {
+        value: string;
+        onChange: (next: string) => void;
+    }): JSX.Element => (
+        <input
+            data-testid="ap-stub-post-title"
+            value={value}
+            onChange={(event) => onChange(event.target.value)}
+        />
+    ),
+}));
+
+import { canvasStyles } from '../canvas-styles';
+import { EditorCanvas } from '../editor-canvas';
+
+describe('EditorCanvas', () => {
+    it('renders the block list inside a BlockCanvas iframe', () => {
+        render(
+            <EditorCanvas
+                showTitle
+                title="Hello"
+                onTitleChange={() => undefined}
+                blockContext={null}
+            />
+        );
+
+        const canvas = screen.getByTestId('ap-stub-block-canvas');
+
+        expect(canvas).toBeInTheDocument();
+        expect(canvas).toContainElement(
+            screen.getByTestId('ap-stub-block-list')
+        );
+    });
+
+    it('hands the assembled canvasStyles bundle to BlockCanvas for iframe injection', () => {
+        blockCanvasProps.mockClear();
+
+        render(
+            <EditorCanvas
+                showTitle
+                title=""
+                onTitleChange={() => undefined}
+                blockContext={null}
+            />
+        );
+
+        expect(blockCanvasProps).toHaveBeenCalledTimes(1);
+        expect(blockCanvasProps.mock.calls[0]?.[0]).toMatchObject({
+            styles: canvasStyles,
+            height: '100%',
+        });
+    });
+
+    it('renders PostTitle above the BlockCanvas when the document type supports a title', () => {
+        render(
+            <EditorCanvas
+                showTitle
+                title="My post"
+                onTitleChange={() => undefined}
+                blockContext={null}
+            />
+        );
+
+        const title = screen.getByTestId('ap-stub-post-title');
+        const canvas = screen.getByTestId('ap-stub-block-canvas');
+
+        expect(title).toHaveValue('My post');
+        // Source order: the title precedes the canvas in the DOM.
+        expect(
+            title.compareDocumentPosition(canvas) &
+                Node.DOCUMENT_POSITION_FOLLOWING
+        ).toBeTruthy();
+    });
+
+    it('omits PostTitle when the document type has no title support', () => {
+        render(
+            <EditorCanvas
+                showTitle={false}
+                title=""
+                onTitleChange={() => undefined}
+                blockContext={null}
+            />
+        );
+
+        expect(
+            screen.queryByTestId('ap-stub-post-title')
+        ).not.toBeInTheDocument();
+    });
+
+    it('wraps the block list in a BlockContextProvider for cms-framework entities', () => {
+        render(
+            <EditorCanvas
+                showTitle
+                title=""
+                onTitleChange={() => undefined}
+                blockContext={{ postType: 'page', postId: 42 }}
+            />
+        );
+
+        const provider = screen.getByTestId('ap-stub-block-context-provider');
+
+        expect(provider).toHaveAttribute(
+            'data-context',
+            JSON.stringify({ postType: 'page', postId: 42 })
+        );
+        expect(provider).toContainElement(
+            screen.getByTestId('ap-stub-block-list')
+        );
+    });
+
+    it('skips the BlockContextProvider wrap when there is no entity context', () => {
+        render(
+            <EditorCanvas
+                showTitle
+                title=""
+                onTitleChange={() => undefined}
+                blockContext={null}
+            />
+        );
+
+        expect(
+            screen.queryByTestId('ap-stub-block-context-provider')
+        ).not.toBeInTheDocument();
+        expect(screen.getByTestId('ap-stub-block-list')).toBeInTheDocument();
+    });
+});

--- a/resources/js/visual-editor/editor/canvas-styles.ts
+++ b/resources/js/visual-editor/editor/canvas-styles.ts
@@ -1,0 +1,66 @@
+/**
+ * Canvas iframe stylesheet bundle — #347.
+ *
+ * `editor-app.tsx` renders the block list inside a `BlockCanvas` iframe
+ * (A1 follow-up: isolating the editor's React tree from the admin DOM
+ * is what stops the color-picker fast-drag crash — the per-frame
+ * `setAttributes` backpressure no longer contends with parent layout
+ * updates past React's update-depth guard).
+ *
+ * The iframe document is sandboxed: none of the Vite-injected
+ * `@wordpress/*` stylesheets in the parent document cross into it, and
+ * `BlockCanvas`'s built-in `getCompatibilityStyles` copy skips them
+ * because Vite's `<style>` tags carry no `id`. So the canvas styles
+ * have to be assembled here and handed to `BlockCanvas` via its
+ * `styles` prop, which injects them into the iframe through
+ * `__unstableEditorStyles`.
+ *
+ * Each file is imported with Vite's `?inline` query so it resolves to
+ * its CSS text rather than a side-effect injection into the parent
+ * document. `editor-app.tsx` keeps its own side-effect imports of the
+ * same `@wordpress/*` stylesheets for the editor chrome (top bar,
+ * block toolbar, inspector) that renders *outside* the iframe.
+ */
+
+import blockEditorContent from '@wordpress/block-editor/build-style/content.css?inline';
+import blockEditorStyle from '@wordpress/block-editor/build-style/style.css?inline';
+import blockLibraryEditor from '@wordpress/block-library/build-style/editor.css?inline';
+import blockLibraryStyle from '@wordpress/block-library/build-style/style.css?inline';
+import componentsStyle from '@wordpress/components/build-style/style.css?inline';
+
+import { DEFAULT_CANVAS_STYLES } from '../editor-settings';
+
+import canvasThemeTokens from './canvas-theme-tokens.css?inline';
+
+/** A single stylesheet entry in the shape `BlockCanvas`'s `styles` prop expects. */
+export interface CanvasStyle {
+    css: string;
+}
+
+/**
+ * Ordered `{ css }` entries handed to `BlockCanvas`'s `styles` prop.
+ * The order is the cascade order inside the iframe:
+ *
+ *   1. the token bridge first, so every rule below it can read the
+ *      `--wp-*` / `--color-*` custom properties;
+ *   2. the `@wordpress/*` stylesheets (components → block-editor →
+ *      block-library), matching the parent-document import order in
+ *      `editor-app.tsx`;
+ *   3. `DEFAULT_CANVAS_STYLES` last, so the package's typographic
+ *      baseline wins over the Gutenberg defaults — a theme.json
+ *      stylesheet will append after this entry and win in turn once
+ *      the theme.json bridge lands.
+ *
+ * `BlockCanvas` passes this straight to `__unstableEditorStyles` with
+ * no wrapper selector, so the CSS is injected into the iframe verbatim
+ * (`transformStyles` is a no-op without a scope or `baseURL`).
+ */
+export const canvasStyles: readonly CanvasStyle[] = [
+    { css: canvasThemeTokens },
+    { css: componentsStyle },
+    { css: blockEditorStyle },
+    { css: blockEditorContent },
+    { css: blockLibraryStyle },
+    { css: blockLibraryEditor },
+    { css: DEFAULT_CANVAS_STYLES },
+];

--- a/resources/js/visual-editor/editor/canvas-theme-tokens.css
+++ b/resources/js/visual-editor/editor/canvas-theme-tokens.css
@@ -1,0 +1,67 @@
+/**
+ * Canvas (iframe) theme token bridge — #347.
+ *
+ * `editor-app.tsx` now renders the block list inside a `BlockCanvas`
+ * iframe. That iframe document is isolated: it inherits none of the
+ * host admin's DaisyUI `--color-*` tokens, and none of the shell-scoped
+ * `--wp-*` mappings from `visual-editor-theme.css` reach it either —
+ * that file targets `.ap-visual-editor__shell`, an element that only
+ * exists in the parent document.
+ *
+ * This stylesheet re-establishes those tokens on the iframe root so
+ * in-canvas chrome — block selection outlines, the empty-block
+ * appender, inline inserter accents — picks up the editor palette
+ * instead of falling back to WordPress blue (or an invalid `var()`
+ * with no fallback). It's injected via `BlockCanvas`'s `styles` prop;
+ * see `canvas-styles.ts`.
+ *
+ * The canvas is always a light-mode surface (see `editor-app.css`), so
+ * the DaisyUI tokens are pinned to their light values rather than
+ * mirrored from the host `data-theme`. Every `--wp-*` mapping keeps a
+ * hex fallback so the canvas still renders correctly when the editor
+ * is mounted outside a DaisyUI host.
+ */
+
+:root {
+    --color-base-100: #ffffff;
+    --color-base-200: #f3f4f6;
+    --color-base-300: #e5e7eb;
+    --color-base-content: #1f2937;
+
+    --wp-admin-theme-color: var(--color-primary, #2563eb);
+    --wp-admin-theme-color-darker-10: var(--color-primary, #2271b1);
+    --wp-admin-theme-color-darker-20: var(--color-primary, #135e96);
+    --wp-admin-border-width-focus: 2px;
+
+    --wp-components-color-accent: var(--color-primary, #2563eb);
+    --wp-components-color-accent-darker-10: var(--color-primary, #2271b1);
+    --wp-components-color-accent-darker-20: var(--color-primary, #135e96);
+    --wp-components-color-accent-inverted: var(--color-primary-content, #ffffff);
+    --wp-components-color-background: var(--color-base-100, #ffffff);
+    --wp-components-color-foreground: var(--color-base-content, #1f2937);
+    --wp-components-color-foreground-inverted: var(--color-base-100, #ffffff);
+    --wp-components-color-gray-100: var(--color-base-200, #f3f4f6);
+    --wp-components-color-gray-200: var(--color-base-200, #f3f4f6);
+    --wp-components-color-gray-300: var(--color-base-300, #e5e7eb);
+    --wp-components-color-gray-400: var(--color-base-300, #d1d5db);
+    --wp-components-color-gray-600: var(--color-base-content, #6b7280);
+    --wp-components-color-gray-700: var(--color-base-content, #374151);
+    --wp-components-color-gray-800: var(--color-base-content, #1f2937);
+    --wp-components-color-gray-900: var(--color-base-content, #111827);
+
+    --wp-block-editor-type-color: var(--color-base-content, #1f2937);
+    --wp-block-synced-color: var(--color-secondary, #7f54b3);
+}
+
+/*
+ * The iframe `<body>` carries the `editor-styles-wrapper` class. Pin its
+ * surface to the canvas background token so the authoring surface stays
+ * white regardless of the host admin theme — the parent-document rule
+ * that used to do this (`.ap-visual-editor__canvas.editor-styles-wrapper`
+ * in `editor-app.css`) no longer matches now that the styled surface
+ * lives inside the iframe.
+ */
+body.editor-styles-wrapper {
+    background-color: var(--ap-editor-canvas-bg, #ffffff);
+    color: var(--ap-editor-canvas-fg, #1f2937);
+}

--- a/resources/js/visual-editor/editor/editor-app.css
+++ b/resources/js/visual-editor/editor/editor-app.css
@@ -75,26 +75,38 @@
     overflow: hidden;
 }
 
+/*
+ * #347: the canvas region is a vertical stack — `PostTitle` (editor
+ * chrome, in the parent document) above the iframed `BlockCanvas`. The
+ * region traps its own overflow; the iframe scrolls its content
+ * internally, so this column does not scroll.
+ */
 .ap-visual-editor__canvas {
     flex: 1 1 auto;
     min-width: 0;
     min-height: 0;
-    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
 }
 
 /*
- * Canvas surface renders against the front-end theme's background so
- * authoring matches the rendered page. The shell scope already forces
- * light-mode tokens; this rule just pins the canvas surface to white
- * (separate from the `--color-base-200` shell background that surrounds
- * the canvas). Hosts can override `--ap-editor-canvas-bg` /
- * `--ap-editor-canvas-fg` per theme — once the theme.json reader lands
- * it'll supply these from `settings.color.background`.
+ * Flex cell the `BlockCanvas` iframe fills. `BlockCanvas` is mounted
+ * with `height="100%"`, which resolves against this frame; keeping it
+ * a separate element (rather than sizing `BlockCanvas` against
+ * `.ap-visual-editor__canvas` directly) leaves room for `PostTitle` to
+ * take its natural height above the iframe.
+ *
+ * The canvas *surface* background is now painted inside the iframe via
+ * `canvas-theme-tokens.css` — the parent-document rule that used to do
+ * it (`.ap-visual-editor__canvas.editor-styles-wrapper`) can't reach
+ * the iframe document. Hosts still override `--ap-editor-canvas-bg` /
+ * `--ap-editor-canvas-fg`; once the theme.json reader lands it'll
+ * supply these from `settings.color.background`.
  */
-.ap-visual-editor__canvas.editor-styles-wrapper,
-.editor-styles-wrapper.ap-visual-editor__canvas {
-    background-color: var(--ap-editor-canvas-bg, #ffffff);
-    color: var(--ap-editor-canvas-fg, #1f2937);
+.ap-visual-editor__canvas-frame {
+    flex: 1 1 auto;
+    min-height: 0;
 }
 
 .ap-visual-editor__sidebar {

--- a/resources/js/visual-editor/editor/editor-app.tsx
+++ b/resources/js/visual-editor/editor/editor-app.tsx
@@ -16,14 +16,7 @@ import {
     useState,
 } from 'react';
 import { Alert, ToastProvider } from '@artisanpack-ui/react/feedback';
-import {
-    BlockContextProvider,
-    BlockEditorProvider,
-    BlockList,
-    BlockTools,
-    ObserveTyping,
-    WritingFlow,
-} from '@wordpress/block-editor';
+import { BlockEditorProvider } from '@wordpress/block-editor';
 import { registerCoreBlocks } from '@wordpress/block-library';
 import { Popover, SlotFillProvider } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -40,13 +33,14 @@ import type { BlockInstance } from '@wordpress/blocks';
 import { addFilter } from '@wordpress/hooks';
 
 import { bootI18n, TEXT_DOMAIN } from '../vendor/i18n';
-import { DEFAULT_CANVAS_STYLES, editorSettings } from '../editor-settings';
+import { editorSettings } from '../editor-settings';
 import { ensureMediaBridgeFilter } from '../media-bridge';
 
 import { BlockLibrarySidebar } from './block-library-sidebar';
 import { registerContrastWarning } from './contrast-warning';
 import { ConvertToPatternControl } from './convert-to-pattern-control';
 import { discoverAndRegisterCustomBlocks } from './custom-blocks';
+import { EditorCanvas } from './editor-canvas';
 import { registerCoreQueryBlockOverride } from './query-block-override';
 import { registerSyncedPatternIndicator } from './synced-pattern-indicator';
 import { registerTaxonomyAndArchiveBlockOverrides } from './taxonomy-archive-block-overrides';
@@ -61,11 +55,16 @@ import {
 import { entityTypeForResource } from './entity-type';
 import { InspectorSidebar } from './inspector-sidebar';
 import { KeyboardShortcutsModal } from './keyboard-shortcuts-modal';
-import { PostTitle } from './post-title';
 import { useSaveNotifications } from './save-notifications';
 import { TopBar } from './top-bar';
 import { usePersistence } from './use-persistence';
 
+// Side-effect imports for the editor *chrome* — the top bar, block
+// toolbar, and inspector sidebar that render in the parent document,
+// outside the `BlockCanvas` iframe. The same stylesheets are injected
+// *into* the iframe separately via `canvas-styles.ts` (#347), because
+// the iframe document doesn't inherit the parent's Vite-injected
+// `<style>` tags.
 import '@wordpress/components/build-style/style.css';
 import '@wordpress/block-editor/build-style/style.css';
 import '@wordpress/block-editor/build-style/content.css';
@@ -865,43 +864,22 @@ function EditorAppShell(props: EditorAppProps): JSX.Element {
                     <BlockLibrarySidebar apiBase={props.apiBase} />
                 </div>
             ) : null}
-            <div className="editor-styles-wrapper ap-visual-editor__canvas">
-                {/*
-                 * Default canvas stylesheet rendered inline. Gutenberg's
-                 * `settings.styles` channel only injects into the
-                 * `<Iframe>` canvas; our editor renders the block list
-                 * in the same DOM tree, so we inline the rules here.
-                 * Themes that ship a theme.json get their stylesheet
-                 * appended after this `<style>` and win on cascade.
-                 */}
-                <style>{DEFAULT_CANVAS_STYLES}</style>
-                {supports?.title !== false && (
-                    <PostTitle value={title} onChange={handleTitleChange} />
-                )}
-                <BlockTools>
-                    <WritingFlow>
-                        <ObserveTyping>
-                            {/*
-                             * G4a: stamp `postType`/`postId` into block context
-                             * for cms-framework Post/Page edits so `core/post-*`
-                             * blocks (which declare `usesContext: ["postId",
-                             * "postType", "queryId"]`) see the active entity.
-                             * Outside an entity-mounted canvas the values stay
-                             * undefined and the blocks render their placeholder
-                             * shell — same behaviour as a query-loop descendant
-                             * with no parent providing the context.
-                             */}
-                            {documentType !== null && numericId !== null ? (
-                                <BlockContextProvider value={blockContextValue}>
-                                    <BlockList />
-                                </BlockContextProvider>
-                            ) : (
-                                <BlockList />
-                            )}
-                        </ObserveTyping>
-                    </WritingFlow>
-                </BlockTools>
-            </div>
+            {/*
+             * #347: the block list renders inside `EditorCanvas`'s
+             * `BlockCanvas` iframe. `blockContextValue` is non-null
+             * exactly for cms-framework Post/Page edits — it stamps
+             * `postType`/`postId` into block context so `core/post-*`
+             * blocks (which declare `usesContext: ["postId",
+             * "postType", "queryId"]`) see the active entity. Outside
+             * an entity-mounted canvas it's null and the blocks render
+             * their placeholder shell.
+             */}
+            <EditorCanvas
+                showTitle={supports?.title !== false}
+                title={title}
+                onTitleChange={handleTitleChange}
+                blockContext={blockContextValue}
+            />
             <Popover.Slot />
             <ConvertToPatternControl apiBase={props.apiBase} />
             {inspectorOpen ? (

--- a/resources/js/visual-editor/editor/editor-canvas.tsx
+++ b/resources/js/visual-editor/editor/editor-canvas.tsx
@@ -1,0 +1,94 @@
+/**
+ * Post-editor canvas region — #347.
+ *
+ * A1 (#343) rendered the block list directly inside the admin chrome.
+ * That worked, but the editor's React tree shared a DOM surface with
+ * the parent admin, so high-frequency `setAttributes` dispatches (the
+ * color/gradient picker dragged fast) accumulated layout-effect
+ * backpressure past React's update-depth guard and crashed the
+ * selected block via `BlockCrashBoundary`.
+ *
+ * `BlockCanvas` (`shouldIframe: true` by default) moves the block list
+ * into a same-origin iframe — the same isolation `@wordpress/editor`
+ * relies on. Block-support hooks measure against the iframe's stable
+ * surface instead of contending with parent layout updates, so the
+ * crash can't accumulate.
+ *
+ * Composition notes:
+ *   - `PostTitle` stays *outside* the iframe. It's editor chrome, not
+ *     block content — keeping it in the parent document means it picks
+ *     up the shell font and the `post-title.css` rules without those
+ *     having to be mirrored into the iframe.
+ *   - `BlockCanvas` already wraps its children in `BlockTools`, and the
+ *     `Iframe` it mounts provides `WritingFlow` internally — so this
+ *     component only supplies `ObserveTyping` + `BlockList` as children.
+ *   - The `BlockEditorProvider` is intentionally *not* here. It stays
+ *     in `editor-app.tsx` wrapping the inserter, canvas, and inspector
+ *     together so they share one `core/block-editor` registry scope
+ *     (the #436 lesson — a provider mounted per-region left the
+ *     inspector blind to block selection).
+ */
+
+import {
+    BlockCanvas,
+    BlockContextProvider,
+    BlockList,
+    ObserveTyping,
+} from '@wordpress/block-editor';
+
+import { canvasStyles } from './canvas-styles';
+import { PostTitle } from './post-title';
+
+/** Block context value stamped onto the canvas for cms-framework entities. */
+export interface CanvasBlockContext {
+    postType: string;
+    postId: number;
+}
+
+export interface EditorCanvasProps {
+    /** Whether the document type supports an editable title. */
+    showTitle: boolean;
+    /** Current title value — mirrored from the editor-app state. */
+    title: string;
+    /** Title change handler — stages the entity edit + save debounce. */
+    onTitleChange: (value: string) => void;
+    /**
+     * `core/post-*` block context. Non-null only when the editor is
+     * mounted against a cms-framework Post/Page; `null` for custom
+     * `HasBlockContent` models and legacy fixtures, where the blocks
+     * render their placeholder shell.
+     */
+    blockContext: CanvasBlockContext | null;
+}
+
+/**
+ * Renders the post title and the iframed block canvas. Assumes a
+ * `BlockEditorProvider` ancestor (mounted in `editor-app.tsx`).
+ */
+export function EditorCanvas(props: EditorCanvasProps): JSX.Element {
+    const { showTitle, title, onTitleChange, blockContext } = props;
+
+    const blockList = <BlockList />;
+
+    return (
+        <div
+            className="ap-visual-editor__canvas"
+            data-testid="ap-visual-editor-canvas"
+        >
+            {showTitle ? (
+                <PostTitle value={title} onChange={onTitleChange} />
+            ) : null}
+            <div className="ap-visual-editor__canvas-frame">
+                <BlockCanvas height="100%" styles={canvasStyles}>
+                    {blockContext !== null ? (
+                        <BlockContextProvider value={blockContext}>
+                            <ObserveTyping>{blockList}</ObserveTyping>
+                        </BlockContextProvider>
+                    ) : (
+                        <ObserveTyping>{blockList}</ObserveTyping>
+                    )}
+                </BlockCanvas>
+            </div>
+        </div>
+    );
+}

--- a/resources/js/visual-editor/vite-env.d.ts
+++ b/resources/js/visual-editor/vite-env.d.ts
@@ -1,0 +1,7 @@
+/// <reference types="vite/client" />
+
+// Pulls in Vite's ambient module declarations for asset imports — most
+// importantly `*.css?inline`, which `editor/canvas-styles.ts` uses to
+// resolve stylesheets to their CSS text for injection into the editor's
+// `BlockCanvas` iframe (#347). Without this reference TypeScript can't
+// resolve the `?inline` query suffix.


### PR DESCRIPTION
## Description

Moves the post-editor canvas into a same-origin iframe via `@wordpress/block-editor`'s `BlockCanvas`, so the editor's React tree is isolated from the admin DOM. This is the architectural difference that stops the color-picker fast-drag crash — Slice 2.5 of `plans/08-themes-site-editor-arc.md`.

**Closes:** #347

## Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds new functionality)
- [x] Enhancement (improves existing functionality)
- [ ] Refactoring (code improvement, no behavior change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Security fix
- [ ] Breaking change (breaks backward compatibility)

## Related Issue

**Issue:** #347

## Motivation and Context

A1 (#343) rendered the block list directly inside the admin chrome. During manual testing, dragging the color/gradient picker fast crashed the selected block with "Maximum update depth exceeded" (caught by `BlockCrashBoundary`) — the per-frame `setAttributes` dispatches from `react-colorful` piled up faster than React could settle.

WordPress's own post editor doesn't hit this because `@wordpress/editor` iframes its canvas: block-support hooks measure against a stable surface instead of contending with parent layout updates. This PR adopts the same isolation.

## Changes Made

- **Extract `EditorCanvas`** — the canvas region (post title + iframed block list) moves out of `editor-app.tsx`. `PostTitle` stays *outside* the iframe (editor chrome, not block content); the `BlockEditorProvider` stays in `editor-app.tsx` so the inserter, canvas, and inspector share one `core/block-editor` registry scope (the #436 lesson).
- **Swap `BlockTools`/`WritingFlow`/`BlockList` for `BlockCanvas`** — `BlockCanvas` mounts the block list in a same-origin iframe and supplies `BlockTools` + `WritingFlow` itself.
- **Add `canvas-styles.ts`** — the iframe document is sandboxed: none of the Vite-injected `@wordpress/*` stylesheets cross into it, and `getCompatibilityStyles` skips them (Vite's `<style>` tags carry no `id`). So the `@wordpress/*` sheets + a token bridge + `DEFAULT_CANVAS_STYLES` are imported with Vite's `?inline` query and handed to `BlockCanvas`'s `styles` prop. `editor-app.tsx` keeps its side-effect imports for the parent-document chrome (top bar, toolbar, inspector).
- **Add `canvas-theme-tokens.css`** — re-establishes the `--wp-*` / `--color-*` custom properties on the iframe root; the shell-scoped `visual-editor-theme.css` targets `.ap-visual-editor__shell`, which doesn't exist inside the iframe.
- **Add `vite-env.d.ts`** — pulls in Vite's ambient `*.css?inline` module declaration.
- **`editor-app.css`** — the canvas region becomes a flex column (`PostTitle` above an iframe-filling frame).

### Known constraint (recorded decision)

The public `BlockCanvas` API only accepts `{ children, height, styles }` — it does not forward `title`, `tabIndex`, or `iframeProps`. The canvas iframe therefore uses WordPress's default `title="Editor canvas"` (not run through this package's text domain). Customizing it would mean dropping to the private `ExperimentalBlockCanvas` API, deliberately avoided here. Tracked for review in the pre-v1.0 accessibility audit, **#450**.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (Darwin 25.5.0)
- Browser (if applicable): Tested in-browser via the Keystone CMS consumer (`/admin/posts/{id}/edit`)
- PHP Version: 8.4
- Project Version: 1.0.0-spike

**Tests Performed:**
1. `npm run test` — full suite, 1028 passing / 1 skipped (110 files).
2. `npm run build` — succeeds; verified the `?inline` `@wordpress/*` CSS and the token bridge land in the built bundle.
3. Manual browser test in Keystone: canvas renders inside the iframe, color picker drags at full speed without crashing, PostTitle renders above the canvas, editor styles apply inside the iframe, chrome (top bar / toolbar / inspector) unaffected.

## Accessibility Tests Run

- [x] Keyboard navigation tested
- [ ] Screen reader tested
- [ ] Color contrast verified
- [ ] ARIA labels checked

**Details:** Keyboard tab in/out of the iframe verified during manual testing (WordPress's `Iframe` renders focus-capture sentinels so the canvas isn't a focus trap). A full WCAG pass over the post editor + site editor — including screen reader and the `BlockCanvas` `title` constraint above — is tracked separately as **#450**, scoped for completion before v1.0.

## Tests Added

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All tests passing

**Test details:**
- `canvas-styles.test.ts` — asserts the `canvasStyles` bundle shape, count, and cascade-order anchor (`DEFAULT_CANVAS_STYLES` last). The `@wordpress/*` `?inline` imports collapse to empty strings under vitest (`css: false`), so the suite verifies structure rather than re-checking Gutenberg's CSS text.
- `editor-canvas.test.tsx` — stubs `@wordpress/block-editor` (the established `canvas-frame.test.tsx` pattern, since the real iframe doesn't mount reliably in jsdom) and verifies the `BlockCanvas` mount, `canvasStyles` injection, `PostTitle` placement, and the cms-framework `BlockContextProvider` wrap.

## Documentation

- [x] Inline code documentation added
- [ ] README updated
- [ ] Wiki updated
- [ ] API documentation updated

**Documentation details:** New files carry file-header doc comments explaining the iframe isolation rationale, the sandboxed-document style-injection path, and the token-bridge scope.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [x] Accessibility tests completed
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced canvas theme tokens and styling system for the editor iframe.
  * Added new EditorCanvas component for managing the visual editor canvas region.

* **Refactor**
  * Refactored canvas layout from single scrolling element to flex column structure with overflow containment.
  * Moved canvas surface styling responsibility from parent document to iframe.

* **Tests**
  * Added comprehensive test suites for canvas styles and EditorCanvas component.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArtisanPack-UI/visual-editor/pull/451)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->