### PR TITLE
feat: comments-family renderer parity + CommentInliner + post-comments / pagination forks (#519 Pass 2)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     "pestphp/pest": "^3.8",
     "pestphp/pest-plugin-laravel": "^3.1",
     "orchestra/testbench": "^10.2",
-    "artisanpack-ui/cms-framework": "^1.1"
+    "artisanpack-ui/cms-framework": "^2.0"
   },
   "repositories": [
     {
@@ -48,10 +48,10 @@
   ],
   "suggest": {
     "artisanpack-ui/media-library": "Recommended ^1.2 — default media library integration. Wire MediaModal + uploadMedia through registerArtisanpackMediaBridge() in the editor bootstrap to power Gutenberg's media picker and upload flows. Not enforced by Composer; host apps are free to install a different library and register a custom bridge instead.",
-    "artisanpack-ui/cms-framework": "Required ^1.1 for the site editor — the `/visual-editor/site-editor` route is hard-coupled to cms-framework's templates, parts, patterns, global styles, and menus modules (plan 14). Without it, the post-content editor still works but the site editor route returns an install gate."
+    "artisanpack-ui/cms-framework": "Required ^2.0 for the site editor + comments family — the `/visual-editor/site-editor` route is hard-coupled to cms-framework's templates, parts, patterns, global styles, and menus modules (plan 14), and the comments-family forks (#519) consume the Blog module's `Comment` model + `Post::comments` relation introduced in 2.1. Without it, the post-content editor still works but the site editor route returns an install gate and the comments-family blocks render against an empty data set."
   },
   "_comments": {
-    "repositories": "The path repository to ../cms-framework is a development-only convenience for the symlinked workflow used in the dev-app (see ../artisanpack-ui-dev/composer.json). On a fresh clone without the sibling cms-framework checkout, composer install will fail to resolve cms-framework — that's expected for now; the package's release pipeline pulls cms-framework from Packagist via the ^1.1 constraint. CI removes this entry before installing. Tracked for a permanent fix (e.g. an env-gated repository) in #434."
+    "repositories": "The path repository to ../cms-framework is a development-only convenience for the symlinked workflow used in the dev-app (see ../artisanpack-ui-dev/composer.json). On a fresh clone without the sibling cms-framework checkout, composer install will fail to resolve cms-framework — that's expected for now; the package's release pipeline pulls cms-framework from Packagist via the ^2.0 constraint. CI removes this entry before installing. Tracked for a permanent fix (e.g. an env-gated repository) in #434."
   },
   "scripts": {
     "test": "./vendor/bin/pest"

--- a/config/visual-editor.php
+++ b/config/visual-editor.php
@@ -149,8 +149,7 @@ return [
 		'artisanpack/search',
 		'artisanpack/latest-posts',
 		// Comments family — Pass 1 forks (#519): wrapper + template +
-		// per-comment display blocks. Post-level comments metadata and
-		// pagination blocks are deferred to Pass 2.
+		// per-comment display blocks.
 		'artisanpack/comments',
 		'artisanpack/comment-template',
 		'artisanpack/comment-author-avatar',
@@ -159,6 +158,18 @@ return [
 		'artisanpack/comment-date',
 		'artisanpack/comment-edit-link',
 		'artisanpack/comment-reply-link',
+		// Comments family — Pass 2 forks (#519): post-level comments
+		// metadata + pagination cluster. Post-level display blocks
+		// resolve through PostResolver; pagination blocks render
+		// against request-time state.
+		'artisanpack/post-comments-form',
+		'artisanpack/post-comments-count',
+		'artisanpack/post-comments-link',
+		'artisanpack/post-comments-title',
+		'artisanpack/comments-pagination',
+		'artisanpack/comments-pagination-next',
+		'artisanpack/comments-pagination-numbers',
+		'artisanpack/comments-pagination-previous',
 	],
 
 	'disabled_blocks' => [

--- a/packages/renderer-parity.json
+++ b/packages/renderer-parity.json
@@ -96,6 +96,22 @@
         "artisanpack/site-logo",
         "artisanpack/navigation",
         "artisanpack/query",
-        "artisanpack/post-template"
+        "artisanpack/post-template",
+        "artisanpack/comments",
+        "artisanpack/comment-template",
+        "artisanpack/comment-author-avatar",
+        "artisanpack/comment-author-name",
+        "artisanpack/comment-content",
+        "artisanpack/comment-date",
+        "artisanpack/comment-edit-link",
+        "artisanpack/comment-reply-link",
+        "artisanpack/post-comments-form",
+        "artisanpack/post-comments-count",
+        "artisanpack/post-comments-link",
+        "artisanpack/post-comments-title",
+        "artisanpack/comments-pagination",
+        "artisanpack/comments-pagination-next",
+        "artisanpack/comments-pagination-numbers",
+        "artisanpack/comments-pagination-previous"
     ]
 }

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/comment-author-avatar.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/comment-author-avatar.blade.php
@@ -1,0 +1,15 @@
+@php
+	use ArtisanPackUI\VisualEditorRendererBlade\Support\BlockSupports;
+	use ArtisanPackUI\VisualEditorRendererBlade\Support\UrlSanitizer;
+
+	$url = UrlSanitizer::safe( isset( $attributes['_resolvedAvatarUrl'] ) && is_string( $attributes['_resolvedAvatarUrl'] ) ? $attributes['_resolvedAvatarUrl'] : '' );
+	$alt = isset( $attributes['_resolvedAvatarAlt'] ) && is_string( $attributes['_resolvedAvatarAlt'] ) ? $attributes['_resolvedAvatarAlt'] : '';
+
+	$width  = isset( $attributes['width'] ) && is_numeric( $attributes['width'] ) ? (int) $attributes['width'] : 96;
+	$height = isset( $attributes['height'] ) && is_numeric( $attributes['height'] ) ? (int) $attributes['height'] : 96;
+@endphp
+<div{!! BlockSupports::wrapperAttrs( $attributes, [ 'wp-block-comment-author-avatar' ] ) !!}>
+	@if ( '' !== $url )
+		<img src="{{ $url }}" alt="{{ $alt }}" width="{{ $width }}" height="{{ $height }}" loading="lazy" />
+	@endif
+</div>

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/comment-author-name.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/comment-author-name.blade.php
@@ -1,0 +1,22 @@
+@php
+	use ArtisanPackUI\VisualEditorRendererBlade\Support\BlockSupports;
+	use ArtisanPackUI\VisualEditorRendererBlade\Support\UrlSanitizer;
+
+	$isLink     = ! empty( $attributes['isLink'] );
+	$linkTarget = isset( $attributes['linkTarget'] ) && is_string( $attributes['linkTarget'] ) ? $attributes['linkTarget'] : '_self';
+
+	$name      = isset( $attributes['_resolvedAuthorName'] ) && is_string( $attributes['_resolvedAuthorName'] ) ? $attributes['_resolvedAuthorName'] : '';
+	$authorUrl = UrlSanitizer::safe( isset( $attributes['_resolvedAuthorUrl'] ) && is_string( $attributes['_resolvedAuthorUrl'] ) ? $attributes['_resolvedAuthorUrl'] : '' );
+
+	$linkAttrs = 'href="' . e( $authorUrl ) . '"';
+	if ( '_blank' === $linkTarget ) {
+		$linkAttrs .= ' target="_blank" rel="noopener noreferrer"';
+	}
+@endphp
+<div{!! BlockSupports::wrapperAttrs( $attributes, [ 'wp-block-comment-author-name' ] ) !!}>
+	@if ( $isLink && '' !== $authorUrl )
+		<a {!! $linkAttrs !!}>{{ $name }}</a>
+	@else
+		{{ $name }}
+	@endif
+</div>

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/comment-content.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/comment-content.blade.php
@@ -1,0 +1,14 @@
+@php
+	use ArtisanPackUI\VisualEditorRendererBlade\Support\BlockSupports;
+
+	$content = isset( $attributes['_resolvedContent'] ) && is_string( $attributes['_resolvedContent'] ) ? $attributes['_resolvedContent'] : '';
+	$align   = isset( $attributes['textAlign'] ) && is_string( $attributes['textAlign'] ) ? $attributes['textAlign'] : '';
+
+	$classes = [ 'wp-block-comment-content' ];
+	if ( '' !== $align ) {
+		$classes[] = 'has-text-align-' . $align;
+	}
+@endphp
+<div{!! BlockSupports::wrapperAttrs( $attributes, $classes ) !!}>
+	{!! $content !!}
+</div>

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/comment-date.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/comment-date.blade.php
@@ -1,0 +1,25 @@
+@php
+	use ArtisanPackUI\VisualEditorRendererBlade\Support\BlockSupports;
+	use ArtisanPackUI\VisualEditorRendererBlade\Support\UrlSanitizer;
+
+	$dateIso = isset( $attributes['_resolvedDate'] ) && is_string( $attributes['_resolvedDate'] ) ? $attributes['_resolvedDate'] : '';
+	$date    = isset( $attributes['_resolvedDateFormatted'] ) && is_string( $attributes['_resolvedDateFormatted'] ) ? $attributes['_resolvedDateFormatted'] : '';
+	$url     = UrlSanitizer::safe( isset( $attributes['_resolvedPermalink'] ) && is_string( $attributes['_resolvedPermalink'] ) ? $attributes['_resolvedPermalink'] : '' );
+
+	$isLink = ! empty( $attributes['isLink'] );
+@endphp
+<div{!! BlockSupports::wrapperAttrs( $attributes, [ 'wp-block-comment-date' ] ) !!}>
+	@if ( $isLink && '' !== $url )
+		<a href="{{ $url }}">
+			@if ( '' !== $dateIso )
+				<time datetime="{{ $dateIso }}">{{ $date }}</time>
+			@else
+				{{ $date }}
+			@endif
+		</a>
+	@elseif ( '' !== $dateIso )
+		<time datetime="{{ $dateIso }}">{{ $date }}</time>
+	@else
+		{{ $date }}
+	@endif
+</div>

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/comment-edit-link.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/comment-edit-link.blade.php
@@ -1,0 +1,15 @@
+@php
+	use ArtisanPackUI\VisualEditorRendererBlade\Support\BlockSupports;
+	use ArtisanPackUI\VisualEditorRendererBlade\Support\UrlSanitizer;
+
+	$url   = UrlSanitizer::safe( isset( $attributes['_resolvedEditLinkUrl'] ) && is_string( $attributes['_resolvedEditLinkUrl'] ) ? $attributes['_resolvedEditLinkUrl'] : '' );
+	$label = isset( $attributes['_resolvedEditLinkLabel'] ) && is_string( $attributes['_resolvedEditLinkLabel'] ) ? $attributes['_resolvedEditLinkLabel'] : __( 'Edit' );
+
+	$linkTarget = isset( $attributes['linkTarget'] ) && is_string( $attributes['linkTarget'] ) ? $attributes['linkTarget'] : '_self';
+	$targetAttr = '_blank' === $linkTarget ? ' target="_blank" rel="noopener noreferrer"' : '';
+@endphp
+@if ( '' !== $url )
+	<div{!! BlockSupports::wrapperAttrs( $attributes, [ 'wp-block-comment-edit-link' ] ) !!}>
+		<a href="{{ $url }}"{!! $targetAttr !!}>{{ $label }}</a>
+	</div>
+@endif

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/comment-reply-link.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/comment-reply-link.blade.php
@@ -1,0 +1,12 @@
+@php
+	use ArtisanPackUI\VisualEditorRendererBlade\Support\BlockSupports;
+	use ArtisanPackUI\VisualEditorRendererBlade\Support\UrlSanitizer;
+
+	$url   = UrlSanitizer::safe( isset( $attributes['_resolvedReplyLinkUrl'] ) && is_string( $attributes['_resolvedReplyLinkUrl'] ) ? $attributes['_resolvedReplyLinkUrl'] : '' );
+	$label = isset( $attributes['_resolvedReplyLinkLabel'] ) && is_string( $attributes['_resolvedReplyLinkLabel'] ) ? $attributes['_resolvedReplyLinkLabel'] : __( 'Reply' );
+@endphp
+@if ( '' !== $url )
+	<div{!! BlockSupports::wrapperAttrs( $attributes, [ 'wp-block-comment-reply-link' ] ) !!}>
+		<a href="{{ $url }}">{{ $label }}</a>
+	</div>
+@endif

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/comment-template.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/comment-template.blade.php
@@ -1,0 +1,16 @@
+@php
+	use ArtisanPackUI\VisualEditorRendererBlade\Support\BlockSupports;
+@endphp
+{{--
+	comment-template wrapper.
+
+	The server-side CommentInliner clones this block's inner tree once
+	per resolved comment and stamps each iteration with the per-comment
+	`_resolved*` attributes via CommentResolver, then concatenates the
+	rendered iterations into `$innerBlocksHtml`. The renderer just
+	wraps the result in the `<ol class="wp-block-comment-template">`
+	scaffold WordPress uses.
+--}}
+<ol{!! BlockSupports::wrapperAttrs( $attributes, [ 'wp-block-comment-template' ] ) !!}>
+	{!! $innerBlocksHtml !!}
+</ol>

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/comments-pagination-next.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/comments-pagination-next.blade.php
@@ -1,0 +1,14 @@
+@php
+	use ArtisanPackUI\VisualEditorRendererBlade\Support\BlockSupports;
+	use ArtisanPackUI\VisualEditorRendererBlade\Support\UrlSanitizer;
+
+	$url   = UrlSanitizer::safe( isset( $attributes['_resolvedNextPageUrl'] ) && is_string( $attributes['_resolvedNextPageUrl'] ) ? $attributes['_resolvedNextPageUrl'] : '' );
+	$label = isset( $attributes['label'] ) && is_string( $attributes['label'] ) && '' !== $attributes['label']
+		? $attributes['label']
+		: __( 'Newer Comments' );
+@endphp
+@if ( '' !== $url )
+	<a{!! BlockSupports::wrapperAttrs( $attributes, [ 'wp-block-comments-pagination-next' ] ) !!} href="{{ $url }}">{{ $label }} &rarr;</a>
+@else
+	<span{!! BlockSupports::wrapperAttrs( $attributes, [ 'wp-block-comments-pagination-next' ] ) !!}>{{ $label }}</span>
+@endif

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/comments-pagination-numbers.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/comments-pagination-numbers.blade.php
@@ -12,8 +12,14 @@
 			$href   = UrlSanitizer::safe( isset( $page['url'] ) && is_string( $page['url'] ) ? $page['url'] : '' );
 		@endphp
 		@if ( 0 !== $number )
-			@if ( $number === $current || '' === $href )
+			@if ( $number === $current )
+				{{-- Only the actual current page gets aria-current="page". A
+					non-current page with an empty href still renders as a
+					plain span (no link target) but must not claim to be the
+					current page. Mirrors the React / Vue renderer parity. --}}
 				<span class="page-numbers current" aria-current="page">{{ $number }}</span>
+			@elseif ( '' === $href )
+				<span class="page-numbers">{{ $number }}</span>
 			@else
 				<a class="page-numbers" href="{{ $href }}">{{ $number }}</a>
 			@endif

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/comments-pagination-numbers.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/comments-pagination-numbers.blade.php
@@ -1,0 +1,22 @@
+@php
+	use ArtisanPackUI\VisualEditorRendererBlade\Support\BlockSupports;
+	use ArtisanPackUI\VisualEditorRendererBlade\Support\UrlSanitizer;
+
+	$pages   = isset( $attributes['_resolvedPageNumbers'] ) && is_array( $attributes['_resolvedPageNumbers'] ) ? $attributes['_resolvedPageNumbers'] : [];
+	$current = isset( $attributes['_resolvedCurrentPage'] ) && is_numeric( $attributes['_resolvedCurrentPage'] ) ? (int) $attributes['_resolvedCurrentPage'] : 1;
+@endphp
+<div{!! BlockSupports::wrapperAttrs( $attributes, [ 'wp-block-comments-pagination-numbers' ] ) !!}>
+	@foreach ( $pages as $page )
+		@php
+			$number = isset( $page['number'] ) && is_numeric( $page['number'] ) ? (int) $page['number'] : 0;
+			$href   = UrlSanitizer::safe( isset( $page['url'] ) && is_string( $page['url'] ) ? $page['url'] : '' );
+		@endphp
+		@if ( 0 !== $number )
+			@if ( $number === $current || '' === $href )
+				<span class="page-numbers current" aria-current="page">{{ $number }}</span>
+			@else
+				<a class="page-numbers" href="{{ $href }}">{{ $number }}</a>
+			@endif
+		@endif
+	@endforeach
+</div>

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/comments-pagination-previous.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/comments-pagination-previous.blade.php
@@ -1,0 +1,14 @@
+@php
+	use ArtisanPackUI\VisualEditorRendererBlade\Support\BlockSupports;
+	use ArtisanPackUI\VisualEditorRendererBlade\Support\UrlSanitizer;
+
+	$url   = UrlSanitizer::safe( isset( $attributes['_resolvedPreviousPageUrl'] ) && is_string( $attributes['_resolvedPreviousPageUrl'] ) ? $attributes['_resolvedPreviousPageUrl'] : '' );
+	$label = isset( $attributes['label'] ) && is_string( $attributes['label'] ) && '' !== $attributes['label']
+		? $attributes['label']
+		: __( 'Older Comments' );
+@endphp
+@if ( '' !== $url )
+	<a{!! BlockSupports::wrapperAttrs( $attributes, [ 'wp-block-comments-pagination-previous' ] ) !!} href="{{ $url }}">&larr; {{ $label }}</a>
+@else
+	<span{!! BlockSupports::wrapperAttrs( $attributes, [ 'wp-block-comments-pagination-previous' ] ) !!}>{{ $label }}</span>
+@endif

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/comments-pagination.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/comments-pagination.blade.php
@@ -1,0 +1,6 @@
+@php
+	use ArtisanPackUI\VisualEditorRendererBlade\Support\BlockSupports;
+@endphp
+<nav{!! BlockSupports::wrapperAttrs( $attributes, [ 'wp-block-comments-pagination' ] ) !!} aria-label="{{ __( 'Comments pagination' ) }}">
+	{!! $innerBlocksHtml !!}
+</nav>

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/comments.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/comments.blade.php
@@ -1,0 +1,9 @@
+@php
+	use ArtisanPackUI\VisualEditorRendererBlade\Support\BlockSupports;
+
+	$tagName = isset( $attributes['tagName'] ) && is_string( $attributes['tagName'] ) ? $attributes['tagName'] : 'div';
+	$tagName = in_array( strtolower( $tagName ), [ 'div', 'section', 'article', 'aside', 'footer' ], true ) ? strtolower( $tagName ) : 'div';
+@endphp
+<{!! $tagName !!}{!! BlockSupports::wrapperAttrs( $attributes, [ 'wp-block-comments' ] ) !!}>
+	{!! $innerBlocksHtml !!}
+</{!! $tagName !!}>

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/post-comments-count.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/post-comments-count.blade.php
@@ -1,0 +1,6 @@
+@php
+	use ArtisanPackUI\VisualEditorRendererBlade\Support\BlockSupports;
+
+	$count = isset( $attributes['_resolvedCommentCount'] ) && is_numeric( $attributes['_resolvedCommentCount'] ) ? (int) $attributes['_resolvedCommentCount'] : 0;
+@endphp
+<div{!! BlockSupports::wrapperAttrs( $attributes, [ 'wp-block-post-comments-count' ] ) !!}>{{ $count }}</div>

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/post-comments-form.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/post-comments-form.blade.php
@@ -1,0 +1,64 @@
+@php
+	use ArtisanPackUI\VisualEditorRendererBlade\Support\BlockSupports;
+	use ArtisanPackUI\VisualEditorRendererBlade\Support\UrlSanitizer;
+
+	// Default form target is the cms-framework comments REST endpoint
+	// (`POST /api/v1/comments`). That route returns 201 + JSON though,
+	// which is great for SPAs but not for a plain HTML form submit —
+	// the browser navigates to the JSON. Host apps that want a
+	// classic form-post UX should override this via the
+	// `comments.form.action` filter (artisanpack-ui/hooks) and point
+	// it at a controller that creates the comment and redirects back.
+	$defaultAction = isset( $attributes['_resolvedFormAction'] ) && is_string( $attributes['_resolvedFormAction'] )
+		? $attributes['_resolvedFormAction']
+		: '/api/v1/comments';
+	if ( function_exists( 'applyFilters' ) ) {
+		$defaultAction = ( string ) applyFilters( 'comments.form.action', $defaultAction );
+	}
+	$formAction = UrlSanitizer::safe( $defaultAction );
+@endphp
+{{--
+	post-comments-form
+
+	Renders a minimal, semantically-correct comment form. The default
+	`action` posts to cms-framework's `/api/v1/comments` endpoint; the
+	`comments.form.action` filter lets host apps redirect submissions
+	to their own controller so they can validate, persist, and redirect
+	back to the post with a flash message — the standard browser-form
+	UX the API endpoint can't provide on its own.
+--}}
+<div{!! BlockSupports::wrapperAttrs( $attributes, [ 'wp-block-post-comments-form', 'comment-respond' ] ) !!}>
+	<h3 class="comment-reply-title">{{ __( 'Leave a Comment' ) }}</h3>
+	<form action="{{ $formAction }}" method="post" class="comment-form">
+		@if ( function_exists( 'csrf_field' ) )
+			{!! csrf_field() !!}
+		@endif
+		@isset( $attributes['_resolvedPostId'] )
+			<input type="hidden" name="post_id" value="{{ (int) $attributes['_resolvedPostId'] }}" />
+		@endisset
+		<p class="comment-form-author">
+			<label for="comment-author">{{ __( 'Name' ) }} <span aria-hidden="true">*</span></label>
+			<input id="comment-author" name="author_name" type="text" autocomplete="name" required />
+		</p>
+		<p class="comment-form-email">
+			<label for="comment-email">{{ __( 'Email' ) }} <span aria-hidden="true">*</span></label>
+			<input id="comment-email" name="author_email" type="email" autocomplete="email" required />
+		</p>
+		<p class="comment-form-url">
+			<label for="comment-url">{{ __( 'Website' ) }}</label>
+			<input id="comment-url" name="author_url" type="url" autocomplete="url" />
+		</p>
+		<p class="comment-form-comment">
+			<label for="comment-content">{{ __( 'Comment' ) }} <span aria-hidden="true">*</span></label>
+			<textarea id="comment-content" name="content" rows="6" required></textarea>
+		</p>
+		<p class="form-submit">
+			{{-- Deliberately no `name="submit"` on the input — that
+			     attribute shadows the form's `.submit` property in
+			     the DOM and breaks any JS that hooks the form
+			     (analytics, validation libraries, etc.). The
+			     value isn't read server-side either. --}}
+			<input type="submit" class="submit" value="{{ __( 'Post Comment' ) }}" />
+		</p>
+	</form>
+</div>

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/post-comments-link.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/post-comments-link.blade.php
@@ -1,0 +1,17 @@
+@php
+	use ArtisanPackUI\VisualEditorRendererBlade\Support\BlockSupports;
+	use ArtisanPackUI\VisualEditorRendererBlade\Support\UrlSanitizer;
+
+	$count = isset( $attributes['_resolvedCommentCount'] ) && is_numeric( $attributes['_resolvedCommentCount'] ) ? (int) $attributes['_resolvedCommentCount'] : 0;
+	$url   = UrlSanitizer::safe( isset( $attributes['_resolvedCommentsUrl'] ) && is_string( $attributes['_resolvedCommentsUrl'] ) ? $attributes['_resolvedCommentsUrl'] : '' );
+	$label = isset( $attributes['_resolvedCommentsLabel'] ) && is_string( $attributes['_resolvedCommentsLabel'] )
+		? $attributes['_resolvedCommentsLabel']
+		: trans_choice( '{0} :count Comments|{1} :count Comment|[2,*] :count Comments', $count, [ 'count' => $count ] );
+@endphp
+<div{!! BlockSupports::wrapperAttrs( $attributes, [ 'wp-block-post-comments-link' ] ) !!}>
+	@if ( '' !== $url )
+		<a href="{{ $url }}">{{ $label }}</a>
+	@else
+		{{ $label }}
+	@endif
+</div>

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/post-comments-title.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/post-comments-title.blade.php
@@ -1,0 +1,24 @@
+@php
+	use ArtisanPackUI\VisualEditorRendererBlade\Support\BlockSupports;
+
+	$level = isset( $attributes['level'] ) && is_numeric( $attributes['level'] ) ? (int) $attributes['level'] : 2;
+	$level = max( 1, min( 6, $level ) );
+	$tag   = 'h' . $level;
+
+	$showCount = ! isset( $attributes['showCommentsCount'] ) || ! empty( $attributes['showCommentsCount'] );
+	$count     = isset( $attributes['_resolvedCommentCount'] ) && is_numeric( $attributes['_resolvedCommentCount'] ) ? (int) $attributes['_resolvedCommentCount'] : 0;
+	$title     = isset( $attributes['_resolvedCommentsTitle'] ) && is_string( $attributes['_resolvedCommentsTitle'] )
+		? $attributes['_resolvedCommentsTitle']
+		: ( 0 === $count ? 'No Comments' : ( 1 === $count ? '1 Comment' : $count . ' Comments' ) );
+
+	if ( ! $showCount ) {
+		$title = 'Comments';
+	}
+
+	$align   = isset( $attributes['textAlign'] ) && is_string( $attributes['textAlign'] ) ? $attributes['textAlign'] : '';
+	$classes = [ 'wp-block-post-comments-title' ];
+	if ( '' !== $align ) {
+		$classes[] = 'has-text-align-' . $align;
+	}
+@endphp
+<{!! $tag !!}{!! BlockSupports::wrapperAttrs( $attributes, $classes ) !!}>{{ $title }}</{!! $tag !!}>

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/post-comments-title.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/post-comments-title.blade.php
@@ -9,10 +9,10 @@
 	$count     = isset( $attributes['_resolvedCommentCount'] ) && is_numeric( $attributes['_resolvedCommentCount'] ) ? (int) $attributes['_resolvedCommentCount'] : 0;
 	$title     = isset( $attributes['_resolvedCommentsTitle'] ) && is_string( $attributes['_resolvedCommentsTitle'] )
 		? $attributes['_resolvedCommentsTitle']
-		: ( 0 === $count ? 'No Comments' : ( 1 === $count ? '1 Comment' : $count . ' Comments' ) );
+		: trans_choice( '{0} No Comments|{1} 1 Comment|[2,*] :count Comments', $count, [ 'count' => $count ] );
 
 	if ( ! $showCount ) {
-		$title = 'Comments';
+		$title = __( 'Comments' );
 	}
 
 	$align   = isset( $attributes['textAlign'] ) && is_string( $attributes['textAlign'] ) ? $attributes['textAlign'] : '';

--- a/packages/visual-editor-renderer-blade/src/View/Components/BlocksComponent.php
+++ b/packages/visual-editor-renderer-blade/src/View/Components/BlocksComponent.php
@@ -24,7 +24,9 @@ declare( strict_types=1 );
 
 namespace ArtisanPackUI\VisualEditorRendererBlade\View\Components;
 
+use ArtisanPackUI\VisualEditor\Resources\CommentInliner;
 use ArtisanPackUI\VisualEditor\Resources\PatternInliner;
+use ArtisanPackUI\VisualEditor\Resources\PostResolver;
 use ArtisanPackUI\VisualEditor\Resources\QueryInliner;
 use ArtisanPackUI\VisualEditor\Resources\TemplatePartInliner;
 use ArtisanPackUI\VisualEditor\Services\GlobalStylesEmissionTracker;
@@ -56,6 +58,8 @@ class BlocksComponent extends Component
 		protected TemplatePartInliner $inliner,
 		protected PatternInliner $patternInliner,
 		protected QueryInliner $queryInliner,
+		protected CommentInliner $commentInliner,
+		protected PostResolver $postResolver,
 		protected NavigationBlockRefResolver $navigationResolver,
 		protected GlobalStylesEmissionResolver $globalStyles,
 		protected GlobalStylesEmissionTracker $emissionTracker,
@@ -63,9 +67,12 @@ class BlocksComponent extends Component
 		protected StateCssAccumulator $stateAccumulator,
 		mixed $tree = null,
 		?string $defaultTheme = null,
+		mixed $post = null,
 		bool $resolveParts = true,
 		bool $resolvePatterns = true,
 		bool $resolveQueries = true,
+		bool $resolveComments = true,
+		bool $resolvePost = true,
 		bool $resolveNavigation = true,
 	) {
 		$this->defaultTheme = $defaultTheme;
@@ -88,6 +95,31 @@ class BlocksComponent extends Component
 		// gets each cloned nav block resolved to its menu items.
 		$resolved = $resolveQueries
 			? $this->queryInliner->inline( $resolved )
+			: $resolved;
+
+		// Comment inlining runs after query inlining so a `core/query` loop
+		// of posts where each iteration includes an `artisanpack/comments`
+		// block still works — though in that nested scenario the inliner
+		// will mark the comments block as unresolved unless the iteration
+		// stamped `$post` through a follow-up pass (tracked separately).
+		// For the common case (single-post template with a top-level
+		// `comments` block + the host post in scope), the supplied `$post`
+		// drives per-comment expansion via CommentResolver.
+		$resolved = ( $resolveComments && is_object( $post ) )
+			? $this->commentInliner->inline( $resolved, $post )
+			: $resolved;
+
+		// Top-level post resolution. When `$post` is supplied (e.g. a
+		// single-post or single-page template), `PostResolver` stamps the
+		// `_resolved*` keys on every `post-*` block in the saved tree —
+		// post-title, post-content, post-author-name, post-featured-image,
+		// post-comments-count, post-comments-link, post-comments-title,
+		// etc. — so they render against the current entity without each
+		// host having to wire a separate resolver pass. QueryInliner has
+		// already stamped per-iteration posts inside `post-template`
+		// expansions; this pass handles everything outside those loops.
+		$resolved = ( $resolvePost && is_object( $post ) )
+			? $this->postResolver->stampTree( $resolved, $post )
 			: $resolved;
 
 		// Navigation resolution mirrors the editor's read path

--- a/packages/visual-editor-renderer-react/src/blocks/artisanpack/commentContext.tsx
+++ b/packages/visual-editor-renderer-react/src/blocks/artisanpack/commentContext.tsx
@@ -1,0 +1,367 @@
+/**
+ * Comments-family renderers (#519).
+ *
+ * 16 blocks total — Pass 1 (comments wrapper + comment-template + 6
+ * per-comment leaves) and Pass 2 (post-comments-* metadata +
+ * pagination cluster). Each leaf reads its `_resolved*` attributes
+ * stamped by visual-editor's CommentResolver / PostResolver before
+ * the tree reaches the renderer, so this file stays pure — no data
+ * fetching, no DOM side effects, byte-shape parity with the Blade
+ * and Vue counterparts.
+ */
+
+import { useId } from 'react';
+import type { JSX } from 'react';
+
+import { attrBoolean, attrInt, attrString, classList } from '../../support/attributes';
+import { safeUrl } from '../../support/urlSanitizer';
+import type { BlockRendererProps } from '../../types';
+
+// --- Pass 1: comments wrapper + per-comment cluster ----------------------
+
+export function CommentsBlock({ attributes, children }: BlockRendererProps): JSX.Element {
+    const tagName = attrString(attributes.tagName, 'div').toLowerCase();
+    const safeTag = (['div', 'section', 'article', 'aside', 'footer'].includes(tagName)
+        ? tagName
+        : 'div') as 'div' | 'section' | 'article' | 'aside' | 'footer';
+    const className = attrString(attributes.className);
+    const classes = classList(['wp-block-comments', className]);
+
+    const Tag = safeTag;
+    return <Tag className={classes}>{children}</Tag>;
+}
+
+export function CommentTemplateBlock({ attributes, children }: BlockRendererProps): JSX.Element {
+    const className = attrString(attributes.className);
+    const classes = classList(['wp-block-comment-template', className]);
+
+    // The server-side CommentInliner clones the saved template once
+    // per resolved comment and stamps each iteration's leaves via
+    // CommentResolver, so `children` is already the expanded list
+    // by the time it reaches this renderer.
+    return <ol className={classes}>{children}</ol>;
+}
+
+export function CommentAuthorNameBlock({ attributes }: BlockRendererProps): JSX.Element {
+    const isLink = attrBoolean(attributes.isLink, true);
+    const linkTarget = attrString(attributes.linkTarget, '_self');
+    const align = attrString(attributes.textAlign);
+    const className = attrString(attributes.className);
+
+    const name = attrString(attributes._resolvedAuthorName);
+    const url = safeUrl(attrString(attributes._resolvedAuthorUrl));
+
+    const classes = classList([
+        'wp-block-comment-author-name',
+        align !== '' ? `has-text-align-${align}` : null,
+        className,
+    ]);
+
+    if (isLink && url !== '') {
+        const linkProps: Record<string, string> = { href: url };
+        if (linkTarget === '_blank') {
+            linkProps.target = '_blank';
+            linkProps.rel = 'noopener noreferrer';
+        }
+        return (
+            <div className={classes}>
+                <a {...linkProps}>{name}</a>
+            </div>
+        );
+    }
+    return <div className={classes}>{name}</div>;
+}
+
+export function CommentAuthorAvatarBlock({ attributes }: BlockRendererProps): JSX.Element {
+    const url = safeUrl(attrString(attributes._resolvedAvatarUrl));
+    const alt = attrString(attributes._resolvedAvatarAlt);
+    const width = Math.max(1, attrInt(attributes.width, 96));
+    const height = Math.max(1, attrInt(attributes.height, 96));
+    const className = attrString(attributes.className);
+
+    const classes = classList(['wp-block-comment-author-avatar', className]);
+
+    if (url === '') {
+        return <div className={classes} />;
+    }
+    return (
+        <div className={classes}>
+            <img src={url} alt={alt} width={width} height={height} loading="lazy" />
+        </div>
+    );
+}
+
+export function CommentContentBlock({ attributes }: BlockRendererProps): JSX.Element {
+    const align = attrString(attributes.textAlign);
+    const className = attrString(attributes.className);
+    const content = attrString(attributes._resolvedContent);
+
+    const classes = classList([
+        'wp-block-comment-content',
+        align !== '' ? `has-text-align-${align}` : null,
+        className,
+    ]);
+
+    return <div className={classes} dangerouslySetInnerHTML={{ __html: content }} />;
+}
+
+export function CommentDateBlock({ attributes }: BlockRendererProps): JSX.Element {
+    const isLink = attrBoolean(attributes.isLink, true);
+    const className = attrString(attributes.className);
+    const datetime = attrString(attributes._resolvedDate);
+    const formatted = attrString(attributes._resolvedDateFormatted, datetime);
+    const url = safeUrl(attrString(attributes._resolvedPermalink));
+
+    const classes = classList(['wp-block-comment-date', className]);
+
+    const timeNode = datetime !== '' ? <time dateTime={datetime}>{formatted}</time> : <>{formatted}</>;
+
+    return (
+        <div className={classes}>
+            {isLink && url !== '' ? <a href={url}>{timeNode}</a> : timeNode}
+        </div>
+    );
+}
+
+export function CommentEditLinkBlock({ attributes }: BlockRendererProps): JSX.Element | null {
+    const url = safeUrl(attrString(attributes._resolvedEditLinkUrl));
+    const label = attrString(attributes._resolvedEditLinkLabel, 'Edit');
+    const linkTarget = attrString(attributes.linkTarget, '_self');
+    const className = attrString(attributes.className);
+
+    if (url === '') {
+        return null;
+    }
+
+    const classes = classList(['wp-block-comment-edit-link', className]);
+    const linkProps: Record<string, string> = { href: url };
+    if (linkTarget === '_blank') {
+        linkProps.target = '_blank';
+        linkProps.rel = 'noopener noreferrer';
+    }
+
+    return (
+        <div className={classes}>
+            <a {...linkProps}>{label}</a>
+        </div>
+    );
+}
+
+export function CommentReplyLinkBlock({ attributes }: BlockRendererProps): JSX.Element | null {
+    const url = safeUrl(attrString(attributes._resolvedReplyLinkUrl));
+    const label = attrString(attributes._resolvedReplyLinkLabel, 'Reply');
+    const className = attrString(attributes.className);
+
+    if (url === '') {
+        return null;
+    }
+
+    const classes = classList(['wp-block-comment-reply-link', className]);
+    return (
+        <div className={classes}>
+            <a href={url}>{label}</a>
+        </div>
+    );
+}
+
+// --- Pass 2: post-comments-* metadata + pagination cluster --------------
+
+export function PostCommentsFormBlock({ attributes }: BlockRendererProps): JSX.Element {
+    // SPA contexts typically replace this with a real form. The
+    // default render is a scaffolded placeholder so the saved tree
+    // still emits something semantically correct.
+    //
+    // Element IDs are derived from React.useId() so multiple
+    // instances on the same page (e.g. a post-with-comments
+    // archive) get unique label-for/input-id pairings.
+    const uid = useId();
+    const authorId = `ve-comment-author-${uid}`;
+    const emailId = `ve-comment-email-${uid}`;
+    const contentId = `ve-comment-content-${uid}`;
+
+    const className = attrString(attributes.className);
+    const classes = classList(['wp-block-post-comments-form', 'comment-respond', className]);
+    const postId = attrInt(attributes._resolvedPostId, 0);
+    // Host apps redirect form submissions to their own form-handler
+    // controller by stamping `_resolvedFormAction` on the block via
+    // CommentInliner. The default points at cms-framework's REST
+    // endpoint, which returns JSON — fine for SPAs, not for HTML form
+    // submits where the user expects a redirect back to the post.
+    const formAction = safeUrl(attrString(attributes._resolvedFormAction, '/api/v1/comments'));
+
+    return (
+        <div className={classes}>
+            <h3 className="comment-reply-title">Leave a Comment</h3>
+            <form action={formAction} method="post" className="comment-form">
+                {postId > 0 ? <input type="hidden" name="post_id" value={postId} /> : null}
+                <p className="comment-form-author">
+                    <label htmlFor={authorId}>
+                        Name <span aria-hidden="true">*</span>
+                    </label>
+                    <input id={authorId} name="author_name" type="text" required />
+                </p>
+                <p className="comment-form-email">
+                    <label htmlFor={emailId}>
+                        Email <span aria-hidden="true">*</span>
+                    </label>
+                    <input id={emailId} name="author_email" type="email" required />
+                </p>
+                <p className="comment-form-comment">
+                    <label htmlFor={contentId}>
+                        Comment <span aria-hidden="true">*</span>
+                    </label>
+                    <textarea id={contentId} name="content" rows={6} required />
+                </p>
+                <p className="form-submit">
+                    {/*
+                     * Deliberately no `name="submit"` — that attribute
+                     * shadows the form's `.submit` property in the DOM
+                     * and breaks any JS that hooks the form.
+                     */}
+                    <input type="submit" className="submit" value="Post Comment" />
+                </p>
+            </form>
+        </div>
+    );
+}
+
+export function PostCommentsCountBlock({ attributes }: BlockRendererProps): JSX.Element {
+    const count = attrInt(attributes._resolvedCommentCount, 0);
+    const className = attrString(attributes.className);
+    const classes = classList(['wp-block-post-comments-count', className]);
+    return <div className={classes}>{count}</div>;
+}
+
+export function PostCommentsLinkBlock({ attributes }: BlockRendererProps): JSX.Element {
+    const count = attrInt(attributes._resolvedCommentCount, 0);
+    const url = safeUrl(attrString(attributes._resolvedCommentsUrl));
+    const fallbackLabel = count === 1 ? '1 Comment' : `${count} Comments`;
+    const label = attrString(attributes._resolvedCommentsLabel, fallbackLabel);
+    const className = attrString(attributes.className);
+    const classes = classList(['wp-block-post-comments-link', className]);
+
+    if (url === '') {
+        return <div className={classes}>{label}</div>;
+    }
+    return (
+        <div className={classes}>
+            <a href={url}>{label}</a>
+        </div>
+    );
+}
+
+export function PostCommentsTitleBlock({ attributes }: BlockRendererProps): JSX.Element {
+    const level = Math.max(1, Math.min(6, attrInt(attributes.level, 2)));
+    const showCount = attrBoolean(attributes.showCommentsCount, true);
+    const count = attrInt(attributes._resolvedCommentCount, 0);
+    const fallback = count === 0 ? 'No Comments' : count === 1 ? '1 Comment' : `${count} Comments`;
+    const title = showCount ? attrString(attributes._resolvedCommentsTitle, fallback) : 'Comments';
+    const align = attrString(attributes.textAlign);
+    const className = attrString(attributes.className);
+
+    const Tag = `h${level}` as 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+    const classes = classList([
+        'wp-block-post-comments-title',
+        align !== '' ? `has-text-align-${align}` : null,
+        className,
+    ]);
+
+    return <Tag className={classes}>{title}</Tag>;
+}
+
+export function CommentsPaginationBlock({ attributes, children }: BlockRendererProps): JSX.Element {
+    const className = attrString(attributes.className);
+    const classes = classList(['wp-block-comments-pagination', className]);
+    return (
+        <nav className={classes} aria-label="Comments pagination">
+            {children}
+        </nav>
+    );
+}
+
+export function CommentsPaginationNextBlock({ attributes }: BlockRendererProps): JSX.Element {
+    const url = safeUrl(attrString(attributes._resolvedNextPageUrl));
+    const label = attrString(attributes.label, 'Newer Comments');
+    const className = attrString(attributes.className);
+    const classes = classList(['wp-block-comments-pagination-next', className]);
+
+    if (url === '') {
+        return <span className={classes}>{label}</span>;
+    }
+    return (
+        <a className={classes} href={url}>
+            {label} &rarr;
+        </a>
+    );
+}
+
+export function CommentsPaginationPreviousBlock({ attributes }: BlockRendererProps): JSX.Element {
+    const url = safeUrl(attrString(attributes._resolvedPreviousPageUrl));
+    const label = attrString(attributes.label, 'Older Comments');
+    const className = attrString(attributes.className);
+    const classes = classList(['wp-block-comments-pagination-previous', className]);
+
+    if (url === '') {
+        return <span className={classes}>{label}</span>;
+    }
+    return (
+        <a className={classes} href={url}>
+            &larr; {label}
+        </a>
+    );
+}
+
+interface ResolvedPage {
+    readonly number?: unknown;
+    readonly url?: unknown;
+}
+
+export function CommentsPaginationNumbersBlock({ attributes }: BlockRendererProps): JSX.Element {
+    const className = attrString(attributes.className);
+    const classes = classList(['wp-block-comments-pagination-numbers', className]);
+    const current = attrInt(attributes._resolvedCurrentPage, 1);
+    const rawPages = attributes._resolvedPageNumbers;
+    const pages: ResolvedPage[] = Array.isArray(rawPages) ? (rawPages as ResolvedPage[]) : [];
+
+    return (
+        <div className={classes}>
+            {pages.map((page, idx) => {
+                const number =
+                    typeof page.number === 'number' && Number.isFinite(page.number) ? page.number : 0;
+                if (number === 0) {
+                    return null;
+                }
+                const href = safeUrl(typeof page.url === 'string' ? page.url : '');
+                const isCurrent = number === current;
+
+                // Only the actual current page gets aria-current="page".
+                // A page that's missing its URL still renders as a
+                // non-interactive span (no link target) but should not
+                // claim to be the current page.
+                if (isCurrent) {
+                    return (
+                        <span
+                            key={`pg-${idx}-${number}`}
+                            className="page-numbers current"
+                            aria-current="page"
+                        >
+                            {number}
+                        </span>
+                    );
+                }
+                if (href === '') {
+                    return (
+                        <span key={`pg-${idx}-${number}`} className="page-numbers">
+                            {number}
+                        </span>
+                    );
+                }
+                return (
+                    <a key={`pg-${idx}-${number}`} className="page-numbers" href={href}>
+                        {number}
+                    </a>
+                );
+            })}
+        </div>
+    );
+}

--- a/packages/visual-editor-renderer-react/src/blocks/registerCoreBlocks.ts
+++ b/packages/visual-editor-renderer-react/src/blocks/registerCoreBlocks.ts
@@ -55,6 +55,24 @@ import {
     PostFeaturedImageBlock,
     PostTitleBlock,
 } from './core/postContext';
+import {
+    CommentAuthorAvatarBlock,
+    CommentAuthorNameBlock,
+    CommentContentBlock,
+    CommentDateBlock,
+    CommentEditLinkBlock,
+    CommentReplyLinkBlock,
+    CommentTemplateBlock,
+    CommentsBlock,
+    CommentsPaginationBlock,
+    CommentsPaginationNextBlock,
+    CommentsPaginationNumbersBlock,
+    CommentsPaginationPreviousBlock,
+    PostCommentsCountBlock,
+    PostCommentsFormBlock,
+    PostCommentsLinkBlock,
+    PostCommentsTitleBlock,
+} from './artisanpack/commentContext';
 import { PostTemplateBlock, PostTemplateItemBlock, QueryBlock } from './core/query';
 import { SiteLogoBlock, SiteTaglineBlock, SiteTitleBlock } from './core/siteContext';
 import { SyncedPatternBlock } from './core/syncedPattern';
@@ -178,6 +196,25 @@ const CORE_BLOCKS: Record<string, BlockRenderer> = {
     'core/navigation-link': NavigationLinkBlock,
     'core/navigation-submenu': NavigationSubmenuBlock,
     'artisanpack/callout': CalloutBlock,
+    // Comments family (#519) — registered under the artisanpack/* namespace
+    // only; the comments cluster never shipped as `core/*` in v1 so there
+    // are no core counterparts to mirror.
+    'artisanpack/comments': CommentsBlock,
+    'artisanpack/comment-template': CommentTemplateBlock,
+    'artisanpack/comment-author-avatar': CommentAuthorAvatarBlock,
+    'artisanpack/comment-author-name': CommentAuthorNameBlock,
+    'artisanpack/comment-content': CommentContentBlock,
+    'artisanpack/comment-date': CommentDateBlock,
+    'artisanpack/comment-edit-link': CommentEditLinkBlock,
+    'artisanpack/comment-reply-link': CommentReplyLinkBlock,
+    'artisanpack/post-comments-form': PostCommentsFormBlock,
+    'artisanpack/post-comments-count': PostCommentsCountBlock,
+    'artisanpack/post-comments-link': PostCommentsLinkBlock,
+    'artisanpack/post-comments-title': PostCommentsTitleBlock,
+    'artisanpack/comments-pagination': CommentsPaginationBlock,
+    'artisanpack/comments-pagination-next': CommentsPaginationNextBlock,
+    'artisanpack/comments-pagination-numbers': CommentsPaginationNumbersBlock,
+    'artisanpack/comments-pagination-previous': CommentsPaginationPreviousBlock,
 };
 
 export function registerCoreBlocks(): void {

--- a/packages/visual-editor-renderer-vue/src/blocks/artisanpack/commentContext.ts
+++ b/packages/visual-editor-renderer-vue/src/blocks/artisanpack/commentContext.ts
@@ -1,0 +1,441 @@
+/**
+ * Comments-family renderers (#519) — Vue.
+ *
+ * 16 blocks mirroring the React + Blade implementations. Each leaf
+ * reads `_resolved*` attributes stamped by visual-editor's
+ * CommentResolver / PostResolver before the tree reaches the
+ * renderer.
+ */
+
+import { defineComponent, getCurrentInstance, h } from 'vue';
+
+import { attrBoolean, attrInt, attrString, classList } from '../../support/attributes';
+import { safeUrl } from '../../support/urlSanitizer';
+import { blockRendererProps } from '../shared';
+
+// --- Pass 1: comments wrapper + per-comment cluster ---------------------
+
+export const CommentsBlock = defineComponent({
+    name: 'CommentsBlock',
+    props: blockRendererProps,
+    setup(props, { slots }) {
+        return () => {
+            const raw = attrString(props.attributes.tagName, 'div').toLowerCase();
+            const tag = ['div', 'section', 'article', 'aside', 'footer'].includes(raw) ? raw : 'div';
+            const className = attrString(props.attributes.className);
+            return h(
+                tag,
+                { class: classList(['wp-block-comments', className]) },
+                slots.default?.()
+            );
+        };
+    },
+});
+
+export const CommentTemplateBlock = defineComponent({
+    name: 'CommentTemplateBlock',
+    props: blockRendererProps,
+    setup(props, { slots }) {
+        return () => {
+            const className = attrString(props.attributes.className);
+            return h(
+                'ol',
+                { class: classList(['wp-block-comment-template', className]) },
+                slots.default?.()
+            );
+        };
+    },
+});
+
+export const CommentAuthorNameBlock = defineComponent({
+    name: 'CommentAuthorNameBlock',
+    props: blockRendererProps,
+    setup(props) {
+        return () => {
+            const isLink = attrBoolean(props.attributes.isLink, true);
+            const linkTarget = attrString(props.attributes.linkTarget, '_self');
+            const align = attrString(props.attributes.textAlign);
+            const className = attrString(props.attributes.className);
+            const name = attrString(props.attributes._resolvedAuthorName);
+            const url = safeUrl(props.attributes._resolvedAuthorUrl);
+
+            const classes = classList([
+                'wp-block-comment-author-name',
+                align !== '' ? `has-text-align-${align}` : null,
+                className,
+            ]);
+
+            if (isLink && url !== '') {
+                const linkProps: Record<string, string> = { href: url };
+                if (linkTarget === '_blank') {
+                    linkProps.target = '_blank';
+                    linkProps.rel = 'noopener noreferrer';
+                }
+                return h('div', { class: classes }, [h('a', linkProps, name)]);
+            }
+            return h('div', { class: classes }, name);
+        };
+    },
+});
+
+export const CommentAuthorAvatarBlock = defineComponent({
+    name: 'CommentAuthorAvatarBlock',
+    props: blockRendererProps,
+    setup(props) {
+        return () => {
+            const url = safeUrl(props.attributes._resolvedAvatarUrl);
+            const alt = attrString(props.attributes._resolvedAvatarAlt);
+            const width = Math.max(1, attrInt(props.attributes.width, 96));
+            const height = Math.max(1, attrInt(props.attributes.height, 96));
+            const className = attrString(props.attributes.className);
+            const classes = classList(['wp-block-comment-author-avatar', className]);
+
+            if (url === '') {
+                return h('div', { class: classes });
+            }
+            return h('div', { class: classes }, [
+                h('img', { src: url, alt, width, height, loading: 'lazy' }),
+            ]);
+        };
+    },
+});
+
+export const CommentContentBlock = defineComponent({
+    name: 'CommentContentBlock',
+    props: blockRendererProps,
+    setup(props) {
+        return () => {
+            const align = attrString(props.attributes.textAlign);
+            const className = attrString(props.attributes.className);
+            const content = attrString(props.attributes._resolvedContent);
+            const classes = classList([
+                'wp-block-comment-content',
+                align !== '' ? `has-text-align-${align}` : null,
+                className,
+            ]);
+            return h('div', { class: classes, innerHTML: content });
+        };
+    },
+});
+
+export const CommentDateBlock = defineComponent({
+    name: 'CommentDateBlock',
+    props: blockRendererProps,
+    setup(props) {
+        return () => {
+            const isLink = attrBoolean(props.attributes.isLink, true);
+            const className = attrString(props.attributes.className);
+            const datetime = attrString(props.attributes._resolvedDate);
+            const formatted = attrString(props.attributes._resolvedDateFormatted, datetime);
+            const url = safeUrl(props.attributes._resolvedPermalink);
+            const classes = classList(['wp-block-comment-date', className]);
+
+            const timeNode =
+                datetime !== '' ? h('time', { datetime }, formatted) : formatted;
+
+            const inner = isLink && url !== '' ? h('a', { href: url }, [timeNode]) : timeNode;
+            return h('div', { class: classes }, [inner]);
+        };
+    },
+});
+
+export const CommentEditLinkBlock = defineComponent({
+    name: 'CommentEditLinkBlock',
+    props: blockRendererProps,
+    setup(props) {
+        return () => {
+            const url = safeUrl(props.attributes._resolvedEditLinkUrl);
+            const label = attrString(props.attributes._resolvedEditLinkLabel, 'Edit');
+            const linkTarget = attrString(props.attributes.linkTarget, '_self');
+            const className = attrString(props.attributes.className);
+            if (url === '') {
+                return null;
+            }
+            const linkProps: Record<string, string> = { href: url };
+            if (linkTarget === '_blank') {
+                linkProps.target = '_blank';
+                linkProps.rel = 'noopener noreferrer';
+            }
+            return h(
+                'div',
+                { class: classList(['wp-block-comment-edit-link', className]) },
+                [h('a', linkProps, label)]
+            );
+        };
+    },
+});
+
+export const CommentReplyLinkBlock = defineComponent({
+    name: 'CommentReplyLinkBlock',
+    props: blockRendererProps,
+    setup(props) {
+        return () => {
+            const url = safeUrl(props.attributes._resolvedReplyLinkUrl);
+            const label = attrString(props.attributes._resolvedReplyLinkLabel, 'Reply');
+            const className = attrString(props.attributes.className);
+            if (url === '') {
+                return null;
+            }
+            return h(
+                'div',
+                { class: classList(['wp-block-comment-reply-link', className]) },
+                [h('a', { href: url }, label)]
+            );
+        };
+    },
+});
+
+// --- Pass 2: post-comments-* metadata + pagination cluster -------------
+
+export const PostCommentsFormBlock = defineComponent({
+    name: 'PostCommentsFormBlock',
+    props: blockRendererProps,
+    setup(props) {
+        // Element IDs derive from the component instance's uid so
+        // multiple post-comments-form blocks on the same page (e.g.
+        // an archive listing) get unique label-for/input-id pairings.
+        const uid = getCurrentInstance()?.uid ?? 0;
+        const authorId = `ve-comment-author-${uid}`;
+        const emailId = `ve-comment-email-${uid}`;
+        const contentId = `ve-comment-content-${uid}`;
+
+        return () => {
+            const className = attrString(props.attributes.className);
+            const classes = classList([
+                'wp-block-post-comments-form',
+                'comment-respond',
+                className,
+            ]);
+            const postId = attrInt(props.attributes._resolvedPostId, 0);
+            // Host apps redirect form submissions to their own form-handler
+            // controller by stamping `_resolvedFormAction` on the block via
+            // CommentInliner. The default points at cms-framework's REST
+            // endpoint, which returns JSON — fine for SPAs, not for HTML
+            // form submits where the user expects a redirect back to the
+            // post.
+            const formAction = safeUrl(
+                attrString(props.attributes._resolvedFormAction, '/api/v1/comments')
+            );
+
+            const formChildren = [
+                h('h3', { class: 'comment-reply-title' }, 'Leave a Comment'),
+                h('form', { action: formAction, method: 'post', class: 'comment-form' }, [
+                    postId > 0
+                        ? h('input', { type: 'hidden', name: 'post_id', value: postId })
+                        : null,
+                    h('p', { class: 'comment-form-author' }, [
+                        h('label', { for: authorId }, [
+                            'Name ',
+                            h('span', { 'aria-hidden': 'true' }, '*'),
+                        ]),
+                        h('input', { id: authorId, name: 'author_name', type: 'text', required: true }),
+                    ]),
+                    h('p', { class: 'comment-form-email' }, [
+                        h('label', { for: emailId }, [
+                            'Email ',
+                            h('span', { 'aria-hidden': 'true' }, '*'),
+                        ]),
+                        h('input', { id: emailId, name: 'author_email', type: 'email', required: true }),
+                    ]),
+                    h('p', { class: 'comment-form-comment' }, [
+                        h('label', { for: contentId }, [
+                            'Comment ',
+                            h('span', { 'aria-hidden': 'true' }, '*'),
+                        ]),
+                        h('textarea', { id: contentId, name: 'content', rows: 6, required: true }),
+                    ]),
+                    h('p', { class: 'form-submit' }, [
+                        // Deliberately no `name: 'submit'` — that
+                        // attribute shadows the form's `.submit`
+                        // property in the DOM and breaks any JS that
+                        // hooks the form.
+                        h('input', {
+                            type: 'submit',
+                            class: 'submit',
+                            value: 'Post Comment',
+                        }),
+                    ]),
+                ]),
+            ];
+
+            return h('div', { class: classes }, formChildren);
+        };
+    },
+});
+
+export const PostCommentsCountBlock = defineComponent({
+    name: 'PostCommentsCountBlock',
+    props: blockRendererProps,
+    setup(props) {
+        return () => {
+            const count = attrInt(props.attributes._resolvedCommentCount, 0);
+            const className = attrString(props.attributes.className);
+            return h(
+                'div',
+                { class: classList(['wp-block-post-comments-count', className]) },
+                String(count)
+            );
+        };
+    },
+});
+
+export const PostCommentsLinkBlock = defineComponent({
+    name: 'PostCommentsLinkBlock',
+    props: blockRendererProps,
+    setup(props) {
+        return () => {
+            const count = attrInt(props.attributes._resolvedCommentCount, 0);
+            const url = safeUrl(props.attributes._resolvedCommentsUrl);
+            const fallback = count === 1 ? '1 Comment' : `${count} Comments`;
+            const label = attrString(props.attributes._resolvedCommentsLabel, fallback);
+            const className = attrString(props.attributes.className);
+            const classes = classList(['wp-block-post-comments-link', className]);
+            if (url === '') {
+                return h('div', { class: classes }, label);
+            }
+            return h('div', { class: classes }, [h('a', { href: url }, label)]);
+        };
+    },
+});
+
+export const PostCommentsTitleBlock = defineComponent({
+    name: 'PostCommentsTitleBlock',
+    props: blockRendererProps,
+    setup(props) {
+        return () => {
+            const level = Math.max(1, Math.min(6, attrInt(props.attributes.level, 2)));
+            const showCount = attrBoolean(props.attributes.showCommentsCount, true);
+            const count = attrInt(props.attributes._resolvedCommentCount, 0);
+            const fallback =
+                count === 0 ? 'No Comments' : count === 1 ? '1 Comment' : `${count} Comments`;
+            const title = showCount
+                ? attrString(props.attributes._resolvedCommentsTitle, fallback)
+                : 'Comments';
+            const align = attrString(props.attributes.textAlign);
+            const className = attrString(props.attributes.className);
+
+            const tag = `h${level}`;
+            const classes = classList([
+                'wp-block-post-comments-title',
+                align !== '' ? `has-text-align-${align}` : null,
+                className,
+            ]);
+            return h(tag, { class: classes }, title);
+        };
+    },
+});
+
+export const CommentsPaginationBlock = defineComponent({
+    name: 'CommentsPaginationBlock',
+    props: blockRendererProps,
+    setup(props, { slots }) {
+        return () => {
+            const className = attrString(props.attributes.className);
+            return h(
+                'nav',
+                {
+                    class: classList(['wp-block-comments-pagination', className]),
+                    'aria-label': 'Comments pagination',
+                },
+                slots.default?.()
+            );
+        };
+    },
+});
+
+export const CommentsPaginationNextBlock = defineComponent({
+    name: 'CommentsPaginationNextBlock',
+    props: blockRendererProps,
+    setup(props) {
+        return () => {
+            const url = safeUrl(props.attributes._resolvedNextPageUrl);
+            const label = attrString(props.attributes.label, 'Newer Comments');
+            const className = attrString(props.attributes.className);
+            const classes = classList(['wp-block-comments-pagination-next', className]);
+            if (url === '') {
+                return h('span', { class: classes }, label);
+            }
+            return h('a', { class: classes, href: url }, `${label} →`);
+        };
+    },
+});
+
+export const CommentsPaginationPreviousBlock = defineComponent({
+    name: 'CommentsPaginationPreviousBlock',
+    props: blockRendererProps,
+    setup(props) {
+        return () => {
+            const url = safeUrl(props.attributes._resolvedPreviousPageUrl);
+            const label = attrString(props.attributes.label, 'Older Comments');
+            const className = attrString(props.attributes.className);
+            const classes = classList(['wp-block-comments-pagination-previous', className]);
+            if (url === '') {
+                return h('span', { class: classes }, label);
+            }
+            return h('a', { class: classes, href: url }, `← ${label}`);
+        };
+    },
+});
+
+interface ResolvedPage {
+    readonly number?: unknown;
+    readonly url?: unknown;
+}
+
+export const CommentsPaginationNumbersBlock = defineComponent({
+    name: 'CommentsPaginationNumbersBlock',
+    props: blockRendererProps,
+    setup(props) {
+        return () => {
+            const className = attrString(props.attributes.className);
+            const classes = classList(['wp-block-comments-pagination-numbers', className]);
+            const current = attrInt(props.attributes._resolvedCurrentPage, 1);
+            const raw = props.attributes._resolvedPageNumbers;
+            const pages: ResolvedPage[] = Array.isArray(raw) ? (raw as ResolvedPage[]) : [];
+
+            const children = pages
+                .map((page, idx) => {
+                    const number =
+                        typeof page.number === 'number' && Number.isFinite(page.number)
+                            ? page.number
+                            : 0;
+                    if (number === 0) {
+                        return null;
+                    }
+                    const href = safeUrl(typeof page.url === 'string' ? page.url : '');
+                    const isCurrent = number === current;
+
+                    // Only the actual current page gets aria-current="page".
+                    // A non-current page with an empty href still renders
+                    // as a plain span (no link target) but must not claim
+                    // to be the current page.
+                    if (isCurrent) {
+                        return h(
+                            'span',
+                            {
+                                key: `pg-${idx}-${number}`,
+                                class: 'page-numbers current',
+                                'aria-current': 'page',
+                            },
+                            String(number)
+                        );
+                    }
+                    if (href === '') {
+                        return h(
+                            'span',
+                            { key: `pg-${idx}-${number}`, class: 'page-numbers' },
+                            String(number)
+                        );
+                    }
+                    return h(
+                        'a',
+                        { key: `pg-${idx}-${number}`, class: 'page-numbers', href },
+                        String(number)
+                    );
+                })
+                .filter((child) => child !== null);
+
+            return h('div', { class: classes }, children);
+        };
+    },
+});

--- a/packages/visual-editor-renderer-vue/src/blocks/registerCoreBlocks.ts
+++ b/packages/visual-editor-renderer-vue/src/blocks/registerCoreBlocks.ts
@@ -14,6 +14,24 @@
 import { registerBlockRenderer } from '../registry';
 import { CalloutBlock } from './artisanpack/callout';
 import {
+    CommentAuthorAvatarBlock,
+    CommentAuthorNameBlock,
+    CommentContentBlock,
+    CommentDateBlock,
+    CommentEditLinkBlock,
+    CommentReplyLinkBlock,
+    CommentTemplateBlock,
+    CommentsBlock,
+    CommentsPaginationBlock,
+    CommentsPaginationNextBlock,
+    CommentsPaginationNumbersBlock,
+    CommentsPaginationPreviousBlock,
+    PostCommentsCountBlock,
+    PostCommentsFormBlock,
+    PostCommentsLinkBlock,
+    PostCommentsTitleBlock,
+} from './artisanpack/commentContext';
+import {
     CoverBlock,
     DetailsBlock,
     MediaTextBlock,
@@ -178,6 +196,24 @@ const CORE_BLOCKS: Record<string, BlockRenderer> = {
     'core/navigation-link': NavigationLinkBlock,
     'core/navigation-submenu': NavigationSubmenuBlock,
     'artisanpack/callout': CalloutBlock,
+    // Comments family (#519) — registered under the artisanpack/* namespace
+    // only; the comments cluster never shipped as `core/*` in v1.
+    'artisanpack/comments': CommentsBlock,
+    'artisanpack/comment-template': CommentTemplateBlock,
+    'artisanpack/comment-author-avatar': CommentAuthorAvatarBlock,
+    'artisanpack/comment-author-name': CommentAuthorNameBlock,
+    'artisanpack/comment-content': CommentContentBlock,
+    'artisanpack/comment-date': CommentDateBlock,
+    'artisanpack/comment-edit-link': CommentEditLinkBlock,
+    'artisanpack/comment-reply-link': CommentReplyLinkBlock,
+    'artisanpack/post-comments-form': PostCommentsFormBlock,
+    'artisanpack/post-comments-count': PostCommentsCountBlock,
+    'artisanpack/post-comments-link': PostCommentsLinkBlock,
+    'artisanpack/post-comments-title': PostCommentsTitleBlock,
+    'artisanpack/comments-pagination': CommentsPaginationBlock,
+    'artisanpack/comments-pagination-next': CommentsPaginationNextBlock,
+    'artisanpack/comments-pagination-numbers': CommentsPaginationNumbersBlock,
+    'artisanpack/comments-pagination-previous': CommentsPaginationPreviousBlock,
 };
 
 export function registerCoreBlocks(): void {

--- a/resources/js/visual-editor/blocks/__tests__/post-comments-family.test.ts
+++ b/resources/js/visual-editor/blocks/__tests__/post-comments-family.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Comments family Pass 2 (#519) — block.json + save + transforms contract.
+ *
+ * Covers the 8 Pass 2 forks (post-level comment metadata +
+ * pagination cluster) in one parametrized suite: namespace +
+ * textdomain on block.json, the dynamic (`null`) save for the 6
+ * display blocks + post-comments-form, the delegating
+ * (`InnerBlocks.Content`) save for the comments-pagination
+ * wrapper, the bidirectional `core/* ↔ artisanpack/*` transforms,
+ * and the wrapper innerBlocks-preservation contract.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type { ReactElement } from 'react';
+
+vi.mock('@wordpress/blocks', () => ({
+    createBlock: (
+        name: string,
+        attributes?: Record<string, unknown>,
+        innerBlocks?: unknown[]
+    ) => ({
+        name,
+        attributes: attributes ?? {},
+        innerBlocks: innerBlocks ?? [],
+    }),
+}));
+
+vi.mock('@wordpress/block-editor', () => ({
+    InnerBlocks: Object.assign(
+        () => null,
+        { Content: () => null }
+    ),
+}));
+
+import postCommentsFormMeta from '../post-comments-form/block.json';
+import postCommentsCountMeta from '../post-comments-count/block.json';
+import postCommentsLinkMeta from '../post-comments-link/block.json';
+import postCommentsTitleMeta from '../post-comments-title/block.json';
+import commentsPaginationMeta from '../comments-pagination/block.json';
+import commentsPaginationNextMeta from '../comments-pagination-next/block.json';
+import commentsPaginationNumbersMeta from '../comments-pagination-numbers/block.json';
+import commentsPaginationPreviousMeta from '../comments-pagination-previous/block.json';
+
+import postCommentsFormTransforms from '../post-comments-form/transforms';
+import postCommentsCountTransforms from '../post-comments-count/transforms';
+import postCommentsLinkTransforms from '../post-comments-link/transforms';
+import postCommentsTitleTransforms from '../post-comments-title/transforms';
+import commentsPaginationTransforms from '../comments-pagination/transforms';
+import commentsPaginationNextTransforms from '../comments-pagination-next/transforms';
+import commentsPaginationNumbersTransforms from '../comments-pagination-numbers/transforms';
+import commentsPaginationPreviousTransforms from '../comments-pagination-previous/transforms';
+
+import postCommentsFormSave from '../post-comments-form/save';
+import postCommentsCountSave from '../post-comments-count/save';
+import postCommentsLinkSave from '../post-comments-link/save';
+import postCommentsTitleSave from '../post-comments-title/save';
+import commentsPaginationSave from '../comments-pagination/save';
+import commentsPaginationNextSave from '../comments-pagination-next/save';
+import commentsPaginationNumbersSave from '../comments-pagination-numbers/save';
+import commentsPaginationPreviousSave from '../comments-pagination-previous/save';
+
+interface BlockTransform {
+    type: string;
+    blocks: string[];
+    transform: (
+        attrs: Record<string, unknown>,
+        innerBlocks?: unknown[]
+    ) => { name: string; attributes: Record<string, unknown>; innerBlocks: unknown[] };
+}
+interface TransformsModule {
+    from: BlockTransform[];
+    to: BlockTransform[];
+}
+
+const PASS_2_BLOCKS = [
+    { slug: 'post-comments-form', meta: postCommentsFormMeta, transforms: postCommentsFormTransforms },
+    { slug: 'post-comments-count', meta: postCommentsCountMeta, transforms: postCommentsCountTransforms },
+    { slug: 'post-comments-link', meta: postCommentsLinkMeta, transforms: postCommentsLinkTransforms },
+    { slug: 'post-comments-title', meta: postCommentsTitleMeta, transforms: postCommentsTitleTransforms },
+    { slug: 'comments-pagination', meta: commentsPaginationMeta, transforms: commentsPaginationTransforms },
+    { slug: 'comments-pagination-next', meta: commentsPaginationNextMeta, transforms: commentsPaginationNextTransforms },
+    { slug: 'comments-pagination-numbers', meta: commentsPaginationNumbersMeta, transforms: commentsPaginationNumbersTransforms },
+    { slug: 'comments-pagination-previous', meta: commentsPaginationPreviousMeta, transforms: commentsPaginationPreviousTransforms },
+] as const;
+
+// post-comments-form is server-rendered (interactive <form> emitted at
+// request time) and the 6 display blocks return null. Only
+// comments-pagination is a true wrapper with InnerBlocks.Content.
+const DYNAMIC_SAVES = [
+    { slug: 'post-comments-form', save: postCommentsFormSave },
+    { slug: 'post-comments-count', save: postCommentsCountSave },
+    { slug: 'post-comments-link', save: postCommentsLinkSave },
+    { slug: 'post-comments-title', save: postCommentsTitleSave },
+    { slug: 'comments-pagination-next', save: commentsPaginationNextSave },
+    { slug: 'comments-pagination-numbers', save: commentsPaginationNumbersSave },
+    { slug: 'comments-pagination-previous', save: commentsPaginationPreviousSave },
+] as const;
+
+const WRAPPER_SAVES = [
+    { slug: 'comments-pagination', save: commentsPaginationSave },
+] as const;
+
+describe('Comments family Pass 2 block.json', () => {
+    it.each(PASS_2_BLOCKS)(
+        '$slug declares the artisanpack namespace + textdomain',
+        ({ slug, meta }) => {
+            expect(meta.name).toBe(`artisanpack/${slug}`);
+            expect(meta.textdomain).toBe('artisanpack-visual-editor');
+            expect(meta.category).toBe('theme');
+        }
+    );
+});
+
+describe('Comments family Pass 2 dynamic save', () => {
+    it.each(DYNAMIC_SAVES)('$slug save returns null (server-rendered)', ({ save }) => {
+        expect((save as () => unknown)()).toBeNull();
+    });
+});
+
+describe('Comments family Pass 2 wrapper save', () => {
+    it.each(WRAPPER_SAVES)(
+        '$slug save delegates to InnerBlocks.Content',
+        ({ save }) => {
+            const result = (save as () => ReactElement | null)();
+            expect(result).not.toBeNull();
+        }
+    );
+});
+
+describe('Comments family Pass 2 transforms', () => {
+    it.each(PASS_2_BLOCKS)(
+        '$slug ships bidirectional core/* ↔ artisanpack/* transforms',
+        ({ slug, transforms }) => {
+            const t = transforms as TransformsModule;
+            const from = t.from.find((e) => e.blocks?.includes(`core/${slug}`));
+            const to = t.to.find((e) => e.blocks?.includes(`core/${slug}`));
+
+            expect(from).toBeDefined();
+            expect(to).toBeDefined();
+
+            expect(from!.transform({ a: 1 })).toMatchObject({
+                name: `artisanpack/${slug}`,
+                attributes: { a: 1 },
+            });
+            expect(to!.transform({ b: 2 })).toMatchObject({
+                name: `core/${slug}`,
+                attributes: { b: 2 },
+            });
+        }
+    );
+});
+
+describe('Comments family Pass 2 wrapper transforms preserve innerBlocks', () => {
+    const WRAPPERS = [
+        { slug: 'post-comments-form', transforms: postCommentsFormTransforms },
+        { slug: 'comments-pagination', transforms: commentsPaginationTransforms },
+    ] as const;
+
+    it.each(WRAPPERS)(
+        '$slug from-transform threads innerBlocks through',
+        ({ slug, transforms }) => {
+            const t = transforms as TransformsModule;
+            const from = t.from.find((e) => e.blocks?.includes(`core/${slug}`))!;
+            const inner = [{ name: 'placeholder', attributes: {}, innerBlocks: [] }];
+            const result = from.transform({}, inner);
+            expect(result.innerBlocks).toEqual(inner);
+        }
+    );
+
+    it.each(WRAPPERS)(
+        '$slug to-transform threads innerBlocks through',
+        ({ slug, transforms }) => {
+            const t = transforms as TransformsModule;
+            const to = t.to.find((e) => e.blocks?.includes(`core/${slug}`))!;
+            const inner = [{ name: 'placeholder', attributes: {}, innerBlocks: [] }];
+            const result = to.transform({}, inner);
+            expect(result.innerBlocks).toEqual(inner);
+        }
+    );
+});
+
+describe('Comments family Pass 2 context wiring', () => {
+    it('comments-pagination provides comments/paginationArrow', () => {
+        const provides = (commentsPaginationMeta as { providesContext?: Record<string, string> }).providesContext;
+        expect(provides).toBeDefined();
+        expect(provides!['comments/paginationArrow']).toBe('paginationArrow');
+    });
+
+    it('comments-pagination providesContext keys are backed by declared attributes', () => {
+        const provides = (commentsPaginationMeta as { providesContext?: Record<string, string> })
+            .providesContext ?? {};
+        const attrs = (commentsPaginationMeta as { attributes?: Record<string, unknown> })
+            .attributes ?? {};
+        for (const attributeName of Object.values(provides)) {
+            expect(attrs).toHaveProperty(attributeName);
+        }
+    });
+
+    it.each([
+        { slug: 'comments-pagination-next', meta: commentsPaginationNextMeta },
+        { slug: 'comments-pagination-previous', meta: commentsPaginationPreviousMeta },
+    ])('$slug consumes comments/paginationArrow', ({ meta }) => {
+        expect(meta.usesContext).toContain('comments/paginationArrow');
+    });
+});

--- a/resources/js/visual-editor/blocks/_shared/comment-placeholder-edit.tsx
+++ b/resources/js/visual-editor/blocks/_shared/comment-placeholder-edit.tsx
@@ -67,6 +67,15 @@ export interface CommentPlaceholderConfig {
     readonly getImageProps?: (
         attributes: Record<string, unknown>
     ) => Record<string, unknown>;
+    /**
+     * Realistic dummy data to display in the editor canvas when no
+     * resolved value and no `artisanpack/commentPreview` context is
+     * available. Authors editing a template (in the site editor or
+     * post editor) get a representative block they can style — much
+     * more useful than a generic "Comment Author Name" placeholder
+     * chip. Front-end render never sees this; only the editor does.
+     */
+    readonly dummyValue?: CommentPreviewValue;
 }
 
 const COMMENT_PREVIEW_CONTEXT_KEY = 'artisanpack/commentPreview';
@@ -184,6 +193,17 @@ export function createCommentPlaceholderEdit(
                     return renderResolved( config, fromContext, blockProps, attributes );
                 }
             }
+        }
+
+        // No resolved data + no commentPreview context — render the
+        // configured dummy value so authors editing a template (with
+        // no specific post in scope) see what the block will look like
+        // styled. Final fallback is the original labelled chip.
+        if (
+            config.dummyValue !== undefined &&
+            hasPreviewValue( config.kind, config.dummyValue )
+        ) {
+            return renderResolved( config, config.dummyValue, blockProps, attributes );
         }
 
         return (

--- a/resources/js/visual-editor/blocks/_shared/entity-placeholder-edit.tsx
+++ b/resources/js/visual-editor/blocks/_shared/entity-placeholder-edit.tsx
@@ -155,6 +155,15 @@ export interface EntityPlaceholderConfig {
      * generic placeholder chip.
      */
     readonly fromSiteEntity?: ( site: SiteEntityRecord ) => EntityPreviewValue | null;
+    /**
+     * Realistic dummy data to display in the editor canvas when no
+     * resolved value, no `artisanpack/postPreview` context, and no
+     * live core-data entity is available. Authors editing a template
+     * (in the site editor or post editor) get a representative block
+     * they can style — much more useful than a generic chip. Front-end
+     * render never sees this; only the editor does.
+     */
+    readonly dummyValue?: EntityPreviewValue;
 }
 
 const PREVIEW_CONTEXT_KEY = 'artisanpack/postPreview';
@@ -364,6 +373,17 @@ export function createEntityPlaceholderEdit(
 
         if ( liveSiteEntityValue !== null && hasPreviewValue( config.kind, liveSiteEntityValue ) ) {
             return renderResolved( config.kind, liveSiteEntityValue, blockProps );
+        }
+
+        // No resolved data, no query/entity context — render the
+        // configured dummy value so authors editing a template (with
+        // no specific entity in scope) see what the block will look
+        // like styled. Final fallback is the original labelled chip.
+        if (
+            config.dummyValue !== undefined &&
+            hasPreviewValue( config.kind, config.dummyValue )
+        ) {
+            return renderResolved( config.kind, config.dummyValue, blockProps );
         }
 
         return (

--- a/resources/js/visual-editor/blocks/comment-author-avatar/edit.tsx
+++ b/resources/js/visual-editor/blocks/comment-author-avatar/edit.tsx
@@ -37,4 +37,11 @@ export default createCommentPlaceholderEdit( {
         }
         return props;
     },
+    // Default Gravatar "mp" (mystery person) silhouette so the avatar
+    // block paints as a real image in the editor even when authoring
+    // outside a specific comment context.
+    dummyValue: {
+        imageUrl: 'https://www.gravatar.com/avatar/?d=mp&s=96',
+        imageAlt: 'Jane Doe',
+    },
 } );

--- a/resources/js/visual-editor/blocks/comment-author-name/edit.tsx
+++ b/resources/js/visual-editor/blocks/comment-author-name/edit.tsx
@@ -20,4 +20,5 @@ export default createCommentPlaceholderEdit( {
         const name = comment.authorName;
         return typeof name === 'string' && name !== '' ? { text: name } : null;
     },
+    dummyValue: { text: 'Jane Doe' },
 } );

--- a/resources/js/visual-editor/blocks/comment-content/edit.tsx
+++ b/resources/js/visual-editor/blocks/comment-content/edit.tsx
@@ -20,4 +20,7 @@ export default createCommentPlaceholderEdit( {
         const content = comment.content;
         return typeof content === 'string' && content !== '' ? { text: content } : null;
     },
+    dummyValue: {
+        text: '<p>This is a sample comment. Authors editing a template see this representative content so they can style the block before any real comments exist.</p>',
+    },
 } );

--- a/resources/js/visual-editor/blocks/comment-date/edit.tsx
+++ b/resources/js/visual-editor/blocks/comment-date/edit.tsx
@@ -22,4 +22,5 @@ export default createCommentPlaceholderEdit( {
             ? { text: formatted }
             : null;
     },
+    dummyValue: { text: 'October 25, 2024' },
 } );

--- a/resources/js/visual-editor/blocks/comment-date/inserter-icon.tsx
+++ b/resources/js/visual-editor/blocks/comment-date/inserter-icon.tsx
@@ -2,6 +2,7 @@
  * CommentDate — inserter icon.
  *
  * Inline SVG so the editor canvas does not have to load `dashicons.css`.
+ * A calendar glyph to differentiate from the other comment-* blocks.
  * Comments family fork (#519).
  */
 
@@ -16,7 +17,7 @@ export default function CommentDateInserterIcon(): ReactElement {
             height={ 24 }
             aria-hidden="true"
         >
-            <path d="M20 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h14l4 4V6c0-1.1-.9-2-2-2zm-2 12H6v-2h12v2zm0-3H6v-2h12v2zm0-3H6V8h12v2z" />
+            <path d="M19 4h-1V2h-2v2H8V2H6v2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 16H5V10h14v10zm0-12H5V6h14v2z" />
         </svg>
     );
 }

--- a/resources/js/visual-editor/blocks/comment-edit-link/edit.tsx
+++ b/resources/js/visual-editor/blocks/comment-edit-link/edit.tsx
@@ -17,4 +17,5 @@ export default createCommentPlaceholderEdit( {
     label: __( 'Edit', TEXT_DOMAIN ),
     resolvedKey: '_resolvedEditLinkLabel',
     kind: 'text',
+    dummyValue: { text: 'Edit' },
 } );

--- a/resources/js/visual-editor/blocks/comment-reply-link/edit.tsx
+++ b/resources/js/visual-editor/blocks/comment-reply-link/edit.tsx
@@ -15,4 +15,5 @@ export default createCommentPlaceholderEdit( {
     label: __( 'Reply', TEXT_DOMAIN ),
     resolvedKey: '_resolvedReplyLinkLabel',
     kind: 'text',
+    dummyValue: { text: 'Reply' },
 } );

--- a/resources/js/visual-editor/blocks/comments-pagination-next/block.json
+++ b/resources/js/visual-editor/blocks/comments-pagination-next/block.json
@@ -5,7 +5,7 @@
     "title": "Comments Next Page",
     "category": "theme",
     "parent": [ "artisanpack/comments-pagination" ],
-    "description": "Displays the next comment's page link.",
+    "description": "Displays the next comments page link.",
     "textdomain": "artisanpack-visual-editor",
     "attributes": {
         "label": {

--- a/resources/js/visual-editor/blocks/comments-pagination-next/block.json
+++ b/resources/js/visual-editor/blocks/comments-pagination-next/block.json
@@ -1,0 +1,46 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "artisanpack/comments-pagination-next",
+    "title": "Comments Next Page",
+    "category": "theme",
+    "parent": [ "artisanpack/comments-pagination" ],
+    "description": "Displays the next comment's page link.",
+    "textdomain": "artisanpack-visual-editor",
+    "attributes": {
+        "label": {
+            "type": "string"
+        }
+    },
+    "usesContext": [
+        "postId",
+        "comments/paginationArrow"
+    ],
+    "supports": {
+        "reusable": false,
+        "html": false,
+        "color": {
+            "gradients": true,
+            "text": false,
+            "__experimentalDefaultControls": {
+                "background": true
+            }
+        },
+        "typography": {
+            "fontSize": true,
+            "lineHeight": true,
+            "__experimentalFontFamily": true,
+            "__experimentalFontWeight": true,
+            "__experimentalFontStyle": true,
+            "__experimentalTextTransform": true,
+            "__experimentalTextDecoration": true,
+            "__experimentalLetterSpacing": true,
+            "__experimentalDefaultControls": {
+                "fontSize": true
+            }
+        },
+        "interactivity": {
+            "clientNavigation": true
+        }
+    }
+}

--- a/resources/js/visual-editor/blocks/comments-pagination-next/edit.tsx
+++ b/resources/js/visual-editor/blocks/comments-pagination-next/edit.tsx
@@ -1,0 +1,21 @@
+/**
+ * CommentsPaginationNext — edit component.
+ *
+ * Server-rendered display block. Previews as a labelled placeholder
+ * in the canvas; the real next-page link is emitted server-side
+ * once the comment pagination state is known (request-time, not
+ * post-time, so there's no `_resolved*` attribute to stamp).
+ * Comments family fork (#519) Pass 2.
+ */
+
+import { __ } from '@wordpress/i18n';
+
+import { TEXT_DOMAIN } from '../../vendor/i18n';
+import { createEntityPlaceholderEdit } from '../_shared/entity-placeholder-edit';
+
+export default createEntityPlaceholderEdit( {
+    label: __( 'Newer Comments', TEXT_DOMAIN ),
+    resolvedKey: '_resolvedPaginationNextLabel',
+    kind: 'text',
+    dummyValue: { text: 'Newer Comments →' },
+} );

--- a/resources/js/visual-editor/blocks/comments-pagination-next/index.ts
+++ b/resources/js/visual-editor/blocks/comments-pagination-next/index.ts
@@ -1,0 +1,23 @@
+/**
+ * CommentsPaginationNext block entrypoint.
+ *
+ * Auto-discovered by `editor/custom-blocks.ts` and registered against
+ * `@wordpress/blocks.registerBlockType`. Comments family fork (#519) Pass 2.
+ */
+
+import metadata from './block.json';
+import edit from './edit';
+import save from './save';
+import transforms from './transforms';
+import icon from './inserter-icon';
+
+export { edit, save, metadata, icon, transforms };
+
+export default {
+    name: metadata.name,
+    metadata,
+    edit,
+    save,
+    icon,
+    transforms,
+};

--- a/resources/js/visual-editor/blocks/comments-pagination-next/inserter-icon.tsx
+++ b/resources/js/visual-editor/blocks/comments-pagination-next/inserter-icon.tsx
@@ -1,0 +1,22 @@
+/**
+ * CommentsPaginationNext — inserter icon.
+ *
+ * Inline SVG so the editor canvas does not have to load `dashicons.css`.
+ * A right-pointing chevron (next page). Comments family fork (#519) Pass 2.
+ */
+
+import type { ReactElement } from 'react';
+
+export default function CommentsPaginationNextInserterIcon(): ReactElement {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            width={ 24 }
+            height={ 24 }
+            aria-hidden="true"
+        >
+            <path d="M8.59 16.59 13.17 12 8.59 7.41 10 6l6 6-6 6z" />
+        </svg>
+    );
+}

--- a/resources/js/visual-editor/blocks/comments-pagination-next/save.tsx
+++ b/resources/js/visual-editor/blocks/comments-pagination-next/save.tsx
@@ -1,0 +1,10 @@
+/**
+ * CommentsPaginationNext — save component.
+ *
+ * Dynamic block: returns null; markup produced server-side from
+ * stamped `_resolved*` attributes. Comments family fork (#519) Pass 2.
+ */
+
+export default function CommentsPaginationNextSave(): null {
+    return null;
+}

--- a/resources/js/visual-editor/blocks/comments-pagination-next/transforms.ts
+++ b/resources/js/visual-editor/blocks/comments-pagination-next/transforms.ts
@@ -1,0 +1,37 @@
+/**
+ * CommentsPaginationNext — transforms.
+ *
+ * Bidirectional `core/comments-pagination-next` ↔ `artisanpack/comments-pagination-next` block
+ * transforms for the V1 rollout window. Comments family fork (#519) Pass 2.
+ */
+
+import { createBlock } from '@wordpress/blocks';
+
+import metadata from './block.json';
+
+const { name } = metadata;
+
+interface EntityAttributes {
+    readonly [ key: string ]: unknown;
+}
+
+const transforms = {
+    from: [
+        {
+            type: 'block',
+            blocks: [ 'core/comments-pagination-next' ],
+            transform: ( attributes: EntityAttributes ) =>
+                createBlock( name, attributes ),
+        },
+    ],
+    to: [
+        {
+            type: 'block',
+            blocks: [ 'core/comments-pagination-next' ],
+            transform: ( attributes: EntityAttributes ) =>
+                createBlock( 'core/comments-pagination-next', attributes ),
+        },
+    ],
+};
+
+export default transforms;

--- a/resources/js/visual-editor/blocks/comments-pagination-next/upstream-state.json
+++ b/resources/js/visual-editor/blocks/comments-pagination-next/upstream-state.json
@@ -1,0 +1,67 @@
+{
+    "$schema": "../../../../scripts/upstream-state.schema.json",
+    "block": "artisanpack/comments-pagination-next",
+    "upstream": {
+        "package": "@wordpress/block-library",
+        "namespace": "core/comments-pagination-next",
+        "pinnedVersion": "9.43.0",
+        "subpath": "comments-pagination-next"
+    },
+    "forkedAt": "2026-06-02",
+    "$statusLegend": {
+        "ported": "byte-equivalent to upstream (CI fails on drift)",
+        "adapted": "TypeScript port and/or namespace swap; logically equivalent",
+        "extended": "fork adds behavior on top of upstream",
+        "rewritten": "fork replaced upstream entirely",
+        "added": "file unique to the fork (no upstream)"
+    },
+    "files": [
+        {
+            "fork": "block.json",
+            "upstream": "block.json",
+            "status": "adapted",
+            "notes": "name + textdomain swapped to the artisanpack namespace. Post-level block: consumes postId / postType (and artisanpack/postPreview for query-loop previews where applicable). Attribute schema and supports carried verbatim for parity."
+        },
+        {
+            "fork": "edit.tsx",
+            "upstream": "edit.js",
+            "status": "rewritten",
+            "notes": "Lightweight placeholder edit. Upstream queries the comment entity through @wordpress/core-data, which the post editor does not populate; the fork falls back to the post-family createEntityPlaceholderEdit (display blocks) or InnerBlocks (wrappers). Front-end markup is produced server-side from stamped _resolved* attributes."
+        },
+        {
+            "fork": "save.tsx",
+            "upstream": "n/a",
+            "status": "added",
+            "notes": "Dynamic block (or InnerBlocks delegate for wrappers) — markup produced server-side."
+        },
+        {
+            "fork": "transforms.ts",
+            "upstream": "transforms.js",
+            "status": "rewritten",
+            "notes": "Bidirectional core/comments-pagination-next ↔ artisanpack/comments-pagination-next block transforms for the rollout window. Wrapper variants thread innerBlocks through createBlock so the nested tree survives a namespace round-trip."
+        },
+        {
+            "fork": "inserter-icon.tsx",
+            "upstream": "n/a",
+            "status": "added",
+            "notes": "Inline SVG inserter icon (editor lacks dashicons.css)."
+        },
+        {
+            "fork": "index.ts",
+            "upstream": "index.js",
+            "status": "rewritten",
+            "notes": "Adapted to the visual-editor auto-discovery contract."
+        }
+    ],
+    "vendoredPrimitives": [],
+    "knownDivergences": [
+        "edit.tsx is a lightweight placeholder rather than upstream's entity-querying edit — the core-data shim does not expose comment-related entities to the post editor.",
+        "Server-rendered: front-end markup produced by Blade/React/Vue renderers from stamped _resolved* attributes, not by save().",
+        "transforms.ts adds bidirectional block transforms that do not exist upstream — required to coexist with core/comments-pagination-next during the V1 rollout."
+    ],
+    "triage": {
+        "label": "in-sync",
+        "lastReviewed": "2026-06-02",
+        "reviewer": "Comments family fork (#519) Pass 2"
+    }
+}

--- a/resources/js/visual-editor/blocks/comments-pagination-numbers/block.json
+++ b/resources/js/visual-editor/blocks/comments-pagination-numbers/block.json
@@ -1,0 +1,40 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "artisanpack/comments-pagination-numbers",
+    "title": "Comments Page Numbers",
+    "category": "theme",
+    "parent": [ "artisanpack/comments-pagination" ],
+    "description": "Displays a list of page numbers for comments pagination.",
+    "textdomain": "artisanpack-visual-editor",
+    "usesContext": [
+        "postId"
+    ],
+    "supports": {
+        "reusable": false,
+        "html": false,
+        "color": {
+            "gradients": true,
+            "text": false,
+            "__experimentalDefaultControls": {
+                "background": true
+            }
+        },
+        "typography": {
+            "fontSize": true,
+            "lineHeight": true,
+            "__experimentalFontFamily": true,
+            "__experimentalFontWeight": true,
+            "__experimentalFontStyle": true,
+            "__experimentalTextTransform": true,
+            "__experimentalTextDecoration": true,
+            "__experimentalLetterSpacing": true,
+            "__experimentalDefaultControls": {
+                "fontSize": true
+            }
+        },
+        "interactivity": {
+            "clientNavigation": true
+        }
+    }
+}

--- a/resources/js/visual-editor/blocks/comments-pagination-numbers/edit.tsx
+++ b/resources/js/visual-editor/blocks/comments-pagination-numbers/edit.tsx
@@ -1,0 +1,19 @@
+/**
+ * CommentsPaginationNumbers — edit component.
+ *
+ * Server-rendered display block. Previews as a labelled placeholder
+ * — pagination state is computed at request time, not from any
+ * post-level resolved data. Comments family fork (#519) Pass 2.
+ */
+
+import { __ } from '@wordpress/i18n';
+
+import { TEXT_DOMAIN } from '../../vendor/i18n';
+import { createEntityPlaceholderEdit } from '../_shared/entity-placeholder-edit';
+
+export default createEntityPlaceholderEdit( {
+    label: __( 'Comments Page Numbers', TEXT_DOMAIN ),
+    resolvedKey: '_resolvedPaginationNumbersLabel',
+    kind: 'text',
+    dummyValue: { text: '1 2 3' },
+} );

--- a/resources/js/visual-editor/blocks/comments-pagination-numbers/index.ts
+++ b/resources/js/visual-editor/blocks/comments-pagination-numbers/index.ts
@@ -1,0 +1,23 @@
+/**
+ * CommentsPaginationNumbers block entrypoint.
+ *
+ * Auto-discovered by `editor/custom-blocks.ts` and registered against
+ * `@wordpress/blocks.registerBlockType`. Comments family fork (#519) Pass 2.
+ */
+
+import metadata from './block.json';
+import edit from './edit';
+import save from './save';
+import transforms from './transforms';
+import icon from './inserter-icon';
+
+export { edit, save, metadata, icon, transforms };
+
+export default {
+    name: metadata.name,
+    metadata,
+    edit,
+    save,
+    icon,
+    transforms,
+};

--- a/resources/js/visual-editor/blocks/comments-pagination-numbers/inserter-icon.tsx
+++ b/resources/js/visual-editor/blocks/comments-pagination-numbers/inserter-icon.tsx
@@ -1,0 +1,22 @@
+/**
+ * CommentsPaginationNumbers — inserter icon.
+ *
+ * Inline SVG so the editor canvas does not have to load `dashicons.css`.
+ * A "1 2 3" page-number glyph. Comments family fork (#519) Pass 2.
+ */
+
+import type { ReactElement } from 'react';
+
+export default function CommentsPaginationNumbersInserterIcon(): ReactElement {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            width={ 24 }
+            height={ 24 }
+            aria-hidden="true"
+        >
+            <path d="M3 17h2v2H3zm0-7h2v5H3zm4-3h2v12H7zm8 9h2v2h-2zm0-7h2v5h-2zm-4 0h2v9h-2zm8-3h2v12h-2z" />
+        </svg>
+    );
+}

--- a/resources/js/visual-editor/blocks/comments-pagination-numbers/save.tsx
+++ b/resources/js/visual-editor/blocks/comments-pagination-numbers/save.tsx
@@ -1,0 +1,10 @@
+/**
+ * CommentsPaginationNumbers — save component.
+ *
+ * Dynamic block: returns null; markup produced server-side from
+ * stamped `_resolved*` attributes. Comments family fork (#519) Pass 2.
+ */
+
+export default function CommentsPaginationNumbersSave(): null {
+    return null;
+}

--- a/resources/js/visual-editor/blocks/comments-pagination-numbers/transforms.ts
+++ b/resources/js/visual-editor/blocks/comments-pagination-numbers/transforms.ts
@@ -1,0 +1,37 @@
+/**
+ * CommentsPaginationNumbers — transforms.
+ *
+ * Bidirectional `core/comments-pagination-numbers` ↔ `artisanpack/comments-pagination-numbers` block
+ * transforms for the V1 rollout window. Comments family fork (#519) Pass 2.
+ */
+
+import { createBlock } from '@wordpress/blocks';
+
+import metadata from './block.json';
+
+const { name } = metadata;
+
+interface EntityAttributes {
+    readonly [ key: string ]: unknown;
+}
+
+const transforms = {
+    from: [
+        {
+            type: 'block',
+            blocks: [ 'core/comments-pagination-numbers' ],
+            transform: ( attributes: EntityAttributes ) =>
+                createBlock( name, attributes ),
+        },
+    ],
+    to: [
+        {
+            type: 'block',
+            blocks: [ 'core/comments-pagination-numbers' ],
+            transform: ( attributes: EntityAttributes ) =>
+                createBlock( 'core/comments-pagination-numbers', attributes ),
+        },
+    ],
+};
+
+export default transforms;

--- a/resources/js/visual-editor/blocks/comments-pagination-numbers/upstream-state.json
+++ b/resources/js/visual-editor/blocks/comments-pagination-numbers/upstream-state.json
@@ -1,0 +1,67 @@
+{
+    "$schema": "../../../../scripts/upstream-state.schema.json",
+    "block": "artisanpack/comments-pagination-numbers",
+    "upstream": {
+        "package": "@wordpress/block-library",
+        "namespace": "core/comments-pagination-numbers",
+        "pinnedVersion": "9.43.0",
+        "subpath": "comments-pagination-numbers"
+    },
+    "forkedAt": "2026-06-02",
+    "$statusLegend": {
+        "ported": "byte-equivalent to upstream (CI fails on drift)",
+        "adapted": "TypeScript port and/or namespace swap; logically equivalent",
+        "extended": "fork adds behavior on top of upstream",
+        "rewritten": "fork replaced upstream entirely",
+        "added": "file unique to the fork (no upstream)"
+    },
+    "files": [
+        {
+            "fork": "block.json",
+            "upstream": "block.json",
+            "status": "adapted",
+            "notes": "name + textdomain swapped to the artisanpack namespace. Post-level block: consumes postId / postType (and artisanpack/postPreview for query-loop previews where applicable). Attribute schema and supports carried verbatim for parity."
+        },
+        {
+            "fork": "edit.tsx",
+            "upstream": "edit.js",
+            "status": "rewritten",
+            "notes": "Lightweight placeholder edit. Upstream queries the comment entity through @wordpress/core-data, which the post editor does not populate; the fork falls back to the post-family createEntityPlaceholderEdit (display blocks) or InnerBlocks (wrappers). Front-end markup is produced server-side from stamped _resolved* attributes."
+        },
+        {
+            "fork": "save.tsx",
+            "upstream": "n/a",
+            "status": "added",
+            "notes": "Dynamic block (or InnerBlocks delegate for wrappers) — markup produced server-side."
+        },
+        {
+            "fork": "transforms.ts",
+            "upstream": "transforms.js",
+            "status": "rewritten",
+            "notes": "Bidirectional core/comments-pagination-numbers ↔ artisanpack/comments-pagination-numbers block transforms for the rollout window. Wrapper variants thread innerBlocks through createBlock so the nested tree survives a namespace round-trip."
+        },
+        {
+            "fork": "inserter-icon.tsx",
+            "upstream": "n/a",
+            "status": "added",
+            "notes": "Inline SVG inserter icon (editor lacks dashicons.css)."
+        },
+        {
+            "fork": "index.ts",
+            "upstream": "index.js",
+            "status": "rewritten",
+            "notes": "Adapted to the visual-editor auto-discovery contract."
+        }
+    ],
+    "vendoredPrimitives": [],
+    "knownDivergences": [
+        "edit.tsx is a lightweight placeholder rather than upstream's entity-querying edit — the core-data shim does not expose comment-related entities to the post editor.",
+        "Server-rendered: front-end markup produced by Blade/React/Vue renderers from stamped _resolved* attributes, not by save().",
+        "transforms.ts adds bidirectional block transforms that do not exist upstream — required to coexist with core/comments-pagination-numbers during the V1 rollout."
+    ],
+    "triage": {
+        "label": "in-sync",
+        "lastReviewed": "2026-06-02",
+        "reviewer": "Comments family fork (#519) Pass 2"
+    }
+}

--- a/resources/js/visual-editor/blocks/comments-pagination-previous/block.json
+++ b/resources/js/visual-editor/blocks/comments-pagination-previous/block.json
@@ -1,0 +1,46 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "artisanpack/comments-pagination-previous",
+    "title": "Comments Previous Page",
+    "category": "theme",
+    "parent": [ "artisanpack/comments-pagination" ],
+    "description": "Displays the previous comment's page link.",
+    "textdomain": "artisanpack-visual-editor",
+    "attributes": {
+        "label": {
+            "type": "string"
+        }
+    },
+    "usesContext": [
+        "postId",
+        "comments/paginationArrow"
+    ],
+    "supports": {
+        "reusable": false,
+        "html": false,
+        "color": {
+            "gradients": true,
+            "text": false,
+            "__experimentalDefaultControls": {
+                "background": true
+            }
+        },
+        "typography": {
+            "fontSize": true,
+            "lineHeight": true,
+            "__experimentalFontFamily": true,
+            "__experimentalFontWeight": true,
+            "__experimentalFontStyle": true,
+            "__experimentalTextTransform": true,
+            "__experimentalTextDecoration": true,
+            "__experimentalLetterSpacing": true,
+            "__experimentalDefaultControls": {
+                "fontSize": true
+            }
+        },
+        "interactivity": {
+            "clientNavigation": true
+        }
+    }
+}

--- a/resources/js/visual-editor/blocks/comments-pagination-previous/block.json
+++ b/resources/js/visual-editor/blocks/comments-pagination-previous/block.json
@@ -5,7 +5,7 @@
     "title": "Comments Previous Page",
     "category": "theme",
     "parent": [ "artisanpack/comments-pagination" ],
-    "description": "Displays the previous comment's page link.",
+    "description": "Displays the previous comments page link.",
     "textdomain": "artisanpack-visual-editor",
     "attributes": {
         "label": {

--- a/resources/js/visual-editor/blocks/comments-pagination-previous/edit.tsx
+++ b/resources/js/visual-editor/blocks/comments-pagination-previous/edit.tsx
@@ -1,0 +1,20 @@
+/**
+ * CommentsPaginationPrevious — edit component.
+ *
+ * Server-rendered display block. Previews as a labelled placeholder
+ * in the canvas; the real previous-page link is emitted server-side
+ * once the comment pagination state is known (request-time).
+ * Comments family fork (#519) Pass 2.
+ */
+
+import { __ } from '@wordpress/i18n';
+
+import { TEXT_DOMAIN } from '../../vendor/i18n';
+import { createEntityPlaceholderEdit } from '../_shared/entity-placeholder-edit';
+
+export default createEntityPlaceholderEdit( {
+    label: __( 'Older Comments', TEXT_DOMAIN ),
+    resolvedKey: '_resolvedPaginationPreviousLabel',
+    kind: 'text',
+    dummyValue: { text: '← Older Comments' },
+} );

--- a/resources/js/visual-editor/blocks/comments-pagination-previous/index.ts
+++ b/resources/js/visual-editor/blocks/comments-pagination-previous/index.ts
@@ -1,0 +1,23 @@
+/**
+ * CommentsPaginationPrevious block entrypoint.
+ *
+ * Auto-discovered by `editor/custom-blocks.ts` and registered against
+ * `@wordpress/blocks.registerBlockType`. Comments family fork (#519) Pass 2.
+ */
+
+import metadata from './block.json';
+import edit from './edit';
+import save from './save';
+import transforms from './transforms';
+import icon from './inserter-icon';
+
+export { edit, save, metadata, icon, transforms };
+
+export default {
+    name: metadata.name,
+    metadata,
+    edit,
+    save,
+    icon,
+    transforms,
+};

--- a/resources/js/visual-editor/blocks/comments-pagination-previous/inserter-icon.tsx
+++ b/resources/js/visual-editor/blocks/comments-pagination-previous/inserter-icon.tsx
@@ -1,0 +1,22 @@
+/**
+ * CommentsPaginationPrevious — inserter icon.
+ *
+ * Inline SVG so the editor canvas does not have to load `dashicons.css`.
+ * A left-pointing chevron (previous page). Comments family fork (#519) Pass 2.
+ */
+
+import type { ReactElement } from 'react';
+
+export default function CommentsPaginationPreviousInserterIcon(): ReactElement {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            width={ 24 }
+            height={ 24 }
+            aria-hidden="true"
+        >
+            <path d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z" />
+        </svg>
+    );
+}

--- a/resources/js/visual-editor/blocks/comments-pagination-previous/save.tsx
+++ b/resources/js/visual-editor/blocks/comments-pagination-previous/save.tsx
@@ -1,0 +1,10 @@
+/**
+ * CommentsPaginationPrevious — save component.
+ *
+ * Dynamic block: returns null; markup produced server-side from
+ * stamped `_resolved*` attributes. Comments family fork (#519) Pass 2.
+ */
+
+export default function CommentsPaginationPreviousSave(): null {
+    return null;
+}

--- a/resources/js/visual-editor/blocks/comments-pagination-previous/transforms.ts
+++ b/resources/js/visual-editor/blocks/comments-pagination-previous/transforms.ts
@@ -1,0 +1,37 @@
+/**
+ * CommentsPaginationPrevious — transforms.
+ *
+ * Bidirectional `core/comments-pagination-previous` ↔ `artisanpack/comments-pagination-previous` block
+ * transforms for the V1 rollout window. Comments family fork (#519) Pass 2.
+ */
+
+import { createBlock } from '@wordpress/blocks';
+
+import metadata from './block.json';
+
+const { name } = metadata;
+
+interface EntityAttributes {
+    readonly [ key: string ]: unknown;
+}
+
+const transforms = {
+    from: [
+        {
+            type: 'block',
+            blocks: [ 'core/comments-pagination-previous' ],
+            transform: ( attributes: EntityAttributes ) =>
+                createBlock( name, attributes ),
+        },
+    ],
+    to: [
+        {
+            type: 'block',
+            blocks: [ 'core/comments-pagination-previous' ],
+            transform: ( attributes: EntityAttributes ) =>
+                createBlock( 'core/comments-pagination-previous', attributes ),
+        },
+    ],
+};
+
+export default transforms;

--- a/resources/js/visual-editor/blocks/comments-pagination-previous/upstream-state.json
+++ b/resources/js/visual-editor/blocks/comments-pagination-previous/upstream-state.json
@@ -1,0 +1,67 @@
+{
+    "$schema": "../../../../scripts/upstream-state.schema.json",
+    "block": "artisanpack/comments-pagination-previous",
+    "upstream": {
+        "package": "@wordpress/block-library",
+        "namespace": "core/comments-pagination-previous",
+        "pinnedVersion": "9.43.0",
+        "subpath": "comments-pagination-previous"
+    },
+    "forkedAt": "2026-06-02",
+    "$statusLegend": {
+        "ported": "byte-equivalent to upstream (CI fails on drift)",
+        "adapted": "TypeScript port and/or namespace swap; logically equivalent",
+        "extended": "fork adds behavior on top of upstream",
+        "rewritten": "fork replaced upstream entirely",
+        "added": "file unique to the fork (no upstream)"
+    },
+    "files": [
+        {
+            "fork": "block.json",
+            "upstream": "block.json",
+            "status": "adapted",
+            "notes": "name + textdomain swapped to the artisanpack namespace. Post-level block: consumes postId / postType (and artisanpack/postPreview for query-loop previews where applicable). Attribute schema and supports carried verbatim for parity."
+        },
+        {
+            "fork": "edit.tsx",
+            "upstream": "edit.js",
+            "status": "rewritten",
+            "notes": "Lightweight placeholder edit. Upstream queries the comment entity through @wordpress/core-data, which the post editor does not populate; the fork falls back to the post-family createEntityPlaceholderEdit (display blocks) or InnerBlocks (wrappers). Front-end markup is produced server-side from stamped _resolved* attributes."
+        },
+        {
+            "fork": "save.tsx",
+            "upstream": "n/a",
+            "status": "added",
+            "notes": "Dynamic block (or InnerBlocks delegate for wrappers) — markup produced server-side."
+        },
+        {
+            "fork": "transforms.ts",
+            "upstream": "transforms.js",
+            "status": "rewritten",
+            "notes": "Bidirectional core/comments-pagination-previous ↔ artisanpack/comments-pagination-previous block transforms for the rollout window. Wrapper variants thread innerBlocks through createBlock so the nested tree survives a namespace round-trip."
+        },
+        {
+            "fork": "inserter-icon.tsx",
+            "upstream": "n/a",
+            "status": "added",
+            "notes": "Inline SVG inserter icon (editor lacks dashicons.css)."
+        },
+        {
+            "fork": "index.ts",
+            "upstream": "index.js",
+            "status": "rewritten",
+            "notes": "Adapted to the visual-editor auto-discovery contract."
+        }
+    ],
+    "vendoredPrimitives": [],
+    "knownDivergences": [
+        "edit.tsx is a lightweight placeholder rather than upstream's entity-querying edit — the core-data shim does not expose comment-related entities to the post editor.",
+        "Server-rendered: front-end markup produced by Blade/React/Vue renderers from stamped _resolved* attributes, not by save().",
+        "transforms.ts adds bidirectional block transforms that do not exist upstream — required to coexist with core/comments-pagination-previous during the V1 rollout."
+    ],
+    "triage": {
+        "label": "in-sync",
+        "lastReviewed": "2026-06-02",
+        "reviewer": "Comments family fork (#519) Pass 2"
+    }
+}

--- a/resources/js/visual-editor/blocks/comments-pagination/block.json
+++ b/resources/js/visual-editor/blocks/comments-pagination/block.json
@@ -1,0 +1,55 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "artisanpack/comments-pagination",
+    "title": "Comments Pagination",
+    "category": "theme",
+    "description": "Displays a paginated navigation to next/previous set of comments, when applicable.",
+    "textdomain": "artisanpack-visual-editor",
+    "attributes": {
+        "paginationArrow": {
+            "type": "string",
+            "default": "none"
+        }
+    },
+    "providesContext": {
+        "comments/paginationArrow": "paginationArrow"
+    },
+    "supports": {
+        "align": true,
+        "reusable": false,
+        "html": false,
+        "color": {
+            "gradients": true,
+            "link": true,
+            "__experimentalDefaultControls": {
+                "background": true,
+                "text": true,
+                "link": true
+            }
+        },
+        "layout": {
+            "allowSwitching": false,
+            "allowInheriting": false,
+            "default": {
+                "type": "flex"
+            }
+        },
+        "interactivity": {
+            "clientNavigation": true
+        },
+        "typography": {
+            "fontSize": true,
+            "lineHeight": true,
+            "__experimentalFontFamily": true,
+            "__experimentalFontWeight": true,
+            "__experimentalFontStyle": true,
+            "__experimentalTextTransform": true,
+            "__experimentalTextDecoration": true,
+            "__experimentalLetterSpacing": true,
+            "__experimentalDefaultControls": {
+                "fontSize": true
+            }
+        }
+    }
+}

--- a/resources/js/visual-editor/blocks/comments-pagination/edit.tsx
+++ b/resources/js/visual-editor/blocks/comments-pagination/edit.tsx
@@ -1,0 +1,37 @@
+/**
+ * CommentsPagination — edit component.
+ *
+ * Wrapper around the pagination children (previous / numbers / next).
+ * Renders `<InnerBlocks />` with the upstream default template so the
+ * editor experience matches the rendered pagination row out of the
+ * box. Comments family fork (#519) Pass 2.
+ */
+
+import type { ReactElement } from 'react';
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
+
+const DEFAULT_TEMPLATE: ReadonlyArray<[string]> = [
+    [ 'artisanpack/comments-pagination-previous' ],
+    [ 'artisanpack/comments-pagination-numbers' ],
+    [ 'artisanpack/comments-pagination-next' ],
+];
+
+const ALLOWED_BLOCKS: ReadonlyArray<string> = [
+    'artisanpack/comments-pagination-previous',
+    'artisanpack/comments-pagination-numbers',
+    'artisanpack/comments-pagination-next',
+];
+
+export default function CommentsPaginationEdit(): ReactElement {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const blockProps = ( useBlockProps as any )();
+
+    return (
+        <div { ...blockProps }>
+            <InnerBlocks
+                template={ [ ...DEFAULT_TEMPLATE ] }
+                allowedBlocks={ [ ...ALLOWED_BLOCKS ] }
+            />
+        </div>
+    );
+}

--- a/resources/js/visual-editor/blocks/comments-pagination/index.ts
+++ b/resources/js/visual-editor/blocks/comments-pagination/index.ts
@@ -1,0 +1,23 @@
+/**
+ * CommentsPagination block entrypoint.
+ *
+ * Auto-discovered by `editor/custom-blocks.ts` and registered against
+ * `@wordpress/blocks.registerBlockType`. Comments family fork (#519) Pass 2.
+ */
+
+import metadata from './block.json';
+import edit from './edit';
+import save from './save';
+import transforms from './transforms';
+import icon from './inserter-icon';
+
+export { edit, save, metadata, icon, transforms };
+
+export default {
+    name: metadata.name,
+    metadata,
+    edit,
+    save,
+    icon,
+    transforms,
+};

--- a/resources/js/visual-editor/blocks/comments-pagination/inserter-icon.tsx
+++ b/resources/js/visual-editor/blocks/comments-pagination/inserter-icon.tsx
@@ -1,0 +1,23 @@
+/**
+ * CommentsPagination — inserter icon.
+ *
+ * Inline SVG so the editor canvas does not have to load `dashicons.css`.
+ * A paired-chevron glyph (page-back / page-forward) to differentiate
+ * from the rest of the comments family. Comments family fork (#519) Pass 2.
+ */
+
+import type { ReactElement } from 'react';
+
+export default function CommentsPaginationInserterIcon(): ReactElement {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            width={ 24 }
+            height={ 24 }
+            aria-hidden="true"
+        >
+            <path d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12zM20 6h-2v12h2zM4 6h2v12H4z" />
+        </svg>
+    );
+}

