### PR TITLE
fix(site-editor): apply schema defaults to pre-parsed block trees (Keystone #49)

### DIFF
--- a/resources/js/visual-editor/site-editor/__tests__/entity-editor.test.tsx
+++ b/resources/js/visual-editor/site-editor/__tests__/entity-editor.test.tsx
@@ -47,6 +47,13 @@ vi.mock('@wordpress/blocks', () => ({
     parse: (raw: string): unknown[] =>
         raw === '' ? [] : [{ name: 'core/paragraph', clientId: 'stub' }],
     serialize: (): string => '',
+    // `applySchemaDefaults` in use-entity-editor.ts (Keystone #49)
+    // calls `getBlockType(name)?.attributes` to fill in missing
+    // default-valued attributes. Stub returns `undefined` for any
+    // block since this suite doesn't exercise the defaults path —
+    // the hook leaves attributes as-is when the registry has no
+    // entry for the block name.
+    getBlockType: (): undefined => undefined,
 }));
 
 vi.mock('@wordpress/format-library', () => ({}));

--- a/resources/js/visual-editor/site-editor/__tests__/use-entity-editor.test.tsx
+++ b/resources/js/visual-editor/site-editor/__tests__/use-entity-editor.test.tsx
@@ -11,6 +11,24 @@ vi.mock('@wordpress/blocks', () => ({
     parse: (raw: string): unknown[] =>
         raw === '' ? [] : [{ name: 'core/paragraph', clientId: 'stub' }],
     serialize: (): string => '',
+    // Block-type registry for `applySchemaDefaults` (Keystone #49).
+    // The hook calls `getBlockType(name)?.attributes` and fills any
+    // attribute with a `default` that's missing from the stored
+    // payload. The fixture below mirrors `core/separator`'s schema
+    // — the one block whose `edit()` actually crashed when
+    // `tagName` was missing.
+    getBlockType: (name: string): unknown => {
+        if (name === 'core/separator') {
+            return {
+                attributes: {
+                    opacity: { type: 'string', default: 'alpha-channel' },
+                    tagName: { type: 'string', default: 'hr' },
+                },
+            };
+        }
+
+        return undefined;
+    },
 }));
 
 import { useEntityEditor } from '../use-entity-editor';
@@ -467,5 +485,86 @@ describe('useEntityEditor', () => {
         expect(result.current.loadStatus).toBe('idle');
         expect(result.current.entity).toBeNull();
         expect(result.current.blocks).toHaveLength(0);
+    });
+
+    it('fills schema defaults on the parsed-blocks path so core/separator gets tagName="hr" (Keystone #49)', async () => {
+        // The seed persists `core/separator` with only `opacity` —
+        // `tagName` (default `"hr"`) is missing. Without the defaults
+        // pass the block's `edit()` would render `<undefined />` and
+        // trip React #130.
+        FETCH_MOCK.mockResolvedValue(
+            makeTemplate({
+                content: {
+                    raw: '',
+                    blocks: [
+                        {
+                            name: 'core/separator',
+                            clientId: 'sep-1',
+                            attributes: { opacity: 'alpha-channel' },
+                            innerBlocks: [],
+                        },
+                    ],
+                },
+            })
+        );
+
+        const { result } = renderHook(() =>
+            useEntityEditor({
+                apiConfig: API_CONFIG,
+                kind: 'template',
+                entityId: '1',
+            })
+        );
+
+        await waitFor(() => expect(result.current.loadStatus).toBe('ready'));
+
+        const [separator] = result.current.blocks as Array<{
+            attributes: { opacity?: string; tagName?: string };
+        }>;
+
+        expect(separator).toBeDefined();
+        expect(separator.attributes.tagName).toBe('hr');
+        // Existing attributes are preserved.
+        expect(separator.attributes.opacity).toBe('alpha-channel');
+    });
+
+    it('recurses into innerBlocks so a nested separator also gets its default tagName (Keystone #49)', async () => {
+        FETCH_MOCK.mockResolvedValue(
+            makeTemplate({
+                content: {
+                    raw: '',
+                    blocks: [
+                        {
+                            name: 'core/group',
+                            clientId: 'g-1',
+                            attributes: {},
+                            innerBlocks: [
+                                {
+                                    name: 'core/separator',
+                                    clientId: 'sep-2',
+                                    attributes: { opacity: 'alpha-channel' },
+                                    innerBlocks: [],
+                                },
+                            ],
+                        },
+                    ],
+                },
+            })
+        );
+
+        const { result } = renderHook(() =>
+            useEntityEditor({
+                apiConfig: API_CONFIG,
+                kind: 'template',
+                entityId: '1',
+            })
+        );
+
+        await waitFor(() => expect(result.current.loadStatus).toBe('ready'));
+
+        const group = result.current.blocks[0] as {
+            innerBlocks: Array<{ attributes: { tagName?: string } }>;
+        };
+        expect(group.innerBlocks[0]?.attributes.tagName).toBe('hr');
     });
 });

