### PR TITLE
fix(site-editor): make Gutenberg Create Overlay land cleanly + navigate to the new part (Keystone #55)

### DIFF
--- a/resources/js/visual-editor/site-editor/__tests__/block-editor-boundary.test.tsx
+++ b/resources/js/visual-editor/site-editor/__tests__/block-editor-boundary.test.tsx
@@ -155,6 +155,65 @@ describe('BlockEditorBoundary', () => {
         expect(settings.styles[1]?.css).toBe(themeCss);
     });
 
+    it('exposes onNavigateToEntityRecord on the provider settings so the Create Overlay flow can switch the canvas (Keystone #55)', () => {
+        LATEST_SETTINGS.value = null;
+
+        render(
+            <BlockEditorBoundary
+                blocks={[]}
+                onChange={() => undefined}
+                onInput={() => undefined}
+                themeGlobalStylesCss=""
+            >
+                <div data-testid="canvas-slot" />
+            </BlockEditorBoundary>
+        );
+
+        const settings = LATEST_SETTINGS.value as {
+            onNavigateToEntityRecord?: (target: {
+                postId: string | number;
+                postType: string;
+            }) => void;
+        };
+
+        expect(typeof settings.onNavigateToEntityRecord).toBe('function');
+    });
+
+    it('honors a host-provided onNavigateToEntityRecord override instead of the default URL handler (Keystone #55)', () => {
+        LATEST_SETTINGS.value = null;
+        const hostHandler = vi.fn();
+
+        render(
+            <BlockEditorBoundary
+                blocks={[]}
+                onChange={() => undefined}
+                onInput={() => undefined}
+                themeGlobalStylesCss=""
+                onNavigateToEntityRecord={hostHandler}
+            >
+                <div data-testid="canvas-slot" />
+            </BlockEditorBoundary>
+        );
+
+        const settings = LATEST_SETTINGS.value as {
+            onNavigateToEntityRecord?: (target: {
+                postId: string | number;
+                postType: string;
+            }) => void;
+        };
+
+        settings.onNavigateToEntityRecord?.({
+            postId: 'jmwd-default//navigation-overlay',
+            postType: 'wp_template_part',
+        });
+
+        expect(hostHandler).toHaveBeenCalledTimes(1);
+        expect(hostHandler).toHaveBeenCalledWith({
+            postId: 'jmwd-default//navigation-overlay',
+            postType: 'wp_template_part',
+        });
+    });
+
     it('mounts the convert-to-pattern control when an apiBase is given', async () => {
         CONVERT_TO_PATTERN_CONTROL_MOCK.mockClear();
         resetThemeGlobalStylesCssCache();

--- a/resources/js/visual-editor/site-editor/block-editor-boundary.tsx
+++ b/resources/js/visual-editor/site-editor/block-editor-boundary.tsx
@@ -26,6 +26,7 @@ import {
     BlockEditorProvider,
 } from '@wordpress/block-editor';
 import { Popover, SlotFillProvider } from '@wordpress/components';
+import { select as wpSelect } from '@wordpress/data';
 import { useMemo } from 'react';
 // `@wordpress/format-library` is a side-effect import: it registers the
 // core rich-text formats (bold, italic, link, …) so the block toolbar's
@@ -129,14 +130,6 @@ export function BlockEditorBoundary(props: BlockEditorBoundaryProps): JSX.Elemen
                 return;
             }
 
-            // `postId` for template-parts arrives as a composite
-            // `{theme}//{slug}` from the block library — encode each
-            // segment so the slug part survives URL routing. We hand
-            // the composite to the SPA's existing template-parts route
-            // (`/admin/site-editor/template-parts/{path?}`); the
-            // host's site-editor controller serves the same shell for
-            // every sub-path and the SPA's client-side router takes
-            // over from there.
             const postType = target.postType ?? '';
             const segment =
                 postType === 'wp_template_part'
@@ -149,17 +142,23 @@ export function BlockEditorBoundary(props: BlockEditorBoundaryProps): JSX.Elemen
                 return;
             }
 
-            const rawId =
-                typeof target.postId === 'number'
-                    ? String(target.postId)
-                    : target.postId;
-            const id = encodeURIComponent(rawId);
+            // `postId` arrives from Gutenberg as a composite
+            // `{theme}//{slug}` string. Hosts route by the entity's
+            // numeric DB id (e.g., `/template-parts/9`), so look the
+            // record up in our entity store and prefer its `id` field
+            // when one is set (`TemplatePartAdapter` ships
+            // `id = wpId` for DB-backed rows). Falls back to the raw
+            // composite when no record is cached — keeps the call
+            // testable and gives standalone installs a deterministic
+            // URL even without the entity registry warm.
+            const navigationId = resolveNavigationId(target.postId, postType);
 
             // Resolve the route base from the editor mount's
-            // `data-route-base` attribute (the host's blade override
-            // sets this to `/admin/site-editor`). Fall back to a
-            // sensible default so a standalone install still navigates
-            // somewhere.
+            // `data-route-base` attribute. Fall back to
+            // `/visual-editor/site` so a standalone install still
+            // navigates somewhere. Hosts that mount under a different
+            // admin shell (Keystone CMS: `/admin/site-editor`) set the
+            // attribute on their mount node.
             const mount = document.querySelector(
                 '[data-ap-visual-editor][data-route-base]'
             );
@@ -167,7 +166,7 @@ export function BlockEditorBoundary(props: BlockEditorBoundaryProps): JSX.Elemen
                 mount?.getAttribute('data-route-base') ??
                 '/visual-editor/site';
 
-            window.location.assign(`${routeBase}/${segment}/${id}`);
+            window.location.assign(`${routeBase}/${segment}/${navigationId}`);
         };
     }, [onNavigateToEntityRecord]);
 
