### PR TITLE
Feature: Icon Block — Phase 4: picker UI (search, set chips, recent tray, paginated grid)

### DIFF
--- a/resources/js/visual-editor/blocks/icon/__tests__/icon-picker.test.tsx
+++ b/resources/js/visual-editor/blocks/icon/__tests__/icon-picker.test.tsx
@@ -1,0 +1,314 @@
+/**
+ * Tests for the Phase 4 IconPicker — search debouncing, set-chip
+ * filtering, recent tray, and keyboard navigation.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+
+vi.mock( '@wordpress/i18n', () => ( {
+    __: ( s: string ) => s,
+    sprintf: ( fmt: string, ...args: unknown[] ) =>
+        fmt.replace( /%(\d+)\$[ds]/g, ( _, idx ) => String( args[ Number( idx ) - 1 ] ) ),
+} ) );
+
+// `@wordpress/components` Modal portals to document.body and brings a
+// number of dependencies the jsdom env doesn't love. Stub it down to
+// the primitives the picker actually relies on.
+vi.mock( '@wordpress/components', () => ( {
+    Modal: ( {
+        children,
+        title,
+    }: {
+        children: React.ReactNode;
+        title: string;
+        onRequestClose?: () => void;
+    } ) => (
+        <div role="dialog" aria-label={ title }>
+            { children }
+        </div>
+    ),
+    Button: ( {
+        children,
+        onClick,
+        disabled,
+        title,
+        variant,
+    }: {
+        children: React.ReactNode;
+        onClick?: () => void;
+        disabled?: boolean;
+        title?: string;
+        variant?: string;
+        size?: string;
+    } ) => (
+        <button type="button" onClick={ onClick } disabled={ disabled } title={ title } data-variant={ variant }>
+            { children }
+        </button>
+    ),
+    Spinner: () => <span role="status">loading</span>,
+    TextControl: ( {
+        value,
+        onChange,
+        label,
+        placeholder,
+    }: {
+        value: string;
+        onChange: ( v: string ) => void;
+        label: string;
+        placeholder?: string;
+    } ) => (
+        <label>
+            { label }
+            <input
+                aria-label={ label }
+                value={ value }
+                placeholder={ placeholder }
+                onChange={ ( event ) => onChange( event.target.value ) }
+            />
+        </label>
+    ),
+} ) );
+
+import IconPicker, { RECENT_STORAGE_KEY, SEARCH_DEBOUNCE_MS } from '../icon-picker';
+
+interface FakeStorage {
+    readonly store: Record< string, string >;
+    getItem( key: string ): string | null;
+    setItem( key: string, value: string ): void;
+}
+
+function makeStorage( initial: Record< string, string > = {} ): FakeStorage {
+    const store = { ...initial };
+    return {
+        store,
+        getItem: ( key ) => ( key in store ? store[ key ] : null ),
+        setItem: ( key, value ) => {
+            store[ key ] = value;
+        },
+    };
+}
+
+function makeFetcher() {
+    const calls: string[] = [];
+    const fetcher = vi.fn( async ( url: string ) => {
+        calls.push( url );
+        if ( url.includes( '/icons/sets' ) ) {
+            return {
+                data: [
+                    { prefix: 'fas', label: 'Solid' },
+                    { prefix: 'fab', label: 'Brands' },
+                ],
+            };
+        }
+        const params = new URL( url, 'http://x' ).searchParams;
+        const q = params.get( 'q' ) ?? '';
+        const set = params.get( 'set' );
+        const ALL = [
+            { name: 'home', set: 'fas', label: 'Home' },
+            { name: 'user', set: 'fas', label: 'User' },
+            { name: 'github', set: 'fab', label: 'GitHub' },
+        ];
+        let rows = ALL;
+        if ( set ) {
+            rows = rows.filter( ( i ) => i.set === set );
+        }
+        if ( q ) {
+            rows = rows.filter( ( i ) => i.name.includes( q.toLowerCase() ) );
+        }
+        return {
+            total: rows.length,
+            page: 1,
+            per_page: 30,
+            data: rows,
+        };
+    } );
+    return { fetcher, calls };
+}
+
+beforeEach( () => {
+    vi.useFakeTimers();
+} );
+
+afterEach( () => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+} );
+
+describe( 'IconPicker', () => {
+    it( 'debounces search input before firing a request', async () => {
+        const onSelect = vi.fn();
+        const onClose = vi.fn();
+        const { fetcher } = makeFetcher();
+        const storage = makeStorage();
+
+        render(
+            <IconPicker
+                onSelect={ onSelect }
+                onClose={ onClose }
+                fetcher={ fetcher }
+                storage={ storage }
+            />
+        );
+
+        await act( async () => {
+            await vi.advanceTimersByTimeAsync( SEARCH_DEBOUNCE_MS + 10 );
+        } );
+
+        const initialSearchCalls = fetcher.mock.calls.filter( ( [ url ] ) =>
+            String( url ).includes( '/icons/search' )
+        ).length;
+
+        const input = screen.getByLabelText( 'Search' ) as HTMLInputElement;
+        fireEvent.change( input, { target: { value: 'h' } } );
+        fireEvent.change( input, { target: { value: 'ho' } } );
+        fireEvent.change( input, { target: { value: 'home' } } );
+
+        // No new search yet — still inside the debounce window.
+        await act( async () => {
+            await vi.advanceTimersByTimeAsync( SEARCH_DEBOUNCE_MS - 20 );
+        } );
+
+        const midSearchCalls = fetcher.mock.calls.filter( ( [ url ] ) =>
+            String( url ).includes( '/icons/search' )
+        ).length;
+        expect( midSearchCalls ).toBe( initialSearchCalls );
+
+        await act( async () => {
+            await vi.advanceTimersByTimeAsync( SEARCH_DEBOUNCE_MS + 10 );
+        } );
+
+        const afterSearchCalls = fetcher.mock.calls.filter( ( [ url ] ) =>
+            String( url ).includes( '/icons/search' )
+        );
+        expect( afterSearchCalls.length ).toBeGreaterThan( initialSearchCalls );
+        expect( String( afterSearchCalls.at( -1 )?.[ 0 ] ) ).toContain( 'q=home' );
+    } );
+
+    it( 'filters results when a set chip is clicked', async () => {
+        const { fetcher } = makeFetcher();
+        const storage = makeStorage();
+
+        render(
+            <IconPicker
+                onSelect={ vi.fn() }
+                onClose={ vi.fn() }
+                fetcher={ fetcher }
+                storage={ storage }
+            />
+        );
+
+        await act( async () => {
+            await vi.advanceTimersByTimeAsync( SEARCH_DEBOUNCE_MS + 10 );
+        } );
+
+        // Pump microtasks left after timer advance.
+        await act( async () => {
+            await Promise.resolve();
+            await Promise.resolve();
+        } );
+        expect( screen.getByText( 'Brands' ) ).toBeInTheDocument();
+
+        fireEvent.click( screen.getByText( 'Brands' ) );
+
+        await act( async () => {
+            await vi.advanceTimersByTimeAsync( SEARCH_DEBOUNCE_MS + 10 );
+        } );
+
+        const last = fetcher.mock.calls.at( -1 )?.[ 0 ];
+        expect( String( last ) ).toContain( 'set=fab' );
+    } );
+
+    it( 'persists selections to the recent tray', async () => {
+        const onSelect = vi.fn();
+        const onClose = vi.fn();
+        const { fetcher } = makeFetcher();
+        const storage = makeStorage();
+
+        render(
+            <IconPicker
+                onSelect={ onSelect }
+                onClose={ onClose }
+                fetcher={ fetcher }
+                storage={ storage }
+            />
+        );
+
+        await act( async () => {
+            await vi.advanceTimersByTimeAsync( SEARCH_DEBOUNCE_MS + 10 );
+        } );
+
+        await act( async () => {
+            await Promise.resolve();
+            await Promise.resolve();
+        } );
+        expect( screen.getByText( 'Home' ) ).toBeInTheDocument();
+
+        fireEvent.click( screen.getByText( 'Home' ) );
+
+        expect( onSelect ).toHaveBeenCalledWith( { set: 'fas', name: 'home' } );
+        expect( onClose ).toHaveBeenCalled();
+        expect( storage.store[ RECENT_STORAGE_KEY ] ).toBeDefined();
+        const persisted = JSON.parse( storage.store[ RECENT_STORAGE_KEY ] ) as Array< {
+            set: string;
+            name: string;
+        } >;
+        expect( persisted[ 0 ] ).toEqual( { set: 'fas', name: 'home' } );
+    } );
+
+    it( 'hydrates the recent tray from storage on open', async () => {
+        const { fetcher } = makeFetcher();
+        const storage = makeStorage( {
+            [ RECENT_STORAGE_KEY ]: JSON.stringify( [ { set: 'fab', name: 'github' } ] ),
+        } );
+
+        render(
+            <IconPicker
+                onSelect={ vi.fn() }
+                onClose={ vi.fn() }
+                fetcher={ fetcher }
+                storage={ storage }
+            />
+        );
+
+        await act( async () => {
+            await vi.advanceTimersByTimeAsync( SEARCH_DEBOUNCE_MS + 10 );
+        } );
+
+        // Recent label + the recent-tray entry both render the icon
+        // name; assert the section header is visible.
+        expect( screen.getByText( 'Recent' ) ).toBeInTheDocument();
+    } );
+
+    it( 'selects the focused icon when Enter is pressed in the grid', async () => {
+        const onSelect = vi.fn();
+        const { fetcher } = makeFetcher();
+        const storage = makeStorage();
+
+        render(
+            <IconPicker
+                onSelect={ onSelect }
+                onClose={ vi.fn() }
+                fetcher={ fetcher }
+                storage={ storage }
+            />
+        );
+
+        await act( async () => {
+            await vi.advanceTimersByTimeAsync( SEARCH_DEBOUNCE_MS + 10 );
+        } );
+
+        await act( async () => {
+            await Promise.resolve();
+            await Promise.resolve();
+        } );
+        expect( screen.getByRole( 'grid' ) ).toBeInTheDocument();
+
+        const grid = screen.getByRole( 'grid' );
+        fireEvent.keyDown( grid, { key: 'ArrowRight' } );
+        fireEvent.keyDown( grid, { key: 'Enter' } );
+
+        // Focus started at 0, ArrowRight → 1 (user), Enter selects it.
+        expect( onSelect ).toHaveBeenCalledWith( { set: 'fas', name: 'user' } );
+    } );
+} );

--- a/resources/js/visual-editor/blocks/icon/edit.tsx
+++ b/resources/js/visual-editor/blocks/icon/edit.tsx
@@ -7,11 +7,14 @@
  * the block exists end-to-end.
  */
 
