### PR TITLE
feat(blocks): semantic <ul>/<li> markup for core/query inliner

### DIFF
--- a/docs/block-library-audit.md
+++ b/docs/block-library-audit.md
@@ -275,19 +275,6 @@ cms-framework `QueryRuntime` contract from G4c-1. `core/query-loop`
 no-results / read-more wrappers stay in the deny-list; they need
 follow-up renderer wiring that's out of scope for #402.
 
-#### Known V1 limitation: per-iteration list-item wrapping
-
-The current expansion produces one `core/post-template` clone per result
-(each rendering as `<ul class="wp-block-post-template">`). Browsers
-render this as N single-item lists rather than one N-item list — the
-visual output is correct, but the markup is semantically a list of
-single-item lists rather than upstream's `<ul><li>...</li></ul>` shape.
-A follow-up issue should refactor the inliner to emit a single
-post-template wrapping N synthetic `core/post-template-item` blocks
-(each rendering as `<li>`); deferring to a follow-up keeps #402
-scope-bounded since the architectural change touches every renderer
-plus a new block-type registration.
-
 ## Crash or backend-required — disabled by default
 
 These blocks call selectors the shim returns `null` for but which the block's

--- a/docs/plans/17-responsive-design-tools.md
+++ b/docs/plans/17-responsive-design-tools.md
@@ -1,0 +1,139 @@
+# Visual Editor — Responsive Design Tools
+
+**Package:** `artisanpack-ui/visual-editor`
+**Version Target:** 1.0.0
+**Created:** 2026-05-30
+**Status:** Planning
+**Related:**
+ - [`06-global-styles.md`](06-global-styles.md) — token system the breakpoint config piggybacks on
+ - [`11-v1-expansion.md`](11-v1-expansion.md) — V1 scope this widens
+ - [`18-state-design-tools.md`](18-state-design-tools.md) — sister feature, shares the value-resolver layer
+
+---
+
+## 1. Problem Statement
+
+Block style and structural settings (e.g. `columns.count`, padding, font size, alignment) currently resolve to a single value that applies across every viewport. Editors who want a 3-column layout on desktop and a stacked layout on mobile have to author two trees, hack the markup, or skip the block entirely. The editor has Tailwind in the stack but no first-class way to author per-breakpoint overrides through the UI.
+
+## 2. Target User
+
+Content editors and developers building responsive layouts who want desktop/tablet/mobile-specific styles **without** dropping into custom CSS, and developers who want to define which breakpoints exist for their app/theme.
+
+## 3. User Stories
+
+- As an editor, I want to set the number of columns differently on mobile, tablet, and desktop so the layout reads well on every device.
+- As an editor, I want padding/margin/font-size/alignment/visibility on any block to vary per breakpoint, with the desktop value cascading down unless I override it at a smaller size.
+- As an editor, I want a viewport switcher in the editor toolbar that shows the canvas at the active breakpoint **and** scopes which breakpoint my style edits apply to.
+- As a developer, I want to add, rename, or remove breakpoints through `config/artisanpack/visual-editor.php` or a theme's `theme.json` so my app can match its own design system, not Tailwind defaults.
+- As a developer, I want the breakpoints I configure to be the same ones Tailwind compiles against, so editor previews and production rendering match.
+
+## 4. Scope
+
+### 4.1 In scope (v1.0)
+
+- **Breakpoint registry** resolved in this priority order (highest wins):
+  1. Active theme's `theme.json` → `settings.custom.artisanpack.breakpoints`
+  2. Application's `config('artisanpack.visual-editor.breakpoints')`
+  3. Package defaults (Tailwind v4 defaults: `sm: 640px`, `md: 768px`, `lg: 1024px`, `xl: 1280px`, `2xl: 1536px`)
+- Breakpoints can be **added** (e.g. `3xl`), **removed**, or **resized** at any layer. The resolver merges by key.
+- **Mobile-first cascade semantics** — a base (unprefixed) value applies everywhere; each named breakpoint override applies at that min-width and up, mirroring Tailwind's `sm:` / `md:` modifiers exactly. The resolver returns the value of the largest matching breakpoint or the base if no breakpoint matches.
+- **Per-breakpoint attribute storage** on every supported attribute, stored as a discriminated object:
+  ```json
+  {
+    "base": 4,
+    "sm": null,
+    "md": 6,
+    "lg": 8,
+    "xl": null
+  }
+  ```
+  `null` means "inherit from the next smaller defined value." Plain scalars remain valid for unmodified blocks and migrate lazily.
+- **Viewport switcher** in the editor toolbar (mobile / tablet / desktop / wide / full, plus any custom breakpoints) that:
+  - resizes the canvas iframe to the breakpoint's min-width,
+  - sets an editor-state `activeBreakpoint` that the InspectorControls read and write into,
+  - shows a "Reset to base" affordance per attribute.
+- **Block support opt-in** declared per block in `block.json` via a new `supports.artisanpackResponsive` key listing which attribute paths are breakpoint-aware. Out of the gate, all `artisanpack/*` forks opt in their layout-affecting attributes: `spacing`, `typography.fontSize`, `align`, `dimensions`, `columns.count` (on `artisanpack/columns`).
+- **CSS emission** — server-side renderer (Blade) outputs Tailwind-class strings using the registered prefixes (`md:px-6`, etc.) when the value maps to a token, and inline CSS via `@media (min-width: …)` queries when it's a custom value. React/Vue renderers do the same client-side.
+- **JS resolver helper** (`useResponsiveValue(attribute, breakpoints)`) for blocks whose edit UI needs the resolved value at the active editor breakpoint.
+- **Schema validation** — bad breakpoint configs (invalid CSS lengths, non-unique values, missing required keys when present) fail loudly with a descriptive error in `php artisan vendor:publish --tag=visual-editor-config` and on theme load.
+
+### 4.2 Out of scope
+
+- **Container queries.** Considered for v1.x once browser support and tooling settle and the value-resolver layer here has a real production track record.
+- **Per-breakpoint block visibility.** Handled by the contextual visibility feature ([`21-block-visibility-contextual.md`](21-block-visibility-contextual.md)) which has its own UI surface.
+- **Per-breakpoint state styles** (e.g. hover-on-mobile-only). Future composition of this feature with [`18-state-design-tools.md`](18-state-design-tools.md); explicitly deferred to v1.x.
+- **Desktop-first or independent (non-cascading) modes.** Mobile-first only for v1.0.
+- **Auto-conversion of existing scalar attributes** beyond lazy promotion on first override. No bulk migration tool.
+
+## 5. Behavior
+
+### 5.1 Happy path
+
+1. Editor selects a Columns block.
+2. They toggle the viewport switcher to **mobile**. The canvas resizes to `sm` (640px).
+3. In the InspectorControls, they set `count = 1`. The attribute storage becomes `{ base: 3, sm: 1 }`.
+4. They switch to **tablet** (`md`). The resolver shows `1` (cascaded from `sm`).
+5. They set `count = 2`. Storage becomes `{ base: 3, sm: 1, md: 2 }`.
+6. They preview the page. Server-side rendering emits a `grid-cols-3 sm:grid-cols-1 md:grid-cols-2` class string. Live page reflects all three layouts as the viewport resizes.
+
+### 5.2 Edge cases
+
+- **Theme adds a custom breakpoint after content is authored.** Existing attribute objects don't have the new key. The resolver treats missing keys as `null` (inherit), so nothing breaks.
+- **Theme removes a breakpoint the content uses.** Stored values for the removed key are preserved on save but ignored at render time; a `php artisan visual-editor:audit-breakpoints` command surfaces orphaned overrides.
+- **Custom value can't be expressed as a Tailwind class.** Renderer falls back to inline `@media` rules in a per-block `<style>` tag scoped by a generated class.
+- **Editor user is offline or the viewport switcher hasn't been touched.** `activeBreakpoint` defaults to `base`; edits go to the base value as today.
+- **Block doesn't declare `supports.artisanpackResponsive` for an attribute.** Inspector shows the single-value control with a tooltip explaining how to enable per-breakpoint values (links to docs).
+
+## 6. Acceptance Criteria
+
+- [ ] Breakpoint registry resolves in the documented `theme.json → config → defaults` order with merge-by-key semantics.
+- [ ] Adding a new breakpoint (`3xl`) via `theme.json` makes it appear in the viewport switcher and as a control row in supported attributes' InspectorControls.
+- [ ] Removing a breakpoint via config drops it from the UI; orphaned stored values are preserved on save and surfaced by `visual-editor:audit-breakpoints`.
+- [ ] Setting `columns.count = 1` at `sm` and `count = 2` at `md` renders the correct Tailwind class string on the server.
+- [ ] The base value cascades up through breakpoints that are `null`; a value set at `md` is visible at `lg` and `xl` unless overridden.
+- [ ] Viewport switcher resizes the canvas and scopes new edits to the active breakpoint.
+- [ ] Lazy migration: a block with a scalar `fontSize` attribute opens in the editor without errors and promotes to the discriminated-object form only when an override is set.
+- [ ] All forked layout-affecting blocks (`group`, `columns`, `column`, `buttons`, `spacer`, `cover`, `media-text`) opt into responsive support for at least `spacing`, `align`, and where applicable `columns.count` / `flex-direction`.
+- [ ] Theme/config schema validation fails loudly on invalid lengths, duplicate values, and unknown keys with line numbers in the error message.
+- [ ] Feature is documented in `docs/responsive-design-tools.md` with examples for editors and developers.
+- [ ] Pest tests cover: resolver cascade, breakpoint registry merging, schema validation, block.json opt-in detection, server renderer Tailwind-class emission, server renderer custom-value `@media` emission.
+- [ ] Playwright E2E covers: viewport switching, per-breakpoint editing on a Columns block, value persistence across save+reload.
+
+## 7. Implementation Notes
+
+### 7.1 Files to create
+
+- `src/Responsive/BreakpointRegistry.php` — resolves the merged registry from theme/config/defaults; exposes `all()`, `get(string $key)`, `prefixes()`, `validate(array $raw)`.
+- `src/Responsive/ResponsiveValueResolver.php` — given an attribute object + active breakpoint, returns the resolved scalar.
+- `src/Responsive/AttributeMigrator.php` — promotes a scalar attribute to the discriminated-object form on first override.
+- `src/Console/AuditBreakpointsCommand.php` — `visual-editor:audit-breakpoints` artisan command.
+- `resources/js/visual-editor/responsive/useResponsiveValue.ts` — JS resolver hook for block edit components.
+- `resources/js/visual-editor/responsive/ViewportSwitcher.tsx` — toolbar component.
+- `resources/js/visual-editor/responsive/ResponsiveControl.tsx` — wrapper used by InspectorControls to render per-breakpoint UIs.
+- `packages/visual-editor-renderer-blade/src/ResponsiveClassResolver.php` — Blade-side class string emission.
+- `packages/visual-editor-renderer-react/src/responsive/` — same role as Blade for React renderer.
+- `packages/visual-editor-renderer-vue/src/responsive/` — same role as Blade for Vue renderer.
+- `tests/Unit/Responsive/*` — resolver, registry, migrator, schema validator.
+- `tests/Feature/Responsive/RendererTest.php` — end-to-end render assertions.
+
+### 7.2 Files to modify
+
+- `config/visual-editor.php` — add the `breakpoints` key with documented defaults.
+- `src/VisualEditorServiceProvider.php` — register `BreakpointRegistry` singleton, bind resolver, register console command.
+- All `artisanpack/*` block `block.json` files that should opt in — add `supports.artisanpackResponsive`.
+- `resources/js/visual-editor/blocks/columns/edit.tsx` — wire `count` through `ResponsiveControl`.
+- `resources/js/visual-editor/blocks/_shared/inspector-controls/*` — extend spacing/typography/align controls to render `ResponsiveControl` when the attribute opts in.
+- `docs/theming.md` and `docs/dev-setup.md` — document the breakpoint registry hierarchy.
+
+### 7.3 Database / schema
+
+No DB migrations. Breakpoint registry is a runtime concern; attribute storage stays in the existing block-tree JSON column.
+
+### 7.4 Dependencies
+
+None new. Tailwind v4 is already in the stack; the resolver emits class strings the existing build picks up.
+
+## 8. Open Questions
+
+- Do we want to bake in a `print` pseudo-breakpoint at v1.0, or defer to a follow-up? (Tentative: defer.)
+- Should `useResponsiveValue` also be exposed to host apps via `@artisanpack-ui/visual-editor/react`? (Tentative: yes, behind an explicit export.)

