### PR TITLE
feat: port accordion + tabs block families

### DIFF
--- a/packages/renderer-parity.json
+++ b/packages/renderer-parity.json
@@ -128,6 +128,12 @@
         "artisanpack/query-pagination-numbers",
         "artisanpack/query-pagination-previous",
         "artisanpack/query-title",
-        "artisanpack/loginout"
+        "artisanpack/loginout",
+        "artisanpack/accordions",
+        "artisanpack/accordion",
+        "artisanpack/accordion-title",
+        "artisanpack/accordion-body",
+        "artisanpack/tabs",
+        "artisanpack/tab-section"
     ]
 }

--- a/packages/visual-editor-renderer-blade/resources/assets/frontend/accordion.css
+++ b/packages/visual-editor-renderer-blade/resources/assets/frontend/accordion.css
@@ -1,0 +1,115 @@
+/**
+ * Front-end styles for the accordion family (artisanpack/accordions,
+ * artisanpack/accordion, artisanpack/accordion-title,
+ * artisanpack/accordion-body — #497).
+ *
+ * Mirrors the editor preview styles in
+ * `resources/js/visual-editor/blocks/accordion/accordion.css`. Host
+ * apps load this stylesheet on any page that renders an accordion
+ * block.
+ */
+
+.ap-accordions {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    margin-block-end: var(--wp--style--block-gap, 1.5rem);
+}
+
+.ap-accordion {
+    border: 1px solid var(--ap-accordion-border, rgba(0, 0, 0, 0.1));
+    border-radius: 0.25rem;
+    overflow: hidden;
+}
+
+.ap-accordion__title {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding-right: 2.5rem;
+}
+
+.ap-accordion__title-content {
+    flex: 1;
+    cursor: pointer;
+    padding: 0.75rem 1rem;
+}
+
+.ap-accordion__title-content:focus-visible {
+    outline: 2px solid currentColor;
+    outline-offset: -2px;
+}
+
+.ap-accordion__icon {
+    position: absolute;
+    right: 0.75rem;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 1rem;
+    height: 1rem;
+    pointer-events: none;
+}
+
+.ap-accordion__icon::before,
+.ap-accordion__icon::after {
+    content: "";
+    position: absolute;
+    background: currentColor;
+    transition: transform 0.15s ease-out;
+}
+
+.ap-accordion__icon--plus-minus::before {
+    left: 50%;
+    top: 0;
+    width: 2px;
+    height: 100%;
+    margin-left: -1px;
+}
+
+.ap-accordion__icon--plus-minus::after {
+    left: 0;
+    top: 50%;
+    width: 100%;
+    height: 2px;
+    margin-top: -1px;
+}
+
+.ap-accordion__title-content[aria-expanded="true"] ~ .ap-accordion__icon--plus-minus::before {
+    transform: scaleY(0);
+}
+
+.ap-accordion__icon--arrows::before {
+    left: 15%;
+    top: 35%;
+    width: 50%;
+    height: 2px;
+    transform-origin: left center;
+    transform: rotate(45deg);
+}
+
+.ap-accordion__icon--arrows::after {
+    right: 15%;
+    top: 35%;
+    width: 50%;
+    height: 2px;
+    transform-origin: right center;
+    transform: rotate(-45deg);
+}
+
+.ap-accordion__title-content[aria-expanded="true"] ~ .ap-accordion__icon--arrows::before {
+    transform: rotate(-45deg);
+}
+
+.ap-accordion__title-content[aria-expanded="true"] ~ .ap-accordion__icon--arrows::after {
+    transform: rotate(45deg);
+}
+
+.ap-accordion__body {
+    padding: 0.75rem 1rem;
+    transition: max-height 0.15s ease-out;
+}
+
+.ap-accordion__body[hidden] {
+    display: none;
+}

--- a/packages/visual-editor-renderer-blade/resources/assets/frontend/accordion.css
+++ b/packages/visual-editor-renderer-blade/resources/assets/frontend/accordion.css
@@ -37,7 +37,7 @@
 }
 
 .ap-accordion__title-content:focus-visible {
-    outline: 2px solid currentColor;
+    outline: 2px solid currentcolor;
     outline-offset: -2px;
 }
 
@@ -55,7 +55,7 @@
 .ap-accordion__icon::after {
     content: "";
     position: absolute;
-    background: currentColor;
+    background: currentcolor;
     transition: transform 0.15s ease-out;
 }
 

--- a/packages/visual-editor-renderer-blade/resources/assets/frontend/interactivity.js
+++ b/packages/visual-editor-renderer-blade/resources/assets/frontend/interactivity.js
@@ -1,0 +1,168 @@
+/**
+ * Front-end interactivity for the interactive block families.
+ *
+ * Currently wires up two block families:
+ *
+ * - `artisanpack/accordion` — click / Enter / Space toggles the panel
+ *   open and closed; mirrors `aria-expanded` and the `hidden` attribute
+ *   on the body so screen readers and styling react together.
+ * - `artisanpack/tabs` — click activates a tab; arrow keys, Home, and
+ *   End move between tabs roving-tabindex style; `hidden` is toggled on
+ *   each panel so only the active one shows.
+ *
+ * Vanilla DOM only — no framework dependencies. The script is
+ * idempotent: it can run more than once on the same DOM and skips
+ * elements it has already bound, so it plays nicely with SPA
+ * navigation that re-runs scripts after replacing markup. Dispatch
+ * `window.dispatchEvent(new Event('ap:rebind'))` after navigation to
+ * pick up freshly-rendered blocks.
+ */
+
+(function () {
+    'use strict';
+
+    var INIT_FLAG = '__apBlockInteractivityBound';
+
+    function ready(callback) {
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', callback, { once: true });
+        } else {
+            callback();
+        }
+    }
+
+    function bindAccordion(root) {
+        if (root[INIT_FLAG]) {
+            return;
+        }
+        root[INIT_FLAG] = true;
+
+        var trigger = root.querySelector('.ap-accordion__title-content[role="button"]');
+        var panel = root.querySelector('.ap-accordion__body[role="region"]');
+
+        if (!trigger || !panel) {
+            return;
+        }
+
+        function setOpen(open) {
+            trigger.setAttribute('aria-expanded', open ? 'true' : 'false');
+            if (open) {
+                panel.removeAttribute('hidden');
+            } else {
+                panel.setAttribute('hidden', '');
+            }
+        }
+
+        setOpen(trigger.getAttribute('aria-expanded') === 'true');
+
+        trigger.addEventListener('click', function () {
+            setOpen(trigger.getAttribute('aria-expanded') !== 'true');
+        });
+
+        trigger.addEventListener('keydown', function (event) {
+            if (event.key === 'Enter' || event.key === ' ' || event.key === 'Spacebar') {
+                event.preventDefault();
+                setOpen(trigger.getAttribute('aria-expanded') !== 'true');
+            }
+        });
+    }
+
+    function bindTabs(root) {
+        if (root[INIT_FLAG]) {
+            return;
+        }
+        root[INIT_FLAG] = true;
+
+        var tablist = root.querySelector('[role="tablist"]');
+        if (!tablist) {
+            return;
+        }
+
+        var triggers = Array.prototype.slice.call(
+            tablist.querySelectorAll('[role="tab"]')
+        );
+        var panels = Array.prototype.slice.call(
+            root.querySelectorAll('.ap-tab-section[role="tabpanel"]')
+        );
+
+        if (triggers.length === 0 || panels.length === 0) {
+            return;
+        }
+
+        function activate(index) {
+            triggers.forEach(function (trigger, triggerIndex) {
+                var selected = triggerIndex === index;
+                trigger.setAttribute('aria-selected', selected ? 'true' : 'false');
+                trigger.setAttribute('tabindex', selected ? '0' : '-1');
+                if (selected) {
+                    trigger.focus({ preventScroll: true });
+                }
+            });
+
+            panels.forEach(function (panel, panelIndex) {
+                if (panelIndex === index) {
+                    panel.removeAttribute('hidden');
+                } else {
+                    panel.setAttribute('hidden', '');
+                }
+            });
+        }
+
+        // Honor whatever initial aria-selected the renderer stamped
+        // (defaults to the first trigger; a host can pre-select a
+        // different one). If none is marked selected, fall back to
+        // index 0.
+        var initialIndex = 0;
+        for (var t = 0; t < triggers.length; t += 1) {
+            if (triggers[t].getAttribute('aria-selected') === 'true') {
+                initialIndex = t;
+                break;
+            }
+        }
+
+        panels.forEach(function (panel, panelIndex) {
+            if (panelIndex !== initialIndex) {
+                panel.setAttribute('hidden', '');
+            }
+        });
+
+        triggers.forEach(function (trigger, triggerIndex) {
+            trigger.addEventListener('click', function (event) {
+                event.preventDefault();
+                activate(triggerIndex);
+            });
+
+            trigger.addEventListener('keydown', function (event) {
+                if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
+                    event.preventDefault();
+                    activate((triggerIndex + 1) % triggers.length);
+                } else if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
+                    event.preventDefault();
+                    activate((triggerIndex - 1 + triggers.length) % triggers.length);
+                } else if (event.key === 'Home') {
+                    event.preventDefault();
+                    activate(0);
+                } else if (event.key === 'End') {
+                    event.preventDefault();
+                    activate(triggers.length - 1);
+                }
+            });
+        });
+    }
+
+    function init() {
+        var accordions = document.querySelectorAll('.ap-accordion');
+        for (var i = 0; i < accordions.length; i += 1) {
+            bindAccordion(accordions[i]);
+        }
+
+        var tabs = document.querySelectorAll('[data-ap-tabs]');
+        for (var j = 0; j < tabs.length; j += 1) {
+            bindTabs(tabs[j]);
+        }
+    }
+
+    ready(init);
+
+    window.addEventListener('ap:rebind', init);
+})();

--- a/packages/visual-editor-renderer-blade/resources/assets/frontend/tabs.css
+++ b/packages/visual-editor-renderer-blade/resources/assets/frontend/tabs.css
@@ -1,0 +1,92 @@
+/**
+ * Front-end styles for the tabs family (artisanpack/tabs,
+ * artisanpack/tab-section — #497).
+ *
+ * Mirrors the editor preview styles in
+ * `resources/js/visual-editor/blocks/tabs/tabs.css`. Host apps load
+ * this stylesheet on any page that renders a tabs block.
+ */
+
+.ap-tabs {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+    margin-block-end: var(--wp--style--block-gap, 1.5rem);
+}
+
+.ap-tabs.align-tabs-vertical {
+    flex-direction: row;
+    align-items: stretch;
+}
+
+.ap-tabs__list {
+    border-bottom: 1px solid var(--ap-tabs-separator, rgba(0, 0, 0, 0.1));
+}
+
+.ap-tabs.align-tabs-vertical .ap-tabs__list {
+    border-right: 1px solid var(--ap-tabs-separator, rgba(0, 0, 0, 0.1));
+    border-bottom: 0;
+}
+
+.ap-tabs__list ul {
+    display: flex;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    gap: 0;
+}
+
+.ap-tabs.align-tabs-vertical .ap-tabs__list ul {
+    flex-direction: column;
+}
+
+.ap-tabs.space-tabs-start .ap-tabs__list ul {
+    justify-content: flex-start;
+}
+
+.ap-tabs.space-tabs-end .ap-tabs__list ul {
+    justify-content: flex-end;
+}
+
+.ap-tabs.space-tabs-center .ap-tabs__list ul {
+    justify-content: center;
+}
+
+.ap-tabs.space-tabs-equal .ap-tabs__list ul li {
+    flex: 1;
+}
+
+.ap-tabs.space-tabs-equal .ap-tabs__list ul li a {
+    text-align: center;
+    width: 100%;
+}
+
+.ap-tabs__list a {
+    display: inline-block;
+    padding: 0.5rem 1rem;
+    text-decoration: none;
+    color: inherit;
+    cursor: pointer;
+}
+
+.ap-tabs__list a[aria-selected="true"] {
+    font-weight: 600;
+    border-bottom: 2px solid currentColor;
+}
+
+.ap-tabs.align-tabs-vertical .ap-tabs__list a[aria-selected="true"] {
+    border-bottom: 0;
+    border-right: 2px solid currentColor;
+}
+
+.ap-tabs__container {
+    flex: 1;
+}
+
+.ap-tab-section {
+    padding: 1rem 0;
+}
+
+.ap-tab-section[hidden] {
+    display: none;
+}

