### PR TITLE
fix: source editor palette and presets from host theme.json instead of hard-coded defaults

### DIFF
--- a/resources/js/visual-editor/__tests__/use-themed-editor-settings.test.ts
+++ b/resources/js/visual-editor/__tests__/use-themed-editor-settings.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Unit tests for the theme-settings extraction helpers (#512).
+ *
+ * The hook itself (`useThemedEditorSettings`) depends on React hooks
+ * and async fetch stubs. The pure extraction functions are tested here
+ * to validate the shape → normalized-array mapping logic without
+ * needing a React render harness.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+    extractThemeFontFamilies,
+    extractThemeFontSizes,
+    extractThemeGradients,
+    extractThemePalette,
+    extractThemeSpacingSizes,
+} from '../use-themed-editor-settings';
+
+describe('extractThemePalette', () => {
+    it('returns null when settings has no color key', () => {
+        expect(extractThemePalette({})).toBeNull();
+    });
+
+    it('returns null when palette is an empty array', () => {
+        expect(extractThemePalette({ color: { palette: [] } })).toBeNull();
+    });
+
+    it('extracts valid palette entries and skips malformed ones', () => {
+        const settings = {
+            color: {
+                palette: [
+                    { slug: 'primary', name: 'Primary', color: '#3b82f6' },
+                    { slug: '', color: '#bad' },
+                    null,
+                    { slug: 'accent', color: '#10b981' },
+                    { slug: 'missing-color' },
+                ],
+            },
+        };
+
+        const result = extractThemePalette(settings);
+        expect(result).toEqual([
+            { slug: 'primary', name: 'Primary', color: '#3b82f6' },
+            { slug: 'accent', name: 'accent', color: '#10b981' },
+        ]);
+    });
+
+    it('falls back to slug as name when name is missing', () => {
+        const settings = {
+            color: { palette: [{ slug: 'brand', color: '#ff0000' }] },
+        };
+
+        const result = extractThemePalette(settings);
+        expect(result).toEqual([{ slug: 'brand', name: 'brand', color: '#ff0000' }]);
+    });
+});
+
+describe('extractThemeFontSizes', () => {
+    it('returns null when settings has no typography key', () => {
+        expect(extractThemeFontSizes({})).toBeNull();
+    });
+
+    it('returns null when fontSizes is an empty array', () => {
+        expect(extractThemeFontSizes({ typography: { fontSizes: [] } })).toBeNull();
+    });
+
+    it('extracts valid font-size entries', () => {
+        const settings = {
+            typography: {
+                fontSizes: [
+                    { slug: 'small', name: 'Small', size: '0.875rem' },
+                    { slug: 'large', size: '1.5rem' },
+                ],
+            },
+        };
+
+        const result = extractThemeFontSizes(settings);
+        expect(result).toEqual([
+            { slug: 'small', name: 'Small', size: '0.875rem' },
+            { slug: 'large', name: 'large', size: '1.5rem' },
+        ]);
+    });
+});
+
+describe('extractThemeFontFamilies', () => {
+    it('returns null when settings has no typography key', () => {
+        expect(extractThemeFontFamilies({})).toBeNull();
+    });
+
+    it('returns null when fontFamilies is an empty array', () => {
+        expect(extractThemeFontFamilies({ typography: { fontFamilies: [] } })).toBeNull();
+    });
+
+    it('extracts valid font-family entries', () => {
+        const settings = {
+            typography: {
+                fontFamilies: [
+                    { slug: 'sans', name: 'Sans', fontFamily: 'Inter, sans-serif' },
+                    { slug: 'serif', fontFamily: 'Georgia, serif' },
+                ],
+            },
+        };
+
+        const result = extractThemeFontFamilies(settings);
+        expect(result).toEqual([
+            { slug: 'sans', name: 'Sans', fontFamily: 'Inter, sans-serif' },
+            { slug: 'serif', name: 'serif', fontFamily: 'Georgia, serif' },
+        ]);
+    });
+
+    it('skips entries with missing fontFamily', () => {
+        const settings = {
+            typography: {
+                fontFamilies: [
+                    { slug: 'mono', name: 'Mono' },
+                    { slug: 'sans', name: 'Sans', fontFamily: 'Inter' },
+                ],
+            },
+        };
+
+        const result = extractThemeFontFamilies(settings);
+        expect(result).toEqual([
+            { slug: 'sans', name: 'Sans', fontFamily: 'Inter' },
+        ]);
+    });
+});
+
+describe('extractThemeSpacingSizes', () => {
+    it('returns null when settings has no spacing key', () => {
+        expect(extractThemeSpacingSizes({})).toBeNull();
+    });
+
+    it('returns null when spacingSizes is an empty array', () => {
+        expect(extractThemeSpacingSizes({ spacing: { spacingSizes: [] } })).toBeNull();
+    });
+
+    it('extracts valid spacing-size entries', () => {
+        const settings = {
+            spacing: {
+                spacingSizes: [
+                    { slug: '20', name: 'Tight', size: '0.5rem' },
+                    { slug: '40', size: '1.5rem' },
+                ],
+            },
+        };
+
+        const result = extractThemeSpacingSizes(settings);
+        expect(result).toEqual([
+            { slug: '20', name: 'Tight', size: '0.5rem' },
+            { slug: '40', name: '40', size: '1.5rem' },
+        ]);
+    });
+});
+
+describe('extractThemeGradients', () => {
+    it('returns null when settings has no color key', () => {
+        expect(extractThemeGradients({})).toBeNull();
+    });
+
+    it('returns null when gradients is an empty array', () => {
+        expect(extractThemeGradients({ color: { gradients: [] } })).toBeNull();
+    });
+
+    it('extracts valid gradient entries', () => {
+        const settings = {
+            color: {
+                gradients: [
+                    {
+                        slug: 'sunset',
+                        name: 'Sunset',
+                        gradient: 'linear-gradient(135deg, #f97316, #ef4444)',
+                    },
+                    {
+                        slug: 'ocean',
+                        gradient: 'linear-gradient(135deg, #3b82f6, #06b6d4)',
+                    },
+                ],
+            },
+        };
+
+        const result = extractThemeGradients(settings);
+        expect(result).toEqual([
+            {
+                slug: 'sunset',
+                name: 'Sunset',
+                gradient: 'linear-gradient(135deg, #f97316, #ef4444)',
+            },
+            {
+                slug: 'ocean',
+                name: 'ocean',
+                gradient: 'linear-gradient(135deg, #3b82f6, #06b6d4)',
+            },
+        ]);
+    });
+});

