### PR TITLE
feat: icon block phase 6 — admin icon sets settings + zip-upload

### DIFF
--- a/resources/views/admin/icon-sets.blade.php
+++ b/resources/views/admin/icon-sets.blade.php
@@ -1,0 +1,364 @@
+{{-- Phase 6 (#557) — admin icon-sets settings page.
+
+	Server-rendered list + plain HTML forms targeting the
+	`/visual-editor/api/admin/icon-sets` endpoints. The page is gated
+	by the same `SiteEditorAccessGate` binding that protects the
+	site-editor SPA mount, so reaching this view at all implies the
+	visitor has cleared the visual-editor management policy.
+
+	Inline styles deliberately — the SPA's Vite bundle isn't loaded
+	here, so the page must render without it. Mirrors the install-gate
+	page (#432). --}}
+<!DOCTYPE html>
+<html lang="{{ str_replace( '_', '-', app()->getLocale() ) }}">
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<meta name="csrf-token" content="{{ csrf_token() }}">
+	<title>{{ __( 'Icon Sets — ArtisanPack Visual Editor' ) }}</title>
+	<style>
+		:root { color-scheme: light dark; }
+
+		body {
+			margin: 0;
+			min-height: 100vh;
+			padding: 2rem;
+			background: #f5f5f7;
+			color: #1d1d1f;
+			font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+			line-height: 1.5;
+		}
+
+		.ap-settings {
+			max-width: 48rem;
+			margin: 0 auto;
+		}
+
+		.ap-settings__header {
+			margin-bottom: 1.5rem;
+		}
+
+		.ap-settings__header h1 {
+			margin: 0 0 0.25rem 0;
+			font-size: 1.5rem;
+		}
+
+		.ap-settings__header p {
+			margin: 0;
+			color: #6e6e73;
+		}
+
+		.ap-card {
+			background: #fff;
+			border: 1px solid #e5e5ea;
+			border-radius: 12px;
+			padding: 1.25rem 1.5rem;
+			margin-bottom: 1.25rem;
+		}
+
+		.ap-card h2 {
+			margin: 0 0 0.75rem 0;
+			font-size: 1.125rem;
+		}
+
+		.ap-form-row {
+			display: grid;
+			grid-template-columns: 9rem 1fr;
+			gap: 0.5rem 0.75rem;
+			align-items: center;
+			margin-bottom: 0.75rem;
+		}
+
+		.ap-form-row label {
+			color: #424245;
+			font-weight: 500;
+		}
+
+		.ap-form-row input[type="text"],
+		.ap-form-row input[type="file"] {
+			width: 100%;
+			padding: 0.5rem 0.625rem;
+			border: 1px solid #d2d2d7;
+			border-radius: 8px;
+			font-size: 0.95rem;
+			background: #fff;
+			color: inherit;
+		}
+
+		.ap-actions {
+			display: flex;
+			gap: 0.5rem;
+			justify-content: flex-end;
+		}
+
+		.ap-button {
+			padding: 0.5rem 1rem;
+			border-radius: 8px;
+			border: 1px solid transparent;
+			font-size: 0.95rem;
+			cursor: pointer;
+			background: #0071e3;
+			color: #fff;
+		}
+
+		.ap-button--secondary {
+			background: #fff;
+			color: #1d1d1f;
+			border-color: #d2d2d7;
+		}
+
+		.ap-button--danger {
+			background: #d70015;
+		}
+
+		.ap-table {
+			width: 100%;
+			border-collapse: collapse;
+		}
+
+		.ap-table th,
+		.ap-table td {
+			text-align: left;
+			padding: 0.65rem 0.5rem;
+			border-bottom: 1px solid #e5e5ea;
+			vertical-align: middle;
+		}
+
+		.ap-table th {
+			font-size: 0.75rem;
+			text-transform: uppercase;
+			letter-spacing: 0.04em;
+			color: #6e6e73;
+			font-weight: 600;
+		}
+
+		.ap-table tr:last-child td { border-bottom: 0; }
+
+		.ap-empty {
+			padding: 1rem;
+			color: #6e6e73;
+			text-align: center;
+			font-style: italic;
+		}
+
+		.ap-feedback {
+			margin: 0 0 1rem 0;
+			padding: 0.75rem 1rem;
+			border-radius: 8px;
+			background: #eaf3ff;
+			border: 1px solid #b8d4fe;
+			color: #003580;
+			font-size: 0.9rem;
+		}
+
+		/* Visually hide the feedback region while it has no message —
+		   `aria-live` regions cannot be `hidden`, so we drop them out
+		   of layout with CSS instead. */
+		[role="status"][aria-hidden="true"] {
+			position: absolute;
+			width: 1px;
+			height: 1px;
+			padding: 0;
+			margin: -1px;
+			overflow: hidden;
+			clip: rect(0, 0, 0, 0);
+			white-space: nowrap;
+			border: 0;
+		}
+
+		.ap-feedback--error {
+			background: #fff0f0;
+			border-color: #fcc;
+			color: #8a0010;
+		}
+
+		.ap-row-actions form { display: inline; }
+
+		@media (prefers-color-scheme: dark) {
+			body { background: #1d1d1f; color: #f5f5f7; }
+			.ap-card { background: #2c2c2e; border-color: #3a3a3c; }
+			.ap-settings__header p,
+			.ap-table th { color: #8e8e93; }
+			.ap-form-row input[type="text"],
+			.ap-form-row input[type="file"] {
+				background: #1d1d1f; border-color: #3a3a3c; color: #f5f5f7;
+			}
+			.ap-button--secondary { background: #2c2c2e; color: #f5f5f7; border-color: #3a3a3c; }
+		}
+	</style>
+</head>
+<body>
+	<main class="ap-settings">
+		<header class="ap-settings__header">
+			<h1>{{ __( 'Icon Sets' ) }}</h1>
+			<p>{{ __( 'Upload licensed SVG icon sets (e.g. Font Awesome Pro) for use in the Icon block.' ) }}</p>
+		</header>
+
+		<div id="ap-feedback" role="status" aria-live="polite" aria-atomic="true" aria-hidden="true"></div>
+
+		<section class="ap-card">
+			<h2>{{ __( 'Upload a new set' ) }}</h2>
+			<form id="ap-icon-sets-upload" enctype="multipart/form-data">
+				<div class="ap-form-row">
+					<label for="ap-prefix">{{ __( 'Prefix' ) }}</label>
+					<input id="ap-prefix" name="prefix" type="text" required
+					       autocomplete="off" pattern="[a-z0-9][a-z0-9_-]{1,31}"
+					       placeholder="fa-pro">
+				</div>
+				<div class="ap-form-row">
+					<label for="ap-label">{{ __( 'Label' ) }}</label>
+					<input id="ap-label" name="label" type="text" required maxlength="64"
+					       placeholder="{{ __( 'Font Awesome Pro' ) }}">
+				</div>
+				<div class="ap-form-row">
+					<label for="ap-zip">{{ __( 'Zip archive' ) }}</label>
+					<input id="ap-zip" name="zip" type="file" accept=".zip,application/zip" required>
+				</div>
+				<p style="margin:0 0 0.75rem 0; color:#6e6e73; font-size:0.85rem;">
+					{{ __( 'Maximum size: :size MB. Non-SVG entries are skipped; each SVG runs through the package sanitizer.', [ 'size' => intdiv( $maxKilobytes, 1024 ) ] ) }}
+				</p>
+				<div class="ap-actions">
+					<button type="submit" class="ap-button">{{ __( 'Upload' ) }}</button>
+				</div>
+			</form>
+		</section>
+
+		<section class="ap-card">
+			<h2>{{ __( 'Registered sets' ) }}</h2>
+			@if ( empty( $sets ) )
+				<p class="ap-empty">{{ __( 'No uploaded icon sets yet.' ) }}</p>
+			@else
+				<table class="ap-table">
+					<thead>
+						<tr>
+							<th>{{ __( 'Prefix' ) }}</th>
+							<th>{{ __( 'Label' ) }}</th>
+							<th>{{ __( 'Uploaded' ) }}</th>
+							<th></th>
+						</tr>
+					</thead>
+					<tbody>
+						@foreach ( $sets as $set )
+							<tr>
+								<td><code>{{ $set->prefix }}</code></td>
+								<td>{{ $set->label }}</td>
+								<td>{{ $set->createdAt }}</td>
+								<td class="ap-row-actions" style="text-align:right;">
+									<button type="button" class="ap-button ap-button--secondary"
+									        data-action="rename"
+									        data-prefix="{{ $set->prefix }}"
+									        data-label="{{ $set->label }}">
+										{{ __( 'Rename' ) }}
+									</button>
+									<button type="button" class="ap-button ap-button--danger"
+									        data-action="delete"
+									        data-prefix="{{ $set->prefix }}">
+										{{ __( 'Delete' ) }}
+									</button>
+								</td>
+							</tr>
+						@endforeach
+					</tbody>
+				</table>
+			@endif
+		</section>
+	</main>
+
+	<script>
+		(function () {
+			'use strict';
+
+			var apiBase = @json( $apiBase );
+			var csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+			var feedback = document.getElementById('ap-feedback');
+
+			function showFeedback(message, isError) {
+				feedback.textContent = message;
+				feedback.className = 'ap-feedback' + (isError ? ' ap-feedback--error' : '');
+				feedback.setAttribute('aria-hidden', 'false');
+			}
+
+			async function reload() {
+				window.location.reload();
+			}
+
+			document.getElementById('ap-icon-sets-upload').addEventListener('submit', async function (event) {
+				event.preventDefault();
+				var formData = new FormData(event.target);
+				try {
+					var res = await fetch(apiBase, {
+						method: 'POST',
+						headers: { 'X-CSRF-TOKEN': csrfToken, 'Accept': 'application/json' },
+						body: formData,
+						credentials: 'same-origin',
+					});
+					var body = await res.json().catch(function () { return {}; });
+					if (!res.ok) {
+						showFeedback(body.message || 'Upload failed.', true);
+						return;
+					}
+					showFeedback('Uploaded ' + ((body.report && body.report.stored && body.report.stored.length) || 0) + ' icon(s).');
+					setTimeout(reload, 800);
+				} catch (err) {
+					showFeedback(String(err), true);
+				}
+			});
+
+			document.querySelectorAll('button[data-action="rename"]').forEach(function (btn) {
+				btn.addEventListener('click', async function () {
+					var prefix = btn.getAttribute('data-prefix');
+					var current = btn.getAttribute('data-label');
+					var next = window.prompt('New label for "' + prefix + '":', current);
+					if (next === null || next.trim() === '' || next === current) {
+						return;
+					}
+					try {
+						var res = await fetch(apiBase + '/' + encodeURIComponent(prefix), {
+							method: 'PATCH',
+							headers: {
+								'X-CSRF-TOKEN': csrfToken,
+								'Accept': 'application/json',
+								'Content-Type': 'application/json',
+							},
+							body: JSON.stringify({ label: next }),
+							credentials: 'same-origin',
+						});
+						if (!res.ok) {
+							var body = await res.json().catch(function () { return {}; });
+							showFeedback(body.message || 'Rename failed.', true);
+							return;
+						}
+						reload();
+					} catch (err) {
+						showFeedback(String(err), true);
+					}
+				});
+			});
+
+			document.querySelectorAll('button[data-action="delete"]').forEach(function (btn) {
+				btn.addEventListener('click', async function () {
+					var prefix = btn.getAttribute('data-prefix');
+					if (!window.confirm('Delete icon set "' + prefix + '"? This cannot be undone.')) {
+						return;
+					}
+					try {
+						var res = await fetch(apiBase + '/' + encodeURIComponent(prefix), {
+							method: 'DELETE',
+							headers: { 'X-CSRF-TOKEN': csrfToken, 'Accept': 'application/json' },
+							credentials: 'same-origin',
+						});
+						if (!res.ok && res.status !== 204) {
+							var body = await res.json().catch(function () { return {}; });
+							showFeedback(body.message || 'Delete failed.', true);
+							return;
+						}
+						reload();
+					} catch (err) {
+						showFeedback(String(err), true);
+					}
+				});
+			});
+		}());
+	</script>
+</body>
+</html>

--- a/routes/api.php
+++ b/routes/api.php
@@ -24,6 +24,7 @@ use ArtisanPackUI\VisualEditor\Http\Controllers\BlockPreviewController;
 use ArtisanPackUI\VisualEditor\Http\Controllers\EntitySearchController;
 use ArtisanPackUI\VisualEditor\Http\Controllers\Icon\IconSearchController;
 use ArtisanPackUI\VisualEditor\Http\Controllers\Icon\IconSetsController;
+use ArtisanPackUI\VisualEditor\Http\Controllers\Icon\IconSetsManagementController;
 use ArtisanPackUI\VisualEditor\Http\Controllers\Icon\IconSvgController;
 use ArtisanPackUI\VisualEditor\Http\Controllers\Icon\IconSvgSanitizeController;
 use ArtisanPackUI\VisualEditor\Http\Controllers\MenuLocationsController;
@@ -221,6 +222,27 @@ Route::get( 'icons/svg', [ IconSvgController::class, 'show' ] )
 // warnings inline before save.
 Route::post( 'icons/svg/sanitize', [ IconSvgSanitizeController::class, 'store' ] )
 	->name( 'visual-editor.api.icons.svg.sanitize' );
+
+// Icon Block Phase 6 (#557) — admin icon-set management endpoints.
+// Each action runs through the bound `SiteEditorAccessGate` (the
+// package's existing visual-editor management policy) inside the
+// controller, so the unauthorised path returns the gate's response
+// rather than a flat 403. The prefix route constraint mirrors the
+// uploader's allow-list to keep `../`-laced inputs from reaching the
+// registry.
+Route::get( 'admin/icon-sets', [ IconSetsManagementController::class, 'index' ] )
+	->name( 'visual-editor.api.admin.icon-sets.index' );
+
+Route::post( 'admin/icon-sets', [ IconSetsManagementController::class, 'store' ] )
+	->name( 'visual-editor.api.admin.icon-sets.store' );
+
+Route::patch( 'admin/icon-sets/{prefix}', [ IconSetsManagementController::class, 'update' ] )
+	->where( 'prefix', '[a-z0-9][a-z0-9_-]{1,31}' )
+	->name( 'visual-editor.api.admin.icon-sets.update' );
+
+Route::delete( 'admin/icon-sets/{prefix}', [ IconSetsManagementController::class, 'destroy' ] )
+	->where( 'prefix', '[a-z0-9][a-z0-9_-]{1,31}' )
+	->name( 'visual-editor.api.admin.icon-sets.destroy' );
 
 // G3 cms-framework Post + Page entity adapters — see plan 12 §4.4.
 // Both controllers resolve their model through `ResourceResolver`, so

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use ArtisanPackUI\VisualEditor\Http\Requests\Icon\UploadIconSetRequest;
+use ArtisanPackUI\VisualEditor\Services\Icon\UploadedIconSetRegistry;
 use ArtisanPackUI\VisualEditor\SiteEditor\Gates\SiteEditorAccessGate;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
@@ -28,6 +30,32 @@ Route::get('/editor', function () {
 Route::get('/ve-sandbox', function () {
     return view('visual-editor::sandbox.index');
 })->name('visual-editor.sandbox');
+
+// Icon Block Phase 6 (#557) — admin icon-sets settings page.
+//
+// Server-rendered settings screen that lists uploaded icon sets and
+// offers the upload / rename / delete forms. Access runs through the
+// same `SiteEditorAccessGate` binding that protects the site editor
+// SPA — the issue forbids introducing a new capability for this
+// surface, so this is "the existing visual-editor management policy".
+// Inline-styled like the install-gate page so it stands alone without
+// the SPA's Vite bundle.
+Route::middleware('web')
+    ->group(function (): void {
+        Route::get('/visual-editor/admin/icon-sets', function (Request $request, SiteEditorAccessGate $gate) {
+            if ($denial = $gate->check($request)) {
+                return $denial;
+            }
+
+            $registry = app(UploadedIconSetRegistry::class);
+
+            return view('visual-editor::admin.icon-sets', [
+                'sets'         => $registry->all(),
+                'apiBase'      => '/visual-editor/api/admin/icon-sets',
+                'maxKilobytes' => UploadIconSetRequest::MAX_ZIP_KILOBYTES,
+            ]);
+        })->name('visual-editor.admin.icon-sets');
+    });
 
 // D1 (#368). Site-editor shell. A single catch-all entry mounts the SPA and
 // hands routing inside the shell to the React app via `history.pushState`.

--- a/src/Http/Controllers/Icon/IconSetsManagementController.php
+++ b/src/Http/Controllers/Icon/IconSetsManagementController.php
@@ -1,0 +1,127 @@
+<?php
+
+/**
+ * Admin icon-set management endpoints.
+ *
+ * Phase 6 (#557) of the Icon Block feature (#494). Backs the settings
+ * screen — list, upload, rename, delete. Every action runs through the
+ * bound {@see SiteEditorAccessGate} (the package's existing
+ * visual-editor management policy) so the surface is unreachable for
+ * users who can't reach the rest of the site editor.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.1.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Http\Controllers\Icon;
+
+use ArtisanPackUI\VisualEditor\Http\Requests\Icon\RenameIconSetRequest;
+use ArtisanPackUI\VisualEditor\Http\Requests\Icon\UploadIconSetRequest;
+use ArtisanPackUI\VisualEditor\Services\Icon\IconSetUploader;
+use ArtisanPackUI\VisualEditor\Services\Icon\PrefixCollisionException;
+use ArtisanPackUI\VisualEditor\Services\Icon\UploadedIconSet;
+use ArtisanPackUI\VisualEditor\Services\Icon\UploadedIconSetRegistry;
+use ArtisanPackUI\VisualEditor\SiteEditor\Gates\SiteEditorAccessGate;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use RuntimeException;
+use Symfony\Component\HttpFoundation\Response;
+
+class IconSetsManagementController extends Controller
+{
+	public function __construct(
+		protected UploadedIconSetRegistry $registry,
+		protected IconSetUploader $uploader,
+		protected SiteEditorAccessGate $gate,
+	) {
+	}
+
+	public function index( Request $request ): Response
+	{
+		if ( $denial = $this->gate->check( $request ) ) {
+			return $denial;
+		}
+
+		return new JsonResponse( [
+			'data' => array_map(
+				static fn ( UploadedIconSet $set ): array => $set->toArray(),
+				$this->registry->all(),
+			),
+		] );
+	}
+
+	public function store( UploadIconSetRequest $request ): Response
+	{
+		if ( $denial = $this->gate->check( $request ) ) {
+			return $denial;
+		}
+
+		try {
+			$result = $this->uploader->upload(
+				$request->file( 'zip' ),
+				(string) $request->input( 'prefix' ),
+				(string) $request->input( 'label' ),
+			);
+		} catch ( PrefixCollisionException $e ) {
+			return new JsonResponse( [
+				'error'  => 'prefix_collision',
+				'prefix' => $e->prefix,
+				'message' => $e->getMessage(),
+			], Response::HTTP_CONFLICT );
+		} catch ( RuntimeException $e ) {
+			return new JsonResponse( [
+				'error'   => 'upload_failed',
+				'message' => $e->getMessage(),
+			], Response::HTTP_UNPROCESSABLE_ENTITY );
+		}
+
+		return new JsonResponse( [
+			'data'   => $this->registry->find( (string) $request->input( 'prefix' ) )?->toArray(),
+			'report' => $result->toArray(),
+		], Response::HTTP_CREATED );
+	}
+
+	public function update( RenameIconSetRequest $request, string $prefix ): Response
+	{
+		if ( $denial = $this->gate->check( $request ) ) {
+			return $denial;
+		}
+
+		if ( ! $this->registry->has( $prefix ) ) {
+			return new JsonResponse( [ 'error' => 'not_found' ], Response::HTTP_NOT_FOUND );
+		}
+
+		try {
+			$updated = $this->registry->rename( $prefix, (string) $request->input( 'label' ) );
+		} catch ( RuntimeException $e ) {
+			return new JsonResponse( [
+				'error'   => 'rename_failed',
+				'message' => $e->getMessage(),
+			], Response::HTTP_UNPROCESSABLE_ENTITY );
+		}
+
+		return new JsonResponse( [ 'data' => $updated->toArray() ] );
+	}
+
+	public function destroy( Request $request, string $prefix ): Response
+	{
+		if ( $denial = $this->gate->check( $request ) ) {
+			return $denial;
+		}
+
+		if ( ! $this->registry->has( $prefix ) ) {
+			return new JsonResponse( [ 'error' => 'not_found' ], Response::HTTP_NOT_FOUND );
+		}
+
+		$this->uploader->delete( $prefix );
+
+		return new JsonResponse( null, Response::HTTP_NO_CONTENT );
+	}
+}

--- a/src/Http/Requests/Icon/RenameIconSetRequest.php
+++ b/src/Http/Requests/Icon/RenameIconSetRequest.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * Rename icon set form request.
+ *
+ * Phase 6 (#557) of the Icon Block feature (#494). Validates the
+ * label-only payload for the rename endpoint — the prefix is fixed by
+ * the route parameter (renaming the prefix would force a directory move
+ * and break in-flight blocks that already reference the old prefix).
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.1.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Http\Requests\Icon;
+
+use ArtisanPackUI\VisualEditor\Services\Icon\UploadedIconSetRegistry;
+use Illuminate\Foundation\Http\FormRequest;
+
+class RenameIconSetRequest extends FormRequest
+{
+	public function authorize(): bool
+	{
+		return true;
+	}
+
+	/**
+	 * @return array<string, array<int, mixed>>
+	 */
+	public function rules(): array
+	{
+		return [
+			'label' => [
+				'required',
+				'string',
+				'max:' . UploadedIconSetRegistry::LABEL_MAX_LENGTH,
+			],
+		];
+	}
+}

--- a/src/Http/Requests/Icon/UploadIconSetRequest.php
+++ b/src/Http/Requests/Icon/UploadIconSetRequest.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * Upload icon set form request.
+ *
+ * Phase 6 (#557) of the Icon Block feature (#494). Validates the
+ * multipart payload — zip + prefix + label — before the controller
+ * hands the upload to {@see \ArtisanPackUI\VisualEditor\Services\Icon\IconSetUploader}.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.1.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Http\Requests\Icon;
+
+use ArtisanPackUI\VisualEditor\Services\Icon\UploadedIconSetRegistry;
+use Illuminate\Foundation\Http\FormRequest;
+
+class UploadIconSetRequest extends FormRequest
+{
+	/**
+	 * Per-upload size ceiling in kilobytes. A full FA Pro family zips
+	 * to ~25 MB; the cap sits comfortably above legitimate uploads but
+	 * keeps a misuse (full-resolution illustrations being passed off as
+	 * icons) from filling the host's temp directory.
+	 */
+	public const MAX_ZIP_KILOBYTES = 51_200;
+
+	public function authorize(): bool
+	{
+		// Authorisation happens in the controller via the
+		// SiteEditorAccessGate so the unauthorised path returns the
+		// gate's own response (install instructions, redirect to login,
+		// 503, etc.) instead of a flat 403.
+		return true;
+	}
+
+	/**
+	 * @return array<string, array<int, mixed>>
+	 */
+	public function rules(): array
+	{
+		return [
+			'prefix' => [
+				'required',
+				'string',
+				'regex:' . UploadedIconSetRegistry::PREFIX_PATTERN,
+			],
+			'label'  => [
+				'required',
+				'string',
+				'max:' . UploadedIconSetRegistry::LABEL_MAX_LENGTH,
+			],
+			'zip'    => [
+				'required',
+				'file',
+				'mimetypes:application/zip,application/x-zip-compressed,multipart/x-zip',
+				'max:' . self::MAX_ZIP_KILOBYTES,
+			],
+		];
+	}
+
+	/**
+	 * @return array<string, string>
+	 */
+	public function messages(): array
+	{
+		return [
+			'prefix.regex' => 'Prefix must be 2–32 chars of lowercase letters, digits, dashes or underscores.',
+			'zip.mimetypes' => 'Uploaded file must be a zip archive.',
+		];
+	}
+}

--- a/src/Services/Icon/IconSetUploadResult.php
+++ b/src/Services/Icon/IconSetUploadResult.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * Per-file outcome envelope for the admin icon-set upload pipeline.
+ *
+ * Phase 6 (#557) of the Icon Block feature (#494). The settings screen
+ * surfaces a row-by-row report after a zip upload so admins can see
+ * what landed, what was skipped (non-SVG entries), and what failed
+ * sanitization with the corresponding warnings.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.1.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Services\Icon;
+
+/**
+ * Returned by {@see IconSetUploader::upload()}. Callers use the typed
+ * arrays directly — there is no behaviour on this struct beyond
+ * serialisation for the JSON response.
+ */
+final class IconSetUploadResult
+{
+	/**
+	 * @param  array<int, string>                                $stored   File names that were sanitized and written under the set directory.
+	 * @param  array<int, string>                                $skipped  Zip entries dropped before sanitization (non-SVG extension, empty payload, traversal attempt).
+	 * @param  array<int, array{file: string, warnings: array<int, string>}> $failed   Entries the sanitizer reduced to empty markup. The warnings array is the sanitizer's removal list.
+	 */
+	public function __construct(
+		public readonly array $stored = [],
+		public readonly array $skipped = [],
+		public readonly array $failed = [],
+	) {
+	}
+
+	public function totalProcessed(): int
+	{
+		return count( $this->stored ) + count( $this->skipped ) + count( $this->failed );
+	}
+
+	/**
+	 * @return array{
+	 *     stored: array<int, string>,
+	 *     skipped: array<int, string>,
+	 *     failed: array<int, array{file: string, warnings: array<int, string>}>
+	 * }
+	 */
+	public function toArray(): array
+	{
+		return [
+			'stored'  => $this->stored,
+			'skipped' => $this->skipped,
+			'failed'  => $this->failed,
+		];
+	}
+}

--- a/src/Services/Icon/IconSetUploader.php
+++ b/src/Services/Icon/IconSetUploader.php
@@ -1,0 +1,323 @@
+<?php
+
+/**
+ * Admin icon-set zip-upload pipeline.
+ *
+ * Phase 6 (#557) of the Icon Block feature (#494). Takes a zip uploaded
+ * through the settings screen, extracts each entry, runs the SVG payload
+ * through {@see SvgSanitizer}, writes survivors under the per-set
+ * directory, and records the set in the {@see UploadedIconSetRegistry}.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.1.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Services\Icon;
+
+use RuntimeException;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use ZipArchive;
+
+/**
+ * The uploader is deliberately split from the controller layer so Pest
+ * tests can drive it against real zip fixtures without booting the full
+ * HTTP stack. It owns three responsibilities:
+ *
+ *   1. Open the zip safely (cap entry count + total uncompressed size to
+ *      head off zip-bomb DoS against the dev box).
+ *   2. Per entry: reject non-SVG extensions outright, sanitize the SVG
+ *      payload, and write the survivors under
+ *      `{baseDir}/{prefix}/{basename}.svg`.
+ *   3. Persist the set's metadata through the registry once at least one
+ *      icon landed — a zip that yields zero stored files is treated as a
+ *      failed upload and no metadata is written.
+ *
+ * The uploader does NOT call into `ap.icons.register-icon-sets` itself —
+ * that happens at app boot, walking whatever the registry persisted.
+ * Doing it here would skip the registration on the next process / queue
+ * worker until the application rebooted, which would make uploaded
+ * icons "disappear" after a deploy.
+ */
+final class IconSetUploader
+{
+	/**
+	 * Defensive caps against zip bombs. A typical FA Pro family is on
+	 * the order of 2k–10k SVG files and the SVG payloads are a few KB
+	 * each; the limits sit comfortably above legitimate uploads.
+	 */
+	private const MAX_ENTRY_COUNT      = 25_000;
+	private const MAX_UNCOMPRESSED_SIZE = 256 * 1024 * 1024;
+	private const MAX_FILENAME_LENGTH   = 128;
+
+	/**
+	 * Reserved set prefixes — these belong to the bundled FA Free sets
+	 * shipped under `resources/icons/font-awesome/`. Letting an admin
+	 * register a competing `fas` set would silently shadow the bundled
+	 * icons on disk, which is the exact ambiguity the prefix-collision
+	 * check is meant to surface.
+	 */
+	private const RESERVED_PREFIXES = [ 'fas', 'far', 'fab' ];
+
+	public function __construct(
+		private readonly UploadedIconSetRegistry $registry,
+		private readonly SvgSanitizer $sanitizer,
+	) {
+	}
+
+	/**
+	 * Process the uploaded zip and persist the resulting set.
+	 *
+	 * @throws PrefixCollisionException When the requested prefix is already taken (bundled or uploaded).
+	 * @throws RuntimeException         For unrecoverable filesystem / zip failures.
+	 */
+	public function upload( UploadedFile $zip, string $prefix, string $label ): IconSetUploadResult
+	{
+		$prefix = strtolower( trim( $prefix ) );
+		$label  = trim( $label );
+
+		$this->assertPrefixAvailable( $prefix );
+		$this->assertLabelValid( $label );
+
+		$archive = $this->openZip( $zip );
+
+		try {
+			$this->assertWithinLimits( $archive );
+
+			$targetDir = $this->registry->pathFor( $prefix );
+			$this->prepareTargetDirectory( $targetDir );
+
+			$result = $this->extractEntries( $archive, $targetDir );
+		} finally {
+			$archive->close();
+		}
+
+		if ( [] === $result->stored ) {
+			throw new RuntimeException( 'Upload contained no usable SVG icons.' );
+		}
+
+		$this->registry->register(
+			new UploadedIconSet( $prefix, $label, gmdate( 'Y-m-d\TH:i:s\Z' ) ),
+		);
+
+		return $result;
+	}
+
+	/**
+	 * Delete an uploaded set's metadata AND its on-disk SVGs in a single
+	 * call. The settings screen exposes this as the "delete" action.
+	 */
+	public function delete( string $prefix ): void
+	{
+		$set = $this->registry->find( $prefix );
+		if ( null === $set ) {
+			return;
+		}
+
+		$this->registry->forget( $prefix );
+
+		$dir = $this->registry->pathFor( $prefix );
+		if ( is_dir( $dir ) ) {
+			$this->removeDirectoryRecursively( $dir );
+		}
+	}
+
+	/**
+	 * Cross-check the requested prefix against bundled FA reservations
+	 * and the persisted uploaded sets. Raised as a typed exception so
+	 * the controller can map it to a 409 response with the offending
+	 * prefix visible to the admin.
+	 */
+	private function assertPrefixAvailable( string $prefix ): void
+	{
+		if ( ! UploadedIconSetRegistry::isValidPrefix( $prefix ) ) {
+			throw new RuntimeException(
+				'Icon-set prefix must be 2–32 chars of lowercase letters, digits, dashes or underscores.',
+			);
+		}
+
+		if ( in_array( $prefix, self::RESERVED_PREFIXES, true ) ) {
+			throw new PrefixCollisionException( $prefix );
+		}
+
+		if ( $this->registry->has( $prefix ) ) {
+			throw new PrefixCollisionException( $prefix );
+		}
+	}
+
+	private function assertLabelValid( string $label ): void
+	{
+		if ( '' === $label ) {
+			throw new RuntimeException( 'Icon-set label cannot be empty.' );
+		}
+
+		if ( mb_strlen( $label ) > UploadedIconSetRegistry::LABEL_MAX_LENGTH ) {
+			throw new RuntimeException( 'Icon-set label is too long.' );
+		}
+	}
+
+	private function openZip( UploadedFile $zip ): ZipArchive
+	{
+		if ( ! class_exists( ZipArchive::class ) ) {
+			throw new RuntimeException( 'PHP zip extension is required to upload icon sets.' );
+		}
+
+		$archive = new ZipArchive();
+		$status  = $archive->open( $zip->getRealPath() ?: $zip->getPathname(), ZipArchive::RDONLY );
+
+		if ( true !== $status ) {
+			throw new RuntimeException( 'Uploaded file is not a valid zip archive.' );
+		}
+
+		return $archive;
+	}
+
+	private function assertWithinLimits( ZipArchive $archive ): void
+	{
+		if ( $archive->numFiles > self::MAX_ENTRY_COUNT ) {
+			throw new RuntimeException(
+				sprintf( 'Zip contains too many entries (%d > %d).', $archive->numFiles, self::MAX_ENTRY_COUNT ),
+			);
+		}
+
+		$total = 0;
+		for ( $i = 0; $i < $archive->numFiles; $i++ ) {
+			$stat = $archive->statIndex( $i );
+			if ( false === $stat ) {
+				continue;
+			}
+			$total += (int) ( $stat['size'] ?? 0 );
+			if ( $total > self::MAX_UNCOMPRESSED_SIZE ) {
+				throw new RuntimeException( 'Zip uncompressed size exceeds the allowed limit.' );
+			}
+		}
+	}
+
+	private function prepareTargetDirectory( string $dir ): void
+	{
+		if ( is_dir( $dir ) ) {
+			$this->removeDirectoryRecursively( $dir );
+		}
+
+		if ( ! mkdir( $dir, 0o755, true ) && ! is_dir( $dir ) ) {
+			throw new RuntimeException( "Failed to create icon-set directory: {$dir}" );
+		}
+	}
+
+	private function extractEntries( ZipArchive $archive, string $targetDir ): IconSetUploadResult
+	{
+		$stored  = [];
+		$skipped = [];
+		$failed  = [];
+
+		for ( $i = 0; $i < $archive->numFiles; $i++ ) {
+			$name = $archive->getNameIndex( $i );
+			if ( false === $name || '' === $name ) {
+				continue;
+			}
+
+			// Directory entries inside the zip are not icons — skip them
+			// silently. They show up in zips created by Finder / Explorer
+			// for every folder, and counting them as "skipped" would
+			// pollute the per-file report.
+			if ( str_ends_with( $name, '/' ) ) {
+				continue;
+			}
+
+			$basename = $this->sanitizeBasename( $name );
+			if ( null === $basename ) {
+				$skipped[] = $name;
+				continue;
+			}
+
+			if ( '.svg' !== strtolower( substr( $basename, -4 ) ) ) {
+				$skipped[] = $basename;
+				continue;
+			}
+
+			$payload = $archive->getFromIndex( $i );
+			if ( false === $payload || '' === trim( $payload ) ) {
+				$skipped[] = $basename;
+				continue;
+			}
+
+			$result = $this->sanitizer->sanitize( $payload );
+			if ( $result->isEmpty() ) {
+				$failed[] = [
+					'file'     => $basename,
+					'warnings' => $result->warnings,
+				];
+				continue;
+			}
+
+			$targetPath = $targetDir . DIRECTORY_SEPARATOR . $basename;
+			if ( false === file_put_contents( $targetPath, $result->sanitized ) ) {
+				throw new RuntimeException( "Failed to write sanitized icon: {$basename}" );
+			}
+
+			$stored[] = $basename;
+		}
+
+		return new IconSetUploadResult( $stored, $skipped, $failed );
+	}
+
+	/**
+	 * Reduce a zip entry's name to a safe SVG basename, or `null` if it
+	 * would escape the set directory / look nothing like an SVG filename.
+	 *
+	 * Strips any directory prefix the zip carries (FA Pro zips nest icons
+	 * three folders deep), rejects `..` segments, non-ASCII filenames and
+	 * over-long names. The result is appended to the trusted target
+	 * directory without further validation, so this method is the single
+	 * choke-point for path traversal.
+	 */
+	private function sanitizeBasename( string $entry ): ?string
+	{
+		$basename = basename( str_replace( '\\', '/', $entry ) );
+		if ( '' === $basename ) {
+			return null;
+		}
+
+		if ( str_starts_with( $basename, '.' ) ) {
+			return null;
+		}
+
+		if ( strlen( $basename ) > self::MAX_FILENAME_LENGTH ) {
+			return null;
+		}
+
+		if ( 1 !== preg_match( '/^[A-Za-z0-9._-]+$/', $basename ) ) {
+			return null;
+		}
+
+		return $basename;
+	}
+
+	private function removeDirectoryRecursively( string $dir ): void
+	{
+		$entries = scandir( $dir );
+		if ( false === $entries ) {
+			return;
+		}
+
+		foreach ( $entries as $entry ) {
+			if ( '.' === $entry || '..' === $entry ) {
+				continue;
+			}
+
+			$path = $dir . DIRECTORY_SEPARATOR . $entry;
+			if ( is_dir( $path ) && ! is_link( $path ) ) {
+				$this->removeDirectoryRecursively( $path );
+			} else {
+				@unlink( $path );
+			}
+		}
+
+		@rmdir( $dir );
+	}
+}

--- a/src/Services/Icon/PrefixCollisionException.php
+++ b/src/Services/Icon/PrefixCollisionException.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * Raised when an admin uploads an icon set whose prefix is already taken.
+ *
+ * Phase 6 (#557) of the Icon Block feature (#494). The controller maps
+ * this exception to a 409 response with the offending prefix visible to
+ * the admin so they can pick a different one without losing their zip.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.1.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Services\Icon;
+
+use RuntimeException;
+
+final class PrefixCollisionException extends RuntimeException
+{
+	public function __construct( public readonly string $prefix )
+	{
+		parent::__construct( "Icon-set prefix \"{$prefix}\" is already registered." );
+	}
+}

--- a/src/Services/Icon/UploadedIconSet.php
+++ b/src/Services/Icon/UploadedIconSet.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * Value object describing a host-uploaded icon set.
+ *
+ * Phase 6 (#557) of the Icon Block feature (#494). Admins upload zips
+ * of licensed SVGs (e.g. Font Awesome Pro) through the settings screen;
+ * each persisted set is represented as one of these structs and stored
+ * alongside the SVG files in `storage/app/artisanpack/visual-editor/icons/`.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.1.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Services\Icon;
+
+/**
+ * Plain DTO — kept dumb on purpose. The registry handles persistence,
+ * the uploader handles storage layout, and the catalog reads these to
+ * surface uploaded sets in the picker. Anything that needs to be a
+ * computed property (e.g. the absolute path, derived from the prefix
+ * and the registry's base directory) lives on the registry, not here.
+ */
+final class UploadedIconSet
+{
+	/**
+	 * @param  string $prefix     Lowercase, kebab-cased identifier (e.g. `fa-pro`).
+	 *                            Doubles as the directory name under the registry base.
+	 * @param  string $label      Human-facing name shown in the picker chip strip.
+	 * @param  string $createdAt  ISO-8601 timestamp recorded on first upload.
+	 */
+	public function __construct(
+		public readonly string $prefix,
+		public readonly string $label,
+		public readonly string $createdAt,
+	) {
+	}
+
+	/**
+	 * Build a DTO from a persisted manifest row. Throws when any of the
+	 * required keys are missing or blank so a corrupt manifest surfaces
+	 * loudly at the call site instead of producing a half-filled DTO
+	 * the catalog would later try to walk. {@see UploadedIconSetRegistry::all()}
+	 * wraps this in try/catch so a single bad row doesn't kill the whole
+	 * boot-time registration loop — the offending row is silently
+	 * dropped and the admin can fix it from the settings screen.
+	 *
+	 * @param  array<string, mixed> $data
+	 */
+	public static function fromArray( array $data ): self
+	{
+		$trimmed = [];
+		foreach ( [ 'prefix', 'label', 'created_at' ] as $field ) {
+			$value = isset( $data[ $field ] ) ? trim( (string) $data[ $field ] ) : '';
+			if ( '' === $value ) {
+				throw new \InvalidArgumentException(
+					"UploadedIconSet manifest row is missing or blank '{$field}'.",
+				);
+			}
+			$trimmed[ $field ] = $value;
+		}
+
+		return new self( $trimmed['prefix'], $trimmed['label'], $trimmed['created_at'] );
+	}
+
+	/**
+	 * @return array{prefix: string, label: string, created_at: string}
+	 */
+	public function toArray(): array
+	{
+		return [
+			'prefix'     => $this->prefix,
+			'label'      => $this->label,
+			'created_at' => $this->createdAt,
+		];
+	}
+}

--- a/src/Services/Icon/UploadedIconSetRegistry.php
+++ b/src/Services/Icon/UploadedIconSetRegistry.php
@@ -1,0 +1,262 @@
+<?php
+
+/**
+ * JSON-backed registry of host-uploaded icon sets.
+ *
+ * Phase 6 (#557) of the Icon Block feature (#494). Persists set
+ * metadata to `storage/app/artisanpack/visual-editor/icons/sets.json`
+ * so the service provider can re-register uploaded sets against the
+ * `ap.icons.register-icon-sets` filter on every boot without re-walking
+ * directories or re-validating zip uploads.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.1.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Services\Icon;
+
+use RuntimeException;
+
+/**
+ * The registry is the single source of truth for "which uploaded sets
+ * does the editor know about". The uploader writes through it after a
+ * successful sanitization pass; the service provider reads from it at
+ * boot to wire the icon-set registration filter; the management
+ * controller reads + mutates it to back the settings screen.
+ *
+ * Persistence is a plain JSON manifest rather than a DB row because the
+ * SVG files themselves live on disk under the same base directory —
+ * keeping the metadata next to the files means a host can rsync the
+ * whole `icons/` tree between environments and bring the sets along
+ * with it without a separate DB dump.
+ */
+final class UploadedIconSetRegistry
+{
+	/**
+	 * Lowercase alphanumeric + dash + underscore, 2–32 characters. Mirrors
+	 * the public prefix surface — the directory name is the prefix, and a
+	 * looser pattern would let an upload write under an arbitrary path
+	 * relative to the storage base.
+	 */
+	public const PREFIX_PATTERN = '/^[a-z0-9][a-z0-9_-]{1,31}$/';
+
+	/**
+	 * Hard cap on label length — the picker chip strip wraps long labels
+	 * awkwardly and a 5 KB label would blow up the JSON manifest with no
+	 * user value.
+	 */
+	public const LABEL_MAX_LENGTH = 64;
+
+	private const MANIFEST_FILENAME = 'sets.json';
+
+	public function __construct( private readonly string $baseDir )
+	{
+	}
+
+	/**
+	 * The absolute directory under which uploaded sets are persisted.
+	 * Used by the uploader to compute target paths and by the boot-time
+	 * registration step.
+	 */
+	public function baseDir(): string
+	{
+		return $this->baseDir;
+	}
+
+	/**
+	 * Resolve the absolute directory for a single set.
+	 *
+	 * Validates the prefix shape before joining so a caller can't push a
+	 * `../`-laced prefix through the registry into the storage tree.
+	 */
+	public function pathFor( string $prefix ): string
+	{
+		if ( ! self::isValidPrefix( $prefix ) ) {
+			throw new RuntimeException( "Invalid icon-set prefix: {$prefix}" );
+		}
+
+		return $this->baseDir . DIRECTORY_SEPARATOR . $prefix;
+	}
+
+	/**
+	 * @return list<UploadedIconSet>
+	 */
+	public function all(): array
+	{
+		$manifest = $this->loadManifest();
+
+		$out = [];
+		foreach ( $manifest['sets'] ?? [] as $row ) {
+			try {
+				$out[] = UploadedIconSet::fromArray( $row );
+			} catch ( \InvalidArgumentException $e ) {
+				// A corrupt row should not take the whole registry
+				// down — boot is supposed to be resilient to a
+				// hand-edited manifest, and the settings screen is
+				// where the admin reconciles the conflict.
+				continue;
+			}
+		}
+
+		return $out;
+	}
+
+	public function find( string $prefix ): ?UploadedIconSet
+	{
+		foreach ( $this->all() as $set ) {
+			if ( $set->prefix === $prefix ) {
+				return $set;
+			}
+		}
+
+		return null;
+	}
+
+	public function has( string $prefix ): bool
+	{
+		return null !== $this->find( $prefix );
+	}
+
+	/**
+	 * Persist a new set entry. Caller is responsible for writing the SVGs
+	 * to the set directory before calling — the registry only tracks
+	 * metadata, not the on-disk SVG layout.
+	 */
+	public function register( UploadedIconSet $set ): void
+	{
+		if ( ! self::isValidPrefix( $set->prefix ) ) {
+			throw new RuntimeException( "Invalid icon-set prefix: {$set->prefix}" );
+		}
+
+		$manifest         = $this->loadManifest();
+		$sets             = $manifest['sets'] ?? [];
+		$replaced         = false;
+
+		foreach ( $sets as $index => $row ) {
+			if ( (string) ( $row['prefix'] ?? '' ) === $set->prefix ) {
+				$sets[ $index ] = $set->toArray();
+				$replaced       = true;
+				break;
+			}
+		}
+
+		if ( ! $replaced ) {
+			$sets[] = $set->toArray();
+		}
+
+		$manifest['sets'] = array_values( $sets );
+		$this->writeManifest( $manifest );
+	}
+
+	/**
+	 * Update the human-facing label of an existing set without touching
+	 * the prefix or the on-disk SVGs.
+	 */
+	public function rename( string $prefix, string $label ): UploadedIconSet
+	{
+		$existing = $this->find( $prefix );
+		if ( null === $existing ) {
+			throw new RuntimeException( "Icon set not found: {$prefix}" );
+		}
+
+		$trimmed = trim( $label );
+		if ( '' === $trimmed ) {
+			throw new RuntimeException( 'Icon set label cannot be empty.' );
+		}
+
+		if ( mb_strlen( $trimmed ) > self::LABEL_MAX_LENGTH ) {
+			throw new RuntimeException( 'Icon set label is too long.' );
+		}
+
+		$updated = new UploadedIconSet( $existing->prefix, $trimmed, $existing->createdAt );
+		$this->register( $updated );
+
+		return $updated;
+	}
+
+	/**
+	 * Drop a set from the manifest. The caller is responsible for
+	 * removing the corresponding on-disk SVG directory — the registry
+	 * intentionally does not touch the filesystem so the storage layout
+	 * stays the uploader's concern.
+	 */
+	public function forget( string $prefix ): void
+	{
+		$manifest = $this->loadManifest();
+		$sets     = $manifest['sets'] ?? [];
+
+		$filtered = array_values( array_filter(
+			$sets,
+			static fn ( array $row ): bool => (string) ( $row['prefix'] ?? '' ) !== $prefix,
+		) );
+
+		if ( count( $filtered ) === count( $sets ) ) {
+			return;
+		}
+
+		$manifest['sets'] = $filtered;
+		$this->writeManifest( $manifest );
+	}
+
+	public static function isValidPrefix( string $prefix ): bool
+	{
+		return 1 === preg_match( self::PREFIX_PATTERN, $prefix );
+	}
+
+	/**
+	 * @return array{sets: list<array<string, mixed>>}
+	 */
+	private function loadManifest(): array
+	{
+		$path = $this->manifestPath();
+		if ( ! is_file( $path ) ) {
+			return [ 'sets' => [] ];
+		}
+
+		$contents = file_get_contents( $path );
+		if ( false === $contents || '' === $contents ) {
+			return [ 'sets' => [] ];
+		}
+
+		$decoded = json_decode( $contents, true );
+		if ( ! is_array( $decoded ) ) {
+			return [ 'sets' => [] ];
+		}
+
+		$sets = is_array( $decoded['sets'] ?? null ) ? array_values( $decoded['sets'] ) : [];
+
+		return [ 'sets' => $sets ];
+	}
+
+	/**
+	 * @param  array{sets: list<array<string, mixed>>} $manifest
+	 */
+	private function writeManifest( array $manifest ): void
+	{
+		if ( ! is_dir( $this->baseDir ) ) {
+			if ( ! mkdir( $this->baseDir, 0o755, true ) && ! is_dir( $this->baseDir ) ) {
+				throw new RuntimeException( "Failed to create icon-set base directory: {$this->baseDir}" );
+			}
+		}
+
+		$encoded = json_encode( $manifest, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
+		if ( false === $encoded ) {
+			throw new RuntimeException( 'Failed to encode icon-set manifest.' );
+		}
+
+		if ( false === file_put_contents( $this->manifestPath(), $encoded . "\n", LOCK_EX ) ) {
+			throw new RuntimeException( 'Failed to write icon-set manifest.' );
+		}
+	}
+
+	private function manifestPath(): string
+	{
+		return $this->baseDir . DIRECTORY_SEPARATOR . self::MANIFEST_FILENAME;
+	}
+}

--- a/src/VisualEditorServiceProvider.php
+++ b/src/VisualEditorServiceProvider.php
@@ -882,10 +882,33 @@ class VisualEditorServiceProvider extends ServiceProvider
 			return $bundled;
 		}
 
+		// Resolve which prefixes the icon-set registry actually accepted
+		// so the picker never surfaces an icon whose prefix didn't make
+		// it through `registerUploadedIconSets()` — `IconSvgResolver`
+		// otherwise can't serve the SVG at click time, and the picker
+		// would render a black tile or a 404. Both paths now share one
+		// source of truth: the result of `ap.icons.register-icon-sets`.
+		$registeredPrefixes = [];
+		if ( class_exists( IconSetRegistration::class ) && function_exists( 'applyFilters' ) ) {
+			$registry = applyFilters( 'ap.icons.register-icon-sets', new IconSetRegistration() );
+			if ( $registry instanceof IconSetRegistration ) {
+				$registeredPrefixes = array_flip( array_keys( $registry->getSets() ) );
+			}
+		}
+
 		$uploadedSets  = [];
 		$uploadedIcons = [];
 
 		foreach ( $persisted->all() as $set ) {
+			// When the filter ran cleanly, gate every uploaded set on
+			// having survived it. With no filter available (icons
+			// package absent, hooks helper missing) we fall back to
+			// the pre-filter `is_dir()` check so a working install
+			// without those plumbing pieces still surfaces uploads.
+			if ( [] !== $registeredPrefixes && ! isset( $registeredPrefixes[ $set->prefix ] ) ) {
+				continue;
+			}
+
 			$dir = $persisted->pathFor( $set->prefix );
 			if ( ! is_dir( $dir ) ) {
 				continue;

--- a/src/VisualEditorServiceProvider.php
+++ b/src/VisualEditorServiceProvider.php
@@ -910,8 +910,14 @@ class VisualEditorServiceProvider extends ServiceProvider
 					continue;
 				}
 
-				$name             = substr( $entry, 0, -4 );
-				$uploadedIcons[]  = [
+				$name = substr( $entry, 0, -4 );
+				if ( '' === $name ) {
+					// A bare `.svg` filename would produce an empty
+					// catalog entry — drop it so the picker grid
+					// never tries to render an unnamed icon.
+					continue;
+				}
+				$uploadedIcons[] = [
 					'name'  => $name,
 					'set'   => $set->prefix,
 					'label' => $this->humanizeIconName( $name ),

--- a/src/VisualEditorServiceProvider.php
+++ b/src/VisualEditorServiceProvider.php
@@ -12,8 +12,10 @@ use ArtisanPackUI\Icons\Registries\IconSetRegistration;
 use ArtisanPackUI\VisualEditor\Blocks\Icon\IconBlock;
 use ArtisanPackUI\VisualEditor\Services\Icon\FontAwesomeFreeIconSets;
 use ArtisanPackUI\VisualEditor\Services\Icon\IconCatalog;
+use ArtisanPackUI\VisualEditor\Services\Icon\IconSetUploader;
 use ArtisanPackUI\VisualEditor\Services\Icon\IconSvgResolver;
 use ArtisanPackUI\VisualEditor\Services\Icon\SvgSanitizer;
+use ArtisanPackUI\VisualEditor\Services\Icon\UploadedIconSetRegistry;
 use ArtisanPackUI\VisualEditor\MediaBridge\GutenbergAttachmentAdapter;
 use ArtisanPackUI\VisualEditor\Services\Adapters\CmsFramework\CmsFrameworkQueryResolver;
 use ArtisanPackUI\VisualEditor\Services\QueryResolverContract;
@@ -106,8 +108,34 @@ class VisualEditorServiceProvider extends ServiceProvider
 		// resolve the catalog out of the container so host apps can swap
 		// in a custom manifest (e.g. extending the bundled FA Free set
 		// with their own brand icons) via `$app->extend()`.
-		$this->app->singleton( IconCatalog::class, function (): IconCatalog {
-			return new IconCatalog();
+		//
+		// Phase 6 (#557): hand the catalog a closure that merges the
+		// bundled FA Free manifest with whatever the
+		// `UploadedIconSetRegistry` has on disk so admin-uploaded sets
+		// show up in the picker without a code change. The closure runs
+		// lazily on first `search()` / `sets()` call — at request time,
+		// after every provider's boot has finished — so it can safely
+		// reach into the container for the registry.
+		$this->app->singleton( IconCatalog::class, function ( $app ): IconCatalog {
+			return new IconCatalog( function () use ( $app ): array {
+				return $this->buildMergedIconManifest( $app );
+			} );
+		} );
+
+		// Phase 6 (#557): the persisted registry of host-uploaded icon
+		// sets. The base directory under `storage/app/...` is created
+		// on first write — binding here keeps the path resolution in
+		// one place so the uploader and the boot-time registration
+		// loop see the exact same location.
+		$this->app->singleton( UploadedIconSetRegistry::class, function ( $app ): UploadedIconSetRegistry {
+			return new UploadedIconSetRegistry( $this->resolveIconSetsBaseDir( $app ) );
+		} );
+
+		$this->app->singleton( IconSetUploader::class, function ( $app ): IconSetUploader {
+			return new IconSetUploader(
+				$app->make( UploadedIconSetRegistry::class ),
+				$app->make( SvgSanitizer::class ),
+			);
 		} );
 
 		$this->app->singleton( VisualEditor::class, function ( $app ) {
@@ -344,6 +372,14 @@ class VisualEditorServiceProvider extends ServiceProvider
 		//      and gitignored; the discovery step no-ops cleanly when the
 		//      sync hasn't run yet, so app boot stays robust.
 		$this->registerFontAwesomeFreeIconSets();
+
+		// 4.2. Icon Block Phase 6 (#557) — re-register host-uploaded
+		//      icon sets on every boot. Reads the persisted registry
+		//      and hooks the same `ap.icons.register-icon-sets` filter
+		//      the bundled FA sets use, so the picker, the SVG
+		//      resolver, and the catalog all surface uploaded icons
+		//      without any further wiring.
+		$this->registerUploadedIconSets();
 
 		// 4a. Register taxonomy/feed dynamic blocks against cms-framework's
 		//     term + post APIs. Gated on the package's presence so
@@ -721,6 +757,188 @@ class VisualEditorServiceProvider extends ServiceProvider
 
 		// Set the final, correctly merged configuration.
 		config( [ 'artisanpack.visual-editor' => $mergedConfig ] );
+	}
+
+	/**
+	 * Hand the persisted uploaded icon sets to the
+	 * `ap.icons.register-icon-sets` filter.
+	 *
+	 * Phase 6 (#557). The {@see UploadedIconSetRegistry} only carries
+	 * metadata; the directories are managed by {@see IconSetUploader}.
+	 * We tolerate (and log) a missing directory rather than throwing,
+	 * so a stale metadata row left over from a manual rm doesn't break
+	 * boot — the admin can delete the dangling row from the settings
+	 * screen.
+	 *
+	 * Prefix collisions raised by the icons-registry are swallowed at
+	 * boot time so a host with overlapping uploads (or a config that
+	 * also registers a same-prefix set) still boots; the management
+	 * controller catches collisions on upload, which is when the admin
+	 * can act on the error.
+	 *
+	 * @since 1.1.0
+	 */
+	protected function registerUploadedIconSets(): void
+	{
+		if ( ! class_exists( IconSetRegistration::class ) || ! function_exists( 'addFilter' ) ) {
+			return;
+		}
+
+		$app = $this->app;
+
+		addFilter(
+			'ap.icons.register-icon-sets',
+			static function ( IconSetRegistration $registry ) use ( $app ): IconSetRegistration {
+				$persisted = $app->make( UploadedIconSetRegistry::class );
+
+				foreach ( $persisted->all() as $set ) {
+					$path = $persisted->pathFor( $set->prefix );
+					if ( ! is_dir( $path ) ) {
+						continue;
+					}
+
+					try {
+						$registry->addSet( $path, $set->prefix );
+					} catch ( \InvalidArgumentException $e ) {
+						// Mirrors the bundled FA registration loop: keep
+						// boot resilient to bad rows. The settings UI is
+						// the place to surface the underlying conflict.
+						continue;
+					}
+				}
+
+				return $registry;
+			}
+		);
+	}
+
+	/**
+	 * Resolve the absolute filesystem directory under which host-
+	 * uploaded icon sets are persisted.
+	 *
+	 * Defaults to `storage/app/artisanpack/visual-editor/icons/`. Hosts
+	 * can override via `artisanpack.visual-editor.icons.uploaded_path`.
+	 *
+	 * @since 1.1.0
+	 */
+	protected function resolveIconSetsBaseDir( $app ): string
+	{
+		$configured = $app['config']->get( 'artisanpack.visual-editor.icons.uploaded_path' );
+		if ( is_string( $configured ) && '' !== $configured ) {
+			return $configured;
+		}
+
+		$storage = method_exists( $app, 'storagePath' )
+			? $app->storagePath()
+			: ( $app['path.storage'] ?? sys_get_temp_dir() );
+
+		return $storage
+			. DIRECTORY_SEPARATOR . 'app'
+			. DIRECTORY_SEPARATOR . 'artisanpack'
+			. DIRECTORY_SEPARATOR . 'visual-editor'
+			. DIRECTORY_SEPARATOR . 'icons';
+	}
+
+	/**
+	 * Build the catalog manifest by merging the bundled FA Free
+	 * `index.json` with whatever the {@see UploadedIconSetRegistry}
+	 * tracks. Each uploaded SVG file becomes one catalog entry whose
+	 * name is the filename without the `.svg` extension — there is no
+	 * separate manifest for uploaded sets, the on-disk layout IS the
+	 * manifest.
+	 *
+	 * Returns the manifest shape {@see IconCatalog} consumes:
+	 * `{version, sets, icons}`. An unreadable / missing bundled manifest
+	 * does not block the uploaded entries from surfacing in the picker.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return array{
+	 *     version?: string,
+	 *     sets: list<array{prefix: string, label: string, source?: string}>,
+	 *     icons: list<array{name: string, set: string, label: string, terms: list<string>}>
+	 * }
+	 */
+	protected function buildMergedIconManifest( $app ): array
+	{
+		$bundled = [ 'version' => '', 'sets' => [], 'icons' => [] ];
+
+		$bundledPath = __DIR__ . '/../resources/icons/font-awesome/index.json';
+		if ( is_file( $bundledPath ) ) {
+			$contents = file_get_contents( $bundledPath );
+			if ( false !== $contents ) {
+				$decoded = json_decode( $contents, true );
+				if ( is_array( $decoded ) ) {
+					$bundled['version'] = isset( $decoded['version'] ) ? (string) $decoded['version'] : '';
+					$bundled['sets']    = is_array( $decoded['sets'] ?? null ) ? array_values( $decoded['sets'] ) : [];
+					$bundled['icons']   = is_array( $decoded['icons'] ?? null ) ? array_values( $decoded['icons'] ) : [];
+				}
+			}
+		}
+
+		try {
+			$persisted = $app->make( UploadedIconSetRegistry::class );
+		} catch ( \Throwable $e ) {
+			return $bundled;
+		}
+
+		$uploadedSets  = [];
+		$uploadedIcons = [];
+
+		foreach ( $persisted->all() as $set ) {
+			$dir = $persisted->pathFor( $set->prefix );
+			if ( ! is_dir( $dir ) ) {
+				continue;
+			}
+
+			$uploadedSets[] = [
+				'prefix' => $set->prefix,
+				'label'  => $set->label,
+				'source' => 'uploaded',
+			];
+
+			$entries = scandir( $dir );
+			if ( false === $entries ) {
+				continue;
+			}
+
+			foreach ( $entries as $entry ) {
+				if ( '.' === $entry || '..' === $entry ) {
+					continue;
+				}
+				if ( '.svg' !== strtolower( substr( $entry, -4 ) ) ) {
+					continue;
+				}
+
+				$name             = substr( $entry, 0, -4 );
+				$uploadedIcons[]  = [
+					'name'  => $name,
+					'set'   => $set->prefix,
+					'label' => $this->humanizeIconName( $name ),
+					'terms' => [],
+				];
+			}
+		}
+
+		return [
+			'version' => $bundled['version'],
+			'sets'    => array_merge( $bundled['sets'], $uploadedSets ),
+			'icons'   => array_merge( $bundled['icons'], $uploadedIcons ),
+		];
+	}
+
+	/**
+	 * Turn an icon basename (`arrow-up`, `user_circle`) into the label
+	 * the picker surfaces (`Arrow Up`, `User Circle`). Used for
+	 * uploaded sets that don't ship a labelled manifest.
+	 *
+	 * @since 1.1.0
+	 */
+	protected function humanizeIconName( string $name ): string
+	{
+		$spaced = preg_replace( '/[-_]+/', ' ', $name ) ?? $name;
+
+		return ucwords( trim( $spaced ) );
 	}
 
 }

--- a/tests/Feature/VisualEditor/IconSetsManagementTest.php
+++ b/tests/Feature/VisualEditor/IconSetsManagementTest.php
@@ -1,0 +1,256 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Services\Icon\UploadedIconSet;
+use ArtisanPackUI\VisualEditor\Services\Icon\UploadedIconSetRegistry;
+use ArtisanPackUI\VisualEditor\SiteEditor\Gates\SiteEditorAccessGate;
+use Illuminate\Http\Request;
+use Illuminate\Http\UploadedFile;
+use Symfony\Component\HttpFoundation\Response;
+use Tests\TestUser;
+
+function bindAllowingGate(): void
+{
+	app()->bind( SiteEditorAccessGate::class, function () {
+		return new class implements SiteEditorAccessGate
+		{
+			public function check( Request $request ): ?Response
+			{
+				return null;
+			}
+		};
+	} );
+}
+
+function bindDenyingGate(): void
+{
+	app()->bind( SiteEditorAccessGate::class, function () {
+		return new class implements SiteEditorAccessGate
+		{
+			public function check( Request $request ): ?Response
+			{
+				return response( 'denied', Response::HTTP_FORBIDDEN );
+			}
+		};
+	} );
+}
+
+function & managementZipPaths(): array
+{
+	static $paths = [];
+
+	return $paths;
+}
+
+function makeManagementTestZip( array $entries ): UploadedFile
+{
+	$path    = sys_get_temp_dir() . '/icon-mgmt-' . bin2hex( random_bytes( 4 ) ) . '.zip';
+	$archive = new ZipArchive();
+	$status  = $archive->open( $path, ZipArchive::CREATE );
+	if ( true !== $status ) {
+		throw new RuntimeException( "Failed to create test zip {$path}: status {$status}" );
+	}
+	foreach ( $entries as $name => $contents ) {
+		$archive->addFromString( $name, $contents );
+	}
+	$archive->close();
+
+	$paths   = & managementZipPaths();
+	$paths[] = $path;
+
+	return new UploadedFile( $path, basename( $path ), 'application/zip', null, true );
+}
+
+function actingAsIconSetsAdmin(): TestUser
+{
+	$user = TestUser::create( [
+		'name'     => 'Icon Sets Admin',
+		'email'    => 'icon-mgmt+' . uniqid() . '@example.com',
+		'password' => bcrypt( 'secret' ),
+	] );
+
+	test()->actingAs( $user );
+
+	return $user;
+}
+
+function rebindRegistryToTempDir(): string
+{
+	$base = sys_get_temp_dir() . '/icon-mgmt-base-' . bin2hex( random_bytes( 4 ) );
+	mkdir( $base, 0o755, true );
+
+	app()->instance( UploadedIconSetRegistry::class, new UploadedIconSetRegistry( $base ) );
+
+	return $base;
+}
+
+beforeEach( function (): void {
+	test()->iconBase = rebindRegistryToTempDir();
+	$paths           = & managementZipPaths();
+	$paths           = [];
+	// Force the uploader to pick up the rebound registry.
+	app()->forgetInstance( \ArtisanPackUI\VisualEditor\Services\Icon\IconSetUploader::class );
+} );
+
+afterEach( function (): void {
+	$rrm = static function ( string $dir ) use ( &$rrm ): void {
+		foreach ( scandir( $dir ) ?: [] as $entry ) {
+			if ( '.' === $entry || '..' === $entry ) {
+				continue;
+			}
+			$path = $dir . DIRECTORY_SEPARATOR . $entry;
+			is_dir( $path ) ? $rrm( $path ) : @unlink( $path );
+		}
+		@rmdir( $dir );
+	};
+
+	if ( isset( test()->iconBase ) && is_dir( test()->iconBase ) ) {
+		$rrm( test()->iconBase );
+	}
+
+	foreach ( managementZipPaths() as $zip ) {
+		if ( is_file( $zip ) ) {
+			@unlink( $zip );
+		}
+	}
+} );
+
+it( 'uploads and persists a new icon set', function (): void {
+	actingAsIconSetsAdmin();
+	bindAllowingGate();
+
+	$zip = makeManagementTestZip( [
+		'home.svg' => '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M0 0"/></svg>',
+		'user.svg' => '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M1 1"/></svg>',
+	] );
+
+	$response = $this->post( '/visual-editor/api/admin/icon-sets', [
+		'prefix' => 'fa-pro',
+		'label'  => 'Font Awesome Pro',
+		'zip'    => $zip,
+	] );
+
+	$response->assertStatus( Response::HTTP_CREATED )
+		->assertJsonPath( 'data.prefix', 'fa-pro' )
+		->assertJsonPath( 'data.label', 'Font Awesome Pro' )
+		->assertJsonCount( 2, 'report.stored' );
+
+	expect( app( UploadedIconSetRegistry::class )->has( 'fa-pro' ) )->toBeTrue()
+		->and( file_exists( test()->iconBase . '/fa-pro/home.svg' ) )->toBeTrue();
+} );
+
+it( 'returns 409 with the offending prefix on collision', function (): void {
+	actingAsIconSetsAdmin();
+	bindAllowingGate();
+
+	app( UploadedIconSetRegistry::class )->register(
+		new UploadedIconSet( 'brand', 'Brand', '2026-01-01T00:00:00Z' ),
+	);
+
+	$zip = makeManagementTestZip( [
+		'home.svg' => '<svg xmlns="http://www.w3.org/2000/svg"><path d="M0 0"/></svg>',
+	] );
+
+	$response = $this->post( '/visual-editor/api/admin/icon-sets', [
+		'prefix' => 'brand',
+		'label'  => 'Brand',
+		'zip'    => $zip,
+	] );
+
+	$response->assertStatus( Response::HTTP_CONFLICT )
+		->assertJsonPath( 'error', 'prefix_collision' )
+		->assertJsonPath( 'prefix', 'brand' );
+} );
+
+it( 'reports skipped non-svg entries and failed sanitization in the upload report', function (): void {
+	actingAsIconSetsAdmin();
+	bindAllowingGate();
+
+	$zip = makeManagementTestZip( [
+		'home.svg'   => '<svg xmlns="http://www.w3.org/2000/svg"><path d="M0 0"/></svg>',
+		'readme.txt' => 'not an icon',
+		'evil.svg'   => '<script>alert(1)</script>',
+	] );
+
+	$response = $this->post( '/visual-editor/api/admin/icon-sets', [
+		'prefix' => 'brand',
+		'label'  => 'Brand',
+		'zip'    => $zip,
+	] );
+
+	$response->assertStatus( Response::HTTP_CREATED )
+		->assertJsonPath( 'report.stored.0', 'home.svg' )
+		->assertJsonPath( 'report.skipped.0', 'readme.txt' )
+		->assertJsonPath( 'report.failed.0.file', 'evil.svg' );
+} );
+
+it( 'lists registered sets', function (): void {
+	actingAsIconSetsAdmin();
+	bindAllowingGate();
+
+	app( UploadedIconSetRegistry::class )->register(
+		new UploadedIconSet( 'brand', 'Brand', '2026-01-01T00:00:00Z' ),
+	);
+
+	$this->getJson( '/visual-editor/api/admin/icon-sets' )
+		->assertOk()
+		->assertJsonPath( 'data.0.prefix', 'brand' )
+		->assertJsonPath( 'data.0.label', 'Brand' );
+} );
+
+it( 'renames a registered set', function (): void {
+	actingAsIconSetsAdmin();
+	bindAllowingGate();
+
+	app( UploadedIconSetRegistry::class )->register(
+		new UploadedIconSet( 'brand', 'Old', '2026-01-01T00:00:00Z' ),
+	);
+
+	$this->patchJson( '/visual-editor/api/admin/icon-sets/brand', [ 'label' => 'New' ] )
+		->assertOk()
+		->assertJsonPath( 'data.label', 'New' );
+} );
+
+it( 'deletes a registered set and clears the registry', function (): void {
+	actingAsIconSetsAdmin();
+	bindAllowingGate();
+
+	app( UploadedIconSetRegistry::class )->register(
+		new UploadedIconSet( 'brand', 'Brand', '2026-01-01T00:00:00Z' ),
+	);
+	mkdir( test()->iconBase . '/brand', 0o755, true );
+	file_put_contents( test()->iconBase . '/brand/home.svg', '<svg/>' );
+
+	$this->delete( '/visual-editor/api/admin/icon-sets/brand' )
+		->assertNoContent();
+
+	expect( app( UploadedIconSetRegistry::class )->has( 'brand' ) )->toBeFalse()
+		->and( is_dir( test()->iconBase . '/brand' ) )->toBeFalse();
+} );
+
+it( 'returns the gate response when the management policy denies access', function (): void {
+	actingAsIconSetsAdmin();
+	bindDenyingGate();
+
+	$this->get( '/visual-editor/api/admin/icon-sets' )
+		->assertStatus( Response::HTTP_FORBIDDEN );
+} );
+
+it( 'serves the settings page through the same gate', function (): void {
+	actingAsIconSetsAdmin();
+	bindAllowingGate();
+
+	$this->withoutVite();
+	$this->get( '/visual-editor/admin/icon-sets' )
+		->assertOk()
+		->assertSee( 'Icon Sets' );
+} );
+
+it( 'hides the settings page from users denied by the gate', function (): void {
+	actingAsIconSetsAdmin();
+	bindDenyingGate();
+
+	$this->get( '/visual-editor/admin/icon-sets' )
+		->assertStatus( Response::HTTP_FORBIDDEN );
+} );

--- a/tests/Unit/VisualEditor/Services/Icon/IconSetUploaderTest.php
+++ b/tests/Unit/VisualEditor/Services/Icon/IconSetUploaderTest.php
@@ -1,0 +1,182 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Services\Icon\IconSetUploader;
+use ArtisanPackUI\VisualEditor\Services\Icon\PrefixCollisionException;
+use ArtisanPackUI\VisualEditor\Services\Icon\SvgSanitizer;
+use ArtisanPackUI\VisualEditor\Services\Icon\UploadedIconSet;
+use ArtisanPackUI\VisualEditor\Services\Icon\UploadedIconSetRegistry;
+use Illuminate\Http\UploadedFile;
+
+function & iconUploaderZipPaths(): array
+{
+	static $paths = [];
+
+	return $paths;
+}
+
+function makeIconZip( array $entries ): string
+{
+	$path    = sys_get_temp_dir() . '/icon-zip-' . bin2hex( random_bytes( 4 ) ) . '.zip';
+	$archive = new ZipArchive();
+	$status  = $archive->open( $path, ZipArchive::CREATE );
+	if ( true !== $status ) {
+		throw new RuntimeException( "Failed to create test zip {$path}: status {$status}" );
+	}
+	foreach ( $entries as $name => $contents ) {
+		$archive->addFromString( $name, $contents );
+	}
+	$archive->close();
+
+	$paths   = & iconUploaderZipPaths();
+	$paths[] = $path;
+
+	return $path;
+}
+
+function makeUploadedZip( array $entries ): UploadedFile
+{
+	$path = makeIconZip( $entries );
+
+	return new UploadedFile( $path, basename( $path ), 'application/zip', null, true );
+}
+
+beforeEach( function (): void {
+	$base = sys_get_temp_dir() . '/icon-uploader-' . bin2hex( random_bytes( 4 ) );
+	mkdir( $base, 0o755, true );
+
+	test()->baseDir  = $base;
+	test()->registry = new UploadedIconSetRegistry( $base );
+	test()->uploader = new IconSetUploader( test()->registry, new SvgSanitizer() );
+
+	$paths = & iconUploaderZipPaths();
+	$paths = [];
+} );
+
+afterEach( function (): void {
+	$rrm = static function ( string $dir ) use ( &$rrm ): void {
+		foreach ( scandir( $dir ) ?: [] as $entry ) {
+			if ( '.' === $entry || '..' === $entry ) {
+				continue;
+			}
+			$path = $dir . DIRECTORY_SEPARATOR . $entry;
+			is_dir( $path ) ? $rrm( $path ) : @unlink( $path );
+		}
+		@rmdir( $dir );
+	};
+
+	if ( isset( test()->baseDir ) && is_dir( test()->baseDir ) ) {
+		$rrm( test()->baseDir );
+	}
+
+	foreach ( iconUploaderZipPaths() as $zip ) {
+		if ( is_file( $zip ) ) {
+			@unlink( $zip );
+		}
+	}
+} );
+
+it( 'stores sanitized svgs under the per-set directory', function (): void {
+	$zip = makeUploadedZip( [
+		'home.svg' => '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M0 0"/></svg>',
+		'user.svg' => '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M1 1"/></svg>',
+	] );
+
+	$result = test()->uploader->upload( $zip, 'fa-pro', 'Font Awesome Pro' );
+
+	expect( $result->stored )->toEqualCanonicalizing( [ 'home.svg', 'user.svg' ] )
+		->and( $result->failed )->toBe( [] )
+		->and( $result->skipped )->toBe( [] )
+		->and( test()->registry->has( 'fa-pro' ) )->toBeTrue()
+		->and( file_exists( test()->baseDir . '/fa-pro/home.svg' ) )->toBeTrue()
+		->and( file_exists( test()->baseDir . '/fa-pro/user.svg' ) )->toBeTrue();
+} );
+
+it( 'skips non-svg entries and never writes them to disk', function (): void {
+	$zip = makeUploadedZip( [
+		'home.svg'    => '<svg xmlns="http://www.w3.org/2000/svg"><path d="M0 0"/></svg>',
+		'readme.txt'  => 'just notes',
+		'logo.png'    => 'fake png bytes',
+	] );
+
+	$result = test()->uploader->upload( $zip, 'brand', 'Brand' );
+
+	expect( $result->stored )->toBe( [ 'home.svg' ] )
+		->and( $result->skipped )->toEqualCanonicalizing( [ 'readme.txt', 'logo.png' ] )
+		->and( file_exists( test()->baseDir . '/brand/readme.txt' ) )->toBeFalse()
+		->and( file_exists( test()->baseDir . '/brand/logo.png' ) )->toBeFalse();
+} );
+
+it( 'reports sanitization failures without writing the empty result', function (): void {
+	$zip = makeUploadedZip( [
+		'evil.svg' => '<script>alert(1)</script>',
+		'good.svg' => '<svg xmlns="http://www.w3.org/2000/svg"><path d="M0 0"/></svg>',
+	] );
+
+	$result = test()->uploader->upload( $zip, 'brand', 'Brand' );
+
+	expect( $result->stored )->toBe( [ 'good.svg' ] )
+		->and( $result->failed )->toHaveCount( 1 )
+		->and( $result->failed[0]['file'] )->toBe( 'evil.svg' )
+		->and( $result->failed[0]['warnings'] )->not->toBe( [] )
+		->and( file_exists( test()->baseDir . '/brand/evil.svg' ) )->toBeFalse();
+} );
+
+it( 'rejects path traversal in the zip entry names', function (): void {
+	$zip = makeUploadedZip( [
+		'../escape.svg' => '<svg xmlns="http://www.w3.org/2000/svg"><path d="M0 0"/></svg>',
+		'safe.svg'      => '<svg xmlns="http://www.w3.org/2000/svg"><path d="M0 0"/></svg>',
+	] );
+
+	$result = test()->uploader->upload( $zip, 'brand', 'Brand' );
+
+	// `../escape.svg` reduces to `escape.svg` via basename(), which is
+	// safe — the rule is that the joined target must never escape the
+	// set directory, and basename() guarantees that.
+	expect( $result->stored )->toContain( 'safe.svg' )
+		->and( file_exists( test()->baseDir . '/escape.svg' ) )->toBeFalse();
+} );
+
+it( 'raises a typed collision when the prefix matches a bundled FA set', function (): void {
+	$zip = makeUploadedZip( [
+		'home.svg' => '<svg xmlns="http://www.w3.org/2000/svg"><path d="M0 0"/></svg>',
+	] );
+
+	expect( fn (): mixed => test()->uploader->upload( $zip, 'fas', 'FA Solid' ) )
+		->toThrow( PrefixCollisionException::class );
+} );
+
+it( 'raises a typed collision when the prefix is already taken by an uploaded set', function (): void {
+	test()->registry->register( new UploadedIconSet( 'brand', 'Brand', '2026-01-01T00:00:00Z' ) );
+
+	$zip = makeUploadedZip( [
+		'home.svg' => '<svg xmlns="http://www.w3.org/2000/svg"><path d="M0 0"/></svg>',
+	] );
+
+	expect( fn (): mixed => test()->uploader->upload( $zip, 'brand', 'Brand' ) )
+		->toThrow( PrefixCollisionException::class );
+} );
+
+it( 'rejects an upload that contains no usable svgs', function (): void {
+	$zip = makeUploadedZip( [
+		'evil.svg' => '<script>alert(1)</script>',
+	] );
+
+	expect( fn (): mixed => test()->uploader->upload( $zip, 'brand', 'Brand' ) )
+		->toThrow( RuntimeException::class );
+} );
+
+it( 'wipes the on-disk directory on delete', function (): void {
+	$zip = makeUploadedZip( [
+		'home.svg' => '<svg xmlns="http://www.w3.org/2000/svg"><path d="M0 0"/></svg>',
+	] );
+
+	test()->uploader->upload( $zip, 'brand', 'Brand' );
+	expect( is_dir( test()->baseDir . '/brand' ) )->toBeTrue();
+
+	test()->uploader->delete( 'brand' );
+
+	expect( test()->registry->has( 'brand' ) )->toBeFalse()
+		->and( is_dir( test()->baseDir . '/brand' ) )->toBeFalse();
+} );

--- a/tests/Unit/VisualEditor/Services/Icon/IconSetUploaderTest.php
+++ b/tests/Unit/VisualEditor/Services/Icon/IconSetUploaderTest.php
@@ -133,8 +133,13 @@ it( 'rejects path traversal in the zip entry names', function (): void {
 
 	// `../escape.svg` reduces to `escape.svg` via basename(), which is
 	// safe — the rule is that the joined target must never escape the
-	// set directory, and basename() guarantees that.
+	// set directory, and basename() guarantees that. Verify both that
+	// the sanitized name lands inside the per-set directory AND that
+	// nothing was written one level up where the unsanitized name
+	// would have escaped to.
 	expect( $result->stored )->toContain( 'safe.svg' )
+		->and( $result->stored )->toContain( 'escape.svg' )
+		->and( file_exists( test()->baseDir . '/brand/escape.svg' ) )->toBeTrue()
 		->and( file_exists( test()->baseDir . '/escape.svg' ) )->toBeFalse();
 } );
 

--- a/tests/Unit/VisualEditor/Services/Icon/UploadedIconSetRegistryTest.php
+++ b/tests/Unit/VisualEditor/Services/Icon/UploadedIconSetRegistryTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Services\Icon\UploadedIconSet;
+use ArtisanPackUI\VisualEditor\Services\Icon\UploadedIconSetRegistry;
+
+beforeEach( function (): void {
+	$base = sys_get_temp_dir() . '/icon-set-registry-' . bin2hex( random_bytes( 4 ) );
+	mkdir( $base, 0o755, true );
+
+	test()->baseDir  = $base;
+	test()->registry = new UploadedIconSetRegistry( $base );
+} );
+
+afterEach( function (): void {
+	$rrm = static function ( string $dir ) use ( &$rrm ): void {
+		foreach ( scandir( $dir ) ?: [] as $entry ) {
+			if ( '.' === $entry || '..' === $entry ) {
+				continue;
+			}
+			$path = $dir . DIRECTORY_SEPARATOR . $entry;
+			is_dir( $path ) ? $rrm( $path ) : @unlink( $path );
+		}
+		@rmdir( $dir );
+	};
+
+	if ( isset( test()->baseDir ) && is_dir( test()->baseDir ) ) {
+		$rrm( test()->baseDir );
+	}
+} );
+
+it( 'returns no sets when the manifest is missing', function (): void {
+	expect( test()->registry->all() )->toBe( [] );
+} );
+
+it( 'persists a registered set across instances', function (): void {
+	test()->registry->register( new UploadedIconSet( 'fa-pro', 'Font Awesome Pro', '2026-01-01T00:00:00Z' ) );
+
+	$fresh = new UploadedIconSetRegistry( test()->baseDir );
+
+	expect( $fresh->has( 'fa-pro' ) )->toBeTrue()
+		->and( $fresh->find( 'fa-pro' )->label )->toBe( 'Font Awesome Pro' );
+} );
+
+it( 'updates an existing set when re-registered with the same prefix', function (): void {
+	test()->registry->register( new UploadedIconSet( 'brand', 'Old', '2026-01-01T00:00:00Z' ) );
+	test()->registry->register( new UploadedIconSet( 'brand', 'New', '2026-01-02T00:00:00Z' ) );
+
+	expect( test()->registry->all() )->toHaveCount( 1 )
+		->and( test()->registry->find( 'brand' )->label )->toBe( 'New' );
+} );
+
+it( 'renames a set without touching the prefix or createdAt', function (): void {
+	test()->registry->register( new UploadedIconSet( 'brand', 'Original', '2026-01-01T00:00:00Z' ) );
+
+	$updated = test()->registry->rename( 'brand', 'Renamed' );
+
+	expect( $updated->label )->toBe( 'Renamed' )
+		->and( $updated->createdAt )->toBe( '2026-01-01T00:00:00Z' );
+} );
+
+it( 'rejects an empty label on rename', function (): void {
+	test()->registry->register( new UploadedIconSet( 'brand', 'Original', '2026-01-01T00:00:00Z' ) );
+
+	expect( fn (): UploadedIconSet => test()->registry->rename( 'brand', '   ' ) )
+		->toThrow( RuntimeException::class );
+} );
+
+it( 'forgets a registered set', function (): void {
+	test()->registry->register( new UploadedIconSet( 'brand', 'Original', '2026-01-01T00:00:00Z' ) );
+	test()->registry->forget( 'brand' );
+
+	expect( test()->registry->has( 'brand' ) )->toBeFalse();
+} );
+
+it( 'rejects path traversal in the prefix', function (): void {
+	expect( fn (): string => test()->registry->pathFor( '../etc' ) )
+		->toThrow( RuntimeException::class );
+} );
+
+it( 'validates prefix shape via the public matcher', function (): void {
+	expect( UploadedIconSetRegistry::isValidPrefix( 'fa-pro' ) )->toBeTrue()
+		->and( UploadedIconSetRegistry::isValidPrefix( 'Fa-Pro' ) )->toBeFalse()
+		->and( UploadedIconSetRegistry::isValidPrefix( 'a' ) )->toBeFalse()
+		->and( UploadedIconSetRegistry::isValidPrefix( '../etc' ) )->toBeFalse();
+} );


### PR DESCRIPTION
## Description

Adds the admin-facing settings surface that lets a host upload licensed SVG icon sets (e.g. Font Awesome Pro) into the visual editor without a code change.

Each entry in the uploaded zip runs through phase 2's `SvgSanitizer`; survivors land under `storage/app/artisanpack/visual-editor/icons/{prefix}/` and are auto-registered against the `ap.icons.register-icon-sets` filter on every boot, so uploaded icons appear in the picker alongside the bundled FA Free sets without any further wiring.

The settings screen and the four REST endpoints (list, upload, rename, delete) are gated by the existing `SiteEditorAccessGate` binding — the issue explicitly forbids introducing a new capability for this surface, so we use the package's existing visual-editor management policy.

**Closes:** #557

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #557

## Motivation and Context

Issue #557 (parent #494) — Phase 6 of the Icon Block feature. Without this, hosts can only use the bundled FA Free sets; licensed sets like FA Pro have no in-app on-ramp.

## Changes Made

- New services: `UploadedIconSet`, `UploadedIconSetRegistry`, `IconSetUploader`, `IconSetUploadResult`, `PrefixCollisionException`
- New controller + form requests: `IconSetsManagementController`, `UploadIconSetRequest`, `RenameIconSetRequest`
- New REST endpoints under `/visual-editor/api/admin/icon-sets` (GET / POST / PATCH / DELETE) — gated by `SiteEditorAccessGate`
- New settings page at `/visual-editor/admin/icon-sets` (server-rendered with inline styles, mirrors the install-gate page pattern)
- `VisualEditorServiceProvider`: bindings, boot-time `ap.icons.register-icon-sets` filter for persisted uploaded sets, merged `IconCatalog` manifest that combines bundled FA entries with uploaded sets
- Zip pipeline: entry-count + uncompressed-size caps, traversal-safe basename sanitization, per-file outcome report (stored / skipped / failed)
- Prefix-collision detection at upload time covers both the bundled FA reservations (`fas` / `far` / `fab`) and previously-uploaded sets
- Uploaded sets persist as JSON metadata next to the SVG directories so a host can rsync the whole tree between environments

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (Darwin 25.5.0)
- Browser: Safari (admin settings page)
- PHP Version: 8.4.3
- Project Version: 1.1 (release/1.1)

**Tests Performed:**
1. Manual upload of a 2-svg zip through the settings page — landed under `storage/app/artisanpack/visual-editor/icons/`, surfaced in `/visual-editor/api/icons/sets` immediately
2. Rename + delete from the settings page — manifest + on-disk directory both cleared
3. Prefix collision against both bundled FA (`fas`) and previously-uploaded prefix returns 409 with the offending prefix visible
4. Pest unit + feature test suite (23 new tests, 0 failures introduced)

## Accessibility Tests Run

- [x] Keyboard navigation tested
- [x] Screen reader tested
- [x] Color contrast verified
- [x] ARIA labels checked

**Details:** Settings page uses semantic `<table>` for the set list, `<form>` for upload, and a `role=\"status\" aria-live=\"polite\"` region for upload feedback so screen readers announce upload results. Inline styles ship a `prefers-color-scheme: dark` variant.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:**
- `tests/Unit/VisualEditor/Services/Icon/UploadedIconSetRegistryTest.php` — 8 tests covering persistence, rename, forget, prefix validation
- `tests/Unit/VisualEditor/Services/Icon/IconSetUploaderTest.php` — 8 tests covering happy path, non-SVG skip, sanitization failure, prefix collision (both bundled + uploaded), traversal rejection, delete cleanup
- `tests/Feature/VisualEditor/IconSetsManagementTest.php` — 9 tests covering full REST CRUD, collision (409), report shape, gate denial on both API + settings page

Two pre-existing failures in `FontAwesomeFreeIconSetsTest` (icons package missing in vendor) are unrelated.

## Documentation

- [x] Inline code documentation added

**Documentation details:** All new classes have file + class-level PHPDoc identifying them as Phase 6 (#557) of the Icon Block feature (#494). Service-provider blocks call out the merged-manifest mechanic and the boot-time auto-registration.

## Pre-Submission Checklist

- [x] Code passes all tests
- [x] Self-review completed
- [x] Comments added for complex code (zip-bomb caps, basename traversal gate, merged-manifest lifecycle)
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admins can upload ZIPs of custom SVG icon sets, rename and delete sets from a new Icon Sets admin screen with inline progress and ARIA feedback.
  * Uploaded icon sets are persisted and automatically included in the Visual Editor icon picker.

* **Tests**
  * Comprehensive feature and unit tests added to validate uploads, sanitization, rename/delete flows, prefix validation, and manifest persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->