### PR TITLE
feat: bundle FA Free SVGs + auto-register icon sets (#554)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,9 @@ dist/
 # predate this rule and stay tracked until a dedicated cleanup PR
 # removes them.
 resources/js/visual-editor/blocks/**/upstream-diff-report.json
+
+# Font Awesome Free SVGs are mirrored from `@fortawesome/fontawesome-free`
+# (a devDependency) by `scripts/sync-fa-icons.mjs` on every `npm run build`.
+# Tracking ~2,800 SVGs would bloat the repo for no gain — the script is
+# deterministic and the source is pinned in package.json. See #554.
+resources/icons/font-awesome/

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,8 @@
     "pestphp/pest": "^3.8",
     "pestphp/pest-plugin-laravel": "^3.1",
     "orchestra/testbench": "^10.2",
-    "artisanpack-ui/cms-framework": "^2.0"
+    "artisanpack-ui/cms-framework": "^2.0",
+    "artisanpack-ui/icons": "^2.1"
   },
   "repositories": [
     {
@@ -43,11 +44,19 @@
       "options": {
         "symlink": true
       }
+    },
+    {
+      "type": "path",
+      "url": "../icons",
+      "options": {
+        "symlink": true
+      }
     }
   ],
   "suggest": {
     "artisanpack-ui/media-library": "Recommended ^1.2 — default media library integration. Wire MediaModal + uploadMedia through registerArtisanpackMediaBridge() in the editor bootstrap to power Gutenberg's media picker and upload flows. Not enforced by Composer; host apps are free to install a different library and register a custom bridge instead.",
-    "artisanpack-ui/cms-framework": "Required ^2.0 for the site editor + comments family — the `/visual-editor/site-editor` route is hard-coupled to cms-framework's templates, parts, patterns, global styles, and menus modules (plan 14), and the comments-family forks (#519) consume the Blog module's `Comment` model + `Post::comments` relation introduced in 2.1. Without it, the post-content editor still works but the site editor route returns an install gate and the comments-family blocks render against an empty data set."
+    "artisanpack-ui/cms-framework": "Required ^2.0 for the site editor + comments family — the `/visual-editor/site-editor` route is hard-coupled to cms-framework's templates, parts, patterns, global styles, and menus modules (plan 14), and the comments-family forks (#519) consume the Blog module's `Comment` model + `Post::comments` relation introduced in 2.1. Without it, the post-content editor still works but the site editor route returns an install gate and the comments-family blocks render against an empty data set.",
+    "artisanpack-ui/icons": "Recommended ^2.1 — bundled FA Free Solid/Regular/Brands sets are registered against the icons package via the `ap.icons.register-icon-sets` filter. Without it, the icon block's `iconRef` paths render as `data-*` carriers (Phase 3, #554) and the picker has no registered icons to surface."
   },
   "_comments": {
     "repositories": "The path repository to ../cms-framework is a development-only convenience for the symlinked workflow used in the dev-app (see ../artisanpack-ui-dev/composer.json). On a fresh clone without the sibling cms-framework checkout, composer install will fail to resolve cms-framework — that's expected for now; the package's release pipeline pulls cms-framework from Packagist via the ^2.0 constraint. CI removes this entry before installing. Tracked for a permanent fix (e.g. an env-gated repository) in #434."

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4e240ef1b479ccbfa9aec61b9f816cd9",
+    "content-hash": "1aef3f90104059beb0c5b3342efce7a9",
     "packages": [
         {
             "name": "artisanpack-ui/core",
@@ -6009,21 +6009,23 @@
         },
         {
             "name": "artisanpack-ui/cms-framework",
-            "version": "1.1.0",
+            "version": "2.2.2",
             "dist": {
                 "type": "path",
                 "url": "../cms-framework",
-                "reference": "b6d2685501ac8f8f0c84aa20928781901d495c70"
+                "reference": "ea984babeddcb5cae5de647282b51bea530e33d8"
             },
             "require": {
                 "artisanpack-ui/accessibility": "^2.1.0",
                 "artisanpack-ui/core": "^1.0",
                 "artisanpack-ui/hooks": "^1.1",
-                "artisanpack-ui/security": "^1.0.3",
+                "artisanpack-ui/rbac": "^1.0",
+                "artisanpack-ui/security": "^1.0.3|^2.0",
                 "dedoc/scramble": "^0.12 || ^0.13",
-                "illuminate/support": "^12.17.0",
+                "illuminate/support": "^12.17.0|^13.0",
                 "justinrainbow/json-schema": "^6.0",
-                "laravel/framework": "^12.0",
+                "laravel/framework": "^12.0|^13.0",
+                "laravel/sanctum": "^4.0.8",
                 "laravel/tinker": "^2.10.1",
                 "php": "^8.2"
             },
@@ -6118,6 +6120,141 @@
             }
         },
         {
+            "name": "artisanpack-ui/icons",
+            "version": "2.1.1",
+            "dist": {
+                "type": "path",
+                "url": "../icons",
+                "reference": "66909169481bb99c6dfd19dc98fc873078d07ded"
+            },
+            "require": {
+                "artisanpack-ui/hooks": "^1.0",
+                "blade-ui-kit/blade-icons": "^1.8",
+                "illuminate/support": "^12.0 || ^13.0",
+                "php": "^8.2"
+            },
+            "require-dev": {
+                "artisanpack-ui/code-style": "^1.0",
+                "artisanpack-ui/code-style-pint": "^1.0",
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.1",
+                "laravel/pint": "^1.25",
+                "mockery/mockery": "^1.6",
+                "orchestra/testbench": "^10.0 || ^11.0",
+                "pestphp/pest": "^3.5",
+                "pestphp/pest-plugin-laravel": "^3.0",
+                "phpunit/phpunit": "^11.5",
+                "squizlabs/php_codesniffer": "^3.13"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "ArtisanPackUI\\Icons\\IconsServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "ArtisanPackUI\\Icons\\": "src/"
+                }
+            },
+            "autoload-dev": {
+                "psr-4": {
+                    "Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ],
+                "code-style": [
+                    "./vendor/bin/phpcs --standard=ArtisanPackUIStandard src"
+                ]
+            },
+            "license": [
+                "MIT"
+            ],
+            "description": "An extensibility layer for Blade Icons that enables flexible registration of custom SVG icon sets via config or events.",
+            "transport-options": {
+                "symlink": true,
+                "relative": true
+            }
+        },
+        {
+            "name": "artisanpack-ui/rbac",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ArtisanPack-UI/rbac.git",
+                "reference": "43f7c5a250d9a6189ba7d53db332e36340503d84"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ArtisanPack-UI/rbac/zipball/43f7c5a250d9a6189ba7d53db332e36340503d84",
+                "reference": "43f7c5a250d9a6189ba7d53db332e36340503d84",
+                "shasum": ""
+            },
+            "require": {
+                "artisanpack-ui/core": "^1.0",
+                "illuminate/support": "^10.0|^11.0|^12.0",
+                "php": "^8.2"
+            },
+            "require-dev": {
+                "artisanpack-ui/code-style": "^1.1",
+                "artisanpack-ui/code-style-pint": "^1.1",
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "friendsofphp/php-cs-fixer": "^3.75",
+                "laravel/pint": "^1.26",
+                "orchestra/testbench": "^10.2",
+                "pestphp/pest": "^3.8",
+                "pestphp/pest-plugin-laravel": "^3.2"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "Rbac": "ArtisanPackUI\\Rbac\\Facades\\Rbac"
+                    },
+                    "providers": [
+                        "ArtisanPackUI\\Rbac\\RbacServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "ArtisanPackUI\\Rbac\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jacob Martella",
+                    "email": "support@artisanpackui.dev"
+                }
+            ],
+            "description": "Role-based access control for Laravel — roles with hierarchy, permissions, Blade directives, middleware, and Gate integration.",
+            "keywords": [
+                "access-control",
+                "authorization",
+                "laravel",
+                "permissions",
+                "rbac",
+                "roles",
+                "security"
+            ],
+            "support": {
+                "issues": "https://github.com/ArtisanPack-UI/rbac/issues",
+                "source": "https://github.com/ArtisanPack-UI/rbac/tree/v1.0.0"
+            },
+            "time": "2026-05-19T19:17:08+00:00"
+        },
+        {
             "name": "artisanpack-ui/security",
             "version": "1.0.3",
             "source": {
@@ -6177,6 +6314,87 @@
                 "source": "https://github.com/ArtisanPack-UI/security/tree/v1.0.3"
             },
             "time": "2025-05-14T21:45:20+00:00"
+        },
+        {
+            "name": "blade-ui-kit/blade-icons",
+            "version": "1.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/driesvints/blade-icons.git",
+                "reference": "74189a80bbaa4966aebaee54fec3a3c2ef0a5f3a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/driesvints/blade-icons/zipball/74189a80bbaa4966aebaee54fec3a3c2ef0a5f3a",
+                "reference": "74189a80bbaa4966aebaee54fec3a3c2ef0a5f3a",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/contracts": "^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
+                "illuminate/filesystem": "^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
+                "illuminate/support": "^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
+                "illuminate/view": "^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
+                "php": "^7.4|^8.0",
+                "symfony/console": "^5.3|^6.0|^7.0|^8.0",
+                "symfony/finder": "^5.3|^6.0|^7.0|^8.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.5.1",
+                "orchestra/testbench": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
+                "phpunit/phpunit": "^9.0|^10.5|^11.0"
+            },
+            "bin": [
+                "bin/blade-icons-generate"
+            ],
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "BladeUI\\Icons\\BladeIconsServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "BladeUI\\Icons\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Dries Vints",
+                    "homepage": "https://driesvints.com"
+                }
+            ],
+            "description": "A package to easily make use of icons in your Laravel Blade views.",
+            "homepage": "https://github.com/driesvints/blade-icons",
+            "keywords": [
+                "blade",
+                "icons",
+                "laravel",
+                "svg"
+            ],
+            "support": {
+                "issues": "https://github.com/driesvints/blade-icons/issues",
+                "source": "https://github.com/driesvints/blade-icons"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/driesvints",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.paypal.com/paypalme/driesvints",
+                    "type": "paypal"
+                }
+            ],
+            "time": "2026-04-23T19:03:45+00:00"
         },
         {
             "name": "brianium/paratest",
@@ -6997,6 +7215,69 @@
                 "source": "https://github.com/laravel/pail"
             },
             "time": "2026-02-09T13:44:54+00:00"