--- a/docs/plans/18-state-design-tools.md
+++ b/docs/plans/18-state-design-tools.md
@@ -1,0 +1,131 @@
+# Visual Editor — State Design Tools
+
+**Package:** `artisanpack-ui/visual-editor`
+**Version Target:** 1.0.0
+**Created:** 2026-05-30
+**Status:** Planning
+**Related:**
+ - [`06-global-styles.md`](06-global-styles.md) — token system the state styles emit against
+ - [`17-responsive-design-tools.md`](17-responsive-design-tools.md) — sister feature, shares the value-resolver layer
+ - [`11-v1-expansion.md`](11-v1-expansion.md) — V1 scope this widens
+
+---
+
+## 1. Problem Statement
+
+Block style attributes resolve to a single value rendered in the default (idle) state. There's no first-class way for an editor to say "this button's background is `accent` normally but `accent-700` on hover" without writing custom CSS. Buttons, links, and any block with an interactive feel ship visually flat as a result.
+
+## 2. Target User
+
+Content editors who want pressable, interactive feedback on hover/focus/active states without leaving the editor, and developers who want a structured place to author state styles that survives theme switches and exports.
+
+## 3. User Stories
+
+- As an editor, I want to set a different background color, text color, border, shadow, and transform for a block when the user hovers it.
+- As an editor, I want the same control for `focus` (and `focus-visible`) so links and buttons get correct keyboard-accessibility treatment.
+- As an editor, I want a state switcher in the InspectorControls that scopes my next edit to the selected state (idle / hover / focus / focus-visible / active / disabled).
+- As an editor, I want a "preview state" affordance that simulates the hover/focus look on the canvas without me having to actually hover with the mouse.
+- As a developer, I want the state styles emitted as standard `:hover` / `:focus-visible` etc. selectors so they work in the published page without JS runtime.
+- As a developer, I want to add custom states (e.g. `aria-current`) through config so design-system custom states are first-class.
+
+## 4. Scope
+
+### 4.1 In scope (v1.0)
+
+- **State registry** with built-in states: `idle` (the base), `hover`, `focus`, `focus-visible`, `active`, `disabled`. Each state has:
+  - a stable key (`hover`)
+  - a CSS pseudo-selector or selector list (`&:hover`)
+  - a display label and an icon
+  - a `inheritsFrom` chain for resolution (e.g. `active` inherits from `hover` inherits from `idle`)
+- **State registry overrides** via `config/artisanpack/visual-editor.php` (`states`) and `theme.json` → `settings.custom.artisanpack.states`. Same priority chain as breakpoints: `theme.json → config → defaults`. Custom states (e.g. `aria-current`, `[data-active="true"]`) are additive.
+- **Per-state attribute storage** on every supported attribute, mirroring the responsive shape:
+  ```json
+  {
+    "idle":  "var(--ap-color-accent)",
+    "hover": "var(--ap-color-accent-700)",
+    "focus-visible": null
+  }
+  ```
+  `null` falls back through the `inheritsFrom` chain.
+- **State switcher** in the InspectorControls header (icon strip), defaulting to `idle`. The active state scopes which slot in the attribute storage the controls read/write.
+- **Canvas "preview state"** affordance — a toolbar toggle that adds a temporary attribute (`data-ap-preview-state="hover"`) to the selected block and a corresponding CSS rule so editors see the hover look without simulating pointer events. The toggle is editor-only and never reaches saved content.
+- **Supported attributes**: `color.background`, `color.text`, `color.gradient`, `border.color`, `border.width`, `border.style`, `border.radius`, `shadow`, `typography.textDecoration`, `dimensions.transform` (scale/translate), `transition` (single composite control). Spacing is **not** state-scoped in v1.0.
+- **Block support opt-in** via `supports.artisanpackStates` in `block.json`. All forked interactive blocks (`button`, `buttons`, `navigation`, `image` (when linked), `cover`, `query-pagination`, `media-text`, `details`, plus the `core/link` element style) opt in by default.
+- **CSS emission** — server-side renderer wraps state styles in a unique class scope: `.ap-block-<uid>:hover { ... }` etc. Where the value maps to a Tailwind token, the renderer prefers a generated class string (`hover:bg-accent-700`); otherwise it emits scoped inline styles.
+- **`transition` control** — a single field that emits `transition-property`, `transition-duration`, and `transition-timing-function` together. Default `all 150ms ease`.
+
+### 4.2 Out of scope
+
+- **Per-breakpoint state styles** (e.g. hover-only-on-desktop). Future composition with [`17-responsive-design-tools.md`](17-responsive-design-tools.md); explicitly deferred to v1.x.
+- **`:has()` / parent-state selectors.** Defer pending broader browser support and a use-case.
+- **Group-level "all children get this hover"** style inheritance. Defer to v1.x.
+- **Animation timing curves** beyond the default + a fixed dropdown of common easings. Custom cubic-béziers can be authored in the next animations feature.
+- **Spacing state styles.** Hover-grows-the-padding is a niche pattern; deferred until requested.
+
+## 5. Behavior
+
+### 5.1 Happy path
+
+1. Editor selects a Button block.
+2. In InspectorControls, they switch the state strip to `hover`.
+3. They change `color.background` to `accent-700` and `dimensions.transform` to `scale(1.02)`. Storage becomes `{ idle: 'accent', hover: 'accent-700' }` for the background and similar for the transform.
+4. They click the preview-state toggle to `hover`; the canvas shows the hovered look.
+5. They save. The server emits a class scope with `.ap-block-{uid}:hover { background-color: var(--ap-color-accent-700); transform: scale(1.02); transition: all 150ms ease; }` (or the Tailwind class equivalent).
+6. The live page reflects the hover behavior with pure CSS — no editor runtime required.
+
+### 5.2 Edge cases
+
+- **State is registered in a custom theme but a block doesn't opt in.** Inspector still shows the state in the strip (greyed) with a tooltip explaining the block doesn't support state styling.
+- **Inheritance chain has a cycle.** Schema validator rejects the config at load time with a descriptive error.
+- **`focus-visible` is the only override.** Resolver falls back through `focus → idle` for browsers without `:focus-visible` support (handled by an `@supports selector(:focus-visible)` rule).
+- **Hover is set on a touch-only device.** The CSS already handles this via the standard `(hover: hover)` media query — emitted automatically when the renderer detects a hover-state override.
+- **A custom state's selector is invalid CSS.** Schema validator rejects with a descriptive error.
+
+## 6. Acceptance Criteria
+
+- [ ] Built-in states (`hover`, `focus`, `focus-visible`, `active`, `disabled`) work out of the box on every opted-in block.
+- [ ] Adding a custom state in `theme.json` makes it appear in the state strip and emit the configured selector.
+- [ ] Inheritance chain works: `active` falls back to `hover` falls back to `idle` when slots are `null`.
+- [ ] State switcher scopes attribute reads/writes; toggling away preserves the previous state's values.
+- [ ] Preview-state toggle visually simulates the state on the canvas and never persists into saved content.
+- [ ] Server-side renderer emits Tailwind classes when the value maps to a token, scoped inline styles otherwise.
+- [ ] `@media (hover: hover)` wrapping is applied to `:hover` styles automatically.
+- [ ] Forked interactive blocks (`button`, `buttons`, `navigation`, `image`, `cover`, `media-text`, `details`, `query-pagination`) opt in by default.
+- [ ] Pest tests cover: state registry resolution, inheritance chain, schema validation, attribute storage migration.
+- [ ] Playwright E2E covers: state switching in InspectorControls, preview-state toggle, save+reload persistence, live page hover behavior.
+- [ ] Docs in `docs/state-design-tools.md` cover registering custom states.
+
+## 7. Implementation Notes
+
+### 7.1 Files to create
+
+- `src/States/StateRegistry.php` — resolves the merged state registry from theme/config/defaults.
+- `src/States/StateValueResolver.php` — given an attribute object + active state, returns the resolved scalar via inheritance chain.
+- `src/States/InheritanceChainValidator.php` — cycle detection.
+- `resources/js/visual-editor/states/StateSwitcher.tsx` — InspectorControls state strip.
+- `resources/js/visual-editor/states/useStateValue.ts` — JS resolver hook.
+- `resources/js/visual-editor/states/PreviewStateToggle.tsx` — toolbar component.
+- `resources/js/visual-editor/states/StateControl.tsx` — InspectorControls wrapper.
+- `packages/visual-editor-renderer-{blade,react,vue}/src/states/` — renderer emission per stack.
+- `tests/Unit/States/*` and `tests/Feature/States/RendererTest.php`.
+
+### 7.2 Files to modify
+
+- `config/visual-editor.php` — add the `states` key with documented defaults.
+- `src/VisualEditorServiceProvider.php` — register `StateRegistry` singleton.
+- All forked interactive `block.json` files — add `supports.artisanpackStates`.
+- `resources/js/visual-editor/blocks/_shared/inspector-controls/*` — extend color/border/shadow/transform controls to use `StateControl`.
+- `docs/theming.md` — document the state registry hierarchy.
+
+### 7.3 Database / schema
+
+No DB migrations.
+
+### 7.4 Dependencies
+
+None new.
+
+## 8. Open Questions
+
+- Do we ship a `visited` state for `core/link`-style elements out of the box? (Tentative: yes, but `idle`-only by default unless explicitly opted in by the block.)
+- Should the preview-state toggle support multi-state preview (e.g. `hover + focus-visible` simultaneously)? (Tentative: defer.)

