### PR TITLE
feat(site-editor): canvas / front-end style parity + working wide-full alignment

### DIFF
--- a/docs/h8-smoke-flow.md
+++ b/docs/h8-smoke-flow.md
@@ -118,12 +118,29 @@ the pattern record, which propagates to every render site-wide.
 3. Save.
 
 **Assert:**
-- `visual_editor_global_styles` carries the edited payload keyed on
-  `dev-sample`.
-- `GlobalStylesCssProvider::css('dev-sample')` emits the new value in
+- cms-framework's `global_styles` table carries the edited payload
+  keyed on `dev-sample` (slice 5 retired the orphan
+  `visual_editor_global_styles` table — emission now flows through
+  cms-framework's `GlobalStylesEmitter`).
+- `GET /visual-editor/api/global-styles/css` returns the new value in
   the `--wp--preset--color--accent` declaration.
 - Public front-end renders the new color (after cache-bust if the
   consumer caches the compiled CSS).
+
+### G2. Canvas ↔ front-end style parity (Keystone #47)
+
+1. Without making any further edits, open a page that includes the
+   `core/heading` and `core/button` blocks in the site editor.
+2. Compare the canvas rendering against the same page on the public
+   front-end (open in two browser tabs).
+
+**Assert:**
+- Heading typography, link color, button background, and palette
+  preset usage match between the two surfaces. The canvas pulls the
+  same compiled CSS the front-end emits (via
+  `/visual-editor/api/global-styles/css`), so divergence here means
+  the canvas's `BlockEditorBoundary` stopped appending it to
+  `editorSettings.styles`.
 
 ### H. Menus + menu locations
 

--- a/docs/h8-smoke-flow.md
+++ b/docs/h8-smoke-flow.md
@@ -34,10 +34,16 @@ before it reaches downstream consumers.
 
 ### A. Install + activate
 
-1. Run package migrations: `php artisan migrate`. Confirm
-   `template_parts`, `menus`, `menu_items`, `menu_location_assignments`,
-   `visual_editor_templates`, `visual_editor_template_parts`,
-   `visual_editor_patterns`, `visual_editor_global_styles` all exist.
+1. Run package migrations: `php artisan migrate`. Confirm the
+   cms-framework site-editor tables — `templates`, `template_parts`,
+   `block_patterns`, `global_styles`, `menus`, `menu_items`,
+   `menu_location_assignments` — all exist. The legacy
+   `visual_editor_templates` / `visual_editor_template_parts` /
+   `visual_editor_patterns` / `visual_editor_global_styles` tables
+   were retired in #434 (Slice 5); fresh installs never create them,
+   and existing installs have them dropped by the same migration set.
+   If any of those four remain after migration, the drop step
+   regressed — file a bug.
 2. Place `themes/dev-sample/` in the host's themes directory (the path
    resolved by `config('cms.themes.directory')`, default `themes/`).
 3. Activate the theme via the host's theme-management UI or by setting

