### PR TITLE
feat: block animations — entrance/hover/continuous + custom keyframes (#489)

### DIFF
--- a/config/visual-editor.php
+++ b/config/visual-editor.php
@@ -464,6 +464,65 @@ return [
 
 	/*
 	|--------------------------------------------------------------------------
+	| Block animations (#489)
+	|--------------------------------------------------------------------------
+	|
+	| Animations the InspectorControls "Animations" panel offers and the
+	| renderer emits CSS for. Three families:
+	|
+	|   - entrance  : plays once on viewport entry (IntersectionObserver)
+	|   - hover     : transition curve + preset on `:hover`
+	|   - continuous: loop animation
+	|
+	| Resolved in priority order:
+	|
+	|   1. Active theme's `theme.json` → `settings.custom.artisanpack.animations`
+	|   2. This config array (host-app overrides)
+	|   3. `AnimationRegistry::DEFAULTS`
+	|
+	| Each entry is `[family => [key => definition]]`. To remove a built-in,
+	| set its key to `null`. See `AnimationRegistry::validate()` for the
+	| required shape per family.
+	|
+	*/
+
+	'animations' => [
+		// 'entrance' => [
+		//     'fade-in-blur' => [
+		//         'label'    => 'Fade in (blur)',
+		//         'keyframe' => 'apFadeInBlur',
+		//         'duration' => 700,
+		//         'easing'   => 'ease-out',
+		//     ],
+		// ],
+	],
+
+	/*
+	|--------------------------------------------------------------------------
+	| Custom keyframes (#489)
+	|--------------------------------------------------------------------------
+	|
+	| Named `@keyframes` blocks the host wants available in the editor's
+	| animation dropdowns. These are merged with whatever the active
+	| theme.json declares under `settings.custom.artisanpack.keyframes`
+	| and with editor-authored keyframes persisted in the Global Styles
+	| JSON. Built-in names are reserved.
+	|
+	*/
+
+	'keyframes' => [
+		// [
+		//     'name'  => 'confetti',
+		//     'stops' => [
+		//         [ 'at' => '0%',   'transform' => 'translateY(0)' ],
+		//         [ 'at' => '50%',  'transform' => 'translateY(-12px) rotate(10deg)' ],
+		//         [ 'at' => '100%', 'transform' => 'translateY(0)' ],
+		//     ],
+		// ],
+	],
+
+	/*
+	|--------------------------------------------------------------------------
 	| Site editor (H5)
 	|--------------------------------------------------------------------------
 	|

--- a/docs/animations.md
+++ b/docs/animations.md
@@ -1,0 +1,172 @@
+# Block Animations
+
+Block animations let editors attach motion to any block that opts into
+`supports.artisanpackAnimations`. The system covers three families:
+
+- **Entrance** — plays once when the block enters the viewport
+  (IntersectionObserver-driven).
+- **Hover** — a transition curve + composable preset
+  (`lift`, `press`, `glow`) on `:hover`.
+- **Continuous** — a CSS loop animation
+  (`pulse`, `bounce`, `spin`, `ping`, `wiggle`, `float`).
+
+It is CSS-first. The server emits a single `<style data-ve-animations>`
+block per page that holds the `@keyframes` definitions plus the scoped
+rules for every block on the page. A small (~3 KB gzipped) JS runtime
+ships only on pages that have at least one entrance animation; it
+swaps an `ap-anim-pre` class for `ap-anim-play` when the block scrolls
+into view.
+
+`prefers-reduced-motion: reduce` is respected by default. Editors can
+opt a single block out by setting **Respect reduced motion** to off in
+the inspector.
+
+## Attribute shape
+
+Stored on the block as `attributes.artisanpackAnimations`:
+
+```json
+{
+    "entrance": {
+        "name":      "fade-in-up",
+        "duration":  600,
+        "delay":     100,
+        "easing":    "ease-out",
+        "threshold": 0.2,
+        "once":      true
+    },
+    "hover": {
+        "name":     "lift",
+        "duration": 200,
+        "easing":   "ease-out"
+    },
+    "continuous": {
+        "name":     "pulse",
+        "duration": 2000,
+        "easing":   "ease-in-out",
+        "count":    "infinite"
+    },
+    "reducedMotion": "respect"
+}
+```
+
+The `entrance.name` and `continuous.name` fields are
+responsive-aware — pass a `{ base, sm, md, lg, xl, 2xl }` map to enable
+different motions per breakpoint, or `null` at a specific breakpoint to
+disable the animation there:
+
+```json
+{ "entrance": { "name": { "base": "fade-in", "md": null } } }
+```
+
+## Registry layers
+
+Animations are resolved in priority order, highest layer wins on key
+collision:
+
+1. **`theme.json` →** `settings.custom.artisanpack.animations`
+2. **app config →** `artisanpack.visual-editor.animations`
+3. **package defaults →** `AnimationRegistry::DEFAULTS`
+
+To remove a built-in animation, set its key to `null` in a higher
+layer.
+
+```php
+// config/artisanpack/visual-editor.php
+'animations' => [
+    'entrance' => [
+        'flip-x'        => null, // drop a built-in
+        'fade-in-blur'  => [
+            'label'    => 'Fade in (blur)',
+            'keyframe' => 'apFadeInBlur',
+            'duration' => 700,
+            'easing'   => 'ease-out',
+        ],
+    ],
+],
+```
+
+## Custom keyframes
+
+Hosts and themes can author named `@keyframes` blocks two ways.
+
+**Config** — declare them on the package config:
+
+```php
+'keyframes' => [
+    [
+        'name'  => 'confetti',
+        'stops' => [
+            [ 'at' => '0%',   'transform' => 'translateY(0)' ],
+            [ 'at' => '50%',  'transform' => 'translateY(-12px) rotate(10deg)' ],
+            [ 'at' => '100%', 'transform' => 'translateY(0)' ],
+        ],
+    ],
+],
+```
+
+**Site Editor UI** — open Styles → Animations and use the Custom
+Keyframe editor. Authored keyframes persist into the Global Styles
+JSON (`styles.custom.artisanpack.keyframes`) and reappear on reload.
+
+Allowed stop properties: `transform`, `opacity`, `filter`, `color`,
+`background-color`, `box-shadow`. Built-in keyframe names (`apFadeIn`,
+`apPulse`, etc.) are reserved.
+
+## Renderer integration
+
+The Blade renderer exposes
+`AnimationMarkupResolver::resolve( $scope, $attributes )` which returns
+the wrapper classes, the data attributes, and the scoped CSS the
+partial drops onto the block. Per-block CSS is funnelled through
+`AnimationCssAccumulator`, which drains once at the top of every
+`<x-ve-blocks>` render into a single `<style data-ve-animations>` tag
+plus a `<noscript>` reveal block.
+
+The React and Vue renderers expose a framework-agnostic
+`resolveAnimationMarkup( attributes )` that returns the same class list
++ data-attribute shape so the runtime sees identical markup regardless
+of renderer.
+
+## Runtime
+
+Loaded once per page (`@artisanpack-ui/visual-editor/animations/runtime`).
+On load it:
+
+1. Reads `prefers-reduced-motion`. If reduce is set, suppresses
+   entrance animations unless the block sets
+   `data-ap-anim-reduced="allow"`.
+2. Builds one `IntersectionObserver` per requested threshold; observes
+   every `[data-ap-anim-entrance]` element.
+3. When a block enters the viewport at its configured threshold,
+   removes `ap-anim-pre` and adds `ap-anim-play`, which carries the
+   real `animation` shorthand.
+4. By default unobserves after one play. Blocks with
+   `data-ap-anim-once="false"` are rearmed when they leave the
+   viewport.
+5. Watches `MutationObserver` for entrance blocks that arrive after
+   bootstrap (e.g. revealed by an accordion expand) and observes them
+   the same way.
+
+Target bundle size: **<5 KB gzipped**. The runtime is intentionally
+side-effecting at import time, so a `<script type="module">` tag is
+all the renderer needs.
+
+## Accessibility
+
+- `prefers-reduced-motion: reduce` is respected by default at both the
+  CSS layer (a `@media` block resets `animation` + `transition` to
+  `none` and `opacity`/`transform` to their final state) and the JS
+  layer (the runtime skips IntersectionObserver setup).
+- A `<noscript>` rule reveals every entrance block in its final state
+  when JS doesn't run.
+- The inspector panel surfaces the reduced-motion preference per block
+  so a designer can intentionally allow motion on essential animations.
+
+## Testing
+
+- Pest unit suites: `tests/Unit/VisualEditor/Animations/*`
+- Pest feature suite: `packages/visual-editor-renderer-blade/tests/Feature/AnimationMarkupResolverTest.php`
+- Vitest: `resources/js/visual-editor/animations/__tests__/*`
+- Playwright spec (deactivated until the runner is wired in CI):
+  `tests/E2E/animations.spec.ts`

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/core/cover.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/core/cover.blade.php
@@ -96,10 +96,15 @@
 		// Scope-hash logic mirrors BlockSupports::resolveAnimations so a
 		// block rendered by either path collides on the same scope key
 		// and the accumulator dedupes correctly.
+		// `serialize()` is the deterministic content-stable fallback —
+		// `spl_object_hash()` would key on object identity, which would
+		// break dedupe across identical attribute bags rendered in
+		// separate passes (e.g. cached fragments).
 		$animationsJson   = json_encode( $attributes );
-		$animationsSuffix = false === $animationsJson
-			? substr( spl_object_hash( (object) $attributes ), 0, 8 )
-			: substr( hash( 'sha1', $animationsJson ), 0, 8 );
+		$animationsSource = false === $animationsJson
+			? serialize( $attributes )
+			: $animationsJson;
+		$animationsSuffix = substr( hash( 'sha1', $animationsSource ), 0, 8 );
 		$animationsScope    = '.ap-block-' . $animationsSuffix;
 		$animationsResolver = app( AnimationMarkupResolver::class );
 		$animationsMarkup   = $animationsResolver->resolve( $animationsScope, $animationsAttr );

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/core/cover.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/core/cover.blade.php
@@ -1,4 +1,6 @@
 @php
+	use ArtisanPackUI\VisualEditorRendererBlade\Animations\AnimationMarkupResolver;
+	use ArtisanPackUI\VisualEditorRendererBlade\Services\AnimationCssAccumulator;
 	use ArtisanPackUI\VisualEditorRendererBlade\Support\BlockSupports;
 
 	$url    = (string) ( $attributes['url'] ?? '' );
@@ -81,8 +83,48 @@
 
 	$styleAttr = '' !== $style ? sprintf( ' style="%s"', e( $style . ';' ) ) : '';
 	$idAttr    = null !== $compiled['id'] ? sprintf( ' id="%s"', e( $compiled['id'] ) ) : '';
+
+	// #489 — resolve any block-animation attribute bag, attach the
+	// wrapper classes + data attributes, and push the per-block CSS
+	// into the accumulator so the BlocksComponent emits a single
+	// `<style data-ve-animations>` block at the top of the response.
+	$animationsAttr = is_array( $attributes['artisanpackAnimations'] ?? null )
+		? (array) $attributes['artisanpackAnimations']
+		: [];
+	$animationsString = '';
+	if ( [] !== $animationsAttr ) {
+		// Scope-hash logic mirrors BlockSupports::resolveAnimations so a
+		// block rendered by either path collides on the same scope key
+		// and the accumulator dedupes correctly.
+		$animationsJson   = json_encode( $attributes );
+		$animationsSuffix = false === $animationsJson
+			? substr( spl_object_hash( (object) $attributes ), 0, 8 )
+			: substr( hash( 'sha1', $animationsJson ), 0, 8 );
+		$animationsScope    = '.ap-block-' . $animationsSuffix;
+		$animationsResolver = app( AnimationMarkupResolver::class );
+		$animationsMarkup   = $animationsResolver->resolve( $animationsScope, $animationsAttr );
+
+		if ( $animationsMarkup['hasAnimations'] ) {
+			foreach ( $animationsMarkup['classes'] as $animationsClass ) {
+				$classes[] = $animationsClass;
+			}
+			$classes[] = ltrim( $animationsScope, '.' );
+
+			app( AnimationCssAccumulator::class )->push(
+				$animationsScope,
+				$animationsMarkup['css'],
+				$animationsMarkup['noscriptCss'],
+				$animationsMarkup['hasEntrance'],
+			);
+
+			$animationsString = $animationsResolver->dataString( $animationsMarkup['data'] );
+			if ( '' !== $animationsString ) {
+				$animationsString = ' ' . $animationsString;
+			}
+		}
+	}
 @endphp
-<div class="{{ implode( ' ', $classes ) }}"{!! $styleAttr !!}{!! $idAttr !!}>
+<div class="{{ implode( ' ', $classes ) }}"{!! $styleAttr !!}{!! $idAttr !!}{!! $animationsString !!}>
 	<span aria-hidden="true" class="wp-block-cover__background has-background-dim" style="opacity: {{ $dimRatio / 100 }};"></span>
 	@if ( '' !== $url )
 		<img class="wp-block-cover__image-background" alt="{{ $alt }}" src="{{ $url }}"/>

--- a/packages/visual-editor-renderer-blade/resources/views/components/blocks.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/components/blocks.blade.php
@@ -13,4 +13,19 @@
 {!! $statesCss !!}
 @endif
 @endisset
+@isset( $animationsCss )
+@if( '' !== $animationsCss )
+{!! $animationsCss !!}
+@endif
+@endisset
+@isset( $animationsNoscript )
+@if( '' !== $animationsNoscript )
+{!! $animationsNoscript !!}
+@endif
+@endisset
 {!! $html !!}
+@isset( $animationsRuntimeNeeded )
+@if( $animationsRuntimeNeeded )
+@include('visual-editor-renderer-blade::partials.animations-runtime')
+@endif
+@endisset

--- a/packages/visual-editor-renderer-blade/resources/views/components/template.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/components/template.blade.php
@@ -20,6 +20,16 @@
 {!! $statesCss !!}
 @endif
 @endisset
+@isset( $animationsCss )
+@if( '' !== $animationsCss )
+{!! $animationsCss !!}
+@endif
+@endisset
+@isset( $animationsNoscript )
+@if( '' !== $animationsNoscript )
+{!! $animationsNoscript !!}
+@endif
+@endisset
 <div class="{{ implode( ' ', $wrapperClasses ) }}" data-ve-template="{{ $slug }}"@if( null !== $matchedSlug && $matchedSlug !== $slug ) data-ve-matched-template="{{ $matchedSlug }}"@endif>
 @if( null !== $resolutionError )
 @if( $inDev )
@@ -29,3 +39,8 @@
 {!! $html !!}
 @endif
 </div>
+@isset( $animationsRuntimeNeeded )
+@if( $animationsRuntimeNeeded )
+@include('visual-editor-renderer-blade::partials.animations-runtime')
+@endif
+@endisset

--- a/packages/visual-editor-renderer-blade/resources/views/partials/animations-runtime.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/partials/animations-runtime.blade.php
@@ -83,15 +83,25 @@ the editor's exported `bootstrapAnimationsRuntime`. --}}
 
 		function observeEntry( el ) {
 			if ( entries.has( el ) ) return;
+			// Reduced-motion must be checked BEFORE the hasIO gate —
+			// otherwise no-IntersectionObserver browsers play the
+			// entrance even when the user prefers reduced motion. The
+			// per-block `data-ap-anim-reduced="allow"` override still
+			// lets a designer keep motion on essential animations.
+			if ( reducedMotion && 'allow' !== el.getAttribute( 'data-ap-anim-reduced' ) ) {
+				play( el );
+				// Record a played entry so a later MutationObserver
+				// callback for the same node (e.g. it was re-parented)
+				// short-circuits at `entries.has( el )` above.
+				entries.set( el, { threshold: 0, once: true, played: true } );
+				return;
+			}
 			// No IntersectionObserver → reveal immediately. The noscript
 			// fallback handles the no-JS case; this branch handles
 			// JS-but-stone-age-browser.
 			if ( ! hasIO ) {
 				play( el );
-				return;
-			}
-			if ( reducedMotion && 'allow' !== el.getAttribute( 'data-ap-anim-reduced' ) ) {
-				play( el );
+				entries.set( el, { threshold: 0, once: true, played: true } );
 				return;
 			}
 			var t = thresholdFor( el );

--- a/packages/visual-editor-renderer-blade/resources/views/partials/animations-runtime.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/partials/animations-runtime.blade.php
@@ -50,25 +50,14 @@ the editor's exported `bootstrapAnimationsRuntime`. --}}
 			return;
 		}
 
-		var byThreshold = {};
 		var entries = new Map();
+		var observersByThreshold = {};
 
-		Array.prototype.forEach.call(
-			document.querySelectorAll( '[data-ap-anim-entrance]' ),
-			function ( el ) {
-				if ( reducedMotion && 'allow' !== el.getAttribute( 'data-ap-anim-reduced' ) ) {
-					play( el );
-					return;
-				}
-				var t = thresholdFor( el );
-				var key = String( t );
-				var once = 'false' !== el.getAttribute( 'data-ap-anim-once' );
-				entries.set( el, { threshold: t, once: once, played: false } );
-				( byThreshold[ key ] = byThreshold[ key ] || [] ).push( el );
+		function observerFor( t ) {
+			var key = String( t );
+			if ( observersByThreshold[ key ] ) {
+				return observersByThreshold[ key ];
 			}
-		);
-
-		Object.keys( byThreshold ).forEach( function ( key ) {
 			var observer = new IntersectionObserver(
 				function ( ioEntries ) {
 					ioEntries.forEach( function ( ioEntry ) {
@@ -89,10 +78,51 @@ the editor's exported `bootstrapAnimationsRuntime`. --}}
 						}
 					} );
 				},
-				{ threshold: parseFloat( key ) }
+				{ threshold: t }
 			);
-			byThreshold[ key ].forEach( function ( el ) { observer.observe( el ); } );
-		} );
+			observersByThreshold[ key ] = observer;
+			return observer;
+		}
+
+		function observeEntry( el ) {
+			if ( entries.has( el ) ) return;
+			if ( reducedMotion && 'allow' !== el.getAttribute( 'data-ap-anim-reduced' ) ) {
+				play( el );
+				return;
+			}
+			var t = thresholdFor( el );
+			var once = 'false' !== el.getAttribute( 'data-ap-anim-once' );
+			entries.set( el, { threshold: t, once: once, played: false } );
+			observerFor( t ).observe( el );
+		}
+
+		Array.prototype.forEach.call(
+			document.querySelectorAll( '[data-ap-anim-entrance]' ),
+			observeEntry
+		);
+
+		// Mirror the TS runtime: pick up entrance elements that arrive
+		// after init() — e.g. inserted by a client-side accordion expand
+		// or a query-loop pagination swap — so they animate on first
+		// reveal instead of staying in the pre-state.
+		if ( 'undefined' !== typeof MutationObserver ) {
+			new MutationObserver( function ( mutations ) {
+				mutations.forEach( function ( mutation ) {
+					Array.prototype.forEach.call( mutation.addedNodes, function ( node ) {
+						if ( ! node || 1 !== node.nodeType ) return;
+						if ( node.matches && node.matches( '[data-ap-anim-entrance]' ) ) {
+							observeEntry( node );
+						}
+						if ( node.querySelectorAll ) {
+							Array.prototype.forEach.call(
+								node.querySelectorAll( '[data-ap-anim-entrance]' ),
+								observeEntry
+							);
+						}
+					} );
+				} );
+			} ).observe( document.body, { childList: true, subtree: true } );
+		}
 	}
 
 	if ( 'loading' === document.readyState ) {

--- a/packages/visual-editor-renderer-blade/resources/views/partials/animations-runtime.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/partials/animations-runtime.blade.php
@@ -1,0 +1,104 @@
+{{-- Block animations runtime (#489).
+
+The minimal inline counterpart of `resources/js/visual-editor/animations/runtime.ts`.
+Emitted on published pages that include at least one entrance animation. ~1 KB
+gzipped. The full TypeScript runtime is the canonical implementation; this
+inline copy exists so the Blade renderer doesn't depend on a host bundling
+the editor's exported `bootstrapAnimationsRuntime`. --}}
+<script>
+(function () {
+	if ( ! document.querySelector( '[data-ap-anim-entrance]' ) ) {
+		return;
+	}
+
+	var PRE = 'ap-anim-pre';
+	var PLAY = 'ap-anim-play';
+
+	function reduced() {
+		return window.matchMedia
+			&& window.matchMedia( '(prefers-reduced-motion: reduce)' ).matches;
+	}
+
+	function thresholdFor( el ) {
+		var raw = el.getAttribute( 'data-ap-anim-threshold' );
+		if ( null === raw ) return 0.2;
+		var v = parseFloat( raw );
+		if ( isNaN( v ) ) return 0.2;
+		if ( v < 0 ) return 0;
+		if ( v > 1 ) return 1;
+		return v;
+	}
+
+	function play( el ) {
+		el.classList.remove( PRE );
+		el.classList.add( PLAY );
+	}
+
+	function rearm( el ) {
+		el.classList.remove( PLAY );
+		el.classList.add( PRE );
+	}
+
+	function init() {
+		var reducedMotion = reduced();
+
+		if ( 'undefined' === typeof IntersectionObserver ) {
+			Array.prototype.forEach.call(
+				document.querySelectorAll( '.' + PRE ),
+				play
+			);
+			return;
+		}
+
+		var byThreshold = {};
+		var entries = new Map();
+
+		Array.prototype.forEach.call(
+			document.querySelectorAll( '[data-ap-anim-entrance]' ),
+			function ( el ) {
+				if ( reducedMotion && 'allow' !== el.getAttribute( 'data-ap-anim-reduced' ) ) {
+					play( el );
+					return;
+				}
+				var t = thresholdFor( el );
+				var key = String( t );
+				var once = 'false' !== el.getAttribute( 'data-ap-anim-once' );
+				entries.set( el, { threshold: t, once: once, played: false } );
+				( byThreshold[ key ] = byThreshold[ key ] || [] ).push( el );
+			}
+		);
+
+		Object.keys( byThreshold ).forEach( function ( key ) {
+			var observer = new IntersectionObserver(
+				function ( ioEntries ) {
+					ioEntries.forEach( function ( ioEntry ) {
+						var meta = entries.get( ioEntry.target );
+						if ( ! meta ) return;
+						if ( ioEntry.isIntersecting ) {
+							if ( ! meta.played ) {
+								play( ioEntry.target );
+								meta.played = true;
+								if ( meta.once ) {
+									observer.unobserve( ioEntry.target );
+									entries.delete( ioEntry.target );
+								}
+							}
+						} else if ( ! meta.once && meta.played ) {
+							rearm( ioEntry.target );
+							meta.played = false;
+						}
+					} );
+				},
+				{ threshold: parseFloat( key ) }
+			);
+			byThreshold[ key ].forEach( function ( el ) { observer.observe( el ); } );
+		} );
+	}
+
+	if ( 'loading' === document.readyState ) {
+		document.addEventListener( 'DOMContentLoaded', init, { once: true } );
+	} else {
+		init();
+	}
+})();
+</script>

--- a/packages/visual-editor-renderer-blade/resources/views/partials/animations-runtime.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/partials/animations-runtime.blade.php
@@ -41,14 +41,11 @@ the editor's exported `bootstrapAnimationsRuntime`. --}}
 
 	function init() {
 		var reducedMotion = reduced();
-
-		if ( 'undefined' === typeof IntersectionObserver ) {
-			Array.prototype.forEach.call(
-				document.querySelectorAll( '.' + PRE ),
-				play
-			);
-			return;
-		}
+		// No-IO browsers reveal everything synchronously — but the
+		// MutationObserver path below still wires up so late-inserted
+		// nodes get revealed too (they'd otherwise stay frozen in the
+		// pre-state forever).
+		var hasIO = 'undefined' !== typeof IntersectionObserver;
 
 		var entries = new Map();
 		var observersByThreshold = {};
@@ -86,6 +83,13 @@ the editor's exported `bootstrapAnimationsRuntime`. --}}
 
 		function observeEntry( el ) {
 			if ( entries.has( el ) ) return;
+			// No IntersectionObserver → reveal immediately. The noscript
+			// fallback handles the no-JS case; this branch handles
+			// JS-but-stone-age-browser.
+			if ( ! hasIO ) {
+				play( el );
+				return;
+			}
 			if ( reducedMotion && 'allow' !== el.getAttribute( 'data-ap-anim-reduced' ) ) {
 				play( el );
 				return;

--- a/packages/visual-editor-renderer-blade/src/Animations/AnimationMarkupResolver.php
+++ b/packages/visual-editor-renderer-blade/src/Animations/AnimationMarkupResolver.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * Animation markup resolver — Blade renderer (#489).
+ *
+ * Bridges the editor's `artisanpackAnimations` attribute bag to the
+ * markup pieces a Blade partial needs:
+ *
+ *  - The CSS scope (`.ap-block-<uid>`) the per-block rules attach to.
+ *  - The class list to add to the block wrapper (`ap-anim`,
+ *    `ap-anim-pre` for entrance blocks).
+ *  - The `data-ap-anim-*` attribute map the runtime keys off.
+ *  - The CSS string itself (`<style>` payload).
+ *  - The noscript fallback CSS (wrapped in `<noscript>` by the caller).
+ *
+ * The class list and data map are returned as arrays so the partial can
+ * `implode` them into the existing attribute soup without parsing.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditorRendererBlade
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.1.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditorRendererBlade\Animations;
+
+use ArtisanPackUI\VisualEditor\Animations\AnimationCssEmitter;
+
+class AnimationMarkupResolver
+{
+	public function __construct( protected AnimationCssEmitter $emitter ) {}
+
+	/**
+	 * Resolves the bag for one block scope. Returns the markup pieces a
+	 * Blade partial needs as a single associative array.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param  string                $scope        e.g. `.ap-block-abc123`.
+	 * @param  array<string, mixed>  $attributes   The `artisanpackAnimations` bag.
+	 *
+	 * @return array{
+	 *     hasAnimations: bool,
+	 *     hasEntrance: bool,
+	 *     classes: array<int, string>,
+	 *     data: array<string, string>,
+	 *     css: string,
+	 *     noscriptCss: string,
+	 * }
+	 */
+	public function resolve( string $scope, array $attributes ): array
+	{
+		return [
+			'hasAnimations' => $this->emitter->hasAny( $attributes ),
+			'hasEntrance'   => $this->emitter->hasEntrance( $attributes ),
+			'classes'       => $this->emitter->wrapperClasses( $attributes ),
+			'data'          => $this->emitter->dataAttributes( $attributes ),
+			'css'           => $this->emitter->emit( $scope, $attributes ),
+			'noscriptCss'   => $this->emitter->noscriptCss( $scope ),
+		];
+	}
+
+	/**
+	 * Emits the data-* attribute soup as a `key="value"`-joined HTML
+	 * fragment, ready to drop into a Blade attribute slot.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param  array<string, string>  $data
+	 */
+	public function dataString( array $data ): string
+	{
+		$pieces = [];
+		foreach ( $data as $key => $value ) {
+			$pieces[] = sprintf( '%s="%s"', $key, htmlspecialchars( $value, ENT_QUOTES, 'UTF-8' ) );
+		}
+
+		return implode( ' ', $pieces );
+	}
+}

--- a/packages/visual-editor-renderer-blade/src/Services/AnimationCssAccumulator.php
+++ b/packages/visual-editor-renderer-blade/src/Services/AnimationCssAccumulator.php
@@ -1,0 +1,145 @@
+<?php
+
+/**
+ * Per-request accumulator for the block-animations CSS (#489).
+ *
+ * Block partials push their per-block animation CSS rule strings into
+ * this service while rendering. The `<x-ve-blocks>` / `<x-ve-template>`
+ * components then drain it once and emit a single
+ * `<style data-ve-animations>` block at the top of the render output,
+ * followed by the runtime-loading hint and the `<noscript>` fallback
+ * payload.
+ *
+ * Mirrors {@see StateCssAccumulator} — same dedupe-by-scope semantics,
+ * same scoped-per-request lifetime — so the three accumulators compose
+ * naturally in the same render pass.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditorRendererBlade
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.1.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditorRendererBlade\Services;
+
+use ArtisanPackUI\VisualEditor\Animations\KeyframeRegistry;
+
+class AnimationCssAccumulator
+{
+	/**
+	 * Map of scope class → CSS rule string.
+	 *
+	 * @var array<string, string>
+	 */
+	protected array $rules = [];
+
+	/**
+	 * Map of scope class → noscript CSS rule string.
+	 *
+	 * @var array<string, string>
+	 */
+	protected array $noscript = [];
+
+	/**
+	 * Tracks whether any pushed block declared an entrance animation —
+	 * so the renderer knows whether to attach the runtime chunk and the
+	 * `<noscript>` fallback.
+	 */
+	protected bool $hasEntrance = false;
+
+	public function __construct( protected KeyframeRegistry $keyframes ) {}
+
+	/**
+	 * Records a block scope's animation CSS plus the noscript fallback
+	 * CSS that reveals it when JS is unavailable.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param  string  $scope        Scope class (e.g. `.ap-block-abc123`).
+	 * @param  string  $css          The animation CSS rule string.
+	 * @param  string  $noscriptCss  The noscript fallback CSS rule string.
+	 * @param  bool    $hasEntrance  Whether this scope uses an entrance
+	 *                               animation. Drives runtime emission.
+	 */
+	public function push( string $scope, string $css, string $noscriptCss, bool $hasEntrance ): void
+	{
+		if ( '' === $scope ) {
+			return;
+		}
+
+		if ( '' !== $css && ! isset( $this->rules[ $scope ] ) ) {
+			$this->rules[ $scope ] = $css;
+		}
+
+		if ( $hasEntrance && '' !== $noscriptCss && ! isset( $this->noscript[ $scope ] ) ) {
+			$this->noscript[ $scope ] = $noscriptCss;
+		}
+
+		if ( $hasEntrance ) {
+			$this->hasEntrance = true;
+		}
+	}
+
+	/**
+	 * Returns the consolidated emission — `@keyframes` + scoped rules,
+	 * the `<noscript>` reveal block, and a boolean indicating whether
+	 * the renderer should attach the runtime chunk.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return array{styleTag: string, noscriptTag: string, runtimeNeeded: bool}
+	 */
+	public function flush(): array
+	{
+		if ( [] === $this->rules && ! $this->hasEntrance ) {
+			$this->reset();
+
+			return [ 'styleTag' => '', 'noscriptTag' => '', 'runtimeNeeded' => false ];
+		}
+
+		$keyframesCss = $this->keyframes->emitCss();
+		$body         = $keyframesCss . ' ' . implode( ' ', array_values( $this->rules ) );
+		$styleTag     = '<style data-ve-animations>' . trim( $body ) . '</style>';
+
+		$noscriptTag = '';
+		if ( $this->hasEntrance && [] !== $this->noscript ) {
+			$noscriptTag = '<noscript><style>' . implode( ' ', array_values( $this->noscript ) ) . '</style></noscript>';
+		}
+
+		$runtimeNeeded = $this->hasEntrance;
+
+		$this->reset();
+
+		return [ 'styleTag' => $styleTag, 'noscriptTag' => $noscriptTag, 'runtimeNeeded' => $runtimeNeeded ];
+	}
+
+	/**
+	 * @since 1.1.0
+	 */
+	public function reset(): void
+	{
+		$this->rules       = [];
+		$this->noscript    = [];
+		$this->hasEntrance = false;
+	}
+
+	/**
+	 * Inspect what's currently accumulated without draining. Test-only.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return array{rules: array<string, string>, noscript: array<string, string>, hasEntrance: bool}
+	 */
+	public function all(): array
+	{
+		return [
+			'rules'       => $this->rules,
+			'noscript'    => $this->noscript,
+			'hasEntrance' => $this->hasEntrance,
+		];
+	}
+}

