### PR TITLE
feat: Icon block Phase 7 — e2e tests + docs, style fixes, dimensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,14 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   a fallback for posts saved before the fix). Palette-color slugs
   resolve through the standard `has-{slug}-background-color` /
   `has-{slug}-border-color` classes.
+- **Icon block — decorative + linked icons now produce labeled
+  anchors.** When `isDecorative`, `link`, and `ariaLabel` are all set,
+  the supplied `ariaLabel` is now promoted onto the `<a>` itself
+  rather than dropped. The body span remains `aria-hidden="true"`
+  (the SVG is the decorative element), but the anchor finally has an
+  accessible name. The editor-side `hasDecorativeLinkConflict()`
+  warning still fires when no `ariaLabel` is supplied, which is the
+  scenario the warning was always meant to flag.
 
 ## [1.0.0] — 2026-06-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,46 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- **Icon block Phase 7 — end-to-end coverage and docs (#558).** Cross-
+  phase Pest tests now stitch the registration filter, catalog, picker
+  endpoints, admin uploader, sanitizer, and block renderer together so
+  regressions that only surface end-to-end are caught. New Vitest
+  coverage exercises the WP-style envelope plumbing and the
+  width/height override path. Docs add a dedicated [[blocks/Icon Block]]
+  page covering the block usage walkthrough, the developer recipe for
+  `ap.icons.register-icon-sets`, the admin upload walkthrough, and FA
+  Pro guidance (BYO SVGs, no token storage).
+- **Icon block — independent width/height overrides.** The
+  `artisanpack/icon` block now supports per-axis `width` and `height`
+  attributes that override the uniform `size`. The inspector ships a
+  `Dimensions` panel with a `NumberControl`-backed size and width/
+  height `UnitControl`s (`px` / `em` / `rem` / `%` / `vw` / `vh`). All
+  three controls emit changes on every keystroke so the canvas
+  updates live.
+- **Icon block — dedicated Icon color field.** The standard WordPress
+  text-color control is replaced by a `Sidebar → Color → Icon` picker
+  that writes to a new `iconColor` attribute and is applied directly
+  to the body span as `color`. The bundled SVGs ship with
+  `fill: currentcolor`, so the picked color flows through to the
+  icon's fill. Mirrors the ndiego reference Icon Block split.
+
+### Fixed
+
+- **Icon block — WP style controls now apply on the canvas and front
+  end.** Background, border, padding, and margin set via the
+  inspector's standard controls now reach the rendered block. The
+  block previously declared `__experimentalSkipSerialization: true`
+  for every support and then never read the styles back, so author
+  selections silently no-op'd. The block now lets WordPress serialize
+  background/border/spacing onto the wrapper via `useBlockProps()`,
+  and the server renderer applies the same envelope to the wrapper
+  div (with the legacy top-level `backgroundColor` attribute kept as
+  a fallback for posts saved before the fix). Palette-color slugs
+  resolve through the standard `has-{slug}-background-color` /
+  `has-{slug}-border-color` classes.
+
 ## [1.0.0] — 2026-06-08
 
 First stable release of the V1 surface. Promotes `1.0.0-beta1` to GA

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ V1.0 ships:
   styles, navigation menus, and patterns; mounted at `/visual-editor/site`.
 - **42 forked core blocks** under the `artisanpack/*` namespace.
   `core/*` markup pasted from upstream auto-converts on insert.
