### PR TITLE
fix: synthesize missing-record placeholder on 404 for entity refs

### DIFF
--- a/resources/js/visual-editor/vendor/__tests__/core-data-shim.test.tsx
+++ b/resources/js/visual-editor/vendor/__tests__/core-data-shim.test.tsx
@@ -5,6 +5,8 @@ import { dispatch, resolveSelect, select } from '@wordpress/data';
 import {
     DEFAULT_ENTITIES,
     EntityProvider,
+    MISSING_RECORD_MARKER,
+    RestRequestError,
     __resetCoreDataShimConfig,
     configureCoreDataShim,
     store,
@@ -607,6 +609,176 @@ describe('core-data-shim fetch → cache', () => {
         expect(
             coreSelect().getEntityRecord('postType', 'wp_template', 7),
         ).toBeNull();
+    });
+
+    it('fetchEntityRecord synthesizes a missing-record placeholder on 404 for a numeric id (#419)', async () => {
+        // Entity-backed core blocks (`core/navigation`, `core/post-*`,
+        // `core/template-part`) crash through to the editor's error
+        // boundary when `useEntityRecord` returns null for a ref that
+        // points at a deleted / never-seeded record. The shim
+        // synthesizes a `{id, _missing: true, status: 'missing'}`
+        // placeholder on 404 so the block's null-check passes and
+        // it can render its own missing-state UI instead.
+        const { fetcher } = mockFetcher(async () => jsonResponse({}, 404));
+
+        configureCoreDataShim({ apiBase: '/api', fetcher });
+
+        const record = await coreDispatch().fetchEntityRecord(
+            'postType',
+            'wp_navigation',
+            21,
+        );
+
+        expect(record).toEqual({
+            id: 21,
+            [MISSING_RECORD_MARKER]: true,
+            status: 'missing',
+        });
+
+        // Cached for subsequent reads — including `getEditedEntityRecord`,
+        // which is what block-library's `useNavigationMenu` reads to
+        // flip its `isNavigationMenuMissing` flag (status !== 'publish'
+        // / 'draft' → missing).
+        expect(
+            coreSelect().getEntityRecord('postType', 'wp_navigation', 21),
+        ).toMatchObject({ id: 21, [MISSING_RECORD_MARKER]: true });
+        expect(
+            coreSelect().getEditedEntityRecord(
+                'postType',
+                'wp_navigation',
+                21,
+            ),
+        ).toMatchObject({ status: 'missing' });
+    });
+
+    it('fetchEntityRecord falls back to null for non-404 errors (#419)', async () => {
+        // 5xx / network failures are transient — the cache must stay
+        // empty so the resolver remains retryable rather than poisoned
+        // with a permanent missing-record sentinel.
+        const { fetcher } = mockFetcher(async () => jsonResponse({}, 503));
+
+        configureCoreDataShim({ apiBase: '/api', fetcher });
+
+        const record = await coreDispatch().fetchEntityRecord(
+            'postType',
+            'wp_navigation',
+            42,
+        );
+
+        expect(record).toBeNull();
+        expect(
+            coreSelect().getEntityRecord('postType', 'wp_navigation', 42),
+        ).toBeNull();
+    });
+
+    it('fetchEntityRecord synthesizes a missing-record placeholder when a composite-id lookup returns no matches (#419)', async () => {
+        // `core/template-part` looks up its referenced part by the
+        // composite `<theme>//<slug>` id. The shim bridges this through
+        // the index endpoint with a theme+slug filter; an empty list
+        // response means the referenced part isn't on the server.
+        // Same placeholder treatment as the numeric-id 404 path so the
+        // block doesn't crash on a null record.
+        const { fetcher } = mockFetcher(async () =>
+            jsonResponse({ data: [], meta: { total: 0, last_page: 1 } }),
+        );
+
+        configureCoreDataShim({ apiBase: '/api', fetcher });
+
+        const record = await coreDispatch().fetchEntityRecord(
+            'postType',
+            'wp_template_part',
+            'artisanpack-base//missing-part',
+        );
+
+        expect(record).toEqual({
+            id: 'artisanpack-base//missing-part',
+            [MISSING_RECORD_MARKER]: true,
+            status: 'missing',
+        });
+        expect(
+            coreSelect().getEntityRecord(
+                'postType',
+                'wp_template_part',
+                'artisanpack-base//missing-part',
+            ),
+        ).toMatchObject({ [MISSING_RECORD_MARKER]: true });
+    });
+
+    it('clears a stale composite-id missing placeholder when the real record later lands (#419)', async () => {
+        // After a composite-id lookup synthesizes a `_missing`
+        // placeholder under `items[<theme>//<slug>]`, a subsequent
+        // fetch that returns the real record stores it under the
+        // numeric primary key and registers a composite alias. Without
+        // explicit invalidation, `selectEntityRecord`'s direct-lookup
+        // path would keep returning the stale placeholder for the
+        // composite id.
+        let respondWithMissing = true;
+        const { fetcher } = mockFetcher(async () => {
+            if (respondWithMissing) {
+                return jsonResponse({
+                    data: [],
+                    meta: { total: 0, last_page: 1 },
+                });
+            }
+
+            return jsonResponse({
+                data: [
+                    {
+                        id: 7,
+                        slug: 'header',
+                        theme: 'artisanpack-base',
+                        title: { rendered: 'Header' },
+                    },
+                ],
+                meta: { total: 1, last_page: 1 },
+            });
+        });
+
+        configureCoreDataShim({ apiBase: '/api', fetcher });
+
+        const compositeId = 'artisanpack-base//header';
+
+        const missing = await coreDispatch().fetchEntityRecord(
+            'postType',
+            'wp_template_part',
+            compositeId,
+        );
+
+        expect(missing).toMatchObject({ [MISSING_RECORD_MARKER]: true });
+
+        // Now the real record lands (e.g. via a seeder or a refresh).
+        respondWithMissing = false;
+
+        await coreDispatch().fetchEntityRecord(
+            'postType',
+            'wp_template_part',
+            compositeId,
+        );
+
+        const resolved = coreSelect().getEntityRecord(
+            'postType',
+            'wp_template_part',
+            compositeId,
+        );
+
+        // The composite-id lookup now resolves to the real record
+        // through the alias map; the stale placeholder is gone.
+        expect(resolved).toMatchObject({ id: 7, slug: 'header' });
+        expect(resolved).not.toHaveProperty(MISSING_RECORD_MARKER);
+    });
+
+    it('RestRequestError carries the response status (#419)', () => {
+        // Callers (notably `fetchEntityRecord`) need to distinguish a
+        // 404 from a 5xx so they can decide whether to synthesize a
+        // missing-record placeholder or leave the cache empty for a
+        // retry. The structured error class exposes `.status` for that.
+        const error = new RestRequestError(404, '/api/menus/21', 'GET');
+
+        expect(error).toBeInstanceOf(Error);
+        expect(error.status).toBe(404);
+        expect(error.url).toBe('/api/menus/21');
+        expect(error.method).toBe('GET');
+        expect(error.name).toBe('RestRequestError');
     });
 
     it('fetchEntityRecords accepts a Laravel { data, meta } envelope', async () => {

--- a/resources/js/visual-editor/vendor/core-data-shim.ts
+++ b/resources/js/visual-editor/vendor/core-data-shim.ts
@@ -363,6 +363,37 @@ function queryKey(query?: Record<string, unknown> | null): string {
         .join('&');
 }
 
+/**
+ * Property on a synthesized record signalling that the upstream
+ * `GET /{entity}/{id}` returned 404 — the ref points at a record that no
+ * longer exists. Block-library entity consumers see a non-null record
+ * (so their `if (!record) {…}` guards don't fire) and can read this flag
+ * to render their own missing-state UI rather than crashing.
+ *
+ * @see {@link buildMissingEntityRecord}
+ * @see https://github.com/ArtisanPack-UI/visual-editor/issues/419
+ */
+export const MISSING_RECORD_MARKER = '_missing' as const;
+
+/**
+ * Synthesizes a minimal entity record representing a referenced row that
+ * was not found on the server. Carries the requested `id` on the entity's
+ * primary key field, a `status: 'missing'` (so the navigation block's
+ * `editedNavigationMenu.status === 'publish'` check resolves to false and
+ * `isNavigationMenuMissing` flips true), and the {@link MISSING_RECORD_MARKER}
+ * sentinel for callers that want to branch on the missing state directly.
+ */
+function buildMissingEntityRecord(
+    config: EntityConfig,
+    id: EntityKey,
+): EntityRecord {
+    return {
+        [config.key]: id,
+        [MISSING_RECORD_MARKER]: true,
+        status: 'missing',
+    };
+}
+
 function recordIdOf(
     record: EntityRecord,
     config: EntityConfig,
@@ -504,6 +535,31 @@ async function parseJson(response: Response): Promise<unknown> {
     }
 }
 
+/**
+ * Error thrown by {@link restRequest} when the upstream response is not OK.
+ *
+ * Carries the HTTP `status` so callers can distinguish a missing-resource
+ * 404 from a transient 5xx / network failure and react accordingly — e.g.
+ * the entity-record fetcher synthesizes a `_missing` placeholder on 404
+ * so entity-backed blocks can render their own missing-state UI instead
+ * of crashing through to the editor's error boundary (#419).
+ */
+export class RestRequestError extends Error {
+    public readonly status: number;
+
+    public readonly url: string;
+
+    public readonly method: string;
+
+    public constructor(status: number, url: string, method: string) {
+        super(`core-data-shim: ${method} ${url} failed with status ${status}`);
+        this.name = 'RestRequestError';
+        this.status = status;
+        this.url = url;
+        this.method = method;
+    }
+}
+
 async function restRequest(
     url: string,
     init: RequestInit,
@@ -516,9 +572,7 @@ async function restRequest(
     const body = await parseJson(response);
 
     if (!response.ok) {
-        throw new Error(
-            `core-data-shim: ${init.method ?? 'GET'} ${url} failed with status ${response.status}`,
-        );
+        throw new RestRequestError(response.status, url, init.method ?? 'GET');
     }
 
     return body;
@@ -605,6 +659,18 @@ function reducer(
 
                 if (compositeKey !== null && compositeKey !== primaryKey) {
                     nextAliases[compositeKey] = primaryKey;
+
+                    // #419: A prior composite-id resolver pass may have
+                    // stored a `_missing` placeholder directly under the
+                    // composite key in `items` (the composite id is the
+                    // record's id because the placeholder has no
+                    // theme/slug to derive an alias from). Drop that
+                    // stale entry now that the real numeric-keyed
+                    // record is authoritative — `selectEntityRecord`'s
+                    // direct-lookup path runs before the alias fallback,
+                    // so without this delete the placeholder would
+                    // continue to win for the composite-id lookup.
+                    delete nextItems[compositeKey];
                 }
             }
 
@@ -1441,9 +1507,33 @@ const actions = {
                             undefined,
                             false,
                         );
+
+                        return record;
                     }
 
-                    return record;
+                    // #419: A successful but empty list response for a
+                    // unique theme+slug filter means the referenced
+                    // template / template-part isn't on the server.
+                    // Synthesize the missing placeholder so the consumer
+                    // (e.g. `core/template-part`) doesn't crash on a
+                    // null record. Matches the numeric-id 404 path
+                    // below.
+                    const placeholder = buildMissingEntityRecord(
+                        config,
+                        id,
+                    );
+
+                    dispatch.receiveEntityRecords(
+                        kind,
+                        name,
+                        [placeholder],
+                        undefined,
+                        undefined,
+                        undefined,
+                        false,
+                    );
+
+                    return placeholder;
                 }
 
                 const record = (await restRequest(entityUrl(config, id), {
@@ -1464,7 +1554,40 @@ const actions = {
                 }
 
                 return record;
-            } catch {
+            } catch (error) {
+                // #419: When a numeric-id show endpoint 404s the referenced
+                // entity is gone (deleted, never seeded, etc.) — return a
+                // sentinel placeholder so entity-backed core blocks
+                // (`core/navigation`, `core/post-*`, `core/template-part`)
+                // see a non-null record and can render their own
+                // missing-state UI instead of crashing the upstream
+                // `useEntityRecord` consumer through to the editor's
+                // error boundary. Mirrors how upstream WP surfaces a
+                // trashed referenced post: the block keeps rendering
+                // and the author can replace or remove the ref.
+                //
+                // Other failure modes (5xx, network, parse) still resolve
+                // to `null` — those are transient and should leave the
+                // resolver retryable rather than poisoning the cache.
+                if (
+                    error instanceof RestRequestError &&
+                    error.status === 404
+                ) {
+                    const placeholder = buildMissingEntityRecord(config, id);
+
+                    dispatch.receiveEntityRecords(
+                        kind,
+                        name,
+                        [placeholder],
+                        undefined,
+                        undefined,
+                        undefined,
+                        false,
+                    );
+
+                    return placeholder;
+                }
+
                 return null;
             }
         },


### PR DESCRIPTION
## Description

Entity-backed core blocks (`core/navigation`, `core/post-*`, `core/template-part`) were crashing through to the editor's `@wordpress/element` `ErrorBoundary` — "This block has encountered an error and cannot be previewed." — whenever their `ref` / `id` attribute pointed at a record that no longer existed on the server. With #395's resolver wiring, the shim now actually fires `GET /visual-editor/api/{entity}/{id}` for those refs; the 404 was being swallowed in `fetchEntityRecord`'s catch block and resolved to `null`, and block-library's edit components couldn't survive that.

This PR makes the shim degrade gracefully on missing refs so the block keeps rendering and the author can replace or remove the reference — mirroring how upstream WP behaves when a referenced post is in the trash.

**Closes:** #419

## Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds new functionality)
- [ ] Enhancement (improves existing functionality)
- [ ] Refactoring (code improvement, no behavior change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Security fix
- [ ] Breaking change (breaks backward compatibility)

## Related Issue

**Issue:** #419

## Motivation and Context

Pre-#395 the resolvers never fired so the cache was perpetually empty and block-library couldn't tell the difference between "still loading" and "ref doesn't exist." With resolution settling cleanly, the null-record case is now reachable and exposed any block whose edit code reads from a null `useEntityRecord` result. Reproduced on `core/navigation` embedded in the seeded `footer` template part (saved markup `<!-- wp:navigation {"ref":21} /-->`) — the menu record isn't on the cms-framework `/menus` endpoint, the show route 404s, and the navigation block's `useEntityRecord` returns null and throws.

The seeding angle from the issue (option 1 — ship realistic seeded refs so a clean install has no orphans) is a separate change: `SampleContentRepository` currently writes legacy `VisualEditor*` tables while `MenuController` reads cms-framework's `Menu` model, so reconciling those crosses package boundaries and warrants its own PR. The defensive shim handles every entity uniformly, regardless of whether the underlying endpoint is cms-framework backed or temporarily missing.

## Changes Made

- Introduced a structured `RestRequestError` (exported) that carries `.status`, `.url`, and `.method`, so `restRequest` callers can branch on the HTTP status instead of parsing error messages.
- `fetchEntityRecord` now branches on `error.status === 404` in its catch block. On a 404 (numeric id) it dispatches a synthesized `{[config.key]: id, _missing: true, status: 'missing'}` placeholder through `receiveEntityRecords` and returns it. Non-404 errors (5xx, network) keep the existing null-return behavior so the resolver stays retryable rather than poisoned with a permanent missing sentinel.
- Composite-id (`<theme>//<slug>`) lookups (used by `core/template-part`) get the same placeholder treatment when the index endpoint returns an empty list — there's no matching record on the server, same outcome as a numeric 404.
- The reducer now drops any stale composite-keyed entry from `items` when a real numeric-keyed record later lands with that composite alias, so `selectEntityRecord`'s direct-lookup path stops returning the placeholder once the underlying record exists (race fix flagged by CodeRabbit).
- Exported `MISSING_RECORD_MARKER` constant so callers can branch on the missing state cleanly.

The `status: 'missing'` value on the placeholder is load-bearing: block-library's `useNavigationMenu` reads `editedNavigationMenu.status === 'publish' || === 'draft'` and flips `isNavigationMenuMissing` to true when neither matches, which is exactly the path that renders the navigation block's own deleted/unavailable UI.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS 15.5
- Browser (if applicable): Safari
- PHP Version: 8.4.3
- Project Version: `release/1.0` HEAD

**Tests Performed:**
1. Vitest suite for the shim — `npx vitest run resources/js/visual-editor/vendor/__tests__/core-data-shim.test.tsx` — 72/72 passing including the new 404 / empty-composite-list / race-fix / `RestRequestError` cases.
2. Manual repro in the dev app: reseeded sample content with the legacy `VisualEditorNavigation` table (so the `ref:21` in the footer template part has no matching `menus` row), opened a template that pulls in the footer template part. Pre-fix the navigation block rendered the editor's error-boundary fallback; post-fix it renders its own missing-state UI and the rest of the editor remains interactive.

PHP test suite has 14 pre-existing failures in `SeedSampleContentCommandTest` because `SampleContentRepository.php` references `VisualEditor{Template,TemplatePart,Navigation,Pattern,GlobalStyles}` models that don't exist in `src/Models/` on `release/1.0` — only `VisualEditorPost.php` is present. Those failures are unrelated to this JS-only change and reproduce on a clean `release/1.0` checkout.

## Accessibility Tests Run

- [ ] Keyboard navigation tested
- [ ] Screen reader tested
- [ ] Color contrast verified
- [ ] ARIA labels checked

**Details:** Pure data-layer change — no rendered UI changes here. The block-library's existing missing-state UI does the actual rendering and already meets WP accessibility requirements.

## Tests Added

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All tests passing

**Test details:**
- `fetchEntityRecord synthesizes a missing-record placeholder on 404 for a numeric id (#419)` — covers the navigation / post / attachment ref crash path.
- `fetchEntityRecord falls back to null for non-404 errors (#419)` — locks in that 5xx / network failures stay retryable.
- `fetchEntityRecord synthesizes a missing-record placeholder when a composite-id lookup returns no matches (#419)` — covers `core/template-part` refs.
- `clears a stale composite-id missing placeholder when the real record later lands (#419)` — race-fix coverage for the items/alias interaction.
- `RestRequestError carries the response status (#419)` — locks in the structured error contract.

## Documentation

- [x] Inline code documentation added
- [ ] README updated
- [ ] Wiki updated
- [ ] API documentation updated

**Documentation details:** JSDoc on `RestRequestError`, `MISSING_RECORD_MARKER`, and `buildMissingEntityRecord`. Inline comments on the catch-block branches and the reducer's composite-alias placeholder cleanup explain why each path exists and link back to #419.

## Screenshots

N/A — pure data-layer change. The block-library missing-state UI is the upstream Gutenberg "Navigation Menu has been deleted or is unavailable" panel; this PR makes it reachable on missing refs instead of being short-circuited by the error boundary.

## Pre-Submission Checklist

Before requesting review, confirm:

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [x] Accessibility tests completed
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of missing entity references with better error distinction between "not found" responses and other server errors.
  * Enhanced entity record caching to properly resolve missing references while preventing stale placeholder records from overriding real data.

* **Tests**
  * Expanded test coverage for missing entity record behavior and error handling scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArtisanPack-UI/visual-editor/pull/471?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->