--- a/resources/js/visual-editor/site-editor/hydrate-blocks.ts
+++ b/resources/js/visual-editor/site-editor/hydrate-blocks.ts
@@ -1,0 +1,88 @@
+/**
+ * Block-tree hydration helpers shared between the entity-editor and
+ * pattern-editor hooks.
+ *
+ * Both hooks receive entity content as `{ raw: string, blocks: object[] }`.
+ * When `raw` is non-empty we run it through Gutenberg's `parse()` which
+ * already fills in schema defaults from the registered block-type. When
+ * only the `blocks` array is present (the database-JSON path our REST
+ * envelope takes for templates / template parts / patterns), `parse()`
+ * never runs and a block whose `edit()` reads a default-valued attribute
+ * (e.g. `core/separator`'s `tagName`) gets `undefined` instead of `"hr"`,
+ * renders `<undefined />`, and trips React error #130 (Keystone #49).
+ *
+ * `applySchemaDefaults` walks the pre-parsed tree and fills in any
+ * registered attribute defaults the persisted JSON is missing,
+ * mirroring the part of `parse()`'s pipeline that hydrates schema
+ * defaults from the block-type registry.
+ */
+
+import { getBlockType, parse, type BlockInstance } from '@wordpress/blocks';
+
+export interface LoadedContent {
+    raw?: string;
+    blocks: unknown[];
+}
+
+/**
+ * Walk a pre-parsed block tree and fill in any registered attribute
+ * defaults the persisted JSON is missing. Recurses into `innerBlocks`
+ * so nested blocks get the same treatment. Unregistered blocks are
+ * left alone — the renderer's fallback handles them, and reading a
+ * non-existent block type's defaults would no-op anyway.
+ */
+export function applySchemaDefaults(blocks: BlockInstance[]): BlockInstance[] {
+    return blocks.map((block) => {
+        const blockType = getBlockType(block.name);
+        const schema = (blockType?.attributes ?? {}) as Record<
+            string,
+            { default?: unknown }
+        >;
+
+        const filled: Record<string, unknown> = { ...(block.attributes ?? {}) };
+        let mutated = false;
+
+        for (const [key, definition] of Object.entries(schema)) {
+            if (definition?.default === undefined) {
+                continue;
+            }
+
+            if (filled[key] === undefined) {
+                filled[key] = definition.default;
+                mutated = true;
+            }
+        }
+
+        const inner =
+            Array.isArray(block.innerBlocks) && block.innerBlocks.length > 0
+                ? applySchemaDefaults(block.innerBlocks)
+                : block.innerBlocks;
+
+        if (!mutated && inner === block.innerBlocks) {
+            return block;
+        }
+
+        return {
+            ...block,
+            attributes: filled as BlockInstance['attributes'],
+            innerBlocks: inner,
+        };
+    });
+}
+
+/**
+ * Hydrate a content envelope into `BlockInstance[]`. Prefers
+ * `content.raw` (canonical Gutenberg HTML form — `parse()` guarantees
+ * fresh `clientId`s and fills schema defaults); falls back to
+ * `content.blocks` when `raw` is empty, applying schema defaults
+ * manually so the parsed-JSON path matches `parse()`'s output shape.
+ */
+export function hydrateBlocks(content: LoadedContent): BlockInstance[] {
+    const raw = typeof content.raw === 'string' ? content.raw.trim() : '';
+
+    if (raw !== '') {
+        return parse(raw);
+    }
+
+    return applySchemaDefaults(content.blocks as BlockInstance[]);
+}