@@ -292,6 +291,57 @@ interface GradientEntry {
     slug: string;
     name: string;
     gradient: string;
+}
+
+/**
+ * Resolve the URL-safe id for a navigation target. Gutenberg's
+ * Create Overlay (and similar) hands the composite `{theme}//{slug}`
+ * id its block-library uses internally, but hosts route by the
+ * entity's numeric DB id (`/template-parts/9`). Look the record up
+ * in `@wordpress/data`'s `'core'` store (our shim) and prefer its
+ * `id` field — for DB-backed rows {@see TemplatePartAdapter} sets
+ * `id = wpId`, so the lookup returns the numeric primary key.
+ *
+ * Falls back to the raw composite when no record is cached — keeps
+ * the helper testable and gives standalone installs a deterministic
+ * URL even before the entity registry warms up.
+ *
+ * @since 1.1.0
+ */
+function resolveNavigationId(
+    postId: number | string,
+    postType: string,
+): string {
+    const composite = typeof postId === 'number' ? String(postId) : postId;
+
+    try {
+        const store = wpSelect( 'core' ) as
+            | {
+                  getEntityRecord?: (
+                      kind: string,
+                      name: string,
+                      id: number | string,
+                  ) => { id?: number | string } | null;
+              }
+            | undefined;
+
+        const record = store?.getEntityRecord?.(
+            'postType',
+            postType,
+            composite,
+        );
+        const resolved = record?.id;
+
+        if (typeof resolved === 'number' || typeof resolved === 'string') {
+            return encodeURIComponent(String(resolved));
+        }
+    } catch {
+        // Defensive — `@wordpress/data` might not have our store
+        // registered in some test contexts. Fall back to the raw
+        // composite below so navigation still produces a URL.
+    }
+
+    return encodeURIComponent(composite);
 }
 
 /**

--- a/resources/js/visual-editor/site-editor/block-editor-boundary.tsx
+++ b/resources/js/visual-editor/site-editor/block-editor-boundary.tsx
@@ -69,6 +69,18 @@ export interface BlockEditorBoundaryProps {
      */
     themeGlobalStylesCss?: string;
     /**
+     * Optional canvas-navigation callback. Some block-library actions
+     * (notably `core/navigation`'s Create Overlay flow) ask the editor
+     * to focus a freshly-created entity record by calling this hook
+     * with `{ postId, postType }`. The boundary forwards the callback
+     * into `BlockEditorProvider`'s `settings.onNavigateToEntityRecord`
+     * slot — without it, those flows succeed server-side but the
+     * editor shows no feedback. When the prop is omitted, the
+     * boundary installs a sensible default that swaps the SPA URL to
+     * `{routeBase}/template-parts/{slug-or-id}` (Keystone #55).
+     */
+    onNavigateToEntityRecord?: (target: NavigateToEntityRecordTarget) => void;
+    /**
      * Canvas and inspector slots. Both must be rendered as children so
      * they share this boundary's `core/block-editor` registry — even
      * when a section portals them into separate DOM nodes.
@@ -76,8 +88,88 @@ export interface BlockEditorBoundaryProps {
     children: ReactNode;
 }
 
+/**
+ * Shape `core/navigation`'s Create Overlay action (and any similar
+ * block-library flow) passes to {@see BlockEditorBoundaryProps.onNavigateToEntityRecord}.
+ *
+ * `postId` is a composite `{theme}//{slug}` id minted by the block
+ * library — that's the same shape our `getEntityRecord` resolver
+ * already understands (see `core-data-shim` composite-id handling).
+ */
+export interface NavigateToEntityRecordTarget {
+    postId: number | string;
+    postType: string;
+    viewport?: string;
+}
+
 export function BlockEditorBoundary(props: BlockEditorBoundaryProps): JSX.Element {
-    const { blocks, onChange, onInput, apiBase, themeGlobalStylesCss, children } = props;
+    const {
+        blocks,
+        onChange,
+        onInput,
+        apiBase,
+        themeGlobalStylesCss,
+        onNavigateToEntityRecord,
+        children,
+    } = props;
+
+    // Default canvas-navigation handler — swaps the SPA URL when a
+    // block-library action asks us to focus a freshly-created entity.
+    // The host can pass an explicit `onNavigateToEntityRecord` to
+    // intercept (e.g., a router-aware push); when omitted, the boundary
+    // installs this fallback so flows like Create Overlay don't no-op
+    // (Keystone #55).
+    const navigateToEntityRecord = useMemo(() => {
+        if (onNavigateToEntityRecord !== undefined) {
+            return onNavigateToEntityRecord;
+        }
+
+        return (target: NavigateToEntityRecordTarget): void => {
+            if (typeof window === 'undefined') {
+                return;
+            }
+
+            // `postId` for template-parts arrives as a composite
+            // `{theme}//{slug}` from the block library — encode each
+            // segment so the slug part survives URL routing. We hand
+            // the composite to the SPA's existing template-parts route
+            // (`/admin/site-editor/template-parts/{path?}`); the
+            // host's site-editor controller serves the same shell for
+            // every sub-path and the SPA's client-side router takes
+            // over from there.
+            const postType = target.postType ?? '';
+            const segment =
+                postType === 'wp_template_part'
+                    ? 'template-parts'
+                    : postType === 'wp_template'
+                      ? 'templates'
+                      : '';
+
+            if (segment === '') {
+                return;
+            }
+
+            const rawId =
+                typeof target.postId === 'number'
+                    ? String(target.postId)
+                    : target.postId;
+            const id = encodeURIComponent(rawId);
+
+            // Resolve the route base from the editor mount's
+            // `data-route-base` attribute (the host's blade override
+            // sets this to `/admin/site-editor`). Fall back to a
+            // sensible default so a standalone install still navigates
+            // somewhere.
+            const mount = document.querySelector(
+                '[data-ap-visual-editor][data-route-base]'
+            );
+            const routeBase =
+                mount?.getAttribute('data-route-base') ??
+                '/visual-editor/site';
+
+            window.location.assign(`${routeBase}/${segment}/${id}`);
+        };
+    }, [onNavigateToEntityRecord]);
 
     // Tests can short-circuit the network by passing a string directly;
     // production drives the value through the hook keyed on `apiBase`.
@@ -113,7 +205,10 @@ export function BlockEditorBoundary(props: BlockEditorBoundaryProps): JSX.Elemen
         const needsGradients = themeGradients !== null;
 
         if (!needsStyles && !needsPalette && !needsFontSizes && !needsGradients) {
-            return editorSettings;
+            return {
+                ...editorSettings,
+                onNavigateToEntityRecord: navigateToEntityRecord,
+            };
         }
 
         const nextStyles = needsStyles
@@ -128,6 +223,7 @@ export function BlockEditorBoundary(props: BlockEditorBoundaryProps): JSX.Elemen
         return {
             ...editorSettings,
             styles: nextStyles,
+            onNavigateToEntityRecord: navigateToEntityRecord,
             // Mirror onto the legacy top-level keys too so older
             // blocks that still read `settings.colors` / `fontSizes`
             // pick up the theme's slugs.
@@ -160,7 +256,7 @@ export function BlockEditorBoundary(props: BlockEditorBoundaryProps): JSX.Elemen
                     : baseTypography,
             },
         };
