### PR TITLE
feat: icon block custom SVG paste/upload (#556)

### DIFF
--- a/resources/js/visual-editor/blocks/icon/__tests__/custom-svg-control.test.tsx
+++ b/resources/js/visual-editor/blocks/icon/__tests__/custom-svg-control.test.tsx
@@ -1,0 +1,204 @@
+/**
+ * Phase 5 (#556) — paste flow updates `customSvg` correctly.
+ *
+ * We mock `@wordpress/components` down to plain DOM primitives so we can
+ * fire `change` / `blur` events without the real Notice / PanelBody
+ * machinery in the way. The `fetchImpl` prop is the seam for the
+ * sanitize endpoint — the test never touches `window.fetch`.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+
+vi.mock( '@wordpress/i18n', () => ( {
+    __: ( s: string ) => s,
+    sprintf: ( fmt: string, ...args: unknown[] ) =>
+        fmt.replace( /%d/g, () => String( args.shift() ) ),
+} ) );
+
+vi.mock( '@wordpress/components', () => ( {
+    PanelBody: ( { children, title }: { children: React.ReactNode; title: string } ) => (
+        <section aria-label={ title }>{ children }</section>
+    ),
+    Button: ( {
+        children,
+        onClick,
+        disabled,
+        variant,
+    }: {
+        children: React.ReactNode;
+        onClick?: () => void;
+        disabled?: boolean;
+        variant?: string;
+    } ) => (
+        <button
+            type="button"
+            onClick={ onClick }
+            disabled={ disabled }
+            data-variant={ variant }
+        >
+            { children }
+        </button>
+    ),
+    Notice: ( {
+        children,
+        status,
+    }: {
+        children: React.ReactNode;
+        status: string;
+    } ) => <div role={ status === 'error' ? 'alert' : 'status' }>{ children }</div>,
+    TextareaControl: ( {
+        value,
+        onChange,
+        onBlur,
+        label,
+    }: {
+        value: string;
+        onChange: ( v: string ) => void;
+        onBlur?: () => void;
+        label: string;
+        rows?: number;
+        help?: string;
+    } ) => (
+        <label>
+            { label }
+            <textarea
+                aria-label={ label }
+                value={ value }
+                onChange={ ( event ) => onChange( event.target.value ) }
+                onBlur={ onBlur }
+            />
+        </label>
+    ),
+} ) );
+
+import CustomSvgControl from '../custom-svg-control';
+
+function makeFetch(
+    body: { svg: string; warnings: readonly string[] },
+    status = 200,
+): typeof fetch {
+    return vi.fn( async () =>
+        ( {
+            ok: status >= 200 && status < 300,
+            status,
+            json: async () => body,
+        } ) as unknown as Response,
+    ) as unknown as typeof fetch;
+}
+
+describe( 'CustomSvgControl paste flow', () => {
+    it( 'updates customSvg with the server-sanitized result on textarea blur', async () => {
+        const onApplied = vi.fn();
+        const onCleared = vi.fn();
+        const sanitizedSvg = '<svg xmlns="http://www.w3.org/2000/svg"><path d="M0 0"/></svg>';
+        const fetchImpl = makeFetch( {
+            svg: sanitizedSvg,
+            warnings: [ 'removed <script> element' ],
+        } );
+
+        render(
+            <CustomSvgControl
+                customSvg=""
+                onApplied={ onApplied }
+                onCleared={ onCleared }
+                fetchImpl={ fetchImpl }
+            />,
+        );
+
+        const textarea = screen.getByLabelText( 'Paste SVG markup' ) as HTMLTextAreaElement;
+
+        await act( async () => {
+            fireEvent.change( textarea, {
+                target: {
+                    value: '<svg><script>alert(1)</script><path d="M0 0"/></svg>',
+                },
+            } );
+        } );
+
+        await act( async () => {
+            fireEvent.blur( textarea );
+        } );
+
+        expect( fetchImpl ).toHaveBeenCalledTimes( 1 );
+        const [ url, init ] = ( fetchImpl as ReturnType< typeof vi.fn > ).mock.calls[ 0 ] as [
+            string,
+            RequestInit,
+        ];
+        expect( url ).toBe( '/visual-editor/api/icons/svg/sanitize' );
+        expect( init.method ).toBe( 'POST' );
+        expect( init.body ).toBeTypeOf( 'string' );
+
+        // The raw paste is sent verbatim — the server is the authority
+        // and reports back exactly what it stripped, so the warning
+        // panel matches reality.
+        const sent = JSON.parse( String( init.body ) ) as { svg: string };
+        expect( sent.svg ).toContain( '<script' );
+
+        expect( onApplied ).toHaveBeenCalledTimes( 1 );
+        expect( onApplied ).toHaveBeenCalledWith( sanitizedSvg, [
+            'removed <script> element',
+        ] );
+        expect( onCleared ).not.toHaveBeenCalled();
+
+        // Warning surfaced inline.
+        expect(
+            screen.getByText( /Some content was removed/i ),
+        ).toBeTruthy();
+    } );
+
+    it( 'clears customSvg when the textarea is emptied and blurred', async () => {
+        const onApplied = vi.fn();
+        const onCleared = vi.fn();
+        const fetchImpl = makeFetch( { svg: '', warnings: [] } );
+
+        render(
+            <CustomSvgControl
+                customSvg='<svg><path d="M0 0"/></svg>'
+                onApplied={ onApplied }
+                onCleared={ onCleared }
+                fetchImpl={ fetchImpl }
+            />,
+        );
+
+        const textarea = screen.getByLabelText( 'Paste SVG markup' ) as HTMLTextAreaElement;
+        await act( async () => {
+            fireEvent.change( textarea, { target: { value: '' } } );
+        } );
+        await act( async () => {
+            fireEvent.blur( textarea );
+        } );
+
+        expect( fetchImpl ).not.toHaveBeenCalled();
+        expect( onCleared ).toHaveBeenCalledTimes( 1 );
+        expect( onApplied ).not.toHaveBeenCalled();
+    } );
+
+    it( 'shows an error and skips the upload when a non-svg file is chosen', async () => {
+        const onApplied = vi.fn();
+        const onCleared = vi.fn();
+        const fetchImpl = makeFetch( { svg: '', warnings: [] } );
+
+        const { container } = render(
+            <CustomSvgControl
+                customSvg=""
+                onApplied={ onApplied }
+                onCleared={ onCleared }
+                fetchImpl={ fetchImpl }
+            />,
+        );
+
+        const fileInput = container.querySelector(
+            'input[type="file"]',
+        ) as HTMLInputElement;
+        const bogus = new File( [ 'not really svg' ], 'fake.png', { type: 'image/png' } );
+
+        await act( async () => {
+            fireEvent.change( fileInput, { target: { files: [ bogus ] } } );
+        } );
+
+        expect( fetchImpl ).not.toHaveBeenCalled();
+        expect( onApplied ).not.toHaveBeenCalled();
+        expect( screen.getByRole( 'alert' ).textContent ).toMatch( /isn’t an SVG/i );
+    } );
+} );

--- a/resources/js/visual-editor/blocks/icon/custom-svg-control.tsx
+++ b/resources/js/visual-editor/blocks/icon/custom-svg-control.tsx
@@ -36,6 +36,11 @@ export default function CustomSvgControl( {
     const [ error, setError ] = useState< string >( '' );
     const [ pending, setPending ] = useState< boolean >( false );
     const fileInputRef = useRef< HTMLInputElement | null >( null );
+    // Monotonic counter so a slow earlier sanitize response can't clobber
+    // the result of a newer paste / upload. Each call to `applyRaw`
+    // captures its own id; the resolution path only commits state if it
+    // still matches the latest.
+    const requestSeqRef = useRef< number >( 0 );
 
     // Resync `draft` when the prop changes from outside this component —
     // most notably when picking an icon clears `customSvg`, or when the
@@ -46,6 +51,7 @@ export default function CustomSvgControl( {
     }, [ customSvg ] );
 
     const applyRaw = async ( raw: string ): Promise< void > => {
+        const requestId = ++requestSeqRef.current;
         setError( '' );
         // Send the raw paste straight to the server so the warning list
         // reflects everything the authoritative sanitizer stripped —
@@ -62,6 +68,9 @@ export default function CustomSvgControl( {
         setPending( true );
         try {
             const result = await sanitizeOnServer( raw, fetchImpl );
+            if ( requestId !== requestSeqRef.current ) {
+                return;
+            }
             setDraft( result.svg );
             setWarnings( result.warnings );
             if ( result.svg.trim().length === 0 ) {
@@ -74,9 +83,14 @@ export default function CustomSvgControl( {
                 onApplied( result.svg, result.warnings );
             }
         } catch ( err ) {
+            if ( requestId !== requestSeqRef.current ) {
+                return;
+            }
             setError( err instanceof Error ? err.message : String( err ) );
         } finally {
-            setPending( false );
+            if ( requestId === requestSeqRef.current ) {
+                setPending( false );
+            }
         }
     };
 

--- a/resources/js/visual-editor/blocks/icon/custom-svg-control.tsx
+++ b/resources/js/visual-editor/blocks/icon/custom-svg-control.tsx
@@ -1,0 +1,191 @@
+/**
+ * Icon block — Custom SVG sidebar control.
+ *
+ * Phase 5 (#556). Lets authors paste raw SVG markup OR upload a `.svg`
+ * file. The flow: cosmetic client-side preflight → POST to the server
+ * sanitize endpoint → persist the sanitized markup into `customSvg` →
+ * surface stripped-content warnings inline.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import type { ChangeEvent, ReactElement } from 'react';
+import { Button, Notice, PanelBody, TextareaControl } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+
+import { MAX_SVG_BYTES, isSvgFile, sanitizeOnServer } from './custom-svg';
+
+interface CustomSvgControlProps {
+    readonly customSvg: string;
+    readonly onApplied: ( sanitized: string, warnings: readonly string[] ) => void;
+    readonly onCleared: () => void;
+    /**
+     * Test seam — vitest replaces this with a stub so the component never
+     * touches the real `window.fetch`. Production callers omit it.
+     */
+    readonly fetchImpl?: typeof fetch;
+}
+
+export default function CustomSvgControl( {
+    customSvg,
+    onApplied,
+    onCleared,
+    fetchImpl,
+}: CustomSvgControlProps ): ReactElement {
+    const [ draft, setDraft ] = useState< string >( customSvg );
+    const [ warnings, setWarnings ] = useState< readonly string[] >( [] );
+    const [ error, setError ] = useState< string >( '' );
+    const [ pending, setPending ] = useState< boolean >( false );
+    const fileInputRef = useRef< HTMLInputElement | null >( null );
+
+    // Resync `draft` when the prop changes from outside this component —
+    // most notably when picking an icon clears `customSvg`, or when the
+    // block attributes are restored on reopen. Guarded against
+    // overwriting in-progress textarea edits by comparing first.
+    useEffect( () => {
+        setDraft( ( current ) => ( current === customSvg ? current : customSvg ) );
+    }, [ customSvg ] );
+
+    const applyRaw = async ( raw: string ): Promise< void > => {
+        setError( '' );
+        // Send the raw paste straight to the server so the warning list
+        // reflects everything the authoritative sanitizer stripped —
+        // doing a client-side scrub first would silently eat the
+        // `<script>` and `on*` removals the author needs to see.
+        setDraft( raw );
+
+        if ( raw.trim().length === 0 ) {
+            setWarnings( [] );
+            onCleared();
+            return;
+        }
+
+        setPending( true );
+        try {
+            const result = await sanitizeOnServer( raw, fetchImpl );
+            setDraft( result.svg );
+            setWarnings( result.warnings );
+            if ( result.svg.trim().length === 0 ) {
+                // The server rejected the markup outright (e.g. root
+                // wasn't <svg>). Clear the block's customSvg so the
+                // canvas falls back to the placeholder rather than
+                // showing stale content.
+                onCleared();
+            } else {
+                onApplied( result.svg, result.warnings );
+            }
+        } catch ( err ) {
+            setError( err instanceof Error ? err.message : String( err ) );
+        } finally {
+            setPending( false );
+        }
+    };
+
+    const handleTextareaCommit = (): void => {
+        void applyRaw( draft );
+    };
+
+    const handleFile = async ( event: ChangeEvent< HTMLInputElement > ): Promise< void > => {
+        const file = event.target.files?.[ 0 ] ?? null;
+        // Reset the input so re-uploading the same file fires `change` again.
+        if ( fileInputRef.current ) {
+            fileInputRef.current.value = '';
+        }
+        if ( file === null ) {
+            return;
+        }
+
+        if ( ! isSvgFile( file ) ) {
+            setError(
+                __(
+                    'That file isn’t an SVG. Pick a file ending in .svg.',
+                    'artisanpack-visual-editor',
+                ),
+            );
+            return;
+        }
+
+        if ( file.size > MAX_SVG_BYTES ) {
+            setError(
+                sprintf(
+                    /* translators: %d is the max upload size in kilobytes. */
+                    __( 'SVG is larger than the %d KB limit.', 'artisanpack-visual-editor' ),
+                    Math.floor( MAX_SVG_BYTES / 1024 ),
+                ),
+            );
+            return;
+        }
+
+        const text = await file.text();
+        await applyRaw( text );
+    };
+
+    const clearSvg = (): void => {
+        setDraft( '' );
+        setWarnings( [] );
+        setError( '' );
+        onCleared();
+    };
+
+    return (
+        <PanelBody
+            title={ __( 'Custom SVG', 'artisanpack-visual-editor' ) }
+            initialOpen={ false }
+        >
+            <TextareaControl
+                label={ __( 'Paste SVG markup', 'artisanpack-visual-editor' ) }
+                value={ draft }
+                onChange={ ( value: string ) => setDraft( value ) }
+                onBlur={ handleTextareaCommit }
+                rows={ 6 }
+                help={ __(
+                    'The SVG is sanitized server-side before it’s saved.',
+                    'artisanpack-visual-editor',
+                ) }
+            />
+            <div style={ { display: 'flex', gap: '8px', marginTop: '8px' } }>
+                <Button
+                    variant="secondary"
+                    onClick={ () => fileInputRef.current?.click() }
+                    disabled={ pending }
+                >
+                    { __( 'Upload .svg…', 'artisanpack-visual-editor' ) }
+                </Button>
+                { customSvg.length > 0 && (
+                    <Button variant="tertiary" onClick={ clearSvg } disabled={ pending }>
+                        { __( 'Clear SVG', 'artisanpack-visual-editor' ) }
+                    </Button>
+                ) }
+            </div>
+            <input
+                ref={ fileInputRef }
+                type="file"
+                accept="image/svg+xml,.svg"
+                style={ { display: 'none' } }
+                onChange={ ( event ) => {
+                    void handleFile( event );
+                } }
+                aria-label={ __( 'Upload SVG file', 'artisanpack-visual-editor' ) }
+            />
+            { error !== '' && (
+                <Notice status="error" isDismissible={ false }>
+                    { error }
+                </Notice>
+            ) }
+            { warnings.length > 0 && (
+                <Notice status="warning" isDismissible={ false }>
+                    <strong>
+                        { __(
+                            'Some content was removed during sanitization:',
+                            'artisanpack-visual-editor',
+                        ) }
+                    </strong>
+                    <ul className="wp-block-artisanpack-icon__svg-warnings">
+                        { warnings.map( ( warning, index ) => (
+                            <li key={ `${ index }-${ warning }` }>{ warning }</li>
+                        ) ) }
+                    </ul>
+                </Notice>
+            ) }
+        </PanelBody>
+    );
+}