+import { useEffect, useState } from 'react';
 import type { ReactElement } from 'react';
-import { useBlockProps } from '@wordpress/block-editor';
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import { Button, PanelBody } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
-import type { IconAttributes } from './types';
+import IconPicker from './icon-picker';
+import type { IconAttributes, IconRef } from './types';
 import {
     composeRel,
     computeIconStyle,
@@ -30,6 +33,63 @@ interface IconEditProps {
 export default function IconEdit( { attributes, setAttributes }: IconEditProps ): ReactElement {
     const normalized = normalizeAttributes( attributes );
     const blockProps = useBlockProps();
+    const [ pickerOpen, setPickerOpen ] = useState( false );
+
+    const openPicker = (): void => setPickerOpen( true );
+    const closePicker = (): void => setPickerOpen( false );
+    const handlePicked = ( ref: IconRef ): void => {
+        // Clear `customSvg` so a previously-pasted SVG doesn't keep
+        // overriding the freshly-picked iconRef on the front end.
+        setAttributes( { iconRef: ref, customSvg: '' } );
+    };
+
+    // Resolve the saved iconRef into inline SVG so the canvas mirrors
+    // what the front end will render. Re-runs whenever the saved ref
+    // changes (picker selection or attribute restore on reopen).
+    const [ resolvedSvg, setResolvedSvg ] = useState< string | null >( null );
+    const iconRefKey = normalized.iconRef
+        ? `${ normalized.iconRef.set }:${ normalized.iconRef.name }`
+        : null;
+
+    useEffect( () => {
+        if ( ! normalized.iconRef ) {
+            setResolvedSvg( null );
+            return;
+        }
+
+        let cancelled = false;
+        const params = new URLSearchParams( {
+            set: normalized.iconRef.set,
+            name: normalized.iconRef.name,
+        } );
+
+        ( async () => {
+            try {
+                const response = await fetch(
+                    `/visual-editor/api/icons/svg?${ params.toString() }`,
+                    { headers: { Accept: 'application/json' }, credentials: 'include' }
+                );
+                if ( ! response.ok ) {
+                    if ( ! cancelled ) {
+                        setResolvedSvg( null );
+                    }
+                    return;
+                }
+                const json = ( await response.json() ) as { svg: string | null };
+                if ( ! cancelled ) {
+                    setResolvedSvg( json.svg ?? null );
+                }
+            } catch {
+                if ( ! cancelled ) {
+                    setResolvedSvg( null );
+                }
+            }
+        } )();
+
+        return () => {
+            cancelled = true;
+        };
+    }, [ iconRefKey ] );
 
     const sizedStyle = computeIconStyle( normalized );
     // Only the transform belongs here — sizedStyle already carries
@@ -46,20 +106,7 @@ export default function IconEdit( { attributes, setAttributes }: IconEditProps )
             type="button"
             className="wp-block-artisanpack-icon__placeholder-button"
             style={ sizedStyle }
-            onClick={ () => {
-                // Phase 4 (#555) wires the real picker. Until then we
-                // open a tiny "type a slug" prompt so authors can still
-                // exercise the block in dev environments.
-                const setName = prompt( __( 'Icon set prefix (e.g. fas, far, fab):', 'artisanpack-visual-editor' ) );
-                if ( ! setName ) {
-                    return;
-                }
-                const iconName = prompt( __( 'Icon name (e.g. github):', 'artisanpack-visual-editor' ) );
-                if ( ! iconName ) {
-                    return;
-                }
-                setAttributes( { iconRef: { set: setName, name: iconName } } );
-            } }
+            onClick={ openPicker }
             aria-label={ __( 'Choose an icon', 'artisanpack-visual-editor' ) }
         >
             <span className="wp-block-artisanpack-icon__placeholder" aria-hidden="true" />
@@ -88,16 +135,25 @@ export default function IconEdit( { attributes, setAttributes }: IconEditProps )
             </span>
         );
     } else if ( normalized.iconRef ) {
-        body = (
+        body = resolvedSvg ? (
+            <span
+                className="wp-block-artisanpack-icon__ref"
+                style={ { ...sizedStyle, ...innerStyle } }
+                aria-hidden={ normalized.isDecorative ? 'true' : undefined }
+                title={ normalized.titleAttr || undefined }
+                // SVG comes from the package's own bundled FA Free set
+                // via IconSvgResolver, which allowlists set + name and
+                // file-reads from a registered directory only. Trusted
+                // source, no network round-trip mutation.
+                dangerouslySetInnerHTML={ { __html: resolvedSvg } }
+            />
+        ) : (
             <span
                 className="wp-block-artisanpack-icon__ref"
                 style={ { ...sizedStyle, ...innerStyle } }
                 aria-hidden={ normalized.isDecorative ? 'true' : undefined }
                 title={ normalized.titleAttr || undefined }
             >
-                { /* The real SVG arrives once the picker (Phase 4) wires
-                     a fetcher; for Phase 1 we render a labeled chip so
-                     authors can see the iconRef round-tripped. */ }
                 <code>
                     { normalized.iconRef.set }:{ normalized.iconRef.name }
                 </code>
@@ -120,7 +176,30 @@ export default function IconEdit( { attributes, setAttributes }: IconEditProps )
     );
 
     return (
-        <div { ...blockProps }>
+        <>
+            <InspectorControls>
+                <PanelBody
+                    title={ __( 'Icon', 'artisanpack-visual-editor' ) }
+                    initialOpen={ true }
+                >
+                    <Button variant="secondary" onClick={ openPicker }>
+                        { normalized.iconRef
+                            ? __( 'Change icon…', 'artisanpack-visual-editor' )
+                            : __( 'Choose icon…', 'artisanpack-visual-editor' ) }
+                    </Button>
+                    { normalized.iconRef && (
+                        <p style={ { marginTop: '8px', fontSize: '12px', opacity: 0.75 } }>
+                            <code>
+                                { normalized.iconRef.set }:{ normalized.iconRef.name }
+                            </code>
+                        </p>
+                    ) }
+                </PanelBody>
+            </InspectorControls>
+            { pickerOpen && (
+                <IconPicker onSelect={ handlePicked } onClose={ closePicker } />
+            ) }
+            <div { ...blockProps }>
             { wrapped }
             { conflict && (
                 <span
@@ -133,6 +212,7 @@ export default function IconEdit( { attributes, setAttributes }: IconEditProps )
                     ) }
                 </span>
             ) }
-        </div>
+            </div>
+        </>
     );
 }

