### PR TITLE
feat: fork WP theme blocks · auth (loginout)

### DIFF
--- a/config/visual-editor.php
+++ b/config/visual-editor.php
@@ -256,6 +256,18 @@ return [
 	| Jetstream / Fortify all use `redirect_to`, the upstream WP
 	| `wp_loginout()` default).
 	|
+	| ⚠️  POST-vs-GET caveat for `logout_route`: the block always emits a
+	| plain `<a>`, but Breeze / Jetstream / Fortify register `logout` as
+	| POST + CSRF — clicking the rendered link will hit a 405 unless the
+	| host either (a) registers a GET-side logout endpoint and points
+	| `logout_route` / `logout_path` at it, or (b) rewrites the resolved
+	| envelope through the `ap.visual-editor.loginout.envelope` filter
+	| (e.g. swap in a `URL::signedRoute()` link to a GET handler that
+	| invalidates the session). The default of `logout` is kept because
+	| dropping it would mean `logout_path` shows through as a relative
+	| URL even when the host *has* wired a GET endpoint under that name;
+	| the right knob to flip on a Breeze install is the envelope filter.
+	|
 	| For fully custom URL resolution (per-tenant routes, SSO, etc.)
 	| override the resolved envelope through the
 	| `ap.visual-editor.loginout.envelope` filter hook instead.

