### PR TITLE
fix(renderer-blade): read core/navigation alignment from layout.justifyContent (Keystone #52)

### DIFF
--- a/packages/visual-editor-renderer-blade/resources/views/blocks/core/navigation.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/core/navigation.blade.php
@@ -1,9 +1,23 @@
 @php
 	use ArtisanPackUI\VisualEditorRendererBlade\Support\BlockSupports;
 
-	$overlayMenu  = isset( $attributes['overlayMenu'] ) && is_string( $attributes['overlayMenu'] ) ? $attributes['overlayMenu'] : 'mobile';
-	$orientation  = isset( $attributes['orientation'] ) && is_string( $attributes['orientation'] ) ? $attributes['orientation'] : 'horizontal';
-	$itemsJustify = isset( $attributes['itemsJustification'] ) && is_string( $attributes['itemsJustification'] ) ? $attributes['itemsJustification'] : '';
+	$overlayMenu = isset( $attributes['overlayMenu'] ) && is_string( $attributes['overlayMenu'] ) ? $attributes['overlayMenu'] : 'mobile';
+
+	// `orientation` ships as a top-level attribute on older saves and
+	// under `layout.orientation` on newer ones (Gutenberg's flex
+	// layout). Check both, preferring the explicit attribute.
+	$layout      = is_array( $attributes['layout'] ?? null ) ? $attributes['layout'] : [];
+	$orientation = isset( $attributes['orientation'] ) && is_string( $attributes['orientation'] )
+		? $attributes['orientation']
+		: ( isset( $layout['orientation'] ) && is_string( $layout['orientation'] ) ? $layout['orientation'] : 'horizontal' );
+
+	// Item justification — Gutenberg writes the modern flex-layout
+	// path to `layout.justifyContent`. The legacy `itemsJustification`
+	// attribute is still emitted by some older saves, so honor both
+	// with the modern path winning when both are set (Keystone #52).
+	$itemsJustify = isset( $layout['justifyContent'] ) && is_string( $layout['justifyContent'] )
+		? $layout['justifyContent']
+		: ( isset( $attributes['itemsJustification'] ) && is_string( $attributes['itemsJustification'] ) ? $attributes['itemsJustification'] : '' );
 
 	$ariaLabel = isset( $attributes['ariaLabel'] ) && is_string( $attributes['ariaLabel'] ) ? $attributes['ariaLabel'] : '';
 

--- a/packages/visual-editor-renderer-blade/tests/Feature/BlocksComponentTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Feature/BlocksComponentTest.php
@@ -101,6 +101,57 @@ it( 'passes the nav-block tree through unchanged when cms-framework is not insta
 		->toContain( '<ul class="wp-block-navigation__container"></ul>' );
 } );
 
+it( 'emits items-justified-* class from layout.justifyContent (Keystone #52)', function () {
+	// Gutenberg writes the modern flex-layout justification to
+	// `attributes.layout.justifyContent`. The legacy top-level
+	// `itemsJustification` attribute is still emitted by some older
+	// saves. Honor both, modern path winning, so a nav block aligned
+	// right in the editor canvas aligns right on the front-end too.
+	$tree = [
+		[
+			'clientId'    => 'nav-1',
+			'name'        => 'core/navigation',
+			'attributes'  => [
+				'layout' => [ 'type' => 'flex', 'justifyContent' => 'right' ],
+			],
+			'innerBlocks' => [
+				[
+					'clientId'    => 'l-1',
+					'name'        => 'core/navigation-link',
+					'attributes'  => [ 'label' => 'Home', 'url' => '/' ],
+					'innerBlocks' => [],
+				],
+			],
+		],
+	];
+
+	$rendered = Blade::render( '<x-ve-blocks :tree="$tree" />', [ 'tree' => $tree ] );
+
+	expect( $rendered )->toContain( 'items-justified-right' );
+} );
+
+it( 'falls back to the legacy itemsJustification attribute when layout.justifyContent is absent (Keystone #52)', function () {
+	$tree = [
+		[
+			'clientId'    => 'nav-1',
+			'name'        => 'core/navigation',
+			'attributes'  => [ 'itemsJustification' => 'center' ],
+			'innerBlocks' => [
+				[
+					'clientId'    => 'l-1',
+					'name'        => 'core/navigation-link',
+					'attributes'  => [ 'label' => 'Home', 'url' => '/' ],
+					'innerBlocks' => [],
+				],
+			],
+		],
+	];
+
+	$rendered = Blade::render( '<x-ve-blocks :tree="$tree" />', [ 'tree' => $tree ] );
+
+	expect( $rendered )->toContain( 'items-justified-center' );
+} );
+
 it( 'preserves authored innerBlocks on a nav block instead of overwriting them (Keystone #51)', function () {
 	// A nav block authored with explicit nav-links keeps them — the
 	// resolver only projects menu items when the tree is empty.


### PR DESCRIPTION
Closes [Keystone #52](https://gitlab.com/jacob-martella-web-design/jacob-martella-web-design/jmwd-keystone-cms/jmwd-keystone-cms/-/work_items/52) — paired with [jmwd-keystone-cms!54](https://gitlab.com/jacob-martella-web-design/jacob-martella-web-design/jmwd-keystone-cms/jmwd-keystone-cms/-/merge_requests/54).

## The bug

A nav block aligned right in the editor canvas rendered **left-aligned** on the front-end. The blade view read `attributes.itemsJustification` (legacy attribute), but Gutenberg writes the modern flex-layout justification to `attributes.layout.justifyContent`. The `items-justified-*` class never landed on the wrapping `<nav>`, so the bundled block-library CSS (which has `.wp-block-navigation.items-justified-right { justify-content: flex-end; }`) had nothing to bind to.

## The fix

\`navigation.blade.php\` now reads \`layout.justifyContent\` first, falls back to \`itemsJustification\` when it's not present. Same pattern applied to \`orientation\` (\`layout.orientation\` is the newer path). Pre-existing saves that only ship the legacy attribute continue to render unchanged.

## Tests

Two new Testbench tests cover the modern + legacy attribute paths. 601/601 PHP green.

## Manual verification

Front-end nav now matches the canvas: \`<nav class=\"wp-block-navigation is-horizontal items-justified-right is-responsive\">\` and the menu aligns flush right against the site title.

## Scope

Spacing (gap) lives in the theme repo — see paired MR. Overlay (hamburger menu) and the \"Create Overlay\" 422 are new follow-ups; #52 is scope-capped to the spacing + alignment parity issues it was filed for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced navigation block layout configuration handling to properly support multiple attribute formats and ensure backward compatibility through fallback to legacy settings.

* **Tests**
  * Added comprehensive tests for navigation block rendering, validating layout class application and behavior when using legacy attribute configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArtisanPack-UI/visual-editor/pull/461?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->