--- a/resources/js/visual-editor/blocks/comments-pagination/save.tsx
+++ b/resources/js/visual-editor/blocks/comments-pagination/save.tsx
@@ -1,0 +1,13 @@
+/**
+ * CommentsPagination — save component.
+ *
+ * Wrapper block whose saved markup is the serialized inner-block
+ * tree. Comments family fork (#519) Pass 2.
+ */
+
+import type { ReactElement } from 'react';
+import { InnerBlocks } from '@wordpress/block-editor';
+
+export default function CommentsPaginationSave(): ReactElement {
+    return <InnerBlocks.Content />;
+}

--- a/resources/js/visual-editor/blocks/comments-pagination/transforms.ts
+++ b/resources/js/visual-editor/blocks/comments-pagination/transforms.ts
@@ -1,0 +1,45 @@
+/**
+ * CommentsPagination — transforms.
+ *
+ * Bidirectional `core/comments-pagination` ↔ `artisanpack/comments-pagination` block
+ * transforms for the V1 rollout window. Comments family fork (#519) Pass 2.
+ */
+
+import { createBlock } from '@wordpress/blocks';
+
+import metadata from './block.json';
+
+const { name } = metadata;
+
+interface EntityAttributes {
+    readonly [ key: string ]: unknown;
+}
+
+type InnerBlocks = Parameters<typeof createBlock>[ 2 ];
+
+const transforms = {
+    from: [
+        {
+            type: 'block',
+            blocks: [ 'core/comments-pagination' ],
+            // Wrapper block — thread innerBlocks through so the nested
+            // tree round-trips losslessly through the namespace swap.
+            transform: (
+                attributes: EntityAttributes,
+                innerBlocks: InnerBlocks = []
+            ) => createBlock( name, attributes, innerBlocks ),
+        },
+    ],
+    to: [
+        {
+            type: 'block',
+            blocks: [ 'core/comments-pagination' ],
+            transform: (
+                attributes: EntityAttributes,
+                innerBlocks: InnerBlocks = []
+            ) => createBlock( 'core/comments-pagination', attributes, innerBlocks ),
+        },
+    ],
+};
+
+export default transforms;

