### PR TITLE
feat(renderer-blade): render core/navigation overlay + hamburger toggle on the front-end (Keystone #54)

### DIFF
--- a/packages/visual-editor-renderer-blade/resources/views/blocks/core/navigation.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/core/navigation.blade.php
@@ -1,4 +1,5 @@
 @php
+	use ArtisanPackUI\VisualEditorRendererBlade\Services\NavigationOverlayTracker;
 	use ArtisanPackUI\VisualEditorRendererBlade\Support\BlockSupports;
 
 	$overlayMenu = isset( $attributes['overlayMenu'] ) && is_string( $attributes['overlayMenu'] ) ? $attributes['overlayMenu'] : 'mobile';
@@ -37,12 +38,127 @@
 		$baseClasses[] = 'is-responsive';
 	}
 
+	// Nav-block-specific color attributes (Keystone #53). The shared
+	// `BlockSupports::applyColor` handles `textColor` / `backgroundColor`
+	// + `style.color.*`, but `core/navigation` uses its own legacy
+	// attribute names — `customTextColor` / `customBackgroundColor`
+	// for the inline-hex pickers, plus a parallel `overlay*` family
+	// for the responsive overlay container. Translate the picks into
+	// `has-{slug}-*` classes / inline styles directly so neither the
+	// canvas nor the front-end is left with picker choices that
+	// visually no-op.
+	$navStyles = [];
+
+	$customTextColor = isset( $attributes['customTextColor'] ) && is_string( $attributes['customTextColor'] )
+		? trim( $attributes['customTextColor'] )
+		: '';
+
+	$customBackgroundColor = isset( $attributes['customBackgroundColor'] ) && is_string( $attributes['customBackgroundColor'] )
+		? trim( $attributes['customBackgroundColor'] )
+		: '';
+
+	// `textColor` / `backgroundColor` (preset slugs) are already added
+	// to the wrapper attrs by `BlockSupports::applyColor`. The block-
+	// specific `custom*Color` attributes need inline-style handling
+	// here. A preset slug WINS over a custom-hex if both are present
+	// — mirrors WP core's nav block serializer.
+	$textSlug = isset( $attributes['textColor'] ) && is_string( $attributes['textColor'] ) && '' !== $attributes['textColor'];
+
+	if ( ! $textSlug && '' !== $customTextColor ) {
+		$navStyles[]   = 'color: ' . $customTextColor;
+		$baseClasses[] = 'has-text-color';
+	}
+
+	$backgroundSlug = isset( $attributes['backgroundColor'] ) && is_string( $attributes['backgroundColor'] ) && '' !== $attributes['backgroundColor'];
+
+	if ( ! $backgroundSlug && '' !== $customBackgroundColor ) {
+		$navStyles[]   = 'background-color: ' . $customBackgroundColor;
+		$baseClasses[] = 'has-background';
+	}
+
+	$ariaLabel = isset( $attributes['ariaLabel'] ) && is_string( $attributes['ariaLabel'] ) ? $attributes['ariaLabel'] : '';
+
 	$navAttrs = '';
 
 	if ( '' !== $ariaLabel ) {
 		$navAttrs .= sprintf( ' aria-label="%s"', e( $ariaLabel ) );
 	}
+
+	if ( [] !== $navStyles ) {
+		$navAttrs .= sprintf( ' style="%s"', e( implode( '; ', $navStyles ) ) );
+	}
+
+	// Overlay rendering (Keystone #54). When `overlayMenu` is
+	// `mobile` (default) or `always`, the nav block ships a
+	// hamburger-toggle button + a `wp-block-navigation__responsive-
+	// container` wrapper around the items. Renderer-blade's bundled
+	// style.css already has the breakpoint media queries, the
+	// `is-menu-open` transitions, and the layout rules — the toggle
+	// JS at the bottom of this file flips the `is-menu-open` class
+	// and `aria-hidden`. `overlayMenu: "never"` skips the overlay
+	// entirely and renders the bare inline `<ul>` for the always-
+	// inline case.
+	$wantsOverlay = 'never' !== $overlayMenu;
+
+	$overlayTracker = $wantsOverlay ? app( NavigationOverlayTracker::class ) : null;
+	$overlayId      = $wantsOverlay ? $overlayTracker->nextOverlayId() : '';
+	$emitScript     = $wantsOverlay && ! $overlayTracker->hasEmittedScript();
+
+	if ( $emitScript ) {
+		$overlayTracker->markScriptEmitted();
+	}
+
+	$overlayClasses = [ 'wp-block-navigation__responsive-container' ];
+
+	if ( 'always' === $overlayMenu ) {
+		$overlayClasses[] = 'is-always-overlay';
+	}
+
+	// Open-button label — `openSubmenusOnClick` is an unrelated
+	// attribute; the open-menu button label has no dedicated attribute
+	// in the block, so use a sensible default. WP core uses "Menu" —
+	// matches the dialog's aria-label.
+	$openLabel  = '' !== $ariaLabel ? $ariaLabel : 'Menu';
+	$closeLabel = 'Close menu';
+
+	// Hamburger icon mirrors the upstream nav block's three-line SVG.
+	$hamburgerIcon = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false"><rect x="4" y="7.5" width="16" height="1.5"/><rect x="4" y="15" width="16" height="1.5"/></svg>';
+	$closeIcon     = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false"><path d="M13 11.8l6.1-6.3-1-1-6.1 6.2-6.1-6.2-1 1 6.1 6.3-6.5 6.7 1 1 6.5-6.6 6.5 6.6 1-1z"/></svg>';
 @endphp
 <nav{!! BlockSupports::wrapperAttrs( $attributes, $baseClasses ) !!}{!! $navAttrs !!}>