--- a/resources/js/visual-editor/blocks/icon/custom-svg.ts
+++ b/resources/js/visual-editor/blocks/icon/custom-svg.ts
@@ -1,0 +1,110 @@
+/**
+ * Icon block — custom-SVG paste/upload helpers.
+ *
+ * Phase 5 (#556). The authoritative sanitizer is the server-side
+ * `SvgSanitizer` reached through `/visual-editor/api/icons/svg/sanitize`.
+ * The helpers in this file handle the request envelope + file-type
+ * gate; everything security-relevant happens server-side so the
+ * warnings the author sees match what the server actually stripped.
+ */
+
+/**
+ * Whether the file looks plausibly like an SVG. We reject by both MIME
+ * type AND extension because:
+ *
+ *  - Browsers occasionally hand back an empty `type` for files dragged
+ *    out of weird sources (Finder previews, some download tools), so a
+ *    pure MIME check rejects legitimate uploads.
+ *  - Trusting the extension alone lets a renamed `payload.exe.svg`
+ *    through without even a smell test; pairing the two narrows the
+ *    gap that the server-side sanitizer has to close.
+ */
+export function isSvgFile( file: File ): boolean {
+    const name = file.name.toLowerCase();
+    const type = file.type.toLowerCase();
+    const extensionOk = name.endsWith( '.svg' );
+    const mimeOk = type === '' || type === 'image/svg+xml' || type === 'image/svg';
+    return extensionOk && mimeOk;
+}
+
+/**
+ * Cap the upload size before we even read the file. Mirrors the 256 KB
+ * cap on the server endpoint so the editor's error message matches what
+ * the API would return on submit.
+ */
+export const MAX_SVG_BYTES = 262_144;
+
+export interface SanitizeResponse {
+    readonly svg: string;
+    readonly warnings: readonly string[];
+}
+
+function readMetaCsrfToken(): string | null {
+    if ( typeof document === 'undefined' ) {
+        return null;
+    }
+    const meta = document.querySelector< HTMLMetaElement >( 'meta[name="csrf-token"]' );
+    return meta ? meta.content : null;
+}
+
+function readXsrfCookie(): string | null {
+    if ( typeof document === 'undefined' ) {
+        return null;
+    }
+    const match = document.cookie.match( /(?:^|;\s*)XSRF-TOKEN=([^;]*)/ );
+    return match ? decodeURIComponent( match[ 1 ] ) : null;
+}
+
+/**
+ * POST the raw markup to the sanitize endpoint and return the
+ * authoritative result. Throws on network / 4xx / 5xx so the caller can
+ * surface a single, consistent error message.
+ */
+export async function sanitizeOnServer(
+    raw: string,
+    fetchImpl: typeof fetch = fetch,
+): Promise< SanitizeResponse > {
+    const headers: Record< string, string > = {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+        'X-Requested-With': 'XMLHttpRequest',
+    };
+    const csrf = readMetaCsrfToken();
+    const xsrf = readXsrfCookie();
+    if ( csrf ) {
+        headers[ 'X-CSRF-TOKEN' ] = csrf;
+    }
+    if ( xsrf ) {
+        headers[ 'X-XSRF-TOKEN' ] = xsrf;
+    }
+
+    const response = await fetchImpl( '/visual-editor/api/icons/svg/sanitize', {
+        method: 'POST',
+        credentials: 'include',
+        headers,
+        body: JSON.stringify( { svg: raw } ),
+    } );
+
+    if ( ! response.ok ) {
+        // Surface the server's warnings if it returned a structured
+        // 4xx (e.g. the 256 KB cap). Falling back to a generic message
+        // for 5xx / network failures keeps the editor copy stable.
+        let warnings: readonly string[] = [];
+        try {
+            const body = ( await response.json() ) as { warnings?: readonly string[] };
+            if ( Array.isArray( body.warnings ) ) {
+                warnings = body.warnings;
+            }
+        } catch {
+            // ignore — body wasn't JSON, fall through to the throw.
+        }
+        const detail = warnings.length > 0 ? `: ${ warnings.join( ', ' ) }` : '';
+        throw new Error( `svg sanitize failed (${ response.status })${ detail }` );
+    }
+
+    const body = ( await response.json() ) as Partial< SanitizeResponse >;
+    return {
+        svg: typeof body.svg === 'string' ? body.svg : '',
+        warnings: Array.isArray( body.warnings ) ? body.warnings : [],
+    };
+}