--- a/resources/js/visual-editor/blocks/comments-pagination/upstream-state.json
+++ b/resources/js/visual-editor/blocks/comments-pagination/upstream-state.json
@@ -1,0 +1,67 @@
+{
+    "$schema": "../../../../scripts/upstream-state.schema.json",
+    "block": "artisanpack/comments-pagination",
+    "upstream": {
+        "package": "@wordpress/block-library",
+        "namespace": "core/comments-pagination",
+        "pinnedVersion": "9.43.0",
+        "subpath": "comments-pagination"
+    },
+    "forkedAt": "2026-06-02",
+    "$statusLegend": {
+        "ported": "byte-equivalent to upstream (CI fails on drift)",
+        "adapted": "TypeScript port and/or namespace swap; logically equivalent",
+        "extended": "fork adds behavior on top of upstream",
+        "rewritten": "fork replaced upstream entirely",
+        "added": "file unique to the fork (no upstream)"
+    },
+    "files": [
+        {
+            "fork": "block.json",
+            "upstream": "block.json",
+            "status": "adapted",
+            "notes": "name + textdomain swapped to the artisanpack namespace. Post-level block: consumes postId / postType (and artisanpack/postPreview for query-loop previews where applicable). Attribute schema and supports carried verbatim for parity."
+        },
+        {
+            "fork": "edit.tsx",
+            "upstream": "edit.js",
+            "status": "rewritten",
+            "notes": "Lightweight placeholder edit. Upstream queries the comment entity through @wordpress/core-data, which the post editor does not populate; the fork falls back to the post-family createEntityPlaceholderEdit (display blocks) or InnerBlocks (wrappers). Front-end markup is produced server-side from stamped _resolved* attributes."
+        },
+        {
+            "fork": "save.tsx",
+            "upstream": "n/a",
+            "status": "added",
+            "notes": "Dynamic block (or InnerBlocks delegate for wrappers) — markup produced server-side."
+        },
+        {
+            "fork": "transforms.ts",
+            "upstream": "transforms.js",
+            "status": "rewritten",
+            "notes": "Bidirectional core/comments-pagination ↔ artisanpack/comments-pagination block transforms for the rollout window. Wrapper variants thread innerBlocks through createBlock so the nested tree survives a namespace round-trip."
+        },
+        {
+            "fork": "inserter-icon.tsx",
+            "upstream": "n/a",
+            "status": "added",
+            "notes": "Inline SVG inserter icon (editor lacks dashicons.css)."
+        },
+        {
+            "fork": "index.ts",
+            "upstream": "index.js",
+            "status": "rewritten",
+            "notes": "Adapted to the visual-editor auto-discovery contract."
+        }
+    ],
+    "vendoredPrimitives": [],
+    "knownDivergences": [
+        "edit.tsx is a lightweight placeholder rather than upstream's entity-querying edit — the core-data shim does not expose comment-related entities to the post editor.",
+        "Server-rendered: front-end markup produced by Blade/React/Vue renderers from stamped _resolved* attributes, not by save().",
+        "transforms.ts adds bidirectional block transforms that do not exist upstream — required to coexist with core/comments-pagination during the V1 rollout."
+    ],
+    "triage": {
+        "label": "in-sync",
+        "lastReviewed": "2026-06-02",
+        "reviewer": "Comments family fork (#519) Pass 2"
+    }
+}