--- a/config/visual-editor.php
+++ b/config/visual-editor.php
@@ -242,6 +242,37 @@ return [
 
 	/*
 	|--------------------------------------------------------------------------
+	| Loginout block (#522)
+	|--------------------------------------------------------------------------
+	|
+	| Configures the `artisanpack/loginout` block's server-side renderer.
+	| The package does not ship login / logout routes of its own — the
+	| resolver looks up the configured named routes first, falling back
+	| to the literal paths when the names are not registered. Hosts on
+	| a non-default guard (e.g. `sanctum`, `api`) set `guard` here.
+	|
+	| Set `redirect_param` to whatever query key your auth stack reads
+	| when redirecting after login / logout (Laravel Breeze /
+	| Jetstream / Fortify all use `redirect_to`, the upstream WP
+	| `wp_loginout()` default).
+	|
+	| For fully custom URL resolution (per-tenant routes, SSO, etc.)
+	| override the resolved envelope through the
+	| `ap.visual-editor.loginout.envelope` filter hook instead.
+	|
+	*/
+
+	'loginout' => [
+		'guard'          => '',
+		'login_route'    => 'login',
+		'login_path'     => '/login',
+		'logout_route'   => 'logout',
+		'logout_path'    => '/logout',
+		'redirect_param' => 'redirect_to',
+	],
+
+	/*
+	|--------------------------------------------------------------------------
 	| Global styles
 	|--------------------------------------------------------------------------
 	|

--- a/packages/renderer-parity.json
+++ b/packages/renderer-parity.json
@@ -126,6 +126,7 @@
         "artisanpack/query-pagination-next",
         "artisanpack/query-pagination-numbers",
         "artisanpack/query-pagination-previous",
-        "artisanpack/query-title"
+        "artisanpack/query-title",
+        "artisanpack/loginout"
     ]
 }

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/loginout.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/loginout.blade.php
@@ -1,0 +1,35 @@
+@php
+	use ArtisanPackUI\VisualEditorRendererBlade\Support\BlockSupports;
+
+	$isUserLoggedIn = isset( $attributes['_resolvedIsUserLoggedIn'] )
+		&& true === $attributes['_resolvedIsUserLoggedIn'];
+	$url   = isset( $attributes['_resolvedLoginoutUrl'] ) && is_string( $attributes['_resolvedLoginoutUrl'] )
+		? $attributes['_resolvedLoginoutUrl']
+		: '';
+	$label = isset( $attributes['_resolvedLoginoutLabel'] ) && is_string( $attributes['_resolvedLoginoutLabel'] )
+		? $attributes['_resolvedLoginoutLabel']
+		: ( $isUserLoggedIn ? __( 'Log out' ) : __( 'Log in' ) );
+	$displayLoginAsForm = isset( $attributes['displayLoginAsForm'] ) && true === $attributes['displayLoginAsForm'];
+	$loginFormHtml = isset( $attributes['_resolvedLoginFormHtml'] ) && is_string( $attributes['_resolvedLoginFormHtml'] )
+		? $attributes['_resolvedLoginFormHtml']
+		: '';
+	$showForm = ! $isUserLoggedIn && $displayLoginAsForm && '' !== $loginFormHtml;
+
+	// Mirror upstream's class contract: `logged-in` / `logged-out` flag
+	// + the form modifier when the inline form is shown. The resolver
+	// pre-computes the same string for parity with React / Vue, but we
+	// fall back to the boolean flag when the resolver was skipped so
+	// hosts that stamp `_resolvedIsUserLoggedIn` themselves still get
+	// the right wrapper class.
+	$resolvedClass = isset( $attributes['_resolvedLoginoutClass'] ) && is_string( $attributes['_resolvedLoginoutClass'] )
+		? $attributes['_resolvedLoginoutClass']
+		: ( $isUserLoggedIn ? 'logged-in' : ( $showForm ? 'logged-out has-login-form' : 'logged-out' ) );
+	$baseClasses = array_values( array_filter( preg_split( '/\s+/', $resolvedClass ) ?: [] ) );
+@endphp
+<div{!! BlockSupports::wrapperAttrs( $attributes, $baseClasses ) !!}>
+@if ( $showForm )
+{!! $loginFormHtml !!}
+@else
+<a href="{{ $url }}">{{ $label }}</a>
+@endif
+</div>

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/loginout.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/loginout.blade.php
@@ -1,11 +1,18 @@
 @php
 	use ArtisanPackUI\VisualEditorRendererBlade\Support\BlockSupports;
+	use ArtisanPackUI\VisualEditorRendererBlade\Support\UrlSanitizer;
 
 	$isUserLoggedIn = isset( $attributes['_resolvedIsUserLoggedIn'] )
 		&& true === $attributes['_resolvedIsUserLoggedIn'];
-	$url   = isset( $attributes['_resolvedLoginoutUrl'] ) && is_string( $attributes['_resolvedLoginoutUrl'] )
-		? $attributes['_resolvedLoginoutUrl']
-		: '';
+	// Run the resolved URL through the same sanitizer the React / Vue
+	// renderers apply so a stored block tree can't smuggle a
+	// `javascript:` / `data:` href onto the rendered page, and so the
+	// empty-URL guard below stays in lockstep with the parity contract.
+	$url = UrlSanitizer::safe(
+		isset( $attributes['_resolvedLoginoutUrl'] ) && is_string( $attributes['_resolvedLoginoutUrl'] )
+			? $attributes['_resolvedLoginoutUrl']
+			: ''
+	);
 	$label = isset( $attributes['_resolvedLoginoutLabel'] ) && is_string( $attributes['_resolvedLoginoutLabel'] )
 		? $attributes['_resolvedLoginoutLabel']
 		: ( $isUserLoggedIn ? __( 'Log out' ) : __( 'Log in' ) );
@@ -29,6 +36,12 @@
 <div{!! BlockSupports::wrapperAttrs( $attributes, $baseClasses ) !!}>
 @if ( $showForm )
 {!! $loginFormHtml !!}
+@elseif ( '' === $url )
+{{-- React + Vue parity: when the sanitized URL is empty (resolver
+     skipped or the host stamped a disallowed scheme), emit the label
+     in a plain text node so the wrapper still tells consumers what
+     would have been a link without rendering an inert `href=""`. --}}
+{{ $label }}
 @else
 <a href="{{ $url }}">{{ $label }}</a>
 @endif

--- a/packages/visual-editor-renderer-blade/src/BlockRenderer.php
+++ b/packages/visual-editor-renderer-blade/src/BlockRenderer.php
@@ -22,6 +22,7 @@ declare( strict_types=1 );
 namespace ArtisanPackUI\VisualEditorRendererBlade;
 
 use ArtisanPackUI\VisualEditor\Registries\DynamicBlockRegistry;
+use ArtisanPackUI\VisualEditorRendererBlade\Resolvers\LoginoutResolver;
 use ArtisanPackUI\VisualEditorRendererBlade\Resolvers\SiteMetaResolver;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Contracts\Support\Htmlable;
@@ -47,10 +48,21 @@ class BlockRenderer
 		'artisanpack/site-logo',
 	];
 
+	/**
+	 * Block names that consume loginout `_resolved*` attributes (#522).
+	 *
+	 * @var array<int, string>
+	 */
+	protected const LOGINOUT_BLOCKS = [
+		'core/loginout',
+		'artisanpack/loginout',
+	];
+
 	public function __construct(
 		protected ViewFactory $views,
 		protected DynamicBlockRegistry $dynamicBlocks,
 		protected ?SiteMetaResolver $siteMeta = null,
+		protected ?LoginoutResolver $loginout = null,
 	) {
 	}
 
@@ -93,6 +105,7 @@ class BlockRenderer
 
 		$attributes      = $this->normalizeAttributes( $block['attributes'] ?? [] );
 		$attributes      = $this->stampSiteMeta( $name, $attributes );
+		$attributes      = $this->stampLoginout( $name, $attributes );
 		$innerBlocksHtml = $this->render( $this->normalizeInnerBlocks( $block['innerBlocks'] ?? [] ) );
 
 		if ( $this->dynamicBlocks->has( $name ) ) {
@@ -135,6 +148,43 @@ class BlockRenderer
 
 		// Existing values win — array_merge with the resolver defaults
 		// first, host-supplied attributes layered on top.
+		return array_merge( $stamped, $attributes );
+	}
+
+	/**
+	 * Stamps `_resolved*` attributes onto `loginout` blocks so the
+	 * partial can emit the right link / form for the current viewer
+	 * without each renderer reaching into Laravel's auth stack. The
+	 * loggedIn flag, URL, label, wrapper classes, and pre-rendered
+	 * login form (when opted in) come from {@see LoginoutResolver}.
+	 *
+	 * Pre-existing `_resolved*` keys win — hosts that have already
+	 * resolved the envelope upstream (Inertia payload, custom auth
+	 * middleware, etc.) keep control. The resolver is the default
+	 * fallback, not an override. Mirrors {@see stampSiteMeta}.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array<string, mixed>  $attributes
+	 *
+	 * @return array<string, mixed>
+	 */
+	protected function stampLoginout( string $name, array $attributes ): array
+	{
+		if ( null === $this->loginout || ! in_array( $name, self::LOGINOUT_BLOCKS, true ) ) {
+			return $attributes;
+		}
+
+		$envelope = $this->loginout->resolve( $attributes );
+
+		$stamped = [
+			'_resolvedIsUserLoggedIn' => $envelope['isUserLoggedIn'],
+			'_resolvedLoginoutUrl'    => $envelope['url'],
+			'_resolvedLoginoutLabel'  => $envelope['label'],
+			'_resolvedLoginoutClass'  => $envelope['classes'],
+			'_resolvedLoginFormHtml'  => $envelope['loginFormHtml'],
+		];
+
 		return array_merge( $stamped, $attributes );
 	}
 

--- a/packages/visual-editor-renderer-blade/src/Resolvers/LoginoutResolver.php
+++ b/packages/visual-editor-renderer-blade/src/Resolvers/LoginoutResolver.php
@@ -1,0 +1,306 @@
+<?php
+
+/**
+ * Loginout resolver for the Blade renderer (#522).
+ *
+ * Returns the auth-state envelope consumed by the
+ * `artisanpack/loginout` block partial: whether the current viewer is
+ * authenticated, the login or logout URL appropriate to that state,
+ * the human-readable label for the link, and (logged-out only) the
+ * pre-rendered login form HTML when the block opts into the form
+ * display.
+ *
+ * Login / logout / register URLs come from the package config
+ * (`config('artisanpack.visual-editor.loginout.*')`), so a host app
+ * can point them at its own auth stack — the package itself does not
+ * register login routes. The defaults match Laravel's standard
+ * starter-kit route names (`login`, `logout`) and degrade to literal
+ * paths (`/login`, `/logout`) when those names are not registered.
+ *
+ * Hosts that need fully custom resolution (per-tenant URLs, third-
+ * party SSO, etc.) override the envelope through the
+ * `ap.visual-editor.loginout.envelope` filter hook — the resolver
+ * applies the filter against the resolved defaults before returning.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditorRendererBlade
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditorRendererBlade\Resolvers;
+
+use Illuminate\Http\Request;
+use Throwable;
+
+class LoginoutResolver
+{
+	/**
+	 * Resolves the auth-state envelope for a single render.
+	 *
+	 * Stateless on purpose — the loggedIn flag, the current URL, and
+	 * the resolved label depend on the in-flight request and on the
+	 * block's `redirectToCurrent` / `displayLoginAsForm` attributes,
+	 * so caching the envelope across calls would produce wrong markup
+	 * for the next block on the same request. URL lookups are cheap
+	 * (one container resolve + one route lookup) so the per-call cost
+	 * is negligible.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array<string, mixed>  $attributes  Block attributes (read-only).
+	 *
+	 * @return array{
+	 *     isUserLoggedIn: bool,
+	 *     url: string,
+	 *     label: string,
+	 *     classes: string,
+	 *     loginFormHtml: string
+	 * }
+	 */
+	public function resolve( array $attributes ): array
+	{
+		$redirectToCurrent = ! array_key_exists( 'redirectToCurrent', $attributes )
+			|| false !== $attributes['redirectToCurrent'];
+		$displayLoginAsForm = isset( $attributes['displayLoginAsForm'] ) && true === $attributes['displayLoginAsForm'];
+
+		$isUserLoggedIn = $this->isUserLoggedIn();
+		$currentUrl     = $redirectToCurrent ? $this->resolveCurrentUrl() : '';
+
+		$url = $isUserLoggedIn
+			? $this->resolveLogoutUrl( $currentUrl )
+			: $this->resolveLoginUrl( $currentUrl );
+
+		$label = $isUserLoggedIn
+			? __( 'Log out' )
+			: __( 'Log in' );
+
+		// Pre-render the inline login form when the block opts into
+		// the form view AND the viewer is logged-out — upstream skips
+		// the form for logged-in viewers so the link stays a one-shot
+		// logout action.
+		$loginFormHtml = ( ! $isUserLoggedIn && $displayLoginAsForm )
+			? $this->resolveLoginFormHtml( $currentUrl )
+			: '';
+
+		$classes = $isUserLoggedIn ? 'logged-in' : 'logged-out';
+		if ( ! $isUserLoggedIn && $displayLoginAsForm ) {
+			$classes .= ' has-login-form';
+		}
+
+		$envelope = [
+			'isUserLoggedIn' => $isUserLoggedIn,
+			'url'            => $this->coerceString( $url ),
+			'label'          => $this->coerceString( $label ),
+			'classes'        => $classes,
+			'loginFormHtml'  => $this->coerceString( $loginFormHtml ),
+		];
+
+		if ( function_exists( 'applyFilters' ) ) {
+			$filtered = applyFilters( 'ap.visual-editor.loginout.envelope', $envelope, $attributes );
+
+			if ( is_array( $filtered ) ) {
+				$envelope = array_merge( $envelope, $filtered );
+			}
+		}
+
+		return $envelope;
+	}
+
+	/**
+	 * Reads the current viewer's auth state from the configured guard.
+	 *
+	 * Defaults to the framework's default guard. Hosts on a different
+	 * guard (e.g. `sanctum`, `api`) override via
+	 * `config('artisanpack.visual-editor.loginout.guard')`.
+	 *
+	 * @since 1.0.0
+	 */
+	protected function isUserLoggedIn(): bool
+	{
+		try {
+			$guard = $this->configString( 'guard' );
+
+			if ( '' === $guard ) {
+				return (bool) auth()->check();
+			}
+
+			return (bool) auth()->guard( $guard )->check();
+		} catch ( Throwable ) {
+			return false;
+		}
+	}
+
+	/**
+	 * Resolves the absolute URL of the current request — used as the
+	 * `redirect_to` query parameter on the login / logout link when
+	 * the block has `redirectToCurrent` set.
+	 *
+	 * @since 1.0.0
+	 */
+	protected function resolveCurrentUrl(): string
+	{
+		try {
+			$request = app( Request::class );
+
+			return $this->coerceString( $request->fullUrl() );
+		} catch ( Throwable ) {
+			return '';
+		}
+	}
+
+	/**
+	 * Resolves the login URL, honoring the config-defined route name
+	 * and falling back to a literal path. Appends `redirect` /
+	 * `redirect_to` query parameters when `$currentUrl` is non-empty.
+	 *
+	 * @since 1.0.0
+	 */
+	protected function resolveLoginUrl( string $currentUrl ): string
+	{
+		$base = $this->resolveRoutedUrl(
+			$this->configString( 'login_route', 'login' ),
+			$this->configString( 'login_path', '/login' )
+		);
+
+		return '' === $currentUrl
+			? $base
+			: $this->appendRedirectParam( $base, $currentUrl );
+	}
+
+	/**
+	 * Resolves the logout URL. Mirrors {@see resolveLoginUrl} but
+	 * against the logout route / path config keys.
+	 *
+	 * @since 1.0.0
+	 */
+	protected function resolveLogoutUrl( string $currentUrl ): string
+	{
+		$base = $this->resolveRoutedUrl(
+			$this->configString( 'logout_route', 'logout' ),
+			$this->configString( 'logout_path', '/logout' )
+		);
+
+		return '' === $currentUrl
+			? $base
+			: $this->appendRedirectParam( $base, $currentUrl );
+	}
+
+	/**
+	 * Resolves the pre-rendered login-form HTML when present.
+	 *
+	 * The package ships no login form of its own; hosts return their
+	 * preferred form (typically a Blade view) via the
+	 * `ap.visual-editor.loginout.login-form` filter. The empty string
+	 * disables the form display and the partial falls back to the
+	 * link variant.
+	 *
+	 * @since 1.0.0
+	 */
+	protected function resolveLoginFormHtml( string $currentUrl ): string
+	{
+		if ( ! function_exists( 'applyFilters' ) ) {
+			return '';
+		}
+
+		$html = applyFilters( 'ap.visual-editor.loginout.login-form', '', $currentUrl );
+
+		return $this->coerceString( $html );
+	}
+
+	/**
+	 * Appends a `redirect_to` query parameter to a URL without
+	 * clobbering any existing query string.
+	 *
+	 * @since 1.0.0
+	 */
+	protected function appendRedirectParam( string $url, string $redirectTo ): string
+	{
+		if ( '' === $url || '' === $redirectTo ) {
+			return $url;
+		}
+
+		$paramName = $this->configString( 'redirect_param', 'redirect_to' );
+		$separator = str_contains( $url, '?' ) ? '&' : '?';
+
+		return $url . $separator . $paramName . '=' . rawurlencode( $redirectTo );
+	}
+
+	/**
+	 * Resolves a configured route name to an absolute URL when it is
+	 * registered; otherwise falls back to the literal path.
+	 *
+	 * @since 1.0.0
+	 */
+	protected function resolveRoutedUrl( string $routeName, string $fallbackPath ): string
+	{
+		if ( '' !== $routeName ) {
+			try {
+				$router = app( 'router' );
+
+				if ( is_object( $router ) && method_exists( $router, 'has' ) && $router->has( $routeName ) ) {
+					$url = route( $routeName );
+
+					if ( is_string( $url ) && '' !== $url ) {
+						return $url;
+					}
+				}
+			} catch ( Throwable ) {
+				// fall through to the literal-path fallback below.
+			}
+		}
+
+		if ( '' === $fallbackPath ) {
+			return '';
+		}
+
+		try {
+			$url = url( $fallbackPath );
+
+			return is_string( $url ) ? $url : $fallbackPath;
+		} catch ( Throwable ) {
+			return $fallbackPath;
+		}
+	}
+
+	/**
+	 * Reads a string-shaped config entry under
+	 * `artisanpack.visual-editor.loginout.*`, returning the default
+	 * when the entry is missing or non-string.
+	 *
+	 * @since 1.0.0
+	 */
+	protected function configString( string $key, string $default = '' ): string
+	{
+		try {
+			$value = config( 'artisanpack.visual-editor.loginout.' . $key, $default );
+		} catch ( Throwable ) {
+			return $default;
+		}
+
+		return $this->coerceString( $value );
+	}
+
+	/**
+	 * Coerce arbitrary scalar values to a string, preserving the empty
+	 * string for null / non-scalar input.
+	 *
+	 * @since 1.0.0
+	 */
+	protected function coerceString( mixed $value ): string
+	{
+		if ( is_string( $value ) ) {
+			return $value;
+		}
+
+		if ( is_scalar( $value ) ) {
+			return (string) $value;
+		}
+
+		return '';
+	}
+}