+        },
+        {
+            "name": "laravel/sanctum",
+            "version": "v4.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/sanctum.git",
+                "reference": "2a9bccc18e9907808e0018dd15fa643937886b1e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/sanctum/zipball/2a9bccc18e9907808e0018dd15fa643937886b1e",
+                "reference": "2a9bccc18e9907808e0018dd15fa643937886b1e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "illuminate/console": "^11.0|^12.0|^13.0",
+                "illuminate/contracts": "^11.0|^12.0|^13.0",
+                "illuminate/database": "^11.0|^12.0|^13.0",
+                "illuminate/support": "^11.0|^12.0|^13.0",
+                "php": "^8.2",
+                "symfony/console": "^7.0|^8.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.6",
+                "orchestra/testbench": "^9.15|^10.8|^11.0",
+                "phpstan/phpstan": "^1.10"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Laravel\\Sanctum\\SanctumServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\Sanctum\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "Laravel Sanctum provides a featherweight authentication system for SPAs and simple APIs.",
+            "keywords": [
+                "auth",
+                "laravel",
+                "sanctum"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/sanctum/issues",
+                "source": "https://github.com/laravel/sanctum"
+            },
+            "time": "2026-04-30T11:46:25+00:00"
         },
         {
             "name": "laravel/tinker",

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
                 "zustand": "^5.0.12"
             },
             "devDependencies": {
+                "@fortawesome/fontawesome-free": "^7.2.0",
                 "@testing-library/dom": "^10.4.0",
                 "@testing-library/jest-dom": "^6.4.6",
                 "@testing-library/react": "^16.1.0",
@@ -1278,6 +1279,16 @@
             "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-7.2.0.tgz",
             "integrity": "sha512-IpR0bER9FY25p+e7BmFH25MZKEwFHTfRAfhOyJubgiDnoJNsSvJ7nigLraHtp4VOG/cy8D7uiV0dLkHOne5Fhw==",
             "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/@fortawesome/fontawesome-free": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-7.2.0.tgz",
+            "integrity": "sha512-3DguDv/oUE+7vjMeTSOjCSG+KeawgVQOHrKRnvUuqYh1mfArrh7s+s8hXW3e4RerBA1+Wh+hBqf8sJNpqNrBWg==",
+            "dev": true,
+            "license": "(CC-BY-4.0 AND OFL-1.1 AND MIT)",
             "engines": {
                 "node": ">=6"
             }

--- a/package.json
+++ b/package.json
@@ -16,15 +16,18 @@
     "scripts": {
         "dev": "vite",
         "dev:sandbox": "vite resources/js/visual-editor/sandbox --port 5176",
+        "prebuild": "node scripts/sync-fa-icons.mjs",
         "build": "vite build",
         "build:lib": "vite build --mode lib",
         "test": "vitest run",
         "test:watch": "vitest",
         "i18n:extract": "node scripts/extract-pot.mjs",
+        "sync:fa-icons": "node scripts/sync-fa-icons.mjs",
         "verify:parity": "node scripts/verify-renderer-parity.mjs",
         "upstream-diff": "node scripts/upstream-diff.mjs"
     },
     "devDependencies": {
+        "@fortawesome/fontawesome-free": "^7.2.0",
         "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^6.4.6",
         "@testing-library/react": "^16.1.0",

--- a/scripts/sync-fa-icons.mjs
+++ b/scripts/sync-fa-icons.mjs
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+/**
+ * sync-fa-icons — copy Font Awesome Free SVGs + build the search index.
+ *
+ * Phase 3 of the Icon Block feature (#494, issue #554). Mirrors the SVGs
+ * from `@fortawesome/fontawesome-free` (a devDependency) into the package's
+ * tracked icon directory layout so the PHP icons registry can resolve
+ * `iconRef` markers without reaching into node_modules at runtime.
+ *
+ * Output layout:
+ *   resources/icons/font-awesome/
+ *     fas/<name>.svg     (solid)
+ *     far/<name>.svg     (regular)
+ *     fab/<name>.svg     (brands)
+ *     index.json         { version, generatedAt, sets, icons[] }
+ *
+ * The output directory is .gitignored — `npm run build` (which runs the
+ * `prebuild` hook) keeps it in sync. The icons-registry filter in
+ * VisualEditorServiceProvider is_dir-gates each set so a fresh checkout
+ * boots even before the first `npm run build`.
+ */
+
+import { copyFileSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync, existsSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __filename = fileURLToPath( import.meta.url )
+const __dirname = dirname( __filename )
+const PACKAGE_ROOT = resolve( __dirname, '..' )
+
+const SOURCE_ROOT = resolve( PACKAGE_ROOT, 'node_modules/@fortawesome/fontawesome-free' )
+const DEST_ROOT = resolve( PACKAGE_ROOT, 'resources/icons/font-awesome' )
+
+// FA ships SVGs under `svgs/{solid,regular,brands}/<name>.svg`. We expose
+// them under prefix directories that match the FA CSS class shorthand
+// (`fas`/`far`/`fab`) so the iconRef in saved block content stays compact.
+const SETS = [
+	{ prefix: 'fas', source: 'solid', label: 'Solid' },
+	{ prefix: 'far', source: 'regular', label: 'Regular' },
+	{ prefix: 'fab', source: 'brands', label: 'Brands' },
+]
+
+function fail( message ) {
+	console.error( `[sync-fa-icons] ${ message }` )
+	process.exit( 1 )
+}
+
+function readJson( filePath ) {
+	try {
+		return JSON.parse( readFileSync( filePath, 'utf8' ) )
+	} catch ( err ) {
+		fail( `Failed to parse ${ filePath }: ${ err.message }` )
+	}
+}
+
+function readSourceVersion() {
+	const pkgPath = join( SOURCE_ROOT, 'package.json' )
+	if ( ! existsSync( pkgPath ) ) {
+		fail(
+			`Font Awesome Free not installed. Run \`npm install\` to pull \`@fortawesome/fontawesome-free\` ` +
+			`(declared as a devDependency in package.json).`,
+		)
+	}
+	return readJson( pkgPath ).version
+}
+
+function readMetadata() {
+	// `icon-families.json` is the canonical index — it carries the search
+	// terms and human labels that Phase 4's server search needs. Falling
+	// back to bare filenames is acceptable if the metadata vanishes in a
+	// future FA release, but we want to know if that happens.
+	const metaPath = join( SOURCE_ROOT, 'metadata/icon-families.json' )
+	if ( ! existsSync( metaPath ) ) {
+		console.warn( '[sync-fa-icons] icon-families.json missing — search terms will be empty.' )
+		return {}
+	}
+	return readJson( metaPath )
+}
+
+function resetDir( path ) {
+	rmSync( path, { recursive: true, force: true } )
+	mkdirSync( path, { recursive: true } )
+}
+
+function copySet( set ) {
+	const sourceDir = join( SOURCE_ROOT, 'svgs', set.source )
+	const destDir = join( DEST_ROOT, set.prefix )
+
+	if ( ! existsSync( sourceDir ) ) {
+		fail( `Source directory missing: ${ sourceDir }` )
+	}
+
+	resetDir( destDir )
+
+	const files = readdirSync( sourceDir ).filter( f => f.endsWith( '.svg' ) )
+	for ( const file of files ) {
+		copyFileSync( join( sourceDir, file ), join( destDir, file ) )
+	}
+
+	return files.map( f => f.slice( 0, -4 ) ).sort()
+}
+
+function buildIndex( setResults, metadata, version ) {
+	// One row per (icon, set) pair so Phase 4's search can filter by family
+	// without re-walking the directory tree. `terms` is the searchable
+	// haystack; `label` is what the picker displays.
+	const icons = []
+	for ( const { set, names } of setResults ) {
+		for ( const name of names ) {
+			const meta = metadata[ name ] ?? {}
+			const terms = Array.isArray( meta?.search?.terms ) ? meta.search.terms.map( String ) : []
+			icons.push( {
+				name,
+				set: set.prefix,
+				label: typeof meta.label === 'string' ? meta.label : name,
+				terms,
+			} )
+		}
+	}
+
+	return {
+		version,
+		generatedAt: new Date().toISOString(),
+		sets: SETS.map( s => ( { prefix: s.prefix, label: s.label, source: s.source } ) ),
+		icons,
+	}
+}
+
+function main() {
+	const version = readSourceVersion()
+	const metadata = readMetadata()
+
+	mkdirSync( DEST_ROOT, { recursive: true } )
+
+	const results = SETS.map( set => ( { set, names: copySet( set ) } ) )
+
+	const index = buildIndex( results, metadata, version )
+	writeFileSync( join( DEST_ROOT, 'index.json' ), JSON.stringify( index, null, 2 ) + '\n' )
+
+	const total = results.reduce( ( n, r ) => n + r.names.length, 0 )
+	console.log( `[sync-fa-icons] mirrored ${ total } icons from FA Free ${ version }` )
+	for ( const { set, names } of results ) {
+		console.log( `[sync-fa-icons]   ${ set.prefix } (${ set.label }): ${ names.length }` )
+	}
+}
+
+main()

--- a/src/Blocks/Icon/IconBlock.php
+++ b/src/Blocks/Icon/IconBlock.php
@@ -401,7 +401,15 @@ class IconBlock extends DynamicBlock
 		return preg_replace_callback(
 			'/<svg\b([^>]*)>/i',
 			static function ( array $match ): string {
-				$attrs = preg_replace( '/\s+(width|height)\s*=\s*"[^"]*"/i', '', $match[1] ) ?? $match[1];
+				// Match any value quoting style — `width="24"`, `width='24'`,
+				// or unquoted `width=24` — so an admin-uploaded set with an
+				// HTML-lenient SVG can't smuggle a duplicate sizing attr
+				// past the rewrite.
+				$attrs = preg_replace(
+					'/\s+(width|height)\s*=\s*(?:"[^"]*"|\'[^\']*\'|[^\s>]+)/i',
+					'',
+					$match[1],
+				) ?? $match[1];
 
 				return '<svg width="100%" height="100%"' . $attrs . '>';
 			},

--- a/src/Blocks/Icon/IconBlock.php
+++ b/src/Blocks/Icon/IconBlock.php
@@ -7,7 +7,7 @@
  * style/transform computation, link wrapping, a11y attribute emission,
  * and custom-SVG sanitization via {@see SvgSanitizer}. The icon-registry
  * resolution path (turning an `iconRef` into inline SVG markup) is wired
- * in Phase 3 (#554) when the FA 6 Free SVGs ship.
+ * in Phase 3 (#554) when the FA Free SVGs ship.
  *
  * @package    ArtisanPack_UI
  * @subpackage VisualEditor
@@ -22,6 +22,7 @@ declare( strict_types=1 );
 namespace ArtisanPackUI\VisualEditor\Blocks\Icon;
 
 use ArtisanPackUI\VisualEditor\Blocks\DynamicBlock;
+use ArtisanPackUI\VisualEditor\Services\Icon\IconSvgResolver;
 use ArtisanPackUI\VisualEditor\Services\Icon\SvgSanitizer;
 
 class IconBlock extends DynamicBlock
@@ -30,8 +31,10 @@ class IconBlock extends DynamicBlock
 	private const ALLOWED_ROTATIONS     = [ 0, 90, 180, 270 ];
 	private const ALLOWED_LINK_TARGETS  = [ '_blank', '_self', '_parent', '_top' ];
 
-	public function __construct( private readonly SvgSanitizer $sanitizer )
-	{
+	public function __construct(
+		private readonly SvgSanitizer $sanitizer,
+		private readonly ?IconSvgResolver $resolver = null,
+	) {
 	}
 
 	public function name(): string
@@ -128,15 +131,30 @@ class IconBlock extends DynamicBlock
 		}
 
 		if ( null !== $attrs['iconRef'] ) {
-			// Phase 3 (#554) swaps this `data-*` carrier for the resolved
-			// inline `<svg>` once the FA 6 Free SVGs are bundled and the
-			// icons registry is consulted at render time.
+			$resolved = null !== $this->resolver
+				? $this->resolver->resolve( $attrs['iconRef']['set'], $attrs['iconRef']['name'] )
+				: null;
+
+			if ( null !== $resolved ) {
+				return sprintf(
+					'<span class="wp-block-artisanpack-icon__ref" data-icon-set="%s" data-icon-name="%s" style="%s"%s>%s</span>',
+					e( $attrs['iconRef']['set'] ),
+					e( $attrs['iconRef']['name'] ),
+					e( $bodyStyle ),
+					$ariaAttrs,
+					$this->prepareInlineSvg( $resolved )
+				);
+			}
+
+			// Resolver miss — sync hasn't run, set not registered, or icon
+			// removed upstream. Falling back to the placeholder keeps the
+			// layout stable rather than leaving an empty `data-*` carrier
+			// the front end has no way to fill.
 			return sprintf(
-				'<span class="wp-block-artisanpack-icon__ref" data-icon-set="%s" data-icon-name="%s" style="%s"%s></span>',
+				'<span class="wp-block-artisanpack-icon__placeholder" data-icon-set="%s" data-icon-name="%s" style="%s" aria-hidden="true"></span>',
 				e( $attrs['iconRef']['set'] ),
 				e( $attrs['iconRef']['name'] ),
-				e( $bodyStyle ),
-				$ariaAttrs
+				e( $bodyStyle )
 			);
 		}
 
@@ -353,6 +371,43 @@ class IconBlock extends DynamicBlock
 		}
 
 		return $trimmed;
+	}
+
+	/**
+	 * Inline-ready SVG markup.
+	 *
+	 * FA Free SVGs ship without `width`/`height` attributes, which means
+	 * an inline `<svg>` falls back to the spec's 300×150 default and
+	 * overflows the sized wrapper span. Inject `width="100%"` /
+	 * `height="100%"` on the root `<svg>` so the SVG fills the wrapper's
+	 * declared box. Strip any existing `width`/`height` first so an icon
+	 * set with intrinsic dimensions (e.g. an admin-uploaded set in Phase 6)
+	 * doesn't fight the wrapper.
+	 *
+	 * The bundled FA Free SVGs are trusted (pinned npm dep, npm-supply-
+	 * chain risk only) — we do NOT route them through {@see SvgSanitizer}
+	 * because doing so on every render would burn DOMDocument cost for no
+	 * security gain. Admin-uploaded sets in Phase 6 (#557) will sanitize
+	 * at upload time, not at render time.
+	 */
+	private function prepareInlineSvg( string $svg ): string
+	{
+		// Single-pass rewrite of the opening `<svg …>` tag: strip every
+		// existing `width`/`height` attribute, then prepend the wrapper-
+		// fill pair. Doing this in two preg_replace calls leaks duplicate
+		// attributes when both are present, because `preg_replace` won't
+		// match a second `width|height` inside the same `<svg …>` opener
+		// once its lazy-match starting cursor has advanced past it.
+		return preg_replace_callback(
+			'/<svg\b([^>]*)>/i',
+			static function ( array $match ): string {
+				$attrs = preg_replace( '/\s+(width|height)\s*=\s*"[^"]*"/i', '', $match[1] ) ?? $match[1];
+
+				return '<svg width="100%" height="100%"' . $attrs . '>';
+			},
+			$svg,
+			1,
+		) ?? $svg;
 	}
 
 	private function formatNumber( float $value ): string

--- a/src/Services/Icon/FontAwesomeFreeIconSets.php
+++ b/src/Services/Icon/FontAwesomeFreeIconSets.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * Font Awesome Free icon-set discovery + filter registration.
+ *
+ * Phase 3 of the Icon Block feature (#494, issue #554). The actual SVGs
+ * are mirrored from `@fortawesome/fontawesome-free` into
+ * `resources/icons/font-awesome/{fas,far,fab}/` by `scripts/sync-fa-icons.mjs`.
+ * This helper turns the on-disk layout into icon-set entries that the
+ * `artisanpack-ui/icons` registry consumes via the
+ * `ap.icons.register-icon-sets` filter.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.1.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Services\Icon;
+
+use ArtisanPackUI\Icons\Registries\IconSetRegistration;
+
+/**
+ * The discovery + registration step is split from the service provider so
+ * Pest can drive it against fixture directories without booting Testbench.
+ * `discover()` is the pure path-collection step; `register()` walks the
+ * discovered sets into the registry and tolerates a missing base directory
+ * (e.g. a fresh checkout that hasn't run `npm run build` yet — boot must
+ * not fail in that case).
+ */
+final class FontAwesomeFreeIconSets
+{
+	/**
+	 * @var array<int, string>
+	 */
+	public const SET_PREFIXES = [ 'fas', 'far', 'fab' ];
+
+	/**
+	 * Return the absolute path for each FA Free set whose directory exists
+	 * under `$baseDir`. Missing sets are silently skipped so a partial
+	 * sync still surfaces the sets that did land.
+	 *
+	 * @return array<string, string> Map of prefix → absolute path.
+	 */
+	public static function discover( string $baseDir ): array
+	{
+		$found = [];
+		foreach ( self::SET_PREFIXES as $prefix ) {
+			$path = $baseDir . DIRECTORY_SEPARATOR . $prefix;
+			if ( is_dir( $path ) ) {
+				$found[ $prefix ] = $path;
+			}
+		}
+
+		return $found;
+	}
+
+	/**
+	 * Register each discovered set on the supplied `IconSetRegistration`.
+	 *
+	 * Returns the same registry instance so this method can be used as the
+	 * body of an `ap.icons.register-icon-sets` filter callback. The
+	 * registry's `addSet()` throws when handed a non-existent path, which
+	 * is exactly why `discover()` filters them first — we want to no-op,
+	 * not blow up, when the FA Free directory is missing.
+	 */
+	public static function register( IconSetRegistration $registry, string $baseDir ): IconSetRegistration
+	{
+		foreach ( self::discover( $baseDir ) as $prefix => $path ) {
+			$registry->addSet( $path, $prefix );
+		}
+
+		return $registry;
+	}
+}

--- a/src/Services/Icon/IconSvgResolver.php
+++ b/src/Services/Icon/IconSvgResolver.php
@@ -1,0 +1,104 @@
+<?php
+
+/**
+ * Reads an iconRef `(set, name)` into the inline SVG markup we drop into
+ * the rendered Icon Block.
+ *
+ * The resolver is constructed once per request from the icon-sets
+ * registry (`ap.icons.register-icon-sets` filter result) and cached as a
+ * singleton. Lookups are file-system reads against the registered set
+ * paths — bundled FA Free SVGs live under `resources/icons/font-awesome/`
+ * after `scripts/sync-fa-icons.mjs` runs.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.1.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Services\Icon;
+
+use Closure;
+
+/**
+ * `IconBlock` already normalizes the `(set, name)` pair to a tight
+ * character class before it reaches `resolve()`, so joining them onto
+ * the registered set path can't escape the set's directory. Keeping the
+ * resolver dumb (string in, string out) lets tests drive it with a
+ * fixture path map without touching the icons package.
+ *
+ * The path map can be supplied either eagerly (an `array` for tests +
+ * fixtures) or lazily (a `Closure` that returns the array). The lazy
+ * form is what production uses: the icon-sets registry is built from
+ * the `ap.icons.register-icon-sets` filter, and that filter's
+ * callbacks are registered across multiple providers' `boot()` phases.
+ * Running the filter at singleton-construction time would race against
+ * those registrations — `IconBlock` is constructed early in `boot()`,
+ * before every provider's boot has finished — so we defer until the
+ * first `resolve()` call, which only ever fires at request time.
+ */
+final class IconSvgResolver
+{
+	/**
+	 * @var array<string, string>|null
+	 */
+	private ?array $resolvedPaths;
+
+	/**
+	 * @var Closure|null
+	 */
+	private $loader;
+
+	/**
+	 * @param  array<string, string>|Closure|null $source  Path map, or a
+	 *         `Closure(): array<string, string>` evaluated on first resolve.
+	 */
+	public function __construct( array|Closure|null $source = null )
+	{
+		if ( $source instanceof Closure ) {
+			$this->loader         = $source;
+			$this->resolvedPaths  = null;
+		} else {
+			$this->resolvedPaths = is_array( $source ) ? $source : [];
+			$this->loader        = null;
+		}
+	}
+
+	/**
+	 * Return the raw SVG markup for `(set, name)`, or `null` if no
+	 * registered set serves the requested icon.
+	 */
+	public function resolve( string $set, string $name ): ?string
+	{
+		$paths = $this->setPaths();
+		if ( ! isset( $paths[ $set ] ) ) {
+			return null;
+		}
+
+		$file = $paths[ $set ] . DIRECTORY_SEPARATOR . $name . '.svg';
+		if ( ! is_file( $file ) ) {
+			return null;
+		}
+
+		$contents = @file_get_contents( $file );
+
+		return false === $contents ? null : $contents;
+	}
+
+	/**
+	 * @return array<string, string>
+	 */
+	public function setPaths(): array
+	{
+		if ( null === $this->resolvedPaths ) {
+			$loaded              = null !== $this->loader ? ( $this->loader )() : [];
+			$this->resolvedPaths = is_array( $loaded ) ? $loaded : [];
+		}
+
+		return $this->resolvedPaths;
+	}
+}

--- a/src/Services/Icon/IconSvgResolver.php
+++ b/src/Services/Icon/IconSvgResolver.php
@@ -71,9 +71,23 @@ final class IconSvgResolver
 	/**
 	 * Return the raw SVG markup for `(set, name)`, or `null` if no
 	 * registered set serves the requested icon.
+	 *
+	 * Inputs are re-validated at the service boundary instead of trusting
+	 * callers' normalization — `IconBlock::normalizeIconRef()` is the
+	 * primary gate, but the resolver is a public service that other
+	 * callers (admin upload preview in Phase 6, future REST endpoints)
+	 * can reach, and a path-traversal escape here would expose the host
+	 * file system. Set/name allowlist mirrors the icons-registry folder
+	 * shape; `..` is explicitly rejected so a name that satisfies the
+	 * regex but encodes a parent-directory hop (e.g. `a..b`) can't
+	 * resolve to a file outside the set's directory.
 	 */
 	public function resolve( string $set, string $name ): ?string
 	{
+		if ( ! $this->isValidSet( $set ) || ! $this->isValidName( $name ) ) {
+			return null;
+		}
+
 		$paths = $this->setPaths();
 		if ( ! isset( $paths[ $set ] ) ) {
 			return null;
@@ -87,6 +101,20 @@ final class IconSvgResolver
 		$contents = @file_get_contents( $file );
 
 		return false === $contents ? null : $contents;
+	}
+
+	private function isValidSet( string $set ): bool
+	{
+		return 1 === preg_match( '/^[a-z0-9][a-z0-9_-]*$/i', $set );
+	}
+
+	private function isValidName( string $name ): bool
+	{
+		if ( str_contains( $name, '..' ) ) {
+			return false;
+		}
+
+		return 1 === preg_match( '/^[a-z0-9][a-z0-9_.-]*$/i', $name );
 	}
 
 	/**

--- a/src/VisualEditorServiceProvider.php
+++ b/src/VisualEditorServiceProvider.php
@@ -8,7 +8,10 @@ use ArtisanPackUI\VisualEditor\Blocks\Core\CategoriesBlock;
 use ArtisanPackUI\VisualEditor\Blocks\Core\LatestPostsBlock;
 use ArtisanPackUI\VisualEditor\Blocks\Core\TagCloudBlock;
 use ArtisanPackUI\VisualEditor\Blocks\Forms\FormBlock;
+use ArtisanPackUI\Icons\Registries\IconSetRegistration;
 use ArtisanPackUI\VisualEditor\Blocks\Icon\IconBlock;
+use ArtisanPackUI\VisualEditor\Services\Icon\FontAwesomeFreeIconSets;
+use ArtisanPackUI\VisualEditor\Services\Icon\IconSvgResolver;
 use ArtisanPackUI\VisualEditor\Services\Icon\SvgSanitizer;
 use ArtisanPackUI\VisualEditor\MediaBridge\GutenbergAttachmentAdapter;
 use ArtisanPackUI\VisualEditor\Services\Adapters\CmsFramework\CmsFrameworkQueryResolver;
@@ -65,6 +68,37 @@ class VisualEditorServiceProvider extends ServiceProvider
 		// (the admin-upload pipeline in Phase 6 #557) can reuse one copy.
 		$this->app->singleton( SvgSanitizer::class, function () {
 			return new SvgSanitizer();
+		} );
+
+		// Icon Block Phase 3 (#554): defer the icon-sets-registry walk
+		// until the first `resolve()` call. IconBlock is constructed
+		// inside boot() (via registerReferenceBlocks), which happens
+		// BEFORE every provider's `addFilter('ap.icons.register-icon-sets',
+		// …)` has fired. Computing the path map eagerly here would race
+		// against those registrations and produce an empty resolver. The
+		// closure runs at request time, by which point boot is finished
+		// and the filter chain is complete.
+		$this->app->singleton( IconSvgResolver::class, function (): IconSvgResolver {
+			return new IconSvgResolver( static function (): array {
+				if ( ! class_exists( IconSetRegistration::class ) || ! function_exists( 'applyFilters' ) ) {
+					return [];
+				}
+
+				$registry = applyFilters( 'ap.icons.register-icon-sets', new IconSetRegistration() );
+				if ( ! $registry instanceof IconSetRegistration ) {
+					return [];
+				}
+
+				$paths = [];
+				foreach ( $registry->getSets() as $prefix => $details ) {
+					$path = $details['path'] ?? null;
+					if ( is_string( $path ) && '' !== $path ) {
+						$paths[ (string) $prefix ] = $path;
+					}
+				}
+
+				return $paths;
+			} );
 		} );
 
 		$this->app->singleton( VisualEditor::class, function ( $app ) {
@@ -295,6 +329,13 @@ class VisualEditorServiceProvider extends ServiceProvider
 		// 4. Register package-native blocks (artisanpack/callout, etc.).
 		$this->registerReferenceBlocks();
 
+		// 4.1. Icon Block Phase 3 (#554) — hand the FA Free SVG sets to
+		//      the `artisanpack-ui/icons` registry. The directories are
+		//      mirrored by `scripts/sync-fa-icons.mjs` (runs in `prebuild`)
+		//      and gitignored; the discovery step no-ops cleanly when the
+		//      sync hasn't run yet, so app boot stays robust.
+		$this->registerFontAwesomeFreeIconSets();
+
 		// 4a. Register taxonomy/feed dynamic blocks against cms-framework's
 		//     term + post APIs. Gated on the package's presence so
 		//     visual-editor still boots when cms-framework is absent.
@@ -427,8 +468,36 @@ class VisualEditorServiceProvider extends ServiceProvider
 		// Phase 1 of the Icon Block (#552/#494): the block.json above gives
 		// the inserter its metadata; this line wires the server-side renderer
 		// so the preview endpoint can produce real markup. Phase 3 (#554)
-		// adds the FA 6 Free registry that turns iconRefs into inline SVG.
+		// adds the FA Free registry that turns iconRefs into inline SVG.
 		$editor->registerDynamicBlock( IconBlock::class );
+	}
+
+	/**
+	 * Hook the FA Free SVG sets into the `ap.icons.register-icon-sets`
+	 * filter.
+	 *
+	 * Gated on the icons package being present so visual-editor still
+	 * boots in setups that haven't pulled `artisanpack-ui/icons` (the
+	 * filter would never fire there anyway, but skipping the registration
+	 * keeps the boot trace clean). Gated on `IconSetRegistration` rather
+	 * than a service-container key so a partial install doesn't NPE.
+	 *
+	 * @since 1.1.0
+	 */
+	protected function registerFontAwesomeFreeIconSets(): void
+	{
+		if ( ! class_exists( IconSetRegistration::class ) || ! function_exists( 'addFilter' ) ) {
+			return;
+		}
+
+		$baseDir = __DIR__ . '/../resources/icons/font-awesome';
+
+		addFilter(
+			'ap.icons.register-icon-sets',
+			static function ( IconSetRegistration $registry ) use ( $baseDir ): IconSetRegistration {
+				return FontAwesomeFreeIconSets::register( $registry, $baseDir );
+			}
+		);
 	}
 
 	/**

--- a/tests/Unit/VisualEditor/Blocks/Icon/IconBlockTest.php
+++ b/tests/Unit/VisualEditor/Blocks/Icon/IconBlockTest.php
@@ -3,10 +3,35 @@
 declare( strict_types=1 );
 
 use ArtisanPackUI\VisualEditor\Blocks\Icon\IconBlock;
+use ArtisanPackUI\VisualEditor\Services\Icon\IconSvgResolver;
 use ArtisanPackUI\VisualEditor\Services\Icon\SvgSanitizer;
 
 beforeEach( function (): void {
-	test()->block = new IconBlock( new SvgSanitizer() );
+	// Most tests want iconRef→inline SVG to "just work" without standing up
+	// the FA Free directory on disk. A fixture path with a single stub SVG
+	// is enough to exercise the resolver path.
+	test()->iconBase = sys_get_temp_dir() . '/icon-block-' . bin2hex( random_bytes( 4 ) );
+	mkdir( test()->iconBase . '/fab', 0o755, true );
+	file_put_contents(
+		test()->iconBase . '/fab/github.svg',
+		'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M0 0"/></svg>',
+	);
+
+	$resolver    = new IconSvgResolver( [ 'fab' => test()->iconBase . '/fab' ] );
+	test()->block = new IconBlock( new SvgSanitizer(), $resolver );
+} );
+
+afterEach( function (): void {
+	$base = test()->iconBase ?? null;
+	if ( is_string( $base ) && is_dir( $base ) ) {
+		foreach ( new RecursiveIteratorIterator(
+			new RecursiveDirectoryIterator( $base, FilesystemIterator::SKIP_DOTS ),
+			RecursiveIteratorIterator::CHILD_FIRST,
+		) as $path ) {
+			$path->isDir() ? rmdir( $path->getRealPath() ) : unlink( $path->getRealPath() );
+		}
+		rmdir( $base );
+	}
 } );
 
 it( 'reports the artisanpack/icon block name', function () {
@@ -21,13 +46,62 @@ it( 'renders a placeholder span when no iconRef or customSvg is set', function (
 		->and( $html )->toContain( 'wp-block-artisanpack-icon' );
 } );
 
-it( 'emits data attributes for an iconRef', function () {
+it( 'inlines the resolved SVG when iconRef matches a registered set', function () {
 	$html = test()->block->render( [
 		'iconRef' => [ 'set' => 'fab', 'name' => 'github' ],
 	] );
 
-	expect( $html )->toContain( 'data-icon-set="fab"' )
-		->and( $html )->toContain( 'data-icon-name="github"' );
+	expect( $html )->toContain( 'wp-block-artisanpack-icon__ref' )
+		->and( $html )->toContain( 'data-icon-set="fab"' )
+		->and( $html )->toContain( '<svg' )
+		->and( $html )->toContain( 'width="100%"' )
+		->and( $html )->toContain( 'height="100%"' )
+		->and( $html )->toContain( 'viewBox="0 0 24 24"' )
+		->and( $html )->toContain( '<path' );
+} );
+
+it( 'falls back to a placeholder when the iconRef cannot be resolved', function () {
+	$html = test()->block->render( [
+		'iconRef' => [ 'set' => 'fab', 'name' => 'does-not-exist' ],
+	] );
+
+	expect( $html )->toContain( 'wp-block-artisanpack-icon__placeholder' )
+		->and( $html )->not->toContain( '<svg' );
+} );
+
+it( 'strips existing width/height from the SVG root before injecting wrapper-fill values', function () {
+	$base = test()->iconBase;
+	file_put_contents(
+		$base . '/fab/sized.svg',
+		'<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M0 0"/></svg>',
+	);
+
+	$resolver = new IconSvgResolver( [ 'fab' => $base . '/fab' ] );
+	$block    = new IconBlock( new SvgSanitizer(), $resolver );
+
+	$html = $block->render( [
+		'iconRef' => [ 'set' => 'fab', 'name' => 'sized' ],
+	] );
+
+	// Exactly one width and one height — the original 24×24 pair must not
+	// survive alongside the injected 100%/100% wrapper-fill pair.
+	expect( substr_count( $html, 'width=' ) )->toBe( 1 )
+		->and( substr_count( $html, 'height=' ) )->toBe( 1 )
+		->and( $html )->toContain( 'width="100%"' )
+		->and( $html )->toContain( 'height="100%"' )
+		->and( $html )->not->toContain( 'width="24"' )
+		->and( $html )->not->toContain( 'height="24"' );
+} );
+
+it( 'still falls back to a placeholder when no resolver is wired', function () {
+	$block = new IconBlock( new SvgSanitizer() );
+
+	$html = $block->render( [
+		'iconRef' => [ 'set' => 'fab', 'name' => 'github' ],
+	] );
+
+	expect( $html )->toContain( 'wp-block-artisanpack-icon__placeholder' )
+		->and( $html )->not->toContain( '<svg' );
 } );
 
 it( 'rejects iconRef sets with disallowed characters', function () {

--- a/tests/Unit/VisualEditor/Blocks/Icon/IconBlockTest.php
+++ b/tests/Unit/VisualEditor/Blocks/Icon/IconBlockTest.php
@@ -69,6 +69,30 @@ it( 'falls back to a placeholder when the iconRef cannot be resolved', function 
 		->and( $html )->not->toContain( '<svg' );
 } );
 
+it( 'strips width/height regardless of value quoting style', function () {
+	$base = test()->iconBase;
+	file_put_contents(
+		$base . '/fab/mixed-quotes.svg',
+		// One double-quoted, one single-quoted, plus an unquoted variant in
+		// the wild — admin-uploaded SVGs are not guaranteed to be XML-strict.
+		"<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"24\" height='24' preserveAspectRatio=xMidYMid viewBox=\"0 0 24 24\"><path d=\"M0 0\"/></svg>",
+	);
+
+	$resolver = new IconSvgResolver( [ 'fab' => $base . '/fab' ] );
+	$block    = new IconBlock( new SvgSanitizer(), $resolver );
+
+	$html = $block->render( [
+		'iconRef' => [ 'set' => 'fab', 'name' => 'mixed-quotes' ],
+	] );
+
+	expect( substr_count( $html, 'width=' ) )->toBe( 1 )
+		->and( substr_count( $html, 'height=' ) )->toBe( 1 )
+		->and( $html )->toContain( 'width="100%"' )
+		->and( $html )->toContain( 'height="100%"' )
+		->and( $html )->not->toContain( "width=\"24\"" )
+		->and( $html )->not->toContain( "height='24'" );
+} );
+
 it( 'strips existing width/height from the SVG root before injecting wrapper-fill values', function () {
 	$base = test()->iconBase;
 	file_put_contents(

--- a/tests/Unit/VisualEditor/Services/Icon/FontAwesomeFreeIconSetsTest.php
+++ b/tests/Unit/VisualEditor/Services/Icon/FontAwesomeFreeIconSetsTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Icons\Registries\IconSetRegistration;
+use ArtisanPackUI\VisualEditor\Services\Icon\FontAwesomeFreeIconSets;
+
+beforeEach( function (): void {
+	test()->fixtureBase = sys_get_temp_dir() . '/fa-free-' . bin2hex( random_bytes( 4 ) );
+	mkdir( test()->fixtureBase, 0o755, true );
+} );
+
+afterEach( function (): void {
+	$base = test()->fixtureBase;
+	if ( is_dir( $base ) ) {
+		// Fixture trees are at most 4 entries deep; a manual walk is enough
+		// and avoids pulling Symfony Finder just for the cleanup.
+		foreach ( new RecursiveIteratorIterator(
+			new RecursiveDirectoryIterator( $base, FilesystemIterator::SKIP_DOTS ),
+			RecursiveIteratorIterator::CHILD_FIRST,
+		) as $path ) {
+			$path->isDir() ? rmdir( $path->getRealPath() ) : unlink( $path->getRealPath() );
+		}
+		rmdir( $base );
+	}
+} );
+
+it( 'discovers fas, far, and fab when all three set directories exist', function () {
+	mkdir( test()->fixtureBase . '/fas' );
+	mkdir( test()->fixtureBase . '/far' );
+	mkdir( test()->fixtureBase . '/fab' );
+
+	$found = FontAwesomeFreeIconSets::discover( test()->fixtureBase );
+
+	expect( $found )->toHaveKeys( [ 'fas', 'far', 'fab' ] )
+		->and( $found['fas'] )->toBe( test()->fixtureBase . '/fas' )
+		->and( $found['fab'] )->toBe( test()->fixtureBase . '/fab' );
+} );
+
+it( 'silently skips sets whose directory has not been synced yet', function () {
+	mkdir( test()->fixtureBase . '/fas' );
+	mkdir( test()->fixtureBase . '/fab' );
+
+	$found = FontAwesomeFreeIconSets::discover( test()->fixtureBase );
+
+	expect( $found )->toHaveKeys( [ 'fas', 'fab' ] )
+		->and( $found )->not->toHaveKey( 'far' );
+} );
+
+it( 'returns an empty array when the base directory is absent', function () {
+	$found = FontAwesomeFreeIconSets::discover( test()->fixtureBase . '/missing' );
+
+	expect( $found )->toBe( [] );
+} );
+
+it( 'registers each discovered set on the IconSetRegistration', function () {
+	mkdir( test()->fixtureBase . '/fas' );
+	mkdir( test()->fixtureBase . '/far' );
+	mkdir( test()->fixtureBase . '/fab' );
+
+	$registry = new IconSetRegistration();
+	$result   = FontAwesomeFreeIconSets::register( $registry, test()->fixtureBase );
+	$sets     = $result->getSets();
+
+	expect( $result )->toBe( $registry )
+		->and( $sets )->toHaveKeys( [ 'fas', 'far', 'fab' ] )
+		->and( $sets['fas']['path'] )->toBe( test()->fixtureBase . '/fas' );
+} );
+
+it( 'does not throw when the base directory is missing', function () {
+	$registry = new IconSetRegistration();
+
+	expect( fn () => FontAwesomeFreeIconSets::register( $registry, test()->fixtureBase . '/missing' ) )
+		->not->toThrow( Throwable::class );
+
+	expect( $registry->getSets() )->toBe( [] );
+} );

--- a/tests/Unit/VisualEditor/Services/Icon/IconSvgResolverTest.php
+++ b/tests/Unit/VisualEditor/Services/Icon/IconSvgResolverTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Services\Icon\IconSvgResolver;
+
+beforeEach( function (): void {
+	test()->base = sys_get_temp_dir() . '/icon-svg-resolver-' . bin2hex( random_bytes( 4 ) );
+	mkdir( test()->base . '/fab', 0o755, true );
+	file_put_contents( test()->base . '/fab/github.svg', '<svg id="github"/>' );
+
+	test()->resolver = new IconSvgResolver( [ 'fab' => test()->base . '/fab' ] );
+} );
+
+afterEach( function (): void {
+	$base = test()->base ?? null;
+	if ( is_string( $base ) && is_dir( $base ) ) {
+		foreach ( new RecursiveIteratorIterator(
+			new RecursiveDirectoryIterator( $base, FilesystemIterator::SKIP_DOTS ),
+			RecursiveIteratorIterator::CHILD_FIRST,
+		) as $path ) {
+			$path->isDir() ? rmdir( $path->getRealPath() ) : unlink( $path->getRealPath() );
+		}
+		rmdir( $base );
+	}
+} );
+
+it( 'returns the raw svg markup for a registered (set, name)', function () {
+	expect( test()->resolver->resolve( 'fab', 'github' ) )->toBe( '<svg id="github"/>' );
+} );
+
+it( 'returns null when the set is not registered', function () {
+	expect( test()->resolver->resolve( 'fas', 'github' ) )->toBeNull();
+} );
+
+it( 'returns null when the icon file is missing', function () {
+	expect( test()->resolver->resolve( 'fab', 'does-not-exist' ) )->toBeNull();
+} );
+
+it( 'returns null when no sets are registered at all', function () {
+	$resolver = new IconSvgResolver();
+
+	expect( $resolver->resolve( 'fab', 'github' ) )->toBeNull();
+} );
+
+it( 'evaluates a closure source lazily — not at construction time', function () {
+	$callCount = 0;
+	$paths     = [ 'fab' => test()->base . '/fab' ];
+
+	$resolver = new IconSvgResolver( function () use ( &$callCount, $paths ): array {
+		$callCount++;
+
+		return $paths;
+	} );
+
+	expect( $callCount )->toBe( 0 );
+
+	$resolver->resolve( 'fab', 'github' );
+	$resolver->resolve( 'fab', 'github' );
+
+	// Cached after the first call — the closure is the path-discovery
+	// gate, not a per-lookup hook.
+	expect( $callCount )->toBe( 1 );
+} );

--- a/tests/Unit/VisualEditor/Services/Icon/IconSvgResolverTest.php
+++ b/tests/Unit/VisualEditor/Services/Icon/IconSvgResolverTest.php
@@ -43,6 +43,25 @@ it( 'returns null when no sets are registered at all', function () {
 	expect( $resolver->resolve( 'fab', 'github' ) )->toBeNull();
 } );
 
+it( 'rejects a name containing parent-directory hops', function () {
+	// Even if a name passes the regex (allows dots), `..` substring must
+	// be refused so a clever (set, name) pair can't escape the set dir.
+	mkdir( test()->base . '/escaped', 0o755, true );
+	file_put_contents( test()->base . '/escaped.svg', 'leak' );
+
+	expect( test()->resolver->resolve( 'fab', 'a..b' ) )->toBeNull()
+		->and( test()->resolver->resolve( 'fab', '..escape' ) )->toBeNull();
+} );
+
+it( 'rejects a set that does not match the allowlist', function () {
+	expect( test()->resolver->resolve( 'fab/..', 'github' ) )->toBeNull()
+		->and( test()->resolver->resolve( '', 'github' ) )->toBeNull();
+} );
+
+it( 'rejects a name with a path separator', function () {
+	expect( test()->resolver->resolve( 'fab', 'sub/github' ) )->toBeNull();
+} );
+
 it( 'evaluates a closure source lazily — not at construction time', function () {
 	$callCount = 0;
 	$paths     = [ 'fab' => test()->base . '/fab' ];


### PR DESCRIPTION
## Description

Phase 3 of the Icon Block feature (#494). Mirrors `@fortawesome/fontawesome-free` SVGs into `resources/icons/font-awesome/{fas,far,fab}/` at build time, registers the three sets with the icons package via the `ap.icons.register-icon-sets` filter, and swaps `IconBlock`'s `data-*` carrier for an actual inline `<svg>` resolved from disk via a new `IconSvgResolver` service.

**Closes:** #554

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #554

## Motivation and Context

Without this phase, `IconBlock` rendered an empty `<span data-icon-set="fab" data-icon-name="github">` carrier with no frontend pickup. Phase 3 closes that loop: SVGs land in a registered directory, the icons package learns about them through the filter, the block resolves and inlines the SVG at render time, and the icon visibly renders on the front end.

## Changes Made

- **`scripts/sync-fa-icons.mjs`** — Node script that mirrors `node_modules/@fortawesome/fontawesome-free/svgs/{solid,regular,brands}/*.svg` into `resources/icons/font-awesome/{fas,far,fab}/` and emits `index.json` (`{ version, generatedAt, sets[], icons[{name,set,label,terms}] }`) for Phase 4's picker search. Wired into `npm run build` via the `prebuild` hook.
- **`.gitignore`** — excludes `resources/icons/font-awesome/` so ~2,860 SVGs don't enter the repo; the script makes them reproducible.
- **`package.json`** — adds `@fortawesome/fontawesome-free@^7.2.0` devDep, `prebuild` hook, `sync:fa-icons` script.
- **`composer.json`** — adds `artisanpack-ui/icons: ^2.1` as a require-dev with a path repo to `../icons` (mirrors the cms-framework dev pattern) plus a `suggest` entry for downstream consumers.
- **`src/Services/Icon/FontAwesomeFreeIconSets.php`** — static `discover()` + `register()` helpers that walk the synced directory and feed paths into `IconSetRegistration`. Skips missing dirs cleanly so a fresh checkout boots before `npm run build` runs.
- **`src/Services/Icon/IconSvgResolver.php`** — file-system `(set, name) → SVG markup` lookup. Accepts either an array (tests/fixtures) or a `Closure` (lazy production binding) for the path map; the closure is evaluated once at first `resolve()` and cached.
- **`src/Blocks/Icon/IconBlock.php`** — accepts an optional `IconSvgResolver`; when an `iconRef` resolves, inlines the SVG inside the existing `__ref` span and forces `width="100%" height="100%"` on the root (stripping any pre-existing pair) so the SVG fills the wrapper. Falls back to a placeholder span when the resolver misses, so the layout stays stable.
- **`src/VisualEditorServiceProvider.php`** — binds `IconSvgResolver` as a singleton with a closure that walks the `ap.icons.register-icon-sets` filter result *lazily* (the closure runs at request time, not at boot time, because `IconBlock` is constructed during `boot()` before every provider's `addFilter` has fired). Adds `registerFontAwesomeFreeIconSets()` that hooks the FA filter callback.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS
- PHP Version: 8.4.3
- Project Version: visual-editor on `release/1.1`

**Tests Performed:**
1. `npm run sync:fa-icons` → mirrored 2,860 icons (fas: 2000, far: 273, fab: 587) from FA Free 7.2.0.
2. `./vendor/bin/pest` → 924 passed, 2,564 assertions. Includes 12 new icon-package tests (`FontAwesomeFreeIconSetsTest`, `IconSvgResolverTest`, plus updated/added cases in `IconBlockTest`).
3. Verified in dev app — `fab:github` icon block now renders the inline GitHub SVG on the front end (resolver returns the FA-Free file, `prepareInlineSvg` injects 100%/100% sizing, `fill="currentColor"` inherits the wrapper's color).
4. Confirmed resolver fallback — unknown iconRef renders the placeholder span instead of the broken `data-*` carrier.
5. CodeRabbit local review passes (3 passes; all findings resolved).

## Accessibility Tests Run

- [x] ARIA labels checked

**Details:** Inline SVG inherits the existing wrapper-span aria attributes (`aria-hidden="true"` when decorative, `aria-label` otherwise) emitted by `IconBlock::ariaAttributes()`. Decorative + linked combination warning is deferred to Phase 5 (editor-side a11y warnings — out of scope for #554).

## Tests Added

- [x] Unit tests added/updated
- [x] All tests passing

**Test details:**
- `FontAwesomeFreeIconSetsTest` — full discovery, partial sync, missing base, registration return, missing-dir graceful no-op (5 cases).
- `IconSvgResolverTest` — happy path, missing set, missing file, no sets, lazy closure evaluation + caching (5 cases).
- `IconBlockTest` — flipped the data-* carrier expectation to inline-SVG inlining, added placeholder-fallback case, added "no resolver wired" case, added width/height-strip regression for the prepareInlineSvg fix.

## Documentation

- [x] Inline code documentation added

**Documentation details:** Class- and method-level PHPDoc covers each new file. The package README walkthrough for Phase 3 → 6 is queued for the Phase 7 docs sweep (#558) so per-phase commits don't churn the README.

## Pre-Submission Checklist

- [x] Code passes all tests
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Icon blocks now support inline Font Awesome Free SVG rendering.

* **Chores**
  * Added tooling to synchronize Font Awesome assets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->