--- a/resources/js/visual-editor/editor/editor-app.tsx
+++ b/resources/js/visual-editor/editor/editor-app.tsx
@@ -32,8 +32,8 @@ import type { BlockInstance } from '@wordpress/blocks';
 import { addFilter } from '@wordpress/hooks';
 
 import { bootI18n, TEXT_DOMAIN } from '../vendor/i18n';
-import { editorSettings } from '../editor-settings';
 import { ensureMediaBridgeFilter } from '../media-bridge';
+import { useThemedEditorSettings } from '../use-themed-editor-settings';
 
 import { registerArtisanPackBlocks } from '../blocks';
 
@@ -282,6 +282,8 @@ function EditorAppShell(props: EditorAppProps): JSX.Element {
         previewUrl = null,
         onMetadataChange,
     } = props;
+
+    const themedSettings = useThemedEditorSettings({ apiBase: props.apiBase });
 
     const documentType = entityTypeForResource(props.resource);
     // Validate against a whole-digit regex *before* parsing so malformed
@@ -849,7 +851,7 @@ function EditorAppShell(props: EditorAppProps): JSX.Element {
     const editorBody = (
         <BlockEditorProvider
             value={blocks}
-            settings={editorSettings}
+            settings={themedSettings}
             onInput={handleInput}
             onChange={handleChange}
         >

--- a/resources/js/visual-editor/site-editor/block-editor-boundary.tsx
+++ b/resources/js/visual-editor/site-editor/block-editor-boundary.tsx
@@ -37,9 +37,7 @@ import '@wordpress/format-library';
 import { type ReactNode } from 'react';
 
 import { ConvertToPatternControl } from '../editor/convert-to-pattern-control';
-import { editorSettings } from '../editor-settings';
-import { useThemeGlobalStylesCss } from './use-theme-global-styles-css';
-import { useThemeGlobalStylesSettings } from './use-theme-global-styles-settings';
+import { useThemedEditorSettings } from '../use-themed-editor-settings';
 
 // Gutenberg editor-surface stylesheets. Previously imported by each
 // canvas component; they follow the provider here so the boundary owns
@@ -186,92 +184,16 @@ export function BlockEditorBoundary(props: BlockEditorBoundaryProps): JSX.Elemen
         };
     }, [onNavigateToEntityRecord]);
 
