### PR TITLE
docs: V1 documentation set and release notes (#325)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,41 @@
-# Digital Shopfront CMS Package Changelog
+# ArtisanPack UI Visual Editor — Changelog
 
-## [Unreleased]
+All notable changes to this project are documented in this file.
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
+this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.0] — V1 release
+
+V1 ships the post editor, the site editor, the block fork to the
+`artisanpack/*` namespace, and first-class pairing with
+`artisanpack-ui/cms-framework`. See the [README](README.md) and the
+[`docs/`](docs/) directory for the full V1 surface.
+
+### Added
+
+- **Site editor (Phase H).** Mounted at `/visual-editor/site`. Templates,
+  template parts, theme.json-backed global styles, navigation menus, and
+  patterns — all editable through a custom shell built on
+  `@wordpress/block-editor`. Backed by cms-framework's
+  `Template`/`TemplatePart`/`GlobalStyles`/`Menu`/`Pattern` models when
+  cms-framework is installed; fail-closed `SiteEditorAccessGate`
+  defaults to deny until the host binds a permissive gate (or installs
+  cms-framework, which auto-binds `CmsFrameworkInstallGate`).
+- **Documentation set.** Fifteen new / refreshed docs covering install,
+  content model, Blade component reference, post-editor surface, custom
+  blocks, renderers, site-editor surface, templates, global styles,
+  navigation, patterns, Livewire and Inertia embedding recipes,
+  theming, troubleshooting, and migration. Entry point:
+  [`docs/getting-started.md`](docs/getting-started.md).
+- **V1 expansion plan retained as historical record:**
+  [`docs/plans/11-v1-expansion.md`](docs/plans/11-v1-expansion.md).
+
+### Changed
+
+- README rewritten to reflect final V1 scope: post editor + site editor
+  + patterns + Livewire/Inertia embedding.
+
+## [1.0.0-alpha.1] — Gutenberg adoption marker
 
 ### Added
 

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -1,0 +1,167 @@
+# Visual Editor — V1 architecture notes
+
+Persisted reference for future work on this package. Read on every
+session start; update when architecture decisions change.
+
+---
+
+## Package shape
+
+- Composer package: `artisanpack-ui/visual-editor` (namespace `ArtisanPackUI\VisualEditor\`, src under `src/`)
+- npm package: `@artisanpack-ui/visual-editor` (built from `resources/js/visual-editor/`)
+- Three sub-packages under `packages/`:
+  - `artisanpack-ui/visual-editor-renderer-blade` (Packagist; published in V1)
+  - `@artisanpack-ui/visual-editor-renderer-react` (npm; mirror unpublished in V1.0.0)
+  - `@artisanpack-ui/visual-editor-renderer-vue` (npm; mirror unpublished in V1.0.0)
+
+## V1 surfaces
+
+Two surfaces, mounted independently:
+
+1. **Post editor** — `<x-visual-editor :model="$model" />` Blade
+   component. Boots a React tree on `[data-ap-visual-editor]`. Edits
+   any model that uses `HasBlockContent`.
+2. **Site editor** — `GET /visual-editor/site/{path?}`. Templates,
+   template parts, patterns, global styles, navigation. Gated by
+   `SiteEditorAccessGate` (`DenyByDefaultGate` by default;
+   cms-framework auto-binds `CmsFrameworkInstallGate`).
+
+## Content model
+
+- `ArtisanPackUI\VisualEditor\Concerns\HasBlockContent` on any Eloquent
+  model. Default column: `content` (JSON); override via
+  `$blockContentColumn`. Optional scope via `$blockContentScope`.
+- Resource map: slug → model class. Read from
+  `config('artisanpack.visual-editor.resources')` + `ap.visual-editor.resources`
+  filter. Static config wins on key collision. Validation deferred to
+  first request (not boot), so contributor packages don't trip boot
+  when absent.
+- Resolver: `ArtisanPackUI\VisualEditor\Resources\ResourceResolver`. Applies
+  `forVisualEditor` scope; throws `InvalidArgumentException` on unknown
+  resource / missing trait.
+
+## REST surface
+
+All under `/visual-editor/api`, middleware
+`config('artisanpack.visual-editor.api.middleware')` (default
+`['api', 'auth']`).
+
+Endpoint families:
+
+- `{resource}/{id}/content` — block content CRUD
+- `blocks/preview`, `blocks` — block registry + dynamic preview
+- `query/resolve` — `core/query` resolution
+- `templates`, `template-parts`, `patterns`, `global-styles`, `menus`,
+  `menu-items`, `menu-locations` — site-editor entities (wp_template
+  shape; matches Gutenberg's REST contract so core-data shim resolves
+  unchanged)
+- `attachments/{id}`, `search`, `site/{id}` — media, link picker,
+  site-meta
+
+cms-framework adds: `posts`, `pages` (REST adapters into
+cms-framework's models).
+
+## @wordpress/* pins
+
+All exact-version pinned, lockstep, audited per release. V1.0.0 ships
+against the `15.16.0` / `32.5.0` / `7.43.0` baseline (see
+`docs/release-notes-inputs-1.0.0.md` §1 + §5). Renovate is paused for the
+group during V1.x expansion phases and resumes post-tag.
+
+Schema version: theme.json **v3** (pinned in
+`config('artisanpack.visual-editor.global_styles.schema_version')` and
+enforced by `UpdateGlobalStylesRequest`).
+
+Bump procedure: `docs/troubleshooting.md` §3 + `docs/global-styles.md` §8.
+
+## Core-data shim
+
+`resources/js/visual-editor/vendor/core-data-shim.ts` — aliased in
+`vite.config.ts` as `@wordpress/core-data`. Provides:
+
+- Entities: `wp_template`, `wp_template_part`, `wp_navigation`, `wp_block`
+  (patterns), `root:globalStyles`, attachments, site-meta.
+- Selectors: `getEntityRecord`, `getEntityRecords`, `getEditedEntityRecord`,
+  `canUser`, `getCurrentUser`, `getMedia`, plus resolver tracking
+  (`hasFinishedResolution`, `isResolving`).
+
+Adding a new entity or selector goes here. Surface only what Gutenberg
+demands; broader surface = more re-verification per upstream bump.
+
+## Block fork (Phase I — closed)
+
+- 42 forked core blocks under `artisanpack/*`. Source of truth:
+  `resources/js/visual-editor/blocks/`.
+- `core/*` no longer registered. `from:core/*` transforms on every fork
+  catch pasted upstream markup.
+- `@wordpress/block-library` demoted to devDependencies; only consumed
+  by `npm run upstream-diff`.
+- Per-block `upstream-state.json` tracks the upstream commit each fork
+  derives from. CI runs the diff on every Renovate PR.
+
+## Renderers
+
+Three packages, all consume the same block-tree JSON. Parity verified
+by `npm run verify:parity`. Static blocks: per-block partial/component
+in each renderer. Dynamic blocks: `DynamicBlock` subclass renders
+server-side; React + Vue fall through to `<DynamicBlock>` that fetches
+from `/visual-editor/api/blocks/preview`.
+
+## Embedding stacks
+
+- Livewire: `wire:ignore` + Alpine listeners on `ve:editor:*` events.
+  See `docs/livewire.md`.
+- Inertia React: imperative `mountVisualEditor(el, config)`.
+- Inertia Vue: `<VisualEditor>` SFC from `@artisanpack-ui/visual-editor/vue`.
+
+Same three browser events fire regardless of stack:
+`ve:editor:change` (debounce edge), `ve:editor:autosave` (debounced
+save returns 200), `ve:editor:save` (explicit save returns 200).
+
+## Theming
+
+- Editor chrome restyled to DaisyUI via `@artisanpack-ui/react`.
+- Known issues: `@artisanpack-ui/react` Popover + Dropdown freeze the
+  canvas — use inline manual patterns. Tabs needs
+  `tabListClassName="tabs-box"` for DaisyUI 5.
+- React package: use subpath imports (`/form`, `/layout`, etc.); root
+  import breaks tests via missing `react-apexcharts` peer.
+
+## Site-editor + cms-framework version pair
+
+V1.x ↔ V1.x. cms-framework provides:
+
+- Models: `Post`, `Page`, `Template`, `TemplatePart`, `Pattern`,
+  `GlobalStyles`, `Menu`, `MenuItem`.
+- Service contracts: `QueryResolver`, `SiteEditorAccessGate` impl
+  (`CmsFrameworkInstallGate`), site-meta via `apGetSetting('site.*')`.
+- Migrations: `block_content` column on `posts`/`pages`, full
+  site-editor tables.
+
+Loose coupling — cms-framework's editor wiring guarded by
+`class_exists(\ArtisanPackUI\VisualEditor\VisualEditor::class)`.
+
+## Smoke flows
+
+Both run against the version pair before every release tag:
+
+- `docs/g6-smoke-flow.md` — Phase G (posts, pages, site-meta, query).
+- `docs/h8-smoke-flow.md` — Phase H (templates, parts, patterns,
+  global styles, navigation).
+
+## Tests
+
+- PHP: `./vendor/bin/pest` (Pest 3.x, Orchestra Testbench).
+- JS: `npm test` (Vitest, jsdom).
+- Parity: `npm run verify:parity`.
+- Upstream diff: `npm run upstream-diff`.
+
+## What's deferred to V1.1+
+
+- `@wordpress/*` upgrade pass (paused during V1.0.0; resumes post-tag).
+- Style variations (theme-level presets).
+- Revision history of global-styles edits.
+- Standalone-without-cms-framework polish (currently usable but the
+  site editor requires cms-framework).
+- WordPress import companion package
+  (`artisanpack-ui/visual-editor-wp-import`).

--- a/README.md
+++ b/README.md
@@ -1,130 +1,268 @@
 # ArtisanPack UI Visual Editor
 
-Description
+A Gutenberg-powered visual editor for Laravel applications. Brings the
+WordPress block editor to any Eloquent model, plus a full site editor
+for templates, template parts, global styles, navigation menus, and
+patterns.
+
+V1.0 ships:
+
+- **Post editor** — block-based content editing on any model that opts
+  in via the `HasBlockContent` trait.
+- **Site editor** — templates, template parts, theme.json-backed global
+  styles, navigation menus, and patterns; mounted at `/visual-editor/site`.
+- **42 forked core blocks** under the `artisanpack/*` namespace.
+  `core/*` markup pasted from upstream auto-converts on insert.
+- **Three renderer packages** — Blade (server-side), React, and Vue —
+  for rendering saved block content on the public site.
+- **First-class pairing** with [`artisanpack-ui/cms-framework`](https://github.com/ArtisanPack-UI/cms-framework)
+  for Posts, Pages, site-meta, navigation, and global-styles persistence.
+  Both packages remain usable standalone.
+
+Full documentation: see [`docs/`](docs/). Start with [Getting started](docs/getting-started.md).
+
+---
 
 ## Installation
 
-You can install the visual-editor package by running the following composer command.
+```bash
+composer require artisanpack-ui/visual-editor
+php artisan migrate
+```
 
-`composer require artisanpack-ui/visual-editor`
+For the site editor (recommended for most apps):
+
+```bash
+composer require artisanpack-ui/cms-framework
+php artisan migrate
+```
+
+See [Getting started](docs/getting-started.md) for the full setup.
+
+---
 
 ## Version compatibility
 
 The visual-editor and `artisanpack-ui/cms-framework` packages ship as a
-version pair — both packages need to be present, and both need to be
-on a compatible major version, for the Phase H site-editor integration
-to work. Install one without the other and the site-editor's install
-gate (#432) surfaces a "cms-framework required" page instead of mounting.
+version pair — both packages need to be present, and both need to be on
+a compatible major version, for the site-editor integration to work.
+Install one without the other and the site-editor's install gate (#432)
+surfaces a "cms-framework required" page instead of mounting.
 
 | visual-editor | cms-framework | Notes                                          |
 | ------------- | ------------- | ---------------------------------------------- |
-| v1.x          | v1.x          | Phase H site-editor integration (this release) |
+| v1.x          | v1.x          | Site-editor integration (this release)         |
 | v0.x          | v0.x          | Pre-v1 — no site-editor integration            |
 
 Bumping the major on either package without bumping the partner is
 unsupported. Both smoke flows run against this version pair before every
-release tag:
-[`docs/g6-smoke-flow.md`](docs/g6-smoke-flow.md) covers Phase G
-(cms-framework content integration — posts, pages, site-meta, query
-loop); [`docs/h8-smoke-flow.md`](docs/h8-smoke-flow.md) covers Phase H
-(site-editor — templates, parts, patterns, global styles, navigation).
+release tag: [`docs/g6-smoke-flow.md`](docs/g6-smoke-flow.md) covers
+Phase G (cms-framework content integration — posts, pages, site-meta,
+query loop); [`docs/h8-smoke-flow.md`](docs/h8-smoke-flow.md) covers
+Phase H (site-editor — templates, parts, patterns, global styles,
+navigation).
 
-## Peer Dependencies
+---
 
-The editor UI is built on [`@artisanpack-ui/react`](https://www.npmjs.com/package/@artisanpack-ui/react), which is styled with DaisyUI and Tailwind CSS. Host applications embedding the editor must have the following installed and loaded:
+## Peer dependencies
+
+The editor UI is built on [`@artisanpack-ui/react`](https://www.npmjs.com/package/@artisanpack-ui/react),
+which is styled with DaisyUI and Tailwind CSS. Host applications
+embedding the editor must have the following installed and loaded:
 
 - `tailwindcss` `^4.0.0`
 - `daisyui` `^5.0.0`
 
+---
+
 ## Usage
 
-You can use any of the visual editor functions like this:
+Add the `HasBlockContent` trait to any model and register it in
+`config/artisanpack/visual-editor.php`:
 
+```php
+use ArtisanPackUI\VisualEditor\Concerns\HasBlockContent;
+
+class Post extends Model
+{
+    use HasBlockContent;
+}
 ```
-Example Here
+
+```php
+// config/artisanpack/visual-editor.php
+return [
+    'resources' => [
+        'posts' => App\Models\Post::class,
+    ],
+];
 ```
 
-## Gutenberg adoption — transient shims (V1)
+Mount the editor in a Blade view:
 
-The V1 editor adopts the upstream `@wordpress/*` packages. Some of those packages expect a WordPress backend that this package does not provide yet, so we ship **temporary shims** under `resources/js/visual-editor/vendor/`:
+```blade
+<x-visual-editor :model="$post" />
+```
 
-- **`core-data-shim.ts`** — aliased in `vite.config.ts` as `@wordpress/core-data`. Registers an empty `core` Redux store via `@wordpress/data` so Gutenberg's selectors (`getEntityRecord`, `getEntityRecords`, `getCurrentUser`, `getUsers`, `getMedia`, etc.) see "no data, done loading" instead of crashing. Blocks that need WordPress-specific data (navigation, query, post-*) render empty; those blocks land in the `disabled_blocks` list in M5.
-- **`media-upload-stub.tsx`** — registers `editor.MediaUpload` via `@wordpress/hooks` so the media-library picker on `core/image` is routed through a stub that displays an "M4 placeholder" notice instead of silently no-op'ing.
+The site editor mounts automatically at `/visual-editor/site` when
+cms-framework is installed and the configured `SiteEditorAccessGate`
+permits the request.
 
-Both shims will be replaced by `artisanpack-ui/cms-framework` (the real Laravel-backed `core-data` store and media bridge). Every selector or filter we implement here is one we have to re-verify against Gutenberg upgrades — expand the surface only when an observed crash demands it.
+See [`docs/blade-component.md`](docs/blade-component.md) for the full
+component reference and [`docs/site-editor.md`](docs/site-editor.md) for
+the site-editor surface.
+
+---
+
+## Documentation
+
+| Topic | Doc |
+|-------|-----|
+| Install and first post | [`docs/getting-started.md`](docs/getting-started.md) |
+| `HasBlockContent` + resource map | [`docs/content-model.md`](docs/content-model.md) |
+| `<x-visual-editor />` reference | [`docs/blade-component.md`](docs/blade-component.md) |
+| Post editor surface tour | [`docs/post-editor.md`](docs/post-editor.md) |
+| Authoring custom blocks | [`docs/custom-blocks.md`](docs/custom-blocks.md) |
+| Blade / React / Vue renderers | [`docs/renderers.md`](docs/renderers.md) |
+| Site editor surface tour | [`docs/site-editor.md`](docs/site-editor.md) |
+| Template hierarchy + parts | [`docs/templates.md`](docs/templates.md) |
+| theme.json-backed global styles | [`docs/global-styles.md`](docs/global-styles.md) |
+| Menus, locations, fallbacks | [`docs/navigation.md`](docs/navigation.md) |
+| Synced vs unsynced patterns | [`docs/patterns.md`](docs/patterns.md) |
+| Embedding in Livewire | [`docs/livewire.md`](docs/livewire.md) |
+| Embedding in Inertia (React/Vue) | [`docs/inertia.md`](docs/inertia.md) |
+| Theming editor chrome | [`docs/theming.md`](docs/theming.md) |
+| Common problems | [`docs/troubleshooting.md`](docs/troubleshooting.md) |
+| Migration & WP import | [`docs/migration.md`](docs/migration.md) |
+
+---
+
+## Gutenberg adoption — transient shims
+
+The V1 editor adopts the upstream `@wordpress/*` packages. Some of those
+packages expect a WordPress backend that this package doesn't provide,
+so we ship temporary shims under `resources/js/visual-editor/vendor/`:
+
+- **`core-data-shim.ts`** — aliased in `vite.config.ts` as
+  `@wordpress/core-data`. Provides the entity registrations and
+  selectors Gutenberg expects (`getEntityRecord`, `getEntityRecords`,
+  resolvers, permissions stubs). Templates, template parts, navigation,
+  patterns, global styles, attachments, and site-meta are wired through
+  to the package's REST surface.
+- **`media-upload-stub.tsx`** — registers `editor.MediaUpload` via
+  `@wordpress/hooks` so the media-library picker on `core/image` is
+  routed through a stub or the real
+  `registerArtisanpackMediaBridge(MediaModal, uploadMedia)` bridge.
+
+Both shims will be replaced over the V1.x release line as the cms-framework
+side surfaces real backings. Every selector or filter implemented here is
+one to re-verify against Gutenberg upgrades. See
+[`docs/core-data-shim.md`](docs/core-data-shim.md) and
+[`docs/troubleshooting.md`](docs/troubleshooting.md#2-core-data-shim-entities-and-missing-data).
+
+---
 
 ## Block defaults
 
-V1 ships with a frozen allow-list of forked blocks under the `artisanpack/*` namespace. The defaults in `config/visual-editor.php` expose every block that landed during the Phase I block fork (plan 13) — `@wordpress/block-library`'s `registerCoreBlocks()` is no longer called, and the editor registers only the in-package forks discovered under `resources/js/visual-editor/blocks/`. The `core/*` → `artisanpack/*` mapping table in [`docs/block-library-audit.md`](docs/block-library-audit.md) is the source of truth for which forks exist.
+V1 ships a frozen allow-list of forked blocks under the `artisanpack/*`
+namespace. The defaults in `config/visual-editor.php` expose every block
+that landed during the Phase I block fork — `@wordpress/block-library`'s
+`registerCoreBlocks()` is no longer called, and the editor registers
+only the in-package forks discovered under
+`resources/js/visual-editor/blocks/`. The `core/*` → `artisanpack/*`
+mapping table in [`docs/block-library-audit.md`](docs/block-library-audit.md)
+is the source of truth for which forks exist.
 
-The forked allow-list covers the content, media, layout, widget, entity, and loop/feed clusters. The entity blocks (`artisanpack/post-*`, `artisanpack/site-*`, `artisanpack/template-part`, `artisanpack/navigation`) and the loop / feed cluster (`artisanpack/query`, `artisanpack/post-template`, `artisanpack/archives`, `artisanpack/categories`, `artisanpack/tag-cloud`) need an entity in scope to render meaningful content — pair the editor with [`artisanpack-ui/cms-framework`](https://github.com/ArtisanPack-UI/cms-framework) (see [Using with cms-framework](#using-with-cms-framework)) and they resolve against Posts / Pages / templates / site settings end-to-end. Standalone, they fall back to empty shells rather than crashing.
+The forked allow-list covers the content, media, layout, widget, entity,
+loop/feed, comments, query/pagination, and authentication clusters.
+Entity blocks (`artisanpack/post-*`, `artisanpack/site-*`,
+`artisanpack/template-part`, `artisanpack/navigation`) and the loop /
+feed cluster (`artisanpack/query`, `artisanpack/post-template`,
+`artisanpack/archives`, `artisanpack/categories`,
+`artisanpack/tag-cloud`) need an entity in scope to render meaningful
+content — pair the editor with
+[`artisanpack-ui/cms-framework`](https://github.com/ArtisanPack-UI/cms-framework)
+and they resolve against Posts / Pages / templates / site settings
+end-to-end. Standalone, they fall back to empty shells rather than
+crashing.
 
-`disabled_blocks` is empty by default: with the I7 cutover (#415) the editor no longer registers any `core/*` block, so there is nothing to deny-list. New `@wordpress/block-library` releases similarly bring no new registrations into this package — additions land only when a fork is added to the in-package blocks directory and to the allow-list. `from:core/*` transforms still ship on each fork so existing `core/*` markup pasted from upstream converts on insert.
+`disabled_blocks` is empty by default: with the I7 cutover (#415) the
+editor no longer registers any `core/*` block, so there's nothing to
+deny-list. New `@wordpress/block-library` releases similarly bring no
+new registrations into this package — additions land only when a fork
+is added to the in-package blocks directory and to the allow-list.
+`from:core/*` transforms ship on each fork so existing `core/*` markup
+pasted from upstream converts on insert.
 
-Override the defaults by publishing the config to `config/artisanpack/visual-editor.php` and editing the `enabled_blocks` / `disabled_blocks` arrays. The deny-list always wins over the allow-list.
+Override the defaults by publishing the config to
+`config/artisanpack/visual-editor.php` and editing the `enabled_blocks`
+/ `disabled_blocks` arrays. The deny-list always wins over the allow-list.
+
+---
 
 ## Using with cms-framework
 
-The visual editor is fully usable standalone, but pairs with [`artisanpack-ui/cms-framework`](https://github.com/ArtisanPack-UI/cms-framework) to unlock editable `Post` and `Page` content, a real backing for `core/site-*` blocks, working `core/post-*` / `core/query` / taxonomy widget blocks, and seeded `visual_editor.*` permissions. The full integration contract lives in [`docs/plans/12-cms-framework-integration.md`](docs/plans/12-cms-framework-integration.md).
+The visual editor is fully usable standalone, but pairs with
+[`artisanpack-ui/cms-framework`](https://github.com/ArtisanPack-UI/cms-framework)
+to unlock:
 
-### Install both packages
+- Editable `Post` and `Page` content out of the box.
+- A real backing for `core/site-*` blocks (site title, tagline, logo, icon).
+- Working `core/post-*`, `core/query`, taxonomy widget, and navigation
+  blocks.
+- Templates, template parts, patterns, global styles, and menus
+  persisted via cms-framework's models.
+- Seeded `visual_editor.*` permissions.
 
 ```bash
 composer require artisanpack-ui/visual-editor artisanpack-ui/cms-framework
-```
-
-Both packages are loosely coupled — cms-framework's editor wiring is guarded by `class_exists(\ArtisanPackUI\VisualEditor\VisualEditor::class)`, so each package remains usable on its own.
-
-### Run migrations
-
-```bash
 php artisan migrate
 ```
 
-cms-framework's V1.x migration set adds a `block_content json nullable` column to its `posts` and `pages` tables (the legacy `content` longText column is preserved for search / excerpt / backwards-compatibility — see plan 12 §4.2 for the dual-state guidance).
+Both packages are loosely coupled — cms-framework's editor wiring is
+guarded by `class_exists(\ArtisanPackUI\VisualEditor\VisualEditor::class)`,
+so each remains usable on its own. The full integration contract lives in
+[`docs/plans/12-cms-framework-integration.md`](docs/plans/12-cms-framework-integration.md).
 
-### Resource map
-
-When both packages are installed, cms-framework registers its `Post` and `Page` into the `ap.visual-editor.resources` filter automatically. The merged map ends up shaped like:
-
-```php
-// Effective config('artisanpack.visual-editor.resources') after the
-// ap.visual-editor.resources filter has run with both packages installed.
-[
-    'posts' => \ArtisanPackUI\CMSFramework\Modules\Blog\Models\Post::class,
-    'pages' => \ArtisanPackUI\CMSFramework\Modules\Pages\Models\Page::class,
-    // …plus any slug → model entries the host app added to
-    //   config/artisanpack/visual-editor.php (static config wins on collision).
-]
-```
-
-Host-app overrides in `config/artisanpack/visual-editor.php` always take precedence on key collision, so swapping `posts` to a custom `App\Models\Post` is just a config edit.
-
-### Version pairing
-
-visual-editor V1.0.x ships against cms-framework V1.x. The compatibility matrix is in [Version compatibility](#version-compatibility) above; the [`docs/g6-smoke-flow.md`](docs/g6-smoke-flow.md) and [`docs/h8-smoke-flow.md`](docs/h8-smoke-flow.md) flows run against the version pair before every release tag.
+---
 
 ## Extensibility
 
-The package exposes a small filter surface so other packages can contribute editor wiring at runtime without forcing host apps to publish-and-edit the package config.
-
 ### `ap.visual-editor.resources`
 
-Register slug → Eloquent model class mappings used by `/visual-editor/api/{resource}/{id}/content`. Filter contributions are merged with `config('artisanpack.visual-editor.resources')`; the static config wins on key collision so host-app overrides always take precedence. Models must use `ArtisanPackUI\VisualEditor\Concerns\HasBlockContent` — invalid entries surface as `InvalidArgumentException` on first request rather than at boot, so a contributor's standalone install never trips host boot.
+Register slug → Eloquent model class mappings used by
+`/visual-editor/api/{resource}/{id}/content`. Filter contributions are
+merged with `config('artisanpack.visual-editor.resources')`; the static
+config wins on key collision so host-app overrides always take
+precedence. Models must use
+`ArtisanPackUI\VisualEditor\Concerns\HasBlockContent` — invalid entries
+surface as `InvalidArgumentException` on first request rather than at
+boot, so a contributor's standalone install never trips host boot.
 
 ```php
-addFilter( 'ap.visual-editor.resources', function ( array $resources ): array {
-    return array_merge( [
+addFilter('ap.visual-editor.resources', function (array $resources): array {
+    return array_merge([
         'posts' => App\Models\Post::class,
-    ], $resources );
-} );
+    ], $resources);
+});
 ```
 
-Full contract (input/output shape, collision behavior, validation guarantees, contributor timing): [`docs/plans/12-cms-framework-integration.md`](docs/plans/12-cms-framework-integration.md) §4.1.
+Full contract:
+[`docs/plans/12-cms-framework-integration.md`](docs/plans/12-cms-framework-integration.md) §4.1.
+
+### `ap.icons.register-icon-sets`
+
+Editor chrome icons resolve through `artisanpack-ui/icons`. Register
+additional icon sets in a service provider — see the
+[`artisanpack-ui/icons`](https://github.com/ArtisanPack-UI/icons) docs.
+
+---
 
 ## i18n
 
-Editor strings use `@wordpress/i18n` with the `artisanpack-visual-editor` text domain. The domain is initialized via `bootI18n()` in `resources/js/visual-editor/vendor/i18n.ts`.
+Editor strings use `@wordpress/i18n` with the `artisanpack-visual-editor`
+text domain. The domain is initialized via `bootI18n()` in
+`resources/js/visual-editor/vendor/i18n.ts`.
 
 Regenerate the placeholder `.pot` catalog with:
 
@@ -132,9 +270,15 @@ Regenerate the placeholder `.pot` catalog with:
 npm run i18n:extract
 ```
 
-The extractor scans `resources/js/visual-editor/**/*.{ts,tsx}` for `__/_x/_n/_nx` calls bound to the text domain and writes `languages/artisanpack-visual-editor.pot`. It is deliberately minimal — a richer extractor (template strings, plural forms, PHP scanning) replaces it post-V1.
+The extractor scans `resources/js/visual-editor/**/*.{ts,tsx}` for
+`__/_x/_n/_nx` calls bound to the text domain and writes
+`languages/artisanpack-visual-editor.pot`.
+
+---
 
 ## Contributing
 
-As an open source project, this package is open to contributions from anyone. Please [read through the contributing
-guidelines](CONTRIBUTING.md) to learn more about how you can contribute to this project.
+As an open source project, this package is open to contributions from
+anyone. Please [read through the contributing
+guidelines](CONTRIBUTING.md) to learn more about how you can contribute
+to this project.

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ one to re-verify against Gutenberg upgrades. See
 ## Block defaults
 
 V1 ships a frozen allow-list of forked blocks under the `artisanpack/*`
-namespace. The defaults in `config/visual-editor.php` expose every block
+namespace. The defaults in `config/artisanpack/visual-editor.php` expose every block
 that landed during the Phase I block fork — `@wordpress/block-library`'s
 `registerCoreBlocks()` is no longer called, and the editor registers
 only the in-package forks discovered under

--- a/docs/blade-component.md
+++ b/docs/blade-component.md
@@ -1,0 +1,124 @@
+# Blade component reference
+
+`<x-visual-editor />` is the single Blade entry point. It renders a
+`<div data-ap-visual-editor>` mount point with data-attributes that the
+React editor reads on boot.
+
+```blade
+<x-visual-editor
+    :model="$post"
+    :initialTitle="$post->title"
+    :initialSlug="$post->slug"
+    :initialStatus="$post->status"
+    :initialExcerpt="$post->excerpt"
+    :initialFeaturedImage="['id' => 12, 'url' => '/uploads/cover.jpg', 'alt' => 'Cover']"
+    :initialAuthorId="$post->author_id"
+    :initialCommentsOpen="$post->comments_open"
+    :authorOptions="$authors"
+    :supports="['excerpt' => true, 'featuredImage' => true, 'comments' => false]"
+    :previewUrl="route('posts.show', $post)"
+    resource="posts"
+/>
+```
+
+---
+
+## Attributes
+
+| Attribute | Type | Required | Default | Purpose |
+|-----------|------|----------|---------|---------|
+| `:model` | Eloquent `Model` | **yes** | — | The model being edited. Must use `HasBlockContent`. |
+| `resource` | `string` | no | reverse-looked-up from the resource map | The slug under which the model is registered. Provide explicitly if your config maps multiple slugs to the same class (or to override). |
+| `:apiBase` | `string` | no | `/visual-editor/api` | API root the editor talks to. Change if you've mounted the package routes under a custom prefix. |
+| `:initialTitle` | `?string` | no | `null` | Pre-fills the document-title field in the editor topbar. |
+| `:initialSlug` | `?string` | no | `null` | Pre-fills the slug field in the document panel. |
+| `:initialStatus` | `?string` | no | `null` | Pre-fills the status pill (`draft`, `published`, custom values). |
+| `:initialExcerpt` | `?string` | no | `null` | Pre-fills the excerpt field. Requires `supports.excerpt = true`. |
+| `:initialFeaturedImage` | `?array` | no | `null` | Pre-fills the featured-image picker. Shape: `['id' => int, 'url' => string, 'alt' => ?string]`. |
+| `:initialAuthorId` | `int\|string\|null` | no | `null` | Pre-selects the author. |
+| `:initialCommentsOpen` | `?bool` | no | `null` | Pre-fills the comments toggle. |
+| `:authorOptions` | `?array` | no | `null` | Dropdown options for the author picker. Shape: `[['value' => 1, 'label' => 'Jane'], …]`. |
+| `:supports` | `?array` | no | `null` | Which document-panel fields to render. Keys: `excerpt`, `featuredImage`, `comments` (all `bool`). Omit to show everything the trait supports. |
+| `:previewUrl` | `?string` | no | `null` | Front-end preview URL. Opens in a new tab from the topbar Preview button. |
+
+The component passes its `$attributes` bag through to the root div, so
+`class`, `id`, `style`, and `wire:ignore` are all forwarded.
+
+---
+
+## Resource resolution
+
+If you omit `resource`, the component reverse-looks-up the model class in
+`config('artisanpack.visual-editor.resources')` and uses the first
+matching slug. If the class isn't in the map, it throws
+`InvalidArgumentException` at render time so misconfiguration surfaces
+loudly.
+
+Always set `resource="…"` explicitly when:
+
+- The same model class is registered under multiple slugs.
+- You want render to fail fast at template time rather than at API time.
+- A future config change might add a sibling mapping.
+
+---
+
+## API surface used by the editor
+
+| Method | Path | When |
+|--------|------|------|
+| `GET` | `{apiBase}/{resource}/{id}/content` | On mount, fetches the persisted block tree. |
+| `PUT` | `{apiBase}/{resource}/{id}/content` | On autosave (debounced ~1s after the last change) and on explicit save (⌘S). |
+| `POST` | `{apiBase}/blocks/preview` | When a dynamic block requests an editor preview render. |
+| `POST` | `{apiBase}/query/resolve` | When a `core/query` block needs paginated results. |
+| `GET` | `{apiBase}/blocks` | Once on mount, to fetch the enabled-block manifest. |
+
+All routes run through the middleware stack in
+`config('artisanpack.visual-editor.api.middleware')` (default
+`['api', 'auth']`).
+
+---
+
+## Browser events
+
+The editor dispatches three `CustomEvent`s on `window`:
+
+| Event | When | `detail` shape |
+|-------|------|----------------|
+| `ve:editor:change` | Debounce window closes, right before autosave fires. | `{ resource, id, blocks }` |
+| `ve:editor:autosave` | Debounce-triggered save returns 200. | `{ resource, id, blocks, updatedAt }` |
+| `ve:editor:save` | Explicit save (⌘S or topbar) returns 200. | `{ resource, id, blocks, updatedAt }` |
+
+`resource` and `id` match the component's `data-resource` / `data-id`
+attributes, so a single listener can disambiguate multiple editors on the
+same page. See [Livewire](livewire.md) and [Inertia](inertia.md) for
+embedding recipes.
+
+---
+
+## Mounting multiple editors
+
+Each mount is a separate React root with its own store. There's no
+cross-talk between them — autosaves don't race, undo histories don't
+share. Use distinct DOM ids if you need to scroll to one programmatically.
+
+```blade
+@foreach ($posts as $post)
+    <x-visual-editor :model="$post" id="editor-{{ $post->id }}" />
+@endforeach
+```
+
+---
+
+## Theming and styling
+
+The root div gets `class="ap-visual-editor"` plus any classes you pass in
+via `$attributes`. Editor chrome is themed through DaisyUI tokens — see
+[Theming](theming.md) for how to override colors and typography.
+
+---
+
+## See also
+
+- [Content model](content-model.md) — `HasBlockContent`, resource map, policies
+- [Getting started](getting-started.md) — end-to-end install
+- [Livewire](livewire.md) / [Inertia](inertia.md) — embedding recipes

--- a/docs/blade-component.md
+++ b/docs/blade-component.md
@@ -51,7 +51,7 @@ The component passes its `$attributes` bag through to the root div, so
 If you omit `resource`, the component reverse-looks-up the model class in
 `config('artisanpack.visual-editor.resources')` and uses the first
 matching slug. If the class isn't in the map, it throws
-`InvalidArgumentException` at render time so misconfiguration surfaces
+`RuntimeException` at render time so misconfiguration surfaces
 loudly.
 
 Always set `resource="…"` explicitly when:

--- a/docs/content-model.md
+++ b/docs/content-model.md
@@ -111,10 +111,11 @@ app's published config is authoritative — packages can suggest a default,
 the app can override.
 
 **Validation timing:** the map is not validated at boot. The first
-request that resolves a missing resource or a model without
-`HasBlockContent` throws `InvalidArgumentException`. This is deliberate —
-contributor packages that aren't installed in a given environment never
-trip boot.
+request that resolves a missing resource raises `NotFoundHttpException`
+(returned to the client as 404); a model that's registered but doesn't
+use `HasBlockContent` raises `InvalidArgumentException`. This is
+deliberate — contributor packages that aren't installed in a given
+environment never trip boot.
 
 ### Resolution flow
 
@@ -134,8 +135,9 @@ Resource models use **their own Laravel policies**. The package does not
 inject a "visual editor policy" on top of them. If your `PostPolicy`
 already gates `update`, the editor's save endpoint inherits it.
 
-The controllers call `$this->authorize('update', $model)` (or
-`'view'` on the show endpoint) before reading/writing block content.
+The controllers call `Gate::authorize('update', $model)` (or
+`Gate::authorize('view', $model)` on the show endpoint) before
+reading/writing block content.
 
 ### Site-editor access gate
 

--- a/docs/content-model.md
+++ b/docs/content-model.md
@@ -1,0 +1,195 @@
+# Content model
+
+The visual editor stores content as a Gutenberg-shaped block tree (a JSON
+array of `{ name, attributes, innerBlocks, … }` nodes) on any Eloquent
+model that opts in via the `HasBlockContent` trait. Models are exposed to
+the editor through the **resource map**, a slug → model class registry
+read by the API layer.
+
+This page covers the trait, the resource map, and the policy / authorization
+surface.
+
+---
+
+## 1. The `HasBlockContent` trait
+
+`ArtisanPackUI\VisualEditor\Concerns\HasBlockContent`
+
+Add the trait to any model whose content should be editable:
+
+```php
+use ArtisanPackUI\VisualEditor\Concerns\HasBlockContent;
+use Illuminate\Database\Eloquent\Model;
+
+class Post extends Model
+{
+    use HasBlockContent;
+}
+```
+
+### Conventions and overrides
+
+| Behaviour | Default | Override |
+|-----------|---------|----------|
+| Column storing the block tree | `content` (JSON) | `protected string $blockContentColumn = 'body'` |
+| Query scope applied by the resource resolver | `forVisualEditor` (passthrough) | `protected string $blockContentScope = 'published'` (must exist on the model as a scope method) |
+| Cast for the block column | `array` (auto-applied if not present) | Set `$casts['content'] = 'json'` explicitly to opt out of the auto-cast |
+| Searchable text | Plain-text extract of the block tree | Override `blockContentSearchableText(): string` |
+
+The trait's `initializeHasBlockContent()` hook auto-applies the `array`
+cast at boot. If your model already casts the column, the trait leaves
+your cast untouched.
+
+### Public API
+
+```php
+$post->getBlockContent();          // array<int, array<string, mixed>>
+$post->setBlockContent($blocks);   // void
+$post->blockContentSearchableText(); // string
+$post->toBlockContentSearchableArray(); // ['block_content' => '…'] for Scout
+Post::query()->forVisualEditor()->get(); // optional content scope
+```
+
+The `forVisualEditor` scope is what the resource resolver applies before
+fetching by id. By default it's a passthrough — override
+`$blockContentScope` to filter by status, ownership, tenant, etc.
+
+### Migration
+
+Add the column when introducing the trait to an existing model:
+
+```php
+Schema::table('posts', function (Blueprint $table) {
+    $table->json('content')->nullable();
+});
+```
+
+The legacy `ve_contents` table the package ships is only used by the
+fallback `VisualEditorPost` model and the `/editor` test route. Host-app
+models never write to it.
+
+---
+
+## 2. The resource map
+
+The resource map is a slug → model class array consulted by every
+content-bearing API endpoint:
+
+```
+GET  /visual-editor/api/{resource}/{id}/content
+PUT  /visual-editor/api/{resource}/{id}/content
+```
+
+`{resource}` is the slug. The map is read from two places, merged at boot:
+
+1. **Static config** — `config('artisanpack.visual-editor.resources')`
+   in `config/artisanpack/visual-editor.php`.
+2. **Filter** — `ap.visual-editor.resources`, contributed by packages
+   like cms-framework.
+
+```php
+// config/artisanpack/visual-editor.php
+return [
+    'resources' => [
+        'posts' => App\Models\Post::class,
+        'pages' => App\Models\Page::class,
+    ],
+];
+```
+
+```php
+// From a package's service provider
+addFilter('ap.visual-editor.resources', function (array $resources): array {
+    return array_merge([
+        'posts' => MyPackage\Models\Post::class,
+    ], $resources);
+});
+```
+
+**Collision wins:** static config beats filter contributions. The host
+app's published config is authoritative — packages can suggest a default,
+the app can override.
+
+**Validation timing:** the map is not validated at boot. The first
+request that resolves a missing resource or a model without
+`HasBlockContent` throws `InvalidArgumentException`. This is deliberate —
+contributor packages that aren't installed in a given environment never
+trip boot.
+
+### Resolution flow
+
+1. Request comes in: `PUT /visual-editor/api/posts/42/content`.
+2. `ResourceResolver` looks up `posts` → `App\Models\Post`.
+3. It calls `Post::query()->forVisualEditor()->findOrFail(42)`.
+4. The controller calls `$post->setBlockContent($blocks)` and `$post->save()`.
+
+The model must use `HasBlockContent` — the resolver checks the trait
+explicitly and throws otherwise.
+
+---
+
+## 3. Policies and authorization
+
+Resource models use **their own Laravel policies**. The package does not
+inject a "visual editor policy" on top of them. If your `PostPolicy`
+already gates `update`, the editor's save endpoint inherits it.
+
+The controllers call `$this->authorize('update', $model)` (or
+`'view'` on the show endpoint) before reading/writing block content.
+
+### Site-editor access gate
+
+The site editor (templates, parts, patterns, global styles, navigation) is
+gated by a single boot-time contract:
+`ArtisanPackUI\VisualEditor\SiteEditor\Contracts\SiteEditorAccessGate`.
+
+Default implementation: `DenyByDefaultGate` — fail-closed. Bind your own
+to open it:
+
+```php
+// AppServiceProvider::register()
+$this->app->bind(
+    \ArtisanPackUI\VisualEditor\SiteEditor\Contracts\SiteEditorAccessGate::class,
+    \App\Auth\AllowAdminsGate::class,
+);
+```
+
+When cms-framework is installed it auto-binds `CmsFrameworkInstallGate`,
+which checks that cms-framework is installed and migrations have run
+before allowing access.
+
+### API middleware
+
+Every `/visual-editor/api/*` route runs through
+`config('artisanpack.visual-editor.api.middleware')` (default:
+`['api', 'auth']`). Replace the default if you need Sanctum, a different
+guard, or unauthenticated read access.
+
+---
+
+## 4. Multiple resources, one editor
+
+A single editor mount edits one resource at a time, scoped by the
+`data-resource` and `data-id` attributes that the Blade component emits.
+You can mount more than one editor on the same page — every editor event
+includes `{ resource, id }` in its `detail`, so listeners can
+disambiguate. See the [Livewire recipe](livewire.md) for an example of
+multiple editors coexisting.
+
+---
+
+## 5. The `ve_contents` fallback table
+
+The package's migration creates `ve_contents` (`id`, `author_id`, `title`,
+`blocks`, `timestamps`). It backs the `VisualEditorPost` model used by the
+default `/editor` route and a handful of tests. Production apps that
+register their own resource models can ignore the table — it stays empty
+and never grows.
+
+---
+
+## See also
+
+- [Blade component reference](blade-component.md) — attribute-by-attribute
+- [Custom blocks](custom-blocks.md) — extending what authors can insert
+- [Renderers](renderers.md) — getting saved content back onto the page

--- a/docs/custom-blocks.md
+++ b/docs/custom-blocks.md
@@ -234,11 +234,22 @@ Use a dynamic block when:
 abstract class DynamicBlock
 {
     abstract public function name(): string;
-    abstract public function render(array $attrs): View|Stringable|string;
+    abstract public function render(array $attrs); // : View|Stringable|string
 
-    public function validateAttrs(array $attrs): array;
-    public function searchableText(array $attrs): string;
-    public function authorize(?Authenticatable $user, array $attrs): bool;
+    public function validateAttrs(array $attrs): array
+    {
+        return $attrs;
+    }
+
+    public function searchableText(array $attrs): string
+    {
+        return '';
+    }
+
+    public function authorize(?Authenticatable $user, array $attrs): bool
+    {
+        return true;
+    }
 }
 ```
 

--- a/docs/custom-blocks.md
+++ b/docs/custom-blocks.md
@@ -225,6 +225,72 @@ Use a dynamic block when:
   render (latest posts, cart totals, stock levels).
 - The block needs to run Laravel authorization before exposing data.
 
+### Dynamic block hooks
+
+`DynamicBlock` exposes four overridable methods. Only `name()` and
+`render()` are required; the others have safe defaults.
+
+```php
+abstract class DynamicBlock
+{
+    abstract public function name(): string;
+    abstract public function render(array $attrs): View|Stringable|string;
+
+    public function validateAttrs(array $attrs): array;
+    public function searchableText(array $attrs): string;
+    public function authorize(?Authenticatable $user, array $attrs): bool;
+}
+```
+
+- **`validateAttrs(array $attrs): array`** — runs before `render()` and
+  before persistence. Normalize, coerce, and reject bad input. Throw
+  `InvalidArgumentException` to abort. Defaults to passthrough.
+
+  ```php
+  public function validateAttrs(array $attrs): array
+  {
+      $limit = filter_var($attrs['limit'] ?? 5, FILTER_VALIDATE_INT);
+      if ($limit === false || $limit < 1 || $limit > 50) {
+          throw new \InvalidArgumentException('limit must be 1–50');
+      }
+
+      return ['limit' => $limit];
+  }
+  ```
+
+- **`searchableText(array $attrs): string`** — plain-text extract used by
+  `HasBlockContent::blockContentSearchableText()` and the Scout searchable
+  array. Return whatever the block contributes to full-text search.
+  Defaults to empty string.
+
+  ```php
+  public function searchableText(array $attrs): string
+  {
+      return (string) ($attrs['heading'] ?? '');
+  }
+  ```
+
+- **`authorize(?Authenticatable $user, array $attrs): bool`** — gates
+  preview rendering during authoring. Return `false` to render an
+  authorization-denied placeholder instead of the block. Defaults to
+  `true`. Public-site renders go through the renderer package directly
+  and run the host app's own authorization.
+
+  ```php
+  public function authorize(?Authenticatable $user, array $attrs): bool
+  {
+      return $user?->can('view-internal-block') ?? false;
+  }
+  ```
+
+### Block preview endpoint
+
+While authoring, dynamic blocks render via
+`POST /visual-editor/api/blocks/preview`. The editor sends
+`{ blockName, attributes }`; the controller resolves the block, runs
+`validateAttrs` → `authorize` → `render`, and returns HTML. Cache misses
+during typing are amortized by the editor's per-block debounce.
+
 ---
 
 ## 5. Rendering on the public frontend

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,192 @@
+# Getting started
+
+Install the visual editor, register a model as editable content, mount the
+Blade component, and ship a first post — under an hour from `composer require`
+to working editor.
+
+If you also need site-wide chrome (templates, template parts, theme
+typography, menus, patterns) install `artisanpack-ui/cms-framework` alongside
+the editor. The two packages are a version pair (V1.x ↔ V1.x). See
+[Version compatibility](../README.md#version-compatibility).
+
+---
+
+## 1. Install
+
+```bash
+composer require artisanpack-ui/visual-editor
+php artisan migrate
+```
+
+The package ships a `ve_contents` table for the legacy `VisualEditorPost`
+fallback model. Host-app resource models you register later don't touch this
+table — they store block content on their own.
+
+### Peer dependencies
+
+The editor UI is built on [`@artisanpack-ui/react`](https://www.npmjs.com/package/@artisanpack-ui/react),
+which is styled with DaisyUI + Tailwind CSS v4. Host apps must have:
+
+- `tailwindcss` `^4.0.0`
+- `daisyui` `^5.0.0`
+
+Both are loaded once at the app shell level. The editor inherits them from
+the host page.
+
+### Pair with cms-framework (recommended)
+
+```bash
+composer require artisanpack-ui/cms-framework
+php artisan migrate
+```
+
+Adds a `block_content` column to cms-framework's `posts` and `pages` tables,
+seeds `visual_editor.*` permissions, and auto-registers
+`Post`/`Page` into the resource map. The site editor's install gate goes
+green and the `core/post-*`, `core/site-*`, `core/query`, taxonomy, and
+navigation blocks all resolve.
+
+You can skip this step — the editor works standalone for a single resource
+model — but you'll have to wire entity blocks yourself.
+
+---
+
+## 2. Publish the config (optional)
+
+```bash
+php artisan vendor:publish --tag=artisanpack-visual-editor-config
+```
+
+Drops `config/artisanpack/visual-editor.php`. Edit it to register
+resources, swap the API middleware, tune the block allow/deny lists, or
+change global-styles theme/schema pinning. See [Blade component reference](blade-component.md)
+and [Custom blocks](custom-blocks.md) for what each key does.
+
+---
+
+## 3. Register a resource model
+
+A "resource" is any Eloquent model whose content is editable via the visual
+editor. Add the `HasBlockContent` trait and declare it in the config:
+
+```php
+// app/Models/Post.php
+namespace App\Models;
+
+use ArtisanPackUI\VisualEditor\Concerns\HasBlockContent;
+use Illuminate\Database\Eloquent\Model;
+
+class Post extends Model
+{
+    use HasBlockContent;
+
+    protected $fillable = ['title', 'slug', 'content'];
+}
+```
+
+```php
+// config/artisanpack/visual-editor.php
+return [
+    'resources' => [
+        'posts' => App\Models\Post::class,
+    ],
+    // …
+];
+```
+
+The trait adds a `content` JSON column convention, a Scout-friendly
+searchable accessor, and the `forVisualEditor` query scope used by the
+resource resolver. Full reference: [Content model](content-model.md).
+
+If your model already has a different column for block content:
+
+```php
+class Post extends Model
+{
+    use HasBlockContent;
+
+    protected $blockContentColumn = 'body';
+}
+```
+
+Run the migration that adds the column:
+
+```bash
+php artisan make:migration add_content_to_posts_table
+```
+
+```php
+Schema::table('posts', function (Blueprint $table) {
+    $table->json('content')->nullable();
+});
+```
+
+---
+
+## 4. Mount the editor
+
+In whatever Blade view backs your edit screen:
+
+```blade
+{{-- resources/views/admin/posts/edit.blade.php --}}
+<x-visual-editor
+    :model="$post"
+    :initialTitle="$post->title"
+    :initialSlug="$post->slug"
+    :initialStatus="$post->status"
+/>
+```
+
+The Blade component emits a single `<div data-ap-visual-editor>` mount
+point. The React app boots against it on page load, fetches block content
+from `/visual-editor/api/posts/{id}/content`, and autosaves on every change.
+
+Full attribute list and event contract: [Blade component reference](blade-component.md).
+
+---
+
+## 5. Build assets
+
+The editor JS bundle is registered automatically by the package's Vite
+plugin. From your app:
+
+```bash
+npm install
+npm run build   # or: npm run dev
+```
+
+The editor mounts on every page that contains a `[data-ap-visual-editor]`
+element.
+
+---
+
+## 6. Try it
+
+1. Run `php artisan serve` (or `composer run dev` in this dev app).
+2. Visit the edit screen.
+3. Insert a Paragraph block, type, watch the autosave indicator fire.
+4. Reload — content persists.
+
+If the editor doesn't appear, check the browser console for missing peer
+deps (Tailwind / DaisyUI) and confirm the resource is registered. See
+[Troubleshooting](troubleshooting.md).
+
+---
+
+## 7. Add the site editor (optional)
+
+If cms-framework is installed, the site editor shell is already mounted at
+`/visual-editor/site`. The default access gate fails closed — implement
+your own `SiteEditorAccessGate` or rely on cms-framework's
+`CmsFrameworkInstallGate`. See [Site editor](site-editor.md).
+
+---
+
+## Where to go next
+
+- **Authoring custom blocks:** [Custom blocks](custom-blocks.md)
+- **Rendering saved content on the public site:** [Renderers](renderers.md)
+- **Editing templates and theme styles:** [Site editor](site-editor.md), [Templates](templates.md), [Global styles](global-styles.md)
+- **Embedding inside Livewire:** [Livewire](livewire.md)
+- **Embedding inside Inertia:** [Inertia](inertia.md)
+- **Things that go wrong:** [Troubleshooting](troubleshooting.md)

--- a/docs/global-styles.md
+++ b/docs/global-styles.md
@@ -1,30 +1,38 @@
-# Global styles — theme.json schema pin
+# Global styles
 
-The visual editor's `globalStyles` singleton is the theme.json-shaped
-record the site editor reads and writes. C3 (#359) introduces the
-backend: a `VisualEditorGlobalStyles` model, migration, REST endpoints,
-validated write path, and policy. This document records the **schema
-version we pin the package to**, the constraints that follow from that
-decision, and how a future version bump is handled.
+The visual editor's global styles are the theme.json-shaped record the
+site editor reads and writes to drive site-wide typography, color,
+layout, and per-block style overrides. One record per theme, accessed as
+a singleton, validated against a pinned schema version, emitted to CSS at
+render time.
 
-## Pinned version
+This page covers the schema pin, record shape, REST surface, validation,
+the site-editor styles panels, CSS emission, and how a future schema bump
+is handled.
+
+---
+
+## 1. Pinned schema version
 
 The package pins to **theme.json schema version 3**. The value lives in
 config at `artisanpack.visual-editor.global_styles.schema_version` (not
-as a hard-coded constant in code) so host apps can override if they
-know what they are doing; the default is what the package is tested
-against.
+as a hard-coded constant) so host apps can override if they know what
+they're doing — the default is what the package is tested against.
 
 The pin tracks the `@wordpress/*` packages vendored into the editor
-bundle (see `package.json` — `@wordpress/block-editor`,
-`@wordpress/block-library`, `@wordpress/components`, etc.). These
-packages target a specific WordPress core release series; the
-corresponding theme.json schema version is the one the package treats
-as "compatible". Updating the pinned `@wordpress/*` versions without a
-conscious theme.json review is what §4.2 of the V1 plan calls out as
-silent drift — the pin is here to force the review.
+bundle (`@wordpress/block-editor`, `@wordpress/blocks`,
+`@wordpress/components`). Those packages target a specific WordPress
+core release; the corresponding theme.json schema version is what the
+package treats as compatible. Updating the pinned `@wordpress/*` versions
+without a conscious theme.json review is the silent drift the V1 plan
+explicitly calls out — the pin is here to force the review.
 
-## Record shape
+See [Troubleshooting §3](troubleshooting.md#3-wordpress-package-upgrades)
+for the schema-bump procedure.
+
+---
+
+## 2. Record shape
 
 The record stores a theme.json-shaped blob:
 
@@ -32,69 +40,137 @@ The record stores a theme.json-shaped blob:
 {
   "id": 7,
   "version": 3,
+  "theme": "artisanpack-base",
   "settings": {
-    "color":      { "palette": [ /* { slug, name, color } */ ] },
+    "color":      { "palette": [ { "slug": "primary", "name": "Primary", "color": "#3b82f6" } ] },
     "typography": {
-      "fontFamilies": [ /* { slug, name, fontFamily } */ ],
-      "fontSizes":    [ /* { slug, name, size } */ ]
+      "fontFamilies": [ { "slug": "sans", "name": "Sans", "fontFamily": "Inter, system-ui, sans-serif" } ],
+      "fontSizes":    [ { "slug": "base", "name": "Base", "size": "1rem" } ]
     },