--- a/resources/js/visual-editor/blocks/post-comments-count/block.json
+++ b/resources/js/visual-editor/blocks/post-comments-count/block.json
@@ -1,0 +1,58 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "artisanpack/post-comments-count",
+    "title": "Comments Count",
+    "category": "theme",
+    "description": "Display a post's comments count.",
+    "textdomain": "artisanpack-visual-editor",
+    "attributes": {
+        "textAlign": {
+            "type": "string"
+        }
+    },
+    "usesContext": [
+        "postId",
+        "postType",
+        "artisanpack/postPreview"
+    ],
+    "example": {
+        "viewportWidth": 300
+    },
+    "supports": {
+        "html": false,
+        "color": {
+            "gradients": true,
+            "__experimentalDefaultControls": {
+                "background": true,
+                "text": true
+            }
+        },
+        "spacing": {
+            "margin": true,
+            "padding": true
+        },
+        "typography": {
+            "fontSize": true,
+            "lineHeight": true,
+            "__experimentalFontFamily": true,
+            "__experimentalFontWeight": true,
+            "__experimentalFontStyle": true,
+            "__experimentalTextTransform": true,
+            "__experimentalTextDecoration": true,
+            "__experimentalLetterSpacing": true,
+            "__experimentalDefaultControls": {
+                "fontSize": true
+            }
+        },
+        "interactivity": {
+            "clientNavigation": true
+        },
+        "__experimentalBorder": {
+            "radius": true,
+            "color": true,
+            "width": true,
+            "style": true
+        }
+    }
+}

