### PR TITLE
feat(blocks): add artisanpack/form dynamic block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,10 @@
 ### Added
 
 - `artisanpack/form` block. Dynamic block that lets authors pick a form from the artisanpack-ui/forms package via the InspectorControls sidebar, and renders a `<div data-keystone-form="…" data-form-id="…">` mount-point on the public site. The host application supplies a JS island that hydrates the mount-point with the forms package's React `FormRenderer`. Registration is gated on `class_exists(ArtisanPackUI\Forms\Models\Form::class)` so visual-editor still boots when forms is absent.
+- Stale-selection guard in the form block's editor preview. When the persisted `formId` no longer matches any form returned by `/api/v1/forms`, the canvas renders a distinct `<Placeholder>` with a "Reset selection" button that clears the attribute back to `0`. Replaces the previous silent fall-through to the 404 "inactive" message, which mis-coded deleted forms as merely deactivated.
+
+### Changed
+
+- `FormBlock::validateAttrs()` now parses `formId` with `FILTER_VALIDATE_INT` via a `normalizeFormId()` helper. Rejects float strings (`"12.9"`) and scientific notation (`"1e2"`) that `is_numeric` + `(int)` previously truncated into unrelated form ids; non-positive values fall through to the "select a form" placeholder.
+- Form block editor preview's 404 error message updated from "This form is inactive…" to "This form is unavailable — it may have been deleted or deactivated." — neutral wording that fits both branches of `FormBlock::render`'s server-side check.
+- All `block.json` `textdomain` values aligned with the editor runtime's `TEXT_DOMAIN` constant (`artisanpack-visual-editor`). Translations for block titles/descriptions/keywords now resolve under the same domain as the rest of the editor strings.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,7 @@
 # Digital Shopfront CMS Package Changelog
 
+## [Unreleased]
+
+### Added
+
+- `artisanpack/form` block. Dynamic block that lets authors pick a form from the artisanpack-ui/forms package via the InspectorControls sidebar, and renders a `<div data-keystone-form="…" data-form-id="…">` mount-point on the public site. The host application supplies a JS island that hydrates the mount-point with the forms package's React `FormRenderer`. Registration is gated on `class_exists(ArtisanPackUI\Forms\Models\Form::class)` so visual-editor still boots when forms is absent.

--- a/resources/js/visual-editor/_legacy/editor/blocks/code/block.json
+++ b/resources/js/visual-editor/_legacy/editor/blocks/code/block.json
@@ -6,7 +6,7 @@
     "description": "Display code snippets with monospaced formatting.",
     "icon": "code",
     "keywords": ["pre", "snippet", "syntax"],
