### PR TITLE
feat(renderer-blade): render core/navigation blocks on the front-end (Keystone #51)

### DIFF
--- a/packages/visual-editor-renderer-blade/src/View/Components/BlocksComponent.php
+++ b/packages/visual-editor-renderer-blade/src/View/Components/BlocksComponent.php
@@ -28,6 +28,7 @@ use ArtisanPackUI\VisualEditor\Resources\PatternInliner;
 use ArtisanPackUI\VisualEditor\Resources\QueryInliner;
 use ArtisanPackUI\VisualEditor\Resources\TemplatePartInliner;
 use ArtisanPackUI\VisualEditor\Services\GlobalStylesEmissionTracker;
+use ArtisanPackUI\VisualEditor\SiteEditor\NavigationBlockRefResolver;
 use ArtisanPackUI\VisualEditorRendererBlade\BlockRenderer;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\GlobalStylesEmissionResolver;
 use Illuminate\Contracts\View\View;
@@ -53,6 +54,7 @@ class BlocksComponent extends Component
 		protected TemplatePartInliner $inliner,
 		protected PatternInliner $patternInliner,
 		protected QueryInliner $queryInliner,
+		protected NavigationBlockRefResolver $navigationResolver,
 		protected GlobalStylesEmissionResolver $globalStyles,
 		protected GlobalStylesEmissionTracker $emissionTracker,
 		mixed $tree = null,
@@ -60,6 +62,7 @@ class BlocksComponent extends Component
 		bool $resolveParts = true,
 		bool $resolvePatterns = true,
 		bool $resolveQueries = true,
+		bool $resolveNavigation = true,
 	) {
 		$this->defaultTheme = $defaultTheme;
 
@@ -76,10 +79,25 @@ class BlocksComponent extends Component
 			? $this->patternInliner->inline( $resolved )
 			: $resolved;
 
-		// Query inlining runs last so a `core/query` block inside a
-		// resolved template part / pattern still gets its loop expanded.
-		$this->tree = $resolveQueries
+		// Query inlining runs before nav-block resolution so a `core/query`
+		// loop with a navigation block inside it (rare but legal) still
+		// gets each cloned nav block resolved to its menu items.
+		$resolved = $resolveQueries
 			? $this->queryInliner->inline( $resolved )
+			: $resolved;
+
+		// Navigation resolution mirrors the editor's read path
+		// (Keystone #48 → #51): `core/navigation` blocks ship with
+		// `__unstableLocation` and/or `ref` but empty `innerBlocks`.
+		// The resolver stamps `ref` from a `(theme, location)` lookup,
+		// strips the legacy attr, and projects the menu's `menu_items`
+		// into the block's `innerBlocks` so the existing
+		// `core/navigation` Blade view renders the items as
+		// `<li><a>` markup without any per-renderer menu-lookup glue.
+		// No-ops cleanly when `$defaultTheme` is null or cms-framework
+		// isn't installed.
+		$this->tree = ( $resolveNavigation && null !== $defaultTheme )
+			? $this->navigationResolver->resolve( $resolved, $defaultTheme )
 			: $resolved;
 	}
 

--- a/packages/visual-editor-renderer-blade/src/View/Components/TemplateComponent.php
+++ b/packages/visual-editor-renderer-blade/src/View/Components/TemplateComponent.php
@@ -31,6 +31,7 @@ namespace ArtisanPackUI\VisualEditorRendererBlade\View\Components;
 
 use ArtisanPackUI\VisualEditor\Resources\PatternInliner;
 use ArtisanPackUI\VisualEditor\Resources\TemplatePartInliner;
+use ArtisanPackUI\VisualEditor\SiteEditor\NavigationBlockRefResolver;
 use ArtisanPackUI\VisualEditor\Services\GlobalStylesEmissionTracker;
 use ArtisanPackUI\VisualEditorRendererBlade\BlockRenderer;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\GlobalStylesEmissionResolver;
@@ -67,6 +68,7 @@ class TemplateComponent extends Component
 		protected BlockRenderer $renderer,
 		protected TemplatePartInliner $inliner,
 		protected PatternInliner $patternInliner,
+		protected NavigationBlockRefResolver $navigationResolver,
 		protected Application $app,
 		protected GlobalStylesEmissionResolver $globalStyles,
 		protected GlobalStylesEmissionTracker $emissionTracker,
@@ -92,7 +94,14 @@ class TemplateComponent extends Component
 
 		$inlinedParts    = $this->inliner->inline( $blocks, $theme );
 		$inlinedPatterns = $this->patternInliner->inline( $inlinedParts );
-		$this->html      = $renderer->render( $inlinedPatterns );
+
+		// Navigation resolution — see `BlocksComponent` for the
+		// full rationale. Keystone #51 (the front-end pair to #48).
+		$resolvedNav = null !== $theme
+			? $this->navigationResolver->resolve( $inlinedPatterns, $theme )
+			: $inlinedPatterns;
+
+		$this->html = $renderer->render( $resolvedNav );
 	}
 
 	public function render(): View

