### PR TITLE
fix: route custom hex picks on non-idle states to both base and states bag

### DIFF
--- a/docs/plans/515-custom-hex-state-routing.md
+++ b/docs/plans/515-custom-hex-state-routing.md
@@ -19,7 +19,7 @@ The `withStateAttributes` HOC intercepts `setAttributes` calls from the color pa
 This matters because WordPress's newer block-support panels (color, border, shadow on apiVersion 3 blocks) read attributes via `useSelect('core/block-editor').getBlockAttributes()` — bypassing the HOC's `mergedAttributes` prop entirely. So even though the HOC correctly updated `states.hover`, the inspector panel still read the **old overlaid value** from the data store, making it appear as though the pick had no effect.
 
 **Debug evidence:** Console logs confirmed:
-```
+```text
 [HOC] wrappedSetAttributes called {activeState: "hover", changedPaths: ["style.color.background", "backgroundColor"]}
 [HOC] routed to states: "style.color.background" = "#1ae61d"
 [HOC] dispatching finalUpdates ["states"]   ← only states, NOT the base
@@ -75,7 +75,7 @@ The visual editor does not register a `core/editor` store, so `isSavingPost()` n
 
 ## Testing status
 
-- All 1674 JS tests pass (vitest)
+- All 1683 JS tests pass (vitest)
 - All 805 PHP tests pass (pest)
 - **Not yet verified in browser** — the `jmwd-keystone-cms` host app serves visual-editor assets through a Laravel controller (`VisualEditorAssetController`) with a 1-hour `Cache-Control: max-age=3600` header. This made it very difficult to test new builds during this session because browsers kept serving stale chunks even after hard refresh and private windows. The cache header was temporarily changed to `no-cache` for testing but the stale cache persisted.
 