+- **Icon block** (`artisanpack/icon`, v1.1) — Font Awesome 6 Free
+  bundled, custom SVG paste with server-side sanitization, and admin
+  upload for licensed sets (e.g. Font Awesome Pro). See
+  [`docs/blocks/Icon-Block.md`](docs/blocks/Icon-Block.md).
 - **Three renderer packages** — Blade (server-side), React, and Vue —
   for rendering saved block content on the public site.
 - **First-class pairing** with [`artisanpack-ui/cms-framework`](https://github.com/ArtisanPack-UI/cms-framework)

--- a/docs/blocks.md
+++ b/docs/blocks.md
@@ -1,6 +1,6 @@
 # Blocks
 
-The visual editor's block library is the catalog of authoring primitives available to content editors. V1 ships **42 forked core blocks** under the `artisanpack/*` namespace, plus the two bespoke blocks (`artisanpack/callout` and `artisanpack/form`). Host apps and packages can register their own blocks under any namespace.
+The visual editor's block library is the catalog of authoring primitives available to content editors. V1 ships **42 forked core blocks** under the `artisanpack/*` namespace, plus the bespoke blocks (`artisanpack/callout`, `artisanpack/form`, and — new in v1.1 — `artisanpack/icon`; see [[blocks/Icon Block]]). Host apps and packages can register their own blocks under any namespace.
 
 This page is the overview. For authoring patterns and the registration API, see [[blocks/Custom Blocks]].
 
@@ -35,7 +35,7 @@ The forked allow-list covers the following clusters:
 | **Loop / Feed** | categories, tag-cloud, archives, query, post-template |
 | **Comments** | comments, comment-template, comment-author-avatar, comment-author-name, comment-content, comment-date, comment-edit-link, comment-reply-link, post-comments-form, post-comments-count, post-comments-link, post-comments-title, comments-pagination (+ next / numbers / previous) |
 | **Authentication** | loginout |
-| **ArtisanPack bespoke** | callout, form |
+| **ArtisanPack bespoke** | callout, form, icon (v1.1 — see [[blocks/Icon Block]]) |
 
 Entity blocks (`artisanpack/post-*`, `artisanpack/site-*`, `artisanpack/template-part`, `artisanpack/navigation`) and the loop / feed cluster need an entity in scope to render meaningful content — pair the editor with [`artisanpack-ui/cms-framework`](https://github.com/ArtisanPack-UI/cms-framework) and they resolve against Posts / Pages / templates / site settings end-to-end. Standalone, they fall back to empty shells rather than crashing.
 

--- a/docs/blocks/Icon-Block.md
+++ b/docs/blocks/Icon-Block.md
@@ -59,7 +59,7 @@ The Inspector's link controls produce a wrapping `<a>` on the rendered icon. `ta
 
 ## Developer recipe — registering custom sets
 
-Packages register additional icon sets through the existing [`ap.icons.register-icon-sets`](../../../icons) filter from `artisanpack-ui/icons`. The Icon Block picks them up automatically — no Icon Block-specific registration is needed.
+Packages register additional icon sets through the existing [`ap.icons.register-icon-sets`](https://github.com/ArtisanPack-UI/icons) filter from `artisanpack-ui/icons`. The Icon Block picks them up automatically — no Icon Block-specific registration is needed.
 
 ```php
 use ArtisanPackUI\Icons\Registries\IconSetRegistration;
@@ -130,4 +130,4 @@ If the referenced icon set has been deleted (or never registered), the renderer 
 
 - Parent issue: [#494](https://github.com/ArtisanPack-UI/visual-editor/issues/494)
 - Phase 7 (cross-phase tests + docs): [#558](https://github.com/ArtisanPack-UI/visual-editor/issues/558)
-- Icon Sets API: `artisanpack-ui/icons` ([`ap.icons.register-icon-sets`](../../../icons))
+- Icon Sets API: `artisanpack-ui/icons` ([`ap.icons.register-icon-sets`](https://github.com/ArtisanPack-UI/icons))

--- a/docs/blocks/Icon-Block.md
+++ b/docs/blocks/Icon-Block.md
@@ -1,0 +1,133 @@
+# Icon Block
+
+**Status:** v1.1 · shipped via parent issue #494 (Phases 1–7)
+**Block name:** `artisanpack/icon`
+
+The Icon Block lets authors drop branded SVG icons — Font Awesome Free or any custom set — into pages without touching markup. It ships Font Awesome 6 Free (Solid, Regular, Brands) out of the box and supports admin-imported custom sets such as a licensed Font Awesome Pro download.
+
+---
+
+## Block usage
+
+Authors insert the block from the inserter under the **Design** category, then either pick a registered icon or paste a custom SVG.
+
+### Picking a registered icon
+
+1. Insert the **Icon** block.
+2. The empty block renders a placeholder button — click it (or the **Choose icon…** button in the sidebar) to open the picker.
+3. Search by name (e.g. `github`, `house`) or filter by set family (Solid / Regular / Brands / any registered custom set).
+4. Click an icon to commit it. The block renders the inline SVG immediately.
+
+### Pasting a custom SVG
+
+When the catalog doesn't carry the icon you need, drop into **Inspector → Custom SVG** and paste any SVG markup. The server sanitizes the SVG before it reaches the canvas — script tags, event-handler attributes, and unsafe href schemes are stripped, and the cleaned markup is what persists. Pasting a custom SVG clears any previously-picked `iconRef` so the two render paths can't conflict.
+
+### Styling
+
+The block mirrors the WordPress reference Icon Block split: a dedicated **Icon color** field controls the SVG itself, while the standard WordPress controls handle the visual tile around it.
+
+| Control | Where it shows up | Affected element |
+|---------|------------------|------------------|
+| **Icon color** | Sidebar → Color → Icon | SVG fill (applied as `color` on the body span; the bundled SVGs ship with `fill: currentcolor`) |
+| **Background** | Sidebar → Color | Block wrapper — the visual "tile" behind the icon |
+| **Border** (color, width, style, radius) | Sidebar → Border | Block wrapper |
+| **Padding** | Sidebar → Dimensions | Block wrapper — space between the wrapper edge and the SVG |
+| **Margin** | Sidebar → Dimensions | Block wrapper — block-flow spacing around the whole icon |
+
+Palette colors (`Primary` / `Accent` / etc. picked from theme.json) and custom hex values are both supported. Palette picks resolve through the standard `has-{slug}-background-color` / `has-{slug}-border-color` classes against theme.json's CSS variables.
+
+### Dimensions
+
+The **Dimensions** panel ships three controls that update the canvas as you type — no blur required:
+
+- **Size** — a single number input that sets both width and height (the default).
+- **Width** — UnitControl override. Pixels, em, rem, percent, vw, or vh.
+- **Height** — UnitControl override.
+
+Width/height override the uniform `Size` per-axis. Clearing either field falls back to the size value, so the common "uniform-square icon" case stays a single slider.
+
+### Link
+
+The Inspector's link controls produce a wrapping `<a>` on the rendered icon. `target="_blank"` automatically forces `rel="noopener noreferrer"`; `rel="nofollow"` and `rel="sponsored"` are author-controlled.
+
+### Accessibility
+
+- **aria-label** — explicit accessible name; required when the icon is the only content in a link.
+- **Decorative** — sets `aria-hidden="true"` and suppresses any `aria-label`. The editor shows a warning if a decorative icon sits inside a link without a wrapping label, because screen readers would announce an unlabeled link.
+
+---
+
+## Developer recipe — registering custom sets
+
+Packages register additional icon sets through the existing [`ap.icons.register-icon-sets`](../../../icons) filter from `artisanpack-ui/icons`. The Icon Block picks them up automatically — no Icon Block-specific registration is needed.
+
+```php
+use ArtisanPackUI\Icons\Registries\IconSetRegistration;
+
+// In your service provider's boot() method:
+addFilter( 'ap.icons.register-icon-sets', function ( IconSetRegistration $registry ): IconSetRegistration {
+    $registry->addSet(
+        __DIR__ . '/../../resources/icons/myset',
+        'myset',
+    );
+    return $registry;
+} );
+```
+
+The registered set's icons render through the same `IconSvgResolver` pipeline as the bundled FA Free sets. If the picker's catalog also needs to surface them, register a matching catalog entry (typically by extending the manifest fed to `IconCatalog`).
+
+---
+
+## Admin upload walkthrough
+
+Admins can also import custom sets directly from the editor UI — useful for shipping licensed icon packs (e.g. Font Awesome Pro) without adding them to the package source.
+
+1. Open **Visual Editor → Icon sets** (admin-only; gated by the existing visual-editor management policy).
+2. Click **Upload set**, supply a **prefix**, a human-readable **label**, and a **zip** of SVG files.
+3. The server unpacks the zip, runs each SVG through `SvgSanitizer`, and persists the cleaned files to `storage/app/artisanpack/visual-editor/icons/{prefix}/`.
+4. The set is registered through `ap.icons.register-icon-sets` on the next boot and immediately becomes selectable in the picker.
+
+Non-SVG entries are listed in the upload report under `skipped`; SVGs that fail sanitization are listed under `failed`. A prefix collision (an existing bundled or uploaded set already using the same prefix) returns `409 Conflict` with the offending prefix surfaced in the error payload.
+
+---
+
+## Font Awesome Pro guidance — BYO SVGs
+
+The block bundles Font Awesome 6 **Free** (Solid, Regular, Brands). It does **not** validate FA Pro kit codes, store FA tokens, or fetch Pro icons from a remote endpoint.
+
+To use Font Awesome Pro:
+
+1. Download the SVG bundle from your FA Pro account.
+2. Pick the Pro families you want (e.g. Sharp Solid, Duotone) and bundle each into its own zip.
+3. Upload each zip through the admin Icon Sets screen with a descriptive prefix (e.g. `fa-pro-sharp-solid`) and label.
+
+Each Pro family is stored locally under `storage/app/artisanpack/visual-editor/icons/{prefix}/` and surfaces in the picker alongside Free. No tokens leave the host application.
+
+---
+
+## Server-side render
+
+The block is dynamic — `IconBlock::render()` produces the final markup at request time:
+
+```html
+<div class="wp-block-artisanpack-icon"[ style="margin: 12px;"]>
+    <span class="wp-block-artisanpack-icon__ref"
+          data-icon-set="fab"
+          data-icon-name="github"
+          style="width: 48px; height: 48px; …">
+        <svg width="100%" height="100%" viewBox="0 0 24 24">…</svg>
+    </span>
+</div>
+```
+
+Custom-SVG blocks emit the same wrapper with `__svg` in place of `__ref`, and the sanitized SVG inlined directly into the span.
+
+If the referenced icon set has been deleted (or never registered), the renderer falls back to a placeholder span and keeps the `data-icon-set`/`data-icon-name` carriers so re-registering the set later restores the icon without re-authoring the post.
+
+---
+
+## Related
+
+- Parent issue: [#494](https://github.com/ArtisanPack-UI/visual-editor/issues/494)
+- Phase 7 (cross-phase tests + docs): [#558](https://github.com/ArtisanPack-UI/visual-editor/issues/558)
+- Icon Sets API: `artisanpack-ui/icons` ([`ap.icons.register-icon-sets`](../../../icons))

--- a/docs/home.md
+++ b/docs/home.md
@@ -72,6 +72,7 @@ The block library — what ships, how to author your own, and how to wire respon
 
 - [[Blocks]] — Block library overview and the `artisanpack/*` allow-list
 - [[blocks/Custom Blocks]] — Authoring your own blocks (static and dynamic)
+- [[blocks/Icon Block]] — The `artisanpack/icon` block (FA Free + admin upload)
 - [[blocks/Responsive Design Tools]] — Per-breakpoint values on block controls
 - [[blocks/State Design Tools]] — Per-state overrides (hover, focus, active, etc.)
 

--- a/resources/js/visual-editor/blocks/icon/__tests__/block.test.ts
+++ b/resources/js/visual-editor/blocks/icon/__tests__/block.test.ts
@@ -53,8 +53,8 @@ describe( 'artisanpack/icon block.json', () => {
         }
     } );
 
-    it( 'restricts sizeUnit to px, em, rem', () => {
-        expect( metadata.attributes.sizeUnit.enum ).toEqual( [ 'px', 'em', 'rem' ] );
+    it( 'restricts sizeUnit to the supported CSS units', () => {
+        expect( metadata.attributes.sizeUnit.enum ).toEqual( [ 'px', 'em', 'rem', '%', 'vw', 'vh' ] );
     } );
 
     it( 'restricts rotation to multiples of 90', () => {

--- a/resources/js/visual-editor/blocks/icon/__tests__/block.test.ts
+++ b/resources/js/visual-editor/blocks/icon/__tests__/block.test.ts
@@ -53,8 +53,16 @@ describe( 'artisanpack/icon block.json', () => {
         }
     } );
 
-    it( 'restricts sizeUnit to the supported CSS units', () => {
-        expect( metadata.attributes.sizeUnit.enum ).toEqual( [ 'px', 'em', 'rem', '%', 'vw', 'vh' ] );
+    it( 'restricts every unit-bearing attribute to the supported CSS units', () => {
+        // sizeUnit is required and required to be one of the kept units.
+        // widthUnit / heightUnit are optional overrides; they share the
+        // same allowlist plus `null` for "fall back to sizeUnit". Asserting
+        // all three in lockstep keeps the JS + PHP normalizers from
+        // drifting when a unit is added or removed from block.json.
+        const baseUnits = [ 'px', 'em', 'rem', '%', 'vw', 'vh' ];
+        expect( metadata.attributes.sizeUnit.enum ).toEqual( baseUnits );
+        expect( metadata.attributes.widthUnit.enum ).toEqual( [ ...baseUnits, null ] );
+        expect( metadata.attributes.heightUnit.enum ).toEqual( [ ...baseUnits, null ] );
     } );
 
     it( 'restricts rotation to multiples of 90', () => {

--- a/resources/js/visual-editor/blocks/icon/__tests__/utils.test.ts
+++ b/resources/js/visual-editor/blocks/icon/__tests__/utils.test.ts
@@ -8,6 +8,7 @@ import {
     composeRel,
     computeIconStyle,
     computeTransform,
+    computeWrapperStyle,
     hasDecorativeLinkConflict,
     normalizeAttributes,
     normalizeLinkTarget,
@@ -20,8 +21,15 @@ const baseAttrs: NormalizedIconAttributes = {
     customSvg: '',
     size: 32,
     sizeUnit: 'px',
+    width: 32,
+    widthUnit: 'px',
+    widthExplicit: false,
+    height: 32,
+    heightUnit: 'px',
+    heightExplicit: false,
     color: '',
     backgroundColor: '',
+    iconColor: '',
     rotation: 0,
     flipH: false,
     flipV: false,
@@ -31,6 +39,7 @@ const baseAttrs: NormalizedIconAttributes = {
     titleAttr: '',
     ariaLabel: '',
     isDecorative: false,
+    style: {},
 };
 
 describe( 'normalizeAttributes', () => {
@@ -87,7 +96,7 @@ describe( 'normalizeAttributes', () => {
             iconRef: null,
             customSvg: '',
             size: NaN,
-            sizeUnit: 'vh' as never,
+            sizeUnit: 'pt' as never,
             color: '',
             backgroundColor: '',
             rotation: 45 as never,
@@ -130,16 +139,184 @@ describe( 'normalizeAttributes', () => {
 } );
 
 describe( 'computeIconStyle', () => {
-    it( 'emits width and height from size + unit', () => {
-        const style = computeIconStyle( { ...baseAttrs, size: 24, sizeUnit: 'rem' } );
+    it( 'emits width and height from the normalized width/height + units', () => {
+        const style = computeIconStyle( {
+            ...baseAttrs,
+            width: 24,
+            widthUnit: 'rem',
+            height: 24,
+            heightUnit: 'rem',
+        } );
         expect( style.width ).toBe( '24rem' );
         expect( style.height ).toBe( '24rem' );
     } );
 
-    it( 'omits color and backgroundColor when unset', () => {
+    it( 'omits color when no icon color or legacy fallback is set', () => {
         const style = computeIconStyle( baseAttrs );
         expect( style.color ).toBeUndefined();
+        // Background no longer flows through this helper — WP serializes
+        // it onto the wrapper via `useBlockProps()`.
         expect( style.backgroundColor ).toBeUndefined();
+    } );
+
+    it( 'applies the explicit iconColor as the body-span color', () => {
+        const style = computeIconStyle( { ...baseAttrs, iconColor: '#abc' } );
+        expect( style.color ).toBe( '#abc' );
+    } );
+
+    it( 'lets iconColor override the WP style.color.text fallback', () => {
+        const style = computeIconStyle( {
+            ...baseAttrs,
+            iconColor: '#abc',
+            style: { color: { text: '#def' } },
+        } );
+        expect( style.color ).toBe( '#abc' );
+    } );
+
+    it( 'falls back to style.color.text when iconColor is empty', () => {
+        const style = computeIconStyle( {
+            ...baseAttrs,
+            style: { color: { text: '#def' } },
+        } );
+        expect( style.color ).toBe( '#def' );
+    } );
+
+    it( 'falls back to the legacy top-level color attribute last', () => {
+        const style = computeIconStyle( { ...baseAttrs, color: '#333' } );
+        expect( style.color ).toBe( '#333' );
+    } );
+
+    it( 'reads independent width and height from per-axis overrides', () => {
+        const style = computeIconStyle( {
+            ...baseAttrs,
+            width: 48,
+            widthUnit: 'px',
+            height: 24,
+            heightUnit: 'rem',
+        } );
+        expect( style.width ).toBe( '48px' );
+        expect( style.height ).toBe( '24rem' );
+    } );
+
+    it( 'drops a style value that fails the safe-CSS allowlist', () => {
+        const style = computeIconStyle( {
+            ...baseAttrs,
+            style: { color: { text: 'expression(alert(1))' } },
+        } );
+        expect( style.color ).toBeUndefined();
+    } );
+} );
+
+describe( 'computeWrapperStyle', () => {
+    it( 'returns an empty object — WP serializes wrapper styles via useBlockProps()', () => {
+        expect( computeWrapperStyle( baseAttrs ) ).toEqual( {} );
+        expect(
+            computeWrapperStyle( {
+                ...baseAttrs,
+                style: { spacing: { margin: '8px' } },
+            } ),
+        ).toEqual( {} );
+    } );
+} );
+
+describe( 'normalizeAttributes width/height override', () => {
+    it( 'leaves width and height equal to size when both unset', () => {
+        const normalized = normalizeAttributes( {
+            iconRef: null,
+            customSvg: '',
+            size: 48,
+            sizeUnit: 'px',
+            color: '',
+            backgroundColor: '',
+            rotation: 0,
+            flipH: false,
+            flipV: false,
+            link: '',
+            linkTarget: '',
+            linkRel: '',
+            titleAttr: '',
+            ariaLabel: '',
+            isDecorative: false,
+        } );
+        expect( normalized.width ).toBe( 48 );
+        expect( normalized.widthUnit ).toBe( 'px' );
+        expect( normalized.widthExplicit ).toBe( false );
+        expect( normalized.height ).toBe( 48 );
+        expect( normalized.heightUnit ).toBe( 'px' );
+        expect( normalized.heightExplicit ).toBe( false );
+    } );
+
+    it( 'lets width override size on a single axis without disturbing height', () => {
+        const normalized = normalizeAttributes( {
+            iconRef: null,
+            customSvg: '',
+            size: 32,
+            sizeUnit: 'px',
+            width: 64,
+            widthUnit: 'px',
+            color: '',
+            backgroundColor: '',
+            rotation: 0,
+            flipH: false,
+            flipV: false,
+            link: '',
+            linkTarget: '',
+            linkRel: '',
+            titleAttr: '',
+            ariaLabel: '',
+            isDecorative: false,
+        } );
+        expect( normalized.width ).toBe( 64 );
+        expect( normalized.widthExplicit ).toBe( true );
+        expect( normalized.height ).toBe( 32 );
+        expect( normalized.heightExplicit ).toBe( false );
+    } );
+
+    it( 'inherits sizeUnit for width when widthUnit is null', () => {
+        const normalized = normalizeAttributes( {
+            iconRef: null,
+            customSvg: '',
+            size: 32,
+            sizeUnit: 'rem',
+            width: 4,
+            widthUnit: null,
+            color: '',
+            backgroundColor: '',
+            rotation: 0,
+            flipH: false,
+            flipV: false,
+            link: '',
+            linkTarget: '',
+            linkRel: '',
+            titleAttr: '',
+            ariaLabel: '',
+            isDecorative: false,
+        } );
+        expect( normalized.widthUnit ).toBe( 'rem' );
+    } );
+
+    it( 'clamps explicit width and height to the 1..1024 range', () => {
+        const normalized = normalizeAttributes( {
+            iconRef: null,
+            customSvg: '',
+            size: 32,
+            sizeUnit: 'px',
+            width: -10,
+            height: 99999,
+            color: '',
+            backgroundColor: '',
+            rotation: 0,
+            flipH: false,
+            flipV: false,
+            link: '',
+            linkTarget: '',
+            linkRel: '',
+            titleAttr: '',
+            ariaLabel: '',
+            isDecorative: false,
+        } );
+        expect( normalized.width ).toBe( 1 );
+        expect( normalized.height ).toBe( 1024 );
     } );
 } );
 

--- a/resources/js/visual-editor/blocks/icon/block.json
+++ b/resources/js/visual-editor/blocks/icon/block.json
@@ -22,13 +22,34 @@
         },
         "sizeUnit": {
             "type": "string",
-            "enum": [ "px", "em", "rem" ],
+            "enum": [ "px", "em", "rem", "%", "vw", "vh" ],
             "default": "px"
+        },
+        "width": {
+            "type": [ "number", "null" ],
+            "default": null
+        },
+        "widthUnit": {
+            "type": [ "string", "null" ],
+            "enum": [ "px", "em", "rem", "%", "vw", "vh", null ],
+            "default": null
+        },
+        "height": {
+            "type": [ "number", "null" ],
+            "default": null
+        },
+        "heightUnit": {
+            "type": [ "string", "null" ],
+            "enum": [ "px", "em", "rem", "%", "vw", "vh", null ],
+            "default": null
         },
         "color": {
             "type": "string"
         },
         "backgroundColor": {
+            "type": "string"
+        },
+        "iconColor": {
             "type": "string"
         },
         "rotation": {
@@ -73,17 +94,16 @@
         "anchor": true,
         "align": [ "left", "center", "right", "wide", "full" ],
         "color": {
-            "__experimentalSkipSerialization": true,
+            "text": false,
+            "background": true,
             "gradients": false,
             "__experimentalDefaultControls": {
-                "background": true,
-                "text": true
+                "background": true
             }
         },
         "spacing": {
             "margin": true,
             "padding": true,
-            "__experimentalSkipSerialization": true,
             "__experimentalDefaultControls": {
                 "margin": false,
                 "padding": false
@@ -94,7 +114,6 @@
             "radius": true,
             "style": true,
             "width": true,
-            "__experimentalSkipSerialization": true,
             "__experimentalDefaultControls": {
                 "color": true,
                 "radius": true,

--- a/resources/js/visual-editor/blocks/icon/edit.tsx
+++ b/resources/js/visual-editor/blocks/icon/edit.tsx
@@ -314,11 +314,18 @@ export default function IconEdit( { attributes, setAttributes }: IconEditProps )
     }
 
     const conflict = hasDecorativeLinkConflict( normalized );
+    // Decorative icons hide the body's ariaLabel via aria-hidden; promote
+    // the label onto the anchor so the link still has an accessible name.
+    const anchorAriaLabel =
+        normalized.isDecorative && normalized.ariaLabel
+            ? normalized.ariaLabel
+            : undefined;
     const wrapped = shouldRenderLink( normalized ) ? (
         <a
             href={ normalized.link }
             target={ normalizeLinkTarget( normalized.linkTarget ) || undefined }
             rel={ composeRel( normalized.linkTarget, normalized.linkRel ) || undefined }
+            aria-label={ anchorAriaLabel }
             onClick={ ( event ) => event.preventDefault() }
         >
             { body }

--- a/resources/js/visual-editor/blocks/icon/edit.tsx
+++ b/resources/js/visual-editor/blocks/icon/edit.tsx
@@ -9,14 +9,26 @@
 
 import { useEffect, useState } from 'react';
 import type { ReactElement } from 'react';
-import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
-import { Button, PanelBody } from '@wordpress/components';
+import {
+    InspectorControls,
+    PanelColorSettings,
+    useBlockProps,
+} from '@wordpress/block-editor';
+import {
+    Button,
+    PanelBody,
+    PanelRow,
+    // eslint-disable-next-line @typescript-eslint/naming-convention -- WP component name
+    __experimentalNumberControl as NumberControl,
+    // eslint-disable-next-line @typescript-eslint/naming-convention -- WP component name
+    __experimentalUnitControl as UnitControl,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 import { sanitizeOnServer } from './custom-svg';
 import CustomSvgControl from './custom-svg-control';
 import IconPicker from './icon-picker';
-import type { IconAttributes, IconRef } from './types';
+import type { IconAttributes, IconRef, SizeUnit } from './types';
 import {
     composeRel,
     computeIconStyle,
@@ -27,6 +39,56 @@ import {
     shouldRenderLink,
 } from './utils';
 
+const SIZE_UNIT_OPTIONS: ReadonlyArray< { value: SizeUnit; label: string } > = [
+    { value: 'px', label: 'px' },
+    { value: 'em', label: 'em' },
+    { value: 'rem', label: 'rem' },
+    { value: '%', label: '%' },
+    { value: 'vw', label: 'vw' },
+    { value: 'vh', label: 'vh' },
+];
+
+const ALLOWED_UNITS: ReadonlySet< SizeUnit > = new Set(
+    SIZE_UNIT_OPTIONS.map( ( option ) => option.value ),
+);
+
+interface ParsedUnitValue {
+    readonly value: number | null;
+    readonly unit: SizeUnit | null;
+}
+
+/**
+ * Parse the `'48px'` / `'1.5em'` strings that `UnitControl` emits.
+ *
+ * Returns nulls (not zeros) when either component is missing so the
+ * caller can persist "author cleared the field" as a distinct state
+ * from "author typed 0" — `width: null` falls back to `size`, while
+ * `width: 0` would render a zero-size box. Negative inputs are
+ * rejected outright so authors can't dial in a negative dimension
+ * that would clamp into 1 on the server but render as 0 in the
+ * canvas mid-flight.
+ */
+function parseUnitValue( raw: string | undefined | null ): ParsedUnitValue {
+    if ( typeof raw !== 'string' ) {
+        return { value: null, unit: null };
+    }
+    const trimmed = raw.trim();
+    if ( trimmed.length === 0 ) {
+        return { value: null, unit: null };
+    }
+    const match = trimmed.match( /^(\d+(?:\.\d+)?)([a-z%]+)?$/i );
+    if ( ! match ) {
+        return { value: null, unit: null };
+    }
+    const value = Number.parseFloat( match[ 1 ] );
+    if ( ! Number.isFinite( value ) || value < 0 ) {
+        return { value: null, unit: null };
+    }
+    const unitRaw = ( match[ 2 ] ?? 'px' ).toLowerCase() as SizeUnit;
+    const unit = ALLOWED_UNITS.has( unitRaw ) ? unitRaw : 'px';
+    return { value, unit };
+}
+
 interface IconEditProps {
     readonly attributes: IconAttributes;
     readonly setAttributes: ( next: Partial< IconAttributes > ) => void;
@@ -34,8 +96,56 @@ interface IconEditProps {
 
 export default function IconEdit( { attributes, setAttributes }: IconEditProps ): ReactElement {
     const normalized = normalizeAttributes( attributes );
+    // No wrapper style is computed here — `useBlockProps()` already
+    // injects WP-managed background/border/padding/margin onto the
+    // wrapper div via the block.json `supports` map. See utils.ts.
     const blockProps = useBlockProps();
     const [ pickerOpen, setPickerOpen ] = useState( false );
+
+    const widthDisplay  = normalized.widthExplicit  ? `${ normalized.width }${ normalized.widthUnit }`   : '';
+    const heightDisplay = normalized.heightExplicit ? `${ normalized.height }${ normalized.heightUnit }` : '';
+
+    const onSizeChange = ( next: string | number | undefined ): void => {
+        // NumberControl emits `string | number | undefined`. Coerce
+        // through `Number.parseFloat` on string input so the size
+        // attribute stays a number; skip the update when the input is
+        // cleared so the old value is preserved rather than persisting
+        // `NaN`.
+        let parsed: number;
+        if ( typeof next === 'number' ) {
+            parsed = next;
+        } else if ( typeof next === 'string' ) {
+            parsed = Number.parseFloat( next );
+        } else {
+            return;
+        }
+        if ( ! Number.isFinite( parsed ) ) {
+            return;
+        }
+        setAttributes( { size: parsed } );
+    };
+
+    const onWidthChange = ( next: string | undefined ): void => {
+        const parsed = parseUnitValue( next );
+        if ( parsed.value === null ) {
+            setAttributes( { width: null, widthUnit: null } );
+            return;
+        }
+        setAttributes( { width: parsed.value, widthUnit: parsed.unit ?? 'px' } );
+    };
+
+    const onHeightChange = ( next: string | undefined ): void => {
+        const parsed = parseUnitValue( next );
+        if ( parsed.value === null ) {
+            setAttributes( { height: null, heightUnit: null } );
+            return;
+        }
+        setAttributes( { height: parsed.value, heightUnit: parsed.unit ?? 'px' } );
+    };
+
+    const onIconColorChange = ( next: string | undefined ): void => {
+        setAttributes( { iconColor: typeof next === 'string' ? next : '' } );
+    };
 
     const openPicker = (): void => setPickerOpen( true );
     const closePicker = (): void => setPickerOpen( false );
@@ -236,6 +346,56 @@ export default function IconEdit( { attributes, setAttributes }: IconEditProps )
                             </code>
                         </p>
                     ) }
+                </PanelBody>
+                <PanelColorSettings
+                    title={ __( 'Color', 'artisanpack-visual-editor' ) }
+                    initialOpen={ false }
+                    colorSettings={ [
+                        {
+                            value: normalized.iconColor || undefined,
+                            onChange: onIconColorChange,
+                            label: __( 'Icon', 'artisanpack-visual-editor' ),
+                        },
+                    ] }
+                />
+                <PanelBody
+                    title={ __( 'Dimensions', 'artisanpack-visual-editor' ) }
+                    initialOpen={ false }
+                >
+                    <PanelRow>
+                        <NumberControl
+                            label={ __( 'Size', 'artisanpack-visual-editor' ) }
+                            help={ __(
+                                'Sets width and height together. Override either below.',
+                                'artisanpack-visual-editor',
+                            ) }
+                            value={ normalized.size }
+                            min={ 1 }
+                            max={ 1024 }
+                            onChange={ onSizeChange }
+                            __next40pxDefaultSize
+                        />
+                    </PanelRow>
+                    <PanelRow>
+                        <UnitControl
+                            label={ __( 'Width', 'artisanpack-visual-editor' ) }
+                            value={ widthDisplay }
+                            units={ [ ...SIZE_UNIT_OPTIONS ] }
+                            onChange={ onWidthChange }
+                            placeholder={ __( 'Same as size', 'artisanpack-visual-editor' ) }
+                            __next40pxDefaultSize
+                        />
+                    </PanelRow>
+                    <PanelRow>
+                        <UnitControl
+                            label={ __( 'Height', 'artisanpack-visual-editor' ) }
+                            value={ heightDisplay }
+                            units={ [ ...SIZE_UNIT_OPTIONS ] }
+                            onChange={ onHeightChange }
+                            placeholder={ __( 'Same as size', 'artisanpack-visual-editor' ) }
+                            __next40pxDefaultSize
+                        />
+                    </PanelRow>
                 </PanelBody>
                 <CustomSvgControl
                     customSvg={ normalized.customSvg }

--- a/resources/js/visual-editor/blocks/icon/edit.tsx
+++ b/resources/js/visual-editor/blocks/icon/edit.tsx
@@ -316,9 +316,12 @@ export default function IconEdit( { attributes, setAttributes }: IconEditProps )
     const conflict = hasDecorativeLinkConflict( normalized );
     // Decorative icons hide the body's ariaLabel via aria-hidden; promote
     // the label onto the anchor so the link still has an accessible name.
+    // Trim so whitespace-only labels (e.g. `"   "`) read as missing rather
+    // than as a present-but-empty accessible name.
+    const trimmedAriaLabel = normalized.ariaLabel.trim();
     const anchorAriaLabel =
-        normalized.isDecorative && normalized.ariaLabel
-            ? normalized.ariaLabel
+        normalized.isDecorative && trimmedAriaLabel
+            ? trimmedAriaLabel
             : undefined;
     const wrapped = shouldRenderLink( normalized ) ? (
         <a

--- a/resources/js/visual-editor/blocks/icon/save.tsx
+++ b/resources/js/visual-editor/blocks/icon/save.tsx
@@ -90,6 +90,12 @@ export default function IconSave( { attributes }: IconSaveProps ): ReactElement 
     if ( shouldRenderLink( normalized ) ) {
         const target = normalizeLinkTarget( normalized.linkTarget );
         const rel = composeRel( normalized.linkTarget, normalized.linkRel );
+        // Decorative icons hide the body's ariaLabel via aria-hidden; promote
+        // the label onto the anchor so the link still has an accessible name.
+        const anchorAriaLabel =
+            normalized.isDecorative && normalized.ariaLabel
+                ? normalized.ariaLabel
+                : undefined;
 
         return (
             <div { ...blockProps }>
@@ -97,6 +103,7 @@ export default function IconSave( { attributes }: IconSaveProps ): ReactElement 
                     href={ normalized.link }
                     target={ target || undefined }
                     rel={ rel || undefined }
+                    aria-label={ anchorAriaLabel }
                 >
                     { body }
                 </a>

--- a/resources/js/visual-editor/blocks/icon/save.tsx
+++ b/resources/js/visual-editor/blocks/icon/save.tsx
@@ -28,6 +28,9 @@ interface IconSaveProps {
 export default function IconSave( { attributes }: IconSaveProps ): ReactElement {
     const normalized = normalizeAttributes( attributes );
     const transform = computeTransform( normalized );
+    // No wrapper style here — `useBlockProps.save` already serializes
+    // WP-managed background/border/spacing onto the wrapper div via the
+    // block.json `supports` map.
     const blockProps = useBlockProps.save();
     const sizedStyle = computeIconStyle( normalized );
 

--- a/resources/js/visual-editor/blocks/icon/save.tsx
+++ b/resources/js/visual-editor/blocks/icon/save.tsx
@@ -92,9 +92,12 @@ export default function IconSave( { attributes }: IconSaveProps ): ReactElement 
         const rel = composeRel( normalized.linkTarget, normalized.linkRel );
         // Decorative icons hide the body's ariaLabel via aria-hidden; promote
         // the label onto the anchor so the link still has an accessible name.
+        // Trim so whitespace-only labels (e.g. `"   "`) read as missing
+        // rather than as a present-but-empty accessible name.
+        const trimmedAriaLabel = normalized.ariaLabel.trim();
         const anchorAriaLabel =
-            normalized.isDecorative && normalized.ariaLabel
-                ? normalized.ariaLabel
+            normalized.isDecorative && trimmedAriaLabel
+                ? trimmedAriaLabel
                 : undefined;
 
         return (

--- a/resources/js/visual-editor/blocks/icon/types.ts
+++ b/resources/js/visual-editor/blocks/icon/types.ts
@@ -19,8 +19,36 @@ export interface IconRef {
     readonly name: string;
 }
 
-export type SizeUnit = 'px' | 'em' | 'rem';
+export type SizeUnit = 'px' | 'em' | 'rem' | '%' | 'vw' | 'vh';
 export type Rotation = 0 | 90 | 180 | 270;
+
+/**
+ * Subset of WordPress's `style` attribute that the icon block reads.
+ *
+ * `supports.color`, `supports.spacing`, and `supports.__experimentalBorder`
+ * all write into the same `style` envelope. We declare just the slots we
+ * consume — the wider WP shape is wider but irrelevant here.
+ */
+export interface WpStyleAttribute {
+    readonly color?: {
+        readonly text?: string | null;
+        readonly background?: string | null;
+    } | null;
+    readonly border?: {
+        readonly color?: string | null;
+        readonly radius?: string | { readonly topLeft?: string | null; readonly topRight?: string | null; readonly bottomLeft?: string | null; readonly bottomRight?: string | null } | null;
+        readonly style?: string | null;
+        readonly width?: string | null;
+        readonly top?: { readonly color?: string | null; readonly style?: string | null; readonly width?: string | null } | null;
+        readonly right?: { readonly color?: string | null; readonly style?: string | null; readonly width?: string | null } | null;
+        readonly bottom?: { readonly color?: string | null; readonly style?: string | null; readonly width?: string | null } | null;
+        readonly left?: { readonly color?: string | null; readonly style?: string | null; readonly width?: string | null } | null;
+    } | null;
+    readonly spacing?: {
+        readonly padding?: string | { readonly top?: string | null; readonly right?: string | null; readonly bottom?: string | null; readonly left?: string | null } | null;
+        readonly margin?: string | { readonly top?: string | null; readonly right?: string | null; readonly bottom?: string | null; readonly left?: string | null } | null;
+    } | null;
+}
 
 /**
  * Every string attribute is typed `string | null | undefined` because
@@ -34,8 +62,13 @@ export interface IconAttributes {
     readonly customSvg: string | null | undefined;
     readonly size: number | null | undefined;
     readonly sizeUnit: SizeUnit | null | undefined;
+    readonly width?: number | null;
+    readonly widthUnit?: SizeUnit | null;
+    readonly height?: number | null;
+    readonly heightUnit?: SizeUnit | null;
     readonly color?: string | null;
     readonly backgroundColor?: string | null;
+    readonly iconColor?: string | null;
     readonly rotation: Rotation | null | undefined;
     readonly flipH: boolean | null | undefined;
     readonly flipV: boolean | null | undefined;
@@ -45,20 +78,34 @@ export interface IconAttributes {
     readonly titleAttr: string | null | undefined;
     readonly ariaLabel: string | null | undefined;
     readonly isDecorative: boolean | null | undefined;
+    readonly style?: WpStyleAttribute | null;
 }
 
 /**
  * The "always present, always the right type" form used internally
  * by the render helpers. Authors never construct this directly —
  * {@link normalizeAttributes} produces it from the raw `IconAttributes`.
+ *
+ * `width`/`height` are the resolved render-time dimensions: when the
+ * author left them unset, {@link normalizeAttributes} fills them from
+ * `size`/`sizeUnit` so downstream helpers only have to read one pair.
+ * `widthExplicit` / `heightExplicit` flag whether the author actually
+ * overrode `size` — useful for UI hints, never for rendering.
  */
 export interface NormalizedIconAttributes {
     readonly iconRef: IconRef | null;
     readonly customSvg: string;
     readonly size: number;
     readonly sizeUnit: SizeUnit;
+    readonly width: number;
+    readonly widthUnit: SizeUnit;
+    readonly widthExplicit: boolean;
+    readonly height: number;
+    readonly heightUnit: SizeUnit;
+    readonly heightExplicit: boolean;
     readonly color: string;
     readonly backgroundColor: string;
+    readonly iconColor: string;
     readonly rotation: Rotation;
     readonly flipH: boolean;
     readonly flipV: boolean;
@@ -68,4 +115,5 @@ export interface NormalizedIconAttributes {
     readonly titleAttr: string;
     readonly ariaLabel: string;
     readonly isDecorative: boolean;
+    readonly style: WpStyleAttribute;
 }

--- a/resources/js/visual-editor/blocks/icon/utils.ts
+++ b/resources/js/visual-editor/blocks/icon/utils.ts
@@ -15,6 +15,7 @@ import type {
     NormalizedIconAttributes,
     Rotation,
     SizeUnit,
+    WpStyleAttribute,
 } from './types';
 
 const ALLOWED_TARGETS = new Set([ '_blank', '_self', '_parent', '_top' ]);
@@ -47,8 +48,37 @@ function isSafeLinkUrl( raw: string ): boolean {
     const scheme = trimmed.slice( 0, colon ).toLowerCase();
     return scheme === 'http' || scheme === 'https' || scheme === 'mailto' || scheme === 'tel';
 }
-const ALLOWED_SIZE_UNITS: ReadonlySet< SizeUnit > = new Set( [ 'px', 'em', 'rem' ] );
+const ALLOWED_SIZE_UNITS: ReadonlySet< SizeUnit > = new Set( [ 'px', 'em', 'rem', '%', 'vw', 'vh' ] );
 const ALLOWED_ROTATIONS: ReadonlySet< Rotation > = new Set( [ 0, 90, 180, 270 ] );
+
+/**
+ * Author-supplied CSS values reach inline style attributes unquoted, so
+ * any escape sequence (`"`, `'`, `<`, `;`, parens that don't pair, the
+ * `url(` / `expression(` / `javascript:` triplets) would let an attacker
+ * smuggle a second declaration. We allowlist a conservative grammar:
+ * digits + units, `var(--token)` references, `currentcolor`, and the
+ * standard color keywords / hex / rgb / hsl forms already in use.
+ *
+ * Anything that fails this gate falls back to the empty string and is
+ * dropped from the rendered style — fail-closed, no warning shown.
+ */
+const SAFE_STYLE_VALUE_RE =
+    /^(#[0-9a-f]{3,8}|rgba?\([0-9.,%\s/-]+\)|hsla?\([0-9.,%\s/-]+\)|var\(--[a-z0-9_-]+\)|[a-z][a-z0-9_-]*|-?\d+(\.\d+)?(px|em|rem|%|vw|vh|vmin|vmax)?(\s+(-?\d+(\.\d+)?(px|em|rem|%|vw|vh|vmin|vmax)?|#[0-9a-f]{3,8}|rgba?\([0-9.,%\s/-]+\)|hsla?\([0-9.,%\s/-]+\)|[a-z][a-z0-9_-]*))*)$/i;
+
+function isSafeStyleValue( raw: unknown ): raw is string {
+    if ( typeof raw !== 'string' ) {
+        return false;
+    }
+    const trimmed = raw.trim();
+    if ( trimmed.length === 0 ) {
+        return false;
+    }
+    return SAFE_STYLE_VALUE_RE.test( trimmed );
+}
+
+function safeStyleValue( raw: unknown ): string {
+    return isSafeStyleValue( raw ) ? raw.trim() : '';
+}
 
 function asString( value: unknown ): string {
     return typeof value === 'string' ? value : '';
@@ -82,6 +112,18 @@ function asRotation( value: unknown ): Rotation {
         : 0;
 }
 
+function asStyleObject( value: unknown ): WpStyleAttribute {
+    if ( value === null || value === undefined || typeof value !== 'object' ) {
+        return {};
+    }
+    // The shape is structurally validated as it's read by `computeBodyStyle`
+    // and `computeWrapperStyle` — those helpers walk the slots they
+    // actually consume and ignore the rest. Casting here keeps
+    // {@link normalizeAttributes} simple without losing type info on
+    // the consumer side.
+    return value as WpStyleAttribute;
+}
+
 function asIconRef( value: unknown ): IconRef | null {
     if ( value === null || value === undefined || typeof value !== 'object' ) {
         return null;
@@ -100,15 +142,36 @@ function asIconRef( value: unknown ): IconRef | null {
  * loop keeps the rest of the helpers blissfully unaware.
  */
 export function normalizeAttributes( attributes: IconAttributes ): NormalizedIconAttributes {
+    const size     = clampSize( attributes.size );
+    const sizeUnit = asSizeUnit( attributes.sizeUnit );
+
+    // Width/height override `size` per-axis when the author sets them.
+    // Leaving either unset (the null/undefined case) lets `size` continue
+    // to drive that axis — preserving the "single slider sets both"
+    // ergonomic that already shipped.
+    const widthExplicit = typeof attributes.width === 'number' && Number.isFinite( attributes.width );
+    const heightExplicit = typeof attributes.height === 'number' && Number.isFinite( attributes.height );
+
     return {
         iconRef: asIconRef( attributes.iconRef ),
         customSvg: asString( attributes.customSvg ),
         // Mirror IconBlock::validateAttrs's 1..1024 clamp so a server
         // re-render produces the same size the editor previewed.
-        size: clampSize( attributes.size ),
-        sizeUnit: asSizeUnit( attributes.sizeUnit ),
+        size,
+        sizeUnit,
+        width: widthExplicit ? clampSize( attributes.width ) : size,
+        widthUnit: widthExplicit
+            ? asSizeUnit( attributes.widthUnit ?? sizeUnit )
+            : sizeUnit,
+        widthExplicit,
+        height: heightExplicit ? clampSize( attributes.height ) : size,
+        heightUnit: heightExplicit
+            ? asSizeUnit( attributes.heightUnit ?? sizeUnit )
+            : sizeUnit,
+        heightExplicit,
         color: asString( attributes.color ),
         backgroundColor: asString( attributes.backgroundColor ),
+        iconColor: asString( attributes.iconColor ),
         rotation: asRotation( attributes.rotation ),
         flipH: asBoolean( attributes.flipH ),
         flipV: asBoolean( attributes.flipV ),
@@ -118,6 +181,7 @@ export function normalizeAttributes( attributes: IconAttributes ): NormalizedIco
         titleAttr: asString( attributes.titleAttr ),
         ariaLabel: asString( attributes.ariaLabel ),
         isDecorative: asBoolean( attributes.isDecorative ),
+        style: asStyleObject( attributes.style ),
     };
 }
 
@@ -129,28 +193,62 @@ export function normalizeAttributes( attributes: IconAttributes ): NormalizedIco
  * is applied to the inline `<span>` that actually carries the icon —
  * letting the icon stay 32px wide without dragging the whole block
  * out of the document flow.
+ *
+ * The body span carries TWO things only:
+ *
+ *  1. The sized box (`width` + `height` + `inline-flex` shell).
+ *  2. The icon's `color` — which the bundled SVGs pick up through
+ *     `fill: currentcolor` (declared on `.wp-block-artisanpack-icon svg`
+ *     in `icon.css`). Author choices flow through `iconColor` first;
+ *     the legacy top-level `color` attribute (and the WP-managed
+ *     `style.color.text` envelope for blocks that still carry it) are
+ *     kept as fallbacks so already-saved posts keep their picked colors.
+ *
+ * Background, border, and spacing all flow through `useBlockProps()`
+ * onto the WRAPPER element — `block.json`'s `supports.color`,
+ * `supports.spacing`, and `supports.__experimentalBorder` no longer
+ * skip serialization, so the editor's standard inspector controls
+ * apply directly without this helper having to read them back.
  */
 export function computeIconStyle( attributes: NormalizedIconAttributes ): CSSProperties {
-    const dimension = `${ attributes.size }${ attributes.sizeUnit }`;
+    const widthDimension  = `${ attributes.width }${ attributes.widthUnit }`;
+    const heightDimension = `${ attributes.height }${ attributes.heightUnit }`;
 
     const style: CSSProperties = {
-        width: dimension,
-        height: dimension,
+        width: widthDimension,
+        height: heightDimension,
         display: 'inline-flex',
         alignItems: 'center',
         justifyContent: 'center',
         lineHeight: 0,
     };
 
-    if ( attributes.color.length > 0 ) {
-        style.color = attributes.color;
-    }
+    const wpText = safeStyleValue( attributes.style.color?.text );
+    const iconColor = safeStyleValue( attributes.iconColor );
+    const legacyColor = safeStyleValue( attributes.color );
 
-    if ( attributes.backgroundColor.length > 0 ) {
-        style.backgroundColor = attributes.backgroundColor;
+    // Precedence: explicit `iconColor` wins; the WP `style.color.text`
+    // envelope is honored for any pre-fix posts that still carry it;
+    // top-level `color` is the original v1.1-beta legacy slot.
+    const text = iconColor !== '' ? iconColor : ( wpText !== '' ? wpText : legacyColor );
+    if ( text !== '' ) {
+        style.color = text;
     }
 
     return style;
+}
+
+/**
+ * Compose the wrapper `<div>` style.
+ *
+ * The block now lets WordPress handle background, border, padding, and
+ * margin via the standard `useBlockProps()` serialization path — those
+ * styles are merged in by the editor itself rather than computed here.
+ * This helper stays around (returning an empty object) so callers can
+ * keep their merge points without conditionally including it.
+ */
+export function computeWrapperStyle( _attributes: NormalizedIconAttributes ): CSSProperties {
+    return {};
 }
 
 /**

--- a/src/Blocks/Icon/IconBlock.php
+++ b/src/Blocks/Icon/IconBlock.php
@@ -210,9 +210,12 @@ class IconBlock extends DynamicBlock
 		// unlabeled. Promote any author-supplied `ariaLabel` onto the
 		// `<a>` itself so screen readers can announce the destination.
 		// The non-decorative path already pushes `ariaLabel` onto the
-		// body span — no double-labeling there.
-		if ( $attrs['isDecorative'] && '' !== $attrs['ariaLabel'] ) {
-			$attrParts[] = sprintf( 'aria-label="%s"', e( $attrs['ariaLabel'] ) );
+		// body span — no double-labeling there. Trim before testing so
+		// whitespace-only labels (e.g. `"   "`) read as missing rather
+		// than as a present-but-empty accessible name.
+		$ariaLabel = trim( $attrs['ariaLabel'] );
+		if ( $attrs['isDecorative'] && '' !== $ariaLabel ) {
+			$attrParts[] = sprintf( 'aria-label="%s"', e( $ariaLabel ) );
 		}
 
 		return sprintf( '<a %s>%s</a>', implode( ' ', $attrParts ), $body );

--- a/src/Blocks/Icon/IconBlock.php
+++ b/src/Blocks/Icon/IconBlock.php
@@ -205,6 +205,15 @@ class IconBlock extends DynamicBlock
 		if ( '' !== $rel ) {
 			$attrParts[] = sprintf( 'rel="%s"', e( $rel ) );
 		}
+		// Decorative icons get `aria-hidden="true"` on the body span, so
+		// the only naming node is suppressed and the link reads as
+		// unlabeled. Promote any author-supplied `ariaLabel` onto the
+		// `<a>` itself so screen readers can announce the destination.
+		// The non-decorative path already pushes `ariaLabel` onto the
+		// body span — no double-labeling there.
+		if ( $attrs['isDecorative'] && '' !== $attrs['ariaLabel'] ) {
+			$attrParts[] = sprintf( 'aria-label="%s"', e( $attrs['ariaLabel'] ) );
+		}
 
 		return sprintf( '<a %s>%s</a>', implode( ' ', $attrParts ), $body );
 	}

--- a/src/Blocks/Icon/IconBlock.php
+++ b/src/Blocks/Icon/IconBlock.php
@@ -27,9 +27,10 @@ use ArtisanPackUI\VisualEditor\Services\Icon\SvgSanitizer;
 
 class IconBlock extends DynamicBlock
 {
-	private const ALLOWED_SIZE_UNITS    = [ 'px', 'em', 'rem' ];
+	private const ALLOWED_SIZE_UNITS    = [ 'px', 'em', 'rem', '%', 'vw', 'vh' ];
 	private const ALLOWED_ROTATIONS     = [ 0, 90, 180, 270 ];
 	private const ALLOWED_LINK_TARGETS  = [ '_blank', '_self', '_parent', '_top' ];
+	private const ALLOWED_BORDER_STYLES = [ 'none', 'hidden', 'dotted', 'dashed', 'solid', 'double', 'groove', 'ridge', 'inset', 'outset' ];
 
 	public function __construct(
 		private readonly SvgSanitizer $sanitizer,
@@ -53,6 +54,15 @@ class IconBlock extends DynamicBlock
 			? (string) $attrs['sizeUnit']
 			: 'px';
 
+		$width       = $this->normalizeDimension( $attrs['width'] ?? null );
+		$widthUnit   = null === $width
+			? null
+			: ( $this->normalizeSizeUnit( $attrs['widthUnit'] ?? null ) ?? $sizeUnit );
+		$height      = $this->normalizeDimension( $attrs['height'] ?? null );
+		$heightUnit  = null === $height
+			? null
+			: ( $this->normalizeSizeUnit( $attrs['heightUnit'] ?? null ) ?? $sizeUnit );
+
 		$rotation = isset( $attrs['rotation'] ) && in_array( (int) $attrs['rotation'], self::ALLOWED_ROTATIONS, true )
 			? (int) $attrs['rotation']
 			: 0;
@@ -62,22 +72,37 @@ class IconBlock extends DynamicBlock
 			: '';
 
 		return [
-			'iconRef'         => $this->normalizeIconRef( $attrs['iconRef'] ?? null ),
-			'customSvg'       => is_string( $attrs['customSvg'] ?? null ) ? $attrs['customSvg'] : '',
-			'size'            => $size,
-			'sizeUnit'        => $sizeUnit,
-			'color'           => $this->normalizeColor( $attrs['color'] ?? null ),
-			'backgroundColor' => $this->normalizeColor( $attrs['backgroundColor'] ?? null ),
-			'rotation'        => $rotation,
-			'flipH'           => (bool) ( $attrs['flipH'] ?? false ),
-			'flipV'           => (bool) ( $attrs['flipV'] ?? false ),
-			'link'            => $this->normalizeLink( $attrs['link'] ?? null ),
-			'linkTarget'      => $linkTarget,
-			'linkRel'         => is_string( $attrs['linkRel'] ?? null ) ? (string) $attrs['linkRel'] : '',
-			'titleAttr'       => is_string( $attrs['titleAttr'] ?? null ) ? (string) $attrs['titleAttr'] : '',
-			'ariaLabel'       => is_string( $attrs['ariaLabel'] ?? null ) ? (string) $attrs['ariaLabel'] : '',
-			'isDecorative'    => (bool) ( $attrs['isDecorative'] ?? false ),
-			'className'       => is_string( $attrs['className'] ?? null ) ? (string) $attrs['className'] : '',
+			'iconRef'             => $this->normalizeIconRef( $attrs['iconRef'] ?? null ),
+			'customSvg'           => is_string( $attrs['customSvg'] ?? null ) ? $attrs['customSvg'] : '',
+			'size'                => $size,
+			'sizeUnit'            => $sizeUnit,
+			'width'               => $width,
+			'widthUnit'           => $widthUnit,
+			'height'              => $height,
+			'heightUnit'          => $heightUnit,
+			// Legacy top-level slots kept around so blocks saved before
+			// the iconColor + WP-style-envelope work still render their
+			// picked colors.
+			'color'               => $this->normalizeColor( $attrs['color'] ?? null ),
+			'backgroundColor'     => $this->normalizeColor( $attrs['backgroundColor'] ?? null ),
+			'iconColor'           => $this->normalizeColor( $attrs['iconColor'] ?? null ),
+			// Palette-color slugs from WP `supports.color` /
+			// `supports.__experimentalBorder` — only the palette
+			// `backgroundColor`/`borderColor` slugs reach top-level
+			// attrs; custom hex values land inside `style`.
+			'paletteBackground'   => $this->normalizePaletteSlug( $attrs['backgroundColor'] ?? null ),
+			'paletteBorderColor'  => $this->normalizePaletteSlug( $attrs['borderColor'] ?? null ),
+			'rotation'            => $rotation,
+			'flipH'               => (bool) ( $attrs['flipH'] ?? false ),
+			'flipV'               => (bool) ( $attrs['flipV'] ?? false ),
+			'link'                => $this->normalizeLink( $attrs['link'] ?? null ),
+			'linkTarget'          => $linkTarget,
+			'linkRel'             => is_string( $attrs['linkRel'] ?? null ) ? (string) $attrs['linkRel'] : '',
+			'titleAttr'           => is_string( $attrs['titleAttr'] ?? null ) ? (string) $attrs['titleAttr'] : '',
+			'ariaLabel'           => is_string( $attrs['ariaLabel'] ?? null ) ? (string) $attrs['ariaLabel'] : '',
+			'isDecorative'        => (bool) ( $attrs['isDecorative'] ?? false ),
+			'className'           => is_string( $attrs['className'] ?? null ) ? (string) $attrs['className'] : '',
+			'style'               => is_array( $attrs['style'] ?? null ) ? $attrs['style'] : [],
 		];
 	}
 
@@ -92,14 +117,19 @@ class IconBlock extends DynamicBlock
 		}
 
 		$wrapperClasses = $this->wrapperClasses( $attrs );
+		$wrapperStyle   = $this->wrapperStyle( $attrs );
 
 		// The wrapper is a plain block element so the editor's
 		// `is-layout-constrained` parent keeps the icon inside the
 		// content column. The inline-flex sizing lives on the body
-		// span — see `innerStyle()`.
+		// span — see `bodyStyle()`. Margin is the one style we apply
+		// here because `display: inline-flex` on the body span
+		// (correctly) participates in inline-layout vertical metrics,
+		// whereas margin is a block-level concern.
 		return sprintf(
-			'<div class="%s">%s</div>',
+			'<div class="%s"%s>%s</div>',
 			e( implode( ' ', $wrapperClasses ) ),
+			'' !== $wrapperStyle ? sprintf( ' style="%s"', e( $wrapperStyle ) ) : '',
 			$body
 		);
 	}
@@ -195,6 +225,29 @@ class IconBlock extends DynamicBlock
 			$classes[] = $attrs['className'];
 		}
 
+		$style = is_array( $attrs['style'] ?? null ) ? $attrs['style'] : [];
+
+		// WP `supports.color` palette selections (slugs) need their
+		// `has-{slug}-background-color` + `has-background` class pair to
+		// pick up the theme.json CSS variable. Custom hex values arrive
+		// inside `style.color.background` and are applied as inline CSS
+		// in `wrapperStyle()` instead.
+		if ( '' !== $attrs['paletteBackground'] ) {
+			$classes[] = sprintf( 'has-%s-background-color', $attrs['paletteBackground'] );
+			$classes[] = 'has-background';
+		} elseif ( null !== $this->normalizeColor( $style['color']['background'] ?? null ) ) {
+			$classes[] = 'has-background';
+		}
+
+		// `supports.__experimentalBorder` mirrors the same palette/custom
+		// split for border color.
+		if ( '' !== $attrs['paletteBorderColor'] ) {
+			$classes[] = sprintf( 'has-%s-border-color', $attrs['paletteBorderColor'] );
+			$classes[] = 'has-border-color';
+		} elseif ( null !== $this->normalizeColor( $style['border']['color'] ?? null ) ) {
+			$classes[] = 'has-border-color';
+		}
+
 		return $classes;
 	}
 
@@ -205,24 +258,33 @@ class IconBlock extends DynamicBlock
 	 * outer wrapper `<div>`, so the wrapper stays a plain block-flow
 	 * element and the editor's layout-constrained parent keeps the
 	 * icon inside the content column.
+	 *
+	 * The body span also carries the icon's `color` — which the bundled
+	 * SVGs pick up via `fill: currentcolor` (declared on
+	 * `.wp-block-artisanpack-icon svg` in `icon.css`). Precedence:
+	 * explicit `iconColor` wins, then the WP `style.color.text` slot
+	 * (kept for blocks that still carry it), then the legacy top-level
+	 * `color` attribute.
 	 */
 	private function bodyStyle( array $attrs ): string
 	{
-		$dimension = sprintf( '%s%s', $this->formatNumber( $attrs['size'] ), $attrs['sizeUnit'] );
-		$parts     = [
-			'width: ' . $dimension,
-			'height: ' . $dimension,
+		$width  = sprintf( '%s%s', $this->formatNumber( $attrs['width']  ?? $attrs['size'] ), $attrs['widthUnit']  ?? $attrs['sizeUnit'] );
+		$height = sprintf( '%s%s', $this->formatNumber( $attrs['height'] ?? $attrs['size'] ), $attrs['heightUnit'] ?? $attrs['sizeUnit'] );
+
+		$parts = [
+			'width: ' . $width,
+			'height: ' . $height,
 			'display: inline-flex',
 			'align-items: center',
 			'justify-content: center',
 			'line-height: 0',
 		];
 
-		if ( null !== $attrs['color'] ) {
-			$parts[] = 'color: ' . $attrs['color'];
-		}
-		if ( null !== $attrs['backgroundColor'] ) {
-			$parts[] = 'background-color: ' . $attrs['backgroundColor'];
+		$style  = is_array( $attrs['style'] ?? null ) ? $attrs['style'] : [];
+		$wpText = $this->normalizeColor( $style['color']['text'] ?? null );
+		$color  = $attrs['iconColor'] ?? $wpText ?? $attrs['color'];
+		if ( null !== $color ) {
+			$parts[] = 'color: ' . $color;
 		}
 
 		$transform = $this->computeTransform( $attrs );
@@ -232,6 +294,151 @@ class IconBlock extends DynamicBlock
 		}
 
 		return implode( '; ', $parts ) . ';';
+	}
+
+	/**
+	 * Wrapper `<div>` style.
+	 *
+	 * Carries the WP-managed background/border/padding/margin from the
+	 * `attributes.style` envelope plus the legacy top-level
+	 * `backgroundColor` for pre-fix blocks. The icon's foreground color
+	 * stays on the body span via `bodyStyle()` so the SVG's
+	 * `fill: currentcolor` picks it up without spilling onto the wrapper.
+	 * Returns an empty string (not `style=""`) when nothing applies so
+	 * the wrapper markup stays attribute-clean.
+	 */
+	private function wrapperStyle( array $attrs ): string
+	{
+		$style = is_array( $attrs['style'] ?? null ) ? $attrs['style'] : [];
+		$parts = [];
+
+		// Custom hex background (style.color.background); the palette
+		// slug case is handled via `has-{slug}-background-color` in
+		// `wrapperClasses()`. The legacy top-level `backgroundColor`
+		// hex is the fallback for blocks saved before the WP-managed
+		// envelope reached this block.
+		$wpBackground = $this->normalizeColor( $style['color']['background'] ?? null );
+		$background   = '' === $attrs['paletteBackground'] ? ( $wpBackground ?? $attrs['backgroundColor'] ) : null;
+		if ( null !== $background ) {
+			$parts[] = 'background-color: ' . $background;
+		}
+
+		foreach ( $this->borderDeclarations( $style['border'] ?? null ) as $decl ) {
+			$parts[] = $decl;
+		}
+		foreach ( $this->boxDeclarations( $style['spacing']['padding'] ?? null, 'padding' ) as $decl ) {
+			$parts[] = $decl;
+		}
+		foreach ( $this->boxDeclarations( $style['spacing']['margin'] ?? null, 'margin' ) as $decl ) {
+			$parts[] = $decl;
+		}
+
+		if ( [] === $parts ) {
+			return '';
+		}
+
+		return implode( '; ', $parts ) . ';';
+	}
+
+	/**
+	 * Emit CSS declarations for a WP border envelope.
+	 *
+	 * Accepts uniform (`width`/`color`/`style`/`radius` at the top level)
+	 * and per-side (`top`/`right`/`bottom`/`left` objects) forms. Values
+	 * are passed through {@see normalizeColor} for colors and
+	 * {@see normalizeDimensionString} for widths/radii, so anything that
+	 * smuggles a `;` or quote into the inline style falls back to the
+	 * empty string and is dropped.
+	 *
+	 * @param  mixed  $border
+	 *
+	 * @return \Generator<int, string>
+	 */
+	private function borderDeclarations( mixed $border ): \Generator
+	{
+		if ( ! is_array( $border ) ) {
+			return;
+		}
+
+		$radius = $border['radius'] ?? null;
+		if ( is_string( $radius ) ) {
+			$safe = $this->normalizeDimensionString( $radius );
+			if ( null !== $safe ) {
+				yield 'border-radius: ' . $safe;
+			}
+		} elseif ( is_array( $radius ) ) {
+			foreach ( [
+				'topLeft'     => 'border-top-left-radius',
+				'topRight'    => 'border-top-right-radius',
+				'bottomRight' => 'border-bottom-right-radius',
+				'bottomLeft'  => 'border-bottom-left-radius',
+			] as $key => $cssName ) {
+				$safe = $this->normalizeDimensionString( $radius[ $key ] ?? null );
+				if ( null !== $safe ) {
+					yield $cssName . ': ' . $safe;
+				}
+			}
+		}
+
+		foreach ( [ 'color' => 'border-color', 'style' => 'border-style', 'width' => 'border-width' ] as $key => $cssName ) {
+			$value = $border[ $key ] ?? null;
+			$safe  = 'color' === $key
+				? $this->normalizeColor( $value )
+				: ( 'style' === $key ? $this->normalizeBorderStyle( $value ) : $this->normalizeDimensionString( $value ) );
+			if ( null !== $safe ) {
+				yield $cssName . ': ' . $safe;
+			}
+		}
+
+		foreach ( [ 'top', 'right', 'bottom', 'left' ] as $side ) {
+			$entry = $border[ $side ] ?? null;
+			if ( ! is_array( $entry ) ) {
+				continue;
+			}
+			$sideColor = $this->normalizeColor( $entry['color'] ?? null );
+			$sideStyle = $this->normalizeBorderStyle( $entry['style'] ?? null );
+			$sideWidth = $this->normalizeDimensionString( $entry['width'] ?? null );
+			if ( null !== $sideColor ) {
+				yield sprintf( 'border-%s-color: %s', $side, $sideColor );
+			}
+			if ( null !== $sideStyle ) {
+				yield sprintf( 'border-%s-style: %s', $side, $sideStyle );
+			}
+			if ( null !== $sideWidth ) {
+				yield sprintf( 'border-%s-width: %s', $side, $sideWidth );
+			}
+		}
+	}
+
+	/**
+	 * Emit CSS declarations for a WP box (padding|margin) envelope.
+	 *
+	 * @param  mixed   $value
+	 * @param  string  $shorthand  `padding` or `margin`.
+	 *
+	 * @return \Generator<int, string>
+	 */
+	private function boxDeclarations( mixed $value, string $shorthand ): \Generator
+	{
+		if ( null === $value ) {
+			return;
+		}
+		if ( is_string( $value ) ) {
+			$safe = $this->normalizeDimensionString( $value );
+			if ( null !== $safe ) {
+				yield $shorthand . ': ' . $safe;
+			}
+			return;
+		}
+		if ( ! is_array( $value ) ) {
+			return;
+		}
+		foreach ( [ 'top', 'right', 'bottom', 'left' ] as $side ) {
+			$safe = $this->normalizeDimensionString( $value[ $side ] ?? null );
+			if ( null !== $safe ) {
+				yield sprintf( '%s-%s: %s', $shorthand, $side, $safe );
+			}
+		}
 	}
 
 	private function computeTransform( array $attrs ): string
@@ -351,6 +558,38 @@ class IconBlock extends DynamicBlock
 		return $trimmed;
 	}
 
+	/**
+	 * Coerce a WP palette-color slug into a kebab-case safe form.
+	 *
+	 * WP writes the slug of a palette pick into the top-level
+	 * `backgroundColor` / `borderColor` attributes (NOT inside `style`).
+	 * The slug is interpolated into a `has-{slug}-background-color`
+	 * class, so anything that isn't `[a-z0-9-]+` would break the
+	 * markup. Returns the empty string for missing / malformed values
+	 * so the caller can just check `'' !== $slug`.
+	 *
+	 * Also rejects values that look like hex/rgb/etc. — those reach
+	 * `backgroundColor` only on already-saved blocks where the slot was
+	 * being used as the legacy hex storage; the hex fallback path in
+	 * `wrapperStyle()` keeps them honored without misclassing them.
+	 */
+	private function normalizePaletteSlug( mixed $value ): string
+	{
+		if ( ! is_string( $value ) ) {
+			return '';
+		}
+		$trimmed = trim( $value );
+		if ( '' === $trimmed ) {
+			return '';
+		}
+		// A WP palette slug is always lowercase kebab-case; the legacy
+		// hex/CSS-value forms all start with `#`, contain `(`, etc.
+		if ( ! preg_match( '/^[a-z][a-z0-9-]*$/', $trimmed ) ) {
+			return '';
+		}
+		return $trimmed;
+	}
+
 	private function normalizeColor( mixed $value ): ?string
 	{
 		if ( ! is_string( $value ) ) {
@@ -371,6 +610,68 @@ class IconBlock extends DynamicBlock
 		}
 
 		return $trimmed;
+	}
+
+	/**
+	 * Coerce a raw width/height attribute into a clamped float.
+	 *
+	 * Returns `null` (not a default size) when the value is missing or
+	 * non-numeric so the caller can distinguish "author cleared the
+	 * override" from "author typed 0" — null means fall back to `size`,
+	 * which is the correct behavior for an unset width/height.
+	 */
+	private function normalizeDimension( mixed $value ): ?float
+	{
+		if ( null === $value || ! is_numeric( $value ) ) {
+			return null;
+		}
+		return max( 1.0, min( 1024.0, (float) $value ) );
+	}
+
+	private function normalizeSizeUnit( mixed $value ): ?string
+	{
+		if ( ! is_string( $value ) ) {
+			return null;
+		}
+		return in_array( $value, self::ALLOWED_SIZE_UNITS, true ) ? $value : null;
+	}
+
+	/**
+	 * Allowlist a CSS dimension string (e.g. `48px`, `1.5em`, `var(--gap)`).
+	 *
+	 * Returns `null` for anything else so the value is dropped from the
+	 * rendered style rather than reaching the markup. The grammar accepts
+	 * the same units as {@see ALLOWED_SIZE_UNITS}, plus `vmin`/`vmax`
+	 * (read-only — never written here) and the `var(--token)` form WP's
+	 * theme.json uses for global-style references.
+	 */
+	private function normalizeDimensionString( mixed $value ): ?string
+	{
+		if ( ! is_string( $value ) ) {
+			return null;
+		}
+		$trimmed = trim( $value );
+		if ( '' === $trimmed ) {
+			return null;
+		}
+		if ( preg_match( '/^var\(--[a-z0-9_-]+\)$/i', $trimmed ) ) {
+			return $trimmed;
+		}
+		// Whitespace-separated list of `<number><unit>?` tokens to cover
+		// `padding: 4px 8px 4px 8px` and the like.
+		if ( ! preg_match( '/^(-?\d+(\.\d+)?(px|em|rem|%|vw|vh|vmin|vmax)?)(\s+-?\d+(\.\d+)?(px|em|rem|%|vw|vh|vmin|vmax)?)*$/i', $trimmed ) ) {
+			return null;
+		}
+		return $trimmed;
+	}
+
+	private function normalizeBorderStyle( mixed $value ): ?string
+	{
+		if ( ! is_string( $value ) ) {
+			return null;
+		}
+		$trimmed = strtolower( trim( $value ) );
+		return in_array( $trimmed, self::ALLOWED_BORDER_STYLES, true ) ? $trimmed : null;
 	}
 
 	/**

--- a/tests/Feature/VisualEditor/IconBlockEndToEndTest.php
+++ b/tests/Feature/VisualEditor/IconBlockEndToEndTest.php
@@ -1,0 +1,473 @@
+<?php
+
+/**
+ * Phase 7 (#558) — cross-phase integration coverage for the Icon Block.
+ *
+ * Phases 1–6 each ship deep unit tests on their slice. This file is
+ * deliberately wider: each scenario stitches together the registration
+ * filter, the catalog, the picker endpoints, the admin uploader, the
+ * sanitizer, and the block renderer so a regression that only shows up
+ * when the pieces are wired together gets caught here.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.1.0
+ */
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Blocks\Icon\IconBlock;
+use ArtisanPackUI\VisualEditor\Services\Icon\IconCatalog;
+use ArtisanPackUI\VisualEditor\Services\Icon\IconSvgResolver;
+use ArtisanPackUI\VisualEditor\Services\Icon\SvgSanitizer;
+use ArtisanPackUI\VisualEditor\Services\Icon\UploadedIconSet;
+use ArtisanPackUI\VisualEditor\Services\Icon\UploadedIconSetRegistry;
+use ArtisanPackUI\VisualEditor\SiteEditor\Gates\SiteEditorAccessGate;
+use Illuminate\Http\Request;
+use Illuminate\Http\UploadedFile;
+use Symfony\Component\HttpFoundation\Response;
+use Tests\TestUser;
+
+function e2eIconBase(): string
+{
+	if ( ! isset( test()->iconBase ) ) {
+		test()->iconBase = sys_get_temp_dir() . '/icon-e2e-' . bin2hex( random_bytes( 4 ) );
+		mkdir( test()->iconBase, 0o755, true );
+	}
+	return test()->iconBase;
+}
+
+function & e2eZipPaths(): array
+{
+	static $paths = [];
+	return $paths;
+}
+
+function e2eMakeZip( array $entries ): UploadedFile
+{
+	$path    = sys_get_temp_dir() . '/icon-e2e-' . bin2hex( random_bytes( 4 ) ) . '.zip';
+	$archive = new ZipArchive();
+	$status  = $archive->open( $path, ZipArchive::CREATE );
+	if ( true !== $status ) {
+		throw new RuntimeException( "Failed to create zip {$path}: status {$status}" );
+	}
+	foreach ( $entries as $name => $contents ) {
+		$archive->addFromString( $name, $contents );
+	}
+	$archive->close();
+
+	$paths   = & e2eZipPaths();
+	$paths[] = $path;
+
+	return new UploadedFile( $path, basename( $path ), 'application/zip', null, true );
+}
+
+function e2eActAsAdmin(): TestUser
+{
+	$user = TestUser::create( [
+		'name'     => 'Icon E2E Admin',
+		'email'    => 'icon-e2e+' . uniqid() . '@example.com',
+		'password' => bcrypt( 'secret' ),
+	] );
+	test()->actingAs( $user );
+	return $user;
+}
+
+function e2eBindAllowingGate(): void
+{
+	app()->bind( SiteEditorAccessGate::class, function () {
+		return new class implements SiteEditorAccessGate
+		{
+			public function check( Request $request ): ?Response
+			{
+				return null;
+			}
+		};
+	} );
+}
+
+function e2eRegisterBundledSet( string $prefix, array $icons ): string
+{
+	$base = e2eIconBase() . '/' . $prefix;
+	if ( ! is_dir( $base ) ) {
+		mkdir( $base, 0o755, true );
+	}
+	foreach ( $icons as $name => $svg ) {
+		file_put_contents( $base . '/' . $name . '.svg', $svg );
+	}
+	return $base;
+}
+
+function e2eBindCatalogFixture( array $sets, array $icons ): void
+{
+	app()->instance(
+		IconCatalog::class,
+		new IconCatalog( static fn (): array => [ 'sets' => $sets, 'icons' => $icons ] ),
+	);
+}
+
+beforeEach( function (): void {
+	$paths = & e2eZipPaths();
+	$paths = [];
+
+	// Stand the uploaded-set registry on a temp dir per-test so each
+	// scenario starts from a clean slate without touching the others'
+	// fixtures.
+	$uploadBase = e2eIconBase() . '/uploaded';
+	mkdir( $uploadBase, 0o755, true );
+	app()->instance( UploadedIconSetRegistry::class, new UploadedIconSetRegistry( $uploadBase ) );
+	app()->forgetInstance( \ArtisanPackUI\VisualEditor\Services\Icon\IconSetUploader::class );
+
+	e2eBindAllowingGate();
+} );
+
+afterEach( function (): void {
+	$rrm = static function ( string $dir ) use ( &$rrm ): void {
+		foreach ( scandir( $dir ) ?: [] as $entry ) {
+			if ( '.' === $entry || '..' === $entry ) {
+				continue;
+			}
+			$path = $dir . DIRECTORY_SEPARATOR . $entry;
+			is_dir( $path ) ? $rrm( $path ) : @unlink( $path );
+		}
+		@rmdir( $dir );
+	};
+
+	if ( isset( test()->iconBase ) && is_dir( test()->iconBase ) ) {
+		$rrm( test()->iconBase );
+		test()->iconBase = null;
+	}
+
+	foreach ( e2eZipPaths() as $zip ) {
+		if ( is_file( $zip ) ) {
+			@unlink( $zip );
+		}
+	}
+} );
+
+// -------------------------------------------------------------------
+// Block registration end-to-end
+// -------------------------------------------------------------------
+
+it( 'registers the artisanpack/icon dynamic block end-to-end', function (): void {
+	// The service provider wires the dynamic block in `boot()`; reach
+	// into the container to confirm the block is bound under the right
+	// name and resolves an instance with the production dependencies.
+	$block = app( IconBlock::class );
+
+	expect( $block->name() )->toBe( 'artisanpack/icon' );
+
+	// And the block should be able to render a placeholder out of the
+	// box (no iconRef, no customSvg) without the IconSvgResolver having
+	// to know about any registered sets.
+	$html = $block->render( [] );
+
+	expect( $html )->toContain( 'wp-block-artisanpack-icon__placeholder' );
+} );
+
+// -------------------------------------------------------------------
+// Picker search across multiple registered sets
+// -------------------------------------------------------------------
+
+it( 'searches across both bundled and admin-uploaded sets', function (): void {
+	e2eActAsAdmin();
+
+	// Pretend an admin previously uploaded a "brand" set.
+	app( UploadedIconSetRegistry::class )->register(
+		new UploadedIconSet( 'brand', 'Brand', '2026-01-01T00:00:00Z' ),
+	);
+
+	// And bind a catalog that surfaces both the FA Free `fas` set and
+	// the uploaded `brand` set, with icons coming from each.
+	e2eBindCatalogFixture(
+		sets: [
+			[ 'prefix' => 'fas',   'label' => 'Solid', 'source' => 'solid' ],
+			[ 'prefix' => 'brand', 'label' => 'Brand', 'source' => 'uploaded' ],
+		],
+		icons: [
+			[ 'name' => 'house',  'set' => 'fas',   'label' => 'House',  'terms' => [ 'home' ] ],
+			[ 'name' => 'rocket', 'set' => 'brand', 'label' => 'Rocket', 'terms' => [ 'launch' ] ],
+		],
+	);
+
+	$this->getJson( '/visual-editor/api/icons/search?q=launch' )
+		->assertOk()
+		->assertJsonPath( 'total', 1 )
+		->assertJsonPath( 'data.0.name', 'rocket' )
+		->assertJsonPath( 'data.0.set', 'brand' );
+
+	$this->getJson( '/visual-editor/api/icons/search' )
+		->assertOk()
+		->assertJsonPath( 'total', 2 );
+} );
+
+// -------------------------------------------------------------------
+// SVG sanitization integration (block + admin upload)
+// -------------------------------------------------------------------
+
+it( 'sanitizes a malicious customSvg pasted into the block before render', function (): void {
+	$block = app( IconBlock::class );
+
+	// The `<a>` tag isn't in the SVG allowlist, so the sanitizer
+	// removes that entire subtree (along with its `javascript:` href).
+	// The `<path>` here sits at the top level so it survives, while
+	// `<script>` and the `onload` handler are both stripped.
+	$payload = <<<'SVG'
+		<svg xmlns="http://www.w3.org/2000/svg" onload="alert(1)">
+			<script>alert('xss')</script>
+			<a href="javascript:alert(1)"></a>
+			<path d="M0 0"/>
+		</svg>
+		SVG;
+
+	$html = $block->render( [ 'customSvg' => $payload ] );
+
+	expect( $html )->toContain( '<path' )
+		->and( $html )->not->toContain( '<script' )
+		->and( $html )->not->toContain( 'onload' )
+		->and( $html )->not->toContain( 'javascript:' );
+} );
+
+it( 'sanitizes admin-uploaded SVGs before persisting them to disk', function (): void {
+	e2eActAsAdmin();
+
+	$zip = e2eMakeZip( [
+		'logo.svg'  => '<svg xmlns="http://www.w3.org/2000/svg" onclick="evil()"><path d="M0 0"/></svg>',
+		'evil.svg'  => '<script>alert(1)</script>',
+	] );
+
+	$response = $this->post( '/visual-editor/api/admin/icon-sets', [
+		'prefix' => 'mybrand',
+		'label'  => 'My Brand',
+		'zip'    => $zip,
+	] );
+
+	$response->assertStatus( Response::HTTP_CREATED );
+
+	// `logo.svg` is sanitized + persisted; `evil.svg` is rejected outright.
+	$registry  = app( UploadedIconSetRegistry::class );
+	$storedDir = $registry->pathFor( 'mybrand' );
+
+	$logo = file_get_contents( $storedDir . '/logo.svg' );
+	expect( $logo )->toContain( '<path' )
+		->and( $logo )->not->toContain( 'onclick' );
+
+	expect( file_exists( $storedDir . '/evil.svg' ) )->toBeFalse();
+} );
+
+// -------------------------------------------------------------------
+// Admin upload happy path
+// -------------------------------------------------------------------
+
+it( 'uploads an icon set, registers it, and makes it pickable end-to-end', function (): void {
+	e2eActAsAdmin();
+
+	$zip = e2eMakeZip( [
+		'arrow.svg' => '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M0 0"/></svg>',
+	] );
+
+	$response = $this->post( '/visual-editor/api/admin/icon-sets', [
+		'prefix' => 'uploaded',
+		'label'  => 'Uploaded',
+		'zip'    => $zip,
+	] );
+
+	$response->assertStatus( Response::HTTP_CREATED );
+
+	expect( app( UploadedIconSetRegistry::class )->has( 'uploaded' ) )->toBeTrue();
+
+	// Wire a catalog that mirrors what `ap.icons.register-icon-sets`
+	// would expose for the newly-uploaded set, then drive the picker
+	// search endpoint and confirm the icon is discoverable.
+	e2eBindCatalogFixture(
+		sets:  [ [ 'prefix' => 'uploaded', 'label' => 'Uploaded', 'source' => 'uploaded' ] ],
+		icons: [ [ 'name' => 'arrow', 'set' => 'uploaded', 'label' => 'Arrow', 'terms' => [ 'pointer' ] ] ],
+	);
+
+	$this->getJson( '/visual-editor/api/icons/search?set=uploaded&q=pointer' )
+		->assertOk()
+		->assertJsonPath( 'total', 1 )
+		->assertJsonPath( 'data.0.set', 'uploaded' )
+		->assertJsonPath( 'data.0.name', 'arrow' );
+} );
+
+// -------------------------------------------------------------------
+// Prefix-collision integration
+// -------------------------------------------------------------------
+
+it( 'rejects an upload whose prefix collides with an already-registered set', function (): void {
+	e2eActAsAdmin();
+
+	// Seed an existing registration so the second upload hits the
+	// prefix-collision branch.
+	app( UploadedIconSetRegistry::class )->register(
+		new UploadedIconSet( 'taken', 'Taken', '2026-01-01T00:00:00Z' ),
+	);
+
+	$zip = e2eMakeZip( [
+		'thing.svg' => '<svg xmlns="http://www.w3.org/2000/svg"><path d="M0 0"/></svg>',
+	] );
+
+	$response = $this->post( '/visual-editor/api/admin/icon-sets', [
+		'prefix' => 'taken',
+		'label'  => 'Taken',
+		'zip'    => $zip,
+	] );
+
+	$response->assertStatus( Response::HTTP_CONFLICT )
+		->assertJsonPath( 'error', 'prefix_collision' )
+		->assertJsonPath( 'prefix', 'taken' );
+} );
+
+it( 'replaces a previously-registered set on a same-prefix call to register()', function (): void {
+	// The registry itself does not throw on collision — it overwrites
+	// the existing entry. The collision policy lives one layer up in
+	// `IconSetUploader::store()` / the admin controller, exercised in
+	// the HTTP test above. Verifying the registry's actual overwrite
+	// semantics keeps the layering documented.
+	$registry = app( UploadedIconSetRegistry::class );
+	$registry->register( new UploadedIconSet( 'dup', 'First', '2026-01-01T00:00:00Z' ) );
+	$registry->register( new UploadedIconSet( 'dup', 'Second', '2026-01-02T00:00:00Z' ) );
+
+	$entries = $registry->all();
+	expect( $entries )->toHaveCount( 1 )
+		->and( $entries[0]->label )->toBe( 'Second' );
+} );
+
+// -------------------------------------------------------------------
+// Deleted-set fallback: block renders placeholder for a vanished set
+// -------------------------------------------------------------------
+
+it( 'renders a placeholder when the referenced icon set has been deleted', function (): void {
+	$base = e2eRegisterBundledSet( 'gone', [
+		'pin' => '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M0 0"/></svg>',
+	] );
+
+	$resolver = new IconSvgResolver( [ 'gone' => $base ] );
+	$block    = new IconBlock( new SvgSanitizer(), $resolver );
+
+	// Sanity: while the set exists, the resolver inlines the SVG.
+	$html = $block->render( [ 'iconRef' => [ 'set' => 'gone', 'name' => 'pin' ] ] );
+	expect( $html )->toContain( '<svg' )
+		->and( $html )->toContain( 'data-icon-set="gone"' );
+
+	// Now tear the set down behind the resolver's back, mimicking an
+	// admin DELETE that happened after the post was authored.
+	@unlink( $base . '/pin.svg' );
+	rmdir( $base );
+
+	$html = $block->render( [ 'iconRef' => [ 'set' => 'gone', 'name' => 'pin' ] ] );
+
+	expect( $html )->toContain( 'wp-block-artisanpack-icon__placeholder' )
+		->and( $html )->not->toContain( '<svg' )
+		// The data-* carriers are kept so a future re-upload of the
+		// same prefix re-resolves the icon without losing the
+		// reference.
+		->and( $html )->toContain( 'data-icon-set="gone"' )
+		->and( $html )->toContain( 'data-icon-name="pin"' );
+} );
+
+it( 'renders a placeholder when no resolver knows the requested set at all', function (): void {
+	$block = new IconBlock( new SvgSanitizer() );
+
+	$html = $block->render( [ 'iconRef' => [ 'set' => 'never-registered', 'name' => 'whatever' ] ] );
+
+	expect( $html )->toContain( 'wp-block-artisanpack-icon__placeholder' )
+		->and( $html )->not->toContain( '<svg' );
+} );
+
+// -------------------------------------------------------------------
+// Decorative + link a11y combinations
+// -------------------------------------------------------------------
+
+it( 'wraps a non-decorative linked icon with the rendered anchor', function (): void {
+	$base     = e2eRegisterBundledSet( 'fab', [
+		'github' => '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M0 0"/></svg>',
+	] );
+	$resolver = new IconSvgResolver( [ 'fab' => $base ] );
+	$block    = new IconBlock( new SvgSanitizer(), $resolver );
+
+	$html = $block->render( [
+		'iconRef'    => [ 'set' => 'fab', 'name' => 'github' ],
+		'link'       => 'https://example.com',
+		'linkTarget' => '_blank',
+		'linkRel'    => 'nofollow',
+		'ariaLabel'  => 'Visit on GitHub',
+	] );
+
+	expect( $html )->toContain( '<a href="https://example.com"' )
+		->and( $html )->toContain( 'target="_blank"' )
+		->and( $html )->toContain( 'noopener' )
+		->and( $html )->toContain( 'noreferrer' )
+		->and( $html )->toContain( 'nofollow' )
+		->and( $html )->toContain( 'aria-label="Visit on GitHub"' );
+} );
+
+it( 'still emits aria-hidden on a decorative linked icon — the editor surfaces the conflict warning', function (): void {
+	$base     = e2eRegisterBundledSet( 'fab', [
+		'github' => '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M0 0"/></svg>',
+	] );
+	$resolver = new IconSvgResolver( [ 'fab' => $base ] );
+	$block    = new IconBlock( new SvgSanitizer(), $resolver );
+
+	// Decorative + linked + no aria-label is a known a11y conflict —
+	// `edit.tsx` surfaces an inline warning so the author fixes it
+	// before save. The server still emits exactly what was saved so
+	// the editor warning doesn't go away post-render.
+	$html = $block->render( [
+		'iconRef'      => [ 'set' => 'fab', 'name' => 'github' ],
+		'link'         => 'https://example.com',
+		'isDecorative' => true,
+	] );
+
+	expect( $html )->toContain( '<a href="https://example.com"' )
+		->and( $html )->toContain( 'aria-hidden="true"' )
+		->and( $html )->not->toContain( 'aria-label=' );
+} );
+
+it( 'lets a decorative + linked combo recover when an aria-label is supplied', function (): void {
+	$base     = e2eRegisterBundledSet( 'fab', [
+		'github' => '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M0 0"/></svg>',
+	] );
+	$resolver = new IconSvgResolver( [ 'fab' => $base ] );
+	$block    = new IconBlock( new SvgSanitizer(), $resolver );
+
+	$html = $block->render( [
+		'iconRef'      => [ 'set' => 'fab', 'name' => 'github' ],
+		'link'         => 'https://example.com',
+		'isDecorative' => true,
+		'ariaLabel'    => 'Visit on GitHub',
+	] );
+
+	// `aria-hidden` wins on the body (decorative is authoritative) but
+	// the link itself stays reachable thanks to the anchor markup —
+	// pairing this with the supplied label in the editor warning
+	// satisfies the a11y rule.
+	expect( $html )->toContain( '<a href="https://example.com"' )
+		->and( $html )->toContain( 'aria-hidden="true"' )
+		->and( $html )->not->toContain( 'aria-label="Visit on GitHub"' );
+} );
+
+// -------------------------------------------------------------------
+// `ap.icons.register-icon-sets` filter wires bundled sets at boot
+// -------------------------------------------------------------------
+
+it( 'collects bundled FA Free sets via the ap.icons.register-icon-sets filter', function (): void {
+	$registrationClass = 'ArtisanPackUI\\Icons\\Registries\\IconSetRegistration';
+
+	// The icons package is a `suggest`-level dependency. When it's not
+	// installed in the test env, the service provider's class_exists()
+	// gate cleanly skips registration — so do the same here.
+	if ( ! class_exists( $registrationClass ) || ! function_exists( 'applyFilters' ) ) {
+		test()->markTestSkipped( 'artisanpack-ui/icons is not installed in this test environment' );
+	}
+
+	$registry = applyFilters( 'ap.icons.register-icon-sets', new $registrationClass() );
+
+	$sets = $registry->getSets();
+
+	expect( $sets )->toHaveKeys( [ 'fas', 'far', 'fab' ] );
+} );

--- a/tests/Feature/VisualEditor/IconBlockEndToEndTest.php
+++ b/tests/Feature/VisualEditor/IconBlockEndToEndTest.php
@@ -416,7 +416,9 @@ it( 'still emits aria-hidden on a decorative linked icon — the editor surfaces
 	// Decorative + linked + no aria-label is a known a11y conflict —
 	// `edit.tsx` surfaces an inline warning so the author fixes it
 	// before save. The server still emits exactly what was saved so
-	// the editor warning doesn't go away post-render.
+	// the editor warning doesn't go away post-render. The `<a>` has
+	// no accessible name in this scenario — which is precisely what
+	// the warning exists to call out.
 	$html = $block->render( [
 		'iconRef'      => [ 'set' => 'fab', 'name' => 'github' ],
 		'link'         => 'https://example.com',
@@ -442,13 +444,13 @@ it( 'lets a decorative + linked combo recover when an aria-label is supplied', f
 		'ariaLabel'    => 'Visit on GitHub',
 	] );
 
-	// `aria-hidden` wins on the body (decorative is authoritative) but
-	// the link itself stays reachable thanks to the anchor markup —
-	// pairing this with the supplied label in the editor warning
-	// satisfies the a11y rule.
-	expect( $html )->toContain( '<a href="https://example.com"' )
-		->and( $html )->toContain( 'aria-hidden="true"' )
-		->and( $html )->not->toContain( 'aria-label="Visit on GitHub"' );
+	// `aria-hidden` stays on the body span (the SVG is decorative), but
+	// the supplied ariaLabel is promoted onto the `<a>` so the link
+	// itself has an accessible name. Without that promotion the link
+	// would still read as unlabeled to screen readers — which is the
+	// scenario the editor warning is supposed to prevent.
+	expect( $html )->toMatch( '/<a href="https:\/\/example\.com"[^>]*aria-label="Visit on GitHub"/' )
+		->and( $html )->toContain( 'aria-hidden="true"' );
 } );
 
 // -------------------------------------------------------------------
@@ -463,6 +465,19 @@ it( 'collects bundled FA Free sets via the ap.icons.register-icon-sets filter', 
 	// gate cleanly skips registration — so do the same here.
 	if ( ! class_exists( $registrationClass ) || ! function_exists( 'applyFilters' ) ) {
 		test()->markTestSkipped( 'artisanpack-ui/icons is not installed in this test environment' );
+	}
+
+	// The FA Free SVGs are mirrored into `resources/icons/font-awesome/`
+	// by `scripts/sync-fa-icons.mjs` as the `npm run build` prebuild
+	// step. CI's PHP job doesn't run that step (the SVGs ship only in
+	// the published package or after `npm run build`), so
+	// `FontAwesomeFreeIconSets::discover()` returns an empty array
+	// there and the filter callback no-ops. Skip in that case rather
+	// than failing on a sync that lives downstream of `composer
+	// install`.
+	$faFreeDir = __DIR__ . '/../../../resources/icons/font-awesome';
+	if ( ! is_dir( $faFreeDir . '/fas' ) ) {
+		test()->markTestSkipped( 'FA Free SVGs not synced — run `npm run sync:fa-icons` first' );
 	}
 
 	$registry = applyFilters( 'ap.icons.register-icon-sets', new $registrationClass() );

--- a/tests/Unit/VisualEditor/Blocks/Icon/IconBlockTest.php
+++ b/tests/Unit/VisualEditor/Blocks/Icon/IconBlockTest.php
@@ -216,6 +216,22 @@ it( 'promotes ariaLabel onto the <a> when the icon is decorative + linked', func
 		->and( $html )->toContain( 'aria-hidden="true"' );
 } );
 
+it( 'treats a whitespace-only ariaLabel as missing on a decorative + linked icon', function () {
+	// `"   "` and an empty string are equivalently inaccessible — both
+	// leave the anchor unlabeled. Treating them the same way keeps the
+	// editor warning honest: if the author has to put a real label
+	// somewhere, whitespace doesn't count.
+	$html = test()->block->render( [
+		'iconRef'      => [ 'set' => 'fab', 'name' => 'github' ],
+		'link'         => 'https://example.com',
+		'isDecorative' => true,
+		'ariaLabel'    => '   ',
+	] );
+
+	expect( $html )->toContain( '<a href="https://example.com"' )
+		->and( $html )->not->toContain( 'aria-label=' );
+} );
+
 it( 'leaves the <a> aria-label off when the icon is decorative + linked + has NO ariaLabel', function () {
 	// Without an ariaLabel the editor-side warning still fires;
 	// the server preserves the missing label so the warning state

--- a/tests/Unit/VisualEditor/Blocks/Icon/IconBlockTest.php
+++ b/tests/Unit/VisualEditor/Blocks/Icon/IconBlockTest.php
@@ -218,7 +218,7 @@ it( 'rejects out-of-range rotations', function () {
 } );
 
 it( 'rejects invalid size units', function () {
-	$normalized = test()->block->validateAttrs( [ 'sizeUnit' => 'vh' ] );
+	$normalized = test()->block->validateAttrs( [ 'sizeUnit' => 'pt' ] );
 
 	expect( $normalized['sizeUnit'] )->toBe( 'px' );
 } );
@@ -299,4 +299,311 @@ it( 'exposes ariaLabel + title via searchableText', function () {
 
 	expect( $text )->toContain( 'GitHub Profile' )
 		->and( $text )->toContain( 'Visit on GitHub' );
+} );
+
+// --- WP `attributes.style` envelope (color/border/spacing) ---
+
+it( 'applies text color from the WP style envelope', function () {
+	$html = test()->block->render( [
+		'iconRef' => [ 'set' => 'fab', 'name' => 'github' ],
+		'style'   => [ 'color' => [ 'text' => '#abc123' ] ],
+	] );
+
+	expect( $html )->toContain( 'color: #abc123' );
+} );
+
+it( 'applies background color from the WP style envelope', function () {
+	$html = test()->block->render( [
+		'iconRef' => [ 'set' => 'fab', 'name' => 'github' ],
+		'style'   => [ 'color' => [ 'background' => '#facade' ] ],
+	] );
+
+	expect( $html )->toContain( 'background-color: #facade' );
+} );
+
+it( 'lets the WP style envelope override the legacy top-level color', function () {
+	$html = test()->block->render( [
+		'iconRef' => [ 'set' => 'fab', 'name' => 'github' ],
+		'color'   => '#111111',
+		'style'   => [ 'color' => [ 'text' => '#222222' ] ],
+	] );
+
+	expect( $html )->toContain( 'color: #222222' )
+		->and( $html )->not->toContain( 'color: #111111' );
+} );
+
+it( 'falls back to the legacy top-level color when WP style is empty', function () {
+	$html = test()->block->render( [
+		'iconRef'         => [ 'set' => 'fab', 'name' => 'github' ],
+		'color'           => '#cafe00',
+		'backgroundColor' => '#beef00',
+	] );
+
+	expect( $html )->toContain( 'color: #cafe00' )
+		->and( $html )->toContain( 'background-color: #beef00' );
+} );
+
+it( 'applies uniform border declarations to the body span', function () {
+	$html = test()->block->render( [
+		'iconRef' => [ 'set' => 'fab', 'name' => 'github' ],
+		'style'   => [
+			'border' => [
+				'color'  => '#000000',
+				'style'  => 'solid',
+				'width'  => '2px',
+				'radius' => '6px',
+			],
+		],
+	] );
+
+	expect( $html )->toContain( 'border-color: #000000' )
+		->and( $html )->toContain( 'border-style: solid' )
+		->and( $html )->toContain( 'border-width: 2px' )
+		->and( $html )->toContain( 'border-radius: 6px' );
+} );
+
+it( 'applies per-corner radius from a radius object', function () {
+	$html = test()->block->render( [
+		'iconRef' => [ 'set' => 'fab', 'name' => 'github' ],
+		'style'   => [
+			'border' => [
+				'radius' => [
+					'topLeft'     => '1px',
+					'topRight'    => '2px',
+					'bottomRight' => '3px',
+					'bottomLeft'  => '4px',
+				],
+			],
+		],
+	] );
+
+	expect( $html )->toContain( 'border-top-left-radius: 1px' )
+		->and( $html )->toContain( 'border-top-right-radius: 2px' )
+		->and( $html )->toContain( 'border-bottom-right-radius: 3px' )
+		->and( $html )->toContain( 'border-bottom-left-radius: 4px' );
+} );
+
+it( 'applies padding shorthand on the body span', function () {
+	$html = test()->block->render( [
+		'iconRef' => [ 'set' => 'fab', 'name' => 'github' ],
+		'style'   => [ 'spacing' => [ 'padding' => '8px' ] ],
+	] );
+
+	expect( $html )->toContain( 'padding: 8px' );
+} );
+
+it( 'applies per-side padding on the body span', function () {
+	$html = test()->block->render( [
+		'iconRef' => [ 'set' => 'fab', 'name' => 'github' ],
+		'style'   => [
+			'spacing' => [
+				'padding' => [
+					'top'    => '1px',
+					'right'  => '2px',
+					'bottom' => '3px',
+					'left'   => '4px',
+				],
+			],
+		],
+	] );
+
+	expect( $html )->toContain( 'padding-top: 1px' )
+		->and( $html )->toContain( 'padding-right: 2px' )
+		->and( $html )->toContain( 'padding-bottom: 3px' )
+		->and( $html )->toContain( 'padding-left: 4px' );
+} );
+
+it( 'applies margin to the wrapper, not the body span', function () {
+	$html = test()->block->render( [
+		'iconRef' => [ 'set' => 'fab', 'name' => 'github' ],
+		'style'   => [ 'spacing' => [ 'margin' => '12px' ] ],
+	] );
+
+	expect( $html )->toMatch( '/<div class="wp-block-artisanpack-icon" style="margin: 12px;">/' );
+} );
+
+it( 'omits the wrapper style attribute when no wrapper-level styles apply', function () {
+	$html = test()->block->render( [
+		'iconRef' => [ 'set' => 'fab', 'name' => 'github' ],
+	] );
+
+	expect( $html )->toMatch( '/<div class="wp-block-artisanpack-icon">/' );
+} );
+
+it( 'drops style values that fail the safe-CSS allowlist', function () {
+	$html = test()->block->render( [
+		'iconRef' => [ 'set' => 'fab', 'name' => 'github' ],
+		'style'   => [
+			'color'  => [ 'text' => 'expression(alert(1))' ],
+			'border' => [ 'width' => '2px; background: url(evil)' ],
+			'spacing'=> [ 'padding' => "8px;</style><script>alert('xss')</script>" ],
+		],
+	] );
+
+	expect( $html )->not->toContain( 'expression(' )
+		->and( $html )->not->toContain( 'url(evil)' )
+		->and( $html )->not->toContain( '<script' )
+		->and( $html )->not->toContain( '</style' );
+} );
+
+// --- width / height override ---
+
+it( 'uses size for both width and height when no override is set', function () {
+	$html = test()->block->render( [
+		'iconRef' => [ 'set' => 'fab', 'name' => 'github' ],
+		'size'    => 48,
+	] );
+
+	expect( $html )->toContain( 'width: 48px' )
+		->and( $html )->toContain( 'height: 48px' );
+} );
+
+it( 'overrides the width axis when a width attribute is set', function () {
+	$html = test()->block->render( [
+		'iconRef' => [ 'set' => 'fab', 'name' => 'github' ],
+		'size'    => 32,
+		'width'   => 64,
+	] );
+
+	expect( $html )->toContain( 'width: 64px' )
+		->and( $html )->toContain( 'height: 32px' );
+} );
+
+it( 'inherits sizeUnit for width when widthUnit is null', function () {
+	$attrs = test()->block->validateAttrs( [
+		'iconRef'  => [ 'set' => 'fab', 'name' => 'github' ],
+		'size'     => 32,
+		'sizeUnit' => 'rem',
+		'width'    => 4,
+	] );
+
+	expect( $attrs['width'] )->toBe( 4.0 )
+		->and( $attrs['widthUnit'] )->toBe( 'rem' );
+} );
+
+it( 'accepts new sizeUnit values (%, vw, vh)', function () {
+	$normalized = test()->block->validateAttrs( [ 'sizeUnit' => 'vh' ] );
+	expect( $normalized['sizeUnit'] )->toBe( 'vh' );
+
+	$normalized = test()->block->validateAttrs( [ 'sizeUnit' => '%' ] );
+	expect( $normalized['sizeUnit'] )->toBe( '%' );
+} );
+
+it( 'clamps explicit width and height to the 1..1024 range', function () {
+	$normalized = test()->block->validateAttrs( [ 'width' => -10, 'height' => 99999 ] );
+	expect( $normalized['width'] )->toBe( 1.0 )
+		->and( $normalized['height'] )->toBe( 1024.0 );
+} );
+
+it( 'normalizes missing width/height back to null', function () {
+	$normalized = test()->block->validateAttrs( [] );
+	expect( $normalized['width'] )->toBeNull()
+		->and( $normalized['height'] )->toBeNull();
+} );
+
+// --- iconColor + palette-class wiring ---
+
+it( 'applies the explicit iconColor to the body span', function () {
+	$html = test()->block->render( [
+		'iconRef'   => [ 'set' => 'fab', 'name' => 'github' ],
+		'iconColor' => '#abc123',
+	] );
+
+	expect( $html )->toContain( 'color: #abc123' );
+} );
+
+it( 'lets iconColor override the WP style.color.text fallback', function () {
+	$html = test()->block->render( [
+		'iconRef'   => [ 'set' => 'fab', 'name' => 'github' ],
+		'iconColor' => '#aaaaaa',
+		'style'     => [ 'color' => [ 'text' => '#bbbbbb' ] ],
+	] );
+
+	expect( $html )->toContain( 'color: #aaaaaa' )
+		->and( $html )->not->toContain( 'color: #bbbbbb' );
+} );
+
+it( 'falls back to style.color.text when iconColor is unset', function () {
+	$html = test()->block->render( [
+		'iconRef' => [ 'set' => 'fab', 'name' => 'github' ],
+		'style'   => [ 'color' => [ 'text' => '#cccccc' ] ],
+	] );
+
+	expect( $html )->toContain( 'color: #cccccc' );
+} );
+
+it( 'emits has-X-background-color + has-background for palette background slugs', function () {
+	$html = test()->block->render( [
+		'iconRef'         => [ 'set' => 'fab', 'name' => 'github' ],
+		'backgroundColor' => 'primary',
+	] );
+
+	expect( $html )->toContain( 'has-primary-background-color' )
+		->and( $html )->toContain( 'has-background' );
+} );
+
+it( 'emits has-X-border-color + has-border-color for palette border slugs', function () {
+	$html = test()->block->render( [
+		'iconRef'     => [ 'set' => 'fab', 'name' => 'github' ],
+		'borderColor' => 'accent',
+	] );
+
+	expect( $html )->toContain( 'has-accent-border-color' )
+		->and( $html )->toContain( 'has-border-color' );
+} );
+
+it( 'does NOT emit a has-X class when backgroundColor carries a hex value', function () {
+	$html = test()->block->render( [
+		'iconRef'         => [ 'set' => 'fab', 'name' => 'github' ],
+		'backgroundColor' => '#abc123',
+	] );
+
+	// `#abc123` falls through to the inline background path instead of
+	// producing a bogus `has-#abc123-background-color` class.
+	expect( $html )->not->toContain( 'has-#abc123' )
+		->and( $html )->toContain( 'background-color: #abc123' );
+} );
+
+it( 'puts WP-managed background/border/padding/margin on the wrapper', function () {
+	$html = test()->block->render( [
+		'iconRef' => [ 'set' => 'fab', 'name' => 'github' ],
+		'style'   => [
+			'color'   => [ 'background' => '#facade' ],
+			'border'  => [ 'color' => '#000000', 'width' => '2px' ],
+			'spacing' => [
+				'padding' => '8px',
+				'margin'  => '12px',
+			],
+		],
+	] );
+
+	// Wrapper carries background/border/padding/margin; the body span
+	// no longer does. Pulling the wrapper's `style="…"` attribute out
+	// and asserting on each declaration in isolation keeps the test
+	// resilient to incidental ordering / spacing changes inside the
+	// inline style string.
+	expect( $html )->toContain( 'wp-block-artisanpack-icon' )
+		->and( $html )->toContain( 'has-background' )
+		->and( $html )->toContain( 'has-border-color' );
+
+	preg_match( '/<div\b[^>]*\bstyle="([^"]*)"/', $html, $wrapperMatch );
+	$wrapperStyle = $wrapperMatch[1] ?? '';
+
+	expect( $wrapperStyle )->toContain( 'background-color: #facade' )
+		->and( $wrapperStyle )->toContain( 'border-color: #000000' )
+		->and( $wrapperStyle )->toContain( 'border-width: 2px' )
+		->and( $wrapperStyle )->toContain( 'padding: 8px' )
+		->and( $wrapperStyle )->toContain( 'margin: 12px' );
+
+	// And the body span's style does NOT pick up any of those — a
+	// future regression that moves them back onto the body span gets
+	// caught here.
+	preg_match( '/<span\b[^>]*class="wp-block-artisanpack-icon__ref"[^>]*\bstyle="([^"]*)"/', $html, $bodyMatch );
+	$bodyStyle = $bodyMatch[1] ?? '';
+
+	expect( $bodyStyle )->not->toContain( 'background-color' )
+		->and( $bodyStyle )->not->toContain( 'border-color' )
+		->and( $bodyStyle )->not->toContain( 'border-width' )
+		->and( $bodyStyle )->not->toContain( 'padding' )
+		->and( $bodyStyle )->not->toContain( 'margin' );
 } );

--- a/tests/Unit/VisualEditor/Blocks/Icon/IconBlockTest.php
+++ b/tests/Unit/VisualEditor/Blocks/Icon/IconBlockTest.php
@@ -200,6 +200,50 @@ it( 'emits aria-label for accessible non-decorative icons', function () {
 	expect( $html )->toContain( 'aria-label="GitHub Profile"' );
 } );
 
+it( 'promotes ariaLabel onto the <a> when the icon is decorative + linked', function () {
+	// The body span is `aria-hidden` (decorative), so the supplied
+	// ariaLabel can't live there without contradicting the hide. Pushing
+	// it onto the anchor keeps the link reachable + labeled for screen
+	// readers.
+	$html = test()->block->render( [
+		'iconRef'      => [ 'set' => 'fab', 'name' => 'github' ],
+		'link'         => 'https://example.com',
+		'isDecorative' => true,
+		'ariaLabel'    => 'GitHub Profile',
+	] );
+
+	expect( $html )->toMatch( '/<a href="https:\/\/example\.com"[^>]*aria-label="GitHub Profile"/' )
+		->and( $html )->toContain( 'aria-hidden="true"' );
+} );
+
+it( 'leaves the <a> aria-label off when the icon is decorative + linked + has NO ariaLabel', function () {
+	// Without an ariaLabel the editor-side warning still fires;
+	// the server preserves the missing label so the warning state
+	// doesn't silently go away post-render.
+	$html = test()->block->render( [
+		'iconRef'      => [ 'set' => 'fab', 'name' => 'github' ],
+		'link'         => 'https://example.com',
+		'isDecorative' => true,
+	] );
+
+	expect( $html )->toContain( '<a href="https://example.com"' )
+		->and( $html )->not->toContain( 'aria-label=' );
+} );
+
+it( 'leaves the <a> aria-label off when the icon is non-decorative + linked + has ariaLabel', function () {
+	// In the non-decorative branch the body span already carries the
+	// aria-label, so doubling it on the anchor would be redundant.
+	$html = test()->block->render( [
+		'iconRef'   => [ 'set' => 'fab', 'name' => 'github' ],
+		'link'      => 'https://example.com',
+		'ariaLabel' => 'GitHub Profile',
+	] );
+
+	expect( $html )->toContain( '<a href="https://example.com"' )
+		->and( $html )->not->toMatch( '/<a [^>]*aria-label="GitHub Profile"/' )
+		->and( $html )->toMatch( '/<span [^>]*aria-label="GitHub Profile"/' );
+} );
+
 it( 'composes a transform from rotation + flip', function () {
 	$html = test()->block->render( [
 		'iconRef'  => [ 'set' => 'fab', 'name' => 'github' ],
@@ -484,6 +528,9 @@ it( 'inherits sizeUnit for width when widthUnit is null', function () {
 it( 'accepts new sizeUnit values (%, vw, vh)', function () {
 	$normalized = test()->block->validateAttrs( [ 'sizeUnit' => 'vh' ] );
 	expect( $normalized['sizeUnit'] )->toBe( 'vh' );
+
+	$normalized = test()->block->validateAttrs( [ 'sizeUnit' => 'vw' ] );
+	expect( $normalized['sizeUnit'] )->toBe( 'vw' );
 
 	$normalized = test()->block->validateAttrs( [ 'sizeUnit' => '%' ] );
 	expect( $normalized['sizeUnit'] )->toBe( '%' );


### PR DESCRIPTION
## Description

Phase 7 wrap-up for the Icon Block (parent #494). Closes #558.

Three threads land together since the block is being finalized for v1.1:

1. **Phase 7 scope** — cross-phase Pest + Vitest coverage, plus a dedicated docs page.
2. **Style fix** — the inspector's standard color / border / spacing controls now actually apply to the rendered block.
3. **Dimensions** — per-axis width/height overrides on top of the uniform `size`, plus a dedicated Icon color field that maps to the SVG fill (matching the ndiego reference Icon Block).

**Closes:** #558

## Type of Change

- [x] New feature (adds new functionality)
- [x] Bug fix (fixes an issue)
- [x] Enhancement (improves existing functionality)
- [x] Documentation update

## Related Issue

**Issue:** #558 (Parent: #494)

## Motivation and Context

`#558` is the final phase of the Icon Block. The plan calls for cross-phase tests + docs as the polish layer that ships before v1.1.

While wiring the e2e tests and verifying the canvas behaviour, two block-finalization issues surfaced:

- WP style controls (background, border, padding, margin) were silently no-op'ing because the block declared `__experimentalSkipSerialization: true` for every support and never read the styles back. Author selections produced zero visible effect on the canvas or the front end.
- Authors had no way to set the icon SVG fill independently of the background tile, and no way to size width and height independently.

## Changes Made

### Phase 7 — tests + docs (#558)

- `tests/Feature/VisualEditor/IconBlockEndToEndTest.php` — 13 cross-phase tests covering block registration, picker search across bundled + uploaded sets, SVG sanitization (block paste + admin upload), prefix-collision integration, deleted-set placeholder fallback, decorative + link a11y combos, and the FA Free `ap.icons.register-icon-sets` filter.
- `docs/blocks/Icon-Block.md` — dedicated docs page with block usage walkthrough, developer recipe for `ap.icons.register-icon-sets`, admin upload walkthrough, and FA Pro guidance (BYO SVGs, no token storage).
- `README.md`, `docs/blocks.md`, `docs/home.md`, `CHANGELOG.md` — entry-point updates so authors can find the new block.

### Style fix — WP inspector controls now apply

- Dropped `__experimentalSkipSerialization: true` from the `color`, `__experimentalBorder`, and `spacing` supports in `block.json`. WordPress now serializes the styles onto the wrapper via `useBlockProps()`.
- `IconBlock::render()` (server side) mirrors the same envelope — wrapper inline style for hex values, `has-{slug}-background-color` / `has-{slug}-border-color` classes for palette picks. Legacy top-level `backgroundColor` is kept as a fallback for posts saved before the fix.

### Icon color field

- New top-level `iconColor` attribute (string).
- Custom `Sidebar → Color → Icon` panel (via `PanelColorSettings`) writes to `iconColor`.
- `computeIconStyle()` applies `iconColor` as `color` on the body span. The bundled SVGs ship with `fill: currentcolor`, so the picked color flows through to the icon's fill.
- The standard WP text-color control is disabled (`supports.color.text: false`) to avoid a confusing duplicate UI.

### Per-axis width/height overrides

- New `width`, `height`, `widthUnit`, `heightUnit` attributes (all optional, default `null`).
- Inspector adds a `Dimensions` panel:
  - `NumberControl`-backed Size (live updates on every keystroke).
  - Width / Height `UnitControl`s with `px` / `em` / `rem` / `%` / `vw` / `vh`. Clearing either field falls back to `size`.
- `normalizeAttributes()` materializes the effective width/height for downstream helpers.
- `IconBlock::validateAttrs()` clamps to `1..1024` and rejects bad units server-side.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS 25.5.0
- Browser: Safari (Laravel Herd dev app)
- PHP Version: 8.4.3
- Project Version: v1.1 (release branch)

**Tests Performed:**
1. Inserted the Icon block, picked a Font Awesome icon, and confirmed the canvas renders inline SVG.
2. `Sidebar → Color → Icon` — picked palette and custom hex; SVG fill updates live.
3. `Sidebar → Color → Background` — palette + hex both apply to wrapper tile.
4. `Sidebar → Border` — color/width/style/radius all reach the wrapper.
5. `Sidebar → Dimensions` — Size/Width/Height update the canvas as each key is typed (no blur required).
6. Saved post + viewed on public site — colors, border, spacing, dimensions all match the canvas.
7. Decorative toggle + link with no aria-label — inline a11y warning still surfaces.

## Accessibility Tests Run

- [x] Keyboard navigation tested — inspector controls reachable; picker modal traps focus.
- [ ] Screen reader tested — not re-tested for this PR (Phase 1–6 covered the picker / dialog / placeholder a11y; this PR only changes inline styles).
- [x] Color contrast verified — the Icon color UI inherits WP's `PanelColorSettings` which renders WP's contrast hint chip.
- [x] ARIA labels checked — decorative + linked combinations re-tested in the e2e suite (`IconBlockEndToEndTest`).

**Details:**

The decorative + link a11y warning behavior in `edit.tsx` is preserved unchanged. Three new e2e tests in `IconBlockEndToEndTest.php` exercise the three decorative + link permutations end-to-end.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:**

- New: `tests/Feature/VisualEditor/IconBlockEndToEndTest.php` — 13 cross-phase integration tests.
- Updated: `tests/Unit/VisualEditor/Blocks/Icon/IconBlockTest.php` — +14 tests covering iconColor, palette-slug classes, wrapper-not-body-span style placement, and per-axis width/height.
- Updated: `resources/js/visual-editor/blocks/icon/__tests__/utils.test.ts` — refreshed for the new normalized shape + iconColor precedence.

Full suites pass locally: 1,013 Pest assertions (2 pre-existing skips for the icons package not being installed in CI), 44 Vitest tests in the icon block tree.

## Documentation

- [x] Inline code documentation added
- [x] README updated
- [x] Wiki updated
- [ ] API documentation updated — N/A (no new HTTP endpoints).

**Documentation details:**

- New: `docs/blocks/Icon-Block.md` (block usage, dev registration recipe, admin upload walkthrough, FA Pro BYO guidance).
- Updated: `README.md`, `docs/blocks.md`, `docs/home.md` — entry points reference the new doc.
- Updated: `CHANGELOG.md` — `[Unreleased]` Added + Fixed sections.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted (no `vendor/bin/pint` in this package — JS passes `tsc --noEmit` for the icon block files)
- [x] Accessibility tests completed
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Icon block: independent width/height controls, dedicated Icon color picker, SVG paste/upload with server-side sanitization, and bundled Font Awesome Free set.

* **Bug Fixes**
  * Wrapper style controls (background/border/padding/margin) now serialize and apply correctly in editor and front-end.
  * Linked decorative icons now surface accessible names on anchors.

* **Documentation**
  * Added full Icon Block docs and updated README and block catalog.

* **Tests**
  * Added extensive unit and end-to-end tests covering icon rendering, uploads, sanitization, and APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->