--- a/packages/visual-editor-renderer-blade/resources/assets/frontend/tabs.css
+++ b/packages/visual-editor-renderer-blade/resources/assets/frontend/tabs.css
@@ -71,12 +71,12 @@
 
 .ap-tabs__list a[aria-selected="true"] {
     font-weight: 600;
-    border-bottom: 2px solid currentColor;
+    border-bottom: 2px solid currentcolor;
 }
 
 .ap-tabs.align-tabs-vertical .ap-tabs__list a[aria-selected="true"] {
     border-bottom: 0;
-    border-right: 2px solid currentColor;
+    border-right: 2px solid currentcolor;
 }
 
 .ap-tabs__container {

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/accordion-body.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/accordion-body.blade.php
@@ -1,0 +1,10 @@
+@php
+	use ArtisanPackUI\VisualEditorRendererBlade\Support\BlockSupports;
+@endphp
+{{-- Fallback wrapper when rendered outside an accordion parent. The parent
+     accordion partial walks innerBlocks directly and emits the full
+     region wiring (id, role, aria-labelledby) using the parent's
+     panelId, so this partial just outputs its content. --}}
+<div{!! BlockSupports::wrapperAttrs( $attributes, [ 'ap-accordion__body' ] ) !!}>
+	{!! $innerBlocksHtml !!}
+</div>

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/accordion-title.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/accordion-title.blade.php
@@ -1,0 +1,10 @@
+@php
+	use ArtisanPackUI\VisualEditorRendererBlade\Support\BlockSupports;
+@endphp
+{{-- Fallback wrapper when rendered outside an accordion parent. The parent
+     accordion partial walks innerBlocks directly and emits the full
+     toggle wiring (role, aria-controls, id, icon) using the parent's
+     panelId, so this partial just outputs its content. --}}
+<div{!! BlockSupports::wrapperAttrs( $attributes, [ 'ap-accordion__title' ] ) !!}>
+	{!! $innerBlocksHtml !!}
+</div>

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/accordion.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/accordion.blade.php
@@ -1,0 +1,63 @@
+@php
+	use ArtisanPackUI\VisualEditorRendererBlade\Support\BlockSupports;
+
+	$renderer = app( \ArtisanPackUI\VisualEditorRendererBlade\BlockRenderer::class );
+
+	$panelId = isset( $attributes['panelId'] ) ? (string) $attributes['panelId'] : '';
+	// Escape once at assignment time so every downstream interpolation
+	// (id / aria-controls / aria-labelledby / data-panel-id) stays safe
+	// even when the persisted data didn't come from the editor's slugify.
+	$panelIdSafe = htmlspecialchars( $panelId, ENT_QUOTES | ENT_HTML5, 'UTF-8' );
+
+	$panelIcon = isset( $attributes['panelIcon'] ) ? (string) $attributes['panelIcon'] : 'plus-minus';
+
+	if ( ! in_array( $panelIcon, [ 'plus-minus', 'arrows' ], true ) ) {
+		$panelIcon = 'plus-minus';
+	}
+
+	$panelIdAttr   = '' === $panelId ? '' : ' data-panel-id="' . $panelIdSafe . '"';
+	$panelIconAttr = ' data-panel-icon="' . $panelIcon . '"';
+	$controlId     = '' === $panelId ? '' : $panelIdSafe . '-control';
+
+	$titleHtml = '';
+	$bodyHtml  = '';
+
+	foreach ( $innerBlocks as $child ) {
+		if ( ! is_array( $child ) || ! isset( $child['name'] ) ) {
+			continue;
+		}
+
+		$childInner = isset( $child['innerBlocks'] ) && is_array( $child['innerBlocks'] )
+			? $renderer->render( $child['innerBlocks'] )
+			: '';
+
+		if ( 'artisanpack/accordion-title' === $child['name'] ) {
+			$titleControlsAttr = '' === $panelId ? '' : ' aria-controls="' . $panelIdSafe . '"';
+			$titleIdAttr       = '' === $controlId ? '' : ' id="' . $controlId . '"';
+			$titleHtml = sprintf(
+				'<div class="ap-accordion__title"><div class="ap-accordion__title-content" role="button" tabindex="0" aria-expanded="false"%s%s>%s</div><span class="ap-accordion__icon ap-accordion__icon--%s" aria-hidden="true"></span></div>',
+				$titleIdAttr,
+				$titleControlsAttr,
+				$childInner,
+				htmlspecialchars( $panelIcon, ENT_QUOTES | ENT_HTML5, 'UTF-8' )
+			);
+			continue;
+		}
+
+		if ( 'artisanpack/accordion-body' === $child['name'] ) {
+			$bodyIdAttr         = '' === $panelId ? '' : ' id="' . $panelIdSafe . '"';
+			$bodyLabelledByAttr = '' === $controlId ? '' : ' aria-labelledby="' . $controlId . '"';
+			$bodyHtml = sprintf(
+				'<div class="ap-accordion__body"%s role="region"%s hidden>%s</div>',
+				$bodyIdAttr,
+				$bodyLabelledByAttr,
+				$childInner
+			);
+			continue;
+		}
+	}
+@endphp
+<div{!! BlockSupports::wrapperAttrs( $attributes, [ 'ap-accordion' ] ) !!}{!! $panelIdAttr !!}{!! $panelIconAttr !!}>
+	{!! $titleHtml !!}
+	{!! $bodyHtml !!}
+</div>

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/accordions.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/accordions.blade.php
@@ -1,0 +1,6 @@
+@php
+	use ArtisanPackUI\VisualEditorRendererBlade\Support\BlockSupports;
+@endphp
+<div{!! BlockSupports::wrapperAttrs( $attributes, [ 'ap-accordions' ] ) !!}>
+	{!! $innerBlocksHtml !!}
+</div>

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/tab-section.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/tab-section.blade.php
@@ -1,0 +1,14 @@
+@php
+	use ArtisanPackUI\VisualEditorRendererBlade\Support\BlockSupports;
+
+	$tabId = isset( $attributes['tabId'] ) ? (string) $attributes['tabId'] : '';
+	// Escape so quotes / brackets in the persisted slug can't break the
+	// surrounding attribute.
+	$tabIdSafe = htmlspecialchars( $tabId, ENT_QUOTES | ENT_HTML5, 'UTF-8' );
+
+	$idAttr        = '' === $tabId ? '' : ' id="tabs-panel-' . $tabIdSafe . '"';
+	$labelledByAttr = '' === $tabId ? '' : ' aria-labelledby="tabs-tab-' . $tabIdSafe . '"';
+@endphp
+<div{!! BlockSupports::wrapperAttrs( $attributes, [ 'ap-tab-section' ] ) !!}{!! $idAttr !!} role="tabpanel"{!! $labelledByAttr !!}>
+	{!! $innerBlocksHtml !!}
+</div>

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/tab-section.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/tab-section.blade.php
@@ -1,13 +1,21 @@
 @php
 	use ArtisanPackUI\VisualEditorRendererBlade\Support\BlockSupports;
 
-	$tabId = isset( $attributes['tabId'] ) ? (string) $attributes['tabId'] : '';
-	// Escape so quotes / brackets in the persisted slug can't break the
-	// surrounding attribute.
-	$tabIdSafe = htmlspecialchars( $tabId, ENT_QUOTES | ENT_HTML5, 'UTF-8' );
+	$tabIdRaw = isset( $attributes['tabId'] ) ? (string) $attributes['tabId'] : '';
+	// Slugify to a valid HTML id (lowercase ASCII + hyphens) so any
+	// special chars in the persisted value can't break the surrounding
+	// attribute markup or produce an unreachable ARIA target. Mirrors
+	// the sanitizeTabId helper in tabs.blade.php / React / Vue
+	// renderers — kept here for the standalone fallback when a
+	// tab-section is rendered outside its tabs parent.
+	$tabIdSlug  = preg_replace( '/[^a-z0-9-]+/', '-', strtolower( $tabIdRaw ) ) ?? '';
+	$tabIdSlug  = trim( $tabIdSlug, '-' );
+	// `block.json` does not declare an `id` support, so
+	// BlockSupports::wrapperAttrs cannot produce an `id` attribute —
+	// emitting our own here can't collide.
 
-	$idAttr        = '' === $tabId ? '' : ' id="tabs-panel-' . $tabIdSafe . '"';
-	$labelledByAttr = '' === $tabId ? '' : ' aria-labelledby="tabs-tab-' . $tabIdSafe . '"';
+	$idAttr        = '' === $tabIdSlug ? '' : ' id="tabs-panel-' . $tabIdSlug . '"';
+	$labelledByAttr = '' === $tabIdSlug ? '' : ' aria-labelledby="tabs-tab-' . $tabIdSlug . '"';
 @endphp
 <div{!! BlockSupports::wrapperAttrs( $attributes, [ 'ap-tab-section' ] ) !!}{!! $idAttr !!} role="tabpanel"{!! $labelledByAttr !!}>
 	{!! $innerBlocksHtml !!}

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/tabs.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/tabs.blade.php
@@ -1,0 +1,122 @@
+@php
+	use ArtisanPackUI\VisualEditorRendererBlade\Support\BlockSupports;
+
+	$renderer = app( \ArtisanPackUI\VisualEditorRendererBlade\BlockRenderer::class );
+
+	$validAlign   = [ 'horizontal', 'vertical' ];
+	$validSpacing = [ 'start', 'end', 'center', 'equal' ];
+
+	$tabsAlign = (string) ( $attributes['tabsAlign'] ?? 'horizontal' );
+
+	if ( ! in_array( $tabsAlign, $validAlign, true ) ) {
+		$tabsAlign = 'horizontal';
+	}
+
+	$tabsSpacing = (string) ( $attributes['tabsSpacing'] ?? 'start' );
+
+	if ( ! in_array( $tabsSpacing, $validSpacing, true ) ) {
+		$tabsSpacing = 'start';
+	}
+
+	/**
+	 * Normalize a tab id so it's safe to interpolate into HTML id /
+	 * aria-controls / fragment href values. Mirrors the React + Vue
+	 * sanitizeTabId helpers; positional fallback when the persisted
+	 * slug is empty.
+	 */
+	$sanitizeTabId = static function ( string $raw, int $sectionIndex ): string {
+		$slug = strtolower( $raw );
+		$slug = preg_replace( '/[^a-z0-9-]+/', '-', $slug ) ?? '';
+		$slug = trim( $slug, '-' );
+		return '' === $slug ? 'tab-' . $sectionIndex : $slug;
+	};
+
+	/**
+	 * Ensure a tab id is unique within the current tabs block — if the
+	 * author duplicated a tab-section (copy/paste, template clone) two
+	 * sections can land on the same slug, which would collapse the
+	 * trigger / panel ARIA wiring. Append a numeric suffix in that
+	 * case.
+	 */
+	$uniqueTabId = static function ( string $base, array &$used ): string {
+		if ( ! isset( $used[ $base ] ) ) {
+			$used[ $base ] = true;
+			return $base;
+		}
+		$suffix    = 2;
+		$candidate = $base . '-' . $suffix;
+		while ( isset( $used[ $candidate ] ) ) {
+			$suffix++;
+			$candidate = $base . '-' . $suffix;
+		}
+		$used[ $candidate ] = true;
+		return $candidate;
+	};
+
+	// Tab triggers AND panels are derived together from the inner
+	// blocks so the trigger anchor / aria-controls always lines up
+	// with the panel id, even when the section's persisted tabId is
+	// empty.
+	$tabs = [];
+	$sectionIndex = 0;
+	$usedIds = [];
+
+	foreach ( $innerBlocks as $child ) {
+		if ( ! is_array( $child ) || ( $child['name'] ?? '' ) !== 'artisanpack/tab-section' ) {
+			continue;
+		}
+
+		$sectionIndex++;
+		$childAttrs = isset( $child['attributes'] ) && is_array( $child['attributes'] ) ? $child['attributes'] : [];
+		$label  = (string) ( $childAttrs['label'] ?? '' );
+		$baseId = $sanitizeTabId( (string) ( $childAttrs['tabId'] ?? '' ), $sectionIndex );
+		$tabId  = $uniqueTabId( $baseId, $usedIds );
+
+		if ( '' === $label ) {
+			$label = 'Tab ' . $sectionIndex;
+		}
+
+		$childInner = isset( $child['innerBlocks'] ) && is_array( $child['innerBlocks'] )
+			? $renderer->render( $child['innerBlocks'] )
+			: '';
+
+		$tabs[] = [
+			'label'   => $label,
+			'tabId'   => $tabId,
+			'content' => $childInner,
+		];
+	}
+
+	$baseClasses = [ 'ap-tabs', 'align-tabs-' . $tabsAlign, 'space-tabs-' . $tabsSpacing ];
+@endphp
+<div{!! BlockSupports::wrapperAttrs( $attributes, $baseClasses ) !!} data-ap-tabs>
+	<div class="ap-tabs__list">
+		<ul role="tablist">
+			@foreach ( $tabs as $index => $trigger )
+				@php
+					$isFirst = 0 === $index;
+				@endphp
+				<li>
+					<a
+						href="#tabs-panel-{{ $trigger['tabId'] }}"
+						id="tabs-tab-{{ $trigger['tabId'] }}"
+						role="tab"
+						aria-controls="tabs-panel-{{ $trigger['tabId'] }}"
+						aria-selected="{{ $isFirst ? 'true' : 'false' }}"
+						tabindex="{{ $isFirst ? '0' : '-1' }}"
+					>{{ $trigger['label'] }}</a>
+				</li>
+			@endforeach
+		</ul>
+	</div>
+	<div class="ap-tabs__container">
+		@foreach ( $tabs as $tab )
+			<div
+				class="ap-tab-section"
+				role="tabpanel"
+				id="tabs-panel-{{ $tab['tabId'] }}"
+				aria-labelledby="tabs-tab-{{ $tab['tabId'] }}"
+			>{!! $tab['content'] !!}</div>
+		@endforeach
+	</div>
+</div>

--- a/packages/visual-editor-renderer-blade/resources/views/components/blocks-styles.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/components/blocks-styles.blade.php
@@ -2,6 +2,11 @@
 <link rel="stylesheet" href="{{ $styleHref }}" data-ve-block-library>
 <link rel="stylesheet" href="{{ $themeHref }}" data-ve-block-library-theme>
 @endif
+@if( $emitInteractive )
+<link rel="stylesheet" href="{{ $accordionStyleHref }}" data-ve-accordion>
+<link rel="stylesheet" href="{{ $tabsStyleHref }}" data-ve-tabs>
+<script src="{{ $interactivityScriptSrc }}" defer data-ve-interactivity></script>
+@endif
 @if( '' !== $themeTokensCss )
 <style data-ve-theme-tokens>{!! $themeTokensCss !!}</style>
 @endif

--- a/packages/visual-editor-renderer-blade/src/BlockRenderer.php
+++ b/packages/visual-editor-renderer-blade/src/BlockRenderer.php
@@ -106,13 +106,14 @@ class BlockRenderer
 		$attributes      = $this->normalizeAttributes( $block['attributes'] ?? [] );
 		$attributes      = $this->stampSiteMeta( $name, $attributes );
 		$attributes      = $this->stampLoginout( $name, $attributes );
-		$innerBlocksHtml = $this->render( $this->normalizeInnerBlocks( $block['innerBlocks'] ?? [] ) );
+		$innerBlocks     = $this->normalizeInnerBlocks( $block['innerBlocks'] ?? [] );
+		$innerBlocksHtml = $this->render( $innerBlocks );
 
 		if ( $this->dynamicBlocks->has( $name ) ) {
 			return $this->renderDynamic( $name, $attributes, $innerBlocksHtml );
 		}
 
-		return $this->renderStatic( $name, $attributes, $innerBlocksHtml );
+		return $this->renderStatic( $name, $attributes, $innerBlocksHtml, $innerBlocks );
 	}
 
 	/**
@@ -222,9 +223,10 @@ class BlockRenderer
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param  array<string, mixed>  $attributes
+	 * @param  array<string, mixed>          $attributes
+	 * @param  array<int, array<string, mixed>> $innerBlocks
 	 */
-	protected function renderStatic( string $name, array $attributes, string $innerBlocksHtml ): string
+	protected function renderStatic( string $name, array $attributes, string $innerBlocksHtml, array $innerBlocks = [] ): string
 	{
 		$partial = $this->resolvePartial( $name );
 
@@ -236,6 +238,7 @@ class BlockRenderer
 			'blockName'       => $name,
 			'attributes'      => $attributes,
 			'attrs'           => $attributes,
+			'innerBlocks'     => $innerBlocks,
 			'innerBlocksHtml' => $innerBlocksHtml,
 		];
 

--- a/packages/visual-editor-renderer-blade/src/View/Components/BlocksStylesComponent.php
+++ b/packages/visual-editor-renderer-blade/src/View/Components/BlocksStylesComponent.php
@@ -57,7 +57,15 @@ class BlocksStylesComponent extends Component
 
 	public string $themeHref;
 
+	public string $accordionStyleHref;
+
+	public string $tabsStyleHref;
+
+	public string $interactivityScriptSrc;
+
 	public bool $emitBlockLibrary;
+
+	public bool $emitInteractive;
 
 	public string $themeTokensCss;
 
@@ -69,19 +77,26 @@ class BlocksStylesComponent extends Component
 	 *                                  Defaults to {@see self::DEFAULT_ASSET_BASE}.
 	 * @param  bool  $bundle  Set to false to skip the block-library `<link>` tags (consumers who
 	 *                        already load Gutenberg's CSS from elsewhere).
+	 * @param  bool  $interactive  Set to false to skip the accordion + tabs front-end stylesheets
+	 *                             and interactivity script. Defaults to on.
 	 */
 	public function __construct(
 		protected ThemeJsonTokensCompiler $compiler,
 		?array $themeJson = null,
 		?string $assetBase = null,
 		bool $bundle = true,
+		bool $interactive = true,
 	) {
 		$base = $this->normaliseBase( $assetBase ?? self::DEFAULT_ASSET_BASE );
 
-		$this->styleHref        = $base . '/style.css';
-		$this->themeHref        = $base . '/theme.css';
-		$this->emitBlockLibrary = $bundle;
-		$this->themeTokensCss   = null === $themeJson ? '' : $this->compiler->compile( $themeJson );
+		$this->styleHref              = $base . '/style.css';
+		$this->themeHref              = $base . '/theme.css';
+		$this->accordionStyleHref     = $base . '/frontend/accordion.css';
+		$this->tabsStyleHref          = $base . '/frontend/tabs.css';
+		$this->interactivityScriptSrc = $base . '/frontend/interactivity.js';
+		$this->emitBlockLibrary       = $bundle;
+		$this->emitInteractive        = $interactive;
+		$this->themeTokensCss         = null === $themeJson ? '' : $this->compiler->compile( $themeJson );
 	}
 
 	public function render(): View

--- a/packages/visual-editor-renderer-blade/src/VisualEditorRendererBladeServiceProvider.php
+++ b/packages/visual-editor-renderer-blade/src/VisualEditorRendererBladeServiceProvider.php
@@ -132,9 +132,12 @@ class VisualEditorRendererBladeServiceProvider extends ServiceProvider
 
 			// Asset publish path: copies the bundled `@wordpress/block-library`
 			// CSS to the consumer's `public/vendor/visual-editor-renderer-blade/`,
-			// which `<x-ve-blocks-styles />` links to by default.
+			// which `<x-ve-blocks-styles />` links to by default. Also ships the
+			// accordion + tabs front-end stylesheets and interactivity script
+			// under `public/vendor/visual-editor-renderer-blade/frontend/`.
 			$this->publishes( [
 				__DIR__ . '/../resources/assets/block-library' => public_path( 'vendor/visual-editor-renderer-blade' ),
+				__DIR__ . '/../resources/assets/frontend'      => public_path( 'vendor/visual-editor-renderer-blade/frontend' ),
 			], 'visual-editor-renderer-blade-assets' );
 		}
 	}

--- a/packages/visual-editor-renderer-blade/tests/Unit/BlockRendererTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Unit/BlockRendererTest.php
@@ -609,6 +609,174 @@ it( 'renders an empty list when breadcrumbs trail is missing', function () {
 		->and( $html )->not->toContain( '<li class="ap-breadcrumbs__item' );
 } );
 