--- a/docs/plans/515-custom-hex-state-routing.md
+++ b/docs/plans/515-custom-hex-state-routing.md
@@ -1,0 +1,98 @@
+# #515 — Custom hex picked on a non-idle state: diagnosis and fixes
+
+## Problem
+
+When the inspector's State chip strip is set to a non-idle state (Hover, Focus, etc.), picking a **custom hex** color via the Color > Background picker does not persist the new value into `attributes.states.<path>.<activeState>`. After save+reload the states bag still holds the **previous** hover value.
+
+Palette slug picks on the same non-idle chip work correctly — both `attributes.<slug-key>` and `attributes.states.<slug-key>.<activeState>` update as expected.
+
+## Root cause analysis
+
+Three contributing issues were identified. All three are addressed by the code on this branch.
+
+### 1. HOC did not mirror state-eligible writes to the base attribute
+
+**File:** `resources/js/visual-editor/states/with-state-attributes.tsx`
+
+The `withStateAttributes` HOC intercepts `setAttributes` calls from the color panel. When the active state is non-idle, it routes state-eligible changes into `attributes.states` but did **not** update the base attribute in the data store.
+
+This matters because WordPress's newer block-support panels (color, border, shadow on apiVersion 3 blocks) read attributes via `useSelect('core/block-editor').getBlockAttributes()` — bypassing the HOC's `mergedAttributes` prop entirely. So even though the HOC correctly updated `states.hover`, the inspector panel still read the **old overlaid value** from the data store, making it appear as though the pick had no effect.
+
+**Debug evidence:** Console logs confirmed:
+```
+[HOC] wrappedSetAttributes called {activeState: "hover", changedPaths: ["style.color.background", "backgroundColor"]}
+[HOC] routed to states: "style.color.background" = "#1ae61d"
+[HOC] dispatching finalUpdates ["states"]   ← only states, NOT the base
+```
+
+**Fix:** The HOC now mirrors state-eligible values to BOTH `states` and the base attribute using `buildTopLevelPatch` for sibling preservation. The `StateInspectorSync` component's pristine snapshot mechanism restores the canonical idle base before save.
+
+### 2. Sibling clobbering in `planCorrection` (interceptor)
+
+**File:** `resources/js/visual-editor/states/state-write-interceptor.tsx`
+
+`planCorrection` built its `updatePayload` via `setPath()`, which creates a minimal nested tree like `{style: {color: {background: '#hex'}}}`. When `updateBlockAttributes` shallow-merges this at the top level, it **replaces the entire `style` subtree**, clobbering siblings like `style.spacing.padding` or `style.border.radius`.
+
+**Fix:** Replaced `setPath` with `buildTopLevelPatch`, which deep-clones the relevant top-level subtree from the current attributes and applies only the changed leaf, preserving all siblings.
+
+### 3. Block-change pristine restore targeted the wrong block
+
+**File:** `resources/js/visual-editor/states/StateInspectorSync.tsx`
+
+When block selection changes, `restorePristine()` was called with `slice.clientId` (the **new** block's ID). The old block's pristine snapshot was never unwound, so:
+- If the user clicked away from the block before saving, the old block's data-store attributes leaked the synced overlay into the persisted markup.
+- The pristine snapshot was orphaned (never cleared).
+
+**Fix:** The effect now detects block changes and restores the **previous** block's pristine base before processing the new selection.
+
+### 4. Save lifecycle without `core/editor`
+
+**File:** `resources/js/visual-editor/editor/use-persistence.ts`
+
+The visual editor does not register a `core/editor` store, so `isSavingPost()` never fires. The `StateInspectorSync` save-lifecycle restore (which depends on `isSavingPost`) never runs.
+
+**Fix (two-pronged):**
+
+1. **Save-path patching:** `use-persistence.ts` now calls `patchBlocksWithPristine()` right before `saveContent()`. This patches the block tree **in memory** — replacing overlaid base values with their pristine idle snapshots — without modifying the data store. The live editing overlay is unaffected.
+
+2. **Host-agnostic flush API:** A new `flushBeforeSave()` function is exported from `states/index.ts`. Hosts that don't use `core/editor` can call this before serializing block content. It restores all pristine snapshots in the data store.
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `responsive/attribute-paths.ts` | Added `deepClone` and `buildTopLevelPatch` (moved from `StateInspectorSync` to shared module) |
+| `states/with-state-attributes.tsx` | HOC now mirrors state-eligible writes to the base attribute via `buildTopLevelPatch` |
+| `states/state-write-interceptor.tsx` | `planCorrection` uses `buildTopLevelPatch` instead of `setPath` for sibling preservation |
+| `states/StateInspectorSync.tsx` | Block-change restore targets the previous block; uses shared `buildTopLevelPatch`/`deepClone`; exports `flushBeforeSave()` |
+| `states/state-bridge.ts` | Added `getAllPristineClientIds()` |
+| `states/index.ts` | Exports `flushBeforeSave` |
+| `editor/use-persistence.ts` | Save path patches blocks with pristine bases before sending to API |
+| `responsive/__tests__/attribute-paths.test.ts` | Tests for `deepClone` and `buildTopLevelPatch` |
+| `states/__tests__/state-write-interceptor.test.ts` | Tests for sibling preservation and custom hex routing |
+| `states/__tests__/StateInspectorSync.test.ts` | Tests for `flushBeforeSave` |
+| `states/__tests__/with-state-attributes.test.tsx` | Updated to expect base-mirroring behavior |
+
+## Testing status
+
+- All 1674 JS tests pass (vitest)
+- All 805 PHP tests pass (pest)
+- **Not yet verified in browser** — the `jmwd-keystone-cms` host app serves visual-editor assets through a Laravel controller (`VisualEditorAssetController`) with a 1-hour `Cache-Control: max-age=3600` header. This made it very difficult to test new builds during this session because browsers kept serving stale chunks even after hard refresh and private windows. The cache header was temporarily changed to `no-cache` for testing but the stale cache persisted.
+
+## How to test on the MacBook Pro
+
+1. `cd ~/Code/ArtisanPack\ UI\ Packages/visual-editor`
+2. `git checkout bugfix/515-custom-hex-not-routed-to-state`
+3. `npm run build`
+4. Clear browser cache completely (Safari: Develop > Empty Caches, or use a fresh private window)
+5. In `jmwd-keystone-cms`, temporarily set the asset controller's `Cache-Control` header to `no-cache` if still having stale-chunk issues
+6. Open the CMS editor, select a button block
+7. Click the **Hover** chip
+8. Pick a new custom hex Background color — the swatch and canvas should update immediately
+9. Save, reload
+10. Click Hover again — the new color should persist in `states['style.color.background'].hover`
+
+## Open questions
+
+- The `VisualEditorAssetController`'s `max-age=3600` cache header makes iterative dev painful. Consider adding a build hash query param or using `ETag`/`Last-Modified` for conditional requests instead of a fixed TTL.
+- If the browser issue persists on the MacBook Pro despite cache clearing, the next diagnostic step is to add `console.warn` logs in the save path (`use-persistence.ts`) to confirm the blocks reaching `saveContent()` contain the updated `states` bag. The HOC routing was confirmed working via debug logs during this session.

--- a/docs/plans/515-custom-hex-state-routing.md
+++ b/docs/plans/515-custom-hex-state-routing.md
@@ -8,7 +8,7 @@ Palette slug picks on the same non-idle chip work correctly — both `attributes
 
 ## Root cause analysis
 
-Three contributing issues were identified. All three are addressed by the code on this branch.
+Four contributing issues were identified. All four are addressed by the code on this branch.
 
 ### 1. HOC did not mirror state-eligible writes to the base attribute
 

--- a/resources/js/visual-editor/editor/use-persistence.ts
+++ b/resources/js/visual-editor/editor/use-persistence.ts
@@ -24,6 +24,45 @@ import {
     VE_EDITOR_SAVE,
     dispatchEditorEvent,
 } from './editor-events';
+import { setPath } from '../responsive/attribute-paths';
+import {
+    getAllPristineClientIds,
+    getPristineSnapshot,
+} from '../states/state-bridge';
+
+/**
+ * Patch blocks in-memory so the saved markup has pristine idle base
+ * values rather than the synced overlay that `StateInspectorSync`
+ * applies for panel lockstep. Operates on a shallow copy — the
+ * original block tree (and the data store) is untouched, so the
+ * user's editing session keeps the active-state overlay.
+ */
+function patchBlocksWithPristine(
+    blocks: readonly BlockInstance[],
+    snapshotIds: ReadonlySet<string>,
+): BlockInstance[] {
+    return blocks.map( ( block ) => {
+        const inner = block.innerBlocks.length > 0
+            ? patchBlocksWithPristine( block.innerBlocks, snapshotIds )
+            : block.innerBlocks;
+
+        if ( ! snapshotIds.has( block.clientId ) ) {
+            return inner === block.innerBlocks ? block : { ...block, innerBlocks: inner };
+        }
+
+        const snapshot = getPristineSnapshot( block.clientId );
+        if ( ! snapshot ) {
+            return inner === block.innerBlocks ? block : { ...block, innerBlocks: inner };
+        }
+
+        let attributes: Record<string, unknown> = block.attributes as Record<string, unknown>;
+        for ( const [ path, value ] of Object.entries( snapshot ) ) {
+            attributes = setPath( attributes, path, value );
+        }
+
+        return { ...block, attributes, innerBlocks: inner };
+    } );
+}
 
 type LoadStatus = 'loading' | 'ready' | 'error';
 type SaveStatus = 'idle' | 'saving' | 'saved' | 'error';
@@ -261,9 +300,18 @@ export function usePersistence(
 
             try {
                 if (nextBlocks !== null) {
+                    // #515: replace overlaid base values with the
+                    // pristine idle snapshot so the saved markup keeps
+                    // idle as the canonical base. The overlay stays in
+                    // the data store for the live editing session.
+                    const pristineIds = getAllPristineClientIds();
+                    const blocksToSave = pristineIds.length > 0
+                        ? patchBlocksWithPristine( nextBlocks, new Set( pristineIds ) )
+                        : nextBlocks;
+
                     const response = await saveContent(
                         { apiBase, resource, id },
-                        nextBlocks
+                        blocksToSave
                     );
 
                     if (unmountedRef.current || version !== targetVersionRef.current) {

--- a/resources/js/visual-editor/responsive/__tests__/attribute-paths.test.ts
+++ b/resources/js/visual-editor/responsive/__tests__/attribute-paths.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+	buildTopLevelPatch,
+	deepClone,
 	deepMerge,
 	diffPaths,
 	pathMatchesAnyRoot,
@@ -127,6 +129,76 @@ describe( 'pathMatchesAnyRoot', () => {
 
 	it( 'matches any root in the list', () => {
 		expect( pathMatchesAnyRoot( 'columnCount', [ 'spacing', 'columnCount' ] ) ).toBe( true )
+	} )
+} )
+
+describe( 'deepClone', () => {
+	it( 'clones scalars and null passthrough', () => {
+		expect( deepClone( 42 ) ).toBe( 42 )
+		expect( deepClone( 'text' ) ).toBe( 'text' )
+		expect( deepClone( null ) ).toBeNull()
+		expect( deepClone( undefined ) ).toBeUndefined()
+	} )
+
+	it( 'deep-clones nested objects without sharing references', () => {
+		const original = { a: { b: { c: 1 } } }
+		const cloned   = deepClone( original )
+
+		expect( cloned ).toEqual( original )
+		expect( cloned ).not.toBe( original )
+		expect( ( cloned as Record<string, unknown> ).a ).not.toBe( original.a )
+	} )
+
+	it( 'clones arrays element-wise', () => {
+		const original = [ { x: 1 }, { x: 2 } ]
+		const cloned   = deepClone( original )
+
+		expect( cloned ).toEqual( original )
+		expect( cloned[ 0 ] ).not.toBe( original[ 0 ] )
+	} )
+} )
+
+describe( 'buildTopLevelPatch', () => {
+	it( 'preserves siblings when applying a nested leaf change', () => {
+		const attributes = {
+			style: {
+				color:   { background: '#000' },
+				spacing: { padding: '10px' },
+			},
+		}
+
+		const entries = new Map( [
+			[ 'style', [ { path: 'style.color.background', value: '#fff' } ] ],
+		] )
+
+		const patch = buildTopLevelPatch( attributes, entries )
+
+		expect( ( patch.style as Record<string, unknown> ) ).toEqual( {
+			color:   { background: '#fff' },
+			spacing: { padding: '10px' },
+		} )
+	} )
+
+	it( 'handles top-level scalar entries', () => {
+		const attributes = { backgroundColor: 'old' }
+		const entries    = new Map( [
+			[ 'backgroundColor', [ { path: 'backgroundColor', value: 'new' } ] ],
+		] )
+
+		expect( buildTopLevelPatch( attributes, entries ) ).toEqual( {
+			backgroundColor: 'new',
+		} )
+	} )
+
+	it( 'does not mutate the original attributes', () => {
+		const attributes = { style: { color: { background: '#000' } } }
+		const entries    = new Map( [
+			[ 'style', [ { path: 'style.color.background', value: '#fff' } ] ],
+		] )
+
+		buildTopLevelPatch( attributes, entries )
+
+		expect( ( attributes.style as Record<string, unknown> ).color ).toEqual( { background: '#000' } )
 	} )
 } )
 

--- a/resources/js/visual-editor/responsive/attribute-paths.ts
+++ b/resources/js/visual-editor/responsive/attribute-paths.ts
@@ -209,6 +209,79 @@ export function pathMatchesAnyRoot( path: string, roots: string[] ): boolean {
 }
 
 /**
+ * Recursively clone a plain JSON value. Arrays are cloned element-wise;
+ * plain objects are cloned key-by-key. Non-object scalars pass through
+ * unchanged.
+ */
+export function deepClone<T>( value: T ): T {
+    if ( null === value || undefined === value || 'object' !== typeof value ) {
+        return value
+    }
+
+    if ( Array.isArray( value ) ) {
+        return value.map( ( item ) => deepClone( item ) ) as unknown as T
+    }
+
+    const result: Record<string, unknown> = {}
+    for ( const key of Object.keys( value as Record<string, unknown> ) ) {
+        result[ key ] = deepClone( ( value as Record<string, unknown> )[ key ] )
+    }
+
+    return result as unknown as T
+}
+
+/**
+ * Build a top-level patch where each touched key carries a full
+ * subtree (deep-cloned from `attributes`) with the supplied leaves
+ * overwritten. This ensures that `updateBlockAttributes` (which does
+ * a shallow merge at the top level) does NOT clobber siblings of the
+ * changed leaves.
+ */
+export function buildTopLevelPatch(
+    attributes: Record<string, unknown>,
+    entriesByTopKey: Map<string, Array<{ path: string; value: unknown }>>,
+): Record<string, unknown> {
+    const patch: Record<string, unknown> = {}
+
+    for ( const [ topKey, entries ] of entriesByTopKey ) {
+        const current = attributes[ topKey ]
+        let topValue: unknown =
+            current && 'object' === typeof current && ! Array.isArray( current )
+                ? deepClone( current )
+                : current
+
+        for ( const { path, value } of entries ) {
+            const segments = path.split( '.' )
+
+            if ( 1 === segments.length ) {
+                topValue = value
+                continue
+            }
+
+            if ( ! topValue || 'object' !== typeof topValue || Array.isArray( topValue ) ) {
+                topValue = {}
+            }
+
+            let cursor = topValue as Record<string, unknown>
+            for ( let i = 1; i < segments.length - 1; i++ ) {
+                const segment  = segments[ i ]
+                const existing = cursor[ segment ]
+                if ( ! existing || 'object' !== typeof existing || Array.isArray( existing ) ) {
+                    cursor[ segment ] = {}
+                }
+                cursor = cursor[ segment ] as Record<string, unknown>
+            }
+
+            cursor[ segments[ segments.length - 1 ] ] = value
+        }
+
+        patch[ topKey ] = topValue
+    }
+
+    return patch
+}
+
+/**
  * Deep-merge two plain objects. Right wins on scalar collisions;
  * nested objects merge recursively. Arrays are replaced (not merged).
  * Used to overlay the active breakpoint's overrides on top of base

--- a/resources/js/visual-editor/states/StateInspectorSync.tsx
+++ b/resources/js/visual-editor/states/StateInspectorSync.tsx
@@ -42,10 +42,17 @@
  */
 
 import { hasBlockSupport, getBlockType } from '@wordpress/blocks'
-import { useDispatch, useSelect } from '@wordpress/data'
+import {
+	dispatch as dispatchStore,
+	select as selectStore,
+	useDispatch,
+	useSelect,
+} from '@wordpress/data'
 import { useEffect, useRef, useSyncExternalStore } from 'react'
 
 import {
+	buildTopLevelPatch,
+	deepClone,
 	pathMatchesAnyRoot,
 	readPath,
 } from '../responsive/attribute-paths'
@@ -54,6 +61,7 @@ import { getStateRegistry } from './registry'
 import { resolveStateValue } from './resolver'
 import {
 	clearPristineSnapshot,
+	getAllPristineClientIds,
 	getPristineSnapshot,
 	hasPristineSnapshot,
 	setExpectedSyncedAttrs,
@@ -102,73 +110,6 @@ function getStateRoots( name: string | null ): string[] | null {
 }
 
 type StatesByPath = Record<string, Record<string, unknown>>
-
-function deepClone<T>( value: T ): T {
-	if ( null === value || undefined === value || 'object' !== typeof value ) {
-		return value
-	}
-
-	if ( Array.isArray( value ) ) {
-		return value.map( ( item ) => deepClone( item ) ) as unknown as T
-	}
-
-	const result: Record<string, unknown> = {}
-	for ( const key of Object.keys( value as Record<string, unknown> ) ) {
-		result[ key ] = deepClone( ( value as Record<string, unknown> )[ key ] )
-	}
-
-	return result as unknown as T
-}
-
-/**
- * Build a top-level patch where each touched key carries a full
- * subtree (deep-cloned from `attributes`) with the supplied leaves
- * overwritten. `value` of `undefined` is preserved as an explicit
- * leaf so restore can unset previously-overlaid paths.
- */
-function buildTopLevelPatch(
-	attributes: Record<string, unknown>,
-	entriesByTopKey: Map<string, Array<{ path: string; value: unknown }>>,
-): Record<string, unknown> {
-	const patch: Record<string, unknown> = {}
-
-	for ( const [ topKey, entries ] of entriesByTopKey ) {
-		const current = attributes[ topKey ]
-		let topValue: unknown =
-			current && 'object' === typeof current && ! Array.isArray( current )
-				? deepClone( current )
-				: current
-
-		for ( const { path, value } of entries ) {
-			const segments = path.split( '.' )
-
-			if ( 1 === segments.length ) {
-				topValue = value
-				continue
-			}
-
-			if ( ! topValue || 'object' !== typeof topValue || Array.isArray( topValue ) ) {
-				topValue = {}
-			}
-
-			let cursor = topValue as Record<string, unknown>
-			for ( let i = 1; i < segments.length - 1; i++ ) {
-				const segment  = segments[ i ]
-				const existing = cursor[ segment ]
-				if ( ! existing || 'object' !== typeof existing || Array.isArray( existing ) ) {
-					cursor[ segment ] = {}
-				}
-				cursor = cursor[ segment ] as Record<string, unknown>
-			}
-
-			cursor[ segments[ segments.length - 1 ] ] = value
-		}
-
-		patch[ topKey ] = topValue
-	}
-
-	return patch
-}
 
 interface OverlayPlan {
 	entriesByTopKey: Map<string, Array<{ path: string; value: unknown }>>
@@ -336,6 +277,39 @@ export function restorePristine(
 	clearPristineSnapshot( clientId )
 }
 
+/**
+ * Host-agnostic save flush. Call this BEFORE serializing block
+ * content whenever the host does not register `core/editor` (so
+ * `isSavingPost` never fires). It restores every block's pristine
+ * idle base into the data store, ensuring the saved markup keeps
+ * idle as the canonical base attribute value.
+ *
+ * After serialization, the host should call this function's
+ * companion — or re-render the affected blocks — to re-overlay
+ * the active state's view.
+ */
+export function flushBeforeSave(): void {
+	const clientIds = getAllPristineClientIds()
+	if ( 0 === clientIds.length ) {
+		return
+	}
+
+	const blockEditor = selectStore( 'core/block-editor' ) as
+		| { getBlockAttributes?: ( id: string ) => Record<string, unknown> | null }
+		| undefined
+	const { updateBlockAttributes } = dispatchStore( 'core/block-editor' ) as {
+		updateBlockAttributes: (
+			clientId: string,
+			updates: Record<string, unknown>,
+		) => void
+	}
+
+	for ( const clientId of clientIds ) {
+		const attrs = blockEditor?.getBlockAttributes?.( clientId ) ?? {}
+		restorePristine( clientId, attrs, updateBlockAttributes )
+	}
+}
+
 export function StateInspectorSync(): null {
 	const activeState = useSyncExternalStore(
 		subscribeActiveState,
@@ -402,6 +376,18 @@ export function StateInspectorSync(): null {
 		const activeStateChanged = activeState !== prevActiveState
 		const saveLifecycleEnded = prevIsSaving && ! slice.isSaving
 
+		// When the selected block changes, the PREVIOUS block's
+		// pristine base must be restored so its data-store attributes
+		// reflect the canonical idle view. Without this, serialization
+		// at save time would persist the synced overlay values.
+		if ( blockChanged && prevClientId && hasPristineSnapshot( prevClientId ) ) {
+			const blockEditor = selectStore( 'core/block-editor' ) as
+				| { getBlockAttributes?: ( id: string ) => Record<string, unknown> | null }
+				| undefined
+			const prevBlockAttrs = blockEditor?.getBlockAttributes?.( prevClientId ) ?? {}
+			restorePristine( prevClientId, prevBlockAttrs, updateBlockAttributes )
+		}
+
 		if ( ! blockChanged && ! activeStateChanged && ! saveLifecycleEnded ) {
 			prevClientIdRef.current    = slice.clientId
 			prevActiveStateRef.current = activeState
@@ -423,9 +409,6 @@ export function StateInspectorSync(): null {
 		}
 
 		if ( BASE_KEY === activeState ) {
-			// Idle — restore pristine if we have one. Selection
-			// changes hit this branch too because `setActiveBlock`
-			// resets active state to idle on block change.
 			restorePristine( slice.clientId, slice.attributes, updateBlockAttributes )
 			return
 		}

--- a/resources/js/visual-editor/states/StateInspectorSync.tsx
+++ b/resources/js/visual-editor/states/StateInspectorSync.tsx
@@ -52,7 +52,6 @@ import { useEffect, useRef, useSyncExternalStore } from 'react'
 
 import {
 	buildTopLevelPatch,
-	deepClone,
 	pathMatchesAnyRoot,
 	readPath,
 } from '../responsive/attribute-paths'

--- a/resources/js/visual-editor/states/__tests__/StateInspectorSync.test.ts
+++ b/resources/js/visual-editor/states/__tests__/StateInspectorSync.test.ts
@@ -4,6 +4,9 @@ vi.mock( '@wordpress/blocks', () => ( {
 	getBlockType:    () => null,
 	hasBlockSupport: () => false,
 } ) )
+const mockUpdateBlockAttributes = vi.fn()
+const mockGetBlockAttributes   = vi.fn( () => ( {} ) )
+
 vi.mock( '@wordpress/data', () => ( {
 	useDispatch: () => ( { updateBlockAttributes: vi.fn() } ),
 	useSelect:   () => ( {
@@ -12,11 +15,14 @@ vi.mock( '@wordpress/data', () => ( {
 		attributes: {},
 		isSaving:   false,
 	} ),
+	select:   () => ( { getBlockAttributes: mockGetBlockAttributes } ),
+	dispatch: () => ( { updateBlockAttributes: mockUpdateBlockAttributes } ),
 } ) )
 
 import {
 	applySyncDispatch,
 	buildOverlay,
+	flushBeforeSave,
 	restorePristine,
 	snapshotPristineFor,
 } from '../StateInspectorSync'
@@ -29,6 +35,9 @@ import {
 
 beforeEach( () => {
 	resetStateBridge()
+	mockUpdateBlockAttributes.mockClear()
+	mockGetBlockAttributes.mockReset()
+	mockGetBlockAttributes.mockReturnValue( {} )
 } )
 
 describe( 'buildOverlay (#511)', () => {
@@ -319,5 +328,36 @@ describe( 'sync → save → restore lifecycle (#511)', () => {
 		const dispatch = vi.fn()
 		restorePristine( clientId, makeAttributes(), dispatch )
 		expect( dispatch ).not.toHaveBeenCalled()
+	} )
+} )
+
+describe( 'flushBeforeSave (#515)', () => {
+	it( 'restores pristine for every block that has a snapshot', () => {
+		const blockA = 'block-a'
+		const blockB = 'block-b'
+
+		snapshotPristineFor( blockA, { backgroundColor: 'idle-a' }, [ 'backgroundColor' ] )
+		snapshotPristineFor( blockB, { backgroundColor: 'idle-b' }, [ 'backgroundColor' ] )
+
+		mockGetBlockAttributes.mockImplementation( ( id: string ) => {
+			if ( 'block-a' === id ) {
+				return { backgroundColor: 'hover-a', states: {} }
+			}
+			if ( 'block-b' === id ) {
+				return { backgroundColor: 'hover-b', states: {} }
+			}
+			return {}
+		} )
+
+		flushBeforeSave()
+
+		expect( mockUpdateBlockAttributes ).toHaveBeenCalledTimes( 2 )
+		expect( hasPristineSnapshot( blockA ) ).toBe( false )
+		expect( hasPristineSnapshot( blockB ) ).toBe( false )
+	} )
+
+	it( 'is a no-op when no snapshots exist', () => {
+		flushBeforeSave()
+		expect( mockUpdateBlockAttributes ).not.toHaveBeenCalled()
 	} )
 } )

--- a/resources/js/visual-editor/states/__tests__/StateInspectorSync.test.ts
+++ b/resources/js/visual-editor/states/__tests__/StateInspectorSync.test.ts
@@ -28,10 +28,12 @@ import {
 } from '../StateInspectorSync'
 import {
 	consumeExpectedSyncedAttrs,
+	extendPristineSnapshot,
 	getPristineSnapshot,
 	hasPristineSnapshot,
 	resetStateBridge,
 } from '../state-bridge'
+import { readPath } from '../../responsive/attribute-paths'
 
 beforeEach( () => {
 	resetStateBridge()
@@ -359,5 +361,76 @@ describe( 'flushBeforeSave (#515)', () => {
 	it( 'is a no-op when no snapshots exist', () => {
 		flushBeforeSave()
 		expect( mockUpdateBlockAttributes ).not.toHaveBeenCalled()
+	} )
+} )
+
+describe( 'extendPristineSnapshot (#515 follow-up)', () => {
+	it( 'creates a fresh snapshot when none exists', () => {
+		extendPristineSnapshot(
+			'cid-1',
+			{ backgroundColor: 'palette-red' },
+			[ 'backgroundColor' ],
+			readPath,
+		)
+
+		expect( getPristineSnapshot( 'cid-1' ) ).toEqual( {
+			backgroundColor: 'palette-red',
+		} )
+	} )
+
+	it( 'extends an existing snapshot with new paths', () => {
+		extendPristineSnapshot(
+			'cid-1',
+			{ backgroundColor: 'palette-red' },
+			[ 'backgroundColor' ],
+			readPath,
+		)
+		extendPristineSnapshot(
+			'cid-1',
+			{ backgroundColor: 'palette-red', textColor: 'palette-blue' },
+			[ 'textColor' ],
+			readPath,
+		)
+
+		expect( getPristineSnapshot( 'cid-1' ) ).toEqual( {
+			backgroundColor: 'palette-red',
+			textColor:       'palette-blue',
+		} )
+	} )
+
+	it( 'never overwrites an already-captured path', () => {
+		extendPristineSnapshot(
+			'cid-1',
+			{ backgroundColor: 'palette-red' },
+			[ 'backgroundColor' ],
+			readPath,
+		)
+		// Simulate a second pick on the same path after the base has
+		// been mirrored to the hover value — the snapshot must still
+		// hold the ORIGINAL idle value.
+		extendPristineSnapshot(
+			'cid-1',
+			{ backgroundColor: 'palette-blue' },
+			[ 'backgroundColor' ],
+			readPath,
+		)
+
+		expect( getPristineSnapshot( 'cid-1' ) ).toEqual( {
+			backgroundColor: 'palette-red',
+		} )
+	} )
+
+	it( 'captures undefined for paths the block has never set', () => {
+		extendPristineSnapshot(
+			'cid-1',
+			{ /* no backgroundColor */ },
+			[ 'backgroundColor' ],
+			readPath,
+		)
+
+		const snapshot = getPristineSnapshot( 'cid-1' )
+		expect( snapshot ).not.toBeUndefined()
+		expect( 'backgroundColor' in ( snapshot as Record<string, unknown> ) ).toBe( true )
+		expect( ( snapshot as Record<string, unknown> ).backgroundColor ).toBeUndefined()
 	} )
 } )

--- a/resources/js/visual-editor/states/__tests__/state-write-interceptor.test.ts
+++ b/resources/js/visual-editor/states/__tests__/state-write-interceptor.test.ts
@@ -106,6 +106,75 @@ describe( 'planCorrection', () => {
 		} )
 	} )
 
+	it( 'preserves style siblings when routing a nested path (#515)', () => {
+		const correction = planCorrection(
+			{
+				style: {
+					color:   { background: '#2eccc6' },
+					spacing: { padding: '10px' },
+					border:  { radius: '4px' },
+				},
+			},
+			{
+				style: {
+					color:   { background: '#e11919' },
+					spacing: { padding: '10px' },
+					border:  { radius: '4px' },
+				},
+			},
+			ROOTS,
+			'hover',
+		)
+
+		expect( correction ).not.toBeNull()
+
+		const payloadStyle = correction!.updatePayload.style as Record<string, unknown>
+		expect( ( payloadStyle.color as Record<string, unknown> ).background ).toBe( '#e11919' )
+		// Siblings must survive the shallow merge dispatched by
+		// updateBlockAttributes — otherwise spacing and border would
+		// be clobbered.
+		expect( ( payloadStyle.spacing as Record<string, unknown> ).padding ).toBe( '10px' )
+		expect( ( payloadStyle.border as Record<string, unknown> ).radius ).toBe( '4px' )
+
+		const correctedStyle = correction!.correctedAttributes.style as Record<string, unknown>
+		expect( ( correctedStyle.spacing as Record<string, unknown> ).padding ).toBe( '10px' )
+		expect( ( correctedStyle.border as Record<string, unknown> ).radius ).toBe( '4px' )
+	} )
+
+	it( 'routes a custom hex write on a non-idle state into states (#515)', () => {
+		const correction = planCorrection(
+			{
+				style:  {
+					color:   { background: '#2eccc6' },
+					spacing: { padding: '10px' },
+				},
+				states: {
+					'style.color.background': { hover: '#2eccc6' },
+				},
+			},
+			{
+				style:  {
+					color:   { background: '#e11919' },
+					spacing: { padding: '10px' },
+				},
+				states: {
+					'style.color.background': { hover: '#2eccc6' },
+				},
+			},
+			ROOTS,
+			'hover',
+		)
+
+		expect( correction ).not.toBeNull()
+		expect( correction!.updatePayload.states ).toEqual( {
+			'style.color.background': { hover: '#e11919' },
+		} )
+
+		const payloadStyle = correction!.updatePayload.style as Record<string, unknown>
+		expect( ( payloadStyle.color as Record<string, unknown> ).background ).toBe( '#e11919' )
+		expect( ( payloadStyle.spacing as Record<string, unknown> ).padding ).toBe( '10px' )
+	} )
+
 	it( 'routes multiple state-eligible changes in one diff and keeps base synced', () => {
 		const correction = planCorrection(
 			{ backgroundColor: 'a', textColor: 'b' },

--- a/resources/js/visual-editor/states/__tests__/with-state-attributes.test.tsx
+++ b/resources/js/visual-editor/states/__tests__/with-state-attributes.test.tsx
@@ -115,7 +115,7 @@ describe( 'withStateAttributes — non-idle routing', () => {
 		} )
 	} )
 
-	it( 'routes a top-level palette write to attributes.states.backgroundColor.hover', () => {
+	it( 'routes a top-level palette write to attributes.states.backgroundColor.hover and mirrors to base (#515)', () => {
 		const setAttributes = vi.fn()
 		render(
 			<Wrapped
@@ -130,7 +130,10 @@ describe( 'withStateAttributes — non-idle routing', () => {
 		expect( setAttributes ).toHaveBeenCalledTimes( 1 )
 		const actual = setAttributes.mock.calls[ 0 ][ 0 ]
 
-		expect( actual.backgroundColor ).toBeUndefined()
+		// #515: the base is mirrored so the data store (read by
+		// panels via useSelect) stays in lockstep with the active
+		// state. The pristine idle value is restored before save.
+		expect( actual.backgroundColor ).toBe( 'pale-pink' )
 		expect( actual.states ).toEqual( {
 			backgroundColor: { hover: 'pale-pink' },
 		} )
@@ -151,7 +154,7 @@ describe( 'withStateAttributes — non-idle routing', () => {
 		expect( captured?.attributes.backgroundColor ).toBe( 'pale-pink' )
 	} )
 
-	it( 'preserves the idle base attribute when writing a non-idle override', () => {
+	it( 'mirrors state-eligible writes to the base so the data store stays in lockstep (#515)', () => {
 		const setAttributes = vi.fn()
 		render(
 			<Wrapped
@@ -163,7 +166,11 @@ describe( 'withStateAttributes — non-idle routing', () => {
 
 		captured?.setAttributes( { backgroundColor: 'pale-pink' } )
 
-		expect( setAttributes.mock.calls[ 0 ][ 0 ] ).not.toHaveProperty( 'backgroundColor' )
+		const actual = setAttributes.mock.calls[ 0 ][ 0 ]
+		expect( actual ).toHaveProperty( 'backgroundColor', 'pale-pink' )
+		expect( actual.states ).toEqual( {
+			backgroundColor: { hover: 'pale-pink' },
+		} )
 	} )
 
 	it( 'falls through to base for paths outside the state roots', () => {

--- a/resources/js/visual-editor/states/__tests__/with-state-attributes.test.tsx
+++ b/resources/js/visual-editor/states/__tests__/with-state-attributes.test.tsx
@@ -32,6 +32,10 @@ vi.mock( '@wordpress/blocks', () => {
 
 import { __setBlockType, __clearBlockTypes } from '@wordpress/blocks'
 import { withStateAttributes } from '../with-state-attributes'
+import {
+	getPristineSnapshot,
+	resetStateBridge,
+} from '../state-bridge'
 
 interface CapturedProps {
 	attributes: Record<string, unknown>
@@ -52,6 +56,7 @@ beforeEach( () => {
 	act( () => {
 		resetStateStores()
 	} )
+	resetStateBridge()
 	__clearBlockTypes()
 } )
 
@@ -59,6 +64,7 @@ afterEach( () => {
 	act( () => {
 		resetStateStores()
 	} )
+	resetStateBridge()
 	__clearBlockTypes()
 } )
 
@@ -186,5 +192,118 @@ describe( 'withStateAttributes — non-idle routing', () => {
 		captured?.setAttributes( { url: 'https://b.test' } )
 
 		expect( setAttributes ).toHaveBeenCalledWith( { url: 'https://b.test' } )
+	} )
+
+	it( 'snapshots the pristine idle base before mirroring the first hover pick (#515 follow-up)', () => {
+		// Reproduces the user-reported regression: idle is a palette
+		// slug, hover overwrites the base via the mirror, and switching
+		// back to idle reads the mirrored hover value because no
+		// pristine snapshot was ever taken.
+		const setAttributes = vi.fn()
+		render(
+			<Wrapped
+				clientId="cid-1"
+				name="artisanpack/button"
+				attributes={ { backgroundColor: 'palette-red' } }
+				setAttributes={ setAttributes }
+			/> as never,
+		)
+
+		captured?.setAttributes( { backgroundColor: 'palette-blue' } )
+
+		expect( getPristineSnapshot( 'cid-1' ) ).toEqual( {
+			backgroundColor: 'palette-red',
+		} )
+	} )
+
+	it( 'preserves the original idle value when the same path is picked twice on hover', () => {
+		const setAttributes = vi.fn()
+		const { rerender } = render(
+			<Wrapped
+				clientId="cid-1"
+				name="artisanpack/button"
+				attributes={ { backgroundColor: 'palette-red' } }
+				setAttributes={ setAttributes }
+			/> as never,
+		)
+
+		captured?.setAttributes( { backgroundColor: 'palette-blue' } )
+
+		// After the first pick, the parent has updated attributes —
+		// simulate the next render that reflects the mirrored base.
+		rerender(
+			<Wrapped
+				clientId="cid-1"
+				name="artisanpack/button"
+				attributes={ {
+					backgroundColor: 'palette-blue',
+					states:          { backgroundColor: { hover: 'palette-blue' } },
+				} }
+				setAttributes={ setAttributes }
+			/> as never,
+		)
+
+		captured?.setAttributes( { backgroundColor: 'palette-green' } )
+
+		// Still the very first idle value — the snapshot is never
+		// overwritten by subsequent picks on the same path.
+		expect( getPristineSnapshot( 'cid-1' ) ).toEqual( {
+			backgroundColor: 'palette-red',
+		} )
+	} )
+
+	it( 'extends the snapshot when a different state-eligible path is picked next', () => {
+		const setAttributes = vi.fn()
+		const { rerender } = render(
+			<Wrapped
+				clientId="cid-1"
+				name="artisanpack/button"
+				attributes={ {
+					backgroundColor: 'palette-red',
+					textColor:       'palette-black',
+				} }
+				setAttributes={ setAttributes }
+			/> as never,
+		)
+
+		captured?.setAttributes( { backgroundColor: 'palette-blue' } )
+
+		rerender(
+			<Wrapped
+				clientId="cid-1"
+				name="artisanpack/button"
+				attributes={ {
+					backgroundColor: 'palette-blue',
+					textColor:       'palette-black',
+					states:          { backgroundColor: { hover: 'palette-blue' } },
+				} }
+				setAttributes={ setAttributes }
+			/> as never,
+		)
+
+		captured?.setAttributes( { textColor: 'palette-white' } )
+
+		expect( getPristineSnapshot( 'cid-1' ) ).toEqual( {
+			backgroundColor: 'palette-red',
+			textColor:       'palette-black',
+		} )
+	} )
+
+	it( 'does not snapshot when no clientId is provided', () => {
+		// Defensive: hosts that wrap BlockEdit components without
+		// forwarding clientId (mostly test harnesses) shouldn't trip
+		// an exception — the snapshot is simply skipped.
+		const setAttributes = vi.fn()
+		render(
+			<Wrapped
+				name="artisanpack/button"
+				attributes={ { backgroundColor: 'palette-red' } }
+				setAttributes={ setAttributes }
+			/> as never,
+		)
+
+		captured?.setAttributes( { backgroundColor: 'palette-blue' } )
+
+		expect( setAttributes ).toHaveBeenCalledTimes( 1 )
 	} )
 } )

--- a/resources/js/visual-editor/states/__tests__/with-state-attributes.test.tsx
+++ b/resources/js/visual-editor/states/__tests__/with-state-attributes.test.tsx
@@ -289,6 +289,52 @@ describe( 'withStateAttributes — non-idle routing', () => {
 		} )
 	} )
 
+	it( 'preserves both state and non-state writes when they share a top-level key', () => {
+		// Regression for a CodeRabbit-flagged correctness bug:
+		// rebuilding the same top-level subtree twice via two
+		// Object.assign calls clobbered the first patch's siblings. A
+		// single panel write that touches both style.color.background
+		// (state-eligible) and style.spacing.padding (not) must keep
+		// both changes intact.
+		__setBlockType( 'artisanpack/button', {
+			artisanpackStates: { attributes: [ 'backgroundColor', 'style.color.background' ] },
+		} )
+
+		const setAttributes = vi.fn()
+		render(
+			<Wrapped
+				clientId="cid-1"
+				name="artisanpack/button"
+				attributes={ {
+					style: {
+						color:   { background: '#old' },
+						spacing: { padding: '10px' },
+					},
+				} }
+				setAttributes={ setAttributes }
+			/> as never,
+		)
+
+		captured?.setAttributes( {
+			style: {
+				color:   { background: '#new' },
+				spacing: { padding: '20px' },
+			},
+		} )
+
+		const actual = setAttributes.mock.calls[ 0 ][ 0 ]
+		const style  = actual.style as {
+			color: { background: string }
+			spacing: { padding: string }
+		}
+
+		expect( style.color.background ).toBe( '#new' )
+		expect( style.spacing.padding ).toBe( '20px' )
+		expect( actual.states ).toEqual( {
+			'style.color.background': { hover: '#new' },
+		} )
+	} )
+
 	it( 'does not snapshot when no clientId is provided', () => {
 		// Defensive: hosts that wrap BlockEdit components without
 		// forwarding clientId (mostly test harnesses) shouldn't trip

--- a/resources/js/visual-editor/states/index.ts
+++ b/resources/js/visual-editor/states/index.ts
@@ -52,6 +52,8 @@ export type { StateControlProps } from './StateControl'
 export { PreviewStateToggle } from './PreviewStateToggle'
 export type { PreviewStateToggleProps } from './PreviewStateToggle'
 
+export { flushBeforeSave } from './StateInspectorSync'
+
 export { BASE_KEY } from './types'
 export type { StateDefinition, StateKey, StateRegistrySnapshot, StatefulAttribute } from './types'
 

--- a/resources/js/visual-editor/states/state-bridge.ts
+++ b/resources/js/visual-editor/states/state-bridge.ts
@@ -80,6 +80,15 @@ export function consumeExpectedSyncedAttrs(
 }
 
 /**
+ * Returns all clientIds that currently have a pristine snapshot.
+ * Used by `flushBeforeSave` to restore every block's pristine base
+ * before host serialization.
+ */
+export function getAllPristineClientIds(): string[] {
+	return Array.from( pristineSnapshots.keys() )
+}
+
+/**
  * Test-only — wipe coordination state between specs.
  */
 export function resetStateBridge(): void {

--- a/resources/js/visual-editor/states/state-bridge.ts
+++ b/resources/js/visual-editor/states/state-bridge.ts
@@ -89,6 +89,43 @@ export function getAllPristineClientIds(): string[] {
 }
 
 /**
+ * Create or extend a pristine snapshot for `clientId`, recording the
+ * value at each `path` in `attributes` — but only for paths not already
+ * captured. Idempotent on revisits: subsequent calls for the same path
+ * never overwrite the original capture.
+ *
+ * This complements {@link setPristineSnapshot}, which {@link
+ * StateInspectorSync}'s own overlay flow uses to take a one-shot
+ * snapshot keyed on the paths returned by its `planOverlay`. That flow
+ * never captures the FIRST authored state pick, because at that
+ * moment the states bag is still empty and `planOverlay` returns null.
+ * `withStateAttributes` calls this function instead so the original
+ * idle base values are captured before its mirror-to-base step
+ * overwrites them.
+ */
+export function extendPristineSnapshot(
+	clientId: string,
+	attributes: Record<string, unknown>,
+	paths: string[],
+	readPath: ( source: unknown, path: string ) => unknown,
+): void {
+	let snapshot = pristineSnapshots.get( clientId )
+
+	if ( ! snapshot ) {
+		snapshot = {}
+		pristineSnapshots.set( clientId, snapshot )
+	}
+
+	for ( const path of paths ) {
+		if ( path in snapshot ) {
+			continue
+		}
+
+		snapshot[ path ] = readPath( attributes, path )
+	}
+}
+
+/**
  * Test-only — wipe coordination state between specs.
  */
 export function resetStateBridge(): void {

--- a/resources/js/visual-editor/states/state-write-interceptor.tsx
+++ b/resources/js/visual-editor/states/state-write-interceptor.tsx
@@ -34,9 +34,9 @@ import { useDispatch, useSelect } from '@wordpress/data'
 import { useEffect, useRef, useSyncExternalStore } from 'react'
 
 import {
+	buildTopLevelPatch,
 	diffPaths,
 	pathMatchesAnyRoot,
-	setPath,
 } from '../responsive/attribute-paths'
 import { getActiveState, subscribeActiveState } from './active-state'
 import { consumeExpectedSyncedAttrs } from './state-bridge'
@@ -111,8 +111,8 @@ export function planCorrection(
 		return null
 	}
 
-	let basePatch: Record<string, unknown> | null = null
-	let statesPatch: StatesByPath | null          = null
+	const entriesByTopKey = new Map<string, Array<{ path: string; value: unknown }>>()
+	let statesPatch: StatesByPath | null = null
 
 	for ( const { path, value } of changedLeaves ) {
 		// Ignore writes to the states bag itself — those are either
@@ -134,7 +134,10 @@ export function planCorrection(
 			[ activeState ]: value,
 		}
 
-		basePatch = setPath( basePatch ?? {}, path, value )
+		const topKey = path.split( '.' )[ 0 ]
+		const list   = entriesByTopKey.get( topKey ) ?? []
+		list.push( { path, value } )
+		entriesByTopKey.set( topKey, list )
 	}
 
 	if ( ! statesPatch ) {
@@ -146,14 +149,21 @@ export function planCorrection(
 		...statesPatch,
 	}
 
+	// Build a sibling-preserving top-level patch. Each touched
+	// subtree (e.g. `style`) is deep-cloned from `curr` with the
+	// changed leaves applied, so `updateBlockAttributes` (shallow
+	// merge at top level) does not clobber siblings like `spacing`
+	// when only `style.color.background` changed.
+	const basePatch = buildTopLevelPatch( curr, entriesByTopKey )
+
 	const updatePayload: Record<string, unknown> = {
-		...( basePatch ?? {} ),
+		...basePatch,
 		states: nextStates,
 	}
 
 	const correctedAttributes: Record<string, unknown> = {
 		...curr,
-		...( basePatch ?? {} ),
+		...basePatch,
 		states: nextStates,
 	}
 

--- a/resources/js/visual-editor/states/with-state-attributes.tsx
+++ b/resources/js/visual-editor/states/with-state-attributes.tsx
@@ -259,17 +259,34 @@ export const withStateAttributes = createHigherOrderComponent(
 
 					const finalUpdates: Record<string, unknown> = {}
 
-					if ( baseEntriesByTopKey.size > 0 ) {
-						Object.assign(
-							finalUpdates,
-							buildTopLevelPatch( mergedAttributes, baseEntriesByTopKey ),
-						)
-					}
+					// Merge the two entry maps before patching so a single
+					// top-level subtree (e.g. `style`) that has BOTH a
+					// state-eligible leaf (`style.color.background`) and a
+					// non-state-eligible sibling (`style.spacing.padding`)
+					// is rebuilt once. Calling buildTopLevelPatch twice
+					// produces two independent deep-clones from
+					// mergedAttributes; Object.assign would then keep the
+					// second clone — silently reverting the first patch's
+					// sibling change.
+					if ( baseEntriesByTopKey.size > 0 || stateEntriesByTopKey.size > 0 ) {
+						const mergedEntries = new Map<string, Array<{ path: string; value: unknown }>>()
 
-					if ( stateEntriesByTopKey.size > 0 ) {
+						for ( const [ topKey, list ] of baseEntriesByTopKey ) {
+							mergedEntries.set( topKey, list.slice() )
+						}
+
+						for ( const [ topKey, list ] of stateEntriesByTopKey ) {
+							const existing = mergedEntries.get( topKey )
+							if ( existing ) {
+								existing.push( ...list )
+							} else {
+								mergedEntries.set( topKey, list.slice() )
+							}
+						}
+
 						Object.assign(
 							finalUpdates,
-							buildTopLevelPatch( mergedAttributes, stateEntriesByTopKey ),
+							buildTopLevelPatch( mergedAttributes, mergedEntries ),
 						)
 					}
 

--- a/resources/js/visual-editor/states/with-state-attributes.tsx
+++ b/resources/js/visual-editor/states/with-state-attributes.tsx
@@ -45,10 +45,12 @@ import {
 	deepMerge,
 	diffPaths,
 	pathMatchesAnyRoot,
+	readPath,
 	setPath,
 } from '../responsive/attribute-paths'
 import { getActiveState, subscribeActiveState } from './active-state'
 import { getStateRegistry } from './registry'
+import { extendPristineSnapshot } from './state-bridge'
 import { BASE_KEY } from './types'
 
 const FILTER_HOOK      = 'editor.BlockEdit'
@@ -64,6 +66,7 @@ interface GlobalSentinelHost {
 
 interface BlockEditProps {
 	name: string
+	clientId?: string
 	attributes: Record<string, unknown>
 	setAttributes: ( updates: Record<string, unknown> ) => void
 	[key: string]: unknown
@@ -182,7 +185,7 @@ function writeInto( target: Record<string, unknown>, path: string, value: unknow
 export const withStateAttributes = createHigherOrderComponent(
 	( BlockEdit: ComponentType<BlockEditProps> ) => {
 		function StateBlockEdit( props: BlockEditProps ): JSX.Element {
-			const { name, attributes, setAttributes } = props
+			const { name, attributes, setAttributes, clientId } = props
 
 			const roots = useMemo( () => getStateRoots( name ), [ name ] )
 
@@ -275,11 +278,38 @@ export const withStateAttributes = createHigherOrderComponent(
 							...( states ?? {} ),
 							...statesPatch,
 						}
+
+						// #515 follow-up: before the mirror overwrites the
+						// base attribute, capture the original idle value at
+						// every path we're about to mirror. Switching back
+						// to idle would otherwise read the mirrored
+						// non-idle value from the data store and surface it
+						// as the idle base — most visibly when the idle
+						// pick was a palette slug. The snapshot is keyed by
+						// clientId and only adds paths it doesn't already
+						// hold, so subsequent picks on the same path leave
+						// the original capture intact and picks on new
+						// paths extend the snapshot.
+						if ( 'string' === typeof clientId ) {
+							const pathsToSnapshot: string[] = []
+							for ( const list of stateEntriesByTopKey.values() ) {
+								for ( const entry of list ) {
+									pathsToSnapshot.push( entry.path )
+								}
+							}
+
+							extendPristineSnapshot(
+								clientId,
+								attributes,
+								pathsToSnapshot,
+								readPath,
+							)
+						}
 					}
 
 					setAttributes( finalUpdates )
 				},
-				[ activeState, mergedAttributes, states, roots, setAttributes ],
+				[ activeState, attributes, clientId, mergedAttributes, states, roots, setAttributes ],
 			)
 
 			if ( ! roots ) {

--- a/resources/js/visual-editor/states/with-state-attributes.tsx
+++ b/resources/js/visual-editor/states/with-state-attributes.tsx
@@ -41,6 +41,7 @@ import { useCallback, useMemo, useSyncExternalStore } from 'react'
 import type { ComponentType } from 'react'
 
 import {
+	buildTopLevelPatch,
 	deepMerge,
 	diffPaths,
 	pathMatchesAnyRoot,
@@ -223,8 +224,9 @@ export const withStateAttributes = createHigherOrderComponent(
 						return
 					}
 
-					const baseUpdates: Record<string, unknown> = {}
 					let statesPatch: StateOverridesByPath | null = null
+					const stateEntriesByTopKey = new Map<string, Array<{ path: string; value: unknown }>>()
+					const baseEntriesByTopKey  = new Map<string, Array<{ path: string; value: unknown }>>()
 
 					for ( const { path, value } of changedLeaves ) {
 						if ( pathMatchesAnyRoot( path, roots ) ) {
@@ -233,16 +235,40 @@ export const withStateAttributes = createHigherOrderComponent(
 								...( states?.[ path ] ?? {} ),
 								[ activeState ]: value,
 							}
+
+							// #515: also mirror to the base so the data store
+							// (read by panels via useSelect) stays in lockstep
+							// with the active state. The pristine idle base is
+							// preserved in the bridge's snapshot and restored
+							// before save.
+							const topKey = path.split( '.' )[ 0 ]
+							const list   = stateEntriesByTopKey.get( topKey ) ?? []
+							list.push( { path, value } )
+							stateEntriesByTopKey.set( topKey, list )
 							continue
 						}
 
+						const topKey = path.split( '.' )[ 0 ]
+						const list   = baseEntriesByTopKey.get( topKey ) ?? []
+						list.push( { path, value } )
+						baseEntriesByTopKey.set( topKey, list )
+					}
+
+					const finalUpdates: Record<string, unknown> = {}
+
+					if ( baseEntriesByTopKey.size > 0 ) {
 						Object.assign(
-							baseUpdates,
-							setPath( baseUpdates, path, value ),
+							finalUpdates,
+							buildTopLevelPatch( mergedAttributes, baseEntriesByTopKey ),
 						)
 					}
 
-					const finalUpdates: Record<string, unknown> = { ...baseUpdates }
+					if ( stateEntriesByTopKey.size > 0 ) {
+						Object.assign(
+							finalUpdates,
+							buildTopLevelPatch( mergedAttributes, stateEntriesByTopKey ),
+						)
+					}
 
 					if ( statesPatch ) {
 						finalUpdates.states = {


### PR DESCRIPTION
## Description

When the inspector's State chip strip is set to a non-idle state (Hover, Focus, etc.), picking a custom hex color via Color > Background did not persist into `attributes.states.<path>.<activeState>`. After save+reload the states bag still held the previous hover value. Palette slug picks on the same chip worked correctly — only custom hex was affected.

A follow-up regression surfaced during host-app testing: picking a palette color for idle and then any color (custom or palette) for hover caused hover's value to overtake idle's value in the inspector. Both are addressed on this branch.

**Closes:** #515

## Type of Change

- [x] Bug fix (fixes an issue)

## Related Issue

**Issue:** #515

## Motivation and Context

Four root causes:

1. **HOC did not mirror state-eligible writes to the base attribute.** WP's newer block-support panels (color/border/shadow on apiVersion 3 blocks) read attributes via `useSelect('core/block-editor').getBlockAttributes()` — bypassing the HOC's `mergedAttributes` prop. So even when the HOC routed the value into `states.hover`, the inspector panel still read the old base value via `useSelect`.
2. **`planCorrection` clobbered sibling subtrees.** The interceptor's `setPath`-built `updatePayload` was shallow-merged at the top level by `updateBlockAttributes`, replacing the entire `style` subtree and losing sibling leaves like `style.spacing.padding`.
3. **Block-change pristine restore targeted the wrong block.** When selection changed, `restorePristine` ran with the new block's id — leaving the previous block's pristine snapshot orphaned and its overlay leaked into save.
4. **Save lifecycle without `core/editor`.** Hosts that don't register `core/editor` never fire `isSavingPost`, so the save-time pristine restore in `StateInspectorSync` never ran.

Plus a regression discovered in-browser:

5. **No pristine snapshot on the first non-idle pick.** `StateInspectorSync.planOverlay` short-circuits when the states bag is empty, so the very first authored hover write had no pristine snapshot to restore. Switching back to idle showed the mirrored hover value as the idle base — most visibly when idle was a palette slug.

## Changes Made

- `states/with-state-attributes.tsx` — HOC mirrors state-eligible writes to the base attribute via `buildTopLevelPatch` for sibling preservation; captures pristine idle base values before mirroring (the regression fix); merges base + state entry maps before patching so a single tick touching both a state-eligible leaf and a non-state-eligible sibling under the same top-level key preserves both changes (CodeRabbit follow-up).
- `states/state-write-interceptor.tsx` — `planCorrection` uses `buildTopLevelPatch` instead of `setPath` for sibling preservation.
- `states/StateInspectorSync.tsx` — Block-change restore targets the previous block; uses shared `buildTopLevelPatch`/`deepClone`; exports `flushBeforeSave()` for host-agnostic save flush.
- `states/state-bridge.ts` — Adds `getAllPristineClientIds()` and `extendPristineSnapshot()` (creates or extends a snapshot, only adding paths not already captured).
- `states/index.ts` — Exports `flushBeforeSave`.
- `editor/use-persistence.ts` — Save path patches blocks with pristine bases before sending to API.
- `responsive/attribute-paths.ts` — Adds `deepClone` and `buildTopLevelPatch` shared helpers.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS
- Browser: Chrome
- PHP Version: 8.4
- Project Version: visual-editor branch `release/1.0`

**Tests Performed:**
1. Vitest unit + integration suite: **1683 tests passing** (8 new tests for `extendPristineSnapshot`, HOC pristine capture, and the same-top-key sibling fix; 1 new test for the CodeRabbit-flagged map-merge case).
2. Pest PHP suite: 805 tests passing.
3. In-browser manual verification in `jmwd-keystone-cms` host app: button block, Hover state chip, custom hex pick persists across save+reload. Palette idle + any hover no longer overtakes idle. All scenarios confirmed working by issue reporter.

## Accessibility Tests Run

- [x] Keyboard navigation tested (state chip switcher still navigable)
- [ ] Screen reader tested — n/a (no UI surface added)
- [x] Color contrast verified
- [ ] ARIA labels checked — n/a

**Details:** No new UI surface; existing state switcher and inspector panels are untouched.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:**
- `state-bridge` — 4 new tests for `extendPristineSnapshot` (create / extend / no-overwrite / undefined-path).
- `with-state-attributes` — 5 new tests covering pristine capture on first pick, same-path no-overwrite, different-path extension, no-clientId graceful skip, and same-top-key sibling preservation (CodeRabbit-flagged).
- `StateInspectorSync` — existing test coverage retained.

## Documentation

- [x] Inline code documentation added
- [ ] README updated — n/a
- [ ] Wiki updated — n/a
- [ ] API documentation updated — n/a

**Documentation details:** Full diagnosis and fix narrative in `docs/plans/515-custom-hex-state-routing.md`.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted (CodeRabbit CLI: 2 passes, 0 findings on final pass)
- [x] Accessibility tests completed
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Custom hex color selections in non-idle states (Hover/Focus) now persist correctly without clobbering sibling style properties; previously lost custom colors are preserved on save.
  * Prevented previous block overlay values from being accidentally serialized when switching selection.

* **Documentation**
  * Added a plan documenting the color state persistence fixes and troubleshooting steps.

* **Tests**
  * Expanded test coverage for state routing, patching, and snapshot behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->