### PR TITLE
feat: PostResolver query-fallback for adjacent posts

### DIFF
--- a/config/visual-editor.php
+++ b/config/visual-editor.php
@@ -64,6 +64,36 @@ return [
 
 	/*
 	|--------------------------------------------------------------------------
+	| Resolver
+	|--------------------------------------------------------------------------
+	|
+	| Behaviour knobs for the server-side `_resolved*` stamping pipeline.
+	|
+	| `adjacency.auto_query` controls the generic query-fallback used by
+	| `PostResolver::adjacentPost()` when stamping `post-navigation-link`
+	| blocks (#527). The resolver first tries common accessors
+	| (`previous_post`, `next_post`, etc.) on the host's Post model. When
+	| no accessor is present and this flag is `true`, the resolver issues
+	| an Eloquent query against `published_at` to find the adjacent
+	| published row. Costs one extra query per `post-navigation-link`
+	| render per direction, so hosts whose Post model already exposes
+	| explicit adjacency accessors should leave this off.
+	|
+	| Requirements for the fallback to run:
+	|
+	|   - the Post model exposes `newQuery()` (Eloquent default), AND
+	|   - the post being rendered has a non-empty `published_at` value.
+	|
+	*/
+
+	'resolver' => [
+		'adjacency' => [
+			'auto_query' => false,
+		],
+	],
+
+	/*
+	|--------------------------------------------------------------------------
 	| Block registry filters
 	|--------------------------------------------------------------------------
 	|

--- a/src/Resources/PostResolver.php
+++ b/src/Resources/PostResolver.php
@@ -521,8 +521,10 @@ class PostResolver
 
 	/**
 	 * Resolve the adjacent post for the given direction. Tries the
-	 * commonly-named accessors first; returns null when the model does
-	 * not expose any adjacency.
+	 * commonly-named accessors first; falls back to an Eloquent query
+	 * against `published_at` when the host opts in via
+	 * `artisanpack.visual-editor.resolver.adjacency.auto_query`. Returns
+	 * null when neither path yields a row.
 	 */
 	protected function adjacentPost( object $post, string $direction ): ?object
 	{
@@ -538,7 +540,50 @@ class PostResolver
 			}
 		}
 
