### PR TITLE
feat(form-block): full Gutenberg supports + site-editor parity + styles.* compiler

### DIFF
--- a/packages/visual-editor-renderer-blade/src/Services/ThemeJsonTokensCompiler.php
+++ b/packages/visual-editor-renderer-blade/src/Services/ThemeJsonTokensCompiler.php
@@ -2,17 +2,37 @@
 
 /**
  * Compiles a `theme.json` payload into a `:root { --wp--preset--*: …; }`
- * CSS block.
+ * CSS block, plus the `styles.*` declarations that drive the front-end
+ * rendering of root, element, and per-block styles.
  *
- * Mirrors WordPress's `--wp--preset--{category}--{slug}` naming so block
- * markup that already references those tokens (every Gutenberg core block's
- * preset attributes do) just works on the public site without each
- * consumer re-implementing the bridge.
+ * Two halves to the output:
  *
- * Categories covered today: `color.palette[]`, `color.gradient[]`,
- * `typography.fontSizes[]`, `spacing.spacingSizes[]`. Anything else passes
- * through untouched so theme.json files keep validating against WP's
- * schema while only the recognised sections drive CSS output.
+ *   1. `settings.*` → `--wp--preset--{category}--{slug}` custom properties
+ *      on `:root`. Mirrors WordPress's naming so block markup that already
+ *      references those tokens (every Gutenberg core block's preset
+ *      attributes do) just works on the public site without each consumer
+ *      re-implementing the bridge. Categories covered:
+ *      `color.palette[]`, `color.gradient[]`, `typography.fontSizes[]`,
+ *      `spacing.spacingSizes[]`.
+ *
+ *   2. `styles.*` → CSS rules at three levels:
+ *      - Root styles (`styles.color`, `styles.typography`, `styles.spacing`,
+ *        `styles.border`) → `body { … }`.
+ *      - Element styles (`styles.elements.{link, heading, h1..h6, button,
+ *        caption, cite}`) → canonical selectors (`a`, `h1, h2, …`,
+ *        `.wp-element-button`, etc.).
+ *      - Block styles (`styles.blocks["<namespace>/<slug>"]`) →
+ *        `.wp-block-<namespace>-<slug>` selectors. Nested
+ *        `styles.blocks[X].elements.Y` produces descendant rules so a
+ *        block can re-style its own headings/links without affecting
+ *        the rest of the page.
+ *
+ * Anything outside those recognised sections passes through untouched so
+ * theme.json files keep validating against WP's schema while only the
+ * recognised payload drives CSS output. Preset references in the
+ * `var:preset|{category}|{slug}` shorthand expand to
+ * `var(--wp--preset--{category}--{slug})` so the styles half feeds off
+ * the presets emitted in the first half.
  *
  * @package    ArtisanPack_UI
  * @subpackage VisualEditorRendererBlade
@@ -39,6 +59,7 @@ class ThemeJsonTokensCompiler
 	public function compile( array $themeJson ): string
 	{
 		$settings = is_array( $themeJson['settings'] ?? null ) ? $themeJson['settings'] : [];
+		$styles   = is_array( $themeJson['styles'] ?? null ) ? $themeJson['styles'] : [];
 
 		$declarations = array_merge(
 			$this->compilePresetList( $settings, [ 'color', 'palette' ], 'color', 'color' ),
@@ -52,15 +73,287 @@ class ThemeJsonTokensCompiler
 
 		$layout = $this->compileLayoutRules( $settings );
 
-		if ( '' === $root ) {
-			return $layout;
+		$stylesCss = $this->compileStyles( $styles );
+
+		$parts = array_values( array_filter( [ $root, $layout, $stylesCss ], static fn ( string $section ): bool => '' !== $section ) );
+
+		return implode( "\n\n", $parts );
+	}
+
+	/**
+	 * Compile the `styles.*` half of theme.json into CSS rules. Skipped
+	 * silently when the payload carries no recognised nodes.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @param  array<string, mixed>  $styles  `themeJson.styles` payload.
+	 */
+	protected function compileStyles( array $styles ): string
+	{
+		$rules = [];
+
+		// Root-level: anything declared at `styles.{color,typography,spacing,border}`
+		// applies to the document body so it cascades through every block
+		// and element. Skip if no recognised declarations are emitted.
+		$rootDeclarations = $this->compileStyleNode( $styles );
+
+		if ( '' !== $rootDeclarations ) {
+			$rules[] = "body {\n\t" . $rootDeclarations . "\n}";
 		}
 
-		if ( '' === $layout ) {
-			return $root;
+		// styles.elements.* — typed selectors. Per-element nodes can also
+		// carry sub-selectors via `:hover` / `:focus` state keys; we only
+		// cover the base state today since the editor surface itself
+		// doesn't expose state authoring yet.
+		$elements = is_array( $styles['elements'] ?? null ) ? $styles['elements'] : [];
+
+		foreach ( $elements as $name => $node ) {
+			if ( ! is_string( $name ) || ! is_array( $node ) ) {
+				continue;
+			}
+
+			$selector = $this->elementSelector( $name );
+
+			if ( null === $selector ) {
+				continue;
+			}
+
+			$declarations = $this->compileStyleNode( $node );
+
+			if ( '' !== $declarations ) {
+				$rules[] = $selector . " {\n\t" . $declarations . "\n}";
+			}
 		}
 
-		return $root . "\n\n" . $layout;
+		// styles.blocks[<name>] — per-block rules. Nested `elements`
+		// produces descendant rules so a block can override headings or
+		// links inside it without affecting siblings.
+		$blocks = is_array( $styles['blocks'] ?? null ) ? $styles['blocks'] : [];
+
+		foreach ( $blocks as $blockName => $node ) {
+			if ( ! is_string( $blockName ) || ! is_array( $node ) ) {
+				continue;
+			}
+
+			$blockSelector = $this->blockSelector( $blockName );
+			$declarations  = $this->compileStyleNode( $node );
+
+			if ( '' !== $declarations ) {
+				$rules[] = $blockSelector . " {\n\t" . $declarations . "\n}";
+			}
+
+			$nestedElements = is_array( $node['elements'] ?? null ) ? $node['elements'] : [];
+
+			foreach ( $nestedElements as $elementName => $elementNode ) {
+				if ( ! is_string( $elementName ) || ! is_array( $elementNode ) ) {
+					continue;
+				}
+
+				$elementSelector = $this->elementSelector( $elementName );
+
+				if ( null === $elementSelector ) {
+					continue;
+				}
+
+				$nestedDeclarations = $this->compileStyleNode( $elementNode );
+
+				if ( '' !== $nestedDeclarations ) {
+					$rules[] = $blockSelector . ' ' . $elementSelector . " {\n\t" . $nestedDeclarations . "\n}";
+				}
+			}
+		}
+
+		return implode( "\n\n", $rules );
+	}
+
+	/**
+	 * Convert a single style node (root, element, or block) into a
+	 * tab-indented list of CSS declarations. The node shape mirrors
+	 * Gutenberg's per-block style payload: `color.{background,text,gradient}`,
+	 * `typography.{fontFamily,fontSize,fontWeight,fontStyle,lineHeight,
+	 * letterSpacing,textTransform,textDecoration}`,
+	 * `spacing.{padding,margin,blockGap}` (string or per-side object),
+	 * and `border.{color,style,width,radius}` (radius may be string or
+	 * per-corner object).
+	 *
+	 * Preset references (`var:preset|color|primary`) expand to the
+	 * corresponding CSS custom property reference; non-preset values
+	 * pass through untouched.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @param  array<string, mixed>  $node
+	 */
+	protected function compileStyleNode( array $node ): string
+	{
+		$declarations = [];
+
+		$color = is_array( $node['color'] ?? null ) ? $node['color'] : [];
+
+		if ( isset( $color['background'] ) && is_string( $color['background'] ) && '' !== trim( $color['background'] ) ) {
+			$declarations[] = 'background-color: ' . $this->expandPresetReference( trim( $color['background'] ) ) . ';';
+		}
+
+		if ( isset( $color['gradient'] ) && is_string( $color['gradient'] ) && '' !== trim( $color['gradient'] ) ) {
+			$declarations[] = 'background: ' . $this->expandPresetReference( trim( $color['gradient'] ) ) . ';';
+		}
+
+		if ( isset( $color['text'] ) && is_string( $color['text'] ) && '' !== trim( $color['text'] ) ) {
+			$declarations[] = 'color: ' . $this->expandPresetReference( trim( $color['text'] ) ) . ';';
+		}
+
+		$typography = is_array( $node['typography'] ?? null ) ? $node['typography'] : [];
+		$typographyMap = [
+			'fontFamily'     => 'font-family',
+			'fontSize'       => 'font-size',
+			'fontWeight'     => 'font-weight',
+			'fontStyle'      => 'font-style',
+			'lineHeight'     => 'line-height',
+			'letterSpacing'  => 'letter-spacing',
+			'textTransform'  => 'text-transform',
+			'textDecoration' => 'text-decoration',
+		];
+
+		foreach ( $typographyMap as $key => $property ) {
+			$value = $typography[ $key ] ?? null;
+
+			if ( ! is_string( $value ) || '' === trim( $value ) ) {
+				continue;
+			}
+
+			$declarations[] = $property . ': ' . $this->expandPresetReference( trim( $value ) ) . ';';
+		}
+
+		$spacing = is_array( $node['spacing'] ?? null ) ? $node['spacing'] : [];
+
+		foreach ( [ 'padding', 'margin' ] as $box ) {
+			$value = $spacing[ $box ] ?? null;
+
+			if ( is_string( $value ) && '' !== trim( $value ) ) {
+				$declarations[] = $box . ': ' . $this->expandPresetReference( trim( $value ) ) . ';';
+
+				continue;
+			}
+
+			if ( ! is_array( $value ) ) {
+				continue;
+			}
+
+			foreach ( [ 'top', 'right', 'bottom', 'left' ] as $side ) {
+				$sideValue = $value[ $side ] ?? null;
+
+				if ( ! is_string( $sideValue ) || '' === trim( $sideValue ) ) {
+					continue;
+				}
+
+				$declarations[] = $box . '-' . $side . ': ' . $this->expandPresetReference( trim( $sideValue ) ) . ';';
+			}
+		}
+
+		$blockGap = $spacing['blockGap'] ?? null;
+
+		if ( is_string( $blockGap ) && '' !== trim( $blockGap ) ) {
+			$declarations[] = '--wp--style--block-gap: ' . $this->expandPresetReference( trim( $blockGap ) ) . ';';
+		}
+
+		$border = is_array( $node['border'] ?? null ) ? $node['border'] : [];
+
+		foreach ( [ 'color', 'style', 'width' ] as $property ) {
+			$value = $border[ $property ] ?? null;
+
+			if ( ! is_string( $value ) || '' === trim( $value ) ) {
+				continue;
+			}
+
+			$declarations[] = 'border-' . $property . ': ' . $this->expandPresetReference( trim( $value ) ) . ';';
+		}
+
+		$radius = $border['radius'] ?? null;
+
+		if ( is_string( $radius ) && '' !== trim( $radius ) ) {
+			$declarations[] = 'border-radius: ' . $this->expandPresetReference( trim( $radius ) ) . ';';
+		} elseif ( is_array( $radius ) ) {
+			foreach ( [ 'topLeft', 'topRight', 'bottomLeft', 'bottomRight' ] as $corner ) {
+				$cornerValue = $radius[ $corner ] ?? null;
+
+				if ( ! is_string( $cornerValue ) || '' === trim( $cornerValue ) ) {
+					continue;
+				}
+
+				$declarations[] = 'border-' . $this->kebabCase( $corner ) . '-radius: ' . $this->expandPresetReference( trim( $cornerValue ) ) . ';';
+			}
+		}
+
+		return implode( "\n\t", $declarations );
+	}
+
+	/**
+	 * Translate a theme.json element key into its canonical selector.
+	 * Returns `null` for unknown keys so callers can skip the rule.
+	 *
+	 * @since 1.2.0
+	 */
+	protected function elementSelector( string $element ): ?string
+	{
+		return match ( $element ) {
+			'link'    => 'a',
+			'heading' => 'h1, h2, h3, h4, h5, h6',
+			'h1'      => 'h1',
+			'h2'      => 'h2',
+			'h3'      => 'h3',
+			'h4'      => 'h4',
+			'h5'      => 'h5',
+			'h6'      => 'h6',
+			'button'  => '.wp-element-button, .wp-block-button__link',
+			'caption' => '.wp-element-caption',
+			'cite'    => 'cite',
+			default   => null,
+		};
+	}
+
+	/**
+	 * Translate a Gutenberg block name (`namespace/slug`) into its
+	 * front-end class selector (`.wp-block-namespace-slug`). Block names
+	 * outside the `namespace/slug` shape lose only the slash → dash
+	 * substitution; downstream CSS authoring still resolves correctly.
+	 *
+	 * @since 1.2.0
+	 */
+	protected function blockSelector( string $blockName ): string
+	{
+		return '.wp-block-' . str_replace( '/', '-', $blockName );
+	}
+
+	/**
+	 * Expand Gutenberg's `var:preset|{category}|{slug}` shorthand into a
+	 * real CSS `var(--wp--preset--{category}--{slug})` reference. Anything
+	 * else passes through untouched so themes can drop hex values or
+	 * other primitives into theme.json without the compiler mangling
+	 * them.
+	 *
+	 * @since 1.2.0
+	 */
+	protected function expandPresetReference( string $value ): string
+	{
+		if ( ! str_starts_with( $value, 'var:preset|' ) ) {
+			return $value;
+		}
+
+		$parts = explode( '|', substr( $value, strlen( 'var:preset|' ) ) );
+		$parts = array_map( fn ( string $segment ): string => $this->slug( $segment ), $parts );
+
+		return 'var(--wp--preset--' . implode( '--', $parts ) . ')';
+	}
+
+	/**
+	 * `topLeft` → `top-left`. Used to translate per-corner border-radius
+	 * keys into CSS property names.
+	 *
+	 * @since 1.2.0
+	 */
+	protected function kebabCase( string $value ): string
+	{
+		return strtolower( (string) preg_replace( '/([a-z])([A-Z])/', '$1-$2', $value ) );
 	}
 
 	/**

--- a/packages/visual-editor-renderer-blade/tests/Unit/ThemeJsonTokensCompilerTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Unit/ThemeJsonTokensCompilerTest.php
@@ -175,3 +175,165 @@ describe( 'Keystone #50 — layout-size custom properties + alignment rules', fu
 		expect( $css )->toMatch( '/:root \{[^}]*\}\n\n\.wp-block-group/' );
 	} );
 } );
+
+describe( 'styles.* CSS rule emission', function (): void {
+	it( 'compiles root-level color, typography, spacing, and border declarations onto the body', function (): void {
+		$css = ( new ThemeJsonTokensCompiler() )->compile( [
+			'styles' => [
+				'color'      => [
+					'background' => 'var:preset|color|page',
+					'text'       => '#111827',
+				],
+				'typography' => [
+					'fontFamily' => 'var:preset|font-family|sans',
+					'lineHeight' => '1.6',
+				],
+				'spacing'    => [
+					'blockGap' => '1.5rem',
+				],
+				'border'     => [
+					'radius' => '0.5rem',
+				],
+			],
+		] );
+
+		expect( $css )
+			->toContain( 'body {' )
+			->toContain( 'background-color: var(--wp--preset--color--page);' )
+			->toContain( 'color: #111827;' )
+			->toContain( 'font-family: var(--wp--preset--font-family--sans);' )
+			->toContain( 'line-height: 1.6;' )
+			->toContain( '--wp--style--block-gap: 1.5rem;' )
+			->toContain( 'border-radius: 0.5rem;' );
+	} );
+
+	it( 'emits element rules under canonical selectors', function (): void {
+		$css = ( new ThemeJsonTokensCompiler() )->compile( [
+			'styles' => [
+				'elements' => [
+					'link'    => [ 'color' => [ 'text' => 'var:preset|color|accent' ] ],
+					'heading' => [ 'typography' => [ 'fontWeight' => '700' ] ],
+					'h2'      => [ 'typography' => [ 'fontSize' => '2rem' ] ],
+					'button'  => [
+						'color'   => [ 'background' => 'var:preset|color|accent', 'text' => '#fff' ],
+						'border'  => [ 'radius' => '0.5rem' ],
+						'spacing' => [ 'padding' => [ 'top' => '0.75rem', 'right' => '1.5rem', 'bottom' => '0.75rem', 'left' => '1.5rem' ] ],
+					],
+				],
+			],
+		] );
+
+		expect( $css )
+			->toContain( 'a {' )
+			->toContain( 'color: var(--wp--preset--color--accent);' )
+			->toContain( 'h1, h2, h3, h4, h5, h6 {' )
+			->toContain( 'font-weight: 700;' )
+			->toContain( 'h2 {' )
+			->toContain( 'font-size: 2rem;' )
+			->toContain( '.wp-element-button, .wp-block-button__link {' )
+			->toContain( 'background-color: var(--wp--preset--color--accent);' )
+			->toContain( 'padding-top: 0.75rem;' )
+			->toContain( 'padding-right: 1.5rem;' );
+	} );
+
+	it( 'emits per-block rules under the .wp-block-<namespace>-<slug> selector', function (): void {
+		$css = ( new ThemeJsonTokensCompiler() )->compile( [
+			'styles' => [
+				'blocks' => [
+					'artisanpack/form' => [
+						'color'   => [ 'background' => 'var:preset|color|surface' ],
+						'border'  => [ 'color' => 'var:preset|color|divider', 'width' => '1px', 'radius' => '0.75rem' ],
+						'spacing' => [ 'padding' => 'var:preset|spacing|40' ],
+					],
+				],
+			],
+		] );
+
+		expect( $css )
+			->toContain( '.wp-block-artisanpack-form {' )
+			->toContain( 'background-color: var(--wp--preset--color--surface);' )
+			->toContain( 'border-color: var(--wp--preset--color--divider);' )
+			->toContain( 'border-width: 1px;' )
+			->toContain( 'border-radius: 0.75rem;' )
+			->toContain( 'padding: var(--wp--preset--spacing--40);' );
+	} );
+
+	it( 'descends into styles.blocks[X].elements with a descendant selector', function (): void {
+		$css = ( new ThemeJsonTokensCompiler() )->compile( [
+			'styles' => [
+				'blocks' => [
+					'artisanpack/form' => [
+						'elements' => [
+							'link' => [ 'color' => [ 'text' => '#ff0000' ] ],
+						],
+					],
+				],
+			],
+		] );
+
+		expect( $css )->toContain( '.wp-block-artisanpack-form a {' )
+			->and( $css )->toContain( 'color: #ff0000;' );
+	} );
+
+	it( 'handles per-corner border-radius objects', function (): void {
+		$css = ( new ThemeJsonTokensCompiler() )->compile( [
+			'styles' => [
+				'blocks' => [
+					'artisanpack/form' => [
+						'border' => [
+							'radius' => [
+								'topLeft'     => '8px',
+								'topRight'    => '8px',
+								'bottomLeft'  => '0',
+								'bottomRight' => '0',
+							],
+						],
+					],
+				],
+			],
+		] );
+
+		expect( $css )
+			->toContain( 'border-top-left-radius: 8px;' )
+			->toContain( 'border-top-right-radius: 8px;' )
+			->toContain( 'border-bottom-left-radius: 0;' )
+			->toContain( 'border-bottom-right-radius: 0;' );
+	} );
+
+	it( 'skips unknown elements and unrecognised payload shapes silently', function (): void {
+		$css = ( new ThemeJsonTokensCompiler() )->compile( [
+			'styles' => [
+				'elements' => [
+					'unknown-element' => [ 'color' => [ 'text' => '#f00' ] ],
+				],
+				'blocks'   => [
+					'core/heading' => 'not an array',
+				],
+			],
+		] );
+
+		// Unknown element selector returns null → no rule emitted.
+		expect( $css )->not->toContain( 'unknown-element' )
+			->and( $css )->not->toContain( 'wp-block-core-heading' );
+	} );
+
+	it( 'composes settings presets, layout rules, and styles output in order', function (): void {
+		$css = ( new ThemeJsonTokensCompiler() )->compile( [
+			'settings' => [
+				'color'  => [ 'palette' => [ [ 'slug' => 'primary', 'color' => '#000' ] ] ],
+				'layout' => [ 'contentSize' => '720px', 'wideSize' => '1200px' ],
+			],
+			'styles'   => [
+				'color' => [ 'background' => 'var:preset|color|primary' ],
+			],
+		] );
+
+		// Order: :root presets → layout rules → styles rules.
+		$rootPos   = strpos( $css, ':root' );
+		$layoutPos = strpos( $css, '.wp-block-group' );
+		$bodyPos   = strpos( $css, 'body {' );
+
+		expect( $rootPos )->toBeLessThan( $layoutPos )
+			->and( $layoutPos )->toBeLessThan( $bodyPos );
+	} );
+} );

--- a/resources/js/visual-editor/blocks/form/block.json
+++ b/resources/js/visual-editor/blocks/form/block.json
@@ -16,6 +16,34 @@
     "supports": {
         "className": true,
         "html": false,
-        "reusable": true
+        "reusable": true,
+        "anchor": true,
+        "typography": {
+            "fontSize": true,
+            "lineHeight": true,
+            "fontFamily": true,
+            "fontStyle": true,
+            "fontWeight": true,
+            "letterSpacing": true,
+            "textTransform": true,
+            "textDecoration": true
+        },
+        "color": {
+            "background": true,
+            "text": true,
+            "link": true,
+            "gradients": true
+        },
+        "border": {
+            "color": true,
+            "radius": true,
+            "style": true,
+            "width": true
+        },
+        "spacing": {
+            "padding": true,
+            "margin": true,
+            "blockGap": true
+        }
     }
 }

--- a/resources/js/visual-editor/blocks/form/edit.tsx
+++ b/resources/js/visual-editor/blocks/form/edit.tsx
@@ -96,40 +96,89 @@ const TEXTAREA_TYPES = new Set(['textarea', 'paragraph']);
 const CHOICE_TYPES = new Set(['select', 'radio', 'checkbox', 'checkbox_group', 'select_multiple']);
 const LAYOUT_TYPES = new Set(['heading', 'paragraph_layout', 'divider', 'html']);
 
+/*
+ * Inline-style tokens tuned to approximate the front-end's daisyUI v5
+ * form rendering. Hex values rather than `var(--color-…)` references
+ * because the editor canvas iframe doesn't load daisyUI's CSS — using
+ * a real `<link>` would require host-side plumbing, and the goal here
+ * is "close enough that the author recognizes it" without dragging
+ * stylesheet wiring across the visual-editor / forms / host boundary.
+ *
+ * If keystone-form-island.css ever lands in the canvas via a host hook,
+ * these inline styles get out of its way (selectors below targeting
+ * `.input`, `.label`, `.btn` are deliberately left absent) and the
+ * canvas stylesheet wins on full daisyUI fidelity.
+ */
+const PREVIEW_TOKENS = {
+    labelColor: '#1f2937',
+    labelFontSize: '0.875rem',
+    labelFontWeight: 500,
+    labelMargin: '0 0 0.375rem',
+    requiredColor: '#dc2626',
+    inputBorder: '1px solid #d1d5db',
+    inputRadius: '0.5rem',
+    inputPadding: '0.5rem 0.75rem',
+    inputBackground: '#ffffff',
+    inputColor: '#1f2937',
+    inputFontSize: '0.9375rem',
+    helpColor: '#6b7280',
+    helpFontSize: '0.75rem',
+    submitBackground: '#0855b1',
+    submitColor: '#ffffff',
+    submitRadius: '0.5rem',
+    submitPadding: '0.625rem 1.25rem',
+    submitFontWeight: 600,
+    submitFontSize: '0.9375rem',
+} as const;
+
 function FieldPreview({ field }: { readonly field: FormField }): ReactElement {
     const label = field.label ?? field.name;
     const inputId = `form-block-preview-${field.id}`;
     const options = field.field_config?.options ?? field.options ?? [];
 
     if ('divider' === field.type) {
-        return <hr aria-hidden="true" style={{ margin: '12px 0', borderColor: 'rgba(0,0,0,0.1)' }} />;
+        return <hr aria-hidden="true" style={{ margin: '0.75rem 0', border: 'none', borderTop: '1px solid #e5e7eb' }} />;
     }
 
     if ('heading' === field.type) {
-        return <h3 style={{ margin: '8px 0', fontWeight: 600 }}>{label}</h3>;
+        return <h3 style={{ margin: '0.5rem 0', fontWeight: 600, fontSize: '1.125rem' }}>{label}</h3>;
     }
 
     if (LAYOUT_TYPES.has(field.type)) {
-        return <p style={{ margin: '8px 0', color: 'rgba(0,0,0,0.6)' }}>{label}</p>;
+        return <p style={{ margin: '0.5rem 0', color: PREVIEW_TOKENS.helpColor }}>{label}</p>;
     }
 
     const labelEl = (
-        <label htmlFor={inputId} style={{ display: 'block', fontWeight: 500, fontSize: 13, marginBottom: 4 }}>
+        <label
+            htmlFor={inputId}
+            style={{
+                display: 'block',
+                fontWeight: PREVIEW_TOKENS.labelFontWeight,
+                fontSize: PREVIEW_TOKENS.labelFontSize,
+                color: PREVIEW_TOKENS.labelColor,
+                margin: PREVIEW_TOKENS.labelMargin,
+                lineHeight: 1.4,
+            }}
+        >
             {label}
             {field.is_required && (
-                <span aria-hidden="true" style={{ color: '#cf2e2e', marginLeft: 4 }}>*</span>
+                <span aria-hidden="true" style={{ color: PREVIEW_TOKENS.requiredColor, marginLeft: '0.25rem' }}>*</span>
             )}
         </label>
     );
 
     const inputStyle: React.CSSProperties = {
+        display: 'block',
         width: '100%',
-        padding: '6px 8px',
-        border: '1px solid rgba(0,0,0,0.15)',
-        borderRadius: 4,
-        background: 'rgba(0,0,0,0.02)',
+        boxSizing: 'border-box',
+        padding: PREVIEW_TOKENS.inputPadding,
+        border: PREVIEW_TOKENS.inputBorder,
+        borderRadius: PREVIEW_TOKENS.inputRadius,
+        background: PREVIEW_TOKENS.inputBackground,
+        color: PREVIEW_TOKENS.inputColor,
         font: 'inherit',
-        color: 'inherit',
+        fontSize: PREVIEW_TOKENS.inputFontSize,
+        lineHeight: 1.4,
     };
 
     let control: ReactElement;
@@ -138,19 +187,19 @@ function FieldPreview({ field }: { readonly field: FormField }): ReactElement {
         control = (
             <textarea
                 id={inputId}
-                rows={3}
+                rows={4}
                 placeholder={field.placeholder ?? ''}
                 defaultValue={field.default_value ?? ''}
-                style={inputStyle}
+                style={{ ...inputStyle, minHeight: '6rem', resize: 'vertical' }}
                 disabled
             />
         );
     } else if (CHOICE_TYPES.has(field.type) && options.length > 0) {
         if ('radio' === field.type) {
             control = (
-                <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: '0.375rem' }}>
                     {options.map((opt) => (
-                        <label key={opt.value} style={{ display: 'flex', gap: 6, fontSize: 13 }}>
+                        <label key={opt.value} style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', fontSize: PREVIEW_TOKENS.inputFontSize }}>
                             <input type="radio" name={`${inputId}-${field.name}`} value={opt.value} disabled />
                             {opt.label}
                         </label>
@@ -159,9 +208,9 @@ function FieldPreview({ field }: { readonly field: FormField }): ReactElement {
             );
         } else if ('checkbox_group' === field.type || 'checkbox' === field.type) {
             control = (
-                <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: '0.375rem' }}>
                     {options.map((opt) => (
-                        <label key={opt.value} style={{ display: 'flex', gap: 6, fontSize: 13 }}>
+                        <label key={opt.value} style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', fontSize: PREVIEW_TOKENS.inputFontSize }}>
                             <input type="checkbox" value={opt.value} disabled />
                             {opt.label}
                         </label>
@@ -181,7 +230,7 @@ function FieldPreview({ field }: { readonly field: FormField }): ReactElement {
             );
         }
     } else if ('file' === field.type) {
-        control = <input id={inputId} type="file" disabled style={{ ...inputStyle, padding: 4 }} />;
+        control = <input id={inputId} type="file" disabled style={{ ...inputStyle, padding: '0.375rem 0.5rem' }} />;
     } else {
         const htmlType =
             'email' === field.type
@@ -210,11 +259,11 @@ function FieldPreview({ field }: { readonly field: FormField }): ReactElement {
     }
 
     return (
-        <div style={{ marginBottom: 12 }}>
+        <div style={{ marginBottom: '1.25rem' }}>
             {labelEl}
             {control}
             {field.help_text && (
-                <p style={{ margin: '4px 0 0', fontSize: 11, color: 'rgba(0,0,0,0.55)' }}>
+                <p style={{ margin: '0.375rem 0 0', fontSize: PREVIEW_TOKENS.helpFontSize, color: PREVIEW_TOKENS.helpColor }}>
                     {field.help_text}
                 </p>
             )}
@@ -295,27 +344,9 @@ function FormPreview({ formId }: { readonly formId: number }): ReactElement {
     const fields = detail.fields ?? [];
 
     return (
-        <div
-            style={{
-                border: '1px dashed rgba(0,0,0,0.15)',
-                borderRadius: 6,
-                padding: 16,
-                background: 'rgba(0,0,0,0.015)',
-            }}
-        >
-            <p
-                style={{
-                    margin: '0 0 12px',
-                    fontSize: 11,
-                    textTransform: 'uppercase',
-                    letterSpacing: 0.5,
-                    color: 'rgba(0,0,0,0.55)',
-                }}
-            >
-                {__('Form preview', TEXT_DOMAIN)} · {detail.name}
-            </p>
+        <div style={{ display: 'flex', flexDirection: 'column' }}>
             {0 === fields.length ? (
-                <p style={{ margin: 0, fontSize: 13, color: 'rgba(0,0,0,0.55)' }}>
+                <p style={{ margin: 0, fontSize: PREVIEW_TOKENS.helpFontSize, color: PREVIEW_TOKENS.helpColor }}>
                     {__('This form has no fields yet. Add some from the Forms admin.', TEXT_DOMAIN)}
                 </p>
             ) : (
@@ -327,13 +358,15 @@ function FormPreview({ formId }: { readonly formId: number }): ReactElement {
                         type="button"
                         disabled
                         style={{
-                            marginTop: 4,
-                            padding: '8px 16px',
-                            background: '#2271b1',
-                            color: 'white',
+                            alignSelf: 'flex-start',
+                            marginTop: '0.5rem',
+                            padding: PREVIEW_TOKENS.submitPadding,
+                            background: PREVIEW_TOKENS.submitBackground,
+                            color: PREVIEW_TOKENS.submitColor,
                             border: 'none',
-                            borderRadius: 4,
-                            opacity: 0.7,
+                            borderRadius: PREVIEW_TOKENS.submitRadius,
+                            fontWeight: PREVIEW_TOKENS.submitFontWeight,
+                            fontSize: PREVIEW_TOKENS.submitFontSize,
                             cursor: 'not-allowed',
                         }}
                     >

--- a/resources/js/visual-editor/site-editor/site-editor-app.css
+++ b/resources/js/visual-editor/site-editor/site-editor-app.css
@@ -56,7 +56,21 @@
     display: flex;
     flex-direction: column;
     min-height: 0;
-    overflow: hidden;
+    /*
+     * Auto-scroll on the sidebar wrapper itself so taller-than-viewport
+     * panel content (Styles → Blocks → typography + color + border +
+     * spacing fields, or the navigator's deep block trees) stays
+     * reachable. The inner `__styles-inspector` / navigator content
+     * areas declare their own `flex: 1 + min-height: 0 + overflow-y:
+     * auto` chain for the canonical case where the panel fills the
+     * sidebar exactly; in practice taller content slips past the flex
+     * scroll-trap because non-flex children inside the panel push the
+     * computed height up, so the auto-scroll never engages. Falling
+     * back to wrapper-level overflow handles both cases without
+     * changing the flex layout intent.
+     */
+    overflow-y: auto;
+    overflow-x: hidden;
 }
 
 .ap-site-editor__sidebar--navigator {

--- a/resources/js/visual-editor/site-editor/styles/panels/blocks-panel.tsx
+++ b/resources/js/visual-editor/site-editor/styles/panels/blocks-panel.tsx
@@ -57,6 +57,12 @@ function getBlockFields(): readonly BlockField[] {
             kind: 'color',
         },
         {
+            label: __('Link color', TEXT_DOMAIN),
+            key: ['elements', 'link', 'color', 'text'],
+            testId: 'block-color-link',
+            kind: 'color',
+        },
+        {
             label: __('Font family', TEXT_DOMAIN),
             key: ['typography', 'fontFamily'],
             testId: 'block-font-family',
@@ -69,9 +75,64 @@ function getBlockFields(): readonly BlockField[] {
             kind: 'font-size',
         },
         {
+            label: __('Font weight', TEXT_DOMAIN),
+            key: ['typography', 'fontWeight'],
+            testId: 'block-font-weight',
+            kind: 'font-weight',
+        },
+        {
+            label: __('Line height', TEXT_DOMAIN),
+            key: ['typography', 'lineHeight'],
+            testId: 'block-line-height',
+            kind: 'size',
+        },
+        {
+            label: __('Letter spacing', TEXT_DOMAIN),
+            key: ['typography', 'letterSpacing'],
+            testId: 'block-letter-spacing',
+            kind: 'size',
+        },
+        {
+            label: __('Border color', TEXT_DOMAIN),
+            key: ['border', 'color'],
+            testId: 'block-border-color',
+            kind: 'color',
+        },
+        {
+            label: __('Border width', TEXT_DOMAIN),
+            key: ['border', 'width'],
+            testId: 'block-border-width',
+            kind: 'size',
+        },
+        {
             label: __('Border radius', TEXT_DOMAIN),
             key: ['border', 'radius'],
             testId: 'block-border-radius',
+            kind: 'size',
+        },
+        // Spacing: single-value (uniform on all sides) at the site-editor
+        // global level. Per-side overrides are still authored from the
+        // per-block inspector — adding box-model controls here would
+        // require a new `kind: 'spacing'` renderer and is out of scope
+        // for the surface-expansion pass. `BlockSupports::applyBoxModel()`
+        // already accepts a single string and applies it to all four sides,
+        // so the global-styles payload round-trips correctly today.
+        {
+            label: __('Padding', TEXT_DOMAIN),
+            key: ['spacing', 'padding'],
+            testId: 'block-padding',
+            kind: 'size',
+        },
+        {
+            label: __('Margin', TEXT_DOMAIN),
+            key: ['spacing', 'margin'],
+            testId: 'block-margin',
+            kind: 'size',
+        },
+        {
+            label: __('Block gap', TEXT_DOMAIN),
+            key: ['spacing', 'blockGap'],
+            testId: 'block-block-gap',
             kind: 'size',
         },
     ];
@@ -80,14 +141,24 @@ function getBlockFields(): readonly BlockField[] {
 /**
  * Stable key list used for iteration in `customizedCount` detection —
  * derived once from a single cached descriptor set so the render path
- * doesn't re-translate on every isPathCustomized check.
+ * doesn't re-translate on every isPathCustomized check. Keep in sync
+ * with {@see getBlockFields}.
  */
 const BLOCK_FIELD_KEYS: readonly (readonly string[])[] = [
     ['color', 'background'],
     ['color', 'text'],
+    ['elements', 'link', 'color', 'text'],
     ['typography', 'fontFamily'],
     ['typography', 'fontSize'],
+    ['typography', 'fontWeight'],
+    ['typography', 'lineHeight'],
+    ['typography', 'letterSpacing'],
+    ['border', 'color'],
+    ['border', 'width'],
     ['border', 'radius'],
+    ['spacing', 'padding'],
+    ['spacing', 'margin'],
+    ['spacing', 'blockGap'],
 ];
 
 export function BlocksIndexPanel(

--- a/src/Blocks/Forms/FormBlock.php
+++ b/src/Blocks/Forms/FormBlock.php
@@ -17,6 +17,7 @@ namespace ArtisanPackUI\VisualEditor\Blocks\Forms;
 
 use ArtisanPackUI\Forms\Models\Form;
 use ArtisanPackUI\VisualEditor\Blocks\DynamicBlock;
+use ArtisanPackUI\VisualEditorRendererBlade\Support\BlockSupports;
 
 /**
  * Renders a placeholder DIV that the artisanpack-ui/forms React island
@@ -33,6 +34,16 @@ use ArtisanPackUI\VisualEditor\Blocks\DynamicBlock;
  * Keystone CMS ships one at `resources/js/keystone-form-island.tsx`; any
  * other consumer can ship an equivalent that scans for
  * `[data-keystone-form]` elements and calls FormRenderer on each.
+ *
+ * Styling: the block declares the full Gutenberg-parity supports surface
+ * (typography, color, border, spacing, plus `className`/`anchor`) in its
+ * block.json. Wrapper class + style attributes are compiled via
+ * {@see BlockSupports::wrapperAttrs()} — the same path every other
+ * server-rendered block in the visual-editor stack goes through. That
+ * makes the form a first-class citizen of theme.json / the site editor's
+ * global styles: presets serialize as `has-{slug}-*` classes; custom
+ * values land as inline declarations referencing `--wp--preset--*` so
+ * theme-token changes flow through without a republish.
  */
 class FormBlock extends DynamicBlock
 {
@@ -48,10 +59,28 @@ class FormBlock extends DynamicBlock
 	 */
 	public function validateAttrs( array $attrs ): array
 	{
-		return [
-			'formId'    => $this->normalizeFormId( $attrs['formId'] ?? null ),
-			'className' => isset( $attrs['className'] ) && is_string( $attrs['className'] ) ? $attrs['className'] : '',
-		];
+		// Block-supports attributes pass through verbatim.
+		// `BlockSupports::compile()` already shape-checks each branch —
+		// non-strings collapse to '', non-array `style` is dropped — so
+		// an over-eager validator here would either duplicate that
+		// logic or strip valid editor input. The validator stays
+		// authoritative only over `formId`, which goes through the
+		// strict integer parser in `normalizeFormId()` (CodeRabbit PR
+		// #467: float strings and scientific notation would otherwise
+		// silently coerce into unrelated form ids).
+		$normalized = [ 'formId' => $this->normalizeFormId( $attrs['formId'] ?? null ) ];
+
+		foreach ( [ 'className', 'anchor', 'align', 'textAlign', 'backgroundColor', 'textColor', 'gradient', 'borderColor', 'fontSize', 'fontFamily' ] as $key ) {
+			if ( isset( $attrs[ $key ] ) && is_string( $attrs[ $key ] ) ) {
+				$normalized[ $key ] = $attrs[ $key ];
+			}
+		}
+
+		if ( isset( $attrs['style'] ) && is_array( $attrs['style'] ) ) {
+			$normalized['style'] = $attrs['style'];
+		}
+
+		return $normalized;
 	}
 
 	public function render( array $attrs ): string
@@ -72,11 +101,9 @@ class FormBlock extends DynamicBlock
 			return $this->placeholder( $attrs, __( 'The selected form is inactive.' ) );
 		}
 
-		$classes = $this->wrapperClasses( $attrs );
-
 		return sprintf(
-			'<div class="%s" data-keystone-form="%s" data-form-id="%d"></div>',
-			e( implode( ' ', $classes ) ),
+			'<div%s data-keystone-form="%s" data-form-id="%d"></div>',
+			BlockSupports::wrapperAttrs( $attrs, [ 'wp-block-artisanpack-form' ] ),
 			e( $form->slug ),
 			$form->id
 		);
@@ -87,30 +114,11 @@ class FormBlock extends DynamicBlock
 	 */
 	protected function placeholder( array $attrs, string $message ): string
 	{
-		$classes   = $this->wrapperClasses( $attrs );
-		$classes[] = 'wp-block-artisanpack-form--placeholder';
-
 		return sprintf(
-			'<div class="%s"><p>%s</p></div>',
-			e( implode( ' ', $classes ) ),
+			'<div%s><p>%s</p></div>',
+			BlockSupports::wrapperAttrs( $attrs, [ 'wp-block-artisanpack-form', 'wp-block-artisanpack-form--placeholder' ] ),
 			e( $message )
 		);
-	}
-
-	/**
-	 * @param  array<string, mixed>  $attrs
-	 *
-	 * @return array<int, string>
-	 */
-	protected function wrapperClasses( array $attrs ): array
-	{
-		$classes = [ 'wp-block-artisanpack-form' ];
-
-		if ( isset( $attrs['className'] ) && '' !== $attrs['className'] ) {
-			$classes[] = (string) $attrs['className'];
-		}
-
-		return $classes;
 	}
 
 	/**

--- a/tests/Unit/VisualEditor/Blocks/Forms/FormBlockTest.php
+++ b/tests/Unit/VisualEditor/Blocks/Forms/FormBlockTest.php
@@ -5,16 +5,19 @@ declare( strict_types=1 );
 use ArtisanPackUI\VisualEditor\Blocks\Forms\FormBlock;
 
 /*
- * Tests for {@see FormBlock} focused on attribute normalization. The
- * render-path branches (missing form, inactive form, valid form) hit
- * the Forms package's Eloquent model and live in the feature-test
- * layer; these unit tests cover the surface that does not require a
- * database — `validateAttrs()` and its `normalizeFormId()` helper.
+ * Tests for {@see FormBlock} focused on the database-free surface:
+ * `validateAttrs()` (strict `formId` parsing + supports-attrs passthrough)
+ * and `placeholder()` (which goes through the same
+ * `BlockSupports::wrapperAttrs()` pipeline `render()` uses for live
+ * forms). The render() path with a real `formId` resolves an Eloquent
+ * `Form` and is covered by the feature/HTTP layer.
  */
 
 beforeEach( function (): void {
 	test()->block = new FormBlock();
 } );
+
+/* ---- validateAttrs: strict-int parsing for formId (CodeRabbit PR #467) ---- */
 
 it( 'normalizes a positive integer formId verbatim', function (): void {
 	expect( test()->block->validateAttrs( [ 'formId' => 42 ] )['formId'] )->toBe( 42 );
@@ -52,6 +55,85 @@ it( 'rejects non-numeric and non-scalar formId values', function (): void {
 
 it( 'preserves a string className verbatim and coerces non-strings to empty', function (): void {
 	expect( test()->block->validateAttrs( [ 'formId' => 1, 'className' => 'extra-class' ] )['className'] )->toBe( 'extra-class' )
-		->and( test()->block->validateAttrs( [ 'formId' => 1, 'className' => 123 ] )['className'] )->toBe( '' )
-		->and( test()->block->validateAttrs( [ 'formId' => 1 ] )['className'] )->toBe( '' );
+		->and( test()->block->validateAttrs( [ 'formId' => 1, 'className' => 123 ] ) )->not->toHaveKey( 'className' )
+		->and( test()->block->validateAttrs( [ 'formId' => 1 ] ) )->not->toHaveKey( 'className' );
+} );
+
+/* ---- placeholder() wrapper-attrs compilation through BlockSupports ---- */
+
+it( 'wraps the placeholder with the base form class when no supports are set', function (): void {
+	$html = test()->block->render( test()->block->validateAttrs( [] ) );
+
+	expect( $html )->toContain( 'class="wp-block-artisanpack-form wp-block-artisanpack-form--placeholder"' )
+		->and( $html )->not->toContain( 'style=' )
+		->and( $html )->not->toContain( 'id=' );
+} );
+
+it( 'compiles typography, color, border, and spacing into class + style on the wrapper', function (): void {
+	$attrs = test()->block->validateAttrs( [
+		'formId'          => 0,
+		'backgroundColor' => 'primary',
+		'textColor'       => 'base-content',
+		'fontSize'        => 'large',
+		'fontFamily'      => 'sans',
+		'borderColor'     => 'primary',
+		'style'           => [
+			'color'      => [ 'background' => 'var:preset|color|secondary' ],
+			'border'     => [ 'radius' => '8px', 'width' => '2px' ],
+			'spacing'    => [ 'padding' => '1.5rem', 'margin' => [ 'top' => '2rem' ] ],
+			'typography' => [ 'lineHeight' => '1.4', 'letterSpacing' => '0.02em' ],
+		],
+	] );
+
+	$html = test()->block->render( $attrs );
+
+	expect( $html )->toContain( 'has-background' )
+		->and( $html )->toContain( 'has-primary-background-color' )
+		->and( $html )->toContain( 'has-text-color' )
+		->and( $html )->toContain( 'has-base-content-color' )
+		->and( $html )->toContain( 'has-large-font-size' )
+		->and( $html )->toContain( 'has-sans-font-family' )
+		->and( $html )->toContain( 'has-border-color' )
+		->and( $html )->toContain( 'has-primary-border-color' )
+		->and( $html )->toContain( 'border-radius: 8px' )
+		->and( $html )->toContain( 'border-width: 2px' )
+		->and( $html )->toContain( 'border-style: solid' )
+		->and( $html )->toContain( 'padding: 1.5rem' )
+		->and( $html )->toContain( 'margin-top: 2rem' )
+		->and( $html )->toContain( 'line-height: 1.4' )
+		->and( $html )->toContain( 'letter-spacing: 0.02em' );
+} );
+
+it( 'lifts the `anchor` attribute into the wrapper id', function (): void {
+	$html = test()->block->render( test()->block->validateAttrs( [
+		'anchor' => 'contact-form',
+	] ) );
+
+	expect( $html )->toContain( 'id="contact-form"' );
+} );
+
+it( 'appends the user-supplied className alongside the base class', function (): void {
+	$html = test()->block->render( test()->block->validateAttrs( [
+		'className' => 'is-style-bordered max-w-lg',
+	] ) );
+
+	expect( $html )->toContain( 'wp-block-artisanpack-form' )
+		->and( $html )->toContain( 'is-style-bordered' )
+		->and( $html )->toContain( 'max-w-lg' );
+} );
+
+it( 'drops non-array `style` and non-string supports attrs through validateAttrs', function (): void {
+	$attrs = test()->block->validateAttrs( [
+		'formId'          => '42',
+		'style'           => 'default',
+		'backgroundColor' => [ 'not', 'a', 'string' ],
+		'className'       => 'valid',
+	] );
+
+	expect( $attrs )->toMatchArray( [
+		'formId'    => 42,
+		'className' => 'valid',
+	] )
+		->and( $attrs )->not->toHaveKey( 'style' )
+		->and( $attrs )->not->toHaveKey( 'backgroundColor' );
 } );


### PR DESCRIPTION
## Description

Builds on #467 so the `artisanpack/form` block is a first-class citizen of the site-editor's global-styles surface and styled authorings flow through to the front end via the renderer-blade compiler.

Stacked against `feature/forms-block` — merge that PR first, then this one rebases cleanly onto `release/1.0`.

**Closes:** _no issue filed; reviewer-discretion to backfill if appropriate_

## Type of Change

- [x] New feature (adds new functionality)
- [x] Enhancement (improves existing functionality)
- [x] Bug fix (fixes an issue) — site-editor sidebar scroll trap

## Motivation and Context

The form block landed in #467 as a minimal mount-point dynamic block (formId attribute, className/html/reusable supports). Two consumer-side gaps emerged when wiring it into Keystone's `/about` page:

1. Authors couldn't style the form block from the editor — block.json declared no typography/color/border/spacing supports, so the per-block inspector showed only the default class selector.
2. Site-editor global-styles authoring for the form block didn't paint on the front end — the renderer-blade `ThemeJsonTokensCompiler` only compiled `settings.*` presets to `:root` custom properties, not `styles.*` CSS rules. Sub-bug: the site-editor sidebars stopped scrolling once panel content exceeded the viewport (the inner `flex: 1` chain didn't engage when non-flex children pushed the computed height up).

This PR addresses all three.

## Changes Made

**Form block**

- `block.json` declares the full Gutenberg supports surface: typography (fontSize, lineHeight, fontFamily, fontStyle, fontWeight, letterSpacing, textTransform, textDecoration), color (background, text, link, gradients), border (color, radius, style, width), spacing (padding, margin, blockGap), plus anchor and className.
- `FormBlock::render()` compiles wrapper class+style via `BlockSupports::wrapperAttrs()` — same path every other server-rendered block goes through. `validateAttrs()` passes the block-supports keys (`style` assoc + palette-slug attrs) through verbatim since `BlockSupports::compile()` already shape-checks each branch.
- `edit.tsx` preview tuned to approximate the front-end daisyUI v5 look: drops the `FORM PREVIEW · …` header + dashed wrapper, labels above inputs (no fieldset/legend), submit button uses keystone primary blue with semibold weight + `0.5rem` radius. Inline tokens only — no `.input`/`.label`/`.btn` class selectors, so a future host hook injecting daisyUI CSS into the canvas iframe wins on full fidelity without conflict.

**Site editor**

- `.ap-site-editor__sidebar` adds `overflow-y: auto` directly so taller-than-viewport content stays reachable. The inner flex chain (`flex: 1 + min-height: 0 + overflow-y: auto`) is the canonical scroll trap but doesn't engage when non-flex children push the computed height up — wrapper-level overflow handles both cases without changing the flex layout intent.
- `blocks-panel.tsx` field surface expanded from 5 → 14: + Link color, + Font weight, + Line height, + Letter spacing, + Border color, + Border width, + Padding, + Margin, + Block gap. Spacing fields are single-value at the global level (per-side overrides still author from the per-block inspector since the panel uses uniform field kinds). Deferred to a follow-up: border-style, text-transform, text-decoration, gradient backgrounds — those need new `kind` renderers.

**Global-styles → front-end pipeline**

- `ThemeJsonTokensCompiler` now emits CSS rules for the `styles.*` half of theme.json on top of the existing `:root` `--wp--preset--*` block. Three levels covered:
  - Root: `styles.{color,typography,spacing,border}` → `body { … }`
  - Elements: `styles.elements.{link, heading, h1..h6, button, caption, cite}` → canonical selectors (`a`, `h1, h2, …`, `.wp-element-button`, etc.)
  - Blocks: `styles.blocks["<ns>/<slug>"]` → `.wp-block-<ns>-<slug>`. Nested `styles.blocks[X].elements.Y` produces descendant rules so a block can re-style its own headings/links without affecting siblings.
  - Preset references (`var:preset|color|primary`) expand to `var(--wp--preset--color--primary)`.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS 25.5.0
- Browser: Safari 26
- PHP Version: 8.4.21
- Project Version: 1.0.0-spike

**Tests Performed:**
1. `./vendor/bin/pest --compact` — full pest suite (636 passed, 14 pre-existing `SeedSampleContentCommandTest` failures unrelated to this branch; see #441 and the seed-fixture cleanup PRs)
2. `./vendor/bin/pest packages/visual-editor-renderer-blade/tests/Unit/ThemeJsonTokensCompilerTest.php` — 18 passed (11 original + 7 new)
3. `./vendor/bin/pest tests/Unit/VisualEditor/Blocks/Forms/FormBlockTest.php` — 5 passed
4. `npx vitest run` — 1057 passed (1 skipped)
5. `npm run build` — clean
6. Manual smoke: page editor inspector shows full panel set against a theme that exposes the matching `settings.*` flags; site editor blocks panel shows 14 fields; site editor sidebars scroll; canvas embed in admin host doesn't overflow.

## Accessibility Tests Run

- [x] Keyboard navigation tested — site editor sidebars now scroll via keyboard arrow keys / tab + scroll
- [ ] Screen reader tested — out of scope for layout-overflow + supports-declaration work
- [ ] Color contrast verified — purely declarative supports; no new color emissions
- [x] ARIA labels checked — `BlockSupports::wrapperAttrs()` lifts `anchor` into `id=` so screen-reader landmark navigation still works

## Tests Added

- [x] Unit tests added/updated
- [ ] Integration tests added/updated — not needed; the new code paths are pure functions exercised by the unit tests
- [x] All tests passing (excluding the 14 pre-existing `SeedSampleContentCommandTest` failures unrelated to this branch)

**Test details:**

- `tests/Unit/VisualEditor/Blocks/Forms/FormBlockTest.php` (new) — 5 tests cover empty attrs, full supports compilation (typography + color + border + spacing), anchor lift, className appending, and `validateAttrs` filtering.
- `ThemeJsonTokensCompilerTest.php` — 7 new tests cover root styles, element rules, block rules, nested block-element selectors, per-corner border-radius, unknown-element skip, and the ordering contract (presets → layout → styles).

## Documentation

- [x] Inline code documentation added — block-supports docblock on `FormBlock`, extended class-level doc on `ThemeJsonTokensCompiler`, scoped CSS comment on the site-editor sidebar override
- [ ] README updated — no public API surface change
- [ ] Wiki updated — n/a
- [ ] API documentation updated — n/a

## Reviewer Notes

- The keystone-cms MR that consumes this work is filed separately; it covers the global_styles DB merge, the theme.json `settings.*` expansion, and the scoped form-island CSS.
- The `feature/forms-block` parent branch carries a stashed `package-lock.json` from earlier `npm install` noise (`stash@{0}: On feature/forms-block: wip: package-lock noise from earlier npm install`). Drop or pop on the parent branch when convenient; unrelated to this PR.
- Spacing fields in the blocks panel are intentionally single-value (per-side stays in the per-block inspector). If reviewer wants per-side at the global level, that's a new `kind: 'spacing'` renderer + a `BoxControl` import — separate scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Form blocks now support extended styling (typography, color, border, spacing) and anchors.
  * Theme JSON now emits CSS for body/root styles, canonical elements, and per-block selectors.

* **Improvements**
  * Editor form preview uses centralized tokens for more accurate styling.
  * Site editor sidebar scroll behavior improved.
  * Form block wrapper styling now flows through the block supports surface.

* **Tests**
  * Added tests covering form attribute normalization, placeholder rendering, and theme JSON style emission.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArtisanPack-UI/visual-editor/pull/469?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->