-    }, [themeCss, themeBase]);
+    }, [themeCss, themeBase, navigateToEntityRecord]);
 
     return (
         <SlotFillProvider>

--- a/resources/js/visual-editor/site-editor/block-editor-boundary.tsx
+++ b/resources/js/visual-editor/site-editor/block-editor-boundary.tsx
@@ -154,19 +154,35 @@ export function BlockEditorBoundary(props: BlockEditorBoundaryProps): JSX.Elemen
             const navigationId = resolveNavigationId(target.postId, postType);
 
             // Resolve the route base from the editor mount's
-            // `data-route-base` attribute. Fall back to
-            // `/visual-editor/site` so a standalone install still
-            // navigates somewhere. Hosts that mount under a different
-            // admin shell (Keystone CMS: `/admin/site-editor`) set the
-            // attribute on their mount node.
+            // `data-route-base` attribute. The Keystone CMS host
+            // sets `data-ap-site-editor` on its mount; standalone
+            // installs use `data-ap-visual-editor`. Match either so
+            // we don't have to know which host we're embedded in.
             const mount = document.querySelector(
-                '[data-ap-visual-editor][data-route-base]'
+                '[data-ap-site-editor][data-route-base], [data-ap-visual-editor][data-route-base]'
             );
             const routeBase =
                 mount?.getAttribute('data-route-base') ??
                 '/visual-editor/site';
 
-            window.location.assign(`${routeBase}/${segment}/${navigationId}`);
+            const targetPath = `${routeBase}/${segment}/${navigationId}`;
+
+            // Client-side navigation: the SPA's own routing hook
+            // (`useSiteEditorRouting`) listens for `popstate` and
+            // re-parses `window.location.pathname` on every event.
+            // Push the new URL onto history and synthesize a popstate
+            // so the listener fires. A full `window.location.assign`
+            // also works but boots the SPA fresh, and the user reported
+            // hydration glitches (canvas briefly stuck on the previous
+            // section's "select a record" placeholder) when navigating
+            // across sections programmatically. PushState avoids the
+            // remount entirely (Keystone #55).
+            if (window.location.pathname === targetPath) {
+                return;
+            }
+
+            window.history.pushState({ segment, navigationId }, '', targetPath);
+            window.dispatchEvent(new PopStateEvent('popstate'));
         };
     }, [onNavigateToEntityRecord]);
 

