### PR TITLE
fix(site-editor): wire theme palette into BlockEditorProvider + handle nav-block legacy color attrs (Keystone #53)

### DIFF
--- a/resources/js/visual-editor/editor-settings.ts
+++ b/resources/js/visual-editor/editor-settings.ts
@@ -314,8 +314,35 @@ export const editorSettings = {
         },
         color: {
             custom: true,
+            customGradient: false,
             text: true,
             background: true,
+            // `link: true` lights up the Link color row in the inspector
+            // (used by `core/navigation`, `core/post-content`, etc).
+            // The previously-warned "drag loop" came from turning on
+            // upstream-core flags (`defaultPalette`, `defaultGradients`,
+            // `defaultDuotone`) without the preset data backing them.
+            // `link` is data-backed by the palette below — no loop
+            // (Keystone #53).
+            link: true,
+            // Expose the palette through the modern features path so
+            // the nav block's color picker (and any block that reads
+            // `__experimentalFeatures.color.palette.theme` first)
+            // surfaces swatches instead of empty rows. Mirror the
+            // legacy top-level `colors:` array so both code paths
+            // converge on the same data.
+            // `__experimentalFeatures.color.palette.{theme,custom,default}`
+            // each take an ARRAY of `{slug, name, color}` entries —
+            // NOT a boolean. Gutenberg's `with-colors` HOC spreads
+            // all three together (`[...theme, ...custom, ...default]`),
+            // so a `custom: true` here crashes with "spread requires
+            // iterable" in `with-colors.mjs`. Leave `custom` as an
+            // empty array; user-defined custom colors get added via
+            // the picker UI at runtime, not seeded here.
+            palette: {
+                theme: DEFAULT_PALETTE,
+                custom: [],
+            },
         },
         typography: {
             customFontSize: true,

--- a/resources/js/visual-editor/site-editor/__tests__/block-editor-boundary.test.tsx
+++ b/resources/js/visual-editor/site-editor/__tests__/block-editor-boundary.test.tsx
@@ -57,6 +57,7 @@ vi.mock('@wordpress/format-library', () => ({}));
 // deterministic and doesn't touch the network under jsdom.
 vi.mock('../styles/global-styles-api', () => ({
     fetchGlobalStylesCss: vi.fn(async (): Promise<string> => ''),
+    fetchGlobalStylesBase: vi.fn(async () => ({ settings: {}, styles: {} })),
 }));
 
 const CONVERT_TO_PATTERN_CONTROL_MOCK = vi.fn((): null => null);

--- a/resources/js/visual-editor/site-editor/block-editor-boundary.tsx
+++ b/resources/js/visual-editor/site-editor/block-editor-boundary.tsx
@@ -38,6 +38,7 @@ import { type ReactNode } from 'react';
 import { ConvertToPatternControl } from '../editor/convert-to-pattern-control';
 import { editorSettings } from '../editor-settings';
 import { useThemeGlobalStylesCss } from './use-theme-global-styles-css';
+import { useThemeGlobalStylesSettings } from './use-theme-global-styles-settings';
 
 // Gutenberg editor-surface stylesheets. Previously imported by each
 // canvas component; they follow the provider here so the boundary owns
@@ -83,25 +84,83 @@ export function BlockEditorBoundary(props: BlockEditorBoundaryProps): JSX.Elemen
     const fetchedCss = useThemeGlobalStylesCss(apiBase);
     const themeCss = themeGlobalStylesCss !== undefined ? themeGlobalStylesCss : fetchedCss;
 
+    // Pull the active theme's `settings` (palette, font-sizes, etc.)
+    // so the picker UIs source their swatches from the same slugs the
+    // server-side emitter binds via `.has-{slug}-*` rules. Without
+    // this the editor used a hard-coded default palette while the
+    // emitter bound the theme palette — picker choices didn't
+    // visually apply because the two palettes don't share slugs
+    // (Keystone #53).
+    const themeBase = useThemeGlobalStylesSettings(apiBase);
+
     // Append the theme's compiled global-styles CSS to the editor's
-    // `styles` array so Gutenberg cascades it into the canvas. Memoized
-    // so identity-stable `editorSettings.styles` doesn't bust the
-    // provider's effects on every parent re-render. When no theme CSS
-    // is available we hand the provider the original `editorSettings`
-    // object — no allocation, no diff.
+    // `styles` array so Gutenberg cascades it into the canvas, and
+    // override the palette / font-sizes in `__experimentalFeatures`
+    // when the theme defines them. Memoized so identity-stable
+    // `editorSettings` doesn't bust the provider's effects on every
+    // parent re-render. When no theme data is available we hand the
+    // provider the original `editorSettings` object — no allocation,
+    // no diff.
     const settings = useMemo(() => {
-        if (themeCss === undefined || themeCss === '') {
+        const themeSettings = themeBase?.settings ?? {};
+        const themePalette = extractThemePalette(themeSettings);
+        const themeFontSizes = extractThemeFontSizes(themeSettings);
+        const themeGradients = extractThemeGradients(themeSettings);
+
+        const needsStyles = themeCss !== undefined && themeCss !== '';
+        const needsPalette = themePalette !== null;
+        const needsFontSizes = themeFontSizes !== null;
+        const needsGradients = themeGradients !== null;
+
+        if (!needsStyles && !needsPalette && !needsFontSizes && !needsGradients) {
             return editorSettings;
         }
 
+        const nextStyles = needsStyles
+            ? [...editorSettings.styles, { css: themeCss as string }]
+            : editorSettings.styles;
+
+        const baseFeatures = editorSettings.__experimentalFeatures ?? {};
+        const baseColor = (baseFeatures as { color?: Record<string, unknown> }).color ?? {};
+        const baseTypography =
+            (baseFeatures as { typography?: Record<string, unknown> }).typography ?? {};
+
         return {
             ...editorSettings,
-            styles: [
-                ...editorSettings.styles,
-                { css: themeCss },
-            ],
+            styles: nextStyles,
+            // Mirror onto the legacy top-level keys too so older
+            // blocks that still read `settings.colors` / `fontSizes`
+            // pick up the theme's slugs.
+            ...(needsPalette ? { colors: themePalette } : {}),
+            ...(needsFontSizes ? { fontSizes: themeFontSizes } : {}),
+            __experimentalFeatures: {
+                ...baseFeatures,
+                color: {
+                    ...baseColor,
+                    ...(needsPalette || needsGradients
+                        ? {
+                              palette: needsPalette
+                                  ? { theme: themePalette, custom: [] }
+                                  : (baseColor as { palette?: unknown }).palette,
+                              gradients: needsGradients
+                                  ? { theme: themeGradients, custom: [] }
+                                  : (baseColor as { gradients?: unknown }).gradients,
+                          }
+                        : {}),
+                },
+                typography: needsFontSizes
+                    ? {
+                          ...baseTypography,
+                          fontSizes: {
+                              ...(((baseTypography as { fontSizes?: Record<string, unknown> })
+                                  .fontSizes) ?? {}),
+                              theme: themeFontSizes,
+                          },
+                      }
+                    : baseTypography,
+            },
         };
-    }, [themeCss]);
+    }, [themeCss, themeBase]);
 
     return (
         <SlotFillProvider>
@@ -119,4 +178,134 @@ export function BlockEditorBoundary(props: BlockEditorBoundaryProps): JSX.Elemen
             </BlockEditorProvider>
         </SlotFillProvider>
     );
+}
+
+interface PaletteEntry {
+    slug: string;
+    name: string;
+    color: string;
+}
+
+interface FontSizeEntry {
+    slug: string;
+    name: string;
+    size: string;
+}
+
+interface GradientEntry {
+    slug: string;
+    name: string;
+    gradient: string;
+}
+
+/**
+ * Pull `settings.color.palette` out of the `/global-styles/base`
+ * payload as a normalized `{ slug, name, color }` list. Returns
+ * `null` (not an empty array) when the theme didn't define one so
+ * the boundary can keep `editorSettings`'s default palette as a
+ * fallback rather than blanking the picker.
+ */
+function extractThemePalette(
+    settings: Record<string, unknown>,
+): readonly PaletteEntry[] | null {
+    const palette = (settings.color as { palette?: unknown })?.palette;
+
+    if (!Array.isArray(palette) || palette.length === 0) {
+        return null;
+    }
+
+    const out: PaletteEntry[] = [];
+
+    for (const entry of palette) {
+        if (entry === null || typeof entry !== 'object') {
+            continue;
+        }
+
+        const slug = (entry as { slug?: unknown }).slug;
+        const color = (entry as { color?: unknown }).color;
+
+        if (typeof slug !== 'string' || slug === '' || typeof color !== 'string') {
+            continue;
+        }
+
+        const name = (entry as { name?: unknown }).name;
+
+        out.push({
+            slug,
+            color,
+            name: typeof name === 'string' ? name : slug,
+        });
+    }
+
+    return out.length === 0 ? null : out;
+}
+
+function extractThemeFontSizes(
+    settings: Record<string, unknown>,
+): readonly FontSizeEntry[] | null {
+    const sizes = (settings.typography as { fontSizes?: unknown })?.fontSizes;
+
+    if (!Array.isArray(sizes) || sizes.length === 0) {
+        return null;
+    }
+
+    const out: FontSizeEntry[] = [];
+
+    for (const entry of sizes) {
+        if (entry === null || typeof entry !== 'object') {
+            continue;
+        }
+
+        const slug = (entry as { slug?: unknown }).slug;
+        const size = (entry as { size?: unknown }).size;
+
+        if (typeof slug !== 'string' || slug === '' || typeof size !== 'string') {
+            continue;
+        }
+
+        const name = (entry as { name?: unknown }).name;
+
+        out.push({
+            slug,
+            size,
+            name: typeof name === 'string' ? name : slug,
+        });
+    }
+
+    return out.length === 0 ? null : out;
+}
+
+function extractThemeGradients(
+    settings: Record<string, unknown>,
+): readonly GradientEntry[] | null {
+    const gradients = (settings.color as { gradients?: unknown })?.gradients;
+
+    if (!Array.isArray(gradients) || gradients.length === 0) {
+        return null;
+    }
+
+    const out: GradientEntry[] = [];
+
+    for (const entry of gradients) {
+        if (entry === null || typeof entry !== 'object') {
+            continue;
+        }
+
+        const slug = (entry as { slug?: unknown }).slug;
+        const gradient = (entry as { gradient?: unknown }).gradient;
+
+        if (typeof slug !== 'string' || slug === '' || typeof gradient !== 'string') {
+            continue;
+        }
+
+        const name = (entry as { name?: unknown }).name;
+
+        out.push({
+            slug,
+            gradient,
+            name: typeof name === 'string' ? name : slug,
+        });
+    }
+
+    return out.length === 0 ? null : out;
 }

