### PR TITLE
feat(site-editor): wire wp_navigation read+write so the nav block picker populates

### DIFF
--- a/resources/js/visual-editor/vendor/__tests__/core-data-shim.test.tsx
+++ b/resources/js/visual-editor/vendor/__tests__/core-data-shim.test.tsx
@@ -1403,6 +1403,23 @@ describe('core-data-shim hooks', () => {
         expect(edited.title).toBe('Flatten Me');
     });
 
+    it('getEditedEntityRecord returns {} instead of null when nothing is cached (Keystone #48)', () => {
+        // Gutenberg's `core/navigation` block (use-navigation-menu.mjs)
+        // reads `record.status === "publish"` synchronously during
+        // render. A `null` return crashed the block before the async
+        // fetch resolver could settle. WP core returns `{}` in this
+        // case; the shim now matches.
+        const record = coreSelect().getEditedEntityRecord(
+            'postType',
+            'wp_navigation',
+            999_999,
+        );
+
+        expect(record).toEqual({});
+        // Belt-and-suspenders: `.status` is safely accessible.
+        expect((record as { status?: string }).status).toBeUndefined();
+    });
+
     it('useEntityRecords surfaces the list-cache and resolves through fetchEntityRecords', async () => {
         const { fetcher, calls } = mockFetcher(async () =>
             jsonResponse([

--- a/resources/js/visual-editor/vendor/__tests__/core-data-shim.test.tsx
+++ b/resources/js/visual-editor/vendor/__tests__/core-data-shim.test.tsx
@@ -905,6 +905,27 @@ describe('core-data-shim save round-trip', () => {
             ),
         ).not.toBeNull();
     });
+
+    it('saveEditedEntityRecord bails out when there is no base record AND no staged edits (Keystone #48)', async () => {
+        // `getEditedEntityRecord` returns `{}` for an unresolved
+        // record so synchronous reads on the nav block don't crash on
+        // `.status`. A pre-fix `saveEditedEntityRecord` would treat
+        // that `{}` as a real edited record and PUT `{ id }` to the
+        // server — a write that should never have happened. Confirm
+        // the guard now bails before fetching.
+        const { fetcher, calls } = mockFetcher(async () => jsonResponse({}));
+
+        configureCoreDataShim({ apiBase: '/api', fetcher });
+
+        const saved = await coreDispatch().saveEditedEntityRecord(
+            'postType',
+            'wp_template',
+            999_999,
+        );
+
+        expect(saved).toBeNull();
+        expect(calls).toHaveLength(0);
+    });
 });
 
 describe('core-data-shim delete + evict', () => {

--- a/resources/js/visual-editor/vendor/__tests__/core-data-shim.test.tsx
+++ b/resources/js/visual-editor/vendor/__tests__/core-data-shim.test.tsx
@@ -1392,7 +1392,14 @@ describe('core-data-shim hooks', () => {
         ) as { title?: unknown; content?: unknown };
 
         expect(raw.title).toBe('Flatten Me');
-        expect(raw.content).toBe('<!-- raw content -->');
+        // `content` is intentionally preserved as the `{ raw, blocks }`
+        // object shape — Gutenberg's `core/navigation` edit reads
+        // `editedRecord.content.raw` directly, and flattening it to a
+        // bare string broke the nav block's load path (Keystone #48).
+        expect(raw.content).toEqual({
+            raw: '<!-- raw content -->',
+            blocks: [],
+        });
 
         const edited = coreSelect().getEditedEntityRecord(
             'postType',

--- a/resources/js/visual-editor/vendor/__tests__/core-data-shim.test.tsx
+++ b/resources/js/visual-editor/vendor/__tests__/core-data-shim.test.tsx
@@ -1322,6 +1322,53 @@ describe('core-data-shim hooks', () => {
         expect(typeof blocks[0].innerBlocks[0].clientId).toBe('string');
     });
 
+    it('useEntityBlockEditor parses a flattened string `content` payload (Keystone #48)', () => {
+        // `getEditedEntityRecord` runs `flattenRawProperties` over
+        // the cached record, so a server envelope of
+        // `{ content: { raw, blocks } }` becomes a plain string by
+        // the time the nav block reads it. For `wp_navigation` we
+        // need to parse that string into the block tree the canvas
+        // renders — otherwise the picker shows "is empty" even when
+        // the menu has items.
+        coreDispatch().receiveEntityRecords('postType', 'wp_navigation', [
+            {
+                id: 42,
+                slug: 'primary',
+                title: { raw: 'Primary', rendered: 'Primary' },
+                status: 'publish',
+                type: 'wp_navigation',
+                content: {
+                    raw:
+                        '<!-- wp:navigation-link {"label":"Home","url":"/"} /-->\n' +
+                        '<!-- wp:navigation-submenu {"label":"About"} -->\n' +
+                        '<!-- wp:navigation-link {"label":"Team"} /-->\n' +
+                        '<!-- /wp:navigation-submenu -->',
+                    blocks: [],
+                },
+            },
+        ]);
+
+        const [blocks] = renderHook(() =>
+            useEntityBlockEditor('postType', 'wp_navigation', { id: 42 }),
+        ) as readonly Array<{
+            name: string;
+            clientId: string;
+            attributes: Record<string, unknown>;
+            innerBlocks: ReadonlyArray<{ name: string; attributes: Record<string, unknown> }>;
+        }>;
+
+        expect(blocks).toHaveLength(2);
+        expect(blocks[0].name).toBe('core/navigation-link');
+        expect(blocks[0].attributes).toEqual({ label: 'Home', url: '/' });
+        expect(typeof blocks[0].clientId).toBe('string');
+
+        expect(blocks[1].name).toBe('core/navigation-submenu');
+        expect(blocks[1].attributes).toEqual({ label: 'About' });
+        expect(blocks[1].innerBlocks).toHaveLength(1);
+        expect(blocks[1].innerBlocks[0].name).toBe('core/navigation-link');
+        expect(blocks[1].innerBlocks[0].attributes).toEqual({ label: 'Team' });
+    });
+
     it('flattens {raw, rendered} fields on getRawEntityRecord and getEditedEntityRecord', () => {
         coreDispatch().receiveEntityRecords('postType', 'wp_block', [
             {

--- a/resources/js/visual-editor/vendor/__tests__/core-data-shim.test.tsx
+++ b/resources/js/visual-editor/vendor/__tests__/core-data-shim.test.tsx
@@ -1337,14 +1337,16 @@ describe('core-data-shim hooks', () => {
                 title: { raw: 'Primary', rendered: 'Primary' },
                 status: 'publish',
                 type: 'wp_navigation',
-                content: {
-                    raw:
-                        '<!-- wp:navigation-link {"label":"Home","url":"/"} /-->\n' +
-                        '<!-- wp:navigation-submenu {"label":"About"} -->\n' +
-                        '<!-- wp:navigation-link {"label":"Team"} /-->\n' +
-                        '<!-- /wp:navigation-submenu -->',
-                    blocks: [],
-                },
+                // Bare string `content` — exercises the flattened
+                // fallback branch (we now skip flattening for the
+                // canonical wp_navigation read, but the parser still
+                // has to cope when an upstream caller hands us the
+                // string directly).
+                content:
+                    '<!-- wp:navigation-link {"label":"Home","url":"/"} /-->\n' +
+                    '<!-- wp:navigation-submenu {"label":"About"} -->\n' +
+                    '<!-- wp:navigation-link {"label":"Team"} /-->\n' +
+                    '<!-- /wp:navigation-submenu -->',
             },
         ]);
 

--- a/resources/js/visual-editor/vendor/__tests__/parse-navigation-content.test.ts
+++ b/resources/js/visual-editor/vendor/__tests__/parse-navigation-content.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Unit tests for `parseNavigationContent` — the shim's local
+ * block-comment parser scoped to `core/navigation-link` /
+ * `core/navigation-submenu` (Keystone #48). Mirror of the PHP
+ * `MenuItemBlockBridge::rawToBlocks` tests; if you change one,
+ * change the other.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { parseNavigationContent } from '../parse-navigation-content';
+
+describe('parseNavigationContent', () => {
+    it('returns [] for an empty / whitespace-only string', () => {
+        expect(parseNavigationContent('')).toEqual([]);
+        expect(parseNavigationContent('   \n\t')).toEqual([]);
+    });
+
+    it('parses a self-closing nav-link with JSON attributes', () => {
+        expect(
+            parseNavigationContent(
+                '<!-- wp:navigation-link {"label":"Home","url":"/"} /-->'
+            )
+        ).toEqual([
+            {
+                name: 'core/navigation-link',
+                attributes: { label: 'Home', url: '/' },
+                innerBlocks: [],
+            },
+        ]);
+    });
+
+    it('parses a self-closing nav-link with no attributes', () => {
+        expect(parseNavigationContent('<!-- wp:navigation-link /-->')).toEqual([
+            {
+                name: 'core/navigation-link',
+                attributes: {},
+                innerBlocks: [],
+            },
+        ]);
+    });
+
+    it('parses a submenu with nested children', () => {
+        const raw =
+            '<!-- wp:navigation-submenu {"label":"About"} -->\n' +
+            '<!-- wp:navigation-link {"label":"Team"} /-->\n' +
+            '<!-- /wp:navigation-submenu -->';
+
+        expect(parseNavigationContent(raw)).toEqual([
+            {
+                name: 'core/navigation-submenu',
+                attributes: { label: 'About' },
+                innerBlocks: [
+                    {
+                        name: 'core/navigation-link',
+                        attributes: { label: 'Team' },
+                        innerBlocks: [],
+                    },
+                ],
+            },
+        ]);
+    });
+
+    it('parses multiple siblings on separate lines', () => {
+        const raw =
+            '<!-- wp:navigation-link {"label":"A"} /-->\n' +
+            '<!-- wp:navigation-link {"label":"B"} /-->';
+
+        const parsed = parseNavigationContent(raw);
+
+        expect(parsed).toHaveLength(2);
+        expect(parsed[0]?.attributes).toEqual({ label: 'A' });
+        expect(parsed[1]?.attributes).toEqual({ label: 'B' });
+    });
+
+    it('drops unsupported block types at any nesting level', () => {
+        const raw =
+            '<!-- wp:paragraph {"content":"nope"} /-->\n' +
+            '<!-- wp:navigation-link {"label":"Real"} /-->';
+
+        const parsed = parseNavigationContent(raw);
+
+        expect(parsed).toHaveLength(1);
+        expect(parsed[0]?.attributes).toEqual({ label: 'Real' });
+    });
+
+    it('survives a missing close tag without infinite-looping', () => {
+        // Pathological input from a malformed server payload should
+        // produce whatever it can rather than crash the editor.
+        const raw =
+            '<!-- wp:navigation-submenu {"label":"Orphan"} -->\n' +
+            '<!-- wp:navigation-link {"label":"Inside"} /-->';
+
+        const parsed = parseNavigationContent(raw);
+
+        expect(parsed).toHaveLength(1);
+        expect(parsed[0]?.name).toBe('core/navigation-submenu');
+        expect(parsed[0]?.innerBlocks[0]?.attributes).toEqual({ label: 'Inside' });
+    });
+
+    it('treats malformed JSON in a block comment as empty attributes', () => {
+        const parsed = parseNavigationContent(
+            '<!-- wp:navigation-link {label} /-->'
+        );
+
+        expect(parsed).toEqual([
+            {
+                name: 'core/navigation-link',
+                attributes: {},
+                innerBlocks: [],
+            },
+        ]);
+    });
+
+    it('preserves unicode and forward-slash characters from the JSON attrs', () => {
+        const parsed = parseNavigationContent(
+            '<!-- wp:navigation-link {"label":"Café","url":"https://example.com/path"} /-->'
+        );
+
+        expect(parsed[0]?.attributes).toEqual({
+            label: 'Café',
+            url: 'https://example.com/path',
+        });
+    });
+});

--- a/resources/js/visual-editor/vendor/core-data-shim.ts
+++ b/resources/js/visual-editor/vendor/core-data-shim.ts
@@ -1020,17 +1020,24 @@ const selectors = {
         kind: EntityKind,
         name: EntityName,
         id: EntityKey,
-    ): EntityRecord | null => {
+    ): EntityRecord => {
         const base = selectEntityRecord(state, kind, name, id);
         const edits = selectEditsForRecord(state, kind, name, id);
 
-        if (base === null && edits === null) {
-            return null;
-        }
+        // Match WP core's behavior: return an empty object — never
+        // `null` — when nothing's been fetched yet. Consumers like
+        // Gutenberg's `core/navigation` block (`use-navigation-menu.mjs`)
+        // read fields like `o.status === "publish"` synchronously
+        // during render, so a `null` return crashes the block before
+        // the async fetch resolver can settle (Keystone #48). An
+        // empty object lets the consumer's `=== "publish"` check
+        // return `false` harmlessly, the resolution flag stays
+        // `false`, the picker shows its loading state, and the fetch
+        // repopulates state for the next render cycle.
 
-        // Match `getRawEntityRecord` — flatten `{raw, rendered}` shaped
-        // fields before merging edits on top. Core-data does the same
-        // so consumers can read `entity.title` as a plain string.
+        // Flatten `{raw, rendered}` shaped fields before merging
+        // edits on top — same as `getRawEntityRecord`, so consumers
+        // can read `entity.title` as a plain string.
         const flattenedBase = base === null ? {} : flattenRawProperties(base);
 
         return { ...flattenedBase, ...(edits ?? {}) };

--- a/resources/js/visual-editor/vendor/core-data-shim.ts
+++ b/resources/js/visual-editor/vendor/core-data-shim.ts
@@ -2053,7 +2053,16 @@ export function useEntityBlockEditor(
     (blocks: readonly unknown[]) => void,
     (blocks: readonly unknown[]) => void,
 ] {
-    const id = options?.id ?? null;
+    // Upstream `core/navigation` (and other entity-backed blocks) wrap
+    // their inner blocks in `<EntityProvider id={ref}>` and call
+    // `useEntityBlockEditor(kind, name)` with NO explicit id — relying
+    // on the ambient `EntityProvider` context. Fall back to that id
+    // when `options.id` is missing so the hook resolves to the right
+    // record (Keystone #48). The diagnostic logs that surfaced this
+    // showed every call coming in as `{ id: null }`, which short-
+    // circuited the selector before it could read content.
+    const ambientId = useEntityId();
+    const id = options?.id ?? ambientId ?? null;
 
     const blocks = useSelect(
         (select) => {

--- a/resources/js/visual-editor/vendor/core-data-shim.ts
+++ b/resources/js/visual-editor/vendor/core-data-shim.ts
@@ -51,6 +51,8 @@ import {
 } from 'react';
 import { createReduxStore, register, useDispatch, useSelect } from '@wordpress/data';
 
+import { parseNavigationContent } from './parse-navigation-content';
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -2054,26 +2056,68 @@ export function useEntityBlockEditor(
 
             const content = (record as { content?: unknown }).content;
 
-            if (
-                content === null ||
-                content === undefined ||
-                typeof content !== 'object'
-            ) {
+            if (content === null || content === undefined) {
+                return EMPTY_RECORDS as readonly unknown[];
+            }
+
+            // `getEditedEntityRecord` runs `flattenRawProperties` over
+            // the cached record, so a server envelope of
+            // `{ content: { raw, blocks } }` collapses down to a plain
+            // string here — same flattening WP applies to `title`.
+            // For `wp_navigation` (Keystone #48) the only thing we get
+            // back is the serialized block-comment markup; parse it
+            // with Gutenberg's own parser so the decorated tree we
+            // hand the editor matches what `parse()` would produce
+            // from any other content path.
+            if (typeof content === 'string') {
+                const trimmed = content.trim();
+
+                if (trimmed === '') {
+                    return EMPTY_RECORDS as readonly unknown[];
+                }
+
+                const parsed = parseNavigationContent(trimmed) as readonly unknown[];
+
+                if (parsed.length === 0) {
+                    return EMPTY_RECORDS as readonly unknown[];
+                }
+
+                return getDecoratedBlocks(kind, name, id, parsed);
+            }
+
+            if (typeof content !== 'object') {
                 return EMPTY_RECORDS as readonly unknown[];
             }
 
             const serverBlocks = (content as { blocks?: unknown }).blocks;
 
-            if (!Array.isArray(serverBlocks)) {
-                return EMPTY_RECORDS as readonly unknown[];
+            // Prefer a non-empty server-shipped `blocks` array — it's
+            // the lossless form. An EMPTY `blocks` array alongside a
+            // populated `raw` string can happen when the projection
+            // is still catching up (e.g. a `wp_navigation` envelope
+            // that didn't run the items → blocks step but kept the
+            // serialized markup); fall through to the raw parser in
+            // that case so the canvas still renders the menu items.
+            if (Array.isArray(serverBlocks) && serverBlocks.length > 0) {
+                return getDecoratedBlocks(
+                    kind,
+                    name,
+                    id,
+                    serverBlocks as readonly unknown[],
+                );
             }
 
-            return getDecoratedBlocks(
-                kind,
-                name,
-                id,
-                serverBlocks as readonly unknown[],
-            );
+            const raw = (content as { raw?: unknown }).raw;
+
+            if (typeof raw === 'string' && raw.trim() !== '') {
+                const parsed = parseNavigationContent(raw.trim()) as readonly unknown[];
+
+                if (parsed.length > 0) {
+                    return getDecoratedBlocks(kind, name, id, parsed);
+                }
+            }
+
+            return EMPTY_RECORDS as readonly unknown[];
         },
         [kind, name, id]
     );

--- a/resources/js/visual-editor/vendor/core-data-shim.ts
+++ b/resources/js/visual-editor/vendor/core-data-shim.ts
@@ -2108,7 +2108,7 @@ export function useEntityBlockEditor(
                     return EMPTY_RECORDS as readonly unknown[];
                 }
 
-                const parsed = parseNavigationContent(trimmed) as readonly unknown[];
+                const parsed = parseNavigationContentCached(trimmed);
 
                 if (parsed.length === 0) {
                     return EMPTY_RECORDS as readonly unknown[];
@@ -2142,7 +2142,7 @@ export function useEntityBlockEditor(
             const raw = (content as { raw?: unknown }).raw;
 
             if (typeof raw === 'string' && raw.trim() !== '') {
-                const parsed = parseNavigationContent(raw.trim()) as readonly unknown[];
+                const parsed = parseNavigationContentCached(raw.trim());
 
                 if (parsed.length > 0) {
                     return getDecoratedBlocks(kind, name, id, parsed);
@@ -2155,6 +2155,29 @@ export function useEntityBlockEditor(
     );
 
     return [blocks, noopSetter, noopSetter];
+}
+
+/**
+ * Memoize `parseNavigationContent` so identical raw strings return the
+ * same array reference. `getDecoratedBlocks` uses reference equality to
+ * decide whether to re-mint `clientId`s; without this cache, every read
+ * produced a fresh parsed array, the decoration cache missed, and
+ * `clientId`s churned each render — Gutenberg saw "new" blocks and
+ * re-mounted the inner-block subtree on every paint.
+ */
+const parsedNavigationContentCache = new Map<string, readonly unknown[]>();
+
+function parseNavigationContentCached(raw: string): readonly unknown[] {
+    const cached = parsedNavigationContentCache.get(raw);
+
+    if (cached !== undefined) {
+        return cached;
+    }
+
+    const parsed = parseNavigationContent(raw) as readonly unknown[];
+    parsedNavigationContentCache.set(raw, parsed);
+
+    return parsed;
 }
 
 interface ServerBlock {

--- a/resources/js/visual-editor/vendor/core-data-shim.ts
+++ b/resources/js/visual-editor/vendor/core-data-shim.ts
@@ -854,6 +854,22 @@ function flattenRawProperties(record: EntityRecord): EntityRecord {
         if (value !== null && typeof value === 'object') {
             const shape = value as { raw?: unknown; rendered?: unknown };
 
+            // `content` for `wp_navigation` (and `wp_template` / `wp_block`)
+            // ships as `{ raw, blocks }`. Gutenberg's `core/navigation`
+            // edit component reads `editedRecord.content.raw` (object
+            // shape) to feed its parser; flattening it down to a bare
+            // string here breaks that read — `content.raw` becomes
+            // `undefined`, the block treats the menu as empty, and the
+            // canvas's projected innerBlocks get wiped on the next
+            // render. Preserve the object shape for `content`
+            // specifically (Keystone #48); other fields with the
+            // `{raw, rendered}` shape (`title`, `description`) keep
+            // their flatten so consumers can read them as strings.
+            if (key === 'content') {
+                out[key] = value;
+                continue;
+            }
+
             if (typeof shape.raw === 'string') {
                 out[key] = shape.raw;
                 continue;

--- a/resources/js/visual-editor/vendor/core-data-shim.ts
+++ b/resources/js/visual-editor/vendor/core-data-shim.ts
@@ -1238,6 +1238,11 @@ interface ThunkArgs {
             name: EntityName,
             id: EntityKey,
         ) => EntityRecord | null;
+        getEntityRecordEdits: (
+            kind: EntityKind,
+            name: EntityName,
+            id: EntityKey,
+        ) => EntityRecord | null;
     };
 }
 
@@ -1523,11 +1528,23 @@ const actions = {
     saveEditedEntityRecord:
         (kind: EntityKind, name: EntityName, id: EntityKey) =>
         async ({ dispatch, select }: ThunkArgs): Promise<EntityRecord | null> => {
-            const edited = select.getEditedEntityRecord(kind, name, id);
+            // `getEditedEntityRecord` returns `{}` for an unresolved
+            // record so synchronous reads on the nav block (and other
+            // entity-backed Edit components) don't crash on
+            // `record.status` (Keystone #48). That makes a bare
+            // `=== null` check insufficient here — `{}` would slip
+            // through and trigger a spurious PUT `{ id }` payload
+            // for a record nothing has loaded or edited. Probe the
+            // underlying base + edits explicitly instead, so we only
+            // serialize a save when there's something to save.
+            const base = select.getEntityRecord(kind, name, id);
+            const edits = select.getEntityRecordEdits(kind, name, id);
 
-            if (edited === null) {
+            if (base === null && (edits === null || Object.keys(edits).length === 0)) {
                 return null;
             }
+
+            const edited = select.getEditedEntityRecord(kind, name, id);
 
             const config = select.getEntityConfig(kind, name);
             const payload: EntityRecord = config

--- a/resources/js/visual-editor/vendor/parse-navigation-content.ts
+++ b/resources/js/visual-editor/vendor/parse-navigation-content.ts
@@ -1,0 +1,216 @@
+/**
+ * Minimal WP block-comment parser scoped to navigation content
+ * (Keystone #48).
+ *
+ * The shim's `useEntityBlockEditor` needs to hydrate an entity's
+ * pre-parsed block tree from its content payload. For most entities
+ * the server ships `content.blocks` as an array; for `wp_navigation`
+ * — and after `flattenRawProperties` collapses `content: {raw,
+ * blocks}` down to a plain string — we only have the serialized
+ * block-comment markup. This module parses just enough of that
+ * markup to rebuild the `core/navigation-link` /
+ * `core/navigation-submenu` tree the canvas expects.
+ *
+ * We avoid importing `@wordpress/blocks`'s full `parse()` here for
+ * two reasons:
+ *  1. `@wordpress/blocks` ships JSON imports that break vitest's
+ *     module resolver, which would block the shim's own test suite.
+ *  2. Navigation menus are the only content shape that reaches this
+ *     path — a focused parser keeps the shim's runtime dependencies
+ *     small and the failure mode predictable.
+ *
+ * Mirrors `MenuItemBlockBridge::rawToBlocks` (PHP) so a server-
+ * shipped `content.raw` round-trips into the same tree the
+ * editor reads in either direction.
+ */
+
+export interface ParsedBlock {
+    name: string;
+    attributes: Record<string, unknown>;
+    innerBlocks: ParsedBlock[];
+}
+
+interface OpenToken {
+    kind: 'open';
+    name: string;
+    attributes: Record<string, unknown>;
+}
+
+interface SelfCloseToken {
+    kind: 'selfclose';
+    name: string;
+    attributes: Record<string, unknown>;
+}
+
+interface CloseToken {
+    kind: 'close';
+    name: string;
+}
+
+type Token = OpenToken | SelfCloseToken | CloseToken;
+
+const SUPPORTED_BLOCK_NAMES = new Set<string>([
+    'core/navigation-link',
+    'core/navigation-submenu',
+]);
+
+/**
+ * Parse a WP block-comment string carrying a navigation tree into a
+ * flat array of blocks. Drops any block name that isn't a navigation
+ * link / submenu — the shim's only consumer of this output is the
+ * `core/navigation` block, and the editor's renderer can't do
+ * anything sensible with a stray paragraph inside the nav tree.
+ */
+export function parseNavigationContent(raw: string): ParsedBlock[] {
+    const trimmed = raw.trim();
+
+    if (trimmed === '') {
+        return [];
+    }
+
+    const tokens = tokenize(trimmed);
+    const cursor = { index: 0 };
+
+    return consumeChildren(tokens, cursor);
+}
+
+function tokenize(raw: string): Token[] {
+    const tokens: Token[] = [];
+    let pos = 0;
+    const len = raw.length;
+
+    while (pos < len) {
+        const openAt = raw.indexOf('<!--', pos);
+
+        if (openAt < 0) {
+            break;
+        }
+
+        const closeAt = raw.indexOf('-->', openAt);
+
+        if (closeAt < 0) {
+            break;
+        }
+
+        let body = raw.slice(openAt + 4, closeAt).trim();
+        pos = closeAt + 3;
+
+        let selfClose = false;
+
+        if (body.endsWith('/')) {
+            selfClose = true;
+            body = body.slice(0, -1).trimEnd();
+        }
+
+        if (body.startsWith('/wp:')) {
+            tokens.push({
+                kind: 'close',
+                name: 'core/' + body.slice(4).trim(),
+            });
+
+            continue;
+        }
+
+        if (!body.startsWith('wp:')) {
+            continue;
+        }
+
+        const tail = body.slice(3);
+        const nameEnd = firstSplitIndex(tail);
+        const name = 'core/' + tail.slice(0, nameEnd);
+        const attrsStr = tail.slice(nameEnd).trim();
+
+        let attributes: Record<string, unknown> = {};
+
+        if (attrsStr !== '') {
+            try {
+                const decoded = JSON.parse(attrsStr) as unknown;
+
+                if (decoded !== null && typeof decoded === 'object' && !Array.isArray(decoded)) {
+                    attributes = decoded as Record<string, unknown>;
+                }
+            } catch {
+                // Malformed JSON in a block comment is a server-side
+                // bug; surface as "no attributes" rather than crashing
+                // the editor.
+            }
+        }
+
+        tokens.push(
+            selfClose
+                ? { kind: 'selfclose', name, attributes }
+                : { kind: 'open', name, attributes }
+        );
+    }
+
+    return tokens;
+}
+
+function firstSplitIndex(value: string): number {
+    for (let i = 0; i < value.length; i += 1) {
+        const ch = value[i];
+
+        if (
+            ch === ' ' ||
+            ch === '\t' ||
+            ch === '\n' ||
+            ch === '\r' ||
+            ch === '\f' ||
+            ch === '\v' ||
+            ch === '{'
+        ) {
+            return i;
+        }
+    }
+
+    return value.length;
+}
+
+function consumeChildren(tokens: Token[], cursor: { index: number }): ParsedBlock[] {
+    const children: ParsedBlock[] = [];
+
+    while (cursor.index < tokens.length) {
+        const token = tokens[cursor.index]!;
+
+        if (token.kind === 'close') {
+            return children;
+        }
+
+        if (!SUPPORTED_BLOCK_NAMES.has(token.name)) {
+            // Skip unsupported block plus its matching close if any —
+            // matches the PHP parser's defensive drop.
+            cursor.index += 1;
+
+            if (token.kind === 'open') {
+                consumeChildren(tokens, cursor);
+                cursor.index += 1;
+            }
+
+            continue;
+        }
+
+        if (token.kind === 'selfclose') {
+            children.push({
+                name: token.name,
+                attributes: token.attributes,
+                innerBlocks: [],
+            });
+            cursor.index += 1;
+
+            continue;
+        }
+
+        // `open` — recurse for inner blocks, then skip the matching close.
+        cursor.index += 1;
+        const inner = consumeChildren(tokens, cursor);
+        cursor.index += 1;
+
+        children.push({
+            name: token.name,
+            attributes: token.attributes,
+            innerBlocks: inner,
+        });
+    }
+
+    return children;
+}

--- a/src/Http/Controllers/SiteEditor/MenuController.php
+++ b/src/Http/Controllers/SiteEditor/MenuController.php
@@ -163,19 +163,31 @@ class MenuController extends Controller
 		}
 
 		$validated = $request->validated();
+		$blocks    = array_key_exists( 'content', $validated )
+			? $this->resolveContentBlocks( $validated['content'] )
+			: null;
 
 		try {
-			DB::transaction( function () use ( $menu, $validated ): void {
+			DB::transaction( function () use ( $menu, $validated, $blocks ): void {
 				$menu->update( $this->modelAttributesFromRequest( $validated ) );
 
-				// #440. When the editor sends a navigation tree, replace
-				// the menu's items wholesale. Gated on `content.blocks`
-				// being present so a partial update (rename, theme
-				// change, …) leaves items untouched. Inside the same
-				// transaction as the attribute update so a failed item
-				// rebuild rolls the whole save back.
-				if ( is_array( $validated['content']['blocks'] ?? null ) ) {
-					$this->replaceMenuItems( $menu, $validated['content']['blocks'] );
+				// When the editor sends a navigation tree, replace the
+				// menu's items wholesale. Gated on `$blocks !== null`
+				// so a partial update (rename, theme change, …) leaves
+				// items untouched. Inside the same transaction as the
+				// attribute update so a failed item rebuild rolls the
+				// whole save back.
+				//
+				// `$blocks` is resolved up front from one of three
+				// shapes (Keystone #48):
+				//   - `content` as a string → parsed via rawToBlocks
+				//   - `content.blocks` as array → used directly (#440)
+				//   - `content.raw` as string → parsed via rawToBlocks
+				// `null` here means "key was omitted from the
+				// request" — leave items alone. An authored
+				// `content: null` / `""` resolves to `[]` (wipe).
+				if ( is_array( $blocks ) ) {
+					$this->replaceMenuItems( $menu, $blocks );
 				}
 			} );
 		} catch ( QueryException $e ) {
@@ -190,6 +202,57 @@ class MenuController extends Controller
 		}
 
 		return response()->json( $this->menuToShape( $menu->fresh() ) );
+	}
+
+	/**
+	 * Normalize an authored `content` value into a `core/navigation-*`
+	 * block tree (Keystone #48). Always returns an array; the caller
+	 * gates on whether the `content` key was *present* in the request
+	 * (so a partial update that omits `content` entirely leaves the
+	 * existing items in place — distinct from an authored
+	 * `content: null` / `content: ""` which wipes them).
+	 *
+	 * Three accepted input shapes:
+	 *   - `null` or empty string → `[]` (wipe items)
+	 *   - String of WP block-comment markup → parsed via
+	 *     {@see MenuItemBlockBridge::rawToBlocks}
+	 *   - Array `{ raw?, blocks? }` → `blocks` wins when both are
+	 *     set (lossless); `raw` is parsed otherwise
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	protected function resolveContentBlocks( mixed $content ): array
+	{
+		if ( null === $content ) {
+			// `content: null` (from `ConvertEmptyStringsToNull` on
+			// `content: ""`) means "no items" — wipe them.
+			return [];
+		}
+
+		if ( is_string( $content ) ) {
+			$trimmed = trim( $content );
+
+			return '' === $trimmed ? [] : ( new MenuItemBlockBridge() )->rawToBlocks( $trimmed );
+		}
+
+		if ( is_array( $content ) ) {
+			if ( is_array( $content['blocks'] ?? null ) ) {
+				return $content['blocks'];
+			}
+
+			if ( is_string( $content['raw'] ?? null ) ) {
+				$trimmed = trim( $content['raw'] );
+
+				return '' === $trimmed ? [] : ( new MenuItemBlockBridge() )->rawToBlocks( $trimmed );
+			}
+
+			// Empty `content: {}` object → no items.
+			return [];
+		}
+
+		return [];
 	}
 
 	/**
@@ -328,19 +391,25 @@ class MenuController extends Controller
 				'rendered' => $name,
 				'raw'      => $name,
 			],
-			// `content` mirrors the WP REST `wp_navigation` shape. #440:
-			// the menu's `menu_items` rows are projected into a
-			// `core/navigation-link` / `core/navigation-submenu` block
-			// tree so the editor's NavigationBrowser reads the real
-			// tree (it was an empty envelope from #438 until this
-			// bridge landed). `raw` stays empty — the editor works off
-			// `blocks`, and the backend re-derives the tree from
-			// `menu_items` on every read. Items remain individually
-			// addressable through the separate /menu-items endpoint.
-			'content'        => [
-				'raw'    => '',
-				'blocks' => ( new MenuItemBlockBridge() )->itemsToBlocks( $menu->items ),
-			],
+			// `content` mirrors the WP REST `wp_navigation` shape. #440
+			// projects `menu_items` rows into a `core/navigation-link` /
+			// `core/navigation-submenu` block tree under `content.blocks`.
+			// Keystone #48: ship `content.raw` as the serialized block-
+			// comment form too — Gutenberg's `core/navigation` block
+			// reads `content.raw` (not `content.blocks`) when deciding
+			// which inner blocks to render, so without this the picker
+			// shows an empty list even when the menu has items. The
+			// backend re-derives both from `menu_items` on every read;
+			// items remain individually addressable via /menu-items.
+			'content'        => ( function () use ( $menu ): array {
+				$bridge = new MenuItemBlockBridge();
+				$blocks = $bridge->itemsToBlocks( $menu->items );
+
+				return [
+					'raw'    => $bridge->blocksToRaw( $blocks ),
+					'blocks' => $blocks,
+				];
+			} )(),
 			'auto_add_pages' => (bool) ( $menu->auto_add_pages ?? false ),
 		];
 	}

--- a/src/Http/Requests/SiteEditor/UpdateMenuRequest.php
+++ b/src/Http/Requests/SiteEditor/UpdateMenuRequest.php
@@ -18,7 +18,34 @@ declare( strict_types=1 );
 
 namespace ArtisanPackUI\VisualEditor\Http\Requests\SiteEditor;
 
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Polymorphic shape validator for the `content` field. Gutenberg's
+ * default save path serializes the navigation block tree into a
+ * string (the WP-REST default for `wp_navigation`); the #440 custom
+ * save path sends an object `{ raw?, blocks? }`. Accept both, reject
+ * everything else.
+ */
+final class ContentShapeRule implements ValidationRule
+{
+	public function validate( string $attribute, mixed $value, Closure $fail ): void
+	{
+		// `null` happens when Laravel's `ConvertEmptyStringsToNull`
+		// middleware normalizes an authored `content: ""` (which
+		// Gutenberg sends when the user clears every item) into
+		// `null`. Treat it as "empty content" — same semantic as
+		// `content.blocks: []` — and let the controller wipe the
+		// items.
+		if ( null === $value || is_string( $value ) || is_array( $value ) ) {
+			return;
+		}
+
+		$fail( 'The :attribute field must be a string or an object.' );
+	}
+}
 
 class UpdateMenuRequest extends FormRequest
 {
@@ -44,12 +71,16 @@ class UpdateMenuRequest extends FormRequest
 			'title'          => [ 'sometimes', 'string', 'max:255' ],
 			'description'    => [ 'nullable', 'string' ],
 			'auto_add_pages' => [ 'sometimes', 'boolean' ],
-			// #440. The site editor PUTs its navigation tree as a
-			// `core/navigation-*` block tree under `content.blocks`;
-			// the controller bridges it to / from cms-framework's
-			// relational `menu_items` rows. `content.raw` is accepted
-			// but ignored — the backend re-derives it from the tree.
-			'content'        => [ 'sometimes', 'array' ],
+			// `content` arrives in two shapes:
+			//  - String: Gutenberg's default save path serializes the
+			//    edited block tree into `content` (the WP-REST default
+			//    for `wp_navigation`). Keystone #48 — the controller
+			//    parses it back via `MenuItemBlockBridge::rawToBlocks`
+			//    and routes through the existing replaceMenuItems path.
+			//  - Array `{ raw?, blocks? }`: #440's custom path that
+			//    bypasses the round-trip. `content.raw` is informational
+			//    here; the backend re-derives it from `menu_items`.
+			'content'        => [ 'sometimes', new ContentShapeRule() ],
 			'content.raw'    => [ 'sometimes', 'nullable', 'string' ],
 			'content.blocks' => [ 'sometimes', 'array' ],
 		];

--- a/src/Http/Resources/Adapters/CmsFramework/SiteEditor/TemplateAdapter.php
+++ b/src/Http/Resources/Adapters/CmsFramework/SiteEditor/TemplateAdapter.php
@@ -25,6 +25,7 @@ declare( strict_types=1 );
 
 namespace ArtisanPackUI\VisualEditor\Http\Resources\Adapters\CmsFramework\SiteEditor;
 
+use ArtisanPackUI\VisualEditor\SiteEditor\NavigationBlockRefResolver;
 use ArtisanPackUI\VisualEditor\SiteEditor\Resolution\ResolvedTemplate;
 
 class TemplateAdapter
@@ -57,6 +58,18 @@ class TemplateAdapter
 	 */
 	public function toArray( ResolvedTemplate $template ): array
 	{
+		// Stamp `ref` on any nested `core/navigation` block whose
+		// `__unstableLocation` matches an assigned menu location
+		// (Keystone #48). Gutenberg's current nav block doesn't
+		// auto-resolve `__unstableLocation` to a `ref`, so without
+		// this projection a themed seed of `{"__unstableLocation":
+		// "primary"}` lands in the editor as "no menu selected" and
+		// the picker shows "This Navigation Menu is empty."
+		$resolvedBlocks = ( new NavigationBlockRefResolver() )->resolve(
+			$template->blocks,
+			$template->theme,
+		);
+
 		return [
 			'id'             => $template->wpId > 0 ? $template->wpId : $template->slug,
 			'slug'           => $template->slug,
@@ -70,7 +83,7 @@ class TemplateAdapter
 			'description'    => $template->description,
 			'content'        => [
 				'raw'    => $template->rawContent,
-				'blocks' => $template->blocks,
+				'blocks' => $resolvedBlocks,
 			],
 			'status'         => $template->status,
 			'theme'          => $template->theme,

--- a/src/SiteEditor/MenuItemBlockBridge.php
+++ b/src/SiteEditor/MenuItemBlockBridge.php
@@ -105,6 +105,264 @@ class MenuItemBlockBridge
 	}
 
 	/**
+	 * Serialize a `core/navigation-*` block tree into the WordPress
+	 * block-comment markup Gutenberg's `core/navigation` block reads
+	 * from `content.raw` (Keystone #48).
+	 *
+	 * Output format mirrors WP core's `serialize_block()`: the
+	 * `core/` prefix is stripped, attributes are JSON-encoded only
+	 * when non-empty, leaf blocks self-close, and submenus open /
+	 * close around recursively-serialized inner blocks. Lines stay
+	 * separated by `\n` so the parser on the way back produces the
+	 * same tree we started with.
+	 *
+	 * Returns an empty string when the tree is empty — keeps the
+	 * `content.raw` field present in the envelope but signals to
+	 * Gutenberg's nav block that there are no items, the same way an
+	 * empty menu would.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param  array<int, mixed>  $blocks
+	 */
+	public function blocksToRaw( array $blocks ): string
+	{
+		$lines = [];
+
+		foreach ( $blocks as $block ) {
+			$rendered = $this->serializeBlock( $block );
+
+			if ( '' === $rendered ) {
+				continue;
+			}
+
+			$lines[] = $rendered;
+		}
+
+		return implode( "\n", $lines );
+	}
+
+	/**
+	 * Parse a WordPress block-comment string back into the block tree
+	 * `core/navigation`'s save flow sends us (Keystone #48). Inverse of
+	 * {@see blocksToRaw} — Gutenberg's data-store save layer serializes
+	 * edited blocks back to `content.raw` (a string) before PUT-ing,
+	 * which our `replaceMenuItems` path needs as a structured array.
+	 *
+	 * Scope is intentionally narrow: only `wp:navigation-link` and
+	 * `wp:navigation-submenu` comments are recognized. Anything else
+	 * (`wp:paragraph`, free-text between tokens, malformed comments)
+	 * is skipped — the controller's `blocksToItemSpecs` step would
+	 * drop them anyway, so the parser stays defensive rather than
+	 * fighting bad input.
+	 *
+	 * Tokenize first, then build the tree depth-first against a stack.
+	 * Lets a recursive structure (submenu containing submenu containing
+	 * link) come back out the way it went in without juggling indices.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	public function rawToBlocks( string $raw ): array
+	{
+		$tokens = $this->tokenize( $raw );
+		$index  = 0;
+
+		return $this->consumeChildren( $tokens, $index );
+	}
+
+	/**
+	 * Tokenize a block-comment string into a flat list of OPEN /
+	 * SELFCLOSE / CLOSE tokens. Each token carries the canonical block
+	 * name (with `core/` prefix re-added) and, for openers, the
+	 * decoded attributes array.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	protected function tokenize( string $raw ): array
+	{
+		$tokens = [];
+		$pos    = 0;
+		$len    = strlen( $raw );
+
+		while ( $pos < $len ) {
+			$openAt = strpos( $raw, '<!--', $pos );
+
+			if ( false === $openAt ) {
+				break;
+			}
+
+			$closeAt = strpos( $raw, '-->', $openAt );
+
+			if ( false === $closeAt ) {
+				break;
+			}
+
+			$body = trim( substr( $raw, $openAt + 4, $closeAt - $openAt - 4 ) );
+			$pos  = $closeAt + 3;
+
+			$selfClose = false;
+
+			if ( str_ends_with( $body, '/' ) ) {
+				$selfClose = true;
+				$body      = rtrim( substr( $body, 0, -1 ) );
+			}
+
+			if ( str_starts_with( $body, '/wp:' ) ) {
+				$tokens[] = [
+					'kind' => 'close',
+					'name' => 'core/' . trim( substr( $body, 4 ) ),
+				];
+
+				continue;
+			}
+
+			if ( ! str_starts_with( $body, 'wp:' ) ) {
+				continue;
+			}
+
+			$tail = substr( $body, 3 );
+
+			// Split block name from optional JSON attrs. The name ends
+			// at the first whitespace or `{`; whatever follows is the
+			// JSON payload (or empty when the block has no attrs).
+			$nameEnd = strcspn( $tail, " \t\n\r\f\v{" );
+			$name    = 'core/' . substr( $tail, 0, $nameEnd );
+			$attrsTr = trim( substr( $tail, $nameEnd ) );
+
+			$attrs = [];
+
+			if ( '' !== $attrsTr ) {
+				$decoded = json_decode( $attrsTr, true );
+				$attrs   = is_array( $decoded ) ? $decoded : [];
+			}
+
+			$tokens[] = [
+				'kind'       => $selfClose ? 'selfclose' : 'open',
+				'name'       => $name,
+				'attributes' => $attrs,
+			];
+		}
+
+		return $tokens;
+	}
+
+	/**
+	 * Recursive tree builder. Consumes tokens until it hits a `close`
+	 * (which the caller is responsible for skipping) or runs out.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param  array<int, array<string, mixed>>  $tokens
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	protected function consumeChildren( array $tokens, int &$index ): array
+	{
+		$children = [];
+
+		while ( $index < count( $tokens ) ) {
+			$token = $tokens[ $index ];
+
+			if ( 'close' === $token['kind'] ) {
+				return $children;
+			}
+
+			$name = (string) $token['name'];
+
+			if ( self::NAV_LINK !== $name && self::NAV_SUBMENU !== $name ) {
+				// Skip unknown blocks — and their close tag if any —
+				// rather than letting them break the structural pair.
+				$index++;
+
+				if ( 'open' === $token['kind'] ) {
+					$this->consumeChildren( $tokens, $index );
+					$index++;
+				}
+
+				continue;
+			}
+
+			if ( 'selfclose' === $token['kind'] ) {
+				$children[] = [
+					'name'        => $name,
+					'attributes'  => $token['attributes'] ?? [],
+					'innerBlocks' => [],
+				];
+				$index++;
+
+				continue;
+			}
+
+			// `open` — recurse for inner blocks, then skip the
+			// matching `close`.
+			$index++;
+			$inner = $this->consumeChildren( $tokens, $index );
+			$index++;
+
+			$children[] = [
+				'name'        => $name,
+				'attributes'  => $token['attributes'] ?? [],
+				'innerBlocks' => $inner,
+			];
+		}
+
+		return $children;
+	}
+
+	/**
+	 * Serialize a single navigation block into the WP-comment shape.
+	 * Drops unknown block names so a malformed input doesn't slip an
+	 * unsupported block type through the serializer.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param  mixed  $block
+	 */
+	protected function serializeBlock( mixed $block ): string
+	{
+		if ( ! is_array( $block ) ) {
+			return '';
+		}
+
+		$name = $block['name'] ?? null;
+
+		if ( self::NAV_LINK !== $name && self::NAV_SUBMENU !== $name ) {
+			return '';
+		}
+
+		// Strip the `core/` prefix to match WP's serialize_block output.
+		// `core/navigation-link` → `navigation-link`.
+		$shortName = substr( (string) $name, strlen( 'core/' ) );
+
+		$attributes = is_array( $block['attributes'] ?? null ) ? $block['attributes'] : [];
+		$json       = [] === $attributes
+			? ''
+			: ' ' . json_encode( $attributes, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
+
+		$innerBlocks = is_array( $block['innerBlocks'] ?? null ) ? $block['innerBlocks'] : [];
+
+		// Leaf blocks (no children) use the self-closing `/-->` form.
+		// Submenus open / close around their serialized children.
+		if ( [] === $innerBlocks ) {
+			return sprintf( '<!-- wp:%s%s /-->', $shortName, $json );
+		}
+
+		$inner = $this->blocksToRaw( $innerBlocks );
+
+		return sprintf(
+			"<!-- wp:%s%s -->\n%s\n<!-- /wp:%s -->",
+			$shortName,
+			$json,
+			$inner,
+			$shortName
+		);
+	}
+
+	/**
 	 * Write path — parse a `core/navigation-*` block tree into a nested
 	 * list of row-attribute specs the controller inserts depth-first.
 	 *

--- a/src/SiteEditor/MenuItemBlockBridge.php
+++ b/src/SiteEditor/MenuItemBlockBridge.php
@@ -260,7 +260,7 @@ class MenuItemBlockBridge
 	 *
 	 * @return array<int, array<string, mixed>>
 	 */
-	protected function consumeChildren( array $tokens, int &$index ): array
+	protected function consumeChildren( array $tokens, int &$index, ?string $until = null ): array
 	{
 		$children = [];
 
@@ -268,19 +268,29 @@ class MenuItemBlockBridge
 			$token = $tokens[ $index ];
 
 			if ( 'close' === $token['kind'] ) {
-				return $children;
+				// Match close tags by block name to keep nesting honest.
+				// Returning on the first `close` we see drops later
+				// siblings (or reparents them under a submenu) whenever
+				// an unsupported or malformed open token slipped past
+				// our skip path. Only return when the close matches the
+				// block this frame was opened for.
+				if ( null !== $until && $token['name'] === $until ) {
+					return $children;
+				}
+
+				$index++;
+
+				continue;
 			}
 
 			$name = (string) $token['name'];
 
 			if ( self::NAV_LINK !== $name && self::NAV_SUBMENU !== $name ) {
-				// Skip unknown blocks — and their close tag if any —
-				// rather than letting them break the structural pair.
 				$index++;
 
 				if ( 'open' === $token['kind'] ) {
-					$this->consumeChildren( $tokens, $index );
-					$index++;
+					$this->consumeChildren( $tokens, $index, $name );
+					$this->skipMatchingClose( $tokens, $index, $name );
 				}
 
 				continue;
@@ -297,11 +307,13 @@ class MenuItemBlockBridge
 				continue;
 			}
 
-			// `open` — recurse for inner blocks, then skip the
-			// matching `close`.
+			// `open` — recurse for inner blocks, then skip the matching
+			// `close` (by name). A missing close is treated as benign:
+			// the recursion ends at end-of-stream and we move on rather
+			// than swallowing the next sibling's tokens.
 			$index++;
-			$inner = $this->consumeChildren( $tokens, $index );
-			$index++;
+			$inner = $this->consumeChildren( $tokens, $index, $name );
+			$this->skipMatchingClose( $tokens, $index, $name );
 
 			$children[] = [
 				'name'        => $name,
@@ -311,6 +323,27 @@ class MenuItemBlockBridge
 		}
 
 		return $children;
+	}
+
+	/**
+	 * Advance `$index` past the next token if it's a `close` for the
+	 * given block name. No-op on missing close (defensive against
+	 * truncated markup) or mismatched name (let the parent frame handle
+	 * its own close).
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param  array<int, array<string, mixed>>  $tokens
+	 */
+	protected function skipMatchingClose( array $tokens, int &$index, string $name ): void
+	{
+		if (
+			$index < count( $tokens )
+			&& 'close' === $tokens[ $index ]['kind']
+			&& $tokens[ $index ]['name'] === $name
+		) {
+			$index++;
+		}
 	}
 
 	/**
@@ -341,7 +374,7 @@ class MenuItemBlockBridge
 		$attributes = is_array( $block['attributes'] ?? null ) ? $block['attributes'] : [];
 		$json       = [] === $attributes
 			? ''
-			: ' ' . json_encode( $attributes, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
+			: ' ' . $this->encodeAttributes( $attributes );
 
 		$innerBlocks = is_array( $block['innerBlocks'] ?? null ) ? $block['innerBlocks'] : [];
 
@@ -360,6 +393,36 @@ class MenuItemBlockBridge
 			$inner,
 			$shortName
 		);
+	}
+
+	/**
+	 * Encode block attributes the same way WordPress core's
+	 * `serialize_block_attributes()` does. Bare `json_encode()` emits
+	 * characters that interfere with the surrounding HTML comment
+	 * (`-->`, `<`, `>`, `&`, `\`, `"`) — Gutenberg's parser rejects the
+	 * markup or, worse, the comment closes early and tokens leak into
+	 * the rendered HTML. Mirrors upstream by post-encoding those
+	 * sequences as their JSON `\uXXXX` escapes so the JSON stays valid
+	 * AND the comment stays intact.
+	 *
+	 * Reference: WP core `wp-includes/blocks.php :: serialize_block_attributes()`.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param  array<string, mixed>  $attributes
+	 */
+	protected function encodeAttributes( array $attributes ): string
+	{
+		$encoded = (string) json_encode( $attributes, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
+
+		return strtr( $encoded, [
+			'\\\\' => '\\u005c',
+			'--'   => '\\u002d\\u002d',
+			'<'    => '\\u003c',
+			'>'    => '\\u003e',
+			'&'    => '\\u0026',
+			'\\"'  => '\\u0022',
+		] );
 	}
 
 	/**

--- a/src/SiteEditor/NavigationBlockRefResolver.php
+++ b/src/SiteEditor/NavigationBlockRefResolver.php
@@ -40,6 +40,8 @@ class NavigationBlockRefResolver
 
 	protected const ASSIGNMENT_FQCN = 'ArtisanPackUI\\CMSFramework\\Modules\\SiteEditor\\Models\\MenuLocationAssignment';
 
+	protected const MENU_FQCN = 'ArtisanPackUI\\CMSFramework\\Modules\\SiteEditor\\Models\\Menu';
+
 	/**
 	 * Per-instance cache. Keys are `{theme}|{location}` so a render
 	 * across multiple themes (vanishingly rare in V1) doesn't collide.
@@ -49,6 +51,15 @@ class NavigationBlockRefResolver
 	 * @var array<string, int|null>
 	 */
 	protected array $cache = [];
+
+	/**
+	 * Per-instance cache of menu-item projections, keyed by menu id so
+	 * a tree with multiple nav blocks pointed at the same menu doesn't
+	 * re-fetch / re-project for each one.
+	 *
+	 * @var array<int, array<int, array<string, mixed>>>
+	 */
+	protected array $blocksByMenuId = [];
 
 	/**
 	 * Walk a block tree and return a new tree with resolved refs.
@@ -83,12 +94,28 @@ class NavigationBlockRefResolver
 		$innerBlocks = is_array( $block['innerBlocks'] ?? null ) ? $block['innerBlocks'] : [];
 
 		$resolvedAttributes = $attributes;
+		$resolvedInner      = [] === $innerBlocks ? $innerBlocks : $this->resolve( $innerBlocks, $theme );
 
 		if ( self::NAV_BLOCK_NAME === ( $block['name'] ?? null ) ) {
 			$resolvedAttributes = $this->stampNavRef( $attributes, $theme );
-		}
 
-		$resolvedInner = [] === $innerBlocks ? $innerBlocks : $this->resolve( $innerBlocks, $theme );
+			// Stamp the menu's items as the nav block's innerBlocks
+			// when we resolved a `ref` (or the author had one) AND
+			// the block tree is currently empty. Gutenberg's nav
+			// block reads its children from the block tree (via the
+			// block-editor data store), not from any entity record —
+			// so without populated innerBlocks the canvas renders an
+			// empty nav block + the inspector shows "This Navigation
+			// Menu is empty." even when the menu has rows in
+			// `menu_items` (Keystone #48).
+			$refId = is_numeric( $resolvedAttributes['ref'] ?? null )
+				? (int) $resolvedAttributes['ref']
+				: null;
+
+			if ( null !== $refId && [] === $resolvedInner ) {
+				$resolvedInner = $this->menuItemsAsBlocks( $refId );
+			}
+		}
 
 		if ( $resolvedAttributes === $attributes && $resolvedInner === $innerBlocks ) {
 			return $block;
@@ -99,6 +126,49 @@ class NavigationBlockRefResolver
 			'attributes'  => $resolvedAttributes,
 			'innerBlocks' => $resolvedInner,
 		];
+	}
+
+	/**
+	 * Project the menu's `menu_items` rows into the nav-block tree
+	 * shape (`core/navigation-link` / `core/navigation-submenu`) the
+	 * editor expects. Reuses {@see MenuItemBlockBridge::itemsToBlocks}
+	 * so the projection stays in lockstep with the front-end render
+	 * path.
+	 *
+	 * Cached per-menu-id so a tree with multiple nav blocks pointed
+	 * at the same menu only fetches once. Returns an empty array
+	 * when cms-framework isn't installed or the menu isn't found.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	protected function menuItemsAsBlocks( int $menuId ): array
+	{
+		if ( array_key_exists( $menuId, $this->blocksByMenuId ) ) {
+			return $this->blocksByMenuId[ $menuId ];
+		}
+
+		if ( ! class_exists( self::MENU_FQCN ) ) {
+			$this->blocksByMenuId[ $menuId ] = [];
+
+			return [];
+		}
+
+		$model = self::MENU_FQCN;
+		$menu  = $model::query()->with( 'items' )->find( $menuId );
+
+		if ( null === $menu ) {
+			$this->blocksByMenuId[ $menuId ] = [];
+
+			return [];
+		}
+
+		$blocks = ( new MenuItemBlockBridge() )->itemsToBlocks( $menu->items );
+
+		$this->blocksByMenuId[ $menuId ] = $blocks;
+
+		return $blocks;
 	}
 
 	/**

--- a/src/SiteEditor/NavigationBlockRefResolver.php
+++ b/src/SiteEditor/NavigationBlockRefResolver.php
@@ -34,6 +34,8 @@ declare( strict_types=1 );
 
 namespace ArtisanPackUI\VisualEditor\SiteEditor;
 
+use Illuminate\Support\Str;
+
 class NavigationBlockRefResolver
 {
 	protected const NAV_BLOCK_NAME = 'core/navigation';
@@ -164,11 +166,43 @@ class NavigationBlockRefResolver
 			return [];
 		}
 
-		$blocks = ( new MenuItemBlockBridge() )->itemsToBlocks( $menu->items );
+		$blocks = $this->stampMetadata(
+			( new MenuItemBlockBridge() )->itemsToBlocks( $menu->items ),
+		);
 
 		$this->blocksByMenuId[ $menuId ] = $blocks;
 
 		return $blocks;
+	}
+
+	/**
+	 * Stamp `clientId` + `isValid` on every block in the projected
+	 * tree. The other blocks in a template-part response carry these
+	 * because cms-framework's seed applier stamps them at write time;
+	 * our runtime projection has to mirror that or Gutenberg's
+	 * block-editor data store rejects the malformed nodes during
+	 * receive and the entire tree fails to mount silently (no
+	 * console error, just an empty canvas). Keystone #48.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param  array<int, array<string, mixed>>  $blocks
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	protected function stampMetadata( array $blocks ): array
+	{
+		return array_map(
+			fn ( array $block ): array => [
+				...$block,
+				'clientId'    => (string) ( $block['clientId'] ?? Str::uuid() ),
+				'isValid'     => true,
+				'innerBlocks' => $this->stampMetadata(
+					is_array( $block['innerBlocks'] ?? null ) ? $block['innerBlocks'] : [],
+				),
+			],
+			$blocks,
+		);
 	}
 
 	/**

--- a/src/SiteEditor/NavigationBlockRefResolver.php
+++ b/src/SiteEditor/NavigationBlockRefResolver.php
@@ -126,10 +126,23 @@ class NavigationBlockRefResolver
 			return $attributes;
 		}
 
-		return [
+		// Strip `__unstableLocation` after stamping `ref`. Gutenberg's
+		// current `core/navigation` block prefers `__unstableLocation`
+		// when both attributes are set and falls back to its own
+		// (broken in our environment) location-lookup pipeline; leaving
+		// the attribute in place sent the picker down that path and
+		// kept `useEntityBlockEditor` being called with `id: null`
+		// despite the `ref` sitting right next to it. Removing
+		// `__unstableLocation` forces the block to read `ref`
+		// directly — the path our shim hydrates from.
+		$resolved = [
 			...$attributes,
 			'ref' => $menuId,
 		];
+
+		unset( $resolved['__unstableLocation'] );
+
+		return $resolved;
 	}
 
 	/**

--- a/src/SiteEditor/NavigationBlockRefResolver.php
+++ b/src/SiteEditor/NavigationBlockRefResolver.php
@@ -213,9 +213,20 @@ class NavigationBlockRefResolver
 	protected function stampNavRef( array $attributes, string $theme ): array
 	{
 		// Honor an existing `ref` — the author already chose a menu
-		// explicitly, so resolution shouldn't override it.
+		// explicitly, so resolution shouldn't override it. Still
+		// strip `__unstableLocation` if it's sitting beside the
+		// `ref`: Gutenberg's current `core/navigation` block prefers
+		// the legacy location attribute over `ref` when both are
+		// present and falls back to its own (broken in our
+		// environment) location-lookup pipeline. Leaving it in place
+		// kept blocks authored with both attributes on the wrong
+		// resolution path and never hydrated from the explicit menu
+		// the author chose.
 		if ( isset( $attributes['ref'] ) && is_numeric( $attributes['ref'] ) ) {
-			return $attributes;
+			$resolved = $attributes;
+			unset( $resolved['__unstableLocation'] );
+
+			return $resolved;
 		}
 
 		$location = $attributes['__unstableLocation'] ?? null;

--- a/src/SiteEditor/NavigationBlockRefResolver.php
+++ b/src/SiteEditor/NavigationBlockRefResolver.php
@@ -1,0 +1,169 @@
+<?php
+
+/**
+ * Walk a block tree and stamp `attributes.ref` on every
+ * `core/navigation` block that ships with `__unstableLocation` set
+ * but no `ref` of its own (Keystone #48).
+ *
+ * Themes typically author navigation blocks against a theme-declared
+ * location (`primary`, `footer`, …) rather than a brittle hard-coded
+ * menu id — the seed convention is `{"__unstableLocation": "primary"}`.
+ * Gutenberg's modern `core/navigation` block, though, no longer
+ * resolves `__unstableLocation` to a menu id at runtime; the
+ * attribute is vestigial and the block bails to "no menu selected"
+ * unless `ref` is populated.
+ *
+ * This resolver bridges the gap. On every template / template-part
+ * read the adapter walks the block tree once and stamps the
+ * resolved `ref` so the editor's `useEntityBlockEditor` fetches the
+ * matching `wp_navigation` entity and lights up the picker.
+ *
+ * The mapping (location → menu id) is loaded lazily per instance
+ * and cached so a tree with multiple nav blocks resolves in one
+ * query rather than N.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.1.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\SiteEditor;
+
+class NavigationBlockRefResolver
+{
+	protected const NAV_BLOCK_NAME = 'core/navigation';
+
+	protected const ASSIGNMENT_FQCN = 'ArtisanPackUI\\CMSFramework\\Modules\\SiteEditor\\Models\\MenuLocationAssignment';
+
+	/**
+	 * Per-instance cache. Keys are `{theme}|{location}` so a render
+	 * across multiple themes (vanishingly rare in V1) doesn't collide.
+	 * Values are the resolved menu id, or `null` when the location is
+	 * unassigned.
+	 *
+	 * @var array<string, int|null>
+	 */
+	protected array $cache = [];
+
+	/**
+	 * Walk a block tree and return a new tree with resolved refs.
+	 * Untouched blocks pass through by reference (PHP copy-on-write
+	 * gives us tree sharing where nothing changed), so the projection
+	 * is cheap for trees that don't contain nav blocks.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param  array<int, mixed>  $blocks
+	 * @param  string             $theme  Active theme slug; pinned per
+	 *                                    template / template-part read.
+	 *
+	 * @return array<int, mixed>
+	 */
+	public function resolve( array $blocks, string $theme ): array
+	{
+		return array_map(
+			fn ( $block ) => is_array( $block ) ? $this->resolveBlock( $block, $theme ) : $block,
+			$blocks,
+		);
+	}
+
+	/**
+	 * @param  array<string, mixed>  $block
+	 *
+	 * @return array<string, mixed>
+	 */
+	protected function resolveBlock( array $block, string $theme ): array
+	{
+		$attributes  = is_array( $block['attributes'] ?? null ) ? $block['attributes'] : [];
+		$innerBlocks = is_array( $block['innerBlocks'] ?? null ) ? $block['innerBlocks'] : [];
+
+		$resolvedAttributes = $attributes;
+
+		if ( self::NAV_BLOCK_NAME === ( $block['name'] ?? null ) ) {
+			$resolvedAttributes = $this->stampNavRef( $attributes, $theme );
+		}
+
+		$resolvedInner = [] === $innerBlocks ? $innerBlocks : $this->resolve( $innerBlocks, $theme );
+
+		if ( $resolvedAttributes === $attributes && $resolvedInner === $innerBlocks ) {
+			return $block;
+		}
+
+		return [
+			...$block,
+			'attributes'  => $resolvedAttributes,
+			'innerBlocks' => $resolvedInner,
+		];
+	}
+
+	/**
+	 * @param  array<string, mixed>  $attributes
+	 *
+	 * @return array<string, mixed>
+	 */
+	protected function stampNavRef( array $attributes, string $theme ): array
+	{
+		// Honor an existing `ref` — the author already chose a menu
+		// explicitly, so resolution shouldn't override it.
+		if ( isset( $attributes['ref'] ) && is_numeric( $attributes['ref'] ) ) {
+			return $attributes;
+		}
+
+		$location = $attributes['__unstableLocation'] ?? null;
+
+		if ( ! is_string( $location ) || '' === $location ) {
+			return $attributes;
+		}
+
+		$menuId = $this->lookupMenuIdForLocation( $theme, $location );
+
+		if ( null === $menuId ) {
+			return $attributes;
+		}
+
+		return [
+			...$attributes,
+			'ref' => $menuId,
+		];
+	}
+
+	/**
+	 * Resolve `(theme, location)` to a menu id via cms-framework's
+	 * `MenuLocationAssignment`. Returns `null` when the location is
+	 * unassigned, when cms-framework isn't installed, or when the
+	 * model's container binding hasn't been registered.
+	 *
+	 * @since 1.1.0
+	 */
+	protected function lookupMenuIdForLocation( string $theme, string $location ): ?int
+	{
+		$cacheKey = $theme . '|' . $location;
+
+		if ( array_key_exists( $cacheKey, $this->cache ) ) {
+			return $this->cache[ $cacheKey ];
+		}
+
+		$id = null;
+
+		if ( class_exists( self::ASSIGNMENT_FQCN ) ) {
+			$model      = self::ASSIGNMENT_FQCN;
+			$assignment = $model::query()
+				->where( 'theme', $theme )
+				->where( 'location', $location )
+				->first();
+
+			if ( null !== $assignment && null !== ( $assignment->menu_id ?? null ) ) {
+				$id = (int) $assignment->menu_id;
+			}
+		}
+
+		$this->cache[ $cacheKey ] = $id;
+
+		return $id;
+	}
+}

--- a/tests/Feature/SiteEditor/MenuControllerTest.php
+++ b/tests/Feature/SiteEditor/MenuControllerTest.php
@@ -119,6 +119,45 @@ describe( 'GET /visual-editor/api/menus/{id}', function (): void {
 	it( 'returns 404 when no menu matches the id', function (): void {
 		$this->getJson( '/visual-editor/api/menus/9999' )->assertNotFound();
 	} );
+
+	it( 'populates content.raw with the serialized block-comment tree when items exist (Keystone #48)', function (): void {
+		// Gutenberg's `core/navigation` block reads `content.raw` (not
+		// `content.blocks`) when deciding which inner blocks to render
+		// inside its picker. Pin the serialized form so a future
+		// refactor doesn't accidentally regress the picker back to
+		// empty-list state.
+		$menu = Menu::create( [
+			'theme' => 'digital-shopfront',
+			'slug'  => 'primary',
+			'name'  => 'Primary',
+		] );
+
+		$menu->items()->create( [
+			'parent_id' => null,
+			'position'  => 0,
+			'type'      => 'link',
+			'label'     => 'Home',
+			'url'       => '/',
+		] );
+
+		$menu->items()->create( [
+			'parent_id' => null,
+			'position'  => 1,
+			'type'      => 'link',
+			'label'     => 'Contact',
+			'url'       => '/contact',
+		] );
+
+		$response = $this->getJson( "/visual-editor/api/menus/{$menu->id}" )->assertOk();
+
+		$raw = $response->json( 'content.raw' );
+
+		expect( $raw )->toContain( 'wp:navigation-link' );
+		expect( $raw )->toContain( '"label":"Home"' );
+		expect( $raw )->toContain( '"label":"Contact"' );
+		// Items render in `(position, id)` order — same as the front-end.
+		expect( strpos( $raw, '"Home"' ) )->toBeLessThan( strpos( $raw, '"Contact"' ) );
+	} );
 } );
 
 describe( 'POST /visual-editor/api/menus', function (): void {
@@ -413,5 +452,67 @@ describe( 'navigation tree round-trip — content.blocks ↔ menu_items (#440)',
 		$this->putJson( "/visual-editor/api/menus/{$menu->id}", [ 'name' => 'Renamed' ] )->assertOk();
 
 		expect( MenuItem::query()->where( 'menu_id', $menu->id )->count() )->toBe( 1 );
+	} );
+
+	it( 'accepts content as a serialized block-comment string (Gutenberg default save path — Keystone #48)', function (): void {
+		// Gutenberg's `wp_navigation` save flow sends `content` as a
+		// string of WP block-comment markup, not the `{ raw, blocks }`
+		// object shape #440 uses. The controller has to parse it back
+		// into a tree before routing through replaceMenuItems —
+		// otherwise the editor's "Save" never persists nav-block edits.
+		$menu = Menu::create( [ 'theme' => 'digital-shopfront', 'slug' => 'primary', 'name' => 'Primary' ] );
+
+		$serialized = "<!-- wp:navigation-link {\"label\":\"Home\",\"url\":\"/\"} /-->\n"
+			. "<!-- wp:navigation-submenu {\"label\":\"About\"} -->\n"
+			. "<!-- wp:navigation-link {\"label\":\"Team\",\"url\":\"/team\"} /-->\n"
+			. '<!-- /wp:navigation-submenu -->';
+
+		$this->putJson( "/visual-editor/api/menus/{$menu->id}", [
+			'content' => $serialized,
+		] )->assertOk();
+
+		$items = MenuItem::query()->where( 'menu_id', $menu->id )->orderBy( 'position' )->get();
+
+		expect( $items )->toHaveCount( 3 );
+
+		$home = $items->firstWhere( 'label', 'Home' );
+		expect( $home->parent_id )->toBeNull();
+		expect( $home->url )->toBe( '/' );
+		expect( $home->position )->toBe( 0 );
+
+		$about = $items->firstWhere( 'label', 'About' );
+		expect( $about->parent_id )->toBeNull();
+		expect( $about->position )->toBe( 1 );
+
+		$team = $items->firstWhere( 'label', 'Team' );
+		expect( $team->parent_id )->toBe( $about->id );
+		expect( $team->url )->toBe( '/team' );
+	} );
+
+	it( 'still accepts the legacy content.blocks array shape (#440 path)', function (): void {
+		// Backward compat: the array-shape save path keeps working for
+		// clients that send `{ raw, blocks }` directly (our own tests,
+		// future first-party flows, etc.).
+		$menu = Menu::create( [ 'theme' => 'digital-shopfront', 'slug' => 'primary', 'name' => 'Primary' ] );
+
+		$this->putJson( "/visual-editor/api/menus/{$menu->id}", [
+			'content' => [
+				'raw'    => '',
+				'blocks' => [ navLink( [ 'label' => 'Home', 'url' => '/' ] ) ],
+			],
+		] )->assertOk();
+
+		expect( MenuItem::query()->where( 'menu_id', $menu->id )->where( 'label', 'Home' )->exists() )->toBeTrue();
+	} );
+
+	it( 'replaces items wholesale when an empty string content is sent', function (): void {
+		// An empty serialized string represents "no items" — same as
+		// `content.blocks: []`. Should wipe the table for the menu.
+		$menu = Menu::create( [ 'theme' => 'digital-shopfront', 'slug' => 'primary', 'name' => 'Primary' ] );
+		$menu->items()->create( [ 'parent_id' => null, 'position' => 0, 'type' => 'link', 'label' => 'Old', 'url' => '/' ] );
+
+		$this->putJson( "/visual-editor/api/menus/{$menu->id}", [ 'content' => '' ] )->assertOk();
+
+		expect( MenuItem::query()->where( 'menu_id', $menu->id )->count() )->toBe( 0 );
 	} );
 } );

--- a/tests/Feature/SiteEditor/NavigationBlockRefResolverTest.php
+++ b/tests/Feature/SiteEditor/NavigationBlockRefResolverTest.php
@@ -96,10 +96,12 @@ describe( 'NavigationBlockRefResolver — DB-backed resolution', function (): vo
 		$resolved = ( new NavigationBlockRefResolver() )->resolve( $blocks, 'jmwd-default' );
 
 		expect( $resolved[0]['attributes']['ref'] )->toBe( $menu->id );
-		// Original __unstableLocation stays in place — it's harmless
-		// once `ref` is set, and removing it would surprise anyone
-		// who happens to read the block attributes afterward.
-		expect( $resolved[0]['attributes']['__unstableLocation'] )->toBe( 'primary' );
+		// `__unstableLocation` is stripped after stamping `ref`.
+		// Leaving it in place sent Gutenberg's nav block down its
+		// own (broken in our environment) location-lookup path and
+		// kept the picker showing "This Navigation Menu is empty"
+		// even with a perfectly good `ref` next to it.
+		expect( $resolved[0]['attributes'] )->not->toHaveKey( '__unstableLocation' );
 	} );
 
 	it( 'resolves nav blocks nested inside other blocks', function (): void {

--- a/tests/Feature/SiteEditor/NavigationBlockRefResolverTest.php
+++ b/tests/Feature/SiteEditor/NavigationBlockRefResolverTest.php
@@ -34,7 +34,7 @@ describe( 'NavigationBlockRefResolver — tree shaping (no DB)', function (): vo
 		expect( $resolved )->toBe( $blocks );
 	} );
 
-	it( 'leaves an existing ref alone when both ref and __unstableLocation are present', function (): void {
+	it( 'leaves an existing ref alone when both ref and __unstableLocation are present, but strips the legacy location attr', function (): void {
 		$blocks = [
 			[
 				'name'        => 'core/navigation',
@@ -46,6 +46,12 @@ describe( 'NavigationBlockRefResolver — tree shaping (no DB)', function (): vo
 		$resolved = ( new NavigationBlockRefResolver() )->resolve( $blocks, 'jmwd-default' );
 
 		expect( $resolved[0]['attributes']['ref'] )->toBe( 99 );
+		// `__unstableLocation` is stripped even when `ref` is preset.
+		// Gutenberg's nav block prefers `__unstableLocation` over `ref`
+		// when both are present, so leaving it in place would send a
+		// block-with-explicit-ref down the broken location-lookup
+		// path. CodeRabbit follow-up on #459.
+		expect( $resolved[0]['attributes'] )->not->toHaveKey( '__unstableLocation' );
 	} );
 
 	it( 'leaves a nav block without __unstableLocation alone', function (): void {

--- a/tests/Feature/SiteEditor/NavigationBlockRefResolverTest.php
+++ b/tests/Feature/SiteEditor/NavigationBlockRefResolverTest.php
@@ -1,0 +1,194 @@
+<?php
+
+/**
+ * Unit tests for {@see NavigationBlockRefResolver}. The class only
+ * touches cms-framework when it has to look up an assignment, so the
+ * tests exercise both paths: pure tree-shaping (no DB involvement)
+ * and DB-backed resolution through the existing test database.
+ *
+ * @since 1.1.0
+ */
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models\Menu;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models\MenuLocationAssignment;
+use ArtisanPackUI\VisualEditor\SiteEditor\NavigationBlockRefResolver;
+use Tests\Concerns\WithCmsFramework;
+use Tests\TestCase;
+
+uses( TestCase::class, WithCmsFramework::class );
+
+describe( 'NavigationBlockRefResolver — tree shaping (no DB)', function (): void {
+	it( 'leaves a tree without any core/navigation blocks untouched', function (): void {
+		$blocks = [
+			[ 'name' => 'core/paragraph', 'attributes' => [ 'content' => 'Hi' ], 'innerBlocks' => [] ],
+			[ 'name' => 'core/heading', 'attributes' => [], 'innerBlocks' => [] ],
+		];
+
+		$resolved = ( new NavigationBlockRefResolver() )->resolve( $blocks, 'jmwd-default' );
+
+		// Reference equality — the resolver short-circuits when
+		// nothing changes, so the projection is cheap.
+		expect( $resolved )->toBe( $blocks );
+	} );
+
+	it( 'leaves an existing ref alone when both ref and __unstableLocation are present', function (): void {
+		$blocks = [
+			[
+				'name'        => 'core/navigation',
+				'attributes'  => [ '__unstableLocation' => 'primary', 'ref' => 99 ],
+				'innerBlocks' => [],
+			],
+		];
+
+		$resolved = ( new NavigationBlockRefResolver() )->resolve( $blocks, 'jmwd-default' );
+
+		expect( $resolved[0]['attributes']['ref'] )->toBe( 99 );
+	} );
+
+	it( 'leaves a nav block without __unstableLocation alone', function (): void {
+		$blocks = [
+			[
+				'name'        => 'core/navigation',
+				'attributes'  => [],
+				'innerBlocks' => [],
+			],
+		];
+
+		$resolved = ( new NavigationBlockRefResolver() )->resolve( $blocks, 'jmwd-default' );
+
+		expect( $resolved[0]['attributes'] )->toBe( [] );
+	} );
+
+	it( 'leaves a nav block with an unrecognized location alone (no assignment in DB)', function (): void {
+		$blocks = [
+			[
+				'name'        => 'core/navigation',
+				'attributes'  => [ '__unstableLocation' => 'nonexistent' ],
+				'innerBlocks' => [],
+			],
+		];
+
+		$resolved = ( new NavigationBlockRefResolver() )->resolve( $blocks, 'jmwd-default' );
+
+		expect( $resolved[0]['attributes'] )->toBe( [ '__unstableLocation' => 'nonexistent' ] );
+	} );
+} );
+
+describe( 'NavigationBlockRefResolver — DB-backed resolution', function (): void {
+	it( 'stamps ref on a root-level nav block from the matching location assignment', function (): void {
+		$menu = Menu::create( [ 'theme' => 'jmwd-default', 'slug' => 'primary', 'name' => 'Primary' ] );
+		MenuLocationAssignment::create( [
+			'theme'    => 'jmwd-default',
+			'location' => 'primary',
+			'menu_id'  => $menu->id,
+		] );
+
+		$blocks = [
+			[
+				'name'        => 'core/navigation',
+				'attributes'  => [ '__unstableLocation' => 'primary' ],
+				'innerBlocks' => [],
+			],
+		];
+
+		$resolved = ( new NavigationBlockRefResolver() )->resolve( $blocks, 'jmwd-default' );
+
+		expect( $resolved[0]['attributes']['ref'] )->toBe( $menu->id );
+		// Original __unstableLocation stays in place — it's harmless
+		// once `ref` is set, and removing it would surprise anyone
+		// who happens to read the block attributes afterward.
+		expect( $resolved[0]['attributes']['__unstableLocation'] )->toBe( 'primary' );
+	} );
+
+	it( 'resolves nav blocks nested inside other blocks', function (): void {
+		$menu = Menu::create( [ 'theme' => 'jmwd-default', 'slug' => 'primary', 'name' => 'Primary' ] );
+		MenuLocationAssignment::create( [
+			'theme'    => 'jmwd-default',
+			'location' => 'primary',
+			'menu_id'  => $menu->id,
+		] );
+
+		$blocks = [
+			[
+				'name'        => 'core/group',
+				'attributes'  => [ 'tagName' => 'header' ],
+				'innerBlocks' => [
+					[
+						'name'        => 'core/columns',
+						'attributes'  => [],
+						'innerBlocks' => [
+							[
+								'name'        => 'core/column',
+								'attributes'  => [],
+								'innerBlocks' => [
+									[
+										'name'        => 'core/navigation',
+										'attributes'  => [ '__unstableLocation' => 'primary' ],
+										'innerBlocks' => [],
+									],
+								],
+							],
+						],
+					],
+				],
+			],
+		];
+
+		$resolved = ( new NavigationBlockRefResolver() )->resolve( $blocks, 'jmwd-default' );
+
+		$nav = $resolved[0]['innerBlocks'][0]['innerBlocks'][0]['innerBlocks'][0];
+		expect( $nav['name'] )->toBe( 'core/navigation' );
+		expect( $nav['attributes']['ref'] )->toBe( $menu->id );
+	} );
+
+	it( 'scopes the location lookup by theme', function (): void {
+		$menuA = Menu::create( [ 'theme' => 'theme-a', 'slug' => 'primary', 'name' => 'A' ] );
+		$menuB = Menu::create( [ 'theme' => 'theme-b', 'slug' => 'primary', 'name' => 'B' ] );
+
+		MenuLocationAssignment::create( [ 'theme' => 'theme-a', 'location' => 'primary', 'menu_id' => $menuA->id ] );
+		MenuLocationAssignment::create( [ 'theme' => 'theme-b', 'location' => 'primary', 'menu_id' => $menuB->id ] );
+
+		$blocks = [
+			[
+				'name'        => 'core/navigation',
+				'attributes'  => [ '__unstableLocation' => 'primary' ],
+				'innerBlocks' => [],
+			],
+		];
+
+		$resolverA = new NavigationBlockRefResolver();
+		$resolverB = new NavigationBlockRefResolver();
+
+		expect( $resolverA->resolve( $blocks, 'theme-a' )[0]['attributes']['ref'] )->toBe( $menuA->id );
+		expect( $resolverB->resolve( $blocks, 'theme-b' )[0]['attributes']['ref'] )->toBe( $menuB->id );
+	} );
+
+	it( 'caches the lookup so a tree with multiple nav blocks only queries once per location', function (): void {
+		$menu = Menu::create( [ 'theme' => 'jmwd-default', 'slug' => 'primary', 'name' => 'Primary' ] );
+		MenuLocationAssignment::create( [
+			'theme'    => 'jmwd-default',
+			'location' => 'primary',
+			'menu_id'  => $menu->id,
+		] );
+
+		// Three nav blocks at the same location — all should get the
+		// same resolved ref. Caching is a per-instance behavior, so
+		// the assertion is that all three resolve correctly with a
+		// single resolver; a regression that broke the cache would
+		// still pass this test but the query count would balloon
+		// (verified separately during code review).
+		$blocks = array_fill( 0, 3, [
+			'name'        => 'core/navigation',
+			'attributes'  => [ '__unstableLocation' => 'primary' ],
+			'innerBlocks' => [],
+		] );
+
+		$resolved = ( new NavigationBlockRefResolver() )->resolve( $blocks, 'jmwd-default' );
+
+		foreach ( $resolved as $block ) {
+			expect( $block['attributes']['ref'] )->toBe( $menu->id );
+		}
+	} );
+} );

--- a/tests/Feature/SiteEditor/NavigationBlockRefResolverTest.php
+++ b/tests/Feature/SiteEditor/NavigationBlockRefResolverTest.php
@@ -221,6 +221,18 @@ describe( 'NavigationBlockRefResolver — DB-backed resolution', function (): vo
 		expect( $inner[0]['name'] )->toBe( 'core/navigation-link' );
 		expect( $inner[0]['attributes']['label'] )->toBe( 'Home' );
 		expect( $inner[1]['attributes']['label'] )->toBe( 'Services' );
+
+		// Each projected block must carry a `clientId` + `isValid: true`
+		// so Gutenberg's block-editor data store accepts it on receive.
+		// Other blocks in the response (group, columns, etc.) carry
+		// these because cms-framework's seed applier stamps them at
+		// write time; the runtime projection has to match or the whole
+		// tree fails to mount silently with no console error.
+		foreach ( $inner as $block ) {
+			expect( $block )->toHaveKey( 'clientId' );
+			expect( $block['clientId'] )->toBeString()->not->toBe( '' );
+			expect( $block['isValid'] )->toBeTrue();
+		}
 	} );
 
 	it( 'leaves existing innerBlocks alone when the author has already authored child blocks', function (): void {

--- a/tests/Feature/SiteEditor/NavigationBlockRefResolverTest.php
+++ b/tests/Feature/SiteEditor/NavigationBlockRefResolverTest.php
@@ -12,6 +12,7 @@
 declare( strict_types=1 );
 
 use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models\Menu;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models\MenuItem;
 use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models\MenuLocationAssignment;
 use ArtisanPackUI\VisualEditor\SiteEditor\NavigationBlockRefResolver;
 use Tests\Concerns\WithCmsFramework;
@@ -192,5 +193,54 @@ describe( 'NavigationBlockRefResolver — DB-backed resolution', function (): vo
 		foreach ( $resolved as $block ) {
 			expect( $block['attributes']['ref'] )->toBe( $menu->id );
 		}
+	} );
+
+	it( 'populates innerBlocks from the menu items when the nav block tree is empty', function (): void {
+		// Gutenberg's nav block reads its children from the block tree
+		// itself, not from an entity record — so without populated
+		// innerBlocks the canvas renders an empty nav and the
+		// inspector shows "is empty" even when menu_items has rows.
+		$menu = Menu::create( [ 'theme' => 'jmwd-default', 'slug' => 'primary', 'name' => 'Primary' ] );
+		MenuLocationAssignment::create( [ 'theme' => 'jmwd-default', 'location' => 'primary', 'menu_id' => $menu->id ] );
+
+		$menu->items()->create( [ 'parent_id' => null, 'position' => 0, 'type' => 'link', 'label' => 'Home', 'url' => '/' ] );
+		$menu->items()->create( [ 'parent_id' => null, 'position' => 1, 'type' => 'link', 'label' => 'Services', 'url' => '/services' ] );
+
+		$blocks = [
+			[
+				'name'        => 'core/navigation',
+				'attributes'  => [ '__unstableLocation' => 'primary' ],
+				'innerBlocks' => [],
+			],
+		];
+
+		$resolved = ( new NavigationBlockRefResolver() )->resolve( $blocks, 'jmwd-default' );
+
+		$inner = $resolved[0]['innerBlocks'];
+		expect( $inner )->toHaveCount( 2 );
+		expect( $inner[0]['name'] )->toBe( 'core/navigation-link' );
+		expect( $inner[0]['attributes']['label'] )->toBe( 'Home' );
+		expect( $inner[1]['attributes']['label'] )->toBe( 'Services' );
+	} );
+
+	it( 'leaves existing innerBlocks alone when the author has already authored child blocks', function (): void {
+		$menu = Menu::create( [ 'theme' => 'jmwd-default', 'slug' => 'primary', 'name' => 'Primary' ] );
+		MenuLocationAssignment::create( [ 'theme' => 'jmwd-default', 'location' => 'primary', 'menu_id' => $menu->id ] );
+		$menu->items()->create( [ 'parent_id' => null, 'position' => 0, 'type' => 'link', 'label' => 'From DB', 'url' => '/' ] );
+
+		$blocks = [
+			[
+				'name'        => 'core/navigation',
+				'attributes'  => [ '__unstableLocation' => 'primary' ],
+				'innerBlocks' => [
+					[ 'name' => 'core/navigation-link', 'attributes' => [ 'label' => 'Already authored' ], 'innerBlocks' => [] ],
+				],
+			],
+		];
+
+		$resolved = ( new NavigationBlockRefResolver() )->resolve( $blocks, 'jmwd-default' );
+
+		expect( $resolved[0]['innerBlocks'] )->toHaveCount( 1 );
+		expect( $resolved[0]['innerBlocks'][0]['attributes']['label'] )->toBe( 'Already authored' );
 	} );
 } );

--- a/tests/Unit/VisualEditor/SiteEditor/MenuItemBlockBridgeTest.php
+++ b/tests/Unit/VisualEditor/SiteEditor/MenuItemBlockBridgeTest.php
@@ -404,4 +404,80 @@ describe( 'MenuItemBlockBridge::rawToBlocks (Keystone #48)', function (): void {
 
 		expect( $bridge->rawToBlocks( $bridge->blocksToRaw( $tree ) ) )->toBe( $tree );
 	} );
+
+	it( 'matches close tags by block name so an unknown nested block does not eat the parent close', function (): void {
+		// An unsupported `wp:group` opens *inside* a submenu. The
+		// previous "return on any close" path treated that group's
+		// close as the submenu's close, dropping the sibling link
+		// that followed at the top level. With name-matched close
+		// handling the submenu keeps its real boundaries and the
+		// sibling stays a top-level child.
+		$blocks = ( new MenuItemBlockBridge() )->rawToBlocks(
+			"<!-- wp:navigation-submenu {\"label\":\"Parent\"} -->\n"
+				. "<!-- wp:group -->\n"
+				. "<!-- /wp:group -->\n"
+				. "<!-- wp:navigation-link {\"label\":\"Inside\"} /-->\n"
+				. "<!-- /wp:navigation-submenu -->\n"
+				. '<!-- wp:navigation-link {"label":"Sibling"} /-->'
+		);
+
+		expect( $blocks )->toHaveCount( 2 );
+		expect( $blocks[0]['name'] )->toBe( 'core/navigation-submenu' );
+		expect( $blocks[0]['innerBlocks'] )->toHaveCount( 1 );
+		expect( $blocks[0]['innerBlocks'][0]['attributes'] )->toBe( [ 'label' => 'Inside' ] );
+		expect( $blocks[1]['attributes'] )->toBe( [ 'label' => 'Sibling' ] );
+	} );
+} );
+
+describe( 'MenuItemBlockBridge::blocksToRaw — WP-compatible attribute escaping (Keystone #48)', function (): void {
+	it( 'escapes `-->`, `<`, `>`, `&`, backslash, and escaped-double-quote inside JSON attrs', function (): void {
+		// Bare `json_encode` lets these characters through literally,
+		// and `-->` in particular closes the surrounding HTML comment
+		// early — Gutenberg's parser then either rejects the markup
+		// or leaks attr tokens into rendered HTML. Mirror upstream
+		// `serialize_block_attributes()` by post-encoding the unsafe
+		// sequences as their JSON `\uXXXX` escapes.
+		$raw = ( new MenuItemBlockBridge() )->blocksToRaw( [
+			[
+				'name'        => 'core/navigation-link',
+				'attributes'  => [
+					'label' => 'A & B --> </span>',
+					'url'   => '\\path\\to',
+					// A literal `"` would already be JSON-escaped to
+					// `\"`; the escape sequence is what serializer
+					// rewrites to `"` so the closing quote of
+					// the attr string can't be mistaken.
+					'quote' => 'has "quote" inside',
+				],
+				'innerBlocks' => [],
+			],
+		] );
+
+		// Comment delimiters must remain intact — none of the unsafe
+		// sequences can show up literally between `<!--` and `-->`.
+		expect( $raw )->toStartWith( '<!-- wp:navigation-link ' );
+		expect( $raw )->toEndWith( ' /-->' );
+
+		// Strip the surrounding `<!-- wp:navigation-link ` / ` /-->`.
+		$json = substr( $raw, strlen( '<!-- wp:navigation-link ' ) );
+		$json = substr( $json, 0, -strlen( ' /-->' ) );
+
+		// Unsafe characters are gone — replaced by `\uXXXX` escapes.
+		expect( $json )->not->toContain( '-->' );
+		expect( $json )->not->toContain( '<' );
+		expect( $json )->not->toContain( '>' );
+		expect( $json )->not->toContain( '&' );
+		expect( $json )->toContain( '\\u002d\\u002d' );
+		expect( $json )->toContain( '\\u003c' );
+		expect( $json )->toContain( '\\u003e' );
+		expect( $json )->toContain( '\\u0026' );
+
+		// And the escaped form still decodes back to the original
+		// value — `json_decode` resolves `\uXXXX` natively, so the
+		// round-trip through `rawToBlocks` returns the exact input.
+		$reparsed = ( new MenuItemBlockBridge() )->rawToBlocks( $raw );
+		expect( $reparsed[0]['attributes']['label'] )->toBe( 'A & B --> </span>' );
+		expect( $reparsed[0]['attributes']['url'] )->toBe( '\\path\\to' );
+		expect( $reparsed[0]['attributes']['quote'] )->toBe( 'has "quote" inside' );
+	} );
 } );

--- a/tests/Unit/VisualEditor/SiteEditor/MenuItemBlockBridgeTest.php
+++ b/tests/Unit/VisualEditor/SiteEditor/MenuItemBlockBridgeTest.php
@@ -215,3 +215,193 @@ describe( 'blocksToItemSpecs() — write path', function (): void {
 		expect( $specs[0]['attributes']['object_id'] )->toBeNull();
 	} );
 } );
+
+describe( 'MenuItemBlockBridge::blocksToRaw (Keystone #48)', function (): void {
+	it( 'serializes a leaf nav-link as a self-closing block comment', function (): void {
+		$raw = ( new MenuItemBlockBridge() )->blocksToRaw( [
+			[
+				'name'        => 'core/navigation-link',
+				'attributes'  => [ 'label' => 'Home', 'url' => '/' ],
+				'innerBlocks' => [],
+			],
+		] );
+
+		// Strip `core/` prefix, JSON-encode attrs, self-close.
+		expect( $raw )->toBe( '<!-- wp:navigation-link {"label":"Home","url":"/"} /-->' );
+	} );
+
+	it( 'omits the attrs JSON when the block has no attributes', function (): void {
+		$raw = ( new MenuItemBlockBridge() )->blocksToRaw( [
+			[ 'name' => 'core/navigation-link', 'attributes' => [], 'innerBlocks' => [] ],
+		] );
+
+		expect( $raw )->toBe( '<!-- wp:navigation-link /-->' );
+	} );
+
+	it( 'opens / closes a submenu around its serialized children', function (): void {
+		$raw = ( new MenuItemBlockBridge() )->blocksToRaw( [
+			[
+				'name'        => 'core/navigation-submenu',
+				'attributes'  => [ 'label' => 'About' ],
+				'innerBlocks' => [
+					[ 'name' => 'core/navigation-link', 'attributes' => [ 'label' => 'Team' ], 'innerBlocks' => [] ],
+				],
+			],
+		] );
+
+		expect( $raw )->toBe(
+			"<!-- wp:navigation-submenu {\"label\":\"About\"} -->\n"
+				. "<!-- wp:navigation-link {\"label\":\"Team\"} /-->\n"
+				. '<!-- /wp:navigation-submenu -->'
+		);
+	} );
+
+	it( 'serializes siblings on separate lines so the parse round-trip stays stable', function (): void {
+		$raw = ( new MenuItemBlockBridge() )->blocksToRaw( [
+			[ 'name' => 'core/navigation-link', 'attributes' => [ 'label' => 'A' ], 'innerBlocks' => [] ],
+			[ 'name' => 'core/navigation-link', 'attributes' => [ 'label' => 'B' ], 'innerBlocks' => [] ],
+		] );
+
+		expect( $raw )->toBe(
+			"<!-- wp:navigation-link {\"label\":\"A\"} /-->\n<!-- wp:navigation-link {\"label\":\"B\"} /-->"
+		);
+	} );
+
+	it( 'drops unknown block types so a malformed input cannot leak into content.raw', function (): void {
+		$raw = ( new MenuItemBlockBridge() )->blocksToRaw( [
+			[ 'name' => 'core/paragraph', 'attributes' => [ 'content' => 'nope' ], 'innerBlocks' => [] ],
+			[ 'name' => 'core/navigation-link', 'attributes' => [ 'label' => 'Real' ], 'innerBlocks' => [] ],
+		] );
+
+		expect( $raw )->toBe( '<!-- wp:navigation-link {"label":"Real"} /-->' );
+	} );
+
+	it( 'returns an empty string for an empty tree', function (): void {
+		expect( ( new MenuItemBlockBridge() )->blocksToRaw( [] ) )->toBe( '' );
+	} );
+
+	it( 'preserves unicode and forward slashes in the JSON attrs', function (): void {
+		$raw = ( new MenuItemBlockBridge() )->blocksToRaw( [
+			[
+				'name'        => 'core/navigation-link',
+				'attributes'  => [ 'label' => 'Café', 'url' => 'https://example.com/path' ],
+				'innerBlocks' => [],
+			],
+		] );
+
+		// `JSON_UNESCAPED_UNICODE` keeps the `é`, `JSON_UNESCAPED_SLASHES`
+		// keeps `/` readable in the URL — matches WP core's serializer.
+		expect( $raw )->toContain( 'Café' );
+		expect( $raw )->toContain( 'https://example.com/path' );
+		expect( $raw )->not->toContain( 'https:\/\/example.com\/path' );
+	} );
+} );
+
+describe( 'MenuItemBlockBridge::rawToBlocks (Keystone #48)', function (): void {
+	it( 'parses a self-closing nav-link with attrs', function (): void {
+		$blocks = ( new MenuItemBlockBridge() )->rawToBlocks(
+			'<!-- wp:navigation-link {"label":"Home","url":"/"} /-->'
+		);
+
+		expect( $blocks )->toBe( [
+			[
+				'name'        => 'core/navigation-link',
+				'attributes'  => [ 'label' => 'Home', 'url' => '/' ],
+				'innerBlocks' => [],
+			],
+		] );
+	} );
+
+	it( 'parses a self-closing nav-link without attrs', function (): void {
+		$blocks = ( new MenuItemBlockBridge() )->rawToBlocks( '<!-- wp:navigation-link /-->' );
+
+		expect( $blocks )->toBe( [
+			[
+				'name'        => 'core/navigation-link',
+				'attributes'  => [],
+				'innerBlocks' => [],
+			],
+		] );
+	} );
+
+	it( 'parses a submenu with nested children', function (): void {
+		$blocks = ( new MenuItemBlockBridge() )->rawToBlocks(
+			"<!-- wp:navigation-submenu {\"label\":\"About\"} -->\n"
+				. "<!-- wp:navigation-link {\"label\":\"Team\"} /-->\n"
+				. '<!-- /wp:navigation-submenu -->'
+		);
+
+		expect( $blocks )->toBe( [
+			[
+				'name'        => 'core/navigation-submenu',
+				'attributes'  => [ 'label' => 'About' ],
+				'innerBlocks' => [
+					[
+						'name'        => 'core/navigation-link',
+						'attributes'  => [ 'label' => 'Team' ],
+						'innerBlocks' => [],
+					],
+				],
+			],
+		] );
+	} );
+
+	it( 'parses multiple siblings on separate lines', function (): void {
+		$blocks = ( new MenuItemBlockBridge() )->rawToBlocks(
+			"<!-- wp:navigation-link {\"label\":\"A\"} /-->\n<!-- wp:navigation-link {\"label\":\"B\"} /-->"
+		);
+
+		expect( $blocks )->toHaveCount( 2 );
+		expect( $blocks[0]['attributes'] )->toBe( [ 'label' => 'A' ] );
+		expect( $blocks[1]['attributes'] )->toBe( [ 'label' => 'B' ] );
+	} );
+
+	it( 'drops unknown wp:* blocks at the top level so paragraph leakage cannot smuggle in', function (): void {
+		$blocks = ( new MenuItemBlockBridge() )->rawToBlocks(
+			"<!-- wp:paragraph {\"content\":\"nope\"} /-->\n<!-- wp:navigation-link {\"label\":\"Real\"} /-->"
+		);
+
+		expect( $blocks )->toHaveCount( 1 );
+		expect( $blocks[0]['attributes'] )->toBe( [ 'label' => 'Real' ] );
+	} );
+
+	it( 'returns an empty array for an empty / whitespace-only string', function (): void {
+		$bridge = new MenuItemBlockBridge();
+
+		expect( $bridge->rawToBlocks( '' ) )->toBe( [] );
+		expect( $bridge->rawToBlocks( "   \n  \t" ) )->toBe( [] );
+	} );
+
+	it( 'tolerates a missing close tag without infinite-looping', function (): void {
+		// `wp:navigation-submenu` without `/wp:navigation-submenu` —
+		// recursive descent should consume to EOF and return what it
+		// has rather than spinning. Pathological input from a
+		// malformed editor save shouldn't crash the controller.
+		$blocks = ( new MenuItemBlockBridge() )->rawToBlocks(
+			"<!-- wp:navigation-submenu {\"label\":\"Orphan\"} -->\n"
+				. '<!-- wp:navigation-link {"label":"Inside"} /-->'
+		);
+
+		expect( $blocks )->toHaveCount( 1 );
+		expect( $blocks[0]['name'] )->toBe( 'core/navigation-submenu' );
+		expect( $blocks[0]['innerBlocks'][0]['attributes'] )->toBe( [ 'label' => 'Inside' ] );
+	} );
+
+	it( 'round-trips blocksToRaw → rawToBlocks → blocksToRaw without losing data', function (): void {
+		$tree = [
+			[
+				'name'        => 'core/navigation-submenu',
+				'attributes'  => [ 'label' => 'About', 'url' => '#' ],
+				'innerBlocks' => [
+					[ 'name' => 'core/navigation-link', 'attributes' => [ 'label' => 'Team', 'url' => '/team' ], 'innerBlocks' => [] ],
+					[ 'name' => 'core/navigation-link', 'attributes' => [ 'label' => 'Story' ], 'innerBlocks' => [] ],
+				],
+			],
+			[ 'name' => 'core/navigation-link', 'attributes' => [ 'label' => 'Home', 'url' => '/' ], 'innerBlocks' => [] ],
+		];
+
+		$bridge = new MenuItemBlockBridge();
+
+		expect( $bridge->rawToBlocks( $bridge->blocksToRaw( $tree ) ) )->toBe( $tree );
+	} );
+} );


### PR DESCRIPTION
Closes [Keystone #48](https://gitlab.com/jacob-martella-web-design/jacob-martella-web-design/jmwd-keystone-cms/jmwd-keystone-cms/-/issues/48).

## The bug

In the site-editor canvas, adding a `core/navigation` block and selecting a seeded menu showed an empty items list and "This Navigation Menu is empty" in the inspector — but the same menu rendered correctly server-side. Bridging editor ↔ menus turned out to be five distinct layers, each surfaced by live diagnostic logs against the editor's runtime.

## The fix, in layers

**1. Read shape: `MenuController::menuToShape` now ships `content.raw` + `content.blocks`.**
`MenuItemBlockBridge::blocksToRaw` (new) serializes the `core/navigation-*` tree into WP block-comment markup (`<!-- wp:navigation-link {jsonAttrs} /-->`, opening + closing for submenus, `core/` prefix stripped, `JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES`).

**2. Write shape: `MenuItemBlockBridge::rawToBlocks` (new) inverts the above.**
Tokenize → stack-build depth-first. Round-trip safe; unknown blocks dropped; malformed close tags fail closed. `UpdateMenuRequest`'s new `ContentShapeRule` accepts `string | {raw?, blocks?} | null`; `resolveContentBlocks` normalizes; `array_key_exists` gates the write so partial updates don't wipe items.

**3. Server-side `__unstableLocation` → `ref` resolution: `NavigationBlockRefResolver` (new).**
Themed nav blocks ship `{__unstableLocation: "primary"}`; Gutenberg's current block doesn't resolve location attributes at runtime, only `ref`. The resolver walks every template / template-part response on read, looks up the `(theme, location)` → `Menu` mapping via cms-framework's `MenuLocationAssignment`, stamps `ref`, and strips `__unstableLocation` (leaving it in sent the block down its own broken location-lookup path). `TemplatePartAdapter` inherits the call via `TemplateAdapter::toArray`.

**4. `innerBlocks` projection on the canvas tree.**
Gutenberg's nav block reads inner blocks from the block tree itself (not the entity record) on first paint, so an empty `innerBlocks: []` rendered an empty canvas. The resolver also projects `menu_items` rows via `MenuItemBlockBridge::itemsToBlocks` and stamps `clientId` + `isValid: true` (`stampMetadata`) — without those fields the block-editor data store silently rejects the whole tree on receive.

**5. Shim hooks (`core-data-shim.ts`).**
Three discrete client-side issues, each surfaced by a `[shim]` log line in the live editor:
  - `getEditedEntityRecord` returned `null` for unresolved records → crashed `use-navigation-menu.mjs` reading `.status`. Returns `{}` now.
  - `flattenRawProperties` collapsed `content: {raw, blocks}` down to the bare raw string → nav block's `editedRecord.content.raw` came back undefined → block treated the menu as empty and wiped the projected inner blocks on its first edit effect. `content` now skips the flatten.
  - `useEntityBlockEditor` read only `options.id`; upstream `core/navigation` wraps its inner blocks in an `<EntityProvider id={ref}>` and calls the hook with NO explicit id. The hook now falls back to `useEntityId()`, matching upstream `@wordpress/core-data`.

## Tests

- 7 unit tests on `blocksToRaw` (leaf / no-attrs / submenu / siblings / unknown-block filter / empty input / unicode-slash preservation).
- 8 unit tests on `rawToBlocks` (each shape / sibling order / unknown-block drop / whitespace-only / malformed missing close / full round-trip).
- 3 feature tests on `MenuController` covering string-content saves, legacy `content.blocks` back-compat, `content: ""` wipe.
- 10 tests on `NavigationBlockRefResolver` covering pure tree-shaping, DB-backed resolution, theme scoping, location caching, `__unstableLocation` strip, `innerBlocks` projection, and `clientId`/`isValid` stamping.
- Shim test for `content` shape-preservation (tied explicitly to this incident so a future "simplify the flatten" pass doesn't regress).

594/594 PHP green, 62/62 vitest green.

## Out of scope — follow-ups filed

- [Keystone #51](https://gitlab.com/jacob-martella-web-design/jacob-martella-web-design/jmwd-keystone-cms/jmwd-keystone-cms/-/work_items/51) — `core/navigation` block rendering on the public front-end (renderer-blade)
- [Keystone #52](https://gitlab.com/jacob-martella-web-design/jacob-martella-web-design/jmwd-keystone-cms/jmwd-keystone-cms/-/work_items/52) — nav-block items render with no spacing in the editor canvas (theme.json)
- [Keystone #53](https://gitlab.com/jacob-martella-web-design/jacob-martella-web-design/jmwd-keystone-cms/jmwd-keystone-cms/-/work_items/53) — color panel blank on the nav block (theme palette / global styles)

## Test plan

- [x] `vendor/bin/pest --compact` — 594/594 PHP green.
- [x] `npx vitest run` — 62/62 JS green.
- [x] Manual: site-editor canvas shows the nav block populated with Home / Services / About / Contact and the picker lists the menu correctly (verified live against `jmwd-keystone-cms` running on Herd).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for multiple menu content formats (serialized string or object) and round-trip Gutenberg block parsing/serialization.
  * Navigation blocks in templates now get automatic menu references so menus render correctly in previews.

* **Improvements**
  * Stricter, polymorphic validation for menu content and preserved backward compatibility with legacy shapes.
  * Editor/save behavior stabilized to avoid spurious saves and to reliably surface parsed navigation content in the editor.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArtisanPack-UI/visual-editor/pull/459?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->