-    "layout":     { "contentSize": "720px", "wideSize": "1120px" }
+    "layout":     { "contentSize": "720px", "wideSize": "1120px" },
+    "spacing":    { "spacingScale": { "operator": "*", "increment": 1.5, "steps": 7 } }
   },
   "styles": {
     "color":      { "background": "...", "text": "..." },
     "typography": { "fontFamily": "...", "fontSize": "...", "lineHeight": "..." },
     "elements":   { "link": { /* ... */ }, "heading": { /* ... */ } },
-    "blocks":     { "core/button": { /* ... */ } }
+    "blocks":     { "artisanpack/button": { /* ... */ } }
   }
 }
 ```
 
-The full reference payload lives at
-`resources/theme-json/default-base.php` and is returned by
-`GET /visual-editor/api/global-styles/base`.
+The packaged defaults live at `resources/theme-json/default-base.php` and
+are returned by `GET /visual-editor/api/global-styles/base`. Host apps
+override defaults by setting
+`artisanpack.visual-editor.global_styles.base_path` to a custom PHP file
+that returns the same shape.
 
-## Endpoints
+---
 
-See `docs/core-data-shim.md` §Global styles for the REST contract the
-core-data shim addresses. C3 ships four endpoints:
+## 3. REST API
 
-- `GET /visual-editor/api/global-styles/lookup` — resolves the active
-  theme's singleton id (creating the row on first access).
-- `GET /visual-editor/api/global-styles/{id}` — user record.
-- `PUT /visual-editor/api/global-styles/{id}` — write user record;
-  validated against the pinned schema version.
-- `GET /visual-editor/api/global-styles/base` — theme defaults; the
-  site-editor diffs the user record against this to show what has been
-  customized.
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/visual-editor/api/global-styles/lookup` | Resolve the active theme's singleton id (creates the record on first access). |
+| `GET` | `/visual-editor/api/global-styles/base` | Theme defaults — the site editor diffs the user record against this to show what's been customized. |
+| `GET` | `/visual-editor/api/global-styles/{id}` | Fetch the user record. |
+| `PUT` | `/visual-editor/api/global-styles/{id}` | Update the user record. Validated against the pinned schema version. |
+| `GET` | `/visual-editor/api/global-styles/css` | Emit the user record as CSS for front-end injection. |
 