--- a/resources/js/visual-editor/site-editor/use-theme-global-styles-settings.ts
+++ b/resources/js/visual-editor/site-editor/use-theme-global-styles-settings.ts
@@ -1,0 +1,120 @@
+/**
+ * Hook that fetches the active theme's `settings` payload from
+ * `/global-styles/base` once per `apiBase` and returns it ready to
+ * merge into the editor's `__experimentalFeatures` (Keystone #53).
+ *
+ * Why this exists: the inspector's color/font-size pickers render
+ * swatches from the slugs in `__experimentalFeatures.color.palette`,
+ * and cms-framework's `GlobalStylesEmitter` binds those same slugs
+ * via `.has-{slug}-*` CSS rules. If the editor uses a hard-coded
+ * default palette while the emitter binds the theme.json palette,
+ * the two palettes don't share slugs — picker choices light up the
+ * swatch but no CSS rule applies the color. This hook closes that
+ * gap by sourcing the same palette from the same place both sides
+ * read from.
+ *
+ * The hook returns `undefined` while the fetch is in flight, an
+ * empty object when no theme is active or cms-framework isn't
+ * installed, and the parsed `settings` once loaded. The boundary
+ * treats `undefined` / `{}` the same way: fall back to
+ * `editorSettings` defaults.
+ *
+ * Module-level cache keyed by `apiBase` matches
+ * {@link useThemeGlobalStylesCss}'s pattern so a remount inside
+ * the same editor session resolves synchronously.
+ */
+
+import { useEffect, useState } from 'react';
+
+import { fetchGlobalStylesBase, type GlobalStylesBase } from './styles/global-styles-api';
+
+export interface GlobalStylesBasePayload {
+    settings: Record<string, unknown>;
+    styles: Record<string, unknown>;
+}
+
+const EMPTY: GlobalStylesBasePayload = { settings: {}, styles: {} };
+
+/**
+ * Wraps {@link fetchGlobalStylesBase}'s throw-on-failure contract in
+ * the empty-payload-on-failure contract this hook expects, so a
+ * missing endpoint / network blip falls back to package defaults
+ * instead of cascading into the editor mount as an uncaught error.
+ */
+function safeFetch(apiBase: string): Promise<GlobalStylesBasePayload> {
+    return fetchGlobalStylesBase({ apiBase })
+        .then((base: GlobalStylesBase) => ({
+            settings: base.settings ?? {},
+            styles: base.styles ?? {},
+        }))
+        .catch(() => EMPTY);
+}
+
+type CachedSettings =
+    | { status: 'pending'; promise: Promise<GlobalStylesBasePayload> }
+    | { status: 'resolved'; value: GlobalStylesBasePayload };
+
+const cache = new Map<string, CachedSettings>();
+
+export function resetThemeGlobalStylesSettingsCache(): void {
+    cache.clear();
+}
+
+export function useThemeGlobalStylesSettings(
+    apiBase: string | undefined
+): GlobalStylesBasePayload | undefined {
+    const [value, setValue] = useState<GlobalStylesBasePayload | undefined>(() => {
+        if (apiBase === undefined || apiBase === '') {
+            return EMPTY;
+        }
+
+        const cached = cache.get(apiBase);
+
+        if (cached?.status === 'resolved') {
+            return cached.value;
+        }
+
+        return undefined;
+    });
+
+    useEffect(() => {
+        if (apiBase === undefined || apiBase === '') {
+            setValue(EMPTY);
+
+            return;
+        }
+
+        let cancelled = false;
+        let entry = cache.get(apiBase);
+
+        if (entry === undefined) {
+            const promise = safeFetch(apiBase);
+            entry = { status: 'pending', promise };
+            cache.set(apiBase, entry);
+
+            promise.then((resolved) => {
+                cache.set(apiBase, { status: 'resolved', value: resolved });
+            });
+        }
+
+        if (entry.status === 'resolved') {
+            setValue(entry.value);
+
+            return () => {
+                cancelled = true;
+            };
+        }
+
+        entry.promise.then((resolved) => {
+            if (!cancelled) {
+                setValue(resolved);
+            }
+        });
+
+        return () => {
+            cancelled = true;
+        };
+    }, [apiBase]);
+
+    return value;
+}


