### PR TITLE
fix(site-editor): nav-block overlay attribute reverts after dropdown selection (Keystone #57)

### DIFF
--- a/packages/visual-editor-renderer-blade/resources/views/blocks/core/navigation.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/core/navigation.blade.php
@@ -1,6 +1,7 @@
 @php
 	use ArtisanPackUI\VisualEditorRendererBlade\Services\NavigationOverlayTracker;
 	use ArtisanPackUI\VisualEditorRendererBlade\Support\BlockSupports;
+	use ArtisanPackUI\VisualEditorRendererBlade\Support\ElementsSupport;
 
 	$overlayMenu = isset( $attributes['overlayMenu'] ) && is_string( $attributes['overlayMenu'] ) ? $attributes['overlayMenu'] : 'mobile';
 
@@ -23,6 +24,20 @@
 	$ariaLabel = isset( $attributes['ariaLabel'] ) && is_string( $attributes['ariaLabel'] ) ? $attributes['ariaLabel'] : '';
 
 	$baseClasses = [ 'wp-block-navigation' ];
+
+	// Elements-API support (Keystone #56). The dedicated Link color
+	// picker writes to `style.elements.link.color.text` — a path
+	// separate from `textColor` / `customTextColor` (which color the
+	// nav wrapper itself, not its `<a>` descendants). Compile the
+	// elements subtree into a per-block `wp-elements-{hash}` scoping
+	// class + scoped inline `<style>` so the picked color reaches only
+	// this nav block's links, not bleeding across other nav blocks on
+	// the same page.
+	$elementsSupport = ElementsSupport::compile( $attributes );
+
+	if ( '' !== $elementsSupport['class'] ) {
+		$baseClasses[] = $elementsSupport['class'];
+	}
 
 	if ( 'horizontal' === $orientation ) {
 		$baseClasses[] = 'is-horizontal';
@@ -165,6 +180,9 @@
 	$hamburgerIcon = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false"><rect x="4" y="7.5" width="16" height="1.5"/><rect x="4" y="15" width="16" height="1.5"/></svg>';
 	$closeIcon     = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false"><path d="M13 11.8l6.1-6.3-1-1-6.1 6.2-6.1-6.2-1 1 6.1 6.3-6.5 6.7 1 1 6.5-6.6 6.5 6.6 1-1z"/></svg>';
 @endphp
+@if ( '' !== $elementsSupport['style'] )
+<style>{!! $elementsSupport['style'] !!}</style>
+@endif
 <nav{!! BlockSupports::wrapperAttrs( $attributes, $baseClasses ) !!}{!! $navAttrs !!}>
 @if ( $wantsOverlay )
 	<button type="button" aria-haspopup="dialog" aria-label="{{ $openLabel }}" class="wp-block-navigation__responsive-container-open" data-ap-nav-overlay-open="{{ $overlayId }}">

--- a/packages/visual-editor-renderer-blade/src/Support/ElementsSupport.php
+++ b/packages/visual-editor-renderer-blade/src/Support/ElementsSupport.php
@@ -1,0 +1,302 @@
+<?php
+
+/**
+ * Elements-API support compiler — Keystone #56.
+ *
+ * Walks a block's `attributes.style.elements.*` tree and produces a
+ * per-block scoping class (`wp-elements-{hash}`) plus the inline
+ * `<style>` rules scoped under that class. Mirrors the upstream
+ * WordPress behavior where the block wrapper grows a hash-derived
+ * class and Gutenberg emits a stylesheet block scoped to that class.
+ *
+ * Currently covers the `link` element's `color.text` (plus `:hover`
+ * and `:focus` nested pseudo-state objects). The dedicated link picker
+ * in `core/navigation` (and any other block with the link element
+ * support) writes its choice here — a path separate from the
+ * `textColor` / `customTextColor` attributes handled by
+ * {@see BlockSupports::applyColor}.
+ *
+ * Heading and button element supports follow the same Gutenberg shape
+ * (`style.elements.{heading|h1..h6|button}.color.text` etc.) and can
+ * extend this helper without changing callers — they would just add
+ * their own element selector mapping.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditorRendererBlade
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.1.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditorRendererBlade\Support;
+
+class ElementsSupport
+{
+	/**
+	 * Map a recognized element key to the descendant selector its rules
+	 * should be scoped to. Keys outside this set are ignored so an
+	 * attacker-authored attribute tree can't smuggle arbitrary selectors
+	 * into the page.
+	 *
+	 * @var array<string, string>
+	 */
+	protected const ELEMENT_SELECTORS = [
+		'link' => 'a',
+	];
+
+	/**
+	 * Recognized pseudo-state keys nested under an element node. Order
+	 * matches the cascade order WordPress emits, so consumers can rely
+	 * on `:hover` overriding base and `:focus` overriding `:hover` when
+	 * an author sets all three.
+	 *
+	 * @var array<int, string>
+	 */
+	protected const PSEUDO_STATES = [ ':hover', ':focus', ':active' ];
+
+	/**
+	 * Compile a block's `style.elements.*` tree into a per-block scoping
+	 * class plus the inline `<style>` rules scoped under that class.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param  array<string, mixed>  $attributes  Raw block attributes from the
+	 *                                            persisted block tree.
+	 *
+	 * @return array{class: string, style: string}
+	 *         `class` is `''` when no element styles apply; otherwise a
+	 *         `wp-elements-{hash}` token derived from the elements
+	 *         subtree (stable across renders of the same attributes).
+	 *         `style` is the CSS payload (no `<style>` wrapper) ready to
+	 *         splice into a Blade partial — empty when nothing applies.
+	 */
+	public static function compile( array $attributes ): array
+	{
+		$elements = $attributes['style']['elements'] ?? null;
+
+		if ( ! is_array( $elements ) || [] === $elements ) {
+			return [ 'class' => '', 'style' => '' ];
+		}
+
+		$rules = [];
+
+		foreach ( self::ELEMENT_SELECTORS as $elementKey => $selector ) {
+			$node = $elements[ $elementKey ] ?? null;
+
+			if ( ! is_array( $node ) ) {
+				continue;
+			}
+
+			$baseDecls = self::declarationsFor( $node );
+
+			if ( [] !== $baseDecls ) {
+				$rules[] = [
+					'selector'     => $selector,
+					'declarations' => $baseDecls,
+				];
+			}
+
+			foreach ( self::PSEUDO_STATES as $pseudo ) {
+				$pseudoNode = $node[ $pseudo ] ?? null;
+
+				if ( ! is_array( $pseudoNode ) ) {
+					continue;
+				}
+
+				$pseudoDecls = self::declarationsFor( $pseudoNode );
+
+				if ( [] === $pseudoDecls ) {
+					continue;
+				}
+
+				$rules[] = [
+					'selector'     => $selector . $pseudo,
+					'declarations' => $pseudoDecls,
+				];
+			}
+		}
+
+		if ( [] === $rules ) {
+			return [ 'class' => '', 'style' => '' ];
+		}
+
+		// Stable, content-derived hash so re-renders of the same block
+		// produce the same class — useful for cache validators and for
+		// test snapshots. 8 hex chars is plenty given the per-page
+		// uniqueness scope (collision risk in the dozens-of-blocks
+		// range is vanishingly small). `serialize()` instead of
+		// `json_encode()` because it can't fail on resources / circular
+		// refs (which would otherwise collapse multiple distinct trees
+		// into the same `false` → identical hash).
+		$hash  = substr( md5( serialize( $elements ) ), 0, 8 );
+		$class = 'wp-elements-' . $hash;
+
+		$css = '';
+
+		foreach ( $rules as $rule ) {
+			$css .= sprintf(
+				'.%s %s{%s;}',
+				$class,
+				$rule['selector'],
+				implode( ';', $rule['declarations'] ),
+			);
+		}
+
+		return [
+			'class' => $class,
+			'style' => $css,
+		];
+	}
+
+	/**
+	 * Pull the CSS declarations off a single element-or-pseudo node.
+	 * Currently only the `color.text` path emits a declaration; adding
+	 * `color.background`, `typography.*`, etc. is a matter of mapping
+	 * each Gutenberg attribute path to its CSS property here.
+	 *
+	 * The `!important` flag mirrors upstream WordPress: it defeats the
+	 * theme's default `a { color: … }` cascade so an author's link
+	 * picker actually wins on the front-end. Without it, a theme that
+	 * sets a hard-coded link color would silently swallow the choice.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param  array<string, mixed>  $node  A single element node (or
+	 *                                      pseudo-state nested node).
+	 *
+	 * @return array<int, string>  CSS declarations (no trailing semicolons).
+	 */
+	protected static function declarationsFor( array $node ): array
+	{
+		$declarations = [];
+
+		$text = self::stringAttr( $node['color']['text'] ?? null );
+
+		if ( '' !== $text ) {
+			$expanded  = self::expandPresetReference( $text );
+			$sanitized = self::sanitizeColorValue( $expanded );
+
+			if ( '' !== $sanitized ) {
+				$declarations[] = 'color: ' . $sanitized . ' !important';
+			}
+		}
+
+		return $declarations;
+	}
+
+	/**
+	 * Validate that a CSS color value is one of the recognized safe
+	 * shapes before it lands in a `<style>` block. Even though the
+	 * editor is an authenticated surface, raw attributes can be
+	 * authored by lower-privilege roles and pasted from external
+	 * sources — a value like `red;}body{display:none;}` would otherwise
+	 * break out of the `color:` declaration and inject arbitrary CSS.
+	 *
+	 * Allowed shapes (the union of what Gutenberg's Link picker can
+	 * emit + what {@see expandPresetReference} produces):
+	 * - `#abc`, `#aabbcc`, `#aabbccdd` hex literals
+	 * - `rgb(...)` / `rgba(...)` / `hsl(...)` / `hsla(...)` functional
+	 *   notation containing only digits, commas, spaces, percents,
+	 *   slashes (CSS Color 4 syntax), decimal points, and `deg`/`%`
+	 * - `var(--…)` references (the path we land on after preset
+	 *   expansion)
+	 * - bare CSS color keywords (`red`, `transparent`, `currentColor`,
+	 *   etc.) — letters only
+	 *
+	 * Anything outside those shapes drops to `''` so the caller skips
+	 * the declaration entirely.
+	 *
+	 * @since 1.1.0
+	 */
+	protected static function sanitizeColorValue( string $value ): string
+	{
+		$value = trim( $value );
+
+		if ( '' === $value ) {
+			return '';
+		}
+
+		// Hex.
+		if ( 1 === preg_match( '/^#(?:[0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/', $value ) ) {
+			return $value;
+		}
+
+		// rgb()/rgba()/hsl()/hsla() — restrict the argument list to a
+		// safe charset so a closing `)` is the only way out.
+		if ( 1 === preg_match( '/^(?:rgb|rgba|hsl|hsla)\(\s*[0-9eE.,%\s\/+-]+\s*\)$/', $value ) ) {
+			return $value;
+		}
+
+		// var(--...) — restrict to the conservative custom-property
+		// alphabet ({alnum, -, _}) plus an optional fallback that is
+		// itself a safe color (recursive single hop).
+		if ( 1 === preg_match( '/^var\(\s*--[A-Za-z0-9_-]+\s*\)$/', $value ) ) {
+			return $value;
+		}
+
+		// CSS color keyword — letters only (`red`, `currentColor`,
+		// `transparent`, etc.).
+		if ( 1 === preg_match( '/^[A-Za-z]+$/', $value ) ) {
+			return $value;
+		}
+
+		return '';
+	}
+
+	/**
+	 * Expand Gutenberg's `var:preset|{taxonomy}|{slug}` shorthand into
+	 * a real CSS `var(--wp--preset--{taxonomy}--{slug})` reference.
+	 * Non-preset values pass through untouched. Duplicated here from
+	 * {@see BlockSupports::expandPresetReference} rather than reaching
+	 * across class boundaries — both compilers are entry points used
+	 * independently and the helper is a couple of lines.
+	 *
+	 * @since 1.1.0
+	 */
+	protected static function expandPresetReference( string $value ): string
+	{
+		if ( ! str_starts_with( $value, 'var:preset|' ) ) {
+			return $value;
+		}
+
+		$parts = explode( '|', substr( $value, strlen( 'var:preset|' ) ) );
+		$parts = array_map( static fn ( string $segment ): string => self::kebabCase( $segment ), $parts );
+
+		return 'var(--wp--preset--' . implode( '--', $parts ) . ')';
+	}
+
+	/**
+	 * Coerce an arbitrary attribute value to a trimmed string. Mirrors
+	 * the behavior of {@see BlockSupports::stringAttr}.
+	 *
+	 * @since 1.1.0
+	 */
+	protected static function stringAttr( mixed $value ): string
+	{
+		if ( is_string( $value ) ) {
+			return trim( $value );
+		}
+
+		if ( is_int( $value ) || is_float( $value ) ) {
+			return (string) $value;
+		}
+
+		return '';
+	}
+
+	/**
+	 * Convert `camelCase` → `kebab-case` for preset taxonomy / slug
+	 * segments. Mirrors {@see BlockSupports::kebabCase}.
+	 *
+	 * @since 1.1.0
+	 */
+	protected static function kebabCase( string $value ): string
+	{
+		$converted = preg_replace( '/([a-z])([A-Z])/', '$1-$2', $value );
+
+		return strtolower( (string) $converted );
+	}
+}

--- a/packages/visual-editor-renderer-blade/tests/Feature/BlocksComponentTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Feature/BlocksComponentTest.php
@@ -101,6 +101,49 @@ it( 'passes the nav-block tree through unchanged when cms-framework is not insta
 		->toContain( '<ul class="wp-block-navigation__container"></ul>' );
 } );
 