--- a/resources/js/visual-editor/blocks/icon/edit.tsx
+++ b/resources/js/visual-editor/blocks/icon/edit.tsx
@@ -13,6 +13,7 @@ import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import { Button, PanelBody } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
+import { sanitizeOnServer } from './custom-svg';
 import CustomSvgControl from './custom-svg-control';
 import IconPicker from './icon-picker';
 import type { IconAttributes, IconRef } from './types';
@@ -43,6 +44,43 @@ export default function IconEdit( { attributes, setAttributes }: IconEditProps )
         // overriding the freshly-picked iconRef on the front end.
         setAttributes( { iconRef: ref, customSvg: '' } );
     };
+
+    // Re-sanitize the hydrated `customSvg` before rendering it into the
+    // canvas. The attribute is normally written through CustomSvgControl
+    // (which already routes through the sanitize endpoint), but a hand-
+    // edited post DB / REST write / migration / older release without
+    // Phase 5 could persist raw SVG. Re-running the sanitize endpoint
+    // here closes that gap so the editor canvas never injects markup
+    // that hasn't been DOM-walked by `SvgSanitizer`. The first paint
+    // shows the placeholder; the sanitized markup mounts as soon as
+    // the request resolves.
+    const [ trustedCustomSvg, setTrustedCustomSvg ] = useState< string >( '' );
+    useEffect( () => {
+        if ( normalized.customSvg.trim().length === 0 ) {
+            setTrustedCustomSvg( '' );
+            return;
+        }
+
+        let cancelled = false;
+        ( async () => {
+            try {
+                const { svg } = await sanitizeOnServer( normalized.customSvg );
+                if ( ! cancelled ) {
+                    setTrustedCustomSvg( svg );
+                }
+            } catch {
+                if ( ! cancelled ) {
+                    // Fail closed — better to show the placeholder than
+                    // mount markup we couldn't verify.
+                    setTrustedCustomSvg( '' );
+                }
+            }
+        } )();
+
+        return () => {
+            cancelled = true;
+        };
+    }, [ normalized.customSvg ] );
 
     // Resolve the saved iconRef into inline SVG so the canvas mirrors
     // what the front end will render. Re-runs whenever the saved ref