+@if ( $wantsOverlay )
+	<button type="button" aria-haspopup="dialog" aria-label="{{ $openLabel }}" class="wp-block-navigation__responsive-container-open" data-ap-nav-overlay-open="{{ $overlayId }}">
+		{!! $hamburgerIcon !!}
+	</button>
+	<div class="{{ implode( ' ', $overlayClasses ) }}" id="{{ $overlayId }}" aria-hidden="true">
+		<div class="wp-block-navigation__responsive-close" tabindex="-1" data-ap-nav-overlay-close>
+			<div class="wp-block-navigation__responsive-dialog" aria-label="{{ $openLabel }}" aria-modal="true" role="dialog">
+				<button type="button" aria-label="{{ $closeLabel }}" class="wp-block-navigation__responsive-container-close" data-ap-nav-overlay-close>
+					{!! $closeIcon !!}
+				</button>
+				<div class="wp-block-navigation__responsive-container-content" id="{{ $overlayId }}-content">
+					<ul class="wp-block-navigation__container">{!! $innerBlocksHtml !!}</ul>
+				</div>
+			</div>
+		</div>
+	</div>
+@else
 	<ul class="wp-block-navigation__container">{!! $innerBlocksHtml !!}</ul>
+@endif
 </nav>
+@if ( $emitScript )
+<script>
+/*! Keystone #54 — nav overlay toggle. Tiny inline controller; emitted once per response. */
+(function(){if(window.__apNavOverlayInit)return;window.__apNavOverlayInit=true;
+function open(c){c.classList.add('is-menu-open');c.setAttribute('aria-hidden','false');document.body.style.overflow='hidden';
+var d=c.querySelector('[role="dialog"]');if(d){var f=d.querySelector('button,[href],[tabindex]:not([tabindex="-1"])');if(f)f.focus();}}
+function close(c){c.classList.remove('is-menu-open');c.setAttribute('aria-hidden','true');document.body.style.overflow='';
+var t=document.querySelector('[data-ap-nav-overlay-open="'+c.id+'"]');if(t)t.focus();}
+document.addEventListener('click',function(e){var o=e.target.closest('[data-ap-nav-overlay-open]');
+if(o){e.preventDefault();var t=document.getElementById(o.getAttribute('data-ap-nav-overlay-open'));if(t)open(t);return;}
+var x=e.target.closest('[data-ap-nav-overlay-close]');if(x){e.preventDefault();
+var c=x.closest('.wp-block-navigation__responsive-container');if(c)close(c);}});
+document.addEventListener('keydown',function(e){if(e.key!=='Escape')return;
+var c=document.querySelector('.wp-block-navigation__responsive-container.is-menu-open');if(c){e.preventDefault();close(c);}});})();
+</script>
+@endif

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/core/navigation.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/core/navigation.blade.php
@@ -189,14 +189,20 @@
 @if ( $emitScript )
 <style>
 /*! Keystone #54 — nav overlay layout fix-ups. Emitted once per response. */