--- a/docs/plans/19-block-animations.md
+++ b/docs/plans/19-block-animations.md
@@ -1,0 +1,124 @@
+# Visual Editor — Block Animations
+
+**Package:** `artisanpack-ui/visual-editor`
+**Version Target:** 1.x
+**Created:** 2026-05-30
+**Status:** Planning
+**Related:**
+ - [`18-state-design-tools.md`](18-state-design-tools.md) — hover/focus animations layer on top of the state engine
+ - [`17-responsive-design-tools.md`](17-responsive-design-tools.md) — animations should respect per-breakpoint enable/disable
+
+---
+
+## 1. Problem Statement
+
+The editor renders blocks statically. There's no way for an editor to add an entrance animation (fade-in on scroll), a continuous animation (pulse on a CTA), a hover transition beyond what the state-design tools already emit, or a custom keyframe sequence. WordPress block plugins like Animate.css and Block Animator have established that this is core-table-stakes for marketing pages.
+
+## 2. Target User
+
+Content editors building landing pages, marketing sites, and product showcases who want motion to draw attention or signal interactivity, and developers/designers who want the motion vocabulary scoped to a curated set of safe defaults plus an escape hatch for bespoke keyframes.
+
+## 3. User Stories
+
+- As an editor, I want to add an entrance animation (fade, slide-up, slide-from-side, zoom, etc.) that plays once when the block scrolls into view.
+- As an editor, I want to control the entrance animation's duration, delay, easing, and viewport threshold.
+- As an editor, I want hover/focus transition curves I can tune (duration, easing) per block.
+- As an editor, I want to add a continuous loop animation (pulse, bounce, spin, ping) for accents like CTAs or notification badges.
+- As a developer, I want to author a custom `@keyframes` sequence in the editor UI and reuse it across blocks.
+- As a developer, I want the motion vocabulary to default to `prefers-reduced-motion: reduce` (suppress animations) and to expose a per-block override only if I explicitly opt in.
+- As a developer, I want to extend the animation library through config or theme.json so my design system's named motions show up in the dropdown.
+
+## 4. Scope
+
+### 4.1 In scope (v1.x)
+
+- **Animation registry** with three families:
+  1. **Entrance** — plays once when the block enters the viewport. Built-ins: `fade-in`, `fade-in-up`, `fade-in-down`, `fade-in-left`, `fade-in-right`, `zoom-in`, `zoom-out`, `slide-in-up`, `slide-in-down`, `slide-in-left`, `slide-in-right`, `flip-x`, `flip-y`, `rotate-in`.
+  2. **Hover/Focus** — composable with [`18-state-design-tools.md`](18-state-design-tools.md). This feature adds a `transition` editor (duration / delay / easing / curve preview) plus prebuilt "motion presets" (`lift`, `press`, `glow`).
+  3. **Continuous** — plays in a loop. Built-ins: `pulse`, `bounce`, `spin`, `ping`, `wiggle`, `float`.
+- **Custom keyframe authoring** — a per-theme registry where developers can define named keyframes in `theme.json` → `settings.custom.artisanpack.keyframes` or via a programmatic API (`apRegisterKeyframes('confetti', [...])`). Custom keyframes appear in the dropdowns of the matching family.
+- **Animation Inspector panel** added to every opted-in block. Three sub-panels (entrance / hover / continuous), each with the same per-family controls: motion, duration, delay, easing, repeat (for continuous), threshold (for entrance).
+- **`prefers-reduced-motion` respect** — by default, the runtime suppresses entrance + continuous animations and shortens transitions to `0ms` when the user has reduced-motion on. A per-block override (`Respect reduced motion` boolean, default ON) is exposed.
+- **Per-breakpoint enable/disable** — composable with [`17-responsive-design-tools.md`](17-responsive-design-tools.md). The animation attribute is a responsive-aware shape, so editors can disable entrance animations on mobile, for example.
+- **CSS-first emission, no runtime by default** — entrance animations use `IntersectionObserver` + a single CSS class swap; continuous animations are pure CSS; transitions are pure CSS. The runtime is one shared module (~3 KB gzipped) loaded only on pages that use entrance animations.
+- **Reusable across renderers** — Blade, React, Vue renderers all consume the same emitted class names + the same runtime module. The runtime is published to `dist/animations.js` and registered as a Vite chunk.
+- **Block support opt-in** via `supports.artisanpackAnimations` in `block.json`. By default, all `artisanpack/*` blocks opt in; blocks can opt out (e.g. inline `core/list-item` would be noisy).
+- **Custom keyframe authoring UI** — a "Custom Motion" editor reachable from the global Site Editor → Styles → Animations panel. UI lets the developer name a keyframe and define stops (0% / 50% / 100% at minimum, with `+ Add stop`); each stop edits the same set of transformable properties (transform, opacity, filter, color). Save persists into the `GlobalStyles` JSON; the keyframe immediately appears in the relevant dropdowns.
+
+### 4.2 Out of scope
+
+- **Scroll-linked animations** (parallax, scroll-driven `@keyframes`). Defer to a future release pending broader browser support for `scroll-timeline`.
+- **Spring physics / FLIP / view transitions.** Defer; the CSS-first foundation must land first.
+- **Per-character text animations.** Defer; would require a text-splitting runtime.
+- **SVG morphing / Lottie integration.** Defer; out of scope for a markup-driven editor.
+
+## 5. Behavior
+
+### 5.1 Happy path
+
+1. Editor selects a Hero `cover` block and opens the Animation panel.
+2. Under **Entrance**, they pick `fade-in-up`, set duration `600ms`, delay `100ms`, easing `ease-out`, threshold `0.2`.
+3. They save. The block markup gains `data-ap-anim-entrance="fade-in-up" data-ap-anim-duration="600" data-ap-anim-delay="100" data-ap-anim-easing="ease-out"` and an initial `ap-anim-pre` class that hides it offscreen.
+4. The shared runtime (loaded once on the page) observes the block via `IntersectionObserver`. When it enters the viewport at the threshold, the runtime swaps `ap-anim-pre` for `ap-anim-play`, which has `animation: fade-in-up 600ms ease-out 100ms forwards`.
+5. The user scrolls; the block fades up. The animation runs once.
+6. If the user has `prefers-reduced-motion: reduce`, the runtime skips the class swap; the block appears statically.
+
+### 5.2 Edge cases
+
+- **Block enters viewport before the runtime loads** (slow JS). The block stays in its pre-animation state until the runtime initializes, then plays normally. Acceptable.
+- **No JS available** (e.g. crawler, no-JS user). The renderer emits a `<noscript>` rule that resets `.ap-anim-pre` to the visible/final state — the block is shown statically.
+- **Continuous animation set + reduced motion enabled.** Continuous animation is suppressed (no class added).
+- **Custom keyframe name collides with a built-in.** Schema validator rejects with a descriptive error; built-in names are reserved.
+- **User configures a 30-second duration.** Allowed. Warning shown in the InspectorControls if duration exceeds a soft threshold (5s) suggesting a continuous animation might be a better fit.
+- **Entrance animation set inside a `display:none` collapsed parent** (e.g. closed accordion). Runtime re-checks on parent state change via `MutationObserver`; animation plays on first reveal.
+
+## 6. Acceptance Criteria
+
+- [ ] Entrance animations work for all built-in motions across Blade, React, and Vue renderers.
+- [ ] Continuous animations work and respect `prefers-reduced-motion`.
+- [ ] Hover transition control emits the correct `transition` CSS and composes with state-design tools.
+- [ ] Custom keyframes registered via `theme.json` show in dropdowns with the configured name.
+- [ ] Custom keyframes authored via the Site Editor UI persist into Global Styles and reappear on reload.
+- [ ] `prefers-reduced-motion` is respected by default; per-block opt-out works.
+- [ ] Per-breakpoint disable works (set `entrance: { base: 'fade-in', md: null }` → no animation under `md`).
+- [ ] Runtime is loaded only on pages that have at least one entrance animation; bundle size <5 KB gzipped.
+- [ ] Block opt-out via `supports.artisanpackAnimations: false` removes the Animation panel.
+- [ ] No-JS fallback renders blocks in their final state via a `<noscript>` rule.
+- [ ] Pest tests cover: registry resolution, schema validation, attribute migration, server emission per family.
+- [ ] Vitest tests cover: runtime IntersectionObserver behavior, reduced-motion suppression, class-swap timing.
+- [ ] Playwright E2E covers: entrance animation play on scroll, continuous animation persists, custom keyframe round-trip, reduced-motion preference suppresses entrance.
+- [ ] Docs in `docs/animations.md` cover the registry, the runtime, custom keyframe authoring, and accessibility guarantees.
+
+## 7. Implementation Notes
+
+### 7.1 Files to create
+
+- `src/Animations/AnimationRegistry.php` — resolves built-ins + theme.json + config + custom keyframes from Global Styles.
+- `src/Animations/KeyframeRegistry.php` — built-in + custom keyframe CSS emission.
+- `src/Animations/AnimationCssEmitter.php` — translates attribute storage to CSS class strings + scoped rules.
+- `resources/js/visual-editor/animations/AnimationPanel.tsx` — three-tab inspector panel.
+- `resources/js/visual-editor/animations/CustomKeyframeEditor.tsx` — Site Editor → Styles → Animations sub-page.
+- `resources/js/visual-editor/animations/runtime.ts` — shared IntersectionObserver + reduced-motion runtime, published to `dist/animations.js`.
+- `packages/visual-editor-renderer-{blade,react,vue}/src/animations/` — per-renderer integration.
+- `tests/Unit/Animations/*`, `tests/Feature/Animations/RendererTest.php`, Vitest + Playwright suites.
+
+### 7.2 Files to modify
+
+- `config/visual-editor.php` — add the `animations` key (registry overrides, default reduced-motion behavior).
+- `src/VisualEditorServiceProvider.php` — register `AnimationRegistry` + `KeyframeRegistry` singletons.
+- All forked `block.json` files — add `supports.artisanpackAnimations: true` (default).
+- `vite.config.ts` — emit the runtime as a separate chunk so it's lazy-loadable.
+- `docs/theming.md` — document custom-keyframe registration.
+
+### 7.3 Database / schema
+
+Custom keyframes authored in the Site Editor live in the existing `GlobalStyles` JSON column (`styles.custom.artisanpack.keyframes`). No new migrations.
+
+### 7.4 Dependencies
+
+None new. IntersectionObserver and `prefers-reduced-motion` are baseline browser APIs.
+
+## 8. Open Questions
+
+- Should the runtime auto-pause continuous animations when the tab is hidden (`document.visibilityState`)? (Tentative: yes, default ON, can be turned off via `data-ap-anim-pause-when-hidden="false"`.)
+- Do we ship "exit" animations (animation when block leaves viewport)? (Tentative: defer — limited real use, adds runtime complexity.)

--- a/docs/plans/20-border-gradients.md
+++ b/docs/plans/20-border-gradients.md
@@ -1,0 +1,116 @@
+# Visual Editor — Border Gradients
+
+**Package:** `artisanpack-ui/visual-editor`
+**Version Target:** 1.x
+**Created:** 2026-05-30
+**Status:** Planning
+**Related:**
+ - [`06-global-styles.md`](06-global-styles.md) — gradient token system reused here
+ - [`18-state-design-tools.md`](18-state-design-tools.md) — border gradients should be state-aware
+ - [`17-responsive-design-tools.md`](17-responsive-design-tools.md) — border gradients should be breakpoint-aware
+
+---
+
+## 1. Problem Statement
+
+Block border styles currently expose a single solid color. Modern design systems lean on gradient borders for emphasis (cards with a hover-glow border, CTAs with a brand-gradient outline). Editors can't author these without dropping into custom CSS, and the resulting CSS doesn't compose with our token system or live-preview correctly.
+
+## 2. Target User
+
+Content editors and designers who want gradient-bordered cards, CTAs, sections, and badges to match their design system, and developers who want gradient borders authored against design tokens (so a token change updates every gradient automatically).
+
+## 3. User Stories
+
+- As an editor, I want to set a block's border to a linear gradient with two or more stops.
+- As an editor, I want to set a radial gradient border (centered on the block).
+- As an editor, I want to set a conic gradient border (rotating around the block — popular for "glow ring" effects).
+- As an editor, I want to use the existing gradient picker from the background color UI for borders, so the controls feel consistent.
+- As an editor, I want to set a hover-state gradient that's different from the idle gradient (the gradient animates smoothly between states).
+- As a developer, I want gradient borders to honor the registered gradient tokens (defined in `theme.json` → `settings.color.gradients`) so editors can pick brand gradients by name.
+- As a developer, I want gradient borders that respect the block's `border-radius` (the gradient hugs rounded corners cleanly, no fringe).
+
+## 4. Scope
+
+### 4.1 In scope (v1.x)
+
+- **Gradient types**: `linear`, `radial`, `conic`.
+- **Stops**: minimum 2, no upper limit. Each stop has a color (token reference or hex/oklch literal) and a position (`%` or auto-spaced).
+- **Single border**: gradient applies to all four sides as one continuous frame.
+- **Border width**: existing `__experimentalBorder.width` control unchanged — width can still be set per-side; gradient maps onto the union frame.
+- **Border radius**: existing `__experimentalBorder.radius` control unchanged — the gradient frame clips correctly around rounded corners via the standard `padding-box` mask trick (`background-clip: padding-box, border-box`).
+- **Token integration**: the gradient picker shows the theme's registered gradient tokens (`theme.json` → `settings.color.gradients`) above the custom-stops editor. Picking a token references it (CSS custom property) instead of inlining the value.
+- **State composition**: when [`18-state-design-tools.md`](18-state-design-tools.md) is enabled for `border.gradient`, a separate gradient can be set per state (`idle`, `hover`, `focus`, etc.). The renderer adds a `transition: border-image 200ms ease` (configurable) so the gradient morphs cleanly.
+- **Breakpoint composition**: composes with [`17-responsive-design-tools.md`](17-responsive-design-tools.md). Per-breakpoint gradients are stored in the same attribute shape and resolved by the responsive resolver.
+- **Block support opt-in**: declared via the existing `supports.__experimentalBorder` schema, extended with a `gradient: true` flag. All forked blocks that already support borders opt in by default (`group`, `columns`, `column`, `cover`, `media-text`, `image`, `button`, `buttons`, `details`, `callout`).
+- **CSS emission strategy** (Blade/React/Vue):
+  - Linear gradients → `border-image: linear-gradient(...) 1;` plus a `padding-box` clip fallback when `border-radius > 0`.
+  - Radial/Conic gradients → the `padding-box`/`border-box` mask technique (a single absolutely-positioned `::before` carrying the gradient, masked to the border ring). Documented and tested.
+  - Tailwind class strings preferred when the gradient maps to a registered token; scoped inline styles otherwise.
+
+### 4.2 Out of scope
+
+- **Per-side independent gradients** (different gradient per top/right/bottom/left). Considered for v2.x — significantly more UI surface and a rare requirement.
+- **Animated gradient (gradient rotation/translation over time)**. Tracked separately under [`19-block-animations.md`](19-block-animations.md) as a future continuous-animation preset.
+- **Gradient masks / non-rectangular shapes**. Out of scope; would need shape-tracing.
+- **Multiple stacked border gradients**. Out of scope.
+
+## 5. Behavior
+
+### 5.1 Happy path
+
+1. Editor selects a card block (`group`).
+2. They open the Border panel and click the gradient swatch.
+3. The gradient picker opens; they pick the theme's `brand-sunset` linear gradient token.
+4. They set border width to `2px` and border radius to `12px`.
+5. Save. The renderer emits a `padding-box` clip + `border-image` rule (or the mask `::before` for radial/conic). On the live page, the card has a clean 2px gradient border that follows the 12px radius.
+
+### 5.2 Edge cases
+
+- **Border width is `0`.** Gradient is preserved in attribute storage but no CSS is emitted (nothing to render).
+- **Border radius exceeds half the block's smaller dimension** (e.g. a pill shape). The mask still clips correctly; tested at radii up to `9999px`.
+- **Gradient token referenced by the block is removed from the theme.** Renderer falls back to the resolved value at the time of the previous render; an editor warning surfaces the dangling token reference.
+- **Browser doesn't support `border-image` on rounded corners cleanly** (some older Safari/Chromium versions). Mask `::before` path is used as the default for radial/conic, eliminating the difference.
+- **State transition with very different gradient angle** (e.g. idle 45°, hover 135°). The transition interpolates the resulting bitmaps via the standard `border-image` transition; documented as a known limitation when angles differ significantly.
+
+## 6. Acceptance Criteria
+
+- [ ] Linear, radial, and conic gradients can be authored on any opted-in block.
+- [ ] Gradients reference theme tokens by name; renaming/removing a token surfaces an editor warning.
+- [ ] Border radius clips the gradient correctly across linear/radial/conic.
+- [ ] Per-state gradients work and transition smoothly between states.
+- [ ] Per-breakpoint gradients work and respect mobile-first cascade.
+- [ ] Renderer prefers Tailwind class strings for token-referenced gradients; falls back to scoped inline styles otherwise.
+- [ ] All previously border-supporting forked blocks gain the gradient option without breaking existing solid-border configurations.
+- [ ] Pest tests cover: attribute storage, schema, server emission per gradient type, token reference resolution.
+- [ ] Vitest tests cover: editor InspectorControls roundtrip, gradient picker UX.
+- [ ] Playwright visual-regression tests cover: linear/radial/conic at radius 0, 8, 12, 24, 9999.
+- [ ] Docs in `docs/border-gradients.md` cover the picker, token integration, and the radial/conic mask technique.
+
+## 7. Implementation Notes
+
+### 7.1 Files to create
+
+- `src/Borders/GradientBorderEmitter.php` — CSS emission per gradient type, including the mask `::before` path.
+- `src/Borders/TokenResolver.php` — resolve a token reference into a concrete gradient string.
+- `resources/js/visual-editor/borders/GradientBorderControl.tsx` — InspectorControls UI extending the existing border panel.
+- `packages/visual-editor-renderer-{blade,react,vue}/src/borders/` — per-renderer integration.
+- `tests/Unit/Borders/*`, `tests/Feature/Borders/RendererTest.php`, Vitest + Playwright suites.
+
+### 7.2 Files to modify
+
+- All forked block `block.json` files with `__experimentalBorder` → add `gradient: true` under that support.
+- `resources/js/visual-editor/blocks/_shared/inspector-controls/border.tsx` — wire `GradientBorderControl` next to the color swatch.
+- `docs/theming.md` — note that registered gradient tokens are picked up by both background and border gradient pickers.
+
+### 7.3 Database / schema
+
+No DB migrations.
+
+### 7.4 Dependencies
+
+None new.
+
+## 8. Open Questions
+
+- Should we expose the transition duration for state changes as part of the State Design Tools `transition` control, or in the Border Gradient sub-panel? (Tentative: State Design Tools owns it; Border Gradient reads it.)
+- Do we expose a "preview gradient angle" affordance with a draggable handle? (Tentative: defer to a follow-up polish issue.)

