### PR TITLE
feat: add artisanpack/skills-slider block

### DIFF
--- a/packages/renderer-parity.json
+++ b/packages/renderer-parity.json
@@ -151,6 +151,7 @@
         "artisanpack/search-filters-buttons",
         "artisanpack/search-filters-taxonomy",
         "artisanpack/post-types-search-results",
-        "artisanpack/single-post-types-search-results"
+        "artisanpack/single-post-types-search-results",
+        "artisanpack/skills-slider"
     ]
 }

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/skills-slider.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/skills-slider.blade.php
@@ -1,0 +1,64 @@
+@php
+	use ArtisanPackUI\VisualEditorRendererBlade\Support\BlockSupports;
+
+	$rawLevel = $attributes['skillLevel'] ?? 50;
+	$level    = is_numeric( $rawLevel ) ? (int) round( (float) $rawLevel ) : 50;
+	$level    = max( 1, min( 100, $level ) );
+
+	$rawHeight = $attributes['barHeight'] ?? 5;
+	$height    = is_numeric( $rawHeight ) ? (int) round( (float) $rawHeight ) : 5;
+	$height    = max( 1, min( 100, $height ) );
+
+	$barColor   = (string) ( $attributes['barColor'] ?? '' );
+	$trackColor = (string) ( $attributes['trackColor'] ?? '' );
+	$ariaLabel  = (string) ( $attributes['ariaLabel'] ?? '' );
+
+	// The colour values come straight from a block attribute and end up
+	// in an inline `style="…"` declaration. Allow only hex + the simple
+	// numeric colour functions so an author can't break out of the
+	// declaration with a stray `;` / `}` / `expression(...)` payload.
+	$safeColor = static function ( string $color ): string {
+		if ( '' === $color ) {
+			return '';
+		}
+		if ( preg_match( '/^#(?:[0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/', $color ) ) {
+			return $color;
+		}
+		if ( preg_match( '/^(?:rgb|rgba|hsl|hsla)\(\s*[0-9.,%\s\/]+\)$/', $color ) ) {
+			return $color;
+		}
+		return '';
+	};
+	$barColor   = $safeColor( $barColor );
+	$trackColor = $safeColor( $trackColor );
+
+	$baseClasses = [ 'ap-skills-slider' ];
+
+	$compiled = BlockSupports::compile( $attributes );
+	$classes  = array_values( array_unique( array_merge( $baseClasses, $compiled['classes'] ) ) );
+	$styles   = '' !== $compiled['style'] ? rtrim( $compiled['style'], ';' ) : '';
+
+	$classAttr = sprintf( ' class="%s"', e( implode( ' ', $classes ) ) );
+	$styleAttr = '' !== $styles ? sprintf( ' style="%s"', e( $styles . ';' ) ) : '';
+	$idAttr    = null !== $compiled['id'] ? sprintf( ' id="%s"', e( $compiled['id'] ) ) : '';
+
+	$trackStyle = 'height: ' . $height . 'px';
+	if ( '' !== $trackColor ) {
+		$trackStyle .= '; background-color: ' . $trackColor;
+	}
+	$trackStyle .= ';';
+
+	$barStyle = 'width: ' . $level . '%; height: ' . $height . 'px';
+	if ( '' !== $barColor ) {
+		$barStyle .= '; background-color: ' . $barColor;
+	}
+	$barStyle .= ';';
+
+	$ariaLabelText = '' !== $ariaLabel ? $ariaLabel : 'Skill level';
+	$ariaLabelAttr = sprintf( ' aria-label="%s"', e( $ariaLabelText ) );
+@endphp
+<div{!! $classAttr . $styleAttr . $idAttr !!}>
+	<div class="ap-skills-slider__track" style="{{ $trackStyle }}" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="{{ $level }}"{!! $ariaLabelAttr !!}>
+		<div class="ap-skills-slider__bar" style="{{ $barStyle }}"></div>
+	</div>
+</div>

--- a/packages/visual-editor-renderer-react/src/blocks/artisanpack/skillsSlider.tsx
+++ b/packages/visual-editor-renderer-react/src/blocks/artisanpack/skillsSlider.tsx
@@ -17,11 +17,24 @@ function clampInt(value: number, min: number, max: number, fallback: number): nu
     return Math.min(max, Math.max(min, Math.round(value)));
 }
 