-## Validation
+All endpoints behind the API middleware stack.
+
+---
+
+## 4. Validation
 
 `PUT` requests flow through
-`ArtisanPackUI\VisualEditor\Http\Requests\UpdateGlobalStylesRequest` which
-enforces:
+`ArtisanPackUI\VisualEditor\Http\Requests\UpdateGlobalStylesRequest`,
+which enforces:
 
 - `version` must equal the pinned `schema_version` — a schema bump is
-  explicit work, not a client-driven drift.
+  explicit work, not client-driven drift.
 - `settings` and `styles` are required arrays.
-- `settings.color.palette` entries must each carry `slug`, `name`,
-  `color`; slugs must be unique across the palette (duplicate slugs
-  collapse to a single CSS variable, masking a real bug).
+- `settings.color.palette` entries each carry `slug`, `name`, `color`;
+  slugs must be unique across the palette (duplicate slugs collapse to a
+  single CSS variable, masking a real bug).
 - `settings.typography.fontFamilies` and `settings.typography.fontSizes`
   likewise require unique slugs.
+- Per-block styles under `styles.blocks.{block}` must reference a
+  registered block name.
 
-A 422 response with a `version`, `settings`, or
-`settings.color.palette` validation error is the signal that the
-payload does not match the pinned schema.
+A 422 response with `version`, `settings`, or `settings.color.palette`
+validation errors is the signal that the payload doesn't match the
+pinned schema.
 