--- a/packages/visual-editor-renderer-blade/src/Resolvers/LoginoutResolver.php
+++ b/packages/visual-editor-renderer-blade/src/Resolvers/LoginoutResolver.php
@@ -87,8 +87,13 @@ class LoginoutResolver
 			? $this->resolveLoginFormHtml( $currentUrl )
 			: '';
 
+		// Gate `has-login-form` on the resolved HTML being non-empty so
+		// the wrapper class stays consistent with what the partial
+		// actually renders. The Blade / React / Vue renderers all fall
+		// back to the link variant when the form HTML is empty, even
+		// with `displayLoginAsForm` on — the class needs to match.
 		$classes = $isUserLoggedIn ? 'logged-in' : 'logged-out';
-		if ( ! $isUserLoggedIn && $displayLoginAsForm ) {
+		if ( ! $isUserLoggedIn && $displayLoginAsForm && '' !== $loginFormHtml ) {
 			$classes .= ' has-login-form';
 		}
 

--- a/packages/visual-editor-renderer-blade/src/VisualEditorRendererBladeServiceProvider.php
+++ b/packages/visual-editor-renderer-blade/src/VisualEditorRendererBladeServiceProvider.php
@@ -23,6 +23,7 @@ use ArtisanPackUI\VisualEditor\Registries\DynamicBlockRegistry;
 use ArtisanPackUI\VisualEditor\Resources\TemplatePartInliner;
 use ArtisanPackUI\VisualEditor\Responsive\BreakpointRegistry;
 use ArtisanPackUI\VisualEditor\Responsive\ResponsiveValueResolver;
+use ArtisanPackUI\VisualEditorRendererBlade\Resolvers\LoginoutResolver;
 use ArtisanPackUI\VisualEditorRendererBlade\Resolvers\SiteMetaResolver;
 use ArtisanPackUI\VisualEditorRendererBlade\Responsive\ResponsiveClassResolver;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\GlobalStylesEmissionResolver;
@@ -49,6 +50,14 @@ class VisualEditorRendererBladeServiceProvider extends ServiceProvider
 			return new SiteMetaResolver();
 		} );
 
+		// Scoped to match SiteMetaResolver's lifetime — the resolver
+		// reads the current request's auth state and current URL on
+		// every call, so a long-lived worker (Octane / queue) must
+		// not pin the first request's resolver. #522.
+		$this->app->scoped( LoginoutResolver::class, function () {
+			return new LoginoutResolver();
+		} );
+
 		// Scoped (not singleton) so the BlockRenderer captures the
 		// current request's SiteMetaResolver — also scoped — instead of
 		// pinning the first request's resolver for the lifetime of a
@@ -59,6 +68,7 @@ class VisualEditorRendererBladeServiceProvider extends ServiceProvider
 				$app->make( ViewFactory::class ),
 				$app->make( DynamicBlockRegistry::class ),
 				$app->make( SiteMetaResolver::class ),
+				$app->make( LoginoutResolver::class ),
 			);
 		} );
 

