### PR TITLE
feat: post-navigation-link InspectorControls direction toggle (#532)

### DIFF
--- a/resources/js/visual-editor/blocks/post-navigation-link/__tests__/edit.test.tsx
+++ b/resources/js/visual-editor/blocks/post-navigation-link/__tests__/edit.test.tsx
@@ -27,104 +27,112 @@ vi.mock( '@wordpress/block-editor', () => ( {
     } ),
 } ) );
 
-vi.mock( '@wordpress/components', () => ( {
-    PanelBody: ( { children }: { children?: React.ReactNode } ) => (
-        <div data-testid="panel">{ children }</div>
-    ),
-    SelectControl: ( {
-        label,
-        value,
-        options,
-        onChange,
-    }: {
-        label?: string;
-        value?: string;
-        options?: ReadonlyArray<{ label: string; value: string }>;
-        onChange?: ( value: string ) => void;
-    } ) => (
-        <select
-            data-testid="arrow-select"
-            aria-label={ label }
-            value={ value }
-            onChange={ ( event ) => onChange?.( event.target.value ) }
-        >
-            { ( options ?? [] ).map( ( option ) => (
-                <option key={ option.value } value={ option.value }>
-                    { option.label }
-                </option>
-            ) ) }
-        </select>
-    ),
-    ToggleControl: ( {
-        label,
-        checked,
-        onChange,
-    }: {
-        label?: string;
-        checked?: boolean;
-        onChange?: ( value: boolean ) => void;
-    } ) => (
-        <input
-            type="checkbox"
-            data-testid="show-title-toggle"
-            aria-label={ label }
-            checked={ Boolean( checked ) }
-            onChange={ ( event ) => onChange?.( event.target.checked ) }
-        />
-    ),
-    __experimentalToggleGroupControl: ( {
-        label,
-        value,
-        onChange,
-        children,
-    }: {
-        label?: string;
-        value?: string;
-        onChange?: ( value: string | number ) => void;
-        children?: React.ReactNode;
-    } ) => {
-        const React = require( 'react' );
+vi.mock( '@wordpress/components', () => {
+    // `vi.mock` factories are hoisted above the file's imports, so we
+    // can't pull React in via the top-level `import React from 'react'`
+    // line — `require()` is the supported escape hatch for getting
+    // React inside a hoisted factory. Lifting it to mock scope keeps
+    // the call once-per-mount instead of once-per-render.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const React = require( 'react' );
 
-        // Wire each child option through `onChange` so clicking an
-        // option exercises the real `setAttributes` write path. The
-        // production `ToggleGroupControl` does the same plumbing through
-        // a context; cloneElement is a lighter equivalent for the mock.
-        const wired = React.Children.map(
+    return {
+        PanelBody: ( { children }: { children?: React.ReactNode } ) => (
+            <div data-testid="panel">{ children }</div>
+        ),
+        SelectControl: ( {
+            label,
+            value,
+            options,
+            onChange,
+        }: {
+            label?: string;
+            value?: string;
+            options?: ReadonlyArray<{ label: string; value: string }>;
+            onChange?: ( value: string ) => void;
+        } ) => (
+            <select
+                data-testid="arrow-select"
+                aria-label={ label }
+                value={ value }
+                onChange={ ( event ) => onChange?.( event.target.value ) }
+            >
+                { ( options ?? [] ).map( ( option ) => (
+                    <option key={ option.value } value={ option.value }>
+                        { option.label }
+                    </option>
+                ) ) }
+            </select>
+        ),
+        ToggleControl: ( {
+            label,
+            checked,
+            onChange,
+        }: {
+            label?: string;
+            checked?: boolean;
+            onChange?: ( value: boolean ) => void;
+        } ) => (
+            <input
+                type="checkbox"
+                data-testid="show-title-toggle"
+                aria-label={ label }
+                checked={ Boolean( checked ) }
+                onChange={ ( event ) => onChange?.( event.target.checked ) }
+            />
+        ),
+        __experimentalToggleGroupControl: ( {
+            label,
+            value,
+            onChange,
             children,
-            ( child: React.ReactNode ) =>
-                React.isValidElement( child )
-                    ? React.cloneElement( child, { onChange } )
-                    : child,
-        );
+        }: {
+            label?: string;
+            value?: string;
+            onChange?: ( value: string | number ) => void;
+            children?: React.ReactNode;
+        } ) => {
+            // Wire each child option through `onChange` so clicking an
+            // option exercises the real `setAttributes` write path. The
+            // production `ToggleGroupControl` does the same plumbing through
+            // a context; cloneElement is a lighter equivalent for the mock.
+            const wired = React.Children.map(
+                children,
+                ( child: React.ReactNode ) =>
+                    React.isValidElement( child )
+                        ? React.cloneElement( child, { onChange } )
+                        : child,
+            );
 
-        return (
-            <div data-testid="direction-toggle-group" data-value={ value } aria-label={ label }>
-                { wired }
-            </div>
-        );
-    },
-    __experimentalToggleGroupControlOption: ( {
-        value,
-        label,
-        onChange,
-    }: {
-        value?: string;
-        label?: string;
-        onChange?: ( value: string | number ) => void;
-    } ) => (
-        <button
-            data-testid={ `direction-${ value }` }
-            type="button"
-            onClick={ () => {
-                if ( value !== undefined ) {
-                    onChange?.( value );
-                }
-            } }
-        >
-            { label }
-        </button>
-    ),
-} ) );
+            return (
+                <div data-testid="direction-toggle-group" data-value={ value } aria-label={ label }>
+                    { wired }
+                </div>
+            );
+        },
+        __experimentalToggleGroupControlOption: ( {
+            value,
+            label,
+            onChange,
+        }: {
+            value?: string;
+            label?: string;
+            onChange?: ( value: string | number ) => void;
+        } ) => (
+            <button
+                data-testid={ `direction-${ value }` }
+                type="button"
+                onClick={ () => {
+                    if ( value !== undefined ) {
+                        onChange?.( value );
+                    }
+                } }
+            >
+                { label }
+            </button>
+        ),
+    };
+} );
 
 // Stub the shared placeholder edit factory so the suite focuses on the
 // InspectorControls wiring this test owns. The real factory pulls in