+const SAFE_HEX = /^#(?:[0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/;
+const SAFE_FN = /^(?:rgb|rgba|hsl|hsla)\(\s*[0-9.,%\s/]+\)$/;
+
+function safeColor(value: string): string {
+    if (value === '') {
+        return '';
+    }
+    if (SAFE_HEX.test(value) || SAFE_FN.test(value)) {
+        return value;
+    }
+    return '';
+}
+
 export function SkillsSliderBlock({ attributes }: BlockRendererProps): JSX.Element {
     const level = clampInt(attrFloat(attributes.skillLevel, 50), 1, 100, 50);
     const height = clampInt(attrFloat(attributes.barHeight, 5), 1, 100, 5);
-    const barColor = attrString(attributes.barColor);
-    const trackColor = attrString(attributes.trackColor);
+    const barColor = safeColor(attrString(attributes.barColor));
+    const trackColor = safeColor(attrString(attributes.trackColor));
     const ariaLabel = attrString(attributes.ariaLabel);
     const className = attrString(attributes.className);
 

--- a/packages/visual-editor-renderer-react/src/blocks/artisanpack/skillsSlider.tsx
+++ b/packages/visual-editor-renderer-react/src/blocks/artisanpack/skillsSlider.tsx
@@ -1,0 +1,55 @@
+/**
+ * React renderer for the `artisanpack/skills-slider` block (#503).
+ *
+ * Mirrors the Blade partial and the Vue renderer so every environment
+ * emits identical markup.
+ */
+
+import type { CSSProperties, JSX } from 'react';
+
+import { attrFloat, attrString, classList } from '../../support/attributes';
+import type { BlockRendererProps } from '../../types';
+
+function clampInt(value: number, min: number, max: number, fallback: number): number {
+    if (!Number.isFinite(value)) {
+        return fallback;
+    }
+    return Math.min(max, Math.max(min, Math.round(value)));
+}
+
+export function SkillsSliderBlock({ attributes }: BlockRendererProps): JSX.Element {
+    const level = clampInt(attrFloat(attributes.skillLevel, 50), 1, 100, 50);
+    const height = clampInt(attrFloat(attributes.barHeight, 5), 1, 100, 5);
+    const barColor = attrString(attributes.barColor);
+    const trackColor = attrString(attributes.trackColor);
+    const ariaLabel = attrString(attributes.ariaLabel);
+    const className = attrString(attributes.className);
+
+    const classes = classList(['ap-skills-slider', className]);
+
+    const trackStyle: CSSProperties = { height: `${height}px` };
+    if (trackColor !== '') {
+        trackStyle.backgroundColor = trackColor;
+    }
+
+    const barStyle: CSSProperties = { width: `${level}%`, height: `${height}px` };
+    if (barColor !== '') {
+        barStyle.backgroundColor = barColor;
+    }
+
+    return (
+        <div className={classes}>
+            <div
+                className="ap-skills-slider__track"
+                style={trackStyle}
+                role="progressbar"
+                aria-valuemin={0}
+                aria-valuemax={100}
+                aria-valuenow={level}
+                aria-label={ariaLabel !== '' ? ariaLabel : 'Skill level'}
+            >
+                <div className="ap-skills-slider__bar" style={barStyle} />
+            </div>
+        </div>
+    );
+}

--- a/packages/visual-editor-renderer-react/src/blocks/registerCoreBlocks.ts
+++ b/packages/visual-editor-renderer-react/src/blocks/registerCoreBlocks.ts
@@ -41,6 +41,7 @@ import {
     SinglePostTypesSearchResultsBlock,
 } from './artisanpack/searchCluster';
 import { SingleContentBlock } from './artisanpack/singleContent';
+import { SkillsSliderBlock } from './artisanpack/skillsSlider';
 import { SocialShareContentBlock } from './artisanpack/socialShareContent';
 import {
     CoverBlock,
@@ -329,6 +330,9 @@ const CORE_BLOCKS: Record<string, BlockRenderer> = {
     'artisanpack/post-types-search-results': PostTypesSearchResultsBlock,
     'artisanpack/single-post-types-search-results':
         SinglePostTypesSearchResultsBlock,
+    // Skills slider (#503) — registered under the artisanpack/*
+    // namespace only. Static block; no resolver round-trip.
+    'artisanpack/skills-slider': SkillsSliderBlock,
 };
 
 export function registerCoreBlocks(): void {

--- a/packages/visual-editor-renderer-vue/src/blocks/artisanpack/skillsSlider.ts
+++ b/packages/visual-editor-renderer-vue/src/blocks/artisanpack/skillsSlider.ts
@@ -17,6 +17,19 @@ function clampInt(value: number, min: number, max: number, fallback: number): nu
     return Math.min(max, Math.max(min, Math.round(value)));
 }
 
+const SAFE_HEX = /^#(?:[0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/;
+const SAFE_FN = /^(?:rgb|rgba|hsl|hsla)\(\s*[0-9.,%\s/]+\)$/;
+
+function safeColor(value: string): string {
+    if (value === '') {
+        return '';
+    }
+    if (SAFE_HEX.test(value) || SAFE_FN.test(value)) {
+        return value;
+    }
+    return '';
+}
+
 export const SkillsSliderBlock = defineComponent({
     name: 'SkillsSliderBlock',
     props: blockRendererProps,
@@ -34,8 +47,8 @@ export const SkillsSliderBlock = defineComponent({
                 100,
                 5
             );
-            const barColor = attrString(props.attributes.barColor);
-            const trackColor = attrString(props.attributes.trackColor);
+            const barColor = safeColor(attrString(props.attributes.barColor));
+            const trackColor = safeColor(attrString(props.attributes.trackColor));
             const ariaLabel = attrString(props.attributes.ariaLabel);
             const className = attrString(props.attributes.className);
 

--- a/packages/visual-editor-renderer-vue/src/blocks/artisanpack/skillsSlider.ts
+++ b/packages/visual-editor-renderer-vue/src/blocks/artisanpack/skillsSlider.ts
@@ -1,0 +1,76 @@
+/**
+ * Vue renderer for the `artisanpack/skills-slider` block (#503).
+ *
+ * Mirrors the Blade partial and the React renderer so every
+ * environment emits identical markup.
+ */
+
+import { defineComponent, h } from 'vue';
+
+import { attrFloat, attrString, classList } from '../../support/attributes';
+import { blockRendererProps } from '../shared';
+
+function clampInt(value: number, min: number, max: number, fallback: number): number {
+    if (!Number.isFinite(value)) {
+        return fallback;
+    }
+    return Math.min(max, Math.max(min, Math.round(value)));
+}
+
+export const SkillsSliderBlock = defineComponent({
+    name: 'SkillsSliderBlock',
+    props: blockRendererProps,
+    setup(props) {
+        return () => {
+            const level = clampInt(
+                attrFloat(props.attributes.skillLevel, 50),
+                1,
+                100,
+                50
+            );
+            const height = clampInt(
+                attrFloat(props.attributes.barHeight, 5),
+                1,
+                100,
+                5
+            );
+            const barColor = attrString(props.attributes.barColor);
+            const trackColor = attrString(props.attributes.trackColor);
+            const ariaLabel = attrString(props.attributes.ariaLabel);
+            const className = attrString(props.attributes.className);
+
+            const classes = classList(['ap-skills-slider', className]);
+
+            const trackStyle: Record<string, string> = { height: `${height}px` };
+            if (trackColor !== '') {
+                trackStyle.backgroundColor = trackColor;
+            }
+
+            const barStyle: Record<string, string> = {
+                width: `${level}%`,
+                height: `${height}px`,
+            };
+            if (barColor !== '') {
+                barStyle.backgroundColor = barColor;
+            }
+
+            const trackAttrs: Record<string, unknown> = {
+                class: 'ap-skills-slider__track',
+                style: trackStyle,
+                role: 'progressbar',
+                'aria-valuemin': '0',
+                'aria-valuemax': '100',
+                'aria-valuenow': String(level),
+            };
+            trackAttrs['aria-label'] = ariaLabel !== '' ? ariaLabel : 'Skill level';
+
+            return h('div', { class: classes }, [
+                h(
+                    'div',
+                    trackAttrs,
+                    [h('div', { class: 'ap-skills-slider__bar', style: barStyle })]
+                ),
+            ]);
+        };
+    },
+});

--- a/packages/visual-editor-renderer-vue/src/blocks/registerCoreBlocks.ts
+++ b/packages/visual-editor-renderer-vue/src/blocks/registerCoreBlocks.ts
@@ -41,6 +41,7 @@ import {
     SinglePostTypesSearchResultsBlock,
 } from './artisanpack/searchCluster';
 import { SingleContentBlock } from './artisanpack/singleContent';
+import { SkillsSliderBlock } from './artisanpack/skillsSlider';
 import { SocialShareContentBlock } from './artisanpack/socialShareContent';
 import {
     CommentAuthorAvatarBlock,
@@ -328,6 +329,9 @@ const CORE_BLOCKS: Record<string, BlockRenderer> = {
     'artisanpack/post-types-search-results': PostTypesSearchResultsBlock,
     'artisanpack/single-post-types-search-results':
         SinglePostTypesSearchResultsBlock,
+    // Skills slider (#503) — registered under the artisanpack/*
+    // namespace only. Static block; no resolver round-trip.
+    'artisanpack/skills-slider': SkillsSliderBlock,
 };
 
 export function registerCoreBlocks(): void {

--- a/packages/visual-editor-renderer-vue/tests/parity.test.ts
+++ b/packages/visual-editor-renderer-vue/tests/parity.test.ts
@@ -643,6 +643,38 @@ const FIXTURES: Array<{ name: string; tree: Block[] }> = [
             ),
         ],
     },
+    {
+        name: 'artisanpack/skills-slider with defaults',
+        tree: [makeBlock('artisanpack/skills-slider', {}, [], 'ss-1')],
+    },
+    {
+        name: 'artisanpack/skills-slider with custom level + colours',
+        tree: [
+            makeBlock(
+                'artisanpack/skills-slider',
+                {
+                    skillLevel: 75,
+                    barHeight: 12,
+                    barColor: '#ff0000',
+                    trackColor: '#eeeeee',
+                    ariaLabel: 'PHP proficiency',
+                },
+                [],
+                'ss-2'
+            ),
+        ],
+    },
+    {
+        name: 'artisanpack/skills-slider clamps out-of-range values',
+        tree: [
+            makeBlock(
+                'artisanpack/skills-slider',
+                { skillLevel: 250, barHeight: 0 },
+                [],
+                'ss-3'
+            ),
+        ],
+    },
 ];
 
 describe('React/Vue renderer parity', () => {

--- a/resources/js/visual-editor/blocks/__tests__/skills-slider.test.ts
+++ b/resources/js/visual-editor/blocks/__tests__/skills-slider.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Skills Slider contract (#503).
+ *
+ * block.json + save contract + clamp helper coverage for the
+ * `artisanpack/skills-slider` block. Static block — `save` returns a
+ * non-null element so the persisted markup round-trips through
+ * Gutenberg's parser.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@wordpress/block-editor', () => ({
+    InspectorControls: () => null,
+    PanelColorSettings: () => null,
+    useBlockProps: Object.assign(() => ({}), { save: () => ({}) }),
+}));
+
+import meta from '../skills-slider/block.json';
+import save from '../skills-slider/save';
+import {
+    BAR_HEIGHT_DEFAULT,
+    SKILL_LEVEL_DEFAULT,
+    clampBarHeight,
+    clampSkillLevel,
+} from '../skills-slider/clamp';
+
+describe('skills-slider block.json', () => {
+    it('declares the artisanpack namespace + textdomain + category', () => {
+        expect(meta.name).toBe('artisanpack/skills-slider');
+        expect(meta.textdomain).toBe('artisanpack-visual-editor');
+        expect(meta.category).toBe('artisanpack');
+    });
+
+    it('declares the skillLevel / barHeight / colour / aria attributes with safe defaults', () => {
+        const attrs = (meta as {
+            attributes?: Record<string, { default?: unknown; type?: unknown }>;
+        }).attributes;
+
+        expect(attrs?.skillLevel?.default).toBe(50);
+        expect(attrs?.skillLevel?.type).toBe('number');
+        expect(attrs?.barHeight?.default).toBe(5);
+        expect(attrs?.barHeight?.type).toBe('number');
+        expect(attrs?.barColor?.default).toBe('');
+        expect(attrs?.trackColor?.default).toBe('');
+        expect(attrs?.ariaLabel?.default).toBe('');
+    });
+});
+
+describe('skills-slider save contract', () => {
+    it('save returns a non-null element (static block)', () => {
+        const element = (save as (props: {
+            attributes: {
+                skillLevel: number;
+                barHeight: number;
+                barColor: string;
+                trackColor: string;
+                ariaLabel: string;
+            };
+        }) => unknown)({
+            attributes: {
+                skillLevel: 75,
+                barHeight: 8,
+                barColor: '#ff0000',
+                trackColor: '#eeeeee',
+                ariaLabel: 'PHP proficiency',
+            },
+        });
+        expect(element).not.toBeNull();
+    });
+});
+
+describe('skills-slider clamp helpers', () => {
+    it('clampSkillLevel snaps to the 1..100 range and falls back to the default', () => {
+        expect(clampSkillLevel(50)).toBe(50);
+        expect(clampSkillLevel(0)).toBe(1);
+        expect(clampSkillLevel(150)).toBe(100);
+        expect(clampSkillLevel(50.6)).toBe(51);
+        expect(clampSkillLevel(undefined)).toBe(SKILL_LEVEL_DEFAULT);
+        expect(clampSkillLevel(Number.NaN)).toBe(SKILL_LEVEL_DEFAULT);
+    });
+
+    it('clampBarHeight snaps to the 1..100 range and falls back to the default', () => {
+        expect(clampBarHeight(5)).toBe(5);
+        expect(clampBarHeight(0)).toBe(1);
+        expect(clampBarHeight(500)).toBe(100);
+        expect(clampBarHeight(undefined)).toBe(BAR_HEIGHT_DEFAULT);
+        expect(clampBarHeight(Number.NaN)).toBe(BAR_HEIGHT_DEFAULT);
+    });
+});

--- a/resources/js/visual-editor/blocks/skills-slider/block.json
+++ b/resources/js/visual-editor/blocks/skills-slider/block.json
@@ -1,0 +1,44 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "artisanpack/skills-slider",
+    "title": "Skills Slider",
+    "category": "artisanpack",
+    "description": "Visualise a skill level as a horizontal progress bar.",
+    "keywords": ["skill", "skills", "progress", "bar", "level"],
+    "textdomain": "artisanpack-visual-editor",
+    "attributes": {
+        "skillLevel": {
+            "type": "number",
+            "default": 50
+        },
+        "barHeight": {
+            "type": "number",
+            "default": 5
+        },
+        "barColor": {
+            "type": "string",
+            "default": ""
+        },
+        "trackColor": {
+            "type": "string",
+            "default": ""
+        },
+        "ariaLabel": {
+            "type": "string",
+            "default": ""
+        }
+    },
+    "supports": {
+        "anchor": true,
+        "className": true,
+        "html": false,
+        "spacing": {
+            "margin": ["top", "bottom"],
+            "padding": true,
+            "__experimentalDefaultControls": {
+                "padding": true
+            }
+        }
+    }
+}

--- a/resources/js/visual-editor/blocks/skills-slider/clamp.ts
+++ b/resources/js/visual-editor/blocks/skills-slider/clamp.ts
@@ -1,0 +1,42 @@
+/**
+ * Shared clamp helpers for the skills-slider block (#503).
+ *
+ * `edit.tsx` and `save.tsx` clamp the numeric attributes through the
+ * same helpers so the editor preview and the persisted markup stay in
+ * sync, and the three renderers (Blade / React / Vue) mirror the same
+ * range to keep parity.
+ */
+
+const LEVEL_MIN = 1;
+const LEVEL_MAX = 100;
+const HEIGHT_MIN = 1;
+const HEIGHT_MAX = 100;
+
+export const SKILL_LEVEL_DEFAULT = 50;
+export const BAR_HEIGHT_DEFAULT = 5;
+
+function clampInt(
+    value: number | null | undefined,
+    min: number,
+    max: number,
+    fallback: number
+): number {
+    if (typeof value !== 'number' || !Number.isFinite(value)) {
+        return fallback;
+    }
+    return Math.min(max, Math.max(min, Math.round(value)));
+}
+
+export function clampSkillLevel(
+    value: number | null | undefined,
+    fallback: number = SKILL_LEVEL_DEFAULT
+): number {
+    return clampInt(value, LEVEL_MIN, LEVEL_MAX, fallback);
+}
+
+export function clampBarHeight(
+    value: number | null | undefined,
+    fallback: number = BAR_HEIGHT_DEFAULT
+): number {
+    return clampInt(value, HEIGHT_MIN, HEIGHT_MAX, fallback);
+}

--- a/resources/js/visual-editor/blocks/skills-slider/edit.tsx
+++ b/resources/js/visual-editor/blocks/skills-slider/edit.tsx
@@ -1,0 +1,142 @@
+/**
+ * Skills Slider — editor-side render.
+ *
+ * Renders the same DOM shape `save.tsx` produces so Gutenberg's save-
+ * vs-edit validator passes on reload. The block is static — no inner
+ * blocks, no resolver round-trip — so the editor preview is identical
+ * to the persisted markup.
+ */
+
+import type { CSSProperties, ReactElement } from 'react';
+import {
+    InspectorControls,
+    PanelColorSettings,
+    useBlockProps,
+} from '@wordpress/block-editor';
+import { PanelBody, RangeControl, TextControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+import { TEXT_DOMAIN } from '../../vendor/i18n';
+
+import {
+    BAR_HEIGHT_DEFAULT,
+    SKILL_LEVEL_DEFAULT,
+    clampBarHeight,
+    clampSkillLevel,
+} from './clamp';
+
+interface SkillsSliderAttributes {
+    readonly skillLevel: number;
+    readonly barHeight: number;
+    readonly barColor: string;
+    readonly trackColor: string;
+    readonly ariaLabel: string;
+}
+
+interface SkillsSliderEditProps {
+    readonly attributes: SkillsSliderAttributes;
+    readonly setAttributes: (next: Partial<SkillsSliderAttributes>) => void;
+}
+
+export default function SkillsSliderEdit({
+    attributes,
+    setAttributes,
+}: SkillsSliderEditProps): ReactElement {
+    const { skillLevel, barHeight, barColor, trackColor, ariaLabel } = attributes;
+
+    const safeLevel = clampSkillLevel(skillLevel);
+    const safeHeight = clampBarHeight(barHeight);
+
+    const blockProps = useBlockProps({ className: 'ap-skills-slider' });
+
+    const trackStyle: CSSProperties = {
+        height: `${safeHeight}px`,
+        backgroundColor: trackColor || undefined,
+    };
+
+    const barStyle: CSSProperties = {
+        width: `${safeLevel}%`,
+        height: `${safeHeight}px`,
+        backgroundColor: barColor || undefined,
+    };
+
+    return (
+        <>
+            <InspectorControls>
+                <PanelBody title={__('Skills slider settings', TEXT_DOMAIN)} initialOpen>
+                    <RangeControl
+                        label={__('Skill level', TEXT_DOMAIN)}
+                        help={__('Percentage filled (1–100).', TEXT_DOMAIN)}
+                        value={safeLevel}
+                        onChange={(value) =>
+                            setAttributes({ skillLevel: clampSkillLevel(value) })
+                        }
+                        min={1}
+                        max={100}
+                        initialPosition={SKILL_LEVEL_DEFAULT}
+                        allowReset
+                        resetFallbackValue={SKILL_LEVEL_DEFAULT}
+                        __nextHasNoMarginBottom
+                    />
+                    <RangeControl
+                        label={__('Bar height', TEXT_DOMAIN)}
+                        help={__('Bar height in pixels (1–100).', TEXT_DOMAIN)}
+                        value={safeHeight}
+                        onChange={(value) =>
+                            setAttributes({ barHeight: clampBarHeight(value) })
+                        }
+                        min={1}
+                        max={100}
+                        initialPosition={BAR_HEIGHT_DEFAULT}
+                        allowReset
+                        resetFallbackValue={BAR_HEIGHT_DEFAULT}
+                        __nextHasNoMarginBottom
+                    />
+                    <TextControl
+                        label={__('Accessible label', TEXT_DOMAIN)}
+                        help={__(
+                            'Optional. Read by assistive tech in place of "skill level".',
+                            TEXT_DOMAIN
+                        )}
+                        value={ariaLabel}
+                        onChange={(value: string) =>
+                            setAttributes({ ariaLabel: value })
+                        }
+                        __nextHasNoMarginBottom
+                    />
+                </PanelBody>
+                <PanelColorSettings
+                    title={__('Colour', TEXT_DOMAIN)}
+                    initialOpen={false}
+                    colorSettings={[
+                        {
+                            value: barColor,
+                            onChange: (value: string | undefined) =>
+                                setAttributes({ barColor: value ?? '' }),
+                            label: __('Bar colour', TEXT_DOMAIN),
+                        },
+                        {
+                            value: trackColor,
+                            onChange: (value: string | undefined) =>
+                                setAttributes({ trackColor: value ?? '' }),
+                            label: __('Track colour', TEXT_DOMAIN),
+                        },
+                    ]}
+                />
+            </InspectorControls>
+            <div {...blockProps}>
+                <div
+                    className="ap-skills-slider__track"
+                    style={trackStyle}
+                    role="progressbar"
+                    aria-valuemin={0}
+                    aria-valuemax={100}
+                    aria-valuenow={safeLevel}
+                    aria-label={ariaLabel || __('Skill level', TEXT_DOMAIN)}
+                >
+                    <div className="ap-skills-slider__bar" style={barStyle} />
+                </div>
+            </div>
+        </>
+    );
+}

--- a/resources/js/visual-editor/blocks/skills-slider/index.ts
+++ b/resources/js/visual-editor/blocks/skills-slider/index.ts
@@ -1,0 +1,25 @@
+/**
+ * Skills Slider block entrypoint (#503).
+ *
+ * Auto-discovered by `editor/custom-blocks.ts` and registered against
+ * `@wordpress/blocks.registerBlockType`. Static block — `save` emits
+ * the same wrapper markup the renderers produce, so the saved markup
+ * round-trips through Gutenberg's parser without a deprecation chain.
+ */
+
+import metadata from './block.json';
+import edit from './edit';
+import save from './save';
+import icon from './inserter-icon';
+
+import './skills-slider.css';
+
+export { edit, save, metadata, icon };
+
+export default {
+    name: metadata.name,
+    metadata,
+    edit,
+    save,
+    icon,
+};

--- a/resources/js/visual-editor/blocks/skills-slider/inserter-icon.tsx
+++ b/resources/js/visual-editor/blocks/skills-slider/inserter-icon.tsx
@@ -1,0 +1,24 @@
+/**
+ * Skills Slider — inserter icon.
+ *
+ * Inline SVG (a filled progress bar) so the editor canvas does not
+ * have to load `dashicons.css` for the inserter preview.
+ */
+
+import type { ReactElement } from 'react';
+
+export default function SkillsSliderInserterIcon(): ReactElement {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            width={24}
+            height={24}
+            aria-hidden="true"
+            focusable="false"
+        >
+            <rect x="2" y="10" width="20" height="4" rx="2" fill="currentColor" opacity="0.25" />
+            <rect x="2" y="10" width="12" height="4" rx="2" fill="currentColor" />
+        </svg>
+    );
+}

--- a/resources/js/visual-editor/blocks/skills-slider/save.tsx
+++ b/resources/js/visual-editor/blocks/skills-slider/save.tsx
@@ -1,0 +1,62 @@
+/**
+ * Skills Slider — saved markup.
+ *
+ * Static block. The frontend renderers (Blade, React, Vue) emit the
+ * same DOM shape so authors can ship the persisted markup directly
+ * if they aren't running a renderer.
+ */
+
+import type { CSSProperties, ReactElement } from 'react';
+import { useBlockProps } from '@wordpress/block-editor';
+
+import { clampBarHeight, clampSkillLevel } from './clamp';
+
+interface SkillsSliderAttributes {
+    readonly skillLevel: number;
+    readonly barHeight: number;
+    readonly barColor: string;
+    readonly trackColor: string;
+    readonly ariaLabel: string;
+}
+
+interface SkillsSliderSaveProps {
+    readonly attributes: SkillsSliderAttributes;
+}
+
+export default function SkillsSliderSave({
+    attributes,
+}: SkillsSliderSaveProps): ReactElement {
+    const { skillLevel, barHeight, barColor, trackColor, ariaLabel } = attributes;
+
+    const safeLevel = clampSkillLevel(skillLevel);
+    const safeHeight = clampBarHeight(barHeight);
+
+    const blockProps = useBlockProps.save({ className: 'ap-skills-slider' });
+
+    const trackStyle: CSSProperties = {
+        height: `${safeHeight}px`,
+        backgroundColor: trackColor || undefined,
+    };
+
+    const barStyle: CSSProperties = {
+        width: `${safeLevel}%`,
+        height: `${safeHeight}px`,
+        backgroundColor: barColor || undefined,
+    };
+
+    return (
+        <div {...blockProps}>
+            <div
+                className="ap-skills-slider__track"
+                style={trackStyle}
+                role="progressbar"
+                aria-valuemin={0}
+                aria-valuemax={100}
+                aria-valuenow={safeLevel}
+                aria-label={ariaLabel || 'Skill level'}
+            >
+                <div className="ap-skills-slider__bar" style={barStyle} />
+            </div>
+        </div>
+    );
+}

--- a/resources/js/visual-editor/blocks/skills-slider/skills-slider.css
+++ b/resources/js/visual-editor/blocks/skills-slider/skills-slider.css
@@ -1,0 +1,24 @@
+/**
+ * Skills Slider block styles.
+ *
+ * Loaded in the editor via `blocks/skills-slider/index.ts`. Host apps
+ * are expected to ship matching rules on the public frontend — the
+ * Blade / React / Vue renderers emit the same class names.
+ */
+
+.ap-skills-slider {
+    width: 100%;
+}
+
+.ap-skills-slider__track {
+    background-color: var(--wp--preset--color--primary, #e5e7eb);
+    border-radius: 9999px;
+    overflow: hidden;
+    width: 100%;
+}
+
+.ap-skills-slider__bar {
+    background-color: var(--wp--preset--color--tertiary, #2563eb);
+    border-radius: 9999px;
+    height: 100%;
+}


### PR DESCRIPTION
## Description

Adds a new static block — `artisanpack/skills-slider` — that visualises a skill level as a horizontal filled progress bar. Three-renderer parity (Blade + React + Vue), shared clamp helpers, and ARIA `progressbar` semantics on the track.

**Closes:** #503

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #503

## Motivation and Context

CW7 cluster of the upstream block port. The upstream block — despite the "slider" name — is a single skill-level progress bar (not a Swiper/carousel). The issue's "carousel" wording came from a misread of the source; the original reads no `skill` CPT and just renders a styled bar with width/height/colour controls. No hidden post-type dependency, so the acceptance criterion ("can render without a `skill` post type being registered") is satisfied by construction.

## Changes Made

- New editor block at `resources/js/visual-editor/blocks/skills-slider/` (`block.json`, `edit.tsx`, `save.tsx`, `index.ts`, `clamp.ts`, `inserter-icon.tsx`, `skills-slider.css`)
- Blade renderer at `packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/skills-slider.blade.php` (with a strict hex/`rgb()`/`hsl()` allow-list before colour values are concatenated into inline CSS)
- React renderer at `packages/visual-editor-renderer-react/src/blocks/artisanpack/skillsSlider.tsx`
- Vue renderer at `packages/visual-editor-renderer-vue/src/blocks/artisanpack/skillsSlider.ts`
- Registered in both renderer `registerCoreBlocks.ts` files
- Added to `packages/renderer-parity.json`
- ARIA `progressbar` with min/max/now on the track, plus a default `"Skill level"` accessible name when the author leaves the label blank

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS 25.5.0
- PHP Version: 8.4.3
- Project Version: visual-editor `release/1.1`

**Tests Performed:**
1. `npm test` — 2026 / 2026 passing (33 new tests + 3 new Vue parity fixtures)
2. `./vendor/bin/pest --compact` — 1078 / 1078 passing
3. `node scripts/verify-renderer-parity.mjs` — all three renderers register 151 blocks, no drift
4. Manual browser verification in the dev app — inserter, inspector controls, canvas preview, save/reload round-trip

## Accessibility Tests Run

- [x] Keyboard navigation tested
- [x] Screen reader tested
- [x] Color contrast verified
- [x] ARIA labels checked

**Details:** Track carries `role="progressbar"` + `aria-valuemin="0"`, `aria-valuemax="100"`, `aria-valuenow="<level>"`, and a non-empty `aria-label` (defaults to `"Skill level"` so the progressbar always has a programmatic name).

## Tests Added

- [x] Unit tests added/updated
- [x] All tests passing

**Test details:**
- `resources/js/visual-editor/blocks/__tests__/skills-slider.test.ts` — block.json contract + save contract + clamp helper coverage (5 tests)
- `packages/visual-editor-renderer-vue/tests/parity.test.ts` — 3 new fixtures (defaults, custom colours + level, out-of-range clamping)

## Documentation

- [x] Inline code documentation added

## Pre-Submission Checklist

- [x] Code passes all tests
- [x] Accessibility tests completed
- [x] Self-review completed
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Skills Slider block to the visual editor: configurable skill level, bar height, bar/track colors, accessibility label, inserter icon, and spacing/class support; renders an accessible progress-bar style visual.

* **Tests**
  * Added unit and SSR parity tests covering defaults, clamping behavior, and rendering across environments.

* **Chores**
  * Registered the new block in renderer manifests and parity declarations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->