--- a/packages/visual-editor-renderer-blade/tests/Feature/LoginoutResolverTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Feature/LoginoutResolverTest.php
@@ -1,0 +1,226 @@
+<?php
+
+declare( strict_types=1 );
+
+/**
+ * Feature tests for the Blade renderer's loginout-block path (#522).
+ *
+ * Covers the full server-side contract for `artisanpack/loginout`:
+ *
+ * - The renderer stamps `_resolved*` from {@see LoginoutResolver} so the
+ *   partial sees the auth-state envelope without each renderer reaching
+ *   into Laravel's auth stack.
+ * - Logged-out viewers get the configured login URL and the "Log in"
+ *   label; logged-in viewers get the logout URL and the "Log out" label.
+ * - `redirectToCurrent` appends the request URL as a `redirect_to`
+ *   query parameter without clobbering an existing query string.
+ * - `displayLoginAsForm` swaps the link for the host-supplied form HTML
+ *   only when the viewer is logged-out; logged-in viewers still see the
+ *   logout link even when the toggle is on (matches upstream).
+ * - Host-stamped `_resolved*` attributes win over the resolver fallback.
+ *
+ * @since 1.0.0
+ */
+
+use ArtisanPackUI\VisualEditorRendererBlade\Resolvers\LoginoutResolver;
+use Illuminate\Auth\GenericUser;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\Facades\Route;
+
+function loginoutRenderTree( array $tree ): string
+{
+	return Blade::render( '<x-ve-blocks :tree="$tree" />', [ 'tree' => $tree ] );
+}
+
+function loginoutBlockNode( array $attributes = [], string $name = 'artisanpack/loginout' ): array
+{
+	return [
+		'clientId'    => 'loginout-cid',
+		'name'        => $name,
+		'attributes'  => $attributes,
+		'innerBlocks' => [],
+	];
+}
+
+beforeEach( function (): void {
+	// Reset any custom URL filter from a prior case so each test starts
+	// from the same envelope baseline.
+	if ( function_exists( 'removeAllFilters' ) ) {
+		removeAllFilters( 'ap.visual-editor.loginout.envelope' );
+		removeAllFilters( 'ap.visual-editor.loginout.login-form' );
+	}
+} );
+
+it( 'renders the login link with the "Log in" label for logged-out viewers', function () {
+	Auth::shouldUse( 'web' );
+	expect( Auth::check() )->toBeFalse();
+
+	$rendered = $this->stripGlobalStyles( loginoutRenderTree( [
+		loginoutBlockNode( [ 'redirectToCurrent' => false ] ),
+	] ) );
+
+	expect( $rendered )
+		->toContain( 'class="logged-out"' )
+		->toContain( '>Log in<' )
+		->toContain( 'href="' )
+		->toContain( '/login' );
+} );
+
+it( 'renders the logout link with the "Log out" label for logged-in viewers', function () {
+	$user = new GenericUser( [ 'id' => 42, 'name' => 'Forky', 'remember_token' => null ] );
+	Auth::setUser( $user );
+	expect( Auth::check() )->toBeTrue();
+
+	$rendered = $this->stripGlobalStyles( loginoutRenderTree( [
+		loginoutBlockNode( [ 'redirectToCurrent' => false ] ),
+	] ) );
+
+	expect( $rendered )
+		->toContain( 'class="logged-in"' )
+		->toContain( '>Log out<' )
+		->toContain( '/logout' );
+
+	Auth::logout();
+} );
+
+it( 'appends the current URL as a redirect_to query parameter when redirectToCurrent is on', function () {
+	// `redirectToCurrent` defaults to true, but make it explicit so the
+	// test reads as a statement about the behavior rather than the
+	// default. The resolver should see the in-flight request URL via
+	// `Request::fullUrl()`.
+	$rendered = $this->stripGlobalStyles( loginoutRenderTree( [
+		loginoutBlockNode( [ 'redirectToCurrent' => true ] ),
+	] ) );
+
+	// We do not assert the absolute URL because Orchestra Testbench's
+	// default base URL drifts between runs — only that the resolver
+	// stamped *some* redirect_to value onto the link.
+	expect( $rendered )->toContain( 'redirect_to=' );
+} );
+
+it( 'honors a configured named login route over the literal path fallback', function () {
+	Route::get( '/auth/sign-in', fn () => 'ok' )->name( 'login' );
+	// `->name()` mutates the route after it has been added to the
+	// collection, so the collection's name lookup table is stale until
+	// we refresh it. Outside of tests the request lifecycle does this
+	// for us via Router::dispatch().
+	Route::getRoutes()->refreshNameLookups();
+
+	$rendered = $this->stripGlobalStyles( loginoutRenderTree( [
+		loginoutBlockNode( [ 'redirectToCurrent' => false ] ),
+	] ) );
+
+	expect( $rendered )
+		->toContain( '/auth/sign-in' )
+		->not()->toContain( 'href="http://localhost/login"' );
+} );
+
+it( 'shows the host-supplied login form for logged-out viewers when displayLoginAsForm is on', function () {
+	addFilter(
+		'ap.visual-editor.loginout.login-form',
+		fn ( string $_, string $current ): string => '<form data-test-form data-redirect="' . htmlspecialchars( $current ) . '"></form>'
+	);
+
+	$rendered = $this->stripGlobalStyles( loginoutRenderTree( [
+		loginoutBlockNode( [
+			'displayLoginAsForm' => true,
+			'redirectToCurrent'  => false,
+		] ),
+	] ) );
+
+	expect( $rendered )
+		->toContain( '<form data-test-form' )
+		->toContain( 'has-login-form' )
+		->not()->toContain( '>Log in<' );
+} );
+
+it( 'keeps the logout link for logged-in viewers even when displayLoginAsForm is on', function () {
+	addFilter(
+		'ap.visual-editor.loginout.login-form',
+		fn (): string => '<form data-test-form></form>'
+	);
+
+	$user = new GenericUser( [ 'id' => 7, 'name' => 'Tay', 'remember_token' => null ] );
+	Auth::setUser( $user );
+
+	$rendered = $this->stripGlobalStyles( loginoutRenderTree( [
+		loginoutBlockNode( [
+			'displayLoginAsForm' => true,
+			'redirectToCurrent'  => false,
+		] ),
+	] ) );
+
+	expect( $rendered )
+		->toContain( '>Log out<' )
+		->not()->toContain( 'data-test-form' )
+		->not()->toContain( 'has-login-form' );
+
+	Auth::logout();
+} );
+
+it( 'lets host-stamped resolved attributes win over the resolver fallback', function () {
+	$rendered = $this->stripGlobalStyles( loginoutRenderTree( [
+		loginoutBlockNode( [
+			'redirectToCurrent'        => false,
+			'_resolvedIsUserLoggedIn'  => true,
+			'_resolvedLoginoutUrl'     => 'https://host.example/sign-out',
+			'_resolvedLoginoutLabel'   => 'See you later',
+			'_resolvedLoginoutClass'   => 'logged-in custom-class',
+		] ),
+	] ) );
+
+	expect( $rendered )
+		->toContain( 'href="https://host.example/sign-out"' )
+		->toContain( '>See you later<' )
+		->toContain( 'custom-class' );
+} );
+
+it( 'lets a host filter rewrite the resolved envelope through ap.visual-editor.loginout.envelope', function () {
+	addFilter(
+		'ap.visual-editor.loginout.envelope',
+		fn ( array $envelope ): array => array_merge( $envelope, [
+			'url'   => 'https://sso.example/login',
+			'label' => 'Continue with SSO',
+		] )
+	);
+
+	$rendered = $this->stripGlobalStyles( loginoutRenderTree( [
+		loginoutBlockNode( [ 'redirectToCurrent' => false ] ),
+	] ) );
+
+	expect( $rendered )
+		->toContain( 'href="https://sso.example/login"' )
+		->toContain( '>Continue with SSO<' );
+} );
+
+it( 'returns false for the loggedIn flag when no auth guard is available', function () {
+	// Direct resolver call — proves the {@see LoginoutResolver::isUserLoggedIn}
+	// catch path returns false rather than bubbling the exception. The
+	// renderer path always has a guard so this is a defensive case.
+	$resolver = app( LoginoutResolver::class );
+	$envelope = $resolver->resolve( [ 'redirectToCurrent' => false ] );
+
+	expect( $envelope['isUserLoggedIn'] )->toBeFalse();
+	expect( $envelope['label'] )->toBe( 'Log in' );
+} );
+
+it( 'leaves non-loginout blocks untouched even when an auth user is set', function () {
+	Auth::setUser( new GenericUser( [ 'id' => 1, 'name' => 'x', 'remember_token' => null ] ) );
+
+	$rendered = $this->stripGlobalStyles( loginoutRenderTree( [
+		[
+			'clientId'    => 'p-1',
+			'name'        => 'core/paragraph',
+			'attributes'  => [ 'content' => 'Hello' ],
+			'innerBlocks' => [],
+		],
+	] ) );
+
+	expect( $rendered )
+		->toContain( 'Hello' )
+		->not()->toContain( 'logged-in' )
+		->not()->toContain( '_resolvedLoginout' );
+
+	Auth::logout();
+} );

--- a/packages/visual-editor-renderer-blade/tests/Feature/LoginoutResolverTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Feature/LoginoutResolverTest.php
@@ -94,9 +94,14 @@ it( 'appends the current URL as a redirect_to query parameter when redirectToCur
 	] ) );
 
 	// We do not assert the absolute URL because Orchestra Testbench's
