### PR TITLE
feat: CW0 pilot — port crosswinds-blocks/breadcrumbs as artisanpack/breadcrumbs

### DIFF
--- a/packages/renderer-parity.json
+++ b/packages/renderer-parity.json
@@ -55,6 +55,7 @@
         "core/post-terms",
         "core/read-more",
         "core/term-description",
+        "artisanpack/breadcrumbs",
         "artisanpack/callout",
         "artisanpack/paragraph",
         "artisanpack/heading",

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/breadcrumbs.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/breadcrumbs.blade.php
@@ -69,7 +69,7 @@
 							<span @if ( $breadcrumbsSchema ) itemprop="name"@endif>{{ $item['label'] }}</span>
 						</a>
 					@else
-						<span class="ap-breadcrumbs__current" @if ( $item['current'] ) aria-current="page"@endif @if ( $breadcrumbsSchema ) itemprop="name"@endif>{{ $item['label'] }}</span>
+						<span @if ( $item['current'] ) class="ap-breadcrumbs__current" aria-current="page"@endif @if ( $breadcrumbsSchema ) itemprop="name"@endif>{{ $item['label'] }}</span>
 					@endif
 					@if ( $breadcrumbsSchema )
 						<meta itemprop="position" content="{{ $position }}" />

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/breadcrumbs.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/breadcrumbs.blade.php
@@ -1,0 +1,86 @@
+@php
+	use ArtisanPackUI\VisualEditorRendererBlade\Support\BlockSupports;
+	use ArtisanPackUI\VisualEditorRendererBlade\Support\UrlSanitizer;
+
+	$validSeparators = [ 'arrow-right', 'chevron-right', 'chevron-double-right', 'long-arrow-right' ];
+
+	$separatorIcon = (string) ( $attributes['separatorIcon'] ?? 'chevron-right' );
+
+	if ( ! in_array( $separatorIcon, $validSeparators, true ) ) {
+		$separatorIcon = 'chevron-right';
+	}
+
+	$separatorPaths = [
+		'arrow-right'          => 'M5 12h14m-6-6 6 6-6 6',
+		'chevron-right'        => 'm9 6 6 6-6 6',
+		'chevron-double-right' => 'm6 6 6 6-6 6m6-12 6 6-6 6',
+		'long-arrow-right'     => 'M3 12h17m-5-5 5 5-5 5',
+	];
+	$separatorPath = $separatorPaths[ $separatorIcon ];
+
+	$breadcrumbsSchema = (bool) ( $attributes['breadcrumbsSchema'] ?? true );
+
+	$trailRaw = $attributes['_resolvedTrail'] ?? [];
+	$trail    = [];
+
+	if ( is_array( $trailRaw ) ) {
+		foreach ( $trailRaw as $entry ) {
+			if ( ! is_array( $entry ) ) {
+				continue;
+			}
+
+			$label = (string) ( $entry['label'] ?? '' );
+
+			if ( '' === $label ) {
+				continue;
+			}
+
+			$rawUrl       = isset( $entry['url'] ) ? (string) $entry['url'] : '';
+			$sanitizedUrl = '' === $rawUrl ? '' : UrlSanitizer::safe( $rawUrl );
+
+			$trail[] = [
+				'label'   => $label,
+				'url'     => '' === $sanitizedUrl ? null : $sanitizedUrl,
+				'current' => ! empty( $entry['current'] ),
+			];
+		}
+	}
+
+	$ariaLabel = (string) ( $attributes['ariaLabel'] ?? 'Breadcrumb' );
+
+	$baseClasses = [ 'ap-breadcrumbs' ];
+
+	$listAttrs     = $breadcrumbsSchema ? ' itemscope itemtype="https://schema.org/BreadcrumbList"' : '';
+	$listItemAttrs = $breadcrumbsSchema ? ' itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem"' : '';
+@endphp
+<nav{!! BlockSupports::wrapperAttrs( $attributes, $baseClasses ) !!} aria-label="{{ $ariaLabel }}">
+	@if ( empty( $trail ) )
+		<ol class="ap-breadcrumbs__list"{!! $listAttrs !!}></ol>
+	@else
+		<ol class="ap-breadcrumbs__list"{!! $listAttrs !!}>
+			@foreach ( $trail as $index => $item )
+				@php
+					$isLast   = $index === count( $trail ) - 1;
+					$position = $index + 1;
+				@endphp
+				<li class="ap-breadcrumbs__item"{!! $listItemAttrs !!}>
+					@if ( $item['url'] && ! $item['current'] )
+						<a class="ap-breadcrumbs__link" href="{{ $item['url'] }}"@if ( $breadcrumbsSchema ) itemprop="item"@endif>
+							<span @if ( $breadcrumbsSchema ) itemprop="name"@endif>{{ $item['label'] }}</span>
+						</a>
+					@else
+						<span class="ap-breadcrumbs__current" @if ( $item['current'] ) aria-current="page"@endif @if ( $breadcrumbsSchema ) itemprop="name"@endif>{{ $item['label'] }}</span>
+					@endif
+					@if ( $breadcrumbsSchema )
+						<meta itemprop="position" content="{{ $position }}" />
+					@endif
+					@if ( ! $isLast )
+						<span class="ap-breadcrumbs__separator" aria-hidden="true">
+							<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="1em" height="1em" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="{{ $separatorPath }}"></path></svg>
+						</span>
+					@endif
+				</li>
+			@endforeach
+		</ol>
+	@endif
+</nav>

--- a/packages/visual-editor-renderer-blade/tests/Unit/BlockRendererTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Unit/BlockRendererTest.php
@@ -526,6 +526,85 @@ it( 'falls back to safe defaults when callout severity or icon is invalid', func
 		->and( $html )->toContain( 'data-severity="info"' );
 } );
 
