### PR TITLE
fix(#542): resolve tsc --noEmit errors in core-data-shim

### DIFF
--- a/resources/js/visual-editor/vendor/__tests__/core-data-shim.test.tsx
+++ b/resources/js/visual-editor/vendor/__tests__/core-data-shim.test.tsx
@@ -507,7 +507,8 @@ describe('core-data-shim fetch → cache', () => {
         // wiped but `hasFinishedResolution` stayed true, so the next
         // read returned the empty wiped cache forever — until the user
         // refreshed the page.
-        const listFetcher = vi.fn(async (url: string) => {
+        const listFetcher = vi.fn(async (input: RequestInfo | URL, _init?: RequestInit) => {
+            const url = String(input);
             if (url.includes('per_page=-1')) {
                 return jsonResponse({
                     data: [
@@ -569,7 +570,8 @@ describe('core-data-shim fetch → cache', () => {
 
         configureCoreDataShim({
             apiBase: '/api',
-            fetcher: vi.fn(async (url: string) => {
+            fetcher: vi.fn(async (input: RequestInfo | URL, _init?: RequestInit) => {
+                const url = String(input);
                 if (url.includes('per_page=-1')) {
                     listFetchCount += 1;
 
@@ -1725,9 +1727,10 @@ describe('core-data-shim hooks', () => {
             },
         ]);
 
-        const [blocks] = renderHook(() =>
+        const [rawBlocks] = renderHook(() =>
             useEntityBlockEditor('postType', 'wp_template_part', { id: 1 }),
-        ) as readonly Array<{
+        );
+        const blocks = rawBlocks as ReadonlyArray<{
             name: string;
             clientId: string;
             isValid: true;
@@ -1774,9 +1777,10 @@ describe('core-data-shim hooks', () => {
             },
         ]);
 
-        const [blocks] = renderHook(() =>
+        const [rawBlocks] = renderHook(() =>
             useEntityBlockEditor('postType', 'wp_navigation', { id: 42 }),
-        ) as readonly Array<{
+        );
+        const blocks = rawBlocks as ReadonlyArray<{
             name: string;
             clientId: string;
             attributes: Record<string, unknown>;

--- a/resources/js/visual-editor/vendor/core-data-shim.ts
+++ b/resources/js/visual-editor/vendor/core-data-shim.ts
@@ -1765,6 +1765,10 @@ const actions = {
 
             const edited = select.getEditedEntityRecord(kind, name, id);
 
+            if (edited === null) {
+                return null;
+            }
+
             const config = select.getEntityConfig(kind, name);
             const payload: EntityRecord = config
                 ? { ...edited, [config.key]: id }
@@ -1986,11 +1990,8 @@ export function useEntityProp<T = unknown>(
     const ambientId = useEntityId();
     const resolvedId = id !== undefined && id !== null ? id : ambientId;
 
-    const { editedValue, fullValue } = useSelect<{
-        editedValue: T | undefined;
-        fullValue: T | undefined;
-    }>(
-        (select) => {
+    const { editedValue, fullValue } = useSelect(
+        (select: <S>(store: S) => unknown) => {
             if (
                 kind === undefined ||
                 name === undefined ||


### PR DESCRIPTION
## Description

Strict TypeScript checking (`npx tsc --noEmit`) surfaced 3 errors in `resources/js/visual-editor/vendor/core-data-shim.ts` and a related cluster in its test file. Vitest passed because esbuild skips strict type checks, but tagging `v1.0.0` requires a clean tsc pass. This PR fixes them.

**Closes:** #542

## Type of Change

- [x] Bug fix (fixes an issue)

## Related Issue

**Issue:** #542

## Motivation and Context

Per the v1.0.0 audit, `tsc --noEmit` must be green before tagging. The shim file had three real type holes that strict checking caught (one nullable-return, one misused `useSelect` generic, one cascading implicit-any), plus mirrored holes in its test file.

## Changes Made

- Guard `saveEditedEntityRecord` when `getEditedEntityRecord` returns `null` so the payload spread no longer trips strict `EntityRecord` typing.
- Drop the misused `useSelect<ReturnShape>` generic in `useEntityProp` — `useSelect`'s type parameter is the `MapSelect` callback, not the return shape — and type the `select` callback so it no longer falls back to `any`.
- Widen two `vi.fn` fetcher mocks in the test file to match `typeof fetch` (`(input: RequestInfo | URL, init?: RequestInit)`).
- Split the tuple destructure from the type cast on two `useEntityBlockEditor` `renderHook` calls. The previous `as readonly Array<...>` applied to the returned tuple (not the blocks array) and used the invalid `readonly Array<>` modifier syntax.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (Darwin 25.5.0)
- Browser: Safari (dev app)
- PHP Version: N/A
- Project Version: `release/1.0`

**Tests Performed:**
1. `npx tsc --noEmit` — no errors in `core-data-shim.ts` or its test file
2. `npx vitest run resources/js/visual-editor/vendor/__tests__/core-data-shim.test.tsx` — 72/72 passing
3. Manual smoke test of the save-edited-entity flow in the dev app — no regression

## Accessibility Tests Run

- [x] N/A — type-only and defensive null-guard changes; no UI surface affected

## Tests Added

- [x] All tests passing

**Test details:** Existing 72 tests in `core-data-shim.test.tsx` continue to pass; the file's own type holes are now also caught by tsc.

## Documentation

- [x] N/A

## Pre-Submission Checklist

- [x] Code passes all tests
- [x] Code has been linted
- [x] Self-review completed
- [x] No new warnings generated

## Follow-ups (pre-existing, surfaced during manual verification)

Two pre-existing issues were observed on `release/1.0` during manual verification of this fix; separate follow-up issues will be filed:

- Post editor title block reads correctly but does not update as the user types.
- Duplicate React keys (`small`, `large`) emitted by `FontSizePickerSelect` inside `@wordpress/components` when a block is selected.

Both reproduce without this branch's changes and are out of scope here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when saving records with no changes

* **Tests**
  * Updated test infrastructure for entity record operations and hook behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->