--- a/docs/plans/21-block-visibility-contextual.md
+++ b/docs/plans/21-block-visibility-contextual.md
@@ -1,0 +1,136 @@
+# Visual Editor — Block Visibility (Contextual)
+
+**Package:** `artisanpack-ui/visual-editor`
+**Version Target:** 1.x
+**Created:** 2026-05-30
+**Status:** Planning
+**Reference:** [Block Visibility (WordPress plugin, by Nick Diego)](https://github.com/ndiego/block-visibility)
+**Related:**
+ - [`22-block-visibility-user-and-auth.md`](22-block-visibility-user-and-auth.md) — sibling feature: user role / login state. Sits under the same Visibility panel UI; deferred to its own release for scope reasons.
+ - [`23-block-visibility-scheduling.md`](23-block-visibility-scheduling.md) — sibling feature: date/time scheduling. Same UI, deferred separately.
+ - [`07-permissions-locking.md`](07-permissions-locking.md) — block-level locking, distinct from visibility (locking affects editing; visibility affects rendering).
+
+---
+
+## 1. Problem Statement
+
+Every block on a page is rendered to every visitor. There's no way for an editor to say "show this banner only on screens larger than 768px," "hide this widget when this query string is set," "show this CTA only to referrals from twitter.com," or simply "hide this block without deleting it (yet)." Marketing teams build a lot of pages where some block instances are situational.
+
+The [Block Visibility WordPress plugin](https://github.com/ndiego/block-visibility) is the canonical reference for this feature in the Gutenberg ecosystem. We port the controls that aren't already covered by other systems in our stack (permissions, post scheduling).
+
+## 2. Target User
+
+Marketing/content editors who want context-dependent rendering on a per-block basis without engineering involvement, and developers who want the contextual checks to run server-side (no client flash-of-content) where possible.
+
+## 3. User Stories
+
+- As an editor, I want a master "Hide block" toggle that removes the block from the rendered output without deleting it from the post.
+- As an editor, I want to show or hide a block based on the current viewport width using the same breakpoints my responsive design tools use.
+- As an editor, I want to show or hide a block based on a query string match (e.g. show only when `?utm_source=newsletter`).
+- As an editor, I want to show or hide a block based on the referrer (e.g. show only when the visitor came from `twitter.com`).
+- As an editor, I want to show or hide a block based on the visitor's browser / OS / device type (mobile / tablet / desktop / bot).
+- As an editor, I want a clear visual indicator in the editor canvas when a block has any visibility rule active (an icon badge on the block toolbar).
+- As an editor, I want the editor preview to optionally simulate the rules (e.g. preview what a mobile visitor on a Twitter referral would see).
+- As a developer, I want the contextual rules to be evaluated server-side when the input is available at request time (referrer, query string, user-agent) and client-side only for inputs that aren't (viewport width).
+
+## 4. Scope
+
+### 4.1 In scope (v1.x)
+
+- **Hide Block (master toggle)** — a single boolean attribute (`hidden: true`) that completely omits the block from rendered output. Renderer never emits markup for hidden blocks. Editor canvas dims the block (50% opacity + hatched overlay) and shows an "Eye off" icon in its block toolbar.
+- **Screen Size visibility** — per-breakpoint show/hide using the same registry as [`17-responsive-design-tools.md`](17-responsive-design-tools.md). The control is a checkbox grid: one cell per registered breakpoint, plus a `base` cell. Rule: hidden if the active breakpoint's cell is unchecked, falling back through the mobile-first cascade for unset cells. Implemented as **CSS** (`@media (min-width:...) { display:none }` for each unchecked cell) — no JS runtime needed.
+- **Query String visibility** — list of `key=value` (value optional) or `key=*` (any value) clauses, with show/hide direction (`Show if matches` / `Hide if matches`) and `Match any` / `Match all` combinator. Evaluated server-side from the request's parsed query.
+- **Referrer visibility** — list of referrer host patterns (literal hostnames, optionally prefixed `*.` for subdomains; plus the magic value `(direct)` to match empty Referer). Show/hide direction + Any/All combinator. Evaluated server-side from `Referer` request header.
+- **Browser / OS / Device visibility** — lists of browsers (Chrome / Safari / Firefox / Edge / Opera / Other), OSes (macOS / Windows / Linux / iOS / Android / Other), and device types (Mobile / Tablet / Desktop / Bot). Show/hide direction. Evaluated server-side via a small UA parser (`jenssegers/agent` is the proposed dep — already common in Laravel apps; falls back to a tiny in-repo parser if not present).
+- **Visibility Panel UI** — an Inspector "Visibility" panel grouping all rules. Master toggle at top; expandable subsections per rule family. Each subsection has a small "Active rule" badge when configured.
+- **Per-block toolbar badge** — when any rule is active, an "Eye" badge appears next to the block movers. Clicking it opens the Visibility panel.
+- **Visibility Preview mode** — a Site Editor toggle that lets the editor mock the inputs (viewport, query string, referrer, browser, device) and previews what a visitor in that state would see. Editor-only; never persists to saved content.
+- **Logging hook** — a hook (`ap.visibility.evaluated`) fires after each evaluation in dev/debug mode with the rule + outcome, so debugging "why is this block hidden?" is straightforward.
+- **Site-wide kill switch** — config flag `visual-editor.visibility.enabled` (default true). Tests, ops debugging, and emergency rollbacks can flip it off.
+
+### 4.2 Out of scope
+
+- **User role / login state visibility** — see [`22-block-visibility-user-and-auth.md`](22-block-visibility-user-and-auth.md). Same UI surface, separate scope.
+- **Date/time scheduling** — see [`23-block-visibility-scheduling.md`](23-block-visibility-scheduling.md). Same UI surface, separate scope.
+- **A/B split visibility (random N% of traffic)** — out of scope; experimentation belongs to the planned A/B Testing component (Phase 5, `08-additional-features.md`).
+- **Geolocation / IP-based visibility** — out of scope; would require an IP-geo service dependency.
+- **Cookie / localStorage visibility** — out of scope; would require client-side evaluation and re-render.
+
+## 5. Behavior
+
+### 5.1 Happy path (Screen Size)
+
+1. Editor selects a promotional Banner block. They open the Visibility panel, expand **Screen Size**, and uncheck `base` and `sm` (so the block is hidden on mobile, visible on `md` and up).
+2. Save. The renderer emits the block markup wrapped in a class (`ap-vis-hide-base ap-vis-hide-sm`) that maps to `@media (max-width: 767px) { .ap-vis-... { display: none; } }`.
+3. The published page hides the banner on phones and shows it on tablet/desktop. Pure CSS — no JS runtime, no layout shift.
+
+### 5.2 Happy path (Query String)
+
+1. Editor selects a newsletter CTA, opens Visibility → **Query String**, adds rule `utm_source = newsletter`, direction `Show if matches`.
+2. Save. Renderer evaluates `request()->query('utm_source') === 'newsletter'`. If false, the block is not emitted.
+3. Visitors arriving without the `utm_source` query never see (or download) the block markup.
+
+### 5.3 Edge cases
+
+- **Multiple rule families active simultaneously.** All families combine with AND — every family that's configured must return "visible" for the block to render.
+- **Query string rule with no value** (`utm_source` alone). Matches any non-empty value for the key.
+- **Bot referrer evaluated for SEO crawlers.** Bots typically have no referrer; `(direct)` clause matches.
+- **Visibility evaluates to hidden on the canvas during edit.** The block stays visible in the canvas (with the hatched overlay) so the editor can edit it; visibility only affects the rendered output on the public site and the Visibility Preview mode.
+- **Editor sets unreachable rule** (hidden on every breakpoint). Inspector shows a warning: "Block will never be visible to visitors."
+- **Configured rule references something later removed** (e.g. a deleted breakpoint). Audit command surfaces the orphaned rule; renderer treats unknown breakpoints as `null` (no effect).
+- **Server can't determine an input** (e.g. behind a CDN that strips Referer). Configured `(direct)` clauses match; pattern-based clauses don't match.
+
+## 6. Acceptance Criteria
+
+- [ ] Master Hide Block toggle removes the block from rendered output across Blade, React, and Vue renderers; canvas dims with hatched overlay.
+- [ ] Screen Size rule emits CSS `display:none` per breakpoint without JS; respects the registered breakpoint set including custom breakpoints.
+- [ ] Query String rule evaluates server-side against the request; supports `key=value`, `key=*`, multiple clauses with Any/All combinator and show/hide direction.
+- [ ] Referrer rule evaluates server-side; supports literal hostnames, `*.` subdomain wildcards, and `(direct)`.
+- [ ] Browser/OS/Device rules evaluate via `jenssegers/agent` when available; fall back to in-repo UA parser otherwise.
+- [ ] Visibility Panel renders only the family subsections; active rules show a badge.
+- [ ] Block toolbar Eye badge appears when any rule is active.
+- [ ] Visibility Preview mode mocks all five rule families and reflects the result on the canvas.
+- [ ] Site-wide kill switch (`config('artisanpack.visual-editor.visibility.enabled')` set to false) bypasses every rule.
+- [ ] All `artisanpack/*` blocks opt in by default; opt-out via `supports.artisanpackVisibility: false` removes the panel.
+- [ ] Pest tests cover every rule family's evaluator with happy-path and edge-case inputs.
+- [ ] Vitest tests cover the Visibility Panel UI + the block toolbar badge.
+- [ ] Playwright E2E covers a full editor → save → published-page flow for each rule family.
+- [ ] Docs in `docs/visibility.md` cover authoring rules, the preview mode, the hook, and the kill switch.
+
+## 7. Implementation Notes
+
+### 7.1 Files to create
+
+- `src/Visibility/VisibilityEvaluator.php` — orchestrates per-block evaluation; returns `visible | hidden`.
+- `src/Visibility/Rules/HiddenRule.php`
+- `src/Visibility/Rules/ScreenSizeRule.php` — produces CSS class names + scoped @media rules.
+- `src/Visibility/Rules/QueryStringRule.php`
+- `src/Visibility/Rules/ReferrerRule.php`
+- `src/Visibility/Rules/UserAgentRule.php` — wraps `jenssegers/agent` if installed, else uses `src/Visibility/Support/MiniUaParser.php`.
+- `src/Visibility/Support/MiniUaParser.php` — fallback UA parser.
+- `resources/js/visual-editor/visibility/VisibilityPanel.tsx`
+- `resources/js/visual-editor/visibility/PreviewControls.tsx` — Site Editor preview-state mocker.
+- `resources/js/visual-editor/visibility/ToolbarBadge.tsx`
+- `packages/visual-editor-renderer-{blade,react,vue}/src/visibility/` — per-renderer integration. Blade renderer skips emission entirely when hidden. React/Vue renderers do the same on server render; client-side these skip the component when the resolved visibility is hidden.
+- `tests/Unit/Visibility/*`, `tests/Feature/Visibility/*`, Vitest + Playwright suites.
+
+### 7.2 Files to modify
+
+- `config/visual-editor.php` — add the `visibility` key (enabled flag, hook registration).
+- `src/VisualEditorServiceProvider.php` — register `VisibilityEvaluator`, fire `ap.visibility.evaluated` hook when in debug.
+- All forked `block.json` files — add `supports.artisanpackVisibility: true`.
+- `composer.json` — add `jenssegers/agent` as a *suggest*, not a hard require (fallback parser keeps the package light).
+- `docs/theming.md` — short note that visibility CSS uses the breakpoint registry.
+
+### 7.3 Database / schema
+
+No DB migrations. Visibility rules live in the block attribute tree (`artisanpackVisibility: { hidden, screenSize, queryString, referrer, userAgent }`).
+
+### 7.4 Dependencies
+
+- Optional: `jenssegers/agent` for UA parsing; bundled fallback otherwise.
+
+## 8. Open Questions
+
+- Should we ship a "show in editor only" / "show in published only" toggle as part of the master toggle? (Tentative: yes — useful for editor-only annotations / TODOs. Add as a sub-toggle inside Hide Block.)
+- Do we want the preview-mode mocked inputs to persist across editor sessions (per user)? (Tentative: yes, store in `localStorage`.)

--- a/docs/plans/22-block-visibility-user-and-auth.md
+++ b/docs/plans/22-block-visibility-user-and-auth.md
@@ -1,0 +1,117 @@
+# Visual Editor — Block Visibility (User Role & Auth State)
+
+**Package:** `artisanpack-ui/visual-editor`
+**Version Target:** TBD (Awaiting Review)
+**Created:** 2026-05-30
+**Status:** Planning
+**Reference:** [Block Visibility (WordPress plugin, by Nick Diego)](https://github.com/ndiego/block-visibility)
+**Related:**
+ - [`21-block-visibility-contextual.md`](21-block-visibility-contextual.md) — primary visibility feature; this extends its panel.
+ - [`07-permissions-locking.md`](07-permissions-locking.md) — block-level locking via cms-framework's role system. Distinct concept (locking gates *editing*; this gates *rendering*).
+
+---
+
+## 1. Problem Statement
+
+The contextual visibility feature ([`21-block-visibility-contextual.md`](21-block-visibility-contextual.md)) handles request-time rules. It deliberately defers user-aware rules to here because of the question of overlap with `artisanpack-ui/cms-framework`'s permission system. This plan resolves that question by adding block-level visibility for:
+
+- the visitor's login state (logged in / logged out),
+- the visitor's user role(s),
+- a specific user (by ID/email),
+
+and explicitly distinguishes those from the cms-framework permission system, which protects *editing* but not *rendering*.
+
+## 2. Target User
+
+Membership-site operators, app builders with role-gated features, and editors who want different content shown to admins vs. members vs. anonymous visitors — all without dropping into custom Blade conditionals.
+
+## 3. User Stories
+
+- As an editor on a membership site, I want a CTA visible to logged-out visitors and a different CTA visible to logged-in members.
+- As an editor, I want a block visible only to users with the `admin` role (e.g. an internal debug widget left in the page).
+- As an editor, I want a block visible only to a specific user (by email) — useful for personalised landing pages.
+- As a developer, I want the role list shown in the InspectorControls to be the roles the host application's permission system actually exposes, not a hard-coded list.
+- As a developer, I want this visibility evaluated server-side so logged-out visitors never receive the markup intended for members.
+
+## 4. Scope
+
+### 4.1 In scope
+
+- **Login State rule** — `Show if logged in` / `Show if logged out` / `Either`.
+- **User Role rule** — list of roles with Any/All combinator and show/hide direction. The list is read at runtime from the host app's permission system; default integration is `cms-framework`'s permission registry, falling back to Laravel's standard `Gate` / role helpers if `cms-framework` isn't installed.
+- **Specific User rule** — list of users by ID or email, with show/hide direction. UI is an autocomplete that queries `/users/search?q=...` (a small new endpoint behind the existing editor middleware).
+- **Anonymous-safe evaluation** — if the visitor is logged out, role and user rules short-circuit cleanly (no DB lookups, no exceptions).
+- **Renderer treats hidden blocks as fully absent** — no markup, no DOM placeholder, no flash of content. This is the existing visibility renderer behavior from [`21-block-visibility-contextual.md`](21-block-visibility-contextual.md).
+- **Visibility Preview mode integration** — extends the existing preview controls with "mock logged-in as: [user picker]" and "mock role: [role picker]".
+- **Migration consideration** — if the cms-framework block-locking system already records "this block is only visible to role X," surface a one-time editor notice on first open: "This block has a legacy role lock. Migrate to the new Visibility panel?" Migration is opt-in per block.
+
+### 4.2 Out of scope
+
+- **Permission-based editing gates.** Already handled by cms-framework + [`07-permissions-locking.md`](07-permissions-locking.md). This feature gates rendering only.
+- **Per-route or per-page visibility.** Use the existing route middleware for that.
+- **Custom claims / OIDC scopes.** Out of scope; would need an integration interface and is rarely needed.
+
+## 5. Behavior
+
+### 5.1 Happy path
+
+1. Editor sets a Premium Content block to "Show if logged in AND role is `member`."
+2. Save. Renderer evaluates against `auth()->user()` and the cms-framework `Permission` registry.
+3. Anonymous visitor: block is not emitted. Markup not present in the response at all.
+4. Logged-in `member`: block renders normally.
+5. Logged-in `admin` (not a member): block is not emitted unless the editor adds `admin` to the role list.
+
+### 5.2 Edge cases
+
+- **Host app has no roles configured** (no permission system installed). Role rule UI shows an empty list with a "No roles available" note; the rule evaluator returns "visible" for any visitor (rule contributes nothing).
+- **Specific User rule references a deleted user.** Audit command flags the orphan; renderer treats as no-match.
+- **Block is rendered inside a cached fragment.** Visibility rules that depend on the request user break caching unless the cache key includes the user. Documented; the editor warns when a block with a role/user rule is placed inside a known-cacheable wrapper (template-part with `cache_until` set).
+- **Visibility Preview "logged in as X" must not actually log the editor in as X.** The preview is rule-evaluation simulation only — no auth side effects.
+
+## 6. Acceptance Criteria
+
+- [ ] Login state rule works end-to-end across all three renderers.
+- [ ] Role rule reads the live role list from cms-framework's permission registry; falls back gracefully when absent.
+- [ ] Specific User rule autocomplete queries the new `/users/search` endpoint behind editor auth middleware.
+- [ ] Anonymous evaluation short-circuits without DB queries.
+- [ ] Visibility Preview lets the editor mock login state, role, and specific user.
+- [ ] Legacy role-lock migration notice appears on first open of a previously locked block.
+- [ ] Cache-warning surfaces when a user/role rule is inside a cacheable template part.
+- [ ] Pest tests cover all three rule evaluators, anonymous edge cases, and the migration path.
+- [ ] Vitest tests cover the InspectorControls + autocomplete.
+- [ ] Playwright E2E covers a member-only-CTA scenario across logged-in / logged-out sessions.
+- [ ] Docs in `docs/visibility.md` extend with a User & Auth section, including the relationship to cms-framework permissions.
+
+## 7. Implementation Notes
+
+### 7.1 Files to create
+
+- `src/Visibility/Rules/LoginStateRule.php`
+- `src/Visibility/Rules/UserRoleRule.php`
+- `src/Visibility/Rules/SpecificUserRule.php`
+- `src/Visibility/RoleRegistryAdapter.php` — abstraction over cms-framework / Laravel Gate; tested with both.
+- `src/Http/Controllers/UserSearchController.php` — autocomplete endpoint.
+- `resources/js/visual-editor/visibility/UserAuthSection.tsx` — extends the existing VisibilityPanel.
+- `resources/js/visual-editor/visibility/UserAutocomplete.tsx`.
+- `tests/Unit/Visibility/Rules/*`, `tests/Feature/Visibility/UserAuth*`, Vitest + Playwright suites.
+
+### 7.2 Files to modify
+
+- `routes/api.php` (or equivalent in the package) — register `/users/search` behind editor auth.
+- `src/Visibility/VisibilityEvaluator.php` — wire in the three new rules.
+- `resources/js/visual-editor/visibility/VisibilityPanel.tsx` — render the new section.
+- `resources/js/visual-editor/visibility/PreviewControls.tsx` — add the auth mockers.
+- `docs/visibility.md` — extend.
+
+### 7.3 Database / schema
+
+No DB migrations. Rules live in the existing `artisanpackVisibility` attribute object.
+
+### 7.4 Dependencies
+
+None new. Depends on [`21-block-visibility-contextual.md`](21-block-visibility-contextual.md) shipping first.
+
+## 8. Open Questions
+
+- Should the role-list source be configurable (default: cms-framework, alternates: Gate / Spatie permissions)? (Tentative: yes, via `config('artisanpack.visual-editor.visibility.role_source')`.)
+- Should we ship a "Show during impersonation" sub-rule for admins impersonating other users? (Tentative: defer; out of scope until impersonation lands in cms-framework.)

--- a/docs/plans/23-block-visibility-scheduling.md
+++ b/docs/plans/23-block-visibility-scheduling.md
@@ -1,0 +1,121 @@
+# Visual Editor — Block Visibility (Date/Time Scheduling)
+
+**Package:** `artisanpack-ui/visual-editor`
+**Version Target:** TBD (Awaiting Review)
+**Created:** 2026-05-30
+**Status:** Planning
+**Reference:** [Block Visibility (WordPress plugin, by Nick Diego)](https://github.com/ndiego/block-visibility)
+**Related:**
+ - [`21-block-visibility-contextual.md`](21-block-visibility-contextual.md) — primary visibility feature; this extends its panel.
+ - [`22-block-visibility-user-and-auth.md`](22-block-visibility-user-and-auth.md) — sibling, deferred to same milestone.
+
+---
+
+## 1. Problem Statement
+
+Post-level scheduling exists (cms-framework `published_at` / `unpublished_at`), but it can't help an editor say "show this 'Black Friday sale' banner only between Nov 24 09:00 and Nov 28 23:59" without duplicating the entire post. Marketing teams want block-level time windows for promotions, seasonal copy, countdowns, and "show after launch" reveals.
+
+## 2. Target User
+
+Marketing editors running time-bound campaigns, editors maintaining seasonal pages, and developers building any time-aware content composition without writing custom Blade conditionals.
+
+## 3. User Stories
+
+- As an editor, I want to schedule a block to start showing at a specific date and time.
+- As an editor, I want to schedule a block to stop showing at a specific date and time.
+- As an editor, I want to configure a recurring schedule (e.g. "every Saturday 09:00–17:00") for an event-related block.
+- As an editor, I want the editor canvas to indicate whether a scheduled block is currently in its visible window, scheduled to show later, or already expired.
+- As an editor, I want the Visibility Preview mode to let me mock "the current time" so I can preview what visitors will see at any moment.
+- As a developer, I want schedules evaluated server-side in the host application's timezone (with explicit per-rule timezone override) so behavior is consistent.
+
+## 4. Scope
+
+### 4.1 In scope
+
+- **Date/Time Window rule** — start and/or end datetime. Either can be unset (open-ended).
+- **Recurring schedule rule** — weekly day-of-week + time-of-day windows. Up to N windows per week (tentative cap: 14, enough for two windows per day).
+- **Per-rule timezone** — defaults to `config('app.timezone')`. Editor can override per rule (e.g. "schedule in PST regardless of app timezone").
+- **Evaluation cadence** — purely server-side at render time. No JS countdown runtime.
+- **Editor status indicators**:
+  - Scheduled (start in the future): clock icon + tooltip "Visible starting {datetime}."
+  - Active: green dot + tooltip "Currently visible. Ends {datetime}." (omit "ends" if open-ended).
+  - Expired (end in the past): grey clock + tooltip "Expired on {datetime}." Includes a "Reactivate" affordance that clears the end date.
+- **Visibility Preview "mock current time"** — extends the preview controls with a datetime picker. The picker only affects rule evaluation in the preview; never mutates `now()` for the rest of the app.
+- **Audit command** — `visual-editor:audit-scheduled-blocks` lists every block with an active or upcoming schedule (post → block → window). Useful for ops planning around big launches.
+
+### 4.2 Out of scope
+
+- **Cron/scheduler-based proactive cache busting**. Documented as a known limitation: schedules don't auto-bust caches; ops should set cache TTL ≤ the smallest reasonable schedule resolution.
+- **iCal feeds / external calendar integration.** Out of scope.
+- **Holiday-aware scheduling** (e.g. "every US federal holiday"). Out of scope.
+- **Countdown timer rendering** (the visible "starts in 4h 12m" widget). That's a separate Countdown block, not a visibility rule.
+
+## 5. Behavior
+
+### 5.1 Happy path (single window)
+
+1. Editor sets a Banner block schedule: start `2026-11-24 09:00 PST`, end `2026-11-28 23:59 PST`.
+2. Save. The block attribute stores the ISO datetimes + timezone.
+3. Renderer evaluates `now()->between(start, end)`. Pre-launch: block is not emitted. During the window: block renders. Post-launch: block is not emitted.
+4. Editor canvas shows "Scheduled (starts Nov 24)" while editing.
+
+### 5.2 Happy path (recurring)
+
+1. Editor sets a Saturday-Sunday `10:00–14:00` recurring window for a "Weekend Brunch" block.
+2. Renderer evaluates against the visitor's request time vs. day-of-week + time-of-day.
+3. Mid-week visitors see no block; weekend daytime visitors see it.
+
+### 5.3 Edge cases
+
+- **App timezone changes after schedules are authored.** Per-rule timezone override prevents drift. If no override was set, the audit command flags ambiguous schedules.
+- **End date precedes start date.** Schema validator rejects on save with a descriptive error.
+- **DST transitions inside a window.** Documented; `now()->between()` handles via Carbon timezone math.
+- **Block placed inside a cached fragment.** Cache invalidation must align with the smallest schedule boundary; renderer auto-shortens `cache_until` when a scheduled block is inside a cached template part. Editor surfaces a warning when this auto-tightening happens.
+- **Schedule with both single window and recurring rule.** Combined with AND — block is visible only when both the single window AND the recurring rule pass.
+
+## 6. Acceptance Criteria
+
+- [ ] Single date/time window rule works for: start-only, end-only, both, neither.
+- [ ] Recurring weekly schedule supports up to 14 windows.
+- [ ] Per-rule timezone override works; defaults to app timezone.
+- [ ] Editor canvas indicators (scheduled / active / expired) render correctly with relative-time tooltips.
+- [ ] Visibility Preview mock-time picker affects only preview evaluation.
+- [ ] `visual-editor:audit-scheduled-blocks` lists every scheduled block.
+- [ ] Cache-auto-tightening fires + warns when a scheduled block is inside a cached template part.
+- [ ] Schema validator rejects nonsensical schedules (end before start, malformed times, unknown timezones).
+- [ ] Pest tests cover: single window, recurring, timezone override, DST transition, combined window+recurring, schema validation.
+- [ ] Vitest tests cover the schedule editor UI + status indicators.
+- [ ] Playwright E2E covers: schedule a block, scrub the preview time, save+reload, observe expired-state UI.
+- [ ] Docs in `docs/visibility.md` extend with a Scheduling section including the cache-invalidation guidance.
+
+## 7. Implementation Notes
+
+### 7.1 Files to create
+
+- `src/Visibility/Rules/ScheduleRule.php` — handles both single window + recurring evaluation.
+- `src/Visibility/Schedule/RecurringWindow.php` — value object.
+- `src/Visibility/Schedule/CacheTightener.php` — adjusts surrounding `cache_until` directives.
+- `src/Console/AuditScheduledBlocksCommand.php`
+- `resources/js/visual-editor/visibility/ScheduleSection.tsx`
+- `resources/js/visual-editor/visibility/ScheduleStatusIndicator.tsx`
+- `tests/Unit/Visibility/Schedule*`, Vitest + Playwright suites.
+
+### 7.2 Files to modify
+
+- `src/Visibility/VisibilityEvaluator.php` — wire in `ScheduleRule`.
+- `resources/js/visual-editor/visibility/VisibilityPanel.tsx` — render the Schedule section.
+- `resources/js/visual-editor/visibility/PreviewControls.tsx` — add the mock-time picker.
+- `docs/visibility.md` — extend.
+
+### 7.3 Database / schema
+
+No DB migrations. Rules live in the existing `artisanpackVisibility` attribute object.
+
+### 7.4 Dependencies
+
+None new. Carbon is already in the stack.
+
+## 8. Open Questions
+
+- Should the recurring schedule support monthly patterns ("first Tuesday of the month")? (Tentative: defer until requested; weekly covers most use cases.)
+- Should we ship a "soft-expire" mode where an expired block stays visible until the next deploy/cache flush, never mid-request? (Tentative: yes, as an opt-in `mode: hard | soft` per rule. Default `hard`.)

--- a/packages/renderer-parity.json
+++ b/packages/renderer-parity.json
@@ -35,6 +35,7 @@
         "core/block",
         "core/query",
         "core/post-template",
+        "core/post-template-item",
         "core/post-title",
         "core/post-content",
         "core/post-excerpt",

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/core/post-template-item.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/core/post-template-item.blade.php
@@ -1,0 +1,13 @@
+@php
+	$postId = isset( $attributes['postId'] ) ? (int) $attributes['postId'] : 0;
+	$className = isset( $attributes['className'] ) && is_string( $attributes['className'] )
+		? trim( $attributes['className'] )
+		: '';
+
+	$classes = array_filter( [ 'wp-block-post-template-item', $className ] );
+	$classAttr = sprintf( 'class="%s"', e( implode( ' ', $classes ) ) );
+	$idAttr = $postId > 0 ? sprintf( ' id="post-%d"', $postId ) : '';
+@endphp
+<li{!! $idAttr !!} {!! $classAttr !!}>
+	{!! $innerBlocksHtml !!}
+</li>

--- a/packages/visual-editor-renderer-blade/src/BlockRenderer.php
+++ b/packages/visual-editor-renderer-blade/src/BlockRenderer.php
@@ -95,10 +95,6 @@ class BlockRenderer
 		$attributes      = $this->stampSiteMeta( $name, $attributes );
 		$innerBlocksHtml = $this->render( $this->normalizeInnerBlocks( $block['innerBlocks'] ?? [] ) );
 
-		if ( '_query-iteration' === $name ) {
-			return $this->renderQueryIteration( $attributes, $innerBlocksHtml );
-		}
-
 		if ( $this->dynamicBlocks->has( $name ) ) {
 			return $this->renderDynamic( $name, $attributes, $innerBlocksHtml );
 		}
@@ -231,33 +227,6 @@ class BlockRenderer
 	 *
 	 * @since 1.0.0
 	 */
-	/**
-	 * Render a single query-loop iteration as an `<li>` with post classes.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param  array<string, mixed>  $attributes
-	 */
-	protected function renderQueryIteration( array $attributes, string $innerBlocksHtml ): string
-	{
-		$postId    = isset( $attributes['postId'] ) ? (int) $attributes['postId'] : 0;
-		$className = isset( $attributes['className'] ) && is_string( $attributes['className'] )
-			? $attributes['className']
-			: '';
-
-		$classes = array_filter( [
-			'wp-block-post',
-			$className,
-		] );
-
-		return sprintf(
-			'<li id="post-%d" class="%s">%s</li>',
-			$postId,
-			e( implode( ' ', $classes ) ),
-			$innerBlocksHtml
-		);
-	}
-
 	protected function renderFallback( string $name, string $innerBlocksHtml ): string
 	{
 		$safeName = htmlspecialchars( $name, ENT_QUOTES | ENT_HTML5, 'UTF-8' );

--- a/packages/visual-editor-renderer-blade/tests/Feature/CoreQueryRenderingTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Feature/CoreQueryRenderingTest.php
@@ -66,9 +66,13 @@ it( 'renders core/query results through the full Blade pipeline', function () {
 		->and( $html )->toContain( 'Second post' )
 		->and( $html )->toContain( '/posts/1' )
 		->and( $html )->toContain( '/posts/2' )
-		// Each result should be wrapped in its own post-template
-		// instance — the rendered HTML contains two anchors.
-		->and( substr_count( $html, 'href="/posts/' ) )->toBe( 2 );
+		->and( substr_count( $html, 'href="/posts/' ) )->toBe( 2 )
+		// Semantic markup: a single `<ul class="wp-block-post-template">`
+		// wraps N `<li class="wp-block-post-template-item">` items
+		// rather than N single-item `<ul>`s.
+		->and( substr_count( $html, '<ul' ) )->toBe( 1 )
+		->and( substr_count( $html, '<li' ) )->toBe( 2 )
+		->and( substr_count( $html, 'wp-block-post-template-item' ) )->toBe( 2 );
 } );
 
 it( 'preserves the surrounding tree when the resolver fails', function () {

--- a/packages/visual-editor-renderer-react/src/blocks/core/query.tsx
+++ b/packages/visual-editor-renderer-react/src/blocks/core/query.tsx
@@ -72,11 +72,11 @@ export function PostTemplateBlock({ attributes, children }: BlockRendererProps):
     return <ul className={classes}>{children}</ul>;
 }
 
-export function QueryIterationBlock({ attributes, children }: BlockRendererProps): JSX.Element {
+export function PostTemplateItemBlock({ attributes, children }: BlockRendererProps): JSX.Element {
     const postId = typeof attributes.postId === 'number' ? attributes.postId : 0;
     const className = attrString(attributes.className);
 
-    const classes = classList(['wp-block-post', className]);
+    const classes = classList(['wp-block-post-template-item', className]);
 
-    return <li id={`post-${postId}`} className={classes}>{children}</li>;
+    return <li id={postId > 0 ? `post-${postId}` : undefined} className={classes}>{children}</li>;
 }

--- a/packages/visual-editor-renderer-react/src/blocks/core/query.tsx
+++ b/packages/visual-editor-renderer-react/src/blocks/core/query.tsx
@@ -73,7 +73,12 @@ export function PostTemplateBlock({ attributes, children }: BlockRendererProps):
 }
 
 export function PostTemplateItemBlock({ attributes, children }: BlockRendererProps): JSX.Element {
-    const postId = typeof attributes.postId === 'number' ? attributes.postId : 0;
+    // Coerce numeric strings ("123") to numbers so the `post-{id}` id stamps
+    // regardless of whether the host serialized the attribute as a number or a
+    // string — matches the Blade partial's `(int)` cast.
+    const rawPostId = attributes.postId;
+    const parsedPostId = typeof rawPostId === 'number' ? rawPostId : Number(rawPostId);
+    const postId = Number.isFinite(parsedPostId) ? parsedPostId : 0;
     const className = attrString(attributes.className);
 
     const classes = classList(['wp-block-post-template-item', className]);

--- a/packages/visual-editor-renderer-react/src/blocks/registerCoreBlocks.ts
+++ b/packages/visual-editor-renderer-react/src/blocks/registerCoreBlocks.ts
@@ -52,7 +52,7 @@ import {
     PostFeaturedImageBlock,
     PostTitleBlock,
 } from './core/postContext';
-import { PostTemplateBlock, QueryBlock, QueryIterationBlock } from './core/query';
+import { PostTemplateBlock, PostTemplateItemBlock, QueryBlock } from './core/query';
 import { SiteLogoBlock, SiteTaglineBlock, SiteTitleBlock } from './core/siteContext';
 import { SyncedPatternBlock } from './core/syncedPattern';
 import { TemplatePartBlock } from './core/templatePart';
@@ -142,7 +142,7 @@ const CORE_BLOCKS: Record<string, BlockRenderer> = {
     'core/post-template': PostTemplateBlock,
     'artisanpack/query': QueryBlock,
     'artisanpack/post-template': PostTemplateBlock,
-    '_query-iteration': QueryIterationBlock,
+    'core/post-template-item': PostTemplateItemBlock,
     'core/post-title': PostTitleBlock,
     'artisanpack/post-title': PostTitleBlock,
     'core/post-content': PostContentBlock,

--- a/packages/visual-editor-renderer-react/src/queries.ts
+++ b/packages/visual-editor-renderer-react/src/queries.ts
@@ -37,6 +37,10 @@ export interface ResolvedPost {
     modifiedAt?: string;
     author?: ResolvedAuthor | null;
     featuredImage?: ResolvedFeaturedImage | null;
+    /** Post type used for the `type-{value}` class on the iteration `<li>`. Defaults to `post`. */
+    type?: string;
+    /** Publication status used for the `status-{value}` class on the iteration `<li>`. Defaults to `publish`. */
+    status?: string;
 }
 
 export interface ResolvedAuthor {
@@ -66,6 +70,9 @@ const POST_CONTEXT_BLOCKS = new Set([
     'core/post-featured-image',
 ]);
 
+const QUERY_BLOCK_NAMES = new Set(['core/query', 'artisanpack/query']);
+const POST_TEMPLATE_BLOCK_NAMES = new Set(['core/post-template', 'artisanpack/post-template']);
+
 export function inlineQueries(tree: Block[], options: InlineQueriesOptions): Block[] {
     const queriesById = new Map<string, ResolvedQuery>();
 
@@ -84,7 +91,7 @@ function walk(tree: Block[], queries: Map<string, ResolvedQuery>): Block[] {
             continue;
         }
 
-        if (block.name === 'core/query') {
+        if (typeof block.name === 'string' && QUERY_BLOCK_NAMES.has(block.name)) {
             out.push(expandQuery(block, queries));
             continue;
         }
@@ -128,23 +135,96 @@ function expandQuery(block: Block, queries: Map<string, ResolvedQuery>): Block {
         };
     }
 
-    const template = Array.isArray(block.innerBlocks) ? (block.innerBlocks as Block[]) : [];
-    const expanded: Block[] = [];
+    const queryInner = Array.isArray(block.innerBlocks) ? (block.innerBlocks as Block[]) : [];
+    const resolvedAttributes = {
+        ...attributes,
+        _resolvedTotal: resolved.total ?? resolved.posts.length,
+        _resolvedItems: resolved.posts.length,
+    };
 
-    for (const post of resolved.posts) {
-        for (const child of template) {
-            expanded.push(stampPost(cloneBlock(child), post));
+    if (resolved.posts.length === 0 || queryInner.length === 0) {
+        return {
+            ...block,
+            attributes: resolvedAttributes,
+            innerBlocks: [],
+        };
+    }
+
+    // Find the post-template child block. Its inner blocks are the
+    // per-iteration template that gets cloned once per result;
+    // everything else (pagination, no-results) stays alongside it.
+    let postTemplateIndex = -1;
+    let iterationTemplate: Block[] = [];
+
+    for (let i = 0; i < queryInner.length; i += 1) {
+        const child = queryInner[i];
+        if (child === null || typeof child !== 'object') {
+            continue;
+        }
+
+        if (typeof child.name === 'string' && POST_TEMPLATE_BLOCK_NAMES.has(child.name)) {
+            postTemplateIndex = i;
+            iterationTemplate = Array.isArray(child.innerBlocks) ? (child.innerBlocks as Block[]) : [];
+            break;
         }
     }
 
+    // No post-template found — fall back to expanding the query's
+    // direct inner blocks once per result, so hosts that drop a custom
+    // template without the post-template wrapper are not regressed.
+    if (postTemplateIndex === -1) {
+        const expandedFlat: Block[] = [];
+
+        for (const post of resolved.posts) {
+            for (const child of queryInner) {
+                expandedFlat.push(stampPost(cloneBlock(child), post));
+            }
+        }
+
+        return {
+            ...block,
+            attributes: resolvedAttributes,
+            innerBlocks: expandedFlat,
+        };
+    }
+
+    const expandedIterations: Block[] = [];
+
+    for (const post of resolved.posts) {
+        const iterationBlocks: Block[] = [];
+
+        for (const tmplChild of iterationTemplate) {
+            iterationBlocks.push(stampPost(cloneBlock(tmplChild), post));
+        }
+
+        const postType = typeof post.type === 'string' && post.type !== '' ? post.type : 'post';
+        const postStatus =
+            typeof post.status === 'string' && post.status !== '' ? post.status : 'publish';
+
+        expandedIterations.push({
+            clientId: `pti-${post.id}`,
+            name: 'core/post-template-item',
+            attributes: {
+                postId: post.id,
+                className: `post-${post.id} post type-${postType} status-${postStatus}`,
+            },
+            innerBlocks: iterationBlocks,
+        });
+    }
+
+    const postTemplate = queryInner[postTemplateIndex];
+    const expandedTemplate: Block = {
+        ...postTemplate,
+        innerBlocks: expandedIterations,
+    };
+
+    const newQueryInner = queryInner.slice();
+    newQueryInner[postTemplateIndex] = expandedTemplate;
+
     return {
         ...block,
-        attributes: {
-            ...attributes,
-            _resolvedTotal: resolved.total ?? resolved.posts.length,
-            _resolvedItems: resolved.posts.length,
-        },
-        innerBlocks: expanded,
+        attributes: resolvedAttributes,
+        innerBlocks: newQueryInner,
     };
 }
 

--- a/packages/visual-editor-renderer-react/src/queries.ts
+++ b/packages/visual-editor-renderer-react/src/queries.ts
@@ -189,6 +189,10 @@ function expandQuery(block: Block, queries: Map<string, ResolvedQuery>): Block {
     }
 
     const expandedIterations: Block[] = [];
+    // Track occurrences so a duplicate post.id within a single result set
+    // gets a unique clientId (avoids React reconciliation key collisions
+    // when BlockTree uses block.clientId as the React key).
+    const seenIds = new Map<number, number>();
 
     for (const post of resolved.posts) {
         const iterationBlocks: Block[] = [];
@@ -201,8 +205,12 @@ function expandQuery(block: Block, queries: Map<string, ResolvedQuery>): Block {
         const postStatus =
             typeof post.status === 'string' && post.status !== '' ? post.status : 'publish';
 
+        const occurrence = seenIds.get(post.id) ?? 0;
+        seenIds.set(post.id, occurrence + 1);
+        const clientId = occurrence === 0 ? `pti-${post.id}` : `pti-${post.id}-${occurrence}`;
+
         expandedIterations.push({
-            clientId: `pti-${post.id}`,
+            clientId,
             name: 'core/post-template-item',
             attributes: {
                 postId: post.id,

--- a/packages/visual-editor-renderer-react/tests/queries.test.ts
+++ b/packages/visual-editor-renderer-react/tests/queries.test.ts
@@ -31,7 +31,7 @@ function fakePost(id: number, title: string): ResolvedPost {
 }
 
 describe('inlineQueries', () => {
-    it('expands core/query into one post-template instance per result', () => {
+    it('expands core/query into one post-template wrapping N post-template-item blocks', () => {
         const tree = [
             makeQueryBlock([
                 { name: 'core/post-title', attributes: {}, innerBlocks: [] } as Block,
@@ -43,14 +43,20 @@ describe('inlineQueries', () => {
         ];
 
         const result = inlineQueries(tree, { queries });
-        const innerBlocks = result[0].innerBlocks ?? [];
+        const queryInner = result[0].innerBlocks ?? [];
+        const postTemplate = queryInner[0];
+        const items = postTemplate.innerBlocks ?? [];
 
-        expect(innerBlocks).toHaveLength(2);
+        expect(queryInner).toHaveLength(1);
+        expect(postTemplate.name).toBe('core/post-template');
+        expect(items).toHaveLength(2);
+        expect(items[0].name).toBe('core/post-template-item');
+        expect(items[1].name).toBe('core/post-template-item');
         expect(
-            (innerBlocks[0].innerBlocks?.[0].attributes as Record<string, unknown>)?._resolvedTitle
+            (items[0].innerBlocks?.[0].attributes as Record<string, unknown>)?._resolvedTitle
         ).toBe('A');
         expect(
-            (innerBlocks[1].innerBlocks?.[0].attributes as Record<string, unknown>)?._resolvedTitle
+            (items[1].innerBlocks?.[0].attributes as Record<string, unknown>)?._resolvedTitle
         ).toBe('B');
     });
 
@@ -90,7 +96,7 @@ describe('inlineQueries', () => {
         ];
 
         const result = inlineQueries(tree, { queries });
-        const stamped = result[0].innerBlocks?.[0].innerBlocks ?? [];
+        const stamped = result[0].innerBlocks?.[0].innerBlocks?.[0].innerBlocks ?? [];
 
         expect((stamped[0].attributes as Record<string, unknown>)._resolvedTitle).toBe('Post');
         expect((stamped[1].attributes as Record<string, unknown>)._resolvedExcerpt).toBe('Excerpt');
@@ -121,7 +127,7 @@ describe('inlineQueries', () => {
 
         const result = inlineQueries(tree as Block[], { queries });
         const innerQuery = result[0].innerBlocks?.[0];
-        const stamped = innerQuery?.innerBlocks?.[0]?.innerBlocks?.[0];
+        const stamped = innerQuery?.innerBlocks?.[0]?.innerBlocks?.[0]?.innerBlocks?.[0];
 
         expect(innerQuery?.name).toBe('core/query');
         expect((stamped?.attributes as Record<string, unknown>)?._resolvedTitle).toBe('Inner');
@@ -143,7 +149,7 @@ describe('inlineQueries', () => {
         ];
 
         const result = inlineQueries(tree, { queries });
-        const stamped = result[0].innerBlocks?.[0].innerBlocks?.[0];
+        const stamped = result[0].innerBlocks?.[0].innerBlocks?.[0].innerBlocks?.[0];
 
         expect((stamped?.attributes as Record<string, unknown>)?._resolvedTitle).toBe(
             'Host override'

--- a/packages/visual-editor-renderer-vue/src/blocks/core/query.ts
+++ b/packages/visual-editor-renderer-vue/src/blocks/core/query.ts
@@ -79,22 +79,23 @@ export const PostTemplateBlock = defineComponent({
     },
 });
 
-export const QueryIterationBlock = defineComponent({
-    name: 'QueryIterationBlock',
+export const PostTemplateItemBlock = defineComponent({
+    name: 'PostTemplateItemBlock',
     props: blockRendererProps,
     setup(props, { slots }) {
         return () => {
             const postId = typeof props.attributes.postId === 'number' ? props.attributes.postId : 0;
             const className = attrString(props.attributes.className);
 
-            return h(
-                'li',
-                {
-                    id: `post-${postId}`,
-                    class: classList(['wp-block-post', className]),
-                },
-                slots.default?.()
-            );
+            const attrs: Record<string, unknown> = {
+                class: classList(['wp-block-post-template-item', className]),
+            };
+
+            if (postId > 0) {
+                attrs.id = `post-${postId}`;
+            }
+
+            return h('li', attrs, slots.default?.());
         };
     },
 });

--- a/packages/visual-editor-renderer-vue/src/blocks/core/query.ts
+++ b/packages/visual-editor-renderer-vue/src/blocks/core/query.ts
@@ -84,7 +84,13 @@ export const PostTemplateItemBlock = defineComponent({
     props: blockRendererProps,
     setup(props, { slots }) {
         return () => {
-            const postId = typeof props.attributes.postId === 'number' ? props.attributes.postId : 0;
+            // Coerce numeric strings ("123") so the `post-{id}` id stamps
+            // regardless of whether the host serialized postId as a number or
+            // a string — matches the Blade partial's `(int)` cast.
+            const rawPostId = props.attributes.postId;
+            const parsedPostId =
+                typeof rawPostId === 'number' ? rawPostId : Number(rawPostId);
+            const postId = Number.isFinite(parsedPostId) ? parsedPostId : 0;
             const className = attrString(props.attributes.className);
 
             const attrs: Record<string, unknown> = {

--- a/packages/visual-editor-renderer-vue/src/blocks/registerCoreBlocks.ts
+++ b/packages/visual-editor-renderer-vue/src/blocks/registerCoreBlocks.ts
@@ -52,7 +52,7 @@ import {
     PostFeaturedImageBlock,
     PostTitleBlock,
 } from './core/postContext';
-import { PostTemplateBlock, QueryBlock, QueryIterationBlock } from './core/query';
+import { PostTemplateBlock, PostTemplateItemBlock, QueryBlock } from './core/query';
 import { SiteLogoBlock, SiteTaglineBlock, SiteTitleBlock } from './core/siteContext';
 import { SyncedPatternBlock } from './core/syncedPattern';
 import { TemplatePartBlock } from './core/templatePart';
@@ -141,7 +141,7 @@ const CORE_BLOCKS: Record<string, BlockRenderer> = {
     'core/post-template': PostTemplateBlock,
     'artisanpack/query': QueryBlock,
     'artisanpack/post-template': PostTemplateBlock,
-    '_query-iteration': QueryIterationBlock,
+    'core/post-template-item': PostTemplateItemBlock,
     'core/block': SyncedPatternBlock,
     'core/post-title': PostTitleBlock,
     'artisanpack/post-title': PostTitleBlock,

--- a/packages/visual-editor-renderer-vue/src/queries.ts
+++ b/packages/visual-editor-renderer-vue/src/queries.ts
@@ -189,6 +189,10 @@ function expandQuery(block: Block, queries: Map<string, ResolvedQuery>): Block {
     }
 
     const expandedIterations: Block[] = [];
+    // Track occurrences so a duplicate post.id within a single result set
+    // gets a unique clientId (avoids Vue key collisions when the renderer
+    // uses block.clientId as the `v-for` key).
+    const seenIds = new Map<number, number>();
 
     for (const post of resolved.posts) {
         const iterationBlocks: Block[] = [];
@@ -201,8 +205,12 @@ function expandQuery(block: Block, queries: Map<string, ResolvedQuery>): Block {
         const postStatus =
             typeof post.status === 'string' && post.status !== '' ? post.status : 'publish';
 
+        const occurrence = seenIds.get(post.id) ?? 0;
+        seenIds.set(post.id, occurrence + 1);
+        const clientId = occurrence === 0 ? `pti-${post.id}` : `pti-${post.id}-${occurrence}`;
+
         expandedIterations.push({
-            clientId: `pti-${post.id}`,
+            clientId,
             name: 'core/post-template-item',
             attributes: {
                 postId: post.id,

--- a/packages/visual-editor-renderer-vue/src/queries.ts
+++ b/packages/visual-editor-renderer-vue/src/queries.ts
@@ -37,6 +37,10 @@ export interface ResolvedPost {
     modifiedAt?: string;
     author?: ResolvedAuthor | null;
     featuredImage?: ResolvedFeaturedImage | null;
+    /** Post type used for the `type-{value}` class on the iteration `<li>`. Defaults to `post`. */
+    type?: string;
+    /** Publication status used for the `status-{value}` class on the iteration `<li>`. Defaults to `publish`. */
+    status?: string;
 }
 
 export interface ResolvedAuthor {
@@ -66,6 +70,9 @@ const POST_CONTEXT_BLOCKS = new Set([
     'core/post-featured-image',
 ]);
 
+const QUERY_BLOCK_NAMES = new Set(['core/query', 'artisanpack/query']);
+const POST_TEMPLATE_BLOCK_NAMES = new Set(['core/post-template', 'artisanpack/post-template']);
+
 export function inlineQueries(tree: Block[], options: InlineQueriesOptions): Block[] {
     const queriesById = new Map<string, ResolvedQuery>();
 
@@ -84,7 +91,7 @@ function walk(tree: Block[], queries: Map<string, ResolvedQuery>): Block[] {
             continue;
         }
 
-        if (block.name === 'core/query') {
+        if (typeof block.name === 'string' && QUERY_BLOCK_NAMES.has(block.name)) {
             out.push(expandQuery(block, queries));
             continue;
         }
@@ -128,23 +135,96 @@ function expandQuery(block: Block, queries: Map<string, ResolvedQuery>): Block {
         };
     }
 
-    const template = Array.isArray(block.innerBlocks) ? (block.innerBlocks as Block[]) : [];
-    const expanded: Block[] = [];
+    const queryInner = Array.isArray(block.innerBlocks) ? (block.innerBlocks as Block[]) : [];
+    const resolvedAttributes = {
+        ...attributes,
+        _resolvedTotal: resolved.total ?? resolved.posts.length,
+        _resolvedItems: resolved.posts.length,
+    };
 
-    for (const post of resolved.posts) {
-        for (const child of template) {
-            expanded.push(stampPost(cloneBlock(child), post));
+    if (resolved.posts.length === 0 || queryInner.length === 0) {
+        return {
+            ...block,
+            attributes: resolvedAttributes,
+            innerBlocks: [],
+        };
+    }
+
+    // Find the post-template child block. Its inner blocks are the
+    // per-iteration template that gets cloned once per result;
+    // everything else (pagination, no-results) stays alongside it.
+    let postTemplateIndex = -1;
+    let iterationTemplate: Block[] = [];
+
+    for (let i = 0; i < queryInner.length; i += 1) {
+        const child = queryInner[i];
+        if (child === null || typeof child !== 'object') {
+            continue;
+        }
+
+        if (typeof child.name === 'string' && POST_TEMPLATE_BLOCK_NAMES.has(child.name)) {
+            postTemplateIndex = i;
+            iterationTemplate = Array.isArray(child.innerBlocks) ? (child.innerBlocks as Block[]) : [];
+            break;
         }
     }
 
+    // No post-template found — fall back to expanding the query's
+    // direct inner blocks once per result, so hosts that drop a custom
+    // template without the post-template wrapper are not regressed.
+    if (postTemplateIndex === -1) {
+        const expandedFlat: Block[] = [];
+
+        for (const post of resolved.posts) {
+            for (const child of queryInner) {
+                expandedFlat.push(stampPost(cloneBlock(child), post));
+            }
+        }
+
+        return {
+            ...block,
+            attributes: resolvedAttributes,
+            innerBlocks: expandedFlat,
+        };
+    }
+
+    const expandedIterations: Block[] = [];
+
+    for (const post of resolved.posts) {
+        const iterationBlocks: Block[] = [];
+
+        for (const tmplChild of iterationTemplate) {
+            iterationBlocks.push(stampPost(cloneBlock(tmplChild), post));
+        }
+
+        const postType = typeof post.type === 'string' && post.type !== '' ? post.type : 'post';
+        const postStatus =
+            typeof post.status === 'string' && post.status !== '' ? post.status : 'publish';
+
+        expandedIterations.push({
+            clientId: `pti-${post.id}`,
+            name: 'core/post-template-item',
+            attributes: {
+                postId: post.id,
+                className: `post-${post.id} post type-${postType} status-${postStatus}`,
+            },
+            innerBlocks: iterationBlocks,
+        });
+    }
+
+    const postTemplate = queryInner[postTemplateIndex];
+    const expandedTemplate: Block = {
+        ...postTemplate,
+        innerBlocks: expandedIterations,
+    };
+
+    const newQueryInner = queryInner.slice();
+    newQueryInner[postTemplateIndex] = expandedTemplate;
+
     return {
         ...block,
-        attributes: {
-            ...attributes,
-            _resolvedTotal: resolved.total ?? resolved.posts.length,
-            _resolvedItems: resolved.posts.length,
-        },
-        innerBlocks: expanded,
+        attributes: resolvedAttributes,
+        innerBlocks: newQueryInner,
     };
 }
 

--- a/packages/visual-editor-renderer-vue/tests/queries.test.ts
+++ b/packages/visual-editor-renderer-vue/tests/queries.test.ts
@@ -31,7 +31,7 @@ function fakePost(id: number, title: string): ResolvedPost {
 }
 
 describe('inlineQueries', () => {
-    it('expands core/query into one post-template instance per result', () => {
+    it('expands core/query into one post-template wrapping N post-template-item blocks', () => {
         const tree = [
             makeQueryBlock([
                 { name: 'core/post-title', attributes: {}, innerBlocks: [] } as Block,
@@ -43,14 +43,20 @@ describe('inlineQueries', () => {
         ];
 
         const result = inlineQueries(tree, { queries });
-        const innerBlocks = result[0].innerBlocks ?? [];
+        const queryInner = result[0].innerBlocks ?? [];
+        const postTemplate = queryInner[0];
+        const items = postTemplate.innerBlocks ?? [];
 
-        expect(innerBlocks).toHaveLength(2);
+        expect(queryInner).toHaveLength(1);
+        expect(postTemplate.name).toBe('core/post-template');
+        expect(items).toHaveLength(2);
+        expect(items[0].name).toBe('core/post-template-item');
+        expect(items[1].name).toBe('core/post-template-item');
         expect(
-            (innerBlocks[0].innerBlocks?.[0].attributes as Record<string, unknown>)?._resolvedTitle
+            (items[0].innerBlocks?.[0].attributes as Record<string, unknown>)?._resolvedTitle
         ).toBe('A');
         expect(
-            (innerBlocks[1].innerBlocks?.[0].attributes as Record<string, unknown>)?._resolvedTitle
+            (items[1].innerBlocks?.[0].attributes as Record<string, unknown>)?._resolvedTitle
         ).toBe('B');
     });
 
@@ -90,7 +96,7 @@ describe('inlineQueries', () => {
         ];
 
         const result = inlineQueries(tree, { queries });
-        const stamped = result[0].innerBlocks?.[0].innerBlocks ?? [];
+        const stamped = result[0].innerBlocks?.[0].innerBlocks?.[0].innerBlocks ?? [];
 
         expect((stamped[0].attributes as Record<string, unknown>)._resolvedTitle).toBe('Post');
         expect((stamped[1].attributes as Record<string, unknown>)._resolvedExcerpt).toBe('Excerpt');
@@ -121,7 +127,7 @@ describe('inlineQueries', () => {
 
         const result = inlineQueries(tree as Block[], { queries });
         const innerQuery = result[0].innerBlocks?.[0];
-        const stamped = innerQuery?.innerBlocks?.[0]?.innerBlocks?.[0];
+        const stamped = innerQuery?.innerBlocks?.[0]?.innerBlocks?.[0]?.innerBlocks?.[0];
 
         expect(innerQuery?.name).toBe('core/query');
         expect((stamped?.attributes as Record<string, unknown>)?._resolvedTitle).toBe('Inner');
@@ -143,7 +149,7 @@ describe('inlineQueries', () => {
         ];
 
         const result = inlineQueries(tree, { queries });
-        const stamped = result[0].innerBlocks?.[0].innerBlocks?.[0];
+        const stamped = result[0].innerBlocks?.[0].innerBlocks?.[0].innerBlocks?.[0];
 
         expect((stamped?.attributes as Record<string, unknown>)?._resolvedTitle).toBe(
             'Host override'

--- a/resources/js/visual-editor/blocks/query/edit.tsx
+++ b/resources/js/visual-editor/blocks/query/edit.tsx
@@ -37,6 +37,17 @@ interface QueryEditProps {
     clientId: string;
 }
 
+// Seed every newly-inserted query with a post-template child so the saved
+// tree has the structure the inliner expects (one post-template wrapping
+// N post-template-item clones). Without this, users can add per-post
+// blocks directly inside the query and the inliner falls back to a flat
+// expansion that skips the semantic <ul>/<li> wrapping. The InnerBlocks
+// `template` only applies on first mount, so it does not overwrite an
+// existing user-arranged tree.
+const DEFAULT_TEMPLATE: ReadonlyArray<[ string ]> = [
+    [ 'artisanpack/post-template' ],
+];
+
 function getQuery( attributes: Record<string, unknown> ): Record<string, unknown> {
     if (
         attributes.query !== null &&
@@ -169,7 +180,7 @@ export default function QueryEdit( {
             </InspectorControls>
             <PreviewBanner preview={ preview } />
             <BlockContextProvider value={ blockContext }>
-                <InnerBlocks />
+                <InnerBlocks template={ [ ...DEFAULT_TEMPLATE ] } />
             </BlockContextProvider>
         </div>
     );

--- a/src/Resources/QueryInliner.php
+++ b/src/Resources/QueryInliner.php
@@ -176,8 +176,12 @@ class QueryInliner
 		}
 
 		// Expand: clone the iteration template once per result, stamp
-		// _resolved* attributes, and wrap each iteration in an <li>
-		// block with post-specific classes.
+		// _resolved* attributes, and wrap each iteration in a synthetic
+		// `core/post-template-item` block. The renderers turn that into
+		// an `<li>` so the parent `core/post-template` emits a single
+		// `<ul>` containing N `<li>` items — matching upstream
+		// Gutenberg's `<ul><li>...</li></ul>` shape rather than N
+		// single-item lists.
 		$expandedIterations = [];
 
 		foreach ( $results as $post ) {
@@ -200,8 +204,8 @@ class QueryInliner
 			}
 
 			$expandedIterations[] = [
-				'clientId'    => 'qi-' . $postId,
-				'name'        => '_query-iteration',
+				'clientId'    => 'pti-' . $postId,
+				'name'        => 'core/post-template-item',
 				'attributes'  => [
 					'postId'    => $postId,
 					'className' => 'post-' . $postId

--- a/tests/Unit/VisualEditor/Resources/QueryInlinerTest.php
+++ b/tests/Unit/VisualEditor/Resources/QueryInlinerTest.php
@@ -44,7 +44,7 @@ beforeEach( function (): void {
 	$this->inliner = new QueryInliner( $this->app, new PostResolver() );
 } );
 
-it( 'expands core/query into one post-template instance per result', function () {
+it( 'expands core/query into one post-template wrapping N post-template-item blocks', function () {
 	$this->fake->setItems( [ postFixture( 1, 'First' ), postFixture( 2, 'Second' ) ] );
 
 	$tree = [ makeQueryBlock( [
@@ -56,14 +56,17 @@ it( 'expands core/query into one post-template instance per result', function ()
 	$query = $inlined[0];
 
 	// The query keeps one post-template child; its innerBlocks hold
-	// one _query-iteration per result, each wrapping the stamped template.
+	// one core/post-template-item per result, each wrapping the
+	// stamped template. The synthetic item blocks render as `<li>` so
+	// the parent post-template emits a single `<ul>` with N items.
 	$postTemplate = $query['innerBlocks'][0];
 
 	expect( $query['name'] )->toBe( 'core/query' )
 		->and( count( $query['innerBlocks'] ) )->toBe( 1 )
 		->and( $postTemplate['name'] )->toBe( 'core/post-template' )
 		->and( count( $postTemplate['innerBlocks'] ) )->toBe( 2 )
-		->and( $postTemplate['innerBlocks'][0]['name'] )->toBe( '_query-iteration' )
+		->and( $postTemplate['innerBlocks'][0]['name'] )->toBe( 'core/post-template-item' )
+		->and( $postTemplate['innerBlocks'][1]['name'] )->toBe( 'core/post-template-item' )
 		->and( $postTemplate['innerBlocks'][0]['innerBlocks'][0]['attributes']['_resolvedTitle'] )->toBe( 'First' )
 		->and( $postTemplate['innerBlocks'][1]['innerBlocks'][0]['attributes']['_resolvedTitle'] )->toBe( 'Second' );
 } );
@@ -168,7 +171,7 @@ it( 'deep-clones the template subtree per result so mutations do not leak', func
 
 	$inlined = $this->inliner->inline( $tree );
 
-	// Post-template → _query-iteration[0] → post-title, iteration[1] → post-title.
+	// Post-template → core/post-template-item[0] → post-title, item[1] → post-title.
 	$postTemplate = $inlined[0]['innerBlocks'][0];
 	$first  = $postTemplate['innerBlocks'][0]['innerBlocks'][0];
 	$second = $postTemplate['innerBlocks'][1]['innerBlocks'][0];


### PR DESCRIPTION
## Description

Refactors the `core/query` inliner so its expanded output is one
`core/post-template` (rendered as `<ul>`) wrapping N synthetic
`core/post-template-item` blocks (each rendered as `<li>`). The result
matches upstream Gutenberg's `<ul><li>...</li></ul>` shape rather than
N standalone single-item lists.

**Closes:** #428

## Type of Change

- [x] Enhancement (improves existing functionality)

## Related Issue

**Issue:** #428

## Motivation and Context

G4c-2 (#402) shipped `core/query` rendering with a known V1 limitation
documented in `docs/block-library-audit.md`: the inliner produced one
`core/post-template` clone per result, each rendering as a standalone
`<ul class="wp-block-post-template">`. Browsers rendered this as N
single-item lists rather than one N-item list — visually correct but
semantically a list of single-item lists rather than upstream
Gutenberg's shape.

This PR ships the deferred follow-up. Benefits:

- Assistive tech and document-outline tooling now see one list of N
  items rather than N lists of one item.
- Host CSS that targets `.wp-block-post-template > li` (a common
  pattern) starts working without host-side overrides.
- Removes the "Known V1 limitation" caveat from the audit doc.

## Changes Made

- **Inliner (PHP)**: `src/Resources/QueryInliner.php` now emits one
  `core/post-template` wrapping N `core/post-template-item` blocks
  (renamed from the prior `_query-iteration` synthetic name).
- **React inliner**: `packages/visual-editor-renderer-react/src/queries.ts`
  rewritten to mirror the PHP shape — locates the post-template child,
  wraps iterations in `core/post-template-item`, handles both
  `core/query` and `artisanpack/query` namespaces. `ResolvedPost`
  gains optional `type` / `status` fields so iteration classes match
  server output.
- **Vue inliner**: same change in
  `packages/visual-editor-renderer-vue/src/queries.ts`.
- **Blade renderer**: new partial
  `packages/visual-editor-renderer-blade/resources/views/blocks/core/post-template-item.blade.php`
  emitting `<li class="wp-block-post-template-item …">`. Dropped the
  hardcoded `_query-iteration` branch from `BlockRenderer.php`.
- **React renderer**: renamed `QueryIterationBlock` →
  `PostTemplateItemBlock`, registered `core/post-template-item`.
- **Vue renderer**: same.
- **Editor**: `resources/js/visual-editor/blocks/query/edit.tsx` seeds
  every new query block with an `artisanpack/post-template` child so
  the saved tree has the structure the inliner expects (the
  no-template fallback path otherwise produces flat, non-semantic
  markup).
- **Tests** updated for the new nesting depth across PHP, React, Vue,
  and the Blade feature test; the Blade test now asserts exactly one
  `<ul>` and two `<li>` for a two-result case.
- **Renderer parity**: `packages/renderer-parity.json` registers the
  new block name across all three renderers.
- **Audit doc**: removed the V1 limitation subsection.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (Darwin 25.5.0)
- PHP Version: 8.4
- Project Version: 1.0 release branch

**Tests Performed:**
1. `./vendor/bin/pest` — **674 tests / 1953 assertions passing**.
2. `npm test` — **204 test files / 1468 tests passing**.
3. `npm run verify:parity` — all 89 blocks registered across blade,
   react, and vue.
4. Manual end-to-end test in `jmwd-keystone-cms` (which symlinks this
   package): added a Query Loop block via the editor, confirmed the
   default `Post Template` is auto-inserted, published, and verified
   the rendered HTML on the public page is a single `<ul
   class="wp-block-post-template">` wrapping two `<li
   class="wp-block-post-template-item …">` items.

## Accessibility Tests Run

- [x] Semantic markup verified — single N-item list now matches what
      screen readers and document-outline tooling expect.

**Details:** The whole point of this refactor is the a11y benefit.
Document-outline tooling and screen readers previously saw N
single-item lists; they now see one N-item list as upstream Gutenberg
produces.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:** Updated `QueryInlinerTest.php`, the React/Vue
`queries.test.ts`, and tightened `CoreQueryRenderingTest.php` to
assert exactly one `<ul>` and N `<li>` items for the multi-result case.

## Documentation

- [x] Inline code documentation added
- [x] Other: removed V1 limitation note from
      `docs/block-library-audit.md`.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added multiple new planning/specs for responsive tools, state tools, animations, border gradients, and several block-visibility features; removed a legacy Query-loop limitation note.

* **User-facing Improvements**
  * Query output now renders as a single semantic post list (one <ul> with per-post <li> items).
  * New queries insert a post-template wrapper by default.
  * Per-item IDs and CSS class names are more accurate and consistent across renderers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArtisanPack-UI/visual-editor/pull/505?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->