### PR TITLE
feat: port crosswinds search cluster (#502)

### DIFF
--- a/packages/renderer-parity.json
+++ b/packages/renderer-parity.json
@@ -145,6 +145,12 @@
         "artisanpack/single-content",
         "artisanpack/related-posts",
         "artisanpack/author-social-icons",
-        "artisanpack/social-share-content"
+        "artisanpack/social-share-content",
+        "artisanpack/search-field",
+        "artisanpack/search-filters",
+        "artisanpack/search-filters-buttons",
+        "artisanpack/search-filters-taxonomy",
+        "artisanpack/post-types-search-results",
+        "artisanpack/single-post-types-search-results"
     ]
 }

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/post-types-search-results.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/post-types-search-results.blade.php
@@ -1,0 +1,12 @@
+{{--
+	artisanpack/post-types-search-results — parent wrapper (#502).
+
+	Each child decides whether to emit anything based on the current
+	`?post_type=` request, so the parent just owns the wrapper div.
+--}}
+@php
+	use ArtisanPackUI\VisualEditorRendererBlade\Support\BlockSupports;
+@endphp
+<div{!! BlockSupports::wrapperAttrs( $attributes, [ 'ap-post-types-search-results' ] ) !!}>
+	{!! $innerBlocksHtml !!}
+</div>

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/query-pagination.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/query-pagination.blade.php
@@ -2,7 +2,13 @@
 	use ArtisanPackUI\VisualEditorRendererBlade\Support\BlockSupports;
 @endphp
 {{-- artisanpack/query-pagination — Phase I-Block-Fork query family (#521).
-	Pagination wrapper around the next / numbers / previous children. --}}
-<nav{!! BlockSupports::wrapperAttrs( $attributes, [ 'wp-block-query-pagination' ] ) !!} aria-label="{{ __( 'Pagination' ) }}">
+	Pagination wrapper around the next / numbers / previous children.
+
+	Translation key intentionally avoids the bare word "Pagination":
+	Laravel ships `vendor/laravel/framework/src/Illuminate/Translation/lang/en/pagination.php`
+	which the JSON translator's case-insensitive fallback matches on
+	`__( 'Pagination' )`, returning the file's array (`previous` /
+	`next`) instead of a string and crashing `e()` downstream. --}}
+<nav{!! BlockSupports::wrapperAttrs( $attributes, [ 'wp-block-query-pagination' ] ) !!} aria-label="{{ __( 'Pagination navigation' ) }}">
 	{!! $innerBlocksHtml !!}
 </nav>

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/search-field.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/search-field.blade.php
@@ -1,0 +1,41 @@
+{{--
+	artisanpack/search-field — search input shell (#502).
+
+	Reads `_resolvedSearchValue` (the current `?s=` value) when stamped by
+	the host pipeline, otherwise falls back to the live request. The
+	`name="s"` keeps the form posting back through the host's existing
+	search route.
+--}}
+@php
+	use ArtisanPackUI\VisualEditorRendererBlade\Support\BlockSupports;
+
+	$label       = (string) ( $attributes['label'] ?? 'Search' );
+	$placeholder = (string) ( $attributes['placeholder'] ?? 'Search …' );
+
+	$searchValue = '';
+	if ( array_key_exists( '_resolvedSearchValue', $attributes ) ) {
+		$searchValue = is_scalar( $attributes['_resolvedSearchValue'] )
+			? (string) $attributes['_resolvedSearchValue']
+			: '';
+	} elseif ( function_exists( 'request' ) ) {
+		$rawValue    = request()->query( 's', '' );
+		$searchValue = is_scalar( $rawValue ) ? (string) $rawValue : '';
+	}
+
+	// Hash via json_encode rather than serialize: `serialize()` throws
+	// on objects (closures, resources) that a host might smuggle into
+	// the attributes envelope. `json_encode` drops what it can't encode
+	// and still yields a stable suffix for the id.
+	$inputId = 'ap-search-field-' . substr( md5( (string) json_encode( $attributes ) ), 0, 8 );
+@endphp
+<div{!! BlockSupports::wrapperAttrs( $attributes, [ 'ap-search-field' ] ) !!}>
+	<label class="ap-search-field__label" for="{{ $inputId }}">{{ $label }}</label>
+	<input
+		type="search"
+		class="ap-search-field__input"
+		id="{{ $inputId }}"
+		name="s"
+		value="{{ $searchValue }}"
+		placeholder="{{ $placeholder }}"
+	/>
+</div>

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/search-filters-buttons.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/search-filters-buttons.blade.php
@@ -1,0 +1,21 @@
+{{--
+	artisanpack/search-filters-buttons — submit + reset pair (#502).
+--}}
+@php
+	use ArtisanPackUI\VisualEditorRendererBlade\Support\BlockSupports;
+
+	$searchLabel = (string) ( $attributes['searchLabel'] ?? 'Search' );
+	$clearLabel  = (string) ( $attributes['clearLabel'] ?? 'Clear' );
+@endphp
+<div{!! BlockSupports::wrapperAttrs( $attributes, [ 'ap-search-filters-buttons' ] ) !!}>
+	<input
+		type="submit"
+		class="ap-search-filters-buttons__submit"
+		value="{{ $searchLabel }}"
+	/>
+	<input
+		type="reset"
+		class="ap-search-filters-buttons__reset"
+		value="{{ $clearLabel }}"
+	/>
+</div>

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/search-filters-buttons.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/search-filters-buttons.blade.php
@@ -4,8 +4,8 @@
 @php
 	use ArtisanPackUI\VisualEditorRendererBlade\Support\BlockSupports;
 
-	$searchLabel = (string) ( $attributes['searchLabel'] ?? 'Search' );
-	$clearLabel  = (string) ( $attributes['clearLabel'] ?? 'Clear' );
+	$searchLabel = (string) ( $attributes['searchLabel'] ?? __( 'Search' ) );
+	$clearLabel  = (string) ( $attributes['clearLabel'] ?? __( 'Clear' ) );
 @endphp
 <div{!! BlockSupports::wrapperAttrs( $attributes, [ 'ap-search-filters-buttons' ] ) !!}>
 	<input

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/search-filters-taxonomy.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/search-filters-taxonomy.blade.php
@@ -18,7 +18,13 @@
 	$label        = (string) ( $attributes['label'] ?? 'Choose' );
 	$taxonomy     = strtolower( (string) ( $attributes['taxonomy'] ?? 'category' ) );
 	$taxonomy     = preg_replace( '/[^a-z0-9_-]/', '', $taxonomy );
-	$taxonomyName = (string) ( $attributes['taxonomyName'] ?? 'Category' );
+	// Derive `$taxonomyName` from the sanitized slug when the author has
+	// not supplied an explicit display name. Title-cases the slug parts
+	// (`post_tag` → `Post Tag`) so the placeholder option reads
+	// correctly regardless of which taxonomy the block points at.
+	$taxonomyName = isset( $attributes['taxonomyName'] ) && '' !== (string) $attributes['taxonomyName']
+		? (string) $attributes['taxonomyName']
+		: ucwords( str_replace( [ '-', '_' ], ' ', $taxonomy ) );
 
 	$termsRaw = $attributes['_resolvedTerms'] ?? null;
 	$terms    = [];
@@ -75,7 +81,14 @@
 		$selectedTerm = is_scalar( $raw ) ? (string) $raw : '';
 	}
 
-	$selectId = 'ap-search-filters-taxonomy-' . $taxonomy;
+	// Suffix the id with a deterministic hash of the block's attributes
+	// so the same template instance always lands on the same id (stable
+	// for SSR + hydration) while two instances pointing at the same
+	// taxonomy on the same page get distinct ids — the latter being
+	// the actual a11y concern when label `for=` references would
+	// otherwise collide.
+	$selectIdSuffix = substr( md5( (string) json_encode( $attributes ) ), 0, 8 );
+	$selectId       = 'ap-search-filters-taxonomy-' . $taxonomy . '-' . $selectIdSuffix;
 @endphp
 <div{!! BlockSupports::wrapperAttrs( $attributes, [ 'ap-search-filters-taxonomy' ] ) !!}>
 	<label class="ap-search-filters-taxonomy__label" for="{{ $selectId }}">{{ $label }}</label>

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/search-filters-taxonomy.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/search-filters-taxonomy.blade.php
@@ -1,0 +1,93 @@
+{{--
+	artisanpack/search-filters-taxonomy — labelled `<select>` (#502).
+
+	Reads `_resolvedTerms` (a list of `{ slug, name }` records) stamped
+	by the host pipeline and pre-selects the term named in the current
+	request's `?{taxonomy}=` parameter via `_resolvedSelectedTerm`. When
+	the host has not stamped a term list we fall back to a direct
+	cms-framework lookup so the dropdown still populates against
+	`category` + `post_tag` (the two taxonomies cms-framework ships).
+	Unknown taxonomies render with just the placeholder option so the
+	form stays usable.
+--}}
+@php
+	use ArtisanPackUI\CMSFramework\Modules\Blog\Models\PostCategory;
+	use ArtisanPackUI\CMSFramework\Modules\Blog\Models\PostTag;
+	use ArtisanPackUI\VisualEditorRendererBlade\Support\BlockSupports;
+
+	$label        = (string) ( $attributes['label'] ?? 'Choose' );
+	$taxonomy     = strtolower( (string) ( $attributes['taxonomy'] ?? 'category' ) );
+	$taxonomy     = preg_replace( '/[^a-z0-9_-]/', '', $taxonomy );
+	$taxonomyName = (string) ( $attributes['taxonomyName'] ?? 'Category' );
+
+	$termsRaw = $attributes['_resolvedTerms'] ?? null;
+	$terms    = [];
+
+	if ( is_array( $termsRaw ) ) {
+		foreach ( $termsRaw as $term ) {
+			if ( ! is_array( $term ) ) {
+				continue;
+			}
+			$slug = isset( $term['slug'] ) ? (string) $term['slug'] : '';
+			$name = isset( $term['name'] ) ? (string) $term['name'] : '';
+			if ( '' === $slug || '' === $name ) {
+				continue;
+			}
+			$terms[] = [ 'slug' => $slug, 'name' => $name ];
+		}
+	} elseif ( '' !== $taxonomy ) {
+		// Fallback: pull terms directly from cms-framework when the host
+		// has not stamped a `_resolvedTerms` envelope. Quiet about errors
+		// so a host that has not installed cms-framework still gets the
+		// placeholder shell instead of a 500.
+		$taxonomyModel = match ( $taxonomy ) {
+			'category', 'categories', 'post_category' => PostCategory::class,
+			'tag', 'tags', 'post_tag'                 => PostTag::class,
+			default                                   => null,
+		};
+
+		if ( null !== $taxonomyModel && class_exists( $taxonomyModel ) ) {
+			try {
+				$terms = $taxonomyModel::query()
+					->orderBy( 'name' )
+					->get( [ 'slug', 'name' ] )
+					->map( static fn ( $row ): array => [
+						'slug' => (string) $row->slug,
+						'name' => (string) $row->name,
+					] )
+					->filter( static fn ( array $t ): bool => '' !== $t['slug'] && '' !== $t['name'] )
+					->values()
+					->all();
+			} catch ( \Throwable $e ) {
+				report( $e );
+				$terms = [];
+			}
+		}
+	}
+
+	$selectedTerm = '';
+	if ( array_key_exists( '_resolvedSelectedTerm', $attributes ) ) {
+		$selectedTerm = is_scalar( $attributes['_resolvedSelectedTerm'] )
+			? (string) $attributes['_resolvedSelectedTerm']
+			: '';
+	} elseif ( '' !== $taxonomy && function_exists( 'request' ) ) {
+		$raw          = request()->query( $taxonomy, '' );
+		$selectedTerm = is_scalar( $raw ) ? (string) $raw : '';
+	}
+
+	$selectId = 'ap-search-filters-taxonomy-' . $taxonomy;
+@endphp
+<div{!! BlockSupports::wrapperAttrs( $attributes, [ 'ap-search-filters-taxonomy' ] ) !!}>
+	<label class="ap-search-filters-taxonomy__label" for="{{ $selectId }}">{{ $label }}</label>
+	<select
+		class="ap-search-filters-taxonomy__select"
+		id="{{ $selectId }}"
+		name="{{ $taxonomy }}"
+	>
+		<option value="">{{ __( 'Select a' ) }} {{ $taxonomyName }}</option>
+		@foreach ( $terms as $term )
+			@php $isSelected = $term['slug'] === $selectedTerm; @endphp
+			<option value="{{ $term['slug'] }}"{!! $isSelected ? ' selected' : '' !!}>{{ $term['name'] }}</option>
+		@endforeach
+	</select>
+</div>

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/search-filters.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/search-filters.blade.php
@@ -1,0 +1,36 @@
+{{--
+	artisanpack/search-filters — GET form wrapper (#502).
+
+	Drops a `<form method="get">` around the inner filter controls and
+	pins them to a single post type via a hidden `post_type` input. The
+	host's stamped `_resolvedFormAction` (or the live request base URL)
+	provides the form's action URL so the form posts back to the site
+	root by default.
+--}}
+@php
+	use ArtisanPackUI\VisualEditorRendererBlade\Support\BlockSupports;
+	use ArtisanPackUI\VisualEditorRendererBlade\Support\UrlSanitizer;
+
+	$postType = strtolower( (string) ( $attributes['postType'] ?? 'post' ) );
+	$postType = preg_replace( '/[^a-z0-9_-]/', '', $postType );
+
+	$rawAction = '';
+	if ( array_key_exists( '_resolvedFormAction', $attributes ) ) {
+		$rawAction = is_scalar( $attributes['_resolvedFormAction'] )
+			? (string) $attributes['_resolvedFormAction']
+			: '';
+	} elseif ( function_exists( 'url' ) ) {
+		$rawAction = url( '/' );
+	}
+	$action = UrlSanitizer::safe( $rawAction );
+
+	if ( '' === $action ) {
+		$action = '/';
+	}
+@endphp
+<div{!! BlockSupports::wrapperAttrs( $attributes, [ 'ap-search-filters' ] ) !!}>
+	<form class="ap-search-filters__form" method="get" action="{{ $action }}">
+		<input type="hidden" name="post_type" value="{{ $postType }}" />
+		{!! $innerBlocksHtml !!}
+	</form>
+</div>

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/single-post-types-search-results.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/single-post-types-search-results.blade.php
@@ -21,6 +21,11 @@
 			$raw       = request()->query( 'post_type', null );
 			$requested = is_scalar( $raw ) ? (string) $raw : '';
 		}
+		// Normalize the incoming query value the same way the saved
+		// `$postType` was sanitized so a request for `?post_type=Post`
+		// still matches a block configured for `post`.
+		$requested = strtolower( $requested );
+		$requested = preg_replace( '/[^a-z0-9_-]/', '', $requested );
 
 		if ( '' === $requested ) {
 			$isActive = 'all' === $postType;

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/single-post-types-search-results.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/single-post-types-search-results.blade.php
@@ -1,0 +1,36 @@
+{{--
+	artisanpack/single-post-types-search-results — conditional section (#502).
+
+	Emits the wrapper + inner blocks only when the section applies to the
+	current request. The host can short-circuit the request lookup by
+	stamping `_resolvedActive` as a boolean. Otherwise the renderer
+	matches the configured `postType` against `?post_type=…`, treating
+	the value `all` as the no-parameter case.
+--}}
+@php
+	use ArtisanPackUI\VisualEditorRendererBlade\Support\BlockSupports;
+
+	$postType = strtolower( (string) ( $attributes['postType'] ?? 'all' ) );
+	$postType = preg_replace( '/[^a-z0-9_-]/', '', $postType );
+
+	if ( array_key_exists( '_resolvedActive', $attributes ) ) {
+		$isActive = (bool) $attributes['_resolvedActive'];
+	} else {
+		$requested = '';
+		if ( function_exists( 'request' ) ) {
+			$raw       = request()->query( 'post_type', null );
+			$requested = is_scalar( $raw ) ? (string) $raw : '';
+		}
+
+		if ( '' === $requested ) {
+			$isActive = 'all' === $postType;
+		} else {
+			$isActive = $requested === $postType;
+		}
+	}
+@endphp
+@if ( $isActive )
+	<div{!! BlockSupports::wrapperAttrs( $attributes, [ 'ap-single-post-types-search-results' ] ) !!}>
+		{!! $innerBlocksHtml !!}
+	</div>
+@endif

--- a/packages/visual-editor-renderer-react/src/blocks/artisanpack/queryContext.tsx
+++ b/packages/visual-editor-renderer-react/src/blocks/artisanpack/queryContext.tsx
@@ -28,7 +28,7 @@ export function QueryPaginationBlock({ attributes, children }: BlockRendererProp
     const classes = classList(['wp-block-query-pagination', className]);
 
     return (
-        <nav className={classes} aria-label="Pagination">
+        <nav className={classes} aria-label="Pagination navigation">
             {children}
         </nav>
     );

--- a/packages/visual-editor-renderer-react/src/blocks/artisanpack/searchCluster.tsx
+++ b/packages/visual-editor-renderer-react/src/blocks/artisanpack/searchCluster.tsx
@@ -1,0 +1,195 @@
+/**
+ * React renderers for the search cluster (#502).
+ *
+ * Mirrors the Blade partials and Vue components so every renderer emits
+ * identical markup. The blocks share a common contract: anything that
+ * depends on the live request — the current `?s=` keyword, the
+ * `?taxonomy=` selection, the `?post_type=` filter — arrives on the
+ * attributes as a `_resolved*` stamp, so the React + Vue renderers stay
+ * purely declarative.
+ */
+
+import { type JSX, type ReactNode } from 'react';
+
+import {
+    attrArray,
+    attrBoolean,
+    attrString,
+    classList,
+} from '../../support/attributes';
+import { safeUrl } from '../../support/urlSanitizer';
+import type { BlockRendererProps } from '../../types';
+
+const SLUG_PATTERN = /[^a-z0-9_-]/gi;
+
+function sanitizeSlug(value: unknown, fallback: string): string {
+    const raw = attrString(value, fallback).replace(SLUG_PATTERN, '').toLowerCase();
+    return raw === '' ? fallback.toLowerCase() : raw;
+}
+
+function shortHash(value: string): string {
+    let hash = 0;
+    for (let i = 0; i < value.length; i++) {
+        hash = (hash * 31 + value.charCodeAt(i)) | 0;
+    }
+    return (hash >>> 0).toString(16).padStart(8, '0').slice(0, 8);
+}
+
+interface TaxonomyTerm {
+    readonly slug: string;
+    readonly name: string;
+}
+
+function normalizeTerms(value: unknown): ReadonlyArray<TaxonomyTerm> {
+    const terms: TaxonomyTerm[] = [];
+    for (const entry of attrArray(value)) {
+        if (entry === null || typeof entry !== 'object') {
+            continue;
+        }
+        const record = entry as Record<string, unknown>;
+        const slug = attrString(record.slug);
+        const name = attrString(record.name);
+        if (slug === '' || name === '') {
+            continue;
+        }
+        terms.push({ slug, name });
+    }
+    return terms;
+}
+
+export function SearchFieldBlock({ attributes }: BlockRendererProps): JSX.Element {
+    const label = attrString(attributes.label, 'Search');
+    const placeholder = attrString(attributes.placeholder, 'Search …');
+    const searchValue = attrString(attributes._resolvedSearchValue);
+    const className = attrString(attributes.className);
+
+    const classes = classList(['ap-search-field', className]);
+    const inputId = `ap-search-field-${shortHash(
+        `${label}|${placeholder}|${searchValue}`
+    )}`;
+
+    return (
+        <div className={classes}>
+            <label className="ap-search-field__label" htmlFor={inputId}>
+                {label}
+            </label>
+            <input
+                type="search"
+                className="ap-search-field__input"
+                id={inputId}
+                name="s"
+                defaultValue={searchValue}
+                placeholder={placeholder}
+            />
+        </div>
+    );
+}
+
+export function SearchFiltersBlock({
+    attributes,
+    children,
+}: BlockRendererProps): JSX.Element {
+    const postType = sanitizeSlug(attributes.postType, 'post');
+    const action = safeUrl(attrString(attributes._resolvedFormAction, '/')) || '/';
+    const className = attrString(attributes.className);
+
+    const classes = classList(['ap-search-filters', className]);
+
+    return (
+        <div className={classes}>
+            <form className="ap-search-filters__form" method="get" action={action}>
+                <input type="hidden" name="post_type" value={postType} />
+                {children}
+            </form>
+        </div>
+    );
+}
+
+export function SearchFiltersButtonsBlock({
+    attributes,
+}: BlockRendererProps): JSX.Element {
+    const searchLabel = attrString(attributes.searchLabel, 'Search');
+    const clearLabel = attrString(attributes.clearLabel, 'Clear');
+    const className = attrString(attributes.className);
+
+    const classes = classList(['ap-search-filters-buttons', className]);
+
+    return (
+        <div className={classes}>
+            <input
+                type="submit"
+                className="ap-search-filters-buttons__submit"
+                value={searchLabel}
+            />
+            <input
+                type="reset"
+                className="ap-search-filters-buttons__reset"
+                value={clearLabel}
+            />
+        </div>
+    );
+}
+
+export function SearchFiltersTaxonomyBlock({
+    attributes,
+}: BlockRendererProps): JSX.Element {
+    const label = attrString(attributes.label, 'Choose');
+    const taxonomy = sanitizeSlug(attributes.taxonomy, 'category');
+    const taxonomyName = attrString(attributes.taxonomyName, 'Category');
+    const className = attrString(attributes.className);
+
+    const terms = normalizeTerms(attributes._resolvedTerms);
+    const selectedTerm = attrString(attributes._resolvedSelectedTerm);
+
+    const classes = classList(['ap-search-filters-taxonomy', className]);
+    const selectId = `ap-search-filters-taxonomy-${taxonomy}`;
+
+    return (
+        <div className={classes}>
+            <label
+                className="ap-search-filters-taxonomy__label"
+                htmlFor={selectId}
+            >
+                {label}
+            </label>
+            <select
+                className="ap-search-filters-taxonomy__select"
+                id={selectId}
+                name={taxonomy}
+                defaultValue={selectedTerm}
+            >
+                <option value="">Select a {taxonomyName}</option>
+                {terms.map((term) => (
+                    <option key={term.slug} value={term.slug}>
+                        {term.name}
+                    </option>
+                ))}
+            </select>
+        </div>
+    );
+}
+
+export function PostTypesSearchResultsBlock({
+    attributes,
+    children,
+}: BlockRendererProps): JSX.Element {
+    const className = attrString(attributes.className);
+    const classes = classList(['ap-post-types-search-results', className]);
+
+    return <div className={classes}>{children}</div>;
+}
+
+export function SinglePostTypesSearchResultsBlock({
+    attributes,
+    children,
+}: BlockRendererProps): ReactNode {
+    const isActive = attrBoolean(attributes._resolvedActive, false);
+    if (!isActive) {
+        return null;
+    }
+
+    const className = attrString(attributes.className);
+    const classes = classList(['ap-single-post-types-search-results', className]);
+
+    return <div className={classes}>{children}</div>;
+}

--- a/packages/visual-editor-renderer-react/src/blocks/registerCoreBlocks.ts
+++ b/packages/visual-editor-renderer-react/src/blocks/registerCoreBlocks.ts
@@ -32,6 +32,14 @@ import {
 } from './artisanpack/postNavigation';
 import { AuthorSocialIconsBlock } from './artisanpack/authorSocialIcons';
 import { RelatedPostsBlock } from './artisanpack/relatedPosts';
+import {
+    PostTypesSearchResultsBlock,
+    SearchFieldBlock,
+    SearchFiltersBlock,
+    SearchFiltersButtonsBlock,
+    SearchFiltersTaxonomyBlock,
+    SinglePostTypesSearchResultsBlock,
+} from './artisanpack/searchCluster';
 import { SingleContentBlock } from './artisanpack/singleContent';
 import { SocialShareContentBlock } from './artisanpack/socialShareContent';
 import {
@@ -310,6 +318,17 @@ const CORE_BLOCKS: Record<string, BlockRenderer> = {
     'artisanpack/related-posts': RelatedPostsBlock,
     'artisanpack/author-social-icons': AuthorSocialIconsBlock,
     'artisanpack/social-share-content': SocialShareContentBlock,
+    // Generic search cluster (#502) — registered under the
+    // artisanpack/* namespace only. Every request-time value
+    // (`?s=`, `?taxonomy=`, `?post_type=`) arrives via a
+    // `_resolved*` stamp so the renderers stay declarative.
+    'artisanpack/search-field': SearchFieldBlock,
+    'artisanpack/search-filters': SearchFiltersBlock,
+    'artisanpack/search-filters-buttons': SearchFiltersButtonsBlock,
+    'artisanpack/search-filters-taxonomy': SearchFiltersTaxonomyBlock,
+    'artisanpack/post-types-search-results': PostTypesSearchResultsBlock,
+    'artisanpack/single-post-types-search-results':
+        SinglePostTypesSearchResultsBlock,
 };
 
 export function registerCoreBlocks(): void {

--- a/packages/visual-editor-renderer-vue/src/blocks/artisanpack/queryContext.ts
+++ b/packages/visual-editor-renderer-vue/src/blocks/artisanpack/queryContext.ts
@@ -37,7 +37,7 @@ export const QueryPaginationBlock = defineComponent({
                 'nav',
                 {
                     class: classList(['wp-block-query-pagination', className]),
-                    'aria-label': 'Pagination',
+                    'aria-label': 'Pagination navigation',
                 },
                 slots.default?.()
             );

--- a/packages/visual-editor-renderer-vue/src/blocks/artisanpack/searchCluster.ts
+++ b/packages/visual-editor-renderer-vue/src/blocks/artisanpack/searchCluster.ts
@@ -1,0 +1,266 @@
+/**
+ * Vue renderers for the search cluster (#502).
+ *
+ * Mirrors the Blade partials and React components so every renderer
+ * emits identical markup. Every request-time value (`?s=`, `?taxonomy=`,
+ * `?post_type=`) arrives via a `_resolved*` stamp, so these components
+ * stay purely declarative.
+ */
+
+import { defineComponent, h, type VNode } from 'vue';
+
+import {
+    attrArray,
+    attrBoolean,
+    attrString,
+    classList,
+} from '../../support/attributes';
+import { safeUrl } from '../../support/urlSanitizer';
+import { blockRendererProps } from '../shared';
+
+const SLUG_PATTERN = /[^a-z0-9_-]/gi;
+
+function sanitizeSlug(value: unknown, fallback: string): string {
+    const raw = attrString(value, fallback).replace(SLUG_PATTERN, '').toLowerCase();
+    return raw === '' ? fallback.toLowerCase() : raw;
+}
+
+function shortHash(value: string): string {
+    let hash = 0;
+    for (let i = 0; i < value.length; i++) {
+        hash = (hash * 31 + value.charCodeAt(i)) | 0;
+    }
+    return (hash >>> 0).toString(16).padStart(8, '0').slice(0, 8);
+}
+
+interface TaxonomyTerm {
+    readonly slug: string;
+    readonly name: string;
+}
+
+function normalizeTerms(value: unknown): ReadonlyArray<TaxonomyTerm> {
+    const terms: TaxonomyTerm[] = [];
+    for (const entry of attrArray(value)) {
+        if (entry === null || typeof entry !== 'object') {
+            continue;
+        }
+        const record = entry as Record<string, unknown>;
+        const slug = attrString(record.slug);
+        const name = attrString(record.name);
+        if (slug === '' || name === '') {
+            continue;
+        }
+        terms.push({ slug, name });
+    }
+    return terms;
+}
+
+export const SearchFieldBlock = defineComponent({
+    name: 'SearchFieldBlock',
+    props: blockRendererProps,
+    setup(props) {
+        return (): VNode => {
+            const label = attrString(props.attributes.label, 'Search');
+            const placeholder = attrString(
+                props.attributes.placeholder,
+                'Search …'
+            );
+            const searchValue = attrString(props.attributes._resolvedSearchValue);
+            const className = attrString(props.attributes.className);
+
+            const classes = classList(['ap-search-field', className]);
+            const inputId = `ap-search-field-${shortHash(
+                `${label}|${placeholder}|${searchValue}`
+            )}`;
+
+            return h('div', { class: classes }, [
+                h(
+                    'label',
+                    { class: 'ap-search-field__label', for: inputId },
+                    label
+                ),
+                h('input', {
+                    type: 'search',
+                    class: 'ap-search-field__input',
+                    id: inputId,
+                    name: 's',
+                    placeholder,
+                    value: searchValue,
+                }),
+            ]);
+        };
+    },
+});
+
+export const SearchFiltersBlock = defineComponent({
+    name: 'SearchFiltersBlock',
+    props: blockRendererProps,
+    setup(props, { slots }) {
+        return (): VNode => {
+            const postType = sanitizeSlug(props.attributes.postType, 'post');
+            const action =
+                safeUrl(attrString(props.attributes._resolvedFormAction, '/')) ||
+                '/';
+            const className = attrString(props.attributes.className);
+
+            const classes = classList(['ap-search-filters', className]);
+
+            return h('div', { class: classes }, [
+                h(
+                    'form',
+                    {
+                        class: 'ap-search-filters__form',
+                        method: 'get',
+                        action,
+                    },
+                    [
+                        h('input', {
+                            type: 'hidden',
+                            name: 'post_type',
+                            value: postType,
+                        }),
+                        slots.default?.(),
+                    ]
+                ),
+            ]);
+        };
+    },
+});
+
+export const SearchFiltersButtonsBlock = defineComponent({
+    name: 'SearchFiltersButtonsBlock',
+    props: blockRendererProps,
+    setup(props) {
+        return (): VNode => {
+            const searchLabel = attrString(
+                props.attributes.searchLabel,
+                'Search'
+            );
+            const clearLabel = attrString(props.attributes.clearLabel, 'Clear');
+            const className = attrString(props.attributes.className);
+
+            const classes = classList(['ap-search-filters-buttons', className]);
+
+            return h('div', { class: classes }, [
+                h('input', {
+                    type: 'submit',
+                    class: 'ap-search-filters-buttons__submit',
+                    value: searchLabel,
+                }),
+                h('input', {
+                    type: 'reset',
+                    class: 'ap-search-filters-buttons__reset',
+                    value: clearLabel,
+                }),
+            ]);
+        };
+    },
+});
+
+export const SearchFiltersTaxonomyBlock = defineComponent({
+    name: 'SearchFiltersTaxonomyBlock',
+    props: blockRendererProps,
+    setup(props) {
+        return (): VNode => {
+            const label = attrString(props.attributes.label, 'Choose');
+            const taxonomy = sanitizeSlug(props.attributes.taxonomy, 'category');
+            const taxonomyName = attrString(
+                props.attributes.taxonomyName,
+                'Category'
+            );
+            const className = attrString(props.attributes.className);
+            const terms = normalizeTerms(props.attributes._resolvedTerms);
+            const selectedTerm = attrString(
+                props.attributes._resolvedSelectedTerm
+            );
+
+            const classes = classList(['ap-search-filters-taxonomy', className]);
+            const selectId = `ap-search-filters-taxonomy-${taxonomy}`;
+
+            const hasMatchingTerm = terms.some(
+                (term) => term.slug === selectedTerm
+            );
+            const placeholderSelected = !hasMatchingTerm;
+
+            const options: VNode[] = [
+                h(
+                    'option',
+                    {
+                        value: '',
+                        ...(placeholderSelected ? { selected: '' } : {}),
+                    },
+                    `Select a ${taxonomyName}`
+                ),
+                ...terms.map((term) =>
+                    h(
+                        'option',
+                        {
+                            value: term.slug,
+                            ...(term.slug === selectedTerm
+                                ? { selected: '' }
+                                : {}),
+                        },
+                        term.name
+                    )
+                ),
+            ];
+
+            return h('div', { class: classes }, [
+                h(
+                    'label',
+                    {
+                        class: 'ap-search-filters-taxonomy__label',
+                        for: selectId,
+                    },
+                    label
+                ),
+                h(
+                    'select',
+                    {
+                        class: 'ap-search-filters-taxonomy__select',
+                        id: selectId,
+                        name: taxonomy,
+                    },
+                    options
+                ),
+            ]);
+        };
+    },
+});
+
+export const PostTypesSearchResultsBlock = defineComponent({
+    name: 'PostTypesSearchResultsBlock',
+    props: blockRendererProps,
+    setup(props, { slots }) {
+        return (): VNode => {
+            const className = attrString(props.attributes.className);
+            const classes = classList([
+                'ap-post-types-search-results',
+                className,
+            ]);
+            return h('div', { class: classes }, slots.default?.());
+        };
+    },
+});
+
+export const SinglePostTypesSearchResultsBlock = defineComponent({
+    name: 'SinglePostTypesSearchResultsBlock',
+    props: blockRendererProps,
+    setup(props, { slots }) {
+        return (): VNode | null => {
+            const isActive = attrBoolean(
+                props.attributes._resolvedActive,
+                false
+            );
+            if (!isActive) {
+                return null;
+            }
+            const className = attrString(props.attributes.className);
+            const classes = classList([
+                'ap-single-post-types-search-results',
+                className,
+            ]);
+            return h('div', { class: classes }, slots.default?.());
+        };
+    },
+});

--- a/packages/visual-editor-renderer-vue/src/blocks/registerCoreBlocks.ts
+++ b/packages/visual-editor-renderer-vue/src/blocks/registerCoreBlocks.ts
@@ -32,6 +32,14 @@ import {
 } from './artisanpack/postNavigation';
 import { AuthorSocialIconsBlock } from './artisanpack/authorSocialIcons';
 import { RelatedPostsBlock } from './artisanpack/relatedPosts';
+import {
+    PostTypesSearchResultsBlock,
+    SearchFieldBlock,
+    SearchFiltersBlock,
+    SearchFiltersButtonsBlock,
+    SearchFiltersTaxonomyBlock,
+    SinglePostTypesSearchResultsBlock,
+} from './artisanpack/searchCluster';
 import { SingleContentBlock } from './artisanpack/singleContent';
 import { SocialShareContentBlock } from './artisanpack/socialShareContent';
 import {
@@ -309,6 +317,17 @@ const CORE_BLOCKS: Record<string, BlockRenderer> = {
     'artisanpack/related-posts': RelatedPostsBlock,
     'artisanpack/author-social-icons': AuthorSocialIconsBlock,
     'artisanpack/social-share-content': SocialShareContentBlock,
+    // Generic search cluster (#502) — registered under the
+    // artisanpack/* namespace only. Every request-time value
+    // (`?s=`, `?taxonomy=`, `?post_type=`) arrives via a
+    // `_resolved*` stamp so the renderers stay declarative.
+    'artisanpack/search-field': SearchFieldBlock,
+    'artisanpack/search-filters': SearchFiltersBlock,
+    'artisanpack/search-filters-buttons': SearchFiltersButtonsBlock,
+    'artisanpack/search-filters-taxonomy': SearchFiltersTaxonomyBlock,
+    'artisanpack/post-types-search-results': PostTypesSearchResultsBlock,
+    'artisanpack/single-post-types-search-results':
+        SinglePostTypesSearchResultsBlock,
 };
 
 export function registerCoreBlocks(): void {

--- a/packages/visual-editor-renderer-vue/tests/parity.test.ts
+++ b/packages/visual-editor-renderer-vue/tests/parity.test.ts
@@ -505,6 +505,144 @@ const FIXTURES: Array<{ name: string; tree: Block[] }> = [
             ),
         ],
     },
+    {
+        name: 'artisanpack/search-field with no resolved value',
+        tree: [
+            makeBlock(
+                'artisanpack/search-field',
+                { label: 'Find', placeholder: 'Type a query …' },
+                [],
+                'sf-1'
+            ),
+        ],
+    },
+    {
+        name: 'artisanpack/search-field with a resolved query',
+        tree: [
+            makeBlock(
+                'artisanpack/search-field',
+                {
+                    label: 'Find',
+                    placeholder: 'Type a query …',
+                    _resolvedSearchValue: 'hello',
+                },
+                [],
+                'sf-2'
+            ),
+        ],
+    },
+    {
+        name: 'artisanpack/search-filters wraps inner blocks in a GET form',
+        tree: [
+            makeBlock(
+                'artisanpack/search-filters',
+                { postType: 'project', _resolvedFormAction: 'https://example.test/' },
+                [
+                    makeBlock(
+                        'artisanpack/search-field',
+                        { label: 'Find', placeholder: 'Type …' },
+                        [],
+                        'sf-inner'
+                    ),
+                ],
+                'sfilters-1'
+            ),
+        ],
+    },
+    {
+        name: 'artisanpack/search-filters drops unsafe action URLs',
+        tree: [
+            makeBlock(
+                'artisanpack/search-filters',
+                {
+                    postType: 'post',
+                    _resolvedFormAction: 'javascript:alert(1)',
+                },
+                [],
+                'sfilters-2'
+            ),
+        ],
+    },
+    {
+        name: 'artisanpack/search-filters-buttons renders submit + reset pair',
+        tree: [
+            makeBlock(
+                'artisanpack/search-filters-buttons',
+                { searchLabel: 'Go', clearLabel: 'Reset' },
+                [],
+                'sfb-1'
+            ),
+        ],
+    },
+    {
+        name: 'artisanpack/search-filters-taxonomy with resolved terms + selection',
+        tree: [
+            makeBlock(
+                'artisanpack/search-filters-taxonomy',
+                {
+                    label: 'Topic',
+                    taxonomy: 'topic',
+                    taxonomyName: 'Topic',
+                    _resolvedTerms: [
+                        { slug: 'news', name: 'News' },
+                        { slug: 'guides', name: 'Guides' },
+                    ],
+                    _resolvedSelectedTerm: 'guides',
+                },
+                [],
+                'sft-1'
+            ),
+        ],
+    },
+    {
+        name: 'artisanpack/search-filters-taxonomy with no resolved terms',
+        tree: [
+            makeBlock(
+                'artisanpack/search-filters-taxonomy',
+                { label: 'Topic', taxonomy: 'topic', taxonomyName: 'Topic' },
+                [],
+                'sft-2'
+            ),
+        ],
+    },
+    {
+        name: 'artisanpack/post-types-search-results wraps active children only',
+        tree: [
+            makeBlock(
+                'artisanpack/post-types-search-results',
+                {},
+                [
+                    makeBlock(
+                        'artisanpack/single-post-types-search-results',
+                        { postType: 'post', _resolvedActive: true },
+                        [
+                            makeBlock(
+                                'core/paragraph',
+                                { content: 'Active section' },
+                                [],
+                                'p-active'
+                            ),
+                        ],
+                        'spr-active'
+                    ),
+                    makeBlock(
+                        'artisanpack/single-post-types-search-results',
+                        { postType: 'project', _resolvedActive: false },
+                        [
+                            makeBlock(
+                                'core/paragraph',
+                                { content: 'Inactive section' },
+                                [],
+                                'p-inactive'
+                            ),
+                        ],
+                        'spr-inactive'
+                    ),
+                ],
+                'ptsr-1'
+            ),
+        ],
+    },
 ];
 
 describe('React/Vue renderer parity', () => {

--- a/resources/js/visual-editor/blocks/__tests__/search-cluster-family.test.ts
+++ b/resources/js/visual-editor/blocks/__tests__/search-cluster-family.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Generic search cluster contract (#502).
+ *
+ * block.json + save contract for the six search blocks:
+ *
+ *   - search-field
+ *   - search-filters (container)
+ *   - search-filters-buttons
+ *   - search-filters-taxonomy
+ *   - post-types-search-results (parent container)
+ *   - single-post-types-search-results (child of post-types-search-results)
+ *
+ * All six live under the `artisanpack` namespace + category and the
+ * `artisanpack-visual-editor` textdomain. Every block is a dynamic
+ * block (save returns null) so the renderers can read live request
+ * state at render time.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@wordpress/block-editor', () => ({
+    InnerBlocks: Object.assign(() => null, { Content: () => null }),
+    RichText: Object.assign(() => null, { Content: () => null }),
+    useBlockProps: Object.assign(() => ({}), { save: () => ({}) }),
+    useInnerBlocksProps: Object.assign(() => ({}), { save: () => ({}) }),
+    InspectorControls: () => null,
+}));
+
+vi.mock('@wordpress/components', () => ({
+    PanelBody: () => null,
+    SelectControl: () => null,
+    TextControl: () => null,
+}));
+
+vi.mock('@wordpress/i18n', () => ({
+    __: (value: string) => value,
+}));
+
+import searchFieldMeta from '../search-field/block.json';
+import searchFiltersMeta from '../search-filters/block.json';
+import searchFiltersButtonsMeta from '../search-filters-buttons/block.json';
+import searchFiltersTaxonomyMeta from '../search-filters-taxonomy/block.json';
+import postTypesSearchResultsMeta from '../post-types-search-results/block.json';
+import singlePostTypesSearchResultsMeta from '../single-post-types-search-results/block.json';
+
+import searchFieldSave from '../search-field/save';
+import searchFiltersSave from '../search-filters/save';
+import searchFiltersButtonsSave from '../search-filters-buttons/save';
+import searchFiltersTaxonomySave from '../search-filters-taxonomy/save';
+import postTypesSearchResultsSave from '../post-types-search-results/save';
+import singlePostTypesSearchResultsSave from '../single-post-types-search-results/save';
+
+const FAMILY = [
+    { slug: 'search-field', meta: searchFieldMeta },
+    { slug: 'search-filters', meta: searchFiltersMeta },
+    { slug: 'search-filters-buttons', meta: searchFiltersButtonsMeta },
+    { slug: 'search-filters-taxonomy', meta: searchFiltersTaxonomyMeta },
+    { slug: 'post-types-search-results', meta: postTypesSearchResultsMeta },
+    {
+        slug: 'single-post-types-search-results',
+        meta: singlePostTypesSearchResultsMeta,
+    },
+] as const;
+
+describe('search cluster block.json', () => {
+    it.each(FAMILY)(
+        '$slug declares the artisanpack namespace + textdomain + category',
+        ({ slug, meta }) => {
+            expect(meta.name).toBe(`artisanpack/${slug}`);
+            expect(meta.textdomain).toBe('artisanpack-visual-editor');
+            expect(meta.category).toBe('artisanpack');
+        }
+    );
+
+    it('search-field declares the label + placeholder attributes with safe defaults', () => {
+        const attrs = (
+            searchFieldMeta as { attributes?: Record<string, { default?: unknown }> }
+        ).attributes;
+        expect(attrs?.label?.default).toBe('Search');
+        expect(attrs?.placeholder?.default).toBe('Search …');
+    });
+
+    it('search-filters declares the postType attribute with a `post` default', () => {
+        const attrs = (
+            searchFiltersMeta as { attributes?: Record<string, { default?: unknown }> }
+        ).attributes;
+        expect(attrs?.postType?.default).toBe('post');
+    });
+
+    it('search-filters-buttons declares searchLabel + clearLabel attributes', () => {
+        const attrs = (
+            searchFiltersButtonsMeta as {
+                attributes?: Record<string, { default?: unknown }>;
+            }
+        ).attributes;
+        expect(attrs?.searchLabel?.default).toBe('Search');
+        expect(attrs?.clearLabel?.default).toBe('Clear');
+    });
+
+    it('search-filters-taxonomy declares label + taxonomy + taxonomyName attributes', () => {
+        const attrs = (
+            searchFiltersTaxonomyMeta as {
+                attributes?: Record<string, { default?: unknown }>;
+            }
+        ).attributes;
+        expect(attrs?.label?.default).toBe('Choose');
+        expect(attrs?.taxonomy?.default).toBe('category');
+        expect(attrs?.taxonomyName?.default).toBe('Category');
+    });
+
+    it('single-post-types-search-results declares the post-type parent + postType attribute', () => {
+        const meta = singlePostTypesSearchResultsMeta as {
+            parent?: ReadonlyArray<string>;
+            attributes?: Record<string, { default?: unknown }>;
+        };
+        expect(meta.parent).toContain('artisanpack/post-types-search-results');
+        expect(meta.attributes?.postType?.default).toBe('all');
+    });
+});
+
+describe('search cluster save contract', () => {
+    it.each(FAMILY)('$slug.save returns null (dynamic block)', ({ slug }) => {
+        const save = (
+            {
+                'search-field': searchFieldSave,
+                'search-filters': searchFiltersSave,
+                'search-filters-buttons': searchFiltersButtonsSave,
+                'search-filters-taxonomy': searchFiltersTaxonomySave,
+                'post-types-search-results': postTypesSearchResultsSave,
+                'single-post-types-search-results':
+                    singlePostTypesSearchResultsSave,
+            } as Record<string, () => null>
+        )[slug];
+        expect(save()).toBeNull();
+    });
+});

--- a/resources/js/visual-editor/blocks/post-types-search-results/block.json
+++ b/resources/js/visual-editor/blocks/post-types-search-results/block.json
@@ -1,0 +1,25 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "artisanpack/post-types-search-results",
+    "title": "Post Types Search Results",
+    "category": "artisanpack",
+    "description": "Wrap a set of post-type-specific result sections that render conditionally based on the searched post type.",
+    "keywords": ["search", "results", "post types"],
+    "textdomain": "artisanpack-visual-editor",
+    "supports": {
+        "align": ["wide", "full"],
+        "ariaLabel": true,
+        "className": true,
+        "html": false,
+        "spacing": {
+            "margin": ["top", "bottom"],
+            "padding": true,
+            "blockGap": true,
+            "__experimentalDefaultControls": {
+                "padding": true,
+                "blockGap": true
+            }
+        }
+    }
+}

--- a/resources/js/visual-editor/blocks/post-types-search-results/edit.tsx
+++ b/resources/js/visual-editor/blocks/post-types-search-results/edit.tsx
@@ -1,0 +1,27 @@
+/**
+ * Post Types Search Results — editor-side component (#502).
+ *
+ * Wrapper that accepts one or more
+ * `artisanpack/single-post-types-search-results` children. Each child
+ * owns its own post-type filter so the same parent can host result
+ * sections for multiple post types.
+ */
+
+import type { ReactElement } from 'react';
+import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
+
+const ALLOWED_BLOCKS: string[] = ['artisanpack/single-post-types-search-results'];
+
+const TEMPLATE: [string, Record<string, unknown>][] = [
+    ['artisanpack/single-post-types-search-results', { postType: 'all' }],
+];
+
+export default function PostTypesSearchResultsEdit(): ReactElement {
+    const blockProps = useBlockProps({ className: 'ap-post-types-search-results' });
+    const innerBlocksProps = useInnerBlocksProps(blockProps, {
+        allowedBlocks: ALLOWED_BLOCKS,
+        template: TEMPLATE,
+    });
+
+    return <div {...innerBlocksProps} />;
+}

--- a/resources/js/visual-editor/blocks/post-types-search-results/index.ts
+++ b/resources/js/visual-editor/blocks/post-types-search-results/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Post Types Search Results block entrypoint (#502).
+ *
+ * Container for one or more `artisanpack/single-post-types-search-results`
+ * children. Each child shows only when its `postType` attribute matches
+ * the current `?post_type=…` query parameter.
+ */
+
+import metadata from './block.json';
+import edit from './edit';
+import save from './save';
+import icon from './inserter-icon';
+
+export { edit, save, metadata, icon };
+
+export default {
+    name: metadata.name,
+    metadata,
+    edit,
+    save,
+    icon,
+};

--- a/resources/js/visual-editor/blocks/post-types-search-results/inserter-icon.tsx
+++ b/resources/js/visual-editor/blocks/post-types-search-results/inserter-icon.tsx
@@ -1,0 +1,20 @@
+/**
+ * Post Types Search Results — inserter icon.
+ */
+
+import type { ReactElement } from 'react';
+
+export default function PostTypesSearchResultsInserterIcon(): ReactElement {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            width={24}
+            height={24}
+            aria-hidden="true"
+            focusable="false"
+        >
+            <path d="M3 4h18v3H3V4zm0 6h18v3H3v-3zm0 6h18v3H3v-3z" />
+        </svg>
+    );
+}

--- a/resources/js/visual-editor/blocks/post-types-search-results/save.tsx
+++ b/resources/js/visual-editor/blocks/post-types-search-results/save.tsx
@@ -1,0 +1,10 @@
+/**
+ * Post Types Search Results — save component.
+ *
+ * Dynamic block: each renderer walks the persisted inner-block tree at
+ * request time and lets each child decide whether to emit anything.
+ */
+
+export default function PostTypesSearchResultsSave(): null {
+    return null;
+}

--- a/resources/js/visual-editor/blocks/search-field/block.json
+++ b/resources/js/visual-editor/blocks/search-field/block.json
@@ -1,0 +1,51 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "artisanpack/search-field",
+    "title": "Search Field",
+    "category": "artisanpack",
+    "description": "Render a labelled search input that posts the keyword to the host page as the `s` query parameter.",
+    "keywords": ["search", "keyword", "filter", "input"],
+    "textdomain": "artisanpack-visual-editor",
+    "attributes": {
+        "label": {
+            "type": "string",
+            "default": "Search"
+        },
+        "placeholder": {
+            "type": "string",
+            "default": "Search …"
+        }
+    },
+    "supports": {
+        "ariaLabel": true,
+        "className": true,
+        "html": false,
+        "spacing": {
+            "margin": ["top", "bottom"],
+            "padding": true,
+            "blockGap": true,
+            "__experimentalDefaultControls": {
+                "padding": true,
+                "blockGap": true
+            }
+        },
+        "color": {
+            "gradients": true,
+            "link": true,
+            "__experimentalDefaultControls": {
+                "background": true,
+                "text": true
+            }
+        },
+        "typography": {
+            "fontSize": true,
+            "lineHeight": true,
+            "__experimentalFontFamily": true,
+            "__experimentalFontWeight": true,
+            "__experimentalDefaultControls": {
+                "fontSize": true
+            }
+        }
+    }
+}

--- a/resources/js/visual-editor/blocks/search-field/edit.tsx
+++ b/resources/js/visual-editor/blocks/search-field/edit.tsx
@@ -1,0 +1,66 @@
+/**
+ * Search Field — editor-side preview (#502).
+ *
+ * Renders an empty search input + label so authors see the chrome
+ * immediately. The runtime renderers fill the input's value from the
+ * current `s` query parameter.
+ */
+
+import type { ReactElement } from 'react';
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import { PanelBody, TextControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+import { TEXT_DOMAIN } from '../../vendor/i18n';
+
+interface SearchFieldAttributes {
+    readonly label: string;
+    readonly placeholder: string;
+}
+
+interface SearchFieldEditProps {
+    readonly attributes: SearchFieldAttributes;
+    readonly setAttributes: (next: Partial<SearchFieldAttributes>) => void;
+}
+
+export default function SearchFieldEdit({
+    attributes,
+    setAttributes,
+}: SearchFieldEditProps): ReactElement {
+    const { label, placeholder } = attributes;
+
+    const blockProps = useBlockProps({ className: 'ap-search-field' });
+
+    return (
+        <>
+            <InspectorControls>
+                <PanelBody title={__('Search field settings', TEXT_DOMAIN)} initialOpen>
+                    <TextControl
+                        label={__('Label', TEXT_DOMAIN)}
+                        value={label}
+                        onChange={(value) => setAttributes({ label: value })}
+                        __nextHasNoMarginBottom
+                    />
+                    <TextControl
+                        label={__('Placeholder', TEXT_DOMAIN)}
+                        value={placeholder}
+                        onChange={(value) => setAttributes({ placeholder: value })}
+                        __nextHasNoMarginBottom
+                    />
+                </PanelBody>
+            </InspectorControls>
+            <div {...blockProps}>
+                <label className="ap-search-field__label" htmlFor="ap-search-field-preview">
+                    {label}
+                </label>
+                <input
+                    type="search"
+                    className="ap-search-field__input"
+                    id="ap-search-field-preview"
+                    placeholder={placeholder}
+                    disabled
+                />
+            </div>
+        </>
+    );
+}

--- a/resources/js/visual-editor/blocks/search-field/edit.tsx
+++ b/resources/js/visual-editor/blocks/search-field/edit.tsx
@@ -6,7 +6,7 @@
  * current `s` query parameter.
  */
 
-import type { ReactElement } from 'react';
+import { useId, type ReactElement } from 'react';
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import { PanelBody, TextControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -30,6 +30,7 @@ export default function SearchFieldEdit({
     const { label, placeholder } = attributes;
 
     const blockProps = useBlockProps({ className: 'ap-search-field' });
+    const previewId = useId();
 
     return (
         <>
@@ -50,13 +51,13 @@ export default function SearchFieldEdit({
                 </PanelBody>
             </InspectorControls>
             <div {...blockProps}>
-                <label className="ap-search-field__label" htmlFor="ap-search-field-preview">
+                <label className="ap-search-field__label" htmlFor={previewId}>
                     {label}
                 </label>
                 <input
                     type="search"
                     className="ap-search-field__input"
-                    id="ap-search-field-preview"
+                    id={previewId}
                     placeholder={placeholder}
                     disabled
                 />

--- a/resources/js/visual-editor/blocks/search-field/index.ts
+++ b/resources/js/visual-editor/blocks/search-field/index.ts
@@ -1,0 +1,25 @@
+/**
+ * Search Field block entrypoint (#502).
+ *
+ * Auto-discovered by `editor/custom-blocks.ts` and registered against
+ * `@wordpress/blocks.registerBlockType`. Dynamic block: `edit` previews
+ * an empty input so authors see the label + placeholder, and the real
+ * markup is emitted by the Blade / React / Vue renderers at request
+ * time (the input value comes from the current `s` query parameter so
+ * the host page can pre-fill it).
+ */
+
+import metadata from './block.json';
+import edit from './edit';
+import save from './save';
+import icon from './inserter-icon';
+
+export { edit, save, metadata, icon };
+
+export default {
+    name: metadata.name,
+    metadata,
+    edit,
+    save,
+    icon,
+};

--- a/resources/js/visual-editor/blocks/search-field/inserter-icon.tsx
+++ b/resources/js/visual-editor/blocks/search-field/inserter-icon.tsx
@@ -1,0 +1,23 @@
+/**
+ * Search Field — inserter icon.
+ *
+ * Inline SVG (magnifying glass) so the canvas does not have to load
+ * `dashicons.css` for the inserter preview.
+ */
+
+import type { ReactElement } from 'react';
+
+export default function SearchFieldInserterIcon(): ReactElement {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            width={24}
+            height={24}
+            aria-hidden="true"
+            focusable="false"
+        >
+            <path d="M13.5 6C10.5 6 8 8.5 8 11.5c0 1.1.3 2.1.9 3l-3.4 3 1 1.1 3.4-3c1 .9 2.2 1.4 3.6 1.4 3 0 5.5-2.5 5.5-5.5C19 8.5 16.5 6 13.5 6zm0 9.5c-2.2 0-4-1.8-4-4s1.8-4 4-4 4 1.8 4 4-1.8 4-4 4z" />
+        </svg>
+    );
+}

--- a/resources/js/visual-editor/blocks/search-field/save.tsx
+++ b/resources/js/visual-editor/blocks/search-field/save.tsx
@@ -1,0 +1,10 @@
+/**
+ * Search Field — save component.
+ *
+ * Dynamic block: the renderers emit the input shell at request time so
+ * the current keyword can be pre-filled from the `s` query parameter.
+ */
+
+export default function SearchFieldSave(): null {
+    return null;
+}

--- a/resources/js/visual-editor/blocks/search-filters-buttons/block.json
+++ b/resources/js/visual-editor/blocks/search-filters-buttons/block.json
@@ -1,0 +1,34 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "artisanpack/search-filters-buttons",
+    "title": "Search Filters Buttons",
+    "category": "artisanpack",
+    "description": "Render the submit + reset buttons that drive the surrounding search filters form.",
+    "keywords": ["search", "filters", "submit", "reset"],
+    "textdomain": "artisanpack-visual-editor",
+    "attributes": {
+        "searchLabel": {
+            "type": "string",
+            "default": "Search"
+        },
+        "clearLabel": {
+            "type": "string",
+            "default": "Clear"
+        }
+    },
+    "supports": {
+        "ariaLabel": true,
+        "className": true,
+        "html": false,
+        "typography": {
+            "fontSize": true,
+            "lineHeight": true,
+            "__experimentalFontFamily": true,
+            "__experimentalFontWeight": true,
+            "__experimentalDefaultControls": {
+                "fontSize": true
+            }
+        }
+    }
+}

--- a/resources/js/visual-editor/blocks/search-filters-buttons/edit.tsx
+++ b/resources/js/visual-editor/blocks/search-filters-buttons/edit.tsx
@@ -1,0 +1,68 @@
+/**
+ * Search Filters Buttons — editor-side preview (#502).
+ *
+ * Renders the submit + reset button pair so authors can adjust the
+ * labels and see the spacing in place. The real markup is emitted by
+ * the runtime renderers.
+ */
+
+import type { ReactElement } from 'react';
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import { PanelBody, TextControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+import { TEXT_DOMAIN } from '../../vendor/i18n';
+
+interface SearchFiltersButtonsAttributes {
+    readonly searchLabel: string;
+    readonly clearLabel: string;
+}
+
+interface SearchFiltersButtonsEditProps {
+    readonly attributes: SearchFiltersButtonsAttributes;
+    readonly setAttributes: (next: Partial<SearchFiltersButtonsAttributes>) => void;
+}
+
+export default function SearchFiltersButtonsEdit({
+    attributes,
+    setAttributes,
+}: SearchFiltersButtonsEditProps): ReactElement {
+    const { searchLabel, clearLabel } = attributes;
+
+    const blockProps = useBlockProps({ className: 'ap-search-filters-buttons' });
+
+    return (
+        <>
+            <InspectorControls>
+                <PanelBody title={__('Button labels', TEXT_DOMAIN)} initialOpen>
+                    <TextControl
+                        label={__('Submit label', TEXT_DOMAIN)}
+                        value={searchLabel}
+                        onChange={(value) => setAttributes({ searchLabel: value })}
+                        __nextHasNoMarginBottom
+                    />
+                    <TextControl
+                        label={__('Reset label', TEXT_DOMAIN)}
+                        value={clearLabel}
+                        onChange={(value) => setAttributes({ clearLabel: value })}
+                        __nextHasNoMarginBottom
+                    />
+                </PanelBody>
+            </InspectorControls>
+            <div {...blockProps}>
+                <input
+                    type="submit"
+                    className="ap-search-filters-buttons__submit"
+                    value={searchLabel}
+                    disabled
+                />
+                <input
+                    type="reset"
+                    className="ap-search-filters-buttons__reset"
+                    value={clearLabel}
+                    disabled
+                />
+            </div>
+        </>
+    );
+}

--- a/resources/js/visual-editor/blocks/search-filters-buttons/index.ts
+++ b/resources/js/visual-editor/blocks/search-filters-buttons/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Search Filters Buttons block entrypoint (#502).
+ *
+ * Submit + reset pair for the surrounding `artisanpack/search-filters`
+ * form. Renderers emit `<input type="submit">` + `<input type="reset">`
+ * pairs at request time.
+ */
+
+import metadata from './block.json';
+import edit from './edit';
+import save from './save';
+import icon from './inserter-icon';
+
+export { edit, save, metadata, icon };
+
+export default {
+    name: metadata.name,
+    metadata,
+    edit,
+    save,
+    icon,
+};

--- a/resources/js/visual-editor/blocks/search-filters-buttons/inserter-icon.tsx
+++ b/resources/js/visual-editor/blocks/search-filters-buttons/inserter-icon.tsx
@@ -1,0 +1,20 @@
+/**
+ * Search Filters Buttons — inserter icon.
+ */
+
+import type { ReactElement } from 'react';
+
+export default function SearchFiltersButtonsInserterIcon(): ReactElement {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            width={24}
+            height={24}
+            aria-hidden="true"
+            focusable="false"
+        >
+            <path d="M3 8h8v4H3V8zm10 0h8v4h-8V8zM3 14h18v4H3v-4z" />
+        </svg>
+    );
+}

--- a/resources/js/visual-editor/blocks/search-filters-buttons/save.tsx
+++ b/resources/js/visual-editor/blocks/search-filters-buttons/save.tsx
@@ -1,0 +1,9 @@
+/**
+ * Search Filters Buttons — save component.
+ *
+ * Dynamic block: the renderers emit the button pair at render time.
+ */
+
+export default function SearchFiltersButtonsSave(): null {
+    return null;
+}

--- a/resources/js/visual-editor/blocks/search-filters-taxonomy/block.json
+++ b/resources/js/visual-editor/blocks/search-filters-taxonomy/block.json
@@ -1,0 +1,55 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "artisanpack/search-filters-taxonomy",
+    "title": "Search Filters Taxonomy",
+    "category": "artisanpack",
+    "description": "Render a labelled `<select>` populated from a taxonomy so visitors can narrow search results by term.",
+    "keywords": ["search", "filters", "taxonomy", "select"],
+    "textdomain": "artisanpack-visual-editor",
+    "attributes": {
+        "label": {
+            "type": "string",
+            "default": "Choose"
+        },
+        "taxonomy": {
+            "type": "string",
+            "default": "category"
+        },
+        "taxonomyName": {
+            "type": "string",
+            "default": "Category"
+        }
+    },
+    "supports": {
+        "ariaLabel": true,
+        "className": true,
+        "html": false,
+        "spacing": {
+            "margin": ["top", "bottom"],
+            "padding": true,
+            "blockGap": true,
+            "__experimentalDefaultControls": {
+                "padding": true,
+                "blockGap": true
+            }
+        },
+        "color": {
+            "gradients": true,
+            "link": true,
+            "__experimentalDefaultControls": {
+                "background": true,
+                "text": true
+            }
+        },
+        "typography": {
+            "fontSize": true,
+            "lineHeight": true,
+            "__experimentalFontFamily": true,
+            "__experimentalFontWeight": true,
+            "__experimentalDefaultControls": {
+                "fontSize": true
+            }
+        }
+    }
+}

--- a/resources/js/visual-editor/blocks/search-filters-taxonomy/edit.tsx
+++ b/resources/js/visual-editor/blocks/search-filters-taxonomy/edit.tsx
@@ -6,7 +6,7 @@
  * the actual term list from the host's `_resolvedTerms` stamp.
  */
 
-import type { ReactElement } from 'react';
+import { useId, type ReactElement } from 'react';
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import { PanelBody, TextControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -33,6 +33,7 @@ export default function SearchFiltersTaxonomyEdit({
     const { label, taxonomy, taxonomyName } = attributes;
 
     const blockProps = useBlockProps({ className: 'ap-search-filters-taxonomy' });
+    const previewId = useId();
 
     return (
         <>
@@ -74,13 +75,13 @@ export default function SearchFiltersTaxonomyEdit({
             <div {...blockProps}>
                 <label
                     className="ap-search-filters-taxonomy__label"
-                    htmlFor={`ap-search-filters-taxonomy-${taxonomy || 'unset'}-preview`}
+                    htmlFor={previewId}
                 >
                     {label}
                 </label>
                 <select
                     className="ap-search-filters-taxonomy__select"
-                    id={`ap-search-filters-taxonomy-${taxonomy || 'unset'}-preview`}
+                    id={previewId}
                     disabled
                 >
                     <option value="">

--- a/resources/js/visual-editor/blocks/search-filters-taxonomy/edit.tsx
+++ b/resources/js/visual-editor/blocks/search-filters-taxonomy/edit.tsx
@@ -1,0 +1,93 @@
+/**
+ * Search Filters Taxonomy — editor-side preview (#502).
+ *
+ * Renders a labelled `<select>` with a placeholder option so authors
+ * see the chrome immediately. The runtime renderers populate it with
+ * the actual term list from the host's `_resolvedTerms` stamp.
+ */
+
+import type { ReactElement } from 'react';
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import { PanelBody, TextControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+import { TEXT_DOMAIN } from '../../vendor/i18n';
+
+interface SearchFiltersTaxonomyAttributes {
+    readonly label: string;
+    readonly taxonomy: string;
+    readonly taxonomyName: string;
+}
+
+interface SearchFiltersTaxonomyEditProps {
+    readonly attributes: SearchFiltersTaxonomyAttributes;
+    readonly setAttributes: (next: Partial<SearchFiltersTaxonomyAttributes>) => void;
+}
+
+const TAXONOMY_SLUG_PATTERN = /^[a-z][a-z0-9_-]*$/;
+
+export default function SearchFiltersTaxonomyEdit({
+    attributes,
+    setAttributes,
+}: SearchFiltersTaxonomyEditProps): ReactElement {
+    const { label, taxonomy, taxonomyName } = attributes;
+
+    const blockProps = useBlockProps({ className: 'ap-search-filters-taxonomy' });
+
+    return (
+        <>
+            <InspectorControls>
+                <PanelBody title={__('Taxonomy search settings', TEXT_DOMAIN)} initialOpen>
+                    <TextControl
+                        label={__('Label', TEXT_DOMAIN)}
+                        value={label}
+                        onChange={(value) => setAttributes({ label: value })}
+                        __nextHasNoMarginBottom
+                    />
+                    <TextControl
+                        label={__('Taxonomy slug', TEXT_DOMAIN)}
+                        value={taxonomy}
+                        onChange={(value) => {
+                            const next = value.trim().toLowerCase();
+                            if (next === '' || TAXONOMY_SLUG_PATTERN.test(next)) {
+                                setAttributes({ taxonomy: next });
+                            }
+                        }}
+                        help={__(
+                            'Lowercase slug of the taxonomy. Posted to the host page as the GET key under which the selected term lives.',
+                            TEXT_DOMAIN
+                        )}
+                        __nextHasNoMarginBottom
+                    />
+                    <TextControl
+                        label={__('Taxonomy display name', TEXT_DOMAIN)}
+                        value={taxonomyName}
+                        onChange={(value) => setAttributes({ taxonomyName: value })}
+                        help={__(
+                            'Shown inside the placeholder option (e.g. "Select a Category").',
+                            TEXT_DOMAIN
+                        )}
+                        __nextHasNoMarginBottom
+                    />
+                </PanelBody>
+            </InspectorControls>
+            <div {...blockProps}>
+                <label
+                    className="ap-search-filters-taxonomy__label"
+                    htmlFor={`ap-search-filters-taxonomy-${taxonomy || 'unset'}-preview`}
+                >
+                    {label}
+                </label>
+                <select
+                    className="ap-search-filters-taxonomy__select"
+                    id={`ap-search-filters-taxonomy-${taxonomy || 'unset'}-preview`}
+                    disabled
+                >
+                    <option value="">
+                        {__('Select a', TEXT_DOMAIN)} {taxonomyName}
+                    </option>
+                </select>
+            </div>
+        </>
+    );
+}

--- a/resources/js/visual-editor/blocks/search-filters-taxonomy/index.ts
+++ b/resources/js/visual-editor/blocks/search-filters-taxonomy/index.ts
@@ -1,0 +1,23 @@
+/**
+ * Search Filters Taxonomy block entrypoint (#502).
+ *
+ * Auto-discovered by `editor/custom-blocks.ts`. Dynamic block:
+ * renderers populate the `<select>` from the host's stamped
+ * `_resolvedTerms` attribute and pre-select the queried term from the
+ * current request.
+ */
+
+import metadata from './block.json';
+import edit from './edit';
+import save from './save';
+import icon from './inserter-icon';
+
+export { edit, save, metadata, icon };
+
+export default {
+    name: metadata.name,
+    metadata,
+    edit,
+    save,
+    icon,
+};

--- a/resources/js/visual-editor/blocks/search-filters-taxonomy/inserter-icon.tsx
+++ b/resources/js/visual-editor/blocks/search-filters-taxonomy/inserter-icon.tsx
@@ -1,0 +1,20 @@
+/**
+ * Search Filters Taxonomy — inserter icon.
+ */
+
+import type { ReactElement } from 'react';
+
+export default function SearchFiltersTaxonomyInserterIcon(): ReactElement {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            width={24}
+            height={24}
+            aria-hidden="true"
+            focusable="false"
+        >
+            <path d="M3 6h18v2H3V6zm0 5h12v2H3v-2zm0 5h8v2H3v-2zm15 0 4-4-4-4v3h-3v2h3v3z" />
+        </svg>
+    );
+}

--- a/resources/js/visual-editor/blocks/search-filters-taxonomy/save.tsx
+++ b/resources/js/visual-editor/blocks/search-filters-taxonomy/save.tsx
@@ -1,0 +1,10 @@
+/**
+ * Search Filters Taxonomy — save component.
+ *
+ * Dynamic block: renderers populate the `<select>` from the resolved
+ * term list at request time.
+ */
+
+export default function SearchFiltersTaxonomySave(): null {
+    return null;
+}

--- a/resources/js/visual-editor/blocks/search-filters/block.json
+++ b/resources/js/visual-editor/blocks/search-filters/block.json
@@ -1,0 +1,61 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "artisanpack/search-filters",
+    "title": "Search Filters",
+    "category": "artisanpack",
+    "description": "Wrap a set of filter controls (search field, taxonomy dropdowns, submit + reset buttons) in a single GET form that posts back to the host site.",
+    "keywords": ["search", "filters", "form"],
+    "textdomain": "artisanpack-visual-editor",
+    "attributes": {
+        "postType": {
+            "type": "string",
+            "default": "post"
+        }
+    },
+    "supports": {
+        "align": ["wide", "full"],
+        "ariaLabel": true,
+        "className": true,
+        "html": false,
+        "spacing": {
+            "margin": ["top", "bottom"],
+            "padding": true,
+            "blockGap": true,
+            "__experimentalDefaultControls": {
+                "padding": true,
+                "blockGap": true
+            }
+        },
+        "color": {
+            "gradients": true,
+            "link": true,
+            "__experimentalDefaultControls": {
+                "background": true,
+                "text": true
+            }
+        },
+        "shadow": true,
+        "__experimentalBorder": {
+            "color": true,
+            "radius": true,
+            "style": true,
+            "width": true,
+            "__experimentalDefaultControls": {
+                "color": true,
+                "radius": true,
+                "style": true,
+                "width": true
+            }
+        },
+        "typography": {
+            "fontSize": true,
+            "lineHeight": true,
+            "__experimentalFontFamily": true,
+            "__experimentalFontWeight": true,
+            "__experimentalDefaultControls": {
+                "fontSize": true
+            }
+        }
+    }
+}

--- a/resources/js/visual-editor/blocks/search-filters/edit.tsx
+++ b/resources/js/visual-editor/blocks/search-filters/edit.tsx
@@ -1,0 +1,91 @@
+/**
+ * Search Filters — editor-side component (#502).
+ *
+ * Wrapper that drops a `<form>` chrome around the inner filter blocks
+ * (search field, taxonomy dropdowns, submit + reset buttons). The
+ * inspector picks the post type the form scopes its search to; the
+ * post-type list comes from the editor's content-type registry so the
+ * dropdown stays in sync with whichever post types the host has
+ * published.
+ */
+
+import type { ReactElement } from 'react';
+import {
+    InnerBlocks,
+    InspectorControls,
+    useBlockProps,
+    useInnerBlocksProps,
+} from '@wordpress/block-editor';
+import { PanelBody, SelectControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+import { TEXT_DOMAIN } from '../../vendor/i18n';
+import { getContentTypes } from '../../editor/content-type-registry';
+
+interface SearchFiltersAttributes {
+    readonly postType: string;
+}
+
+interface SearchFiltersEditProps {
+    readonly attributes: SearchFiltersAttributes;
+    readonly setAttributes: (next: Partial<SearchFiltersAttributes>) => void;
+}
+
+const ALLOWED_BLOCKS: string[] = [
+    'artisanpack/search-field',
+    'artisanpack/search-filters-taxonomy',
+    'artisanpack/search-filters-buttons',
+];
+
+const TEMPLATE: [string, Record<string, unknown>][] = [
+    ['artisanpack/search-field', {}],
+    ['artisanpack/search-filters-buttons', {}],
+];
+
+export default function SearchFiltersEdit({
+    attributes,
+    setAttributes,
+}: SearchFiltersEditProps): ReactElement {
+    const { postType } = attributes;
+
+    const blockProps = useBlockProps({ className: 'ap-search-filters' });
+    // Wrap inner blocks in a `<div>` for the editor — not a `<form>` —
+    // so Gutenberg's inline + sibling appenders render properly. The
+    // runtime renderers wrap the same children in a `<form method="get">`
+    // when emitting front-end markup.
+    const innerBlocksProps = useInnerBlocksProps(blockProps, {
+        allowedBlocks: ALLOWED_BLOCKS,
+        template: TEMPLATE,
+        renderAppender: InnerBlocks.ButtonBlockAppender,
+    });
+
+    const options = getContentTypes().map((entry) => ({
+        value: entry.slug,
+        label: entry.label,
+    }));
+
+    if (options.length === 0) {
+        options.push({ value: 'post', label: __('Posts', TEXT_DOMAIN) });
+    }
+
+    return (
+        <>
+            <InspectorControls>
+                <PanelBody title={__('Search filters settings', TEXT_DOMAIN)} initialOpen>
+                    <SelectControl
+                        label={__('Post type', TEXT_DOMAIN)}
+                        value={postType}
+                        options={options}
+                        onChange={(value) => setAttributes({ postType: value })}
+                        help={__(
+                            'Scope the form to a single post type. Posted as a hidden `post_type` field so the host search route can filter results.',
+                            TEXT_DOMAIN
+                        )}
+                        __nextHasNoMarginBottom
+                    />
+                </PanelBody>
+            </InspectorControls>
+            <div {...innerBlocksProps} />
+        </>
+    );
+}

--- a/resources/js/visual-editor/blocks/search-filters/index.ts
+++ b/resources/js/visual-editor/blocks/search-filters/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Search Filters block entrypoint (#502).
+ *
+ * Auto-discovered by `editor/custom-blocks.ts`. Wraps a set of inner
+ * filter controls inside a single GET form that posts back to the host
+ * site, scoped to the configured post type via a hidden input.
+ */
+
+import metadata from './block.json';
+import edit from './edit';
+import save from './save';
+import icon from './inserter-icon';
+
+export { edit, save, metadata, icon };
+
+export default {
+    name: metadata.name,
+    metadata,
+    edit,
+    save,
+    icon,
+};

--- a/resources/js/visual-editor/blocks/search-filters/inserter-icon.tsx
+++ b/resources/js/visual-editor/blocks/search-filters/inserter-icon.tsx
@@ -1,0 +1,23 @@
+/**
+ * Search Filters — inserter icon.
+ *
+ * Inline SVG (a funnel) so the canvas does not have to load
+ * `dashicons.css` for the inserter preview.
+ */
+
+import type { ReactElement } from 'react';
+
+export default function SearchFiltersInserterIcon(): ReactElement {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            width={24}
+            height={24}
+            aria-hidden="true"
+            focusable="false"
+        >
+            <path d="M3 4h18v2l-7 8v6l-4-2v-4L3 6V4z" />
+        </svg>
+    );
+}

--- a/resources/js/visual-editor/blocks/search-filters/save.tsx
+++ b/resources/js/visual-editor/blocks/search-filters/save.tsx
@@ -1,0 +1,11 @@
+/**
+ * Search Filters — save component.
+ *
+ * Dynamic block: the renderers walk the persisted inner-block tree at
+ * render time so the wrapper form's `action` can resolve to the host
+ * site's home URL.
+ */
+
+export default function SearchFiltersSave(): null {
+    return null;
+}

--- a/resources/js/visual-editor/blocks/single-post-types-search-results/block.json
+++ b/resources/js/visual-editor/blocks/single-post-types-search-results/block.json
@@ -1,0 +1,61 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "artisanpack/single-post-types-search-results",
+    "title": "Single Post Type Search Results",
+    "category": "artisanpack",
+    "description": "Render its inner blocks only when the host page's `?post_type=` query parameter matches the configured post type (or `all` when no parameter is set).",
+    "keywords": ["search", "results", "post type"],
+    "parent": ["artisanpack/post-types-search-results"],
+    "textdomain": "artisanpack-visual-editor",
+    "attributes": {
+        "postType": {
+            "type": "string",
+            "default": "all"
+        }
+    },
+    "supports": {
+        "ariaLabel": true,
+        "className": true,
+        "html": false,
+        "spacing": {
+            "margin": ["top", "bottom"],
+            "padding": true,
+            "blockGap": true,
+            "__experimentalDefaultControls": {
+                "padding": true,
+                "blockGap": true
+            }
+        },
+        "color": {
+            "gradients": true,
+            "link": true,
+            "__experimentalDefaultControls": {
+                "background": true,
+                "text": true
+            }
+        },
+        "shadow": true,
+        "__experimentalBorder": {
+            "color": true,
+            "radius": true,
+            "style": true,
+            "width": true,
+            "__experimentalDefaultControls": {
+                "color": true,
+                "radius": true,
+                "style": true,
+                "width": true
+            }
+        },
+        "typography": {
+            "fontSize": true,
+            "lineHeight": true,
+            "__experimentalFontFamily": true,
+            "__experimentalFontWeight": true,
+            "__experimentalDefaultControls": {
+                "fontSize": true
+            }
+        }
+    }
+}

--- a/resources/js/visual-editor/blocks/single-post-types-search-results/edit.tsx
+++ b/resources/js/visual-editor/blocks/single-post-types-search-results/edit.tsx
@@ -1,0 +1,80 @@
+/**
+ * Single Post Type Search Results — editor-side component (#502).
+ *
+ * Lets the author pick which post type this section renders for and
+ * accepts any inner blocks they want to show for that post type.
+ * Intentionally ships no default template so authors decide what
+ * "results" looks like (a query loop, static cards, an empty state, …).
+ */
+
+import type { ReactElement } from 'react';
+import {
+    InspectorControls,
+    useBlockProps,
+    useInnerBlocksProps,
+} from '@wordpress/block-editor';
+import { PanelBody, SelectControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+import { TEXT_DOMAIN } from '../../vendor/i18n';
+import { getContentTypes } from '../../editor/content-type-registry';
+
+interface SinglePostTypesSearchResultsAttributes {
+    readonly postType: string;
+}
+
+interface SinglePostTypesSearchResultsEditProps {
+    readonly attributes: SinglePostTypesSearchResultsAttributes;
+    readonly setAttributes: (
+        next: Partial<SinglePostTypesSearchResultsAttributes>
+    ) => void;
+}
+
+export default function SinglePostTypesSearchResultsEdit({
+    attributes,
+    setAttributes,
+}: SinglePostTypesSearchResultsEditProps): ReactElement {
+    const { postType } = attributes;
+
+    const blockProps = useBlockProps({
+        className: 'ap-single-post-types-search-results',
+    });
+    // No default `template`: the section accepts any inner blocks the
+    // author wants to show for the matched post type. Forcing an
+    // `artisanpack/query` here would prepopulate a query-pagination
+    // sub-tree that's not always the right fit for a search result
+    // section, so we leave the choice to the author.
+    const innerBlocksProps = useInnerBlocksProps(blockProps, {});
+
+    const options = [
+        { value: 'all', label: __('All post types', TEXT_DOMAIN) },
+        ...getContentTypes().map((entry) => ({
+            value: entry.slug,
+            label: entry.label,
+        })),
+    ];
+
+    return (
+        <>
+            <InspectorControls>
+                <PanelBody
+                    title={__('Single post type results settings', TEXT_DOMAIN)}
+                    initialOpen
+                >
+                    <SelectControl
+                        label={__('Post type', TEXT_DOMAIN)}
+                        value={postType}
+                        options={options}
+                        onChange={(value) => setAttributes({ postType: value })}
+                        help={__(
+                            'Show this section when the host page\'s `?post_type=` matches this value. Choose "All post types" to show it when no parameter is set.',
+                            TEXT_DOMAIN
+                        )}
+                        __nextHasNoMarginBottom
+                    />
+                </PanelBody>
+            </InspectorControls>
+            <div {...innerBlocksProps} />
+        </>
+    );
+}

--- a/resources/js/visual-editor/blocks/single-post-types-search-results/index.ts
+++ b/resources/js/visual-editor/blocks/single-post-types-search-results/index.ts
@@ -1,0 +1,23 @@
+/**
+ * Single Post Type Search Results block entrypoint (#502).
+ *
+ * Child of `artisanpack/post-types-search-results`. Each instance owns
+ * a `postType` attribute; the renderers emit the wrapper + inner blocks
+ * only when the host page's `?post_type=` parameter matches the
+ * attribute (or when neither is set and the attribute is `all`).
+ */
+
+import metadata from './block.json';
+import edit from './edit';
+import save from './save';
+import icon from './inserter-icon';
+
+export { edit, save, metadata, icon };
+
+export default {
+    name: metadata.name,
+    metadata,
+    edit,
+    save,
+    icon,
+};

--- a/resources/js/visual-editor/blocks/single-post-types-search-results/inserter-icon.tsx
+++ b/resources/js/visual-editor/blocks/single-post-types-search-results/inserter-icon.tsx
@@ -1,0 +1,20 @@
+/**
+ * Single Post Type Search Results — inserter icon.
+ */
+
+import type { ReactElement } from 'react';
+
+export default function SinglePostTypesSearchResultsInserterIcon(): ReactElement {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            width={24}
+            height={24}
+            aria-hidden="true"
+            focusable="false"
+        >
+            <path d="M4 4h16v3H4V4zm0 6h10v3H4v-3zm0 6h16v3H4v-3z" />
+        </svg>
+    );
+}

--- a/resources/js/visual-editor/blocks/single-post-types-search-results/save.tsx
+++ b/resources/js/visual-editor/blocks/single-post-types-search-results/save.tsx
@@ -1,0 +1,11 @@
+/**
+ * Single Post Type Search Results — save component.
+ *
+ * Dynamic block: each renderer evaluates the `_resolvedActive` stamp
+ * (or falls back to `?post_type=` matching) and emits the wrapper +
+ * inner blocks only when the section applies to the current request.
+ */
+
+export default function SinglePostTypesSearchResultsSave(): null {
+    return null;
+}


### PR DESCRIPTION
## Description

Forks the six generic search-cluster blocks under the `artisanpack/*` namespace as first-party blocks with full Blade + React + Vue parity. The cluster lets visitors search and filter by post type + taxonomy term through a single GET form that posts back to the host site.

**Closes:** #502

## Type of Change

- [x] New feature (adds new functionality)
- [x] Bug fix (fixes an issue)

## Related Issue

**Issue:** #502

## Motivation and Context

CW6 of the upstream port (umbrella #495). These six blocks make up the generic, non-CPT-coupled half of the upstream search ecosystem. The CPT-coupled `project-*` / `download-*` siblings remain deferred per the umbrella scope. Two pre-existing bugs surfaced while wiring the new templates and were fixed in the same PR so the cluster renders cleanly end-to-end.

## Changes Made

- **6 new blocks** registered under `artisanpack/*`: `search-field`, `search-filters`, `search-filters-buttons`, `search-filters-taxonomy`, `post-types-search-results`, `single-post-types-search-results`. Each ships `block.json`, dynamic `save`, editor-side preview/inspector, inserter icon, and partials/components in all three renderers.
- **Request-state contract** — runtime values (`?s=`, `?{taxonomy}=`, `?post_type=`) arrive via `_resolved*` attribute stamps. Blade falls back to the live request when the host has not pre-resolved, and to a direct `cms-framework` `PostCategory` / `PostTag` lookup when `_resolvedTerms` is absent so the dropdown populates out of the box.
- **Renderer registration** — added the six names to both `registerCoreBlocks.ts` maps and the `packages/renderer-parity.json` manifest. `verify-renderer-parity.mjs` passes (150/150 blocks).
- **Tests** — new `search-cluster-family.test.ts` (block.json + save contract) and 7 React/Vue parity fixtures covering populated/empty term lists, taxonomy selection, unsafe action-URL drop, and active/inactive single-post-type sections.
- **Pre-existing bug: `__('Pagination')` collision** in `artisanpack/query-pagination` — Laravel ships `lang/en/pagination.php`, and the JSON translator's case-insensitive fallback matched the bare `Pagination` key against the file, returning the `['previous' => …, 'next' => …]` array and crashing `e()` downstream. Renamed the aria-label key to `'Pagination navigation'` with an inline note explaining the collision.
- **Pre-existing bug: Blade `@endif` lexer gap** — Blade's directive tokenizer doesn't recognize `@endif` when it sits directly after a non-whitespace character, so the literal `@endif` leaked into the compiled output and unbalanced the surrounding `<?php if(...): ?>`. Replaced the inline-attribute `@if` pattern in the new taxonomy template with a `@php` flag plus `{!! $flag ? ' selected' : '' !!}`.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (Darwin 25.5.0)
- Browser: Safari
- PHP Version: 8.4
- Project Version: `feature/495-port-crosswinds-blocks`

**Tests Performed:**
1. `./vendor/bin/pest` — **1078/1078 passing** (3039 assertions)
2. `npm test -- --run` — **2018/2018 passing** (239 test files)
3. `node scripts/verify-renderer-parity.mjs` — 150/150 blocks registered across blade/react/vue
4. Manual browser verification in the dev app: inserted all six blocks on a sample post; confirmed the form submits with the expected query string and the taxonomy dropdown populates from cms-framework's `PostCategory` / `PostTag` rows.

## Accessibility Tests Run

- [x] Keyboard navigation tested
- [x] ARIA labels checked

**Details:** All form fields have associated `<label for="…">`s. The taxonomy `<select>` uses a placeholder option marked as the empty default. The fix to `query-pagination.blade.php` also restores its `aria-label` to a non-colliding string.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:**

- `resources/js/visual-editor/blocks/__tests__/search-cluster-family.test.ts` — 17 tests covering namespace, textdomain, default attributes, parent/child relationship, and the dynamic-save contract for all six blocks.
- `packages/visual-editor-renderer-vue/tests/parity.test.ts` — 7 new fixtures asserting React/Vue produce byte-identical HTML for: empty + populated search-field, populated + URL-sanitized search-filters, the submit/reset button pair, taxonomy with + without resolved terms, and the active/inactive single-post-type result wrapper.

## Documentation

- [x] Inline code documentation added

**Documentation details:** Each new block file carries a header docblock describing its contract (request-state shape, parent/child constraints, runtime renderer responsibilities). The two pre-existing bug fixes carry inline comments explaining what failed and why, so future contributors don't reintroduce the same patterns.

## Pre-Submission Checklist

- [x] Code passes all tests
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “search cluster”: configurable search field, filters (taxonomy & post-type), submit/clear buttons, and post-type-aware results blocks.

* **Accessibility / Bug Fixes**
  * Clarified pagination aria-label to “Pagination navigation” to avoid translation-related rendering issues.

* **Tests**
  * Added renderer parity and unit tests covering the new search cluster components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->