--- a/resources/js/visual-editor/blocks/post-navigation-link/__tests__/edit.test.tsx
+++ b/resources/js/visual-editor/blocks/post-navigation-link/__tests__/edit.test.tsx
@@ -1,0 +1,299 @@
+/**
+ * Tests for the `artisanpack/post-navigation-link` edit component.
+ *
+ * Covers the InspectorControls wiring added in #532: the Direction
+ * ToggleGroupControl reflects `attributes.type`, the showTitle
+ * ToggleControl reflects `attributes.showTitle`, and the Arrow
+ * SelectControl reflects `attributes.arrow`. Each control routes
+ * its onChange through `setAttributes` so the canvas preview
+ * (already reactive on `attributes.type` / `attributes.arrow`)
+ * follows the toggle without dropping into HTML edit mode.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+
+vi.mock( '@wordpress/i18n', () => ( {
+    __: ( text: string ) => text,
+} ) );
+
+vi.mock( '@wordpress/block-editor', () => ( {
+    InspectorControls: ( { children }: { children?: React.ReactNode } ) => (
+        <div data-testid="inspector">{ children }</div>
+    ),
+    useBlockProps: ( props?: Record<string, unknown> ) => ( {
+        ...props,
+        'data-testid': 'empty-wrapper',
+    } ),
+} ) );
+
+vi.mock( '@wordpress/components', () => ( {
+    PanelBody: ( { children }: { children?: React.ReactNode } ) => (
+        <div data-testid="panel">{ children }</div>
+    ),
+    SelectControl: ( {
+        label,
+        value,
+        options,
+        onChange,
+    }: {
+        label?: string;
+        value?: string;
+        options?: ReadonlyArray<{ label: string; value: string }>;
+        onChange?: ( value: string ) => void;
+    } ) => (
+        <select
+            data-testid="arrow-select"
+            aria-label={ label }
+            value={ value }
+            onChange={ ( event ) => onChange?.( event.target.value ) }
+        >
+            { ( options ?? [] ).map( ( option ) => (
+                <option key={ option.value } value={ option.value }>
+                    { option.label }
+                </option>
+            ) ) }
+        </select>
+    ),
+    ToggleControl: ( {
+        label,
+        checked,
+        onChange,
+    }: {
+        label?: string;
+        checked?: boolean;
+        onChange?: ( value: boolean ) => void;
+    } ) => (
+        <input
+            type="checkbox"
+            data-testid="show-title-toggle"
+            aria-label={ label }
+            checked={ Boolean( checked ) }
+            onChange={ ( event ) => onChange?.( event.target.checked ) }
+        />
+    ),
+    __experimentalToggleGroupControl: ( {
+        label,
+        value,
+        children,
+    }: {
+        label?: string;
+        value?: string;
+        children?: React.ReactNode;
+    } ) => (
+        <div data-testid="direction-toggle-group" data-value={ value } aria-label={ label }>
+            { children }
+        </div>
+    ),
+    __experimentalToggleGroupControlOption: ( {
+        value,
+        label,
+    }: {
+        value?: string;
+        label?: string;
+    } ) => (
+        <button data-testid={ `direction-${ value }` } type="button">
+            { label }
+        </button>
+    ),
+} ) );
+
+// Stub the shared placeholder edit factory so the suite focuses on the
+// InspectorControls wiring this test owns. The real factory pulls in
+// the core-data shim and the live-entity hooks, which are out of scope
+// for the toggle assertions below.
+vi.mock( '../../_shared/entity-placeholder-edit', () => ( {
+    createEntityPlaceholderEdit: () => ( props: { attributes?: Record<string, unknown> } ) => (
+        <div
+            data-testid="placeholder-preview"
+            data-resolved={ String( props.attributes?._resolvedAdjacentTitle ?? '' ) }
+        />
+    ),
+    PREVIEW_CONTEXT_KEY: 'artisanpack/postPreview',
+} ) );
+
+( globalThis as { React?: unknown } ).React = require( 'react' );
+
+import PostNavigationLinkEdit from '../edit';
+
+describe( 'PostNavigationLinkEdit InspectorControls', () => {
+    it( 'mounts the InspectorControls panel when setAttributes is provided', () => {
+        const { getByTestId } = render(
+            <PostNavigationLinkEdit attributes={ {} } setAttributes={ vi.fn() } />,
+        );
+
+        expect( getByTestId( 'inspector' ) ).toBeTruthy();
+        expect( getByTestId( 'panel' ) ).toBeTruthy();
+        expect( getByTestId( 'direction-toggle-group' ) ).toBeTruthy();
+    } );
+
+    it( 'omits the InspectorControls panel when setAttributes is not provided', () => {
+        const { queryByTestId } = render(
+            <PostNavigationLinkEdit attributes={ {} } />,
+        );
+
+        expect( queryByTestId( 'inspector' ) ).toBeNull();
+    } );
+
+    it( 'reflects the current `type` attribute on the Direction toggle group', () => {
+        const { getByTestId, rerender } = render(
+            <PostNavigationLinkEdit
+                attributes={ { type: 'previous' } }
+                setAttributes={ vi.fn() }
+            />,
+        );
+
+        expect(
+            getByTestId( 'direction-toggle-group' ).getAttribute( 'data-value' ),
+        ).toBe( 'previous' );
+
+        rerender(
+            <PostNavigationLinkEdit attributes={ { type: 'next' } } setAttributes={ vi.fn() } />,
+        );
+
+        expect(
+            getByTestId( 'direction-toggle-group' ).getAttribute( 'data-value' ),
+        ).toBe( 'next' );
+    } );
+
+    it( 'defaults the Direction toggle to "next" when `type` is unset or unknown', () => {
+        const { getByTestId, rerender } = render(
+            <PostNavigationLinkEdit attributes={ {} } setAttributes={ vi.fn() } />,
+        );
+
+        expect(
+            getByTestId( 'direction-toggle-group' ).getAttribute( 'data-value' ),
+        ).toBe( 'next' );
+
+        rerender(
+            <PostNavigationLinkEdit
+                attributes={ { type: 'sideways' } }
+                setAttributes={ vi.fn() }
+            />,
+        );
+
+        expect(
+            getByTestId( 'direction-toggle-group' ).getAttribute( 'data-value' ),
+        ).toBe( 'next' );
+    } );
+
+    it( 'routes the showTitle toggle through setAttributes', () => {
+        const setAttributes = vi.fn();
+        const { getByTestId } = render(
+            <PostNavigationLinkEdit
+                attributes={ { showTitle: false } }
+                setAttributes={ setAttributes }
+            />,
+        );
+
+        const toggle = getByTestId( 'show-title-toggle' ) as HTMLInputElement;
+        expect( toggle.checked ).toBe( false );
+
+        fireEvent.click( toggle );
+
+        expect( setAttributes ).toHaveBeenCalledWith( { showTitle: true } );
+    } );
+
+    it( 'routes the Arrow select through setAttributes', () => {
+        const setAttributes = vi.fn();
+        const { getByTestId } = render(
+            <PostNavigationLinkEdit
+                attributes={ { arrow: 'none' } }
+                setAttributes={ setAttributes }
+            />,
+        );
+
+        const select = getByTestId( 'arrow-select' ) as HTMLSelectElement;
+        expect( select.value ).toBe( 'none' );
+
+        fireEvent.change( select, { target: { value: 'chevron' } } );
+
+        expect( setAttributes ).toHaveBeenCalledWith( { arrow: 'chevron' } );
+    } );
+
+    it( 'decorates the placeholder preview with the configured arrow glyph in each direction', () => {
+        const { getByTestId, rerender } = render(
+            <PostNavigationLinkEdit
+                attributes={ {
+                    type: 'next',
+                    arrow: 'arrow',
+                    _resolvedNextTitle: 'Newer release',
+                } }
+                setAttributes={ vi.fn() }
+            />,
+        );
+
+        expect(
+            getByTestId( 'placeholder-preview' ).getAttribute( 'data-resolved' ),
+        ).toBe( 'Newer release →' );
+
+        rerender(
+            <PostNavigationLinkEdit
+                attributes={ {
+                    type: 'previous',
+                    arrow: 'chevron',
+                    _resolvedPrevTitle: 'Older release',
+                } }
+                setAttributes={ vi.fn() }
+            />,
+        );
+
+        expect(
+            getByTestId( 'placeholder-preview' ).getAttribute( 'data-resolved' ),
+        ).toBe( '« Older release' );
+    } );
+
+    it( 'renders an empty block wrapper (no placeholder text) when no adjacent post and no label resolve', () => {
+        const { getByTestId, queryByTestId } = render(
+            <PostNavigationLinkEdit
+                attributes={ { type: 'next', arrow: 'arrow' } }
+                setAttributes={ vi.fn() }
+            />,
+        );
+
+        expect( queryByTestId( 'placeholder-preview' ) ).toBeNull();
+        const wrapper = getByTestId( 'empty-wrapper' );
+        expect( wrapper.tagName ).toBe( 'DIV' );
+        expect( wrapper.textContent ).toBe( '' );
+    } );
+
+    it( 'still renders the InspectorControls panel when the empty-wrapper branch is taken', () => {
+        const { getByTestId } = render(
+            <PostNavigationLinkEdit attributes={ {} } setAttributes={ vi.fn() } />,
+        );
+
+        expect( getByTestId( 'inspector' ) ).toBeTruthy();
+        expect( getByTestId( 'empty-wrapper' ) ).toBeTruthy();
+    } );
+
+    it( 'falls back to the custom `label` attribute when no adjacent post is resolved', () => {
+        const { getByTestId } = render(
+            <PostNavigationLinkEdit
+                attributes={ { type: 'previous', arrow: 'arrow', label: 'Older articles' } }
+                setAttributes={ vi.fn() }
+            />,
+        );
+
+        expect(
+            getByTestId( 'placeholder-preview' ).getAttribute( 'data-resolved' ),
+        ).toBe( '← Older articles' );
+    } );
+
+    it( 'prefers query-preview adjacent title over the custom label when both are present', () => {
+        const { getByTestId } = render(
+            <PostNavigationLinkEdit
+                attributes={ { type: 'next', arrow: 'none', label: 'Older articles' } }
+                context={ {
+                    'artisanpack/postPreview': {
+                        adjacent: { next: { title: 'Adjacent title', url: '/x' } },
+                    },
+                } }
+                setAttributes={ vi.fn() }
+            />,
+        );
+
+        expect(
+            getByTestId( 'placeholder-preview' ).getAttribute( 'data-resolved' ),
+        ).toBe( 'Adjacent title' );
+    } );
+} );

--- a/resources/js/visual-editor/blocks/post-navigation-link/__tests__/edit.test.tsx
+++ b/resources/js/visual-editor/blocks/post-navigation-link/__tests__/edit.test.tsx
@@ -75,24 +75,52 @@ vi.mock( '@wordpress/components', () => ( {
     __experimentalToggleGroupControl: ( {
         label,
         value,
+        onChange,
         children,
     }: {
         label?: string;
         value?: string;
+        onChange?: ( value: string | number ) => void;
         children?: React.ReactNode;
-    } ) => (
-        <div data-testid="direction-toggle-group" data-value={ value } aria-label={ label }>
-            { children }
-        </div>
-    ),
+    } ) => {
+        const React = require( 'react' );
+
+        // Wire each child option through `onChange` so clicking an
+        // option exercises the real `setAttributes` write path. The
+        // production `ToggleGroupControl` does the same plumbing through
+        // a context; cloneElement is a lighter equivalent for the mock.
+        const wired = React.Children.map(
+            children,
+            ( child: React.ReactNode ) =>
+                React.isValidElement( child )
+                    ? React.cloneElement( child, { onChange } )
+                    : child,
+        );
+
+        return (
+            <div data-testid="direction-toggle-group" data-value={ value } aria-label={ label }>
+                { wired }
+            </div>
+        );
+    },
     __experimentalToggleGroupControlOption: ( {
         value,
         label,
+        onChange,
     }: {
         value?: string;
         label?: string;
+        onChange?: ( value: string | number ) => void;
     } ) => (
-        <button data-testid={ `direction-${ value }` } type="button">
+        <button
+            data-testid={ `direction-${ value }` }
+            type="button"
+            onClick={ () => {
+                if ( value !== undefined ) {
+                    onChange?.( value );
+                }
+            } }
+        >
             { label }
         </button>
     ),
@@ -175,6 +203,22 @@ describe( 'PostNavigationLinkEdit InspectorControls', () => {
         expect(
             getByTestId( 'direction-toggle-group' ).getAttribute( 'data-value' ),
         ).toBe( 'next' );
+    } );
+
+    it( 'routes the Direction toggle through setAttributes for both options', () => {
+        const setAttributes = vi.fn();
+        const { getByTestId } = render(
+            <PostNavigationLinkEdit
+                attributes={ { type: 'next' } }
+                setAttributes={ setAttributes }
+            />,
+        );
+
+        fireEvent.click( getByTestId( 'direction-previous' ) );
+        expect( setAttributes ).toHaveBeenCalledWith( { type: 'previous' } );
+
+        fireEvent.click( getByTestId( 'direction-next' ) );
+        expect( setAttributes ).toHaveBeenCalledWith( { type: 'next' } );
     } );
 
     it( 'routes the showTitle toggle through setAttributes', () => {

--- a/resources/js/visual-editor/blocks/post-navigation-link/edit.tsx
+++ b/resources/js/visual-editor/blocks/post-navigation-link/edit.tsx
@@ -196,7 +196,9 @@ export default function PostNavigationLinkEdit(
                             __next40pxDefaultSize
                             __nextHasNoMarginBottom
                             onChange={ ( value: string | number ) =>
-                                setAttributes( { type: String( value ) } )
+                                setAttributes( {
+                                    type: value === 'previous' ? 'previous' : 'next',
+                                } )
                             }
                         >
                             <ToggleGroupControlOption

--- a/resources/js/visual-editor/blocks/post-navigation-link/edit.tsx
+++ b/resources/js/visual-editor/blocks/post-navigation-link/edit.tsx
@@ -17,8 +17,28 @@
  *     with the configured arrow glyph so the canvas shows the styled
  *     shape even with no adjacent post resolved.
  *
+ * `InspectorControls` (#532) surfaces the `type`, `arrow`, and
+ * `showTitle` attributes through a Settings sidebar panel so authors
+ * can flip the direction (and the other display options) without
+ * dropping into HTML edit mode. Matches upstream `core/post-navigation-link`'s
+ * Settings layout, with the additional `arrow` glyph control the fork
+ * exposes on top of upstream.
+ *
  * Phase I-Block-Fork — post navigation / metadata family (#520).
  */