--- a/src/Http/Controllers/SiteEditor/TemplatePartController.php
+++ b/src/Http/Controllers/SiteEditor/TemplatePartController.php
@@ -165,6 +165,29 @@ class TemplatePartController extends Controller
 			$part = $model::create( $this->modelAttributesFromRequest( $validated ) );
 		} catch ( QueryException $e ) {
 			if ( $this->isUniqueViolation( $e ) ) {
+				// Race-safe idempotency. The pre-check above catches the
+				// common case, but two concurrent Create Overlay clicks
+				// (or any duplicate POST) can both clear the pre-check
+				// and one of them collides on insert. Re-fetch the
+				// existing row and return the same 200 envelope the
+				// pre-check path would have surfaced (Keystone #55).
+				$existing = $model::query()
+					->where( 'theme', $validated['theme'] )
+					->where( 'slug', (string) ( $validated['slug'] ?? '' ) )
+					->first();
+
+				if ( null !== $existing ) {
+					$this->refreshResolver();
+					$resolved = $this->resolver->find( (string) $existing->slug );
+
+					if ( $resolved instanceof ResolvedTemplatePart ) {
+						return response()->json(
+							( new TemplatePartAdapter() )->toArray( $resolved ),
+							Response::HTTP_OK,
+						);
+					}
+				}
+
 				return response()->json( [
 					'message' => 'A template part with this slug already exists for the active theme.',
 					'errors'  => [ 'slug' => [ 'Slug must be unique within the theme.' ] ],

--- a/src/Http/Controllers/SiteEditor/TemplatePartController.php
+++ b/src/Http/Controllers/SiteEditor/TemplatePartController.php
@@ -124,11 +124,41 @@ class TemplatePartController extends Controller
 		// installs with no ThemeManager bound. Mirrors the theme
 		// inference applied to update()/destroy() in #438.
 		//
-		// `StoreTemplatePartRequest` requires `theme`, so the fallback
-		// is always a non-empty string — no empty-theme guard needed.
-		$validated['theme'] = $this->activeThemeSlug() ?? $validated['theme'];
+		// `theme` is `sometimes` on the request (Keystone #55 —
+		// Gutenberg's Create Overlay action POSTs without it), so we
+		// have to guard the empty-string case before write.
+		$validated['theme'] = $this->activeThemeSlug() ?? ( $validated['theme'] ?? '' );
+
+		if ( '' === $validated['theme'] ) {
+			return response()->json( [
+				'message' => 'The theme field is required when no theme is active.',
+				'errors'  => [ 'theme' => [ 'The theme field is required when no theme is active.' ] ],
+			], Response::HTTP_UNPROCESSABLE_ENTITY );
+		}
 
 		$model = self::CMS_TEMPLATE_PART_FQCN;
+
+		// Idempotency for Gutenberg's Create Overlay action — re-clicking
+		// the same nav block should NOT 409. Check for an existing
+		// (theme, slug) row first and hand it back with 200 instead.
+		// Mirrors WP core's REST behavior for re-creating identical
+		// parts (Keystone #55).
+		$existing = $model::query()
+			->where( 'theme', $validated['theme'] )
+			->where( 'slug', (string) ( $validated['slug'] ?? '' ) )
+			->first();
+
+		if ( null !== $existing ) {
+			$this->refreshResolver();
+			$resolved = $this->resolver->find( (string) $existing->slug );
+
+			if ( $resolved instanceof ResolvedTemplatePart ) {
+				return response()->json(
+					( new TemplatePartAdapter() )->toArray( $resolved ),
+					Response::HTTP_OK,
+				);
+			}
+		}
 
 		try {
 			/** @var object $part */

--- a/src/Http/Requests/SiteEditor/ContentShapeRule.php
+++ b/src/Http/Requests/SiteEditor/ContentShapeRule.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * Polymorphic validator for the `content` field on
+ * `wp_template`-shape REST payloads.
+ *
+ * Accepts:
+ *
+ *   - `null` (empty body — happens when Laravel's
+ *     `ConvertEmptyStringsToNull` middleware normalizes
+ *     `content: ""` into `null`).
+ *   - `string` — Gutenberg's default save path serializes a block
+ *     tree into a `content` string (`<!-- wp:foo --><p>x</p><!-- /wp:foo -->`).
+ *     The store-side controller(s) parse it or pass it through.
+ *   - `array { raw?, blocks? }` — the custom save path that ships
+ *     both the serialized markup AND the parsed tree.
+ *
+ * Rejects everything else.
+ *
+ * Used by both {@see UpdateMenuRequest} (#48 round-trip path) and
+ * {@see StoreTemplatePartRequest} (#55 — Gutenberg's Create Overlay
+ * POSTs `content` as a string when first creating an overlay
+ * template part).
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.1.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Http\Requests\SiteEditor;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+
+final class ContentShapeRule implements ValidationRule
+{
+	public function validate( string $attribute, mixed $value, Closure $fail ): void
+	{
+		if ( null === $value || is_string( $value ) || is_array( $value ) ) {
+			return;
+		}
+
+		$fail( 'The :attribute field must be a string or an object.' );
+	}
+}

--- a/src/Http/Requests/SiteEditor/StoreTemplatePartRequest.php
+++ b/src/Http/Requests/SiteEditor/StoreTemplatePartRequest.php
@@ -23,7 +23,6 @@ namespace ArtisanPackUI\VisualEditor\Http\Requests\SiteEditor;
 
 use ArtisanPackUI\VisualEditor\Rules\TemplateBlockTreeRule;
 use ArtisanPackUI\VisualEditor\SiteEditor\Resolution\ResolvedTemplatePart;
-use Closure;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
@@ -45,9 +44,18 @@ class StoreTemplatePartRequest extends FormRequest
 			'slug'           => [ 'required', 'string', 'max:191' ],
 			'title'          => [ 'sometimes', 'string', 'max:255' ],
 			'description'    => [ 'nullable', 'string' ],
-			'content'        => [ 'nullable', 'array', $this->envelopeShapeRule() ],
-			'content.raw'    => [ 'nullable', 'string' ],
-			'content.blocks' => [ 'nullable', 'array', new TemplateBlockTreeRule() ],
+			// `content` arrives in two shapes:
+			//  - String: Gutenberg's default save path (e.g., Create
+			//    Overlay on `core/navigation`) serializes the
+			//    block tree into a `content` string. Keystone #55.
+			//  - Array `{ raw?, blocks? }`: the custom save path
+			//    that ships both the serialized markup AND the
+			//    parsed tree.
+			// Mirrors the polymorphic acceptance already in
+			// {@see UpdateMenuRequest::rules()}.
+			'content'        => [ 'sometimes', new ContentShapeRule() ],
+			'content.raw'    => [ 'sometimes', 'nullable', 'string' ],
+			'content.blocks' => [ 'sometimes', 'nullable', 'array', new TemplateBlockTreeRule() ],
 			'area'           => [ 'required', 'string', Rule::in( ResolvedTemplatePart::AREAS ) ],
 			// `theme` is optional on the request — Gutenberg's Create
 			// Overlay action POSTs without it. The controller falls back
@@ -70,17 +78,5 @@ class StoreTemplatePartRequest extends FormRequest
 		return [
 			'area.in' => 'The area must be one of: ' . implode( ', ', ResolvedTemplatePart::AREAS ) . '.',
 		];
-	}
-
-	/**
-	 * @since 1.0.0
-	 */
-	protected function envelopeShapeRule(): Closure
-	{
-		return function ( string $attribute, mixed $value, Closure $fail ): void {
-			if ( is_array( $value ) && [] !== $value && array_is_list( $value ) ) {
-				$fail( 'The :attribute must be a { raw, blocks } envelope, not a bare list of blocks.' );
-			}
-		};
 	}
 }

--- a/src/Http/Requests/SiteEditor/StoreTemplatePartRequest.php
+++ b/src/Http/Requests/SiteEditor/StoreTemplatePartRequest.php
@@ -49,7 +49,13 @@ class StoreTemplatePartRequest extends FormRequest
 			'content.raw'    => [ 'nullable', 'string' ],
 			'content.blocks' => [ 'nullable', 'array', new TemplateBlockTreeRule() ],
 			'area'           => [ 'required', 'string', Rule::in( ResolvedTemplatePart::AREAS ) ],
-			'theme'          => [ 'required', 'string', 'max:191' ],
+			// `theme` is optional on the request — Gutenberg's Create
+			// Overlay action POSTs without it. The controller falls back
+			// to the active theme via `ThemeManager::getActiveTheme()`
+			// when the field is missing, so a host with cms-framework
+			// integrated always lands with a non-empty theme on the row
+			// (Keystone #55).
+			'theme'          => [ 'sometimes', 'string', 'max:191' ],
 			'is_custom'      => [ 'sometimes', 'boolean' ],
 		];
 	}

--- a/src/Http/Requests/SiteEditor/UpdateMenuRequest.php
+++ b/src/Http/Requests/SiteEditor/UpdateMenuRequest.php
@@ -18,34 +18,7 @@ declare( strict_types=1 );
 
 namespace ArtisanPackUI\VisualEditor\Http\Requests\SiteEditor;
 
-use Closure;
-use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
-
-/**
- * Polymorphic shape validator for the `content` field. Gutenberg's
- * default save path serializes the navigation block tree into a
- * string (the WP-REST default for `wp_navigation`); the #440 custom
- * save path sends an object `{ raw?, blocks? }`. Accept both, reject
- * everything else.
- */
-final class ContentShapeRule implements ValidationRule
-{
-	public function validate( string $attribute, mixed $value, Closure $fail ): void
-	{
-		// `null` happens when Laravel's `ConvertEmptyStringsToNull`
-		// middleware normalizes an authored `content: ""` (which
-		// Gutenberg sends when the user clears every item) into
-		// `null`. Treat it as "empty content" — same semantic as
-		// `content.blocks: []` — and let the controller wipe the
-		// items.
-		if ( null === $value || is_string( $value ) || is_array( $value ) ) {
-			return;
-		}
-
-		$fail( 'The :attribute field must be a string or an object.' );
-	}
-}
 
 class UpdateMenuRequest extends FormRequest
 {

--- a/src/SiteEditor/Resolution/ResolvedTemplatePart.php
+++ b/src/SiteEditor/Resolution/ResolvedTemplatePart.php
@@ -34,7 +34,7 @@ class ResolvedTemplatePart extends ResolvedTemplate
 	 *
 	 * @since 1.0.0
 	 */
-	public const AREAS = [ 'header', 'footer', 'sidebar', 'uncategorized' ];
+	public const AREAS = [ 'header', 'footer', 'sidebar', 'uncategorized', 'navigation-overlay' ];
 
 	/**
 	 * @since 1.0.0

--- a/src/SiteEditor/Resolution/ResolvedTemplatePart.php
+++ b/src/SiteEditor/Resolution/ResolvedTemplatePart.php
@@ -84,6 +84,17 @@ class ResolvedTemplatePart extends ResolvedTemplate
 		$slug = self::requireString( $data, 'slug' );
 		$area = self::requireString( $data, 'area', $slug );
 
+		// Back-compat for rows persisted under the pre-#55 enum, when
+		// the catch-all area was `general` instead of WP core's
+		// `uncategorized` (Keystone #55). The live host DB scan
+		// before the rename found zero `general` rows, but downstream
+		// consumers may have older data. Map the legacy value forward
+		// so old rows continue to resolve cleanly without a
+		// schema-side migration.
+		if ( 'general' === $area ) {
+			$area = 'uncategorized';
+		}
+
 		if ( ! in_array( $area, self::AREAS, true ) ) {
 			throw SiteEditorRegistrationException::invalidField(
 				static::FILTER_NAME,

--- a/src/SiteEditor/Resolution/ResolvedTemplatePart.php
+++ b/src/SiteEditor/Resolution/ResolvedTemplatePart.php
@@ -34,7 +34,7 @@ class ResolvedTemplatePart extends ResolvedTemplate
 	 *
 	 * @since 1.0.0
 	 */
-	public const AREAS = [ 'header', 'footer', 'sidebar', 'general' ];
+	public const AREAS = [ 'header', 'footer', 'sidebar', 'uncategorized' ];
 
 	/**
 	 * @since 1.0.0

--- a/tests/Feature/SiteEditor/TemplatePartControllerTest.php
+++ b/tests/Feature/SiteEditor/TemplatePartControllerTest.php
@@ -251,6 +251,30 @@ describe( 'POST /visual-editor/api/template-parts', function (): void {
 		expect( TemplatePart::query()->where( 'slug', 'header' )->count() )->toBe( 1 );
 	} );
 
+	it( 'accepts the exact payload Gutenberg posts for Create Overlay (Keystone #55)', function (): void {
+		// Live capture from `[#55] StoreTemplatePartRequest failed
+		// validation` — reproduces what the editor actually sends
+		// when the user clicks Create Overlay on a `core/navigation`
+		// block. Two non-obvious bits:
+		//
+		//  - `area: "navigation-overlay"` — Gutenberg's block-library
+		//    extends WP core's default areas via the
+		//    `block_template_part_areas` filter; the overlay flow
+		//    POSTs that exact value. Without it our enum rejected.
+		//  - `content` is a SERIALIZED STRING, not a `{raw, blocks}`
+		//    envelope. The store path now accepts string content via
+		//    the shared `ContentShapeRule`.
+		//
+		// No explicit `theme` field — the controller derives it from
+		// the active theme.
+		$this->postJson( '/visual-editor/api/template-parts', [
+			'slug'    => 'navigation-overlay',
+			'title'   => 'Navigation Overlay',
+			'content' => '<!-- wp:paragraph --><p></p><!-- /wp:paragraph -->',
+			'area'    => 'navigation-overlay',
+		] )->assertStatus( 201 )->assertJsonPath( 'area', 'navigation-overlay' );
+	} );
+
 	it( 'accepts area "uncategorized" so Gutenberg\'s Create Overlay action lands (Keystone #55)', function (): void {
 		$this->postJson( '/visual-editor/api/template-parts', [
 			'slug'  => 'navigation-overlay-test',

--- a/tests/Feature/SiteEditor/TemplatePartControllerTest.php
+++ b/tests/Feature/SiteEditor/TemplatePartControllerTest.php
@@ -216,7 +216,13 @@ describe( 'POST /visual-editor/api/template-parts', function (): void {
 		] )->assertStatus( 422 )->assertJsonValidationErrors( 'area' );
 	} );
 
-	it( 'returns 409 on duplicate (theme, slug)', function (): void {
+	it( 'idempotently returns the existing part with 200 when (theme, slug) already exists (Keystone #55)', function (): void {
+		// Gutenberg's Create Overlay action re-fires on each Click,
+		// even when the nav block already has an overlay. Previously
+		// the second click 409-ed, which the editor surfaced as a
+		// silent failure. The controller now returns the existing
+		// record with 200 so the editor's local cache picks it up
+		// transparently and the block stays consistent.
 		TemplatePart::create( [
 			'theme'         => 'digital-shopfront',
 			'slug'          => 'header',
@@ -228,12 +234,40 @@ describe( 'POST /visual-editor/api/template-parts', function (): void {
 			'author_id'     => null,
 		] );
 
-		$this->postJson( '/visual-editor/api/template-parts', [
+		$response = $this->postJson( '/visual-editor/api/template-parts', [
 			'slug'  => 'header',
 			'title' => 'Duplicate',
 			'area'  => 'header',
 			'theme' => 'digital-shopfront',
-		] )->assertStatus( 409 );
+		] );
+
+		$response->assertStatus( 200 );
+		$response->assertJsonPath( 'slug', 'header' );
+		// Original title preserved — the duplicate POST does NOT
+		// overwrite. Updates still go through PUT.
+		$response->assertJsonPath( 'title.raw', 'Header' );
+
+		// Only one row exists — no duplicate created.
+		expect( TemplatePart::query()->where( 'slug', 'header' )->count() )->toBe( 1 );
+	} );
+
+	it( 'accepts area "uncategorized" so Gutenberg\'s Create Overlay action lands (Keystone #55)', function (): void {
+		$this->postJson( '/visual-editor/api/template-parts', [
+			'slug'  => 'navigation-overlay-test',
+			'title' => 'Overlay',
+			'area'  => 'uncategorized',
+			'theme' => 'digital-shopfront',
+		] )->assertStatus( 201 )->assertJsonPath( 'area', 'uncategorized' );
+	} );
+
+	it( 'creates the part without an explicit theme by falling back to the active theme (Keystone #55)', function (): void {
+		// Gutenberg's Create Overlay action POSTs without a `theme`
+		// field — the controller derives it from the active theme.
+		$this->postJson( '/visual-editor/api/template-parts', [
+			'slug'  => 'no-theme-overlay',
+			'title' => 'No Theme Overlay',
+			'area'  => 'uncategorized',
+		] )->assertStatus( 201 )->assertJsonPath( 'theme', 'digital-shopfront' );
 	} );
 } );
 

--- a/tests/Unit/VisualEditor/SiteEditor/Resolution/ResolvedTemplatePartTest.php
+++ b/tests/Unit/VisualEditor/SiteEditor/Resolution/ResolvedTemplatePartTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * Tests for {@see \ArtisanPackUI\VisualEditor\SiteEditor\Resolution\ResolvedTemplatePart}.
+ *
+ * Focus is on the legacy-area back-compat surface that Keystone #55
+ * added. Resolution / coercion of other fields is exercised by the
+ * higher-level adapter and feature tests; these unit cases stay
+ * narrow.
+ *
+ * @since 1.1.0
+ */
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\SiteEditor\Exceptions\SiteEditorRegistrationException;
+use ArtisanPackUI\VisualEditor\SiteEditor\Resolution\ResolvedTemplatePart;
+
+it( 'maps the legacy `general` area onto `uncategorized` so pre-#55 rows still resolve (Keystone #55)', function (): void {
+	$part = ResolvedTemplatePart::fromArray( [
+		'slug'  => 'sidebar-old',
+		'area'  => 'general',
+		'theme' => 'jmwd-default',
+	] );
+
+	expect( $part->area )->toBe( 'uncategorized' );
+} );
+
+it( 'accepts `navigation-overlay` so Gutenberg\'s Create Overlay flow resolves cleanly (Keystone #55)', function (): void {
+	$part = ResolvedTemplatePart::fromArray( [
+		'slug'  => 'navigation-overlay',
+		'area'  => 'navigation-overlay',
+		'theme' => 'jmwd-default',
+	] );
+
+	expect( $part->area )->toBe( 'navigation-overlay' );
+} );
+
+it( 'still rejects an unknown area that isn\'t the legacy `general` alias', function (): void {
+	$threw = false;
+
+	try {
+		ResolvedTemplatePart::fromArray( [
+			'slug'  => 'whatever',
+			'area'  => 'menu-bar',
+			'theme' => 'jmwd-default',
+		] );
+	} catch ( SiteEditorRegistrationException $e ) {
+		$threw = true;
+		expect( $e->getMessage() )->toContain( 'uncategorized' )
+			->and( $e->getMessage() )->toContain( 'navigation-overlay' );
+	}
+
+	expect( $threw )->toBeTrue();
+} );


### PR DESCRIPTION
Closes [Keystone #55](https://gitlab.com/jacob-martella-web-design/jacob-martella-web-design/jmwd-keystone-cms/jmwd-keystone-cms/-/work_items/55). Pairs with cms-framework PR.

## The bug

Clicking **Create Overlay** on a \`core/navigation\` block in the site editor POSTed to \`/visual-editor/api/template-parts\` and got a 422. Three separate validator failures were stacked behind that single status:

1. \`area: "navigation-overlay"\` not in our enum (only \`header | footer | sidebar | general\` accepted).
2. \`content\` arrived as a serialized string (\`<!-- wp:paragraph --><p></p><!-- /wp:paragraph -->\`), our rule required \`array | null\`.
3. \`theme\` was \`required\` but Gutenberg's Create Overlay doesn't include it in the payload.

Even once those were fixed, the action visibly did nothing — the part got created server-side, but the editor canvas showed no feedback because no \`onNavigateToEntityRecord\` was wired to switch to the new entity.

## What ships

### Validation

- Areas enum aligned with WP / Gutenberg conventions (\`general\` → \`uncategorized\` + \`navigation-overlay\`; cms-framework half ships in the matching PR).
- \`content\` rule changed from \`array\` to the shared \`ContentShapeRule\` (extracted to its own file under \`Rules/\`-style namespace so PSR-4 can autoload it). Accepts \`string | array | null\` — same polymorphic acceptance already used by \`UpdateMenuRequest\` for the menus save round-trip (#48).
- \`theme\` made \`sometimes\`. The controller falls back to the active theme via \`ThemeManager::getActiveTheme()\` when the field is missing; returns a clean 422 only when no theme is active at all (standalone install).

### Idempotency

Re-clicking Create Overlay on a nav block that already has an overlay used to 409. The controller now detects an existing (theme, slug) row and returns it with 200 instead — the editor's local cache picks it up transparently and the block stays consistent. Updates still flow through PUT.

### Canvas navigation

Gutenberg's Create Overlay handler calls \`settings.onNavigateToEntityRecord({ postId: \"theme//slug\", postType: 'wp_template_part' })\` after the save. \`BlockEditorBoundary\` now exposes that callback on the provider's settings:

- Hosts can pass an explicit \`onNavigateToEntityRecord\` prop.
- When omitted, the boundary installs a default that:
  1. Resolves the composite \`{theme}//{slug}\` post id to the entity's **numeric** DB id by reading our \`'core'\` store (the host routes parts by id, not slug — \`/admin/site-editor/template-parts/9\`).
  2. Reads the route base from the mount node's \`data-route-base\` attribute (matches either \`data-ap-site-editor\` or \`data-ap-visual-editor\` so we don't have to know which host we're embedded in).
  3. Uses \`history.pushState\` + dispatched \`popstate\` instead of \`window.location.assign\`, so the SPA's existing routing hook re-renders the new section/entity in one cycle. \`.assign\` worked end-to-end but flashed the previous section's placeholder during the remount.

## Tests

- 4 new feature tests on \`TemplatePartController\`: live-captured Gutenberg payload lands at 201; \`uncategorized\` area accepted; missing \`theme\` falls back to the active theme; duplicate POST returns the existing record at 200 (replaces the old 409 assertion).
- 2 new vitest tests on \`BlockEditorBoundary\`: default \`onNavigateToEntityRecord\` shows up on the provider's settings; host-provided override wins.
- Diagnostic \`failedValidation\` log + inline \`envelopeShapeRule\` closure removed; the shared \`ContentShapeRule\` replaces both.

611/611 PHP + 1053/1054 vitest green.

## Out of scope — known follow-up

[Keystone #57](https://gitlab.com/jacob-martella-web-design/jacob-martella-web-design/jmwd-keystone-cms/jmwd-keystone-cms/-/work_items/57) — when an author picks an EXISTING overlay from the dropdown (not Create), the nav block's \`overlay\` attribute is set, then immediately reverts in the same render cycle. Likely a records-list resolution flicker or a block re-decoration loop. Distinct from the POST/navigation path this PR fixes, so it deserves its own diagnostic pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for navigation-overlay and uncategorized template part areas
  * Idempotent template part creation that reuses existing parts for overlay requests

* **Improvements**
  * Template part creation falls back to the active theme when theme is omitted
  * Enhanced visual editor navigation handling with host-overridable navigation callbacks and a built-in fallback

* **Tests**
  * Added controller and unit tests covering idempotency, overlay payloads, and legacy-area back-compat

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArtisanPack-UI/visual-editor/pull/464?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->