-/* The bundled style.css reads `--navigation-layout-justify` on the
- * responsive container's content wrapper. When the parent nav has
- * `items-justified-right`, that var resolves to `flex-end` and the
- * inner `<ul>` packs to the right edge — so the vertically-stacked
- * menu items render flush right inside the open overlay. Override
- * with stretch alignment so the items lay out full-width left-aligned. */
-.wp-block-navigation__responsive-container.is-menu-open .wp-block-navigation__responsive-container-content{justify-content:flex-start;align-items:stretch;}
-.wp-block-navigation__responsive-container.is-menu-open .wp-block-navigation__container{align-items:stretch;}
+/* The bundled style.css reads `--navigation-layout-justification-setting`
+ * and `--navigation-layout-justify` on the `<ul>`, each `<li>`, and the
+ * page-list inside `is-menu-open`. When the parent nav has
+ * `items-justified-right`, those vars resolve to `flex-end` and items
+ * render flush against the right edge of the overlay (which is wrong —
+ * an open mobile overlay should stack items full-width starting from
+ * the inline-start edge, regardless of the desktop justification).
+ *
+ * Override the vars on the responsive container so the bundled rules
+ * (whose specificity we don't reliably beat with class selectors)
+ * read stretch / start values instead. Vars cascade to all descendants,
+ * so a single declaration on the container fixes the `<ul>`, `<li>`,
+ * `<a>`, and the page-list at once. */
+.wp-block-navigation__responsive-container.is-menu-open{--navigation-layout-justification-setting:stretch;--navigation-layout-justify:flex-start;--navigation-layout-align:stretch;}
 </style>
 <script>
 /*! Keystone #54 — nav overlay toggle. Tiny inline controller; emitted once per response. */

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/core/navigation.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/core/navigation.blade.php
@@ -171,7 +171,7 @@
 		{!! $hamburgerIcon !!}
 	</button>
 	<div class="{{ implode( ' ', $overlayClasses ) }}" id="{{ $overlayId }}" aria-hidden="true"{!! $overlayStyleAttr !!}>
-		<div class="wp-block-navigation__responsive-close" tabindex="-1" data-ap-nav-overlay-close>
+		<div class="wp-block-navigation__responsive-close" tabindex="-1" data-ap-nav-overlay-backdrop>
 			<div class="wp-block-navigation__responsive-dialog" aria-label="{{ $openLabel }}" aria-modal="true" role="dialog">
 				<button type="button" aria-label="{{ $closeLabel }}" class="wp-block-navigation__responsive-container-close" data-ap-nav-overlay-close>
 					{!! $closeIcon !!}
@@ -214,7 +214,10 @@ var t=document.querySelector('[data-ap-nav-overlay-open="'+c.id+'"]');if(t)t.foc
 document.addEventListener('click',function(e){var o=e.target.closest('[data-ap-nav-overlay-open]');
 if(o){e.preventDefault();var t=document.getElementById(o.getAttribute('data-ap-nav-overlay-open'));if(t)open(t);return;}
 var x=e.target.closest('[data-ap-nav-overlay-close]');if(x){e.preventDefault();
-var c=x.closest('.wp-block-navigation__responsive-container');if(c)close(c);}});
+var c=x.closest('.wp-block-navigation__responsive-container');if(c)close(c);return;}
+/* Backdrop click — only when the click target IS the backdrop itself, not a descendant. Without the identity check, every menu-link click bubbles up to the backdrop and triggers a close + preventDefault, breaking link navigation. */
+var b=e.target.closest('[data-ap-nav-overlay-backdrop]');
+if(b&&e.target===b){var c=b.closest('.wp-block-navigation__responsive-container');if(c)close(c);}});
 document.addEventListener('keydown',function(e){if(e.key!=='Escape')return;
 var c=document.querySelector('.wp-block-navigation__responsive-container.is-menu-open');if(c){e.preventDefault();close(c);}});})();
 </script>

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/core/navigation.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/core/navigation.blade.php
@@ -202,7 +202,7 @@
  * read stretch / start values instead. Vars cascade to all descendants,
  * so a single declaration on the container fixes the `<ul>`, `<li>`,
  * `<a>`, and the page-list at once. */
-.wp-block-navigation__responsive-container.is-menu-open{--navigation-layout-justification-setting:stretch;--navigation-layout-justify:flex-start;--navigation-layout-align:stretch;}
+.wp-block-navigation__responsive-container.is-menu-open{--navigation-layout-justification-setting:stretch;--navigation-layout-justify:flex-start;--navigation-layout-align:stretch;--wp--style--root--padding-top:1.5rem;--wp--style--root--padding-right:1.5rem;--wp--style--root--padding-bottom:1.5rem;--wp--style--root--padding-left:1.5rem;}
 </style>
 <script>
 /*! Keystone #54 — nav overlay toggle. Tiny inline controller; emitted once per response. */

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/core/navigation.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/core/navigation.blade.php
@@ -114,6 +114,46 @@
 		$overlayClasses[] = 'is-always-overlay';
 	}
 