--- a/packages/visual-editor-renderer-blade/tests/Feature/BlocksComponentTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Feature/BlocksComponentTest.php
@@ -55,3 +55,73 @@ it( 'publishes block views under the visual-editor-blade-views tag', function ()
 
 	$artisan->assertExitCode( 0 );
 } );
+
+it( 'passes the nav-block tree through unchanged when no defaultTheme is supplied (Keystone #51)', function () {
+	// Without a theme, the navigation resolver has no `(theme, location)`
+	// to query against, so the tree should pass through. The block's
+	// own Blade view renders an empty `<nav>` — same as before #51.
+	$tree = [
+		[
+			'clientId'    => 'nav-1',
+			'name'        => 'core/navigation',
+			'attributes'  => [ '__unstableLocation' => 'primary' ],
+			'innerBlocks' => [],
+		],
+	];
+
+	$rendered = Blade::render( '<x-ve-blocks :tree="$tree" />', [ 'tree' => $tree ] );
+
+	expect( $rendered )->toContain( 'wp-block-navigation' );
+	// Empty container — no menu items projected.
+	expect( $this->normalizeHtml( $this->stripGlobalStyles( $rendered ) ) )
+		->toContain( '<ul class="wp-block-navigation__container"></ul>' );
+} );
+
+it( 'passes the nav-block tree through unchanged when cms-framework is not installed (Keystone #51)', function () {
+	// cms-framework's `MenuLocationAssignment` model isn't autoloaded in
+	// this Testbench environment, so the resolver's `class_exists` guard
+	// short-circuits the lookup. With a theme present but no DB to
+	// query, the tree still passes through — no menu items, no error.
+	$tree = [
+		[
+			'clientId'    => 'nav-1',
+			'name'        => 'core/navigation',
+			'attributes'  => [ '__unstableLocation' => 'primary' ],
+			'innerBlocks' => [],
+		],
+	];
+
+	$rendered = Blade::render(
+		'<x-ve-blocks :tree="$tree" default-theme="jmwd-default" />',
+		[ 'tree' => $tree ],
+	);
+
+	expect( $rendered )->toContain( 'wp-block-navigation' );
+	expect( $this->normalizeHtml( $this->stripGlobalStyles( $rendered ) ) )
+		->toContain( '<ul class="wp-block-navigation__container"></ul>' );
+} );
+
+it( 'preserves authored innerBlocks on a nav block instead of overwriting them (Keystone #51)', function () {
+	// A nav block authored with explicit nav-links keeps them — the
+	// resolver only projects menu items when the tree is empty.
+	$tree = [
+		[
+			'clientId'    => 'nav-1',
+			'name'        => 'core/navigation',
+			'attributes'  => [],
+			'innerBlocks' => [
+				[
+					'clientId'    => 'l-1',
+					'name'        => 'core/navigation-link',
+					'attributes'  => [ 'label' => 'Authored', 'url' => '/authored' ],
+					'innerBlocks' => [],
+				],
+			],
+		],
+	];
+
+	$rendered = Blade::render( '<x-ve-blocks :tree="$tree" />', [ 'tree' => $tree ] );
+
+	expect( $rendered )->toContain( 'Authored' );
+	expect( $rendered )->toContain( 'href="/authored"' );
+} );

--- a/src/SiteEditor/NavigationBlockRefResolver.php
+++ b/src/SiteEditor/NavigationBlockRefResolver.php
@@ -34,6 +34,7 @@ declare( strict_types=1 );
 
 namespace ArtisanPackUI\VisualEditor\SiteEditor;
 
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 
 class NavigationBlockRefResolver
@@ -163,7 +164,15 @@ class NavigationBlockRefResolver
 			$menu = $model::query()->with( 'items' )->find( $menuId );
 		} catch ( \Throwable $e ) {
 			// Same partial-install / missing-table defense as
-			// `lookupMenuIdForLocation` — Keystone #51.
+			// `lookupMenuIdForLocation` — Keystone #51. Log the
+			// failure so a real DB problem (lost connection,
+			// permissions, schema drift) doesn't hide behind the
+			// "missing table" fallback in production.
+			Log::warning( 'NavigationBlockRefResolver: failed to load menu items', [
+				'menu_id'   => $menuId,
+				'exception' => $e->getMessage(),
+			] );
+
 			$this->blocksByMenuId[ $menuId ] = [];
 
 			return [];
@@ -300,7 +309,15 @@ class NavigationBlockRefResolver
 				// not run yet (fresh install, test environment without
 				// the menus tables, partial deploy). Treat as
 				// "unassigned" rather than blowing up the front-end
-				// render — Keystone #51.
+				// render — Keystone #51. Log the failure so a real
+				// DB problem doesn't hide behind the missing-table
+				// fallback in production.
+				Log::warning( 'NavigationBlockRefResolver: failed to look up menu location', [
+					'theme'     => $theme,
+					'location'  => $location,
+					'exception' => $e->getMessage(),
+				] );
+
 				$this->cache[ $cacheKey ] = null;
 
 				return null;

--- a/src/SiteEditor/NavigationBlockRefResolver.php
+++ b/src/SiteEditor/NavigationBlockRefResolver.php
@@ -158,7 +158,16 @@ class NavigationBlockRefResolver
 		}
 
 		$model = self::MENU_FQCN;
