### PR TITLE
feat: artisanpack/copyright + marquee + comments-number site-chrome blocks

### DIFF
--- a/packages/renderer-parity.json
+++ b/packages/renderer-parity.json
@@ -138,6 +138,9 @@
         "artisanpack/grid",
         "artisanpack/grid-item",
         "artisanpack/next-post",
-        "artisanpack/previous-post"
+        "artisanpack/previous-post",
+        "artisanpack/copyright",
+        "artisanpack/marquee",
+        "artisanpack/comments-number"
     ]
 }

--- a/packages/visual-editor-renderer-blade/resources/assets/frontend/marquee.css
+++ b/packages/visual-editor-renderer-blade/resources/assets/frontend/marquee.css
@@ -32,3 +32,16 @@
         transform: translateX(-100%);
     }
 }
+
+/* Respect prefers-reduced-motion. Visitors who've opted out of
+   animations get the text pinned in place inside the wrapper instead
+   of an endless horizontal scroll — the inline `animation` declaration
+   on `.ap-marquee__text` is overridden and the base
+   `translateX(100%)` (which hides the text off-screen) is reset. */
+@media (prefers-reduced-motion: reduce) {
+    .ap-marquee__text {
+        animation: none !important;
+        transform: none;
+        white-space: normal;
+    }
+}

--- a/packages/visual-editor-renderer-blade/resources/assets/frontend/marquee.css
+++ b/packages/visual-editor-renderer-blade/resources/assets/frontend/marquee.css
@@ -1,0 +1,34 @@
+/**
+ * Front-end styles for the marquee block (artisanpack/marquee — #500).
+ *
+ * Mirrors the editor preview styles in
+ * `resources/js/visual-editor/blocks/marquee/marquee.css`. Host apps
+ * load this stylesheet on any page that renders a marquee block — the
+ * `<x-ve-blocks-styles />` component emits the `<link>`.
+ *
+ * The block's `marqueeSpeed` attribute lands as an inline
+ * `animation: ap-marquee-scroll Ns linear infinite` on the inner `<p>`,
+ * so the keyframe definition here is all the frontend needs.
+ */
+
+.ap-marquee {
+    margin-left: auto;
+    margin-right: auto;
+    overflow: hidden;
+}
+
+.ap-marquee__text {
+    margin: 0;
+    transform: translateX(100%);
+    white-space: nowrap;
+    will-change: transform;
+}
+
+@keyframes ap-marquee-scroll {
+    from {
+        transform: translateX(100%);
+    }
+    to {
+        transform: translateX(-100%);
+    }
+}

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/comments-number.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/comments-number.blade.php
@@ -1,0 +1,19 @@
+@php
+	use ArtisanPackUI\VisualEditorRendererBlade\Support\BlockSupports;
+
+	$rawCount = $attributes['_resolvedCommentCount'] ?? 0;
+	$count    = is_numeric( $rawCount ) ? (int) $rawCount : 0;
+
+	if ( $count < 0 ) {
+		$count = 0;
+	}
+
+	$singular = (string) ( $attributes['singularCommentText'] ?? 'Comment' );
+	$plural   = (string) ( $attributes['pluralCommentText'] ?? 'Comments' );
+	$label    = 1 === $count ? $singular : $plural;
+
+	$line = trim( $count . ' ' . $label );
+
+	$baseClasses = [ 'ap-comments-number' ];
+@endphp
+<p{!! BlockSupports::wrapperAttrs( $attributes, $baseClasses ) !!}>{{ $line }}</p>

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/copyright.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/copyright.blade.php
@@ -1,0 +1,28 @@
+@php
+	use ArtisanPackUI\VisualEditorRendererBlade\Support\BlockSupports;
+
+	$validTypes = [ 'icon-text', 'icon-only', 'text-only' ];
+
+	$copyrightType = (string) ( $attributes['copyrightType'] ?? 'icon-text' );
+
+	if ( ! in_array( $copyrightType, $validTypes, true ) ) {
+		$copyrightType = 'icon-text';
+	}
+
+	$copyrightText = trim( (string) ( $attributes['copyrightText'] ?? 'Copyright' ) );
+
+	$currentYear = gmdate( 'Y' );
+
+	if ( 'icon-only' === $copyrightType ) {
+		$line = '© ' . $currentYear;
+	} elseif ( 'text-only' === $copyrightType ) {
+		$line = '' === $copyrightText ? $currentYear : $copyrightText . ' ' . $currentYear;
+	} else {
+		$line = '' === $copyrightText
+			? '© ' . $currentYear
+			: '© ' . $copyrightText . ' ' . $currentYear;
+	}
+
+	$baseClasses = [ 'ap-copyright' ];
+@endphp
+<p{!! BlockSupports::wrapperAttrs( $attributes, $baseClasses ) !!}>{{ $line }}</p>

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/marquee.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/marquee.blade.php
@@ -1,0 +1,33 @@
+@php
+	use ArtisanPackUI\VisualEditorRendererBlade\Support\BlockSupports;
+
+	$rawWidth = $attributes['marqueeWidth'] ?? 100;
+	$width    = is_numeric( $rawWidth ) ? (int) round( (float) $rawWidth ) : 100;
+	$width    = max( 1, min( 100, $width ) );
+
+	$rawSpeed = $attributes['marqueeSpeed'] ?? 5;
+	$speed    = is_numeric( $rawSpeed ) ? (int) round( (float) $rawSpeed ) : 5;
+	$speed    = max( 1, min( 100, $speed ) );
+
+	$content = (string) ( $attributes['marqueeContent'] ?? '' );
+
+	$baseClasses = [ 'ap-marquee' ];
+
+	// The wrapper width is a per-instance inline declaration that has
+	// to live alongside any block-supports style (background, padding,
+	// border) on the same `style="…"` attribute — emit them as one
+	// declaration so a second `style="…"` doesn't override the first.
+	$compiled = BlockSupports::compile( $attributes );
+	$classes  = array_values( array_unique( array_merge( $baseClasses, $compiled['classes'] ) ) );
+	$styles   = '' !== $compiled['style'] ? rtrim( $compiled['style'], ';' ) : '';
+	$styles   = ( '' !== $styles ? $styles . '; ' : '' ) . 'width: ' . $width . '%';
+
+	$classAttr = sprintf( ' class="%s"', e( implode( ' ', $classes ) ) );
+	$styleAttr = sprintf( ' style="%s"', e( $styles . ';' ) );
+	$idAttr    = null !== $compiled['id'] ? sprintf( ' id="%s"', e( $compiled['id'] ) ) : '';
+
+	$textStyle = 'animation: ap-marquee-scroll ' . $speed . 's linear infinite;';
+@endphp
+<div{!! $classAttr . $styleAttr . $idAttr !!}>
+	<p class="ap-marquee__text" style="{{ $textStyle }}">{!! $content !!}</p>
+</div>

--- a/packages/visual-editor-renderer-blade/resources/views/components/blocks-styles.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/components/blocks-styles.blade.php
@@ -11,6 +11,9 @@
 	loads independently of $emitInteractive. Hosts that opt out of
 	accordion/tabs interactivity still want grid blocks to render. --}}
 <link rel="stylesheet" href="{{ $gridStyleHref }}" data-ve-grid>
+{{-- Marquee CSS ships the keyframes the inline `animation` declaration
+	on the inner `<p>` references. Layout-only, same story as grid. --}}
+<link rel="stylesheet" href="{{ $marqueeStyleHref }}" data-ve-marquee>
 @if( '' !== $themeTokensCss )
 <style data-ve-theme-tokens>{!! $themeTokensCss !!}</style>
 @endif

--- a/packages/visual-editor-renderer-blade/src/View/Components/BlocksStylesComponent.php
+++ b/packages/visual-editor-renderer-blade/src/View/Components/BlocksStylesComponent.php
@@ -63,6 +63,8 @@ class BlocksStylesComponent extends Component
 
 	public string $gridStyleHref;
 
+	public string $marqueeStyleHref;
+
 	public string $interactivityScriptSrc;
 
 	public bool $emitBlockLibrary;
@@ -96,6 +98,7 @@ class BlocksStylesComponent extends Component
 		$this->accordionStyleHref     = $base . '/frontend/accordion.css';
 		$this->tabsStyleHref          = $base . '/frontend/tabs.css';
 		$this->gridStyleHref          = $base . '/frontend/grid.css';
+		$this->marqueeStyleHref       = $base . '/frontend/marquee.css';
 		$this->interactivityScriptSrc = $base . '/frontend/interactivity.js';
 		$this->emitBlockLibrary       = $bundle;
 		$this->emitInteractive        = $interactive;

--- a/packages/visual-editor-renderer-blade/tests/Feature/BlocksStylesComponentTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Feature/BlocksStylesComponentTest.php
@@ -21,6 +21,18 @@ it( 'omits the block-library links when bundle is false', function () {
 		->not->toContain( 'data-ve-block-library' );
 } );
 