--- a/resources/js/visual-editor/blocks/icon/icon-picker.tsx
+++ b/resources/js/visual-editor/blocks/icon/icon-picker.tsx
@@ -1,0 +1,511 @@
+/**
+ * Icon picker UI — Phase 4 (#555).
+ *
+ * Modal picker that hits `/visual-editor/api/icons/search` for a
+ * debounced text search and `/visual-editor/api/icons/sets` for the
+ * set-family chips. Selection persists a 12-item "recent" tray to
+ * `localStorage` so the author lands on a useful first screen on every
+ * subsequent open.
+ *
+ * The component is intentionally self-contained — it imports nothing
+ * from the rest of the editor bundle besides `@wordpress/components`
+ * primitives, so the same picker can later be reused by sidebar
+ * variants or other artisanpack/* blocks that need icon selection.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { CSSProperties, KeyboardEvent, ReactElement } from 'react';
+import { Modal, Button, Spinner, TextControl } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+
+import type { IconRef } from './types';
+
+export const RECENT_STORAGE_KEY = 'artisanpack-visual-editor:icon-picker:recent';
+export const RECENT_MAX = 12;
+export const SEARCH_DEBOUNCE_MS = 250;
+
+interface IconSet {
+    readonly prefix: string;
+    readonly label: string;
+}
+
+interface SearchResultIcon {
+    readonly name: string;
+    readonly set: string;
+    readonly label: string;
+    readonly svg?: string;
+}
+
+interface SearchEnvelope {
+    readonly total: number;
+    readonly page: number;
+    readonly per_page: number;
+    readonly data: readonly SearchResultIcon[];
+}
+
+export interface IconPickerProps {
+    readonly onSelect: ( ref: IconRef ) => void;
+    readonly onClose: () => void;
+    /** Override for tests / SSR-less environments. */
+    readonly apiBase?: string;
+    /** Override the fetcher for tests. Must return a parsed JSON object. */
+    readonly fetcher?: ( url: string ) => Promise< unknown >;
+    /** Storage adapter — defaults to `window.localStorage`. */
+    readonly storage?: Pick< Storage, 'getItem' | 'setItem' >;
+}
+
+function readMetaCsrfToken(): string | null {
+    if ( typeof document === 'undefined' ) {
+        return null;
+    }
+    const meta = document.querySelector< HTMLMetaElement >( 'meta[name="csrf-token"]' );
+    return meta ? meta.content : null;
+}
+
+function readXsrfCookie(): string | null {
+    if ( typeof document === 'undefined' ) {
+        return null;
+    }
+    const match = document.cookie.match( /(?:^|;\s*)XSRF-TOKEN=([^;]*)/ );
+    return match ? decodeURIComponent( match[ 1 ] ) : null;
+}
+
+function buildHeaders(): Record< string, string > {
+    const headers: Record< string, string > = { Accept: 'application/json' };
+    const csrf = readMetaCsrfToken();
+    const xsrf = readXsrfCookie();
+    if ( csrf ) {
+        headers[ 'X-CSRF-TOKEN' ] = csrf;
+    }
+    if ( xsrf ) {
+        headers[ 'X-XSRF-TOKEN' ] = xsrf;
+    }
+    return headers;
+}
+
+async function defaultFetcher( url: string ): Promise< unknown > {
+    const response = await fetch( url, {
+        headers: buildHeaders(),
+        credentials: 'include',
+    } );
+    if ( ! response.ok ) {
+        throw new Error( `HTTP ${ response.status }` );
+    }
+    return response.json();
+}
+
+function getStorage( override?: Pick< Storage, 'getItem' | 'setItem' > ): Pick< Storage, 'getItem' | 'setItem' > | null {
+    if ( override ) {
+        return override;
+    }
+    if ( typeof window === 'undefined' ) {
+        return null;
+    }
+    try {
+        return window.localStorage;
+    } catch {
+        // Private mode / locked-down iframes throw on `localStorage`
+        // access. The recent tray is a nice-to-have, so swallow.
+        return null;
+    }
+}
+
+function readRecent( storage: Pick< Storage, 'getItem' | 'setItem' > | null ): IconRef[] {
+    if ( ! storage ) {
+        return [];
+    }
+    try {
+        const raw = storage.getItem( RECENT_STORAGE_KEY );
+        if ( ! raw ) {
+            return [];
+        }
+        const parsed: unknown = JSON.parse( raw );
+        if ( ! Array.isArray( parsed ) ) {
+            return [];
+        }
+        return parsed
+            .filter(
+                ( item ): item is IconRef =>
+                    !! item &&
+                    'object' === typeof item &&
+                    'string' === typeof ( item as IconRef ).set &&
+                    'string' === typeof ( item as IconRef ).name
+            )
+            .slice( 0, RECENT_MAX );
+    } catch {
+        return [];
+    }
+}
+
+function writeRecent(
+    storage: Pick< Storage, 'getItem' | 'setItem' > | null,
+    next: readonly IconRef[]
+): void {
+    if ( ! storage ) {
+        return;
+    }
+    try {
+        storage.setItem( RECENT_STORAGE_KEY, JSON.stringify( next.slice( 0, RECENT_MAX ) ) );
+    } catch {
+        // Quota / locked-down iframe — silently drop. Recent tray is
+        // best-effort.
+    }
+}
+
+function pushRecent( current: readonly IconRef[], next: IconRef ): IconRef[] {
+    const without = current.filter(
+        ( item ) => ! ( item.set === next.set && item.name === next.name )
+    );
+    return [ next, ...without ].slice( 0, RECENT_MAX );
+}
+
+const GRID_STYLE: CSSProperties = {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(auto-fill, minmax(64px, 1fr))',
+    gap: '8px',
+    margin: '12px 0',
+    minHeight: '240px',
+};
+
+const GRID_BUTTON_STYLE: CSSProperties = {
+    aspectRatio: '1 / 1',
+    borderWidth: '1px',
+    borderStyle: 'solid',
+    borderColor: 'transparent',
+    borderRadius: '6px',
+    background: 'transparent',
+    cursor: 'pointer',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: '8px',
+    fontSize: '11px',
+    textAlign: 'center',
+};
+
+const GRID_BUTTON_FOCUSED_STYLE: CSSProperties = {
+    ...GRID_BUTTON_STYLE,
+    borderColor: 'var(--wp-admin-theme-color, #2271b1)',
+    background: 'rgba(34, 113, 177, 0.08)',
+};
+
+const CHIP_ROW_STYLE: CSSProperties = {
+    display: 'flex',
+    gap: '6px',
+    flexWrap: 'wrap',
+    margin: '8px 0',
+};
+
+const RECENT_ROW_STYLE: CSSProperties = {
+    ...CHIP_ROW_STYLE,
+    marginBottom: '12px',
+};
+
+export default function IconPicker( props: IconPickerProps ): ReactElement {
+    const { onSelect, onClose } = props;
+    const apiBase = props.apiBase ?? '/visual-editor/api';
+    const fetcher = props.fetcher ?? defaultFetcher;
+    const storage = useMemo(
+        () => getStorage( props.storage ),
+        [ props.storage ]
+    );
+
+    const [ query, setQuery ] = useState( '' );
+    const [ debouncedQuery, setDebouncedQuery ] = useState( '' );
+    const [ activeSet, setActiveSet ] = useState< string | null >( null );
+    const [ sets, setSets ] = useState< IconSet[] >( [] );
+    const [ results, setResults ] = useState< SearchResultIcon[] >( [] );
+    const [ total, setTotal ] = useState( 0 );
+    const [ page, setPage ] = useState( 1 );
+    const [ loading, setLoading ] = useState( false );
+    const [ error, setError ] = useState< string | null >( null );
+    const [ focusIndex, setFocusIndex ] = useState( 0 );
+    const [ recent, setRecent ] = useState< IconRef[] >( () => readRecent( storage ) );
+
+    const perPage = 30;
+
+    // Debounce the typed query so we don't fire a fetch on every
+    // keystroke. 250ms feels live without flooding the endpoint.
+    useEffect( () => {
+        const handle = setTimeout( () => {
+            setDebouncedQuery( query );
+            setPage( 1 );
+        }, SEARCH_DEBOUNCE_MS );
+        return () => clearTimeout( handle );
+    }, [ query ] );
+
+    // Load registered icon sets once.
+    useEffect( () => {
+        let cancelled = false;
+        ( async () => {
+            try {
+                const json = ( await fetcher( `${ apiBase }/icons/sets` ) ) as {
+                    data: IconSet[];
+                };
+                if ( ! cancelled ) {
+                    setSets( Array.isArray( json.data ) ? json.data : [] );
+                }
+            } catch {
+                if ( ! cancelled ) {
+                    setSets( [] );
+                }
+            }
+        } )();
+        return () => {
+            cancelled = true;
+        };
+    }, [ apiBase, fetcher ] );
+
+    // Run the actual search whenever the debounced query, set, or page
+    // changes.
+    useEffect( () => {
+        let cancelled = false;
+        setLoading( true );
+        setError( null );
+
+        const params = new URLSearchParams();
+        if ( debouncedQuery ) {
+            params.set( 'q', debouncedQuery );
+        }
+        if ( activeSet ) {
+            params.set( 'set', activeSet );
+        }
+        params.set( 'page', String( page ) );
+        params.set( 'per_page', String( perPage ) );
+
+        ( async () => {
+            try {
+                const json = ( await fetcher( `${ apiBase }/icons/search?${ params.toString() }` ) ) as SearchEnvelope;
+                if ( cancelled ) {
+                    return;
+                }
+                setResults( Array.isArray( json.data ) ? [ ...json.data ] : [] );
+                setTotal( typeof json.total === 'number' ? json.total : 0 );
+                setFocusIndex( 0 );
+            } catch ( err ) {
+                if ( cancelled ) {
+                    return;
+                }
+                setError(
+                    err instanceof Error
+                        ? err.message
+                        : __( 'Failed to load icons.', 'artisanpack-visual-editor' )
+                );
+                setResults( [] );
+                setTotal( 0 );
+            } finally {
+                if ( ! cancelled ) {
+                    setLoading( false );
+                }
+            }
+        } )();
+
+        return () => {
+            cancelled = true;
+        };
+    }, [ apiBase, fetcher, debouncedQuery, activeSet, page ] );
+
+    const commitSelection = useCallback(
+        ( ref: IconRef ) => {
+            const nextRecent = pushRecent( recent, ref );
+            setRecent( nextRecent );
+            writeRecent( storage, nextRecent );
+            onSelect( ref );
+            onClose();
+        },
+        [ onSelect, onClose, recent, storage ]
+    );
+
+    const totalPages = Math.max( 1, Math.ceil( total / perPage ) );
+
+    const handleGridKeyDown = useCallback(
+        ( event: KeyboardEvent< HTMLDivElement > ) => {
+            if ( results.length === 0 ) {
+                return;
+            }
+            // Approximate the visible row width so arrow up/down moves
+            // by a row. With a min cell of 64px and modal width of
+            // ~600px, six columns is a reasonable assumption — and
+            // overshooting is fine because clamp(0, length-1) catches.
+            const columns = 6;
+            if ( event.key === 'ArrowRight' ) {
+                event.preventDefault();
+                setFocusIndex( ( i ) => Math.min( results.length - 1, i + 1 ) );
+            } else if ( event.key === 'ArrowLeft' ) {
+                event.preventDefault();
+                setFocusIndex( ( i ) => Math.max( 0, i - 1 ) );
+            } else if ( event.key === 'ArrowDown' ) {
+                event.preventDefault();
+                setFocusIndex( ( i ) => Math.min( results.length - 1, i + columns ) );
+            } else if ( event.key === 'ArrowUp' ) {
+                event.preventDefault();
+                setFocusIndex( ( i ) => Math.max( 0, i - columns ) );
+            } else if ( event.key === 'Enter' ) {
+                event.preventDefault();
+                const target = results[ focusIndex ];
+                if ( target ) {
+                    commitSelection( { set: target.set, name: target.name } );
+                }
+            }
+        },
+        [ results, focusIndex, commitSelection ]
+    );
+
+    return (
+        <Modal
+            title={ __( 'Choose an icon', 'artisanpack-visual-editor' ) }
+            onRequestClose={ onClose }
+            className="wp-block-artisanpack-icon__picker"
+            size="medium"
+        >
+            <TextControl
+                label={ __( 'Search', 'artisanpack-visual-editor' ) }
+                value={ query }
+                onChange={ ( next ) => setQuery( next ) }
+                placeholder={ __( 'home, arrow, github…', 'artisanpack-visual-editor' ) }
+                autoComplete="off"
+                __next40pxDefaultSize
+                __nextHasNoMarginBottom
+            />
+
+            { sets.length > 0 && (
+                <div className="wp-block-artisanpack-icon__picker-sets" style={ CHIP_ROW_STYLE } role="group" aria-label={ __( 'Filter by icon set', 'artisanpack-visual-editor' ) }>
+                    <Button
+                        variant={ activeSet === null ? 'primary' : 'secondary' }
+                        size="small"
+                        onClick={ () => {
+                            setActiveSet( null );
+                            setPage( 1 );
+                        } }
+                    >
+                        { __( 'All', 'artisanpack-visual-editor' ) }
+                    </Button>
+                    { sets.map( ( set ) => (
+                        <Button
+                            key={ set.prefix }
+                            variant={ activeSet === set.prefix ? 'primary' : 'secondary' }
+                            size="small"
+                            onClick={ () => {
+                                setActiveSet( set.prefix );
+                                setPage( 1 );
+                            } }
+                        >
+                            { set.label }
+                        </Button>
+                    ) ) }
+                </div>
+            ) }
+
+            { recent.length > 0 && (
+                <div>
+                    <p style={ { margin: '4px 0', fontSize: '11px', textTransform: 'uppercase', opacity: 0.7 } }>
+                        { __( 'Recent', 'artisanpack-visual-editor' ) }
+                    </p>
+                    <div className="wp-block-artisanpack-icon__picker-recent" style={ RECENT_ROW_STYLE } role="list">
+                        { recent.map( ( ref ) => (
+                            <Button
+                                key={ `${ ref.set }:${ ref.name }` }
+                                variant="tertiary"
+                                size="small"
+                                onClick={ () => commitSelection( ref ) }
+                                title={ `${ ref.set }:${ ref.name }` }
+                            >
+                                { ref.name }
+                            </Button>
+                        ) ) }
+                    </div>
+                </div>
+            ) }
+
+            { loading && (
+                <div style={ { textAlign: 'center', padding: '16px' } }>
+                    <Spinner />
+                </div>
+            ) }
+
+            { error && (
+                <p role="alert" style={ { color: '#b32d2e' } }>
+                    { error }
+                </p>
+            ) }
+
+            { ! loading && ! error && results.length === 0 && (
+                <p style={ { padding: '12px 0', opacity: 0.7 } }>
+                    { __( 'No icons matched.', 'artisanpack-visual-editor' ) }
+                </p>
+            ) }
+
+            { ! loading && ! error && results.length > 0 && (
+                /* eslint-disable-next-line jsx-a11y/no-static-element-interactions */
+                <div
+                    role="grid"
+                    aria-label={ __( 'Icon results', 'artisanpack-visual-editor' ) }
+                    tabIndex={ 0 }
+                    onKeyDown={ handleGridKeyDown }
+                    style={ GRID_STYLE }
+                    className="wp-block-artisanpack-icon__picker-grid"
+                >
+                    { results.map( ( icon, index ) => (
+                        <button
+                            key={ `${ icon.set }:${ icon.name }` }
+                            type="button"
+                            role="gridcell"
+                            style={ index === focusIndex ? GRID_BUTTON_FOCUSED_STYLE : GRID_BUTTON_STYLE }
+                            onClick={ () => commitSelection( { set: icon.set, name: icon.name } ) }
+                            onMouseEnter={ () => setFocusIndex( index ) }
+                            title={ `${ icon.set }:${ icon.name }` }
+                            aria-label={ `${ icon.label } (${ icon.set })` }
+                        >
+                            { icon.svg ? (
+                                <span
+                                    aria-hidden="true"
+                                    style={ { width: '24px', height: '24px', display: 'inline-flex' } }
+                                    // Bundled FA SVGs ship from the
+                                    // package's own disk — they're
+                                    // trusted, the picker is gated to
+                                    // authenticated editor users, and
+                                    // the IconSvgResolver allowlists
+                                    // both set and name. Inlining is
+                                    // the only way to recolor via CSS.
+                                    dangerouslySetInnerHTML={ { __html: icon.svg } }
+                                />
+                            ) : (
+                                <span>{ icon.label || icon.name }</span>
+                            ) }
+                        </button>
+                    ) ) }
+                </div>
+            ) }
+
+            { totalPages > 1 && (
+                <div style={ { display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: '12px' } }>
+                    <Button
+                        variant="secondary"
+                        size="small"
+                        disabled={ page <= 1 }
+                        onClick={ () => setPage( ( p ) => Math.max( 1, p - 1 ) ) }
+                    >
+                        { __( 'Previous', 'artisanpack-visual-editor' ) }
+                    </Button>
+                    <span style={ { fontSize: '12px', opacity: 0.7 } }>
+                        { sprintf(
+                            /* translators: 1: current page, 2: total pages, 3: total result count. */
+                            __( 'Page %1$d of %2$d (%3$d icons)', 'artisanpack-visual-editor' ),
+                            page,
+                            totalPages,
+                            total
+                        ) }
+                    </span>
+                    <Button
+                        variant="secondary"
+                        size="small"
+                        disabled={ page >= totalPages }
+                        onClick={ () => setPage( ( p ) => Math.min( totalPages, p + 1 ) ) }
+                    >
+                        { __( 'Next', 'artisanpack-visual-editor' ) }
+                    </Button>
+                </div>
+            ) }
+        </Modal>
+    );
+}