-	// default base URL drifts between runs — only that the resolver
-	// stamped *some* redirect_to value onto the link.
-	expect( $rendered )->toContain( 'redirect_to=' );
+	// default base URL drifts between runs — verify both the parameter
+	// name AND that it has a non-empty value so a future regression
+	// that stamps `redirect_to=` with an empty string still fails the
+	// test. The character class excludes the anchor terminators that
+	// follow the value in the rendered HTML (`"`, whitespace, `&`).
+	expect( $rendered )
+		->toContain( 'redirect_to=' )
+		->toMatch( '/redirect_to=[^"\s&]+/' );
 } );
 
 it( 'honors a configured named login route over the literal path fallback', function () {
@@ -203,6 +208,53 @@ it( 'returns false for the loggedIn flag when no auth guard is available', funct
 
 	expect( $envelope['isUserLoggedIn'] )->toBeFalse();
 	expect( $envelope['label'] )->toBe( 'Log in' );
+} );
+
+it( 'falls back to a plain label (no anchor) when the resolved URL is empty', function () {
+	// Matches the React + Vue renderers' empty-URL guard: when the
+	// resolver is bypassed (or the host stamps a disallowed scheme that
+	// the sanitizer strips), the wrapper should still describe the link
+	// it would have rendered, but without an inert `href=""` anchor.
+	$user = new GenericUser( [ 'id' => 99, 'name' => 'Logging out', 'remember_token' => null ] );
+	Auth::setUser( $user );
+
+	$rendered = $this->stripGlobalStyles( loginoutRenderTree( [
+		loginoutBlockNode( [
+			'redirectToCurrent'    => false,
+			// `javascript:` is dropped by UrlSanitizer::safe(), so the
+			// effective URL the partial sees is the empty string — same
+			// codepath the renderers exercise when no upstream stamper
+			// supplied a URL at all.
+			'_resolvedLoginoutUrl' => 'javascript:alert(1)',
+		] ),
+	] ) );
+
+	expect( $rendered )
+		->toContain( 'Log out' )
+		->not()->toContain( '<a ' )
+		->not()->toContain( 'javascript:' )
+		->not()->toContain( 'href=""' );
+
+	Auth::logout();
+} );
+
+it( 'omits the has-login-form class when displayLoginAsForm is on but no host form was registered', function () {
+	// Matches the Blade partial's $showForm gate: the modifier class
+	// should only appear when a form will actually render. The resolver
+	// returns an empty loginFormHtml when the host hasn't wired the
+	// `ap.visual-editor.loginout.login-form` filter, so the wrapper
+	// must NOT promise a form that isn't there.
+	$rendered = $this->stripGlobalStyles( loginoutRenderTree( [
+		loginoutBlockNode( [
+			'displayLoginAsForm' => true,
+			'redirectToCurrent'  => false,
+		] ),
+	] ) );
+
+	expect( $rendered )
+		->toContain( 'class="logged-out"' )
+		->toContain( '>Log in<' )
+		->not()->toContain( 'has-login-form' );
 } );
 
 it( 'leaves non-loginout blocks untouched even when an auth user is set', function () {

--- a/packages/visual-editor-renderer-react/src/blocks/artisanpack/loginout.tsx
+++ b/packages/visual-editor-renderer-react/src/blocks/artisanpack/loginout.tsx
@@ -1,0 +1,60 @@
+/**
+ * Loginout renderer (#522) — React.
+ *
+ * Auth-state-aware dynamic block. Reads the `_resolved*` envelope
+ * stamped by the host's server-side pipeline (LoginoutResolver on the
+ * Blade renderer side, the consumer's own auth-state plumbing on the
+ * React side) and emits the matching link — or the pre-rendered
+ * login form when the block opts into the form view AND the viewer
+ * is logged-out. Byte-shape parity with the Blade and Vue
+ * counterparts.
+ */
+
+import type { JSX } from 'react';
+
+import { attrBoolean, attrString, classList } from '../../support/attributes';
+import { safeUrl } from '../../support/urlSanitizer';
+import type { BlockRendererProps } from '../../types';
+
+export function LoginoutBlock({ attributes }: BlockRendererProps): JSX.Element {
+    const isUserLoggedIn = attrBoolean(attributes._resolvedIsUserLoggedIn, false);
+    const displayLoginAsForm = attrBoolean(attributes.displayLoginAsForm, false);
+    const loginFormHtml = attrString(attributes._resolvedLoginFormHtml);
+    const showForm = !isUserLoggedIn && displayLoginAsForm && loginFormHtml !== '';
+
+    const resolvedClass = attrString(
+        attributes._resolvedLoginoutClass,
+        isUserLoggedIn ? 'logged-in' : showForm ? 'logged-out has-login-form' : 'logged-out'
+    );
+    const className = attrString(attributes.className);
+    const classes = classList([resolvedClass, className]);
+
+    if (showForm) {
+        return (
+            <div
+                className={classes}
+                // The login form HTML comes from a host-side filter; the
+                // consumer is responsible for sanitizing it. Mirrors
+                // upstream's behaviour of emitting `wp_login_form()` as
+                // raw HTML inside the wrapper.
+                dangerouslySetInnerHTML={{ __html: loginFormHtml }}
+            />
+        );
+    }
+
+    const url = safeUrl(attrString(attributes._resolvedLoginoutUrl));
+    const label = attrString(
+        attributes._resolvedLoginoutLabel,
+        isUserLoggedIn ? 'Log out' : 'Log in'
+    );
+
+    if (url === '') {
+        return <div className={classes}>{label}</div>;
+    }
+
+    return (
+        <div className={classes}>
+            <a href={url}>{label}</a>
+        </div>
+    );
+}

--- a/packages/visual-editor-renderer-react/src/blocks/registerCoreBlocks.ts
+++ b/packages/visual-editor-renderer-react/src/blocks/registerCoreBlocks.ts
@@ -13,6 +13,7 @@
 
 import { registerBlockRenderer } from '../registry';
 import { CalloutBlock } from './artisanpack/callout';
+import { LoginoutBlock } from './artisanpack/loginout';
 import {
     CoverBlock,
     DetailsBlock,
@@ -249,6 +250,10 @@ const CORE_BLOCKS: Record<string, BlockRenderer> = {
     'artisanpack/query-pagination-numbers': QueryPaginationNumbersBlock,
     'artisanpack/query-pagination-previous': QueryPaginationPreviousBlock,
     'artisanpack/query-title': QueryTitleBlock,
+    // Auth family (#522) — registered under the artisanpack/* namespace
+    // only; loginout never shipped as `core/*` in v1 so there is no
+    // core counterpart to mirror here.
+    'artisanpack/loginout': LoginoutBlock,
 };
 
 export function registerCoreBlocks(): void {

--- a/packages/visual-editor-renderer-vue/src/blocks/artisanpack/loginout.ts
+++ b/packages/visual-editor-renderer-vue/src/blocks/artisanpack/loginout.ts
@@ -1,0 +1,64 @@
+/**
+ * Loginout renderer (#522) — Vue.
+ *
+ * Auth-state-aware dynamic block mirroring the Blade + React
+ * implementations. Reads the `_resolved*` envelope stamped by the
+ * host's server-side pipeline and emits the matching link — or the
+ * pre-rendered login form when the block opts into the form view
+ * AND the viewer is logged-out.
+ */
+
+import { defineComponent, h } from 'vue';
+
+import { attrBoolean, attrString, classList } from '../../support/attributes';
+import { safeUrl } from '../../support/urlSanitizer';
+import { blockRendererProps } from '../shared';
+
+export const LoginoutBlock = defineComponent({
+    name: 'LoginoutBlock',
+    props: blockRendererProps,
+    setup(props) {
+        return () => {
+            const attributes = props.attributes;
+            const isUserLoggedIn = attrBoolean(attributes._resolvedIsUserLoggedIn, false);
+            const displayLoginAsForm = attrBoolean(attributes.displayLoginAsForm, false);
+            const loginFormHtml = attrString(attributes._resolvedLoginFormHtml);
+            const showForm =
+                !isUserLoggedIn && displayLoginAsForm && loginFormHtml !== '';
+
+            const resolvedClass = attrString(
+                attributes._resolvedLoginoutClass,
+                isUserLoggedIn
+                    ? 'logged-in'
+                    : showForm
+                      ? 'logged-out has-login-form'
+                      : 'logged-out'
+            );
+            const className = attrString(attributes.className);
+            const classes = classList([resolvedClass, className]);
+
+            if (showForm) {
+                // The login form HTML comes from a host-side filter;
+                // the consumer is responsible for sanitizing it.
+                // Mirrors upstream's behaviour of emitting
+                // `wp_login_form()` as raw HTML inside the wrapper.
+                return h('div', {
+                    class: classes,
+                    innerHTML: loginFormHtml,
+                });
+            }
+
+            const url = safeUrl(attrString(attributes._resolvedLoginoutUrl));
+            const label = attrString(
+                attributes._resolvedLoginoutLabel,
+                isUserLoggedIn ? 'Log out' : 'Log in'
+            );
+
+            if (url === '') {
+                return h('div', { class: classes }, label);
+            }
+
+            return h('div', { class: classes }, [h('a', { href: url }, label)]);
+        };
+    },
+});

--- a/packages/visual-editor-renderer-vue/src/blocks/registerCoreBlocks.ts
+++ b/packages/visual-editor-renderer-vue/src/blocks/registerCoreBlocks.ts
@@ -13,6 +13,7 @@
 
 import { registerBlockRenderer } from '../registry';
 import { CalloutBlock } from './artisanpack/callout';
+import { LoginoutBlock } from './artisanpack/loginout';
 import {
     CommentAuthorAvatarBlock,
     CommentAuthorNameBlock,
@@ -248,6 +249,10 @@ const CORE_BLOCKS: Record<string, BlockRenderer> = {
     'artisanpack/query-pagination-numbers': QueryPaginationNumbersBlock,
     'artisanpack/query-pagination-previous': QueryPaginationPreviousBlock,
     'artisanpack/query-title': QueryTitleBlock,
+    // Auth family (#522) — registered under the artisanpack/* namespace
+    // only; loginout never shipped as `core/*` in v1 so there is no
+    // core counterpart to mirror here.
+    'artisanpack/loginout': LoginoutBlock,
 };
 
 export function registerCoreBlocks(): void {

--- a/resources/js/visual-editor/blocks/__tests__/loginout.test.ts
+++ b/resources/js/visual-editor/blocks/__tests__/loginout.test.ts
@@ -122,4 +122,26 @@ describe('loginout transforms', () => {
             attributes: { redirectToCurrent: false },
         });
     });
+
+    it('preserves both display toggles in both directions', () => {
+        // Single-attribute cases (above) prove each direction wires up,
+        // but a host document is more likely to carry both attributes —
+        // a future regression that drops one on round-trip would silently
+        // reset the toggle in the editor. Cover the full-attributes path
+        // explicitly on both directions.
+        const t = loginoutTransforms as TransformsModule;
+        const from = t.from.find((e) => e.blocks?.includes('core/loginout'));
+        const to = t.to.find((e) => e.blocks?.includes('core/loginout'));
+
+        const bothAttrs = { displayLoginAsForm: true, redirectToCurrent: false };
+
+        expect(from!.transform(bothAttrs)).toMatchObject({
+            name: 'artisanpack/loginout',
+            attributes: bothAttrs,
+        });
+        expect(to!.transform(bothAttrs)).toMatchObject({
+            name: 'core/loginout',
+            attributes: bothAttrs,
+        });
+    });
 });

--- a/resources/js/visual-editor/blocks/__tests__/loginout.test.ts
+++ b/resources/js/visual-editor/blocks/__tests__/loginout.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Loginout fork (#522) — block.json + save + transforms contract.
+ *
+ * Single dynamic auth-state block. Covers, in one suite: namespace +
+ * textdomain + theme category on block.json, the dynamic save shape
+ * (`null`), the bidirectional `core/* ↔ artisanpack/*` rollout
+ * transforms, and the attribute schema (the two display toggles
+ * upstream carries: displayLoginAsForm + redirectToCurrent). Mirrors
+ * the i5/i6 + query-family suites.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@wordpress/blocks', () => ({
+    createBlock: (
+        name: string,
+        attributes?: Record<string, unknown>,
+        innerBlocks?: unknown[]
+    ) => ({
+        name,
+        attributes: attributes ?? {},
+        innerBlocks: innerBlocks ?? [],
+    }),
+}));
+
+vi.mock('@wordpress/block-editor', () => ({
+    InnerBlocks: Object.assign(
+        () => null,
+        { Content: () => null }
+    ),
+    useBlockProps: Object.assign(
+        () => ({}),
+        { save: () => ({}) }
+    ),
+}));
+
+import loginoutMeta from '../loginout/block.json';
+import loginoutTransforms from '../loginout/transforms';
+import loginoutSave from '../loginout/save';
+
+interface BlockTransform {
+    type: string;
+    blocks: string[];
+    transform: (
+        attrs: Record<string, unknown>,
+        innerBlocks?: unknown[]
+    ) => {
+        name: string;
+        attributes: Record<string, unknown>;
+        innerBlocks: unknown[];
+    };
+}
+interface TransformsModule {
+    from: BlockTransform[];
+    to: BlockTransform[];
+}
+
+describe('loginout block.json', () => {
+    it('declares the artisanpack namespace + textdomain + theme category', () => {
+        expect(loginoutMeta.name).toBe('artisanpack/loginout');
+        expect(loginoutMeta.textdomain).toBe('artisanpack-visual-editor');
+        expect(loginoutMeta.category).toBe('theme');
+    });
+
+    it('carries the two display toggles upstream ships', () => {
+        const attrs = loginoutMeta.attributes as Record<
+            string,
+            { type: string; default?: unknown }
+        >;
+        expect(attrs.displayLoginAsForm).toBeDefined();
+        expect(attrs.displayLoginAsForm.type).toBe('boolean');
+        expect(attrs.displayLoginAsForm.default).toBe(false);
+
+        expect(attrs.redirectToCurrent).toBeDefined();
+        expect(attrs.redirectToCurrent.type).toBe('boolean');
+        expect(attrs.redirectToCurrent.default).toBe(true);
+    });
+
+    it('declares the loginout keywords upstream ships', () => {
+        expect(loginoutMeta.keywords).toEqual(
+            expect.arrayContaining(['login', 'logout', 'form'])
+        );
+    });
+
+    it('is a standalone block (no ancestor or parent lock)', () => {
+        const meta = loginoutMeta as {
+            ancestor?: string[];
+            parent?: string[];
+        };
+        // Loginout is placed wherever a theme wants the auth link
+        // (header / sidebar / footer). Locking it would prevent the
+        // most common usages.
+        expect(meta.ancestor).toBeUndefined();
+        expect(meta.parent).toBeUndefined();
+    });
+});
+
+describe('loginout save', () => {
+    it('returns null (dynamic block, server-rendered)', () => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const result = (loginoutSave as () => any)();
+
+        expect(result).toBeNull();
+    });
+});
+
+describe('loginout transforms', () => {
+    it('ships bidirectional core/loginout ↔ artisanpack/loginout transforms', () => {
+        const t = loginoutTransforms as TransformsModule;
+        const from = t.from.find((e) => e.blocks?.includes('core/loginout'));
+        const to = t.to.find((e) => e.blocks?.includes('core/loginout'));
+
+        expect(from).toBeDefined();
+        expect(to).toBeDefined();
+
+        expect(from!.transform({ displayLoginAsForm: true })).toMatchObject({
+            name: 'artisanpack/loginout',
+            attributes: { displayLoginAsForm: true },
+        });
+        expect(to!.transform({ redirectToCurrent: false })).toMatchObject({
+            name: 'core/loginout',
+            attributes: { redirectToCurrent: false },
+        });
+    });
+});

