### PR TITLE
fix: emit is-layout-flow block-gap rule for paragraph spacing

### DIFF
--- a/packages/visual-editor-renderer-blade/resources/views/components/blocks-styles.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/components/blocks-styles.blade.php
@@ -6,7 +6,7 @@
 <style data-ve-theme-tokens>{!! $themeTokensCss !!}</style>
 @endif
 {{--
-	Layout baseline rules — flex + grid.
+	Layout baseline rules — flow + constrained + flex + grid.
 
 	Upstream emits `display: flex; flex-wrap: wrap; align-items: center`
 	per-instance via `useLayoutStyles` (editor) and
@@ -17,13 +17,28 @@
 	as block flow on the public site even though the editor wrapper
 	already carries `is-layout-flex`.
 
-	Static fallback below mirrors `LAYOUT_DEFINITIONS.flex.baseStyles`
-	+ `.grid.baseStyles` from @wordpress/block-editor. Per-block
-	compound selectors (`wp-block-gallery-is-layout-flex`,
-	`wp-block-cover-is-layout-flex`, …) inherit from the generic
-	`.is-layout-flex` rule so we don't enumerate block names.
+	Static fallback below mirrors `LAYOUT_DEFINITIONS.flow.baseStyles`,
+	`.constrained.baseStyles`, `.flex.baseStyles`, and `.grid.baseStyles`
+	from @wordpress/block-editor. Per-block compound selectors
+	(`wp-block-gallery-is-layout-flex`, `wp-block-cover-is-layout-flex`,
+	…) inherit from the generic `.is-layout-flex` rule so we don't
+	enumerate block names.
+
+	`:where()` on the flow/constrained selectors keeps specificity at
+	(0,0,0) so any theme rule with higher specificity continues to win
+	— matches WordPress's own output. The `var(--wp--style--block-gap,
+	24px)` fallback mirrors core's default when `theme.json` does not
+	set `styles.spacing.blockGap`.
 --}}
 <style data-ve-layout-baseline>
+:where(.is-layout-flow) > :first-child { margin-block-start: 0; }
+:where(.is-layout-flow) > :last-child { margin-block-end: 0; }
+:where(.is-layout-flow) > * { margin-block-start: 0; margin-block-end: 0; }
+:where(.is-layout-flow) > * + * { margin-block-start: var(--wp--style--block-gap, 24px); margin-block-end: 0; }
+:where(.is-layout-constrained) > :first-child { margin-block-start: 0; }
+:where(.is-layout-constrained) > :last-child { margin-block-end: 0; }
+:where(.is-layout-constrained) > * { margin-block-start: 0; margin-block-end: 0; }
+:where(.is-layout-constrained) > * + * { margin-block-start: var(--wp--style--block-gap, 24px); margin-block-end: 0; }
 .is-layout-flex { display: flex; flex-wrap: wrap; align-items: center; }
 .is-layout-flex > :is(*, div) { margin: 0; }
 .is-layout-grid { display: grid; }

--- a/packages/visual-editor-renderer-blade/tests/Feature/BlocksStylesComponentTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Feature/BlocksStylesComponentTest.php
@@ -98,6 +98,21 @@ it( 'silently skips theme.json entries missing slug or value', function () {
 		->not->toContain( 'missing-value' );
 } );
 
+it( 'emits the layout-flow block-gap baseline rule for sibling spacing', function () {
+	// Issue #539 — paragraphs (and any flow-layout children) had no
+	// vertical spacing because the canonical
+	// `:where(.is-layout-flow) > * + * { margin-block-start:
+	// var(--wp--style--block-gap, …) }` rule was not emitted anywhere.
+	// Assert the rule is present in the renderer-static baseline.
+	$rendered = Blade::render( '<x-ve-blocks-styles />' );
+
+	expect( $rendered )
+		->toContain( 'data-ve-layout-baseline' )
+		->toContain( ':where(.is-layout-flow) > * + *' )
+		->toContain( ':where(.is-layout-constrained) > * + *' )
+		->toContain( 'margin-block-start: var(--wp--style--block-gap, 24px)' );
+} );
+
 it( 'publishes block-library assets under the visual-editor-renderer-blade-assets tag', function () {
 	$artisan = $this->artisan( 'vendor:publish', [
 		'--tag'   => 'visual-editor-renderer-blade-assets',

--- a/packages/visual-editor-renderer-blade/tests/Unit/ThemeJsonTokensCompilerTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Unit/ThemeJsonTokensCompilerTest.php
@@ -258,6 +258,31 @@ describe( 'styles.* CSS rule emission', function (): void {
 			->toContain( 'padding: var(--wp--preset--spacing--40);' );
 	} );
 
+	it( 'emits per-block --wp--style--block-gap overrides that cascade to flow children', function (): void {
+		// Issue #539 — verify that a block-level spacing.blockGap is
+		// emitted as a per-container custom-property override, so the
+		// renderer-static `:where(.is-layout-flow) > * + *` rule
+		// (emitted by `<x-ve-blocks-styles />`) picks it up via the
+		// `var(--wp--style--block-gap, …)` reference and produces the
+		// correct sibling spacing inside that block.
+		$css = ( new ThemeJsonTokensCompiler() )->compile( [
+			'styles' => [
+				'spacing' => [ 'blockGap' => '2em' ],
+				'blocks'  => [
+					'artisanpack/group' => [
+						'spacing' => [ 'blockGap' => '3rem' ],
+					],
+				],
+			],
+		] );
+
+		expect( $css )
+			->toContain( 'body {' )
+			->toContain( '--wp--style--block-gap: 2em;' )
+			->toContain( '.wp-block-artisanpack-group {' )
+			->toContain( '--wp--style--block-gap: 3rem;' );
+	} );
+
 	it( 'descends into styles.blocks[X].elements with a descendant selector', function (): void {
 		$css = ( new ThemeJsonTokensCompiler() )->compile( [
 			'styles' => [

--- a/packages/visual-editor-renderer-react/src/LayoutBaseline.tsx
+++ b/packages/visual-editor-renderer-react/src/LayoutBaseline.tsx
@@ -1,0 +1,30 @@
+/**
+ * Emits the renderer-static layout baseline CSS — the `is-layout-flow`,
+ * `is-layout-constrained`, `is-layout-flex`, and `is-layout-grid` rules
+ * that make Gutenberg's flow / constrained / flex / grid containers
+ * actually lay out their children correctly on the public site.
+ *
+ * Mirrors the `<style data-ve-layout-baseline>` block emitted by the
+ * Blade renderer's `<x-ve-blocks-styles />` component byte-for-byte, so
+ * a React host that does not load the published Blade CSS bundle can
+ * still get the block-gap + flex-baseline behavior the visual editor's
+ * canvas already shows.
+ *
+ * Mount once near the top of the layout (alongside `<GlobalStyles />`).
+ * The component takes no props — the rules are renderer-static.
+ *
+ * @since 1.0.0
+ */
+
+import type { ReactElement } from 'react';
+
+import { LAYOUT_BASELINE_CSS } from './support/layoutBaselineCss';
+
+export function LayoutBaseline(): ReactElement {
+    return (
+        <style
+            data-ve-layout-baseline=""
+            dangerouslySetInnerHTML={{ __html: LAYOUT_BASELINE_CSS }}
+        />
+    );
+}

--- a/packages/visual-editor-renderer-react/src/index.ts
+++ b/packages/visual-editor-renderer-react/src/index.ts
@@ -19,6 +19,7 @@ export { DynamicBlock } from './DynamicBlock';
 export type { DynamicBlockProps } from './DynamicBlock';
 export { GlobalStyles } from './GlobalStyles';
 export type { GlobalStylesProps } from './GlobalStyles';
+export { LayoutBaseline } from './LayoutBaseline';
 export { UnknownBlock } from './blocks/unknownBlock';
 export {
     getBlockRenderer,

--- a/packages/visual-editor-renderer-react/src/support/layoutBaselineCss.ts
+++ b/packages/visual-editor-renderer-react/src/support/layoutBaselineCss.ts
@@ -1,0 +1,32 @@
+/**
+ * Renderer-static layout baseline CSS — shared between React's
+ * `<LayoutBaseline />` component and its Vue counterpart so all three
+ * renderers (Blade, React, Vue) emit byte-identical output.
+ *
+ * Mirrors the inline `<style data-ve-layout-baseline>` block in
+ * `packages/visual-editor-renderer-blade/resources/views/components/
+ * blocks-styles.blade.php`. Keep the strings in sync when changing one
+ * — the renderer parity tests assert on it.
+ *
+ * `:where()` on the flow/constrained selectors keeps specificity at
+ * (0,0,0) so any theme rule with higher specificity continues to win —
+ * matches WordPress's own output. The `var(--wp--style--block-gap,
+ * 24px)` fallback mirrors core's default when `theme.json` does not set
+ * `styles.spacing.blockGap`.
+ *
+ * @since 1.0.0
+ */
+
+export const LAYOUT_BASELINE_CSS =
+    ':where(.is-layout-flow) > :first-child { margin-block-start: 0; }\n' +
+    ':where(.is-layout-flow) > :last-child { margin-block-end: 0; }\n' +
+    ':where(.is-layout-flow) > * { margin-block-start: 0; margin-block-end: 0; }\n' +
+    ':where(.is-layout-flow) > * + * { margin-block-start: var(--wp--style--block-gap, 24px); margin-block-end: 0; }\n' +
+    ':where(.is-layout-constrained) > :first-child { margin-block-start: 0; }\n' +
+    ':where(.is-layout-constrained) > :last-child { margin-block-end: 0; }\n' +
+    ':where(.is-layout-constrained) > * { margin-block-start: 0; margin-block-end: 0; }\n' +
+    ':where(.is-layout-constrained) > * + * { margin-block-start: var(--wp--style--block-gap, 24px); margin-block-end: 0; }\n' +
+    '.is-layout-flex { display: flex; flex-wrap: wrap; align-items: center; }\n' +
+    '.is-layout-flex > :is(*, div) { margin: 0; }\n' +
+    '.is-layout-grid { display: grid; }\n' +
+    '.is-layout-grid > :is(*, div) { margin: 0; }';

--- a/packages/visual-editor-renderer-react/tests/LayoutBaseline.test.tsx
+++ b/packages/visual-editor-renderer-react/tests/LayoutBaseline.test.tsx
@@ -1,0 +1,34 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import '../src/index';
+import { LayoutBaseline } from '../src/LayoutBaseline';
+
+describe('LayoutBaseline', () => {
+    it('renders a <style data-ve-layout-baseline> tag', () => {
+        const { container } = render(<LayoutBaseline />);
+
+        const style = container.querySelector('style[data-ve-layout-baseline]');
+
+        expect(style).not.toBeNull();
+    });
+
+    it('emits the canonical is-layout-flow block-gap rule (issue #539)', () => {
+        const { container } = render(<LayoutBaseline />);
+
+        const css = container.querySelector('style[data-ve-layout-baseline]')?.innerHTML ?? '';
+
+        expect(css).toContain(':where(.is-layout-flow) > * + *');
+        expect(css).toContain(':where(.is-layout-constrained) > * + *');
+        expect(css).toContain('margin-block-start: var(--wp--style--block-gap, 24px)');
+    });
+
+    it('emits the flex + grid baselines', () => {
+        const { container } = render(<LayoutBaseline />);
+
+        const css = container.querySelector('style[data-ve-layout-baseline]')?.innerHTML ?? '';
+
+        expect(css).toContain('.is-layout-flex { display: flex;');
+        expect(css).toContain('.is-layout-grid { display: grid; }');
+    });
+});

--- a/packages/visual-editor-renderer-vue/src/LayoutBaseline.ts
+++ b/packages/visual-editor-renderer-vue/src/LayoutBaseline.ts
@@ -1,0 +1,37 @@
+/**
+ * Emits the renderer-static layout baseline CSS — the `is-layout-flow`,
+ * `is-layout-constrained`, `is-layout-flex`, and `is-layout-grid` rules
+ * that make Gutenberg's flow / constrained / flex / grid containers
+ * actually lay out their children correctly on the public site.
+ *
+ * Mirrors the `<style data-ve-layout-baseline>` block emitted by the
+ * Blade renderer's `<x-ve-blocks-styles />` component byte-for-byte, so
+ * a Vue host that does not load the published Blade CSS bundle can
+ * still get the block-gap + flex-baseline behavior the visual editor's
+ * canvas already shows.
+ *
+ * Mount once near the top of the layout (alongside `<GlobalStyles />`).
+ * The component takes no props — the rules are renderer-static.
+ *
+ * @since 1.0.0
+ */
+
+import { defineComponent, h } from 'vue';
+import type { VNode } from 'vue';
+
+import { LAYOUT_BASELINE_CSS } from './support/layoutBaselineCss';
+
+export const LayoutBaseline = defineComponent({
+    name: 'LayoutBaseline',
+    setup() {
+        return (): VNode =>
+            h(
+                'style',
+                {
+                    'data-ve-layout-baseline': '',
+                    innerHTML: LAYOUT_BASELINE_CSS,
+                },
+                []
+            );
+    },
+});

--- a/packages/visual-editor-renderer-vue/src/index.ts
+++ b/packages/visual-editor-renderer-vue/src/index.ts
@@ -19,6 +19,7 @@ export { DynamicBlock } from './DynamicBlock';
 export type { DynamicBlockProps } from './DynamicBlock';
 export { GlobalStyles } from './GlobalStyles';
 export type { GlobalStylesProps } from './GlobalStyles';
+export { LayoutBaseline } from './LayoutBaseline';
 export { UnknownBlock } from './blocks/unknownBlock';
 export {
     getBlockRenderer,

--- a/packages/visual-editor-renderer-vue/src/support/layoutBaselineCss.ts
+++ b/packages/visual-editor-renderer-vue/src/support/layoutBaselineCss.ts
@@ -1,0 +1,32 @@
+/**
+ * Renderer-static layout baseline CSS — shared between Vue's
+ * `<LayoutBaseline />` component and its React counterpart so all three
+ * renderers (Blade, React, Vue) emit byte-identical output.
+ *
+ * Mirrors the inline `<style data-ve-layout-baseline>` block in
+ * `packages/visual-editor-renderer-blade/resources/views/components/
+ * blocks-styles.blade.php`. Keep the strings in sync when changing one
+ * — the renderer parity tests assert on it.
+ *
+ * `:where()` on the flow/constrained selectors keeps specificity at
+ * (0,0,0) so any theme rule with higher specificity continues to win —
+ * matches WordPress's own output. The `var(--wp--style--block-gap,
+ * 24px)` fallback mirrors core's default when `theme.json` does not set
+ * `styles.spacing.blockGap`.
+ *
+ * @since 1.0.0
+ */
+
+export const LAYOUT_BASELINE_CSS =
+    ':where(.is-layout-flow) > :first-child { margin-block-start: 0; }\n' +
+    ':where(.is-layout-flow) > :last-child { margin-block-end: 0; }\n' +
+    ':where(.is-layout-flow) > * { margin-block-start: 0; margin-block-end: 0; }\n' +
+    ':where(.is-layout-flow) > * + * { margin-block-start: var(--wp--style--block-gap, 24px); margin-block-end: 0; }\n' +
+    ':where(.is-layout-constrained) > :first-child { margin-block-start: 0; }\n' +
+    ':where(.is-layout-constrained) > :last-child { margin-block-end: 0; }\n' +
+    ':where(.is-layout-constrained) > * { margin-block-start: 0; margin-block-end: 0; }\n' +
+    ':where(.is-layout-constrained) > * + * { margin-block-start: var(--wp--style--block-gap, 24px); margin-block-end: 0; }\n' +
+    '.is-layout-flex { display: flex; flex-wrap: wrap; align-items: center; }\n' +
+    '.is-layout-flex > :is(*, div) { margin: 0; }\n' +
+    '.is-layout-grid { display: grid; }\n' +
+    '.is-layout-grid > :is(*, div) { margin: 0; }';

--- a/packages/visual-editor-renderer-vue/tests/LayoutBaseline.test.ts
+++ b/packages/visual-editor-renderer-vue/tests/LayoutBaseline.test.ts
@@ -1,0 +1,30 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+
+import '../src/index';
+import { LayoutBaseline } from '../src/LayoutBaseline';
+
+describe('LayoutBaseline', () => {
+    it('renders a <style data-ve-layout-baseline> tag', () => {
+        const wrapper = mount(LayoutBaseline);
+
+        expect(wrapper.find('style[data-ve-layout-baseline]').exists()).toBe(true);
+    });
+
+    it('emits the canonical is-layout-flow block-gap rule (issue #539)', () => {
+        const wrapper = mount(LayoutBaseline);
+        const css = wrapper.find('style[data-ve-layout-baseline]').element.innerHTML;
+
+        expect(css).toContain(':where(.is-layout-flow) > * + *');
+        expect(css).toContain(':where(.is-layout-constrained) > * + *');
+        expect(css).toContain('margin-block-start: var(--wp--style--block-gap, 24px)');
+    });
+
+    it('emits the flex + grid baselines', () => {
+        const wrapper = mount(LayoutBaseline);
+        const css = wrapper.find('style[data-ve-layout-baseline]').element.innerHTML;
+
+        expect(css).toContain('.is-layout-flex { display: flex;');
+        expect(css).toContain('.is-layout-grid { display: grid; }');
+    });
+});


### PR DESCRIPTION
## Description

Renderers did not implement WordPress's block-gap system for flow-layout containers, so consecutive paragraph blocks (and any flow-layout children) rendered flush with zero spacing on the front end. This adds the canonical `:where(.is-layout-flow) > * + * { margin-block-start: var(--wp--style--block-gap, 24px) }` rule (and the constrained equivalent) to all three renderers so `theme.json` `styles.spacing.blockGap` is honored.

**Closes:** #539

## Type of Change

- [x] Bug fix (fixes an issue)

## Related Issue

**Issue:** #539

## Motivation and Context

The `ThemeJsonTokensCompiler` already emitted `--wp--style--block-gap` as a custom property, but nothing consumed it for sibling spacing in `is-layout-flow` / `is-layout-constrained` containers. Group blocks correctly emit the layout classes, but the CSS that turns those classes into spacing was missing — the canonical WordPress rule was nowhere in our bundled stylesheet or compiled output.

## Changes Made

- **Blade**: extended the existing `<style data-ve-layout-baseline>` block in `<x-ve-blocks-styles />` with the flow/constrained block-gap rules. `:where()` keeps specificity at (0,0,0) so theme overrides win.
- **React**: new `<LayoutBaseline />` component (`packages/visual-editor-renderer-react/src/LayoutBaseline.tsx`) sourcing CSS from a shared `LAYOUT_BASELINE_CSS` constant.
- **Vue**: matching `<LayoutBaseline />` component (`packages/visual-editor-renderer-vue/src/LayoutBaseline.ts`) using the same source string so output stays byte-identical across renderers.
- Per-block `--wp--style--block-gap` overrides emitted by `ThemeJsonTokensCompiler` cascade into the new rule via the `var(--wp--style--block-gap, …)` reference — no compiler changes needed.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (Darwin 25.5.0)
- Browser: Safari / Chrome
- PHP Version: 8.4.3
- Project Version: bugfix branch off `release/1.0`

**Tests Performed:**
1. Ran the full Pest suite — 880 tests pass (2458 assertions)
2. Ran the full vitest suite for React + Vue — 320 tests pass
3. Manual verification: rendered the M3 Smoke Test Post in the dev app's M9 Blade preview, confirmed paragraphs now have the default ~24px block-gap

## Accessibility Tests Run

- [x] Keyboard navigation tested — N/A (CSS-only change)
- [x] Screen reader tested — N/A (visual spacing only)
- [x] Color contrast verified — N/A
- [x] ARIA labels checked — N/A

**Details:** This is a CSS-only spacing change. Visual block separation improves readability for screen-reader users navigating by paragraph; no semantic changes.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:**
- `BlocksStylesComponentTest::emits the layout-flow block-gap baseline rule for sibling spacing` — asserts the rendered `<x-ve-blocks-styles />` contains `:where(.is-layout-flow) > * + *` and the `var(--wp--style--block-gap, 24px)` reference
- `ThemeJsonTokensCompilerTest::emits per-block --wp--style--block-gap overrides that cascade to flow children` — asserts root + per-block `blockGap` declarations are emitted as the new rule's variable source
- `LayoutBaseline.test.tsx` (React) + `LayoutBaseline.test.ts` (Vue) — assert each renderer emits a `<style data-ve-layout-baseline>` tag with the canonical flow/constrained rules and flex/grid baselines

## Documentation

- [x] Inline code documentation added
- [ ] README updated — N/A
- [ ] Wiki updated — follow-up if needed
- [ ] API documentation updated — N/A

**Documentation details:** New components (`LayoutBaseline` for React/Vue) carry JSDoc explaining when to mount them and the parity guarantee with Blade. Inline blade comment updated to cover flow + constrained in addition to flex + grid.

## Screenshots

Before: paragraphs flush with no spacing. After: ~24px gap between siblings, honoring `theme.json` `styles.spacing.blockGap` when set.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [x] Accessibility tests completed
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added layout baseline CSS styling across renderers for consistent block spacing behavior, including block gap fallback support and stable rendering for flow, constrained, flex, and grid layouts.

* **Tests**
  * Added comprehensive test coverage for layout baseline functionality across multiple renderers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->