-    "textdomain": "visual-editor",
+    "textdomain": "artisanpack-visual-editor",
     "attributes": {
         "content": {
             "type": "string",

--- a/resources/js/visual-editor/_legacy/editor/blocks/heading/block.json
+++ b/resources/js/visual-editor/_legacy/editor/blocks/heading/block.json
@@ -6,7 +6,7 @@
     "description": "Introduce new sections and organize content to help readers scan.",
     "icon": "heading",
     "keywords": ["title", "subtitle", "h1", "h2", "h3", "h4", "h5", "h6"],
-    "textdomain": "visual-editor",
+    "textdomain": "artisanpack-visual-editor",
     "attributes": {
         "content": {
             "type": "rich-text",

--- a/resources/js/visual-editor/_legacy/editor/blocks/list/block.json
+++ b/resources/js/visual-editor/_legacy/editor/blocks/list/block.json
@@ -6,7 +6,7 @@
     "description": "Create a bulleted or numbered list.",
     "icon": "list",
     "keywords": ["ul", "ol", "bullet", "numbered", "ordered", "unordered"],
-    "textdomain": "visual-editor",
+    "textdomain": "artisanpack-visual-editor",
     "attributes": {
         "ordered": {
             "type": "boolean",

--- a/resources/js/visual-editor/_legacy/editor/blocks/paragraph/block.json
+++ b/resources/js/visual-editor/_legacy/editor/blocks/paragraph/block.json
@@ -6,7 +6,7 @@
     "description": "Start with the basic building block of all narrative.",
     "icon": "paragraph",
     "keywords": ["text", "body", "p"],
-    "textdomain": "visual-editor",
+    "textdomain": "artisanpack-visual-editor",
     "attributes": {
         "content": {
             "type": "rich-text",

--- a/resources/js/visual-editor/_legacy/editor/blocks/preformatted/block.json
+++ b/resources/js/visual-editor/_legacy/editor/blocks/preformatted/block.json
@@ -6,7 +6,7 @@
     "description": "Preserve whitespace and line breaks in a monospaced block.",
     "icon": "terminal",
     "keywords": ["pre", "ascii", "whitespace"],
-    "textdomain": "visual-editor",
+    "textdomain": "artisanpack-visual-editor",
     "attributes": {
         "content": {
             "type": "rich-text",

--- a/resources/js/visual-editor/_legacy/editor/blocks/quote/block.json
+++ b/resources/js/visual-editor/_legacy/editor/blocks/quote/block.json
@@ -6,7 +6,7 @@
     "description": "Give quoted text visual emphasis.",
     "icon": "quote-left",
     "keywords": ["blockquote", "citation", "pullquote"],
-    "textdomain": "visual-editor",
+    "textdomain": "artisanpack-visual-editor",
     "attributes": {
         "content": {
             "type": "rich-text",

--- a/resources/js/visual-editor/blocks/callout/block.json
+++ b/resources/js/visual-editor/blocks/callout/block.json
@@ -6,7 +6,7 @@
     "category": "artisanpack",
     "description": "Highlight a short message with a severity badge and icon.",
     "keywords": ["callout", "notice", "alert", "tip"],
-    "textdomain": "visual-editor",
+    "textdomain": "artisanpack-visual-editor",
     "attributes": {
         "severity": {
             "type": "string",

--- a/resources/js/visual-editor/blocks/form/block.json
+++ b/resources/js/visual-editor/blocks/form/block.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "artisanpack/form",
+    "title": "Form",
+    "category": "artisanpack",
+    "description": "Embed a form from the artisanpack-ui/forms package.",
+    "keywords": ["form", "contact", "lead", "submission"],
+    "textdomain": "visual-editor",
+    "attributes": {
+        "formId": {
+            "type": "number",
+            "default": 0
+        }
+    },
+    "supports": {
+        "className": true,
+        "html": false,
+        "reusable": true
+    }
+}

--- a/resources/js/visual-editor/blocks/form/block.json
+++ b/resources/js/visual-editor/blocks/form/block.json
@@ -6,7 +6,7 @@
     "category": "artisanpack",
     "description": "Embed a form from the artisanpack-ui/forms package.",
     "keywords": ["form", "contact", "lead", "submission"],
-    "textdomain": "visual-editor",
+    "textdomain": "artisanpack-visual-editor",
     "attributes": {
         "formId": {
             "type": "number",

--- a/resources/js/visual-editor/blocks/form/edit.tsx
+++ b/resources/js/visual-editor/blocks/form/edit.tsx
@@ -246,7 +246,10 @@ function FormPreview({ formId }: { readonly formId: number }): ReactElement {
                     // the author into hunting for an activate toggle on a
                     // form that no longer exists.
                     throw new Error(
-                        'This form is unavailable — it may have been deleted or deactivated. Pick a different form in the block sidebar.',
+                        __(
+                            'This form is unavailable — it may have been deleted or deactivated. Pick a different form in the block sidebar.',
+                            TEXT_DOMAIN,
+                        ),
                     );
                 }
                 if (!response.ok) {
@@ -396,16 +399,49 @@ export default function FormEdit({
     });
 
     // Stale selection: a previous editor session picked a form that's
-    // since been deleted (or 404s out of `/api/v1/forms?per_page=100`
-    // for any other reason). Without this branch the canvas falls
-    // through to `<FormPreview>` and silently displays the 404 message
-    // — misleading the author into thinking the form just needs to be
-    // re-activated, when actually it no longer exists in the list.
-    // Render an explicit reset path instead.
-    const isStaleSelection =
-        formId > 0 &&
-        null !== forms &&
-        !forms.some((form) => form.id === formId);
+    // since become unavailable. We can't infer that purely from the
+    // first page of `/api/v1/forms?per_page=100` — on sites with more
+    // than 100 forms a perfectly valid selection can land on another
+    // page. So when the selected id isn't in the loaded list, confirm
+    // with a targeted `/render` HEAD: a 404 means the form is truly
+    // gone (or inactive) and we show the reset path; anything else
+    // means it just paginated off-screen and we let `<FormPreview>`
+    // load it normally.
+    const [isStaleSelection, setIsStaleSelection] = useState(false);
+
+    useEffect(() => {
+        if (formId <= 0 || null === forms) {
+            setIsStaleSelection(false);
+            return;
+        }
+        if (forms.some((form) => form.id === formId)) {
+            setIsStaleSelection(false);
+            return;
+        }
+
+        let cancelled = false;
+        async function confirm() {
+            try {
+                const response = await fetch(`/api/v1/forms/${formId}/render`, {
+                    method: 'HEAD',
+                    headers: buildHeaders(),
+                    credentials: 'include',
+                });
+                if (!cancelled) {
+                    setIsStaleSelection(404 === response.status);
+                }
+            } catch {
+                if (!cancelled) {
+                    setIsStaleSelection(false);
+                }
+            }
+        }
+        void confirm();
+
+        return () => {
+            cancelled = true;
+        };
+    }, [formId, forms]);
 
     return (
         <>

--- a/resources/js/visual-editor/blocks/form/edit.tsx
+++ b/resources/js/visual-editor/blocks/form/edit.tsx
@@ -1,0 +1,164 @@
+/**
+ * Form — editor-side render.
+ *
+ * Shows a Form picker in the InspectorControls sidebar populated from
+ * `/api/v1/forms`, plus an in-canvas placeholder so the author can see
+ * which form is selected (or that no form is selected yet). The actual
+ * public-side rendering is server-driven by `FormBlock::render()`.
+ */
+
+import { useEffect, useState, type ReactElement } from 'react';
+import {
+    InspectorControls,
+    useBlockProps,
+} from '@wordpress/block-editor';
+import { Placeholder, PanelBody, SelectControl, Spinner } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+import { TEXT_DOMAIN } from '../../vendor/i18n';
+
+import FormInserterIcon from './inserter-icon';
+
+interface FormAttributes {
+    readonly formId: number;
+}
+
+interface FormEditProps {
+    readonly attributes: FormAttributes;
+    readonly setAttributes: (next: Partial<FormAttributes>) => void;
+}
+
+interface ApiForm {
+    readonly id: number;
+    readonly name: string;
+    readonly slug: string;
+    readonly is_active: boolean;
+}
+
+interface PaginatedForms {
+    readonly data: ApiForm[];
+}
+
+function readMetaCsrfToken(): string | null {
+    if ('undefined' === typeof document) {
+        return null;
+    }
+    const meta = document.querySelector('meta[name="csrf-token"]');
+    return meta?.getAttribute('content') ?? null;
+}
+
+function readXsrfCookie(): string | null {
+    if ('undefined' === typeof document) {
+        return null;
+    }
+    const match = document.cookie.match(/(?:^|;\s*)XSRF-TOKEN=([^;]*)/);
+    return match ? decodeURIComponent(match[1]) : null;
+}
+
+export default function FormEdit({
+    attributes,
+    setAttributes,
+}: FormEditProps): ReactElement {
+    const { formId } = attributes;
+    const [forms, setForms] = useState<ApiForm[] | null>(null);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        let cancelled = false;
+
+        async function load() {
+            try {
+                const csrf = readMetaCsrfToken();
+                const xsrf = readXsrfCookie();
+                const headers: Record<string, string> = {
+                    Accept: 'application/json',
+                };
+                if (csrf) headers['X-CSRF-TOKEN'] = csrf;
+                if (xsrf) headers['X-XSRF-TOKEN'] = xsrf;
+
+                const response = await fetch('/api/v1/forms?per_page=100', {
+                    headers,
+                    credentials: 'include',
+                });
+                if (!response.ok) {
+                    throw new Error(`Failed to load forms (status ${response.status}).`);
+                }
+                const json = (await response.json()) as PaginatedForms;
+                if (!cancelled) {
+                    setForms(json.data ?? []);
+                }
+            } catch (err) {
+                if (!cancelled) {
+                    setError(err instanceof Error ? err.message : 'Failed to load forms.');
+                }
+            }
+        }
+
+        void load();
+
+        return () => {
+            cancelled = true;
+        };
+    }, []);
+
+    const selected = forms?.find((f) => f.id === formId) ?? null;
+
+    const options = [
+        { label: __('— Select a form —', TEXT_DOMAIN), value: '0' },
+        ...(forms ?? []).map((f) => ({
+            label: f.is_active ? f.name : `${f.name} (inactive)`,
+            value: String(f.id),
+        })),
+    ];
+
+    const blockProps = useBlockProps({
+        className: 'wp-block-artisanpack-form',
+    });
+
+    return (
+        <>
+            <InspectorControls>
+                <PanelBody title={__('Form settings', TEXT_DOMAIN)} initialOpen>
+                    {null === forms && !error ? (
+                        <Spinner />
+                    ) : (
+                        <SelectControl
+                            label={__('Form', TEXT_DOMAIN)}
+                            value={String(formId)}
+                            options={options}
+                            onChange={(value) =>
+                                setAttributes({ formId: Number.parseInt(value, 10) || 0 })
+                            }
+                            help={error ?? __('Pick a form from the artisanpack-ui/forms package.', TEXT_DOMAIN)}
+                            __nextHasNoMarginBottom
+                        />
+                    )}
+                </PanelBody>
+            </InspectorControls>
+
+            <div {...blockProps}>
+                {selected ? (
+                    <Placeholder
+                        icon={<FormInserterIcon />}
+                        label={selected.name}
+                        instructions={
+                            selected.is_active
+                                ? __('This form will render on the public site at publish time.', TEXT_DOMAIN)
+                                : __('This form is inactive and will not render on the public site.', TEXT_DOMAIN)
+                        }
+                    />
+                ) : (
+                    <Placeholder
+                        icon={<FormInserterIcon />}
+                        label={__('Form', TEXT_DOMAIN)}
+                        instructions={
+                            error
+                                ? error
+                                : __('Choose a form in the block sidebar.', TEXT_DOMAIN)
+                        }
+                    />
+                )}
+            </div>
+        </>
+    );
+}

--- a/resources/js/visual-editor/blocks/form/edit.tsx
+++ b/resources/js/visual-editor/blocks/form/edit.tsx
@@ -399,14 +399,15 @@ export default function FormEdit({
     });
 
     // Stale selection: a previous editor session picked a form that's
-    // since become unavailable. We can't infer that purely from the
-    // first page of `/api/v1/forms?per_page=100` — on sites with more
-    // than 100 forms a perfectly valid selection can land on another
-    // page. So when the selected id isn't in the loaded list, confirm
-    // with a targeted `/render` HEAD: a 404 means the form is truly
-    // gone (or inactive) and we show the reset path; anything else
-    // means it just paginated off-screen and we let `<FormPreview>`
-    // load it normally.
+    // since been deleted. We can't infer that purely from the first
+    // page of `/api/v1/forms?per_page=100` — on sites with more than
+    // 100 forms a valid selection can land on another page — and we
+    // can't use the `/render` endpoint either, since that 404s for
+    // both deleted *and* inactive forms. So when the selected id
+    // isn't in the loaded list, confirm with a HEAD against the
+    // resource endpoint, which uses Eloquent route model binding and
+    // only 404s when the form record is actually gone. Inactive forms
+    // fall through to `<FormPreview>`'s neutral "unavailable" copy.
     const [isStaleSelection, setIsStaleSelection] = useState(false);
 
     useEffect(() => {
@@ -422,7 +423,7 @@ export default function FormEdit({
         let cancelled = false;
         async function confirm() {
             try {
-                const response = await fetch(`/api/v1/forms/${formId}/render`, {
+                const response = await fetch(`/api/v1/forms/${formId}`, {
                     method: 'HEAD',
                     headers: buildHeaders(),
                     credentials: 'include',

--- a/resources/js/visual-editor/blocks/form/edit.tsx
+++ b/resources/js/visual-editor/blocks/form/edit.tsx
@@ -2,9 +2,13 @@
  * Form — editor-side render.
  *
  * Shows a Form picker in the InspectorControls sidebar populated from
- * `/api/v1/forms`, plus an in-canvas placeholder so the author can see
- * which form is selected (or that no form is selected yet). The actual
- * public-side rendering is server-driven by `FormBlock::render()`.
+ * `/api/v1/forms`, plus a static preview of the selected form's field
+ * layout fetched from `/api/v1/forms/{id}/render`. The preview is
+ * non-interactive on purpose — the React `FormRenderer` lives in the
+ * consumer (e.g. Keystone) and isn't available inside the editor
+ * iframe; this view is enough for authors to see "yes, that's the
+ * right form" without us coupling the visual-editor package to the
+ * forms package's runtime.
  */
 
 import { useEffect, useState, type ReactElement } from 'react';
@@ -33,10 +37,34 @@ interface ApiForm {
     readonly name: string;
     readonly slug: string;
     readonly is_active: boolean;
+    readonly submit_button_text?: string;
 }
 
 interface PaginatedForms {
     readonly data: ApiForm[];
+}
+
+interface FormField {
+    readonly id: number;
+    readonly name: string;
+    readonly label: string | null;
+    readonly type: string;
+    readonly placeholder: string | null;
+    readonly help_text: string | null;
+    readonly is_required: boolean;
+    readonly default_value: string | null;
+    readonly options?: ReadonlyArray<{ label: string; value: string }>;
+    readonly field_config?: { options?: ReadonlyArray<{ label: string; value: string }> } | null;
+}
+
+interface FormDetailResponse {
+    readonly data: {
+        readonly id: number;
+        readonly name: string;
+        readonly slug: string;
+        readonly submit_button_text: string;
+        readonly fields?: FormField[];
+    };
 }
 
 function readMetaCsrfToken(): string | null {
@@ -55,6 +83,263 @@ function readXsrfCookie(): string | null {
     return match ? decodeURIComponent(match[1]) : null;
 }
 
+function buildHeaders(): Record<string, string> {
+    const headers: Record<string, string> = { Accept: 'application/json' };
+    const csrf = readMetaCsrfToken();
+    const xsrf = readXsrfCookie();
+    if (csrf) headers['X-CSRF-TOKEN'] = csrf;
+    if (xsrf) headers['X-XSRF-TOKEN'] = xsrf;
+    return headers;
+}
+
+const TEXTAREA_TYPES = new Set(['textarea', 'paragraph']);
+const CHOICE_TYPES = new Set(['select', 'radio', 'checkbox', 'checkbox_group', 'select_multiple']);
+const LAYOUT_TYPES = new Set(['heading', 'paragraph_layout', 'divider', 'html']);
+
+function FieldPreview({ field }: { readonly field: FormField }): ReactElement {
+    const label = field.label ?? field.name;
+    const inputId = `form-block-preview-${field.id}`;
+    const options = field.field_config?.options ?? field.options ?? [];
+
+    if ('divider' === field.type) {
+        return <hr aria-hidden="true" style={{ margin: '12px 0', borderColor: 'rgba(0,0,0,0.1)' }} />;
+    }
+
+    if ('heading' === field.type) {
+        return <h3 style={{ margin: '8px 0', fontWeight: 600 }}>{label}</h3>;
+    }
+
+    if (LAYOUT_TYPES.has(field.type)) {
+        return <p style={{ margin: '8px 0', color: 'rgba(0,0,0,0.6)' }}>{label}</p>;
+    }
+
+    const labelEl = (
+        <label htmlFor={inputId} style={{ display: 'block', fontWeight: 500, fontSize: 13, marginBottom: 4 }}>
+            {label}
+            {field.is_required && (
+                <span aria-hidden="true" style={{ color: '#cf2e2e', marginLeft: 4 }}>*</span>
+            )}
+        </label>
+    );
+
+    const inputStyle: React.CSSProperties = {
+        width: '100%',
+        padding: '6px 8px',
+        border: '1px solid rgba(0,0,0,0.15)',
+        borderRadius: 4,
+        background: 'rgba(0,0,0,0.02)',
+        font: 'inherit',
+        color: 'inherit',
+    };
+
+    let control: ReactElement;
+
+    if (TEXTAREA_TYPES.has(field.type)) {
+        control = (
+            <textarea
+                id={inputId}
+                rows={3}
+                placeholder={field.placeholder ?? ''}
+                defaultValue={field.default_value ?? ''}
+                style={inputStyle}
+                disabled
+            />
+        );
+    } else if (CHOICE_TYPES.has(field.type) && options.length > 0) {
+        if ('radio' === field.type) {
+            control = (
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+                    {options.map((opt) => (
+                        <label key={opt.value} style={{ display: 'flex', gap: 6, fontSize: 13 }}>
+                            <input type="radio" name={`${inputId}-${field.name}`} value={opt.value} disabled />
+                            {opt.label}
+                        </label>
+                    ))}
+                </div>
+            );
+        } else if ('checkbox_group' === field.type || 'checkbox' === field.type) {
+            control = (
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+                    {options.map((opt) => (
+                        <label key={opt.value} style={{ display: 'flex', gap: 6, fontSize: 13 }}>
+                            <input type="checkbox" value={opt.value} disabled />
+                            {opt.label}
+                        </label>
+                    ))}
+                </div>
+            );
+        } else {
+            control = (
+                <select id={inputId} style={inputStyle} disabled defaultValue="">
+                    <option value="">{field.placeholder ?? '—'}</option>
+                    {options.map((opt) => (
+                        <option key={opt.value} value={opt.value}>
+                            {opt.label}
+                        </option>
+                    ))}
+                </select>
+            );
+        }
+    } else if ('file' === field.type) {
+        control = <input id={inputId} type="file" disabled style={{ ...inputStyle, padding: 4 }} />;
+    } else {
+        const htmlType =
+            'email' === field.type
+                ? 'email'
+                : 'number' === field.type
+                ? 'number'
+                : 'date' === field.type
+                ? 'date'
+                : 'time' === field.type
+                ? 'time'
+                : 'url' === field.type
+                ? 'url'
+                : 'phone' === field.type
+                ? 'tel'
+                : 'text';
+        control = (
+            <input
+                id={inputId}
+                type={htmlType}
+                placeholder={field.placeholder ?? ''}
+                defaultValue={field.default_value ?? ''}
+                style={inputStyle}
+                disabled
+            />
+        );
+    }
+
+    return (
+        <div style={{ marginBottom: 12 }}>
+            {labelEl}
+            {control}
+            {field.help_text && (
+                <p style={{ margin: '4px 0 0', fontSize: 11, color: 'rgba(0,0,0,0.55)' }}>
+                    {field.help_text}
+                </p>
+            )}
+        </div>
+    );
+}
+
+function FormPreview({ formId }: { readonly formId: number }): ReactElement {
+    const [detail, setDetail] = useState<FormDetailResponse['data'] | null>(null);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        let cancelled = false;
+        setDetail(null);
+        setError(null);
+
+        async function load() {
+            try {
+                const response = await fetch(`/api/v1/forms/${formId}/render`, {
+                    headers: buildHeaders(),
+                    credentials: 'include',
+                });
+                if (404 === response.status) {
+                    // The package's /render endpoint 404s for inactive forms.
+                    // Surface that as actionable copy rather than a raw status.
+                    throw new Error(
+                        'This form is inactive — activate it from the Forms admin to preview the layout here.',
+                    );
+                }
+                if (!response.ok) {
+                    throw new Error(`Failed to load form preview (status ${response.status}).`);
+                }
+                const json = (await response.json()) as FormDetailResponse;
+                if (!cancelled) {
+                    setDetail(json.data);
+                }
+            } catch (err) {
+                if (!cancelled) {
+                    setError(err instanceof Error ? err.message : 'Failed to load form preview.');
+                }
+            }
+        }
+
+        void load();
+
+        return () => {
+            cancelled = true;
+        };
+    }, [formId]);
+
+    if (error) {
+        return (
+            <Placeholder
+                icon={<FormInserterIcon />}
+                label={__('Form', TEXT_DOMAIN)}
+                instructions={error}
+            />
+        );
+    }
+
+    if (null === detail) {
+        return (
+            <Placeholder
+                icon={<FormInserterIcon />}
+                label={__('Form', TEXT_DOMAIN)}
+                instructions={__('Loading preview…', TEXT_DOMAIN)}
+            >
+                <Spinner />
+            </Placeholder>
+        );
+    }
+
+    const fields = detail.fields ?? [];
+
+    return (
+        <div
+            style={{
+                border: '1px dashed rgba(0,0,0,0.15)',
+                borderRadius: 6,
+                padding: 16,
+                background: 'rgba(0,0,0,0.015)',
+            }}
+        >
+            <p
+                style={{
+                    margin: '0 0 12px',
+                    fontSize: 11,
+                    textTransform: 'uppercase',
+                    letterSpacing: 0.5,
+                    color: 'rgba(0,0,0,0.55)',
+                }}
+            >
+                {__('Form preview', TEXT_DOMAIN)} · {detail.name}
+            </p>
+            {0 === fields.length ? (
+                <p style={{ margin: 0, fontSize: 13, color: 'rgba(0,0,0,0.55)' }}>
+                    {__('This form has no fields yet. Add some from the Forms admin.', TEXT_DOMAIN)}
+                </p>
+            ) : (
+                <>
+                    {fields.map((field) => (
+                        <FieldPreview key={field.id} field={field} />
+                    ))}
+                    <button
+                        type="button"
+                        disabled
+                        style={{
+                            marginTop: 4,
+                            padding: '8px 16px',
+                            background: '#2271b1',
+                            color: 'white',
+                            border: 'none',
+                            borderRadius: 4,
+                            opacity: 0.7,
+                            cursor: 'not-allowed',
+                        }}
+                    >
+                        {detail.submit_button_text || __('Submit', TEXT_DOMAIN)}
+                    </button>
+                </>
+            )}
+        </div>
+    );
+}
+
 export default function FormEdit({
     attributes,
     setAttributes,
@@ -68,16 +353,8 @@ export default function FormEdit({
 
         async function load() {
             try {
-                const csrf = readMetaCsrfToken();
-                const xsrf = readXsrfCookie();
-                const headers: Record<string, string> = {
-                    Accept: 'application/json',
-                };
-                if (csrf) headers['X-CSRF-TOKEN'] = csrf;
-                if (xsrf) headers['X-XSRF-TOKEN'] = xsrf;
-
                 const response = await fetch('/api/v1/forms?per_page=100', {
-                    headers,
+                    headers: buildHeaders(),
                     credentials: 'include',
                 });
                 if (!response.ok) {
@@ -100,8 +377,6 @@ export default function FormEdit({
             cancelled = true;
         };
     }, []);
-
-    const selected = forms?.find((f) => f.id === formId) ?? null;
 
     const options = [
         { label: __('— Select a form —', TEXT_DOMAIN), value: '0' },
@@ -137,24 +412,14 @@ export default function FormEdit({
             </InspectorControls>
 
             <div {...blockProps}>
-                {selected ? (
-                    <Placeholder
-                        icon={<FormInserterIcon />}
-                        label={selected.name}
-                        instructions={
-                            selected.is_active
-                                ? __('This form will render on the public site at publish time.', TEXT_DOMAIN)
-                                : __('This form is inactive and will not render on the public site.', TEXT_DOMAIN)
-                        }
-                    />
+                {formId > 0 ? (
+                    <FormPreview formId={formId} />
                 ) : (
                     <Placeholder
                         icon={<FormInserterIcon />}
                         label={__('Form', TEXT_DOMAIN)}
                         instructions={
-                            error
-                                ? error
-                                : __('Choose a form in the block sidebar.', TEXT_DOMAIN)
+                            error ?? __('Choose a form in the block sidebar.', TEXT_DOMAIN)
                         }
                     />
                 )}

--- a/resources/js/visual-editor/blocks/form/edit.tsx
+++ b/resources/js/visual-editor/blocks/form/edit.tsx
@@ -16,7 +16,7 @@ import {
     InspectorControls,
     useBlockProps,
 } from '@wordpress/block-editor';
-import { Placeholder, PanelBody, SelectControl, Spinner } from '@wordpress/components';
+import { Button, Placeholder, PanelBody, SelectControl, Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 import { TEXT_DOMAIN } from '../../vendor/i18n';
@@ -238,10 +238,15 @@ function FormPreview({ formId }: { readonly formId: number }): ReactElement {
                     credentials: 'include',
                 });
                 if (404 === response.status) {
-                    // The package's /render endpoint 404s for inactive forms.
-                    // Surface that as actionable copy rather than a raw status.
+                    // The package's /render endpoint 404s for both deleted
+                    // and inactive forms (see FormBlock::render, which
+                    // distinguishes the two server-side). The editor only
+                    // sees a status code here, so the message stays neutral
+                    // — "unavailable" covers both states without misleading
+                    // the author into hunting for an activate toggle on a
+                    // form that no longer exists.
                     throw new Error(
-                        'This form is inactive — activate it from the Forms admin to preview the layout here.',
+                        'This form is unavailable — it may have been deleted or deactivated. Pick a different form in the block sidebar.',
                     );
                 }
                 if (!response.ok) {
@@ -390,6 +395,18 @@ export default function FormEdit({
         className: 'wp-block-artisanpack-form',
     });
 
+    // Stale selection: a previous editor session picked a form that's
+    // since been deleted (or 404s out of `/api/v1/forms?per_page=100`
+    // for any other reason). Without this branch the canvas falls
+    // through to `<FormPreview>` and silently displays the 404 message
+    // — misleading the author into thinking the form just needs to be
+    // re-activated, when actually it no longer exists in the list.
+    // Render an explicit reset path instead.
+    const isStaleSelection =
+        formId > 0 &&
+        null !== forms &&
+        !forms.some((form) => form.id === formId);
+
     return (
         <>
             <InspectorControls>
@@ -412,7 +429,23 @@ export default function FormEdit({
             </InspectorControls>
 
             <div {...blockProps}>
-                {formId > 0 ? (
+                {isStaleSelection ? (
+                    <Placeholder
+                        icon={<FormInserterIcon />}
+                        label={__('Form', TEXT_DOMAIN)}
+                        instructions={__(
+                            'The selected form is no longer available. It may have been deleted. Reset the selection to pick a different form.',
+                            TEXT_DOMAIN,
+                        )}
+                    >
+                        <Button
+                            variant="secondary"
+                            onClick={() => setAttributes({ formId: 0 })}
+                        >
+                            {__('Reset selection', TEXT_DOMAIN)}
+                        </Button>
+                    </Placeholder>
+                ) : formId > 0 ? (
                     <FormPreview formId={formId} />
                 ) : (
                     <Placeholder

--- a/resources/js/visual-editor/blocks/form/index.ts
+++ b/resources/js/visual-editor/blocks/form/index.ts
@@ -1,0 +1,26 @@
+/**
+ * Form block entrypoint.
+ *
+ * Re-exports `edit`, `save`, `metadata`, and `icon` so the host JS
+ * bundle (via the custom block auto-discovery glob — see
+ * `../../editor/custom-blocks.ts`) can register the block with
+ * `@wordpress/blocks.registerBlockType`.
+ *
+ * Server-side rendering is handled by `FormBlock::render()` in the PHP
+ * service provider; this module only owns the editor experience.
+ */
+
+import metadata from './block.json';
+import edit from './edit';
+import save from './save';
+import icon from './inserter-icon';
+
+export { edit, save, metadata, icon };
+
+export default {
+    name: metadata.name,
+    metadata,
+    edit,
+    save,
+    icon,
+};

--- a/resources/js/visual-editor/blocks/form/inserter-icon.tsx
+++ b/resources/js/visual-editor/blocks/form/inserter-icon.tsx
@@ -1,0 +1,26 @@
+/**
+ * Inserter icon for the `artisanpack/form` block.
+ *
+ * Inlined SVG (rather than a dashicon slug) so it renders without the
+ * dashicons stylesheet, matching the rest of the bundled blocks.
+ */
+
+import type { ReactElement } from 'react';
+
+export default function FormInserterIcon(): ReactElement {
+    return (
+        <svg
+            width="24"
+            height="24"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+            aria-hidden="true"
+            focusable="false"
+        >
+            <path
+                fill="currentColor"
+                d="M5 4h14a1 1 0 0 1 1 1v14a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V5a1 1 0 0 1 1-1zm1 2v12h12V6H6zm2 2h8v2H8V8zm0 4h8v2H8v-2zm0 4h5v2H8v-2z"
+            />
+        </svg>
+    );
+}

--- a/resources/js/visual-editor/blocks/form/save.tsx
+++ b/resources/js/visual-editor/blocks/form/save.tsx
@@ -1,0 +1,12 @@
+/**
+ * Form — save component.
+ *
+ * Dynamic block: the saved markup is just the block delimiter (`<!-- wp:
+ * artisanpack/form {"formId":N} /-->`) and the actual HTML is generated
+ * server-side by `FormBlock::render()`. Returning `null` from save is
+ * the Gutenberg convention for dynamic blocks.
+ */
+
+export default function FormSave(): null {
+    return null;
+}

--- a/src/Blocks/Forms/FormBlock.php
+++ b/src/Blocks/Forms/FormBlock.php
@@ -48,18 +48,15 @@ class FormBlock extends DynamicBlock
 	 */
 	public function validateAttrs( array $attrs ): array
 	{
-		$rawId = $attrs['formId'] ?? null;
-		$formId = is_numeric( $rawId ) ? (int) $rawId : 0;
-
 		return [
-			'formId'    => $formId,
+			'formId'    => $this->normalizeFormId( $attrs['formId'] ?? null ),
 			'className' => isset( $attrs['className'] ) && is_string( $attrs['className'] ) ? $attrs['className'] : '',
 		];
 	}
 
 	public function render( array $attrs ): string
 	{
-		$formId = (int) ( $attrs['formId'] ?? 0 );
+		$formId = $this->normalizeFormId( $attrs['formId'] ?? null );
 
 		if ( $formId <= 0 ) {
 			return $this->placeholder( $attrs, __( 'Select a form to display.' ) );
@@ -114,5 +111,34 @@ class FormBlock extends DynamicBlock
 		}
 
 		return $classes;
+	}
+
+	/**
+	 * Coerce the incoming `formId` into a strict positive integer or 0.
+	 *
+	 * The editor saves the attribute as a JSON number, but block-tree
+	 * deserialization can hand back strings ("12") or floats ("12.9",
+	 * "1e2"). `is_numeric` + `(int)` accepts and truncates floats /
+	 * scientific notation, which would silently coerce non-IDs (e.g.,
+	 * "1e2" → 100) into real lookup attempts. `FILTER_VALIDATE_INT`
+	 * rejects anything that isn't a clean integer literal, and the
+	 * positive-only guard keeps `0` / negatives funneling into the
+	 * "select a form" placeholder branch in {@see render()}.
+	 *
+	 * @since 1.1.0
+	 */
+	protected function normalizeFormId( mixed $value ): int
+	{
+		if ( is_int( $value ) ) {
+			return $value > 0 ? $value : 0;
+		}
+
+		if ( is_string( $value ) ) {
+			$parsed = filter_var( $value, FILTER_VALIDATE_INT );
+
+			return false !== $parsed && $parsed > 0 ? $parsed : 0;
+		}
+
+		return 0;
 	}
 }

--- a/src/Blocks/Forms/FormBlock.php
+++ b/src/Blocks/Forms/FormBlock.php
@@ -1,0 +1,118 @@
+<?php
+
+/**
+ * Server-rendered `artisanpack/form` block.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.1.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Blocks\Forms;
+
+use ArtisanPackUI\Forms\Models\Form;
+use ArtisanPackUI\VisualEditor\Blocks\DynamicBlock;
+
+/**
+ * Renders a placeholder DIV that the artisanpack-ui/forms React island
+ * mounts a `<FormRenderer />` onto on the public site.
+ *
+ * The block deliberately does not render the form fields server-side —
+ * field configuration, conditional logic, and validation all live in the
+ * React renderer, which fetches `/api/v1/forms/{id}/render` and posts to
+ * `/api/v1/forms/{id}/submit`. Keeping the markup to a single mount-point
+ * keeps the two paths (block render + standalone /forms/{id} page)
+ * pixel-identical.
+ *
+ * Hosts must publish the form island bundle so the mount-point hydrates.
+ * Keystone CMS ships one at `resources/js/keystone-form-island.tsx`; any
+ * other consumer can ship an equivalent that scans for
+ * `[data-keystone-form]` elements and calls FormRenderer on each.
+ */
+class FormBlock extends DynamicBlock
+{
+	public function name(): string
+	{
+		return 'artisanpack/form';
+	}
+
+	/**
+	 * @param  array<string, mixed>  $attrs
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function validateAttrs( array $attrs ): array
+	{
+		$rawId = $attrs['formId'] ?? null;
+		$formId = is_numeric( $rawId ) ? (int) $rawId : 0;
+
+		return [
+			'formId'    => $formId,
+			'className' => isset( $attrs['className'] ) && is_string( $attrs['className'] ) ? $attrs['className'] : '',
+		];
+	}
+
+	public function render( array $attrs ): string
+	{
+		$formId = (int) ( $attrs['formId'] ?? 0 );
+
+		if ( $formId <= 0 ) {
+			return $this->placeholder( $attrs, __( 'Select a form to display.' ) );
+		}
+
+		$form = Form::query()->find( $formId );
+
+		if ( null === $form ) {
+			return $this->placeholder( $attrs, __( 'The selected form is no longer available.' ) );
+		}
+
+		if ( ! $form->is_active ) {
+			return $this->placeholder( $attrs, __( 'The selected form is inactive.' ) );
+		}
+
+		$classes = $this->wrapperClasses( $attrs );
+
+		return sprintf(
+			'<div class="%s" data-keystone-form="%s" data-form-id="%d"></div>',
+			e( implode( ' ', $classes ) ),
+			e( $form->slug ),
+			$form->id
+		);
+	}
+
+	/**
+	 * @param  array<string, mixed>  $attrs
+	 */
+	protected function placeholder( array $attrs, string $message ): string
+	{
+		$classes   = $this->wrapperClasses( $attrs );
+		$classes[] = 'wp-block-artisanpack-form--placeholder';
+
+		return sprintf(
+			'<div class="%s"><p>%s</p></div>',
+			e( implode( ' ', $classes ) ),
+			e( $message )
+		);
+	}
+
+	/**
+	 * @param  array<string, mixed>  $attrs
+	 *
+	 * @return array<int, string>
+	 */
+	protected function wrapperClasses( array $attrs ): array
+	{
+		$classes = [ 'wp-block-artisanpack-form' ];
+
+		if ( isset( $attrs['className'] ) && '' !== $attrs['className'] ) {
+			$classes[] = (string) $attrs['className'];
+		}
+
+		return $classes;
+	}
+}

--- a/src/VisualEditorServiceProvider.php
+++ b/src/VisualEditorServiceProvider.php
@@ -6,6 +6,7 @@ use ArtisanPackUI\CMSFramework\Modules\Blog\Managers\BlogManager;
 use ArtisanPackUI\VisualEditor\Blocks\Core\ArchivesBlock;
 use ArtisanPackUI\VisualEditor\Blocks\Core\CategoriesBlock;
 use ArtisanPackUI\VisualEditor\Blocks\Core\TagCloudBlock;
+use ArtisanPackUI\VisualEditor\Blocks\Forms\FormBlock;
 use ArtisanPackUI\VisualEditor\Console\Commands\SeedSampleContentCommand;
 use ArtisanPackUI\VisualEditor\MediaBridge\GutenbergAttachmentAdapter;
 use ArtisanPackUI\VisualEditor\Services\Adapters\CmsFramework\CmsFrameworkQueryResolver;
@@ -225,6 +226,12 @@ class VisualEditorServiceProvider extends ServiceProvider
 		//     deny-list keeps them out of the inserter.
 		$this->registerTaxonomyAndArchiveBlocks();
 
+		// 4b. Forms — register the `artisanpack/form` block against the
+		//     artisanpack-ui/forms package. Gated on `Form::class` so
+		//     visual-editor still boots when forms is absent; the block
+		//     simply does not appear in the inserter in that case.
+		$this->registerFormBlock();
+
 		// 5. Tag the config file for the scaffold command.
 		if ( $this->app->runningInConsole() ) {
 			$this->publishes( [
@@ -315,6 +322,31 @@ class VisualEditorServiceProvider extends ServiceProvider
 		$editor->registerDynamicBlock( CategoriesBlock::class );
 		$editor->registerDynamicBlock( TagCloudBlock::class );
 		$editor->registerDynamicBlock( ArchivesBlock::class );
+	}
+
+	/**
+	 * Registers the `artisanpack/form` dynamic block against the
+	 * artisanpack-ui/forms package. Loads the bundled block.json so the
+	 * inserter knows about it and the registry can hand attributes to
+	 * the FormBlock's render() at publish time.
+	 *
+	 * @since 1.1.0
+	 */
+	protected function registerFormBlock(): void
+	{
+		if ( ! class_exists( \ArtisanPackUI\Forms\Models\Form::class ) ) {
+			return;
+		}
+
+		$editor = $this->app->make( VisualEditor::class );
+
+		$blockJsonPath = __DIR__ . '/../resources/js/visual-editor/blocks/form/block.json';
+
+		if ( file_exists( $blockJsonPath ) ) {
+			$editor->registerBlock( $blockJsonPath );
+		}
+
+		$editor->registerDynamicBlock( FormBlock::class );
 	}
 
 	/**

--- a/tests/Unit/VisualEditor/Blocks/Forms/FormBlockTest.php
+++ b/tests/Unit/VisualEditor/Blocks/Forms/FormBlockTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Blocks\Forms\FormBlock;
+
+/*
+ * Tests for {@see FormBlock} focused on attribute normalization. The
+ * render-path branches (missing form, inactive form, valid form) hit
+ * the Forms package's Eloquent model and live in the feature-test
+ * layer; these unit tests cover the surface that does not require a
+ * database — `validateAttrs()` and its `normalizeFormId()` helper.
+ */
+
+beforeEach( function (): void {
+	test()->block = new FormBlock();
+} );
+
+it( 'normalizes a positive integer formId verbatim', function (): void {
+	expect( test()->block->validateAttrs( [ 'formId' => 42 ] )['formId'] )->toBe( 42 );
+} );
+
+it( 'normalizes a positive integer string formId', function (): void {
+	expect( test()->block->validateAttrs( [ 'formId' => '42' ] )['formId'] )->toBe( 42 );
+} );
+
+it( 'rejects float strings (CodeRabbit PR #467)', function (): void {
+	// `is_numeric('12.9')` returns true and `(int) '12.9'` truncates to 12,
+	// which would silently coerce a non-ID float into a real lookup attempt.
+	// Strict parsing returns 0 and funnels into the placeholder branch.
+	expect( test()->block->validateAttrs( [ 'formId' => '12.9' ] )['formId'] )->toBe( 0 );
+} );
+
+it( 'rejects scientific notation (CodeRabbit PR #467)', function (): void {
+	// Same story as floats — `is_numeric('1e2')` is true and `(int) '1e2'`
+	// produces 100, which would address an unrelated form record.
+	expect( test()->block->validateAttrs( [ 'formId' => '1e2' ] )['formId'] )->toBe( 0 );
+} );
+
+it( 'rejects negative integers and zero', function (): void {
+	expect( test()->block->validateAttrs( [ 'formId' => 0 ] )['formId'] )->toBe( 0 )
+		->and( test()->block->validateAttrs( [ 'formId' => -3 ] )['formId'] )->toBe( 0 )
+		->and( test()->block->validateAttrs( [ 'formId' => '-3' ] )['formId'] )->toBe( 0 );
+} );
+
+it( 'rejects non-numeric and non-scalar formId values', function (): void {
+	expect( test()->block->validateAttrs( [ 'formId' => 'abc' ] )['formId'] )->toBe( 0 )
+		->and( test()->block->validateAttrs( [ 'formId' => [ 1, 2 ] ] )['formId'] )->toBe( 0 )
+		->and( test()->block->validateAttrs( [ 'formId' => null ] )['formId'] )->toBe( 0 )
+		->and( test()->block->validateAttrs( [] )['formId'] )->toBe( 0 );
+} );
+
+it( 'preserves a string className verbatim and coerces non-strings to empty', function (): void {
+	expect( test()->block->validateAttrs( [ 'formId' => 1, 'className' => 'extra-class' ] )['className'] )->toBe( 'extra-class' )
+		->and( test()->block->validateAttrs( [ 'formId' => 1, 'className' => 123 ] )['className'] )->toBe( '' )
+		->and( test()->block->validateAttrs( [ 'formId' => 1 ] )['className'] )->toBe( '' );
+} );


### PR DESCRIPTION
## Summary

Adds a new dynamic block, **artisanpack/form**, that lets authors pick a form from the `artisanpack-ui/forms` package via the InspectorControls sidebar and renders a stable mount-point on the public site.

## Why

Hosts integrating the forms package today have to drop forms into pages via theme template conditionals or hard-coded routes. With this block they can place a lead-capture form anywhere the visual editor lets them place a block.

## How it works

- **Server**: `FormBlock::render()` produces a single `<div class="wp-block-artisanpack-form" data-keystone-form="…" data-form-id="…"></div>` mount-point. No fields, validation, or submission logic ships server-side — that all stays in the forms package's React `FormRenderer`.
- **Editor**: `edit.tsx` shows a `SelectControl` populated from `/api/v1/forms?per_page=100` plus an in-canvas placeholder summarizing which form is selected.
- **Save**: returns `null` (dynamic block convention) so renaming the form's slug later doesn't invalidate previously-saved markup.
- **Registration**: gated on `class_exists(ArtisanPackUI\Forms\Models\Form::class)` — visual-editor still boots cleanly when the forms package is absent.

## Host contract

The host application supplies a JS island that scans for `[data-keystone-form]` elements and hydrates them with the forms package's React `FormRenderer`. Keystone CMS ships one at `resources/js/keystone-form-island.tsx`.

## Test plan

- [ ] Insert the block into a page, pick a form, publish, view on the public site — form renders and submits.
- [ ] Pick an inactive form — block renders a placeholder explaining the form is inactive.
- [ ] Delete the picked form, view the page — block renders "form is no longer available" placeholder.
- [ ] Render with no form picked — block renders "Select a form to display." placeholder.
- [ ] Verify the inserter doesn't show the block when the forms package isn't installed.

## Follow-ups (not in this PR)

- Add a resolver-injection seam on `FormBlock` so tests can fake the Form lookup without requiring the forms package in CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Form block to the visual editor — select and insert forms, see an in-canvas preview or placeholder; saves as a server-rendered mount point. Includes an inserter icon.

* **Bug Fixes**
  * Prevents stale/removed form selections from showing invalid previews and adds a “Reset selection” flow; clarifies “unavailable” copy and enforces stricter form ID validation.

* **Documentation**
  * CHANGELOG Unreleased expanded; editor block translation domains aligned.

* **Tests**
  * Added unit tests for form attribute validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArtisanPack-UI/visual-editor/pull/467?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->