-## Multi-theme scoping
+---
 
-The record carries a `theme` column so each installed theme gets its
-own singleton. The active theme is configured at
+## 5. Multi-theme scoping
+
+The record carries a `theme` column so each installed theme gets its own
+singleton. The active theme is configured at
 `artisanpack.visual-editor.global_styles.theme` (default
-`artisanpack-base`). Switching themes gets a fresh singleton rather
+`artisanpack-base`). Switching themes loads a fresh singleton rather
 than inheriting the previous theme's customizations.
 
-## Handling a future schema bump
+---
+
+## 6. Site-editor styles panels
+
+The site editor's Styles section exposes four nested panels:
+
+- **Typography** — font families, font sizes, base type styles
+  (`styles.typography`), element overrides (heading, link).
+- **Colors** — palette, background, text, link.
+- **Layout** — content width, wide width, root padding, spacing scale.
+- **Blocks** — per-block style overrides (`styles.blocks.{block}`),
+  organized alphabetically by block name.
+
+Each panel is a controlled form over a slice of the record; saves are
+debounced and write the full record via PUT.
+
+A "Reset to theme default" button at the panel level (and per-field
+chevrons) deletes the user value for that key, restoring whatever
+`/global-styles/base` returns.
+
+---
+
+## 7. CSS emission
+
+`GET /visual-editor/api/global-styles/css` returns a stylesheet derived
+from the user record. The Blade renderer's `<x-ve-blocks>` and React/Vue
+`<GlobalStyles>` components inject it once at the root.
+
+Generated CSS shape:
+
+```css
+:root {
+    --wp--preset--color--primary: #3b82f6;
+    --wp--preset--font-size--base: 1rem;
+    --wp--preset--font-family--sans: Inter, system-ui, sans-serif;
+}
+
+body {
+    color: var(--wp--preset--color--text);
+    background-color: var(--wp--preset--color--background);
+    font-family: var(--wp--preset--font-family--sans);
+}
+
+.is-style-h1, h1.wp-block-heading {
+    font-size: var(--wp--preset--font-size--xxx-large);
+}
+
+.wp-block-button {
+    /* per-block styles emitted from styles.blocks['artisanpack/button'] */
+}
+```
+
+CSS variables follow the `--wp--preset--{category}--{slug}` convention
+so existing Gutenberg block markup using `var(--wp--preset--*)` resolves
+without modification.
+
+---
+
+## 8. Handling a future schema bump
 
 When the `@wordpress/*` pins are upgraded and the upstream theme.json
 schema changes:
@@ -107,21 +183,20 @@ schema changes:
 3. Update `resources/theme-json/default-base.php` so the defaults match
    the new schema.
 4. Ship a migration that either rewrites existing user records into the
-   new schema shape or documents an upgrade path for host apps that
-   have customized their global styles.
+   new schema shape or documents an upgrade path for host apps that have
+   customized their global styles.
 5. Update this doc with the new pinned version and the WP core release
    it tracks.
 
-The point of the pin is that each of these steps is a conscious
-decision — not a silent change that happens the next time `composer
-update` or `npm update` runs.
+The point of the pin is that each of these steps is a conscious decision
+— not a silent change that happens the next time `composer update` or
+`npm update` runs.
 
-## Out of scope for C3
+---
 
-- CSS emission / frontend rendering — **E1** (front-end global-styles
-  CSS emission).
-- Site-editor global-styles UI (typography, colors, layout, blocks,
-  variations) — **D3**.
-- Style variations (theme-level presets) — deferred; §8 of the plan doc
-  tracks this as an open question for 1.1.
-- Revision history of global-styles edits.
+## See also
+
+- [Site editor](site-editor.md) — the surface that edits global styles
+- [Templates](templates.md) — templates that the styles apply to
+- [Renderers](renderers.md) — CSS injection on the public site
+- [Troubleshooting](troubleshooting.md) — schema-bump procedure

--- a/docs/inertia.md
+++ b/docs/inertia.md
@@ -103,9 +103,20 @@ unmount.
 To preserve unsaved edits during programmatic navigation, gate
 `Inertia.visit()` on the editor's `getBlocks()` returning a clean state:
 