-    // Tests can short-circuit the network by passing a string directly;
-    // production drives the value through the hook keyed on `apiBase`.
-    const fetchedCss = useThemeGlobalStylesCss(apiBase);
-    const themeCss = themeGlobalStylesCss !== undefined ? themeGlobalStylesCss : fetchedCss;
+    const extraSettings = useMemo(
+        () => ({ onNavigateToEntityRecord: navigateToEntityRecord }),
+        [navigateToEntityRecord],
+    );
 
-    // Pull the active theme's `settings` (palette, font-sizes, etc.)
-    // so the picker UIs source their swatches from the same slugs the
-    // server-side emitter binds via `.has-{slug}-*` rules. Without
-    // this the editor used a hard-coded default palette while the
-    // emitter bound the theme palette — picker choices didn't
-    // visually apply because the two palettes don't share slugs
-    // (Keystone #53).
-    const themeBase = useThemeGlobalStylesSettings(apiBase);
-
-    // Append the theme's compiled global-styles CSS to the editor's
-    // `styles` array so Gutenberg cascades it into the canvas, and
-    // override the palette / font-sizes in `__experimentalFeatures`
-    // when the theme defines them. Memoized so identity-stable
-    // `editorSettings` doesn't bust the provider's effects on every
-    // parent re-render. When no theme data is available we hand the
-    // provider the original `editorSettings` object — no allocation,
-    // no diff.
-    const settings = useMemo(() => {
-        const themeSettings = themeBase?.settings ?? {};
-        const themePalette = extractThemePalette(themeSettings);
-        const themeFontSizes = extractThemeFontSizes(themeSettings);
-        const themeGradients = extractThemeGradients(themeSettings);
-
-        const needsStyles = themeCss !== undefined && themeCss !== '';
-        const needsPalette = themePalette !== null;
-        const needsFontSizes = themeFontSizes !== null;
-        const needsGradients = themeGradients !== null;
-
-        if (!needsStyles && !needsPalette && !needsFontSizes && !needsGradients) {
-            return {
-                ...editorSettings,
-                onNavigateToEntityRecord: navigateToEntityRecord,
-            };
-        }
-
-        const nextStyles = needsStyles
-            ? [...editorSettings.styles, { css: themeCss as string }]
-            : editorSettings.styles;
-
-        const baseFeatures = editorSettings.__experimentalFeatures ?? {};
-        const baseColor = (baseFeatures as { color?: Record<string, unknown> }).color ?? {};
-        const baseTypography =
-            (baseFeatures as { typography?: Record<string, unknown> }).typography ?? {};
-
-        return {
-            ...editorSettings,
-            styles: nextStyles,
-            onNavigateToEntityRecord: navigateToEntityRecord,
-            // Mirror onto the legacy top-level keys too so older
-            // blocks that still read `settings.colors` / `fontSizes`
-            // pick up the theme's slugs.
-            ...(needsPalette ? { colors: themePalette } : {}),
-            ...(needsFontSizes ? { fontSizes: themeFontSizes } : {}),
-            __experimentalFeatures: {
-                ...baseFeatures,
-                color: {
-                    ...baseColor,
-                    ...(needsPalette || needsGradients
-                        ? {
-                              palette: needsPalette
-                                  ? { theme: themePalette, custom: [] }
-                                  : (baseColor as { palette?: unknown }).palette,
-                              gradients: needsGradients
-                                  ? { theme: themeGradients, custom: [] }
-                                  : (baseColor as { gradients?: unknown }).gradients,
-                          }
-                        : {}),
-                },
-                typography: needsFontSizes
-                    ? {
-                          ...baseTypography,
-                          fontSizes: {
-                              ...(((baseTypography as { fontSizes?: Record<string, unknown> })
-                                  .fontSizes) ?? {}),
-                              theme: themeFontSizes,
-                          },
-                      }
-                    : baseTypography,
-            },
-        };
-    }, [themeCss, themeBase, navigateToEntityRecord]);
+    const settings = useThemedEditorSettings({
+        apiBase,
+        themeGlobalStylesCss,
+        extraSettings,
+    });
 
     return (
         <SlotFillProvider>
@@ -289,24 +211,6 @@ export function BlockEditorBoundary(props: BlockEditorBoundaryProps): JSX.Elemen
             </BlockEditorProvider>
         </SlotFillProvider>
     );