+	// Overlay-specific color attributes (Keystone #54). The nav block
+	// ships a parallel `overlayTextColor` / `overlayBackgroundColor`
+	// (preset slugs) + `customOverlay*` (hex) family that targets the
+	// responsive container, NOT the inline nav. Without this the
+	// overlay inherits the inline nav's colors — a red nav on
+	// desktop renders the mobile overlay red too even when the
+	// author picked a dark overlay background.
+	$overlayStyles = [];
+
+	$overlayBgSlug = isset( $attributes['overlayBackgroundColor'] ) && is_string( $attributes['overlayBackgroundColor'] )
+		? trim( $attributes['overlayBackgroundColor'] )
+		: '';
+	$overlayBgCustom = isset( $attributes['customOverlayBackgroundColor'] ) && is_string( $attributes['customOverlayBackgroundColor'] )
+		? trim( $attributes['customOverlayBackgroundColor'] )
+		: '';
+	$overlayTextSlug = isset( $attributes['overlayTextColor'] ) && is_string( $attributes['overlayTextColor'] )
+		? trim( $attributes['overlayTextColor'] )
+		: '';
+	$overlayTextCustom = isset( $attributes['customOverlayTextColor'] ) && is_string( $attributes['customOverlayTextColor'] )
+		? trim( $attributes['customOverlayTextColor'] )
+		: '';
+
+	if ( '' !== $overlayBgSlug ) {
+		$overlayClasses[] = 'has-' . $overlayBgSlug . '-background-color';
+		$overlayClasses[] = 'has-background';
+	} elseif ( '' !== $overlayBgCustom ) {
+		$overlayStyles[]  = 'background-color: ' . $overlayBgCustom;
+		$overlayClasses[] = 'has-background';
+	}
+
+	if ( '' !== $overlayTextSlug ) {
+		$overlayClasses[] = 'has-' . $overlayTextSlug . '-color';
+		$overlayClasses[] = 'has-text-color';
+	} elseif ( '' !== $overlayTextCustom ) {
+		$overlayStyles[]  = 'color: ' . $overlayTextCustom;
+		$overlayClasses[] = 'has-text-color';
+	}
+
+	$overlayStyleAttr = [] === $overlayStyles ? '' : sprintf( ' style="%s"', e( implode( '; ', $overlayStyles ) ) );
+
 	// Open-button label — `openSubmenusOnClick` is an unrelated
 	// attribute; the open-menu button label has no dedicated attribute
 	// in the block, so use a sensible default. WP core uses "Menu" —
@@ -130,7 +170,7 @@
 	<button type="button" aria-haspopup="dialog" aria-label="{{ $openLabel }}" class="wp-block-navigation__responsive-container-open" data-ap-nav-overlay-open="{{ $overlayId }}">
 		{!! $hamburgerIcon !!}
 	</button>
-	<div class="{{ implode( ' ', $overlayClasses ) }}" id="{{ $overlayId }}" aria-hidden="true">
+	<div class="{{ implode( ' ', $overlayClasses ) }}" id="{{ $overlayId }}" aria-hidden="true"{!! $overlayStyleAttr !!}>
 		<div class="wp-block-navigation__responsive-close" tabindex="-1" data-ap-nav-overlay-close>
 			<div class="wp-block-navigation__responsive-dialog" aria-label="{{ $openLabel }}" aria-modal="true" role="dialog">
 				<button type="button" aria-label="{{ $closeLabel }}" class="wp-block-navigation__responsive-container-close" data-ap-nav-overlay-close>
@@ -147,6 +187,17 @@
 @endif
 </nav>
 @if ( $emitScript )