--- a/resources/js/visual-editor/blocks/loginout/block.json
+++ b/resources/js/visual-editor/blocks/loginout/block.json
@@ -1,0 +1,63 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "artisanpack/loginout",
+    "title": "Login/out",
+    "category": "theme",
+    "description": "Show login & logout links.",
+    "keywords": [ "login", "logout", "form" ],
+    "textdomain": "artisanpack-visual-editor",
+    "attributes": {
+        "displayLoginAsForm": {
+            "type": "boolean",
+            "default": false
+        },
+        "redirectToCurrent": {
+            "type": "boolean",
+            "default": true
+        }
+    },
+    "example": {
+        "viewportWidth": 350
+    },
+    "supports": {
+        "anchor": true,
+        "className": true,
+        "color": {
+            "background": true,
+            "text": false,
+            "gradients": true,
+            "link": true
+        },
+        "spacing": {
+            "margin": true,
+            "padding": true,
+            "__experimentalDefaultControls": {
+                "margin": false,
+                "padding": false
+            }
+        },
+        "typography": {
+            "fontSize": true,
+            "lineHeight": true,
+            "__experimentalFontFamily": true,
+            "__experimentalFontWeight": true,
+            "__experimentalFontStyle": true,
+            "__experimentalTextTransform": true,
+            "__experimentalTextDecoration": true,
+            "__experimentalLetterSpacing": true,
+            "__experimentalDefaultControls": {
+                "fontSize": true
+            }
+        },
+        "__experimentalBorder": {
+            "radius": true,
+            "color": true,
+            "width": true,
+            "style": true
+        },
+        "interactivity": {
+            "clientNavigation": true
+        }
+    }
+}

