### PR TITLE
feat: responsive design tools — per-breakpoint styles & settings (#487)

### DIFF
--- a/config/visual-editor.php
+++ b/config/visual-editor.php
@@ -243,6 +243,37 @@ return [
 
 	/*
 	|--------------------------------------------------------------------------
+	| Breakpoints (#487)
+	|--------------------------------------------------------------------------
+	|
+	| Named breakpoints the editor's viewport switcher and the responsive
+	| value resolver use. Resolved in priority order:
+	|
+	|   1. Active theme's `theme.json` → `settings.custom.artisanpack.breakpoints`
+	|   2. This config array (host-app overrides)
+	|   3. `BreakpointRegistry::DEFAULTS` (Tailwind v4 mins)
+	|
+	| Merging is by key, so an entry here for `sm` resizes the default
+	| `sm` breakpoint without affecting the others; a new key like `3xl`
+	| adds a breakpoint. Values may be integer pixels (`640`) or CSS
+	| length strings (`'640px'`). Validation runs at registry-build time
+	| and throws on bad input — see `BreakpointRegistry::validate()`.
+	|
+	| The implicit `base` slot (no min-width, applies everywhere) is
+	| reserved and cannot be redefined here.
+	|
+	*/
+
+	'breakpoints' => [
+		// 'sm'  => '640px',
+		// 'md'  => '768px',
+		// 'lg'  => '1024px',
+		// 'xl'  => '1280px',
+		// '2xl' => '1536px',
+	],
+
+	/*
+	|--------------------------------------------------------------------------
 	| Site editor (H5)
 	|--------------------------------------------------------------------------
 	|

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -63,3 +63,15 @@ Canonical fixtures ship under the package's
 distributed composer tarball via `.gitattributes`). Host apps that
 want to vendor their own can copy the tree into, for example,
 `database/seeders/fixtures/visual-editor/` and point `--path` at it.
+
+## Breakpoints (#487)
+
+The editor reads its registered breakpoints from the same hierarchy
+documented in [`theming.md`](theming.md#breakpoints-487): theme.json →
+config → package defaults. The JS bootstrap snapshot exposes the
+resolved registry on `window.artisanpackVisualEditor.settings`, and
+block edit components hydrate a client-side `BreakpointRegistry`
+through `registryFromSnapshot()`.
+
+See [`responsive-design-tools.md`](responsive-design-tools.md) for the
+editor + developer workflow.

--- a/docs/responsive-design-tools.md
+++ b/docs/responsive-design-tools.md
@@ -185,7 +185,7 @@ $result = $resolver->emit(
 // $result['css']   → '' (every value tokenized)
 ```
 
-When the value can't be tokenized, the resolver falls back to a generated wrapper class plus a scoped `<style>` block:
+When the value can't be tokenized, the resolver falls back to a generated wrapper class plus the scoped CSS rules:
 
 ```php
 $result = $resolver->emit(
@@ -198,7 +198,7 @@ $result = $resolver->emit(
 // $result['css']   → '.ve-r-abcd123456{font-size:13px}@media (min-width:768px){.ve-r-abcd123456{font-size:18px}}'
 ```
 
-Block partials merge `$result['class']` into the wrapper class list and accumulate `$result['css']` into a single per-block `<style>` block.
+Block partials merge `$result['class']` into the wrapper class list and push `$result['css']` into the request-scoped `ResponsiveCssAccumulator`. The `<x-ve-blocks>` and `<x-ve-template>` components drain the accumulator at the top of the render output and emit one consolidated `<style data-ve-responsive>` block — there is no per-block `<style>` tag interleaved with the wrapper's children. Duplicate payloads (the same overrides on N siblings) collapse to one rule set, keyed by scope class.
 
 ### 2.6 Lazy migration
 

--- a/docs/responsive-design-tools.md
+++ b/docs/responsive-design-tools.md
@@ -1,0 +1,241 @@
+# Responsive Design Tools
+
+**Status:** v1.0
+**Plan:** [`plans/17-responsive-design-tools.md`](plans/17-responsive-design-tools.md)
+**Issue:** #487
+
+The editor lets editors and developers author per-breakpoint style and structural overrides without hand-editing CSS. The same registry that drives the editor UI also drives the server-side renderer, so previews match production exactly.
+
+This document covers both the editor-facing workflow and the developer integration surface. See also:
+
+- [`theming.md`](theming.md) — for the breakpoint registry hierarchy (where overrides live).
+- [`dev-setup.md`](dev-setup.md) — for the JS bootstrap snapshot the editor consumes.
+
+---
+
+## 1. For editors
+
+### 1.1 The viewport switcher
+
+The editor toolbar shows one button per registered breakpoint, plus an `All` button on the left for the unprefixed base value:
+
+```
+[ All ] [ Mobile ] [ Tablet ] [ Desktop ] [ Wide ] [ Full ]
+```
+
+Selecting a button does two things:
+
+1. **Resizes the canvas** to the breakpoint's min-width so you can preview the layout at that size.
+2. **Scopes the next style edit** to that breakpoint. Any Inspector control that supports responsive overrides records your change at the active breakpoint.
+
+The `All` button writes to the unprefixed base value — the value that applies everywhere unless a larger breakpoint overrides it.
+
+### 1.2 Setting a per-breakpoint override
+
+1. Select the block you want to customize.
+2. Click the viewport switcher button for the breakpoint you want to target (e.g. **Mobile**).
+3. Adjust the control (padding, font size, column count, alignment, …) in the Inspector.
+
+The value you just set applies at that breakpoint and up, until another override at a larger breakpoint replaces it.
+
+### 1.3 Resetting an override
+
+Each per-breakpoint control surfaces a **Reset to base** button when an override is currently set at the active breakpoint. Clicking it removes that single override and lets the value cascade through from the next-smaller defined slot.
+
+If clearing the override leaves no other overrides, the stored attribute collapses back to the simple scalar form — no extra JSON on disk.
+
+### 1.4 Mobile-first cascade
+
+The cascade is always mobile-first:
+
+- `base` applies everywhere unless overridden.
+- A value set at `md` applies at `md` (≥768px) and up, unless `lg`, `xl`, or `2xl` overrides it.
+- A value set at `lg` does **not** affect `sm` or `md` — those continue to inherit `base` (or whatever smaller breakpoint was set).
+
+This mirrors the way Tailwind's `sm:` / `md:` modifiers work in CSS.
+
+---
+
+## 2. For developers
+
+### 2.1 Configuring breakpoints
+
+Breakpoints resolve in priority order — highest layer wins on key collision:
+
+1. **Active theme's `theme.json`** — `settings.custom.artisanpack.breakpoints`
+2. **Application config** — `artisanpack.visual-editor.breakpoints`
+3. **Package defaults** — `BreakpointRegistry::DEFAULTS` (Tailwind v4 mins)
+
+#### Config example
+
+```php
+// config/artisanpack/visual-editor.php
+return [
+    'breakpoints' => [
+        // Resize the default `lg` breakpoint:
+        'lg'  => '1100px',
+        // Add a new `3xl` breakpoint:
+        '3xl' => 1920,
+    ],
+];
+```
+
+#### theme.json example
+
+```json
+{
+    "settings": {
+        "custom": {
+            "artisanpack": {
+                "breakpoints": {
+                    "lg":  "1200px",
+                    "3xl": 1920
+                }
+            }
+        }
+    }
+}
+```
+
+Values may be integer pixels (`640`) or CSS-length strings (`'640px'`). Other lengths (`rem`, `vw`, …) are rejected at load time with a descriptive error.
+
+The implicit `base` slot (no min-width, applies everywhere) is reserved — using it as a key throws.
+
+### 2.2 Opting a block into responsive support
+
+Add `supports.artisanpackResponsive` to the block's `block.json`. List the attribute paths that should expose per-breakpoint UI:
+
+```jsonc
+{
+    "name": "artisanpack/columns",
+    "supports": {
+        "artisanpackResponsive": {
+            "attributes": [
+                "spacing",
+                "align",
+                "columns.count"
+            ]
+        }
+    }
+}
+```
+
+Out of the box the following forked layout blocks opt in: `group`, `columns`, `column`, `buttons`, `spacer`, `cover`, `media-text`. Blocks that don't opt in still render correctly — their Inspector simply shows the single-value control as today.
+
+### 2.3 Reading a responsive attribute in a block's edit component
+
+```tsx
+import { useResponsiveValue, registryFromSnapshot } from '@artisanpack-ui/visual-editor/responsive'
+
+// `bootstrap.breakpoints` comes from the editor's PHP-stamped settings.
+const registry = registryFromSnapshot( bootstrap.breakpoints )
+
+export function Edit( { attributes }: BlockEditProps ) {
+    const padding = useResponsiveValue<string>( attributes.padding, registry )
+
+    return <div style={ { padding: padding ?? '0' } }>…</div>
+}
+```
+
+`useResponsiveValue` re-renders the component every time the editor switches breakpoints, so the preview stays in sync without manual subscriptions.
+
+### 2.4 Writing per-breakpoint values from an InspectorControl
+
+Wrap the underlying primitive in `ResponsiveControl`. The wrapper handles promotion (scalar → discriminated form) and reset-to-base for you:
+
+```tsx
+import { ResponsiveControl } from '@artisanpack-ui/visual-editor/responsive'
+
+<ResponsiveControl
+    registry={ registry }
+    value={ attributes.padding }
+    onChange={ ( next ) => setAttributes( { padding: next } ) }
+    label="Padding"
+    render={ ( { value, setValue } ) => (
+        <RangeControl
+            value={ value ?? 0 }
+            onChange={ ( v ) => setValue( v ) }
+            min={ 0 }
+            max={ 80 }
+        />
+    ) }
+/>
+```
+
+### 2.5 Server-side rendering
+
+The Blade renderer's `ResponsiveClassResolver` emits the correct class string or `@media` rule for any responsive attribute. Pass a token map when the values can be expressed as Tailwind utilities:
+
+```php
+use ArtisanPackUI\VisualEditorRendererBlade\Responsive\ResponsiveClassResolver;
+
+$resolver = app( ResponsiveClassResolver::class );
+
+$result = $resolver->emit(
+    $attribute,            // [ 'base' => 3, 'sm' => 1, 'md' => 2 ]
+    'grid-template-columns',
+    [
+        '1' => 'grid-cols-1',
+        '2' => 'grid-cols-2',
+        '3' => 'grid-cols-3',
+    ],
+);
+
+// $result['class'] → 'grid-cols-3 sm:grid-cols-1 md:grid-cols-2'
+// $result['css']   → '' (every value tokenized)
+```
+
+When the value can't be tokenized, the resolver falls back to a generated wrapper class plus a scoped `<style>` block:
+
+```php
+$result = $resolver->emit(
+    [ 'base' => '13px', 'md' => '18px' ],
+    'font-size',
+    [], // no token map
+);
+
+// $result['class'] → 've-r-abcd123456'
+// $result['css']   → '.ve-r-abcd123456{font-size:13px}@media (min-width:768px){.ve-r-abcd123456{font-size:18px}}'
+```
+
+Block partials merge `$result['class']` into the wrapper class list and accumulate `$result['css']` into a single per-block `<style>` block.
+
+### 2.6 Lazy migration
+
+Scalar values are first-class — they load without error and only inflate to the discriminated `{ base, sm, … }` form the first time an editor sets a per-breakpoint override. There is no batch migration; existing content keeps working.
+
+When every override is cleared back to inheriting the base, the storage collapses back to the scalar form so saved JSON stays compact.
+
+### 2.7 Auditing orphaned overrides
+
+When a theme or config removes a breakpoint that was previously in use, the values stored under that key are preserved on save but skipped at render time. Use the audit command to surface them:
+
+```bash
+php artisan visual-editor:audit-breakpoints
+```
+
+Sample output:
+
+```
++-------------+-----------+------------------------------------------+
+| Resource    | Record ID | Orphaned overrides                       |
++-------------+-----------+------------------------------------------+
+| pages       | 42        | artisanpack/columns@spacing → [legacy]   |
++-------------+-----------+------------------------------------------+
+Audited 17 record(s). 1 record(s) carry orphaned overrides.
+```
+
+Flags:
+
+- `--resource=<slug>` — limit the audit to a single resource from `artisanpack.visual-editor.resources`.
+- `--json` — emit a machine-readable report for CI.
+
+---
+
+## 3. What's out of scope (v1.0)
+
+- **Container queries** — deferred to v1.x.
+- **Per-breakpoint visibility** — handled by [`21-block-visibility-contextual.md`](plans/21-block-visibility-contextual.md).
+- **Per-breakpoint state styles** — future composition with [`18-state-design-tools.md`](plans/18-state-design-tools.md).
+- **Desktop-first or independent (non-cascading) modes** — mobile-first only.
+- **Bulk migration of existing scalar attributes** — lazy promotion only.

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -148,3 +148,26 @@ pragmatic answer is:
 - **Popovers from `@wordpress/components`.** Their shadow and border
   radius are tokenized; their default background is `#fff` hardcoded in
   some cases. Monitor on upgrade; file a follow-up if it regresses.
+
+## Breakpoints (#487)
+
+The editor's viewport switcher and the responsive value resolver share
+a single registry resolved in this order — highest layer wins:
+
+1. **Active theme's `theme.json`** —
+   `settings.custom.artisanpack.breakpoints`
+2. **Application config** —
+   `config('artisanpack.visual-editor.breakpoints')`
+3. **Package defaults** — `BreakpointRegistry::DEFAULTS`
+   (Tailwind v4: `sm 640`, `md 768`, `lg 1024`, `xl 1280`, `2xl 1536`)
+
+Merging is by key, so a theme can resize an existing breakpoint
+(`"lg": "1100px"`), add a new one (`"3xl": 1920`), or replace defaults
+wholesale. Values are integer pixels or CSS `Npx` strings; anything
+else throws a descriptive error at load time.
+
+The implicit `base` slot (no min-width, applies everywhere) is
+reserved and cannot be redefined.
+
+See [`responsive-design-tools.md`](responsive-design-tools.md) for the
+editor + developer workflow built on top of this registry.

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/core/column.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/core/column.blade.php
@@ -126,7 +126,10 @@
 	}
 
 	if ( [] !== $responsiveWidths ) {
-		$widthRegistry = BreakpointRegistry::fromLayers();
+		// Use the request-scoped registry from the container so
+		// host-configured breakpoints are respected — see the matching
+		// comment in columns.blade.php for the full rationale.
+		$widthRegistry = app( BreakpointRegistry::class );
 		$widthScope    = 've-w-' . substr( hash( 'xxh3', (string) json_encode( $responsiveWidths ) ), 0, 10 );
 		$widthRules    = [];
 		// Triple-class selector matches the (0,0,3,0) specificity of

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/core/column.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/core/column.blade.php
@@ -1,4 +1,5 @@
 @php
+	use ArtisanPackUI\VisualEditor\Responsive\BreakpointRegistry;
 	use ArtisanPackUI\VisualEditorRendererBlade\Support\BlockSupports;
 
 	$baseClasses = [ 'wp-block-column' ];
@@ -16,21 +17,168 @@
 	$classes  = array_values( array_unique( array_merge( $baseClasses, $compiled['classes'] ) ) );
 	$styles   = '' !== $compiled['style'] ? rtrim( $compiled['style'], ';' ) : '';
 
-	if ( ! empty( $attributes['width'] ) ) {
-		$width = $attributes['width'];
+	// Normalize a width attribute into a `flex-basis` value. Returns
+	// `{ basis, percent }` — `basis` is the CSS expression to plug into
+	// `flex-basis:`; `percent` is the numeric percent when the value is
+	// a percentage (used downstream to subtract the parent's block-gap
+	// from the basis), or `null` for absolute units (`100px`, `20em`).
+	$normalizeBasis = static function ( $value ): array {
+		if ( is_numeric( $value ) ) {
+			$percent   = (float) $value;
+			$formatted = rtrim( rtrim( sprintf( '%F', $percent ), '0' ), '.' );
 
-		if ( is_numeric( $width ) ) {
-			$formatted = rtrim( rtrim( sprintf( '%F', (float) $width ), '0' ), '.' );
-			$basis     = ( '' === $formatted ? '0' : $formatted ) . '%';
-		} else {
-			$basis = (string) $width;
+			return [
+				'basis'   => ( '' === $formatted ? '0' : $formatted ) . '%',
+				'percent' => $percent,
+			];
 		}
 
-		$styles = ( '' !== $styles ? $styles . '; ' : '' ) . 'flex-basis: ' . $basis;
+		$string = (string) $value;
+
+		if ( 1 === preg_match( '/^(\d+(?:\.\d+)?)\s*%$/', $string, $matches ) ) {
+			return [
+				'basis'   => $string,
+				'percent' => (float) $matches[1],
+			];
+		}
+
+		return [
+			'basis'   => $string,
+			'percent' => null,
+		];
+	};
+
+	// For percentage widths, subtract the parent's block-gap from the
+	// basis using the same `calc(X% - var(--wp--style--block-gap, ...) * factor)`
+	// pattern WP uses for `wp-block-button.is-width-{N}` widths (see
+	// `wp-block-library/style.css` lines 250-259). Without this, a
+	// theme that sets `gap` on `.wp-block-columns` pushes
+	// `50% + gap + 50%` past `100%` and the second column wraps to
+	// a new line — visually identical to the stacking the WP mobile
+	// rule produces.
+	$basisExpr = static function ( array $normalized ) {
+		if ( null === $normalized['percent'] ) {
+			return $normalized['basis'];
+		}
+
+		$factor          = ( 100.0 - $normalized['percent'] ) / 100.0;
+		$formattedFactor = rtrim( rtrim( sprintf( '%F', $factor ), '0' ), '.' );
+
+		if ( '' === $formattedFactor || '0' === $formattedFactor ) {
+			return $normalized['basis'];
+		}
+
+		return sprintf(
+			'calc(%s - var(--wp--style--block-gap, 0.5em) * %s)',
+			$normalized['basis'],
+			$formattedFactor
+		);
+	};
+
+	if ( ! empty( $attributes['width'] ) ) {
+		$styles = ( '' !== $styles ? $styles . '; ' : '' ) . 'flex-basis: ' . $normalizeBasis( $attributes['width'] )['basis'];
 	}
 
 	$styleAttr = '' !== $styles ? sprintf( ' style="%s"', e( $styles . ';' ) ) : '';
 	$idAttr    = null !== $compiled['id'] ? sprintf( ' id="%s"', e( $compiled['id'] ) ) : '';
+
+	// #487 — column-specific responsive width.
+	//
+	// The column attribute `width` translates to `flex-basis` (not
+	// `width`) so it can fight WP core's
+	// `.wp-block-columns:not(.is-not-stacked-on-mobile) > .wp-block-column { flex-basis: 100% !important }`
+	// stacking rule. The generic responsive emitter in BlockSupports
+	// stays out of this path; emitting `width: X !important` wouldn't
+	// help — the WP rule writes `flex-basis` directly.
+	//
+	// Two width sources merge here:
+	//
+	//  - `attributes.width` (the legacy scalar that the editor's HOC
+	//    leaves alone at the `base` breakpoint — mobile-first cascade
+	//    treats base as the unprefixed default, so it skips routing
+	//    through `responsive.width`). Without promoting it into a
+	//    class rule, the inline `style="flex-basis: 50%"` loses on
+	//    specificity to WP's `!important` stacking rule on every
+	//    viewport below 782px.
+	//
+	//  - `attributes.responsive.width.{sm,md,lg,…}` — explicit
+	//    per-breakpoint overrides written through the HOC.
+	//
+	// We treat the legacy width as the implicit `base` entry and
+	// merge it with the responsive overrides. The combined map
+	// emits one rule per breakpoint with `flex-basis` AND
+	// `flex-grow: 0` — both `!important`. `flex-grow: 0` matches WP's
+	// own behavior for columns with explicit widths (otherwise
+	// `flex-grow: 1` lets the column expand past the intended size on
+	// rows with leftover space).
+	$responsiveWidths = $attributes['responsive']['width'] ?? [];
+
+	if ( ! is_array( $responsiveWidths ) ) {
+		$responsiveWidths = [];
+	}
+
+	// Promote the legacy `width` attribute into the `base` slot when
+	// the editor hasn't already written a base override through the
+	// HOC. The HOC writes responsive overrides ONLY at non-base
+	// breakpoints, so this branch picks up the "All sizes" value.
+	if ( ! empty( $attributes['width'] ) && ! isset( $responsiveWidths['base'] ) ) {
+		$responsiveWidths = [ 'base' => $attributes['width'] ] + $responsiveWidths;
+	}
+
+	if ( [] !== $responsiveWidths ) {
+		$widthRegistry = BreakpointRegistry::fromLayers();
+		$widthScope    = 've-w-' . substr( hash( 'xxh3', (string) json_encode( $responsiveWidths ) ), 0, 10 );
+		$widthRules    = [];
+		// Triple-class selector matches the (0,0,3,0) specificity of
+		// the WP stacking rule. Combined with `!important` on both
+		// sides and source-order tiebreak (our consolidated style
+		// block emits in `<body>` after every external stylesheet),
+		// our rule wins the cascade.
+		$widthSelector = sprintf( '.%1$s.%1$s.%1$s', $widthScope );
+
+		foreach ( $responsiveWidths as $bp => $value ) {
+			if ( null === $value || '' === $value ) {
+				continue;
+			}
+
+			$declaration = sprintf(
+				'flex-basis:%s!important;flex-grow:0!important',
+				$basisExpr( $normalizeBasis( $value ) )
+			);
+
+			if ( BreakpointRegistry::BASE_KEY === $bp ) {
+				$widthRules[] = sprintf( '%s{%s}', $widthSelector, $declaration );
+				continue;
+			}
+
+			$minWidth = $widthRegistry->get( (string) $bp );
+			if ( null === $minWidth ) {
+				continue;
+			}
+
+			$widthRules[] = sprintf(
+				'@media (min-width:%dpx){%s{%s}}',
+				$minWidth,
+				$widthSelector,
+				$declaration
+			);
+		}
+
+		if ( [] !== $widthRules ) {
+			// Only attach the scope class to the wrapper once we
+			// know the rules survived (every override might have
+			// been filtered out as orphan breakpoints). An orphan
+			// class on the wrapper would leak `ve-w-…` into the
+			// markup without a corresponding rule in the
+			// consolidated style block.
+			$classes[] = $widthScope;
+
+			// #509 — push into the per-request accumulator (see
+			// columns.blade.php / BlockSupports::pushResponsive for
+			// rationale).
+			BlockSupports::pushResponsive( $widthScope, implode( '', $widthRules ) );
+		}
+	}
 @endphp
 <div class="{{ implode( ' ', $classes ) }}"{!! $styleAttr !!}{!! $idAttr !!}>
 	{!! $innerBlocksHtml !!}

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/core/columns.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/core/columns.blade.php
@@ -1,4 +1,5 @@
 @php
+	use ArtisanPackUI\VisualEditor\Responsive\BreakpointRegistry;
 	use ArtisanPackUI\VisualEditorRendererBlade\Support\BlockSupports;
 
 	$baseClasses = [ 'wp-block-columns' ];
@@ -9,6 +10,73 @@
 
 	if ( ! empty( $attributes['verticalAlignment'] ) ) {
 		$baseClasses[] = 'are-vertically-aligned-' . $attributes['verticalAlignment'];
+	}
+
+	// #487 — columns-specific responsive layout. `columnCount` overrides
+	// translate to per-breakpoint `grid-template-columns` rules. The
+	// generic responsive emitter in BlockSupports handles
+	// padding/margin/border/etc.; the columns block declares its own
+	// layout-specific path here.
+	$columnCountOverrides = $attributes['responsive']['columnCount'] ?? null;
+
+	if ( is_array( $columnCountOverrides ) && [] !== $columnCountOverrides ) {
+		$columnsRegistry = BreakpointRegistry::fromLayers();
+		$columnsScope    = 've-cols-' . substr( hash( 'xxh3', (string) json_encode( $columnCountOverrides ) ), 0, 10 );
+		$columnsRules    = [];
+
+		// Tripled scope class matches BlockSupports::compileResponsive()
+		// — boosts specificity to (0,0,3,0) so the grid rule beats
+		// WP core's `.wp-block-columns:not(.is-not-stacked-on-mobile) > .wp-block-column { flex-basis: 100% !important }`
+		// stacking rule that would otherwise force every column to
+		// full-width at small viewports.
+		$columnsSelector = sprintf( '.%1$s.%1$s.%1$s', $columnsScope );
+
+		foreach ( $columnCountOverrides as $bp => $count ) {
+			$intCount = (int) $count;
+
+			if ( $intCount < 1 ) {
+				continue;
+			}
+
+			$declarations = sprintf(
+				'display:grid!important;grid-template-columns:repeat(%d,minmax(0,1fr))!important',
+				$intCount
+			);
+
+			if ( BreakpointRegistry::BASE_KEY === $bp ) {
+				$columnsRules[] = sprintf( '%s{%s}', $columnsSelector, $declarations );
+				continue;
+			}
+
+			$minWidth = $columnsRegistry->get( (string) $bp );
+			if ( null === $minWidth ) {
+				continue;
+			}
+
+			$columnsRules[] = sprintf(
+				'@media (min-width:%dpx){%s{%s}}',
+				$minWidth,
+				$columnsSelector,
+				$declarations
+			);
+		}
+
+		if ( [] !== $columnsRules ) {
+			// Only attach the scope class once we know the rules
+			// survived (every override might have been filtered out
+			// as orphan breakpoints) — an orphan class on the
+			// wrapper would leak `ve-cols-…` into the markup without
+			// a corresponding rule in the consolidated style block.
+			$baseClasses[] = $columnsScope;
+
+			// #509 — push into the per-request accumulator instead of
+			// inlining a `<style>` tag here. The `<x-ve-blocks>` /
+			// `<x-ve-template>` components drain the accumulator into
+			// one consolidated `<style data-ve-responsive>` block at
+			// the top of the render output, keeping the flex
+			// container free of interleaved style elements.
+			BlockSupports::pushResponsive( $columnsScope, implode( '', $columnsRules ) );
+		}
 	}
 @endphp
 <div{!! BlockSupports::wrapperAttrs( $attributes, $baseClasses ) !!}>

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/core/columns.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/core/columns.blade.php
@@ -20,7 +20,14 @@
 	$columnCountOverrides = $attributes['responsive']['columnCount'] ?? null;
 
 	if ( is_array( $columnCountOverrides ) && [] !== $columnCountOverrides ) {
-		$columnsRegistry = BreakpointRegistry::fromLayers();
+		// Pull the request-scoped registry from the container so
+		// host-configured breakpoints (theme.json + config) are
+		// respected. `fromLayers()` without arguments would silently
+		// return only the Tailwind defaults — any custom key (e.g.
+		// `3xl`) would resolve to `null` here and the override would
+		// be skipped at render even though it's persisted in the
+		// block tree.
+		$columnsRegistry = app( BreakpointRegistry::class );
 		$columnsScope    = 've-cols-' . substr( hash( 'xxh3', (string) json_encode( $columnCountOverrides ) ), 0, 10 );
 		$columnsRules    = [];
 

--- a/packages/visual-editor-renderer-blade/resources/views/components/blocks.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/components/blocks.blade.php
@@ -3,4 +3,9 @@
 <style data-ve-global-styles>{!! $globalStylesCss !!}</style>
 @endif
 @endisset
+@isset( $responsiveCss )
+@if( '' !== $responsiveCss )
+{!! $responsiveCss !!}
+@endif
+@endisset
 {!! $html !!}

--- a/packages/visual-editor-renderer-blade/resources/views/components/template.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/components/template.blade.php
@@ -10,6 +10,11 @@
 <style data-ve-global-styles>{!! $globalStylesCss !!}</style>
 @endif
 @endisset
+@isset( $responsiveCss )
+@if( '' !== $responsiveCss )
+{!! $responsiveCss !!}
+@endif
+@endisset
 <div class="{{ implode( ' ', $wrapperClasses ) }}" data-ve-template="{{ $slug }}"@if( null !== $matchedSlug && $matchedSlug !== $slug ) data-ve-matched-template="{{ $matchedSlug }}"@endif>
 @if( null !== $resolutionError )
 @if( $inDev )

--- a/packages/visual-editor-renderer-blade/src/Responsive/ResponsiveClassResolver.php
+++ b/packages/visual-editor-renderer-blade/src/Responsive/ResponsiveClassResolver.php
@@ -182,17 +182,18 @@ class ResponsiveClassResolver
 
 	/**
 	 * Whitelists characters legal in a CSS value expression — letters,
-	 * digits, the units / operators / punctuation real CSS values use,
-	 * and whitespace. Drops everything else so values can never close
-	 * out of the declaration (`;`, `}`) or escape the `<style>` tag
-	 * (`<`, `>`). Returns an empty string when the input contains no
-	 * allowed characters.
+	 * digits, the units / operators / punctuation real CSS values use
+	 * (including calc() operators `+`, `-`, `*`, `/`), and whitespace.
+	 * Drops everything else so values can never close out of the
+	 * declaration (`;`, `}`) or escape the `<style>` tag (`<`, `>`).
+	 * Returns an empty string when the input contains no allowed
+	 * characters.
 	 *
 	 * @since 1.0.0
 	 */
 	protected static function sanitizeCssValue( string $value ): string
 	{
-		return (string) preg_replace( '/[^a-zA-Z0-9_\-.,()%#\/\s]/', '', $value );
+		return (string) preg_replace( '/[^a-zA-Z0-9_+\-*\/.,()%#\s]/', '', $value );
 	}
 
 	/**

--- a/packages/visual-editor-renderer-blade/src/Responsive/ResponsiveClassResolver.php
+++ b/packages/visual-editor-renderer-blade/src/Responsive/ResponsiveClassResolver.php
@@ -1,0 +1,250 @@
+<?php
+
+/**
+ * Responsive class / @media emitter — Blade renderer (#487).
+ *
+ * Bridges the discriminated `{base, sm, md, …}` attribute storage to
+ * the markup the server-side Blade partials produce. There are two
+ * output modes per attribute:
+ *
+ *  - **Token mode** — when the value at every distinct breakpoint maps
+ *    to a Tailwind utility (via a caller-supplied token → class map),
+ *    the resolver emits a Tailwind class string using the registered
+ *    breakpoint prefixes (e.g. `px-4 sm:px-6 lg:px-8`).
+ *  - **Custom mode** — when at least one value can't be tokenized, the
+ *    resolver emits a generated wrapper class plus a `<style>` block
+ *    containing `@media (min-width: …) { .ctx-class { prop: value } }`
+ *    rules scoped to that class.
+ *
+ * Renderers call {@see emit()} with the attribute, a CSS property
+ * name, and an optional token map. The result is `{ class, css }` —
+ * the class merges into the wrapper class list; the CSS string is
+ * accumulated and emitted once in a single per-block `<style>` block.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditorRendererBlade
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditorRendererBlade\Responsive;
+
+use ArtisanPackUI\VisualEditor\Responsive\BreakpointRegistry;
+use ArtisanPackUI\VisualEditor\Responsive\ResponsiveValueResolver;
+
+class ResponsiveClassResolver
+{
+	public function __construct(
+		protected BreakpointRegistry $registry,
+		protected ResponsiveValueResolver $resolver,
+	) {}
+
+	/**
+	 * Emit class string + CSS for a single attribute.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  mixed                            $attribute  Either a scalar
+	 *                                                      or a `{base, sm, …}`
+	 *                                                      object.
+	 * @param  string                           $property   CSS property to emit
+	 *                                                      when falling back to
+	 *                                                      `@media` rules
+	 *                                                      (e.g. `padding`,
+	 *                                                      `font-size`).
+	 * @param  array<string, string>|callable   $tokenMap   When an array, maps
+	 *                                                      stored value → Tailwind
+	 *                                                      utility (e.g.
+	 *                                                      `['4' => 'px-4']`).
+	 *                                                      When a callable, called
+	 *                                                      as `(value) => ?string`
+	 *                                                      returning the utility
+	 *                                                      or `null` to fall back
+	 *                                                      to custom CSS.
+	 *
+	 * @return array{class: string, css: string}
+	 */
+	public function emit( $attribute, string $property, $tokenMap = [] ): array
+	{
+		$distinct = $this->resolver->distinctOverrides( $attribute );
+
+		if ( [] === $distinct ) {
+			return [ 'class' => '', 'css' => '' ];
+		}
+
+		// First pass: try the token route for every distinct value.
+		$tokens      = [];
+		$canTokenize = true;
+
+		foreach ( $distinct as $key => $value ) {
+			$utility = $this->lookupToken( $value, $tokenMap );
+
+			if ( null === $utility ) {
+				$canTokenize = false;
+				break;
+			}
+
+			$tokens[ $key ] = $utility;
+		}
+
+		if ( $canTokenize ) {
+			return [
+				'class' => $this->buildTailwindClasses( $tokens ),
+				'css'   => '',
+			];
+		}
+
+		// Custom mode — scope under a generated class.
+		$scope = $this->generateScopeClass( $attribute, $property );
+
+		return [
+			'class' => $scope,
+			'css'   => $this->buildMediaCss( $scope, $property, $distinct ),
+		];
+	}
+
+	/**
+	 * Returns a Tailwind class string ordered by ascending breakpoint
+	 * width, using the registered prefixes (e.g. `sm:`, `md:`).
+	 *
+	 * @param  array<string, string>  $tokens  `[breakpoint => utility]`.
+	 */
+	protected function buildTailwindClasses( array $tokens ): string
+	{
+		$pieces = [];
+
+		// Ensure stable, ascending order regardless of the input order.
+		// `distinctOverrides()` already walks the registry, but custom
+		// callers may pass a hand-rolled token map.
+		foreach ( $this->registry->keysWithBase() as $key ) {
+			if ( ! array_key_exists( $key, $tokens ) ) {
+				continue;
+			}
+
+			$pieces[] = BreakpointRegistry::BASE_KEY === $key
+				? $tokens[ $key ]
+				: $key . ':' . $tokens[ $key ];
+		}
+
+		return implode( ' ', $pieces );
+	}
+
+	/**
+	 * @param  array<string, mixed>  $distinct
+	 */
+	protected function buildMediaCss( string $scope, string $property, array $distinct ): string
+	{
+		$rules = [];
+
+		foreach ( $distinct as $key => $value ) {
+			$stringified = $this->stringifyValue( $value );
+
+			// `stringifyValue` returns '' for arrays and other
+			// non-castable shapes — skip those slots rather than
+			// emitting a malformed `padding:;` declaration.
+			if ( '' === $stringified ) {
+				continue;
+			}
+
+			$safe = self::sanitizeCssValue( $stringified );
+
+			if ( '' === $safe ) {
+				continue;
+			}
+
+			$declaration = sprintf( '%s:%s', $property, $safe );
+
+			if ( BreakpointRegistry::BASE_KEY === $key ) {
+				$rules[] = sprintf( '.%s{%s}', $scope, $declaration );
+				continue;
+			}
+
+			$minWidth = $this->registry->get( $key );
+
+			if ( null === $minWidth ) {
+				continue;
+			}
+
+			$rules[] = sprintf(
+				'@media (min-width:%dpx){.%s{%s}}',
+				$minWidth,
+				$scope,
+				$declaration
+			);
+		}
+
+		return implode( '', $rules );
+	}
+
+	/**
+	 * Whitelists characters legal in a CSS value expression — letters,
+	 * digits, the units / operators / punctuation real CSS values use,
+	 * and whitespace. Drops everything else so values can never close
+	 * out of the declaration (`;`, `}`) or escape the `<style>` tag
+	 * (`<`, `>`). Returns an empty string when the input contains no
+	 * allowed characters.
+	 *
+	 * @since 1.0.0
+	 */
+	protected static function sanitizeCssValue( string $value ): string
+	{
+		return (string) preg_replace( '/[^a-zA-Z0-9_\-.,()%#\/\s]/', '', $value );
+	}
+
+	/**
+	 * @param  mixed                          $value
+	 * @param  array<string, string>|callable $tokenMap
+	 */
+	protected function lookupToken( $value, $tokenMap ): ?string
+	{
+		if ( is_callable( $tokenMap ) ) {
+			$result = $tokenMap( $value );
+
+			return is_string( $result ) && '' !== $result ? $result : null;
+		}
+
+		if ( ! is_array( $tokenMap ) ) {
+			return null;
+		}
+
+		$key = is_scalar( $value ) ? (string) $value : null;
+
+		if ( null === $key ) {
+			return null;
+		}
+
+		return $tokenMap[ $key ] ?? null;
+	}
+
+	protected function stringifyValue( $value ): string
+	{
+		if ( is_bool( $value ) ) {
+			return $value ? 'true' : 'false';
+		}
+
+		if ( is_array( $value ) ) {
+			return '';
+		}
+
+		return (string) $value;
+	}
+
+	/**
+	 * Generates a stable, content-derived class name so the same
+	 * attribute value re-renders to the same scope (cache-friendly).
+	 */
+	protected function generateScopeClass( $attribute, string $property ): string
+	{
+		$hash = substr(
+			hash( 'xxh3', $property . '|' . json_encode( $attribute ) ),
+			0,
+			10
+		);
+
+		return 've-r-' . $hash;
+	}
+}

--- a/packages/visual-editor-renderer-blade/src/Services/ResponsiveCssAccumulator.php
+++ b/packages/visual-editor-renderer-blade/src/Services/ResponsiveCssAccumulator.php
@@ -1,0 +1,121 @@
+<?php
+
+/**
+ * Per-request accumulator for the responsive design tools' CSS (#487, #509).
+ *
+ * Block partials push their per-breakpoint CSS strings into this
+ * service while rendering. The `<x-ve-blocks>` / `<x-ve-template>`
+ * components then drain it once and emit a single `<style data-ve-responsive>`
+ * block at the top of the render output.
+ *
+ * This replaces the previous v1.0 approach of inlining a `<style>`
+ * block immediately before each block's wrapper, which had two
+ * problems:
+ *
+ *  - The `<style>` tags ended up interleaved with sibling block
+ *    children inside flex / grid containers. Per spec `<style>` is
+ *    `display: none`, but the placement was fragile and made the
+ *    cascade hard to reason about.
+ *  - Duplicate scope classes (the same payload on N columns) emitted
+ *    N identical `<style>` blocks. Now they collapse to one.
+ *
+ * Storage is keyed by scope class so the same payload pushed by
+ * multiple block instances only contributes one rule set to the
+ * consolidated output. Insertion order is preserved for stable diffs.
+ *
+ * Bound via `$this->app->scoped()` so a long-lived worker (Octane,
+ * RoadRunner, queued job rendering many blocks per run) gets a fresh
+ * accumulator per request scope. A singleton would leak rules from
+ * one request into the next.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditorRendererBlade
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditorRendererBlade\Services;
+
+class ResponsiveCssAccumulator
+{
+	/**
+	 * Map of scope class → CSS rule string. Keyed so duplicate pushes
+	 * collapse to one entry; iteration order preserves first-push order
+	 * since PHP arrays remember insertion order.
+	 *
+	 * @var array<string, string>
+	 */
+	protected array $rules = [];
+
+	/**
+	 * Adds a rule set for the given scope class. Subsequent calls with
+	 * the same scope are ignored — block partials are expected to use
+	 * content-derived scope classes so an identical payload always
+	 * hashes to the same key.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string  $scope  The scope class (e.g. `ve-r-abc123`).
+	 * @param  string  $css    The CSS rule string (no surrounding
+	 *                         `<style>` tag).
+	 */
+	public function push( string $scope, string $css ): void
+	{
+		if ( '' === $scope || '' === $css ) {
+			return;
+		}
+
+		if ( isset( $this->rules[ $scope ] ) ) {
+			return;
+		}
+
+		$this->rules[ $scope ] = $css;
+	}
+
+	/**
+	 * Returns the consolidated `<style data-ve-responsive>` block and
+	 * clears the accumulator. Called once per render at the top of the
+	 * `<x-ve-blocks>` / `<x-ve-template>` output. Returns an empty
+	 * string when no rules were pushed.
+	 *
+	 * @since 1.0.0
+	 */
+	public function flush(): string
+	{
+		if ( [] === $this->rules ) {
+			return '';
+		}
+
+		$body = implode( '', array_values( $this->rules ) );
+		$this->rules = [];
+
+		return '<style data-ve-responsive>' . $body . '</style>';
+	}
+
+	/**
+	 * Resets the accumulator without emitting. Tests use this to clear
+	 * state between assertions inside a single PHP process.
+	 *
+	 * @since 1.0.0
+	 */
+	public function reset(): void
+	{
+		$this->rules = [];
+	}
+
+	/**
+	 * Inspect what's currently accumulated without draining. Test-only.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<string, string>
+	 */
+	public function all(): array
+	{
+		return $this->rules;
+	}
+}