-		$menu  = $model::query()->with( 'items' )->find( $menuId );
+
+		try {
+			$menu = $model::query()->with( 'items' )->find( $menuId );
+		} catch ( \Throwable $e ) {
+			// Same partial-install / missing-table defense as
+			// `lookupMenuIdForLocation` — Keystone #51.
+			$this->blocksByMenuId[ $menuId ] = [];
+
+			return [];
+		}
 
 		if ( null === $menu ) {
 			$this->blocksByMenuId[ $menuId ] = [];
@@ -279,11 +288,23 @@ class NavigationBlockRefResolver
 		$id = null;
 
 		if ( class_exists( self::ASSIGNMENT_FQCN ) ) {
-			$model      = self::ASSIGNMENT_FQCN;
-			$assignment = $model::query()
-				->where( 'theme', $theme )
-				->where( 'location', $location )
-				->first();
+			$model = self::ASSIGNMENT_FQCN;
+
+			try {
+				$assignment = $model::query()
+					->where( 'theme', $theme )
+					->where( 'location', $location )
+					->first();
+			} catch ( \Throwable $e ) {
+				// cms-framework is autoloaded but the migrations have
+				// not run yet (fresh install, test environment without
+				// the menus tables, partial deploy). Treat as
+				// "unassigned" rather than blowing up the front-end
+				// render — Keystone #51.
+				$this->cache[ $cacheKey ] = null;
+
+				return null;
+			}
 
 			if ( null !== $assignment && null !== ( $assignment->menu_id ?? null ) ) {
 				$id = (int) $assignment->menu_id;


### PR DESCRIPTION
Closes [Keystone #51](https://gitlab.com/jacob-martella-web-design/jacob-martella-web-design/jmwd-keystone-cms/jmwd-keystone-cms/-/work_items/51).

## The bug

The site-editor canvas resolves nav blocks via \`NavigationBlockRefResolver\` (stamps \`ref\`, strips \`__unstableLocation\`, projects \`menu_items\` into \`innerBlocks\`) on every template-part read since #48. The front-end render path never ran that resolution, so themed nav blocks authored as \`<!-- wp:navigation {\"__unstableLocation\":\"primary\"} /-->\` landed in the public HTML as empty \`<nav><ul></ul></nav>\` shells.

## The fix

Renderer-blade reuses the same resolver from visual-editor:

- **\`BlocksComponent\`** — adds a final inliner step after parts / patterns / queries. Gated on \`$defaultTheme !== null\` and behind a \`:resolve-navigation=\"false\"\` opt-out flag, mirroring the existing inliner controls.
- **\`TemplateComponent\`** — runs the same pass after its own parts/patterns inlining so a \`<x-ve-template>\`-driven page picks up the resolution too.
- **\`NavigationBlockRefResolver\`** got two defensive \`try/catch\` guards around its Eloquent reads (menu lookup, location lookup). A partial cms-framework install — model classes autoloaded but migrations not yet run — now no-ops cleanly instead of bubbling a \`QueryException\` through the render. Both catches emit \`Log::warning\` so a real production DB problem doesn't hide behind the missing-table fallback.

## Tests

- 3 new renderer-blade Testbench tests covering the renderer-blade-specific wiring: no-theme passthrough, missing-cms-framework passthrough, authored-innerBlocks preservation.
- Existing 10 \`NavigationBlockRefResolver\` tests on visual-editor cover the resolver logic itself.
- 599/599 PHP green.

## Manual verification

\`GET /\` against the running Herd site now returns the full nav with Home / Services / About / Contact links rendered through the existing \`core/navigation-link\` Blade view. Verified visually.

## Out of scope — known follow-ups

- [Keystone #52](https://gitlab.com/jacob-martella-web-design/jacob-martella-web-design/jmwd-keystone-cms/jmwd-keystone-cms/-/work_items/52) — nav items render with no spacing on both editor and front-end (same root cause on both surfaces; theme-level \`blockGap\` token + CSS).
- [Keystone #53](https://gitlab.com/jacob-martella-web-design/jacob-martella-web-design/jmwd-keystone-cms/jmwd-keystone-cms/-/work_items/53) — color panel blank on the nav block (editor-only; theme palette plumbing).

## Test plan

- [x] \`vendor/bin/pest --compact\` — 599/599 green.
- [x] Manual: \`GET /\` returns the populated nav with all four menu items rendered.
- [x] CodeRabbit local: clean review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for resolving navigation blocks during rendering preparation.

* **Bug Fixes**
  * Improved error handling for navigation block resolution when themes are missing or the framework is incomplete.
  * Navigation blocks now render gracefully without errors in edge-case scenarios.

* **Tests**
  * Added test coverage for navigation block rendering in various configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArtisanPack-UI/visual-editor/pull/460?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->