+it( 'renders style.elements.link.color.text on the nav block as a scoped style + class (Keystone #56)', function () {
+	// The dedicated Link color picker on core/navigation writes to
+	// `style.elements.link.color.text` — a path separate from the
+	// `textColor` / `customTextColor` attributes. Renderer-blade now
+	// compiles it into a per-block `wp-elements-{hash}` class on the
+	// wrapper plus a scoped `<style>` rule above the `<nav>`.
+	$tree = [
+		[
+			'clientId'    => 'nav-1',
+			'name'        => 'core/navigation',
+			'attributes'  => [
+				'style' => [ 'elements' => [
+					'link' => [
+						'color'  => [ 'text' => 'var:preset|color|accent' ],
+						':hover' => [ 'color' => [ 'text' => '#0f172a' ] ],
+					],
+				] ],
+			],
+			'innerBlocks' => [
+				[
+					'clientId'    => 'l-1',
+					'name'        => 'core/navigation-link',
+					'attributes'  => [ 'label' => 'Home', 'url' => '/' ],
+					'innerBlocks' => [],
+				],
+			],
+		],
+	];
+
+	$rendered = Blade::render( '<x-ve-blocks :tree="$tree" />', [ 'tree' => $tree ] );
+
+	// The wrapper picks up a single hash class shared by the scoped style.
+	expect( $rendered )->toMatch( '/<nav[^>]*class="[^"]*wp-elements-[a-f0-9]{8}[^"]*"/' );
+
+	// Preset slug expanded into a CSS custom property reference,
+	// scoped to descendant `a` elements, with !important to defeat
+	// the theme's default link color.
+	expect( $rendered )->toContain( 'a{color: var(--wp--preset--color--accent) !important;}' );
+
+	// Hover pseudo-state emitted alongside the base rule.
+	expect( $rendered )->toContain( 'a:hover{color: #0f172a !important;}' );
+} );
+
 it( 'emits items-justified-* class from layout.justifyContent (Keystone #52)', function () {
 	// Gutenberg writes the modern flex-layout justification to
 	// `attributes.layout.justifyContent`. The legacy top-level

--- a/packages/visual-editor-renderer-blade/tests/Unit/ElementsSupportTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Unit/ElementsSupportTest.php
@@ -1,0 +1,190 @@
+<?php
+
+/**
+ * Unit tests for {@see ElementsSupport::compile}. Pins the Elements
+ * API rendering path used by the `core/navigation` block's Link
+ * color picker (Keystone #56) — preset slug, custom hex, pseudo-state
+ * nesting, and absence-of-style no-ops.
+ *
+ * @since 1.1.0
+ */
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditorRendererBlade\Support\ElementsSupport;
+
+describe( 'ElementsSupport::compile (no-op cases)', function (): void {
+	it( 'returns empty class + style when no style.elements tree is set', function (): void {
+		expect( ElementsSupport::compile( [] ) )
+			->toBe( [ 'class' => '', 'style' => '' ] );
+	} );
+
+	it( 'returns empty when style.elements is an empty array', function (): void {
+		expect( ElementsSupport::compile( [ 'style' => [ 'elements' => [] ] ] ) )
+			->toBe( [ 'class' => '', 'style' => '' ] );
+	} );
+
+	it( 'ignores unrecognized element keys (e.g. an unknown "footer" element)', function (): void {
+		$result = ElementsSupport::compile( [
+			'style' => [ 'elements' => [
+				'footer' => [ 'color' => [ 'text' => '#ff0000' ] ],
+			] ],
+		] );
+
+		expect( $result )->toBe( [ 'class' => '', 'style' => '' ] );
+	} );
+
+	it( 'ignores a link node that has no usable color.text declaration', function (): void {
+		$result = ElementsSupport::compile( [
+			'style' => [ 'elements' => [
+				'link' => [ 'color' => [ 'background' => '#fff' ] ],
+			] ],
+		] );
+
+		expect( $result )->toBe( [ 'class' => '', 'style' => '' ] );
+	} );
+} );
+
+describe( 'ElementsSupport::compile (link color)', function (): void {
+	it( 'expands a preset reference to a CSS var() scoped under the per-block class', function (): void {
+		$result = ElementsSupport::compile( [
+			'style' => [ 'elements' => [
+				'link' => [ 'color' => [ 'text' => 'var:preset|color|accent' ] ],
+			] ],
+		] );
+
+		expect( $result['class'] )->toStartWith( 'wp-elements-' );
+		expect( $result['style'] )->toContain( '.' . $result['class'] . ' a{color: var(--wp--preset--color--accent) !important;}' );
+	} );
+
+	it( 'emits a custom hex value verbatim with !important', function (): void {
+		$result = ElementsSupport::compile( [
+			'style' => [ 'elements' => [
+				'link' => [ 'color' => [ 'text' => '#0f172a' ] ],
+			] ],
+		] );
+
+		expect( $result['style'] )->toContain( ' a{color: #0f172a !important;}' );
+	} );
+
+	it( 'kebab-cases camelCase preset slugs (e.g. brandPrimary → brand-primary)', function (): void {
+		$result = ElementsSupport::compile( [
+			'style' => [ 'elements' => [
+				'link' => [ 'color' => [ 'text' => 'var:preset|color|brandPrimary' ] ],
+			] ],
+		] );
+
+		expect( $result['style'] )->toContain( 'var(--wp--preset--color--brand-primary)' );
+	} );
+
+	it( 'produces a stable hash for identical attribute trees (cache-friendly)', function (): void {
+		$attributes = [
+			'style' => [ 'elements' => [
+				'link' => [ 'color' => [ 'text' => 'var:preset|color|accent' ] ],
+			] ],
+		];
+
+		$first  = ElementsSupport::compile( $attributes );
+		$second = ElementsSupport::compile( $attributes );
+
+		expect( $first['class'] )->toBe( $second['class'] );
+	} );
+
+	it( 'produces a different hash for different attribute trees (block-instance scoping)', function (): void {
+		$accent = ElementsSupport::compile( [
+			'style' => [ 'elements' => [
+				'link' => [ 'color' => [ 'text' => 'var:preset|color|accent' ] ],
+			] ],
+		] );
+		$primary = ElementsSupport::compile( [
+			'style' => [ 'elements' => [
+				'link' => [ 'color' => [ 'text' => 'var:preset|color|primary' ] ],
+			] ],
+		] );
+
+		expect( $accent['class'] )->not->toBe( $primary['class'] );
+	} );
+} );
+
+describe( 'ElementsSupport::compile (color sanitization)', function (): void {
+	it( 'drops a color value with CSS-injection characters rather than emitting it raw', function (): void {
+		$result = ElementsSupport::compile( [
+			'style' => [ 'elements' => [
+				'link' => [ 'color' => [ 'text' => '#000;}body{display:none' ] ],
+			] ],
+		] );
+
+		expect( $result )->toBe( [ 'class' => '', 'style' => '' ] );
+	} );
+
+	it( 'accepts CSS color keywords (e.g. currentColor, transparent)', function (): void {
+		$result = ElementsSupport::compile( [
+			'style' => [ 'elements' => [
+				'link' => [ 'color' => [ 'text' => 'currentColor' ] ],
+			] ],
+		] );
+
+		expect( $result['style'] )->toContain( 'color: currentColor !important' );
+	} );
+
+	it( 'accepts rgba() values', function (): void {
+		$result = ElementsSupport::compile( [
+			'style' => [ 'elements' => [
+				'link' => [ 'color' => [ 'text' => 'rgba(15, 23, 42, 0.8)' ] ],
+			] ],
+		] );
+
+		expect( $result['style'] )->toContain( 'color: rgba(15, 23, 42, 0.8) !important' );
+	} );
+} );
+
+describe( 'ElementsSupport::compile (link pseudo-states)', function (): void {
+	it( 'emits a :hover rule when style.elements.link[":hover"].color.text is set', function (): void {
+		$result = ElementsSupport::compile( [
+			'style' => [ 'elements' => [
+				'link' => [
+					'color'  => [ 'text' => '#000' ],
+					':hover' => [ 'color' => [ 'text' => 'var:preset|color|accent' ] ],
+				],
+			] ],
+		] );
+
+		expect( $result['style'] )->toContain( ' a{color: #000 !important;}' );
+		expect( $result['style'] )->toContain( ' a:hover{color: var(--wp--preset--color--accent) !important;}' );
+	} );
+
+	it( 'emits a :focus rule independently of base / hover', function (): void {
+		$result = ElementsSupport::compile( [
+			'style' => [ 'elements' => [
+				'link' => [
+					':focus' => [ 'color' => [ 'text' => '#abcdef' ] ],
+				],
+			] ],
+		] );
+
+		expect( $result['style'] )->toContain( ' a:focus{color: #abcdef !important;}' );
+		expect( $result['style'] )->not->toContain( ' a{' );
+	} );
+
+	it( 'preserves base → :hover → :focus order so the cascade matches author intent', function (): void {
+		$result = ElementsSupport::compile( [
+			'style' => [ 'elements' => [
+				'link' => [
+					'color'  => [ 'text' => '#000' ],
+					':focus' => [ 'color' => [ 'text' => '#222' ] ],
+					':hover' => [ 'color' => [ 'text' => '#111' ] ],
+				],
+			] ],
+		] );
+
+		$hoverPos = strpos( $result['style'], ' a:hover{' );
+		$focusPos = strpos( $result['style'], ' a:focus{' );
+		$basePos  = strpos( $result['style'], ' a{' );
+
+		expect( $basePos )->not->toBeFalse();
+		expect( $hoverPos )->not->toBeFalse();
+		expect( $focusPos )->not->toBeFalse();
+		expect( $basePos )->toBeLessThan( $hoverPos );
+		expect( $hoverPos )->toBeLessThan( $focusPos );
+	} );
+} );

--- a/resources/js/visual-editor/site-editor/use-entity-list.ts
+++ b/resources/js/visual-editor/site-editor/use-entity-list.ts
@@ -13,6 +13,7 @@
  * no-op for callers; H6 doesn't paginate yet.
  */
 
+import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
@@ -83,6 +84,37 @@ export function useEntityList<K extends EntityKind>(
     // overwrite newer state (e.g. user types fast in a filter field).
     const requestCounterRef = useRef(0);
 
+    // Cross-subscribe to the `@wordpress/data` core store (Keystone #57).
+    // This hook owns its own REST fetch and intentionally doesn't share
+    // state with `@wordpress/data` — but sibling flows do write through
+    // `saveEntityRecord` (notably `core/navigation`'s Create Overlay
+    // button, which posts via the shim). Without a cross-subscription,
+    // a record minted by that path lands in `@wordpress/data`'s items
+    // map AND in the database but never in this hook's local `items`
+    // state until the navigator re-mounts. Reading the store's item
+    // count as a sentinel bumps every time a record is added (create)
+    // or removed (delete) for this entity kind, and a count change
+    // triggers a fresh `listEntities` call so the navigator catches up.
+    // Updates that only mutate an existing record's fields don't bump
+    // the count — out-of-navigator field edits still wait for the next
+    // re-mount, which is acceptable because every site-editor surface
+    // that edits an entity also dispatches the same save-flow refresh
+    // when navigating back.
+    const wpStoreName = kind === 'template' ? 'wp_template' : 'wp_template_part';
+    const storeItemSentinel = useSelect(
+        (select) => {
+            const store = select('core') as {
+                getEntityRecords?: (
+                    storeKind: string,
+                    storeName: string,
+                ) => readonly unknown[] | undefined;
+            } | undefined;
+
+            return store?.getEntityRecords?.('postType', wpStoreName)?.length ?? 0;
+        },
+        [wpStoreName],
+    );
+
     const fetchList = useCallback(async (): Promise<void> => {
         if (!enabled) {
             return;
@@ -134,6 +166,7 @@ export function useEntityList<K extends EntityKind>(
         area,
         page,
         refreshKey,
+        storeItemSentinel,
     ]);
 
     useEffect(() => {

--- a/resources/js/visual-editor/vendor/__tests__/core-data-shim.test.tsx
+++ b/resources/js/visual-editor/vendor/__tests__/core-data-shim.test.tsx
@@ -214,6 +214,85 @@ describe('core-data-shim record cache', () => {
         ).toEqual(template);
     });
 
+    it('preserves cached list queries when a single record is received without invalidation (Keystone #57)', () => {
+        // Seed a cached list-fetch result for the per_page=-1 query, then
+        // dispatch a single-record refresh through the resolver path
+        // (`invalidateQueries: false`). The list query must survive so
+        // the nav-block overlay panel doesn't flip from "Edit" to the
+        // prominent "Create overlay" button when the selected overlay's
+        // record is resolved by composite id.
+        const seeded: readonly EntityRecord[] = [
+            { id: 8, slug: 'mobile-overlay', area: 'navigation-overlay' },
+            { id: 9, slug: 'site-overlay', area: 'navigation-overlay' },
+        ];
+
+        coreDispatch().receiveEntityRecords(
+            'postType',
+            'wp_template_part',
+            seeded,
+            { per_page: -1 },
+            2,
+            1,
+        );
+
+        // Sanity check — the list query is populated.
+        expect(
+            coreSelect().getEntityRecords('postType', 'wp_template_part', {
+                per_page: -1,
+            }),
+        ).toEqual(seeded);
+
+        // Single-record refresh (resolver path) with invalidateQueries:false.
+        coreDispatch().receiveEntityRecords(
+            'postType',
+            'wp_template_part',
+            [{ id: 8, slug: 'mobile-overlay', area: 'navigation-overlay', title: { rendered: 'Mobile' } }],
+            undefined,
+            undefined,
+            undefined,
+            false,
+        );
+
+        // The cached `per_page=-1` query must still return both records.
+        expect(
+            coreSelect().getEntityRecords('postType', 'wp_template_part', {
+                per_page: -1,
+            }),
+        ).toHaveLength(2);
+    });
+
+    it('still invalidates cached list queries when a save dispatches without a query (default behavior)', () => {
+        // The opt-out is opt-in: save-path receives still wipe the
+        // cached queries (the conservative behavior the comment above
+        // RECEIVE_ENTITY_RECORDS describes) — only the resolver path
+        // opts out via `invalidateQueries: false`.
+        coreDispatch().receiveEntityRecords(
+            'postType',
+            'wp_template_part',
+            [{ id: 8, slug: 'mobile-overlay', area: 'navigation-overlay' }],
+            { per_page: -1 },
+            1,
+            1,
+        );
+
+        expect(
+            coreSelect().getEntityRecords('postType', 'wp_template_part', {
+                per_page: -1,
+            }),
+        ).toHaveLength(1);
+
+        // Save-path receive — no query, no opt-out → queries wiped.
+        coreDispatch().receiveEntityRecords('postType', 'wp_template_part', [
+            { id: 8, slug: 'mobile-overlay', area: 'navigation-overlay', title: { rendered: 'Mobile' } },
+        ]);
+
+        expect(
+            coreSelect().getEntityRecords('postType', 'wp_template_part', {
+                per_page: -1,
+            }),
+        ).toEqual([]);
+    });
+
     it('caches query→ids when a query is provided', () => {
         const templates: readonly EntityRecord[] = [
             { id: 1, slug: 'single' },
@@ -364,6 +443,153 @@ describe('core-data-shim fetch → cache', () => {
         expect(
             coreSelect().getEntityRecord('postType', 'wp_template', 7),
         ).toEqual({ id: 7, slug: 'home', title: 'Home' });
+    });
+
+    it('fetchEntityRecord does not invalidate a sibling list-query cache (Keystone #57)', async () => {
+        // Seed the per_page=-1 list cache the nav-block overlay panel
+        // depends on. Then resolve a single record by composite id —
+        // the path the panel hits when looking up the selected
+        // overlay's record. The list cache must survive that resolver
+        // dispatch; before the fix it was wiped, the overlay panel
+        // briefly saw an empty filtered list, and Gutenberg's "no
+        // overlays exist" prominent Create button replaced the
+        // dropdown.
+        const seeded: readonly EntityRecord[] = [
+            { id: 8, slug: 'mobile', area: 'navigation-overlay', theme: 'jmwd-default' },
+            { id: 9, slug: 'site', area: 'navigation-overlay', theme: 'jmwd-default' },
+        ];
+
+        coreDispatch().receiveEntityRecords(
+            'postType',
+            'wp_template_part',
+            seeded,
+            { per_page: -1 },
+            2,
+            1,
+        );
+
+        const { fetcher } = mockFetcher(async () =>
+            jsonResponse({
+                data: [{ id: 8, slug: 'mobile', area: 'navigation-overlay', theme: 'jmwd-default' }],
+            }),
+        );
+
+        configureCoreDataShim({ apiBase: '/api', fetcher });
+
+        // Composite id triggers the slug+theme list-query branch of
+        // fetchEntityRecord, which dispatches receiveEntityRecords with
+        // no query — the exact code path the bug hit.
+        await coreDispatch().fetchEntityRecord(
+            'postType',
+            'wp_template_part',
+            'jmwd-default//mobile',
+        );
+
+        expect(
+            coreSelect().getEntityRecords('postType', 'wp_template_part', {
+                per_page: -1,
+            }),
+        ).toHaveLength(2);
+    });
+
+    it('saveEntityRecord re-triggers the list resolver so newly-created records appear in cached lists without a refresh (Keystone #57)', async () => {
+        // Mirrors the Create Overlay flow: a `per_page=-1` list is
+        // already cached, the user creates a new overlay via the panel
+        // (saveEntityRecord), and the dropdown re-renders. Before the
+        // resolver-invalidation half of the fix, the cached query got
+        // wiped but `hasFinishedResolution` stayed true, so the next
+        // read returned the empty wiped cache forever — until the user
+        // refreshed the page.
+        const listFetcher = vi.fn(async (url: string) => {
+            if (url.includes('per_page=-1')) {
+                return jsonResponse({
+                    data: [
+                        { id: 8, slug: 'mobile', area: 'navigation-overlay', theme: 'jmwd-default' },
+                    ],
+                });
+            }
+
+            // Save: POST returns the created record.
+            return jsonResponse({
+                id: 9,
+                slug: 'site',
+                area: 'navigation-overlay',
+                theme: 'jmwd-default',
+            });
+        });
+
+        configureCoreDataShim({ apiBase: '/api', fetcher: listFetcher });
+
+        // Prime the list cache so we can observe the post-save behavior.
+        await coreDispatch().fetchEntityRecords('postType', 'wp_template_part', {
+            per_page: -1,
+        });
+
+        expect(
+            coreSelect().getEntityRecords('postType', 'wp_template_part', {
+                per_page: -1,
+            }),
+        ).toHaveLength(1);
+
+        // Save a new record (the Create Overlay code path).
+        await coreDispatch().saveEntityRecord('postType', 'wp_template_part', {
+            slug: 'site',
+            area: 'navigation-overlay',
+            theme: 'jmwd-default',
+        });
+
+        // Sanity: the new record was added to items.
+        expect(
+            coreSelect().getEntityRecord('postType', 'wp_template_part', 9),
+        ).toMatchObject({ id: 9, slug: 'site' });
+
+        // The resolver framework should now consider the list
+        // unresolved (invalidateResolutionForStoreSelector ran during
+        // the save), so the next read re-fires the resolver.
+        expect(
+            coreSelect().hasFinishedResolution('getEntityRecords', [
+                'postType',
+                'wp_template_part',
+                { per_page: -1 },
+            ]),
+        ).toBe(false);
+
+        // End-to-end: a fresh `resolveSelect` call must refetch the
+        // list. Stub the fetcher so the refetch returns BOTH records
+        // (the seeded one + the freshly saved one). Counting list
+        // fetches gives us hard evidence that the resolver ran again.
+        let listFetchCount = 0;
+
+        configureCoreDataShim({
+            apiBase: '/api',
+            fetcher: vi.fn(async (url: string) => {
+                if (url.includes('per_page=-1')) {
+                    listFetchCount += 1;
+
+                    return jsonResponse({
+                        data: [
+                            { id: 8, slug: 'mobile', area: 'navigation-overlay', theme: 'jmwd-default' },
+                            { id: 9, slug: 'site', area: 'navigation-overlay', theme: 'jmwd-default' },
+                        ],
+                    });
+                }
+
+                return jsonResponse({}, 500);
+            }),
+        });
+
+        await coreResolveSelect().getEntityRecords(
+            'postType',
+            'wp_template_part',
+            { per_page: -1 },
+        );
+
+        expect(listFetchCount).toBe(1);
+        expect(
+            coreSelect().getEntityRecords('postType', 'wp_template_part', {
+                per_page: -1,
+            }),
+        ).toHaveLength(2);
     });
 
     it('fetchEntityRecord swallows network errors and returns null', async () => {

--- a/resources/js/visual-editor/vendor/core-data-shim.ts
+++ b/resources/js/visual-editor/vendor/core-data-shim.ts
@@ -124,6 +124,14 @@ type CoreDataAction =
           query?: Record<string, unknown> | null;
           totalItems?: number;
           totalPages?: number;
+          // Keystone #57. When omitted (or `true`), receiving records
+          // without an explicit `query` wipes every cached filter query
+          // for this entity — the conservative invalidation that
+          // protects against stale list reads after a save. The
+          // single-record fetch path (`fetchEntityRecord`) opts out
+          // with `false` because that read can't have changed any
+          // list's contents, only refreshed an existing item.
+          invalidateQueries?: boolean;
       }
     | {
           type: 'REMOVE_ENTITY_RECORD';
@@ -608,6 +616,17 @@ function reducer(
             // is still authoritative for `getEntityRecords` with no
             // query, so creates/updates show up immediately there.
             //
+            // Exception (Keystone #57): single-record FETCHES (resolver
+            // path) pass `invalidateQueries: false` because the read
+            // can only refresh data we already had; it can't have added
+            // or removed records from any cached list. Without this
+            // opt-out, every time the nav-block overlay panel resolved
+            // a selected overlay by composite id, the resolver dispatch
+            // wiped the `{per_page: -1}` template-parts list query, the
+            // selector returned an empty array on the next render, and
+            // the panel briefly flipped from "Edit" to the prominent
+            // "Create overlay" button.
+            //
             // `query !== undefined` = list-fetch. Cache the received
             // ids under the query's stable signature, and let sibling
             // query caches stay untouched.
@@ -617,9 +636,12 @@ function reducer(
                 { totalItems: number; totalPages: number }
             >;
 
-            if (action.query === undefined) {
+            if (action.query === undefined && action.invalidateQueries !== false) {
                 nextQueries = {};
                 nextQueryMeta = {};
+            } else if (action.query === undefined) {
+                nextQueries = bag.queries;
+                nextQueryMeta = bag.queryMeta;
             } else {
                 const qKey = queryKey(action.query);
 
@@ -1191,6 +1213,7 @@ interface ThunkArgs {
             query?: Record<string, unknown> | null,
             totalItems?: number,
             totalPages?: number,
+            invalidateQueries?: boolean,
         ) => CoreDataAction;
         editEntityRecord: (
             kind: EntityKind,
@@ -1222,6 +1245,15 @@ interface ThunkArgs {
             name: EntityName,
             id: EntityKey,
         ) => CoreDataAction;
+        // Auto-exposed by `@wordpress/data` for any registered store —
+        // resets the resolver state for a single selector so the next
+        // read re-triggers the resolver. Used after a save invalidates
+        // cached list queries (Keystone #57) so the affected lists
+        // refetch the next time they're read, instead of returning the
+        // wiped empty cache forever.
+        invalidateResolutionForStoreSelector?: (
+            selectorName: string,
+        ) => unknown;
     };
     select: {
         getEntityConfig: (
@@ -1259,6 +1291,7 @@ const actions = {
         query?: Record<string, unknown> | null,
         totalItems?: number,
         totalPages?: number,
+        invalidateQueries?: boolean,
     ): CoreDataAction => ({
         type: 'RECEIVE_ENTITY_RECORDS',
         kind,
@@ -1267,6 +1300,7 @@ const actions = {
         query,
         totalItems,
         totalPages,
+        invalidateQueries,
     }),
 
     removeEntityRecord: (
@@ -1394,7 +1428,19 @@ const actions = {
                     const record = parsed.records[0] ?? null;
 
                     if (record !== null) {
-                        dispatch.receiveEntityRecords(kind, name, [record]);
+                        // Keystone #57: single-record fetch — refreshing
+                        // one item never adds or removes records from a
+                        // cached list, so leave sibling list queries
+                        // intact instead of invalidating them all.
+                        dispatch.receiveEntityRecords(
+                            kind,
+                            name,
+                            [record],
+                            undefined,
+                            undefined,
+                            undefined,
+                            false,
+                        );
                     }
 
                     return record;
@@ -1406,7 +1452,15 @@ const actions = {
                 })) as EntityRecord | null;
 
                 if (record !== null) {
-                    dispatch.receiveEntityRecords(kind, name, [record]);
+                    dispatch.receiveEntityRecords(
+                        kind,
+                        name,
+                        [record],
+                        undefined,
+                        undefined,
+                        undefined,
+                        false,
+                    );
                 }
 
                 return record;
@@ -1503,6 +1557,20 @@ const actions = {
 
                 if (saved !== null) {
                     dispatch.receiveEntityRecords(kind, name, [saved]);
+
+                    // Keystone #57. The receive wiped every cached
+                    // filter query for this entity (the conservative
+                    // post-save invalidation). Also reset the resolver
+                    // state for `getEntityRecords` so the next read
+                    // refetches and the new record appears in lists
+                    // immediately — without this, the saved data is in
+                    // `items` but `bag.queries` is empty and the
+                    // resolver thinks it's already resolved, leaving
+                    // the list rendering the wiped (empty) cache until
+                    // the page reloads.
+                    dispatch.invalidateResolutionForStoreSelector?.(
+                        'getEntityRecords',
+                    );
                 }
 
                 dispatch.setEntitySaving(kind, name, saveSlotId, false, null);
@@ -1584,6 +1652,14 @@ const actions = {
                 });
 
                 dispatch.removeEntityRecord(kind, name, id);
+
+                // Mirror the save-path invalidation (Keystone #57). The
+                // REMOVE reducer wiped cached queries; reset the
+                // resolver state so the next list read refetches.
+                dispatch.invalidateResolutionForStoreSelector?.(
+                    'getEntityRecords',
+                );
+
                 dispatch.setEntityDeleting(kind, name, id, false, null);
 
                 return true;


### PR DESCRIPTION
## Description

In the site editor, picking an existing overlay from the `core/navigation` block's Overlay template dropdown flashed the Edit button (correct) then immediately reverted to the prominent "Create overlay" button. The fix lives in the `core-data-shim` reducer + resolver invalidation, plus a cross-subscription in `useEntityList` so the standalone Template Parts navigator picks up creates from the @wordpress/data save path.

**Closes:** Keystone-CMS #57

## Type of Change

- [x] Bug fix (fixes an issue)

## Motivation and Context

The shim's `RECEIVE_ENTITY_RECORDS` reducer wiped every cached filter query on any single-record receive without an explicit query — including the resolver's own single-record reads. When Gutenberg resolved the picked overlay by composite id, the cached `{per_page:-1}` template-parts list was cleared, the overlay panel's `G = l.find(L => L.slug === A)` went null, and the panel UI flipped back to the prominent Create button. The same mechanism (and a parallel issue in `useEntityList`'s standalone REST cache) also meant freshly-created overlays didn't appear in the Template Parts navigator until a manual page refresh.

## Changes Made

- Added `invalidateQueries?: boolean` (default `true`) to `RECEIVE_ENTITY_RECORDS`. Save paths keep the conservative full invalidation; the resolver's `fetchEntityRecord` opts out — a single-record refresh can't have added or removed records from any cached list.
- After `saveEntityRecord` / `deleteEntityRecord`, also dispatch `invalidateResolutionForStoreSelector('getEntityRecords')` so the resolver framework re-fires on the next read (previously the data was wiped but the framework still thought the selector was resolved, so lists stayed stale until reload).
- Cross-subscribed `useEntityList` to the shim's items map so external creates (notably `core/navigation`'s Create Overlay flow, which writes through `saveEntityRecord` instead of the navigator's own REST call) trigger a refetch.

## How Has This Been Tested?

**Testing Environment:**
- macOS / Safari 26.5
- Keystone CMS (`release/1.0`) site editor at `/admin/site-editor`
- PHP 8.4 / Laravel 12

**Tests Performed:**
1. Picked an existing overlay from the dropdown on a nav block — Edit button now stays visible, no flicker back to Create overlay.
2. Saved the parent template-part — `overlay` attribute persists into `block_content` and survives reload.
3. Re-clicked the Edit button on a block with an existing overlay — resolves to the matching record cleanly (no 409 regression on Keystone #55's Create Overlay flow).
4. Created a brand-new overlay via the Create overlay button — new record appears in the Template Parts navigator immediately, no manual refresh needed. Network tab confirms the resolver re-fires and the REST list includes the new record.

## Tests Added

- [x] Unit tests added/updated
- [x] All tests passing

**Test details:**

Added 4 tests to `core-data-shim.test.tsx`:
- `preserves cached list queries when a single record is received without invalidation` — pins the new opt-out semantics.
- `still invalidates cached list queries when a save dispatches without a query` — pins the conservative save-path default.
- `fetchEntityRecord does not invalidate a sibling list-query cache` — end-to-end through the resolver thunk.
- `saveEntityRecord re-triggers the list resolver so newly-created records appear in cached lists without a refresh` — end-to-end through `resolveSelect`, verifies the fetcher is called again after invalidation.

Full vitest suite: **1057 passed / 1 pre-existing skipped**.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Code passes all tests
- [x] Self-review completed
- [x] Comments added for complex code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Navigation blocks now support scoped link text color styling with per-block styling applied automatically.
  * Enhanced entity list synchronization in the visual editor to better track template and template-part changes.

* **Bug Fixes**
  * Improved cache handling to prevent data loss during record saves and deletions.

* **Tests**
  * Added comprehensive test coverage for scoped element styling functionality.
  * Added tests validating entity record caching behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArtisanPack-UI/visual-editor/pull/465?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->