--- a/resources/js/visual-editor/editor-settings.ts
+++ b/resources/js/visual-editor/editor-settings.ts
@@ -97,23 +97,6 @@ export const DEFAULT_CANVAS_STYLES = `
     color: #1f2937;
 }
 
-.editor-styles-wrapper .block-editor-block-list__layout {
-    max-width: 720px;
-    margin-left: auto;
-    margin-right: auto;
-    padding: 48px 24px 96px;
-}
-
-.editor-styles-wrapper .wp-block[data-align="wide"] {
-    max-width: 1080px;
-    margin-left: auto;
-    margin-right: auto;
-}
-
-.editor-styles-wrapper .wp-block[data-align="full"] {
-    max-width: none;
-}
-
 .editor-styles-wrapper p {
     margin: 0 0 1em;
     font-size: 1rem;
@@ -183,6 +166,86 @@ export const DEFAULT_CANVAS_STYLES = `
 `;
 
 /**
+ * Per-block alignment overrides for the root canvas. Shipped via
+ * {@link DEFAULT_CANVAS_STYLES} since both editors need them — the
+ * toolbar's wide/full buttons set `data-align="wide" | "full"` on the
+ * block; these rules make those attributes visually take effect by
+ * resizing each direct child of the root layout (Keystone #47).
+ *
+ * The previous model clamped the root layout itself to 720px and then
+ * tried to override with `.wp-block[data-align=...] { max-width }` —
+ * which doesn't break out because the parent layout is the cap. This
+ * model flips it: the root layout is full-bleed, and direct children
+ * are sized individually by alignment.
+ *
+ * Scoped to `> .wp-block` so nested blocks (inside `core/group`,
+ * `core/columns`, etc.) aren't affected — those nested layouts have
+ * their own constrained / flex / grid rules.
+ */
+export const ALIGNMENT_OVERRIDE_STYLES = `
+.editor-styles-wrapper .block-editor-block-list__layout.is-root-container > .wp-block.alignwide {
+    max-width: 1080px;
+    margin-left: auto;
+    margin-right: auto;
+}
+
+.editor-styles-wrapper .block-editor-block-list__layout.is-root-container > .wp-block.alignfull {
+    max-width: none;
+    margin-left: 0;
+    margin-right: 0;
+}
+`;
+
+/**
+ * Post-editor-only canvas framing (Keystone #47). Lifted out of
+ * {@link DEFAULT_CANVAS_STYLES} so the site editor's canvas — which
+ * edits templates and template parts that span the full viewport on
+ * the front-end — doesn't inherit a 720px content column it has no
+ * business showing. Post content edits sit inside the front-end's
+ * constrained column, so the post editor keeps the framing.
+ *
+ * Targets each direct child of the root layout rather than the root
+ * itself so blocks marked `data-align="wide" | "full"` (see
+ * {@link ALIGNMENT_OVERRIDE_STYLES}) can break out — clamping the
+ * root container would cap every child regardless of alignment.
+ *
+ * The `is-root-container` scope keeps nested layouts (`<li>` inside
+ * `core/list`, columns inside `core/columns`, every inner container
+ * of `core/group`) out of the rule so each child of a nested layout
+ * doesn't inherit 720px / 48px padding too.
+ */
+export const POST_EDITOR_FRAMING_STYLES = `
+.editor-styles-wrapper .block-editor-block-list__layout.is-root-container {
+    padding: 48px 24px 96px;
+}
+
+.editor-styles-wrapper .block-editor-block-list__layout.is-root-container > .wp-block:not(.alignwide):not(.alignfull) {
+    max-width: 720px;
+    margin-left: auto;
+    margin-right: auto;
+}
+`;
+
+/**
+ * Layout descriptor passed to the root `<BlockList layout={...}>` so
+ * Gutenberg's `BlockLayoutContext` resolves to a `constrained` layout
+ * with explicit `contentSize` / `wideSize`. Without it the root
+ * `BlockList` falls back to the package-internal `{type:"default"}`
+ * default, whose `getAlignments()` returns an empty list — the actual
+ * reason the wide / full alignment buttons never appeared on the
+ * block toolbar (Keystone #47).
+ *
+ * Hardcoded for now; a follow-up will sync `contentSize` / `wideSize`
+ * from the active theme's `theme.json` `settings.layout` via the
+ * `/global-styles/base` endpoint.
+ */
+export const ROOT_CANVAS_LAYOUT = {
+    type: 'constrained',
+    contentSize: '720px',
+    wideSize: '1080px',
+} as const;
+
+/**
  * Block-editor settings seeded with the block-support features needed
  * to light up the inspector panels (Color, Typography, Dimensions,
  * Border, Layout) and the toolbar text-align control. Fed into
@@ -191,6 +254,42 @@ export const DEFAULT_CANVAS_STYLES = `
 export const editorSettings = {
     mediaUpload: mediaUploadSetting,
     alignWide: true,
+    /*
+     * Top-level `layout` mirror of `__experimentalFeatures.layout`.
+     * Mirrored as a value via `ROOT_CANVAS_LAYOUT` below — the canvas
+     * components pass that constant as the `layout` prop to the root
+     * `<BlockList>` so Gutenberg's layout context resolves to
+     * `constrained` instead of the `{type:"default"}` fallback, which
+     * was the actual reason wide/full alignment buttons never showed
+     * on the block toolbar (Keystone #47).
+     * Gutenberg's `useAvailableAlignments` reads from this top-level
+     * setting when deciding whether to show wide/full in the block
+     * toolbar — without it the buttons are hidden even though
+     * `alignWide: true` and the block declares `supports.align`
+     * (Keystone #47). The explicit `type: "constrained"` is
+     * required: the constrained-layout `getAlignments` is what
+     * unshifts `wide` / `full` into the available list (it reads
+     * `contentSize` / `wideSize` off this same object). Without
+     * the type, Gutenberg falls back to the default handler which
+     * surfaces only left/center/right. The
+     * `__experimentalFeatures.layout` path stays around because
+     * other Gutenberg surfaces (the layout panel in the inspector)
+     * read from there.
+     */
+    layout: {
+        type: 'constrained',
+        contentSize: '720px',
+        wideSize: '1080px',
+    },
+    /*
+     * Required alongside `layout` so `useAvailableAlignments` takes
+     * the "supports layout" branch — which invokes the constrained
+     * layout's own `getAlignments(layout, blockBasedTheme)` and
+     * returns wide+full. Without it the function falls into the
+     * legacy branch that only checks the canonical alignment list
+     * and never actually exposes wide/full on `core/group`.
+     */
+    supportsLayout: true,
     /*
      * Default canvas stylesheet (`{ css }`) gives blocks a typographic
      * baseline so headings/paragraphs/links visually differentiate

--- a/resources/js/visual-editor/editor/__tests__/canvas-styles.test.ts
+++ b/resources/js/visual-editor/editor/__tests__/canvas-styles.test.ts
@@ -13,7 +13,10 @@
 
 import { describe, expect, it } from 'vitest';
 
-import { DEFAULT_CANVAS_STYLES } from '../../editor-settings';
+import {
+    DEFAULT_CANVAS_STYLES,
+    POST_EDITOR_FRAMING_STYLES,
+} from '../../editor-settings';
 import { canvasStyles } from '../canvas-styles';
 
 describe('canvasStyles', () => {
@@ -26,15 +29,30 @@ describe('canvasStyles', () => {
         }
     });
 
-    it('bundles the theme token bridge, the three @wordpress sheet groups, and the canvas baseline', () => {
+    it('bundles the theme token bridge, the three @wordpress sheet groups, the canvas baseline, alignment overrides, and the post-editor framing', () => {
         // token bridge + components + block-editor (style + content)
-        // + block-library (style + editor) + DEFAULT_CANVAS_STYLES.
-        expect(canvasStyles).toHaveLength(7);
+        // + block-library (style + editor) + DEFAULT_CANVAS_STYLES
+        // + ALIGNMENT_OVERRIDE_STYLES + POST_EDITOR_FRAMING_STYLES
+        // (Keystone #47 — site-editor canvases skip the framing
+        // entry but keep the alignment overrides so the wide/full
+        // toolbar buttons take effect there too).
+        expect(canvasStyles).toHaveLength(9);
     });
 
-    it('ends with DEFAULT_CANVAS_STYLES so the package typographic baseline wins the cascade', () => {
-        expect(canvasStyles[canvasStyles.length - 1]?.css).toBe(
-            DEFAULT_CANVAS_STYLES
+    it('places DEFAULT_CANVAS_STYLES before POST_EDITOR_FRAMING_STYLES so the framing wins the cascade', () => {
+        const defaultsIndex = canvasStyles.findIndex(
+            (entry) => entry.css === DEFAULT_CANVAS_STYLES
         );
+        const framingIndex = canvasStyles.findIndex(
+            (entry) => entry.css === POST_EDITOR_FRAMING_STYLES
+        );
+
+        expect(defaultsIndex).toBeGreaterThanOrEqual(0);
+        expect(framingIndex).toBeGreaterThan(defaultsIndex);
+        // Framing is the cascade anchor for the post editor's page-like
+        // visual; if anything else were to land after it, that entry
+        // would have to be intentional (theme.json bridge for the post
+        // editor will land after framing).
+        expect(framingIndex).toBe(canvasStyles.length - 1);
     });
 });

--- a/resources/js/visual-editor/editor/canvas-styles.ts
+++ b/resources/js/visual-editor/editor/canvas-styles.ts
@@ -28,7 +28,11 @@ import blockLibraryEditor from '@wordpress/block-library/build-style/editor.css?
 import blockLibraryStyle from '@wordpress/block-library/build-style/style.css?inline';
 import componentsStyle from '@wordpress/components/build-style/style.css?inline';
 
-import { DEFAULT_CANVAS_STYLES } from '../editor-settings';
+import {
+    ALIGNMENT_OVERRIDE_STYLES,
+    DEFAULT_CANVAS_STYLES,
+    POST_EDITOR_FRAMING_STYLES,
+} from '../editor-settings';
 
 import canvasThemeTokens from './canvas-theme-tokens.css?inline';
 
@@ -63,4 +67,13 @@ export const canvasStyles: readonly CanvasStyle[] = [
     { css: blockLibraryStyle },
     { css: blockLibraryEditor },
     { css: DEFAULT_CANVAS_STYLES },
+    // Per-block wide/full overrides. Shared with the site editor —
+    // both need the toolbar's alignment buttons to actually resize
+    // blocks (Keystone #47).
+    { css: ALIGNMENT_OVERRIDE_STYLES },
+    // Post-editor framing — 720px content column applied to direct
+    // children of the root layout. Site-editor canvases skip this
+    // entry so templates + template parts span full-bleed like the
+    // front-end (#47).
+    { css: POST_EDITOR_FRAMING_STYLES },
 ];

--- a/resources/js/visual-editor/editor/editor-app.tsx
+++ b/resources/js/visual-editor/editor/editor-app.tsx
@@ -879,6 +879,7 @@ function EditorAppShell(props: EditorAppProps): JSX.Element {
                 title={title}
                 onTitleChange={handleTitleChange}
                 blockContext={blockContextValue}
+                apiBase={props.apiBase}
             />
             <Popover.Slot />
             <ConvertToPatternControl apiBase={props.apiBase} />

--- a/resources/js/visual-editor/editor/editor-canvas.tsx
+++ b/resources/js/visual-editor/editor/editor-canvas.tsx
@@ -35,9 +35,12 @@ import {
     BlockList,
     ObserveTyping,
 } from '@wordpress/block-editor';
+import { useMemo } from 'react';
 
 import { canvasStyles } from './canvas-styles';
 import { PostTitle } from './post-title';
+import { ROOT_CANVAS_LAYOUT } from '../editor-settings';
+import { useThemeGlobalStylesCss } from '../site-editor/use-theme-global-styles-css';
 
 /** Block context value stamped onto the canvas for cms-framework entities. */
 export interface CanvasBlockContext {
@@ -59,6 +62,14 @@ export interface EditorCanvasProps {
      * render their placeholder shell.
      */
     blockContext: CanvasBlockContext | null;
+    /**
+     * Visual-editor REST base. When supplied, the canvas appends the
+     * active theme's compiled CSS (cms-framework's `GlobalStylesEmitter`
+     * output + `themes/{slug}/style.css`) to {@link canvasStyles} so the
+     * iframe matches the public front-end (Keystone #47). Omit to keep
+     * the canvas on the package-default baseline.
+     */
+    apiBase?: string;
 }
 
 /**
@@ -66,9 +77,23 @@ export interface EditorCanvasProps {
  * `BlockEditorProvider` ancestor (mounted in `editor-app.tsx`).
  */
 export function EditorCanvas(props: EditorCanvasProps): JSX.Element {
-    const { showTitle, title, onTitleChange, blockContext } = props;
+    const { showTitle, title, onTitleChange, blockContext, apiBase } = props;
 
-    const blockList = <BlockList />;
+    // Keystone #47: pull the compiled theme CSS once per `apiBase` and
+    // append it to the iframe's styles array so the canvas surface
+    // matches the public front-end. `useThemeGlobalStylesCss` caches
+    // module-level so multiple consumers (site editor + post editor)
+    // share one fetch when mounted in the same SPA session.
+    const themeCss = useThemeGlobalStylesCss(apiBase);
+    const styles = useMemo(
+        () =>
+            themeCss === undefined || themeCss === ''
+                ? canvasStyles
+                : [...canvasStyles, { css: themeCss }],
+        [themeCss]
+    );
+
+    const blockList = <BlockList layout={ROOT_CANVAS_LAYOUT} />;
 
     return (
         <div
@@ -79,7 +104,7 @@ export function EditorCanvas(props: EditorCanvasProps): JSX.Element {
                 <PostTitle value={title} onChange={onTitleChange} />
             ) : null}
             <div className="ap-visual-editor__canvas-frame">
-                <BlockCanvas height="100%" styles={canvasStyles}>
+                <BlockCanvas height="100%" styles={styles}>
                     {blockContext !== null ? (
                         <BlockContextProvider value={blockContext}>
                             <ObserveTyping>{blockList}</ObserveTyping>

--- a/resources/js/visual-editor/site-editor/__tests__/block-editor-boundary.test.tsx
+++ b/resources/js/visual-editor/site-editor/__tests__/block-editor-boundary.test.tsx
@@ -11,17 +11,29 @@
  * the fix. The provider internals are Gutenberg's; they're stubbed.
  */
 
-import { render, screen, within } from '@testing-library/react';
+import { act, render, screen, within } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
 // Stub `BlockEditorProvider` as a labelled wrapper so the test can
 // assert structure (how many providers, which children sit inside)
-// without booting the real Gutenberg data store under jsdom.
+// without booting the real Gutenberg data store under jsdom. We also
+// capture the latest `settings` prop so the Keystone #47 parity tests
+// can assert what ends up in the canvas's `styles` array.
+const LATEST_SETTINGS = { value: null as unknown };
+
 vi.mock('@wordpress/block-editor', () => ({
-    BlockEditorProvider: ({ children }: { children?: ReactNode }): JSX.Element => (
-        <div data-testid="ap-stub-block-editor-provider">{children}</div>
-    ),
+    BlockEditorProvider: ({
+        children,
+        settings,
+    }: {
+        children?: ReactNode;
+        settings?: unknown;
+    }): JSX.Element => {
+        LATEST_SETTINGS.value = settings;
+
+        return <div data-testid="ap-stub-block-editor-provider">{children}</div>;
+    },
 }));
 
 vi.mock('@wordpress/components', () => {
@@ -40,6 +52,13 @@ vi.mock('@wordpress/components', () => {
 
 vi.mock('@wordpress/format-library', () => ({}));
 
+// Keystone #47: the boundary fetches compiled theme CSS through this
+// module when an apiBase is supplied. Stub it so the test stays
+// deterministic and doesn't touch the network under jsdom.
+vi.mock('../styles/global-styles-api', () => ({
+    fetchGlobalStylesCss: vi.fn(async (): Promise<string> => ''),
+}));
+
 const CONVERT_TO_PATTERN_CONTROL_MOCK = vi.fn((): null => null);
 
 vi.mock('../../editor/convert-to-pattern-control', () => ({
@@ -47,6 +66,8 @@ vi.mock('../../editor/convert-to-pattern-control', () => ({
 }));
 
 import { BlockEditorBoundary } from '../block-editor-boundary';
+import { DEFAULT_CANVAS_STYLES } from '../../editor-settings';
+import { resetThemeGlobalStylesCssCache } from '../use-theme-global-styles-css';
 
 describe('BlockEditorBoundary', () => {
     it('wraps the canvas and inspector slots in a single shared provider', () => {
@@ -88,19 +109,71 @@ describe('BlockEditorBoundary', () => {
         expect(CONVERT_TO_PATTERN_CONTROL_MOCK).not.toHaveBeenCalled();
     });
 
-    it('mounts the convert-to-pattern control when an apiBase is given', () => {
-        CONVERT_TO_PATTERN_CONTROL_MOCK.mockClear();
+    it('passes only DEFAULT_CANVAS_STYLES to the provider when no theme CSS is available (Keystone #47)', () => {
+        LATEST_SETTINGS.value = null;
+        resetThemeGlobalStylesCssCache();
 
         render(
             <BlockEditorBoundary
                 blocks={[]}
                 onChange={() => undefined}
                 onInput={() => undefined}
-                apiBase="/visual-editor/api"
+                themeGlobalStylesCss=""
             >
                 <div data-testid="canvas-slot" />
             </BlockEditorBoundary>
         );
+
+        const settings = LATEST_SETTINGS.value as { styles: { css: string }[] };
+        expect(settings.styles).toHaveLength(1);
+        expect(settings.styles[0]?.css).toBe(DEFAULT_CANVAS_STYLES);
+    });
+
+    it('appends the theme global-styles CSS after DEFAULT_CANVAS_STYLES so it wins on cascade (Keystone #47)', () => {
+        LATEST_SETTINGS.value = null;
+        resetThemeGlobalStylesCssCache();
+
+        const themeCss = ':root { --wp--preset--color--primary: #0f172a; }';
+
+        render(
+            <BlockEditorBoundary
+                blocks={[]}
+                onChange={() => undefined}
+                onInput={() => undefined}
+                themeGlobalStylesCss={themeCss}
+            >
+                <div data-testid="canvas-slot" />
+            </BlockEditorBoundary>
+        );
+
+        const settings = LATEST_SETTINGS.value as { styles: { css: string }[] };
+        // Order matters — Gutenberg cascades the array in order, so the
+        // theme CSS must come after the package's default baseline.
+        expect(settings.styles).toHaveLength(2);
+        expect(settings.styles[0]?.css).toBe(DEFAULT_CANVAS_STYLES);
+        expect(settings.styles[1]?.css).toBe(themeCss);
+    });
+
+    it('mounts the convert-to-pattern control when an apiBase is given', async () => {
+        CONVERT_TO_PATTERN_CONTROL_MOCK.mockClear();
+        resetThemeGlobalStylesCssCache();
+
+        // The boundary's theme-CSS hook fires a fetch when apiBase is
+        // non-empty; flush the in-flight promise inside act() so the
+        // setState that resolves it doesn't trigger the "update was
+        // not wrapped in act" warning.
+        await act(async () => {
+            render(
+                <BlockEditorBoundary
+                    blocks={[]}
+                    onChange={() => undefined}
+                    onInput={() => undefined}
+                    apiBase="/visual-editor/api"
+                >
+                    <div data-testid="canvas-slot" />
+                </BlockEditorBoundary>
+            );
+        });
 
         expect(CONVERT_TO_PATTERN_CONTROL_MOCK).toHaveBeenCalled();
     });

--- a/resources/js/visual-editor/site-editor/__tests__/use-theme-global-styles-css.test.tsx
+++ b/resources/js/visual-editor/site-editor/__tests__/use-theme-global-styles-css.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * Keystone #47 — `useThemeGlobalStylesCss` is the canvas's bridge to
+ * the active theme's compiled global-styles CSS. These tests pin the
+ * three states the boundary depends on:
+ *
+ *   1. No apiBase → settle synchronously to `''` so the boundary
+ *      renders with just `DEFAULT_CANVAS_STYLES`.
+ *   2. apiBase given → fetch on mount, settle to the resolved string.
+ *   3. Module-level cache de-duplicates concurrent mounts so a
+ *      remount inside the same SPA session doesn't re-hit the network.
+ */
+
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+vi.mock('../styles/global-styles-api', () => ({
+    fetchGlobalStylesCss: vi.fn(),
+}));
+
+import { fetchGlobalStylesCss as fetchGlobalStylesCssRaw } from '../styles/global-styles-api';
+
+const FETCH_GLOBAL_STYLES_CSS = vi.mocked(fetchGlobalStylesCssRaw);
+
+import {
+    resetThemeGlobalStylesCssCache,
+    useThemeGlobalStylesCss,
+} from '../use-theme-global-styles-css';
+
+describe('useThemeGlobalStylesCss', () => {
+    beforeEach(() => {
+        FETCH_GLOBAL_STYLES_CSS.mockReset();
+        resetThemeGlobalStylesCssCache();
+    });
+
+    it('settles to "" synchronously when no apiBase is given', () => {
+        const { result } = renderHook(() => useThemeGlobalStylesCss(undefined));
+
+        expect(result.current).toBe('');
+        expect(FETCH_GLOBAL_STYLES_CSS).not.toHaveBeenCalled();
+    });
+
+    it('fetches once on mount and surfaces the resolved CSS', async () => {
+        const css = ':root { --wp--preset--color--primary: #0f172a; }';
+        FETCH_GLOBAL_STYLES_CSS.mockResolvedValue(css);
+
+        const { result } = renderHook(() =>
+            useThemeGlobalStylesCss('/visual-editor/api')
+        );
+
+        // Before the fetch resolves the hook returns `undefined` so
+        // the boundary keeps rendering the package's default canvas
+        // baseline without partial styles.
+        expect(result.current).toBeUndefined();
+
+        await act(async () => {
+            // Flush microtasks so the .then() inside the hook fires.
+        });
+
+        expect(result.current).toBe(css);
+        expect(FETCH_GLOBAL_STYLES_CSS).toHaveBeenCalledTimes(1);
+        expect(FETCH_GLOBAL_STYLES_CSS).toHaveBeenCalledWith({
+            apiBase: '/visual-editor/api',
+        });
+    });
+
+    it('reuses the cached fetch across remounts for the same apiBase', async () => {
+        FETCH_GLOBAL_STYLES_CSS.mockResolvedValue('/*cached*/');
+
+        const first = renderHook(() =>
+            useThemeGlobalStylesCss('/visual-editor/api')
+        );
+
+        await act(async () => {});
+
+        first.unmount();
+
+        renderHook(() => useThemeGlobalStylesCss('/visual-editor/api'));
+
+        await act(async () => {});
+
+        // One fetch total — the cache short-circuits the second mount.
+        expect(FETCH_GLOBAL_STYLES_CSS).toHaveBeenCalledTimes(1);
+    });
+});

--- a/resources/js/visual-editor/site-editor/__tests__/use-theme-global-styles-css.test.tsx
+++ b/resources/js/visual-editor/site-editor/__tests__/use-theme-global-styles-css.test.tsx
@@ -81,4 +81,29 @@ describe('useThemeGlobalStylesCss', () => {
         // One fetch total — the cache short-circuits the second mount.
         expect(FETCH_GLOBAL_STYLES_CSS).toHaveBeenCalledTimes(1);
     });
+
+    it('returns the resolved CSS synchronously from useState on remount-after-resolve', async () => {
+        const css = ':root { --wp--preset--color--primary: #0f172a; }';
+        FETCH_GLOBAL_STYLES_CSS.mockResolvedValue(css);
+
+        const first = renderHook(() =>
+            useThemeGlobalStylesCss('/visual-editor/api')
+        );
+
+        // Wait for the fetch to settle so the cache entry transitions
+        // from `pending` to `resolved`.
+        await act(async () => {});
+        expect(first.result.current).toBe(css);
+
+        first.unmount();
+
+        // The remount must return the cached value on its FIRST
+        // render — no transient `undefined`, no flash of unstyled
+        // canvas (CodeRabbit on PR #456).
+        const second = renderHook(() =>
+            useThemeGlobalStylesCss('/visual-editor/api')
+        );
+
+        expect(second.result.current).toBe(css);
+    });
 });

--- a/resources/js/visual-editor/site-editor/block-editor-boundary.tsx
+++ b/resources/js/visual-editor/site-editor/block-editor-boundary.tsx
@@ -26,6 +26,7 @@ import {
     BlockEditorProvider,
 } from '@wordpress/block-editor';
 import { Popover, SlotFillProvider } from '@wordpress/components';
+import { useMemo } from 'react';
 // `@wordpress/format-library` is a side-effect import: it registers the
 // core rich-text formats (bold, italic, link, …) so the block toolbar's
 // inline formatting controls work inside RichText blocks. It lived in
@@ -36,6 +37,7 @@ import { type ReactNode } from 'react';
 
 import { ConvertToPatternControl } from '../editor/convert-to-pattern-control';
 import { editorSettings } from '../editor-settings';
+import { useThemeGlobalStylesCss } from './use-theme-global-styles-css';
 
 // Gutenberg editor-surface stylesheets. Previously imported by each
 // canvas component; they follow the provider here so the boundary owns
@@ -58,6 +60,14 @@ export interface BlockEditorBoundaryProps {
      */
     apiBase?: string;
     /**
+     * Test-only override for the active theme's compiled CSS. In
+     * production the boundary fetches this through
+     * {@see useThemeGlobalStylesCss} keyed on `apiBase`; tests pass an
+     * explicit string to avoid hitting the network. When `undefined`
+     * the hook drives the value (Keystone #47).
+     */
+    themeGlobalStylesCss?: string;
+    /**
      * Canvas and inspector slots. Both must be rendered as children so
      * they share this boundary's `core/block-editor` registry — even
      * when a section portals them into separate DOM nodes.
@@ -66,13 +76,38 @@ export interface BlockEditorBoundaryProps {
 }
 
 export function BlockEditorBoundary(props: BlockEditorBoundaryProps): JSX.Element {
-    const { blocks, onChange, onInput, apiBase, children } = props;
+    const { blocks, onChange, onInput, apiBase, themeGlobalStylesCss, children } = props;
+
+    // Tests can short-circuit the network by passing a string directly;
+    // production drives the value through the hook keyed on `apiBase`.
+    const fetchedCss = useThemeGlobalStylesCss(apiBase);
+    const themeCss = themeGlobalStylesCss !== undefined ? themeGlobalStylesCss : fetchedCss;
+
+    // Append the theme's compiled global-styles CSS to the editor's
+    // `styles` array so Gutenberg cascades it into the canvas. Memoized
+    // so identity-stable `editorSettings.styles` doesn't bust the
+    // provider's effects on every parent re-render. When no theme CSS
+    // is available we hand the provider the original `editorSettings`
+    // object — no allocation, no diff.
+    const settings = useMemo(() => {
+        if (themeCss === undefined || themeCss === '') {
+            return editorSettings;
+        }
+
+        return {
+            ...editorSettings,
+            styles: [
+                ...editorSettings.styles,
+                { css: themeCss },
+            ],
+        };
+    }, [themeCss]);
 
     return (
         <SlotFillProvider>
             <BlockEditorProvider
                 value={blocks}
-                settings={editorSettings}
+                settings={settings}
                 onChange={onChange}
                 onInput={onInput}
             >

--- a/resources/js/visual-editor/site-editor/canvas-theme-styles.tsx
+++ b/resources/js/visual-editor/site-editor/canvas-theme-styles.tsx
@@ -1,0 +1,44 @@
+/**
+ * Inline `<style>` tag carrying the active theme's compiled CSS
+ * (Keystone #47). Lives inside the `.editor-styles-wrapper` so
+ * the rules cascade onto every block in the canvas — same as the
+ * package's `DEFAULT_CANVAS_STYLES` baseline that sits next to it.
+ *
+ * Why inline instead of `BlockEditorProvider`'s `settings.styles`
+ * channel: the site editor renders the block list in the parent
+ * DOM tree (not in a `<BlockCanvas>` iframe — see #418). Gutenberg
+ * only injects `settings.styles` into the iframe surface; for the
+ * inline path the rules have to live in the DOM as a real `<style>`
+ * tag.
+ *
+ * The CSS comes from `/global-styles/css` — server-side that's
+ * cms-framework's `GlobalStylesEmitter::emit()` plus the active
+ * theme's hand-authored `themes/{slug}/style.css`, concatenated in
+ * cascade order so emitter rules declare `--wp--preset--*` tokens
+ * and the hand-authored sheet consumes / overrides them.
+ *
+ * Renders nothing when no `apiBase` is wired, when the fetch is
+ * still in flight, or when the response was empty — the canvas
+ * stays on `DEFAULT_CANVAS_STYLES` as the floor.
+ */
+
+import { useThemeGlobalStylesCss } from './use-theme-global-styles-css';
+
+export interface CanvasThemeStylesProps {
+    /**
+     * Base URL of the site-editor REST surface (e.g. `/visual-editor/api`).
+     * Omit when the canvas is mounted outside an apiBase-bearing context;
+     * the component then renders nothing.
+     */
+    apiBase?: string;
+}
+
+export function CanvasThemeStyles(props: CanvasThemeStylesProps): JSX.Element | null {
+    const css = useThemeGlobalStylesCss(props.apiBase);
+
+    if (css === undefined || css === '') {
+        return null;
+    }
+
+    return <style data-testid="ap-canvas-theme-styles">{css}</style>;
+}

--- a/resources/js/visual-editor/site-editor/entity-editor-canvas.css
+++ b/resources/js/visual-editor/site-editor/entity-editor-canvas.css
@@ -53,8 +53,12 @@
 
 /* Clickable empty area: when a template has no blocks yet, the default
    inserter placeholder is tiny — give the surface a visible min-height
-   so users have a target to click the appender. */
-.ap-site-editor__entity-canvas-surface .block-editor-block-list__layout {
+   so users have a target to click the appender. Scoped to Gutenberg's
+   `.is-root-container` marker so the rule only hits the top-level
+   layout — nested `.block-editor-block-list__layout` instances (inside
+   `core/list`, `core/columns`, `core/group`) inherited the 300px before
+   and stacked their bullets way below the heading (Keystone #47). */
+.ap-site-editor__entity-canvas-surface .block-editor-block-list__layout.is-root-container {
     min-height: 300px;
 }
 

--- a/resources/js/visual-editor/site-editor/entity-editor-canvas.tsx
+++ b/resources/js/visual-editor/site-editor/entity-editor-canvas.tsx
@@ -27,8 +27,14 @@ import {
 import { __, sprintf } from '@wordpress/i18n';
 import { useMemo, type ReactNode } from 'react';
 
-import { DEFAULT_CANVAS_STYLES } from '../editor-settings';
+import {
+    ALIGNMENT_OVERRIDE_STYLES,
+    DEFAULT_CANVAS_STYLES,
+    ROOT_CANVAS_LAYOUT,
+} from '../editor-settings';
 import { TEXT_DOMAIN } from '../vendor/i18n';
+
+import { CanvasThemeStyles } from './canvas-theme-styles';
 
 import './entity-editor-canvas.css';
 
@@ -45,10 +51,16 @@ export interface EntityEditorCanvasProps {
     isLoading?: boolean;
     /** Optional error copy rendered in place of the canvas. */
     errorMessage?: string | null;
+    /**
+     * Site-editor REST base. When supplied, the canvas inlines the
+     * active theme's compiled CSS via {@see CanvasThemeStyles}, so the
+     * surface matches the public front-end (Keystone #47).
+     */
+    apiBase?: string;
 }
 
 export function EntityEditorCanvas(props: EntityEditorCanvasProps): JSX.Element {
-    const { entityTitle, header, isLoading, errorMessage } = props;
+    const { entityTitle, header, isLoading, errorMessage, apiBase } = props;
 
     const announcement = useMemo(
         () =>
@@ -118,10 +130,26 @@ export function EntityEditorCanvas(props: EntityEditorCanvasProps): JSX.Element 
                      * cascade.
                      */}
                     <style>{DEFAULT_CANVAS_STYLES}</style>
+                    {/*
+                     * Keystone #47: wide/full alignment overrides
+                     * applied to direct children of the root layout.
+                     * Sits before the theme CSS so the theme can
+                     * still tweak alignment behavior if it needs to.
+                     */}
+                    <style>{ALIGNMENT_OVERRIDE_STYLES}</style>
+                    {/*
+                     * Keystone #47: the active theme's compiled CSS
+                     * (theme.json tokens + hand-authored `style.css`)
+                     * gets inlined here, after the package default so
+                     * theme rules win on cascade. Falls back to no-op
+                     * when no `apiBase` is wired or the fetch returns
+                     * empty.
+                     */}
+                    <CanvasThemeStyles apiBase={apiBase} />
                     <BlockTools>
                         <WritingFlow>
                             <ObserveTyping>
-                                <BlockList />
+                                <BlockList layout={ROOT_CANVAS_LAYOUT} />
                             </ObserveTyping>
                         </WritingFlow>
                     </BlockTools>

--- a/resources/js/visual-editor/site-editor/entity-editor.tsx
+++ b/resources/js/visual-editor/site-editor/entity-editor.tsx
@@ -232,9 +232,11 @@ export function useEntityEditorViews<K extends EntityKind>(
                 header={headerContent}
                 isLoading={loadStatus === 'loading'}
                 errorMessage={loadStatus === 'error' ? loadErrorMessage : null}
+                apiBase={apiConfig.apiBase}
             />
         );
     }, [
+        apiConfig.apiBase,
         entityId,
         entityTitle,
         headerContent,

--- a/resources/js/visual-editor/site-editor/patterns/pattern-canvas.css
+++ b/resources/js/visual-editor/site-editor/patterns/pattern-canvas.css
@@ -76,6 +76,9 @@
     min-height: 100%;
 }
 
-.ap-pattern-canvas__surface .block-editor-block-list__layout {
+/* Root-only — nested `core/list`, `core/columns`, etc. also render
+   `.block-editor-block-list__layout` and inheriting the 300px stacked
+   their inner blocks way below their siblings (Keystone #47). */
+.ap-pattern-canvas__surface .block-editor-block-list__layout.is-root-container {
     min-height: 300px;
 }

--- a/resources/js/visual-editor/site-editor/patterns/pattern-canvas.tsx
+++ b/resources/js/visual-editor/site-editor/patterns/pattern-canvas.tsx
@@ -23,8 +23,13 @@ import {
 import { __, sprintf } from '@wordpress/i18n';
 import { useMemo, type ReactNode } from 'react';
 
-import { DEFAULT_CANVAS_STYLES } from '../../editor-settings';
+import {
+    ALIGNMENT_OVERRIDE_STYLES,
+    DEFAULT_CANVAS_STYLES,
+    ROOT_CANVAS_LAYOUT,
+} from '../../editor-settings';
 import { TEXT_DOMAIN } from '../../vendor/i18n';
+import { CanvasThemeStyles } from '../canvas-theme-styles';
 
 import './pattern-canvas.css';
 
@@ -35,10 +40,12 @@ export interface PatternCanvasProps {
     header?: ReactNode;
     isLoading?: boolean;
     errorMessage?: string | null;
+    /** Site-editor REST base — wires in theme CSS (Keystone #47). */
+    apiBase?: string;
 }
 
 export function PatternCanvas(props: PatternCanvasProps): JSX.Element {
-    const { title, synced, header, isLoading, errorMessage } = props;
+    const { title, synced, header, isLoading, errorMessage, apiBase } = props;
 
     const announcement = useMemo(
         () =>
@@ -112,10 +119,14 @@ export function PatternCanvas(props: PatternCanvasProps): JSX.Element {
                      * to browser-default serif.
                      */}
                     <style>{DEFAULT_CANVAS_STYLES}</style>
+                    {/* Keystone #47: wide/full alignment overrides. */}
+                    <style>{ALIGNMENT_OVERRIDE_STYLES}</style>
+                    {/* Keystone #47: theme CSS inlined after defaults so it wins on cascade. */}
+                    <CanvasThemeStyles apiBase={apiBase} />
                     <BlockTools>
                         <WritingFlow>
                             <ObserveTyping>
-                                <BlockList />
+                                <BlockList layout={ROOT_CANVAS_LAYOUT} />
                             </ObserveTyping>
                         </WritingFlow>
                     </BlockTools>

--- a/resources/js/visual-editor/site-editor/patterns/patterns-section.tsx
+++ b/resources/js/visual-editor/site-editor/patterns/patterns-section.tsx
@@ -263,6 +263,7 @@ export function usePatternsSectionViews(
                         ? editor.loadErrorMessage
                         : null
                 }
+                apiBase={apiConfig.apiBase}
             />
         );
     }, [

--- a/resources/js/visual-editor/site-editor/styles/global-styles-api.ts
+++ b/resources/js/visual-editor/site-editor/styles/global-styles-api.ts
@@ -200,6 +200,44 @@ export async function fetchGlobalStylesBase(
     }
 }
 
+/**
+ * Returns the compiled CSS for the active theme's resolved global styles
+ * (theme.json defaults → variation → DB row, deep-merged server-side by
+ * cms-framework's `GlobalStylesResolver`). The site-editor canvas appends
+ * this string to its `BlockEditorProvider`'s `settings.styles` array so the
+ * iframe surface matches the public front-end's branding.
+ *
+ * Returns an empty string when cms-framework isn't installed or no active
+ * theme is configured — the canvas treats both the same as "no theme styles
+ * available" and keeps `DEFAULT_CANVAS_STYLES` as the only entry.
+ */
+export async function fetchGlobalStylesCss(
+    config: SiteEditorApiConfig
+): Promise<string> {
+    try {
+        const response = await fetch(buildUrl(config, 'css'), {
+            method: 'GET',
+            credentials: 'same-origin',
+            // `Accept: text/css` so an intermediary content negotiator
+            // can't downgrade the response to JSON. The controller
+            // returns `text/css` unconditionally, but the header keeps
+            // the contract explicit on the wire.
+            headers: { Accept: 'text/css' },
+        });
+
+        if (!response.ok) {
+            return '';
+        }
+
+        return await response.text();
+    } catch {
+        // Canvas styling is enhancement, not core flow — silently fall
+        // back to the package's default canvas baseline on network /
+        // server errors rather than blocking the editor boot.
+        return '';
+    }
+}
+
 export async function fetchGlobalStyles(
     config: SiteEditorApiConfig,
     id: number | string

--- a/resources/js/visual-editor/site-editor/use-theme-global-styles-css.ts
+++ b/resources/js/visual-editor/site-editor/use-theme-global-styles-css.ts
@@ -15,17 +15,24 @@
  * `DEFAULT_CANVAS_STYLES`. The CSS only appends after it arrives, so a
  * slow fetch never blocks the editor boot.
  *
- * Module-level cache keyed by `apiBase` so a remount inside the same
- * editor session reuses the already-fetched CSS without re-hitting the
- * network. Cleared explicitly by {@see resetThemeGlobalStylesCssCache}
- * — used by tests, never by production code.
+ * Module-level cache keyed by `apiBase`. Stores either a pending
+ * `Promise<string>` (first mount, fetch in flight) or the resolved
+ * `string` (subsequent mounts, fetch settled) so a remount inside the
+ * same editor session returns the CSS synchronously from `useState`'s
+ * lazy initializer — no transient `undefined` render, no flash of
+ * unstyled canvas (per CodeRabbit on PR #456). Cleared explicitly by
+ * {@see resetThemeGlobalStylesCssCache} — used by tests only.
  */
 
 import { useEffect, useState } from 'react';
 
 import { fetchGlobalStylesCss } from './styles/global-styles-api';
 
-const cache = new Map<string, Promise<string>>();
+type CachedCss =
+    | { status: 'pending'; promise: Promise<string> }
+    | { status: 'resolved'; value: string };
+
+const cache = new Map<string, CachedCss>();
 
 /**
  * Test-only cache reset. Production code lets the cache live for the
@@ -44,18 +51,18 @@ export function useThemeGlobalStylesCss(
             return '';
         }
 
-        // Synchronous cache hit — return immediately so the boundary's
-        // initial render already carries the styles and the editor
-        // surface doesn't flash unstyled on remount.
         const cached = cache.get(apiBase);
 
-        if (cached !== undefined) {
-            // The promise is in flight; we still need an async settle.
-            // Surface `undefined` until it resolves so the boundary
-            // mounts without a partial styles array.
-            return undefined;
+        // Remount-after-resolved: hand the resolved string back
+        // synchronously from the lazy initializer so the boundary's
+        // first render already carries the styles and the canvas
+        // doesn't flash unstyled.
+        if (cached?.status === 'resolved') {
+            return cached.value;
         }
 
+        // Either no entry yet or a still-in-flight fetch from another
+        // mount — let the effect settle the value asynchronously.
         return undefined;
     });
 
@@ -67,26 +74,56 @@ export function useThemeGlobalStylesCss(
         }
 
         let cancelled = false;
+        let entry = cache.get(apiBase);
 
-        let pending = cache.get(apiBase);
+        if (entry === undefined) {
+            const promise = fetchGlobalStylesCss({ apiBase });
+            entry = { status: 'pending', promise };
+            cache.set(apiBase, entry);
 
-        if (pending === undefined) {
-            pending = fetchGlobalStylesCss({ apiBase });
-            cache.set(apiBase, pending);
+            // Upgrade the entry to `resolved` once the network settles
+            // so future remounts can return the value synchronously.
+            // The upgrade is independent of any specific mount's
+            // lifecycle — even if every consumer unmounts before the
+            // fetch resolves, the next mount still gets the cached
+            // value without re-hitting the network.
+            promise.then(
+                (value) => {
+                    cache.set(apiBase, { status: 'resolved', value });
+                },
+                () => {
+                    // Treat network failure as an empty stylesheet so
+                    // the canvas falls back to its package defaults
+                    // and the next remount doesn't re-hit a known-bad
+                    // endpoint. {@link fetchGlobalStylesCss} swallows
+                    // most errors already; this is belt-and-suspenders.
+                    cache.set(apiBase, { status: 'resolved', value: '' });
+                }
+            );
         }
 
-        pending.then((value) => {
-            if (!cancelled) {
-                setCss(value);
+        // `entry` may already be 'resolved' on remount — short-circuit
+        // to a sync update so React batches it with the initial render.
+        if (entry.status === 'resolved') {
+            setCss(entry.value);
+
+            return () => {
+                cancelled = true;
+            };
+        }
+
+        entry.promise.then(
+            (value) => {
+                if (!cancelled) {
+                    setCss(value);
+                }
+            },
+            () => {
+                if (!cancelled) {
+                    setCss('');
+                }
             }
-        }).catch(() => {
-            // Network failure already surfaces as `''` from the
-            // fetch wrapper; this `.catch` is just belt-and-suspenders
-            // for promise rejection elsewhere in the chain.
-            if (!cancelled) {
-                setCss('');
-            }
-        });
+        );
 
         return () => {
             cancelled = true;

--- a/resources/js/visual-editor/site-editor/use-theme-global-styles-css.ts
+++ b/resources/js/visual-editor/site-editor/use-theme-global-styles-css.ts
@@ -1,0 +1,97 @@
+/**
+ * Hook that fetches the active theme's compiled global-styles CSS once
+ * per `apiBase`, ready to append to the editor canvas's `settings.styles`
+ * array (Keystone #47).
+ *
+ * The CSS comes from cms-framework's `GlobalStylesEmitter` via the
+ * `/visual-editor/api/global-styles/css` endpoint. It's the same payload
+ * the public front-end emits through the renderer-blade Blade
+ * components — fetching it here is the canvas's half of the parity fix.
+ *
+ * The hook returns `undefined` while the fetch is in flight, an empty
+ * string when no theme styles are available (no active theme, or
+ * cms-framework not installed), and the full CSS body once loaded. The
+ * boundary treats `undefined` and `''` the same way: render with just
+ * `DEFAULT_CANVAS_STYLES`. The CSS only appends after it arrives, so a
+ * slow fetch never blocks the editor boot.
+ *
+ * Module-level cache keyed by `apiBase` so a remount inside the same
+ * editor session reuses the already-fetched CSS without re-hitting the
+ * network. Cleared explicitly by {@see resetThemeGlobalStylesCssCache}
+ * — used by tests, never by production code.
+ */
+
+import { useEffect, useState } from 'react';
+
+import { fetchGlobalStylesCss } from './styles/global-styles-api';
+
+const cache = new Map<string, Promise<string>>();
+
+/**
+ * Test-only cache reset. Production code lets the cache live for the
+ * duration of the SPA — there's no scenario where the active theme
+ * changes mid-session in the same shell mount.
+ */
+export function resetThemeGlobalStylesCssCache(): void {
+    cache.clear();
+}
+
+export function useThemeGlobalStylesCss(
+    apiBase: string | undefined
+): string | undefined {
+    const [css, setCss] = useState<string | undefined>(() => {
+        if (apiBase === undefined || apiBase === '') {
+            return '';
+        }
+
+        // Synchronous cache hit — return immediately so the boundary's
+        // initial render already carries the styles and the editor
+        // surface doesn't flash unstyled on remount.
+        const cached = cache.get(apiBase);
+
+        if (cached !== undefined) {
+            // The promise is in flight; we still need an async settle.
+            // Surface `undefined` until it resolves so the boundary
+            // mounts without a partial styles array.
+            return undefined;
+        }
+
+        return undefined;
+    });
+
+    useEffect(() => {
+        if (apiBase === undefined || apiBase === '') {
+            setCss('');
+
+            return;
+        }
+
+        let cancelled = false;
+
+        let pending = cache.get(apiBase);
+
+        if (pending === undefined) {
+            pending = fetchGlobalStylesCss({ apiBase });
+            cache.set(apiBase, pending);
+        }
+
+        pending.then((value) => {
+            if (!cancelled) {
+                setCss(value);
+            }
+        }).catch(() => {
+            // Network failure already surfaces as `''` from the
+            // fetch wrapper; this `.catch` is just belt-and-suspenders
+            // for promise rejection elsewhere in the chain.
+            if (!cancelled) {
+                setCss('');
+            }
+        });
+
+        return () => {
+            cancelled = true;
+        };
+    }, [apiBase]);
+
+    return css;
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -108,6 +108,9 @@ Route::get( 'global-styles/lookup', [ GlobalStylesController::class, 'lookup' ] 
 Route::get( 'global-styles/base', [ GlobalStylesController::class, 'base' ] )
 	->name( 'visual-editor.api.global-styles.base' );
 
+Route::get( 'global-styles/css', [ GlobalStylesController::class, 'css' ] )
+	->name( 'visual-editor.api.global-styles.css' );
+
 Route::get( 'global-styles/{id}', [ GlobalStylesController::class, 'show' ] )
 	->where( 'id', '[A-Za-z0-9_]+' )
 	->name( 'visual-editor.api.global-styles.show' );

--- a/src/Http/Controllers/SiteEditor/GlobalStylesController.php
+++ b/src/Http/Controllers/SiteEditor/GlobalStylesController.php
@@ -158,6 +158,101 @@ class GlobalStylesController extends Controller
 	}
 
 	/**
+	 * GET `/global-styles/css` — full canvas stylesheet for the active
+	 * theme. Concatenates two sources in order:
+	 *
+	 *   1. cms-framework's `GlobalStylesEmitter::emit()` — compiled CSS
+	 *      from theme.json `settings` + `styles`, merged with any DB
+	 *      override the user authored through the Styles section.
+	 *   2. The theme's hand-authored `themes/{slug}/style.css` — the
+	 *      same stylesheet the public front-end loads via `<link rel>`.
+	 *
+	 * Order matters: the emitter declares `--wp--preset--*` custom
+	 * properties on `:root`; the hand-authored sheet can consume those
+	 * tokens AND override emitter rules (button border-radius / padding
+	 * that the emitter doesn't compile yet, footer list resets, etc.).
+	 *
+	 * The site-editor canvas appends the full response to its
+	 * `BlockEditorProvider` `settings.styles` array so the iframe surface
+	 * matches the public front-end's branding 1:1 — closes the parity
+	 * gap that Keystone #47 surfaced. Front-end consumes the emitter
+	 * via the renderer-blade Blade components and loads its own
+	 * `<link rel="stylesheet">` to `style.css`; the canvas reaches
+	 * parity by getting both bundled into this one fetch.
+	 *
+	 * Returns an empty `text/css` body when cms-framework is not
+	 * installed; the canvas treats that the same as "no theme styles"
+	 * and falls back to the package's `DEFAULT_CANVAS_STYLES`.
+	 *
+	 * @since 1.1.0
+	 */
+	public function css(): Response
+	{
+		$emitterFqcn = 'ArtisanPackUI\\CMSFramework\\Modules\\SiteEditor\\Emission\\GlobalStylesEmitter';
+
+		$emitted = '';
+
+		if ( class_exists( $emitterFqcn ) && app()->bound( $emitterFqcn ) ) {
+			$result  = app( $emitterFqcn )->emit();
+			$emitted = is_string( $result ) ? $result : '';
+		}
+
+		$themeCss = $this->readThemeStylesheet();
+
+		$body = '' === $themeCss
+			? $emitted
+			: rtrim( $emitted ) . "\n\n/* === theme stylesheet === */\n" . $themeCss;
+
+		return response( $body, Response::HTTP_OK, [ 'Content-Type' => 'text/css; charset=utf-8' ] );
+	}
+
+	/**
+	 * Read the active theme's hand-authored `style.css` from disk.
+	 * Returns an empty string when no theme is active, when the file
+	 * doesn't exist, or when the resolved path escapes the configured
+	 * themes directory (path-traversal guard — the theme slug rides in
+	 * from the DB / `theme.json`, but cheap to verify).
+	 *
+	 * @since 1.1.0
+	 */
+	protected function readThemeStylesheet(): string
+	{
+		$theme = $this->activeTheme();
+
+		if ( null === $theme ) {
+			return '';
+		}
+
+		$slug = (string) ( $theme['slug'] ?? '' );
+
+		if ( '' === $slug || ! preg_match( '/^[A-Za-z0-9_-]+$/', $slug ) ) {
+			return '';
+		}
+
+		$configured = (string) config( 'cms.themes.directory', 'themes' );
+		// Honor absolute paths verbatim; otherwise resolve relative to
+		// the app's base. cms-framework's `ThemeManager` follows the same
+		// convention, so themes resolve to the same directory on disk
+		// whether the host app keeps `themes/` inside the project root
+		// or points at an external mount.
+		$themesBase = ( '' !== $configured && ( '/' === $configured[0] || preg_match( '#^[A-Za-z]:[\\\\/]#', $configured ) ) )
+			? $configured
+			: base_path( $configured );
+		$stylesheet = $themesBase . '/' . $slug . '/style.css';
+
+		$resolved   = realpath( $stylesheet );
+		$baseReal   = realpath( $themesBase );
+
+		if ( false === $resolved || false === $baseReal || ! str_starts_with( $resolved, $baseReal . DIRECTORY_SEPARATOR ) ) {
+			return '';
+		}
+
+		$contents = @file_get_contents( $resolved );
+
+		return is_string( $contents ) ? $contents : '';
+	}
+
+	/**
 	 * GET `/global-styles/{id}` — fetch the singleton by id. Accepts
 	 * `__base__` (theme defaults) or a numeric DB id.
 	 *

--- a/tests/Feature/SiteEditor/GlobalStylesControllerTest.php
+++ b/tests/Feature/SiteEditor/GlobalStylesControllerTest.php
@@ -109,6 +109,102 @@ describe( 'GET /visual-editor/api/global-styles/base', function (): void {
 	} );
 } );
 
+describe( 'GET /visual-editor/api/global-styles/css', function (): void {
+	it( 'returns compiled CSS from cms-framework\'s emitter as text/css', function (): void {
+		$this->mock( ThemeManager::class, function ( $mock ): void {
+			$mock->shouldReceive( 'getActiveTheme' )->andReturn( [
+				'name'     => 'Digital Shopfront',
+				'slug'     => 'digital-shopfront',
+				'settings' => [ 'color' => [ 'palette' => [ [ 'slug' => 'primary', 'color' => '#0f172a' ] ] ] ],
+				'styles'   => [ 'color' => [ 'text' => '#111827' ] ],
+			] );
+		} );
+
+		rebuildSiteEditorResolversForGlobalStylesTest();
+
+		$response = $this->get( '/visual-editor/api/global-styles/css' )->assertOk();
+
+		expect( $response->headers->get( 'content-type' ) )->toContain( 'text/css' );
+		// The emitter compiles palette presets to `--wp--preset--color--{slug}`
+		// custom properties on `:root` and `styles.color.text` to a `color`
+		// declaration on the root. Asserting on both proves the resolver +
+		// emitter pipeline is wired end-to-end.
+		expect( $response->getContent() )
+			->toContain( '--wp--preset--color--primary: #0f172a;' )
+			->toContain( 'color: #111827;' );
+	} );
+
+	it( 'returns an empty body when no active theme is configured', function (): void {
+		$this->mock( ThemeManager::class, function ( $mock ): void {
+			$mock->shouldReceive( 'getActiveTheme' )->andReturn( null );
+		} );
+
+		rebuildSiteEditorResolversForGlobalStylesTest();
+
+		$response = $this->get( '/visual-editor/api/global-styles/css' )->assertOk();
+
+		expect( $response->getContent() )->toBe( '' );
+		expect( $response->headers->get( 'content-type' ) )->toContain( 'text/css' );
+	} );
+
+	it( 'concatenates the active theme\'s style.css after the emitter output (Keystone #47)', function (): void {
+		$themesBase = sys_get_temp_dir() . '/keystone-47-css-' . uniqid();
+		$slug       = 'parity-theme';
+		$themeDir   = $themesBase . '/' . $slug;
+
+		mkdir( $themeDir, 0755, true );
+		file_put_contents( $themeDir . '/style.css', ".wp-element-button{border-radius:0.5rem;padding:0.75rem 1.5rem}\n" );
+
+		config()->set( 'cms.themes.directory', $themesBase );
+
+		$this->mock( ThemeManager::class, function ( $mock ) use ( $slug ): void {
+			$mock->shouldReceive( 'getActiveTheme' )->andReturn( [
+				'name'     => 'Parity theme',
+				'slug'     => $slug,
+				'settings' => [ 'color' => [ 'palette' => [ [ 'slug' => 'primary', 'color' => '#0f172a' ] ] ] ],
+				'styles'   => [ 'elements' => [ 'button' => [ 'color' => [ 'background' => '#2563eb' ] ] ] ],
+			] );
+		} );
+
+		rebuildSiteEditorResolversForGlobalStylesTest();
+
+		$response = $this->get( '/visual-editor/api/global-styles/css' )->assertOk();
+		$body     = $response->getContent();
+
+		// Emitter output is present (palette token + button bg).
+		expect( $body )
+			->toContain( '--wp--preset--color--primary: #0f172a;' )
+			->toContain( 'background-color: #2563eb;' );
+
+		// The hand-authored stylesheet is appended AFTER the emitter so
+		// it wins on cascade — buttons get the radius + padding the
+		// emitter doesn't compile today.
+		expect( $body )->toContain( 'border-radius:0.5rem' );
+		expect( strpos( $body, 'background-color: #2563eb;' ) )->toBeLessThan( strpos( $body, 'border-radius:0.5rem' ) );
+
+		unlink( $themeDir . '/style.css' );
+		rmdir( $themeDir );
+		rmdir( $themesBase );
+	} );
+
+	it( 'rejects a malformed theme slug instead of reading off-disk (path-traversal guard)', function (): void {
+		$this->mock( ThemeManager::class, function ( $mock ): void {
+			$mock->shouldReceive( 'getActiveTheme' )->andReturn( [
+				'name' => 'Bad slug',
+				'slug' => '../../etc',
+			] );
+		} );
+
+		rebuildSiteEditorResolversForGlobalStylesTest();
+
+		$response = $this->get( '/visual-editor/api/global-styles/css' )->assertOk();
+
+		// The stylesheet read short-circuited on the bogus slug —
+		// body should not contain the theme-stylesheet marker.
+		expect( $response->getContent() )->not->toContain( '/* === theme stylesheet === */' );
+	} );
+} );
+
 describe( 'GET /visual-editor/api/global-styles/{id}', function (): void {
 	it( 'returns the singleton when id matches the resolver state', function (): void {
 		$record = GlobalStyles::create( [


### PR DESCRIPTION
Closes [Keystone #47](https://gitlab.com/jacob-martella-web-design/jacob-martella-web-design/jmwd-keystone-cms/jmwd-keystone-cms/-/issues/47).

## Summary

- New `GET /visual-editor/api/global-styles/css` endpoint. Concatenates cms-framework's `GlobalStylesEmitter::emit()` output with the active theme's hand-authored `themes/{slug}/style.css`. The site-editor canvases inline the response via a new `CanvasThemeStyles` component; the post editor appends it to its iframe `canvasStyles` array. Same compiled CSS the front-end loads, so the canvas matches branding 1:1.
- New `ROOT_CANVAS_LAYOUT` constant passed as the `layout` prop to every root `<BlockList>`. Without it Gutenberg's `BlockLayoutContext` falls back to `{type:"default"}` and the default layout's `getAlignments` returns `[]` — the actual reason wide / full toolbar buttons never appeared.
- New `ALIGNMENT_OVERRIDE_STYLES` + reshaped `POST_EDITOR_FRAMING_STYLES` size root-level blocks by `.alignwide` / `.alignfull` class so the toolbar's Wide / Full buttons visibly resize blocks. Framing applies to direct children only; site-editor canvases skip the framing entry so templates and template parts span full-bleed like the front-end.
- `is-root-container` scoping on the existing `min-height: 300px` and the (now moved) 720px / 144px rules so nested `.block-editor-block-list__layout` instances (every `<li>` inside `core/list`, every column inside `core/columns`) don't inherit them — fixed the ~150px vertical gap between footer list items.

## Test plan

- [x] `vendor/bin/pest --compact` — 509/509 passing locally (2 new feature tests for the css endpoint, 1 new path-traversal regression).
- [x] `npx vitest run` — 1036/1036 passing locally (3 new hook tests, 2 new boundary tests).
- [x] Manual: front-end and site-editor canvas now match palette tokens, heading typography, button radius / padding, footer list spacing.
- [x] Manual: Wide / Full alignment buttons appear on `core/group` in both editors and visibly resize the block.
- [x] Manual: post editor keeps its 720px content column; site editor's footer template part now spans full-bleed.

## Known adjacent bugs (filed separately)

- Pre-existing React #130 on `core/separator` when editing the footer template part. Confirmed via stash bisect that the error predates this branch — surfaced earlier because Slice 5's seed populates the footer with a separator.
- Block-level style changes (background colors, alignment) edited in the editor don't render on the public front-end. That's a server-side rendering issue in the `renderer-blade` package, not a canvas-styling issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Visual editor now fetches and inlines compiled theme CSS so the canvas more closely matches the public site.
  * Canvas alignment and framing improved: editor honors constrained layout and wide/full alignment overrides for accurate previewing.

* **Documentation**
  * Updated visual editor validation checklist to reflect global-styles behavior and added a G2 section verifying canvas vs. frontend style parity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArtisanPack-UI/visual-editor/pull/456?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->