### PR DESCRIPTION
Closes [Keystone #53](https://gitlab.com/jacob-martella-web-design/jacob-martella-web-design/jmwd-keystone-cms/jmwd-keystone-cms/-/work_items/53). Paired with cms-framework PR (emitter class bindings) and jmwd-keystone-cms MR (theme CSS).

## The bug

The Color panel on the \`core/navigation\` block rendered Text / Background / Link rows with **no swatches inside**, and picker choices that DID appear (after partial fixes) didn't visually apply because the editor was using a hard-coded \`DEFAULT_PALETTE\` while the server's emitter bound rules to a *different* palette (theme.json's). Slugs didn't match → classes had no CSS to bind to.

Additionally, the \`core/navigation\` block uses block-specific legacy attribute names (\`customTextColor\`, \`customBackgroundColor\`) that \`BlockSupports::applyColor\` doesn't know about — custom-hex picker choices silently dropped.

## The fix

**Wire the theme palette through to the editor:**

- New hook \`useThemeGlobalStylesSettings\` fetches \`/global-styles/base\` (same payload cms-framework emits CSS from) and surfaces the parsed \`settings\` to React.
- \`BlockEditorBoundary\` merges the theme's palette / font-sizes / gradients into \`__experimentalFeatures\` AND the legacy top-level \`colors\` / \`fontSizes\` keys. Both sides now share slug identity, so picker choices produce classes the emitter has bindings for.
- \`DEFAULT_PALETTE\` stays as the fallback for standalone installs / cms-framework-absent environments.

**Wire \`__experimentalFeatures.color\` to include link + palette:**

- Added \`link: true\` to enable the Link picker row (was missing — only \`text\` + \`background\`).
- Added \`palette: { theme: DEFAULT_PALETTE, custom: [] }\` so the modern features path surfaces swatches.
- \`custom: []\` (NOT \`true\`) because Gutenberg's \`with-colors\` HOC spreads \`[...theme, ...custom, ...default]\`; a boolean here crashes with \"spread requires iterable\".
- \`customGradient: false\` explicit-off so the gradient picker doesn't fall back to upstream default data we don't ship.

**Handle nav-block legacy color attrs in renderer-blade:**

- \`navigation.blade.php\` now reads \`customTextColor\` / \`customBackgroundColor\` (block-specific hex attributes) and emits them as inline \`style=\"color: ...\"\` / \`background-color: ...\` declarations. Preset slug attributes (\`textColor\` / \`backgroundColor\`) still flow through \`BlockSupports::applyColor\` and produce \`has-{slug}-*\` classes.
- Also added: \`layout.justifyContent\` and \`layout.orientation\` reading so the modern flex-layout attribute paths line up with the editor canvas (paired with the earlier #52 alignment work).

## Tests

- 1051/1052 vitest green (1 pre-existing skip).
- \`block-editor-boundary.test.tsx\` mock extended with \`fetchGlobalStylesBase\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated theme-based global styles (colors, fonts, gradients) into the visual editor
  * Enabled link color configuration in the color inspector
  * Enhanced color palette management with improved theme synchronization

* **Refactor**
  * Restructured editor settings to support modern feature configuration paths alongside legacy options

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArtisanPack-UI/visual-editor/pull/462?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->