### PR TITLE
feat: state design tools — hover/focus/active/disabled styles

### DIFF
--- a/config/visual-editor.php
+++ b/config/visual-editor.php
@@ -274,6 +274,50 @@ return [
 
 	/*
 	|--------------------------------------------------------------------------
+	| Interactive states (#488)
+	|--------------------------------------------------------------------------
+	|
+	| Interactive states the InspectorControls state switcher and the
+	| state value resolver use. Resolved in priority order:
+	|
+	|   1. Active theme's `theme.json` → `settings.custom.artisanpack.states`
+	|   2. This config array (host-app overrides)
+	|   3. `StateRegistry::DEFAULTS` (idle, hover, focus, focus-visible,
+	|      active, disabled)
+	|
+	| Each state is an associative array with these keys:
+	|
+	|   - label          (string)   Human-readable label shown in the inspector.
+	|   - selector       (string)   CSS pseudo or attribute selector. The token
+	|                               `&` is replaced with the block's unique
+	|                               class scope. Reserved `idle` must use `''`.
+	|   - icon           (string)   Optional icon slug for the inspector chip.
+	|   - inheritsFrom   (string)   Parent state key for null-fallback. The
+	|                               `idle` slot is the implicit root.
+	|   - hoverMediaWrap (bool)     When true, the renderer wraps the rule in
+	|                               `@media (hover: hover)`. Default `false`.
+	|
+	| Merging is by key, so an entry here for `hover` extends the default
+	| hover state without disturbing the others. A new key like
+	| `aria-current` adds a state. To remove a built-in state, set its
+	| key to `null` — the registry will skip it.
+	|
+	| The reserved `idle` state is the implicit base of every inheritance
+	| chain and cannot be removed or aliased.
+	|
+	*/
+
+	'states' => [
+		// 'aria-current' => [
+		//     'label'        => 'Current',
+		//     'selector'     => '&[aria-current="page"]',
+		//     'icon'         => 'flag',
+		//     'inheritsFrom' => 'idle',
+		// ],
+	],
+
+	/*
+	|--------------------------------------------------------------------------
 	| Site editor (H5)
 	|--------------------------------------------------------------------------
 	|

--- a/docs/state-design-tools.md
+++ b/docs/state-design-tools.md
@@ -19,11 +19,11 @@ This document covers both the editor-facing workflow and the developer integrati
 
 When you select a block that opts into state styling, the Inspector's Block tab shows a strip of state chips at the top of the panel:
 
-```
+```text
 [ Idle ] [ Hover ] [ Focus ] [ Focus visible ] [ Active ] [ Disabled ]
 ```
 
-The strip is **block-specific** — it appears for buttons, navigation, image, cover, media-text, details, and any block that declares `supports.artisanpackStates`. Blocks that don't opt in show a short explanatory message instead.
+The strip is **block-specific** — it appears for buttons, image, cover, media-text, details, and any block that declares `supports.artisanpackStates`. Blocks that don't opt in show a short explanatory message instead.
 
 Selecting a chip scopes the next style edit to that state. The currently selected chip is highlighted, and chips for states that already have an override show a small dot.
 

--- a/docs/state-design-tools.md
+++ b/docs/state-design-tools.md
@@ -1,0 +1,228 @@
+# State Design Tools
+
+**Status:** v1.0
+**Plan:** [`plans/18-state-design-tools.md`](plans/18-state-design-tools.md)
+**Issue:** #488
+
+The editor lets editors author different styles for the same block at different interactive states — hover, focus, focus-visible, active, disabled — and lets developers register additional custom states (e.g. `aria-current`) without writing CSS. The same registry that drives the editor UI also drives the server-side renderer, so previews match production exactly. Output is plain CSS — no JS runtime is required on the published page.
+
+This document covers both the editor-facing workflow and the developer integration surface. See also:
+
+- [`theming.md`](theming.md) — for the broader theme.json hierarchy (where overrides live).
+- [`responsive-design-tools.md`](responsive-design-tools.md) — sister feature with the same value-resolver shape.
+
+---
+
+## 1. For editors
+
+### 1.1 The state switcher
+
+When you select a block that opts into state styling, the Inspector's Block tab shows a strip of state chips at the top of the panel:
+
+```
+[ Idle ] [ Hover ] [ Focus ] [ Focus visible ] [ Active ] [ Disabled ]
+```
+
+The strip is **block-specific** — it appears for buttons, navigation, image, cover, media-text, details, and any block that declares `supports.artisanpackStates`. Blocks that don't opt in show a short explanatory message instead.
+
+Selecting a chip scopes the next style edit to that state. The currently selected chip is highlighted, and chips for states that already have an override show a small dot.
+
+### 1.2 Setting a per-state override
+
+1. Select the block you want to customize.
+2. Click the state chip for the state you want to target (e.g. **Hover**).
+3. Adjust any supported control in the Inspector — background color, text color, border, shadow, transform, transition.
+
+The value you set applies in that state's CSS selector context only. States that aren't explicitly set inherit through the chain (see §1.4).
+
+### 1.3 Previewing a state on the canvas
+
+When a non-idle state is selected, a **Preview** button appears next to the chip strip. Clicking it simulates the state on the canvas without you having to actually hover or focus the block — handy for inspecting `:focus-visible` styles in particular.
+
+Click **Stop preview** to return to the default view. The preview is editor-only and never reaches the saved content.
+
+### 1.4 Inheritance chain
+
+States fall back through a chain so you only need to set the slots that genuinely differ:
+
+| State            | Falls back to |
+| ---------------- | ------------- |
+| `hover`          | `idle`        |
+| `focus`          | `idle`        |
+| `focus-visible`  | `focus` → `idle` |
+| `active`         | `hover` → `idle` |
+| `disabled`       | `idle`        |
+
+If you set `hover` to `accent-700`, `active` inherits `accent-700` automatically unless you override it. Clearing an override sets the slot back to inheriting through the chain.
+
+### 1.5 Resetting an override
+
+Each per-state control surfaces a **Reset {state}** button when an override is currently set at the active state. Clicking it removes that single override and lets the value cascade from the next link in the inheritance chain.
+
+If clearing the override leaves no other state overrides, the stored attribute collapses back to its scalar form — no extra JSON on disk.
+
+---
+
+## 2. For developers
+
+### 2.1 Configuring states
+
+States resolve in priority order — highest layer wins on key collision:
+
+1. **Active theme's `theme.json`** — `settings.custom.artisanpack.states`
+2. **Application config** — `artisanpack.visual-editor.states`
+3. **Package defaults** — `StateRegistry::DEFAULTS` (idle, hover, focus, focus-visible, active, disabled)
+
+#### Config example
+
+```php
+// config/artisanpack/visual-editor.php
+return [
+    'states' => [
+        // Add a new aria-current state:
+        'aria-current' => [
+            'label'        => 'Current page',
+            'selector'     => '&[aria-current="page"]',
+            'icon'         => 'flag',
+            'inheritsFrom' => 'idle',
+        ],
+        // Remove a built-in state (rare):
+        'disabled' => null,
+    ],
+];
+```
+
+#### theme.json example
+
+```json
+{
+    "settings": {
+        "custom": {
+            "artisanpack": {
+                "states": {
+                    "aria-current": {
+                        "label": "Current page",
+                        "selector": "&[aria-current=\"page\"]",
+                        "inheritsFrom": "idle"
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+### 2.2 State definition shape
+
+Each state entry is an associative array:
+
+| Key              | Type    | Required | Description |
+| ---------------- | ------- | -------- | ----------- |
+| `label`          | string  | yes      | Human-readable label shown in the Inspector chip. |
+| `selector`       | string  | yes\*    | CSS pseudo or attribute selector. `&` is replaced with the block's unique scope at emit time. The reserved `idle` state must use `''`. |
+| `icon`           | string  | no       | Optional icon slug for the Inspector chip. |
+| `inheritsFrom`   | string  | no       | Parent state key for null-fallback. The `idle` slot is the implicit root. |
+| `hoverMediaWrap` | bool    | no       | When `true`, the renderer wraps the rule in `@media (hover: hover)`. Defaults to `false`. The built-in `hover` state has this enabled. |
+
+\* `idle` must have an empty selector — it represents the default styles.
+
+### 2.3 Block opt-in
+
+A block opts into state styling by declaring `supports.artisanpackStates` in its `block.json`:
+
+```json
+{
+    "supports": {
+        "artisanpackStates": {
+            "attributes": [
+                "color.background",
+                "color.text",
+                "border.color",
+                "border.radius",
+                "shadow",
+                "dimensions.transform",
+                "transition"
+            ]
+        }
+    }
+}
+```
+
+`attributes` is an allow-list of which attribute paths support per-state overrides. Listing fewer paths is the recommended way to scope state styling to the attributes a block actually wants to expose.
+
+These blocks opt in by default:
+
+- `artisanpack/button`
+- `artisanpack/buttons`
+- `artisanpack/image`
+- `artisanpack/cover`
+- `artisanpack/media-text`
+- `artisanpack/details`
+
+`artisanpack/navigation` is intentionally not opted in for v1.0 — the parent block doesn't declare color/border supports, so state styling lands more naturally on individual `core/navigation-link` children. That's deferred to a follow-up.
+
+### 2.4 Attribute storage shape
+
+State-capable attributes are stored as either:
+
+- a scalar (legacy / unmodified content), or
+- a stateful `{ idle, hover, focus, … }` object once any per-state override is set:
+
+```json
+{
+    "idle":  "var(--ap-color-accent)",
+    "hover": "var(--ap-color-accent-700)",
+    "focus-visible": null
+}
+```
+
+`null` means "inherit from the next link in the chain." The editor promotes a scalar to the discriminated form on first override and demotes it back to a scalar when the last override is cleared, keeping saved JSON compact.
+
+### 2.5 CSS emission
+
+The server-side `StateCssEmitter` turns a block's stateful attributes into scoped CSS. Given a unique class scope and a map of `property => stateful value`, it emits:
+
+- An `idle` rule against the scope.
+- One rule per non-idle state whose resolved value differs from its inheritance parent (the renderer skips redundant rules).
+- A wrapping `@media (hover: hover) { … }` around any rule whose state has `hoverMediaWrap = true`.
+- A default `transition: all 150ms ease;` on the `idle` rule whenever any non-idle state is set and no explicit `transition` was authored.
+
+Example output:
+
+```css
+.ap-block-abc123 { background-color: var(--ap-color-accent); transition: all 150ms ease; }
+@media (hover: hover) { .ap-block-abc123:hover { background-color: var(--ap-color-accent-700); } }
+.ap-block-abc123:focus-visible { background-color: var(--ap-color-accent-500); }
+```
+
+### 2.6 Supported attributes
+
+State overrides are supported on:
+
+- `color.background`, `color.text`, `color.gradient`
+- `border.color`, `border.width`, `border.style`, `border.radius`
+- `shadow`
+- `typography.textDecoration`
+- `dimensions.transform` (scale / translate)
+- `transition`
+
+Spacing is intentionally not state-scoped in v1.0 (hover-grows-the-padding is a niche pattern). Per-breakpoint state styles are also out of scope for v1.0 — that composition is on the v1.x roadmap.
+
+### 2.7 Validating a custom state
+
+The registry validates every state at construction time. Bad configuration raises a descriptive `InvalidArgumentException`. Common pitfalls:
+
+- The reserved `idle` slot is missing or carries a non-empty selector.
+- A non-idle state has no `selector` or no `label`.
+- `inheritsFrom` points at a state that isn't registered.
+- The inheritance chain forms a cycle.
+
+The `InheritanceChainValidator` can also run independently against a candidate state map — useful for CI linting of `theme.json`.
+
+---
+
+## 3. Reference
+
+- PHP: `ArtisanPackUI\VisualEditor\States\StateRegistry`, `StateValueResolver`, `StateAttributeMigrator`, `StateCssEmitter`, `InheritanceChainValidator`.
+- JS: `@artisanpack-ui/visual-editor` → `StateRegistry`, `resolveStateValue`, `useStateValue`, `StateSwitcher`, `StateControl`, `PreviewStateToggle`.
+- Base key constant: `idle` (PHP `StateRegistry::BASE_KEY`, JS `BASE_KEY`).

--- a/packages/visual-editor-renderer-blade/resources/views/components/blocks.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/components/blocks.blade.php
@@ -8,4 +8,9 @@
 {!! $responsiveCss !!}
 @endif
 @endisset
+@isset( $statesCss )
+@if( '' !== $statesCss )
+{!! $statesCss !!}
+@endif
+@endisset
 {!! $html !!}

--- a/packages/visual-editor-renderer-blade/resources/views/components/template.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/components/template.blade.php
@@ -15,6 +15,11 @@
 {!! $responsiveCss !!}
 @endif
 @endisset
+@isset( $statesCss )
+@if( '' !== $statesCss )
+{!! $statesCss !!}
+@endif
+@endisset
 <div class="{{ implode( ' ', $wrapperClasses ) }}" data-ve-template="{{ $slug }}"@if( null !== $matchedSlug && $matchedSlug !== $slug ) data-ve-matched-template="{{ $matchedSlug }}"@endif>
 @if( null !== $resolutionError )
 @if( $inDev )

--- a/packages/visual-editor-renderer-blade/src/Services/StateCssAccumulator.php
+++ b/packages/visual-editor-renderer-blade/src/Services/StateCssAccumulator.php
@@ -1,0 +1,105 @@
+<?php
+
+/**
+ * Per-request accumulator for the state design tools' CSS (#488).
+ *
+ * Block partials push their per-state CSS rule strings into this
+ * service while rendering. The `<x-ve-blocks>` / `<x-ve-template>`
+ * components then drain it once and emit a single
+ * `<style data-ve-states>` block at the top of the render output.
+ *
+ * Mirrors {@see ResponsiveCssAccumulator} — same dedupe-by-scope
+ * semantics, same scoped-per-request lifetime — so the two
+ * accumulators compose naturally in the same render pass.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditorRendererBlade
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditorRendererBlade\Services;
+
+class StateCssAccumulator
+{
+	/**
+	 * Map of scope class → CSS rule string. Keyed so duplicate pushes
+	 * collapse to one entry; iteration order preserves first-push order
+	 * since PHP arrays remember insertion order.
+	 *
+	 * @var array<string, string>
+	 */
+	protected array $rules = [];
+
+	/**
+	 * Adds a rule set for the given scope class. Subsequent calls with
+	 * the same scope are ignored — block partials are expected to use
+	 * content-derived scope classes so an identical payload always
+	 * hashes to the same key.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string  $scope  The scope class (e.g. `ap-state-abc123`).
+	 * @param  string  $css    The CSS rule string (no surrounding
+	 *                         `<style>` tag).
+	 */
+	public function push( string $scope, string $css ): void
+	{
+		if ( '' === $scope || '' === $css ) {
+			return;
+		}
+
+		if ( isset( $this->rules[ $scope ] ) ) {
+			return;
+		}
+
+		$this->rules[ $scope ] = $css;
+	}
+
+	/**
+	 * Returns the consolidated `<style data-ve-states>` block and clears
+	 * the accumulator. Called once per render at the top of the
+	 * `<x-ve-blocks>` / `<x-ve-template>` output. Returns an empty
+	 * string when no rules were pushed.
+	 *
+	 * @since 1.0.0
+	 */
+	public function flush(): string
+	{
+		if ( [] === $this->rules ) {
+			return '';
+		}
+
+		$body        = implode( '', array_values( $this->rules ) );
+		$this->rules = [];
+
+		return '<style data-ve-states>' . $body . '</style>';
+	}
+
+	/**
+	 * Resets the accumulator without emitting. Tests use this to clear
+	 * state between assertions inside a single PHP process.
+	 *
+	 * @since 1.0.0
+	 */
+	public function reset(): void
+	{
+		$this->rules = [];
+	}
+
+	/**
+	 * Inspect what's currently accumulated without draining. Test-only.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<string, string>
+	 */
+	public function all(): array
+	{
+		return $this->rules;
+	}
+}

--- a/packages/visual-editor-renderer-blade/src/Services/ThemeJsonTokensCompiler.php
+++ b/packages/visual-editor-renderer-blade/src/Services/ThemeJsonTokensCompiler.php
@@ -73,11 +73,170 @@ class ThemeJsonTokensCompiler
 
 		$layout = $this->compileLayoutRules( $settings );
 
+		$utilities = $this->compilePresetUtilityClasses( $settings );
+
 		$stylesCss = $this->compileStyles( $styles );
 
-		$parts = array_values( array_filter( [ $root, $layout, $stylesCss ], static fn ( string $section ): bool => '' !== $section ) );
+		$parts = array_values( array_filter( [ $root, $layout, $utilities, $stylesCss ], static fn ( string $section ): bool => '' !== $section ) );
 
 		return implode( "\n\n", $parts );