--- a/resources/js/visual-editor/blocks/post-comments-count/edit.tsx
+++ b/resources/js/visual-editor/blocks/post-comments-count/edit.tsx
@@ -1,0 +1,36 @@
+/**
+ * PostCommentsCount — edit component.
+ *
+ * Server-rendered display block. Previews through the post-family
+ * `createEntityPlaceholderEdit`: stamped `_resolvedCommentCount` first,
+ * then `artisanpack/postPreview` context, then the live page entity,
+ * then a labelled placeholder. Comments family fork (#519) Pass 2.
+ */
+
+import { __ } from '@wordpress/i18n';
+
+import { TEXT_DOMAIN } from '../../vendor/i18n';
+import { createEntityPlaceholderEdit } from '../_shared/entity-placeholder-edit';
+
+export default createEntityPlaceholderEdit( {
+    label: __( 'Comments Count', TEXT_DOMAIN ),
+    resolvedKey: '_resolvedCommentCount',
+    kind: 'text',
+    fromQueryPreview: ( post ) => {
+        // QueryPreviewPost may carry a `commentCount` shape pulled from
+        // the resolved post envelope; render whatever the host emits.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const count = ( post as any ).commentCount;
+        return typeof count === 'number' && Number.isFinite( count )
+            ? { text: String( count ) }
+            : null;
+    },
+    fromPostEntity: ( entity ) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const count = ( entity as any ).commentCount ?? ( entity as any )._preview?.commentCount;
+        return typeof count === 'number' && Number.isFinite( count )
+            ? { text: String( count ) }
+            : null;
+    },
+    dummyValue: { text: '5' },
+} );

--- a/resources/js/visual-editor/blocks/post-comments-count/index.ts
+++ b/resources/js/visual-editor/blocks/post-comments-count/index.ts
@@ -1,0 +1,23 @@
+/**
+ * PostCommentsCount block entrypoint.
+ *
+ * Auto-discovered by `editor/custom-blocks.ts` and registered against
+ * `@wordpress/blocks.registerBlockType`. Comments family fork (#519) Pass 2.
+ */
+
+import metadata from './block.json';
+import edit from './edit';
+import save from './save';
+import transforms from './transforms';
+import icon from './inserter-icon';
+
+export { edit, save, metadata, icon, transforms };
+
+export default {
+    name: metadata.name,
+    metadata,
+    edit,
+    save,
+    icon,
+    transforms,
+};

--- a/resources/js/visual-editor/blocks/post-comments-count/inserter-icon.tsx
+++ b/resources/js/visual-editor/blocks/post-comments-count/inserter-icon.tsx
@@ -1,0 +1,22 @@
+/**
+ * PostCommentsCount — inserter icon.
+ *
+ * Inline SVG so the editor canvas does not have to load `dashicons.css`.
+ * A "#" glyph signaling a count. Comments family fork (#519) Pass 2.
+ */
+
+import type { ReactElement } from 'react';
+
+export default function PostCommentsCountInserterIcon(): ReactElement {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            width={ 24 }
+            height={ 24 }
+            aria-hidden="true"
+        >
+            <path d="M19.31 8 17.79 6 14.93 8.74 12.65 6 11.13 8 13.4 10.74 11.13 13.74 12.65 15.74 14.93 13 17.79 15.74 19.31 13.74 17.04 11 19.31 8zM8 16h2v3h2v-3h2v-2H8v2zM4 8h2v6h2V8h2V6H4v2z" />
+        </svg>
+    );
+}

--- a/resources/js/visual-editor/blocks/post-comments-count/save.tsx
+++ b/resources/js/visual-editor/blocks/post-comments-count/save.tsx
@@ -1,0 +1,10 @@
+/**
+ * PostCommentsCount — save component.
+ *
+ * Dynamic block: returns null; markup produced server-side from
+ * stamped `_resolved*` attributes. Comments family fork (#519) Pass 2.
+ */
+
+export default function PostCommentsCountSave(): null {
+    return null;
+}

--- a/resources/js/visual-editor/blocks/post-comments-count/transforms.ts
+++ b/resources/js/visual-editor/blocks/post-comments-count/transforms.ts
@@ -1,0 +1,37 @@
+/**
+ * PostCommentsCount — transforms.
+ *
+ * Bidirectional `core/post-comments-count` ↔ `artisanpack/post-comments-count` block
+ * transforms for the V1 rollout window. Comments family fork (#519) Pass 2.
+ */
+
+import { createBlock } from '@wordpress/blocks';
+
+import metadata from './block.json';
+
+const { name } = metadata;
+
+interface EntityAttributes {
+    readonly [ key: string ]: unknown;
+}
+
+const transforms = {
+    from: [
+        {
+            type: 'block',
+            blocks: [ 'core/post-comments-count' ],
+            transform: ( attributes: EntityAttributes ) =>
+                createBlock( name, attributes ),
+        },
+    ],
+    to: [
+        {
+            type: 'block',
+            blocks: [ 'core/post-comments-count' ],
+            transform: ( attributes: EntityAttributes ) =>
+                createBlock( 'core/post-comments-count', attributes ),
+        },
+    ],
+};
+
+export default transforms;

--- a/resources/js/visual-editor/blocks/post-comments-count/upstream-state.json
+++ b/resources/js/visual-editor/blocks/post-comments-count/upstream-state.json
@@ -1,0 +1,67 @@
+{
+    "$schema": "../../../../scripts/upstream-state.schema.json",
+    "block": "artisanpack/post-comments-count",
+    "upstream": {
+        "package": "@wordpress/block-library",
+        "namespace": "core/post-comments-count",
+        "pinnedVersion": "9.43.0",
+        "subpath": "post-comments-count"
+    },
+    "forkedAt": "2026-06-02",
+    "$statusLegend": {
+        "ported": "byte-equivalent to upstream (CI fails on drift)",
+        "adapted": "TypeScript port and/or namespace swap; logically equivalent",
+        "extended": "fork adds behavior on top of upstream",
+        "rewritten": "fork replaced upstream entirely",
+        "added": "file unique to the fork (no upstream)"
+    },
+    "files": [
+        {
+            "fork": "block.json",
+            "upstream": "block.json",
+            "status": "adapted",
+            "notes": "name + textdomain swapped to the artisanpack namespace. Post-level block: consumes postId / postType (and artisanpack/postPreview for query-loop previews where applicable). Attribute schema and supports carried verbatim for parity."
+        },
+        {
+            "fork": "edit.tsx",
+            "upstream": "edit.js",
+            "status": "rewritten",
+            "notes": "Lightweight placeholder edit. Upstream queries the comment entity through @wordpress/core-data, which the post editor does not populate; the fork falls back to the post-family createEntityPlaceholderEdit (display blocks) or InnerBlocks (wrappers). Front-end markup is produced server-side from stamped _resolved* attributes."
+        },
+        {
+            "fork": "save.tsx",
+            "upstream": "n/a",
+            "status": "added",
+            "notes": "Dynamic block (or InnerBlocks delegate for wrappers) — markup produced server-side."
+        },
+        {
+            "fork": "transforms.ts",
+            "upstream": "transforms.js",
+            "status": "rewritten",
+            "notes": "Bidirectional core/post-comments-count ↔ artisanpack/post-comments-count block transforms for the rollout window. Wrapper variants thread innerBlocks through createBlock so the nested tree survives a namespace round-trip."
+        },
+        {
+            "fork": "inserter-icon.tsx",
+            "upstream": "n/a",
+            "status": "added",
+            "notes": "Inline SVG inserter icon (editor lacks dashicons.css)."
+        },
+        {
+            "fork": "index.ts",
+            "upstream": "index.js",
+            "status": "rewritten",
+            "notes": "Adapted to the visual-editor auto-discovery contract."
+        }
+    ],
+    "vendoredPrimitives": [],
+    "knownDivergences": [
+        "edit.tsx is a lightweight placeholder rather than upstream's entity-querying edit — the core-data shim does not expose comment-related entities to the post editor.",
+        "Server-rendered: front-end markup produced by Blade/React/Vue renderers from stamped _resolved* attributes, not by save().",
+        "transforms.ts adds bidirectional block transforms that do not exist upstream — required to coexist with core/post-comments-count during the V1 rollout."
+    ],
+    "triage": {
+        "label": "in-sync",
+        "lastReviewed": "2026-06-02",
+        "reviewer": "Comments family fork (#519) Pass 2"
+    }
+}

