### PR TITLE
feat(renderer-blade): honor nav-block overlay attribute on the front-end (Keystone #58)

### DIFF
--- a/packages/visual-editor-renderer-blade/resources/views/blocks/core/navigation.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/core/navigation.blade.php
@@ -169,6 +169,57 @@
 
 	$overlayStyleAttr = [] === $overlayStyles ? '' : sprintf( ' style="%s"', e( implode( '; ', $overlayStyles ) ) );
 
+	// Overlay template-part contents (Keystone #58). When the author
+	// picks (or creates) an overlay via Gutenberg's overlay-template
+	// dropdown, the chosen `template-part` slug lands on
+	// `attributes.overlay`. Honor it on the front-end by rendering
+	// that part's blocks INSIDE the responsive container instead of
+	// the duplicate-of-the-inline-menu fallback — matching WP core's
+	// behavior where the mobile drawer can show whatever the author
+	// authored in the overlay (custom layout, search, social links,
+	// CTA, etc.) rather than a copy of the desktop menu.
+	//
+	// Resolution goes through cms-framework's TemplatePartResolver
+	// (the same path the editor uses), so theme-file overrides and
+	// DB rows compose the same way they do in the canvas. Bail
+	// gracefully on any of: cms-framework absent, slug unresolvable,
+	// resolved record not in the navigation-overlay area, blocks
+	// payload missing, or any thrown exception (partial install,
+	// missing migrations). Each fallback path lands on the
+	// inline-menu duplicate the bundled style.css's mobile rules
+	// were already styled against.
+	$overlayInnerHtml = null;
+
+	if ( $wantsOverlay ) {
+		$overlaySlug = isset( $attributes['overlay'] ) && is_string( $attributes['overlay'] )
+			? trim( $attributes['overlay'] )
+			: '';
+
+		if ( '' !== $overlaySlug ) {
+			$resolverClass = 'ArtisanPackUI\\CMSFramework\\Modules\\SiteEditor\\Resolution\\TemplatePartResolver';
+
+			if ( class_exists( $resolverClass ) ) {
+				try {
+					$resolved = app( $resolverClass )->resolve( $overlaySlug );
+
+					if ( null !== $resolved && 'navigation-overlay' === ( $resolved->area ?? null ) ) {
+						$overlayBlocks = is_array( $resolved->blocks ?? null ) ? $resolved->blocks : [];
+
+						if ( [] !== $overlayBlocks ) {
+							$overlayInnerHtml = app( \ArtisanPackUI\VisualEditorRendererBlade\BlockRenderer::class )
+								->render( $overlayBlocks );
+						}
+					}
+				} catch ( \Throwable $e ) {
+					\Illuminate\Support\Facades\Log::warning( 'Navigation overlay resolution failed', [
+						'slug'      => $overlaySlug,
+						'exception' => $e->getMessage(),
+					] );
+				}
+			}
+		}
+	}
+
 	// Open-button label — `openSubmenusOnClick` is an unrelated
 	// attribute; the open-menu button label has no dedicated attribute
 	// in the block, so use a sensible default. WP core uses "Menu" —
@@ -194,8 +245,18 @@
 				<button type="button" aria-label="{{ $closeLabel }}" class="wp-block-navigation__responsive-container-close" data-ap-nav-overlay-close>
 					{!! $closeIcon !!}
 				</button>
-				<div class="wp-block-navigation__responsive-container-content" id="{{ $overlayId }}-content">
+				<div class="wp-block-navigation__responsive-container-content{{ null !== $overlayInnerHtml ? ' has-overlay-template' : '' }}" id="{{ $overlayId }}-content">
+					{{-- Keystone #58: when an overlay template-part resolves,
+					     render BOTH the regular menu (shown inline on
+					     desktop / when the drawer is closed) AND the overlay
+					     content (shown only while the drawer is open). The
+					     `has-overlay-template` marker scopes the emitted
+					     toggle CSS so navs WITHOUT an overlay keep their
+					     menu visible in the open drawer. --}}
 					<ul class="wp-block-navigation__container">{!! $innerBlocksHtml !!}</ul>
+					@if ( null !== $overlayInnerHtml )
+						<div class="wp-block-navigation__overlay-content">{!! $overlayInnerHtml !!}</div>
+					@endif
 				</div>
 			</div>
 		</div>
@@ -221,6 +282,16 @@
  * so a single declaration on the container fixes the `<ul>`, `<li>`,
  * `<a>`, and the page-list at once. */
 .wp-block-navigation__responsive-container.is-menu-open{--navigation-layout-justification-setting:stretch;--navigation-layout-justify:flex-start;--navigation-layout-align:stretch;--wp--style--root--padding-top:1.5rem;--wp--style--root--padding-right:1.5rem;--wp--style--root--padding-bottom:1.5rem;--wp--style--root--padding-left:1.5rem;}
+/*! Keystone #58 — overlay template-part swap. A nav whose `overlay`
+ * attribute resolves renders BOTH the regular menu and the overlay
+ * content (marked `has-overlay-template`). The overlay is hidden by
+ * default (the inline desktop view shows the menu); once the drawer
+ * opens (`is-menu-open`) the menu is swapped out for the overlay's
+ * content. Scoped to `.has-overlay-template` so navs without an
+ * overlay keep showing their menu in the open drawer. */
+.wp-block-navigation__responsive-container-content.has-overlay-template .wp-block-navigation__overlay-content{display:none;}
+.wp-block-navigation__responsive-container.is-menu-open .wp-block-navigation__responsive-container-content.has-overlay-template .wp-block-navigation__container{display:none;}
+.wp-block-navigation__responsive-container.is-menu-open .wp-block-navigation__responsive-container-content.has-overlay-template .wp-block-navigation__overlay-content{display:block;}
 </style>
 <script>
 /*! Keystone #54 — nav overlay toggle. Tiny inline controller; emitted once per response. */

--- a/packages/visual-editor-renderer-blade/tests/Feature/BlocksComponentTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Feature/BlocksComponentTest.php
@@ -101,6 +101,153 @@ it( 'passes the nav-block tree through unchanged when cms-framework is not insta
 		->toContain( '<ul class="wp-block-navigation__container"></ul>' );
 } );
 