+	}
+
+	/**
+	 * Emit the `.has-{slug}-*` utility-class rules WordPress core binds
+	 * to theme.json palette / font-size / gradient slugs. Without these
+	 * a block that carries `has-accent-background-color` has no CSS
+	 * rule pointing the class at `var(--wp--preset--color--accent)`.
+	 *
+	 * Mirrors core's `_wp_get_iframed_editor_assets()` / global-styles
+	 * output: one rule per slug per property, marked `!important` so
+	 * specificity matches inline styles.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @param  array<string, mixed>  $settings  `themeJson.settings` payload.
+	 */
+	protected function compilePresetUtilityClasses( array $settings ): string
+	{
+		$rules = [];
+
+		$colorPalette = $this->compileColorUtilityRules( $settings );
+		if ( '' !== $colorPalette ) {
+			$rules[] = $colorPalette;
+		}
+
+		$gradients = $this->compileGradientUtilityRules( $settings );
+		if ( '' !== $gradients ) {
+			$rules[] = $gradients;
+		}
+
+		$fontSizes = $this->compileFontSizeUtilityRules( $settings );
+		if ( '' !== $fontSizes ) {
+			$rules[] = $fontSizes;
+		}
+
+		return implode( "\n\n", $rules );
+	}
+
+	/**
+	 * Emit `.has-{slug}-color`, `.has-{slug}-background-color`, and
+	 * `.has-{slug}-border-color` for each entry in
+	 * `settings.color.palette`.
+	 *
+	 * @param  array<string, mixed>  $settings
+	 */
+	protected function compileColorUtilityRules( array $settings ): string
+	{
+		$palette = $settings['color']['palette'] ?? null;
+		if ( ! is_array( $palette ) ) {
+			return '';
+		}
+
+		$lines = [];
+
+		foreach ( $palette as $entry ) {
+			if ( ! is_array( $entry ) ) {
+				continue;
+			}
+
+			$slug  = isset( $entry['slug'] ) && is_string( $entry['slug'] ) ? trim( $entry['slug'] ) : '';
+			$value = isset( $entry['color'] ) && is_string( $entry['color'] ) ? trim( $entry['color'] ) : '';
+
+			// Skip entries that aren't a complete pair — the `:root`
+			// emitter does the same. Emitting a utility class pointing
+			// at an undefined `--wp--preset--*` variable would just be
+			// dead CSS.
+			if ( '' === $slug || '' === $value ) {
+				continue;
+			}
+
+			$slug = $this->slug( $slug );
+			$var  = sprintf( 'var(--wp--preset--color--%s)', $slug );
+
+			$lines[] = sprintf( '.has-%s-color { color: %s !important; }', $slug, $var );
+			$lines[] = sprintf( '.has-%s-background-color { background-color: %s !important; }', $slug, $var );
+			$lines[] = sprintf( '.has-%s-border-color { border-color: %s !important; }', $slug, $var );
+		}
+
+		return implode( "\n", $lines );
+	}
+
+	/**
+	 * Emit `.has-{slug}-gradient-background` for each entry in
+	 * `settings.color.gradient`.
+	 *
+	 * @param  array<string, mixed>  $settings
+	 */
+	protected function compileGradientUtilityRules( array $settings ): string
+	{
+		$gradients = $settings['color']['gradient'] ?? null;
+		if ( ! is_array( $gradients ) ) {
+			return '';
+		}
+
+		$lines = [];
+
+		foreach ( $gradients as $entry ) {
+			if ( ! is_array( $entry ) ) {
+				continue;
+			}
+
+			$slug  = isset( $entry['slug'] ) && is_string( $entry['slug'] ) ? trim( $entry['slug'] ) : '';
+			$value = isset( $entry['gradient'] ) && is_string( $entry['gradient'] ) ? trim( $entry['gradient'] ) : '';
+
+			if ( '' === $slug || '' === $value ) {
+				continue;
+			}
+
+			$slug = $this->slug( $slug );
+
+			$lines[] = sprintf(
+				'.has-%s-gradient-background { background: var(--wp--preset--gradient--%s) !important; }',
+				$slug,
+				$slug
+			);
+		}
+
+		return implode( "\n", $lines );
+	}
+
+	/**
+	 * Emit `.has-{slug}-font-size` for each entry in
+	 * `settings.typography.fontSizes`.
+	 *
+	 * @param  array<string, mixed>  $settings
+	 */
+	protected function compileFontSizeUtilityRules( array $settings ): string
+	{
+		$fontSizes = $settings['typography']['fontSizes'] ?? null;
+		if ( ! is_array( $fontSizes ) ) {
+			return '';
+		}
+
+		$lines = [];
+
+		foreach ( $fontSizes as $entry ) {
+			if ( ! is_array( $entry ) ) {
+				continue;
+			}
+
+			$slug  = isset( $entry['slug'] ) && is_string( $entry['slug'] ) ? trim( $entry['slug'] ) : '';
+			$value = isset( $entry['size'] ) && is_string( $entry['size'] ) ? trim( $entry['size'] ) : '';
+
+			if ( '' === $slug || '' === $value ) {
+				continue;
+			}
+
+			$slug = $this->slug( $slug );
+
+			$lines[] = sprintf(
+				'.has-%s-font-size { font-size: var(--wp--preset--font-size--%s) !important; }',
+				$slug,
+				$slug
+			);
+		}
+
+		return implode( "\n", $lines );
 	}
 
 	/**

--- a/packages/visual-editor-renderer-blade/src/Support/BlockSupports.php
+++ b/packages/visual-editor-renderer-blade/src/Support/BlockSupports.php
@@ -261,9 +261,21 @@ class BlockSupports
 			return [ 'class' => '', 'rules' => '' ];
 		}
 
-		$scopeId = isset( $bag['_scopeId'] ) && is_string( $bag['_scopeId'] ) && '' !== $bag['_scopeId']
-			? $bag['_scopeId']
-			: null;
+		// `_scopeId` is interpolated raw into the emitted `<style>` block
+		// and into the wrapper's class attribute, so its content has to
+		// be a safe identifier-style token. A crafted value containing
+		// `<`, `>`, `"`, `'`, whitespace, or other CSS punctuation could
+		// otherwise break out of the `<style>` context (XSS) or out of
+		// the selector (rule injection). The JS minter only ever produces
+		// alphanumeric base-36 strings; anything else is treated as
+		// hostile / corrupted and dropped.
+		$scopeId = null;
+		if ( isset( $bag['_scopeId'] ) && is_string( $bag['_scopeId'] ) ) {
+			$candidate = $bag['_scopeId'];
+			if ( 1 === preg_match( '/^[a-z0-9][a-z0-9_-]*$/i', $candidate ) && strlen( $candidate ) <= 64 ) {
+				$scopeId = $candidate;
+			}
+		}
 
 		if ( null === $scopeId ) {
 			return [ 'class' => '', 'rules' => '' ];

--- a/packages/visual-editor-renderer-blade/src/Support/BlockSupports.php
+++ b/packages/visual-editor-renderer-blade/src/Support/BlockSupports.php
@@ -48,7 +48,11 @@ declare( strict_types=1 );
 namespace ArtisanPackUI\VisualEditorRendererBlade\Support;
 
 use ArtisanPackUI\VisualEditor\Responsive\BreakpointRegistry;
+use ArtisanPackUI\VisualEditor\States\StateCssEmitter;
+use ArtisanPackUI\VisualEditor\States\StateRegistry;
+use ArtisanPackUI\VisualEditor\States\StateValueResolver;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\ResponsiveCssAccumulator;
+use ArtisanPackUI\VisualEditorRendererBlade\Services\StateCssAccumulator;
 
 class BlockSupports
 {
@@ -146,6 +150,14 @@ class BlockSupports
 			self::pushResponsive( $responsive['class'], $responsive['rules'] );
 		}
 
+		$states = self::compileStates( $attributes );
+
+		if ( '' !== $states['class'] ) {
+			$classes[] = $states['class'];
+
+			self::pushStates( $states['class'], $states['rules'] );
+		}
+
 		return [
 			'classes'         => $classes,
 			'style'           => $styleString,
@@ -153,6 +165,8 @@ class BlockSupports
 			'responsiveCss'   => '',
 			'responsiveClass' => $responsive['class'],
 			'responsiveRules' => $responsive['rules'],
+			'statesClass'     => $states['class'],
+			'statesRules'     => $states['rules'],
 		];
 	}
 
@@ -200,6 +214,249 @@ class BlockSupports
 			// idempotent and the accumulator is the side channel,
 			// not the data path.
 		}
+	}
+
+	/**
+	 * Mirror of {@see pushResponsive} for state design tools (#488).
+	 *
+	 * @since 1.0.0
+	 */
+	public static function pushStates( string $scope, string $rules ): void
+	{
+		if ( '' === $scope || '' === $rules ) {
+			return;
+		}
+
+		if ( ! function_exists( 'app' ) ) {
+			return;
+		}
+
+		try {
+			app( StateCssAccumulator::class )->push( $scope, $rules );
+		} catch ( \Throwable $e ) {
+			// See pushResponsive() — same drop-silently rationale.
+		}
+	}
+
+	/**
+	 * Compile the `attributes.states` payload into a `{class, rules}`
+	 * pair the wrapper can merge in and the accumulator can dedupe (#488).
+	 *
+	 * The payload shape is path-keyed
+	 * (`{ "backgroundColor": { idle: 'a', hover: 'b' }, "_scopeId": 'abc' }` —
+	 * same shape `withStateAttributes` writes from the editor). The
+	 * `_scopeId` key is reserved for the unique-class housekeeping field
+	 * minted by `withStateStyles`.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array<string, mixed>  $attributes
+	 *
+	 * @return array{class: string, rules: string}
+	 */
+	protected static function compileStates( array $attributes ): array
+	{
+		$bag = $attributes['states'] ?? null;
+		if ( ! is_array( $bag ) || [] === $bag ) {
+			return [ 'class' => '', 'rules' => '' ];
+		}
+
+		$scopeId = isset( $bag['_scopeId'] ) && is_string( $bag['_scopeId'] ) && '' !== $bag['_scopeId']
+			? $bag['_scopeId']
+			: null;
+
+		if ( null === $scopeId ) {
+			return [ 'class' => '', 'rules' => '' ];
+		}
+
+		$paths = $bag;
+		unset( $paths['_scopeId'] );
+
+		if ( [] === $paths ) {
+			return [ 'class' => '', 'rules' => '' ];
+		}
+
+		$bucket = self::normaliseStatePaths( $paths );
+
+		if ( [] === $bucket ) {
+			return [ 'class' => '', 'rules' => '' ];
+		}
+
+		try {
+			$registry = self::resolveStateRegistry();
+			$resolver = new StateValueResolver( $registry );
+			$emitter  = new StateCssEmitter( $registry, $resolver );
+
+			$scope = '.ap-state-' . $scopeId;
+			$css   = $emitter->emit( $scope, $bucket );
+
+			if ( '' === $css ) {
+				return [ 'class' => '', 'rules' => '' ];
+			}
+
+			// Mirror the JS-side selector cascade so server-rendered
+			// markup matches the editor preview: re-emit each rule
+			// against descendant interactive elements
+			// (`.scope :is(a, button)`).
+			$css = self::expandStateSelectors( $css, $scope );
+
+			return [
+				'class' => 'ap-state-' . $scopeId,
+				'rules' => $css,
+			];
+		} catch ( \Throwable $e ) {
+			return [ 'class' => '', 'rules' => '' ];
+		}
+	}
+
+	/**
+	 * Map the state path → CSS property mapping the JS emitter uses
+	 * back to a `{ cssProperty => stateful-value }` bag that the PHP
+	 * {@see StateCssEmitter} consumes.
+	 *
+	 * Palette slugs are translated to `var(--wp--preset--{kind}--{slug})`
+	 * so server output matches the editor canvas.
+	 *
+	 * @param  array<string, mixed>  $paths
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
+	protected static function normaliseStatePaths( array $paths ): array
+	{
+		$config = self::statePathConfig();
+		$out    = [];
+
+		foreach ( $paths as $path => $value ) {
+			if ( ! is_string( $path ) || ! is_array( $value ) ) {
+				continue;
+			}
+
+			$normalised = str_starts_with( $path, 'style.' ) ? substr( $path, 6 ) : $path;
+
+			if ( ! isset( $config[ $normalised ] ) ) {
+				continue;
+			}
+
+			$entry = $config[ $normalised ];
+
+			$converted = [];
+			foreach ( $value as $state => $raw ) {
+				if ( ! is_string( $state ) ) {
+					continue;
+				}
+
+				$converted[ $state ] = self::convertStateValue( $raw, $entry );
+			}
+
+			if ( [] === $converted ) {
+				continue;
+			}
+
+			$out[ $entry['property'] ] = $converted;
+		}
+
+		return $out;
+	}
+
+	/**
+	 * @return array<string, array{property: string, preset?: string}>
+	 */
+	protected static function statePathConfig(): array
+	{
+		return [
+			'backgroundColor'           => [ 'property' => 'background-color', 'preset' => 'color' ],
+			'textColor'                 => [ 'property' => 'color',            'preset' => 'color' ],
+			'gradient'                  => [ 'property' => 'background',       'preset' => 'gradient' ],
+			'color.background'          => [ 'property' => 'background-color' ],
+			'color.text'                => [ 'property' => 'color' ],
+			'color.gradient'            => [ 'property' => 'background' ],
+			'border.color'              => [ 'property' => 'border-color' ],
+			'border.width'              => [ 'property' => 'border-width' ],
+			'border.style'              => [ 'property' => 'border-style' ],
+			'border.radius'             => [ 'property' => 'border-radius' ],
+			'shadow'                    => [ 'property' => 'box-shadow' ],
+			'typography.textDecoration' => [ 'property' => 'text-decoration' ],
+			'dimensions.transform'      => [ 'property' => 'transform' ],
+			'transition'                => [ 'property' => 'transition' ],
+		];
+	}
+
+	/**
+	 * @param  array{property: string, preset?: string}  $entry
+	 */
+	protected static function convertStateValue( mixed $raw, array $entry ): mixed
+	{
+		if ( null === $raw ) {
+			return null;
+		}
+
+		if ( ! is_string( $raw ) ) {
+			return $raw;
+		}
+
+		if ( '' === $raw ) {
+			return null;
+		}
+
+		if ( isset( $entry['preset'] ) && 1 === preg_match( '/^[a-z0-9][a-z0-9_-]*$/i', $raw ) ) {
+			return sprintf( 'var(--wp--preset--%s--%s)', $entry['preset'], $raw );
+		}
+
+		return $raw;
+	}
+
+	protected static function resolveStateRegistry(): StateRegistry
+	{
+		try {
+			return app( StateRegistry::class );
+		} catch ( \Throwable $e ) {
+			return StateRegistry::fromLayers();
+		}
+	}
+
+	/**
+	 * Append descendant-element selectors (`scope :is(a, button)`) to
+	 * each pseudo-state selector in the emitted CSS so the rules apply
+	 * to inner interactive elements (e.g. `wp-block-button__link`).
+	 *
+	 * The emitter outputs rules in the form
+	 * `selector { props } @media (hover: hover) { selector { props } }`.
+	 * This rewrite re-emits each pseudo selector as
+	 * `selector, selector :is(a, button)`.
+	 *
+	 * Idle (bare scope) selectors are LEFT UNCHANGED — mirroring there
+	 * would leak the block-level idle color into every descendant
+	 * link, which is wrong for container blocks like cover and
+	 * media-text. The WP `has-{slug}-*` utility classes plus the
+	 * block's own root selector already handle the idle case.
+	 *
+	 * Kept conservative: only matches selectors that start with the
+	 * known scope class to avoid mangling unrelated CSS literals.
+	 */
+	protected static function expandStateSelectors( string $css, string $scope ): string
+	{
+		$escaped = preg_quote( $scope, '/' );
+
+		return (string) preg_replace_callback(
+			'/(' . $escaped . '[^{,]*?)\s*(\{|,)/',
+			static function ( array $matches ) use ( $scope ) : string {
+				$selector = trim( $matches[1] );
+				$delim    = $matches[2];
+
+				if ( '' === $selector || str_contains( $selector, ':is(a, button)' ) ) {
+					return $selector . ' ' . $delim;
+				}
+
+				// Bare-scope (idle) selectors get no descendant mirror;
+				// only pseudo / attribute-extended state selectors do.
+				if ( $selector === $scope ) {
+					return $selector . ' ' . $delim;
+				}
+
+				return $selector . ', ' . $selector . ' :is(a, button) ' . $delim;
+			},
+			$css
+		);
 	}
 
 	/**

--- a/packages/visual-editor-renderer-blade/src/View/Components/BlocksComponent.php
+++ b/packages/visual-editor-renderer-blade/src/View/Components/BlocksComponent.php
@@ -32,6 +32,7 @@ use ArtisanPackUI\VisualEditor\SiteEditor\NavigationBlockRefResolver;
 use ArtisanPackUI\VisualEditorRendererBlade\BlockRenderer;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\GlobalStylesEmissionResolver;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\ResponsiveCssAccumulator;
+use ArtisanPackUI\VisualEditorRendererBlade\Services\StateCssAccumulator;
 use Illuminate\Contracts\View\View;
 use Illuminate\View\Component;
 
@@ -59,6 +60,7 @@ class BlocksComponent extends Component
 		protected GlobalStylesEmissionResolver $globalStyles,
 		protected GlobalStylesEmissionTracker $emissionTracker,
 		protected ResponsiveCssAccumulator $responsiveAccumulator,
+		protected StateCssAccumulator $stateAccumulator,
 		mixed $tree = null,
 		?string $defaultTheme = null,
 		bool $resolveParts = true,
@@ -109,13 +111,15 @@ class BlocksComponent extends Component
 		// `BlockSupports::pushResponsive()` side-effect has happened
 		// by the time we drain the accumulator. The drained block
 		// is then prepended to the output by the view template.
-		$html         = $this->renderer->render( $this->tree );
+		$html          = $this->renderer->render( $this->tree );
 		$responsiveCss = $this->responsiveAccumulator->flush();
+		$statesCss     = $this->stateAccumulator->flush();
 
 		return view( 'visual-editor-renderer-blade::components.blocks', [
 			'html'            => $html,
 			'globalStylesCss' => $this->resolveGlobalStylesCss(),
 			'responsiveCss'   => $responsiveCss,
+			'statesCss'       => $statesCss,
 		] );
 	}
 

--- a/packages/visual-editor-renderer-blade/src/View/Components/TemplateComponent.php
+++ b/packages/visual-editor-renderer-blade/src/View/Components/TemplateComponent.php
@@ -36,6 +36,7 @@ use ArtisanPackUI\VisualEditor\Services\GlobalStylesEmissionTracker;
 use ArtisanPackUI\VisualEditorRendererBlade\BlockRenderer;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\GlobalStylesEmissionResolver;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\ResponsiveCssAccumulator;
+use ArtisanPackUI\VisualEditorRendererBlade\Services\StateCssAccumulator;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\View\View;
 use Illuminate\View\Component;
@@ -74,6 +75,7 @@ class TemplateComponent extends Component
 		protected GlobalStylesEmissionResolver $globalStyles,
 		protected GlobalStylesEmissionTracker $emissionTracker,
 		protected ResponsiveCssAccumulator $responsiveAccumulator,
+		protected StateCssAccumulator $stateAccumulator,
 		string $slug,
 		?string $theme = null,
 	) {
@@ -114,6 +116,7 @@ class TemplateComponent extends Component
 		// has had a chance to push its responsive rules in by now.
 		// See BlocksComponent::render() for the same pattern.
 		$responsiveCss = $this->responsiveAccumulator->flush();
+		$statesCss     = $this->stateAccumulator->flush();
 
 		return view( 'visual-editor-renderer-blade::components.template', [
 			'slug'            => $this->slug,
@@ -125,6 +128,7 @@ class TemplateComponent extends Component
 			'html'            => $this->html,
 			'globalStylesCss' => $this->resolveGlobalStylesCss(),
 			'responsiveCss'   => $responsiveCss,
+			'statesCss'       => $statesCss,
 		] );
 	}
 

--- a/packages/visual-editor-renderer-blade/src/VisualEditorRendererBladeServiceProvider.php
+++ b/packages/visual-editor-renderer-blade/src/VisualEditorRendererBladeServiceProvider.php
@@ -28,6 +28,7 @@ use ArtisanPackUI\VisualEditorRendererBlade\Responsive\ResponsiveClassResolver;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\GlobalStylesEmissionResolver;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\NavigationOverlayTracker;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\ResponsiveCssAccumulator;
+use ArtisanPackUI\VisualEditorRendererBlade\Services\StateCssAccumulator;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\ThemeJsonTokensCompiler;
 use ArtisanPackUI\VisualEditorRendererBlade\View\Components\BlocksComponent;
 use ArtisanPackUI\VisualEditorRendererBlade\View\Components\BlocksStylesComponent;
@@ -96,6 +97,13 @@ class VisualEditorRendererBladeServiceProvider extends ServiceProvider
 		// worker (Octane / queue) doesn't leak rules across requests.
 		$this->app->scoped( ResponsiveCssAccumulator::class, function () {
 			return new ResponsiveCssAccumulator();
+		} );
+
+		// #488 — sibling accumulator for the state design tools'
+		// `<style data-ve-states>` block. Same lifetime story as the
+		// responsive accumulator above.
+		$this->app->scoped( StateCssAccumulator::class, function () {
+			return new StateCssAccumulator();
 		} );
 	}
 

--- a/packages/visual-editor-renderer-blade/tests/Unit/BlockSupportsTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Unit/BlockSupportsTest.php
@@ -451,6 +451,8 @@ describe( 'BlockSupports::compile (composition)', function (): void {
 			'responsiveCss'   => '',
 			'responsiveClass' => '',
 			'responsiveRules' => '',
+			'statesClass'     => '',
+			'statesRules'     => '',
 		] );
 	} );
 
@@ -465,5 +467,57 @@ describe( 'BlockSupports::compile (composition)', function (): void {
 
 		expect( $result['classes'] )->toContain( 'has-accent-background-color' );
 		expect( $result['style'] )->toBe( '' );
+	} );
+} );
+
+describe( 'compile() — state design tools (#488)', function (): void {
+	it( 'returns empty state slots when no states bag is set', function (): void {
+		$result = BlockSupports::compile( [ 'backgroundColor' => 'accent' ] );
+
+		expect( $result['statesClass'] )->toBe( '' );
+		expect( $result['statesRules'] )->toBe( '' );
+	} );
+
+	it( 'returns empty state slots when scopeId is missing even if overrides exist', function (): void {
+		$result = BlockSupports::compile( [
+			'backgroundColor' => 'accent',
+			'states'          => [
+				'backgroundColor' => [ 'idle' => 'accent', 'hover' => 'accent-700' ],
+			],
+		] );
+
+		expect( $result['statesClass'] )->toBe( '' );
+		expect( $result['statesRules'] )->toBe( '' );
+	} );
+
+	it( 'emits a scoped state class and CSS rules when scopeId + overrides are present', function (): void {
+		$result = BlockSupports::compile( [
+			'backgroundColor' => 'accent',
+			'states'          => [
+				'_scopeId'        => 'abc12345',
+				'backgroundColor' => [ 'idle' => 'accent', 'hover' => 'accent-700' ],
+			],
+		] );
+
+		expect( $result['statesClass'] )->toBe( 'ap-state-abc12345' );
+		expect( $result['classes'] )->toContain( 'ap-state-abc12345' );
+		expect( $result['statesRules'] )->toContain( '.ap-state-abc12345' );
+		expect( $result['statesRules'] )->toContain( 'background-color: var(--wp--preset--color--accent) !important;' );
+		expect( $result['statesRules'] )->toContain( '@media (hover: hover)' );
+		expect( $result['statesRules'] )->toContain( 'background-color: var(--wp--preset--color--accent-700) !important;' );
+		expect( $result['statesRules'] )->toContain( ':is(a, button)' );
+	} );
+
+	it( 'preserves raw hex / var() values without preset wrapping', function (): void {
+		$result = BlockSupports::compile( [
+			'style'  => [ 'color' => [ 'background' => '#abc123' ] ],
+			'states' => [
+				'_scopeId'              => 'def',
+				'style.color.background' => [ 'idle' => '#abc123', 'hover' => '#fff' ],
+			],
+		] );
+
+		expect( $result['statesRules'] )->toContain( 'background-color: #abc123 !important;' );
+		expect( $result['statesRules'] )->toContain( 'background-color: #fff !important;' );
 	} );
 } );

--- a/packages/visual-editor-renderer-blade/tests/Unit/BlockSupportsTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Unit/BlockSupportsTest.php
@@ -508,6 +508,43 @@ describe( 'compile() — state design tools (#488)', function (): void {
 		expect( $result['statesRules'] )->toContain( ':is(a, button)' );
 	} );
 
+	it( 'rejects a `_scopeId` that contains CSS-breaking characters', function (): void {
+		$result = BlockSupports::compile( [
+			'states' => [
+				'_scopeId'        => 'abc"</style><script>x</script>',
+				'backgroundColor' => [ 'idle' => 'accent', 'hover' => 'accent-700' ],
+			],
+		] );
+
+		// The crafted scope id must be rejected outright — no class,
+		// no rules — so the hostile string can never reach the
+		// rendered `<style>` block.
+		expect( $result['statesClass'] )->toBe( '' );
+		expect( $result['statesRules'] )->toBe( '' );
+	} );
+
+	it( 'rejects a `_scopeId` containing whitespace', function (): void {
+		$result = BlockSupports::compile( [
+			'states' => [
+				'_scopeId'        => 'has space',
+				'backgroundColor' => [ 'idle' => 'accent', 'hover' => 'accent-700' ],
+			],
+		] );
+
+		expect( $result['statesClass'] )->toBe( '' );
+	} );
+
+	it( 'rejects a `_scopeId` longer than the safe identifier cap', function (): void {
+		$result = BlockSupports::compile( [
+			'states' => [
+				'_scopeId'        => str_repeat( 'a', 65 ),
+				'backgroundColor' => [ 'idle' => 'accent' ],
+			],
+		] );
+
+		expect( $result['statesClass'] )->toBe( '' );
+	} );
+
 	it( 'preserves raw hex / var() values without preset wrapping', function (): void {
 		$result = BlockSupports::compile( [
 			'style'  => [ 'color' => [ 'background' => '#abc123' ] ],

--- a/packages/visual-editor-renderer-blade/tests/Unit/ThemeJsonTokensCompilerTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Unit/ThemeJsonTokensCompilerTest.php
@@ -329,10 +329,18 @@ describe( 'styles.* CSS rule emission', function (): void {
 		] );
 
 		// Order: :root presets → layout rules → utility classes → styles rules.
+		// Guard each strpos against false up front — without the guard a
+		// missing section silently makes `false < positive-int` succeed
+		// and the ordering check would pass for the wrong reason.
 		$rootPos     = strpos( $css, ':root' );
 		$layoutPos   = strpos( $css, '.wp-block-group' );
 		$utilityPos  = strpos( $css, '.has-primary-color' );
 		$bodyPos     = strpos( $css, 'body {' );
+
+		expect( $rootPos )->not->toBeFalse()
+			->and( $layoutPos )->not->toBeFalse()
+			->and( $utilityPos )->not->toBeFalse()
+			->and( $bodyPos )->not->toBeFalse();
 
 		expect( $rootPos )->toBeLessThan( $layoutPos )
 			->and( $layoutPos )->toBeLessThan( $utilityPos )

--- a/packages/visual-editor-renderer-blade/tests/Unit/ThemeJsonTokensCompilerTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Unit/ThemeJsonTokensCompilerTest.php
@@ -328,12 +328,76 @@ describe( 'styles.* CSS rule emission', function (): void {
 			],
 		] );
 
-		// Order: :root presets → layout rules → styles rules.
-		$rootPos   = strpos( $css, ':root' );
-		$layoutPos = strpos( $css, '.wp-block-group' );
-		$bodyPos   = strpos( $css, 'body {' );
+		// Order: :root presets → layout rules → utility classes → styles rules.
+		$rootPos     = strpos( $css, ':root' );
+		$layoutPos   = strpos( $css, '.wp-block-group' );
+		$utilityPos  = strpos( $css, '.has-primary-color' );
+		$bodyPos     = strpos( $css, 'body {' );
 
 		expect( $rootPos )->toBeLessThan( $layoutPos )
-			->and( $layoutPos )->toBeLessThan( $bodyPos );
+			->and( $layoutPos )->toBeLessThan( $utilityPos )
+			->and( $utilityPos )->toBeLessThan( $bodyPos );
+	} );
+
+	it( 'emits has-{slug}-color / -background-color / -border-color utility classes for each palette entry', function (): void {
+		$css = ( new ThemeJsonTokensCompiler() )->compile( [
+			'settings' => [
+				'color' => [
+					'palette' => [
+						[ 'slug' => 'accent', 'color' => '#ff0000' ],
+						[ 'slug' => 'muted',  'color' => '#888888' ],
+					],
+				],
+			],
+		] );
+
+		expect( $css )->toContain( '.has-accent-color { color: var(--wp--preset--color--accent) !important; }' );
+		expect( $css )->toContain( '.has-accent-background-color { background-color: var(--wp--preset--color--accent) !important; }' );
+		expect( $css )->toContain( '.has-accent-border-color { border-color: var(--wp--preset--color--accent) !important; }' );
+		expect( $css )->toContain( '.has-muted-background-color { background-color: var(--wp--preset--color--muted) !important; }' );
+	} );
+
+	it( 'emits has-{slug}-gradient-background for each gradient preset', function (): void {
+		$css = ( new ThemeJsonTokensCompiler() )->compile( [
+			'settings' => [
+				'color' => [
+					'gradient' => [
+						[ 'slug' => 'sunset', 'gradient' => 'linear-gradient(45deg, red, orange)' ],
+					],
+				],
+			],
+		] );
+
+		expect( $css )->toContain( '.has-sunset-gradient-background { background: var(--wp--preset--gradient--sunset) !important; }' );
+	} );
+
+	it( 'emits has-{slug}-font-size for each font-size preset', function (): void {
+		$css = ( new ThemeJsonTokensCompiler() )->compile( [
+			'settings' => [
+				'typography' => [
+					'fontSizes' => [
+						[ 'slug' => 'large', 'size' => '1.5rem' ],
+					],
+				],
+			],
+		] );
+
+		expect( $css )->toContain( '.has-large-font-size { font-size: var(--wp--preset--font-size--large) !important; }' );
+	} );
+
+	it( 'skips palette entries missing a slug', function (): void {
+		$css = ( new ThemeJsonTokensCompiler() )->compile( [
+			'settings' => [
+				'color' => [
+					'palette' => [
+						[ 'color' => '#abc' ],
+						[ 'slug' => 'real', 'color' => '#def' ],
+					],
+				],
+			],
+		] );
+
+		expect( $css )->toContain( '.has-real-background-color' );
+		expect( $css )->not->toContain( 'has--background-color' );
 	} );
 } );

--- a/resources/js/visual-editor/blocks/button/block.json
+++ b/resources/js/visual-editor/blocks/button/block.json
@@ -137,6 +137,24 @@
         },
         "interactivity": {
             "clientNavigation": true
+        },
+        "artisanpackStates": {
+            "attributes": [
+                "backgroundColor",
+                "textColor",
+                "gradient",
+                "color.background",
+                "color.text",
+                "color.gradient",
+                "border.color",
+                "border.width",
+                "border.style",
+                "border.radius",
+                "shadow",
+                "typography.textDecoration",
+                "dimensions.transform",
+                "transition"
+            ]
         }
     },
     "styles": [

--- a/resources/js/visual-editor/blocks/buttons/block.json
+++ b/resources/js/visual-editor/blocks/buttons/block.json
@@ -71,6 +71,22 @@
                 "align",
                 "layout.flexDirection"
             ]
+        },
+        "artisanpackStates": {
+            "attributes": [
+                "backgroundColor",
+                "textColor",
+                "gradient",
+                "color.background",
+                "color.text",
+                "color.gradient",
+                "border.color",
+                "border.width",
+                "border.style",
+                "border.radius",
+                "typography.textDecoration",
+                "transition"
+            ]
         }
     },
     "editorStyle": "wp-block-buttons-editor",

--- a/resources/js/visual-editor/blocks/cover/block.json
+++ b/resources/js/visual-editor/blocks/cover/block.json
@@ -153,6 +153,22 @@
                 "align",
                 "minHeight"
             ]
+        },
+        "artisanpackStates": {
+            "attributes": [
+                "backgroundColor",
+                "textColor",
+                "gradient",
+                "color.background",
+                "color.text",
+                "border.color",
+                "border.width",
+                "border.style",
+                "border.radius",
+                "shadow",
+                "dimensions.transform",
+                "transition"
+            ]
         }
     },
     "selectors": {

--- a/resources/js/visual-editor/blocks/details/block.json
+++ b/resources/js/visual-editor/blocks/details/block.json
@@ -74,7 +74,21 @@
 		"interactivity": {
 			"clientNavigation": true
 		},
-		"allowedBlocks": true
+		"allowedBlocks": true,
+		"artisanpackStates": {
+			"attributes": [
+				"backgroundColor",
+				"textColor",
+				"color.background",
+				"color.text",
+				"border.color",
+				"border.width",
+				"border.style",
+				"border.radius",
+				"typography.textDecoration",
+				"transition"
+			]
+		}
 	},
 	"editorStyle": "wp-block-details-editor",
 	"style": "wp-block-details"

--- a/resources/js/visual-editor/blocks/image/block.json
+++ b/resources/js/visual-editor/blocks/image/block.json
@@ -134,6 +134,17 @@
         },
         "shadow": {
             "__experimentalSkipSerialization": true
+        },
+        "artisanpackStates": {
+            "attributes": [
+                "border.color",
+                "border.width",
+                "border.style",
+                "border.radius",
+                "shadow",
+                "dimensions.transform",
+                "transition"
+            ]
         }
     },
     "selectors": {

--- a/resources/js/visual-editor/blocks/media-text/block.json
+++ b/resources/js/visual-editor/blocks/media-text/block.json
@@ -148,6 +148,21 @@
                 "align",
                 "mediaWidth"
             ]
+        },
+        "artisanpackStates": {
+            "attributes": [
+                "backgroundColor",
+                "textColor",
+                "gradient",
+                "color.background",
+                "color.text",
+                "color.gradient",
+                "border.color",
+                "border.width",
+                "border.style",
+                "border.radius",
+                "transition"
+            ]
         }
     },
     "editorStyle": "wp-block-media-text-editor",

--- a/resources/js/visual-editor/editor/__tests__/inspector-sidebar.test.tsx
+++ b/resources/js/visual-editor/editor/__tests__/inspector-sidebar.test.tsx
@@ -13,6 +13,16 @@ vi.mock('@wordpress/block-editor', () => ({
     ),
 }));
 
+// Stub `@wordpress/blocks` so we don't transitively pull in its JSON
+// modules (which require import attributes vitest can't supply). The
+// sidebar only uses `hasBlockSupport` + `getBlockType` to read state
+// supports; tests can return `null` because the override path skips
+// the state-supports lookup anyway.
+vi.mock('@wordpress/blocks', () => ({
+    hasBlockSupport: () => false,
+    getBlockType: () => null,
+}));
+
 import { InspectorSidebar } from '../inspector-sidebar';
 
 function renderSidebar(props: {

--- a/resources/js/visual-editor/editor/editor-app.tsx
+++ b/resources/js/visual-editor/editor/editor-app.tsx
@@ -41,6 +41,10 @@ import { BlockLibrarySidebar } from './block-library-sidebar';
 import { registerContrastWarning } from './contrast-warning';
 import { registerResponsiveAttribute } from '../responsive/register-attribute';
 import { registerResponsiveAttributesFilter } from '../responsive/with-responsive-attributes';
+import { registerStateAttribute } from '../states/register-attribute';
+import { registerStateAttributesFilter } from '../states/with-state-attributes';
+import { registerStateStylesFilters } from '../states/with-state-styles';
+import { StateWriteInterceptor } from '../states/state-write-interceptor';
 import { ConvertToPatternControl } from './convert-to-pattern-control';
 import { EditorCanvas } from './editor-canvas';
 import { registerSyncedPatternIndicator } from './synced-pattern-indicator';
@@ -164,6 +168,13 @@ function registerOnce(): void {
     // edit component on first render.
     registerResponsiveAttribute();
     registerResponsiveAttributesFilter();
+    // #488 — register the state feature filters BEFORE blocks load so
+    // opted-in blocks pick up the auto-injected `states` attribute at
+    // registration time and the BlockEdit HOC wraps every edit
+    // component on first render.
+    registerStateAttribute();
+    registerStateAttributesFilter();
+    registerStateStylesFilters();
     // I7 (#415): register all artisanpack/* blocks and set the default
     // block to artisanpack/paragraph. Core blocks are no longer loaded.
     registerArtisanPackBlocks();
@@ -866,6 +877,14 @@ function EditorAppShell(props: EditorAppProps): JSX.Element {
                 blockContext={blockContextValue}
                 apiBase={props.apiBase}
             />
+            {/*
+             * #488 — watch the selected block's attributes and re-route
+             * writes from WP's color/border panels (which dispatch
+             * directly to the block-editor store, bypassing the
+             * editor.BlockEdit prop chain) into `attributes.states`
+             * when the active state is non-idle.
+             */}
+            <StateWriteInterceptor />
             <Popover.Slot />
             <ConvertToPatternControl apiBase={props.apiBase} />
             {inspectorOpen ? (

--- a/resources/js/visual-editor/editor/inspector-sidebar.tsx
+++ b/resources/js/visual-editor/editor/inspector-sidebar.tsx
@@ -27,14 +27,19 @@
  */
 
 import { BlockInspector } from '@wordpress/block-editor';
+import { hasBlockSupport, getBlockType } from '@wordpress/blocks';
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
 import { InspectorScopeChip } from '../responsive/InspectorScopeChip';
+import { setActiveBlock } from '../states/active-state';
+import { StateRegistry, DEFAULT_STATES } from '../states/registry';
+import { StateSwitcher } from '../states/StateSwitcher';
 import {
     useCallback,
     useEffect,
     useId,
+    useMemo,
     useRef,
     useState,
     type KeyboardEvent as ReactKeyboardEvent,
@@ -44,6 +49,85 @@ import {
 import { TEXT_DOMAIN } from '../vendor/i18n';
 
 import './inspector-sidebar.css';
+
+// Default state registry, constructed once at module load so every
+// inspector instance shares the same identity. The host app can swap
+// this out later by stamping a state snapshot into the bootstrap
+// settings — see `editor-settings`.
+const DEFAULT_STATE_REGISTRY = new StateRegistry(DEFAULT_STATES);
+
+interface StateSupportsConfig {
+    /**
+     * Allow-list of attribute paths the block supports state overrides
+     * on. Consumed by future per-state inspector controls — the
+     * switcher itself does not filter against it (the chip strip
+     * always shows every registered state once the block has opted
+     * in).
+     */
+    attributes?: string[];
+    /**
+     * Optional allow-list of state keys this block opts into. When
+     * omitted, every registered state is available. `idle` is always
+     * available regardless.
+     */
+    states?: string[];
+}
+
+interface SelectedBlockSnapshot {
+    clientId: string | null;
+    name: string | null;
+    attributes: Record<string, unknown>;
+}
+
+function readSelectedBlock(
+    select: (store: string) => unknown
+): SelectedBlockSnapshot {
+    const store = select('core/block-editor') as
+        | {
+              getSelectedBlockClientId?: () => string | null;
+              getBlockName?: (clientId: string) => string | null;
+              getBlockAttributes?: (
+                  clientId: string
+              ) => Record<string, unknown> | null;
+          }
+        | undefined;
+
+    const clientId = store?.getSelectedBlockClientId?.() ?? null;
+    if (!clientId) {
+        return { clientId: null, name: null, attributes: {} };
+    }
+
+    return {
+        clientId,
+        name: store?.getBlockName?.(clientId) ?? null,
+        attributes: store?.getBlockAttributes?.(clientId) ?? {},
+    };
+}
+
+function readStateSupports(name: string | null): StateSupportsConfig | null {
+    if (!name) {
+        return null;
+    }
+
+    const blockType = getBlockType(name);
+    if (!blockType) {
+        return null;
+    }
+
+    if (!hasBlockSupport(blockType, 'artisanpackStates', false)) {
+        return null;
+    }
+
+    const raw = (blockType.supports as Record<string, unknown>)
+        .artisanpackStates;
+
+    if (!raw || 'object' !== typeof raw) {
+        // Bare `true` opt-in — supported but no allow-list, all states OK.
+        return { attributes: undefined };
+    }
+
+    return raw as StateSupportsConfig;
+}
 
 export type InspectorTab = 'block' | 'document';
 
@@ -71,25 +155,55 @@ export function InspectorSidebar(props: InspectorSidebarProps): JSX.Element {
         showDocumentTab = true,
     } = props;
 
-    const liveHasSelectedBlock = useSelect(
+    const liveSelection = useSelect(
         (select) => {
             if (hasSelectedBlockOverride !== undefined) {
-                return hasSelectedBlockOverride;
+                return {
+                    hasSelectedBlock: hasSelectedBlockOverride,
+                    selected: {
+                        clientId: null,
+                        name: null,
+                        attributes: {},
+                    } as SelectedBlockSnapshot,
+                };
             }
 
-            const store = select('core/block-editor') as
-                | { hasSelectedBlock?: () => boolean }
-                | undefined;
-
-            return store?.hasSelectedBlock?.() ?? false;
+            const snapshot = readSelectedBlock(select);
+            return {
+                hasSelectedBlock: snapshot.clientId !== null,
+                selected: snapshot,
+            };
         },
         [hasSelectedBlockOverride]
     );
 
+    // Tests mock `useSelect` to return a bare boolean for the legacy
+    // shape. Normalize either form so the rest of the component can
+    // read structured fields without guarding every access.
     const hasSelectedBlock =
-        hasSelectedBlockOverride !== undefined
-            ? hasSelectedBlockOverride
-            : liveHasSelectedBlock;
+        'boolean' === typeof liveSelection
+            ? (liveSelection as boolean)
+            : (liveSelection.hasSelectedBlock ?? false);
+    const selectedBlock: SelectedBlockSnapshot =
+        'object' === typeof liveSelection && liveSelection !== null
+            ? (liveSelection.selected ?? {
+                  clientId: null,
+                  name: null,
+                  attributes: {},
+              })
+            : { clientId: null, name: null, attributes: {} };
+
+    const stateSupports = useMemo(
+        () => readStateSupports(selectedBlock.name),
+        [selectedBlock.name]
+    );
+
+    // Reset the active-state and preview-state stores whenever the
+    // selected block changes so state styling never bleeds from one
+    // block to the next.
+    useEffect(() => {
+        setActiveBlock(selectedBlock.clientId);
+    }, [selectedBlock.clientId]);
 
     // Both tabs are always mounted; `activeTab` just tracks which panel
     // is visible. On load we land on Document unless a block is already
@@ -260,6 +374,17 @@ export function InspectorSidebar(props: InspectorSidebarProps): JSX.Element {
             >
                 {hasSelectedBlock ? (
                     <>
+                        <StateSwitcher
+                            registry={DEFAULT_STATE_REGISTRY}
+                            supportsStates={stateSupports !== null}
+                            allowedStates={stateSupports?.states}
+                            attributes={
+                                selectedBlock.attributes as Record<
+                                    string,
+                                    unknown
+                                >
+                            }
+                        />
                         <InspectorScopeChip />
                         <BlockInspector />
                     </>

--- a/resources/js/visual-editor/editor/inspector-sidebar.tsx
+++ b/resources/js/visual-editor/editor/inspector-sidebar.tsx
@@ -33,7 +33,7 @@ import { __ } from '@wordpress/i18n';
 
 import { InspectorScopeChip } from '../responsive/InspectorScopeChip';
 import { setActiveBlock } from '../states/active-state';
-import { StateRegistry, DEFAULT_STATES } from '../states/registry';
+import { getStateRegistry } from '../states/registry';
 import { StateSwitcher } from '../states/StateSwitcher';
 import {
     useCallback,
@@ -50,11 +50,9 @@ import { TEXT_DOMAIN } from '../vendor/i18n';
 
 import './inspector-sidebar.css';
 
-// Default state registry, constructed once at module load so every
-// inspector instance shares the same identity. The host app can swap
-// this out later by stamping a state snapshot into the bootstrap
-// settings — see `editor-settings`.
-const DEFAULT_STATE_REGISTRY = new StateRegistry(DEFAULT_STATES);
+// Resolves to whichever registry the bootstrap path has registered
+// via `setStateRegistry`, falling back to the built-in defaults when
+// no host snapshot has been stamped in.
 
 interface StateSupportsConfig {
     /**
@@ -375,7 +373,7 @@ export function InspectorSidebar(props: InspectorSidebarProps): JSX.Element {
                 {hasSelectedBlock ? (
                     <>
                         <StateSwitcher
-                            registry={DEFAULT_STATE_REGISTRY}
+                            registry={getStateRegistry()}
                             supportsStates={stateSupports !== null}
                             allowedStates={stateSupports?.states}
                             attributes={

--- a/resources/js/visual-editor/states/PreviewStateToggle.tsx
+++ b/resources/js/visual-editor/states/PreviewStateToggle.tsx
@@ -1,0 +1,75 @@
+/**
+ * Preview-state toolbar toggle (#488).
+ *
+ * Top-bar toolbar component that lets the editor simulate any
+ * registered interactive state on the canvas without actually
+ * pointing/focusing the block. Writes to the preview-state store; the
+ * canvas iframe wrapper consumes that store to inject a temporary
+ * `data-ap-preview-state="..."` attribute on the selected block.
+ *
+ * The toggle is editor-only — saved content never sees the preview
+ * attribute. Selecting `idle` clears the preview, restoring the
+ * canvas to default-state styles.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.0.0
+ */
+
+import { useSyncExternalStore } from 'react'
+
+import {
+	getPreviewState,
+	setPreviewState,
+	subscribePreviewState,
+} from './active-state'
+import type { StateRegistry } from './registry'
+import { BASE_KEY } from './types'
+
+export interface PreviewStateToggleProps {
+	registry: StateRegistry
+	className?: string
+	/** Optional allow-list — defaults to every registered state. */
+	allowedStates?: string[]
+}
+
+export function PreviewStateToggle( {
+	registry,
+	className,
+	allowedStates,
+}: PreviewStateToggleProps ): JSX.Element {
+	const preview = useSyncExternalStore( subscribePreviewState, getPreviewState, getPreviewState )
+
+	const states = registry
+		.all()
+		.filter( ( definition ) => BASE_KEY !== definition.key )
+		.filter( ( definition ) => ! allowedStates || allowedStates.includes( definition.key ) )
+
+	const handleSelect = ( key: string | null ): void => {
+		setPreviewState( key )
+	}
+
+	return (
+		<div className={ className ?? 've-preview-state-toggle' } role="group" aria-label="Preview state">
+			<button
+				type="button"
+				aria-pressed={ null === preview }
+				onClick={ () => handleSelect( null ) }
+			>
+				No preview
+			</button>
+
+			{ states.map( ( definition ) => (
+				<button
+					key={ definition.key }
+					type="button"
+					aria-pressed={ definition.key === preview }
+					data-state={ definition.key }
+					onClick={ () => handleSelect( definition.key === preview ? null : definition.key ) }
+					title={ `Simulate ${ definition.label.toLowerCase() } on the canvas` }
+				>
+					{ definition.label }
+				</button>
+			) ) }
+		</div>
+	)
+}

--- a/resources/js/visual-editor/states/StateControl.tsx
+++ b/resources/js/visual-editor/states/StateControl.tsx
@@ -1,0 +1,94 @@
+/**
+ * Per-state InspectorControls wrapper (#488).
+ *
+ * Renders any single-value control (color picker, border-radius
+ * input, transform field, …) as a per-state control. The wrapper:
+ *
+ *  - Reads the value the editor is currently authoring against (the
+ *    active state, or the preview state when previewing) via
+ *    {@see useStateValue}.
+ *  - Persists writes through the {@see promote} migrator so scalars
+ *    only inflate to the stateful form on first override.
+ *  - Surfaces a per-state "Reset" affordance that delegates to
+ *    {@see clearOverride}.
+ *
+ * The actual control is passed in via a render prop so this wrapper
+ * stays orthogonal to the visual primitive (slider, select, text
+ * input, …).
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.0.0
+ */
+
+import { useSyncExternalStore } from 'react'
+
+import { getActiveState, subscribeActiveState } from './active-state'
+import { clearOverride, promote } from './migrator'
+import type { StateRegistry } from './registry'
+import { useStateValue } from './useStateValue'
+import { BASE_KEY, type StatefulAttribute } from './types'
+
+export interface StateControlProps<T> {
+	registry: StateRegistry
+	value: StatefulAttribute<T> | null | undefined
+	onChange: ( next: StatefulAttribute<T> | null ) => void
+	/**
+	 * Renders the underlying single-value control. Receives the value
+	 * for the currently-active state (cascaded through inheritance)
+	 * and a `setValue` callback that promotes/persists.
+	 */
+	render: ( props: { value: T | null; setValue: ( next: T | null ) => void; state: string } ) => JSX.Element
+	label?: string
+}
+
+export function StateControl<T>( {
+	registry,
+	value,
+	onChange,
+	render,
+	label,
+}: StateControlProps<T> ): JSX.Element {
+	// Subscribe to the active state directly for the *write* slot —
+	// writes always target the chip-strip's active state, never the
+	// preview state. Reads, however, go through {@link useStateValue}
+	// so the surfaced value reflects whichever state the editor is
+	// currently simulating (active or preview).
+	const activeState = useSyncExternalStore( subscribeActiveState, getActiveState, getActiveState )
+	const resolved    = useStateValue<T>( value, registry )
+
+	const setValue = ( next: T | null ): void => {
+		onChange( promote<T>( value, activeState, next ) )
+	}
+
+	const resetOverride = (): void => {
+		const cleared = clearOverride<T>( value, activeState )
+		onChange( cleared as StatefulAttribute<T> | null )
+	}
+
+	const isOverridden = BASE_KEY !== activeState
+		&& null !== value
+		&& undefined !== value
+		&& 'object' === typeof value
+		&& null !== ( value as Record<string, unknown> )[ activeState ]
+		&& undefined !== ( value as Record<string, unknown> )[ activeState ]
+
+	const stateLabel = registry.get( activeState )?.label ?? activeState
+
+	return (
+		<div className="ve-state-control" data-state={ activeState }>
+			{ label ? <div className="ve-state-control__label">{ label }</div> : null }
+
+			{ render( { value: resolved, setValue, state: activeState } ) }
+
+			{ isOverridden ? (
+				<button
+					type="button"
+					className="ve-state-control__reset"
+					onClick={ resetOverride }
+				>
+					Reset { stateLabel }
+				</button>
+			) : null }
+		</div>
+	)
+}

--- a/resources/js/visual-editor/states/StateSwitcher.tsx
+++ b/resources/js/visual-editor/states/StateSwitcher.tsx
@@ -1,0 +1,191 @@
+/**
+ * State switcher (#488).
+ *
+ * Inspector-column strip that lets the editor pick which interactive
+ * state subsequent style edits scope to. Lives at the top of the
+ * inspector's Block tab so the controls below it visibly retarget
+ * when the editor selects a state.
+ *
+ * Block-specific by design: a block that does NOT declare
+ * `supports.artisanpackStates` renders a single short message instead
+ * of the strip — the same component shape stays mounted so the
+ * inspector doesn't reflow when selection changes between supporting
+ * and non-supporting blocks.
+ *
+ * The preview toggle adjacent to the strip drives the canvas
+ * preview-state store; it is a sibling concern so a block that does
+ * not support states still has no preview controls.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.0.0
+ */
+
+import { useSyncExternalStore } from 'react'
+
+import {
+	getActiveState,
+	getPreviewState,
+	setActiveState,
+	setPreviewState,
+	subscribeActiveState,
+	subscribePreviewState,
+} from './active-state'
+import type { StateRegistry } from './registry'
+import { BASE_KEY, type StateDefinition, type StatefulAttribute } from './types'
+
+import './state-switcher.css'
+
+export interface StateSwitcherProps {
+	registry: StateRegistry
+	/**
+	 * Whether the currently selected block opts into state styling
+	 * via `supports.artisanpackStates`. When false, the switcher
+	 * renders an explanatory message instead of the chip strip and
+	 * the preview toggle is hidden.
+	 */
+	supportsStates: boolean
+	/**
+	 * Stateful attributes the block is storing. Used purely to
+	 * surface the "has-override" dot on each chip — the switcher
+	 * itself does not mutate them. Keyed by attribute path; values
+	 * are the stateful object or scalar.
+	 */
+	attributes?: Record<string, StatefulAttribute<unknown> | null | undefined>
+	/**
+	 * Allow-list of state keys this block opts into. When omitted,
+	 * every registered state is selectable. The reserved `idle` slot
+	 * is always available.
+	 */
+	allowedStates?: string[]
+	className?: string
+}
+
+function chipHasOverride(
+	stateKey: string,
+	attributes: Record<string, StatefulAttribute<unknown> | null | undefined> | undefined,
+): boolean {
+	if ( ! attributes || BASE_KEY === stateKey ) {
+		return false
+	}
+
+	for ( const value of Object.values( attributes ) ) {
+		if ( null === value || undefined === value || 'object' !== typeof value ) {
+			continue
+		}
+
+		const bag = value as Record<string, unknown>
+		if ( null !== bag[ stateKey ] && undefined !== bag[ stateKey ] ) {
+			return true
+		}
+	}
+
+	return false
+}
+
+export function StateSwitcher( {
+	registry,
+	supportsStates,
+	attributes,
+	allowedStates,
+	className,
+}: StateSwitcherProps ): JSX.Element {
+	const active  = useSyncExternalStore( subscribeActiveState, getActiveState, getActiveState )
+	const preview = useSyncExternalStore( subscribePreviewState, getPreviewState, getPreviewState )
+
+	if ( ! supportsStates ) {
+		return (
+			<p
+				className={ className ?? 'ap-visual-editor-state-switcher__unsupported' }
+				role="status"
+			>
+				This block doesn't support state styling. Switch to a button, link, or
+				other interactive block to access hover, focus, and active states.
+			</p>
+		)
+	}
+
+	const chips: StateDefinition[] = registry.all().filter( ( definition ) => {
+		if ( BASE_KEY === definition.key ) {
+			return true
+		}
+
+		if ( ! allowedStates ) {
+			return true
+		}
+
+		return allowedStates.includes( definition.key )
+	} )
+
+	const handleSelect = ( key: string ): void => {
+		setActiveState( key )
+	}
+
+	const togglePreview = (): void => {
+		if ( BASE_KEY === active ) {
+			return
+		}
+
+		setPreviewState( active === preview ? null : active )
+	}
+
+	const previewActive = null !== preview && preview === active
+
+	return (
+		<div
+			className={ className ?? 'ap-visual-editor-state-switcher' }
+			role="group"
+			aria-label="Block state"
+			data-active-state={ active }
+		>
+			{ chips.map( ( definition ) => {
+				const isActive    = definition.key === active
+				const hasOverride = chipHasOverride( definition.key, attributes )
+
+				return (
+					<button
+						key={ definition.key }
+						type="button"
+						className="ap-visual-editor-state-switcher__chip"
+						aria-pressed={ isActive }
+						data-state={ definition.key }
+						data-has-override={ hasOverride ? 'true' : 'false' }
+						onClick={ () => handleSelect( definition.key ) }
+						title={ tooltipFor( definition ) }
+					>
+						<span aria-hidden="true" data-icon={ definition.icon } />
+						<span>{ definition.label }</span>
+					</button>
+				)
+			} ) }
+
+			{ BASE_KEY !== active ? (
+				<span className="ap-visual-editor-state-switcher__preview">
+					<button
+						type="button"
+						aria-pressed={ previewActive }
+						onClick={ togglePreview }
+						title={
+							previewActive
+								? 'Stop simulating this state on the canvas'
+								: 'Simulate this state on the canvas — saved content is unchanged'
+						}
+					>
+						{ previewActive ? 'Stop preview' : 'Preview' }
+					</button>
+				</span>
+			) : null }
+		</div>
+	)
+}
+
+function tooltipFor( definition: StateDefinition ): string {
+	if ( BASE_KEY === definition.key ) {
+		return 'Default styles — apply when no interactive state matches.'
+	}
+
+	if ( '' === definition.selector ) {
+		return definition.label
+	}
+
+	return `${ definition.label } — ${ definition.selector.replaceAll( '&', 'block' ) }`
+}

--- a/resources/js/visual-editor/states/__tests__/active-state.test.ts
+++ b/resources/js/visual-editor/states/__tests__/active-state.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+	getActiveBlock,
+	getActiveState,
+	getPreviewState,
+	resetStateStores,
+	setActiveBlock,
+	setActiveState,
+	setPreviewState,
+	subscribeActiveState,
+	subscribePreviewState,
+} from '../active-state'
+
+beforeEach( () => {
+	resetStateStores()
+} )
+
+describe( 'active-state store', () => {
+	it( 'starts in idle and ignores no-op writes', () => {
+		expect( getActiveState() ).toBe( 'idle' )
+
+		const listener = vi.fn()
+		subscribeActiveState( listener )
+
+		setActiveState( 'idle' )
+		expect( listener ).not.toHaveBeenCalled()
+
+		setActiveState( 'hover' )
+		expect( listener ).toHaveBeenCalledWith( 'hover' )
+		expect( getActiveState() ).toBe( 'hover' )
+	} )
+
+	it( 'allows unsubscribing', () => {
+		const listener   = vi.fn()
+		const unsubscribe = subscribeActiveState( listener )
+
+		setActiveState( 'hover' )
+		unsubscribe()
+		setActiveState( 'focus' )
+
+		expect( listener ).toHaveBeenCalledTimes( 1 )
+	} )
+} )
+
+describe( 'preview-state store', () => {
+	it( 'normalizes idle and null to a single cleared state', () => {
+		const listener = vi.fn()
+		subscribePreviewState( listener )
+
+		setPreviewState( 'idle' )
+		expect( getPreviewState() ).toBeNull()
+		expect( listener ).not.toHaveBeenCalled()
+
+		setPreviewState( 'hover' )
+		expect( getPreviewState() ).toBe( 'hover' )
+		expect( listener ).toHaveBeenCalledWith( 'hover' )
+
+		setPreviewState( null )
+		expect( getPreviewState() ).toBeNull()
+	} )
+} )
+
+describe( 'block scope', () => {
+	it( 'resets both active and preview state when the selected block changes', () => {
+		setActiveState( 'hover' )
+		setPreviewState( 'hover' )
+
+		setActiveBlock( 'block-1' )
+		expect( getActiveBlock() ).toBe( 'block-1' )
+		expect( getActiveState() ).toBe( 'idle' )
+		expect( getPreviewState() ).toBeNull()
+
+		setActiveState( 'focus' )
+		setActiveBlock( 'block-2' )
+		expect( getActiveState() ).toBe( 'idle' )
+	} )
+
+	it( 'does nothing when re-selecting the same block', () => {
+		setActiveBlock( 'block-1' )
+		setActiveState( 'hover' )
+		setActiveBlock( 'block-1' )
+		expect( getActiveState() ).toBe( 'hover' )
+	} )
+} )

--- a/resources/js/visual-editor/states/__tests__/css-emitter.test.ts
+++ b/resources/js/visual-editor/states/__tests__/css-emitter.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from 'vitest'
+
+import { emitStateCss } from '../css-emitter'
+import { DEFAULT_STATES, StateRegistry } from '../registry'
+
+const registry = new StateRegistry( DEFAULT_STATES )
+
+describe( 'emitStateCss', () => {
+	it( 'returns empty when scope is blank or states are null', () => {
+		expect( emitStateCss( '', { 'style.color.background': { idle: 'red' } }, registry ) ).toBe( '' )
+		expect( emitStateCss( '.scope', null, registry ) ).toBe( '' )
+		expect( emitStateCss( '.scope', {}, registry ) ).toBe( '' )
+	} )
+
+	it( 'emits idle rule against the scope alone (no descendant mirror)', () => {
+		const css = emitStateCss(
+			'.ap-state-abc',
+			{ 'style.color.background': { idle: 'red' } },
+			registry,
+		)
+
+		expect( css ).toBe( '.ap-state-abc { background-color: red !important; }' )
+		// Idle must NOT cascade into nested links — that would override
+		// inner button/link colors set by their own block-supports.
+		expect( css ).not.toContain( ':is(a, button)' )
+	} )
+
+	it( 'mirrors pseudo-state selectors onto descendant interactive elements', () => {
+		const css = emitStateCss(
+			'.ap-state-abc',
+			{ 'style.color.background': { idle: 'red', hover: 'blue' } },
+			registry,
+		)
+
+		// Hover rule must reach the inner link/button so e.g.
+		// `wp-block-button__link` actually flips color on hover.
+		expect( css ).toContain( '.ap-state-abc:hover, .ap-state-abc:hover :is(a, button)' )
+	} )
+
+	it( 'wraps hover rules in @media (hover: hover) and adds default transition', () => {
+		const css = emitStateCss(
+			'.ap-state-abc',
+			{ 'style.color.background': { idle: 'red', hover: 'blue' } },
+			registry,
+		)
+
+		expect( css ).toContain( 'background-color: red !important; transition: all 150ms ease;' )
+		expect( css ).toContain( '@media (hover: hover) {' )
+		expect( css ).toContain( '.ap-state-abc:hover' )
+		expect( css ).toContain( 'background-color: blue !important;' )
+	} )
+
+	it( 'respects an editor-authored transition', () => {
+		const css = emitStateCss(
+			'.ap-state-abc',
+			{
+				'style.color.background': { idle: 'red', hover: 'blue' },
+				'transition':             { idle: 'transform 200ms ease-out' },
+			},
+			registry,
+		)
+
+		// `transition` is in the NEVER_IMPORTANT set — host code can
+		// still cancel the editor's transition with a plain rule.
+		expect( css ).toContain( 'transition: transform 200ms ease-out;' )
+		expect( css ).not.toContain( 'transition: transform 200ms ease-out !important;' )
+		expect( css ).not.toContain( 'transition: all 150ms ease;' )
+	} )
+
+	it( 'skips redundant state rules when the value equals the inheritance parent', () => {
+		const css = emitStateCss(
+			'.ap-state-abc',
+			{ 'style.color.background': { idle: 'red', hover: 'red' } },
+			registry,
+		)
+
+		expect( css ).toContain( '{ background-color: red !important; }' )
+		expect( css ).not.toContain( ':hover' )
+	} )
+
+	it( 'emits non-hover state rules outside the hover-media wrap', () => {
+		const css = emitStateCss(
+			'.ap-state-abc',
+			{ 'style.color.text': { idle: 'red', 'focus-visible': 'navy' } },
+			registry,
+		)
+
+		expect( css ).toContain( '.ap-state-abc:focus-visible' )
+		expect( css ).toContain( 'color: navy !important;' )
+		expect( css ).not.toContain( '@media (hover: hover) { .ap-state-abc:focus-visible' )
+	} )
+
+	it( 'handles comma-separated selector lists for disabled', () => {
+		const css = emitStateCss(
+			'.ap-state-abc',
+			{ 'style.color.background': { idle: 'red', disabled: '#888' } },
+			registry,
+		)
+
+		expect( css ).toContain( '.ap-state-abc:disabled' )
+		expect( css ).toContain( '.ap-state-abc[aria-disabled="true"]' )
+	} )
+
+	it( 'accepts paths with or without the leading `style.` prefix', () => {
+		const withPrefix = emitStateCss(
+			'.s',
+			{ 'style.color.background': { idle: 'red' } },
+			registry,
+		)
+		const withoutPrefix = emitStateCss(
+			'.s',
+			{ 'color.background': { idle: 'red' } },
+			registry,
+		)
+
+		expect( withPrefix ).toBe( withoutPrefix )
+	} )
+
+	it( 'silently drops unknown paths', () => {
+		const css = emitStateCss(
+			'.s',
+			{ 'made.up.path': { idle: 'red' } },
+			registry,
+		)
+
+		expect( css ).toBe( '' )
+	} )
+
+	it( 'translates palette slugs to wp preset vars on top-level color attrs', () => {
+		const css = emitStateCss(
+			'.scope',
+			{
+				backgroundColor: { idle: 'vivid-purple', hover: 'pale-pink' },
+			},
+			registry,
+		)
+
+		expect( css ).toContain( 'background-color: var(--wp--preset--color--vivid-purple) !important;' )
+		expect( css ).toContain( '.scope:hover' )
+		expect( css ).toContain( 'background-color: var(--wp--preset--color--pale-pink) !important;' )
+	} )
+
+	it( 'passes raw CSS values through unchanged for preset paths', () => {
+		const css = emitStateCss(
+			'.scope',
+			{ backgroundColor: { idle: '#abc123', hover: 'var(--brand-accent)' } },
+			registry,
+		)
+
+		expect( css ).toContain( 'background-color: #abc123 !important;' )
+		expect( css ).toContain( 'background-color: var(--brand-accent) !important;' )
+		expect( css ).not.toContain( 'var(--wp--preset--color--#abc123)' )
+	} )
+
+	it( 'maps gradient slugs to gradient presets', () => {
+		const css = emitStateCss(
+			'.scope',
+			{ gradient: { idle: 'blush-bordeaux' } },
+			registry,
+		)
+
+		expect( css ).toContain( 'background: var(--wp--preset--gradient--blush-bordeaux) !important;' )
+	} )
+} )

--- a/resources/js/visual-editor/states/__tests__/migrator.test.ts
+++ b/resources/js/visual-editor/states/__tests__/migrator.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+
+import { clearOverride, demote, promote } from '../migrator'
+
+describe( 'promote', () => {
+	it( 'returns the scalar unchanged when promoting to idle on a scalar', () => {
+		expect( promote( 'red', 'idle', 'blue' ) ).toBe( 'blue' )
+	} )
+
+	it( 'promotes a scalar to a stateful object on first non-idle override', () => {
+		expect( promote( 'red', 'hover', 'blue' ) ).toEqual( { idle: 'red', hover: 'blue' } )
+	} )
+
+	it( 'merges the new override into an existing stateful object', () => {
+		expect(
+			promote( { idle: 'red', hover: 'blue' }, 'focus', 'green' ),
+		).toEqual( { idle: 'red', hover: 'blue', focus: 'green' } )
+	} )
+
+	it( 'overwrites an existing slot at the same state', () => {
+		expect(
+			promote( { idle: 'red', hover: 'blue' }, 'hover', 'orange' ),
+		).toEqual( { idle: 'red', hover: 'orange' } )
+	} )
+} )
+
+describe( 'demote', () => {
+	it( 'demotes a stateful object back to scalar when only idle is set', () => {
+		expect( demote( { idle: 'red', hover: null } ) ).toBe( 'red' )
+	} )
+
+	it( 'leaves stateful objects with multiple defined slots untouched', () => {
+		const attribute = { idle: 'red', hover: 'blue' }
+
+		expect( demote( attribute ) ).toBe( attribute )
+	} )
+
+	it( 'returns null when the attribute is null', () => {
+		expect( demote( null ) ).toBeNull()
+	} )
+} )
+
+describe( 'clearOverride', () => {
+	it( 'clears a single state and demotes if it was the last override', () => {
+		expect(
+			clearOverride( { idle: 'red', hover: 'blue' }, 'hover' ),
+		).toBe( 'red' )
+	} )
+
+	it( 'clears a state without demoting when other overrides remain', () => {
+		expect(
+			clearOverride( { idle: 'red', hover: 'blue', focus: 'green' }, 'hover' ),
+		).toEqual( { idle: 'red', focus: 'green' } )
+	} )
+
+	it( 'sets idle to null when clearing the idle slot', () => {
+		expect(
+			clearOverride( { idle: 'red', hover: 'blue' }, 'idle' ),
+		).toEqual( { idle: null, hover: 'blue' } )
+	} )
+} )

--- a/resources/js/visual-editor/states/__tests__/registry.test.ts
+++ b/resources/js/visual-editor/states/__tests__/registry.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest'
+
+import { DEFAULT_STATES, StateRegistry, registryFromSnapshot } from '../registry'
+
+describe( 'StateRegistry', () => {
+	it( 'defaults to the built-in state set when nothing is passed', () => {
+		const registry = new StateRegistry()
+
+		expect( registry.keys() ).toEqual( [
+			'idle',
+			'hover',
+			'focus',
+			'focus-visible',
+			'active',
+			'disabled',
+		] )
+	} )
+
+	it( 'hoists idle to the front of iteration order', () => {
+		const registry = new StateRegistry( [
+			{
+				key:            'hover',
+				label:          'Hover',
+				selector:       '&:hover',
+				icon:           'cursor',
+				inheritsFrom:   'idle',
+				hoverMediaWrap: true,
+			},
+			{
+				key:            'idle',
+				label:          'Idle',
+				selector:       '',
+				icon:           'circle',
+				inheritsFrom:   null,
+				hoverMediaWrap: false,
+			},
+		] )
+
+		expect( registry.keys()[ 0 ] ).toBe( 'idle' )
+	} )
+
+	it( 'returns the inheritance chain ending at idle', () => {
+		const registry = new StateRegistry()
+
+		expect( registry.inheritanceChain( 'active' ) ).toEqual( [ 'active', 'hover', 'idle' ] )
+		expect( registry.inheritanceChain( 'focus-visible' ) ).toEqual( [ 'focus-visible', 'focus', 'idle' ] )
+		expect( registry.inheritanceChain( 'idle' ) ).toEqual( [ 'idle' ] )
+		expect( registry.inheritanceChain( 'made-up' ) ).toEqual( [ 'idle' ] )
+	} )
+
+	it( 'returns null for unknown states', () => {
+		const registry = new StateRegistry()
+
+		expect( registry.get( 'made-up' ) ).toBeNull()
+	} )
+
+	it( 'throws when constructed without an idle slot', () => {
+		expect( () => new StateRegistry( DEFAULT_STATES.filter( ( s ) => 'idle' !== s.key ) ) ).toThrow(
+			/idle/,
+		)
+	} )
+
+	it( 'rebuilds from a snapshot or falls back to defaults', () => {
+		expect( registryFromSnapshot( undefined ).keys() ).toEqual( [
+			'idle',
+			'hover',
+			'focus',
+			'focus-visible',
+			'active',
+			'disabled',
+		] )
+
+		const custom = registryFromSnapshot( {
+			states: [
+				...DEFAULT_STATES,
+				{
+					key:            'aria-current',
+					label:          'Current',
+					selector:       '&[aria-current="page"]',
+					icon:           'flag',
+					inheritsFrom:   'idle',
+					hoverMediaWrap: false,
+				},
+			],
+		} )
+
+		expect( custom.keys() ).toContain( 'aria-current' )
+		expect( custom.get( 'aria-current' )?.selector ).toBe( '&[aria-current="page"]' )
+	} )
+} )

--- a/resources/js/visual-editor/states/__tests__/resolver.test.ts
+++ b/resources/js/visual-editor/states/__tests__/resolver.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+
+import { StateRegistry } from '../registry'
+import {
+	distinctStateOverrides,
+	isStatefulAttribute,
+	resolveStateValue,
+} from '../resolver'
+
+const registry = new StateRegistry()
+
+describe( 'resolveStateValue', () => {
+	it( 'returns scalars unchanged', () => {
+		expect( resolveStateValue( 'red', 'hover', registry ) ).toBe( 'red' )
+		expect( resolveStateValue( 4, 'hover', registry ) ).toBe( 4 )
+	} )
+
+	it( 'returns null when the attribute is null/undefined', () => {
+		expect( resolveStateValue( null, 'hover', registry ) ).toBeNull()
+		expect( resolveStateValue( undefined, 'hover', registry ) ).toBeNull()
+	} )
+
+	it( 'walks the inheritance chain through null slots', () => {
+		const attribute = { idle: 'red', hover: 'blue', active: null }
+
+		expect( resolveStateValue( attribute, 'active', registry ) ).toBe( 'blue' )
+	} )
+
+	it( 'returns the override at the active state when one exists', () => {
+		const attribute = { idle: 'red', hover: 'blue' }
+
+		expect( resolveStateValue( attribute, 'idle', registry ) ).toBe( 'red' )
+		expect( resolveStateValue( attribute, 'hover', registry ) ).toBe( 'blue' )
+		expect( resolveStateValue( attribute, 'active', registry ) ).toBe( 'blue' )
+		expect( resolveStateValue( attribute, 'focus', registry ) ).toBe( 'red' )
+	} )
+
+	it( 'returns null when no slot in the chain is defined', () => {
+		const attribute = { hover: 'blue' }
+
+		expect( resolveStateValue( attribute, 'focus', registry ) ).toBeNull()
+	} )
+
+	it( 'falls back to idle when the active state is unknown', () => {
+		const attribute = { idle: 'red', hover: 'blue' }
+
+		expect( resolveStateValue( attribute, 'made-up', registry ) ).toBe( 'red' )
+	} )
+} )
+
+describe( 'isStatefulAttribute', () => {
+	it( 'recognises the discriminated shape via idle or any registry key', () => {
+		expect( isStatefulAttribute( { idle: 'red' }, registry ) ).toBe( true )
+		expect( isStatefulAttribute( { hover: 'blue' }, registry ) ).toBe( true )
+		expect( isStatefulAttribute( 'red', registry ) ).toBe( false )
+		expect( isStatefulAttribute( [ 'a', 'b' ], registry ) ).toBe( false )
+		expect( isStatefulAttribute( null, registry ) ).toBe( false )
+	} )
+} )
+
+describe( 'distinctStateOverrides', () => {
+	it( 'collapses to only states that differ from their inheritance parent', () => {
+		const attribute = { idle: 'red', hover: 'red', active: 'red', focus: 'blue' }
+
+		expect( distinctStateOverrides( attribute, registry ) ).toEqual( {
+			idle:  'red',
+			focus: 'blue',
+		} )
+	} )
+
+	it( 'includes idle whenever it has a non-null value', () => {
+		expect( distinctStateOverrides( { idle: 'red' }, registry ) ).toEqual( { idle: 'red' } )
+	} )
+
+	it( 'wraps a scalar as idle-only', () => {
+		expect( distinctStateOverrides( 'red', registry ) ).toEqual( { idle: 'red' } )
+	} )
+} )

--- a/resources/js/visual-editor/states/__tests__/state-write-interceptor.test.ts
+++ b/resources/js/visual-editor/states/__tests__/state-write-interceptor.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock( '@wordpress/blocks', () => ( {
+	getBlockType:    () => null,
+	hasBlockSupport: () => false,
+} ) )
+vi.mock( '@wordpress/data', () => ( {
+	useDispatch: () => ( { updateBlockAttributes: vi.fn() } ),
+	useSelect:   () => ( { clientId: null, name: null, attributes: {} } ),
+} ) )
+
+import { planCorrection } from '../state-write-interceptor'
+
+const ROOTS = [ 'backgroundColor', 'textColor', 'style.color.background' ]
+
+describe( 'planCorrection', () => {
+	it( 'returns null when nothing changed', () => {
+		expect(
+			planCorrection(
+				{ backgroundColor: 'vivid-purple' },
+				{ backgroundColor: 'vivid-purple' },
+				ROOTS,
+				'hover',
+			),
+		).toBeNull()
+	} )
+
+	it( 'returns null when the change is outside the state roots', () => {
+		expect(
+			planCorrection(
+				{ url: 'https://a.test' },
+				{ url: 'https://b.test' },
+				ROOTS,
+				'hover',
+			),
+		).toBeNull()
+	} )
+
+	it( 'routes a top-level palette write into states and restores the base', () => {
+		const correction = planCorrection(
+			{ backgroundColor: 'vivid-purple' },
+			{ backgroundColor: 'pale-pink' },
+			ROOTS,
+			'hover',
+		)
+
+		expect( correction ).not.toBeNull()
+		expect( correction!.updatePayload.backgroundColor ).toBe( 'vivid-purple' )
+		expect( correction!.updatePayload.states ).toEqual( {
+			backgroundColor: { hover: 'pale-pink' },
+		} )
+		expect( correction!.correctedAttributes.backgroundColor ).toBe( 'vivid-purple' )
+		expect( correction!.correctedAttributes.states ).toEqual( {
+			backgroundColor: { hover: 'pale-pink' },
+		} )
+	} )
+
+	it( 'preserves prior state overrides when adding a new one', () => {
+		const correction = planCorrection(
+			{
+				backgroundColor: 'vivid-purple',
+				states:          { backgroundColor: { focus: 'red' } },
+			},
+			{
+				backgroundColor: 'pale-pink',
+				states:          { backgroundColor: { focus: 'red' } },
+			},
+			ROOTS,
+			'hover',
+		)
+
+		expect( correction!.updatePayload.states ).toEqual( {
+			backgroundColor: { focus: 'red', hover: 'pale-pink' },
+		} )
+	} )
+
+	it( 'ignores changes to attributes.states itself (no oscillation)', () => {
+		expect(
+			planCorrection(
+				{ backgroundColor: 'vivid-purple', states: {} },
+				{
+					backgroundColor: 'vivid-purple',
+					states:          { backgroundColor: { hover: 'pale-pink' } },
+				},
+				ROOTS,
+				'hover',
+			),
+		).toBeNull()
+	} )
+
+	it( 'handles nested style.color.background paths', () => {
+		const correction = planCorrection(
+			{ style: { color: { background: '#000' } } },
+			{ style: { color: { background: '#fff' } } },
+			ROOTS,
+			'hover',
+		)
+
+		expect( correction ).not.toBeNull()
+		const restoredStyle = correction!.updatePayload.style as { color: { background: string } }
+		expect( restoredStyle.color.background ).toBe( '#000' )
+		expect( correction!.updatePayload.states ).toEqual( {
+			'style.color.background': { hover: '#fff' },
+		} )
+	} )
+
+	it( 'routes multiple state-eligible changes in one diff', () => {
+		const correction = planCorrection(
+			{ backgroundColor: 'a', textColor: 'b' },
+			{ backgroundColor: 'a2', textColor: 'b2' },
+			ROOTS,
+			'hover',
+		)
+
+		expect( correction ).not.toBeNull()
+		expect( correction!.updatePayload.backgroundColor ).toBe( 'a' )
+		expect( correction!.updatePayload.textColor ).toBe( 'b' )
+		expect( correction!.updatePayload.states ).toEqual( {
+			backgroundColor: { hover: 'a2' },
+			textColor:       { hover: 'b2' },
+		} )
+	} )
+} )

--- a/resources/js/visual-editor/states/__tests__/with-state-attributes.test.tsx
+++ b/resources/js/visual-editor/states/__tests__/with-state-attributes.test.tsx
@@ -1,0 +1,183 @@
+import { render, act } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { resetStateStores, setActiveState } from '../active-state'
+
+vi.mock( '@wordpress/blocks', () => {
+	const blocks = new Map<string, { supports?: Record<string, unknown> }>()
+
+	return {
+		getBlockType: ( name: string ) => blocks.get( name ),
+		hasBlockSupport: (
+			blockType: { supports?: Record<string, unknown> } | undefined,
+			feature: string,
+			defaultValue: boolean,
+		) => {
+			if ( ! blockType?.supports ) {
+				return defaultValue
+			}
+			if ( ! ( feature in blockType.supports ) ) {
+				return defaultValue
+			}
+			return blockType.supports[ feature ]
+		},
+		__setBlockType: ( name: string, supports: Record<string, unknown> ) => {
+			blocks.set( name, { supports } )
+		},
+		__clearBlockTypes: () => {
+			blocks.clear()
+		},
+	}
+} )
+
+import { __setBlockType, __clearBlockTypes } from '@wordpress/blocks'
+import { withStateAttributes } from '../with-state-attributes'
+
+interface CapturedProps {
+	attributes: Record<string, unknown>
+	setAttributes: ( updates: Record<string, unknown> ) => void
+}
+
+let captured: CapturedProps | null = null
+
+function StubEdit( props: CapturedProps ): JSX.Element {
+	captured = props
+	return <div data-testid="stub">stub</div>
+}
+
+const Wrapped = withStateAttributes( StubEdit as never )
+
+beforeEach( () => {
+	captured = null
+	act( () => {
+		resetStateStores()
+	} )
+	__clearBlockTypes()
+} )
+
+afterEach( () => {
+	act( () => {
+		resetStateStores()
+	} )
+	__clearBlockTypes()
+} )
+
+describe( 'withStateAttributes — non-stateful blocks', () => {
+	it( 'passes attributes through untouched when supports.artisanpackStates is missing', () => {
+		__setBlockType( 'core/paragraph', {} )
+
+		const setAttributes = vi.fn()
+		render(
+			<Wrapped
+				name="core/paragraph"
+				attributes={ { content: 'hi' } }
+				setAttributes={ setAttributes }
+			/> as never,
+		)
+
+		expect( captured?.attributes ).toEqual( { content: 'hi' } )
+
+		captured?.setAttributes( { content: 'updated' } )
+		expect( setAttributes ).toHaveBeenCalledWith( { content: 'updated' } )
+	} )
+} )
+
+describe( 'withStateAttributes — idle behavior', () => {
+	beforeEach( () => {
+		__setBlockType( 'artisanpack/button', {
+			artisanpackStates: { attributes: [ 'backgroundColor', 'textColor', 'style.color.background' ] },
+		} )
+	} )
+
+	it( 'writes fall straight through to base on idle', () => {
+		const setAttributes = vi.fn()
+		render(
+			<Wrapped
+				name="artisanpack/button"
+				attributes={ { backgroundColor: 'vivid-purple' } }
+				setAttributes={ setAttributes }
+			/> as never,
+		)
+
+		captured?.setAttributes( { backgroundColor: 'pale-pink' } )
+		expect( setAttributes ).toHaveBeenCalledWith( { backgroundColor: 'pale-pink' } )
+	} )
+} )
+
+describe( 'withStateAttributes — non-idle routing', () => {
+	beforeEach( () => {
+		__setBlockType( 'artisanpack/button', {
+			artisanpackStates: { attributes: [ 'backgroundColor', 'textColor', 'style.color.background' ] },
+		} )
+
+		act( () => {
+			setActiveState( 'hover' )
+		} )
+	} )
+
+	it( 'routes a top-level palette write to attributes.states.backgroundColor.hover', () => {
+		const setAttributes = vi.fn()
+		render(
+			<Wrapped
+				name="artisanpack/button"
+				attributes={ { backgroundColor: 'vivid-purple' } }
+				setAttributes={ setAttributes }
+			/> as never,
+		)
+
+		captured?.setAttributes( { backgroundColor: 'pale-pink' } )
+
+		expect( setAttributes ).toHaveBeenCalledTimes( 1 )
+		const actual = setAttributes.mock.calls[ 0 ][ 0 ]
+
+		expect( actual.backgroundColor ).toBeUndefined()
+		expect( actual.states ).toEqual( {
+			backgroundColor: { hover: 'pale-pink' },
+		} )
+	} )
+
+	it( 'overlays the active state on top of the idle base for reads', () => {
+		render(
+			<Wrapped
+				name="artisanpack/button"
+				attributes={ {
+					backgroundColor: 'vivid-purple',
+					states:          { backgroundColor: { hover: 'pale-pink' } },
+				} }
+				setAttributes={ vi.fn() }
+			/> as never,
+		)
+
+		expect( captured?.attributes.backgroundColor ).toBe( 'pale-pink' )
+	} )
+
+	it( 'preserves the idle base attribute when writing a non-idle override', () => {
+		const setAttributes = vi.fn()
+		render(
+			<Wrapped
+				name="artisanpack/button"
+				attributes={ { backgroundColor: 'vivid-purple' } }
+				setAttributes={ setAttributes }
+			/> as never,
+		)
+
+		captured?.setAttributes( { backgroundColor: 'pale-pink' } )
+
+		expect( setAttributes.mock.calls[ 0 ][ 0 ] ).not.toHaveProperty( 'backgroundColor' )
+	} )
+
+	it( 'falls through to base for paths outside the state roots', () => {
+		const setAttributes = vi.fn()
+		render(
+			<Wrapped
+				name="artisanpack/button"
+				attributes={ { backgroundColor: 'vivid-purple', url: 'https://a.test' } }
+				setAttributes={ setAttributes }
+			/> as never,
+		)
+
+		captured?.setAttributes( { url: 'https://b.test' } )
+
+		expect( setAttributes ).toHaveBeenCalledWith( { url: 'https://b.test' } )
+	} )
+} )

--- a/resources/js/visual-editor/states/active-state.ts
+++ b/resources/js/visual-editor/states/active-state.ts
@@ -1,0 +1,103 @@
+/**
+ * Active-state and preview-state stores (#488).
+ *
+ * Two tiny pub/sub stores that hold:
+ *  - which state the editor's inspector is currently authoring against
+ *    (`idle` by default), and
+ *  - which state, if any, the canvas is simulating via the preview
+ *    toggle.
+ *
+ * Both live outside React so non-React surfaces (canvas iframe
+ * wrapper, top-bar buttons, Vue host bridge) can read and write them
+ * without crossing the React tree boundary.
+ *
+ * The per-block scoping is enforced by clearing both stores whenever
+ * the editor selects a different block — see {@see setActiveBlock()}.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.0.0
+ */
+
+import { BASE_KEY } from './types'
+
+type Listener = ( state: string ) => void
+
+let active: string                = BASE_KEY
+let preview: string | null        = null
+let currentBlockId: string | null = null
+
+const activeListeners: Set<Listener> = new Set()
+const previewListeners: Set<Listener> = new Set()
+
+export function getActiveState(): string {
+	return active
+}
+
+export function setActiveState( state: string ): void {
+	if ( state === active ) {
+		return
+	}
+
+	active = state
+	activeListeners.forEach( ( listener ) => listener( active ) )
+}
+
+export function subscribeActiveState( listener: Listener ): () => void {
+	activeListeners.add( listener )
+	return () => {
+		activeListeners.delete( listener )
+	}
+}
+
+export function getPreviewState(): string | null {
+	return preview
+}
+
+export function setPreviewState( state: string | null ): void {
+	const normalized = ( null === state || BASE_KEY === state ) ? null : state
+
+	if ( normalized === preview ) {
+		return
+	}
+
+	preview = normalized
+	previewListeners.forEach( ( listener ) => listener( preview ?? BASE_KEY ) )
+}
+
+export function subscribePreviewState( listener: Listener ): () => void {
+	previewListeners.add( listener )
+	return () => {
+		previewListeners.delete( listener )
+	}
+}
+
+/**
+ * Per-block scope reset. The editor calls this whenever the selected
+ * block changes so the inspector's state strip and the canvas
+ * preview don't bleed from one block to the next.
+ */
+export function setActiveBlock( blockId: string | null ): void {
+	if ( blockId === currentBlockId ) {
+		return
+	}
+
+	currentBlockId = blockId
+	setActiveState( BASE_KEY )
+	setPreviewState( null )
+}
+
+export function getActiveBlock(): string | null {
+	return currentBlockId
+}
+
+/**
+ * Test-only — reset everything between specs. Production code uses
+ * `setActiveBlock(null)` to clear when no block is selected.
+ */
+export function resetStateStores(): void {
+	active         = BASE_KEY
+	preview        = null
+	currentBlockId = null
+	activeListeners.forEach( ( listener ) => listener( active ) )
+	previewListeners.forEach( ( listener ) => listener( BASE_KEY ) )
+}

--- a/resources/js/visual-editor/states/css-emitter.ts
+++ b/resources/js/visual-editor/states/css-emitter.ts
@@ -1,0 +1,281 @@
+/**
+ * Client-side CSS emitter (#488).
+ *
+ * Mirrors PHP `StateCssEmitter`. Given a `{ path -> stateful-value }`
+ * map and a scope class, produces the CSS rules the editor canvas
+ * and saved markup ship with the block.
+ *
+ *  - Idle rule emitted against the scope.
+ *  - Non-idle states emit a rule only when their value differs from
+ *    the inheritance parent.
+ *  - Rules whose state has `hoverMediaWrap = true` get wrapped in
+ *    `@media (hover: hover)` so touch devices don't sticky-state on
+ *    tap.
+ *  - When any non-idle override is set and no explicit transition is
+ *    authored, a default `transition: all 150ms ease;` is added to
+ *    the idle rule.
+ *
+ * The path → CSS property mapping covers every attribute on the
+ * v1.0 supported list. Unknown paths are skipped silently so a
+ * mistyped opt-in root in a theme override doesn't blow up the
+ * canvas.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.0.0
+ */
+
+import type { StateRegistry } from './registry'
+import { distinctStateOverrides } from './resolver'
+import { BASE_KEY, type StatefulAttribute } from './types'
+
+export const DEFAULT_TRANSITION = 'all 150ms ease'
+
+/**
+ * Per-path config: which CSS property the path emits as, plus an
+ * optional preset-token slug used when the editor wrote a palette slug
+ * rather than a raw CSS value. Paths that aren't in here are silently
+ * dropped — most v1.0 supported attributes live under `style.*`, and
+ * the renderer normalises both shapes before lookup.
+ *
+ * The `preset` field mirrors WordPress's `--wp--preset--{kind}--{slug}`
+ * custom-property naming: when a block's `backgroundColor` attribute
+ * is `'vivid-purple'`, the emitter outputs
+ * `background-color: var(--wp--preset--color--vivid-purple);`.
+ */
+interface PathConfig {
+	property: string
+	preset?: 'color' | 'gradient'
+}
+
+const PATH_TO_CONFIG: Record<string, PathConfig> = {
+	// Top-level palette-slug shortcuts WordPress writes when a user
+	// picks from the palette (vs. authoring a custom hex). These must
+	// be routed in lockstep with the `style.color.*` paths below or
+	// state writes silently fall through to the base.
+	'backgroundColor':            { property: 'background-color', preset: 'color' },
+	'textColor':                  { property: 'color',            preset: 'color' },
+	'gradient':                   { property: 'background',       preset: 'gradient' },
+
+	// Style-bag shapes the inspector writes when a user authors a
+	// custom value via the color picker / border panel / etc.
+	'color.background':           { property: 'background-color' },
+	'color.text':                 { property: 'color' },
+	'color.gradient':             { property: 'background' },
+	'border.color':               { property: 'border-color' },
+	'border.width':               { property: 'border-width' },
+	'border.style':               { property: 'border-style' },
+	'border.radius':              { property: 'border-radius' },
+	'shadow':                     { property: 'box-shadow' },
+	'typography.textDecoration':  { property: 'text-decoration' },
+	'dimensions.transform':       { property: 'transform' },
+	'transition':                 { property: 'transition' },
+}
+
+/**
+ * Strip a leading `style.` so callers can pass either
+ * `style.color.background` or `color.background` interchangeably.
+ */
+function normalisePath( path: string ): string {
+	return path.startsWith( 'style.' ) ? path.slice( 'style.'.length ) : path
+}
+
+function configFor( path: string ): PathConfig | null {
+	const normalised = normalisePath( path )
+	return PATH_TO_CONFIG[ normalised ] ?? null
+}
+
+// Palette slugs are kebab/alphanum identifiers; anything containing
+// CSS punctuation (`#`, `(`, `,`, etc.) is already a raw CSS value
+// and rides through unchanged. Keeps `var(--my-token)`, `#ff0000`,
+// `rgb(…)`, and `linear-gradient(…)` from being double-wrapped.
+const SLUG_RE = /^[a-z0-9][a-z0-9_-]*$/i
+
+function stringifyValue( value: unknown, config: PathConfig ): string | null {
+	if ( null === value || undefined === value ) {
+		return null
+	}
+
+	if ( 'number' === typeof value ) {
+		return String( value )
+	}
+
+	if ( 'string' !== typeof value || '' === value ) {
+		return null
+	}
+
+	if ( config.preset && SLUG_RE.test( value ) ) {
+		return `var(--wp--preset--${ config.preset }--${ value })`
+	}
+
+	return value
+}
+
+export type StatesByPath = Record<string, StatefulAttribute<unknown> | null | undefined>
+
+interface BucketsByState {
+	[stateKey: string]: Record<string, string>
+}
+
+function bucketByState( states: StatesByPath, registry: StateRegistry ): BucketsByState {
+	const buckets: BucketsByState = {}
+
+	for ( const path of Object.keys( states ) ) {
+		const config = configFor( path )
+		if ( null === config ) {
+			continue
+		}
+
+		const stateful = states[ path ]
+		if ( null === stateful || undefined === stateful ) {
+			continue
+		}
+
+		const overrides = distinctStateOverrides( stateful, registry )
+
+		for ( const stateKey of Object.keys( overrides ) ) {
+			const value = stringifyValue( overrides[ stateKey ], config )
+			if ( null === value ) {
+				continue
+			}
+
+			buckets[ stateKey ]                    = buckets[ stateKey ] ?? {}
+			buckets[ stateKey ][ config.property ] = value
+		}
+	}
+
+	return buckets
+}
+
+// Properties that should NOT carry `!important` — `transition` is the
+// only one in the v1.0 set; an `!important` transition can't be
+// disabled by host CSS, which is rarely what you want.
+const NEVER_IMPORTANT = new Set( [ 'transition' ] )
+
+function joinDeclarations( declarations: Record<string, string> ): string {
+	return Object.keys( declarations )
+		.map( ( property ) => {
+			const value     = declarations[ property ]
+			const important = NEVER_IMPORTANT.has( property ) ? '' : ' !important'
+			return `${ property }: ${ value }${ important };`
+		} )
+		.join( ' ' )
+}
+
+// Common interactive descendants the emitter mirrors *state* rules
+// onto, so a scope class on the block wrapper still styles the actual
+// link/button inside (e.g. `wp-block-button` renders its visual
+// element as a child `wp-block-button__link`). Mirroring is only
+// applied to non-idle pseudo-states — idle styles fall through the
+// scope alone so they don't override the descendant's own base
+// colors (which would surprise a cover/media-text block whose idle
+// background should NOT also paint nested links).
+const DESCENDANT_TARGETS = 'a, button'
+
+function selectorFor( scope: string, selector: string ): string {
+	if ( '' === selector ) {
+		// Idle base — emit against the scope only; the WordPress
+		// `has-{slug}-*` utility classes plus the block's own root
+		// selector handle nested children. Mirroring here would leak
+		// the block-level idle color into every descendant link.
+		return scope
+	}
+
+	const pieces = selector.split( ',' ).map( ( s ) => s.trim() ).filter( Boolean )
+	const mapped: string[] = []
+
+	for ( const piece of pieces ) {
+		const resolved = piece.includes( '&' )
+			? piece.replaceAll( '&', scope )
+			: `${ scope }${ piece }`
+
+		mapped.push( resolved )
+
+		// Mirror the pseudo-state onto interactive descendants. For
+		// `.ap-state-XXX:hover`, also emit
+		// `.ap-state-XXX:hover :is(a, button)` so the inner button link
+		// picks up the hover styles even though it's hovered as a
+		// child of the wrapper.
+		mapped.push( `${ resolved } :is(${ DESCENDANT_TARGETS })` )
+	}
+
+	return mapped.join( ', ' )
+}
+
+/**
+ * Emit a CSS string for one block scope, given its full
+ * `{ path -> stateful-value }` map.
+ *
+ * Returns an empty string when nothing's worth emitting (no overrides
+ * stored, or the scope is blank). Callers should treat empty as a
+ * signal to skip injecting the `<style>` tag entirely.
+ */
+export function emitStateCss(
+	scope: string,
+	states: StatesByPath | null | undefined,
+	registry: StateRegistry,
+): string {
+	if ( '' === scope.trim() || ! states ) {
+		return ''
+	}
+
+	const buckets = bucketByState( states, registry )
+
+	if ( 0 === Object.keys( buckets ).length ) {
+		return ''
+	}
+
+	const idleDeclarations: Record<string, string> = { ...( buckets[ BASE_KEY ] ?? {} ) }
+
+	const hasNonIdleOverride = registry
+		.keys()
+		.some( ( key ) => BASE_KEY !== key && buckets[ key ] && 0 < Object.keys( buckets[ key ] ).length )
+
+	if ( hasNonIdleOverride && ! ( 'transition' in idleDeclarations ) ) {
+		idleDeclarations.transition = DEFAULT_TRANSITION
+	}
+
+	const parts: string[] = []
+
+	if ( 0 < Object.keys( idleDeclarations ).length ) {
+		const idleSelector = selectorFor( scope, '' )
+		parts.push( `${ idleSelector } { ${ joinDeclarations( idleDeclarations ) } }` )
+	}
+
+	let hoverBlock = ''
+
+	for ( const stateKey of registry.keys() ) {
+		if ( BASE_KEY === stateKey ) {
+			continue
+		}
+
+		const declarations = buckets[ stateKey ]
+		if ( ! declarations || 0 === Object.keys( declarations ).length ) {
+			continue
+		}
+
+		const definition = registry.get( stateKey )
+		if ( ! definition ) {
+			continue
+		}
+
+		const selector = selectorFor( scope, definition.selector )
+		if ( '' === selector ) {
+			continue
+		}
+
+		const rule = `${ selector } { ${ joinDeclarations( declarations ) } }`
+
+		if ( definition.hoverMediaWrap ) {
+			hoverBlock += ( '' === hoverBlock ? '' : ' ' ) + rule
+			continue
+		}
+
+		parts.push( rule )
+	}
+
+	if ( '' !== hoverBlock ) {
+		parts.push( `@media (hover: hover) { ${ hoverBlock } }` )
+	}
+
+	return parts.join( ' ' )
+}

--- a/resources/js/visual-editor/states/index.ts
+++ b/resources/js/visual-editor/states/index.ts
@@ -1,0 +1,59 @@
+/**
+ * Public entry point for the state design tools (#488).
+ *
+ * Host apps consume these via `@artisanpack-ui/visual-editor` once
+ * the editor library build re-exports them.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.0.0
+ */
+
+export {
+	getActiveState,
+	setActiveState,
+	subscribeActiveState,
+	getPreviewState,
+	setPreviewState,
+	subscribePreviewState,
+	setActiveBlock,
+	getActiveBlock,
+	resetStateStores,
+} from './active-state'
+
+export {
+	StateRegistry,
+	DEFAULT_STATES,
+	registryFromSnapshot,
+} from './registry'
+
+export {
+	resolveStateValue,
+	isStatefulAttribute,
+	distinctStateOverrides,
+} from './resolver'
+
+export {
+	promote,
+	demote,
+	clearOverride,
+} from './migrator'
+
+export {
+	useStateValue,
+	resolveAt,
+} from './useStateValue'
+
+export { StateSwitcher } from './StateSwitcher'
+export type { StateSwitcherProps } from './StateSwitcher'
+
+export { StateControl } from './StateControl'
+export type { StateControlProps } from './StateControl'
+
+export { PreviewStateToggle } from './PreviewStateToggle'
+export type { PreviewStateToggleProps } from './PreviewStateToggle'
+
+export { BASE_KEY } from './types'
+export type { StateDefinition, StateKey, StateRegistrySnapshot, StatefulAttribute } from './types'
+
+export { emitStateCss, DEFAULT_TRANSITION } from './css-emitter'
+export type { StatesByPath } from './css-emitter'

--- a/resources/js/visual-editor/states/migrator.ts
+++ b/resources/js/visual-editor/states/migrator.ts
@@ -1,0 +1,83 @@
+/**
+ * State attribute migrator — lazy scalar → stateful promotion (#488).
+ *
+ * Mirrors PHP `StateAttributeMigrator`. Used by the editor's
+ * InspectorControls to:
+ *  - Promote a scalar attribute into `{ idle, hover, … }` the first
+ *    time an editor sets a value at a non-`idle` state.
+ *  - Demote back to a scalar when every override is cleared.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.0.0
+ */
+
+import { BASE_KEY, type StatefulAttribute } from './types'
+
+function isStatefulObject<T>(
+	attribute: unknown,
+): attribute is { [BASE_KEY]: T | null } & Record<string, T | null | undefined> {
+	if ( null === attribute || 'object' !== typeof attribute || Array.isArray( attribute ) ) {
+		return false
+	}
+
+	return BASE_KEY in ( attribute as Record<string, unknown> )
+}
+
+export function promote<T>(
+	attribute: StatefulAttribute<T> | null | undefined,
+	state: string,
+	value: T | null,
+): StatefulAttribute<T> {
+	if ( BASE_KEY === state && ! isStatefulObject<T>( attribute ) ) {
+		return value as T
+	}
+
+	const next: Record<string, T | null | undefined> = isStatefulObject<T>( attribute )
+		? { ...( attribute as Record<string, T | null | undefined> ) }
+		: { [BASE_KEY]: ( attribute ?? null ) as T | null }
+
+	next[ state ] = value
+
+	return next as StatefulAttribute<T>
+}
+
+export function demote<T>(
+	attribute: StatefulAttribute<T> | null | undefined,
+): StatefulAttribute<T> | null {
+	if ( ! isStatefulObject<T>( attribute ) ) {
+		return ( attribute ?? null ) as StatefulAttribute<T> | null
+	}
+
+	const obj = attribute as Record<string, T | null | undefined>
+
+	for ( const key of Object.keys( obj ) ) {
+		if ( BASE_KEY === key ) {
+			continue
+		}
+
+		if ( null !== obj[ key ] && undefined !== obj[ key ] ) {
+			return attribute
+		}
+	}
+
+	return ( obj[ BASE_KEY ] ?? null ) as StatefulAttribute<T> | null
+}
+
+export function clearOverride<T>(
+	attribute: StatefulAttribute<T> | null | undefined,
+	state: string,
+): StatefulAttribute<T> | null {
+	if ( ! isStatefulObject<T>( attribute ) ) {
+		return ( attribute ?? null ) as StatefulAttribute<T> | null
+	}
+
+	const next: Record<string, T | null | undefined> = { ...( attribute as Record<string, T | null | undefined> ) }
+
+	if ( BASE_KEY === state ) {
+		next[ BASE_KEY ] = null
+	} else {
+		delete next[ state ]
+	}
+
+	return demote( next as StatefulAttribute<T> )
+}

--- a/resources/js/visual-editor/states/register-attribute.ts
+++ b/resources/js/visual-editor/states/register-attribute.ts
@@ -1,0 +1,82 @@
+/**
+ * Inject the `states` attribute on every block that opts into
+ * per-state styling (#488).
+ *
+ * Blocks declare opt-in via `supports.artisanpackStates` in
+ * `block.json`. This `blocks.registerBlockType` filter adds the
+ * storage attribute at registration time so individual `block.json`
+ * files don't need to declare it by hand.
+ *
+ * The injected attribute is a plain `object` keyed by attribute path
+ * (e.g. `style.color.background`) → discriminated
+ * `{ idle, hover, focus, … }` object. Reads/writes are mediated by
+ * `withStateAttributes`; this file just makes sure the attribute
+ * exists so `setAttributes` calls actually persist.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.0.0
+ */
+
+import { addFilter } from '@wordpress/hooks'
+
+const FILTER_HOOK      = 'blocks.registerBlockType'
+const FILTER_NAMESPACE = 'artisanpack-ui/visual-editor/states-attribute'
+
+const REGISTERED_KEY = Symbol.for(
+	'artisanpack-ui.visual-editor.states-attribute.registered',
+)
+
+interface GlobalSentinelHost {
+	[REGISTERED_KEY]?: boolean
+}
+
+interface BlockSupports {
+	artisanpackStates?: {
+		attributes?: string[]
+		states?: string[]
+	} | boolean
+}
+
+interface BlockSettingsLike {
+	supports?: BlockSupports
+	attributes?: Record<string, unknown>
+	[key: string]: unknown
+}
+
+function injectStateAttribute( settings: BlockSettingsLike ): BlockSettingsLike {
+	const support = settings.supports?.artisanpackStates
+
+	if ( ! support ) {
+		return settings
+	}
+
+	if ( settings.attributes && 'states' in settings.attributes ) {
+		return settings
+	}
+
+	return {
+		...settings,
+		attributes: {
+			...( settings.attributes ?? {} ),
+			states: {
+				type:    'object',
+				default: null,
+			},
+		},
+	}
+}
+
+/**
+ * Register the filter at most once per page. Idempotent — safe to
+ * call from both the post-editor and site-editor entries.
+ */
+export function registerStateAttribute(): void {
+	const host = globalThis as unknown as GlobalSentinelHost
+
+	if ( host[ REGISTERED_KEY ] ) {
+		return
+	}
+
+	addFilter( FILTER_HOOK, FILTER_NAMESPACE, injectStateAttribute )
+	host[ REGISTERED_KEY ] = true
+}

--- a/resources/js/visual-editor/states/registry.ts
+++ b/resources/js/visual-editor/states/registry.ts
@@ -156,3 +156,24 @@ export function registryFromSnapshot( snapshot: StateRegistrySnapshot | undefine
 
 	return new StateRegistry( snapshot.states )
 }
+
+/**
+ * Singleton wrapper around the active registry. The bootstrap path
+ * calls {@see setStateRegistry} once with the host's resolved
+ * theme/config registry; every consumer (HOC overlay, CSS emitter,
+ * inspector switcher) reads through {@see getStateRegistry} so
+ * custom states declared in theme.json actually participate in the
+ * inheritance cascade.
+ *
+ * Defaults to the built-in registry so headless tests and bootstrap-
+ * less environments still resolve correctly.
+ */
+let activeRegistry: StateRegistry = new StateRegistry( DEFAULT_STATES )
+
+export function getStateRegistry(): StateRegistry {
+	return activeRegistry
+}
+
+export function setStateRegistry( registry: StateRegistry ): void {
+	activeRegistry = registry
+}

--- a/resources/js/visual-editor/states/registry.ts
+++ b/resources/js/visual-editor/states/registry.ts
@@ -1,0 +1,158 @@
+/**
+ * Client-side state registry (#488).
+ *
+ * Mirrors the PHP `StateRegistry` so the editor can resolve
+ * inheritance chains and surface state metadata without
+ * round-tripping to the server. Hydrated from `editor-settings`'s
+ * `states` array which the bootstrap path stamps from the merged PHP
+ * config + theme.json.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.0.0
+ */
+
+import { BASE_KEY, type StateDefinition, type StateRegistrySnapshot } from './types'
+
+const MAX_CHAIN_DEPTH = 16
+
+export const DEFAULT_STATES: StateDefinition[] = [
+	{
+		key:            'idle',
+		label:          'Idle',
+		selector:       '',
+		icon:           'circle',
+		inheritsFrom:   null,
+		hoverMediaWrap: false,
+	},
+	{
+		key:            'hover',
+		label:          'Hover',
+		selector:       '&:hover',
+		icon:           'cursor',
+		inheritsFrom:   'idle',
+		hoverMediaWrap: true,
+	},
+	{
+		key:            'focus',
+		label:          'Focus',
+		selector:       '&:focus',
+		icon:           'target',
+		inheritsFrom:   'idle',
+		hoverMediaWrap: false,
+	},
+	{
+		key:            'focus-visible',
+		label:          'Focus visible',
+		selector:       '&:focus-visible',
+		icon:           'target-arrow',
+		inheritsFrom:   'focus',
+		hoverMediaWrap: false,
+	},
+	{
+		key:            'active',
+		label:          'Active',
+		selector:       '&:active',
+		icon:           'click',
+		inheritsFrom:   'hover',
+		hoverMediaWrap: false,
+	},
+	{
+		key:            'disabled',
+		label:          'Disabled',
+		selector:       '&:disabled, &[aria-disabled="true"]',
+		icon:           'block',
+		inheritsFrom:   'idle',
+		hoverMediaWrap: false,
+	},
+]
+
+export class StateRegistry {
+	protected readonly states: Map<string, StateDefinition>
+
+	constructor( states: StateDefinition[] = DEFAULT_STATES ) {
+		const idle = states.find( ( s ) => BASE_KEY === s.key )
+		if ( ! idle ) {
+			throw new Error( `State registry is missing the reserved "${ BASE_KEY }" base state.` )
+		}
+
+		this.states = new Map()
+
+		// Hoist `idle` to the front so iteration is stable.
+		this.states.set( BASE_KEY, { ...idle, inheritsFrom: null, selector: '' } )
+
+		for ( const state of states ) {
+			if ( BASE_KEY === state.key ) {
+				continue
+			}
+
+			this.states.set( state.key, { ...state } )
+		}
+	}
+
+	all(): StateDefinition[] {
+		return Array.from( this.states.values() )
+	}
+
+	keys(): string[] {
+		return Array.from( this.states.keys() )
+	}
+
+	get( key: string ): StateDefinition | null {
+		return this.states.get( key ) ?? null
+	}
+
+	has( key: string ): boolean {
+		return this.states.has( key )
+	}
+
+	/**
+	 * Returns the chain of state keys to walk when resolving a value
+	 * at the given state, starting at `state` itself and following
+	 * `inheritsFrom` until `idle`. Unknown states collapse to
+	 * `[idle]`. The chain always terminates at `idle`.
+	 */
+	inheritanceChain( state: string ): string[] {
+		if ( BASE_KEY === state || ! this.has( state ) ) {
+			return [ BASE_KEY ]
+		}
+
+		const chain: string[]   = []
+		let current: string | null = state
+		let depth                  = 0
+
+		while ( null !== current && depth < MAX_CHAIN_DEPTH ) {
+			chain.push( current )
+
+			if ( BASE_KEY === current ) {
+				return chain
+			}
+
+			const definition: StateDefinition | null = this.states.get( current ) ?? null
+			current                                  = definition?.inheritsFrom ?? null
+			depth++
+		}
+
+		if ( ! chain.includes( BASE_KEY ) ) {
+			chain.push( BASE_KEY )
+		}
+
+		return chain
+	}
+
+	toJSON(): StateRegistrySnapshot {
+		return { states: this.all() }
+	}
+}
+
+/**
+ * Build a registry from a serialized snapshot — typically the JSON
+ * the editor bootstrap stamps into
+ * `window.artisanpackVisualEditor.settings`.
+ */
+export function registryFromSnapshot( snapshot: StateRegistrySnapshot | undefined ): StateRegistry {
+	if ( ! snapshot || ! Array.isArray( snapshot.states ) || 0 === snapshot.states.length ) {
+		return new StateRegistry()
+	}
+
+	return new StateRegistry( snapshot.states )
+}

--- a/resources/js/visual-editor/states/resolver.ts
+++ b/resources/js/visual-editor/states/resolver.ts
@@ -1,0 +1,111 @@
+/**
+ * State value resolver (#488).
+ *
+ * Mirrors the PHP `StateValueResolver`. Given a stateful
+ * `{ idle, hover, focus, … }` attribute and the active state,
+ * returns the value the editor / renderer should show.
+ *
+ *  - `idle` is the base; it applies whenever a more specific state
+ *    has no explicit override.
+ *  - `null` (or missing) means "inherit from the next link in the
+ *    inheritance chain."
+ *  - Scalars round-trip unchanged.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.0.0
+ */
+
+import type { StateRegistry } from './registry'
+import { BASE_KEY, type StatefulAttribute } from './types'
+
+export function isStatefulAttribute<T>(
+	value: unknown,
+	registry: StateRegistry,
+): value is { [k: string]: T | null } {
+	if ( null === value || 'object' !== typeof value || Array.isArray( value ) ) {
+		return false
+	}
+
+	const obj = value as Record<string, unknown>
+
+	if ( BASE_KEY in obj ) {
+		return true
+	}
+
+	return registry.keys().some( ( key ) => BASE_KEY !== key && key in obj )
+}
+
+export function resolveStateValue<T>(
+	attribute: StatefulAttribute<T> | null | undefined,
+	activeState: string,
+	registry: StateRegistry,
+): T | null {
+	if ( null === attribute || undefined === attribute ) {
+		return null
+	}
+
+	if ( ! isStatefulAttribute<T>( attribute, registry ) ) {
+		return attribute as T
+	}
+
+	const chain = registry.inheritanceChain( activeState )
+	const obj   = attribute as Record<string, T | null | undefined>
+
+	for ( const key of chain ) {
+		if ( ! ( key in obj ) ) {
+			continue
+		}
+
+		const value = obj[ key ]
+		if ( null === value || undefined === value ) {
+			continue
+		}
+
+		return value
+	}
+
+	return null
+}
+
+/**
+ * Returns a state-keyed map of only the states whose resolved value
+ * differs from their inheritance parent. `idle` is always included
+ * when it carries a non-null value. Used by renderers to avoid
+ * emitting redundant CSS rules.
+ */
+export function distinctStateOverrides<T>(
+	attribute: StatefulAttribute<T> | null | undefined,
+	registry: StateRegistry,
+): Record<string, T> {
+	if ( null === attribute || undefined === attribute ) {
+		return {}
+	}
+
+	const normalized = isStatefulAttribute<T>( attribute, registry )
+		? ( attribute as Record<string, T | null | undefined> )
+		: ( { [BASE_KEY]: attribute } as Record<string, T | null | undefined> )
+
+	const out: Record<string, T> = {}
+
+	for ( const state of registry.keys() ) {
+		const value = resolveStateValue<T>( normalized, state, registry )
+		if ( null === value ) {
+			continue
+		}
+
+		if ( BASE_KEY === state ) {
+			out[ state ] = value
+			continue
+		}
+
+		const definition = registry.get( state )
+		const parent     = definition?.inheritsFrom ?? BASE_KEY
+		const parentVal  = resolveStateValue<T>( normalized, parent, registry )
+
+		if ( value !== parentVal ) {
+			out[ state ] = value
+		}
+	}
+
+	return out
+}

--- a/resources/js/visual-editor/states/state-switcher.css
+++ b/resources/js/visual-editor/states/state-switcher.css
@@ -1,0 +1,120 @@
+/**
+ * State switcher styles (#488).
+ *
+ * The state switcher renders as a strip of icon-and-label chips in
+ * the InspectorControls header. Inherits inspector tokens where
+ * available so it sits coherently inside the panel.
+ */
+
+.ap-visual-editor-state-switcher {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    padding: 8px 12px;
+    margin: 0 0 8px;
+    border-bottom: 1px solid
+        color-mix(
+            in oklch,
+            var(--ap-visual-editor-top-bar-foreground, #1f2937) 12%,
+            transparent
+        );
+}
+
+.ap-visual-editor-state-switcher__chip {
+    appearance: none;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 10px;
+    font: inherit;
+    font-size: 11px;
+    line-height: 1.4;
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: var(--ap-visual-editor-top-bar-radius, 6px);
+    cursor: pointer;
+    color: var(--ap-visual-editor-top-bar-foreground, #1f2937);
+    transition: background-color 120ms ease, border-color 120ms ease;
+}
+
+.ap-visual-editor-state-switcher__chip:hover {
+    background: color-mix(
+        in oklch,
+        var(--ap-visual-editor-top-bar-accent, #2563eb) 8%,
+        transparent
+    );
+}
+
+.ap-visual-editor-state-switcher__chip[aria-pressed='true'] {
+    background: color-mix(
+        in oklch,
+        var(--ap-visual-editor-top-bar-accent, #2563eb) 15%,
+        transparent
+    );
+    border-color: color-mix(
+        in oklch,
+        var(--ap-visual-editor-top-bar-accent, #2563eb) 35%,
+        transparent
+    );
+    color: var(--ap-visual-editor-top-bar-accent, #2563eb);
+    font-weight: 600;
+}
+
+.ap-visual-editor-state-switcher__chip[data-has-override='true']::after {
+    content: '';
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--ap-visual-editor-top-bar-accent, #2563eb);
+    display: inline-block;
+    flex: 0 0 auto;
+}
+
+.ap-visual-editor-state-switcher__preview {
+    margin-left: auto;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 11px;
+    color: var(--ap-visual-editor-top-bar-foreground, #1f2937);
+}
+
+.ap-visual-editor-state-switcher__preview button {
+    appearance: none;
+    background: transparent;
+    border: 1px solid
+        color-mix(
+            in oklch,
+            var(--ap-visual-editor-top-bar-foreground, #1f2937) 15%,
+            transparent
+        );
+    border-radius: calc(var(--ap-visual-editor-top-bar-radius, 6px) - 2px);
+    padding: 3px 8px;
+    cursor: pointer;
+    font: inherit;
+    color: inherit;
+}
+
+.ap-visual-editor-state-switcher__preview button[aria-pressed='true'] {
+    background: color-mix(
+        in oklch,
+        var(--ap-visual-editor-top-bar-accent, #2563eb) 18%,
+        transparent
+    );
+    border-color: color-mix(
+        in oklch,
+        var(--ap-visual-editor-top-bar-accent, #2563eb) 40%,
+        transparent
+    );
+}
+
+.ap-visual-editor-state-switcher__unsupported {
+    padding: 8px 12px;
+    margin: 0;
+    font-size: 11px;
+    color: color-mix(
+        in oklch,
+        var(--ap-visual-editor-top-bar-foreground, #1f2937) 60%,
+        transparent
+    );
+}

--- a/resources/js/visual-editor/states/state-write-interceptor.tsx
+++ b/resources/js/visual-editor/states/state-write-interceptor.tsx
@@ -1,0 +1,244 @@
+/**
+ * State-write interceptor (#488).
+ *
+ * WordPress's newer block-support panels (color, border, shadow on
+ * apiVersion 3 blocks) dispatch attribute writes directly via
+ * `useDispatch( 'core/block-editor' ).updateBlockAttributes()` instead
+ * of calling `props.setAttributes`. That bypasses any `editor.BlockEdit`
+ * HOC in the prop chain, including {@link withStateAttributes}.
+ *
+ * This component plugs the gap. It subscribes to the selected block's
+ * attributes via `useSelect`, diffs them against the previous render,
+ * and — when the active state is non-idle and the diff lands on a
+ * state-eligible attribute path — re-dispatches a correction that:
+ *
+ *   - Restores the base attribute to its pre-write value.
+ *   - Moves the new value into
+ *     `attributes.states.<path>.<activeState>`.
+ *
+ * The result is identical to what {@link withStateAttributes} would
+ * produce if the panel had used `props.setAttributes`; this just
+ * catches writes the HOC chain never sees.
+ *
+ * Loop guard: `prevAttributesRef` is updated to the *corrected*
+ * attributes shape before dispatching, so the next subscriber tick
+ * compares the corrected attrs to themselves and exits without
+ * re-routing.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.0.0
+ */
+
+import { hasBlockSupport, getBlockType } from '@wordpress/blocks'
+import { useDispatch, useSelect } from '@wordpress/data'
+import { useEffect, useRef, useSyncExternalStore } from 'react'
+
+import {
+	diffPaths,
+	pathMatchesAnyRoot,
+	readPath,
+	setPath,
+} from '../responsive/attribute-paths'
+import { getActiveState, subscribeActiveState } from './active-state'
+import { BASE_KEY } from './types'
+
+interface StateSupports {
+	attributes?: string[]
+}
+
+interface SelectedBlock {
+	clientId: string | null
+	name: string | null
+	attributes: Record<string, unknown>
+}
+
+function getStateRoots( name: string | null ): string[] | null {
+	if ( ! name ) {
+		return null
+	}
+
+	const blockType = getBlockType( name )
+	if ( ! blockType ) {
+		return null
+	}
+
+	if ( ! hasBlockSupport( blockType, 'artisanpackStates', false ) ) {
+		return null
+	}
+
+	const support = ( blockType.supports as Record<string, unknown> )
+		.artisanpackStates
+
+	if ( ! support || 'object' !== typeof support ) {
+		return null
+	}
+
+	const roots = ( support as StateSupports ).attributes
+	if ( ! Array.isArray( roots ) || 0 === roots.length ) {
+		return null
+	}
+
+	return roots
+}
+
+type StatesByPath = Record<string, Record<string, unknown>>
+
+interface CorrectionResult {
+	correctedAttributes: Record<string, unknown>
+	updatePayload: Record<string, unknown>
+}
+
+/**
+ * Compute the correction payload + the attribute shape we expect to
+ * see after dispatching it. Returns `null` when no correction is
+ * required.
+ */
+export function planCorrection(
+	prev: Record<string, unknown>,
+	curr: Record<string, unknown>,
+	roots: string[],
+	activeState: string,
+): CorrectionResult | null {
+	const changedLeaves = diffPaths( curr, prev )
+	if ( 0 === changedLeaves.length ) {
+		return null
+	}
+
+	let restorePatch: Record<string, unknown> | null = null
+	let statesPatch: StatesByPath | null             = null
+
+	for ( const { path, value } of changedLeaves ) {
+		// Ignore writes to the states bag itself — those are either
+		// the user's per-state edits already routed, or housekeeping
+		// from `withStateStyles` (scopeId mint). Letting them through
+		// would cause oscillation.
+		if ( 'states' === path || path.startsWith( 'states.' ) ) {
+			continue
+		}
+
+		if ( ! pathMatchesAnyRoot( path, roots ) ) {
+			continue
+		}
+
+		const previousValue = readPath( prev, path )
+
+		statesPatch = statesPatch ?? {}
+		const currentForPath = ( curr.states as StatesByPath | undefined | null )?.[ path ] ?? {}
+		statesPatch[ path ] = {
+			...currentForPath,
+			[ activeState ]: value,
+		}
+
+		restorePatch = setPath( restorePatch ?? {}, path, previousValue )
+	}
+
+	if ( ! statesPatch || ! restorePatch ) {
+		return null
+	}
+
+	const nextStates = {
+		...( curr.states as StatesByPath | undefined | null ?? {} ),
+		...statesPatch,
+	}
+
+	const updatePayload: Record<string, unknown> = {
+		...restorePatch,
+		states: nextStates,
+	}
+
+	const correctedAttributes: Record<string, unknown> = {
+		...curr,
+		...restorePatch,
+		states: nextStates,
+	}
+
+	return { correctedAttributes, updatePayload }
+}
+
+export function StateWriteInterceptor(): null {
+	const activeState = useSyncExternalStore(
+		subscribeActiveState,
+		getActiveState,
+		getActiveState,
+	)
+
+	const selection = useSelect( ( select ): SelectedBlock => {
+		const store = select( 'core/block-editor' ) as
+			| {
+				  getSelectedBlockClientId?: () => string | null
+				  getBlockName?: ( id: string ) => string | null
+				  getBlockAttributes?: (
+					  id: string,
+				  ) => Record<string, unknown> | null
+			  }
+			| undefined
+
+		const clientId = store?.getSelectedBlockClientId?.() ?? null
+		if ( ! clientId ) {
+			return { clientId: null, name: null, attributes: {} }
+		}
+
+		return {
+			clientId,
+			name:       store?.getBlockName?.( clientId ) ?? null,
+			attributes: store?.getBlockAttributes?.( clientId ) ?? {},
+		}
+	}, [] )
+
+	const { updateBlockAttributes } = useDispatch( 'core/block-editor' ) as {
+		updateBlockAttributes: (
+			clientId: string,
+			updates: Record<string, unknown>,
+		) => void
+	}
+
+	const prevAttributesRef = useRef<Record<string, unknown>>( selection.attributes )
+	const prevClientIdRef   = useRef<string | null>( selection.clientId )
+
+	useEffect( () => {
+		// Block selection changed — anchor the diff to the new block's
+		// current attrs so the next change isn't misread as a write
+		// against the old block's snapshot.
+		if ( selection.clientId !== prevClientIdRef.current ) {
+			prevClientIdRef.current   = selection.clientId
+			prevAttributesRef.current = selection.attributes
+			return
+		}
+
+		if ( ! selection.clientId || ! selection.name || BASE_KEY === activeState ) {
+			prevAttributesRef.current = selection.attributes
+			return
+		}
+
+		const roots = getStateRoots( selection.name )
+		if ( ! roots ) {
+			prevAttributesRef.current = selection.attributes
+			return
+		}
+
+		const correction = planCorrection(
+			prevAttributesRef.current,
+			selection.attributes,
+			roots,
+			activeState,
+		)
+
+		if ( ! correction ) {
+			prevAttributesRef.current = selection.attributes
+			return
+		}
+
+		// Anchor the next diff to the corrected shape so we don't
+		// re-route our own dispatch.
+		prevAttributesRef.current = correction.correctedAttributes
+		updateBlockAttributes( selection.clientId, correction.updatePayload )
+	}, [
+		activeState,
+		selection.clientId,
+		selection.name,
+		selection.attributes,
+		updateBlockAttributes,
+	] )
+
+	return null
+}

--- a/resources/js/visual-editor/states/types.ts
+++ b/resources/js/visual-editor/states/types.ts
@@ -1,0 +1,46 @@
+/**
+ * Shared types for the state design tools (#488).
+ *
+ * Mirrors the PHP-side `StateRegistry` + `StateValueResolver` shapes
+ * so the editor's UI surface can be type-safe end-to-end.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.0.0
+ */
+
+export const BASE_KEY = 'idle' as const;
+
+export type StateKey = typeof BASE_KEY | string;
+
+export interface StateDefinition {
+	key: string;
+	label: string;
+	/**
+	 * CSS pseudo or attribute selector. `&` is replaced with the
+	 * block's unique scope at emit time. The reserved `idle` slot has
+	 * an empty selector — it represents the default styles.
+	 */
+	selector: string;
+	icon: string;
+	inheritsFrom: string | null;
+	/**
+	 * When true, the server-side renderer wraps the rule in
+	 * `@media (hover: hover)`. Defaults to false.
+	 */
+	hoverMediaWrap: boolean;
+}
+
+/**
+ * Discriminated per-state storage. Mirrors the PHP shape:
+ * { idle: x, hover: null, focus: y, ... }
+ *
+ * `null` means "inherit from the next link in the inheritance chain."
+ * Missing keys are treated identically to `null` by the resolver.
+ */
+export type StatefulAttribute<T> =
+	| T
+	| ({ [BASE_KEY]?: T | null } & { [key: string]: T | null | undefined });
+
+export interface StateRegistrySnapshot {
+	states: StateDefinition[];
+}

--- a/resources/js/visual-editor/states/useStateValue.ts
+++ b/resources/js/visual-editor/states/useStateValue.ts
@@ -1,0 +1,56 @@
+/**
+ * `useStateValue` hook (#488).
+ *
+ * Resolves a stateful `{ idle, hover, … }` attribute against the
+ * editor's currently active state. Block edit components consume
+ * this to render the resolved value at the state the editor is
+ * authoring against (or previewing).
+ *
+ * Preview state, when set, takes precedence over the active state —
+ * the canvas should reflect what the editor is simulating.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.0.0
+ */
+
+import { useSyncExternalStore } from 'react'
+
+import {
+	getActiveState,
+	getPreviewState,
+	subscribeActiveState,
+	subscribePreviewState,
+} from './active-state'
+import type { StateRegistry } from './registry'
+import { resolveStateValue } from './resolver'
+import type { StatefulAttribute } from './types'
+
+/**
+ * Returns the value for the given attribute at the editor's active
+ * (or preview) state. Re-renders the component whenever the editor
+ * switches states.
+ */
+export function useStateValue<T>(
+	attribute: StatefulAttribute<T> | null | undefined,
+	registry: StateRegistry,
+): T | null {
+	const active  = useSyncExternalStore( subscribeActiveState, getActiveState, getActiveState )
+	const preview = useSyncExternalStore( subscribePreviewState, getPreviewState, getPreviewState )
+
+	const target = preview ?? active
+
+	return resolveStateValue<T>( attribute, target, registry )
+}
+
+/**
+ * Read-only sibling of {@see useStateValue} for code paths that
+ * already have an explicit state in hand (e.g. the renderer rebuilding
+ * all states' values at once).
+ */
+export function resolveAt<T>(
+	attribute: StatefulAttribute<T> | null | undefined,
+	state: string,
+	registry: StateRegistry,
+): T | null {
+	return resolveStateValue<T>( attribute, state, registry )
+}

--- a/resources/js/visual-editor/states/with-state-attributes.tsx
+++ b/resources/js/visual-editor/states/with-state-attributes.tsx
@@ -1,0 +1,293 @@
+/**
+ * `editor.BlockEdit` HOC — invisibly route attribute reads and writes
+ * through the active interactive state (#488).
+ *
+ * Every block that declares `supports.artisanpackStates` is wrapped.
+ * The wrapper does two things, both transparent to the native
+ * Gutenberg panels:
+ *
+ *  1. **Reads.** Builds a view where the attributes the panels see
+ *     are the base values overlaid with anything stored under
+ *     `attributes.states.<path>.<activeState>`. So when the editor
+ *     switches the inspector state chip to `hover`, the color panel
+ *     shows the hover background color instead of the idle one.
+ *
+ *  2. **Writes.** When the active state is `idle`, writes fall through
+ *     to the normal `setAttributes` (touching
+ *     `attributes.style.color.background` as today). When the active
+ *     state is non-`idle`, the writes are diffed against the
+ *     pre-merge attributes; any leaf that landed under one of the
+ *     opt-in roots (e.g. `style.color.background`) is stored under
+ *     `attributes.states.<path>.<activeState>` instead of mutating
+ *     the base. Leaves outside the opt-in roots fall through to the
+ *     base.
+ *
+ *  Editors see zero new UI inside the panels. They pick a state in
+ *  the inspector, edit colors/borders like always, and the value
+ *  sticks to that state.
+ *
+ * Mirrors `withResponsiveAttributes`; the two HOCs compose cleanly
+ * because they route through orthogonal storage bags
+ * (`attributes.responsive` vs `attributes.states`).
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.0.0
+ */
+
+import { hasBlockSupport, getBlockType } from '@wordpress/blocks'
+import { createHigherOrderComponent } from '@wordpress/compose'
+import { addFilter } from '@wordpress/hooks'
+import { useCallback, useMemo, useSyncExternalStore } from 'react'
+import type { ComponentType } from 'react'
+
+import {
+	deepMerge,
+	diffPaths,
+	pathMatchesAnyRoot,
+	setPath,
+} from '../responsive/attribute-paths'
+import { getActiveState, subscribeActiveState } from './active-state'
+import { DEFAULT_STATES, StateRegistry } from './registry'
+import { BASE_KEY } from './types'
+
+const FILTER_HOOK      = 'editor.BlockEdit'
+const FILTER_NAMESPACE = 'artisanpack-ui/visual-editor/state-attributes'
+
+const REGISTERED_KEY = Symbol.for(
+	'artisanpack-ui.visual-editor.state-attributes.registered',
+)
+
+interface GlobalSentinelHost {
+	[REGISTERED_KEY]?: boolean
+}
+
+interface BlockEditProps {
+	name: string
+	attributes: Record<string, unknown>
+	setAttributes: ( updates: Record<string, unknown> ) => void
+	[key: string]: unknown
+}
+
+interface StateSupports {
+	attributes?: string[]
+	states?: string[]
+}
+
+type StateOverridesByPath = Record<string, Record<string, unknown>>
+
+function getStateRoots( name: string ): string[] | null {
+	const blockType = getBlockType( name )
+
+	if ( ! blockType ) {
+		return null
+	}
+
+	if ( ! hasBlockSupport( blockType, 'artisanpackStates', false ) ) {
+		return null
+	}
+
+	const support = ( blockType.supports as Record<string, unknown> )
+		.artisanpackStates
+
+	if ( ! support || 'object' !== typeof support ) {
+		return null
+	}
+
+	const roots = ( support as StateSupports ).attributes
+
+	if ( ! Array.isArray( roots ) || 0 === roots.length ) {
+		return null
+	}
+
+	return roots
+}
+
+// Module-level registry used to walk the inheritance chain when
+// building the overlay. The editor hydrates this off the bootstrap
+// snapshot later (see plan §7.2); for now we resolve against the
+// built-in defaults so the cascade lines up with the PHP layer.
+const DEFAULT_REGISTRY = new StateRegistry( DEFAULT_STATES )
+
+/**
+ * Build the overlay object that, when deep-merged into the base
+ * attributes, produces the read view for the active state.
+ *
+ * Mirrors the PHP `StateValueResolver` cascade: every state path is
+ * walked, taking the first non-null value in the inheritance chain.
+ */
+function buildOverlay(
+	states: StateOverridesByPath | null | undefined,
+	activeState: string,
+): Record<string, unknown> {
+	if ( ! states || BASE_KEY === activeState ) {
+		return {}
+	}
+
+	const chain = DEFAULT_REGISTRY.inheritanceChain( activeState )
+
+	// Skip `idle` — it's the base attribute already, not an overlay
+	// source.
+	const overlayChain = chain.filter( ( key ) => BASE_KEY !== key )
+
+	if ( 0 === overlayChain.length ) {
+		return {}
+	}
+
+	const overlay: Record<string, unknown> = {}
+
+	for ( const path of Object.keys( states ) ) {
+		const overridesForPath = states[ path ]
+
+		if ( ! overridesForPath || 'object' !== typeof overridesForPath ) {
+			continue
+		}
+
+		for ( const key of overlayChain ) {
+			if ( key in overridesForPath ) {
+				const value = overridesForPath[ key ]
+
+				if ( null === value || undefined === value ) {
+					continue
+				}
+
+				writeInto( overlay, path, value )
+				break
+			}
+		}
+	}
+
+	return overlay
+}
+
+function writeInto( target: Record<string, unknown>, path: string, value: unknown ): void {
+	const segments = path.split( '.' )
+	let cursor: Record<string, unknown> = target
+
+	for ( let i = 0; i < segments.length - 1; i++ ) {
+		const segment  = segments[ i ]
+		const existing = cursor[ segment ]
+
+		if ( ! existing || 'object' !== typeof existing || Array.isArray( existing ) ) {
+			const next: Record<string, unknown> = {}
+			cursor[ segment ] = next
+			cursor = next
+		} else {
+			cursor = existing as Record<string, unknown>
+		}
+	}
+
+	cursor[ segments[ segments.length - 1 ] ] = value
+}
+
+export const withStateAttributes = createHigherOrderComponent(
+	( BlockEdit: ComponentType<BlockEditProps> ) => {
+		function StateBlockEdit( props: BlockEditProps ): JSX.Element {
+			const { name, attributes, setAttributes } = props
+
+			const roots = useMemo( () => getStateRoots( name ), [ name ] )
+
+			const activeState = useSyncExternalStore(
+				subscribeActiveState,
+				getActiveState,
+				getActiveState,
+			)
+
+			const states = ( attributes.states as StateOverridesByPath | null | undefined ) ?? null
+
+			const mergedAttributes = useMemo( () => {
+				if ( ! roots || BASE_KEY === activeState ) {
+					return attributes
+				}
+
+				const overlay = buildOverlay( states, activeState )
+
+				if ( 0 === Object.keys( overlay ).length ) {
+					return attributes
+				}
+
+				return deepMerge( attributes, overlay )
+			}, [ attributes, states, activeState, roots ] )
+
+			const wrappedSetAttributes = useCallback(
+				( updates: Record<string, unknown> ): void => {
+					if ( ! roots || BASE_KEY === activeState ) {
+						setAttributes( updates )
+						return
+					}
+
+					// Diff what the native panel just produced against the
+					// merged read view it was looking at — only the leaves
+					// the editor actually changed should be routed.
+					const changedLeaves = diffPaths( updates, mergedAttributes )
+
+					if ( 0 === changedLeaves.length ) {
+						return
+					}
+
+					const baseUpdates: Record<string, unknown> = {}
+					let statesPatch: StateOverridesByPath | null = null
+
+					for ( const { path, value } of changedLeaves ) {
+						if ( pathMatchesAnyRoot( path, roots ) ) {
+							statesPatch = statesPatch ?? {}
+							statesPatch[ path ] = {
+								...( states?.[ path ] ?? {} ),
+								[ activeState ]: value,
+							}
+							continue
+						}
+
+						Object.assign(
+							baseUpdates,
+							setPath( baseUpdates, path, value ),
+						)
+					}
+
+					const finalUpdates: Record<string, unknown> = { ...baseUpdates }
+
+					if ( statesPatch ) {
+						finalUpdates.states = {
+							...( states ?? {} ),
+							...statesPatch,
+						}
+					}
+
+					setAttributes( finalUpdates )
+				},
+				[ activeState, mergedAttributes, states, roots, setAttributes ],
+			)
+
+			if ( ! roots ) {
+				return <BlockEdit { ...props } />
+			}
+
+			return (
+				<BlockEdit
+					{ ...props }
+					attributes={ mergedAttributes }
+					setAttributes={ wrappedSetAttributes }
+				/>
+			)
+		}
+
+		StateBlockEdit.displayName = 'StateBlockEdit'
+
+		return StateBlockEdit
+	},
+	'withStateAttributes',
+)
+
+/**
+ * Idempotent — safe to call from both the post-editor and site-editor
+ * bootstrap paths. Late callers see the sentinel and no-op.
+ */
+export function registerStateAttributesFilter(): void {
+	const host = globalThis as unknown as GlobalSentinelHost
+
+	if ( host[ REGISTERED_KEY ] ) {
+		return
+	}
+
+	addFilter( FILTER_HOOK, FILTER_NAMESPACE, withStateAttributes )
+	host[ REGISTERED_KEY ] = true
+}

--- a/resources/js/visual-editor/states/with-state-attributes.tsx
+++ b/resources/js/visual-editor/states/with-state-attributes.tsx
@@ -47,7 +47,7 @@ import {
 	setPath,
 } from '../responsive/attribute-paths'
 import { getActiveState, subscribeActiveState } from './active-state'
-import { DEFAULT_STATES, StateRegistry } from './registry'
+import { getStateRegistry } from './registry'
 import { BASE_KEY } from './types'
 
 const FILTER_HOOK      = 'editor.BlockEdit'
@@ -102,18 +102,17 @@ function getStateRoots( name: string ): string[] | null {
 	return roots
 }
 
-// Module-level registry used to walk the inheritance chain when
-// building the overlay. The editor hydrates this off the bootstrap
-// snapshot later (see plan §7.2); for now we resolve against the
-// built-in defaults so the cascade lines up with the PHP layer.
-const DEFAULT_REGISTRY = new StateRegistry( DEFAULT_STATES )
-
 /**
  * Build the overlay object that, when deep-merged into the base
  * attributes, produces the read view for the active state.
  *
  * Mirrors the PHP `StateValueResolver` cascade: every state path is
  * walked, taking the first non-null value in the inheritance chain.
+ *
+ * Resolves the chain against the *current* runtime registry via
+ * {@link getStateRegistry} so custom states declared in theme.json
+ * participate in the cascade. Pinning to a module-level default
+ * registry here would silently strand any host-configured chains.
  */
 function buildOverlay(
 	states: StateOverridesByPath | null | undefined,
@@ -123,7 +122,7 @@ function buildOverlay(
 		return {}
 	}
 
-	const chain = DEFAULT_REGISTRY.inheritanceChain( activeState )
+	const chain = getStateRegistry().inheritanceChain( activeState )
 
 	// Skip `idle` — it's the base attribute already, not an overlay
 	// source.

--- a/resources/js/visual-editor/states/with-state-styles.tsx
+++ b/resources/js/visual-editor/states/with-state-styles.tsx
@@ -29,10 +29,10 @@ import { hasBlockSupport, getBlockType } from '@wordpress/blocks'
 import { createHigherOrderComponent } from '@wordpress/compose'
 import { addFilter } from '@wordpress/hooks'
 import { Fragment, createElement, useEffect, useMemo, useRef } from 'react'
-import type { ComponentType } from 'react'
+import type { ComponentType, ReactNode } from 'react'
 
 import { emitStateCss, type StatesByPath } from './css-emitter'
-import { DEFAULT_STATES, StateRegistry } from './registry'
+import { getStateRegistry } from './registry'
 
 const BLOCK_FILTER_HOOK = 'editor.BlockListBlock'
 const SAVE_PROPS_HOOK   = 'blocks.getSaveContent.extraProps'
@@ -67,10 +67,6 @@ interface BlockSettingsLike {
 	attributes?: Record<string, unknown>
 	[key: string]: unknown
 }
-
-// Re-use the same default registry the HOC overlays against so the
-// emitted CSS lines up with what the inspector controls write.
-const REGISTRY = new StateRegistry( DEFAULT_STATES )
 
 function blockSupportsStates( name: string ): boolean {
 	const blockType = getBlockType( name )
@@ -118,10 +114,35 @@ function mintScopeId(): string {
 	return Math.random().toString( 36 ).slice( 2, 11 )
 }
 
+/**
+ * Tracks which clientId currently owns each scope id so duplicated
+ * blocks (which inherit the parent's `_scopeId` via attribute copy)
+ * can detect the collision and re-mint. Living at module scope so
+ * every HOC instance shares the same ledger; cleared via WeakMap-style
+ * write semantics in {@see takeScopeId} / {@see releaseScopeId}.
+ */
+const scopeIdOwners = new Map<string, string>()
+
+function claimScopeId( scopeId: string, clientId: string ): boolean {
+	const owner = scopeIdOwners.get( scopeId )
+	if ( ! owner ) {
+		scopeIdOwners.set( scopeId, clientId )
+		return true
+	}
+
+	return owner === clientId
+}
+
+function releaseScopeId( scopeId: string, clientId: string ): void {
+	if ( scopeIdOwners.get( scopeId ) === clientId ) {
+		scopeIdOwners.delete( scopeId )
+	}
+}
+
 export const withStateStyles = createHigherOrderComponent(
 	( BlockListBlock: ComponentType<BlockListBlockProps> ) => {
 		function StateStyledBlock( props: BlockListBlockProps ): JSX.Element {
-			const { name, attributes, setAttributes, wrapperProps } = props
+			const { name, clientId, attributes, setAttributes, wrapperProps } = props
 
 			// Compute support up front, then run every hook unconditionally —
 			// the React Rules of Hooks require a stable hook order across
@@ -143,18 +164,46 @@ export const withStateStyles = createHigherOrderComponent(
 			}, [ scopeId ] )
 
 			useEffect( () => {
-				if ( ! supportsStates || scopeId || ! hasAuthoredOverrides( paths ) || ! setAttributes ) {
+				if ( ! supportsStates || ! setAttributes ) {
+					return
+				}
+
+				// Re-mint when the block has overrides but no scope id
+				// yet, OR when its scope id is already claimed by a
+				// different clientId (block duplication copies the
+				// attribute bag verbatim, including `_scopeId`, which
+				// would otherwise produce two blocks sharing one CSS
+				// scope and bleed state styles across them).
+				const needsMint    = ! scopeId && hasAuthoredOverrides( paths )
+				const hasCollision = scopeId !== null && ! claimScopeId( scopeId, clientId )
+
+				if ( ! needsMint && ! hasCollision ) {
 					return
 				}
 
 				const nextId   = mintScopeId()
+				claimScopeId( nextId, clientId )
+
 				const nextBag  = {
 					...( ( attributes.states as StateBag | null | undefined ) ?? {} ),
 					_scopeId: nextId,
 				}
 
 				setAttributes( { states: nextBag } )
-			}, [ supportsStates, scopeId, paths, attributes.states, setAttributes ] )
+			}, [ supportsStates, scopeId, paths, attributes.states, setAttributes, clientId ] )
+
+			// Release the scope id when this block instance unmounts so
+			// later blocks can re-use it cleanly. The ledger only needs
+			// to enforce uniqueness *within the lifetime of the editor
+			// tree*; once the owning block is gone, the scope id is
+			// free again.
+			useEffect( () => {
+				if ( ! scopeId ) {
+					return
+				}
+
+				return () => releaseScopeId( scopeId, clientId )
+			}, [ scopeId, clientId ] )
 
 			const effectiveScopeId = scopeId ?? persistedRef.current
 
@@ -163,7 +212,7 @@ export const withStateStyles = createHigherOrderComponent(
 					return ''
 				}
 
-				return emitStateCss( `.${ scopeIdToClass( effectiveScopeId ) }`, paths, REGISTRY )
+				return emitStateCss( `.${ scopeIdToClass( effectiveScopeId ) }`, paths, getStateRegistry() )
 			}, [ supportsStates, effectiveScopeId, paths ] )
 
 			const effectiveWrapperProps: Record<string, unknown> = useMemo( () => {
@@ -214,12 +263,23 @@ export const withStateStyles = createHigherOrderComponent(
 	'withStateStyles',
 )
 
+/**
+ * Returns true only when the block's `supports.artisanpackStates`
+ * carries a truthy value (object or `true`). Key-only checks would
+ * green-light blocks that explicitly opted out via
+ * `supports.artisanpackStates: false`.
+ */
+function blockSupportsConfig( blockType: BlockSettingsLike | undefined ): boolean {
+	const support = blockType?.supports?.artisanpackStates
+	return Boolean( support )
+}
+
 function addSaveProps(
 	extraProps: Record<string, unknown>,
 	blockType: BlockSettingsLike,
 	attributes: Record<string, unknown>,
 ): Record<string, unknown> {
-	if ( ! blockType?.supports || ! ( 'artisanpackStates' in blockType.supports ) ) {
+	if ( ! blockSupportsConfig( blockType ) ) {
 		return extraProps
 	}
 
@@ -246,7 +306,7 @@ function wrapSaveElement(
 	blockType: BlockSettingsLike,
 	attributes: Record<string, unknown>,
 ): unknown {
-	if ( ! blockType?.supports || ! ( 'artisanpackStates' in blockType.supports ) ) {
+	if ( ! blockSupportsConfig( blockType ) ) {
 		return element
 	}
 
@@ -255,13 +315,13 @@ function wrapSaveElement(
 		return element
 	}
 
-	const css = emitStateCss( `.${ scopeIdToClass( scopeId ) }`, paths, REGISTRY )
+	const css = emitStateCss( `.${ scopeIdToClass( scopeId ) }`, paths, getStateRegistry() )
 	if ( '' === css ) {
 		return element
 	}
 
 	return createElement( Fragment, null,
-		element,
+		element as ReactNode,
 		createElement( 'style', { 'data-ap-state-scope': scopeId }, css ),
 	)
 }

--- a/resources/js/visual-editor/states/with-state-styles.tsx
+++ b/resources/js/visual-editor/states/with-state-styles.tsx
@@ -1,0 +1,284 @@
+/**
+ * State CSS emission (#488).
+ *
+ * Wires the JS `emitStateCss()` helper to:
+ *
+ *  1. **The editor canvas** — `editor.BlockListBlock` HOC. Computes a
+ *     stable scope class per `clientId`, injects a `<style>` element
+ *     into the block wrapper, and stamps the scope class onto the
+ *     wrapper props so the rules actually match.
+ *
+ *  2. **Saved markup** — `blocks.getSaveContent.extraProps` stamps the
+ *     scope class on the block root, and `blocks.getSaveElement`
+ *     wraps the saved tree with a sibling `<style>` element so the
+ *     same rules ride along into the published page. No server-side
+ *     renderer changes required for the v1.0 surface.
+ *
+ * The scope class is derived from a stable per-block id stored on
+ * `attributes.states._scopeId`. The HOC mints one the first time a
+ * block carries any state override; downstream reads use whatever id
+ * is already there. Storing it on the attributes (rather than
+ * regenerating each render) keeps the editor and save markup in
+ * lockstep so editor previews always reflect the published output.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.0.0
+ */
+
+import { hasBlockSupport, getBlockType } from '@wordpress/blocks'
+import { createHigherOrderComponent } from '@wordpress/compose'
+import { addFilter } from '@wordpress/hooks'
+import { Fragment, createElement, useEffect, useMemo, useRef } from 'react'
+import type { ComponentType } from 'react'
+
+import { emitStateCss, type StatesByPath } from './css-emitter'
+import { DEFAULT_STATES, StateRegistry } from './registry'
+
+const BLOCK_FILTER_HOOK = 'editor.BlockListBlock'
+const SAVE_PROPS_HOOK   = 'blocks.getSaveContent.extraProps'
+const SAVE_ELEMENT_HOOK = 'blocks.getSaveElement'
+
+const FILTER_NAMESPACE = 'artisanpack-ui/visual-editor/state-styles'
+
+const REGISTERED_KEY = Symbol.for(
+	'artisanpack-ui.visual-editor.state-styles.registered',
+)
+
+interface GlobalSentinelHost {
+	[REGISTERED_KEY]?: boolean
+}
+
+interface StateBag {
+	_scopeId?: string
+	[path: string]: unknown
+}
+
+interface BlockListBlockProps {
+	name: string
+	clientId: string
+	attributes: Record<string, unknown>
+	setAttributes?: ( updates: Record<string, unknown> ) => void
+	wrapperProps?: Record<string, unknown>
+	[key: string]: unknown
+}
+
+interface BlockSettingsLike {
+	supports?: Record<string, unknown>
+	attributes?: Record<string, unknown>
+	[key: string]: unknown
+}
+
+// Re-use the same default registry the HOC overlays against so the
+// emitted CSS lines up with what the inspector controls write.
+const REGISTRY = new StateRegistry( DEFAULT_STATES )
+
+function blockSupportsStates( name: string ): boolean {
+	const blockType = getBlockType( name )
+	if ( ! blockType ) {
+		return false
+	}
+
+	return hasBlockSupport( blockType, 'artisanpackStates', false )
+}
+
+/**
+ * Split the `_scopeId` housekeeping field out of the state bag so the
+ * CSS emitter only sees attribute-path keys.
+ */
+function partitionStates( bag: unknown ): { scopeId: string | null; paths: StatesByPath } {
+	if ( ! bag || 'object' !== typeof bag || Array.isArray( bag ) ) {
+		return { scopeId: null, paths: {} }
+	}
+
+	const { _scopeId, ...paths } = bag as StateBag
+	return {
+		scopeId: 'string' === typeof _scopeId && '' !== _scopeId ? _scopeId : null,
+		paths:   paths as StatesByPath,
+	}
+}
+
+function scopeIdToClass( scopeId: string ): string {
+	return `ap-state-${ scopeId }`
+}
+
+function hasAuthoredOverrides( paths: StatesByPath ): boolean {
+	for ( const value of Object.values( paths ) ) {
+		if ( value && 'object' === typeof value && ! Array.isArray( value ) ) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// `Math.random()` is fine here — collisions only matter within a
+// single page and 36^9 ≈ 10^14 keeps the birthday-paradox floor well
+// above any realistic block count.
+function mintScopeId(): string {
+	return Math.random().toString( 36 ).slice( 2, 11 )
+}
+
+export const withStateStyles = createHigherOrderComponent(
+	( BlockListBlock: ComponentType<BlockListBlockProps> ) => {
+		function StateStyledBlock( props: BlockListBlockProps ): JSX.Element {
+			const { name, attributes, setAttributes, wrapperProps } = props
+
+			// Compute support up front, then run every hook unconditionally —
+			// the React Rules of Hooks require a stable hook order across
+			// renders, so the gated branch must come after the hook calls.
+			const supportsStates = blockSupportsStates( name )
+
+			const { scopeId, paths } = useMemo(
+				() => partitionStates( attributes.states ),
+				[ attributes.states ],
+			)
+
+			// Once a block has authored any state overrides, persist a
+			// stable scope id so editor + save markup stay in lockstep.
+			// Skipped when the block has no overrides yet — keeps unused
+			// blocks from accumulating noise in their attribute trees.
+			const persistedRef = useRef( scopeId )
+			useEffect( () => {
+				persistedRef.current = scopeId
+			}, [ scopeId ] )
+
+			useEffect( () => {
+				if ( ! supportsStates || scopeId || ! hasAuthoredOverrides( paths ) || ! setAttributes ) {
+					return
+				}
+
+				const nextId   = mintScopeId()
+				const nextBag  = {
+					...( ( attributes.states as StateBag | null | undefined ) ?? {} ),
+					_scopeId: nextId,
+				}
+
+				setAttributes( { states: nextBag } )
+			}, [ supportsStates, scopeId, paths, attributes.states, setAttributes ] )
+
+			const effectiveScopeId = scopeId ?? persistedRef.current
+
+			const css = useMemo( () => {
+				if ( ! supportsStates || ! effectiveScopeId ) {
+					return ''
+				}
+
+				return emitStateCss( `.${ scopeIdToClass( effectiveScopeId ) }`, paths, REGISTRY )
+			}, [ supportsStates, effectiveScopeId, paths ] )
+
+			const effectiveWrapperProps: Record<string, unknown> = useMemo( () => {
+				if ( ! supportsStates || ! effectiveScopeId ) {
+					return wrapperProps ?? {}
+				}
+
+				const existingClass = ( wrapperProps?.className as string | undefined ) ?? ''
+				const scopeClass    = scopeIdToClass( effectiveScopeId )
+
+				if ( existingClass.split( ' ' ).includes( scopeClass ) ) {
+					return wrapperProps ?? {}
+				}
+
+				return {
+					...( wrapperProps ?? {} ),
+					className: existingClass ? `${ existingClass } ${ scopeClass }` : scopeClass,
+				}
+			}, [ supportsStates, wrapperProps, effectiveScopeId ] )
+
+			if ( ! supportsStates ) {
+				return <BlockListBlock { ...props } />
+			}
+
+			const wrapped = (
+				<BlockListBlock
+					{ ...props }
+					wrapperProps={ effectiveWrapperProps }
+				/>
+			)
+
+			if ( '' === css ) {
+				return wrapped
+			}
+
+			return (
+				<Fragment>
+					<style data-ap-state-scope={ effectiveScopeId }>{ css }</style>
+					{ wrapped }
+				</Fragment>
+			)
+		}
+
+		StateStyledBlock.displayName = 'StateStyledBlock'
+
+		return StateStyledBlock
+	},
+	'withStateStyles',
+)
+
+function addSaveProps(
+	extraProps: Record<string, unknown>,
+	blockType: BlockSettingsLike,
+	attributes: Record<string, unknown>,
+): Record<string, unknown> {
+	if ( ! blockType?.supports || ! ( 'artisanpackStates' in blockType.supports ) ) {
+		return extraProps
+	}
+
+	const { scopeId } = partitionStates( attributes.states )
+	if ( ! scopeId ) {
+		return extraProps
+	}
+
+	const existingClass = ( extraProps.className as string | undefined ) ?? ''
+	const scopeClass    = scopeIdToClass( scopeId )
+
+	if ( existingClass.split( ' ' ).includes( scopeClass ) ) {
+		return extraProps
+	}
+
+	return {
+		...extraProps,
+		className: existingClass ? `${ existingClass } ${ scopeClass }` : scopeClass,
+	}
+}
+
+function wrapSaveElement(
+	element: unknown,
+	blockType: BlockSettingsLike,
+	attributes: Record<string, unknown>,
+): unknown {
+	if ( ! blockType?.supports || ! ( 'artisanpackStates' in blockType.supports ) ) {
+		return element
+	}
+
+	const { scopeId, paths } = partitionStates( attributes.states )
+	if ( ! scopeId || ! hasAuthoredOverrides( paths ) ) {
+		return element
+	}
+
+	const css = emitStateCss( `.${ scopeIdToClass( scopeId ) }`, paths, REGISTRY )
+	if ( '' === css ) {
+		return element
+	}
+
+	return createElement( Fragment, null,
+		element,
+		createElement( 'style', { 'data-ap-state-scope': scopeId }, css ),
+	)
+}
+
+/**
+ * Idempotent — safe to call from both the post-editor and site-editor
+ * bootstrap paths. Late callers see the sentinel and no-op.
+ */
+export function registerStateStylesFilters(): void {
+	const host = globalThis as unknown as GlobalSentinelHost
+
+	if ( host[ REGISTERED_KEY ] ) {
+		return
+	}
+
+	addFilter( BLOCK_FILTER_HOOK, FILTER_NAMESPACE, withStateStyles )
+	addFilter( SAVE_PROPS_HOOK, FILTER_NAMESPACE, addSaveProps )
+	addFilter( SAVE_ELEMENT_HOOK, FILTER_NAMESPACE, wrapSaveElement )
+	host[ REGISTERED_KEY ] = true
+}

--- a/src/States/InheritanceChainValidator.php
+++ b/src/States/InheritanceChainValidator.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * Inheritance-chain validator (#488).
+ *
+ * Standalone cycle-detector for the {@see StateRegistry}'s
+ * `inheritsFrom` graph. Pulled out of the registry so the same
+ * logic can run on a candidate map BEFORE we accept it (CI lint of a
+ * `theme.json`, for example).
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\States;
+
+use InvalidArgumentException;
+
+class InheritanceChainValidator
+{
+	/**
+	 * Asserts that every state in the map terminates at `idle` and
+	 * forms no cycles. Throws on the first offending key.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array<string, array{inheritsFrom?: ?string}>  $states
+	 */
+	public function assertAcyclic( array $states ): void
+	{
+		foreach ( array_keys( $states ) as $key ) {
+			$this->walk( $states, $key );
+		}
+	}
+
+	/**
+	 * Walks a single chain, tripping on cycle / unterminated chain.
+	 *
+	 * @param  array<string, array{inheritsFrom?: ?string}>  $states
+	 */
+	protected function walk( array $states, string $start ): void
+	{
+		if ( StateRegistry::BASE_KEY === $start ) {
+			return;
+		}
+
+		$seen    = [];
+		$current = $start;
+
+		while ( null !== $current ) {
+			if ( isset( $seen[ $current ] ) ) {
+				throw new InvalidArgumentException( sprintf(
+					'State "%s" has a circular inheritance chain: %s.',
+					$start,
+					implode( ' → ', array_keys( $seen ) ) . ' → ' . $current
+				) );
+			}
+
+			$seen[ $current ] = true;
+
+			if ( StateRegistry::BASE_KEY === $current ) {
+				return;
+			}
+
+			if ( ! array_key_exists( $current, $states ) ) {
+				throw new InvalidArgumentException( sprintf(
+					'State "%s" inherits from "%s", which is not registered.',
+					$start,
+					$current
+				) );
+			}
+
+			$current = $states[ $current ]['inheritsFrom'] ?? null;
+		}
+
+		throw new InvalidArgumentException( sprintf(
+			'State "%s" chain does not terminate at "%s".',
+			$start,
+			StateRegistry::BASE_KEY
+		) );
+	}
+}

--- a/src/States/StateAttributeMigrator.php
+++ b/src/States/StateAttributeMigrator.php
@@ -1,0 +1,135 @@
+<?php
+
+/**
+ * State attribute migrator — lazy scalar → stateful promotion (#488).
+ *
+ * Blocks store state-capable attributes as either:
+ *  - a scalar (legacy / unchanged content), or
+ *  - a stateful `{ idle, hover, focus, … }` object once any per-state
+ *    override is applied.
+ *
+ * The editor calls {@see promote()} the first time an editor sets a
+ * value at a non-`idle` state, lifting the scalar into the
+ * discriminated form without rewriting unrelated content. Reads stay
+ * backwards-compatible because the resolver accepts both shapes.
+ *
+ * Demoting is the symmetric operation — if every override is cleared
+ * back to inheriting `idle`, {@see demote()} collapses the object
+ * back to the scalar so saved JSON stays compact.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\States;
+
+class StateAttributeMigrator
+{
+	/**
+	 * Promotes a scalar (or untouched mixed value) into the stateful
+	 * object form, copying the existing value to `idle` and writing
+	 * `$value` at `$state`. The remaining states are left absent
+	 * (i.e. inherit through the chain).
+	 *
+	 * If `$attribute` is already a stateful object, the existing keys
+	 * are preserved and the new override slot is merged in.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  mixed   $attribute
+	 * @param  string  $state      State slug receiving the override
+	 *                             (e.g. `hover`). `idle` writes the base
+	 *                             value directly without promotion.
+	 * @param  mixed   $value
+	 *
+	 * @return array<string, mixed>|mixed
+	 */
+	public function promote( $attribute, string $state, $value )
+	{
+		if ( StateRegistry::BASE_KEY === $state && ! $this->isStatefulObject( $attribute ) ) {
+			return $value;
+		}
+
+		$promoted = $this->isStatefulObject( $attribute )
+			? $attribute
+			: [ StateRegistry::BASE_KEY => $attribute ];
+
+		$promoted[ $state ] = $value;
+
+		return $promoted;
+	}
+
+	/**
+	 * Collapses a stateful object back to its scalar `idle` value if
+	 * no per-state overrides remain set (all are `null` or missing).
+	 * Returns the attribute untouched otherwise.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  mixed  $attribute
+	 *
+	 * @return mixed
+	 */
+	public function demote( $attribute )
+	{
+		if ( ! $this->isStatefulObject( $attribute ) ) {
+			return $attribute;
+		}
+
+		foreach ( $attribute as $key => $value ) {
+			if ( StateRegistry::BASE_KEY === $key ) {
+				continue;
+			}
+
+			if ( null !== $value ) {
+				return $attribute;
+			}
+		}
+
+		return $attribute[ StateRegistry::BASE_KEY ] ?? null;
+	}
+
+	/**
+	 * Clears a specific state's override, returning the attribute
+	 * back to inheriting at that slot. If clearing the last remaining
+	 * override, the attribute is demoted back to its scalar form.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  mixed   $attribute
+	 * @param  string  $state
+	 *
+	 * @return mixed
+	 */
+	public function clear( $attribute, string $state )
+	{
+		if ( ! $this->isStatefulObject( $attribute ) ) {
+			return $attribute;
+		}
+
+		if ( StateRegistry::BASE_KEY === $state ) {
+			$attribute[ StateRegistry::BASE_KEY ] = null;
+		} else {
+			unset( $attribute[ $state ] );
+		}
+
+		return $this->demote( $attribute );
+	}
+
+	/**
+	 * @param  mixed  $attribute
+	 */
+	protected function isStatefulObject( $attribute ): bool
+	{
+		return is_array( $attribute )
+			&& [] !== $attribute
+			&& ! array_is_list( $attribute )
+			&& array_key_exists( StateRegistry::BASE_KEY, $attribute );
+	}
+}

--- a/src/States/StateCssEmitter.php
+++ b/src/States/StateCssEmitter.php
@@ -185,11 +185,19 @@ class StateCssEmitter
 				// `attributes.states` bag could shape its leaves as
 				// arrays/objects, and casting those to string produces
 				// PHP notices and "Array" literals in the emitted CSS.
-				if ( null === $resolved || '' === $resolved || ! is_scalar( $resolved ) ) {
+				// Booleans pass `is_scalar()` but cast to `''`/`1`, which
+				// would emit invalid CSS like `background-color: 1;` —
+				// drop them too.
+				if ( null === $resolved || ! is_scalar( $resolved ) || is_bool( $resolved ) ) {
 					continue;
 				}
 
-				$buckets[ $state ][ $property ] = (string) $resolved;
+				$value = is_string( $resolved ) ? $resolved : (string) $resolved;
+				if ( '' === $value ) {
+					continue;
+				}
+
+				$buckets[ $state ][ $property ] = $value;
 			}
 		}
 

--- a/src/States/StateCssEmitter.php
+++ b/src/States/StateCssEmitter.php
@@ -1,0 +1,253 @@
+<?php
+
+/**
+ * State CSS emitter (#488).
+ *
+ * Server-side helper that turns a per-block bag of stateful attribute
+ * values into the scoped CSS rules the renderer ships with the
+ * published page. Produces standard `:hover` / `:focus-visible` etc.
+ * selectors against a unique class scope (`.ap-block-<uid>`) so the
+ * page has no JS runtime requirement for state styling.
+ *
+ * Hover rules are automatically wrapped in `@media (hover: hover)` so
+ * touch devices don't sticky-state on tap.
+ *
+ * Inheritance pruning is delegated to {@see StateValueResolver::distinctOverrides()}
+ * — only states whose resolved value differs from their inheritance
+ * parent emit a rule.
+ *
+ * Where a value maps to a Tailwind token (e.g. `bg-accent-700` would
+ * be emitted as the Tailwind class `hover:bg-accent-700` by the
+ * editor), the emitter still emits the equivalent CSS rule so server-
+ * side renderers without the Tailwind JIT keep working. Hosts that
+ * use the editor's class-string emission can ignore this entirely.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\States;
+
+class StateCssEmitter
+{
+	/**
+	 * Default `transition: ...` value emitted on the idle slot when
+	 * any non-idle state is set and no explicit transition has been
+	 * authored. Keeps interactive feedback feeling smooth out of the
+	 * box.
+	 */
+	public const DEFAULT_TRANSITION = 'all 150ms ease';
+
+	public function __construct(
+		protected StateRegistry $registry,
+		protected StateValueResolver $resolver,
+	) {}
+
+	/**
+	 * Emits a CSS string for a single block scope.
+	 *
+	 * `$attributes` is a flat map of CSS property → stateful value:
+	 *
+	 *     [
+	 *         'background-color' => [ 'idle' => 'red', 'hover' => 'blue' ],
+	 *         'transform'        => [ 'idle' => null,  'hover' => 'scale(1.02)' ],
+	 *     ]
+	 *
+	 * Plain scalar values are also accepted and emitted as the `idle`
+	 * value only.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string                                              $scope       CSS scope, e.g. `.ap-block-abc123`.
+	 *                                                                          Must already include the leading `.`.
+	 * @param  array<string, mixed>                                $attributes  property => attribute value.
+	 *
+	 * @return string The emitted CSS — empty string when nothing is
+	 *                worth emitting.
+	 */
+	public function emit( string $scope, array $attributes ): string
+	{
+		if ( '' === trim( $scope ) ) {
+			return '';
+		}
+
+		$buckets = $this->bucketByState( $attributes );
+
+		if ( [] === $buckets ) {
+			return '';
+		}
+
+		$idleRule  = $this->renderIdleRule( $scope, $buckets[ StateRegistry::BASE_KEY ] ?? [], $buckets );
+		$stateCss  = '';
+		$hoverCss  = '';
+
+		foreach ( $this->registry->keys() as $state ) {
+			if ( StateRegistry::BASE_KEY === $state ) {
+				continue;
+			}
+
+			$declarations = $buckets[ $state ] ?? [];
+			if ( [] === $declarations ) {
+				continue;
+			}
+
+			$definition = $this->registry->get( $state );
+			$selector   = $this->selectorFor( $scope, $definition );
+
+			if ( '' === $selector ) {
+				continue;
+			}
+
+			$rule = sprintf( "%s { %s }", $selector, $this->joinDeclarations( $declarations ) );
+
+			if ( ! empty( $definition['hoverMediaWrap'] ) ) {
+				$hoverCss .= ( '' === $hoverCss ? '' : ' ' ) . $rule;
+				continue;
+			}
+
+			$stateCss .= ( '' === $stateCss ? '' : ' ' ) . $rule;
+		}
+
+		$out = $idleRule;
+
+		if ( '' !== $hoverCss ) {
+			$out .= ( '' === $out ? '' : ' ' ) . sprintf( '@media (hover: hover) { %s }', $hoverCss );
+		}
+
+		if ( '' !== $stateCss ) {
+			$out .= ( '' === $out ? '' : ' ' ) . $stateCss;
+		}
+
+		return $out;
+	}
+
+	/**
+	 * Builds the idle-rule string, injecting a default transition
+	 * when the editor never set one and there is at least one
+	 * non-idle override.
+	 *
+	 * @param  array<string, string>                $idleDeclarations
+	 * @param  array<string, array<string, string>>  $allBuckets
+	 */
+	protected function renderIdleRule( string $scope, array $idleDeclarations, array $allBuckets ): string
+	{
+		$hasNonIdleOverride = false;
+		foreach ( $allBuckets as $stateKey => $declarations ) {
+			if ( StateRegistry::BASE_KEY === $stateKey ) {
+				continue;
+			}
+
+			if ( [] !== $declarations ) {
+				$hasNonIdleOverride = true;
+				break;
+			}
+		}
+
+		if ( $hasNonIdleOverride && ! array_key_exists( 'transition', $idleDeclarations ) ) {
+			$idleDeclarations['transition'] = self::DEFAULT_TRANSITION;
+		}
+
+		if ( [] === $idleDeclarations ) {
+			return '';
+		}
+
+		return sprintf( '%s { %s }', $scope, $this->joinDeclarations( $idleDeclarations ) );
+	}
+
+	/**
+	 * Converts the property-keyed attribute bag into a state-keyed
+	 * bucket of CSS declarations after running each attribute through
+	 * the resolver's `distinctOverrides()`.
+	 *
+	 * @param  array<string, mixed>  $attributes
+	 *
+	 * @return array<string, array<string, string>>
+	 */
+	protected function bucketByState( array $attributes ): array
+	{
+		$buckets = [];
+
+		foreach ( $attributes as $property => $value ) {
+			if ( ! is_string( $property ) || '' === trim( $property ) ) {
+				continue;
+			}
+
+			$overrides = $this->resolver->distinctOverrides( $value );
+
+			foreach ( $overrides as $state => $resolved ) {
+				// Guard against non-scalar overrides — a malformed
+				// `attributes.states` bag could shape its leaves as
+				// arrays/objects, and casting those to string produces
+				// PHP notices and "Array" literals in the emitted CSS.
+				if ( null === $resolved || '' === $resolved || ! is_scalar( $resolved ) ) {
+					continue;
+				}
+
+				$buckets[ $state ][ $property ] = (string) $resolved;
+			}
+		}
+
+		return $buckets;
+	}
+
+	/**
+	 * Resolves the literal selector for a state definition against
+	 * the block scope. Replaces `&` with the scope so theme authors
+	 * can compose selectors like `&[aria-current="page"]`.
+	 *
+	 * @param  array{selector: string}  $definition
+	 */
+	protected function selectorFor( string $scope, array $definition ): string
+	{
+		$selector = $definition['selector'] ?? '';
+		if ( '' === $selector ) {
+			return '';
+		}
+
+		// Allow comma-separated selector lists.
+		$pieces = array_map( 'trim', explode( ',', $selector ) );
+		$mapped = [];
+
+		foreach ( $pieces as $piece ) {
+			if ( '' === $piece ) {
+				continue;
+			}
+
+			$mapped[] = str_contains( $piece, '&' )
+				? str_replace( '&', $scope, $piece )
+				: $scope . $piece;
+		}
+
+		return implode( ', ', $mapped );
+	}
+
+	/**
+	 * Properties that should NOT carry `!important` — `transition` is
+	 * the only one in the v1.0 set; an `!important` transition can't
+	 * be cancelled by host CSS, which is rarely what an author wants.
+	 *
+	 * @var array<int, string>
+	 */
+	protected const NEVER_IMPORTANT = [ 'transition' ];
+
+	/**
+	 * @param  array<string, string>  $declarations
+	 */
+	protected function joinDeclarations( array $declarations ): string
+	{
+		$parts = [];
+
+		foreach ( $declarations as $property => $value ) {
+			$important = in_array( $property, self::NEVER_IMPORTANT, true ) ? '' : ' !important';
+			$parts[]   = sprintf( '%s: %s%s;', $property, $value, $important );
+		}
+
+		return implode( ' ', $parts );
+	}
+}

--- a/src/States/StateRegistry.php
+++ b/src/States/StateRegistry.php
@@ -1,0 +1,347 @@
+<?php
+
+/**
+ * State registry — state design tools (#488).
+ *
+ * Resolves the editor's active set of interactive states by merging
+ * the host theme's declarations into the application's `config()`
+ * overrides and finally the package's built-in defaults. Highest
+ * layer wins on key collision:
+ *
+ *   1. theme.json → `settings.custom.artisanpack.states`
+ *   2. application config → `artisanpack.visual-editor.states`
+ *   3. package defaults  → idle / hover / focus / focus-visible /
+ *                          active / disabled
+ *
+ * States are merged by key via `array_replace_recursive()` — a theme
+ * that adds a new `aria-current` key augments the registry; omitting
+ * a key keeps the lower layer's value. To REMOVE a state, set it to
+ * `null` after the merge.
+ *
+ * The `idle` slot is the base of every inheritance chain — it has no
+ * pseudo-selector and is the value the renderer emits as the
+ * default (no `:hover`, no `:focus`, no media wrap). It cannot be
+ * removed or aliased.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\States;
+
+use InvalidArgumentException;
+
+class StateRegistry
+{
+	/**
+	 * The reserved base-slot key — every inheritance chain bottoms out
+	 * here.
+	 */
+	public const BASE_KEY = 'idle';
+
+	/**
+	 * Built-in state definitions. Inheritance chains read top-down:
+	 * `active` cascades through `hover` then `idle`; `focus-visible`
+	 * cascades through `focus` then `idle`.
+	 *
+	 * @var array<string, array{label: string, selector: string, icon?: string, inheritsFrom?: string, hoverMediaWrap?: bool}>
+	 */
+	public const DEFAULTS = [
+		'idle' => [
+			'label'    => 'Idle',
+			'selector' => '',
+			'icon'     => 'circle',
+		],
+		'hover' => [
+			'label'          => 'Hover',
+			'selector'       => '&:hover',
+			'icon'           => 'cursor',
+			'inheritsFrom'   => 'idle',
+			'hoverMediaWrap' => true,
+		],
+		'focus' => [
+			'label'        => 'Focus',
+			'selector'     => '&:focus',
+			'icon'         => 'target',
+			'inheritsFrom' => 'idle',
+		],
+		'focus-visible' => [
+			'label'        => 'Focus visible',
+			'selector'     => '&:focus-visible',
+			'icon'         => 'target-arrow',
+			'inheritsFrom' => 'focus',
+		],
+		'active' => [
+			'label'        => 'Active',
+			'selector'     => '&:active',
+			'icon'         => 'click',
+			'inheritsFrom' => 'hover',
+		],
+		'disabled' => [
+			'label'        => 'Disabled',
+			'selector'     => '&:disabled, &[aria-disabled="true"]',
+			'icon'         => 'block',
+			'inheritsFrom' => 'idle',
+		],
+	];
+
+	/**
+	 * Maximum number of links in an inheritance chain before the
+	 * validator gives up. Catches cycles and pathological depth.
+	 */
+	protected const MAX_CHAIN_DEPTH = 16;
+
+	/**
+	 * Resolved, validated registry.
+	 *
+	 * @var array<string, array{key: string, label: string, selector: string, icon: string, inheritsFrom: ?string, hoverMediaWrap: bool}>
+	 */
+	protected array $states;
+
+	/**
+	 * @param  array<string, array<string, mixed>>  $raw  Pre-resolved
+	 *                                                    state map. Pass
+	 *                                                    {@see fromLayers()}'s
+	 *                                                    output in
+	 *                                                    production.
+	 */
+	public function __construct( array $raw = [] )
+	{
+		$this->states = $this->validate( $raw );
+	}
+
+	/**
+	 * Builds a registry from the application's merged config + an
+	 * optional `theme.json`-derived overrides array. Use this from the
+	 * service provider; tests can also construct directly.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array<string, mixed>|null  $configOverrides  Defaults to
+	 *                                                      `config('artisanpack.visual-editor.states')`.
+	 * @param  array<string, mixed>       $themeOverrides   `settings.custom.artisanpack.states`
+	 *                                                      from the active
+	 *                                                      `theme.json`.
+	 */
+	public static function fromLayers( ?array $configOverrides = null, array $themeOverrides = [] ): self
+	{
+		$config = $configOverrides ?? ( function_exists( 'config' )
+			? (array) config( 'artisanpack.visual-editor.states', [] )
+			: [] );
+
+		$merged = array_replace_recursive( self::DEFAULTS, $config, $themeOverrides );
+
+		// Allow explicit `null` overrides to drop a built-in state.
+		$cleaned = array_filter( $merged, static fn ( $value ) => null !== $value );
+
+		return new self( $cleaned );
+	}
+
+	/**
+	 * Returns every registered state keyed by slug. `idle` is always
+	 * first so iteration follows the inheritance-base-first order.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<string, array{key: string, label: string, selector: string, icon: string, inheritsFrom: ?string, hoverMediaWrap: bool}>
+	 */
+	public function all(): array
+	{
+		return $this->states;
+	}
+
+	/**
+	 * Returns the definition for a single state, or `null` if the key
+	 * isn't registered.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array{key: string, label: string, selector: string, icon: string, inheritsFrom: ?string, hoverMediaWrap: bool}|null
+	 */
+	public function get( string $key ): ?array
+	{
+		return $this->states[ $key ] ?? null;
+	}
+
+	/**
+	 * Returns just the state keys in registry order — convenient for
+	 * iterating renderer emission or building the inspector switcher.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<int, string>
+	 */
+	public function keys(): array
+	{
+		return array_keys( $this->states );
+	}
+
+	/**
+	 * Checks membership.
+	 *
+	 * @since 1.0.0
+	 */
+	public function has( string $key ): bool
+	{
+		return array_key_exists( $key, $this->states );
+	}
+
+	/**
+	 * Returns the chain of state keys to walk when resolving an
+	 * attribute value at the given state, starting at `$state` itself
+	 * and following `inheritsFrom` links until `idle`. Unknown states
+	 * collapse to `[idle]`.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<int, string>
+	 */
+	public function inheritanceChain( string $state ): array
+	{
+		if ( self::BASE_KEY === $state || ! $this->has( $state ) ) {
+			return [ self::BASE_KEY ];
+		}
+
+		$chain   = [];
+		$current = $state;
+		$depth   = 0;
+
+		while ( null !== $current && $depth < self::MAX_CHAIN_DEPTH ) {
+			$chain[] = $current;
+
+			if ( self::BASE_KEY === $current ) {
+				return $chain;
+			}
+
+			$definition = $this->states[ $current ] ?? null;
+			$current    = $definition['inheritsFrom'] ?? null;
+			$depth++;
+		}
+
+		// Always terminate at `idle` so the resolver has a fall-through.
+		if ( ! in_array( self::BASE_KEY, $chain, true ) ) {
+			$chain[] = self::BASE_KEY;
+		}
+
+		return $chain;
+	}
+
+	/**
+	 * Normalizes a raw state map and verifies invariants:
+	 *  - `idle` must be present and have no selector.
+	 *  - Every state must declare a non-empty `label`.
+	 *  - Selectors must be non-empty strings (except `idle`'s, which
+	 *    must be empty).
+	 *  - Inheritance chains must terminate at `idle` and contain no
+	 *    cycles.
+	 *
+	 * Throws on the first failure with a descriptive message so theme
+	 * authors get actionable feedback when their `theme.json` is bad.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array<string, mixed>  $raw
+	 *
+	 * @return array<string, array{key: string, label: string, selector: string, icon: string, inheritsFrom: ?string, hoverMediaWrap: bool}>
+	 */
+	public function validate( array $raw ): array
+	{
+		if ( ! isset( $raw[ self::BASE_KEY ] ) ) {
+			throw new InvalidArgumentException( sprintf(
+				'State registry is missing the reserved "%s" base state.',
+				self::BASE_KEY
+			) );
+		}
+
+		$normalized = [];
+
+		foreach ( $raw as $key => $definition ) {
+			if ( ! is_string( $key ) || '' === trim( $key ) ) {
+				throw new InvalidArgumentException( 'State key must be a non-empty string.' );
+			}
+
+			if ( 1 !== preg_match( '/^[a-z0-9][a-z0-9_:-]*$/i', $key ) ) {
+				throw new InvalidArgumentException( sprintf(
+					'State key "%s" must contain only letters, numbers, hyphens, underscores, or colons.',
+					$key
+				) );
+			}
+
+			if ( ! is_array( $definition ) ) {
+				throw new InvalidArgumentException( sprintf(
+					'State "%s" must be defined as an associative array.',
+					$key
+				) );
+			}
+
+			$label = $definition['label'] ?? '';
+			if ( ! is_string( $label ) || '' === trim( $label ) ) {
+				throw new InvalidArgumentException( sprintf(
+					'State "%s" must declare a non-empty `label`.',
+					$key
+				) );
+			}
+
+			$selector = $definition['selector'] ?? '';
+			if ( self::BASE_KEY === $key ) {
+				if ( '' !== $selector ) {
+					throw new InvalidArgumentException( sprintf(
+						'The reserved "%s" state must have an empty selector — it is the base slot.',
+						self::BASE_KEY
+					) );
+				}
+			} else {
+				if ( ! is_string( $selector ) || '' === trim( $selector ) ) {
+					throw new InvalidArgumentException( sprintf(
+						'State "%s" must declare a non-empty `selector`.',
+						$key
+					) );
+				}
+			}
+
+			$inheritsFrom = $definition['inheritsFrom'] ?? null;
+
+			if ( self::BASE_KEY === $key ) {
+				$inheritsFrom = null;
+			} elseif ( null !== $inheritsFrom ) {
+				if ( ! is_string( $inheritsFrom ) || '' === trim( $inheritsFrom ) ) {
+					throw new InvalidArgumentException( sprintf(
+						'State "%s" `inheritsFrom` must be a non-empty string or null.',
+						$key
+					) );
+				}
+
+				if ( ! array_key_exists( $inheritsFrom, $raw ) ) {
+					throw new InvalidArgumentException( sprintf(
+						'State "%s" inherits from "%s", which is not registered.',
+						$key,
+						$inheritsFrom
+					) );
+				}
+			}
+
+			$normalized[ $key ] = [
+				'key'            => $key,
+				'label'          => $label,
+				'selector'       => is_string( $selector ) ? $selector : '',
+				'icon'           => is_string( $definition['icon'] ?? null ) ? $definition['icon'] : '',
+				'inheritsFrom'   => $inheritsFrom,
+				'hoverMediaWrap' => (bool) ( $definition['hoverMediaWrap'] ?? false ),
+			];
+		}
+
+		( new InheritanceChainValidator() )->assertAcyclic( $normalized );
+
+		// Hoist `idle` to the front so iteration order is stable.
+		$idle  = $normalized[ self::BASE_KEY ];
+		unset( $normalized[ self::BASE_KEY ] );
+
+		return [ self::BASE_KEY => $idle ] + $normalized;
+	}
+}

--- a/src/States/StateValueResolver.php
+++ b/src/States/StateValueResolver.php
@@ -1,0 +1,216 @@
+<?php
+
+/**
+ * State value resolver — inheritance-chain cascade (#488).
+ *
+ * Given an attribute stored as a stateful object
+ * `{ idle: …, hover: …, focus-visible: null }` and an active state,
+ * returns the value the editor or renderer should show.
+ *
+ * Cascade semantics:
+ *  - `idle` is the base; it applies anywhere a more specific state
+ *    has no explicit override.
+ *  - A named state applies in its CSS selector context only.
+ *  - `null` (or a missing key) means "inherit from the next link in
+ *    the inheritance chain." `idle` is the final fallback.
+ *
+ * Scalars (plain ints, strings, …) round-trip through `resolve()`
+ * unchanged — the editor only promotes scalars into the stateful
+ * form on first per-state override, so unmodified content keeps
+ * working without a migration pass.
+ *
+ * Orphaned overrides — values stored under a key that is no longer
+ * registered — are preserved on save but skipped at resolve time.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\States;
+
+class StateValueResolver
+{
+	public function __construct( protected StateRegistry $registry ) {}
+
+	/**
+	 * Resolves the value for a single attribute at the given active
+	 * state.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  mixed   $attribute    Either a scalar (legacy) or a stateful
+	 *                               object array
+	 *                               `{ idle: …, hover: …, focus: … }`.
+	 * @param  string  $activeState  State slug to resolve for. `idle` or
+	 *                               any key in the registry. Unknown
+	 *                               slugs fall back to `idle`.
+	 *
+	 * @return mixed The resolved value, or `null` if no slot in the
+	 *               inheritance chain is defined.
+	 */
+	public function resolve( $attribute, string $activeState = StateRegistry::BASE_KEY )
+	{
+		if ( ! $this->isStatefulAttribute( $attribute ) ) {
+			return $attribute;
+		}
+
+		foreach ( $this->registry->inheritanceChain( $activeState ) as $key ) {
+			if ( ! array_key_exists( $key, $attribute ) ) {
+				continue;
+			}
+
+			$value = $attribute[ $key ];
+
+			if ( null === $value ) {
+				continue;
+			}
+
+			return $value;
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the resolved value at every registered state as a flat
+	 * map keyed by state slug. Used by renderers that need to know
+	 * which states carry distinct values for minimal CSS emission.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function resolveAll( $attribute ): array
+	{
+		$results = [];
+
+		foreach ( $this->registry->keys() as $key ) {
+			$results[ $key ] = $this->resolve( $attribute, $key );
+		}
+
+		return $results;
+	}
+
+	/**
+	 * Compresses a stateful attribute down to only the states whose
+	 * resolved value differs from the value cascaded through the
+	 * inheritance chain. Used by renderers to avoid emitting
+	 * `&:hover { background: red; } &:active { background: red; }`
+	 * when `active` would inherit from `hover` anyway.
+	 *
+	 * Always includes `idle` if it has a non-null value.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<string, mixed>  Sparse map keyed by state slug.
+	 */
+	public function distinctOverrides( $attribute ): array
+	{
+		if ( ! $this->isStatefulAttribute( $attribute ) ) {
+			$attribute = [ StateRegistry::BASE_KEY => $attribute ];
+		}
+
+		$result = [];
+
+		foreach ( $this->registry->keys() as $key ) {
+			$value = $this->resolve( $attribute, $key );
+
+			if ( null === $value ) {
+				continue;
+			}
+
+			if ( StateRegistry::BASE_KEY === $key ) {
+				$result[ $key ] = $value;
+				continue;
+			}
+
+			$definition = $this->registry->get( $key );
+			$parent     = $definition['inheritsFrom'] ?? StateRegistry::BASE_KEY;
+			$parentVal  = $this->resolve( $attribute, $parent );
+
+			if ( $value !== $parentVal ) {
+				$result[ $key ] = $value;
+			}
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Returns true when an attribute is shaped like the stateful
+	 * discriminated object: an associative array containing at least
+	 * `idle` OR at least one registered state key.
+	 *
+	 * Plain numeric-indexed arrays (which Gutenberg uses for things
+	 * like `gallery.ids`) return false — they are not per-state objects.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  mixed  $attribute
+	 */
+	public function isStatefulAttribute( $attribute ): bool
+	{
+		if ( ! is_array( $attribute ) || [] === $attribute ) {
+			return false;
+		}
+
+		if ( array_is_list( $attribute ) ) {
+			return false;
+		}
+
+		if ( array_key_exists( StateRegistry::BASE_KEY, $attribute ) ) {
+			return true;
+		}
+
+		foreach ( $this->registry->keys() as $key ) {
+			if ( StateRegistry::BASE_KEY === $key ) {
+				continue;
+			}
+
+			if ( array_key_exists( $key, $attribute ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Returns stored override keys that are NOT registered in the
+	 * active state registry (orphans). The audit command (future)
+	 * will consume this.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<int, string>
+	 */
+	public function orphanedKeys( $attribute ): array
+	{
+		if ( ! is_array( $attribute ) || [] === $attribute || array_is_list( $attribute ) ) {
+			return [];
+		}
+
+		$valid   = array_flip( $this->registry->keys() );
+		$orphans = [];
+
+		foreach ( array_keys( $attribute ) as $key ) {
+			if ( ! is_string( $key ) ) {
+				continue;
+			}
+
+			if ( isset( $valid[ $key ] ) ) {
+				continue;
+			}
+
+			$orphans[] = $key;
+		}
+
+		return $orphans;
+	}
+}

--- a/src/VisualEditorServiceProvider.php
+++ b/src/VisualEditorServiceProvider.php
@@ -24,6 +24,10 @@ use ArtisanPackUI\VisualEditor\Resources\ResourceResolver;
 use ArtisanPackUI\VisualEditor\Responsive\AttributeMigrator;
 use ArtisanPackUI\VisualEditor\Responsive\BreakpointRegistry;
 use ArtisanPackUI\VisualEditor\Responsive\ResponsiveValueResolver;
+use ArtisanPackUI\VisualEditor\States\StateAttributeMigrator;
+use ArtisanPackUI\VisualEditor\States\StateCssEmitter;
+use ArtisanPackUI\VisualEditor\States\StateRegistry;
+use ArtisanPackUI\VisualEditor\States\StateValueResolver;
 use ArtisanPackUI\VisualEditor\Search\BlockTreeSearchExtractor;
 use ArtisanPackUI\VisualEditor\SiteEditor\Resolution\GlobalStylesResolver as SiteEditorGlobalStylesResolver;
 use ArtisanPackUI\VisualEditor\SiteEditor\Resolution\MenuResolver as SiteEditorMenuResolver;
@@ -148,6 +152,31 @@ class VisualEditorServiceProvider extends ServiceProvider
 
 		$this->app->singleton( AttributeMigrator::class, function () {
 			return new AttributeMigrator();
+		} );
+
+		// #488 — state design tools. Same lifetime story as the
+		// breakpoint registry: scoped per request because theme.json
+		// can swap a state set between requests, and singletons would
+		// leak the resolved registry across them.
+		$this->app->scoped( StateRegistry::class, function ( $app ) {
+			$config = (array) $app['config']->get( 'artisanpack.visual-editor.states', [] );
+
+			return StateRegistry::fromLayers( $config );
+		} );
+
+		$this->app->scoped( StateValueResolver::class, function ( $app ) {
+			return new StateValueResolver( $app->make( StateRegistry::class ) );
+		} );
+
+		$this->app->scoped( StateCssEmitter::class, function ( $app ) {
+			return new StateCssEmitter(
+				$app->make( StateRegistry::class ),
+				$app->make( StateValueResolver::class ),
+			);
+		} );
+
+		$this->app->singleton( StateAttributeMigrator::class, function () {
+			return new StateAttributeMigrator();
 		} );
 
 		// #434: `GlobalStylesCssProvider` + `GlobalStylesCacheInvalidator`

--- a/tests/Feature/VisualEditor/States/StateCssEmitterTest.php
+++ b/tests/Feature/VisualEditor/States/StateCssEmitterTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\States\StateCssEmitter;
+use ArtisanPackUI\VisualEditor\States\StateRegistry;
+use ArtisanPackUI\VisualEditor\States\StateValueResolver;
+
+function makeEmitter( array $configOverrides = [], array $themeOverrides = [] ): StateCssEmitter
+{
+	$registry = StateRegistry::fromLayers( $configOverrides, $themeOverrides );
+	$resolver = new StateValueResolver( $registry );
+
+	return new StateCssEmitter( $registry, $resolver );
+}
+
+it( 'emits nothing for empty inputs', function () {
+	$emitter = makeEmitter();
+
+	expect( $emitter->emit( '.ap-block-abc', [] ) )->toBe( '' );
+	expect( $emitter->emit( '', [ 'color' => 'red' ] ) )->toBe( '' );
+} );
+
+it( 'emits the idle rule only when no per-state overrides exist', function () {
+	$emitter = makeEmitter();
+
+	$css = $emitter->emit( '.ap-block-abc', [
+		'background-color' => 'red',
+	] );
+
+	expect( $css )->toBe( '.ap-block-abc { background-color: red !important; }' );
+} );
+
+it( 'emits hover styles inside a hover-media wrap', function () {
+	$emitter = makeEmitter();
+
+	$css = $emitter->emit( '.ap-block-abc', [
+		'background-color' => [ 'idle' => 'red', 'hover' => 'blue' ],
+	] );
+
+	expect( $css )->toContain( '.ap-block-abc { background-color: red !important;' );
+	expect( $css )->toContain( '@media (hover: hover) { .ap-block-abc:hover { background-color: blue !important; }' );
+} );
+
+it( 'adds a default transition to idle when any non-idle state is set', function () {
+	$emitter = makeEmitter();
+
+	$css = $emitter->emit( '.ap-block-abc', [
+		'background-color' => [ 'idle' => 'red', 'hover' => 'blue' ],
+	] );
+
+	expect( $css )->toContain( 'transition: all 150ms ease;' );
+} );
+
+it( 'respects an editor-authored transition value', function () {
+	$emitter = makeEmitter();
+
+	$css = $emitter->emit( '.ap-block-abc', [
+		'background-color' => [ 'idle' => 'red', 'hover' => 'blue' ],
+		'transition'       => 'transform 200ms ease-out',
+	] );
+
+	// `transition` is in the NEVER_IMPORTANT set — author-supplied
+	// values stay overridable by host CSS, unlike colors/borders.
+	expect( $css )->toContain( 'transition: transform 200ms ease-out;' );
+	expect( $css )->not->toContain( 'transition: transform 200ms ease-out !important;' );
+	expect( $css )->not->toContain( 'transition: all 150ms ease;' );
+} );
+
+it( 'does not wrap non-hover states in the hover media query', function () {
+	$emitter = makeEmitter();
+
+	$css = $emitter->emit( '.ap-block-abc', [
+		'color' => [ 'idle' => 'red', 'focus-visible' => 'blue' ],
+	] );
+
+	expect( $css )->toContain( '.ap-block-abc:focus-visible { color: blue !important; }' );
+	expect( $css )->not->toContain( '@media (hover: hover) { .ap-block-abc:focus-visible' );
+} );
+
+it( 'skips emitting a state rule when the resolved value equals the inheritance parent', function () {
+	$emitter = makeEmitter();
+
+	$css = $emitter->emit( '.ap-block-abc', [
+		'background-color' => [ 'idle' => 'red', 'hover' => 'red' ],
+	] );
+
+	expect( $css )->toContain( '.ap-block-abc { background-color: red !important;' );
+	expect( $css )->not->toContain( ':hover { background-color: red' );
+} );
+
+it( 'supports custom states with attribute selectors', function () {
+	$emitter = makeEmitter( [], [
+		'aria-current' => [
+			'label'        => 'Current',
+			'selector'     => '&[aria-current="page"]',
+			'inheritsFrom' => 'idle',
+		],
+	] );
+
+	$css = $emitter->emit( '.ap-block-abc', [
+		'background-color' => [ 'idle' => 'red', 'aria-current' => 'navy' ],
+	] );
+
+	expect( $css )->toContain( '.ap-block-abc[aria-current="page"] { background-color: navy !important; }' );
+} );
+
+it( 'supports comma-separated selector lists', function () {
+	$emitter = makeEmitter();
+
+	$css = $emitter->emit( '.ap-block-abc', [
+		'opacity' => [ 'idle' => '1', 'disabled' => '0.5' ],
+	] );
+
+	expect( $css )->toContain( '.ap-block-abc:disabled, .ap-block-abc[aria-disabled="true"]' );
+} );

--- a/tests/Feature/VisualEditor/States/StateCssEmitterTest.php
+++ b/tests/Feature/VisualEditor/States/StateCssEmitterTest.php
@@ -114,3 +114,23 @@ it( 'supports comma-separated selector lists', function () {
 
 	expect( $css )->toContain( '.ap-block-abc:disabled, .ap-block-abc[aria-disabled="true"]' );
 } );
+
+it( 'drops boolean overrides without emitting `0` / `1` declarations', function () {
+	$emitter = makeEmitter();
+
+	$css = $emitter->emit( '.ap-block-abc', [
+		'background-color' => [ 'idle' => true, 'hover' => false ],
+	] );
+
+	expect( $css )->toBe( '' );
+} );
+
+it( 'drops non-scalar overrides instead of casting them to garbage strings', function () {
+	$emitter = makeEmitter();
+
+	$css = $emitter->emit( '.ap-block-abc', [
+		'background-color' => [ 'idle' => [ 'nested' => 'wrong' ] ],
+	] );
+
+	expect( $css )->toBe( '' );
+} );

--- a/tests/Unit/VisualEditor/States/InheritanceChainValidatorTest.php
+++ b/tests/Unit/VisualEditor/States/InheritanceChainValidatorTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\States\InheritanceChainValidator;
+
+it( 'accepts a chain that terminates at idle', function () {
+	$validator = new InheritanceChainValidator();
+
+	$validator->assertAcyclic( [
+		'idle'  => [ 'inheritsFrom' => null ],
+		'hover' => [ 'inheritsFrom' => 'idle' ],
+		'focus' => [ 'inheritsFrom' => 'idle' ],
+	] );
+
+	expect( true )->toBeTrue(); // No exception thrown.
+} );
+
+it( 'rejects a direct cycle', function () {
+	( new InheritanceChainValidator() )->assertAcyclic( [
+		'idle' => [ 'inheritsFrom' => null ],
+		'a'    => [ 'inheritsFrom' => 'b' ],
+		'b'    => [ 'inheritsFrom' => 'a' ],
+	] );
+} )->throws( InvalidArgumentException::class, 'circular' );
+
+it( 'rejects an inheritsFrom that points at an unregistered state', function () {
+	( new InheritanceChainValidator() )->assertAcyclic( [
+		'idle' => [ 'inheritsFrom' => null ],
+		'a'    => [ 'inheritsFrom' => 'missing' ],
+	] );
+} )->throws( InvalidArgumentException::class, 'inherits' );
+
+it( 'rejects a self-referencing state', function () {
+	( new InheritanceChainValidator() )->assertAcyclic( [
+		'idle' => [ 'inheritsFrom' => null ],
+		'a'    => [ 'inheritsFrom' => 'a' ],
+	] );
+} )->throws( InvalidArgumentException::class, 'circular' );

--- a/tests/Unit/VisualEditor/States/StateAttributeMigratorTest.php
+++ b/tests/Unit/VisualEditor/States/StateAttributeMigratorTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\States\StateAttributeMigrator;
+
+function makeStateMigrator(): StateAttributeMigrator
+{
+	return new StateAttributeMigrator();
+}
+
+it( 'returns the scalar unchanged when promoting to idle on a scalar', function () {
+	expect( makeStateMigrator()->promote( 'red', 'idle', 'blue' ) )->toBe( 'blue' );
+} );
+
+it( 'promotes a scalar to a stateful object on first non-idle override', function () {
+	$result = makeStateMigrator()->promote( 'red', 'hover', 'blue' );
+
+	expect( $result )->toBe( [ 'idle' => 'red', 'hover' => 'blue' ] );
+} );
+
+it( 'merges the new override into an existing stateful object', function () {
+	$result = makeStateMigrator()->promote(
+		[ 'idle' => 'red', 'hover' => 'blue' ],
+		'focus',
+		'green',
+	);
+
+	expect( $result )->toBe( [ 'idle' => 'red', 'hover' => 'blue', 'focus' => 'green' ] );
+} );
+
+it( 'overwrites an existing slot at the same state', function () {
+	$result = makeStateMigrator()->promote(
+		[ 'idle' => 'red', 'hover' => 'blue' ],
+		'hover',
+		'orange',
+	);
+
+	expect( $result )->toBe( [ 'idle' => 'red', 'hover' => 'orange' ] );
+} );
+
+it( 'demotes a stateful object back to scalar when only idle is set', function () {
+	$result = makeStateMigrator()->demote( [ 'idle' => 'red', 'hover' => null ] );
+
+	expect( $result )->toBe( 'red' );
+} );
+
+it( 'leaves stateful objects with multiple defined slots untouched', function () {
+	$attribute = [ 'idle' => 'red', 'hover' => 'blue' ];
+
+	expect( makeStateMigrator()->demote( $attribute ) )->toBe( $attribute );
+} );
+
+it( 'clears a single state and demotes if it was the last override', function () {
+	$result = makeStateMigrator()->clear(
+		[ 'idle' => 'red', 'hover' => 'blue' ],
+		'hover',
+	);
+
+	expect( $result )->toBe( 'red' );
+} );
+
+it( 'clears a state without demoting when other overrides remain', function () {
+	$result = makeStateMigrator()->clear(
+		[ 'idle' => 'red', 'hover' => 'blue', 'focus' => 'green' ],
+		'hover',
+	);
+
+	expect( $result )->toBe( [ 'idle' => 'red', 'focus' => 'green' ] );
+} );

--- a/tests/Unit/VisualEditor/States/StateRegistryTest.php
+++ b/tests/Unit/VisualEditor/States/StateRegistryTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\States\StateRegistry;
+
+it( 'falls back to built-in defaults when nothing overrides them', function () {
+	$registry = StateRegistry::fromLayers( [], [] );
+
+	expect( $registry->keys() )->toBe( [
+		'idle',
+		'hover',
+		'focus',
+		'focus-visible',
+		'active',
+		'disabled',
+	] );
+} );
+
+it( 'merges config overrides on top of defaults', function () {
+	$registry = StateRegistry::fromLayers(
+		[ 'hover' => [ 'label' => 'Hovered' ] ],
+		[]
+	);
+
+	$hover = $registry->get( 'hover' );
+
+	expect( $hover )->not->toBeNull();
+	expect( $hover['label'] )->toBe( 'Hovered' );
+	expect( $hover['selector'] )->toBe( '&:hover' );
+} );
+
+it( 'merges theme.json overrides on top of config', function () {
+	$registry = StateRegistry::fromLayers(
+		[ 'hover' => [ 'label' => 'Config label' ] ],
+		[ 'aria-current' => [
+			'label'        => 'Current',
+			'selector'     => '&[aria-current="page"]',
+			'inheritsFrom' => 'idle',
+		] ]
+	);
+
+	expect( $registry->has( 'aria-current' ) )->toBeTrue();
+	expect( $registry->get( 'aria-current' )['selector'] )->toBe( '&[aria-current="page"]' );
+} );
+
+it( 'hoists idle to the front so iteration order is stable', function () {
+	$registry = StateRegistry::fromLayers(
+		[],
+		[ 'aria-current' => [
+			'label'        => 'Current',
+			'selector'     => '&[aria-current]',
+			'inheritsFrom' => 'idle',
+		] ]
+	);
+
+	expect( $registry->keys()[0] )->toBe( 'idle' );
+} );
+
+it( 'returns the inheritance chain ending at idle', function () {
+	$registry = StateRegistry::fromLayers( [], [] );
+
+	expect( $registry->inheritanceChain( 'active' ) )->toBe( [ 'active', 'hover', 'idle' ] );
+	expect( $registry->inheritanceChain( 'focus-visible' ) )->toBe( [ 'focus-visible', 'focus', 'idle' ] );
+	expect( $registry->inheritanceChain( 'idle' ) )->toBe( [ 'idle' ] );
+	expect( $registry->inheritanceChain( 'made-up' ) )->toBe( [ 'idle' ] );
+} );
+
+it( 'rejects a registry missing the reserved idle slot', function () {
+	StateRegistry::fromLayers(
+		[ 'idle' => null ],
+		[]
+	);
+} )->throws( InvalidArgumentException::class, 'idle' );
+
+it( 'rejects an idle slot with a non-empty selector', function () {
+	StateRegistry::fromLayers(
+		[ 'idle' => [ 'label' => 'Idle', 'selector' => '&:idle' ] ],
+		[]
+	);
+} )->throws( InvalidArgumentException::class, 'idle' );
+
+it( 'rejects a non-idle state with a missing or empty selector', function () {
+	StateRegistry::fromLayers(
+		[],
+		[ 'broken' => [ 'label' => 'Broken', 'selector' => '', 'inheritsFrom' => 'idle' ] ]
+	);
+} )->throws( InvalidArgumentException::class, 'selector' );
+
+it( 'rejects a state whose inheritsFrom is not registered', function () {
+	StateRegistry::fromLayers(
+		[],
+		[ 'orphan' => [
+			'label'        => 'Orphan',
+			'selector'     => '&[data-orphan]',
+			'inheritsFrom' => 'made-up',
+		] ]
+	);
+} )->throws( InvalidArgumentException::class, 'inherits' );
+
+it( 'allows removing a built-in state by setting it to null', function () {
+	$registry = StateRegistry::fromLayers( [ 'disabled' => null ], [] );
+
+	expect( $registry->has( 'disabled' ) )->toBeFalse();
+	expect( $registry->has( 'hover' ) )->toBeTrue();
+} );
+
+it( 'flags hover with hoverMediaWrap=true by default', function () {
+	$registry = StateRegistry::fromLayers( [], [] );
+
+	expect( $registry->get( 'hover' )['hoverMediaWrap'] )->toBeTrue();
+	expect( $registry->get( 'focus' )['hoverMediaWrap'] )->toBeFalse();
+} );

--- a/tests/Unit/VisualEditor/States/StateValueResolverTest.php
+++ b/tests/Unit/VisualEditor/States/StateValueResolverTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\States\StateRegistry;
+use ArtisanPackUI\VisualEditor\States\StateValueResolver;
+
+function makeStateResolver(): StateValueResolver
+{
+	return new StateValueResolver( StateRegistry::fromLayers( [], [] ) );
+}
+
+it( 'returns scalars unchanged', function () {
+	expect( makeStateResolver()->resolve( 'red', 'hover' ) )->toBe( 'red' );
+	expect( makeStateResolver()->resolve( 4, 'hover' ) )->toBe( 4 );
+} );
+
+it( 'returns idle when no per-state overrides exist', function () {
+	$attribute = [ 'idle' => 'red' ];
+
+	expect( makeStateResolver()->resolve( $attribute, 'hover' ) )->toBe( 'red' );
+} );
+
+it( 'walks the inheritance chain through null slots', function () {
+	$attribute = [ 'idle' => 'red', 'hover' => 'blue', 'active' => null ];
+
+	expect( makeStateResolver()->resolve( $attribute, 'active' ) )->toBe( 'blue' );
+} );
+
+it( 'returns the override at the active state when one exists', function () {
+	$attribute = [ 'idle' => 'red', 'hover' => 'blue' ];
+	$resolver  = makeStateResolver();
+
+	expect( $resolver->resolve( $attribute, 'idle' ) )->toBe( 'red' );
+	expect( $resolver->resolve( $attribute, 'hover' ) )->toBe( 'blue' );
+	expect( $resolver->resolve( $attribute, 'active' ) )->toBe( 'blue' );
+	expect( $resolver->resolve( $attribute, 'focus' ) )->toBe( 'red' );
+} );
+
+it( 'returns null when no slot in the chain is defined', function () {
+	$attribute = [ 'hover' => 'blue' ];
+
+	expect( makeStateResolver()->resolve( $attribute, 'focus' ) )->toBeNull();
+} );
+
+it( 'falls back to idle when active state is unknown', function () {
+	$attribute = [ 'idle' => 'red', 'hover' => 'blue' ];
+
+	expect( makeStateResolver()->resolve( $attribute, 'made-up' ) )->toBe( 'red' );
+} );
+
+it( 'recognises stateful shape via idle or any registry key', function () {
+	$resolver = makeStateResolver();
+
+	expect( $resolver->isStatefulAttribute( [ 'idle' => 'a' ] ) )->toBeTrue();
+	expect( $resolver->isStatefulAttribute( [ 'hover' => 'a' ] ) )->toBeTrue();
+	expect( $resolver->isStatefulAttribute( 'red' ) )->toBeFalse();
+	expect( $resolver->isStatefulAttribute( [ 'a', 'b' ] ) )->toBeFalse();
+	expect( $resolver->isStatefulAttribute( [] ) )->toBeFalse();
+} );
+
+it( 'collapses distinctOverrides to only states that differ from their inheritance parent', function () {
+	$attribute = [ 'idle' => 'red', 'hover' => 'red', 'active' => 'red', 'focus' => 'blue' ];
+
+	$result = makeStateResolver()->distinctOverrides( $attribute );
+
+	expect( $result )->toBe( [ 'idle' => 'red', 'focus' => 'blue' ] );
+} );
+
+it( 'includes idle in distinctOverrides whenever it has a non-null value', function () {
+	$attribute = [ 'idle' => 'red' ];
+
+	expect( makeStateResolver()->distinctOverrides( $attribute ) )->toBe( [ 'idle' => 'red' ] );
+} );
+
+it( 'returns orphaned keys for states not present in the registry', function () {
+	$attribute = [ 'idle' => 'a', 'hover' => 'b', 'legacy-state' => 'c' ];
+
+	expect( makeStateResolver()->orphanedKeys( $attribute ) )->toBe( [ 'legacy-state' ] );
+} );
+
+it( 'resolveAll returns the cascaded value for every registered state', function () {
+	$attribute = [ 'idle' => 'red', 'hover' => 'blue' ];
+
+	$all = makeStateResolver()->resolveAll( $attribute );
+
+	expect( $all['idle'] )->toBe( 'red' );
+	expect( $all['hover'] )->toBe( 'blue' );
+	expect( $all['active'] )->toBe( 'blue' );
+	expect( $all['focus'] )->toBe( 'red' );
+	expect( $all['focus-visible'] )->toBe( 'red' );
+	expect( $all['disabled'] )->toBe( 'red' );
+} );


### PR DESCRIPTION
## Description

Adds the State Design Tools v1.0 feature — editors can author hover, focus, focus-visible, active, and disabled styles (plus theme-extensible custom states) on opted-in blocks without writing CSS. Output is plain CSS with `:hover` / `:focus-visible` / `:disabled` selectors, so the published page has no runtime requirement.

**Closes:** #488

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #488

## Motivation and Context

Block style attributes resolved to a single value rendered in the default (idle) state. There was no first-class way for an editor to say "this button's background is `accent` normally but `accent-700` on hover" without writing custom CSS — so buttons, links, and any block with an interactive feel shipped visually flat.

## Changes Made

- **PHP `src/States/`** — `StateRegistry` (theme.json → config → defaults, inheritance chains with cycle detection), `StateValueResolver` (chain-walking cascade + `distinctOverrides` pruning), `StateAttributeMigrator` (scalar↔stateful), `StateCssEmitter` (scoped CSS with auto `@media (hover: hover)` wrap, default `transition: all 150ms ease`, and `!important` on every property except `transition`), `InheritanceChainValidator`.
- **Blade renderer (`packages/visual-editor-renderer-blade`)** — `BlockSupports::compileStates()` emits scoped state rules with a dual-selector cascade onto descendant interactive elements (`a, button`); idle stays bare-scope so block-level idle colors don't bleed into nested links. `StateCssAccumulator` consolidates per-request rules into a single `<style data-ve-states>` block at the top of the render output. `ThemeJsonTokensCompiler` now also emits `.has-{slug}-color/-background-color/-border-color/-font-size/-gradient-background` utility classes so idle palette slugs visibly bind on the front end.
- **Editor (`resources/js/visual-editor/states/`)** — `StateRegistry`/resolver/migrator/css-emitter mirroring the PHP layer; block-specific `StateSwitcher` chip strip in the inspector with per-state `has-override` dot indicator and a Preview toggle; `withStateAttributes` editor.BlockEdit HOC routing per-state reads/writes; `StateWriteInterceptor` data-store subscriber catching color/border panel writes that bypass the BlockEdit prop chain (WP's newer panels dispatch directly via `useDispatch`); `withStateStyles` editor.BlockListBlock HOC + save filters injecting the scoped `<style>` tag and unique class into both editor canvas and saved markup.
- **Block opt-ins** — `artisanpack/button`, `artisanpack/buttons`, `artisanpack/image`, `artisanpack/cover`, `artisanpack/media-text`, `artisanpack/details`. `artisanpack/navigation` is intentionally deferred to a follow-up (the parent block doesn't expose color/border supports — per-link state styling is the right shape there).
- **Config + provider** — `config/visual-editor.php` gets a `states` key documenting custom-state registration; service providers register `StateRegistry`, `StateValueResolver`, `StateAttributeMigrator`, `StateCssEmitter`, and `StateCssAccumulator` per-request.
- **Docs** — new `docs/state-design-tools.md` covering both editor workflow and the developer integration surface.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS 14
- Browser: Chromium-based (manual)
- PHP Version: 8.4
- Project Version: feature/488-state-design-tools off release/1.0

**Tests Performed:**

1. Editor: select a button → switch to Hover chip → pick a different palette color → idle base attribute remains the original, `attributes.states.backgroundColor.hover` carries the new value, canvas Preview toggle flips the button color.
2. Save → reload front end → mouse hovers the button → background swaps via the emitted `@media (hover: hover) .ap-state-XXX:hover` rule. Confirmed by host running keystone-cms.
3. Custom hex via `style.color.background` routes the same way; palette slugs translate to `var(--wp--preset--color--{slug})` server-side.
4. Switching to a non-supporting block (paragraph) shows the explanatory state-strip message instead of the chip grid.

## Accessibility Tests Run

- [x] Keyboard navigation tested (chip strip buttons are focusable in DOM order with visible focus rings)
- [ ] Screen reader tested (chips have `aria-pressed`; the Preview toggle is a button with `aria-pressed`; the state-strip group has `role="group" aria-label="Block state"`)
- [x] Color contrast verified (chip selected state uses tokens already exercised by the responsive toolbar)
- [x] ARIA labels checked

**Details:** Each chip emits `aria-pressed`, the strip wraps in a `role="group"` with a labelled name, the Preview toggle exposes the preview action via `aria-pressed`, and unsupported-block messaging uses `role="status"`. Screen-reader testing pending — flagging for the review pass.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:** 800 Pest tests (2229 assertions) and 1626 Vitest tests, all green. New coverage: `StateRegistry`, `StateValueResolver`, `StateAttributeMigrator`, `StateCssEmitter` (PHP); `registry`, `resolver`, `migrator`, `active-state`, `css-emitter`, `state-write-interceptor`, `with-state-attributes` (JS); `BlockSupports::compile()` state slot and `ThemeJsonTokensCompiler` utility-class emission in the renderer-blade unit suite. Inspector-sidebar test gets a `@wordpress/blocks` stub so the new HOC import doesn't trip JSON-import-attribute issues under vitest.

## Documentation

- [x] Inline code documentation added
- [ ] README updated
- [ ] Wiki updated
- [ ] API documentation updated

**Documentation details:** New `docs/state-design-tools.md` covers editor flow + custom-state registration + supported attributes. Inline PHPDoc + TSDoc on every new module.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted (TypeScript compile clean on the new state files; WordPress-typings warnings in other files are pre-existing)
- [ ] Accessibility tests completed (manual SR check still to do)
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

## Known follow-up issues

Two pre-existing / out-of-scope gaps surfaced while building this feature and are tracked separately:

- **#511** — Inspector color/border/shadow swatches always show the idle value on non-idle states (cosmetic only — saved markup, canvas preview, and front-end CSS are correct; the WP panel reads via `useSelect` and bypasses the HOC overlay).
- **#512** — Editor palette is hard-coded in `editor-settings.ts` and ignores the host theme.json palette. Slugs that don't overlap (`secondary`, `success`, …) bind to nothing on the front end.

Three CodeRabbit review passes against `release/1.0` were run during development; all valid findings (Rules of Hooks violation, descendant-selector leak on idle, dead CSS, slug normalization, palette-slug-only entries, supports mismatch on `navigation`/`buttons`/`media-text`) were applied before this PR opened.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive state styling: per-state attributes, scoped CSS emission, inspector state switcher, preview toggle, and inspector controls for managing/resetting state overrides. Blocks opting in get automated registration and save-time wiring so authored state styles are applied and exported.

* **Documentation**
  * Comprehensive state design tools guide for editor usage and developer configuration.

* **Tests**
  * Extensive unit and integration tests covering registry, resolver, migrator, CSS emission, write interception, HOCs, and editor stores.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->