+it( 'renders the artisanpack/breadcrumbs block with a resolved trail and schema microdata', function () {
+	$tree = [
+		makeBlock( 'artisanpack/breadcrumbs', [
+			'separatorIcon'     => 'chevron-right',
+			'breadcrumbsSchema' => true,
+			'_resolvedTrail'    => [
+				[ 'label' => 'Home', 'url' => '/' ],
+				[ 'label' => 'Blog', 'url' => '/blog' ],
+				[ 'label' => 'Hello World', 'current' => true ],
+			],
+		] ),
+	];
+
+	$html = makeRenderer()->render( $tree );
+
+	expect( $html )->toContain( '<nav' )
+		->and( $html )->toContain( 'ap-breadcrumbs' )
+		->and( $html )->toContain( 'aria-label="Breadcrumb"' )
+		->and( $html )->toContain( 'itemtype="https://schema.org/BreadcrumbList"' )
+		->and( $html )->toContain( 'itemtype="https://schema.org/ListItem"' )
+		->and( $html )->toContain( '<a class="ap-breadcrumbs__link" href="/"' )
+		->and( $html )->toContain( '<a class="ap-breadcrumbs__link" href="/blog"' )
+		->and( $html )->toContain( 'Hello World' )
+		->and( $html )->toContain( 'aria-current="page"' )
+		->and( $html )->toContain( 'itemprop="position" content="1"' )
+		->and( $html )->toContain( 'itemprop="position" content="3"' )
+		->and( $html )->toContain( '<svg' )
+		->and( $html )->toContain( 'd="m9 6 6 6-6 6"' );
+} );
+
+it( 'falls back to safe defaults when breadcrumbs separator is invalid and omits schema when disabled', function () {
+	$tree = [
+		makeBlock( 'artisanpack/breadcrumbs', [
+			'separatorIcon'     => 'spinning-rocket',
+			'breadcrumbsSchema' => false,
+			'_resolvedTrail'    => [
+				[ 'label' => 'Home', 'url' => '/' ],
+				[ 'label' => 'Page', 'current' => true ],
+			],
+		] ),
+	];
+
+	$html = makeRenderer()->render( $tree );
+
+	expect( $html )->toContain( 'd="m9 6 6 6-6 6"' )
+		->and( $html )->not->toContain( 'schema.org/BreadcrumbList' )
+		->and( $html )->not->toContain( 'itemprop="position"' );
+} );
+
+it( 'drops unsafe URLs from breadcrumbs trail entries', function () {
+	$tree = [
+		makeBlock( 'artisanpack/breadcrumbs', [
+			'_resolvedTrail' => [
+				[ 'label' => 'Home', 'url' => '/' ],
+				[ 'label' => 'XSS', 'url' => 'javascript:alert(1)' ],
+				[ 'label' => 'Page', 'current' => true ],
+			],
+		] ),
+	];
+
+	$html = makeRenderer()->render( $tree );
+
+	expect( $html )->not->toContain( 'javascript:' )
+		->and( $html )->not->toContain( 'href="javascript:alert(1)"' )
+		->and( $html )->toContain( 'href="/"' )
+		->and( $html )->toContain( '>XSS<' );
+} );
+
+it( 'renders an empty list when breadcrumbs trail is missing', function () {
+	$tree = [
+		makeBlock( 'artisanpack/breadcrumbs', [] ),
+	];
+
+	$html = makeRenderer()->render( $tree );
+
+	expect( $html )->toContain( 'ap-breadcrumbs__list' )
+		->and( $html )->not->toContain( '<li class="ap-breadcrumbs__item' );
+} );
+
 describe( 'Keystone #50 — block-supports compilation on the rendered HTML', function (): void {
 	it( 'renders a custom background color on core/group as both class marker and inline style', function (): void {
 		$tree = [ makeBlock( 'core/group', [

--- a/packages/visual-editor-renderer-blade/tests/Unit/BlockRendererTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Unit/BlockRendererTest.php
@@ -591,7 +591,11 @@ it( 'drops unsafe URLs from breadcrumbs trail entries', function () {
 	expect( $html )->not->toContain( 'javascript:' )
 		->and( $html )->not->toContain( 'href="javascript:alert(1)"' )
 		->and( $html )->toContain( 'href="/"' )
-		->and( $html )->toContain( '>XSS<' );
+		->and( $html )->toContain( '>XSS<' )
+		// Non-current entries whose URL was sanitized away render as plain
+		// spans — never with the "current" class, which only marks the
+		// trail's final crumb.
+		->and( substr_count( $html, 'ap-breadcrumbs__current' ) )->toBe( 1 );
 } );
 
 it( 'renders an empty list when breadcrumbs trail is missing', function () {

--- a/packages/visual-editor-renderer-react/src/blocks/artisanpack/breadcrumbs.tsx
+++ b/packages/visual-editor-renderer-react/src/blocks/artisanpack/breadcrumbs.tsx
@@ -1,0 +1,167 @@
+/**
+ * React renderer for the `artisanpack/breadcrumbs` block (CW0 pilot — #496).
+ *
+ * Mirrors the Blade partial at
+ * `packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/breadcrumbs.blade.php`
+ * and the Vue renderer so every environment emits identical markup. The
+ * trail itself is server-resolved and arrives on the `_resolvedTrail`
+ * attribute as an array of `{ label, url?, current? }` entries; this
+ * renderer is responsible for the wrapper, separator chevron, and
+ * (optionally) the schema.org BreadcrumbList microdata.
+ */
+
+import type { ReactElement } from 'react';
+
+import { attrArray, attrBoolean, attrString, classList } from '../../support/attributes';
+import { safeUrl } from '../../support/urlSanitizer';
+import type { BlockRendererProps } from '../../types';
+
+type SeparatorIconName =
+    | 'arrow-right'
+    | 'chevron-right'
+    | 'chevron-double-right'
+    | 'long-arrow-right';
+
+const VALID_SEPARATORS: ReadonlyArray<SeparatorIconName> = [
+    'arrow-right',
+    'chevron-right',
+    'chevron-double-right',
+    'long-arrow-right',
+];
+
+const SEPARATOR_PATHS: Readonly<Record<SeparatorIconName, string>> = {
+    'arrow-right': 'M5 12h14m-6-6 6 6-6 6',
+    'chevron-right': 'm9 6 6 6-6 6',
+    'chevron-double-right': 'm6 6 6 6-6 6m6-12 6 6-6 6',
+    'long-arrow-right': 'M3 12h17m-5-5 5 5-5 5',
+};
+
+interface TrailItem {
+    readonly label: string;
+    readonly url: string | null;
+    readonly current: boolean;
+}
+
+function normalizeSeparator(value: unknown): SeparatorIconName {
+    const raw = attrString(value, 'chevron-right');
+    return (VALID_SEPARATORS as ReadonlyArray<string>).includes(raw)
+        ? (raw as SeparatorIconName)
+        : 'chevron-right';
+}
+
+function normalizeTrail(value: unknown): ReadonlyArray<TrailItem> {
+    const items: TrailItem[] = [];
+
+    for (const entry of attrArray(value)) {
+        if (entry === null || typeof entry !== 'object') {
+            continue;
+        }
+
+        const record = entry as Record<string, unknown>;
+        const label = attrString(record.label);
+
+        if (label === '') {
+            continue;
+        }
+
+        const sanitizedUrl = safeUrl(record.url);
+
+        items.push({
+            label,
+            url: sanitizedUrl === '' ? null : sanitizedUrl,
+            current: attrBoolean(record.current, false),
+        });
+    }
+
+    return items;
+}
+
+export function BreadcrumbsBlock({ attributes }: BlockRendererProps): ReactElement {
+    const separatorIcon = normalizeSeparator(attributes.separatorIcon);
+    const breadcrumbsSchema = attrBoolean(attributes.breadcrumbsSchema, true);
+    const trail = normalizeTrail(attributes._resolvedTrail);
+    const ariaLabel = attrString(attributes.ariaLabel, 'Breadcrumb');
+    const className = attrString(attributes.className);
+
+    const wrapperClasses = classList(['ap-breadcrumbs', className]);
+    const separatorPath = SEPARATOR_PATHS[separatorIcon];
+
+    const listProps = breadcrumbsSchema
+        ? {
+              className: 'ap-breadcrumbs__list',
+              itemScope: true,
+              itemType: 'https://schema.org/BreadcrumbList',
+          }
+        : { className: 'ap-breadcrumbs__list' };
+
+    return (
+        <nav className={wrapperClasses} aria-label={ariaLabel}>
+            <ol {...listProps}>
+                {trail.map((item, index) => {
+                    const isLast = index === trail.length - 1;
+                    const position = index + 1;
+
+                    const itemProps = breadcrumbsSchema
+                        ? {
+                              className: 'ap-breadcrumbs__item',
+                              itemProp: 'itemListElement',
+                              itemScope: true,
+                              itemType: 'https://schema.org/ListItem',
+                          }
+                        : { className: 'ap-breadcrumbs__item' };
+
+                    return (
+                        <li key={`${position}-${item.label}`} {...itemProps}>
+                            {item.url !== null && !item.current ? (
+                                <a
+                                    className="ap-breadcrumbs__link"
+                                    href={item.url}
+                                    {...(breadcrumbsSchema ? { itemProp: 'item' } : {})}
+                                >
+                                    <span
+                                        {...(breadcrumbsSchema ? { itemProp: 'name' } : {})}
+                                    >
+                                        {item.label}
+                                    </span>
+                                </a>
+                            ) : (
+                                <span
+                                    className="ap-breadcrumbs__current"
+                                    {...(item.current ? { 'aria-current': 'page' as const } : {})}
+                                    {...(breadcrumbsSchema ? { itemProp: 'name' } : {})}
+                                >
+                                    {item.label}
+                                </span>
+                            )}
+                            {breadcrumbsSchema && (
+                                <meta itemProp="position" content={String(position)} />
+                            )}
+                            {!isLast && (
+                                <span
+                                    className="ap-breadcrumbs__separator"
+                                    aria-hidden="true"
+                                >
+                                    <svg
+                                        xmlns="http://www.w3.org/2000/svg"
+                                        viewBox="0 0 24 24"
+                                        width="1em"
+                                        height="1em"
+                                        fill="none"
+                                        stroke="currentColor"
+                                        strokeWidth="2"
+                                        strokeLinecap="round"
+                                        strokeLinejoin="round"
+                                        aria-hidden="true"
+                                        focusable="false"
+                                    >
+                                        <path d={separatorPath} />
+                                    </svg>
+                                </span>
+                            )}
+                        </li>
+                    );
+                })}
+            </ol>
+        </nav>
+    );
+}

--- a/packages/visual-editor-renderer-react/src/blocks/artisanpack/breadcrumbs.tsx
+++ b/packages/visual-editor-renderer-react/src/blocks/artisanpack/breadcrumbs.tsx
@@ -111,7 +111,7 @@ export function BreadcrumbsBlock({ attributes }: BlockRendererProps): ReactEleme
                         : { className: 'ap-breadcrumbs__item' };
 
                     return (
-                        <li key={`${position}-${item.label}`} {...itemProps}>
+                        <li key={index} {...itemProps}>
                             {item.url !== null && !item.current ? (
                                 <a
                                     className="ap-breadcrumbs__link"
@@ -126,8 +126,12 @@ export function BreadcrumbsBlock({ attributes }: BlockRendererProps): ReactEleme
                                 </a>
                             ) : (
                                 <span
-                                    className="ap-breadcrumbs__current"
-                                    {...(item.current ? { 'aria-current': 'page' as const } : {})}
+                                    {...(item.current
+                                        ? {
+                                              className: 'ap-breadcrumbs__current',
+                                              'aria-current': 'page' as const,
+                                          }
+                                        : {})}
                                     {...(breadcrumbsSchema ? { itemProp: 'name' } : {})}
                                 >
                                     {item.label}

--- a/packages/visual-editor-renderer-react/src/blocks/registerCoreBlocks.ts
+++ b/packages/visual-editor-renderer-react/src/blocks/registerCoreBlocks.ts
@@ -12,6 +12,7 @@
  */
 
 import { registerBlockRenderer } from '../registry';
+import { BreadcrumbsBlock } from './artisanpack/breadcrumbs';
 import { CalloutBlock } from './artisanpack/callout';
 import { LoginoutBlock } from './artisanpack/loginout';
 import {
@@ -210,6 +211,7 @@ const CORE_BLOCKS: Record<string, BlockRenderer> = {
     'artisanpack/navigation': NavigationBlock,
     'core/navigation-link': NavigationLinkBlock,
     'core/navigation-submenu': NavigationSubmenuBlock,
+    'artisanpack/breadcrumbs': BreadcrumbsBlock,
     'artisanpack/callout': CalloutBlock,
     // Post navigation / metadata family (#520) — same renderer for both
     // namespaces; PostResolver stamps the same `_resolved*` attributes.

--- a/packages/visual-editor-renderer-react/tests/BlockTree.test.tsx
+++ b/packages/visual-editor-renderer-react/tests/BlockTree.test.tsx
@@ -681,6 +681,7 @@ describe('Core design blocks', () => {
         expect(html).not.toContain('javascript:');
         expect(html).toContain('href="/"');
         expect(html).toContain('>XSS<');
+        expect((html.match(/ap-breadcrumbs__current/g) ?? []).length).toBe(1);
     });
 
     it('renders an empty breadcrumbs list when the trail is missing', () => {

--- a/packages/visual-editor-renderer-react/tests/BlockTree.test.tsx
+++ b/packages/visual-editor-renderer-react/tests/BlockTree.test.tsx
@@ -616,6 +616,81 @@ describe('Core design blocks', () => {
         expect(html).toContain('ap-callout--info');
         expect(html).toContain('data-severity="info"');
     });
+
+    it('renders the artisanpack/breadcrumbs block with a resolved trail and schema microdata', () => {
+        const tree = [
+            makeBlock('artisanpack/breadcrumbs', {
+                separatorIcon: 'chevron-right',
+                breadcrumbsSchema: true,
+                _resolvedTrail: [
+                    { label: 'Home', url: '/' },
+                    { label: 'Blog', url: '/blog' },
+                    { label: 'Hello World', current: true },
+                ],
+            }),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('<nav');
+        expect(html).toContain('class="ap-breadcrumbs"');
+        expect(html).toContain('aria-label="Breadcrumb"');
+        expect(html).toContain('itemtype="https://schema.org/BreadcrumbList"');
+        expect(html).toContain('itemtype="https://schema.org/ListItem"');
+        expect(html).toContain('<a class="ap-breadcrumbs__link" href="/"');
+        expect(html).toContain('<a class="ap-breadcrumbs__link" href="/blog"');
+        expect(html).toContain('Hello World');
+        expect(html).toContain('aria-current="page"');
+        expect(html).toContain('itemprop="position" content="1"');
+        expect(html).toContain('itemprop="position" content="3"');
+        expect(html).toContain('d="m9 6 6 6-6 6"');
+    });
+
+    it('normalizes invalid breadcrumbs separator and omits schema when disabled', () => {
+        const tree = [
+            makeBlock('artisanpack/breadcrumbs', {
+                separatorIcon: 'spinning-rocket',
+                breadcrumbsSchema: false,
+                _resolvedTrail: [
+                    { label: 'Home', url: '/' },
+                    { label: 'Page', current: true },
+                ],
+            }),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('d="m9 6 6 6-6 6"');
+        expect(html).not.toContain('schema.org/BreadcrumbList');
+        expect(html).not.toContain('itemprop="position"');
+    });
+
+    it('drops unsafe URLs from breadcrumbs trail entries', () => {
+        const tree = [
+            makeBlock('artisanpack/breadcrumbs', {
+                _resolvedTrail: [
+                    { label: 'Home', url: '/' },
+                    { label: 'XSS', url: 'javascript:alert(1)' },
+                    { label: 'Page', current: true },
+                ],
+            }),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).not.toContain('javascript:');
+        expect(html).toContain('href="/"');
+        expect(html).toContain('>XSS<');
+    });
+
+    it('renders an empty breadcrumbs list when the trail is missing', () => {
+        const tree = [makeBlock('artisanpack/breadcrumbs', {})];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('ap-breadcrumbs__list');
+        expect(html).not.toContain('<li class="ap-breadcrumbs__item');
+    });
 });
 
 describe('Registry + dynamic fallback', () => {

--- a/packages/visual-editor-renderer-vue/src/blocks/artisanpack/breadcrumbs.ts
+++ b/packages/visual-editor-renderer-vue/src/blocks/artisanpack/breadcrumbs.ts
@@ -1,0 +1,194 @@
+/**
+ * Vue renderer for the `artisanpack/breadcrumbs` block (CW0 pilot — #496).
+ *
+ * Mirrors the Blade partial and the React renderer so every environment
+ * emits identical markup. The trail is server-resolved and arrives on
+ * the `_resolvedTrail` attribute as an array of
+ * `{ label, url?, current? }` entries.
+ */
+
+import { defineComponent, h, type VNode } from 'vue';
+
+import { attrArray, attrBoolean, attrString, classList } from '../../support/attributes';
+import { safeUrl } from '../../support/urlSanitizer';
+import { blockRendererProps } from '../shared';
+
+type SeparatorIconName =
+    | 'arrow-right'
+    | 'chevron-right'
+    | 'chevron-double-right'
+    | 'long-arrow-right';
+
+const VALID_SEPARATORS: ReadonlyArray<SeparatorIconName> = [
+    'arrow-right',
+    'chevron-right',
+    'chevron-double-right',
+    'long-arrow-right',
+];
+
+const SEPARATOR_PATHS: Readonly<Record<SeparatorIconName, string>> = {
+    'arrow-right': 'M5 12h14m-6-6 6 6-6 6',
+    'chevron-right': 'm9 6 6 6-6 6',
+    'chevron-double-right': 'm6 6 6 6-6 6m6-12 6 6-6 6',
+    'long-arrow-right': 'M3 12h17m-5-5 5 5-5 5',
+};
+
+interface TrailItem {
+    readonly label: string;
+    readonly url: string | null;
+    readonly current: boolean;
+}
+
+function normalizeSeparator(value: unknown): SeparatorIconName {
+    const raw = attrString(value, 'chevron-right');
+    return (VALID_SEPARATORS as ReadonlyArray<string>).includes(raw)
+        ? (raw as SeparatorIconName)
+        : 'chevron-right';
+}
+
+function normalizeTrail(value: unknown): ReadonlyArray<TrailItem> {
+    const items: TrailItem[] = [];
+
+    for (const entry of attrArray(value)) {
+        if (entry === null || typeof entry !== 'object') {
+            continue;
+        }
+
+        const record = entry as Record<string, unknown>;
+        const label = attrString(record.label);
+
+        if (label === '') {
+            continue;
+        }
+
+        const sanitizedUrl = safeUrl(record.url);
+
+        items.push({
+            label,
+            url: sanitizedUrl === '' ? null : sanitizedUrl,
+            current: attrBoolean(record.current, false),
+        });
+    }
+
+    return items;
+}
+
+export const BreadcrumbsBlock = defineComponent({
+    name: 'BreadcrumbsBlock',
+    props: blockRendererProps,
+    setup(props) {
+        return () => {
+            const separatorIcon = normalizeSeparator(props.attributes.separatorIcon);
+            const breadcrumbsSchema = attrBoolean(
+                props.attributes.breadcrumbsSchema,
+                true
+            );
+            const trail = normalizeTrail(props.attributes._resolvedTrail);
+            const ariaLabel = attrString(props.attributes.ariaLabel, 'Breadcrumb');
+            const className = attrString(props.attributes.className);
+
+            const wrapperClasses = classList(['ap-breadcrumbs', className]);
+            const separatorPath = SEPARATOR_PATHS[separatorIcon];
+
+            const listAttrs: Record<string, unknown> = {
+                class: 'ap-breadcrumbs__list',
+            };
+
+            if (breadcrumbsSchema) {
+                listAttrs.itemscope = '';
+                listAttrs.itemtype = 'https://schema.org/BreadcrumbList';
+            }
+
+            const renderItem = (item: TrailItem, index: number): VNode => {
+                const isLast = index === trail.length - 1;
+                const position = index + 1;
+
+                const itemAttrs: Record<string, unknown> = {
+                    class: 'ap-breadcrumbs__item',
+                    key: `${position}-${item.label}`,
+                };
+
+                if (breadcrumbsSchema) {
+                    itemAttrs.itemprop = 'itemListElement';
+                    itemAttrs.itemscope = '';
+                    itemAttrs.itemtype = 'https://schema.org/ListItem';
+                }
+
+                const children: VNode[] = [];
+
+                if (item.url !== null && !item.current) {
+                    const linkAttrs: Record<string, unknown> = {
+                        class: 'ap-breadcrumbs__link',
+                        href: item.url,
+                    };
+                    if (breadcrumbsSchema) {
+                        linkAttrs.itemprop = 'item';
+                    }
+                    const labelAttrs: Record<string, unknown> = {};
+                    if (breadcrumbsSchema) {
+                        labelAttrs.itemprop = 'name';
+                    }
+                    children.push(
+                        h('a', linkAttrs, [h('span', labelAttrs, item.label)])
+                    );
+                } else {
+                    const labelAttrs: Record<string, unknown> = {
+                        class: 'ap-breadcrumbs__current',
+                    };
+                    if (item.current) {
+                        labelAttrs['aria-current'] = 'page';
+                    }
+                    if (breadcrumbsSchema) {
+                        labelAttrs.itemprop = 'name';
+                    }
+                    children.push(h('span', labelAttrs, item.label));
+                }
+
+                if (breadcrumbsSchema) {
+                    children.push(
+                        h('meta', { itemprop: 'position', content: String(position) })
+                    );
+                }
+
+                if (!isLast) {
+                    children.push(
+                        h(
+                            'span',
+                            {
+                                class: 'ap-breadcrumbs__separator',
+                                'aria-hidden': 'true',
+                            },
+                            [
+                                h(
+                                    'svg',
+                                    {
+                                        xmlns: 'http://www.w3.org/2000/svg',
+                                        viewBox: '0 0 24 24',
+                                        width: '1em',
+                                        height: '1em',
+                                        fill: 'none',
+                                        stroke: 'currentColor',
+                                        'stroke-width': '2',
+                                        'stroke-linecap': 'round',
+                                        'stroke-linejoin': 'round',
+                                        'aria-hidden': 'true',
+                                        focusable: 'false',
+                                    },
+                                    [h('path', { d: separatorPath })]
+                                ),
+                            ]
+                        )
+                    );
+                }
+
+                return h('li', itemAttrs, children);
+            };
+
+            return h(
+                'nav',
+                { class: wrapperClasses, 'aria-label': ariaLabel },
+                [h('ol', listAttrs, trail.map(renderItem))]
+            );
+        };
+    },
+});

--- a/packages/visual-editor-renderer-vue/src/blocks/artisanpack/breadcrumbs.ts
+++ b/packages/visual-editor-renderer-vue/src/blocks/artisanpack/breadcrumbs.ts
@@ -132,10 +132,9 @@ export const BreadcrumbsBlock = defineComponent({
                         h('a', linkAttrs, [h('span', labelAttrs, item.label)])
                     );
                 } else {
-                    const labelAttrs: Record<string, unknown> = {
-                        class: 'ap-breadcrumbs__current',
-                    };
+                    const labelAttrs: Record<string, unknown> = {};
                     if (item.current) {
+                        labelAttrs.class = 'ap-breadcrumbs__current';
                         labelAttrs['aria-current'] = 'page';
                     }
                     if (breadcrumbsSchema) {

--- a/packages/visual-editor-renderer-vue/src/blocks/registerCoreBlocks.ts
+++ b/packages/visual-editor-renderer-vue/src/blocks/registerCoreBlocks.ts
@@ -12,6 +12,7 @@
  */
 
 import { registerBlockRenderer } from '../registry';
+import { BreadcrumbsBlock } from './artisanpack/breadcrumbs';
 import { CalloutBlock } from './artisanpack/callout';
 import { LoginoutBlock } from './artisanpack/loginout';
 import {
@@ -210,6 +211,7 @@ const CORE_BLOCKS: Record<string, BlockRenderer> = {
     'artisanpack/navigation': NavigationBlock,
     'core/navigation-link': NavigationLinkBlock,
     'core/navigation-submenu': NavigationSubmenuBlock,
+    'artisanpack/breadcrumbs': BreadcrumbsBlock,
     'artisanpack/callout': CalloutBlock,
     // Post navigation / metadata family (#520) — same renderer for both
     // namespaces; PostResolver stamps the same `_resolved*` attributes.

--- a/packages/visual-editor-renderer-vue/tests/BlockTree.test.ts
+++ b/packages/visual-editor-renderer-vue/tests/BlockTree.test.ts
@@ -615,6 +615,81 @@ describe('Core design blocks', () => {
         expect(html).toContain('ap-callout--info');
         expect(html).toContain('data-severity="info"');
     });
+
+    it('renders the artisanpack/breadcrumbs block with a resolved trail and schema microdata', () => {
+        const tree = [
+            makeBlock('artisanpack/breadcrumbs', {
+                separatorIcon: 'chevron-right',
+                breadcrumbsSchema: true,
+                _resolvedTrail: [
+                    { label: 'Home', url: '/' },
+                    { label: 'Blog', url: '/blog' },
+                    { label: 'Hello World', current: true },
+                ],
+            }),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('<nav');
+        expect(html).toContain('class="ap-breadcrumbs"');
+        expect(html).toContain('aria-label="Breadcrumb"');
+        expect(html).toContain('itemtype="https://schema.org/BreadcrumbList"');
+        expect(html).toContain('itemtype="https://schema.org/ListItem"');
+        expect(html).toContain('<a class="ap-breadcrumbs__link" href="/"');
+        expect(html).toContain('<a class="ap-breadcrumbs__link" href="/blog"');
+        expect(html).toContain('Hello World');
+        expect(html).toContain('aria-current="page"');
+        expect(html).toContain('itemprop="position" content="1"');
+        expect(html).toContain('itemprop="position" content="3"');
+        expect(html).toContain('d="m9 6 6 6-6 6"');
+    });
+
+    it('normalizes invalid breadcrumbs separator and omits schema when disabled', () => {
+        const tree = [
+            makeBlock('artisanpack/breadcrumbs', {
+                separatorIcon: 'spinning-rocket',
+                breadcrumbsSchema: false,
+                _resolvedTrail: [
+                    { label: 'Home', url: '/' },
+                    { label: 'Page', current: true },
+                ],
+            }),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('d="m9 6 6 6-6 6"');
+        expect(html).not.toContain('schema.org/BreadcrumbList');
+        expect(html).not.toContain('itemprop="position"');
+    });
+
+    it('drops unsafe URLs from breadcrumbs trail entries', () => {
+        const tree = [
+            makeBlock('artisanpack/breadcrumbs', {
+                _resolvedTrail: [
+                    { label: 'Home', url: '/' },
+                    { label: 'XSS', url: 'javascript:alert(1)' },
+                    { label: 'Page', current: true },
+                ],
+            }),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).not.toContain('javascript:');
+        expect(html).toContain('href="/"');
+        expect(html).toContain('>XSS<');
+    });
+
+    it('renders an empty breadcrumbs list when the trail is missing', () => {
+        const tree = [makeBlock('artisanpack/breadcrumbs', {})];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('ap-breadcrumbs__list');
+        expect(html).not.toContain('<li class="ap-breadcrumbs__item');
+    });
 });
 
 describe('Registry + dynamic fallback', () => {

--- a/packages/visual-editor-renderer-vue/tests/BlockTree.test.ts
+++ b/packages/visual-editor-renderer-vue/tests/BlockTree.test.ts
@@ -680,6 +680,7 @@ describe('Core design blocks', () => {
         expect(html).not.toContain('javascript:');
         expect(html).toContain('href="/"');
         expect(html).toContain('>XSS<');
+        expect((html.match(/ap-breadcrumbs__current/g) ?? []).length).toBe(1);
     });
 
     it('renders an empty breadcrumbs list when the trail is missing', () => {

--- a/resources/js/visual-editor/blocks/breadcrumbs/block.json
+++ b/resources/js/visual-editor/blocks/breadcrumbs/block.json
@@ -1,0 +1,70 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "artisanpack/breadcrumbs",
+    "title": "Breadcrumbs",
+    "category": "artisanpack",
+    "description": "Display a breadcrumbs trail so visitors know where they are on your site.",
+    "keywords": ["breadcrumbs", "navigation", "trail"],
+    "textdomain": "artisanpack-visual-editor",
+    "attributes": {
+        "separatorIcon": {
+            "type": "string",
+            "enum": ["arrow-right", "chevron-right", "chevron-double-right", "long-arrow-right"],
+            "default": "chevron-right"
+        },
+        "breadcrumbsSchema": {
+            "type": "boolean",
+            "default": true
+        }
+    },
+    "supports": {
+        "align": ["wide", "full"],
+        "ariaLabel": true,
+        "className": true,
+        "html": false,
+        "spacing": {
+            "margin": ["top", "bottom"],
+            "padding": true,
+            "blockGap": true,
+            "__experimentalDefaultControls": {
+                "padding": true,
+                "blockGap": true
+            }
+        },
+        "color": {
+            "gradients": true,
+            "link": true,
+            "__experimentalDefaultControls": {
+                "background": true,
+                "text": true
+            }
+        },
+        "shadow": true,
+        "__experimentalBorder": {
+            "color": true,
+            "radius": true,
+            "style": true,
+            "width": true,
+            "__experimentalDefaultControls": {
+                "color": true,
+                "radius": true,
+                "style": true,
+                "width": true
+            }
+        },
+        "typography": {
+            "fontSize": true,
+            "lineHeight": true,
+            "__experimentalFontFamily": true,
+            "__experimentalFontWeight": true,
+            "__experimentalFontStyle": true,
+            "__experimentalTextTransform": true,
+            "__experimentalTextDecoration": true,
+            "__experimentalLetterSpacing": true,
+            "__experimentalDefaultControls": {
+                "fontSize": true
+            }
+        }
+    }
+}

--- a/resources/js/visual-editor/blocks/breadcrumbs/breadcrumbs.css
+++ b/resources/js/visual-editor/blocks/breadcrumbs/breadcrumbs.css
@@ -1,0 +1,40 @@
+/**
+ * Breadcrumbs block styles.
+ *
+ * Loaded in the editor via `blocks/breadcrumbs/index.ts`. Host apps
+ * are expected to ship matching (or compatible) rules on the public
+ * frontend — the Blade / React / Vue renderers emit the same class names.
+ */
+
+.ap-breadcrumbs__list {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5rem;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+
+.ap-breadcrumbs__item {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.ap-breadcrumbs__separator {
+    display: inline-flex;
+    align-items: center;
+    width: 1em;
+    height: 1em;
+    opacity: 0.6;
+}
+
+.ap-breadcrumbs__separator svg {
+    width: 100%;
+    height: 100%;
+}
+
+.ap-breadcrumbs__current {
+    font-weight: 600;
+}

--- a/resources/js/visual-editor/blocks/breadcrumbs/edit.tsx
+++ b/resources/js/visual-editor/blocks/breadcrumbs/edit.tsx
@@ -1,0 +1,158 @@
+/**
+ * Breadcrumbs — editor-side preview.
+ *
+ * Shows a stub trail (Home › Page › Current) so authors get an immediate
+ * visual of the chosen separator and schema toggle. The real trail is
+ * rendered at runtime by the Blade / React / Vue renderers from the
+ * server-stamped `_resolvedTrail` attribute, so the edit component only
+ * cares about chrome (separator + wrapper attributes).
+ */
+
+import type { ReactElement } from 'react';
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import { PanelBody, SelectControl, ToggleControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+import { TEXT_DOMAIN } from '../../vendor/i18n';
+
+import {
+    SEPARATOR_ICON_NAMES,
+    SeparatorIcon,
+    type SeparatorIconName,
+} from './separators';
+
+interface BreadcrumbsAttributes {
+    readonly separatorIcon: SeparatorIconName;
+    readonly breadcrumbsSchema: boolean;
+}
+
+interface BreadcrumbsEditProps {
+    readonly attributes: BreadcrumbsAttributes;
+    readonly setAttributes: (next: Partial<BreadcrumbsAttributes>) => void;
+}
+
+const SEPARATOR_LABELS: Readonly<Record<SeparatorIconName, string>> = {
+    'arrow-right': 'Arrow Right',
+    'chevron-right': 'Chevron Right',
+    'chevron-double-right': 'Chevron Double Right',
+    'long-arrow-right': 'Long Arrow Right',
+};
+
+const SEPARATOR_OPTIONS = SEPARATOR_ICON_NAMES.map((value) => ({
+    label: SEPARATOR_LABELS[value],
+    value,
+}));
+
+function isSeparatorIconName(value: string): value is SeparatorIconName {
+    return (SEPARATOR_ICON_NAMES as ReadonlyArray<string>).includes(value);
+}
+
+export default function BreadcrumbsEdit({
+    attributes,
+    setAttributes,
+}: BreadcrumbsEditProps): ReactElement {
+    const { separatorIcon, breadcrumbsSchema } = attributes;
+
+    const blockProps = useBlockProps({
+        className: 'ap-breadcrumbs',
+    });
+
+    const stub: ReadonlyArray<string> = [
+        __('Home', TEXT_DOMAIN),
+        __('Section', TEXT_DOMAIN),
+        __('Current Page', TEXT_DOMAIN),
+    ];
+
+    // The block's stylesheet is imported as a side effect in index.ts so
+    // it lives in the parent document, but the editor's `BlockCanvas`
+    // mounts inside a sandboxed iframe that none of those rules reach.
+    // Inline the layout-critical rules here so authors get an accurate
+    // preview without expanding scope into `canvas-styles.ts`. The
+    // sibling `breadcrumbs.css` keeps shipping for the public frontend.
+    const listStyle: React.CSSProperties = {
+        display: 'flex',
+        flexWrap: 'wrap',
+        alignItems: 'center',
+        gap: '0.5rem',
+        margin: 0,
+        padding: 0,
+        listStyle: 'none',
+    };
+    const itemStyle: React.CSSProperties = {
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: '0.5rem',
+    };
+    const separatorStyle: React.CSSProperties = {
+        display: 'inline-flex',
+        alignItems: 'center',
+        opacity: 0.6,
+    };
+
+    return (
+        <>
+            <InspectorControls>
+                <PanelBody title={__('Breadcrumbs settings', TEXT_DOMAIN)} initialOpen>
+                    <SelectControl
+                        label={__('Separator icon', TEXT_DOMAIN)}
+                        value={separatorIcon}
+                        options={SEPARATOR_OPTIONS.map((option) => ({
+                            label: __(option.label, TEXT_DOMAIN),
+                            value: option.value,
+                        }))}
+                        onChange={(value) => {
+                            if (isSeparatorIconName(value)) {
+                                setAttributes({ separatorIcon: value });
+                            }
+                        }}
+                        __nextHasNoMarginBottom
+                    />
+                    <ToggleControl
+                        label={__('Include schema.org markup', TEXT_DOMAIN)}
+                        help={__(
+                            'Disable if your SEO plugin already emits BreadcrumbList structured data.',
+                            TEXT_DOMAIN
+                        )}
+                        checked={breadcrumbsSchema}
+                        onChange={(next) => setAttributes({ breadcrumbsSchema: next })}
+                        __nextHasNoMarginBottom
+                    />
+                </PanelBody>
+            </InspectorControls>
+            <nav {...blockProps} aria-label={__('Breadcrumb', TEXT_DOMAIN)}>
+                <ol className="ap-breadcrumbs__list" style={listStyle}>
+                    {stub.map((label, index) => {
+                        const isLast = index === stub.length - 1;
+                        return (
+                            <li
+                                key={label}
+                                className="ap-breadcrumbs__item"
+                                style={itemStyle}
+                            >
+                                <span
+                                    className={
+                                        isLast
+                                            ? 'ap-breadcrumbs__current'
+                                            : 'ap-breadcrumbs__link'
+                                    }
+                                    style={isLast ? { fontWeight: 600 } : undefined}
+                                >
+                                    {label}
+                                </span>
+                                {!isLast && (
+                                    <span
+                                        className="ap-breadcrumbs__separator"
+                                        aria-hidden="true"
+                                        style={separatorStyle}
+                                    >
+                                        <SeparatorIcon name={separatorIcon} />
+                                    </span>
+                                )}
+                            </li>
+                        );
+                    })}
+                </ol>
+            </nav>
+        </>
+    );
+}

--- a/resources/js/visual-editor/blocks/breadcrumbs/index.ts
+++ b/resources/js/visual-editor/blocks/breadcrumbs/index.ts
@@ -1,0 +1,27 @@
+/**
+ * Breadcrumbs block entrypoint.
+ *
+ * Auto-discovered by `editor/custom-blocks.ts` and registered against
+ * `@wordpress/blocks.registerBlockType`. CW0 pilot of the crosswinds-blocks
+ * port (#496) — server-rendered display block: `edit` previews a stub
+ * trail so authors see the chosen separator immediately, and the real
+ * trail is produced at runtime by the renderers from the stamped
+ * `_resolvedTrail` attribute. Upstream had no transforms.
+ */
+
+import metadata from './block.json';
+import edit from './edit';
+import save from './save';
+import icon from './inserter-icon';
+
+import './breadcrumbs.css';
+
+export { edit, save, metadata, icon };
+
+export default {
+    name: metadata.name,
+    metadata,
+    edit,
+    save,
+    icon,
+};

--- a/resources/js/visual-editor/blocks/breadcrumbs/inserter-icon.tsx
+++ b/resources/js/visual-editor/blocks/breadcrumbs/inserter-icon.tsx
@@ -1,0 +1,24 @@
+/**
+ * Breadcrumbs — inserter icon.
+ *
+ * Inline SVG so the editor canvas does not have to load `dashicons.css`.
+ * A trail-of-pills shape reads as "breadcrumbs" at the inserter's small
+ * preview size.
+ */
+
+import type { ReactElement } from 'react';
+
+export default function BreadcrumbsInserterIcon(): ReactElement {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            width={24}
+            height={24}
+            aria-hidden="true"
+            focusable="false"
+        >
+            <path d="M3 10h4v4H3v-4zm5 2 2-2v4l-2-2zm3-2h4v4h-4v-4zm5 2 2-2v4l-2-2zm3-2h4v4h-4v-4z" />
+        </svg>
+    );
+}

--- a/resources/js/visual-editor/blocks/breadcrumbs/save.tsx
+++ b/resources/js/visual-editor/blocks/breadcrumbs/save.tsx
@@ -1,0 +1,12 @@
+/**
+ * Breadcrumbs — save component.
+ *
+ * Dynamic block: the trail is resolved server-side from the current
+ * request (the renderers consume the stamped `_resolvedTrail` attribute).
+ * Returning `null` from save is the Gutenberg convention for dynamic
+ * blocks — only the block delimiter and attributes are persisted.
+ */
+
+export default function BreadcrumbsSave(): null {
+    return null;
+}

--- a/resources/js/visual-editor/blocks/breadcrumbs/separators.tsx
+++ b/resources/js/visual-editor/blocks/breadcrumbs/separators.tsx
@@ -1,0 +1,58 @@
+/**
+ * Inline SVG separator icons shared between the breadcrumbs edit
+ * component and the inserter icon.
+ *
+ * Inlining (instead of pulling Font Awesome like upstream did) keeps the
+ * editor bundle free of an extra runtime icon dependency and guarantees
+ * the saved markup is byte-identical across host environments — the same
+ * paths are baked into the Blade / React / Vue renderers so authors see
+ * the same chevron the public frontend renders.
+ */
+
+import type { ReactElement } from 'react';
+
+export type SeparatorIconName =
+    | 'arrow-right'
+    | 'chevron-right'
+    | 'chevron-double-right'
+    | 'long-arrow-right';
+
+export const SEPARATOR_ICON_NAMES: ReadonlyArray<SeparatorIconName> = [
+    'arrow-right',
+    'chevron-right',
+    'chevron-double-right',
+    'long-arrow-right',
+];
+
+export const SEPARATOR_ICON_PATHS: Readonly<Record<SeparatorIconName, string>> = {
+    'arrow-right': 'M5 12h14m-6-6 6 6-6 6',
+    'chevron-right': 'm9 6 6 6-6 6',
+    'chevron-double-right': 'm6 6 6 6-6 6m6-12 6 6-6 6',
+    'long-arrow-right': 'M3 12h17m-5-5 5 5-5 5',
+};
+
+interface SeparatorIconProps {
+    readonly name: SeparatorIconName;
+}
+
+export function SeparatorIcon({ name }: SeparatorIconProps): ReactElement {
+    const d = SEPARATOR_ICON_PATHS[name] ?? SEPARATOR_ICON_PATHS['chevron-right'];
+
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            width="1em"
+            height="1em"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+            focusable="false"
+        >
+            <path d={d} />
+        </svg>
+    );
+}


### PR DESCRIPTION
## Description

Forks the upstream `crosswinds-blocks/breadcrumbs` block into the visual-editor package as `artisanpack/breadcrumbs` and establishes the pattern for CW1–CW7 to follow.

**Closes:** #496

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #496 (under umbrella #495)

## Motivation and Context

CW0 — first of the 8-phase crosswinds-blocks port. Breadcrumbs is the cleanest pilot: single block, server-rendered, no inner blocks, no JS interactivity. Locking in the editor scaffold + three-renderer parity + tests pattern here lets CW1–CW7 fan out in parallel.

## Changes Made

- **Editor scaffold** at `resources/js/visual-editor/blocks/breadcrumbs/` — `block.json` (separatorIcon, breadcrumbsSchema; full block-supports inheriting upstream), `edit.tsx` with InspectorControls panel + stub trail preview, `save.tsx` returning `null` (dynamic), `index.ts`, `inserter-icon.tsx`, shared `separators.tsx`, `breadcrumbs.css`. Dropped the upstream `breadrcumbsSchema` typo for `breadcrumbsSchema` since this is a fresh namespace.
- **Three renderers** under `packages/visual-editor-renderer-{blade,react,vue}/` — read a server-stamped `_resolvedTrail` (`Array<{ label, url?, current? }>`) and emit `<nav><ol>…</ol></nav>` with the selected chevron separator. Schema.org BreadcrumbList microdata when `breadcrumbsSchema=true`. URLs run through the existing `UrlSanitizer` / `safeUrl` helpers so unsafe schemes (`javascript:`, etc.) are dropped.
- **Renderer parity tests** — 4 cases × 3 renderers (12 specs, ~50 assertions): schema-on with resolved trail, schema-off + invalid-separator fallback, unsafe URL rejection, empty trail. `packages/renderer-parity.json` includes `artisanpack/breadcrumbs`.
- **No transforms** — upstream did not define any for breadcrumbs.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS 25.5.0
- PHP Version: 8.4.3
- Project Version: feature/495-port-crosswinds-blocks

**Tests Performed:**
1. Inserted the block in the visual-editor; toggled separator + schema toggle; verified preview updates and selections persist.
2. Full vitest suite — 235 files / 1901 tests, all passing.
3. Full Pest suite — 1024 tests / 2857 assertions, all passing.
4. `node scripts/verify-renderer-parity.mjs` — passes.
5. CodeRabbit CLI (`cr review --base feature/495-port-crosswinds-blocks`) — 1 valid finding addressed (URL sanitization), 1 false-positive skipped (SVG path is correct), final pass returned 0 findings.

## Accessibility Tests Run

- [x] Keyboard navigation tested
- [x] Screen reader tested
- [x] Color contrast verified
- [x] ARIA labels checked

**Details:** The rendered `<nav>` carries an `aria-label` (defaulting to "Breadcrumb"); the current page entry carries `aria-current="page"`; separators are `aria-hidden`. Schema.org BreadcrumbList microdata is emitted unless the author disables it.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:** 12 new renderer parity specs (4 per renderer) covering happy-path schema rendering, separator/schema fallback, unsafe-URL rejection, and empty-trail behavior.

## Documentation

- [x] Inline code documentation added

**Documentation details:** Docblocks on every new file explain the upstream provenance, the dynamic-block contract (server stamps `_resolvedTrail`), and the editor-vs-renderer split. Follow-ups for runtime + iframe CSS pipeline filed as #565 and #566 under umbrella #495.

## Screenshots

<!-- Editor preview shown in conversation thread on #496. -->

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [x] Accessibility tests completed
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Breadcrumbs navigation block with configurable separator icons, editor preview, inserter icon, and rich editor controls (spacing, styling, typography, color).
  * Optional schema.org BreadcrumbList microdata support and safe URL handling so unsafe links are excluded.

* **Tests**
  * Added comprehensive tests verifying rendering, separator normalization, schema toggling, URL sanitization, and empty-trail behavior across renderers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->