+/**
+ * Bind a stub under cms-framework's TemplatePartResolver FQCN so the
+ * nav block's `class_exists()` gate passes (the real class autoloads
+ * in this monorepo) AND `app($fqcn)` returns our controllable stub
+ * instead of the real resolver (which needs an active theme + DB row).
+ * `$resolved` is what the stub's `resolve()` hands back.
+ */
+function bindOverlayResolverStub( ?object $resolved ): void {
+	$stub = new class( $resolved ) {
+		public function __construct( private ?object $resolved ) {}
+
+		public function resolve( string $slug ): ?object
+		{
+			return $this->resolved;
+		}
+	};
+
+	app()->bind(
+		'ArtisanPackUI\\CMSFramework\\Modules\\SiteEditor\\Resolution\\TemplatePartResolver',
+		fn () => $stub,
+	);
+}
+
+it( 'renders the overlay template-part contents inside the responsive container when overlay attr resolves (Keystone #58)', function () {
+	// The overlay points at a navigation-overlay template-part whose
+	// blocks should REPLACE the duplicate inline-menu fallback in
+	// the responsive container. WP core renders the picked overlay's
+	// blocks here (custom layout, search, etc.) so the mobile drawer
+	// can diverge from the desktop nav.
+	bindOverlayResolverStub( (object) [
+		'area'   => 'navigation-overlay',
+		'blocks' => [
+			[
+				'clientId'    => 'p-1',
+				'name'        => 'core/paragraph',
+				'attributes'  => [ 'content' => 'Welcome to the overlay' ],
+				'innerBlocks' => [],
+			],
+		],
+	] );
+
+	$tree = [
+		[
+			'clientId'    => 'nav-1',
+			'name'        => 'core/navigation',
+			'attributes'  => [ 'overlay' => 'mobile-overlay' ],
+			'innerBlocks' => [
+				[
+					'clientId'    => 'l-1',
+					'name'        => 'core/navigation-link',
+					'attributes'  => [ 'label' => 'Home', 'url' => '/' ],
+					'innerBlocks' => [],
+				],
+			],
+		],
+	];
+
+	$rendered = Blade::render( '<x-ve-blocks :tree="$tree" />', [ 'tree' => $tree ] );
+
+	expect( $rendered )
+		// Overlay content rendered for the open-drawer view.
+		->toContain( '<p class="wp-block-paragraph">Welcome to the overlay</p>' )
+		->and( $rendered )->toContain( '<div class="wp-block-navigation__overlay-content">' )
+		// Dual-render (Keystone #58): the regular menu is STILL present
+		// for the inline desktop / closed-drawer view — the overlay
+		// adds to the DOM, it doesn't erase the navigation.
+		->and( $rendered )->toContain( '<ul class="wp-block-navigation__container">' )
+		->and( $rendered )->toContain( '<a class="wp-block-navigation-item__content" href="/">' )
+		// The content container is marked so the emitted toggle CSS can
+		// swap menu ↔ overlay based on `is-menu-open`.
+		->and( $rendered )->toContain( 'wp-block-navigation__responsive-container-content has-overlay-template' );
+} );
+
+it( 'falls back to the duplicate inline-menu container when overlay slug resolves to a non-overlay area (Keystone #58)', function () {
+	// Defensive: a stale overlay slug that now points at a header /
+	// footer template-part must NOT render that part's blocks in the
+	// nav-block's drawer — the author meant a navigation-overlay,
+	// and rendering a header inside the mobile menu would surprise
+	// everyone. Bail to the inline-menu duplicate.
+	bindOverlayResolverStub( (object) [
+		'area'   => 'header',
+		'blocks' => [
+			[
+				'clientId'    => 'p-1',
+				'name'        => 'core/paragraph',
+				'attributes'  => [ 'content' => 'I am a header — do not render me' ],
+				'innerBlocks' => [],
+			],
+		],
+	] );
+
+	$tree = [
+		[
+			'clientId'    => 'nav-1',
+			'name'        => 'core/navigation',
+			'attributes'  => [ 'overlay' => 'header' ],
+			'innerBlocks' => [
+				[
+					'clientId'    => 'l-1',
+					'name'        => 'core/navigation-link',
+					'attributes'  => [ 'label' => 'Home', 'url' => '/' ],
+					'innerBlocks' => [],
+				],
+			],
+		],
+	];
+
+	$rendered = Blade::render( '<x-ve-blocks :tree="$tree" />', [ 'tree' => $tree ] );
+
+	expect( $rendered )
+		->not->toContain( 'I am a header — do not render me' )
+		// No overlay swap: no marker class, no overlay-content wrapper.
+		->and( $rendered )->not->toContain( 'responsive-container-content has-overlay-template' )
+		->and( $rendered )->not->toContain( '<div class="wp-block-navigation__overlay-content">' )
+		// The regular menu still renders.
+		->and( $rendered )->toContain( '<ul class="wp-block-navigation__container">' );
+} );
+
+it( 'falls back to the duplicate inline-menu container when the overlay slug resolves to null (Keystone #58)', function () {
+	bindOverlayResolverStub( null );
+
+	$tree = [
+		[
+			'clientId'    => 'nav-1',
+			'name'        => 'core/navigation',
+			'attributes'  => [ 'overlay' => 'deleted-overlay' ],
+			'innerBlocks' => [
+				[
+					'clientId'    => 'l-1',
+					'name'        => 'core/navigation-link',
+					'attributes'  => [ 'label' => 'Home', 'url' => '/' ],
+					'innerBlocks' => [],
+				],
+			],
+		],
+	];
+
+	$rendered = Blade::render( '<x-ve-blocks :tree="$tree" />', [ 'tree' => $tree ] );
+
+	expect( $rendered )
+		// A deleted / unresolvable overlay slug never swaps in overlay
+		// markup — the menu renders as if no overlay were set.
+		->not->toContain( 'responsive-container-content has-overlay-template' )
+		->and( $rendered )->not->toContain( '<div class="wp-block-navigation__overlay-content">' )
+		->and( $rendered )->toContain( '<ul class="wp-block-navigation__container">' );
+} );
+
 it( 'renders style.elements.link.color.text on the nav block as a scoped style + class (Keystone #56)', function () {
 	// The dedicated Link color picker on core/navigation writes to
 	// `style.elements.link.color.text` — a path separate from the


### PR DESCRIPTION
## Description

Renders a `core/navigation` block's selected overlay template-part inside the responsive drawer on the public front-end. Previously the `overlay` attribute was editor-only — the front-end always duplicated the inline menu in the drawer.

**Closes:** Keystone-CMS #58

## Type of Change

- [x] New feature (adds new functionality)

## Motivation and Context

The #54 nav implementation uses a single `responsive-container-content` for both the inline desktop menu (`@media (min-width:600px)` → `display:block`) and the mobile drawer. A naive "swap the container content for the overlay" would have erased the navigation links on desktop. The dual-render approach renders both the menu and the overlay, toggling them via CSS based on `is-menu-open`.

## Changes Made

- `navigation.blade.php`: resolve `attributes.overlay` via cms-framework's `TemplatePartResolver` (class_exists-guarded), render the overlay's blocks through `BlockRenderer` into a new `<div class="wp-block-navigation__overlay-content">` wrapper alongside the regular menu `<ul>`. Mark the content container `has-overlay-template`.
- Emitted toggle CSS (in the existing once-per-response `<style>` block): overlay hidden by default; on `is-menu-open` the menu `<ul>` is hidden and the overlay shown — scoped to `.has-overlay-template` so non-overlay navs are untouched.
- Graceful fallback to menu-only on: cms-framework absent, unresolvable slug, resolved record not in `navigation-overlay` area, empty blocks, or any thrown exception (logged).

## How Has This Been Tested?

**Testing Environment:**
- macOS / Safari 26.5
- Keystone CMS `release/1.0` site editor + public front-end
- PHP 8.4 / Laravel 12

**Tests Performed:**
1. Set an overlay template-part with distinct content on the header nav. Desktop (≥600px): inline menu unchanged. Mobile (<600px): hamburger drawer shows the overlay content, not the duplicated menu.
2. Toggled viewport width — menu ↔ overlay swap cleanly.
3. Nav without an overlay: drawer still shows the menu (no regression).

## Tests Added

- [x] Unit/feature tests added
- [x] All tests passing

**Test details:** 3 new feature tests in `BlocksComponentTest.php` (overlay resolves → dual-render; resolves to non-overlay area → menu-only fallback; resolves to null → menu-only fallback). Stubs cms-framework's resolver via a container binding. Full RendererBlade suite: **164 passing**.

## Pre-Submission Checklist

- [x] Code passes all tests
- [x] Self-review completed
- [x] Comments added for complex code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Navigation blocks now support custom overlay templates in responsive navigation drawers, displaying selected overlay content instead of duplicating the inline menu.
  * Graceful fallback to original menu behavior if overlay resolution fails.

* **Tests**
  * Added comprehensive test coverage for navigation overlay functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArtisanPack-UI/visual-editor/pull/466?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->