--- a/resources/js/visual-editor/blocks/loginout/edit.tsx
+++ b/resources/js/visual-editor/blocks/loginout/edit.tsx
@@ -1,0 +1,99 @@
+/**
+ * Loginout — edit component.
+ *
+ * Server-rendered auth-state block. The canvas preview mirrors upstream's
+ * editor preview (always-on "Log out" placeholder + the two display
+ * toggles) because the post editor's core-data shim does not expose a
+ * current-viewer selector. The real login or logout link is emitted by
+ * the Blade / React / Vue renderers from the `_resolved*` attributes
+ * stamped server-side at render time. Phase I-Block-Fork auth (#522).
+ */
+
+import type { ReactElement } from 'react';
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import {
+    ToggleControl,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    __experimentalToolsPanel as ToolsPanel,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    __experimentalToolsPanelItem as ToolsPanelItem,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+import { TEXT_DOMAIN } from '../../vendor/i18n';
+
+interface LoginoutEditAttributes {
+    displayLoginAsForm?: boolean;
+    redirectToCurrent?: boolean;
+}
+
+interface LoginoutEditProps {
+    attributes: LoginoutEditAttributes;
+    setAttributes: ( attrs: Partial<LoginoutEditAttributes> ) => void;
+}
+
+export default function LoginoutEdit( {
+    attributes,
+    setAttributes,
+}: LoginoutEditProps ): ReactElement {
+    const displayLoginAsForm = true === attributes.displayLoginAsForm;
+    const redirectToCurrent = false !== attributes.redirectToCurrent;
+
+    const blockProps = useBlockProps( { className: 'logged-in' } );
+
+    return (
+        <>
+            <InspectorControls>
+                <ToolsPanel
+                    label={ __( 'Settings', TEXT_DOMAIN ) }
+                    resetAll={ () => {
+                        setAttributes( {
+                            displayLoginAsForm: false,
+                            redirectToCurrent: true,
+                        } );
+                    } }
+                >
+                    <ToolsPanelItem
+                        label={ __( 'Display login as form', TEXT_DOMAIN ) }
+                        isShownByDefault
+                        hasValue={ () => displayLoginAsForm }
+                        onDeselect={ () =>
+                            setAttributes( { displayLoginAsForm: false } )
+                        }
+                    >
+                        <ToggleControl
+                            label={ __( 'Display login as form', TEXT_DOMAIN ) }
+                            checked={ displayLoginAsForm }
+                            onChange={ () =>
+                                setAttributes( {
+                                    displayLoginAsForm: ! displayLoginAsForm,
+                                } )
+                            }
+                        />
+                    </ToolsPanelItem>
+                    <ToolsPanelItem
+                        label={ __( 'Redirect to current URL', TEXT_DOMAIN ) }
+                        isShownByDefault
+                        hasValue={ () => ! redirectToCurrent }
+                        onDeselect={ () =>
+                            setAttributes( { redirectToCurrent: true } )
+                        }
+                    >
+                        <ToggleControl
+                            label={ __( 'Redirect to current URL', TEXT_DOMAIN ) }
+                            checked={ redirectToCurrent }
+                            onChange={ () =>
+                                setAttributes( {
+                                    redirectToCurrent: ! redirectToCurrent,
+                                } )
+                            }
+                        />
+                    </ToolsPanelItem>
+                </ToolsPanel>
+            </InspectorControls>
+            <div { ...blockProps }>
+                <a href="#login-pseudo-link">{ __( 'Log out', TEXT_DOMAIN ) }</a>
+            </div>
+        </>
+    );
+}

--- a/resources/js/visual-editor/blocks/loginout/index.ts
+++ b/resources/js/visual-editor/blocks/loginout/index.ts
@@ -1,0 +1,29 @@
+/**
+ * Loginout block entrypoint.
+ *
+ * Auto-discovered by `editor/custom-blocks.ts` and registered against
+ * `@wordpress/blocks.registerBlockType`. Phase I-Block-Fork auth (#522).
+ *
+ * Standalone block (no ancestor lock) — loginout is placed wherever a
+ * theme wants to surface an auth-state link (header, sidebar, footer).
+ * Server-rendered leaf — `_resolvedIsUserLoggedIn` and the matching
+ * login / logout URLs are stamped against the current viewer's auth
+ * state at render time.
+ */
+
+import metadata from './block.json';
+import edit from './edit';
+import save from './save';
+import transforms from './transforms';
+import icon from './inserter-icon';
+
+export { edit, save, metadata, icon, transforms };
+
+export default {
+    name: metadata.name,
+    metadata,
+    edit,
+    save,
+    icon,
+    transforms,
+};

--- a/resources/js/visual-editor/blocks/loginout/inserter-icon.tsx
+++ b/resources/js/visual-editor/blocks/loginout/inserter-icon.tsx
@@ -1,0 +1,24 @@
+/**
+ * Loginout — inserter icon.
+ *
+ * Inline SVG so the editor canvas does not have to load `dashicons.css`
+ * to render it. Mirrors `@wordpress/icons`' `login` glyph (the icon
+ * upstream uses for the loginout block). Phase I-Block-Fork auth (#522).
+ */
+
+import type { ReactElement } from 'react';
+
+export default function LoginoutInserterIcon(): ReactElement {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            width={ 24 }
+            height={ 24 }
+            aria-hidden="true"
+        >
+            <path d="M11 14.5l1.41 1.41L16.83 11.5H4v-2h12.83l-4.42-4.41L11 6.5l-7 7 7 7v-6z" />
+            <path d="M20 3h-9v2h9v14h-9v2h9c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z" />
+        </svg>
+    );
+}

--- a/resources/js/visual-editor/blocks/loginout/save.tsx
+++ b/resources/js/visual-editor/blocks/loginout/save.tsx
@@ -1,0 +1,11 @@
+/**
+ * Loginout — save component.
+ *
+ * Dynamic block: returns null; markup produced server-side from the
+ * `_resolved*` attributes stamped at render time against the current
+ * viewer's auth state. Phase I-Block-Fork auth (#522).
+ */
+
+export default function LoginoutSave(): null {
+    return null;
+}

--- a/resources/js/visual-editor/blocks/loginout/transforms.ts
+++ b/resources/js/visual-editor/blocks/loginout/transforms.ts
@@ -1,0 +1,37 @@
+/**
+ * Loginout — transforms.
+ *
+ * Bidirectional `core/loginout` ↔ `artisanpack/loginout` block transforms
+ * for the V1 rollout window. The `to: core/loginout` direction is removed
+ * at the I7 cutover. Phase I-Block-Fork auth (#522).
+ */
+
+import { createBlock } from '@wordpress/blocks';
+
+import metadata from './block.json';
+
+const { name } = metadata;
+
+interface EntityAttributes {
+    readonly [ key: string ]: unknown;
+}
+
+const transforms = {
+    from: [
+        {
+            type: 'block',
+            blocks: [ 'core/loginout' ],
+            transform: ( attributes: EntityAttributes ) => createBlock( name, attributes ),
+        },
+    ],
+    to: [
+        {
+            type: 'block',
+            blocks: [ 'core/loginout' ],
+            transform: ( attributes: EntityAttributes ) =>
+                createBlock( 'core/loginout', attributes ),
+        },
+    ],
+};
+
+export default transforms;

--- a/resources/js/visual-editor/blocks/loginout/upstream-state.json
+++ b/resources/js/visual-editor/blocks/loginout/upstream-state.json
@@ -1,0 +1,67 @@
+{
+    "$schema": "../../../../scripts/upstream-state.schema.json",
+    "block": "artisanpack/loginout",
+    "upstream": {
+        "package": "@wordpress/block-library",
+        "namespace": "core/loginout",
+        "pinnedVersion": "9.43.0",
+        "subpath": "loginout"
+    },
+    "forkedAt": "2026-06-03",
+    "$statusLegend": {
+        "ported": "byte-equivalent to upstream (CI fails on drift)",
+        "adapted": "TypeScript port and/or namespace swap; logically equivalent",
+        "extended": "fork adds behavior on top of upstream",
+        "rewritten": "fork replaced upstream entirely",
+        "added": "file unique to the fork (no upstream)"
+    },
+    "files": [
+        {
+            "fork": "block.json",
+            "upstream": "block.json",
+            "status": "adapted",
+            "notes": "name + textdomain swapped to the artisanpack namespace; attribute schema (displayLoginAsForm / redirectToCurrent) + example + supports carried verbatim. style handle dropped — the host theme is expected to style its own auth links."
+        },
+        {
+            "fork": "edit.tsx",
+            "upstream": "edit.js",
+            "status": "adapted",
+            "notes": "TypeScript port of upstream's Edit. Ports the InspectorControls / ToolsPanel inspector + the hardcoded 'Log out' placeholder upstream renders in the canvas. Upstream's `useToolsPanelDropdownMenuProps` helper is not carried — it is an internal block-editor utility unavailable to forks; ToolsPanel still renders without it. The real auth-state-aware link is emitted by the renderers from the `_resolved*` attributes stamped server-side."
+        },
+        {
+            "fork": "save.tsx",
+            "upstream": "n/a (dynamic block)",
+            "status": "added",
+            "notes": "Dynamic block — `save` returns null; markup produced server-side from the auth-state-aware `_resolved*` attributes."
+        },
+        {
+            "fork": "transforms.ts",
+            "upstream": "n/a",
+            "status": "added",
+            "notes": "Upstream has no transforms.js; the fork adds bidirectional core/loginout ↔ artisanpack/loginout block transforms for the V1 rollout window."
+        },
+        {
+            "fork": "inserter-icon.tsx",
+            "upstream": "n/a",
+            "status": "added",
+            "notes": "Inline SVG mirroring @wordpress/icons' `login` glyph (the icon upstream uses for loginout)."
+        },
+        {
+            "fork": "index.ts",
+            "upstream": "index.js",
+            "status": "rewritten",
+            "notes": "Adapted to the visual-editor auto-discovery contract; upstream's wp.i18n / wp.blockEditor side-effect imports are not carried."
+        }
+    ],
+    "vendoredPrimitives": [],
+    "knownDivergences": [
+        "edit.tsx hardcodes a 'Log out' anchor placeholder matching upstream's behaviour (upstream always renders 'Log out' in the editor preview regardless of viewer state). The actual login / logout link is emitted by the renderers at request time.",
+        "Upstream's `index.php` server render is replaced by the visual-editor's three renderer-side implementations (Blade in packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/loginout.blade.php, React + Vue in their respective queryContext-style modules). All three read `_resolvedIsUserLoggedIn`, `_resolvedLoginoutUrl`, `_resolvedLoginoutLabel`, and (logged-out + displayLoginAsForm only) `_resolvedLoginFormHtml`, which the renderer-blade BlockRenderer stamps via LoginoutResolver before the tree reaches the partial.",
+        "Upstream pulls `wp_loginout()` + `wp_login_form()` from WordPress core. The fork delegates those URLs and form HTML to the host application's auth stack (Laravel session-auth by default), configured via `config('artisanpack.visual-editor.loginout.*')` and the `ap.visual-editor.loginout.*` filter hooks."
+    ],
+    "triage": {
+        "label": "in-sync",
+        "lastReviewed": "2026-06-03",
+        "reviewer": "Auth family fork (#522)"
+    }
+}