-}
-
-interface PaletteEntry {
-    slug: string;
-    name: string;
-    color: string;
-}
-
-interface FontSizeEntry {
-    slug: string;
-    name: string;
-    size: string;
-}
-
-interface GradientEntry {
-    slug: string;
-    name: string;
-    gradient: string;
 }
 
 /**
@@ -360,114 +264,3 @@ function resolveNavigationId(
     return encodeURIComponent(composite);
 }
 
-/**
- * Pull `settings.color.palette` out of the `/global-styles/base`
- * payload as a normalized `{ slug, name, color }` list. Returns
- * `null` (not an empty array) when the theme didn't define one so
- * the boundary can keep `editorSettings`'s default palette as a
- * fallback rather than blanking the picker.
- */
-function extractThemePalette(
-    settings: Record<string, unknown>,
-): readonly PaletteEntry[] | null {
-    const palette = (settings.color as { palette?: unknown })?.palette;
-
-    if (!Array.isArray(palette) || palette.length === 0) {
-        return null;
-    }
-
-    const out: PaletteEntry[] = [];
-
-    for (const entry of palette) {
-        if (entry === null || typeof entry !== 'object') {
-            continue;
-        }
-
-        const slug = (entry as { slug?: unknown }).slug;
-        const color = (entry as { color?: unknown }).color;
-
-        if (typeof slug !== 'string' || slug === '' || typeof color !== 'string') {
-            continue;
-        }
-
-        const name = (entry as { name?: unknown }).name;
-
-        out.push({
-            slug,
-            color,
-            name: typeof name === 'string' ? name : slug,
-        });
-    }
-
-    return out.length === 0 ? null : out;
-}
-
-function extractThemeFontSizes(
-    settings: Record<string, unknown>,
-): readonly FontSizeEntry[] | null {
-    const sizes = (settings.typography as { fontSizes?: unknown })?.fontSizes;
-
-    if (!Array.isArray(sizes) || sizes.length === 0) {
-        return null;
-    }
-
-    const out: FontSizeEntry[] = [];
-
-    for (const entry of sizes) {
-        if (entry === null || typeof entry !== 'object') {
-            continue;
-        }
-
-        const slug = (entry as { slug?: unknown }).slug;
-        const size = (entry as { size?: unknown }).size;
-
-        if (typeof slug !== 'string' || slug === '' || typeof size !== 'string') {
-            continue;
-        }
-
-        const name = (entry as { name?: unknown }).name;
-
-        out.push({
-            slug,
-            size,
-            name: typeof name === 'string' ? name : slug,
-        });
-    }
-
-    return out.length === 0 ? null : out;
-}
-
-function extractThemeGradients(
-    settings: Record<string, unknown>,
-): readonly GradientEntry[] | null {
-    const gradients = (settings.color as { gradients?: unknown })?.gradients;
-
-    if (!Array.isArray(gradients) || gradients.length === 0) {
-        return null;
-    }
-
-    const out: GradientEntry[] = [];
-
-    for (const entry of gradients) {
-        if (entry === null || typeof entry !== 'object') {
-            continue;
-        }
-
-        const slug = (entry as { slug?: unknown }).slug;
-        const gradient = (entry as { gradient?: unknown }).gradient;
-
-        if (typeof slug !== 'string' || slug === '' || typeof gradient !== 'string') {
-            continue;
-        }
-
-        const name = (entry as { name?: unknown }).name;
-
-        out.push({
-            slug,
-            gradient,
-            name: typeof name === 'string' ? name : slug,
-        });
-    }
-
-    return out.length === 0 ? null : out;
-}