--- a/resources/js/visual-editor/blocks/post-comments-form/block.json
+++ b/resources/js/visual-editor/blocks/post-comments-form/block.json
@@ -1,0 +1,59 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "artisanpack/post-comments-form",
+    "title": "Comments Form",
+    "category": "theme",
+    "description": "Display a post's comments form.",
+    "textdomain": "artisanpack-visual-editor",
+    "attributes": {
+        "textAlign": {
+            "type": "string"
+        }
+    },
+    "usesContext": [
+        "postId",
+        "postType"
+    ],
+    "supports": {
+        "anchor": true,
+        "align": [ "wide", "full" ],
+        "html": false,
+        "color": {
+            "gradients": true,
+            "heading": true,
+            "link": true,
+            "__experimentalDefaultControls": {
+                "background": true,
+                "text": true,
+                "link": true
+            }
+        },
+        "spacing": {
+            "margin": true,
+            "padding": true
+        },
+        "typography": {
+            "fontSize": true,
+            "lineHeight": true,
+            "__experimentalFontFamily": true,
+            "__experimentalFontWeight": true,
+            "__experimentalFontStyle": true,
+            "__experimentalTextTransform": true,
+            "__experimentalTextDecoration": true,
+            "__experimentalLetterSpacing": true,
+            "__experimentalDefaultControls": {
+                "fontSize": true
+            }
+        },
+        "interactivity": {
+            "clientNavigation": true
+        },
+        "__experimentalBorder": {
+            "radius": true,
+            "color": true,
+            "width": true,
+            "style": true
+        }
+    }
+}

--- a/resources/js/visual-editor/blocks/post-comments-form/edit.tsx
+++ b/resources/js/visual-editor/blocks/post-comments-form/edit.tsx
@@ -1,0 +1,70 @@
+/**
+ * PostCommentsForm — edit component.
+ *
+ * Server-rendered interactive block. The real comment form is emitted
+ * by the front-end renderer from `_resolved*` attributes; the editor
+ * preview renders a representative, non-interactive form so authors
+ * can style every label, input, and submit-button state in the
+ * canvas. Comments family fork (#519) Pass 2.
+ */
+
+import type { CSSProperties, ReactElement } from 'react';
+import { useBlockProps } from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
+
+import { TEXT_DOMAIN } from '../../vendor/i18n';
+
+const wrapperStyle: CSSProperties = {
+    pointerEvents: 'none',
+};
+
+export default function PostCommentsFormEdit(): ReactElement {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const blockProps = ( useBlockProps as any )( {
+        className: 'wp-block-post-comments-form comment-respond',
+        style: wrapperStyle,
+    } );
+
+    return (
+        <div { ...blockProps }>
+            <h3 className="comment-reply-title">
+                { __( 'Leave a Comment', TEXT_DOMAIN ) }
+            </h3>
+            <form className="comment-form" onSubmit={ ( e ) => e.preventDefault() }>
+                <p className="comment-form-author">
+                    <label>
+                        { __( 'Name', TEXT_DOMAIN ) }{ ' ' }
+                        <span aria-hidden="true">*</span>
+                    </label>
+                    <input type="text" disabled />
+                </p>
+                <p className="comment-form-email">
+                    <label>
+                        { __( 'Email', TEXT_DOMAIN ) }{ ' ' }
+                        <span aria-hidden="true">*</span>
+                    </label>
+                    <input type="email" disabled />
+                </p>
+                <p className="comment-form-url">
+                    <label>{ __( 'Website', TEXT_DOMAIN ) }</label>
+                    <input type="url" disabled />
+                </p>
+                <p className="comment-form-comment">
+                    <label>
+                        { __( 'Comment', TEXT_DOMAIN ) }{ ' ' }
+                        <span aria-hidden="true">*</span>
+                    </label>
+                    <textarea rows={ 6 } disabled />
+                </p>
+                <p className="form-submit">
+                    <input
+                        type="submit"
+                        className="submit"
+                        value={ __( 'Post Comment', TEXT_DOMAIN ) }
+                        disabled
+                    />
+                </p>
+            </form>
+        </div>
+    );
+}

--- a/resources/js/visual-editor/blocks/post-comments-form/index.ts
+++ b/resources/js/visual-editor/blocks/post-comments-form/index.ts
@@ -1,0 +1,23 @@
+/**
+ * PostCommentsForm block entrypoint.
+ *
+ * Auto-discovered by `editor/custom-blocks.ts` and registered against
+ * `@wordpress/blocks.registerBlockType`. Comments family fork (#519) Pass 2.
+ */
+
+import metadata from './block.json';
+import edit from './edit';
+import save from './save';
+import transforms from './transforms';
+import icon from './inserter-icon';
+
+export { edit, save, metadata, icon, transforms };
+
+export default {
+    name: metadata.name,
+    metadata,
+    edit,
+    save,
+    icon,
+    transforms,
+};

--- a/resources/js/visual-editor/blocks/post-comments-form/inserter-icon.tsx
+++ b/resources/js/visual-editor/blocks/post-comments-form/inserter-icon.tsx
@@ -1,0 +1,22 @@
+/**
+ * PostCommentsForm — inserter icon.
+ *
+ * Inline SVG so the editor canvas does not have to load `dashicons.css`.
+ * A form/lines-with-textbox glyph. Comments family fork (#519) Pass 2.
+ */
+
+import type { ReactElement } from 'react';
+
+export default function PostCommentsFormInserterIcon(): ReactElement {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            width={ 24 }
+            height={ 24 }
+            aria-hidden="true"
+        >
+            <path d="M20 2H4c-1.11 0-2 .9-2 2v18l4-4h14c1.11 0 2-.9 2-2V4c0-1.11-.89-2-2-2zM6 9h12v2H6V9zm8 5H6v-2h8v2zm4-6H6V6h12v2z" />
+        </svg>
+    );
+}

--- a/resources/js/visual-editor/blocks/post-comments-form/save.tsx
+++ b/resources/js/visual-editor/blocks/post-comments-form/save.tsx
@@ -1,0 +1,11 @@
+/**
+ * PostCommentsForm — save component.
+ *
+ * Dynamic block: returns null; the real <form> markup is emitted by
+ * the front-end renderer at request time. Upstream WP serializes
+ * post-comments-form the same way. Comments family fork (#519) Pass 2.
+ */
+
+export default function PostCommentsFormSave(): null {
+    return null;
+}

--- a/resources/js/visual-editor/blocks/post-comments-form/transforms.ts
+++ b/resources/js/visual-editor/blocks/post-comments-form/transforms.ts
@@ -1,0 +1,45 @@
+/**
+ * PostCommentsForm — transforms.
+ *
+ * Bidirectional `core/post-comments-form` ↔ `artisanpack/post-comments-form` block
+ * transforms for the V1 rollout window. Comments family fork (#519) Pass 2.
+ */
+
+import { createBlock } from '@wordpress/blocks';
+
+import metadata from './block.json';
+
+const { name } = metadata;
+
+interface EntityAttributes {
+    readonly [ key: string ]: unknown;
+}
+
+type InnerBlocks = Parameters<typeof createBlock>[ 2 ];
+
+const transforms = {
+    from: [
+        {
+            type: 'block',
+            blocks: [ 'core/post-comments-form' ],
+            // Wrapper block — thread innerBlocks through so the nested
+            // tree round-trips losslessly through the namespace swap.
+            transform: (
+                attributes: EntityAttributes,
+                innerBlocks: InnerBlocks = []
+            ) => createBlock( name, attributes, innerBlocks ),
+        },
+    ],
+    to: [
+        {
+            type: 'block',
+            blocks: [ 'core/post-comments-form' ],
+            transform: (
+                attributes: EntityAttributes,
+                innerBlocks: InnerBlocks = []
+            ) => createBlock( 'core/post-comments-form', attributes, innerBlocks ),
+        },
+    ],
+};
+
+export default transforms;

--- a/resources/js/visual-editor/blocks/post-comments-form/upstream-state.json
+++ b/resources/js/visual-editor/blocks/post-comments-form/upstream-state.json
@@ -1,0 +1,67 @@
+{
+    "$schema": "../../../../scripts/upstream-state.schema.json",
+    "block": "artisanpack/post-comments-form",
+    "upstream": {
+        "package": "@wordpress/block-library",
+        "namespace": "core/post-comments-form",
+        "pinnedVersion": "9.43.0",
+        "subpath": "post-comments-form"
+    },
+    "forkedAt": "2026-06-02",
+    "$statusLegend": {
+        "ported": "byte-equivalent to upstream (CI fails on drift)",
+        "adapted": "TypeScript port and/or namespace swap; logically equivalent",
+        "extended": "fork adds behavior on top of upstream",
+        "rewritten": "fork replaced upstream entirely",
+        "added": "file unique to the fork (no upstream)"
+    },
+    "files": [
+        {
+            "fork": "block.json",
+            "upstream": "block.json",
+            "status": "adapted",
+            "notes": "name + textdomain swapped to the artisanpack namespace. Post-level block: consumes postId / postType (and artisanpack/postPreview for query-loop previews where applicable). Attribute schema and supports carried verbatim for parity."
+        },
+        {
+            "fork": "edit.tsx",
+            "upstream": "edit.js",
+            "status": "rewritten",
+            "notes": "Lightweight placeholder edit. Upstream queries the comment entity through @wordpress/core-data, which the post editor does not populate; the fork falls back to the post-family createEntityPlaceholderEdit (display blocks) or InnerBlocks (wrappers). Front-end markup is produced server-side from stamped _resolved* attributes."
+        },
+        {
+            "fork": "save.tsx",
+            "upstream": "n/a",
+            "status": "added",
+            "notes": "Dynamic block (or InnerBlocks delegate for wrappers) — markup produced server-side."
+        },
+        {
+            "fork": "transforms.ts",
+            "upstream": "transforms.js",
+            "status": "rewritten",
+            "notes": "Bidirectional core/post-comments-form ↔ artisanpack/post-comments-form block transforms for the rollout window. Wrapper variants thread innerBlocks through createBlock so the nested tree survives a namespace round-trip."
+        },
+        {
+            "fork": "inserter-icon.tsx",
+            "upstream": "n/a",
+            "status": "added",
+            "notes": "Inline SVG inserter icon (editor lacks dashicons.css)."
+        },
+        {
+            "fork": "index.ts",
+            "upstream": "index.js",
+            "status": "rewritten",
+            "notes": "Adapted to the visual-editor auto-discovery contract."
+        }
+    ],
+    "vendoredPrimitives": [],
+    "knownDivergences": [
+        "edit.tsx is a lightweight placeholder rather than upstream's entity-querying edit — the core-data shim does not expose comment-related entities to the post editor.",
+        "Server-rendered: front-end markup produced by Blade/React/Vue renderers from stamped _resolved* attributes, not by save().",
+        "transforms.ts adds bidirectional block transforms that do not exist upstream — required to coexist with core/post-comments-form during the V1 rollout."
+    ],
+    "triage": {
+        "label": "in-sync",
+        "lastReviewed": "2026-06-02",
+        "reviewer": "Comments family fork (#519) Pass 2"
+    }
+}

--- a/resources/js/visual-editor/blocks/post-comments-link/block.json
+++ b/resources/js/visual-editor/blocks/post-comments-link/block.json
@@ -1,0 +1,59 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "artisanpack/post-comments-link",
+    "title": "Comments Link",
+    "category": "theme",
+    "description": "Displays the link to the current post comments.",
+    "textdomain": "artisanpack-visual-editor",
+    "attributes": {
+        "textAlign": {
+            "type": "string"
+        }
+    },
+    "usesContext": [
+        "postType",
+        "postId",
+        "artisanpack/postPreview"
+    ],
+    "example": {
+        "viewportWidth": 350
+    },
+    "supports": {
+        "html": false,
+        "color": {
+            "gradients": true,
+            "link": true,
+            "__experimentalDefaultControls": {
+                "background": true,
+                "link": true
+            }
+        },
+        "spacing": {
+            "margin": true,
+            "padding": true
+        },
+        "typography": {
+            "fontSize": true,
+            "lineHeight": true,
+            "__experimentalFontFamily": true,
+            "__experimentalFontWeight": true,
+            "__experimentalFontStyle": true,
+            "__experimentalTextTransform": true,
+            "__experimentalTextDecoration": true,
+            "__experimentalLetterSpacing": true,
+            "__experimentalDefaultControls": {
+                "fontSize": true
+            }
+        },
+        "interactivity": {
+            "clientNavigation": true
+        },
+        "__experimentalBorder": {
+            "radius": true,
+            "color": true,
+            "width": true,
+            "style": true
+        }
+    }
+}

--- a/resources/js/visual-editor/blocks/post-comments-link/edit.tsx
+++ b/resources/js/visual-editor/blocks/post-comments-link/edit.tsx
@@ -1,0 +1,21 @@
+/**
+ * PostCommentsLink — edit component.
+ *
+ * Server-rendered display block. Previews through the post-family
+ * `createEntityPlaceholderEdit`. The link itself is emitted server-side
+ * from the stamped `_resolvedCommentsUrl` / `_resolvedCommentsLabel`
+ * attributes; the editor preview just shows the label text.
+ * Comments family fork (#519) Pass 2.
+ */
+
+import { __ } from '@wordpress/i18n';
+
+import { TEXT_DOMAIN } from '../../vendor/i18n';
+import { createEntityPlaceholderEdit } from '../_shared/entity-placeholder-edit';
+
+export default createEntityPlaceholderEdit( {
+    label: __( 'Comments Link', TEXT_DOMAIN ),
+    resolvedKey: '_resolvedCommentsLabel',
+    kind: 'text',
+    dummyValue: { text: '5 Comments' },
+} );

--- a/resources/js/visual-editor/blocks/post-comments-link/index.ts
+++ b/resources/js/visual-editor/blocks/post-comments-link/index.ts
@@ -1,0 +1,23 @@
+/**
+ * PostCommentsLink block entrypoint.
+ *
+ * Auto-discovered by `editor/custom-blocks.ts` and registered against
+ * `@wordpress/blocks.registerBlockType`. Comments family fork (#519) Pass 2.
+ */
+
+import metadata from './block.json';
+import edit from './edit';
+import save from './save';
+import transforms from './transforms';
+import icon from './inserter-icon';
+
+export { edit, save, metadata, icon, transforms };
+
+export default {
+    name: metadata.name,
+    metadata,
+    edit,
+    save,
+    icon,
+    transforms,
+};

--- a/resources/js/visual-editor/blocks/post-comments-link/inserter-icon.tsx
+++ b/resources/js/visual-editor/blocks/post-comments-link/inserter-icon.tsx
@@ -1,0 +1,22 @@
+/**
+ * PostCommentsLink — inserter icon.
+ *
+ * Inline SVG so the editor canvas does not have to load `dashicons.css`.
+ * A chain-link glyph. Comments family fork (#519) Pass 2.
+ */
+
+import type { ReactElement } from 'react';
+
+export default function PostCommentsLinkInserterIcon(): ReactElement {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            width={ 24 }
+            height={ 24 }
+            aria-hidden="true"
+        >
+            <path d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z" />
+        </svg>
+    );
+}

--- a/resources/js/visual-editor/blocks/post-comments-link/save.tsx
+++ b/resources/js/visual-editor/blocks/post-comments-link/save.tsx
@@ -1,0 +1,10 @@
+/**
+ * PostCommentsLink — save component.
+ *
+ * Dynamic block: returns null; markup produced server-side from
+ * stamped `_resolved*` attributes. Comments family fork (#519) Pass 2.
+ */
+
+export default function PostCommentsLinkSave(): null {
+    return null;
+}

--- a/resources/js/visual-editor/blocks/post-comments-link/transforms.ts
+++ b/resources/js/visual-editor/blocks/post-comments-link/transforms.ts
@@ -1,0 +1,37 @@
+/**
+ * PostCommentsLink — transforms.
+ *
+ * Bidirectional `core/post-comments-link` ↔ `artisanpack/post-comments-link` block
+ * transforms for the V1 rollout window. Comments family fork (#519) Pass 2.
+ */
+
+import { createBlock } from '@wordpress/blocks';
+
+import metadata from './block.json';
+
+const { name } = metadata;
+
+interface EntityAttributes {
+    readonly [ key: string ]: unknown;
+}
+
+const transforms = {
+    from: [
+        {
+            type: 'block',
+            blocks: [ 'core/post-comments-link' ],
+            transform: ( attributes: EntityAttributes ) =>
+                createBlock( name, attributes ),
+        },
+    ],
+    to: [
+        {
+            type: 'block',
+            blocks: [ 'core/post-comments-link' ],
+            transform: ( attributes: EntityAttributes ) =>
+                createBlock( 'core/post-comments-link', attributes ),
+        },
+    ],
+};
+
+export default transforms;

--- a/resources/js/visual-editor/blocks/post-comments-link/upstream-state.json
+++ b/resources/js/visual-editor/blocks/post-comments-link/upstream-state.json
@@ -1,0 +1,67 @@
+{
+    "$schema": "../../../../scripts/upstream-state.schema.json",
+    "block": "artisanpack/post-comments-link",
+    "upstream": {
+        "package": "@wordpress/block-library",
+        "namespace": "core/post-comments-link",
+        "pinnedVersion": "9.43.0",
+        "subpath": "post-comments-link"
+    },
+    "forkedAt": "2026-06-02",
+    "$statusLegend": {
+        "ported": "byte-equivalent to upstream (CI fails on drift)",
+        "adapted": "TypeScript port and/or namespace swap; logically equivalent",
+        "extended": "fork adds behavior on top of upstream",
+        "rewritten": "fork replaced upstream entirely",
+        "added": "file unique to the fork (no upstream)"
+    },
+    "files": [
+        {
+            "fork": "block.json",
+            "upstream": "block.json",
+            "status": "adapted",
+            "notes": "name + textdomain swapped to the artisanpack namespace. Post-level block: consumes postId / postType (and artisanpack/postPreview for query-loop previews where applicable). Attribute schema and supports carried verbatim for parity."
+        },
+        {
+            "fork": "edit.tsx",
+            "upstream": "edit.js",
+            "status": "rewritten",
+            "notes": "Lightweight placeholder edit. Upstream queries the comment entity through @wordpress/core-data, which the post editor does not populate; the fork falls back to the post-family createEntityPlaceholderEdit (display blocks) or InnerBlocks (wrappers). Front-end markup is produced server-side from stamped _resolved* attributes."
+        },
+        {
+            "fork": "save.tsx",
+            "upstream": "n/a",
+            "status": "added",
+            "notes": "Dynamic block (or InnerBlocks delegate for wrappers) — markup produced server-side."
+        },
+        {
+            "fork": "transforms.ts",
+            "upstream": "transforms.js",
+            "status": "rewritten",
+            "notes": "Bidirectional core/post-comments-link ↔ artisanpack/post-comments-link block transforms for the rollout window. Wrapper variants thread innerBlocks through createBlock so the nested tree survives a namespace round-trip."
+        },
+        {
+            "fork": "inserter-icon.tsx",
+            "upstream": "n/a",
+            "status": "added",
+            "notes": "Inline SVG inserter icon (editor lacks dashicons.css)."
+        },
+        {
+            "fork": "index.ts",
+            "upstream": "index.js",
+            "status": "rewritten",
+            "notes": "Adapted to the visual-editor auto-discovery contract."
+        }
+    ],
+    "vendoredPrimitives": [],
+    "knownDivergences": [
+        "edit.tsx is a lightweight placeholder rather than upstream's entity-querying edit — the core-data shim does not expose comment-related entities to the post editor.",
+        "Server-rendered: front-end markup produced by Blade/React/Vue renderers from stamped _resolved* attributes, not by save().",
+        "transforms.ts adds bidirectional block transforms that do not exist upstream — required to coexist with core/post-comments-link during the V1 rollout."
+    ],
+    "triage": {
+        "label": "in-sync",
+        "lastReviewed": "2026-06-02",
+        "reviewer": "Comments family fork (#519) Pass 2"
+    }
+}

--- a/resources/js/visual-editor/blocks/post-comments-title/block.json
+++ b/resources/js/visual-editor/blocks/post-comments-title/block.json
@@ -1,0 +1,72 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "artisanpack/post-comments-title",
+    "title": "Comments Title",
+    "category": "theme",
+    "description": "Displays a title with the number of comments.",
+    "textdomain": "artisanpack-visual-editor",
+    "attributes": {
+        "textAlign": {
+            "type": "string"
+        },
+        "showPostTitle": {
+            "type": "boolean",
+            "default": false
+        },
+        "showCommentsCount": {
+            "type": "boolean",
+            "default": true
+        },
+        "level": {
+            "type": "number",
+            "default": 2
+        },
+        "levelOptions": {
+            "type": "array"
+        }
+    },
+    "usesContext": [
+        "postId",
+        "postType",
+        "artisanpack/postPreview"
+    ],
+    "supports": {
+        "anchor": false,
+        "align": [ "wide", "full" ],
+        "html": false,
+        "__experimentalBorder": {
+            "radius": true,
+            "color": true,
+            "width": true,
+            "style": true
+        },
+        "color": {
+            "gradients": true,
+            "__experimentalDefaultControls": {
+                "background": true,
+                "text": true
+            }
+        },
+        "spacing": {
+            "margin": true,
+            "padding": true
+        },
+        "typography": {
+            "fontSize": true,
+            "lineHeight": true,
+            "__experimentalFontFamily": true,
+            "__experimentalFontWeight": true,
+            "__experimentalFontStyle": true,
+            "__experimentalTextTransform": true,
+            "__experimentalTextDecoration": true,
+            "__experimentalLetterSpacing": true,
+            "__experimentalDefaultControls": {
+                "fontSize": true
+            }
+        },
+        "interactivity": {
+            "clientNavigation": true
+        }
+    }
+}

--- a/resources/js/visual-editor/blocks/post-comments-title/edit.tsx
+++ b/resources/js/visual-editor/blocks/post-comments-title/edit.tsx
@@ -1,0 +1,23 @@
+/**
+ * PostCommentsTitle — edit component.
+ *
+ * Server-rendered display block. Previews through the post-family
+ * `createEntityPlaceholderEdit`: stamped `_resolvedCommentsTitle`
+ * first, then a labelled placeholder. The server-side renderer
+ * computes the final "X Comments" string from `_resolvedCommentCount`
+ * and the `showCommentsCount` / `showPostTitle` attributes; the
+ * editor preview just shows the stamped value or the label.
+ * Comments family fork (#519) Pass 2.
+ */
+
+import { __ } from '@wordpress/i18n';
+
+import { TEXT_DOMAIN } from '../../vendor/i18n';
+import { createEntityPlaceholderEdit } from '../_shared/entity-placeholder-edit';
+
+export default createEntityPlaceholderEdit( {
+    label: __( 'Comments Title', TEXT_DOMAIN ),
+    resolvedKey: '_resolvedCommentsTitle',
+    kind: 'text',
+    dummyValue: { text: '5 Comments' },
+} );

--- a/resources/js/visual-editor/blocks/post-comments-title/index.ts
+++ b/resources/js/visual-editor/blocks/post-comments-title/index.ts
@@ -1,0 +1,23 @@
+/**
+ * PostCommentsTitle block entrypoint.
+ *
+ * Auto-discovered by `editor/custom-blocks.ts` and registered against
+ * `@wordpress/blocks.registerBlockType`. Comments family fork (#519) Pass 2.
+ */
+
+import metadata from './block.json';
+import edit from './edit';
+import save from './save';
+import transforms from './transforms';
+import icon from './inserter-icon';
+
+export { edit, save, metadata, icon, transforms };
+
+export default {
+    name: metadata.name,
+    metadata,
+    edit,
+    save,
+    icon,
+    transforms,
+};

--- a/resources/js/visual-editor/blocks/post-comments-title/inserter-icon.tsx
+++ b/resources/js/visual-editor/blocks/post-comments-title/inserter-icon.tsx
@@ -1,0 +1,22 @@
+/**
+ * PostCommentsTitle — inserter icon.
+ *
+ * Inline SVG so the editor canvas does not have to load `dashicons.css`.
+ * A heading-style "H" glyph. Comments family fork (#519) Pass 2.
+ */
+
+import type { ReactElement } from 'react';
+
+export default function PostCommentsTitleInserterIcon(): ReactElement {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            width={ 24 }
+            height={ 24 }
+            aria-hidden="true"
+        >
+            <path d="M5 4v3h5.5v12h3V7H19V4z" />
+        </svg>
+    );
+}

--- a/resources/js/visual-editor/blocks/post-comments-title/save.tsx
+++ b/resources/js/visual-editor/blocks/post-comments-title/save.tsx
@@ -1,0 +1,10 @@
+/**
+ * PostCommentsTitle — save component.
+ *
+ * Dynamic block: returns null; markup produced server-side from
+ * stamped `_resolved*` attributes. Comments family fork (#519) Pass 2.
+ */
+
+export default function PostCommentsTitleSave(): null {
+    return null;
+}

--- a/resources/js/visual-editor/blocks/post-comments-title/transforms.ts
+++ b/resources/js/visual-editor/blocks/post-comments-title/transforms.ts
@@ -1,0 +1,37 @@
+/**
+ * PostCommentsTitle — transforms.
+ *
+ * Bidirectional `core/post-comments-title` ↔ `artisanpack/post-comments-title` block
+ * transforms for the V1 rollout window. Comments family fork (#519) Pass 2.
+ */
+
+import { createBlock } from '@wordpress/blocks';
+
+import metadata from './block.json';
+
+const { name } = metadata;
+
+interface EntityAttributes {
+    readonly [ key: string ]: unknown;
+}
+
+const transforms = {
+    from: [
+        {
+            type: 'block',
+            blocks: [ 'core/post-comments-title' ],
+            transform: ( attributes: EntityAttributes ) =>
+                createBlock( name, attributes ),
+        },
+    ],
+    to: [
+        {
+            type: 'block',
+            blocks: [ 'core/post-comments-title' ],
+            transform: ( attributes: EntityAttributes ) =>
+                createBlock( 'core/post-comments-title', attributes ),
+        },
+    ],
+};
+
+export default transforms;

