### PR TITLE
feat: artisanpack/next-post + artisanpack/previous-post container blocks

### DIFF
--- a/packages/renderer-parity.json
+++ b/packages/renderer-parity.json
@@ -136,6 +136,8 @@
         "artisanpack/tabs",
         "artisanpack/tab-section",
         "artisanpack/grid",
-        "artisanpack/grid-item"
+        "artisanpack/grid-item",
+        "artisanpack/next-post",
+        "artisanpack/previous-post"
     ]
 }

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/next-post.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/next-post.blade.php
@@ -1,0 +1,18 @@
+{{--
+	artisanpack/next-post — adjacent-post container (#499).
+
+	Reads the `_resolvedHasAdjacent` flag PostResolver stamps after
+	resolving the next adjacent post. When the host post has no neighbor
+	the wrapper renders nothing — matches the original block contract
+	where empty markup is preferred to a dangling placeholder. The
+	inner-block tree itself is already resolved against the adjacent
+	post upstream, so this template only owns the wrapper.
+--}}
+@php
+	use ArtisanPackUI\VisualEditorRendererBlade\Support\BlockSupports;
+
+	$hasAdjacent = ! empty( $attributes['_resolvedHasAdjacent'] );
+@endphp
+@if ( $hasAdjacent )
+	<div{!! BlockSupports::wrapperAttrs( $attributes, [ 'wp-block-artisanpack-next-post', 'navigation-post' ] ) !!}>{!! $innerBlocksHtml !!}</div>
+@endif

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/previous-post.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/previous-post.blade.php
@@ -1,0 +1,18 @@
+{{--
+	artisanpack/previous-post — adjacent-post container (#499).
+
+	Reads the `_resolvedHasAdjacent` flag PostResolver stamps after
+	resolving the previous adjacent post. When the host post has no
+	neighbor the wrapper renders nothing — matches the original block
+	contract where empty markup is preferred to a dangling placeholder.
+	The inner-block tree itself is already resolved against the
+	adjacent post upstream, so this template only owns the wrapper.
+--}}
+@php
+	use ArtisanPackUI\VisualEditorRendererBlade\Support\BlockSupports;
+
+	$hasAdjacent = ! empty( $attributes['_resolvedHasAdjacent'] );
+@endphp
+@if ( $hasAdjacent )
+	<div{!! BlockSupports::wrapperAttrs( $attributes, [ 'wp-block-artisanpack-previous-post', 'navigation-post' ] ) !!}>{!! $innerBlocksHtml !!}</div>
+@endif

--- a/packages/visual-editor-renderer-blade/tests/Unit/BlockRendererTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Unit/BlockRendererTest.php
@@ -902,6 +902,66 @@ it( 'compiles spacing.blockGap with horizontal/vertical sides into row-gap + col
 		->and( $html )->toContain( 'column-gap: 1rem' );
 } );
 
+it( 'renders artisanpack/next-post wrapper around its inner blocks when an adjacent post is resolved', function () {
+	$tree = [
+		makeBlock(
+			'artisanpack/next-post',
+			[ '_resolvedHasAdjacent' => true ],
+			[ makeBlock( 'core/paragraph', [ 'content' => 'Adjacent body' ] ) ]
+		),
+	];
+
+	$html = makeRenderer()->render( $tree );
+
+	expect( $html )->toContain( 'wp-block-artisanpack-next-post' )
+		->and( $html )->toContain( 'navigation-post' )
+		->and( $html )->toContain( 'Adjacent body' );
+} );
+
+it( 'emits nothing for artisanpack/next-post when no adjacent post is resolved', function () {
+	$tree = [
+		makeBlock(
+			'artisanpack/next-post',
+			[ '_resolvedHasAdjacent' => false ],
+			[ makeBlock( 'core/paragraph', [ 'content' => 'Hidden' ] ) ]
+		),
+	];
+
+	$html = trim( makeRenderer()->render( $tree ) );
+
+	expect( $html )->toBe( '' );
+} );
+
+it( 'renders artisanpack/previous-post wrapper around its inner blocks when an adjacent post is resolved', function () {
+	$tree = [
+		makeBlock(
+			'artisanpack/previous-post',
+			[ '_resolvedHasAdjacent' => true ],
+			[ makeBlock( 'core/paragraph', [ 'content' => 'Older neighbor' ] ) ]
+		),
+	];
+
+	$html = makeRenderer()->render( $tree );
+
+	expect( $html )->toContain( 'wp-block-artisanpack-previous-post' )
+		->and( $html )->toContain( 'navigation-post' )
+		->and( $html )->toContain( 'Older neighbor' );
+} );
+
+it( 'emits nothing for artisanpack/previous-post when no adjacent post is resolved', function () {
+	$tree = [
+		makeBlock(
+			'artisanpack/previous-post',
+			[ '_resolvedHasAdjacent' => false ],
+			[ makeBlock( 'core/paragraph', [ 'content' => 'Hidden' ] ) ]
+		),
+	];
+
+	$html = trim( makeRenderer()->render( $tree ) );
+
+	expect( $html )->toBe( '' );
+} );
+
 describe( 'Keystone #50 — block-supports compilation on the rendered HTML', function (): void {
 	it( 'renders a custom background color on core/group as both class marker and inline style', function (): void {
 		$tree = [ makeBlock( 'core/group', [

--- a/packages/visual-editor-renderer-react/src/blocks/artisanpack/postNavigation.tsx
+++ b/packages/visual-editor-renderer-react/src/blocks/artisanpack/postNavigation.tsx
@@ -1,0 +1,42 @@
+/**
+ * React renderers for the post-navigation container family (#499).
+ *
+ *   - artisanpack/next-post
+ *   - artisanpack/previous-post
+ *
+ * Container blocks: server-side `PostResolver` resolves the adjacent
+ * post and re-stamps the inner-block tree against it. This renderer
+ * only owns the wrapper: when `_resolvedHasAdjacent` is true, emit the
+ * `<div>` shell with the `wp-block-…` + `navigation-post` classes; when
+ * false (no neighbor in the chosen direction), emit nothing — matches
+ * the Blade + Vue counterparts.
+ */
+
+import type { ReactElement } from 'react';
+
+import { attrBoolean, attrString, classList } from '../../support/attributes';
+import type { BlockRendererProps } from '../../types';
+
+function renderAdjacentContainer(
+    wrapperClass: string,
+    { attributes, children }: BlockRendererProps
+): ReactElement | null {
+    const hasAdjacent = attrBoolean(attributes._resolvedHasAdjacent, false);
+
+    if (!hasAdjacent) {
+        return null;
+    }
+
+    const className = attrString(attributes.className);
+    const classes = classList([wrapperClass, 'navigation-post', className]);
+
+    return <div className={classes}>{children}</div>;
+}
+
+export function NextPostBlock(props: BlockRendererProps): ReactElement | null {
+    return renderAdjacentContainer('wp-block-artisanpack-next-post', props);
+}
+
+export function PreviousPostBlock(props: BlockRendererProps): ReactElement | null {
+    return renderAdjacentContainer('wp-block-artisanpack-previous-post', props);
+}

--- a/packages/visual-editor-renderer-react/src/blocks/registerCoreBlocks.ts
+++ b/packages/visual-editor-renderer-react/src/blocks/registerCoreBlocks.ts
@@ -24,6 +24,10 @@ import { GridBlock, GridItemBlock } from './artisanpack/grid';
 import { TabSectionBlock, TabsBlock } from './artisanpack/tabs';
 import { LoginoutBlock } from './artisanpack/loginout';
 import {
+    NextPostBlock,
+    PreviousPostBlock,
+} from './artisanpack/postNavigation';
+import {
     CoverBlock,
     DetailsBlock,
     MediaTextBlock,
@@ -234,6 +238,12 @@ const CORE_BLOCKS: Record<string, BlockRenderer> = {
     // per-breakpoint span classes and inner-layout flex class.
     'artisanpack/grid': GridBlock,
     'artisanpack/grid-item': GridItemBlock,
+    // Adjacent-post container family (#499). PostResolver re-stamps the
+    // inner-block tree against the resolved neighbor and sets
+    // `_resolvedHasAdjacent`; renderer emits the `<div>` wrapper when
+    // that flag is true and nothing otherwise.
+    'artisanpack/next-post': NextPostBlock,
+    'artisanpack/previous-post': PreviousPostBlock,
     // Post navigation / metadata family (#520) — same renderer for both
     // namespaces; PostResolver stamps the same `_resolved*` attributes.
     'core/post-navigation-link': PostNavigationLinkBlock,

--- a/packages/visual-editor-renderer-react/tests/BlockTree.test.tsx
+++ b/packages/visual-editor-renderer-react/tests/BlockTree.test.tsx
@@ -993,6 +993,66 @@ describe('Core design blocks', () => {
         expect(html).not.toContain('<script>');
         expect(html).not.toContain('ap-grid-item-layout-evil');
     });
+
+    it('renders artisanpack/next-post wrapper around its inner blocks when an adjacent post is resolved', () => {
+        const tree = [
+            makeBlock(
+                'artisanpack/next-post',
+                { _resolvedHasAdjacent: true },
+                [makeBlock('core/paragraph', { content: 'Adjacent body' })]
+            ),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('wp-block-artisanpack-next-post');
+        expect(html).toContain('navigation-post');
+        expect(html).toContain('Adjacent body');
+    });
+
+    it('emits nothing for artisanpack/next-post when no adjacent post is resolved', () => {
+        const tree = [
+            makeBlock(
+                'artisanpack/next-post',
+                { _resolvedHasAdjacent: false },
+                [makeBlock('core/paragraph', { content: 'Hidden' })]
+            ),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toBe('');
+    });
+
+    it('renders artisanpack/previous-post wrapper around its inner blocks when an adjacent post is resolved', () => {
+        const tree = [
+            makeBlock(
+                'artisanpack/previous-post',
+                { _resolvedHasAdjacent: true },
+                [makeBlock('core/paragraph', { content: 'Older neighbor' })]
+            ),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('wp-block-artisanpack-previous-post');
+        expect(html).toContain('navigation-post');
+        expect(html).toContain('Older neighbor');
+    });
+
+    it('emits nothing for artisanpack/previous-post when no adjacent post is resolved', () => {
+        const tree = [
+            makeBlock(
+                'artisanpack/previous-post',
+                { _resolvedHasAdjacent: false },
+                [makeBlock('core/paragraph', { content: 'Hidden' })]
+            ),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toBe('');
+    });
 });
 
 describe('Registry + dynamic fallback', () => {

--- a/packages/visual-editor-renderer-vue/src/blocks/artisanpack/postNavigation.ts
+++ b/packages/visual-editor-renderer-vue/src/blocks/artisanpack/postNavigation.ts
@@ -1,0 +1,56 @@
+/**
+ * Vue renderers for the post-navigation container family (#499).
+ *
+ *   - artisanpack/next-post
+ *   - artisanpack/previous-post
+ *
+ * Container blocks: server-side `PostResolver` resolves the adjacent
+ * post and re-stamps the inner-block tree against it. This renderer
+ * only owns the wrapper: when `_resolvedHasAdjacent` is true, emit the
+ * `<div>` shell with the `wp-block-…` + `navigation-post` classes; when
+ * false (no neighbor in the chosen direction), emit nothing — matches
+ * the Blade + React counterparts.
+ */
+
+import { defineComponent, h, type VNode } from 'vue';
+
+import { attrBoolean, attrString, classList } from '../../support/attributes';
+import { blockRendererProps } from '../shared';
+
+function adjacentContainer(name: string, wrapperClass: string) {
+    return defineComponent({
+        name,
+        props: blockRendererProps,
+        setup(props, { slots }) {
+            return (): VNode | null => {
+                const hasAdjacent = attrBoolean(
+                    props.attributes._resolvedHasAdjacent,
+                    false
+                );
+
+                if (!hasAdjacent) {
+                    return null;
+                }
+
+                const className = attrString(props.attributes.className);
+                const classes = classList([
+                    wrapperClass,
+                    'navigation-post',
+                    className,
+                ]);
+
+                return h('div', { class: classes }, slots.default?.());
+            };
+        },
+    });
+}
+
+export const NextPostBlock = adjacentContainer(
+    'NextPostBlock',
+    'wp-block-artisanpack-next-post'
+);
+
+export const PreviousPostBlock = adjacentContainer(
+    'PreviousPostBlock',
+    'wp-block-artisanpack-previous-post'
+);

--- a/packages/visual-editor-renderer-vue/src/blocks/registerCoreBlocks.ts
+++ b/packages/visual-editor-renderer-vue/src/blocks/registerCoreBlocks.ts
@@ -24,6 +24,10 @@ import { GridBlock, GridItemBlock } from './artisanpack/grid';
 import { TabSectionBlock, TabsBlock } from './artisanpack/tabs';
 import { LoginoutBlock } from './artisanpack/loginout';
 import {
+    NextPostBlock,
+    PreviousPostBlock,
+} from './artisanpack/postNavigation';
+import {
     CommentAuthorAvatarBlock,
     CommentAuthorNameBlock,
     CommentContentBlock,
@@ -234,6 +238,12 @@ const CORE_BLOCKS: Record<string, BlockRenderer> = {
     // per-breakpoint span classes and inner-layout flex class.
     'artisanpack/grid': GridBlock,
     'artisanpack/grid-item': GridItemBlock,
+    // Adjacent-post container family (#499). PostResolver re-stamps the
+    // inner-block tree against the resolved neighbor and sets
+    // `_resolvedHasAdjacent`; renderer emits the `<div>` wrapper when
+    // that flag is true and nothing otherwise.
+    'artisanpack/next-post': NextPostBlock,
+    'artisanpack/previous-post': PreviousPostBlock,
     // Post navigation / metadata family (#520) — same renderer for both
     // namespaces; PostResolver stamps the same `_resolved*` attributes.
     'core/post-navigation-link': PostNavigationLinkBlock,

--- a/packages/visual-editor-renderer-vue/tests/BlockTree.test.ts
+++ b/packages/visual-editor-renderer-vue/tests/BlockTree.test.ts
@@ -992,6 +992,66 @@ describe('Core design blocks', () => {
         expect(html).not.toContain('<script>');
         expect(html).not.toContain('ap-grid-item-layout-evil');
     });
+
+    it('renders artisanpack/next-post wrapper around its inner blocks when an adjacent post is resolved', () => {
+        const tree = [
+            makeBlock(
+                'artisanpack/next-post',
+                { _resolvedHasAdjacent: true },
+                [makeBlock('core/paragraph', { content: 'Adjacent body' })]
+            ),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('wp-block-artisanpack-next-post');
+        expect(html).toContain('navigation-post');
+        expect(html).toContain('Adjacent body');
+    });
+
+    it('emits nothing for artisanpack/next-post when no adjacent post is resolved', () => {
+        const tree = [
+            makeBlock(
+                'artisanpack/next-post',
+                { _resolvedHasAdjacent: false },
+                [makeBlock('core/paragraph', { content: 'Hidden' })]
+            ),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toBe('');
+    });
+
+    it('renders artisanpack/previous-post wrapper around its inner blocks when an adjacent post is resolved', () => {
+        const tree = [
+            makeBlock(
+                'artisanpack/previous-post',
+                { _resolvedHasAdjacent: true },
+                [makeBlock('core/paragraph', { content: 'Older neighbor' })]
+            ),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('wp-block-artisanpack-previous-post');
+        expect(html).toContain('navigation-post');
+        expect(html).toContain('Older neighbor');
+    });
+
+    it('emits nothing for artisanpack/previous-post when no adjacent post is resolved', () => {
+        const tree = [
+            makeBlock(
+                'artisanpack/previous-post',
+                { _resolvedHasAdjacent: false },
+                [makeBlock('core/paragraph', { content: 'Hidden' })]
+            ),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toBe('');
+    });
 });
 
 describe('Registry + dynamic fallback', () => {

--- a/resources/js/visual-editor/blocks/__tests__/adjacent-post-container-family.test.ts
+++ b/resources/js/visual-editor/blocks/__tests__/adjacent-post-container-family.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Adjacent-post container family contract (#499).
+ *
+ * block.json + save contract for the two wrapper blocks:
+ *
+ *   - next-post
+ *   - previous-post
+ *
+ * Both blocks share the same shape: dynamic save (`null`), `theme`
+ * category, `artisanpack` namespace + `artisanpack-visual-editor`
+ * textdomain, and a `postType` / `queryId` providesContext map so
+ * inner post-* children render against the resolved adjacent post
+ * upstream.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import nextPostMeta from '../next-post/block.json';
+import previousPostMeta from '../previous-post/block.json';
+
+import nextPostSave from '../next-post/save';
+import previousPostSave from '../previous-post/save';
+
+const FAMILY = [
+    { slug: 'next-post', meta: nextPostMeta, save: nextPostSave },
+    { slug: 'previous-post', meta: previousPostMeta, save: previousPostSave },
+] as const;
+
+describe('adjacent-post container family block.json', () => {
+    it.each(FAMILY)(
+        '$slug declares the artisanpack namespace + textdomain',
+        ({ slug, meta }) => {
+            expect(meta.name).toBe(`artisanpack/${slug}`);
+            expect(meta.textdomain).toBe('artisanpack-visual-editor');
+            expect(meta.category).toBe('theme');
+        }
+    );
+
+    it.each(FAMILY)(
+        '$slug provides postType / queryId context for inner post-* children',
+        ({ meta }) => {
+            const providesContext = (meta as { providesContext?: Record<string, string> })
+                .providesContext;
+            expect(providesContext).toBeDefined();
+            expect(providesContext?.postType).toBe('postType');
+            expect(providesContext?.queryId).toBe('queryId');
+        }
+    );
+
+    it.each(FAMILY)('$slug declares a default postType of "post"', ({ meta }) => {
+        const attrs = (meta as { attributes?: Record<string, { default?: unknown }> })
+            .attributes;
+        expect(attrs?.postType?.default).toBe('post');
+    });
+});
+
+describe('adjacent-post container family save contract', () => {
+    it.each(FAMILY)('$slug.save returns null (dynamic block)', ({ save }) => {
+        expect((save as () => null)()).toBeNull();
+    });
+});

--- a/resources/js/visual-editor/blocks/_shared/__tests__/entity-placeholder-live-entity.test.tsx
+++ b/resources/js/visual-editor/blocks/_shared/__tests__/entity-placeholder-live-entity.test.tsx
@@ -13,6 +13,13 @@ import { select } from '@wordpress/data';
 
 vi.mock('@wordpress/block-editor', () => ({
     useBlockProps: () => ({ className: 'fallback-wrapper' }),
+    // The post-title edit exposes an InspectorControls panel for the
+    // isLink / linkTarget / rel attributes — stub it out as a no-op
+    // wrapper so the test environment doesn't have to mount the real
+    // sidebar slot.
+    InspectorControls: ({ children }: { children: React.ReactNode }) => (
+        <>{children}</>
+    ),
     // Minimal PlainText stub: renders a controlled textarea so the
     // editable post-title path can be asserted with RTL queries.
     PlainText: ({
@@ -42,6 +49,12 @@ vi.mock('@wordpress/block-editor', () => ({
             />
         );
     },
+}));
+
+vi.mock('@wordpress/components', () => ({
+    PanelBody: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    ToggleControl: () => null,
+    TextControl: () => null,
 }));
 
 import {

--- a/resources/js/visual-editor/blocks/_shared/__tests__/entity-placeholder-query-preview.test.tsx
+++ b/resources/js/visual-editor/blocks/_shared/__tests__/entity-placeholder-query-preview.test.tsx
@@ -10,6 +10,13 @@ import { render } from '@testing-library/react';
 
 vi.mock('@wordpress/block-editor', () => ({
     useBlockProps: () => ({ className: 'fallback-wrapper' }),
+    // The post-title edit exposes an InspectorControls panel for the
+    // isLink / linkTarget / rel attributes — stub it out as a no-op
+    // wrapper so the test environment doesn't have to mount the real
+    // sidebar slot.
+    InspectorControls: ({ children }: { children: React.ReactNode }) => (
+        <>{children}</>
+    ),
     // Minimal PlainText stub; the query-preview tests never reach the
     // editable post-title path, but the import has to resolve when the
     // edit module loads.
@@ -29,6 +36,12 @@ vi.mock('@wordpress/block-editor', () => ({
             onChange={(event) => onChange(event.target.value)}
         />
     ),
+}));
+
+vi.mock('@wordpress/components', () => ({
+    PanelBody: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    ToggleControl: () => null,
+    TextControl: () => null,
 }));
 
 import { createEntityPlaceholderEdit } from '../entity-placeholder-edit';

--- a/resources/js/visual-editor/blocks/next-post/block.json
+++ b/resources/js/visual-editor/blocks/next-post/block.json
@@ -1,0 +1,45 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "artisanpack/next-post",
+    "title": "Next Post",
+    "category": "theme",
+    "description": "Wrap inner blocks against the next post in the same post type so post-* children render the newer neighbor's data.",
+    "keywords": ["next", "post", "navigation", "adjacent"],
+    "textdomain": "artisanpack-visual-editor",
+    "attributes": {
+        "postType": {
+            "type": "string",
+            "default": "post"
+        },
+        "queryId": {
+            "type": "number"
+        },
+        "tagName": {
+            "type": "string",
+            "default": "div"
+        }
+    },
+    "providesContext": {
+        "postType": "postType",
+        "queryId": "queryId"
+    },
+    "supports": {
+        "anchor": true,
+        "align": ["wide", "full"],
+        "html": false,
+        "reusable": false,
+        "color": {
+            "gradients": true,
+            "link": true,
+            "__experimentalDefaultControls": {
+                "background": true,
+                "text": true
+            }
+        },
+        "spacing": {
+            "margin": ["top", "bottom"],
+            "padding": true
+        }
+    }
+}

--- a/resources/js/visual-editor/blocks/next-post/edit.tsx
+++ b/resources/js/visual-editor/blocks/next-post/edit.tsx
@@ -1,0 +1,30 @@
+/**
+ * Next Post — editor-side component (#499).
+ *
+ * Container block: hosts one or more post-* children whose data will be
+ * re-resolved against the next adjacent post in the same post type at
+ * render time. The canvas previews the children against the host post
+ * (or the active query-preview entry, if any) — server-side
+ * `PostResolver` swaps the post context to the resolved adjacent post
+ * before the renderer walks the inner tree.
+ *
+ * No inspector controls of its own — the children carry their own
+ * styling / layout knobs; this block is purely the wrapper that scopes
+ * them to the next post.
+ */
+
+import type { ReactElement } from 'react';
+import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
+
+const TEMPLATE: [string, Record<string, unknown>][] = [
+    ['artisanpack/post-title', {}],
+];
+
+export default function NextPostEdit(): ReactElement {
+    const blockProps = useBlockProps({ className: 'wp-block-artisanpack-next-post navigation-post' });
+    const innerBlocksProps = useInnerBlocksProps(blockProps, {
+        template: TEMPLATE,
+    });
+
+    return <div {...innerBlocksProps} />;
+}

--- a/resources/js/visual-editor/blocks/next-post/index.ts
+++ b/resources/js/visual-editor/blocks/next-post/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Next Post block entrypoint.
+ *
+ * Auto-discovered by `editor/custom-blocks.ts` and registered against
+ * `@wordpress/blocks.registerBlockType`. Wraps inner blocks against the
+ * next adjacent post; the server-side `PostResolver` swaps the post
+ * context to the resolved adjacent post before the renderer walks the
+ * inner tree. (#499)
+ */
+
+import metadata from './block.json';
+import edit from './edit';
+import save from './save';
+
+export { edit, save, metadata };
+
+export default {
+    name: metadata.name,
+    metadata,
+    edit,
+    save,
+};

--- a/resources/js/visual-editor/blocks/next-post/save.tsx
+++ b/resources/js/visual-editor/blocks/next-post/save.tsx
@@ -1,0 +1,12 @@
+/**
+ * Next Post — save component.
+ *
+ * Dynamic block: each renderer reads the persisted inner-block tree
+ * (re-resolved against the adjacent post by `PostResolver`) and emits
+ * the final markup, so returning `null` keeps Gutenberg from
+ * serializing wrapper markup into post_content. (#499)
+ */
+
+export default function NextPostSave(): null {
+    return null;
+}

--- a/resources/js/visual-editor/blocks/post-title/edit.tsx
+++ b/resources/js/visual-editor/blocks/post-title/edit.tsx
@@ -23,7 +23,16 @@
  */
 
 import type { CSSProperties, ReactElement } from 'react';
-import { useBlockProps, PlainText } from '@wordpress/block-editor';
+import {
+    InspectorControls,
+    useBlockProps,
+    PlainText,
+} from '@wordpress/block-editor';
+import {
+    PanelBody,
+    TextControl,
+    ToggleControl,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 import { useEntityProp } from '../../vendor/core-data-shim';
@@ -120,10 +129,57 @@ function tagNameForLevel( level: unknown ): string {
     return 'h2';
 }
 
+interface LinkSettingsProps {
+    readonly attributes: AnyProps;
+    readonly setAttributes: ( next: AnyProps ) => void;
+}
+
+function LinkSettings( { attributes, setAttributes }: LinkSettingsProps ): ReactElement {
+    const isLink = Boolean( attributes.isLink );
+    const linkTarget = typeof attributes.linkTarget === 'string' ? attributes.linkTarget : '_self';
+    const rel = typeof attributes.rel === 'string' ? attributes.rel : '';
+
+    return (
+        <InspectorControls>
+            <PanelBody title={ __( 'Link settings', TEXT_DOMAIN ) } initialOpen={ false }>
+                <ToggleControl
+                    // @ts-expect-error - upstream prop
+                    __nextHasNoMarginBottom
+                    label={ __( 'Make title a link to the post', TEXT_DOMAIN ) }
+                    checked={ isLink }
+                    onChange={ ( value: boolean ) => setAttributes( { isLink: value } ) }
+                />
+                { isLink && (
+                    <>
+                        <ToggleControl
+                            // @ts-expect-error - upstream prop
+                            __nextHasNoMarginBottom
+                            label={ __( 'Open in new tab', TEXT_DOMAIN ) }
+                            checked={ linkTarget === '_blank' }
+                            onChange={ ( value: boolean ) =>
+                                setAttributes( { linkTarget: value ? '_blank' : '_self' } )
+                            }
+                        />
+                        <TextControl
+                            // @ts-expect-error - upstream prop
+                            __next40pxDefaultSize
+                            __nextHasNoMarginBottom
+                            label={ __( 'Link rel', TEXT_DOMAIN ) }
+                            value={ rel }
+                            onChange={ ( value: string ) => setAttributes( { rel: value } ) }
+                        />
+                    </>
+                ) }
+            </PanelBody>
+        </InspectorControls>
+    );
+}
+
 export default function PostTitleEdit( props: AnyProps ): ReactElement {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const blockProps = ( useBlockProps as any )();
     const attributes = props.attributes ?? {};
+    const setAttributes = props.setAttributes ?? ( () => undefined );
     const context = props.context ?? {};
 
     const identity = readPostEntityIdentity( context );
@@ -143,16 +199,30 @@ export default function PostTitleEdit( props: AnyProps ): ReactElement {
         hasLiveEntity ? identity.postId : null,
     );
 
+    const settings = (
+        <LinkSettings attributes={ attributes } setAttributes={ setAttributes } />
+    );
+
     // 1. Stamped `_resolvedTitle` — server-rendered preview.
     const stamped = asString( attributes._resolvedTitle );
     if ( stamped !== '' ) {
-        return <div { ...blockProps }>{ stamped }</div>;
+        return (
+            <>
+                { settings }
+                <div { ...blockProps }>{ stamped }</div>
+            </>
+        );
     }
 
     // 2. Query-loop preview — readonly first-post title.
     const queryPreviewTitle = readQueryPreviewTitle( context );
     if ( queryPreviewTitle !== null ) {
-        return <div { ...blockProps }>{ queryPreviewTitle }</div>;
+        return (
+            <>
+                { settings }
+                <div { ...blockProps }>{ queryPreviewTitle }</div>
+            </>
+        );
     }
 
     // 3. Live entity, not in a query loop — editable inline.
@@ -177,25 +247,33 @@ export default function PostTitleEdit( props: AnyProps ): ReactElement {
             // plain-text only — inline formatting on a `core/post-title`
             // would diverge from the rendered output.
             return (
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                <PlainText
-                    tagName={ TagName as never }
-                    placeholder={ __( '(no title)', TEXT_DOMAIN ) }
-                    value={ titleText }
-                    onChange={ ( next: string ) => setTitle( next ) }
-                    __experimentalVersion={ 2 }
-                    { ...blockProps }
-                />
+                <>
+                    { settings }
+                    {
+                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                        <PlainText
+                            tagName={ TagName as never }
+                            placeholder={ __( '(no title)', TEXT_DOMAIN ) }
+                            value={ titleText }
+                            onChange={ ( next: string ) => setTitle( next ) }
+                            __experimentalVersion={ 2 }
+                            { ...blockProps }
+                        />
+                    }
+                </>
             );
         }
     }
 
     // 4. Placeholder.
     return (
-        <div { ...blockProps }>
-            <span style={ placeholderStyle } contentEditable={ false }>
-                { __( 'Post Title', TEXT_DOMAIN ) }
-            </span>
-        </div>
+        <>
+            { settings }
+            <div { ...blockProps }>
+                <span style={ placeholderStyle } contentEditable={ false }>
+                    { __( 'Post Title', TEXT_DOMAIN ) }
+                </span>
+            </div>
+        </>
     );
 }

--- a/resources/js/visual-editor/blocks/previous-post/block.json
+++ b/resources/js/visual-editor/blocks/previous-post/block.json
@@ -1,0 +1,45 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "artisanpack/previous-post",
+    "title": "Previous Post",
+    "category": "theme",
+    "description": "Wrap inner blocks against the previous post in the same post type so post-* children render the older neighbor's data.",
+    "keywords": ["previous", "post", "navigation", "adjacent"],
+    "textdomain": "artisanpack-visual-editor",
+    "attributes": {
+        "postType": {
+            "type": "string",
+            "default": "post"
+        },
+        "queryId": {
+            "type": "number"
+        },
+        "tagName": {
+            "type": "string",
+            "default": "div"
+        }
+    },
+    "providesContext": {
+        "postType": "postType",
+        "queryId": "queryId"
+    },
+    "supports": {
+        "anchor": true,
+        "align": ["wide", "full"],
+        "html": false,
+        "reusable": false,
+        "color": {
+            "gradients": true,
+            "link": true,
+            "__experimentalDefaultControls": {
+                "background": true,
+                "text": true
+            }
+        },
+        "spacing": {
+            "margin": ["top", "bottom"],
+            "padding": true
+        }
+    }
+}

--- a/resources/js/visual-editor/blocks/previous-post/edit.tsx
+++ b/resources/js/visual-editor/blocks/previous-post/edit.tsx
@@ -1,0 +1,30 @@
+/**
+ * Previous Post — editor-side component (#499).
+ *
+ * Container block: hosts one or more post-* children whose data will be
+ * re-resolved against the previous adjacent post in the same post type
+ * at render time. The canvas previews the children against the host
+ * post (or the active query-preview entry, if any) — server-side
+ * `PostResolver` swaps the post context to the resolved adjacent post
+ * before the renderer walks the inner tree.
+ *
+ * No inspector controls of its own — the children carry their own
+ * styling / layout knobs; this block is purely the wrapper that scopes
+ * them to the previous post.
+ */
+
+import type { ReactElement } from 'react';
+import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
+
+const TEMPLATE: [string, Record<string, unknown>][] = [
+    ['artisanpack/post-title', {}],
+];
+
+export default function PreviousPostEdit(): ReactElement {
+    const blockProps = useBlockProps({ className: 'wp-block-artisanpack-previous-post navigation-post' });
+    const innerBlocksProps = useInnerBlocksProps(blockProps, {
+        template: TEMPLATE,
+    });
+
+    return <div {...innerBlocksProps} />;
+}

--- a/resources/js/visual-editor/blocks/previous-post/index.ts
+++ b/resources/js/visual-editor/blocks/previous-post/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Previous Post block entrypoint.
+ *
+ * Auto-discovered by `editor/custom-blocks.ts` and registered against
+ * `@wordpress/blocks.registerBlockType`. Wraps inner blocks against the
+ * previous adjacent post; the server-side `PostResolver` swaps the post
+ * context to the resolved adjacent post before the renderer walks the
+ * inner tree. (#499)
+ */
+
+import metadata from './block.json';
+import edit from './edit';
+import save from './save';
+
+export { edit, save, metadata };
+
+export default {
+    name: metadata.name,
+    metadata,
+    edit,
+    save,
+};

--- a/resources/js/visual-editor/blocks/previous-post/save.tsx
+++ b/resources/js/visual-editor/blocks/previous-post/save.tsx
@@ -1,0 +1,12 @@
+/**
+ * Previous Post — save component.
+ *
+ * Dynamic block: each renderer reads the persisted inner-block tree
+ * (re-resolved against the adjacent post by `PostResolver`) and emits
+ * the final markup, so returning `null` keeps Gutenberg from
+ * serializing wrapper markup into post_content. (#499)
+ */
+
+export default function PreviousPostSave(): null {
+    return null;
+}

--- a/src/Resources/PostResolver.php
+++ b/src/Resources/PostResolver.php
@@ -92,6 +92,21 @@ class PostResolver
 	];
 
 	/**
+	 * Container blocks that swap the post context of their inner blocks
+	 * to the adjacent post in the same post type (#499). The block
+	 * itself gets a `_resolvedHasAdjacent` flag so the renderer can
+	 * decide whether to emit a wrapper or nothing; the inner tree is
+	 * recursively stamped against the resolved adjacent post so every
+	 * `post-*` child renders the neighbor's data.
+	 *
+	 * @var array<int, string>
+	 */
+	protected const ADJACENT_POST_CONTAINERS = [
+		'artisanpack/next-post'     => 'next',
+		'artisanpack/previous-post' => 'previous',
+	];
+
+	/**
 	 * Recursively walk a block subtree and stamp every supported
 	 * `core/post-*` block against the given post.
 	 *
@@ -130,6 +145,34 @@ class PostResolver
 		$name = isset( $block['name'] ) && is_string( $block['name'] ) ? $block['name'] : '';
 
 		$attributes = isset( $block['attributes'] ) && is_array( $block['attributes'] ) ? $block['attributes'] : [];
+
+		// Adjacent-post container blocks (#499): swap the post context
+		// for the inner tree to the resolved adjacent post so every
+		// `post-*` child renders the neighbor's data. The block itself
+		// gets a `_resolvedHasAdjacent` flag so the renderer can emit a
+		// no-op shell when no neighbor exists.
+		if ( array_key_exists( $name, self::ADJACENT_POST_CONTAINERS ) ) {
+			$direction = self::ADJACENT_POST_CONTAINERS[ $name ];
+			$adjacent  = $this->adjacentPost( $post, $direction );
+
+			$rawInner = isset( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] )
+				? $block['innerBlocks']
+				: [];
+
+			$inner = null === $adjacent
+				? $rawInner
+				: $this->stampTree( $rawInner, $adjacent );
+
+			$attributes = array_merge(
+				[ '_resolvedHasAdjacent' => null !== $adjacent ],
+				$attributes
+			);
+
+			return array_merge( $block, [
+				'attributes'  => $attributes,
+				'innerBlocks' => $inner,
+			] );
+		}
 
 		if ( in_array( $name, self::SUPPORTED_BLOCKS, true ) ) {
 			$attributes = array_merge( $this->resolveAttributesFor( $name, $post ), $attributes );

--- a/tests/Unit/VisualEditor/Resources/PostResolverAdjacentPostContainerTest.php
+++ b/tests/Unit/VisualEditor/Resources/PostResolverAdjacentPostContainerTest.php
@@ -1,0 +1,169 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Resources\PostResolver;
+
+/**
+ * Adjacent-post container family (#499).
+ *
+ * `artisanpack/next-post` and `artisanpack/previous-post` are wrapper
+ * blocks: PostResolver resolves the neighbor in the same post type and
+ * re-stamps the inner-block tree against it so every `post-*` child
+ * renders the adjacent post's data. The wrapper itself only carries a
+ * `_resolvedHasAdjacent` boolean so renderers can collapse to empty
+ * markup when no neighbor exists.
+ */
+
+function adjacencyHostPost(): object
+{
+	$post            = new stdClass();
+	$post->title     = 'Current post';
+	$post->permalink = 'https://example.test/posts/current';
+
+	$post->next_post = (object) [
+		'title'     => 'Next neighbor title',
+		'permalink' => 'https://example.test/posts/next',
+	];
+
+	$post->previous_post = (object) [
+		'title'     => 'Previous neighbor title',
+		'permalink' => 'https://example.test/posts/previous',
+	];
+
+	return $post;
+}
+
+it( 'stamps _resolvedHasAdjacent=true on next-post when the host has a next neighbor', function (): void {
+	$resolved = ( new PostResolver() )->stampBlock(
+		[
+			'name'        => 'artisanpack/next-post',
+			'attributes'  => [],
+			'innerBlocks' => [],
+		],
+		adjacencyHostPost()
+	);
+
+	expect( $resolved['attributes']['_resolvedHasAdjacent'] )->toBeTrue();
+} );
+
+it( 'stamps _resolvedHasAdjacent=true on previous-post when the host has a previous neighbor', function (): void {
+	$resolved = ( new PostResolver() )->stampBlock(
+		[
+			'name'        => 'artisanpack/previous-post',
+			'attributes'  => [],
+			'innerBlocks' => [],
+		],
+		adjacencyHostPost()
+	);
+
+	expect( $resolved['attributes']['_resolvedHasAdjacent'] )->toBeTrue();
+} );
+
+it( 'stamps _resolvedHasAdjacent=false when no neighbor is available in the chosen direction', function ( string $name ): void {
+	$post = new stdClass();
+	$post->title = 'Solo';
+
+	$resolved = ( new PostResolver() )->stampBlock(
+		[ 'name' => $name, 'attributes' => [], 'innerBlocks' => [] ],
+		$post
+	);
+
+	expect( $resolved['attributes']['_resolvedHasAdjacent'] )->toBeFalse();
+} )->with( [
+	'next'     => [ 'artisanpack/next-post' ],
+	'previous' => [ 'artisanpack/previous-post' ],
+] );
+
+it( 'rewrites inner post-title against the adjacent post when a neighbor exists', function (): void {
+	$tree = [
+		[
+			'name'        => 'artisanpack/next-post',
+			'attributes'  => [],
+			'innerBlocks' => [
+				[
+					'name'        => 'artisanpack/post-title',
+					'attributes'  => [],
+					'innerBlocks' => [],
+				],
+			],
+		],
+	];
+
+	$resolved = ( new PostResolver() )->stampTree( $tree, adjacencyHostPost() );
+
+	$titleAttrs = $resolved[0]['innerBlocks'][0]['attributes'];
+
+	expect( $titleAttrs['_resolvedTitle'] )->toBe( 'Next neighbor title' )
+		->and( $titleAttrs['_resolvedPermalink'] )->toBe( 'https://example.test/posts/next' );
+} );
+
+it( 'rewrites inner post-title against the previous post for previous-post wrappers', function (): void {
+	$tree = [
+		[
+			'name'        => 'artisanpack/previous-post',
+			'attributes'  => [],
+			'innerBlocks' => [
+				[
+					'name'        => 'artisanpack/post-title',
+					'attributes'  => [],
+					'innerBlocks' => [],
+				],
+			],
+		],
+	];
+
+	$resolved = ( new PostResolver() )->stampTree( $tree, adjacencyHostPost() );
+
+	$titleAttrs = $resolved[0]['innerBlocks'][0]['attributes'];
+
+	expect( $titleAttrs['_resolvedTitle'] )->toBe( 'Previous neighbor title' )
+		->and( $titleAttrs['_resolvedPermalink'] )->toBe( 'https://example.test/posts/previous' );
+} );
+
+it( 'leaves inner blocks untouched when no neighbor exists so renderers emit empty markup', function (): void {
+	$post = new stdClass();
+	$post->title = 'Solo';
+
+	$tree = [
+		[
+			'name'        => 'artisanpack/next-post',
+			'attributes'  => [],
+			'innerBlocks' => [
+				[
+					'name'        => 'artisanpack/post-title',
+					'attributes'  => [],
+					'innerBlocks' => [],
+				],
+			],
+		],
+	];
+
+	$resolved = ( new PostResolver() )->stampTree( $tree, $post );
+
+	// No stamping happens against the host post itself — the renderer
+	// reads `_resolvedHasAdjacent` and skips emitting markup, so the
+	// inner attributes never reach a partial.
+	$titleAttrs = $resolved[0]['innerBlocks'][0]['attributes'];
+
+	expect( $titleAttrs )->not->toHaveKey( '_resolvedTitle' );
+} );
+
+it( 'lets a pre-existing _resolvedHasAdjacent flag win over the resolver default', function (): void {
+	$post = new stdClass();
+	$post->title = 'Solo';
+
+	$resolved = ( new PostResolver() )->stampBlock(
+		[
+			'name'        => 'artisanpack/next-post',
+			'attributes'  => [ '_resolvedHasAdjacent' => true ],
+			'innerBlocks' => [],
+		],
+		$post
+	);
+
+	// Host-supplied resolved values must always win on merge so hosts
+	// can pre-resolve the envelope upstream (custom Inertia payload,
+	// etc.) without the resolver clobbering it.
+	expect( $resolved['attributes']['_resolvedHasAdjacent'] )->toBeTrue();
+} );


### PR DESCRIPTION
## Description

Adds two adjacent-post container blocks — `artisanpack/next-post` and `artisanpack/previous-post` — that wrap inner `post-*` children against the resolved neighbor in the same post type. `PostResolver` recursively re-stamps the inner-block subtree against the neighbor and sets a `_resolvedHasAdjacent` flag so each renderer can collapse to empty markup when no neighbor exists in the chosen direction.

While exercising the blocks end-to-end, the existing `artisanpack/post-title` block was found to declare `isLink` / `linkTarget` / `rel` attributes (the Blade / React / Vue renderers already honor them) but expose no editor UI to toggle them. Added a "Link settings" Settings sidebar panel on `post-title` so authors can make titles clickable links to the post — which is what makes the new wrappers actually useful as navigation.

**Closes:** #499

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #499

## Motivation and Context

CW3 cluster of the umbrella block port (#495). Single-post navigation cluster: a server-rendered, lean wrapper that re-binds inner-block post context to the adjacent post in the same post type, so authors can compose the navigation card with any `post-*` building blocks (title, date, featured image, excerpt, ...).

## Changes Made

- **Editor blocks** at `resources/js/visual-editor/blocks/{next-post,previous-post}/`: `block.json` (theme category, `artisanpack-visual-editor` textdomain, `providesContext: postType + queryId`, dynamic save), `edit.tsx` (inner-block container via `useInnerBlocksProps`, default template is a single `post-title`), `save.tsx` (returns null), `index.ts`.
- **`PostResolver`** (`src/Resources/PostResolver.php`): new `ADJACENT_POST_CONTAINERS` map. When `stampBlock` encounters one of these wrappers, it resolves the neighbor via the existing `adjacentPost()` helper, recursively stamps the inner subtree against the neighbor, and merges `_resolvedHasAdjacent` onto the wrapper attributes (resolver-supplied default; host-supplied wins on merge).
- **Blade renderers**: `packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/{next-post,previous-post}.blade.php` — emit `<div class="wp-block-artisanpack-{name} navigation-post">{innerBlocksHtml}</div>` when `_resolvedHasAdjacent` is true, nothing otherwise.
- **React renderer**: `packages/visual-editor-renderer-react/src/blocks/artisanpack/postNavigation.tsx` with `NextPostBlock` + `PreviousPostBlock`. Registered in `registerCoreBlocks.ts`.
- **Vue renderer**: `packages/visual-editor-renderer-vue/src/blocks/artisanpack/postNavigation.ts` (mirror of React). Registered in `registerCoreBlocks.ts`.
- **Renderer parity manifest**: `packages/renderer-parity.json` updated; verify:parity reports 137 blocks per renderer.
- **`post-title` editor link panel**: `resources/js/visual-editor/blocks/post-title/edit.tsx` — `LinkSettings` `InspectorControls` panel with `isLink` toggle, "Open in new tab" toggle, and "Link rel" text input. Mounted in every render branch (stamped preview, query-loop preview, live entity, placeholder) so the panel binds regardless of which preview mode the title is in.
- **Test mocks**: `resources/js/visual-editor/blocks/_shared/__tests__/entity-placeholder-{query-preview,live-entity}.test.tsx` — added `InspectorControls` to the `@wordpress/block-editor` mock and a `@wordpress/components` stub (`PanelBody` / `ToggleControl` / `TextControl`) so the new panel renders cleanly inside the existing test environments.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS 14 (darwin 25.5.0)
- Browser (if applicable): Chrome (Laravel Herd, `https://artisanpack-ui-dev.test`)
- PHP Version: 8.4.3
- Project Version: visual-editor v1.0.0-dev (`feature/495-port-crosswinds-blocks`)

**Tests Performed:**
1. Full JS suite: `npm test` — **1947 passed (236 files)**.
2. Full PHP suite: `./vendor/bin/pest --compact` — 1051 passed; the 2 pre-existing `FontAwesomeFreeIconSetsTest` failures are unrelated and reproduce on the base branch.
3. Renderer parity check: `npm run verify:parity` — **OK** (137 blocks each across react / vue / blade).
4. End-to-end dev-app verification via `<x-ve-blocks :tree :post>` — first post emits only the `next-post` wrapper, middle posts emit both, last post emits only the `previous-post` wrapper. `_resolvedHasAdjacent` correctly drives the empty-markup branch when no neighbor exists.
5. CodeRabbit local review against `feature/495-port-crosswinds-blocks` (`cr review --agent`) — **0 findings on the second pass.**

## Accessibility Tests Run

- [x] Keyboard navigation tested (Settings panel toggles + text input)
- [ ] Screen reader tested
- [x] Color contrast verified (no new color choices — inherits theme styles)
- [x] ARIA labels checked (inner `post-*` children carry their own a11y semantics; wrapper is a plain `<div>` so it doesn't hijack the document outline)

**Details:** the wrapper itself is a stateless `<div>`. When no neighbor exists, the wrapper renders nothing — which means assistive tech doesn't see a stranded empty navigation landmark on standalone posts.

## Tests Added

- [x] Unit tests added (PHP + JS)
- [x] Integration tests added (Blade renderer + React BlockTree + Vue BlockTree)
- [x] All tests passing

**Test details:**

- **PostResolver — adjacent-post container behavior** (`tests/Unit/VisualEditor/Resources/PostResolverAdjacentPostContainerTest.php`): 8 tests covering the `_resolvedHasAdjacent` flag in both directions, the inner-tree re-stamp against the neighbor, the no-neighbor fall-through (inner blocks left untouched), and the host-supplied-wins merge contract.
- **Blade renderer** (`packages/visual-editor-renderer-blade/tests/Unit/BlockRendererTest.php`): 4 tests — wrapper + inner content when an adjacent post is resolved; empty markup when not.
- **React renderer** (`packages/visual-editor-renderer-react/tests/BlockTree.test.tsx`): 4 tests mirroring the Blade coverage.
- **Vue renderer** (`packages/visual-editor-renderer-vue/tests/BlockTree.test.ts`): 4 tests mirroring the Blade + React coverage.
- **Block.json + save contract** (`resources/js/visual-editor/blocks/__tests__/adjacent-post-container-family.test.ts`): 8 tests parametrized across both blocks — namespace / textdomain / category / providesContext / default postType / dynamic-null-save.

## Documentation

- [x] Inline code documentation added (file headers + comments wherever the why isn't obvious from the code)
- [ ] README updated
- [ ] Wiki updated
- [ ] API documentation updated

**Documentation details:** block-level docblocks on the two new editor blocks, both new renderer files, and the new PostResolver branch explain *why* the wrapper exists and how the resolver / renderer split owns its piece of the contract.

## Screenshots

_None — server-side renderer + Inspector panel toggle; the visual behavior is "title becomes a link" / "navigation card disappears at boundaries", best verified by exercising the dev-app preview at `?stack=livewire&post={1..6}`._

## Pre-Submission Checklist

Before requesting review, confirm:

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted (`vitest`-level type errors caught + fixed; no Pint/PHPCS in this package's `vendor/bin/`)
- [x] Accessibility tests completed
- [x] Code follows project style guide (matches `breadcrumbs` / `accordion` / `grid` port conventions; first-party `artisanpack/*` naming per `CLAUDE.md`)
- [x] Self-review completed
- [x] Comments added for complex code (resolver branch + renderer wrapper rationale)
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Next Post" and "Previous Post" navigation blocks to display adjacent posts in your sequence
  * Blocks automatically hide when no adjacent post is available, keeping your layout clean
  * Added link configuration options for post titles (target page, new tab behavior, link relation)

* **Tests**
  * Added comprehensive test coverage for new navigation blocks and their conditional rendering behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->