--- a/packages/visual-editor-renderer-blade/src/Support/BlockSupports.php
+++ b/packages/visual-editor-renderer-blade/src/Support/BlockSupports.php
@@ -47,8 +47,35 @@ declare( strict_types=1 );
 
 namespace ArtisanPackUI\VisualEditorRendererBlade\Support;
 
+use ArtisanPackUI\VisualEditor\Responsive\BreakpointRegistry;
+use ArtisanPackUI\VisualEditorRendererBlade\Services\ResponsiveCssAccumulator;
+
 class BlockSupports
 {
+	/**
+	 * Path → CSS property mapping for responsive overrides. Paths
+	 * outside this map are ignored by the generic emitter; blocks
+	 * with bespoke layout concerns (e.g. `artisanpack/columns` and
+	 * its `columnCount`) handle their own responsive paths inside
+	 * the partial.
+	 */
+	protected const RESPONSIVE_CSS_PROPERTY_MAP = [
+		'style.spacing.padding'  => 'padding',
+		'style.spacing.margin'   => 'margin',
+		'style.spacing.blockGap' => 'gap',
+		'style.border.radius'    => 'border-radius',
+		'style.border.width'     => 'border-width',
+		'style.border.style'     => 'border-style',
+		'style.border.color'     => 'border-color',
+		// `width` is intentionally absent. The artisanpack/column block
+		// translates its `width` attribute to a `flex-basis` declaration
+		// (not `width`), and the WP core `.wp-block-columns:not(.is-not-stacked-on-mobile) > .wp-block-column { flex-basis: 100% !important }`
+		// stacking rule only loses to another `flex-basis` rule of
+		// equal-or-greater specificity. The column partial handles
+		// `responsive.width` itself (see column.blade.php) — same
+		// pattern as columns.blade.php handles `responsive.columnCount`.
+	];
+
 	/**
 	 * Recognized values for the block-level `align` attribute. Values
 	 * outside this set are dropped to keep stored data from injecting
@@ -106,11 +133,273 @@ class BlockSupports
 
 		$styleString = '' === implode( '', $style ) ? '' : implode( '; ', $style ) . ';';
 
+		$responsive = self::compileResponsive( $attributes );
+
+		if ( '' !== $responsive['class'] ) {
+			$classes[] = $responsive['class'];
+
+			// Push into the per-request accumulator so a single
+			// `<style data-ve-responsive>` block at the top of the
+			// render output picks up every block's rules. The push is
+			// keyed by scope class so the same payload on N siblings
+			// only emits once.
+			self::pushResponsive( $responsive['class'], $responsive['rules'] );
+		}
+
 		return [
-			'classes' => $classes,
-			'style'   => $styleString,
-			'id'      => $id,
+			'classes'         => $classes,
+			'style'           => $styleString,
+			'id'              => $id,
+			'responsiveCss'   => '',
+			'responsiveClass' => $responsive['class'],
+			'responsiveRules' => $responsive['rules'],
 		];
+	}
+
+	/**
+	 * Push a scope's rules into the request-scoped accumulator so the
+	 * consolidated `<style data-ve-responsive>` block at the top of the
+	 * render output picks them up. Called automatically from compile();
+	 * the columns/column partial helpers below call it too for their
+	 * own bespoke rules (columnCount, flex-basis).
+	 *
+	 * @since 1.0.0
+	 */
+	public static function pushResponsive( string $scope, string $rules ): void
+	{
+		if ( '' === $scope || '' === $rules ) {
+			return;
+		}
+
+		if ( ! function_exists( 'app' ) ) {
+			return;
+		}
+
+		try {
+			app( ResponsiveCssAccumulator::class )->push( $scope, $rules );
+		} catch ( \Throwable $e ) {
+			// Container not booted (very-early call path or a unit
+			// test that exercises BlockSupports without the package
+			// service provider). Silently drop — the call is
+			// idempotent and the accumulator is the side channel,
+			// not the data path.
+		}
+	}
+
+	/**
+	 * Walk the `attributes.responsive` payload and emit a scoped
+	 * `<style>` block that overrides the base wrapper styles at each
+	 * declared breakpoint.
+	 *
+	 * The payload is path-keyed (`{ "style.spacing.padding": { md: "2rem" } }`
+	 * — same shape the `withResponsiveAttributes` editor HOC writes).
+	 * Paths in {@see self::RESPONSIVE_CSS_PROPERTY_MAP} are handled by
+	 * the generic CSS emitter; everything else (e.g. the columns
+	 * block's `columnCount` override) is the partial's responsibility.
+	 *
+	 * Returns `{class, rules}` — the class merges into the wrapper
+	 * class list so the emitted `@media` rules target it; `rules` is
+	 * the bare CSS body (no surrounding `<style>` tag) that gets
+	 * pushed into the per-request {@see ResponsiveCssAccumulator}.
+	 * Both are empty when no actionable overrides are present.
+	 *
+	 * #509 — consolidated emission. compile() automatically pushes
+	 * these rules into the accumulator, and `<x-ve-blocks>` /
+	 * `<x-ve-template>` drain the accumulator into one
+	 * `<style data-ve-responsive>` block at the top of the render
+	 * output. Per-block partials no longer emit their own `<style>`
+	 * tags inline.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array<string, mixed>  $attributes
+	 *
+	 * @return array{class: string, rules: string}
+	 */
+	public static function compileResponsive( array $attributes ): array
+	{
+		$responsive = $attributes['responsive'] ?? null;
+
+		if ( ! is_array( $responsive ) || [] === $responsive ) {
+			return [ 'class' => '', 'rules' => '' ];
+		}
+
+		$registry = BreakpointRegistry::fromLayers();
+		$rules    = [];
+		$scope    = self::generateResponsiveScopeClass( $responsive );
+
+		// Tripled scope class boosts the rule's specificity to
+		// (0,0,3,0), matching WP core's own
+		// `.wp-block-columns:not(.is-not-stacked-on-mobile) > .wp-block-column`
+		// rule. Both rules then carry `!important`, so source order
+		// decides — and this `<style>` block is emitted right before
+		// the wrapper, after every WP core stylesheet, so we win.
+		$selector = sprintf( '.%1$s.%1$s.%1$s', $scope );
+
+		foreach ( $responsive as $path => $overrides ) {
+			if ( ! is_array( $overrides ) ) {
+				continue;
+			}
+
+			if ( ! isset( self::RESPONSIVE_CSS_PROPERTY_MAP[ $path ] ) ) {
+				continue;
+			}
+
+			$property = self::RESPONSIVE_CSS_PROPERTY_MAP[ $path ];
+
+			foreach ( $overrides as $breakpoint => $value ) {
+				if ( null === $value || '' === $value ) {
+					continue;
+				}
+
+				$declarations = self::responsiveDeclarations( $property, $value );
+
+				if ( '' === $declarations ) {
+					continue;
+				}
+
+				if ( BreakpointRegistry::BASE_KEY === $breakpoint ) {
+					$rules[] = sprintf( '%s{%s}', $selector, $declarations );
+
+					continue;
+				}
+
+				$minWidth = $registry->get( (string) $breakpoint );
+
+				if ( null === $minWidth ) {
+					continue;
+				}
+
+				$rules[] = sprintf(
+					'@media (min-width:%dpx){%s{%s}}',
+					$minWidth,
+					$selector,
+					$declarations
+				);
+			}
+		}
+
+		if ( [] === $rules ) {
+			return [ 'class' => '', 'rules' => '' ];
+		}
+
+		return [
+			'class' => $scope,
+			'rules' => implode( '', $rules ),
+		];
+	}
+
+	/**
+	 * Turn a single override value into one or more CSS declarations.
+	 * Scalars become `property: value`. Per-side objects (the shape
+	 * Gutenberg uses for spacing/border: `{top, right, bottom, left}`)
+	 * become per-side declarations (`padding-top: ...`, etc.). The
+	 * resulting declaration list is `;`-joined with no trailing
+	 * semicolon — callers add the wrapping `{}` and any trailing `;`
+	 * they need.
+	 *
+	 * Every declaration is suffixed with `!important` because the
+	 * block-supports compiler also writes scalar values into the
+	 * wrapper's inline `style="…"` attribute (Gutenberg's default
+	 * shape for padding/margin/border). Inline styles always beat
+	 * class-based rules on specificity, so without `!important` the
+	 * per-breakpoint overrides emit but never apply on the front end.
+	 * #509 (consolidated emission) will keep the same suffix.
+	 */
+	protected static function responsiveDeclarations( string $property, $value ): string
+	{
+		if ( is_scalar( $value ) ) {
+			return $property . ':' . self::resolvePresetVar( (string) $value ) . '!important';
+		}
+
+		if ( ! is_array( $value ) ) {
+			return '';
+		}
+
+		$pieces = [];
+
+		foreach ( [ 'top', 'right', 'bottom', 'left' ] as $side ) {
+			if ( ! isset( $value[ $side ] ) || null === $value[ $side ] || '' === $value[ $side ] ) {
+				continue;
+			}
+
+			$pieces[] = sprintf(
+				'%s-%s:%s!important',
+				$property,
+				$side,
+				self::resolvePresetVar( (string) $value[ $side ] )
+			);
+		}
+
+		return implode( ';', $pieces );
+	}
+
+	/**
+	 * `var:preset|color|primary` → `var(--wp--preset--color--primary)`,
+	 * mirroring Gutenberg's serializer. Plain values pass through.
+	 */
+	protected static function resolvePresetVar( string $value ): string
+	{
+		if ( ! str_starts_with( $value, 'var:preset|' ) ) {
+			return $value;
+		}
+
+		$segments = explode( '|', substr( $value, strlen( 'var:preset|' ) ) );
+		$slug     = implode( '--', array_map(
+			static fn ( string $segment ): string => str_replace( '_', '-', $segment ),
+			$segments
+		) );
+
+		return sprintf( 'var(--wp--preset--%s)', $slug );
+	}
+
+	/**
+	 * Generates a stable, content-derived class so the same responsive
+	 * payload re-renders to the same scope (cache-friendly + idempotent).
+	 */
+	protected static function generateResponsiveScopeClass( array $responsive ): string
+	{
+		$hash = substr(
+			hash( 'xxh3', (string) json_encode( $responsive ) ),
+			0,
+			10
+		);
+
+		return 've-r-' . $hash;
+	}
+
+	/**
+	 * Back-compat shim. Previously emitted a per-block `<style>` tag
+	 * before the wrapper; now a no-op because compile() pushes the
+	 * rules into the per-request accumulator and
+	 * `<x-ve-blocks>` / `<x-ve-template>` drain it into one
+	 * consolidated `<style data-ve-responsive>` block at the top of
+	 * the render output. Kept so partials calling
+	 * `{!! BlockSupports::wrapperCss( $attributes ) !!}` continue to
+	 * compile — the call becomes harmless.
+	 *
+	 * Forked or host-app partials that referenced this should drop
+	 * the line; nothing else needs to change.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array<string, mixed>  $attributes
+	 *
+	 * @deprecated 1.0.0 — accumulator-based emission supersedes per-block tags.
+	 */
+	public static function wrapperCss( array $attributes ): string
+	{
+		// Trigger the side-effect (accumulator push) for partials
+		// that don't go through compile() — though every shipped
+		// partial does. Keeps behavior consistent if a host calls
+		// wrapperCss() without first calling wrapperAttrs().
+		$responsive = self::compileResponsive( $attributes );
+
+		if ( '' !== $responsive['class'] ) {
+			self::pushResponsive( $responsive['class'], $responsive['rules'] );
+		}
+
+		return '';
 	}
 
 	/**

--- a/packages/visual-editor-renderer-blade/src/Support/BlockSupports.php
+++ b/packages/visual-editor-renderer-blade/src/Support/BlockSupports.php
@@ -157,6 +157,22 @@ class BlockSupports
 	}
 
 	/**
+	 * Resolve the request-scoped breakpoint registry from the
+	 * container, falling back to package defaults when the container
+	 * isn't booted (very-early call path / unit-test isolation).
+	 *
+	 * @since 1.0.0
+	 */
+	protected static function resolveRegistry(): BreakpointRegistry
+	{
+		try {
+			return app( BreakpointRegistry::class );
+		} catch ( \Throwable $e ) {
+			return BreakpointRegistry::fromLayers();
+		}
+	}
+
+	/**
 	 * Push a scope's rules into the request-scoped accumulator so the
 	 * consolidated `<style data-ve-responsive>` block at the top of the
 	 * render output picks them up. Called automatically from compile();
@@ -224,7 +240,17 @@ class BlockSupports
 			return [ 'class' => '', 'rules' => '' ];
 		}
 
-		$registry = BreakpointRegistry::fromLayers();
+		// Pull the request-scoped registry from the container so
+		// host-configured breakpoints (theme.json → config) are
+		// respected. `fromLayers()` without args only returns the
+		// Tailwind defaults — any custom key (e.g. `3xl`) would
+		// resolve to null here and the override would be silently
+		// dropped at render time. The fallback to defaults preserves
+		// the behavior for callers (mostly tests) that hit
+		// `compileResponsive` outside the container.
+		$registry = function_exists( 'app' )
+			? self::resolveRegistry()
+			: BreakpointRegistry::fromLayers();
 		$rules    = [];
 		$scope    = self::generateResponsiveScopeClass( $responsive );
 
@@ -309,7 +335,13 @@ class BlockSupports
 	protected static function responsiveDeclarations( string $property, $value ): string
 	{
 		if ( is_scalar( $value ) ) {
-			return $property . ':' . self::resolvePresetVar( (string) $value ) . '!important';
+			$resolved = self::sanitizeCssValue( self::resolvePresetVar( (string) $value ) );
+
+			if ( '' === $resolved ) {
+				return '';
+			}
+
+			return $property . ':' . $resolved . '!important';
 		}
 
 		if ( ! is_array( $value ) ) {
@@ -323,11 +355,17 @@ class BlockSupports
 				continue;
 			}
 
+			$resolved = self::sanitizeCssValue( self::resolvePresetVar( (string) $value[ $side ] ) );
+
+			if ( '' === $resolved ) {
+				continue;
+			}
+
 			$pieces[] = sprintf(
 				'%s-%s:%s!important',
 				$property,
 				$side,
-				self::resolvePresetVar( (string) $value[ $side ] )
+				$resolved
 			);
 		}
 
@@ -351,6 +389,26 @@ class BlockSupports
 		) );
 
 		return sprintf( 'var(--wp--preset--%s)', $slug );
+	}
+
+	/**
+	 * Whitelists characters legal in a CSS value expression — letters,
+	 * digits, units, calc() operators (`+`, `-`, `*`, `/`), CSS var
+	 * punctuation, whitespace. Drops everything else so a stored block
+	 * tree with a hostile value (e.g. `</style><script>…`) can never
+	 * close the `<style data-ve-responsive>` block we emit it inside.
+	 *
+	 * Defense-in-depth: block-tree JSON is editor-authored content that
+	 * WordPress treats as trusted, but the responsive payload reaches
+	 * the renderer via `{!! !!}` (raw output) inside a `<style>` tag,
+	 * so an escaping bypass anywhere upstream would land directly in
+	 * the DOM. The whitelist is the last line of defense.
+	 *
+	 * @since 1.0.0
+	 */
+	protected static function sanitizeCssValue( string $value ): string
+	{
+		return (string) preg_replace( '/[^a-zA-Z0-9_+\-*\/.,()%#\s]/', '', $value );
 	}
 
 	/**

--- a/packages/visual-editor-renderer-blade/src/View/Components/BlocksComponent.php
+++ b/packages/visual-editor-renderer-blade/src/View/Components/BlocksComponent.php
@@ -31,6 +31,7 @@ use ArtisanPackUI\VisualEditor\Services\GlobalStylesEmissionTracker;
 use ArtisanPackUI\VisualEditor\SiteEditor\NavigationBlockRefResolver;
 use ArtisanPackUI\VisualEditorRendererBlade\BlockRenderer;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\GlobalStylesEmissionResolver;
+use ArtisanPackUI\VisualEditorRendererBlade\Services\ResponsiveCssAccumulator;
 use Illuminate\Contracts\View\View;
 use Illuminate\View\Component;
 
@@ -57,6 +58,7 @@ class BlocksComponent extends Component
 		protected NavigationBlockRefResolver $navigationResolver,
 		protected GlobalStylesEmissionResolver $globalStyles,
 		protected GlobalStylesEmissionTracker $emissionTracker,
+		protected ResponsiveCssAccumulator $responsiveAccumulator,
 		mixed $tree = null,
 		?string $defaultTheme = null,
 		bool $resolveParts = true,
@@ -103,9 +105,17 @@ class BlocksComponent extends Component
 
 	public function render(): View
 	{
+		// Render the block tree FIRST so every partial's
+		// `BlockSupports::pushResponsive()` side-effect has happened
+		// by the time we drain the accumulator. The drained block
+		// is then prepended to the output by the view template.
+		$html         = $this->renderer->render( $this->tree );
+		$responsiveCss = $this->responsiveAccumulator->flush();
+
 		return view( 'visual-editor-renderer-blade::components.blocks', [
-			'html'            => $this->renderer->render( $this->tree ),
+			'html'            => $html,
 			'globalStylesCss' => $this->resolveGlobalStylesCss(),
+			'responsiveCss'   => $responsiveCss,
 		] );
 	}
 

--- a/packages/visual-editor-renderer-blade/src/View/Components/TemplateComponent.php
+++ b/packages/visual-editor-renderer-blade/src/View/Components/TemplateComponent.php
@@ -35,6 +35,7 @@ use ArtisanPackUI\VisualEditor\SiteEditor\NavigationBlockRefResolver;
 use ArtisanPackUI\VisualEditor\Services\GlobalStylesEmissionTracker;
 use ArtisanPackUI\VisualEditorRendererBlade\BlockRenderer;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\GlobalStylesEmissionResolver;
+use ArtisanPackUI\VisualEditorRendererBlade\Services\ResponsiveCssAccumulator;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\View\View;
 use Illuminate\View\Component;
@@ -72,6 +73,7 @@ class TemplateComponent extends Component
 		protected Application $app,
 		protected GlobalStylesEmissionResolver $globalStyles,
 		protected GlobalStylesEmissionTracker $emissionTracker,
+		protected ResponsiveCssAccumulator $responsiveAccumulator,
 		string $slug,
 		?string $theme = null,
 	) {
@@ -106,6 +108,13 @@ class TemplateComponent extends Component
 
 	public function render(): View
 	{
+		// Drain the per-request responsive CSS accumulator. The
+		// constructor already invoked `$renderer->render()` (line
+		// where `$this->html` is assigned), so every block partial
+		// has had a chance to push its responsive rules in by now.
+		// See BlocksComponent::render() for the same pattern.
+		$responsiveCss = $this->responsiveAccumulator->flush();
+
 		return view( 'visual-editor-renderer-blade::components.template', [
 			'slug'            => $this->slug,
 			'theme'           => $this->theme,
@@ -115,6 +124,7 @@ class TemplateComponent extends Component
 			'inDev'           => ! $this->app->environment( 'production' ),
 			'html'            => $this->html,
 			'globalStylesCss' => $this->resolveGlobalStylesCss(),
+			'responsiveCss'   => $responsiveCss,
 		] );
 	}
 

--- a/packages/visual-editor-renderer-blade/src/VisualEditorRendererBladeServiceProvider.php
+++ b/packages/visual-editor-renderer-blade/src/VisualEditorRendererBladeServiceProvider.php
@@ -21,9 +21,13 @@ namespace ArtisanPackUI\VisualEditorRendererBlade;
 
 use ArtisanPackUI\VisualEditor\Registries\DynamicBlockRegistry;
 use ArtisanPackUI\VisualEditor\Resources\TemplatePartInliner;
+use ArtisanPackUI\VisualEditor\Responsive\BreakpointRegistry;
+use ArtisanPackUI\VisualEditor\Responsive\ResponsiveValueResolver;
 use ArtisanPackUI\VisualEditorRendererBlade\Resolvers\SiteMetaResolver;
+use ArtisanPackUI\VisualEditorRendererBlade\Responsive\ResponsiveClassResolver;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\GlobalStylesEmissionResolver;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\NavigationOverlayTracker;
+use ArtisanPackUI\VisualEditorRendererBlade\Services\ResponsiveCssAccumulator;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\ThemeJsonTokensCompiler;
 use ArtisanPackUI\VisualEditorRendererBlade\View\Components\BlocksComponent;
 use ArtisanPackUI\VisualEditorRendererBlade\View\Components\BlocksStylesComponent;
@@ -75,6 +79,23 @@ class VisualEditorRendererBladeServiceProvider extends ServiceProvider
 		// script to fire at most once per response (Keystone #54).
 		$this->app->scoped( NavigationOverlayTracker::class, function () {
 			return new NavigationOverlayTracker();
+		} );
+
+		// #487 — server-side responsive class / @media emitter. Scoped
+		// to match the lifetime of the registry it depends on.
+		$this->app->scoped( ResponsiveClassResolver::class, function ( $app ) {
+			return new ResponsiveClassResolver(
+				$app->make( BreakpointRegistry::class ),
+				$app->make( ResponsiveValueResolver::class ),
+			);
+		} );
+
+		// #509 — per-request accumulator that collects every block's
+		// responsive CSS into one `<style data-ve-responsive>` block
+		// at the top of the render output. Scoped so a long-lived
+		// worker (Octane / queue) doesn't leak rules across requests.
+		$this->app->scoped( ResponsiveCssAccumulator::class, function () {
+			return new ResponsiveCssAccumulator();
 		} );
 	}
 

--- a/packages/visual-editor-renderer-blade/tests/Feature/Responsive/ColumnResponsiveWidthTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Feature/Responsive/ColumnResponsiveWidthTest.php
@@ -1,0 +1,230 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditorRendererBlade\Services\ResponsiveCssAccumulator;
+use Illuminate\Support\Facades\Blade;
+
+beforeEach( function (): void {
+	app( ResponsiveCssAccumulator::class )->reset();
+} );
+
+it( 'emits a flex-basis @media rule (not width) with gap-aware calc for responsive column width', function () {
+	$tree = [
+		[
+			'clientId'   => 'col-1',
+			'name'       => 'artisanpack/column',
+			'attributes' => [
+				'responsive' => [
+					'width' => [ 'md' => 25 ],
+				],
+			],
+			'innerBlocks' => [],
+		],
+	];
+
+	$rendered = $this->stripGlobalStyles( Blade::render( '<x-ve-blocks :tree="$tree" />', [ 'tree' => $tree ] ) );
+
+	expect( $rendered )->toContain( '<style data-ve-responsive>' );
+	expect( $rendered )->toContain( '@media (min-width:768px)' );
+	// 25% width → factor (100-25)/100 = 0.75
+	expect( $rendered )->toContain( 'flex-basis:calc(25% - var(--wp--style--block-gap, 0.5em) * 0.75)!important' );
+	expect( $rendered )->toContain( 'flex-grow:0!important' );
+	expect( $rendered )->not->toContain( 'width:25%' );
+} );
+
+it( 'promotes legacy width attribute into a gap-aware base !important rule', function () {
+	$tree = [
+		[
+			'clientId'   => 'col-1',
+			'name'       => 'artisanpack/column',
+			'attributes' => [ 'width' => '50%' ],
+			'innerBlocks' => [],
+		],
+	];
+
+	$rendered = $this->stripGlobalStyles( Blade::render( '<x-ve-blocks :tree="$tree" />', [ 'tree' => $tree ] ) );
+
+	// Legacy `width` attribute keeps producing the bare inline style
+	// (for backward compat) AND a base rule with `!important` so it
+	// beats WP core's stacking rule at <782px. The base rule
+	// subtracts the parent's block-gap so two 50% columns fit on one
+	// row when the theme sets `gap` on `.wp-block-columns`.
+	expect( $rendered )->toContain( 'style="flex-basis: 50%;"' );
+	expect( $rendered )->toContain( '<style data-ve-responsive>' );
+	// 50% width → factor (100-50)/100 = 0.5
+	expect( $rendered )->toMatch( '/\.ve-w-[a-f0-9]+\.ve-w-[a-f0-9]+\.ve-w-[a-f0-9]+\{flex-basis:calc\(50% - var\(--wp--style--block-gap, 0\.5em\) \* 0\.5\)!important;flex-grow:0!important\}/' );
+} );
+
+it( 'merges legacy base width with responsive overrides into one rule set', function () {
+	$tree = [
+		[
+			'clientId'   => 'col-1',
+			'name'       => 'artisanpack/column',
+			'attributes' => [
+				'width'      => '50%',
+				'responsive' => [
+					'width' => [ 'md' => 25 ],
+				],
+			],
+			'innerBlocks' => [],
+		],
+	];
+
+	$rendered = $this->stripGlobalStyles( Blade::render( '<x-ve-blocks :tree="$tree" />', [ 'tree' => $tree ] ) );
+
+	// Base rule (no @media) for the legacy 50% AND a @media rule for
+	// the md 25% override — both with the gap-aware calc.
+	expect( $rendered )->toContain( 'flex-basis:calc(50% - var(--wp--style--block-gap, 0.5em) * 0.5)!important' );
+	expect( $rendered )->toContain( 'flex-basis:calc(25% - var(--wp--style--block-gap, 0.5em) * 0.75)!important' );
+	expect( $rendered )->toContain( '@media (min-width:768px)' );
+} );
+
+it( 'prefers an explicit responsive.base over the legacy width attribute', function () {
+	$tree = [
+		[
+			'clientId'   => 'col-1',
+			'name'       => 'artisanpack/column',
+			'attributes' => [
+				'width'      => '50%',
+				'responsive' => [
+					'width' => [ 'base' => '60%' ],
+				],
+			],
+			'innerBlocks' => [],
+		],
+	];
+
+	$rendered = $this->stripGlobalStyles( Blade::render( '<x-ve-blocks :tree="$tree" />', [ 'tree' => $tree ] ) );
+
+	expect( $rendered )->toContain( 'flex-basis:calc(60% - var(--wp--style--block-gap, 0.5em) * 0.4)!important' );
+	expect( $rendered )->not->toContain( 'flex-basis:calc(50%' );
+} );
+
+it( 'tripled selector specificity beats WP core stacking rule', function () {
+	$tree = [
+		[
+			'clientId'   => 'col-1',
+			'name'       => 'artisanpack/column',
+			'attributes' => [
+				'responsive' => [
+					'width' => [ 'sm' => 50, 'md' => 25 ],
+				],
+			],
+			'innerBlocks' => [],
+		],
+	];
+
+	$rendered = $this->stripGlobalStyles( Blade::render( '<x-ve-blocks :tree="$tree" />', [ 'tree' => $tree ] ) );
+
+	expect( $rendered )->toMatch( '/\.ve-w-[a-f0-9]+\.ve-w-[a-f0-9]+\.ve-w-[a-f0-9]+\{flex-basis:calc\(50% - var\(--wp--style--block-gap, 0\.5em\) \* 0\.5\)!important;flex-grow:0!important\}/' );
+	expect( $rendered )->toMatch( '/\.ve-w-[a-f0-9]+\.ve-w-[a-f0-9]+\.ve-w-[a-f0-9]+\{flex-basis:calc\(25% - var\(--wp--style--block-gap, 0\.5em\) \* 0\.75\)!important;flex-grow:0!important\}/' );
+} );
+
+it( 'passes string percentage values through with gap-aware calc', function () {
+	$tree = [
+		[
+			'clientId'   => 'col-1',
+			'name'       => 'artisanpack/column',
+			'attributes' => [
+				'responsive' => [
+					'width' => [ 'md' => '33.33%' ],
+				],
+			],
+			'innerBlocks' => [],
+		],
+	];
+
+	$rendered = $this->stripGlobalStyles( Blade::render( '<x-ve-blocks :tree="$tree" />', [ 'tree' => $tree ] ) );
+
+	expect( $rendered )->toContain( 'flex-basis:calc(33.33% - var(--wp--style--block-gap, 0.5em) * 0.6667)!important' );
+} );
+
+it( 'emits absolute units (e.g. 200px) without the calc wrapper', function () {
+	$tree = [
+		[
+			'clientId'   => 'col-1',
+			'name'       => 'artisanpack/column',
+			'attributes' => [
+				'responsive' => [
+					'width' => [ 'md' => '200px' ],
+				],
+			],
+			'innerBlocks' => [],
+		],
+	];
+
+	$rendered = $this->stripGlobalStyles( Blade::render( '<x-ve-blocks :tree="$tree" />', [ 'tree' => $tree ] ) );
+
+	expect( $rendered )->toContain( 'flex-basis:200px!important' );
+	expect( $rendered )->not->toContain( 'calc(200px' );
+} );
+
+it( 'emits 100% width without the calc wrapper (factor would be 0)', function () {
+	$tree = [
+		[
+			'clientId'   => 'col-1',
+			'name'       => 'artisanpack/column',
+			'attributes' => [
+				'responsive' => [
+					'width' => [ 'md' => 100 ],
+				],
+			],
+			'innerBlocks' => [],
+		],
+	];
+
+	$rendered = $this->stripGlobalStyles( Blade::render( '<x-ve-blocks :tree="$tree" />', [ 'tree' => $tree ] ) );
+
+	expect( $rendered )->toContain( 'flex-basis:100%!important' );
+	expect( $rendered )->not->toContain( 'calc(100%' );
+} );
+
+it( 'skips the consolidated style block when no width overrides are present', function () {
+	$tree = [
+		[
+			'clientId'    => 'col-1',
+			'name'        => 'artisanpack/column',
+			'attributes'  => [],
+			'innerBlocks' => [],
+		],
+	];
+
+	$rendered = $this->stripGlobalStyles( Blade::render( '<x-ve-blocks :tree="$tree" />', [ 'tree' => $tree ] ) );
+
+	expect( $rendered )->not->toContain( '<style data-ve-responsive>' );
+} );
+
+it( 'multiple columns with the same width payload only emit one rule set', function () {
+	$tree = [
+		[
+			'clientId'   => 'cols-1',
+			'name'       => 'artisanpack/columns',
+			'attributes' => [],
+			'innerBlocks' => [
+				[
+					'clientId'   => 'col-1',
+					'name'       => 'artisanpack/column',
+					'attributes' => [
+						'responsive' => [ 'width' => [ 'md' => 50 ] ],
+					],
+					'innerBlocks' => [],
+				],
+				[
+					'clientId'   => 'col-2',
+					'name'       => 'artisanpack/column',
+					'attributes' => [
+						'responsive' => [ 'width' => [ 'md' => 50 ] ],
+					],
+					'innerBlocks' => [],
+				],
+			],
+		],
+	];
+
+	$rendered = $this->stripGlobalStyles( Blade::render( '<x-ve-blocks :tree="$tree" />', [ 'tree' => $tree ] ) );
+
+	// Both columns share the same payload → one scope class → one
+	// rule set in the consolidated style block.
+	expect( substr_count( $rendered, 'flex-basis:calc(50%' ) )->toBe( 1 );
+} );

--- a/packages/visual-editor-renderer-blade/tests/Feature/Responsive/ColumnsResponsiveRenderTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Feature/Responsive/ColumnsResponsiveRenderTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditorRendererBlade\Services\ResponsiveCssAccumulator;
+use Illuminate\Support\Facades\Blade;
+
+beforeEach( function (): void {
+	app( ResponsiveCssAccumulator::class )->reset();
+} );
+
+it( 'consolidates spacing overrides into a single <style data-ve-responsive> block at the top', function () {
+	$tree = [
+		[
+			'clientId'   => 'cols-1',
+			'name'       => 'artisanpack/columns',
+			'attributes' => [
+				'responsive' => [
+					'style.spacing.padding' => [ 'md' => '2rem' ],
+				],
+			],
+			'innerBlocks' => [],
+		],
+	];
+
+	$rendered = $this->stripGlobalStyles( Blade::render( '<x-ve-blocks :tree="$tree" />', [ 'tree' => $tree ] ) );
+
+	// One consolidated style block, not one per scope class.
+	expect( $rendered )->toContain( '<style data-ve-responsive>' );
+	expect( substr_count( $rendered, '<style data-ve-responsive>' ) )->toBe( 1 );
+	expect( $rendered )->toContain( '@media (min-width:768px)' );
+	expect( $rendered )->toContain( '{padding:2rem!important}' );
+	expect( $rendered )->toMatch( '/class="wp-block-columns is-stacked-on-mobile ve-r-[a-f0-9]+"/' );
+
+	// Style block lives BEFORE the column wrapper, not inside it.
+	$styleEnd      = strpos( $rendered, '</style>' );
+	$wrapperOpens  = strpos( $rendered, '<div class="wp-block-columns' );
+	expect( $styleEnd )->toBeLessThan( $wrapperOpens );
+
+	// No per-block `<style data-ve-r="..">` tags remain inside the
+	// flex container — the whole point of #509.
+	expect( $rendered )->not->toContain( '<style data-ve-r=' );
+} );
+
+it( 'consolidates columnCount overrides through the same accumulator', function () {
+	$tree = [
+		[
+			'clientId'   => 'cols-1',
+			'name'       => 'artisanpack/columns',
+			'attributes' => [
+				'responsive' => [
+					'columnCount' => [ 'md' => 4 ],
+				],
+			],
+			'innerBlocks' => [],
+		],
+	];
+
+	$rendered = $this->stripGlobalStyles( Blade::render( '<x-ve-blocks :tree="$tree" />', [ 'tree' => $tree ] ) );
+
+	expect( $rendered )->toContain( '<style data-ve-responsive>' );
+	expect( $rendered )->toContain( 'grid-template-columns:repeat(4,minmax(0,1fr))!important' );
+	expect( $rendered )->toMatch( '/class="wp-block-columns is-stacked-on-mobile ve-cols-[a-f0-9]+"/' );
+} );
+
+it( 'merges spacing + columnCount + multiple blocks into one style block', function () {
+	$tree = [
+		[
+			'clientId'   => 'cols-1',
+			'name'       => 'artisanpack/columns',
+			'attributes' => [
+				'responsive' => [
+					'style.spacing.padding' => [ 'md' => '2rem' ],
+					'columnCount'           => [ 'md' => 4 ],
+				],
+			],
+			'innerBlocks' => [],
+		],
+		[
+			'clientId'   => 'cols-2',
+			'name'       => 'artisanpack/columns',
+			'attributes' => [
+				'responsive' => [
+					'style.spacing.padding' => [ 'lg' => '4rem' ],
+				],
+			],
+			'innerBlocks' => [],
+		],
+	];
+
+	$rendered = $this->stripGlobalStyles( Blade::render( '<x-ve-blocks :tree="$tree" />', [ 'tree' => $tree ] ) );
+
+	// One and only one consolidated style block, even though
+	// three distinct rule sets contributed to it.
+	expect( substr_count( $rendered, '<style data-ve-responsive>' ) )->toBe( 1 );
+	expect( $rendered )->toContain( '{padding:2rem!important}' );
+	expect( $rendered )->toContain( '{padding:4rem!important}' );
+	expect( $rendered )->toContain( 'grid-template-columns:repeat(4' );
+} );
+
+it( 'skips the consolidated style block when no responsive overrides are present', function () {
+	$tree = [
+		[
+			'clientId'    => 'cols-1',
+			'name'        => 'artisanpack/columns',
+			'attributes'  => [],
+			'innerBlocks' => [],
+		],
+	];
+
+	$rendered = $this->stripGlobalStyles( Blade::render( '<x-ve-blocks :tree="$tree" />', [ 'tree' => $tree ] ) );
+
+	expect( $rendered )->not->toContain( '<style data-ve-responsive>' );
+	expect( $rendered )->not->toContain( '<style data-ve-r=' );
+} );
+
+it( 'skips invalid columnCount overrides (zero / negative)', function () {
+	$tree = [
+		[
+			'clientId'   => 'cols-1',
+			'name'       => 'artisanpack/columns',
+			'attributes' => [
+				'responsive' => [
+					'columnCount' => [ 'md' => 0 ],
+				],
+			],
+			'innerBlocks' => [],
+		],
+	];
+
+	$rendered = $this->stripGlobalStyles( Blade::render( '<x-ve-blocks :tree="$tree" />', [ 'tree' => $tree ] ) );
+
+	expect( $rendered )->not->toContain( 'grid-template-columns' );
+} );

--- a/packages/visual-editor-renderer-blade/tests/Unit/BlockSupportsResponsiveTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Unit/BlockSupportsResponsiveTest.php
@@ -1,0 +1,189 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditorRendererBlade\Services\ResponsiveCssAccumulator;
+use ArtisanPackUI\VisualEditorRendererBlade\Support\BlockSupports;
+
+beforeEach( function (): void {
+	app( ResponsiveCssAccumulator::class )->reset();
+} );
+
+it( 'returns empty rules and class when no responsive overrides exist', function (): void {
+	$result = BlockSupports::compileResponsive( [] );
+
+	expect( $result )->toBe( [ 'class' => '', 'rules' => '' ] );
+} );
+
+it( 'returns empty rules when the responsive payload is empty', function (): void {
+	$result = BlockSupports::compileResponsive( [ 'responsive' => [] ] );
+
+	expect( $result )->toBe( [ 'class' => '', 'rules' => '' ] );
+} );
+
+it( 'emits a scoped @media rule for a scalar spacing override', function (): void {
+	$result = BlockSupports::compileResponsive( [
+		'responsive' => [
+			'style.spacing.padding' => [ 'md' => '2rem' ],
+		],
+	] );
+
+	expect( $result['class'] )->toStartWith( 've-r-' );
+	expect( $result['rules'] )->toContain( '@media (min-width:768px)' );
+	expect( $result['rules'] )->toContain( '{padding:2rem!important}' );
+	expect( $result['rules'] )->not->toContain( '<style' );
+} );
+
+it( 'emits a base rule (no @media) for the base breakpoint', function (): void {
+	$result = BlockSupports::compileResponsive( [
+		'responsive' => [
+			'style.spacing.padding' => [ 'base' => '1rem' ],
+		],
+	] );
+
+	$tripled = sprintf( '.%1$s.%1$s.%1$s', $result['class'] );
+	expect( $result['rules'] )->toContain( $tripled . '{padding:1rem!important}' );
+	expect( $result['rules'] )->not->toContain( '@media' );
+} );
+
+it( 'emits per-side declarations for a spacing object', function (): void {
+	$result = BlockSupports::compileResponsive( [
+		'responsive' => [
+			'style.spacing.padding' => [
+				'md' => [
+					'top'    => '1rem',
+					'bottom' => '2rem',
+				],
+			],
+		],
+	] );
+
+	expect( $result['rules'] )->toContain( 'padding-top:1rem!important' );
+	expect( $result['rules'] )->toContain( 'padding-bottom:2rem!important' );
+	expect( $result['rules'] )->not->toContain( 'padding-left' );
+	expect( $result['rules'] )->not->toContain( 'padding-right' );
+} );
+
+it( 'maps blockGap to gap and border.radius to border-radius', function (): void {
+	$result = BlockSupports::compileResponsive( [
+		'responsive' => [
+			'style.spacing.blockGap' => [ 'md' => '8px' ],
+			'style.border.radius'    => [ 'lg' => '4px' ],
+		],
+	] );
+
+	expect( $result['rules'] )->toContain( 'gap:8px!important' );
+	expect( $result['rules'] )->toContain( 'border-radius:4px!important' );
+	expect( $result['rules'] )->toContain( '@media (min-width:768px)' );
+	expect( $result['rules'] )->toContain( '@media (min-width:1024px)' );
+} );
+
+it( 'expands a Gutenberg preset reference to a CSS var', function (): void {
+	$result = BlockSupports::compileResponsive( [
+		'responsive' => [
+			'style.spacing.padding' => [ 'md' => 'var:preset|spacing|40' ],
+		],
+	] );
+
+	expect( $result['rules'] )->toContain( 'padding:var(--wp--preset--spacing--40)!important' );
+} );
+
+it( 'skips overrides for unknown breakpoints (orphans)', function (): void {
+	$result = BlockSupports::compileResponsive( [
+		'responsive' => [
+			'style.spacing.padding' => [ 'legacy' => '4rem' ],
+		],
+	] );
+
+	expect( $result )->toBe( [ 'class' => '', 'rules' => '' ] );
+} );
+
+it( 'skips paths outside the property map', function (): void {
+	$result = BlockSupports::compileResponsive( [
+		'responsive' => [
+			'columnCount' => [ 'md' => 5 ],
+		],
+	] );
+
+	// columnCount is handled by the columns partial, not the generic emitter.
+	expect( $result )->toBe( [ 'class' => '', 'rules' => '' ] );
+} );
+
+it( 'compile() pushes responsive rules into the per-request accumulator', function (): void {
+	$accumulator = app( ResponsiveCssAccumulator::class );
+
+	$compiled = BlockSupports::compile( [
+		'responsive' => [
+			'style.spacing.padding' => [ 'md' => '2rem' ],
+		],
+	] );
+
+	expect( $compiled['responsiveClass'] )->toStartWith( 've-r-' );
+	expect( $compiled['classes'] )->toContain( $compiled['responsiveClass'] );
+
+	$accumulated = $accumulator->all();
+	expect( $accumulated )->toHaveKey( $compiled['responsiveClass'] );
+	expect( $accumulated[ $compiled['responsiveClass'] ] )->toContain( '{padding:2rem!important}' );
+} );
+
+it( 'duplicate pushes for the same scope collapse to one accumulator entry', function (): void {
+	$accumulator = app( ResponsiveCssAccumulator::class );
+
+	$attributes = [
+		'responsive' => [
+			'style.spacing.padding' => [ 'md' => '2rem' ],
+		],
+	];
+
+	BlockSupports::compile( $attributes );
+	BlockSupports::compile( $attributes );
+	BlockSupports::compile( $attributes );
+
+	expect( $accumulator->all() )->toHaveCount( 1 );
+} );
+
+it( 'wrapperCss() returns an empty string (rules now go through the accumulator)', function (): void {
+	expect( BlockSupports::wrapperCss( [
+		'responsive' => [
+			'style.spacing.padding' => [ 'md' => '2rem' ],
+		],
+	] ) )->toBe( '' );
+} );
+
+it( 'wrapperCss() still pushes into the accumulator for the side effect', function (): void {
+	$accumulator = app( ResponsiveCssAccumulator::class );
+
+	BlockSupports::wrapperCss( [
+		'responsive' => [
+			'style.spacing.margin' => [ 'md' => '0.5rem' ],
+		],
+	] );
+
+	expect( $accumulator->all() )->not->toBeEmpty();
+} );
+
+it( 'wrapperAttrs() includes the responsive class in the class attribute', function (): void {
+	$html = BlockSupports::wrapperAttrs(
+		[
+			'responsive' => [
+				'style.spacing.padding' => [ 'md' => '2rem' ],
+			],
+		],
+		[ 'wp-block-columns' ]
+	);
+
+	expect( $html )->toMatch( '/class="wp-block-columns ve-r-[a-f0-9]+"/' );
+} );
+
+it( 'produces a stable scope class for the same responsive payload', function (): void {
+	$payload = [
+		'responsive' => [
+			'style.spacing.padding' => [ 'md' => '2rem' ],
+		],
+	];
+
+	$first  = BlockSupports::compileResponsive( $payload );
+	$second = BlockSupports::compileResponsive( $payload );
+
+	expect( $first['class'] )->toBe( $second['class'] );
+} );

--- a/packages/visual-editor-renderer-blade/tests/Unit/BlockSupportsTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Unit/BlockSupportsTest.php
@@ -445,9 +445,12 @@ describe( 'BlockSupports::compile (composition)', function (): void {
 		$result = BlockSupports::compile( [] );
 
 		expect( $result )->toBe( [
-			'classes' => [],
-			'style'   => '',
-			'id'      => null,
+			'classes'         => [],
+			'style'           => '',
+			'id'              => null,
+			'responsiveCss'   => '',
+			'responsiveClass' => '',
+			'responsiveRules' => '',
 		] );
 	} );
 

--- a/packages/visual-editor-renderer-blade/tests/Unit/ResponsiveClassResolverTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Unit/ResponsiveClassResolverTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Responsive\BreakpointRegistry;
+use ArtisanPackUI\VisualEditor\Responsive\ResponsiveValueResolver;
+use ArtisanPackUI\VisualEditorRendererBlade\Responsive\ResponsiveClassResolver;
+
+function makeBladeResponsiveResolver( array $configOverrides = [] ): ResponsiveClassResolver
+{
+	$registry = BreakpointRegistry::fromLayers( $configOverrides, [] );
+	$resolver = new ResponsiveValueResolver( $registry );
+
+	return new ResponsiveClassResolver( $registry, $resolver );
+}
+
+it( 'returns empty class+css when given a null attribute', function () {
+	$resolver = makeBladeResponsiveResolver();
+
+	expect( $resolver->emit( null, 'padding' ) )->toBe( [ 'class' => '', 'css' => '' ] );
+} );
+
+it( 'emits Tailwind class strings when every value maps to a token', function () {
+	$resolver = makeBladeResponsiveResolver();
+
+	$attribute = [ 'base' => 4, 'sm' => 1, 'md' => 2 ];
+	$tokenMap  = [
+		'4' => 'grid-cols-4',
+		'1' => 'grid-cols-1',
+		'2' => 'grid-cols-2',
+	];
+
+	$result = $resolver->emit( $attribute, 'grid-template-columns', $tokenMap );
+
+	expect( $result['css'] )->toBe( '' );
+	expect( $result['class'] )->toBe( 'grid-cols-4 sm:grid-cols-1 md:grid-cols-2' );
+} );
+
+it( 'skips redundant inherited values when tokenizing', function () {
+	$resolver = makeBladeResponsiveResolver();
+
+	$attribute = [ 'base' => 4, 'sm' => 4, 'md' => 6, 'lg' => 6 ];
+	$tokenMap  = [
+		'4' => 'px-4',
+		'6' => 'px-6',
+	];
+
+	$result = $resolver->emit( $attribute, 'padding', $tokenMap );
+
+	expect( $result['class'] )->toBe( 'px-4 md:px-6' );
+} );
+
+it( 'falls back to @media rules when a value cannot be tokenized', function () {
+	$resolver = makeBladeResponsiveResolver();
+
+	$attribute = [ 'base' => '13px', 'md' => '18px' ];
+
+	$result = $resolver->emit( $attribute, 'font-size', [] );
+
+	expect( $result['class'] )->toStartWith( 've-r-' );
+	expect( $result['css'] )->toContain( 'font-size:13px' );
+	expect( $result['css'] )->toContain( '@media (min-width:768px)' );
+	expect( $result['css'] )->toContain( 'font-size:18px' );
+} );
+
+it( 'accepts a callable token map', function () {
+	$resolver = makeBladeResponsiveResolver();
+
+	$attribute = [ 'base' => 1, 'md' => 3 ];
+
+	$result = $resolver->emit(
+		$attribute,
+		'grid-template-columns',
+		static fn ( $value ): ?string => is_int( $value ) ? 'cols-' . $value : null,
+	);
+
+	expect( $result['class'] )->toBe( 'cols-1 md:cols-3' );
+	expect( $result['css'] )->toBe( '' );
+} );
+
+it( 'uses the active registry prefixes for class output', function () {
+	// Adding a `3xl` breakpoint via config should make `3xl:` show up
+	// in the emitted class string.
+	$resolver = makeBladeResponsiveResolver( [ '3xl' => 1920 ] );
+
+	$attribute = [ 'base' => 1, '3xl' => 5 ];
+	$tokenMap  = [
+		'1' => 'cols-1',
+		'5' => 'cols-5',
+	];
+
+	$result = $resolver->emit( $attribute, 'grid-template-columns', $tokenMap );
+
+	expect( $result['class'] )->toBe( 'cols-1 3xl:cols-5' );
+} );

--- a/resources/js/visual-editor/blocks/buttons/block.json
+++ b/resources/js/visual-editor/blocks/buttons/block.json
@@ -64,7 +64,14 @@
             "clientNavigation": true
         },
         "listView": true,
-        "contentRole": true
+        "contentRole": true,
+        "artisanpackResponsive": {
+            "attributes": [
+                "spacing",
+                "align",
+                "layout.flexDirection"
+            ]
+        }
     },
     "editorStyle": "wp-block-buttons-editor",
     "style": "wp-block-buttons"

--- a/resources/js/visual-editor/blocks/column/block.json
+++ b/resources/js/visual-editor/blocks/column/block.json
@@ -76,7 +76,6 @@
         "artisanpackResponsive": {
             "attributes": [
                 "spacing",
-                "align",
                 "width"
             ]
         }

--- a/resources/js/visual-editor/blocks/column/block.json
+++ b/resources/js/visual-editor/blocks/column/block.json
@@ -72,6 +72,13 @@
         "interactivity": {
             "clientNavigation": true
         },
-        "allowedBlocks": true
+        "allowedBlocks": true,
+        "artisanpackResponsive": {
+            "attributes": [
+                "spacing",
+                "align",
+                "width"
+            ]
+        }
     }
 }

--- a/resources/js/visual-editor/blocks/columns/block.json
+++ b/resources/js/visual-editor/blocks/columns/block.json
@@ -18,6 +18,9 @@
         "templateLock": {
             "type": [ "string", "boolean" ],
             "enum": [ "all", "insert", "contentOnly", false ]
+        },
+        "columnCount": {
+            "type": "number"
         }
     },
     "supports": {
@@ -83,7 +86,14 @@
         "interactivity": {
             "clientNavigation": true
         },
-        "shadow": true
+        "shadow": true,
+        "artisanpackResponsive": {
+            "attributes": [
+                "spacing",
+                "align",
+                "columnCount"
+            ]
+        }
     },
     "editorStyle": "wp-block-columns-editor",
     "style": "wp-block-columns"

--- a/resources/js/visual-editor/blocks/columns/edit.tsx
+++ b/resources/js/visual-editor/blocks/columns/edit.tsx
@@ -42,6 +42,8 @@ import {
     toWidthPrecision,
 } from './utils';
 
+import { getActiveBreakpoint, BASE_KEY } from '../../responsive';
+
 const COLUMN_BLOCK = 'artisanpack/column';
 const DEFAULT_BLOCK = { name: COLUMN_BLOCK };
 
@@ -49,6 +51,7 @@ interface ColumnsAttributes {
     readonly verticalAlignment?: string;
     readonly isStackedOnMobile?: boolean;
     readonly templateLock?: string | boolean;
+    readonly columnCount?: number;
 }
 
 interface ColumnsEditProps {
@@ -62,10 +65,12 @@ function ColumnInspectorControls({
     clientId,
     setAttributes,
     isStackedOnMobile,
+    columnCount,
 }: {
     clientId: string;
     setAttributes: (attrs: Partial<ColumnsAttributes>) => void;
     isStackedOnMobile?: boolean;
+    columnCount?: number;
 }): ReactElement {
     const { count, canInsertColumnBlock, minCount } = useSelect(
         (select: any) => {
@@ -147,14 +152,35 @@ function ColumnInspectorControls({
                         // @ts-expect-error - upstream prop
                         __next40pxDefaultSize
                         label={__('Columns')}
-                        value={count}
-                        onChange={(value: number) =>
-                            updateColumns(count, Math.max(minCount, value))
-                        }
+                        // The HOC merges responsive overrides into the
+                        // `columnCount` attribute, so `columnCount`
+                        // reflects the resolved value for the active
+                        // breakpoint. At base it's typically undefined
+                        // (the inner-block count is the source of
+                        // truth), so fall back to `count`.
+                        value={columnCount ?? count}
+                        onChange={(value: number) => {
+                            const next = Math.max(minCount, value);
+                            // At `base`, reshape the inner blocks
+                            // physically (today's behavior) AND record
+                            // the count attribute so the responsive
+                            // cascade has a base to inherit from.
+                            // At non-base, the HOC routes
+                            // `columnCount` into
+                            // `attributes.responsive.columnCount.<bp>`
+                            // — the inner block tree stays intact
+                            // because that breakpoint is editor-only
+                            // at v1.0; the server renderer applies
+                            // the override on publish.
+                            if (getActiveBreakpoint() === BASE_KEY) {
+                                updateColumns(count, next);
+                            }
+                            setAttributes({ columnCount: next });
+                        }}
                         min={Math.max(1, minCount)}
-                        max={Math.max(6, count)}
+                        max={Math.max(6, columnCount ?? count)}
                     />
-                    {count > 6 && (
+                    {(columnCount ?? count) > 6 && (
                         <Notice status="warning" isDismissible={false}>
                             {__(
                                 'This column count exceeds the recommended amount and may cause visual breakage.'
@@ -190,7 +216,12 @@ function ColumnsEditContainer({
     setAttributes,
     clientId,
 }: ColumnsEditProps): ReactElement {
-    const { isStackedOnMobile, verticalAlignment, templateLock } = attributes;
+    const {
+        isStackedOnMobile,
+        verticalAlignment,
+        templateLock,
+        columnCount,
+    } = attributes;
     const registry = useRegistry();
     const { getBlockOrder } = useSelect(blockEditorStore) as any;
     const { updateBlockAttributes } = useDispatch(blockEditorStore) as any;
@@ -234,6 +265,7 @@ function ColumnsEditContainer({
                     clientId={clientId}
                     setAttributes={setAttributes}
                     isStackedOnMobile={isStackedOnMobile}
+                    columnCount={columnCount}
                 />
             </InspectorControls>
             <div {...innerBlocksProps} />

--- a/resources/js/visual-editor/blocks/cover/block.json
+++ b/resources/js/visual-editor/blocks/cover/block.json
@@ -146,7 +146,14 @@
         "filter": {
             "duotone": true
         },
-        "allowedBlocks": true
+        "allowedBlocks": true,
+        "artisanpackResponsive": {
+            "attributes": [
+                "spacing",
+                "align",
+                "minHeight"
+            ]
+        }
     },
     "selectors": {
         "filter": {

--- a/resources/js/visual-editor/blocks/group/block.json
+++ b/resources/js/visual-editor/blocks/group/block.json
@@ -91,7 +91,13 @@
         "interactivity": {
             "clientNavigation": true
         },
-        "allowedBlocks": true
+        "allowedBlocks": true,
+        "artisanpackResponsive": {
+            "attributes": [
+                "spacing",
+                "align"
+            ]
+        }
     },
     "editorStyle": "wp-block-group-editor",
     "style": "wp-block-group"

--- a/resources/js/visual-editor/blocks/media-text/block.json
+++ b/resources/js/visual-editor/blocks/media-text/block.json
@@ -141,7 +141,14 @@
         "interactivity": {
             "clientNavigation": true
         },
-        "allowedBlocks": true
+        "allowedBlocks": true,
+        "artisanpackResponsive": {
+            "attributes": [
+                "spacing",
+                "align",
+                "mediaWidth"
+            ]
+        }
     },
     "editorStyle": "wp-block-media-text-editor",
     "style": "wp-block-media-text"

--- a/resources/js/visual-editor/blocks/spacer/block.json
+++ b/resources/js/visual-editor/blocks/spacer/block.json
@@ -26,6 +26,13 @@
         },
         "interactivity": {
             "clientNavigation": true
+        },
+        "artisanpackResponsive": {
+            "attributes": [
+                "height",
+                "width",
+                "spacing"
+            ]
         }
     },
     "editorStyle": "wp-block-spacer-editor",

--- a/resources/js/visual-editor/editor-settings.ts
+++ b/resources/js/visual-editor/editor-settings.ts
@@ -58,6 +58,23 @@ export const DEFAULT_FONT_SIZES = [
     { name: __('Huge', TEXT_DOMAIN), slug: 'huge', size: '36px' },
 ];
 
+/**
+ * Default spacing scale exposed to the spacing panel when a theme hasn't
+ * shipped its own `settings.spacing.spacingSizes`. Slugs run `20 → 70`,
+ * matching WordPress core's numeric-stepped slug convention so saved
+ * markup stays portable when a theme overrides with its own scale.
+ */
+export const DEFAULT_SPACING_SIZES = [
+    { slug: '20', name: __('Tight', TEXT_DOMAIN), size: '0.5rem' },
+    { slug: '30', name: __('Small', TEXT_DOMAIN), size: '1rem' },
+    { slug: '40', name: __('Medium', TEXT_DOMAIN), size: '1.5rem' },
+    { slug: '50', name: __('Large', TEXT_DOMAIN), size: '3rem' },
+    { slug: '60', name: __('X-Large', TEXT_DOMAIN), size: '5rem' },
+    { slug: '70', name: __('Section', TEXT_DOMAIN), size: '7rem' },
+];
+
+export const DEFAULT_SPACING_UNITS = ['px', 'em', 'rem', '%', 'vh', 'vw'];
+
 export const DEFAULT_FONT_FAMILIES = [
     {
         name: __('System', TEXT_DOMAIN),
@@ -302,11 +319,20 @@ export const editorSettings = {
     // haven't migrated to `__experimentalFeatures`.
     colors: DEFAULT_PALETTE,
     fontSizes: DEFAULT_FONT_SIZES,
-    // Minimal `__experimentalFeatures` — only the keys needed for the
-    // Typography panel's font-family picker and the text-alignment
-    // toolbar. Turning on more keys (border, spacing, duotone, default
-    // palettes) re-introduces the color-picker drag loop we're hunting;
-    // keep this config narrow until the upstream fix lands.
+    // `__experimentalFeatures` lights up the inspector panels
+    // (Color, Typography, Dimensions, Border) plus the toolbar
+    // text-alignment control.
+    //
+    // History: this block previously excluded `spacing`, `border`,
+    // `dimensions`, `defaultPalette`, `defaultGradients`, and
+    // `defaultDuotone` to avoid an upstream Gutenberg drag-loop bug
+    // that fired when color/spacing controls escaped the editor frame.
+    // The Phase A iframe migration scopes those events to the canvas
+    // iframe, so `spacing`/`border`/`dimensions` are now re-enabled
+    // here. Default palette/gradient/duotone keys are still left off —
+    // they pull in upstream preset data we don't ship, and the
+    // palette/font-size data is already surfaced via the explicit
+    // `palette` and `fontSizes` entries below.
     __experimentalFeatures: {
         layout: {
             contentSize: '720px',
@@ -355,6 +381,35 @@ export const editorSettings = {
             textTransform: true,
             fontSizes: { custom: DEFAULT_FONT_SIZES },
             fontFamilies: { custom: DEFAULT_FONT_FAMILIES },
+        },
+        spacing: {
+            // Padding, margin, blockGap → the Dimensions panel on
+            // every block that declares `supports.spacing`. The
+            // spacing scale below is the default theme.json mirror;
+            // host themes override via `settings.spacing.spacingSizes`.
+            padding: true,
+            margin: true,
+            blockGap: true,
+            customSpacingSize: true,
+            units: DEFAULT_SPACING_UNITS,
+            spacingScale: { steps: 0 },
+            spacingSizes: { theme: DEFAULT_SPACING_SIZES, custom: [] },
+        },
+        border: {
+            // Border controls (color, radius, style, width) → the
+            // Border panel on every block that declares
+            // `supports.__experimentalBorder`.
+            color: true,
+            radius: true,
+            style: true,
+            width: true,
+        },
+        dimensions: {
+            // Min-height + aspect-ratio → the Dimensions panel on
+            // blocks like core/cover, core/post-featured-image, and
+            // our `artisanpack/cover` / `artisanpack/group` forks.
+            minHeight: true,
+            aspectRatio: true,
         },
     },
 };

--- a/resources/js/visual-editor/editor/editor-app.tsx
+++ b/resources/js/visual-editor/editor/editor-app.tsx
@@ -39,6 +39,8 @@ import { registerArtisanPackBlocks } from '../blocks';
 
 import { BlockLibrarySidebar } from './block-library-sidebar';
 import { registerContrastWarning } from './contrast-warning';
+import { registerResponsiveAttribute } from '../responsive/register-attribute';
+import { registerResponsiveAttributesFilter } from '../responsive/with-responsive-attributes';
 import { ConvertToPatternControl } from './convert-to-pattern-control';
 import { EditorCanvas } from './editor-canvas';
 import { registerSyncedPatternIndicator } from './synced-pattern-indicator';
@@ -156,6 +158,12 @@ function registerOnce(): void {
     disableContrastCheckerOnBlocks();
     registerContrastWarning();
     registerSyncedPatternIndicator();
+    // #487 — register the responsive feature filters BEFORE blocks load
+    // so opted-in blocks pick up the auto-injected `responsive`
+    // attribute at registration time and the BlockEdit HOC wraps every
+    // edit component on first render.
+    registerResponsiveAttribute();
+    registerResponsiveAttributesFilter();
     // I7 (#415): register all artisanpack/* blocks and set the default
     // block to artisanpack/paragraph. Core blocks are no longer loaded.
     registerArtisanPackBlocks();

--- a/resources/js/visual-editor/editor/inspector-sidebar.tsx
+++ b/resources/js/visual-editor/editor/inspector-sidebar.tsx
@@ -29,6 +29,8 @@
 import { BlockInspector } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
+
+import { InspectorScopeChip } from '../responsive/InspectorScopeChip';
 import {
     useCallback,
     useEffect,
@@ -257,7 +259,10 @@ export function InspectorSidebar(props: InspectorSidebarProps): JSX.Element {
                 data-testid="ap-visual-editor-inspector-block-panel"
             >
                 {hasSelectedBlock ? (
-                    <BlockInspector />
+                    <>
+                        <InspectorScopeChip />
+                        <BlockInspector />
+                    </>
                 ) : (
                     <p
                         className="ap-visual-editor-inspector-sidebar__empty"

--- a/resources/js/visual-editor/editor/top-bar-viewport.css
+++ b/resources/js/visual-editor/editor/top-bar-viewport.css
@@ -1,0 +1,53 @@
+/**
+ * Viewport switcher styles for the editor top bar (#487).
+ *
+ * Reads from the existing `--ap-visual-editor-top-bar-*` custom
+ * properties so the switcher matches the surrounding chrome and
+ * inherits the host theme's DaisyUI tokens.
+ */
+
+.ap-visual-editor-top-bar__group--center {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 1 auto;
+}
+
+.ap-visual-editor-viewport-switcher {
+    display: inline-flex;
+    align-items: center;
+    gap: 2px;
+    padding: 2px;
+    background: color-mix(
+        in oklch,
+        var(--ap-visual-editor-top-bar-foreground, #1f2937) 6%,
+        transparent
+    );
+    border: 1px solid var(--ap-visual-editor-top-bar-border, #e5e7eb);
+    border-radius: var(--ap-visual-editor-top-bar-radius, 6px);
+    font-size: 12px;
+    line-height: 1;
+}
+
+.ap-visual-editor-viewport-switcher button {
+    appearance: none;
+    background: transparent;
+    border: 0;
+    color: var(--ap-visual-editor-top-bar-foreground, #1f2937);
+    cursor: pointer;
+    padding: 4px 10px;
+    border-radius: calc(var(--ap-visual-editor-top-bar-radius, 6px) - 2px);
+    transition:
+        background-color 120ms ease,
+        color 120ms ease;
+    font: inherit;
+}
+
+.ap-visual-editor-viewport-switcher button:hover {
+    background: var(--ap-visual-editor-top-bar-hover, rgba(37, 99, 235, 0.1));
+}
+
+.ap-visual-editor-viewport-switcher button[aria-pressed='true'] {
+    background: var(--ap-visual-editor-top-bar-accent, #2563eb);
+    color: var(--ap-visual-editor-top-bar-accent-contrast, #ffffff);
+}

--- a/resources/js/visual-editor/editor/top-bar.tsx
+++ b/resources/js/visual-editor/editor/top-bar.tsx
@@ -32,8 +32,18 @@ import {
 import { __ } from '@wordpress/i18n';
 
 import { TEXT_DOMAIN } from '../vendor/i18n';
+import { BreakpointRegistry, TAILWIND_V4_DEFAULTS } from '../responsive/registry';
+import { ViewportSwitcher } from '../responsive/ViewportSwitcher';
 
 import './top-bar.css';
+import './top-bar-viewport.css';
+
+// Default registry used when the host app hasn't stamped its own
+// breakpoint snapshot into the bootstrap settings. Constructed once at
+// module load so every top-bar instance shares the same identity.
+const DEFAULT_VIEWPORT_REGISTRY = new BreakpointRegistry(
+    TAILWIND_V4_DEFAULTS,
+);
 
 export type SaveStatus = 'idle' | 'saving' | 'saved' | 'error';
 
@@ -437,6 +447,12 @@ export function TopBar(props: TopBarProps): JSX.Element {
                         />
                     </svg>
                 </button>
+            </div>
+            <div className="ap-visual-editor-top-bar__group ap-visual-editor-top-bar__group--center">
+                <ViewportSwitcher
+                    registry={DEFAULT_VIEWPORT_REGISTRY}
+                    className="ap-visual-editor-viewport-switcher"
+                />
             </div>
             <div className="ap-visual-editor-top-bar__group ap-visual-editor-top-bar__group--end">
                 <span

--- a/resources/js/visual-editor/responsive/InspectorScopeChip.tsx
+++ b/resources/js/visual-editor/responsive/InspectorScopeChip.tsx
@@ -1,0 +1,69 @@
+/**
+ * Inspector scope chip (#487).
+ *
+ * Small banner rendered at the top of the inspector's Block tab. When
+ * the editor's active breakpoint is not `base`, it tells the editor
+ * which viewport their next style edit will apply to — otherwise the
+ * inspector controls would look like they were silently changing the
+ * default value when they're actually scoped.
+ *
+ * Hidden entirely at `base` so the inspector stays uncluttered
+ * during normal editing.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.0.0
+ */
+
+import { useSyncExternalStore } from 'react'
+
+import { getActiveBreakpoint, setActiveBreakpoint, subscribeActiveBreakpoint } from './active-breakpoint'
+import { BASE_KEY } from './types'
+
+import './inspector-scope-chip.css'
+
+// See ViewportSwitcher.tsx for why these are size-keyed rather than
+// device-named.
+const LABELS: Record<string, string> = {
+    [ BASE_KEY ]: 'All sizes',
+    sm:          'sm and up',
+    md:          'md and up',
+    lg:          'lg and up',
+    xl:          'xl and up',
+    '2xl':       '2xl and up',
+}
+
+export function InspectorScopeChip(): JSX.Element | null {
+    const active = useSyncExternalStore(
+        subscribeActiveBreakpoint,
+        getActiveBreakpoint,
+        getActiveBreakpoint,
+    )
+
+    if ( BASE_KEY === active ) {
+        return null
+    }
+
+    const label = LABELS[ active ] ?? active
+
+    return (
+        <div
+            className="ap-visual-editor-inspector-scope-chip"
+            role="status"
+            aria-live="polite"
+        >
+            <span className="ap-visual-editor-inspector-scope-chip__label">
+                Editing at <strong>{ label }</strong>
+                <span className="ap-visual-editor-inspector-scope-chip__key">
+                    ({ active })
+                </span>
+            </span>
+            <button
+                type="button"
+                className="ap-visual-editor-inspector-scope-chip__reset"
+                onClick={ () => setActiveBreakpoint( BASE_KEY ) }
+            >
+                Switch to All sizes
+            </button>
+        </div>
+    )
+}

--- a/resources/js/visual-editor/responsive/ResponsiveControl.tsx
+++ b/resources/js/visual-editor/responsive/ResponsiveControl.tsx
@@ -1,0 +1,87 @@
+/**
+ * Per-breakpoint InspectorControls wrapper (#487).
+ *
+ * Renders any single-value control (number input, alignment toggle,
+ * font-size picker, etc.) as a per-breakpoint control. The wrapper:
+ *
+ *  - Reads the value the editor is currently authoring against (the
+ *    active breakpoint) via {@see useResponsiveValue}.
+ *  - Persists writes through the {@see promote} migrator so scalars
+ *    only inflate to the discriminated form on first override.
+ *  - Surfaces a per-breakpoint "Reset to base" affordance that
+ *    delegates to {@see clearOverride}.
+ *
+ * The actual control is passed in via a render prop so this wrapper
+ * stays orthogonal to the visual primitive (which differs per
+ * attribute — slider, select, text input, …).
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.0.0
+ */
+
+import { useSyncExternalStore } from 'react'
+
+import { getActiveBreakpoint, subscribeActiveBreakpoint } from './active-breakpoint'
+import { clearOverride, promote } from './migrator'
+import type { BreakpointRegistry } from './registry'
+import { resolveResponsiveValue } from './resolver'
+import { BASE_KEY, type ResponsiveAttribute } from './types'
+
+export interface ResponsiveControlProps<T> {
+	registry: BreakpointRegistry
+	value: ResponsiveAttribute<T> | null | undefined
+	onChange: ( next: ResponsiveAttribute<T> | null ) => void
+	/**
+	 * Renders the underlying single-value control. Receives the value
+	 * for the currently-active breakpoint (or the cascaded value) and
+	 * a `setValue` callback that promotes/persists into the
+	 * discriminated form.
+	 */
+	render: ( props: { value: T | null; setValue: ( next: T | null ) => void; breakpoint: string } ) => JSX.Element
+	label?: string
+}
+
+export function ResponsiveControl<T>( {
+	registry,
+	value,
+	onChange,
+	render,
+	label,
+}: ResponsiveControlProps<T> ): JSX.Element {
+	const activeBreakpoint = useSyncExternalStore( subscribeActiveBreakpoint, getActiveBreakpoint, getActiveBreakpoint )
+
+	const resolved = resolveResponsiveValue<T>( value, activeBreakpoint, registry )
+
+	const setValue = ( next: T | null ): void => {
+		onChange( promote<T>( value, activeBreakpoint, next ) )
+	}
+
+	const resetOverride = (): void => {
+		const cleared = clearOverride<T>( value, activeBreakpoint )
+		onChange( cleared as ResponsiveAttribute<T> | null )
+	}
+
+	const isOverridden = BASE_KEY !== activeBreakpoint
+		&& value !== null
+		&& 'object' === typeof value
+		&& null !== ( value as Record<string, unknown> )[ activeBreakpoint ]
+		&& undefined !== ( value as Record<string, unknown> )[ activeBreakpoint ]
+
+	return (
+		<div className="ve-responsive-control" data-breakpoint={ activeBreakpoint }>
+			{ label ? <div className="ve-responsive-control__label">{ label }</div> : null }
+
+			{ render( { value: resolved, setValue, breakpoint: activeBreakpoint } ) }
+
+			{ isOverridden ? (
+				<button
+					type="button"
+					className="ve-responsive-control__reset"
+					onClick={ resetOverride }
+				>
+					Reset to base
+				</button>
+			) : null }
+		</div>
+	)
+}

--- a/resources/js/visual-editor/responsive/ViewportSwitcher.tsx
+++ b/resources/js/visual-editor/responsive/ViewportSwitcher.tsx
@@ -1,0 +1,96 @@
+/**
+ * Viewport switcher (#487).
+ *
+ * Toolbar component that lets the editor preview the canvas at a
+ * specific breakpoint AND scope subsequent style edits to that
+ * breakpoint.
+ *
+ * Behavior:
+ *  - Renders one button per registered breakpoint plus a `base`
+ *    button on the left.
+ *  - Selecting a button (a) updates the active-breakpoint store,
+ *    (b) sets the canvas iframe's width to the breakpoint's
+ *    min-width (or unconstrained for `base`), (c) keeps the
+ *    selection visible via aria-pressed.
+ *  - The actual canvas-resize side-effect is delegated to an
+ *    `onChange` callback so different host shells (admin editor,
+ *    sandbox, site-editor) can resize their own surface.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.0.0
+ */
+
+import { useSyncExternalStore } from 'react'
+
+import { getActiveBreakpoint, setActiveBreakpoint, subscribeActiveBreakpoint } from './active-breakpoint'
+import type { BreakpointRegistry } from './registry'
+import { BASE_KEY } from './types'
+
+export interface ViewportSwitcherProps {
+	registry: BreakpointRegistry
+	/** Optional side-effect — typically resizes the canvas iframe. */
+	onChange?: ( breakpoint: string, minWidthPx: number ) => void
+	className?: string
+	/** Override the visible labels (defaults to the breakpoint key, e.g. "sm"). */
+	labels?: Record<string, string>
+}
+
+// Labels are intentionally size-keyed (`sm+`, `md+`) rather than
+// device-named (`Mobile`, `Tablet`). The editor uses mobile-first
+// cascade semantics — `base` applies everywhere, and each named
+// breakpoint is a progressive override at that min-width and up. A
+// label like "Mobile" for `sm` mis-suggests it scopes to phones only;
+// the `+` suffix makes the "this size and up" semantics obvious.
+const DEFAULT_LABELS: Record<string, string> = {
+	[ BASE_KEY ]: 'All sizes',
+	sm:          'sm+',
+	md:          'md+',
+	lg:          'lg+',
+	xl:          'xl+',
+	'2xl':       '2xl+',
+}
+
+function tooltipFor( key: string, minWidth: number ): string {
+	if ( BASE_KEY === key ) {
+		return 'Applies to every viewport. Smaller breakpoints inherit this value unless overridden.'
+	}
+
+	return `Applies at ${ minWidth }px and up (mobile-first cascade).`
+}
+
+export function ViewportSwitcher( { registry, onChange, className, labels }: ViewportSwitcherProps ): JSX.Element {
+	const active  = useSyncExternalStore( subscribeActiveBreakpoint, getActiveBreakpoint, getActiveBreakpoint )
+	const display = { ...DEFAULT_LABELS, ...( labels ?? {} ) }
+	const keys    = registry.keysWithBase()
+
+	const handleSelect = ( key: string ): void => {
+		setActiveBreakpoint( key )
+
+		if ( onChange ) {
+			onChange( key, registry.get( key ) ?? 0 )
+		}
+	}
+
+	return (
+		<div className={ className ?? 've-viewport-switcher' } role="group" aria-label="Preview viewport">
+			{ keys.map( ( key ) => {
+				const isActive = key === active
+				const minWidth = registry.get( key ) ?? 0
+
+				return (
+					<button
+						key={ key }
+						type="button"
+						aria-pressed={ isActive }
+						data-active={ isActive ? 'true' : 'false' }
+						data-breakpoint={ key }
+						title={ tooltipFor( key, minWidth ) }
+						onClick={ () => handleSelect( key ) }
+					>
+						{ display[ key ] ?? key }
+					</button>
+				)
+			} ) }
+		</div>
+	)
+}

--- a/resources/js/visual-editor/responsive/__tests__/active-breakpoint.test.ts
+++ b/resources/js/visual-editor/responsive/__tests__/active-breakpoint.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+	getActiveBreakpoint,
+	resetActiveBreakpoint,
+	setActiveBreakpoint,
+	subscribeActiveBreakpoint,
+} from '../active-breakpoint'
+
+afterEach( () => {
+	resetActiveBreakpoint()
+} )
+
+describe( 'active-breakpoint store', () => {
+	it( 'starts at base', () => {
+		expect( getActiveBreakpoint() ).toBe( 'base' )
+	} )
+
+	it( 'notifies subscribers when the breakpoint changes', () => {
+		const listener = vi.fn()
+		const unsubscribe = subscribeActiveBreakpoint( listener )
+
+		setActiveBreakpoint( 'md' )
+
+		expect( listener ).toHaveBeenCalledWith( 'md' )
+		expect( getActiveBreakpoint() ).toBe( 'md' )
+
+		unsubscribe()
+	} )
+
+	it( 'does not notify when the breakpoint is set to the current value', () => {
+		setActiveBreakpoint( 'md' )
+
+		const listener = vi.fn()
+		const unsubscribe = subscribeActiveBreakpoint( listener )
+
+		setActiveBreakpoint( 'md' )
+
+		expect( listener ).not.toHaveBeenCalled()
+
+		unsubscribe()
+	} )
+} )

--- a/resources/js/visual-editor/responsive/__tests__/attribute-paths.test.ts
+++ b/resources/js/visual-editor/responsive/__tests__/attribute-paths.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+	deepMerge,
+	diffPaths,
+	pathMatchesAnyRoot,
+	readPath,
+	setPath,
+} from '../attribute-paths'
+
+describe( 'readPath', () => {
+	it( 'reads a top-level value', () => {
+		expect( readPath( { foo: 1 }, 'foo' ) ).toBe( 1 )
+	} )
+
+	it( 'reads a nested value through dotted segments', () => {
+		expect( readPath( { a: { b: { c: 'leaf' } } }, 'a.b.c' ) ).toBe( 'leaf' )
+	} )
+
+	it( 'returns undefined for a missing segment', () => {
+		expect( readPath( { a: { b: 1 } }, 'a.b.c' ) ).toBeUndefined()
+	} )
+
+	it( 'returns undefined for a non-object source', () => {
+		expect( readPath( null, 'a' ) ).toBeUndefined()
+		expect( readPath( 4, 'a' ) ).toBeUndefined()
+	} )
+
+	it( 'does not descend into arrays', () => {
+		expect( readPath( { arr: [ 1, 2 ] }, 'arr.0' ) ).toBeUndefined()
+	} )
+} )
+
+describe( 'setPath', () => {
+	it( 'sets a top-level value without mutating the input', () => {
+		const source = { foo: 1 }
+		const next   = setPath( source, 'foo', 2 )
+
+		expect( next ).toEqual( { foo: 2 } )
+		expect( source ).toEqual( { foo: 1 } )
+	} )
+
+	it( 'creates intermediate objects when missing', () => {
+		expect( setPath( {}, 'a.b.c', 'leaf' ) ).toEqual( {
+			a: { b: { c: 'leaf' } },
+		} )
+	} )
+
+	it( 'merges into existing objects rather than replacing them', () => {
+		const source = { a: { b: { keep: true } } }
+
+		expect( setPath( source, 'a.b.c', 'leaf' ) ).toEqual( {
+			a: { b: { keep: true, c: 'leaf' } },
+		} )
+	} )
+
+	it( 'replaces a scalar with an object when the path traverses it', () => {
+		expect( setPath( { a: 'string' }, 'a.b', 'leaf' ) ).toEqual( {
+			a: { b: 'leaf' },
+		} )
+	} )
+
+	it( 'deletes a leaf when value is undefined and prunes empty parents', () => {
+		expect( setPath( { a: { b: { c: 'leaf' } } }, 'a.b.c', undefined ) ).toEqual( {} )
+	} )
+
+	it( 'preserves sibling values when deleting one leaf', () => {
+		expect( setPath( { a: { b: 1, c: 2 } }, 'a.b', undefined ) ).toEqual( {
+			a: { c: 2 },
+		} )
+	} )
+} )
+
+describe( 'diffPaths', () => {
+	it( 'returns an empty list when nothing changed', () => {
+		expect( diffPaths( { a: 1 }, { a: 1 } ) ).toEqual( [] )
+	} )
+
+	it( 'flags a single top-level change', () => {
+		expect( diffPaths( { a: 2 }, { a: 1 } ) ).toEqual( [
+			{ path: 'a', value: 2 },
+		] )
+	} )
+
+	it( 'recurses into nested objects', () => {
+		expect( diffPaths( { a: { b: 5 } }, { a: { b: 4 } } ) ).toEqual( [
+			{ path: 'a.b', value: 5 },
+		] )
+	} )
+
+	it( 'treats arrays as leaves and replaces them wholesale', () => {
+		const result = diffPaths( { items: [ 1, 2 ] }, { items: [ 1 ] } )
+		expect( result ).toEqual( [ { path: 'items', value: [ 1, 2 ] } ] )
+	} )
+
+	it( 'detects a leaf change inside a deep object', () => {
+		const updates = { style: { spacing: { padding: '2rem', margin: '1rem' } } }
+		const prev    = { style: { spacing: { padding: '1rem', margin: '1rem' } } }
+
+		expect( diffPaths( updates, prev ) ).toEqual( [
+			{ path: 'style.spacing.padding', value: '2rem' },
+		] )
+	} )
+} )
+
+describe( 'pathMatchesAnyRoot', () => {
+	it( 'matches exact equality', () => {
+		expect( pathMatchesAnyRoot( 'spacing', [ 'spacing' ] ) ).toBe( true )
+	} )
+
+	it( 'matches a prefix on a segment boundary', () => {
+		expect( pathMatchesAnyRoot( 'spacing.padding', [ 'spacing' ] ) ).toBe( true )
+	} )
+
+	it( 'matches a root that appears as a middle segment', () => {
+		expect( pathMatchesAnyRoot( 'style.spacing.padding', [ 'spacing' ] ) ).toBe( true )
+	} )
+
+	it( 'matches a root that appears as the last segment', () => {
+		expect( pathMatchesAnyRoot( 'style.spacing', [ 'spacing' ] ) ).toBe( true )
+	} )
+
+	it( 'does not match a partial-word prefix', () => {
+		expect( pathMatchesAnyRoot( 'spacingScale', [ 'spacing' ] ) ).toBe( false )
+		expect( pathMatchesAnyRoot( 'lineSpacing', [ 'spacing' ] ) ).toBe( false )
+	} )
+
+	it( 'matches any root in the list', () => {
+		expect( pathMatchesAnyRoot( 'columnCount', [ 'spacing', 'columnCount' ] ) ).toBe( true )
+	} )
+} )
+
+describe( 'deepMerge', () => {
+	it( 'returns base when overlay is null/undefined', () => {
+		expect( deepMerge( { a: 1 }, null ) ).toEqual( { a: 1 } )
+		expect( deepMerge( { a: 1 }, undefined ) ).toEqual( { a: 1 } )
+	} )
+
+	it( 'overrides scalars with overlay values', () => {
+		expect( deepMerge( { a: 1, b: 2 }, { a: 10 } ) ).toEqual( {
+			a: 10,
+			b: 2,
+		} )
+	} )
+
+	it( 'merges nested objects recursively', () => {
+		expect(
+			deepMerge(
+				{ style: { spacing: { padding: '1rem', margin: '0.5rem' } } },
+				{ style: { spacing: { padding: '2rem' } } },
+			),
+		).toEqual( {
+			style: { spacing: { padding: '2rem', margin: '0.5rem' } },
+		} )
+	} )
+
+	it( 'replaces arrays wholesale instead of concatenating', () => {
+		expect( deepMerge( { tags: [ 'a' ] }, { tags: [ 'b', 'c' ] } ) ).toEqual( {
+			tags: [ 'b', 'c' ],
+		} )
+	} )
+
+	it( 'never mutates the base', () => {
+		const base = { a: { b: 1 } }
+		deepMerge( base, { a: { c: 2 } } )
+
+		expect( base ).toEqual( { a: { b: 1 } } )
+	} )
+} )

--- a/resources/js/visual-editor/responsive/__tests__/migrator.test.ts
+++ b/resources/js/visual-editor/responsive/__tests__/migrator.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+
+import { clearOverride, demote, promote } from '../migrator'
+
+describe( 'promote', () => {
+	it( 'leaves scalars unchanged when writing the base slot', () => {
+		expect( promote( 4, 'base', 5 ) ).toBe( 5 )
+	} )
+
+	it( 'promotes a scalar into the discriminated form on first non-base override', () => {
+		expect( promote( 4, 'md', 6 ) ).toEqual( { base: 4, md: 6 } )
+	} )
+
+	it( 'merges new overrides into an existing discriminated attribute', () => {
+		const start = { base: 4, md: 6 }
+		expect( promote( start, 'lg', 8 ) ).toEqual( { base: 4, md: 6, lg: 8 } )
+	} )
+} )
+
+describe( 'demote', () => {
+	it( 'collapses back to scalar when every override is null', () => {
+		expect( demote( { base: 4, md: null, lg: null } ) ).toBe( 4 )
+	} )
+
+	it( 'leaves the attribute untouched when overrides remain', () => {
+		const attr = { base: 4, md: 6 }
+		expect( demote( attr ) ).toEqual( attr )
+	} )
+} )
+
+describe( 'clearOverride', () => {
+	it( 'clears a non-base override and demotes when nothing else remains', () => {
+		expect( clearOverride( { base: 4, md: 6 }, 'md' ) ).toBe( 4 )
+	} )
+
+	it( 'clears a single override out of many and keeps the rest', () => {
+		expect( clearOverride( { base: 4, sm: 1, md: 6 }, 'md' ) ).toEqual( {
+			base: 4,
+			sm:   1,
+		} )
+	} )
+} )

--- a/resources/js/visual-editor/responsive/__tests__/registry.test.ts
+++ b/resources/js/visual-editor/responsive/__tests__/registry.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+
+import { BreakpointRegistry, TAILWIND_V4_DEFAULTS, registryFromSnapshot } from '../registry'
+
+describe( 'BreakpointRegistry', () => {
+	it( 'defaults to Tailwind v4 mins when nothing else is passed', () => {
+		const registry = new BreakpointRegistry()
+
+		expect( registry.prefixes() ).toEqual( [ 'sm', 'md', 'lg', 'xl', '2xl' ] )
+		expect( registry.get( 'md' ) ).toBe( 768 )
+	} )
+
+	it( 'sorts breakpoints ascending regardless of input order', () => {
+		const registry = new BreakpointRegistry( [
+			{ key: '2xl', minWidthPx: 1536 },
+			{ key: 'sm', minWidthPx: 640 },
+			{ key: 'md', minWidthPx: 768 },
+		] )
+
+		expect( registry.prefixes() ).toEqual( [ 'sm', 'md', '2xl' ] )
+	} )
+
+	it( 'returns 0 for base and lists it in keysWithBase()', () => {
+		const registry = new BreakpointRegistry()
+
+		expect( registry.get( 'base' ) ).toBe( 0 )
+		expect( registry.keysWithBase()[ 0 ] ).toBe( 'base' )
+		expect( registry.has( 'base' ) ).toBe( true )
+	} )
+
+	it( 'returns null for unknown breakpoints', () => {
+		const registry = new BreakpointRegistry()
+
+		expect( registry.get( 'made-up' ) ).toBeNull()
+	} )
+
+	it( 'rebuilds from a snapshot or falls back to defaults', () => {
+		expect( registryFromSnapshot( undefined ).prefixes() ).toEqual( [ 'sm', 'md', 'lg', 'xl', '2xl' ] )
+
+		const custom = registryFromSnapshot( {
+			breakpoints: [
+				{ key: 'sm', minWidthPx: 640 },
+				{ key: 'huge', minWidthPx: 2000 },
+			],
+		} )
+
+		expect( custom.prefixes() ).toEqual( [ 'sm', 'huge' ] )
+		expect( custom.get( 'huge' ) ).toBe( 2000 )
+	} )
+
+	it( 'exports the Tailwind v4 default list as a constant', () => {
+		expect( TAILWIND_V4_DEFAULTS.map( ( bp ) => bp.key ) ).toEqual( [ 'sm', 'md', 'lg', 'xl', '2xl' ] )
+	} )
+} )

--- a/resources/js/visual-editor/responsive/__tests__/resolver.test.ts
+++ b/resources/js/visual-editor/responsive/__tests__/resolver.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+
+import { BreakpointRegistry, TAILWIND_V4_DEFAULTS } from '../registry'
+import { distinctOverrides, isResponsiveAttribute, resolveResponsiveValue } from '../resolver'
+
+const registry = new BreakpointRegistry( TAILWIND_V4_DEFAULTS )
+
+describe( 'resolveResponsiveValue', () => {
+	it( 'returns scalars unchanged', () => {
+		expect( resolveResponsiveValue( 4, 'md', registry ) ).toBe( 4 )
+		expect( resolveResponsiveValue( 'left', 'md', registry ) ).toBe( 'left' )
+	} )
+
+	it( 'returns null for null/undefined input', () => {
+		expect( resolveResponsiveValue( null, 'md', registry ) ).toBeNull()
+		expect( resolveResponsiveValue( undefined, 'md', registry ) ).toBeNull()
+	} )
+
+	it( 'cascades smaller breakpoint values through null slots', () => {
+		const attribute = { base: 4, sm: 1, md: null, lg: null }
+
+		expect( resolveResponsiveValue( attribute, 'sm', registry ) ).toBe( 1 )
+		expect( resolveResponsiveValue( attribute, 'md', registry ) ).toBe( 1 )
+		expect( resolveResponsiveValue( attribute, 'lg', registry ) ).toBe( 1 )
+	} )
+
+	it( 'returns the largest defined override at or below the active breakpoint', () => {
+		const attribute = { base: 3, sm: 1, md: 2 }
+
+		expect( resolveResponsiveValue( attribute, 'sm', registry ) ).toBe( 1 )
+		expect( resolveResponsiveValue( attribute, 'md', registry ) ).toBe( 2 )
+		expect( resolveResponsiveValue( attribute, 'lg', registry ) ).toBe( 2 )
+		expect( resolveResponsiveValue( attribute, 'base', registry ) ).toBe( 3 )
+	} )
+
+	it( 'returns null when no slot at or below the active breakpoint is defined', () => {
+		const attribute = { md: 5 }
+
+		expect( resolveResponsiveValue( attribute, 'sm', registry ) ).toBeNull()
+	} )
+
+	it( 'falls back to base when active breakpoint is unknown', () => {
+		const attribute = { base: 7, md: 9 }
+
+		expect( resolveResponsiveValue( attribute, 'made-up', registry ) ).toBe( 7 )
+	} )
+} )
+
+describe( 'isResponsiveAttribute', () => {
+	it( 'recognises base-keyed and registry-keyed objects', () => {
+		expect( isResponsiveAttribute( { base: 1 }, registry ) ).toBe( true )
+		expect( isResponsiveAttribute( { md: 1 }, registry ) ).toBe( true )
+		expect( isResponsiveAttribute( { unrelated: 1 }, registry ) ).toBe( false )
+		expect( isResponsiveAttribute( [ 1, 2, 3 ], registry ) ).toBe( false )
+		expect( isResponsiveAttribute( 'string', registry ) ).toBe( false )
+	} )
+} )
+
+describe( 'distinctOverrides', () => {
+	it( 'compresses redundant inherited values', () => {
+		expect( distinctOverrides( { base: 4, sm: 4, md: 6, lg: 6 }, registry ) ).toEqual( {
+			base: 4,
+			md:   6,
+		} )
+	} )
+} )

--- a/resources/js/visual-editor/responsive/__tests__/with-responsive-attributes.test.tsx
+++ b/resources/js/visual-editor/responsive/__tests__/with-responsive-attributes.test.tsx
@@ -1,0 +1,293 @@
+import { render, screen, act } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+	resetActiveBreakpoint,
+	setActiveBreakpoint,
+} from '../active-breakpoint'
+
+// `withResponsiveAttributes` uses `getBlockType` to discover the
+// opt-in roots. Stub it so tests don't need to register a real block.
+vi.mock( '@wordpress/blocks', () => {
+	const blocks = new Map<string, { supports?: Record<string, unknown> }>()
+
+	return {
+		getBlockType: ( name: string ) => blocks.get( name ),
+		// Mirrors the real `@wordpress/blocks.hasBlockSupport` contract:
+		// returns the actual configured value (not just `feature in supports`),
+		// so a falsy support entry is honored. Falls back to `defaultValue`
+		// when the block isn't registered or doesn't declare supports.
+		hasBlockSupport: (
+			blockType: { supports?: Record<string, unknown> } | undefined,
+			feature: string,
+			defaultValue: boolean,
+		) => {
+			if ( ! blockType?.supports ) {
+				return defaultValue
+			}
+			if ( ! ( feature in blockType.supports ) ) {
+				return defaultValue
+			}
+			return blockType.supports[ feature ]
+		},
+		__setBlockType: ( name: string, supports: Record<string, unknown> ) => {
+			blocks.set( name, { supports } )
+		},
+		__clearBlockTypes: () => {
+			blocks.clear()
+		},
+	}
+} )
+
+import { __setBlockType, __clearBlockTypes } from '@wordpress/blocks'
+import { withResponsiveAttributes } from '../with-responsive-attributes'
+
+interface CapturedProps {
+	attributes: Record<string, unknown>
+	setAttributes: ( updates: Record<string, unknown> ) => void
+}
+
+let captured: CapturedProps | null = null
+
+function StubEdit( props: CapturedProps ): JSX.Element {
+	captured = props
+	return <div data-testid="stub">stub</div>
+}
+
+const Wrapped = withResponsiveAttributes( StubEdit as never )
+
+beforeEach( () => {
+	captured = null
+	act( () => {
+		resetActiveBreakpoint()
+	} )
+	__clearBlockTypes()
+} )
+
+afterEach( () => {
+	act( () => {
+		resetActiveBreakpoint()
+	} )
+	__clearBlockTypes()
+} )
+
+describe( 'withResponsiveAttributes — non-responsive blocks', () => {
+	it( 'passes attributes through untouched when supports.artisanpackResponsive is missing', () => {
+		__setBlockType( 'core/paragraph', {} )
+
+		const setAttributes = vi.fn()
+		render(
+			<Wrapped
+				name="core/paragraph"
+				attributes={ { content: 'hi' } }
+				setAttributes={ setAttributes }
+			/> as never,
+		)
+
+		expect( captured?.attributes ).toEqual( { content: 'hi' } )
+
+		captured?.setAttributes( { content: 'updated' } )
+		expect( setAttributes ).toHaveBeenCalledWith( { content: 'updated' } )
+	} )
+} )
+
+describe( 'withResponsiveAttributes — base breakpoint behavior', () => {
+	beforeEach( () => {
+		__setBlockType( 'artisanpack/columns', {
+			artisanpackResponsive: { attributes: [ 'spacing', 'columnCount' ] },
+		} )
+	} )
+
+	it( 'passes base attributes through untouched at base', () => {
+		render(
+			<Wrapped
+				name="artisanpack/columns"
+				attributes={ { columnCount: 3 } }
+				setAttributes={ vi.fn() }
+			/> as never,
+		)
+
+		expect( captured?.attributes.columnCount ).toBe( 3 )
+	} )
+
+	it( 'forwards writes to setAttributes verbatim at base', () => {
+		const setAttributes = vi.fn()
+		render(
+			<Wrapped
+				name="artisanpack/columns"
+				attributes={ { columnCount: 3 } }
+				setAttributes={ setAttributes }
+			/> as never,
+		)
+
+		captured?.setAttributes( { columnCount: 5 } )
+		expect( setAttributes ).toHaveBeenCalledWith( { columnCount: 5 } )
+	} )
+} )
+
+describe( 'withResponsiveAttributes — non-base breakpoint behavior', () => {
+	beforeEach( () => {
+		__setBlockType( 'artisanpack/columns', {
+			artisanpackResponsive: { attributes: [ 'spacing', 'columnCount' ] },
+		} )
+	} )
+
+	it( 'merges responsive overrides into the attributes the inner BlockEdit sees', () => {
+		act( () => {
+			setActiveBreakpoint( 'md' )
+		} )
+
+		render(
+			<Wrapped
+				name="artisanpack/columns"
+				attributes={ {
+					columnCount: 3,
+					responsive: {
+						columnCount: { md: 5 },
+					},
+				} }
+				setAttributes={ vi.fn() }
+			/> as never,
+		)
+
+		expect( captured?.attributes.columnCount ).toBe( 5 )
+	} )
+
+	it( 'cascades a smaller breakpoint up through null/missing slots', () => {
+		act( () => {
+			setActiveBreakpoint( 'lg' )
+		} )
+
+		render(
+			<Wrapped
+				name="artisanpack/columns"
+				attributes={ {
+					columnCount: 3,
+					responsive: {
+						columnCount: { sm: 1, md: 2 },
+					},
+				} }
+				setAttributes={ vi.fn() }
+			/> as never,
+		)
+
+		// lg has no override, md does → cascade returns 2.
+		expect( captured?.attributes.columnCount ).toBe( 2 )
+	} )
+
+	it( 'routes a responsive write into attributes.responsive at the active breakpoint', () => {
+		act( () => {
+			setActiveBreakpoint( 'md' )
+		} )
+
+		const setAttributes = vi.fn()
+		render(
+			<Wrapped
+				name="artisanpack/columns"
+				attributes={ { columnCount: 3 } }
+				setAttributes={ setAttributes }
+			/> as never,
+		)
+
+		captured?.setAttributes( { columnCount: 5 } )
+
+		expect( setAttributes ).toHaveBeenCalledWith( {
+			responsive: {
+				columnCount: { md: 5 },
+			},
+		} )
+	} )
+
+	it( 'merges into existing responsive overrides without dropping other breakpoints', () => {
+		act( () => {
+			setActiveBreakpoint( 'lg' )
+		} )
+
+		const setAttributes = vi.fn()
+		render(
+			<Wrapped
+				name="artisanpack/columns"
+				attributes={ {
+					columnCount: 3,
+					responsive: { columnCount: { sm: 1 } },
+				} }
+				setAttributes={ setAttributes }
+			/> as never,
+		)
+
+		captured?.setAttributes( { columnCount: 4 } )
+
+		expect( setAttributes ).toHaveBeenCalledWith( {
+			responsive: {
+				columnCount: { sm: 1, lg: 4 },
+			},
+		} )
+	} )
+
+	it( 'falls through to the base for attributes outside the opt-in roots', () => {
+		act( () => {
+			setActiveBreakpoint( 'md' )
+		} )
+
+		const setAttributes = vi.fn()
+		render(
+			<Wrapped
+				name="artisanpack/columns"
+				attributes={ { verticalAlignment: 'top' } }
+				setAttributes={ setAttributes }
+			/> as never,
+		)
+
+		captured?.setAttributes( { verticalAlignment: 'center' } )
+
+		// `verticalAlignment` is not declared in supports.artisanpackResponsive.attributes,
+		// so it must write to the base attribute regardless of the active breakpoint.
+		expect( setAttributes ).toHaveBeenCalledWith( { verticalAlignment: 'center' } )
+	} )
+
+	it( 'routes a deep spacing path into responsive without touching base style', () => {
+		act( () => {
+			setActiveBreakpoint( 'md' )
+		} )
+
+		const setAttributes = vi.fn()
+		render(
+			<Wrapped
+				name="artisanpack/columns"
+				attributes={ {
+					style: { spacing: { padding: '1rem' } },
+				} }
+				setAttributes={ setAttributes }
+			/> as never,
+		)
+
+		captured?.setAttributes( {
+			style: { spacing: { padding: '2rem' } },
+		} )
+
+		expect( setAttributes ).toHaveBeenCalledWith( {
+			responsive: {
+				'style.spacing.padding': { md: '2rem' },
+			},
+		} )
+	} )
+
+	it( 'no-ops the write when nothing actually changed', () => {
+		act( () => {
+			setActiveBreakpoint( 'md' )
+		} )
+
+		const setAttributes = vi.fn()
+		render(
+			<Wrapped
+				name="artisanpack/columns"
+				attributes={ { columnCount: 3 } }
+				setAttributes={ setAttributes }
+			/> as never,
+		)
+
+		captured?.setAttributes( { columnCount: 3 } )
+
+		expect( setAttributes ).not.toHaveBeenCalled()
+	} )
+} )

--- a/resources/js/visual-editor/responsive/active-breakpoint.ts
+++ b/resources/js/visual-editor/responsive/active-breakpoint.ts
@@ -1,0 +1,53 @@
+/**
+ * Active-breakpoint state (#487).
+ *
+ * Tiny pub/sub store that holds which breakpoint the editor is
+ * currently authoring against. Lives outside React so non-React
+ * surfaces (canvas iframe wrapper, top-bar buttons rendered by Volt,
+ * Vue host bridge) can read and write it without crossing the React
+ * tree boundary.
+ *
+ * The React-friendly `useActiveBreakpoint()` hook in `./hooks` wraps
+ * this with `useSyncExternalStore` so component re-renders happen
+ * automatically when the editor changes breakpoints.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.0.0
+ */
+
+import { BASE_KEY } from './types'
+
+type Listener = ( breakpoint: string ) => void
+
+let current: string         = BASE_KEY
+const listeners: Set<Listener> = new Set()
+
+export function getActiveBreakpoint(): string {
+	return current
+}
+
+export function setActiveBreakpoint( breakpoint: string ): void {
+	if ( breakpoint === current ) {
+		return
+	}
+
+	current = breakpoint
+	listeners.forEach( ( listener ) => listener( current ) )
+}
+
+export function subscribeActiveBreakpoint( listener: Listener ): () => void {
+	listeners.add( listener )
+
+	return () => {
+		listeners.delete( listener )
+	}
+}
+
+/**
+ * Test-only — reset back to `base` between specs. Production code
+ * should set an explicit breakpoint instead.
+ */
+export function resetActiveBreakpoint(): void {
+	current = BASE_KEY
+	listeners.forEach( ( listener ) => listener( current ) )
+}

--- a/resources/js/visual-editor/responsive/attribute-paths.ts
+++ b/resources/js/visual-editor/responsive/attribute-paths.ts
@@ -46,12 +46,25 @@ export function readPath<T = unknown>( source: unknown, path: string ): T | unde
 }
 
 /**
+ * Defense-in-depth guard against prototype-pollution via crafted
+ * dotted paths or object keys. Internal callers pass Gutenberg
+ * attribute trees that never contain these segments, but the helpers
+ * are exported reusable utilities — a single guard keeps the public
+ * surface safe even if a future caller routes externally-influenced
+ * keys through them.
+ */
+const FORBIDDEN_KEYS = new Set( [ '__proto__', 'constructor', 'prototype' ] )
+
+/**
  * Returns a new tree with `path` set to `value`. Intermediate objects
  * are created as plain `{}`; arrays are NOT created. Used both for
  * applying responsive overrides back into the merged read view and
  * for shimming a write under `attributes.responsive.<path>.<bp>`.
  *
  * Setting `undefined` deletes the leaf and prunes empty parents.
+ *
+ * Path segments matching `__proto__`, `constructor`, or `prototype`
+ * are silently dropped — see `FORBIDDEN_KEYS` for rationale.
  */
 export function setPath<T extends Record<string, unknown>>(
     source: T | undefined | null,
@@ -65,6 +78,11 @@ export function setPath<T extends Record<string, unknown>>(
 
     for ( let i = 0; i < segments.length - 1; i++ ) {
         const segment = segments[ i ]
+
+        if ( FORBIDDEN_KEYS.has( segment ) ) {
+            return root
+        }
+
         const existing = cursor[ segment ]
 
         const next: Record<string, unknown> =
@@ -77,6 +95,10 @@ export function setPath<T extends Record<string, unknown>>(
     }
 
     const leaf = segments[ segments.length - 1 ]
+
+    if ( FORBIDDEN_KEYS.has( leaf ) ) {
+        return root
+    }
 
     if ( undefined === value ) {
         delete cursor[ leaf ]
@@ -203,6 +225,10 @@ export function deepMerge<T extends Record<string, unknown>>(
     const result: Record<string, unknown> = { ...base }
 
     for ( const [ key, value ] of Object.entries( overlay ) ) {
+        if ( FORBIDDEN_KEYS.has( key ) ) {
+            continue
+        }
+
         const baseValue = result[ key ]
 
         if (

--- a/resources/js/visual-editor/responsive/attribute-paths.ts
+++ b/resources/js/visual-editor/responsive/attribute-paths.ts
@@ -1,0 +1,227 @@
+/**
+ * Path-keyed attribute read/write helpers (#487).
+ *
+ * The responsive HOC mediates writes from the native Gutenberg
+ * panels by intercepting `setAttributes({style: {...}})` calls,
+ * comparing the resulting attributes tree against what was there
+ * before, and routing the diff into `attributes.responsive` when the
+ * active breakpoint is not `base`.
+ *
+ * This file gives us the path arithmetic those steps depend on:
+ *  - Read a value at a dotted path (`style.spacing.padding`).
+ *  - Set a value at a dotted path (immutable, returns a new tree).
+ *  - Diff two attribute trees and return the changed leaf paths.
+ *  - Decide whether a path falls under one of the opt-in roots
+ *    (e.g. `["spacing", "align"]` matches `style.spacing.padding` and
+ *    `align` but not `verticalAlignment`).
+ *
+ * Pure data manipulation. No React, no Gutenberg, fully testable in
+ * isolation.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.0.0
+ */
+
+/**
+ * Reads a nested value by dotted path. Returns `undefined` when any
+ * segment misses.
+ */
+export function readPath<T = unknown>( source: unknown, path: string ): T | undefined {
+    if ( null === source || 'object' !== typeof source ) {
+        return undefined
+    }
+
+    const segments = path.split( '.' )
+    let cursor: unknown = source
+
+    for ( const segment of segments ) {
+        if ( null === cursor || 'object' !== typeof cursor || Array.isArray( cursor ) ) {
+            return undefined
+        }
+
+        cursor = ( cursor as Record<string, unknown> )[ segment ]
+    }
+
+    return cursor as T | undefined
+}
+
+/**
+ * Returns a new tree with `path` set to `value`. Intermediate objects
+ * are created as plain `{}`; arrays are NOT created. Used both for
+ * applying responsive overrides back into the merged read view and
+ * for shimming a write under `attributes.responsive.<path>.<bp>`.
+ *
+ * Setting `undefined` deletes the leaf and prunes empty parents.
+ */
+export function setPath<T extends Record<string, unknown>>(
+    source: T | undefined | null,
+    path: string,
+    value: unknown,
+): T {
+    const segments = path.split( '.' )
+    const root     = source ? { ...source } : ( {} as T )
+
+    let cursor: Record<string, unknown> = root as Record<string, unknown>
+
+    for ( let i = 0; i < segments.length - 1; i++ ) {
+        const segment = segments[ i ]
+        const existing = cursor[ segment ]
+
+        const next: Record<string, unknown> =
+            existing && 'object' === typeof existing && ! Array.isArray( existing )
+                ? { ...( existing as Record<string, unknown> ) }
+                : {}
+
+        cursor[ segment ] = next
+        cursor            = next
+    }
+
+    const leaf = segments[ segments.length - 1 ]
+
+    if ( undefined === value ) {
+        delete cursor[ leaf ]
+    } else {
+        cursor[ leaf ] = value
+    }
+
+    return pruneEmpty( root ) as T
+}
+
+/**
+ * Recursively drop empty `{}` branches so an `attributes.style` that
+ * only had `{spacing: {}}` after a delete collapses back to absent.
+ * Operates on a copy; never mutates the input.
+ */
+function pruneEmpty<T>( node: T ): T {
+    if ( null === node || 'object' !== typeof node || Array.isArray( node ) ) {
+        return node
+    }
+
+    const result: Record<string, unknown> = {}
+
+    for ( const [ key, value ] of Object.entries( node as Record<string, unknown> ) ) {
+        if ( value && 'object' === typeof value && ! Array.isArray( value ) ) {
+            const cleaned = pruneEmpty( value )
+
+            if ( 0 !== Object.keys( cleaned as Record<string, unknown> ).length ) {
+                result[ key ] = cleaned
+            }
+        } else if ( undefined !== value ) {
+            result[ key ] = value
+        }
+    }
+
+    return result as T
+}
+
+/**
+ * Walks an updates object emitted by a native panel and yields every
+ * changed leaf path (relative to the attributes root). Only deep
+ * objects are recursed; arrays + scalars are leaves.
+ */
+export function diffPaths(
+    updates: Record<string, unknown>,
+    previous: Record<string, unknown>,
+    prefix: string = '',
+): Array<{ path: string; value: unknown }> {
+    const out: Array<{ path: string; value: unknown }> = []
+
+    for ( const [ key, value ] of Object.entries( updates ) ) {
+        const path = '' === prefix ? key : prefix + '.' + key
+
+        const isObjectValue =
+            null !== value && 'object' === typeof value && ! Array.isArray( value )
+
+        const prev = previous[ key ]
+
+        if ( isObjectValue && prev && 'object' === typeof prev && ! Array.isArray( prev ) ) {
+            out.push(
+                ...diffPaths(
+                    value as Record<string, unknown>,
+                    prev as Record<string, unknown>,
+                    path,
+                ),
+            )
+            continue
+        }
+
+        if ( value === prev ) {
+            continue
+        }
+
+        out.push( { path, value } )
+    }
+
+    return out
+}
+
+/**
+ * Returns true when the given dotted path falls under any of the
+ * opt-in roots. A root of `spacing` matches `style.spacing.padding`,
+ * `spacing.blockGap`, and `spacing` itself; it does NOT match
+ * `spacingScale` or `lineSpacing`.
+ *
+ * Match rules:
+ *  - exact equality (`path === root`)
+ *  - prefix with a `.` separator (`path` starts with `root + "."`)
+ *  - the root appears as a complete segment anywhere in the path
+ *    (`style.spacing.padding` matches root `spacing` because
+ *    `.spacing.` is a segment boundary)
+ */
+export function pathMatchesAnyRoot( path: string, roots: string[] ): boolean {
+    for ( const root of roots ) {
+        if ( path === root ) {
+            return true
+        }
+
+        if ( path.startsWith( root + '.' ) ) {
+            return true
+        }
+
+        if ( path.includes( '.' + root + '.' ) || path.endsWith( '.' + root ) ) {
+            return true
+        }
+    }
+
+    return false
+}
+
+/**
+ * Deep-merge two plain objects. Right wins on scalar collisions;
+ * nested objects merge recursively. Arrays are replaced (not merged).
+ * Used to overlay the active breakpoint's overrides on top of base
+ * attributes for the read view.
+ */
+export function deepMerge<T extends Record<string, unknown>>(
+    base: T,
+    overlay: Record<string, unknown> | null | undefined,
+): T {
+    if ( ! overlay ) {
+        return base
+    }
+
+    const result: Record<string, unknown> = { ...base }
+
+    for ( const [ key, value ] of Object.entries( overlay ) ) {
+        const baseValue = result[ key ]
+
+        if (
+            value &&
+            'object' === typeof value &&
+            ! Array.isArray( value ) &&
+            baseValue &&
+            'object' === typeof baseValue &&
+            ! Array.isArray( baseValue )
+        ) {
+            result[ key ] = deepMerge(
+                baseValue as Record<string, unknown>,
+                value as Record<string, unknown>,
+            )
+            continue
+        }
+
+        result[ key ] = value
+    }
+
+    return result as T
+}

--- a/resources/js/visual-editor/responsive/index.ts
+++ b/resources/js/visual-editor/responsive/index.ts
@@ -1,0 +1,56 @@
+/**
+ * Public entry point for the responsive design tools (#487).
+ *
+ * Host apps consume these via `@artisanpack-ui/visual-editor` once
+ * the editor library build re-exports them.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.0.0
+ */
+
+export {
+	getActiveBreakpoint,
+	setActiveBreakpoint,
+	subscribeActiveBreakpoint,
+	resetActiveBreakpoint,
+} from './active-breakpoint'
+
+export {
+	BreakpointRegistry,
+	TAILWIND_V4_DEFAULTS,
+	registryFromSnapshot,
+} from './registry'
+
+export {
+	resolveResponsiveValue,
+	isResponsiveAttribute,
+	distinctOverrides,
+} from './resolver'
+
+export {
+	promote,
+	demote,
+	clearOverride,
+} from './migrator'
+
+export {
+	useResponsiveValue,
+	resolveAt,
+} from './useResponsiveValue'
+
+export { ViewportSwitcher } from './ViewportSwitcher'
+export type { ViewportSwitcherProps } from './ViewportSwitcher'
+
+export { ResponsiveControl } from './ResponsiveControl'
+export type { ResponsiveControlProps } from './ResponsiveControl'
+
+export { InspectorScopeChip } from './InspectorScopeChip'
+
+// `withResponsiveAttributes` + the filter registrars are intentionally
+// not re-exported here. They pull in `@wordpress/blocks`, which trips
+// JSON-import-attribute requirements when host bundlers (or vitest)
+// walk this barrel transitively. The editor bootstrap imports them
+// directly from `./with-responsive-attributes` and `./register-attribute`.
+
+export { BASE_KEY } from './types'
+export type { Breakpoint, BreakpointKey, BreakpointRegistrySnapshot, ResponsiveAttribute } from './types'

--- a/resources/js/visual-editor/responsive/inspector-scope-chip.css
+++ b/resources/js/visual-editor/responsive/inspector-scope-chip.css
@@ -1,0 +1,61 @@
+/**
+ * Inspector scope chip styles (#487).
+ *
+ * Reads from the inspector sidebar tokens where possible so it sits
+ * coherently inside the panel. Falls back to neutral defaults so the
+ * chip still reads outside a themed host.
+ */
+
+.ap-visual-editor-inspector-scope-chip {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 8px 12px;
+    margin: 8px 12px 0;
+    background: color-mix(
+        in oklch,
+        var(--ap-visual-editor-top-bar-accent, #2563eb) 8%,
+        transparent
+    );
+    border: 1px solid
+        color-mix(
+            in oklch,
+            var(--ap-visual-editor-top-bar-accent, #2563eb) 30%,
+            transparent
+        );
+    border-radius: var(--ap-visual-editor-top-bar-radius, 6px);
+    font-size: 12px;
+    line-height: 1.4;
+    color: var(--ap-visual-editor-top-bar-foreground, #1f2937);
+}
+
+.ap-visual-editor-inspector-scope-chip__label strong {
+    font-weight: 600;
+}
+
+.ap-visual-editor-inspector-scope-chip__key {
+    margin-left: 4px;
+    opacity: 0.65;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.ap-visual-editor-inspector-scope-chip__reset {
+    appearance: none;
+    background: transparent;
+    border: 0;
+    color: var(--ap-visual-editor-top-bar-accent, #2563eb);
+    cursor: pointer;
+    font: inherit;
+    padding: 2px 6px;
+    border-radius: calc(var(--ap-visual-editor-top-bar-radius, 6px) - 2px);
+    transition: background-color 120ms ease;
+}
+
+.ap-visual-editor-inspector-scope-chip__reset:hover {
+    background: color-mix(
+        in oklch,
+        var(--ap-visual-editor-top-bar-accent, #2563eb) 15%,
+        transparent
+    );
+}

--- a/resources/js/visual-editor/responsive/migrator.ts
+++ b/resources/js/visual-editor/responsive/migrator.ts
@@ -1,0 +1,79 @@
+/**
+ * Attribute migrator — lazy scalar → discriminated promotion (#487).
+ *
+ * Mirrors PHP `AttributeMigrator`. Used by the editor's InspectorControls
+ * to:
+ *  - Promote a scalar attribute into `{base, sm, …}` the first time an
+ *    editor sets a value at a non-`base` breakpoint.
+ *  - Demote back to a scalar when every override is cleared.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.0.0
+ */
+
+import { BASE_KEY, type ResponsiveAttribute } from './types'
+
+function isResponsiveObject<T>( attribute: unknown ): attribute is { [BASE_KEY]: T | null } & Record<string, T | null | undefined> {
+	if ( null === attribute || 'object' !== typeof attribute || Array.isArray( attribute ) ) {
+		return false
+	}
+
+	return BASE_KEY in ( attribute as Record<string, unknown> )
+}
+
+export function promote<T>(
+	attribute: ResponsiveAttribute<T> | null | undefined,
+	breakpoint: string,
+	value: T | null,
+): ResponsiveAttribute<T> {
+	if ( BASE_KEY === breakpoint && ! isResponsiveObject<T>( attribute ) ) {
+		return value as T
+	}
+
+	const next: Record<string, T | null | undefined> = isResponsiveObject<T>( attribute )
+		? { ...( attribute as Record<string, T | null | undefined> ) }
+		: { [BASE_KEY]: ( attribute ?? null ) as T | null }
+
+	next[ breakpoint ] = value
+
+	return next as ResponsiveAttribute<T>
+}
+
+export function demote<T>( attribute: ResponsiveAttribute<T> | null | undefined ): ResponsiveAttribute<T> | null {
+	if ( ! isResponsiveObject<T>( attribute ) ) {
+		return ( attribute ?? null ) as ResponsiveAttribute<T> | null
+	}
+
+	const obj = attribute as Record<string, T | null | undefined>
+
+	for ( const key of Object.keys( obj ) ) {
+		if ( BASE_KEY === key ) {
+			continue
+		}
+
+		if ( null !== obj[ key ] && undefined !== obj[ key ] ) {
+			return attribute
+		}
+	}
+
+	return ( obj[ BASE_KEY ] ?? null ) as ResponsiveAttribute<T> | null
+}
+
+export function clearOverride<T>(
+	attribute: ResponsiveAttribute<T> | null | undefined,
+	breakpoint: string,
+): ResponsiveAttribute<T> | null {
+	if ( ! isResponsiveObject<T>( attribute ) ) {
+		return ( attribute ?? null ) as ResponsiveAttribute<T> | null
+	}
+
+	const next: Record<string, T | null | undefined> = { ...( attribute as Record<string, T | null | undefined> ) }
+
+	if ( BASE_KEY === breakpoint ) {
+		next[ BASE_KEY ] = null
+	} else {
+		delete next[ breakpoint ]
+	}
+
+	return demote( next as ResponsiveAttribute<T> )
+}

--- a/resources/js/visual-editor/responsive/register-attribute.ts
+++ b/resources/js/visual-editor/responsive/register-attribute.ts
@@ -1,0 +1,82 @@
+/**
+ * Inject the `responsive` attribute on every block that opts into
+ * per-breakpoint editing (#487).
+ *
+ * Blocks declare opt-in via `supports.artisanpackResponsive` in
+ * `block.json`. Rather than asking each block's `block.json` to also
+ * declare the `responsive` attribute by hand (easy to forget, easy to
+ * mistype, doubles the noise per block), this `blocks.registerBlockType`
+ * filter adds it automatically at registration time.
+ *
+ * The injected attribute is a plain `object` keyed by attribute path
+ * (e.g. `style.spacing.padding`) → discriminated `{ sm, md, lg, … }`
+ * object. Reads/writes are mediated by `withResponsiveAttributes`; this
+ * file is just responsible for making sure the attribute exists so
+ * `setAttributes` calls actually persist.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.0.0
+ */
+
+import { addFilter } from '@wordpress/hooks'
+
+const FILTER_HOOK    = 'blocks.registerBlockType'
+const FILTER_NAMESPACE = 'artisanpack-ui/visual-editor/responsive-attribute'
+
+const REGISTERED_KEY = Symbol.for(
+    'artisanpack-ui.visual-editor.responsive-attribute.registered',
+)
+
+interface GlobalSentinelHost {
+    [REGISTERED_KEY]?: boolean
+}
+
+interface BlockSupports {
+    artisanpackResponsive?: {
+        attributes?: string[]
+    }
+}
+
+interface BlockSettingsLike {
+    supports?: BlockSupports
+    attributes?: Record<string, unknown>
+    [key: string]: unknown
+}
+
+function injectResponsiveAttribute( settings: BlockSettingsLike ): BlockSettingsLike {
+    const responsiveSupport = settings.supports?.artisanpackResponsive
+
+    if ( ! responsiveSupport || ! Array.isArray( responsiveSupport.attributes ) || 0 === responsiveSupport.attributes.length ) {
+        return settings
+    }
+
+    if ( settings.attributes && 'responsive' in settings.attributes ) {
+        return settings
+    }
+
+    return {
+        ...settings,
+        attributes: {
+            ...( settings.attributes ?? {} ),
+            responsive: {
+                type:    'object',
+                default: null,
+            },
+        },
+    }
+}
+
+/**
+ * Register the filter at most once per page. Idempotent — safe to
+ * call from both the post-editor and site-editor entries.
+ */
+export function registerResponsiveAttribute(): void {
+    const host = globalThis as unknown as GlobalSentinelHost
+
+    if ( host[ REGISTERED_KEY ] ) {
+        return
+    }
+
+    addFilter( FILTER_HOOK, FILTER_NAMESPACE, injectResponsiveAttribute )
+    host[ REGISTERED_KEY ] = true
+}

--- a/resources/js/visual-editor/responsive/registry.ts
+++ b/resources/js/visual-editor/responsive/registry.ts
@@ -1,0 +1,71 @@
+/**
+ * Client-side breakpoint registry (#487).
+ *
+ * Mirrors the PHP `BreakpointRegistry` so the editor can resolve
+ * cascades and emit Tailwind class strings without round-tripping to
+ * the server. Hydrated from `editor-settings`'s `breakpoints` array
+ * which the bootstrap path stamps from the merged PHP config +
+ * theme.json.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.0.0
+ */
+
+import { BASE_KEY, type Breakpoint, type BreakpointRegistrySnapshot } from './types'
+
+export const TAILWIND_V4_DEFAULTS: Breakpoint[] = [
+	{ key: 'sm', minWidthPx: 640 },
+	{ key: 'md', minWidthPx: 768 },
+	{ key: 'lg', minWidthPx: 1024 },
+	{ key: 'xl', minWidthPx: 1280 },
+	{ key: '2xl', minWidthPx: 1536 },
+]
+
+export class BreakpointRegistry {
+	protected readonly breakpoints: Breakpoint[]
+
+	constructor( breakpoints: Breakpoint[] = TAILWIND_V4_DEFAULTS ) {
+		this.breakpoints = [ ...breakpoints ].sort( ( a, b ) => a.minWidthPx - b.minWidthPx )
+	}
+
+	all(): Breakpoint[] {
+		return [ ...this.breakpoints ]
+	}
+
+	prefixes(): string[] {
+		return this.breakpoints.map( ( bp ) => bp.key )
+	}
+
+	keysWithBase(): string[] {
+		return [ BASE_KEY, ...this.prefixes() ]
+	}
+
+	get( key: string ): number | null {
+		if ( BASE_KEY === key ) {
+			return 0
+		}
+
+		const found = this.breakpoints.find( ( bp ) => bp.key === key )
+		return found ? found.minWidthPx : null
+	}
+
+	has( key: string ): boolean {
+		return BASE_KEY === key || this.breakpoints.some( ( bp ) => bp.key === key )
+	}
+
+	toJSON(): BreakpointRegistrySnapshot {
+		return { breakpoints: this.all() }
+	}
+}
+
+/**
+ * Build a registry from a serialized snapshot (typically the JSON the
+ * editor bootstrap stamps into window.artisanpackVisualEditor.settings).
+ */
+export function registryFromSnapshot( snapshot: BreakpointRegistrySnapshot | undefined ): BreakpointRegistry {
+	if ( ! snapshot || ! Array.isArray( snapshot.breakpoints ) || 0 === snapshot.breakpoints.length ) {
+		return new BreakpointRegistry()
+	}
+
+	return new BreakpointRegistry( snapshot.breakpoints )
+}

--- a/resources/js/visual-editor/responsive/resolver.ts
+++ b/resources/js/visual-editor/responsive/resolver.ts
@@ -1,0 +1,113 @@
+/**
+ * Mobile-first responsive value resolver (#487).
+ *
+ * Mirrors the PHP `ResponsiveValueResolver`. Given a discriminated
+ * `{base, sm, md, …}` attribute and the active breakpoint, returns
+ * the value the editor / renderer should show.
+ *
+ *  - `base` is the unprefixed value; it applies everywhere unless a
+ *    larger breakpoint overrides it.
+ *  - `null` (or missing) means "inherit from the next smaller
+ *    defined slot."
+ *  - Scalars round-trip unchanged.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.0.0
+ */
+
+import type { BreakpointRegistry } from './registry'
+import { BASE_KEY, type ResponsiveAttribute } from './types'
+
+export function isResponsiveAttribute<T>( value: unknown, registry: BreakpointRegistry ): value is { [k: string]: T | null } {
+	if ( null === value || 'object' !== typeof value || Array.isArray( value ) ) {
+		return false
+	}
+
+	const obj = value as Record<string, unknown>
+
+	if ( BASE_KEY in obj ) {
+		return true
+	}
+
+	return registry.prefixes().some( ( key ) => key in obj )
+}
+
+export function resolveResponsiveValue<T>(
+	attribute: ResponsiveAttribute<T> | null | undefined,
+	activeBreakpoint: string,
+	registry: BreakpointRegistry,
+): T | null {
+	if ( null === attribute || undefined === attribute ) {
+		return null
+	}
+
+	if ( ! isResponsiveAttribute<T>( attribute, registry ) ) {
+		return attribute as T
+	}
+
+	const cascade = cascadeKeys( activeBreakpoint, registry )
+	const obj     = attribute as Record<string, T | null | undefined>
+
+	for ( const key of cascade ) {
+		if ( ! ( key in obj ) ) {
+			continue
+		}
+
+		const value = obj[ key ]
+		if ( null === value || undefined === value ) {
+			continue
+		}
+
+		return value
+	}
+
+	return null
+}
+
+export function distinctOverrides<T>(
+	attribute: ResponsiveAttribute<T> | null | undefined,
+	registry: BreakpointRegistry,
+): Record<string, T> {
+	if ( null === attribute || undefined === attribute ) {
+		return {}
+	}
+
+	const normalized = isResponsiveAttribute<T>( attribute, registry )
+		? ( attribute as Record<string, T | null | undefined> )
+		: ( { [BASE_KEY]: attribute } as Record<string, T | null | undefined> )
+
+	const out: Record<string, T> = {}
+	let previous: T | null       = null
+	let first                    = true
+
+	for ( const key of registry.keysWithBase() ) {
+		const value = resolveResponsiveValue<T>( normalized, key, registry )
+
+		if ( null === value ) {
+			continue
+		}
+
+		if ( first || value !== previous ) {
+			out[ key ] = value
+			previous   = value
+			first      = false
+		}
+	}
+
+	return out
+}
+
+function cascadeKeys( activeBreakpoint: string, registry: BreakpointRegistry ): string[] {
+	const ordered = registry.keysWithBase()
+
+	if ( BASE_KEY === activeBreakpoint || ! registry.has( activeBreakpoint ) ) {
+		return [ BASE_KEY ]
+	}
+
+	const activeIndex = ordered.indexOf( activeBreakpoint )
+	if ( -1 === activeIndex ) {
+		return [ BASE_KEY ]
+	}
+
+	return ordered.slice( 0, activeIndex + 1 ).reverse()
+}

--- a/resources/js/visual-editor/responsive/types.ts
+++ b/resources/js/visual-editor/responsive/types.ts
@@ -1,0 +1,34 @@
+/**
+ * Shared types for the responsive design tools (#487).
+ *
+ * Mirrors the PHP-side BreakpointRegistry + ResponsiveValueResolver
+ * shapes so the editor's UI surface can be type-safe end-to-end.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.0.0
+ */
+
+export const BASE_KEY = 'base' as const;
+
+export type BreakpointKey = typeof BASE_KEY | string;
+
+export interface Breakpoint {
+	key: string;
+	minWidthPx: number;
+}
+
+/**
+ * Discriminated per-breakpoint storage. Mirrors the PHP shape:
+ * { base: x, sm: null, md: y, ... }
+ *
+ * `null` means "inherit from the next smaller defined slot."
+ * Missing keys are treated identically to `null` by the resolver.
+ */
+export type ResponsiveAttribute<T> =
+	| T
+	| ({ [BASE_KEY]?: T | null } & { [key: string]: T | null | undefined });
+
+export interface BreakpointRegistrySnapshot {
+	/** Ascending-sorted named breakpoints (no `base`). */
+	breakpoints: Breakpoint[];
+}

--- a/resources/js/visual-editor/responsive/useResponsiveValue.ts
+++ b/resources/js/visual-editor/responsive/useResponsiveValue.ts
@@ -1,0 +1,50 @@
+/**
+ * `useResponsiveValue` hook (#487).
+ *
+ * Resolves a discriminated `{base, sm, md, …}` attribute against the
+ * editor's currently active breakpoint. Block edit components consume
+ * this to render the resolved value at the breakpoint the editor is
+ * authoring against.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.0.0
+ */
+
+import { useSyncExternalStore } from 'react'
+
+import { getActiveBreakpoint, subscribeActiveBreakpoint } from './active-breakpoint'
+import type { BreakpointRegistry } from './registry'
+import { resolveResponsiveValue } from './resolver'
+import type { ResponsiveAttribute } from './types'
+
+/**
+ * Returns the value for the given attribute at the editor's active
+ * breakpoint. Re-renders the component whenever the editor switches
+ * breakpoints, so the resolved value stays in sync.
+ *
+ * @param attribute  Either a scalar (legacy / unmodified) or the
+ *                   discriminated object form.
+ * @param registry   The active breakpoint registry — pass the
+ *                   per-editor instance, not the bare snapshot.
+ */
+export function useResponsiveValue<T>(
+	attribute: ResponsiveAttribute<T> | null | undefined,
+	registry: BreakpointRegistry,
+): T | null {
+	const activeBreakpoint = useSyncExternalStore( subscribeActiveBreakpoint, getActiveBreakpoint, getActiveBreakpoint )
+
+	return resolveResponsiveValue<T>( attribute, activeBreakpoint, registry )
+}
+
+/**
+ * Read-only sibling of {@see useResponsiveValue} for code paths that
+ * already have an explicit breakpoint in hand (e.g. the renderer
+ * rebuilding all breakpoints' values at once).
+ */
+export function resolveAt<T>(
+	attribute: ResponsiveAttribute<T> | null | undefined,
+	breakpoint: string,
+	registry: BreakpointRegistry,
+): T | null {
+	return resolveResponsiveValue<T>( attribute, breakpoint, registry )
+}

--- a/resources/js/visual-editor/responsive/with-responsive-attributes.tsx
+++ b/resources/js/visual-editor/responsive/with-responsive-attributes.tsx
@@ -1,0 +1,288 @@
+/**
+ * `editor.BlockEdit` HOC — invisibly route attribute reads and writes
+ * through the active breakpoint (#487).
+ *
+ * Every block that declares `supports.artisanpackResponsive` is
+ * wrapped. The wrapper does two things, both transparent to the
+ * native Gutenberg panels:
+ *
+ *  1. **Reads.** Builds a view where the attributes the panels see
+ *     are the base values overlaid with anything stored under
+ *     `attributes.responsive.<path>.<activeBreakpoint>`. So when the
+ *     editor switches the top-bar viewport to `md`, the spacing
+ *     panel's BoxControl shows the `md` value instead of the base.
+ *
+ *  2. **Writes.** When the active breakpoint is `base`, writes fall
+ *     through to the normal `setAttributes` (touching
+ *     `attributes.style.spacing.padding` as today). When the active
+ *     breakpoint is non-`base`, the writes are diffed against the
+ *     pre-merge attributes; any leaf that landed under one of the
+ *     opt-in roots (e.g. `spacing`, `align`, `columns.count`) is
+ *     stored under `attributes.responsive.<path>.<activeBreakpoint>`
+ *     instead of mutating the base. Leaves outside the opt-in roots
+ *     fall through to the base, so non-responsive attributes (e.g.
+ *     `verticalAlignment`) still write directly.
+ *
+ *  Editors see zero new UI inside the panels. They pick a viewport
+ *  in the top bar, edit padding/margin/border like always, and the
+ *  value sticks to that viewport.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.0.0
+ */
+
+import { hasBlockSupport, getBlockType } from '@wordpress/blocks'
+import { createHigherOrderComponent } from '@wordpress/compose'
+import { addFilter } from '@wordpress/hooks'
+import { useCallback, useMemo, useSyncExternalStore } from 'react'
+import type { ComponentType } from 'react'
+
+import { getActiveBreakpoint, subscribeActiveBreakpoint } from './active-breakpoint'
+import {
+    deepMerge,
+    diffPaths,
+    pathMatchesAnyRoot,
+    setPath,
+} from './attribute-paths'
+import { BASE_KEY } from './types'
+
+const FILTER_HOOK      = 'editor.BlockEdit'
+const FILTER_NAMESPACE = 'artisanpack-ui/visual-editor/responsive-attributes'
+
+const REGISTERED_KEY = Symbol.for(
+    'artisanpack-ui.visual-editor.responsive-attributes.registered',
+)
+
+interface GlobalSentinelHost {
+    [REGISTERED_KEY]?: boolean
+}
+
+interface BlockEditProps {
+    name: string
+    attributes: Record<string, unknown>
+    setAttributes: ( updates: Record<string, unknown> ) => void
+    [key: string]: unknown
+}
+
+interface ResponsiveSupports {
+    attributes: string[]
+}
+
+type ResponsiveOverridesByPath = Record<string, Record<string, unknown>>
+
+function getResponsiveRoots( name: string ): string[] | null {
+    const blockType = getBlockType( name )
+
+    if ( ! blockType ) {
+        return null
+    }
+
+    const supports = hasBlockSupport( blockType, 'artisanpackResponsive', false )
+        ? ( blockType.supports as Record<string, unknown> ).artisanpackResponsive
+        : null
+
+    if ( ! supports || 'object' !== typeof supports ) {
+        return null
+    }
+
+    const roots = ( supports as ResponsiveSupports ).attributes
+
+    if ( ! Array.isArray( roots ) || 0 === roots.length ) {
+        return null
+    }
+
+    return roots
+}
+
+/**
+ * Build the overlay object that, when deep-merged into the base
+ * attributes, produces the read view for the active breakpoint.
+ *
+ * Mirrors the PHP `ResponsiveValueResolver` cascade: every responsive
+ * path is walked, taking the largest defined value ≤ the active
+ * breakpoint and using it.
+ */
+function buildOverlay(
+    responsive: ResponsiveOverridesByPath | null | undefined,
+    activeBreakpoint: string,
+    breakpointOrder: string[],
+): Record<string, unknown> {
+    if ( ! responsive || BASE_KEY === activeBreakpoint ) {
+        return {}
+    }
+
+    const activeIndex = breakpointOrder.indexOf( activeBreakpoint )
+
+    if ( -1 === activeIndex ) {
+        return {}
+    }
+
+    // Largest breakpoint at or below active, walking down.
+    const cascade = breakpointOrder.slice( 0, activeIndex + 1 ).reverse()
+    const overlay: Record<string, unknown> = {}
+
+    for ( const path of Object.keys( responsive ) ) {
+        const overridesForPath = responsive[ path ]
+
+        if ( ! overridesForPath || 'object' !== typeof overridesForPath ) {
+            continue
+        }
+
+        for ( const bp of cascade ) {
+            if ( bp in overridesForPath ) {
+                const value = overridesForPath[ bp ]
+
+                if ( null === value || undefined === value ) {
+                    continue
+                }
+
+                overlay[ '__placeholder' ] = true
+                writeInto( overlay, path, value )
+                break
+            }
+        }
+    }
+
+    delete overlay[ '__placeholder' ]
+    return overlay
+}
+
+function writeInto( target: Record<string, unknown>, path: string, value: unknown ): void {
+    const segments = path.split( '.' )
+    let cursor: Record<string, unknown> = target
+
+    for ( let i = 0; i < segments.length - 1; i++ ) {
+        const segment  = segments[ i ]
+        const existing = cursor[ segment ]
+
+        if ( ! existing || 'object' !== typeof existing || Array.isArray( existing ) ) {
+            const next: Record<string, unknown> = {}
+            cursor[ segment ] = next
+            cursor = next
+        } else {
+            cursor = existing as Record<string, unknown>
+        }
+    }
+
+    cursor[ segments[ segments.length - 1 ] ] = value
+}
+
+/**
+ * Default breakpoint ordering — must match `TAILWIND_V4_DEFAULTS` in
+ * registry.ts. Hard-coded here to keep this module independent of the
+ * registry singleton (which won't be hydrated until the editor's
+ * bootstrap snapshot lands; see plan §7.2).
+ */
+const DEFAULT_BREAKPOINT_ORDER = [ BASE_KEY, 'sm', 'md', 'lg', 'xl', '2xl' ]
+
+export const withResponsiveAttributes = createHigherOrderComponent(
+    ( BlockEdit: ComponentType<BlockEditProps> ) => {
+        function ResponsiveBlockEdit( props: BlockEditProps ): JSX.Element {
+            const { name, attributes, setAttributes } = props
+
+            const roots = useMemo( () => getResponsiveRoots( name ), [ name ] )
+
+            const activeBreakpoint = useSyncExternalStore(
+                subscribeActiveBreakpoint,
+                getActiveBreakpoint,
+                getActiveBreakpoint,
+            )
+
+            const responsive = ( attributes.responsive as ResponsiveOverridesByPath | null | undefined ) ?? null
+
+            const mergedAttributes = useMemo( () => {
+                if ( ! roots || BASE_KEY === activeBreakpoint ) {
+                    return attributes
+                }
+
+                const overlay = buildOverlay( responsive, activeBreakpoint, DEFAULT_BREAKPOINT_ORDER )
+
+                if ( 0 === Object.keys( overlay ).length ) {
+                    return attributes
+                }
+
+                return deepMerge( attributes, overlay )
+            }, [ attributes, responsive, activeBreakpoint, roots ] )
+
+            const wrappedSetAttributes = useCallback(
+                ( updates: Record<string, unknown> ): void => {
+                    if ( ! roots || BASE_KEY === activeBreakpoint ) {
+                        setAttributes( updates )
+                        return
+                    }
+
+                    // Diff what the native panel just produced against
+                    // the read view it was looking at.
+                    const changedLeaves = diffPaths( updates, mergedAttributes )
+
+                    if ( 0 === changedLeaves.length ) {
+                        return
+                    }
+
+                    const baseUpdates: Record<string, unknown> = {}
+                    let responsivePatch: ResponsiveOverridesByPath | null = null
+
+                    for ( const { path, value } of changedLeaves ) {
+                        if ( pathMatchesAnyRoot( path, roots ) ) {
+                            responsivePatch = responsivePatch ?? {}
+                            responsivePatch[ path ] = {
+                                ...( responsive?.[ path ] ?? {} ),
+                                [ activeBreakpoint ]: value,
+                            }
+                            continue
+                        }
+
+                        Object.assign(
+                            baseUpdates,
+                            setPath( baseUpdates, path, value ),
+                        )
+                    }
+
+                    const finalUpdates: Record<string, unknown> = { ...baseUpdates }
+
+                    if ( responsivePatch ) {
+                        finalUpdates.responsive = {
+                            ...( responsive ?? {} ),
+                            ...responsivePatch,
+                        }
+                    }
+
+                    setAttributes( finalUpdates )
+                },
+                [ activeBreakpoint, mergedAttributes, responsive, roots, setAttributes ],
+            )
+
+            if ( ! roots ) {
+                return <BlockEdit { ...props } />
+            }
+
+            return (
+                <BlockEdit
+                    { ...props }
+                    attributes={ mergedAttributes }
+                    setAttributes={ wrappedSetAttributes }
+                />
+            )
+        }
+
+        ResponsiveBlockEdit.displayName = 'ResponsiveBlockEdit'
+
+        return ResponsiveBlockEdit
+    },
+    'withResponsiveAttributes',
+)
+
+/**
+ * Idempotent — safe to call from both the post-editor and site-editor
+ * bootstrap paths. Late callers see the sentinel and no-op.
+ */
+export function registerResponsiveAttributesFilter(): void {
+    const host = globalThis as unknown as GlobalSentinelHost
+
+    if ( host[ REGISTERED_KEY ] ) {
+        return
+    }
+
+    addFilter( FILTER_HOOK, FILTER_NAMESPACE, withResponsiveAttributes )
+    host[ REGISTERED_KEY ] = true
+}

--- a/src/Console/AuditBreakpointsCommand.php
+++ b/src/Console/AuditBreakpointsCommand.php
@@ -71,40 +71,44 @@ class AuditBreakpointsCommand extends Command
 		}
 
 		foreach ( $models as $slug => $modelClass ) {
+			// Wraps BOTH `query()` and the cursor iteration in one
+			// try/catch — a DB/hydration error mid-cursor would
+			// otherwise abort the entire audit instead of skipping
+			// the offending resource with a warning.
 			try {
 				/** @var \Illuminate\Database\Eloquent\Builder $query */
 				$query = $modelClass::query();
+
+				foreach ( $query->cursor() as $record ) {
+					$scanned++;
+
+					$column = method_exists( $record, 'getBlockContentColumn' )
+						? (string) $record->getBlockContentColumn()
+						: 'blocks';
+
+					$blocks = $record->{$column} ?? null;
+
+					if ( ! is_array( $blocks ) ) {
+						continue;
+					}
+
+					$orphans = [];
+					$this->walkBlocks( $blocks, $resolver, $known, $orphans );
+
+					if ( [] === $orphans ) {
+						continue;
+					}
+
+					$report[] = [
+						'resource' => $slug,
+						'id'       => $record->getKey(),
+						'orphans'  => $orphans,
+					];
+				}
 			} catch ( Throwable $e ) {
 				$this->warn( sprintf( 'Skipping resource "%s": %s', $slug, $e->getMessage() ) );
 
 				continue;
-			}
-
-			foreach ( $query->cursor() as $record ) {
-				$scanned++;
-
-				$column = method_exists( $record, 'getBlockContentColumn' )
-					? (string) $record->getBlockContentColumn()
-					: 'blocks';
-
-				$blocks = $record->{$column} ?? null;
-
-				if ( ! is_array( $blocks ) ) {
-					continue;
-				}
-
-				$orphans = [];
-				$this->walkBlocks( $blocks, $resolver, $known, $orphans );
-
-				if ( [] === $orphans ) {
-					continue;
-				}
-
-				$report[] = [
-					'resource' => $slug,
-					'id'       => $record->getKey(),
-					'orphans'  => $orphans,
-				];
 			}
 		}
 

--- a/src/Console/AuditBreakpointsCommand.php
+++ b/src/Console/AuditBreakpointsCommand.php
@@ -1,0 +1,280 @@
+<?php
+
+/**
+ * `visual-editor:audit-breakpoints` console command (#487).
+ *
+ * Walks every block tree stored in the host application's
+ * editor-backed models and reports any per-breakpoint overrides whose
+ * key is no longer present in the resolved {@see BreakpointRegistry}.
+ *
+ * Orphans are preserved on save — the resolver simply skips them at
+ * render time. This command surfaces them so theme/config authors can
+ * decide whether to reintroduce the breakpoint, migrate the value to
+ * a different breakpoint, or strip it.
+ *
+ * Resource models are discovered through the same map the resource
+ * resolver uses: `config('artisanpack.visual-editor.resources')`. The
+ * legacy `VisualEditorPost` table is also scanned when present.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Console;
+
+use ArtisanPackUI\VisualEditor\Models\VisualEditorPost;
+use ArtisanPackUI\VisualEditor\Responsive\BreakpointRegistry;
+use ArtisanPackUI\VisualEditor\Responsive\ResponsiveValueResolver;
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Config\Repository as ConfigRepository;
+use Throwable;
+
+class AuditBreakpointsCommand extends Command
+{
+	/**
+	 * @var string
+	 */
+	protected $signature = 'visual-editor:audit-breakpoints
+		{--resource= : Limit the audit to a single resource slug from config.}
+		{--json : Output the report as machine-readable JSON instead of a table.}';
+
+	/**
+	 * @var string
+	 */
+	protected $description = 'Find block attributes that store overrides for breakpoints that are no longer registered.';
+
+	public function handle(
+		ConfigRepository $config,
+		BreakpointRegistry $registry,
+		ResponsiveValueResolver $resolver,
+	): int {
+		$scoped   = (string) $this->option( 'resource' );
+		$outputAs = $this->option( 'json' ) ? 'json' : 'table';
+
+		$known = array_flip( $registry->keysWithBase() );
+
+		$report  = [];
+		$scanned = 0;
+
+		$models = $this->collectModels( $config, '' === $scoped ? null : $scoped );
+
+		if ( [] === $models ) {
+			$this->warn( 'No resource models discovered. Configure `artisanpack.visual-editor.resources` or install the legacy `ve_contents` table.' );
+
+			return self::SUCCESS;
+		}
+
+		foreach ( $models as $slug => $modelClass ) {
+			try {
+				/** @var \Illuminate\Database\Eloquent\Builder $query */
+				$query = $modelClass::query();
+			} catch ( Throwable $e ) {
+				$this->warn( sprintf( 'Skipping resource "%s": %s', $slug, $e->getMessage() ) );
+
+				continue;
+			}
+
+			foreach ( $query->cursor() as $record ) {
+				$scanned++;
+
+				$column = method_exists( $record, 'getBlockContentColumn' )
+					? (string) $record->getBlockContentColumn()
+					: 'blocks';
+
+				$blocks = $record->{$column} ?? null;
+
+				if ( ! is_array( $blocks ) ) {
+					continue;
+				}
+
+				$orphans = [];
+				$this->walkBlocks( $blocks, $resolver, $known, $orphans );
+
+				if ( [] === $orphans ) {
+					continue;
+				}
+
+				$report[] = [
+					'resource' => $slug,
+					'id'       => $record->getKey(),
+					'orphans'  => $orphans,
+				];
+			}
+		}
+
+		if ( 'json' === $outputAs ) {
+			$encoded = json_encode(
+				[
+					'scanned' => $scanned,
+					'records' => $report,
+				],
+				JSON_PRETTY_PRINT
+			);
+
+			if ( false === $encoded ) {
+				$this->error( 'Failed to encode breakpoint audit as JSON: ' . json_last_error_msg() );
+
+				return self::FAILURE;
+			}
+
+			$this->line( $encoded );
+
+			return self::SUCCESS;
+		}
+
+		if ( [] === $report ) {
+			$this->info( sprintf( 'Audited %d record(s). No orphaned breakpoint overrides found.', $scanned ) );
+
+			return self::SUCCESS;
+		}
+
+		$rows = [];
+
+		foreach ( $report as $entry ) {
+			$rows[] = [
+				$entry['resource'],
+				(string) $entry['id'],
+				implode( ', ', $this->flattenOrphans( $entry['orphans'] ) ),
+			];
+		}
+
+		$this->table( [ 'Resource', 'Record ID', 'Orphaned overrides' ], $rows );
+
+		$this->warn( sprintf( 'Audited %d record(s). %d record(s) carry orphaned overrides.', $scanned, count( $report ) ) );
+
+		return self::SUCCESS;
+	}
+
+	/**
+	 * @return array<string, class-string>
+	 */
+	protected function collectModels( ConfigRepository $config, ?string $scoped ): array
+	{
+		$resources = (array) $config->get( 'artisanpack.visual-editor.resources', [] );
+
+		$models = [];
+
+		foreach ( $resources as $slug => $class ) {
+			if ( ! is_string( $slug ) || ! is_string( $class ) || ! class_exists( $class ) ) {
+				continue;
+			}
+
+			if ( null !== $scoped && $slug !== $scoped ) {
+				continue;
+			}
+
+			$models[ $slug ] = $class;
+		}
+
+		if ( null === $scoped || 've_contents' === $scoped ) {
+			if ( class_exists( VisualEditorPost::class ) ) {
+				$models['ve_contents'] = VisualEditorPost::class;
+			}
+		}
+
+		return $models;
+	}
+
+	/**
+	 * Recursively walks a block tree, accumulating orphaned override
+	 * keys per `block.attribute_path`.
+	 *
+	 * @param  array<int, mixed>             $blocks
+	 * @param  array<string, int>            $known   Map of valid breakpoint keys
+	 *                                                (`base`, `sm`, …) → 0.
+	 * @param  array<string, array<int, string>>  $orphans  Output accumulator,
+	 *                                                      keyed by
+	 *                                                      `block_name@path`.
+	 */
+	protected function walkBlocks(
+		array $blocks,
+		ResponsiveValueResolver $resolver,
+		array $known,
+		array &$orphans,
+	): void {
+		foreach ( $blocks as $block ) {
+			if ( ! is_array( $block ) ) {
+				continue;
+			}
+
+			$name  = (string) ( $block['blockName'] ?? $block['name'] ?? 'unknown' );
+			$attrs = $block['attrs'] ?? $block['attributes'] ?? [];
+
+			if ( is_array( $attrs ) ) {
+				$this->walkAttributes( $name, '', $attrs, $resolver, $known, $orphans );
+			}
+
+			$inner = $block['innerBlocks'] ?? [];
+
+			if ( is_array( $inner ) ) {
+				$this->walkBlocks( $inner, $resolver, $known, $orphans );
+			}
+		}
+	}
+
+	/**
+	 * @param  array<string, mixed>                 $attrs
+	 * @param  array<string, int>                   $known
+	 * @param  array<string, array<int, string>>    $orphans
+	 */
+	protected function walkAttributes(
+		string $blockName,
+		string $path,
+		array $attrs,
+		ResponsiveValueResolver $resolver,
+		array $known,
+		array &$orphans,
+	): void {
+		foreach ( $attrs as $key => $value ) {
+			$childPath = '' === $path ? (string) $key : $path . '.' . (string) $key;
+
+			if ( is_array( $value ) && ! array_is_list( $value ) ) {
+				$discovered = $resolver->orphanedKeys( $value );
+
+				if ( [] !== $discovered ) {
+					// Filter out keys that are actually nested attribute
+					// names (e.g. nested style objects); orphanedKeys()
+					// gives us every non-registry key, but only string
+					// keys that aren't themselves arrays are overrides.
+					$filtered = array_values( array_filter(
+						$discovered,
+						static fn ( string $k ): bool => ! is_array( $value[ $k ] ?? null )
+							&& ! isset( $known[ $k ] )
+					) );
+
+					if ( [] !== $filtered ) {
+						$bucket             = $blockName . '@' . $childPath;
+						$orphans[ $bucket ] = array_values( array_unique( array_merge(
+							$orphans[ $bucket ] ?? [],
+							$filtered
+						) ) );
+					}
+				}
+
+				$this->walkAttributes( $blockName, $childPath, $value, $resolver, $known, $orphans );
+			}
+		}
+	}
+
+	/**
+	 * @param  array<string, array<int, string>>  $orphans
+	 *
+	 * @return array<int, string>
+	 */
+	protected function flattenOrphans( array $orphans ): array
+	{
+		$rows = [];
+
+		foreach ( $orphans as $location => $keys ) {
+			$rows[] = $location . ' → [' . implode( ', ', $keys ) . ']';
+		}
+
+		return $rows;
+	}
+}

--- a/src/Responsive/AttributeMigrator.php
+++ b/src/Responsive/AttributeMigrator.php
@@ -1,0 +1,137 @@
+<?php
+
+/**
+ * Attribute migrator — lazy scalar → discriminated promotion (#487).
+ *
+ * Blocks store responsive-capable attributes as either:
+ *  - a scalar (legacy / unchanged content), or
+ *  - a discriminated `{base, sm, md, …}` object once any per-breakpoint
+ *    override is applied.
+ *
+ * The editor calls {@see promote()} the first time an editor sets a
+ * value at a non-`base` breakpoint, lifting the scalar into the
+ * discriminated form without rewriting any unrelated content. Reads
+ * stay backwards-compatible because the resolver accepts both shapes.
+ *
+ * Demoting is the symmetric operation — if every override is cleared
+ * back to inheriting the base, {@see demote()} collapses the object
+ * back to its scalar so saved JSON stays compact.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Responsive;
+
+class AttributeMigrator
+{
+	/**
+	 * Promotes a scalar (or untouched mixed value) into the
+	 * discriminated object form, copying the existing value to `base`
+	 * and writing `$value` at `$breakpoint`. The remaining breakpoints
+	 * are left absent (i.e. inherit).
+	 *
+	 * If `$attribute` is already a discriminated object, the existing
+	 * keys are preserved and the new override slot is merged in.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  mixed   $attribute
+	 * @param  string  $breakpoint  The breakpoint slug receiving the
+	 *                              override (e.g. `md`). `base` writes
+	 *                              the base value directly without
+	 *                              promotion.
+	 * @param  mixed   $value
+	 *
+	 * @return array<string, mixed>|mixed
+	 */
+	public function promote( $attribute, string $breakpoint, $value )
+	{
+		if ( BreakpointRegistry::BASE_KEY === $breakpoint && ! $this->isResponsiveObject( $attribute ) ) {
+			return $value;
+		}
+
+		$promoted = $this->isResponsiveObject( $attribute )
+			? $attribute
+			: [ BreakpointRegistry::BASE_KEY => $attribute ];
+
+		$promoted[ $breakpoint ] = $value;
+
+		return $promoted;
+	}
+
+	/**
+	 * Collapses a discriminated object back to its scalar `base` value
+	 * if no per-breakpoint overrides remain set (all are `null` or
+	 * missing). Returns the attribute untouched otherwise.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  mixed  $attribute
+	 *
+	 * @return mixed
+	 */
+	public function demote( $attribute )
+	{
+		if ( ! $this->isResponsiveObject( $attribute ) ) {
+			return $attribute;
+		}
+
+		foreach ( $attribute as $key => $value ) {
+			if ( BreakpointRegistry::BASE_KEY === $key ) {
+				continue;
+			}
+
+			if ( null !== $value ) {
+				return $attribute;
+			}
+		}
+
+		return $attribute[ BreakpointRegistry::BASE_KEY ] ?? null;
+	}
+
+	/**
+	 * Clears a specific breakpoint's override, returning the attribute
+	 * back to inheriting the cascade at that slot. If clearing the
+	 * last remaining override, the attribute is demoted back to its
+	 * scalar form.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  mixed   $attribute
+	 * @param  string  $breakpoint
+	 *
+	 * @return mixed
+	 */
+	public function clear( $attribute, string $breakpoint )
+	{
+		if ( ! $this->isResponsiveObject( $attribute ) ) {
+			return $attribute;
+		}
+
+		if ( BreakpointRegistry::BASE_KEY === $breakpoint ) {
+			$attribute[ BreakpointRegistry::BASE_KEY ] = null;
+		} else {
+			unset( $attribute[ $breakpoint ] );
+		}
+
+		return $this->demote( $attribute );
+	}
+
+	/**
+	 * @param  mixed  $attribute
+	 */
+	protected function isResponsiveObject( $attribute ): bool
+	{
+		return is_array( $attribute )
+			&& [] !== $attribute
+			&& ! array_is_list( $attribute )
+			&& array_key_exists( BreakpointRegistry::BASE_KEY, $attribute );
+	}
+}

--- a/src/Responsive/BreakpointRegistry.php
+++ b/src/Responsive/BreakpointRegistry.php
@@ -1,0 +1,273 @@
+<?php
+
+/**
+ * Breakpoint registry — responsive design tools (#487).
+ *
+ * Resolves the editor's active set of breakpoints by merging the host
+ * theme's declarations into the application's `config()` overrides and
+ * finally the package's Tailwind v4 defaults. Highest layer wins on key
+ * collision:
+ *
+ *   1. theme.json → `settings.custom.artisanpack.breakpoints`
+ *   2. application config → `artisanpack.visual-editor.breakpoints`
+ *   3. package defaults  → Tailwind v4 min-width tokens
+ *
+ * Breakpoints are merged by key via `array_replace()` —  a theme that
+ * ships a new `3xl` key adds it; omitting a key keeps the lower
+ * layer's value (defaults win unless explicitly overridden). To
+ * REMOVE a key, set it to `null` or `''` — `fromLayers()` filters
+ * those out after the merge. The resulting registry is sorted
+ * ascending by the resolved pixel value so callers can iterate it
+ * mobile-first without re-sorting.
+ *
+ * The `base` slot is implicit (always present, no min-width) and is
+ * NEVER stored in the registry itself — the registry only describes
+ * the named, prefixed breakpoints.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Responsive;
+
+use InvalidArgumentException;
+
+class BreakpointRegistry
+{
+	/**
+	 * Tailwind v4 defaults, used when nothing higher in the stack
+	 * overrides them.
+	 *
+	 * @var array<string, string>
+	 */
+	public const DEFAULTS = [
+		'sm'  => '640px',
+		'md'  => '768px',
+		'lg'  => '1024px',
+		'xl'  => '1280px',
+		'2xl' => '1536px',
+	];
+
+	/**
+	 * Implicit base slot — always present alongside the registered
+	 * breakpoints. Stored separately because it has no min-width and
+	 * cannot be overridden.
+	 */
+	public const BASE_KEY = 'base';
+
+	/**
+	 * Resolved, validated, ascending-sorted registry.
+	 *
+	 * @var array<string, int>  Keys are breakpoint slugs; values are the
+	 *                          min-width in pixels.
+	 */
+	protected array $breakpoints;
+
+	/**
+	 * @param  array<string, int|string>  $raw  Pre-resolved breakpoints.
+	 *                                          Pass the output of
+	 *                                          {@see fromLayers()}
+	 *                                          unless you're constructing
+	 *                                          a one-off registry in a test.
+	 */
+	public function __construct( array $raw = [] )
+	{
+		$resolved          = $this->validate( $raw );
+		asort( $resolved );
+		$this->breakpoints = $resolved;
+	}
+
+	/**
+	 * Builds a registry from the application's merged config + an
+	 * optional `theme.json`-derived overrides array. Use this from the
+	 * service provider; tests can also construct directly.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array<string, int|string>|null  $configOverrides  Defaults to
+	 *                                                           `config('artisanpack.visual-editor.breakpoints')`.
+	 * @param  array<string, int|string>       $themeOverrides   `settings.custom.artisanpack.breakpoints`
+	 *                                                           from the active `theme.json`.
+	 */
+	public static function fromLayers( ?array $configOverrides = null, array $themeOverrides = [] ): self
+	{
+		$config = $configOverrides ?? ( function_exists( 'config' )
+			? (array) config( 'artisanpack.visual-editor.breakpoints', [] )
+			: [] );
+
+		$merged = array_replace( self::DEFAULTS, $config, $themeOverrides );
+
+		$cleaned = array_filter( $merged, static fn ( $value ) => null !== $value && '' !== $value );
+
+		return new self( $cleaned );
+	}
+
+	/**
+	 * Returns every registered breakpoint as `[key => min-width-px]`,
+	 * ascending by pixel value. The implicit `base` slot is NOT
+	 * included — callers that need it can prepend `'base' => 0` to the
+	 * result.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<string, int>
+	 */
+	public function all(): array
+	{
+		return $this->breakpoints;
+	}
+
+	/**
+	 * Returns the min-width (in px) for a single breakpoint, or `null`
+	 * if the key isn't registered. The implicit `base` slot returns
+	 * `0`.
+	 *
+	 * @since 1.0.0
+	 */
+	public function get( string $key ): ?int
+	{
+		if ( self::BASE_KEY === $key ) {
+			return 0;
+		}
+
+		return $this->breakpoints[ $key ] ?? null;
+	}
+
+	/**
+	 * Returns just the breakpoint slugs (no widths) in ascending order
+	 * — convenient for emitting Tailwind class prefixes (`sm:`, `md:`,
+	 * `lg:`).
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<int, string>
+	 */
+	public function prefixes(): array
+	{
+		return array_keys( $this->breakpoints );
+	}
+
+	/**
+	 * Returns the slugs with `base` prepended — the full ordered list
+	 * the value resolver walks when cascading.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<int, string>
+	 */
+	public function keysWithBase(): array
+	{
+		return array_merge( [ self::BASE_KEY ], $this->prefixes() );
+	}
+
+	/**
+	 * Checks membership without the `null`-vs-`0` ambiguity of
+	 * `get()`.
+	 *
+	 * @since 1.0.0
+	 */
+	public function has( string $key ): bool
+	{
+		return self::BASE_KEY === $key || array_key_exists( $key, $this->breakpoints );
+	}
+
+	/**
+	 * Validates a raw breakpoint map. Accepts integer pixel values and
+	 * CSS-length strings ending in `px`. Rejects empty keys, the
+	 * reserved `base` key, non-positive widths, duplicate widths, and
+	 * anything that doesn't parse to a positive integer pixel value.
+	 *
+	 * Throws on the first failure with a descriptive message so theme
+	 * authors get actionable feedback when their `theme.json` is bad.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array<string, int|string>  $raw
+	 *
+	 * @return array<string, int>  Cleaned `[key => px-int]`.
+	 */
+	public function validate( array $raw ): array
+	{
+		$cleaned = [];
+		$seen    = [];
+
+		foreach ( $raw as $key => $value ) {
+			if ( ! is_string( $key ) || '' === trim( $key ) ) {
+				throw new InvalidArgumentException( 'Breakpoint key must be a non-empty string.' );
+			}
+
+			if ( self::BASE_KEY === $key ) {
+				throw new InvalidArgumentException( sprintf(
+					'Breakpoint key "%s" is reserved for the implicit base slot.',
+					self::BASE_KEY
+				) );
+			}
+
+			if ( 1 !== preg_match( '/^[a-z0-9][a-z0-9_-]*$/i', $key ) ) {
+				throw new InvalidArgumentException( sprintf(
+					'Breakpoint key "%s" must contain only letters, numbers, hyphens, and underscores.',
+					$key
+				) );
+			}
+
+			$pixels = $this->parsePixels( $value, $key );
+
+			if ( in_array( $pixels, $seen, true ) ) {
+				throw new InvalidArgumentException( sprintf(
+					'Breakpoint key "%s" has the same min-width (%dpx) as another breakpoint.',
+					$key,
+					$pixels
+				) );
+			}
+
+			$cleaned[ $key ] = $pixels;
+			$seen[]          = $pixels;
+		}
+
+		return $cleaned;
+	}
+
+	/**
+	 * @param  mixed   $value
+	 * @param  string  $key   Used for the error message only.
+	 */
+	protected function parsePixels( $value, string $key ): int
+	{
+		if ( is_int( $value ) ) {
+			$pixels = $value;
+		} elseif ( is_string( $value ) ) {
+			$trimmed = trim( $value );
+
+			if ( 1 !== preg_match( '/^(\d+)(px)?$/i', $trimmed, $matches ) ) {
+				throw new InvalidArgumentException( sprintf(
+					'Breakpoint "%s" has invalid value "%s". Expected an integer or a `Npx` string.',
+					$key,
+					$value
+				) );
+			}
+
+			$pixels = (int) $matches[1];
+		} else {
+			throw new InvalidArgumentException( sprintf(
+				'Breakpoint "%s" must be an integer or a `Npx` string.',
+				$key
+			) );
+		}
+
+		if ( $pixels <= 0 ) {
+			throw new InvalidArgumentException( sprintf(
+				'Breakpoint "%s" must be a positive pixel value, got %d.',
+				$key,
+				$pixels
+			) );
+		}
+
+		return $pixels;
+	}
+}

--- a/src/Responsive/ResponsiveValueResolver.php
+++ b/src/Responsive/ResponsiveValueResolver.php
@@ -1,0 +1,241 @@
+<?php
+
+/**
+ * Responsive value resolver — mobile-first cascade (#487).
+ *
+ * Given an attribute stored as a discriminated `{base, sm, md, lg, …}`
+ * object and an active breakpoint, returns the value the editor or
+ * renderer should show.
+ *
+ * Cascade semantics (mirrors Tailwind's `sm:` / `md:` modifiers):
+ *  - `base` is the unprefixed value; it applies everywhere unless a
+ *    larger breakpoint overrides it.
+ *  - A named breakpoint applies at its min-width and up, until another
+ *    explicit override at a larger breakpoint replaces it.
+ *  - `null` (or a missing key) means "inherit from the next-smaller
+ *    defined slot." `base` is the final fallback.
+ *
+ * Scalars (plain ints, strings, booleans, etc.) round-trip through
+ * `resolve()` unchanged — the editor only promotes scalars into the
+ * discriminated form on first per-breakpoint override, so unmodified
+ * content keeps working without a migration pass.
+ *
+ * Orphaned overrides — values stored under a key that is no longer in
+ * the registry (e.g. the theme removed `xl`) — are preserved on save
+ * but skipped at resolve time. The audit command surfaces them.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Responsive;
+
+class ResponsiveValueResolver
+{
+	public function __construct( protected BreakpointRegistry $registry ) {}
+
+	/**
+	 * Resolves the value for a single attribute at the given active
+	 * breakpoint.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  mixed   $attribute        Either a scalar (legacy) or a
+	 *                                   discriminated object array
+	 *                                   `{base: …, sm: …, md: …}`.
+	 * @param  string  $activeBreakpoint Slug to resolve for. `base` or any
+	 *                                   key from the registry. Unknown
+	 *                                   slugs fall back to `base`.
+	 *
+	 * @return mixed The resolved value, or `null` if no slot at or below
+	 *               the active breakpoint is defined.
+	 */
+	public function resolve( $attribute, string $activeBreakpoint = BreakpointRegistry::BASE_KEY )
+	{
+		if ( ! $this->isResponsiveAttribute( $attribute ) ) {
+			return $attribute;
+		}
+
+		$cascade = $this->cascadeKeys( $activeBreakpoint );
+
+		foreach ( $cascade as $key ) {
+			if ( ! array_key_exists( $key, $attribute ) ) {
+				continue;
+			}
+
+			$value = $attribute[ $key ];
+
+			if ( null === $value ) {
+				continue;
+			}
+
+			return $value;
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the resolved value at every registered breakpoint
+	 * (including `base`) as a flat map. Useful for renderers that need
+	 * to know which breakpoints carry distinct values to keep CSS
+	 * emission minimal.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function resolveAll( $attribute ): array
+	{
+		$results = [];
+
+		foreach ( $this->registry->keysWithBase() as $key ) {
+			$results[ $key ] = $this->resolve( $attribute, $key );
+		}
+
+		return $results;
+	}
+
+	/**
+	 * Compresses a discriminated attribute to only the breakpoints
+	 * whose resolved value differs from the next-smaller cascaded
+	 * value. Used by renderers to avoid emitting redundant
+	 * `md:px-4 lg:px-4` when both lg and md would inherit anyway.
+	 *
+	 * Always includes `base` if it has a non-null value.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<string, mixed>  Sparse map: keys present only when
+	 *                               their resolved value differs from
+	 *                               the cascade.
+	 */
+	public function distinctOverrides( $attribute ): array
+	{
+		if ( ! $this->isResponsiveAttribute( $attribute ) ) {
+			$attribute = [ BreakpointRegistry::BASE_KEY => $attribute ];
+		}
+
+		$result   = [];
+		$previous = null;
+		$first    = true;
+
+		foreach ( $this->registry->keysWithBase() as $key ) {
+			$value = $this->resolve( $attribute, $key );
+
+			if ( null === $value ) {
+				continue;
+			}
+
+			if ( $first || $value !== $previous ) {
+				$result[ $key ] = $value;
+				$previous       = $value;
+				$first          = false;
+			}
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Returns true when an attribute is shaped like the responsive
+	 * discriminated object: an associative array containing at least
+	 * `base` OR at least one registered breakpoint key.
+	 *
+	 * Plain numeric-indexed arrays (which Gutenberg uses for things
+	 * like `gallery.ids`) return false — they are not per-breakpoint
+	 * objects.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  mixed  $attribute
+	 */
+	public function isResponsiveAttribute( $attribute ): bool
+	{
+		if ( ! is_array( $attribute ) || [] === $attribute ) {
+			return false;
+		}
+
+		// Sequential (list-style) array — not a responsive object.
+		if ( array_is_list( $attribute ) ) {
+			return false;
+		}
+
+		if ( array_key_exists( BreakpointRegistry::BASE_KEY, $attribute ) ) {
+			return true;
+		}
+
+		foreach ( $this->registry->prefixes() as $key ) {
+			if ( array_key_exists( $key, $attribute ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Returns stored override keys that are NOT present in the active
+	 * registry (orphans). The audit command consumes this.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<int, string>
+	 */
+	public function orphanedKeys( $attribute ): array
+	{
+		if ( ! is_array( $attribute ) || [] === $attribute || array_is_list( $attribute ) ) {
+			return [];
+		}
+
+		$valid   = array_flip( $this->registry->keysWithBase() );
+		$orphans = [];
+
+		foreach ( array_keys( $attribute ) as $key ) {
+			if ( ! is_string( $key ) ) {
+				continue;
+			}
+
+			if ( isset( $valid[ $key ] ) ) {
+				continue;
+			}
+
+			$orphans[] = $key;
+		}
+
+		return $orphans;
+	}
+
+	/**
+	 * Returns the breakpoint keys to walk for a given active key, in
+	 * cascade order (largest defined ≤ active, then walking down to
+	 * `base`).
+	 *
+	 * @return array<int, string>
+	 */
+	protected function cascadeKeys( string $activeBreakpoint ): array
+	{
+		$ordered = $this->registry->keysWithBase();
+
+		if ( BreakpointRegistry::BASE_KEY === $activeBreakpoint || ! $this->registry->has( $activeBreakpoint ) ) {
+			return [ BreakpointRegistry::BASE_KEY ];
+		}
+
+		$activeIndex = array_search( $activeBreakpoint, $ordered, true );
+
+		if ( false === $activeIndex ) {
+			return [ BreakpointRegistry::BASE_KEY ];
+		}
+
+		// Walk from active down to base.
+		$slice = array_slice( $ordered, 0, $activeIndex + 1 );
+
+		return array_reverse( $slice );
+	}
+}

--- a/src/VisualEditorServiceProvider.php
+++ b/src/VisualEditorServiceProvider.php
@@ -17,9 +17,13 @@ use ArtisanPackUI\VisualEditor\Models\VisualEditorPost;
 use ArtisanPackUI\VisualEditor\Policies\VisualEditorPostPolicy;
 use ArtisanPackUI\VisualEditor\Registries\BlockTypeRegistry;
 use ArtisanPackUI\VisualEditor\Registries\DynamicBlockRegistry;
+use ArtisanPackUI\VisualEditor\Console\AuditBreakpointsCommand;
 use ArtisanPackUI\VisualEditor\Resources\PostResolver;
 use ArtisanPackUI\VisualEditor\Resources\QueryInliner;
 use ArtisanPackUI\VisualEditor\Resources\ResourceResolver;
+use ArtisanPackUI\VisualEditor\Responsive\AttributeMigrator;
+use ArtisanPackUI\VisualEditor\Responsive\BreakpointRegistry;
+use ArtisanPackUI\VisualEditor\Responsive\ResponsiveValueResolver;
 use ArtisanPackUI\VisualEditor\Search\BlockTreeSearchExtractor;
 use ArtisanPackUI\VisualEditor\SiteEditor\Resolution\GlobalStylesResolver as SiteEditorGlobalStylesResolver;
 use ArtisanPackUI\VisualEditor\SiteEditor\Resolution\MenuResolver as SiteEditorMenuResolver;
@@ -123,6 +127,27 @@ class VisualEditorServiceProvider extends ServiceProvider
 		// the first one served by the worker.
 		$this->app->scoped( GlobalStylesEmissionTracker::class, function () {
 			return new GlobalStylesEmissionTracker();
+		} );
+
+		// #487 — responsive design tools. The registry is scoped per
+		// request because theme.json overrides can change between
+		// requests when the host swaps themes; singletons would leak
+		// the resolved registry across requests. The resolver and
+		// migrator are stateless wrappers and could be singletons, but
+		// scoping them keeps lifetimes uniform with the registry they
+		// depend on.
+		$this->app->scoped( BreakpointRegistry::class, function ( $app ) {
+			$config = (array) $app['config']->get( 'artisanpack.visual-editor.breakpoints', [] );
+
+			return BreakpointRegistry::fromLayers( $config );
+		} );
+
+		$this->app->scoped( ResponsiveValueResolver::class, function ( $app ) {
+			return new ResponsiveValueResolver( $app->make( BreakpointRegistry::class ) );
+		} );
+
+		$this->app->singleton( AttributeMigrator::class, function () {
+			return new AttributeMigrator();
 		} );
 
 		// #434: `GlobalStylesCssProvider` + `GlobalStylesCacheInvalidator`
@@ -232,6 +257,11 @@ class VisualEditorServiceProvider extends ServiceProvider
 			$this->publishes( [
 								  __DIR__ . '/../config/visual-editor.php' => config_path( 'artisanpack/visual-editor.php' ),
 							  ], 'artisanpack-package-config' );
+
+			// #487 — surface the breakpoint audit command.
+			$this->commands( [
+				AuditBreakpointsCommand::class,
+			] );
 		}
 	}
 

--- a/tests/Feature/VisualEditor/Responsive/AuditBreakpointsCommandTest.php
+++ b/tests/Feature/VisualEditor/Responsive/AuditBreakpointsCommandTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Models\VisualEditorPost;
+
+beforeEach( function () {
+	// Only the visual-editor's default 'sm', 'md', 'lg', 'xl', '2xl' breakpoints
+	// are registered, plus the implicit `base`. Anything else is an orphan.
+	config()->set( 'artisanpack.visual-editor.breakpoints', [] );
+} );
+
+it( 'reports orphaned breakpoint overrides on stored block trees', function () {
+	VisualEditorPost::create( [
+		'title'  => 'Has orphans',
+		'blocks' => [
+			[
+				'blockName' => 'artisanpack/columns',
+				'attrs'     => [
+					'spacing' => [ 'base' => 4, 'md' => 6, 'legacy' => 9 ],
+				],
+				'innerBlocks' => [],
+			],
+		],
+	] );
+
+	$this->artisan( 'visual-editor:audit-breakpoints' )
+		->assertExitCode( 0 )
+		->expectsOutputToContain( 'legacy' );
+} );
+
+it( 'reports zero orphans when every override key is in the registry', function () {
+	VisualEditorPost::create( [
+		'title'  => 'Clean',
+		'blocks' => [
+			[
+				'blockName' => 'artisanpack/columns',
+				'attrs'     => [
+					'spacing' => [ 'base' => 4, 'md' => 6 ],
+				],
+				'innerBlocks' => [],
+			],
+		],
+	] );
+
+	$this->artisan( 'visual-editor:audit-breakpoints' )
+		->assertExitCode( 0 )
+		->expectsOutputToContain( 'No orphaned breakpoint overrides found' );
+} );
+
+it( 'outputs JSON when --json flag is passed', function () {
+	VisualEditorPost::create( [
+		'title'  => 'JSON output',
+		'blocks' => [
+			[
+				'blockName' => 'artisanpack/columns',
+				'attrs'     => [
+					'spacing' => [ 'base' => 4, 'legacy' => 9 ],
+				],
+				'innerBlocks' => [],
+			],
+		],
+	] );
+
+	$this->artisan( 'visual-editor:audit-breakpoints --json' )
+		->assertExitCode( 0 )
+		->expectsOutputToContain( '"scanned"' );
+} );

--- a/tests/Unit/VisualEditor/Responsive/AttributeMigratorTest.php
+++ b/tests/Unit/VisualEditor/Responsive/AttributeMigratorTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Responsive\AttributeMigrator;
+
+it( 'leaves a scalar untouched when promoting to base', function () {
+	$migrator = new AttributeMigrator();
+
+	expect( $migrator->promote( 4, 'base', 5 ) )->toBe( 5 );
+} );
+
+it( 'promotes a scalar into the discriminated form on the first non-base override', function () {
+	$migrator = new AttributeMigrator();
+
+	expect( $migrator->promote( 4, 'md', 6 ) )->toBe( [
+		'base' => 4,
+		'md'   => 6,
+	] );
+} );
+
+it( 'merges another override into an already-discriminated attribute', function () {
+	$migrator = new AttributeMigrator();
+	$start    = [ 'base' => 4, 'md' => 6 ];
+
+	expect( $migrator->promote( $start, 'lg', 8 ) )->toBe( [
+		'base' => 4,
+		'md'   => 6,
+		'lg'   => 8,
+	] );
+} );
+
+it( 'demotes back to scalar when every override is cleared', function () {
+	$migrator = new AttributeMigrator();
+	$attr     = [ 'base' => 4, 'md' => null, 'lg' => null ];
+
+	expect( $migrator->demote( $attr ) )->toBe( 4 );
+} );
+
+it( 'leaves the attribute alone when overrides remain', function () {
+	$migrator = new AttributeMigrator();
+	$attr     = [ 'base' => 4, 'md' => 6 ];
+
+	expect( $migrator->demote( $attr ) )->toBe( $attr );
+} );
+
+it( 'clears a specific override and demotes when nothing else remains', function () {
+	$migrator = new AttributeMigrator();
+	$attr     = [ 'base' => 4, 'md' => 6 ];
+
+	expect( $migrator->clear( $attr, 'md' ) )->toBe( 4 );
+} );
+
+it( 'clears a single override out of many and keeps the rest', function () {
+	$migrator = new AttributeMigrator();
+	$attr     = [ 'base' => 4, 'sm' => 1, 'md' => 6 ];
+
+	expect( $migrator->clear( $attr, 'md' ) )->toBe( [
+		'base' => 4,
+		'sm'   => 1,
+	] );
+} );

--- a/tests/Unit/VisualEditor/Responsive/BreakpointRegistryTest.php
+++ b/tests/Unit/VisualEditor/Responsive/BreakpointRegistryTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Responsive\BreakpointRegistry;
+
+it( 'falls back to Tailwind v4 defaults when nothing overrides them', function () {
+	$registry = BreakpointRegistry::fromLayers( [], [] );
+
+	expect( $registry->all() )->toBe( [
+		'sm'  => 640,
+		'md'  => 768,
+		'lg'  => 1024,
+		'xl'  => 1280,
+		'2xl' => 1536,
+	] );
+} );
+
+it( 'merges config overrides on top of defaults', function () {
+	$registry = BreakpointRegistry::fromLayers( [ 'lg' => 1100 ], [] );
+
+	expect( $registry->get( 'lg' ) )->toBe( 1100 );
+	expect( $registry->get( 'md' ) )->toBe( 768 );
+} );
+
+it( 'merges theme.json overrides on top of config', function () {
+	$registry = BreakpointRegistry::fromLayers(
+		[ 'lg' => 1100 ],
+		[ 'lg' => '1200px', '3xl' => 1920 ]
+	);
+
+	expect( $registry->get( 'lg' ) )->toBe( 1200 );
+	expect( $registry->get( '3xl' ) )->toBe( 1920 );
+	expect( $registry->prefixes() )->toContain( '3xl' );
+} );
+
+it( 'sorts the registry ascending by min-width', function () {
+	$registry = BreakpointRegistry::fromLayers(
+		[],
+		[ '3xl' => 1920, 'xxs' => 320 ]
+	);
+
+	expect( array_keys( $registry->all() ) )->toBe( [
+		'xxs', 'sm', 'md', 'lg', 'xl', '2xl', '3xl',
+	] );
+} );
+
+it( 'returns 0 for the implicit base slot and exposes it in keysWithBase()', function () {
+	$registry = BreakpointRegistry::fromLayers( [], [] );
+
+	expect( $registry->get( 'base' ) )->toBe( 0 );
+	expect( $registry->keysWithBase() )->toBe( [ 'base', 'sm', 'md', 'lg', 'xl', '2xl' ] );
+	expect( $registry->has( 'base' ) )->toBeTrue();
+} );
+
+it( 'rejects the reserved `base` key during validation', function () {
+	BreakpointRegistry::fromLayers( [ 'base' => 0 ], [] );
+} )->throws( InvalidArgumentException::class, 'reserved' );
+
+it( 'rejects breakpoints with non-positive widths', function () {
+	BreakpointRegistry::fromLayers( [ 'sm' => 0 ], [] );
+} )->throws( InvalidArgumentException::class, 'positive pixel value' );
+
+it( 'rejects breakpoints with duplicate widths', function () {
+	BreakpointRegistry::fromLayers( [], [ 'foo' => 640 ] );
+} )->throws( InvalidArgumentException::class, 'same min-width' );
+
+it( 'rejects breakpoints with non-numeric strings', function () {
+	BreakpointRegistry::fromLayers( [], [ 'foo' => '10rem' ] );
+} )->throws( InvalidArgumentException::class, 'invalid value' );
+
+it( 'rejects breakpoints with invalid key characters', function () {
+	BreakpointRegistry::fromLayers( [], [ 'big screen!' => 1900 ] );
+} )->throws( InvalidArgumentException::class, 'letters, numbers' );

--- a/tests/Unit/VisualEditor/Responsive/ResponsiveValueResolverTest.php
+++ b/tests/Unit/VisualEditor/Responsive/ResponsiveValueResolverTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Responsive\BreakpointRegistry;
+use ArtisanPackUI\VisualEditor\Responsive\ResponsiveValueResolver;
+
+function makeResolver(): ResponsiveValueResolver
+{
+	return new ResponsiveValueResolver( BreakpointRegistry::fromLayers( [], [] ) );
+}
+
+it( 'returns scalars unchanged', function () {
+	expect( makeResolver()->resolve( 4, 'md' ) )->toBe( 4 );
+	expect( makeResolver()->resolve( 'left', 'md' ) )->toBe( 'left' );
+} );
+
+it( 'returns the base value when no breakpoint overrides exist', function () {
+	$attribute = [ 'base' => 4 ];
+
+	expect( makeResolver()->resolve( $attribute, 'lg' ) )->toBe( 4 );
+} );
+
+it( 'cascades a smaller breakpoint up through null slots', function () {
+	$attribute = [ 'base' => 4, 'sm' => 1, 'md' => null, 'lg' => null ];
+	$resolver  = makeResolver();
+
+	expect( $resolver->resolve( $attribute, 'sm' ) )->toBe( 1 );
+	expect( $resolver->resolve( $attribute, 'md' ) )->toBe( 1 );
+	expect( $resolver->resolve( $attribute, 'lg' ) )->toBe( 1 );
+} );
+
+it( 'returns the largest defined override at or below the active breakpoint', function () {
+	$attribute = [ 'base' => 3, 'sm' => 1, 'md' => 2 ];
+	$resolver  = makeResolver();
+
+	expect( $resolver->resolve( $attribute, 'sm' ) )->toBe( 1 );
+	expect( $resolver->resolve( $attribute, 'md' ) )->toBe( 2 );
+	expect( $resolver->resolve( $attribute, 'lg' ) )->toBe( 2 );
+	expect( $resolver->resolve( $attribute, 'xl' ) )->toBe( 2 );
+	expect( $resolver->resolve( $attribute, '2xl' ) )->toBe( 2 );
+	expect( $resolver->resolve( $attribute, 'base' ) )->toBe( 3 );
+} );
+
+it( 'returns null when no slot at or below the active breakpoint is defined', function () {
+	$attribute = [ 'md' => 5 ];
+
+	expect( makeResolver()->resolve( $attribute, 'sm' ) )->toBeNull();
+} );
+
+it( 'falls back to base when active breakpoint is unknown', function () {
+	$attribute = [ 'base' => 7, 'md' => 9 ];
+
+	expect( makeResolver()->resolve( $attribute, 'made-up' ) )->toBe( 7 );
+} );
+
+it( 'recognises responsive shape via base or any registry key', function () {
+	$resolver = makeResolver();
+
+	expect( $resolver->isResponsiveAttribute( [ 'base' => 1 ] ) )->toBeTrue();
+	expect( $resolver->isResponsiveAttribute( [ 'md' => 1 ] ) )->toBeTrue();
+	expect( $resolver->isResponsiveAttribute( [ 'orphan' => 1 ] ) )->toBeFalse();
+	expect( $resolver->isResponsiveAttribute( [ 1, 2, 3 ] ) )->toBeFalse();
+	expect( $resolver->isResponsiveAttribute( 'string' ) )->toBeFalse();
+} );
+
+it( 'compresses distinct overrides to skip redundant inherited values', function () {
+	$resolver  = makeResolver();
+	$attribute = [ 'base' => 4, 'sm' => 4, 'md' => 6, 'lg' => 6 ];
+
+	expect( $resolver->distinctOverrides( $attribute ) )->toBe( [
+		'base' => 4,
+		'md'   => 6,
+	] );
+} );
+
+it( 'lists override keys that are not in the active registry as orphans', function () {
+	$resolver  = makeResolver();
+	$attribute = [ 'base' => 1, 'md' => 2, 'legacy' => 3 ];
+
+	expect( $resolver->orphanedKeys( $attribute ) )->toBe( [ 'legacy' ] );
+} );


### PR DESCRIPTION
## Description

Per-breakpoint editing for spacing, border, column count, and column width — end-to-end from the inspector through to consolidated server-rendered CSS. Mobile-first cascade semantics matching Tailwind v4's `sm/md/lg/xl/2xl` defaults; the registry is theme-configurable via `theme.json` or app config.

**Closes:** #487
**Also closes:** #509 (consolidated `<style data-ve-responsive>` emission was pulled forward into this PR)

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #487

## Motivation and Context

Block styles previously resolved to a single value across every viewport. Editors who wanted per-device layouts had to author two trees, hack markup, or skip the block. Tailwind was in the stack but with no first-class per-breakpoint UI.

## Changes Made

**PHP backend (`src/Responsive/`):**
- `BreakpointRegistry` — resolves theme.json → config → Tailwind v4 defaults, with schema validation
- `ResponsiveValueResolver` — mobile-first cascade with null-inherits semantics
- `AttributeMigrator` — lazy scalar → discriminated-object promotion
- `Console/AuditBreakpointsCommand` — `visual-editor:audit-breakpoints` artisan command for orphaned overrides

**Blade renderer (`packages/visual-editor-renderer-blade/`):**
- `BlockSupports::compileResponsive()` — emits scoped `@media` rules for spacing/border paths
- `ResponsiveCssAccumulator` — per-request scoped service that collects every block's CSS
- `<x-ve-blocks>` / `<x-ve-template>` drain it into ONE `<style data-ve-responsive>` block at the top of the render output (no `<style>` tags interleaved in flex containers)
- Specificity wins: tripled-class selectors (`.ve-r-x.ve-r-x.ve-r-x`) + `!important` + `flex-grow:0 !important` + gap-aware `calc(X% - var(--wp--style--block-gap) * factor)` to beat WP core's column-stacking rule
- Column partial special-cases `responsive.width` → `flex-basis` (not `width`) and `responsive.columnCount` → `grid-template-columns`

**Editor (`resources/js/visual-editor/`):**
- `ViewportSwitcher` in the top bar (`All sizes / sm+ / md+ / lg+ / xl+ / 2xl+` — labels match mobile-first semantics, no misleading device names)
- `InspectorScopeChip` surfaces the active viewport scope inside the inspector
- `withResponsiveAttributes` editor.BlockEdit HOC — invisibly routes reads/writes through the active breakpoint so native Gutenberg controls (BoxControl, RangeControl, UnitControl, BorderControl) become breakpoint-aware with zero per-control wrapping
- `blocks.registerBlockType` filter auto-injects the `responsive` attribute on opted-in blocks
- Spacing/border/dimensions re-enabled in `__experimentalFeatures` (Phase A iframe migration fixed the underlying drag-loop bug that previously gated them)

**Forked blocks opted in via `supports.artisanpackResponsive`:** columns, column, group, buttons, spacer, cover, media-text.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS 25.5.0
- Browser: Safari
- PHP Version: 8.4.3
- Project Version: release/1.0 branch

**Tests Performed:**
1. Editor: switch top-bar viewport to a breakpoint, set per-attribute values, confirm reverting to "All sizes" shows base values and the chip disappears
2. Front-end render: set column width per breakpoint, confirm consolidated `<style data-ve-responsive>` block at top, no interleaved tags inside flex container
3. Layout cascade: 4 columns at 50% base / 25% md+ → 2x2 on mobile, 1x4 on tablet+
4. Audit: `php artisan visual-editor:audit-breakpoints` reports zero orphans on clean content; reports correctly when overrides exist for removed breakpoints
5. Three CodeRabbit review passes against `release/1.0` — final pass returned 0 findings

## Accessibility Tests Run

- [x] Keyboard navigation tested (viewport switcher buttons, scope chip reset button)
- [x] ARIA labels checked (`role="status"` + `aria-live="polite"` on the scope chip; `aria-pressed` on viewport buttons; `role="group"` on the switcher with `aria-label="Preview viewport"`)
- [ ] Screen reader tested
- [ ] Color contrast verified

**Details:** Viewport switcher and scope chip use semantic toggle/status patterns. Tooltips explain mobile-first cascade behavior to screen-reader users.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:**
- 749 PHP tests (35 new in `tests/Unit/VisualEditor/Responsive/`, `tests/Feature/VisualEditor/Responsive/`, `packages/visual-editor-renderer-blade/tests/Unit/BlockSupportsResponsiveTest.php`, and `packages/visual-editor-renderer-blade/tests/Feature/Responsive/`)
- 1569 vitest tests (37 new across `resources/js/visual-editor/responsive/__tests__/`)

## Documentation

- [x] Inline code documentation added (extensive docblocks on every new class)
- [x] Wiki updated (`docs/responsive-design-tools.md` — editor + developer workflow)

**Documentation details:**
- `docs/responsive-design-tools.md` — full feature doc with editor workflow and developer integration guide
- `docs/theming.md` — added breakpoint registry hierarchy section
- `docs/dev-setup.md` — added breakpoint snapshot bootstrap section

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests (749 PHP + 1569 JS)
- [x] Code has been linted (CodeRabbit clean)
- [ ] Accessibility tests completed (partial — keyboard + ARIA verified, screen reader + contrast pending)
- [x] Code follows project style guide (WordPress-style spacing per package conventions)
- [x] Self-review completed
- [x] Comments added for complex code (specificity tricks, !important rationale, gap-aware calc formula, accumulator pattern all documented inline)
- [x] No new warnings generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-breakpoint responsive editing for many blocks, with viewport switcher, inspector scope chip, and responsive controls
  * Central breakpoint configuration and server-side consolidation of responsive CSS for rendered content
* **Documentation**
  * Added detailed guides for breakpoints and responsive design tools
* **Tests**
  * Comprehensive unit and feature tests covering responsive registry, resolution, migration, and rendering
* **Chores**
  * New global_styles.breakpoints config entry (defaults preserved until populated)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->