-		return null;
+		return $this->queryAdjacentPost( $post, $direction );
+	}
+
+	/**
+	 * Generic safety-net for hosts whose Post model does not expose
+	 * `previous_post` / `next_post` accessors but DOES expose an
+	 * Eloquent query builder and a `published_at` timestamp.
+	 *
+	 * Gated behind `artisanpack.visual-editor.resolver.adjacency.auto_query`
+	 * (default `false`) so hosts opt-in to the extra query per render.
+	 * Returns null when the host has opted out, the model is not Eloquent,
+	 * `published_at` is missing, or no adjacent row is found.
+	 *
+	 * @since 1.0.0
+	 */
+	protected function queryAdjacentPost( object $post, string $direction ): ?object
+	{
+		if ( true !== config( 'artisanpack.visual-editor.resolver.adjacency.auto_query', false ) ) {
+			return null;
+		}
+
+		if ( ! method_exists( $post, 'newQuery' ) ) {
+			return null;
+		}
+
+		$publishedAt = $post->published_at ?? null;
+
+		if ( null === $publishedAt || '' === $publishedAt ) {
+			return null;
+		}
+
+		$isPrevious = 'previous' === $direction;
+
+		try {
+			$query = $post->newQuery()
+				->where( 'published_at', $isPrevious ? '<' : '>', $publishedAt )
+				->orderBy( 'published_at', $isPrevious ? 'desc' : 'asc' );
+
+			$result = $query->first();
+		} catch ( \Throwable ) {
+			return null;
+		}
+
+		return is_object( $result ) ? $result : null;
 	}
 
 	/**

--- a/tests/Unit/VisualEditor/Resources/PostResolverAdjacencyQueryFallbackTest.php
+++ b/tests/Unit/VisualEditor/Resources/PostResolverAdjacencyQueryFallbackTest.php
@@ -1,0 +1,219 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Resources\PostResolver;
+
+/**
+ * #527 — Generic query-fallback for `post-navigation-link` when the host's
+ * Post model exposes neither `previous_post` / `next_post` accessors nor any
+ * of the other named adjacency conventions. Gated behind
+ * `artisanpack.visual-editor.resolver.adjacency.auto_query` so hosts opt in
+ * to the extra query per render.
+ */
+
+/**
+ * Lightweight fake that mimics the surface the fallback inspects on an
+ * Eloquent Post model: a `newQuery()` method and a public `published_at`
+ * property. The returned builder records the where/orderBy/first calls so
+ * the test can both stub the result and assert the query shape.
+ */
+#[AllowDynamicProperties]
+class FakeAdjacencyPost
+{
+	public ?string $published_at = null;
+
+	public ?object $stubResult = null;
+
+	public ?object $lastBuilder = null;
+
+	public function newQuery(): object
+	{
+		$this->lastBuilder = new class( $this->stubResult ) {
+			public string $whereColumn   = '';
+			public string $whereOperator = '';
+			public mixed $whereValue     = null;
+			public string $orderColumn   = '';
+			public string $orderDir      = '';
+
+			public function __construct( private readonly ?object $result )
+			{
+			}
+
+			public function where( string $column, string $operator, mixed $value ): static
+			{
+				$this->whereColumn   = $column;
+				$this->whereOperator = $operator;
+				$this->whereValue    = $value;
+
+				return $this;
+			}
+
+			public function orderBy( string $column, string $direction ): static
+			{
+				$this->orderColumn = $column;
+				$this->orderDir    = $direction;
+
+				return $this;
+			}
+
+			public function first(): ?object
+			{
+				return $this->result;
+			}
+		};
+
+		return $this->lastBuilder;
+	}
+}
+
+it( 'does not run the query fallback when the config flag is off', function (): void {
+	config()->set( 'artisanpack.visual-editor.resolver.adjacency.auto_query', false );
+
+	$post                = new FakeAdjacencyPost();
+	$post->published_at  = '2026-01-15 10:00:00';
+	$post->stubResult    = (object) [
+		'title'     => 'Should not be used',
+		'permalink' => 'https://example.test/should-not-be-used',
+	];
+
+	$resolved = ( new PostResolver() )->stampBlock(
+		[ 'name' => 'artisanpack/post-navigation-link', 'attributes' => [], 'innerBlocks' => [] ],
+		$post
+	);
+
+	expect( $resolved['attributes']['_resolvedPrevUrl'] )->toBe( '' )
+		->and( $resolved['attributes']['_resolvedNextUrl'] )->toBe( '' )
+		->and( $post->lastBuilder )->toBeNull();
+} );
+
+it( 'runs the query fallback for both directions when the config flag is on', function (): void {
+	config()->set( 'artisanpack.visual-editor.resolver.adjacency.auto_query', true );
+
+	$previous = (object) [
+		'title'     => 'Older post',
+		'permalink' => 'https://example.test/posts/older',
+	];
+	$next = (object) [
+		'title'     => 'Newer post',
+		'permalink' => 'https://example.test/posts/newer',
+	];
+
+	// Two separate fakes so each direction's query result is independent.
+	$resolver = new class extends PostResolver {
+		public function exposeAdjacent( object $post, string $direction ): ?object
+		{
+			return $this->adjacentPost( $post, $direction );
+		}
+	};
+
+	$prevHost                 = new FakeAdjacencyPost();
+	$prevHost->published_at   = '2026-01-15 10:00:00';
+	$prevHost->stubResult     = $previous;
+
+	$nextHost                 = new FakeAdjacencyPost();
+	$nextHost->published_at   = '2026-01-15 10:00:00';
+	$nextHost->stubResult     = $next;
+
+	expect( $resolver->exposeAdjacent( $prevHost, 'previous' ) )->toBe( $previous )
+		->and( $prevHost->lastBuilder->whereColumn )->toBe( 'published_at' )
+		->and( $prevHost->lastBuilder->whereOperator )->toBe( '<' )
+		->and( $prevHost->lastBuilder->whereValue )->toBe( '2026-01-15 10:00:00' )
+		->and( $prevHost->lastBuilder->orderColumn )->toBe( 'published_at' )
+		->and( $prevHost->lastBuilder->orderDir )->toBe( 'desc' );
+
+	expect( $resolver->exposeAdjacent( $nextHost, 'next' ) )->toBe( $next )
+		->and( $nextHost->lastBuilder->whereOperator )->toBe( '>' )
+		->and( $nextHost->lastBuilder->orderDir )->toBe( 'asc' );
+} );
+
+it( 'stamps both adjacent links through the query fallback when the flag is on', function (): void {
+	config()->set( 'artisanpack.visual-editor.resolver.adjacency.auto_query', true );
+
+	$post                = new FakeAdjacencyPost();
+	$post->published_at  = '2026-01-15 10:00:00';
+	$post->stubResult    = (object) [
+		'title'     => 'Adjacent post',
+		'permalink' => 'https://example.test/posts/adjacent',
+	];
+
+	$resolved = ( new PostResolver() )->stampBlock(
+		[ 'name' => 'artisanpack/post-navigation-link', 'attributes' => [], 'innerBlocks' => [] ],
+		$post
+	);
+
+	expect( $resolved['attributes']['_resolvedPrevUrl'] )->toBe( 'https://example.test/posts/adjacent' )
+		->and( $resolved['attributes']['_resolvedPrevTitle'] )->toBe( 'Adjacent post' )
+		->and( $resolved['attributes']['_resolvedNextUrl'] )->toBe( 'https://example.test/posts/adjacent' )
+		->and( $resolved['attributes']['_resolvedNextTitle'] )->toBe( 'Adjacent post' );
+} );
+
+it( 'skips the query fallback when the model lacks newQuery()', function (): void {
+	config()->set( 'artisanpack.visual-editor.resolver.adjacency.auto_query', true );
+
+	$post                = new stdClass();
+	$post->published_at  = '2026-01-15 10:00:00';
+
+	$resolved = ( new PostResolver() )->stampBlock(
+		[ 'name' => 'artisanpack/post-navigation-link', 'attributes' => [], 'innerBlocks' => [] ],
+		$post
+	);
+
+	expect( $resolved['attributes']['_resolvedPrevUrl'] )->toBe( '' )
+		->and( $resolved['attributes']['_resolvedNextUrl'] )->toBe( '' );
+} );
+
+it( 'skips the query fallback when published_at is missing', function (): void {
+	config()->set( 'artisanpack.visual-editor.resolver.adjacency.auto_query', true );
+
+	$post = new FakeAdjacencyPost();
+	// published_at intentionally left null.
+
+	$resolved = ( new PostResolver() )->stampBlock(
+		[ 'name' => 'artisanpack/post-navigation-link', 'attributes' => [], 'innerBlocks' => [] ],
+		$post
+	);
+
+	expect( $resolved['attributes']['_resolvedPrevUrl'] )->toBe( '' )
+		->and( $resolved['attributes']['_resolvedNextUrl'] )->toBe( '' )
+		->and( $post->lastBuilder )->toBeNull();
+} );
+
+it( 'prefers the named accessor over the query fallback when both are available', function (): void {
+	config()->set( 'artisanpack.visual-editor.resolver.adjacency.auto_query', true );
+
+	$post                = new FakeAdjacencyPost();
+	$post->published_at  = '2026-01-15 10:00:00';
+	$post->stubResult    = (object) [
+		'title'     => 'Should not win',
+		'permalink' => 'https://example.test/should-not-win',
+	];
+	$post->previous_post = (object) [
+		'title'     => 'Explicit previous',
+		'permalink' => 'https://example.test/posts/explicit-previous',
+	];
+
+	$resolved = ( new PostResolver() )->stampBlock(
+		[ 'name' => 'artisanpack/post-navigation-link', 'attributes' => [], 'innerBlocks' => [] ],
+		$post
+	);
+
+	expect( $resolved['attributes']['_resolvedPrevUrl'] )->toBe( 'https://example.test/posts/explicit-previous' )
+		->and( $resolved['attributes']['_resolvedPrevTitle'] )->toBe( 'Explicit previous' );
+} );
+
+it( 'returns empty stamps when the query fallback finds no adjacent row', function (): void {
+	config()->set( 'artisanpack.visual-editor.resolver.adjacency.auto_query', true );
+
+	$post                = new FakeAdjacencyPost();
+	$post->published_at  = '2026-01-15 10:00:00';
+	$post->stubResult    = null;
+
+	$resolved = ( new PostResolver() )->stampBlock(
+		[ 'name' => 'artisanpack/post-navigation-link', 'attributes' => [], 'innerBlocks' => [] ],
+		$post
+	);
+
+	expect( $resolved['attributes']['_resolvedPrevUrl'] )->toBe( '' )
+		->and( $resolved['attributes']['_resolvedNextUrl'] )->toBe( '' );
+} );