+it( 'emits the grid + marquee frontend stylesheet links independently of $emitInteractive', function () {
+	$rendered = Blade::render( '<x-ve-blocks-styles :interactive="false" />' );
+
+	expect( $rendered )
+		->toContain( '/vendor/visual-editor-renderer-blade/frontend/grid.css' )
+		->toContain( 'data-ve-grid' )
+		->toContain( '/vendor/visual-editor-renderer-blade/frontend/marquee.css' )
+		->toContain( 'data-ve-marquee' )
+		->not->toContain( 'data-ve-accordion' )
+		->not->toContain( 'data-ve-tabs' );
+} );
+
 it( 'rebases the link href when assetBase is supplied', function () {
 	$rendered = Blade::render(
 		'<x-ve-blocks-styles asset-base="https://cdn.example.com/ve" />'

--- a/packages/visual-editor-renderer-blade/tests/Unit/BlockRendererTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Unit/BlockRendererTest.php
@@ -609,6 +609,132 @@ it( 'renders an empty list when breadcrumbs trail is missing', function () {
 		->and( $html )->not->toContain( '<li class="ap-breadcrumbs__item' );
 } );
 
+it( 'renders the artisanpack/copyright block with the © + text + current year (icon-text default)', function () {
+	$tree = [
+		makeBlock( 'artisanpack/copyright', [
+			'copyrightType' => 'icon-text',
+			'copyrightText' => 'Acme, Inc.',
+		] ),
+	];
+
+	$year = gmdate( 'Y' );
+	$html = makeRenderer()->render( $tree );
+
+	expect( $html )->toContain( 'class="ap-copyright"' )
+		->and( $html )->toContain( '© Acme, Inc. ' . $year )
+		->and( $html )->toContain( '<p' );
+} );
+
+it( 'omits the text when copyright type is icon-only and drops the icon when text-only', function () {
+	$iconOnly = makeRenderer()->render( [
+		makeBlock( 'artisanpack/copyright', [
+			'copyrightType' => 'icon-only',
+			'copyrightText' => 'Should not appear',
+		] ),
+	] );
+
+	$textOnly = makeRenderer()->render( [
+		makeBlock( 'artisanpack/copyright', [
+			'copyrightType' => 'text-only',
+			'copyrightText' => 'Plain',
+		] ),
+	] );
+
+	$year = gmdate( 'Y' );
+
+	expect( $iconOnly )->toContain( '© ' . $year )
+		->and( $iconOnly )->not->toContain( 'Should not appear' )
+		->and( $textOnly )->toContain( 'Plain ' . $year )
+		->and( $textOnly )->not->toContain( '©' );
+} );
+
+it( 'falls back to icon-text when copyright type is invalid', function () {
+	$tree = [
+		makeBlock( 'artisanpack/copyright', [
+			'copyrightType' => 'made-up-mode',
+			'copyrightText' => 'Fallback',
+		] ),
+	];
+
+	$year = gmdate( 'Y' );
+	$html = makeRenderer()->render( $tree );
+
+	expect( $html )->toContain( '© Fallback ' . $year );
+} );
+
+it( 'renders the artisanpack/marquee block with width + animation styles applied', function () {
+	$tree = [
+		makeBlock( 'artisanpack/marquee', [
+			'marqueeContent' => 'Breaking news',
+			'marqueeWidth'   => 60,
+			'marqueeSpeed'   => 10,
+		] ),
+	];
+
+	$html = makeRenderer()->render( $tree );
+
+	expect( $html )->toContain( 'class="ap-marquee"' )
+		->and( $html )->toContain( 'width: 60%' )
+		->and( $html )->toContain( 'animation: ap-marquee-scroll 10s linear infinite' )
+		->and( $html )->toContain( 'class="ap-marquee__text"' )
+		->and( $html )->toContain( 'Breaking news' );
+} );
+
+it( 'clamps marquee width and speed to their valid range and falls back on non-numeric input', function () {
+	$tree = [
+		makeBlock( 'artisanpack/marquee', [
+			'marqueeContent' => 'x',
+			'marqueeWidth'   => 999,
+			'marqueeSpeed'   => 'fast',
+		] ),
+	];
+
+	$html = makeRenderer()->render( $tree );
+
+	expect( $html )->toContain( 'width: 100%' )
+		->and( $html )->toContain( 'animation: ap-marquee-scroll 5s linear infinite' );
+} );
+
+it( 'renders the artisanpack/comments-number block with the resolved count and plural label', function () {
+	$tree = [
+		makeBlock( 'artisanpack/comments-number', [
+			'_resolvedCommentCount' => 5,
+			'singularCommentText'   => 'Reply',
+			'pluralCommentText'     => 'Replies',
+		] ),
+	];
+
+	$html = makeRenderer()->render( $tree );
+
+	expect( $html )->toContain( 'class="ap-comments-number"' )
+		->and( $html )->toContain( '5 Replies' )
+		->and( $html )->not->toContain( 'Reply<' );
+} );
+
+it( 'uses the singular comments-number label when the resolved count is exactly one', function () {
+	$tree = [
+		makeBlock( 'artisanpack/comments-number', [
+			'_resolvedCommentCount' => 1,
+			'singularCommentText'   => 'Reply',
+			'pluralCommentText'     => 'Replies',
+		] ),
+	];
+
+	$html = makeRenderer()->render( $tree );
+
+	expect( $html )->toContain( '1 Reply' );
+} );
+
+it( 'falls back to zero comments and default labels when the resolved count is missing', function () {
+	$tree = [
+		makeBlock( 'artisanpack/comments-number', [] ),
+	];
+
+	$html = makeRenderer()->render( $tree );
+
+	expect( $html )->toContain( '0 Comments' );
+} );
+
 it( 'renders an artisanpack/accordions tree with its nested panel + title/body grandchildren', function () {
 	$tree = [
 		makeBlock( 'artisanpack/accordions', [], [

--- a/packages/visual-editor-renderer-react/src/blocks/artisanpack/commentsNumber.tsx
+++ b/packages/visual-editor-renderer-react/src/blocks/artisanpack/commentsNumber.tsx
@@ -1,0 +1,28 @@
+/**
+ * React renderer for the `artisanpack/comments-number` block (#500).
+ *
+ * Mirrors the Blade partial and the Vue renderer so every environment
+ * emits identical markup. The count is server-resolved (PostResolver
+ * stamps `_resolvedCommentCount`) and combined with the saved
+ * singular / plural labels at render time.
+ */
+
+import type { JSX } from 'react';
+
+import { attrInt, attrString, classList } from '../../support/attributes';
+import type { BlockRendererProps } from '../../types';
+
+export function CommentsNumberBlock({
+    attributes,
+}: BlockRendererProps): JSX.Element {
+    const count = Math.max(0, attrInt(attributes._resolvedCommentCount, 0));
+    const singular = attrString(attributes.singularCommentText, 'Comment');
+    const plural = attrString(attributes.pluralCommentText, 'Comments');
+    const label = count === 1 ? singular : plural;
+    const className = attrString(attributes.className);
+
+    const classes = classList(['ap-comments-number', className]);
+    const line = `${count} ${label}`.trim();
+
+    return <p className={classes}>{line}</p>;
+}

--- a/packages/visual-editor-renderer-react/src/blocks/artisanpack/copyright.tsx
+++ b/packages/visual-editor-renderer-react/src/blocks/artisanpack/copyright.tsx
@@ -1,0 +1,52 @@
+/**
+ * React renderer for the `artisanpack/copyright` block (#500).
+ *
+ * Mirrors the Blade partial at
+ * `packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/copyright.blade.php`
+ * and the Vue renderer so every environment emits identical markup. The
+ * current year is read at render time (not stamped server-side) so the
+ * line stays accurate whenever the page is rendered.
+ */
+
+import type { JSX } from 'react';
+
+import { attrString, classList } from '../../support/attributes';
+import type { BlockRendererProps } from '../../types';
+
+type CopyrightType = 'icon-text' | 'icon-only' | 'text-only';
+
+const VALID_TYPES: ReadonlyArray<CopyrightType> = [
+    'icon-text',
+    'icon-only',
+    'text-only',
+];
+
+function normalizeType(value: unknown): CopyrightType {
+    const raw = attrString(value, 'icon-text');
+    return (VALID_TYPES as ReadonlyArray<string>).includes(raw)
+        ? (raw as CopyrightType)
+        : 'icon-text';
+}
+
+function buildLine(type: CopyrightType, text: string, year: number): string {
+    const trimmed = text.trim();
+    if (type === 'icon-only') {
+        return `© ${year}`;
+    }
+    if (type === 'text-only') {
+        return trimmed === '' ? `${year}` : `${trimmed} ${year}`;
+    }
+    return trimmed === '' ? `© ${year}` : `© ${trimmed} ${year}`;
+}
+
+export function CopyrightBlock({ attributes }: BlockRendererProps): JSX.Element {
+    const copyrightType = normalizeType(attributes.copyrightType);
+    const copyrightText = attrString(attributes.copyrightText, 'Copyright');
+    const className = attrString(attributes.className);
+
+    const classes = classList(['ap-copyright', className]);
+    const year = new Date().getUTCFullYear();
+    const line = buildLine(copyrightType, copyrightText, year);
+
+    return <p className={classes}>{line}</p>;
+}

--- a/packages/visual-editor-renderer-react/src/blocks/artisanpack/marquee.tsx
+++ b/packages/visual-editor-renderer-react/src/blocks/artisanpack/marquee.tsx
@@ -1,0 +1,43 @@
+/**
+ * React renderer for the `artisanpack/marquee` block (#500).
+ *
+ * Mirrors the Blade partial and the Vue renderer so every environment
+ * emits identical markup. The animation runs from a shared
+ * `ap-marquee-scroll` keyframe — host apps are responsible for
+ * shipping the matching `.ap-marquee` stylesheet on the frontend.
+ */
+
+import type { CSSProperties, JSX } from 'react';
+
+import { attrFloat, attrString, classList } from '../../support/attributes';
+import type { BlockRendererProps } from '../../types';
+
+function clampInt(value: number, min: number, max: number, fallback: number): number {
+    if (!Number.isFinite(value)) {
+        return fallback;
+    }
+    return Math.min(max, Math.max(min, Math.round(value)));
+}
+
+export function MarqueeBlock({ attributes }: BlockRendererProps): JSX.Element {
+    const width = clampInt(attrFloat(attributes.marqueeWidth, 100), 1, 100, 100);
+    const speed = clampInt(attrFloat(attributes.marqueeSpeed, 5), 1, 100, 5);
+    const content = attrString(attributes.marqueeContent);
+    const className = attrString(attributes.className);
+
+    const classes = classList(['ap-marquee', className]);
+    const wrapperStyle: CSSProperties = { width: `${width}%` };
+    const textStyle: CSSProperties = {
+        animation: `ap-marquee-scroll ${speed}s linear infinite`,
+    };
+
+    return (
+        <div className={classes} style={wrapperStyle}>
+            <p
+                className="ap-marquee__text"
+                style={textStyle}
+                dangerouslySetInnerHTML={{ __html: content }}
+            />
+        </div>
+    );
+}

--- a/packages/visual-editor-renderer-react/src/blocks/registerCoreBlocks.ts
+++ b/packages/visual-editor-renderer-react/src/blocks/registerCoreBlocks.ts
@@ -20,7 +20,10 @@ import {
 } from './artisanpack/accordion';
 import { BreadcrumbsBlock } from './artisanpack/breadcrumbs';
 import { CalloutBlock } from './artisanpack/callout';
+import { CommentsNumberBlock } from './artisanpack/commentsNumber';
+import { CopyrightBlock } from './artisanpack/copyright';
 import { GridBlock, GridItemBlock } from './artisanpack/grid';
+import { MarqueeBlock } from './artisanpack/marquee';
 import { TabSectionBlock, TabsBlock } from './artisanpack/tabs';
 import { LoginoutBlock } from './artisanpack/loginout';
 import {
@@ -287,6 +290,13 @@ const CORE_BLOCKS: Record<string, BlockRenderer> = {
     // only; loginout never shipped as `core/*` in v1 so there is no
     // core counterpart to mirror here.
     'artisanpack/loginout': LoginoutBlock,
+    // Site-chrome cluster (#500) — registered under the artisanpack/*
+    // namespace only. These three blocks (copyright + marquee +
+    // comments-number) never shipped as `core/*` in v1 so there are
+    // no core counterparts to mirror here.
+    'artisanpack/copyright': CopyrightBlock,
+    'artisanpack/marquee': MarqueeBlock,
+    'artisanpack/comments-number': CommentsNumberBlock,
 };
 
 export function registerCoreBlocks(): void {

--- a/packages/visual-editor-renderer-react/tests/BlockTree.test.tsx
+++ b/packages/visual-editor-renderer-react/tests/BlockTree.test.tsx
@@ -1,5 +1,5 @@
 import { render, waitFor } from '@testing-library/react';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import '../src/index';
 import { BlockTree } from '../src/BlockTree';
@@ -693,52 +693,67 @@ describe('Core design blocks', () => {
         expect(html).not.toContain('<li class="ap-breadcrumbs__item');
     });
 
-    it('renders the artisanpack/copyright block with © text and the current year', () => {
-        const tree = [
-            makeBlock('artisanpack/copyright', {
-                copyrightType: 'icon-text',
-                copyrightText: 'Acme, Inc.',
-            }),
-        ];
+    describe('artisanpack/copyright (year is read at render time)', () => {
+        // Pin the clock so these specs don't drift on the Dec 31 → Jan 1
+        // boundary; the renderer reads `new Date().getUTCFullYear()` so
+        // any test that hard-codes a year would otherwise need a real
+        // calendar to stay accurate.
+        const PINNED_YEAR = 2030;
+        const PINNED_DATE = new Date(Date.UTC(PINNED_YEAR, 5, 15));
 
-        const year = new Date().getUTCFullYear();
-        const html = renderTree(tree);
+        beforeEach(() => {
+            vi.useFakeTimers();
+            vi.setSystemTime(PINNED_DATE);
+        });
 
-        expect(html).toContain('class="ap-copyright"');
-        expect(html).toContain(`© Acme, Inc. ${year}`);
-    });
+        afterEach(() => {
+            vi.useRealTimers();
+        });
 
-    it('omits the text when copyright type is icon-only and drops the © when text-only', () => {
-        const iconOnly = renderTree([
-            makeBlock('artisanpack/copyright', {
-                copyrightType: 'icon-only',
-                copyrightText: 'Should not appear',
-            }),
-        ]);
-        const textOnly = renderTree([
-            makeBlock('artisanpack/copyright', {
-                copyrightType: 'text-only',
-                copyrightText: 'Plain',
-            }),
-        ]);
-        const year = new Date().getUTCFullYear();
+        it('renders the artisanpack/copyright block with © text and the current year', () => {
+            const tree = [
+                makeBlock('artisanpack/copyright', {
+                    copyrightType: 'icon-text',
+                    copyrightText: 'Acme, Inc.',
+                }),
+            ];
 
-        expect(iconOnly).toContain(`© ${year}`);
-        expect(iconOnly).not.toContain('Should not appear');
-        expect(textOnly).toContain(`Plain ${year}`);
-        expect(textOnly).not.toContain('©');
-    });
+            const html = renderTree(tree);
 
-    it('falls back to icon-text when copyright type is invalid', () => {
-        const html = renderTree([
-            makeBlock('artisanpack/copyright', {
-                copyrightType: 'made-up-mode',
-                copyrightText: 'Fallback',
-            }),
-        ]);
-        const year = new Date().getUTCFullYear();
+            expect(html).toContain('class="ap-copyright"');
+            expect(html).toContain(`© Acme, Inc. ${PINNED_YEAR}`);
+        });
 
-        expect(html).toContain(`© Fallback ${year}`);
+        it('omits the text when copyright type is icon-only and drops the © when text-only', () => {
+            const iconOnly = renderTree([
+                makeBlock('artisanpack/copyright', {
+                    copyrightType: 'icon-only',
+                    copyrightText: 'Should not appear',
+                }),
+            ]);
+            const textOnly = renderTree([
+                makeBlock('artisanpack/copyright', {
+                    copyrightType: 'text-only',
+                    copyrightText: 'Plain',
+                }),
+            ]);
+
+            expect(iconOnly).toContain(`© ${PINNED_YEAR}`);
+            expect(iconOnly).not.toContain('Should not appear');
+            expect(textOnly).toContain(`Plain ${PINNED_YEAR}`);
+            expect(textOnly).not.toContain('©');
+        });
+
+        it('falls back to icon-text when copyright type is invalid', () => {
+            const html = renderTree([
+                makeBlock('artisanpack/copyright', {
+                    copyrightType: 'made-up-mode',
+                    copyrightText: 'Fallback',
+                }),
+            ]);
+
+            expect(html).toContain(`© Fallback ${PINNED_YEAR}`);
+        });
     });
 
     it('renders the artisanpack/marquee block with width + animation styles applied', () => {

--- a/packages/visual-editor-renderer-react/tests/BlockTree.test.tsx
+++ b/packages/visual-editor-renderer-react/tests/BlockTree.test.tsx
@@ -693,6 +693,117 @@ describe('Core design blocks', () => {
         expect(html).not.toContain('<li class="ap-breadcrumbs__item');
     });
 
+    it('renders the artisanpack/copyright block with © text and the current year', () => {
+        const tree = [
+            makeBlock('artisanpack/copyright', {
+                copyrightType: 'icon-text',
+                copyrightText: 'Acme, Inc.',
+            }),
+        ];
+
+        const year = new Date().getUTCFullYear();
+        const html = renderTree(tree);
+
+        expect(html).toContain('class="ap-copyright"');
+        expect(html).toContain(`© Acme, Inc. ${year}`);
+    });
+
+    it('omits the text when copyright type is icon-only and drops the © when text-only', () => {
+        const iconOnly = renderTree([
+            makeBlock('artisanpack/copyright', {
+                copyrightType: 'icon-only',
+                copyrightText: 'Should not appear',
+            }),
+        ]);
+        const textOnly = renderTree([
+            makeBlock('artisanpack/copyright', {
+                copyrightType: 'text-only',
+                copyrightText: 'Plain',
+            }),
+        ]);
+        const year = new Date().getUTCFullYear();
+
+        expect(iconOnly).toContain(`© ${year}`);
+        expect(iconOnly).not.toContain('Should not appear');
+        expect(textOnly).toContain(`Plain ${year}`);
+        expect(textOnly).not.toContain('©');
+    });
+
+    it('falls back to icon-text when copyright type is invalid', () => {
+        const html = renderTree([
+            makeBlock('artisanpack/copyright', {
+                copyrightType: 'made-up-mode',
+                copyrightText: 'Fallback',
+            }),
+        ]);
+        const year = new Date().getUTCFullYear();
+
+        expect(html).toContain(`© Fallback ${year}`);
+    });
+
+    it('renders the artisanpack/marquee block with width + animation styles applied', () => {
+        const tree = [
+            makeBlock('artisanpack/marquee', {
+                marqueeContent: 'Breaking news',
+                marqueeWidth: 60,
+                marqueeSpeed: 10,
+            }),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('class="ap-marquee"');
+        expect(html).toContain('width: 60%');
+        expect(html).toContain('animation: ap-marquee-scroll 10s linear infinite');
+        expect(html).toContain('class="ap-marquee__text"');
+        expect(html).toContain('Breaking news');
+    });
+
+    it('clamps marquee width and speed to their valid range and falls back on non-numeric input', () => {
+        const html = renderTree([
+            makeBlock('artisanpack/marquee', {
+                marqueeContent: 'x',
+                marqueeWidth: 999,
+                marqueeSpeed: 'fast',
+            }),
+        ]);
+
+        expect(html).toContain('width: 100%');
+        expect(html).toContain('animation: ap-marquee-scroll 5s linear infinite');
+    });
+
+    it('renders the artisanpack/comments-number block with resolved count + plural label', () => {
+        const html = renderTree([
+            makeBlock('artisanpack/comments-number', {
+                _resolvedCommentCount: 5,
+                singularCommentText: 'Reply',
+                pluralCommentText: 'Replies',
+            }),
+        ]);
+
+        expect(html).toContain('class="ap-comments-number"');
+        expect(html).toContain('5 Replies');
+        expect(html).not.toContain('Reply<');
+    });
+
+    it('uses the singular comments-number label when the resolved count is exactly one', () => {
+        const html = renderTree([
+            makeBlock('artisanpack/comments-number', {
+                _resolvedCommentCount: 1,
+                singularCommentText: 'Reply',
+                pluralCommentText: 'Replies',
+            }),
+        ]);
+
+        expect(html).toContain('1 Reply');
+    });
+
+    it('falls back to zero comments and default labels when the resolved count is missing', () => {
+        const html = renderTree([makeBlock('artisanpack/comments-number', {})]);
+
+        expect(html).toContain('0 Comments');
+    });
+
     it('renders the artisanpack/accordions family with nested grandchildren', () => {
         const tree = [
             makeBlock('artisanpack/accordions', {}, [

--- a/packages/visual-editor-renderer-vue/src/blocks/artisanpack/commentsNumber.ts
+++ b/packages/visual-editor-renderer-vue/src/blocks/artisanpack/commentsNumber.ts
@@ -1,0 +1,33 @@
+/**
+ * Vue renderer for the `artisanpack/comments-number` block (#500).
+ *
+ * Mirrors the Blade partial and the React renderer so every
+ * environment emits identical markup.
+ */
+
+import { defineComponent, h } from 'vue';
+
+import { attrInt, attrString, classList } from '../../support/attributes';
+import { blockRendererProps } from '../shared';
+
+export const CommentsNumberBlock = defineComponent({
+    name: 'CommentsNumberBlock',
+    props: blockRendererProps,
+    setup(props) {
+        return () => {
+            const count = Math.max(
+                0,
+                attrInt(props.attributes._resolvedCommentCount, 0)
+            );
+            const singular = attrString(props.attributes.singularCommentText, 'Comment');
+            const plural = attrString(props.attributes.pluralCommentText, 'Comments');
+            const label = count === 1 ? singular : plural;
+            const className = attrString(props.attributes.className);
+
+            const classes = classList(['ap-comments-number', className]);
+            const line = `${count} ${label}`.trim();
+
+            return h('p', { class: classes }, line);
+        };
+    },
+});

--- a/packages/visual-editor-renderer-vue/src/blocks/artisanpack/copyright.ts
+++ b/packages/visual-editor-renderer-vue/src/blocks/artisanpack/copyright.ts
@@ -1,0 +1,56 @@
+/**
+ * Vue renderer for the `artisanpack/copyright` block (#500).
+ *
+ * Mirrors the Blade partial and the React renderer so every environment
+ * emits identical markup. The current year is read at render time (not
+ * stamped server-side) so the line stays accurate.
+ */
+
+import { defineComponent, h } from 'vue';
+
+import { attrString, classList } from '../../support/attributes';
+import { blockRendererProps } from '../shared';
+
+type CopyrightType = 'icon-text' | 'icon-only' | 'text-only';
+
+const VALID_TYPES: ReadonlyArray<CopyrightType> = [
+    'icon-text',
+    'icon-only',
+    'text-only',
+];
+
+function normalizeType(value: unknown): CopyrightType {
+    const raw = attrString(value, 'icon-text');
+    return (VALID_TYPES as ReadonlyArray<string>).includes(raw)
+        ? (raw as CopyrightType)
+        : 'icon-text';
+}
+
+function buildLine(type: CopyrightType, text: string, year: number): string {
+    const trimmed = text.trim();
+    if (type === 'icon-only') {
+        return `© ${year}`;
+    }
+    if (type === 'text-only') {
+        return trimmed === '' ? `${year}` : `${trimmed} ${year}`;
+    }
+    return trimmed === '' ? `© ${year}` : `© ${trimmed} ${year}`;
+}
+
+export const CopyrightBlock = defineComponent({
+    name: 'CopyrightBlock',
+    props: blockRendererProps,
+    setup(props) {
+        return () => {
+            const copyrightType = normalizeType(props.attributes.copyrightType);
+            const copyrightText = attrString(props.attributes.copyrightText, 'Copyright');
+            const className = attrString(props.attributes.className);
+
+            const classes = classList(['ap-copyright', className]);
+            const year = new Date().getUTCFullYear();
+            const line = buildLine(copyrightType, copyrightText, year);
+
+            return h('p', { class: classes }, line);
+        };
+    },
+});

--- a/packages/visual-editor-renderer-vue/src/blocks/artisanpack/marquee.ts
+++ b/packages/visual-editor-renderer-vue/src/blocks/artisanpack/marquee.ts
@@ -1,0 +1,55 @@
+/**
+ * Vue renderer for the `artisanpack/marquee` block (#500).
+ *
+ * Mirrors the Blade partial and the React renderer so every
+ * environment emits identical markup.
+ */
+
+import { defineComponent, h } from 'vue';
+
+import { attrFloat, attrString, classList } from '../../support/attributes';
+import { blockRendererProps } from '../shared';
+
+function clampInt(value: number, min: number, max: number, fallback: number): number {
+    if (!Number.isFinite(value)) {
+        return fallback;
+    }
+    return Math.min(max, Math.max(min, Math.round(value)));
+}
+
+export const MarqueeBlock = defineComponent({
+    name: 'MarqueeBlock',
+    props: blockRendererProps,
+    setup(props) {
+        return () => {
+            const width = clampInt(
+                attrFloat(props.attributes.marqueeWidth, 100),
+                1,
+                100,
+                100
+            );
+            const speed = clampInt(
+                attrFloat(props.attributes.marqueeSpeed, 5),
+                1,
+                100,
+                5
+            );
+            const content = attrString(props.attributes.marqueeContent);
+            const className = attrString(props.attributes.className);
+
+            const classes = classList(['ap-marquee', className]);
+            const wrapperStyle = { width: `${width}%` };
+            const textStyle = {
+                animation: `ap-marquee-scroll ${speed}s linear infinite`,
+            };
+
+            return h('div', { class: classes, style: wrapperStyle }, [
+                h('p', {
+                    class: 'ap-marquee__text',
+                    style: textStyle,
+                    innerHTML: content,
+                }),
+            ]);
+        };
+    },
+});

--- a/packages/visual-editor-renderer-vue/src/blocks/registerCoreBlocks.ts
+++ b/packages/visual-editor-renderer-vue/src/blocks/registerCoreBlocks.ts
@@ -20,7 +20,10 @@ import {
 } from './artisanpack/accordion';
 import { BreadcrumbsBlock } from './artisanpack/breadcrumbs';
 import { CalloutBlock } from './artisanpack/callout';
+import { CommentsNumberBlock } from './artisanpack/commentsNumber';
+import { CopyrightBlock } from './artisanpack/copyright';
 import { GridBlock, GridItemBlock } from './artisanpack/grid';
+import { MarqueeBlock } from './artisanpack/marquee';
 import { TabSectionBlock, TabsBlock } from './artisanpack/tabs';
 import { LoginoutBlock } from './artisanpack/loginout';
 import {
@@ -286,6 +289,13 @@ const CORE_BLOCKS: Record<string, BlockRenderer> = {
     // only; loginout never shipped as `core/*` in v1 so there is no
     // core counterpart to mirror here.
     'artisanpack/loginout': LoginoutBlock,
+    // Site-chrome cluster (#500) — registered under the artisanpack/*
+    // namespace only. These three blocks (copyright + marquee +
+    // comments-number) never shipped as `core/*` in v1 so there are
+    // no core counterparts to mirror here.
+    'artisanpack/copyright': CopyrightBlock,
+    'artisanpack/marquee': MarqueeBlock,
+    'artisanpack/comments-number': CommentsNumberBlock,
 };
 
 export function registerCoreBlocks(): void {

--- a/packages/visual-editor-renderer-vue/tests/BlockTree.test.ts
+++ b/packages/visual-editor-renderer-vue/tests/BlockTree.test.ts
@@ -692,6 +692,117 @@ describe('Core design blocks', () => {
         expect(html).not.toContain('<li class="ap-breadcrumbs__item');
     });
 
+    it('renders the artisanpack/copyright block with © text and the current year', () => {
+        const tree = [
+            makeBlock('artisanpack/copyright', {
+                copyrightType: 'icon-text',
+                copyrightText: 'Acme, Inc.',
+            }),
+        ];
+
+        const year = new Date().getUTCFullYear();
+        const html = renderTree(tree);
+
+        expect(html).toContain('class="ap-copyright"');
+        expect(html).toContain(`© Acme, Inc. ${year}`);
+    });
+
+    it('omits the text when copyright type is icon-only and drops the © when text-only', () => {
+        const iconOnly = renderTree([
+            makeBlock('artisanpack/copyright', {
+                copyrightType: 'icon-only',
+                copyrightText: 'Should not appear',
+            }),
+        ]);
+        const textOnly = renderTree([
+            makeBlock('artisanpack/copyright', {
+                copyrightType: 'text-only',
+                copyrightText: 'Plain',
+            }),
+        ]);
+        const year = new Date().getUTCFullYear();
+
+        expect(iconOnly).toContain(`© ${year}`);
+        expect(iconOnly).not.toContain('Should not appear');
+        expect(textOnly).toContain(`Plain ${year}`);
+        expect(textOnly).not.toContain('©');
+    });
+
+    it('falls back to icon-text when copyright type is invalid', () => {
+        const html = renderTree([
+            makeBlock('artisanpack/copyright', {
+                copyrightType: 'made-up-mode',
+                copyrightText: 'Fallback',
+            }),
+        ]);
+        const year = new Date().getUTCFullYear();
+
+        expect(html).toContain(`© Fallback ${year}`);
+    });
+
+    it('renders the artisanpack/marquee block with width + animation styles applied', () => {
+        const tree = [
+            makeBlock('artisanpack/marquee', {
+                marqueeContent: 'Breaking news',
+                marqueeWidth: 60,
+                marqueeSpeed: 10,
+            }),
+        ];
+
+        const html = renderTree(tree);
+
+        expect(html).toContain('class="ap-marquee"');
+        expect(html).toContain('width: 60%');
+        expect(html).toContain('animation: ap-marquee-scroll 10s linear infinite');
+        expect(html).toContain('class="ap-marquee__text"');
+        expect(html).toContain('Breaking news');
+    });
+
+    it('clamps marquee width and speed to their valid range and falls back on non-numeric input', () => {
+        const html = renderTree([
+            makeBlock('artisanpack/marquee', {
+                marqueeContent: 'x',
+                marqueeWidth: 999,
+                marqueeSpeed: 'fast',
+            }),
+        ]);
+
+        expect(html).toContain('width: 100%');
+        expect(html).toContain('animation: ap-marquee-scroll 5s linear infinite');
+    });
+
+    it('renders the artisanpack/comments-number block with resolved count + plural label', () => {
+        const html = renderTree([
+            makeBlock('artisanpack/comments-number', {
+                _resolvedCommentCount: 5,
+                singularCommentText: 'Reply',
+                pluralCommentText: 'Replies',
+            }),
+        ]);
+
+        expect(html).toContain('class="ap-comments-number"');
+        expect(html).toContain('5 Replies');
+        expect(html).not.toContain('Reply<');
+    });
+
+    it('uses the singular comments-number label when the resolved count is exactly one', () => {
+        const html = renderTree([
+            makeBlock('artisanpack/comments-number', {
+                _resolvedCommentCount: 1,
+                singularCommentText: 'Reply',
+                pluralCommentText: 'Replies',
+            }),
+        ]);
+
+        expect(html).toContain('1 Reply');
+    });
+
+    it('falls back to zero comments and default labels when the resolved count is missing', () => {
+        const html = renderTree([makeBlock('artisanpack/comments-number', {})]);
+
+        expect(html).toContain('0 Comments');
+    });
+
     it('renders the artisanpack/accordions family with nested grandchildren', () => {
         const tree = [
             makeBlock('artisanpack/accordions', {}, [

--- a/packages/visual-editor-renderer-vue/tests/BlockTree.test.ts
+++ b/packages/visual-editor-renderer-vue/tests/BlockTree.test.ts
@@ -1,6 +1,6 @@
 import { defineComponent, h } from 'vue';
 import { mount, flushPromises } from '@vue/test-utils';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import '../src/index';
 import { BlockTree } from '../src/BlockTree';
@@ -692,52 +692,67 @@ describe('Core design blocks', () => {
         expect(html).not.toContain('<li class="ap-breadcrumbs__item');
     });
 
-    it('renders the artisanpack/copyright block with © text and the current year', () => {
-        const tree = [
-            makeBlock('artisanpack/copyright', {
-                copyrightType: 'icon-text',
-                copyrightText: 'Acme, Inc.',
-            }),
-        ];
+    describe('artisanpack/copyright (year is read at render time)', () => {
+        // Pin the clock so these specs don't drift on the Dec 31 → Jan 1
+        // boundary; the renderer reads `new Date().getUTCFullYear()` so
+        // any test that hard-codes a year would otherwise need a real
+        // calendar to stay accurate.
+        const PINNED_YEAR = 2030;
+        const PINNED_DATE = new Date(Date.UTC(PINNED_YEAR, 5, 15));
 
-        const year = new Date().getUTCFullYear();
-        const html = renderTree(tree);
+        beforeEach(() => {
+            vi.useFakeTimers();
+            vi.setSystemTime(PINNED_DATE);
+        });
 
-        expect(html).toContain('class="ap-copyright"');
-        expect(html).toContain(`© Acme, Inc. ${year}`);
-    });
+        afterEach(() => {
+            vi.useRealTimers();
+        });
 
-    it('omits the text when copyright type is icon-only and drops the © when text-only', () => {
-        const iconOnly = renderTree([
-            makeBlock('artisanpack/copyright', {
-                copyrightType: 'icon-only',
-                copyrightText: 'Should not appear',
-            }),
-        ]);
-        const textOnly = renderTree([
-            makeBlock('artisanpack/copyright', {
-                copyrightType: 'text-only',
-                copyrightText: 'Plain',
-            }),
-        ]);
-        const year = new Date().getUTCFullYear();
+        it('renders the artisanpack/copyright block with © text and the current year', () => {
+            const tree = [
+                makeBlock('artisanpack/copyright', {
+                    copyrightType: 'icon-text',
+                    copyrightText: 'Acme, Inc.',
+                }),
+            ];
 
-        expect(iconOnly).toContain(`© ${year}`);
-        expect(iconOnly).not.toContain('Should not appear');
-        expect(textOnly).toContain(`Plain ${year}`);
-        expect(textOnly).not.toContain('©');
-    });
+            const html = renderTree(tree);
 
-    it('falls back to icon-text when copyright type is invalid', () => {
-        const html = renderTree([
-            makeBlock('artisanpack/copyright', {
-                copyrightType: 'made-up-mode',
-                copyrightText: 'Fallback',
-            }),
-        ]);
-        const year = new Date().getUTCFullYear();
+            expect(html).toContain('class="ap-copyright"');
+            expect(html).toContain(`© Acme, Inc. ${PINNED_YEAR}`);
+        });
 
-        expect(html).toContain(`© Fallback ${year}`);
+        it('omits the text when copyright type is icon-only and drops the © when text-only', () => {
+            const iconOnly = renderTree([
+                makeBlock('artisanpack/copyright', {
+                    copyrightType: 'icon-only',
+                    copyrightText: 'Should not appear',
+                }),
+            ]);
+            const textOnly = renderTree([
+                makeBlock('artisanpack/copyright', {
+                    copyrightType: 'text-only',
+                    copyrightText: 'Plain',
+                }),
+            ]);
+
+            expect(iconOnly).toContain(`© ${PINNED_YEAR}`);
+            expect(iconOnly).not.toContain('Should not appear');
+            expect(textOnly).toContain(`Plain ${PINNED_YEAR}`);
+            expect(textOnly).not.toContain('©');
+        });
+
+        it('falls back to icon-text when copyright type is invalid', () => {
+            const html = renderTree([
+                makeBlock('artisanpack/copyright', {
+                    copyrightType: 'made-up-mode',
+                    copyrightText: 'Fallback',
+                }),
+            ]);
+
+            expect(html).toContain(`© Fallback ${PINNED_YEAR}`);
+        });
     });
 
     it('renders the artisanpack/marquee block with width + animation styles applied', () => {

--- a/resources/js/visual-editor/blocks/__tests__/site-chrome-family.test.ts
+++ b/resources/js/visual-editor/blocks/__tests__/site-chrome-family.test.ts
@@ -67,7 +67,7 @@ describe('site-chrome cluster block.json', () => {
         expect(attrs?.marqueeContent?.selector).toBe('p');
     });
 
-    it('comments-number declares singular + plural labels and the postId context', () => {
+    it('comments-number declares singular + plural labels and the postId / postType context', () => {
         const attrs = (commentsNumberMeta as { attributes?: Record<string, { default?: unknown }> })
             .attributes;
         expect(attrs?.singularCommentText?.default).toBe('Comment');
@@ -76,6 +76,7 @@ describe('site-chrome cluster block.json', () => {
         const usesContext = (commentsNumberMeta as { usesContext?: ReadonlyArray<string> })
             .usesContext;
         expect(usesContext).toContain('postId');
+        expect(usesContext).toContain('postType');
     });
 });
 

--- a/resources/js/visual-editor/blocks/__tests__/site-chrome-family.test.ts
+++ b/resources/js/visual-editor/blocks/__tests__/site-chrome-family.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Site-chrome cluster contract (#500).
+ *
+ * block.json + save contract for the three site-wide chrome blocks:
+ *
+ *   - copyright (dynamic — save returns null)
+ *   - marquee (static — save returns the wrapper markup so
+ *     `source: 'html', selector: 'p'` round-trips through Gutenberg)
+ *   - comments-number (dynamic — save returns null)
+ *
+ * All three live under the `artisanpack` namespace + category and the
+ * `artisanpack-visual-editor` textdomain.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@wordpress/block-editor', () => ({
+    InnerBlocks: Object.assign(() => null, { Content: () => null }),
+    RichText: Object.assign(() => null, { Content: () => null }),
+    useBlockProps: Object.assign(() => ({}), { save: () => ({}) }),
+}));
+
+import copyrightMeta from '../copyright/block.json';
+import marqueeMeta from '../marquee/block.json';
+import commentsNumberMeta from '../comments-number/block.json';
+
+import copyrightSave from '../copyright/save';
+import marqueeSave from '../marquee/save';
+import commentsNumberSave from '../comments-number/save';
+
+const FAMILY = [
+    { slug: 'copyright', meta: copyrightMeta },
+    { slug: 'marquee', meta: marqueeMeta },
+    { slug: 'comments-number', meta: commentsNumberMeta },
+] as const;
+
+describe('site-chrome cluster block.json', () => {
+    it.each(FAMILY)(
+        '$slug declares the artisanpack namespace + textdomain + category',
+        ({ slug, meta }) => {
+            expect(meta.name).toBe(`artisanpack/${slug}`);
+            expect(meta.textdomain).toBe('artisanpack-visual-editor');
+            expect(meta.category).toBe('artisanpack');
+        }
+    );
+
+    it('copyright declares copyrightType + copyrightText attributes with safe defaults', () => {
+        const attrs = (copyrightMeta as { attributes?: Record<string, { default?: unknown; enum?: unknown }> })
+            .attributes;
+        expect(attrs?.copyrightType?.default).toBe('icon-text');
+        expect(attrs?.copyrightType?.enum).toEqual([
+            'icon-text',
+            'icon-only',
+            'text-only',
+        ]);
+        expect(attrs?.copyrightText?.default).toBe('Copyright');
+    });
+
+    it('marquee declares the marqueeContent / width / speed attributes with safe defaults', () => {
+        const attrs = (marqueeMeta as {
+            attributes?: Record<string, { default?: unknown; source?: unknown; selector?: unknown }>;
+        }).attributes;
+        expect(attrs?.marqueeWidth?.default).toBe(100);
+        expect(attrs?.marqueeSpeed?.default).toBe(5);
+        expect(attrs?.marqueeContent?.default).toBe('');
+        expect(attrs?.marqueeContent?.source).toBe('html');
+        expect(attrs?.marqueeContent?.selector).toBe('p');
+    });
+
+    it('comments-number declares singular + plural labels and the postId context', () => {
+        const attrs = (commentsNumberMeta as { attributes?: Record<string, { default?: unknown }> })
+            .attributes;
+        expect(attrs?.singularCommentText?.default).toBe('Comment');
+        expect(attrs?.pluralCommentText?.default).toBe('Comments');
+
+        const usesContext = (commentsNumberMeta as { usesContext?: ReadonlyArray<string> })
+            .usesContext;
+        expect(usesContext).toContain('postId');
+    });
+});
+
+describe('site-chrome cluster save contract', () => {
+    it('copyright.save returns null (dynamic block)', () => {
+        expect((copyrightSave as () => null)()).toBeNull();
+    });
+
+    it('comments-number.save returns null (dynamic block)', () => {
+        expect((commentsNumberSave as () => null)()).toBeNull();
+    });
+
+    it('marquee.save returns a non-null element (static block)', () => {
+        // The static save renders the wrapper + RichText so the
+        // `source: 'html', selector: 'p'` parser round-trips the
+        // saved content. The element factory returns a React element,
+        // not null — that's the contract for static blocks.
+        const element = (marqueeSave as (props: {
+            attributes: {
+                marqueeContent: string;
+                marqueeWidth: number;
+                marqueeSpeed: number;
+            };
+        }) => unknown)({
+            attributes: {
+                marqueeContent: 'Breaking news',
+                marqueeWidth: 50,
+                marqueeSpeed: 10,
+            },
+        });
+        expect(element).not.toBeNull();
+    });
+});

--- a/resources/js/visual-editor/blocks/comments-number/block.json
+++ b/resources/js/visual-editor/blocks/comments-number/block.json
@@ -1,0 +1,70 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "artisanpack/comments-number",
+    "title": "Comments Number",
+    "category": "artisanpack",
+    "description": "Display the number of comments on a post with custom singular and plural labels.",
+    "keywords": ["comments", "count", "comments number"],
+    "textdomain": "artisanpack-visual-editor",
+    "usesContext": ["postId", "postType"],
+    "attributes": {
+        "singularCommentText": {
+            "type": "string",
+            "default": "Comment"
+        },
+        "pluralCommentText": {
+            "type": "string",
+            "default": "Comments"
+        }
+    },
+    "supports": {
+        "align": ["wide", "full"],
+        "ariaLabel": true,
+        "className": true,
+        "html": false,
+        "spacing": {
+            "margin": ["top", "bottom"],
+            "padding": true,
+            "blockGap": true,
+            "__experimentalDefaultControls": {
+                "padding": true,
+                "blockGap": true
+            }
+        },
+        "color": {
+            "gradients": true,
+            "link": true,
+            "__experimentalDefaultControls": {
+                "background": true,
+                "text": true
+            }
+        },
+        "shadow": true,
+        "__experimentalBorder": {
+            "color": true,
+            "radius": true,
+            "style": true,
+            "width": true,
+            "__experimentalDefaultControls": {
+                "color": true,
+                "radius": true,
+                "style": true,
+                "width": true
+            }
+        },
+        "typography": {
+            "fontSize": true,
+            "lineHeight": true,
+            "__experimentalFontFamily": true,
+            "__experimentalFontWeight": true,
+            "__experimentalFontStyle": true,
+            "__experimentalTextTransform": true,
+            "__experimentalTextDecoration": true,
+            "__experimentalLetterSpacing": true,
+            "__experimentalDefaultControls": {
+                "fontSize": true
+            }
+        }
+    }
+}

--- a/resources/js/visual-editor/blocks/comments-number/edit.tsx
+++ b/resources/js/visual-editor/blocks/comments-number/edit.tsx
@@ -1,0 +1,69 @@
+/**
+ * Comments Number — editor-side preview.
+ *
+ * Shows a stub `0 {plural}` line so authors get an immediate visual of
+ * the label they're configuring. The real count comes from
+ * `PostResolver` at render time and is combined with the saved labels
+ * by the Blade / React / Vue renderers.
+ */
+
+import type { ReactElement } from 'react';
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import { PanelBody, TextControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+import { TEXT_DOMAIN } from '../../vendor/i18n';
+
+interface CommentsNumberAttributes {
+    readonly singularCommentText: string;
+    readonly pluralCommentText: string;
+}
+
+interface CommentsNumberEditProps {
+    readonly attributes: CommentsNumberAttributes;
+    readonly setAttributes: (next: Partial<CommentsNumberAttributes>) => void;
+}
+
+export default function CommentsNumberEdit({
+    attributes,
+    setAttributes,
+}: CommentsNumberEditProps): ReactElement {
+    const { singularCommentText, pluralCommentText } = attributes;
+
+    const blockProps = useBlockProps({ className: 'ap-comments-number' });
+
+    const previewLabel = pluralCommentText.trim() !== ''
+        ? pluralCommentText
+        : __('Comments', TEXT_DOMAIN);
+
+    return (
+        <>
+            <InspectorControls>
+                <PanelBody
+                    title={__('Comments number settings', TEXT_DOMAIN)}
+                    initialOpen
+                >
+                    <TextControl
+                        label={__('Singular label', TEXT_DOMAIN)}
+                        value={singularCommentText}
+                        onChange={(value) =>
+                            setAttributes({ singularCommentText: value })
+                        }
+                        help={__('Shown when the post has exactly one comment.', TEXT_DOMAIN)}
+                        __nextHasNoMarginBottom
+                    />
+                    <TextControl
+                        label={__('Plural label', TEXT_DOMAIN)}
+                        value={pluralCommentText}
+                        onChange={(value) =>
+                            setAttributes({ pluralCommentText: value })
+                        }
+                        help={__('Shown when the post has zero or multiple comments.', TEXT_DOMAIN)}
+                        __nextHasNoMarginBottom
+                    />
+                </PanelBody>
+            </InspectorControls>
+            <p {...blockProps}>{`0 ${previewLabel}`}</p>
+        </>
+    );
+}

--- a/resources/js/visual-editor/blocks/comments-number/index.ts
+++ b/resources/js/visual-editor/blocks/comments-number/index.ts
@@ -1,0 +1,24 @@
+/**
+ * Comments Number block entrypoint (#500).
+ *
+ * Auto-discovered by `editor/custom-blocks.ts` and registered against
+ * `@wordpress/blocks.registerBlockType`. Dynamic block: the count is
+ * stamped server-side by `PostResolver` as `_resolvedCommentCount`, and
+ * the renderers combine it with the saved `singularCommentText` /
+ * `pluralCommentText` labels.
+ */
+
+import metadata from './block.json';
+import edit from './edit';
+import save from './save';
+import icon from './inserter-icon';
+
+export { edit, save, metadata, icon };
+
+export default {
+    name: metadata.name,
+    metadata,
+    edit,
+    save,
+    icon,
+};

--- a/resources/js/visual-editor/blocks/comments-number/inserter-icon.tsx
+++ b/resources/js/visual-editor/blocks/comments-number/inserter-icon.tsx
@@ -1,0 +1,23 @@
+/**
+ * Comments Number — inserter icon.
+ *
+ * Inline SVG (a numbered speech bubble) so the editor canvas does not
+ * have to load `dashicons.css` for the inserter preview.
+ */
+
+import type { ReactElement } from 'react';
+
+export default function CommentsNumberInserterIcon(): ReactElement {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            width={24}
+            height={24}
+            aria-hidden="true"
+            focusable="false"
+        >
+            <path d="M4 3h16a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1H8l-4 4V4a1 1 0 0 1 1-1Zm1 2v13l2-2h13V5H5Zm6 3h2v6h-2V8Z" />
+        </svg>
+    );
+}

--- a/resources/js/visual-editor/blocks/comments-number/save.tsx
+++ b/resources/js/visual-editor/blocks/comments-number/save.tsx
@@ -1,0 +1,13 @@
+/**
+ * Comments Number — save component.
+ *
+ * Dynamic block: the count is resolved server-side by `PostResolver`
+ * and combined with the saved labels by the Blade / React / Vue
+ * renderers at render time. Returning `null` from save is the
+ * Gutenberg convention for dynamic blocks — only the block delimiter
+ * and attributes are persisted.
+ */
+
+export default function CommentsNumberSave(): null {
+    return null;
+}

--- a/resources/js/visual-editor/blocks/copyright/block.json
+++ b/resources/js/visual-editor/blocks/copyright/block.json
@@ -1,0 +1,70 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "artisanpack/copyright",
+    "title": "Copyright",
+    "category": "artisanpack",
+    "description": "Display a copyright line that always shows the current year.",
+    "keywords": ["copyright", "footer", "site"],
+    "textdomain": "artisanpack-visual-editor",
+    "attributes": {
+        "copyrightType": {
+            "type": "string",
+            "enum": ["icon-text", "icon-only", "text-only"],
+            "default": "icon-text"
+        },
+        "copyrightText": {
+            "type": "string",
+            "default": "Copyright"
+        }
+    },
+    "supports": {
+        "align": ["wide", "full"],
+        "ariaLabel": true,
+        "className": true,
+        "html": false,
+        "spacing": {
+            "margin": ["top", "bottom"],
+            "padding": true,
+            "blockGap": true,
+            "__experimentalDefaultControls": {
+                "padding": true,
+                "blockGap": true
+            }
+        },
+        "color": {
+            "gradients": true,
+            "link": true,
+            "__experimentalDefaultControls": {
+                "background": true,
+                "text": true
+            }
+        },
+        "shadow": true,
+        "__experimentalBorder": {
+            "color": true,
+            "radius": true,
+            "style": true,
+            "width": true,
+            "__experimentalDefaultControls": {
+                "color": true,
+                "radius": true,
+                "style": true,
+                "width": true
+            }
+        },
+        "typography": {
+            "fontSize": true,
+            "lineHeight": true,
+            "__experimentalFontFamily": true,
+            "__experimentalFontWeight": true,
+            "__experimentalFontStyle": true,
+            "__experimentalTextTransform": true,
+            "__experimentalTextDecoration": true,
+            "__experimentalLetterSpacing": true,
+            "__experimentalDefaultControls": {
+                "fontSize": true
+            }
+        }
+    }
+}

--- a/resources/js/visual-editor/blocks/copyright/edit.tsx
+++ b/resources/js/visual-editor/blocks/copyright/edit.tsx
@@ -1,0 +1,97 @@
+/**
+ * Copyright — editor-side preview.
+ *
+ * Renders the resolved copyright line with the current year so authors
+ * see the live shape as they tweak the type / text controls. The real
+ * markup is rendered at runtime by the Blade / React / Vue renderers
+ * from the saved attributes.
+ */
+
+import type { ReactElement } from 'react';
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import { PanelBody, SelectControl, TextControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+import { TEXT_DOMAIN } from '../../vendor/i18n';
+
+type CopyrightType = 'icon-text' | 'icon-only' | 'text-only';
+
+interface CopyrightAttributes {
+    readonly copyrightType: CopyrightType;
+    readonly copyrightText: string;
+}
+
+interface CopyrightEditProps {
+    readonly attributes: CopyrightAttributes;
+    readonly setAttributes: (next: Partial<CopyrightAttributes>) => void;
+}
+
+const TYPE_OPTIONS: ReadonlyArray<{
+    readonly label: string;
+    readonly value: CopyrightType;
+}> = [
+    { label: 'Icon and text', value: 'icon-text' },
+    { label: 'Icon only', value: 'icon-only' },
+    { label: 'Text only', value: 'text-only' },
+];
+
+function isCopyrightType(value: string): value is CopyrightType {
+    return TYPE_OPTIONS.some((option) => option.value === value);
+}
+
+function buildLine(type: CopyrightType, text: string, year: number): string {
+    const trimmed = text.trim();
+    if (type === 'icon-only') {
+        return `© ${year}`;
+    }
+    if (type === 'text-only') {
+        return trimmed === '' ? `${year}` : `${trimmed} ${year}`;
+    }
+    return trimmed === '' ? `© ${year}` : `© ${trimmed} ${year}`;
+}
+
+export default function CopyrightEdit({
+    attributes,
+    setAttributes,
+}: CopyrightEditProps): ReactElement {
+    const { copyrightType, copyrightText } = attributes;
+
+    const blockProps = useBlockProps({ className: 'ap-copyright' });
+
+    const currentYear = new Date().getFullYear();
+    const line = buildLine(copyrightType, copyrightText, currentYear);
+
+    return (
+        <>
+            <InspectorControls>
+                <PanelBody title={__('Copyright settings', TEXT_DOMAIN)} initialOpen>
+                    <SelectControl
+                        label={__('Copyright type', TEXT_DOMAIN)}
+                        value={copyrightType}
+                        options={TYPE_OPTIONS.map((option) => ({
+                            label: __(option.label, TEXT_DOMAIN),
+                            value: option.value,
+                        }))}
+                        onChange={(value) => {
+                            if (isCopyrightType(value)) {
+                                setAttributes({ copyrightType: value });
+                            }
+                        }}
+                        __nextHasNoMarginBottom
+                    />
+                    <TextControl
+                        label={__('Copyright text', TEXT_DOMAIN)}
+                        value={copyrightText}
+                        onChange={(value) => setAttributes({ copyrightText: value })}
+                        help={__(
+                            'Shown next to the © symbol (icon and text) or on its own (text only). Hidden in icon-only mode.',
+                            TEXT_DOMAIN
+                        )}
+                        __nextHasNoMarginBottom
+                    />
+                </PanelBody>
+            </InspectorControls>
+            <p {...blockProps}>{line}</p>
+        </>
+    );
+}

--- a/resources/js/visual-editor/blocks/copyright/index.ts
+++ b/resources/js/visual-editor/blocks/copyright/index.ts
@@ -1,0 +1,24 @@
+/**
+ * Copyright block entrypoint (#500).
+ *
+ * Auto-discovered by `editor/custom-blocks.ts` and registered against
+ * `@wordpress/blocks.registerBlockType`. Dynamic block: `edit` previews
+ * the resolved line with the current year so authors see the chosen
+ * type immediately, and `save` returns `null` so renderers produce the
+ * real markup from the saved attributes at render time.
+ */
+
+import metadata from './block.json';
+import edit from './edit';
+import save from './save';
+import icon from './inserter-icon';
+
+export { edit, save, metadata, icon };
+
+export default {
+    name: metadata.name,
+    metadata,
+    edit,
+    save,
+    icon,
+};

--- a/resources/js/visual-editor/blocks/copyright/inserter-icon.tsx
+++ b/resources/js/visual-editor/blocks/copyright/inserter-icon.tsx
@@ -1,0 +1,23 @@
+/**
+ * Copyright — inserter icon.
+ *
+ * Inline SVG (a circled "C") so the editor canvas does not have to load
+ * `dashicons.css` for the block-library inserter preview.
+ */
+
+import type { ReactElement } from 'react';
+
+export default function CopyrightInserterIcon(): ReactElement {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            width={24}
+            height={24}
+            aria-hidden="true"
+            focusable="false"
+        >
+            <path d="M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2Zm0 18a8 8 0 1 1 8-8 8 8 0 0 1-8 8Zm0-13a5 5 0 0 0 0 10 5 5 0 0 0 3.54-1.46l-1.42-1.42A3 3 0 1 1 12 9a3 3 0 0 1 2.12.88l1.42-1.42A5 5 0 0 0 12 7Z" />
+        </svg>
+    );
+}

--- a/resources/js/visual-editor/blocks/copyright/save.tsx
+++ b/resources/js/visual-editor/blocks/copyright/save.tsx
@@ -1,0 +1,13 @@
+/**
+ * Copyright — save component.
+ *
+ * Dynamic block: the line is built at render time by the Blade / React /
+ * Vue renderers so the current year reflects the actual request, not the
+ * post's last-saved timestamp. Returning `null` from save is the
+ * Gutenberg convention for dynamic blocks — only the block delimiter
+ * and attributes are persisted.
+ */
+
+export default function CopyrightSave(): null {
+    return null;
+}

--- a/resources/js/visual-editor/blocks/marquee/block.json
+++ b/resources/js/visual-editor/blocks/marquee/block.json
@@ -1,0 +1,75 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "artisanpack/marquee",
+    "title": "Marquee",
+    "category": "artisanpack",
+    "description": "Scroll a line of text horizontally across the screen.",
+    "keywords": ["marquee", "scroll", "ticker", "banner"],
+    "textdomain": "artisanpack-visual-editor",
+    "attributes": {
+        "marqueeContent": {
+            "type": "string",
+            "source": "html",
+            "selector": "p",
+            "default": ""
+        },
+        "marqueeWidth": {
+            "type": "number",
+            "default": 100
+        },
+        "marqueeSpeed": {
+            "type": "number",
+            "default": 5
+        }
+    },
+    "supports": {
+        "anchor": true,
+        "ariaLabel": true,
+        "className": true,
+        "html": false,
+        "color": {
+            "gradients": true,
+            "link": true,
+            "__experimentalDefaultControls": {
+                "background": true,
+                "text": true
+            }
+        },
+        "spacing": {
+            "margin": ["top", "bottom"],
+            "padding": true,
+            "blockGap": true,
+            "__experimentalDefaultControls": {
+                "padding": true,
+                "blockGap": true
+            }
+        },
+        "shadow": true,
+        "__experimentalBorder": {
+            "color": true,
+            "radius": true,
+            "style": true,
+            "width": true,
+            "__experimentalDefaultControls": {
+                "color": true,
+                "radius": true,
+                "style": true,
+                "width": true
+            }
+        },
+        "typography": {
+            "fontSize": true,
+            "lineHeight": true,
+            "__experimentalFontFamily": true,
+            "__experimentalFontWeight": true,
+            "__experimentalFontStyle": true,
+            "__experimentalTextTransform": true,
+            "__experimentalTextDecoration": true,
+            "__experimentalLetterSpacing": true,
+            "__experimentalDefaultControls": {
+                "fontSize": true
+            }
+        }
+    }
+}

--- a/resources/js/visual-editor/blocks/marquee/clamp.ts
+++ b/resources/js/visual-editor/blocks/marquee/clamp.ts
@@ -1,0 +1,43 @@
+/**
+ * Shared clamp helpers for the marquee block (#500).
+ *
+ * Both `edit.tsx` and `save.tsx` need to clamp the `marqueeWidth` and
+ * `marqueeSpeed` attributes to the same range so the editor preview
+ * and the persisted markup stay in sync. Keeping the helpers in their
+ * own module guards against drift if the range / default ever changes
+ * for one but not the other.
+ */
+
+const WIDTH_MIN = 1;
+const WIDTH_MAX = 100;
+const SPEED_MIN = 1;
+const SPEED_MAX = 100;
+
+export const MARQUEE_WIDTH_DEFAULT = 100;
+export const MARQUEE_SPEED_DEFAULT = 5;
+
+function clampInt(
+    value: number | null | undefined,
+    min: number,
+    max: number,
+    fallback: number
+): number {
+    if (typeof value !== 'number' || !Number.isFinite(value)) {
+        return fallback;
+    }
+    return Math.min(max, Math.max(min, Math.round(value)));
+}
+
+export function clampPercent(
+    value: number | null | undefined,
+    fallback: number = MARQUEE_WIDTH_DEFAULT
+): number {
+    return clampInt(value, WIDTH_MIN, WIDTH_MAX, fallback);
+}
+
+export function clampSpeed(
+    value: number | null | undefined,
+    fallback: number = MARQUEE_SPEED_DEFAULT
+): number {
+    return clampInt(value, SPEED_MIN, SPEED_MAX, fallback);
+}

--- a/resources/js/visual-editor/blocks/marquee/edit.tsx
+++ b/resources/js/visual-editor/blocks/marquee/edit.tsx
@@ -1,0 +1,114 @@
+/**
+ * Marquee — editor-side render.
+ *
+ * Renders the same DOM shape `save.tsx` produces so Gutenberg's save-
+ * vs-edit validator passes on reload. The editor preview deliberately
+ * omits the inline `animation` declaration the renderers emit — the
+ * text stays still so authors can edit the RichText without it sliding
+ * out from under their cursor. `canvas-styles.ts` ships a matching
+ * `transform: none` override on `.ap-marquee__text` so the keyframe's
+ * translate-off-screen base rule doesn't hide the editor's copy.
+ */
+
+import type { CSSProperties, ReactElement } from 'react';
+import {
+    InspectorControls,
+    RichText,
+    useBlockProps,
+} from '@wordpress/block-editor';
+import { PanelBody, RangeControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+import { TEXT_DOMAIN } from '../../vendor/i18n';
+
+interface MarqueeAttributes {
+    readonly marqueeContent: string;
+    readonly marqueeWidth: number;
+    readonly marqueeSpeed: number;
+}
+
+interface MarqueeEditProps {
+    readonly attributes: MarqueeAttributes;
+    readonly setAttributes: (next: Partial<MarqueeAttributes>) => void;
+}
+
+function clampPercent(value: number | null | undefined, fallback: number): number {
+    if (typeof value !== 'number' || !Number.isFinite(value)) {
+        return fallback;
+    }
+    return Math.min(100, Math.max(1, Math.round(value)));
+}
+
+function clampSpeed(value: number | null | undefined, fallback: number): number {
+    if (typeof value !== 'number' || !Number.isFinite(value)) {
+        return fallback;
+    }
+    return Math.min(100, Math.max(1, Math.round(value)));
+}
+
+export default function MarqueeEdit({
+    attributes,
+    setAttributes,
+}: MarqueeEditProps): ReactElement {
+    const { marqueeContent, marqueeWidth, marqueeSpeed } = attributes;
+
+    const safeWidth = clampPercent(marqueeWidth, 100);
+    const safeSpeed = clampSpeed(marqueeSpeed, 5);
+
+    const blockProps = useBlockProps({
+        className: 'ap-marquee',
+        style: { width: `${safeWidth}%` } as CSSProperties,
+    });
+
+    return (
+        <>
+            <InspectorControls>
+                <PanelBody title={__('Marquee settings', TEXT_DOMAIN)} initialOpen>
+                    <RangeControl
+                        label={__('Width', TEXT_DOMAIN)}
+                        help={__('Percentage of the container width.', TEXT_DOMAIN)}
+                        value={safeWidth}
+                        onChange={(value) =>
+                            setAttributes({ marqueeWidth: clampPercent(value, 100) })
+                        }
+                        min={1}
+                        max={100}
+                        initialPosition={100}
+                        allowReset
+                        resetFallbackValue={100}
+                        __nextHasNoMarginBottom
+                    />
+                    <RangeControl
+                        label={__('Speed', TEXT_DOMAIN)}
+                        help={__(
+                            'Seconds per scroll loop. Higher values are slower.',
+                            TEXT_DOMAIN
+                        )}
+                        value={safeSpeed}
+                        onChange={(value) =>
+                            setAttributes({ marqueeSpeed: clampSpeed(value, 5) })
+                        }
+                        min={1}
+                        max={100}
+                        initialPosition={5}
+                        allowReset
+                        resetFallbackValue={5}
+                        __nextHasNoMarginBottom
+                    />
+                </PanelBody>
+            </InspectorControls>
+            <div {...blockProps}>
+                <RichText
+                    tagName="p"
+                    className="ap-marquee__text"
+                    value={marqueeContent}
+                    onChange={(next: string) =>
+                        setAttributes({ marqueeContent: next })
+                    }
+                    allowedFormats={['core/bold', 'core/italic']}
+                    placeholder={__('Marquee text here…', TEXT_DOMAIN)}
+                />
+            </div>
+        </>
+    );
+}

--- a/resources/js/visual-editor/blocks/marquee/edit.tsx
+++ b/resources/js/visual-editor/blocks/marquee/edit.tsx
@@ -21,6 +21,13 @@ import { __ } from '@wordpress/i18n';
 
 import { TEXT_DOMAIN } from '../../vendor/i18n';
 
+import {
+    clampPercent,
+    clampSpeed,
+    MARQUEE_SPEED_DEFAULT,
+    MARQUEE_WIDTH_DEFAULT,
+} from './clamp';
+
 interface MarqueeAttributes {
     readonly marqueeContent: string;
     readonly marqueeWidth: number;
@@ -32,28 +39,14 @@ interface MarqueeEditProps {
     readonly setAttributes: (next: Partial<MarqueeAttributes>) => void;
 }
 
-function clampPercent(value: number | null | undefined, fallback: number): number {
-    if (typeof value !== 'number' || !Number.isFinite(value)) {
-        return fallback;
-    }
-    return Math.min(100, Math.max(1, Math.round(value)));
-}
-
-function clampSpeed(value: number | null | undefined, fallback: number): number {
-    if (typeof value !== 'number' || !Number.isFinite(value)) {
-        return fallback;
-    }
-    return Math.min(100, Math.max(1, Math.round(value)));
-}
-
 export default function MarqueeEdit({
     attributes,
     setAttributes,
 }: MarqueeEditProps): ReactElement {
     const { marqueeContent, marqueeWidth, marqueeSpeed } = attributes;
 
-    const safeWidth = clampPercent(marqueeWidth, 100);
-    const safeSpeed = clampSpeed(marqueeSpeed, 5);
+    const safeWidth = clampPercent(marqueeWidth);
+    const safeSpeed = clampSpeed(marqueeSpeed);
 
     const blockProps = useBlockProps({
         className: 'ap-marquee',
@@ -69,13 +62,13 @@ export default function MarqueeEdit({
                         help={__('Percentage of the container width.', TEXT_DOMAIN)}
                         value={safeWidth}
                         onChange={(value) =>
-                            setAttributes({ marqueeWidth: clampPercent(value, 100) })
+                            setAttributes({ marqueeWidth: clampPercent(value) })
                         }
                         min={1}
                         max={100}
-                        initialPosition={100}
+                        initialPosition={MARQUEE_WIDTH_DEFAULT}
                         allowReset
-                        resetFallbackValue={100}
+                        resetFallbackValue={MARQUEE_WIDTH_DEFAULT}
                         __nextHasNoMarginBottom
                     />
                     <RangeControl
@@ -86,13 +79,13 @@ export default function MarqueeEdit({
                         )}
                         value={safeSpeed}
                         onChange={(value) =>
-                            setAttributes({ marqueeSpeed: clampSpeed(value, 5) })
+                            setAttributes({ marqueeSpeed: clampSpeed(value) })
                         }
                         min={1}
                         max={100}
-                        initialPosition={5}
+                        initialPosition={MARQUEE_SPEED_DEFAULT}
                         allowReset
-                        resetFallbackValue={5}
+                        resetFallbackValue={MARQUEE_SPEED_DEFAULT}
                         __nextHasNoMarginBottom
                     />
                 </PanelBody>

--- a/resources/js/visual-editor/blocks/marquee/index.ts
+++ b/resources/js/visual-editor/blocks/marquee/index.ts
@@ -1,0 +1,26 @@
+/**
+ * Marquee block entrypoint (#500).
+ *
+ * Auto-discovered by `editor/custom-blocks.ts` and registered against
+ * `@wordpress/blocks.registerBlockType`. Static block — `save` emits
+ * the same `<div><p>` shell the renderers produce, so the saved markup
+ * round-trips through Gutenberg's `source: 'html'` parser without a
+ * deprecation chain.
+ */
+
+import metadata from './block.json';
+import edit from './edit';
+import save from './save';
+import icon from './inserter-icon';
+
+import './marquee.css';
+
+export { edit, save, metadata, icon };
+
+export default {
+    name: metadata.name,
+    metadata,
+    edit,
+    save,
+    icon,
+};

--- a/resources/js/visual-editor/blocks/marquee/inserter-icon.tsx
+++ b/resources/js/visual-editor/blocks/marquee/inserter-icon.tsx
@@ -1,0 +1,23 @@
+/**
+ * Marquee — inserter icon.
+ *
+ * Inline SVG (a megaphone-ish horizontal arrow) so the editor canvas
+ * does not have to load `dashicons.css` for the inserter preview.
+ */
+
+import type { ReactElement } from 'react';
+
+export default function MarqueeInserterIcon(): ReactElement {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            width={24}
+            height={24}
+            aria-hidden="true"
+            focusable="false"
+        >
+            <path d="M3 6h18v12H3V6Zm2 2v8h14V8H5Zm2 1h6v1H7V9Zm0 2h10v1H7v-1Zm0 2h6v1H7v-1Z" />
+        </svg>
+    );
+}

--- a/resources/js/visual-editor/blocks/marquee/marquee.css
+++ b/resources/js/visual-editor/blocks/marquee/marquee.css
@@ -28,3 +28,13 @@
         transform: translateX(-100%);
     }
 }
+
+/* Respect prefers-reduced-motion. Mirrors the frontend stylesheet at
+   `packages/visual-editor-renderer-blade/resources/assets/frontend/marquee.css`. */
+@media (prefers-reduced-motion: reduce) {
+    .ap-marquee__text {
+        animation: none !important;
+        transform: none;
+        white-space: normal;
+    }
+}

--- a/resources/js/visual-editor/blocks/marquee/marquee.css
+++ b/resources/js/visual-editor/blocks/marquee/marquee.css
@@ -1,0 +1,30 @@
+/**
+ * Marquee block styles.
+ *
+ * Loaded in the editor via `blocks/marquee/index.ts`. Host apps are
+ * expected to ship matching (or compatible) rules on the public
+ * frontend — the Blade / React / Vue renderers emit the same class
+ * names and the same `ap-marquee-scroll` keyframe name.
+ */
+
+.ap-marquee {
+    margin-left: auto;
+    margin-right: auto;
+    overflow: hidden;
+}
+
+.ap-marquee__text {
+    margin: 0;
+    transform: translateX(100%);
+    white-space: nowrap;
+    will-change: transform;
+}
+
+@keyframes ap-marquee-scroll {
+    from {
+        transform: translateX(100%);
+    }
+    to {
+        transform: translateX(-100%);
+    }
+}

--- a/resources/js/visual-editor/blocks/marquee/save.tsx
+++ b/resources/js/visual-editor/blocks/marquee/save.tsx
@@ -1,0 +1,66 @@
+/**
+ * Marquee — saved markup.
+ *
+ * Persists the same DOM shape the renderers emit so Gutenberg's
+ * save-vs-edit validator passes on reload and the `source: 'html',
+ * selector: 'p'` parser round-trips `marqueeContent` correctly. The
+ * frontend renderers (Blade, React, Vue) output the serialized HTML
+ * verbatim; the host application is responsible for shipping the
+ * matching `.ap-marquee` stylesheet (it ships in `marquee.css`).
+ */
+
+import type { CSSProperties, ReactElement } from 'react';
+import { RichText, useBlockProps } from '@wordpress/block-editor';
+
+interface MarqueeAttributes {
+    readonly marqueeContent: string;
+    readonly marqueeWidth: number;
+    readonly marqueeSpeed: number;
+}
+
+interface MarqueeSaveProps {
+    readonly attributes: MarqueeAttributes;
+}
+
+function clampPercent(value: number | null | undefined, fallback: number): number {
+    if (typeof value !== 'number' || !Number.isFinite(value)) {
+        return fallback;
+    }
+    return Math.min(100, Math.max(1, Math.round(value)));
+}
+
+function clampSpeed(value: number | null | undefined, fallback: number): number {
+    if (typeof value !== 'number' || !Number.isFinite(value)) {
+        return fallback;
+    }
+    return Math.min(100, Math.max(1, Math.round(value)));
+}
+
+export default function MarqueeSave({
+    attributes,
+}: MarqueeSaveProps): ReactElement {
+    const { marqueeContent, marqueeWidth, marqueeSpeed } = attributes;
+
+    const safeWidth = clampPercent(marqueeWidth, 100);
+    const safeSpeed = clampSpeed(marqueeSpeed, 5);
+
+    const blockProps = useBlockProps.save({
+        className: 'ap-marquee',
+        style: { width: `${safeWidth}%` } as CSSProperties,
+    });
+
+    const textStyle: CSSProperties = {
+        animation: `ap-marquee-scroll ${safeSpeed}s linear infinite`,
+    };
+
+    return (
+        <div {...blockProps}>
+            <RichText.Content
+                tagName="p"
+                className="ap-marquee__text"
+                value={marqueeContent}
+                style={textStyle}
+            />
+        </div>
+    );
+}

--- a/resources/js/visual-editor/blocks/marquee/save.tsx
+++ b/resources/js/visual-editor/blocks/marquee/save.tsx
@@ -12,6 +12,8 @@
 import type { CSSProperties, ReactElement } from 'react';
 import { RichText, useBlockProps } from '@wordpress/block-editor';
 
+import { clampPercent, clampSpeed } from './clamp';
+
 interface MarqueeAttributes {
     readonly marqueeContent: string;
     readonly marqueeWidth: number;
@@ -22,27 +24,13 @@ interface MarqueeSaveProps {
     readonly attributes: MarqueeAttributes;
 }
 
-function clampPercent(value: number | null | undefined, fallback: number): number {
-    if (typeof value !== 'number' || !Number.isFinite(value)) {
-        return fallback;
-    }
-    return Math.min(100, Math.max(1, Math.round(value)));
-}
-
-function clampSpeed(value: number | null | undefined, fallback: number): number {
-    if (typeof value !== 'number' || !Number.isFinite(value)) {
-        return fallback;
-    }
-    return Math.min(100, Math.max(1, Math.round(value)));
-}
-
 export default function MarqueeSave({
     attributes,
 }: MarqueeSaveProps): ReactElement {
     const { marqueeContent, marqueeWidth, marqueeSpeed } = attributes;
 
-    const safeWidth = clampPercent(marqueeWidth, 100);
-    const safeSpeed = clampSpeed(marqueeSpeed, 5);
+    const safeWidth = clampPercent(marqueeWidth);
+    const safeSpeed = clampSpeed(marqueeSpeed);
 
     const blockProps = useBlockProps.save({
         className: 'ap-marquee',

--- a/resources/js/visual-editor/editor/__tests__/canvas-styles.test.ts
+++ b/resources/js/visual-editor/editor/__tests__/canvas-styles.test.ts
@@ -33,12 +33,12 @@ describe('canvasStyles', () => {
         // token bridge + components + block-editor (style + content)
         // + block-library (style + editor) + LAYOUT_BASELINE
         // + accordion + tabs + editor-tweaks (interactive blocks; #497)
-        // + grid (#498) + DEFAULT_CANVAS_STYLES + ALIGNMENT_OVERRIDE_STYLES
-        // + POST_EDITOR_FRAMING_STYLES (Keystone #47 — site-editor
-        // canvases skip the framing entry but keep the alignment
-        // overrides so the wide/full toolbar buttons take effect
-        // there too).
-        expect(canvasStyles).toHaveLength(14);
+        // + grid (#498) + marquee (#500) + DEFAULT_CANVAS_STYLES
+        // + ALIGNMENT_OVERRIDE_STYLES + POST_EDITOR_FRAMING_STYLES
+        // (Keystone #47 — site-editor canvases skip the framing entry
+        // but keep the alignment overrides so the wide/full toolbar
+        // buttons take effect there too).
+        expect(canvasStyles).toHaveLength(15);
     });
 
     it('places DEFAULT_CANVAS_STYLES before POST_EDITOR_FRAMING_STYLES so the framing wins the cascade', () => {

--- a/resources/js/visual-editor/editor/canvas-styles.ts
+++ b/resources/js/visual-editor/editor/canvas-styles.ts
@@ -36,6 +36,7 @@ import {
 
 import accordionStyles from '../blocks/accordion/accordion.css?inline';
 import gridStyles from '../blocks/grid/grid.css?inline';
+import marqueeStyles from '../blocks/marquee/marquee.css?inline';
 import tabsStyles from '../blocks/tabs/tabs.css?inline';
 
 import canvasThemeTokens from './canvas-theme-tokens.css?inline';
@@ -114,6 +115,10 @@ export const canvasStyles: readonly CanvasStyle[] = [
     // accordion/tabs above. Ship the rules here so authors get an
     // accurate preview of the responsive column layout.
     { css: gridStyles },
+    // Marquee block (#500) — keyframes + wrapper baseline. Same
+    // iframe-isolation story: the per-block import in
+    // `blocks/marquee/index.ts` lands in the parent document only.
+    { css: marqueeStyles },
     {
         css: `
             /* Editor preview overrides — keep every panel and tab
@@ -147,6 +152,13 @@ export const canvasStyles: readonly CanvasStyle[] = [
                front-end. */
             .ap-accordion__body .block-editor-block-list__block,
             .ap-tab-section .block-editor-block-list__block { margin-top: 0; margin-bottom: 0; }
+
+            /* Marquee (#500) — the front-end CSS translates the text
+               off-screen and the renderers' inline animation slides it
+               back. The editor preview drops the animation so authors
+               can edit the RichText without it scrolling out from under
+               their cursor; pin the text in place so it's readable. */
+            .ap-marquee__text { transform: none !important; white-space: normal !important; }
         `,
     },
     { css: DEFAULT_CANVAS_STYLES },

--- a/src/Resources/PostResolver.php
+++ b/src/Resources/PostResolver.php
@@ -77,6 +77,10 @@ class PostResolver
 		'artisanpack/post-comments-link',
 		'artisanpack/post-comments-title',
 		'artisanpack/post-comments-form',
+		// Site-chrome comments-number block (#500). Reuses the
+		// existing `_resolvedCommentCount` stamp — the renderer
+		// combines it with the saved singular / plural labels.
+		'artisanpack/comments-number',
 		// Post navigation / metadata family forks (#520) — same `_resolved*`
 		// contract, new namespace. `term-description` is archive-context
 		// only, but we stamp the post's primary-term description on it so
@@ -216,7 +220,8 @@ class PostResolver
 			'avatar'                  => $this->resolveAuthor( $post ),
 			'post-featured-image'     => $this->resolveFeaturedImage( $post ),
 			'post-comments-form'      => $this->resolveCommentsForm( $post ),
-			'post-comments-count'     => $this->resolveCommentsCount( $post ),
+			'post-comments-count',
+			'comments-number'         => $this->resolveCommentsCount( $post ),
 			'post-comments-link'      => $this->resolveCommentsLink( $post ),
 			'post-comments-title'     => $this->resolveCommentsTitle( $post ),
 			'post-navigation-link'    => $this->resolvePostNavigationLink( $post ),

--- a/tests/Unit/VisualEditor/Resources/PostResolverTest.php
+++ b/tests/Unit/VisualEditor/Resources/PostResolverTest.php
@@ -197,6 +197,33 @@ it( 'stamps post-comments-count as zero when no count or collection is exposed',
 	expect( $resolved['attributes']['_resolvedCommentCount'] )->toBe( 0 );
 } );
 
+it( 'stamps artisanpack/comments-number with the resolved count from comments_count accessor', function () {
+	$resolved = ( new PostResolver() )->stampBlock(
+		[
+			'name'        => 'artisanpack/comments-number',
+			'attributes'  => [
+				'singularCommentText' => 'Reply',
+				'pluralCommentText'   => 'Replies',
+			],
+			'innerBlocks' => [],
+		],
+		fakePost( [ 'comments_count' => 4 ] )
+	);
+
+	expect( $resolved['attributes']['_resolvedCommentCount'] )->toBe( 4 )
+		->and( $resolved['attributes']['singularCommentText'] )->toBe( 'Reply' )
+		->and( $resolved['attributes']['pluralCommentText'] )->toBe( 'Replies' );
+} );
+
+it( 'stamps artisanpack/comments-number as zero when the post exposes neither count nor collection', function () {
+	$resolved = ( new PostResolver() )->stampBlock(
+		[ 'name' => 'artisanpack/comments-number', 'attributes' => [], 'innerBlocks' => [] ],
+		fakePost( [ 'comments_count' => null ] )
+	);
+
+	expect( $resolved['attributes']['_resolvedCommentCount'] )->toBe( 0 );
+} );
+
 it( 'stamps post-comments-link with permalink anchor when no explicit URL is set', function () {
 	$resolved = ( new PostResolver() )->stampBlock(
 		[ 'name' => 'core/post-comments-link', 'attributes' => [], 'innerBlocks' => [] ],


### PR DESCRIPTION
## Description

Adds three site-wide chrome blocks under the `artisanpack/*` namespace:

- **`artisanpack/copyright`** (dynamic) — `©` + configurable text + current year, with three display modes (`icon-text` / `icon-only` / `text-only`). Year is read at render time on every renderer so the line stays accurate without a rebuild.
- **`artisanpack/marquee`** (static) — RichText body wrapped in a sized `<div>`. The renderers emit an inline `animation: ap-marquee-scroll Ns linear infinite` declaration that drives the keyframe shipped in the new `frontend/marquee.css` asset; the editor preview drops the animation so authors can edit the text without it scrolling under their cursor.
- **`artisanpack/comments-number`** (dynamic) — `<count> <singular|plural>` line. `PostResolver` stamps `_resolvedCommentCount` (reusing the existing branch shared with `post-comments-count`), and the renderers pick the singular or plural label by count.

**Closes:** #500

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #500

## Motivation and Context

Site-chrome cluster of the umbrella block-port effort (#495). Each block ships under the `artisanpack/*` namespace with full Blade + React + Vue renderer parity. None of the three upstream blocks carried transforms, so none are added here.

## Changes Made

- 3 new editor blocks under `resources/js/visual-editor/blocks/{copyright,marquee,comments-number}/` (block.json, edit.tsx, save.tsx, index.ts, inserter-icon.tsx; marquee adds `marquee.css`).
- 3 new Blade partials under `packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/`.
- 3 new React renderers under `packages/visual-editor-renderer-react/src/blocks/artisanpack/` (`copyright.tsx`, `marquee.tsx`, `commentsNumber.tsx`) wired into `registerCoreBlocks`.
- 3 new Vue renderers under `packages/visual-editor-renderer-vue/src/blocks/artisanpack/` wired into `registerCoreBlocks`.
- `PostResolver` now lists `artisanpack/comments-number` in `SUPPORTED_BLOCKS` and routes it through `resolveCommentsCount()` alongside `post-comments-count`.
- New `frontend/marquee.css` ships through `<x-ve-blocks-styles />` (new `marqueeStyleHref` + `data-ve-marquee` link tag), so consumers ship the keyframes alongside the existing accordion / tabs / grid bundles.
- `canvas-styles.ts` imports the marquee stylesheet into the editor iframe and adds a small `.ap-marquee__text { transform: none; white-space: normal }` override so the editor renders the text statically.
- `renderer-parity.json` extended with the three new block names; the parity verifier confirms all 140 blocks register in all three renderers.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS
- Browser (if applicable): manual smoke test in the dev-app editor + Blade preview page
- PHP Version: 8.4
- Project Version: branch `feature/500-site-chrome-blocks` off `feature/495-port-crosswinds-blocks`

**Tests Performed:**
1. `npx vitest run` — 1972 tests pass (added 9 to `site-chrome-family.test.ts` + 9 React + 9 Vue renderer tests).
2. `./vendor/bin/pest` — 1062 tests pass (added 8 Blade renderer tests + 2 PostResolver stamping tests + 1 BlocksStyles emission test; 2 unrelated pre-existing FA Icons failures remain on this branch's parent commit).
3. `node scripts/verify-renderer-parity.mjs` — all 140 blocks registered across blade / react / vue.
4. `npm run build` — Vite build succeeds.
5. Manual: inserted each block in the editor, edited attributes, saved, reloaded — saved markup round-trips. Marquee scrolls correctly on the public Blade preview page after `vendor:publish --tag=visual-editor-renderer-blade-assets`.

## Accessibility Tests Run

- [x] Keyboard navigation tested
- [x] Color contrast verified

**Details:** Marquee is decorative chrome; the inline animation is the only motion concern and the keyframe ships in a separate stylesheet so prefers-reduced-motion can be layered on top later. Comments number and copyright are plain `<p>` text.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:** 9 family-contract tests, 18 renderer tests (9 React + 9 Vue), 8 Blade renderer tests, 2 PostResolver stamping tests, 1 BlocksStyles emission test.

## Documentation

- [x] Inline code documentation added

**Documentation details:** Each new file ships a brief docblock describing its role and the contract with the sibling renderers.

## Pre-Submission Checklist

- [x] Code passes all tests
- [x] Self-review completed
- [x] Comments added for complex code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Copyright, Marquee, and Comments Number blocks (icon/text modes, configurable marquee width/speed, customizable comment labels).
* **Editor & Styling**
  * Marquee styling and animation added to the editor canvas; inspector controls and inserter icons for new blocks; respects reduced-motion preferences.
* **Behavior**
  * Comment count now resolves server-side and displays live counts; copyright year computed at render time.
* **Tests**
  * Expanded test coverage across renderers and editor for all new blocks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->