--- a/resources/js/visual-editor/site-editor/block-editor-boundary.tsx
+++ b/resources/js/visual-editor/site-editor/block-editor-boundary.tsx
@@ -61,10 +61,9 @@ export interface BlockEditorBoundaryProps {
     apiBase?: string;
     /**
      * Test-only override for the active theme's compiled CSS. In
-     * production the boundary fetches this through
-     * {@see useThemeGlobalStylesCss} keyed on `apiBase`; tests pass an
-     * explicit string to avoid hitting the network. When `undefined`
-     * the hook drives the value (Keystone #47).
+     * production {@see useThemedEditorSettings} fetches this
+     * internally; tests pass an explicit string to avoid hitting the
+     * network. When `undefined` the hook drives the value.
      */
     themeGlobalStylesCss?: string;
     /**

--- a/resources/js/visual-editor/use-themed-editor-settings.ts
+++ b/resources/js/visual-editor/use-themed-editor-settings.ts
@@ -1,0 +1,363 @@
+/**
+ * Shared hook that merges the active theme's global-styles presets
+ * (palette, font sizes, font families, spacing sizes, gradients) and
+ * compiled CSS into the package's default `editorSettings` (#512).
+ *
+ * Both the post editor (`editor/editor-app.tsx`) and the site editor
+ * (`site-editor/block-editor-boundary.tsx`) consume this hook so every
+ * editing surface sources its inspector swatches from the host theme's
+ * `theme.json` settings rather than the hard-coded `DEFAULT_*` arrays
+ * in `editor-settings.ts`. The hard-coded arrays remain as fallbacks
+ * when no theme data is available (standalone installs without
+ * cms-framework).
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since   1.0.0
+ */
+
+import { useMemo } from 'react';
+
+import { editorSettings } from './editor-settings';
+import { useThemeGlobalStylesCss } from './site-editor/use-theme-global-styles-css';
+import { useThemeGlobalStylesSettings } from './site-editor/use-theme-global-styles-settings';
+
+interface PaletteEntry {
+    slug: string;
+    name: string;
+    color: string;
+}
+
+interface FontSizeEntry {
+    slug: string;
+    name: string;
+    size: string;
+}
+
+interface FontFamilyEntry {
+    slug: string;
+    name: string;
+    fontFamily: string;
+}
+
+interface SpacingSizeEntry {
+    slug: string;
+    name: string;
+    size: string;
+}
+
+interface GradientEntry {
+    slug: string;
+    name: string;
+    gradient: string;
+}
+
+export interface UseThemedEditorSettingsOptions {
+    apiBase: string | undefined;
+    /**
+     * Test-only override for the active theme's compiled CSS. In
+     * production the hook fetches this through
+     * {@see useThemeGlobalStylesCss} keyed on `apiBase`; tests pass an
+     * explicit string to avoid hitting the network.
+     */
+    themeGlobalStylesCss?: string;
+    /** Extra properties to merge into the returned settings object. */
+    extraSettings?: Record<string, unknown>;
+}
+
+/**
+ * Pull `settings.color.palette` out of the `/global-styles/base`
+ * payload as a normalized `{ slug, name, color }` list. Returns
+ * `null` (not an empty array) when the theme didn't define one so
+ * callers can keep `editorSettings`'s default palette as a fallback
+ * rather than blanking the picker.
+ */
+export function extractThemePalette(
+    settings: Record<string, unknown>,
+): readonly PaletteEntry[] | null {
+    const palette = (settings.color as { palette?: unknown })?.palette;
+
+    if (!Array.isArray(palette) || palette.length === 0) {
+        return null;
+    }
+
+    const out: PaletteEntry[] = [];
+
+    for (const entry of palette) {
+        if (entry === null || typeof entry !== 'object') {
+            continue;
+        }
+
+        const slug = (entry as { slug?: unknown }).slug;
+        const color = (entry as { color?: unknown }).color;
+
+        if (typeof slug !== 'string' || slug === '' || typeof color !== 'string') {
+            continue;
+        }
+
+        const name = (entry as { name?: unknown }).name;
+
+        out.push({
+            slug,
+            color,
+            name: typeof name === 'string' ? name : slug,
+        });
+    }
+
+    return out.length === 0 ? null : out;
+}
+
+export function extractThemeFontSizes(
+    settings: Record<string, unknown>,
+): readonly FontSizeEntry[] | null {
+    const sizes = (settings.typography as { fontSizes?: unknown })?.fontSizes;
+
+    if (!Array.isArray(sizes) || sizes.length === 0) {
+        return null;
+    }
+
+    const out: FontSizeEntry[] = [];
+
+    for (const entry of sizes) {
+        if (entry === null || typeof entry !== 'object') {
+            continue;
+        }
+
+        const slug = (entry as { slug?: unknown }).slug;
+        const size = (entry as { size?: unknown }).size;
+
+        if (typeof slug !== 'string' || slug === '' || typeof size !== 'string') {
+            continue;
+        }
+
+        const name = (entry as { name?: unknown }).name;
+
+        out.push({
+            slug,
+            size,
+            name: typeof name === 'string' ? name : slug,
+        });
+    }
+
+    return out.length === 0 ? null : out;
+}
+
+export function extractThemeFontFamilies(
+    settings: Record<string, unknown>,
+): readonly FontFamilyEntry[] | null {
+    const families = (settings.typography as { fontFamilies?: unknown })?.fontFamilies;
+
+    if (!Array.isArray(families) || families.length === 0) {
+        return null;
+    }
+
+    const out: FontFamilyEntry[] = [];
+
+    for (const entry of families) {
+        if (entry === null || typeof entry !== 'object') {
+            continue;
+        }
+
+        const slug = (entry as { slug?: unknown }).slug;
+        const fontFamily = (entry as { fontFamily?: unknown }).fontFamily;
+
+        if (typeof slug !== 'string' || slug === '' || typeof fontFamily !== 'string') {
+            continue;
+        }
+
+        const name = (entry as { name?: unknown }).name;
+
+        out.push({
+            slug,
+            fontFamily,
+            name: typeof name === 'string' ? name : slug,
+        });
+    }
+
+    return out.length === 0 ? null : out;
+}
+
+export function extractThemeSpacingSizes(
+    settings: Record<string, unknown>,
+): readonly SpacingSizeEntry[] | null {
+    const sizes = (settings.spacing as { spacingSizes?: unknown })?.spacingSizes;
+
+    if (!Array.isArray(sizes) || sizes.length === 0) {
+        return null;
+    }
+
+    const out: SpacingSizeEntry[] = [];
+
+    for (const entry of sizes) {
+        if (entry === null || typeof entry !== 'object') {
+            continue;
+        }
+
+        const slug = (entry as { slug?: unknown }).slug;
+        const size = (entry as { size?: unknown }).size;
+
+        if (typeof slug !== 'string' || slug === '' || typeof size !== 'string') {
+            continue;
+        }
+
+        const name = (entry as { name?: unknown }).name;
+
+        out.push({
+            slug,
+            size,
+            name: typeof name === 'string' ? name : slug,
+        });
+    }
+
+    return out.length === 0 ? null : out;
+}
+
+export function extractThemeGradients(
+    settings: Record<string, unknown>,
+): readonly GradientEntry[] | null {
+    const gradients = (settings.color as { gradients?: unknown })?.gradients;
+
+    if (!Array.isArray(gradients) || gradients.length === 0) {
+        return null;
+    }
+
+    const out: GradientEntry[] = [];
+
+    for (const entry of gradients) {
+        if (entry === null || typeof entry !== 'object') {
+            continue;
+        }
+
+        const slug = (entry as { slug?: unknown }).slug;
+        const gradient = (entry as { gradient?: unknown }).gradient;
+
+        if (typeof slug !== 'string' || slug === '' || typeof gradient !== 'string') {
+            continue;
+        }
+
+        const name = (entry as { name?: unknown }).name;
+
+        out.push({
+            slug,
+            gradient,
+            name: typeof name === 'string' ? name : slug,
+        });
+    }
+
+    return out.length === 0 ? null : out;
+}
+
+/**
+ * Merge the active theme's global-styles presets and CSS into the
+ * package's default `editorSettings`. Returns the original
+ * `editorSettings` (with any `extraSettings` spread) when no theme
+ * data is available — no extra allocation.
+ */
+export function useThemedEditorSettings(
+    options: UseThemedEditorSettingsOptions,
+): Record<string, unknown> {
+    const { apiBase, themeGlobalStylesCss, extraSettings } = options;
+
+    const fetchedCss = useThemeGlobalStylesCss(apiBase);
+    const themeCss = themeGlobalStylesCss !== undefined ? themeGlobalStylesCss : fetchedCss;
+
+    const themeBase = useThemeGlobalStylesSettings(apiBase);
+
+    return useMemo(() => {
+        const themeSettings = themeBase?.settings ?? {};
+        const themePalette = extractThemePalette(themeSettings);
+        const themeFontSizes = extractThemeFontSizes(themeSettings);
+        const themeFontFamilies = extractThemeFontFamilies(themeSettings);
+        const themeSpacingSizes = extractThemeSpacingSizes(themeSettings);
+        const themeGradients = extractThemeGradients(themeSettings);
+
+        const needsStyles = themeCss !== undefined && themeCss !== '';
+        const needsPalette = themePalette !== null;
+        const needsFontSizes = themeFontSizes !== null;
+        const needsFontFamilies = themeFontFamilies !== null;
+        const needsSpacingSizes = themeSpacingSizes !== null;
+        const needsGradients = themeGradients !== null;
+
+        if (
+            !needsStyles &&
+            !needsPalette &&
+            !needsFontSizes &&
+            !needsFontFamilies &&
+            !needsSpacingSizes &&
+            !needsGradients
+        ) {
+            if (extraSettings !== undefined && Object.keys(extraSettings).length > 0) {
+                return { ...editorSettings, ...extraSettings };
+            }
+
+            return editorSettings;
+        }
+
+        const nextStyles = needsStyles
+            ? [...editorSettings.styles, { css: themeCss as string }]
+            : editorSettings.styles;
+
+        const baseFeatures = editorSettings.__experimentalFeatures ?? {};
+        const baseColor = (baseFeatures as { color?: Record<string, unknown> }).color ?? {};
+        const baseTypography =
+            (baseFeatures as { typography?: Record<string, unknown> }).typography ?? {};
+        const baseSpacing =
+            (baseFeatures as { spacing?: Record<string, unknown> }).spacing ?? {};
+
+        return {
+            ...editorSettings,
+            styles: nextStyles,
+            ...(extraSettings ?? {}),
+            ...(needsPalette ? { colors: themePalette } : {}),
+            ...(needsFontSizes ? { fontSizes: themeFontSizes } : {}),
+            __experimentalFeatures: {
+                ...baseFeatures,
+                color: {
+                    ...baseColor,
+                    ...(needsPalette || needsGradients
+                        ? {
+                              palette: needsPalette
+                                  ? { theme: themePalette, custom: [] }
+                                  : (baseColor as { palette?: unknown }).palette,
+                              gradients: needsGradients
+                                  ? { theme: themeGradients, custom: [] }
+                                  : (baseColor as { gradients?: unknown }).gradients,
+                          }
+                        : {}),
+                },
+                typography: {
+                    ...baseTypography,
+                    ...(needsFontSizes
+                        ? {
+                              fontSizes: {
+                                  ...((baseTypography as { fontSizes?: Record<string, unknown> })
+                                      .fontSizes ?? {}),
+                                  theme: themeFontSizes,
+                              },
+                          }
+                        : {}),
+                    ...(needsFontFamilies
+                        ? {
+                              fontFamilies: {
+                                  ...((baseTypography as { fontFamilies?: Record<string, unknown> })
+                                      .fontFamilies ?? {}),
+                                  theme: themeFontFamilies,
+                              },
+                          }
+                        : {}),
+                },
+                spacing: {
+                    ...baseSpacing,
+                    ...(needsSpacingSizes
+                        ? {
+                              spacingSizes: {
+                                  ...((baseSpacing as { spacingSizes?: Record<string, unknown> })
+                                      .spacingSizes ?? {}),
+                                  theme: themeSpacingSizes,
+                              },
+                          }
+                        : {}),
+                },
+            },
+        };
+    }, [themeCss, themeBase, extraSettings]);
+}


### PR DESCRIPTION
## Description

The editor's color palette, font sizes, font families, spacing sizes, and gradients were hard-coded in `editor-settings.ts`. When the host theme's `theme.json` shipped different slugs, picker choices wrote `.has-{slug}-*` classes that had no matching CSS custom property on the front end — the color never visually applied.

**Closes:** #512

## Type of Change

- [x] Bug fix (fixes an issue)

## Related Issue

**Issue:** #512

## Motivation and Context

The site editor already overlaid theme settings via `useThemeGlobalStylesSettings`, but the post editor passed the hard-coded `editorSettings` directly to `BlockEditorProvider`. Hosts whose `theme.json` palette didn't overlap with the hard-coded slugs saw swatches in the editor that produced no visible effect on the front end.

## Changes Made

- Created shared `useThemedEditorSettings` hook (`use-themed-editor-settings.ts`) that merges the active theme's global-styles presets into the package's default `editorSettings`
- Extracted palette, font-size, font-family, spacing-size, and gradient extraction functions into the shared module
- Wired the **post editor** (`editor-app.tsx`) through the shared hook so it now fetches and applies the host theme's presets
- Refactored the **site editor** (`block-editor-boundary.tsx`) to delegate to the shared hook, removing ~200 lines of inline extraction logic
- Added font-family and spacing-size extraction (previously missing from even the site editor)

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS
- Browser: Safari / Chrome
- PHP Version: 8.4
- Project Version: 1.0.0-alpha

**Tests Performed:**
1. Opened post editor in Keystone CMS — verified color palette swatches reflect the host theme's `theme.json` palette
2. Opened site editor — verified palette still works (regression check)
3. Inserted a button block, picked a palette color, saved, and verified the front end renders the color correctly
4. Verified font-size picker shows theme values when a theme is active

## Accessibility Tests Run

- [x] Keyboard navigation tested
- [x] Color contrast verified

**Details:** No new UI elements introduced — the change only affects which preset values populate existing picker panels.

## Tests Added

- [x] Unit tests added/updated
- [x] All tests passing

**Test details:** Added 17 unit tests for the five extraction functions (`extractThemePalette`, `extractThemeFontSizes`, `extractThemeFontFamilies`, `extractThemeSpacingSizes`, `extractThemeGradients`) covering valid input, empty/missing data, malformed entries, and name fallback behavior. All 1664 JS tests and 805 PHP tests pass.

## Documentation

- [x] Inline code documentation added

**Documentation details:** JSDoc on the new hook and extraction functions. No external docs needed — the change is transparent to consumers.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [x] Accessibility tests completed
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit tests for theme settings extraction, validating palette, font sizes/families, spacing, and gradients, including handling of missing or malformed entries.

* **New Features**
  * Centralized theme-driven editor settings: unified merging of host theme colors, typography, spacing and compiled CSS into the visual editor while preserving defaults and allowing optional overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->