### PR DESCRIPTION
## Description

`PostResolver::adjacentPost()` falls through to an Eloquent query against `published_at` when the host's Post model does not expose a `previous_post` / `next_post` accessor. The fallback is gated behind `artisanpack.visual-editor.resolver.adjacency.auto_query` (default `false`) so hosts opt in to the extra query per render. cms-framework's Post model still wins via its explicit accessors — the new path only kicks in for non-cms-framework hosts and other resource models (e.g. `Page`) that lack adjacency accessors.

**Closes:** #527

## Type of Change

- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds new functionality)
- [x] Enhancement (improves existing functionality)
- [ ] Refactoring (code improvement, no behavior change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Security fix
- [ ] Breaking change (breaks backward compatibility)

## Related Issue

**Issue:** #527

## Motivation and Context

`post-navigation-link` blocks rendered against a host model with no `previous_post` / `next_post` accessors previously fell through to empty stamps and emitted an empty `<div class="wp-block-post-navigation-link"></div>`. cms-framework's Post will expose the accessors once cms-framework#154 ships, but hosts on a different stack (or older cms-framework versions) need a safety-net so the block can resolve adjacency without forcing every host to wire its own accessor.

## Changes Made

- `src/Resources/PostResolver.php` — refactored `adjacentPost()` to fall through to a new `queryAdjacentPost()` helper when no accessor is present. The helper gates on the config flag, checks `method_exists($post, 'newQuery')` and a non-empty `published_at`, then issues `where('published_at', </>, value)->orderBy(...)->first()`. Wrapped in `try / catch \Throwable` so DB hiccups degrade to empty stamps instead of 500s.
- `config/visual-editor.php` — new `resolver.adjacency.auto_query` block (default `false`) with full docblock explaining the cost and the requirements.
- `tests/Unit/VisualEditor/Resources/PostResolverAdjacencyQueryFallbackTest.php` — 7 new tests covering: opt-out (default), opt-in for both directions, query shape (`where` operator + `orderBy` direction), missing `newQuery()`, missing `published_at`, accessor-wins-over-fallback, and null query result.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS 25.5.0 (Darwin)
- Browser (if applicable): n/a — backend resolver change
- PHP Version: 8.4.3
- Project Version: visual-editor `release/1.0`

**Tests Performed:**
1. `./vendor/bin/pest tests/Unit/VisualEditor/Resources/PostResolverAdjacencyQueryFallbackTest.php` — 7 new tests pass (25 assertions).
2. `./vendor/bin/pest tests/Unit/VisualEditor/Resources/` — full resolver suite: 90 passing (239 assertions), 0 regressions.
3. End-to-end manual test against `jmwd-keystone-cms`:
   - Enabled the flag in keystone's published config and cleared the config cache.
   - Stamped an `artisanpack/post-navigation-link` block against `Page` #7 (no adjacency accessors on the model). Resolver correctly returned prev → "Home" and next → "Test Layout Blocks".
   - Verified cms-framework's `Post` model still wins via its accessor path (fallback dormant by design).

## Accessibility Tests Run

- [ ] Keyboard navigation tested
- [ ] Screen reader tested
- [ ] Color contrast verified
- [ ] ARIA labels checked

**Details:** N/A — server-side resolver change with no UI surface.

## Tests Added

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All tests passing

**Test details:** 7 new unit tests in `tests/Unit/VisualEditor/Resources/PostResolverAdjacencyQueryFallbackTest.php`. Uses a lightweight fake (`FakeAdjacencyPost`) that satisfies the `newQuery()` / `published_at` surface so the test asserts the exact `where` operator and `orderBy` direction for each branch without touching a real Eloquent connection.

## Documentation

- [x] Inline code documentation added
- [ ] README updated
- [ ] Wiki updated
- [ ] API documentation updated

**Documentation details:** Resolver method has a docblock explaining the config gate, requirements, and degradation behavior. `config/visual-editor.php` carries a top-block comment with the same explanation so hosts publishing the config see the contract without reading the source.

## Screenshots

N/A — server-side change.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted (CodeRabbit CLI pre-PR pass — 0 findings)
- [ ] Accessibility tests completed
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

## Follow-up

- #532 — separate UX gap surfaced during manual testing: `post-navigation-link`'s React `edit` component lacks an `InspectorControls` toggle for `previous`/`next` direction. Independent of this PR's resolver-side change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional automatic adjacency resolution for post navigation blocks. When enabled, the system can now find adjacent posts based on publication date when manual accessor methods are unavailable. This feature is disabled by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->