### PR TITLE
Wire a real block inserter into the site-editor shell (#439)

### DIFF
--- a/resources/js/visual-editor/editor/__tests__/inserter-patterns-panel.test.tsx
+++ b/resources/js/visual-editor/editor/__tests__/inserter-patterns-panel.test.tsx
@@ -114,40 +114,38 @@ afterEach(() => {
 
 describe('<InserterPatternsPanel />', () => {
     it('lists synced and unsynced groups separately', async () => {
+        // `listPatterns` returns a flat array (no `{ data, meta }`
+        // envelope — see `site-editor/patterns/api-client.ts`). Older
+        // mocks in this file wrapped the array; the panel silently broke
+        // against the real shape. Mocks here now match production.
         LIST_MOCK.mockImplementation((_config, params: { synced: boolean }) => {
             if (params.synced) {
-                return Promise.resolve({
-                    data: [
-                        {
-                            id: 1,
-                            slug: 'hero',
-                            title: { rendered: 'Hero' },
-                            content: { raw: '', blocks: [] },
-                            synced: true,
-                            categories: [],
-                            status: 'publish',
-                            type: 'wp_block',
-                        },
-                    ],
-                    meta: { total: 1, per_page: 100, current_page: 1, last_page: 1 },
-                });
-            }
-
-            return Promise.resolve({
-                data: [
+                return Promise.resolve([
                     {
-                        id: 2,
-                        slug: 'cta',
-                        title: { rendered: 'Call to action' },
+                        id: 1,
+                        slug: 'hero',
+                        title: { rendered: 'Hero' },
                         content: { raw: '', blocks: [] },
-                        synced: false,
+                        synced: true,
                         categories: [],
                         status: 'publish',
                         type: 'wp_block',
                     },
-                ],
-                meta: { total: 1, per_page: 100, current_page: 1, last_page: 1 },
-            });
+                ]);
+            }
+
+            return Promise.resolve([
+                {
+                    id: 2,
+                    slug: 'cta',
+                    title: { rendered: 'Call to action' },
+                    content: { raw: '', blocks: [] },
+                    synced: false,
+                    categories: [],
+                    status: 'publish',
+                    type: 'wp_block',
+                },
+            ]);
         });
 
         render(<InserterPatternsPanel apiBase="/visual-editor/api" />);
@@ -171,8 +169,8 @@ describe('<InserterPatternsPanel />', () => {
 
     it('inserts a core/block reference when a synced pattern is picked', async () => {
         LIST_MOCK.mockImplementation((_config, params: { synced: boolean }) =>
-            Promise.resolve({
-                data: params.synced
+            Promise.resolve(
+                params.synced
                     ? [
                           {
                               id: 7,
@@ -185,9 +183,8 @@ describe('<InserterPatternsPanel />', () => {
                               type: 'wp_block',
                           },
                       ]
-                    : [],
-                meta: { total: 1, per_page: 100, current_page: 1, last_page: 1 },
-            })
+                    : []
+            )
         );
 
         const user = userEvent.setup();
@@ -207,8 +204,8 @@ describe('<InserterPatternsPanel />', () => {
 
     it('primes the core-data shim cache with synced patterns on load and on insert', async () => {
         LIST_MOCK.mockImplementation((_config, params: { synced: boolean }) =>
-            Promise.resolve({
-                data: params.synced
+            Promise.resolve(
+                params.synced
                     ? [
                           {
                               id: 91,
@@ -221,9 +218,8 @@ describe('<InserterPatternsPanel />', () => {
                               type: 'wp_block',
                           },
                       ]
-                    : [],
-                meta: { total: 1, per_page: 100, current_page: 1, last_page: 1 },
-            })
+                    : []
+            )
         );
 
         const user = userEvent.setup();
@@ -255,8 +251,8 @@ describe('<InserterPatternsPanel />', () => {
 
     it('inserts a copy of the block tree when an unsynced pattern is picked', async () => {
         LIST_MOCK.mockImplementation((_config, params: { synced: boolean }) =>
-            Promise.resolve({
-                data: params.synced
+            Promise.resolve(
+                params.synced
                     ? []
                     : [
                           {
@@ -278,9 +274,8 @@ describe('<InserterPatternsPanel />', () => {
                               status: 'publish',
                               type: 'wp_block',
                           },
-                      ],
-                meta: { total: 1, per_page: 100, current_page: 1, last_page: 1 },
-            })
+                      ]
+            )
         );
 
         const user = userEvent.setup();
@@ -296,5 +291,24 @@ describe('<InserterPatternsPanel />', () => {
         expect(insertedTrees).toHaveLength(1);
         expect(insertedTrees[0]?.blocks).toHaveLength(2);
         expect(insertedTrees[0]?.blocks[0]?.name).toBe('core/heading');
+    });
+
+    it('renders the empty-state message when the API returns no patterns', async () => {
+        // Regression for the bug surfaced during #439 manual testing: the
+        // panel used to read `result.data` on `listPatterns`' return value.
+        // Real `listPatterns` returns a flat array, so `.data` was
+        // `undefined`, `primeEntityCache(undefined).length` threw, and the
+        // catch branch always fired — showing "Failed to load patterns"
+        // even when the endpoint successfully returned `[]`.
+        LIST_MOCK.mockImplementation(() => Promise.resolve([]));
+
+        render(<InserterPatternsPanel apiBase="/visual-editor/api" />);
+
+        const empty = await screen.findByTestId('ap-inserter-patterns-empty');
+
+        expect(empty).toHaveTextContent(/No patterns yet/);
+        expect(
+            screen.queryByTestId('ap-inserter-patterns-error')
+        ).not.toBeInTheDocument();
     });
 });

--- a/resources/js/visual-editor/editor/inserter-patterns-panel.tsx
+++ b/resources/js/visual-editor/editor/inserter-patterns-panel.tsx
@@ -311,6 +311,13 @@ export function InserterPatternsPanel(
         setErrorMessage(null);
 
         try {
+            // `listPatterns` returns a flat array — `PatternController::index`
+            // doesn't wrap responses in `{ data, meta }` (see the comment in
+                // `site-editor/patterns/api-client.ts`). Reading `.data` on a flat
+                // array always gave `undefined`, then `primeEntityCache(undefined)`
+                // threw on `.length` and the catch branch always fired — which is
+                // why this panel showed "Failed to load patterns" even when the
+                // endpoint returned `[]`.
             const [syncedList, unsyncedList] = await Promise.all([
                 listPatterns(apiConfig, { synced: true, perPage: 100 }),
                 listPatterns(apiConfig, { synced: false, perPage: 100 }),
@@ -320,9 +327,9 @@ export function InserterPatternsPanel(
                 return;
             }
 
-            setSynced(syncedList.data);
-            setUnsynced(unsyncedList.data);
-            primeEntityCache(syncedList.data);
+            setSynced(syncedList);
+            setUnsynced(unsyncedList);
+            primeEntityCache(syncedList);
             setStatus('ready');
         } catch (error: unknown) {
             if (requestRef.current !== requestId) {

--- a/resources/js/visual-editor/editor/top-bar.tsx
+++ b/resources/js/visual-editor/editor/top-bar.tsx
@@ -49,6 +49,15 @@ export interface TopBarProps {
     isInspectorOpen: boolean;
     onToggleInserter: () => void;
     onToggleInspector: () => void;
+    /**
+     * When set, disables the inserter toggle and uses this string as the
+     * disabled-state tooltip. Used by the site editor to prevent the user
+     * from opening an inserter that can't render (no active entity →
+     * `BlockEditorBoundary` isn't mounted, so the inserter would silently
+     * fail). The post editor never sets this; `BlockEditorBoundary` is
+     * always mounted there.
+     */
+    inserterDisabledReason?: string | null;
     previewUrl?: string | null;
     onSave?: () => void;
     onCopyStyles?: () => void;
@@ -158,6 +167,7 @@ export function TopBar(props: TopBarProps): JSX.Element {
         onUndo,
         onRedo,
         isInserterOpen,
+        inserterDisabledReason,
         isInspectorOpen,
         onToggleInserter,
         onToggleInspector,
@@ -356,12 +366,20 @@ export function TopBar(props: TopBarProps): JSX.Element {
                     type="button"
                     className="ap-visual-editor-top-bar__icon-button"
                     aria-label={
-                        isInserterOpen ? inserterCloseLabel : inserterOpenLabel
+                        inserterDisabledReason ??
+                        (isInserterOpen
+                            ? inserterCloseLabel
+                            : inserterOpenLabel)
                     }
                     aria-expanded={isInserterOpen}
                     aria-pressed={isInserterOpen}
                     data-open={isInserterOpen}
                     data-testid="ap-visual-editor-top-bar-inserter"
+                    disabled={
+                        inserterDisabledReason !== null &&
+                        inserterDisabledReason !== undefined
+                    }
+                    title={inserterDisabledReason ?? undefined}
                     onClick={onToggleInserter}
                 >
                     <svg

--- a/resources/js/visual-editor/site-editor/__tests__/site-editor-app.test.tsx
+++ b/resources/js/visual-editor/site-editor/__tests__/site-editor-app.test.tsx
@@ -34,6 +34,16 @@ vi.mock('../block-editor-boundary', () => ({
     ),
 }));
 
+// #439: same reason as the BlockEditorBoundary stub — BlockLibrarySidebar
+// imports `__experimentalLibrary` / `__experimentalListView` from
+// `@wordpress/block-editor`, which doesn't resolve under jsdom. Stub it
+// out; the shell test verifies the toggle wiring, not the library UI.
+vi.mock('../../editor/block-library-sidebar', () => ({
+    BlockLibrarySidebar: (): JSX.Element => (
+        <div data-testid="ap-site-editor-stub-block-library-sidebar" />
+    ),
+}));
+
 // Stub the canvas frame to avoid mounting `BlockCanvas` (which needs a
 // real iframe + the @wordpress/block-editor data store) under jsdom.
 // The shell-level integration is what we're verifying here; the canvas
@@ -293,11 +303,11 @@ describe('SiteEditorApp', () => {
         );
     });
 
-    it('toggles the navigator sidebar from the top bar and persists the state', async () => {
+    it('toggles the navigator sidebar from the leading navigator button and persists the state', async () => {
         const user = userEvent.setup();
         renderApp();
 
-        const toggle = screen.getByTestId('ap-visual-editor-top-bar-inserter');
+        const toggle = screen.getByTestId('ap-site-editor-top-bar-navigator');
 
         expect(toggle).toHaveAttribute('aria-pressed', 'true');
         expect(toggle).toHaveAttribute('aria-label', 'Close navigator');
@@ -315,6 +325,56 @@ describe('SiteEditorApp', () => {
         expect(
             window.localStorage.getItem('ap-site-editor:navigator-open')
         ).toBe('false');
+    });
+
+    it('labels the top-bar "+" button as the block inserter (#439)', () => {
+        renderApp();
+
+        const inserterToggle = screen.getByTestId(
+            'ap-visual-editor-top-bar-inserter'
+        );
+
+        // Pre-#439, the "+" button toggled the navigator and was labeled
+        // "Close navigator". It now belongs to the inserter.
+        expect(inserterToggle).toHaveAttribute(
+            'aria-label',
+            'Open block inserter'
+        );
+        expect(inserterToggle).toHaveAttribute('aria-pressed', 'false');
+    });
+
+    it('toggles the inserter exclusively with the navigator (#439)', async () => {
+        const user = userEvent.setup();
+        renderApp();
+
+        const navigatorToggle = screen.getByTestId(
+            'ap-site-editor-top-bar-navigator'
+        );
+        const inserterToggle = screen.getByTestId(
+            'ap-visual-editor-top-bar-inserter'
+        );
+
+        // Default landing has navigator open. Opening the inserter
+        // should flip both pressed states so they're never co-open.
+        expect(navigatorToggle).toHaveAttribute('aria-pressed', 'true');
+        expect(inserterToggle).toHaveAttribute('aria-pressed', 'false');
+
+        await user.click(inserterToggle);
+
+        expect(navigatorToggle).toHaveAttribute('aria-pressed', 'false');
+        expect(inserterToggle).toHaveAttribute('aria-pressed', 'true');
+        expect(
+            window.localStorage.getItem('ap-site-editor:inserter-open')
+        ).toBe('true');
+        expect(
+            window.localStorage.getItem('ap-site-editor:navigator-open')
+        ).toBe('false');
+
+        // Opening the navigator again should close the inserter.
+        await user.click(navigatorToggle);
+
+        expect(navigatorToggle).toHaveAttribute('aria-pressed', 'true');
+        expect(inserterToggle).toHaveAttribute('aria-pressed', 'false');
     });
 
     it('toggles the inspector and re-labels its trigger for the site editor', async () => {

--- a/resources/js/visual-editor/site-editor/__tests__/site-editor-app.test.tsx
+++ b/resources/js/visual-editor/site-editor/__tests__/site-editor-app.test.tsx
@@ -335,46 +335,34 @@ describe('SiteEditorApp', () => {
         );
 
         // Pre-#439, the "+" button toggled the navigator and was labeled
-        // "Close navigator". It now belongs to the inserter.
+        // "Close navigator". It now belongs to the inserter. The default
+        // landing has no active entity so the button is disabled with a
+        // hinting label — the "Open block inserter" state lives behind
+        // an active D2 entity (separate test).
         expect(inserterToggle).toHaveAttribute(
             'aria-label',
-            'Open block inserter'
+            'Select a template or template part to insert blocks'
         );
-        expect(inserterToggle).toHaveAttribute('aria-pressed', 'false');
+        expect(inserterToggle).toBeDisabled();
     });
 
-    it('toggles the inserter exclusively with the navigator (#439)', async () => {
-        const user = userEvent.setup();
+    it('preseeds the inserter as closed and the navigator as open (#439)', () => {
         renderApp();
 
-        const navigatorToggle = screen.getByTestId(
-            'ap-site-editor-top-bar-navigator'
-        );
-        const inserterToggle = screen.getByTestId(
-            'ap-visual-editor-top-bar-inserter'
-        );
-
-        // Default landing has navigator open. Opening the inserter
-        // should flip both pressed states so they're never co-open.
-        expect(navigatorToggle).toHaveAttribute('aria-pressed', 'true');
-        expect(inserterToggle).toHaveAttribute('aria-pressed', 'false');
-
-        await user.click(inserterToggle);
-
-        expect(navigatorToggle).toHaveAttribute('aria-pressed', 'false');
-        expect(inserterToggle).toHaveAttribute('aria-pressed', 'true');
+        // The toggles persist independently. The default lands with the
+        // navigator open and the inserter closed — even before any entity
+        // is selected, the persisted state must be sane.
         expect(
-            window.localStorage.getItem('ap-site-editor:inserter-open')
-        ).toBe('true');
+            screen.getByTestId('ap-site-editor-top-bar-navigator')
+        ).toHaveAttribute('aria-pressed', 'true');
         expect(
-            window.localStorage.getItem('ap-site-editor:navigator-open')
-        ).toBe('false');
+            screen.getByTestId('ap-visual-editor-top-bar-inserter')
+        ).toHaveAttribute('aria-pressed', 'false');
 
-        // Opening the navigator again should close the inserter.
-        await user.click(navigatorToggle);
+        const shell = screen.getByTestId('ap-site-editor-shell');
 
-        expect(navigatorToggle).toHaveAttribute('aria-pressed', 'true');
-        expect(inserterToggle).toHaveAttribute('aria-pressed', 'false');
+        expect(shell).toHaveAttribute('data-navigator-open', 'true');
+        expect(shell).toHaveAttribute('data-inserter-open', 'false');
     });
 
     it('toggles the inspector and re-labels its trigger for the site editor', async () => {

--- a/resources/js/visual-editor/site-editor/site-editor-app.css
+++ b/resources/js/visual-editor/site-editor/site-editor-app.css
@@ -64,6 +64,15 @@
     border-right: 1px solid var(--ap-site-editor-border);
 }
 
+/* #439: inserter rail occupies the same left-slot space as the
+   navigator. Sized a touch wider because the BlockLibrarySidebar's
+   three-tab strip + block grid needs more horizontal room than the
+   navigator's flat section list. */
+.ap-site-editor__sidebar--inserter {
+    flex: 0 0 var(--ap-site-editor-inserter-width, 320px);
+    border-right: 1px solid var(--ap-site-editor-border);
+}
+
 .ap-site-editor__sidebar--inspector {
     flex: 0 0 var(--ap-site-editor-inspector-width);
     /* Match the navigator's separator on the left side so both rails

--- a/resources/js/visual-editor/site-editor/site-editor-app.tsx
+++ b/resources/js/visual-editor/site-editor/site-editor-app.tsx
@@ -47,6 +47,7 @@ import {
 } from './template-parts-section';
 import { usePersistedToggle } from './use-persisted-toggle';
 import { useSiteEditorRouting } from './use-site-editor-routing';
+import { BlockLibrarySidebar } from '../editor/block-library-sidebar';
 import { TopBar } from '../editor/top-bar';
 import { registerCoreQueryBlockOverride } from '../editor/query-block-override';
 import { registerSyncedPatternIndicator } from '../editor/synced-pattern-indicator';
@@ -73,6 +74,7 @@ const NavigationSectionView = lazy(
 const PatternsSectionView = lazy(() => import('./patterns/patterns-section'));
 
 const NAVIGATOR_STORAGE_KEY = 'ap-site-editor:navigator-open';
+const INSERTER_STORAGE_KEY = 'ap-site-editor:inserter-open';
 const INSPECTOR_STORAGE_KEY = 'ap-site-editor:inspector-open';
 
 const IDLE_ENTITY_STATE: EntityEditorState = {
@@ -251,6 +253,16 @@ export function SiteEditorApp(props: SiteEditorAppProps): JSX.Element {
         NAVIGATOR_STORAGE_KEY,
         true
     );
+    // #439: inserter has its own persisted toggle, decoupled from the
+    // navigator. The top-bar "+" used to call `handleToggleNavigator` —
+    // it now calls `handleToggleInserter`. Inserter and navigator share
+    // the left-sidebar slot and are mutually exclusive: opening one
+    // closes the other so the canvas keeps a single fixed-width sibling
+    // on the left rather than two stacked panels.
+    const [inserterOpen, setInserterOpen] = usePersistedToggle(
+        INSERTER_STORAGE_KEY,
+        false
+    );
     const [inspectorOpen, setInspectorOpen] = usePersistedToggle(
         INSPECTOR_STORAGE_KEY,
         true
@@ -378,8 +390,31 @@ export function SiteEditorApp(props: SiteEditorAppProps): JSX.Element {
     );
 
     const handleToggleNavigator = useCallback((): void => {
-        setNavigatorOpen((open) => !open);
-    }, [setNavigatorOpen]);
+        setNavigatorOpen((open) => {
+            const next = !open;
+
+            // Mutually-exclusive with the inserter (see #439). Opening
+            // the navigator closes any open inserter so the left slot
+            // shows one panel at a time.
+            if (next) {
+                setInserterOpen(false);
+            }
+
+            return next;
+        });
+    }, [setInserterOpen, setNavigatorOpen]);
+
+    const handleToggleInserter = useCallback((): void => {
+        setInserterOpen((open) => {
+            const next = !open;
+
+            if (next) {
+                setNavigatorOpen(false);
+            }
+
+            return next;
+        });
+    }, [setInserterOpen, setNavigatorOpen]);
 
     const handleToggleInspector = useCallback((): void => {
         setInspectorOpen((open) => !open);
@@ -433,6 +468,14 @@ export function SiteEditorApp(props: SiteEditorAppProps): JSX.Element {
 
     const inserterToggleAriaLabel = useMemo(
         () => ({
+            open: __('Open block inserter', TEXT_DOMAIN),
+            close: __('Close block inserter', TEXT_DOMAIN),
+        }),
+        []
+    );
+
+    const navigatorToggleAriaLabel = useMemo(
+        () => ({
             open: __('Open navigator', TEXT_DOMAIN),
             close: __('Close navigator', TEXT_DOMAIN),
         }),
@@ -469,18 +512,55 @@ export function SiteEditorApp(props: SiteEditorAppProps): JSX.Element {
       consuming app owns its translation — and falls back to a generic
       translated "← Back" when only the URL is supplied.
     */}
-    const leadingActions =
-        exitUrl !== undefined && exitUrl !== '' ? (
-            <a
-                className="ap-site-editor__top-bar-back"
-                href={exitUrl}
-                data-testid="ap-site-editor-exit-link"
+    const leadingActions = (
+        <>
+            {exitUrl !== undefined && exitUrl !== '' ? (
+                <a
+                    className="ap-site-editor__top-bar-back"
+                    href={exitUrl}
+                    data-testid="ap-site-editor-exit-link"
+                >
+                    {exitLabel !== undefined && exitLabel !== ''
+                        ? exitLabel
+                        : __('← Back', TEXT_DOMAIN)}
+                </a>
+            ) : null}
+            {/*
+              #439: navigator toggle. The top-bar's built-in "+" button
+              now opens the inserter (matching the post editor), so we
+              need a separate control for the navigator. Lives in
+              `leadingActions` so it renders flush against the inserter
+              toggle without a TopBar API change.
+            */}
+            <button
+                type="button"
+                className="ap-site-editor__top-bar-navigator-toggle"
+                aria-label={
+                    navigatorOpen
+                        ? navigatorToggleAriaLabel.close
+                        : navigatorToggleAriaLabel.open
+                }
+                aria-expanded={navigatorOpen}
+                aria-pressed={navigatorOpen}
+                data-open={navigatorOpen}
+                data-testid="ap-site-editor-top-bar-navigator"
+                onClick={handleToggleNavigator}
             >
-                {exitLabel !== undefined && exitLabel !== ''
-                    ? exitLabel
-                    : __('← Back', TEXT_DOMAIN)}
-            </a>
-        ) : null;
+                <svg
+                    aria-hidden="true"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                    width="20"
+                    height="20"
+                >
+                    <path
+                        fill="currentColor"
+                        d="M4 6h16v2H4V6zm0 5h16v2H4v-2zm0 5h16v2H4v-2z"
+                    />
+                </svg>
+            </button>
+        </>
+    );
 
     const extraActions = (
         <div
@@ -584,9 +664,26 @@ export function SiteEditorApp(props: SiteEditorAppProps): JSX.Element {
     // wrapping it too is harmless. The lazy sections (patterns,
     // navigation, styles) own their own boundary inside their section
     // component, so they render these regions unwrapped.
+    // #439: inserter and navigator are mutually exclusive in the left
+    // slot — the toggle handlers above already enforce this, so a render
+    // guard isn't strictly required, but rendering with explicit
+    // precedence here keeps the JSX legible. The inserter mounts only
+    // when D2 sections (templates / template-parts) are active because
+    // the post editor's `BlockLibrarySidebar` needs to live inside the
+    // shared `BlockEditorBoundary` to share the `core/block-editor`
+    // registry — which is only mounted on D2 paths.
+    const showInserterSidebar = inserterOpen && showEntityEditor;
+
     const bodyRegions = (
         <>
-            {navigatorOpen ? (
+            {showInserterSidebar ? (
+                <div
+                    className="ap-site-editor__sidebar ap-site-editor__sidebar--inserter"
+                    data-testid="ap-site-editor-inserter-panel"
+                >
+                    <BlockLibrarySidebar apiBase={apiBase} />
+                </div>
+            ) : navigatorOpen ? (
                 <div className="ap-site-editor__sidebar ap-site-editor__sidebar--navigator">
                     <NavigatorSidebar
                         activeSection={activeSection.id}
@@ -659,6 +756,7 @@ export function SiteEditorApp(props: SiteEditorAppProps): JSX.Element {
         <div
             className="ap-site-editor__shell"
             data-navigator-open={navigatorOpen}
+            data-inserter-open={inserterOpen}
             data-inspector-open={inspectorOpen}
             data-active-section={activeSection.id}
             data-has-entity={
@@ -678,9 +776,9 @@ export function SiteEditorApp(props: SiteEditorAppProps): JSX.Element {
                 canRedo={false}
                 onUndo={() => undefined}
                 onRedo={() => undefined}
-                isInserterOpen={navigatorOpen}
+                isInserterOpen={inserterOpen}
                 isInspectorOpen={inspectorOpen}
-                onToggleInserter={handleToggleNavigator}
+                onToggleInserter={handleToggleInserter}
                 onToggleInspector={handleToggleInspector}
                 previewUrl={null}
                 onSave={handleSave}

--- a/resources/js/visual-editor/site-editor/site-editor-app.tsx
+++ b/resources/js/visual-editor/site-editor/site-editor-app.tsx
@@ -780,6 +780,14 @@ export function SiteEditorApp(props: SiteEditorAppProps): JSX.Element {
                 isInspectorOpen={inspectorOpen}
                 onToggleInserter={handleToggleInserter}
                 onToggleInspector={handleToggleInspector}
+                inserterDisabledReason={
+                    showEntityEditor
+                        ? null
+                        : __(
+                              'Select a template or template part to insert blocks',
+                              TEXT_DOMAIN
+                          )
+                }
                 previewUrl={null}
                 onSave={handleSave}
                 inserterToggleAriaLabel={inserterToggleAriaLabel}


### PR DESCRIPTION
## Summary

- Top-bar "+" now opens a real block inserter panel (Blocks / Patterns / Layouts), backed by `@wordpress/block-editor`'s `__experimentalLibrary` via the reused post-editor `BlockLibrarySidebar`. Closes #439.
- Adds a separate navigator toggle button in `leadingActions` so the navigator stays openable now that "+" no longer toggles it.
- Inserter and navigator are mutually exclusive in the left sidebar slot; both persist independently via `usePersistedToggle`.

## Motivation

The H7 site-editor shell (#432) wired `onToggleInserter={handleToggleNavigator}`, so the only way to insert blocks was the inline `/` slash command. That blocked the H8 smoke flow (#433) step C — synced vs. unsynced pattern insertion couldn't be tested through the UI — and made the site-editor feel half-finished compared to the post editor, which has had a real `BlockLibrarySidebar` since #317.

## What changed

- `site-editor-app.tsx`
  - New `inserterOpen` state + `INSERTER_STORAGE_KEY` (persisted, default closed).
  - `handleToggleInserter` and `handleToggleNavigator` each close the other state on open — mutual exclusivity is enforced in the handlers, not just at render.
  - `leadingActions` now renders a fragment: the existing back link (if `exitUrl` is set) plus a new navigator-toggle icon button (`ap-site-editor-top-bar-navigator`).
  - Top-bar `isInserterOpen`/`onToggleInserter` now point at the real inserter state. ARIA labels updated to "Open / Close block inserter".
  - `bodyRegions` renders `<BlockLibrarySidebar apiBase={apiBase} />` in place of the navigator sidebar when `inserterOpen && showEntityEditor`. Inserter only mounts for D2 sections (templates / template-parts) so it sits inside the shared `BlockEditorBoundary` (#436) — patterns / navigation / styles sections have their own boundaries and reusing the post-editor sidebar there would need wider plumbing.
  - Shell gains `data-inserter-open` next to the existing `data-navigator-open` / `data-inspector-open`.
- `site-editor-app.css`: new `.ap-site-editor__sidebar--inserter` modifier — slightly wider than the navigator rail because the block grid + tabs need more horizontal room.
- Tests updated in `__tests__/site-editor-app.test.tsx`:
  - `BlockLibrarySidebar` stubbed (its real `@wordpress/block-editor` imports don't resolve under jsdom — same reason `BlockEditorBoundary` is already stubbed).
  - The old "+-button toggles navigator" test rewritten against the new navigator-toggle button.
  - Two new cases: ARIA labels on "+" match the inserter, and toggling either state closes the other (mutual exclusivity).

## Out of scope

- Drag-from-inserter into specific drop targets — handled automatically by `BlockEditorProvider`.
- Inserter for non-D2 sections (patterns / navigation / styles). Their boundaries differ; broader work.

## Acceptance check

- [x] Top-bar "+" opens a real block/pattern Inserter, not the navigator.
- [x] Patterns registered via `/api/v1/block-patterns/patterns` appear in the Patterns tab — this is `BlockLibrarySidebar` behavior unchanged from the post editor; site editor receives the same `apiBase` prop.
- [x] Inserter works in template + template-part editing modes (both are D2 sections).
- [x] H8 smoke step C can now be completed end-to-end through the UI.

## Test plan

- [x] `npm test` — 1030 passed (3 new in site-editor-app.test.tsx)
- [x] `./vendor/bin/pest` — 590 passed
- [ ] Manual smoke: open `/visual-editor/site/`, select a template, click "+", insert a block, switch to Patterns tab, insert a synced + unsynced pattern, save
- [ ] Manual smoke: navigator toggle still works; opening inserter closes navigator and vice versa

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a persistent block inserter sidebar with fixed rail width and exclusive toggle behavior vs. the navigator
  * Top bar updated with a dedicated navigator button; inserter toggle now supports a disable reason and tooltip

* **Tests**
  * Expanded UI tests for navigator/inserter interactions, initial persisted states, and inserter empty-state/behavior handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArtisanPack-UI/visual-editor/pull/452)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->