+Inside the `useEffect`, hold the editor handle in a ref so it survives
+between renders:
+
 ```tsx
+const editorRef = useRef<ReturnType<typeof mountVisualEditor>>();
+
+useEffect(() => {
+    if (!mountRef.current) return;
+    editorRef.current = mountVisualEditor(mountRef.current, { /* …config */ });
+    return () => editorRef.current?.unmount();
+}, [post.id]);
+
 const handleNavigate = (href: string) => {
-    if (editor.current?.isDirty()) {
+    if (editorRef.current?.isDirty()) {
         if (!confirm('You have unsaved changes. Leave?')) return;
     }
     Inertia.visit(href);
@@ -145,6 +156,10 @@ defineProps<{
 
 const onSave = (detail) => {
     // Sync Inertia state, show toast, etc.
+};
+
+const onChange = (detail) => {
+    // Edits in-flight — mark dirty, defer navigation, etc.
 };
 </script>
 

--- a/docs/inertia.md
+++ b/docs/inertia.md
@@ -1,0 +1,241 @@
+# Inertia embedding recipes
+
+The visual editor is a React app under the hood, so embedding inside
+Inertia is just a matter of mounting the Blade component on the Inertia
+page and letting the React tree boot inside it. The same recipe works
+inside Inertia + React (direct) and Inertia + Vue (via the Vue wrapper).
+
+Both recipes assume the editor is being mounted inside an Inertia page
+that the host app owns — the host controls auth, navigation, and
+non-editor chrome; the editor takes over the canvas region.
+
+---
+
+## 1. Inertia + React
+
+The Blade `<x-visual-editor />` mount works inside an Inertia-rendered
+template because Inertia hydrates inside an outer Blade layout. Mount the
+editor as a top-level page or inside a content slot, and import the
+editor's React bundle from the host's entrypoint.
+
+### Server-side: the Inertia page
+
+```php
+// app/Http/Controllers/PostEditorController.php
+public function edit(Post $post)
+{
+    return Inertia::render('Posts/Edit', [
+        'post' => [
+            'id'             => $post->id,
+            'title'          => $post->title,
+            'slug'           => $post->slug,
+            'status'         => $post->status,
+            'previewUrl'     => route('posts.show', $post),
+        ],
+    ]);
+}
+```
+
+### Client-side: the React page
+
+```tsx
+// resources/js/Pages/Posts/Edit.tsx
+import { useEffect, useRef } from 'react';
+import { mountVisualEditor } from '@artisanpack-ui/visual-editor';
+
+export default function PostEditor({ post }) {
+    const mountRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        if (!mountRef.current) return;
+
+        const editor = mountVisualEditor(mountRef.current, {
+            resource: 'posts',
+            id: String(post.id),
+            apiBase: '/visual-editor/api',
+            initialTitle: post.title,
+            initialSlug: post.slug,
+            initialStatus: post.status,
+            previewUrl: post.previewUrl,
+            supports: { excerpt: true, featuredImage: true },
+        });
+
+        return () => editor.unmount();
+    }, [post.id]);
+
+    return (
+        <Layout>
+            <div ref={mountRef} className="ap-visual-editor" />
+        </Layout>
+    );
+}
+```
+
+The `mountVisualEditor(el, config)` helper is the imperative equivalent
+of the Blade component — pass the same config keys (camelCase). It returns
+an `{ unmount, save, getBlocks }` handle.
+
+### Bridging editor events
+
+The same `ve:editor:*` events the Blade component dispatches fire here.
+Listen in the page component:
+
+```tsx
+useEffect(() => {
+    const onSave = (event: CustomEvent) => {
+        if (event.detail.resource !== 'posts') return;
+        if (event.detail.id !== String(post.id)) return;
+        // Sync Inertia state, show toast, etc.
+    };
+
+    window.addEventListener('ve:editor:save', onSave as EventListener);
+    return () => window.removeEventListener('ve:editor:save', onSave as EventListener);
+}, [post.id]);
+```
+
+### Inertia navigation and `wire:ignore`-equivalent
+
+Inertia doesn't have `wire:ignore` — when navigating between Inertia
+pages, the React tree unmounts entirely. The cleanup function in the
+`useEffect` handles this; the editor's autosave debounce flushes before
+unmount.
+
+To preserve unsaved edits during programmatic navigation, gate
+`Inertia.visit()` on the editor's `getBlocks()` returning a clean state:
+
+```tsx
+const handleNavigate = (href: string) => {
+    if (editor.current?.isDirty()) {
+        if (!confirm('You have unsaved changes. Leave?')) return;
+    }
+    Inertia.visit(href);
+};
+```
+
+---
+
+## 2. Inertia + Vue
+
+The Vue wrapper at `@artisanpack-ui/visual-editor/vue` exports a
+`<VisualEditor>` Vue component that wraps the React editor in a Vue tree
+(the editor itself stays React; Vue manages mount/unmount + prop
+reactivity).
+
+### Server-side: same Inertia page
+
+The controller is identical to the React recipe — Inertia doesn't care
+which client renderer the page uses.
+
+### Client-side: the Vue page
+
+```vue
+<!-- resources/js/Pages/Posts/Edit.vue -->
+<script setup lang="ts">
+import { VisualEditor } from '@artisanpack-ui/visual-editor/vue';
+
+defineProps<{
+    post: {
+        id: number;
+        title: string;
+        slug: string;
+        status: string;
+        previewUrl: string;
+    };
+}>();
+
+const onSave = (detail) => {
+    // Sync Inertia state, show toast, etc.
+};
+</script>
+
+<template>
+    <Layout>
+        <VisualEditor
+            resource="posts"
+            :id="String(post.id)"
+            :initial-title="post.title"
+            :initial-slug="post.slug"
+            :initial-status="post.status"
+            :preview-url="post.previewUrl"
+            :supports="{ excerpt: true, featuredImage: true }"
+            @save="onSave"
+            @autosave="onSave"
+            @change="onChange"
+        />
+    </Layout>
+</template>
+```
+
+The Vue component re-emits `ve:editor:*` browser events as Vue
+component events (`save`, `autosave`, `change`) so you can wire them
+declaratively.
+
+### Vue → React data flow
+
+Props on `<VisualEditor>` map 1:1 to the React editor's config. Changing
+a prop after mount re-renders the React tree with the new config — but
+the editor doesn't reload content on a re-render. Change `:id` or
+`:resource` and the editor will detect it and fetch the new entity.
+
+---
+
+## 3. Front-end rendering
+
+The Inertia + React / Inertia + Vue recipes above are for the **edit
+surface**. Rendering saved content on the public site uses the renderer
+packages:
+
+- React: `@artisanpack-ui/visual-editor-renderer-react`
+- Vue: `@artisanpack-ui/visual-editor-renderer-vue`
+
+```tsx
+// resources/js/Pages/Posts/Show.tsx
+import { BlockTree, GlobalStyles } from '@artisanpack-ui/visual-editor-renderer-react';
+
+export default function PostShow({ post }) {
+    return (
+        <>
+            <GlobalStyles />
+            <BlockTree tree={post.blocks} />
+        </>
+    );
+}
+```
+
+See [Renderers](renderers.md) for the full client renderer API.
+
+---
+
+## 4. SSR
+
+The editor itself is client-only (it relies on `window` and DOM APIs).
+Inertia SSR will skip the editor's render pass — wrap the mount in a
+`<ClientOnly>` (Inertia + Vue) or guard the `useEffect` (Inertia + React)
+so server rendering produces an empty mount point.
+
+Front-end **renderers** work in SSR — the React renderer renders to
+static HTML, the Vue renderer renders to static markup. Use the Blade
+renderer when you want SSR via Laravel itself (Inertia or not).
+
+---
+
+## 5. Authentication
+
+The editor's API calls inherit the host page's session cookies — no
+extra wiring needed when Inertia uses the standard `web` middleware. For
+Sanctum / API-token auth, override the API middleware:
+
+```php
+// config/artisanpack/visual-editor.php
+'api' => [
+    'middleware' => ['api', 'auth:sanctum'],
+],
+```
+
+---
+
+## See also
+
+- [Blade component reference](blade-component.md) — the underlying mount contract
+- [Renderers](renderers.md) — public-site rendering
+- [Livewire](livewire.md) — alternative embedding inside a server-rendered Blade page

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,0 +1,148 @@
+# Migration
+
+Migrating content **from WordPress into the visual editor** is handled
+by a companion package, not by `visual-editor` itself. This page
+explains why, what the companion does, and what the in-package
+migrations cover.
+
+---
+
+## 1. WordPress import — companion package
+
+**Package:** `artisanpack-ui/visual-editor-wp-import`
+**Status:** Planned. Ships separately on its own release cadence;
+first version targets after V1.0.0 of `visual-editor`.
+
+The companion handles the one-way migration from a WordPress export
+(WXR or direct database connection) into your Laravel app:
+
+- Maps WP `posts`, `pages`, `wp_template`, `wp_template_part`,
+  `wp_navigation`, `wp_block` (patterns), and `wp_global_styles` into
+  the corresponding Laravel models.
+- Rewrites `core/*` block names to `artisanpack/*` using the same
+  transform table the block forks ship (`from:core/*` in each block.json).
+- Resolves attachment URLs to media library records.
+- Resolves user references to local user records by email or username.
+- Optionally preserves WP post ids, slugs, dates, and meta.
+
+Reasons it lives in its own package:
+
+- Importer dependencies (WP XML parsers, HTTP clients for remote media,
+  optional MySQL drivers) are heavy and only needed once.
+- Import is a one-off operation — bundling it into the runtime package
+  bloats every install.
+- Importer release cycle is faster than the editor's; a bug in the
+  importer shouldn't force a `visual-editor` patch release.
+
+When the companion is published, this page will link to its own
+documentation. Until then, manual migration is the path: export WP
+content, transform locally, seed via Laravel.
+
+---
+
+## 2. In-package migrations
+
+`visual-editor` ships these migrations under `database/migrations/`:
+
+| Migration | Purpose |
+|-----------|---------|
+| `2026_04_14_000000_create_ve_contents_table.php` | Creates the `ve_contents` fallback table used by the legacy `VisualEditorPost` model and the `/editor` test route. Host-app resource models don't touch this table. |
+| `2026_05_15_000000_drop_legacy_visual_editor_tables.php` | Drops the Phase D legacy tables (`visual_editor_templates`, `_template_parts`, `_global_styles`, `_navigations`, `_patterns`, `_pattern_categories`, and the pivot). Idempotent — safe on fresh installs. |
+
+cms-framework provides the actual storage tables for templates, parts,
+patterns, global styles, and menus. Install cms-framework and run
+`php artisan migrate` and the site-editor REST surface is backed by real
+tables.
+
+---
+
+## 3. Upgrading existing host-app models
+
+Adding `HasBlockContent` to an existing model requires a column:
+
+```php
+Schema::table('posts', function (Blueprint $table) {
+    $table->json('content')->nullable();
+});
+```
+
+Set `$blockContentColumn` on the model if the column name is something
+other than `content`.
+
+For models that already store HTML or Markdown in a different column,
+keep both: the legacy column remains the source of truth until you've
+backfilled the block-content column from it, then deprecate the
+legacy column. cms-framework follows this pattern — its `posts` and
+`pages` tables retain a `content longText` column alongside the new
+`block_content json` column. See plan-12 §4.2.
+
+---
+
+## 4. Upgrading from `v1.0.0-alpha.1`
+
+If you installed `v1.0.0-alpha.1` (the Gutenberg-adoption marker), the
+upgrade path to `v1.0.0` is:
+
+1. `composer update artisanpack-ui/visual-editor`.
+2. `php artisan migrate` to apply the legacy-table drop.
+3. `npm install` then `npm run build` to pick up the new editor bundle.
+4. Review the [CHANGELOG](../CHANGELOG.md) for breaking changes —
+   notable: all `core/*` blocks are now `artisanpack/*` via the
+   Phase I block fork; pasted upstream `core/*` markup auto-converts on
+   insert via the `from:core/*` transforms shipped on every fork.
+
+Existing post content saved against `v1.0.0-alpha.1`'s `core/*` blocks
+re-renders correctly — the renderers recognize both namespaces during
+V1. From V2 onwards, only `artisanpack/*` is registered for new content;
+old `core/*` content continues to render via the transform table.
+
+---
+
+## 5. Upgrading from a future version
+
+`visual-editor` follows semver:
+
+- Patch releases (`v1.0.x`) — bug fixes, no API changes.
+- Minor releases (`v1.x.0`) — new features, backwards-compatible.
+- Major releases (`v2.0.0`) — breaking changes, documented migration
+  path in that release's CHANGELOG.
+
+Each major release ships a `docs/upgrade-{from}-to-{to}.md` doc
+covering the breaking changes and required migration steps.
+
+---
+
+## 6. Manual content migration
+
+If `visual-editor-wp-import` isn't an option (custom CMS source,
+hand-crafted content), the manual path is:
+
+1. **Export source content** — get the source HTML/JSON into a
+   transformable shape.
+2. **Map to block trees** — write a transformer that produces
+   Gutenberg-shape block JSON:
+
+   ```php
+   [
+       [
+           'name'         => 'artisanpack/paragraph',
+           'attributes'   => ['content' => $htmlParagraph],
+           'innerBlocks'  => [],
+       ],
+       // …
+   ];
+   ```
+
+3. **Seed via Laravel** — set the block tree on each model via
+   `$model->setBlockContent($blocks)` and save.
+
+The block content column is plain JSON; you can backfill via a
+database seeder, an artisan command, or a one-off migration script.
+
+---
+
+## See also
+
+- [Getting started](getting-started.md)
+- [Content model](content-model.md) — `HasBlockContent`, resource map
+- [`visual-editor-wp-import` repo](https://github.com/ArtisanPack-UI/visual-editor-wp-import) (when published)

--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -1,0 +1,200 @@
+# Navigation
+
+Navigation menus are editable through the site editor's Navigation
+section, persisted by cms-framework's `Menu` model, exposed via REST,
+and rendered on the public site through the `core/navigation` block.
+
+This page covers menu locations, the fallback chain, the `core/navigation`
+block, REST endpoints, and the nav editor UI.
+
+---
+
+## 1. Concepts
+
+- **Menu** — a named, ordered tree of links. Persisted in cms-framework's
+  `menus` table. Can be assigned to one or more **menu locations**.
+- **Menu item** — a single link inside a menu. Persisted in `menu_items`
+  (id, menu_id, parent_id, title, url, type, object, position).
+- **Menu location** — a theme-declared slot (e.g. `primary`, `footer`,
+  `mobile`). The theme decides what locations exist; the site editor
+  assigns menus to them.
+- **`core/navigation` block** — renders a menu by id or by location with
+  a fallback chain.
+
+---
+
+## 2. Menu locations
+
+Locations are declared in config:
+
+```php
+// config/artisanpack/visual-editor.php
+'site-editor' => [
+    'navigation' => [
+        'locations' => [
+            'primary' => ['title' => 'Primary Menu'],
+            'footer'  => ['title' => 'Footer Menu'],
+            'mobile'  => ['title' => 'Mobile Menu'],
+        ],
+    ],
+],
+```
+
+The site editor lists declared locations in the Navigation section and
+lets authors assign any menu to any location.
+
+Locations are read-only via REST — `GET /visual-editor/api/menu-locations`
+returns the declared list; menu → location assignment is written via the
+menu's `location` field on `PUT /menus/{id}`.
+
+---
+
+## 3. Fallback chain
+
+When a `core/navigation` block renders, the resolver walks this chain:
+
+1. **Explicit menu id** on the block attributes — `{ menuId: 7 }`.
+2. **Menu assigned to the requested location** — `{ location: 'primary' }`
+   resolves to whatever menu currently holds `location = 'primary'`.
+3. **Fallback menu** — declared in config as the location's `fallback`
+   key:
+
+   ```php
+   'locations' => [
+       'primary' => [
+           'title'    => 'Primary Menu',
+           'fallback' => 'auto',  // 'auto' | 'first' | menu-slug | null
+       ],
+   ],
+   ```
+
+   - `'auto'` — auto-generate from top-level pages (the WordPress
+     default behaviour).
+   - `'first'` — the first menu by created_at.
+   - `'menu-slug'` — a specific menu's slug.
+   - `null` — render nothing.
+
+4. **Empty render** — emits a wrapping `<nav>` with no items.
+
+---
+
+## 4. `core/navigation` block
+
+Attributes:
+
+| Attribute | Type | Purpose |
+|-----------|------|---------|
+| `menuId` | number | Explicit menu id; wins over location. |
+| `location` | string | Menu-location slug. |
+| `ref` | number | Pattern reference id for synced nav patterns. |
+| `overlayMenu` | string | `'always'` \| `'mobile'` \| `'never'`. |
+| `openSubmenusOnClick` | boolean | Click vs hover for submenus. |
+| `showSubmenuIcon` | boolean | Render the chevron icon. |
+| `textColor` / `backgroundColor` | string | Color presets. |
+
+The block stores no inner blocks — the items come from the resolved
+menu at render time. Editing the menu in the site editor updates every
+page using this block.
+
+---
+
+## 5. The nav editor UI
+
+The Navigation section of the site editor has two view modes:
+
+- **List view** — flat list of all menus with their locations. Click a
+  menu to edit.
+- **Tree view** — drag-and-drop reorderable tree of items inside a menu.
+  Add items via the inserter (page, post, custom URL, taxonomy term).
+
+The link-control picker (used when adding items) hits
+`GET /visual-editor/api/search` to find pages, posts, and template parts
+across the resource map.
+
+Submenus are nested by indenting items under a parent. Drag an item one
+level right to make it a child of the item above it.
+
+---
+
+## 6. REST API
+
+### Menus
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/visual-editor/api/menus` | List menus (optionally filter by `?location=...`). |
+| `POST` | `/visual-editor/api/menus` | Create a menu. |
+| `GET` | `/visual-editor/api/menus/{id}` | Fetch a menu with its items. |
+| `PUT` | `/visual-editor/api/menus/{id}` | Update menu name, location. |
+| `DELETE` | `/visual-editor/api/menus/{id}` | Delete a menu (cascades to items). |
+
+### Menu items
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/visual-editor/api/menu-items?menu_id={id}` | List items in a menu. |
+| `POST` | `/visual-editor/api/menu-items` | Create an item (requires `menu_id`). |
+| `GET` | `/visual-editor/api/menu-items/{id}` | Fetch an item. |
+| `PUT` | `/visual-editor/api/menu-items/{id}` | Update title, url, position, parent. |
+| `DELETE` | `/visual-editor/api/menu-items/{id}` | Delete an item (cascades to children). |
+
+### Locations
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/visual-editor/api/menu-locations` | List declared locations (read-only). |
+
+The endpoint shape mirrors `wp_navigation` from the WordPress REST API
+so the Gutenberg navigation block resolves against it unchanged.
+
+---
+
+## 7. Rendering on the public site
+
+### Blade
+
+```blade
+<x-ve-blocks :tree="[
+    [
+        'name' => 'core/navigation',
+        'attributes' => ['location' => 'primary'],
+        'innerBlocks' => [],
+    ],
+]" />
+```
+
+Or inside a template — the navigation block is just one node in the
+tree. `<x-ve-template :slug="$slug" />` resolves nav blocks
+transparently.
+
+### React / Vue
+
+Both client renderers ship a `<Navigation>` component that fetches and
+renders the resolved menu:
+
+```tsx
+import { Navigation } from '@artisanpack-ui/visual-editor-renderer-react';
+
+<Navigation location="primary" />
+```
+
+---
+
+## 8. Performance
+
+The resolver caches resolved menus per request — a template that
+includes the same nav block twice (e.g. desktop + mobile variants) only
+hits the database once.
+
+For long-term caching across requests, decorate the resolver in a
+service provider or wrap the rendered output in your own Laravel cache.
+The package doesn't ship a built-in cache because nav data is rarely
+the bottleneck.
+
+---
+
+## See also
+
+- [Site editor](site-editor.md) — the surface that edits menus
+- [Templates](templates.md) — templates that include `core/navigation`
+- [Renderers](renderers.md) — `<x-ve-blocks>` and `<Navigation>` components

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -1,0 +1,201 @@
+# Patterns
+
+Patterns are reusable block snippets that authors drop into post or
+template content. They come in two flavours — **synced** (referenced by
+id; edits propagate everywhere the pattern is used) and **unsynced**
+(inlined at insert time; later edits don't propagate).
+
+This page covers the two flavours, authoring patterns in the site
+editor, the library + inserter integration, and the REST surface.
+
+---
+
+## 1. Synced vs unsynced
+
+| Aspect | Synced | Unsynced |
+|--------|--------|----------|
+| Storage | Pattern store (`wp_block` shape) — one canonical record. | Inlined into the host's block tree at insert time. |
+| Reference | `core/block` block with `{ ref: <id> }`. | Inlined raw blocks. |
+| Editing | Edit once, updates everywhere. | Edit per-page; original pattern untouched. |
+| Use case | Site-wide hero, repeating CTA, footer disclaimer. | Layout starter, "boilerplate" insertable, theme starter content. |
+
+Synced patterns are persistent first-class entities with a slug, title,
+content, and lifecycle. Unsynced patterns are template fragments — they
+live in the pattern library but produce inlined blocks when inserted.
+
+The flavour is set at authoring time: every pattern record has a
+`synced: bool` field that decides which behaviour applies on insert.
+
+---
+
+## 2. Authoring patterns
+
+The Patterns section of the site editor's navigator lists every pattern
+the system knows about, grouped by source (theme / user) and category.
+
+### Create
+
+The "New pattern" button prompts for:
+
+- Title
+- Slug (auto-generated from title; editable)
+- Synced toggle
+- Category (any string; auto-suggests from existing categories)
+- Block types (optional — restrict which blocks the pattern can be
+  inserted near; matches Gutenberg's `blockTypes` filter)
+
+The pattern then opens in the canvas — author it like any other block
+tree and save.
+
+### Edit
+
+Click a pattern in the navigator to load it into the canvas. For synced
+patterns, edits update every page that references the pattern on next
+render. For unsynced patterns, edits only affect future inserts —
+existing inline copies stay as-is.
+
+### Delete
+
+Delete from the navigator's overflow menu. For synced patterns this
+breaks every reference (the renderer emits an empty placeholder).
+Delete with care; the editor surfaces a "this pattern is referenced N
+times" warning before confirming.
+
+---
+
+## 3. The pattern library and inserter
+
+Patterns appear in two places in the editor:
+
+- **Inserter sidebar** — Patterns tab, grouped by category, searchable.
+  Drag a pattern into the canvas to insert.
+- **Site-editor navigator** — Patterns section, listing all patterns for
+  authoring.
+
+Filtering: the inserter filters by category and by the pattern's
+`blockTypes` restriction. A pattern with `blockTypes: ['core/group']`
+only appears when a group is selected.
+
+---
+
+## 4. The `core/block` block (pattern reference)
+
+Synced patterns render via the `core/block` block:
+
+```json
+{
+    "name": "core/block",
+    "attributes": { "ref": 42 }
+}
+```
+
+Attributes:
+
+| Attribute | Type | Purpose |
+|-----------|------|---------|
+| `ref` | number | The pattern's id in the pattern store. |
+
+On render, the resolver looks up the pattern record by id and inlines
+its content. Missing references emit an empty placeholder.
+
+Unsynced patterns produce no `core/block` block — they paste raw blocks
+into the host tree at insert time. From the renderer's perspective an
+unsynced pattern is invisible after insertion.
+
+---
+
+## 5. Theme-provided patterns
+
+Themes can ship patterns alongside templates by declaring them in config:
+
+```php
+// config/artisanpack/visual-editor.php
+'site-editor' => [
+    'patterns' => [
+        'hero' => [
+            'title'      => 'Hero',
+            'categories' => ['layout'],
+            'content'    => '<!-- wp:cover {...} --><!-- /wp:cover -->',
+        ],
+    ],
+],
+```
+
+Static patterns are merged with DB-stored user patterns. They show up in
+the inserter alongside user-created patterns and get a "theme" badge in
+the navigator. Editing a theme pattern in the site editor creates a user
+override (same fallback-chain pattern as templates).
+
+---
+
+## 6. REST API
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/visual-editor/api/patterns` | List patterns (filter by `?category=...` or `?synced=true`). |
+| `POST` | `/visual-editor/api/patterns` | Create a pattern. |
+| `GET` | `/visual-editor/api/patterns/{slug}` | Fetch a pattern. |
+| `PUT` | `/visual-editor/api/patterns/{slug}` | Update a pattern. |
+| `DELETE` | `/visual-editor/api/patterns/{slug}` | Delete a user pattern. |
+
+The slug regex allows `user/<slug>` segments — cms-framework's user-source
+patterns are namespaced this way to keep them distinct from theme patterns.
+
+---
+
+## 7. Categories
+
+Pattern categories are free-form strings. Common conventions:
+
+- `featured` — patterns surfaced first in the inserter.
+- `layout` — full-page or full-section starters.
+- `text` — text-heavy snippets (testimonial, quote, CTA).
+- `media` — media-heavy snippets (hero, gallery, video).
+- `header` / `footer` — chrome patterns.
+
+The inserter groups patterns by category and shows the most-used
+category first.
+
+---
+
+## 8. Rendering on the public site
+
+The Blade renderer's `<x-ve-blocks>` resolves `core/block` references by
+calling the pattern resolver and inlining the content. The React and Vue
+renderers fetch via `GET /visual-editor/api/patterns/{slug}` and inline
+client-side.
+
+Performance: synced patterns are cached per request — a page that
+references the same pattern five times only fetches once. For long-term
+caching across requests, wrap the pattern resolver in a Laravel cache or
+decorate it.
+
+---
+
+## 9. Pattern locking
+
+Patterns can lock their contained blocks against editing — useful for
+"do not modify" boilerplate:
+
+```json
+{
+    "name": "core/group",
+    "attributes": {
+        "templateLock": "all"     // "all" | "insert" | "contentOnly" | false
+    },
+    "innerBlocks": [ /* ... */ ]
+}
+```
+
+`all` — no move, no insert, no remove. `insert` — no insert/remove but
+can rearrange. `contentOnly` — only edit text/media within blocks, not
+structure. See WordPress's [block locking documentation](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-templates/#locking)
+for the full contract.
+
+---
+
+## See also
+
+- [Site editor](site-editor.md) — the surface that edits patterns
+- [Templates](templates.md) — patterns inside templates
+- [Renderers](renderers.md) — rendering `core/block` references

--- a/docs/post-editor.md
+++ b/docs/post-editor.md
@@ -1,0 +1,199 @@
+# Post editor
+
+The post editor is the surface authors use to edit a single resource
+(post, page, custom CPT). It's mounted via the
+[`<x-visual-editor />` Blade component](blade-component.md) and built on
+top of `@wordpress/block-editor`, with chrome restyled to DaisyUI through
+[`@artisanpack-ui/react`](https://www.npmjs.com/package/@artisanpack-ui/react).
+
+This page is a tour of the surface: what's where, how to extend each
+region, what API endpoints back it.
+
+---
+
+## 1. Layout
+
+```text
+┌───────────────────────────────────────────────────────────────────────┐
+│  Topbar: Title · Status · Preview · Save · Inserter toggle           │
+├──────────────┬──────────────────────────────────────┬─────────────────┤
+│              │                                      │                 │
+│   Block      │            Canvas                    │   Inspector     │
+│   library    │     (iframe-wrapped editor)          │   sidebar       │
+│   sidebar    │                                      │                 │
+│              │                                      │                 │
+├──────────────┴──────────────────────────────────────┴─────────────────┤
+│  Footer: breadcrumbs, autosave indicator, block count                │
+└───────────────────────────────────────────────────────────────────────┘
+```
+
+- **Topbar** — document chrome (title, status, preview, save, inserter
+  toggle).
+- **Block library sidebar** (left, collapsible) — browsable list of all
+  registered blocks, grouped by category. Also surfaces patterns.
+- **Canvas** (center) — iframe-wrapped block editor. Isolated styles so
+  the front-end theme renders inside without leaking out.
+- **Inspector sidebar** (right) — block-level controls (alignment, color,
+  typography, spacing, advanced).
+- **Footer** — breadcrumbs through the block tree, autosave status,
+  block count.
+
+---
+
+## 2. Canvas
+
+The canvas is an iframe-wrapped `BlockEditorProvider` from
+`@wordpress/block-editor`. Iframe isolation gives blocks access to the
+theme's typography and color CSS without leaking editor chrome styles
+into the content.
+
+Theme CSS injection is driven by the active global-styles record (see
+[Global styles](global-styles.md)). The CSS is fetched from
+`GET /visual-editor/api/global-styles/lookup` → `GET /global-styles/{id}`
+on boot and injected into the iframe via the React renderer's
+`<GlobalStyles>` component.
+
+Block selection, drag-and-drop, undo/redo, and keyboard shortcuts come
+from `@wordpress/block-editor` unchanged.
+
+---
+
+## 3. Inspector sidebar
+
+The right sidebar renders `InspectorControls` for the currently selected
+block. Every forked `artisanpack/*` block ships a complete control set:
+
+- Alignment + dimensions
+- Color (text, background, link, gradient)
+- Typography (font family, size, line height, letter spacing)
+- Spacing (margin, padding, block gap)
+- Border (radius, style, width, color)
+- Advanced (HTML anchor, additional CSS class)
+
+Block authors add their own controls inside `<InspectorControls>` from
+their `edit.tsx` — see [Custom blocks §5](custom-blocks.md).
+
+The sidebar is also where the document-settings panel renders (status,
+slug, excerpt, featured image, author, comments). Visibility is controlled
+by the `supports` attribute on `<x-visual-editor />` — fields you don't
+want shown can be turned off without code changes.
+
+---
+
+## 4. Block library sidebar
+
+Opens with the topbar inserter button. Lists every block returned by
+`GET /visual-editor/api/blocks`, grouped by `category` (from `block.json`)
+and filtered by the enabled-block allow/deny lists.
+
+The same panel also surfaces **patterns** — both synced (referenced from
+the pattern store) and unsynced (template snippets to drop inline). See
+[Patterns](patterns.md).
+
+Slash command (typed inline in any rich-text block) routes through the
+same registry — `/heading`, `/image`, `/pattern hero`, etc.
+
+---
+
+## 5. Media library integration
+
+Image, cover, video, audio, file, and post-featured-image blocks all
+route media picking through Gutenberg's `editor.MediaUpload` hook.
+
+The package ships two implementations:
+
+- **Stub** (`media-bridge/media-upload-stub.tsx`) — registered by
+  default. Shows a placeholder picker that does nothing. Useful in the
+  dev sandbox and in apps that don't have a media library yet.
+- **Real bridge** — host apps that ship `artisanpack-ui/media-library`
+  (or any compatible store) call
+  `registerArtisanpackMediaBridge(MediaModal, uploadMedia)` from
+  `@artisanpack-ui/visual-editor` before mounting the editor. The bridge
+  swaps the stub for a `MediaModal` that opens the host's picker UI.
+
+```ts
+import { registerArtisanpackMediaBridge } from '@artisanpack-ui/visual-editor';
+import { MediaModal, uploadMedia } from '@artisanpack-ui/media-library';
+
+registerArtisanpackMediaBridge(MediaModal, uploadMedia);
+```
+
+Selected media is fetched server-side from
+`GET /visual-editor/api/attachments/{id}` and returned in the
+WordPress-shape `Attachment` object Gutenberg blocks expect (`id`,
+`source_url`, `alt_text`, `media_details`).
+
+The active bridge slug is recorded in
+`config('artisanpack.visual-editor.media.bridge')` (default
+`'artisanpack-ui/media-library'`); the server-side adapter that
+converts host media records into WP-shape attachments is set in
+`config('artisanpack.visual-editor.media.adapter')` (default:
+`GutenbergAttachmentAdapter`). Swap the adapter to integrate with a
+different media store.
+
+---
+
+## 6. Document settings panel
+
+Inside the inspector sidebar, the document panel exposes:
+
+| Field | Source | `supports` key |
+|-------|--------|----------------|
+| Title | `:initialTitle` | always shown |
+| Slug | `:initialSlug` | always shown |
+| Status | `:initialStatus` | always shown |
+| Excerpt | `:initialExcerpt` | `excerpt` |
+| Featured image | `:initialFeaturedImage` | `featuredImage` |
+| Author | `:initialAuthorId` + `:authorOptions` | always shown |
+| Comments | `:initialCommentsOpen` | `comments` |
+
+Pass `supports = ['excerpt' => true, 'featuredImage' => false, 'comments' => true]`
+to opt fields in or out — see [Blade component reference](blade-component.md).
+
+Document-field changes write back to the model via the same content
+endpoint, batched with block changes.
+
+---
+
+## 7. Autosave + save flow
+
+1. Author edits a block.
+2. After ~1s of idle, the editor dispatches `ve:editor:change` on
+   `window`.
+3. The autosave request fires: `PUT /visual-editor/api/{resource}/{id}/content`.
+4. On 200, the editor dispatches `ve:editor:autosave` with `{ resource, id, blocks, updatedAt }`.
+5. ⌘S or topbar Save bypasses the debounce and dispatches `ve:editor:save`
+   with the same payload.
+
+See [Livewire](livewire.md) for the pattern of bridging these events back
+to a server-rendered shell.
+
+---
+
+## 8. Keyboard shortcuts
+
+Standard Gutenberg shortcuts: `⌘B`/`⌘I`/`⌘U`, `⌘K` (link),
+`⌘⇧K` (unlink), `⌘Z`/`⌘⇧Z` (undo/redo), `⌘⌥M` (insert media),
+`⌘S` (save), `/` (slash inserter), `??` (open shortcut help modal).
+
+The shortcut help modal is restyled with `@artisanpack-ui/react`'s
+`Modal` so it picks up the host theme.
+
+---
+
+## 9. Embedding
+
+The post editor is the same surface whether mounted via Blade, Livewire,
+or Inertia. Embedding recipes:
+
+- [Livewire](livewire.md)
+- [Inertia](inertia.md)
+
+---
+
+## See also
+
+- [Blade component reference](blade-component.md)
+- [Custom blocks](custom-blocks.md)
+- [Renderers](renderers.md) — get saved content back onto the public site
+- [Theming](theming.md) — restyle editor chrome

--- a/docs/release-notes-inputs-1.0.0.md
+++ b/docs/release-notes-inputs-1.0.0.md
@@ -157,3 +157,56 @@ the dev-app soak.
 - 🟡 Dev-app soak window — exercised against this branch as part of the
   #416 PR; sign-off recorded in the PR description before the gate
   merges.
+
+---
+
+## 5. V1.0.0 audit conclusion (#325)
+
+Plan 11 §4.1 requires "one audited upgrade pass near the end of Phase E
+before beta tagging." Performed against the pins recorded in §1 above on
+the branch carrying #325.
+
+**Decision: hold the pins. No `@wordpress/*` bumps in V1.0.0.**
+
+Upstream state at audit time:
+
+| Package | Pinned | Latest minor | Δ |
+|---------|--------|--------------|---|
+| `@wordpress/block-editor` | `15.16.0` | `15.21.0` | +5 minors |
+| `@wordpress/blocks` | `15.16.0` | `15.21.0` | +5 minors |
+| `@wordpress/components` | `32.5.0` | `35.0.0` | +3 **majors** |
+| `@wordpress/core-data` | `7.43.0` | `7.48.0` | +5 minors |
+| `@wordpress/format-library` | `5.43.0` | `5.48.0` | +5 minors |
+| `@wordpress/hooks` | `4.43.0` | `4.48.0` | +5 minors |
+| `@wordpress/i18n` | `6.17.0` | `6.21.0` | +5 minors |
+| `@wordpress/patterns` | `2.43.0` | `2.48.0` | +5 minors |
+| `@wordpress/reusable-blocks` | `5.43.0` | `5.48.0` | +5 minors |
+| `@wordpress/block-library` (dev) | `9.43.0` | `9.48.0` | +5 minors |
+
+Rationale for holding:
+
+1. `@wordpress/components` is three majors behind. Adopting requires
+   restyling work across every place we override Gutenberg component
+   styles (buttons, modals, popovers, panels). That's V1.1 work, not
+   V1.0.0 work.
+2. Gutenberg's cross-package version coupling assumes lockstep — moving
+   one minor without the others risks runtime breakage. The `components`
+   major blocker means the whole group stays put.
+3. The pinned baseline has been soaked through the entire Phase G + H
+   + I work — adopting fresh versions hours before beta inverts the
+   risk profile the plan deliberately built in.
+4. Renovate resumes on the post-fork baseline (§3.1) so the next minor
+   bump cycle starts immediately after V1.0.0 ships; the audited upgrade
+   pass for V1.1 will exercise the new versions on a working tree, not
+   a release-candidate tree.
+
+**Action for the V1.0.0 ship:**
+
+- Keep `package.json` pins exactly as listed in §1. No file changes.
+- The pinned table in §1 becomes the v1.0.0 release notes' "shipped
+  against" section.
+- Note in the release notes: theme.json schema version 3 stays pinned
+  (matches the `@wordpress/*` baseline above).
+- First post-V1.0.0 Renovate PR — assign to the maintainer running the
+  upstream-diff CI cycle (§3.2). Triage drift; decide whether to adopt
+  per cluster.

--- a/docs/renderers.md
+++ b/docs/renderers.md
@@ -1,0 +1,209 @@
+# Renderers
+
+The visual editor saves a Gutenberg-shaped block tree to your model.
+**Renderers** are the packages that take that block tree and turn it back
+into HTML for the public site. V1 ships three:
+
+| Package | Type | Where it runs | Use it when |
+|---------|------|---------------|-------------|
+| `artisanpack-ui/visual-editor-renderer-blade` | Composer (PHP) | Server-side, inside Blade views | Traditional Laravel app, Blade + Livewire, no SPA front-end |
+| `@artisanpack-ui/visual-editor-renderer-react` | npm | Client-side, inside React tree | Inertia+React, headless React front-end |
+| `@artisanpack-ui/visual-editor-renderer-vue` | npm | Client-side, inside Vue tree | Inertia+Vue, headless Vue front-end |
+
+All three resolve a per-block partial/component by block name and fall
+through to a placeholder when nothing's registered. Dynamic blocks
+render server-side regardless of the client renderer — the Blade renderer
+calls `DynamicBlock::render()` directly, the React and Vue renderers
+proxy through `/visual-editor/api/blocks/preview`.
+
+---
+
+## 1. Blade renderer
+
+`composer require artisanpack-ui/visual-editor-renderer-blade`
+
+```blade
+<x-ve-blocks :tree="$post->getBlockContent()" />
+```
+
+The `<x-ve-blocks>` component walks the block tree and renders each block:
+
+1. If it's a dynamic block, call the registered
+   `DynamicBlock::render($attributes)`.
+2. Otherwise, render the partial
+   `visual-editor-renderer-blade::blocks.{namespace}.{name}` with
+   `$attributes` and `$innerBlocksHtml` in scope.
+3. If no partial exists, emit an HTML comment placeholder.
+
+Static-block partials live under
+`packages/visual-editor-renderer-blade/resources/views/blocks/{namespace}/{block}.blade.php`.
+Host apps override individual partials by publishing the view namespace:
+
+```bash
+php artisan vendor:publish --tag=visual-editor-blade-views
+```
+
+Then edit
+`resources/views/vendor/visual-editor-renderer-blade/blocks/artisanpack/callout.blade.php`.
+
+### Rendering a template
+
+For full-template rendering (with template-part resolution and the
+`<head>` block emitted by global styles):
+
+```blade
+<x-ve-template :slug="$templateSlug" />
+```
+
+`<x-ve-template>` looks up the template via `TemplateResolver`, applies
+the fallback chain (theme file → user override → custom), and inlines
+template parts. See [Templates](templates.md) for hierarchy details.
+
+### Registering a custom block renderer
+
+Static blocks: add the partial. Dynamic blocks: register the `DynamicBlock`
+subclass in your service provider:
+
+```php
+VisualEditor::registerDynamicBlock(LatestPostsBlock::class);
+```
+
+The renderer picks it up automatically.
+
+---
+
+## 2. React renderer
+
+`npm install @artisanpack-ui/visual-editor-renderer-react`
+
+```tsx
+import { BlockTree, registerBlockRenderer } from '@artisanpack-ui/visual-editor-renderer-react';
+import { CalloutBlock } from './blocks/callout';
+
+registerBlockRenderer('artisanpack/callout', CalloutBlock);
+
+export function Post({ blocks }) {
+    return <BlockTree tree={blocks} />;
+}
+```
+
+Each renderer component receives `{ attributes, innerBlocks, children }`:
+
+```tsx
+export function CalloutBlock({ attributes, children }) {
+    const severity = attributes.severity ?? 'info';
+    return (
+        <div className={`ap-callout ap-callout--${severity}`}>
+            <div className="ap-callout__body">{children}</div>
+        </div>
+    );
+}
+```
+
+`children` is the pre-rendered innerBlocks tree — pass it straight into
+whatever wrapper the block needs. If you'd rather render innerBlocks
+manually, use `<BlockTree tree={innerBlocks} />`.
+
+### Dynamic blocks in React
+
+The React renderer ships a `<DynamicBlock>` fallback that fetches the
+server-rendered HTML from `POST /visual-editor/api/blocks/preview` and
+injects it via `dangerouslySetInnerHTML`. The fallback fires whenever a
+block has no client registration but the server has a `DynamicBlock` for
+that name.
+
+To skip the round-trip, register a client renderer for the dynamic block
+that produces equivalent HTML from the same attributes. This is a
+denormalization — keep the two in sync deliberately.
+
+### Rendering templates and global styles
+
+```tsx
+import { Template, GlobalStyles } from '@artisanpack-ui/visual-editor-renderer-react';
+
+<>
+    <GlobalStyles />
+    <Template slug={templateSlug} />
+</>
+```
+
+`<GlobalStyles>` fetches and emits the CSS from
+`/visual-editor/api/global-styles/css`. Mount it once at the root.
+
+---
+
+## 3. Vue renderer
+
+`npm install @artisanpack-ui/visual-editor-renderer-vue`
+
+Same registry pattern. Renderer components are Vue SFCs (or `defineComponent`):
+
+```ts
+import { defineComponent, h } from 'vue';
+import { registerBlockRenderer, BlockTree } from '@artisanpack-ui/visual-editor-renderer-vue';
+
+const CalloutBlock = defineComponent({
+    props: ['attributes', 'innerBlocks'],
+    setup(props, { slots }) {
+        return () => h(
+            'div',
+            { class: `ap-callout ap-callout--${props.attributes.severity ?? 'info'}` },
+            [h('div', { class: 'ap-callout__body' }, slots.default?.())],
+        );
+    },
+});
+
+registerBlockRenderer('artisanpack/callout', CalloutBlock);
+```
+
+The `<BlockTree>` / `<Template>` / `<GlobalStyles>` components mirror the
+React renderer's API.
+
+---
+
+## 4. Which renderer for which stack
+
+- **Traditional Laravel (Blade, Livewire, Volt)** — Blade renderer only.
+  Dynamic blocks resolve in-process; no extra network round-trips.
+- **Inertia + React** — React renderer on the front-end, Blade renderer
+  optional for SSR. Most apps don't need SSR.
+- **Inertia + Vue** — Vue renderer on the front-end.
+- **API-driven SPA (no Inertia)** — fetch the block tree from
+  `/visual-editor/api/{resource}/{id}/content` and render with the React
+  or Vue package.
+
+See [Inertia recipes](inertia.md) for end-to-end examples.
+
+---
+
+## 5. Renderer parity
+
+The three renderers must produce equivalent HTML for the same block tree.
+The package's `npm run verify:parity` script renders a fixture tree
+through all three and diffs the output. Add a fixture entry whenever you
+add a custom block that ships partials/components in more than one
+renderer.
+
+---
+
+## 6. Distribution
+
+The three renderer packages live under `packages/` in the monorepo and
+are split out to:
+
+- `artisanpack-ui/visual-editor-renderer-blade` (Packagist)
+- `@artisanpack-ui/visual-editor-renderer-react` (npm)
+- `@artisanpack-ui/visual-editor-renderer-vue` (npm)
+
+V1.0.0 publishes the Blade renderer; React and Vue renderers ship from
+the dev app via a path/file repository until their first Packagist/npm
+publish. See [PACKAGING.md](../PACKAGING.md).
+
+---
+
+## See also
+
+- [Custom blocks](custom-blocks.md) — authoring blocks that need renderers
+- [Templates](templates.md) — template fallback chain and `core/template-part`
+- [Global styles](global-styles.md) — CSS emission contract
+- [Inertia](inertia.md) — embedding the renderers inside Inertia apps

--- a/docs/site-editor.md
+++ b/docs/site-editor.md
@@ -1,0 +1,220 @@
+# Site editor
+
+The site editor is the surface for editing site-wide chrome — templates,
+template parts, global styles, navigation menus, and patterns — without
+touching post content. It mounts at `/visual-editor/site` and uses the
+same Gutenberg block-editor primitives as the post editor, wrapped in a
+custom shell that owns the navigation, tab structure, and entity
+switching.
+
+The site editor requires `artisanpack-ui/cms-framework` to be installed —
+templates, template parts, global styles, patterns, and navigation menus
+are persisted by cms-framework's models. When cms-framework is missing,
+the install gate (#432) surfaces a "cms-framework required" page instead
+of mounting the editor.
+
+---
+
+## 1. Layout
+
+```text
+┌─────────────────────────────────────────────────────────────────────┐
+│  Topbar: Site · entity title · Save · Preview                      │
+├─────────────────────┬───────────────────────────────────────────────┤
+│                     │                                               │
+│   Navigator         │            Canvas frame                       │
+│   sidebar           │            (iframe + block editor)            │
+│                     │                                               │
+│   ── Templates      │                                               │
+│   ── Template parts │                                               │
+│   ── Patterns       │                                               │
+│   ── Styles         │                                               │
+│   ── Navigation     │                                               │
+│                     │                                               │
+└─────────────────────┴───────────────────────────────────────────────┘
+```
+
+- **Topbar** — entity-title, save, preview, "back to site" link.
+- **Navigator sidebar** (left) — tree of all editable entities, grouped
+  into five sections: Templates, Template Parts, Patterns, Styles,
+  Navigation. Click an entity to load it into the canvas.
+- **Canvas frame** (center) — iframe-wrapped block editor. Same component
+  set as the post editor, scoped to the selected entity.
+
+---
+
+## 2. Access gate
+
+Site-editor access is fail-closed. The default
+`SiteEditorAccessGate` binding is `DenyByDefaultGate` — every request
+returns 403 until you bind something permissive:
+
+```php
+// AppServiceProvider::register()
+$this->app->bind(
+    \ArtisanPackUI\VisualEditor\SiteEditor\Contracts\SiteEditorAccessGate::class,
+    \App\Auth\AllowAdminsGate::class,
+);
+```
+
+When cms-framework is installed it auto-binds `CmsFrameworkInstallGate`,
+which:
+
+1. Confirms cms-framework is installed and migrations have run.
+2. Confirms the current user has the `visual_editor.site.edit`
+   permission (or the legacy "any authenticated" baseline in V1.0).
+
+Override the binding to integrate with your own RBAC. See
+[Content model §3](content-model.md#3-policies-and-authorization).
+
+---
+
+## 3. Sections
+
+### Templates
+
+Server-stored template records (`wp_template` shape) that drive
+full-page rendering. The navigator lists every template the resolver
+knows about — both theme-provided defaults and user overrides — and the
+editor lets authors edit either.
+
+See [Templates](templates.md) for the hierarchy, fallback chain, and
+how the front-end renderer picks a template for a route.
+
+### Template parts
+
+Reusable chunks (`wp_template_part` shape) that get included into
+templates via the `core/template-part` block. Headers, footers, sidebars
+— anything shared across templates lives here.
+
+See [Templates §3](templates.md#3-template-parts) for the
+`core/template-part` contract.
+
+### Patterns
+
+Reusable block snippets. Two flavours:
+
+- **Synced** — pattern lives in the pattern store; every reference
+  updates when the pattern changes.
+- **Unsynced** — the snippet is dropped inline at insert time; later
+  edits to the pattern don't propagate.
+
+See [Patterns](patterns.md).
+
+### Styles
+
+The theme-wide style record (theme.json-shaped). Edits here change typography,
+color palette, spacing scale, layout defaults, and per-block style overrides
+for every page on the site.
+
+See [Global styles](global-styles.md).
+
+### Navigation
+
+Menus and menu items. Each menu can be assigned to one or more theme-declared
+menu locations; the `core/navigation` block resolves location → menu at
+render time.
+
+See [Navigation](navigation.md).
+
+---
+
+## 4. Canvas and entity loading
+
+The canvas is the same iframe-wrapped block editor as the post editor.
+When you select an entity in the navigator:
+
+1. The site-editor shell dispatches `core/editor` to load the entity by id.
+2. Gutenberg's core-data shim fetches the entity from the REST surface
+   (`/visual-editor/api/templates/{slug}`, `/template-parts/{slug}`, etc.).
+3. The canvas renders the entity's block tree.
+4. Edits autosave back through the same REST endpoint.
+
+Switching entities saves pending edits to the previous entity first
+(blocking on the network round-trip), then loads the new entity.
+
+---
+
+## 5. URL routing
+
+The site editor is a single Laravel route (`GET /visual-editor/site/{path?}`)
+that hands off to React routing client-side. Direct links to a specific
+entity work:
+
+```
+/visual-editor/site/templates/single
+/visual-editor/site/template-parts/header
+/visual-editor/site/patterns/hero
+/visual-editor/site/styles
+/visual-editor/site/navigation/primary
+```
+
+These are shareable — bookmark or send to a colleague to jump straight
+into editing that entity.
+
+---
+
+## 6. Preview
+
+The topbar Preview button opens the entity's front-end rendering in a new
+tab. For templates, this is the slug rendered against a representative
+record (e.g. `single` → most recent post). For template parts and
+patterns, it's an isolated preview page. For global styles, it's the
+home page.
+
+The preview URL is computed by `apGetSiteEditorPreviewUrl()` and can be
+overridden per-section by binding your own preview resolver in
+`config('artisanpack.visual-editor.site-editor.previews')`.
+
+---
+
+## 7. REST API surface
+
+| Section | Endpoints |
+|---------|-----------|
+| Templates | `GET/POST /templates`, `GET/PUT/DELETE /templates/{slug}` |
+| Template parts | `GET/POST /template-parts`, `GET/PUT/DELETE /template-parts/{slug}` |
+| Patterns | `GET/POST /patterns`, `GET/PUT/DELETE /patterns/{slug}` |
+| Global styles | `GET /global-styles/lookup`, `GET /global-styles/base`, `GET /global-styles/css`, `GET/PUT /global-styles/{id}` |
+| Navigation | `GET/POST /menus`, `GET/PUT/DELETE /menus/{id}`, `GET/POST/PUT/DELETE /menu-items`, `GET /menu-locations` |
+| Entity search | `GET /search` — backs the link-control picker across all entity types |
+
+All under the `/visual-editor/api/` prefix, all behind the API middleware
+stack.
+
+---
+
+## 8. Static configuration
+
+Some site-editor entities can be declared in config rather than the
+database — useful for templates and patterns that ship with the host
+app's theme:
+
+```php
+// config/artisanpack/visual-editor.php
+'site-editor' => [
+    'templates' => [
+        'single' => ['title' => 'Single Post', 'content' => '...'],
+    ],
+    'template-parts' => [
+        'header' => ['title' => 'Header', 'content' => '...'],
+    ],
+    'patterns' => [
+        'hero' => ['title' => 'Hero', 'content' => '...'],
+    ],
+    'navigation' => [
+        'primary' => ['title' => 'Primary Menu'],
+    ],
+],
+```
+
+Static configs are merged with DB-stored user overrides via the fallback
+chain — user records win on the same slug. See [Templates §4](templates.md#4-fallback-chain).
+
+---
+
+## See also
+
+- [Templates](templates.md) · [Global styles](global-styles.md) · [Navigation](navigation.md) · [Patterns](patterns.md)
+- [Content model](content-model.md) — site-editor access gate
+- [Renderers](renderers.md) — render saved entities on the public site

--- a/docs/site-editor.md
+++ b/docs/site-editor.md
@@ -141,7 +141,7 @@ The site editor is a single Laravel route (`GET /visual-editor/site/{path?}`)
 that hands off to React routing client-side. Direct links to a specific
 entity work:
 
-```
+```text
 /visual-editor/site/templates/single
 /visual-editor/site/template-parts/header
 /visual-editor/site/patterns/hero

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -1,0 +1,213 @@
+# Templates
+
+Templates are full-page block trees that drive front-end rendering. The
+package follows WordPress's `wp_template` model: templates are looked up
+by **slug** against a hierarchy, the resolver walks the chain from
+specific to generic, and each template can include reusable
+`core/template-part` blocks.
+
+This page covers the template hierarchy, the resolver, template parts,
+and how the renderer turns it all into HTML.
+
+---
+
+## 1. Template hierarchy
+
+A request for a single post (slug `hello-world`, post type `post`)
+resolves templates in this order, stopping at the first match:
+
+```
+single-post-hello-world  (slug-specific)
+single-post              (post-type-specific)
+single                   (single-record default)
+index                    (final fallback)
+```
+
+The full hierarchy (mirrors WordPress core):
+
+| Context | Slug order |
+|---------|------------|
+| Single post | `single-{post_type}-{slug}` → `single-{post_type}` → `single` → `index` |
+| Page | `page-{slug}` → `page-{id}` → `page` → `singular` → `index` |
+| Category archive | `category-{slug}` → `category-{id}` → `category` → `archive` → `index` |
+| Tag archive | `tag-{slug}` → `tag-{id}` → `tag` → `archive` → `index` |
+| Taxonomy archive | `taxonomy-{taxonomy}-{term}` → `taxonomy-{taxonomy}` → `taxonomy` → `archive` → `index` |
+| Author archive | `author-{nicename}` → `author-{id}` → `author` → `archive` → `index` |
+| Date archive | `date` → `archive` → `index` |
+| Search results | `search` → `index` |
+| 404 | `404` → `index` |
+| Front page | `front-page` → `home` → `index` |
+
+The host app's route handler picks the context and asks
+`TemplateResolver::bySlug()` to walk the chain.
+
+---
+
+## 2. The `TemplateResolver`
+
+`ArtisanPackUI\VisualEditor\SiteEditor\Resolution\TemplateResolver`
+
+```php
+$resolver = app(\ArtisanPackUI\VisualEditor\SiteEditor\Resolution\TemplateResolver::class);
+$template = $resolver->bySlug('single-post');
+```
+
+Returns a `ResolvedTemplate` value object:
+
+```php
+ResolvedTemplate {
+    public string $slug;
+    public string $theme;
+    public string $title;
+    public string $status;       // 'auto-draft' | 'publish'
+    public string $source;       // 'theme' | 'user' | 'custom'
+    public array  $content;      // ['raw' => '...', 'blocks' => [...]]
+    public bool   $has_theme_file;
+    public bool   $is_custom;
+    public ?int   $wp_id;        // user override id, if present
+}
+```
+
+`bySlug()` returns `null` if nothing matches. The host renderer is
+expected to walk the hierarchy and pick the first non-null result:
+
+```php
+foreach (['single-post-hello-world', 'single-post', 'single', 'index'] as $slug) {
+    $template = $resolver->bySlug($slug);
+    if ($template !== null) {
+        break;
+    }
+}
+```
+
+The Blade renderer's `<x-ve-template :slug="$slug" />` does this internally.
+
+---
+
+## 3. Template parts
+
+Template parts are reusable chunks (header, footer, sidebar) included
+into templates via the `core/template-part` block.
+
+### `core/template-part` block
+
+Attributes:
+
+| Attribute | Type | Purpose |
+|-----------|------|---------|
+| `slug` | string | Template part slug to include (e.g. `header`, `footer`). |
+| `theme` | string (optional) | Theme slug; defaults to the active theme. |
+| `area` | string (optional) | One of `header`, `footer`, `sidebar`, `uncategorized`. Drives navigator grouping; doesn't affect rendering. |
+
+The block stores no inner blocks — its content is whatever the linked
+template part stores at render time. Editing the linked template part
+updates every template that includes it.
+
+### Server-side rendering
+
+`TemplatePartResolver::bySlug($slug, $theme = null)` returns a
+`ResolvedTemplatePart` value object with the same shape as
+`ResolvedTemplate`. The Blade renderer's `<x-ve-blocks>` component
+recognizes `core/template-part` nodes and inlines the resolved part's
+content.
+
+If the linked part is missing, the renderer emits an empty wrapper rather
+than an error — the canvas already warns the author during editing.
+
+---
+
+## 4. Fallback chain
+
+For each slug the resolver checks three sources in order, returning the
+first match:
+
+1. **User record** — a row in `cms-framework`'s templates table
+   (`source = 'user'`). Always wins.
+2. **Static config** — entries in
+   `config('artisanpack.visual-editor.site-editor.templates')` keyed by
+   slug (`source = 'theme'`).
+3. **Theme file** — packaged template files shipped by themes
+   (`source = 'theme'`, `has_theme_file = true`).
+
+Authors editing a theme-provided template in the site editor create a
+user override — the user record then shadows the theme version. The
+"reset to theme default" button in the editor deletes the user record,
+restoring the theme version.
+
+---
+
+## 5. REST API
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/visual-editor/api/templates` | List all templates (theme + user). |
+| `POST` | `/visual-editor/api/templates` | Create a new user template. |
+| `GET` | `/visual-editor/api/templates/{slug}` | Fetch a single template. |
+| `PUT` | `/visual-editor/api/templates/{slug}` | Update — creates a user record if one doesn't exist. |
+| `DELETE` | `/visual-editor/api/templates/{slug}` | Delete the user record (theme version remains). |
+| `GET/POST/GET/PUT/DELETE` | `/visual-editor/api/template-parts[/{slug}]` | Same surface for template parts. |
+
+All endpoints behind the API middleware stack. Slug regex allows path-style
+segments (`single/post/hello-world`).
+
+---
+
+## 6. Custom templates
+
+Custom templates (not part of the hierarchy) are templates an author
+created from scratch in the site editor with a free-form name. They don't
+auto-resolve for any route — the host app opts pages into them
+explicitly:
+
+```php
+// In your page model
+public function getTemplate(): string
+{
+    return $this->custom_template_slug ?? 'singular';
+}
+```
+
+```blade
+<x-ve-template :slug="$page->getTemplate()" />
+```
+
+The site editor's New Template button creates these; they're persisted
+with `is_custom = true`.
+
+---
+
+## 7. Editing in the site editor
+
+The Templates section of the site-editor navigator lists every template
+the resolver knows about, grouped by source:
+
+- **Theme templates** — defaults shipped by the active theme.
+- **Custom templates** — created by authors.
+- **User-modified** — theme templates with user overrides.
+
+Clicking a template loads it into the canvas. The save endpoint always
+writes a user record; the theme version remains available via
+"reset to theme default".
+
+---
+
+## 8. Where templates live
+
+- **Theme files:** loaded by the active theme; no migration required.
+- **Static config:** `config('artisanpack.visual-editor.site-editor.templates')` — version-controlled with the app.
+- **User overrides:** `cms-framework`'s templates table — written by the site editor.
+
+Picking the right home for each template:
+
+- **Theme file or static config** for templates that ship with the app,
+  evolve via deploys, and should reset cleanly.
+- **User record** for one-off edits authors make at runtime.
+
+---
+
+## See also
+
+- [Site editor](site-editor.md) — the surface that edits templates
+- [Renderers](renderers.md) — render templates on the public site
+- [Patterns](patterns.md) — `core/block` references inside templates
+- [Global styles](global-styles.md) — theme.json driving template appearance

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -16,7 +16,7 @@ and how the renderer turns it all into HTML.
 A request for a single post (slug `hello-world`, post type `post`)
 resolves templates in this order, stopping at the first match:
 
-```
+```text
 single-post-hello-world  (slug-specific)
 single-post              (post-type-specific)
 single                   (single-record default)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,226 @@
+# Troubleshooting
+
+Common problems and the underlying constraints they surface, in rough
+order of how often they come up.
+
+---
+
+## 1. Editor doesn't appear
+
+The Blade component rendered, but the React app didn't boot. Most likely
+causes, in order:
+
+1. **Vite bundle not built.** Run `npm run build` (or `npm run dev` in
+   development). The editor mounts from the package's compiled JS bundle,
+   which Vite emits to `public/build/`.
+2. **Peer dependencies missing.** Tailwind CSS v4 + DaisyUI v5 must be
+   loaded at the page level. The editor inherits them — without them,
+   the React tree renders but is invisible.
+3. **JS console errors.** Open the browser console. Missing `core-data`
+   shim (the package aliases `@wordpress/core-data` to its own shim in
+   `vite.config.ts` — confirm your Vite config doesn't override the
+   alias).
+4. **The mount point is hidden by CSS.** `[data-ap-visual-editor]` needs
+   visible dimensions — wrap it in a layout that gives it height.
+
+---
+
+## 2. Core-data shim entities and missing data
+
+The package ships its own `@wordpress/core-data` shim under
+`resources/js/visual-editor/vendor/core-data-shim.ts`. The shim
+implements a curated subset of selectors that Gutenberg expects:
+`getEntityRecord`, `getEntityRecords`, `getEditedEntityRecord`,
+`canUser`, `getCurrentUser`, `getMedia`, plus the resolver machinery
+(`hasFinishedResolution`, `isResolving`).
+
+Symptoms when the shim doesn't cover a code path:
+
+- A block renders empty in the canvas with no error.
+- The console shows `Cannot read properties of undefined` from a
+  Gutenberg internal.
+- A core-data selector returns `null` and the block infinite-loops on
+  `isResolving`.
+
+**Diagnosing.** Add a debugger to the shim's `getEntityRecord` and see
+what `{ kind, name, id }` the block is asking for. If `kind:name` is
+unregistered, the shim returns `null` — register the entity in
+`core-data-shim.ts` or add a back-compat stub.
+
+**Fixing.** New entities go into the `entities` array; new selectors go
+into the `selectors` map. Both files are tested by `vitest run` —
+adding a fixture for the new entity and asserting the shim returns it
+catches regressions.
+
+Full inventory: [`docs/core-data-shim.md`](core-data-shim.md).
+
+---
+
+## 3. WordPress package upgrades
+
+The package pins `@wordpress/*` to the versions listed in `package.json`.
+Renovate / Dependabot is **paused** for these packages during V1.x —
+mid-stream minor bumps invalidate weeks of UI work.
+
+### Upgrade procedure
+
+1. **Decide to upgrade deliberately.** Read the upstream `CHANGELOG.md`
+   for every `@wordpress/*` package being bumped. Note schema-version
+   bumps, removed selectors, renamed components.
+2. **Update `package.json` pins together.** All `@wordpress/*` packages
+   should move in lockstep — they share internal contracts and skewing
+   them cross-version causes subtle runtime breakage.
+3. **Re-run the parity check.** `npm run verify:parity` renders fixture
+   trees through Blade + React + Vue renderers and diffs the output.
+   Drift means a block fork's markup changed upstream.
+4. **Re-run upstream-diff.** `npm run upstream-diff` compares each
+   forked block's `register()` call to a fresh upstream registration
+   and surfaces drift in attributes / supports / variations.
+5. **Decide on each drift.** Adopt upstream change → update the fork +
+   bump its `upstream-state.json`. Reject the change → annotate the
+   `upstream-state.json` with the rejection reason.
+6. **Schema-version check.** If theme.json schema bumped, follow
+   [Global styles §8](global-styles.md#8-handling-a-future-schema-bump).
+7. **Run the full test suite.** `./vendor/bin/pest && npm test`.
+
+### Symptoms of an unaudited upgrade
+
+- New block variations appearing in the inserter that the team didn't
+  agree to ship.
+- Removed selectors causing core-data shim warnings on selector lookup.
+- theme.json `version` validation errors on `PUT /global-styles/{id}`.
+- `@wordpress/components` style regressions (the package overrides
+  Gutenberg button/modal styling — restyling work needs to be redone
+  against the new component internals).
+
+---
+
+## 4. theme.json schema upgrades
+
+The pinned schema version (currently 3) is enforced by
+`UpdateGlobalStylesRequest` — every PUT must include
+`version === 3`. When the upstream schema bumps:
+
+1. Audit the new schema's added/removed top-level keys.
+2. Update `artisanpack.visual-editor.global_styles.schema_version` to
+   the new version.
+3. Update `resources/theme-json/default-base.php` defaults.
+4. Ship a migration that either rewrites existing user records into the
+   new schema or documents a manual upgrade path for customized records.
+5. Update [Global styles](global-styles.md#1-pinned-schema-version).
+
+The pin exists precisely so this is conscious work — not silent drift on
+`npm update`.
+
+---
+
+## 5. Theming quirks
+
+The editor restyles `@wordpress/components` (Button, Modal, Notice, etc.)
+to DaisyUI via the
+[`@artisanpack-ui/react`](https://www.npmjs.com/package/@artisanpack-ui/react)
+component pack. Restyling is best-effort — some quirks:
+
+- **Modal layering.** Gutenberg's modals use a portal at document root.
+  If the host page has its own portal root with a higher `z-index`, the
+  Gutenberg modal can render behind it. Bump the host portal to
+  `z-index: 60` or lower.
+- **Color tokens.** The editor reads palette tokens from the active
+  global-styles record. If colors look wrong, check `/global-styles/css`
+  in DevTools to confirm the expected variables are emitted.
+- **Dark mode.** Toggled by DaisyUI's `data-theme` attribute on a parent
+  element. The editor inherits the host page's theme; flipping themes
+  inside the editor without a remount produces inconsistent paint
+  states until the next interaction.
+- **Avoid `@artisanpack-ui/react` Popover and Dropdown inside the
+  editor.** Both have known interactions with the editor's portal that
+  freeze the canvas. Use inline manual patterns or
+  `@wordpress/components` Popover / Dropdown directly.
+
+Full theme contract: [Theming](theming.md).
+
+---
+
+## 6. "Unknown resource" on save
+
+`PUT /visual-editor/api/{resource}/{id}/content` returns 404 with
+"Unknown resource '{slug}'". The slug isn't in
+`config('artisanpack.visual-editor.resources')` and no
+`ap.visual-editor.resources` filter contributor added it.
+
+Check:
+
+- `php artisan config:clear` if you recently edited the config.
+- The Blade component's `resource="..."` attribute matches a registered
+  slug.
+- If you're relying on cms-framework auto-registration, confirm
+  cms-framework is installed and the version pair is compatible.
+
+---
+
+## 7. Saves succeed but content disappears on reload
+
+The model is using `HasBlockContent` but `$blockContentColumn` doesn't
+match an actual column on the model, or the column isn't cast to JSON.
+
+Check:
+
+- The migration added a JSON column with the expected name (default:
+  `content`).
+- If the model already had a `content` column with a non-JSON cast
+  (e.g. `string`), set `$blockContentColumn` to a different name or
+  override the cast in `casts()`.
+
+---
+
+## 8. Site editor returns 403
+
+The default `SiteEditorAccessGate` is `DenyByDefaultGate` — fail-closed.
+Either:
+
+- Bind a permissive gate in your app service provider (see
+  [Content model §3](content-model.md#3-policies-and-authorization)).
+- Install cms-framework, which binds `CmsFrameworkInstallGate`
+  automatically.
+
+---
+
+## 9. Renderer parity drift
+
+`npm run verify:parity` fails after editing a block. The Blade, React,
+and Vue renderers produce different HTML for the same block tree.
+
+Common causes:
+
+- Edited the `save.tsx` markup but didn't update the corresponding
+  Blade partial / React component / Vue component.
+- Static block has different default attribute coercion in two
+  renderers (e.g. one falls back to `''`, another to `null`).
+- Dynamic block's `render()` output drifted from the React renderer's
+  `<DynamicBlock>` fallback expectations.
+
+Fix the renderer that disagrees with `edit.tsx` / `save.tsx`. The
+parity script is the source of truth — if a fixture produces three
+different HTML strings, the fixture is wrong or one of the renderers is
+wrong, never the script.
+
+---
+
+## 10. Dev sandbox specifics
+
+The `/ve-sandbox` route (`npm run dev:sandbox`) is a standalone editor
+playground that doesn't talk to the API. Useful for block authoring in
+isolation; will be removed post-V1.
+
+If the sandbox crashes but the real editor works, you've probably hit a
+sandbox-only regression — file under `area:sandbox` rather than
+debugging the production editor.
+
+---
+
+## See also
+
+- [Getting started](getting-started.md)
+- [Core-data shim](core-data-shim.md)
+- [Global styles](global-styles.md)
+- [Theming](theming.md)


### PR DESCRIPTION
## Description

Writes the full V1 documentation set, refreshes README + CHANGELOG for the V1 ship, and records the audited @wordpress/* version decision for V1.0.0.

**Closes:** #325
**Closes:** #309

## Type of Change

- [x] Documentation update

## Related Issue

**Issue:** #325

## Motivation and Context

M15 is the V1 release ticket. This PR delivers everything #325's acceptance criteria asks for under "docs" (15 doc files + README + CHANGELOG + plan 11 retained as historical record), plus the @wordpress/* audit pass from plan 11 §4.1 and the package's root MEMORY.md. Tagging v1.0.0-beta.1 and v1.0.0 happens after this PR merges.

## Changes Made

**New docs (12):**

- `docs/getting-started.md` — install, config, first post under an hour
- `docs/content-model.md` — `HasBlockContent`, resource map, policies, site-editor access gate
- `docs/blade-component.md` — full `<x-visual-editor />` reference
- `docs/post-editor.md` — canvas, inspector, document settings, media bridge, autosave flow
- `docs/renderers.md` — Blade vs React vs Vue, registering custom renderers, parity
- `docs/site-editor.md` — shell, navigator, canvas, sections, REST surface
- `docs/templates.md` — hierarchy, `TemplateResolver`, template parts, fallback chain
- `docs/navigation.md` — menus, locations, fallback chain, `core/navigation` block, REST
- `docs/patterns.md` — synced vs unsynced, authoring, library/inserter, `core/block` references
- `docs/inertia.md` — Inertia+React (`mountVisualEditor`) and Inertia+Vue (`<VisualEditor>`) recipes
- `docs/troubleshooting.md` — core-data shim, WordPress package upgrade procedure, theme.json schema upgrades, theming quirks, common errors
- `docs/migration.md` — `visual-editor-wp-import` companion pointer, in-package migrations, alpha.1 → 1.0.0 upgrade path

**Refreshed docs:**

- `docs/custom-blocks.md` — added `DynamicBlock` hooks section (`validateAttrs`, `searchableText`, `authorize`) + preview endpoint contract
- `docs/global-styles.md` — rewrote out of the C3-ship framing into the V1 final state; added panels reference (typography, colors, layout, blocks) and CSS emission section

**Other:**

- `README.md` rewritten to lead with V1 final scope; new doc table linking every page
- `CHANGELOG.md` — `[1.0.0]` section opened for the ship; alpha.1 entries moved under their own header; package name fixed
- `docs/release-notes-inputs-1.0.0.md` §5 — V1.0.0 @wordpress/* audit conclusion (hold pins; resume Renovate post-tag; +3 majors on @wordpress/components is the blocker for adoption)
- `MEMORY.md` (root) — final V1 architecture reference for future sessions

`docs/livewire.md` already covered the M13 recipe end-to-end, so left as-is. `docs/plans/11-v1-expansion.md` retained as historical record per acceptance criteria.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS Darwin 25.5.0
- PHP Version: 8.4.3 (Herd)
- Project Version: 1.0.0 (composer.json), 1.0.0-spike (package.json — bump to 1.0.0-beta.1 happens post-merge at tag time)

**Tests Performed:**
1. `./vendor/bin/pest --compact` → **878 passed (2450 assertions)**
2. `npm test` → **1836 passed across 229 test files**
3. CodeRabbit local CLI pass — 0 findings after two iterations
4. Manual sense-check of new docs vs codebase (API paths, config keys, class names quoted verbatim from the Explore-agent survey of src/, routes/, config/)

## Accessibility Tests Run

- [x] N/A — docs-only PR. No UI surface added. The underlying editor's a11y is covered by #535 and #450 already on `release/1.0`.

## Tests Added

- [x] All tests passing — no code changes, so no new tests needed.

**Test details:** Docs-only PR. Existing Pest + Vitest suites both green against the branch HEAD.

## Documentation

- [x] Inline code documentation added — N/A (no code changes)
- [x] README updated — rewritten for V1 final scope
- [x] Wiki updated — out of scope; in-repo docs are the V1 source of truth

**Documentation details:** This PR _is_ the documentation update.

## Screenshots

N/A — docs only.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests (Pest 878 ✅, Vitest 1836 ✅)
- [x] Code has been linted (N/A — docs only)
- [x] Accessibility tests completed (N/A — no UI changes)
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code (N/A)
- [x] No new warnings generated

## Post-merge

After this merges, the v1.0.0 release sequence is:

1. Bump `package.json` version to `1.0.0-beta.1`; tag `v1.0.0-beta.1` from `release/1.0` HEAD.
2. Smoke-test against the dev app per `docs/g6-smoke-flow.md` + `docs/h8-smoke-flow.md`.
3. Bump to `1.0.0`; tag `v1.0.0`.
4. Confirm both packages of the version pair tag together (cms-framework V1.x must be tagged first per `docs/release-notes-inputs-1.0.0.md` §2.3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive v1.0.0 docs: installation, post & site editors, custom blocks, patterns, navigation, templates, global styles, renderers, embedding (Blade/Livewire/Inertia), troubleshooting, migration, and API/usage guides.

* **Changelog**
  * Rewrote release notes to a v1.0.0‑oriented structure with an alpha adoption marker and organized Added/Changed sections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->