### PR TITLE
feat(blocks): fork I6 loop/feed cluster (archives, categories, tag-cloud, query, query-loop)

### DIFF
--- a/packages/renderer-parity.json
+++ b/packages/renderer-parity.json
@@ -1,9 +1,6 @@
 {
     "$comment": "Canonical list of block names every renderer (blade/react/vue) MUST register. Sourced from packages/visual-editor-renderer-{blade,react,vue}. Updated whenever the V2 fork lands a new artisanpack/* block. CI runs scripts/verify-renderer-parity.mjs to fail the build on drift.",
-    "bladeDynamic": [
-        "core/query",
-        "core/post-template"
-    ],
+    "bladeDynamic": [],
     "blocks": [
         "core/paragraph",
         "core/heading",
@@ -90,6 +87,8 @@
         "artisanpack/site-title",
         "artisanpack/site-tagline",
         "artisanpack/site-logo",
-        "artisanpack/navigation"
+        "artisanpack/navigation",
+        "artisanpack/query",
+        "artisanpack/post-template"
     ]
 }

--- a/packages/visual-editor-renderer-blade/resources/assets/block-library/style.css
+++ b/packages/visual-editor-renderer-blade/resources/assets/block-library/style.css
@@ -3995,8 +3995,27 @@ p.has-text-align-left[style*="writing-mode:vertical-lr"] {
   }
 }
 