--- a/resources/js/visual-editor/blocks/icon/icon.css
+++ b/resources/js/visual-editor/blocks/icon/icon.css
@@ -39,6 +39,14 @@
     text-decoration: none;
 }
 
+/* Phase 4 picker grid — make inlined FA SVGs fill the cell and
+   inherit the cell's text color so dark/light themes look right. */
+.wp-block-artisanpack-icon__picker-grid svg {
+    width: 100%;
+    height: 100%;
+    fill: currentcolor;
+}
+
 /* Placeholder shown when neither iconRef nor customSvg is set. */
 .wp-block-artisanpack-icon__placeholder {
     border: 1px dashed currentcolor;

--- a/routes/api.php
+++ b/routes/api.php
@@ -22,6 +22,9 @@ use ArtisanPackUI\VisualEditor\Http\Controllers\Adapters\CmsFramework\PostContro
 use ArtisanPackUI\VisualEditor\Http\Controllers\AttachmentController;
 use ArtisanPackUI\VisualEditor\Http\Controllers\BlockPreviewController;
 use ArtisanPackUI\VisualEditor\Http\Controllers\EntitySearchController;
+use ArtisanPackUI\VisualEditor\Http\Controllers\Icon\IconSearchController;
+use ArtisanPackUI\VisualEditor\Http\Controllers\Icon\IconSetsController;
+use ArtisanPackUI\VisualEditor\Http\Controllers\Icon\IconSvgController;
 use ArtisanPackUI\VisualEditor\Http\Controllers\MenuLocationsController;
 use ArtisanPackUI\VisualEditor\Http\Controllers\QueryResolveController;
 use ArtisanPackUI\VisualEditor\Http\Controllers\SiteController;
@@ -195,6 +198,19 @@ Route::get( 'menu-locations', [ MenuLocationsController::class, 'index' ] )
 // template parts. Read-only.
 Route::get( 'search', [ EntitySearchController::class, 'index' ] )
 	->name( 'visual-editor.api.search.index' );
+
+// Icon Block Phase 4 (#555) — picker search + set-family chips.
+// Both routes are read-only; the catalog is backed by the bundled
+// `index.json` manifest and exposes paginated results so the editor
+// never has to ship the full FA Free term index to the browser.
+Route::get( 'icons/sets', [ IconSetsController::class, 'index' ] )
+	->name( 'visual-editor.api.icons.sets' );
+
+Route::get( 'icons/search', [ IconSearchController::class, 'index' ] )
+	->name( 'visual-editor.api.icons.search' );
+
+Route::get( 'icons/svg', [ IconSvgController::class, 'show' ] )
+	->name( 'visual-editor.api.icons.svg' );
 
 // G3 cms-framework Post + Page entity adapters — see plan 12 §4.4.
 // Both controllers resolve their model through `ResourceResolver`, so

--- a/src/Http/Controllers/Icon/IconSearchController.php
+++ b/src/Http/Controllers/Icon/IconSearchController.php
@@ -35,10 +35,14 @@ class IconSearchController extends Controller
 
 	public function index( Request $request ): JsonResponse
 	{
-		$query   = (string) $request->query( 'q', '' );
-		$set     = $request->query( 'set' );
-		$page    = max( 1, (int) $request->query( 'page', 1 ) );
-		$perPage = max( 1, (int) $request->query( 'per_page', IconCatalog::DEFAULT_PER_PAGE ) );
+		// Explicit `is_string` guards before string-cast — `?q[]=foo`
+		// would otherwise cast to the literal "Array" and become the
+		// search needle.
+		$rawQuery = $request->query( 'q', '' );
+		$query    = is_string( $rawQuery ) ? $rawQuery : '';
+		$set      = $request->query( 'set' );
+		$page     = max( 1, (int) $request->query( 'page', 1 ) );
+		$perPage  = max( 1, (int) $request->query( 'per_page', IconCatalog::DEFAULT_PER_PAGE ) );
 
 		$result = $this->catalog->search(
 			$query,

--- a/src/Http/Controllers/Icon/IconSearchController.php
+++ b/src/Http/Controllers/Icon/IconSearchController.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * Icon search endpoint.
+ *
+ * Backs the Phase 4 picker (#555). Accepts `?q=`, `?set=`, `?page=`,
+ * `?per_page=` and returns a paginated envelope shaped for the React
+ * picker's grid.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.1.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Http\Controllers\Icon;
+
+use ArtisanPackUI\VisualEditor\Services\Icon\IconCatalog;
+use ArtisanPackUI\VisualEditor\Services\Icon\IconSvgResolver;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+
+class IconSearchController extends Controller
+{
+	public function __construct(
+		protected IconCatalog $catalog,
+		protected IconSvgResolver $resolver,
+	) {
+	}
+
+	public function index( Request $request ): JsonResponse
+	{
+		$query   = (string) $request->query( 'q', '' );
+		$set     = $request->query( 'set' );
+		$page    = max( 1, (int) $request->query( 'page', 1 ) );
+		$perPage = max( 1, (int) $request->query( 'per_page', IconCatalog::DEFAULT_PER_PAGE ) );
+
+		$result = $this->catalog->search(
+			$query,
+			is_string( $set ) && '' !== $set ? $set : null,
+			$page,
+			$perPage,
+		);
+
+		// Decorate each row with inline SVG markup so the picker grid
+		// can render the real glyphs instead of just the names. The
+		// SVGs come straight from disk via the trusted icons registry,
+		// so no sanitization is layered on here.
+		$result['data'] = array_map(
+			fn ( array $icon ): array => $icon + [
+				'svg' => $this->resolver->resolve( $icon['set'], $icon['name'] ) ?? '',
+			],
+			$result['data'],
+		);
+
+		return response()->json( $result );
+	}
+}

--- a/src/Http/Controllers/Icon/IconSetsController.php
+++ b/src/Http/Controllers/Icon/IconSetsController.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * Icon sets listing endpoint.
+ *
+ * Backs the Phase 4 picker's set-family chips (#555). The list comes
+ * straight from the bundled `index.json` manifest so chips automatically
+ * track whatever sets `scripts/sync-fa-icons.mjs` mirrors.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.1.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Http\Controllers\Icon;
+
+use ArtisanPackUI\VisualEditor\Services\Icon\IconCatalog;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Routing\Controller;
+
+class IconSetsController extends Controller
+{
+	public function __construct( protected IconCatalog $catalog )
+	{
+	}
+
+	public function index(): JsonResponse
+	{
+		return response()->json( [ 'data' => $this->catalog->sets() ] );
+	}
+}

--- a/src/Http/Controllers/Icon/IconSvgController.php
+++ b/src/Http/Controllers/Icon/IconSvgController.php
@@ -35,8 +35,14 @@ class IconSvgController extends Controller
 
 	public function show( Request $request ): JsonResponse
 	{
-		$set  = (string) $request->query( 'set', '' );
-		$name = (string) $request->query( 'name', '' );
+		// Explicit `is_string` guards before string-cast so array-style
+		// query params (`?set[]=fas`) don't pass through as the literal
+		// "Array" — the resolver would reject them anyway via its set/
+		// name allowlist, but guarding here keeps the 400 path clean.
+		$rawSet  = $request->query( 'set', '' );
+		$rawName = $request->query( 'name', '' );
+		$set     = is_string( $rawSet ) ? $rawSet : '';
+		$name    = is_string( $rawName ) ? $rawName : '';
 
 		if ( '' === $set || '' === $name ) {
 			return response()->json( [ 'svg' => null ], 400 );

--- a/src/Http/Controllers/Icon/IconSvgController.php
+++ b/src/Http/Controllers/Icon/IconSvgController.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * Single-icon SVG lookup.
+ *
+ * Backs the Phase 4 canvas render (#555): once an iconRef is saved on a
+ * block, the editor fetches the actual SVG markup through this endpoint
+ * and inlines it into the placeholder. The picker has the SVG already
+ * (it ships inline with search results), but a reopened post-editor
+ * session needs a way to resolve the saved iconRef without reopening
+ * the picker.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.1.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Http\Controllers\Icon;
+
+use ArtisanPackUI\VisualEditor\Services\Icon\IconSvgResolver;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+
+class IconSvgController extends Controller
+{
+	public function __construct( protected IconSvgResolver $resolver )
+	{
+	}
+
+	public function show( Request $request ): JsonResponse
+	{
+		$set  = (string) $request->query( 'set', '' );
+		$name = (string) $request->query( 'name', '' );
+
+		if ( '' === $set || '' === $name ) {
+			return response()->json( [ 'svg' => null ], 400 );
+		}
+
+		$svg = $this->resolver->resolve( $set, $name );
+
+		if ( null === $svg ) {
+			return response()->json( [ 'svg' => null ], 404 );
+		}
+
+		return response()->json( [ 'svg' => $svg ] );
+	}
+}

--- a/src/Services/Icon/IconCatalog.php
+++ b/src/Services/Icon/IconCatalog.php
@@ -1,0 +1,247 @@
+<?php
+
+/**
+ * In-memory catalog of registered icons, backed by the bundled
+ * `index.json` metadata manifest written by `scripts/sync-fa-icons.mjs`.
+ *
+ * Phase 4 of the Icon Block feature (#494, issue #555). The picker UI
+ * needs a server-side search surface so the editor never has to ship
+ * thousands of icon names and aliases to the browser; the catalog
+ * lazy-loads the manifest on first query and serves filtered, paginated
+ * results to `IconSearchController` and `IconSetsController`.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.1.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Services\Icon;
+
+use Closure;
+
+/**
+ * The catalog is intentionally dumb: it reads one JSON file (or accepts a
+ * `Closure` that returns the array form for tests) and provides a search
+ * + listing surface on top of it. No DB, no Scout — the picker is
+ * read-only against a static manifest, and the manifest already carries
+ * the search terms each upstream FA entry ships with.
+ */
+final class IconCatalog
+{
+	/**
+	 * Hard cap on the number of icons returned by a single search call.
+	 * The picker pages through results client-side; this cap exists so a
+	 * pathological `per_page` query can't fan out into a 10k-row JSON
+	 * response.
+	 */
+	public const MAX_PER_PAGE = 60;
+
+	/**
+	 * Default page size when the caller does not specify one.
+	 */
+	public const DEFAULT_PER_PAGE = 30;
+
+	/**
+	 * @var string|Closure|null
+	 */
+	private $source;
+
+	/**
+	 * @var array{
+	 *     version?: string,
+	 *     sets: list<array{prefix: string, label: string, source?: string}>,
+	 *     icons: list<array{name: string, set: string, label: string, terms: list<string>}>
+	 * }|null
+	 */
+	private ?array $manifest = null;
+
+	/**
+	 * @param  string|Closure|null $source  Absolute path to an `index.json`,
+	 *         a `Closure(): array` that returns the manifest shape, or null
+	 *         to fall back to the bundled FA Free manifest.
+	 */
+	public function __construct( string|Closure|null $source = null )
+	{
+		$this->source = $source;
+	}
+
+	/**
+	 * Return the registered icon sets, in declared order. Each entry is
+	 * shaped `{prefix, label}` for direct rendering as set-family chips
+	 * in the picker UI.
+	 *
+	 * @return list<array{prefix: string, label: string}>
+	 */
+	public function sets(): array
+	{
+		$manifest = $this->load();
+		$out      = [];
+		foreach ( $manifest['sets'] as $set ) {
+			$prefix = (string) ( $set['prefix'] ?? '' );
+			$label  = (string) ( $set['label'] ?? $prefix );
+			if ( '' === $prefix ) {
+				continue;
+			}
+			$out[] = [ 'prefix' => $prefix, 'label' => $label ];
+		}
+
+		return $out;
+	}
+
+	/**
+	 * Search the catalog for icons matching `$query`, optionally
+	 * restricted to a single set prefix. Results are paginated 1-indexed
+	 * by `$page` with `$perPage` items per page (clamped to
+	 * `MAX_PER_PAGE`).
+	 *
+	 * The empty-query branch returns the first page of every registered
+	 * icon — the picker uses this for the initial grid render before the
+	 * user types anything.
+	 *
+	 * @return array{
+	 *     total: int,
+	 *     page: int,
+	 *     per_page: int,
+	 *     data: list<array{name: string, set: string, label: string}>
+	 * }
+	 */
+	public function search( string $query, ?string $set = null, int $page = 1, int $perPage = self::DEFAULT_PER_PAGE ): array
+	{
+		$manifest = $this->load();
+		$needle   = mb_strtolower( trim( $query ) );
+		$setSlug  = null !== $set ? trim( $set ) : '';
+
+		$matches = [];
+		foreach ( $manifest['icons'] as $icon ) {
+			if ( '' !== $setSlug && $icon['set'] !== $setSlug ) {
+				continue;
+			}
+
+			if ( '' !== $needle && ! $this->iconMatches( $icon, $needle ) ) {
+				continue;
+			}
+
+			$matches[] = [
+				'name'  => (string) $icon['name'],
+				'set'   => (string) $icon['set'],
+				'label' => (string) ( $icon['label'] ?? $icon['name'] ),
+			];
+		}
+
+		$total   = count( $matches );
+		$perPage = max( 1, min( self::MAX_PER_PAGE, $perPage ) );
+		$page    = max( 1, $page );
+		$offset  = ( $page - 1 ) * $perPage;
+		$slice   = array_slice( $matches, $offset, $perPage );
+
+		return [
+			'total'    => $total,
+			'page'     => $page,
+			'per_page' => $perPage,
+			'data'     => array_values( $slice ),
+		];
+	}
+
+	/**
+	 * Test whether a manifest row matches the lowercased needle. The
+	 * `label` and `name` fields are checked first because they're the
+	 * most common author-typed match; `terms` cover the upstream FA
+	 * alias list.
+	 *
+	 * @param  array{name: string, label: string, terms: list<string>} $icon
+	 */
+	private function iconMatches( array $icon, string $needle ): bool
+	{
+		if ( str_contains( mb_strtolower( (string) $icon['name'] ), $needle ) ) {
+			return true;
+		}
+		if ( str_contains( mb_strtolower( (string) ( $icon['label'] ?? '' ) ), $needle ) ) {
+			return true;
+		}
+		foreach ( $icon['terms'] ?? [] as $term ) {
+			if ( str_contains( mb_strtolower( (string) $term ), $needle ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Lazy-load + memoize the manifest. Resolution order:
+	 *
+	 *   1. Closure source — invoked once, expected to return the array
+	 *      shape directly (used by Pest fixtures).
+	 *   2. String source — treated as an absolute path to a JSON file.
+	 *   3. `null` source — fall back to the bundled FA Free manifest.
+	 *
+	 * Any missing-file or malformed-JSON case produces an empty manifest
+	 * so the picker degrades to "no results" rather than throwing inside
+	 * the request lifecycle.
+	 *
+	 * @return array{
+	 *     version?: string,
+	 *     sets: list<array{prefix: string, label: string, source?: string}>,
+	 *     icons: list<array{name: string, set: string, label: string, terms: list<string>}>
+	 * }
+	 */
+	private function load(): array
+	{
+		if ( null !== $this->manifest ) {
+			return $this->manifest;
+		}
+
+		$raw = $this->readSource();
+
+		if ( ! is_array( $raw ) ) {
+			$this->manifest = [ 'sets' => [], 'icons' => [] ];
+
+			return $this->manifest;
+		}
+
+		$sets  = is_array( $raw['sets'] ?? null ) ? array_values( $raw['sets'] ) : [];
+		$icons = is_array( $raw['icons'] ?? null ) ? array_values( $raw['icons'] ) : [];
+
+		$this->manifest = [
+			'version' => isset( $raw['version'] ) ? (string) $raw['version'] : '',
+			'sets'    => $sets,
+			'icons'   => $icons,
+		];
+
+		return $this->manifest;
+	}
+
+	/**
+	 * @return array<string, mixed>|null
+	 */
+	private function readSource(): ?array
+	{
+		if ( $this->source instanceof Closure ) {
+			$value = ( $this->source )();
+
+			return is_array( $value ) ? $value : null;
+		}
+
+		$path = is_string( $this->source ) && '' !== $this->source
+			? $this->source
+			: __DIR__ . '/../../../resources/icons/font-awesome/index.json';
+
+		if ( ! is_file( $path ) ) {
+			return null;
+		}
+
+		$contents = @file_get_contents( $path );
+		if ( false === $contents ) {
+			return null;
+		}
+
+		$decoded = json_decode( $contents, true );
+
+		return is_array( $decoded ) ? $decoded : null;
+	}
+}

--- a/src/Services/Icon/IconCatalog.php
+++ b/src/Services/Icon/IconCatalog.php
@@ -235,12 +235,19 @@ final class IconCatalog
 			return null;
 		}
 
-		$contents = @file_get_contents( $path );
+		$contents = file_get_contents( $path );
 		if ( false === $contents ) {
 			return null;
 		}
 
+		// `json_last_error()` separates a genuine parse failure from a
+		// valid `null` payload; the catalog only accepts the array
+		// shape, so a parse error and a non-array payload both fall
+		// through to `null` here.
 		$decoded = json_decode( $contents, true );
+		if ( JSON_ERROR_NONE !== json_last_error() ) {
+			return null;
+		}
 
 		return is_array( $decoded ) ? $decoded : null;
 	}

--- a/src/VisualEditorServiceProvider.php
+++ b/src/VisualEditorServiceProvider.php
@@ -11,6 +11,7 @@ use ArtisanPackUI\VisualEditor\Blocks\Forms\FormBlock;
 use ArtisanPackUI\Icons\Registries\IconSetRegistration;
 use ArtisanPackUI\VisualEditor\Blocks\Icon\IconBlock;
 use ArtisanPackUI\VisualEditor\Services\Icon\FontAwesomeFreeIconSets;
+use ArtisanPackUI\VisualEditor\Services\Icon\IconCatalog;
 use ArtisanPackUI\VisualEditor\Services\Icon\IconSvgResolver;
 use ArtisanPackUI\VisualEditor\Services\Icon\SvgSanitizer;
 use ArtisanPackUI\VisualEditor\MediaBridge\GutenbergAttachmentAdapter;
@@ -99,6 +100,14 @@ class VisualEditorServiceProvider extends ServiceProvider
 
 				return $paths;
 			} );
+		} );
+
+		// Icon Block Phase 4 (#555): the picker's search + sets endpoints
+		// resolve the catalog out of the container so host apps can swap
+		// in a custom manifest (e.g. extending the bundled FA Free set
+		// with their own brand icons) via `$app->extend()`.
+		$this->app->singleton( IconCatalog::class, function (): IconCatalog {
+			return new IconCatalog();
 		} );
 
 		$this->app->singleton( VisualEditor::class, function ( $app ) {

--- a/tests/Feature/VisualEditor/IconPickerEndpointsTest.php
+++ b/tests/Feature/VisualEditor/IconPickerEndpointsTest.php
@@ -1,0 +1,155 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Services\Icon\IconCatalog;
+use ArtisanPackUI\VisualEditor\Services\Icon\IconSvgResolver;
+use Tests\TestUser;
+
+function actingAsIconPickerUser(): TestUser
+{
+	$user = TestUser::create( [
+		'name'     => 'Icon Picker Tester',
+		'email'    => 'icon+' . uniqid() . '@example.com',
+		'password' => bcrypt( 'secret' ),
+	] );
+
+	test()->actingAs( $user );
+
+	return $user;
+}
+
+function bindIconCatalogFixture(): void
+{
+	app()->instance(
+		IconCatalog::class,
+		new IconCatalog( static fn (): array => [
+			'sets'  => [
+				[ 'prefix' => 'fas', 'label' => 'Solid', 'source' => 'solid' ],
+				[ 'prefix' => 'fab', 'label' => 'Brands', 'source' => 'brands' ],
+			],
+			'icons' => [
+				[ 'name' => 'home', 'set' => 'fas', 'label' => 'Home', 'terms' => [ 'house' ] ],
+				[ 'name' => 'user', 'set' => 'fas', 'label' => 'User', 'terms' => [ 'profile' ] ],
+				[ 'name' => 'github', 'set' => 'fab', 'label' => 'GitHub', 'terms' => [ 'octocat' ] ],
+			],
+		] ),
+	);
+}
+
+it( 'returns the registered icon sets', function () {
+	actingAsIconPickerUser();
+	bindIconCatalogFixture();
+
+	$this->getJson( '/visual-editor/api/icons/sets' )
+		->assertOk()
+		->assertJsonPath( 'data.0.prefix', 'fas' )
+		->assertJsonPath( 'data.0.label', 'Solid' )
+		->assertJsonPath( 'data.1.prefix', 'fab' );
+} );
+
+it( 'returns paginated search results matching the query', function () {
+	actingAsIconPickerUser();
+	bindIconCatalogFixture();
+
+	$this->getJson( '/visual-editor/api/icons/search?q=home' )
+		->assertOk()
+		->assertJsonPath( 'total', 1 )
+		->assertJsonPath( 'data.0.name', 'home' )
+		->assertJsonPath( 'data.0.set', 'fas' );
+} );
+
+it( 'returns every icon when no query is supplied', function () {
+	actingAsIconPickerUser();
+	bindIconCatalogFixture();
+
+	$this->getJson( '/visual-editor/api/icons/search' )
+		->assertOk()
+		->assertJsonPath( 'total', 3 );
+} );
+
+it( 'restricts search results to the requested set', function () {
+	actingAsIconPickerUser();
+	bindIconCatalogFixture();
+
+	$this->getJson( '/visual-editor/api/icons/search?set=fab' )
+		->assertOk()
+		->assertJsonPath( 'total', 1 )
+		->assertJsonPath( 'data.0.set', 'fab' )
+		->assertJsonPath( 'data.0.name', 'github' );
+} );
+
+it( 'matches against the term aliases shipped with each icon', function () {
+	actingAsIconPickerUser();
+	bindIconCatalogFixture();
+
+	$this->getJson( '/visual-editor/api/icons/search?q=octocat' )
+		->assertOk()
+		->assertJsonPath( 'total', 1 )
+		->assertJsonPath( 'data.0.name', 'github' );
+} );
+
+it( 'decorates search results with inline svg markup', function () {
+	actingAsIconPickerUser();
+	bindIconCatalogFixture();
+
+	$base = sys_get_temp_dir() . '/icon-picker-search-' . bin2hex( random_bytes( 4 ) );
+	mkdir( $base . '/fas', 0o755, true );
+	file_put_contents( $base . '/fas/home.svg', '<svg id="home"/>' );
+
+	app()->instance(
+		IconSvgResolver::class,
+		new IconSvgResolver( [ 'fas' => $base . '/fas' ] ),
+	);
+
+	try {
+		$this->getJson( '/visual-editor/api/icons/search?q=home' )
+			->assertOk()
+			->assertJsonPath( 'data.0.svg', '<svg id="home"/>' );
+	} finally {
+		unlink( $base . '/fas/home.svg' );
+		rmdir( $base . '/fas' );
+		rmdir( $base );
+	}
+} );
+
+it( 'returns the resolved svg for a known (set, name) via the svg endpoint', function () {
+	actingAsIconPickerUser();
+
+	$base = sys_get_temp_dir() . '/icon-picker-svg-' . bin2hex( random_bytes( 4 ) );
+	mkdir( $base . '/fab', 0o755, true );
+	file_put_contents( $base . '/fab/github.svg', '<svg id="github"/>' );
+
+	app()->instance(
+		IconSvgResolver::class,
+		new IconSvgResolver( [ 'fab' => $base . '/fab' ] ),
+	);
+
+	try {
+		$this->getJson( '/visual-editor/api/icons/svg?set=fab&name=github' )
+			->assertOk()
+			->assertJsonPath( 'svg', '<svg id="github"/>' );
+	} finally {
+		unlink( $base . '/fab/github.svg' );
+		rmdir( $base . '/fab' );
+		rmdir( $base );
+	}
+} );
+
+it( 'returns 404 from the svg endpoint when the icon is unknown', function () {
+	actingAsIconPickerUser();
+
+	app()->instance( IconSvgResolver::class, new IconSvgResolver( [] ) );
+
+	$this->getJson( '/visual-editor/api/icons/svg?set=fab&name=nope' )
+		->assertNotFound()
+		->assertJsonPath( 'svg', null );
+} );
+
+it( 'returns 400 from the svg endpoint when set or name is missing', function () {
+	actingAsIconPickerUser();
+
+	$this->getJson( '/visual-editor/api/icons/svg' )
+		->assertStatus( 400 )
+		->assertJsonPath( 'svg', null );
+} );

--- a/tests/Unit/VisualEditor/Services/Icon/IconCatalogTest.php
+++ b/tests/Unit/VisualEditor/Services/Icon/IconCatalogTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Services\Icon\IconCatalog;
+
+function makeManifest(): array
+{
+	return [
+		'version' => '1.0.0',
+		'sets'    => [
+			[ 'prefix' => 'fas', 'label' => 'Solid', 'source' => 'solid' ],
+			[ 'prefix' => 'fab', 'label' => 'Brands', 'source' => 'brands' ],
+		],
+		'icons'   => [
+			[ 'name' => 'home', 'set' => 'fas', 'label' => 'Home', 'terms' => [ 'house', 'main' ] ],
+			[ 'name' => 'user', 'set' => 'fas', 'label' => 'User', 'terms' => [ 'person', 'profile' ] ],
+			[ 'name' => 'github', 'set' => 'fab', 'label' => 'GitHub', 'terms' => [ 'octocat', 'git' ] ],
+			[ 'name' => 'gitlab', 'set' => 'fab', 'label' => 'GitLab', 'terms' => [ 'git' ] ],
+		],
+	];
+}
+
+function makeCatalog(): IconCatalog
+{
+	return new IconCatalog( static fn (): array => makeManifest() );
+}
+
+it( 'lists registered sets in declared order', function () {
+	$sets = makeCatalog()->sets();
+
+	expect( $sets )->toHaveCount( 2 );
+	expect( $sets[0] )->toBe( [ 'prefix' => 'fas', 'label' => 'Solid' ] );
+	expect( $sets[1] )->toBe( [ 'prefix' => 'fab', 'label' => 'Brands' ] );
+} );
+
+it( 'returns all icons when query is empty', function () {
+	$result = makeCatalog()->search( '' );
+
+	expect( $result['total'] )->toBe( 4 );
+	expect( $result['data'] )->toHaveCount( 4 );
+} );
+
+it( 'matches against the name field', function () {
+	$result = makeCatalog()->search( 'home' );
+
+	expect( $result['total'] )->toBe( 1 );
+	expect( $result['data'][0]['name'] )->toBe( 'home' );
+} );
+
+it( 'matches against the term aliases', function () {
+	$result = makeCatalog()->search( 'octocat' );
+
+	expect( $result['total'] )->toBe( 1 );
+	expect( $result['data'][0]['name'] )->toBe( 'github' );
+} );
+
+it( 'filters by set when a prefix is provided', function () {
+	$result = makeCatalog()->search( 'git', 'fab' );
+
+	expect( $result['total'] )->toBe( 2 );
+	$names = array_column( $result['data'], 'name' );
+	expect( $names )->toContain( 'github' )->toContain( 'gitlab' );
+} );
+
+it( 'paginates the result set', function () {
+	$page1 = makeCatalog()->search( '', null, 1, 2 );
+	$page2 = makeCatalog()->search( '', null, 2, 2 );
+
+	expect( $page1['total'] )->toBe( 4 );
+	expect( $page1['data'] )->toHaveCount( 2 );
+	expect( $page2['data'] )->toHaveCount( 2 );
+	expect( $page1['data'][0]['name'] )->not->toBe( $page2['data'][0]['name'] );
+} );
+
+it( 'clamps per_page to the documented maximum', function () {
+	$result = makeCatalog()->search( '', null, 1, IconCatalog::MAX_PER_PAGE + 50 );
+
+	expect( $result['per_page'] )->toBe( IconCatalog::MAX_PER_PAGE );
+} );
+
+it( 'returns empty data when the manifest source is missing', function () {
+	$catalog = new IconCatalog( '/nonexistent/index.json' );
+
+	expect( $catalog->sets() )->toBe( [] );
+	expect( $catalog->search( 'anything' )['total'] )->toBe( 0 );
+} );


### PR DESCRIPTION
## Description

Wires the author-facing icon picker on top of Phase 3's FA Free registry. Adds a modal picker with debounced search, set-family chips, a per-user recent tray persisted to localStorage, paginated grid with inline SVG previews, and keyboard navigation. The canvas fetches the resolved SVG for the saved iconRef so authors see the real glyph instead of a labeled chip.

**Closes:** #555

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #555

## Motivation and Context

Phase 3 (#554) bundled the FA Free SVGs and the metadata index but the editor still relied on a `prompt()` placeholder to type `(set, name)` by hand. Phase 4 replaces that with a real picker so authors can find icons by search/term, browse by set, and reuse recent selections.

## Changes Made

**Backend**
- `IconCatalog` — lazy-loaded reader over the bundled `index.json` manifest with set listing, term-aware search, set filtering, and pagination (default 30/page, clamped to 60).
- `GET /visual-editor/api/icons/sets` — returns the registered set-family chips.
- `GET /visual-editor/api/icons/search?q=&set=&page=&per_page=` — paginated results decorated with inline SVG markup via `IconSvgResolver` so the grid renders real glyphs.
- `GET /visual-editor/api/icons/svg?set=&name=` — single-icon lookup used by the canvas to rehydrate the SVG for a saved iconRef on post reopen.
- `IconCatalog` bound as a singleton in the service provider so host apps can extend the manifest via `$app->extend()`.

**Frontend**
- `icon-picker.tsx` — Modal picker: 250ms-debounced search, All/set-prefix chips, inline-SVG grid (auto-fill 64px cells, `currentColor`), 12-item localStorage recent tray, arrow-key + Enter keyboard navigation, prev/next pagination footer.
- `edit.tsx` — Replaced `prompt()` placeholder with the picker. Added `InspectorControls` panel with a "Change icon" button. Fetches `/icons/svg` for the saved iconRef and inlines the resolved SVG into the canvas.
- `icon.css` — Added a small rule so picker grid SVGs fill the cell and inherit the cell's text color.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS
- Browser: Chrome
- PHP Version: 8.4
- Project Version: 1.1.x

**Tests Performed:**
1. Manual exercise in the dev app — picker opens from canvas placeholder + Inspector button; search/debounce/chip filter/recent tray/keyboard nav/pagination all confirmed working; canvas + grid render real FA SVGs.
2. Pest unit + feature suite — 941 tests passing (catalog search/pagination, set filter, term aliases, controller responses, SVG endpoint 200/404/400).
3. Vitest suite — 1879 tests passing (debounce, set-chip filter, recent tray hydration + persistence, keyboard navigation → Enter selects).

## Accessibility Tests Run

- [x] Keyboard navigation tested — arrow keys move focus inside the grid, Enter selects, Escape closes the modal.
- [x] ARIA labels checked — grid cells get `aria-label="{label} ({set})"`; set chip row is a labeled `role="group"`; recent tray and error states use semantic roles.
- [ ] Screen reader tested — not yet (will retest before marking ready).
- [ ] Color contrast verified — relies on the active admin theme; will sweep before marking ready.

**Details:** Modal title + chip group label are localized; the grid `tabIndex={0}` keeps focus reachable; selecting an icon both closes the modal and returns focus to the previously-focused trigger via WP's `Modal` behavior.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:**
- `tests/Unit/VisualEditor/Services/Icon/IconCatalogTest.php` — 8 tests covering listing, name/label/term matching, set filter, pagination, per_page clamping, and missing-manifest fallback.
- `tests/Feature/VisualEditor/IconPickerEndpointsTest.php` — 9 tests covering sets endpoint, search (empty query, term aliases, set filter, paginated envelope, inline-SVG decoration) and svg endpoint (200/404/400).
- `resources/js/visual-editor/blocks/icon/__tests__/icon-picker.test.tsx` — 5 vitest tests covering debounce, set chip filter, recent tray persistence, recent tray hydration, and Enter-to-select keyboard nav.

## Documentation

- [x] Inline code documentation added
- [ ] README updated — not required for an additive picker
- [ ] Wiki updated — to follow when Phase 5 lands
- [ ] API documentation updated — endpoints documented inline

**Documentation details:** PHPDoc on every new class/method explains why each piece exists (lazy loading, clamping, defense-in-depth on params). The picker file's header explains the storage key, debounce, and the trust boundary on inline SVG.

## Screenshots

_To follow — capture the picker open with FA glyphs visible and the inspector panel._

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted (PHP formatter not installed in this package; eslint/vitest clean)
- [ ] Accessibility tests completed — see Accessibility section
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Icon picker modal with debounced text search, set/family filter chips, grid selection, keyboard navigation (arrows + Enter), and a recent-icons tray that persists selections.
  * Live inline SVG preview of the selected icon in the editor.

* **Tests**
  * Added UI and API tests covering picker behaviors, persistence, search, and SVG endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->