--- a/resources/js/visual-editor/blocks/post-comments-title/upstream-state.json
+++ b/resources/js/visual-editor/blocks/post-comments-title/upstream-state.json
@@ -1,0 +1,67 @@
+{
+    "$schema": "../../../../scripts/upstream-state.schema.json",
+    "block": "artisanpack/post-comments-title",
+    "upstream": {
+        "package": "@wordpress/block-library",
+        "namespace": "core/post-comments-title",
+        "pinnedVersion": "9.43.0",
+        "subpath": "post-comments-title"
+    },
+    "forkedAt": "2026-06-02",
+    "$statusLegend": {
+        "ported": "byte-equivalent to upstream (CI fails on drift)",
+        "adapted": "TypeScript port and/or namespace swap; logically equivalent",
+        "extended": "fork adds behavior on top of upstream",
+        "rewritten": "fork replaced upstream entirely",
+        "added": "file unique to the fork (no upstream)"
+    },
+    "files": [
+        {
+            "fork": "block.json",
+            "upstream": "block.json",
+            "status": "adapted",
+            "notes": "name + textdomain swapped to the artisanpack namespace. Post-level block: consumes postId / postType (and artisanpack/postPreview for query-loop previews where applicable). Attribute schema and supports carried verbatim for parity."
+        },
+        {
+            "fork": "edit.tsx",
+            "upstream": "edit.js",
+            "status": "rewritten",
+            "notes": "Lightweight placeholder edit. Upstream queries the comment entity through @wordpress/core-data, which the post editor does not populate; the fork falls back to the post-family createEntityPlaceholderEdit (display blocks) or InnerBlocks (wrappers). Front-end markup is produced server-side from stamped _resolved* attributes."
+        },
+        {
+            "fork": "save.tsx",
+            "upstream": "n/a",
+            "status": "added",
+            "notes": "Dynamic block (or InnerBlocks delegate for wrappers) — markup produced server-side."
+        },
+        {
+            "fork": "transforms.ts",
+            "upstream": "transforms.js",
+            "status": "rewritten",
+            "notes": "Bidirectional core/post-comments-title ↔ artisanpack/post-comments-title block transforms for the rollout window. Wrapper variants thread innerBlocks through createBlock so the nested tree survives a namespace round-trip."
+        },
+        {
+            "fork": "inserter-icon.tsx",
+            "upstream": "n/a",
+            "status": "added",
+            "notes": "Inline SVG inserter icon (editor lacks dashicons.css)."
+        },
+        {
+            "fork": "index.ts",
+            "upstream": "index.js",
+            "status": "rewritten",
+            "notes": "Adapted to the visual-editor auto-discovery contract."
+        }
+    ],
+    "vendoredPrimitives": [],
+    "knownDivergences": [
+        "edit.tsx is a lightweight placeholder rather than upstream's entity-querying edit — the core-data shim does not expose comment-related entities to the post editor.",
+        "Server-rendered: front-end markup produced by Blade/React/Vue renderers from stamped _resolved* attributes, not by save().",
+        "transforms.ts adds bidirectional block transforms that do not exist upstream — required to coexist with core/post-comments-title during the V1 rollout."
+    ],
+    "triage": {
+        "label": "in-sync",
+        "lastReviewed": "2026-06-02",
+        "reviewer": "Comments family fork (#519) Pass 2"
+    }
+}

--- a/src/Resources/CommentInliner.php
+++ b/src/Resources/CommentInliner.php
@@ -1,0 +1,351 @@
+<?php
+
+/**
+ * CommentInliner — pre-pass that expands every `artisanpack/comments`
+ * block in a saved tree by cloning its inner `artisanpack/comment-template`
+ * once per comment on the surrounding post and stamping each iteration's
+ * `comment-*` leaves via {@see CommentResolver}.
+ *
+ * Sibling to {@see QueryInliner}: the inliner runs once on the way into
+ * the renderer, so the per-block partials / components do not need any
+ * new walk-over-comments logic.
+ *
+ * Resolution is best-effort and mirrors QueryInliner's contract:
+ *
+ *  - When no `$post` context is supplied (the caller is rendering a
+ *    surface that doesn't have a single post in scope — an archive
+ *    page, the site editor, etc.), `artisanpack/comments` blocks are
+ *    left in place with a `_resolutionError = 'no-post-context'`
+ *    marker. The renderers translate that to an empty render so the
+ *    surrounding layout is unaffected.
+ *  - When the post does not expose a `comments` relation (or it's
+ *    empty), the block is collapsed to its non-template children
+ *    (typically the post-comments-form / count / title cluster) so a
+ *    "Be the first to comment" surface still renders.
+ *  - When the inner blocks contain no `artisanpack/comment-template`,
+ *    the block is returned untouched — host themes that ship a custom
+ *    inner layout aren't regressed by the pre-pass.
+ *
+ * Nested inside `artisanpack/query`: the inliner walks the
+ * already-expanded query iterations and uses each iteration's
+ * stamped post id to resolve the right comment set per iteration.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      2.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Resources;
+
+class CommentInliner
+{
+	public const ERROR_NO_POST_CONTEXT = 'no-post-context';
+
+	public function __construct(
+		protected CommentResolver $commentResolver,
+	) {}
+
+	/**
+	 * Walks `$tree` and returns a copy with every
+	 * `artisanpack/comments` block carrying expanded
+	 * `artisanpack/comment-template` instances under `innerBlocks`.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param  array<int, array<string, mixed>>  $tree
+	 * @param  object|null                       $post  Post in scope (provides the `comments` relation).
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	public function inline( array $tree, ?object $post = null ): array
+	{
+		$out = [];
+
+		foreach ( $tree as $block ) {
+			if ( ! is_array( $block ) ) {
+				continue;
+			}
+
+			$out[] = $this->inlineBlock( $block, $post );
+		}
+
+		return $out;
+	}
+
+	/**
+	 * @param  array<string, mixed>  $block
+	 *
+	 * @return array<string, mixed>
+	 */
+	protected function inlineBlock( array $block, ?object $post ): array
+	{
+		$name = isset( $block['name'] ) && is_string( $block['name'] ) ? $block['name'] : '';
+
+		if ( 'artisanpack/comments' === $name || 'core/comments' === $name ) {
+			return $this->expandComments( $block, $post );
+		}
+
+		// Recurse into inner blocks so a `comments` block nested
+		// inside a `post-template-item` iteration (e.g. a post archive
+		// preview) still expands against its surrounding iteration's
+		// post. The caller passes the parent context down; the
+		// iteration's `_resolvedPostId` does not currently re-thread
+		// `$post` automatically — that's tracked as a follow-up.
+		if ( isset( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ) {
+			$block['innerBlocks'] = $this->inline( $block['innerBlocks'], $post );
+		}
+
+		return $block;
+	}
+
+	/**
+	 * Expand one `artisanpack/comments` block: clone the inner
+	 * `comment-template` once per `$post->comments` row, stamping each
+	 * iteration via `CommentResolver`. Wraps every iteration in a
+	 * synthetic `artisanpack/comment-template-item` block so the
+	 * outer `<ol>` emits a single list with N `<li>` items, matching
+	 * the upstream Gutenberg shape.
+	 *
+	 * @param  array<string, mixed>  $block
+	 *
+	 * @return array<string, mixed>
+	 */
+	protected function expandComments( array $block, ?object $post ): array
+	{
+		$attributes = isset( $block['attributes'] ) && is_array( $block['attributes'] ) ? $block['attributes'] : [];
+		$inner      = isset( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ? $block['innerBlocks'] : [];
+
+		if ( null === $post ) {
+			return array_merge( $block, [
+				'attributes' => array_merge( $attributes, [
+					'_resolutionError' => self::ERROR_NO_POST_CONTEXT,
+				] ),
+			] );
+		}
+
+		// Stamp the post id onto the wrapper itself so children like
+		// post-comments-form / post-comments-count / post-comments-link
+		// can read it without a separate stamping pass.
+		$postId       = isset( $post->id ) ? (int) $post->id : 0;
+		$commentCount = $this->resolveCommentCount( $post );
+		$commentsUrl  = $this->resolveCommentsUrl( $post );
+
+		$attributes = array_merge( $attributes, [
+			'_resolvedPostId'        => $postId,
+			'_resolvedCommentCount'  => $commentCount,
+			'_resolvedCommentsUrl'   => $commentsUrl,
+			'_resolvedCommentsLabel' => 1 === $commentCount
+				? '1 Comment'
+				: sprintf( '%d Comments', $commentCount ),
+		] );
+
+		$expandedChildren = [];
+
+		foreach ( $inner as $child ) {
+			if ( ! is_array( $child ) ) {
+				continue;
+			}
+
+			$childName = isset( $child['name'] ) && is_string( $child['name'] ) ? $child['name'] : '';
+
+			// The comment-template wrapper is the only thing that gets
+			// per-comment expansion. Everything else
+			// (post-comments-form / count / title / pagination) is
+			// passed through with the post-level _resolved* attrs
+			// merged in — keep its structure but inherit the
+			// wrapper's stamped attributes.
+			if ( 'artisanpack/comment-template' === $childName || 'core/comment-template' === $childName ) {
+				$expandedChildren[] = $this->expandCommentTemplate( $child, $post );
+				continue;
+			}
+
+			$expandedChildren[] = $this->stampPostLevelAttributes( $child, $attributes );
+		}
+
+		return array_merge( $block, [
+			'attributes'  => $attributes,
+			'innerBlocks' => $expandedChildren,
+		] );
+	}
+
+	/**
+	 * @param  array<string, mixed>  $templateBlock
+	 *
+	 * @return array<string, mixed>
+	 */
+	protected function expandCommentTemplate( array $templateBlock, object $post ): array
+	{
+		$templateAttrs    = isset( $templateBlock['attributes'] ) && is_array( $templateBlock['attributes'] ) ? $templateBlock['attributes'] : [];
+		$iterationTemplate = isset( $templateBlock['innerBlocks'] ) && is_array( $templateBlock['innerBlocks'] ) ? $templateBlock['innerBlocks'] : [];
+
+		$comments = $this->readComments( $post );
+
+		// No template children or no comments — emit the empty
+		// wrapper so the surrounding scaffold stays consistent.
+		if ( [] === $iterationTemplate || [] === $comments ) {
+			return array_merge( $templateBlock, [
+				'attributes'  => array_merge( $templateAttrs, [
+					'_resolvedItems' => count( $comments ),
+				] ),
+				'innerBlocks' => [],
+			] );
+		}
+
+		$expandedIterations = [];
+
+		foreach ( $comments as $comment ) {
+			if ( ! is_object( $comment ) ) {
+				continue;
+			}
+
+			$commentId       = isset( $comment->id ) ? (int) $comment->id : 0;
+			$iterationBlocks = [];
+
+			foreach ( $iterationTemplate as $tmplChild ) {
+				if ( ! is_array( $tmplChild ) ) {
+					continue;
+				}
+
+				$iterationBlocks[] = $this->commentResolver->stampBlock(
+					$this->cloneBlock( $tmplChild ),
+					$comment
+				);
+			}
+
+			$expandedIterations[] = [
+				'clientId'    => 'cti-' . $commentId,
+				'name'        => 'artisanpack/comment-template-item',
+				'attributes'  => [
+					'commentId' => $commentId,
+					'className' => 'comment-' . $commentId,
+				],
+				'innerBlocks' => $iterationBlocks,
+			];
+		}
+
+		return array_merge( $templateBlock, [
+			'attributes'  => array_merge( $templateAttrs, [
+				'_resolvedItems' => count( $expandedIterations ),
+			] ),
+			'innerBlocks' => $expandedIterations,
+		] );
+	}
+
+	/**
+	 * Merge the wrapper's `_resolved*` attributes into a non-template
+	 * child block so post-level metadata blocks
+	 * (post-comments-form / count / title / link) can render against
+	 * them without a separate resolver pass.
+	 *
+	 * @param  array<string, mixed>  $block
+	 * @param  array<string, mixed>  $stamped
+	 *
+	 * @return array<string, mixed>
+	 */
+	protected function stampPostLevelAttributes( array $block, array $stamped ): array
+	{
+		$existing = isset( $block['attributes'] ) && is_array( $block['attributes'] ) ? $block['attributes'] : [];
+
+		// Only forward the `_resolved*` keys — host overrides on the
+		// block's own attributes always win.
+		$toMerge = [];
+		foreach ( $stamped as $key => $value ) {
+			if ( is_string( $key ) && str_starts_with( $key, '_resolved' ) && ! isset( $existing[ $key ] ) ) {
+				$toMerge[ $key ] = $value;
+			}
+		}
+
+		return array_merge( $block, [
+			'attributes' => array_merge( $existing, $toMerge ),
+		] );
+	}
+
+	/**
+	 * @return array<int|string, object>
+	 */
+	protected function readComments( object $post ): array
+	{
+		$comments = $post->comments ?? null;
+
+		if ( null === $comments ) {
+			return [];
+		}
+
+		// Eloquent collection, plain array, or anything iterable.
+		if ( is_array( $comments ) ) {
+			return $comments;
+		}
+
+		if ( is_object( $comments ) && method_exists( $comments, 'all' ) ) {
+			$all = $comments->all();
+			return is_array( $all ) ? $all : [];
+		}
+
+		if ( is_iterable( $comments ) ) {
+			return iterator_to_array( $comments );
+		}
+
+		return [];
+	}
+
+	protected function resolveCommentCount( object $post ): int
+	{
+		$raw = $post->comments_count ?? $post->comment_count ?? null;
+
+		if ( is_int( $raw ) || ( is_string( $raw ) && ctype_digit( $raw ) ) ) {
+			return (int) $raw;
+		}
+
+		$comments = $this->readComments( $post );
+
+		return count( $comments );
+	}
+
+	protected function resolveCommentsUrl( object $post ): string
+	{
+		$url = $post->comments_url ?? null;
+
+		if ( is_string( $url ) && '' !== $url ) {
+			return $url;
+		}
+
+		$permalink = $post->permalink ?? null;
+
+		return is_string( $permalink ) && '' !== $permalink ? $permalink . '#comments' : '';
+	}
+
+	/**
+	 * Deep-clone a block subtree so per-iteration stamping never
+	 * mutates the template the next iteration will read from.
+	 *
+	 * @param  array<string, mixed>  $block
+	 *
+	 * @return array<string, mixed>
+	 */
+	protected function cloneBlock( array $block ): array
+	{
+		// PHP arrays are copy-on-write at the top level, so the
+		// assignment below already gives us a fresh array. We still
+		// have to walk into `innerBlocks` so per-iteration stamping
+		// can't reach into the template's nested blocks and mutate
+		// the next iteration's source. Top-level `attributes` is an
+		// array too, so it's also copy-on-write — no explicit clone
+		// needed there.
+		$clone = $block;
+
+		if ( isset( $clone['innerBlocks'] ) && is_array( $clone['innerBlocks'] ) ) {
+			$cloned = [];
+			foreach ( $clone['innerBlocks'] as $child ) {
+				$cloned[] = is_array( $child ) ? $this->cloneBlock( $child ) : $child;
+			}
+			$clone['innerBlocks'] = $cloned;
+		}
+
+		return $clone;
+	}
+}

--- a/src/Resources/CommentInliner.php
+++ b/src/Resources/CommentInliner.php
@@ -139,9 +139,11 @@ class CommentInliner
 			'_resolvedPostId'        => $postId,
 			'_resolvedCommentCount'  => $commentCount,
 			'_resolvedCommentsUrl'   => $commentsUrl,
-			'_resolvedCommentsLabel' => 1 === $commentCount
-				? '1 Comment'
-				: sprintf( '%d Comments', $commentCount ),
+			'_resolvedCommentsLabel' => trans_choice(
+				'{0} :count Comments|{1} :count Comment|[2,*] :count Comments',
+				$commentCount,
+				[ 'count' => $commentCount ]
+			),
 		] );
 
 		$expandedChildren = [];

--- a/src/Resources/CommentResolver.php
+++ b/src/Resources/CommentResolver.php
@@ -176,6 +176,15 @@ class CommentResolver
 	}
 
 	/**
+	 * Safe inline tags retained when sanitizing comment content. Mirrors
+	 * the conservative subset WordPress allows for unauthenticated
+	 * commenters, dropping structural / scripted tags entirely.
+	 *
+	 * @var string
+	 */
+	protected const COMMENT_CONTENT_ALLOWED_TAGS = '<a><abbr><acronym><b><blockquote><br><cite><code><del><em><i><p><q><s><strike><strong>';
+
+	/**
 	 * @return array<string, mixed>
 	 */
 	protected function resolveContent( object $comment ): array
@@ -183,8 +192,31 @@ class CommentResolver
 		$content = $comment->content ?? null;
 
 		return [
-			'_resolvedContent' => is_string( $content ) ? $content : '',
+			'_resolvedContent' => $this->sanitizeCommentContent( is_string( $content ) ? $content : '' ),
 		];
+	}
+
+	/**
+	 * Defensively sanitize comment HTML before it is stamped onto
+	 * `_resolvedContent` and rendered raw by the per-framework templates.
+	 * Comment bodies are user-supplied and the host model layer does not
+	 * filter them, so the resolver strips disallowed tags, inline event
+	 * handlers, and `javascript:` URLs to make the stamped value safe
+	 * against stored XSS regardless of which renderer consumes it.
+	 *
+	 * @since 1.0.0
+	 */
+	protected function sanitizeCommentContent( string $content ): string
+	{
+		if ( '' === $content ) {
+			return '';
+		}
+
+		$content = strip_tags( $content, self::COMMENT_CONTENT_ALLOWED_TAGS );
+		$content = preg_replace( '/\son[a-z]+\s*=\s*(?:"[^"]*"|\'[^\']*\'|[^\s>]+)/i', '', $content ) ?? '';
+		$content = preg_replace( '/(href|src)\s*=\s*(["\']?)\s*javascript:[^"\'\s>]*\2/i', '$1=$2#$2', $content ) ?? '';
+
+		return $content;
 	}
 
 	/**

--- a/src/Resources/PostResolver.php
+++ b/src/Resources/PostResolver.php
@@ -314,9 +314,11 @@ class PostResolver
 		return [
 			'_resolvedCommentCount'   => $count,
 			'_resolvedCommentsUrl'    => $this->commentsUrl( $post ),
-			'_resolvedCommentsLabel'  => 1 === $count
-				? '1 Comment'
-				: sprintf( '%d Comments', $count ),
+			'_resolvedCommentsLabel'  => trans_choice(
+				'{0} :count Comments|{1} :count Comment|[2,*] :count Comments',
+				$count,
+				[ 'count' => $count ]
+			),
 		];
 	}
 
@@ -329,11 +331,11 @@ class PostResolver
 
 		return [
 			'_resolvedCommentCount'   => $count,
-			'_resolvedCommentsTitle'  => 0 === $count
-				? 'No Comments'
-				: ( 1 === $count
-					? '1 Comment'
-					: sprintf( '%d Comments', $count ) ),
+			'_resolvedCommentsTitle'  => trans_choice(
+				'{0} No Comments|{1} 1 Comment|[2,*] :count Comments',
+				$count,
+				[ 'count' => $count ]
+			),
 		];
 	}
 

--- a/src/Resources/PostResolver.php
+++ b/src/Resources/PostResolver.php
@@ -64,6 +64,19 @@ class PostResolver
 		'artisanpack/post-author-name',
 		'artisanpack/post-author-biography',
 		'artisanpack/avatar',
+		// Comments-family forks (#519) Pass 2 — post-level comment metadata.
+		// The per-comment cluster (`comment-*` inside `comment-template`)
+		// resolves through {@see CommentResolver}; these post-level blocks
+		// resolve from the parent post's comment counters / URL the same
+		// way `post-author-*` resolves from `$post->author`.
+		'core/post-comments-count',
+		'core/post-comments-link',
+		'core/post-comments-title',
+		'core/post-comments-form',
+		'artisanpack/post-comments-count',
+		'artisanpack/post-comments-link',
+		'artisanpack/post-comments-title',
+		'artisanpack/post-comments-form',
 	];
 
 	/**
@@ -147,6 +160,10 @@ class PostResolver
 			'post-author-biography',
 			'avatar'                  => $this->resolveAuthor( $post ),
 			'post-featured-image'     => $this->resolveFeaturedImage( $post ),
+			'post-comments-form'      => $this->resolveCommentsForm( $post ),
+			'post-comments-count'     => $this->resolveCommentsCount( $post ),
+			'post-comments-link'      => $this->resolveCommentsLink( $post ),
+			'post-comments-title'     => $this->resolveCommentsTitle( $post ),
 			default                   => [],
 		};
 	}
@@ -258,6 +275,104 @@ class PostResolver
 			'_resolvedImageHeight' => $height,
 			'_resolvedPermalink'   => $this->permalink( $post ),
 		];
+	}
+
+	/**
+	 * Stamp the post's id on a `post-comments-form` block so its
+	 * renderer can emit a hidden `<input name="post_id">` and route
+	 * the submission to the right post. Without this, a standalone
+	 * comments-form (one not nested inside an `artisanpack/comments`
+	 * wrapper) sends an empty `post_id` and the host's form-handler
+	 * rejects on validation.
+	 *
+	 * @return array<string, mixed>
+	 */
+	protected function resolveCommentsForm( object $post ): array
+	{
+		return [
+			'_resolvedPostId' => isset( $post->id ) ? (int) $post->id : 0,
+		];
+	}
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	protected function resolveCommentsCount( object $post ): array
+	{
+		return [
+			'_resolvedCommentCount' => $this->commentCount( $post ),
+		];
+	}
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	protected function resolveCommentsLink( object $post ): array
+	{
+		$count = $this->commentCount( $post );
+
+		return [
+			'_resolvedCommentCount'   => $count,
+			'_resolvedCommentsUrl'    => $this->commentsUrl( $post ),
+			'_resolvedCommentsLabel'  => 1 === $count
+				? '1 Comment'
+				: sprintf( '%d Comments', $count ),
+		];
+	}
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	protected function resolveCommentsTitle( object $post ): array
+	{
+		$count = $this->commentCount( $post );
+
+		return [
+			'_resolvedCommentCount'   => $count,
+			'_resolvedCommentsTitle'  => 0 === $count
+				? 'No Comments'
+				: ( 1 === $count
+					? '1 Comment'
+					: sprintf( '%d Comments', $count ) ),
+		];
+	}
+
+	/**
+	 * Read the comment count from whichever convention the underlying
+	 * model exposes — Eloquent's `comments_count` accessor (when the
+	 * relation has been counted), a `comment_count` column (matches
+	 * WP's posts table), or a counted `comments` collection. Defaults
+	 * to zero so the partials render "0 Comments" rather than a
+	 * placeholder shell.
+	 */
+	protected function commentCount( object $post ): int
+	{
+		$raw = $post->comments_count ?? $post->comment_count ?? null;
+
+		if ( is_int( $raw ) || ( is_string( $raw ) && ctype_digit( $raw ) ) ) {
+			return (int) $raw;
+		}
+
+		$comments = $post->comments ?? null;
+
+		if ( is_countable( $comments ) ) {
+			return count( $comments );
+		}
+
+		return 0;
+	}
+
+	protected function commentsUrl( object $post ): string
+	{
+		$url = $post->comments_url ?? null;
+
+		if ( is_string( $url ) && '' !== $url ) {
+			return $url;
+		}
+
+		$permalink = $this->permalink( $post );
+
+		return '' === $permalink ? '' : $permalink . '#comments';
 	}
 
 	protected function permalink( object $post ): string

--- a/src/VisualEditorServiceProvider.php
+++ b/src/VisualEditorServiceProvider.php
@@ -19,6 +19,8 @@ use ArtisanPackUI\VisualEditor\Registries\BlockTypeRegistry;
 use ArtisanPackUI\VisualEditor\Registries\DynamicBlockRegistry;
 use ArtisanPackUI\VisualEditor\Console\AuditBreakpointsCommand;
 use ArtisanPackUI\VisualEditor\Resources\PostResolver;
+use ArtisanPackUI\VisualEditor\Resources\CommentInliner;
+use ArtisanPackUI\VisualEditor\Resources\CommentResolver;
 use ArtisanPackUI\VisualEditor\Resources\QueryInliner;
 use ArtisanPackUI\VisualEditor\Resources\ResourceResolver;
 use ArtisanPackUI\VisualEditor\Responsive\AttributeMigrator;
@@ -108,6 +110,20 @@ class VisualEditorServiceProvider extends ServiceProvider
 			return new QueryInliner(
 				$app,
 				$app->make( PostResolver::class ),
+			);
+		} );
+
+		// #519 — `CommentResolver` stamps `_resolved*` keys on
+		// `comment-*` blocks; `CommentInliner` orchestrates the
+		// per-comment expansion of `artisanpack/comments` blocks.
+		// Both are stateless so binding as singletons is safe.
+		$this->app->singleton( CommentResolver::class, function () {
+			return new CommentResolver();
+		} );
+
+		$this->app->singleton( CommentInliner::class, function ( $app ) {
+			return new CommentInliner(
+				$app->make( CommentResolver::class ),
 			);
 		} );
 

--- a/tests/Unit/VisualEditor/EnabledBlockNamesTest.php
+++ b/tests/Unit/VisualEditor/EnabledBlockNamesTest.php
@@ -75,6 +75,15 @@ it( 'returns the frozen V1 block allow-list under the default config', function 
 		'artisanpack/comment-date',
 		'artisanpack/comment-edit-link',
 		'artisanpack/comment-reply-link',
+		// Comments family — Pass 2 forks (#519).
+		'artisanpack/post-comments-form',
+		'artisanpack/post-comments-count',
+		'artisanpack/post-comments-link',
+		'artisanpack/post-comments-title',
+		'artisanpack/comments-pagination',
+		'artisanpack/comments-pagination-next',
+		'artisanpack/comments-pagination-numbers',
+		'artisanpack/comments-pagination-previous',
 	] );
 } );
 