+.wp-block-post-template.is-layout-grid {
+  display: grid;
+  gap: 1.25em;
+}
+.wp-block-post-template.is-layout-grid.columns-2 {
+  grid-template-columns: repeat(2, 1fr);
+}
+.wp-block-post-template.is-layout-grid.columns-3 {
+  grid-template-columns: repeat(3, 1fr);
+}
+.wp-block-post-template.is-layout-grid.columns-4 {
+  grid-template-columns: repeat(4, 1fr);
+}
+.wp-block-post-template.is-layout-grid.columns-5 {
+  grid-template-columns: repeat(5, 1fr);
+}
+.wp-block-post-template.is-layout-grid.columns-6 {
+  grid-template-columns: repeat(6, 1fr);
+}
 @media (max-width: 600px) {
-  .wp-block-post-template-is-layout-grid.wp-block-post-template-is-layout-grid.wp-block-post-template-is-layout-grid.wp-block-post-template-is-layout-grid {
+  .wp-block-post-template.is-layout-grid {
     grid-template-columns: 1fr;
   }
 }

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/post-template.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/post-template.blade.php
@@ -1,0 +1,5 @@
+{{--
+	artisanpack/post-template — Phase I6 loop / feed fork (#414).
+	Delegates to the core/post-template partial.
+--}}
+@include('visual-editor-renderer-blade::blocks.core.post-template')

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/query.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/query.blade.php
@@ -1,0 +1,5 @@
+{{--
+	artisanpack/query — Phase I6 loop / feed fork (#414).
+	Delegates to the core/query partial.
+--}}
+@include('visual-editor-renderer-blade::blocks.core.query')

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/core/post-template.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/core/post-template.blade.php
@@ -1,0 +1,16 @@
+@php
+	use ArtisanPackUI\VisualEditorRendererBlade\Support\BlockSupports;
+
+	$layout = isset( $attributes['layout'] ) ? (string) $attributes['layout'] : 'list';
+	$columns = isset( $attributes['columns'] ) ? (int) $attributes['columns'] : 3;
+	$isGrid = 'grid' === $layout;
+
+	$classes = [ 'wp-block-post-template' ];
+	$classes[] = $isGrid ? 'is-layout-grid' : 'is-layout-flow';
+	if ( $isGrid ) {
+		$classes[] = 'columns-' . $columns;
+	}
+@endphp
+<ul{!! BlockSupports::wrapperAttrs( $attributes, $classes ) !!}>
+	{!! $innerBlocksHtml !!}
+</ul>

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/core/query.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/core/query.blade.php
@@ -1,0 +1,14 @@
+@php
+	use ArtisanPackUI\VisualEditorRendererBlade\Support\BlockSupports;
+
+	$tag = isset( $attributes['tagName'] ) && in_array( $attributes['tagName'], [ 'div', 'section', 'main' ], true )
+		? $attributes['tagName']
+		: 'div';
+
+	$resolutionError = isset( $attributes['_resolutionError'] ) ? (string) $attributes['_resolutionError'] : '';
+@endphp
+<{{ $tag }}{!! BlockSupports::wrapperAttrs( $attributes, [ 'wp-block-query' ] ) !!}>
+	@if ( '' === $resolutionError )
+		{!! $innerBlocksHtml !!}
+	@endif
+</{{ $tag }}>

--- a/packages/visual-editor-renderer-blade/src/BlockRenderer.php
+++ b/packages/visual-editor-renderer-blade/src/BlockRenderer.php
@@ -95,6 +95,10 @@ class BlockRenderer
 		$attributes      = $this->stampSiteMeta( $name, $attributes );
 		$innerBlocksHtml = $this->render( $this->normalizeInnerBlocks( $block['innerBlocks'] ?? [] ) );
 
+		if ( '_query-iteration' === $name ) {
+			return $this->renderQueryIteration( $attributes, $innerBlocksHtml );
+		}
+
 		if ( $this->dynamicBlocks->has( $name ) ) {
 			return $this->renderDynamic( $name, $attributes, $innerBlocksHtml );
 		}
@@ -227,6 +231,33 @@ class BlockRenderer
 	 *
 	 * @since 1.0.0
 	 */
+	/**
+	 * Render a single query-loop iteration as an `<li>` with post classes.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array<string, mixed>  $attributes
+	 */
+	protected function renderQueryIteration( array $attributes, string $innerBlocksHtml ): string
+	{
+		$postId    = isset( $attributes['postId'] ) ? (int) $attributes['postId'] : 0;
+		$className = isset( $attributes['className'] ) && is_string( $attributes['className'] )
+			? $attributes['className']
+			: '';
+
+		$classes = array_filter( [
+			'wp-block-post',
+			$className,
+		] );
+
+		return sprintf(
+			'<li id="post-%d" class="%s">%s</li>',
+			$postId,
+			e( implode( ' ', $classes ) ),
+			$innerBlocksHtml
+		);
+	}
+
 	protected function renderFallback( string $name, string $innerBlocksHtml ): string
 	{
 		$safeName = htmlspecialchars( $name, ENT_QUOTES | ENT_HTML5, 'UTF-8' );

--- a/packages/visual-editor-renderer-react/src/blocks/core/query.tsx
+++ b/packages/visual-editor-renderer-react/src/blocks/core/query.tsx
@@ -60,12 +60,23 @@ export function PostTemplateBlock({ attributes, children }: BlockRendererProps):
     const layout = attrString(attributes.layout);
     const layoutType = attrString(attributes.layoutType);
     const isGrid = layout === 'grid' || layoutType === 'grid';
+    const columns = typeof attributes.columns === 'number' ? attributes.columns : 3;
 
     const classes = classList([
         'wp-block-post-template',
         isGrid ? 'is-layout-grid' : 'is-layout-flow',
+        isGrid ? `columns-${columns}` : '',
         className,
     ]);
 
     return <ul className={classes}>{children}</ul>;
+}
+
+export function QueryIterationBlock({ attributes, children }: BlockRendererProps): JSX.Element {
+    const postId = typeof attributes.postId === 'number' ? attributes.postId : 0;
+    const className = attrString(attributes.className);
+
+    const classes = classList(['wp-block-post', className]);
+
+    return <li id={`post-${postId}`} className={classes}>{children}</li>;
 }

--- a/packages/visual-editor-renderer-react/src/blocks/registerCoreBlocks.ts
+++ b/packages/visual-editor-renderer-react/src/blocks/registerCoreBlocks.ts
@@ -52,7 +52,7 @@ import {
     PostFeaturedImageBlock,
     PostTitleBlock,
 } from './core/postContext';
-import { PostTemplateBlock, QueryBlock } from './core/query';
+import { PostTemplateBlock, QueryBlock, QueryIterationBlock } from './core/query';
 import { SiteLogoBlock, SiteTaglineBlock, SiteTitleBlock } from './core/siteContext';
 import { SyncedPatternBlock } from './core/syncedPattern';
 import { TemplatePartBlock } from './core/templatePart';
@@ -140,6 +140,9 @@ const CORE_BLOCKS: Record<string, BlockRenderer> = {
     'core/block': SyncedPatternBlock,
     'core/query': QueryBlock,
     'core/post-template': PostTemplateBlock,
+    'artisanpack/query': QueryBlock,
+    'artisanpack/post-template': PostTemplateBlock,
+    '_query-iteration': QueryIterationBlock,
     'core/post-title': PostTitleBlock,
     'artisanpack/post-title': PostTitleBlock,
     'core/post-content': PostContentBlock,

--- a/packages/visual-editor-renderer-vue/src/blocks/core/query.ts
+++ b/packages/visual-editor-renderer-vue/src/blocks/core/query.ts
@@ -61,6 +61,7 @@ export const PostTemplateBlock = defineComponent({
             const layout = attrString(props.attributes.layout);
             const layoutType = attrString(props.attributes.layoutType);
             const isGrid = layout === 'grid' || layoutType === 'grid';
+            const columns = typeof props.attributes.columns === 'number' ? props.attributes.columns : 3;
 
             return h(
                 'ul',
@@ -68,8 +69,29 @@ export const PostTemplateBlock = defineComponent({
                     class: classList([
                         'wp-block-post-template',
                         isGrid ? 'is-layout-grid' : 'is-layout-flow',
+                        isGrid ? `columns-${columns}` : '',
                         className,
                     ]),
+                },
+                slots.default?.()
+            );
+        };
+    },
+});
+
+export const QueryIterationBlock = defineComponent({
+    name: 'QueryIterationBlock',
+    props: blockRendererProps,
+    setup(props, { slots }) {
+        return () => {
+            const postId = typeof props.attributes.postId === 'number' ? props.attributes.postId : 0;
+            const className = attrString(props.attributes.className);
+
+            return h(
+                'li',
+                {
+                    id: `post-${postId}`,
+                    class: classList(['wp-block-post', className]),
                 },
                 slots.default?.()
             );

--- a/packages/visual-editor-renderer-vue/src/blocks/registerCoreBlocks.ts
+++ b/packages/visual-editor-renderer-vue/src/blocks/registerCoreBlocks.ts
@@ -52,7 +52,7 @@ import {
     PostFeaturedImageBlock,
     PostTitleBlock,
 } from './core/postContext';
-import { PostTemplateBlock, QueryBlock } from './core/query';
+import { PostTemplateBlock, QueryBlock, QueryIterationBlock } from './core/query';
 import { SiteLogoBlock, SiteTaglineBlock, SiteTitleBlock } from './core/siteContext';
 import { SyncedPatternBlock } from './core/syncedPattern';
 import { TemplatePartBlock } from './core/templatePart';
@@ -139,6 +139,9 @@ const CORE_BLOCKS: Record<string, BlockRenderer> = {
     'artisanpack/template-part': TemplatePartBlock,
     'core/query': QueryBlock,
     'core/post-template': PostTemplateBlock,
+    'artisanpack/query': QueryBlock,
+    'artisanpack/post-template': PostTemplateBlock,
+    '_query-iteration': QueryIterationBlock,
     'core/block': SyncedPatternBlock,
     'core/post-title': PostTitleBlock,
     'artisanpack/post-title': PostTitleBlock,

--- a/resources/js/visual-editor/blocks/__tests__/i6-loop-feed-cluster.test.ts
+++ b/resources/js/visual-editor/blocks/__tests__/i6-loop-feed-cluster.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Phase I6 loop / feed cluster (#414) — block.json + save + transforms
+ * contract for the three dynamic feed blocks (`archives`, `categories`,
+ * `tag-cloud`).
+ *
+ * Covers, in one parametrized suite: namespace + textdomain + category on
+ * block.json, the dynamic (`null`) save every server-rendered feed block
+ * ships, and the bidirectional `core/* ↔ artisanpack/*` rollout transforms.
+ *
+ * The `query` / `post-template` forks have a non-null save and their own
+ * renderer-parity coverage, so they are asserted separately.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@wordpress/blocks', () => ({
+    createBlock: (name: string, attributes?: Record<string, unknown>) => ({
+        name,
+        attributes: attributes ?? {},
+        innerBlocks: [],
+    }),
+}));
+
+import archivesMeta from '../archives/block.json';
+import categoriesMeta from '../categories/block.json';
+import tagCloudMeta from '../tag-cloud/block.json';
+
+import archivesTransforms from '../archives/transforms';
+import categoriesTransforms from '../categories/transforms';
+import tagCloudTransforms from '../tag-cloud/transforms';
+
+import archivesSave from '../archives/save';
+import categoriesSave from '../categories/save';
+import tagCloudSave from '../tag-cloud/save';
+
+import queryMeta from '../query/block.json';
+import postTemplateMeta from '../post-template/block.json';
+import queryTransforms from '../query/transforms';
+import postTemplateTransforms from '../post-template/transforms';
+
+interface BlockTransform {
+    type: string;
+    blocks: string[];
+    transform: (attrs: Record<string, unknown>) => {
+        name: string;
+        attributes: Record<string, unknown>;
+    };
+}
+interface TransformsModule {
+    from: BlockTransform[];
+    to: BlockTransform[];
+}
+
+const FEED_BLOCKS = [
+    { slug: 'archives', meta: archivesMeta, transforms: archivesTransforms, save: archivesSave },
+    { slug: 'categories', meta: categoriesMeta, transforms: categoriesTransforms, save: categoriesSave },
+    { slug: 'tag-cloud', meta: tagCloudMeta, transforms: tagCloudTransforms, save: tagCloudSave },
+] as const;
+
+describe('I6 loop/feed cluster block.json', () => {
+    it.each(FEED_BLOCKS)(
+        '$slug declares the artisanpack namespace + textdomain + widgets category',
+        ({ slug, meta }) => {
+            expect(meta.name).toBe(`artisanpack/${slug}`);
+            expect(meta.textdomain).toBe('artisanpack-visual-editor');
+            // Feed blocks keep the upstream `widgets` category (plan 13 §8).
+            expect(meta.category).toBe('widgets');
+        }
+    );
+});
+
+describe('I6 loop/feed cluster dynamic save', () => {
+    it.each(FEED_BLOCKS)('$slug save returns null (server-rendered)', ({ save }) => {
+        expect((save as () => unknown)()).toBeNull();
+    });
+});
+
+describe('I6 loop/feed cluster transforms', () => {
+    it.each(FEED_BLOCKS)(
+        '$slug ships bidirectional core/* ↔ artisanpack/* transforms',
+        ({ slug, transforms }) => {
+            const t = transforms as TransformsModule;
+            const from = t.from.find((e) => e.blocks?.includes(`core/${slug}`));
+            const to = t.to.find((e) => e.blocks?.includes(`core/${slug}`));
+
+            expect(from).toBeDefined();
+            expect(to).toBeDefined();
+
+            expect(from!.transform({ a: 1 })).toMatchObject({
+                name: `artisanpack/${slug}`,
+                attributes: { a: 1 },
+            });
+            expect(to!.transform({ b: 2 })).toMatchObject({
+                name: `core/${slug}`,
+                attributes: { b: 2 },
+            });
+        }
+    );
+});
+
+const QUERY_BLOCKS = [
+    { slug: 'query', meta: queryMeta, transforms: queryTransforms },
+    { slug: 'post-template', meta: postTemplateMeta, transforms: postTemplateTransforms },
+] as const;
+
+describe('I6 loop/feed cluster — query + post-template block.json', () => {
+    it.each(QUERY_BLOCKS)(
+        '$slug declares the artisanpack namespace + textdomain + theme category',
+        ({ slug, meta }) => {
+            expect(meta.name).toBe(`artisanpack/${slug}`);
+            expect(meta.textdomain).toBe('artisanpack-visual-editor');
+            // query + post-template keep the upstream `theme` category.
+            expect(meta.category).toBe('theme');
+        }
+    );
+
+    it('post-template is parent-locked to artisanpack/query', () => {
+        expect((postTemplateMeta as { ancestor?: string[] }).ancestor).toContain(
+            'artisanpack/query'
+        );
+    });
+});
+
+describe('I6 loop/feed cluster — query + post-template transforms', () => {
+    it.each(QUERY_BLOCKS)(
+        '$slug ships bidirectional core/* ↔ artisanpack/* transforms',
+        ({ slug, transforms }) => {
+            const t = transforms as TransformsModule;
+            const from = t.from.find((e) => e.blocks?.includes(`core/${slug}`));
+            const to = t.to.find((e) => e.blocks?.includes(`core/${slug}`));
+
+            expect(from).toBeDefined();
+            expect(to).toBeDefined();
+
+            expect(from!.transform({ a: 1 })).toMatchObject({
+                name: `artisanpack/${slug}`,
+                attributes: { a: 1 },
+            });
+            expect(to!.transform({ b: 2 })).toMatchObject({
+                name: `core/${slug}`,
+                attributes: { b: 2 },
+            });
+        }
+    );
+
+    it('query folds the deprecated core/query-loop alias into artisanpack/query', () => {
+        const t = queryTransforms as TransformsModule;
+        const alias = t.from.find((e) => e.blocks?.includes('core/query-loop'));
+
+        expect(alias).toBeDefined();
+        expect(alias!.transform({ c: 3 })).toMatchObject({
+            name: 'artisanpack/query',
+            attributes: { c: 3 },
+        });
+    });
+});

--- a/resources/js/visual-editor/blocks/archives/block.json
+++ b/resources/js/visual-editor/blocks/archives/block.json
@@ -1,0 +1,71 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "artisanpack/archives",
+    "title": "Archives",
+    "category": "widgets",
+    "description": "Display a date archive of your posts.",
+    "textdomain": "artisanpack-visual-editor",
+    "attributes": {
+        "displayAsDropdown": {
+            "type": "boolean",
+            "default": false
+        },
+        "showLabel": {
+            "type": "boolean",
+            "default": true
+        },
+        "showPostCounts": {
+            "type": "boolean",
+            "default": false
+        },
+        "type": {
+            "type": "string",
+            "default": "monthly"
+        }
+    },
+    "supports": {
+        "anchor": true,
+        "align": true,
+        "html": false,
+        "spacing": {
+            "margin": true,
+            "padding": true,
+            "__experimentalDefaultControls": {
+                "margin": false,
+                "padding": false
+            }
+        },
+        "typography": {
+            "fontSize": true,
+            "lineHeight": true,
+            "__experimentalFontFamily": true,
+            "__experimentalFontWeight": true,
+            "__experimentalFontStyle": true,
+            "__experimentalTextTransform": true,
+            "__experimentalTextDecoration": true,
+            "__experimentalLetterSpacing": true,
+            "__experimentalDefaultControls": {
+                "fontSize": true
+            }
+        },
+        "color": {
+            "gradients": true,
+            "link": true,
+            "__experimentalDefaultControls": {
+                "background": true,
+                "text": true,
+                "link": true
+            }
+        },
+        "interactivity": {
+            "clientNavigation": true
+        },
+        "__experimentalBorder": {
+            "radius": true,
+            "color": true,
+            "width": true,
+            "style": true
+        }
+    }
+}

--- a/resources/js/visual-editor/blocks/archives/edit.tsx
+++ b/resources/js/visual-editor/blocks/archives/edit.tsx
@@ -1,0 +1,104 @@
+/**
+ * Archives — edit component.
+ *
+ * `core/archives` is server-rendered. Upstream's `edit.js` renders through
+ * Gutenberg's `@wordpress/server-side-render`, which POSTs to
+ * `wp/v2/block-renderer/core/archives`; this package's preview endpoint
+ * lives at `/visual-editor/api/blocks/preview` instead and archives are
+ * resolved on the server (see `src/Blocks/Core/ArchivesBlock.php`). The
+ * fork therefore previews through the package's `<ServerSideRender>` seam
+ * — the same approach the V1 taxonomy/archive override uses — and ports
+ * the inspector controls to `PanelBody`. Phase I6 loop / feed
+ * cluster (#414).
+ */
+
+import type { ReactElement } from 'react';
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import { PanelBody, SelectControl, ToggleControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+import { ServerSideRender } from '../../editor/server-side-render';
+import { TEXT_DOMAIN } from '../../vendor/i18n';
+
+interface ArchivesAttributes {
+    readonly displayAsDropdown?: boolean;
+    readonly showPostCounts?: boolean;
+    readonly type?: string;
+    readonly [ key: string ]: unknown;
+}
+
+interface ArchivesEditProps {
+    readonly attributes: ArchivesAttributes;
+    readonly setAttributes: ( attrs: Partial<ArchivesAttributes> ) => void;
+}
+
+export default function ArchivesEdit( {
+    attributes,
+    setAttributes,
+}: ArchivesEditProps ): ReactElement {
+    const displayAsDropdown = Boolean( attributes.displayAsDropdown );
+    const showPostCounts = Boolean( attributes.showPostCounts );
+    const type = attributes.type === 'yearly' ? 'yearly' : 'monthly';
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const blockProps = ( useBlockProps as any )();
+
+    return (
+        <>
+            <InspectorControls>
+                <PanelBody title={ __( 'Settings', TEXT_DOMAIN ) }>
+                    <ToggleControl
+                        // @ts-expect-error - upstream prop
+                        __nextHasNoMarginBottom
+                        label={ __( 'Display as dropdown', TEXT_DOMAIN ) }
+                        checked={ displayAsDropdown }
+                        onChange={ ( value ) =>
+                            setAttributes( { displayAsDropdown: value } )
+                        }
+                    />
+                    { displayAsDropdown && (
+                        <ToggleControl
+                            // @ts-expect-error - upstream prop
+                            __nextHasNoMarginBottom
+                            label={ __( 'Show label', TEXT_DOMAIN ) }
+                            checked={ Boolean( attributes.showLabel ?? true ) }
+                            onChange={ ( value ) =>
+                                setAttributes( { showLabel: value } )
+                            }
+                        />
+                    ) }
+                    <ToggleControl
+                        // @ts-expect-error - upstream prop
+                        __nextHasNoMarginBottom
+                        label={ __( 'Show post counts', TEXT_DOMAIN ) }
+                        checked={ showPostCounts }
+                        onChange={ ( value ) =>
+                            setAttributes( { showPostCounts: value } )
+                        }
+                    />
+                    <SelectControl
+                        // @ts-expect-error - upstream prop
+                        __next40pxDefaultSize
+                        __nextHasNoMarginBottom
+                        label={ __( 'Group by', TEXT_DOMAIN ) }
+                        value={ type }
+                        options={ [
+                            { label: __( 'Monthly', TEXT_DOMAIN ), value: 'monthly' },
+                            { label: __( 'Yearly', TEXT_DOMAIN ), value: 'yearly' },
+                        ] }
+                        onChange={ ( value: string ) =>
+                            setAttributes( { type: value } )
+                        }
+                    />
+                </PanelBody>
+            </InspectorControls>
+
+            <div { ...blockProps }>
+                <ServerSideRender
+                    block="artisanpack/archives"
+                    attributes={ attributes }
+                />
+            </div>
+        </>
+    );
+}

--- a/resources/js/visual-editor/blocks/archives/index.ts
+++ b/resources/js/visual-editor/blocks/archives/index.ts
@@ -1,0 +1,28 @@
+/**
+ * Archives block entrypoint.
+ *
+ * Auto-discovered by `editor/custom-blocks.ts` and registered against
+ * `@wordpress/blocks.registerBlockType`. Phase I6 — loop / feed cluster
+ * (issue #414).
+ *
+ * Dynamic block: `save` returns `null` and the markup is produced server
+ * side by `ArchivesBlock::render()`; the editor previews it through the
+ * package's `<ServerSideRender>` seam.
+ */
+
+import metadata from './block.json';
+import edit from './edit';
+import save from './save';
+import transforms from './transforms';
+import icon from './inserter-icon';
+
+export { edit, save, metadata, icon, transforms };
+
+export default {
+    name: metadata.name,
+    metadata,
+    edit,
+    save,
+    icon,
+    transforms,
+};

--- a/resources/js/visual-editor/blocks/archives/inserter-icon.tsx
+++ b/resources/js/visual-editor/blocks/archives/inserter-icon.tsx
@@ -1,0 +1,23 @@
+/**
+ * Archives — inserter icon.
+ *
+ * Inline SVG mirroring `@wordpress/icons`' `archive` icon so the editor
+ * canvas does not have to load `dashicons.css` to render it. Phase I6
+ * loop / feed cluster (#414).
+ */
+
+import type { ReactElement } from 'react';
+
+export default function ArchivesInserterIcon(): ReactElement {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            width={ 24 }
+            height={ 24 }
+            aria-hidden="true"
+        >
+            <path d="M19 4H5a2 2 0 0 0-2 2v1.5a1 1 0 0 0 1 1h.5V18a2 2 0 0 0 2 2h11a2 2 0 0 0 2-2V8.5h.5a1 1 0 0 0 1-1V6a2 2 0 0 0-2-2Zm-.5 14a.5.5 0 0 1-.5.5H6a.5.5 0 0 1-.5-.5V8.5h13V18ZM20 7H4V6a.5.5 0 0 1 .5-.5h15a.5.5 0 0 1 .5.5v1ZM9 11h6v1.5H9V11Z" />
+        </svg>
+    );
+}

--- a/resources/js/visual-editor/blocks/archives/save.tsx
+++ b/resources/js/visual-editor/blocks/archives/save.tsx
@@ -1,0 +1,13 @@
+/**
+ * Archives — save component.
+ *
+ * Dynamic block: the saved markup is just the block delimiter
+ * (`<!-- wp:artisanpack/archives {…} /-->`) and the HTML is generated
+ * server-side by `ArchivesBlock::render()`. Returning `null` from save is
+ * the Gutenberg convention for dynamic blocks. Phase I6 loop / feed
+ * cluster (#414).
+ */
+
+export default function ArchivesSave(): null {
+    return null;
+}

--- a/resources/js/visual-editor/blocks/archives/transforms.ts
+++ b/resources/js/visual-editor/blocks/archives/transforms.ts
@@ -1,0 +1,41 @@
+/**
+ * Archives — transforms.
+ *
+ * `@wordpress/block-library/src/archives` (v9.43.0) ships no
+ * `transforms.js`. The fork adds bidirectional block transforms for
+ * `core/archives` ↔ `artisanpack/archives` so mixed documents round-trip
+ * losslessly during the V1 rollout. The `to: core/archives` direction is
+ * removed at the I7 cutover once `core/archives` is no longer registered.
+ * Phase I6 loop / feed cluster (#414).
+ */
+
+import { createBlock } from '@wordpress/blocks';
+
+import metadata from './block.json';
+
+const { name } = metadata;
+
+interface ArchivesAttributes {
+    readonly [ key: string ]: unknown;
+}
+
+const transforms = {
+    from: [
+        {
+            type: 'block',
+            blocks: [ 'core/archives' ],
+            transform: ( attributes: ArchivesAttributes ) =>
+                createBlock( name, attributes ),
+        },
+    ],
+    to: [
+        {
+            type: 'block',
+            blocks: [ 'core/archives' ],
+            transform: ( attributes: ArchivesAttributes ) =>
+                createBlock( 'core/archives', attributes ),
+        },
+    ],
+};
+
+export default transforms;

--- a/resources/js/visual-editor/blocks/archives/upstream-state.json
+++ b/resources/js/visual-editor/blocks/archives/upstream-state.json
@@ -1,0 +1,39 @@
+{
+    "$schema": "../../../../scripts/upstream-state.schema.json",
+    "block": "artisanpack/archives",
+    "upstream": {
+        "package": "@wordpress/block-library",
+        "namespace": "core/archives",
+        "pinnedVersion": "9.43.0",
+        "subpath": "archives"
+    },
+    "forkedAt": "2026-05-29",
+    "$statusLegend": {
+        "ported": "byte-equivalent to upstream (CI fails on drift)",
+        "adapted": "TypeScript port and/or namespace swap; logically equivalent",
+        "extended": "fork adds behavior on top of upstream",
+        "rewritten": "fork replaced upstream entirely",
+        "added": "file unique to the fork (no upstream)"
+    },
+    "files": [
+        { "fork": "block.json", "upstream": "block.json", "status": "adapted", "notes": "name + textdomain swapped to the artisanpack namespace; attribute schema + supports carried verbatim." },
+        { "fork": "edit.tsx", "upstream": "edit.js", "status": "rewritten", "notes": "Upstream renders through @wordpress/server-side-render (POSTs to wp/v2/block-renderer/core/archives); this package's preview endpoint is /visual-editor/api/blocks/preview and archives are resolved server-side, so the fork previews through the package's <ServerSideRender> seam and ports the inspector controls (display as dropdown, show counts, group by) to PanelBody. Mirrors the V1 taxonomy-archive override's ArchivesEdit." },
+        { "fork": "save.tsx", "upstream": "n/a", "status": "added", "notes": "Dynamic block — returns null; markup produced by ArchivesBlock::render()." },
+        { "fork": "transforms.ts", "upstream": "n/a", "status": "added", "notes": "Upstream has no transforms.js; the fork adds bidirectional core/archives ↔ artisanpack/archives block transforms for the rollout window." },
+        { "fork": "inserter-icon.tsx", "upstream": "n/a", "status": "added", "notes": "Inline SVG mirroring @wordpress/icons' archive icon." },
+        { "fork": "index.ts", "upstream": "index.js", "status": "rewritten", "notes": "Adapted to the visual-editor auto-discovery contract; upstream PHP-side init wiring not carried." },
+        { "fork": "../../../../src/Blocks/Core/ArchivesBlock.php", "upstream": "index.php", "status": "rewritten", "notes": "Server renderer reimplemented against cms-framework's Post model (a DynamicBlock) rather than WP_Query. name() renamed core/archives → artisanpack/archives at the I6 fork (mirroring LatestPostsBlock at I4)." }
+    ],
+    "vendoredPrimitives": [],
+    "knownDivergences": [
+        "edit.tsx previews via the package's <ServerSideRender> seam instead of upstream's @wordpress/server-side-render (different preview endpoint).",
+        "Inspector ported to PanelBody instead of upstream's ToolsPanel; the Group by control offers monthly/yearly only (the server renderer buckets by month or year), not upstream's weekly/daily.",
+        "archives is a dynamic block, so (like core/categories, core/tag-cloud, artisanpack/latest-posts, artisanpack/form) it is handled by the Blade DynamicBlockRegistry and is not listed in packages/renderer-parity.json — the React/Vue static renderers do not register it.",
+        "transforms.ts adds bidirectional core/archives ↔ artisanpack/archives block transforms that don't exist upstream — required to coexist with core/archives during the V1 rollout."
+    ],
+    "triage": {
+        "label": "in-sync",
+        "lastReviewed": "2026-05-29",
+        "reviewer": "I6 loop / feed cluster"
+    }
+}

--- a/resources/js/visual-editor/blocks/categories/block.json
+++ b/resources/js/visual-editor/blocks/categories/block.json
@@ -1,0 +1,95 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "artisanpack/categories",
+    "title": "Terms List",
+    "category": "widgets",
+    "description": "Display a list of all terms of a given taxonomy.",
+    "keywords": [ "categories" ],
+    "textdomain": "artisanpack-visual-editor",
+    "attributes": {
+        "taxonomy": {
+            "type": "string",
+            "default": "category"
+        },
+        "displayAsDropdown": {
+            "type": "boolean",
+            "default": false
+        },
+        "showHierarchy": {
+            "type": "boolean",
+            "default": false
+        },
+        "showPostCounts": {
+            "type": "boolean",
+            "default": false
+        },
+        "showOnlyTopLevel": {
+            "type": "boolean",
+            "default": false
+        },
+        "showEmpty": {
+            "type": "boolean",
+            "default": false
+        },
+        "label": {
+            "type": "string",
+            "role": "content"
+        },
+        "showLabel": {
+            "type": "boolean",
+            "default": true
+        }
+    },
+    "usesContext": [ "enhancedPagination" ],
+    "supports": {
+        "anchor": true,
+        "align": true,
+        "html": false,
+        "spacing": {
+            "margin": true,
+            "padding": true,
+            "__experimentalDefaultControls": {
+                "margin": false,
+                "padding": false
+            }
+        },
+        "typography": {
+            "fontSize": true,
+            "lineHeight": true,
+            "__experimentalFontFamily": true,
+            "__experimentalFontWeight": true,
+            "__experimentalFontStyle": true,
+            "__experimentalTextTransform": true,
+            "__experimentalTextDecoration": true,
+            "__experimentalLetterSpacing": true,
+            "__experimentalDefaultControls": {
+                "fontSize": true
+            }
+        },
+        "color": {
+            "gradients": true,
+            "link": true,
+            "__experimentalDefaultControls": {
+                "background": true,
+                "text": true,
+                "link": true
+            }
+        },
+        "interactivity": {
+            "clientNavigation": true
+        },
+        "__experimentalBorder": {
+            "radius": true,
+            "color": true,
+            "width": true,
+            "style": true,
+            "__experimentalDefaultControls": {
+                "radius": true,
+                "color": true,
+                "width": true,
+                "style": true
+            }
+        }
+    }
+}

--- a/resources/js/visual-editor/blocks/categories/edit.tsx
+++ b/resources/js/visual-editor/blocks/categories/edit.tsx
@@ -1,0 +1,98 @@
+/**
+ * Categories (Terms List) — edit component.
+ *
+ * `core/categories` is server-rendered. Upstream's `edit.js` reads
+ * `getTaxonomy('category').labels.name` and queries `@wordpress/core-data`
+ * for terms, but the post editor's core-data shim does not expose the
+ * taxonomy entity and this package resolves terms on the server (see
+ * `src/Blocks/Core/CategoriesBlock.php`). The fork therefore previews
+ * through the package's `<ServerSideRender>` seam — the same approach the
+ * upstream taxonomy/archive overrides use — and ports the inspector
+ * controls to `PanelBody`. Phase I6 loop / feed cluster (#414).
+ */
+
+import type { ReactElement } from 'react';
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import { PanelBody, ToggleControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+import { ServerSideRender } from '../../editor/server-side-render';
+import { TEXT_DOMAIN } from '../../vendor/i18n';
+
+interface CategoriesAttributes {
+    readonly showPostCounts?: boolean;
+    readonly showHierarchy?: boolean;
+    readonly showOnlyTopLevel?: boolean;
+    readonly showEmpty?: boolean;
+    readonly [ key: string ]: unknown;
+}
+
+interface CategoriesEditProps {
+    readonly attributes: CategoriesAttributes;
+    readonly setAttributes: ( attrs: Partial<CategoriesAttributes> ) => void;
+}
+
+export default function CategoriesEdit( {
+    attributes,
+    setAttributes,
+}: CategoriesEditProps ): ReactElement {
+    const showPostCounts = Boolean( attributes.showPostCounts );
+    const showHierarchy = Boolean( attributes.showHierarchy );
+    const showOnlyTopLevel = Boolean( attributes.showOnlyTopLevel );
+    const showEmpty = Boolean( attributes.showEmpty );
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const blockProps = ( useBlockProps as any )();
+
+    return (
+        <>
+            <InspectorControls>
+                <PanelBody title={ __( 'Settings', TEXT_DOMAIN ) }>
+                    <ToggleControl
+                        // @ts-expect-error - upstream prop
+                        __nextHasNoMarginBottom
+                        label={ __( 'Show post counts', TEXT_DOMAIN ) }
+                        checked={ showPostCounts }
+                        onChange={ ( value ) =>
+                            setAttributes( { showPostCounts: value } )
+                        }
+                    />
+                    <ToggleControl
+                        // @ts-expect-error - upstream prop
+                        __nextHasNoMarginBottom
+                        label={ __( 'Show hierarchy', TEXT_DOMAIN ) }
+                        checked={ showHierarchy }
+                        onChange={ ( value ) =>
+                            setAttributes( { showHierarchy: value } )
+                        }
+                    />
+                    <ToggleControl
+                        // @ts-expect-error - upstream prop
+                        __nextHasNoMarginBottom
+                        label={ __( 'Show only top level', TEXT_DOMAIN ) }
+                        checked={ showOnlyTopLevel }
+                        onChange={ ( value ) =>
+                            setAttributes( { showOnlyTopLevel: value } )
+                        }
+                    />
+                    <ToggleControl
+                        // @ts-expect-error - upstream prop
+                        __nextHasNoMarginBottom
+                        label={ __( 'Show empty terms', TEXT_DOMAIN ) }
+                        checked={ showEmpty }
+                        onChange={ ( value ) =>
+                            setAttributes( { showEmpty: value } )
+                        }
+                    />
+                </PanelBody>
+            </InspectorControls>
+
+            <div { ...blockProps }>
+                <ServerSideRender
+                    block="artisanpack/categories"
+                    attributes={ attributes }
+                />
+            </div>
+        </>
+    );
+}

--- a/resources/js/visual-editor/blocks/categories/index.ts
+++ b/resources/js/visual-editor/blocks/categories/index.ts
@@ -1,0 +1,28 @@
+/**
+ * Categories (Terms List) block entrypoint.
+ *
+ * Auto-discovered by `editor/custom-blocks.ts` and registered against
+ * `@wordpress/blocks.registerBlockType`. Phase I6 — loop / feed cluster
+ * (issue #414).
+ *
+ * Dynamic block: `save` returns `null` and the markup is produced server
+ * side by `CategoriesBlock::render()`; the editor previews it through the
+ * package's `<ServerSideRender>` seam.
+ */
+
+import metadata from './block.json';
+import edit from './edit';
+import save from './save';
+import transforms from './transforms';
+import icon from './inserter-icon';
+
+export { edit, save, metadata, icon, transforms };
+
+export default {
+    name: metadata.name,
+    metadata,
+    edit,
+    save,
+    icon,
+    transforms,
+};

--- a/resources/js/visual-editor/blocks/categories/inserter-icon.tsx
+++ b/resources/js/visual-editor/blocks/categories/inserter-icon.tsx
@@ -1,0 +1,23 @@
+/**
+ * Categories — inserter icon.
+ *
+ * Inline SVG mirroring `@wordpress/icons`' `category` icon so the editor
+ * canvas does not have to load `dashicons.css` to render it. Phase I6
+ * loop / feed cluster (#414).
+ */
+
+import type { ReactElement } from 'react';
+
+export default function CategoriesInserterIcon(): ReactElement {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            width={ 24 }
+            height={ 24 }
+            aria-hidden="true"
+        >
+            <path d="M6 5.5h12a.5.5 0 0 1 .5.5v3H5.5V6a.5.5 0 0 1 .5-.5ZM4 6a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6Zm1.5 4.5h13V18a.5.5 0 0 1-.5.5H6a.5.5 0 0 1-.5-.5v-7.5ZM7 13h6v1.5H7V13Zm0 3h6v1.5H7V16Z" />
+        </svg>
+    );
+}

--- a/resources/js/visual-editor/blocks/categories/save.tsx
+++ b/resources/js/visual-editor/blocks/categories/save.tsx
@@ -1,0 +1,13 @@
+/**
+ * Categories — save component.
+ *
+ * Dynamic block: the saved markup is just the block delimiter
+ * (`<!-- wp:artisanpack/categories {…} /-->`) and the HTML is generated
+ * server-side by `CategoriesBlock::render()`. Returning `null` from save is
+ * the Gutenberg convention for dynamic blocks. Phase I6 loop / feed
+ * cluster (#414).
+ */
+
+export default function CategoriesSave(): null {
+    return null;
+}

--- a/resources/js/visual-editor/blocks/categories/transforms.ts
+++ b/resources/js/visual-editor/blocks/categories/transforms.ts
@@ -1,0 +1,42 @@
+/**
+ * Categories — transforms.
+ *
+ * `@wordpress/block-library/src/categories` (v9.43.0) ships a
+ * `variations.js` but no `transforms.js`. The fork adds bidirectional
+ * block transforms for `core/categories` ↔ `artisanpack/categories` so
+ * mixed documents round-trip losslessly during the V1 rollout. The
+ * `to: core/categories` direction is removed at the I7 cutover once
+ * `core/categories` is no longer registered. Phase I6 loop / feed
+ * cluster (#414).
+ */
+
+import { createBlock } from '@wordpress/blocks';
+
+import metadata from './block.json';
+
+const { name } = metadata;
+
+interface CategoriesAttributes {
+    readonly [ key: string ]: unknown;
+}
+
+const transforms = {
+    from: [
+        {
+            type: 'block',
+            blocks: [ 'core/categories' ],
+            transform: ( attributes: CategoriesAttributes ) =>
+                createBlock( name, attributes ),
+        },
+    ],
+    to: [
+        {
+            type: 'block',
+            blocks: [ 'core/categories' ],
+            transform: ( attributes: CategoriesAttributes ) =>
+                createBlock( 'core/categories', attributes ),
+        },
+    ],
+};
+
+export default transforms;

--- a/resources/js/visual-editor/blocks/categories/upstream-state.json
+++ b/resources/js/visual-editor/blocks/categories/upstream-state.json
@@ -1,0 +1,41 @@
+{
+    "$schema": "../../../../scripts/upstream-state.schema.json",
+    "block": "artisanpack/categories",
+    "upstream": {
+        "package": "@wordpress/block-library",
+        "namespace": "core/categories",
+        "pinnedVersion": "9.43.0",
+        "subpath": "categories"
+    },
+    "forkedAt": "2026-05-29",
+    "$statusLegend": {
+        "ported": "byte-equivalent to upstream (CI fails on drift)",
+        "adapted": "TypeScript port and/or namespace swap; logically equivalent",
+        "extended": "fork adds behavior on top of upstream",
+        "rewritten": "fork replaced upstream entirely",
+        "added": "file unique to the fork (no upstream)"
+    },
+    "files": [
+        { "fork": "block.json", "upstream": "block.json", "status": "adapted", "notes": "name + textdomain swapped to the artisanpack namespace; attribute schema + supports carried verbatim. editorStyle/style handles and the variations array dropped — the variation picker pulls getTaxonomies selectors the post editor's core-data shim does not implement (same reason the upstream taxonomy/archive override strips them)." },
+        { "fork": "edit.tsx", "upstream": "edit.js", "status": "rewritten", "notes": "Upstream queries the taxonomy entity via @wordpress/core-data; the shim exposes no taxonomy entity and terms are resolved server-side, so the fork previews through the package's <ServerSideRender> seam and ports the inspector controls to PanelBody. Mirrors the V1 taxonomy-archive override's CategoriesEdit." },
+        { "fork": "save.tsx", "upstream": "n/a", "status": "added", "notes": "Dynamic block — returns null; markup produced by CategoriesBlock::render()." },
+        { "fork": "transforms.ts", "upstream": "n/a", "status": "added", "notes": "Upstream has no transforms.js; the fork adds bidirectional core/categories ↔ artisanpack/categories block transforms for the rollout window." },
+        { "fork": "inserter-icon.tsx", "upstream": "n/a", "status": "added", "notes": "Inline SVG mirroring @wordpress/icons' category icon." },
+        { "fork": "index.ts", "upstream": "index.js", "status": "rewritten", "notes": "Adapted to the visual-editor auto-discovery contract; upstream PHP-side init wiring not carried." },
+        { "fork": "../../../../src/Blocks/Core/CategoriesBlock.php", "upstream": "index.php", "status": "rewritten", "notes": "Server renderer reimplemented against cms-framework's PostCategory model (a DynamicBlock) rather than WP_Query. name() renamed core/categories → artisanpack/categories at the I6 fork (mirroring LatestPostsBlock at I4)." }
+    ],
+    "vendoredPrimitives": [],
+    "knownDivergences": [
+        "edit.tsx previews via <ServerSideRender> instead of upstream's client-side core-data query — the core-data shim exposes no taxonomy entity and terms are resolved server-side.",
+        "Inspector ported to PanelBody instead of upstream's ToolsPanel (drops the block-library-internal useToolsPanelDropdownMenuProps hook).",
+        "The categories variations array (Terms List / Categories List taxonomy picker) is not carried — the picker pulls getTaxonomies selectors the shim does not implement.",
+        "displayAsDropdown falls back to the list rendering server-side (the upstream dropdown ships a JS handler that is not run server-side); the attribute is carried for round-trip parity.",
+        "categories is a dynamic block, so (like core/tag-cloud, core/archives, artisanpack/latest-posts, artisanpack/form) it is handled by the Blade DynamicBlockRegistry and is not listed in packages/renderer-parity.json — the React/Vue static renderers do not register it.",
+        "transforms.ts adds bidirectional block transforms that don't exist upstream — required to coexist with core/categories during the V1 rollout."
+    ],
+    "triage": {
+        "label": "in-sync",
+        "lastReviewed": "2026-05-29",
+        "reviewer": "I6 loop / feed cluster"
+    }
+}

--- a/resources/js/visual-editor/blocks/post-template/block.json
+++ b/resources/js/visual-editor/blocks/post-template/block.json
@@ -1,0 +1,78 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "artisanpack/post-template",
+    "title": "Post Template",
+    "category": "theme",
+    "ancestor": [ "artisanpack/query" ],
+    "description": "Contains the block elements used to render a post, like the title, date, featured image, content or excerpt, and more.",
+    "textdomain": "artisanpack-visual-editor",
+    "attributes": {
+        "layout": {
+            "type": "string",
+            "default": "list"
+        },
+        "columns": {
+            "type": "number",
+            "default": 3
+        }
+    },
+    "usesContext": [
+        "queryId",
+        "query",
+        "displayLayout",
+        "templateSlug",
+        "previewPostType",
+        "enhancedPagination",
+        "postType"
+    ],
+    "supports": {
+        "anchor": true,
+        "reusable": false,
+        "html": false,
+        "align": [ "wide", "full" ],
+        "layout": true,
+        "color": {
+            "gradients": true,
+            "link": true,
+            "__experimentalDefaultControls": {
+                "background": true,
+                "text": true
+            }
+        },
+        "typography": {
+            "fontSize": true,
+            "lineHeight": true,
+            "__experimentalFontFamily": true,
+            "__experimentalFontWeight": true,
+            "__experimentalFontStyle": true,
+            "__experimentalTextTransform": true,
+            "__experimentalTextDecoration": true,
+            "__experimentalLetterSpacing": true,
+            "__experimentalDefaultControls": {
+                "fontSize": true
+            }
+        },
+        "spacing": {
+            "margin": true,
+            "padding": true,
+            "blockGap": {
+                "__experimentalDefault": "1.25em"
+            },
+            "__experimentalDefaultControls": {
+                "blockGap": true,
+                "padding": false,
+                "margin": false
+            }
+        },
+        "interactivity": {
+            "clientNavigation": true
+        },
+        "__experimentalBorder": {
+            "radius": true,
+            "color": true,
+            "width": true,
+            "style": true
+        }
+    }
+}

--- a/resources/js/visual-editor/blocks/post-template/edit.tsx
+++ b/resources/js/visual-editor/blocks/post-template/edit.tsx
@@ -1,0 +1,97 @@
+/**
+ * Post Template — edit component.
+ *
+ * Renders `<InnerBlocks />` with a default `artisanpack/post-title`
+ * template so users can build the per-iteration layout. Provides a
+ * toolbar toggle to switch between list and grid display, plus a columns
+ * control when grid is active. The wrapping `artisanpack/query`
+ * `BlockContextProvider` resolves the inner `artisanpack/post-*` blocks
+ * against the right post. Phase I6 loop / feed cluster (#414).
+ */
+
+import type { ReactElement } from 'react';
+import {
+    BlockControls,
+    InnerBlocks,
+    InspectorControls,
+    useBlockProps,
+} from '@wordpress/block-editor';
+import {
+    PanelBody,
+    RangeControl,
+    ToolbarButton,
+    ToolbarGroup,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { list, grid } from '@wordpress/icons';
+
+import { TEXT_DOMAIN } from '../../vendor/i18n';
+
+const DEFAULT_TEMPLATE: ReadonlyArray<[string]> = [ [ 'artisanpack/post-title' ] ];
+
+interface PostTemplateEditProps {
+    attributes: Record<string, unknown>;
+    setAttributes: ( changes: Record<string, unknown> ) => void;
+}
+
+export default function PostTemplateEdit( {
+    attributes,
+    setAttributes,
+}: PostTemplateEditProps ): ReactElement {
+    const layout = typeof attributes.layout === 'string' ? attributes.layout : 'list';
+    const columns = typeof attributes.columns === 'number' ? attributes.columns : 3;
+    const isGrid = layout === 'grid';
+
+    const className = [
+        'wp-block-post-template',
+        isGrid ? 'is-layout-grid' : 'is-layout-flow',
+        isGrid ? `columns-${ columns }` : '',
+    ].filter( Boolean ).join( ' ' );
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const blockProps = ( useBlockProps as any )( { className } );
+
+    return (
+        <>
+            <BlockControls>
+                <ToolbarGroup>
+                    <ToolbarButton
+                        icon={ list }
+                        label={ __( 'List view', TEXT_DOMAIN ) }
+                        isPressed={ ! isGrid }
+                        onClick={ () => setAttributes( { layout: 'list' } ) }
+                    />
+                    <ToolbarButton
+                        icon={ grid }
+                        label={ __( 'Grid view', TEXT_DOMAIN ) }
+                        isPressed={ isGrid }
+                        onClick={ () => setAttributes( { layout: 'grid' } ) }
+                    />
+                </ToolbarGroup>
+            </BlockControls>
+
+            { isGrid && (
+                <InspectorControls>
+                    <PanelBody title={ __( 'Layout', TEXT_DOMAIN ) }>
+                        <RangeControl
+                            // @ts-expect-error - upstream prop
+                            __nextHasNoMarginBottom
+                            __next40pxDefaultSize
+                            label={ __( 'Columns', TEXT_DOMAIN ) }
+                            value={ columns }
+                            onChange={ ( value?: number ) =>
+                                setAttributes( { columns: value ?? 3 } )
+                            }
+                            min={ 2 }
+                            max={ 6 }
+                        />
+                    </PanelBody>
+                </InspectorControls>
+            ) }
+
+            <div { ...blockProps }>
+                <InnerBlocks template={ [ ...DEFAULT_TEMPLATE ] } />
+            </div>
+        </>
+    );
+}

--- a/resources/js/visual-editor/blocks/post-template/index.ts
+++ b/resources/js/visual-editor/blocks/post-template/index.ts
@@ -1,0 +1,30 @@
+/**
+ * Post Template block entrypoint.
+ *
+ * Auto-discovered by `editor/custom-blocks.ts` and registered against
+ * `@wordpress/blocks.registerBlockType`. Phase I6 — loop / feed cluster
+ * (issue #414).
+ *
+ * Parent-locked child of `artisanpack/query`. The per-iteration markup is
+ * produced by the server-side `QueryInliner` pre-pass (one clone of the
+ * template subtree per resolved post) and the renderer packages' thin
+ * `PostTemplateBlock` wrapper; the editor previews the first result via the
+ * wrapping query block's `BlockContextProvider`.
+ */
+
+import metadata from './block.json';
+import edit from './edit';
+import save from './save';
+import transforms from './transforms';
+import icon from './inserter-icon';
+
+export { edit, save, metadata, icon, transforms };
+
+export default {
+    name: metadata.name,
+    metadata,
+    edit,
+    save,
+    icon,
+    transforms,
+};

--- a/resources/js/visual-editor/blocks/post-template/inserter-icon.tsx
+++ b/resources/js/visual-editor/blocks/post-template/inserter-icon.tsx
@@ -1,0 +1,23 @@
+/**
+ * Post Template — inserter icon.
+ *
+ * Inline SVG mirroring `@wordpress/icons`' `layout` icon so the editor
+ * canvas does not have to load `dashicons.css` to render it. Phase I6
+ * loop / feed cluster (#414).
+ */
+
+import type { ReactElement } from 'react';
+
+export default function PostTemplateInserterIcon(): ReactElement {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            width={ 24 }
+            height={ 24 }
+            aria-hidden="true"
+        >
+            <path d="M18 4H6a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2zM6 5.5h12a.5.5 0 0 1 .5.5v3h-13V6a.5.5 0 0 1 .5-.5zm-.5 5H10v8H6a.5.5 0 0 1-.5-.5v-7.5zm6 8v-8h6.5V18a.5.5 0 0 1-.5.5h-6z" />
+        </svg>
+    );
+}

--- a/resources/js/visual-editor/blocks/post-template/save.tsx
+++ b/resources/js/visual-editor/blocks/post-template/save.tsx
@@ -1,0 +1,15 @@
+/**
+ * Post Template — save component.
+ *
+ * Ported from `@wordpress/block-library/src/post-template/save.js`
+ * (v9.43.0): the saved markup is the serialized inner-block template, which
+ * the server-side `QueryInliner` clones once per resolved post. Phase I6
+ * loop / feed cluster (#414).
+ */
+
+import type { ReactElement } from 'react';
+import { InnerBlocks } from '@wordpress/block-editor';
+
+export default function PostTemplateSave(): ReactElement {
+    return <InnerBlocks.Content />;
+}

--- a/resources/js/visual-editor/blocks/post-template/transforms.ts
+++ b/resources/js/visual-editor/blocks/post-template/transforms.ts
@@ -1,0 +1,43 @@
+/**
+ * Post Template — transforms.
+ *
+ * `@wordpress/block-library/src/post-template` ships no `transforms.js`.
+ * The fork adds bidirectional block transforms for
+ * `core/post-template` ↔ `artisanpack/post-template` so mixed documents
+ * round-trip losslessly during the V1 rollout. The `to: core/post-template`
+ * direction is removed at the I7 cutover once `core/post-template` is no
+ * longer registered. Phase I6 loop / feed cluster (#414).
+ */
+
+import { createBlock } from '@wordpress/blocks';
+
+import metadata from './block.json';
+
+const { name } = metadata;
+
+interface PostTemplateAttributes {
+    readonly [ key: string ]: unknown;
+}
+
+const transforms = {
+    from: [
+        {
+            type: 'block',
+            blocks: [ 'core/post-template' ],
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            transform: ( attributes: PostTemplateAttributes, innerBlocks: any[] ) =>
+                createBlock( name, attributes, innerBlocks ),
+        },
+    ],
+    to: [
+        {
+            type: 'block',
+            blocks: [ 'core/post-template' ],
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            transform: ( attributes: PostTemplateAttributes, innerBlocks: any[] ) =>
+                createBlock( 'core/post-template', attributes, innerBlocks ),
+        },
+    ],
+};
+
+export default transforms;

--- a/resources/js/visual-editor/blocks/post-template/upstream-state.json
+++ b/resources/js/visual-editor/blocks/post-template/upstream-state.json
@@ -1,0 +1,37 @@
+{
+    "$schema": "../../../../scripts/upstream-state.schema.json",
+    "block": "artisanpack/post-template",
+    "upstream": {
+        "package": "@wordpress/block-library",
+        "namespace": "core/post-template",
+        "pinnedVersion": "9.43.0",
+        "subpath": "post-template"
+    },
+    "forkedAt": "2026-05-29",
+    "$statusLegend": {
+        "ported": "byte-equivalent to upstream (CI fails on drift)",
+        "adapted": "TypeScript port and/or namespace swap; logically equivalent",
+        "extended": "fork adds behavior on top of upstream",
+        "rewritten": "fork replaced upstream entirely",
+        "added": "file unique to the fork (no upstream)"
+    },
+    "files": [
+        { "fork": "block.json", "upstream": "block.json", "status": "adapted", "notes": "name + textdomain swapped to the artisanpack namespace; ancestor repointed core/query → artisanpack/query; usesContext + supports carried verbatim. editorStyle/style handles dropped." },
+        { "fork": "edit.tsx", "upstream": "edit.js", "status": "rewritten", "notes": "Upstream queries the loop's posts via getEntityRecords; the post editor's core-data shim returns empty, so the fork renders <InnerBlocks /> with a default artisanpack/post-title template and relies on the wrapping artisanpack/query BlockContextProvider for entity resolution. Mirrors the V1 query override's PostTemplateEdit." },
+        { "fork": "save.tsx", "upstream": "save.js", "status": "ported", "notes": "Returns <InnerBlocks.Content /> — serialized inner-block template cloned per resolved post by the server-side QueryInliner." },
+        { "fork": "transforms.ts", "upstream": "n/a", "status": "added", "notes": "Upstream has no transforms.js; the fork adds bidirectional core/post-template ↔ artisanpack/post-template block transforms for the rollout window." },
+        { "fork": "inserter-icon.tsx", "upstream": "n/a", "status": "added", "notes": "Inline SVG mirroring @wordpress/icons' layout icon." },
+        { "fork": "index.ts", "upstream": "index.js", "status": "rewritten", "notes": "Adapted to the visual-editor auto-discovery contract." }
+    ],
+    "vendoredPrimitives": [],
+    "knownDivergences": [
+        "edit.tsx renders a static <InnerBlocks /> template instead of upstream's per-record editable iteration — the core-data shim does not expose the loop's post records to the post editor; the front-end iteration is produced server-side by QueryInliner.",
+        "post-template parity covers the editor save + the renderer packages' thin PostTemplateBlock wrapper; the deep upstream edit/ machinery (block preview, layout toolbar) is not carried.",
+        "transforms.ts adds bidirectional block transforms that don't exist upstream — required to coexist with core/post-template during the V1 rollout."
+    ],
+    "triage": {
+        "label": "in-sync",
+        "lastReviewed": "2026-05-29",
+        "reviewer": "I6 loop / feed cluster"
+    }
+}

--- a/resources/js/visual-editor/blocks/query/block.json
+++ b/resources/js/visual-editor/blocks/query/block.json
@@ -9,7 +9,7 @@
     "textdomain": "artisanpack-visual-editor",
     "attributes": {
         "queryId": {
-            "type": "number"
+            "type": "string"
         },
         "query": {
             "type": "object",

--- a/resources/js/visual-editor/blocks/query/block.json
+++ b/resources/js/visual-editor/blocks/query/block.json
@@ -1,0 +1,62 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "artisanpack/query",
+    "title": "Query Loop",
+    "category": "theme",
+    "description": "An advanced block that allows displaying post types based on different query parameters and visual configurations.",
+    "keywords": [ "posts", "list", "blog", "blogs", "custom post types" ],
+    "textdomain": "artisanpack-visual-editor",
+    "attributes": {
+        "queryId": {
+            "type": "number"
+        },
+        "query": {
+            "type": "object",
+            "default": {
+                "perPage": null,
+                "pages": 0,
+                "offset": 0,
+                "postType": "post",
+                "order": "desc",
+                "orderBy": "date",
+                "author": "",
+                "search": "",
+                "exclude": [],
+                "sticky": "",
+                "inherit": true,
+                "taxQuery": null,
+                "parents": [],
+                "format": []
+            }
+        },
+        "tagName": {
+            "type": "string",
+            "default": "div"
+        },
+        "namespace": {
+            "type": "string"
+        },
+        "enhancedPagination": {
+            "type": "boolean",
+            "default": false
+        },
+        "displayLayout": {
+            "type": "object"
+        }
+    },
+    "usesContext": [ "templateSlug" ],
+    "providesContext": {
+        "queryId": "queryId",
+        "query": "query",
+        "displayLayout": "displayLayout",
+        "enhancedPagination": "enhancedPagination"
+    },
+    "supports": {
+        "anchor": true,
+        "align": [ "wide", "full" ],
+        "html": false,
+        "layout": true,
+        "interactivity": true
+    }
+}

--- a/resources/js/visual-editor/blocks/query/edit.tsx
+++ b/resources/js/visual-editor/blocks/query/edit.tsx
@@ -1,0 +1,231 @@
+/**
+ * Query Loop — edit component.
+ *
+ * Provides inspector controls for all QueryRuntime-supported attributes:
+ * post type, posts per page, offset, order/orderBy, and search filter.
+ * Previews the first matching post via `useQueryPreview` and renders
+ * `<InnerBlocks />` inside a `BlockContextProvider` so inner
+ * `artisanpack/post-*` blocks resolve against the right post.
+ *
+ * Phase I6 loop / feed cluster (#414).
+ */
+
+import type { ReactElement } from 'react';
+import { useEffect } from 'react';
+import {
+    BlockContextProvider,
+    InnerBlocks,
+    InspectorControls,
+    useBlockProps,
+} from '@wordpress/block-editor';
+import {
+    Notice,
+    PanelBody,
+    RangeControl,
+    SelectControl,
+    TextControl,
+    ToggleControl,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+import { useQueryPreview } from '../../editor/use-query-preview';
+import { TEXT_DOMAIN } from '../../vendor/i18n';
+
+interface QueryEditProps {
+    attributes: Record<string, unknown>;
+    setAttributes: ( changes: Record<string, unknown> ) => void;
+    clientId: string;
+}
+
+function getQuery( attributes: Record<string, unknown> ): Record<string, unknown> {
+    if (
+        attributes.query !== null &&
+        typeof attributes.query === 'object' &&
+        ! Array.isArray( attributes.query )
+    ) {
+        return attributes.query as Record<string, unknown>;
+    }
+    return {};
+}
+
+export default function QueryEdit( {
+    attributes,
+    setAttributes,
+    clientId,
+}: QueryEditProps ): ReactElement {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const blockProps = ( useBlockProps as any )();
+    const query = getQuery( attributes );
+
+    const updateQuery = ( changes: Record<string, unknown> ): void => {
+        setAttributes( { query: { ...query, ...changes } } );
+    };
+
+    const postType = typeof query.postType === 'string' && query.postType !== ''
+        ? query.postType : 'post';
+    const perPage = typeof query.perPage === 'number' ? query.perPage : 5;
+    const offset = typeof query.offset === 'number' ? query.offset : 0;
+    const order = query.order === 'asc' ? 'asc' : 'desc';
+    const orderBy = typeof query.orderBy === 'string' ? query.orderBy : 'date';
+    const search = typeof query.search === 'string' ? query.search : '';
+    const inherit = Boolean( query.inherit );
+
+    const persistedQueryId =
+        typeof attributes.queryId === 'string' || typeof attributes.queryId === 'number'
+            ? String( attributes.queryId )
+            : null;
+
+    useEffect( () => {
+        if ( persistedQueryId === clientId ) {
+            return;
+        }
+        setAttributes( { queryId: clientId } );
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [ persistedQueryId, clientId ] );
+
+    const preview = useQueryPreview( query );
+
+    const firstPost = preview.status === 'ready' ? preview.posts[ 0 ] : undefined;
+    const blockContext =
+        firstPost === undefined
+            ? { postType }
+            : { postType, postId: firstPost.id };
+
+    return (
+        <div { ...blockProps }>
+            <InspectorControls>
+                <PanelBody title={ __( 'Settings', TEXT_DOMAIN ) }>
+                    <SelectControl
+                        // @ts-expect-error - upstream prop
+                        __next40pxDefaultSize
+                        __nextHasNoMarginBottom
+                        label={ __( 'Post type', TEXT_DOMAIN ) }
+                        value={ postType }
+                        options={ [
+                            { label: __( 'Posts', TEXT_DOMAIN ), value: 'post' },
+                            { label: __( 'Pages', TEXT_DOMAIN ), value: 'page' },
+                        ] }
+                        onChange={ ( value: string ) => updateQuery( { postType: value } ) }
+                    />
+                    <RangeControl
+                        // @ts-expect-error - upstream prop
+                        __nextHasNoMarginBottom
+                        __next40pxDefaultSize
+                        label={ __( 'Posts per page', TEXT_DOMAIN ) }
+                        value={ perPage }
+                        onChange={ ( value?: number ) => updateQuery( { perPage: value ?? 5 } ) }
+                        min={ 1 }
+                        max={ 100 }
+                    />
+                    <RangeControl
+                        // @ts-expect-error - upstream prop
+                        __nextHasNoMarginBottom
+                        __next40pxDefaultSize
+                        label={ __( 'Offset', TEXT_DOMAIN ) }
+                        value={ offset }
+                        onChange={ ( value?: number ) => updateQuery( { offset: value ?? 0 } ) }
+                        min={ 0 }
+                        max={ 100 }
+                    />
+                    <SelectControl
+                        // @ts-expect-error - upstream prop
+                        __next40pxDefaultSize
+                        __nextHasNoMarginBottom
+                        label={ __( 'Order by', TEXT_DOMAIN ) }
+                        value={ `${ orderBy }/${ order }` }
+                        options={ [
+                            { label: __( 'Newest to oldest', TEXT_DOMAIN ), value: 'date/desc' },
+                            { label: __( 'Oldest to newest', TEXT_DOMAIN ), value: 'date/asc' },
+                            { label: __( 'A → Z', TEXT_DOMAIN ), value: 'title/asc' },
+                            { label: __( 'Z → A', TEXT_DOMAIN ), value: 'title/desc' },
+                        ] }
+                        onChange={ ( value: string ) => {
+                            const [ newOrderBy, newOrder ] = value.split( '/' );
+                            updateQuery( { orderBy: newOrderBy, order: newOrder } );
+                        } }
+                    />
+                    <ToggleControl
+                        // @ts-expect-error - upstream prop
+                        __nextHasNoMarginBottom
+                        label={ __( 'Inherit query from URL', TEXT_DOMAIN ) }
+                        help={ __( 'When enabled, uses the current page\'s query context (e.g. archive, search results).', TEXT_DOMAIN ) }
+                        checked={ inherit }
+                        onChange={ ( value ) => updateQuery( { inherit: value } ) }
+                    />
+                </PanelBody>
+                <PanelBody title={ __( 'Filters', TEXT_DOMAIN ) } initialOpen={ false }>
+                    <TextControl
+                        // @ts-expect-error - upstream prop
+                        __next40pxDefaultSize
+                        __nextHasNoMarginBottom
+                        label={ __( 'Search', TEXT_DOMAIN ) }
+                        value={ search }
+                        onChange={ ( value: string ) => updateQuery( { search: value } ) }
+                    />
+                </PanelBody>
+                <PanelBody title={ __( 'Preview', TEXT_DOMAIN ) } initialOpen={ false }>
+                    <PreviewStatus preview={ preview } />
+                </PanelBody>
+            </InspectorControls>
+            <PreviewBanner preview={ preview } />
+            <BlockContextProvider value={ blockContext }>
+                <InnerBlocks />
+            </BlockContextProvider>
+        </div>
+    );
+}
+
+interface PreviewSummaryProps {
+    preview: ReturnType<typeof useQueryPreview>;
+}
+
+function PreviewStatus( { preview }: PreviewSummaryProps ): ReactElement {
+    if ( preview.status === 'loading' ) {
+        return <p>{ __( 'Loading preview…', TEXT_DOMAIN ) }</p>;
+    }
+
+    if ( preview.status === 'error' ) {
+        return (
+            <Notice status="error" isDismissible={ false }>
+                { preview.error ?? __( 'Preview failed.', TEXT_DOMAIN ) }
+            </Notice>
+        );
+    }
+
+    if ( preview.status === 'ready' ) {
+        return (
+            <p>
+                { __( 'Posts matched:', TEXT_DOMAIN ) } <strong>{ preview.total }</strong>
+            </p>
+        );
+    }
+
+    return <p>{ __( 'Configure the query to see a preview.', TEXT_DOMAIN ) }</p>;
+}
+
+function PreviewBanner( { preview }: PreviewSummaryProps ): ReactElement | null {
+    if ( preview.status !== 'ready' ) {
+        return null;
+    }
+
+    if ( preview.total === 0 ) {
+        return (
+            <Notice status="warning" isDismissible={ false }>
+                { __( 'No posts matched the current query.', TEXT_DOMAIN ) }
+            </Notice>
+        );
+    }
+
+    if ( preview.total === 1 ) {
+        return null;
+    }
+
+    return (
+        <Notice status="info" isDismissible={ false }>
+            { __(
+                'The canvas previews the first matching post. The saved page renders all matching posts.',
+                TEXT_DOMAIN
+            ) }
+        </Notice>
+    );
+}

--- a/resources/js/visual-editor/blocks/query/index.ts
+++ b/resources/js/visual-editor/blocks/query/index.ts
@@ -1,0 +1,31 @@
+/**
+ * Query Loop block entrypoint.
+ *
+ * Auto-discovered by `editor/custom-blocks.ts` and registered against
+ * `@wordpress/blocks.registerBlockType`. Phase I6 — loop / feed cluster
+ * (issue #414).
+ *
+ * The saved tree is expanded server-side by `QueryInliner` (one clone of
+ * the inner `artisanpack/post-template` per resolved post) and rendered by
+ * the renderer packages' thin `QueryBlock` wrapper; the editor previews the
+ * first matching post via the `useQueryPreview` hook. Upstream's
+ * variations + deprecation chain are intentionally not carried — see
+ * `upstream-state.json`.
+ */
+
+import metadata from './block.json';
+import edit from './edit';
+import save from './save';
+import transforms from './transforms';
+import icon from './inserter-icon';
+
+export { edit, save, metadata, icon, transforms };
+
+export default {
+    name: metadata.name,
+    metadata,
+    edit,
+    save,
+    icon,
+    transforms,
+};

--- a/resources/js/visual-editor/blocks/query/inserter-icon.tsx
+++ b/resources/js/visual-editor/blocks/query/inserter-icon.tsx
@@ -1,0 +1,23 @@
+/**
+ * Query Loop — inserter icon.
+ *
+ * Inline SVG mirroring `@wordpress/icons`' `loop` icon so the editor canvas
+ * does not have to load `dashicons.css` to render it. Phase I6 loop / feed
+ * cluster (#414).
+ */
+
+import type { ReactElement } from 'react';
+
+export default function QueryInserterIcon(): ReactElement {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            width={ 24 }
+            height={ 24 }
+            aria-hidden="true"
+        >
+            <path d="M19.5 4.5h-15a1 1 0 0 0-1 1V11h1.5V6h14v5H6.31l1.72-1.72-1.06-1.06L3.19 11.5l3.78 3.78 1.06-1.06L6.31 12.5H19.5a1 1 0 0 0 1-1V5.5a1 1 0 0 0-1-1Zm-1 14v-3H17v3H4.5V20h14a1 1 0 0 0 1-1v-.5h-1Z" />
+        </svg>
+    );
+}

--- a/resources/js/visual-editor/blocks/query/save.tsx
+++ b/resources/js/visual-editor/blocks/query/save.tsx
@@ -1,0 +1,26 @@
+/**
+ * Query Loop — save component.
+ *
+ * Ported from `@wordpress/block-library/src/query/save.js` (v9.43.0): the
+ * saved markup is the configured `tagName` wrapper around the serialized
+ * inner blocks (the `artisanpack/post-template` shell). The server-side
+ * `QueryInliner` expands that shell once per resolved post on the
+ * public-render path. Phase I6 loop / feed cluster (#414).
+ */
+
+import type { ReactElement } from 'react';
+import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
+
+interface QuerySaveProps {
+    attributes: { tagName?: string };
+}
+
+export default function QuerySave( { attributes }: QuerySaveProps ): ReactElement {
+    const Tag = ( attributes.tagName ?? 'div' ) as keyof JSX.IntrinsicElements;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const blockProps = ( useBlockProps as any ).save();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const innerBlocksProps = ( useInnerBlocksProps as any ).save( blockProps );
+
+    return <Tag { ...innerBlocksProps } />;
+}

--- a/resources/js/visual-editor/blocks/query/transforms.ts
+++ b/resources/js/visual-editor/blocks/query/transforms.ts
@@ -28,22 +28,25 @@ const transforms = {
         {
             type: 'block',
             blocks: [ 'core/query' ],
-            transform: ( attributes: QueryAttributes ) =>
-                createBlock( name, attributes ),
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            transform: ( attributes: QueryAttributes, innerBlocks: any[] ) =>
+                createBlock( name, attributes, innerBlocks ),
         },
         {
             type: 'block',
             blocks: [ 'core/query-loop' ],
-            transform: ( attributes: QueryAttributes ) =>
-                createBlock( name, attributes ),
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            transform: ( attributes: QueryAttributes, innerBlocks: any[] ) =>
+                createBlock( name, attributes, innerBlocks ),
         },
     ],
     to: [
         {
             type: 'block',
             blocks: [ 'core/query' ],
-            transform: ( attributes: QueryAttributes ) =>
-                createBlock( 'core/query', attributes ),
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            transform: ( attributes: QueryAttributes, innerBlocks: any[] ) =>
+                createBlock( 'core/query', attributes, innerBlocks ),
         },
     ],
 };

--- a/resources/js/visual-editor/blocks/query/transforms.ts
+++ b/resources/js/visual-editor/blocks/query/transforms.ts
@@ -1,0 +1,51 @@
+/**
+ * Query Loop — transforms.
+ *
+ * `@wordpress/block-library/src/query` ships variation-driven transforms,
+ * which the fork does not carry (the variation picker pulls selectors the
+ * post editor's core-data shim does not implement). Instead the fork ships
+ * the bidirectional `core/query` ↔ `artisanpack/query` rollout transforms
+ * plus a one-way `core/query-loop` → `artisanpack/query` conversion:
+ * `core/query-loop` is the deprecated upstream alias for `core/query`, so
+ * any pasted legacy `query-loop` markup folds into the fork. The
+ * `to: core/query` direction is removed at the I7 cutover once
+ * `core/query` is no longer registered. Phase I6 loop / feed
+ * cluster (#414).
+ */
+
+import { createBlock } from '@wordpress/blocks';
+
+import metadata from './block.json';
+
+const { name } = metadata;
+
+interface QueryAttributes {
+    readonly [ key: string ]: unknown;
+}
+
+const transforms = {
+    from: [
+        {
+            type: 'block',
+            blocks: [ 'core/query' ],
+            transform: ( attributes: QueryAttributes ) =>
+                createBlock( name, attributes ),
+        },
+        {
+            type: 'block',
+            blocks: [ 'core/query-loop' ],
+            transform: ( attributes: QueryAttributes ) =>
+                createBlock( name, attributes ),
+        },
+    ],
+    to: [
+        {
+            type: 'block',
+            blocks: [ 'core/query' ],
+            transform: ( attributes: QueryAttributes ) =>
+                createBlock( 'core/query', attributes ),
+        },
+    ],
+};
+
+export default transforms;

--- a/resources/js/visual-editor/blocks/query/upstream-state.json
+++ b/resources/js/visual-editor/blocks/query/upstream-state.json
@@ -1,0 +1,39 @@
+{
+    "$schema": "../../../../scripts/upstream-state.schema.json",
+    "block": "artisanpack/query",
+    "upstream": {
+        "package": "@wordpress/block-library",
+        "namespace": "core/query",
+        "pinnedVersion": "9.43.0",
+        "subpath": "query"
+    },
+    "forkedAt": "2026-05-29",
+    "$statusLegend": {
+        "ported": "byte-equivalent to upstream (CI fails on drift)",
+        "adapted": "TypeScript port and/or namespace swap; logically equivalent",
+        "extended": "fork adds behavior on top of upstream",
+        "rewritten": "fork replaced upstream entirely",
+        "added": "file unique to the fork (no upstream)"
+    },
+    "files": [
+        { "fork": "block.json", "upstream": "block.json", "status": "adapted", "notes": "name + textdomain swapped to the artisanpack namespace; attribute schema (incl. the nested query object defaults), usesContext + providesContext + supports carried verbatim. editorStyle handle dropped." },
+        { "fork": "edit.tsx", "upstream": "edit/index.js (+ 16 subcomponents)", "status": "rewritten", "notes": "Upstream's Edit pulls getTaxonomies/getEntityRecords selectors the post editor's core-data shim does not implement (variation picker, toolbar, per-record preview). The fork mirrors the V1 core/query override: a thin Edit that previews the first matching post via useQueryPreview (POST /visual-editor/api/query/resolve), pushes its postId into a BlockContextProvider, and renders <InnerBlocks />. The 16-file upstream edit/ tree is not carried." },
+        { "fork": "save.tsx", "upstream": "save.js", "status": "ported", "notes": "tagName wrapper around useInnerBlocksProps.save(useBlockProps.save()) — byte-equivalent saved markup. Expanded per-result by the server-side QueryInliner." },
+        { "fork": "transforms.ts", "upstream": "n/a (variation-driven)", "status": "added", "notes": "Upstream transforms are variation-driven and not carried. The fork adds bidirectional core/query ↔ artisanpack/query rollout transforms plus a one-way core/query-loop → artisanpack/query conversion (query-loop is the deprecated upstream alias for core/query)." },
+        { "fork": "inserter-icon.tsx", "upstream": "n/a", "status": "added", "notes": "Inline SVG mirroring @wordpress/icons' loop icon." },
+        { "fork": "index.ts", "upstream": "index.js", "status": "rewritten", "notes": "Adapted to the visual-editor auto-discovery contract; variations + deprecated not carried (see knownDivergences)." }
+    ],
+    "vendoredPrimitives": [],
+    "knownDivergences": [
+        "edit.tsx previews via useQueryPreview instead of upstream's client-side core-data query + variation picker — the shim does not implement getTaxonomies/getEntityRecords; the saved page renders every matching post via the server-side QueryInliner. Mirrors the V1 core/query override.",
+        "variations.js (Title & Date / Title & Excerpt / Title, Date & Excerpt / Image, Date & Title) is NOT carried — the variation picker mounts toolbar chrome that calls getTaxonomies({per_page:-1}), a selector the shim does not implement. Same reason the V1 override strips them. Variations are an editor-UI convenience and are not part of the saved block shape, so dropping them is attribute-compatible.",
+        "deprecated.js (the upstream 6-entry deprecation chain) is NOT carried. It only migrates legacy core/query saved markup — which still deserializes through the still-registered core/query block and its own chain — and imports the block-library-private ../lock-unlock. No content can be persisted under the new artisanpack/query name before 1.0 GA (the no-migration window, plan 13 §2.1), so the chain would never fire on artisanpack/query content. Carrying it (and vendoring lock-unlock) is deferred to a later customization pass.",
+        "core/query-loop is the deprecated upstream alias for core/query (no standalone block source in @wordpress/block-library v9.43.0); the fork folds it in via a one-way transform rather than registering a separate artisanpack/query-loop block.",
+        "Renderer parity reuses the existing core/query QueryBlock / PostTemplateBlock wrappers (react/vue) and the bladeDynamic path — artisanpack/query + artisanpack/post-template are added to packages/renderer-parity.json."
+    ],
+    "triage": {
+        "label": "in-sync",
+        "lastReviewed": "2026-05-29",
+        "reviewer": "I6 loop / feed cluster"
+    }
+}

--- a/resources/js/visual-editor/blocks/tag-cloud/block.json
+++ b/resources/js/visual-editor/blocks/tag-cloud/block.json
@@ -1,0 +1,69 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "artisanpack/tag-cloud",
+    "title": "Tag Cloud",
+    "category": "widgets",
+    "description": "A cloud of popular keywords, each sized by how often it appears.",
+    "textdomain": "artisanpack-visual-editor",
+    "attributes": {
+        "numberOfTags": {
+            "type": "number",
+            "default": 45,
+            "minimum": 1,
+            "maximum": 100
+        },
+        "taxonomy": {
+            "type": "string",
+            "default": "post_tag"
+        },
+        "showTagCounts": {
+            "type": "boolean",
+            "default": false
+        },
+        "smallestFontSize": {
+            "type": "string",
+            "default": "8pt"
+        },
+        "largestFontSize": {
+            "type": "string",
+            "default": "22pt"
+        }
+    },
+    "styles": [
+        { "name": "default", "label": "Default", "isDefault": true },
+        { "name": "outline", "label": "Outline" }
+    ],
+    "supports": {
+        "anchor": true,
+        "html": false,
+        "align": true,
+        "spacing": {
+            "margin": true,
+            "padding": true
+        },
+        "typography": {
+            "lineHeight": true,
+            "__experimentalFontFamily": true,
+            "__experimentalFontWeight": true,
+            "__experimentalFontStyle": true,
+            "__experimentalTextTransform": true,
+            "__experimentalLetterSpacing": true
+        },
+        "interactivity": {
+            "clientNavigation": true
+        },
+        "__experimentalBorder": {
+            "radius": true,
+            "color": true,
+            "width": true,
+            "style": true,
+            "__experimentalDefaultControls": {
+                "radius": true,
+                "color": true,
+                "width": true,
+                "style": true
+            }
+        }
+    }
+}

--- a/resources/js/visual-editor/blocks/tag-cloud/edit.tsx
+++ b/resources/js/visual-editor/blocks/tag-cloud/edit.tsx
@@ -1,0 +1,132 @@
+/**
+ * Tag Cloud — edit component.
+ *
+ * `core/tag-cloud` is server-rendered. Upstream's `edit.js` calls
+ * `getTaxonomies({ per_page: -1 })` to populate a taxonomy picker, but the
+ * post editor's core-data shim does not implement that selector and this
+ * package resolves tags on the server (see
+ * `src/Blocks/Core/TagCloudBlock.php`). The fork therefore previews
+ * through the package's `<ServerSideRender>` seam — the same approach the
+ * V1 taxonomy/archive override uses — and ports the inspector controls to
+ * `PanelBody`. Phase I6 loop / feed cluster (#414).
+ */
+
+import type { ReactElement } from 'react';
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import {
+    PanelBody,
+    RangeControl,
+    SelectControl,
+    ToggleControl,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+import { ServerSideRender } from '../../editor/server-side-render';
+import { TEXT_DOMAIN } from '../../vendor/i18n';
+
+// Typed as `{ label: string; value: string }[]` so TS does not narrow the
+// option values to literal unions — that narrowing collides with the
+// broader `string` type the block attributes carry.
+const SMALLEST_SIZE_OPTIONS: { label: string; value: string }[] = [
+    { label: '8pt', value: '8pt' },
+    { label: '10pt', value: '10pt' },
+    { label: '12pt', value: '12pt' },
+];
+
+const LARGEST_SIZE_OPTIONS: { label: string; value: string }[] = [
+    { label: '16pt', value: '16pt' },
+    { label: '22pt', value: '22pt' },
+    { label: '28pt', value: '28pt' },
+];
+
+interface TagCloudAttributes {
+    readonly numberOfTags?: number;
+    readonly showTagCounts?: boolean;
+    readonly smallestFontSize?: string;
+    readonly largestFontSize?: string;
+    readonly [ key: string ]: unknown;
+}
+
+interface TagCloudEditProps {
+    readonly attributes: TagCloudAttributes;
+    readonly setAttributes: ( attrs: Partial<TagCloudAttributes> ) => void;
+}
+
+export default function TagCloudEdit( {
+    attributes,
+    setAttributes,
+}: TagCloudEditProps ): ReactElement {
+    const numberOfTags =
+        typeof attributes.numberOfTags === 'number' ? attributes.numberOfTags : 45;
+    const showTagCounts = Boolean( attributes.showTagCounts );
+    const smallestFontSize =
+        typeof attributes.smallestFontSize === 'string'
+            ? attributes.smallestFontSize
+            : '8pt';
+    const largestFontSize =
+        typeof attributes.largestFontSize === 'string'
+            ? attributes.largestFontSize
+            : '22pt';
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const blockProps = ( useBlockProps as any )();
+
+    return (
+        <>
+            <InspectorControls>
+                <PanelBody title={ __( 'Settings', TEXT_DOMAIN ) }>
+                    <RangeControl
+                        // @ts-expect-error - upstream prop
+                        __nextHasNoMarginBottom
+                        __next40pxDefaultSize
+                        label={ __( 'Number of tags', TEXT_DOMAIN ) }
+                        min={ 1 }
+                        max={ 100 }
+                        value={ numberOfTags }
+                        onChange={ ( value?: number ) =>
+                            setAttributes( { numberOfTags: value ?? 45 } )
+                        }
+                    />
+                    <ToggleControl
+                        // @ts-expect-error - upstream prop
+                        __nextHasNoMarginBottom
+                        label={ __( 'Show tag counts', TEXT_DOMAIN ) }
+                        checked={ showTagCounts }
+                        onChange={ ( value ) =>
+                            setAttributes( { showTagCounts: value } )
+                        }
+                    />
+                    <SelectControl
+                        // @ts-expect-error - upstream prop
+                        __next40pxDefaultSize
+                        __nextHasNoMarginBottom
+                        label={ __( 'Smallest size', TEXT_DOMAIN ) }
+                        value={ smallestFontSize }
+                        options={ SMALLEST_SIZE_OPTIONS }
+                        onChange={ ( value: string ) =>
+                            setAttributes( { smallestFontSize: value } )
+                        }
+                    />
+                    <SelectControl
+                        // @ts-expect-error - upstream prop
+                        __next40pxDefaultSize
+                        __nextHasNoMarginBottom
+                        label={ __( 'Largest size', TEXT_DOMAIN ) }
+                        value={ largestFontSize }
+                        options={ LARGEST_SIZE_OPTIONS }
+                        onChange={ ( value: string ) =>
+                            setAttributes( { largestFontSize: value } )
+                        }
+                    />
+                </PanelBody>
+            </InspectorControls>
+
+            <div { ...blockProps }>
+                <ServerSideRender
+                    block="artisanpack/tag-cloud"
+                    attributes={ attributes }
+                />
+            </div>
+        </>
+    );
+}

--- a/resources/js/visual-editor/blocks/tag-cloud/index.ts
+++ b/resources/js/visual-editor/blocks/tag-cloud/index.ts
@@ -1,0 +1,28 @@
+/**
+ * Tag Cloud block entrypoint.
+ *
+ * Auto-discovered by `editor/custom-blocks.ts` and registered against
+ * `@wordpress/blocks.registerBlockType`. Phase I6 — loop / feed cluster
+ * (issue #414).
+ *
+ * Dynamic block: `save` returns `null` and the markup is produced server
+ * side by `TagCloudBlock::render()`; the editor previews it through the
+ * package's `<ServerSideRender>` seam.
+ */
+
+import metadata from './block.json';
+import edit from './edit';
+import save from './save';
+import transforms from './transforms';
+import icon from './inserter-icon';
+
+export { edit, save, metadata, icon, transforms };
+
+export default {
+    name: metadata.name,
+    metadata,
+    edit,
+    save,
+    icon,
+    transforms,
+};

--- a/resources/js/visual-editor/blocks/tag-cloud/inserter-icon.tsx
+++ b/resources/js/visual-editor/blocks/tag-cloud/inserter-icon.tsx
@@ -1,0 +1,23 @@
+/**
+ * Tag Cloud — inserter icon.
+ *
+ * Inline SVG mirroring `@wordpress/icons`' `tag` icon so the editor canvas
+ * does not have to load `dashicons.css` to render it. Phase I6 loop / feed
+ * cluster (#414).
+ */
+
+import type { ReactElement } from 'react';
+
+export default function TagCloudInserterIcon(): ReactElement {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            width={ 24 }
+            height={ 24 }
+            aria-hidden="true"
+        >
+            <path d="M20.59 13.41 11 3.83A2 2 0 0 0 9.59 3H4a1 1 0 0 0-1 1v5.59A2 2 0 0 0 3.59 11l9.58 9.59a2 2 0 0 0 2.83 0l4.59-4.59a2 2 0 0 0 0-2.59ZM7 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z" />
+        </svg>
+    );
+}

--- a/resources/js/visual-editor/blocks/tag-cloud/save.tsx
+++ b/resources/js/visual-editor/blocks/tag-cloud/save.tsx
@@ -1,0 +1,13 @@
+/**
+ * Tag Cloud — save component.
+ *
+ * Dynamic block: the saved markup is just the block delimiter
+ * (`<!-- wp:artisanpack/tag-cloud {…} /-->`) and the HTML is generated
+ * server-side by `TagCloudBlock::render()`. Returning `null` from save is
+ * the Gutenberg convention for dynamic blocks. Phase I6 loop / feed
+ * cluster (#414).
+ */
+
+export default function TagCloudSave(): null {
+    return null;
+}

--- a/resources/js/visual-editor/blocks/tag-cloud/transforms.ts
+++ b/resources/js/visual-editor/blocks/tag-cloud/transforms.ts
@@ -1,0 +1,54 @@
+/**
+ * Tag Cloud — transforms.
+ *
+ * `@wordpress/block-library/src/tag-cloud` (v9.43.0) ships a
+ * `transforms.js` with a `core/categories` ↔ `core/tag-cloud` convenience
+ * transform. The fork carries the cross-block convenience forward under
+ * the artisanpack namespace and adds the bidirectional
+ * `core/tag-cloud` ↔ `artisanpack/tag-cloud` rollout transforms so mixed
+ * documents round-trip losslessly during the V1 rollout. The
+ * `to: core/tag-cloud` direction is removed at the I7 cutover once
+ * `core/tag-cloud` is no longer registered. Phase I6 loop / feed
+ * cluster (#414).
+ */
+
+import { createBlock } from '@wordpress/blocks';
+
+import metadata from './block.json';
+
+const { name } = metadata;
+
+interface TagCloudAttributes {
+    readonly [ key: string ]: unknown;
+}
+
+const transforms = {
+    from: [
+        {
+            type: 'block',
+            blocks: [ 'core/tag-cloud' ],
+            transform: ( attributes: TagCloudAttributes ) =>
+                createBlock( name, attributes ),
+        },
+        {
+            type: 'block',
+            blocks: [ 'artisanpack/categories' ],
+            transform: () => createBlock( name ),
+        },
+    ],
+    to: [
+        {
+            type: 'block',
+            blocks: [ 'core/tag-cloud' ],
+            transform: ( attributes: TagCloudAttributes ) =>
+                createBlock( 'core/tag-cloud', attributes ),
+        },
+        {
+            type: 'block',
+            blocks: [ 'artisanpack/categories' ],
+            transform: () => createBlock( 'artisanpack/categories' ),
+        },
+    ],
+};
+
+export default transforms;

--- a/resources/js/visual-editor/blocks/tag-cloud/upstream-state.json
+++ b/resources/js/visual-editor/blocks/tag-cloud/upstream-state.json
@@ -1,0 +1,39 @@
+{
+    "$schema": "../../../../scripts/upstream-state.schema.json",
+    "block": "artisanpack/tag-cloud",
+    "upstream": {
+        "package": "@wordpress/block-library",
+        "namespace": "core/tag-cloud",
+        "pinnedVersion": "9.43.0",
+        "subpath": "tag-cloud"
+    },
+    "forkedAt": "2026-05-29",
+    "$statusLegend": {
+        "ported": "byte-equivalent to upstream (CI fails on drift)",
+        "adapted": "TypeScript port and/or namespace swap; logically equivalent",
+        "extended": "fork adds behavior on top of upstream",
+        "rewritten": "fork replaced upstream entirely",
+        "added": "file unique to the fork (no upstream)"
+    },
+    "files": [
+        { "fork": "block.json", "upstream": "block.json", "status": "adapted", "notes": "name + textdomain swapped to the artisanpack namespace; attribute schema, styles (default/outline), and supports carried verbatim." },
+        { "fork": "edit.tsx", "upstream": "edit.js", "status": "rewritten", "notes": "Upstream calls getTaxonomies({per_page:-1}) via @wordpress/core-data; the shim does not implement that selector and tags are resolved server-side, so the fork previews through the package's <ServerSideRender> seam and ports the inspector controls (number of tags, show counts, smallest/largest size) to PanelBody. Mirrors the V1 taxonomy-archive override's TagCloudEdit." },
+        { "fork": "save.tsx", "upstream": "n/a", "status": "added", "notes": "Dynamic block — returns null; markup produced by TagCloudBlock::render()." },
+        { "fork": "transforms.ts", "upstream": "transforms.js", "status": "adapted", "notes": "Carries the upstream categories↔tag-cloud convenience transform (renamespaced to artisanpack/categories) and adds the bidirectional core/tag-cloud ↔ artisanpack/tag-cloud rollout transforms." },
+        { "fork": "inserter-icon.tsx", "upstream": "n/a", "status": "added", "notes": "Inline SVG mirroring @wordpress/icons' tag icon." },
+        { "fork": "index.ts", "upstream": "index.js", "status": "rewritten", "notes": "Adapted to the visual-editor auto-discovery contract; upstream PHP-side init wiring not carried." },
+        { "fork": "../../../../src/Blocks/Core/TagCloudBlock.php", "upstream": "index.php", "status": "rewritten", "notes": "Server renderer reimplemented against cms-framework's PostTag model (a DynamicBlock) rather than WP_Query. name() renamed core/tag-cloud → artisanpack/tag-cloud at the I6 fork (mirroring LatestPostsBlock at I4)." }
+    ],
+    "vendoredPrimitives": [],
+    "knownDivergences": [
+        "edit.tsx previews via <ServerSideRender> instead of upstream's client-side core-data query — the core-data shim does not implement getTaxonomies and tags are resolved server-side.",
+        "Inspector ported to PanelBody instead of upstream's ToolsPanel (drops the block-library-internal useToolsPanelDropdownMenuProps hook); smallest/largest size use fixed SelectControl option lists rather than the upstream UnitControl.",
+        "tag-cloud is a dynamic block, so (like core/categories, core/archives, artisanpack/latest-posts, artisanpack/form) it is handled by the Blade DynamicBlockRegistry and is not listed in packages/renderer-parity.json — the React/Vue static renderers do not register it.",
+        "transforms.ts adds bidirectional core/tag-cloud ↔ artisanpack/tag-cloud block transforms that don't exist upstream — required to coexist with core/tag-cloud during the V1 rollout."
+    ],
+    "triage": {
+        "label": "in-sync",
+        "lastReviewed": "2026-05-29",
+        "reviewer": "I6 loop / feed cluster"
+    }
+}

--- a/resources/js/visual-editor/editor/forked-block-cutover.ts
+++ b/resources/js/visual-editor/editor/forked-block-cutover.ts
@@ -70,6 +70,16 @@ export const FORKED_CORE_BLOCKS: readonly string[] = [
     'core/site-tagline',
     'core/site-logo',
     'core/navigation',
+    // Loop / feed cluster (I6) — dynamic feed + query blocks.
+    // `core/post-template` is forked alongside `core/query` (it is a
+    // parent-locked child of the query block); `core/query-loop` is the
+    // deprecated alias for `core/query` and carries no inserter entry of
+    // its own, so it is intentionally absent.
+    'core/archives',
+    'core/categories',
+    'core/tag-cloud',
+    'core/query',
+    'core/post-template',
 ];
 
 const FORKED_BLOCK_CUTOVER_FILTER =

--- a/src/Blocks/Core/ArchivesBlock.php
+++ b/src/Blocks/Core/ArchivesBlock.php
@@ -35,7 +35,7 @@ class ArchivesBlock extends DynamicBlock
 {
 	public function name(): string
 	{
-		return 'core/archives';
+		return 'artisanpack/archives';
 	}
 
 	public function validateAttrs( array $attrs ): array

--- a/src/Blocks/Core/CategoriesBlock.php
+++ b/src/Blocks/Core/CategoriesBlock.php
@@ -30,7 +30,7 @@ class CategoriesBlock extends DynamicBlock
 {
 	public function name(): string
 	{
-		return 'core/categories';
+		return 'artisanpack/categories';
 	}
 
 	public function validateAttrs( array $attrs ): array

--- a/src/Blocks/Core/TagCloudBlock.php
+++ b/src/Blocks/Core/TagCloudBlock.php
@@ -31,7 +31,7 @@ class TagCloudBlock extends DynamicBlock
 {
 	public function name(): string
 	{
-		return 'core/tag-cloud';
+		return 'artisanpack/tag-cloud';
 	}
 
 	public function validateAttrs( array $attrs ): array

--- a/src/Resources/QueryInliner.php
+++ b/src/Resources/QueryInliner.php
@@ -85,7 +85,10 @@ class QueryInliner
 	{
 		$name = isset( $block['name'] ) && is_string( $block['name'] ) ? $block['name'] : '';
 
-		if ( 'core/query' === $name ) {
+		// `artisanpack/query` is the I6 fork of `core/query`; both share the
+		// nested `query` attribute shape and inner-template structure, so the
+		// same expansion applies to either namespace.
+		if ( 'core/query' === $name || 'artisanpack/query' === $name ) {
 			return $this->expandQuery( $block );
 		}
 
@@ -130,10 +133,10 @@ class QueryInliner
 			return $this->markFailed( $block, self::ERROR_RESOLVER_ERROR );
 		}
 
-		$results  = $paginator->items();
-		$template = isset( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ? $block['innerBlocks'] : [];
+		$results    = $paginator->items();
+		$queryInner = isset( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ? $block['innerBlocks'] : [];
 
-		if ( [] === $results || [] === $template ) {
+		if ( [] === $results || [] === $queryInner ) {
 			return array_merge( $block, [
 				'innerBlocks' => [],
 				'attributes'  => array_merge( $attributes, [
@@ -143,6 +146,106 @@ class QueryInliner
 			] );
 		}
 
+		// Find the post-template child block. Its inner blocks are the
+		// per-iteration template that gets cloned once per result.
+		// Everything else (pagination, no-results) stays alongside it.
+		$postTemplateIndex = null;
+		$iterationTemplate = [];
+
+		foreach ( $queryInner as $i => $child ) {
+			if ( ! is_array( $child ) ) {
+				continue;
+			}
+
+			$childName = isset( $child['name'] ) && is_string( $child['name'] ) ? $child['name'] : '';
+
+			if ( 'core/post-template' === $childName || 'artisanpack/post-template' === $childName ) {
+				$postTemplateIndex = $i;
+				$iterationTemplate = isset( $child['innerBlocks'] ) && is_array( $child['innerBlocks'] )
+					? $child['innerBlocks']
+					: [];
+				break;
+			}
+		}
+
+		// No post-template found — fall back to cloning whatever is
+		// there so hosts that drop a custom template without the
+		// post-template wrapper are not regressed.
+		if ( null === $postTemplateIndex ) {
+			return $this->expandFlat( $block, $attributes, $queryInner, $results, $paginator );
+		}
+
+		// Expand: clone the iteration template once per result, stamp
+		// _resolved* attributes, and wrap each iteration in an <li>
+		// block with post-specific classes.
+		$expandedIterations = [];
+
+		foreach ( $results as $post ) {
+			if ( ! is_object( $post ) ) {
+				continue;
+			}
+
+			$postId = isset( $post->id ) ? (int) $post->id : 0;
+			$iterationBlocks = [];
+
+			foreach ( $iterationTemplate as $tmplChild ) {
+				if ( ! is_array( $tmplChild ) ) {
+					continue;
+				}
+
+				$iterationBlocks[] = $this->postResolver->stampBlock(
+					$this->cloneBlock( $tmplChild ),
+					$post
+				);
+			}
+
+			$expandedIterations[] = [
+				'clientId'    => 'qi-' . $postId,
+				'name'        => '_query-iteration',
+				'attributes'  => [
+					'postId'    => $postId,
+					'className' => 'post-' . $postId
+					. ' post'
+					. ' type-' . ( isset( $post->post_type ) ? (string) $post->post_type : ( isset( $post->type ) ? (string) $post->type : 'post' ) )
+					. ' status-' . ( isset( $post->status ) && is_object( $post->status ) && isset( $post->status->value ) ? (string) $post->status->value : ( isset( $post->status ) && is_string( $post->status ) ? $post->status : 'publish' ) ),
+				],
+				'innerBlocks' => $iterationBlocks,
+			];
+		}
+
+		// Replace post-template's inner blocks with the expanded
+		// iterations; preserve its own attributes (layout, columns).
+		$expandedTemplate = array_merge( $queryInner[ $postTemplateIndex ], [
+			'innerBlocks' => $expandedIterations,
+		] );
+
+		$newQueryInner = $queryInner;
+		$newQueryInner[ $postTemplateIndex ] = $expandedTemplate;
+
+		return array_merge( $block, [
+			'innerBlocks' => $newQueryInner,
+			'attributes'  => array_merge( $attributes, [
+				'_resolvedTotal' => $paginator->total(),
+				'_resolvedItems' => count( $results ),
+			] ),
+		] );
+	}
+
+	/**
+	 * @param  array<string, mixed>  $block
+	 *
+	 * @return array<string, mixed>
+	 */
+	/**
+	 * Legacy flat expansion for query blocks without a post-template child.
+	 *
+	 * @param  array<string, mixed>               $block
+	 * @param  array<string, mixed>               $attributes
+	 * @param  array<int, array<string, mixed>>   $template
+	 * @param  array<int, object>                 $results
+	 */
+	protected function expandFlat( array $block, array $attributes, array $template, array $results, \Illuminate\Contracts\Pagination\LengthAwarePaginator $paginator ): array
+	{
 		$expanded = [];
 
 		foreach ( $results as $post ) {
@@ -171,11 +274,6 @@ class QueryInliner
 		] );
 	}
 
-	/**
-	 * @param  array<string, mixed>  $block
-	 *
-	 * @return array<string, mixed>
-	 */
 	protected function markFailed( array $block, string $reason ): array
 	{
 		$attributes = isset( $block['attributes'] ) && is_array( $block['attributes'] ) ? $block['attributes'] : [];

--- a/tests/Unit/VisualEditor/Resources/QueryInlinerTest.php
+++ b/tests/Unit/VisualEditor/Resources/QueryInlinerTest.php
@@ -55,11 +55,17 @@ it( 'expands core/query into one post-template instance per result', function ()
 
 	$query = $inlined[0];
 
+	// The query keeps one post-template child; its innerBlocks hold
+	// one _query-iteration per result, each wrapping the stamped template.
+	$postTemplate = $query['innerBlocks'][0];
+
 	expect( $query['name'] )->toBe( 'core/query' )
-		->and( count( $query['innerBlocks'] ) )->toBe( 2 )
-		->and( $query['innerBlocks'][0]['name'] )->toBe( 'core/post-template' )
-		->and( $query['innerBlocks'][0]['innerBlocks'][0]['attributes']['_resolvedTitle'] )->toBe( 'First' )
-		->and( $query['innerBlocks'][1]['innerBlocks'][0]['attributes']['_resolvedTitle'] )->toBe( 'Second' );
+		->and( count( $query['innerBlocks'] ) )->toBe( 1 )
+		->and( $postTemplate['name'] )->toBe( 'core/post-template' )
+		->and( count( $postTemplate['innerBlocks'] ) )->toBe( 2 )
+		->and( $postTemplate['innerBlocks'][0]['name'] )->toBe( '_query-iteration' )
+		->and( $postTemplate['innerBlocks'][0]['innerBlocks'][0]['attributes']['_resolvedTitle'] )->toBe( 'First' )
+		->and( $postTemplate['innerBlocks'][1]['innerBlocks'][0]['attributes']['_resolvedTitle'] )->toBe( 'Second' );
 } );
 
 it( 'forwards the nested query attribute payload to the resolver', function () {
@@ -162,8 +168,10 @@ it( 'deep-clones the template subtree per result so mutations do not leak', func
 
 	$inlined = $this->inliner->inline( $tree );
 
-	$first  = $inlined[0]['innerBlocks'][0]['innerBlocks'][0];
-	$second = $inlined[0]['innerBlocks'][1]['innerBlocks'][0];
+	// Post-template → _query-iteration[0] → post-title, iteration[1] → post-title.
+	$postTemplate = $inlined[0]['innerBlocks'][0];
+	$first  = $postTemplate['innerBlocks'][0]['innerBlocks'][0];
+	$second = $postTemplate['innerBlocks'][1]['innerBlocks'][0];
 
 	expect( $first['attributes']['_resolvedTitle'] )->toBe( 'A' )
 		->and( $second['attributes']['_resolvedTitle'] )->toBe( 'B' );


### PR DESCRIPTION
## Description

Fork the 5-block loop/feed cluster into the `artisanpack/*` namespace, plus `post-template` as query infrastructure (6 blocks total). This is Phase I6 of the block fork plan (`docs/plans/13-block-fork.md` §4.6).

**Closes:** #414

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #414
**Umbrella:** #331

## Motivation and Context

The I6 loop/feed cluster (`archives`, `categories`, `tag-cloud`, `query`, `query-loop`) was the last cluster gated on cms-framework prerequisites (G4b term endpoints + G4c QueryRuntime). Both prerequisites are now closed (#401, #402, cms-framework #97), so the fork is unblocked. Forking before 1.0.0 GA means no host app ever persists `core/*` trees for these blocks — no migration required.

## Changes Made

**JS blocks (6 new block directories):**
- `archives/`, `categories/`, `tag-cloud/` — dynamic feed blocks with `<ServerSideRender>` edit, inspector controls (post counts, hierarchy, dropdown, tag counts, font sizes, group-by), `save() → null`, bidirectional transforms
- `query/` — full inspector: post type, posts per page, offset, order/orderBy, inherit toggle, search filter; `useQueryPreview` canvas preview; `save` ported from upstream (tagName wrapper + InnerBlocks)
- `post-template/` — list/grid toolbar toggle, columns control, `ancestor: [artisanpack/query]`; `save` returns `<InnerBlocks.Content />`
- `core/query-loop` folded via one-way transform (deprecated upstream alias)

**PHP:**
- `CategoriesBlock`, `TagCloudBlock`, `ArchivesBlock` `name()` renamed `core/* → artisanpack/*`
- `QueryInliner` refactored: finds the post-template child, clones its inner blocks per result into `_query-iteration` `<li>` wrappers (fixes grid layout + adds post-specific `id`/classes)
- `BlockRenderer` handles `_query-iteration` → `<li id="post-{id}" class="wp-block-post post-{id} ...">` 

**Renderers (all 3 — Blade/React/Vue):**
- Blade partials for `core/query`, `core/post-template` (+ artisanpack aliases)
- React/Vue `QueryIterationBlock` for `<li>` wrappers
- `columns-{n}` class added to `PostTemplateBlock` renderers
- CSS grid rules (`.wp-block-post-template.is-layout-grid`) in `block-library/style.css`
- Renderer parity: 88/88

**Infrastructure:**
- `forked-block-cutover.ts` — 5 new `core/*` names hidden from inserter
- `renderer-parity.json` updated

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS
- PHP Version: 8.4
- Node: 22.x

**Tests Performed:**
1. Vitest: 204 files, 1468 tests passing
2. Pest: 674 tests passing (1 pre-existing BlocksControllerTest failure on release/1.0)
3. Renderer parity verifier: 88/88 OK
4. Manual testing in jmwd-keystone-cms: all 6 blocks inserted via editor, front-end grid layout verified, QueryInliner expansion produces correct `<ul><li>` structure

## Accessibility Tests Run

- [x] Keyboard navigation tested
- [x] Screen reader tested
- [x] ARIA labels checked

**Details:** Feed blocks inherit upstream ARIA patterns. Query loop iterations render as semantic `<li>` elements inside `<ul>`.

## Tests Added

- [x] Unit tests added/updated
- [x] All tests passing

**Test details:**
- `i6-loop-feed-cluster.test.ts` — 15 tests covering block.json namespace/textdomain/category, dynamic save (null), bidirectional transforms for all feed blocks + query + post-template, query-loop alias fold
- `QueryInlinerTest.php` — updated 2 tests for new post-template-aware expansion shape (single wrapper with `_query-iteration` children)

## Documentation

- [x] Inline code documentation added

**Documentation details:** `upstream-state.json` for each forked block documents the fork status, divergences, and upstream version pin (9.43.0).

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Accessibility tests completed
- [x] Code follows project style guide
- [x] Self-review completed
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added forked visual-editor blocks: Query Loop, Post Template, Archives, Categories, and Tag Cloud with editor UIs, inserter icons, server-side rendering, and bidirectional transforms for migration.
  * Post-template grid layout with responsive 2–6 column support and CSS grid styling.
  * Query preview improvements with per-post iteration wrappers and robust preview/error handling.
  * Inserter suppression of upstream core block variants when forks exist.

* **Tests**
  * Added unit and editor tests covering loop/feed cluster behavior and transforms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArtisanPack-UI/visual-editor/pull/484?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->