@@ -116,16 +154,14 @@ export default function IconEdit( { attributes, setAttributes }: IconEditProps )
 
     let body: ReactElement = placeholder;
 
-    if ( normalized.customSvg.trim().length > 0 ) {
-        // Phase 5 (#556): customSvg is only ever written through the
-        // server-side sanitize endpoint (see CustomSvgControl), so the
-        // markup at this point has already been DOM-walked + scrubbed
-        // by `SvgSanitizer`. Mounting it via `dangerouslySetInnerHTML`
-        // is safe in the same sense that the iconRef path below is —
-        // both render trusted, server-sanitized SVG markup. The live
-        // front-end render still re-sanitizes at output time, so a
-        // hand-edited post DB that bypasses the editor can't escape
-        // the sanitizer either.
+    if ( trustedCustomSvg.trim().length > 0 ) {
+        // Phase 5 (#556): we mount the SERVER-sanitized copy of the
+        // saved `customSvg`, never the raw attribute. The async
+        // hydration effect above pipes `normalized.customSvg` through
+        // `sanitizeOnServer` first, so even hand-edited markup gets a
+        // round trip through `SvgSanitizer` before reaching the DOM
+        // here. On the first paint (or if sanitization fails) the
+        // placeholder shows instead — fail-closed by design.
         body = (
             <span
                 className="wp-block-artisanpack-icon__svg"
@@ -137,7 +173,7 @@ export default function IconEdit( { attributes, setAttributes }: IconEditProps )
                         : undefined
                 }
                 title={ normalized.titleAttr || undefined }
-                dangerouslySetInnerHTML={ { __html: normalized.customSvg } }
+                dangerouslySetInnerHTML={ { __html: trustedCustomSvg } }
             />
         );
     } else if ( normalized.iconRef ) {

--- a/resources/js/visual-editor/blocks/icon/edit.tsx
+++ b/resources/js/visual-editor/blocks/icon/edit.tsx
@@ -13,6 +13,7 @@ import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import { Button, PanelBody } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
+import CustomSvgControl from './custom-svg-control';
 import IconPicker from './icon-picker';
 import type { IconAttributes, IconRef } from './types';
 import {
@@ -116,23 +117,28 @@ export default function IconEdit( { attributes, setAttributes }: IconEditProps )
     let body: ReactElement = placeholder;
 
     if ( normalized.customSvg.trim().length > 0 ) {
-        // Phase 1: NEVER render saved customSvg raw in the editor. The
-        // client-side sanitizer lands in Phase 5 (#556); until then a
-        // pasted SVG that bypassed server sanitization (or was edited
-        // by hand in the post DB) would otherwise mount unsanitized
-        // markup inside the editor iframe. Render an inert preview
-        // chip so authors can see the block exists and round-trips,
-        // and let the live front end (which always passes through
-        // IconBlock::render → SvgSanitizer) handle the real display.
+        // Phase 5 (#556): customSvg is only ever written through the
+        // server-side sanitize endpoint (see CustomSvgControl), so the
+        // markup at this point has already been DOM-walked + scrubbed
+        // by `SvgSanitizer`. Mounting it via `dangerouslySetInnerHTML`
+        // is safe in the same sense that the iconRef path below is —
+        // both render trusted, server-sanitized SVG markup. The live
+        // front-end render still re-sanitizes at output time, so a
+        // hand-edited post DB that bypasses the editor can't escape
+        // the sanitizer either.
         body = (
             <span
-                className="wp-block-artisanpack-icon__svg-preview"
+                className="wp-block-artisanpack-icon__svg"
                 style={ { ...sizedStyle, ...innerStyle } }
-                aria-hidden="true"
-                title={ __( 'Custom SVG (rendered on the front end)', 'artisanpack-visual-editor' ) }
-            >
-                <code>{ __( 'SVG', 'artisanpack-visual-editor' ) }</code>
-            </span>
+                aria-hidden={ normalized.isDecorative ? 'true' : undefined }
+                aria-label={
+                    ! normalized.isDecorative && normalized.ariaLabel.length > 0
+                        ? normalized.ariaLabel
+                        : undefined
+                }
+                title={ normalized.titleAttr || undefined }
+                dangerouslySetInnerHTML={ { __html: normalized.customSvg } }
+            />
         );
     } else if ( normalized.iconRef ) {
         body = resolvedSvg ? (
@@ -195,6 +201,18 @@ export default function IconEdit( { attributes, setAttributes }: IconEditProps )
                         </p>
                     ) }
                 </PanelBody>
+                <CustomSvgControl
+                    customSvg={ normalized.customSvg }
+                    onApplied={ ( sanitized ) => {
+                        // Mirror the picker flow: setting a customSvg
+                        // clears any existing iconRef so the two render
+                        // paths never overlap.
+                        setAttributes( { customSvg: sanitized, iconRef: null } );
+                    } }
+                    onCleared={ () => {
+                        setAttributes( { customSvg: '' } );
+                    } }
+                />
             </InspectorControls>
             { pickerOpen && (
                 <IconPicker onSelect={ handlePicked } onClose={ closePicker } />

--- a/routes/api.php
+++ b/routes/api.php
@@ -25,6 +25,7 @@ use ArtisanPackUI\VisualEditor\Http\Controllers\EntitySearchController;
 use ArtisanPackUI\VisualEditor\Http\Controllers\Icon\IconSearchController;
 use ArtisanPackUI\VisualEditor\Http\Controllers\Icon\IconSetsController;
 use ArtisanPackUI\VisualEditor\Http\Controllers\Icon\IconSvgController;
+use ArtisanPackUI\VisualEditor\Http\Controllers\Icon\IconSvgSanitizeController;
 use ArtisanPackUI\VisualEditor\Http\Controllers\MenuLocationsController;
 use ArtisanPackUI\VisualEditor\Http\Controllers\QueryResolveController;
 use ArtisanPackUI\VisualEditor\Http\Controllers\SiteController;
@@ -211,6 +212,15 @@ Route::get( 'icons/search', [ IconSearchController::class, 'index' ] )
 
 Route::get( 'icons/svg', [ IconSvgController::class, 'show' ] )
 	->name( 'visual-editor.api.icons.svg' );
+
+// Icon Block Phase 5 (#556) — custom SVG paste/upload sanitization. The
+// editor POSTs the pasted/uploaded markup, gets back the SvgSanitizer
+// output + warnings, and persists the sanitized result into the block's
+// `customSvg` attribute. Authoritative sanitization still runs at render
+// time inside IconBlock; this endpoint is what lets the editor surface
+// warnings inline before save.
+Route::post( 'icons/svg/sanitize', [ IconSvgSanitizeController::class, 'store' ] )
+	->name( 'visual-editor.api.icons.svg.sanitize' );
 
 // G3 cms-framework Post + Page entity adapters — see plan 12 §4.4.
 // Both controllers resolve their model through `ResourceResolver`, so

--- a/src/Http/Controllers/Icon/IconSvgSanitizeController.php
+++ b/src/Http/Controllers/Icon/IconSvgSanitizeController.php
@@ -41,6 +41,18 @@ class IconSvgSanitizeController extends Controller
 
 	public function store( Request $request ): JsonResponse
 	{
+		// Gate the raw body first so the JSON-escaped payload size — not
+		// just the decoded `svg` field — is bounded. A 200 KB SVG of
+		// nested quotes can blow past 256 KB after JSON escaping; without
+		// this the framework would still allocate + parse the whole body
+		// before the per-field cap below caught it.
+		if ( strlen( (string) $request->getContent() ) > self::MAX_INPUT_BYTES ) {
+			return response()->json( [
+				'svg'      => '',
+				'warnings' => [ 'request exceeds the 256 KB size limit' ],
+			], 413 );
+		}
+
 		$rawSvg = $request->input( 'svg', '' );
 		if ( ! is_string( $rawSvg ) ) {
 			return response()->json( [

--- a/src/Http/Controllers/Icon/IconSvgSanitizeController.php
+++ b/src/Http/Controllers/Icon/IconSvgSanitizeController.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * Custom SVG sanitization endpoint.
+ *
+ * Phase 5 (#556) of the Icon Block feature (#494). Authors paste or
+ * upload a one-off SVG in the block sidebar; the editor POSTs it here
+ * to get the canonical sanitized result + the human-readable list of
+ * things that were stripped. The block persists the sanitized SVG into
+ * its `customSvg` attribute and renders the warnings inline.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.1.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Http\Controllers\Icon;
+
+use ArtisanPackUI\VisualEditor\Services\Icon\SvgSanitizer;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+
+class IconSvgSanitizeController extends Controller
+{
+	/**
+	 * Cap the payload at 256 KB. Inline icon SVGs are usually a few KB;
+	 * anything dramatically larger is either a misuse (full illustrations
+	 * being pasted as icons) or a DoS attempt against the DOM parser.
+	 */
+	private const MAX_INPUT_BYTES = 262_144;
+
+	public function __construct( protected SvgSanitizer $sanitizer )
+	{
+	}
+
+	public function store( Request $request ): JsonResponse
+	{
+		$rawSvg = $request->input( 'svg', '' );
+		if ( ! is_string( $rawSvg ) ) {
+			return response()->json( [
+				'svg'      => '',
+				'warnings' => [ 'svg must be a string' ],
+			], 422 );
+		}
+
+		if ( strlen( $rawSvg ) > self::MAX_INPUT_BYTES ) {
+			return response()->json( [
+				'svg'      => '',
+				'warnings' => [ 'svg exceeds the 256 KB size limit' ],
+			], 413 );
+		}
+
+		$result = $this->sanitizer->sanitize( $rawSvg );
+
+		return response()->json( [
+			'svg'      => $result->sanitized,
+			'warnings' => $result->warnings,
+		] );
+	}
+}

--- a/src/Services/Icon/SvgSanitizer.php
+++ b/src/Services/Icon/SvgSanitizer.php
@@ -289,10 +289,13 @@ class SvgSanitizer
 				$bad = true;
 			} elseif ( false !== strpos( $lower, '-moz-binding' ) ) {
 				$bad = true;
-			} elseif ( preg_match( '/url\(\s*["\']?\s*(?!#)([a-z]+:|\/\/)/i', $lower ) ) {
-				// `url(http://…)`, `url(//host/…)`, `url(data:…)` — any
-				// scheme-bearing or protocol-relative reference. The
-				// `(?!#)` negative lookahead keeps `url(#gradient1)`.
+			} elseif ( preg_match( '/url\(\s*["\']?\s*(?!#)/i', $lower ) ) {
+				// Any `url(…)` whose target isn't an internal fragment.
+				// That covers `url(http://…)`, `url(//host/…)`,
+				// `url(data:…)`, AND relative paths like `url(/a.svg)`
+				// or `url(icon.svg)` — all external references in the
+				// same threat class (tracking pixels, asset leaks,
+				// chained navigation away from the page).
 				$bad = true;
 			}
 

--- a/src/Services/Icon/SvgSanitizer.php
+++ b/src/Services/Icon/SvgSanitizer.php
@@ -115,6 +115,17 @@ class SvgSanitizer
 		'gradientUnits',
 		'gradientTransform',
 		'spreadMethod',
+		// Modern authoring tools (Illustrator, Figma, Inkscape) write
+		// presentation rules into `style="…"` rather than discrete
+		// `fill=` / `stroke=` attributes — stripping it wholesale turns
+		// any of those exports into a black silhouette. We let it
+		// through and scrub the value below (`expression()`, external
+		// `url()`, `javascript:` are rejected).
+		'style',
+		// Harmless metadata that Illustrator stamps onto the root.
+		// Excluding them just produces noisy warnings on every paste.
+		'version',
+		'xml:space',
 		// URI attributes — passed through the allowlist gate so the
 		// downstream `isSafeUri` check gets a chance to keep internal
 		// anchor references (`#gradient1`) and reject everything else.
@@ -226,11 +237,13 @@ class SvgSanitizer
 
 			$value = (string) $attr->nodeValue;
 
-			// `style` is not in the allowlist; this guard catches any future
-			// addition that forgets to filter `expression()`.
-			if ( 'style' === $name && false !== stripos( $value, 'expression' ) ) {
-				$drop[]     = $name;
-				$warnings[] = sprintf( 'removed CSS expression() from style on <%s>', $element->localName );
+			if ( 'style' === $name ) {
+				$cleaned = $this->scrubStyleValue( $value, $element->localName, $warnings );
+				if ( '' === $cleaned ) {
+					$drop[] = $name;
+				} elseif ( $cleaned !== $value ) {
+					$attr->nodeValue = $cleaned;
+				}
 				continue;
 			}
 
@@ -244,6 +257,54 @@ class SvgSanitizer
 		foreach ( $drop as $attrName ) {
 			$element->removeAttribute( $attrName );
 		}
+	}
+
+	/**
+	 * Filter individual CSS declarations from a `style="…"` value.
+	 *
+	 * We keep declarations whose values are inert (`fill: #abc`, `opacity: 0.5`)
+	 * and reject anything carrying a known script vector — `expression(…)`
+	 * (IE legacy), `javascript:` / `vbscript:` URIs, `-moz-binding`, and
+	 * external `url(http://…)` / `url(data:…)` references. Internal anchor
+	 * refs (`url(#gradient1)`) are preserved because gradients depend on
+	 * them.
+	 *
+	 * @param  array<int, string> $warnings
+	 */
+	private function scrubStyleValue( string $value, string $tag, array &$warnings ): string
+	{
+		$kept = [];
+		foreach ( explode( ';', $value ) as $declaration ) {
+			$trimmed = trim( $declaration );
+			if ( '' === $trimmed ) {
+				continue;
+			}
+
+			$lower = strtolower( $trimmed );
+			$bad   = false;
+
+			if ( false !== strpos( $lower, 'expression(' ) ) {
+				$bad = true;
+			} elseif ( false !== strpos( $lower, 'javascript:' ) || false !== strpos( $lower, 'vbscript:' ) ) {
+				$bad = true;
+			} elseif ( false !== strpos( $lower, '-moz-binding' ) ) {
+				$bad = true;
+			} elseif ( preg_match( '/url\(\s*["\']?\s*(?!#)([a-z]+:|\/\/)/i', $lower ) ) {
+				// `url(http://…)`, `url(//host/…)`, `url(data:…)` — any
+				// scheme-bearing or protocol-relative reference. The
+				// `(?!#)` negative lookahead keeps `url(#gradient1)`.
+				$bad = true;
+			}
+
+			if ( $bad ) {
+				$warnings[] = sprintf( 'removed unsafe style declaration on <%s>', $tag );
+				continue;
+			}
+
+			$kept[] = $trimmed;
+		}
+
+		return implode( '; ', $kept );
 	}
 
 	private function isUriAttr( string $name ): bool

--- a/tests/Feature/VisualEditor/IconPickerEndpointsTest.php
+++ b/tests/Feature/VisualEditor/IconPickerEndpointsTest.php
@@ -153,3 +153,50 @@ it( 'returns 400 from the svg endpoint when set or name is missing', function ()
 		->assertStatus( 400 )
 		->assertJsonPath( 'svg', null );
 } );
+
+// Phase 5 (#556) — custom SVG paste/upload sanitize endpoint.
+it( 'strips a malicious svg and reports warnings via the sanitize endpoint', function () {
+	actingAsIconPickerUser();
+
+	$hostile = '<svg xmlns="http://www.w3.org/2000/svg" onload="alert(1)">'
+		. '<script>steal()</script>'
+		. '<path d="M0 0h10v10H0z" onclick="alert(2)"/>'
+		. '</svg>';
+
+	$response = $this->postJson(
+		'/visual-editor/api/icons/svg/sanitize',
+		[ 'svg' => $hostile ],
+	)->assertOk();
+
+	$sanitized = $response->json( 'svg' );
+	$warnings  = $response->json( 'warnings' );
+
+	expect( $sanitized )->toBeString()
+		->not->toContain( '<script' )
+		->not->toContain( 'onload' )
+		->not->toContain( 'onclick' )
+		->not->toContain( 'alert' )
+		->toContain( '<path' );
+
+	expect( $warnings )->toBeArray()->not->toBeEmpty();
+	expect( implode( "\n", $warnings ) )->toContain( '<script>' );
+} );
+
+it( 'returns 422 from the sanitize endpoint when svg is not a string', function () {
+	actingAsIconPickerUser();
+
+	$this->postJson( '/visual-editor/api/icons/svg/sanitize', [ 'svg' => [ 'not', 'a', 'string' ] ] )
+		->assertStatus( 422 )
+		->assertJsonPath( 'svg', '' );
+} );
+
+it( 'returns 413 from the sanitize endpoint when the payload exceeds the size limit', function () {
+	actingAsIconPickerUser();
+
+	// 256 KB cap + 1 byte. The endpoint never even calls the parser.
+	$oversize = '<svg>' . str_repeat( 'x', 262_144 ) . '</svg>';
+
+	$this->postJson( '/visual-editor/api/icons/svg/sanitize', [ 'svg' => $oversize ] )
+		->assertStatus( 413 )
+		->assertJsonPath( 'svg', '' );
+} );

--- a/tests/Feature/VisualEditor/IconPickerEndpointsTest.php
+++ b/tests/Feature/VisualEditor/IconPickerEndpointsTest.php
@@ -200,3 +200,24 @@ it( 'returns 413 from the sanitize endpoint when the payload exceeds the size li
 		->assertStatus( 413 )
 		->assertJsonPath( 'svg', '' );
 } );
+
+it( 'returns 413 when the raw request body exceeds the cap even if `svg` decodes smaller', function () {
+	actingAsIconPickerUser();
+
+	// JSON escaping of a string of double-quotes blows the wire size
+	// well past 256 KB even though the decoded `svg` value is shorter.
+	$bigField = str_repeat( '\"x\"', 80_000 );
+
+	$this->call(
+		'POST',
+		'/visual-editor/api/icons/svg/sanitize',
+		[],
+		[],
+		[],
+		[
+			'HTTP_ACCEPT'       => 'application/json',
+			'CONTENT_TYPE'      => 'application/json',
+		],
+		'{"svg":"' . $bigField . '"}',
+	)->assertStatus( 413 );
+} );

--- a/tests/Unit/VisualEditor/Services/Icon/SvgSanitizerTest.php
+++ b/tests/Unit/VisualEditor/Services/Icon/SvgSanitizerTest.php
@@ -111,6 +111,19 @@ it( 'strips javascript:, expression(), and external url() from style', function 
 		->and( $result->warnings )->not->toBeEmpty();
 } );
 
+it( 'strips relative-path url() references from style (any non-fragment target)', function () {
+	$svg = '<svg xmlns="http://www.w3.org/2000/svg">'
+		. '<path d="M0 0" style="fill:url(/asset.svg)"/>'
+		. '<path d="M0 0" style="fill:url(icon.svg)"/>'
+		. '</svg>';
+
+	$result = test()->sanitizer->sanitize( $svg );
+
+	expect( $result->sanitized )->not->toContain( '/asset.svg' )
+		->and( $result->sanitized )->not->toContain( 'icon.svg' )
+		->and( $result->warnings )->not->toBeEmpty();
+} );
+
 it( 'keeps internal url(#…) references inside style', function () {
 	$svg = '<svg xmlns="http://www.w3.org/2000/svg">'
 		. '<defs><linearGradient id="g1"/></defs>'

--- a/tests/Unit/VisualEditor/Services/Icon/SvgSanitizerTest.php
+++ b/tests/Unit/VisualEditor/Services/Icon/SvgSanitizerTest.php
@@ -82,6 +82,58 @@ it( 'rejects unparseable input', function () {
 	expect( $result->isEmpty() )->toBeTrue();
 } );
 
+it( 'preserves inline style declarations carrying inert presentation rules', function () {
+	$svg = '<svg xmlns="http://www.w3.org/2000/svg" style="fill:#abc">'
+		. '<path d="M0 0" style="fill:#123;opacity:0.5"/>'
+		. '</svg>';
+
+	$result = test()->sanitizer->sanitize( $svg );
+
+	expect( $result->sanitized )->toContain( 'fill:#abc' )
+		->and( $result->sanitized )->toContain( 'fill:#123' )
+		->and( $result->sanitized )->toContain( 'opacity:0.5' )
+		->and( $result->hasWarnings() )->toBeFalse();
+} );
+
+it( 'strips javascript:, expression(), and external url() from style', function () {
+	$svg = '<svg xmlns="http://www.w3.org/2000/svg">'
+		. '<path d="M0 0" style="fill:#abc;background:expression(alert(1))"/>'
+		. '<path d="M0 0" style="fill:url(http://evil.example/x.png)"/>'
+		. '<path d="M0 0" style="fill:javascript:alert(1)"/>'
+		. '</svg>';
+
+	$result = test()->sanitizer->sanitize( $svg );
+
+	expect( $result->sanitized )->not->toContain( 'expression' )
+		->and( $result->sanitized )->not->toContain( 'javascript:' )
+		->and( $result->sanitized )->not->toContain( 'evil.example' )
+		->and( $result->sanitized )->toContain( 'fill:#abc' )
+		->and( $result->warnings )->not->toBeEmpty();
+} );
+
+it( 'keeps internal url(#…) references inside style', function () {
+	$svg = '<svg xmlns="http://www.w3.org/2000/svg">'
+		. '<defs><linearGradient id="g1"/></defs>'
+		. '<rect style="fill:url(#g1)" width="10" height="10"/>'
+		. '</svg>';
+
+	$result = test()->sanitizer->sanitize( $svg );
+
+	expect( $result->sanitized )->toContain( 'url(#g1)' )
+		->and( $result->hasWarnings() )->toBeFalse();
+} );
+
+it( 'allows harmless version and xml:space root attributes', function () {
+	$svg = '<svg xmlns="http://www.w3.org/2000/svg" version="1.1" xml:space="preserve">'
+		. '<path d="M0 0"/></svg>';
+
+	$result = test()->sanitizer->sanitize( $svg );
+
+	expect( $result->sanitized )->toContain( 'version="1.1"' )
+		->and( $result->sanitized )->toContain( 'xml:space="preserve"' )
+		->and( $result->hasWarnings() )->toBeFalse();
+} );
+
 it( 'strips DOCTYPEs without trying to resolve external entities', function () {
 	$svg = '<!DOCTYPE svg [<!ENTITY xxe SYSTEM "file:///etc/passwd">]>'
 		. '<svg xmlns="http://www.w3.org/2000/svg"><path d="M0 0"/></svg>';


### PR DESCRIPTION
## Description

Phase 5 of the Icon Block feature (#494). Lets authors paste raw SVG markup or upload a `.svg` file when no shipped icon fits. All input flows through the server-side `SvgSanitizer`; warnings about stripped content surface inline in the editor.

**Closes:** #556

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #556 (parent #494)

## Motivation and Context

Authors occasionally need a one-off SVG that no registered icon set covers (a custom brand mark, a sketch from a designer, a glyph downloaded from a CC asset library). Without paste/upload support, the block forces them to drop in HTML blocks instead — losing the icon block's styling/a11y controls and skipping sanitization. Phase 5 closes that gap.

## Changes Made

- **New endpoint** `POST /visual-editor/api/icons/svg/sanitize` — runs the `SvgSanitizer` and returns `{svg, warnings}` so the editor can preview + warn before persisting. 256 KB cap with a 413 response for oversized payloads.
- **New `CustomSvgControl` sidebar panel** — textarea for paste + hidden file picker for upload. Rejects non-`.svg` files with a clear error. Surfaces sanitization warnings inline as a `Notice`.
- **Icon block canvas** now renders the sanitized `customSvg` directly via `dangerouslySetInnerHTML` (replacing the Phase 1 inert preview chip). Safe because the attribute is only ever written through the sanitize endpoint; the live front-end render re-sanitizes anyway.
- **`SvgSanitizer` allowlist expansion** — `style`, `version`, `xml:space` now pass through. Style values are scrubbed: inert declarations (`fill:#abc`, `opacity:0.5`, `url(#gradient)`) survive; `expression()`, `javascript:`/`vbscript:`, `-moz-binding`, and external/protocol-relative `url()` references are stripped with warnings. Fixes a real bug where Illustrator/Figma exports rendered as black silhouettes because every inline `style="fill:…"` was wiped.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS
- Browser: Chrome
- PHP Version: 8.4.3
- Project Version: release/1.1

**Tests Performed:**
1. Pasted a clean SVG → canvas rendered the icon, no warnings.
2. Pasted a hostile SVG with `<script>`, `onload`, `onclick` → markup persisted minus the dangerous bits, warning list showed each removal.
3. Uploaded a real ArtisanPack logo SVG (Illustrator export with inline `style`) → rendered with the correct fills + harmless-attribute warnings.
4. Uploaded a `.png` → got an explicit "isn't an SVG" error, no request fired.
5. Cleared SVG → block returned to placeholder; picker still worked afterwards.

## Accessibility Tests Run

- [x] Keyboard navigation tested
- [x] ARIA labels checked

**Details:** The textarea has a label, the upload button is keyboard-reachable, the file input gets an `aria-label`, and warning/error Notices use `role="status"`/`role="alert"` via the WP components. Decorative-link conflict warning from earlier phases is preserved.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:**
- **Pest (`IconPickerEndpointsTest`)**: hostile SVG → stripped + warnings emitted; non-string payload → 422; oversize payload → 413.
- **Pest (`SvgSanitizerTest`)**: `style` allowlist + scrubbing for `expression()`/`javascript:`/external `url()`; internal `url(#…)` preserved; `version`/`xml:space` allowed.
- **Vitest (`custom-svg-control.test.tsx`)**: paste flow updates `customSvg` and surfaces server warnings; emptying textarea clears the attribute; non-svg file shows an error and skips the request.
- Full suite: 948 Pest tests + 1882 vitest tests passing on this branch.

## Documentation

- [x] Inline code documentation added

**Documentation details:** New files (`IconSvgSanitizeController`, `custom-svg.ts`, `custom-svg-control.tsx`) carry phase + intent docblocks. The sanitizer's new style-scrubbing helper documents the script-vector allowlist.

## Pre-Submission Checklist

- [x] Code passes all tests
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Paste-or-upload custom SVGs with explicit Upload and Clear controls and rendered preview in the editor.
  * Server-side sanitization that preserves safe presentation styles and returns inline warnings; failures clear the custom SVG.
  * File validation enforcing SVG format and 256 KB size limit; same-file reselect supported.

* **Tests**
  * End-to-end and unit tests covering sanitization, style handling, upload/paste flows, and the sanitize API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->