--- a/resources/js/visual-editor/site-editor/patterns/__tests__/use-pattern-editor.test.tsx
+++ b/resources/js/visual-editor/site-editor/patterns/__tests__/use-pattern-editor.test.tsx
@@ -10,6 +10,10 @@ const UPDATE_MOCK = vi.fn();
 vi.mock('@wordpress/blocks', () => ({
     parse: vi.fn(() => []),
     serialize: vi.fn(() => '<!-- wp:paragraph -->'),
+    // `applySchemaDefaults` (Keystone #49) calls this to fill missing
+    // default-valued attributes. Stub returns `undefined` so the hook
+    // leaves attributes as-is when the registry has no entry.
+    getBlockType: vi.fn(() => undefined),
 }));
 
 vi.mock('../api-client', async () => {

--- a/resources/js/visual-editor/site-editor/patterns/use-pattern-editor.ts
+++ b/resources/js/visual-editor/site-editor/patterns/use-pattern-editor.ts
@@ -8,12 +8,13 @@
  * the shared one from accumulating sub-section conditionals.
  */
 
-import { parse, serialize, type BlockInstance } from '@wordpress/blocks';
+import { serialize, type BlockInstance } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { TEXT_DOMAIN } from '../../vendor/i18n';
 import type { SiteEditorApiConfig } from '../api-client';
+import { hydrateBlocks } from '../hydrate-blocks';
 
 import {
     fetchPattern,
@@ -73,16 +74,6 @@ function isPatternContent(value: unknown): value is LoadedContent {
         'blocks' in value &&
         Array.isArray((value as { blocks: unknown }).blocks)
     );
-}
-
-function hydrateBlocks(content: LoadedContent): BlockInstance[] {
-    const raw = typeof content.raw === 'string' ? content.raw.trim() : '';
-
-    if (raw !== '') {
-        return parse(raw);
-    }
-
-    return content.blocks as BlockInstance[];
 }
 
 function fieldsForRecord(record: PatternRecord | null): PatternEditorFields {

--- a/resources/js/visual-editor/site-editor/use-entity-editor.ts
+++ b/resources/js/visual-editor/site-editor/use-entity-editor.ts
@@ -12,11 +12,13 @@
  * calls — without the canvas having to render the button itself.
  */
 
-import { parse, serialize, type BlockInstance } from '@wordpress/blocks';
+import { serialize, type BlockInstance } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { TEXT_DOMAIN } from '../vendor/i18n';
+
+import { hydrateBlocks } from './hydrate-blocks';
 
 import {
     fetchEntity,
@@ -90,25 +92,6 @@ function isEntityContent(value: unknown): value is LoadedContent {
     );
 }
 
-/**
- * Hydrate a raw-serialized block tree into BlockInstances Gutenberg can
- * render. Prefers `content.raw` (the canonical Gutenberg HTML form —
- * guarantees fresh `clientId`s) and only falls back to the parsed
- * `blocks` array when raw is empty. This matches what the legacy
- * post-editor's `use-persistence` does for its response shape.
- */
-function hydrateBlocks(content: LoadedContent): BlockInstance[] {
-    const raw = typeof content.raw === 'string' ? content.raw.trim() : '';
-
-    if (raw !== '') {
-        return parse(raw);
-    }
-
-    // No raw serialization — trust the parsed array. `parse()` cannot run
-    // against an already-parsed tree, so cast through `BlockInstance` and
-    // let Gutenberg regenerate missing metadata when it renders.
-    return content.blocks as BlockInstance[];
-}
 
 export function useEntityEditor<K extends EntityKind>(
     options: UseEntityEditorOptions<K>


### PR DESCRIPTION
Closes [Keystone #49](https://gitlab.com/jacob-martella-web-design/jacob-martella-web-design/jmwd-keystone-cms/jmwd-keystone-cms/-/issues/49).

## The bug

Editing the footer template part in the site-editor canvas triggered:

> Error: Minified React error #130 — Element type is invalid: got undefined

`core/separator` blocks persisted in the database with only `{ opacity: "alpha-channel" }` were the trigger. Confirmed via `git stash` bisect during the #50 work that the error predates the recent canvas changes.

## Root cause

`core/separator`'s `edit()` reads `attributes.tagName` (defaults to `"hr"` per its block.json schema) and renders `i.jsx(tagName, ...)`. Gutenberg's `parse()` pipeline normally fills schema defaults from the registered block-type when hydrating saved blocks — but our content envelope rides as `{ raw: "", blocks: object[] }` for templates / template parts / patterns (the database-JSON path), so `parse()` never runs. `tagName` arrives `undefined`, React renders `<undefined />`, #130 fires.

## Fix

New `applySchemaDefaults` helper in `site-editor/hydrate-blocks.ts` walks the pre-parsed tree and fills any registered attribute defaults the persisted JSON is missing — mirroring `parse()`'s schema-defaults pass. Recurses into `innerBlocks` so a separator nested inside `core/group` (which is what the footer ships) gets the same treatment.

Consolidates `hydrateBlocks` (previously duplicated in `use-entity-editor.ts` and `use-pattern-editor.ts`) into the shared module so both content-loading paths get the fix in one place.

## Tests

- 2 new integration tests on `useEntityEditor` proving `core/separator` with only `opacity` gets `tagName: "hr"` filled, and that the recursion handles a nested separator inside `core/group`.
- `@wordpress/blocks` mocks in `use-entity-editor.test.tsx`, `entity-editor.test.tsx`, and `use-pattern-editor.test.tsx` extended with a `getBlockType` stub so the hooks' new lookup resolves.
- All 1039 JS tests pass.

## Test plan

- [x] `npx vitest run` — 1039 green locally.
- [ ] Manual: open the footer template part in the site editor. No more "This block has encountered an error and cannot be previewed" panel; the separator renders inline as expected.
- [ ] Manual: regression sweep on the home page — no console errors, separator block renders cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency in applying block attribute schema defaults across the visual editor, ensuring missing attributes are properly populated when editing blocks.

* **Tests**
  * Added test coverage for schema default application during block hydration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArtisanPack-UI/visual-editor/pull/458?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->