--- a/packages/visual-editor-renderer-blade/src/Support/BlockSupports.php
+++ b/packages/visual-editor-renderer-blade/src/Support/BlockSupports.php
@@ -755,6 +755,20 @@ class BlockSupports
 			static fn ( string $class ): bool => '' !== trim( $class ),
 		) ) );
 
+		// #489 — drop the animation wrapper classes, scope class, and
+		// data-* attributes onto any block carrying an
+		// `artisanpackAnimations` attribute bag. Centralising it here
+		// means every block partial that uses `wrapperAttrs` (image,
+		// table, navigation, etc.) picks up animations for free; cover
+		// builds its attrs by hand and handles this inline.
+		$animations = self::resolveAnimations( $attributes );
+
+		if ( null !== $animations ) {
+			foreach ( $animations['classes'] as $class ) {
+				$classes[] = $class;
+			}
+		}
+
 		$parts = [];
 
 		if ( [] !== $classes ) {
@@ -769,7 +783,73 @@ class BlockSupports
 			$parts[] = sprintf( 'id="%s"', e( $compiled['id'] ) );
 		}
 
+		if ( null !== $animations && '' !== $animations['dataString'] ) {
+			$parts[] = $animations['dataString'];
+		}
+
 		return [] === $parts ? '' : ' ' . implode( ' ', $parts );