+<style>
+/*! Keystone #54 — nav overlay layout fix-ups. Emitted once per response. */
+/* The bundled style.css reads `--navigation-layout-justify` on the
+ * responsive container's content wrapper. When the parent nav has
+ * `items-justified-right`, that var resolves to `flex-end` and the
+ * inner `<ul>` packs to the right edge — so the vertically-stacked
+ * menu items render flush right inside the open overlay. Override
+ * with stretch alignment so the items lay out full-width left-aligned. */
+.wp-block-navigation__responsive-container.is-menu-open .wp-block-navigation__responsive-container-content{justify-content:flex-start;align-items:stretch;}
+.wp-block-navigation__responsive-container.is-menu-open .wp-block-navigation__container{align-items:stretch;}
+</style>
 <script>
 /*! Keystone #54 — nav overlay toggle. Tiny inline controller; emitted once per response. */
 (function(){if(window.__apNavOverlayInit)return;window.__apNavOverlayInit=true;

--- a/packages/visual-editor-renderer-blade/src/Services/NavigationOverlayTracker.php
+++ b/packages/visual-editor-renderer-blade/src/Services/NavigationOverlayTracker.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * Per-request bookkeeping for nav-block overlay rendering.
+ *
+ * `core/navigation` blocks with `overlayMenu` set to `mobile` or `always`
+ * render a hamburger-toggle wrapper + a responsive-container `<div>`
+ * that the editor canvas already exposes (Keystone #54). The toggle
+ * needs:
+ *
+ *   - A unique DOM id per overlay so multiple nav blocks on the same
+ *     page don't collide. {@see nextOverlayId()} hands out monotonically
+ *     increasing ids, scoped to the request.
+ *   - A small JS controller that runs once per page regardless of how
+ *     many nav blocks the page has. {@see hasEmittedScript()} /
+ *     {@see markScriptEmitted()} gate the inline `<script>` block so
+ *     it appears at most once per response.
+ *
+ * Bound via `$this->app->scoped()` in the renderer-blade service
+ * provider so the tracker is rebuilt at the start of every request
+ * scope. That keeps a long-lived worker (Octane, RoadRunner, queue
+ * worker rendering blocks per job) from carrying overlay state across
+ * requests.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditorRendererBlade
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.1.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditorRendererBlade\Services;
+
+class NavigationOverlayTracker
+{
+	protected int $counter = 0;
+
+	protected bool $scriptEmitted = false;
+
+	/**
+	 * Mint a new overlay id. Format mirrors WordPress core's
+	 * `modal-nav-{n}` convention so the editor canvas and front-end
+	 * resolve identical selectors.
+	 *
+	 * @since 1.1.0
+	 */
+	public function nextOverlayId(): string
+	{
+		$this->counter++;
+
+		return 'ap-modal-nav-' . $this->counter;
+	}
+
+	public function hasEmittedScript(): bool
+	{
+		return $this->scriptEmitted;
+	}
+
+	public function markScriptEmitted(): void
+	{
+		$this->scriptEmitted = true;
+	}
+
+	/**
+	 * Resets both the counter and the script-emitted flag. Used by
+	 * tests that exercise multiple renders inside a single process.
+	 *
+	 * @since 1.1.0
+	 */
+	public function reset(): void
+	{
+		$this->counter       = 0;
+		$this->scriptEmitted = false;
+	}
+}

--- a/packages/visual-editor-renderer-blade/src/VisualEditorRendererBladeServiceProvider.php
+++ b/packages/visual-editor-renderer-blade/src/VisualEditorRendererBladeServiceProvider.php
@@ -23,6 +23,7 @@ use ArtisanPackUI\VisualEditor\Registries\DynamicBlockRegistry;
 use ArtisanPackUI\VisualEditor\Resources\TemplatePartInliner;
 use ArtisanPackUI\VisualEditorRendererBlade\Resolvers\SiteMetaResolver;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\GlobalStylesEmissionResolver;
+use ArtisanPackUI\VisualEditorRendererBlade\Services\NavigationOverlayTracker;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\ThemeJsonTokensCompiler;
 use ArtisanPackUI\VisualEditorRendererBlade\View\Components\BlocksComponent;
 use ArtisanPackUI\VisualEditorRendererBlade\View\Components\BlocksStylesComponent;
@@ -66,6 +67,14 @@ class VisualEditorRendererBladeServiceProvider extends ServiceProvider
 
 		$this->app->singleton( GlobalStylesEmissionResolver::class, function () {
 			return new GlobalStylesEmissionResolver();
+		} );
+
+		// Scoped so a long-lived worker doesn't carry overlay state
+		// across requests (Octane / queue). The tracker hands out
+		// per-request DOM ids and gates the inline overlay toggle
+		// script to fire at most once per response (Keystone #54).
+		$this->app->scoped( NavigationOverlayTracker::class, function () {
+			return new NavigationOverlayTracker();
 		} );
 	}
 

--- a/packages/visual-editor-renderer-blade/tests/Feature/BlocksComponentTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Feature/BlocksComponentTest.php
@@ -152,6 +152,125 @@ it( 'falls back to the legacy itemsJustification attribute when layout.justifyCo
 	expect( $rendered )->toContain( 'items-justified-center' );
 } );
 
+it( 'renders the overlay container + hamburger toggle by default (Keystone #54)', function () {
+	// `overlayMenu` defaults to "mobile" so a nav block authored
+	// without an explicit value still gets the responsive overlay
+	// scaffolding on the front-end. The bundled style.css's
+	// breakpoint media queries then collapse it on small screens.
+	$tree = [
+		[
+			'clientId'    => 'nav-1',
+			'name'        => 'core/navigation',
+			'attributes'  => [],
+			'innerBlocks' => [
+				[
+					'clientId'    => 'l-1',
+					'name'        => 'core/navigation-link',
+					'attributes'  => [ 'label' => 'Home', 'url' => '/' ],
+					'innerBlocks' => [],
+				],
+			],
+		],
+	];
+
+	app( \ArtisanPackUI\VisualEditorRendererBlade\Services\NavigationOverlayTracker::class )->reset();
+
+	$rendered = Blade::render( '<x-ve-blocks :tree="$tree" />', [ 'tree' => $tree ] );
+
+	expect( $rendered )
+		->toContain( 'wp-block-navigation__responsive-container-open' )
+		->and( $rendered )->toContain( 'wp-block-navigation__responsive-container' )
+		->and( $rendered )->toContain( 'wp-block-navigation__responsive-dialog' )
+		->and( $rendered )->toContain( 'wp-block-navigation__responsive-container-close' )
+		->and( $rendered )->toContain( 'data-ap-nav-overlay-open="ap-modal-nav-1"' )
+		->and( $rendered )->toContain( 'id="ap-modal-nav-1"' )
+		->and( $rendered )->toContain( 'aria-hidden="true"' )
+		->and( $rendered )->toContain( 'aria-modal="true"' )
+		->and( $rendered )->toContain( 'role="dialog"' )
+		// Inline toggle script emitted once.
+		->and( $rendered )->toContain( '__apNavOverlayInit' );
+} );
+
+it( 'adds the is-always-overlay class when overlayMenu is "always" (Keystone #54)', function () {
+	$tree = [
+		[
+			'clientId'    => 'nav-1',
+			'name'        => 'core/navigation',
+			'attributes'  => [ 'overlayMenu' => 'always' ],
+			'innerBlocks' => [],
+		],
+	];
+
+	app( \ArtisanPackUI\VisualEditorRendererBlade\Services\NavigationOverlayTracker::class )->reset();
+
+	$rendered = Blade::render( '<x-ve-blocks :tree="$tree" />', [ 'tree' => $tree ] );
+
+	expect( $rendered )
+		->toContain( 'is-always-overlay' )
+		->and( $rendered )->toContain( 'wp-block-navigation__responsive-container-open' );
+} );
+
+it( 'skips overlay scaffolding entirely when overlayMenu is "never" (Keystone #54)', function () {
+	$tree = [
+		[
+			'clientId'    => 'nav-1',
+			'name'        => 'core/navigation',
+			'attributes'  => [ 'overlayMenu' => 'never' ],
+			'innerBlocks' => [
+				[
+					'clientId'    => 'l-1',
+					'name'        => 'core/navigation-link',
+					'attributes'  => [ 'label' => 'Home', 'url' => '/' ],
+					'innerBlocks' => [],
+				],
+			],
+		],
+	];
+
+	app( \ArtisanPackUI\VisualEditorRendererBlade\Services\NavigationOverlayTracker::class )->reset();
+
+	$rendered = Blade::render( '<x-ve-blocks :tree="$tree" />', [ 'tree' => $tree ] );
+
+	expect( $rendered )
+		->not->toContain( 'wp-block-navigation__responsive-container' )
+		->and( $rendered )->not->toContain( 'wp-block-navigation__responsive-container-open' )
+		->and( $rendered )->not->toContain( '__apNavOverlayInit' )
+		// Inline `<ul>` still renders with the menu item.
+		->and( $rendered )->toContain( 'wp-block-navigation__container' )
+		->and( $rendered )->toContain( 'href="/"' )
+		->and( $rendered )->toContain( 'Home' );
+} );
+
+it( 'emits the overlay toggle script exactly once even with multiple nav blocks (Keystone #54)', function () {
+	// Two nav blocks on the same page get distinct overlay ids and
+	// share a single inline `<script>` — the tracker gates emission
+	// so the toggle controller only initializes once.
+	$tree = [
+		[
+			'clientId'    => 'nav-1',
+			'name'        => 'core/navigation',
+			'attributes'  => [],
+			'innerBlocks' => [],
+		],
+		[
+			'clientId'    => 'nav-2',
+			'name'        => 'core/navigation',
+			'attributes'  => [],
+			'innerBlocks' => [],
+		],
+	];
+
+	app( \ArtisanPackUI\VisualEditorRendererBlade\Services\NavigationOverlayTracker::class )->reset();
+
+	$rendered = Blade::render( '<x-ve-blocks :tree="$tree" />', [ 'tree' => $tree ] );
+
+	expect( substr_count( $rendered, 'data-ap-nav-overlay-open="ap-modal-nav-1"' ) )->toBe( 1 );
+	expect( substr_count( $rendered, 'data-ap-nav-overlay-open="ap-modal-nav-2"' ) )->toBe( 1 );
+	// One `<script>` block regardless of how many nav blocks fired —
+	// the comment marker is unique to the controller header.
+	expect( substr_count( $rendered, 'Keystone #54 — nav overlay toggle' ) )->toBe( 1 );
+} );
+
 it( 'preserves authored innerBlocks on a nav block instead of overwriting them (Keystone #51)', function () {
 	// A nav block authored with explicit nav-links keeps them — the
 	// resolver only projects menu items when the tree is empty.

--- a/packages/visual-editor-renderer-blade/tests/Feature/BlocksComponentTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Feature/BlocksComponentTest.php
@@ -241,6 +241,54 @@ it( 'skips overlay scaffolding entirely when overlayMenu is "never" (Keystone #5
 		->and( $rendered )->toContain( 'Home' );
 } );
 
+it( 'applies overlayBackgroundColor + overlayTextColor presets to the responsive container (Keystone #54)', function () {
+	$tree = [
+		[
+			'clientId'    => 'nav-1',
+			'name'        => 'core/navigation',
+			'attributes'  => [
+				'overlayBackgroundColor' => 'page',
+				'overlayTextColor'       => 'accent',
+			],
+			'innerBlocks' => [],
+		],
+	];
+
+	app( \ArtisanPackUI\VisualEditorRendererBlade\Services\NavigationOverlayTracker::class )->reset();
+
+	$rendered = Blade::render( '<x-ve-blocks :tree="$tree" />', [ 'tree' => $tree ] );
+
+	// Overlay container picks up the preset classes — bound to
+	// `.has-{slug}-*` rules by cms-framework's emitter (Keystone #53).
+	expect( $rendered )
+		->toMatch( '/<div class="[^"]*has-page-background-color[^"]*has-background[^"]*"[^>]*id="ap-modal-nav-1"/' )
+		->and( $rendered )->toContain( 'has-accent-color' )
+		->and( $rendered )->toContain( 'has-text-color' );
+} );
+
+it( 'applies customOverlayBackgroundColor + customOverlayTextColor as inline styles on the responsive container (Keystone #54)', function () {
+	$tree = [
+		[
+			'clientId'    => 'nav-1',
+			'name'        => 'core/navigation',
+			'attributes'  => [
+				'customOverlayBackgroundColor' => '#0a0606',
+				'customOverlayTextColor'       => '#ffffff',
+			],
+			'innerBlocks' => [],
+		],
+	];
+
+	app( \ArtisanPackUI\VisualEditorRendererBlade\Services\NavigationOverlayTracker::class )->reset();
+
+	$rendered = Blade::render( '<x-ve-blocks :tree="$tree" />', [ 'tree' => $tree ] );
+
+	// Inline style wins over the bundled `background-color: inherit`
+	// rule — overlay no longer inherits the parent nav's color.
+	expect( $rendered )
+		->toMatch( '/<div class="[^"]*wp-block-navigation__responsive-container[^"]*"[^>]*id="ap-modal-nav-1"[^>]*style="background-color: #0a0606; color: #ffffff"/' );
+} );
+
 it( 'emits the overlay toggle script exactly once even with multiple nav blocks (Keystone #54)', function () {
 	// Two nav blocks on the same page get distinct overlay ids and
 	// share a single inline `<script>` — the tracker gates emission

--- a/packages/visual-editor-renderer-blade/tests/Feature/BlocksComponentTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Feature/BlocksComponentTest.php
@@ -191,6 +191,36 @@ it( 'renders the overlay container + hamburger toggle by default (Keystone #54)'
 		->and( $rendered )->toContain( '__apNavOverlayInit' );
 } );
 
+it( 'distinguishes the backdrop wrapper from the close button so link clicks inside the dialog navigate (CodeRabbit follow-up on #54)', function () {
+	// Backdrop carries `data-ap-nav-overlay-backdrop`, close button
+	// carries `data-ap-nav-overlay-close`. The JS handler only
+	// treats backdrop clicks as close when the click target IS the
+	// backdrop (not a descendant). Without this split a menu-link
+	// click inside the dialog bubbles up to the backdrop, matches
+	// `closest("[data-ap-nav-overlay-close]")`, and `preventDefault`
+	// cancels the link navigation.
+	$tree = [
+		[
+			'clientId'    => 'nav-1',
+			'name'        => 'core/navigation',
+			'attributes'  => [],
+			'innerBlocks' => [],
+		],
+	];
+
+	app( \ArtisanPackUI\VisualEditorRendererBlade\Services\NavigationOverlayTracker::class )->reset();
+
+	$rendered = Blade::render( '<x-ve-blocks :tree="$tree" />', [ 'tree' => $tree ] );
+
+	// Backdrop wrapper — close-on-self only.
+	expect( $rendered )->toMatch( '/<div class="wp-block-navigation__responsive-close"[^>]*data-ap-nav-overlay-backdrop/' );
+	// Close button — intentional close trigger.
+	expect( $rendered )->toMatch( '/<button[^>]+class="wp-block-navigation__responsive-container-close"[^>]+data-ap-nav-overlay-close/' );
+	// Backdrop does NOT carry data-ap-nav-overlay-close — would
+	// re-introduce the bubbling-click-cancels-link bug.
+	expect( $rendered )->not->toMatch( '/<div class="wp-block-navigation__responsive-close"[^>]*data-ap-nav-overlay-close/' );
+} );
+
 it( 'adds the is-always-overlay class when overlayMenu is "always" (Keystone #54)', function () {
 	$tree = [
 		[


### PR DESCRIPTION
Closes [Keystone #54](https://gitlab.com/jacob-martella-web-design/jacob-martella-web-design/jmwd-keystone-cms/jmwd-keystone-cms/-/work_items/54).

## The bug

The editor canvas wrapped a \`core/navigation\` block in a responsive container with a hamburger toggle so the menu collapsed below the breakpoint per the \`overlayMenu\` attribute. Renderer-blade only emitted the bare inline \`<nav><ul>\` — at every viewport the menu rendered every item inline, ignoring \`overlayMenu\` entirely.

Renderer-blade's bundled style.css already ships the responsive-container visual rules (breakpoint media queries, \`is-menu-open\` transitions, slide-in animation), so the visual half came for free once the structural markup arrived. The work was the markup + a tiny toggle controller + four targeted CSS fix-ups for gaps in the bundled rules.

## What ships

### Overlay markup

\`navigation.blade.php\` now emits the hamburger button + responsive container + dialog wrapper when \`overlayMenu\` is \`mobile\` (default) or \`always\`. \`overlayMenu: \"never\"\` keeps the bare inline \`<ul>\` for the always-inline case. \`overlayMenu: \"always\"\` adds the \`is-always-overlay\` class so the bundled CSS shows the hamburger at every viewport.

### Per-request overlay ids

New \`NavigationOverlayTracker\` service (scoped via \`$this->app->scoped()\` so a long-lived worker doesn't carry counter state across requests). \`nextOverlayId()\` hands out \`ap-modal-nav-{n}\` ids so multiple nav blocks on the same page don't collide on selectors.

### Inline toggle JS

~30-line controller handles click-to-open, click-on-close-button (and the backdrop-click variant via \`data-ap-nav-overlay-close\`), \`Escape\` keydown, focus restoration on close, and scroll-lock while open. Emitted at most once per response via the same tracker's \`hasEmittedScript()\` flag.

### Overlay-specific color attrs

The nav block ships a parallel \`overlayTextColor\` / \`overlayBackgroundColor\` (preset slugs) + \`customOverlay*Color\` (hex) family that targets the responsive container, NOT the inline nav. Without this the open overlay inherited the inline nav's colors — a red nav rendered a red overlay even when the author picked a dark overlay bg. The blade view now reads all four attrs, with preset slugs winning over custom hex when both are present (mirrors WP core's nav block serializer).

### CSS fix-ups for bundled-rule gaps

Two issues surfaced once the overlay rendered live; both are gaps in the bundled package CSS (which we don't own), so renderer-blade emits a small one-shot \`<style>\` block alongside the toggle script to patch them:

- **Items rendered flush right.** Bundled rules set \`align-items: var(--navigation-layout-justification-setting)\` on the \`<ul>\` / each \`<li>\` / the page-list inside \`is-menu-open\` (4-class selector). When the parent nav has \`items-justified-right\`, the var resolves to \`flex-end\` and items pack to the right of the column-direction overlay. Override the vars on \`.is-menu-open\` directly — var cascade beats specificity matching because the bundled rules just READ the var; setting it on the open container wins for the container's subtree.

- **No padding around items.** Bundled \`padding: clamp(1rem, var(--wp--style--root--padding-*), 20rem)\` uses a var WITHOUT a fallback. When undefined (cms-framework's emitter doesn't ship those vars from theme.json yet), the whole \`clamp()\` evaluates to invalid → declaration dropped → padding 0. Seeded the vars on \`.is-menu-open\` with 1.5rem so the bundled clamp resolves to its minimum.

## Tests

6 new BlocksComponent Testbench tests cover:

- Default (\`overlayMenu: mobile\`) renders full overlay scaffolding + inline script
- \`overlayMenu: always\` adds the \`is-always-overlay\` class
- \`overlayMenu: never\` falls back to the inline \`<ul>\` (no script, no container)
- Two nav blocks on the same page → distinct overlay ids + single script emission
- \`overlayBackgroundColor\` / \`overlayTextColor\` preset slugs add the right classes
- \`customOverlayBackgroundColor\` / \`customOverlayTextColor\` hex values emit inline styles

607/607 PHP green.

## Manual verification

- Desktop viewport: nav renders inline, hamburger hidden by the bundled breakpoint media query.
- Mobile viewport: hamburger appears in the right corner, click opens the overlay full-screen.
- Inside the overlay: items stack vertically full-width with 1.5rem padding, dark background, accent-colored text (overlay color attrs applied).
- ESC or × button closes the overlay; focus returns to the hamburger; body scroll unlocks.

## Out of scope — known gaps

- The bundled padding clamp could be fixed properly by having cms-framework's emitter ship \`--wp--style--root--padding-*\` from theme.json's \`styles.spacing.padding\`. The 1.5rem seed here is the bandage; the proper fix is a separate emitter improvement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Navigation blocks now support responsive overlay/hamburger mode with modal dialog toggling, focus management, and Escape-to-close.
  * Overlay supports preset or custom text/background colors with class or inline style fallbacks.
  * Page scroll is locked while overlay is open; ARIA attributes update for accessibility.

* **Tests**
  * Added feature tests covering overlay scaffolding, color handling, single-script initialization, and multi-navigation IDs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArtisanPack-UI/visual-editor/pull/463?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->