### PR TITLE
enhancement: add resolver-injection seam to FormBlock

### DIFF
--- a/src/Blocks/Forms/FormBlock.php
+++ b/src/Blocks/Forms/FormBlock.php
@@ -18,6 +18,7 @@ namespace ArtisanPackUI\VisualEditor\Blocks\Forms;
 use ArtisanPackUI\Forms\Models\Form;
 use ArtisanPackUI\VisualEditor\Blocks\DynamicBlock;
 use ArtisanPackUI\VisualEditorRendererBlade\Support\BlockSupports;
+use Closure;
 
 /**
  * Renders a placeholder DIV that the artisanpack-ui/forms React island
@@ -47,6 +48,29 @@ use ArtisanPackUI\VisualEditorRendererBlade\Support\BlockSupports;
  */
 class FormBlock extends DynamicBlock
 {
+	/**
+	 * Resolver for the form record keyed off the validated `formId`.
+	 *
+	 * Injected so tests can exercise the missing / inactive / active
+	 * branches of {@see render()} without booting the
+	 * `artisanpack-ui/forms` package and migrating its tables. The
+	 * closure receives a positive integer id and returns either a
+	 * `Form`-shaped object exposing `id`, `slug`, and `is_active`, or
+	 * `null` when no record matches. Production callers fall through to
+	 * the default Eloquent lookup.
+	 *
+	 * @var Closure(int): ?object
+	 */
+	private Closure $resolveForm;
+
+	/**
+	 * @param  (Closure(int): ?object)|null  $resolveForm  Optional form resolver. Defaults to an Eloquent `Form` lookup.
+	 */
+	public function __construct( ?Closure $resolveForm = null )
+	{
+		$this->resolveForm = $resolveForm ?? static fn ( int $id ): ?Form => Form::query()->find( $id );
+	}
+
 	public function name(): string
 	{
 		return 'artisanpack/form';
@@ -91,7 +115,7 @@ class FormBlock extends DynamicBlock
 			return $this->placeholder( $attrs, __( 'Select a form to display.' ) );
 		}
 
-		$form = Form::query()->find( $formId );
+		$form = ( $this->resolveForm )( $formId );
 
 		if ( null === $form ) {
 			return $this->placeholder( $attrs, __( 'The selected form is no longer available.' ) );

--- a/tests/Unit/VisualEditor/Blocks/Forms/FormBlockTest.php
+++ b/tests/Unit/VisualEditor/Blocks/Forms/FormBlockTest.php
@@ -122,6 +122,75 @@ it( 'appends the user-supplied className alongside the base class', function ():
 		->and( $html )->toContain( 'max-w-lg' );
 } );
 
+/* ---- render() with an injected resolver (issue #468) ---- */
+
+/**
+ * Stand-in for `ArtisanPackUI\Forms\Models\Form`. The block only ever
+ * reads `id`, `slug`, and `is_active` on the resolved object, so a
+ * plain value object is enough to exercise every render branch without
+ * pulling the forms package in as a dev dep.
+ */
+$fakeForm = static function ( int $id, string $slug, bool $isActive ): object {
+	return new class( $id, $slug, $isActive )
+	{
+		public function __construct( public int $id, public string $slug, public bool $is_active ) {}
+	};
+};
+
+it( 'renders the missing-form placeholder when the resolver returns null', function (): void {
+	$block = new FormBlock( fn ( int $id ): ?object => null );
+
+	$html = $block->render( $block->validateAttrs( [ 'formId' => 42 ] ) );
+
+	expect( $html )->toContain( 'wp-block-artisanpack-form--placeholder' )
+		->and( $html )->toContain( 'no longer available' )
+		->and( $html )->not->toContain( 'data-keystone-form' );
+} );
+
+it( 'renders the inactive-form placeholder when the resolved form is not active', function () use ( $fakeForm ): void {
+	$block = new FormBlock( fn ( int $id ): ?object => $fakeForm( $id, 'contact', false ) );
+
+	$html = $block->render( $block->validateAttrs( [ 'formId' => 7 ] ) );
+
+	expect( $html )->toContain( 'wp-block-artisanpack-form--placeholder' )
+		->and( $html )->toContain( 'inactive' )
+		->and( $html )->not->toContain( 'data-keystone-form' );
+} );
+
+it( 'renders the mount-point markup for an active resolved form', function () use ( $fakeForm ): void {
+	$block = new FormBlock( fn ( int $id ): ?object => $fakeForm( $id, 'contact', true ) );
+
+	$html = $block->render( $block->validateAttrs( [ 'formId' => 7 ] ) );
+
+	expect( $html )->toContain( 'class="wp-block-artisanpack-form"' )
+		->and( $html )->toContain( 'data-keystone-form="contact"' )
+		->and( $html )->toContain( 'data-form-id="7"' )
+		->and( $html )->not->toContain( 'placeholder' );
+} );
+
+it( 'passes a custom className through onto the active-form wrapper', function () use ( $fakeForm ): void {
+	$block = new FormBlock( fn ( int $id ): ?object => $fakeForm( $id, 'contact', true ) );
+
+	$html = $block->render( $block->validateAttrs( [
+		'formId'    => 7,
+		'className' => 'is-style-bordered max-w-lg',
+	] ) );
+
+	expect( $html )->toContain( 'wp-block-artisanpack-form' )
+		->and( $html )->toContain( 'is-style-bordered' )
+		->and( $html )->toContain( 'max-w-lg' )
+		->and( $html )->toContain( 'data-keystone-form="contact"' );
+} );
+
+it( 'escapes the resolved form slug into the mount-point attribute', function () use ( $fakeForm ): void {
+	$block = new FormBlock( fn ( int $id ): ?object => $fakeForm( $id, 'contact"><script>', true ) );
+
+	$html = $block->render( $block->validateAttrs( [ 'formId' => 1 ] ) );
+
+	expect( $html )->not->toContain( '<script>' )
+		->and( $html )->toContain( '&lt;script&gt;' );
+} );
+
 it( 'drops non-array `style` and non-string supports attrs through validateAttrs', function (): void {
 	$attrs = test()->block->validateAttrs( [
 		'formId'          => '42',


### PR DESCRIPTION
## Description

Decouples `FormBlock::render()` from a hard reference to `ArtisanPackUI\Forms\Models\Form` so the missing / inactive / active render branches can be unit-tested without installing the `artisanpack-ui/forms` package and running its migrations.

**Closes:** #468

## Type of Change

- [x] Enhancement (improves existing functionality)

## Related Issue

**Issue:** #468

## Motivation and Context

`FormBlock` (added in #467) called `Form::query()->find($id)` directly. Because the visual-editor package does not carry `artisanpack-ui/forms` as a dev dep, a feature test for the block's render had three bad options: pull the forms package in as a dev requirement, skip-in-CI when the class is missing, or stand up a brittle stub model that has to track real fields. None of those are sustainable for what is otherwise a small, well-defined render surface. Injecting a closure resolver lets the unit test layer hand in a fake form object and exercise every branch without any DB or package coupling. Production callers pass nothing and fall through to the default Eloquent lookup, so behavior on the live block is unchanged.

## Changes Made

- Added `__construct(?Closure $resolveForm = null)` to `FormBlock` with a default closure that resolves to `Form::query()->find($id)`.
- Switched `render()` to call `($this->resolveForm)($formId)` instead of hitting the model directly.
- Added five unit tests covering the previously DB-coupled branches: missing form, inactive form, active-form mount-point markup, custom `className` passthrough on the active wrapper, and slug escaping into the `data-keystone-form` attribute.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (Darwin 25.5.0)
- PHP Version: 8.4.3
- Project Version: release/1.0

**Tests Performed:**
1. `./vendor/bin/pest --filter=FormBlock` — 17/17 passing (12 existing + 5 new).
2. Full suite run — the 14 pre-existing failures in `SeedSampleContentCommandTest` are unrelated to this change (confirmed by stashing the diff and re-running on a clean `release/1.0` checkout).

## Accessibility Tests Run

- [x] N/A — no markup changes for live forms; the active-form branch still emits the same `<div class=\"wp-block-artisanpack-form\" data-keystone-form=\"...\" data-form-id=\"...\"></div>` mount-point.

## Tests Added

- [x] Unit tests added/updated
- [x] All tests passing (for the surface this PR touches)

**Test details:** 5 new tests in `tests/Unit/VisualEditor/Blocks/Forms/FormBlockTest.php`, each using an inline anonymous-class fake form to exercise a render branch through the public API.

## Documentation

- [x] Inline code documentation added (PHPDoc on the new `\$resolveForm` property + constructor)

## Pre-Submission Checklist

- [x] Code passes all tests (FormBlock surface)
- [x] Self-review completed
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Form blocks now gracefully handle missing forms and display "no longer available" messaging
  * Inactive forms are properly identified and displayed with appropriate placeholders
  * Form mount-point attributes are secured with HTML escaping
  * Custom CSS classes on form blocks are preserved during rendering

* **Tests**
  * Added comprehensive test coverage for form block rendering across multiple scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArtisanPack-UI/visual-editor/pull/470?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->