+
+import type { ReactElement } from 'react';
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import {
+    PanelBody,
+    SelectControl,
+    ToggleControl,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    __experimentalToggleGroupControl as ToggleGroupControl,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    __experimentalToggleGroupControlOption as ToggleGroupControlOption,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 
 import {
     createEntityPlaceholderEdit,
@@ -26,14 +46,22 @@ import {
     type EntityPreviewValue,
 } from '../_shared/entity-placeholder-edit';
 import type { QueryPreviewPost } from '../../editor/use-query-preview';
+import { TEXT_DOMAIN } from '../../vendor/i18n';
 
 interface NavigationAttributes {
     readonly type?: string;
     readonly label?: string;
     readonly arrow?: string;
+    readonly showTitle?: boolean;
     readonly _resolvedPrevTitle?: string;
     readonly _resolvedNextTitle?: string;
     readonly _resolvedAdjacentTitle?: string;
+}
+
+interface PostNavigationLinkEditProps {
+    readonly attributes?: NavigationAttributes;
+    readonly setAttributes?: ( attrs: Partial<NavigationAttributes> ) => void;
+    readonly context?: unknown;
 }
 
 function arrowFor( type: string, arrow: string ): string {
@@ -98,13 +126,31 @@ const PlaceholderEdit = createEntityPlaceholderEdit( {
     kind: 'text',
 } );
 
-export default function PostNavigationLinkEdit( props: {
-    attributes?: NavigationAttributes;
-    context?: unknown;
-} ): ReturnType<typeof PlaceholderEdit > {
+/**
+ * Empty block wrapper rendered when no adjacent post is resolved and no
+ * custom `label` is set. Mirrors the server-side renderers, which emit
+ * no markup for a post with no neighbor in the chosen direction —
+ * showing a neutral "Previous post" / "Next post" placeholder in the
+ * canvas would misrepresent the front-end output. Lives in its own
+ * component so `useBlockProps` stays under React's rules-of-hooks
+ * (called unconditionally per render).
+ */
+function EmptyPostNavigationLink(): ReactElement {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const blockProps = ( useBlockProps as any )();
+
+    return <div { ...blockProps } />;
+}
+
+export default function PostNavigationLinkEdit(
+    props: PostNavigationLinkEditProps,
+): ReactElement {
     const attributes = props.attributes ?? {};
+    const setAttributes = props.setAttributes;
     const type = attributes.type === 'previous' ? 'previous' : 'next';
     const label = typeof attributes.label === 'string' ? attributes.label : '';
+    const arrow = typeof attributes.arrow === 'string' ? attributes.arrow : 'none';
+    const showTitle = Boolean( attributes.showTitle );
 
     const stampedKey: keyof NavigationAttributes =
         type === 'previous' ? '_resolvedPrevTitle' : '_resolvedNextTitle';
@@ -115,7 +161,12 @@ export default function PostNavigationLinkEdit( props: {
     //   1. Stamped `_resolvedPrevTitle` / `_resolvedNextTitle`
     //   2. `artisanpack/postPreview.adjacent[direction].title`
     //   3. The block's own `label` attribute
-    //   4. Neutral fallback ("Previous post" / "Next post")
+    //
+    // When none of these resolve the editor preview renders nothing —
+    // matching the server-side renderers, which emit empty markup for
+    // posts with no neighbor in the chosen direction. The block wrapper
+    // (`useBlockProps`) still mounts so the Settings panel binds and
+    // the empty block stays selectable via the list view.
     let text = stamped;
 
     if ( text === '' ) {
@@ -126,16 +177,69 @@ export default function PostNavigationLinkEdit( props: {
         text = label;
     }
 
-    if ( text === '' ) {
-        text = type === 'previous' ? 'Previous post' : 'Next post';
-    }
-
-    const decorated = decoratePlaceholderText( attributes, text );
+    const decorated = text === '' ? '' : decoratePlaceholderText( attributes, text );
 
     const synthesizedAttributes: NavigationAttributes & EntityPreviewValue = {
         ...attributes,
         _resolvedAdjacentTitle: decorated,
     };
 
-    return PlaceholderEdit( { ...props, attributes: synthesizedAttributes } );
+    return (
+        <>
+            { setAttributes !== undefined && (
+                <InspectorControls>
+                    <PanelBody title={ __( 'Settings', TEXT_DOMAIN ) }>
+                        <ToggleGroupControl
+                            label={ __( 'Direction', TEXT_DOMAIN ) }
+                            value={ type }
+                            isBlock
+                            __next40pxDefaultSize
+                            __nextHasNoMarginBottom
+                            onChange={ ( value: string | number ) =>
+                                setAttributes( { type: String( value ) } )
+                            }
+                        >
+                            <ToggleGroupControlOption
+                                value="previous"
+                                label={ __( 'Previous', TEXT_DOMAIN ) }
+                            />
+                            <ToggleGroupControlOption
+                                value="next"
+                                label={ __( 'Next', TEXT_DOMAIN ) }
+                            />
+                        </ToggleGroupControl>
+                        <ToggleControl
+                            // @ts-expect-error - upstream prop
+                            __nextHasNoMarginBottom
+                            label={ __( 'Display the title as a link', TEXT_DOMAIN ) }
+                            checked={ showTitle }
+                            onChange={ ( value: boolean ) =>
+                                setAttributes( { showTitle: value } )
+                            }
+                        />
+                        <SelectControl
+                            // @ts-expect-error - upstream prop
+                            __next40pxDefaultSize
+                            __nextHasNoMarginBottom
+                            label={ __( 'Arrow', TEXT_DOMAIN ) }
+                            value={ arrow }
+                            options={ [
+                                { label: __( 'None', TEXT_DOMAIN ), value: 'none' },
+                                { label: __( 'Arrow', TEXT_DOMAIN ), value: 'arrow' },
+                                { label: __( 'Chevron', TEXT_DOMAIN ), value: 'chevron' },
+                            ] }
+                            onChange={ ( value: string ) =>
+                                setAttributes( { arrow: value } )
+                            }
+                        />
+                    </PanelBody>
+                </InspectorControls>
+            ) }
+            { decorated === '' ? (
+                <EmptyPostNavigationLink />
+            ) : (
+                <PlaceholderEdit { ...props } attributes={ synthesizedAttributes } />
+            ) }
+        </>
+    );
 }


### PR DESCRIPTION
## Description

Wires a Settings `InspectorControls` panel into the fork's `post-navigation-link/edit.tsx` so authors can flip the block's direction (Previous / Next), toggle the title link, and pick an arrow glyph without dropping into HTML edit mode. Matches upstream `core/post-navigation-link`'s Settings layout, with the fork's extra `arrow` (None / Arrow / Chevron) control surfaced alongside.

Also tightens the editor preview: drops the neutral "Previous post" / "Next post" placeholder text and renders an empty block wrapper when no adjacent post resolves and no custom `label` is set — mirroring the server-side renderers (Blade / React / Vue), which emit empty markup for posts with no neighbor in the chosen direction.

**Closes:** #532

## Type of Change

- [x] Enhancement (improves existing functionality)

## Related Issue

**Issue:** #532

## Motivation and Context

Before this change, dropping `artisanpack/post-navigation-link` from the inserter always produced a `"next"` instance and the only way to flip it to `"previous"` was to enter HTML editing mode. Surfaced while manually testing #527 — the resolver-side stamping for both directions is verified end-to-end, but exercising the `"previous"` path in the editor required HTML editing.

## Changes Made

- Add an `InspectorControls` Settings panel to `post-navigation-link/edit.tsx`:
  - `ToggleGroupControl` for `attributes.type` (Previous / Next)
  - `ToggleControl` for `attributes.showTitle` (Display the title as a link)
  - `SelectControl` for `attributes.arrow` (None / Arrow / Chevron)
- Drop the neutral `"Previous post"` / `"Next post"` fallback in the editor preview; render an empty wrapper when nothing resolves (matches the front-end renderers).
- Extract an `EmptyPostNavigationLink` component so `useBlockProps` stays under rules-of-hooks (called unconditionally per render).
- Add 11 Vitest cases in `post-navigation-link/__tests__/edit.test.tsx` covering panel mount/unmount, direction reflection, default normalization, ToggleControl/SelectControl `setAttributes` wiring, arrow-glyph decoration, the empty-render branch, and label / query-preview precedence.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (Darwin 25.5.0)
- Browser: Safari / Chrome via Laravel Herd
- PHP Version: 8.4.3
- Project Version: 1.0 (release/1.0)

**Tests Performed:**
1. `npx vitest run` — 229 files, **1835 tests passing** (including 11 new cases for the edit component).
2. Manual testing in the `jmwd-keystone-cms` host app: inserted Post Navigation Link, opened the Settings sidebar, confirmed Direction / Show Title / Arrow controls all bind to `setAttributes` and the canvas preview updates reactively. Confirmed empty-render behavior for posts with no neighbor (front-end Blade renderer + editor preview both emit an empty wrapper).
3. CodeRabbit CLI: clean (no actionable findings).

## Accessibility Tests Run

- [x] Keyboard navigation tested (Tab / arrow keys move through the panel controls)
- [ ] Screen reader tested
- [x] Color contrast verified (uses upstream WordPress component primitives, inherits theme palette)
- [x] ARIA labels checked (controls carry their labels via the WordPress `__()` strings; renderer-side aria-label for the navigation anchor is unchanged from upstream)

**Details:**

The Settings panel uses `PanelBody` + `ToggleGroupControl` / `ToggleControl` / `SelectControl` from `@wordpress/components`, which carry their accessibility primitives. Front-end markup is unchanged — the aria-label on the navigation anchor still reads "Previous post" / "Next post" via the existing Blade / React / Vue renderers.

## Tests Added

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All tests passing

**Test details:**

New file: `resources/js/visual-editor/blocks/post-navigation-link/__tests__/edit.test.tsx` (11 cases). Covers the InspectorControls wiring (mount, omit-when-headless, direction reflection / default normalization, ToggleControl / SelectControl `setAttributes` plumbing) and the empty-render behavior (no stamped / no preview / no label → empty wrapper; label fallback still renders; query-preview precedence over label).

## Documentation

- [x] Inline code documentation added
- [ ] README updated
- [ ] Wiki updated
- [ ] API documentation updated

**Documentation details:**

The edit component's leading docblock now describes the InspectorControls panel and the empty-render contract. The extracted `EmptyPostNavigationLink` carries its own docblock explaining the rules-of-hooks rationale for the split.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted (CodeRabbit CLI clean)
- [x] Accessibility tests completed
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Settings inspector to the post navigation link block with direction control, title visibility toggle, and arrow glyph selector.
  * Improved preview and empty-state handling: block stays mounted when no adjacent post; previews decorate resolved titles, fall back to label, or render an empty wrapper when appropriate.

* **Tests**
  * Added editor tests covering inspector visibility, direction/arrow/title controls, preview resolution, and empty-state behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->