### PR TITLE
feat: prefer rendered_content accessor in PostResolver

### DIFF
--- a/src/Http/Resources/Adapters/CmsFramework/WpEntityResource.php
+++ b/src/Http/Resources/Adapters/CmsFramework/WpEntityResource.php
@@ -71,8 +71,15 @@ abstract class WpEntityResource extends JsonResource
 				// matching renderer package. Kept on the envelope so
 				// shim selectors that probe `content.raw` don't see
 				// `undefined`.
-				'raw'    => '',
-				'blocks' => $this->blocks( $model ),
+				'raw'      => '',
+				// `rendered` mirrors the front-end `_resolvedContent`
+				// stamping (#526). Hosts whose model exposes a
+				// `rendered_content` accessor (cms-framework's
+				// HasBlockContent trait provides one) get the rendered
+				// HTML on the editor-preview envelope; everything else
+				// sees an empty string and falls back to the block tree.
+				'rendered' => $this->stringField( $model, 'rendered_content' ),
+				'blocks'   => $this->blocks( $model ),
 			],
 			'status'         => $this->stringField( $model, 'status', 'publish' ),
 			'type'           => $this->type(),

--- a/src/Resources/PostResolver.php
+++ b/src/Resources/PostResolver.php
@@ -200,10 +200,20 @@ class PostResolver
 	 */
 	protected function resolveContent( object $post ): array
 	{
-		// `content` may be a saved block tree (HasBlockContent stores
-		// it as JSON), a pre-rendered HTML string, or null. The block
-		// partial just needs a string; pass HTML through, otherwise
+		// Prefer `$post->rendered_content` when the host model exposes a
+		// rendered-HTML accessor (cms-framework's HasBlockContent trait
+		// provides one). Falls back to `$post->content`, which may be a
+		// saved block tree, a pre-rendered HTML string, or null. The
+		// block partial just needs a string; pass HTML through, otherwise
 		// leave empty so the partial emits its placeholder shell.
+		$rendered = $post->rendered_content ?? null;
+
+		if ( is_string( $rendered ) && '' !== $rendered ) {
+			return [
+				'_resolvedContent' => $rendered,
+			];
+		}
+
 		$content = $post->content ?? null;
 
 		return [

--- a/tests/Unit/VisualEditor/Resources/PostResolverTest.php
+++ b/tests/Unit/VisualEditor/Resources/PostResolverTest.php
@@ -58,6 +58,33 @@ it( 'stamps post-content attributes', function () {
 	expect( $resolved['attributes']['_resolvedContent'] )->toBe( '<p>Body.</p>' );
 } );
 
+it( 'prefers rendered_content over content when the host exposes the accessor', function () {
+	$resolved = ( new PostResolver() )->stampBlock(
+		[ 'name' => 'core/post-content', 'attributes' => [], 'innerBlocks' => [] ],
+		fakePost( [
+			'content'          => [ [ 'name' => 'core/paragraph' ] ],
+			'rendered_content' => '<p>Rendered HTML.</p>',
+		] )
+	);
+
+	expect( $resolved['attributes']['_resolvedContent'] )->toBe( '<p>Rendered HTML.</p>' );
+} );
+
+it( 'falls back to content when rendered_content is missing or empty', function () {
+	$emptyRendered = ( new PostResolver() )->stampBlock(
+		[ 'name' => 'core/post-content', 'attributes' => [], 'innerBlocks' => [] ],
+		fakePost( [ 'rendered_content' => '' ] )
+	);
+
+	$nonStringContent = ( new PostResolver() )->stampBlock(
+		[ 'name' => 'core/post-content', 'attributes' => [], 'innerBlocks' => [] ],
+		fakePost( [ 'content' => [ [ 'name' => 'core/paragraph' ] ] ] )
+	);
+
+	expect( $emptyRendered['attributes']['_resolvedContent'] )->toBe( '<p>Body.</p>' )
+		->and( $nonStringContent['attributes']['_resolvedContent'] )->toBe( '' );
+} );
+
 it( 'stamps post-excerpt attributes', function () {
 	$resolved = ( new PostResolver() )->stampBlock(
 		[ 'name' => 'core/post-excerpt', 'attributes' => [], 'innerBlocks' => [] ],


### PR DESCRIPTION
## Description

`PostResolver::resolveContent()` now prefers `$post->rendered_content` when the host model exposes the accessor (cms-framework's `HasBlockContent` trait provides one as of cms-framework #155 / 2.2), falling back to the existing string-or-empty behavior so hosts that don't define the accessor are unaffected.

`WpEntityResource` adds a matching `content.rendered` key to the editor-preview envelope so the editor canvas surfaces the same rendered HTML the front-end `PostResolver` stamps onto `_resolvedContent`.

**Closes:** #526

## Type of Change

- [x] Enhancement (improves existing functionality)

## Related Issue

**Issue:** #526

## Motivation and Context

Hosts that store `content` as a parsed block tree (the `HasBlockContent` trait does this) were dropping straight to an empty `_resolvedContent` stamp, so `core/post-content` and `artisanpack/post-content` rendered as an empty `<div class="entry-content wp-block-post-content"></div>`. With cms-framework 2.2 shipping a `rendered_content` accessor, `PostResolver` now prefers it so the post body actually appears on the front end without each host wiring its own resolver subclass.

## Changes Made

- `PostResolver::resolveContent()` reads `$post->rendered_content` first; falls back to `$post->content` (string-or-empty) when the accessor isn't defined.
- `WpEntityResource::toArray()` adds `content.rendered` to the editor-preview envelope, sourced from the same `rendered_content` attribute.
- `PostResolverTest` adds two cases: rendered_content preferred when present; fallback path when rendered_content is missing/empty or content is a non-string.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS
- PHP Version: 8.4
- Project Version: visual-editor `release/1.0`

**Tests Performed:**
1. `./vendor/bin/pest` — all 871 tests pass (2 new tests added for the rendered_content branch + fallback).
2. Manual verification in the `jmwd-keystone-cms` dev app (cms-framework 2.2): visited `/blog/storefront-copy-tips`, `/blog/cms-first-business`, and `/blog/redesigned-checkout`; `artisanpack/post-content` now renders the post body HTML from the `rendered_content` accessor.

## Accessibility Tests Run

- [x] N/A — backend-only resolver change; rendered markup unchanged.

## Tests Added

- [x] Unit tests added/updated
- [x] All tests passing

**Test details:** Two new `it(...)` blocks in `tests/Unit/VisualEditor/Resources/PostResolverTest.php` cover the rendered_content-preferred path and the fallback path.

## Documentation

- [x] Inline code documentation added (PHPDoc updated on `resolveContent()` and on the new `content.rendered` envelope key).

## Pre-Submission Checklist

- [x] Code passes all tests
- [x] Self-review completed
- [x] Comments added for complex code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Content responses now include rendered HTML output for improved editor and rendering compatibility when available, with automatic fallback to raw content.

* **Tests**
  * Added unit tests covering content rendering resolution and fallback behavior scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->