+	}
+
+	/**
+	 * Resolves the animation markup pieces for a block scope and pushes
+	 * the per-block CSS into the request-scoped accumulator. Returns
+	 * `null` when the block has no animations configured.
+	 *
+	 * The scope class is derived from a stable hash of the block's
+	 * attribute bag so identical render passes (e.g. the same block
+	 * inside a query loop) collide on key, letting the accumulator
+	 * dedupe.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param  array<string, mixed>  $attributes
+	 *
+	 * @return array{classes: array<int, string>, dataString: string}|null
+	 */
+	protected static function resolveAnimations( array $attributes ): ?array
+	{
+		$bag = $attributes['artisanpackAnimations'] ?? null;
+		if ( ! is_array( $bag ) || [] === $bag ) {
+			return null;
+		}
+
+		if ( ! function_exists( 'app' ) ) {
+			return null;
+		}
+
+		try {
+			$resolver = app( \ArtisanPackUI\VisualEditorRendererBlade\Animations\AnimationMarkupResolver::class );
+			$accumulator = app( \ArtisanPackUI\VisualEditorRendererBlade\Services\AnimationCssAccumulator::class );
+		} catch ( \Throwable $e ) {
+			return null;
+		}
+
+		$hashSource = json_encode( $attributes );
+		$scopeSuffix = false === $hashSource
+			? substr( spl_object_hash( (object) $attributes ), 0, 8 )
+			: substr( hash( 'sha1', $hashSource ), 0, 8 );
+		$scope = '.ap-block-' . $scopeSuffix;
+
+		$markup = $resolver->resolve( $scope, $bag );
+
+		if ( ! $markup['hasAnimations'] ) {
+			return null;
+		}
+
+		$accumulator->push(
+			$scope,
+			$markup['css'],
+			$markup['noscriptCss'],
+			$markup['hasEntrance'],
+		);
+
+		$classes = $markup['classes'];
+		$classes[] = ltrim( $scope, '.' );
+
+		return [
+			'classes'    => $classes,
+			'dataString' => $resolver->dataString( $markup['data'] ),
+		];
 	}
 
 	/**

--- a/packages/visual-editor-renderer-blade/src/Support/BlockSupports.php
+++ b/packages/visual-editor-renderer-blade/src/Support/BlockSupports.php
@@ -824,11 +824,14 @@ class BlockSupports
 			return null;
 		}
 
-		$hashSource = json_encode( $attributes );
-		$scopeSuffix = false === $hashSource
-			? substr( spl_object_hash( (object) $attributes ), 0, 8 )
-			: substr( hash( 'sha1', $hashSource ), 0, 8 );
-		$scope = '.ap-block-' . $scopeSuffix;
+		// `serialize()` is the deterministic content-stable fallback —
+		// `spl_object_hash()` keys on object identity, which would
+		// break dedupe across identical bags rendered in separate
+		// passes (e.g. cached fragments).
+		$hashSource  = json_encode( $attributes );
+		$source      = false === $hashSource ? serialize( $attributes ) : $hashSource;
+		$scopeSuffix = substr( hash( 'sha1', $source ), 0, 8 );
+		$scope       = '.ap-block-' . $scopeSuffix;
 
 		$markup = $resolver->resolve( $scope, $bag );
 

--- a/packages/visual-editor-renderer-blade/src/View/Components/BlocksComponent.php
+++ b/packages/visual-editor-renderer-blade/src/View/Components/BlocksComponent.php
@@ -34,6 +34,7 @@ use ArtisanPackUI\VisualEditor\SiteEditor\NavigationBlockRefResolver;
 use ArtisanPackUI\VisualEditorRendererBlade\BlockRenderer;
 use ArtisanPackUI\VisualEditorRendererBlade\Resolvers\BreadcrumbsResolver;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\GlobalStylesEmissionResolver;
+use ArtisanPackUI\VisualEditorRendererBlade\Services\AnimationCssAccumulator;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\ResponsiveCssAccumulator;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\StateCssAccumulator;
 use Illuminate\Contracts\View\View;
@@ -67,6 +68,7 @@ class BlocksComponent extends Component
 		protected GlobalStylesEmissionTracker $emissionTracker,
 		protected ResponsiveCssAccumulator $responsiveAccumulator,
 		protected StateCssAccumulator $stateAccumulator,
+		protected AnimationCssAccumulator $animationAccumulator,
 		mixed $tree = null,
 		?string $defaultTheme = null,
 		mixed $post = null,
@@ -158,14 +160,18 @@ class BlocksComponent extends Component
 		// by the time we drain the accumulator. The drained block
 		// is then prepended to the output by the view template.
 		$html          = $this->renderer->render( $this->tree );
-		$responsiveCss = $this->responsiveAccumulator->flush();
-		$statesCss     = $this->stateAccumulator->flush();
+		$responsiveCss   = $this->responsiveAccumulator->flush();
+		$statesCss       = $this->stateAccumulator->flush();
+		$animationOutput = $this->animationAccumulator->flush();
 
 		return view( 'visual-editor-renderer-blade::components.blocks', [
 			'html'            => $html,
 			'globalStylesCss' => $this->resolveGlobalStylesCss(),
 			'responsiveCss'   => $responsiveCss,
 			'statesCss'       => $statesCss,
+			'animationsCss'   => $animationOutput['styleTag'],
+			'animationsNoscript' => $animationOutput['noscriptTag'],
+			'animationsRuntimeNeeded' => $animationOutput['runtimeNeeded'],
 		] );
 	}
 

--- a/packages/visual-editor-renderer-blade/src/View/Components/TemplateComponent.php
+++ b/packages/visual-editor-renderer-blade/src/View/Components/TemplateComponent.php
@@ -35,6 +35,7 @@ use ArtisanPackUI\VisualEditor\SiteEditor\NavigationBlockRefResolver;
 use ArtisanPackUI\VisualEditor\Services\GlobalStylesEmissionTracker;
 use ArtisanPackUI\VisualEditorRendererBlade\BlockRenderer;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\GlobalStylesEmissionResolver;
+use ArtisanPackUI\VisualEditorRendererBlade\Services\AnimationCssAccumulator;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\ResponsiveCssAccumulator;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\StateCssAccumulator;
 use Illuminate\Contracts\Foundation\Application;
@@ -76,6 +77,7 @@ class TemplateComponent extends Component
 		protected GlobalStylesEmissionTracker $emissionTracker,
 		protected ResponsiveCssAccumulator $responsiveAccumulator,
 		protected StateCssAccumulator $stateAccumulator,
+		protected AnimationCssAccumulator $animationAccumulator,
 		string $slug,
 		?string $theme = null,
 	) {
@@ -115,8 +117,9 @@ class TemplateComponent extends Component
 		// where `$this->html` is assigned), so every block partial
 		// has had a chance to push its responsive rules in by now.
 		// See BlocksComponent::render() for the same pattern.
-		$responsiveCss = $this->responsiveAccumulator->flush();
-		$statesCss     = $this->stateAccumulator->flush();
+		$responsiveCss   = $this->responsiveAccumulator->flush();
+		$statesCss       = $this->stateAccumulator->flush();
+		$animationOutput = $this->animationAccumulator->flush();
 
 		return view( 'visual-editor-renderer-blade::components.template', [
 			'slug'            => $this->slug,
@@ -129,6 +132,9 @@ class TemplateComponent extends Component
 			'globalStylesCss' => $this->resolveGlobalStylesCss(),
 			'responsiveCss'   => $responsiveCss,
 			'statesCss'       => $statesCss,
+			'animationsCss'   => $animationOutput['styleTag'],
+			'animationsNoscript' => $animationOutput['noscriptTag'],
+			'animationsRuntimeNeeded' => $animationOutput['runtimeNeeded'],
 		] );
 	}
 

--- a/packages/visual-editor-renderer-blade/src/VisualEditorRendererBladeServiceProvider.php
+++ b/packages/visual-editor-renderer-blade/src/VisualEditorRendererBladeServiceProvider.php
@@ -26,7 +26,11 @@ use ArtisanPackUI\VisualEditor\Responsive\ResponsiveValueResolver;
 use ArtisanPackUI\VisualEditorRendererBlade\Resolvers\BreadcrumbsResolver;
 use ArtisanPackUI\VisualEditorRendererBlade\Resolvers\LoginoutResolver;
 use ArtisanPackUI\VisualEditorRendererBlade\Resolvers\SiteMetaResolver;
+use ArtisanPackUI\VisualEditor\Animations\AnimationCssEmitter;
+use ArtisanPackUI\VisualEditor\Animations\KeyframeRegistry;
+use ArtisanPackUI\VisualEditorRendererBlade\Animations\AnimationMarkupResolver;
 use ArtisanPackUI\VisualEditorRendererBlade\Responsive\ResponsiveClassResolver;
+use ArtisanPackUI\VisualEditorRendererBlade\Services\AnimationCssAccumulator;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\GlobalStylesEmissionResolver;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\NavigationOverlayTracker;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\ResponsiveCssAccumulator;
@@ -124,6 +128,21 @@ class VisualEditorRendererBladeServiceProvider extends ServiceProvider
 		// responsive accumulator above.
 		$this->app->scoped( StateCssAccumulator::class, function () {
 			return new StateCssAccumulator();
+		} );
+
+		// #489 — block-animations resolver + accumulator. Same lifetime
+		// story as the responsive / state accumulators: scoped per
+		// request so worker-runtime hosts don't leak across requests.
+		$this->app->scoped( AnimationMarkupResolver::class, function ( $app ) {
+			return new AnimationMarkupResolver(
+				$app->make( AnimationCssEmitter::class ),
+			);
+		} );
+
+		$this->app->scoped( AnimationCssAccumulator::class, function ( $app ) {
+			return new AnimationCssAccumulator(
+				$app->make( KeyframeRegistry::class ),
+			);
 		} );
 	}
 

--- a/packages/visual-editor-renderer-blade/tests/Feature/AnimationCoverIntegrationTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Feature/AnimationCoverIntegrationTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare( strict_types=1 );
+
+use Illuminate\Support\Facades\Blade;
+
+it( 'wires the block-animations bag into the cover blade partial', function () {
+	$tree = [
+		[
+			'clientId'    => 'cover-1',
+			'name'        => 'artisanpack/cover',
+			'attributes'  => [
+				'url'                   => 'https://example.test/image.jpg',
+				'alt'                   => 'Cover image',
+				'artisanpackAnimations' => [
+					'entrance' => [
+						'name'      => 'fade-in-up',
+						'threshold' => 0.3,
+					],
+				],
+			],
+			'innerBlocks' => [],
+		],
+	];
+
+	$rendered = Blade::render( '<x-ve-blocks :tree="$tree" />', [ 'tree' => $tree ] );
+
+	// The block wrapper picks up the runtime classes + data attributes.
+	expect( $rendered )->toContain( 'ap-anim ap-anim-pre' );
+	expect( $rendered )->toContain( 'data-ap-anim-entrance="fade-in-up"' );
+	expect( $rendered )->toContain( 'data-ap-anim-threshold="0.3"' );
+
+	// The accumulator emits a single `<style data-ve-animations>` block
+	// with the `@keyframes` definitions plus the scoped rule.
+	expect( $rendered )->toContain( '<style data-ve-animations>' );
+	expect( $rendered )->toContain( '@keyframes apFadeInUp' );
+	expect( $rendered )->toContain( '@media (prefers-reduced-motion: reduce)' );
+
+	// The noscript fallback reveals the block when JS is disabled.
+	expect( $rendered )->toContain( '<noscript>' );
+	expect( $rendered )->toContain( 'opacity: 1' );
+
+	// The inline runtime ships only when at least one entrance animation
+	// is on the page.
+	expect( $rendered )->toContain( 'data-ap-anim-entrance' );
+	expect( $rendered )->toContain( 'IntersectionObserver' );
+} );
+
+it( 'wires the block-animations bag into the image blade partial via wrapperAttrs', function () {
+	$tree = [
+		[
+			'clientId'    => 'image-1',
+			'name'        => 'artisanpack/image',
+			'attributes'  => [
+				'url'                   => 'https://example.test/photo.jpg',
+				'alt'                   => 'Photo',
+				'artisanpackAnimations' => [
+					'entrance' => [ 'name' => 'fade-in-up', 'threshold' => 0.3 ],
+				],
+			],
+			'innerBlocks' => [],
+		],
+	];
+
+	$rendered = Blade::render( '<x-ve-blocks :tree="$tree" />', [ 'tree' => $tree ] );
+
+	expect( $rendered )->toContain( 'data-ap-anim-entrance="fade-in-up"' );
+	expect( $rendered )->toContain( 'data-ap-anim-threshold="0.3"' );
+	expect( $rendered )->toContain( 'ap-anim' );
+	expect( $rendered )->toContain( 'ap-anim-pre' );
+	expect( $rendered )->toContain( '<style data-ve-animations>' );
+	expect( $rendered )->toContain( '@keyframes apFadeInUp' );
+	expect( $rendered )->toContain( 'IntersectionObserver' );
+} );
+
+it( 'omits the animation infrastructure entirely when no block opts in', function () {
+	$tree = [
+		[
+			'clientId'    => 'cover-1',
+			'name'        => 'artisanpack/cover',
+			'attributes'  => [ 'url' => 'https://example.test/image.jpg' ],
+			'innerBlocks' => [],
+		],
+	];
+
+	$rendered = Blade::render( '<x-ve-blocks :tree="$tree" />', [ 'tree' => $tree ] );
+
+	expect( $rendered )->not->toContain( 'data-ve-animations' );
+	expect( $rendered )->not->toContain( 'data-ap-anim-entrance' );
+	expect( $rendered )->not->toContain( 'IntersectionObserver' );
+} );

--- a/packages/visual-editor-renderer-blade/tests/Feature/AnimationCoverIntegrationTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Feature/AnimationCoverIntegrationTest.php
@@ -73,6 +73,41 @@ it( 'wires the block-animations bag into the image blade partial via wrapperAttr
 	expect( $rendered )->toContain( 'IntersectionObserver' );
 } );
 
+it( 'inlines the runtime with the reduced-motion check before the no-IO branch', function () {
+	// Regression for the CodeRabbit critical finding: the inline
+	// runtime must respect `prefers-reduced-motion: reduce` in
+	// no-IntersectionObserver browsers too. Verifying the source
+	// ordering is the closest the Pest layer can get without a JS
+	// engine — vitest can't reach the Blade-embedded script.
+	$tree = [
+		[
+			'clientId'    => 'image-1',
+			'name'        => 'artisanpack/image',
+			'attributes'  => [
+				'url'                   => 'https://example.test/photo.jpg',
+				'artisanpackAnimations' => [ 'entrance' => [ 'name' => 'fade-in' ] ],
+			],
+			'innerBlocks' => [],
+		],
+	];
+
+	$rendered = \Illuminate\Support\Facades\Blade::render( '<x-ve-blocks :tree="$tree" />', [ 'tree' => $tree ] );
+
+	// Find the `observeEntry` body specifically — `! hasIO` also
+	// appears earlier as part of the comment / variable declaration,
+	// which would confuse a naïve `strpos`.
+	$observe = strpos( $rendered, 'function observeEntry' );
+	expect( $observe )->not->toBeFalse();
+
+	$body      = substr( $rendered, $observe );
+	$reducedAt = strpos( $body, 'reducedMotion &&' );
+	$hasIoAt   = strpos( $body, 'if ( ! hasIO )' );
+
+	expect( $reducedAt )->not->toBeFalse();
+	expect( $hasIoAt )->not->toBeFalse();
+	expect( $reducedAt < $hasIoAt )->toBeTrue();
+} );
+
 it( 'omits the animation infrastructure entirely when no block opts in', function () {
 	$tree = [
 		[

--- a/packages/visual-editor-renderer-blade/tests/Feature/AnimationMarkupResolverTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Feature/AnimationMarkupResolverTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Animations\AnimationCssEmitter;
+use ArtisanPackUI\VisualEditorRendererBlade\Animations\AnimationMarkupResolver;
+
+it( 'resolves the markup pieces a Blade partial needs for an entrance block', function () {
+	$emitter  = $this->app->make( AnimationCssEmitter::class );
+	$resolver = new AnimationMarkupResolver( $emitter );
+
+	$markup = $resolver->resolve( '.ap-block-abc', [
+		'entrance' => [ 'name' => 'fade-in-up', 'threshold' => 0.3 ],
+	] );
+
+	expect( $markup['hasAnimations'] )->toBeTrue();
+	expect( $markup['hasEntrance'] )->toBeTrue();
+	expect( $markup['classes'] )->toContain( 'ap-anim' );
+	expect( $markup['classes'] )->toContain( 'ap-anim-pre' );
+	expect( $markup['data']['data-ap-anim-entrance'] )->toBe( 'fade-in-up' );
+	expect( $markup['data']['data-ap-anim-threshold'] )->toBe( '0.3' );
+	expect( $markup['css'] )->toContain( 'apFadeInUp' );
+	expect( $markup['css'] )->not->toBeEmpty();
+	expect( $markup['noscriptCss'] )->toContain( 'opacity: 1' );
+} );
+
+it( 'returns an empty result for a block without animations', function () {
+	$emitter  = $this->app->make( AnimationCssEmitter::class );
+	$resolver = new AnimationMarkupResolver( $emitter );
+
+	$markup = $resolver->resolve( '.ap-block-abc', [] );
+
+	expect( $markup['hasAnimations'] )->toBeFalse();
+	expect( $markup['classes'] )->toBe( [] );
+	expect( $markup['data'] )->toBe( [] );
+	expect( $markup['css'] )->toBe( '' );
+} );
+
+it( 'escapes attribute values when serialising to a string', function () {
+	$emitter  = $this->app->make( AnimationCssEmitter::class );
+	$resolver = new AnimationMarkupResolver( $emitter );
+
+	$string = $resolver->dataString( [ 'data-ap-x' => 'foo"bar' ] );
+
+	expect( $string )->toContain( '&quot;' );
+} );

--- a/packages/visual-editor-renderer-blade/tests/Unit/AnimationCssAccumulatorTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Unit/AnimationCssAccumulatorTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Animations\KeyframeRegistry;
+use ArtisanPackUI\VisualEditorRendererBlade\Services\AnimationCssAccumulator;
+
+function makeAnimAccumulator(): AnimationCssAccumulator
+{
+	return new AnimationCssAccumulator( new KeyframeRegistry() );
+}
+
+it( 'emits an empty result when nothing is pushed', function () {
+	$flushed = makeAnimAccumulator()->flush();
+
+	expect( $flushed['styleTag'] )->toBe( '' );
+	expect( $flushed['noscriptTag'] )->toBe( '' );
+	expect( $flushed['runtimeNeeded'] )->toBeFalse();
+} );
+
+it( 'wraps accumulated rules in a single <style> tag with built-in keyframes', function () {
+	$accumulator = makeAnimAccumulator();
+	$accumulator->push( '.ap-block-a', '.ap-block-a { animation: apFadeIn 600ms; }', '', false );
+	$accumulator->push( '.ap-block-b', '.ap-block-b { animation: apPulse 2s infinite; }', '', false );
+
+	$flushed = $accumulator->flush();
+
+	expect( $flushed['styleTag'] )->toStartWith( '<style data-ve-animations>' );
+	expect( $flushed['styleTag'] )->toEndWith( '</style>' );
+	expect( $flushed['styleTag'] )->toContain( '@keyframes apFadeIn' );
+	expect( $flushed['styleTag'] )->toContain( '.ap-block-a' );
+	expect( $flushed['styleTag'] )->toContain( '.ap-block-b' );
+} );
+
+it( 'collects noscript fallbacks only for entrance blocks', function () {
+	$accumulator = makeAnimAccumulator();
+	$accumulator->push(
+		'.ap-block-a',
+		'.ap-block-a.ap-anim-pre { opacity: 0; }',
+		'.ap-block-a.ap-anim-pre { opacity: 1; transform: none; }',
+		true,
+	);
+
+	$flushed = $accumulator->flush();
+
+	expect( $flushed['noscriptTag'] )->toContain( '<noscript>' );
+	expect( $flushed['noscriptTag'] )->toContain( 'opacity: 1' );
+	expect( $flushed['runtimeNeeded'] )->toBeTrue();
+} );
+
+it( 'deduplicates pushes for the same scope', function () {
+	$accumulator = makeAnimAccumulator();
+	$accumulator->push( '.ap-block-a', '.ap-block-a { animation: apFadeIn; }', '', false );
+	$accumulator->push( '.ap-block-a', '.ap-block-a { animation: apPulse; }', '', false );
+
+	$state = $accumulator->all();
+
+	expect( count( $state['rules'] ) )->toBe( 1 );
+} );
+
+it( 'resets after flushing', function () {
+	$accumulator = makeAnimAccumulator();
+	$accumulator->push( '.ap-block-a', '.ap-block-a { x: y; }', '', false );
+	$accumulator->flush();
+
+	$state = $accumulator->all();
+
+	expect( $state['rules'] )->toBe( [] );
+} );

--- a/packages/visual-editor-renderer-react/src/animations/index.ts
+++ b/packages/visual-editor-renderer-react/src/animations/index.ts
@@ -24,8 +24,17 @@ export interface AnimationsAttributeShape {
 		threshold?: number;
 		once?: boolean;
 	};
-	hover?: { name?: string | Record<string, string | null> };
-	continuous?: { name?: string | Record<string, string | null> };
+	hover?: {
+		name?: string | Record<string, string | null>;
+		duration?: number;
+		easing?: string;
+	};
+	continuous?: {
+		name?: string | Record<string, string | null>;
+		duration?: number;
+		easing?: string;
+		count?: number | 'infinite';
+	};
 	reducedMotion?: 'respect' | 'allow';
 }
 
@@ -74,9 +83,21 @@ function hasAnyName( name: unknown ): boolean {
  */
 export function resolveAnimationMarkup( attributes: AnimationsAttributeShape | undefined ): AnimationMarkup {
 	const entrance = attributes?.entrance ?? {};
+	const hover = attributes?.hover;
+	const continuous = attributes?.continuous;
 	const hasEntrance = hasAnyName( entrance.name );
-	const hasHover = hasAnyName( attributes?.hover?.name );
-	const hasContinuous = hasAnyName( attributes?.continuous?.name );
+	// Mirrors `AnimationCssEmitter::hasHover`: treat as enabled when a
+	// preset name OR a duration/easing curve is authored, so a custom
+	// timing on the hover state alone produces a transition.
+	const hasHover =
+		hasAnyName( hover?.name ) ||
+		undefined !== hover?.duration ||
+		undefined !== hover?.easing;
+	// Mirrors `AnimationCssEmitter::hasContinuousAnywhere`: any
+	// configured name in the shape (base or per-breakpoint) qualifies.
+	// Duration/easing alone do not enable continuous (the loop needs a
+	// keyframe), matching the server.
+	const hasContinuous = hasAnyName( continuous?.name );
 	const hasAnimations = hasEntrance || hasHover || hasContinuous;
 
 	const classes: string[] = [];

--- a/packages/visual-editor-renderer-react/src/animations/index.ts
+++ b/packages/visual-editor-renderer-react/src/animations/index.ts
@@ -1,0 +1,108 @@
+/**
+ * Animation hooks for the React renderer (#489).
+ *
+ * The CSS for block animations is produced server-side by
+ * `AnimationCssEmitter` and ships in the editor's `<style data-ve-animations>`
+ * block at the top of the markup. The renderer's only client-side
+ * responsibility is:
+ *
+ *  - Apply the `ap-anim` and `ap-anim-pre` wrapper classes when the
+ *    block has any animations configured.
+ *  - Stamp the `data-ap-anim-*` attribute set onto the wrapper so the
+ *    shared runtime can find it.
+ *
+ * The runtime itself is loaded once per page by the host bundle — it
+ * lives in `@artisanpack-ui/visual-editor/animations/runtime`.
+ *
+ * @package @artisanpack-ui/visual-editor-renderer-react
+ * @since 1.1.0
+ */
+
+export interface AnimationsAttributeShape {
+	entrance?: {
+		name?: string | Record<string, string | null>;
+		threshold?: number;
+		once?: boolean;
+	};
+	hover?: { name?: string | Record<string, string | null> };
+	continuous?: { name?: string | Record<string, string | null> };
+	reducedMotion?: 'respect' | 'allow';
+}
+
+export interface AnimationMarkup {
+	hasAnimations: boolean;
+	hasEntrance: boolean;
+	classes: string[];
+	dataAttributes: Record<string, string>;
+}
+
+function baseValue( name: unknown ): string | null {
+	if ( 'string' === typeof name ) {
+		return '' === name ? null : name;
+	}
+	if ( name && 'object' === typeof name ) {
+		const base = ( name as Record<string, unknown> ).base;
+		return 'string' === typeof base && '' !== base ? base : null;
+	}
+	return null;
+}
+
+function hasAnyName( name: unknown ): boolean {
+	if ( null !== baseValue( name ) ) {
+		return true;
+	}
+	if ( name && 'object' === typeof name ) {
+		for ( const value of Object.values( name as Record<string, unknown> ) ) {
+			if ( 'string' === typeof value && '' !== value ) {
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
+/**
+ * Computes the wrapper classes + data-* attributes for a block whose
+ * `artisanpackAnimations` attribute bag has been hydrated from the
+ * server-rendered tree.
+ *
+ * Mirrors {@see AnimationCssEmitter::wrapperClasses()} and
+ * {@see AnimationCssEmitter::dataAttributes()} on the PHP side so the
+ * client and server agree exactly on what markup the runtime sees.
+ *
+ * @since 1.1.0
+ */
+export function resolveAnimationMarkup( attributes: AnimationsAttributeShape | undefined ): AnimationMarkup {
+	const entrance = attributes?.entrance ?? {};
+	const hasEntrance = hasAnyName( entrance.name );
+	const hasHover = hasAnyName( attributes?.hover?.name );
+	const hasContinuous = hasAnyName( attributes?.continuous?.name );
+	const hasAnimations = hasEntrance || hasHover || hasContinuous;
+
+	const classes: string[] = [];
+	if ( hasAnimations ) {
+		classes.push( 'ap-anim' );
+	}
+	if ( hasEntrance ) {
+		classes.push( 'ap-anim-pre' );
+	}
+
+	const dataAttributes: Record<string, string> = {};
+	const entranceBase = baseValue( entrance.name );
+	if ( entranceBase ) {
+		dataAttributes[ 'data-ap-anim-entrance' ] = entranceBase;
+
+		if ( 'number' === typeof entrance.threshold ) {
+			dataAttributes[ 'data-ap-anim-threshold' ] = String( entrance.threshold );
+		}
+		if ( false === entrance.once ) {
+			dataAttributes[ 'data-ap-anim-once' ] = 'false';
+		}
+	}
+
+	if ( 'allow' === attributes?.reducedMotion ) {
+		dataAttributes[ 'data-ap-anim-reduced' ] = 'allow';
+	}
+
+	return { hasAnimations, hasEntrance, classes, dataAttributes };
+}

--- a/packages/visual-editor-renderer-vue/src/animations/index.ts
+++ b/packages/visual-editor-renderer-vue/src/animations/index.ts
@@ -16,8 +16,17 @@ export interface AnimationsAttributeShape {
 		threshold?: number;
 		once?: boolean;
 	};
-	hover?: { name?: string | Record<string, string | null> };
-	continuous?: { name?: string | Record<string, string | null> };
+	hover?: {
+		name?: string | Record<string, string | null>;
+		duration?: number;
+		easing?: string;
+	};
+	continuous?: {
+		name?: string | Record<string, string | null>;
+		duration?: number;
+		easing?: string;
+		count?: number | 'infinite';
+	};
 	reducedMotion?: 'respect' | 'allow';
 }
 
@@ -55,9 +64,15 @@ function hasAnyName( name: unknown ): boolean {
 
 export function resolveAnimationMarkup( attributes: AnimationsAttributeShape | undefined ): AnimationMarkup {
 	const entrance = attributes?.entrance ?? {};
+	const hover = attributes?.hover;
+	const continuous = attributes?.continuous;
 	const hasEntrance = hasAnyName( entrance.name );
-	const hasHover = hasAnyName( attributes?.hover?.name );
-	const hasContinuous = hasAnyName( attributes?.continuous?.name );
+	// Mirrors `AnimationCssEmitter::hasHover`: name OR custom timing.
+	const hasHover =
+		hasAnyName( hover?.name ) ||
+		undefined !== hover?.duration ||
+		undefined !== hover?.easing;
+	const hasContinuous = hasAnyName( continuous?.name );
 	const hasAnimations = hasEntrance || hasHover || hasContinuous;
 
 	const classes: string[] = [];

--- a/packages/visual-editor-renderer-vue/src/animations/index.ts
+++ b/packages/visual-editor-renderer-vue/src/animations/index.ts
@@ -1,0 +1,88 @@
+/**
+ * Animation helpers for the Vue renderer (#489).
+ *
+ * Re-exports the same shape the React renderer uses — the resolver is
+ * framework-agnostic. The runtime CSS is server-side; the renderer's
+ * only job is computing wrapper classes + data attributes from the
+ * `artisanpackAnimations` attribute bag.
+ *
+ * @package @artisanpack-ui/visual-editor-renderer-vue
+ * @since 1.1.0
+ */
+
+export interface AnimationsAttributeShape {
+	entrance?: {
+		name?: string | Record<string, string | null>;
+		threshold?: number;
+		once?: boolean;
+	};
+	hover?: { name?: string | Record<string, string | null> };
+	continuous?: { name?: string | Record<string, string | null> };
+	reducedMotion?: 'respect' | 'allow';
+}
+
+export interface AnimationMarkup {
+	hasAnimations: boolean;
+	hasEntrance: boolean;
+	classes: string[];
+	dataAttributes: Record<string, string>;
+}
+
+function baseValue( name: unknown ): string | null {
+	if ( 'string' === typeof name ) {
+		return '' === name ? null : name;
+	}
+	if ( name && 'object' === typeof name ) {
+		const base = ( name as Record<string, unknown> ).base;
+		return 'string' === typeof base && '' !== base ? base : null;
+	}
+	return null;
+}
+
+function hasAnyName( name: unknown ): boolean {
+	if ( null !== baseValue( name ) ) {
+		return true;
+	}
+	if ( name && 'object' === typeof name ) {
+		for ( const value of Object.values( name as Record<string, unknown> ) ) {
+			if ( 'string' === typeof value && '' !== value ) {
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
+export function resolveAnimationMarkup( attributes: AnimationsAttributeShape | undefined ): AnimationMarkup {
+	const entrance = attributes?.entrance ?? {};
+	const hasEntrance = hasAnyName( entrance.name );
+	const hasHover = hasAnyName( attributes?.hover?.name );
+	const hasContinuous = hasAnyName( attributes?.continuous?.name );
+	const hasAnimations = hasEntrance || hasHover || hasContinuous;
+
+	const classes: string[] = [];
+	if ( hasAnimations ) {
+		classes.push( 'ap-anim' );
+	}
+	if ( hasEntrance ) {
+		classes.push( 'ap-anim-pre' );
+	}
+
+	const dataAttributes: Record<string, string> = {};
+	const entranceBase = baseValue( entrance.name );
+	if ( entranceBase ) {
+		dataAttributes[ 'data-ap-anim-entrance' ] = entranceBase;
+		if ( 'number' === typeof entrance.threshold ) {
+			dataAttributes[ 'data-ap-anim-threshold' ] = String( entrance.threshold );
+		}
+		if ( false === entrance.once ) {
+			dataAttributes[ 'data-ap-anim-once' ] = 'false';
+		}
+	}
+
+	if ( 'allow' === attributes?.reducedMotion ) {
+		dataAttributes[ 'data-ap-anim-reduced' ] = 'allow';
+	}
+
+	return { hasAnimations, hasEntrance, classes, dataAttributes };
+}

--- a/resources/js/visual-editor/animations/AnimationPanel.tsx
+++ b/resources/js/visual-editor/animations/AnimationPanel.tsx
@@ -228,8 +228,11 @@ export function AnimationPanel( {
 							patchContinuous( { count: 'infinite' } );
 							return;
 						}
-						const parsed = parseInt( next, 10 );
-						if ( ! Number.isNaN( parsed ) && parsed > 0 ) {
+						// `Number.isInteger` rejects mixed input like
+						// `"2abc"` that `parseInt` would silently accept
+						// as `2`.
+						const parsed = Number( next );
+						if ( Number.isInteger( parsed ) && parsed > 0 ) {
 							patchContinuous( { count: parsed } );
 						}
 					} }

--- a/resources/js/visual-editor/animations/AnimationPanel.tsx
+++ b/resources/js/visual-editor/animations/AnimationPanel.tsx
@@ -1,0 +1,240 @@
+/**
+ * Animation inspector panel (#489).
+ *
+ * Three sub-panels — Entrance, Hover, Continuous — that surface every
+ * animation in their family for the selected block. The panel is
+ * mounted into the inspector by `withAnimationAttributes()` (the
+ * higher-order component below).
+ *
+ * Per-family controls:
+ *   - Animation dropdown (with "(none)" → clears the attribute)
+ *   - Duration (number, ms)
+ *   - Delay (number, ms) — entrance + hover only
+ *   - Easing (text — accepts `ease`, `linear`, `cubic-bezier(...)`, etc.)
+ *   - Threshold (number, 0–1) — entrance only
+ *   - Repeat (text/number, `infinite` or N) — continuous only
+ *
+ * The Animations panel also exposes the global "Respect reduced motion"
+ * toggle (default on).
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.1.0
+ */
+
+import {
+	PanelBody,
+	SelectControl,
+	TextControl,
+	ToggleControl,
+	__experimentalNumberControl as NumberControl,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+import type { AnimationRegistry } from './registry';
+import type {
+	AnimationsAttribute,
+	ContinuousAttribute,
+	EntranceAttribute,
+	HoverAttribute,
+} from './types';
+import { FAMILY_CONTINUOUS, FAMILY_ENTRANCE, FAMILY_HOVER } from './types';
+
+export interface AnimationPanelProps {
+	registry: AnimationRegistry;
+	value: AnimationsAttribute | undefined;
+	onChange: ( next: AnimationsAttribute ) => void;
+	/** Set false when the block declares `supports.artisanpackAnimations: false`. */
+	supportsAnimations?: boolean;
+}
+
+function dropdownOptions( registry: AnimationRegistry, family: 'entrance' | 'hover' | 'continuous' ) {
+	return [
+		{ label: __( '(none)', 'visual-editor' ), value: '' },
+		...registry.family( family ).map( ( def ) => ( {
+			label: def.label,
+			value: def.key,
+		} ) ),
+	];
+}
+
+function baseString( name: EntranceAttribute['name'] | undefined ): string {
+	if ( 'string' === typeof name ) {
+		return name;
+	}
+	if ( name && 'object' === typeof name ) {
+		const base = ( name as Record<string, string | null | undefined> ).base;
+		return 'string' === typeof base ? base : '';
+	}
+	return '';
+}
+
+/**
+ * Parse a NumberControl onChange value into a finite number or
+ * `undefined`. Guards against `NaN` (e.g. `Number('')` is 0 but
+ * `Number(undefined)` is NaN) from being persisted into the
+ * `artisanpackAnimations` bag — NaN duration / threshold breaks
+ * `AnimationCssEmitter`'s `intOr` fallback by passing `is_numeric`
+ * but rendering as the literal `NaN` in CSS.
+ */
+function parseNumber( next: unknown ): number | undefined {
+	if ( undefined === next || '' === next ) {
+		return undefined;
+	}
+	const parsed = Number( next );
+	return Number.isFinite( parsed ) ? parsed : undefined;
+}
+
+export function AnimationPanel( {
+	registry,
+	value,
+	onChange,
+	supportsAnimations = true,
+}: AnimationPanelProps ): JSX.Element | null {
+	if ( ! supportsAnimations ) {
+		return null;
+	}
+
+	const entrance:   EntranceAttribute   = value?.entrance   ?? {};
+	const hover:      HoverAttribute      = value?.hover      ?? {};
+	const continuous: ContinuousAttribute = value?.continuous ?? {};
+	const reducedMotion = value?.reducedMotion ?? 'respect';
+
+	function patch( next: Partial<AnimationsAttribute> ): void {
+		onChange( { ...( value ?? {} ), ...next } );
+	}
+
+	function patchEntrance( next: Partial<EntranceAttribute> ): void {
+		patch( { entrance: { ...entrance, ...next } } );
+	}
+
+	function patchHover( next: Partial<HoverAttribute> ): void {
+		patch( { hover: { ...hover, ...next } } );
+	}
+
+	function patchContinuous( next: Partial<ContinuousAttribute> ): void {
+		patch( { continuous: { ...continuous, ...next } } );
+	}
+
+	return (
+		<>
+			<PanelBody title={ __( 'Motion preferences', 'visual-editor' ) } initialOpen={ false }>
+				<ToggleControl
+					label={ __( 'Respect reduced motion', 'visual-editor' ) }
+					help={ __(
+						'When on, the runtime suppresses entrance + continuous animations for visitors who set “reduce motion” in their OS.',
+						'visual-editor'
+					) }
+					checked={ 'respect' === reducedMotion }
+					onChange={ ( next: boolean ) =>
+						patch( { reducedMotion: next ? 'respect' : 'allow' } )
+					}
+				/>
+			</PanelBody>
+
+			<PanelBody title={ __( 'Entrance animation', 'visual-editor' ) } initialOpen={ false }>
+				<SelectControl
+					label={ __( 'Motion', 'visual-editor' ) }
+					value={ baseString( entrance.name ) }
+					options={ dropdownOptions( registry, FAMILY_ENTRANCE ) }
+					onChange={ ( next: string ) =>
+						patchEntrance( { name: '' === next ? undefined : next } )
+					}
+				/>
+				<NumberControl
+					label={ __( 'Duration (ms)', 'visual-editor' ) }
+					value={ entrance.duration ?? '' }
+					min={ 0 }
+					step={ 50 }
+					onChange={ ( next ) => patchEntrance( { duration: parseNumber( next ) } ) }
+				/>
+				<NumberControl
+					label={ __( 'Delay (ms)', 'visual-editor' ) }
+					value={ entrance.delay ?? '' }
+					min={ 0 }
+					step={ 50 }
+					onChange={ ( next ) => patchEntrance( { delay: parseNumber( next ) } ) }
+				/>
+				<TextControl
+					label={ __( 'Easing', 'visual-editor' ) }
+					value={ entrance.easing ?? '' }
+					onChange={ ( next: string ) => patchEntrance( { easing: '' === next ? undefined : next } ) }
+				/>
+				<NumberControl
+					label={ __( 'Viewport threshold (0–1)', 'visual-editor' ) }
+					value={ entrance.threshold ?? '' }
+					min={ 0 }
+					max={ 1 }
+					step={ 0.05 }
+					onChange={ ( next ) => patchEntrance( { threshold: parseNumber( next ) } ) }
+				/>
+			</PanelBody>
+
+			<PanelBody title={ __( 'Hover animation', 'visual-editor' ) } initialOpen={ false }>
+				<SelectControl
+					label={ __( 'Preset', 'visual-editor' ) }
+					value={ baseString( hover.name ) }
+					options={ dropdownOptions( registry, FAMILY_HOVER ) }
+					onChange={ ( next: string ) =>
+						patchHover( { name: '' === next ? undefined : next } )
+					}
+				/>
+				<NumberControl
+					label={ __( 'Duration (ms)', 'visual-editor' ) }
+					value={ hover.duration ?? '' }
+					min={ 0 }
+					step={ 25 }
+					onChange={ ( next ) => patchHover( { duration: parseNumber( next ) } ) }
+				/>
+				<TextControl
+					label={ __( 'Easing', 'visual-editor' ) }
+					value={ hover.easing ?? '' }
+					onChange={ ( next: string ) => patchHover( { easing: '' === next ? undefined : next } ) }
+				/>
+			</PanelBody>
+
+			<PanelBody title={ __( 'Continuous animation', 'visual-editor' ) } initialOpen={ false }>
+				<SelectControl
+					label={ __( 'Motion', 'visual-editor' ) }
+					value={ baseString( continuous.name ) }
+					options={ dropdownOptions( registry, FAMILY_CONTINUOUS ) }
+					onChange={ ( next: string ) =>
+						patchContinuous( { name: '' === next ? undefined : next } )
+					}
+				/>
+				<NumberControl
+					label={ __( 'Duration (ms)', 'visual-editor' ) }
+					value={ continuous.duration ?? '' }
+					min={ 0 }
+					step={ 100 }
+					onChange={ ( next ) => patchContinuous( { duration: parseNumber( next ) } ) }
+				/>
+				<TextControl
+					label={ __( 'Easing', 'visual-editor' ) }
+					value={ continuous.easing ?? '' }
+					onChange={ ( next: string ) =>
+						patchContinuous( { easing: '' === next ? undefined : next } )
+					}
+				/>
+				<TextControl
+					label={ __( 'Repeat', 'visual-editor' ) }
+					help={ __( '“infinite” or a positive integer.', 'visual-editor' ) }
+					value={ undefined === continuous.count ? '' : String( continuous.count ) }
+					onChange={ ( next: string ) => {
+						if ( '' === next ) {
+							patchContinuous( { count: undefined } );
+							return;
+						}
+						if ( 'infinite' === next ) {
+							patchContinuous( { count: 'infinite' } );
+							return;
+						}
+						const parsed = parseInt( next, 10 );
+						if ( ! Number.isNaN( parsed ) && parsed > 0 ) {
+							patchContinuous( { count: parsed } );
+						}
+					} }
+				/>
+			</PanelBody>
+		</>
+	);
+}

--- a/resources/js/visual-editor/animations/CustomKeyframeEditor.tsx
+++ b/resources/js/visual-editor/animations/CustomKeyframeEditor.tsx
@@ -1,0 +1,195 @@
+/**
+ * Custom keyframe editor (#489).
+ *
+ * Site Editor → Styles → Animations sub-page that lets developers
+ * author named `@keyframes` blocks and persist them into the Global
+ * Styles JSON. The editor authors keyframes as a list of stops; each
+ * stop edits a small allow-listed set of transform / opacity / filter
+ * properties.
+ *
+ * The component is fully controlled — it never reads the canonical
+ * store directly. The Site Editor host wires `value` + `onChange` to
+ * `styles.custom.artisanpack.keyframes`.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.1.0
+ */
+
+import { Button, TextControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+import type { CustomKeyframe, CustomKeyframeStop } from './types';
+
+const ALLOWED_PROPERTIES: ( keyof CustomKeyframeStop )[] = [
+	'transform',
+	'opacity',
+	'filter',
+	'color',
+	'background-color',
+	'box-shadow',
+];
+
+const NAME_PATTERN = /^[a-z][a-z0-9_-]*$/i;
+
+export interface CustomKeyframeEditorProps {
+	value: CustomKeyframe[];
+	onChange: ( next: CustomKeyframe[] ) => void;
+	/** Names the editor must not allow because they collide with built-ins. */
+	reservedNames: string[];
+}
+
+function emptyStop( at: string ): CustomKeyframeStop {
+	return { at };
+}
+
+function patchKeyframe(
+	list: CustomKeyframe[],
+	index: number,
+	patch: Partial<CustomKeyframe>,
+): CustomKeyframe[] {
+	const next = list.slice();
+	next[ index ] = { ...next[ index ], ...patch };
+	return next;
+}
+
+export function CustomKeyframeEditor( {
+	value,
+	onChange,
+	reservedNames,
+}: CustomKeyframeEditorProps ): JSX.Element {
+	const reserved = new Set( reservedNames.map( ( n ) => n.toLowerCase() ) );
+
+	function addKeyframe(): void {
+		onChange( [
+			...value,
+			{
+				name:  '',
+				stops: [ emptyStop( '0%' ), emptyStop( '100%' ) ],
+			},
+		] );
+	}
+
+	function removeKeyframe( index: number ): void {
+		onChange( value.filter( ( _, i ) => i !== index ) );
+	}
+
+	function setName( index: number, name: string ): void {
+		onChange( patchKeyframe( value, index, { name } ) );
+	}
+
+	function setStop( index: number, stopIndex: number, patch: Partial<CustomKeyframeStop> ): void {
+		const next = value.slice();
+		const stops = next[ index ].stops.slice();
+		stops[ stopIndex ] = { ...stops[ stopIndex ], ...patch };
+		next[ index ] = { ...next[ index ], stops };
+		onChange( next );
+	}
+
+	function addStop( index: number ): void {
+		const next = value.slice();
+		const stops = next[ index ].stops.slice();
+		stops.splice( stops.length - 1, 0, emptyStop( '50%' ) );
+		next[ index ] = { ...next[ index ], stops };
+		onChange( next );
+	}
+
+	function removeStop( index: number, stopIndex: number ): void {
+		const next = value.slice();
+		if ( next[ index ].stops.length <= 2 ) {
+			return;
+		}
+		const stops = next[ index ].stops.filter( ( _, i ) => i !== stopIndex );
+		next[ index ] = { ...next[ index ], stops };
+		onChange( next );
+	}
+
+	function nameError( name: string, index: number ): string | null {
+		if ( '' === name ) {
+			return __( 'Required.', 'visual-editor' );
+		}
+		if ( ! NAME_PATTERN.test( name ) ) {
+			return __( 'Use letters, numbers, hyphens, or underscores.', 'visual-editor' );
+		}
+		if ( reserved.has( name.toLowerCase() ) ) {
+			return __( 'This name is reserved by a built-in.', 'visual-editor' );
+		}
+		const duplicate = value.findIndex(
+			( kf, i ) => i !== index && kf.name.toLowerCase() === name.toLowerCase()
+		);
+		if ( -1 !== duplicate ) {
+			return __( 'Already used by another keyframe.', 'visual-editor' );
+		}
+		return null;
+	}
+
+	return (
+		<div className="ap-custom-keyframes">
+			<p>
+				{ __(
+					'Author named @keyframes blocks. They become available in the entrance and continuous dropdowns.',
+					'visual-editor'
+				) }
+			</p>
+
+			{ value.map( ( keyframe, index ) => {
+				const error = nameError( keyframe.name, index );
+				return (
+					<div key={ index } className="ap-custom-keyframes__row">
+						<TextControl
+							label={ __( 'Name', 'visual-editor' ) }
+							value={ keyframe.name }
+							onChange={ ( next: string ) => setName( index, next ) }
+							help={ error ?? undefined }
+						/>
+
+						{ keyframe.stops.map( ( stop, stopIndex ) => (
+							<fieldset key={ stopIndex } className="ap-custom-keyframes__stop">
+								<legend>
+									{ __( 'Stop', 'visual-editor' ) } { stopIndex + 1 }
+								</legend>
+
+								<TextControl
+									label={ __( 'At', 'visual-editor' ) }
+									value={ stop.at }
+									onChange={ ( next: string ) => setStop( index, stopIndex, { at: next } ) }
+								/>
+
+								{ ALLOWED_PROPERTIES.map( ( property ) => (
+									<TextControl
+										key={ property }
+										label={ property }
+										value={ stop[ property ] ?? '' }
+										onChange={ ( next: string ) =>
+											setStop( index, stopIndex, { [ property ]: '' === next ? undefined : next } )
+										}
+									/>
+								) ) }
+
+								<Button
+									variant="tertiary"
+									isDestructive
+									onClick={ () => removeStop( index, stopIndex ) }
+									disabled={ keyframe.stops.length <= 2 }
+								>
+									{ __( 'Remove stop', 'visual-editor' ) }
+								</Button>
+							</fieldset>
+						) ) }
+
+						<Button variant="secondary" onClick={ () => addStop( index ) }>
+							{ __( '+ Add stop', 'visual-editor' ) }
+						</Button>
+
+						<Button variant="tertiary" isDestructive onClick={ () => removeKeyframe( index ) }>
+							{ __( 'Delete keyframe', 'visual-editor' ) }
+						</Button>
+					</div>
+				);
+			} ) }
+
+			<Button variant="primary" onClick={ addKeyframe }>
+				{ __( '+ Add custom keyframe', 'visual-editor' ) }
+			</Button>
+		</div>
+	);
+}

--- a/resources/js/visual-editor/animations/CustomKeyframeEditor.tsx
+++ b/resources/js/visual-editor/animations/CustomKeyframeEditor.tsx
@@ -30,6 +30,10 @@ const ALLOWED_PROPERTIES: ( keyof CustomKeyframeStop )[] = [
 ];
 
 const NAME_PATTERN = /^[a-z][a-z0-9_-]*$/i;
+// Matches the backend `KeyframeRegistry::validateOne()` rule: 0–100
+// with an optional `%` suffix. Surfacing the error inline prevents
+// the save → reject → fix cycle the user would otherwise hit.
+const STOP_AT_PATTERN = /^(0|[1-9]\d?|100)(%)?$/;
 
 export interface CustomKeyframeEditorProps {
 	value: CustomKeyframe[];
@@ -122,6 +126,17 @@ export function CustomKeyframeEditor( {
 		return null;
 	}
 
+	function stopAtError( at: string ): string | null {
+		const trimmed = at.trim();
+		if ( '' === trimmed ) {
+			return __( 'Required.', 'visual-editor' );
+		}
+		if ( ! STOP_AT_PATTERN.test( trimmed ) ) {
+			return __( 'Use a percentage from 0 to 100 (e.g. 50 or 50%).', 'visual-editor' );
+		}
+		return null;
+	}
+
 	return (
 		<div className="ap-custom-keyframes">
 			<p>
@@ -152,6 +167,7 @@ export function CustomKeyframeEditor( {
 									label={ __( 'At', 'visual-editor' ) }
 									value={ stop.at }
 									onChange={ ( next: string ) => setStop( index, stopIndex, { at: next } ) }
+									help={ stopAtError( stop.at ) ?? undefined }
 								/>
 
 								{ ALLOWED_PROPERTIES.map( ( property ) => (

--- a/resources/js/visual-editor/animations/__tests__/registry.test.ts
+++ b/resources/js/visual-editor/animations/__tests__/registry.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+	AnimationRegistry,
+	DEFAULT_ANIMATIONS,
+	registryFromSnapshot,
+} from '../registry'
+import { FAMILY_CONTINUOUS, FAMILY_ENTRANCE, FAMILY_HOVER } from '../types'
+
+describe( 'AnimationRegistry', () => {
+	it( 'defaults to the built-in set when nothing is passed', () => {
+		const registry = new AnimationRegistry()
+
+		expect( registry.has( FAMILY_ENTRANCE, 'fade-in' ) ).toBe( true )
+		expect( registry.has( FAMILY_HOVER, 'lift' ) ).toBe( true )
+		expect( registry.has( FAMILY_CONTINUOUS, 'pulse' ) ).toBe( true )
+	} )
+
+	it( 'exposes definitions by family', () => {
+		const registry = new AnimationRegistry()
+
+		const entrance = registry.family( FAMILY_ENTRANCE )
+		expect( entrance.length ).toBeGreaterThan( 0 )
+		expect( entrance.every( ( def ) => def.family === FAMILY_ENTRANCE ) ).toBe( true )
+	} )
+
+	it( 'returns null for unknown keys', () => {
+		const registry = new AnimationRegistry()
+
+		expect( registry.get( FAMILY_ENTRANCE, 'made-up' ) ).toBeNull()
+	} )
+
+	it( 'hydrates from a snapshot', () => {
+		const registry = registryFromSnapshot( {
+			animations: {
+				[ FAMILY_ENTRANCE ]:   { 'fade-in': DEFAULT_ANIMATIONS[ FAMILY_ENTRANCE ][ 0 ] },
+				[ FAMILY_HOVER ]:      {},
+				[ FAMILY_CONTINUOUS ]: {},
+			},
+			customKeyframes: [ { name: 'confetti', stops: [
+				{ at: '0%',   transform: 'translateY(0)' },
+				{ at: '100%', transform: 'translateY(0)' },
+			] } ],
+		} )
+
+		expect( registry.has( FAMILY_ENTRANCE, 'fade-in' ) ).toBe( true )
+		expect( registry.customs().map( ( kf ) => kf.name ) ).toEqual( [ 'confetti' ] )
+	} )
+
+	it( 'returns an empty registry when given no snapshot', () => {
+		const registry = registryFromSnapshot( undefined )
+
+		expect( registry.has( FAMILY_ENTRANCE, 'fade-in' ) ).toBe( true )
+	} )
+} )

--- a/resources/js/visual-editor/animations/__tests__/runtime.test.ts
+++ b/resources/js/visual-editor/animations/__tests__/runtime.test.ts
@@ -172,4 +172,40 @@ describe( 'block-animations runtime', () => {
 		expect( observers.length ).toBe( 1 )
 		expect( observers[ 0 ].observed.size ).toBe( 2 )
 	} )
+
+	it( 'isolates teardown between concurrent bootstrap instances', () => {
+		// Two roots → two bootstrap() calls. Disposing the first must
+		// not disconnect the second instance's observers, otherwise
+		// a host that mounts the editor into multiple iframes / shadow
+		// roots would silently break later mounts.
+		const blockA = placeBlock(
+			'<div class="ap-anim ap-anim-pre" data-ap-anim-entrance="fade-in" data-ap-anim-threshold="0.1"></div>'
+		)
+		const disposeA = bootstrap( { root: document, prefersReducedMotion: () => false } )
+		const observerA = observers[ observers.length - 1 ]
+
+		const blockB = placeBlock(
+			'<div class="ap-anim ap-anim-pre" data-ap-anim-entrance="fade-in-up" data-ap-anim-threshold="0.9"></div>'
+		)
+		const disposeB = bootstrap( { root: document, prefersReducedMotion: () => false } )
+		const observerB = observers[ observers.length - 1 ]
+
+		// Sanity: the two bootstraps produced two distinct observers
+		// keyed off their distinct thresholds.
+		expect( observerA ).not.toBe( observerB )
+
+		// Tear down only the first instance.
+		disposeA()
+
+		// The second instance's observer must still respond to
+		// intersection events.
+		observerB.trigger( blockB, true )
+		expect( blockB.classList.contains( 'ap-anim-play' ) ).toBe( true )
+
+		// And the first block must not have animated as a side effect.
+		expect( blockA.classList.contains( 'ap-anim-pre' ) ).toBe( true )
+		expect( blockA.classList.contains( 'ap-anim-play' ) ).toBe( false )
+
+		disposeB()
+	} )
 } )

--- a/resources/js/visual-editor/animations/__tests__/runtime.test.ts
+++ b/resources/js/visual-editor/animations/__tests__/runtime.test.ts
@@ -1,0 +1,175 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { bootstrap } from '../runtime'
+
+interface FakeObserver {
+	callback: IntersectionObserverCallback
+	options:  IntersectionObserverInit
+	observed: Set<Element>
+	trigger:  ( target: Element, isIntersecting: boolean ) => void
+}
+
+const observers: FakeObserver[] = []
+
+class TestIntersectionObserver implements IntersectionObserver {
+	root         = null
+	rootMargin   = ''
+	thresholds:  ReadonlyArray<number> = []
+	private cb:  IntersectionObserverCallback
+
+	observed = new Set<Element>()
+
+	constructor( callback: IntersectionObserverCallback, options: IntersectionObserverInit = {} ) {
+		this.cb = callback
+		this.thresholds = Array.isArray( options.threshold )
+			? options.threshold
+			: [ ( options.threshold as number ) ?? 0 ]
+
+		observers.push( {
+			callback: callback,
+			options:  options,
+			observed: this.observed,
+			trigger:  ( target: Element, isIntersecting: boolean ) => {
+				this.cb(
+					[ { target, isIntersecting, intersectionRatio: isIntersecting ? 1 : 0 } as IntersectionObserverEntry ],
+					this,
+				)
+			},
+		} )
+	}
+
+	observe( target: Element ): void {
+		this.observed.add( target )
+	}
+
+	unobserve( target: Element ): void {
+		this.observed.delete( target )
+	}
+
+	disconnect(): void {
+		this.observed.clear()
+	}
+
+	takeRecords(): IntersectionObserverEntry[] {
+		return []
+	}
+}
+
+beforeEach( () => {
+	observers.length = 0
+	;( globalThis as unknown as { IntersectionObserver: typeof IntersectionObserver } ).IntersectionObserver =
+		TestIntersectionObserver as unknown as typeof IntersectionObserver
+} )
+
+afterEach( () => {
+	document.body.innerHTML = ''
+} )
+
+function placeBlock( html: string ): HTMLElement {
+	const wrapper = document.createElement( 'div' )
+	wrapper.innerHTML = html.trim()
+	const node = wrapper.firstElementChild as HTMLElement
+	document.body.appendChild( node )
+	return node
+}
+
+describe( 'block-animations runtime', () => {
+	it( 'swaps ap-anim-pre for ap-anim-play when a block enters the viewport', () => {
+		const block = placeBlock( '<div class="ap-anim ap-anim-pre" data-ap-anim-entrance="fade-in"></div>' )
+
+		const dispose = bootstrap( { root: document, prefersReducedMotion: () => false } )
+
+		observers[ 0 ].trigger( block, true )
+
+		expect( block.classList.contains( 'ap-anim-pre' ) ).toBe( false )
+		expect( block.classList.contains( 'ap-anim-play' ) ).toBe( true )
+
+		dispose()
+	} )
+
+	it( 'suppresses the entrance when reduced motion is on (block opts in)', () => {
+		const block = placeBlock(
+			'<div class="ap-anim ap-anim-pre" data-ap-anim-entrance="fade-in"></div>'
+		)
+
+		bootstrap( { root: document, prefersReducedMotion: () => true } )
+
+		// Reveal happened immediately with no observer; no observer was
+		// registered because the block was preemptively played.
+		expect( block.classList.contains( 'ap-anim-play' ) ).toBe( true )
+	} )
+
+	it( 'plays the entrance even with reduced motion when the block opts out', () => {
+		const block = placeBlock(
+			'<div class="ap-anim ap-anim-pre" data-ap-anim-entrance="fade-in" data-ap-anim-reduced="allow"></div>'
+		)
+
+		bootstrap( { root: document, prefersReducedMotion: () => true } )
+
+		// Reduced motion was overridden, so the observer takes over.
+		expect( block.classList.contains( 'ap-anim-pre' ) ).toBe( true )
+		observers[ 0 ].trigger( block, true )
+		expect( block.classList.contains( 'ap-anim-play' ) ).toBe( true )
+	} )
+
+	it( 'unobserves the block after a single play by default', () => {
+		const block = placeBlock( '<div class="ap-anim ap-anim-pre" data-ap-anim-entrance="fade-in"></div>' )
+
+		bootstrap( { root: document, prefersReducedMotion: () => false } )
+		observers[ 0 ].trigger( block, true )
+
+		expect( observers[ 0 ].observed.has( block ) ).toBe( false )
+	} )
+
+	it( 'rearms the block when once=false and it leaves the viewport', () => {
+		const block = placeBlock(
+			'<div class="ap-anim ap-anim-pre" data-ap-anim-entrance="fade-in" data-ap-anim-once="false"></div>'
+		)
+
+		bootstrap( { root: document, prefersReducedMotion: () => false } )
+
+		observers[ 0 ].trigger( block, true )
+		expect( block.classList.contains( 'ap-anim-play' ) ).toBe( true )
+
+		observers[ 0 ].trigger( block, false )
+		expect( block.classList.contains( 'ap-anim-pre' ) ).toBe( true )
+	} )
+
+	it( 'reads the per-block threshold attribute', () => {
+		placeBlock(
+			'<div class="ap-anim ap-anim-pre" data-ap-anim-entrance="fade-in" data-ap-anim-threshold="0.5"></div>'
+		)
+
+		bootstrap( { root: document, prefersReducedMotion: () => false } )
+
+		expect( observers[ 0 ].options.threshold ).toBe( 0.5 )
+	} )
+
+	it( 'uses one observer per distinct threshold', () => {
+		placeBlock(
+			'<div class="ap-anim ap-anim-pre" data-ap-anim-entrance="fade-in" data-ap-anim-threshold="0.1"></div>'
+		)
+		placeBlock(
+			'<div class="ap-anim ap-anim-pre" data-ap-anim-entrance="fade-in-up" data-ap-anim-threshold="0.5"></div>'
+		)
+
+		bootstrap( { root: document, prefersReducedMotion: () => false } )
+
+		const thresholds = observers.map( ( o ) => o.options.threshold ).sort()
+		expect( thresholds ).toEqual( [ 0.1, 0.5 ] )
+	} )
+
+	it( 'shares observers for blocks at the same threshold', () => {
+		placeBlock(
+			'<div class="ap-anim ap-anim-pre" data-ap-anim-entrance="fade-in" data-ap-anim-threshold="0.2"></div>'
+		)
+		placeBlock(
+			'<div class="ap-anim ap-anim-pre" data-ap-anim-entrance="fade-in-up" data-ap-anim-threshold="0.2"></div>'
+		)
+
+		bootstrap( { root: document, prefersReducedMotion: () => false } )
+
+		expect( observers.length ).toBe( 1 )
+		expect( observers[ 0 ].observed.size ).toBe( 2 )
+	} )
+} )

--- a/resources/js/visual-editor/animations/index.ts
+++ b/resources/js/visual-editor/animations/index.ts
@@ -1,0 +1,40 @@
+/**
+ * Public entry point for the block-animations system (#489).
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.1.0
+ */
+
+export {
+	AnimationRegistry,
+	DEFAULT_ANIMATIONS,
+	registryFromSnapshot,
+} from './registry';
+
+export {
+	ANIMATION_FAMILIES,
+	FAMILY_CONTINUOUS,
+	FAMILY_ENTRANCE,
+	FAMILY_HOVER,
+} from './types';
+
+export type {
+	AnimationDefinition,
+	AnimationFamily,
+	AnimationRegistrySnapshot,
+	AnimationsAttribute,
+	ContinuousAttribute,
+	CustomKeyframe,
+	CustomKeyframeStop,
+	EntranceAttribute,
+	HoverAttribute,
+	ReducedMotionPolicy,
+} from './types';
+
+export { AnimationPanel } from './AnimationPanel';
+export type { AnimationPanelProps } from './AnimationPanel';
+
+export { CustomKeyframeEditor } from './CustomKeyframeEditor';
+export type { CustomKeyframeEditorProps } from './CustomKeyframeEditor';
+
+export { bootstrap as bootstrapAnimationsRuntime } from './runtime';

--- a/resources/js/visual-editor/animations/register-attribute.ts
+++ b/resources/js/visual-editor/animations/register-attribute.ts
@@ -1,0 +1,72 @@
+/**
+ * Inject the `artisanpackAnimations` attribute on every block that
+ * opts into block animations (#489).
+ *
+ * Blocks declare opt-in via `supports.artisanpackAnimations` in
+ * `block.json`. This `blocks.registerBlockType` filter adds the
+ * storage attribute at registration time so individual `block.json`
+ * files don't need to declare it by hand.
+ *
+ * The injected attribute is a plain `object` matching the shape the
+ * PHP `AnimationCssEmitter` consumes — see `types.ts` for the schema.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.1.0
+ */
+
+import { addFilter } from '@wordpress/hooks';
+
+const FILTER_HOOK      = 'blocks.registerBlockType';
+const FILTER_NAMESPACE = 'artisanpack-ui/visual-editor/animations-attribute';
+
+const REGISTERED_KEY = Symbol.for(
+	'artisanpack-ui.visual-editor.animations-attribute.registered',
+);
+
+interface GlobalSentinelHost {
+	[REGISTERED_KEY]?: boolean;
+}
+
+interface BlockSupports {
+	artisanpackAnimations?: boolean | { families?: string[] };
+}
+
+interface BlockSettingsLike {
+	supports?: BlockSupports;
+	attributes?: Record<string, unknown>;
+	[key: string]: unknown;
+}
+
+function injectAnimationsAttribute( settings: BlockSettingsLike ): BlockSettingsLike {
+	const support = settings.supports?.artisanpackAnimations;
+
+	if ( ! support ) {
+		return settings;
+	}
+
+	if ( settings.attributes && 'artisanpackAnimations' in settings.attributes ) {
+		return settings;
+	}
+
+	return {
+		...settings,
+		attributes: {
+			...( settings.attributes ?? {} ),
+			artisanpackAnimations: {
+				type:    'object',
+				default: null,
+			},
+		},
+	};
+}
+
+export function registerAnimationsAttribute(): void {
+	const host = globalThis as unknown as GlobalSentinelHost;
+
+	if ( host[ REGISTERED_KEY ] ) {
+		return;
+	}
+
+	addFilter( FILTER_HOOK, FILTER_NAMESPACE, injectAnimationsAttribute );
+	host[ REGISTERED_KEY ] = true;
+}

--- a/resources/js/visual-editor/animations/registry.ts
+++ b/resources/js/visual-editor/animations/registry.ts
@@ -1,0 +1,112 @@
+/**
+ * Client-side animation registry (#489).
+ *
+ * Mirrors the PHP `AnimationRegistry` so the editor can resolve
+ * animations and surface metadata without round-tripping to the
+ * server. Hydrated from `editor-settings`'s `animations` snapshot,
+ * which the bootstrap path stamps from the merged PHP config + theme.json
+ * + Global Styles.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.1.0
+ */
+
+import {
+	ANIMATION_FAMILIES,
+	type AnimationDefinition,
+	type AnimationFamily,
+	type AnimationRegistrySnapshot,
+	type CustomKeyframe,
+	FAMILY_CONTINUOUS,
+	FAMILY_ENTRANCE,
+	FAMILY_HOVER,
+} from './types';
+
+export const DEFAULT_ANIMATIONS: Record<AnimationFamily, AnimationDefinition[]> = {
+	[ FAMILY_ENTRANCE ]: [
+		{ key: 'fade-in',        family: FAMILY_ENTRANCE, label: 'Fade in',         keyframe: 'apFadeIn',       duration: 600, easing: 'ease-out' },
+		{ key: 'fade-in-up',     family: FAMILY_ENTRANCE, label: 'Fade in up',      keyframe: 'apFadeInUp',     duration: 600, easing: 'ease-out' },
+		{ key: 'fade-in-down',   family: FAMILY_ENTRANCE, label: 'Fade in down',    keyframe: 'apFadeInDown',   duration: 600, easing: 'ease-out' },
+		{ key: 'fade-in-left',   family: FAMILY_ENTRANCE, label: 'Fade in left',    keyframe: 'apFadeInLeft',   duration: 600, easing: 'ease-out' },
+		{ key: 'fade-in-right',  family: FAMILY_ENTRANCE, label: 'Fade in right',   keyframe: 'apFadeInRight',  duration: 600, easing: 'ease-out' },
+		{ key: 'zoom-in',        family: FAMILY_ENTRANCE, label: 'Zoom in',         keyframe: 'apZoomIn',       duration: 500, easing: 'ease-out' },
+		{ key: 'zoom-out',       family: FAMILY_ENTRANCE, label: 'Zoom out',        keyframe: 'apZoomOut',      duration: 500, easing: 'ease-out' },
+		{ key: 'slide-in-up',    family: FAMILY_ENTRANCE, label: 'Slide in up',     keyframe: 'apSlideInUp',    duration: 600, easing: 'ease-out' },
+		{ key: 'slide-in-down',  family: FAMILY_ENTRANCE, label: 'Slide in down',   keyframe: 'apSlideInDown',  duration: 600, easing: 'ease-out' },
+		{ key: 'slide-in-left',  family: FAMILY_ENTRANCE, label: 'Slide in left',   keyframe: 'apSlideInLeft',  duration: 600, easing: 'ease-out' },
+		{ key: 'slide-in-right', family: FAMILY_ENTRANCE, label: 'Slide in right',  keyframe: 'apSlideInRight', duration: 600, easing: 'ease-out' },
+		{ key: 'flip-x',         family: FAMILY_ENTRANCE, label: 'Flip X',          keyframe: 'apFlipX',        duration: 700, easing: 'ease-out' },
+		{ key: 'flip-y',         family: FAMILY_ENTRANCE, label: 'Flip Y',          keyframe: 'apFlipY',        duration: 700, easing: 'ease-out' },
+		{ key: 'rotate-in',      family: FAMILY_ENTRANCE, label: 'Rotate in',       keyframe: 'apRotateIn',     duration: 700, easing: 'ease-out' },
+	],
+	[ FAMILY_HOVER ]: [
+		{ key: 'lift',  family: FAMILY_HOVER, label: 'Lift',  preset: 'lift',  duration: 200, easing: 'ease-out' },
+		{ key: 'press', family: FAMILY_HOVER, label: 'Press', preset: 'press', duration: 120, easing: 'ease-in' },
+		{ key: 'glow',  family: FAMILY_HOVER, label: 'Glow',  preset: 'glow',  duration: 250, easing: 'ease-in-out' },
+	],
+	[ FAMILY_CONTINUOUS ]: [
+		{ key: 'pulse',  family: FAMILY_CONTINUOUS, label: 'Pulse',  keyframe: 'apPulse',  duration: 2000, easing: 'ease-in-out' },
+		{ key: 'bounce', family: FAMILY_CONTINUOUS, label: 'Bounce', keyframe: 'apBounce', duration: 1000, easing: 'ease-in-out' },
+		{ key: 'spin',   family: FAMILY_CONTINUOUS, label: 'Spin',   keyframe: 'apSpin',   duration: 2000, easing: 'linear' },
+		{ key: 'ping',   family: FAMILY_CONTINUOUS, label: 'Ping',   keyframe: 'apPing',   duration: 1000, easing: 'cubic-bezier(0, 0, 0.2, 1)' },
+		{ key: 'wiggle', family: FAMILY_CONTINUOUS, label: 'Wiggle', keyframe: 'apWiggle', duration: 800,  easing: 'ease-in-out' },
+		{ key: 'float',  family: FAMILY_CONTINUOUS, label: 'Float',  keyframe: 'apFloat',  duration: 3000, easing: 'ease-in-out' },
+	],
+};
+
+export class AnimationRegistry {
+	protected readonly byFamily: Record<AnimationFamily, Map<string, AnimationDefinition>>;
+	protected readonly customKeyframes: Map<string, CustomKeyframe>;
+
+	constructor(
+		animations: Record<AnimationFamily, AnimationDefinition[]> = DEFAULT_ANIMATIONS,
+		customKeyframes: CustomKeyframe[] = [],
+	) {
+		this.byFamily = {
+			[ FAMILY_ENTRANCE ]:   new Map(),
+			[ FAMILY_HOVER ]:      new Map(),
+			[ FAMILY_CONTINUOUS ]: new Map(),
+		};
+
+		for ( const family of ANIMATION_FAMILIES ) {
+			for ( const def of animations[ family ] ?? [] ) {
+				this.byFamily[ family ].set( def.key, def );
+			}
+		}
+
+		this.customKeyframes = new Map();
+		for ( const kf of customKeyframes ) {
+			this.customKeyframes.set( kf.name, kf );
+		}
+	}
+
+	family( family: AnimationFamily ): AnimationDefinition[] {
+		return Array.from( this.byFamily[ family ].values() );
+	}
+
+	get( family: AnimationFamily, key: string ): AnimationDefinition | null {
+		return this.byFamily[ family ].get( key ) ?? null;
+	}
+
+	has( family: AnimationFamily, key: string ): boolean {
+		return this.byFamily[ family ].has( key );
+	}
+
+	customs(): CustomKeyframe[] {
+		return Array.from( this.customKeyframes.values() );
+	}
+}
+
+export function registryFromSnapshot( snapshot: AnimationRegistrySnapshot | undefined ): AnimationRegistry {
+	if ( ! snapshot ) {
+		return new AnimationRegistry();
+	}
+
+	const animations: Record<AnimationFamily, AnimationDefinition[]> = {
+		[ FAMILY_ENTRANCE ]:   Object.values( snapshot.animations[ FAMILY_ENTRANCE ]   ?? {} ),
+		[ FAMILY_HOVER ]:      Object.values( snapshot.animations[ FAMILY_HOVER ]      ?? {} ),
+		[ FAMILY_CONTINUOUS ]: Object.values( snapshot.animations[ FAMILY_CONTINUOUS ] ?? {} ),
+	};
+
+	return new AnimationRegistry( animations, snapshot.customKeyframes ?? [] );
+}

--- a/resources/js/visual-editor/animations/runtime.ts
+++ b/resources/js/visual-editor/animations/runtime.ts
@@ -1,0 +1,227 @@
+/**
+ * Block-animations runtime (#489).
+ *
+ * The shared JS module loaded on published pages that have at least one
+ * entrance animation. It:
+ *
+ *  - Subscribes a single IntersectionObserver to every element with
+ *    `data-ap-anim-entrance`.
+ *  - Respects `prefers-reduced-motion: reduce` by default. A block can
+ *    opt-out with `data-ap-anim-reduced="allow"`.
+ *  - Watches DOM mutations for blocks that were initially hidden (e.g.
+ *    inside a collapsed accordion) so an entrance plays on first reveal.
+ *  - Re-arms blocks whose `data-ap-anim-once="false"` opts into replays.
+ *
+ * The runtime is intentionally side-effecting at import time so the
+ * renderer can just `<script type="module" src=".../animations.js">` it
+ * and forget — there's no public `init()` to call. Tests import
+ * `bootstrap()` directly to inject a fake document.
+ *
+ * Target gzipped size: <5 KB.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.1.0
+ */
+
+const PRE_CLASS = 'ap-anim-pre';
+const PLAY_CLASS = 'ap-anim-play';
+
+export interface RuntimeOptions {
+	root?: Document | ShadowRoot;
+	prefersReducedMotion?: () => boolean;
+}
+
+interface ObservedEntry {
+	element: HTMLElement;
+	threshold: number;
+	once: boolean;
+	played: boolean;
+}
+
+const observers: IntersectionObserver[] = [];
+
+function defaultReducedMotion(): boolean {
+	if ( 'undefined' === typeof window || ! window.matchMedia ) {
+		return false;
+	}
+
+	return window.matchMedia( '( prefers-reduced-motion: reduce )' ).matches;
+}
+
+function readThreshold( element: HTMLElement ): number {
+	const raw = element.getAttribute( 'data-ap-anim-threshold' );
+	if ( null === raw ) {
+		return 0.2;
+	}
+	const parsed = parseFloat( raw );
+	if ( Number.isNaN( parsed ) ) {
+		return 0.2;
+	}
+	return Math.min( 1, Math.max( 0, parsed ) );
+}
+
+function readOnce( element: HTMLElement ): boolean {
+	return 'false' !== element.getAttribute( 'data-ap-anim-once' );
+}
+
+function shouldSuppress( element: HTMLElement, reducedMotion: boolean ): boolean {
+	if ( ! reducedMotion ) {
+		return false;
+	}
+
+	return 'allow' !== element.getAttribute( 'data-ap-anim-reduced' );
+}
+
+function play( element: HTMLElement ): void {
+	element.classList.remove( PRE_CLASS );
+	element.classList.add( PLAY_CLASS );
+}
+
+function rearm( element: HTMLElement ): void {
+	element.classList.remove( PLAY_CLASS );
+	element.classList.add( PRE_CLASS );
+}
+
+export function bootstrap( options: RuntimeOptions = {} ): () => void {
+	const root = options.root ?? ( 'undefined' === typeof document ? null : document );
+	if ( null === root ) {
+		return () => undefined;
+	}
+
+	const reducedMotion = ( options.prefersReducedMotion ?? defaultReducedMotion )();
+
+	if ( 'undefined' === typeof IntersectionObserver ) {
+		// Without IO support, reveal everything immediately. The
+		// noscript fallback CSS handles the no-JS case; this branch
+		// handles JS-but-stone-age-browser.
+		root
+			.querySelectorAll<HTMLElement>( `.${ PRE_CLASS }` )
+			.forEach( ( el ) => play( el ) );
+		return () => undefined;
+	}
+
+	const entries = new Map<Element, ObservedEntry>();
+
+	// One IntersectionObserver per threshold so each element gets the
+	// exact threshold it requested instead of a coarse shared value.
+	// Stored in a map so the MutationObserver path below can look up
+	// (or lazily create) the right observer for a late-added element.
+	const observersByThreshold = new Map<number, IntersectionObserver>();
+
+	function observerFor( threshold: number ): IntersectionObserver {
+		let observer = observersByThreshold.get( threshold );
+		if ( observer ) {
+			return observer;
+		}
+		observer = new IntersectionObserver(
+			( ioEntries ) => {
+				for ( const ioEntry of ioEntries ) {
+					const meta = entries.get( ioEntry.target );
+					if ( ! meta ) {
+						continue;
+					}
+
+					if ( ioEntry.isIntersecting ) {
+						if ( ! meta.played ) {
+							play( meta.element );
+							meta.played = true;
+							if ( meta.once ) {
+								observer!.unobserve( meta.element );
+								entries.delete( meta.element );
+							}
+						}
+					} else if ( ! meta.once && meta.played ) {
+						rearm( meta.element );
+						meta.played = false;
+					}
+				}
+			},
+			{ threshold },
+		);
+		observersByThreshold.set( threshold, observer );
+		observers.push( observer );
+		return observer;
+	}
+
+	const candidates = Array.from(
+		root.querySelectorAll<HTMLElement>( '[data-ap-anim-entrance]' )
+	);
+
+	for ( const element of candidates ) {
+		if ( shouldSuppress( element, reducedMotion ) ) {
+			// Reveal immediately, skip observation.
+			play( element );
+			continue;
+		}
+
+		const entry: ObservedEntry = {
+			element,
+			threshold: readThreshold( element ),
+			once:      readOnce( element ),
+			played:    false,
+		};
+		entries.set( element, entry );
+
+		observerFor( entry.threshold ).observe( element );
+	}
+
+	// Watch for entrance blocks that were initially `display: none`
+	// (e.g. inside a closed accordion) and become visible later.
+	let mutationObserver: MutationObserver | null = null;
+	if ( 'undefined' !== typeof MutationObserver ) {
+		mutationObserver = new MutationObserver( ( mutations ) => {
+			for ( const mutation of mutations ) {
+				for ( const node of Array.from( mutation.addedNodes ) ) {
+					if ( ! ( node instanceof HTMLElement ) ) {
+						continue;
+					}
+					const added = node.matches?.( '[data-ap-anim-entrance]' )
+						? [ node ]
+						: Array.from( node.querySelectorAll?.<HTMLElement>( '[data-ap-anim-entrance]' ) ?? [] );
+
+					for ( const element of added ) {
+						if ( entries.has( element ) ) {
+							continue;
+						}
+						if ( shouldSuppress( element, reducedMotion ) ) {
+							play( element );
+							continue;
+						}
+						const entry: ObservedEntry = {
+							element,
+							threshold: readThreshold( element ),
+							once:      readOnce( element ),
+							played:    false,
+						};
+						entries.set( element, entry );
+						observerFor( entry.threshold ).observe( element );
+					}
+				}
+			}
+		} );
+
+		if ( root instanceof Document ) {
+			mutationObserver.observe( root.body, { childList: true, subtree: true } );
+		} else {
+			mutationObserver.observe( root as ShadowRoot, { childList: true, subtree: true } );
+		}
+	}
+
+	return () => {
+		for ( const observer of observers ) {
+			observer.disconnect();
+		}
+		observers.length = 0;
+		entries.clear();
+		mutationObserver?.disconnect();
+	};
+}
+
+// Side-effecting auto-boot when imported in a browser.
+if ( 'undefined' !== typeof document ) {
+	if ( 'loading' === document.readyState ) {
+		document.addEventListener( 'DOMContentLoaded', () => bootstrap(), { once: true } );
+	} else {
+		bootstrap();
+	}
+}

--- a/resources/js/visual-editor/animations/runtime.ts
+++ b/resources/js/visual-editor/animations/runtime.ts
@@ -38,8 +38,6 @@ interface ObservedEntry {
 	played: boolean;
 }
 
-const observers: IntersectionObserver[] = [];
-
 function defaultReducedMotion(): boolean {
 	if ( 'undefined' === typeof window || ! window.matchMedia ) {
 		return false;
@@ -87,6 +85,11 @@ export function bootstrap( options: RuntimeOptions = {} ): () => void {
 	if ( null === root ) {
 		return () => undefined;
 	}
+
+	// Per-bootstrap observer list so the returned disposer only tears
+	// down THIS instance — concurrent mounts on different roots stay
+	// isolated.
+	const observers: IntersectionObserver[] = [];
 
 	const reducedMotion = ( options.prefersReducedMotion ?? defaultReducedMotion )();
 

--- a/resources/js/visual-editor/animations/types.ts
+++ b/resources/js/visual-editor/animations/types.ts
@@ -1,0 +1,90 @@
+/**
+ * Shared types for the block animations system (#489).
+ *
+ * Mirrors the PHP-side AnimationRegistry / KeyframeRegistry /
+ * AnimationCssEmitter shapes so the editor's UI is type-safe end-to-end.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.1.0
+ */
+
+import type { ResponsiveAttribute } from '../responsive/types';
+
+export const FAMILY_ENTRANCE = 'entrance' as const;
+export const FAMILY_HOVER = 'hover' as const;
+export const FAMILY_CONTINUOUS = 'continuous' as const;
+
+export type AnimationFamily =
+	| typeof FAMILY_ENTRANCE
+	| typeof FAMILY_HOVER
+	| typeof FAMILY_CONTINUOUS;
+
+export const ANIMATION_FAMILIES: AnimationFamily[] = [
+	FAMILY_ENTRANCE,
+	FAMILY_HOVER,
+	FAMILY_CONTINUOUS,
+];
+
+export interface AnimationDefinition {
+	key: string;
+	family: AnimationFamily;
+	label: string;
+	duration: number;
+	easing: string;
+	/** Set on entrance + continuous entries. */
+	keyframe?: string;
+	/** Set on hover entries. */
+	preset?: string;
+}
+
+export interface AnimationRegistrySnapshot {
+	animations: Record<AnimationFamily, Record<string, AnimationDefinition>>;
+	customKeyframes: CustomKeyframe[];
+}
+
+export interface CustomKeyframeStop {
+	at: string;
+	transform?: string;
+	opacity?: string;
+	filter?: string;
+	color?: string;
+	'background-color'?: string;
+	'box-shadow'?: string;
+}
+
+export interface CustomKeyframe {
+	name: string;
+	stops: CustomKeyframeStop[];
+}
+
+export interface EntranceAttribute {
+	name?: ResponsiveAttribute<string | null>;
+	duration?: number;
+	delay?: number;
+	easing?: string;
+	threshold?: number;
+	once?: boolean;
+}
+
+export interface HoverAttribute {
+	name?: ResponsiveAttribute<string | null>;
+	duration?: number;
+	delay?: number;
+	easing?: string;
+}
+
+export interface ContinuousAttribute {
+	name?: ResponsiveAttribute<string | null>;
+	duration?: number;
+	easing?: string;
+	count?: number | 'infinite';
+}
+
+export type ReducedMotionPolicy = 'respect' | 'allow';
+
+export interface AnimationsAttribute {
+	entrance?: EntranceAttribute;
+	hover?: HoverAttribute;
+	continuous?: ContinuousAttribute;
+	reducedMotion?: ReducedMotionPolicy;
+}

--- a/resources/js/visual-editor/animations/with-animations-panel.tsx
+++ b/resources/js/visual-editor/animations/with-animations-panel.tsx
@@ -1,0 +1,104 @@
+/**
+ * `editor.BlockEdit` HOC — inject the AnimationPanel into every block
+ * that opts into `supports.artisanpackAnimations` (#489).
+ *
+ * Unlike the responsive / state HOCs, this one does NOT rewrite reads
+ * or writes — the `artisanpackAnimations` attribute is a leaf bag, and
+ * the panel mutates it directly via `setAttributes`. The HOC just
+ * makes sure the panel renders inside the inspector column whenever a
+ * supporting block is selected.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.1.0
+ */
+
+import { InspectorControls } from '@wordpress/block-editor';
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { addFilter } from '@wordpress/hooks';
+import type { ComponentType } from 'react';
+
+import { AnimationPanel } from './AnimationPanel';
+import { AnimationRegistry, DEFAULT_ANIMATIONS } from './registry';
+import type { AnimationsAttribute } from './types';
+
+const FILTER_HOOK      = 'editor.BlockEdit';
+const FILTER_NAMESPACE = 'artisanpack-ui/visual-editor/animations-panel';
+
+const REGISTERED_KEY = Symbol.for(
+	'artisanpack-ui.visual-editor.animations-panel.registered',
+);
+
+interface GlobalSentinelHost {
+	[REGISTERED_KEY]?: boolean;
+	__artisanpackAnimationRegistry?: AnimationRegistry;
+}
+
+interface BlockEditProps {
+	name: string;
+	attributes: Record<string, unknown> & {
+		artisanpackAnimations?: AnimationsAttribute | null;
+	};
+	setAttributes: ( updates: Record<string, unknown> ) => void;
+	[key: string]: unknown;
+}
+
+function getRegistry(): AnimationRegistry {
+	const host = globalThis as unknown as GlobalSentinelHost;
+	if ( ! host.__artisanpackAnimationRegistry ) {
+		host.__artisanpackAnimationRegistry = new AnimationRegistry( DEFAULT_ANIMATIONS );
+	}
+	return host.__artisanpackAnimationRegistry;
+}
+
+function blockSupports( _name: string, attributes: BlockEditProps['attributes'] ): boolean {
+	// `registerAnimationsAttribute` injects the `artisanpackAnimations`
+	// attribute (default `null`) whenever a block.json declares
+	// `supports.artisanpackAnimations: true`. So attribute presence is
+	// the canonical signal: if the schema has it, the block opted in.
+	return 'artisanpackAnimations' in attributes;
+}
+
+export const withAnimationsPanel = createHigherOrderComponent(
+	( BlockEdit: ComponentType<BlockEditProps> ) => {
+		function AnimationsBlockEdit( props: BlockEditProps ): JSX.Element {
+			const supports = blockSupports( props.name, props.attributes );
+
+			if ( ! supports ) {
+				return <BlockEdit { ...props } />;
+			}
+
+			const value = ( props.attributes.artisanpackAnimations ?? undefined ) as AnimationsAttribute | undefined;
+
+			return (
+				<>
+					<BlockEdit { ...props } />
+					<InspectorControls>
+						<AnimationPanel
+							registry={ getRegistry() }
+							value={ value }
+							onChange={ ( next ) =>
+								props.setAttributes( { artisanpackAnimations: next } )
+							}
+						/>
+					</InspectorControls>
+				</>
+			);
+		}
+
+		AnimationsBlockEdit.displayName = 'AnimationsBlockEdit';
+
+		return AnimationsBlockEdit;
+	},
+	'withAnimationsPanel',
+);
+
+export function registerAnimationsPanel(): void {
+	const host = globalThis as unknown as GlobalSentinelHost;
+
+	if ( host[ REGISTERED_KEY ] ) {
+		return;
+	}
+
+	addFilter( FILTER_HOOK, FILTER_NAMESPACE, withAnimationsPanel );
+	host[ REGISTERED_KEY ] = true;
+}

--- a/resources/js/visual-editor/blocks/accordion/block.json
+++ b/resources/js/visual-editor/blocks/accordion/block.json
@@ -20,6 +20,7 @@
         }
     },
     "supports": {
+        "artisanpackAnimations": true,
         "align": ["wide", "full"],
         "ariaLabel": true,
         "className": true,

--- a/resources/js/visual-editor/blocks/accordions/block.json
+++ b/resources/js/visual-editor/blocks/accordions/block.json
@@ -9,6 +9,7 @@
     "textdomain": "artisanpack-visual-editor",
     "attributes": {},
     "supports": {
+        "artisanpackAnimations": true,
         "align": ["wide", "full"],
         "ariaLabel": true,
         "className": true,

--- a/resources/js/visual-editor/blocks/archives/block.json
+++ b/resources/js/visual-editor/blocks/archives/block.json
@@ -25,6 +25,7 @@
         }
     },
     "supports": {
+        "artisanpackAnimations": true,
         "anchor": true,
         "align": true,
         "html": false,

--- a/resources/js/visual-editor/blocks/audio/block.json
+++ b/resources/js/visual-editor/blocks/audio/block.json
@@ -49,6 +49,7 @@
         }
     },
     "supports": {
+        "artisanpackAnimations": true,
         "anchor": true,
         "align": true,
         "spacing": {

--- a/resources/js/visual-editor/blocks/author-social-icons/block.json
+++ b/resources/js/visual-editor/blocks/author-social-icons/block.json
@@ -49,6 +49,7 @@
         }
     },
     "supports": {
+        "artisanpackAnimations": true,
         "anchor": true,
         "align": ["wide", "full"],
         "ariaLabel": true,

--- a/resources/js/visual-editor/blocks/avatar/block.json
+++ b/resources/js/visual-editor/blocks/avatar/block.json
@@ -31,6 +31,7 @@
         "artisanpack/postPreview"
     ],
     "supports": {
+        "artisanpackAnimations": true,
         "anchor": true,
         "html": false,
         "align": true,

--- a/resources/js/visual-editor/blocks/breadcrumbs/block.json
+++ b/resources/js/visual-editor/blocks/breadcrumbs/block.json
@@ -19,6 +19,7 @@
         }
     },
     "supports": {
+        "artisanpackAnimations": true,
         "align": ["wide", "full"],
         "ariaLabel": true,
         "className": true,

--- a/resources/js/visual-editor/blocks/button/block.json
+++ b/resources/js/visual-editor/blocks/button/block.json
@@ -66,6 +66,7 @@
         }
     },
     "supports": {
+        "artisanpackAnimations": true,
         "anchor": true,
         "splitting": true,
         "align": false,

--- a/resources/js/visual-editor/blocks/buttons/block.json
+++ b/resources/js/visual-editor/blocks/buttons/block.json
@@ -9,6 +9,7 @@
     "keywords": [ "link" ],
     "textdomain": "artisanpack-visual-editor",
     "supports": {
+        "artisanpackAnimations": true,
         "anchor": true,
         "align": [ "wide", "full" ],
         "html": false,

--- a/resources/js/visual-editor/blocks/callout/block.json
+++ b/resources/js/visual-editor/blocks/callout/block.json
@@ -26,6 +26,7 @@
         }
     },
     "supports": {
+        "artisanpackAnimations": true,
         "className": true,
         "html": false
     }

--- a/resources/js/visual-editor/blocks/categories/block.json
+++ b/resources/js/visual-editor/blocks/categories/block.json
@@ -43,6 +43,7 @@
     },
     "usesContext": [ "enhancedPagination" ],
     "supports": {
+        "artisanpackAnimations": true,
         "anchor": true,
         "align": true,
         "html": false,

--- a/resources/js/visual-editor/blocks/code/block.json
+++ b/resources/js/visual-editor/blocks/code/block.json
@@ -16,6 +16,7 @@
         }
     },
     "supports": {
+        "artisanpackAnimations": true,
         "align": [ "wide" ],
         "anchor": true,
         "typography": {

--- a/resources/js/visual-editor/blocks/columns/block.json
+++ b/resources/js/visual-editor/blocks/columns/block.json
@@ -24,6 +24,7 @@
         }
     },
     "supports": {
+        "artisanpackAnimations": true,
         "anchor": true,
         "align": [ "wide", "full" ],
         "html": false,

--- a/resources/js/visual-editor/blocks/comments-number/block.json
+++ b/resources/js/visual-editor/blocks/comments-number/block.json
@@ -19,6 +19,7 @@
         }
     },
     "supports": {
+        "artisanpackAnimations": true,
         "align": ["wide", "full"],
         "ariaLabel": true,
         "className": true,

--- a/resources/js/visual-editor/blocks/comments/block.json
+++ b/resources/js/visual-editor/blocks/comments/block.json
@@ -25,6 +25,7 @@
         "postType"
     ],
     "supports": {
+        "artisanpackAnimations": true,
         "anchor": true,
         "align": [ "wide", "full" ],
         "html": false,

--- a/resources/js/visual-editor/blocks/copyright/block.json
+++ b/resources/js/visual-editor/blocks/copyright/block.json
@@ -19,6 +19,7 @@
         }
     },
     "supports": {
+        "artisanpackAnimations": true,
         "align": ["wide", "full"],
         "ariaLabel": true,
         "className": true,

--- a/resources/js/visual-editor/blocks/cover/__tests__/color-utils.test.ts
+++ b/resources/js/visual-editor/blocks/cover/__tests__/color-utils.test.ts
@@ -8,6 +8,9 @@ import {
 
 describe( 'getMediaColor', () => {
 	afterEach( () => {
+		// Restore real timers FIRST so a thrown assertion in a fake-
+		// timer test can't leak fake timers into subsequent tests.
+		vi.useRealTimers()
 		vi.restoreAllMocks()
 	} )
 
@@ -43,7 +46,5 @@ describe( 'getMediaColor', () => {
 
 		const color = await pending
 		expect( color ).toBe( DEFAULT_BACKGROUND_COLOR )
-
-		vi.useRealTimers()
 	} )
 } )

--- a/resources/js/visual-editor/blocks/cover/__tests__/color-utils.test.ts
+++ b/resources/js/visual-editor/blocks/cover/__tests__/color-utils.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+	DEFAULT_BACKGROUND_COLOR,
+	getMediaColor,
+	retrieveFastAverageColor,
+} from '../edit/color-utils'
+
+describe( 'getMediaColor', () => {
+	afterEach( () => {
+		vi.restoreAllMocks()
+	} )
+
+	it( 'returns the default background colour when given an empty url', async () => {
+		const color = await getMediaColor( undefined )
+		expect( color ).toBe( DEFAULT_BACKGROUND_COLOR )
+	} )
+
+	it( 'falls back to the default background colour when getColorAsync rejects', async () => {
+		vi.spyOn( retrieveFastAverageColor(), 'getColorAsync' ).mockRejectedValueOnce(
+			new Error( 'CORS-tainted canvas' )
+		)
+
+		const color = await getMediaColor( 'https://example.test/img-' + Math.random() + '.jpg' )
+		expect( color ).toBe( DEFAULT_BACKGROUND_COLOR )
+	} )
+
+	it( 'falls back to the default colour when the underlying load never resolves (5 s timeout)', async () => {
+		vi.useFakeTimers()
+
+		// Return a promise that never resolves — simulates a stalled `<img>`
+		// request that never fires load/error/abort.
+		vi.spyOn( retrieveFastAverageColor(), 'getColorAsync' ).mockReturnValueOnce(
+			new Promise( () => undefined ) as unknown as ReturnType<
+				typeof retrieveFastAverageColor.prototype.getColorAsync
+			>
+		)
+
+		const url = 'https://example.test/stalled-' + Math.random() + '.jpg'
+		const pending = getMediaColor( url )
+
+		vi.advanceTimersByTime( 5_000 )
+
+		const color = await pending
+		expect( color ).toBe( DEFAULT_BACKGROUND_COLOR )
+
+		vi.useRealTimers()
+	} )
+} )

--- a/resources/js/visual-editor/blocks/cover/block.json
+++ b/resources/js/visual-editor/blocks/cover/block.json
@@ -93,6 +93,7 @@
         "align": true,
         "html": false,
         "shadow": true,
+        "artisanpackAnimations": true,
         "spacing": {
             "padding": true,
             "margin": ["top", "bottom"],

--- a/resources/js/visual-editor/blocks/cover/edit/color-utils.ts
+++ b/resources/js/visual-editor/blocks/cover/edit/color-utils.ts
@@ -48,6 +48,28 @@ export function retrieveFastAverageColor(): FastAverageColor {
     return cache.fastAverageColor;
 }
 
+/**
+ * Hard cap on how long we'll wait for FastAverageColor to resolve. The
+ * library wires `load`/`error`/`abort` handlers on the `<img>` it
+ * creates, but a stalled browser request (CORS preflight stall, a
+ * service-worker that never responds, certain mixed-content blocks the
+ * browser silently drops) never fires any of those events — leaving
+ * the promise pending forever. Without the timeout, the editor's
+ * color-picker and media-select code paths await this promise and
+ * appear to hang. 5 s is long enough to cover legitimately slow
+ * loads (FastAverageColor uses a regular HTTP fetch under the hood)
+ * while keeping the inspector responsive when the URL is broken.
+ */
+const GET_MEDIA_COLOR_TIMEOUT_MS = 5000;
+
+function timeout( ms: number ): Promise<typeof TIMEOUT_SENTINEL> {
+    return new Promise( ( resolve ) => {
+        setTimeout( () => resolve( TIMEOUT_SENTINEL ), ms );
+    } );
+}
+
+const TIMEOUT_SENTINEL = Symbol( 'getMediaColor.timeout' );
+
 export const getMediaColor = memoize(async (url: string | undefined) => {
     if (!url) {
         return DEFAULT_BACKGROUND_COLOR;
@@ -61,12 +83,28 @@ export const getMediaColor = memoize(async (url: string | undefined) => {
             undefined,
             url
         );
-        const color = await retrieveFastAverageColor().getColorAsync(url, {
+        const colorPromise = retrieveFastAverageColor().getColorAsync(url, {
             defaultColor: [r, g, b, a * 255],
             silent: process.env.NODE_ENV === 'production',
             crossOrigin: imgCrossOrigin as string | undefined,
         });
-        return color.hex;
+
+        const winner = await Promise.race( [
+            colorPromise,
+            timeout( GET_MEDIA_COLOR_TIMEOUT_MS ),
+        ] );
+
+        if ( winner === TIMEOUT_SENTINEL ) {
+            if ( 'production' !== process.env.NODE_ENV ) {
+                // eslint-disable-next-line no-console -- developer-facing diagnostic.
+                console.warn(
+                    `[cover] getMediaColor timed out after ${ GET_MEDIA_COLOR_TIMEOUT_MS }ms for URL "${ url }"; falling back to default. The <img> load event never fired — usually a CORS, mixed-content, or service-worker issue.`
+                );
+            }
+            return DEFAULT_BACKGROUND_COLOR;
+        }
+
+        return winner.hex;
     } catch {
         return DEFAULT_BACKGROUND_COLOR;
     }

--- a/resources/js/visual-editor/blocks/cover/edit/color-utils.ts
+++ b/resources/js/visual-editor/blocks/cover/edit/color-utils.ts
@@ -62,10 +62,26 @@ export function retrieveFastAverageColor(): FastAverageColor {
  */
 const GET_MEDIA_COLOR_TIMEOUT_MS = 5000;
 
-function timeout( ms: number ): Promise<typeof TIMEOUT_SENTINEL> {
-    return new Promise( ( resolve ) => {
-        setTimeout( () => resolve( TIMEOUT_SENTINEL ), ms );
+/**
+ * Build a cancellable timeout promise. The `cancel` callback clears
+ * the pending `setTimeout` so a winning `colorPromise` doesn't leave
+ * a timer scheduled for the full window — under frequent calls (e.g.
+ * dragging a color across the picker) the unused timers would
+ * otherwise pile up until they fire.
+ */
+function timeout( ms: number ): { promise: Promise<typeof TIMEOUT_SENTINEL>; cancel: () => void } {
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    const promise = new Promise<typeof TIMEOUT_SENTINEL>( ( resolve ) => {
+        timeoutId = setTimeout( () => resolve( TIMEOUT_SENTINEL ), ms );
     } );
+    return {
+        promise,
+        cancel: () => {
+            if ( undefined !== timeoutId ) {
+                clearTimeout( timeoutId );
+            }
+        },
+    };
 }
 
 const TIMEOUT_SENTINEL = Symbol( 'getMediaColor.timeout' );
@@ -89,10 +105,16 @@ export const getMediaColor = memoize(async (url: string | undefined) => {
             crossOrigin: imgCrossOrigin as string | undefined,
         });
 
-        const winner = await Promise.race( [
-            colorPromise,
-            timeout( GET_MEDIA_COLOR_TIMEOUT_MS ),
-        ] );
+        const timer = timeout( GET_MEDIA_COLOR_TIMEOUT_MS );
+        let winner;
+        try {
+            winner = await Promise.race( [ colorPromise, timer.promise ] );
+        } finally {
+            // Clear the timer whether the colorPromise won, threw, or
+            // the timer itself fired — no point keeping a fired timer
+            // around but no harm calling clearTimeout on it either.
+            timer.cancel();
+        }
 
         if ( winner === TIMEOUT_SENTINEL ) {
             if ( 'production' !== process.env.NODE_ENV ) {

--- a/resources/js/visual-editor/blocks/details/block.json
+++ b/resources/js/visual-editor/blocks/details/block.json
@@ -29,6 +29,7 @@
 		}
 	},
 	"supports": {
+		"artisanpackAnimations": true,
 		"__experimentalOnEnter": true,
 		"align": [ "wide", "full" ],
 		"anchor": true,

--- a/resources/js/visual-editor/blocks/embed/block.json
+++ b/resources/js/visual-editor/blocks/embed/block.json
@@ -41,6 +41,7 @@
         }
     },
     "supports": {
+        "artisanpackAnimations": true,
         "anchor": true,
         "align": true,
         "spacing": {

--- a/resources/js/visual-editor/blocks/file/block.json
+++ b/resources/js/visual-editor/blocks/file/block.json
@@ -63,6 +63,7 @@
 		}
 	},
 	"supports": {
+		"artisanpackAnimations": true,
 		"anchor": true,
 		"align": true,
 		"spacing": {

--- a/resources/js/visual-editor/blocks/form/block.json
+++ b/resources/js/visual-editor/blocks/form/block.json
@@ -14,6 +14,7 @@
         }
     },
     "supports": {
+        "artisanpackAnimations": true,
         "className": true,
         "html": false,
         "reusable": true,

--- a/resources/js/visual-editor/blocks/gallery/block.json
+++ b/resources/js/visual-editor/blocks/gallery/block.json
@@ -116,6 +116,7 @@
         }
     },
     "supports": {
+        "artisanpackAnimations": true,
         "anchor": true,
         "align": true,
         "__experimentalBorder": {

--- a/resources/js/visual-editor/blocks/grid/block.json
+++ b/resources/js/visual-editor/blocks/grid/block.json
@@ -17,6 +17,7 @@
         "numColumns": "numColumns"
     },
     "supports": {
+        "artisanpackAnimations": true,
         "anchor": true,
         "align": ["wide", "full"],
         "ariaLabel": true,

--- a/resources/js/visual-editor/blocks/group/block.json
+++ b/resources/js/visual-editor/blocks/group/block.json
@@ -18,6 +18,7 @@
         }
     },
     "supports": {
+        "artisanpackAnimations": true,
         "__experimentalOnEnter": true,
         "__experimentalOnMerge": true,
         "__experimentalSettings": true,

--- a/resources/js/visual-editor/blocks/heading/block.json
+++ b/resources/js/visual-editor/blocks/heading/block.json
@@ -26,6 +26,7 @@
         }
     },
     "supports": {
+        "artisanpackAnimations": true,
         "align": [ "wide", "full" ],
         "anchor": true,
         "className": true,

--- a/resources/js/visual-editor/blocks/icon/block.json
+++ b/resources/js/visual-editor/blocks/icon/block.json
@@ -91,6 +91,7 @@
         }
     },
     "supports": {
+        "artisanpackAnimations": true,
         "anchor": true,
         "align": [ "left", "center", "right", "wide", "full" ],
         "color": {

--- a/resources/js/visual-editor/blocks/image/block.json
+++ b/resources/js/visual-editor/blocks/image/block.json
@@ -111,6 +111,7 @@
         "interactivity": true,
         "align": [ "left", "center", "right", "wide", "full" ],
         "anchor": true,
+        "artisanpackAnimations": true,
         "color": {
             "text": false,
             "background": false

--- a/resources/js/visual-editor/blocks/latest-posts/block.json
+++ b/resources/js/visual-editor/blocks/latest-posts/block.json
@@ -83,6 +83,7 @@
         }
     },
     "supports": {
+        "artisanpackAnimations": true,
         "anchor": true,
         "align": true,
         "html": false,

--- a/resources/js/visual-editor/blocks/list/block.json
+++ b/resources/js/visual-editor/blocks/list/block.json
@@ -36,6 +36,7 @@
         }
     },
     "supports": {
+        "artisanpackAnimations": true,
         "anchor": true,
         "html": false,
         "__experimentalBorder": {

--- a/resources/js/visual-editor/blocks/loginout/block.json
+++ b/resources/js/visual-editor/blocks/loginout/block.json
@@ -21,6 +21,7 @@
         "viewportWidth": 350
     },
     "supports": {
+        "artisanpackAnimations": true,
         "anchor": true,
         "className": true,
         "color": {

--- a/resources/js/visual-editor/blocks/marquee/block.json
+++ b/resources/js/visual-editor/blocks/marquee/block.json
@@ -24,6 +24,7 @@
         }
     },
     "supports": {
+        "artisanpackAnimations": true,
         "anchor": true,
         "ariaLabel": true,
         "className": true,

--- a/resources/js/visual-editor/blocks/media-text/block.json
+++ b/resources/js/visual-editor/blocks/media-text/block.json
@@ -97,6 +97,7 @@
     },
     "usesContext": [ "postId", "postType" ],
     "supports": {
+        "artisanpackAnimations": true,
         "anchor": true,
         "align": [ "wide", "full" ],
         "html": false,

--- a/resources/js/visual-editor/blocks/navigation/block.json
+++ b/resources/js/visual-editor/blocks/navigation/block.json
@@ -125,6 +125,7 @@
         "maxNestingLevel": "maxNestingLevel"
     },
     "supports": {
+        "artisanpackAnimations": true,
         "anchor": true,
         "align": [
             "wide",

--- a/resources/js/visual-editor/blocks/next-post/block.json
+++ b/resources/js/visual-editor/blocks/next-post/block.json
@@ -25,6 +25,7 @@
         "queryId": "queryId"
     },
     "supports": {
+        "artisanpackAnimations": true,
         "anchor": true,
         "align": ["wide", "full"],
         "html": false,

--- a/resources/js/visual-editor/blocks/paragraph/block.json
+++ b/resources/js/visual-editor/blocks/paragraph/block.json
@@ -27,6 +27,7 @@
         }
     },
     "supports": {
+        "artisanpackAnimations": true,
         "align": [ "wide", "full" ],
         "splitting": true,
         "anchor": true,

--- a/resources/js/visual-editor/blocks/post-author-biography/block.json
+++ b/resources/js/visual-editor/blocks/post-author-biography/block.json
@@ -16,6 +16,7 @@
         "viewportWidth": 350
     },
     "supports": {
+        "artisanpackAnimations": true,
         "anchor": true,
         "spacing": {
             "margin": true,

--- a/resources/js/visual-editor/blocks/post-author-name/block.json
+++ b/resources/js/visual-editor/blocks/post-author-name/block.json
@@ -28,6 +28,7 @@
         "viewportWidth": 350
     },
     "supports": {
+        "artisanpackAnimations": true,
         "anchor": true,
         "html": false,
         "spacing": {

--- a/resources/js/visual-editor/blocks/post-author/block.json
+++ b/resources/js/visual-editor/blocks/post-author/block.json
@@ -42,6 +42,7 @@
         "artisanpack/postPreview"
     ],
     "supports": {
+        "artisanpackAnimations": true,
         "inserter": false,
         "anchor": true,
         "html": false,

--- a/resources/js/visual-editor/blocks/post-comments-count/block.json
+++ b/resources/js/visual-editor/blocks/post-comments-count/block.json
@@ -20,6 +20,7 @@
         "viewportWidth": 300
     },
     "supports": {
+        "artisanpackAnimations": true,
         "html": false,
         "color": {
             "gradients": true,

--- a/resources/js/visual-editor/blocks/post-comments-form/block.json
+++ b/resources/js/visual-editor/blocks/post-comments-form/block.json
@@ -16,6 +16,7 @@
         "postType"
     ],
     "supports": {
+        "artisanpackAnimations": true,
         "anchor": true,
         "align": [ "wide", "full" ],
         "html": false,

--- a/resources/js/visual-editor/blocks/post-comments-link/block.json
+++ b/resources/js/visual-editor/blocks/post-comments-link/block.json
@@ -20,6 +20,7 @@
         "viewportWidth": 350
     },
     "supports": {
+        "artisanpackAnimations": true,
         "html": false,
         "color": {
             "gradients": true,

--- a/resources/js/visual-editor/blocks/post-comments-title/block.json
+++ b/resources/js/visual-editor/blocks/post-comments-title/block.json
@@ -32,6 +32,7 @@
         "artisanpack/postPreview"
     ],
     "supports": {
+        "artisanpackAnimations": true,
         "anchor": false,
         "align": [ "wide", "full" ],
         "html": false,

--- a/resources/js/visual-editor/blocks/post-content/block.json
+++ b/resources/js/visual-editor/blocks/post-content/block.json
@@ -21,6 +21,7 @@
         "viewportWidth": 350
     },
     "supports": {
+        "artisanpackAnimations": true,
         "anchor": true,
         "align": [
             "wide",

--- a/resources/js/visual-editor/blocks/post-date/block.json
+++ b/resources/js/visual-editor/blocks/post-date/block.json
@@ -30,6 +30,7 @@
         "viewportWidth": 350
     },
     "supports": {
+        "artisanpackAnimations": true,
         "anchor": true,
         "html": false,
         "color": {

--- a/resources/js/visual-editor/blocks/post-excerpt/block.json
+++ b/resources/js/visual-editor/blocks/post-excerpt/block.json
@@ -30,6 +30,7 @@
         "viewportWidth": 350
     },
     "supports": {
+        "artisanpackAnimations": true,
         "anchor": true,
         "html": false,
         "color": {

--- a/resources/js/visual-editor/blocks/post-featured-image/block.json
+++ b/resources/js/visual-editor/blocks/post-featured-image/block.json
@@ -70,6 +70,7 @@
         "viewportWidth": 350
     },
     "supports": {
+        "artisanpackAnimations": true,
         "anchor": true,
         "align": [
             "left",

--- a/resources/js/visual-editor/blocks/post-navigation-link/block.json
+++ b/resources/js/visual-editor/blocks/post-navigation-link/block.json
@@ -38,6 +38,7 @@
         "artisanpack/postPreview"
     ],
     "supports": {
+        "artisanpackAnimations": true,
         "anchor": true,
         "reusable": false,
         "html": false,

--- a/resources/js/visual-editor/blocks/post-terms/block.json
+++ b/resources/js/visual-editor/blocks/post-terms/block.json
@@ -35,6 +35,7 @@
         "viewportWidth": 350
     },
     "supports": {
+        "artisanpackAnimations": true,
         "anchor": true,
         "html": false,
         "color": {

--- a/resources/js/visual-editor/blocks/post-title/block.json
+++ b/resources/js/visual-editor/blocks/post-title/block.json
@@ -44,6 +44,7 @@
         "viewportWidth": 350
     },
     "supports": {
+        "artisanpackAnimations": true,
         "anchor": true,
         "align": [
             "wide",

--- a/resources/js/visual-editor/blocks/post-types-search-results/block.json
+++ b/resources/js/visual-editor/blocks/post-types-search-results/block.json
@@ -8,6 +8,7 @@
     "keywords": ["search", "results", "post types"],
     "textdomain": "artisanpack-visual-editor",
     "supports": {
+        "artisanpackAnimations": true,
         "align": ["wide", "full"],
         "ariaLabel": true,
         "className": true,

--- a/resources/js/visual-editor/blocks/preformatted/block.json
+++ b/resources/js/visual-editor/blocks/preformatted/block.json
@@ -16,6 +16,7 @@
         }
     },
     "supports": {
+        "artisanpackAnimations": true,
         "anchor": true,
         "color": {
             "gradients": true,

--- a/resources/js/visual-editor/blocks/previous-post/block.json
+++ b/resources/js/visual-editor/blocks/previous-post/block.json
@@ -25,6 +25,7 @@
         "queryId": "queryId"
     },
     "supports": {
+        "artisanpackAnimations": true,
         "anchor": true,
         "align": ["wide", "full"],
         "html": false,

--- a/resources/js/visual-editor/blocks/pullquote/block.json
+++ b/resources/js/visual-editor/blocks/pullquote/block.json
@@ -24,6 +24,7 @@
         }
     },
     "supports": {
+        "artisanpackAnimations": true,
         "anchor": true,
         "align": [ "left", "right", "wide", "full" ],
         "background": {

--- a/resources/js/visual-editor/blocks/query-pagination/block.json
+++ b/resources/js/visual-editor/blocks/query-pagination/block.json
@@ -28,6 +28,7 @@
         "showLabel": "showLabel"
     },
     "supports": {
+        "artisanpackAnimations": true,
         "anchor": true,
         "align": true,
         "reusable": false,

--- a/resources/js/visual-editor/blocks/query-title/block.json
+++ b/resources/js/visual-editor/blocks/query-title/block.json
@@ -33,6 +33,7 @@
     },
     "usesContext": [ "query" ],
     "supports": {
+        "artisanpackAnimations": true,
         "anchor": true,
         "align": [ "wide", "full" ],
         "html": false,

--- a/resources/js/visual-editor/blocks/quote/block.json
+++ b/resources/js/visual-editor/blocks/quote/block.json
@@ -27,6 +27,7 @@
         }
     },
     "supports": {
+        "artisanpackAnimations": true,
         "anchor": true,
         "align": [ "left", "right", "wide", "full" ],
         "html": false,

--- a/resources/js/visual-editor/blocks/read-more/block.json
+++ b/resources/js/visual-editor/blocks/read-more/block.json
@@ -22,6 +22,7 @@
         "artisanpack/postPreview"
     ],
     "supports": {
+        "artisanpackAnimations": true,
         "anchor": true,
         "html": false,
         "color": {

--- a/resources/js/visual-editor/blocks/related-posts/block.json
+++ b/resources/js/visual-editor/blocks/related-posts/block.json
@@ -51,6 +51,7 @@
         "enhancedPagination": "enhancedPagination"
     },
     "supports": {
+        "artisanpackAnimations": true,
         "anchor": true,
         "align": ["wide", "full"],
         "ariaLabel": true,

--- a/resources/js/visual-editor/blocks/search-filters/block.json
+++ b/resources/js/visual-editor/blocks/search-filters/block.json
@@ -14,6 +14,7 @@
         }
     },
     "supports": {
+        "artisanpackAnimations": true,
         "align": ["wide", "full"],
         "ariaLabel": true,
         "className": true,

--- a/resources/js/visual-editor/blocks/search/block.json
+++ b/resources/js/visual-editor/blocks/search/block.json
@@ -49,6 +49,7 @@
         }
     },
     "supports": {
+        "artisanpackAnimations": true,
         "anchor": true,
         "align": [ "left", "center", "right" ],
         "color": {

--- a/resources/js/visual-editor/blocks/separator/block.json
+++ b/resources/js/visual-editor/blocks/separator/block.json
@@ -19,6 +19,7 @@
         }
     },
     "supports": {
+        "artisanpackAnimations": true,
         "anchor": true,
         "align": [ "center", "wide", "full" ],
         "color": {

--- a/resources/js/visual-editor/blocks/site-logo/block.json
+++ b/resources/js/visual-editor/blocks/site-logo/block.json
@@ -32,6 +32,7 @@
         }
     },
     "supports": {
+        "artisanpackAnimations": true,
         "anchor": true,
         "html": false,
         "align": true,

--- a/resources/js/visual-editor/blocks/site-tagline/block.json
+++ b/resources/js/visual-editor/blocks/site-tagline/block.json
@@ -38,6 +38,7 @@
         }
     },
     "supports": {
+        "artisanpackAnimations": true,
         "anchor": true,
         "align": [
             "wide",

--- a/resources/js/visual-editor/blocks/site-title/block.json
+++ b/resources/js/visual-editor/blocks/site-title/block.json
@@ -38,6 +38,7 @@
         "viewportWidth": 500
     },
     "supports": {
+        "artisanpackAnimations": true,
         "anchor": true,
         "align": [
             "wide",

--- a/resources/js/visual-editor/blocks/skills-slider/block.json
+++ b/resources/js/visual-editor/blocks/skills-slider/block.json
@@ -30,6 +30,7 @@
         }
     },
     "supports": {
+        "artisanpackAnimations": true,
         "anchor": true,
         "className": true,
         "html": false,

--- a/resources/js/visual-editor/blocks/social-share-content/block.json
+++ b/resources/js/visual-editor/blocks/social-share-content/block.json
@@ -49,6 +49,7 @@
         }
     },
     "supports": {
+        "artisanpackAnimations": true,
         "anchor": true,
         "align": ["wide", "full"],
         "ariaLabel": true,

--- a/resources/js/visual-editor/blocks/spacer/block.json
+++ b/resources/js/visual-editor/blocks/spacer/block.json
@@ -17,6 +17,7 @@
     },
     "usesContext": [ "orientation" ],
     "supports": {
+        "artisanpackAnimations": true,
         "anchor": true,
         "spacing": {
             "margin": [ "top", "bottom" ],

--- a/resources/js/visual-editor/blocks/table/block.json
+++ b/resources/js/visual-editor/blocks/table/block.json
@@ -157,6 +157,7 @@
         }
     },
     "supports": {
+        "artisanpackAnimations": true,
         "anchor": true,
         "align": true,
         "color": {

--- a/resources/js/visual-editor/blocks/tabs/block.json
+++ b/resources/js/visual-editor/blocks/tabs/block.json
@@ -20,6 +20,7 @@
         }
     },
     "supports": {
+        "artisanpackAnimations": true,
         "align": ["wide", "full"],
         "anchor": true,
         "ariaLabel": true,

--- a/resources/js/visual-editor/blocks/tag-cloud/block.json
+++ b/resources/js/visual-editor/blocks/tag-cloud/block.json
@@ -35,6 +35,7 @@
         { "name": "outline", "label": "Outline" }
     ],
     "supports": {
+        "artisanpackAnimations": true,
         "anchor": true,
         "html": false,
         "align": true,

--- a/resources/js/visual-editor/blocks/term-description/block.json
+++ b/resources/js/visual-editor/blocks/term-description/block.json
@@ -8,6 +8,7 @@
     "textdomain": "artisanpack-visual-editor",
     "usesContext": [ "termId", "taxonomy" ],
     "supports": {
+        "artisanpackAnimations": true,
         "anchor": true,
         "align": [ "wide", "full" ],
         "html": false,

--- a/resources/js/visual-editor/blocks/verse/block.json
+++ b/resources/js/visual-editor/blocks/verse/block.json
@@ -17,6 +17,7 @@
         }
     },
     "supports": {
+        "artisanpackAnimations": true,
         "anchor": true,
         "background": {
             "backgroundImage": true,

--- a/resources/js/visual-editor/blocks/video/block.json
+++ b/resources/js/visual-editor/blocks/video/block.json
@@ -83,6 +83,7 @@
 		}
 	},
 	"supports": {
+		"artisanpackAnimations": true,
 		"anchor": true,
 		"align": true,
 		"spacing": {

--- a/resources/js/visual-editor/editor/editor-app.tsx
+++ b/resources/js/visual-editor/editor/editor-app.tsx
@@ -45,6 +45,8 @@ import { registerResponsiveAttributesFilter } from '../responsive/with-responsiv
 import { registerStateAttribute } from '../states/register-attribute';
 import { registerStateAttributesFilter } from '../states/with-state-attributes';
 import { registerStateStylesFilters } from '../states/with-state-styles';
+import { registerAnimationsAttribute } from '../animations/register-attribute';
+import { registerAnimationsPanel } from '../animations/with-animations-panel';
 import { StateInspectorSync } from '../states/StateInspectorSync';
 import { StateWriteInterceptor } from '../states/state-write-interceptor';
 import { ConvertToPatternControl } from './convert-to-pattern-control';
@@ -177,6 +179,13 @@ function registerOnce(): void {
     registerStateAttribute();
     registerStateAttributesFilter();
     registerStateStylesFilters();
+    // #489 — register the animation feature filters BEFORE blocks load
+    // so opted-in blocks pick up the auto-injected
+    // `artisanpackAnimations` attribute at registration time and the
+    // BlockEdit HOC drops the AnimationPanel into the inspector on
+    // first render.
+    registerAnimationsAttribute();
+    registerAnimationsPanel();
     // I7 (#415): register all artisanpack/* blocks and set the default
     // block to artisanpack/paragraph. Core blocks are no longer loaded.
     registerArtisanPackBlocks();

--- a/src/Animations/AnimationAttributeResolver.php
+++ b/src/Animations/AnimationAttributeResolver.php
@@ -1,0 +1,104 @@
+<?php
+
+/**
+ * Animation attribute resolver — block animations (#489).
+ *
+ * Walks a responsive-aware animation attribute and returns the effective
+ * value for a given breakpoint, following the mobile-first cascade. The
+ * shape mirrors {@see \ArtisanPackUI\VisualEditor\Responsive\ResponsiveValueResolver}:
+ *
+ *     [
+ *         'base' => 'fade-in',
+ *         'md'   => null,        // disables under `md`
+ *     ]
+ *
+ * A scalar value is treated as the `base`-only shape.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.1.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Animations;
+
+use ArtisanPackUI\VisualEditor\Responsive\BreakpointRegistry;
+
+class AnimationAttributeResolver
+{
+	public function __construct( protected BreakpointRegistry $breakpoints ) {}
+
+	/**
+	 * Resolves the effective animation value for `$breakpoint`. Walks
+	 * from the requested breakpoint down through the registered ordering
+	 * (and finally `base`) returning the first non-`null` entry. An
+	 * explicit `null` at the requested breakpoint short-circuits to
+	 * "disabled" so authors can opt out of an animation per-breakpoint.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param  mixed   $value
+	 */
+	public function resolve( $value, string $breakpoint = BreakpointRegistry::BASE_KEY ): mixed
+	{
+		if ( ! is_array( $value ) ) {
+			return BreakpointRegistry::BASE_KEY === $breakpoint ? $value : null;
+		}
+
+		$order = $this->breakpoints->keysWithBase();
+
+		// Build the cascade from the requested breakpoint down to base.
+		$index = array_search( $breakpoint, $order, true );
+		if ( false === $index ) {
+			return $value[ BreakpointRegistry::BASE_KEY ] ?? null;
+		}
+
+		// Walk from $index → 0 inclusive.
+		for ( $i = $index; $i >= 0; $i-- ) {
+			$key = $order[ $i ];
+			if ( ! array_key_exists( $key, $value ) ) {
+				continue;
+			}
+
+			// Explicit null at the EXACT requested breakpoint disables
+			// the animation. A null further down the cascade is treated
+			// as "not set at this breakpoint" and skipped.
+			if ( null === $value[ $key ] ) {
+				if ( $i === $index ) {
+					return null;
+				}
+				continue;
+			}
+
+			return $value[ $key ];
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the resolved values for every registered breakpoint plus
+	 * `base`, in cascade order. Useful for the renderer when it needs to
+	 * emit one CSS rule per breakpoint scope.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param  mixed  $value
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function resolveAll( $value ): array
+	{
+		$resolved = [];
+
+		foreach ( $this->breakpoints->keysWithBase() as $key ) {
+			$resolved[ $key ] = $this->resolve( $value, $key );
+		}
+
+		return $resolved;
+	}
+}

--- a/src/Animations/AnimationAttributeResolver.php
+++ b/src/Animations/AnimationAttributeResolver.php
@@ -45,8 +45,11 @@ class AnimationAttributeResolver
 	 */
 	public function resolve( $value, string $breakpoint = BreakpointRegistry::BASE_KEY ): mixed
 	{
+		// A scalar value is the "base shape" and applies across every
+		// breakpoint — matches `ResponsiveValueResolver::resolve()` and
+		// the documented behaviour in `types.ts`.
 		if ( ! is_array( $value ) ) {
-			return BreakpointRegistry::BASE_KEY === $breakpoint ? $value : null;
+			return $value;
 		}
 
 		$order = $this->breakpoints->keysWithBase();

--- a/src/Animations/AnimationCssEmitter.php
+++ b/src/Animations/AnimationCssEmitter.php
@@ -1,0 +1,563 @@
+<?php
+
+/**
+ * Animation CSS emitter — block animations (#489).
+ *
+ * Server-side helper that turns a block's `animations` attribute bag
+ * into the scoped CSS rules plus the markup hints the renderers need:
+ *
+ *  - Per-block CSS scoped to `.ap-block-<uid>` covering entrance,
+ *    continuous, hover-transition + preset classes, and per-breakpoint
+ *    overrides (including "disabled at this breakpoint" → reset).
+ *  - A `<noscript>` rule that reveals the block in its final state when
+ *    JS is unavailable.
+ *  - The `data-ap-anim-*` attributes the runtime reads to know when to
+ *    swap an entrance block out of its hidden pre-state.
+ *  - The CSS class list to add to the block's wrapper.
+ *
+ * The shape the emitter accepts (and the editor persists into
+ * `attributes.artisanpackAnimations`) is:
+ *
+ *     [
+ *         'entrance' => [
+ *             'name'      => 'fade-in-up' | null,
+ *             'duration'  => 600,
+ *             'delay'     => 100,
+ *             'easing'    => 'ease-out',
+ *             'threshold' => 0.2,
+ *             'once'      => true,
+ *         ],
+ *         'hover' => [
+ *             'name'     => 'lift' | null,
+ *             'duration' => 200,
+ *             'delay'    => 0,
+ *             'easing'   => 'ease-out',
+ *         ],
+ *         'continuous' => [
+ *             'name'     => 'pulse' | null,
+ *             'duration' => 2000,
+ *             'easing'   => 'ease-in-out',
+ *             'count'    => 'infinite' | int,
+ *         ],
+ *         'reducedMotion' => 'respect' | 'allow',
+ *     ]
+ *
+ * The `entrance` and `continuous` `name` fields may also be a
+ * responsive-aware shape, e.g. `[ 'base' => 'fade-in', 'md' => null ]`
+ * — the resolver walks them per-breakpoint.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.1.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Animations;
+
+use ArtisanPackUI\VisualEditor\Responsive\BreakpointRegistry;
+
+class AnimationCssEmitter
+{
+	public const PRE_CLASS  = 'ap-anim-pre';
+	public const PLAY_CLASS = 'ap-anim-play';
+	public const ROOT_CLASS = 'ap-anim';
+
+	/**
+	 * Hover presets — composable CSS fragments the emitter snaps onto
+	 * the `:hover` rule when an editor picks one. The transition curve
+	 * controls timing; the preset controls the transform / shadow.
+	 *
+	 * @var array<string, array{transform?: string, box-shadow?: string, filter?: string}>
+	 */
+	protected const HOVER_PRESETS = [
+		'lift'  => [ 'transform' => 'translateY(-3px)', 'box-shadow' => '0 8px 24px rgba(0,0,0,0.12)' ],
+		'press' => [ 'transform' => 'translateY(1px) scale(0.99)' ],
+		'glow'  => [ 'box-shadow' => '0 0 0 4px rgba(99,102,241,0.35)' ],
+	];
+
+	public function __construct(
+		protected AnimationRegistry $registry,
+		protected KeyframeRegistry $keyframes,
+		protected BreakpointRegistry $breakpoints,
+		protected AnimationAttributeResolver $resolver,
+	) {}
+
+	/**
+	 * Emits the animation CSS for a block scope.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param  string                $scope       e.g. `.ap-block-abc123`.
+	 *                                            Must include the leading `.`.
+	 * @param  array<string, mixed>  $attributes  The block's `animations` bag.
+	 *
+	 * @return string Empty string when nothing should be emitted.
+	 */
+	public function emit( string $scope, array $attributes ): string
+	{
+		if ( '' === trim( $scope ) || [] === $attributes ) {
+			return '';
+		}
+
+		$css = '';
+
+		$css .= $this->emitEntrance( $scope, $attributes['entrance'] ?? [] );
+		$css .= $this->emitHover( $scope, $attributes['hover'] ?? [] );
+		$css .= $this->emitContinuous( $scope, $attributes['continuous'] ?? [] );
+
+		if ( $this->respectsReducedMotion( $attributes ) ) {
+			$css .= $this->emitReducedMotionGuard( $scope );
+		}
+
+		$css .= $this->emitNoscriptFallback( $scope, $attributes );
+
+		return trim( $css );
+	}
+
+	/**
+	 * Returns the wrapper class list the renderer should attach to a
+	 * block when it has any animations configured. The runtime swaps
+	 * `PRE_CLASS` for `PLAY_CLASS` when the block enters the viewport.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param  array<string, mixed>  $attributes
+	 *
+	 * @return array<int, string>
+	 */
+	public function wrapperClasses( array $attributes ): array
+	{
+		$classes = [];
+
+		if ( $this->hasAny( $attributes ) ) {
+			$classes[] = self::ROOT_CLASS;
+		}
+
+		if ( $this->hasEntranceAnywhere( $attributes ) ) {
+			$classes[] = self::PRE_CLASS;
+		}
+
+		return $classes;
+	}
+
+	/**
+	 * Returns the `data-*` attribute map the renderer adds to a block's
+	 * wrapper. The runtime keys off these to know which entrance
+	 * animation to play, when to play it, and whether the host opted out
+	 * of the global `prefers-reduced-motion` respect.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param  array<string, mixed>  $attributes
+	 *
+	 * @return array<string, string>
+	 */
+	public function dataAttributes( array $attributes ): array
+	{
+		$data = [];
+
+		$entrance = $attributes['entrance'] ?? [];
+		$base     = $this->resolver->resolve( $entrance['name'] ?? null, BreakpointRegistry::BASE_KEY );
+
+		if ( is_string( $base ) && '' !== $base ) {
+			$data['data-ap-anim-entrance'] = $base;
+
+			$threshold = $entrance['threshold'] ?? null;
+			if ( is_numeric( $threshold ) ) {
+				$data['data-ap-anim-threshold'] = (string) (float) $threshold;
+			}
+
+			$once = $entrance['once'] ?? true;
+			if ( false === $once ) {
+				$data['data-ap-anim-once'] = 'false';
+			}
+		}
+
+		$reduced = $attributes['reducedMotion'] ?? 'respect';
+		if ( 'allow' === $reduced ) {
+			$data['data-ap-anim-reduced'] = 'allow';
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Reports whether any family has a configured animation. Used by
+	 * the renderer to decide whether to attach the runtime chunk.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param  array<string, mixed>  $attributes
+	 */
+	public function hasAny( array $attributes ): bool
+	{
+		return $this->hasEntranceAnywhere( $attributes )
+			|| $this->hasHover( $attributes['hover'] ?? [] )
+			|| $this->hasContinuousAnywhere( $attributes );
+	}
+
+	/**
+	 * Reports whether any entrance animation is configured at any
+	 * breakpoint. The runtime only needs to load on pages where this is
+	 * true.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param  array<string, mixed>  $attributes
+	 */
+	public function hasEntrance( array $attributes ): bool
+	{
+		return $this->hasEntranceAnywhere( $attributes );
+	}
+
+	/**
+	 * @param  array<string, mixed>  $entrance
+	 */
+	protected function emitEntrance( string $scope, array $entrance ): string
+	{
+		if ( ! $this->hasEntranceAnywhere( [ 'entrance' => $entrance ] ) ) {
+			return '';
+		}
+
+		$base = $this->resolver->resolve( $entrance['name'] ?? null, BreakpointRegistry::BASE_KEY );
+		$css  = '';
+
+		if ( is_string( $base ) && $this->registry->has( AnimationRegistry::FAMILY_ENTRANCE, $base ) ) {
+			$definition = $this->registry->get( AnimationRegistry::FAMILY_ENTRANCE, $base );
+			$css       .= $this->preStateRule( $scope );
+			$css       .= sprintf(
+				'%s.%s { animation: %s %dms %s %dms both; }',
+				$scope,
+				self::PLAY_CLASS,
+				$definition['keyframe'],
+				$this->intOr( $entrance['duration'] ?? null, (int) $definition['duration'] ),
+				$this->easingOr( $entrance['easing'] ?? null, (string) $definition['easing'] ),
+				$this->intOr( $entrance['delay'] ?? null, 0 ),
+			);
+		}
+
+		$css .= $this->emitEntranceBreakpointOverrides( $scope, $entrance );
+
+		return $css;
+	}
+
+	/**
+	 * @param  array<string, mixed>  $entrance
+	 */
+	protected function emitEntranceBreakpointOverrides( string $scope, array $entrance ): string
+	{
+		$name = $entrance['name'] ?? null;
+		if ( ! is_array( $name ) ) {
+			return '';
+		}
+
+		$css = '';
+
+		foreach ( $this->breakpoints->all() as $prefix => $minWidth ) {
+			if ( ! array_key_exists( $prefix, $name ) ) {
+				continue;
+			}
+
+			$value = $name[ $prefix ];
+
+			if ( null === $value ) {
+				// Disable at this breakpoint — reset both the pre-state
+				// hiding and the animation property so the block reads
+				// statically.
+				$css .= sprintf(
+					'@media (min-width: %dpx) { %s.%s, %s.%s { animation: none; opacity: 1; transform: none; } }',
+					$minWidth,
+					$scope,
+					self::PRE_CLASS,
+					$scope,
+					self::PLAY_CLASS,
+				);
+				continue;
+			}
+
+			if ( ! is_string( $value ) || ! $this->registry->has( AnimationRegistry::FAMILY_ENTRANCE, $value ) ) {
+				continue;
+			}
+
+			$definition = $this->registry->get( AnimationRegistry::FAMILY_ENTRANCE, $value );
+
+			$css .= sprintf(
+				'@media (min-width: %dpx) { %s.%s { animation: %s %dms %s %dms both; } }',
+				$minWidth,
+				$scope,
+				self::PLAY_CLASS,
+				$definition['keyframe'],
+				$this->intOr( $entrance['duration'] ?? null, (int) $definition['duration'] ),
+				$this->easingOr( $entrance['easing'] ?? null, (string) $definition['easing'] ),
+				$this->intOr( $entrance['delay'] ?? null, 0 ),
+			);
+		}
+
+		return $css;
+	}
+
+	protected function preStateRule( string $scope ): string
+	{
+		// Pre-state hides the block by zeroing opacity. The runtime
+		// removes `.ap-anim-pre` and adds `.ap-anim-play`, which has the
+		// real `animation` property. Transform is left to the keyframe
+		// 0% stop so we don't fight the choreography.
+		return sprintf( '%s.%s { opacity: 0; } ', $scope, self::PRE_CLASS );
+	}
+
+	/**
+	 * @param  array<string, mixed>  $hover
+	 */
+	protected function emitHover( string $scope, array $hover ): string
+	{
+		$name = $this->resolver->resolve( $hover['name'] ?? null, BreakpointRegistry::BASE_KEY );
+		if ( ! is_string( $name ) || ! $this->registry->has( AnimationRegistry::FAMILY_HOVER, $name ) ) {
+			// Even without a preset, an authored duration/easing should
+			// emit a transition curve so the state engine's transitions
+			// inherit the chosen timing.
+			if ( ! isset( $hover['duration'] ) && ! isset( $hover['easing'] ) ) {
+				return '';
+			}
+
+			$duration = $this->intOr( $hover['duration'] ?? null, 150 );
+			$easing   = $this->easingOr( $hover['easing'] ?? null, 'ease' );
+
+			return sprintf( '%s { transition: all %dms %s; } ', $scope, $duration, $easing );
+		}
+
+		$definition = $this->registry->get( AnimationRegistry::FAMILY_HOVER, $name );
+		$duration   = $this->intOr( $hover['duration'] ?? null, (int) $definition['duration'] );
+		$easing     = $this->easingOr( $hover['easing'] ?? null, (string) $definition['easing'] );
+		$preset     = (string) ( $definition['preset'] ?? '' );
+
+		$rule  = sprintf( '%s { transition: all %dms %s; } ', $scope, $duration, $easing );
+		$preset_decls = self::HOVER_PRESETS[ $preset ] ?? null;
+
+		if ( null !== $preset_decls ) {
+			$decls = [];
+			foreach ( $preset_decls as $property => $value ) {
+				$decls[] = sprintf( '%s: %s;', $property, $value );
+			}
+
+			$rule .= sprintf(
+				'@media (hover: hover) { %s:hover { %s } } ',
+				$scope,
+				implode( ' ', $decls )
+			);
+		}
+
+		return $rule;
+	}
+
+	/**
+	 * @param  array<string, mixed>  $continuous
+	 */
+	protected function emitContinuous( string $scope, array $continuous ): string
+	{
+		$base = $this->resolver->resolve( $continuous['name'] ?? null, BreakpointRegistry::BASE_KEY );
+		$css  = '';
+
+		if ( is_string( $base ) && $this->registry->has( AnimationRegistry::FAMILY_CONTINUOUS, $base ) ) {
+			$definition = $this->registry->get( AnimationRegistry::FAMILY_CONTINUOUS, $base );
+			$css       .= sprintf(
+				'%s { animation: %s %dms %s 0ms %s; } ',
+				$scope,
+				$definition['keyframe'],
+				$this->intOr( $continuous['duration'] ?? null, (int) $definition['duration'] ),
+				$this->easingOr( $continuous['easing'] ?? null, (string) $definition['easing'] ),
+				$this->countOr( $continuous['count'] ?? null ),
+			);
+		}
+
+		if ( is_array( $continuous['name'] ?? null ) ) {
+			foreach ( $this->breakpoints->all() as $prefix => $minWidth ) {
+				if ( ! array_key_exists( $prefix, $continuous['name'] ) ) {
+					continue;
+				}
+
+				$value = $continuous['name'][ $prefix ];
+
+				if ( null === $value ) {
+					$css .= sprintf(
+						'@media (min-width: %dpx) { %s { animation: none; } } ',
+						$minWidth,
+						$scope,
+					);
+					continue;
+				}
+
+				if ( ! is_string( $value ) || ! $this->registry->has( AnimationRegistry::FAMILY_CONTINUOUS, $value ) ) {
+					continue;
+				}
+
+				$definition = $this->registry->get( AnimationRegistry::FAMILY_CONTINUOUS, $value );
+
+				$css .= sprintf(
+					'@media (min-width: %dpx) { %s { animation: %s %dms %s 0ms %s; } } ',
+					$minWidth,
+					$scope,
+					$definition['keyframe'],
+					$this->intOr( $continuous['duration'] ?? null, (int) $definition['duration'] ),
+					$this->easingOr( $continuous['easing'] ?? null, (string) $definition['easing'] ),
+					$this->countOr( $continuous['count'] ?? null ),
+				);
+			}
+		}
+
+		return $css;
+	}
+
+	protected function emitReducedMotionGuard( string $scope ): string
+	{
+		return sprintf(
+			'@media (prefers-reduced-motion: reduce) { %s, %s.%s, %s.%s { animation: none !important; transition: none !important; opacity: 1 !important; transform: none !important; } } ',
+			$scope,
+			$scope,
+			self::PRE_CLASS,
+			$scope,
+			self::PLAY_CLASS,
+		);
+	}
+
+	/**
+	 * @param  array<string, mixed>  $attributes
+	 */
+	protected function emitNoscriptFallback( string $scope, array $attributes ): string
+	{
+		if ( ! $this->hasEntranceAnywhere( $attributes ) ) {
+			return '';
+		}
+
+		// The noscript fallback CSS itself is included unconditionally —
+		// the renderer wraps the actual <style> tag in <noscript>. We
+		// return the rule that resets the pre-state when JS is missing.
+		return '';
+	}
+
+	/**
+	 * The CSS the renderer should drop inside a `<noscript>` tag — when
+	 * JS doesn't run, this reveals the block in its final state.
+	 *
+	 * @since 1.1.0
+	 */
+	public function noscriptCss( string $scope ): string
+	{
+		return sprintf(
+			'%s.%s { opacity: 1; transform: none; }',
+			$scope,
+			self::PRE_CLASS
+		);
+	}
+
+	protected function respectsReducedMotion( array $attributes ): bool
+	{
+		$value = $attributes['reducedMotion'] ?? 'respect';
+
+		return 'allow' !== $value;
+	}
+
+	/**
+	 * @param  array<string, mixed>  $hover
+	 */
+	protected function hasHover( array $hover ): bool
+	{
+		$name = $hover['name'] ?? null;
+		if ( is_string( $name ) && '' !== $name ) {
+			return true;
+		}
+
+		return isset( $hover['duration'] ) || isset( $hover['easing'] );
+	}
+
+	/**
+	 * @param  array<string, mixed>  $attributes
+	 */
+	protected function hasEntranceAnywhere( array $attributes ): bool
+	{
+		$name = $attributes['entrance']['name'] ?? null;
+
+		return $this->nameNotEmpty( $name );
+	}
+
+	/**
+	 * @param  array<string, mixed>  $attributes
+	 */
+	protected function hasContinuousAnywhere( array $attributes ): bool
+	{
+		$name = $attributes['continuous']['name'] ?? null;
+
+		return $this->nameNotEmpty( $name );
+	}
+
+	protected function nameNotEmpty( $name ): bool
+	{
+		if ( is_string( $name ) && '' !== $name ) {
+			return true;
+		}
+
+		if ( is_array( $name ) ) {
+			foreach ( $name as $value ) {
+				if ( is_string( $value ) && '' !== $value ) {
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+
+	protected function intOr( $value, int $fallback ): int
+	{
+		if ( is_int( $value ) && $value >= 0 ) {
+			return $value;
+		}
+
+		if ( is_numeric( $value ) ) {
+			$cast = (int) $value;
+
+			return $cast >= 0 ? $cast : $fallback;
+		}
+
+		return $fallback;
+	}
+
+	protected function easingOr( $value, string $fallback ): string
+	{
+		if ( ! is_string( $value ) ) {
+			return $fallback;
+		}
+
+		$trimmed = trim( $value );
+		if ( '' === $trimmed ) {
+			return $fallback;
+		}
+
+		// Defence-in-depth: reject anything with characters that could
+		// break out of the `animation` shorthand.
+		if ( 1 === preg_match( '/[<>{};]/', $trimmed ) ) {
+			return $fallback;
+		}
+
+		return $trimmed;
+	}
+
+	protected function countOr( $value ): string
+	{
+		if ( is_int( $value ) && $value > 0 ) {
+			return (string) $value;
+		}
+
+		if ( is_string( $value ) && '' !== trim( $value ) ) {
+			$trimmed = trim( $value );
+			if ( 'infinite' === $trimmed || ctype_digit( $trimmed ) ) {
+				return $trimmed;
+			}
+		}
+
+		return 'infinite';
+	}
+}

--- a/src/Animations/AnimationCssEmitter.php
+++ b/src/Animations/AnimationCssEmitter.php
@@ -103,11 +103,18 @@ class AnimationCssEmitter
 			return '';
 		}
 
+		$entrance   = $attributes['entrance'] ?? [];
+		$continuous = $attributes['continuous'] ?? [];
+
 		$css = '';
 
-		$css .= $this->emitEntrance( $scope, $attributes['entrance'] ?? [] );
+		// Entrance + continuous compose by sharing the `animation`
+		// property — the play-class rule emits a comma-joined shorthand
+		// when both families resolve, so the entrance doesn't clobber
+		// the continuous loop the moment `.ap-anim-play` is added.
+		$css .= $this->emitEntrance( $scope, $entrance, $continuous );
 		$css .= $this->emitHover( $scope, $attributes['hover'] ?? [] );
-		$css .= $this->emitContinuous( $scope, $attributes['continuous'] ?? [] );
+		$css .= $this->emitContinuous( $scope, $continuous );
 
 		if ( $this->respectsReducedMotion( $attributes ) ) {
 			$css .= $this->emitReducedMotionGuard( $scope );
@@ -162,9 +169,15 @@ class AnimationCssEmitter
 
 		$entrance = $attributes['entrance'] ?? [];
 		$base     = $this->resolver->resolve( $entrance['name'] ?? null, BreakpointRegistry::BASE_KEY );
+		// Fall back to the first responsive-only entrance value so
+		// `{ md: 'fade-in' }` configs still surface the data attr the
+		// runtime needs to know the block is an entrance candidate.
+		$effective = is_string( $base ) && '' !== $base
+			? $base
+			: $this->firstConfiguredEntrance( $entrance['name'] ?? null );
 
-		if ( is_string( $base ) && '' !== $base ) {
-			$data['data-ap-anim-entrance'] = $base;
+		if ( is_string( $effective ) && '' !== $effective ) {
+			$data['data-ap-anim-entrance'] = $effective;
 
 			$threshold = $entrance['threshold'] ?? null;
 			if ( is_numeric( $threshold ) ) {
@@ -217,38 +230,122 @@ class AnimationCssEmitter
 	/**
 	 * @param  array<string, mixed>  $entrance
 	 */
-	protected function emitEntrance( string $scope, array $entrance ): string
+	protected function emitEntrance( string $scope, array $entrance, array $continuous = [] ): string
 	{
 		if ( ! $this->hasEntranceAnywhere( [ 'entrance' => $entrance ] ) ) {
 			return '';
 		}
 
-		$base = $this->resolver->resolve( $entrance['name'] ?? null, BreakpointRegistry::BASE_KEY );
-		$css  = '';
+		$base   = $this->resolver->resolve( $entrance['name'] ?? null, BreakpointRegistry::BASE_KEY );
+		$effect = is_string( $base ) && $this->registry->has( AnimationRegistry::FAMILY_ENTRANCE, $base )
+			? $base
+			: $this->firstConfiguredEntrance( $entrance['name'] ?? null );
+
+		$css = '';
+
+		if ( null !== $effect ) {
+			// Pre-state always emitted when ANY entrance breakpoint
+			// configures a valid name — covers responsive-only entrance
+			// configs (e.g. `{ md: 'fade-in' }`) so the block hides
+			// before the runtime swaps the play class.
+			$css .= $this->preStateRule( $scope );
+		}
 
 		if ( is_string( $base ) && $this->registry->has( AnimationRegistry::FAMILY_ENTRANCE, $base ) ) {
-			$definition = $this->registry->get( AnimationRegistry::FAMILY_ENTRANCE, $base );
-			$css       .= $this->preStateRule( $scope );
-			$css       .= sprintf(
-				'%s.%s { animation: %s %dms %s %dms both; }',
-				$scope,
-				self::PLAY_CLASS,
+			$definition  = $this->registry->get( AnimationRegistry::FAMILY_ENTRANCE, $base );
+			$entranceCss = $this->animationShorthand(
 				$definition['keyframe'],
 				$this->intOr( $entrance['duration'] ?? null, (int) $definition['duration'] ),
 				$this->easingOr( $entrance['easing'] ?? null, (string) $definition['easing'] ),
 				$this->intOr( $entrance['delay'] ?? null, 0 ),
+				'both',
+			);
+
+			$continuousCss = $this->resolvedContinuousShorthand( $continuous );
+
+			$animation = null !== $continuousCss
+				? $entranceCss . ', ' . $continuousCss
+				: $entranceCss;
+
+			$css .= sprintf(
+				'%s.%s { animation: %s; }',
+				$scope,
+				self::PLAY_CLASS,
+				$animation,
 			);
 		}
 
-		$css .= $this->emitEntranceBreakpointOverrides( $scope, $entrance );
+		$css .= $this->emitEntranceBreakpointOverrides( $scope, $entrance, $continuous );
 
 		return $css;
 	}
 
 	/**
+	 * Returns the first responsive-named entrance value that resolves to
+	 * a registered animation, or `null`. Used to drive pre-state CSS +
+	 * `data-ap-anim-entrance` even when only a non-`base` breakpoint
+	 * configures an entrance.
+	 */
+	protected function firstConfiguredEntrance( $name ): ?string
+	{
+		if ( is_string( $name ) && $this->registry->has( AnimationRegistry::FAMILY_ENTRANCE, $name ) ) {
+			return $name;
+		}
+
+		if ( ! is_array( $name ) ) {
+			return null;
+		}
+
+		foreach ( $name as $value ) {
+			if ( is_string( $value ) && $this->registry->has( AnimationRegistry::FAMILY_ENTRANCE, $value ) ) {
+				return $value;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Builds an `animation`-shorthand value for the given parameters.
+	 */
+	protected function animationShorthand( string $keyframe, int $duration, string $easing, int $delay, string $tail ): string
+	{
+		return sprintf( '%s %dms %s %dms %s', $keyframe, $duration, $easing, $delay, $tail );
+	}
+
+	/**
+	 * Returns the continuous animation shorthand (without `animation:`
+	 * prefix) when the base breakpoint resolves cleanly. Used by the
+	 * entrance emitter to compose entrance + continuous on the play
+	 * class so the entrance doesn't override the continuous loop.
+	 */
+	protected function resolvedContinuousShorthand( array $continuous ): ?string
+	{
+		if ( [] === $continuous ) {
+			return null;
+		}
+
+		$base = $this->resolver->resolve( $continuous['name'] ?? null, BreakpointRegistry::BASE_KEY );
+
+		if ( ! is_string( $base ) || ! $this->registry->has( AnimationRegistry::FAMILY_CONTINUOUS, $base ) ) {
+			return null;
+		}
+
+		$definition = $this->registry->get( AnimationRegistry::FAMILY_CONTINUOUS, $base );
+
+		return sprintf(
+			'%s %dms %s 0ms %s',
+			$definition['keyframe'],
+			$this->intOr( $continuous['duration'] ?? null, (int) $definition['duration'] ),
+			$this->easingOr( $continuous['easing'] ?? null, (string) $definition['easing'] ),
+			$this->countOr( $continuous['count'] ?? null ),
+		);
+	}
+
+	/**
 	 * @param  array<string, mixed>  $entrance
 	 */
-	protected function emitEntranceBreakpointOverrides( string $scope, array $entrance ): string
+	protected function emitEntranceBreakpointOverrides( string $scope, array $entrance, array $continuous = [] ): string
 	{
 		$name = $entrance['name'] ?? null;
 		if ( ! is_array( $name ) ) {
@@ -285,15 +382,26 @@ class AnimationCssEmitter
 
 			$definition = $this->registry->get( AnimationRegistry::FAMILY_ENTRANCE, $value );
 
-			$css .= sprintf(
-				'@media (min-width: %dpx) { %s.%s { animation: %s %dms %s %dms both; } }',
-				$minWidth,
-				$scope,
-				self::PLAY_CLASS,
+			$entranceShorthand = $this->animationShorthand(
 				$definition['keyframe'],
 				$this->intOr( $entrance['duration'] ?? null, (int) $definition['duration'] ),
 				$this->easingOr( $entrance['easing'] ?? null, (string) $definition['easing'] ),
 				$this->intOr( $entrance['delay'] ?? null, 0 ),
+				'both',
+			);
+
+			$continuousShorthand = $this->resolvedContinuousShorthand( $continuous );
+
+			$animation = null !== $continuousShorthand
+				? $entranceShorthand . ', ' . $continuousShorthand
+				: $entranceShorthand;
+
+			$css .= sprintf(
+				'@media (min-width: %dpx) { %s.%s { animation: %s; } }',
+				$minWidth,
+				$scope,
+				self::PLAY_CLASS,
+				$animation,
 			);
 		}
 

--- a/src/Animations/AnimationRegistry.php
+++ b/src/Animations/AnimationRegistry.php
@@ -1,0 +1,340 @@
+<?php
+
+/**
+ * Animation registry — block animations (#489).
+ *
+ * Resolves the editor's active set of animations by merging the host
+ * theme's declarations into the application's `config()` overrides and
+ * finally the package's built-in defaults. Highest layer wins on key
+ * collision:
+ *
+ *   1. theme.json → `settings.custom.artisanpack.animations`
+ *   2. application config → `artisanpack.visual-editor.animations`
+ *   3. package defaults  → entrance / hover / continuous built-ins
+ *
+ * Animations are organized into three families and merged by family + key
+ * via `array_replace_recursive()`. To REMOVE a built-in animation, set
+ * its key to `null` after the merge.
+ *
+ * The built-in animation names are reserved — a theme that tries to
+ * register a custom `fade-in` keyframe under the entrance family will be
+ * rejected at validate-time.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.1.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Animations;
+
+use InvalidArgumentException;
+
+class AnimationRegistry
+{
+	public const FAMILY_ENTRANCE   = 'entrance';
+	public const FAMILY_HOVER      = 'hover';
+	public const FAMILY_CONTINUOUS = 'continuous';
+
+	/**
+	 * Every family the registry recognises. Order is meaningful: the
+	 * inspector panel renders sub-panels in this order.
+	 *
+	 * @var array<int, string>
+	 */
+	public const FAMILIES = [
+		self::FAMILY_ENTRANCE,
+		self::FAMILY_HOVER,
+		self::FAMILY_CONTINUOUS,
+	];
+
+	/**
+	 * Built-in animation definitions, by family. Every animation maps to
+	 * a CSS `animation-name` (which matches a `@keyframes` block emitted
+	 * by {@see KeyframeRegistry}) plus default duration / easing values
+	 * the editor pre-fills on first attachment.
+	 *
+	 * Hover-family entries are special: they don't have a keyframe; they
+	 * configure a CSS `transition` curve plus an optional "motion preset"
+	 * that composes a transform/box-shadow on the `:hover` state.
+	 *
+	 * @var array<string, array<string, array<string, mixed>>>
+	 */
+	public const DEFAULTS = [
+		self::FAMILY_ENTRANCE => [
+			'fade-in'        => [ 'label' => 'Fade in',         'keyframe' => 'apFadeIn',       'duration' => 600, 'easing' => 'ease-out' ],
+			'fade-in-up'     => [ 'label' => 'Fade in up',      'keyframe' => 'apFadeInUp',     'duration' => 600, 'easing' => 'ease-out' ],
+			'fade-in-down'   => [ 'label' => 'Fade in down',    'keyframe' => 'apFadeInDown',   'duration' => 600, 'easing' => 'ease-out' ],
+			'fade-in-left'   => [ 'label' => 'Fade in left',    'keyframe' => 'apFadeInLeft',   'duration' => 600, 'easing' => 'ease-out' ],
+			'fade-in-right'  => [ 'label' => 'Fade in right',   'keyframe' => 'apFadeInRight',  'duration' => 600, 'easing' => 'ease-out' ],
+			'zoom-in'        => [ 'label' => 'Zoom in',         'keyframe' => 'apZoomIn',       'duration' => 500, 'easing' => 'ease-out' ],
+			'zoom-out'       => [ 'label' => 'Zoom out',        'keyframe' => 'apZoomOut',      'duration' => 500, 'easing' => 'ease-out' ],
+			'slide-in-up'    => [ 'label' => 'Slide in up',     'keyframe' => 'apSlideInUp',    'duration' => 600, 'easing' => 'ease-out' ],
+			'slide-in-down'  => [ 'label' => 'Slide in down',   'keyframe' => 'apSlideInDown',  'duration' => 600, 'easing' => 'ease-out' ],
+			'slide-in-left'  => [ 'label' => 'Slide in left',   'keyframe' => 'apSlideInLeft',  'duration' => 600, 'easing' => 'ease-out' ],
+			'slide-in-right' => [ 'label' => 'Slide in right',  'keyframe' => 'apSlideInRight', 'duration' => 600, 'easing' => 'ease-out' ],
+			'flip-x'         => [ 'label' => 'Flip X',          'keyframe' => 'apFlipX',        'duration' => 700, 'easing' => 'ease-out' ],
+			'flip-y'         => [ 'label' => 'Flip Y',          'keyframe' => 'apFlipY',        'duration' => 700, 'easing' => 'ease-out' ],
+			'rotate-in'      => [ 'label' => 'Rotate in',       'keyframe' => 'apRotateIn',     'duration' => 700, 'easing' => 'ease-out' ],
+		],
+		self::FAMILY_HOVER => [
+			'lift'  => [ 'label' => 'Lift',  'preset' => 'lift',  'duration' => 200, 'easing' => 'ease-out' ],
+			'press' => [ 'label' => 'Press', 'preset' => 'press', 'duration' => 120, 'easing' => 'ease-in' ],
+			'glow'  => [ 'label' => 'Glow',  'preset' => 'glow',  'duration' => 250, 'easing' => 'ease-in-out' ],
+		],
+		self::FAMILY_CONTINUOUS => [
+			'pulse'  => [ 'label' => 'Pulse',  'keyframe' => 'apPulse',  'duration' => 2000, 'easing' => 'ease-in-out' ],
+			'bounce' => [ 'label' => 'Bounce', 'keyframe' => 'apBounce', 'duration' => 1000, 'easing' => 'ease-in-out' ],
+			'spin'   => [ 'label' => 'Spin',   'keyframe' => 'apSpin',   'duration' => 2000, 'easing' => 'linear' ],
+			'ping'   => [ 'label' => 'Ping',   'keyframe' => 'apPing',   'duration' => 1000, 'easing' => 'cubic-bezier(0, 0, 0.2, 1)' ],
+			'wiggle' => [ 'label' => 'Wiggle', 'keyframe' => 'apWiggle', 'duration' => 800,  'easing' => 'ease-in-out' ],
+			'float'  => [ 'label' => 'Float',  'keyframe' => 'apFloat',  'duration' => 3000, 'easing' => 'ease-in-out' ],
+		],
+	];
+
+	/**
+	 * Resolved, validated registry.
+	 *
+	 * @var array<string, array<string, array<string, mixed>>>
+	 */
+	protected array $animations;
+
+	/**
+	 * @param  array<string, array<string, mixed>>  $raw  Pre-resolved
+	 *                                                    family map.
+	 */
+	public function __construct( array $raw = [] )
+	{
+		$this->animations = $this->validate( $raw );
+	}
+
+	/**
+	 * Builds a registry from the application's merged config + an
+	 * optional `theme.json`-derived overrides array.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param  array<string, mixed>|null  $configOverrides
+	 * @param  array<string, mixed>       $themeOverrides
+	 */
+	public static function fromLayers( ?array $configOverrides = null, array $themeOverrides = [] ): self
+	{
+		$config = $configOverrides ?? ( function_exists( 'config' )
+			? (array) config( 'artisanpack.visual-editor.animations', [] )
+			: [] );
+
+		$merged = array_replace_recursive( self::DEFAULTS, $config, $themeOverrides );
+
+		// Filter `null` entries at the family + animation level so a
+		// theme can drop a built-in by setting it to `null`.
+		$cleaned = [];
+		foreach ( $merged as $family => $items ) {
+			if ( ! is_array( $items ) ) {
+				continue;
+			}
+			$cleaned[ $family ] = array_filter( $items, static fn ( $value ) => null !== $value );
+		}
+
+		return new self( $cleaned );
+	}
+
+	/**
+	 * Returns every registered animation grouped by family.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return array<string, array<string, array<string, mixed>>>
+	 */
+	public function all(): array
+	{
+		return $this->animations;
+	}
+
+	/**
+	 * Returns the animations for a single family, keyed by slug.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
+	public function family( string $family ): array
+	{
+		return $this->animations[ $family ] ?? [];
+	}
+
+	/**
+	 * Returns one animation definition or `null` if unregistered.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return array<string, mixed>|null
+	 */
+	public function get( string $family, string $key ): ?array
+	{
+		return $this->animations[ $family ][ $key ] ?? null;
+	}
+
+	/**
+	 * Checks membership.
+	 *
+	 * @since 1.1.0
+	 */
+	public function has( string $family, string $key ): bool
+	{
+		return isset( $this->animations[ $family ][ $key ] );
+	}
+
+	/**
+	 * Returns the list of family slugs.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return array<int, string>
+	 */
+	public function families(): array
+	{
+		return array_keys( $this->animations );
+	}
+
+	/**
+	 * Reserved built-in names — theme authors cannot override these
+	 * under a different family without explicitly setting the original
+	 * to `null` first.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return array<int, string>
+	 */
+	public function reservedKeys(): array
+	{
+		$reserved = [];
+		foreach ( self::DEFAULTS as $items ) {
+			foreach ( array_keys( $items ) as $key ) {
+				$reserved[] = $key;
+			}
+		}
+
+		return $reserved;
+	}
+
+	/**
+	 * Normalizes a raw animations map. Validates that:
+	 *  - every key is a string of `[a-z0-9_-]` (slug shape)
+	 *  - every family is one of {@see self::FAMILIES}
+	 *  - every entrance / continuous entry has a non-empty `keyframe`
+	 *  - every hover entry has a non-empty `preset`
+	 *  - every entry has a `label`, a positive integer `duration` (ms)
+	 *    and a non-empty `easing` string
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param  array<string, mixed>  $raw
+	 *
+	 * @return array<string, array<string, array<string, mixed>>>
+	 */
+	public function validate( array $raw ): array
+	{
+		$normalized = [];
+
+		foreach ( self::FAMILIES as $family ) {
+			$normalized[ $family ] = [];
+		}
+
+		foreach ( $raw as $family => $items ) {
+			if ( ! in_array( $family, self::FAMILIES, true ) ) {
+				throw new InvalidArgumentException( sprintf(
+					'Animation family "%s" is not recognised. Allowed: %s.',
+					(string) $family,
+					implode( ', ', self::FAMILIES )
+				) );
+			}
+
+			if ( ! is_array( $items ) ) {
+				throw new InvalidArgumentException( sprintf(
+					'Animation family "%s" must be an associative array.',
+					$family
+				) );
+			}
+
+			foreach ( $items as $key => $definition ) {
+				if ( ! is_string( $key ) || 1 !== preg_match( '/^[a-z0-9][a-z0-9_-]*$/i', $key ) ) {
+					throw new InvalidArgumentException( sprintf(
+						'Animation key "%s" must contain only letters, numbers, hyphens, and underscores.',
+						(string) $key
+					) );
+				}
+
+				if ( ! is_array( $definition ) ) {
+					throw new InvalidArgumentException( sprintf(
+						'Animation "%s.%s" must be defined as an associative array.',
+						$family,
+						$key
+					) );
+				}
+
+				$label = $definition['label'] ?? '';
+				if ( ! is_string( $label ) || '' === trim( $label ) ) {
+					throw new InvalidArgumentException( sprintf(
+						'Animation "%s.%s" must declare a non-empty `label`.',
+						$family,
+						$key
+					) );
+				}
+
+				$duration = $definition['duration'] ?? 0;
+				if ( ! is_int( $duration ) || $duration <= 0 ) {
+					throw new InvalidArgumentException( sprintf(
+						'Animation "%s.%s" must declare a positive integer `duration` (ms).',
+						$family,
+						$key
+					) );
+				}
+
+				$easing = $definition['easing'] ?? '';
+				if ( ! is_string( $easing ) || '' === trim( $easing ) ) {
+					throw new InvalidArgumentException( sprintf(
+						'Animation "%s.%s" must declare a non-empty `easing` string.',
+						$family,
+						$key
+					) );
+				}
+
+				if ( self::FAMILY_HOVER === $family ) {
+					$preset = $definition['preset'] ?? '';
+					if ( ! is_string( $preset ) || '' === trim( $preset ) ) {
+						throw new InvalidArgumentException( sprintf(
+							'Hover animation "%s" must declare a non-empty `preset` slug.',
+							$key
+						) );
+					}
+				} else {
+					$keyframe = $definition['keyframe'] ?? '';
+					if ( ! is_string( $keyframe ) || '' === trim( $keyframe ) ) {
+						throw new InvalidArgumentException( sprintf(
+							'Animation "%s.%s" must declare a non-empty `keyframe` name.',
+							$family,
+							$key
+						) );
+					}
+				}
+
+				$normalized[ $family ][ $key ] = array_merge(
+					$definition,
+					[
+						'key'      => $key,
+						'family'   => $family,
+						'label'    => $label,
+						'duration' => $duration,
+						'easing'   => $easing,
+					]
+				);
+			}
+		}
+
+		return $normalized;
+	}
+}

--- a/src/Animations/KeyframeRegistry.php
+++ b/src/Animations/KeyframeRegistry.php
@@ -121,7 +121,25 @@ class KeyframeRegistry
 			}
 		}
 
-		return new self( array_values( $merged ) );
+		// `fromLayers()` is wired into a Laravel scoped binding, so a
+		// throw here would crash every request that resolves the
+		// registry (e.g. via `<x-ve-blocks>`). Skip + log invalid
+		// entries instead. The strict-throw behaviour stays on the
+		// direct constructor path for tests and programmatic use.
+		$registry = new self();
+
+		foreach ( array_values( $merged ) as $entry ) {
+			try {
+				$normalised = $registry->validateOne( $entry );
+				$registry->custom[ $normalised['name'] ] = $normalised['stops'];
+			} catch ( InvalidArgumentException $e ) {
+				if ( function_exists( 'logger' ) ) {
+					logger()->warning( '[block-animations] Skipping invalid custom keyframe: ' . $e->getMessage() );
+				}
+			}
+		}
+
+		return $registry;
 	}
 
 	/**
@@ -274,11 +292,17 @@ class KeyframeRegistry
 			) );
 		}
 
-		if ( array_key_exists( $name, self::BUILT_INS ) ) {
-			throw new InvalidArgumentException( sprintf(
-				'Custom keyframe name "%s" collides with a built-in. Built-in names are reserved.',
-				$name
-			) );
+		// Case-insensitive collision check mirrors the client-side
+		// CustomKeyframeEditor so a `apfadein` config can't end-run the
+		// reservation that the editor UI enforces on `apFadeIn`.
+		$nameLower = strtolower( $name );
+		foreach ( array_keys( self::BUILT_INS ) as $builtIn ) {
+			if ( strtolower( $builtIn ) === $nameLower ) {
+				throw new InvalidArgumentException( sprintf(
+					'Custom keyframe name "%s" collides with a built-in. Built-in names are reserved.',
+					$name
+				) );
+			}
 		}
 
 		$stops = $entry['stops'] ?? [];

--- a/src/Animations/KeyframeRegistry.php
+++ b/src/Animations/KeyframeRegistry.php
@@ -1,0 +1,354 @@
+<?php
+
+/**
+ * Keyframe registry — block animations (#489).
+ *
+ * Owns the `@keyframes` CSS that the entrance + continuous families
+ * reference. Built-ins are baked in. Theme authors can register custom
+ * keyframes via `theme.json` → `settings.custom.artisanpack.keyframes`
+ * or via the Site Editor → Styles → Animations UI (which persists into
+ * the Global Styles JSON).
+ *
+ * Custom keyframes are stored as an array of stops:
+ *
+ *     [
+ *         'name' => 'confetti',
+ *         'stops' => [
+ *             [ 'at' => '0%',   'transform' => 'translateY(0)' ],
+ *             [ 'at' => '50%',  'transform' => 'translateY(-12px) rotate(10deg)' ],
+ *             [ 'at' => '100%', 'transform' => 'translateY(0)' ],
+ *         ],
+ *     ]
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.1.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Animations;
+
+use InvalidArgumentException;
+
+class KeyframeRegistry
+{
+	/**
+	 * The list of CSS properties an editor-authored stop is allowed to
+	 * touch. Restricting the set keeps the persisted JSON to a known
+	 * shape and avoids surprises like `position` or `display` jumping
+	 * during an animation.
+	 *
+	 * @var array<int, string>
+	 */
+	public const ALLOWED_STOP_PROPERTIES = [
+		'transform',
+		'opacity',
+		'filter',
+		'color',
+		'background-color',
+		'box-shadow',
+	];
+
+	/**
+	 * Built-in `@keyframes` definitions. Names match the `keyframe`
+	 * values referenced by {@see AnimationRegistry::DEFAULTS}.
+	 *
+	 * @var array<string, string>
+	 */
+	public const BUILT_INS = [
+		'apFadeIn'       => '0% { opacity: 0; } 100% { opacity: 1; }',
+		'apFadeInUp'     => '0% { opacity: 0; transform: translateY(16px); } 100% { opacity: 1; transform: translateY(0); }',
+		'apFadeInDown'   => '0% { opacity: 0; transform: translateY(-16px); } 100% { opacity: 1; transform: translateY(0); }',
+		'apFadeInLeft'   => '0% { opacity: 0; transform: translateX(-16px); } 100% { opacity: 1; transform: translateX(0); }',
+		'apFadeInRight'  => '0% { opacity: 0; transform: translateX(16px); } 100% { opacity: 1; transform: translateX(0); }',
+		'apZoomIn'       => '0% { opacity: 0; transform: scale(0.92); } 100% { opacity: 1; transform: scale(1); }',
+		'apZoomOut'      => '0% { opacity: 0; transform: scale(1.08); } 100% { opacity: 1; transform: scale(1); }',
+		'apSlideInUp'    => '0% { transform: translateY(32px); } 100% { transform: translateY(0); }',
+		'apSlideInDown'  => '0% { transform: translateY(-32px); } 100% { transform: translateY(0); }',
+		'apSlideInLeft'  => '0% { transform: translateX(-32px); } 100% { transform: translateX(0); }',
+		'apSlideInRight' => '0% { transform: translateX(32px); } 100% { transform: translateX(0); }',
+		'apFlipX'        => '0% { transform: rotateX(90deg); opacity: 0; } 100% { transform: rotateX(0); opacity: 1; }',
+		'apFlipY'        => '0% { transform: rotateY(90deg); opacity: 0; } 100% { transform: rotateY(0); opacity: 1; }',
+		'apRotateIn'     => '0% { transform: rotate(-12deg) scale(0.95); opacity: 0; } 100% { transform: rotate(0) scale(1); opacity: 1; }',
+		'apPulse'        => '0%, 100% { transform: scale(1); } 50% { transform: scale(1.04); }',
+		'apBounce'       => '0%, 100% { transform: translateY(0); } 50% { transform: translateY(-12px); }',
+		'apSpin'         => '0% { transform: rotate(0deg); } 100% { transform: rotate(360deg); }',
+		'apPing'         => '0% { transform: scale(1); opacity: 1; } 75%, 100% { transform: scale(2); opacity: 0; }',
+		'apWiggle'       => '0%, 100% { transform: rotate(-2deg); } 50% { transform: rotate(2deg); }',
+		'apFloat'        => '0%, 100% { transform: translateY(0); } 50% { transform: translateY(-8px); }',
+	];
+
+	/**
+	 * Custom keyframes by sanitised name.
+	 *
+	 * @var array<string, array<int, array<string, string>>>
+	 */
+	protected array $custom = [];
+
+	/**
+	 * @param  array<int, array<string, mixed>>  $rawCustom
+	 */
+	public function __construct( array $rawCustom = [] )
+	{
+		foreach ( $rawCustom as $entry ) {
+			$normalised = $this->validateOne( $entry );
+			$this->custom[ $normalised['name'] ] = $normalised['stops'];
+		}
+	}
+
+	/**
+	 * Builds the registry from theme.json + Global Styles JSON entries.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param  array<int, array<string, mixed>>  $themeKeyframes
+	 * @param  array<int, array<string, mixed>>  $globalStylesKeyframes
+	 */
+	public static function fromLayers( array $themeKeyframes = [], array $globalStylesKeyframes = [] ): self
+	{
+		// Global Styles wins on name collision — the editor UI is the
+		// most recently authored layer.
+		$merged = [];
+		foreach ( [ $themeKeyframes, $globalStylesKeyframes ] as $layer ) {
+			foreach ( $layer as $entry ) {
+				if ( is_array( $entry ) && isset( $entry['name'] ) && is_string( $entry['name'] ) ) {
+					$merged[ $entry['name'] ] = $entry;
+				}
+			}
+		}
+
+		return new self( array_values( $merged ) );
+	}
+
+	/**
+	 * Returns the list of registered keyframe names (built-ins + custom).
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return array<int, string>
+	 */
+	public function names(): array
+	{
+		return array_values( array_unique( array_merge(
+			array_keys( self::BUILT_INS ),
+			array_keys( $this->custom )
+		) ) );
+	}
+
+	/**
+	 * Returns just the custom keyframe names.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return array<int, string>
+	 */
+	public function customNames(): array
+	{
+		return array_keys( $this->custom );
+	}
+
+	/**
+	 * Returns the stops for a custom keyframe, or `null` if it's not
+	 * registered (or refers to a built-in).
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return array<int, array<string, string>>|null
+	 */
+	public function stops( string $name ): ?array
+	{
+		return $this->custom[ $name ] ?? null;
+	}
+
+	/**
+	 * Reports whether the registry knows the name as a built-in.
+	 *
+	 * @since 1.1.0
+	 */
+	public function isBuiltIn( string $name ): bool
+	{
+		return array_key_exists( $name, self::BUILT_INS );
+	}
+
+	/**
+	 * Reports whether the registry knows the name at all.
+	 *
+	 * @since 1.1.0
+	 */
+	public function has( string $name ): bool
+	{
+		return $this->isBuiltIn( $name ) || array_key_exists( $name, $this->custom );
+	}
+
+	/**
+	 * Emits the CSS for every registered `@keyframes` block — built-ins
+	 * first, then custom. Suitable for inclusion in a `<style>` tag.
+	 *
+	 * @since 1.1.0
+	 */
+	public function emitCss(): string
+	{
+		$out = '';
+
+		foreach ( self::BUILT_INS as $name => $body ) {
+			$out .= sprintf( '@keyframes %s { %s } ', $name, $body );
+		}
+
+		foreach ( $this->custom as $name => $stops ) {
+			$out .= sprintf( '@keyframes %s { %s } ', $name, $this->renderStops( $stops ) );
+		}
+
+		return rtrim( $out );
+	}
+
+	/**
+	 * Emits CSS for one custom keyframe by name.
+	 *
+	 * @since 1.1.0
+	 */
+	public function emitOne( string $name ): string
+	{
+		if ( $this->isBuiltIn( $name ) ) {
+			return sprintf( '@keyframes %s { %s }', $name, self::BUILT_INS[ $name ] );
+		}
+
+		$stops = $this->custom[ $name ] ?? null;
+		if ( null === $stops ) {
+			return '';
+		}
+
+		return sprintf( '@keyframes %s { %s }', $name, $this->renderStops( $stops ) );
+	}
+
+	/**
+	 * @param  array<int, array<string, string>>  $stops
+	 */
+	protected function renderStops( array $stops ): string
+	{
+		$parts = [];
+
+		foreach ( $stops as $stop ) {
+			$at = $stop['at'] ?? '';
+			if ( '' === $at ) {
+				continue;
+			}
+
+			$declarations = [];
+			foreach ( $stop as $property => $value ) {
+				if ( 'at' === $property ) {
+					continue;
+				}
+				$declarations[] = sprintf( '%s: %s;', $property, $value );
+			}
+
+			if ( [] === $declarations ) {
+				continue;
+			}
+
+			$parts[] = sprintf( '%s { %s }', $at, implode( ' ', $declarations ) );
+		}
+
+		return implode( ' ', $parts );
+	}
+
+	/**
+	 * @param  array<string, mixed>  $entry
+	 *
+	 * @return array{name: string, stops: array<int, array<string, string>>}
+	 */
+	protected function validateOne( array $entry ): array
+	{
+		$name = $entry['name'] ?? '';
+		if ( ! is_string( $name ) || '' === trim( $name ) ) {
+			throw new InvalidArgumentException( 'Custom keyframe must declare a non-empty `name`.' );
+		}
+
+		if ( 1 !== preg_match( '/^[a-z][a-z0-9_-]*$/i', $name ) ) {
+			throw new InvalidArgumentException( sprintf(
+				'Custom keyframe name "%s" must start with a letter and contain only letters, numbers, hyphens, and underscores.',
+				$name
+			) );
+		}
+
+		if ( array_key_exists( $name, self::BUILT_INS ) ) {
+			throw new InvalidArgumentException( sprintf(
+				'Custom keyframe name "%s" collides with a built-in. Built-in names are reserved.',
+				$name
+			) );
+		}
+
+		$stops = $entry['stops'] ?? [];
+		if ( ! is_array( $stops ) || count( $stops ) < 2 ) {
+			throw new InvalidArgumentException( sprintf(
+				'Custom keyframe "%s" must declare at least two `stops`.',
+				$name
+			) );
+		}
+
+		$normalisedStops = [];
+
+		foreach ( $stops as $stop ) {
+			if ( ! is_array( $stop ) ) {
+				throw new InvalidArgumentException( sprintf(
+					'Custom keyframe "%s" has a non-array stop.',
+					$name
+				) );
+			}
+
+			$at = $stop['at'] ?? '';
+			if ( ! is_string( $at ) || 1 !== preg_match( '/^(0|[1-9]\d?|100)(%)?$/', trim( $at ) ) ) {
+				throw new InvalidArgumentException( sprintf(
+					'Custom keyframe "%s" stop has invalid `at` value "%s". Expected a percentage 0%%–100%%.',
+					$name,
+					(string) $at
+				) );
+			}
+
+			$normalised = [ 'at' => str_ends_with( trim( $at ), '%' ) ? trim( $at ) : trim( $at ) . '%' ];
+
+			foreach ( $stop as $property => $value ) {
+				if ( 'at' === $property ) {
+					continue;
+				}
+
+				if ( ! in_array( $property, self::ALLOWED_STOP_PROPERTIES, true ) ) {
+					throw new InvalidArgumentException( sprintf(
+						'Custom keyframe "%s" stop has unsupported property "%s". Allowed: %s.',
+						$name,
+						(string) $property,
+						implode( ', ', self::ALLOWED_STOP_PROPERTIES )
+					) );
+				}
+
+				if ( ! is_string( $value ) || '' === trim( $value ) ) {
+					throw new InvalidArgumentException( sprintf(
+						'Custom keyframe "%s" stop property "%s" must be a non-empty string.',
+						$name,
+						$property
+					) );
+				}
+
+				// Reject anything that smells like an attempt to escape
+				// the CSS value context. Animations never need angle
+				// brackets, braces, or semicolons inside a value.
+				if ( 1 === preg_match( '/[<>{};]/', $value ) ) {
+					throw new InvalidArgumentException( sprintf(
+						'Custom keyframe "%s" stop property "%s" contains disallowed characters.',
+						$name,
+						$property
+					) );
+				}
+
+				$normalised[ $property ] = trim( $value );
+			}
+
+			$normalisedStops[] = $normalised;
+		}
+
+		return [ 'name' => $name, 'stops' => $normalisedStops ];
+	}
+}

--- a/src/Animations/KeyframeRegistry.php
+++ b/src/Animations/KeyframeRegistry.php
@@ -110,17 +110,6 @@ class KeyframeRegistry
 	 */
 	public static function fromLayers( array $themeKeyframes = [], array $globalStylesKeyframes = [] ): self
 	{
-		// Global Styles wins on name collision — the editor UI is the
-		// most recently authored layer.
-		$merged = [];
-		foreach ( [ $themeKeyframes, $globalStylesKeyframes ] as $layer ) {
-			foreach ( $layer as $entry ) {
-				if ( is_array( $entry ) && isset( $entry['name'] ) && is_string( $entry['name'] ) ) {
-					$merged[ $entry['name'] ] = $entry;
-				}
-			}
-		}
-
 		// `fromLayers()` is wired into a Laravel scoped binding, so a
 		// throw here would crash every request that resolves the
 		// registry (e.g. via `<x-ve-blocks>`). Skip + log invalid
@@ -128,13 +117,23 @@ class KeyframeRegistry
 		// direct constructor path for tests and programmatic use.
 		$registry = new self();
 
-		foreach ( array_values( $merged ) as $entry ) {
-			try {
-				$normalised = $registry->validateOne( $entry );
-				$registry->custom[ $normalised['name'] ] = $normalised['stops'];
-			} catch ( InvalidArgumentException $e ) {
-				if ( function_exists( 'logger' ) ) {
-					logger()->warning( '[block-animations] Skipping invalid custom keyframe: ' . $e->getMessage() );
+		// Validate as we iterate, in layer order. Global Styles wins on
+		// name collision only when its entry is VALID — an invalid
+		// global-styles entry must not overwrite a valid theme entry,
+		// otherwise the theme keyframe vanishes entirely.
+		foreach ( [ $themeKeyframes, $globalStylesKeyframes ] as $layer ) {
+			foreach ( $layer as $entry ) {
+				if ( ! is_array( $entry ) ) {
+					continue;
+				}
+
+				try {
+					$normalised = $registry->validateOne( $entry );
+					$registry->custom[ $normalised['name'] ] = $normalised['stops'];
+				} catch ( InvalidArgumentException $e ) {
+					if ( function_exists( 'logger' ) ) {
+						logger()->warning( '[block-animations] Skipping invalid custom keyframe: ' . $e->getMessage() );
+					}
 				}
 			}
 		}

--- a/src/VisualEditorServiceProvider.php
+++ b/src/VisualEditorServiceProvider.php
@@ -31,6 +31,10 @@ use ArtisanPackUI\VisualEditor\Resources\CommentInliner;
 use ArtisanPackUI\VisualEditor\Resources\CommentResolver;
 use ArtisanPackUI\VisualEditor\Resources\QueryInliner;
 use ArtisanPackUI\VisualEditor\Resources\ResourceResolver;
+use ArtisanPackUI\VisualEditor\Animations\AnimationAttributeResolver;
+use ArtisanPackUI\VisualEditor\Animations\AnimationCssEmitter;
+use ArtisanPackUI\VisualEditor\Animations\AnimationRegistry;
+use ArtisanPackUI\VisualEditor\Animations\KeyframeRegistry;
 use ArtisanPackUI\VisualEditor\Responsive\AttributeMigrator;
 use ArtisanPackUI\VisualEditor\Responsive\BreakpointRegistry;
 use ArtisanPackUI\VisualEditor\Responsive\ResponsiveValueResolver;
@@ -273,6 +277,37 @@ class VisualEditorServiceProvider extends ServiceProvider
 
 		$this->app->singleton( StateAttributeMigrator::class, function () {
 			return new StateAttributeMigrator();
+		} );
+
+		// #489 — block animations. Scoped per request, same as the
+		// responsive and state registries: theme.json overrides can
+		// swap between requests, and a singleton would leak the
+		// resolved animations across them.
+		$this->app->scoped( AnimationRegistry::class, function ( $app ) {
+			$config = (array) $app['config']->get( 'artisanpack.visual-editor.animations', [] );
+
+			return AnimationRegistry::fromLayers( $config );
+		} );
+
+		$this->app->scoped( KeyframeRegistry::class, function ( $app ) {
+			$themeKeyframes = (array) $app['config']->get( 'artisanpack.visual-editor.keyframes', [] );
+
+			$globalStyles = (array) $app['config']->get( 'artisanpack.visual-editor.site-editor.global-styles.styles.custom.artisanpack.keyframes', [] );
+
+			return KeyframeRegistry::fromLayers( $themeKeyframes, $globalStyles );
+		} );
+
+		$this->app->scoped( AnimationAttributeResolver::class, function ( $app ) {
+			return new AnimationAttributeResolver( $app->make( BreakpointRegistry::class ) );
+		} );
+
+		$this->app->scoped( AnimationCssEmitter::class, function ( $app ) {
+			return new AnimationCssEmitter(
+				$app->make( AnimationRegistry::class ),
+				$app->make( KeyframeRegistry::class ),
+				$app->make( BreakpointRegistry::class ),
+				$app->make( AnimationAttributeResolver::class ),
+			);
 		} );
 
 		// #434: `GlobalStylesCssProvider` + `GlobalStylesCacheInvalidator`

--- a/src/VisualEditorServiceProvider.php
+++ b/src/VisualEditorServiceProvider.php
@@ -292,9 +292,26 @@ class VisualEditorServiceProvider extends ServiceProvider
 		$this->app->scoped( KeyframeRegistry::class, function ( $app ) {
 			$themeKeyframes = (array) $app['config']->get( 'artisanpack.visual-editor.keyframes', [] );
 
-			$globalStyles = (array) $app['config']->get( 'artisanpack.visual-editor.site-editor.global-styles.styles.custom.artisanpack.keyframes', [] );
+			// Resolve editor-authored keyframes from the same filter-
+			// merged global-styles payload that `SiteEditorGlobalStylesResolver`
+			// consumes, so a host that registers global styles through
+			// the `ap.visual-editor.global-styles` filter (cms-framework
+			// being the canonical caller) sees its custom keyframes
+			// reach the editor and renderer. Reading directly from
+			// config would miss the filter contributions.
+			try {
+				$resolver     = $app->make( SiteEditorGlobalStylesResolver::class );
+				$globalStyles = $resolver->raw();
+			} catch ( \Throwable $e ) {
+				$globalStyles = null;
+			}
 
-			return KeyframeRegistry::fromLayers( $themeKeyframes, $globalStyles );
+			$editorKeyframes = [];
+			if ( is_array( $globalStyles['styles']['custom']['artisanpack']['keyframes'] ?? null ) ) {
+				$editorKeyframes = $globalStyles['styles']['custom']['artisanpack']['keyframes'];
+			}
+
+			return KeyframeRegistry::fromLayers( $themeKeyframes, $editorKeyframes );
 		} );
 
 		$this->app->scoped( AnimationAttributeResolver::class, function ( $app ) {

--- a/tests/E2E/animations.spec.ts
+++ b/tests/E2E/animations.spec.ts
@@ -1,0 +1,82 @@
+/**
+ * E2E specification for the block-animations system (#489).
+ *
+ * The package does not yet ship Playwright as a runtime dependency
+ * (it's not wired into the CI matrix in `release/1.1`). This file
+ * documents the test plan in Playwright shape so the suite can be
+ * activated as soon as the runner is added. Until then, the assertions
+ * here serve as executable documentation of the runtime contract: an
+ * engineer reading this knows exactly what behaviour the system must
+ * exhibit end-to-end.
+ *
+ * To activate, install `@playwright/test`, add a `playwright.config.ts`
+ * pointing at the dev app, and uncomment the imports at the top of
+ * this file.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.1.0
+ */
+
+// import { expect, test } from '@playwright/test'
+//
+// test.describe( 'block animations', () => {
+// 	test( 'entrance animation plays once on viewport entry', async ( { page } ) => {
+// 		await page.goto( '/visual-editor/preview/animations-entrance' )
+//
+// 		const block = page.locator( '[data-ap-anim-entrance="fade-in-up"]' )
+// 		await expect( block ).toHaveClass( /ap-anim-pre/ )
+//
+// 		await block.scrollIntoViewIfNeeded()
+//
+// 		await expect( block ).toHaveClass( /ap-anim-play/ )
+// 	} )
+//
+// 	test( 'continuous animation persists across scroll', async ( { page } ) => {
+// 		await page.goto( '/visual-editor/preview/animations-continuous' )
+//
+// 		const block = page.locator( '.continuous-target' )
+// 		const animationName = await block.evaluate( ( el ) =>
+// 			getComputedStyle( el ).animationName,
+// 		)
+// 		expect( animationName ).toBe( 'apPulse' )
+// 	} )
+//
+// 	test( 'prefers-reduced-motion suppresses entrance + continuous', async ( {
+// 		browser,
+// 	} ) => {
+// 		const context = await browser.newContext( { reducedMotion: 'reduce' } )
+// 		const page = await context.newPage()
+// 		await page.goto( '/visual-editor/preview/animations-entrance' )
+//
+// 		const block = page.locator( '[data-ap-anim-entrance="fade-in-up"]' )
+// 		await expect( block ).toHaveClass( /ap-anim-play/ )
+// 	} )
+//
+// 	test( 'a custom keyframe authored in Site Editor round-trips', async ( {
+// 		page,
+// 	} ) => {
+// 		await page.goto( '/visual-editor/site-editor/styles/animations' )
+// 		await page.getByRole( 'button', { name: '+ Add custom keyframe' } ).click()
+// 		await page.getByLabel( 'Name' ).fill( 'confetti' )
+// 		await page.getByRole( 'button', { name: 'Save' } ).click()
+// 		await page.reload()
+//
+// 		await expect( page.getByLabel( 'Name' ) ).toHaveValue( 'confetti' )
+// 	} )
+//
+// 	test( 'noscript fallback reveals blocks when JS is disabled', async ( {
+// 		browser,
+// 	} ) => {
+// 		const context = await browser.newContext( { javaScriptEnabled: false } )
+// 		const page = await context.newPage()
+// 		await page.goto( '/visual-editor/preview/animations-entrance' )
+//
+// 		const block = page.locator( '[data-ap-anim-entrance="fade-in-up"]' )
+// 		const opacity = await block.evaluate( ( el ) =>
+// 			getComputedStyle( el ).opacity,
+// 		)
+// 		expect( opacity ).toBe( '1' )
+// 	} )
+// } )
+
+export {}

--- a/tests/Unit/VisualEditor/Animations/AnimationAttributeResolverTest.php
+++ b/tests/Unit/VisualEditor/Animations/AnimationAttributeResolverTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Animations\AnimationAttributeResolver;
+use ArtisanPackUI\VisualEditor\Responsive\BreakpointRegistry;
+
+function makeAnimResolver(): AnimationAttributeResolver
+{
+	return new AnimationAttributeResolver( BreakpointRegistry::fromLayers( [], [] ) );
+}
+
+it( 'returns a scalar value unchanged at base', function () {
+	expect( makeAnimResolver()->resolve( 'fade-in', 'base' ) )->toBe( 'fade-in' );
+} );
+
+it( 'returns null for a scalar value at a non-base breakpoint', function () {
+	expect( makeAnimResolver()->resolve( 'fade-in', 'md' ) )->toBeNull();
+} );
+
+it( 'returns the base value when no breakpoint overrides exist', function () {
+	$value = [ 'base' => 'fade-in' ];
+
+	expect( makeAnimResolver()->resolve( $value, 'lg' ) )->toBe( 'fade-in' );
+} );
+
+it( 'returns null when the breakpoint explicitly disables the animation', function () {
+	$value = [ 'base' => 'fade-in', 'md' => null ];
+
+	expect( makeAnimResolver()->resolve( $value, 'md' ) )->toBeNull();
+	expect( makeAnimResolver()->resolve( $value, 'base' ) )->toBe( 'fade-in' );
+	expect( makeAnimResolver()->resolve( $value, 'sm' ) )->toBe( 'fade-in' );
+} );
+
+it( 'returns the override at the requested breakpoint', function () {
+	$value = [ 'base' => 'fade-in', 'md' => 'zoom-in' ];
+
+	expect( makeAnimResolver()->resolve( $value, 'md' ) )->toBe( 'zoom-in' );
+} );
+
+it( 'resolves the full cascade at once', function () {
+	$value = [ 'base' => 'fade-in', 'md' => 'zoom-in', 'xl' => null ];
+	$all   = makeAnimResolver()->resolveAll( $value );
+
+	expect( $all['base'] )->toBe( 'fade-in' );
+	expect( $all['sm'] )->toBe( 'fade-in' );
+	expect( $all['md'] )->toBe( 'zoom-in' );
+	expect( $all['lg'] )->toBe( 'zoom-in' );
+	expect( $all['xl'] )->toBeNull();
+} );

--- a/tests/Unit/VisualEditor/Animations/AnimationAttributeResolverTest.php
+++ b/tests/Unit/VisualEditor/Animations/AnimationAttributeResolverTest.php
@@ -14,8 +14,11 @@ it( 'returns a scalar value unchanged at base', function () {
 	expect( makeAnimResolver()->resolve( 'fade-in', 'base' ) )->toBe( 'fade-in' );
 } );
 
-it( 'returns null for a scalar value at a non-base breakpoint', function () {
-	expect( makeAnimResolver()->resolve( 'fade-in', 'md' ) )->toBeNull();
+it( 'treats a scalar value as the base shape at every breakpoint', function () {
+	// Mirrors `ResponsiveValueResolver::resolve()`: a scalar applies
+	// uniformly across the cascade.
+	expect( makeAnimResolver()->resolve( 'fade-in', 'md' ) )->toBe( 'fade-in' );
+	expect( makeAnimResolver()->resolve( 'fade-in', 'xl' ) )->toBe( 'fade-in' );
 } );
 
 it( 'returns the base value when no breakpoint overrides exist', function () {

--- a/tests/Unit/VisualEditor/Animations/AnimationCssEmitterTest.php
+++ b/tests/Unit/VisualEditor/Animations/AnimationCssEmitterTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Animations\AnimationAttributeResolver;
+use ArtisanPackUI\VisualEditor\Animations\AnimationCssEmitter;
+use ArtisanPackUI\VisualEditor\Animations\AnimationRegistry;
+use ArtisanPackUI\VisualEditor\Animations\KeyframeRegistry;
+use ArtisanPackUI\VisualEditor\Responsive\BreakpointRegistry;
+
+function makeAnimEmitter(): AnimationCssEmitter
+{
+	$breakpoints = BreakpointRegistry::fromLayers( [], [] );
+
+	return new AnimationCssEmitter(
+		AnimationRegistry::fromLayers( [], [] ),
+		new KeyframeRegistry(),
+		$breakpoints,
+		new AnimationAttributeResolver( $breakpoints ),
+	);
+}
+
+it( 'emits nothing for an empty attribute bag', function () {
+	expect( makeAnimEmitter()->emit( '.ap-block-x', [] ) )->toBe( '' );
+} );
+
+it( 'emits the entrance pre-state and play rule', function () {
+	$css = makeAnimEmitter()->emit( '.ap-block-x', [
+		'entrance' => [ 'name' => 'fade-in-up' ],
+	] );
+
+	expect( $css )->toContain( '.ap-block-x.ap-anim-pre { opacity: 0; }' );
+	expect( $css )->toContain( 'animation: apFadeInUp' );
+	expect( $css )->toContain( '600ms' );
+} );
+
+it( 'lets a per-breakpoint null disable the entrance animation', function () {
+	$css = makeAnimEmitter()->emit( '.ap-block-x', [
+		'entrance' => [ 'name' => [ 'base' => 'fade-in', 'md' => null ] ],
+	] );
+
+	expect( $css )->toContain( '@media (min-width: 768px)' );
+	expect( $css )->toContain( 'animation: none' );
+} );
+
+it( 'emits a hover preset rule wrapped in a hover media query', function () {
+	$css = makeAnimEmitter()->emit( '.ap-block-x', [
+		'hover' => [ 'name' => 'lift' ],
+	] );
+
+	expect( $css )->toContain( '@media (hover: hover)' );
+	expect( $css )->toContain( 'translateY(-3px)' );
+	expect( $css )->toContain( 'transition' );
+} );
+
+it( 'emits a continuous animation with infinite iteration by default', function () {
+	$css = makeAnimEmitter()->emit( '.ap-block-x', [
+		'continuous' => [ 'name' => 'pulse' ],
+	] );
+
+	expect( $css )->toContain( 'animation: apPulse' );
+	expect( $css )->toContain( 'infinite' );
+} );
+
+it( 'guards entrance + continuous against prefers-reduced-motion by default', function () {
+	$css = makeAnimEmitter()->emit( '.ap-block-x', [
+		'entrance' => [ 'name' => 'fade-in' ],
+	] );
+
+	expect( $css )->toContain( '@media (prefers-reduced-motion: reduce)' );
+	expect( $css )->toContain( 'animation: none !important' );
+} );
+
+it( 'skips the reduced-motion guard when the block opts out', function () {
+	$css = makeAnimEmitter()->emit( '.ap-block-x', [
+		'entrance'      => [ 'name' => 'fade-in' ],
+		'reducedMotion' => 'allow',
+	] );
+
+	expect( $css )->not->toContain( 'prefers-reduced-motion' );
+} );
+
+it( 'reports whether any family has an animation set', function () {
+	$emitter = makeAnimEmitter();
+
+	expect( $emitter->hasAny( [] ) )->toBeFalse();
+	expect( $emitter->hasAny( [ 'entrance' => [ 'name' => 'fade-in' ] ] ) )->toBeTrue();
+	expect( $emitter->hasAny( [ 'hover' => [ 'name' => 'lift' ] ] ) )->toBeTrue();
+	expect( $emitter->hasAny( [ 'continuous' => [ 'name' => 'pulse' ] ] ) )->toBeTrue();
+} );
+
+it( 'reports whether any entrance is configured for runtime gating', function () {
+	$emitter = makeAnimEmitter();
+
+	expect( $emitter->hasEntrance( [ 'continuous' => [ 'name' => 'pulse' ] ] ) )->toBeFalse();
+	expect( $emitter->hasEntrance( [ 'entrance' => [ 'name' => 'fade-in' ] ] ) )->toBeTrue();
+} );
+
+it( 'computes the wrapper class list', function () {
+	$classes = makeAnimEmitter()->wrapperClasses( [
+		'entrance' => [ 'name' => 'fade-in' ],
+	] );
+
+	expect( $classes )->toContain( 'ap-anim' );
+	expect( $classes )->toContain( 'ap-anim-pre' );
+} );
+
+it( 'computes data-* attributes the runtime keys off', function () {
+	$data = makeAnimEmitter()->dataAttributes( [
+		'entrance' => [ 'name' => 'fade-in', 'threshold' => 0.5, 'once' => false ],
+	] );
+
+	expect( $data['data-ap-anim-entrance'] )->toBe( 'fade-in' );
+	expect( $data['data-ap-anim-threshold'] )->toBe( '0.5' );
+	expect( $data['data-ap-anim-once'] )->toBe( 'false' );
+} );
+
+it( 'returns the noscript fallback CSS for entrance blocks', function () {
+	expect( makeAnimEmitter()->noscriptCss( '.ap-block-x' ) )
+		->toContain( '.ap-block-x.ap-anim-pre' )
+		->toContain( 'opacity: 1' );
+} );
+
+it( 'rejects easing values containing CSS-injection characters', function () {
+	$css = makeAnimEmitter()->emit( '.ap-block-x', [
+		'entrance' => [ 'name' => 'fade-in', 'easing' => 'ease; } body {' ],
+	] );
+
+	// Falls back to the registered default easing rather than echoing
+	// the attacker-controlled value into the animation shorthand.
+	expect( $css )->toContain( 'ease-out' );
+	expect( $css )->not->toContain( 'body {' );
+} );

--- a/tests/Unit/VisualEditor/Animations/AnimationCssEmitterTest.php
+++ b/tests/Unit/VisualEditor/Animations/AnimationCssEmitterTest.php
@@ -121,6 +121,36 @@ it( 'returns the noscript fallback CSS for entrance blocks', function () {
 		->toContain( 'opacity: 1' );
 } );
 
+it( 'composes entrance + continuous so the continuous loop survives the play class swap', function () {
+	$css = makeAnimEmitter()->emit( '.ap-block-x', [
+		'entrance'   => [ 'name' => 'fade-in-up' ],
+		'continuous' => [ 'name' => 'pulse' ],
+	] );
+
+	// Both keyframes must appear comma-joined on the same play-class
+	// rule so adding `.ap-anim-play` doesn't clobber the continuous
+	// pulse loop emitted on the base scope.
+	expect( $css )->toMatch( '/\.ap-block-x\.ap-anim-play\s*\{\s*animation:\s*apFadeInUp[^,]*,\s*apPulse/' );
+
+	// Continuous still emits its own base-scope rule so it starts
+	// running before the entrance fires.
+	expect( $css )->toMatch( '/\.ap-block-x\s*\{\s*animation:\s*apPulse/' );
+} );
+
+it( 'emits the pre-state and data attr for responsive-only entrance configs', function () {
+	$emitter = makeAnimEmitter();
+
+	$attributes = [
+		'entrance' => [ 'name' => [ 'md' => 'fade-in-up' ] ],
+	];
+
+	$css  = $emitter->emit( '.ap-block-x', $attributes );
+	$data = $emitter->dataAttributes( $attributes );
+
+	expect( $css )->toContain( '.ap-block-x.ap-anim-pre { opacity: 0; }' );
+	expect( $data['data-ap-anim-entrance'] )->toBe( 'fade-in-up' );
+} );
+
 it( 'rejects easing values containing CSS-injection characters', function () {
 	$css = makeAnimEmitter()->emit( '.ap-block-x', [
 		'entrance' => [ 'name' => 'fade-in', 'easing' => 'ease; } body {' ],

--- a/tests/Unit/VisualEditor/Animations/AnimationRegistryTest.php
+++ b/tests/Unit/VisualEditor/Animations/AnimationRegistryTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Animations\AnimationRegistry;
+
+it( 'falls back to built-in defaults when nothing overrides them', function () {
+	$registry = AnimationRegistry::fromLayers( [], [] );
+
+	expect( $registry->families() )->toEqualCanonicalizing( [ 'entrance', 'hover', 'continuous' ] );
+	expect( $registry->has( 'entrance', 'fade-in-up' ) )->toBeTrue();
+	expect( $registry->has( 'continuous', 'pulse' ) )->toBeTrue();
+	expect( $registry->has( 'hover', 'lift' ) )->toBeTrue();
+} );
+
+it( 'merges config overrides on top of defaults', function () {
+	$registry = AnimationRegistry::fromLayers(
+		[ 'entrance' => [ 'fade-in' => [ 'label' => 'Soft fade' ] ] ],
+		[]
+	);
+
+	$def = $registry->get( 'entrance', 'fade-in' );
+
+	expect( $def )->not->toBeNull();
+	expect( $def['label'] )->toBe( 'Soft fade' );
+	// Defaults flow through.
+	expect( $def['keyframe'] )->toBe( 'apFadeIn' );
+	expect( $def['duration'] )->toBe( 600 );
+} );
+
+it( 'lets a theme override drop a built-in by setting it to null', function () {
+	$registry = AnimationRegistry::fromLayers(
+		[],
+		[ 'entrance' => [ 'flip-x' => null ] ]
+	);
+
+	expect( $registry->has( 'entrance', 'flip-x' ) )->toBeFalse();
+	expect( $registry->has( 'entrance', 'fade-in' ) )->toBeTrue();
+} );
+
+it( 'lets a theme register a new animation in the entrance family', function () {
+	$registry = AnimationRegistry::fromLayers(
+		[],
+		[ 'entrance' => [ 'fade-in-blur' => [
+			'label'    => 'Fade in (blur)',
+			'keyframe' => 'apFadeInBlur',
+			'duration' => 700,
+			'easing'   => 'ease-out',
+		] ] ]
+	);
+
+	expect( $registry->has( 'entrance', 'fade-in-blur' ) )->toBeTrue();
+	expect( $registry->get( 'entrance', 'fade-in-blur' )['keyframe'] )->toBe( 'apFadeInBlur' );
+} );
+
+it( 'rejects an unknown family slug', function () {
+	AnimationRegistry::fromLayers(
+		[],
+		[ 'parallax' => [ 'scroll' => [ 'label' => 'Scroll', 'keyframe' => 'x', 'duration' => 1000, 'easing' => 'ease' ] ] ]
+	);
+} )->throws( InvalidArgumentException::class, 'family' );
+
+it( 'rejects an entry missing the keyframe', function () {
+	AnimationRegistry::fromLayers(
+		[],
+		[ 'entrance' => [ 'broken' => [ 'label' => 'Broken', 'duration' => 600, 'easing' => 'ease' ] ] ]
+	);
+} )->throws( InvalidArgumentException::class, 'keyframe' );
+
+it( 'rejects a hover entry missing the preset', function () {
+	AnimationRegistry::fromLayers(
+		[],
+		[ 'hover' => [ 'broken' => [ 'label' => 'Broken', 'duration' => 200, 'easing' => 'ease' ] ] ]
+	);
+} )->throws( InvalidArgumentException::class, 'preset' );
+
+it( 'rejects a non-positive duration', function () {
+	AnimationRegistry::fromLayers(
+		[],
+		[ 'entrance' => [ 'broken' => [
+			'label' => 'Broken', 'keyframe' => 'x', 'duration' => 0, 'easing' => 'ease',
+		] ] ]
+	);
+} )->throws( InvalidArgumentException::class, 'duration' );
+
+it( 'rejects a key with invalid characters', function () {
+	AnimationRegistry::fromLayers(
+		[],
+		[ 'entrance' => [ 'fade in' => [
+			'label' => 'Bad', 'keyframe' => 'x', 'duration' => 100, 'easing' => 'ease',
+		] ] ]
+	);
+} )->throws( InvalidArgumentException::class );

--- a/tests/Unit/VisualEditor/Animations/KeyframeRegistryTest.php
+++ b/tests/Unit/VisualEditor/Animations/KeyframeRegistryTest.php
@@ -61,6 +61,62 @@ it( 'fromLayers skips and logs invalid entries instead of throwing', function ()
 	expect( $registry->customNames() )->toBe( [ 'confetti' ] );
 } );
 
+it( 'does not let an invalid global-styles entry overwrite a valid theme entry of the same name', function () {
+	// Regression for the validate-then-merge fix: if global-styles
+	// stomps the merge dict pre-validation, the (valid) theme entry
+	// vanishes because the (invalid) global entry replaces it and is
+	// then dropped at validate time. Both layers reference the same
+	// name so we can isolate the precedence behaviour.
+	$registry = KeyframeRegistry::fromLayers(
+		[
+			[
+				'name'  => 'confetti',
+				'stops' => [
+					[ 'at' => '0%',   'transform' => 'translateY(0)' ],
+					[ 'at' => '100%', 'transform' => 'translateY(0)' ],
+				],
+			],
+		],
+		[
+			// Invalid: only one stop. Must NOT overwrite the theme
+			// entry above.
+			[ 'name' => 'confetti', 'stops' => [ [ 'at' => '0%', 'opacity' => '0' ] ] ],
+		]
+	);
+
+	expect( $registry->customNames() )->toBe( [ 'confetti' ] );
+	expect( $registry->emitOne( 'confetti' ) )->toContain( 'translateY(0)' );
+} );
+
+it( 'global-styles wins over theme when both layers are valid', function () {
+	$registry = KeyframeRegistry::fromLayers(
+		[
+			[
+				'name'  => 'confetti',
+				'stops' => [
+					[ 'at' => '0%',   'opacity' => '0' ],
+					[ 'at' => '100%', 'opacity' => '1' ],
+				],
+			],
+		],
+		[
+			[
+				'name'  => 'confetti',
+				'stops' => [
+					[ 'at' => '0%',   'transform' => 'translateY(0)' ],
+					[ 'at' => '100%', 'transform' => 'translateY(-12px)' ],
+				],
+			],
+		]
+	);
+
+	$emitted = $registry->emitOne( 'confetti' );
+	// The Global Styles version (transforms) wins, not the theme one
+	// (opacity).
+	expect( $emitted )->toContain( 'translateY(-12px)' );
+	expect( $emitted )->not->toContain( 'opacity' );
+} );
+
 it( 'rejects a custom keyframe whose name collides with a built-in', function () {
 	new KeyframeRegistry( [
 		[

--- a/tests/Unit/VisualEditor/Animations/KeyframeRegistryTest.php
+++ b/tests/Unit/VisualEditor/Animations/KeyframeRegistryTest.php
@@ -39,10 +39,44 @@ it( 'accepts and emits a custom keyframe', function () {
 	expect( $registry->emitOne( 'confetti' ) )->toContain( 'translateY(-12px)' );
 } );
 
+it( 'fromLayers skips and logs invalid entries instead of throwing', function () {
+	// Mixed: one valid + two invalid. Boot must never crash on a
+	// malformed host config — the scoped service-provider binding
+	// resolves on every request, so a throw here would 500 the editor.
+	$registry = KeyframeRegistry::fromLayers(
+		[
+			[
+				'name'  => 'confetti',
+				'stops' => [
+					[ 'at' => '0%',   'transform' => 'translateY(0)' ],
+					[ 'at' => '100%', 'transform' => 'translateY(0)' ],
+				],
+			],
+			[ 'stops' => [] ],
+			[ 'name' => 'broken', 'stops' => [ [ 'at' => '0%', 'opacity' => '0' ] ] ],
+		],
+		[]
+	);
+
+	expect( $registry->customNames() )->toBe( [ 'confetti' ] );
+} );
+
 it( 'rejects a custom keyframe whose name collides with a built-in', function () {
 	new KeyframeRegistry( [
 		[
 			'name'  => 'apFadeIn',
+			'stops' => [
+				[ 'at' => '0%',   'opacity' => '0' ],
+				[ 'at' => '100%', 'opacity' => '1' ],
+			],
+		],
+	] );
+} )->throws( InvalidArgumentException::class, 'reserved' );
+
+it( 'rejects case-variant collisions with a built-in keyframe name', function () {
+	new KeyframeRegistry( [
+		[
+			'name'  => 'apfadein',
 			'stops' => [
 				[ 'at' => '0%',   'opacity' => '0' ],
 				[ 'at' => '100%', 'opacity' => '1' ],

--- a/tests/Unit/VisualEditor/Animations/KeyframeRegistryTest.php
+++ b/tests/Unit/VisualEditor/Animations/KeyframeRegistryTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Animations\KeyframeRegistry;
+
+it( 'exposes built-in keyframe names', function () {
+	$registry = new KeyframeRegistry();
+
+	expect( $registry->isBuiltIn( 'apFadeIn' ) )->toBeTrue();
+	expect( $registry->isBuiltIn( 'apPulse' ) )->toBeTrue();
+	expect( $registry->isBuiltIn( 'apBounce' ) )->toBeTrue();
+	expect( $registry->has( 'apFadeIn' ) )->toBeTrue();
+} );
+
+it( 'emits CSS for every built-in keyframe', function () {
+	$registry = new KeyframeRegistry();
+	$css      = $registry->emitCss();
+
+	expect( $css )->toContain( '@keyframes apFadeIn' );
+	expect( $css )->toContain( '@keyframes apPulse' );
+	expect( $css )->toContain( '@keyframes apSpin' );
+} );
+
+it( 'accepts and emits a custom keyframe', function () {
+	$registry = new KeyframeRegistry( [
+		[
+			'name'  => 'confetti',
+			'stops' => [
+				[ 'at' => '0%',   'transform' => 'translateY(0)' ],
+				[ 'at' => '50%',  'transform' => 'translateY(-12px) rotate(10deg)' ],
+				[ 'at' => '100%', 'transform' => 'translateY(0)' ],
+			],
+		],
+	] );
+
+	expect( $registry->customNames() )->toBe( [ 'confetti' ] );
+	expect( $registry->emitOne( 'confetti' ) )->toContain( '@keyframes confetti' );
+	expect( $registry->emitOne( 'confetti' ) )->toContain( 'translateY(-12px)' );
+} );
+
+it( 'rejects a custom keyframe whose name collides with a built-in', function () {
+	new KeyframeRegistry( [
+		[
+			'name'  => 'apFadeIn',
+			'stops' => [
+				[ 'at' => '0%',   'opacity' => '0' ],
+				[ 'at' => '100%', 'opacity' => '1' ],
+			],
+		],
+	] );
+} )->throws( InvalidArgumentException::class, 'reserved' );
+
+it( 'rejects fewer than two stops', function () {
+	new KeyframeRegistry( [
+		[ 'name' => 'oneStop', 'stops' => [ [ 'at' => '0%', 'opacity' => '0' ] ] ],
+	] );
+} )->throws( InvalidArgumentException::class, 'two' );
+
+it( 'rejects an unsupported stop property', function () {
+	new KeyframeRegistry( [
+		[
+			'name'  => 'bad',
+			'stops' => [
+				[ 'at' => '0%',   'position' => 'absolute' ],
+				[ 'at' => '100%', 'opacity' => '1' ],
+			],
+		],
+	] );
+} )->throws( InvalidArgumentException::class, 'property' );
+
+it( 'rejects an at value outside 0-100 percent', function () {
+	new KeyframeRegistry( [
+		[
+			'name'  => 'bad',
+			'stops' => [
+				[ 'at' => '150%', 'opacity' => '0' ],
+				[ 'at' => '100%', 'opacity' => '1' ],
+			],
+		],
+	] );
+} )->throws( InvalidArgumentException::class );
+
+it( 'rejects a CSS-injection attempt in a value', function () {
+	new KeyframeRegistry( [
+		[
+			'name'  => 'bad',
+			'stops' => [
+				[ 'at' => '0%',   'opacity' => '0; } body { display: none' ],
+				[ 'at' => '100%', 'opacity' => '1' ],
+			],
+		],
+	] );
+} )->throws( InvalidArgumentException::class, 'disallowed' );


### PR DESCRIPTION
## Description

Adds the v1.x **block-animations** system — entrance, hover, and continuous animation families plus editor-authored custom keyframes. CSS-first emission with a small shared `IntersectionObserver` runtime for entrance animations. Respects `prefers-reduced-motion` by default.

**Closes:** #489

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #489

## Motivation and Context

Block plugins like Animate.css and Block Animator established that motion controls are core table-stakes for marketing pages. The editor renders blocks statically — there is no way for an editor to add entrance, hover, or continuous animations short of dropping into raw CSS. This system adds that vocabulary across all three renderers (Blade, React, Vue), with an extensible registry that themes/hosts can augment.

## Changes Made

### PHP — `src/Animations/`
- **`AnimationRegistry`** — three-family registry (entrance / hover / continuous) merged from `theme.json` → app config → package defaults. `null` overrides drop built-ins.
- **`KeyframeRegistry`** — 20 built-in `@keyframes` plus editor-authored custom keyframes persisted to Global Styles. Stop properties allow-listed to `transform / opacity / filter / color / background-color / box-shadow`. CSS-injection guarded.
- **`AnimationAttributeResolver`** — walks responsive-aware `{ base, sm, md, … }` shapes per breakpoint.
- **`AnimationCssEmitter`** — turns an `artisanpackAnimations` attribute bag into scoped CSS + wrapper classes + `data-ap-anim-*` attrs + noscript fallback CSS. Composes with the breakpoint registry for per-breakpoint disable.

### Renderer integration
- **Blade**: `AnimationMarkupResolver` + `AnimationCssAccumulator` drain a single `<style data-ve-animations>` block per request, ship a `<noscript>` reveal, and inject an inline `IntersectionObserver` runtime on pages with entrance animations. Wired centrally into `BlockSupports::wrapperAttrs()` so every block that uses it picks up animations for free; cover's bespoke partial handles its own wrapper inline.
- **React** + **Vue**: framework-agnostic `resolveAnimationMarkup(attributes)` mirrors the PHP class list + data attrs so client and server agree exactly on what markup the runtime sees.

### React surface
- **`AnimationPanel`** — inspector panel with three sub-panels (entrance / hover / continuous) and a per-block reduced-motion toggle.
- **`CustomKeyframeEditor`** — Site Editor → Styles → Animations sub-page that lets developers author named `@keyframes` with stops; reserved built-in names + duplicate names + invalid characters all rejected.
- **`runtime.ts`** — shared IntersectionObserver + reduced-motion + MutationObserver runtime, <5 KB gzipped.
- **`registerAnimationsAttribute`** filter — injects the `artisanpackAnimations` storage attribute on blocks declaring `supports.artisanpackAnimations`.
- **`withAnimationsPanel`** HOC — mounts the AnimationPanel into the inspector for every opted-in block.

### Block opt-in
- 68 standalone `artisanpack/*` blocks opt in via `supports.artisanpackAnimations: true` in `block.json`. Template children (column, list-item, comment-template descendants, query loop children, grid-item, accordion/tabs/comments-pagination inner pieces, etc.) skipped — their parent wrapper carries the animation instead.

### Cover hardening
- Defensive 5-second `Promise.race` timeout on `getMediaColor` (`cover/edit/color-utils.ts`) so a stalled `<img>` request (CORS preflight stall, service-worker stall, mixed-content silent block) can no longer hang the picker code path. Issue #578 tracks a separate cover-specific editor hang that this PR does not address.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (Darwin 25.5.0)
- Browser: Chrome (latest stable)
- PHP Version: 8.4
- Project Version: `release/1.1` baseline

**Tests Performed:**
1. Manual end-to-end on `artisanpack/image`: entrance Fade in up + threshold 0.3 → confirmed fade-in on scroll on the published page; cover renders the same data attributes + scoped CSS + runtime script.
2. `<style data-ve-animations>` block contains the `@keyframes` definitions plus the per-block rule; `<noscript>` reveal payload present when entrance animations are configured.
3. Reduced-motion OS preference suppresses animation correctly; per-block override (`Respect reduced motion` toggle → off) plays animation anyway.

## Accessibility Tests Run

- [x] `prefers-reduced-motion: reduce` respected by default — CSS guard + JS runtime both suppress
- [x] `<noscript>` fallback reveals blocks in their final state when JS is disabled
- [x] Inspector panel controls keyboard-navigable (standard `@wordpress/components`)
- [x] Per-block reduced-motion override is a `ToggleControl` with descriptive help text

**Details:** The CSS layer emits a `@media (prefers-reduced-motion: reduce)` block that resets `animation: none / transition: none / opacity: 1 / transform: none` so the block reads statically. The JS runtime also short-circuits and reveals the block immediately when the OS preference is set. Per-block override surfaces via `data-ap-anim-reduced="allow"`.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:**
- Pest unit: `AnimationRegistry` (9), `KeyframeRegistry` (7), `AnimationAttributeResolver` (6), `AnimationCssEmitter` (14) → 36 cases
- Pest feature: `AnimationMarkupResolver` (3), `AnimationCoverIntegration` (3 — cover, image, no-opt-in) → 6 cases
- Pest renderer-blade unit: `AnimationCssAccumulator` (5) → 5 cases
- Vitest: registry (5), runtime IntersectionObserver behaviour (6), cover `getMediaColor` timeout (3) → 14 cases
- Playwright spec (`tests/E2E/animations.spec.ts`) authored in deactivated form documenting the e2e contract; activates as soon as the runner lands in the CI matrix.

**Totals after this PR:** **1140 Pest** (3230 assertions) / **2046 Vitest** — all green.

## Documentation

- [x] Inline code documentation added
- [x] Wiki updated *(via `docs/animations.md` — wiki sync is a separate downstream task)*

**Documentation details:** `docs/animations.md` covers the attribute shape, registry layers, custom-keyframe authoring (config + theme.json + Site Editor), renderer integration, runtime contract, and accessibility guarantees.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [ ] Code has been linted *(pint not available in this package; PHP-CS-Fixer not installed locally)*
- [x] Accessibility tests completed
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Block animation system (entrance, hover, continuous) with per-block controls, editor panel, global reduced‑motion toggle, and custom keyframe authoring via UI or config
  * Runtime: scoped CSS emission, pooled IntersectionObserver playback, MutationObserver for late nodes, noscript fallbacks, and per-page consolidated animation styles
  * Animation support enabled across many core blocks

* **Documentation**
  * Comprehensive docs on config, authoring, rendering, runtime, accessibility, and disabling built-ins

* **Tests**
  * Added unit/integration tests covering registry, keyframes, runtime, emitter, and templates
<!-- end of auto-generated comment: release notes by coderabbit.ai -->