+it( 'renders an artisanpack/accordions tree with its nested panel + title/body grandchildren', function () {
+	$tree = [
+		makeBlock( 'artisanpack/accordions', [], [
+			makeBlock( 'artisanpack/accordion', [
+				'panelId'   => 'faq-1',
+				'panelIcon' => 'arrows',
+			], [
+				makeBlock( 'artisanpack/accordion-title', [], [
+					makeBlock( 'core/heading', [ 'level' => 3, 'content' => 'Question' ], [], 'h-1' ),
+				], 'title-1' ),
+				makeBlock( 'artisanpack/accordion-body', [], [
+					makeBlock( 'core/paragraph', [ 'content' => 'Answer.' ], [], 'p-1' ),
+				], 'body-1' ),
+			], 'panel-1' ),
+		] ),
+	];
+
+	$html = makeRenderer()->render( $tree );
+
+	expect( $html )->toContain( 'class="ap-accordions"' )
+		->and( $html )->toContain( 'class="ap-accordion"' )
+		->and( $html )->toContain( 'data-panel-id="faq-1"' )
+		->and( $html )->toContain( 'data-panel-icon="arrows"' )
+		->and( $html )->toContain( 'id="faq-1-control"' )
+		->and( $html )->toContain( 'aria-controls="faq-1"' )
+		->and( $html )->toContain( 'aria-expanded="false"' )
+		->and( $html )->toContain( 'ap-accordion__icon--arrows' )
+		->and( $html )->toContain( 'id="faq-1"' )
+		->and( $html )->toContain( 'aria-labelledby="faq-1-control"' )
+		->and( $html )->toContain( '<p class="wp-block-paragraph">Answer.</p>' )
+		->and( $html )->toContain( '<h3 class="wp-block-heading">Question</h3>' );
+} );
+
+it( 'falls back to safe defaults when accordion panelIcon is invalid', function () {
+	$tree = [
+		makeBlock( 'artisanpack/accordion', [
+			'panelId'   => 'faq-1',
+			'panelIcon' => 'evil"><script>',
+		] ),
+	];
+
+	$html = makeRenderer()->render( $tree );
+
+	expect( $html )->toContain( 'data-panel-icon="plus-minus"' )
+		->and( $html )->not->toContain( '<script>' );
+} );
+
+it( 'omits accordion-title aria wiring when the parent panel id is empty', function () {
+	$tree = [
+		makeBlock( 'artisanpack/accordion', [ 'panelId' => '', 'panelIcon' => 'plus-minus' ], [
+			makeBlock( 'artisanpack/accordion-title', [], [], 'title-1' ),
+			makeBlock( 'artisanpack/accordion-body', [], [], 'body-1' ),
+		] ),
+	];
+
+	$html = makeRenderer()->render( $tree );
+
+	expect( $html )->not->toContain( 'aria-controls=' )
+		->and( $html )->not->toContain( 'aria-labelledby=' )
+		->and( $html )->not->toContain( 'id="-control"' );
+} );
+
+it( 'renders an artisanpack/tabs tree with triggers derived from tab-section children', function () {
+	$tree = [
+		makeBlock( 'artisanpack/tabs', [
+			'tabsAlign'   => 'horizontal',
+			'tabsSpacing' => 'center',
+		], [
+			makeBlock( 'artisanpack/tab-section', [
+				'label' => 'Overview',
+				'tabId' => 'overview',
+			], [
+				makeBlock( 'core/paragraph', [ 'content' => 'Tab body' ], [], 'p-1' ),
+			], 'sec-1' ),
+			makeBlock( 'artisanpack/tab-section', [
+				'label' => 'Specs',
+				'tabId' => 'specs',
+			], [], 'sec-2' ),
+		] ),
+	];
+
+	$html = makeRenderer()->render( $tree );
+
+	expect( $html )->toContain( 'align-tabs-horizontal' )
+		->and( $html )->toContain( 'space-tabs-center' )
+		->and( $html )->toContain( 'data-ap-tabs' )
+		->and( $html )->toContain( 'role="tablist"' )
+		->and( $html )->toContain( 'href="#tabs-panel-overview"' )
+		->and( $html )->toContain( 'aria-controls="tabs-panel-overview"' )
+		->and( $html )->toContain( 'id="tabs-tab-overview"' )
+		->and( $html )->toContain( 'aria-selected="true"' )
+		->and( $html )->toContain( 'aria-selected="false"' )
+		->and( $html )->toContain( '>Overview</a>' )
+		->and( $html )->toContain( '>Specs</a>' )
+		->and( $html )->toContain( 'id="tabs-panel-overview"' )
+		->and( $html )->toContain( 'aria-labelledby="tabs-tab-overview"' )
+		->and( $html )->toContain( 'role="tabpanel"' )
+		->and( $html )->toContain( 'Tab body' );
+} );
+
+it( 'falls back to safe defaults when tabsAlign / tabsSpacing are invalid', function () {
+	$tree = [
+		makeBlock( 'artisanpack/tabs', [
+			'tabsAlign'   => 'diagonal',
+			'tabsSpacing' => 'sprawl',
+		] ),
+	];
+
+	$html = makeRenderer()->render( $tree );
+
+	expect( $html )->toContain( 'align-tabs-horizontal' )
+		->and( $html )->toContain( 'space-tabs-start' );
+} );
+
+it( 'deduplicates tab ids when two sections share the same slug', function () {
+	$tree = [
+		makeBlock( 'artisanpack/tabs', [], [
+			makeBlock( 'artisanpack/tab-section', [ 'label' => 'One', 'tabId' => 'overview' ], [], 'sec-1' ),
+			makeBlock( 'artisanpack/tab-section', [ 'label' => 'Two', 'tabId' => 'overview' ], [], 'sec-2' ),
+			makeBlock( 'artisanpack/tab-section', [ 'label' => 'Three', 'tabId' => 'overview' ], [], 'sec-3' ),
+		] ),
+	];
+
+	$html = makeRenderer()->render( $tree );
+
+	expect( $html )->toContain( 'id="tabs-panel-overview"' )
+		->and( $html )->toContain( 'id="tabs-panel-overview-2"' )
+		->and( $html )->toContain( 'id="tabs-panel-overview-3"' )
+		->and( $html )->toContain( 'href="#tabs-panel-overview-2"' )
+		->and( $html )->toContain( 'href="#tabs-panel-overview-3"' );
+} );
+
+it( 'auto-fills tab labels and ids by position when sections leave them blank', function () {
+	$tree = [
+		makeBlock( 'artisanpack/tabs', [], [
+			makeBlock( 'artisanpack/tab-section', [], [], 'sec-1' ),
+			makeBlock( 'artisanpack/tab-section', [], [], 'sec-2' ),
+		] ),
+	];
+
+	$html = makeRenderer()->render( $tree );
+
+	expect( $html )->toContain( '>Tab 1</a>' )
+		->and( $html )->toContain( '>Tab 2</a>' )
+		// Triggers and panels MUST share the same resolved id so the
+		// aria-controls / id hookup actually resolves.
+		->and( $html )->toContain( 'href="#tabs-panel-tab-1"' )
+		->and( $html )->toContain( 'href="#tabs-panel-tab-2"' )
+		->and( $html )->toContain( 'id="tabs-panel-tab-1"' )
+		->and( $html )->toContain( 'id="tabs-panel-tab-2"' )
+		->and( $html )->toContain( 'aria-labelledby="tabs-tab-tab-1"' )
+		->and( $html )->toContain( 'aria-labelledby="tabs-tab-tab-2"' );
+} );
+
+it( 'renders a tab-section without aria wiring when tabId is empty', function () {
+	$tree = [
+		makeBlock( 'artisanpack/tab-section', [ 'tabId' => '' ], [
+			makeBlock( 'core/paragraph', [ 'content' => 'Naked' ], [], 'p-1' ),
+		] ),
+	];
+
+	$html = makeRenderer()->render( $tree );
+
+	expect( $html )->not->toContain( 'id="tabs-panel-"' )
+		->and( $html )->not->toContain( 'aria-labelledby=' )
+		->and( $html )->toContain( 'Naked' );
+} );
+
 describe( 'Keystone #50 — block-supports compilation on the rendered HTML', function (): void {
 	it( 'renders a custom background color on core/group as both class marker and inline style', function (): void {
 		$tree = [ makeBlock( 'core/group', [

--- a/packages/visual-editor-renderer-react/src/blocks/artisanpack/accordion.tsx
+++ b/packages/visual-editor-renderer-react/src/blocks/artisanpack/accordion.tsx
@@ -1,0 +1,129 @@
+/**
+ * React renderers for the `artisanpack/accordions` family (#497).
+ * Mirrors the Blade partials and the Vue components so every renderer
+ * emits identical markup.
+ *
+ * The accordion is the single source of truth for the panel id and
+ * toggle icon. Its renderer walks the pre-rendered children, extracts
+ * the title and body grandchildren by name, and re-wraps them with the
+ * matching `id` / `aria-controls` / `aria-labelledby` wiring. The
+ * standalone title and body renderers just emit plain wrappers so they
+ * still produce reasonable markup if rendered outside an accordion.
+ */
+
+import { Children, isValidElement, type JSX, type ReactNode } from 'react';
+
+import { attrString, classList } from '../../support/attributes';
+import type { Block, BlockRendererProps } from '../../types';
+
+type AccordionPanelIcon = 'plus-minus' | 'arrows';
+
+const VALID_PANEL_ICONS: ReadonlyArray<AccordionPanelIcon> = ['plus-minus', 'arrows'];
+
+function normalizePanelIcon(value: unknown): AccordionPanelIcon {
+    const raw = attrString(value, 'plus-minus');
+    return (VALID_PANEL_ICONS as ReadonlyArray<string>).includes(raw)
+        ? (raw as AccordionPanelIcon)
+        : 'plus-minus';
+}
+
+function findChildByName(
+    children: ReactNode,
+    innerBlocks: Block[],
+    name: string
+): ReactNode {
+    const index = innerBlocks.findIndex((block) => block.name === name);
+    if (index === -1) {
+        return null;
+    }
+
+    const childArray = Children.toArray(children);
+    const child = childArray[index];
+
+    if (!isValidElement(child)) {
+        return null;
+    }
+
+    // Each child renderer wraps its own grandchildren in a plain block
+    // wrapper; we want the grandchildren (heading / paragraph etc),
+    // not the title/body's own wrapper. Reach through `props.children`
+    // to grab the pre-rendered grandchildren the BlockTree walker
+    // already produced.
+    const props = child.props as { children?: ReactNode };
+    return props.children ?? null;
+}
+
+export function AccordionsBlock({ attributes, children }: BlockRendererProps): JSX.Element {
+    const className = attrString(attributes.className);
+    const classes = classList(['ap-accordions', className]);
+
+    return <div className={classes}>{children}</div>;
+}
+
+export function AccordionBlock({
+    attributes,
+    innerBlocks,
+    children,
+}: BlockRendererProps): JSX.Element {
+    const panelId = attrString(attributes.panelId);
+    const panelIcon = normalizePanelIcon(attributes.panelIcon);
+    const className = attrString(attributes.className);
+    const classes = classList(['ap-accordion', className]);
+
+    const titleContent = findChildByName(children, innerBlocks, 'artisanpack/accordion-title');
+    const bodyContent = findChildByName(children, innerBlocks, 'artisanpack/accordion-body');
+
+    const wrapperAttrs: Record<string, unknown> = {
+        className: classes,
+        'data-panel-icon': panelIcon,
+    };
+    if (panelId !== '') {
+        wrapperAttrs['data-panel-id'] = panelId;
+    }
+
+    const triggerAttrs: Record<string, unknown> = {
+        className: 'ap-accordion__title-content',
+        role: 'button',
+        tabIndex: 0,
+        'aria-expanded': 'false',
+    };
+    if (panelId !== '') {
+        triggerAttrs.id = `${panelId}-control`;
+        triggerAttrs['aria-controls'] = panelId;
+    }
+
+    const bodyAttrs: Record<string, unknown> = {
+        className: 'ap-accordion__body',
+        role: 'region',
+        hidden: true,
+    };
+    if (panelId !== '') {
+        bodyAttrs.id = panelId;
+        bodyAttrs['aria-labelledby'] = `${panelId}-control`;
+    }
+
+    return (
+        <div {...wrapperAttrs}>
+            <div className="ap-accordion__title">
+                <div {...triggerAttrs}>{titleContent}</div>
+                <span
+                    className={`ap-accordion__icon ap-accordion__icon--${panelIcon}`}
+                    aria-hidden="true"
+                />
+            </div>
+            <div {...bodyAttrs}>{bodyContent}</div>
+        </div>
+    );
+}
+
+// Standalone fallback when rendered outside an accordion. The accordion
+// wrapper reaches through `children` and rewraps them, so these only
+// surface when something else renders the title/body in isolation.
+
+export function AccordionTitleBlock({ children }: BlockRendererProps): JSX.Element {
+    return <div className="ap-accordion__title">{children}</div>;
+}
+
+export function AccordionBodyBlock({ children }: BlockRendererProps): JSX.Element {
+    return <div className="ap-accordion__body">{children}</div>;
+}

--- a/packages/visual-editor-renderer-react/src/blocks/artisanpack/tabs.tsx
+++ b/packages/visual-editor-renderer-react/src/blocks/artisanpack/tabs.tsx
@@ -1,0 +1,190 @@
+/**
+ * React renderers for the `artisanpack/tabs` family (#497).
+ *
+ * Tab triggers are derived from the inner-block tab-sections — each
+ * section owns its own `label` and `tabId`. The tabs renderer walks
+ * `innerBlocks` to build the tablist AND re-wraps each tab-section's
+ * pre-rendered grandchildren with the SAME resolved tabId, so the
+ * trigger `aria-controls` always lines up with the panel `id` even
+ * when the persisted tabId is missing and a positional fallback kicks
+ * in.
+ */
+
+import { Children, isValidElement, type JSX, type ReactNode } from 'react';
+
+import { attrString, classList } from '../../support/attributes';
+import type { Block, BlockRendererProps } from '../../types';
+
+type TabsAlign = 'horizontal' | 'vertical';
+type TabsSpacing = 'start' | 'end' | 'center' | 'equal';
+
+const VALID_ALIGNS: ReadonlyArray<TabsAlign> = ['horizontal', 'vertical'];
+const VALID_SPACINGS: ReadonlyArray<TabsSpacing> = ['start', 'end', 'center', 'equal'];
+
+interface TabRecord {
+    readonly label: string;
+    readonly tabId: string;
+    readonly content: ReactNode;
+}
+
+function normalizeAlign(value: unknown): TabsAlign {
+    const raw = attrString(value, 'horizontal');
+    return (VALID_ALIGNS as ReadonlyArray<string>).includes(raw)
+        ? (raw as TabsAlign)
+        : 'horizontal';
+}
+
+function normalizeSpacing(value: unknown): TabsSpacing {
+    const raw = attrString(value, 'start');
+    return (VALID_SPACINGS as ReadonlyArray<string>).includes(raw)
+        ? (raw as TabsSpacing)
+        : 'start';
+}
+
+/**
+ * Normalize a tab id so it's safe to interpolate into HTML id /
+ * aria-controls / fragment href values. Mirrors the editor-side
+ * slugify, with a positional fallback when the result is empty.
+ */
+function sanitizeTabId(raw: string, sectionIndex: number): string {
+    const slug = raw
+        .toLowerCase()
+        .replace(/[^a-z0-9-]+/g, '-')
+        .replace(/^-+|-+$/g, '');
+    return slug === '' ? `tab-${sectionIndex}` : slug;
+}
+
+/**
+ * Ensure a tab id is unique within the current tabs block — if the
+ * author duplicated a tab-section (copy/paste, template clone) two
+ * sections can land on the same slug, which would collapse the
+ * trigger / panel ARIA wiring. Append a numeric suffix in that case.
+ */
+function uniqueTabId(base: string, used: Set<string>): string {
+    if (!used.has(base)) {
+        used.add(base);
+        return base;
+    }
+    let suffix = 2;
+    let candidate = `${base}-${suffix}`;
+    while (used.has(candidate)) {
+        suffix += 1;
+        candidate = `${base}-${suffix}`;
+    }
+    used.add(candidate);
+    return candidate;
+}
+
+export function TabsBlock({
+    attributes,
+    innerBlocks,
+    children,
+}: BlockRendererProps): JSX.Element {
+    const tabsAlign = normalizeAlign(attributes.tabsAlign);
+    const tabsSpacing = normalizeSpacing(attributes.tabsSpacing);
+    const className = attrString(attributes.className);
+
+    const classes = classList([
+        'ap-tabs',
+        `align-tabs-${tabsAlign}`,
+        `space-tabs-${tabsSpacing}`,
+        className,
+    ]);
+
+    const childArray = Children.toArray(children);
+
+    const tabs: TabRecord[] = [];
+    const usedIds = new Set<string>();
+    let sectionIndex = 0;
+    innerBlocks.forEach((child: Block, index: number) => {
+        if (child.name !== 'artisanpack/tab-section') {
+            return;
+        }
+        sectionIndex += 1;
+        const childAttrs = (child.attributes ?? {}) as Record<string, unknown>;
+        const labelRaw = attrString(childAttrs.label);
+        const baseId = sanitizeTabId(attrString(childAttrs.tabId), sectionIndex);
+        const tabId = uniqueTabId(baseId, usedIds);
+
+        // Reach through the pre-rendered child element to grab its
+        // grandchildren (the paragraph, group, … the tab-section
+        // wraps). Re-wrapping them here lets us stamp the resolved
+        // tabId onto the panel so the trigger anchor always lines up.
+        // `childArray[index]` uses the raw innerBlocks index so
+        // non-tab-section siblings stay paired with their own VNode.
+        const childEl = childArray[index];
+        const content = isValidElement(childEl)
+            ? (childEl.props as { children?: ReactNode }).children ?? null
+            : null;
+
+        tabs.push({
+            label: labelRaw === '' ? `Tab ${sectionIndex}` : labelRaw,
+            tabId,
+            content,
+        });
+    });
+
+    return (
+        <div className={classes} data-ap-tabs>
+            <div className="ap-tabs__list">
+                <ul role="tablist">
+                    {tabs.map((tab, index) => {
+                        const isFirst = index === 0;
+                        return (
+                            <li key={`${index}-${tab.tabId}`}>
+                                <a
+                                    href={`#tabs-panel-${tab.tabId}`}
+                                    id={`tabs-tab-${tab.tabId}`}
+                                    role="tab"
+                                    aria-controls={`tabs-panel-${tab.tabId}`}
+                                    aria-selected={isFirst ? 'true' : 'false'}
+                                    tabIndex={isFirst ? 0 : -1}
+                                >
+                                    {tab.label}
+                                </a>
+                            </li>
+                        );
+                    })}
+                </ul>
+            </div>
+            <div className="ap-tabs__container">
+                {tabs.map((tab, index) => (
+                    <div
+                        key={`panel-${index}-${tab.tabId}`}
+                        className="ap-tab-section"
+                        role="tabpanel"
+                        id={`tabs-panel-${tab.tabId}`}
+                        aria-labelledby={`tabs-tab-${tab.tabId}`}
+                    >
+                        {tab.content}
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+}
+
+// Standalone fallback when rendered outside a tabs parent. The tabs
+// wrapper reaches through `children` and rewraps them, so this only
+// surfaces when something else renders the section in isolation.
+export function TabSectionBlock({
+    attributes,
+    children,
+}: BlockRendererProps): JSX.Element {
+    const tabId = attrString(attributes.tabId);
+    const className = attrString(attributes.className);
+    const classes = classList(['ap-tab-section', className]);
+
+    const wrapperProps: Record<string, unknown> = {
+        className: classes,
+        role: 'tabpanel',
+    };
+
+    if (tabId !== '') {
+        const safeId = sanitizeTabId(tabId, 1);
+        wrapperProps.id = `tabs-panel-${safeId}`;
+        wrapperProps['aria-labelledby'] = `tabs-tab-${safeId}`;
+    }
+
+    return <div {...wrapperProps}>{children}</div>;
+}

--- a/packages/visual-editor-renderer-react/src/blocks/registerCoreBlocks.ts
+++ b/packages/visual-editor-renderer-react/src/blocks/registerCoreBlocks.ts
@@ -12,8 +12,15 @@
  */
 
 import { registerBlockRenderer } from '../registry';
+import {
+    AccordionBlock,
+    AccordionBodyBlock,
+    AccordionTitleBlock,
+    AccordionsBlock,
+} from './artisanpack/accordion';
 import { BreadcrumbsBlock } from './artisanpack/breadcrumbs';
 import { CalloutBlock } from './artisanpack/callout';
+import { TabSectionBlock, TabsBlock } from './artisanpack/tabs';
 import { LoginoutBlock } from './artisanpack/loginout';
 import {
     CoverBlock,
@@ -213,6 +220,14 @@ const CORE_BLOCKS: Record<string, BlockRenderer> = {
     'core/navigation-submenu': NavigationSubmenuBlock,
     'artisanpack/breadcrumbs': BreadcrumbsBlock,
     'artisanpack/callout': CalloutBlock,
+    // Accordion + tabs families (#497). Interactive blocks with
+    // parent/child inner-block relationships preserved across renderers.
+    'artisanpack/accordions': AccordionsBlock,
+    'artisanpack/accordion': AccordionBlock,
+    'artisanpack/accordion-title': AccordionTitleBlock,
+    'artisanpack/accordion-body': AccordionBodyBlock,
+    'artisanpack/tabs': TabsBlock,
+    'artisanpack/tab-section': TabSectionBlock,
     // Post navigation / metadata family (#520) — same renderer for both
     // namespaces; PostResolver stamps the same `_resolved*` attributes.
     'core/post-navigation-link': PostNavigationLinkBlock,

--- a/packages/visual-editor-renderer-react/tests/BlockTree.test.tsx
+++ b/packages/visual-editor-renderer-react/tests/BlockTree.test.tsx
@@ -692,6 +692,193 @@ describe('Core design blocks', () => {
         expect(html).toContain('ap-breadcrumbs__list');
         expect(html).not.toContain('<li class="ap-breadcrumbs__item');
     });
+
+    it('renders the artisanpack/accordions family with nested grandchildren', () => {
+        const tree = [
+            makeBlock('artisanpack/accordions', {}, [
+                makeBlock(
+                    'artisanpack/accordion',
+                    { panelId: 'faq-1', panelIcon: 'arrows' },
+                    [
+                        makeBlock('artisanpack/accordion-title', {}, [
+                            makeBlock('core/heading', {
+                                level: 3,
+                                content: 'Question',
+                            }),
+                        ]),
+                        makeBlock('artisanpack/accordion-body', {}, [
+                            makeBlock('core/paragraph', { content: 'Answer.' }),
+                        ]),
+                    ]
+                ),
+            ]),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('class="ap-accordions"');
+        expect(html).toContain('class="ap-accordion"');
+        expect(html).toContain('data-panel-id="faq-1"');
+        expect(html).toContain('data-panel-icon="arrows"');
+        expect(html).toContain('id="faq-1-control"');
+        expect(html).toContain('aria-controls="faq-1"');
+        expect(html).toContain('aria-expanded="false"');
+        expect(html).toContain('ap-accordion__icon--arrows');
+        expect(html).toContain('id="faq-1"');
+        expect(html).toContain('aria-labelledby="faq-1-control"');
+        expect(html).toContain('<p class="wp-block-paragraph">Answer.</p>');
+    });
+
+    it('falls back to safe defaults when accordion panelIcon is invalid', () => {
+        const tree = [
+            makeBlock('artisanpack/accordion', {
+                panelId: 'faq-1',
+                panelIcon: 'evil"><script>',
+            }),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('data-panel-icon="plus-minus"');
+        expect(html).not.toContain('<script>');
+    });
+
+    it('omits accordion aria wiring when the parent panel id is empty', () => {
+        const tree = [
+            makeBlock(
+                'artisanpack/accordion',
+                { panelId: '', panelIcon: 'plus-minus' },
+                [
+                    makeBlock('artisanpack/accordion-title', {}),
+                    makeBlock('artisanpack/accordion-body', {}),
+                ]
+            ),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).not.toContain('aria-controls=');
+        expect(html).not.toContain('aria-labelledby=');
+        expect(html).not.toContain('id="-control"');
+    });
+
+    it('renders the artisanpack/tabs family with triggers derived from tab-section children', () => {
+        const tree = [
+            makeBlock(
+                'artisanpack/tabs',
+                {
+                    tabsAlign: 'horizontal',
+                    tabsSpacing: 'center',
+                },
+                [
+                    makeBlock(
+                        'artisanpack/tab-section',
+                        { label: 'Overview', tabId: 'overview' },
+                        [makeBlock('core/paragraph', { content: 'Tab body' })]
+                    ),
+                    makeBlock('artisanpack/tab-section', {
+                        label: 'Specs',
+                        tabId: 'specs',
+                    }),
+                ]
+            ),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('align-tabs-horizontal');
+        expect(html).toContain('space-tabs-center');
+        expect(html).toContain('data-ap-tabs');
+        expect(html).toContain('role="tablist"');
+        expect(html).toContain('href="#tabs-panel-overview"');
+        expect(html).toContain('aria-controls="tabs-panel-overview"');
+        expect(html).toContain('id="tabs-tab-overview"');
+        expect(html).toContain('aria-selected="true"');
+        expect(html).toContain('aria-selected="false"');
+        expect(html).toContain('>Overview</a>');
+        expect(html).toContain('>Specs</a>');
+        expect(html).toContain('id="tabs-panel-overview"');
+        expect(html).toContain('aria-labelledby="tabs-tab-overview"');
+        expect(html).toContain('role="tabpanel"');
+        expect(html).toContain('Tab body');
+    });
+
+    it('falls back to safe defaults when tabsAlign / tabsSpacing are invalid', () => {
+        const tree = [
+            makeBlock('artisanpack/tabs', {
+                tabsAlign: 'diagonal',
+                tabsSpacing: 'sprawl',
+            }),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('align-tabs-horizontal');
+        expect(html).toContain('space-tabs-start');
+    });
+
+    it('deduplicates tab ids when two sections share the same slug', () => {
+        const tree = [
+            makeBlock('artisanpack/tabs', {}, [
+                makeBlock('artisanpack/tab-section', {
+                    label: 'One',
+                    tabId: 'overview',
+                }),
+                makeBlock('artisanpack/tab-section', {
+                    label: 'Two',
+                    tabId: 'overview',
+                }),
+                makeBlock('artisanpack/tab-section', {
+                    label: 'Three',
+                    tabId: 'overview',
+                }),
+            ]),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('id="tabs-panel-overview"');
+        expect(html).toContain('id="tabs-panel-overview-2"');
+        expect(html).toContain('id="tabs-panel-overview-3"');
+        expect(html).toContain('href="#tabs-panel-overview-2"');
+        expect(html).toContain('href="#tabs-panel-overview-3"');
+    });
+
+    it('auto-fills tab labels and ids by position when sections leave them blank', () => {
+        const tree = [
+            makeBlock('artisanpack/tabs', {}, [
+                makeBlock('artisanpack/tab-section', {}),
+                makeBlock('artisanpack/tab-section', {}),
+            ]),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('>Tab 1</a>');
+        expect(html).toContain('>Tab 2</a>');
+        expect(html).toContain('href="#tabs-panel-tab-1"');
+        expect(html).toContain('href="#tabs-panel-tab-2"');
+        // Triggers and panels MUST share the same resolved id so the
+        // aria-controls / id hookup actually resolves.
+        expect(html).toContain('id="tabs-panel-tab-1"');
+        expect(html).toContain('id="tabs-panel-tab-2"');
+        expect(html).toContain('aria-labelledby="tabs-tab-tab-1"');
+        expect(html).toContain('aria-labelledby="tabs-tab-tab-2"');
+    });
+
+    it('renders a tab-section without aria wiring when tabId is empty', () => {
+        const tree = [
+            makeBlock('artisanpack/tab-section', { tabId: '' }, [
+                makeBlock('core/paragraph', { content: 'Naked' }),
+            ]),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).not.toContain('id="tabs-panel-"');
+        expect(html).not.toContain('aria-labelledby=');
+        expect(html).toContain('Naked');
+    });
 });
 
 describe('Registry + dynamic fallback', () => {

--- a/packages/visual-editor-renderer-vue/src/blocks/artisanpack/accordion.ts
+++ b/packages/visual-editor-renderer-vue/src/blocks/artisanpack/accordion.ts
@@ -1,0 +1,168 @@
+/**
+ * Vue renderers for the `artisanpack/accordions` family (#497).
+ * Mirrors the Blade partials and React renderers so every environment
+ * emits identical markup.
+ *
+ * The accordion is the single source of truth for the panel id and
+ * toggle icon. Its renderer reaches through the slot's title/body
+ * VNodes to grab the grandchildren (the heading and paragraph) so it
+ * can re-wrap them with the matching `id` / `aria-controls` /
+ * `aria-labelledby` wiring.
+ */
+
+import { defineComponent, h, type VNode } from 'vue';
+
+import { attrString, classList } from '../../support/attributes';
+import { blockRendererProps } from '../shared';
+
+type AccordionPanelIcon = 'plus-minus' | 'arrows';
+
+const VALID_PANEL_ICONS: ReadonlyArray<AccordionPanelIcon> = ['plus-minus', 'arrows'];
+
+function normalizePanelIcon(value: unknown): AccordionPanelIcon {
+    const raw = attrString(value, 'plus-minus');
+    return (VALID_PANEL_ICONS as ReadonlyArray<string>).includes(raw)
+        ? (raw as AccordionPanelIcon)
+        : 'plus-minus';
+}
+
+function extractSlotContent(vnode: VNode | null): unknown {
+    if (vnode === null || vnode === undefined) {
+        return null;
+    }
+
+    const children = vnode.children;
+    if (children !== null && typeof children === 'object' && 'default' in children) {
+        const slot = (children as { default?: () => unknown }).default;
+        return typeof slot === 'function' ? slot() : null;
+    }
+
+    return null;
+}
+
+function findChildBlockVnode(
+    slotVnodes: VNode[],
+    innerBlocks: ReadonlyArray<{ name?: string }>,
+    name: string
+): VNode | null {
+    const index = innerBlocks.findIndex((block) => block?.name === name);
+    if (index === -1) {
+        return null;
+    }
+    return slotVnodes[index] ?? null;
+}
+
+export const AccordionsBlock = defineComponent({
+    name: 'AccordionsBlock',
+    props: blockRendererProps,
+    setup(props, { slots }) {
+        return () => {
+            const className = attrString(props.attributes.className);
+            const classes = classList(['ap-accordions', className]);
+
+            return h(
+                'div',
+                { class: classes },
+                slots.default ? slots.default() : []
+            );
+        };
+    },
+});
+
+export const AccordionBlock = defineComponent({
+    name: 'AccordionBlock',
+    props: blockRendererProps,
+    setup(props, { slots }) {
+        return () => {
+            const panelId = attrString(props.attributes.panelId);
+            const panelIcon = normalizePanelIcon(props.attributes.panelIcon);
+            const className = attrString(props.attributes.className);
+            const classes = classList(['ap-accordion', className]);
+
+            const slotVnodes = (slots.default ? slots.default() : []) as VNode[];
+            const titleVnode = findChildBlockVnode(
+                slotVnodes,
+                props.innerBlocks,
+                'artisanpack/accordion-title'
+            );
+            const bodyVnode = findChildBlockVnode(
+                slotVnodes,
+                props.innerBlocks,
+                'artisanpack/accordion-body'
+            );
+
+            const wrapperAttrs: Record<string, unknown> = {
+                class: classes,
+                'data-panel-icon': panelIcon,
+            };
+            if (panelId !== '') {
+                wrapperAttrs['data-panel-id'] = panelId;
+            }
+
+            const triggerAttrs: Record<string, unknown> = {
+                class: 'ap-accordion__title-content',
+                role: 'button',
+                tabindex: '0',
+                'aria-expanded': 'false',
+            };
+            if (panelId !== '') {
+                triggerAttrs.id = `${panelId}-control`;
+                triggerAttrs['aria-controls'] = panelId;
+            }
+
+            const bodyAttrs: Record<string, unknown> = {
+                class: 'ap-accordion__body',
+                role: 'region',
+                hidden: '',
+            };
+            if (panelId !== '') {
+                bodyAttrs.id = panelId;
+                bodyAttrs['aria-labelledby'] = `${panelId}-control`;
+            }
+
+            const titleContent = extractSlotContent(titleVnode) as VNode[] | null;
+            const bodyContent = extractSlotContent(bodyVnode) as VNode[] | null;
+
+            return h('div', wrapperAttrs, [
+                h('div', { class: 'ap-accordion__title' }, [
+                    h('div', triggerAttrs, titleContent ?? []),
+                    h('span', {
+                        class: `ap-accordion__icon ap-accordion__icon--${panelIcon}`,
+                        'aria-hidden': 'true',
+                    }),
+                ]),
+                h('div', bodyAttrs, bodyContent ?? []),
+            ]);
+        };
+    },
+});
+
+// Standalone fallback when rendered outside an accordion. The accordion
+// wrapper reaches into these via the slot mechanism, so these only
+// surface when something else renders the title/body in isolation.
+
+export const AccordionTitleBlock = defineComponent({
+    name: 'AccordionTitleBlock',
+    props: blockRendererProps,
+    setup(_props, { slots }) {
+        return () =>
+            h(
+                'div',
+                { class: 'ap-accordion__title' },
+                slots.default ? slots.default() : []
+            );
+    },
+});
+
+export const AccordionBodyBlock = defineComponent({
+    name: 'AccordionBodyBlock',
+    props: blockRendererProps,
+    setup(_props, { slots }) {
+        return () =>
+            h(
+                'div',
+                { class: 'ap-accordion__body' },
+                slots.default ? slots.default() : []
+            );
+    },
+});

--- a/packages/visual-editor-renderer-vue/src/blocks/artisanpack/tabs.ts
+++ b/packages/visual-editor-renderer-vue/src/blocks/artisanpack/tabs.ts
@@ -1,0 +1,193 @@
+/**
+ * Vue renderers for the `artisanpack/tabs` family (#497). Mirrors the
+ * Blade and React renderers so every rendering environment emits
+ * identical markup.
+ *
+ * Tab triggers are derived from the inner-block tab-sections — each
+ * section owns its own `label` and `tabId`. The tabs renderer walks
+ * `innerBlocks` to build the tablist AND re-wraps each tab-section's
+ * pre-rendered grandchildren with the SAME resolved tabId so the
+ * trigger `aria-controls` always lines up with the panel `id`.
+ */
+
+import { defineComponent, h, type VNode } from 'vue';
+
+import { attrString, classList } from '../../support/attributes';
+import { blockRendererProps } from '../shared';
+
+type TabsAlign = 'horizontal' | 'vertical';
+type TabsSpacing = 'start' | 'end' | 'center' | 'equal';
+
+const VALID_ALIGNS: ReadonlyArray<TabsAlign> = ['horizontal', 'vertical'];
+const VALID_SPACINGS: ReadonlyArray<TabsSpacing> = ['start', 'end', 'center', 'equal'];
+
+interface TabRecord {
+    readonly label: string;
+    readonly tabId: string;
+    readonly content: VNode[];
+}
+
+function normalizeAlign(value: unknown): TabsAlign {
+    const raw = attrString(value, 'horizontal');
+    return (VALID_ALIGNS as ReadonlyArray<string>).includes(raw)
+        ? (raw as TabsAlign)
+        : 'horizontal';
+}
+
+function normalizeSpacing(value: unknown): TabsSpacing {
+    const raw = attrString(value, 'start');
+    return (VALID_SPACINGS as ReadonlyArray<string>).includes(raw)
+        ? (raw as TabsSpacing)
+        : 'start';
+}
+
+function sanitizeTabId(raw: string, sectionIndex: number): string {
+    const slug = raw
+        .toLowerCase()
+        .replace(/[^a-z0-9-]+/g, '-')
+        .replace(/^-+|-+$/g, '');
+    return slug === '' ? `tab-${sectionIndex}` : slug;
+}
+
+/**
+ * Ensure a tab id is unique within the current tabs block — if the
+ * author duplicated a tab-section (copy/paste, template clone) two
+ * sections can land on the same slug, which would collapse the
+ * trigger / panel ARIA wiring. Append a numeric suffix in that case.
+ */
+function uniqueTabId(base: string, used: Set<string>): string {
+    if (!used.has(base)) {
+        used.add(base);
+        return base;
+    }
+    let suffix = 2;
+    let candidate = `${base}-${suffix}`;
+    while (used.has(candidate)) {
+        suffix += 1;
+        candidate = `${base}-${suffix}`;
+    }
+    used.add(candidate);
+    return candidate;
+}
+
+function extractSlotContent(vnode: VNode | null | undefined): VNode[] {
+    if (vnode === null || vnode === undefined) {
+        return [];
+    }
+    const children = vnode.children;
+    if (children !== null && typeof children === 'object' && 'default' in children) {
+        const slot = (children as { default?: () => unknown }).default;
+        if (typeof slot === 'function') {
+            const result = slot();
+            return Array.isArray(result) ? (result as VNode[]) : [];
+        }
+    }
+    return [];
+}
+
+export const TabsBlock = defineComponent({
+    name: 'TabsBlock',
+    props: blockRendererProps,
+    setup(props, { slots }) {
+        return () => {
+            const tabsAlign = normalizeAlign(props.attributes.tabsAlign);
+            const tabsSpacing = normalizeSpacing(props.attributes.tabsSpacing);
+            const className = attrString(props.attributes.className);
+            const classes = classList([
+                'ap-tabs',
+                `align-tabs-${tabsAlign}`,
+                `space-tabs-${tabsSpacing}`,
+                className,
+            ]);
+
+            const slotVnodes = (slots.default ? slots.default() : []) as VNode[];
+
+            const tabs: TabRecord[] = [];
+            const usedIds = new Set<string>();
+            let sectionIndex = 0;
+            props.innerBlocks.forEach((child, index) => {
+                if (child.name !== 'artisanpack/tab-section') {
+                    return;
+                }
+                sectionIndex += 1;
+                const childAttrs = (child.attributes ?? {}) as Record<string, unknown>;
+                const labelRaw = attrString(childAttrs.label);
+                const baseId = sanitizeTabId(attrString(childAttrs.tabId), sectionIndex);
+                const tabId = uniqueTabId(baseId, usedIds);
+
+                tabs.push({
+                    label: labelRaw === '' ? `Tab ${sectionIndex}` : labelRaw,
+                    tabId,
+                    content: extractSlotContent(slotVnodes[index]),
+                });
+            });
+
+            const triggerVnodes: VNode[] = tabs.map((tab, index) => {
+                const isFirst = index === 0;
+                return h('li', { key: `${index}-${tab.tabId}` }, [
+                    h(
+                        'a',
+                        {
+                            href: `#tabs-panel-${tab.tabId}`,
+                            id: `tabs-tab-${tab.tabId}`,
+                            role: 'tab',
+                            'aria-controls': `tabs-panel-${tab.tabId}`,
+                            'aria-selected': isFirst ? 'true' : 'false',
+                            tabindex: isFirst ? '0' : '-1',
+                        },
+                        tab.label
+                    ),
+                ]);
+            });
+
+            const panelVnodes: VNode[] = tabs.map((tab, index) =>
+                h(
+                    'div',
+                    {
+                        key: `panel-${index}-${tab.tabId}`,
+                        class: 'ap-tab-section',
+                        role: 'tabpanel',
+                        id: `tabs-panel-${tab.tabId}`,
+                        'aria-labelledby': `tabs-tab-${tab.tabId}`,
+                    },
+                    tab.content
+                )
+            );
+
+            return h('div', { class: classes, 'data-ap-tabs': '' }, [
+                h('div', { class: 'ap-tabs__list' }, [
+                    h('ul', { role: 'tablist' }, triggerVnodes),
+                ]),
+                h('div', { class: 'ap-tabs__container' }, panelVnodes),
+            ]);
+        };
+    },
+});
+
+// Standalone fallback when rendered outside a tabs parent. The tabs
+// wrapper reaches into the slot vnodes and re-wraps them, so this only
+// surfaces when something else renders the section in isolation.
+export const TabSectionBlock = defineComponent({
+    name: 'TabSectionBlock',
+    props: blockRendererProps,
+    setup(props, { slots }) {
+        return () => {
+            const tabId = attrString(props.attributes.tabId);
+            const className = attrString(props.attributes.className);
+            const classes = classList(['ap-tab-section', className]);
+
+            const attrs: Record<string, unknown> = {
+                class: classes,
+                role: 'tabpanel',
+            };
+
+            if (tabId !== '') {
+                const safeId = sanitizeTabId(tabId, 1);
+                attrs.id = `tabs-panel-${safeId}`;
+                attrs['aria-labelledby'] = `tabs-tab-${safeId}`;
+            }
+
+            return h('div', attrs, slots.default ? slots.default() : []);
+        };
+    },
+});

--- a/packages/visual-editor-renderer-vue/src/blocks/registerCoreBlocks.ts
+++ b/packages/visual-editor-renderer-vue/src/blocks/registerCoreBlocks.ts
@@ -12,8 +12,15 @@
  */
 
 import { registerBlockRenderer } from '../registry';
+import {
+    AccordionBlock,
+    AccordionBodyBlock,
+    AccordionTitleBlock,
+    AccordionsBlock,
+} from './artisanpack/accordion';
 import { BreadcrumbsBlock } from './artisanpack/breadcrumbs';
 import { CalloutBlock } from './artisanpack/callout';
+import { TabSectionBlock, TabsBlock } from './artisanpack/tabs';
 import { LoginoutBlock } from './artisanpack/loginout';
 import {
     CommentAuthorAvatarBlock,
@@ -213,6 +220,14 @@ const CORE_BLOCKS: Record<string, BlockRenderer> = {
     'core/navigation-submenu': NavigationSubmenuBlock,
     'artisanpack/breadcrumbs': BreadcrumbsBlock,
     'artisanpack/callout': CalloutBlock,
+    // Accordion + tabs families (#497). Interactive blocks with
+    // parent/child inner-block relationships preserved across renderers.
+    'artisanpack/accordions': AccordionsBlock,
+    'artisanpack/accordion': AccordionBlock,
+    'artisanpack/accordion-title': AccordionTitleBlock,
+    'artisanpack/accordion-body': AccordionBodyBlock,
+    'artisanpack/tabs': TabsBlock,
+    'artisanpack/tab-section': TabSectionBlock,
     // Post navigation / metadata family (#520) — same renderer for both
     // namespaces; PostResolver stamps the same `_resolved*` attributes.
     'core/post-navigation-link': PostNavigationLinkBlock,

--- a/packages/visual-editor-renderer-vue/tests/BlockTree.test.ts
+++ b/packages/visual-editor-renderer-vue/tests/BlockTree.test.ts
@@ -691,6 +691,193 @@ describe('Core design blocks', () => {
         expect(html).toContain('ap-breadcrumbs__list');
         expect(html).not.toContain('<li class="ap-breadcrumbs__item');
     });
+
+    it('renders the artisanpack/accordions family with nested grandchildren', () => {
+        const tree = [
+            makeBlock('artisanpack/accordions', {}, [
+                makeBlock(
+                    'artisanpack/accordion',
+                    { panelId: 'faq-1', panelIcon: 'arrows' },
+                    [
+                        makeBlock('artisanpack/accordion-title', {}, [
+                            makeBlock('core/heading', {
+                                level: 3,
+                                content: 'Question',
+                            }),
+                        ]),
+                        makeBlock('artisanpack/accordion-body', {}, [
+                            makeBlock('core/paragraph', { content: 'Answer.' }),
+                        ]),
+                    ]
+                ),
+            ]),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('class="ap-accordions"');
+        expect(html).toContain('class="ap-accordion"');
+        expect(html).toContain('data-panel-id="faq-1"');
+        expect(html).toContain('data-panel-icon="arrows"');
+        expect(html).toContain('id="faq-1-control"');
+        expect(html).toContain('aria-controls="faq-1"');
+        expect(html).toContain('aria-expanded="false"');
+        expect(html).toContain('ap-accordion__icon--arrows');
+        expect(html).toContain('id="faq-1"');
+        expect(html).toContain('aria-labelledby="faq-1-control"');
+        expect(html).toContain('<p class="wp-block-paragraph">Answer.</p>');
+    });
+
+    it('falls back to safe defaults when accordion panelIcon is invalid', () => {
+        const tree = [
+            makeBlock('artisanpack/accordion', {
+                panelId: 'faq-1',
+                panelIcon: 'evil"><script>',
+            }),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('data-panel-icon="plus-minus"');
+        expect(html).not.toContain('<script>');
+    });
+
+    it('omits accordion aria wiring when the parent panel id is empty', () => {
+        const tree = [
+            makeBlock(
+                'artisanpack/accordion',
+                { panelId: '', panelIcon: 'plus-minus' },
+                [
+                    makeBlock('artisanpack/accordion-title', {}),
+                    makeBlock('artisanpack/accordion-body', {}),
+                ]
+            ),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).not.toContain('aria-controls=');
+        expect(html).not.toContain('aria-labelledby=');
+        expect(html).not.toContain('id="-control"');
+    });
+
+    it('renders the artisanpack/tabs family with triggers derived from tab-section children', () => {
+        const tree = [
+            makeBlock(
+                'artisanpack/tabs',
+                {
+                    tabsAlign: 'horizontal',
+                    tabsSpacing: 'center',
+                },
+                [
+                    makeBlock(
+                        'artisanpack/tab-section',
+                        { label: 'Overview', tabId: 'overview' },
+                        [makeBlock('core/paragraph', { content: 'Tab body' })]
+                    ),
+                    makeBlock('artisanpack/tab-section', {
+                        label: 'Specs',
+                        tabId: 'specs',
+                    }),
+                ]
+            ),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('align-tabs-horizontal');
+        expect(html).toContain('space-tabs-center');
+        expect(html).toContain('data-ap-tabs');
+        expect(html).toContain('role="tablist"');
+        expect(html).toContain('href="#tabs-panel-overview"');
+        expect(html).toContain('aria-controls="tabs-panel-overview"');
+        expect(html).toContain('id="tabs-tab-overview"');
+        expect(html).toContain('aria-selected="true"');
+        expect(html).toContain('aria-selected="false"');
+        expect(html).toContain('>Overview</a>');
+        expect(html).toContain('>Specs</a>');
+        expect(html).toContain('id="tabs-panel-overview"');
+        expect(html).toContain('aria-labelledby="tabs-tab-overview"');
+        expect(html).toContain('role="tabpanel"');
+        expect(html).toContain('Tab body');
+    });
+
+    it('falls back to safe defaults when tabsAlign / tabsSpacing are invalid', () => {
+        const tree = [
+            makeBlock('artisanpack/tabs', {
+                tabsAlign: 'diagonal',
+                tabsSpacing: 'sprawl',
+            }),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('align-tabs-horizontal');
+        expect(html).toContain('space-tabs-start');
+    });
+
+    it('deduplicates tab ids when two sections share the same slug', () => {
+        const tree = [
+            makeBlock('artisanpack/tabs', {}, [
+                makeBlock('artisanpack/tab-section', {
+                    label: 'One',
+                    tabId: 'overview',
+                }),
+                makeBlock('artisanpack/tab-section', {
+                    label: 'Two',
+                    tabId: 'overview',
+                }),
+                makeBlock('artisanpack/tab-section', {
+                    label: 'Three',
+                    tabId: 'overview',
+                }),
+            ]),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('id="tabs-panel-overview"');
+        expect(html).toContain('id="tabs-panel-overview-2"');
+        expect(html).toContain('id="tabs-panel-overview-3"');
+        expect(html).toContain('href="#tabs-panel-overview-2"');
+        expect(html).toContain('href="#tabs-panel-overview-3"');
+    });
+
+    it('auto-fills tab labels and ids by position when sections leave them blank', () => {
+        const tree = [
+            makeBlock('artisanpack/tabs', {}, [
+                makeBlock('artisanpack/tab-section', {}),
+                makeBlock('artisanpack/tab-section', {}),
+            ]),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('>Tab 1</a>');
+        expect(html).toContain('>Tab 2</a>');
+        expect(html).toContain('href="#tabs-panel-tab-1"');
+        expect(html).toContain('href="#tabs-panel-tab-2"');
+        // Triggers and panels MUST share the same resolved id so the
+        // aria-controls / id hookup actually resolves.
+        expect(html).toContain('id="tabs-panel-tab-1"');
+        expect(html).toContain('id="tabs-panel-tab-2"');
+        expect(html).toContain('aria-labelledby="tabs-tab-tab-1"');
+        expect(html).toContain('aria-labelledby="tabs-tab-tab-2"');
+    });
+
+    it('renders a tab-section without aria wiring when tabId is empty', () => {
+        const tree = [
+            makeBlock('artisanpack/tab-section', { tabId: '' }, [
+                makeBlock('core/paragraph', { content: 'Naked' }),
+            ]),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).not.toContain('id="tabs-panel-"');
+        expect(html).not.toContain('aria-labelledby=');
+        expect(html).toContain('Naked');
+    });
 });
 
 describe('Registry + dynamic fallback', () => {

--- a/resources/js/visual-editor/blocks/accordion-body/block.json
+++ b/resources/js/visual-editor/blocks/accordion-body/block.json
@@ -1,0 +1,60 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "artisanpack/accordion-body",
+    "title": "Accordion Body",
+    "category": "artisanpack",
+    "description": "The expandable content of an accordion panel.",
+    "parent": ["artisanpack/accordion"],
+    "textdomain": "artisanpack-visual-editor",
+    "attributes": {},
+    "supports": {
+        "align": ["wide", "full"],
+        "ariaLabel": true,
+        "className": true,
+        "html": false,
+        "spacing": {
+            "margin": ["top", "bottom"],
+            "padding": true,
+            "blockGap": true,
+            "__experimentalDefaultControls": {
+                "padding": true,
+                "blockGap": true
+            }
+        },
+        "color": {
+            "gradients": true,
+            "link": true,
+            "__experimentalDefaultControls": {
+                "background": true,
+                "text": true
+            }
+        },
+        "shadow": true,
+        "__experimentalBorder": {
+            "color": true,
+            "radius": true,
+            "style": true,
+            "width": true,
+            "__experimentalDefaultControls": {
+                "color": true,
+                "radius": true,
+                "style": true,
+                "width": true
+            }
+        },
+        "typography": {
+            "fontSize": true,
+            "lineHeight": true,
+            "__experimentalFontFamily": true,
+            "__experimentalFontWeight": true,
+            "__experimentalFontStyle": true,
+            "__experimentalTextTransform": true,
+            "__experimentalTextDecoration": true,
+            "__experimentalLetterSpacing": true,
+            "__experimentalDefaultControls": {
+                "fontSize": true
+            }
+        }
+    }
+}

--- a/resources/js/visual-editor/blocks/accordion-body/edit.tsx
+++ b/resources/js/visual-editor/blocks/accordion-body/edit.tsx
@@ -1,0 +1,28 @@
+/**
+ * Accordion body — editor-side component.
+ *
+ * Grandchild of `artisanpack/accordions`; nested under
+ * `artisanpack/accordion`. The body is purely a content container in
+ * the editor — the region wiring (`role`, `id`, `aria-labelledby`) is
+ * stamped by the parent accordion renderer at render time using the
+ * parent's `panelId` attribute. That keeps the panel id a single source
+ * of truth on the accordion block.
+ */
+
+import type { ReactElement } from 'react';
+import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
+
+import { TEXT_DOMAIN } from '../../vendor/i18n';
+
+const TEMPLATE: [string, Record<string, unknown>][] = [['artisanpack/paragraph', {}]];
+
+export default function AccordionBodyEdit(): ReactElement {
+    const blockProps = useBlockProps({ className: 'ap-accordion__body' });
+    const innerBlocksProps = useInnerBlocksProps(blockProps, {
+        template: TEMPLATE,
+        placeholder: __('Add panel content…', TEXT_DOMAIN),
+    });
+
+    return <div {...innerBlocksProps} />;
+}

--- a/resources/js/visual-editor/blocks/accordion-body/index.ts
+++ b/resources/js/visual-editor/blocks/accordion-body/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Accordion body block entrypoint.
+ *
+ * Auto-discovered by `editor/custom-blocks.ts`. Grandchild of
+ * `artisanpack/accordions`; the expandable content of a panel (#497).
+ */
+
+import metadata from './block.json';
+import edit from './edit';
+import save from './save';
+
+export { edit, save, metadata };
+
+export default {
+    name: metadata.name,
+    metadata,
+    edit,
+    save,
+};

--- a/resources/js/visual-editor/blocks/accordion-body/save.tsx
+++ b/resources/js/visual-editor/blocks/accordion-body/save.tsx
@@ -1,0 +1,9 @@
+/**
+ * Accordion body — save component.
+ *
+ * Dynamic block: the renderers walk the persisted inner-block tree.
+ */
+
+export default function AccordionBodySave(): null {
+    return null;
+}

--- a/resources/js/visual-editor/blocks/accordion-title/block.json
+++ b/resources/js/visual-editor/blocks/accordion-title/block.json
@@ -1,0 +1,60 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "artisanpack/accordion-title",
+    "title": "Accordion Title",
+    "category": "artisanpack",
+    "description": "The clickable header of an accordion panel.",
+    "parent": ["artisanpack/accordion"],
+    "textdomain": "artisanpack-visual-editor",
+    "attributes": {},
+    "supports": {
+        "align": ["wide", "full"],
+        "ariaLabel": true,
+        "className": true,
+        "html": false,
+        "spacing": {
+            "margin": ["top", "bottom"],
+            "padding": true,
+            "blockGap": true,
+            "__experimentalDefaultControls": {
+                "padding": true,
+                "blockGap": true
+            }
+        },
+        "color": {
+            "gradients": true,
+            "link": true,
+            "__experimentalDefaultControls": {
+                "background": true,
+                "text": true
+            }
+        },
+        "shadow": true,
+        "__experimentalBorder": {
+            "color": true,
+            "radius": true,
+            "style": true,
+            "width": true,
+            "__experimentalDefaultControls": {
+                "color": true,
+                "radius": true,
+                "style": true,
+                "width": true
+            }
+        },
+        "typography": {
+            "fontSize": true,
+            "lineHeight": true,
+            "__experimentalFontFamily": true,
+            "__experimentalFontWeight": true,
+            "__experimentalFontStyle": true,
+            "__experimentalTextTransform": true,
+            "__experimentalTextDecoration": true,
+            "__experimentalLetterSpacing": true,
+            "__experimentalDefaultControls": {
+                "fontSize": true
+            }
+        }
+    }
+}

--- a/resources/js/visual-editor/blocks/accordion-title/edit.tsx
+++ b/resources/js/visual-editor/blocks/accordion-title/edit.tsx
@@ -1,0 +1,70 @@
+/**
+ * Accordion title — editor-side component.
+ *
+ * Grandchild of `artisanpack/accordions`; nested under
+ * `artisanpack/accordion`. The title is purely a content container in
+ * the editor — the toggle wiring (`role`, `aria-controls`, `aria-expanded`)
+ * is stamped by the parent accordion renderer at render time using the
+ * parent's `panelId` / `panelIcon` attributes. The editor still reads
+ * the parent's `panelIcon` so the inserter / canvas preview can show
+ * the right toggle icon next to each title.
+ */
+
+import type { ReactElement } from 'react';
+import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
+import { useSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+
+import { TEXT_DOMAIN } from '../../vendor/i18n';
+
+interface AccordionTitleEditProps {
+    readonly clientId: string;
+}
+
+type AccordionPanelIcon = 'plus-minus' | 'arrows';
+
+const TEMPLATE: [string, Record<string, unknown>][] = [
+    ['artisanpack/heading', { level: 3 }],
+];
+
+function normalizeIcon(value: unknown): AccordionPanelIcon {
+    return value === 'arrows' ? 'arrows' : 'plus-minus';
+}
+
+export default function AccordionTitleEdit({
+    clientId,
+}: AccordionTitleEditProps): ReactElement {
+    const panelIcon = useSelect<AccordionPanelIcon>(
+        (select) => {
+            const store = select('core/block-editor') as unknown as {
+                getBlockRootClientId: (id: string) => string | null;
+                getBlock: (id: string) => {
+                    attributes?: Record<string, unknown>;
+                } | null;
+            };
+            const parentId = store.getBlockRootClientId(clientId);
+            if (parentId === null || parentId === '') {
+                return 'plus-minus';
+            }
+            const parent = store.getBlock(parentId);
+            return normalizeIcon(parent?.attributes?.panelIcon);
+        },
+        [clientId]
+    );
+
+    const blockProps = useBlockProps({ className: 'ap-accordion__title-content' });
+    const innerBlocksProps = useInnerBlocksProps(blockProps, {
+        template: TEMPLATE,
+        placeholder: __('Add a heading…', TEXT_DOMAIN),
+    });
+
+    return (
+        <div className="ap-accordion__title">
+            <div {...innerBlocksProps} />
+            <span
+                className={`ap-accordion__icon ap-accordion__icon--${panelIcon}`}
+                aria-hidden="true"
+            />
+        </div>
+    );
+}

--- a/resources/js/visual-editor/blocks/accordion-title/index.ts
+++ b/resources/js/visual-editor/blocks/accordion-title/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Accordion title block entrypoint.
+ *
+ * Auto-discovered by `editor/custom-blocks.ts`. Grandchild of
+ * `artisanpack/accordions`; the clickable header for a panel (#497).
+ */
+
+import metadata from './block.json';
+import edit from './edit';
+import save from './save';
+
+export { edit, save, metadata };
+
+export default {
+    name: metadata.name,
+    metadata,
+    edit,
+    save,
+};

--- a/resources/js/visual-editor/blocks/accordion-title/save.tsx
+++ b/resources/js/visual-editor/blocks/accordion-title/save.tsx
@@ -1,0 +1,10 @@
+/**
+ * Accordion title — save component.
+ *
+ * Dynamic block: the renderers walk the persisted inner-block tree and
+ * stamp the toggle wiring from the parent accordion's `panelId`.
+ */
+
+export default function AccordionTitleSave(): null {
+    return null;
+}

--- a/resources/js/visual-editor/blocks/accordion/accordion.css
+++ b/resources/js/visual-editor/blocks/accordion/accordion.css
@@ -36,7 +36,7 @@
 }
 
 .ap-accordion__title-content:focus-visible {
-    outline: 2px solid currentColor;
+    outline: 2px solid currentcolor;
     outline-offset: -2px;
 }
 
@@ -54,7 +54,7 @@
 .ap-accordion__icon::after {
     content: "";
     position: absolute;
-    background: currentColor;
+    background: currentcolor;
     transition: transform 0.15s ease-out;
 }
 

--- a/resources/js/visual-editor/blocks/accordion/accordion.css
+++ b/resources/js/visual-editor/blocks/accordion/accordion.css
@@ -1,0 +1,116 @@
+/**
+ * Accordion family styles (#497).
+ *
+ * Loaded in the editor via `blocks/{accordions,accordion}/index.ts`.
+ * On the public frontend the Blade renderer serves an identical copy
+ * from `packages/visual-editor-renderer-blade/resources/assets/frontend/accordion.css`,
+ * wired up by `<x-ve-blocks-styles />`. React/Vue renderers emit the
+ * same class names so a single stylesheet covers all three.
+ */
+
+.ap-accordions {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    margin-block-end: var(--wp--style--block-gap, 1.5rem);
+}
+
+.ap-accordion {
+    border: 1px solid var(--ap-accordion-border, rgba(0, 0, 0, 0.1));
+    border-radius: 0.25rem;
+    overflow: hidden;
+}
+
+.ap-accordion__title {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding-right: 2.5rem;
+}
+
+.ap-accordion__title-content {
+    flex: 1;
+    cursor: pointer;
+    padding: 0.75rem 1rem;
+}
+
+.ap-accordion__title-content:focus-visible {
+    outline: 2px solid currentColor;
+    outline-offset: -2px;
+}
+
+.ap-accordion__icon {
+    position: absolute;
+    right: 0.75rem;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 1rem;
+    height: 1rem;
+    pointer-events: none;
+}
+
+.ap-accordion__icon::before,
+.ap-accordion__icon::after {
+    content: "";
+    position: absolute;
+    background: currentColor;
+    transition: transform 0.15s ease-out;
+}
+
+/* Plus / minus icon */
+.ap-accordion__icon--plus-minus::before {
+    left: 50%;
+    top: 0;
+    width: 2px;
+    height: 100%;
+    margin-left: -1px;
+}
+
+.ap-accordion__icon--plus-minus::after {
+    left: 0;
+    top: 50%;
+    width: 100%;
+    height: 2px;
+    margin-top: -1px;
+}
+
+.ap-accordion__title-content[aria-expanded="true"] ~ .ap-accordion__icon--plus-minus::before {
+    transform: scaleY(0);
+}
+
+/* Arrows icon — a chevron rendered with two rotated bars. */
+.ap-accordion__icon--arrows::before {
+    left: 15%;
+    top: 35%;
+    width: 50%;
+    height: 2px;
+    transform-origin: left center;
+    transform: rotate(45deg);
+}
+
+.ap-accordion__icon--arrows::after {
+    right: 15%;
+    top: 35%;
+    width: 50%;
+    height: 2px;
+    transform-origin: right center;
+    transform: rotate(-45deg);
+}
+
+.ap-accordion__title-content[aria-expanded="true"] ~ .ap-accordion__icon--arrows::before {
+    transform: rotate(-45deg);
+}
+
+.ap-accordion__title-content[aria-expanded="true"] ~ .ap-accordion__icon--arrows::after {
+    transform: rotate(45deg);
+}
+
+.ap-accordion__body {
+    padding: 0.75rem 1rem;
+    transition: max-height 0.15s ease-out;
+}
+
+.ap-accordion__body[hidden] {
+    display: none;
+}

--- a/resources/js/visual-editor/blocks/accordion/block.json
+++ b/resources/js/visual-editor/blocks/accordion/block.json
@@ -1,0 +1,71 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "artisanpack/accordion",
+    "title": "Accordion Panel",
+    "category": "artisanpack",
+    "description": "Add an accordion panel containing a title and a body.",
+    "keywords": ["accordion", "collapsible", "panel"],
+    "parent": ["artisanpack/accordions"],
+    "textdomain": "artisanpack-visual-editor",
+    "attributes": {
+        "panelId": {
+            "type": "string",
+            "default": ""
+        },
+        "panelIcon": {
+            "type": "string",
+            "enum": ["plus-minus", "arrows"],
+            "default": "plus-minus"
+        }
+    },
+    "supports": {
+        "align": ["wide", "full"],
+        "ariaLabel": true,
+        "className": true,
+        "html": false,
+        "spacing": {
+            "margin": ["top", "bottom"],
+            "padding": true,
+            "blockGap": true,
+            "__experimentalDefaultControls": {
+                "padding": true,
+                "blockGap": true
+            }
+        },
+        "color": {
+            "gradients": true,
+            "link": true,
+            "__experimentalDefaultControls": {
+                "background": true,
+                "text": true
+            }
+        },
+        "shadow": true,
+        "__experimentalBorder": {
+            "color": true,
+            "radius": true,
+            "style": true,
+            "width": true,
+            "__experimentalDefaultControls": {
+                "color": true,
+                "radius": true,
+                "style": true,
+                "width": true
+            }
+        },
+        "typography": {
+            "fontSize": true,
+            "lineHeight": true,
+            "__experimentalFontFamily": true,
+            "__experimentalFontWeight": true,
+            "__experimentalFontStyle": true,
+            "__experimentalTextTransform": true,
+            "__experimentalTextDecoration": true,
+            "__experimentalLetterSpacing": true,
+            "__experimentalDefaultControls": {
+                "fontSize": true
+            }
+        }
+    }
+}

--- a/resources/js/visual-editor/blocks/accordion/edit.tsx
+++ b/resources/js/visual-editor/blocks/accordion/edit.tsx
@@ -1,0 +1,112 @@
+/**
+ * Accordion panel — editor-side component.
+ *
+ * Child of `artisanpack/accordions`; ships its own pair of grandchildren
+ * (`accordion-title` + `accordion-body`). The accordion is the single
+ * source of truth for the panel id and toggle icon — the renderer
+ * stamps those onto the title's `aria-controls` / icon class and the
+ * body's `id` automatically, so authors only ever set the id once. A
+ * stable id is auto-generated on first mount if the author hasn't set
+ * one, so the wiring works out of the box.
+ */
+
+import { useEffect, type ReactElement } from 'react';
+import { InspectorControls, useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
+import { PanelBody, SelectControl, TextControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+import { TEXT_DOMAIN } from '../../vendor/i18n';
+
+interface AccordionAttributes {
+    readonly panelId: string;
+    readonly panelIcon: 'plus-minus' | 'arrows';
+}
+
+interface AccordionEditProps {
+    readonly attributes: AccordionAttributes;
+    readonly setAttributes: (next: Partial<AccordionAttributes>) => void;
+    readonly clientId: string;
+}
+
+const ALLOWED_BLOCKS: string[] = [
+    'artisanpack/accordion-title',
+    'artisanpack/accordion-body',
+];
+
+const TEMPLATE: [string, Record<string, unknown>][] = [
+    ['artisanpack/accordion-title', {}],
+    ['artisanpack/accordion-body', {}],
+];
+
+const ICON_OPTIONS = [
+    { value: 'plus-minus' as const, label: 'Plus / Minus' },
+    { value: 'arrows' as const, label: 'Arrows' },
+];
+
+function slugify(value: string): string {
+    return value
+        .toLowerCase()
+        .replace(/[^a-z0-9-]+/g, '-')
+        .replace(/^-+|-+$/g, '');
+}
+
+function makeAutoPanelId(clientId: string): string {
+    // Derive from clientId so the same accordion always lands on the
+    // same id across re-renders; trim to keep DOM ids short.
+    const suffix = clientId.replace(/-/g, '').slice(0, 8);
+    return `panel-${suffix}`;
+}
+
+export default function AccordionEdit({
+    attributes,
+    setAttributes,
+    clientId,
+}: AccordionEditProps): ReactElement {
+    const { panelId, panelIcon } = attributes;
+
+    useEffect(() => {
+        if (panelId === '') {
+            setAttributes({ panelId: makeAutoPanelId(clientId) });
+        }
+    }, [panelId, clientId, setAttributes]);
+
+    const blockProps = useBlockProps({ className: 'ap-accordion' });
+    const innerBlocksProps = useInnerBlocksProps(blockProps, {
+        allowedBlocks: ALLOWED_BLOCKS,
+        template: TEMPLATE,
+    });
+
+    return (
+        <>
+            <InspectorControls>
+                <PanelBody title={__('Accordion settings', TEXT_DOMAIN)} initialOpen>
+                    <TextControl
+                        label={__('Panel id', TEXT_DOMAIN)}
+                        help={__(
+                            'Auto-generated on insert. Used for the panel id and the toggle aria-controls hookup.',
+                            TEXT_DOMAIN
+                        )}
+                        value={panelId}
+                        onChange={(value) => setAttributes({ panelId: slugify(value) })}
+                        __nextHasNoMarginBottom
+                    />
+                    <SelectControl
+                        label={__('Toggle icon', TEXT_DOMAIN)}
+                        value={panelIcon}
+                        options={ICON_OPTIONS.map((option) => ({
+                            label: __(option.label, TEXT_DOMAIN),
+                            value: option.value,
+                        }))}
+                        onChange={(value) => {
+                            if (value === 'plus-minus' || value === 'arrows') {
+                                setAttributes({ panelIcon: value });
+                            }
+                        }}
+                        __nextHasNoMarginBottom
+                    />
+                </PanelBody>
+            </InspectorControls>
+            <div {...innerBlocksProps} />
+        </>
+    );
+}

--- a/resources/js/visual-editor/blocks/accordion/index.ts
+++ b/resources/js/visual-editor/blocks/accordion/index.ts
@@ -1,0 +1,21 @@
+/**
+ * Accordion panel block entrypoint.
+ *
+ * Auto-discovered by `editor/custom-blocks.ts`. Child of
+ * `artisanpack/accordions`; renders a single collapsible panel (#497).
+ */
+
+import metadata from './block.json';
+import edit from './edit';
+import save from './save';
+
+import './accordion.css';
+
+export { edit, save, metadata };
+
+export default {
+    name: metadata.name,
+    metadata,
+    edit,
+    save,
+};

--- a/resources/js/visual-editor/blocks/accordion/save.tsx
+++ b/resources/js/visual-editor/blocks/accordion/save.tsx
@@ -1,0 +1,9 @@
+/**
+ * Accordion panel — save component.
+ *
+ * Dynamic block: the renderers walk the persisted inner-block tree.
+ */
+
+export default function AccordionSave(): null {
+    return null;
+}

--- a/resources/js/visual-editor/blocks/accordions/block.json
+++ b/resources/js/visual-editor/blocks/accordions/block.json
@@ -1,0 +1,52 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "artisanpack/accordions",
+    "title": "Accordions",
+    "category": "artisanpack",
+    "description": "Group one or more accordion panels into a collapsible section.",
+    "keywords": ["accordion", "accordions", "collapsible", "faq"],
+    "textdomain": "artisanpack-visual-editor",
+    "attributes": {},
+    "supports": {
+        "align": ["wide", "full"],
+        "ariaLabel": true,
+        "className": true,
+        "html": false,
+        "spacing": {
+            "margin": ["top", "bottom"],
+            "padding": true,
+            "blockGap": true,
+            "__experimentalDefaultControls": {
+                "padding": true,
+                "blockGap": true
+            }
+        },
+        "shadow": true,
+        "__experimentalBorder": {
+            "color": true,
+            "radius": true,
+            "style": true,
+            "width": true,
+            "__experimentalDefaultControls": {
+                "color": true,
+                "radius": true,
+                "style": true,
+                "width": true
+            }
+        },
+        "typography": {
+            "fontSize": true,
+            "lineHeight": true,
+            "__experimentalFontFamily": true,
+            "__experimentalFontWeight": true,
+            "__experimentalFontStyle": true,
+            "__experimentalTextTransform": true,
+            "__experimentalTextDecoration": true,
+            "__experimentalLetterSpacing": true,
+            "__experimentalDefaultControls": {
+                "fontSize": true
+            }
+        }
+    }
+}

--- a/resources/js/visual-editor/blocks/accordions/edit.tsx
+++ b/resources/js/visual-editor/blocks/accordions/edit.tsx
@@ -1,0 +1,26 @@
+/**
+ * Accordions — editor-side component.
+ *
+ * Parent block in the accordion family (#497). Renders a single block
+ * `div` that hosts one or more `artisanpack/accordion` children via
+ * `useInnerBlocksProps`. No inspector controls of its own — styling
+ * and layout are surfaced through the standard block supports
+ * (background, border, spacing, …) declared in `block.json`.
+ */
+
+import type { ReactElement } from 'react';
+import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
+
+const ALLOWED_BLOCKS: string[] = ['artisanpack/accordion'];
+
+const TEMPLATE: [string, Record<string, unknown>][] = [['artisanpack/accordion', {}]];
+
+export default function AccordionsEdit(): ReactElement {
+    const blockProps = useBlockProps({ className: 'ap-accordions' });
+    const innerBlocksProps = useInnerBlocksProps(blockProps, {
+        allowedBlocks: ALLOWED_BLOCKS,
+        template: TEMPLATE,
+    });
+
+    return <div {...innerBlocksProps} />;
+}

--- a/resources/js/visual-editor/blocks/accordions/index.ts
+++ b/resources/js/visual-editor/blocks/accordions/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Accordions block entrypoint.
+ *
+ * Auto-discovered by `editor/custom-blocks.ts` and registered against
+ * `@wordpress/blocks.registerBlockType`. Parent block of the accordion
+ * family (#497).
+ */
+
+import metadata from './block.json';
+import edit from './edit';
+import save from './save';
+
+import '../accordion/accordion.css';
+
+export { edit, save, metadata };
+
+export default {
+    name: metadata.name,
+    metadata,
+    edit,
+    save,
+};

--- a/resources/js/visual-editor/blocks/accordions/save.tsx
+++ b/resources/js/visual-editor/blocks/accordions/save.tsx
@@ -1,0 +1,12 @@
+/**
+ * Accordions — save component.
+ *
+ * The accordion family ships as dynamic (server-rendered) blocks: each
+ * renderer reads the persisted inner-block tree and emits the final
+ * markup. Returning `null` keeps Gutenberg from serializing redundant
+ * wrapper markup into post_content.
+ */
+
+export default function AccordionsSave(): null {
+    return null;
+}

--- a/resources/js/visual-editor/blocks/tab-section/block.json
+++ b/resources/js/visual-editor/blocks/tab-section/block.json
@@ -1,0 +1,47 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "artisanpack/tab-section",
+    "title": "Tab Section",
+    "category": "artisanpack",
+    "description": "A single tab panel shown when its matching tab is active.",
+    "parent": ["artisanpack/tabs"],
+    "textdomain": "artisanpack-visual-editor",
+    "attributes": {
+        "label": {
+            "type": "string",
+            "default": ""
+        },
+        "tabId": {
+            "type": "string",
+            "default": ""
+        }
+    },
+    "supports": {
+        "ariaLabel": true,
+        "className": true,
+        "html": false,
+        "spacing": {
+            "margin": ["top", "bottom"],
+            "padding": true,
+            "blockGap": true,
+            "__experimentalDefaultControls": {
+                "padding": true,
+                "blockGap": true
+            }
+        },
+        "shadow": true,
+        "__experimentalBorder": {
+            "color": true,
+            "radius": true,
+            "style": true,
+            "width": true,
+            "__experimentalDefaultControls": {
+                "color": true,
+                "radius": true,
+                "style": true,
+                "width": true
+            }
+        }
+    }
+}

--- a/resources/js/visual-editor/blocks/tab-section/edit.tsx
+++ b/resources/js/visual-editor/blocks/tab-section/edit.tsx
@@ -1,0 +1,127 @@
+/**
+ * Tab section — editor-side component.
+ *
+ * Child of `artisanpack/tabs`. Each section owns its own `label` (the
+ * text rendered on the tab trigger) and `tabId` (the slug). Both
+ * auto-fill on first mount when blank — `label` from the position,
+ * `tabId` from `label` — so authors can drop tabs in without doing any
+ * id bookkeeping. The parent tabs renderer reads these attributes from
+ * inner blocks to build the tab list.
+ */
+
+import { useEffect, type ReactElement } from 'react';
+import { InspectorControls, useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
+import { useSelect } from '@wordpress/data';
+import { PanelBody, TextControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+import { TEXT_DOMAIN } from '../../vendor/i18n';
+
+interface TabSectionAttributes {
+    readonly label: string;
+    readonly tabId: string;
+}
+
+interface TabSectionEditProps {
+    readonly attributes: TabSectionAttributes;
+    readonly setAttributes: (next: Partial<TabSectionAttributes>) => void;
+    readonly clientId: string;
+}
+
+const TEMPLATE: [string, Record<string, unknown>][] = [['artisanpack/group', {}]];
+
+function slugify(value: string): string {
+    return value
+        .toLowerCase()
+        .replace(/[^a-z0-9-]+/g, '-')
+        .replace(/^-+|-+$/g, '');
+}
+
+function makeAutoTabId(clientId: string): string {
+    const suffix = clientId.replace(/-/g, '').slice(0, 8);
+    return `tab-${suffix}`;
+}
+
+export default function TabSectionEdit({
+    attributes,
+    setAttributes,
+    clientId,
+}: TabSectionEditProps): ReactElement {
+    const { label, tabId } = attributes;
+
+    // Derive the section's position among its tabs siblings so the
+    // auto-generated default label reads "Tab 1", "Tab 2", … instead
+    // of every section starting life as plain "Tab".
+    const position = useSelect(
+        (select) => {
+            const store = select('core/block-editor') as unknown as {
+                getBlockRootClientId: (id: string) => string | null;
+                getBlockOrder: (id: string) => string[];
+            };
+            const parentId = store.getBlockRootClientId(clientId);
+            if (parentId === null || parentId === '') {
+                return 1;
+            }
+            const order = store.getBlockOrder(parentId);
+            const index = order.indexOf(clientId);
+            return index === -1 ? 1 : index + 1;
+        },
+        [clientId]
+    );
+
+    // Intentional: an empty label or tabId is always refilled with
+    // the positional default. Authors who clear the field will see
+    // the default snap back in — they should overwrite, not blank
+    // out, since a missing label / id breaks the rendered tab list.
+    // The check is strict equality with `''` (not "is auto-generated")
+    // because we can't distinguish a default the author typed in
+    // ("Tab 2") from one we filled in for them; both should be
+    // treated as user-owned once persisted.
+    useEffect(() => {
+        const patch: Partial<TabSectionAttributes> = {};
+        if (label === '') {
+            patch.label = `${__('Tab', TEXT_DOMAIN)} ${position}`;
+        }
+        if (tabId === '') {
+            patch.tabId = makeAutoTabId(clientId);
+        }
+        if (Object.keys(patch).length > 0) {
+            setAttributes(patch);
+        }
+    }, [label, tabId, position, clientId, setAttributes]);
+
+    const blockProps = useBlockProps({ className: 'ap-tab-section' });
+    const innerBlocksProps = useInnerBlocksProps(blockProps, {
+        template: TEMPLATE,
+    });
+
+    return (
+        <>
+            <InspectorControls>
+                <PanelBody title={__('Tab section', TEXT_DOMAIN)} initialOpen>
+                    <TextControl
+                        label={__('Tab label', TEXT_DOMAIN)}
+                        help={__(
+                            'Shown on the tab trigger above this panel.',
+                            TEXT_DOMAIN
+                        )}
+                        value={label}
+                        onChange={(value) => setAttributes({ label: value })}
+                        __nextHasNoMarginBottom
+                    />
+                    <TextControl
+                        label={__('Tab id', TEXT_DOMAIN)}
+                        help={__(
+                            'Auto-generated on insert; override if you need a stable URL anchor.',
+                            TEXT_DOMAIN
+                        )}
+                        value={tabId}
+                        onChange={(value) => setAttributes({ tabId: slugify(value) })}
+                        __nextHasNoMarginBottom
+                    />
+                </PanelBody>
+            </InspectorControls>
+            <div {...innerBlocksProps} />
+        </>
+    );
+}

--- a/resources/js/visual-editor/blocks/tab-section/index.ts
+++ b/resources/js/visual-editor/blocks/tab-section/index.ts
@@ -1,0 +1,21 @@
+/**
+ * Tab section block entrypoint.
+ *
+ * Auto-discovered by `editor/custom-blocks.ts`. Child of
+ * `artisanpack/tabs`; renders a single tab panel (#497).
+ */
+
+import metadata from './block.json';
+import edit from './edit';
+import save from './save';
+
+import '../tabs/tabs.css';
+
+export { edit, save, metadata };
+
+export default {
+    name: metadata.name,
+    metadata,
+    edit,
+    save,
+};

--- a/resources/js/visual-editor/blocks/tab-section/save.tsx
+++ b/resources/js/visual-editor/blocks/tab-section/save.tsx
@@ -1,0 +1,9 @@
+/**
+ * Tab section — save component.
+ *
+ * Dynamic block: the renderers walk the persisted inner-block tree.
+ */
+
+export default function TabSectionSave(): null {
+    return null;
+}

--- a/resources/js/visual-editor/blocks/tabs/block.json
+++ b/resources/js/visual-editor/blocks/tabs/block.json
@@ -1,0 +1,74 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "artisanpack/tabs",
+    "title": "Tabs",
+    "category": "artisanpack",
+    "description": "Group content into a tabbed interface.",
+    "keywords": ["tabs", "tabbed", "navigation"],
+    "textdomain": "artisanpack-visual-editor",
+    "attributes": {
+        "tabsAlign": {
+            "type": "string",
+            "enum": ["horizontal", "vertical"],
+            "default": "horizontal"
+        },
+        "tabsSpacing": {
+            "type": "string",
+            "enum": ["start", "end", "center", "equal"],
+            "default": "start"
+        }
+    },
+    "supports": {
+        "align": ["wide", "full"],
+        "anchor": true,
+        "ariaLabel": true,
+        "className": true,
+        "html": false,
+        "spacing": {
+            "margin": ["top", "bottom"],
+            "padding": true,
+            "blockGap": true,
+            "__experimentalDefaultControls": {
+                "padding": true,
+                "blockGap": true
+            }
+        },
+        "color": {
+            "background": true,
+            "text": true,
+            "link": true,
+            "gradients": true,
+            "__experimentalDefaultControls": {
+                "background": true,
+                "text": true
+            }
+        },
+        "shadow": true,
+        "__experimentalBorder": {
+            "color": true,
+            "radius": true,
+            "style": true,
+            "width": true,
+            "__experimentalDefaultControls": {
+                "color": true,
+                "radius": true,
+                "style": true,
+                "width": true
+            }
+        },
+        "typography": {
+            "fontSize": true,
+            "lineHeight": true,
+            "__experimentalFontFamily": true,
+            "__experimentalFontWeight": true,
+            "__experimentalFontStyle": true,
+            "__experimentalTextTransform": true,
+            "__experimentalTextDecoration": true,
+            "__experimentalLetterSpacing": true,
+            "__experimentalDefaultControls": {
+                "fontSize": true
+            }
+        }
+    }
+}

--- a/resources/js/visual-editor/blocks/tabs/edit.tsx
+++ b/resources/js/visual-editor/blocks/tabs/edit.tsx
@@ -1,0 +1,205 @@
+/**
+ * Tabs — editor-side component.
+ *
+ * Parent block in the tabs family (#497). The tab triggers are derived
+ * directly from the inner-block tab-sections — each section owns its
+ * own `label` + `tabId`, and the tabs block just stitches them into a
+ * tablist. The editor shows the tab list with one trigger active at a
+ * time so authors can switch between sections; "Add tab" appends a
+ * new tab-section child.
+ */
+
+import { useMemo, useState, type ReactElement } from 'react';
+import { InspectorControls, useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { Button, PanelBody, SelectControl } from '@wordpress/components';
+import { createBlock } from '@wordpress/blocks';
+import { __ } from '@wordpress/i18n';
+
+import { TEXT_DOMAIN } from '../../vendor/i18n';
+
+type TabsAlign = 'horizontal' | 'vertical';
+type TabsSpacing = 'start' | 'end' | 'center' | 'equal';
+
+interface TabsAttributes {
+    readonly tabsAlign: TabsAlign;
+    readonly tabsSpacing: TabsSpacing;
+}
+
+interface TabsEditProps {
+    readonly attributes: TabsAttributes;
+    readonly setAttributes: (next: Partial<TabsAttributes>) => void;
+    readonly clientId: string;
+}
+
+const ALLOWED_BLOCKS: string[] = ['artisanpack/tab-section'];
+
+const TEMPLATE: [string, Record<string, unknown>][] = [
+    ['artisanpack/tab-section', {}],
+    ['artisanpack/tab-section', {}],
+];
+
+const ALIGN_OPTIONS: ReadonlyArray<{ value: TabsAlign; label: string }> = [
+    { value: 'horizontal', label: 'Horizontal' },
+    { value: 'vertical', label: 'Vertical' },
+];
+
+const SPACING_OPTIONS: ReadonlyArray<{ value: TabsSpacing; label: string }> = [
+    { value: 'start', label: 'Start (Top / Left)' },
+    { value: 'end', label: 'End (Bottom / Right)' },
+    { value: 'center', label: 'Center' },
+    { value: 'equal', label: 'Equal' },
+];
+
+interface SectionSummary {
+    readonly clientId: string;
+    readonly label: string;
+    readonly tabId: string;
+}
+
+export default function TabsEdit({
+    attributes,
+    setAttributes,
+    clientId,
+}: TabsEditProps): ReactElement {
+    const { tabsAlign, tabsSpacing } = attributes;
+    const [activeClientId, setActiveClientId] = useState<string | null>(null);
+
+    const sections = useSelect<SectionSummary[]>(
+        (select) => {
+            const store = select('core/block-editor') as unknown as {
+                getBlocks: (id: string) => Array<{
+                    clientId: string;
+                    name: string;
+                    attributes: Record<string, unknown>;
+                }>;
+            };
+            return store
+                .getBlocks(clientId)
+                .filter((block) => block.name === 'artisanpack/tab-section')
+                .map((block) => ({
+                    clientId: block.clientId,
+                    label:
+                        typeof block.attributes.label === 'string'
+                            ? block.attributes.label
+                            : '',
+                    tabId:
+                        typeof block.attributes.tabId === 'string'
+                            ? block.attributes.tabId
+                            : '',
+                }));
+        },
+        [clientId]
+    );
+
+    const { insertBlock, selectBlock } = useDispatch('core/block-editor') as unknown as {
+        insertBlock: (block: unknown, index?: number, rootClientId?: string) => void;
+        selectBlock: (clientId: string) => void;
+    };
+
+    const activeId = useMemo(() => {
+        if (sections.length === 0) {
+            return null;
+        }
+        if (activeClientId !== null && sections.some((s) => s.clientId === activeClientId)) {
+            return activeClientId;
+        }
+        return sections[0].clientId;
+    }, [activeClientId, sections]);
+
+    const blockProps = useBlockProps({
+        className: `ap-tabs align-tabs-${tabsAlign} space-tabs-${tabsSpacing}`,
+    });
+
+    const innerBlocksProps = useInnerBlocksProps(
+        { className: 'ap-tabs__container', 'data-active-tab': activeId ?? '' },
+        {
+            allowedBlocks: ALLOWED_BLOCKS,
+            template: TEMPLATE,
+            renderAppender: false,
+        }
+    );
+
+    const handleAddTab = (): void => {
+        const block = createBlock('artisanpack/tab-section', {});
+        insertBlock(block, sections.length, clientId);
+    };
+
+    return (
+        <>
+            <InspectorControls>
+                <PanelBody title={__('Layout', TEXT_DOMAIN)} initialOpen>
+                    <SelectControl
+                        label={__('Tab list orientation', TEXT_DOMAIN)}
+                        value={tabsAlign}
+                        options={ALIGN_OPTIONS.map((option) => ({
+                            label: __(option.label, TEXT_DOMAIN),
+                            value: option.value,
+                        }))}
+                        onChange={(value) => {
+                            if (value === 'horizontal' || value === 'vertical') {
+                                setAttributes({ tabsAlign: value });
+                            }
+                        }}
+                        __nextHasNoMarginBottom
+                    />
+                    <SelectControl
+                        label={__('Tab list spacing', TEXT_DOMAIN)}
+                        value={tabsSpacing}
+                        options={SPACING_OPTIONS.map((option) => ({
+                            label: __(option.label, TEXT_DOMAIN),
+                            value: option.value,
+                        }))}
+                        onChange={(value) => {
+                            if (
+                                value === 'start' ||
+                                value === 'end' ||
+                                value === 'center' ||
+                                value === 'equal'
+                            ) {
+                                setAttributes({ tabsSpacing: value });
+                            }
+                        }}
+                        __nextHasNoMarginBottom
+                    />
+                </PanelBody>
+            </InspectorControls>
+            <div {...blockProps}>
+                <div className="ap-tabs__list" role="tablist">
+                    <ul>
+                        {sections.map((section) => {
+                            const isActive = section.clientId === activeId;
+                            return (
+                                <li key={section.clientId}>
+                                    <button
+                                        type="button"
+                                        role="tab"
+                                        aria-selected={isActive ? 'true' : 'false'}
+                                        tabIndex={isActive ? 0 : -1}
+                                        onClick={() => {
+                                            setActiveClientId(section.clientId);
+                                            selectBlock(section.clientId);
+                                        }}
+                                    >
+                                        {section.label ||
+                                            __('Untitled tab', TEXT_DOMAIN)}
+                                    </button>
+                                </li>
+                            );
+                        })}
+                        <li className="ap-tabs__add-tab">
+                            <Button
+                                variant="secondary"
+                                onClick={handleAddTab}
+                                aria-label={__('Add tab', TEXT_DOMAIN)}
+                            >
+                                {__('+ Tab', TEXT_DOMAIN)}
+                            </Button>
+                        </li>
+                    </ul>
+                </div>
+                <div {...innerBlocksProps} />
+            </div>
+        </>
+    );
+}

--- a/resources/js/visual-editor/blocks/tabs/index.ts
+++ b/resources/js/visual-editor/blocks/tabs/index.ts
@@ -1,0 +1,21 @@
+/**
+ * Tabs block entrypoint.
+ *
+ * Auto-discovered by `editor/custom-blocks.ts`. Parent block of the
+ * tabs family (#497).
+ */
+
+import metadata from './block.json';
+import edit from './edit';
+import save from './save';
+
+import './tabs.css';
+
+export { edit, save, metadata };
+
+export default {
+    name: metadata.name,
+    metadata,
+    edit,
+    save,
+};

--- a/resources/js/visual-editor/blocks/tabs/save.tsx
+++ b/resources/js/visual-editor/blocks/tabs/save.tsx
@@ -1,0 +1,9 @@
+/**
+ * Tabs — save component.
+ *
+ * Dynamic block: the renderers walk the persisted inner-block tree.
+ */
+
+export default function TabsSave(): null {
+    return null;
+}

--- a/resources/js/visual-editor/blocks/tabs/tabs.css
+++ b/resources/js/visual-editor/blocks/tabs/tabs.css
@@ -80,13 +80,13 @@
 .ap-tabs__list a[aria-selected="true"],
 .ap-tabs__list button[aria-selected="true"] {
     font-weight: 600;
-    border-bottom: 2px solid currentColor;
+    border-bottom: 2px solid currentcolor;
 }
 
 .ap-tabs.align-tabs-vertical .ap-tabs__list a[aria-selected="true"],
 .ap-tabs.align-tabs-vertical .ap-tabs__list button[aria-selected="true"] {
     border-bottom: 0;
-    border-right: 2px solid currentColor;
+    border-right: 2px solid currentcolor;
 }
 
 .ap-tabs__container {

--- a/resources/js/visual-editor/blocks/tabs/tabs.css
+++ b/resources/js/visual-editor/blocks/tabs/tabs.css
@@ -1,0 +1,106 @@
+/**
+ * Tabs family styles (#497).
+ *
+ * Loaded in the editor via `blocks/{tabs,tab-section}/index.ts`. On
+ * the public frontend the Blade renderer serves an identical copy
+ * from `packages/visual-editor-renderer-blade/resources/assets/frontend/tabs.css`,
+ * wired up by `<x-ve-blocks-styles />`. React/Vue renderers emit the
+ * same class names so a single stylesheet covers all three.
+ */
+
+.ap-tabs {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+    margin-block-end: var(--wp--style--block-gap, 1.5rem);
+}
+
+.ap-tabs.align-tabs-vertical {
+    flex-direction: row;
+    align-items: stretch;
+}
+
+.ap-tabs__list {
+    border-bottom: 1px solid var(--ap-tabs-separator, rgba(0, 0, 0, 0.1));
+}
+
+.ap-tabs.align-tabs-vertical .ap-tabs__list {
+    border-right: 1px solid var(--ap-tabs-separator, rgba(0, 0, 0, 0.1));
+    border-bottom: 0;
+}
+
+.ap-tabs__list ul {
+    display: flex;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    gap: 0;
+}
+
+.ap-tabs.align-tabs-vertical .ap-tabs__list ul {
+    flex-direction: column;
+}
+
+/* Tab spacing modes: start / end / center pack the triggers; equal
+   distributes them evenly across the tablist. */
+.ap-tabs.space-tabs-start .ap-tabs__list ul {
+    justify-content: flex-start;
+}
+
+.ap-tabs.space-tabs-end .ap-tabs__list ul {
+    justify-content: flex-end;
+}
+
+.ap-tabs.space-tabs-center .ap-tabs__list ul {
+    justify-content: center;
+}
+
+.ap-tabs.space-tabs-equal .ap-tabs__list ul li {
+    flex: 1;
+}
+
+.ap-tabs.space-tabs-equal .ap-tabs__list ul li a,
+.ap-tabs.space-tabs-equal .ap-tabs__list ul li button {
+    text-align: center;
+    width: 100%;
+}
+
+.ap-tabs__list a,
+.ap-tabs__list button {
+    display: inline-block;
+    padding: 0.5rem 1rem;
+    text-decoration: none;
+    color: inherit;
+    cursor: pointer;
+    background: transparent;
+    border: 0;
+    font: inherit;
+}
+
+.ap-tabs__list a[aria-selected="true"],
+.ap-tabs__list button[aria-selected="true"] {
+    font-weight: 600;
+    border-bottom: 2px solid currentColor;
+}
+
+.ap-tabs.align-tabs-vertical .ap-tabs__list a[aria-selected="true"],
+.ap-tabs.align-tabs-vertical .ap-tabs__list button[aria-selected="true"] {
+    border-bottom: 0;
+    border-right: 2px solid currentColor;
+}
+
+.ap-tabs__container {
+    flex: 1;
+}
+
+.ap-tab-section {
+    padding: 1rem 0;
+}
+
+/* Hide inactive sections on the front-end. The interactivity script
+   toggles the `hidden` attribute when switching tabs. In the editor,
+   all sections stay visible so authors can edit each panel without
+   constantly toggling tabs. */
+.ap-tab-section[hidden] {
+    display: none;
+}

--- a/resources/js/visual-editor/editor/__tests__/canvas-styles.test.ts
+++ b/resources/js/visual-editor/editor/__tests__/canvas-styles.test.ts
@@ -32,12 +32,13 @@ describe('canvasStyles', () => {
     it('bundles the theme token bridge, the three @wordpress sheet groups, the canvas baseline, alignment overrides, and the post-editor framing', () => {
         // token bridge + components + block-editor (style + content)
         // + block-library (style + editor) + LAYOUT_BASELINE
+        // + accordion + tabs + editor-tweaks (interactive blocks; #497)
         // + DEFAULT_CANVAS_STYLES + ALIGNMENT_OVERRIDE_STYLES
         // + POST_EDITOR_FRAMING_STYLES (Keystone #47 — site-editor
         // canvases skip the framing entry but keep the alignment
         // overrides so the wide/full toolbar buttons take effect
         // there too).
-        expect(canvasStyles).toHaveLength(10);
+        expect(canvasStyles).toHaveLength(13);
     });
 
     it('places DEFAULT_CANVAS_STYLES before POST_EDITOR_FRAMING_STYLES so the framing wins the cascade', () => {

--- a/resources/js/visual-editor/editor/canvas-styles.ts
+++ b/resources/js/visual-editor/editor/canvas-styles.ts
@@ -34,6 +34,9 @@ import {
     POST_EDITOR_FRAMING_STYLES,
 } from '../editor-settings';
 
+import accordionStyles from '../blocks/accordion/accordion.css?inline';
+import tabsStyles from '../blocks/tabs/tabs.css?inline';
+
 import canvasThemeTokens from './canvas-theme-tokens.css?inline';
 
 /** A single stylesheet entry in the shape `BlockCanvas`'s `styles` prop expects. */
@@ -98,6 +101,49 @@ export const canvasStyles: readonly CanvasStyle[] = [
     { css: blockLibraryStyle },
     { css: blockLibraryEditor },
     { css: LAYOUT_BASELINE_STYLES },
+    // Interactive block families (#497) — accordion + tabs.
+    // The editor canvas runs in a sandboxed iframe so the per-block
+    // CSS imports in `blocks/{accordion,tabs}/index.ts` don't reach
+    // it; ship the rules here too so authors get an accurate preview.
+    // Editor-specific overrides (showing all panels at once for
+    // editability) are appended after the front-end rules.
+    { css: accordionStyles },
+    { css: tabsStyles },
+    {
+        css: `
+            /* Editor preview overrides — keep every panel and tab
+               section expanded so authors can edit each one without
+               toggling. The front-end interactivity script restores
+               normal accordion / tab behavior at render time. */
+            .ap-accordion__body[hidden] { display: block !important; }
+            .ap-tab-section[hidden] { display: block !important; }
+
+            /* Drop list bullets from the tab list — Gutenberg's editor
+               stylesheet adds them back inside the iframe. */
+            .ap-tabs__list ul { list-style: none !important; padding-left: 0 !important; }
+            .ap-tabs__list ul li { margin: 0 !important; padding: 0 !important; }
+
+            /* Inner-block reset: Gutenberg's editor stylesheet adds
+               generous top/bottom margins to headings and paragraphs
+               (the "is-layout-flow" baseline), which doubles up with
+               our wrapper padding. Collapse the first/last child
+               margin so the accordion title + body and tab section
+               line up tight against the wrapper edges in the canvas. */
+            .ap-accordion__title-content > :first-child,
+            .ap-accordion__body > :first-child,
+            .ap-tab-section > :first-child { margin-block-start: 0 !important; }
+            .ap-accordion__title-content > :last-child,
+            .ap-accordion__body > :last-child,
+            .ap-tab-section > :last-child { margin-block-end: 0 !important; }
+
+            /* The block-editor wraps every block in a .block-editor-block-list__block
+               div that adds its own margin. Inside the accordion / tab containers,
+               trim that wrapper margin so the visual cadence matches the
+               front-end. */
+            .ap-accordion__body .block-editor-block-list__block,
+            .ap-tab-section .block-editor-block-list__block { margin-top: 0; margin-bottom: 0; }
+        `,
+    },
     { css: DEFAULT_CANVAS_STYLES },
     // Per-block wide/full overrides. Shared with the site editor —
     // both need the toolbar's alignment buttons to actually resize


### PR DESCRIPTION
## Description

Adds six new `artisanpack/*` blocks covering two interactive families — accordion + tabs — with three-renderer parity (Blade + React + Vue), front-end CSS, and a vanilla interactivity script.

**Closes:** #497

## Type of Change

- [x] New feature (adds new functionality)
- [x] Enhancement (improves existing functionality)

## Related Issue

**Issue:** #497

## Motivation and Context

Phase CW1 of the broader port to first-party ArtisanPack UI blocks (umbrella #495). These two families exercise the parent / child / grandchild inner-block pattern (`accordions` → `accordion` → `accordion-title` + `accordion-body`) and the parent / child pattern (`tabs` → `tab-section`), plus JS-driven interactivity. Both families ship as first-party blocks under `artisanpack/*` — the upstream attribution lives in the umbrella issue, not the block code itself.

## Changes Made

### Accordion family
- `accordions` parent owns the wrapper; `accordion` child owns the `panelId` + `panelIcon`, auto-generated from the clientId on mount.
- `accordion-title` and `accordion-body` are content-only — the `accordion` renderer walks its children and re-wraps them with matching `id` / `aria-controls` / `aria-labelledby` / `hidden` wiring, so authors only ever set the panel id once.

### Tabs family
- `tab-section` owns its own `label` + `tabId` (both auto-fill on mount: label as `Tab N`, tabId as `tab-<clientId-suffix>`).
- `tabs` renderer walks `innerBlocks` to build the tablist AND re-wraps each section's grandchildren with the resolved tabId, so trigger `aria-controls` always matches panel `id`. Includes positional fallback for missing tabIds and dedup for duplicate slugs.

### Renderer infrastructure
- `BlockRenderer.php` now passes the raw `innerBlocks` array to Blade partials alongside the pre-rendered `innerBlocksHtml` so partials can walk children when they need to derive parent state.

### Front-end + editor canvas
- Per-family CSS + a vanilla interactivity script ship from `visual-editor-renderer-blade` under `public/vendor/.../frontend/`, wired into the new `<x-ve-blocks-styles />` emission.
- The interactivity script handles accordion toggle (click + Enter/Space) and tab switching (click + arrow keys + Home/End). Respects server-rendered initial `aria-selected`. Re-binds on `window.dispatchEvent(new Event('ap:rebind'))` for SPA navigation.
- Editor canvas iframe picks up the styles via `canvas-styles` with editor-only overrides that keep every panel / section expanded for editing.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS Darwin 25.5.0
- Browser: Chrome (latest)
- PHP Version: 8.4.3
- Project Version: `feature/495-port-crosswinds-blocks` HEAD

**Tests Performed:**
1. Inserted Accordions block in editor — panel id auto-generated, title shows toggle icon, body editable
2. Switched accordion icon (plus/minus → arrows) — title icon updates instantly via `useSelect`
3. Inserted Tabs block — tab labels auto-fill as "Tab 1", "Tab 2"; "+ Tab" appends new section
4. Edited tab section label / id via Inspector — tablist updates
5. Rendered both blocks on the public preview page — interactivity works (toggle, tab switch, keyboard nav)

## Accessibility Tests Run

- [x] Keyboard navigation tested
- [x] ARIA labels checked

**Details:** Accordion title is `role="button"` with `aria-expanded` toggling on Enter / Space; body is `role="region"` with `aria-labelledby` pointing at the title. Tabs use `role="tablist"` / `role="tab"` / `role="tabpanel"` with full keyboard support (Tab, arrow keys, Home, End). Color contrast and screen-reader testing left for a dedicated accessibility audit pass.

## Tests Added

- [x] Unit tests added/updated
- [x] All tests passing

**Test details:** 6 new Blade tests, 7 new React tests, 7 new Vue tests covering happy-path rendering, safe-default fallbacks for invalid enums, empty-id edge cases, positional auto-fill, and tabId dedup. All 1031 Pest tests + 1915 vitest tests + renderer-parity check green.

## Documentation

- [x] Inline code documentation added

**Documentation details:** Each new block, renderer, and helper carries a file-level docblock explaining intent + parent/child relationship. Editor-side comments call out non-obvious patterns (e.g., why the accordion renderer reaches into pre-rendered children to re-wrap them).

## Screenshots

_Editor + front-end screenshots captured during local manual testing; see the issue thread for a record._

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Code passes all tests
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Accordion and Tabs block families with accessible toggle/tab behaviors, keyboard navigation, customizable icons, alignment/spacing options, and editor UI for composing sections.
* **Style**
  * New styles for accordion and tabs for both editor preview and frontend, plus conditional asset loading when interactive features are enabled.
* **Tests**
  * Added unit and renderer tests covering rendering, ARIA wiring, sanitization, and ID deduplication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->