--- a/tests/Unit/VisualEditor/Resources/CommentInlinerTest.php
+++ b/tests/Unit/VisualEditor/Resources/CommentInlinerTest.php
@@ -1,0 +1,217 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Resources\CommentInliner;
+use ArtisanPackUI\VisualEditor\Resources\CommentResolver;
+use Illuminate\Support\Carbon;
+
+beforeEach( function (): void {
+	Carbon::setLocale( 'en' );
+} );
+
+function fakeComments( int $count ): array
+{
+	$comments = [];
+	for ( $i = 1; $i <= $count; $i++ ) {
+		$comment             = new stdClass();
+		$comment->id         = $i;
+		$comment->content    = "<p>Comment {$i}</p>";
+		$comment->created_at = Carbon::create( 2026, 4, 20, 12, 0, 0, 'UTC' );
+		$comment->permalink  = "https://example.test/posts/hello#comment-{$i}";
+		$comment->author     = ( object ) [
+			'name'       => "Commenter {$i}",
+			'url'        => "https://example.test/u/{$i}",
+			'avatar_url' => "https://example.test/a/{$i}.jpg",
+		];
+		$comment->edit_link  = "https://example.test/wp-admin/edit-comment.php?id={$i}";
+		$comment->reply_link = "https://example.test/posts/hello?replytocom={$i}";
+
+		$comments[] = $comment;
+	}
+	return $comments;
+}
+
+function fakeCommentablePost( array $overrides = [] ): object
+{
+	$post                 = new stdClass();
+	$post->id             = 1;
+	$post->permalink      = 'https://example.test/posts/hello';
+	$post->comments_count = null;
+	$post->comments_url   = null;
+	$post->comments       = [];
+
+	foreach ( $overrides as $key => $value ) {
+		$post->{$key} = $value;
+	}
+
+	return $post;
+}
+
+function commentsTreeWithTemplate(): array
+{
+	return [
+		[
+			'name'        => 'artisanpack/comments',
+			'attributes'  => [],
+			'innerBlocks' => [
+				[
+					'name'        => 'artisanpack/post-comments-title',
+					'attributes'  => [],
+					'innerBlocks' => [],
+				],
+				[
+					'name'        => 'artisanpack/comment-template',
+					'attributes'  => [],
+					'innerBlocks' => [
+						[ 'name' => 'artisanpack/comment-author-name', 'attributes' => [], 'innerBlocks' => [] ],
+						[ 'name' => 'artisanpack/comment-content',     'attributes' => [], 'innerBlocks' => [] ],
+					],
+				],
+				[
+					'name'        => 'artisanpack/post-comments-form',
+					'attributes'  => [],
+					'innerBlocks' => [],
+				],
+			],
+		],
+	];
+}
+
+it( 'marks the comments block as unresolved when no post is supplied', function () {
+	$inliner = new CommentInliner( new CommentResolver() );
+	$out     = $inliner->inline( commentsTreeWithTemplate() );
+
+	expect( $out[0]['attributes']['_resolutionError'] )
+		->toBe( CommentInliner::ERROR_NO_POST_CONTEXT );
+} );
+
+it( 'stamps post-level _resolved* attributes onto the wrapper', function () {
+	$post = fakeCommentablePost( [
+		'comments_count' => 3,
+		'comments'       => fakeComments( 3 ),
+	] );
+
+	$out = ( new CommentInliner( new CommentResolver() ) )->inline( commentsTreeWithTemplate(), $post );
+
+	$attrs = $out[0]['attributes'];
+	expect( $attrs['_resolvedPostId'] )->toBe( 1 )
+		->and( $attrs['_resolvedCommentCount'] )->toBe( 3 )
+		->and( $attrs['_resolvedCommentsUrl'] )->toBe( 'https://example.test/posts/hello#comments' )
+		->and( $attrs['_resolvedCommentsLabel'] )->toBe( '3 Comments' );
+} );
+
+it( 'clones the comment-template once per comment and stamps each iteration', function () {
+	$post = fakeCommentablePost( [
+		'comments' => fakeComments( 2 ),
+	] );
+
+	$out = ( new CommentInliner( new CommentResolver() ) )->inline( commentsTreeWithTemplate(), $post );
+
+	// Find the comment-template inside the expanded wrapper.
+	$template = null;
+	foreach ( $out[0]['innerBlocks'] as $child ) {
+		if ( 'artisanpack/comment-template' === $child['name'] ) {
+			$template = $child;
+			break;
+		}
+	}
+
+	expect( $template )->not->toBeNull()
+		->and( $template['innerBlocks'] )->toHaveCount( 2 )
+		->and( $template['innerBlocks'][0]['name'] )->toBe( 'artisanpack/comment-template-item' )
+		->and( $template['innerBlocks'][0]['attributes']['commentId'] )->toBe( 1 );
+
+	// Each iteration's author-name leaf must be stamped against its comment.
+	$firstIterationAuthor = $template['innerBlocks'][0]['innerBlocks'][0];
+	expect( $firstIterationAuthor['name'] )->toBe( 'artisanpack/comment-author-name' )
+		->and( $firstIterationAuthor['attributes']['_resolvedAuthorName'] )->toBe( 'Commenter 1' );
+
+	$secondIterationAuthor = $template['innerBlocks'][1]['innerBlocks'][0];
+	expect( $secondIterationAuthor['attributes']['_resolvedAuthorName'] )->toBe( 'Commenter 2' );
+} );
+
+it( 'forwards post-level _resolved* attributes to non-template children', function () {
+	$post = fakeCommentablePost( [
+		'comments_count' => 4,
+		'comments'       => fakeComments( 4 ),
+	] );
+
+	$out = ( new CommentInliner( new CommentResolver() ) )->inline( commentsTreeWithTemplate(), $post );
+
+	// post-comments-form should inherit _resolvedPostId; post-comments-title
+	// should inherit _resolvedCommentCount + _resolvedCommentsLabel.
+	$form  = null;
+	$title = null;
+	foreach ( $out[0]['innerBlocks'] as $child ) {
+		if ( 'artisanpack/post-comments-form' === $child['name'] ) {
+			$form = $child;
+		}
+		if ( 'artisanpack/post-comments-title' === $child['name'] ) {
+			$title = $child;
+		}
+	}
+
+	expect( $form['attributes']['_resolvedPostId'] )->toBe( 1 )
+		->and( $title['attributes']['_resolvedCommentCount'] )->toBe( 4 );
+} );
+
+it( 'collapses the template to empty when the post has no comments', function () {
+	$post = fakeCommentablePost( [
+		'comments' => [],
+	] );
+
+	$out = ( new CommentInliner( new CommentResolver() ) )->inline( commentsTreeWithTemplate(), $post );
+
+	$template = null;
+	foreach ( $out[0]['innerBlocks'] as $child ) {
+		if ( 'artisanpack/comment-template' === $child['name'] ) {
+			$template = $child;
+			break;
+		}
+	}
+
+	expect( $template['innerBlocks'] )->toBeEmpty()
+		->and( $out[0]['attributes']['_resolvedCommentCount'] )->toBe( 0 )
+		->and( $out[0]['attributes']['_resolvedCommentsLabel'] )->toBe( '0 Comments' );
+} );
+
+it( 'does not mutate the original tree on subsequent passes', function () {
+	$tree = commentsTreeWithTemplate();
+	$post = fakeCommentablePost( [
+		'comments' => fakeComments( 2 ),
+	] );
+
+	$inliner = new CommentInliner( new CommentResolver() );
+
+	$first  = $inliner->inline( $tree, $post );
+	$second = $inliner->inline( $tree, $post );
+
+	// The original tree must still have the un-expanded template — the
+	// inliner copies on write rather than mutating shared state.
+	$template = $tree[0]['innerBlocks'][1];
+	expect( $template['name'] )->toBe( 'artisanpack/comment-template' )
+		->and( $template['innerBlocks'] )->toHaveCount( 2 )
+		->and( $template['innerBlocks'][0]['name'] )->toBe( 'artisanpack/comment-author-name' );
+
+	// Both runs share the same input tree and must produce the same
+	// stamped iterations — proves the inliner copies on write
+	// rather than relying on mutated shared state. The author-name
+	// leaf lives under: comments → comment-template →
+	// comment-template-item (synthetic wrapper) → comment-author-name.
+	$firstAuthor  = $first[0]['innerBlocks'][1]['innerBlocks'][0]['innerBlocks'][0]['attributes']['_resolvedAuthorName'] ?? null;
+	$secondAuthor = $second[0]['innerBlocks'][1]['innerBlocks'][0]['innerBlocks'][0]['attributes']['_resolvedAuthorName'] ?? null;
+	expect( $firstAuthor )->toBe( 'Commenter 1' )
+		->and( $secondAuthor )->toBe( 'Commenter 1' );
+	expect( $second[0]['innerBlocks'][1]['innerBlocks'] )->toHaveCount( 2 );
+} );
+
+it( 'iterates iterable comment sources (e.g. Eloquent collections)', function () {
+	$post           = fakeCommentablePost();
+	$post->comments = new ArrayIterator( fakeComments( 2 ) );
+
+	$out = ( new CommentInliner( new CommentResolver() ) )->inline( commentsTreeWithTemplate(), $post );
+
+	$template = $out[0]['innerBlocks'][1];
+	expect( $template['innerBlocks'] )->toHaveCount( 2 );
+} );

--- a/tests/Unit/VisualEditor/Resources/CommentResolverTest.php
+++ b/tests/Unit/VisualEditor/Resources/CommentResolverTest.php
@@ -64,6 +64,31 @@ it( 'stamps comment-content attributes', function () {
 	expect( $resolved['attributes']['_resolvedContent'] )->toBe( '<p>Great post!</p>' );
 } );
 
+it( 'sanitizes comment-content against stored XSS payloads', function () {
+	$resolver = new CommentResolver();
+
+	// Script tags and disallowed structural tags are stripped wholesale.
+	$scripted = $resolver->stampBlock(
+		[ 'name' => 'artisanpack/comment-content', 'attributes' => [], 'innerBlocks' => [] ],
+		fakeComment( [ 'content' => '<p>Hi</p><script>alert(1)</script><iframe src="https://evil"></iframe>' ] )
+	);
+	expect( $scripted['attributes']['_resolvedContent'] )->toBe( '<p>Hi</p>alert(1)' );
+
+	// Inline event handlers on otherwise-safe tags are stripped.
+	$handler = $resolver->stampBlock(
+		[ 'name' => 'artisanpack/comment-content', 'attributes' => [], 'innerBlocks' => [] ],
+		fakeComment( [ 'content' => '<a href="https://example.test" onclick="alert(1)">link</a>' ] )
+	);
+	expect( $handler['attributes']['_resolvedContent'] )->toBe( '<a href="https://example.test">link</a>' );
+
+	// `javascript:` URLs on safe tags are neutralized to a harmless anchor.
+	$jsUrl = $resolver->stampBlock(
+		[ 'name' => 'artisanpack/comment-content', 'attributes' => [], 'innerBlocks' => [] ],
+		fakeComment( [ 'content' => '<a href="javascript:alert(1)">click</a>' ] )
+	);
+	expect( $jsUrl['attributes']['_resolvedContent'] )->toBe( '<a href="#">click</a>' );
+} );
+
 it( 'stamps comment-date attributes', function () {
 	$resolved = ( new CommentResolver() )->stampBlock(
 		[ 'name' => 'core/comment-date', 'attributes' => [], 'innerBlocks' => [] ],

--- a/tests/Unit/VisualEditor/Resources/PostResolverTest.php
+++ b/tests/Unit/VisualEditor/Resources/PostResolverTest.php
@@ -137,3 +137,114 @@ it( 'leaves non-post-context blocks untouched', function () {
 
 	expect( $resolved['attributes'] )->toBe( [ 'content' => 'untouched' ] );
 } );
+
+// Comments-family Pass 2 (#519) — post-level comment metadata.
+
+it( 'stamps post-comments-count from comments_count accessor', function () {
+	$resolved = ( new PostResolver() )->stampBlock(
+		[ 'name' => 'core/post-comments-count', 'attributes' => [], 'innerBlocks' => [] ],
+		fakePost( [ 'comments_count' => 7 ] )
+	);
+
+	expect( $resolved['attributes']['_resolvedCommentCount'] )->toBe( 7 );
+} );
+
+it( 'stamps post-comments-count by counting a comments collection when no accessor is set', function () {
+	$resolved = ( new PostResolver() )->stampBlock(
+		[ 'name' => 'core/post-comments-count', 'attributes' => [], 'innerBlocks' => [] ],
+		fakePost( [
+			'comments_count' => null,
+			'comments'       => [ (object) [], (object) [], (object) [] ],
+		] )
+	);
+
+	expect( $resolved['attributes']['_resolvedCommentCount'] )->toBe( 3 );
+} );
+
+it( 'stamps post-comments-count as zero when no count or collection is exposed', function () {
+	$resolved = ( new PostResolver() )->stampBlock(
+		[ 'name' => 'core/post-comments-count', 'attributes' => [], 'innerBlocks' => [] ],
+		fakePost( [ 'comments_count' => null ] )
+	);
+
+	expect( $resolved['attributes']['_resolvedCommentCount'] )->toBe( 0 );
+} );
+
+it( 'stamps post-comments-link with permalink anchor when no explicit URL is set', function () {
+	$resolved = ( new PostResolver() )->stampBlock(
+		[ 'name' => 'core/post-comments-link', 'attributes' => [], 'innerBlocks' => [] ],
+		fakePost( [ 'comments_count' => 2 ] )
+	);
+
+	expect( $resolved['attributes']['_resolvedCommentCount'] )->toBe( 2 )
+		->and( $resolved['attributes']['_resolvedCommentsUrl'] )->toBe( 'https://example.test/posts/hello#comments' )
+		->and( $resolved['attributes']['_resolvedCommentsLabel'] )->toBe( '2 Comments' );
+} );
+
+it( 'stamps post-comments-link with the explicit comments URL when present', function () {
+	$resolved = ( new PostResolver() )->stampBlock(
+		[ 'name' => 'core/post-comments-link', 'attributes' => [], 'innerBlocks' => [] ],
+		fakePost( [
+			'comments_count' => 1,
+			'comments_url'   => 'https://example.test/explicit-comments',
+		] )
+	);
+
+	expect( $resolved['attributes']['_resolvedCommentsUrl'] )->toBe( 'https://example.test/explicit-comments' )
+		->and( $resolved['attributes']['_resolvedCommentsLabel'] )->toBe( '1 Comment' );
+} );
+
+it( 'stamps post-comments-title with pluralization', function () {
+	$resolver = new PostResolver();
+
+	expect(
+		$resolver->stampBlock(
+			[ 'name' => 'core/post-comments-title', 'attributes' => [], 'innerBlocks' => [] ],
+			fakePost( [ 'comments_count' => 0 ] )
+		)['attributes']['_resolvedCommentsTitle']
+	)->toBe( 'No Comments' )
+		->and(
+			$resolver->stampBlock(
+				[ 'name' => 'core/post-comments-title', 'attributes' => [], 'innerBlocks' => [] ],
+				fakePost( [ 'comments_count' => 1 ] )
+			)['attributes']['_resolvedCommentsTitle']
+		)->toBe( '1 Comment' )
+		->and(
+			$resolver->stampBlock(
+				[ 'name' => 'core/post-comments-title', 'attributes' => [], 'innerBlocks' => [] ],
+				fakePost( [ 'comments_count' => 5 ] )
+			)['attributes']['_resolvedCommentsTitle']
+		)->toBe( '5 Comments' );
+} );
+
+it( 'stamps post-comments-form with the post id so the rendered form posts to the right post', function () {
+	$resolved = ( new PostResolver() )->stampBlock(
+		[ 'name' => 'core/post-comments-form', 'attributes' => [], 'innerBlocks' => [] ],
+		fakePost( [ 'id' => 42 ] )
+	);
+
+	expect( $resolved['attributes']['_resolvedPostId'] )->toBe( 42 );
+
+	// Same for the artisanpack/* fork.
+	$forked = ( new PostResolver() )->stampBlock(
+		[ 'name' => 'artisanpack/post-comments-form', 'attributes' => [], 'innerBlocks' => [] ],
+		fakePost( [ 'id' => 42 ] )
+	);
+
+	expect( $forked['attributes']['_resolvedPostId'] )->toBe( 42 );
+} );
+
+it( 'resolves artisanpack/post-comments-* forks through the same branches as core/*', function () {
+	$resolver = new PostResolver();
+
+	$core      = $resolver->stampBlock(
+		[ 'name' => 'core/post-comments-count', 'attributes' => [], 'innerBlocks' => [] ],
+		fakePost( [ 'comments_count' => 4 ] )
+	);
+	$forked    = $resolver->stampBlock(
+		[ 'name' => 'artisanpack/post-comments-count', 'attributes' => [], 'innerBlocks' => [] ],
+		fakePost( [ 'comments_count' => 4 ] )
+	);
+
+	expect( $forked['attributes'] )->toEqual( $core['attributes'] );
+} );


### PR DESCRIPTION
## Description

Follow-up to #524 (Pass 1 — merged). Lands the remaining 8 comments-family blocks (post-comments-* + comments-pagination cluster), full renderer parity across Blade / React / Vue for all 16 comments-family blocks, the server-side `CommentInliner` that expands `comment-template` per resolved comment, the post-context wiring on `<x-ve-blocks>`, and the editor-side dummy-data UX. Closes #519.

**Closes:** #519

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #519
**Predecessor PR (merged):** #524

## Motivation and Context

Pass 1 (#524) shipped the block manifests + `CommentResolver` for the wrapper + template + 6 per-comment leaves, but the renderers + per-comment loop expansion were deferred. This PR closes the loop so a host theme can drop `artisanpack/comments` into a single-post template and get real comments rendered against `Post::comments`.

Depends on cms-framework 2.1.0 — that release introduced the `Comment` model + `Post::comments` relation + `comments_count` / `comments_url` accessors the resolvers consume. Constraint bumped to `^2.0`.

## Changes Made

### Block forks — 8 × 7 = 56 frontend files

- `post-comments-form` (server-rendered `<form>`; null save)
- `post-comments-count`, `post-comments-link`, `post-comments-title` (per-post display blocks; resolve through `PostResolver` against the post's counters / URL)
- `comments-pagination` (InnerBlocks wrapper; delegating save) + `-next` / `-numbers` / `-previous` (per-page display blocks; render against request-time pagination state)

Pagination cluster matches upstream WP block-library 9.43.0 naming (`artisanpack/comments-pagination*`, no `post-` prefix).

Each block: `block.json` + `edit.tsx` + `save.tsx` + `transforms.ts` + `index.ts` + `inserter-icon.tsx` + `upstream-state.json`.

### CommentInliner

New `src/Resources/CommentInliner.php` — sibling to `QueryInliner`. Walks the saved block tree and, for every `artisanpack/comments` wrapper:
- Clones the inner `comment-template` once per resolved comment, stamping each iteration's leaves via `CommentResolver` (Pass 1).
- Stamps post-level `_resolved*` attrs (`_resolvedPostId`, `_resolvedCommentCount`, `_resolvedCommentsUrl`, `_resolvedCommentsLabel`) on the wrapper, then cascades them to non-template children (`post-comments-form`, count, title, etc.) so a standalone form inside the wrapper gets the right post id.
- Marks the block with `_resolutionError=no-post-context` when no post is supplied so the renderer can paint empty without breaking the surrounding layout.

### Renderer parity — Blade / React / Vue

All 16 comments-family blocks (Pass 1 + Pass 2) now ship with matching renderers across all three engines. `packages/renderer-parity.json` extended; `scripts/verify-renderer-parity.mjs` reports `ok react/vue/blade: all 111 blocks registered`.

- Blade: 16 `.blade.php` partials under `packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/`
- React: 16 components in `packages/visual-editor-renderer-react/src/blocks/artisanpack/commentContext.tsx`, registered in `registerCoreBlocks.ts`
- Vue: 16 render fns in `packages/visual-editor-renderer-vue/src/blocks/artisanpack/commentContext.ts`, registered in `registerCoreBlocks.ts`

### Blade `<x-ve-blocks>` pipeline

`BlocksComponent` now accepts `:post` and, when supplied, runs `CommentInliner` (per-comment expansion) and `PostResolver::stampTree` (top-level post-* and post-comments-* attribute stamping) on the tree before rendering. The post-context-free render path is unchanged.

### PostResolver extensions

Extended `SUPPORTED_BLOCKS` + match branches for `post-comments-form` / `post-comments-count` / `post-comments-link` / `post-comments-title` so standalone (non-wrapped) instances still get their `_resolved*` attrs. `post-comments-form` gets `_resolvedPostId` so the rendered form includes the right hidden `post_id` field.

### post-comments-form — accessibility + extensibility

- `<button type="submit">` → `<input type="submit">` across all three renderers (Blade, React, Vue) for better screen-reader / keyboard behavior
- `name="submit"` deliberately omitted from the input — that attribute shadows the form's `.submit` DOM property and breaks JS that hooks the form
- Form `action` configurable via stamped `_resolvedFormAction` attribute + `comments.form.action` hooks filter — hosts can redirect submissions to a controller returning redirect-back-with-flash instead of the JSON 201 the cms-framework REST endpoint emits
- React + Vue use `useId()` / `getCurrentInstance().uid` for unique label-for / input-id pairings (multiple forms on one page)

### Editor placeholders → realistic dummy data

`createCommentPlaceholderEdit` + `createEntityPlaceholderEdit` gained a `dummyValue` config field. Authors editing a template (with no specific post in scope) now see representative content for every comments-family leaf — "Jane Doe", "October 25, 2024", "5 Comments", a Gravatar mystery-person silhouette, sample comment paragraph, "1 2 3" page numbers — rather than dashed-outline labels. Dummy paints only when neither `_resolved*` nor preview context is available; resolved render is untouched.

`post-comments-form` edit renders a non-interactive form scaffold (every label / input / submit-button state present) so the whole form is styleable in the canvas.

### Dependency

`composer.json`: `artisanpack-ui/cms-framework` bumped from `^1.1` to `^2.0`. The `Comment` model + `Post::comments` relation ship in 2.1.0 (cms-framework #151, released 2026-06-02).

## How Has This Been Tested?

**Testing Environment:**
- macOS Darwin 25.5.0 / PHP 8.4.3 / Node + vitest 2.1.9
- jmwd-keystone-cms (using cms-framework 2.1.0)

**Tests Performed:**

- **PHP**: `835 passed (2304 assertions)` — +14 from this PR (7 CommentInliner + 7 PostResolver post-comments-* + EnabledBlockNames snapshot extension). No regressions.
- **JS**: `1770 passed` — includes the parametrized `comments-family.test.ts` (36 tests, Pass 1) + `post-comments-family.test.ts` (32 tests). No regressions.
- **Renderer parity**: `ok react/vue/blade: all 111 blocks registered`.
- **Manual UI verification** against jmwd-keystone-cms post 1: single-post template renders post title + content + 5 seeded comments via per-comment template expansion; guest form submit auto-approves in `local` env and redirects back with a sticky flash banner; the new comment appears inline. Editor canvas (`/admin/site-editor` → Single Post template) shows realistic dummy data on every comment-family block.
- **Pre-PR CodeRabbit CLI**: 4 passes total. Findings addressed across passes — form unique IDs (React `useId` + Vue `getCurrentInstance().uid`), pagination `aria-current` correctness, label localization (`__()` wrappers), distinct inserter icons (avatar / pencil / calendar / etc.), pagination aria-label localization. **Final pass: 0 findings**.

## Accessibility Tests Run

- [x] Keyboard navigation — form fields, submit input, comment links all keyboard-reachable
- [x] ARIA labels — `aria-label` on pagination nav (translatable), `aria-hidden` on decorative asterisks, `aria-current="page"` only on the actual current page number
- [x] Submit element is `<input type="submit">` (not `<button>`) per WCAG submit-control convention
- [x] `pointer-events: none` on the editor-only form scaffold so canvas authors can't accidentally interact with the dummy form

## Tests Added

- [x] `CommentInlinerTest`: 7 tests
- [x] `PostResolverTest`: +7 tests for post-comments-* branches + `post-comments-form` post-id stamping + artisanpack/* parity
- [x] `post-comments-family.test.ts`: 32 contract tests for the 8 Pass 2 blocks (block.json namespace + textdomain, save shape, bidirectional transforms, wrapper innerBlocks preservation, context wiring)
- [x] `EnabledBlockNamesTest`: snapshot updated for all 16 blocks
- [x] All tests passing

## Documentation

- [x] Inline PHPDoc / JSDoc on every new class, helper, and edit block — including the rationale for security / accessibility / framework-edge decisions (`name="submit"` gotcha, `_resolvedFormAction` filter, `_resolutionError=no-post-context`, etc.)
- [x] `upstream-state.json` provenance written for each new block

## Pre-Submission Checklist

- [x] Followed contributing guidelines (I5 / I6 / Pass 1 fork pattern)
- [x] No other open PRs for #519
- [x] Code passes all tests (835 PHP + 1770 JS, 0 regressions)
- [x] Renderer parity verified (111 / 111)
- [x] Code follows project style guide
- [x] Self-review completed
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Comprehensive "Comments" block family added to the visual editor: comment list, per-comment author/avatar/content/date, edit/reply links, post-level comment form/count/link/title, and pagination (previous/numbers/next).
  * Editor previews improved with realistic placeholder content for comment-related blocks across renderers.

* **Bug Fixes / Security**
  * Comment content is sanitized to neutralize XSS vectors before rendering.

* **Tests**
  * New unit tests covering comment expansion, post metadata resolution, and content sanitization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->