### PR TITLE
fix: add paragraph block-gap fix to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   constraint; the package PHP floor (`^8.2`) is unchanged for users
   staying on Laravel 11/12.
 
+### Fixed
+
+- **Paragraph block-gap spacing.** Paragraph blocks now correctly
+  inherit `is-layout-flow` block-gap spacing in the rendered output
+  (#540).
+
 ## [1.0.0-beta1] — V1 beta release
 
 First public beta of the V1 surface. Ships the post editor, the site


### PR DESCRIPTION
## Description

Add a `### Fixed` entry under `[Unreleased]` in `CHANGELOG.md` documenting the paragraph `is-layout-flow` block-gap fix shipped in commit `9548317` (PR #540). Without this entry, the fix would be missed when 1.0.0 is tagged.

**Closes:** #543

## Type of Change

- [x] Documentation update

## Related Issue

**Issue:** #543

## Motivation and Context

Surfaced by today's 1.0.0 audit — the `[Unreleased]` section only mentioned Laravel 13 support, omitting the paragraph block-gap fix from #540. Must be added before tagging 1.0.0 final for accurate release notes.

## Changes Made

- Added `### Fixed` subsection under `[Unreleased]` in `CHANGELOG.md`
- Documented the paragraph `is-layout-flow` block-gap fix with a link to #540

## How Has This Been Tested?

Documentation-only change; verified by reading the rendered changelog.

## Tests Added

- [x] No tests needed — documentation-only change

## Documentation

- [x] CHANGELOG updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed paragraph block gap spacing that now correctly inherits layout styles in the rendered output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->