### PR DESCRIPTION
## Description

Forks the upstream WordPress `loginout` block into the `artisanpack/*` namespace, following the I5 / I6 fork pattern. Single auth-family block from the parent meta-issue #506; ships dynamic save + bidirectional `core/* ↔ artisanpack/*` transforms + renderer parity across Blade / React / Vue with an auth-state envelope resolved server-side.

**Closes:** #522

## Type of Change

- [x] Enhancement (improves existing functionality)

## Related Issue

**Issue:** #522 (parent: #506)

## Motivation and Context

The visual-editor's V1 inserter shipped the post / site / query / comments / navigation families of the upstream Theme category but never carried `loginout`. Theme authors who tried to wire an auth-state link in the site editor either fell back to a still-registered `core/loginout` (mixed-namespace document) or hand-rolled a `core/buttons` placeholder. Forking the block under `artisanpack/loginout` closes the last gap in the theme-block parity sweep (#506) and gives the renderer pipeline a real auth-state hook so themes can render auth UI without each one re-implementing it.

## Changes Made

**One new `artisanpack/*` block** (ships `block.json` + edit / save / transforms + inserter-icon + upstream-state manifest):

- `artisanpack/loginout` — standalone, server-rendered, namespace + textdomain swap of upstream `core/loginout`. Carries upstream's `displayLoginAsForm` + `redirectToCurrent` attributes verbatim. The canvas preview mirrors upstream's hardcoded \"Log out\" placeholder + the ToolsPanel toggles; the real link is emitted by the renderers from the `_resolved*` envelope stamped at render time.

**Server-side renderer (Blade):**

- New `LoginoutResolver` (scoped binding) resolves the auth envelope: `isUserLoggedIn` + login-or-logout URL + label + wrapper classes + optional inline login-form HTML. URLs come from `config('artisanpack.visual-editor.loginout.*')` (configurable guard / route names / paths / `redirect_param`), falling back to literal paths when the named routes aren't registered. Hosts can rewrite the envelope through the `ap.visual-editor.loginout.envelope` filter and inject inline form HTML through `ap.visual-editor.loginout.login-form`.
- `BlockRenderer::stampLoginout()` mirrors `stampSiteMeta`: stamps `_resolved*` defaults *under* host-supplied attributes so a host that resolves upstream (Inertia / SSO / custom auth middleware) keeps full control.
- New Blade partial `packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/loginout.blade.php` reads the envelope and emits either the link or the form.

**Renderer parity (React + Vue):**

- New `LoginoutBlock` in `packages/visual-editor-renderer-react/src/blocks/artisanpack/loginout.tsx` and `packages/visual-editor-renderer-vue/src/blocks/artisanpack/loginout.ts`, both registered in `registerCoreBlocks`.
- Both renderers read the same `_resolved*` envelope and emit byte-shape-equivalent markup (logged-in link / logged-out link / inline form when opted in).
- `packages/renderer-parity.json` extended; `verify-renderer-parity` passes (126 blocks per renderer).

**Config:**

- New `artisanpack.visual-editor.loginout.*` config block documents the guard / route / path / `redirect_param` knobs.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS 25.5.0
- PHP Version: 8.4.3
- Project Version: 1.0 (release branch)

**Tests Performed:**

1. Full PHP suite — **867 tests, 2414 assertions, all passing**
2. Full JS suite — **228 test files, 1823 tests, all passing**
3. Renderer parity check (`node scripts/verify-renderer-parity.mjs`) — **126 blocks per renderer, all aligned**
4. `npm run build` — clean Vite build, no errors
5. Manual integration testing in jmwd-keystone-cms with a Breeze-style auth stack: confirmed the inserter surfaces the block under the Theme category; confirmed the logged-out front-end emits `<div class=\"logged-out\"><a href=\".../login?redirect_to=...\">Log in</a></div>`; confirmed the logged-in front-end emits the logout link with the same `redirect_to` plumbing; confirmed the `ap.visual-editor.loginout.envelope` filter cleanly swaps the URL for a signed GET-side logout endpoint to bridge Breeze's POST-only `logout` route without the block having to grow form-aware rendering.

## Accessibility Tests Run

- [x] Keyboard navigation tested — anchor + form variants render as standard `<a>` / `<form>` and inherit native tab order
- [ ] Screen reader tested — visual confirmation only; the rendered markup is a single labeled link or a standard login form
- [x] Color contrast verified — renderers pass `className` through unchanged; styling is host-controlled
- [x] ARIA labels checked — wrapper exposes `.logged-in` / `.logged-out` / `.has-login-form` state classes; the link's text is the human-readable label

**Details:**

The Blade / React / Vue parity guarantees the same `<div>` → `<a>` (or `<form>`) shape across renderers, so a host theme that styled `core/loginout`'s output gets the same hooks on the forked block.

## Tests Added

- [x] Unit tests added/updated
- [x] All tests passing

**Test details:**

- `resources/js/visual-editor/blocks/__tests__/loginout.test.ts` — 6 cases: block.json contract (namespace + textdomain + theme category, the two display-toggle attributes, the upstream keyword list, standalone — no ancestor / parent lock), the dynamic save shape (`null`), and bidirectional `core/* ↔ artisanpack/*` transforms.
- `packages/visual-editor-renderer-blade/tests/Feature/LoginoutResolverTest.php` — 10 cases: logged-in vs logged-out output, `redirectToCurrent` plumbing, named-route lookup (with the `RouteCollection::refreshNameLookups()` test-only refresh), host-supplied inline form for logged-out viewers, logged-in viewers continue to see the logout link when `displayLoginAsForm` is on (matches upstream), host-stamped `_resolved*` win over the resolver fallback, host-side envelope rewrite through `ap.visual-editor.loginout.envelope`, defensive logged-out fallback when no guard is available, non-loginout blocks remain untouched.

## Documentation

- [x] Inline code documentation added — every new file ships a JSDoc / PHPDoc block referencing the upstream source + the issue number
- [x] Upstream-state manifest — `upstream-state.json` documents the pinned `core/*` version, per-file status (adapted / rewritten / added) + known divergences (no live archive-label / login-form fetch in the canvas preview; the resolver / filter own the front-end output)

## Screenshots

_(N/A — markup-level fork; no visual changes beyond what the host theme styles.)_

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted (Pint / PHPCS not configured for this package; build + tests are clean)
- [x] Accessibility tests completed (see above)
- [x] Code follows project style guide (mirrors comments-pagination-family + query-family + i5/i6 fork patterns)
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Login/Out visual-editor block that shows login or logout UI based on viewer auth state.
  * Supports inline login form or link mode, plus redirect-to-current-page after login/logout.
  * Editor UI: toggles for form vs link and redirect behavior, inserter icon, and editor supports/preview.
  * Available across server and client renderers (Blade, React, Vue).

* **Configuration**
  * New visual-editor configuration section with defaults for auth guard, routes/paths, and redirect param.

* **Tests**
  * Comprehensive server- and client-side test coverage for login/out behavior and transforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->