### PR TITLE
feat(blocks): fork content cluster as artisanpack/* (I1, #409)

### DIFF
--- a/packages/renderer-parity.json
+++ b/packages/renderer-parity.json
@@ -51,6 +51,15 @@
         "core/navigation-link",
         "core/navigation-submenu",
         "artisanpack/callout",
-        "artisanpack/paragraph"
+        "artisanpack/paragraph",
+        "artisanpack/heading",
+        "artisanpack/list",
+        "artisanpack/list-item",
+        "artisanpack/quote",
+        "artisanpack/code",
+        "artisanpack/preformatted",
+        "artisanpack/verse",
+        "artisanpack/pullquote",
+        "artisanpack/table"
     ]
 }

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/code.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/code.blade.php
@@ -1,0 +1,2 @@
+{{-- artisanpack/code — delegates to core/code. --}}
+@include('visual-editor-renderer-blade::blocks.core.code', ['attributes' => $attributes ?? [], 'innerContent' => $innerContent ?? ''])

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/heading.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/heading.blade.php
@@ -1,0 +1,11 @@
+{{--
+    artisanpack/heading — delegates to the upstream core/heading partial.
+
+    The saved markup for artisanpack/heading is byte-equivalent to upstream
+    core/heading, so we share one Blade partial for both namespaces. If
+    the artisanpack fork ever diverges visually, lift the body of
+    core/heading.blade.php into this file and edit independently.
+
+    Phase I1 content cluster (issue #409).
+--}}
+@include('visual-editor-renderer-blade::blocks.core.heading', ['attributes' => $attributes ?? [], 'innerContent' => $innerContent ?? ''])

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/list-item.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/list-item.blade.php
@@ -1,0 +1,2 @@
+{{-- artisanpack/list-item — delegates to core/list-item. --}}
+@include('visual-editor-renderer-blade::blocks.core.list-item', ['attributes' => $attributes ?? [], 'innerContent' => $innerContent ?? ''])

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/list.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/list.blade.php
@@ -1,0 +1,5 @@
+{{--
+    artisanpack/list — delegates to the upstream core/list partial. See
+    artisanpack/heading.blade.php for the rationale.
+--}}
+@include('visual-editor-renderer-blade::blocks.core.list', ['attributes' => $attributes ?? [], 'innerContent' => $innerContent ?? ''])

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/preformatted.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/preformatted.blade.php
@@ -1,0 +1,2 @@
+{{-- artisanpack/preformatted — delegates to core/preformatted. --}}
+@include('visual-editor-renderer-blade::blocks.core.preformatted', ['attributes' => $attributes ?? [], 'innerContent' => $innerContent ?? ''])

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/pullquote.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/pullquote.blade.php
@@ -1,0 +1,2 @@
+{{-- artisanpack/pullquote — delegates to core/pullquote. --}}
+@include('visual-editor-renderer-blade::blocks.core.pullquote', ['attributes' => $attributes ?? [], 'innerContent' => $innerContent ?? ''])

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/quote.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/quote.blade.php
@@ -1,0 +1,2 @@
+{{-- artisanpack/quote — delegates to core/quote. --}}
+@include('visual-editor-renderer-blade::blocks.core.quote', ['attributes' => $attributes ?? [], 'innerContent' => $innerContent ?? ''])

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/table.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/table.blade.php
@@ -1,0 +1,2 @@
+{{-- artisanpack/table — delegates to core/table. --}}
+@include('visual-editor-renderer-blade::blocks.core.table', ['attributes' => $attributes ?? [], 'innerContent' => $innerContent ?? ''])

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/verse.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/verse.blade.php
@@ -1,0 +1,2 @@
+{{-- artisanpack/verse — delegates to core/verse. --}}
+@include('visual-editor-renderer-blade::blocks.core.verse', ['attributes' => $attributes ?? [], 'innerContent' => $innerContent ?? ''])

--- a/packages/visual-editor-renderer-react/src/blocks/registerCoreBlocks.ts
+++ b/packages/visual-editor-renderer-react/src/blocks/registerCoreBlocks.ts
@@ -71,19 +71,27 @@ import type { BlockRenderer } from '../types';
 
 const CORE_BLOCKS: Record<string, BlockRenderer> = {
     'core/paragraph': ParagraphBlock,
-    // Fork: artisanpack/paragraph reuses the same renderer as core/paragraph.
-    // Both blocks emit identical markup so mixed documents (during the V2
-    // migration window) render identically regardless of which namespace
-    // the editor persisted.
+    // Fork: artisanpack/* reuses the same renderer as the upstream core/*
+    // because the saved markup is byte-equivalent across the two
+    // namespaces. Mixed documents render identically regardless of which
+    // namespace the editor persisted. Phase I1 content cluster (#409).
     'artisanpack/paragraph': ParagraphBlock,
     'core/heading': HeadingBlock,
+    'artisanpack/heading': HeadingBlock,
     'core/list': ListBlock,
+    'artisanpack/list': ListBlock,
     'core/list-item': ListItemBlock,
+    'artisanpack/list-item': ListItemBlock,
     'core/quote': QuoteBlock,
+    'artisanpack/quote': QuoteBlock,
     'core/code': CodeBlock,
+    'artisanpack/code': CodeBlock,
     'core/preformatted': PreformattedBlock,
+    'artisanpack/preformatted': PreformattedBlock,
     'core/verse': VerseBlock,
+    'artisanpack/verse': VerseBlock,
     'core/pullquote': PullquoteBlock,
+    'artisanpack/pullquote': PullquoteBlock,
     'core/image': ImageBlock,
     'core/gallery': GalleryBlock,
     'core/video': VideoBlock,
@@ -100,6 +108,7 @@ const CORE_BLOCKS: Record<string, BlockRenderer> = {
     'core/cover': CoverBlock,
     'core/media-text': MediaTextBlock,
     'core/table': TableBlock,
+    'artisanpack/table': TableBlock,
     'core/details': DetailsBlock,
     'core/search': SearchBlock,
     'core/separator': SeparatorBlock,

--- a/packages/visual-editor-renderer-vue/src/blocks/registerCoreBlocks.ts
+++ b/packages/visual-editor-renderer-vue/src/blocks/registerCoreBlocks.ts
@@ -71,19 +71,27 @@ import type { BlockRenderer } from '../types';
 
 const CORE_BLOCKS: Record<string, BlockRenderer> = {
     'core/paragraph': ParagraphBlock,
-    // Fork: artisanpack/paragraph reuses the same renderer as core/paragraph.
-    // Both blocks emit identical markup so mixed documents (during the V2
-    // migration window) render identically regardless of which namespace
-    // the editor persisted.
+    // Fork: artisanpack/* reuses the same renderer as the upstream core/*
+    // because the saved markup is byte-equivalent across the two
+    // namespaces. Mixed documents render identically regardless of which
+    // namespace the editor persisted. Phase I1 content cluster (#409).
     'artisanpack/paragraph': ParagraphBlock,
     'core/heading': HeadingBlock,
+    'artisanpack/heading': HeadingBlock,
     'core/list': ListBlock,
+    'artisanpack/list': ListBlock,
     'core/list-item': ListItemBlock,
+    'artisanpack/list-item': ListItemBlock,
     'core/quote': QuoteBlock,
+    'artisanpack/quote': QuoteBlock,
     'core/code': CodeBlock,
+    'artisanpack/code': CodeBlock,
     'core/preformatted': PreformattedBlock,
+    'artisanpack/preformatted': PreformattedBlock,
     'core/verse': VerseBlock,
+    'artisanpack/verse': VerseBlock,
     'core/pullquote': PullquoteBlock,
+    'artisanpack/pullquote': PullquoteBlock,
     'core/image': ImageBlock,
     'core/gallery': GalleryBlock,
     'core/video': VideoBlock,
@@ -100,6 +108,7 @@ const CORE_BLOCKS: Record<string, BlockRenderer> = {
     'core/cover': CoverBlock,
     'core/media-text': MediaTextBlock,
     'core/table': TableBlock,
+    'artisanpack/table': TableBlock,
     'core/details': DetailsBlock,
     'core/search': SearchBlock,
     'core/separator': SeparatorBlock,

--- a/resources/js/visual-editor/blocks/_shared/__tests__/fork-class-name-alias.test.ts
+++ b/resources/js/visual-editor/blocks/_shared/__tests__/fork-class-name-alias.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Tests for the I1 fork class-name alias filter.
+ *
+ * The module exports a one-shot registrar (idempotent for production
+ * safety). Tests use `vi.resetModules` to get a fresh module per test so
+ * the singleton flag doesn't bleed across cases.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+interface FilterHandler {
+    name: string;
+    callback: (...args: unknown[]) => unknown;
+}
+
+const filters = new Map<string, FilterHandler[]>();
+
+vi.mock('@wordpress/hooks', () => ({
+    addFilter: (
+        hookName: string,
+        name: string,
+        callback: (...args: unknown[]) => unknown
+    ) => {
+        if (!filters.has(hookName)) {
+            filters.set(hookName, []);
+        }
+        filters.get(hookName)!.push({ name, callback });
+    },
+}));
+
+function applyFilter(hookName: string, value: unknown, ...args: unknown[]): unknown {
+    const handlers = filters.get(hookName) ?? [];
+    return handlers.reduce(
+        (acc, { callback }) => callback(acc, ...args),
+        value
+    );
+}
+
+beforeEach(() => {
+    filters.clear();
+    vi.resetModules();
+});
+
+describe('registerForkClassNameAlias', () => {
+    it('is idempotent — calling twice registers the filter once', async () => {
+        const mod = await import('../fork-class-name-alias');
+        mod.registerForkClassNameAlias();
+        mod.registerForkClassNameAlias();
+        expect(filters.get('blocks.getBlockDefaultClassName')).toHaveLength(1);
+    });
+
+    it('remaps every I1 fork block name to its upstream class', async () => {
+        const mod = await import('../fork-class-name-alias');
+        mod.registerForkClassNameAlias();
+        const slugs = [
+            'heading',
+            'list',
+            'list-item',
+            'quote',
+            'code',
+            'preformatted',
+            'pullquote',
+            'verse',
+            'table',
+        ];
+        for (const slug of slugs) {
+            expect(
+                applyFilter(
+                    'blocks.getBlockDefaultClassName',
+                    `wp-block-artisanpack-${slug}`,
+                    `artisanpack/${slug}`
+                )
+            ).toBe(`wp-block-${slug}`);
+        }
+    });
+
+    it('leaves unknown artisanpack blocks alone (e.g. artisanpack/callout)', async () => {
+        const mod = await import('../fork-class-name-alias');
+        mod.registerForkClassNameAlias();
+        expect(
+            applyFilter(
+                'blocks.getBlockDefaultClassName',
+                'wp-block-artisanpack-callout',
+                'artisanpack/callout'
+            )
+        ).toBe('wp-block-artisanpack-callout');
+    });
+
+    it('leaves core/* blocks alone', async () => {
+        const mod = await import('../fork-class-name-alias');
+        mod.registerForkClassNameAlias();
+        expect(
+            applyFilter(
+                'blocks.getBlockDefaultClassName',
+                'wp-block-table',
+                'core/table'
+            )
+        ).toBe('wp-block-table');
+    });
+});

--- a/resources/js/visual-editor/blocks/_shared/fork-class-name-alias.ts
+++ b/resources/js/visual-editor/blocks/_shared/fork-class-name-alias.ts
@@ -1,0 +1,65 @@
+/**
+ * Fork class-name alias filter.
+ *
+ * `@wordpress/blocks.getBlockDefaultClassName(name)` derives a wrapper
+ * class from the block name by stripping the `core/` prefix and replacing
+ * the slash with a hyphen — so `core/table` → `wp-block-table`, and
+ * `artisanpack/table` → `wp-block-artisanpack-table`.
+ *
+ * Every CSS rule in `@wordpress/block-library`'s stylesheet (which is
+ * bundled into our gutenberg chunk) targets the *upstream* class
+ * (`.wp-block-table`, `.wp-block-heading`, …). The I1 content-cluster
+ * forks emit byte-equivalent saved markup to their `core/*` counterparts
+ * — but without this filter their wrapper element gets a different class
+ * and none of the upstream CSS applies, so e.g. table cells render at 0×0
+ * and look like blank space in the editor.
+ *
+ * The filter remaps the default class for each I1 fork to its upstream
+ * equivalent. The wrapper still gets an `artisanpack`-namespaced class
+ * additively (block-editor adds both), so per-fork CSS overrides remain
+ * possible — but the base rules from upstream "just work".
+ *
+ * Scoped to a known whitelist of fork slugs so we never accidentally
+ * collide with a block that genuinely needs an `artisanpack`-only class
+ * (e.g. `artisanpack/callout`).
+ */
+
+import { addFilter } from '@wordpress/hooks';
+
+const I1_FORK_SLUGS: ReadonlyArray<string> = [
+    'heading',
+    'list',
+    'list-item',
+    'quote',
+    'code',
+    'preformatted',
+    'pullquote',
+    'verse',
+    'table',
+];
+
+const FORK_NAMESPACE_PREFIX = 'artisanpack/';
+
+let registered = false;
+
+export function registerForkClassNameAlias(): void {
+    if (registered) {
+        return;
+    }
+    registered = true;
+
+    addFilter(
+        'blocks.getBlockDefaultClassName',
+        'artisanpack/visual-editor/fork-class-name-alias',
+        (className: string, blockName: string) => {
+            if (!blockName.startsWith(FORK_NAMESPACE_PREFIX)) {
+                return className;
+            }
+            const slug = blockName.slice(FORK_NAMESPACE_PREFIX.length);
+            if (!I1_FORK_SLUGS.includes(slug)) {
+                return className;
+            }
+            return `wp-block-${slug}`;
+        }
+    );
+}

--- a/resources/js/visual-editor/blocks/_shared/migrate-font-family.ts
+++ b/resources/js/visual-editor/blocks/_shared/migrate-font-family.ts
@@ -1,0 +1,64 @@
+// Vendored from @wordpress/block-library/src/utils/migrate-font-family.js (v9.43.0).
+//
+// Migrates the legacy `style.typography.fontFamily` shape
+// ("var:preset|font-family|helvetica-arial") to the top-level
+// `fontFamily` attribute. The upstream helper reaches into
+// `@wordpress/block-editor` privateApis to call `cleanEmptyObject`; we
+// inline a self-contained equivalent so we don't depend on that
+// unlock-gated API.
+
+interface AttributesWithStyle {
+    style?: {
+        typography?: {
+            fontFamily?: string;
+        } & Record<string, unknown>;
+    } & Record<string, unknown>;
+    fontFamily?: string;
+    [key: string]: unknown;
+}
+
+function isEmptyObject(value: unknown): boolean {
+    return (
+        typeof value === 'object' &&
+        value !== null &&
+        Object.keys(value as Record<string, unknown>).length === 0
+    );
+}
+
+function cleanEmptyObject<T extends Record<string, unknown>>(
+    object: T | undefined
+): T | undefined {
+    if (object === undefined || object === null) {
+        return undefined;
+    }
+    const cleaned: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(object)) {
+        if (value && typeof value === 'object' && !Array.isArray(value)) {
+            const recursed = cleanEmptyObject(value as Record<string, unknown>);
+            if (recursed !== undefined) {
+                cleaned[key] = recursed;
+            }
+        } else if (value !== undefined) {
+            cleaned[key] = value;
+        }
+    }
+    return isEmptyObject(cleaned) ? undefined : (cleaned as T);
+}
+
+export function migrateFontFamily<T extends AttributesWithStyle>(attributes: T): T {
+    if (!attributes?.style?.typography?.fontFamily) {
+        return attributes;
+    }
+    const { fontFamily, ...typography } = attributes.style.typography;
+
+    return {
+        ...attributes,
+        style: cleanEmptyObject({
+            ...attributes.style,
+            typography,
+        }),
+        fontFamily: fontFamily.split('|').pop(),
+    } as T;
+}
+
+export default migrateFontFamily;

--- a/resources/js/visual-editor/blocks/_shared/migrate-text-align.ts
+++ b/resources/js/visual-editor/blocks/_shared/migrate-text-align.ts
@@ -1,0 +1,37 @@
+// Vendored from @wordpress/block-library/src/utils/migrate-text-align.js (v9.43.0).
+//
+// Migrates a top-level `textAlign` attribute into the canonical
+// `style.typography.textAlign` block-support shape. Used by the heading,
+// quote, code, preformatted, pullquote, and verse deprecation chains —
+// hence the promotion out of any single block directory.
+
+interface AttributesWithStyle {
+    textAlign?: string;
+    style?: {
+        typography?: {
+            textAlign?: string;
+        } & Record<string, unknown>;
+    } & Record<string, unknown>;
+    [key: string]: unknown;
+}
+
+export function migrateTextAlignAttributeToBlockSupport<
+    T extends AttributesWithStyle,
+>(attributes: T): T {
+    const { textAlign, ...restAttributes } = attributes;
+    if (!textAlign) {
+        return attributes;
+    }
+    return {
+        ...(restAttributes as T),
+        style: {
+            ...attributes.style,
+            typography: {
+                ...attributes.style?.typography,
+                textAlign,
+            },
+        },
+    };
+}
+
+export default migrateTextAlignAttributeToBlockSupport;

--- a/resources/js/visual-editor/blocks/code/__tests__/deprecated.test.tsx
+++ b/resources/js/visual-editor/blocks/code/__tests__/deprecated.test.tsx
@@ -1,0 +1,14 @@
+/**
+ * Locks the (empty) deprecation chain for `artisanpack/code`.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import deprecated from '../deprecated';
+
+describe('code deprecation chain', () => {
+    it('ships an empty chain matching upstream (which has none)', () => {
+        expect(Array.isArray(deprecated)).toBe(true);
+        expect(deprecated).toHaveLength(0);
+    });
+});

--- a/resources/js/visual-editor/blocks/code/__tests__/edit.test.tsx
+++ b/resources/js/visual-editor/blocks/code/__tests__/edit.test.tsx
@@ -1,0 +1,59 @@
+/**
+ * Tests for the `artisanpack/code` edit component.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+vi.mock('@wordpress/i18n', () => ({
+    __: (text: string) => text,
+}));
+
+vi.mock('@wordpress/blocks', () => ({
+    createBlock: vi.fn(),
+    getDefaultBlockName: () => 'core/paragraph',
+}));
+
+vi.mock('@wordpress/block-editor', () => ({
+    useBlockProps: Object.assign(
+        (props?: Record<string, unknown>) => ({ ...props }),
+        { save: (props?: Record<string, unknown>) => ({ ...props }) }
+    ),
+    RichText: function RichText(props: {
+        value?: string;
+        onChange?: (value: string) => void;
+        placeholder?: string;
+    }) {
+        return (
+            <div
+                role="textbox"
+                aria-label="code-rich-text"
+                data-placeholder={props.placeholder}
+                onClick={() => props.onChange?.('console.log(1)')}
+                dangerouslySetInnerHTML={{ __html: props.value ?? '' }}
+            />
+        );
+    },
+}));
+
+import CodeEdit from '../edit';
+
+describe('CodeEdit', () => {
+    it('renders a code RichText with the write-code placeholder', () => {
+        const setAttributes = vi.fn();
+        render(
+            <CodeEdit attributes={{ content: '' }} setAttributes={setAttributes} />
+        );
+        const textbox = screen.getByRole('textbox', { name: 'code-rich-text' });
+        expect(textbox.getAttribute('data-placeholder')).toBe('Write code…');
+    });
+
+    it('calls setAttributes with code content on change', () => {
+        const setAttributes = vi.fn();
+        render(
+            <CodeEdit attributes={{ content: '' }} setAttributes={setAttributes} />
+        );
+        fireEvent.click(screen.getByRole('textbox', { name: 'code-rich-text' }));
+        expect(setAttributes).toHaveBeenCalledWith({ content: 'console.log(1)' });
+    });
+});

--- a/resources/js/visual-editor/blocks/code/__tests__/save.test.tsx
+++ b/resources/js/visual-editor/blocks/code/__tests__/save.test.tsx
@@ -1,0 +1,75 @@
+/**
+ * Tests for the `artisanpack/code` save component.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+vi.mock('@wordpress/block-editor', () => ({
+    useBlockProps: Object.assign(
+        (props?: Record<string, unknown>) => ({ ...props }),
+        { save: (props?: Record<string, unknown>) => ({ ...props }) }
+    ),
+    RichText: Object.assign(() => null, {
+        Content: ({
+            value,
+            tagName,
+        }: { value?: string; tagName?: string }) => {
+            const Tag = (tagName ?? 'code') as keyof JSX.IntrinsicElements;
+            return (
+                <Tag dangerouslySetInnerHTML={{ __html: value ?? '' }} />
+            );
+        },
+    }),
+}));
+
+import CodeSave from '../save';
+import metadata from '../block.json';
+import { escape } from '../utils';
+
+describe('artisanpack/code block.json', () => {
+    it('declares the artisanpack namespace and text category', () => {
+        expect(metadata.name).toBe('artisanpack/code');
+        expect(metadata.category).toBe('text');
+    });
+
+    it('content attribute uses the code selector and preserveWhiteSpace flag', () => {
+        expect(metadata.attributes.content.selector).toBe('code');
+        expect(metadata.attributes.content.__unstablePreserveWhiteSpace).toBe(true);
+    });
+});
+
+describe('escape helper', () => {
+    it('escapes opening square brackets', () => {
+        expect(escape('[embed]')).toBe('&#91;embed]');
+    });
+
+    it('escapes isolated URL protocol slashes', () => {
+        expect(escape('https://example.com/x')).toBe('https:&#47;&#47;example.com/x');
+    });
+
+    it('leaves arbitrary text alone', () => {
+        expect(escape('hello world')).toBe('hello world');
+    });
+});
+
+describe('CodeSave', () => {
+    it('renders a pre wrapping a code tag', () => {
+        const html = renderToStaticMarkup(
+            <CodeSave attributes={{ content: 'console.log(1)' }} />
+        );
+        expect(html).toContain('<pre');
+        expect(html).toContain('<code');
+        expect(html).toContain('console.log(1)');
+    });
+
+    it('escapes brackets in saved markup', () => {
+        // dangerouslySetInnerHTML passes characters through verbatim; the &
+        // ends up as `&amp;` when serialized by renderToStaticMarkup, so the
+        // expected literal in the output is `&amp;#91;`.
+        const html = renderToStaticMarkup(
+            <CodeSave attributes={{ content: '[shortcode]' }} />
+        );
+        expect(html).toContain('#91;shortcode');
+    });
+});

--- a/resources/js/visual-editor/blocks/code/__tests__/transforms.test.ts
+++ b/resources/js/visual-editor/blocks/code/__tests__/transforms.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Transforms tests for `artisanpack/code`.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@wordpress/blocks', () => ({
+    createBlock: (name: string, attributes?: Record<string, unknown>) => ({
+        name,
+        attributes: attributes ?? {},
+        innerBlocks: [],
+    }),
+}));
+
+vi.mock('@wordpress/rich-text', () => ({
+    create: (input: { text: string }) => ({ text: input.text }),
+    toHTMLString: ({ value }: { value: { text: string } }) => value.text,
+}));
+
+import transforms from '../transforms';
+
+describe('code transforms', () => {
+    it('declares from/to arrays', () => {
+        expect(Array.isArray(transforms.from)).toBe(true);
+        expect(Array.isArray(transforms.to)).toBe(true);
+    });
+
+    it('input transform on ``` creates an empty code block', () => {
+        const input = transforms.from.find(
+            (t: { type: string }) => t.type === 'input'
+        ) as { transform: () => { name: string } };
+        expect(input.transform().name).toBe('artisanpack/code');
+    });
+
+    it('paragraph → code preserves content', () => {
+        const fromParagraph = transforms.from.find(
+            (t: { type: string; blocks?: string[] }) =>
+                t.type === 'block' && t.blocks?.includes('core/paragraph')
+        ) as {
+            transform: (a: Record<string, unknown>) => {
+                name: string;
+                attributes: Record<string, unknown>;
+            };
+        };
+        const result = fromParagraph.transform({ content: 'hi' });
+        expect(result.name).toBe('artisanpack/code');
+        expect(result.attributes).toMatchObject({ content: 'hi' });
+    });
+
+    it('block transform from core/code → artisanpack/code', () => {
+        const fromBlock = transforms.from.find(
+            (t: { type: string; blocks?: string[] }) =>
+                t.type === 'block' &&
+                t.blocks?.length === 1 &&
+                t.blocks[0] === 'core/code'
+        ) as {
+            transform: (a: Record<string, unknown>) => { name: string };
+        };
+        expect(fromBlock.transform({ content: 'x' }).name).toBe('artisanpack/code');
+    });
+
+    it('block transform to core/code', () => {
+        const toBlock = transforms.to.find(
+            (t: { type: string; blocks?: string[] }) =>
+                t.type === 'block' && t.blocks?.[0] === 'core/code'
+        ) as {
+            transform: (a: Record<string, unknown>) => { name: string };
+        };
+        expect(toBlock.transform({ content: 'x' }).name).toBe('core/code');
+    });
+});

--- a/resources/js/visual-editor/blocks/code/block.json
+++ b/resources/js/visual-editor/blocks/code/block.json
@@ -1,0 +1,66 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "artisanpack/code",
+    "title": "Code",
+    "category": "text",
+    "description": "Display code snippets that respect your spacing and tabs.",
+    "textdomain": "artisanpack-visual-editor",
+    "attributes": {
+        "content": {
+            "type": "rich-text",
+            "source": "rich-text",
+            "selector": "code",
+            "__unstablePreserveWhiteSpace": true,
+            "role": "content"
+        }
+    },
+    "supports": {
+        "align": [ "wide" ],
+        "anchor": true,
+        "typography": {
+            "fontSize": true,
+            "lineHeight": true,
+            "__experimentalFontFamily": true,
+            "__experimentalFontWeight": true,
+            "__experimentalFontStyle": true,
+            "__experimentalTextTransform": true,
+            "__experimentalTextDecoration": true,
+            "__experimentalLetterSpacing": true,
+            "__experimentalDefaultControls": {
+                "fontSize": true
+            }
+        },
+        "spacing": {
+            "margin": [ "top", "bottom" ],
+            "padding": true,
+            "__experimentalDefaultControls": {
+                "margin": false,
+                "padding": false
+            }
+        },
+        "__experimentalBorder": {
+            "radius": true,
+            "color": true,
+            "width": true,
+            "style": true,
+            "__experimentalDefaultControls": {
+                "width": true,
+                "color": true
+            }
+        },
+        "color": {
+            "text": true,
+            "background": true,
+            "gradients": true,
+            "__experimentalDefaultControls": {
+                "background": true,
+                "text": true
+            }
+        },
+        "interactivity": {
+            "clientNavigation": true
+        }
+    },
+    "style": "wp-block-code"
+}

--- a/resources/js/visual-editor/blocks/code/code.css
+++ b/resources/js/visual-editor/blocks/code/code.css
@@ -1,0 +1,26 @@
+/*
+ * Code — frontend + editor styles.
+ *
+ * Combined port of `@wordpress/block-library/src/code/style.scss`,
+ * `theme.scss`, and `editor.scss` (v9.43.0).
+ */
+
+.wp-block-code {
+    box-sizing: border-box;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    font-family: Menlo, Consolas, monaco, monospace;
+    padding: 0.8em 1em;
+}
+
+.wp-block-code code {
+    display: block;
+    font-family: inherit;
+    overflow-wrap: break-word;
+    white-space: pre-wrap;
+    background: none;
+    /*!rtl:begin:ignore*/
+    direction: ltr;
+    text-align: initial;
+    /*!rtl:end:ignore*/
+}

--- a/resources/js/visual-editor/blocks/code/deprecated.tsx
+++ b/resources/js/visual-editor/blocks/code/deprecated.tsx
@@ -1,0 +1,12 @@
+/**
+ * Code — deprecation chain.
+ *
+ * Upstream `@wordpress/block-library/src/code/` ships no `deprecated.js`
+ * (v9.43.0). The block's save shape has been stable since pre-rich-text;
+ * an empty chain preserves parity. The file exists so the auto-discovery
+ * glob always finds the same module surface across forks.
+ */
+
+const deprecated: Array<Record<string, unknown>> = [];
+
+export default deprecated;

--- a/resources/js/visual-editor/blocks/code/edit.tsx
+++ b/resources/js/visual-editor/blocks/code/edit.tsx
@@ -1,0 +1,54 @@
+/**
+ * Code — editor-side render.
+ *
+ * Ported from `@wordpress/block-library/src/code/edit.js` (v9.43.0).
+ */
+
+import type { ReactElement } from 'react';
+import { __ } from '@wordpress/i18n';
+import { RichText, useBlockProps } from '@wordpress/block-editor';
+import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
+
+interface CodeAttributes {
+    readonly content: string;
+}
+
+interface CodeEditProps {
+    readonly attributes: CodeAttributes;
+    readonly setAttributes: (next: Partial<CodeAttributes>) => void;
+    readonly onRemove?: () => void;
+    readonly insertBlocksAfter?: (block: unknown) => void;
+    readonly mergeBlocks?: (forward?: boolean) => void;
+}
+
+export default function CodeEdit({
+    attributes,
+    setAttributes,
+    onRemove,
+    insertBlocksAfter,
+    mergeBlocks,
+}: CodeEditProps): ReactElement {
+    const blockProps = useBlockProps();
+    return (
+        <pre {...blockProps}>
+            <RichText
+                tagName="code"
+                identifier="content"
+                value={attributes.content}
+                onChange={(content: string) => setAttributes({ content })}
+                onRemove={onRemove}
+                onMerge={mergeBlocks}
+                placeholder={__('Write code…')}
+                aria-label={__('Code')}
+                preserveWhiteSpace
+                __unstablePastePlainText
+                __unstableOnSplitAtDoubleLineEnd={() => {
+                    const defaultName = getDefaultBlockName();
+                    if (defaultName) {
+                        insertBlocksAfter?.(createBlock(defaultName));
+                    }
+                }}
+            />
+        </pre>
+    );
+}

--- a/resources/js/visual-editor/blocks/code/index.ts
+++ b/resources/js/visual-editor/blocks/code/index.ts
@@ -1,0 +1,26 @@
+/**
+ * Code block entrypoint.
+ *
+ * Fork target: V2 block-fork phase I1 (content cluster, issue #409).
+ */
+
+import metadata from './block.json';
+import edit from './edit';
+import save from './save';
+import deprecated from './deprecated';
+import transforms from './transforms';
+import icon from './inserter-icon';
+
+import './code.css';
+
+export { edit, save, metadata, icon, deprecated, transforms };
+
+export default {
+    name: metadata.name,
+    metadata,
+    edit,
+    save,
+    icon,
+    deprecated,
+    transforms,
+};

--- a/resources/js/visual-editor/blocks/code/inserter-icon.tsx
+++ b/resources/js/visual-editor/blocks/code/inserter-icon.tsx
@@ -1,0 +1,19 @@
+/**
+ * Code — inserter icon.
+ */
+
+import type { ReactElement } from 'react';
+
+export default function CodeInserterIcon(): ReactElement {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            width={24}
+            height={24}
+            aria-hidden="true"
+        >
+            <path d="M20.8 10.7l-4.3-4.3-1.1 1.1 4.3 4.3c.1.1.1.3 0 .4l-4.3 4.3 1.1 1.1 4.3-4.3c.7-.8.7-1.9 0-2.6zM4.2 11.7L8.5 7.4 7.4 6.3l-4.3 4.3c-.7.7-.7 1.8 0 2.5l4.3 4.3 1.1-1.1-4.3-4.3c-.1 0-.1-.2 0-.3zM9.8 17.6h1.5l3-11.1H12.8z" />
+        </svg>
+    );
+}

--- a/resources/js/visual-editor/blocks/code/save.tsx
+++ b/resources/js/visual-editor/blocks/code/save.tsx
@@ -15,11 +15,23 @@ interface ContentValue {
 }
 
 interface CodeSaveAttributes {
-    readonly content: string | ContentValue;
+    readonly content: string | ContentValue | null | undefined;
 }
 
 interface CodeSaveProps {
     readonly attributes: CodeSaveAttributes;
+}
+
+function resolveContent(
+    content: string | ContentValue | null | undefined
+): string {
+    if (typeof content === 'string') {
+        return content;
+    }
+    // Guard the optional rich-text value: legacy serialized attributes can
+    // arrive null/undefined for empty code blocks; the `toHTMLString` call
+    // chain would otherwise blow up on the first paint.
+    return content?.toHTMLString?.({ preserveWhiteSpace: true }) ?? '';
 }
 
 export default function CodeSave({ attributes }: CodeSaveProps): ReactElement {
@@ -27,13 +39,7 @@ export default function CodeSave({ attributes }: CodeSaveProps): ReactElement {
         <pre {...useBlockProps.save()}>
             <RichText.Content
                 tagName="code"
-                value={escape(
-                    typeof attributes.content === 'string'
-                        ? attributes.content
-                        : attributes.content.toHTMLString?.({
-                              preserveWhiteSpace: true,
-                          }) ?? ''
-                )}
+                value={escape(resolveContent(attributes.content))}
             />
         </pre>
     );

--- a/resources/js/visual-editor/blocks/code/save.tsx
+++ b/resources/js/visual-editor/blocks/code/save.tsx
@@ -1,0 +1,40 @@
+/**
+ * Code — saved markup.
+ *
+ * Ported from `@wordpress/block-library/src/code/save.js` (v9.43.0).
+ * Save shape is byte-equivalent to upstream `core/code`.
+ */
+
+import type { ReactElement } from 'react';
+import { RichText, useBlockProps } from '@wordpress/block-editor';
+
+import { escape } from './utils';
+
+interface ContentValue {
+    toHTMLString?: (opts: { preserveWhiteSpace: boolean }) => string;
+}
+
+interface CodeSaveAttributes {
+    readonly content: string | ContentValue;
+}
+
+interface CodeSaveProps {
+    readonly attributes: CodeSaveAttributes;
+}
+
+export default function CodeSave({ attributes }: CodeSaveProps): ReactElement {
+    return (
+        <pre {...useBlockProps.save()}>
+            <RichText.Content
+                tagName="code"
+                value={escape(
+                    typeof attributes.content === 'string'
+                        ? attributes.content
+                        : attributes.content.toHTMLString?.({
+                              preserveWhiteSpace: true,
+                          }) ?? ''
+                )}
+            />
+        </pre>
+    );
+}

--- a/resources/js/visual-editor/blocks/code/transforms.ts
+++ b/resources/js/visual-editor/blocks/code/transforms.ts
@@ -1,0 +1,95 @@
+/**
+ * Code — transforms.
+ *
+ * Ported from `@wordpress/block-library/src/code/transforms.js` (v9.43.0).
+ * Extended with bidirectional block transforms for `core/code` ↔
+ * `artisanpack/code`.
+ */
+
+import { createBlock } from '@wordpress/blocks';
+import { create, toHTMLString } from '@wordpress/rich-text';
+
+import metadata from './block.json';
+
+const { name } = metadata;
+
+interface CodeAttributes {
+    content?: string;
+    [key: string]: unknown;
+}
+
+interface RawTransformNode {
+    readonly nodeName: string;
+    readonly children: { readonly length: number };
+    readonly firstChild: { readonly nodeName: string };
+}
+
+const transforms = {
+    from: [
+        {
+            type: 'input',
+            regExp: /^```$/,
+            transform: () => createBlock(name),
+        },
+        {
+            type: 'block',
+            blocks: ['core/paragraph', 'artisanpack/paragraph'],
+            transform: (attributes: CodeAttributes) => {
+                const { content } = attributes;
+                return createBlock(name, { ...attributes, content });
+            },
+        },
+        {
+            type: 'block',
+            blocks: ['core/html'],
+            transform: (attributes: CodeAttributes) => {
+                const { content: text } = attributes;
+                return createBlock(name, {
+                    ...attributes,
+                    content: toHTMLString({ value: create({ text }) }),
+                });
+            },
+        },
+        {
+            type: 'raw',
+            isMatch: (node: RawTransformNode) =>
+                node.nodeName === 'PRE' &&
+                node.children.length === 1 &&
+                node.firstChild.nodeName === 'CODE',
+            schema: {
+                pre: {
+                    children: {
+                        code: {
+                            children: {
+                                '#text': {},
+                            },
+                        },
+                    },
+                },
+            },
+        },
+        {
+            type: 'block',
+            blocks: ['core/code'],
+            transform: (attributes: CodeAttributes) => createBlock(name, attributes),
+        },
+    ],
+    to: [
+        {
+            type: 'block',
+            blocks: ['core/paragraph'],
+            transform: (attributes: CodeAttributes) => {
+                const { content } = attributes;
+                return createBlock('core/paragraph', { ...attributes, content });
+            },
+        },
+        {
+            type: 'block',
+            blocks: ['core/code'],
+            transform: (attributes: CodeAttributes) =>
+                createBlock('core/code', attributes),
+        },
+    ],
+};
+
+export default transforms;

--- a/resources/js/visual-editor/blocks/code/upstream-diff-report.json
+++ b/resources/js/visual-editor/blocks/code/upstream-diff-report.json
@@ -28,7 +28,7 @@
             "status": "adapted",
             "notes": "TypeScript port; verbatim escape() handling.",
             "result": "skipped-status",
-            "forkDigest": "4bec7abce058"
+            "forkDigest": "40217da11be8"
         },
         {
             "fork": "deprecated.tsx",
@@ -60,7 +60,7 @@
             "status": "adapted",
             "notes": "Three SCSS files combined.",
             "result": "skipped-status",
-            "forkDigest": "607300b27afb"
+            "forkDigest": "01bb17e65907"
         },
         {
             "fork": "inserter-icon.tsx",

--- a/resources/js/visual-editor/blocks/code/upstream-diff-report.json
+++ b/resources/js/visual-editor/blocks/code/upstream-diff-report.json
@@ -1,0 +1,82 @@
+{
+    "block": "code",
+    "status": "in-sync",
+    "upstream": {
+        "pinnedVersion": "9.43.0",
+        "subpath": "code"
+    },
+    "files": [
+        {
+            "fork": "block.json",
+            "upstream": "block.json",
+            "status": "adapted",
+            "notes": "name + textdomain swapped.",
+            "result": "skipped-status",
+            "forkDigest": "71769a7d763e"
+        },
+        {
+            "fork": "edit.tsx",
+            "upstream": "edit.js",
+            "status": "adapted",
+            "notes": "TypeScript port.",
+            "result": "skipped-status",
+            "forkDigest": "9df372547e5f"
+        },
+        {
+            "fork": "save.tsx",
+            "upstream": "save.js",
+            "status": "adapted",
+            "notes": "TypeScript port; verbatim escape() handling.",
+            "result": "skipped-status",
+            "forkDigest": "4bec7abce058"
+        },
+        {
+            "fork": "deprecated.tsx",
+            "upstream": "n/a",
+            "status": "added",
+            "notes": "No upstream deprecation chain; empty array preserves the file shape across forks.",
+            "result": "skipped-status",
+            "forkDigest": "d72b88a6dc74"
+        },
+        {
+            "fork": "transforms.ts",
+            "upstream": "transforms.js",
+            "status": "extended",
+            "notes": "Upstream raw/input/block transforms preserved; added bidirectional core/code ↔ artisanpack/code + accepts artisanpack/paragraph.",
+            "result": "skipped-status",
+            "forkDigest": "e6f0a721ae1b"
+        },
+        {
+            "fork": "utils.ts",
+            "upstream": "utils.js",
+            "status": "adapted",
+            "notes": "TypeScript port; dropped @wordpress/compose `pipe` dependency in favor of direct composition.",
+            "result": "skipped-status",
+            "forkDigest": "becdd7541046"
+        },
+        {
+            "fork": "code.css",
+            "upstream": "style.scss + theme.scss + editor.scss",
+            "status": "adapted",
+            "notes": "Three SCSS files combined.",
+            "result": "skipped-status",
+            "forkDigest": "607300b27afb"
+        },
+        {
+            "fork": "inserter-icon.tsx",
+            "upstream": "n/a",
+            "status": "added",
+            "notes": "Inline SVG.",
+            "result": "skipped-status",
+            "forkDigest": "26509e754542"
+        },
+        {
+            "fork": "index.ts",
+            "upstream": "index.js",
+            "status": "rewritten",
+            "notes": "Adapted to the visual-editor auto-discovery contract.",
+            "result": "skipped-status",
+            "forkDigest": "b67345f8aad6"
+        }
+    ]
+}

--- a/resources/js/visual-editor/blocks/code/upstream-state.json
+++ b/resources/js/visual-editor/blocks/code/upstream-state.json
@@ -1,0 +1,39 @@
+{
+    "$schema": "../../../../scripts/upstream-state.schema.json",
+    "block": "artisanpack/code",
+    "upstream": {
+        "package": "@wordpress/block-library",
+        "namespace": "core/code",
+        "pinnedVersion": "9.43.0",
+        "subpath": "code"
+    },
+    "forkedAt": "2026-05-27",
+    "$statusLegend": {
+        "ported": "byte-equivalent to upstream (CI fails on drift)",
+        "adapted": "TypeScript port and/or namespace swap; logically equivalent",
+        "extended": "fork adds behavior on top of upstream",
+        "rewritten": "fork replaced upstream entirely",
+        "added": "file unique to the fork (no upstream)"
+    },
+    "files": [
+        { "fork": "block.json", "upstream": "block.json", "status": "adapted", "notes": "name + textdomain swapped." },
+        { "fork": "edit.tsx", "upstream": "edit.js", "status": "adapted", "notes": "TypeScript port." },
+        { "fork": "save.tsx", "upstream": "save.js", "status": "adapted", "notes": "TypeScript port; verbatim escape() handling." },
+        { "fork": "deprecated.tsx", "upstream": "n/a", "status": "added", "notes": "No upstream deprecation chain; empty array preserves the file shape across forks." },
+        { "fork": "transforms.ts", "upstream": "transforms.js", "status": "extended", "notes": "Upstream raw/input/block transforms preserved; added bidirectional core/code ↔ artisanpack/code + accepts artisanpack/paragraph." },
+        { "fork": "utils.ts", "upstream": "utils.js", "status": "adapted", "notes": "TypeScript port; dropped @wordpress/compose `pipe` dependency in favor of direct composition." },
+        { "fork": "code.css", "upstream": "style.scss + theme.scss + editor.scss", "status": "adapted", "notes": "Three SCSS files combined." },
+        { "fork": "inserter-icon.tsx", "upstream": "n/a", "status": "added", "notes": "Inline SVG." },
+        { "fork": "index.ts", "upstream": "index.js", "status": "rewritten", "notes": "Adapted to the visual-editor auto-discovery contract." }
+    ],
+    "vendoredPrimitives": [],
+    "knownDivergences": [
+        "utils.ts inlines the upstream `pipe` composition rather than depending on `@wordpress/compose.pipe`.",
+        "transforms.ts adds bidirectional block transforms with core/code."
+    ],
+    "triage": {
+        "label": "in-sync",
+        "lastReviewed": "2026-05-27",
+        "reviewer": "I1 content cluster"
+    }
+}

--- a/resources/js/visual-editor/blocks/code/utils.ts
+++ b/resources/js/visual-editor/blocks/code/utils.ts
@@ -1,0 +1,25 @@
+/**
+ * Code — escape helpers.
+ *
+ * Ported from `@wordpress/block-library/src/code/utils.js` (v9.43.0).
+ * Two transforms in series: escape opening square brackets so shortcodes
+ * don't execute on the PHP side, and rewrite isolated-URL protocol
+ * slashes so embeds don't auto-resolve.
+ */
+
+function escapeOpeningSquareBrackets(content: string): string {
+    return content.replace(/\[/g, '&#91;');
+}
+
+function escapeProtocolInIsolatedUrls(content: string): string {
+    return content.replace(
+        /^(\s*https?:)\/\/([^\s<>"]+\s*)$/m,
+        '$1&#47;&#47;$2'
+    );
+}
+
+export function escape(content: string): string {
+    return escapeProtocolInIsolatedUrls(
+        escapeOpeningSquareBrackets(content || '')
+    );
+}

--- a/resources/js/visual-editor/blocks/heading/__tests__/deprecated.test.tsx
+++ b/resources/js/visual-editor/blocks/heading/__tests__/deprecated.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * Locks the deprecation chain for `artisanpack/heading`.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+vi.mock('@wordpress/block-editor', () => ({
+    useBlockProps: Object.assign(
+        (props?: Record<string, unknown>) => ({ ...props }),
+        { save: (props?: Record<string, unknown>) => ({ ...props }) }
+    ),
+    RichText: Object.assign(() => null, {
+        Content: ({
+            value,
+            tagName,
+            ...rest
+        }: { value?: string; tagName?: string } & Record<string, unknown>) => {
+            const Tag = (tagName ?? 'h2') as keyof JSX.IntrinsicElements;
+            return value !== undefined ? (
+                <Tag {...rest} dangerouslySetInnerHTML={{ __html: value }} />
+            ) : null;
+        },
+    }),
+    getColorClassName: (prefix: string, slug?: string) =>
+        slug ? `has-${slug}-${prefix}` : undefined,
+}));
+
+import deprecated from '../deprecated';
+
+describe('heading deprecation chain', () => {
+    it('has 6 historical entries', () => {
+        expect(deprecated).toHaveLength(6);
+    });
+
+    it('every entry exposes a save callable', () => {
+        deprecated.forEach((entry, index) => {
+            expect(
+                typeof (entry as { save?: unknown }).save,
+                `entry ${index} save`
+            ).toBe('function');
+        });
+    });
+
+    it('every entry exposes attributes', () => {
+        deprecated.forEach((entry, index) => {
+            expect(
+                (entry as { attributes?: unknown }).attributes,
+                `entry ${index} attributes`
+            ).toBeTruthy();
+        });
+    });
+
+    it('v6 (entries[0]) renders the heading tag with has-text-align-* class', () => {
+        const entry = deprecated[0] as {
+            save: (props: { attributes: Record<string, unknown> }) => React.ReactElement;
+        };
+        const html = renderToStaticMarkup(
+            entry.save({
+                attributes: { textAlign: 'center', content: 'hi', level: 3 },
+            })
+        );
+        expect(html).toContain('<h3');
+        expect(html).toContain('has-text-align-center');
+        expect(html).toContain('hi');
+    });
+
+    it('v6 migrates textAlign into style.typography.textAlign', () => {
+        const entry = deprecated[0] as {
+            migrate: (attrs: Record<string, unknown>) => Record<string, unknown>;
+        };
+        const migrated = entry.migrate({
+            textAlign: 'center',
+            content: 'x',
+            level: 2,
+        });
+        expect(migrated.style).toEqual({
+            typography: { textAlign: 'center' },
+        });
+    });
+
+    it('v1 (entries[5]) renders RichText.Content with color classes', () => {
+        const entry = deprecated[5] as {
+            save: (props: { attributes: Record<string, unknown> }) => React.ReactElement;
+        };
+        const html = renderToStaticMarkup(
+            entry.save({
+                attributes: {
+                    align: 'right',
+                    content: 'body',
+                    level: 2,
+                    textColor: 'primary',
+                },
+            })
+        );
+        expect(html).toContain('has-primary-color');
+    });
+});

--- a/resources/js/visual-editor/blocks/heading/__tests__/edit.test.tsx
+++ b/resources/js/visual-editor/blocks/heading/__tests__/edit.test.tsx
@@ -1,0 +1,101 @@
+/**
+ * Tests for the `artisanpack/heading` edit component.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+vi.mock('@wordpress/i18n', () => ({
+    __: (text: string) => text,
+}));
+
+vi.mock('@wordpress/element', async () => {
+    const React = await import('react');
+    return {
+        useEffect: React.useEffect,
+        Platform: { isNative: false },
+    };
+});
+
+vi.mock('@wordpress/data', () => ({
+    useSelect: () => ({ canGenerateAnchors: false }),
+    useDispatch: () => ({
+        __unstableMarkNextChangeAsNotPersistent: vi.fn(),
+    }),
+}));
+
+vi.mock('@wordpress/block-editor', () => ({
+    useBlockProps: Object.assign(
+        (props?: Record<string, unknown>) => ({
+            ...props,
+            'data-testid': 'block-props',
+        }),
+        { save: (props?: Record<string, unknown>) => ({ ...props }) }
+    ),
+    RichText: Object.assign(
+        function RichText(props: {
+            value?: string;
+            className?: string;
+            onChange?: (value: string) => void;
+            placeholder?: string;
+            tagName?: string;
+        }) {
+            return (
+                <div
+                    role="textbox"
+                    aria-label="heading-rich-text"
+                    className={props.className}
+                    data-tag={props.tagName}
+                    data-placeholder={props.placeholder}
+                    onClick={() => props.onChange?.('changed')}
+                    dangerouslySetInnerHTML={{ __html: props.value ?? '' }}
+                />
+            );
+        },
+        { isEmpty: (v?: string) => !v || v.length === 0 }
+    ),
+    store: { name: 'core/block-editor' },
+}));
+
+import HeadingEdit from '../edit';
+
+describe('HeadingEdit', () => {
+    it('renders a RichText with the correct heading tagName', () => {
+        const setAttributes = vi.fn();
+        render(
+            <HeadingEdit
+                attributes={{ content: 'hi', level: 3 }}
+                setAttributes={setAttributes}
+                clientId="abc"
+            />
+        );
+        const textbox = screen.getByRole('textbox', { name: 'heading-rich-text' });
+        expect(textbox.getAttribute('data-tag')).toBe('h3');
+    });
+
+    it('uses the default placeholder when none is provided', () => {
+        const setAttributes = vi.fn();
+        render(
+            <HeadingEdit
+                attributes={{ content: '', level: 2 }}
+                setAttributes={setAttributes}
+                clientId="abc"
+            />
+        );
+        const textbox = screen.getByRole('textbox', { name: 'heading-rich-text' });
+        expect(textbox.getAttribute('data-placeholder')).toBe('Heading');
+    });
+
+    it('calls setAttributes when RichText fires onChange', () => {
+        const setAttributes = vi.fn();
+        render(
+            <HeadingEdit
+                attributes={{ content: 'hi', level: 2 }}
+                setAttributes={setAttributes}
+                clientId="abc"
+            />
+        );
+        fireEvent.click(screen.getByRole('textbox', { name: 'heading-rich-text' }));
+        expect(setAttributes).toHaveBeenCalledWith({ content: 'changed' });
+    });
+});

--- a/resources/js/visual-editor/blocks/heading/__tests__/edit.test.tsx
+++ b/resources/js/visual-editor/blocks/heading/__tests__/edit.test.tsx
@@ -98,4 +98,30 @@ describe('HeadingEdit', () => {
         fireEvent.click(screen.getByRole('textbox', { name: 'heading-rich-text' }));
         expect(setAttributes).toHaveBeenCalledWith({ content: 'changed' });
     });
+
+    it('clamps an out-of-range level (0) up to h1', () => {
+        const setAttributes = vi.fn();
+        render(
+            <HeadingEdit
+                attributes={{ content: 'hi', level: 0 }}
+                setAttributes={setAttributes}
+                clientId="abc"
+            />
+        );
+        const textbox = screen.getByRole('textbox', { name: 'heading-rich-text' });
+        expect(textbox.getAttribute('data-tag')).toBe('h1');
+    });
+
+    it('clamps an out-of-range level (7) down to h6', () => {
+        const setAttributes = vi.fn();
+        render(
+            <HeadingEdit
+                attributes={{ content: 'hi', level: 7 }}
+                setAttributes={setAttributes}
+                clientId="abc"
+            />
+        );
+        const textbox = screen.getByRole('textbox', { name: 'heading-rich-text' });
+        expect(textbox.getAttribute('data-tag')).toBe('h6');
+    });
 });

--- a/resources/js/visual-editor/blocks/heading/__tests__/save.test.tsx
+++ b/resources/js/visual-editor/blocks/heading/__tests__/save.test.tsx
@@ -1,0 +1,67 @@
+/**
+ * Tests for the `artisanpack/heading` save component.
+ *
+ * Save shape MUST stay byte-equivalent to upstream `core/heading`.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+vi.mock('@wordpress/block-editor', () => ({
+    useBlockProps: Object.assign(
+        (props?: Record<string, unknown>) => ({ ...props }),
+        { save: (props?: Record<string, unknown>) => ({ ...props }) }
+    ),
+    RichText: Object.assign(() => null, {
+        Content: ({ value }: { value?: string }) =>
+            value !== undefined && value !== ''
+                ? <span dangerouslySetInnerHTML={{ __html: value }} />
+                : null,
+    }),
+}));
+
+import HeadingSave from '../save';
+import metadata from '../block.json';
+
+describe('artisanpack/heading block.json', () => {
+    it('declares the artisanpack namespace and text category', () => {
+        expect(metadata.name).toBe('artisanpack/heading');
+        expect(metadata.category).toBe('text');
+    });
+
+    it('keeps the upstream content rich-text shape', () => {
+        expect(metadata.attributes.content.type).toBe('rich-text');
+        expect(metadata.attributes.content.source).toBe('rich-text');
+        expect(metadata.attributes.content.selector).toBe('h1,h2,h3,h4,h5,h6');
+    });
+
+    it('defaults level to 2', () => {
+        expect(metadata.attributes.level.default).toBe(2);
+    });
+});
+
+describe('HeadingSave', () => {
+    it('renders an h2 by default', () => {
+        const html = renderToStaticMarkup(
+            <HeadingSave attributes={{ content: 'Hello', level: 2 }} />
+        );
+        expect(html).toContain('<h2');
+        expect(html).toContain('Hello');
+    });
+
+    it('renders h1–h6 based on the level attribute', () => {
+        for (const level of [1, 2, 3, 4, 5, 6]) {
+            const html = renderToStaticMarkup(
+                <HeadingSave attributes={{ content: 'x', level }} />
+            );
+            expect(html).toContain(`<h${level}`);
+        }
+    });
+
+    it('renders empty content as a heading tag with no children', () => {
+        const html = renderToStaticMarkup(
+            <HeadingSave attributes={{ content: '', level: 3 }} />
+        );
+        expect(html).toMatch(/<h3[^>]*><\/h3>/);
+    });
+});

--- a/resources/js/visual-editor/blocks/heading/__tests__/transforms.test.ts
+++ b/resources/js/visual-editor/blocks/heading/__tests__/transforms.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Transforms tests for `artisanpack/heading`.
+ *
+ * Round-trip parity with `core/heading` is enforced.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@wordpress/blocks', () => ({
+    createBlock: (name: string, attributes: Record<string, unknown>) => ({
+        name,
+        attributes,
+        innerBlocks: [],
+    }),
+    getBlockAttributes: (_name: string, html: string) => ({
+        content: html.replace(/<[^>]*>/g, ''),
+    }),
+}));
+
+import transforms from '../transforms';
+
+describe('heading transforms', () => {
+    it('declares from/to arrays', () => {
+        expect(Array.isArray(transforms.from)).toBe(true);
+        expect(Array.isArray(transforms.to)).toBe(true);
+    });
+
+    it('includes a raw transform with the h1-h6 selector', () => {
+        const raw = transforms.from.find(
+            (t: { type: string }) => t.type === 'raw'
+        ) as { type: 'raw'; selector: string };
+        expect(raw).toBeDefined();
+        expect(raw.selector).toBe('h1,h2,h3,h4,h5,h6');
+    });
+
+    it('raw transform infers level from node name', () => {
+        const raw = transforms.from.find(
+            (t: { type: string }) => t.type === 'raw'
+        ) as {
+            type: 'raw';
+            transform: (node: {
+                outerHTML: string;
+                nodeName: string;
+                style?: { textAlign?: string };
+            }) => { name: string; attributes: Record<string, unknown> };
+        };
+        const result = raw.transform({
+            outerHTML: '<h3>Hi</h3>',
+            nodeName: 'H3',
+        });
+        expect(result.name).toBe('artisanpack/heading');
+        expect((result.attributes as { level?: number }).level).toBe(3);
+    });
+
+    it('includes six prefix transforms (one per heading level)', () => {
+        const prefixTransforms = transforms.from.filter(
+            (t: { type: string }) => t.type === 'prefix'
+        );
+        expect(prefixTransforms.length).toBe(6);
+    });
+
+    it('includes six enter transforms (/h1 through /h6)', () => {
+        const enterTransforms = transforms.from.filter(
+            (t: { type: string }) => t.type === 'enter'
+        );
+        expect(enterTransforms.length).toBe(6);
+    });
+
+    it('block transform converts core/heading → artisanpack/heading losslessly', () => {
+        const fromBlock = transforms.from.find(
+            (t: { type: string; blocks?: string[]; isMultiBlock?: boolean }) =>
+                t.type === 'block' &&
+                !t.isMultiBlock &&
+                t.blocks?.includes('core/heading')
+        ) as {
+            transform: (attrs: Record<string, unknown>) => {
+                name: string;
+                attributes: Record<string, unknown>;
+            };
+        };
+        const result = fromBlock.transform({ content: 'Hi', level: 4 });
+        expect(result.name).toBe('artisanpack/heading');
+        expect(result.attributes).toEqual({ content: 'Hi', level: 4 });
+    });
+
+    it('block transform converts artisanpack/heading → core/heading losslessly', () => {
+        const toBlock = transforms.to.find(
+            (t: { type: string; blocks?: string[]; isMultiBlock?: boolean }) =>
+                t.type === 'block' &&
+                !t.isMultiBlock &&
+                t.blocks?.includes('core/heading')
+        ) as {
+            transform: (attrs: Record<string, unknown>) => {
+                name: string;
+                attributes: Record<string, unknown>;
+            };
+        };
+        const result = toBlock.transform({ content: 'Hi', level: 4 });
+        expect(result.name).toBe('core/heading');
+        expect(result.attributes).toEqual({ content: 'Hi', level: 4 });
+    });
+});

--- a/resources/js/visual-editor/blocks/heading/autogenerate-anchors.ts
+++ b/resources/js/visual-editor/blocks/heading/autogenerate-anchors.ts
@@ -1,0 +1,47 @@
+/**
+ * Heading — anchor slug generator.
+ *
+ * Ported from `@wordpress/block-library/src/heading/autogenerate-anchors.js`
+ * (v9.43.0). Maintains the per-client anchor registry so duplicate slugs
+ * across multiple heading blocks get a `-1`, `-2`, … suffix.
+ */
+
+import removeAccents from 'remove-accents';
+
+const anchors: Record<string, string | null> = {};
+
+function getTextWithoutMarkup(text: string): string {
+    const dummyElement = document.createElement('div');
+    dummyElement.innerHTML = text;
+    return dummyElement.innerText;
+}
+
+function getSlug(content: string): string {
+    return removeAccents(getTextWithoutMarkup(content))
+        .replace(/[^\p{L}\p{N}]+/gu, '-')
+        .toLowerCase()
+        .replace(/(^-+)|(-+$)/g, '');
+}
+
+export function generateAnchor(clientId: string, content: string): string | null {
+    const slug = getSlug(content);
+    if (slug === '') {
+        return null;
+    }
+
+    delete anchors[clientId];
+
+    let anchor = slug;
+    let i = 0;
+
+    while (Object.values(anchors).includes(anchor)) {
+        i += 1;
+        anchor = `${slug}-${i}`;
+    }
+
+    return anchor;
+}
+
+export function setAnchor(clientId: string, anchor: string | null): void {
+    anchors[clientId] = anchor;
+}

--- a/resources/js/visual-editor/blocks/heading/block.json
+++ b/resources/js/visual-editor/blocks/heading/block.json
@@ -1,0 +1,79 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "artisanpack/heading",
+    "title": "Heading",
+    "category": "text",
+    "description": "Introduce new sections and organize content to help visitors (and search engines) understand the structure of your content.",
+    "keywords": [ "title", "subtitle" ],
+    "textdomain": "artisanpack-visual-editor",
+    "attributes": {
+        "content": {
+            "type": "rich-text",
+            "source": "rich-text",
+            "selector": "h1,h2,h3,h4,h5,h6",
+            "role": "content"
+        },
+        "level": {
+            "type": "number",
+            "default": 2
+        },
+        "levelOptions": {
+            "type": "array"
+        },
+        "placeholder": {
+            "type": "string"
+        }
+    },
+    "supports": {
+        "align": [ "wide", "full" ],
+        "anchor": true,
+        "className": true,
+        "splitting": true,
+        "__experimentalBorder": {
+            "color": true,
+            "radius": true,
+            "style": true,
+            "width": true
+        },
+        "color": {
+            "gradients": true,
+            "link": true,
+            "__experimentalDefaultControls": {
+                "background": true,
+                "text": true
+            }
+        },
+        "spacing": {
+            "margin": true,
+            "padding": true,
+            "__experimentalDefaultControls": {
+                "margin": false,
+                "padding": false
+            }
+        },
+        "typography": {
+            "fontSize": true,
+            "lineHeight": true,
+            "textAlign": true,
+            "__experimentalFontFamily": true,
+            "__experimentalFontStyle": true,
+            "__experimentalFontWeight": true,
+            "__experimentalLetterSpacing": true,
+            "__experimentalTextTransform": true,
+            "__experimentalTextDecoration": true,
+            "__experimentalWritingMode": true,
+            "fitText": true,
+            "__experimentalDefaultControls": {
+                "fontSize": true
+            }
+        },
+        "__unstablePasteTextInline": true,
+        "__experimentalSlashInserter": true,
+        "interactivity": {
+            "clientNavigation": true
+        }
+    },
+    "editorStyle": "wp-block-heading-editor",
+    "style": "wp-block-heading"
+}

--- a/resources/js/visual-editor/blocks/heading/deprecated.tsx
+++ b/resources/js/visual-editor/blocks/heading/deprecated.tsx
@@ -1,0 +1,372 @@
+/**
+ * Heading — deprecation chain.
+ *
+ * Full port of `@wordpress/block-library/src/heading/deprecated.js` (v9.43.0).
+ * Every historical save shape is preserved so saved markup from
+ * `core/heading` in old posts deserializes cleanly when opened against
+ * the editor that now registers `artisanpack/heading`.
+ */
+
+import clsx from 'clsx';
+import {
+    getColorClassName,
+    RichText,
+    useBlockProps,
+} from '@wordpress/block-editor';
+
+import migrateTextAlignAttributeToBlockSupport from '../_shared/migrate-text-align';
+
+const blockSupports = {
+    className: false,
+    anchor: true,
+};
+
+const blockAttributes = {
+    align: {
+        type: 'string',
+    },
+    content: {
+        type: 'string',
+        source: 'html',
+        selector: 'h1,h2,h3,h4,h5,h6',
+        default: '',
+    },
+    level: {
+        type: 'number',
+        default: 2,
+    },
+    placeholder: {
+        type: 'string',
+    },
+} as const;
+
+interface LegacyHeadingAttributes {
+    align?: string;
+    content?: string;
+    level?: number;
+    placeholder?: string;
+    textColor?: string;
+    customTextColor?: string;
+    textAlign?: string;
+    className?: string;
+    style?: Record<string, unknown>;
+    [key: string]: unknown;
+}
+
+const migrateCustomColors = (
+    attributes: LegacyHeadingAttributes
+): LegacyHeadingAttributes => {
+    if (!attributes.customTextColor) {
+        return attributes;
+    }
+    const style = {
+        color: {
+            text: attributes.customTextColor,
+        },
+    };
+
+    const { customTextColor, ...restAttributes } = attributes;
+
+    return {
+        ...restAttributes,
+        style,
+    };
+};
+
+const TEXT_ALIGN_OPTIONS = ['left', 'right', 'center'] as const;
+
+const migrateTextAlign = (
+    attributes: LegacyHeadingAttributes
+): LegacyHeadingAttributes => {
+    const { align, ...rest } = attributes;
+    return TEXT_ALIGN_OPTIONS.includes(align as 'left' | 'right' | 'center')
+        ? { ...rest, textAlign: align }
+        : attributes;
+};
+
+const v1 = {
+    supports: blockSupports,
+    attributes: {
+        ...blockAttributes,
+        customTextColor: { type: 'string' },
+        textColor: { type: 'string' },
+    },
+    migrate: (attributes: LegacyHeadingAttributes) =>
+        migrateTextAlignAttributeToBlockSupport(
+            migrateCustomColors(migrateTextAlign(attributes))
+        ),
+    save({ attributes }: { attributes: LegacyHeadingAttributes }) {
+        const { align, level = 2, content, textColor, customTextColor } = attributes;
+        const tagName = `h${level}` as 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+        const textClass = getColorClassName('color', textColor);
+
+        const className = clsx({
+            [textClass as string]: textClass,
+        });
+
+        return (
+            <RichText.Content
+                className={className ? className : undefined}
+                tagName={tagName}
+                style={{
+                    textAlign: align,
+                    color: textClass ? undefined : customTextColor,
+                }}
+                value={content}
+            />
+        );
+    },
+};
+
+const v2 = {
+    attributes: {
+        ...blockAttributes,
+        customTextColor: { type: 'string' },
+        textColor: { type: 'string' },
+    },
+    migrate: (attributes: LegacyHeadingAttributes) =>
+        migrateTextAlignAttributeToBlockSupport(
+            migrateCustomColors(migrateTextAlign(attributes))
+        ),
+    save({ attributes }: { attributes: LegacyHeadingAttributes }) {
+        const { align, content, customTextColor, level = 2, textColor } = attributes;
+        const tagName = `h${level}` as 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+        const textClass = getColorClassName('color', textColor);
+
+        const className = clsx({
+            [textClass as string]: textClass,
+            [`has-text-align-${align}`]: align,
+        });
+
+        return (
+            <RichText.Content
+                className={className ? className : undefined}
+                tagName={tagName}
+                style={{
+                    color: textClass ? undefined : customTextColor,
+                }}
+                value={content}
+            />
+        );
+    },
+    supports: blockSupports,
+};
+
+const v3 = {
+    supports: blockSupports,
+    attributes: {
+        ...blockAttributes,
+        customTextColor: { type: 'string' },
+        textColor: { type: 'string' },
+    },
+    migrate: (attributes: LegacyHeadingAttributes) =>
+        migrateTextAlignAttributeToBlockSupport(
+            migrateCustomColors(migrateTextAlign(attributes))
+        ),
+    save({ attributes }: { attributes: LegacyHeadingAttributes }) {
+        const { align, content, customTextColor, level = 2, textColor } = attributes;
+        const tagName = `h${level}` as 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+        const textClass = getColorClassName('color', textColor);
+
+        const className = clsx({
+            [textClass as string]: textClass,
+            'has-text-color': textColor || customTextColor,
+            [`has-text-align-${align}`]: align,
+        });
+
+        return (
+            <RichText.Content
+                className={className ? className : undefined}
+                tagName={tagName}
+                style={{
+                    color: textClass ? undefined : customTextColor,
+                }}
+                value={content}
+            />
+        );
+    },
+};
+
+const v4 = {
+    supports: {
+        align: ['wide', 'full'],
+        anchor: true,
+        className: false,
+        color: { link: true },
+        fontSize: true,
+        lineHeight: true,
+        __experimentalSelector: {
+            'core/heading/h1': 'h1',
+            'core/heading/h2': 'h2',
+            'core/heading/h3': 'h3',
+            'core/heading/h4': 'h4',
+            'core/heading/h5': 'h5',
+            'core/heading/h6': 'h6',
+        },
+        __unstablePasteTextInline: true,
+    },
+    attributes: blockAttributes,
+    isEligible: ({ align }: LegacyHeadingAttributes) =>
+        TEXT_ALIGN_OPTIONS.includes(align as 'left' | 'right' | 'center'),
+    migrate: (attributes: LegacyHeadingAttributes) =>
+        migrateTextAlignAttributeToBlockSupport(
+            migrateCustomColors(migrateTextAlign(attributes))
+        ),
+    save({ attributes }: { attributes: LegacyHeadingAttributes }) {
+        const { align, content, level = 2 } = attributes;
+        const TagName = `h${level}` as 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+
+        const className = clsx({
+            [`has-text-align-${align}`]: align,
+        });
+
+        return (
+            <TagName {...useBlockProps.save({ className })}>
+                <RichText.Content value={content} />
+            </TagName>
+        );
+    },
+};
+
+const v5 = {
+    supports: {
+        align: ['wide', 'full'],
+        anchor: true,
+        className: false,
+        color: {
+            gradients: true,
+            link: true,
+            __experimentalDefaultControls: { background: true, text: true },
+        },
+        spacing: {
+            margin: true,
+            padding: true,
+        },
+        typography: {
+            fontSize: true,
+            lineHeight: true,
+            __experimentalFontFamily: true,
+            __experimentalFontStyle: true,
+            __experimentalFontWeight: true,
+            __experimentalLetterSpacing: true,
+            __experimentalTextTransform: true,
+            __experimentalTextDecoration: true,
+            __experimentalDefaultControls: {
+                fontSize: true,
+                fontAppearance: true,
+                textTransform: true,
+            },
+        },
+        __experimentalSelector: 'h1,h2,h3,h4,h5,h6',
+        __unstablePasteTextInline: true,
+        __experimentalSlashInserter: true,
+    },
+    attributes: {
+        textAlign: { type: 'string' },
+        content: {
+            type: 'string',
+            source: 'html',
+            selector: 'h1,h2,h3,h4,h5,h6',
+            default: '',
+            role: 'content',
+        },
+        level: { type: 'number', default: 2 },
+        placeholder: { type: 'string' },
+    },
+    save({ attributes }: { attributes: LegacyHeadingAttributes }) {
+        const { textAlign, content, level = 2 } = attributes;
+        const TagName = `h${level}` as 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+
+        const className = clsx({
+            [`has-text-align-${textAlign}`]: textAlign,
+        });
+
+        return (
+            <TagName {...useBlockProps.save({ className })}>
+                <RichText.Content value={content} />
+            </TagName>
+        );
+    },
+    migrate: (attributes: LegacyHeadingAttributes) =>
+        migrateTextAlignAttributeToBlockSupport(
+            migrateCustomColors(migrateTextAlign(attributes))
+        ),
+};
+
+const v6 = {
+    supports: {
+        align: ['wide', 'full'],
+        anchor: true,
+        className: true,
+        splitting: true,
+        __experimentalBorder: {
+            color: true,
+            radius: true,
+            style: true,
+            width: true,
+        },
+        color: {
+            gradients: true,
+            link: true,
+            __experimentalDefaultControls: { background: true, text: true },
+        },
+        spacing: { margin: true, padding: true },
+        typography: {
+            fontSize: true,
+            lineHeight: true,
+            __experimentalFontFamily: true,
+            __experimentalFontStyle: true,
+            __experimentalFontWeight: true,
+            __experimentalLetterSpacing: true,
+            __experimentalTextTransform: true,
+            __experimentalTextDecoration: true,
+            __experimentalWritingMode: true,
+            fitText: true,
+            __experimentalDefaultControls: { fontSize: true },
+        },
+        __unstablePasteTextInline: true,
+        __experimentalSlashInserter: true,
+        interactivity: { clientNavigation: true },
+    },
+    attributes: {
+        textAlign: { type: 'string' },
+        content: {
+            type: 'string',
+            source: 'html',
+            selector: 'h1,h2,h3,h4,h5,h6',
+            default: '',
+            role: 'content',
+        },
+        level: { type: 'number', default: 2 },
+        levelOptions: { type: 'array' },
+        placeholder: { type: 'string' },
+    },
+    save({ attributes }: { attributes: LegacyHeadingAttributes }) {
+        const { textAlign, content, level = 2 } = attributes;
+        const TagName = `h${level}` as 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+
+        const className = clsx({
+            [`has-text-align-${textAlign}`]: textAlign,
+        });
+
+        return (
+            <TagName {...useBlockProps.save({ className })}>
+                <RichText.Content value={content} />
+            </TagName>
+        );
+    },
+    migrate: (attributes: LegacyHeadingAttributes) =>
+        migrateTextAlignAttributeToBlockSupport(
+            migrateCustomColors(migrateTextAlign(attributes))
+        ),
+    isEligible(attributes: LegacyHeadingAttributes) {
+        return (
+            !!attributes.textAlign ||
+            !!attributes.className?.match(/\bhas-text-align-(left|center|right)\b/)
+        );
+    },
+};
+
+const deprecated = [v6, v5, v4, v3, v2, v1];
+
+export default deprecated;

--- a/resources/js/visual-editor/blocks/heading/edit.tsx
+++ b/resources/js/visual-editor/blocks/heading/edit.tsx
@@ -1,0 +1,117 @@
+/**
+ * Heading — editor-side render.
+ *
+ * Ported from `@wordpress/block-library/src/heading/edit.js` (v9.43.0).
+ * Behaviour parity: anchor auto-generation tied to the table-of-contents
+ * setting, content/anchor side-effect, identical RichText wiring.
+ */
+
+import type { ReactElement } from 'react';
+import { __ } from '@wordpress/i18n';
+import { useEffect } from '@wordpress/element';
+import { useDispatch, useSelect } from '@wordpress/data';
+import {
+    RichText,
+    useBlockProps,
+    store as blockEditorStore,
+} from '@wordpress/block-editor';
+
+import { generateAnchor, setAnchor } from './autogenerate-anchors';
+
+interface HeadingAttributes {
+    readonly content: string;
+    readonly level: number;
+    readonly placeholder?: string;
+    readonly anchor?: string;
+}
+
+interface HeadingEditProps {
+    readonly attributes: HeadingAttributes;
+    readonly setAttributes: (next: Partial<HeadingAttributes>) => void;
+    readonly mergeBlocks?: (forward?: boolean) => void;
+    readonly onReplace?: (blocks: unknown[]) => void;
+    readonly clientId: string;
+    readonly style?: Record<string, unknown>;
+}
+
+interface BlockEditorSelect {
+    getGlobalBlockCount: (blockName?: string) => number;
+    getSettings: () => Record<string, unknown> & { generateAnchors?: boolean };
+}
+
+// Clamp the level attribute to a valid heading range. Mirrors `save.tsx`
+// so the editor canvas and the saved markup agree on the tag for any
+// out-of-range legacy attribute (level=0, level=7, …).
+function clampHeadingLevel(level: number | undefined): 1 | 2 | 3 | 4 | 5 | 6 {
+    const numeric = Number(level);
+    if (!Number.isFinite(numeric)) {
+        return 2;
+    }
+    return Math.max(1, Math.min(6, Math.trunc(numeric))) as 1 | 2 | 3 | 4 | 5 | 6;
+}
+
+export default function HeadingEdit(props: HeadingEditProps): ReactElement {
+    const { attributes, setAttributes, mergeBlocks, onReplace, style, clientId } = props;
+    const { content, level, placeholder, anchor } = attributes;
+    const safeLevel = clampHeadingLevel(level);
+    const tagName = `h${safeLevel}` as 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+    const blockProps = useBlockProps({ style });
+
+    const { canGenerateAnchors } = useSelect((select) => {
+        const store = select(blockEditorStore) as unknown as BlockEditorSelect;
+        const settings = store.getSettings();
+        return {
+            canGenerateAnchors:
+                !!settings.generateAnchors ||
+                store.getGlobalBlockCount('core/table-of-contents') > 0,
+        };
+    }, []) as { canGenerateAnchors: boolean };
+
+    const dispatchStore = useDispatch(blockEditorStore) as unknown as {
+        __unstableMarkNextChangeAsNotPersistent: () => void;
+    };
+    const { __unstableMarkNextChangeAsNotPersistent } = dispatchStore;
+
+    useEffect(() => {
+        if (!canGenerateAnchors) {
+            return;
+        }
+
+        if (!anchor && content) {
+            __unstableMarkNextChangeAsNotPersistent();
+            setAttributes({
+                anchor: generateAnchor(clientId, content) ?? undefined,
+            });
+        }
+        setAnchor(clientId, anchor ?? null);
+
+        return () => setAnchor(clientId, null);
+    }, [anchor, content, clientId, canGenerateAnchors]);
+
+    const onContentChange = (value: string): void => {
+        const newAttrs: Partial<HeadingAttributes> = { content: value };
+        if (
+            canGenerateAnchors &&
+            (!anchor ||
+                !value ||
+                generateAnchor(clientId, content) === anchor)
+        ) {
+            newAttrs.anchor = generateAnchor(clientId, value) ?? undefined;
+        }
+        setAttributes(newAttrs);
+    };
+
+    return (
+        <RichText
+            identifier="content"
+            tagName={tagName}
+            value={content}
+            onChange={onContentChange}
+            onMerge={mergeBlocks}
+            onReplace={onReplace}
+            onRemove={() => onReplace?.([])}
+            placeholder={placeholder || __('Heading')}
+            {...blockProps}
+        />
+    );
+}

--- a/resources/js/visual-editor/blocks/heading/heading.css
+++ b/resources/js/visual-editor/blocks/heading/heading.css
@@ -1,0 +1,32 @@
+/*
+ * Heading — frontend styles.
+ *
+ * Ported from `@wordpress/block-library/src/heading/style.scss` (v9.43.0).
+ * Sass variables resolved inline ($block-bg-padding--v → 1.25em, --h → 2.375em)
+ * so the package's CSS-only vite pipeline doesn't need a Sass toolchain.
+ * No upstream editor.scss — heading is frontend-only styles.
+ */
+
+h1:where(.wp-block-heading).has-background,
+h2:where(.wp-block-heading).has-background,
+h3:where(.wp-block-heading).has-background,
+h4:where(.wp-block-heading).has-background,
+h5:where(.wp-block-heading).has-background,
+h6:where(.wp-block-heading).has-background {
+    padding: 1.25em 2.375em;
+}
+
+h1.has-text-align-right[style*='writing-mode']:where([style*='vertical-rl']),
+h1.has-text-align-left[style*='writing-mode']:where([style*='vertical-lr']),
+h2.has-text-align-right[style*='writing-mode']:where([style*='vertical-rl']),
+h2.has-text-align-left[style*='writing-mode']:where([style*='vertical-lr']),
+h3.has-text-align-right[style*='writing-mode']:where([style*='vertical-rl']),
+h3.has-text-align-left[style*='writing-mode']:where([style*='vertical-lr']),
+h4.has-text-align-right[style*='writing-mode']:where([style*='vertical-rl']),
+h4.has-text-align-left[style*='writing-mode']:where([style*='vertical-lr']),
+h5.has-text-align-right[style*='writing-mode']:where([style*='vertical-rl']),
+h5.has-text-align-left[style*='writing-mode']:where([style*='vertical-lr']),
+h6.has-text-align-right[style*='writing-mode']:where([style*='vertical-rl']),
+h6.has-text-align-left[style*='writing-mode']:where([style*='vertical-lr']) {
+    rotate: 180deg;
+}

--- a/resources/js/visual-editor/blocks/heading/index.ts
+++ b/resources/js/visual-editor/blocks/heading/index.ts
@@ -1,0 +1,31 @@
+/**
+ * Heading block entrypoint.
+ *
+ * Re-exports `edit`, `save`, `metadata`, `deprecated`, `transforms`, and
+ * `icon` so the host JS bundle (via the custom-block auto-discovery glob —
+ * see `../../editor/custom-blocks.ts`) can register the block with
+ * `@wordpress/blocks.registerBlockType`.
+ *
+ * Fork target: V2 block-fork phase I1 (content cluster, issue #409).
+ */
+
+import metadata from './block.json';
+import edit from './edit';
+import save from './save';
+import deprecated from './deprecated';
+import transforms from './transforms';
+import icon from './inserter-icon';
+
+import './heading.css';
+
+export { edit, save, metadata, icon, deprecated, transforms };
+
+export default {
+    name: metadata.name,
+    metadata,
+    edit,
+    save,
+    icon,
+    deprecated,
+    transforms,
+};

--- a/resources/js/visual-editor/blocks/heading/inserter-icon.tsx
+++ b/resources/js/visual-editor/blocks/heading/inserter-icon.tsx
@@ -1,0 +1,21 @@
+/**
+ * Heading — inserter icon.
+ *
+ * Inline SVG (matches Gutenberg's `heading` icon from `@wordpress/icons`).
+ */
+
+import type { ReactElement } from 'react';
+
+export default function HeadingInserterIcon(): ReactElement {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            width={24}
+            height={24}
+            aria-hidden="true"
+        >
+            <path d="M6.2 5.2v13.4l5.8-4.8 5.8 4.8V5.2z" />
+        </svg>
+    );
+}

--- a/resources/js/visual-editor/blocks/heading/save.tsx
+++ b/resources/js/visual-editor/blocks/heading/save.tsx
@@ -1,0 +1,43 @@
+/**
+ * Heading — saved markup.
+ *
+ * Ported from `@wordpress/block-library/src/heading/save.js` (v9.43.0).
+ * Output is byte-equivalent to upstream so documents authored against
+ * `core/heading` round-trip losslessly through the `core/heading` ↔
+ * `artisanpack/heading` transforms.
+ */
+
+import type { ReactElement } from 'react';
+import { RichText, useBlockProps } from '@wordpress/block-editor';
+
+interface HeadingSaveAttributes {
+    readonly content: string;
+    readonly level: number;
+}
+
+interface HeadingSaveProps {
+    readonly attributes: HeadingSaveAttributes;
+}
+
+// Clamp the level attribute to a valid heading range before constructing
+// the tag — guards against malformed legacy attributes (level=0, level=7)
+// that would otherwise produce invalid `<h0>` / `<h7>` markup.
+function clampHeadingLevel(level: number | undefined): 1 | 2 | 3 | 4 | 5 | 6 {
+    const numeric = Number(level);
+    if (!Number.isFinite(numeric)) {
+        return 2;
+    }
+    return Math.max(1, Math.min(6, Math.trunc(numeric))) as 1 | 2 | 3 | 4 | 5 | 6;
+}
+
+export default function HeadingSave({ attributes }: HeadingSaveProps): ReactElement {
+    const { content, level } = attributes;
+    const safeLevel = clampHeadingLevel(level);
+    const TagName = `h${safeLevel}` as 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+
+    return (
+        <TagName {...useBlockProps.save()}>
+            <RichText.Content value={content} />
+        </TagName>
+    );
+}

--- a/resources/js/visual-editor/blocks/heading/transforms.ts
+++ b/resources/js/visual-editor/blocks/heading/transforms.ts
@@ -1,0 +1,161 @@
+/**
+ * Heading — transforms.
+ *
+ * Ported from `@wordpress/block-library/src/heading/transforms.js`
+ * (v9.43.0). Extended with bidirectional block transforms for
+ * `core/heading` ↔ `artisanpack/heading` so mixed documents round-trip
+ * losslessly during the V2 rollout. The upstream `core/paragraph`
+ * transforms are namespaced to `artisanpack/paragraph` since this fork
+ * lives in the same package and the renderers map both blocks to the
+ * same component.
+ */
+
+import { createBlock, getBlockAttributes } from '@wordpress/blocks';
+
+import metadata from './block.json';
+
+const { name } = metadata;
+
+interface HeadingAttributes {
+    content?: string;
+    level?: number;
+    anchor?: string;
+    placeholder?: string;
+    style?: {
+        typography?: {
+            textAlign?: string;
+        } & Record<string, unknown>;
+    };
+    [key: string]: unknown;
+}
+
+interface RawTransformContext {
+    readonly phrasingContentSchema: unknown;
+    readonly isPaste: boolean;
+}
+
+interface DOMNodeLike {
+    readonly outerHTML: string;
+    readonly nodeName: string;
+    readonly style?: { readonly textAlign?: string };
+}
+
+function getLevelFromHeadingNodeName(nodeName: string): number {
+    return Number(nodeName.substring(1));
+}
+
+const transforms = {
+    from: [
+        {
+            type: 'block',
+            isMultiBlock: true,
+            blocks: ['core/paragraph', 'artisanpack/paragraph'],
+            transform: (attributes: HeadingAttributes[]) =>
+                attributes.map((_attributes) => {
+                    const { content, anchor, style } = _attributes;
+                    const textAlign = style?.typography?.textAlign;
+                    return createBlock(name, {
+                        content,
+                        anchor,
+                        ...(textAlign && {
+                            style: {
+                                typography: {
+                                    textAlign,
+                                },
+                            },
+                        }),
+                    });
+                }),
+        },
+        {
+            type: 'raw',
+            selector: 'h1,h2,h3,h4,h5,h6',
+            schema: ({ phrasingContentSchema, isPaste }: RawTransformContext) => {
+                const schema = {
+                    children: phrasingContentSchema,
+                    attributes: isPaste ? [] : ['style', 'id'],
+                };
+                return {
+                    h1: schema,
+                    h2: schema,
+                    h3: schema,
+                    h4: schema,
+                    h5: schema,
+                    h6: schema,
+                };
+            },
+            transform(node: DOMNodeLike) {
+                const attributes = getBlockAttributes(
+                    name,
+                    node.outerHTML
+                ) as HeadingAttributes;
+                const { textAlign } = node.style || {};
+
+                attributes.level = getLevelFromHeadingNodeName(node.nodeName);
+
+                if (
+                    textAlign === 'left' ||
+                    textAlign === 'center' ||
+                    textAlign === 'right'
+                ) {
+                    attributes.style = {
+                        ...attributes.style,
+                        typography: {
+                            ...attributes.style?.typography,
+                            textAlign,
+                        },
+                    };
+                }
+
+                return createBlock(name, attributes);
+            },
+        },
+        ...[1, 2, 3, 4, 5, 6].map((level) => ({
+            type: 'prefix',
+            prefix: Array(level + 1).join('#'),
+            transform(content: string) {
+                return createBlock(name, { level, content });
+            },
+        })),
+        ...[1, 2, 3, 4, 5, 6].map((level) => ({
+            type: 'enter',
+            regExp: new RegExp(`^/(h|H)${level}$`),
+            transform: () => createBlock(name, { level }),
+        })),
+        {
+            type: 'block',
+            blocks: ['core/heading'],
+            transform: (attributes: HeadingAttributes) => createBlock(name, attributes),
+        },
+    ],
+    to: [
+        {
+            type: 'block',
+            isMultiBlock: true,
+            blocks: ['core/paragraph'],
+            transform: (attributes: HeadingAttributes[]) =>
+                attributes.map((_attributes) => {
+                    const { content, style } = _attributes;
+                    const textAlign = style?.typography?.textAlign;
+                    return createBlock('core/paragraph', {
+                        content,
+                        ...(textAlign && {
+                            style: {
+                                typography: {
+                                    textAlign,
+                                },
+                            },
+                        }),
+                    });
+                }),
+        },
+        {
+            type: 'block',
+            blocks: ['core/heading'],
+            transform: (attributes: HeadingAttributes) =>
+                createBlock('core/heading', attributes),
+        },
+    ],
+};
+
+export default transforms;

--- a/resources/js/visual-editor/blocks/heading/upstream-diff-report.json
+++ b/resources/js/visual-editor/blocks/heading/upstream-diff-report.json
@@ -1,0 +1,82 @@
+{
+    "block": "heading",
+    "status": "in-sync",
+    "upstream": {
+        "pinnedVersion": "9.43.0",
+        "subpath": "heading"
+    },
+    "files": [
+        {
+            "fork": "block.json",
+            "upstream": "block.json",
+            "status": "adapted",
+            "notes": "name + textdomain swapped to artisanpack namespace; supports/attributes verbatim.",
+            "result": "skipped-status",
+            "forkDigest": "00e94bf238de"
+        },
+        {
+            "fork": "edit.tsx",
+            "upstream": "edit.js",
+            "status": "adapted",
+            "notes": "TypeScript port; upstream `useDeprecatedTextAlign` hook is replaced by the inline migrate-text-align deprecation path so the heading edit doesn't reach into block-library private utilities.",
+            "result": "skipped-status",
+            "forkDigest": "5494744dc230"
+        },
+        {
+            "fork": "save.tsx",
+            "upstream": "save.js",
+            "status": "adapted",
+            "notes": "TypeScript port; verbatim semantics.",
+            "result": "skipped-status",
+            "forkDigest": "bd1a88dfd5b1"
+        },
+        {
+            "fork": "deprecated.tsx",
+            "upstream": "deprecated.js",
+            "status": "adapted",
+            "notes": "Full 6-entry chain ported verbatim (v6 → v1). Imports the shared migrate-text-align primitive from blocks/_shared/.",
+            "result": "skipped-status",
+            "forkDigest": "12ce02d62709"
+        },
+        {
+            "fork": "transforms.ts",
+            "upstream": "transforms.js",
+            "status": "extended",
+            "notes": "Upstream raw/prefix/enter transforms preserved (namespaced to artisanpack/heading); added bidirectional block transforms for core/heading ↔ artisanpack/heading and accepts artisanpack/paragraph as a from-source.",
+            "result": "skipped-status",
+            "forkDigest": "2519507b7789"
+        },
+        {
+            "fork": "autogenerate-anchors.ts",
+            "upstream": "autogenerate-anchors.js",
+            "status": "adapted",
+            "notes": "TypeScript port; behavior unchanged.",
+            "result": "skipped-status",
+            "forkDigest": "030b7dc4a62d"
+        },
+        {
+            "fork": "heading.css",
+            "upstream": "style.scss",
+            "status": "adapted",
+            "notes": "Sass variables resolved inline ($block-bg-padding--v → 1.25em, --h → 2.375em).",
+            "result": "skipped-status",
+            "forkDigest": "bb7474a4f53f"
+        },
+        {
+            "fork": "inserter-icon.tsx",
+            "upstream": "n/a",
+            "status": "added",
+            "notes": "Inline SVG for the inserter (editor doesn't bundle dashicons).",
+            "result": "skipped-status",
+            "forkDigest": "9642479e4ff2"
+        },
+        {
+            "fork": "index.ts",
+            "upstream": "index.js",
+            "status": "rewritten",
+            "notes": "Adapted to the visual-editor auto-discovery contract (custom-blocks.ts glob). Upstream index.js wires `init` and PHP server-side init; we don't need either.",
+            "result": "skipped-status",
+            "forkDigest": "5a52c3c95b4e"
+        }
+    ]
+}

--- a/resources/js/visual-editor/blocks/heading/upstream-diff-report.json
+++ b/resources/js/visual-editor/blocks/heading/upstream-diff-report.json
@@ -20,7 +20,7 @@
             "status": "adapted",
             "notes": "TypeScript port; upstream `useDeprecatedTextAlign` hook is replaced by the inline migrate-text-align deprecation path so the heading edit doesn't reach into block-library private utilities.",
             "result": "skipped-status",
-            "forkDigest": "5494744dc230"
+            "forkDigest": "b474675f0a2c"
         },
         {
             "fork": "save.tsx",
@@ -28,7 +28,7 @@
             "status": "adapted",
             "notes": "TypeScript port; verbatim semantics.",
             "result": "skipped-status",
-            "forkDigest": "bd1a88dfd5b1"
+            "forkDigest": "0fd6c1d1fe60"
         },
         {
             "fork": "deprecated.tsx",

--- a/resources/js/visual-editor/blocks/heading/upstream-state.json
+++ b/resources/js/visual-editor/blocks/heading/upstream-state.json
@@ -1,0 +1,41 @@
+{
+    "$schema": "../../../../scripts/upstream-state.schema.json",
+    "block": "artisanpack/heading",
+    "upstream": {
+        "package": "@wordpress/block-library",
+        "namespace": "core/heading",
+        "pinnedVersion": "9.43.0",
+        "subpath": "heading"
+    },
+    "forkedAt": "2026-05-27",
+    "$statusLegend": {
+        "ported": "byte-equivalent to upstream (CI fails on drift)",
+        "adapted": "TypeScript port and/or namespace swap; logically equivalent",
+        "extended": "fork adds behavior on top of upstream",
+        "rewritten": "fork replaced upstream entirely",
+        "added": "file unique to the fork (no upstream)"
+    },
+    "files": [
+        { "fork": "block.json", "upstream": "block.json", "status": "adapted", "notes": "name + textdomain swapped to artisanpack namespace; supports/attributes verbatim." },
+        { "fork": "edit.tsx", "upstream": "edit.js", "status": "adapted", "notes": "TypeScript port; upstream `useDeprecatedTextAlign` hook is replaced by the inline migrate-text-align deprecation path so the heading edit doesn't reach into block-library private utilities." },
+        { "fork": "save.tsx", "upstream": "save.js", "status": "adapted", "notes": "TypeScript port; verbatim semantics." },
+        { "fork": "deprecated.tsx", "upstream": "deprecated.js", "status": "adapted", "notes": "Full 6-entry chain ported verbatim (v6 → v1). Imports the shared migrate-text-align primitive from blocks/_shared/." },
+        { "fork": "transforms.ts", "upstream": "transforms.js", "status": "extended", "notes": "Upstream raw/prefix/enter transforms preserved (namespaced to artisanpack/heading); added bidirectional block transforms for core/heading ↔ artisanpack/heading and accepts artisanpack/paragraph as a from-source." },
+        { "fork": "autogenerate-anchors.ts", "upstream": "autogenerate-anchors.js", "status": "adapted", "notes": "TypeScript port; behavior unchanged." },
+        { "fork": "heading.css", "upstream": "style.scss", "status": "adapted", "notes": "Sass variables resolved inline ($block-bg-padding--v → 1.25em, --h → 2.375em)." },
+        { "fork": "inserter-icon.tsx", "upstream": "n/a", "status": "added", "notes": "Inline SVG for the inserter (editor doesn't bundle dashicons)." },
+        { "fork": "index.ts", "upstream": "index.js", "status": "rewritten", "notes": "Adapted to the visual-editor auto-discovery contract (custom-blocks.ts glob). Upstream index.js wires `init` and PHP server-side init; we don't need either." }
+    ],
+    "vendoredPrimitives": [
+        "_shared/migrate-text-align.ts"
+    ],
+    "knownDivergences": [
+        "transforms.ts adds bidirectional block transforms with core/heading and accepts artisanpack/paragraph as a paragraph source.",
+        "edit.tsx omits the upstream `useDeprecatedTextAlign` hook; the deprecation chain handles the legacy `align` attribute migration on load."
+    ],
+    "triage": {
+        "label": "in-sync",
+        "lastReviewed": "2026-05-27",
+        "reviewer": "I1 content cluster"
+    }
+}

--- a/resources/js/visual-editor/blocks/list-item/__tests__/deprecated.test.tsx
+++ b/resources/js/visual-editor/blocks/list-item/__tests__/deprecated.test.tsx
@@ -1,0 +1,14 @@
+/**
+ * Locks the (empty) deprecation chain for `artisanpack/list-item`.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import deprecated from '../deprecated';
+
+describe('list-item deprecation chain', () => {
+    it('matches upstream (empty)', () => {
+        expect(Array.isArray(deprecated)).toBe(true);
+        expect(deprecated).toHaveLength(0);
+    });
+});

--- a/resources/js/visual-editor/blocks/list-item/__tests__/edit.test.tsx
+++ b/resources/js/visual-editor/blocks/list-item/__tests__/edit.test.tsx
@@ -1,0 +1,62 @@
+/**
+ * Tests for the `artisanpack/list-item` edit component.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+vi.mock('@wordpress/block-editor', () => ({
+    useBlockProps: Object.assign(
+        (props?: Record<string, unknown>) => ({ ...props }),
+        { save: (props?: Record<string, unknown>) => ({ ...props }) }
+    ),
+    useInnerBlocksProps: (props?: Record<string, unknown>) => ({
+        ...props,
+        children: <div data-testid="inner-blocks" />,
+    }),
+    RichText: function RichText(props: {
+        value?: string;
+        onChange?: (v: string) => void;
+        placeholder?: string;
+    }) {
+        return (
+            <div
+                role="textbox"
+                aria-label="list-item-rich-text"
+                data-placeholder={props.placeholder}
+                onClick={() => props.onChange?.('changed')}
+                dangerouslySetInnerHTML={{ __html: props.value ?? '' }}
+            />
+        );
+    },
+}));
+
+import ListItemEdit from '../edit';
+
+describe('ListItemEdit', () => {
+    it('renders a RichText with the default List placeholder', () => {
+        const setAttributes = vi.fn();
+        render(
+            <ListItemEdit
+                attributes={{ content: '' }}
+                setAttributes={setAttributes}
+            />
+        );
+        const textbox = screen.getByRole('textbox', { name: 'list-item-rich-text' });
+        expect(textbox.getAttribute('data-placeholder')).toBe('List');
+    });
+
+    it('forwards onChange to setAttributes', () => {
+        const setAttributes = vi.fn();
+        render(
+            <ListItemEdit
+                attributes={{ content: '' }}
+                setAttributes={setAttributes}
+            />
+        );
+        fireEvent.click(
+            screen.getByRole('textbox', { name: 'list-item-rich-text' })
+        );
+        expect(setAttributes).toHaveBeenCalledWith({ content: 'changed' });
+    });
+});

--- a/resources/js/visual-editor/blocks/list-item/__tests__/save.test.tsx
+++ b/resources/js/visual-editor/blocks/list-item/__tests__/save.test.tsx
@@ -1,0 +1,45 @@
+/**
+ * Tests for the `artisanpack/list-item` save component.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+vi.mock('@wordpress/block-editor', () => ({
+    useBlockProps: Object.assign(
+        (props?: Record<string, unknown>) => ({ ...props }),
+        { save: (props?: Record<string, unknown>) => ({ ...props }) }
+    ),
+    InnerBlocks: Object.assign(() => null, {
+        Content: () => null,
+    }),
+    RichText: Object.assign(() => null, {
+        Content: ({ value }: { value?: string }) =>
+            value !== undefined ? (
+                <span dangerouslySetInnerHTML={{ __html: value }} />
+            ) : null,
+    }),
+}));
+
+import ListItemSave from '../save';
+import metadata from '../block.json';
+
+describe('artisanpack/list-item block.json', () => {
+    it('parent is artisanpack/list', () => {
+        expect(metadata.parent).toEqual(['artisanpack/list']);
+    });
+
+    it('allowedBlocks is artisanpack/list (for nesting)', () => {
+        expect(metadata.allowedBlocks).toEqual(['artisanpack/list']);
+    });
+});
+
+describe('ListItemSave', () => {
+    it('renders an li with content', () => {
+        const html = renderToStaticMarkup(
+            <ListItemSave attributes={{ content: 'Item text' }} />
+        );
+        expect(html).toContain('<li');
+        expect(html).toContain('Item text');
+    });
+});

--- a/resources/js/visual-editor/blocks/list-item/__tests__/transforms.test.ts
+++ b/resources/js/visual-editor/blocks/list-item/__tests__/transforms.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Transforms tests for `artisanpack/list-item`.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@wordpress/blocks', () => ({
+    createBlock: (
+        name: string,
+        attributes?: Record<string, unknown>,
+        innerBlocks?: unknown[]
+    ) => ({ name, attributes: attributes ?? {}, innerBlocks: innerBlocks ?? [] }),
+    cloneBlock: (block: { name: string; attributes: Record<string, unknown> }) => ({
+        ...block,
+    }),
+}));
+
+import transforms from '../transforms';
+
+describe('list-item transforms', () => {
+    it('block transform from core/list-item → artisanpack/list-item', () => {
+        const fromBlock = transforms.from.find(
+            (t: { type: string; blocks?: string[] }) =>
+                t.type === 'block' && t.blocks?.[0] === 'core/list-item'
+        ) as {
+            transform: (
+                a: Record<string, unknown>,
+                inner: unknown[]
+            ) => { name: string };
+        };
+        expect(fromBlock.transform({ content: 'x' }, []).name).toBe(
+            'artisanpack/list-item'
+        );
+    });
+
+    it('list-item → paragraph (with innerBlocks appended)', () => {
+        const toBlock = transforms.to.find(
+            (t: { type: string; blocks?: string[] }) =>
+                t.type === 'block' && t.blocks?.[0] === 'core/paragraph'
+        ) as {
+            transform: (
+                a: Record<string, unknown>,
+                inner: unknown[]
+            ) => Array<{ name: string }>;
+        };
+        const result = toBlock.transform({ content: 'x' }, []);
+        expect(Array.isArray(result)).toBe(true);
+        expect(result[0].name).toBe('core/paragraph');
+    });
+
+    it('block transform to core/list-item', () => {
+        const toBlock = transforms.to.find(
+            (t: { type: string; blocks?: string[] }) =>
+                t.type === 'block' && t.blocks?.[0] === 'core/list-item'
+        ) as {
+            transform: (
+                a: Record<string, unknown>,
+                inner: unknown[]
+            ) => { name: string };
+        };
+        expect(toBlock.transform({}, []).name).toBe('core/list-item');
+    });
+});

--- a/resources/js/visual-editor/blocks/list-item/block.json
+++ b/resources/js/visual-editor/blocks/list-item/block.json
@@ -1,0 +1,70 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "artisanpack/list-item",
+    "title": "List Item",
+    "category": "text",
+    "parent": [ "artisanpack/list" ],
+    "allowedBlocks": [ "artisanpack/list" ],
+    "description": "An individual item within a list.",
+    "textdomain": "artisanpack-visual-editor",
+    "attributes": {
+        "placeholder": {
+            "type": "string"
+        },
+        "content": {
+            "type": "rich-text",
+            "source": "rich-text",
+            "selector": "li",
+            "role": "content"
+        }
+    },
+    "supports": {
+        "anchor": true,
+        "html": false,
+        "className": false,
+        "splitting": true,
+        "__experimentalBorder": {
+            "color": true,
+            "radius": true,
+            "style": true,
+            "width": true
+        },
+        "color": {
+            "gradients": true,
+            "link": true,
+            "background": true,
+            "__experimentalDefaultControls": {
+                "text": true
+            }
+        },
+        "spacing": {
+            "margin": true,
+            "padding": true,
+            "__experimentalDefaultControls": {
+                "margin": false,
+                "padding": false
+            }
+        },
+        "typography": {
+            "fontSize": true,
+            "lineHeight": true,
+            "__experimentalFontFamily": true,
+            "__experimentalFontWeight": true,
+            "__experimentalFontStyle": true,
+            "__experimentalTextTransform": true,
+            "__experimentalTextDecoration": true,
+            "__experimentalLetterSpacing": true,
+            "__experimentalDefaultControls": {
+                "fontSize": true
+            }
+        },
+        "interactivity": {
+            "clientNavigation": true
+        }
+    },
+    "selectors": {
+        "root": ".wp-block-list > li",
+        "border": ".wp-block-list:not(.wp-block-list .wp-block-list) > li"
+    }
+}

--- a/resources/js/visual-editor/blocks/list-item/deprecated.tsx
+++ b/resources/js/visual-editor/blocks/list-item/deprecated.tsx
@@ -1,0 +1,10 @@
+/**
+ * List item — deprecation chain.
+ *
+ * Upstream `@wordpress/block-library/src/list-item/` ships no
+ * `deprecated.js` (v9.43.0). Empty chain preserves parity.
+ */
+
+const deprecated: Array<Record<string, unknown>> = [];
+
+export default deprecated;

--- a/resources/js/visual-editor/blocks/list-item/edit.tsx
+++ b/resources/js/visual-editor/blocks/list-item/edit.tsx
@@ -1,0 +1,59 @@
+/**
+ * List item — editor-side render.
+ *
+ * Simplified port of `@wordpress/block-library/src/list-item/edit.js`
+ * (v9.43.0). The upstream edit ships indent/outdent toolbar buttons + the
+ * `useEnter`/`useSpace`/`useMerge` hooks that hook into block-editor
+ * private dispatch surface to manage nested-list keyboard navigation.
+ * This fork ships the RichText editing surface; the indent/outdent
+ * keyboard behaviour falls back to the editor's default block-list
+ * navigation. Nesting works via standard inner-block insertion.
+ */
+
+import type { ReactElement } from 'react';
+import {
+    RichText,
+    useBlockProps,
+    useInnerBlocksProps,
+} from '@wordpress/block-editor';
+
+interface ListItemAttributes {
+    readonly placeholder?: string;
+    readonly content: string;
+}
+
+interface ListItemEditProps {
+    readonly attributes: ListItemAttributes;
+    readonly setAttributes: (next: Partial<ListItemAttributes>) => void;
+    readonly mergeBlocks?: (forward?: boolean) => void;
+}
+
+export default function ListItemEdit({
+    attributes,
+    setAttributes,
+    mergeBlocks,
+}: ListItemEditProps): ReactElement {
+    const { placeholder, content } = attributes;
+    const blockProps = useBlockProps();
+    const innerBlocksProps = useInnerBlocksProps(blockProps, {
+        renderAppender: false,
+        __unstableDisableDropZone: true,
+    });
+
+    return (
+        <li {...innerBlocksProps}>
+            <RichText
+                identifier="content"
+                tagName="div"
+                onChange={(nextContent: string) =>
+                    setAttributes({ content: nextContent })
+                }
+                value={content}
+                aria-label="List text"
+                placeholder={placeholder || 'List'}
+                onMerge={mergeBlocks}
+            />
+            {(innerBlocksProps as { children?: React.ReactNode }).children}
+        </li>
+    );
+}

--- a/resources/js/visual-editor/blocks/list-item/index.ts
+++ b/resources/js/visual-editor/blocks/list-item/index.ts
@@ -1,0 +1,26 @@
+/**
+ * List item block entrypoint.
+ *
+ * Fork target: V2 block-fork phase I1 (content cluster, issue #409).
+ */
+
+import metadata from './block.json';
+import edit from './edit';
+import save from './save';
+import deprecated from './deprecated';
+import transforms from './transforms';
+import icon from './inserter-icon';
+
+import './list-item.css';
+
+export { edit, save, metadata, icon, deprecated, transforms };
+
+export default {
+    name: metadata.name,
+    metadata,
+    edit,
+    save,
+    icon,
+    deprecated,
+    transforms,
+};

--- a/resources/js/visual-editor/blocks/list-item/inserter-icon.tsx
+++ b/resources/js/visual-editor/blocks/list-item/inserter-icon.tsx
@@ -1,0 +1,20 @@
+/**
+ * List item — inserter icon.
+ */
+
+import type { ReactElement } from 'react';
+
+export default function ListItemInserterIcon(): ReactElement {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            width={24}
+            height={24}
+            aria-hidden="true"
+        >
+            <circle cx="4" cy="12" r="2" />
+            <path d="M8 11h12v2H8z" />
+        </svg>
+    );
+}

--- a/resources/js/visual-editor/blocks/list-item/list-item.css
+++ b/resources/js/visual-editor/blocks/list-item/list-item.css
@@ -1,0 +1,7 @@
+/*
+ * List item — frontend styles.
+ *
+ * Upstream `@wordpress/block-library/src/list-item/` ships no top-level
+ * style.scss (only native styles). Empty stylesheet preserves the
+ * auto-discovery shape so the css import in index.ts succeeds.
+ */

--- a/resources/js/visual-editor/blocks/list-item/save.tsx
+++ b/resources/js/visual-editor/blocks/list-item/save.tsx
@@ -1,0 +1,27 @@
+/**
+ * List item — saved markup.
+ *
+ * Ported from `@wordpress/block-library/src/list-item/save.js` (v9.43.0).
+ */
+
+import type { ReactElement } from 'react';
+import { InnerBlocks, RichText, useBlockProps } from '@wordpress/block-editor';
+
+interface ListItemSaveAttributes {
+    readonly content: string;
+}
+
+interface ListItemSaveProps {
+    readonly attributes: ListItemSaveAttributes;
+}
+
+export default function ListItemSave({
+    attributes,
+}: ListItemSaveProps): ReactElement {
+    return (
+        <li {...useBlockProps.save()}>
+            <RichText.Content value={attributes.content} />
+            <InnerBlocks.Content />
+        </li>
+    );
+}

--- a/resources/js/visual-editor/blocks/list-item/transforms.ts
+++ b/resources/js/visual-editor/blocks/list-item/transforms.ts
@@ -1,0 +1,58 @@
+/**
+ * List item — transforms.
+ *
+ * Ported from `@wordpress/block-library/src/list-item/transforms.js`
+ * (v9.43.0). Extended with bidirectional block transforms for
+ * `core/list-item` ↔ `artisanpack/list-item`.
+ */
+
+import { createBlock, cloneBlock } from '@wordpress/blocks';
+// `cloneBlock` accepts the public WP block instance shape — we type the
+// inner-blocks argument with that import so the call site doesn't need a
+// suppressing cast.
+import type { BlockInstance } from '@wordpress/blocks';
+
+import metadata from './block.json';
+
+const { name } = metadata;
+
+interface ListItemAttributes {
+    content?: string;
+    [key: string]: unknown;
+}
+
+const transforms = {
+    from: [
+        {
+            type: 'block',
+            blocks: ['core/list-item'],
+            transform: (
+                attributes: ListItemAttributes,
+                innerBlocks: BlockInstance[] = []
+            ) => createBlock(name, attributes, innerBlocks),
+        },
+    ],
+    to: [
+        {
+            type: 'block',
+            blocks: ['core/paragraph'],
+            transform: (
+                attributes: ListItemAttributes,
+                innerBlocks: BlockInstance[] = []
+            ) => [
+                createBlock('core/paragraph', attributes),
+                ...innerBlocks.map((block) => cloneBlock(block)),
+            ],
+        },
+        {
+            type: 'block',
+            blocks: ['core/list-item'],
+            transform: (
+                attributes: ListItemAttributes,
+                innerBlocks: BlockInstance[] = []
+            ) => createBlock('core/list-item', attributes, innerBlocks),
+        },
+    ],
+};
+
+export default transforms;

--- a/resources/js/visual-editor/blocks/list-item/upstream-diff-report.json
+++ b/resources/js/visual-editor/blocks/list-item/upstream-diff-report.json
@@ -44,7 +44,7 @@
             "status": "extended",
             "notes": "Upstream paragraph transform preserved; added bidirectional core/list-item ↔ artisanpack/list-item.",
             "result": "skipped-status",
-            "forkDigest": "46a23ebb6dec"
+            "forkDigest": "874b4d3ae6f8"
         },
         {
             "fork": "list-item.css",

--- a/resources/js/visual-editor/blocks/list-item/upstream-diff-report.json
+++ b/resources/js/visual-editor/blocks/list-item/upstream-diff-report.json
@@ -1,0 +1,74 @@
+{
+    "block": "list-item",
+    "status": "in-sync",
+    "upstream": {
+        "pinnedVersion": "9.43.0",
+        "subpath": "list-item"
+    },
+    "files": [
+        {
+            "fork": "block.json",
+            "upstream": "block.json",
+            "status": "adapted",
+            "notes": "name + textdomain + parent + allowedBlocks updated to artisanpack/* names.",
+            "result": "skipped-status",
+            "forkDigest": "3c945bc637f2"
+        },
+        {
+            "fork": "edit.tsx",
+            "upstream": "edit.js",
+            "status": "rewritten",
+            "notes": "Simplified edit. Upstream's `hooks.js` ships `useEnter`, `useSpace`, `useIndentListItem`, `useOutdentListItem`, `useMerge` — all reach into block-editor private dispatch surface for nested-list keyboard navigation. Deferred to post-I7. RichText editing and inner-block nesting still work.",
+            "result": "skipped-status",
+            "forkDigest": "3d1af5528bd3"
+        },
+        {
+            "fork": "save.tsx",
+            "upstream": "save.js",
+            "status": "adapted",
+            "notes": "TypeScript port; verbatim save shape.",
+            "result": "skipped-status",
+            "forkDigest": "65c263caeb7f"
+        },
+        {
+            "fork": "deprecated.tsx",
+            "upstream": "n/a",
+            "status": "added",
+            "notes": "No upstream deprecation chain; empty array preserves the file shape.",
+            "result": "skipped-status",
+            "forkDigest": "a9fcc4fcd2b7"
+        },
+        {
+            "fork": "transforms.ts",
+            "upstream": "transforms.js",
+            "status": "extended",
+            "notes": "Upstream paragraph transform preserved; added bidirectional core/list-item ↔ artisanpack/list-item.",
+            "result": "skipped-status",
+            "forkDigest": "46a23ebb6dec"
+        },
+        {
+            "fork": "list-item.css",
+            "upstream": "n/a (only style.native.scss)",
+            "status": "added",
+            "notes": "Empty stylesheet; upstream ships only a native-mobile style.",
+            "result": "skipped-status",
+            "forkDigest": "3874eddfb79a"
+        },
+        {
+            "fork": "inserter-icon.tsx",
+            "upstream": "n/a",
+            "status": "added",
+            "notes": "Inline SVG.",
+            "result": "skipped-status",
+            "forkDigest": "f36c8e7cd420"
+        },
+        {
+            "fork": "index.ts",
+            "upstream": "index.js",
+            "status": "rewritten",
+            "notes": "Auto-discovery contract.",
+            "result": "skipped-status",
+            "forkDigest": "8dff279ef478"
+        }
+    ]
+}

--- a/resources/js/visual-editor/blocks/list-item/upstream-state.json
+++ b/resources/js/visual-editor/blocks/list-item/upstream-state.json
@@ -1,0 +1,38 @@
+{
+    "$schema": "../../../../scripts/upstream-state.schema.json",
+    "block": "artisanpack/list-item",
+    "upstream": {
+        "package": "@wordpress/block-library",
+        "namespace": "core/list-item",
+        "pinnedVersion": "9.43.0",
+        "subpath": "list-item"
+    },
+    "forkedAt": "2026-05-27",
+    "$statusLegend": {
+        "ported": "byte-equivalent to upstream (CI fails on drift)",
+        "adapted": "TypeScript port and/or namespace swap; logically equivalent",
+        "extended": "fork adds behavior on top of upstream",
+        "rewritten": "fork replaced upstream entirely",
+        "added": "file unique to the fork (no upstream)"
+    },
+    "files": [
+        { "fork": "block.json", "upstream": "block.json", "status": "adapted", "notes": "name + textdomain + parent + allowedBlocks updated to artisanpack/* names." },
+        { "fork": "edit.tsx", "upstream": "edit.js", "status": "rewritten", "notes": "Simplified edit. Upstream's `hooks.js` ships `useEnter`, `useSpace`, `useIndentListItem`, `useOutdentListItem`, `useMerge` — all reach into block-editor private dispatch surface for nested-list keyboard navigation. Deferred to post-I7. RichText editing and inner-block nesting still work." },
+        { "fork": "save.tsx", "upstream": "save.js", "status": "adapted", "notes": "TypeScript port; verbatim save shape." },
+        { "fork": "deprecated.tsx", "upstream": "n/a", "status": "added", "notes": "No upstream deprecation chain; empty array preserves the file shape." },
+        { "fork": "transforms.ts", "upstream": "transforms.js", "status": "extended", "notes": "Upstream paragraph transform preserved; added bidirectional core/list-item ↔ artisanpack/list-item." },
+        { "fork": "list-item.css", "upstream": "n/a (only style.native.scss)", "status": "added", "notes": "Empty stylesheet; upstream ships only a native-mobile style." },
+        { "fork": "inserter-icon.tsx", "upstream": "n/a", "status": "added", "notes": "Inline SVG." },
+        { "fork": "index.ts", "upstream": "index.js", "status": "rewritten", "notes": "Auto-discovery contract." }
+    ],
+    "vendoredPrimitives": [],
+    "knownDivergences": [
+        "edit.tsx omits the `hooks.js` keyboard-navigation suite. Tab indent/outdent and Enter-to-split behaviour falls back to the default block-editor behaviour. The post-I7 customization phase ports these.",
+        "transforms.ts adds bidirectional block transforms with core/list-item."
+    ],
+    "triage": {
+        "label": "in-sync",
+        "lastReviewed": "2026-05-27",
+        "reviewer": "I1 content cluster"
+    }
+}

--- a/resources/js/visual-editor/blocks/list/__tests__/deprecated.test.tsx
+++ b/resources/js/visual-editor/blocks/list/__tests__/deprecated.test.tsx
@@ -1,0 +1,71 @@
+/**
+ * Locks the deprecation chain for `artisanpack/list`.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+vi.mock('@wordpress/block-editor', () => ({
+    useBlockProps: Object.assign(
+        (props?: Record<string, unknown>) => ({ ...props }),
+        { save: (props?: Record<string, unknown>) => ({ ...props }) }
+    ),
+    InnerBlocks: Object.assign(() => null, {
+        Content: () => null,
+    }),
+    RichText: Object.assign(() => null, {
+        Content: ({ value }: { value?: string }) =>
+            value !== undefined ? (
+                <span dangerouslySetInnerHTML={{ __html: value }} />
+            ) : null,
+    }),
+}));
+
+vi.mock('@wordpress/blocks', () => ({
+    createBlock: (name: string, attributes?: Record<string, unknown>) => ({
+        name,
+        attributes: attributes ?? {},
+        innerBlocks: [],
+    }),
+}));
+
+import deprecated from '../deprecated';
+
+describe('list deprecation chain', () => {
+    it('has 4 historical entries', () => {
+        expect(deprecated).toHaveLength(4);
+    });
+
+    it('every entry exposes a save callable', () => {
+        deprecated.forEach((entry, i) => {
+            expect(
+                typeof (entry as { save?: unknown }).save,
+                `entry ${i}`
+            ).toBe('function');
+        });
+    });
+
+    it('v3 (entries[0]) renders ul/ol with the list-style-type style', () => {
+        const entry = deprecated[0] as {
+            save: (p: { attributes: Record<string, unknown> }) => React.ReactElement;
+        };
+        const ul = renderToStaticMarkup(
+            entry.save({ attributes: { ordered: false } })
+        );
+        expect(ul).toContain('<ul');
+        const ol = renderToStaticMarkup(
+            entry.save({ attributes: { ordered: true, type: 'upper-alpha' } })
+        );
+        expect(ol).toContain('<ol');
+    });
+
+    it('v2 migrates legacy `type` (A/a/I/i) to inline-style values', () => {
+        const entry = deprecated[1] as {
+            migrate: (a: Record<string, unknown>) => Record<string, unknown>;
+            isEligible: (a: Record<string, unknown>) => boolean;
+        };
+        expect(entry.isEligible({ type: 'A' })).toBe(true);
+        const migrated = entry.migrate({ type: 'A' });
+        expect(migrated.type).toBe('upper-alpha');
+    });
+});

--- a/resources/js/visual-editor/blocks/list/__tests__/edit.test.tsx
+++ b/resources/js/visual-editor/blocks/list/__tests__/edit.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * Tests for the `artisanpack/list` edit component.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+vi.mock('@wordpress/components', () => ({
+    PanelBody: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    SelectControl: ({
+        value,
+        onChange,
+    }: { value?: string; onChange: (v: string) => void }) => (
+        <select
+            aria-label="list-style"
+            value={value}
+            onChange={(e) => onChange(e.target.value)}
+        >
+            <option value="decimal">decimal</option>
+            <option value="upper-alpha">upper-alpha</option>
+        </select>
+    ),
+    TextControl: ({
+        label,
+        value,
+        onChange,
+    }: { label: string; value?: string; onChange: (v: string) => void }) => (
+        <input
+            aria-label={label}
+            value={value ?? ''}
+            onChange={(e) => onChange(e.target.value)}
+        />
+    ),
+    ToggleControl: ({
+        label,
+        checked,
+        onChange,
+    }: { label: string; checked: boolean; onChange: (v: boolean) => void }) => (
+        <label>
+            {label}
+            <input
+                type="checkbox"
+                aria-label={label}
+                checked={checked}
+                onChange={(e) => onChange(e.target.checked)}
+            />
+        </label>
+    ),
+    ToolbarButton: ({
+        title,
+        isActive,
+        onClick,
+    }: { title: string; isActive?: boolean; onClick: () => void }) => (
+        <button
+            aria-pressed={isActive}
+            aria-label={title}
+            onClick={onClick}
+        >
+            {title}
+        </button>
+    ),
+}));
+
+vi.mock('@wordpress/block-editor', () => ({
+    useBlockProps: Object.assign(
+        (props?: Record<string, unknown>) => ({ ...props }),
+        { save: (props?: Record<string, unknown>) => ({ ...props }) }
+    ),
+    useInnerBlocksProps: (props?: Record<string, unknown>) => ({
+        ...props,
+        children: <div data-testid="inner-blocks" />,
+    }),
+    BlockControls: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    InspectorControls: ({ children }: { children: React.ReactNode }) => (
+        <div>{children}</div>
+    ),
+}));
+
+import ListEdit from '../edit';
+
+describe('ListEdit', () => {
+    it('renders the UL toolbar button as active when ordered is false', () => {
+        const setAttributes = vi.fn();
+        render(
+            <ListEdit attributes={{ ordered: false }} setAttributes={setAttributes} />
+        );
+        expect(screen.getByLabelText('Unordered').getAttribute('aria-pressed')).toBe(
+            'true'
+        );
+    });
+
+    it('switches to ordered when the Ordered toolbar button is clicked', () => {
+        const setAttributes = vi.fn();
+        render(
+            <ListEdit attributes={{ ordered: false }} setAttributes={setAttributes} />
+        );
+        fireEvent.click(screen.getByLabelText('Ordered'));
+        expect(setAttributes).toHaveBeenCalledWith({ ordered: true });
+    });
+
+    it('shows ordered-list settings when ordered=true', () => {
+        const setAttributes = vi.fn();
+        render(
+            <ListEdit attributes={{ ordered: true }} setAttributes={setAttributes} />
+        );
+        expect(screen.getByLabelText('list-style')).toBeTruthy();
+    });
+});

--- a/resources/js/visual-editor/blocks/list/__tests__/save.test.tsx
+++ b/resources/js/visual-editor/blocks/list/__tests__/save.test.tsx
@@ -1,0 +1,50 @@
+/**
+ * Tests for the `artisanpack/list` save component.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+vi.mock('@wordpress/block-editor', () => ({
+    useBlockProps: Object.assign(
+        (props?: Record<string, unknown>) => ({ ...props }),
+        { save: (props?: Record<string, unknown>) => ({ ...props }) }
+    ),
+    InnerBlocks: Object.assign(() => null, {
+        Content: () => null,
+    }),
+}));
+
+import ListSave from '../save';
+import metadata from '../block.json';
+
+describe('artisanpack/list block.json', () => {
+    it('declares the artisanpack namespace', () => {
+        expect(metadata.name).toBe('artisanpack/list');
+        expect(metadata.allowedBlocks).toEqual(['artisanpack/list-item']);
+    });
+});
+
+describe('ListSave', () => {
+    it('renders a ul when ordered is false', () => {
+        const html = renderToStaticMarkup(
+            <ListSave attributes={{ ordered: false }} />
+        );
+        expect(html).toContain('<ul');
+    });
+
+    it('renders an ol when ordered is true', () => {
+        const html = renderToStaticMarkup(
+            <ListSave attributes={{ ordered: true }} />
+        );
+        expect(html).toContain('<ol');
+    });
+
+    it('passes reversed and start through on ordered lists', () => {
+        const html = renderToStaticMarkup(
+            <ListSave attributes={{ ordered: true, reversed: true, start: 5 }} />
+        );
+        expect(html).toContain('reversed');
+        expect(html).toMatch(/start="?5/);
+    });
+});

--- a/resources/js/visual-editor/blocks/list/__tests__/transforms.test.ts
+++ b/resources/js/visual-editor/blocks/list/__tests__/transforms.test.ts
@@ -40,7 +40,7 @@ describe('list transforms', () => {
         expect(result.innerBlocks[0].name).toBe('artisanpack/list-item');
     });
 
-    it('block transform from core/list → artisanpack/list preserves innerBlocks', () => {
+    it('core/list → artisanpack/list remaps core/list-item children to artisanpack/list-item', () => {
         const fromBlock = transforms.from.find(
             (t: { type: string; blocks?: string[] }) =>
                 t.type === 'block' &&
@@ -50,15 +50,70 @@ describe('list transforms', () => {
             transform: (
                 a: Record<string, unknown>,
                 inner: unknown[]
-            ) => { name: string; innerBlocks: unknown[] };
+            ) => {
+                name: string;
+                innerBlocks: Array<{ name: string; innerBlocks: unknown[] }>;
+            };
         };
-        const inner = [{ name: 'core/list-item', attributes: { content: 'x' }, innerBlocks: [] }];
+        const inner = [
+            {
+                name: 'core/list-item',
+                attributes: { content: 'x' },
+                innerBlocks: [
+                    {
+                        name: 'core/list',
+                        attributes: {},
+                        innerBlocks: [
+                            {
+                                name: 'core/list-item',
+                                attributes: { content: 'nested' },
+                                innerBlocks: [],
+                            },
+                        ],
+                    },
+                ],
+            },
+        ];
         const result = fromBlock.transform({ ordered: true }, inner);
         expect(result.name).toBe('artisanpack/list');
-        expect(result.innerBlocks).toEqual(inner);
+        expect(result.innerBlocks[0].name).toBe('artisanpack/list-item');
+        // Nested list-items are remapped too — `core/list` containers stay
+        // because the transform only renames list-items.
+        const nestedList = result.innerBlocks[0].innerBlocks[0] as {
+            name: string;
+            innerBlocks: Array<{ name: string }>;
+        };
+        expect(nestedList.innerBlocks[0].name).toBe('artisanpack/list-item');
     });
 
-    it('block transform to core/list', () => {
+    it('artisanpack/list → core/list remaps artisanpack/list-item children back to core/list-item', () => {
+        const toBlock = transforms.to.find(
+            (t: { type: string; blocks?: string[] }) =>
+                t.type === 'block' &&
+                t.blocks?.length === 1 &&
+                t.blocks[0] === 'core/list'
+        ) as {
+            transform: (
+                a: Record<string, unknown>,
+                inner: unknown[]
+            ) => {
+                name: string;
+                innerBlocks: Array<{ name: string }>;
+            };
+        };
+        const inner = [
+            {
+                name: 'artisanpack/list-item',
+                attributes: { content: 'x' },
+                innerBlocks: [],
+            },
+        ];
+        const result = toBlock.transform({ ordered: true }, inner);
+        expect(result.name).toBe('core/list');
+        expect(result.innerBlocks[0].name).toBe('core/list-item');
+    });
+
+    it('block transform to core/list (smoke)', () => {
         const toBlock = transforms.to.find(
             (t: { type: string; blocks?: string[] }) =>
                 t.type === 'block' && t.blocks?.[0] === 'core/list'

--- a/resources/js/visual-editor/blocks/list/__tests__/transforms.test.ts
+++ b/resources/js/visual-editor/blocks/list/__tests__/transforms.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Transforms tests for `artisanpack/list`.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@wordpress/blocks', () => ({
+    createBlock: (
+        name: string,
+        attributes?: Record<string, unknown>,
+        innerBlocks?: unknown[]
+    ) => ({
+        name,
+        attributes: attributes ?? {},
+        innerBlocks: innerBlocks ?? [],
+    }),
+}));
+
+vi.mock('@wordpress/rich-text', () => ({
+    create: (input: { html: string }) => ({ text: input.html }),
+    split: (value: { text: string }) => [value],
+    toHTMLString: ({ value }: { value: { text: string } }) => value.text,
+}));
+
+import transforms from '../transforms';
+
+describe('list transforms', () => {
+    it('paragraph → list creates a list with list-item children', () => {
+        const fromBlock = transforms.from.find(
+            (t: { type: string; blocks?: string[] }) =>
+                t.type === 'block' && t.blocks?.includes('core/paragraph')
+        ) as {
+            transform: (attrs: Array<Record<string, unknown>>) => {
+                name: string;
+                innerBlocks: Array<{ name: string }>;
+            };
+        };
+        const result = fromBlock.transform([{ content: 'hi' }]);
+        expect(result.name).toBe('artisanpack/list');
+        expect(result.innerBlocks[0].name).toBe('artisanpack/list-item');
+    });
+
+    it('block transform from core/list → artisanpack/list preserves innerBlocks', () => {
+        const fromBlock = transforms.from.find(
+            (t: { type: string; blocks?: string[] }) =>
+                t.type === 'block' &&
+                t.blocks?.length === 1 &&
+                t.blocks[0] === 'core/list'
+        ) as {
+            transform: (
+                a: Record<string, unknown>,
+                inner: unknown[]
+            ) => { name: string; innerBlocks: unknown[] };
+        };
+        const inner = [{ name: 'core/list-item', attributes: { content: 'x' }, innerBlocks: [] }];
+        const result = fromBlock.transform({ ordered: true }, inner);
+        expect(result.name).toBe('artisanpack/list');
+        expect(result.innerBlocks).toEqual(inner);
+    });
+
+    it('block transform to core/list', () => {
+        const toBlock = transforms.to.find(
+            (t: { type: string; blocks?: string[] }) =>
+                t.type === 'block' && t.blocks?.[0] === 'core/list'
+        ) as { transform: (a: Record<string, unknown>, inner: unknown[]) => { name: string } };
+        expect(toBlock.transform({}, []).name).toBe('core/list');
+    });
+
+    it('prefix transform on `*` creates an unordered list', () => {
+        const prefix = transforms.from.find(
+            (t: { type: string; prefix?: string }) =>
+                t.type === 'prefix' && t.prefix === '*'
+        ) as {
+            transform: (content: string) => {
+                name: string;
+                attributes: Record<string, unknown>;
+            };
+        };
+        const result = prefix.transform('item');
+        expect(result.name).toBe('artisanpack/list');
+        expect(result.attributes.ordered).toBeUndefined();
+    });
+
+    it('prefix transform on `1.` creates an ordered list', () => {
+        const prefix = transforms.from.find(
+            (t: { type: string; prefix?: string }) =>
+                t.type === 'prefix' && t.prefix === '1.'
+        ) as {
+            transform: (content: string) => {
+                name: string;
+                attributes: Record<string, unknown>;
+            };
+        };
+        const result = prefix.transform('item');
+        expect(result.attributes.ordered).toBe(true);
+    });
+});

--- a/resources/js/visual-editor/blocks/list/block.json
+++ b/resources/js/visual-editor/blocks/list/block.json
@@ -1,0 +1,89 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "artisanpack/list",
+    "title": "List",
+    "category": "text",
+    "allowedBlocks": [ "artisanpack/list-item" ],
+    "description": "An organized collection of items displayed in a specific order.",
+    "keywords": [ "bullet list", "ordered list", "numbered list" ],
+    "textdomain": "artisanpack-visual-editor",
+    "attributes": {
+        "ordered": {
+            "type": "boolean",
+            "default": false,
+            "role": "content"
+        },
+        "values": {
+            "type": "string",
+            "source": "html",
+            "selector": "ol,ul",
+            "multiline": "li",
+            "default": "",
+            "role": "content"
+        },
+        "type": {
+            "type": "string"
+        },
+        "start": {
+            "type": "number"
+        },
+        "reversed": {
+            "type": "boolean"
+        },
+        "placeholder": {
+            "type": "string"
+        }
+    },
+    "supports": {
+        "anchor": true,
+        "html": false,
+        "__experimentalBorder": {
+            "color": true,
+            "radius": true,
+            "style": true,
+            "width": true
+        },
+        "typography": {
+            "fontSize": true,
+            "lineHeight": true,
+            "__experimentalFontFamily": true,
+            "__experimentalFontWeight": true,
+            "__experimentalFontStyle": true,
+            "__experimentalTextTransform": true,
+            "__experimentalTextDecoration": true,
+            "__experimentalLetterSpacing": true,
+            "__experimentalDefaultControls": {
+                "fontSize": true
+            }
+        },
+        "color": {
+            "gradients": true,
+            "link": true,
+            "__experimentalDefaultControls": {
+                "background": true,
+                "text": true
+            }
+        },
+        "spacing": {
+            "margin": true,
+            "padding": true,
+            "__experimentalDefaultControls": {
+                "margin": false,
+                "padding": false
+            }
+        },
+        "__unstablePasteTextInline": true,
+        "__experimentalOnMerge": true,
+        "__experimentalSlashInserter": true,
+        "interactivity": {
+            "clientNavigation": true
+        },
+        "listView": true
+    },
+    "selectors": {
+        "border": ".wp-block-list:not(.wp-block-list .wp-block-list)"
+    },
+    "editorStyle": "wp-block-list-editor",
+    "style": "wp-block-list"
+}

--- a/resources/js/visual-editor/blocks/list/deprecated.tsx
+++ b/resources/js/visual-editor/blocks/list/deprecated.tsx
@@ -1,0 +1,209 @@
+/**
+ * List — deprecation chain.
+ *
+ * Full port of `@wordpress/block-library/src/list/deprecated.js` (v9.43.0).
+ * v3 → v0 cover historical save shapes. v0 + v1 migrate the legacy
+ * `values` HTML attribute into inner `artisanpack/list-item` blocks via
+ * `migrateToListV2`. v2 migrates the legacy `type` attribute (A/a/I/i)
+ * into the modern `list-style-type` inline-style values.
+ */
+
+import { RichText, InnerBlocks, useBlockProps } from '@wordpress/block-editor';
+import { createBlock } from '@wordpress/blocks';
+
+import { migrateFontFamily } from '../_shared/migrate-font-family';
+
+interface LegacyListAttributes {
+    ordered?: boolean;
+    values?: string;
+    type?: string;
+    start?: number;
+    reversed?: boolean;
+    placeholder?: string;
+    style?: { typography?: { fontFamily?: string } };
+    [key: string]: unknown;
+}
+
+const LIST_STYLES: Record<string, string> = {
+    A: 'upper-alpha',
+    a: 'lower-alpha',
+    I: 'upper-roman',
+    i: 'lower-roman',
+};
+
+function migrateTypeToInlineStyle(attributes: LegacyListAttributes): LegacyListAttributes {
+    const { type } = attributes;
+    if (type && LIST_STYLES[type]) {
+        return { ...attributes, type: LIST_STYLES[type] };
+    }
+    return attributes;
+}
+
+/**
+ * Synthesizes inner `artisanpack/list-item` blocks from the legacy `values`
+ * HTML string. Upstream uses `rawHandler` which involves the paste pipeline;
+ * we do a lightweight DOM parse to avoid pulling that dependency.
+ */
+function migrateToListV2(
+    attributes: LegacyListAttributes
+): [LegacyListAttributes, unknown[]] {
+    const { values, start, reversed, ordered, type, ...rest } = attributes;
+    const tagName = ordered ? 'ol' : 'ul';
+
+    const container =
+        typeof document !== 'undefined'
+            ? document.createElement('div')
+            : null;
+    let innerBlocks: unknown[] = [];
+
+    if (container) {
+        container.innerHTML = `<${tagName}>${values ?? ''}</${tagName}>`;
+        const list = container.firstChild as HTMLElement | null;
+        if (list) {
+            innerBlocks = Array.from(list.children).map((item) =>
+                createBlock('artisanpack/list-item', { content: item.innerHTML })
+            );
+        }
+    }
+
+    return [
+        {
+            ...rest,
+            ordered,
+            type: type && LIST_STYLES[type] ? LIST_STYLES[type] : type,
+            ...(start !== undefined && { start }),
+            ...(reversed !== undefined && { reversed }),
+        },
+        innerBlocks,
+    ];
+}
+
+const baseAttributes = {
+    ordered: { type: 'boolean', default: false, role: 'content' },
+    values: {
+        type: 'string',
+        source: 'html',
+        selector: 'ol,ul',
+        multiline: 'li',
+        __unstableMultilineWrapperTags: ['ol', 'ul'],
+        default: '',
+        role: 'content',
+    },
+    type: { type: 'string' },
+    start: { type: 'number' },
+    reversed: { type: 'boolean' },
+    placeholder: { type: 'string' },
+} as const;
+
+const v0 = {
+    attributes: baseAttributes,
+    supports: {
+        anchor: true,
+        className: false,
+        typography: { fontSize: true, __experimentalFontFamily: true },
+        color: { gradients: true, link: true },
+        __unstablePasteTextInline: true,
+        __experimentalSelector: 'ol,ul',
+        __experimentalSlashInserter: true,
+    },
+    save({ attributes }: { attributes: LegacyListAttributes }) {
+        const { ordered, values, type, reversed, start } = attributes;
+        const TagName = ordered ? 'ol' : 'ul';
+        return (
+            <TagName {...useBlockProps.save({ type, reversed, start })}>
+                <RichText.Content value={values} multiline="li" />
+            </TagName>
+        );
+    },
+    migrate: migrateFontFamily,
+    isEligible({ style }: LegacyListAttributes) {
+        return !!style?.typography?.fontFamily;
+    },
+};
+
+const v1 = {
+    attributes: baseAttributes,
+    supports: {
+        anchor: true,
+        className: false,
+        typography: { fontSize: true, lineHeight: true },
+        color: { gradients: true, link: true },
+        __unstablePasteTextInline: true,
+        __experimentalSelector: 'ol,ul',
+        __experimentalSlashInserter: true,
+    },
+    save({ attributes }: { attributes: LegacyListAttributes }) {
+        const { ordered, values, type, reversed, start } = attributes;
+        const TagName = ordered ? 'ol' : 'ul';
+        return (
+            <TagName {...useBlockProps.save({ type, reversed, start })}>
+                <RichText.Content value={values} multiline="li" />
+            </TagName>
+        );
+    },
+    migrate: migrateToListV2,
+};
+
+const v2 = {
+    attributes: baseAttributes,
+    supports: {
+        anchor: true,
+        className: false,
+        typography: { fontSize: true, lineHeight: true },
+        color: { gradients: true, link: true },
+        spacing: { margin: true, padding: true },
+        __unstablePasteTextInline: true,
+        __experimentalSelector: 'ol,ul',
+        __experimentalSlashInserter: true,
+    },
+    isEligible({ type }: LegacyListAttributes) {
+        return !!type;
+    },
+    save({ attributes }: { attributes: LegacyListAttributes }) {
+        const { ordered, type, reversed, start } = attributes;
+        const TagName = ordered ? 'ol' : 'ul';
+        return (
+            <TagName {...useBlockProps.save({ type, reversed, start })}>
+                <InnerBlocks.Content />
+            </TagName>
+        );
+    },
+    migrate: migrateTypeToInlineStyle,
+};
+
+const v3 = {
+    attributes: baseAttributes,
+    supports: {
+        anchor: true,
+        className: false,
+        typography: { fontSize: true, lineHeight: true },
+        color: { gradients: true, link: true },
+        spacing: { margin: true, padding: true },
+        __unstablePasteTextInline: true,
+        __experimentalSelector: 'ol,ul',
+        __experimentalOnMerge: 'true',
+        __experimentalSlashInserter: true,
+    },
+    save({ attributes }: { attributes: LegacyListAttributes }) {
+        const { ordered, type, reversed, start } = attributes;
+        const TagName = ordered ? 'ol' : 'ul';
+        return (
+            <TagName
+                {...useBlockProps.save({
+                    reversed,
+                    start,
+                    style: {
+                        listStyleType:
+                            ordered && type !== 'decimal' ? type : undefined,
+                    },
+                })}
+            >
+                <InnerBlocks.Content />
+            </TagName>
+        );
+    },
+};
+
+const deprecated = [v3, v2, v1, v0];
+
+export default deprecated;

--- a/resources/js/visual-editor/blocks/list/edit.tsx
+++ b/resources/js/visual-editor/blocks/list/edit.tsx
@@ -1,0 +1,127 @@
+/**
+ * List — editor-side render.
+ *
+ * Simplified port of `@wordpress/block-library/src/list/edit.js` (v9.43.0).
+ * The upstream edit ships ordered/unordered toggle buttons + indent/outdent
+ * toolbar + ordered-list settings panel; this fork ships the toggle buttons
+ * and a minimal ordered-list settings panel. The indent/outdent hooks rely
+ * on block-editor private dispatch surface and are deferred to the post-I7
+ * customization phase. Inner-block insertion still uses
+ * `artisanpack/list-item` so list nesting works.
+ */
+
+import type { ReactElement } from 'react';
+import {
+    BlockControls,
+    InspectorControls,
+    useBlockProps,
+    useInnerBlocksProps,
+} from '@wordpress/block-editor';
+import {
+    PanelBody,
+    SelectControl,
+    TextControl,
+    ToggleControl,
+    ToolbarButton,
+} from '@wordpress/components';
+
+interface ListAttributes {
+    readonly ordered?: boolean;
+    readonly type?: string;
+    readonly reversed?: boolean;
+    readonly start?: number;
+}
+
+interface ListEditProps {
+    readonly attributes: ListAttributes;
+    readonly setAttributes: (next: Partial<ListAttributes>) => void;
+}
+
+const TEMPLATE: ReadonlyArray<readonly [string, Record<string, unknown>]> = [
+    ['artisanpack/list-item', {}],
+];
+
+const LIST_STYLE_OPTIONS = [
+    { label: 'Numbers', value: 'decimal' },
+    { label: 'Uppercase letters', value: 'upper-alpha' },
+    { label: 'Lowercase letters', value: 'lower-alpha' },
+    { label: 'Uppercase Roman numerals', value: 'upper-roman' },
+    { label: 'Lowercase Roman numerals', value: 'lower-roman' },
+];
+
+export default function ListEdit({
+    attributes,
+    setAttributes,
+}: ListEditProps): ReactElement {
+    const { ordered, type, reversed, start } = attributes;
+    const blockProps = useBlockProps({
+        style: {
+            listStyleType: ordered && type !== 'decimal' ? type : undefined,
+        },
+    });
+    const innerBlocksProps = useInnerBlocksProps(blockProps, {
+        defaultBlock: { name: 'artisanpack/list-item' } as unknown as never,
+        directInsert: true,
+        template: TEMPLATE as unknown as readonly [string, Record<string, unknown>][],
+        templateLock: false,
+        templateInsertUpdatesSelection: true,
+    });
+
+    const TagName = ordered ? 'ol' : 'ul';
+
+    return (
+        <>
+            <BlockControls group="block">
+                <ToolbarButton
+                    title="Unordered"
+                    isActive={ordered === false}
+                    onClick={() => setAttributes({ ordered: false })}
+                >
+                    UL
+                </ToolbarButton>
+                <ToolbarButton
+                    title="Ordered"
+                    isActive={ordered === true}
+                    onClick={() => setAttributes({ ordered: true })}
+                >
+                    OL
+                </ToolbarButton>
+            </BlockControls>
+            {ordered && (
+                <InspectorControls>
+                    <PanelBody title="Settings">
+                        <SelectControl
+                            label="List style"
+                            options={LIST_STYLE_OPTIONS}
+                            value={type ?? 'decimal'}
+                            onChange={(value) =>
+                                setAttributes({ type: value || undefined })
+                            }
+                        />
+                        <TextControl
+                            label="Start value"
+                            type="number"
+                            value={
+                                Number.isInteger(start) ? String(start) : ''
+                            }
+                            onChange={(value) => {
+                                const int = parseInt(value, 10);
+                                setAttributes({
+                                    start: isNaN(int) ? undefined : int,
+                                });
+                            }}
+                        />
+                        <ToggleControl
+                            label="Reverse order"
+                            checked={!!reversed}
+                            onChange={(value) =>
+                                setAttributes({ reversed: value || undefined })
+                            }
+                        />
+                    </PanelBody>
+                </InspectorControls>
+            )}
+            <TagName {...innerBlocksProps} />
+        </>
+    );
+}

--- a/resources/js/visual-editor/blocks/list/index.ts
+++ b/resources/js/visual-editor/blocks/list/index.ts
@@ -1,0 +1,26 @@
+/**
+ * List block entrypoint.
+ *
+ * Fork target: V2 block-fork phase I1 (content cluster, issue #409).
+ */
+
+import metadata from './block.json';
+import edit from './edit';
+import save from './save';
+import deprecated from './deprecated';
+import transforms from './transforms';
+import icon from './inserter-icon';
+
+import './list.css';
+
+export { edit, save, metadata, icon, deprecated, transforms };
+
+export default {
+    name: metadata.name,
+    metadata,
+    edit,
+    save,
+    icon,
+    deprecated,
+    transforms,
+};

--- a/resources/js/visual-editor/blocks/list/inserter-icon.tsx
+++ b/resources/js/visual-editor/blocks/list/inserter-icon.tsx
@@ -1,0 +1,19 @@
+/**
+ * List — inserter icon.
+ */
+
+import type { ReactElement } from 'react';
+
+export default function ListInserterIcon(): ReactElement {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            width={24}
+            height={24}
+            aria-hidden="true"
+        >
+            <path d="M4 6h2v2H4V6zm16 0H8v2h12V6zM4 11h2v2H4v-2zm16 0H8v2h12v-2zM4 16h2v2H4v-2zm16 0H8v2h12v-2z" />
+        </svg>
+    );
+}

--- a/resources/js/visual-editor/blocks/list/list.css
+++ b/resources/js/visual-editor/blocks/list/list.css
@@ -1,0 +1,14 @@
+/*
+ * List — frontend styles.
+ *
+ * Ported from `@wordpress/block-library/src/list/style.scss` (v9.43.0).
+ */
+
+ol,
+ul {
+    box-sizing: border-box;
+}
+
+:root :where(.wp-block-list.has-background) {
+    padding: 1.25em 2.375em;
+}

--- a/resources/js/visual-editor/blocks/list/save.tsx
+++ b/resources/js/visual-editor/blocks/list/save.tsx
@@ -1,0 +1,37 @@
+/**
+ * List — saved markup.
+ *
+ * Ported from `@wordpress/block-library/src/list/save.js` (v9.43.0).
+ */
+
+import type { ReactElement } from 'react';
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
+
+interface ListSaveAttributes {
+    readonly ordered?: boolean;
+    readonly type?: string;
+    readonly reversed?: boolean;
+    readonly start?: number;
+}
+
+interface ListSaveProps {
+    readonly attributes: ListSaveAttributes;
+}
+
+export default function ListSave({ attributes }: ListSaveProps): ReactElement {
+    const { ordered, type, reversed, start } = attributes;
+    const TagName = ordered ? 'ol' : 'ul';
+    return (
+        <TagName
+            {...useBlockProps.save({
+                reversed,
+                start,
+                style: {
+                    listStyleType: ordered && type !== 'decimal' ? type : undefined,
+                },
+            })}
+        >
+            <InnerBlocks.Content />
+        </TagName>
+    );
+}

--- a/resources/js/visual-editor/blocks/list/transforms.ts
+++ b/resources/js/visual-editor/blocks/list/transforms.ts
@@ -142,6 +142,42 @@ function getListContentFlat(
     });
 }
 
+/**
+ * Recursively rename a list-item block name across an inner-block tree.
+ *
+ * The `core/list` ↔ `artisanpack/list` round-trip transforms must remap
+ * every `core/list-item` → `artisanpack/list-item` (and vice versa) on
+ * the way through — leaving the children at the old namespace would
+ * mean `artisanpack/list` contains `core/list-item` children, which
+ * violates the block's `allowedBlocks` contract.
+ */
+function remapListItemNames(
+    blocks: Array<{
+        name: string;
+        attributes: Record<string, unknown>;
+        innerBlocks?: unknown[];
+    }>,
+    from: 'core/list-item' | 'artisanpack/list-item',
+    to: 'core/list-item' | 'artisanpack/list-item'
+): Array<{
+    name: string;
+    attributes: Record<string, unknown>;
+    innerBlocks: unknown[];
+}> {
+    return blocks.map((block) => {
+        const childBlocks = (block.innerBlocks ?? []) as Array<{
+            name: string;
+            attributes: Record<string, unknown>;
+            innerBlocks?: unknown[];
+        }>;
+        return {
+            name: block.name === from ? to : block.name,
+            attributes: block.attributes,
+            innerBlocks: remapListItemNames(childBlocks, from, to),
+        };
+    });
+}
+
 const transforms = {
     from: [
         {
@@ -212,7 +248,15 @@ const transforms = {
                     innerBlocks: unknown[];
                 }>
             ) =>
-                createBlock(name, attributes, innerBlocks),
+                createBlock(
+                    name,
+                    attributes,
+                    remapListItemNames(
+                        innerBlocks,
+                        'core/list-item',
+                        'artisanpack/list-item'
+                    )
+                ),
         },
     ],
     to: [
@@ -237,8 +281,21 @@ const transforms = {
             blocks: ['core/list'],
             transform: (
                 attributes: ListAttributes,
-                innerBlocks: Array<unknown>
-            ) => createBlock('core/list', attributes, innerBlocks),
+                innerBlocks: Array<{
+                    name: string;
+                    attributes: Record<string, unknown>;
+                    innerBlocks: unknown[];
+                }>
+            ) =>
+                createBlock(
+                    'core/list',
+                    attributes,
+                    remapListItemNames(
+                        innerBlocks,
+                        'artisanpack/list-item',
+                        'core/list-item'
+                    )
+                ),
         },
     ],
 };

--- a/resources/js/visual-editor/blocks/list/transforms.ts
+++ b/resources/js/visual-editor/blocks/list/transforms.ts
@@ -1,0 +1,246 @@
+/**
+ * List — transforms.
+ *
+ * Ported from `@wordpress/block-library/src/list/transforms.js` (v9.43.0).
+ * Extended with bidirectional block transforms for `core/list` ↔
+ * `artisanpack/list`. The raw paste transform produces nested
+ * `artisanpack/list-item` blocks.
+ */
+
+import { createBlock } from '@wordpress/blocks';
+import { create, split, toHTMLString } from '@wordpress/rich-text';
+
+import metadata from './block.json';
+
+const { name } = metadata;
+
+interface ListAttributes {
+    content?: string;
+    anchor?: string;
+    [key: string]: unknown;
+}
+
+interface RawTransformContext {
+    readonly phrasingContentSchema: unknown;
+}
+
+interface RawListElement {
+    readonly tagName: string;
+    readonly id?: string;
+    readonly children: HTMLCollection;
+    getAttribute(name: string): string | null;
+    hasAttribute(name: string): boolean;
+}
+
+const LIST_STYLES: Record<string, string> = {
+    A: 'upper-alpha',
+    a: 'lower-alpha',
+    I: 'upper-roman',
+    i: 'lower-roman',
+};
+
+function getListContentSchema({
+    phrasingContentSchema,
+}: RawTransformContext): Record<string, unknown> {
+    const listContentSchema: Record<string, unknown> = {
+        ...(phrasingContentSchema as Record<string, unknown>),
+        ul: {},
+        ol: { attributes: ['type', 'start', 'reversed'] },
+    };
+    (['ul', 'ol'] as const).forEach((tag) => {
+        (listContentSchema[tag] as Record<string, unknown>).children = {
+            li: { children: listContentSchema },
+        };
+    });
+    return listContentSchema;
+}
+
+function createListBlockFromDOMElement(
+    listElement: RawListElement
+): { name: string } {
+    const type = listElement.getAttribute('type');
+    const listAttributes = {
+        ordered: 'OL' === listElement.tagName,
+        anchor: listElement.id ? listElement.id : undefined,
+        start: listElement.getAttribute('start')
+            ? parseInt(listElement.getAttribute('start') as string, 10)
+            : undefined,
+        reversed: listElement.hasAttribute('reversed') ? true : undefined,
+        type: type && LIST_STYLES[type] ? LIST_STYLES[type] : undefined,
+    };
+
+    const innerBlocks = Array.from(listElement.children).map((listItem) => {
+        const itemEl = listItem as Element;
+        const children = Array.from(itemEl.childNodes).filter(
+            (node) =>
+                node.nodeType !== Node.TEXT_NODE ||
+                (node.textContent ?? '').trim().length !== 0
+        );
+        children.reverse();
+        const [nestedList, ...nodes] = children as Element[];
+
+        const hasNestedList =
+            (nestedList as Element)?.tagName === 'UL' ||
+            (nestedList as Element)?.tagName === 'OL';
+
+        if (!hasNestedList) {
+            return createBlock('artisanpack/list-item', {
+                content: itemEl.innerHTML,
+            });
+        }
+
+        const htmlNodes = nodes.map((node) => {
+            if (node.nodeType === Node.TEXT_NODE) {
+                return node.textContent ?? '';
+            }
+            return (node as Element).outerHTML;
+        });
+        htmlNodes.reverse();
+        const childAttributes = { content: htmlNodes.join('').trim() };
+        const childInnerBlocks = [
+            createListBlockFromDOMElement(
+                nestedList as unknown as RawListElement
+            ),
+        ];
+        return createBlock(
+            'artisanpack/list-item',
+            childAttributes,
+            childInnerBlocks as unknown[]
+        );
+    });
+
+    return createBlock(name, listAttributes, innerBlocks as unknown[]);
+}
+
+function getListContentFlat(
+    blocks: Array<{
+        name: string;
+        attributes: Record<string, unknown>;
+        innerBlocks?: unknown[];
+    }>
+): string[] {
+    return blocks.flatMap(({ name: blockName, attributes, innerBlocks = [] }) => {
+        if (blockName === 'artisanpack/list-item' || blockName === 'core/list-item') {
+            return [
+                String(attributes.content ?? ''),
+                ...getListContentFlat(
+                    innerBlocks as Array<{
+                        name: string;
+                        attributes: Record<string, unknown>;
+                        innerBlocks?: unknown[];
+                    }>
+                ),
+            ];
+        }
+        return getListContentFlat(
+            innerBlocks as Array<{
+                name: string;
+                attributes: Record<string, unknown>;
+                innerBlocks?: unknown[];
+            }>
+        );
+    });
+}
+
+const transforms = {
+    from: [
+        {
+            type: 'block',
+            isMultiBlock: true,
+            blocks: [
+                'core/paragraph',
+                'core/heading',
+                'artisanpack/paragraph',
+                'artisanpack/heading',
+            ],
+            transform: (blockAttributes: ListAttributes[]) => {
+                let childBlocks: unknown[] = [];
+                if (blockAttributes.length > 1) {
+                    childBlocks = blockAttributes.map(({ content }) =>
+                        createBlock('artisanpack/list-item', { content })
+                    );
+                } else if (blockAttributes.length === 1) {
+                    const value = create({ html: blockAttributes[0].content });
+                    childBlocks = split(value, '\n').map((result) =>
+                        createBlock('artisanpack/list-item', {
+                            content: toHTMLString({ value: result }),
+                        })
+                    );
+                }
+                return createBlock(
+                    name,
+                    { anchor: blockAttributes[0]?.anchor },
+                    childBlocks
+                );
+            },
+        },
+        {
+            type: 'raw',
+            selector: 'ol,ul',
+            schema: (args: RawTransformContext) => ({
+                ol: (getListContentSchema(args) as { ol: unknown }).ol,
+                ul: (getListContentSchema(args) as { ul: unknown }).ul,
+            }),
+            transform: createListBlockFromDOMElement,
+        },
+        ...['*', '-'].map((prefix) => ({
+            type: 'prefix' as const,
+            prefix,
+            transform(content: string) {
+                return createBlock(name, {}, [
+                    createBlock('artisanpack/list-item', { content }),
+                ]);
+            },
+        })),
+        ...['1.', '1)'].map((prefix) => ({
+            type: 'prefix' as const,
+            prefix,
+            transform(content: string) {
+                return createBlock(name, { ordered: true }, [
+                    createBlock('artisanpack/list-item', { content }),
+                ]);
+            },
+        })),
+        {
+            type: 'block',
+            blocks: ['core/list'],
+            transform: (
+                attributes: ListAttributes,
+                innerBlocks: Array<{
+                    name: string;
+                    attributes: Record<string, unknown>;
+                    innerBlocks: unknown[];
+                }>
+            ) =>
+                createBlock(name, attributes, innerBlocks),
+        },
+    ],
+    to: [
+        ...['core/paragraph', 'core/heading'].map((blockName) => ({
+            type: 'block' as const,
+            blocks: [blockName],
+            transform: (
+                _attributes: ListAttributes,
+                childBlocks: Array<{
+                    name: string;
+                    attributes: Record<string, unknown>;
+                    innerBlocks?: unknown[];
+                }>
+            ) => {
+                return getListContentFlat(childBlocks).map((content) =>
+                    createBlock(blockName, { content })
+                );
+            },
+        })),
+        {
+            type: 'block',
+            blocks: ['core/list'],
+            transform: (
+                attributes: ListAttributes,
+                innerBlocks: Array<unknown>
+            ) => createBlock('core/list', attributes, innerBlocks),
+        },
+    ],
+};
+
+export default transforms;

--- a/resources/js/visual-editor/blocks/list/upstream-diff-report.json
+++ b/resources/js/visual-editor/blocks/list/upstream-diff-report.json
@@ -36,7 +36,7 @@
             "status": "adapted",
             "notes": "Full 4-entry chain ported (v3 → v0). `migrateToListV2` rewritten to a lightweight DOM parse — upstream uses `rawHandler` which would pull the entire paste pipeline.",
             "result": "skipped-status",
-            "forkDigest": "4f50203b33e2"
+            "forkDigest": "de1dc9a0ceab"
         },
         {
             "fork": "transforms.ts",
@@ -44,7 +44,7 @@
             "status": "extended",
             "notes": "Upstream paragraph/heading/raw/prefix transforms preserved; added bidirectional core/list ↔ artisanpack/list. Raw transform creates artisanpack/list-item inner blocks.",
             "result": "skipped-status",
-            "forkDigest": "273bf647c60a"
+            "forkDigest": "d527a2b8e5d2"
         },
         {
             "fork": "list.css",

--- a/resources/js/visual-editor/blocks/list/upstream-diff-report.json
+++ b/resources/js/visual-editor/blocks/list/upstream-diff-report.json
@@ -1,0 +1,74 @@
+{
+    "block": "list",
+    "status": "in-sync",
+    "upstream": {
+        "pinnedVersion": "9.43.0",
+        "subpath": "list"
+    },
+    "files": [
+        {
+            "fork": "block.json",
+            "upstream": "block.json",
+            "status": "adapted",
+            "notes": "name + textdomain swapped; allowedBlocks updated to artisanpack/list-item.",
+            "result": "skipped-status",
+            "forkDigest": "be992d451934"
+        },
+        {
+            "fork": "edit.tsx",
+            "upstream": "edit.js",
+            "status": "rewritten",
+            "notes": "Simplified edit. Upstream's indent/outdent toolbar reaches into private block-editor dispatch surface (replaceBlocks via useOutdentList hook) — deferred to post-I7 customization. The Unordered/Ordered toggle and ordered-list settings panel are preserved. Inner-block template uses artisanpack/list-item.",
+            "result": "skipped-status",
+            "forkDigest": "d759cb75e642"
+        },
+        {
+            "fork": "save.tsx",
+            "upstream": "save.js",
+            "status": "adapted",
+            "notes": "TypeScript port; verbatim.",
+            "result": "skipped-status",
+            "forkDigest": "0f33f88e9450"
+        },
+        {
+            "fork": "deprecated.tsx",
+            "upstream": "deprecated.js",
+            "status": "adapted",
+            "notes": "Full 4-entry chain ported (v3 → v0). `migrateToListV2` rewritten to a lightweight DOM parse — upstream uses `rawHandler` which would pull the entire paste pipeline.",
+            "result": "skipped-status",
+            "forkDigest": "4f50203b33e2"
+        },
+        {
+            "fork": "transforms.ts",
+            "upstream": "transforms.js",
+            "status": "extended",
+            "notes": "Upstream paragraph/heading/raw/prefix transforms preserved; added bidirectional core/list ↔ artisanpack/list. Raw transform creates artisanpack/list-item inner blocks.",
+            "result": "skipped-status",
+            "forkDigest": "273bf647c60a"
+        },
+        {
+            "fork": "list.css",
+            "upstream": "style.scss",
+            "status": "adapted",
+            "notes": "Sass variables resolved inline.",
+            "result": "skipped-status",
+            "forkDigest": "3f61e3772031"
+        },
+        {
+            "fork": "inserter-icon.tsx",
+            "upstream": "n/a",
+            "status": "added",
+            "notes": "Inline SVG.",
+            "result": "skipped-status",
+            "forkDigest": "afb5d34a5859"
+        },
+        {
+            "fork": "index.ts",
+            "upstream": "index.js",
+            "status": "rewritten",
+            "notes": "Auto-discovery contract.",
+            "result": "skipped-status",
+            "forkDigest": "110c15543f0c"
+        }
+    ]
+}

--- a/resources/js/visual-editor/blocks/list/upstream-state.json
+++ b/resources/js/visual-editor/blocks/list/upstream-state.json
@@ -1,0 +1,41 @@
+{
+    "$schema": "../../../../scripts/upstream-state.schema.json",
+    "block": "artisanpack/list",
+    "upstream": {
+        "package": "@wordpress/block-library",
+        "namespace": "core/list",
+        "pinnedVersion": "9.43.0",
+        "subpath": "list"
+    },
+    "forkedAt": "2026-05-27",
+    "$statusLegend": {
+        "ported": "byte-equivalent to upstream (CI fails on drift)",
+        "adapted": "TypeScript port and/or namespace swap; logically equivalent",
+        "extended": "fork adds behavior on top of upstream",
+        "rewritten": "fork replaced upstream entirely",
+        "added": "file unique to the fork (no upstream)"
+    },
+    "files": [
+        { "fork": "block.json", "upstream": "block.json", "status": "adapted", "notes": "name + textdomain swapped; allowedBlocks updated to artisanpack/list-item." },
+        { "fork": "edit.tsx", "upstream": "edit.js", "status": "rewritten", "notes": "Simplified edit. Upstream's indent/outdent toolbar reaches into private block-editor dispatch surface (replaceBlocks via useOutdentList hook) — deferred to post-I7 customization. The Unordered/Ordered toggle and ordered-list settings panel are preserved. Inner-block template uses artisanpack/list-item." },
+        { "fork": "save.tsx", "upstream": "save.js", "status": "adapted", "notes": "TypeScript port; verbatim." },
+        { "fork": "deprecated.tsx", "upstream": "deprecated.js", "status": "adapted", "notes": "Full 4-entry chain ported (v3 → v0). `migrateToListV2` rewritten to a lightweight DOM parse — upstream uses `rawHandler` which would pull the entire paste pipeline." },
+        { "fork": "transforms.ts", "upstream": "transforms.js", "status": "extended", "notes": "Upstream paragraph/heading/raw/prefix transforms preserved; added bidirectional core/list ↔ artisanpack/list. Raw transform creates artisanpack/list-item inner blocks." },
+        { "fork": "list.css", "upstream": "style.scss", "status": "adapted", "notes": "Sass variables resolved inline." },
+        { "fork": "inserter-icon.tsx", "upstream": "n/a", "status": "added", "notes": "Inline SVG." },
+        { "fork": "index.ts", "upstream": "index.js", "status": "rewritten", "notes": "Auto-discovery contract." }
+    ],
+    "vendoredPrimitives": [
+        "_shared/migrate-font-family.ts"
+    ],
+    "knownDivergences": [
+        "edit.tsx ships a simpler edit experience — no indent/outdent toolbar. Save shape is byte-equivalent so host content deserializes correctly.",
+        "deprecated.tsx `migrateToListV2` uses a direct DOM parse instead of `rawHandler`. The migration outcome is equivalent for well-formed list markup.",
+        "transforms.ts adds bidirectional block transforms with core/list and produces artisanpack/list-item innerBlocks."
+    ],
+    "triage": {
+        "label": "in-sync",
+        "lastReviewed": "2026-05-27",
+        "reviewer": "I1 content cluster"
+    }
+}

--- a/resources/js/visual-editor/blocks/preformatted/__tests__/deprecated.test.tsx
+++ b/resources/js/visual-editor/blocks/preformatted/__tests__/deprecated.test.tsx
@@ -1,0 +1,14 @@
+/**
+ * Locks the (empty) deprecation chain for `artisanpack/preformatted`.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import deprecated from '../deprecated';
+
+describe('preformatted deprecation chain', () => {
+    it('matches upstream (empty)', () => {
+        expect(Array.isArray(deprecated)).toBe(true);
+        expect(deprecated).toHaveLength(0);
+    });
+});

--- a/resources/js/visual-editor/blocks/preformatted/__tests__/edit.test.tsx
+++ b/resources/js/visual-editor/blocks/preformatted/__tests__/edit.test.tsx
@@ -1,0 +1,71 @@
+/**
+ * Tests for the `artisanpack/preformatted` edit component.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+vi.mock('@wordpress/i18n', () => ({
+    __: (text: string) => text,
+}));
+
+vi.mock('@wordpress/blocks', () => ({
+    createBlock: vi.fn(),
+    getDefaultBlockName: () => 'core/paragraph',
+}));
+
+vi.mock('@wordpress/block-editor', () => ({
+    useBlockProps: Object.assign(
+        (props?: Record<string, unknown>) => ({ ...props }),
+        { save: (props?: Record<string, unknown>) => ({ ...props }) }
+    ),
+    RichText: function RichText(props: {
+        value?: string;
+        onChange?: (v: string) => void;
+        placeholder?: string;
+    }) {
+        return (
+            <div
+                role="textbox"
+                aria-label="preformatted-rich-text"
+                data-placeholder={props.placeholder}
+                onClick={() => props.onChange?.('multi\nline')}
+                dangerouslySetInnerHTML={{ __html: props.value ?? '' }}
+            />
+        );
+    },
+}));
+
+import PreformattedEdit from '../edit';
+
+describe('PreformattedEdit', () => {
+    it('renders a pre RichText with the right placeholder', () => {
+        const setAttributes = vi.fn();
+        render(
+            <PreformattedEdit
+                attributes={{ content: '' }}
+                setAttributes={setAttributes}
+            />
+        );
+        const textbox = screen.getByRole('textbox', {
+            name: 'preformatted-rich-text',
+        });
+        expect(textbox.getAttribute('data-placeholder')).toBe(
+            'Write preformatted text…'
+        );
+    });
+
+    it('forwards changes to setAttributes', () => {
+        const setAttributes = vi.fn();
+        render(
+            <PreformattedEdit
+                attributes={{ content: '' }}
+                setAttributes={setAttributes}
+            />
+        );
+        fireEvent.click(
+            screen.getByRole('textbox', { name: 'preformatted-rich-text' })
+        );
+        expect(setAttributes).toHaveBeenCalledWith({ content: 'multi\nline' });
+    });
+});

--- a/resources/js/visual-editor/blocks/preformatted/__tests__/save.test.tsx
+++ b/resources/js/visual-editor/blocks/preformatted/__tests__/save.test.tsx
@@ -1,0 +1,44 @@
+/**
+ * Tests for the `artisanpack/preformatted` save component.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+vi.mock('@wordpress/block-editor', () => ({
+    useBlockProps: Object.assign(
+        (props?: Record<string, unknown>) => ({ ...props }),
+        { save: (props?: Record<string, unknown>) => ({ ...props }) }
+    ),
+    RichText: Object.assign(() => null, {
+        Content: ({ value }: { value?: string }) =>
+            value !== undefined && value !== ''
+                ? <span dangerouslySetInnerHTML={{ __html: value }} />
+                : null,
+    }),
+}));
+
+import PreformattedSave from '../save';
+import metadata from '../block.json';
+
+describe('artisanpack/preformatted block.json', () => {
+    it('declares the artisanpack namespace', () => {
+        expect(metadata.name).toBe('artisanpack/preformatted');
+        expect(metadata.category).toBe('text');
+    });
+
+    it('content attribute uses the pre selector with preserveWhiteSpace', () => {
+        expect(metadata.attributes.content.selector).toBe('pre');
+        expect(metadata.attributes.content.__unstablePreserveWhiteSpace).toBe(true);
+    });
+});
+
+describe('PreformattedSave', () => {
+    it('renders a pre tag', () => {
+        const html = renderToStaticMarkup(
+            <PreformattedSave attributes={{ content: 'hello\nworld' }} />
+        );
+        expect(html).toContain('<pre');
+        expect(html).toContain('hello');
+    });
+});

--- a/resources/js/visual-editor/blocks/preformatted/__tests__/transforms.test.ts
+++ b/resources/js/visual-editor/blocks/preformatted/__tests__/transforms.test.ts
@@ -24,13 +24,15 @@ describe('preformatted transforms', () => {
         const fromBlock = transforms.from.find(
             (t: { type: string; blocks?: string[] }) =>
                 t.type === 'block' && t.blocks?.includes('core/paragraph')
-        ) as {
+        );
+        expect(fromBlock).toBeDefined();
+        const typed = fromBlock as {
             transform: (a: Record<string, unknown>) => {
                 name: string;
                 attributes: Record<string, unknown>;
             };
         };
-        const result = fromBlock.transform({ content: 'x', anchor: 'a' });
+        const result = typed.transform({ content: 'x', anchor: 'a' });
         expect(result.name).toBe('artisanpack/preformatted');
         expect(result.attributes).toEqual({ content: 'x', anchor: 'a' });
     });
@@ -41,19 +43,23 @@ describe('preformatted transforms', () => {
                 t.type === 'block' &&
                 t.blocks?.length === 1 &&
                 t.blocks[0] === 'core/preformatted'
-        ) as {
+        );
+        expect(fromBlock).toBeDefined();
+        const typed = fromBlock as {
             transform: (a: Record<string, unknown>) => { name: string };
         };
-        expect(fromBlock.transform({}).name).toBe('artisanpack/preformatted');
+        expect(typed.transform({}).name).toBe('artisanpack/preformatted');
     });
 
     it('block transform to core/preformatted', () => {
         const toBlock = transforms.to.find(
             (t: { type: string; blocks?: string[] }) =>
-                t.type === 'block' && t.blocks?.[0] === 'core/preformatted'
-        ) as {
+                t.type === 'block' && t.blocks?.includes('core/preformatted')
+        );
+        expect(toBlock).toBeDefined();
+        const typed = toBlock as {
             transform: (a: Record<string, unknown>) => { name: string };
         };
-        expect(toBlock.transform({}).name).toBe('core/preformatted');
+        expect(typed.transform({}).name).toBe('core/preformatted');
     });
 });

--- a/resources/js/visual-editor/blocks/preformatted/__tests__/transforms.test.ts
+++ b/resources/js/visual-editor/blocks/preformatted/__tests__/transforms.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Transforms tests for `artisanpack/preformatted`.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@wordpress/blocks', () => ({
+    createBlock: (name: string, attributes?: Record<string, unknown>) => ({
+        name,
+        attributes: attributes ?? {},
+        innerBlocks: [],
+    }),
+}));
+
+import transforms from '../transforms';
+
+describe('preformatted transforms', () => {
+    it('declares from/to arrays', () => {
+        expect(Array.isArray(transforms.from)).toBe(true);
+        expect(Array.isArray(transforms.to)).toBe(true);
+    });
+
+    it('paragraph → preformatted preserves content + anchor', () => {
+        const fromBlock = transforms.from.find(
+            (t: { type: string; blocks?: string[] }) =>
+                t.type === 'block' && t.blocks?.includes('core/paragraph')
+        ) as {
+            transform: (a: Record<string, unknown>) => {
+                name: string;
+                attributes: Record<string, unknown>;
+            };
+        };
+        const result = fromBlock.transform({ content: 'x', anchor: 'a' });
+        expect(result.name).toBe('artisanpack/preformatted');
+        expect(result.attributes).toEqual({ content: 'x', anchor: 'a' });
+    });
+
+    it('block transform from core/preformatted → artisanpack/preformatted', () => {
+        const fromBlock = transforms.from.find(
+            (t: { type: string; blocks?: string[] }) =>
+                t.type === 'block' &&
+                t.blocks?.length === 1 &&
+                t.blocks[0] === 'core/preformatted'
+        ) as {
+            transform: (a: Record<string, unknown>) => { name: string };
+        };
+        expect(fromBlock.transform({}).name).toBe('artisanpack/preformatted');
+    });
+
+    it('block transform to core/preformatted', () => {
+        const toBlock = transforms.to.find(
+            (t: { type: string; blocks?: string[] }) =>
+                t.type === 'block' && t.blocks?.[0] === 'core/preformatted'
+        ) as {
+            transform: (a: Record<string, unknown>) => { name: string };
+        };
+        expect(toBlock.transform({}).name).toBe('core/preformatted');
+    });
+});

--- a/resources/js/visual-editor/blocks/preformatted/block.json
+++ b/resources/js/visual-editor/blocks/preformatted/block.json
@@ -1,0 +1,61 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "artisanpack/preformatted",
+    "title": "Preformatted",
+    "category": "text",
+    "description": "Add text that respects your spacing and tabs, and also allows styling.",
+    "textdomain": "artisanpack-visual-editor",
+    "attributes": {
+        "content": {
+            "type": "rich-text",
+            "source": "rich-text",
+            "selector": "pre",
+            "__unstablePreserveWhiteSpace": true,
+            "role": "content"
+        }
+    },
+    "supports": {
+        "anchor": true,
+        "color": {
+            "gradients": true,
+            "__experimentalDefaultControls": {
+                "background": true,
+                "text": true
+            }
+        },
+        "spacing": {
+            "padding": true,
+            "margin": true
+        },
+        "typography": {
+            "fontSize": true,
+            "lineHeight": true,
+            "__experimentalFontFamily": true,
+            "__experimentalFontWeight": true,
+            "__experimentalFontStyle": true,
+            "__experimentalTextTransform": true,
+            "__experimentalTextDecoration": true,
+            "__experimentalLetterSpacing": true,
+            "__experimentalDefaultControls": {
+                "fontSize": true
+            }
+        },
+        "interactivity": {
+            "clientNavigation": true
+        },
+        "__experimentalBorder": {
+            "radius": true,
+            "color": true,
+            "width": true,
+            "style": true,
+            "__experimentalDefaultControls": {
+                "radius": true,
+                "color": true,
+                "width": true,
+                "style": true
+            }
+        }
+    },
+    "style": "wp-block-preformatted"
+}

--- a/resources/js/visual-editor/blocks/preformatted/deprecated.tsx
+++ b/resources/js/visual-editor/blocks/preformatted/deprecated.tsx
@@ -1,0 +1,10 @@
+/**
+ * Preformatted — deprecation chain.
+ *
+ * Upstream `@wordpress/block-library/src/preformatted/` ships no
+ * `deprecated.js` (v9.43.0). Empty chain preserves parity.
+ */
+
+const deprecated: Array<Record<string, unknown>> = [];
+
+export default deprecated;

--- a/resources/js/visual-editor/blocks/preformatted/edit.tsx
+++ b/resources/js/visual-editor/blocks/preformatted/edit.tsx
@@ -1,0 +1,59 @@
+/**
+ * Preformatted — editor-side render.
+ *
+ * Ported from `@wordpress/block-library/src/preformatted/edit.js` (v9.43.0).
+ */
+
+import type { ReactElement } from 'react';
+import { __ } from '@wordpress/i18n';
+import { RichText, useBlockProps } from '@wordpress/block-editor';
+import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
+
+interface PreformattedAttributes {
+    readonly content: string;
+}
+
+interface PreformattedEditProps {
+    readonly attributes: PreformattedAttributes;
+    readonly setAttributes: (next: Partial<PreformattedAttributes>) => void;
+    readonly mergeBlocks?: (forward?: boolean) => void;
+    readonly onRemove?: () => void;
+    readonly insertBlocksAfter?: (block: unknown) => void;
+    readonly style?: Record<string, unknown>;
+}
+
+export default function PreformattedEdit({
+    attributes,
+    mergeBlocks,
+    setAttributes,
+    onRemove,
+    insertBlocksAfter,
+    style,
+}: PreformattedEditProps): ReactElement {
+    const { content } = attributes;
+    const blockProps = useBlockProps({ style });
+
+    return (
+        <RichText
+            tagName="pre"
+            identifier="content"
+            preserveWhiteSpace
+            value={content}
+            onChange={(nextContent: string) =>
+                setAttributes({ content: nextContent })
+            }
+            onRemove={onRemove}
+            aria-label={__('Preformatted text')}
+            placeholder={__('Write preformatted text…')}
+            onMerge={mergeBlocks}
+            {...blockProps}
+            __unstablePastePlainText
+            __unstableOnSplitAtDoubleLineEnd={() => {
+                const defaultName = getDefaultBlockName();
+                if (defaultName) {
+                    insertBlocksAfter?.(createBlock(defaultName));
+                }
+            }}
+        />
+    );
+}

--- a/resources/js/visual-editor/blocks/preformatted/index.ts
+++ b/resources/js/visual-editor/blocks/preformatted/index.ts
@@ -1,0 +1,26 @@
+/**
+ * Preformatted block entrypoint.
+ *
+ * Fork target: V2 block-fork phase I1 (content cluster, issue #409).
+ */
+
+import metadata from './block.json';
+import edit from './edit';
+import save from './save';
+import deprecated from './deprecated';
+import transforms from './transforms';
+import icon from './inserter-icon';
+
+import './preformatted.css';
+
+export { edit, save, metadata, icon, deprecated, transforms };
+
+export default {
+    name: metadata.name,
+    metadata,
+    edit,
+    save,
+    icon,
+    deprecated,
+    transforms,
+};

--- a/resources/js/visual-editor/blocks/preformatted/inserter-icon.tsx
+++ b/resources/js/visual-editor/blocks/preformatted/inserter-icon.tsx
@@ -1,0 +1,19 @@
+/**
+ * Preformatted — inserter icon.
+ */
+
+import type { ReactElement } from 'react';
+
+export default function PreformattedInserterIcon(): ReactElement {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            width={24}
+            height={24}
+            aria-hidden="true"
+        >
+            <path d="M19 4H5a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2zm.5 14a.5.5 0 0 1-.5.5H5a.5.5 0 0 1-.5-.5V6a.5.5 0 0 1 .5-.5h14a.5.5 0 0 1 .5.5v12zM6 10.5h2V12H6zm0 3.5h2v1.5H6zm3.5-3.5h9V12h-9zm0 3.5h9v1.5h-9zM6 7h12v1.5H6z" />
+        </svg>
+    );
+}

--- a/resources/js/visual-editor/blocks/preformatted/preformatted.css
+++ b/resources/js/visual-editor/blocks/preformatted/preformatted.css
@@ -1,0 +1,16 @@
+/*
+ * Preformatted — frontend styles.
+ *
+ * Ported from `@wordpress/block-library/src/preformatted/style.scss`
+ * (v9.43.0). Sass variable `$block-bg-padding--v / --h` resolved inline
+ * to 1.25em / 2.375em (matching paragraph and heading forks).
+ */
+
+.wp-block-preformatted {
+    box-sizing: border-box;
+    white-space: pre-wrap;
+}
+
+:where(.wp-block-preformatted.has-background) {
+    padding: 1.25em 2.375em;
+}

--- a/resources/js/visual-editor/blocks/preformatted/save.tsx
+++ b/resources/js/visual-editor/blocks/preformatted/save.tsx
@@ -1,0 +1,28 @@
+/**
+ * Preformatted — saved markup.
+ *
+ * Ported from `@wordpress/block-library/src/preformatted/save.js` (v9.43.0).
+ */
+
+import type { ReactElement } from 'react';
+import { RichText, useBlockProps } from '@wordpress/block-editor';
+
+interface PreformattedSaveAttributes {
+    readonly content: string;
+}
+
+interface PreformattedSaveProps {
+    readonly attributes: PreformattedSaveAttributes;
+}
+
+export default function PreformattedSave({
+    attributes,
+}: PreformattedSaveProps): ReactElement {
+    const { content } = attributes;
+
+    return (
+        <pre {...useBlockProps.save()}>
+            <RichText.Content value={content} />
+        </pre>
+    );
+}

--- a/resources/js/visual-editor/blocks/preformatted/transforms.ts
+++ b/resources/js/visual-editor/blocks/preformatted/transforms.ts
@@ -1,0 +1,95 @@
+/**
+ * Preformatted — transforms.
+ *
+ * Ported from `@wordpress/block-library/src/preformatted/transforms.js`
+ * (v9.43.0). Extended with bidirectional block transforms for
+ * `core/preformatted` ↔ `artisanpack/preformatted`.
+ */
+
+import { createBlock } from '@wordpress/blocks';
+
+import metadata from './block.json';
+
+const { name } = metadata;
+
+interface PreformattedAttributes {
+    content?: string;
+    anchor?: string;
+    [key: string]: unknown;
+}
+
+interface RawTransformNode {
+    readonly nodeName: string;
+    readonly children: { readonly length: number };
+    readonly firstChild: { readonly nodeName: string };
+}
+
+interface RawTransformContext {
+    readonly phrasingContentSchema: unknown;
+}
+
+const transforms = {
+    from: [
+        {
+            type: 'block',
+            blocks: [
+                'core/code',
+                'core/paragraph',
+                'core/verse',
+                'artisanpack/code',
+                'artisanpack/paragraph',
+                'artisanpack/verse',
+            ],
+            transform: ({ content, anchor }: PreformattedAttributes) =>
+                createBlock(name, { content, anchor }),
+        },
+        {
+            type: 'raw',
+            isMatch: (node: RawTransformNode) =>
+                node.nodeName === 'PRE' &&
+                !(
+                    node.children.length === 1 &&
+                    node.firstChild.nodeName === 'CODE'
+                ),
+            schema: ({ phrasingContentSchema }: RawTransformContext) => ({
+                pre: {
+                    children: phrasingContentSchema,
+                },
+            }),
+        },
+        {
+            type: 'block',
+            blocks: ['core/preformatted'],
+            transform: (attributes: PreformattedAttributes) =>
+                createBlock(name, attributes),
+        },
+    ],
+    to: [
+        {
+            type: 'block',
+            blocks: ['core/paragraph'],
+            transform: (attributes: PreformattedAttributes) =>
+                createBlock('core/paragraph', attributes),
+        },
+        {
+            type: 'block',
+            blocks: ['core/code'],
+            transform: (attributes: PreformattedAttributes) =>
+                createBlock('core/code', attributes),
+        },
+        {
+            type: 'block',
+            blocks: ['core/verse'],
+            transform: (attributes: PreformattedAttributes) =>
+                createBlock('core/verse', attributes),
+        },
+        {
+            type: 'block',
+            blocks: ['core/preformatted'],
+            transform: (attributes: PreformattedAttributes) =>
+                createBlock('core/preformatted', attributes),
+        },
+    ],
+};
+
+export default transforms;

--- a/resources/js/visual-editor/blocks/preformatted/upstream-diff-report.json
+++ b/resources/js/visual-editor/blocks/preformatted/upstream-diff-report.json
@@ -1,0 +1,74 @@
+{
+    "block": "preformatted",
+    "status": "in-sync",
+    "upstream": {
+        "pinnedVersion": "9.43.0",
+        "subpath": "preformatted"
+    },
+    "files": [
+        {
+            "fork": "block.json",
+            "upstream": "block.json",
+            "status": "adapted",
+            "notes": "name + textdomain swapped.",
+            "result": "skipped-status",
+            "forkDigest": "466f47c6524e"
+        },
+        {
+            "fork": "edit.tsx",
+            "upstream": "edit.js",
+            "status": "adapted",
+            "notes": "TypeScript port; semantics verbatim.",
+            "result": "skipped-status",
+            "forkDigest": "1de53881dfa8"
+        },
+        {
+            "fork": "save.tsx",
+            "upstream": "save.js",
+            "status": "adapted",
+            "notes": "TypeScript port; semantics verbatim.",
+            "result": "skipped-status",
+            "forkDigest": "9d92de9b278f"
+        },
+        {
+            "fork": "deprecated.tsx",
+            "upstream": "n/a",
+            "status": "added",
+            "notes": "No upstream deprecation chain; empty array preserves the file shape.",
+            "result": "skipped-status",
+            "forkDigest": "84e634d2530d"
+        },
+        {
+            "fork": "transforms.ts",
+            "upstream": "transforms.js",
+            "status": "extended",
+            "notes": "Upstream raw/block transforms preserved; added bidirectional core/preformatted ↔ artisanpack/preformatted and accepts artisanpack/code, artisanpack/paragraph, artisanpack/verse as from-sources.",
+            "result": "skipped-status",
+            "forkDigest": "ef4d93815ece"
+        },
+        {
+            "fork": "preformatted.css",
+            "upstream": "style.scss",
+            "status": "adapted",
+            "notes": "Sass variables resolved inline.",
+            "result": "skipped-status",
+            "forkDigest": "2c4f11fb226e"
+        },
+        {
+            "fork": "inserter-icon.tsx",
+            "upstream": "n/a",
+            "status": "added",
+            "notes": "Inline SVG.",
+            "result": "skipped-status",
+            "forkDigest": "036764c60981"
+        },
+        {
+            "fork": "index.ts",
+            "upstream": "index.js",
+            "status": "rewritten",
+            "notes": "Auto-discovery contract.",
+            "result": "skipped-status",
+            "forkDigest": "1ce5fac20a16"
+        }
+    ]
+}

--- a/resources/js/visual-editor/blocks/preformatted/upstream-state.json
+++ b/resources/js/visual-editor/blocks/preformatted/upstream-state.json
@@ -1,0 +1,37 @@
+{
+    "$schema": "../../../../scripts/upstream-state.schema.json",
+    "block": "artisanpack/preformatted",
+    "upstream": {
+        "package": "@wordpress/block-library",
+        "namespace": "core/preformatted",
+        "pinnedVersion": "9.43.0",
+        "subpath": "preformatted"
+    },
+    "forkedAt": "2026-05-27",
+    "$statusLegend": {
+        "ported": "byte-equivalent to upstream (CI fails on drift)",
+        "adapted": "TypeScript port and/or namespace swap; logically equivalent",
+        "extended": "fork adds behavior on top of upstream",
+        "rewritten": "fork replaced upstream entirely",
+        "added": "file unique to the fork (no upstream)"
+    },
+    "files": [
+        { "fork": "block.json", "upstream": "block.json", "status": "adapted", "notes": "name + textdomain swapped." },
+        { "fork": "edit.tsx", "upstream": "edit.js", "status": "adapted", "notes": "TypeScript port; semantics verbatim." },
+        { "fork": "save.tsx", "upstream": "save.js", "status": "adapted", "notes": "TypeScript port; semantics verbatim." },
+        { "fork": "deprecated.tsx", "upstream": "n/a", "status": "added", "notes": "No upstream deprecation chain; empty array preserves the file shape." },
+        { "fork": "transforms.ts", "upstream": "transforms.js", "status": "extended", "notes": "Upstream raw/block transforms preserved; added bidirectional core/preformatted ↔ artisanpack/preformatted and accepts artisanpack/code, artisanpack/paragraph, artisanpack/verse as from-sources." },
+        { "fork": "preformatted.css", "upstream": "style.scss", "status": "adapted", "notes": "Sass variables resolved inline." },
+        { "fork": "inserter-icon.tsx", "upstream": "n/a", "status": "added", "notes": "Inline SVG." },
+        { "fork": "index.ts", "upstream": "index.js", "status": "rewritten", "notes": "Auto-discovery contract." }
+    ],
+    "vendoredPrimitives": [],
+    "knownDivergences": [
+        "transforms.ts adds bidirectional core/preformatted ↔ artisanpack/preformatted."
+    ],
+    "triage": {
+        "label": "in-sync",
+        "lastReviewed": "2026-05-27",
+        "reviewer": "I1 content cluster"
+    }
+}

--- a/resources/js/visual-editor/blocks/pullquote/__tests__/deprecated.test.tsx
+++ b/resources/js/visual-editor/blocks/pullquote/__tests__/deprecated.test.tsx
@@ -1,0 +1,73 @@
+/**
+ * Locks the deprecation chain for `artisanpack/pullquote`.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+vi.mock('@wordpress/block-editor', () => ({
+    useBlockProps: Object.assign(
+        (props?: Record<string, unknown>) => ({ ...props }),
+        { save: (props?: Record<string, unknown>) => ({ ...props }) }
+    ),
+    RichText: Object.assign(() => null, {
+        isEmpty: (v?: string) => !v || v.length === 0,
+        Content: ({ value, tagName }: { value?: string; tagName?: string }) => {
+            const Tag = (tagName ?? 'span') as keyof JSX.IntrinsicElements;
+            return value !== undefined ? (
+                <Tag dangerouslySetInnerHTML={{ __html: value }} />
+            ) : null;
+        },
+    }),
+    getColorClassName: (prefix: string, slug?: string) =>
+        slug ? `has-${slug}-${prefix}` : undefined,
+}));
+
+import deprecated from '../deprecated';
+
+describe('pullquote deprecation chain', () => {
+    it('has 6 historical entries', () => {
+        expect(deprecated).toHaveLength(6);
+    });
+
+    it('every entry exposes a save callable', () => {
+        deprecated.forEach((entry, i) => {
+            expect(
+                typeof (entry as { save?: unknown }).save,
+                `entry ${i}`
+            ).toBe('function');
+        });
+    });
+
+    it('v5 (entries[0]) renders figure > blockquote with has-text-align-*', () => {
+        const entry = deprecated[0] as {
+            save: (p: { attributes: Record<string, unknown> }) => React.ReactElement;
+        };
+        const html = renderToStaticMarkup(
+            entry.save({
+                attributes: { textAlign: 'center', value: 'x', citation: 'A' },
+            })
+        );
+        expect(html).toContain('<figure');
+        expect(html).toContain('<blockquote');
+        expect(html).toContain('has-text-align-center');
+    });
+
+    it('v0 (entries[5]) renders citation in a footer tag', () => {
+        const entry = deprecated[5] as {
+            save: (p: { attributes: Record<string, unknown> }) => React.ReactElement;
+        };
+        const html = renderToStaticMarkup(
+            entry.save({ attributes: { value: 'x', citation: 'A', align: 'none' } })
+        );
+        expect(html).toContain('<footer');
+    });
+
+    it('v5 migrate converts multiline value to inline <br>-joined HTML', () => {
+        const entry = deprecated[0] as {
+            migrate: (a: Record<string, unknown>) => Record<string, unknown>;
+        };
+        const migrated = entry.migrate({ value: '<p>a</p><p>b</p>' });
+        expect(migrated.value).toBe('a<br>b');
+    });
+});

--- a/resources/js/visual-editor/blocks/pullquote/__tests__/edit.test.tsx
+++ b/resources/js/visual-editor/blocks/pullquote/__tests__/edit.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * Tests for the `artisanpack/pullquote` edit component.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+vi.mock('@wordpress/i18n', () => ({
+    __: (text: string) => text,
+}));
+
+vi.mock('@wordpress/blocks', () => ({
+    createBlock: vi.fn(),
+    getDefaultBlockName: () => 'core/paragraph',
+}));
+
+vi.mock('@wordpress/block-editor', () => ({
+    useBlockProps: Object.assign(
+        (props?: Record<string, unknown>) => ({ ...props }),
+        { save: (props?: Record<string, unknown>) => ({ ...props }) }
+    ),
+    AlignmentControl: ({
+        value,
+        onChange,
+    }: { value?: string; onChange: (v?: string) => void }) => (
+        <button onClick={() => onChange('right')}>
+            align:{value ?? 'none'}
+        </button>
+    ),
+    BlockControls: ({ children }: { children: React.ReactNode }) => (
+        <div>{children}</div>
+    ),
+    RichText: Object.assign(
+        function RichText(props: {
+            value?: string;
+            onChange?: (v: string) => void;
+            placeholder?: string;
+            identifier?: string;
+        }) {
+            return (
+                <div
+                    role="textbox"
+                    aria-label={`pullquote-${props.identifier}`}
+                    data-placeholder={props.placeholder}
+                    onClick={() => props.onChange?.(`new-${props.identifier}`)}
+                    dangerouslySetInnerHTML={{ __html: props.value ?? '' }}
+                />
+            );
+        },
+        { isEmpty: (v?: string) => !v || v.length === 0 }
+    ),
+}));
+
+import PullquoteEdit from '../edit';
+
+describe('PullquoteEdit', () => {
+    it('renders the value RichText with the quote placeholder', () => {
+        const setAttributes = vi.fn();
+        render(
+            <PullquoteEdit
+                attributes={{}}
+                setAttributes={setAttributes}
+                isSelected={false}
+            />
+        );
+        const valueBox = screen.getByRole('textbox', { name: 'pullquote-value' });
+        expect(valueBox.getAttribute('data-placeholder')).toBe('Add quote');
+    });
+
+    it('shows the citation RichText when selected (even with empty citation)', () => {
+        const setAttributes = vi.fn();
+        render(
+            <PullquoteEdit
+                attributes={{}}
+                setAttributes={setAttributes}
+                isSelected
+            />
+        );
+        const citeBox = screen.getByRole('textbox', {
+            name: 'pullquote-citation',
+        });
+        expect(citeBox).toBeTruthy();
+    });
+
+    it('forwards alignment changes to setAttributes', () => {
+        const setAttributes = vi.fn();
+        render(
+            <PullquoteEdit
+                attributes={{}}
+                setAttributes={setAttributes}
+                isSelected={false}
+            />
+        );
+        fireEvent.click(screen.getByText('align:none'));
+        expect(setAttributes).toHaveBeenCalledWith({ textAlign: 'right' });
+    });
+});

--- a/resources/js/visual-editor/blocks/pullquote/__tests__/save.test.tsx
+++ b/resources/js/visual-editor/blocks/pullquote/__tests__/save.test.tsx
@@ -1,0 +1,57 @@
+/**
+ * Tests for the `artisanpack/pullquote` save component.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+vi.mock('@wordpress/block-editor', () => ({
+    useBlockProps: Object.assign(
+        (props?: Record<string, unknown>) => ({ ...props }),
+        { save: (props?: Record<string, unknown>) => ({ ...props }) }
+    ),
+    RichText: Object.assign(() => null, {
+        isEmpty: (v?: string) => !v || v.length === 0,
+        Content: ({ value, tagName }: { value?: string; tagName?: string }) => {
+            const Tag = (tagName ?? 'span') as keyof JSX.IntrinsicElements;
+            return value !== undefined ? (
+                <Tag dangerouslySetInnerHTML={{ __html: value }} />
+            ) : null;
+        },
+    }),
+}));
+
+import PullquoteSave from '../save';
+import metadata from '../block.json';
+
+describe('artisanpack/pullquote block.json', () => {
+    it('declares the artisanpack namespace', () => {
+        expect(metadata.name).toBe('artisanpack/pullquote');
+        expect(metadata.category).toBe('text');
+    });
+});
+
+describe('PullquoteSave', () => {
+    it('renders a figure > blockquote > p with value', () => {
+        const html = renderToStaticMarkup(
+            <PullquoteSave attributes={{ value: 'Hi' }} />
+        );
+        expect(html).toContain('<figure');
+        expect(html).toContain('<blockquote');
+        expect(html).toContain('<p');
+    });
+
+    it('renders citation when present', () => {
+        const html = renderToStaticMarkup(
+            <PullquoteSave attributes={{ value: 'Hi', citation: 'Author' }} />
+        );
+        expect(html).toContain('<cite');
+    });
+
+    it('adds has-text-align-* class when textAlign is set', () => {
+        const html = renderToStaticMarkup(
+            <PullquoteSave attributes={{ value: 'Hi', textAlign: 'right' }} />
+        );
+        expect(html).toContain('has-text-align-right');
+    });
+});

--- a/resources/js/visual-editor/blocks/pullquote/__tests__/transforms.test.ts
+++ b/resources/js/visual-editor/blocks/pullquote/__tests__/transforms.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Transforms tests for `artisanpack/pullquote`.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@wordpress/blocks', () => ({
+    createBlock: (name: string, attributes?: Record<string, unknown>) => ({
+        name,
+        attributes: attributes ?? {},
+        innerBlocks: [],
+    }),
+}));
+
+vi.mock('@wordpress/rich-text', () => ({
+    create: (input: { html: string }) => ({ text: input.html }),
+    join: (values: Array<{ text: string }>, sep: string) => ({
+        text: values.map((v) => v.text).join(sep),
+    }),
+    toHTMLString: ({ value }: { value: { text: string } }) => value.text,
+}));
+
+import transforms from '../transforms';
+
+describe('pullquote transforms', () => {
+    it('heading → pullquote preserves content + anchor', () => {
+        const fromBlock = transforms.from.find(
+            (t: { type: string; blocks?: string[] }) =>
+                t.type === 'block' && t.blocks?.includes('core/heading')
+        ) as {
+            transform: (a: Record<string, unknown>) => {
+                name: string;
+                attributes: Record<string, unknown>;
+            };
+        };
+        const result = fromBlock.transform({ content: 'Hi', anchor: 'a' });
+        expect(result.name).toBe('artisanpack/pullquote');
+        expect(result.attributes).toEqual({ value: 'Hi', anchor: 'a' });
+    });
+
+    it('block transform from core/pullquote → artisanpack/pullquote', () => {
+        const fromBlock = transforms.from.find(
+            (t: { type: string; blocks?: string[] }) =>
+                t.type === 'block' &&
+                t.blocks?.length === 1 &&
+                t.blocks[0] === 'core/pullquote'
+        ) as { transform: (a: Record<string, unknown>) => { name: string } };
+        expect(fromBlock.transform({}).name).toBe('artisanpack/pullquote');
+    });
+
+    it('block transform to core/pullquote', () => {
+        const toBlock = transforms.to.find(
+            (t: { type: string; blocks?: string[] }) =>
+                t.type === 'block' && t.blocks?.[0] === 'core/pullquote'
+        ) as { transform: (a: Record<string, unknown>) => { name: string } };
+        expect(toBlock.transform({}).name).toBe('core/pullquote');
+    });
+
+    it('pullquote → paragraph emits two paragraphs when both value and citation are present', () => {
+        const toBlock = transforms.to.find(
+            (t: { type: string; blocks?: string[] }) =>
+                t.type === 'block' && t.blocks?.[0] === 'core/paragraph'
+        ) as {
+            transform: (a: Record<string, unknown>) =>
+                | Array<{ name: string; attributes: Record<string, unknown> }>
+                | { name: string };
+        };
+        const result = toBlock.transform({ value: 'Hi', citation: 'Author' });
+        expect(Array.isArray(result)).toBe(true);
+        expect((result as unknown[]).length).toBe(2);
+    });
+});

--- a/resources/js/visual-editor/blocks/pullquote/block.json
+++ b/resources/js/visual-editor/blocks/pullquote/block.json
@@ -1,0 +1,92 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "artisanpack/pullquote",
+    "title": "Pullquote",
+    "category": "text",
+    "description": "Give special visual emphasis to a quote from your text.",
+    "textdomain": "artisanpack-visual-editor",
+    "attributes": {
+        "value": {
+            "type": "rich-text",
+            "source": "rich-text",
+            "selector": "p",
+            "role": "content"
+        },
+        "citation": {
+            "type": "rich-text",
+            "source": "rich-text",
+            "selector": "cite",
+            "role": "content"
+        },
+        "textAlign": {
+            "type": "string"
+        }
+    },
+    "supports": {
+        "anchor": true,
+        "align": [ "left", "right", "wide", "full" ],
+        "background": {
+            "backgroundImage": true,
+            "backgroundSize": true,
+            "__experimentalDefaultControls": {
+                "backgroundImage": true
+            }
+        },
+        "color": {
+            "gradients": true,
+            "background": true,
+            "link": true,
+            "__experimentalDefaultControls": {
+                "background": true,
+                "text": true
+            }
+        },
+        "dimensions": {
+            "minHeight": true,
+            "__experimentalDefaultControls": {
+                "minHeight": false
+            }
+        },
+        "spacing": {
+            "margin": true,
+            "padding": true
+        },
+        "typography": {
+            "fontSize": true,
+            "lineHeight": true,
+            "__experimentalFontFamily": true,
+            "__experimentalFontWeight": true,
+            "__experimentalFontStyle": true,
+            "__experimentalTextTransform": true,
+            "__experimentalTextDecoration": true,
+            "__experimentalLetterSpacing": true,
+            "__experimentalDefaultControls": {
+                "fontSize": true
+            }
+        },
+        "__experimentalBorder": {
+            "color": true,
+            "radius": true,
+            "style": true,
+            "width": true,
+            "__experimentalDefaultControls": {
+                "color": true,
+                "radius": true,
+                "style": true,
+                "width": true
+            }
+        },
+        "__experimentalStyle": {
+            "typography": {
+                "fontSize": "1.5em",
+                "lineHeight": "1.6"
+            }
+        },
+        "interactivity": {
+            "clientNavigation": true
+        }
+    },
+    "editorStyle": "wp-block-pullquote-editor",
+    "style": "wp-block-pullquote"
+}

--- a/resources/js/visual-editor/blocks/pullquote/deprecated.tsx
+++ b/resources/js/visual-editor/blocks/pullquote/deprecated.tsx
@@ -1,0 +1,483 @@
+/**
+ * Pullquote — deprecation chain.
+ *
+ * Full port of `@wordpress/block-library/src/pullquote/deprecated.js`
+ * (v9.43.0). v5 → v0 cover every historical save shape.
+ *
+ * Divergence: upstream `v2.save` calls
+ * `select(blockEditorStore).getSettings().colors` to resolve a named
+ * `mainColor` into a border-color. Calling a `select` inside `save` is
+ * an anti-pattern (save must be pure) — and reaches into block-editor
+ * private state in a way the fork can't safely depend on. v2.save in
+ * this fork omits the named-color border lookup; the migrate function
+ * still handles `mainColor` correctly. Legacy pullquote blocks that
+ * persisted a default-style + `mainColor` (no `customMainColor`) will
+ * fail v2's parity check and fall through to v1 or get re-saved as
+ * the current shape.
+ */
+
+import clsx from 'clsx';
+import {
+    getColorClassName,
+    RichText,
+    useBlockProps,
+} from '@wordpress/block-editor';
+
+import { SOLID_COLOR_CLASS } from './shared';
+
+interface LegacyPullquoteAttributes {
+    value?: string;
+    citation?: string;
+    mainColor?: string;
+    customMainColor?: string;
+    textColor?: string;
+    customTextColor?: string;
+    textAlign?: string;
+    align?: string;
+    className?: string;
+    figureStyle?: string;
+    style?: Record<string, unknown>;
+    [key: string]: unknown;
+}
+
+const blockAttributes = {
+    value: {
+        type: 'string',
+        source: 'html',
+        selector: 'blockquote',
+        multiline: 'p',
+    },
+    citation: {
+        type: 'string',
+        source: 'html',
+        selector: 'cite',
+        default: '',
+    },
+    mainColor: { type: 'string' },
+    customMainColor: { type: 'string' },
+    textColor: { type: 'string' },
+    customTextColor: { type: 'string' },
+} as const;
+
+function parseBorderColor(styleString: string | undefined): string | undefined {
+    if (!styleString) {
+        return undefined;
+    }
+    const matches = styleString.match(/border-color:([^;]+)[;]?/);
+    if (matches && matches[1]) {
+        return matches[1];
+    }
+    return undefined;
+}
+
+function multilineToInline(value: string | undefined): string {
+    const safeValue = value || '<p></p>';
+    const padded = `</p>${safeValue}<p>`;
+    const values = padded.split('</p><p>');
+    values.shift();
+    values.pop();
+    return values.join('<br>');
+}
+
+const v5 = {
+    attributes: {
+        value: {
+            type: 'string',
+            source: 'html',
+            selector: 'blockquote',
+            multiline: 'p',
+            role: 'content',
+        },
+        citation: {
+            type: 'string',
+            source: 'html',
+            selector: 'cite',
+            default: '',
+            role: 'content',
+        },
+        textAlign: { type: 'string' },
+    },
+    supports: {
+        anchor: true,
+        align: ['left', 'right', 'wide', 'full'],
+        color: {
+            gradients: true,
+            background: true,
+            link: true,
+        },
+        typography: { fontSize: true, lineHeight: true },
+        __experimentalBorder: { color: true, radius: true, style: true, width: true },
+    },
+    save({ attributes }: { attributes: LegacyPullquoteAttributes }) {
+        const { textAlign, citation, value } = attributes;
+        const shouldShowCitation = !RichText.isEmpty(citation);
+        return (
+            <figure
+                {...useBlockProps.save({
+                    className: clsx({
+                        [`has-text-align-${textAlign}`]: textAlign,
+                    }),
+                })}
+            >
+                <blockquote>
+                    <RichText.Content value={value} multiline />
+                    {shouldShowCitation && (
+                        <RichText.Content tagName="cite" value={citation} />
+                    )}
+                </blockquote>
+            </figure>
+        );
+    },
+    migrate({ value, ...attributes }: LegacyPullquoteAttributes) {
+        return {
+            value: multilineToInline(value),
+            ...attributes,
+        };
+    },
+};
+
+const v4 = {
+    attributes: { ...blockAttributes },
+    supports: {
+        anchor: true,
+        align: ['left', 'right', 'wide', 'full'],
+        color: { gradients: true, background: true, link: true },
+        __experimentalBorder: { color: true, radius: true, style: true, width: true },
+    },
+    save({ attributes }: { attributes: LegacyPullquoteAttributes }) {
+        const {
+            mainColor,
+            customMainColor,
+            customTextColor,
+            textColor,
+            value,
+            citation,
+            className,
+        } = attributes;
+        const isSolidColorStyle = className?.includes(SOLID_COLOR_CLASS);
+
+        let figureClasses: string | undefined;
+        let figureStyles: Record<string, unknown> | undefined;
+
+        if (isSolidColorStyle) {
+            const backgroundClass = getColorClassName('background-color', mainColor);
+            figureClasses = clsx({
+                'has-background': backgroundClass || customMainColor,
+                [backgroundClass as string]: backgroundClass,
+            });
+            figureStyles = {
+                backgroundColor: backgroundClass ? undefined : customMainColor,
+            };
+        } else if (customMainColor) {
+            figureStyles = { borderColor: customMainColor };
+        }
+
+        const blockquoteTextColorClass = getColorClassName('color', textColor);
+        const blockquoteClasses = clsx({
+            'has-text-color': textColor || customTextColor,
+            [blockquoteTextColorClass as string]: blockquoteTextColorClass,
+        });
+        const blockquoteStyles = blockquoteTextColorClass
+            ? undefined
+            : { color: customTextColor };
+
+        return (
+            <figure
+                {...useBlockProps.save({
+                    className: figureClasses,
+                    style: figureStyles,
+                })}
+            >
+                <blockquote className={blockquoteClasses} style={blockquoteStyles}>
+                    <RichText.Content value={value} multiline />
+                    {!RichText.isEmpty(citation) && (
+                        <RichText.Content tagName="cite" value={citation} />
+                    )}
+                </blockquote>
+            </figure>
+        );
+    },
+    migrate({
+        value,
+        className,
+        mainColor,
+        customMainColor,
+        customTextColor,
+        ...attributes
+    }: LegacyPullquoteAttributes) {
+        const isSolidColorStyle = className?.includes(SOLID_COLOR_CLASS);
+        let style: Record<string, unknown> | undefined;
+
+        if (customMainColor) {
+            style = isSolidColorStyle
+                ? { color: { background: customMainColor } }
+                : { border: { color: customMainColor } };
+        }
+
+        if (customTextColor && style) {
+            const existingColor = (style.color ?? {}) as Record<string, unknown>;
+            style.color = { ...existingColor, text: customTextColor };
+        }
+
+        return {
+            value: multilineToInline(value),
+            className,
+            backgroundColor: isSolidColorStyle ? mainColor : undefined,
+            borderColor: isSolidColorStyle ? undefined : mainColor,
+            textAlign: isSolidColorStyle ? 'left' : undefined,
+            ...attributes,
+            style,
+        };
+    },
+};
+
+const v3 = {
+    attributes: {
+        ...blockAttributes,
+        figureStyle: {
+            source: 'attribute',
+            selector: 'figure',
+            attribute: 'style',
+        },
+    },
+    save({ attributes }: { attributes: LegacyPullquoteAttributes }) {
+        const {
+            mainColor,
+            customMainColor,
+            textColor,
+            customTextColor,
+            value,
+            citation,
+            className,
+            figureStyle,
+        } = attributes;
+        const isSolidColorStyle = className?.includes(SOLID_COLOR_CLASS);
+
+        let figureClasses: string | undefined;
+        let figureStyles: Record<string, unknown> | undefined;
+
+        if (isSolidColorStyle) {
+            const backgroundClass = getColorClassName('background-color', mainColor);
+            figureClasses = clsx({
+                'has-background': backgroundClass || customMainColor,
+                [backgroundClass as string]: backgroundClass,
+            });
+            figureStyles = {
+                backgroundColor: backgroundClass ? undefined : customMainColor,
+            };
+        } else if (customMainColor) {
+            figureStyles = { borderColor: customMainColor };
+        } else if (mainColor) {
+            const borderColor = parseBorderColor(figureStyle);
+            figureStyles = { borderColor };
+        }
+
+        const blockquoteTextColorClass = getColorClassName('color', textColor);
+        const blockquoteClasses =
+            textColor || customTextColor
+                ? clsx('has-text-color', {
+                      [blockquoteTextColorClass as string]: blockquoteTextColorClass,
+                  })
+                : undefined;
+        const blockquoteStyles = blockquoteTextColorClass
+            ? undefined
+            : { color: customTextColor };
+
+        return (
+            <figure className={figureClasses} style={figureStyles}>
+                <blockquote className={blockquoteClasses} style={blockquoteStyles}>
+                    <RichText.Content value={value} multiline />
+                    {!RichText.isEmpty(citation) && (
+                        <RichText.Content tagName="cite" value={citation} />
+                    )}
+                </blockquote>
+            </figure>
+        );
+    },
+    migrate({
+        value,
+        className,
+        figureStyle,
+        mainColor,
+        customMainColor,
+        customTextColor,
+        ...attributes
+    }: LegacyPullquoteAttributes) {
+        const isSolidColorStyle = className?.includes(SOLID_COLOR_CLASS);
+        let style: Record<string, unknown> | undefined;
+
+        if (customMainColor) {
+            style = isSolidColorStyle
+                ? { color: { background: customMainColor } }
+                : { border: { color: customMainColor } };
+        }
+
+        if (customTextColor && style) {
+            const existingColor = (style.color ?? {}) as Record<string, unknown>;
+            style.color = { ...existingColor, text: customTextColor };
+        }
+
+        if (!isSolidColorStyle && mainColor && figureStyle) {
+            const borderColor = parseBorderColor(figureStyle);
+            if (borderColor) {
+                return {
+                    value: multilineToInline(value),
+                    ...attributes,
+                    className,
+                    style: { border: { color: borderColor } },
+                };
+            }
+        }
+        return {
+            value: multilineToInline(value),
+            className,
+            backgroundColor: isSolidColorStyle ? mainColor : undefined,
+            borderColor: isSolidColorStyle ? undefined : mainColor,
+            textAlign: isSolidColorStyle ? 'left' : undefined,
+            ...attributes,
+            style,
+        };
+    },
+};
+
+const v2 = {
+    attributes: blockAttributes,
+    save({ attributes }: { attributes: LegacyPullquoteAttributes }) {
+        const {
+            mainColor,
+            customMainColor,
+            textColor,
+            customTextColor,
+            value,
+            citation,
+            className,
+        } = attributes;
+        const isSolidColorStyle = className?.includes(SOLID_COLOR_CLASS);
+
+        let figureClass: string | undefined;
+        let figureStyles: Record<string, unknown> | undefined;
+
+        if (isSolidColorStyle) {
+            figureClass = getColorClassName('background-color', mainColor);
+            if (!figureClass) {
+                figureStyles = { backgroundColor: customMainColor };
+            }
+        } else if (customMainColor) {
+            figureStyles = { borderColor: customMainColor };
+        }
+        // Divergence: upstream resolves named `mainColor` to a hex value via
+        // `select(blockEditorStore).getSettings().colors` here. Calling a
+        // store inside save() is impure; we skip it.
+
+        const blockquoteTextColorClass = getColorClassName('color', textColor);
+        const blockquoteClasses =
+            textColor || customTextColor
+                ? clsx('has-text-color', {
+                      [blockquoteTextColorClass as string]: blockquoteTextColorClass,
+                  })
+                : undefined;
+        const blockquoteStyle = blockquoteTextColorClass
+            ? undefined
+            : { color: customTextColor };
+
+        return (
+            <figure className={figureClass} style={figureStyles}>
+                <blockquote className={blockquoteClasses} style={blockquoteStyle}>
+                    <RichText.Content value={value} multiline />
+                    {!RichText.isEmpty(citation) && (
+                        <RichText.Content tagName="cite" value={citation} />
+                    )}
+                </blockquote>
+            </figure>
+        );
+    },
+    migrate({
+        value,
+        className,
+        mainColor,
+        customMainColor,
+        customTextColor,
+        ...attributes
+    }: LegacyPullquoteAttributes) {
+        const isSolidColorStyle = className?.includes(SOLID_COLOR_CLASS);
+        let style: Record<string, unknown> = {};
+
+        if (customMainColor) {
+            style = isSolidColorStyle
+                ? { color: { background: customMainColor } }
+                : { border: { color: customMainColor } };
+        }
+
+        if (customTextColor && style) {
+            const existingColor = (style.color ?? {}) as Record<string, unknown>;
+            style.color = { ...existingColor, text: customTextColor };
+        }
+
+        return {
+            value: multilineToInline(value),
+            className,
+            backgroundColor: isSolidColorStyle ? mainColor : undefined,
+            borderColor: isSolidColorStyle ? undefined : mainColor,
+            textAlign: isSolidColorStyle ? 'left' : undefined,
+            ...attributes,
+            style,
+        };
+    },
+};
+
+const v1 = {
+    attributes: { ...blockAttributes },
+    save({ attributes }: { attributes: LegacyPullquoteAttributes }) {
+        const { value, citation } = attributes;
+        return (
+            <blockquote>
+                <RichText.Content value={value} multiline />
+                {!RichText.isEmpty(citation) && (
+                    <RichText.Content tagName="cite" value={citation} />
+                )}
+            </blockquote>
+        );
+    },
+    migrate({ value, ...attributes }: LegacyPullquoteAttributes) {
+        return {
+            value: multilineToInline(value),
+            ...attributes,
+        };
+    },
+};
+
+const v0 = {
+    attributes: {
+        ...blockAttributes,
+        citation: {
+            type: 'string',
+            source: 'html',
+            selector: 'footer',
+        },
+        align: {
+            type: 'string',
+            default: 'none',
+        },
+    },
+    save({ attributes }: { attributes: LegacyPullquoteAttributes }) {
+        const { value, citation, align } = attributes;
+        return (
+            <blockquote className={`align${align}`}>
+                <RichText.Content value={value} multiline />
+                {!RichText.isEmpty(citation) && (
+                    <RichText.Content tagName="footer" value={citation} />
+                )}
+            </blockquote>
+        );
+    },
+    migrate({ value, ...attributes }: LegacyPullquoteAttributes) {
+        return {
+            value: multilineToInline(value),
+            ...attributes,
+        };
+    },
+};
+
+const deprecated = [v5, v4, v3, v2, v1, v0];
+
+export default deprecated;

--- a/resources/js/visual-editor/blocks/pullquote/edit.tsx
+++ b/resources/js/visual-editor/blocks/pullquote/edit.tsx
@@ -1,0 +1,91 @@
+/**
+ * Pullquote — editor-side render.
+ *
+ * Ported from `@wordpress/block-library/src/pullquote/edit.js` (v9.43.0).
+ */
+
+import type { ReactElement } from 'react';
+import clsx from 'clsx';
+import { __ } from '@wordpress/i18n';
+import {
+    AlignmentControl,
+    BlockControls,
+    RichText,
+    useBlockProps,
+} from '@wordpress/block-editor';
+import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
+
+interface PullquoteAttributes {
+    readonly textAlign?: string;
+    readonly citation?: string;
+    readonly value?: string;
+}
+
+interface PullquoteEditProps {
+    readonly attributes: PullquoteAttributes;
+    readonly setAttributes: (next: Partial<PullquoteAttributes>) => void;
+    readonly isSelected: boolean;
+    readonly insertBlocksAfter?: (block: unknown) => void;
+}
+
+export default function PullquoteEdit({
+    attributes,
+    setAttributes,
+    isSelected,
+    insertBlocksAfter,
+}: PullquoteEditProps): ReactElement {
+    const { textAlign, citation, value } = attributes;
+    const blockProps = useBlockProps({
+        className: clsx({
+            [`has-text-align-${textAlign}`]: textAlign,
+        }),
+    });
+    const shouldShowCitation = !RichText.isEmpty(citation) || isSelected;
+
+    return (
+        <>
+            <BlockControls group="block">
+                <AlignmentControl
+                    value={textAlign}
+                    onChange={(nextAlign?: string) => {
+                        setAttributes({ textAlign: nextAlign });
+                    }}
+                />
+            </BlockControls>
+            <figure {...blockProps}>
+                <blockquote>
+                    <RichText
+                        identifier="value"
+                        tagName="p"
+                        value={value ?? ''}
+                        onChange={(nextValue: string) =>
+                            setAttributes({ value: nextValue })
+                        }
+                        aria-label={__('Pullquote text')}
+                        placeholder={__('Add quote')}
+                    />
+                    {shouldShowCitation && (
+                        <RichText
+                            identifier="citation"
+                            tagName="cite"
+                            style={{ display: 'block' }}
+                            value={citation ?? ''}
+                            aria-label={__('Pullquote citation text')}
+                            placeholder={__('Add citation')}
+                            onChange={(nextCitation: string) =>
+                                setAttributes({ citation: nextCitation })
+                            }
+                            className="wp-block-pullquote__citation"
+                            __unstableOnSplitAtEnd={() => {
+                                const defaultName = getDefaultBlockName();
+                                if (defaultName) {
+                                    insertBlocksAfter?.(createBlock(defaultName));
+                                }
+                            }}
+                        />
+                    )}
+                </blockquote>
+            </figure>
+        </>
+    );
+}

--- a/resources/js/visual-editor/blocks/pullquote/index.ts
+++ b/resources/js/visual-editor/blocks/pullquote/index.ts
@@ -1,0 +1,26 @@
+/**
+ * Pullquote block entrypoint.
+ *
+ * Fork target: V2 block-fork phase I1 (content cluster, issue #409).
+ */
+
+import metadata from './block.json';
+import edit from './edit';
+import save from './save';
+import deprecated from './deprecated';
+import transforms from './transforms';
+import icon from './inserter-icon';
+
+import './pullquote.css';
+
+export { edit, save, metadata, icon, deprecated, transforms };
+
+export default {
+    name: metadata.name,
+    metadata,
+    edit,
+    save,
+    icon,
+    deprecated,
+    transforms,
+};

--- a/resources/js/visual-editor/blocks/pullquote/inserter-icon.tsx
+++ b/resources/js/visual-editor/blocks/pullquote/inserter-icon.tsx
@@ -1,0 +1,19 @@
+/**
+ * Pullquote — inserter icon.
+ */
+
+import type { ReactElement } from 'react';
+
+export default function PullquoteInserterIcon(): ReactElement {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            width={24}
+            height={24}
+            aria-hidden="true"
+        >
+            <path d="M21 5H3v2h18V5zm-6 12H3v2h12v-2zm6-4H3v-2h18v2z" />
+        </svg>
+    );
+}

--- a/resources/js/visual-editor/blocks/pullquote/pullquote.css
+++ b/resources/js/visual-editor/blocks/pullquote/pullquote.css
@@ -1,0 +1,84 @@
+/*
+ * Pullquote — frontend styles.
+ *
+ * Ported from `@wordpress/block-library/src/pullquote/style.scss`
+ * (v9.43.0). The `$content-width * 0.5` Sass calc is resolved to the
+ * Gutenberg default 350px (half of the 700px content-width baseline).
+ */
+
+.wp-block-pullquote {
+    text-align: center;
+    overflow-wrap: break-word;
+    box-sizing: border-box;
+    margin: 0 0 1em 0;
+    padding: 4em 0;
+}
+
+.wp-block-pullquote p,
+.wp-block-pullquote blockquote {
+    color: inherit;
+}
+
+.wp-block-pullquote blockquote {
+    margin: 0;
+}
+
+.wp-block-pullquote p {
+    margin-top: 0;
+}
+
+.wp-block-pullquote p:last-child {
+    margin-bottom: 0;
+}
+
+.wp-block-pullquote.alignleft,
+.wp-block-pullquote.alignright {
+    max-width: 350px;
+}
+
+.wp-block-pullquote cite,
+.wp-block-pullquote footer {
+    position: relative;
+}
+
+.wp-block-pullquote .has-text-color a {
+    color: inherit;
+}
+
+.wp-block-pullquote.has-text-align-left blockquote {
+    text-align: left;
+}
+
+.wp-block-pullquote.has-text-align-right blockquote {
+    text-align: right;
+}
+
+.wp-block-pullquote.has-text-align-center blockquote {
+    text-align: center;
+}
+
+.wp-block-pullquote.is-style-solid-color {
+    border: none;
+}
+
+.wp-block-pullquote.is-style-solid-color blockquote {
+    margin-left: auto;
+    margin-right: auto;
+    max-width: 60%;
+}
+
+.wp-block-pullquote.is-style-solid-color blockquote p {
+    margin-top: 0;
+    margin-bottom: 0;
+    font-size: 2em;
+}
+
+.wp-block-pullquote.is-style-solid-color blockquote cite {
+    text-transform: none;
+    font-style: normal;
+}
+
+.wp-block-pullquote :where(cite) {
+    color: inherit;
+    display: block;
+}

--- a/resources/js/visual-editor/blocks/pullquote/save.tsx
+++ b/resources/js/visual-editor/blocks/pullquote/save.tsx
@@ -1,0 +1,43 @@
+/**
+ * Pullquote — saved markup.
+ *
+ * Ported from `@wordpress/block-library/src/pullquote/save.js` (v9.43.0).
+ */
+
+import type { ReactElement } from 'react';
+import clsx from 'clsx';
+import { RichText, useBlockProps } from '@wordpress/block-editor';
+
+interface PullquoteSaveAttributes {
+    readonly textAlign?: string;
+    readonly citation?: string;
+    readonly value?: string;
+}
+
+interface PullquoteSaveProps {
+    readonly attributes: PullquoteSaveAttributes;
+}
+
+export default function PullquoteSave({
+    attributes,
+}: PullquoteSaveProps): ReactElement {
+    const { textAlign, citation, value } = attributes;
+    const shouldShowCitation = !RichText.isEmpty(citation);
+
+    return (
+        <figure
+            {...useBlockProps.save({
+                className: clsx({
+                    [`has-text-align-${textAlign}`]: textAlign,
+                }),
+            })}
+        >
+            <blockquote>
+                <RichText.Content tagName="p" value={value} />
+                {shouldShowCitation && (
+                    <RichText.Content tagName="cite" value={citation} />
+                )}
+            </blockquote>
+        </figure>
+    );
+}

--- a/resources/js/visual-editor/blocks/pullquote/shared.ts
+++ b/resources/js/visual-editor/blocks/pullquote/shared.ts
@@ -1,0 +1,7 @@
+/**
+ * Pullquote — shared constants.
+ *
+ * Ported from `@wordpress/block-library/src/pullquote/shared.js` (v9.43.0).
+ */
+
+export const SOLID_COLOR_CLASS = 'is-style-solid-color';

--- a/resources/js/visual-editor/blocks/pullquote/transforms.ts
+++ b/resources/js/visual-editor/blocks/pullquote/transforms.ts
@@ -1,0 +1,100 @@
+/**
+ * Pullquote — transforms.
+ *
+ * Ported from `@wordpress/block-library/src/pullquote/transforms.js`
+ * (v9.43.0). Extended with bidirectional block transforms for
+ * `core/pullquote` ↔ `artisanpack/pullquote`.
+ */
+
+import { createBlock } from '@wordpress/blocks';
+import { create, join, toHTMLString } from '@wordpress/rich-text';
+
+import metadata from './block.json';
+
+const { name } = metadata;
+
+interface PullquoteAttributes {
+    value?: string;
+    citation?: string;
+    content?: string;
+    anchor?: string;
+    [key: string]: unknown;
+}
+
+const transforms = {
+    from: [
+        {
+            type: 'block',
+            isMultiBlock: true,
+            blocks: ['core/paragraph', 'artisanpack/paragraph'],
+            transform: (attributes: PullquoteAttributes[]) =>
+                createBlock(name, {
+                    value: toHTMLString({
+                        value: join(
+                            attributes.map(({ content }) =>
+                                create({ html: content ?? '' })
+                            ),
+                            '\n'
+                        ),
+                    }),
+                    anchor: attributes[0]?.anchor,
+                }),
+        },
+        {
+            type: 'block',
+            blocks: ['core/heading', 'artisanpack/heading'],
+            transform: ({ content, anchor }: PullquoteAttributes) =>
+                createBlock(name, { value: content, anchor }),
+        },
+        {
+            type: 'block',
+            blocks: ['core/pullquote'],
+            transform: (attributes: PullquoteAttributes) =>
+                createBlock(name, attributes),
+        },
+    ],
+    to: [
+        {
+            type: 'block',
+            blocks: ['core/paragraph'],
+            transform: ({ value, citation }: PullquoteAttributes) => {
+                const paragraphs = [];
+                if (value) {
+                    paragraphs.push(createBlock('core/paragraph', { content: value }));
+                }
+                if (citation) {
+                    paragraphs.push(createBlock('core/paragraph', { content: citation }));
+                }
+                if (paragraphs.length === 0) {
+                    return createBlock('core/paragraph', { content: '' });
+                }
+                return paragraphs;
+            },
+        },
+        {
+            type: 'block',
+            blocks: ['core/heading'],
+            transform: ({ value, citation }: PullquoteAttributes) => {
+                if (!value) {
+                    return createBlock('core/heading', { content: citation });
+                }
+                const headingBlock = createBlock('core/heading', { content: value });
+                if (!citation) {
+                    return headingBlock;
+                }
+                return [
+                    headingBlock,
+                    createBlock('core/heading', { content: citation }),
+                ];
+            },
+        },
+        {
+            type: 'block',
+            blocks: ['core/pullquote'],
+            transform: (attributes: PullquoteAttributes) =>
+                createBlock('core/pullquote', attributes),
+        },
+    ],
+};
+
+export default transforms;

--- a/resources/js/visual-editor/blocks/pullquote/upstream-diff-report.json
+++ b/resources/js/visual-editor/blocks/pullquote/upstream-diff-report.json
@@ -1,0 +1,82 @@
+{
+    "block": "pullquote",
+    "status": "in-sync",
+    "upstream": {
+        "pinnedVersion": "9.43.0",
+        "subpath": "pullquote"
+    },
+    "files": [
+        {
+            "fork": "block.json",
+            "upstream": "block.json",
+            "status": "adapted",
+            "notes": "name + textdomain swapped.",
+            "result": "skipped-status",
+            "forkDigest": "ef5a94f1fa23"
+        },
+        {
+            "fork": "edit.tsx",
+            "upstream": "edit.js",
+            "status": "adapted",
+            "notes": "TypeScript port. Figure/BlockQuote string aliases inlined (no separate files).",
+            "result": "skipped-status",
+            "forkDigest": "f6c359ed6493"
+        },
+        {
+            "fork": "save.tsx",
+            "upstream": "save.js",
+            "status": "adapted",
+            "notes": "TypeScript port.",
+            "result": "skipped-status",
+            "forkDigest": "0835297809f7"
+        },
+        {
+            "fork": "deprecated.tsx",
+            "upstream": "deprecated.js",
+            "status": "adapted",
+            "notes": "Full 6-entry chain ported (v5 → v0). v2.save omits the named-color → hex lookup that upstream did via `select(blockEditorStore)` — calling a store inside save() is impure. Migration semantics preserved.",
+            "result": "skipped-status",
+            "forkDigest": "7ddd41d68c33"
+        },
+        {
+            "fork": "transforms.ts",
+            "upstream": "transforms.js",
+            "status": "extended",
+            "notes": "Upstream paragraph/heading transforms preserved; added bidirectional core/pullquote ↔ artisanpack/pullquote and accepts artisanpack/paragraph + artisanpack/heading.",
+            "result": "skipped-status",
+            "forkDigest": "84ac9137c550"
+        },
+        {
+            "fork": "shared.ts",
+            "upstream": "shared.js",
+            "status": "adapted",
+            "notes": "TypeScript port of a single constant. Logically equivalent — upstream uses a template literal, the fork uses a single-quoted string.",
+            "result": "skipped-status",
+            "forkDigest": "377d31cf329d"
+        },
+        {
+            "fork": "pullquote.css",
+            "upstream": "style.scss",
+            "status": "adapted",
+            "notes": "Sass `$content-width * 0.5` resolved inline to 350px (Gutenberg's default content-width is 700).",
+            "result": "skipped-status",
+            "forkDigest": "971acccc3b12"
+        },
+        {
+            "fork": "inserter-icon.tsx",
+            "upstream": "n/a",
+            "status": "added",
+            "notes": "Inline SVG.",
+            "result": "skipped-status",
+            "forkDigest": "9fc69a31f3a9"
+        },
+        {
+            "fork": "index.ts",
+            "upstream": "index.js",
+            "status": "rewritten",
+            "notes": "Auto-discovery contract.",
+            "result": "skipped-status",
+            "forkDigest": "c7c53d1c9198"
+        }
+    ]
+}

--- a/resources/js/visual-editor/blocks/pullquote/upstream-state.json
+++ b/resources/js/visual-editor/blocks/pullquote/upstream-state.json
@@ -1,0 +1,40 @@
+{
+    "$schema": "../../../../scripts/upstream-state.schema.json",
+    "block": "artisanpack/pullquote",
+    "upstream": {
+        "package": "@wordpress/block-library",
+        "namespace": "core/pullquote",
+        "pinnedVersion": "9.43.0",
+        "subpath": "pullquote"
+    },
+    "forkedAt": "2026-05-27",
+    "$statusLegend": {
+        "ported": "byte-equivalent to upstream (CI fails on drift)",
+        "adapted": "TypeScript port and/or namespace swap; logically equivalent",
+        "extended": "fork adds behavior on top of upstream",
+        "rewritten": "fork replaced upstream entirely",
+        "added": "file unique to the fork (no upstream)"
+    },
+    "files": [
+        { "fork": "block.json", "upstream": "block.json", "status": "adapted", "notes": "name + textdomain swapped." },
+        { "fork": "edit.tsx", "upstream": "edit.js", "status": "adapted", "notes": "TypeScript port. Figure/BlockQuote string aliases inlined (no separate files)." },
+        { "fork": "save.tsx", "upstream": "save.js", "status": "adapted", "notes": "TypeScript port." },
+        { "fork": "deprecated.tsx", "upstream": "deprecated.js", "status": "adapted", "notes": "Full 6-entry chain ported (v5 → v0). v2.save omits the named-color → hex lookup that upstream did via `select(blockEditorStore)` — calling a store inside save() is impure. Migration semantics preserved." },
+        { "fork": "transforms.ts", "upstream": "transforms.js", "status": "extended", "notes": "Upstream paragraph/heading transforms preserved; added bidirectional core/pullquote ↔ artisanpack/pullquote and accepts artisanpack/paragraph + artisanpack/heading." },
+        { "fork": "shared.ts", "upstream": "shared.js", "status": "adapted", "notes": "TypeScript port of a single constant. Logically equivalent — upstream uses a template literal, the fork uses a single-quoted string." },
+        { "fork": "pullquote.css", "upstream": "style.scss", "status": "adapted", "notes": "Sass `$content-width * 0.5` resolved inline to 350px (Gutenberg's default content-width is 700)." },
+        { "fork": "inserter-icon.tsx", "upstream": "n/a", "status": "added", "notes": "Inline SVG." },
+        { "fork": "index.ts", "upstream": "index.js", "status": "rewritten", "notes": "Auto-discovery contract." }
+    ],
+    "vendoredPrimitives": [],
+    "knownDivergences": [
+        "deprecated.tsx v2.save drops the upstream `select(blockEditorStore).getSettings().colors` named-color lookup. Legacy pullquote blocks persisted with default style + a named `mainColor` (no `customMainColor`) may not validate against v2's save shape and will fall through to v1 or get re-serialized as the current shape on first edit.",
+        "edit.tsx inlines Figure ('figure') and BlockQuote ('blockquote') as direct JSX rather than importing the single-line string-alias files from upstream.",
+        "transforms.ts adds bidirectional block transforms with core/pullquote."
+    ],
+    "triage": {
+        "label": "in-sync",
+        "lastReviewed": "2026-05-27",
+        "reviewer": "I1 content cluster"
+    }
+}

--- a/resources/js/visual-editor/blocks/quote/__tests__/deprecated.test.tsx
+++ b/resources/js/visual-editor/blocks/quote/__tests__/deprecated.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * Locks the deprecation chain for `artisanpack/quote`.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+vi.mock('@wordpress/block-editor', () => ({
+    useBlockProps: Object.assign(
+        (props?: Record<string, unknown>) => ({ ...props }),
+        { save: (props?: Record<string, unknown>) => ({ ...props }) }
+    ),
+    InnerBlocks: Object.assign(() => null, {
+        Content: () => <div data-testid="inner" />,
+    }),
+    RichText: Object.assign(() => null, {
+        isEmpty: (v?: string) => !v || v.length === 0,
+        Content: ({ value, tagName }: { value?: string; tagName?: string }) => {
+            const Tag = (tagName ?? 'span') as keyof JSX.IntrinsicElements;
+            return value !== undefined ? (
+                <Tag dangerouslySetInnerHTML={{ __html: value }} />
+            ) : null;
+        },
+    }),
+}));
+
+vi.mock('@wordpress/blocks', () => ({
+    createBlock: (name: string, attributes?: Record<string, unknown>) => ({
+        name,
+        attributes: attributes ?? {},
+        innerBlocks: [],
+    }),
+    parseWithAttributeSchema: () => [],
+}));
+
+import deprecated, { migrateToQuoteV2 } from '../deprecated';
+
+describe('quote deprecation chain', () => {
+    it('has 5 historical entries', () => {
+        expect(deprecated).toHaveLength(5);
+    });
+
+    it('every entry exposes a save callable', () => {
+        deprecated.forEach((entry, index) => {
+            expect(
+                typeof (entry as { save?: unknown }).save,
+                `entry ${index}`
+            ).toBe('function');
+        });
+    });
+
+    it('v4 (entries[0]) renders blockquote with has-text-align-*', () => {
+        const entry = deprecated[0] as {
+            save: (props: { attributes: Record<string, unknown> }) => React.ReactElement;
+        };
+        const html = renderToStaticMarkup(
+            entry.save({ attributes: { align: 'right', citation: 'Author' } })
+        );
+        expect(html).toContain('<blockquote');
+        expect(html).toContain('has-text-align-right');
+        expect(html).toContain('<cite');
+    });
+
+    it('v0 (entries[4]) renders citation in a footer tag', () => {
+        const entry = deprecated[4] as {
+            save: (props: { attributes: Record<string, unknown> }) => React.ReactElement;
+        };
+        const html = renderToStaticMarkup(
+            entry.save({
+                attributes: { value: 'q', citation: 'Author', style: 1 },
+            })
+        );
+        expect(html).toContain('<footer');
+    });
+
+    it('migrateToQuoteV2 returns an attributes/innerBlocks tuple', () => {
+        const result = migrateToQuoteV2({ value: '', citation: 'cite' });
+        expect(Array.isArray(result)).toBe(true);
+        expect(result).toHaveLength(2);
+        expect((result[0] as { citation?: string }).citation).toBe('cite');
+    });
+});

--- a/resources/js/visual-editor/blocks/quote/__tests__/edit.test.tsx
+++ b/resources/js/visual-editor/blocks/quote/__tests__/edit.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * Tests for the `artisanpack/quote` edit component.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+vi.mock('@wordpress/i18n', () => ({
+    __: (text: string) => text,
+}));
+
+vi.mock('@wordpress/block-editor', () => ({
+    useBlockProps: Object.assign(
+        (props?: Record<string, unknown>) => ({ ...props }),
+        { save: (props?: Record<string, unknown>) => ({ ...props }) }
+    ),
+    useInnerBlocksProps: (
+        props?: Record<string, unknown>,
+        _config?: Record<string, unknown>
+    ) => ({ ...props, children: <div data-testid="inner-blocks" /> }),
+    AlignmentControl: ({
+        value,
+        onChange,
+    }: { value?: string; onChange: (v?: string) => void }) => (
+        <button onClick={() => onChange(value === 'right' ? undefined : 'right')}>
+            align:{value ?? 'none'}
+        </button>
+    ),
+    BlockControls: ({ children }: { children: React.ReactNode }) => (
+        <div>{children}</div>
+    ),
+    RichText: function RichText(props: {
+        value?: string;
+        className?: string;
+        onChange?: (value: string) => void;
+        placeholder?: string;
+    }) {
+        return (
+            <div
+                role="textbox"
+                aria-label="citation-rich-text"
+                className={props.className}
+                data-placeholder={props.placeholder}
+                onClick={() => props.onChange?.('Author')}
+                dangerouslySetInnerHTML={{ __html: props.value ?? '' }}
+            />
+        );
+    },
+}));
+
+import QuoteEdit from '../edit';
+
+describe('QuoteEdit', () => {
+    it('renders a citation RichText with placeholder', () => {
+        const setAttributes = vi.fn();
+        render(
+            <QuoteEdit
+                attributes={{}}
+                setAttributes={setAttributes}
+                clientId="abc"
+            />
+        );
+        const textbox = screen.getByRole('textbox', { name: 'citation-rich-text' });
+        expect(textbox.getAttribute('data-placeholder')).toBe('Add citation');
+    });
+
+    it('calls setAttributes when citation RichText fires onChange', () => {
+        const setAttributes = vi.fn();
+        render(
+            <QuoteEdit
+                attributes={{}}
+                setAttributes={setAttributes}
+                clientId="abc"
+            />
+        );
+        fireEvent.click(screen.getByRole('textbox', { name: 'citation-rich-text' }));
+        expect(setAttributes).toHaveBeenCalledWith({ citation: 'Author' });
+    });
+
+    it('alignment control updates textAlign', () => {
+        const setAttributes = vi.fn();
+        render(
+            <QuoteEdit
+                attributes={{}}
+                setAttributes={setAttributes}
+                clientId="abc"
+            />
+        );
+        fireEvent.click(screen.getByText('align:none'));
+        expect(setAttributes).toHaveBeenCalledWith({ textAlign: 'right' });
+    });
+});

--- a/resources/js/visual-editor/blocks/quote/__tests__/save.test.tsx
+++ b/resources/js/visual-editor/blocks/quote/__tests__/save.test.tsx
@@ -1,0 +1,72 @@
+/**
+ * Tests for the `artisanpack/quote` save component.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+vi.mock('@wordpress/block-editor', () => ({
+    useBlockProps: Object.assign(
+        (props?: Record<string, unknown>) => ({ ...props }),
+        { save: (props?: Record<string, unknown>) => ({ ...props }) }
+    ),
+    InnerBlocks: Object.assign(() => null, {
+        Content: () => <div data-testid="inner-blocks" />,
+    }),
+    RichText: Object.assign(() => null, {
+        isEmpty: (value?: string) => !value || value.length === 0,
+        Content: ({
+            value,
+            tagName,
+        }: { value?: string; tagName?: string }) => {
+            const Tag = (tagName ?? 'span') as keyof JSX.IntrinsicElements;
+            return value !== undefined ? (
+                <Tag dangerouslySetInnerHTML={{ __html: value }} />
+            ) : null;
+        },
+    }),
+}));
+
+import QuoteSave from '../save';
+import metadata from '../block.json';
+
+describe('artisanpack/quote block.json', () => {
+    it('declares the artisanpack namespace and text category', () => {
+        expect(metadata.name).toBe('artisanpack/quote');
+        expect(metadata.category).toBe('text');
+    });
+
+    it('keeps the upstream content attribute selectors', () => {
+        expect(metadata.attributes.value.selector).toBe('blockquote');
+        expect(metadata.attributes.citation.selector).toBe('cite');
+    });
+});
+
+describe('QuoteSave', () => {
+    it('renders a blockquote element', () => {
+        const html = renderToStaticMarkup(<QuoteSave attributes={{}} />);
+        expect(html).toContain('<blockquote');
+    });
+
+    it('adds has-text-align-* class when textAlign is set', () => {
+        const html = renderToStaticMarkup(
+            <QuoteSave attributes={{ textAlign: 'right' }} />
+        );
+        expect(html).toContain('has-text-align-right');
+    });
+
+    it('renders citation in a cite tag when present', () => {
+        const html = renderToStaticMarkup(
+            <QuoteSave attributes={{ citation: 'Author Name' }} />
+        );
+        expect(html).toContain('<cite');
+        expect(html).toContain('Author Name');
+    });
+
+    it('omits cite tag when citation is empty', () => {
+        const html = renderToStaticMarkup(
+            <QuoteSave attributes={{ citation: '' }} />
+        );
+        expect(html).not.toContain('<cite');
+    });
+});

--- a/resources/js/visual-editor/blocks/quote/__tests__/transforms.test.ts
+++ b/resources/js/visual-editor/blocks/quote/__tests__/transforms.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Transforms tests for `artisanpack/quote`.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@wordpress/blocks', () => ({
+    createBlock: (
+        name: string,
+        attributes: Record<string, unknown>,
+        innerBlocks?: unknown[]
+    ) => ({
+        name,
+        attributes,
+        innerBlocks: innerBlocks ?? [],
+    }),
+}));
+
+import transforms from '../transforms';
+
+describe('quote transforms', () => {
+    it('declares from/to arrays', () => {
+        expect(Array.isArray(transforms.from)).toBe(true);
+        expect(Array.isArray(transforms.to)).toBe(true);
+    });
+
+    it('block transform from core/quote → artisanpack/quote', () => {
+        const fromBlock = transforms.from.find(
+            (t: { type: string; blocks?: string[]; isMultiBlock?: boolean }) =>
+                t.type === 'block' &&
+                !t.isMultiBlock &&
+                t.blocks?.length === 1 &&
+                t.blocks[0] === 'core/quote'
+        ) as {
+            transform: (
+                attrs: Record<string, unknown>,
+                innerBlocks: unknown[]
+            ) => { name: string; attributes: Record<string, unknown>; innerBlocks: unknown[] };
+        };
+        const inner = [{ name: 'core/paragraph', attributes: { content: 'hi' }, innerBlocks: [] }];
+        const result = fromBlock.transform({ citation: 'Author' }, inner);
+        expect(result.name).toBe('artisanpack/quote');
+        expect(result.attributes).toEqual({ citation: 'Author' });
+        expect(result.innerBlocks).toEqual(inner);
+    });
+
+    it('block transform to core/quote', () => {
+        const toBlock = transforms.to.find(
+            (t: { type: string; blocks?: string[] }) =>
+                t.type === 'block' && t.blocks?.[0] === 'core/quote'
+        ) as {
+            transform: (
+                attrs: Record<string, unknown>,
+                innerBlocks: unknown[]
+            ) => { name: string; attributes: Record<string, unknown>; innerBlocks: unknown[] };
+        };
+        const inner = [{ name: 'core/paragraph', attributes: { content: 'hi' }, innerBlocks: [] }];
+        const result = toBlock.transform({ citation: 'Author' }, inner);
+        expect(result.name).toBe('core/quote');
+        expect(result.attributes).toEqual({ citation: 'Author' });
+    });
+
+    it('prefix transform on > creates a quote wrapping a paragraph', () => {
+        const prefix = transforms.from.find(
+            (t: { type: string; prefix?: string }) =>
+                t.type === 'prefix' && t.prefix === '>'
+        ) as {
+            transform: (content: string) => {
+                name: string;
+                innerBlocks: unknown[];
+            };
+        };
+        const result = prefix.transform('quoted');
+        expect(result.name).toBe('artisanpack/quote');
+        expect(result.innerBlocks).toHaveLength(1);
+    });
+});

--- a/resources/js/visual-editor/blocks/quote/block.json
+++ b/resources/js/visual-editor/blocks/quote/block.json
@@ -1,0 +1,105 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "artisanpack/quote",
+    "title": "Quote",
+    "category": "text",
+    "description": "Give quoted text visual emphasis. \"In quoting others, we cite ourselves.\" — Julio Cortázar",
+    "keywords": [ "blockquote", "cite" ],
+    "textdomain": "artisanpack-visual-editor",
+    "attributes": {
+        "value": {
+            "type": "string",
+            "source": "html",
+            "selector": "blockquote",
+            "multiline": "p",
+            "default": "",
+            "role": "content"
+        },
+        "citation": {
+            "type": "rich-text",
+            "source": "rich-text",
+            "selector": "cite",
+            "role": "content"
+        },
+        "textAlign": {
+            "type": "string"
+        }
+    },
+    "supports": {
+        "anchor": true,
+        "align": [ "left", "right", "wide", "full" ],
+        "html": false,
+        "background": {
+            "backgroundImage": true,
+            "backgroundSize": true,
+            "__experimentalDefaultControls": {
+                "backgroundImage": true
+            }
+        },
+        "__experimentalBorder": {
+            "color": true,
+            "radius": true,
+            "style": true,
+            "width": true,
+            "__experimentalDefaultControls": {
+                "color": true,
+                "radius": true,
+                "style": true,
+                "width": true
+            }
+        },
+        "dimensions": {
+            "minHeight": true,
+            "__experimentalDefaultControls": {
+                "minHeight": false
+            }
+        },
+        "__experimentalOnEnter": true,
+        "__experimentalOnMerge": true,
+        "typography": {
+            "fontSize": true,
+            "lineHeight": true,
+            "__experimentalFontFamily": true,
+            "__experimentalFontWeight": true,
+            "__experimentalFontStyle": true,
+            "__experimentalTextTransform": true,
+            "__experimentalTextDecoration": true,
+            "__experimentalLetterSpacing": true,
+            "__experimentalDefaultControls": {
+                "fontSize": true
+            }
+        },
+        "color": {
+            "gradients": true,
+            "heading": true,
+            "link": true,
+            "__experimentalDefaultControls": {
+                "background": true,
+                "text": true
+            }
+        },
+        "layout": {
+            "allowEditing": false
+        },
+        "spacing": {
+            "blockGap": true,
+            "padding": true,
+            "margin": true
+        },
+        "interactivity": {
+            "clientNavigation": true
+        },
+        "allowedBlocks": true
+    },
+    "styles": [
+        {
+            "name": "default",
+            "label": "Default",
+            "isDefault": true
+        },
+        { "name": "plain", "label": "Plain" }
+    ],
+    "editorStyle": "wp-block-quote-editor",
+    "style": "wp-block-quote"
+}

--- a/resources/js/visual-editor/blocks/quote/deprecated.tsx
+++ b/resources/js/visual-editor/blocks/quote/deprecated.tsx
@@ -1,0 +1,284 @@
+/**
+ * Quote — deprecation chain.
+ *
+ * Full port of `@wordpress/block-library/src/quote/deprecated.js` (v9.43.0).
+ * v4 → v0 cover historical save shapes; v3+v2+v1+v0 also migrate the legacy
+ * `value` attribute into core/paragraph inner blocks.
+ */
+
+import clsx from 'clsx';
+import {
+    InnerBlocks,
+    RichText,
+    useBlockProps,
+} from '@wordpress/block-editor';
+import { createBlock, parseWithAttributeSchema } from '@wordpress/blocks';
+
+interface LegacyQuoteAttributes {
+    value?: string;
+    citation?: string;
+    align?: string;
+    textAlign?: string;
+    style?: number | Record<string, unknown>;
+    className?: string;
+    [key: string]: unknown;
+}
+
+const TEXT_ALIGN_OPTIONS = ['left', 'right', 'center'] as const;
+
+export const migrateToQuoteV2 = (
+    attributes: LegacyQuoteAttributes
+): [LegacyQuoteAttributes, unknown[]] => {
+    const { value, ...restAttributes } = attributes;
+
+    return [
+        { ...restAttributes },
+        value
+            ? parseWithAttributeSchema(value, {
+                  type: 'array',
+                  source: 'query',
+                  selector: 'p',
+                  query: {
+                      content: {
+                          type: 'string',
+                          source: 'html',
+                      },
+                  },
+              }).map(({ content }: { content: string }) =>
+                  createBlock('core/paragraph', { content })
+              )
+            : [createBlock('core/paragraph')],
+    ];
+};
+
+const migrateTextAlign = (
+    attributes: LegacyQuoteAttributes,
+    innerBlocks: unknown[]
+): [LegacyQuoteAttributes, unknown[]] => {
+    const { align, ...rest } = attributes;
+    const migratedAttributes = TEXT_ALIGN_OPTIONS.includes(
+        align as 'left' | 'right' | 'center'
+    )
+        ? { ...rest, textAlign: align }
+        : attributes;
+    return [migratedAttributes, innerBlocks];
+};
+
+const migrateLargeStyle = (
+    attributes: LegacyQuoteAttributes,
+    innerBlocks: unknown[]
+): [LegacyQuoteAttributes, unknown[]] => {
+    return [
+        {
+            ...attributes,
+            className: attributes.className
+                ? `${attributes.className} is-style-large`
+                : 'is-style-large',
+        },
+        innerBlocks,
+    ];
+};
+
+const v4 = {
+    attributes: {
+        value: {
+            type: 'string',
+            source: 'html',
+            selector: 'blockquote',
+            multiline: 'p',
+            default: '',
+            role: 'content',
+        },
+        citation: {
+            type: 'string',
+            source: 'html',
+            selector: 'cite',
+            default: '',
+            role: 'content',
+        },
+        align: { type: 'string' },
+    },
+    supports: {
+        anchor: true,
+        html: false,
+        __experimentalOnEnter: true,
+        __experimentalOnMerge: true,
+    },
+    isEligible: ({ align }: LegacyQuoteAttributes) =>
+        TEXT_ALIGN_OPTIONS.includes(align as 'left' | 'right' | 'center'),
+    save({ attributes }: { attributes: LegacyQuoteAttributes }) {
+        const { align, citation } = attributes;
+        const className = clsx({
+            [`has-text-align-${align}`]: align,
+        });
+        return (
+            <blockquote {...useBlockProps.save({ className })}>
+                <InnerBlocks.Content />
+                {!RichText.isEmpty(citation) && (
+                    <RichText.Content tagName="cite" value={citation} />
+                )}
+            </blockquote>
+        );
+    },
+    migrate: migrateTextAlign,
+};
+
+const v3 = {
+    attributes: {
+        value: {
+            type: 'string',
+            source: 'html',
+            selector: 'blockquote',
+            multiline: 'p',
+            default: '',
+            role: 'content',
+        },
+        citation: {
+            type: 'string',
+            source: 'html',
+            selector: 'cite',
+            default: '',
+            role: 'content',
+        },
+        align: { type: 'string' },
+    },
+    supports: { anchor: true },
+    save({ attributes }: { attributes: LegacyQuoteAttributes }) {
+        const { align, value, citation } = attributes;
+        const className = clsx({
+            [`has-text-align-${align}`]: align,
+        });
+        return (
+            <blockquote {...useBlockProps.save({ className })}>
+                <RichText.Content multiline value={value} />
+                {!RichText.isEmpty(citation) && (
+                    <RichText.Content tagName="cite" value={citation} />
+                )}
+            </blockquote>
+        );
+    },
+    migrate(attributes: LegacyQuoteAttributes) {
+        return migrateTextAlign(...migrateToQuoteV2(attributes));
+    },
+};
+
+const v2 = {
+    attributes: {
+        value: {
+            type: 'string',
+            source: 'html',
+            selector: 'blockquote',
+            multiline: 'p',
+            default: '',
+        },
+        citation: {
+            type: 'string',
+            source: 'html',
+            selector: 'cite',
+            default: '',
+        },
+        align: { type: 'string' },
+    },
+    migrate(attributes: LegacyQuoteAttributes) {
+        return migrateTextAlign(...migrateToQuoteV2(attributes));
+    },
+    save({ attributes }: { attributes: LegacyQuoteAttributes }) {
+        const { align, value, citation } = attributes;
+        return (
+            <blockquote style={{ textAlign: align ? align : undefined }}>
+                <RichText.Content multiline value={value} />
+                {!RichText.isEmpty(citation) && (
+                    <RichText.Content tagName="cite" value={citation} />
+                )}
+            </blockquote>
+        );
+    },
+};
+
+const v1 = {
+    attributes: {
+        value: {
+            type: 'string',
+            source: 'html',
+            selector: 'blockquote',
+            multiline: 'p',
+            default: '',
+        },
+        citation: {
+            type: 'string',
+            source: 'html',
+            selector: 'cite',
+            default: '',
+        },
+        align: { type: 'string' },
+        style: { type: 'number', default: 1 },
+    },
+    migrate(attributes: LegacyQuoteAttributes) {
+        if (attributes.style === 2) {
+            const { style, ...restAttributes } = attributes;
+            return migrateTextAlign(
+                ...migrateLargeStyle(...migrateToQuoteV2(restAttributes))
+            );
+        }
+        return migrateTextAlign(...migrateToQuoteV2(attributes));
+    },
+    save({ attributes }: { attributes: LegacyQuoteAttributes }) {
+        const { align, value, citation, style } = attributes;
+        return (
+            <blockquote
+                className={style === 2 ? 'is-large' : ''}
+                style={{ textAlign: align ? align : undefined }}
+            >
+                <RichText.Content multiline value={value} />
+                {!RichText.isEmpty(citation) && (
+                    <RichText.Content tagName="cite" value={citation} />
+                )}
+            </blockquote>
+        );
+    },
+};
+
+const v0 = {
+    attributes: {
+        value: {
+            type: 'string',
+            source: 'html',
+            selector: 'blockquote',
+            multiline: 'p',
+            default: '',
+        },
+        citation: {
+            type: 'string',
+            source: 'html',
+            selector: 'footer',
+            default: '',
+        },
+        align: { type: 'string' },
+        style: { type: 'number', default: 1 },
+    },
+    migrate(attributes: LegacyQuoteAttributes) {
+        if (!isNaN(parseInt(String(attributes.style)))) {
+            const { style, ...restAttributes } = attributes;
+            return migrateTextAlign(...migrateToQuoteV2(restAttributes));
+        }
+        return migrateTextAlign(...migrateToQuoteV2(attributes));
+    },
+    save({ attributes }: { attributes: LegacyQuoteAttributes }) {
+        const { align, value, citation, style } = attributes;
+        return (
+            <blockquote
+                className={`blocks-quote-style-${style}`}
+                style={{ textAlign: align ? align : undefined }}
+            >
+                <RichText.Content multiline value={value} />
+                {!RichText.isEmpty(citation) && (
+                    <RichText.Content tagName="footer" value={citation} />
+                )}
+            </blockquote>
+        );
+    },
+};
+
+const deprecated = [v4, v3, v2, v1, v0];
+
+export default deprecated;

--- a/resources/js/visual-editor/blocks/quote/edit.tsx
+++ b/resources/js/visual-editor/blocks/quote/edit.tsx
@@ -4,7 +4,8 @@
  * Ported from `@wordpress/block-library/src/quote/edit.js` (v9.43.0).
  * Behaviour parity with upstream: inner-block paragraph template, citation
  * RichText, alignment control. The upstream `useMigrateOnLoad` hook is
- * preserved; the deprecation chain mirrors upstream's `migrateToQuoteV2`.
+ * NOT ported here — the deprecation chain handles legacy `value` →
+ * inner-blocks migration via `migrateToQuoteV2` on block load instead.
  */
 
 import type { ReactElement } from 'react';

--- a/resources/js/visual-editor/blocks/quote/edit.tsx
+++ b/resources/js/visual-editor/blocks/quote/edit.tsx
@@ -1,0 +1,85 @@
+/**
+ * Quote — editor-side render.
+ *
+ * Ported from `@wordpress/block-library/src/quote/edit.js` (v9.43.0).
+ * Behaviour parity with upstream: inner-block paragraph template, citation
+ * RichText, alignment control. The upstream `useMigrateOnLoad` hook is
+ * preserved; the deprecation chain mirrors upstream's `migrateToQuoteV2`.
+ */
+
+import type { ReactElement } from 'react';
+import clsx from 'clsx';
+import { __ } from '@wordpress/i18n';
+import {
+    AlignmentControl,
+    BlockControls,
+    RichText,
+    useBlockProps,
+    useInnerBlocksProps,
+} from '@wordpress/block-editor';
+
+interface QuoteAttributes {
+    readonly textAlign?: string;
+    readonly citation?: string;
+    readonly value?: string;
+    readonly allowedBlocks?: string[];
+}
+
+interface QuoteEditProps {
+    readonly attributes: QuoteAttributes;
+    readonly setAttributes: (next: Partial<QuoteAttributes>) => void;
+    readonly clientId: string;
+    readonly className?: string;
+}
+
+const TEMPLATE: ReadonlyArray<readonly [string, Record<string, unknown>]> = [
+    ['core/paragraph', {}],
+];
+
+export default function QuoteEdit({
+    attributes,
+    setAttributes,
+    className,
+}: QuoteEditProps): ReactElement {
+    const { textAlign, citation, allowedBlocks } = attributes;
+
+    const blockProps = useBlockProps({
+        className: clsx(className, {
+            [`has-text-align-${textAlign}`]: textAlign,
+        }),
+    });
+
+    const innerBlocksProps = useInnerBlocksProps(blockProps, {
+        template: TEMPLATE as unknown as readonly [string, Record<string, unknown>][],
+        templateInsertUpdatesSelection: true,
+        renderAppender: false,
+        allowedBlocks,
+    });
+
+    return (
+        <>
+            <BlockControls group="block">
+                <AlignmentControl
+                    value={textAlign}
+                    onChange={(nextAlign?: string) => {
+                        setAttributes({ textAlign: nextAlign });
+                    }}
+                />
+            </BlockControls>
+            <blockquote {...innerBlocksProps}>
+                {(innerBlocksProps as { children?: React.ReactNode }).children}
+                <RichText
+                    identifier="citation"
+                    tagName="cite"
+                    style={{ display: 'block' }}
+                    value={citation ?? ''}
+                    onChange={(nextCitation: string) =>
+                        setAttributes({ citation: nextCitation })
+                    }
+                    placeholder={__('Add citation')}
+                    className="wp-block-quote__citation"
+                />
+            </blockquote>
+        </>
+    );
+}

--- a/resources/js/visual-editor/blocks/quote/index.ts
+++ b/resources/js/visual-editor/blocks/quote/index.ts
@@ -1,0 +1,26 @@
+/**
+ * Quote block entrypoint.
+ *
+ * Fork target: V2 block-fork phase I1 (content cluster, issue #409).
+ */
+
+import metadata from './block.json';
+import edit from './edit';
+import save from './save';
+import deprecated from './deprecated';
+import transforms from './transforms';
+import icon from './inserter-icon';
+
+import './quote.css';
+
+export { edit, save, metadata, icon, deprecated, transforms };
+
+export default {
+    name: metadata.name,
+    metadata,
+    edit,
+    save,
+    icon,
+    deprecated,
+    transforms,
+};

--- a/resources/js/visual-editor/blocks/quote/inserter-icon.tsx
+++ b/resources/js/visual-editor/blocks/quote/inserter-icon.tsx
@@ -1,0 +1,21 @@
+/**
+ * Quote — inserter icon.
+ *
+ * Inline SVG (matches Gutenberg's `quote` icon from `@wordpress/icons`).
+ */
+
+import type { ReactElement } from 'react';
+
+export default function QuoteInserterIcon(): ReactElement {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            width={24}
+            height={24}
+            aria-hidden="true"
+        >
+            <path d="M13 6v6h5.2L15 18h2.4l3.2-6V6H13zm-9 6h5.2L6 18h2.4l3.2-6V6H4v6z" />
+        </svg>
+    );
+}

--- a/resources/js/visual-editor/blocks/quote/quote.css
+++ b/resources/js/visual-editor/blocks/quote/quote.css
@@ -1,0 +1,35 @@
+/*
+ * Quote — frontend styles.
+ *
+ * Ported from `@wordpress/block-library/src/quote/style.scss` (v9.43.0).
+ */
+
+.wp-block-quote {
+    box-sizing: border-box;
+    overflow-wrap: break-word;
+}
+
+.wp-block-quote.is-style-large:where(:not(.is-style-plain)),
+.wp-block-quote.is-large:where(:not(.is-style-plain)) {
+    margin-bottom: 1em;
+    padding: 0 1em;
+}
+
+.wp-block-quote.is-style-large:where(:not(.is-style-plain)) p,
+.wp-block-quote.is-large:where(:not(.is-style-plain)) p {
+    font-size: 1.5em;
+    font-style: italic;
+    line-height: 1.6;
+}
+
+.wp-block-quote.is-style-large:where(:not(.is-style-plain)) cite,
+.wp-block-quote.is-style-large:where(:not(.is-style-plain)) footer,
+.wp-block-quote.is-large:where(:not(.is-style-plain)) cite,
+.wp-block-quote.is-large:where(:not(.is-style-plain)) footer {
+    font-size: 1.125em;
+    text-align: right;
+}
+
+.wp-block-quote > cite {
+    display: block;
+}

--- a/resources/js/visual-editor/blocks/quote/save.tsx
+++ b/resources/js/visual-editor/blocks/quote/save.tsx
@@ -1,0 +1,36 @@
+/**
+ * Quote — saved markup.
+ *
+ * Ported from `@wordpress/block-library/src/quote/save.js` (v9.43.0).
+ * Output is byte-equivalent to upstream `core/quote`.
+ */
+
+import type { ReactElement } from 'react';
+import clsx from 'clsx';
+import { InnerBlocks, RichText, useBlockProps } from '@wordpress/block-editor';
+
+interface QuoteSaveAttributes {
+    readonly textAlign?: string;
+    readonly citation?: string;
+}
+
+interface QuoteSaveProps {
+    readonly attributes: QuoteSaveAttributes;
+}
+
+export default function QuoteSave({ attributes }: QuoteSaveProps): ReactElement {
+    const { textAlign, citation } = attributes;
+
+    const className = clsx({
+        [`has-text-align-${textAlign}`]: textAlign,
+    });
+
+    return (
+        <blockquote {...useBlockProps.save({ className })}>
+            <InnerBlocks.Content />
+            {!RichText.isEmpty(citation) && (
+                <RichText.Content tagName="cite" value={citation} />
+            )}
+        </blockquote>
+    );
+}

--- a/resources/js/visual-editor/blocks/quote/transforms.ts
+++ b/resources/js/visual-editor/blocks/quote/transforms.ts
@@ -1,0 +1,119 @@
+/**
+ * Quote — transforms.
+ *
+ * Ported from `@wordpress/block-library/src/quote/transforms.js` (v9.43.0).
+ * Extended with bidirectional block transforms for `core/quote` ↔
+ * `artisanpack/quote`.
+ */
+
+import { createBlock } from '@wordpress/blocks';
+
+import metadata from './block.json';
+
+const { name } = metadata;
+
+interface QuoteAttributes {
+    value?: string;
+    citation?: string;
+    align?: string;
+    textAlign?: string;
+    anchor?: string;
+    fontSize?: string;
+    style?: Record<string, unknown> | number;
+    [key: string]: unknown;
+}
+
+interface BlockLike {
+    readonly name: string;
+    readonly attributes: Record<string, unknown>;
+    readonly innerBlocks: readonly BlockLike[];
+}
+
+const transforms = {
+    from: [
+        {
+            type: 'block',
+            blocks: ['core/verse', 'artisanpack/verse'],
+            transform: ({ content }: { content: string }) =>
+                createBlock(name, {}, [
+                    createBlock('core/paragraph', { content }),
+                ]),
+        },
+        {
+            type: 'block',
+            blocks: ['core/pullquote', 'artisanpack/pullquote'],
+            transform: ({
+                value,
+                align,
+                citation,
+                anchor,
+                fontSize,
+                style,
+            }: QuoteAttributes) =>
+                createBlock(
+                    name,
+                    { align, citation, anchor, fontSize, style },
+                    [createBlock('core/paragraph', { content: value })]
+                ),
+        },
+        {
+            type: 'prefix',
+            prefix: '>',
+            transform: (content: string) =>
+                createBlock(name, {}, [
+                    createBlock('core/paragraph', { content }),
+                ]),
+        },
+        {
+            type: 'block',
+            isMultiBlock: true,
+            blocks: ['*'],
+            isMatch: (_attrs: unknown, blocks: BlockLike[]) => {
+                if (blocks.length === 1) {
+                    return [
+                        'core/paragraph',
+                        'core/heading',
+                        'core/list',
+                        'core/pullquote',
+                        'artisanpack/paragraph',
+                        'artisanpack/heading',
+                        'artisanpack/list',
+                        'artisanpack/pullquote',
+                    ].includes(blocks[0].name);
+                }
+                return !blocks.some(
+                    ({ name: blockName }) =>
+                        blockName === 'core/quote' || blockName === name
+                );
+            },
+            __experimentalConvert: (blocks: BlockLike[]) =>
+                createBlock(
+                    name,
+                    {},
+                    blocks.map((block) =>
+                        createBlock(
+                            block.name,
+                            block.attributes,
+                            block.innerBlocks as unknown as BlockLike[]
+                        )
+                    )
+                ),
+        },
+        {
+            type: 'block',
+            blocks: ['core/quote'],
+            transform: (attributes: QuoteAttributes, innerBlocks: BlockLike[]) =>
+                createBlock(name, attributes, innerBlocks),
+        },
+    ],
+    to: [
+        {
+            type: 'block',
+            blocks: ['core/quote'],
+            transform: (attributes: QuoteAttributes, innerBlocks: BlockLike[]) =>
+                createBlock('core/quote', attributes, innerBlocks),
+        },
+    ],
+};
+
+export default transforms;

--- a/resources/js/visual-editor/blocks/quote/upstream-diff-report.json
+++ b/resources/js/visual-editor/blocks/quote/upstream-diff-report.json
@@ -1,0 +1,74 @@
+{
+    "block": "quote",
+    "status": "in-sync",
+    "upstream": {
+        "pinnedVersion": "9.43.0",
+        "subpath": "quote"
+    },
+    "files": [
+        {
+            "fork": "block.json",
+            "upstream": "block.json",
+            "status": "adapted",
+            "notes": "name + textdomain swapped to artisanpack namespace.",
+            "result": "skipped-status",
+            "forkDigest": "77137856d4c1"
+        },
+        {
+            "fork": "edit.tsx",
+            "upstream": "edit.js",
+            "status": "adapted",
+            "notes": "TypeScript port. Inlines a minimal citation editor using RichText; the upstream Caption utility is not vendored (single-use, post-V2 enhancement target).",
+            "result": "skipped-status",
+            "forkDigest": "9a3a5059060c"
+        },
+        {
+            "fork": "save.tsx",
+            "upstream": "save.js",
+            "status": "adapted",
+            "notes": "TypeScript port; verbatim save shape.",
+            "result": "skipped-status",
+            "forkDigest": "23f4d5382bb2"
+        },
+        {
+            "fork": "deprecated.tsx",
+            "upstream": "deprecated.js",
+            "status": "adapted",
+            "notes": "Full 5-entry chain ported verbatim (v4 → v0). `migrateToQuoteV2` exported for the edit-side hook.",
+            "result": "skipped-status",
+            "forkDigest": "880320e205b2"
+        },
+        {
+            "fork": "transforms.ts",
+            "upstream": "transforms.js",
+            "status": "extended",
+            "notes": "Upstream raw/prefix/multi-block transforms preserved; added bidirectional block transforms for core/quote ↔ artisanpack/quote and accepts artisanpack/* peers (verse, pullquote, paragraph, heading, list).",
+            "result": "skipped-status",
+            "forkDigest": "7ab5feb357e9"
+        },
+        {
+            "fork": "quote.css",
+            "upstream": "style.scss",
+            "status": "adapted",
+            "notes": "Sass nesting flattened.",
+            "result": "skipped-status",
+            "forkDigest": "b6cb83b46ccb"
+        },
+        {
+            "fork": "inserter-icon.tsx",
+            "upstream": "n/a",
+            "status": "added",
+            "notes": "Inline SVG for the inserter.",
+            "result": "skipped-status",
+            "forkDigest": "bdd1599ebeaf"
+        },
+        {
+            "fork": "index.ts",
+            "upstream": "index.js",
+            "status": "rewritten",
+            "notes": "Adapted to the visual-editor auto-discovery contract.",
+            "result": "skipped-status",
+            "forkDigest": "dbf9d0c4e608"
+        }
+    ]
+}

--- a/resources/js/visual-editor/blocks/quote/upstream-diff-report.json
+++ b/resources/js/visual-editor/blocks/quote/upstream-diff-report.json
@@ -20,7 +20,7 @@
             "status": "adapted",
             "notes": "TypeScript port. Inlines a minimal citation editor using RichText; the upstream Caption utility is not vendored (single-use, post-V2 enhancement target).",
             "result": "skipped-status",
-            "forkDigest": "9a3a5059060c"
+            "forkDigest": "0347c7ebe9a7"
         },
         {
             "fork": "save.tsx",

--- a/resources/js/visual-editor/blocks/quote/upstream-state.json
+++ b/resources/js/visual-editor/blocks/quote/upstream-state.json
@@ -1,0 +1,37 @@
+{
+    "$schema": "../../../../scripts/upstream-state.schema.json",
+    "block": "artisanpack/quote",
+    "upstream": {
+        "package": "@wordpress/block-library",
+        "namespace": "core/quote",
+        "pinnedVersion": "9.43.0",
+        "subpath": "quote"
+    },
+    "forkedAt": "2026-05-27",
+    "$statusLegend": {
+        "ported": "byte-equivalent to upstream (CI fails on drift)",
+        "adapted": "TypeScript port and/or namespace swap; logically equivalent",
+        "extended": "fork adds behavior on top of upstream",
+        "rewritten": "fork replaced upstream entirely",
+        "added": "file unique to the fork (no upstream)"
+    },
+    "files": [
+        { "fork": "block.json", "upstream": "block.json", "status": "adapted", "notes": "name + textdomain swapped to artisanpack namespace." },
+        { "fork": "edit.tsx", "upstream": "edit.js", "status": "adapted", "notes": "TypeScript port. Inlines a minimal citation editor using RichText; the upstream Caption utility is not vendored (single-use, post-V2 enhancement target)." },
+        { "fork": "save.tsx", "upstream": "save.js", "status": "adapted", "notes": "TypeScript port; verbatim save shape." },
+        { "fork": "deprecated.tsx", "upstream": "deprecated.js", "status": "adapted", "notes": "Full 5-entry chain ported verbatim (v4 → v0). `migrateToQuoteV2` exported for the edit-side hook." },
+        { "fork": "transforms.ts", "upstream": "transforms.js", "status": "extended", "notes": "Upstream raw/prefix/multi-block transforms preserved; added bidirectional block transforms for core/quote ↔ artisanpack/quote and accepts artisanpack/* peers (verse, pullquote, paragraph, heading, list)." },
+        { "fork": "quote.css", "upstream": "style.scss", "status": "adapted", "notes": "Sass nesting flattened." },
+        { "fork": "inserter-icon.tsx", "upstream": "n/a", "status": "added", "notes": "Inline SVG for the inserter." },
+        { "fork": "index.ts", "upstream": "index.js", "status": "rewritten", "notes": "Adapted to the visual-editor auto-discovery contract." }
+    ],
+    "vendoredPrimitives": [],
+    "knownDivergences": [
+        "edit.tsx omits the upstream `useMigrateOnLoad` hook + Caption utility. The deprecation chain still handles legacy `value`→inner-blocks migration via `migrateToQuoteV2` on block load."
+    ],
+    "triage": {
+        "label": "in-sync",
+        "lastReviewed": "2026-05-27",
+        "reviewer": "I1 content cluster"
+    }
+}

--- a/resources/js/visual-editor/blocks/table/__tests__/deprecated.test.tsx
+++ b/resources/js/visual-editor/blocks/table/__tests__/deprecated.test.tsx
@@ -1,0 +1,66 @@
+/**
+ * Locks the deprecation chain for `artisanpack/table`.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+vi.mock('@wordpress/block-editor', () => ({
+    useBlockProps: Object.assign(
+        (props?: Record<string, unknown>) => ({ ...props }),
+        { save: (props?: Record<string, unknown>) => ({ ...props }) }
+    ),
+    RichText: Object.assign(() => null, {
+        isEmpty: (v?: string) => !v || v.length === 0,
+        Content: ({ value, tagName }: { value?: string; tagName?: string }) => {
+            const Tag = (tagName ?? 'td') as keyof JSX.IntrinsicElements;
+            return (
+                <Tag dangerouslySetInnerHTML={{ __html: value ?? '' }} />
+            );
+        },
+    }),
+    getColorClassName: (prefix: string, slug?: string) =>
+        slug ? `has-${slug}-${prefix}` : undefined,
+    __experimentalGetBorderClassesAndStyles: () => ({ className: '', style: {} }),
+    __experimentalGetColorClassesAndStyles: () => ({ className: '', style: {} }),
+    __experimentalGetElementClassName: () => 'wp-element-caption',
+}));
+
+import deprecated from '../deprecated';
+
+describe('table deprecation chain', () => {
+    it('has 4 historical entries', () => {
+        expect(deprecated).toHaveLength(4);
+    });
+
+    it('every entry exposes a save callable', () => {
+        deprecated.forEach((entry, i) => {
+            expect(
+                typeof (entry as { save?: unknown }).save,
+                `entry ${i}`
+            ).toBe('function');
+        });
+    });
+
+    it('v4 (entries[0]) returns null for empty tables', () => {
+        const entry = deprecated[0] as {
+            save: (p: { attributes: Record<string, unknown> }) => React.ReactElement | null;
+        };
+        const result = entry.save({
+            attributes: { hasFixedLayout: true, head: [], body: [], foot: [] },
+        });
+        expect(result).toBeNull();
+    });
+
+    it('v2 (entries[2]) migrates legacy backgroundColor slug to style.color.background', () => {
+        const entry = deprecated[2] as {
+            migrate: (a: Record<string, unknown>) => Record<string, unknown>;
+            isEligible: (a: Record<string, unknown>) => boolean;
+        };
+        expect(entry.isEligible({ backgroundColor: 'subtle-pale-green' })).toBe(true);
+        const migrated = entry.migrate({ backgroundColor: 'subtle-pale-green' });
+        expect((migrated.style as { color?: { background?: string } })?.color?.background).toBe(
+            '#e9fbe5'
+        );
+    });
+});

--- a/resources/js/visual-editor/blocks/table/__tests__/edit.test.tsx
+++ b/resources/js/visual-editor/blocks/table/__tests__/edit.test.tsx
@@ -1,0 +1,169 @@
+/**
+ * Tests for the `artisanpack/table` edit component.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+vi.mock('@wordpress/i18n', () => ({
+    __: (text: string) => text,
+}));
+
+vi.mock('@wordpress/element', async () => {
+    const React = await import('react');
+    return { useState: React.useState };
+});
+
+vi.mock('@wordpress/components', () => ({
+    Button: ({
+        children,
+        type,
+        onClick,
+    }: {
+        children: React.ReactNode;
+        type?: 'button' | 'submit';
+        onClick?: () => void;
+    }) => (
+        <button type={type} onClick={onClick}>
+            {children}
+        </button>
+    ),
+    PanelBody: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    Placeholder: ({
+        children,
+        label,
+    }: { children: React.ReactNode; label: string }) => (
+        <div data-testid="placeholder" aria-label={label}>
+            {children}
+        </div>
+    ),
+    TextControl: ({
+        label,
+        value,
+        onChange,
+    }: { label: string; value: string; onChange: (v: string) => void }) => (
+        <label>
+            {label}
+            <input
+                aria-label={label}
+                value={value}
+                onChange={(e) => onChange(e.target.value)}
+            />
+        </label>
+    ),
+    ToggleControl: ({
+        label,
+        checked,
+        onChange,
+    }: { label: string; checked: boolean; onChange: () => void }) => (
+        <label>
+            {label}
+            <input
+                type="checkbox"
+                aria-label={label}
+                checked={checked}
+                onChange={onChange}
+            />
+        </label>
+    ),
+}));
+
+vi.mock('@wordpress/block-editor', () => ({
+    useBlockProps: Object.assign(
+        (props?: Record<string, unknown>) => ({ ...props }),
+        { save: (props?: Record<string, unknown>) => ({ ...props }) }
+    ),
+    BlockControls: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+    InspectorControls: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+    RichText: function RichText(props: {
+        value?: string;
+        onChange?: (v: string) => void;
+        placeholder?: string;
+        tagName?: string;
+        'aria-label'?: string;
+    }) {
+        return (
+            <div
+                role="textbox"
+                aria-label={props['aria-label'] ?? 'rich-text'}
+                data-tag={props.tagName}
+                onClick={() => props.onChange?.('changed')}
+                dangerouslySetInnerHTML={{ __html: props.value ?? '' }}
+            />
+        );
+    },
+}));
+
+import TableEdit from '../edit';
+
+describe('TableEdit', () => {
+    it('renders the placeholder for an empty table', () => {
+        const setAttributes = vi.fn();
+        render(
+            <TableEdit
+                attributes={{ hasFixedLayout: true, head: [], body: [], foot: [] }}
+                setAttributes={setAttributes}
+            />
+        );
+        expect(screen.getByTestId('placeholder')).toBeTruthy();
+    });
+
+    it('creates a table when the Create button is clicked', () => {
+        const setAttributes = vi.fn();
+        render(
+            <TableEdit
+                attributes={{ hasFixedLayout: true, head: [], body: [], foot: [] }}
+                setAttributes={setAttributes}
+            />
+        );
+        fireEvent.click(screen.getByText('Create table'));
+        expect(setAttributes).toHaveBeenCalled();
+        const arg = setAttributes.mock.calls[0][0] as {
+            body: Array<{ cells: unknown[] }>;
+        };
+        expect(Array.isArray(arg.body)).toBe(true);
+        expect(arg.body.length).toBeGreaterThan(0);
+    });
+
+    it('renders a populated table with body cells', () => {
+        const setAttributes = vi.fn();
+        render(
+            <TableEdit
+                attributes={{
+                    hasFixedLayout: true,
+                    head: [],
+                    body: [{ cells: [{ content: 'A', tag: 'td' }] }],
+                    foot: [],
+                }}
+                setAttributes={setAttributes}
+            />
+        );
+        const cell = screen.getByRole('textbox', { name: 'Cell' });
+        expect(cell).toBeTruthy();
+    });
+
+    it('keeps a single figure element across the placeholder → populated transition', () => {
+        const { container, rerender } = render(
+            <TableEdit
+                attributes={{ hasFixedLayout: true, head: [], body: [], foot: [] }}
+                setAttributes={vi.fn()}
+            />
+        );
+        const emptyFigure = container.querySelector('figure');
+        expect(emptyFigure).not.toBeNull();
+
+        rerender(
+            <TableEdit
+                attributes={{
+                    hasFixedLayout: true,
+                    head: [],
+                    body: [{ cells: [{ content: '', tag: 'td' }] }],
+                    foot: [],
+                }}
+                setAttributes={vi.fn()}
+            />
+        );
+        const populatedFigure = container.querySelector('figure');
+        expect(populatedFigure).toBe(emptyFigure);
+    });
+});

--- a/resources/js/visual-editor/blocks/table/__tests__/save.test.tsx
+++ b/resources/js/visual-editor/blocks/table/__tests__/save.test.tsx
@@ -1,0 +1,93 @@
+/**
+ * Tests for the `artisanpack/table` save component.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+vi.mock('@wordpress/block-editor', () => ({
+    useBlockProps: Object.assign(
+        (props?: Record<string, unknown>) => ({ ...props }),
+        { save: (props?: Record<string, unknown>) => ({ ...props }) }
+    ),
+    RichText: Object.assign(() => null, {
+        isEmpty: (v?: string) => !v || v.length === 0,
+        Content: ({ value, tagName }: { value?: string; tagName?: string }) => {
+            const Tag = (tagName ?? 'td') as keyof JSX.IntrinsicElements;
+            return (
+                <Tag dangerouslySetInnerHTML={{ __html: value ?? '' }} />
+            );
+        },
+    }),
+    __experimentalGetBorderClassesAndStyles: () => ({ className: '', style: {} }),
+    __experimentalGetColorClassesAndStyles: () => ({ className: '', style: {} }),
+    __experimentalGetElementClassName: () => 'wp-element-caption',
+}));
+
+import TableSave from '../save';
+import metadata from '../block.json';
+
+describe('artisanpack/table block.json', () => {
+    it('declares the artisanpack namespace', () => {
+        expect(metadata.name).toBe('artisanpack/table');
+        expect(metadata.category).toBe('text');
+    });
+
+    it('has thead/tbody/tfoot query attributes', () => {
+        expect(metadata.attributes.head.selector).toBe('thead tr');
+        expect(metadata.attributes.body.selector).toBe('tbody tr');
+        expect(metadata.attributes.foot.selector).toBe('tfoot tr');
+    });
+});
+
+describe('TableSave', () => {
+    it('returns null for empty tables', () => {
+        const html = renderToStaticMarkup(
+            <TableSave
+                attributes={{
+                    hasFixedLayout: true,
+                    head: [],
+                    body: [],
+                    foot: [],
+                }}
+            />
+        );
+        expect(html).toBe('');
+    });
+
+    it('renders a figure > table when body has rows', () => {
+        const html = renderToStaticMarkup(
+            <TableSave
+                attributes={{
+                    hasFixedLayout: true,
+                    head: [],
+                    body: [
+                        { cells: [{ content: 'cell', tag: 'td' }] },
+                    ],
+                    foot: [],
+                }}
+            />
+        );
+        expect(html).toContain('<figure');
+        expect(html).toContain('<table');
+        expect(html).toContain('has-fixed-layout');
+        expect(html).toContain('<td');
+        expect(html).toContain('cell');
+    });
+
+    it('renders caption when present', () => {
+        const html = renderToStaticMarkup(
+            <TableSave
+                attributes={{
+                    hasFixedLayout: true,
+                    caption: 'A caption',
+                    head: [],
+                    body: [{ cells: [{ content: 'c', tag: 'td' }] }],
+                    foot: [],
+                }}
+            />
+        );
+        expect(html).toContain('<figcaption');
+        expect(html).toContain('A caption');
+    });
+});

--- a/resources/js/visual-editor/blocks/table/__tests__/transforms.test.ts
+++ b/resources/js/visual-editor/blocks/table/__tests__/transforms.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Transforms tests for `artisanpack/table`.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@wordpress/blocks', () => ({
+    createBlock: (name: string, attributes?: Record<string, unknown>) => ({
+        name,
+        attributes: attributes ?? {},
+        innerBlocks: [],
+    }),
+}));
+
+import transforms from '../transforms';
+import { normalizeRowColSpan } from '../utils';
+
+describe('normalizeRowColSpan', () => {
+    it('returns undefined for the default value (1)', () => {
+        expect(normalizeRowColSpan('1')).toBeUndefined();
+        expect(normalizeRowColSpan(1)).toBeUndefined();
+    });
+
+    it('returns undefined for non-numeric input', () => {
+        expect(normalizeRowColSpan('abc')).toBeUndefined();
+        expect(normalizeRowColSpan(null)).toBeUndefined();
+        expect(normalizeRowColSpan(undefined)).toBeUndefined();
+    });
+
+    it('returns the string form of integers > 1', () => {
+        expect(normalizeRowColSpan('3')).toBe('3');
+        expect(normalizeRowColSpan(5)).toBe('5');
+    });
+
+    it('returns undefined for negative values', () => {
+        expect(normalizeRowColSpan('-2')).toBeUndefined();
+    });
+
+    it('returns undefined for zero (an explicit colspan/rowspan of 0)', () => {
+        expect(normalizeRowColSpan(0)).toBeUndefined();
+        expect(normalizeRowColSpan('0')).toBeUndefined();
+    });
+});
+
+describe('table transforms', () => {
+    it('block transform from core/table → artisanpack/table', () => {
+        const fromBlock = transforms.from.find(
+            (t: { type: string; blocks?: string[] }) =>
+                t.type === 'block' && t.blocks?.[0] === 'core/table'
+        ) as { transform: (a: Record<string, unknown>) => { name: string } };
+        expect(fromBlock.transform({}).name).toBe('artisanpack/table');
+    });
+
+    it('block transform to core/table', () => {
+        const toBlock = transforms.to.find(
+            (t: { type: string; blocks?: string[] }) =>
+                t.type === 'block' && t.blocks?.[0] === 'core/table'
+        ) as { transform: (a: Record<string, unknown>) => { name: string } };
+        expect(toBlock.transform({}).name).toBe('core/table');
+    });
+});

--- a/resources/js/visual-editor/blocks/table/__tests__/transforms.test.ts
+++ b/resources/js/visual-editor/blocks/table/__tests__/transforms.test.ts
@@ -46,7 +46,7 @@ describe('table transforms', () => {
     it('block transform from core/table → artisanpack/table', () => {
         const fromBlock = transforms.from.find(
             (t: { type: string; blocks?: string[] }) =>
-                t.type === 'block' && t.blocks?.[0] === 'core/table'
+                t.type === 'block' && !!t.blocks?.includes('core/table')
         ) as { transform: (a: Record<string, unknown>) => { name: string } };
         expect(fromBlock.transform({}).name).toBe('artisanpack/table');
     });
@@ -54,7 +54,7 @@ describe('table transforms', () => {
     it('block transform to core/table', () => {
         const toBlock = transforms.to.find(
             (t: { type: string; blocks?: string[] }) =>
-                t.type === 'block' && t.blocks?.[0] === 'core/table'
+                t.type === 'block' && !!t.blocks?.includes('core/table')
         ) as { transform: (a: Record<string, unknown>) => { name: string } };
         expect(toBlock.transform({}).name).toBe('core/table');
     });

--- a/resources/js/visual-editor/blocks/table/block.json
+++ b/resources/js/visual-editor/blocks/table/block.json
@@ -1,0 +1,220 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "artisanpack/table",
+    "title": "Table",
+    "category": "text",
+    "description": "Create structured content in rows and columns to display information.",
+    "textdomain": "artisanpack-visual-editor",
+    "attributes": {
+        "hasFixedLayout": {
+            "type": "boolean",
+            "default": true
+        },
+        "caption": {
+            "type": "rich-text",
+            "source": "rich-text",
+            "selector": "figcaption",
+            "role": "content"
+        },
+        "head": {
+            "type": "array",
+            "default": [],
+            "source": "query",
+            "selector": "thead tr",
+            "query": {
+                "cells": {
+                    "type": "array",
+                    "default": [],
+                    "source": "query",
+                    "selector": "td,th",
+                    "query": {
+                        "content": {
+                            "type": "rich-text",
+                            "source": "rich-text",
+                            "role": "content"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "default": "td",
+                            "source": "tag"
+                        },
+                        "scope": {
+                            "type": "string",
+                            "source": "attribute",
+                            "attribute": "scope"
+                        },
+                        "align": {
+                            "type": "string",
+                            "source": "attribute",
+                            "attribute": "data-align"
+                        },
+                        "colspan": {
+                            "type": "string",
+                            "source": "attribute",
+                            "attribute": "colspan"
+                        },
+                        "rowspan": {
+                            "type": "string",
+                            "source": "attribute",
+                            "attribute": "rowspan"
+                        }
+                    }
+                }
+            }
+        },
+        "body": {
+            "type": "array",
+            "default": [],
+            "source": "query",
+            "selector": "tbody tr",
+            "query": {
+                "cells": {
+                    "type": "array",
+                    "default": [],
+                    "source": "query",
+                    "selector": "td,th",
+                    "query": {
+                        "content": {
+                            "type": "rich-text",
+                            "source": "rich-text",
+                            "role": "content"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "default": "td",
+                            "source": "tag"
+                        },
+                        "scope": {
+                            "type": "string",
+                            "source": "attribute",
+                            "attribute": "scope"
+                        },
+                        "align": {
+                            "type": "string",
+                            "source": "attribute",
+                            "attribute": "data-align"
+                        },
+                        "colspan": {
+                            "type": "string",
+                            "source": "attribute",
+                            "attribute": "colspan"
+                        },
+                        "rowspan": {
+                            "type": "string",
+                            "source": "attribute",
+                            "attribute": "rowspan"
+                        }
+                    }
+                }
+            }
+        },
+        "foot": {
+            "type": "array",
+            "default": [],
+            "source": "query",
+            "selector": "tfoot tr",
+            "query": {
+                "cells": {
+                    "type": "array",
+                    "default": [],
+                    "source": "query",
+                    "selector": "td,th",
+                    "query": {
+                        "content": {
+                            "type": "rich-text",
+                            "source": "rich-text",
+                            "role": "content"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "default": "td",
+                            "source": "tag"
+                        },
+                        "scope": {
+                            "type": "string",
+                            "source": "attribute",
+                            "attribute": "scope"
+                        },
+                        "align": {
+                            "type": "string",
+                            "source": "attribute",
+                            "attribute": "data-align"
+                        },
+                        "colspan": {
+                            "type": "string",
+                            "source": "attribute",
+                            "attribute": "colspan"
+                        },
+                        "rowspan": {
+                            "type": "string",
+                            "source": "attribute",
+                            "attribute": "rowspan"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "supports": {
+        "anchor": true,
+        "align": true,
+        "color": {
+            "__experimentalSkipSerialization": true,
+            "gradients": true,
+            "__experimentalDefaultControls": {
+                "background": true,
+                "text": true
+            }
+        },
+        "spacing": {
+            "margin": true,
+            "padding": true,
+            "__experimentalDefaultControls": {
+                "margin": false,
+                "padding": false
+            }
+        },
+        "typography": {
+            "fontSize": true,
+            "lineHeight": true,
+            "__experimentalFontFamily": true,
+            "__experimentalFontStyle": true,
+            "__experimentalFontWeight": true,
+            "__experimentalLetterSpacing": true,
+            "__experimentalTextTransform": true,
+            "__experimentalTextDecoration": true,
+            "__experimentalDefaultControls": {
+                "fontSize": true
+            }
+        },
+        "__experimentalBorder": {
+            "__experimentalSkipSerialization": true,
+            "color": true,
+            "style": true,
+            "width": true,
+            "__experimentalDefaultControls": {
+                "color": true,
+                "style": true,
+                "width": true
+            }
+        },
+        "interactivity": {
+            "clientNavigation": true
+        }
+    },
+    "selectors": {
+        "root": ".wp-block-table > table",
+        "spacing": ".wp-block-table"
+    },
+    "styles": [
+        {
+            "name": "regular",
+            "label": "Default",
+            "isDefault": true
+        },
+        { "name": "stripes", "label": "Stripes" }
+    ],
+    "editorStyle": "wp-block-table-editor",
+    "style": "wp-block-table"
+}

--- a/resources/js/visual-editor/blocks/table/deprecated.tsx
+++ b/resources/js/visual-editor/blocks/table/deprecated.tsx
@@ -1,0 +1,456 @@
+/**
+ * Table — deprecation chain.
+ *
+ * Full port of `@wordpress/block-library/src/table/deprecated.js` (v9.43.0).
+ * v4 → v1 cover historical save shapes. The v2 chain also handles the
+ * legacy `subtle-light-gray`/etc. `backgroundColor` slugs by migrating
+ * them into `style.color.background` hex values.
+ */
+
+import clsx from 'clsx';
+import {
+    RichText,
+    getColorClassName,
+    useBlockProps,
+    __experimentalGetBorderClassesAndStyles as getBorderClassesAndStyles,
+    __experimentalGetColorClassesAndStyles as getColorClassesAndStyles,
+    __experimentalGetElementClassName,
+} from '@wordpress/block-editor';
+
+const oldColors: Record<string, string> = {
+    'subtle-light-gray': '#f3f4f5',
+    'subtle-pale-green': '#e9fbe5',
+    'subtle-pale-blue': '#e7f5fe',
+    'subtle-pale-pink': '#fcf0ef',
+};
+
+interface LegacyTableCell {
+    content?: string;
+    tag?: string;
+    scope?: string;
+    align?: string;
+    colspan?: string;
+    rowspan?: string;
+}
+
+interface LegacyTableRow {
+    cells: LegacyTableCell[];
+}
+
+interface LegacyTableAttributes {
+    hasFixedLayout?: boolean;
+    backgroundColor?: string;
+    caption?: string;
+    head?: LegacyTableRow[];
+    body?: LegacyTableRow[];
+    foot?: LegacyTableRow[];
+    style?: Record<string, unknown>;
+    [key: string]: unknown;
+}
+
+const v4Query = {
+    content: { type: 'rich-text', source: 'rich-text' },
+    tag: { type: 'string', default: 'td', source: 'tag' },
+    scope: { type: 'string', source: 'attribute', attribute: 'scope' },
+    align: { type: 'string', source: 'attribute', attribute: 'data-align' },
+    colspan: { type: 'string', source: 'attribute', attribute: 'colspan' },
+    rowspan: { type: 'string', source: 'attribute', attribute: 'rowspan' },
+};
+
+const sharedSectionAttributes = (query: object) => ({
+    head: {
+        type: 'array',
+        default: [],
+        source: 'query',
+        selector: 'thead tr',
+        query: {
+            cells: {
+                type: 'array',
+                default: [],
+                source: 'query',
+                selector: 'td,th',
+                query,
+            },
+        },
+    },
+    body: {
+        type: 'array',
+        default: [],
+        source: 'query',
+        selector: 'tbody tr',
+        query: {
+            cells: {
+                type: 'array',
+                default: [],
+                source: 'query',
+                selector: 'td,th',
+                query,
+            },
+        },
+    },
+    foot: {
+        type: 'array',
+        default: [],
+        source: 'query',
+        selector: 'tfoot tr',
+        query: {
+            cells: {
+                type: 'array',
+                default: [],
+                source: 'query',
+                selector: 'td,th',
+                query,
+            },
+        },
+    },
+});
+
+const v4 = {
+    attributes: {
+        hasFixedLayout: { type: 'boolean', default: false },
+        caption: {
+            type: 'rich-text',
+            source: 'rich-text',
+            selector: 'figcaption',
+        },
+        ...sharedSectionAttributes(v4Query),
+    },
+    supports: {
+        anchor: true,
+        align: true,
+        color: { __experimentalSkipSerialization: true, gradients: true },
+        spacing: { margin: true, padding: true },
+        typography: { fontSize: true, lineHeight: true },
+        __experimentalBorder: {
+            __experimentalSkipSerialization: true,
+            color: true,
+            style: true,
+            width: true,
+        },
+        __experimentalSelector: '.wp-block-table > table',
+    },
+    save({ attributes }: { attributes: LegacyTableAttributes }) {
+        const { hasFixedLayout, head = [], body = [], foot = [], caption } = attributes;
+        const isEmpty = !head.length && !body.length && !foot.length;
+        if (isEmpty) {
+            return null;
+        }
+
+        const colorProps = getColorClassesAndStyles(attributes);
+        const borderProps = getBorderClassesAndStyles(attributes);
+
+        const classes = clsx(colorProps.className, borderProps.className, {
+            'has-fixed-layout': hasFixedLayout,
+        });
+        const hasCaption = !RichText.isEmpty(caption);
+
+        const renderSection = (type: 'head' | 'body' | 'foot', rows: LegacyTableRow[]) => {
+            if (!rows.length) {
+                return null;
+            }
+            const Tag = `t${type}` as 'thead' | 'tbody' | 'tfoot';
+            return (
+                <Tag>
+                    {rows.map(({ cells }, rowIndex) => (
+                        <tr key={rowIndex}>
+                            {cells.map((cell, cellIndex) => {
+                                const cellClasses = clsx({
+                                    [`has-text-align-${cell.align}`]: cell.align,
+                                });
+                                return (
+                                    <RichText.Content
+                                        className={cellClasses ? cellClasses : undefined}
+                                        data-align={cell.align}
+                                        tagName={cell.tag}
+                                        value={cell.content}
+                                        key={cellIndex}
+                                        scope={cell.tag === 'th' ? cell.scope : undefined}
+                                        colSpan={cell.colspan}
+                                        rowSpan={cell.rowspan}
+                                    />
+                                );
+                            })}
+                        </tr>
+                    ))}
+                </Tag>
+            );
+        };
+
+        return (
+            <figure {...useBlockProps.save()}>
+                <table
+                    className={classes === '' ? undefined : classes}
+                    style={{ ...colorProps.style, ...borderProps.style }}
+                >
+                    {renderSection('head', head)}
+                    {renderSection('body', body)}
+                    {renderSection('foot', foot)}
+                </table>
+                {hasCaption && (
+                    <RichText.Content
+                        tagName="figcaption"
+                        value={caption}
+                        className={__experimentalGetElementClassName('caption')}
+                    />
+                )}
+            </figure>
+        );
+    },
+};
+
+const v3Query = {
+    content: { type: 'string', source: 'html' },
+    tag: { type: 'string', default: 'td', source: 'tag' },
+    scope: { type: 'string', source: 'attribute', attribute: 'scope' },
+    align: { type: 'string', source: 'attribute', attribute: 'data-align' },
+};
+
+const v3 = {
+    attributes: {
+        hasFixedLayout: { type: 'boolean', default: false },
+        caption: {
+            type: 'string',
+            source: 'html',
+            selector: 'figcaption',
+            default: '',
+        },
+        ...sharedSectionAttributes(v3Query),
+    },
+    supports: {
+        anchor: true,
+        align: true,
+        color: { __experimentalSkipSerialization: true, gradients: true },
+        spacing: { margin: true, padding: true },
+        typography: { fontSize: true, lineHeight: true },
+        __experimentalBorder: {
+            __experimentalSkipSerialization: true,
+            color: true,
+            style: true,
+            width: true,
+        },
+        __experimentalSelector: '.wp-block-table > table',
+    },
+    save({ attributes }: { attributes: LegacyTableAttributes }) {
+        const { hasFixedLayout, head = [], body = [], foot = [], caption } = attributes;
+        const isEmpty = !head.length && !body.length && !foot.length;
+        if (isEmpty) {
+            return null;
+        }
+
+        const colorProps = getColorClassesAndStyles(attributes);
+        const borderProps = getBorderClassesAndStyles(attributes);
+        const classes = clsx(colorProps.className, borderProps.className, {
+            'has-fixed-layout': hasFixedLayout,
+        });
+        const hasCaption = !RichText.isEmpty(caption);
+
+        const renderSection = (type: 'head' | 'body' | 'foot', rows: LegacyTableRow[]) => {
+            if (!rows.length) {
+                return null;
+            }
+            const Tag = `t${type}` as 'thead' | 'tbody' | 'tfoot';
+            return (
+                <Tag>
+                    {rows.map(({ cells }, rowIndex) => (
+                        <tr key={rowIndex}>
+                            {cells.map((cell, cellIndex) => {
+                                const cellClasses = clsx({
+                                    [`has-text-align-${cell.align}`]: cell.align,
+                                });
+                                return (
+                                    <RichText.Content
+                                        className={cellClasses ? cellClasses : undefined}
+                                        data-align={cell.align}
+                                        tagName={cell.tag}
+                                        value={cell.content}
+                                        key={cellIndex}
+                                        scope={cell.tag === 'th' ? cell.scope : undefined}
+                                    />
+                                );
+                            })}
+                        </tr>
+                    ))}
+                </Tag>
+            );
+        };
+
+        return (
+            <figure {...useBlockProps.save()}>
+                <table
+                    className={classes === '' ? undefined : classes}
+                    style={{ ...colorProps.style, ...borderProps.style }}
+                >
+                    {renderSection('head', head)}
+                    {renderSection('body', body)}
+                    {renderSection('foot', foot)}
+                </table>
+                {hasCaption && (
+                    <RichText.Content tagName="figcaption" value={caption} />
+                )}
+            </figure>
+        );
+    },
+};
+
+const v2Query = v3Query;
+
+const v2 = {
+    attributes: {
+        hasFixedLayout: { type: 'boolean', default: false },
+        backgroundColor: { type: 'string' },
+        caption: {
+            type: 'string',
+            source: 'html',
+            selector: 'figcaption',
+            default: '',
+        },
+        ...sharedSectionAttributes(v2Query),
+    },
+    supports: {
+        anchor: true,
+        align: true,
+        __experimentalSelector: '.wp-block-table > table',
+    },
+    save({ attributes }: { attributes: LegacyTableAttributes }) {
+        const {
+            hasFixedLayout,
+            head = [],
+            body = [],
+            foot = [],
+            backgroundColor,
+            caption,
+        } = attributes;
+        const isEmpty = !head.length && !body.length && !foot.length;
+        if (isEmpty) {
+            return null;
+        }
+        const backgroundClass = getColorClassName('background-color', backgroundColor);
+
+        const classes = clsx(backgroundClass, {
+            'has-fixed-layout': hasFixedLayout,
+            'has-background': !!backgroundClass,
+        });
+        const hasCaption = !RichText.isEmpty(caption);
+
+        const renderSection = (type: 'head' | 'body' | 'foot', rows: LegacyTableRow[]) => {
+            if (!rows.length) {
+                return null;
+            }
+            const Tag = `t${type}` as 'thead' | 'tbody' | 'tfoot';
+            return (
+                <Tag>
+                    {rows.map(({ cells }, rowIndex) => (
+                        <tr key={rowIndex}>
+                            {cells.map((cell, cellIndex) => {
+                                const cellClasses = clsx({
+                                    [`has-text-align-${cell.align}`]: cell.align,
+                                });
+                                return (
+                                    <RichText.Content
+                                        className={cellClasses ? cellClasses : undefined}
+                                        data-align={cell.align}
+                                        tagName={cell.tag}
+                                        value={cell.content}
+                                        key={cellIndex}
+                                        scope={cell.tag === 'th' ? cell.scope : undefined}
+                                    />
+                                );
+                            })}
+                        </tr>
+                    ))}
+                </Tag>
+            );
+        };
+
+        return (
+            <figure {...useBlockProps.save()}>
+                <table className={classes === '' ? undefined : classes}>
+                    {renderSection('head', head)}
+                    {renderSection('body', body)}
+                    {renderSection('foot', foot)}
+                </table>
+                {hasCaption && <RichText.Content tagName="figcaption" value={caption} />}
+            </figure>
+        );
+    },
+    isEligible: (attributes: LegacyTableAttributes) => {
+        return (
+            !!attributes.backgroundColor &&
+            attributes.backgroundColor in oldColors &&
+            !attributes.style
+        );
+    },
+    migrate: (attributes: LegacyTableAttributes) => {
+        return {
+            ...attributes,
+            backgroundColor: undefined,
+            style: {
+                color: {
+                    background: oldColors[attributes.backgroundColor as string],
+                },
+            },
+        };
+    },
+};
+
+const v1Query = {
+    content: { type: 'string', source: 'html' },
+    tag: { type: 'string', default: 'td', source: 'tag' },
+    scope: { type: 'string', source: 'attribute', attribute: 'scope' },
+};
+
+const v1 = {
+    attributes: {
+        hasFixedLayout: { type: 'boolean', default: false },
+        backgroundColor: { type: 'string' },
+        ...sharedSectionAttributes(v1Query),
+    },
+    supports: { align: true },
+    save({ attributes }: { attributes: LegacyTableAttributes }) {
+        const { hasFixedLayout, head = [], body = [], foot = [], backgroundColor } = attributes;
+        const isEmpty = !head.length && !body.length && !foot.length;
+        if (isEmpty) {
+            return null;
+        }
+        const backgroundClass = getColorClassName('background-color', backgroundColor);
+        const classes = clsx(backgroundClass, {
+            'has-fixed-layout': hasFixedLayout,
+            'has-background': !!backgroundClass,
+        });
+
+        const renderSection = (type: 'head' | 'body' | 'foot', rows: LegacyTableRow[]) => {
+            if (!rows.length) {
+                return null;
+            }
+            const Tag = `t${type}` as 'thead' | 'tbody' | 'tfoot';
+            return (
+                <Tag>
+                    {rows.map(({ cells }, rowIndex) => (
+                        <tr key={rowIndex}>
+                            {cells.map((cell, cellIndex) => (
+                                <RichText.Content
+                                    tagName={cell.tag}
+                                    value={cell.content}
+                                    key={cellIndex}
+                                    scope={cell.tag === 'th' ? cell.scope : undefined}
+                                />
+                            ))}
+                        </tr>
+                    ))}
+                </Tag>
+            );
+        };
+
+        return (
+            <table className={classes}>
+                {renderSection('head', head)}
+                {renderSection('body', body)}
+                {renderSection('foot', foot)}
+            </table>
+        );
+    },
+};
+
+const deprecated = [v4, v3, v2, v1];
+
+export default deprecated;

--- a/resources/js/visual-editor/blocks/table/edit.tsx
+++ b/resources/js/visual-editor/blocks/table/edit.tsx
@@ -1,0 +1,237 @@
+/**
+ * Table — editor-side render.
+ *
+ * Simplified port of `@wordpress/block-library/src/table/edit.js` (v9.43.0).
+ *
+ * Upstream's 650-line edit ships a full toolbar (row/col add/delete, cell
+ * tag switch, scope picker, alignment, header/footer toggles, …) and a
+ * `state.js` of table-mutation helpers. This fork ships the core editing
+ * surface — the empty-table placeholder, cell RichText editing, a caption,
+ * and a fixed-layout toggle — and defers the heavier toolbar work to a
+ * post-I7 customization phase, alongside the indent/outdent work for the
+ * list/list-item forks.
+ *
+ * Layout note: the `<figure>` is a single stable element across the
+ * placeholder → populated transition. The block-editor's internal ref
+ * tracker is anchored to whatever element receives `useBlockProps`;
+ * swapping figures on the transition leaves dangling refs in upstream
+ * gutenberg's post-insert focus handler.
+ *
+ * CSS note: the upstream gutenberg CSS targets `.wp-block-table`, but
+ * `getBlockDefaultClassName('artisanpack/table')` would normally emit
+ * `wp-block-artisanpack-table`. The `_shared/fork-class-name-alias.ts`
+ * filter remaps the I1 forks back to their upstream class names so the
+ * bundled CSS applies — without it, cells render at 0×0.
+ */
+
+import type { ReactElement } from 'react';
+import { useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import {
+    BlockControls,
+    InspectorControls,
+    RichText,
+    useBlockProps,
+} from '@wordpress/block-editor';
+import {
+    Button,
+    PanelBody,
+    Placeholder,
+    TextControl,
+    ToggleControl,
+} from '@wordpress/components';
+
+interface TableCell {
+    content: string;
+    tag: string;
+    scope?: string;
+    align?: string;
+    colspan?: string;
+    rowspan?: string;
+}
+
+interface TableRow {
+    cells: TableCell[];
+}
+
+interface TableAttributes {
+    hasFixedLayout: boolean;
+    caption?: string;
+    head: TableRow[];
+    body: TableRow[];
+    foot: TableRow[];
+}
+
+interface TableEditProps {
+    readonly attributes: TableAttributes;
+    readonly setAttributes: (next: Partial<TableAttributes>) => void;
+}
+
+function createTable(rowCount: number, columnCount: number): TableRow[] {
+    return Array.from({ length: rowCount }).map(() => ({
+        cells: Array.from({ length: columnCount }).map(() => ({
+            content: '',
+            tag: 'td',
+        })),
+    }));
+}
+
+function updateCell(
+    section: TableRow[],
+    rowIndex: number,
+    columnIndex: number,
+    next: Partial<TableCell>
+): TableRow[] {
+    return section.map((row, ri) => {
+        if (ri !== rowIndex) {
+            return row;
+        }
+        return {
+            cells: row.cells.map((cell, ci) =>
+                ci === columnIndex ? { ...cell, ...next } : cell
+            ),
+        };
+    });
+}
+
+export default function TableEdit({
+    attributes,
+    setAttributes,
+}: TableEditProps): ReactElement {
+    const { hasFixedLayout, caption, head, body, foot } = attributes;
+    const isEmpty = head.length === 0 && body.length === 0 && foot.length === 0;
+    const [initialRowCount, setInitialRowCount] = useState(2);
+    const [initialColumnCount, setInitialColumnCount] = useState(2);
+    const blockProps = useBlockProps();
+
+    const renderSection = (
+        section: 'head' | 'body' | 'foot',
+        rows: TableRow[]
+    ) => {
+        if (!rows.length) {
+            return null;
+        }
+        const Tag = `t${section}` as 'thead' | 'tbody' | 'tfoot';
+        return (
+            <Tag>
+                {rows.map(({ cells }, rowIndex) => (
+                    <tr key={rowIndex}>
+                        {cells.map((cell, columnIndex) => {
+                            const CellTag = (cell.tag || 'td') as 'td' | 'th';
+                            return (
+                                <CellTag
+                                    key={columnIndex}
+                                    data-align={cell.align}
+                                    scope={
+                                        CellTag === 'th' ? cell.scope : undefined
+                                    }
+                                    colSpan={cell.colspan}
+                                    rowSpan={cell.rowspan}
+                                >
+                                    <RichText
+                                        value={cell.content}
+                                        onChange={(content: string) => {
+                                            setAttributes({
+                                                [section]: updateCell(
+                                                    rows,
+                                                    rowIndex,
+                                                    columnIndex,
+                                                    { content }
+                                                ),
+                                            });
+                                        }}
+                                        aria-label={__('Cell')}
+                                    />
+                                </CellTag>
+                            );
+                        })}
+                    </tr>
+                ))}
+            </Tag>
+        );
+    };
+
+    return (
+        <figure {...blockProps}>
+            {!isEmpty && (
+                <>
+                    <BlockControls group="block" />
+                    <InspectorControls>
+                        <PanelBody title={__('Settings')}>
+                            <ToggleControl
+                                label={__('Fixed width table cells')}
+                                checked={!!hasFixedLayout}
+                                onChange={() =>
+                                    setAttributes({
+                                        hasFixedLayout: !hasFixedLayout,
+                                    })
+                                }
+                            />
+                        </PanelBody>
+                    </InspectorControls>
+                </>
+            )}
+            {isEmpty ? (
+                <Placeholder
+                    label={__('Table')}
+                    instructions={__('Insert a table for sharing data.')}
+                >
+                    <form
+                        onSubmit={(event) => {
+                            event.preventDefault();
+                            setAttributes({
+                                body: createTable(
+                                    initialRowCount,
+                                    initialColumnCount
+                                ),
+                            });
+                        }}
+                    >
+                        <TextControl
+                            type="number"
+                            label={__('Column count')}
+                            value={String(initialColumnCount)}
+                            onChange={(value) =>
+                                setInitialColumnCount(parseInt(value, 10) || 1)
+                            }
+                            min={1}
+                        />
+                        <TextControl
+                            type="number"
+                            label={__('Row count')}
+                            value={String(initialRowCount)}
+                            onChange={(value) =>
+                                setInitialRowCount(parseInt(value, 10) || 1)
+                            }
+                            min={1}
+                        />
+                        <Button type="submit" variant="primary">
+                            {__('Create table')}
+                        </Button>
+                    </form>
+                </Placeholder>
+            ) : (
+                <>
+                    <table
+                        className={
+                            hasFixedLayout ? 'has-fixed-layout' : undefined
+                        }
+                    >
+                        {renderSection('head', head)}
+                        {renderSection('body', body)}
+                        {renderSection('foot', foot)}
+                    </table>
+                    <RichText
+                        tagName="figcaption"
+                        aria-label={__('Table caption text')}
+                        placeholder={__('Add caption')}
+                        value={caption ?? ''}
+                        onChange={(value: string) =>
+                            setAttributes({ caption: value })
+                        }
+                    />
+                </>
+            )}
+        </figure>
+    );
+}

--- a/resources/js/visual-editor/blocks/table/edit.tsx
+++ b/resources/js/visual-editor/blocks/table/edit.tsx
@@ -192,7 +192,9 @@ export default function TableEdit({
                             label={__('Column count')}
                             value={String(initialColumnCount)}
                             onChange={(value) =>
-                                setInitialColumnCount(parseInt(value, 10) || 1)
+                                setInitialColumnCount(
+                                    Math.max(1, parseInt(value, 10) || 1)
+                                )
                             }
                             min={1}
                         />
@@ -201,7 +203,9 @@ export default function TableEdit({
                             label={__('Row count')}
                             value={String(initialRowCount)}
                             onChange={(value) =>
-                                setInitialRowCount(parseInt(value, 10) || 1)
+                                setInitialRowCount(
+                                    Math.max(1, parseInt(value, 10) || 1)
+                                )
                             }
                             min={1}
                         />

--- a/resources/js/visual-editor/blocks/table/index.ts
+++ b/resources/js/visual-editor/blocks/table/index.ts
@@ -1,0 +1,26 @@
+/**
+ * Table block entrypoint.
+ *
+ * Fork target: V2 block-fork phase I1 (content cluster, issue #409).
+ */
+
+import metadata from './block.json';
+import edit from './edit';
+import save from './save';
+import deprecated from './deprecated';
+import transforms from './transforms';
+import icon from './inserter-icon';
+
+import './table.css';
+
+export { edit, save, metadata, icon, deprecated, transforms };
+
+export default {
+    name: metadata.name,
+    metadata,
+    edit,
+    save,
+    icon,
+    deprecated,
+    transforms,
+};

--- a/resources/js/visual-editor/blocks/table/inserter-icon.tsx
+++ b/resources/js/visual-editor/blocks/table/inserter-icon.tsx
@@ -1,0 +1,19 @@
+/**
+ * Table — inserter icon.
+ */
+
+import type { ReactElement } from 'react';
+
+export default function TableInserterIcon(): ReactElement {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            width={24}
+            height={24}
+            aria-hidden="true"
+        >
+            <path d="M19.5 4h-15a1.5 1.5 0 0 0-1.5 1.5v13A1.5 1.5 0 0 0 4.5 20h15a1.5 1.5 0 0 0 1.5-1.5v-13A1.5 1.5 0 0 0 19.5 4zm0 4.5h-5V5.5h5V8.5zm-6.5 0h-3.5v-3h3.5v3zm0 1.5v3.5h-3.5v-3.5h3.5zm-5-1.5h-3.5v-3h3.5v3zm0 1.5v3.5h-3.5v-3.5h3.5zm0 5v3h-3.5v-3h3.5zm1.5 0h3.5v3h-3.5v-3zm5 0h5v3h-5v-3zm5-1.5h-5v-3.5h5v3.5z" />
+        </svg>
+    );
+}

--- a/resources/js/visual-editor/blocks/table/save.tsx
+++ b/resources/js/visual-editor/blocks/table/save.tsx
@@ -1,0 +1,129 @@
+/**
+ * Table — saved markup.
+ *
+ * Ported from `@wordpress/block-library/src/table/save.js` (v9.43.0).
+ * Save shape is byte-equivalent to upstream `core/table`.
+ *
+ * Note: upstream pulls `__experimentalGetBorderClassesAndStyles`,
+ * `__experimentalGetColorClassesAndStyles`, and
+ * `__experimentalGetElementClassName` from `@wordpress/block-editor`. These
+ * are public exports (despite the `__experimental` prefix). We re-import
+ * them as-is so the fork stays in sync with the upstream API surface.
+ */
+
+import type { ReactElement } from 'react';
+import clsx from 'clsx';
+import {
+    RichText,
+    useBlockProps,
+    __experimentalGetBorderClassesAndStyles as getBorderClassesAndStyles,
+    __experimentalGetColorClassesAndStyles as getColorClassesAndStyles,
+    __experimentalGetElementClassName,
+} from '@wordpress/block-editor';
+
+interface TableCell {
+    readonly content: string;
+    readonly tag: string;
+    readonly scope?: string;
+    readonly align?: string;
+    readonly colspan?: string;
+    readonly rowspan?: string;
+}
+
+interface TableRow {
+    readonly cells: readonly TableCell[];
+}
+
+interface TableSaveAttributes {
+    readonly hasFixedLayout: boolean;
+    readonly caption?: string;
+    readonly head: readonly TableRow[];
+    readonly body: readonly TableRow[];
+    readonly foot: readonly TableRow[];
+}
+
+interface TableSaveProps {
+    readonly attributes: TableSaveAttributes;
+}
+
+interface SectionProps {
+    readonly type: 'head' | 'body' | 'foot';
+    readonly rows: readonly TableRow[];
+}
+
+function Section({ type, rows }: SectionProps): ReactElement | null {
+    if (!rows.length) {
+        return null;
+    }
+    const Tag = `t${type}` as 'thead' | 'tbody' | 'tfoot';
+    return (
+        <Tag>
+            {rows.map(({ cells }, rowIndex) => (
+                <tr key={rowIndex}>
+                    {cells.map(
+                        (
+                            { content, tag, scope, align, colspan, rowspan },
+                            cellIndex
+                        ) => {
+                            const cellClasses = clsx({
+                                [`has-text-align-${align}`]: align,
+                            });
+                            return (
+                                <RichText.Content
+                                    className={cellClasses ? cellClasses : undefined}
+                                    data-align={align}
+                                    tagName={tag}
+                                    value={content}
+                                    key={cellIndex}
+                                    scope={tag === 'th' ? scope : undefined}
+                                    colSpan={colspan}
+                                    rowSpan={rowspan}
+                                />
+                            );
+                        }
+                    )}
+                </tr>
+            ))}
+        </Tag>
+    );
+}
+
+export default function TableSave({
+    attributes,
+}: TableSaveProps): ReactElement | null {
+    const { hasFixedLayout, head, body, foot, caption } = attributes;
+    const isEmpty = !head.length && !body.length && !foot.length;
+
+    if (isEmpty) {
+        return null;
+    }
+
+    const colorProps = getColorClassesAndStyles(attributes);
+    const borderProps = getBorderClassesAndStyles(attributes);
+
+    const classes = clsx(colorProps.className, borderProps.className, {
+        'has-fixed-layout': hasFixedLayout,
+    });
+
+    const hasCaption = !RichText.isEmpty(caption);
+
+    return (
+        <figure {...useBlockProps.save()}>
+            <table
+                className={classes === '' ? undefined : classes}
+                style={{ ...colorProps.style, ...borderProps.style }}
+            >
+                <Section type="head" rows={head} />
+                <Section type="body" rows={body} />
+                <Section type="foot" rows={foot} />
+            </table>
+            {hasCaption && (
+                <RichText.Content
+                    tagName="figcaption"
+                    value={caption}
+                    className={__experimentalGetElementClassName('caption')}
+                />
+            )}
+        </figure>
+    );
+}

--- a/resources/js/visual-editor/blocks/table/table.css
+++ b/resources/js/visual-editor/blocks/table/table.css
@@ -1,0 +1,169 @@
+/*
+ * Table — frontend styles.
+ *
+ * Ported from `@wordpress/block-library/src/table/style.scss` (v9.43.0).
+ * Sass variables / nesting resolved inline. The `border-color: inherit`
+ * pattern is preserved verbatim (it's load-bearing for the block-support
+ * border color/style propagation).
+ */
+
+.wp-block-table {
+    overflow-x: auto;
+}
+
+.wp-block-table table {
+    border-collapse: collapse;
+    width: 100%;
+}
+
+.wp-block-table thead {
+    border-bottom: 3px solid;
+}
+
+.wp-block-table tfoot {
+    border-top: 3px solid;
+}
+
+.wp-block-table td,
+.wp-block-table th {
+    border: 1px solid;
+    padding: 0.5em;
+}
+
+.wp-block-table .has-fixed-layout {
+    table-layout: fixed;
+    width: 100%;
+}
+
+.wp-block-table .has-fixed-layout td,
+.wp-block-table .has-fixed-layout th {
+    word-break: break-word;
+}
+
+.wp-block-table.alignleft,
+.wp-block-table.aligncenter,
+.wp-block-table.alignright {
+    display: table;
+    width: auto;
+}
+
+.wp-block-table.alignleft td,
+.wp-block-table.alignleft th,
+.wp-block-table.aligncenter td,
+.wp-block-table.aligncenter th,
+.wp-block-table.alignright td,
+.wp-block-table.alignright th {
+    word-break: break-word;
+}
+
+.wp-block-table .has-subtle-light-gray-background-color {
+    background-color: #f3f4f5;
+}
+
+.wp-block-table .has-subtle-pale-green-background-color {
+    background-color: #e9fbe5;
+}
+
+.wp-block-table .has-subtle-pale-blue-background-color {
+    background-color: #e7f5fe;
+}
+
+.wp-block-table .has-subtle-pale-pink-background-color {
+    background-color: #fcf0ef;
+}
+
+.wp-block-table.is-style-stripes {
+    border-spacing: 0;
+    border-collapse: inherit;
+    background-color: transparent;
+    border-bottom: 1px solid #f0f0f0;
+}
+
+.wp-block-table.is-style-stripes tbody tr:nth-child(odd) {
+    background-color: #f0f0f0;
+}
+
+.wp-block-table.is-style-stripes.has-subtle-light-gray-background-color tbody tr:nth-child(odd) {
+    background-color: #f3f4f5;
+}
+
+.wp-block-table.is-style-stripes.has-subtle-pale-green-background-color tbody tr:nth-child(odd) {
+    background-color: #e9fbe5;
+}
+
+.wp-block-table.is-style-stripes.has-subtle-pale-blue-background-color tbody tr:nth-child(odd) {
+    background-color: #e7f5fe;
+}
+
+.wp-block-table.is-style-stripes.has-subtle-pale-pink-background-color tbody tr:nth-child(odd) {
+    background-color: #fcf0ef;
+}
+
+.wp-block-table.is-style-stripes th,
+.wp-block-table.is-style-stripes td {
+    border-color: transparent;
+}
+
+.wp-block-table .has-border-color > *,
+.wp-block-table .has-border-color tr,
+.wp-block-table .has-border-color th,
+.wp-block-table .has-border-color td {
+    border-color: inherit;
+}
+
+.wp-block-table table[style*='border-top-color'] > *,
+.wp-block-table table[style*='border-top-color'] tr:first-child {
+    border-top-color: inherit;
+}
+
+.wp-block-table table[style*='border-top-color'] tr:first-child th,
+.wp-block-table table[style*='border-top-color'] tr:first-child td {
+    border-top-color: inherit;
+}
+
+.wp-block-table table[style*='border-top-color'] tr:not(:first-child) {
+    border-top-color: currentColor;
+}
+
+.wp-block-table table[style*='border-right-color'] > *,
+.wp-block-table table[style*='border-right-color'] tr,
+.wp-block-table table[style*='border-right-color'] th,
+.wp-block-table table[style*='border-right-color'] td:last-child {
+    border-right-color: inherit;
+}
+
+.wp-block-table table[style*='border-bottom-color'] > *,
+.wp-block-table table[style*='border-bottom-color'] tr:last-child {
+    border-bottom-color: inherit;
+}
+
+.wp-block-table table[style*='border-bottom-color'] tr:last-child th,
+.wp-block-table table[style*='border-bottom-color'] tr:last-child td {
+    border-bottom-color: inherit;
+}
+
+.wp-block-table table[style*='border-bottom-color'] tr:not(:last-child) {
+    border-bottom-color: currentColor;
+}
+
+.wp-block-table table[style*='border-left-color'] > *,
+.wp-block-table table[style*='border-left-color'] tr,
+.wp-block-table table[style*='border-left-color'] th,
+.wp-block-table table[style*='border-left-color'] td:first-child {
+    border-left-color: inherit;
+}
+
+.wp-block-table table[style*='border-style'] > *,
+.wp-block-table table[style*='border-style'] tr,
+.wp-block-table table[style*='border-style'] th,
+.wp-block-table table[style*='border-style'] td {
+    border-style: inherit;
+}
+
+.wp-block-table table[style*='border-width'] > *,
+.wp-block-table table[style*='border-width'] tr,
+.wp-block-table table[style*='border-width'] th,
+.wp-block-table table[style*='border-width'] td {
+    border-width: inherit;
+    border-style: inherit;
+}

--- a/resources/js/visual-editor/blocks/table/transforms.ts
+++ b/resources/js/visual-editor/blocks/table/transforms.ts
@@ -1,0 +1,133 @@
+/**
+ * Table — transforms.
+ *
+ * Ported from `@wordpress/block-library/src/table/transforms.js` (v9.43.0).
+ * Extended with bidirectional block transforms for `core/table` ↔
+ * `artisanpack/table`.
+ */
+
+import { createBlock } from '@wordpress/blocks';
+
+import metadata from './block.json';
+import { normalizeRowColSpan } from './utils';
+
+const { name } = metadata;
+
+interface PasteTransformNode {
+    readonly children: HTMLCollectionOf<Element>;
+    readonly nodeName: string;
+}
+
+interface RawTransformContext {
+    readonly phrasingContentSchema: unknown;
+}
+
+const tableContentPasteSchema = ({
+    phrasingContentSchema,
+}: RawTransformContext) => ({
+    tr: {
+        allowEmpty: true,
+        children: {
+            th: {
+                allowEmpty: true,
+                children: phrasingContentSchema,
+                attributes: ['scope', 'colspan', 'rowspan', 'style'],
+            },
+            td: {
+                allowEmpty: true,
+                children: phrasingContentSchema,
+                attributes: ['colspan', 'rowspan', 'style'],
+            },
+        },
+    },
+});
+
+const tablePasteSchema = (args: RawTransformContext) => ({
+    table: {
+        children: {
+            thead: { allowEmpty: true, children: tableContentPasteSchema(args) },
+            tfoot: { allowEmpty: true, children: tableContentPasteSchema(args) },
+            tbody: { allowEmpty: true, children: tableContentPasteSchema(args) },
+        },
+    },
+});
+
+const transforms = {
+    from: [
+        {
+            type: 'raw',
+            selector: 'table',
+            schema: tablePasteSchema,
+            transform: (node: PasteTransformNode) => {
+                const attributes = Array.from(node.children).reduce(
+                    (sectionAcc, section) => {
+                        if (!section.children.length) {
+                            return sectionAcc;
+                        }
+                        const sectionName = section.nodeName.toLowerCase().slice(1);
+                        const sectionAttributes = Array.from(section.children).reduce(
+                            (rowAcc, row) => {
+                                if (!row.children.length) {
+                                    return rowAcc;
+                                }
+                                const rowAttributes = Array.from(row.children).reduce(
+                                    (colAcc, col) => {
+                                        const rowspan = normalizeRowColSpan(
+                                            col.getAttribute('rowspan')
+                                        );
+                                        const colspan = normalizeRowColSpan(
+                                            col.getAttribute('colspan')
+                                        );
+                                        const styledCol = col as HTMLElement;
+                                        const { textAlign } = styledCol.style || {};
+                                        let align;
+                                        if (
+                                            textAlign === 'left' ||
+                                            textAlign === 'center' ||
+                                            textAlign === 'right'
+                                        ) {
+                                            align = textAlign;
+                                        }
+                                        (colAcc as unknown[]).push({
+                                            tag: col.nodeName.toLowerCase(),
+                                            content: col.innerHTML,
+                                            rowspan,
+                                            colspan,
+                                            align,
+                                        });
+                                        return colAcc;
+                                    },
+                                    [] as unknown[]
+                                );
+                                (rowAcc as unknown[]).push({ cells: rowAttributes });
+                                return rowAcc;
+                            },
+                            [] as unknown[]
+                        );
+                        (sectionAcc as Record<string, unknown>)[sectionName] =
+                            sectionAttributes;
+                        return sectionAcc;
+                    },
+                    {} as Record<string, unknown>
+                );
+                return createBlock(name, attributes);
+            },
+        },
+        {
+            type: 'block',
+            blocks: ['core/table'],
+            transform: (attributes: Record<string, unknown>) =>
+                createBlock(name, attributes),
+        },
+    ],
+    to: [
+        {
+            type: 'block',
+            blocks: ['core/table'],
+            transform: (attributes: Record<string, unknown>) =>
+                createBlock('core/table', attributes),
+        },
+    ],
+};
+
+export default transforms;

--- a/resources/js/visual-editor/blocks/table/upstream-diff-report.json
+++ b/resources/js/visual-editor/blocks/table/upstream-diff-report.json
@@ -20,7 +20,7 @@
             "status": "rewritten",
             "notes": "Simplified edit owned by the fork. Ships the empty-table placeholder, RichText cell editing, caption, and the fixed-layout toggle. The heavier toolbar surface (row/col add/delete, cell tag switching, scope/alignment per cell, header/footer toggles) is intentionally deferred to a post-I7 customization phase. The fork keeps a single `<figure>` element across the placeholder → populated transition — swapping it leaves dangling refs in gutenberg's post-insert focus handler. CSS parity comes from the `_shared/fork-class-name-alias.ts` filter that remaps the I1 fork class names back to their `wp-block-{slug}` upstream forms.",
             "result": "skipped-status",
-            "forkDigest": "f5628c85642a"
+            "forkDigest": "a1fe42e92daa"
         },
         {
             "fork": "save.tsx",
@@ -52,7 +52,7 @@
             "status": "adapted",
             "notes": "TypeScript port of `normalizeRowColSpan`.",
             "result": "skipped-status",
-            "forkDigest": "61b2491d8bb6"
+            "forkDigest": "19be89642938"
         },
         {
             "fork": "table.css",

--- a/resources/js/visual-editor/blocks/table/upstream-diff-report.json
+++ b/resources/js/visual-editor/blocks/table/upstream-diff-report.json
@@ -1,0 +1,82 @@
+{
+    "block": "table",
+    "status": "in-sync",
+    "upstream": {
+        "pinnedVersion": "9.43.0",
+        "subpath": "table"
+    },
+    "files": [
+        {
+            "fork": "block.json",
+            "upstream": "block.json",
+            "status": "adapted",
+            "notes": "name + textdomain swapped.",
+            "result": "skipped-status",
+            "forkDigest": "f6e534e0f0ca"
+        },
+        {
+            "fork": "edit.tsx",
+            "upstream": "edit.js",
+            "status": "rewritten",
+            "notes": "Simplified edit owned by the fork. Ships the empty-table placeholder, RichText cell editing, caption, and the fixed-layout toggle. The heavier toolbar surface (row/col add/delete, cell tag switching, scope/alignment per cell, header/footer toggles) is intentionally deferred to a post-I7 customization phase. The fork keeps a single `<figure>` element across the placeholder → populated transition — swapping it leaves dangling refs in gutenberg's post-insert focus handler. CSS parity comes from the `_shared/fork-class-name-alias.ts` filter that remaps the I1 fork class names back to their `wp-block-{slug}` upstream forms.",
+            "result": "skipped-status",
+            "forkDigest": "f5628c85642a"
+        },
+        {
+            "fork": "save.tsx",
+            "upstream": "save.js",
+            "status": "adapted",
+            "notes": "TypeScript port; markup verbatim to upstream.",
+            "result": "skipped-status",
+            "forkDigest": "a729c5f5152b"
+        },
+        {
+            "fork": "deprecated.tsx",
+            "upstream": "deprecated.js",
+            "status": "adapted",
+            "notes": "Full 4-entry chain ported verbatim (v4 → v1). v2 carries the legacy `subtle-light-gray`/etc. backgroundColor → style.color.background migration.",
+            "result": "skipped-status",
+            "forkDigest": "2009ddc56795"
+        },
+        {
+            "fork": "transforms.ts",
+            "upstream": "transforms.js",
+            "status": "extended",
+            "notes": "Upstream raw HTML paste schema preserved; added bidirectional core/table ↔ artisanpack/table.",
+            "result": "skipped-status",
+            "forkDigest": "4259de94d9c6"
+        },
+        {
+            "fork": "utils.ts",
+            "upstream": "utils.js",
+            "status": "adapted",
+            "notes": "TypeScript port of `normalizeRowColSpan`.",
+            "result": "skipped-status",
+            "forkDigest": "61b2491d8bb6"
+        },
+        {
+            "fork": "table.css",
+            "upstream": "style.scss + theme.scss + editor.scss",
+            "status": "adapted",
+            "notes": "Sass nesting flattened; Sass variables resolved inline. The block-supports `border-color: inherit` chain is preserved.",
+            "result": "skipped-status",
+            "forkDigest": "ff13c6330f94"
+        },
+        {
+            "fork": "inserter-icon.tsx",
+            "upstream": "n/a",
+            "status": "added",
+            "notes": "Inline SVG.",
+            "result": "skipped-status",
+            "forkDigest": "efa04897a824"
+        },
+        {
+            "fork": "index.ts",
+            "upstream": "index.js",
+            "status": "rewritten",
+            "notes": "Auto-discovery contract.",
+            "result": "skipped-status",
+            "forkDigest": "3ffbe061e2d3"
+        }
+    ]
+}

--- a/resources/js/visual-editor/blocks/table/upstream-state.json
+++ b/resources/js/visual-editor/blocks/table/upstream-state.json
@@ -1,0 +1,41 @@
+{
+    "$schema": "../../../../scripts/upstream-state.schema.json",
+    "block": "artisanpack/table",
+    "upstream": {
+        "package": "@wordpress/block-library",
+        "namespace": "core/table",
+        "pinnedVersion": "9.43.0",
+        "subpath": "table"
+    },
+    "forkedAt": "2026-05-27",
+    "$statusLegend": {
+        "ported": "byte-equivalent to upstream (CI fails on drift)",
+        "adapted": "TypeScript port and/or namespace swap; logically equivalent",
+        "extended": "fork adds behavior on top of upstream",
+        "rewritten": "fork replaced upstream entirely",
+        "added": "file unique to the fork (no upstream)"
+    },
+    "files": [
+        { "fork": "block.json", "upstream": "block.json", "status": "adapted", "notes": "name + textdomain swapped." },
+        { "fork": "edit.tsx", "upstream": "edit.js", "status": "rewritten", "notes": "Simplified edit owned by the fork. Ships the empty-table placeholder, RichText cell editing, caption, and the fixed-layout toggle. The heavier toolbar surface (row/col add/delete, cell tag switching, scope/alignment per cell, header/footer toggles) is intentionally deferred to a post-I7 customization phase. The fork keeps a single `<figure>` element across the placeholder → populated transition — swapping it leaves dangling refs in gutenberg's post-insert focus handler. CSS parity comes from the `_shared/fork-class-name-alias.ts` filter that remaps the I1 fork class names back to their `wp-block-{slug}` upstream forms." },
+        { "fork": "save.tsx", "upstream": "save.js", "status": "adapted", "notes": "TypeScript port; markup verbatim to upstream." },
+        { "fork": "deprecated.tsx", "upstream": "deprecated.js", "status": "adapted", "notes": "Full 4-entry chain ported verbatim (v4 → v1). v2 carries the legacy `subtle-light-gray`/etc. backgroundColor → style.color.background migration." },
+        { "fork": "transforms.ts", "upstream": "transforms.js", "status": "extended", "notes": "Upstream raw HTML paste schema preserved; added bidirectional core/table ↔ artisanpack/table." },
+        { "fork": "utils.ts", "upstream": "utils.js", "status": "adapted", "notes": "TypeScript port of `normalizeRowColSpan`." },
+        { "fork": "table.css", "upstream": "style.scss + theme.scss + editor.scss", "status": "adapted", "notes": "Sass nesting flattened; Sass variables resolved inline. The block-supports `border-color: inherit` chain is preserved." },
+        { "fork": "inserter-icon.tsx", "upstream": "n/a", "status": "added", "notes": "Inline SVG." },
+        { "fork": "index.ts", "upstream": "index.js", "status": "rewritten", "notes": "Auto-discovery contract." }
+    ],
+    "vendoredPrimitives": [],
+    "knownDivergences": [
+        "edit.tsx ships a simpler edit experience than upstream. Row/col add/delete, cell tag switching, scope/alignment per cell, and header/footer toggles are NOT in the fork. Upstream's `state.js` (347 lines of table-mutation helpers) is not vendored; the simplified edit only needs `createTable` and one `updateCell` helper, both inlined.",
+        "transforms.ts adds bidirectional block transforms with core/table.",
+        "save.tsx and deprecated.tsx are byte-equivalent to upstream — host content saved against any upstream save shape still deserializes correctly.",
+        "CSS parity with upstream depends on the `_shared/fork-class-name-alias.ts` filter (registered at editor boot), which remaps `wp-block-artisanpack-table` to `wp-block-table` so the bundled gutenberg stylesheet applies."
+    ],
+    "triage": {
+        "label": "in-sync",
+        "lastReviewed": "2026-05-27",
+        "reviewer": "I1 content cluster"
+    }
+}

--- a/resources/js/visual-editor/blocks/table/utils.ts
+++ b/resources/js/visual-editor/blocks/table/utils.ts
@@ -1,0 +1,21 @@
+/**
+ * Table — rowspan/colspan normalizer.
+ *
+ * Ported from `@wordpress/block-library/src/table/utils.js` (v9.43.0).
+ * Returns undefined for non-positive numbers or the default value (1).
+ */
+
+export function normalizeRowColSpan(
+    rowColSpan: string | number | null | undefined
+): string | undefined {
+    const parsedValue = parseInt(String(rowColSpan ?? ''), 10);
+    if (!Number.isInteger(parsedValue)) {
+        return undefined;
+    }
+    // Treat zero as "no span" so an explicit colspan="0"/rowspan="0"
+    // doesn't get serialized into saved markup; upstream filters on the
+    // same condition.
+    return parsedValue <= 0 || parsedValue === 1
+        ? undefined
+        : parsedValue.toString();
+}

--- a/resources/js/visual-editor/blocks/verse/__tests__/deprecated.test.tsx
+++ b/resources/js/visual-editor/blocks/verse/__tests__/deprecated.test.tsx
@@ -1,0 +1,60 @@
+/**
+ * Locks the deprecation chain for `artisanpack/verse`.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+vi.mock('@wordpress/block-editor', () => ({
+    useBlockProps: Object.assign(
+        (props?: Record<string, unknown>) => ({ ...props }),
+        { save: (props?: Record<string, unknown>) => ({ ...props }) }
+    ),
+    RichText: Object.assign(() => null, {
+        Content: ({
+            value,
+            tagName,
+        }: { value?: string; tagName?: string }) => {
+            const Tag = (tagName ?? 'pre') as keyof JSX.IntrinsicElements;
+            return value !== undefined ? (
+                <Tag dangerouslySetInnerHTML={{ __html: value }} />
+            ) : null;
+        },
+    }),
+}));
+
+import deprecated from '../deprecated';
+
+describe('verse deprecation chain', () => {
+    it('has 3 historical entries', () => {
+        expect(deprecated).toHaveLength(3);
+    });
+
+    it('every entry exposes a save callable', () => {
+        deprecated.forEach((entry, i) => {
+            expect(
+                typeof (entry as { save?: unknown }).save,
+                `entry ${i}`
+            ).toBe('function');
+        });
+    });
+
+    it('v3 (entries[0]) renders pre with has-text-align-* class', () => {
+        const entry = deprecated[0] as {
+            save: (p: { attributes: Record<string, unknown> }) => React.ReactElement;
+        };
+        const html = renderToStaticMarkup(
+            entry.save({ attributes: { textAlign: 'center', content: 'x' } })
+        );
+        expect(html).toContain('<pre');
+        expect(html).toContain('has-text-align-center');
+    });
+
+    it('v3 migrates textAlign into style.typography.textAlign', () => {
+        const entry = deprecated[0] as {
+            migrate: (a: Record<string, unknown>) => Record<string, unknown>;
+        };
+        const migrated = entry.migrate({ textAlign: 'right', content: 'x' });
+        expect(migrated.style).toEqual({ typography: { textAlign: 'right' } });
+    });
+});

--- a/resources/js/visual-editor/blocks/verse/__tests__/edit.test.tsx
+++ b/resources/js/visual-editor/blocks/verse/__tests__/edit.test.tsx
@@ -1,0 +1,59 @@
+/**
+ * Tests for the `artisanpack/verse` edit component.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+vi.mock('@wordpress/i18n', () => ({
+    __: (text: string) => text,
+}));
+
+vi.mock('@wordpress/blocks', () => ({
+    createBlock: vi.fn(),
+    getDefaultBlockName: () => 'core/paragraph',
+}));
+
+vi.mock('@wordpress/block-editor', () => ({
+    useBlockProps: Object.assign(
+        (props?: Record<string, unknown>) => ({ ...props }),
+        { save: (props?: Record<string, unknown>) => ({ ...props }) }
+    ),
+    RichText: function RichText(props: {
+        value?: string;
+        onChange?: (v: string) => void;
+        placeholder?: string;
+    }) {
+        return (
+            <div
+                role="textbox"
+                aria-label="verse-rich-text"
+                data-placeholder={props.placeholder}
+                onClick={() => props.onChange?.('Roses are red')}
+                dangerouslySetInnerHTML={{ __html: props.value ?? '' }}
+            />
+        );
+    },
+}));
+
+import VerseEdit from '../edit';
+
+describe('VerseEdit', () => {
+    it('renders a pre RichText with the poetry placeholder', () => {
+        const setAttributes = vi.fn();
+        render(
+            <VerseEdit attributes={{ content: '' }} setAttributes={setAttributes} />
+        );
+        const textbox = screen.getByRole('textbox', { name: 'verse-rich-text' });
+        expect(textbox.getAttribute('data-placeholder')).toBe('Write poetry…');
+    });
+
+    it('forwards onChange to setAttributes', () => {
+        const setAttributes = vi.fn();
+        render(
+            <VerseEdit attributes={{ content: '' }} setAttributes={setAttributes} />
+        );
+        fireEvent.click(screen.getByRole('textbox', { name: 'verse-rich-text' }));
+        expect(setAttributes).toHaveBeenCalledWith({ content: 'Roses are red' });
+    });
+});

--- a/resources/js/visual-editor/blocks/verse/__tests__/save.test.tsx
+++ b/resources/js/visual-editor/blocks/verse/__tests__/save.test.tsx
@@ -1,0 +1,39 @@
+/**
+ * Tests for the `artisanpack/verse` save component.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+vi.mock('@wordpress/block-editor', () => ({
+    useBlockProps: Object.assign(
+        (props?: Record<string, unknown>) => ({ ...props }),
+        { save: (props?: Record<string, unknown>) => ({ ...props }) }
+    ),
+    RichText: Object.assign(() => null, {
+        Content: ({ value }: { value?: string }) =>
+            value !== undefined && value !== ''
+                ? <span dangerouslySetInnerHTML={{ __html: value }} />
+                : null,
+    }),
+}));
+
+import VerseSave from '../save';
+import metadata from '../block.json';
+
+describe('artisanpack/verse block.json', () => {
+    it('declares the artisanpack namespace', () => {
+        expect(metadata.name).toBe('artisanpack/verse');
+        expect(metadata.category).toBe('text');
+    });
+});
+
+describe('VerseSave', () => {
+    it('renders a pre tag with content', () => {
+        const html = renderToStaticMarkup(
+            <VerseSave attributes={{ content: 'Roses are red' }} />
+        );
+        expect(html).toContain('<pre');
+        expect(html).toContain('Roses are red');
+    });
+});

--- a/resources/js/visual-editor/blocks/verse/__tests__/transforms.test.ts
+++ b/resources/js/visual-editor/blocks/verse/__tests__/transforms.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Transforms tests for `artisanpack/verse`.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@wordpress/blocks', () => ({
+    createBlock: (name: string, attributes?: Record<string, unknown>) => ({
+        name,
+        attributes: attributes ?? {},
+        innerBlocks: [],
+    }),
+}));
+
+import transforms from '../transforms';
+
+describe('verse transforms', () => {
+    it('paragraph → verse', () => {
+        const fromBlock = transforms.from.find(
+            (t: { type: string; blocks?: string[] }) =>
+                t.type === 'block' && t.blocks?.includes('core/paragraph')
+        ) as { transform: (a: Record<string, unknown>) => { name: string } };
+        expect(fromBlock.transform({ content: 'x' }).name).toBe(
+            'artisanpack/verse'
+        );
+    });
+
+    it('core/verse → artisanpack/verse', () => {
+        const fromBlock = transforms.from.find(
+            (t: { type: string; blocks?: string[] }) =>
+                t.type === 'block' &&
+                t.blocks?.length === 1 &&
+                t.blocks[0] === 'core/verse'
+        ) as { transform: (a: Record<string, unknown>) => { name: string } };
+        expect(fromBlock.transform({}).name).toBe('artisanpack/verse');
+    });
+
+    it('artisanpack/verse → core/verse', () => {
+        const toBlock = transforms.to.find(
+            (t: { type: string; blocks?: string[] }) =>
+                t.type === 'block' && t.blocks?.[0] === 'core/verse'
+        ) as { transform: (a: Record<string, unknown>) => { name: string } };
+        expect(toBlock.transform({}).name).toBe('core/verse');
+    });
+});

--- a/resources/js/visual-editor/blocks/verse/block.json
+++ b/resources/js/visual-editor/blocks/verse/block.json
@@ -1,0 +1,77 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "artisanpack/verse",
+    "title": "Poetry",
+    "category": "text",
+    "description": "Insert poetry. Use special spacing formats. Or quote song lyrics.",
+    "keywords": [ "poetry", "poem", "verse", "stanza", "song", "lyrics" ],
+    "textdomain": "artisanpack-visual-editor",
+    "attributes": {
+        "content": {
+            "type": "rich-text",
+            "source": "rich-text",
+            "selector": "pre",
+            "__unstablePreserveWhiteSpace": true,
+            "role": "content"
+        }
+    },
+    "supports": {
+        "anchor": true,
+        "background": {
+            "backgroundImage": true,
+            "backgroundSize": true,
+            "__experimentalDefaultControls": {
+                "backgroundImage": true
+            }
+        },
+        "color": {
+            "gradients": true,
+            "link": true,
+            "__experimentalDefaultControls": {
+                "background": true,
+                "text": true
+            }
+        },
+        "dimensions": {
+            "minHeight": true,
+            "__experimentalDefaultControls": {
+                "minHeight": false
+            }
+        },
+        "typography": {
+            "fontSize": true,
+            "__experimentalFontFamily": true,
+            "lineHeight": true,
+            "textAlign": true,
+            "__experimentalFontStyle": true,
+            "__experimentalFontWeight": true,
+            "__experimentalLetterSpacing": true,
+            "__experimentalTextTransform": true,
+            "__experimentalTextDecoration": true,
+            "__experimentalWritingMode": true,
+            "__experimentalDefaultControls": {
+                "fontSize": true
+            }
+        },
+        "spacing": {
+            "margin": true,
+            "padding": true,
+            "__experimentalDefaultControls": {
+                "margin": false,
+                "padding": false
+            }
+        },
+        "__experimentalBorder": {
+            "radius": true,
+            "width": true,
+            "color": true,
+            "style": true
+        },
+        "interactivity": {
+            "clientNavigation": true
+        }
+    },
+    "style": "wp-block-verse",
+    "editorStyle": "wp-block-verse-editor"
+}

--- a/resources/js/visual-editor/blocks/verse/deprecated.tsx
+++ b/resources/js/visual-editor/blocks/verse/deprecated.tsx
@@ -1,0 +1,145 @@
+/**
+ * Verse — deprecation chain.
+ *
+ * Full port of `@wordpress/block-library/src/verse/deprecated.js` (v9.43.0).
+ * v3 → v1 covered.
+ */
+
+import clsx from 'clsx';
+import { RichText, useBlockProps } from '@wordpress/block-editor';
+
+import { migrateFontFamily } from '../_shared/migrate-font-family';
+import { migrateTextAlignAttributeToBlockSupport as migrateTextAlign } from '../_shared/migrate-text-align';
+
+interface LegacyVerseAttributes {
+    content?: string;
+    textAlign?: string;
+    style?: {
+        typography?: {
+            fontFamily?: string;
+        } & Record<string, unknown>;
+    } & Record<string, unknown>;
+    fontFamily?: string;
+    className?: string;
+    [key: string]: unknown;
+}
+
+const v1 = {
+    attributes: {
+        content: {
+            type: 'string',
+            source: 'html',
+            selector: 'pre',
+            default: '',
+        },
+        textAlign: { type: 'string' },
+    },
+    save({ attributes }: { attributes: LegacyVerseAttributes }) {
+        const { textAlign, content } = attributes;
+        return (
+            <RichText.Content
+                tagName="pre"
+                style={{ textAlign }}
+                value={content}
+            />
+        );
+    },
+    migrate: migrateTextAlign,
+};
+
+const v2 = {
+    attributes: {
+        content: {
+            type: 'string',
+            source: 'html',
+            selector: 'pre',
+            default: '',
+            __unstablePreserveWhiteSpace: true,
+            role: 'content',
+        },
+        textAlign: { type: 'string' },
+    },
+    supports: {
+        anchor: true,
+        color: { gradients: true, link: true },
+        typography: { fontSize: true, __experimentalFontFamily: true },
+        spacing: { padding: true },
+    },
+    save({ attributes }: { attributes: LegacyVerseAttributes }) {
+        const { textAlign, content } = attributes;
+        const className = clsx({
+            [`has-text-align-${textAlign}`]: textAlign,
+        });
+        return (
+            <pre {...useBlockProps.save({ className })}>
+                <RichText.Content value={content} />
+            </pre>
+        );
+    },
+    migrate(attributes: LegacyVerseAttributes) {
+        return migrateTextAlign(migrateFontFamily(attributes));
+    },
+    isEligible({ style, textAlign }: LegacyVerseAttributes) {
+        return !!style?.typography?.fontFamily || !!textAlign;
+    },
+};
+
+const v3 = {
+    attributes: {
+        content: {
+            type: 'rich-text',
+            source: 'rich-text',
+            selector: 'pre',
+            __unstablePreserveWhiteSpace: true,
+            role: 'content',
+        },
+        textAlign: { type: 'string' },
+    },
+    supports: {
+        anchor: true,
+        background: { backgroundImage: true, backgroundSize: true },
+        color: { gradients: true, link: true },
+        dimensions: { minHeight: true },
+        typography: {
+            fontSize: true,
+            __experimentalFontFamily: true,
+            lineHeight: true,
+            __experimentalFontStyle: true,
+            __experimentalFontWeight: true,
+            __experimentalLetterSpacing: true,
+            __experimentalTextTransform: true,
+            __experimentalTextDecoration: true,
+            __experimentalWritingMode: true,
+        },
+        spacing: { margin: true, padding: true },
+        __experimentalBorder: {
+            radius: true,
+            width: true,
+            color: true,
+            style: true,
+        },
+        interactivity: { clientNavigation: true },
+    },
+    save({ attributes }: { attributes: LegacyVerseAttributes }) {
+        const { textAlign, content } = attributes;
+        const className = clsx({
+            [`has-text-align-${textAlign}`]: textAlign,
+        });
+        return (
+            <pre {...useBlockProps.save({ className })}>
+                <RichText.Content value={content} />
+            </pre>
+        );
+    },
+    migrate: migrateTextAlign,
+    isEligible(attributes: LegacyVerseAttributes) {
+        return (
+            !!attributes.textAlign ||
+            !!attributes.className?.match(/\bhas-text-align-(left|center|right)\b/)
+        );
+    },
+};
+
+const deprecated = [v3, v2, v1];
+
+export default deprecated;

--- a/resources/js/visual-editor/blocks/verse/edit.tsx
+++ b/resources/js/visual-editor/blocks/verse/edit.tsx
@@ -1,0 +1,61 @@
+/**
+ * Verse — editor-side render.
+ *
+ * Ported from `@wordpress/block-library/src/verse/edit.js` (v9.43.0).
+ * Upstream `useDeprecatedTextAlign` is omitted — the deprecation chain
+ * handles legacy `textAlign` migration on load.
+ */
+
+import type { ReactElement } from 'react';
+import { __ } from '@wordpress/i18n';
+import { RichText, useBlockProps } from '@wordpress/block-editor';
+import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
+
+interface VerseAttributes {
+    readonly content: string;
+}
+
+interface VerseEditProps {
+    readonly attributes: VerseAttributes;
+    readonly setAttributes: (next: Partial<VerseAttributes>) => void;
+    readonly mergeBlocks?: (forward?: boolean) => void;
+    readonly onRemove?: () => void;
+    readonly insertBlocksAfter?: (block: unknown) => void;
+    readonly style?: Record<string, unknown>;
+}
+
+export default function VerseEdit({
+    attributes,
+    setAttributes,
+    mergeBlocks,
+    onRemove,
+    insertBlocksAfter,
+    style,
+}: VerseEditProps): ReactElement {
+    const { content } = attributes;
+    const blockProps = useBlockProps({ style });
+
+    return (
+        <RichText
+            tagName="pre"
+            identifier="content"
+            preserveWhiteSpace
+            value={content}
+            onChange={(nextContent: string) =>
+                setAttributes({ content: nextContent })
+            }
+            aria-label={__('Poetry text')}
+            placeholder={__('Write poetry…')}
+            onRemove={onRemove}
+            onMerge={mergeBlocks}
+            {...blockProps}
+            __unstablePastePlainText
+            __unstableOnSplitAtDoubleLineEnd={() => {
+                const defaultName = getDefaultBlockName();
+                if (defaultName) {
+                    insertBlocksAfter?.(createBlock(defaultName));
+                }
+            }}
+        />
+    );
+}

--- a/resources/js/visual-editor/blocks/verse/index.ts
+++ b/resources/js/visual-editor/blocks/verse/index.ts
@@ -1,0 +1,26 @@
+/**
+ * Verse block entrypoint.
+ *
+ * Fork target: V2 block-fork phase I1 (content cluster, issue #409).
+ */
+
+import metadata from './block.json';
+import edit from './edit';
+import save from './save';
+import deprecated from './deprecated';
+import transforms from './transforms';
+import icon from './inserter-icon';
+
+import './verse.css';
+
+export { edit, save, metadata, icon, deprecated, transforms };
+
+export default {
+    name: metadata.name,
+    metadata,
+    edit,
+    save,
+    icon,
+    deprecated,
+    transforms,
+};

--- a/resources/js/visual-editor/blocks/verse/inserter-icon.tsx
+++ b/resources/js/visual-editor/blocks/verse/inserter-icon.tsx
@@ -1,0 +1,19 @@
+/**
+ * Verse — inserter icon.
+ */
+
+import type { ReactElement } from 'react';
+
+export default function VerseInserterIcon(): ReactElement {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            width={24}
+            height={24}
+            aria-hidden="true"
+        >
+            <path d="M17.8 2c-.6.6-1.2 1.2-1.2 2.5 0 1.7 1.4 2 1.4 3.5 0 .8-.4 1.5-.9 2L18 11c1.2-1.1 2-2 2-3.6 0-1.8-1.4-2.3-1.4-3.5 0-.5.2-1 .6-1.4L17.8 2zm-5 0c-.6.6-1.2 1.2-1.2 2.5 0 1.7 1.4 2 1.4 3.5 0 .8-.4 1.5-.9 2L13 11c1.2-1.1 2-2 2-3.6 0-1.8-1.4-2.3-1.4-3.5 0-.5.2-1 .6-1.4L12.8 2zM4 13c-1.1 0-2 .9-2 2v5h2v-5h5v-2H4zm17 0v2h-5v-2h5z" />
+        </svg>
+    );
+}

--- a/resources/js/visual-editor/blocks/verse/save.tsx
+++ b/resources/js/visual-editor/blocks/verse/save.tsx
@@ -1,0 +1,25 @@
+/**
+ * Verse — saved markup.
+ *
+ * Ported from `@wordpress/block-library/src/verse/save.js` (v9.43.0).
+ */
+
+import type { ReactElement } from 'react';
+import { RichText, useBlockProps } from '@wordpress/block-editor';
+
+interface VerseSaveAttributes {
+    readonly content: string;
+}
+
+interface VerseSaveProps {
+    readonly attributes: VerseSaveAttributes;
+}
+
+export default function VerseSave({ attributes }: VerseSaveProps): ReactElement {
+    const { content } = attributes;
+    return (
+        <pre {...useBlockProps.save()}>
+            <RichText.Content value={content} />
+        </pre>
+    );
+}

--- a/resources/js/visual-editor/blocks/verse/transforms.ts
+++ b/resources/js/visual-editor/blocks/verse/transforms.ts
@@ -1,0 +1,51 @@
+/**
+ * Verse — transforms.
+ *
+ * Ported from `@wordpress/block-library/src/verse/transforms.js` (v9.43.0).
+ * Extended with bidirectional block transforms for `core/verse` ↔
+ * `artisanpack/verse`.
+ */
+
+import { createBlock } from '@wordpress/blocks';
+
+import metadata from './block.json';
+
+const { name } = metadata;
+
+interface VerseAttributes {
+    content?: string;
+    [key: string]: unknown;
+}
+
+const transforms = {
+    from: [
+        {
+            type: 'block',
+            blocks: ['core/paragraph', 'artisanpack/paragraph'],
+            transform: (attributes: VerseAttributes) =>
+                createBlock(name, attributes),
+        },
+        {
+            type: 'block',
+            blocks: ['core/verse'],
+            transform: (attributes: VerseAttributes) =>
+                createBlock(name, attributes),
+        },
+    ],
+    to: [
+        {
+            type: 'block',
+            blocks: ['core/paragraph'],
+            transform: (attributes: VerseAttributes) =>
+                createBlock('core/paragraph', attributes),
+        },
+        {
+            type: 'block',
+            blocks: ['core/verse'],
+            transform: (attributes: VerseAttributes) =>
+                createBlock('core/verse', attributes),
+        },
+    ],
+};
+
+export default transforms;

--- a/resources/js/visual-editor/blocks/verse/upstream-diff-report.json
+++ b/resources/js/visual-editor/blocks/verse/upstream-diff-report.json
@@ -1,0 +1,74 @@
+{
+    "block": "verse",
+    "status": "in-sync",
+    "upstream": {
+        "pinnedVersion": "9.43.0",
+        "subpath": "verse"
+    },
+    "files": [
+        {
+            "fork": "block.json",
+            "upstream": "block.json",
+            "status": "adapted",
+            "notes": "name + textdomain swapped.",
+            "result": "skipped-status",
+            "forkDigest": "84a267f33923"
+        },
+        {
+            "fork": "edit.tsx",
+            "upstream": "edit.js",
+            "status": "adapted",
+            "notes": "TypeScript port. `useDeprecatedTextAlign` not vendored; deprecation chain handles legacy `textAlign`.",
+            "result": "skipped-status",
+            "forkDigest": "c7982858f0dd"
+        },
+        {
+            "fork": "save.tsx",
+            "upstream": "save.js",
+            "status": "adapted",
+            "notes": "TypeScript port.",
+            "result": "skipped-status",
+            "forkDigest": "48c922f51bb3"
+        },
+        {
+            "fork": "deprecated.tsx",
+            "upstream": "deprecated.js",
+            "status": "adapted",
+            "notes": "Full 3-entry chain ported verbatim (v3 → v1). Imports `migrate-text-align` and `migrate-font-family` from blocks/_shared.",
+            "result": "skipped-status",
+            "forkDigest": "39f256eb7bd4"
+        },
+        {
+            "fork": "transforms.ts",
+            "upstream": "transforms.js",
+            "status": "extended",
+            "notes": "Upstream paragraph transforms preserved; added bidirectional core/verse ↔ artisanpack/verse and accepts artisanpack/paragraph.",
+            "result": "skipped-status",
+            "forkDigest": "f803527d2f74"
+        },
+        {
+            "fork": "verse.css",
+            "upstream": "style.scss",
+            "status": "adapted",
+            "notes": "Sass nesting flattened; no variables.",
+            "result": "skipped-status",
+            "forkDigest": "55f946331b7e"
+        },
+        {
+            "fork": "inserter-icon.tsx",
+            "upstream": "n/a",
+            "status": "added",
+            "notes": "Inline SVG.",
+            "result": "skipped-status",
+            "forkDigest": "6591e6e20d15"
+        },
+        {
+            "fork": "index.ts",
+            "upstream": "index.js",
+            "status": "rewritten",
+            "notes": "Auto-discovery contract.",
+            "result": "skipped-status",
+            "forkDigest": "8d381252ee3a"
+        }
+    ]
+}

--- a/resources/js/visual-editor/blocks/verse/upstream-state.json
+++ b/resources/js/visual-editor/blocks/verse/upstream-state.json
@@ -1,0 +1,41 @@
+{
+    "$schema": "../../../../scripts/upstream-state.schema.json",
+    "block": "artisanpack/verse",
+    "upstream": {
+        "package": "@wordpress/block-library",
+        "namespace": "core/verse",
+        "pinnedVersion": "9.43.0",
+        "subpath": "verse"
+    },
+    "forkedAt": "2026-05-27",
+    "$statusLegend": {
+        "ported": "byte-equivalent to upstream (CI fails on drift)",
+        "adapted": "TypeScript port and/or namespace swap; logically equivalent",
+        "extended": "fork adds behavior on top of upstream",
+        "rewritten": "fork replaced upstream entirely",
+        "added": "file unique to the fork (no upstream)"
+    },
+    "files": [
+        { "fork": "block.json", "upstream": "block.json", "status": "adapted", "notes": "name + textdomain swapped." },
+        { "fork": "edit.tsx", "upstream": "edit.js", "status": "adapted", "notes": "TypeScript port. `useDeprecatedTextAlign` not vendored; deprecation chain handles legacy `textAlign`." },
+        { "fork": "save.tsx", "upstream": "save.js", "status": "adapted", "notes": "TypeScript port." },
+        { "fork": "deprecated.tsx", "upstream": "deprecated.js", "status": "adapted", "notes": "Full 3-entry chain ported verbatim (v3 → v1). Imports `migrate-text-align` and `migrate-font-family` from blocks/_shared." },
+        { "fork": "transforms.ts", "upstream": "transforms.js", "status": "extended", "notes": "Upstream paragraph transforms preserved; added bidirectional core/verse ↔ artisanpack/verse and accepts artisanpack/paragraph." },
+        { "fork": "verse.css", "upstream": "style.scss", "status": "adapted", "notes": "Sass nesting flattened; no variables." },
+        { "fork": "inserter-icon.tsx", "upstream": "n/a", "status": "added", "notes": "Inline SVG." },
+        { "fork": "index.ts", "upstream": "index.js", "status": "rewritten", "notes": "Auto-discovery contract." }
+    ],
+    "vendoredPrimitives": [
+        "_shared/migrate-text-align.ts",
+        "_shared/migrate-font-family.ts"
+    ],
+    "knownDivergences": [
+        "_shared/migrate-font-family.ts inlines a self-contained `cleanEmptyObject` rather than depending on @wordpress/block-editor's privateApis-gated helper.",
+        "edit.tsx omits the upstream `useDeprecatedTextAlign` hook."
+    ],
+    "triage": {
+        "label": "in-sync",
+        "lastReviewed": "2026-05-27",
+        "reviewer": "I1 content cluster"
+    }
+}

--- a/resources/js/visual-editor/blocks/verse/verse.css
+++ b/resources/js/visual-editor/blocks/verse/verse.css
@@ -1,0 +1,17 @@
+/*
+ * Verse — frontend styles.
+ *
+ * Ported from `@wordpress/block-library/src/verse/style.scss` (v9.43.0).
+ */
+
+pre.wp-block-verse {
+    box-sizing: border-box;
+    overflow: auto;
+    white-space: pre-wrap;
+    min-width: 1em;
+    word-break: break-word;
+}
+
+:where(pre.wp-block-verse) {
+    font-family: inherit;
+}

--- a/resources/js/visual-editor/editor/custom-blocks.ts
+++ b/resources/js/visual-editor/editor/custom-blocks.ts
@@ -17,6 +17,8 @@
 import { getCategories, registerBlockType, setCategories } from '@wordpress/blocks';
 import type { BlockConfiguration } from '@wordpress/blocks';
 
+import { registerForkClassNameAlias } from '../blocks/_shared/fork-class-name-alias';
+
 export const ARTISANPACK_CATEGORY_SLUG = 'artisanpack';
 
 export interface CustomBlockModule {
@@ -160,6 +162,13 @@ interface GlobbedModule {
  * Returns the registered block names for diagnostic logging.
  */
 export function discoverAndRegisterCustomBlocks(): ReadonlyArray<string> {
+    // Register the I1 fork class-name alias filter BEFORE any block
+    // registers — `getBlockDefaultClassName` is consulted during
+    // `registerBlockType` for the saved-markup CSS class, and once the
+    // first block is registered, the filter has to be in place or the
+    // bundled gutenberg CSS won't match the fork's wrapper element.
+    registerForkClassNameAlias();
+
     // `import.meta.glob` is a Vite-specific API that Vite transforms at
     // build time — the string literal + options object MUST appear
     // inline, otherwise Vite leaves the call in place and the runtime


### PR DESCRIPTION
## Description

Phase **I1** of the V1 block fork ([plan 13](docs/plans/13-block-fork.md) §2.2.1 + §3): port the 8 content-cluster blocks — `heading`, `list` (+ `list-item`), `quote`, `code`, `preformatted`, `pullquote`, `verse`, `table` — into the `artisanpack/*` namespace under `resources/js/visual-editor/blocks/`, following the I0 paragraph-pilot reference layout.

**Closes:** #409

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #409 (umbrella: #331)

## Motivation and Context

Plan 13 inverts the V1 bet to "adopt @wordpress/block-library at runtime" by porting each `core/*` block in the visual-editor's allow-list into the package under `artisanpack/*`. I0 shipped the paragraph pilot + the diff/parity tooling. **I1 is the content cluster**, the first of the parallelizable cluster milestones. Forking inside 1.0.0 (before any host app persists `core/*` trees) is permanently migration-free.

## Changes Made

- **9 forked block directories** under `resources/js/visual-editor/blocks/` — each ships `block.json`, `edit.tsx`, `save.tsx`, `deprecated.tsx`, `transforms.ts`, `inserter-icon.tsx`, combined CSS, `upstream-state.json`, and a `__tests__/` suite covering save + transforms + deprecations + edit.
- **Round-trip block transforms** wire each fork bidirectionally with its `core/*` counterpart (and accept `artisanpack/*` peers as from-sources where it makes sense — e.g. `artisanpack/quote` accepts both `core/paragraph` and `artisanpack/paragraph`).
- **Shared primitives** under `blocks/_shared/`: `migrate-text-align.ts` and `migrate-font-family.ts` (used by heading/list/quote/verse deprecation chains).
- **`blocks.getBlockDefaultClassName` filter** (`_shared/fork-class-name-alias.ts`) remaps the I1 fork class names back to their `wp-block-{slug}` upstream forms so the bundled gutenberg CSS applies. Without it, e.g. table cells render at 0×0 because every upstream rule targets `.wp-block-table`, not `.wp-block-artisanpack-table`.
- **Renderer parity** across Blade / React / Vue: each new `artisanpack/*` namespace registers against the existing `core/*` renderer component (saved markup is byte-equivalent, so one renderer covers both namespaces). `packages/renderer-parity.json` updated.

## How Has This Been Tested?

**Testing Environment:**
- macOS Darwin 25.5.0
- Node 20+ / Vitest 2.1.9
- Manual editor testing in `jmwd-keystone-cms` (the V1 host app) on Chrome/Safari

**Tests Performed:**
1. `npm test` — full suite, 1000+ tests passing
2. `npm run verify:parity` — all 3 renderers register the full set
3. `npm run upstream-diff` — all forks in sync with their pinned upstream (9.43.0)
4. Manual: inserted each of the 8 block types in keystone-cms, edited content, saved, reloaded, verified frontend render against core/* equivalents

## Accessibility Tests Run

- [x] Keyboard navigation tested (insert/edit/exit for each fork)
- [ ] Screen reader tested
- [ ] Color contrast verified
- [x] ARIA labels checked (cells expose `aria-label="Cell"`, headings/lists/quotes carry their upstream labels)

**Details:** Each fork keeps the upstream `aria-label` strings — `RichText.isEmpty` placeholders match upstream copy.

## Tests Added

- [x] Unit tests added/updated
- [x] All tests passing

**Test details:** 4-file tests per fork (`save`, `transforms`, `deprecated`, `edit`) + a `_shared/__tests__/fork-class-name-alias.test.ts` for the new filter. Save tests assert byte-equivalent markup shape against upstream; deprecation tests lock the chain entry counts and migration semantics; transforms tests cover the bidirectional `core/* ↔ artisanpack/*` round-trip.

## Documentation

- [x] Inline code documentation added (each fork's `upstream-state.json` documents per-file `status` + `knownDivergences`)
- [ ] README updated
- [ ] Wiki updated
- [ ] API documentation updated

**Documentation details:** Per the I0 pilot's convention, `docs/block-fork-workflow.md` already covers the fork shape — no doc rewrites needed for I1. The `upstream-state.json` files are the per-block source of truth for drift triage.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [ ] Accessibility tests completed (basic ARIA labels in place; full screen-reader audit deferred to post-I7)
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

## Known divergences from upstream

Captured per-block in `upstream-state.json`. The notable ones for this cluster:

- `table/edit.tsx` ships a simpler edit experience than upstream (no row/col add/delete toolbar, no per-cell scope/alignment picker, no header/footer toggles). Deferred to the post-I7 customization phase. **Save shape and deprecation chain are byte-equivalent**, so existing host content continues to deserialize correctly.
- `list/edit.tsx` and `list-item/edit.tsx` omit the upstream indent/outdent hooks (`useIndentListItem`, `useOutdentListItem`, `useEnter`, `useSpace`, `useMerge`) — they reach into block-editor private dispatch surface. Same deferral.
- `pullquote/deprecated.tsx` v2 drops the upstream `select(blockEditorStore).getSettings().colors` named-color lookup in its `save()`. Calling a store inside `save` is impure; legacy pullquote blocks persisted with default style + a named `mainColor` (no `customMainColor`) may fall through to v1 instead of v2 on first re-edit.
- Class-name aliasing is required for CSS parity — without the `blocks.getBlockDefaultClassName` filter, the bundled gutenberg CSS doesn't apply to forks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added nine visual editor blocks (Heading, List, List Item, Quote, Pullquote, Code, Preformatted, Table, Verse) and ensured they behave like existing core blocks.
  * Improved block parity with seamless bidirectional conversions and migration support between related block types.

* **Tests**
  * Added extensive unit and integration tests covering editing, saving, transforms, and deprecation/migration paths for the new blocks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArtisanPack-UI/visual-editor/pull/476?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->