### PR TITLE
feat: border gradients (linear/radial/conic) + tabbed color/gradient picker (#490)

### DIFF
--- a/docs/border-gradients.md
+++ b/docs/border-gradients.md
@@ -96,11 +96,16 @@ Each block with a gradient border gets a stable, content-derived
 scope class (`ve-gb-<hash>`) and the rules below:
 
 ```css
-.ve-gb-abc123 { position: relative; }
+.ve-gb-abc123 {
+    position: relative;
+    border-color: transparent !important;  /* suppress any stale border-color */
+}
 .ve-gb-abc123::before {
     content: '';
     position: absolute;
-    inset: 0;
+    inset: calc(-1 * 2px);       /* extend OUT past the padding-box edge
+                                    by the border-width so the ring sits
+                                    on the actual border-box edge */
     padding: 2px;                /* the border width */
     border-radius: inherit;      /* matches the wrapper's radius */
     background: linear-gradient(135deg, #ff0080, #7928ca);

--- a/docs/border-gradients.md
+++ b/docs/border-gradients.md
@@ -1,0 +1,288 @@
+# Border Gradients & Color-Picker Consistency
+
+Status: **v1.1.0** — Issue [#490](https://github.com/ArtisanPack-UI/visual-editor/issues/490).
+
+Block borders can be painted with a linear, radial, or conic gradient.
+The feature composes with the existing State Design Tools and
+Responsive Design Tools (per-state and per-breakpoint overrides),
+honors registered gradient tokens from `theme.json`, and clips
+correctly at any `border-radius`.
+
+The PR also sweeps the rest of the editor so that **every per-block
+color picker offers a Color | Gradient tabbed UX**, matching the way
+backgrounds work natively in Gutenberg. See "Color-picker consistency"
+below for the audit + deltas.
+
+## Authoring
+
+In the editor, open any block that supports borders, scroll to the
+**Border** group in the inspector, and find the **Gradient border**
+panel. Pick a gradient from the theme palette, or paste a raw CSS
+gradient value (`linear-gradient(...)`, `radial-gradient(...)`,
+`conic-gradient(...)`).
+
+To set a different gradient for hover (or focus, active, etc.), switch
+the state chip in the inspector to that state and re-pick. The
+underlying writes go through the standard `withStateAttributes` HOC,
+so the cascade and inheritance behavior match every other state-able
+property.
+
+Same story for breakpoints — switch the viewport chip to `md` (or any
+breakpoint) and re-pick. Writes land in `attributes.responsive`,
+respecting the mobile-first cascade.
+
+## Opting a block in
+
+Add `gradient: true` to the block's existing border support:
+
+```json
+{
+  "supports": {
+    "__experimentalBorder": {
+      "color":  true,
+      "radius": true,
+      "style":  true,
+      "width":  true,
+      "gradient": true
+    }
+  }
+}
+```
+
+(Or under the plain `"border"` key for non-experimental blocks.) Every
+block in this package that already supported border was opted in
+automatically by `scripts/opt-in-gradient-border.mjs`.
+
+The `withGradientBorderControl` HOC and `extend-supports` filter
+auto-detect the flag — no per-block UI code is needed.
+
+## Theme tokens
+
+Tokens are picked up from `theme.json`:
+
+```json
+{
+  "settings": {
+    "color": {
+      "gradients": [
+        {
+          "slug":     "primary-glow",
+          "name":     "Primary Glow",
+          "gradient": "linear-gradient(135deg, #ff0080 0%, #7928ca 100%)"
+        }
+      ]
+    }
+  }
+}
+```
+
+The editor stores the slug (`primary-glow`) on the block. The renderer
+expands it to `var(--wp--preset--gradient--primary-glow)` at emit
+time, which resolves against the same custom properties WordPress
+generates for the background gradient palette.
+
+### Missing token warning
+
+If you rename or delete a referenced gradient slug from `theme.json`,
+the editor's inspector panel shows a yellow `Notice` listing the
+affected slugs. Until the token is restored (or the block re-picks),
+the border renders as `transparent` on that cascade slot.
+
+## How it renders
+
+The CSS strategy is a single mask-pseudo emission — one path that
+handles all three gradient kinds × all border-radius values cleanly.
+Each block with a gradient border gets a stable, content-derived
+scope class (`ve-gb-<hash>`) and the rules below:
+
+```css
+.ve-gb-abc123 { position: relative; }
+.ve-gb-abc123::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    padding: 2px;                /* the border width */
+    border-radius: inherit;      /* matches the wrapper's radius */
+    background: linear-gradient(135deg, #ff0080, #7928ca);
+    -webkit-mask:
+        linear-gradient(#000 0 0) content-box,
+        linear-gradient(#000 0 0);
+    -webkit-mask-composite: xor;
+    mask:
+        linear-gradient(#000 0 0) content-box,
+        linear-gradient(#000 0 0);
+    mask-composite: exclude;
+    pointer-events: none;
+}
+```
+
+`border-image` would have been simpler for linear gradients on a
+zero-radius block, but it doesn't follow `border-radius` — the
+gradient renders square and fringes at every rounded corner. The
+mask-composite trick is a touch heavier (one extra paint layer) but
+produces pixel-correct output across the full matrix.
+
+### State composition
+
+A `:hover` override is emitted as an additional `::before` rule
+wrapped in `@media (hover: hover)` so touch devices don't sticky-state:
+
+```css
+.ve-gb-abc123::before { transition: background 200ms ease, opacity 200ms ease; }
+@media (hover: hover) {
+    .ve-gb-abc123:hover::before { background: linear-gradient(135deg, #7928ca, #ff0080); }
+}
+```
+
+Other states (`:focus`, `:active`, `:disabled`, …) get the same
+treatment without the `@media` wrap. The state list is the
+canonical `StateRegistry::DEFAULT_STATES` set.
+
+### Breakpoint composition
+
+A per-breakpoint override emits an additional `@media (min-width:…)`
+rule:
+
+```css
+@media (min-width: 768px) {
+    .ve-gb-abc123::before { background: linear-gradient(180deg, #ff0080, #7928ca); }
+}
+```
+
+Mobile-first cascade — same semantics as the rest of the responsive
+design tools.
+
+## Output location
+
+All gradient border CSS for a render pass is collected into one
+`<style data-ve-gradient-borders>` block prepended to the rendered
+HTML, dedupe-keyed by scope class so a block tree with N siblings
+sharing the same payload emits the rule once.
+
+## Files
+
+| Concern                              | File                                                                                                  |
+| ------------------------------------ | ----------------------------------------------------------------------------------------------------- |
+| PHP resolver (cascade → payload)     | `src/GradientBorder/GradientBorderResolver.php`                                                       |
+| PHP emitter (payload → CSS)          | `src/GradientBorder/GradientBorderEmitter.php`                                                        |
+| PHP per-request accumulator          | `packages/visual-editor-renderer-blade/src/Services/GradientBorderCssAccumulator.php`                 |
+| PHP compile integration              | `packages/visual-editor-renderer-blade/src/Support/BlockSupports.php` → `compileGradientBorder()`     |
+| JS resolver                          | `resources/js/visual-editor/gradient-borders/resolver.ts`                                             |
+| JS emitter                           | `resources/js/visual-editor/gradient-borders/emitter.ts`                                              |
+| JS inspector control + token warning | `resources/js/visual-editor/gradient-borders/with-gradient-border-control.tsx`                        |
+| JS supports auto-extension           | `resources/js/visual-editor/gradient-borders/extend-supports.ts`                                      |
+| JS one-shot registrar                | `resources/js/visual-editor/gradient-borders/register.ts`                                             |
+| Bulk block opt-in script             | `scripts/opt-in-gradient-border.mjs`                                                                  |
+| Visual regression contract           | `tests/visual/border-gradients.spec.ts`                                                               |
+
+## Color-picker consistency
+
+Each per-block color picker now offers Color | Gradient tabs:
+
+- **Background, text, link** — Gutenberg's auto-injected color panel
+  renders `ColorGradientControl` (tabbed) whenever a block declares
+  `supports.color.gradients: true`. Seven forked blocks were missing
+  that flag and have been updated by
+  `scripts/opt-in-color-gradients.mjs`: cover, icon, post-navigation-link,
+  term-description, list (core), preformatted (core), quote (core).
+- **Border color** — see the "How it renders" section above. The
+  native `BorderBoxControl` color popover trigger is hidden via a
+  scoped CSS rule in `with-gradient-border-control.tsx`; in its place,
+  our own tools-panel item renders `ColorGradientControl` (with all
+  four palette keys, so the Gradient tab is always available). A
+  dedicated style picker (Solid / Dashed / Dotted) sits alongside,
+  replacing what the native popover used to bundle.
+- **Cover overlay (placeholder state)** — `blocks/cover/edit/index.tsx`
+  used a color-only `ColorPalette` before media was chosen; it now
+  uses `ColorGradientControl` for symmetry with the full inspector
+  control (`inspector-controls.tsx`), which has always been tabbed.
+
+### Theme.json must define `settings.color.gradients`
+
+Gutenberg's auto-injected Background / Text color panels (the ones that
+appear on any block declaring `supports.color.gradients: true`) read
+their palette from `useSettings('color.gradients')`. **If the active
+theme.json doesn't define `settings.color.gradients`, those panels
+silently fall back to color-only** — even though every block in this
+package opts into gradients. The Gradient tab disappears with no warning.
+
+Themes consuming this package should set:
+
+```json
+{
+  "settings": {
+    "color": {
+      "gradients": [
+        { "name": "...", "slug": "...", "gradient": "linear-gradient(...)" }
+      ],
+      "defaultGradients": true,
+      "customGradient": true
+    }
+  }
+}
+```
+
+`defaultGradients: true` also pulls in WP's bundled palette. The dev
+themes (`themes/dev-sample/theme.json`, `resources/theme.json`) carry
+this setting.
+
+### Why `ColorGradientControl` needs all four palette keys
+
+A subtle gotcha that bit this PR repeatedly: Gutenberg's
+`__experimentalColorGradientControl` only honors caller-supplied
+palettes when ALL FOUR of these props are present:
+
+```ts
+colors
+gradients
+disableCustomColors
+disableCustomGradients
+```
+
+Pass three of them and it silently falls through to
+`ColorGradientControlSelect`, which reads `color.gradients` from
+`useSettings()`. In a theme that doesn't define gradients at the
+settings level, that returns empty and the Gradient tab disappears.
+
+So every call site in this PR passes all four explicitly — same shape
+the editor's own background picker uses.
+
+### Deferred to a follow-up
+
+Two site-editor surfaces still render bare `ColorPalette` and weren't
+upgraded in this PR because adding gradient support requires a new
+storage model:
+
+- `site-editor/styles/panels/styles-fields.tsx:160` — entity-level
+  style values for theme defaults. Stored as palette REFS
+  (`paletteRefFromColor(...)`); supporting gradients would require a
+  parallel "gradient ref" concept and a site-wide gradient palette.
+- `site-editor/styles/panels/colors-panel.tsx:548` — site-wide
+  defaults (background / text / link). Same palette-ref shape.
+- `site-editor/styles/panels/colors-panel.tsx:414` — the palette
+  editor's own bespoke `ColorIndicator + ColorPicker` for adding new
+  palette entries. Editing the color-palette itself is a different
+  conceptual surface from picking a value; not a candidate for tabs.
+
+These belong to a separate "site-wide gradient palette" feature, not
+to the per-block color story.
+
+## What's out of scope (v1.x)
+
+The following from the original issue are deferred to a v2 milestone:
+
+- **Per-side independent gradients** — v1 paints one continuous frame
+  on all four sides.
+- **Animated / rotating border gradients** — tracked under Block
+  Animations.
+- **Gradient masks / non-rectangular shapes** — tracked separately.
+- **Multiple stacked border gradients** — single layer only in v1.
+- **Per-state-per-breakpoint nested cascades** — per-state and
+  per-breakpoint each work independently; nesting them (e.g. "hover
+  at the `md` breakpoint") is not supported in v1. The existing
+  `attributes.states` / `attributes.responsive` bags are siblings,
+  not composable, so this is a structural limitation that lands when
+  the upstream cascading is reworked.
+- **Playwright visual-regression runner** — the matrix lives in
+  `tests/visual/border-gradients.spec.ts` as the contract; wiring
+  the runner, baselines, and CI job is its own infrastructure issue.

--- a/packages/visual-editor-renderer-blade/resources/views/components/blocks.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/components/blocks.blade.php
@@ -13,4 +13,9 @@
 {!! $statesCss !!}
 @endif
 @endisset
+@isset( $gradientBordersCss )
+@if( '' !== $gradientBordersCss )
+{!! $gradientBordersCss !!}
+@endif
+@endisset
 {!! $html !!}

--- a/packages/visual-editor-renderer-blade/resources/views/components/template.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/components/template.blade.php
@@ -20,6 +20,11 @@
 {!! $statesCss !!}
 @endif
 @endisset
+@isset( $gradientBordersCss )
+@if( '' !== $gradientBordersCss )
+{!! $gradientBordersCss !!}
+@endif
+@endisset
 <div class="{{ implode( ' ', $wrapperClasses ) }}" data-ve-template="{{ $slug }}"@if( null !== $matchedSlug && $matchedSlug !== $slug ) data-ve-matched-template="{{ $matchedSlug }}"@endif>
 @if( null !== $resolutionError )
 @if( $inDev )

--- a/packages/visual-editor-renderer-blade/src/BlockRenderer.php
+++ b/packages/visual-editor-renderer-blade/src/BlockRenderer.php
@@ -24,6 +24,7 @@ namespace ArtisanPackUI\VisualEditorRendererBlade;
 use ArtisanPackUI\VisualEditor\Registries\DynamicBlockRegistry;
 use ArtisanPackUI\VisualEditorRendererBlade\Resolvers\LoginoutResolver;
 use ArtisanPackUI\VisualEditorRendererBlade\Resolvers\SiteMetaResolver;
+use ArtisanPackUI\VisualEditorRendererBlade\Support\BlockSupports;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Contracts\View\Factory as ViewFactory;
@@ -260,8 +261,18 @@ class BlockRenderer
 		try {
 			$validated = $block->validateAttrs( $attributes );
 			$result    = $block->render( $validated );
+			$html      = $this->coerceToString( $result );
 
-			return $this->coerceToString( $result );
+			// #490 — dynamic blocks build their own wrapper HTML and
+			// don't go through `BlockSupports::compile`, so the
+			// gradient-border pipeline never sees them by default.
+			// Post-process the rendered HTML to push the rule into the
+			// per-request accumulator AND stamp the scope class onto
+			// the first opening tag. No-op when the block has no
+			// gradient configured.
+			$html = BlockSupports::applyGradientBorder( $html, $attributes );
+
+			return $html;
 		} catch ( Throwable $e ) {
 			report( $e );
 

--- a/packages/visual-editor-renderer-blade/src/BlockRenderer.php
+++ b/packages/visual-editor-renderer-blade/src/BlockRenderer.php
@@ -268,9 +268,13 @@ class BlockRenderer
 			// gradient-border pipeline never sees them by default.
 			// Post-process the rendered HTML to push the rule into the
 			// per-request accumulator AND stamp the scope class onto
-			// the first opening tag. No-op when the block has no
-			// gradient configured.
-			$html = BlockSupports::applyGradientBorder( $html, $attributes );
+			// the first opening tag. Use `$validated` (not raw
+			// `$attributes`) so the scope class + emitted CSS stay
+			// aligned with the input the dynamic block actually
+			// rendered from — keeping editor preview and saved markup
+			// in lockstep across attribute normalization passes.
+			// No-op when the block has no gradient configured.
+			$html = BlockSupports::applyGradientBorder( $html, $validated );
 
 			return $html;
 		} catch ( Throwable $e ) {

--- a/packages/visual-editor-renderer-blade/src/Services/GradientBorderCssAccumulator.php
+++ b/packages/visual-editor-renderer-blade/src/Services/GradientBorderCssAccumulator.php
@@ -1,0 +1,103 @@
+<?php
+
+/**
+ * Per-request accumulator for the gradient border feature's CSS (#490).
+ *
+ * Block partials push their per-scope gradient border rules into this
+ * service while rendering. The `<x-ve-blocks>` / `<x-ve-template>`
+ * components drain it once and emit a single
+ * `<style data-ve-gradient-borders>` block at the top of the render
+ * output — same pattern as {@see StateCssAccumulator} and
+ * {@see ResponsiveCssAccumulator}.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditorRendererBlade
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.1.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditorRendererBlade\Services;
+
+class GradientBorderCssAccumulator
+{
+	/**
+	 * Map of scope class → CSS rule string. Keyed so duplicate pushes
+	 * collapse to one entry; PHP arrays preserve insertion order so
+	 * iteration produces deterministic output.
+	 *
+	 * @var array<string, string>
+	 */
+	protected array $rules = [];
+
+	/**
+	 * Adds a rule set for the given scope class. Subsequent calls with
+	 * the same scope are ignored — block partials are expected to use
+	 * content-derived scope classes so identical payloads land in the
+	 * same bucket.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param  string  $scope  The scope class (e.g. `ve-gb-abc123`).
+	 * @param  string  $css    The CSS rule string (no surrounding
+	 *                         `<style>` tag).
+	 */
+	public function push( string $scope, string $css ): void
+	{
+		if ( '' === $scope || '' === $css ) {
+			return;
+		}
+
+		if ( isset( $this->rules[ $scope ] ) ) {
+			return;
+		}
+
+		$this->rules[ $scope ] = $css;
+	}
+
+	/**
+	 * Returns the consolidated `<style data-ve-gradient-borders>` block
+	 * and clears the accumulator. Called once per render at the top of
+	 * the `<x-ve-blocks>` / `<x-ve-template>` output. Returns an empty
+	 * string when no rules were pushed.
+	 *
+	 * @since 1.1.0
+	 */
+	public function flush(): string
+	{
+		if ( [] === $this->rules ) {
+			return '';
+		}
+
+		$body        = implode( '', array_values( $this->rules ) );
+		$this->rules = [];
+
+		return '<style data-ve-gradient-borders>' . $body . '</style>';
+	}
+
+	/**
+	 * Resets the accumulator without emitting. Tests use this to clear
+	 * state between assertions inside a single PHP process.
+	 *
+	 * @since 1.1.0
+	 */
+	public function reset(): void
+	{
+		$this->rules = [];
+	}
+
+	/**
+	 * Inspect what's currently accumulated without draining. Test-only.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return array<string, string>
+	 */
+	public function all(): array
+	{
+		return $this->rules;
+	}
+}

--- a/packages/visual-editor-renderer-blade/src/Support/BlockSupports.php
+++ b/packages/visual-editor-renderer-blade/src/Support/BlockSupports.php
@@ -47,10 +47,13 @@ declare( strict_types=1 );
 
 namespace ArtisanPackUI\VisualEditorRendererBlade\Support;
 
+use ArtisanPackUI\VisualEditor\GradientBorder\GradientBorderEmitter;
+use ArtisanPackUI\VisualEditor\GradientBorder\GradientBorderResolver;
 use ArtisanPackUI\VisualEditor\Responsive\BreakpointRegistry;
 use ArtisanPackUI\VisualEditor\States\StateCssEmitter;
 use ArtisanPackUI\VisualEditor\States\StateRegistry;
 use ArtisanPackUI\VisualEditor\States\StateValueResolver;
+use ArtisanPackUI\VisualEditorRendererBlade\Services\GradientBorderCssAccumulator;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\ResponsiveCssAccumulator;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\StateCssAccumulator;
 
@@ -158,15 +161,25 @@ class BlockSupports
 			self::pushStates( $states['class'], $states['rules'] );
 		}
 
+		$gradientBorder = self::compileGradientBorder( $attributes );
+
+		if ( '' !== $gradientBorder['class'] ) {
+			$classes[] = $gradientBorder['class'];
+
+			self::pushGradientBorder( $gradientBorder['class'], $gradientBorder['rules'] );
+		}
+
 		return [
-			'classes'         => $classes,
-			'style'           => $styleString,
-			'id'              => $id,
-			'responsiveCss'   => '',
-			'responsiveClass' => $responsive['class'],
-			'responsiveRules' => $responsive['rules'],
-			'statesClass'     => $states['class'],
-			'statesRules'     => $states['rules'],
+			'classes'             => $classes,
+			'style'               => $styleString,
+			'id'                  => $id,
+			'responsiveCss'       => '',
+			'responsiveClass'     => $responsive['class'],
+			'responsiveRules'     => $responsive['rules'],
+			'statesClass'         => $states['class'],
+			'statesRules'         => $states['rules'],
+			'gradientBorderClass' => $gradientBorder['class'],
+			'gradientBorderRules' => $gradientBorder['rules'],
 		];
 	}
 
@@ -236,6 +249,104 @@ class BlockSupports
 		} catch ( \Throwable $e ) {
 			// See pushResponsive() — same drop-silently rationale.
 		}
+	}
+
+	/**
+	 * Mirror of {@see pushResponsive} for gradient borders (#490).
+	 *
+	 * @since 1.1.0
+	 */
+	public static function pushGradientBorder( string $scope, string $rules ): void
+	{
+		if ( '' === $scope || '' === $rules ) {
+			return;
+		}
+
+		if ( ! function_exists( 'app' ) ) {
+			return;
+		}
+
+		try {
+			app( GradientBorderCssAccumulator::class )->push( $scope, $rules );
+		} catch ( \Throwable $e ) {
+			// See pushResponsive() — same drop-silently rationale.
+		}
+	}
+
+	/**
+	 * Apply the gradient border feature to an already-rendered block's
+	 * HTML output (#490).
+	 *
+	 * Static blocks (Blade partials) get gradient border handling for
+	 * free via {@see wrapperAttrs} → {@see compile}. Dynamic blocks
+	 * (subclasses of `DynamicBlock`) render their own HTML and never
+	 * call into the compile pipeline — so the renderer pipes their
+	 * output through this method to push the scope's CSS rule into the
+	 * accumulator AND stamp the scope class onto the first opening
+	 * tag.
+	 *
+	 * No-op when the block carries no gradient border configuration at
+	 * any cascade level. Idempotent on the class injection — calling
+	 * twice with the same scope is harmless (the class is deduped at
+	 * the wrapper level by the consumer).
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param  string               $html       Block's pre-rendered HTML.
+	 * @param  array<string, mixed> $attributes Block's attribute payload
+	 *                                          (the same shape `compile`
+	 *                                          would receive).
+	 */
+	public static function applyGradientBorder( string $html, array $attributes ): string
+	{
+		if ( '' === $html ) {
+			return $html;
+		}
+
+		$compiled = self::compileGradientBorder( $attributes );
+
+		if ( '' === $compiled['class'] || '' === $compiled['rules'] ) {
+			return $html;
+		}
+
+		self::pushGradientBorder( $compiled['class'], $compiled['rules'] );
+
+		return self::injectClassIntoFirstTag( $html, $compiled['class'] );
+	}
+
+	/**
+	 * Merge a single class token into the `class` attribute of the
+	 * first opening tag in `$html`. Adds the attribute when missing.
+	 * Returns the input unchanged when no opening tag is found (broken
+	 * markup, comment-only output, etc.).
+	 *
+	 * @since 1.1.0
+	 */
+	protected static function injectClassIntoFirstTag( string $html, string $class ): string
+	{
+		// Existing `class="..."` on the first opening tag — append.
+		if ( 1 === preg_match( '/^(\s*<[a-zA-Z][^>]*?)\bclass="([^"]*)"([^>]*>)/s', $html, $matches ) ) {
+			$existing = trim( $matches[2] );
+			$tokens   = '' === $existing ? [] : preg_split( '/\s+/', $existing );
+
+			if ( false !== $tokens && in_array( $class, $tokens, true ) ) {
+				return $html;
+			}
+
+			$nextClass = '' === $existing ? $class : $existing . ' ' . $class;
+			$prefix    = $matches[1] . 'class="' . $nextClass . '"' . $matches[3];
+
+			return $prefix . substr( $html, strlen( $matches[0] ) );
+		}
+
+		// No `class` attribute — add one to the first opening tag.
+		if ( 1 === preg_match( '/^(\s*<[a-zA-Z][^>]*?)(\/?>)/s', $html, $matches ) ) {
+			$prefix = $matches[1] . ' class="' . $class . '"' . $matches[2];
+
+			return $prefix . substr( $html, strlen( $matches[0] ) );
+		}
+
+		return $html;
 	}
 
 	/**
@@ -469,6 +580,91 @@ class BlockSupports
 			},
 			$css
 		);
+	}
+
+	/**
+	 * Compile the `style.border` gradient payload into a `{class, rules}`
+	 * pair the wrapper merges in and the accumulator dedupes (#490).
+	 *
+	 * Returns `{class: '', rules: ''}` when no gradient configuration
+	 * is present at any cascade level — callers should treat empty as
+	 * a signal to skip both wrapper merge and accumulator push.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param  array<string, mixed>  $attributes
+	 *
+	 * @return array{class: string, rules: string}
+	 */
+	protected static function compileGradientBorder( array $attributes ): array
+	{
+		$payload = GradientBorderResolver::resolve( $attributes );
+
+		if ( null === $payload ) {
+			return [ 'class' => '', 'rules' => '' ];
+		}
+
+		try {
+			$states      = self::resolveStateRegistry();
+			$breakpoints = function_exists( 'app' )
+				? self::resolveRegistry()
+				: BreakpointRegistry::fromLayers();
+
+			$emitter = new GradientBorderEmitter( $states, $breakpoints );
+
+			$scopeClass = self::resolveGradientBorderScopeClass( $attributes, $payload );
+			$scope      = '.' . $scopeClass;
+			$css        = $emitter->emit( $scope, $payload );
+
+			if ( '' === $css ) {
+				return [ 'class' => '', 'rules' => '' ];
+			}
+
+			return [
+				'class' => $scopeClass,
+				'rules' => $css,
+			];
+		} catch ( \Throwable $e ) {
+			return [ 'class' => '', 'rules' => '' ];
+		}
+	}
+
+	/**
+	 * Prefer the editor-minted `style.border._gradientScopeId` so the
+	 * editor preview and the server-rendered output target the same
+	 * scope class. Falls back to a content-derived hash when no id was
+	 * stamped (legacy content, hand-authored blocks, server-only
+	 * pipelines).
+	 *
+	 * The minted id is interpolated into both the `<style>` block and
+	 * the wrapper's `class` attribute, so its content has to be a
+	 * safe identifier-style token — same defense-in-depth check the
+	 * state pipeline runs on its `_scopeId`.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param  array<string, mixed>  $attributes
+	 * @param  array<string, mixed>  $payload
+	 */
+	protected static function resolveGradientBorderScopeClass( array $attributes, array $payload ): string
+	{
+		$border = $attributes['style']['border'] ?? null;
+
+		if ( is_array( $border ) && isset( $border['_gradientScopeId'] ) && is_string( $border['_gradientScopeId'] ) ) {
+			$candidate = $border['_gradientScopeId'];
+
+			if ( 1 === preg_match( '/^[a-z0-9][a-z0-9_-]*$/i', $candidate ) && strlen( $candidate ) <= 64 ) {
+				return 've-gb-' . $candidate;
+			}
+		}
+
+		$hash = substr(
+			hash( 'xxh3', (string) json_encode( $payload ) ),
+			0,
+			10
+		);
+
+		return 've-gb-' . $hash;
 	}
 
 	/**

--- a/packages/visual-editor-renderer-blade/src/Support/BlockSupports.php
+++ b/packages/visual-editor-renderer-blade/src/Support/BlockSupports.php
@@ -324,17 +324,23 @@ class BlockSupports
 	 */
 	protected static function injectClassIntoFirstTag( string $html, string $class ): string
 	{
-		// Existing `class="..."` on the first opening tag — append.
-		if ( 1 === preg_match( '/^(\s*<[a-zA-Z][^>]*?)\bclass="([^"]*)"([^>]*>)/s', $html, $matches ) ) {
-			$existing = trim( $matches[2] );
-			$tokens   = '' === $existing ? [] : preg_split( '/\s+/', $existing );
+		// Existing class attribute on the first opening tag — append.
+		// Case-insensitive (`/i`) so `CLASS` / `Class` variants are
+		// still detected, and the quote-style is captured as a back-
+		// reference so single AND double quotes are merged (instead of
+		// either being missed → the injector falls through to the
+		// add-new-attribute branch and writes a SECOND `class`
+		// attribute, which is invalid HTML).
+		if ( 1 === preg_match( '/^(\s*<[a-zA-Z][^>]*?)\bclass\s*=\s*(["\'])(.*?)\2([^>]*>)/is', $html, $matches ) ) {
+			$existing = trim( $matches[3] );
+			$tokens   = '' === $existing ? [] : ( preg_split( '/\s+/', $existing ) ?: [] );
 
-			if ( false !== $tokens && in_array( $class, $tokens, true ) ) {
+			if ( in_array( $class, $tokens, true ) ) {
 				return $html;
 			}
 
 			$nextClass = '' === $existing ? $class : $existing . ' ' . $class;
-			$prefix    = $matches[1] . 'class="' . $nextClass . '"' . $matches[3];
+			$prefix    = $matches[1] . 'class="' . $nextClass . '"' . $matches[4];
 
 			return $prefix . substr( $html, strlen( $matches[0] ) );
 		}

--- a/packages/visual-editor-renderer-blade/src/View/Components/BlocksComponent.php
+++ b/packages/visual-editor-renderer-blade/src/View/Components/BlocksComponent.php
@@ -34,6 +34,7 @@ use ArtisanPackUI\VisualEditor\SiteEditor\NavigationBlockRefResolver;
 use ArtisanPackUI\VisualEditorRendererBlade\BlockRenderer;
 use ArtisanPackUI\VisualEditorRendererBlade\Resolvers\BreadcrumbsResolver;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\GlobalStylesEmissionResolver;
+use ArtisanPackUI\VisualEditorRendererBlade\Services\GradientBorderCssAccumulator;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\ResponsiveCssAccumulator;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\StateCssAccumulator;
 use Illuminate\Contracts\View\View;
@@ -67,6 +68,7 @@ class BlocksComponent extends Component
 		protected GlobalStylesEmissionTracker $emissionTracker,
 		protected ResponsiveCssAccumulator $responsiveAccumulator,
 		protected StateCssAccumulator $stateAccumulator,
+		protected GradientBorderCssAccumulator $gradientBorderAccumulator,
 		mixed $tree = null,
 		?string $defaultTheme = null,
 		mixed $post = null,
@@ -157,15 +159,17 @@ class BlocksComponent extends Component
 		// `BlockSupports::pushResponsive()` side-effect has happened
 		// by the time we drain the accumulator. The drained block
 		// is then prepended to the output by the view template.
-		$html          = $this->renderer->render( $this->tree );
-		$responsiveCss = $this->responsiveAccumulator->flush();
-		$statesCss     = $this->stateAccumulator->flush();
+		$html               = $this->renderer->render( $this->tree );
+		$responsiveCss      = $this->responsiveAccumulator->flush();
+		$statesCss          = $this->stateAccumulator->flush();
+		$gradientBordersCss = $this->gradientBorderAccumulator->flush();
 
 		return view( 'visual-editor-renderer-blade::components.blocks', [
-			'html'            => $html,
-			'globalStylesCss' => $this->resolveGlobalStylesCss(),
-			'responsiveCss'   => $responsiveCss,
-			'statesCss'       => $statesCss,
+			'html'               => $html,
+			'globalStylesCss'    => $this->resolveGlobalStylesCss(),
+			'responsiveCss'      => $responsiveCss,
+			'statesCss'          => $statesCss,
+			'gradientBordersCss' => $gradientBordersCss,
 		] );
 	}
 

--- a/packages/visual-editor-renderer-blade/src/View/Components/TemplateComponent.php
+++ b/packages/visual-editor-renderer-blade/src/View/Components/TemplateComponent.php
@@ -35,6 +35,7 @@ use ArtisanPackUI\VisualEditor\SiteEditor\NavigationBlockRefResolver;
 use ArtisanPackUI\VisualEditor\Services\GlobalStylesEmissionTracker;
 use ArtisanPackUI\VisualEditorRendererBlade\BlockRenderer;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\GlobalStylesEmissionResolver;
+use ArtisanPackUI\VisualEditorRendererBlade\Services\GradientBorderCssAccumulator;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\ResponsiveCssAccumulator;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\StateCssAccumulator;
 use Illuminate\Contracts\Foundation\Application;
@@ -76,6 +77,7 @@ class TemplateComponent extends Component
 		protected GlobalStylesEmissionTracker $emissionTracker,
 		protected ResponsiveCssAccumulator $responsiveAccumulator,
 		protected StateCssAccumulator $stateAccumulator,
+		protected GradientBorderCssAccumulator $gradientBorderAccumulator,
 		string $slug,
 		?string $theme = null,
 	) {
@@ -115,20 +117,22 @@ class TemplateComponent extends Component
 		// where `$this->html` is assigned), so every block partial
 		// has had a chance to push its responsive rules in by now.
 		// See BlocksComponent::render() for the same pattern.
-		$responsiveCss = $this->responsiveAccumulator->flush();
-		$statesCss     = $this->stateAccumulator->flush();
+		$responsiveCss      = $this->responsiveAccumulator->flush();
+		$statesCss          = $this->stateAccumulator->flush();
+		$gradientBordersCss = $this->gradientBorderAccumulator->flush();
 
 		return view( 'visual-editor-renderer-blade::components.template', [
-			'slug'            => $this->slug,
-			'theme'           => $this->theme,
-			'matchedSlug'     => $this->matchedSlug,
-			'fallbackChain'   => $this->fallbackChain,
-			'resolutionError' => $this->resolutionError,
-			'inDev'           => ! $this->app->environment( 'production' ),
-			'html'            => $this->html,
-			'globalStylesCss' => $this->resolveGlobalStylesCss(),
-			'responsiveCss'   => $responsiveCss,
-			'statesCss'       => $statesCss,
+			'slug'               => $this->slug,
+			'theme'              => $this->theme,
+			'matchedSlug'        => $this->matchedSlug,
+			'fallbackChain'      => $this->fallbackChain,
+			'resolutionError'    => $this->resolutionError,
+			'inDev'              => ! $this->app->environment( 'production' ),
+			'html'               => $this->html,
+			'globalStylesCss'    => $this->resolveGlobalStylesCss(),
+			'responsiveCss'      => $responsiveCss,
+			'statesCss'          => $statesCss,
+			'gradientBordersCss' => $gradientBordersCss,
 		] );
 	}
 

--- a/packages/visual-editor-renderer-blade/src/VisualEditorRendererBladeServiceProvider.php
+++ b/packages/visual-editor-renderer-blade/src/VisualEditorRendererBladeServiceProvider.php
@@ -28,6 +28,7 @@ use ArtisanPackUI\VisualEditorRendererBlade\Resolvers\LoginoutResolver;
 use ArtisanPackUI\VisualEditorRendererBlade\Resolvers\SiteMetaResolver;
 use ArtisanPackUI\VisualEditorRendererBlade\Responsive\ResponsiveClassResolver;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\GlobalStylesEmissionResolver;
+use ArtisanPackUI\VisualEditorRendererBlade\Services\GradientBorderCssAccumulator;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\NavigationOverlayTracker;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\ResponsiveCssAccumulator;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\StateCssAccumulator;
@@ -124,6 +125,14 @@ class VisualEditorRendererBladeServiceProvider extends ServiceProvider
 		// responsive accumulator above.
 		$this->app->scoped( StateCssAccumulator::class, function () {
 			return new StateCssAccumulator();
+		} );
+
+		// #490 — sibling accumulator for the gradient border feature's
+		// `<style data-ve-gradient-borders>` block. Same scoped lifetime
+		// rationale as the two above; the rules cover the wrapper +
+		// `::before` mask pseudo a gradient border installs.
+		$this->app->scoped( GradientBorderCssAccumulator::class, function () {
+			return new GradientBorderCssAccumulator();
 		} );
 	}
 

--- a/packages/visual-editor-renderer-blade/tests/Unit/BlockSupportsGradientBorderTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Unit/BlockSupportsGradientBorderTest.php
@@ -92,9 +92,9 @@ describe( 'BlockSupports::compile (gradient border)', function (): void {
 	} );
 
 	it( 'survives even when only a per-state override is present (no idle)', function (): void {
-		// Border-radius support flag set but no idle gradient — the
-		// hover still gets emitted, idle ::before falls back to
-		// `transparent` so the cascade has a base.
+		// Gradient border configured only on hover (no idle gradient) —
+		// the hover still gets emitted, idle ::before falls back to
+		// `transparent` so the cascade has a base to override.
 		$result = BlockSupports::compile( [
 			'states' => [
 				'style.border.gradient' => [ 'hover' => 'accent-glow' ],

--- a/packages/visual-editor-renderer-blade/tests/Unit/BlockSupportsGradientBorderTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Unit/BlockSupportsGradientBorderTest.php
@@ -1,0 +1,172 @@
+<?php
+
+/**
+ * Integration tests for the gradient-border slot in
+ * {@see BlockSupports::compile} (#490).
+ *
+ * Verifies the compile() pipeline wires the resolver + emitter
+ * correctly: a wrapper class is added, the scope class is content-
+ * stable, and the rules end up on the accumulator-bound return key.
+ *
+ * @since 1.1.0
+ */
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditorRendererBlade\Support\BlockSupports;
+
+describe( 'BlockSupports::compile (gradient border)', function (): void {
+	it( 'does nothing when no gradient is configured', function (): void {
+		$result = BlockSupports::compile( [
+			'style' => [ 'border' => [ 'width' => '2px', 'color' => '#000' ] ],
+		] );
+
+		expect( $result['gradientBorderClass'] )->toBe( '' );
+		expect( $result['gradientBorderRules'] )->toBe( '' );
+		expect( $result['classes'] )->not->toContain( 'ApplyGradientBorder' );
+	} );
+
+	it( 'attaches a `ve-gb-*` scope class when a gradient is set', function (): void {
+		$result = BlockSupports::compile( [
+			'style' => [ 'border' => [ 'gradient' => 'primary-glow' ] ],
+		] );
+
+		expect( $result['gradientBorderClass'] )->toStartWith( 've-gb-' );
+		expect( $result['classes'] )->toContain( $result['gradientBorderClass'] );
+		expect( $result['gradientBorderRules'] )
+			->toContain( 'var(--wp--preset--gradient--primary-glow)' );
+	} );
+
+	it( 'produces a content-stable scope class for the same payload', function (): void {
+		$payload = [
+			'style' => [ 'border' => [ 'gradient' => 'primary-glow', 'width' => '2px' ] ],
+		];
+
+		$a = BlockSupports::compile( $payload );
+		$b = BlockSupports::compile( $payload );
+
+		expect( $a['gradientBorderClass'] )->toBe( $b['gradientBorderClass'] );
+	} );
+
+	it( 'produces different scope classes for different payloads', function (): void {
+		$a = BlockSupports::compile( [
+			'style' => [ 'border' => [ 'gradient' => 'primary-glow' ] ],
+		] );
+
+		$b = BlockSupports::compile( [
+			'style' => [ 'border' => [ 'gradient' => 'accent-glow' ] ],
+		] );
+
+		expect( $a['gradientBorderClass'] )->not->toBe( $b['gradientBorderClass'] );
+	} );
+
+	it( 'composes with per-state overrides from attributes.states', function (): void {
+		$result = BlockSupports::compile( [
+			'style'  => [ 'border' => [ 'gradient' => 'primary-glow' ] ],
+			'states' => [
+				'style.border.gradient' => [ 'hover' => 'accent-glow' ],
+			],
+		] );
+
+		expect( $result['gradientBorderRules'] )
+			->toContain( 'var(--wp--preset--gradient--primary-glow)' );
+		expect( $result['gradientBorderRules'] )
+			->toContain( 'var(--wp--preset--gradient--accent-glow)' );
+		// Hover wrapped in @media (hover: hover) so touch devices
+		// don't sticky-state.
+		expect( $result['gradientBorderRules'] )->toContain( '@media (hover: hover)' );
+	} );
+
+	it( 'composes with per-breakpoint overrides from attributes.responsive', function (): void {
+		$result = BlockSupports::compile( [
+			'style'      => [ 'border' => [ 'gradient' => 'primary-glow' ] ],
+			'responsive' => [
+				'style.border.gradient' => [ 'md' => 'vertical' ],
+			],
+		] );
+
+		expect( $result['gradientBorderRules'] )
+			->toContain( '@media (min-width:768px)' );
+		expect( $result['gradientBorderRules'] )
+			->toContain( 'var(--wp--preset--gradient--vertical)' );
+	} );
+
+	it( 'survives even when only a per-state override is present (no idle)', function (): void {
+		// Border-radius support flag set but no idle gradient — the
+		// hover still gets emitted, idle ::before falls back to
+		// `transparent` so the cascade has a base.
+		$result = BlockSupports::compile( [
+			'states' => [
+				'style.border.gradient' => [ 'hover' => 'accent-glow' ],
+			],
+		] );
+
+		expect( $result['gradientBorderClass'] )->toStartWith( 've-gb-' );
+		expect( $result['gradientBorderRules'] )->toContain( 'background:transparent' );
+		expect( $result['gradientBorderRules'] )
+			->toContain( 'var(--wp--preset--gradient--accent-glow)' );
+	} );
+} );
+
+describe( 'BlockSupports::applyGradientBorder', function (): void {
+	it( 'returns the HTML unchanged when no gradient is configured', function (): void {
+		$html       = '<div class="wp-block-foo">child</div>';
+		$attributes = [
+			'style' => [ 'border' => [ 'color' => '#000', 'width' => '2px' ] ],
+		];
+
+		expect( BlockSupports::applyGradientBorder( $html, $attributes ) )->toBe( $html );
+	} );
+
+	it( 'injects the scope class onto an existing class attribute', function (): void {
+		$html       = '<div class="wp-block-icon">inner</div>';
+		$attributes = [
+			'style' => [ 'border' => [ 'gradient' => 'primary-glow' ] ],
+		];
+
+		$out = BlockSupports::applyGradientBorder( $html, $attributes );
+
+		expect( $out )->toContain( 'class="wp-block-icon ve-gb-' );
+		expect( $out )->toContain( '>inner</div>' );
+	} );
+
+	it( 'adds a class attribute when the first tag has none', function (): void {
+		$html       = '<div data-x="y">inner</div>';
+		$attributes = [
+			'style' => [ 'border' => [ 'gradient' => 'primary-glow' ] ],
+		];
+
+		$out = BlockSupports::applyGradientBorder( $html, $attributes );
+
+		expect( $out )->toMatch( '/<div [^>]*class="ve-gb-[a-z0-9]+"/' );
+		expect( $out )->toContain( 'data-x="y"' );
+	} );
+
+	it( 'is idempotent — calling twice does not double the scope class', function (): void {
+		$html       = '<div class="wp-block-icon">inner</div>';
+		$attributes = [
+			'style' => [ 'border' => [ 'gradient' => 'primary-glow' ] ],
+		];
+
+		$once  = BlockSupports::applyGradientBorder( $html, $attributes );
+		$twice = BlockSupports::applyGradientBorder( $once, $attributes );
+
+		expect( $twice )->toBe( $once );
+	} );
+
+	it( 'respects an editor-minted `_gradientScopeId` so editor and renderer agree', function (): void {
+		$html       = '<div class="wp-block-icon">inner</div>';
+		$attributes = [
+			'style' => [
+				'border' => [
+					'gradient'         => 'primary-glow',
+					'_gradientScopeId' => 'pn8qudcya',
+				],
+			],
+		];
+
+		$out = BlockSupports::applyGradientBorder( $html, $attributes );
+
+		expect( $out )->toContain( 've-gb-pn8qudcya' );
+	} );
+} );

--- a/packages/visual-editor-renderer-blade/tests/Unit/BlockSupportsGradientBorderTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Unit/BlockSupportsGradientBorderTest.php
@@ -154,6 +154,35 @@ describe( 'BlockSupports::applyGradientBorder', function (): void {
 		expect( $twice )->toBe( $once );
 	} );
 
+	it( 'merges into a single-quoted class attribute instead of duplicating it', function (): void {
+		$html       = "<div class='wp-block-icon'>inner</div>";
+		$attributes = [
+			'style' => [ 'border' => [ 'gradient' => 'primary-glow' ] ],
+		];
+
+		$out = BlockSupports::applyGradientBorder( $html, $attributes );
+
+		// Token order: existing first, then injected; quotes normalised
+		// to double on rewrite so downstream parsers don't trip on the
+		// mixed-quote shape.
+		expect( $out )->toMatch( '/<div class="wp-block-icon ve-gb-[a-z0-9]+">inner<\/div>/' );
+		// Guard against the regression where a second `class` attribute
+		// gets appended because the regex missed the single-quoted form.
+		expect( substr_count( $out, 'class=' ) )->toBe( 1 );
+	} );
+
+	it( 'handles case-variant `CLASS=` attribute names', function (): void {
+		$html       = '<div CLASS="wp-block-icon">inner</div>';
+		$attributes = [
+			'style' => [ 'border' => [ 'gradient' => 'primary-glow' ] ],
+		];
+
+		$out = BlockSupports::applyGradientBorder( $html, $attributes );
+
+		expect( substr_count( strtolower( $out ), 'class=' ) )->toBe( 1 );
+		expect( $out )->toMatch( '/wp-block-icon ve-gb-[a-z0-9]+/' );
+	} );
+
 	it( 'respects an editor-minted `_gradientScopeId` so editor and renderer agree', function (): void {
 		$html       = '<div class="wp-block-icon">inner</div>';
 		$attributes = [

--- a/packages/visual-editor-renderer-blade/tests/Unit/BlockSupportsTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Unit/BlockSupportsTest.php
@@ -445,14 +445,16 @@ describe( 'BlockSupports::compile (composition)', function (): void {
 		$result = BlockSupports::compile( [] );
 
 		expect( $result )->toBe( [
-			'classes'         => [],
-			'style'           => '',
-			'id'              => null,
-			'responsiveCss'   => '',
-			'responsiveClass' => '',
-			'responsiveRules' => '',
-			'statesClass'     => '',
-			'statesRules'     => '',
+			'classes'             => [],
+			'style'               => '',
+			'id'                  => null,
+			'responsiveCss'       => '',
+			'responsiveClass'     => '',
+			'responsiveRules'     => '',
+			'statesClass'         => '',
+			'statesRules'         => '',
+			'gradientBorderClass' => '',
+			'gradientBorderRules' => '',
 		] );
 	} );
 

--- a/resources/js/visual-editor/blocks/accordion-body/block.json
+++ b/resources/js/visual-editor/blocks/accordion-body/block.json
@@ -5,16 +5,24 @@
     "title": "Accordion Body",
     "category": "design",
     "description": "The expandable content of an accordion panel.",
-    "parent": ["artisanpack/accordion"],
+    "parent": [
+        "artisanpack/accordion"
+    ],
     "textdomain": "artisanpack-visual-editor",
     "attributes": {},
     "supports": {
-        "align": ["wide", "full"],
+        "align": [
+            "wide",
+            "full"
+        ],
         "ariaLabel": true,
         "className": true,
         "html": false,
         "spacing": {
-            "margin": ["top", "bottom"],
+            "margin": [
+                "top",
+                "bottom"
+            ],
             "padding": true,
             "blockGap": true,
             "__experimentalDefaultControls": {
@@ -41,7 +49,8 @@
                 "radius": true,
                 "style": true,
                 "width": true
-            }
+            },
+            "gradient": true
         },
         "typography": {
             "fontSize": true,

--- a/resources/js/visual-editor/blocks/accordion-title/block.json
+++ b/resources/js/visual-editor/blocks/accordion-title/block.json
@@ -5,16 +5,24 @@
     "title": "Accordion Title",
     "category": "design",
     "description": "The clickable header of an accordion panel.",
-    "parent": ["artisanpack/accordion"],
+    "parent": [
+        "artisanpack/accordion"
+    ],
     "textdomain": "artisanpack-visual-editor",
     "attributes": {},
     "supports": {
-        "align": ["wide", "full"],
+        "align": [
+            "wide",
+            "full"
+        ],
         "ariaLabel": true,
         "className": true,
         "html": false,
         "spacing": {
-            "margin": ["top", "bottom"],
+            "margin": [
+                "top",
+                "bottom"
+            ],
             "padding": true,
             "blockGap": true,
             "__experimentalDefaultControls": {
@@ -41,7 +49,8 @@
                 "radius": true,
                 "style": true,
                 "width": true
-            }
+            },
+            "gradient": true
         },
         "typography": {
             "fontSize": true,

--- a/resources/js/visual-editor/blocks/accordion/block.json
+++ b/resources/js/visual-editor/blocks/accordion/block.json
@@ -5,8 +5,14 @@
     "title": "Accordion Panel",
     "category": "design",
     "description": "Add an accordion panel containing a title and a body.",
-    "keywords": ["accordion", "collapsible", "panel"],
-    "parent": ["artisanpack/accordions"],
+    "keywords": [
+        "accordion",
+        "collapsible",
+        "panel"
+    ],
+    "parent": [
+        "artisanpack/accordions"
+    ],
     "textdomain": "artisanpack-visual-editor",
     "attributes": {
         "panelId": {
@@ -15,17 +21,26 @@
         },
         "panelIcon": {
             "type": "string",
-            "enum": ["plus-minus", "arrows"],
+            "enum": [
+                "plus-minus",
+                "arrows"
+            ],
             "default": "plus-minus"
         }
     },
     "supports": {
-        "align": ["wide", "full"],
+        "align": [
+            "wide",
+            "full"
+        ],
         "ariaLabel": true,
         "className": true,
         "html": false,
         "spacing": {
-            "margin": ["top", "bottom"],
+            "margin": [
+                "top",
+                "bottom"
+            ],
             "padding": true,
             "blockGap": true,
             "__experimentalDefaultControls": {
@@ -52,7 +67,8 @@
                 "radius": true,
                 "style": true,
                 "width": true
-            }
+            },
+            "gradient": true
         },
         "typography": {
             "fontSize": true,

--- a/resources/js/visual-editor/blocks/accordions/block.json
+++ b/resources/js/visual-editor/blocks/accordions/block.json
@@ -5,16 +5,27 @@
     "title": "Accordions",
     "category": "design",
     "description": "Group one or more accordion panels into a collapsible section.",
-    "keywords": ["accordion", "accordions", "collapsible", "faq"],
+    "keywords": [
+        "accordion",
+        "accordions",
+        "collapsible",
+        "faq"
+    ],
     "textdomain": "artisanpack-visual-editor",
     "attributes": {},
     "supports": {
-        "align": ["wide", "full"],
+        "align": [
+            "wide",
+            "full"
+        ],
         "ariaLabel": true,
         "className": true,
         "html": false,
         "spacing": {
-            "margin": ["top", "bottom"],
+            "margin": [
+                "top",
+                "bottom"
+            ],
             "padding": true,
             "blockGap": true,
             "__experimentalDefaultControls": {
@@ -33,7 +44,8 @@
                 "radius": true,
                 "style": true,
                 "width": true
-            }
+            },
+            "gradient": true
         },
         "typography": {
             "fontSize": true,

--- a/resources/js/visual-editor/blocks/archives/block.json
+++ b/resources/js/visual-editor/blocks/archives/block.json
@@ -65,7 +65,8 @@
             "radius": true,
             "color": true,
             "width": true,
-            "style": true
+            "style": true,
+            "gradient": true
         }
     }
 }

--- a/resources/js/visual-editor/blocks/avatar/block.json
+++ b/resources/js/visual-editor/blocks/avatar/block.json
@@ -51,7 +51,8 @@
             "style": true,
             "__experimentalDefaultControls": {
                 "radius": true
-            }
+            },
+            "gradient": true
         },
         "color": {
             "text": false,

--- a/resources/js/visual-editor/blocks/breadcrumbs/block.json
+++ b/resources/js/visual-editor/blocks/breadcrumbs/block.json
@@ -5,12 +5,21 @@
     "title": "Breadcrumbs",
     "category": "theme",
     "description": "Display a breadcrumbs trail so visitors know where they are on your site.",
-    "keywords": ["breadcrumbs", "navigation", "trail"],
+    "keywords": [
+        "breadcrumbs",
+        "navigation",
+        "trail"
+    ],
     "textdomain": "artisanpack-visual-editor",
     "attributes": {
         "separatorIcon": {
             "type": "string",
-            "enum": ["arrow-right", "chevron-right", "chevron-double-right", "long-arrow-right"],
+            "enum": [
+                "arrow-right",
+                "chevron-right",
+                "chevron-double-right",
+                "long-arrow-right"
+            ],
             "default": "chevron-right"
         },
         "breadcrumbsSchema": {
@@ -19,12 +28,18 @@
         }
     },
     "supports": {
-        "align": ["wide", "full"],
+        "align": [
+            "wide",
+            "full"
+        ],
         "ariaLabel": true,
         "className": true,
         "html": false,
         "spacing": {
-            "margin": ["top", "bottom"],
+            "margin": [
+                "top",
+                "bottom"
+            ],
             "padding": true,
             "blockGap": true,
             "__experimentalDefaultControls": {
@@ -51,7 +66,8 @@
                 "radius": true,
                 "style": true,
                 "width": true
-            }
+            },
+            "gradient": true
         },
         "typography": {
             "fontSize": true,

--- a/resources/js/visual-editor/blocks/button/block.json
+++ b/resources/js/visual-editor/blocks/button/block.json
@@ -4,14 +4,21 @@
     "name": "artisanpack/button",
     "title": "Button",
     "category": "design",
-    "parent": [ "artisanpack/buttons" ],
+    "parent": [
+        "artisanpack/buttons"
+    ],
     "description": "Prompt visitors to take action with a button-style link.",
-    "keywords": [ "link" ],
+    "keywords": [
+        "link"
+    ],
     "textdomain": "artisanpack-visual-editor",
     "attributes": {
         "tagName": {
             "type": "string",
-            "enum": [ "a", "button" ],
+            "enum": [
+                "a",
+                "button"
+            ],
             "default": "a"
         },
         "type": {
@@ -80,7 +87,9 @@
         },
         "dimensions": {
             "width": true,
-            "__experimentalSkipSerialization": [ "width" ],
+            "__experimentalSkipSerialization": [
+                "width"
+            ],
             "__experimentalDefaultControls": {
                 "width": true
             }
@@ -117,7 +126,10 @@
         },
         "spacing": {
             "__experimentalSkipSerialization": true,
-            "padding": [ "horizontal", "vertical" ],
+            "padding": [
+                "horizontal",
+                "vertical"
+            ],
             "__experimentalDefaultControls": {
                 "padding": true
             }
@@ -133,7 +145,8 @@
                 "radius": true,
                 "style": true,
                 "width": true
-            }
+            },
+            "gradient": true
         },
         "interactivity": {
             "clientNavigation": true
@@ -158,8 +171,15 @@
         }
     },
     "styles": [
-        { "name": "fill", "label": "Fill", "isDefault": true },
-        { "name": "outline", "label": "Outline" }
+        {
+            "name": "fill",
+            "label": "Fill",
+            "isDefault": true
+        },
+        {
+            "name": "outline",
+            "label": "Outline"
+        }
     ],
     "editorStyle": "wp-block-button-editor",
     "style": "wp-block-button",

--- a/resources/js/visual-editor/blocks/buttons/block.json
+++ b/resources/js/visual-editor/blocks/buttons/block.json
@@ -4,13 +4,20 @@
     "name": "artisanpack/buttons",
     "title": "Buttons",
     "category": "design",
-    "allowedBlocks": [ "artisanpack/button" ],
+    "allowedBlocks": [
+        "artisanpack/button"
+    ],
     "description": "Prompt visitors to take action with a group of button-style links.",
-    "keywords": [ "link" ],
+    "keywords": [
+        "link"
+    ],
     "textdomain": "artisanpack-visual-editor",
     "supports": {
         "anchor": true,
-        "align": [ "wide", "full" ],
+        "align": [
+            "wide",
+            "full"
+        ],
         "html": false,
         "__experimentalExposeControlsToChildren": true,
         "color": {
@@ -21,9 +28,15 @@
             }
         },
         "spacing": {
-            "blockGap": [ "horizontal", "vertical" ],
+            "blockGap": [
+                "horizontal",
+                "vertical"
+            ],
             "padding": true,
-            "margin": [ "top", "bottom" ],
+            "margin": [
+                "top",
+                "bottom"
+            ],
             "__experimentalDefaultControls": {
                 "blockGap": true
             }
@@ -51,7 +64,8 @@
                 "radius": true,
                 "style": true,
                 "width": true
-            }
+            },
+            "gradient": true
         },
         "layout": {
             "allowSwitching": false,

--- a/resources/js/visual-editor/blocks/categories/block.json
+++ b/resources/js/visual-editor/blocks/categories/block.json
@@ -5,7 +5,9 @@
     "title": "Terms List",
     "category": "widgets",
     "description": "Display a list of all terms of a given taxonomy.",
-    "keywords": [ "categories" ],
+    "keywords": [
+        "categories"
+    ],
     "textdomain": "artisanpack-visual-editor",
     "attributes": {
         "taxonomy": {
@@ -41,7 +43,9 @@
             "default": true
         }
     },
-    "usesContext": [ "enhancedPagination" ],
+    "usesContext": [
+        "enhancedPagination"
+    ],
     "supports": {
         "anchor": true,
         "align": true,
@@ -89,7 +93,8 @@
                 "color": true,
                 "width": true,
                 "style": true
-            }
+            },
+            "gradient": true
         }
     }
 }

--- a/resources/js/visual-editor/blocks/code/block.json
+++ b/resources/js/visual-editor/blocks/code/block.json
@@ -16,7 +16,9 @@
         }
     },
     "supports": {
-        "align": [ "wide" ],
+        "align": [
+            "wide"
+        ],
         "anchor": true,
         "typography": {
             "fontSize": true,
@@ -32,7 +34,10 @@
             }
         },
         "spacing": {
-            "margin": [ "top", "bottom" ],
+            "margin": [
+                "top",
+                "bottom"
+            ],
             "padding": true,
             "__experimentalDefaultControls": {
                 "margin": false,
@@ -47,7 +52,8 @@
             "__experimentalDefaultControls": {
                 "width": true,
                 "color": true
-            }
+            },
+            "gradient": true
         },
         "color": {
             "text": true,

--- a/resources/js/visual-editor/blocks/column/block.json
+++ b/resources/js/visual-editor/blocks/column/block.json
@@ -4,7 +4,9 @@
     "name": "artisanpack/column",
     "title": "Column",
     "category": "design",
-    "parent": [ "artisanpack/columns" ],
+    "parent": [
+        "artisanpack/columns"
+    ],
     "description": "A single column within a columns block.",
     "textdomain": "artisanpack-visual-editor",
     "attributes": {
@@ -15,8 +17,16 @@
             "type": "string"
         },
         "templateLock": {
-            "type": [ "string", "boolean" ],
-            "enum": [ "all", "insert", "contentOnly", false ]
+            "type": [
+                "string",
+                "boolean"
+            ],
+            "enum": [
+                "all",
+                "insert",
+                "contentOnly",
+                false
+            ]
         }
     },
     "supports": {
@@ -53,7 +63,8 @@
                 "radius": true,
                 "style": true,
                 "width": true
-            }
+            },
+            "gradient": true
         },
         "typography": {
             "fontSize": true,

--- a/resources/js/visual-editor/blocks/columns/block.json
+++ b/resources/js/visual-editor/blocks/columns/block.json
@@ -4,7 +4,9 @@
     "name": "artisanpack/columns",
     "title": "Columns",
     "category": "design",
-    "allowedBlocks": [ "artisanpack/column" ],
+    "allowedBlocks": [
+        "artisanpack/column"
+    ],
     "description": "Display content in multiple columns, with blocks added to each column.",
     "textdomain": "artisanpack-visual-editor",
     "attributes": {
@@ -16,8 +18,16 @@
             "default": true
         },
         "templateLock": {
-            "type": [ "string", "boolean" ],
-            "enum": [ "all", "insert", "contentOnly", false ]
+            "type": [
+                "string",
+                "boolean"
+            ],
+            "enum": [
+                "all",
+                "insert",
+                "contentOnly",
+                false
+            ]
         },
         "columnCount": {
             "type": "number"
@@ -25,7 +35,10 @@
     },
     "supports": {
         "anchor": true,
-        "align": [ "wide", "full" ],
+        "align": [
+            "wide",
+            "full"
+        ],
         "html": false,
         "color": {
             "gradients": true,
@@ -40,9 +53,15 @@
         "spacing": {
             "blockGap": {
                 "__experimentalDefault": "2em",
-                "sides": [ "horizontal", "vertical" ]
+                "sides": [
+                    "horizontal",
+                    "vertical"
+                ]
             },
-            "margin": [ "top", "bottom" ],
+            "margin": [
+                "top",
+                "bottom"
+            ],
             "padding": true,
             "__experimentalDefaultControls": {
                 "padding": true,
@@ -68,7 +87,8 @@
                 "radius": true,
                 "style": true,
                 "width": true
-            }
+            },
+            "gradient": true
         },
         "typography": {
             "fontSize": true,

--- a/resources/js/visual-editor/blocks/comment-author-avatar/block.json
+++ b/resources/js/visual-editor/blocks/comment-author-avatar/block.json
@@ -33,7 +33,8 @@
             "radius": true,
             "width": true,
             "color": true,
-            "style": true
+            "style": true,
+            "gradient": true
         }
     }
 }

--- a/resources/js/visual-editor/blocks/comment-author-name/block.json
+++ b/resources/js/visual-editor/blocks/comment-author-name/block.json
@@ -60,7 +60,8 @@
             "radius": true,
             "color": true,
             "width": true,
-            "style": true
+            "style": true,
+            "gradient": true
         }
     }
 }

--- a/resources/js/visual-editor/blocks/comment-content/block.json
+++ b/resources/js/visual-editor/blocks/comment-content/block.json
@@ -31,7 +31,10 @@
             }
         },
         "spacing": {
-            "padding": [ "horizontal", "vertical" ],
+            "padding": [
+                "horizontal",
+                "vertical"
+            ],
             "__experimentalDefaultControls": {
                 "padding": true
             }
@@ -56,7 +59,8 @@
             "radius": true,
             "color": true,
             "width": true,
-            "style": true
+            "style": true,
+            "gradient": true
         }
     }
 }

--- a/resources/js/visual-editor/blocks/comment-date/block.json
+++ b/resources/js/visual-editor/blocks/comment-date/block.json
@@ -58,7 +58,8 @@
             "radius": true,
             "color": true,
             "width": true,
-            "style": true
+            "style": true,
+            "gradient": true
         }
     }
 }

--- a/resources/js/visual-editor/blocks/comment-edit-link/block.json
+++ b/resources/js/visual-editor/blocks/comment-edit-link/block.json
@@ -58,7 +58,8 @@
             "radius": true,
             "color": true,
             "width": true,
-            "style": true
+            "style": true,
+            "gradient": true
         }
     }
 }

--- a/resources/js/visual-editor/blocks/comment-reply-link/block.json
+++ b/resources/js/visual-editor/blocks/comment-reply-link/block.json
@@ -54,7 +54,8 @@
             "radius": true,
             "color": true,
             "width": true,
-            "style": true
+            "style": true,
+            "gradient": true
         }
     }
 }

--- a/resources/js/visual-editor/blocks/comments-number/block.json
+++ b/resources/js/visual-editor/blocks/comments-number/block.json
@@ -5,9 +5,16 @@
     "title": "Comments Number",
     "category": "theme",
     "description": "Display the number of comments on a post with custom singular and plural labels.",
-    "keywords": ["comments", "count", "comments number"],
+    "keywords": [
+        "comments",
+        "count",
+        "comments number"
+    ],
     "textdomain": "artisanpack-visual-editor",
-    "usesContext": ["postId", "postType"],
+    "usesContext": [
+        "postId",
+        "postType"
+    ],
     "attributes": {
         "singularCommentText": {
             "type": "string",
@@ -19,12 +26,18 @@
         }
     },
     "supports": {
-        "align": ["wide", "full"],
+        "align": [
+            "wide",
+            "full"
+        ],
         "ariaLabel": true,
         "className": true,
         "html": false,
         "spacing": {
-            "margin": ["top", "bottom"],
+            "margin": [
+                "top",
+                "bottom"
+            ],
             "padding": true,
             "blockGap": true,
             "__experimentalDefaultControls": {
@@ -51,7 +64,8 @@
                 "radius": true,
                 "style": true,
                 "width": true
-            }
+            },
+            "gradient": true
         },
         "typography": {
             "fontSize": true,

--- a/resources/js/visual-editor/blocks/comments/block.json
+++ b/resources/js/visual-editor/blocks/comments/block.json
@@ -26,7 +26,10 @@
     ],
     "supports": {
         "anchor": true,
-        "align": [ "wide", "full" ],
+        "align": [
+            "wide",
+            "full"
+        ],
         "html": false,
         "color": {
             "gradients": true,
@@ -62,7 +65,8 @@
             "radius": true,
             "color": true,
             "width": true,
-            "style": true
+            "style": true,
+            "gradient": true
         }
     }
 }

--- a/resources/js/visual-editor/blocks/copyright/block.json
+++ b/resources/js/visual-editor/blocks/copyright/block.json
@@ -5,12 +5,20 @@
     "title": "Copyright",
     "category": "theme",
     "description": "Display a copyright line that always shows the current year.",
-    "keywords": ["copyright", "footer", "site"],
+    "keywords": [
+        "copyright",
+        "footer",
+        "site"
+    ],
     "textdomain": "artisanpack-visual-editor",
     "attributes": {
         "copyrightType": {
             "type": "string",
-            "enum": ["icon-text", "icon-only", "text-only"],
+            "enum": [
+                "icon-text",
+                "icon-only",
+                "text-only"
+            ],
             "default": "icon-text"
         },
         "copyrightText": {
@@ -19,12 +27,18 @@
         }
     },
     "supports": {
-        "align": ["wide", "full"],
+        "align": [
+            "wide",
+            "full"
+        ],
         "ariaLabel": true,
         "className": true,
         "html": false,
         "spacing": {
-            "margin": ["top", "bottom"],
+            "margin": [
+                "top",
+                "bottom"
+            ],
             "padding": true,
             "blockGap": true,
             "__experimentalDefaultControls": {
@@ -51,7 +65,8 @@
                 "radius": true,
                 "style": true,
                 "width": true
-            }
+            },
+            "gradient": true
         },
         "typography": {
             "fontSize": true,

--- a/resources/js/visual-editor/blocks/cover/__tests__/edit.test.tsx
+++ b/resources/js/visual-editor/blocks/cover/__tests__/edit.test.tsx
@@ -188,6 +188,15 @@ vi.mock('@wordpress/block-editor', () => {
         }: {
             children?: React.ReactNode;
         }) => <div>{children}</div>,
+        // #490 — cover placeholder now uses ColorGradientControl
+        // (tabbed Color | Gradient) in place of the color-only
+        // ColorPalette. Mock as a passthrough since the placeholder
+        // tests only assert the surrounding TagName.
+        __experimentalColorGradientControl: ({
+            children,
+        }: {
+            children?: React.ReactNode;
+        }) => <div>{children}</div>,
         __experimentalUseMultipleOriginColorsAndGradients: () => ({
             hasColorsOrGradients: false,
         }),

--- a/resources/js/visual-editor/blocks/cover/block.json
+++ b/resources/js/visual-editor/blocks/cover/block.json
@@ -70,8 +70,16 @@
             "default": true
         },
         "templateLock": {
-            "type": ["string", "boolean"],
-            "enum": ["all", "insert", "contentOnly", false]
+            "type": [
+                "string",
+                "boolean"
+            ],
+            "enum": [
+                "all",
+                "insert",
+                "contentOnly",
+                false
+            ]
         },
         "tagName": {
             "type": "string",
@@ -87,7 +95,10 @@
             "attribute": "poster"
         }
     },
-    "usesContext": ["postId", "postType"],
+    "usesContext": [
+        "postId",
+        "postType"
+    ],
     "supports": {
         "anchor": true,
         "align": true,
@@ -95,7 +106,10 @@
         "shadow": true,
         "spacing": {
             "padding": true,
-            "margin": ["top", "bottom"],
+            "margin": [
+                "top",
+                "bottom"
+            ],
             "blockGap": true,
             "__experimentalDefaultControls": {
                 "padding": true,
@@ -112,14 +126,18 @@
                 "radius": true,
                 "style": true,
                 "width": true
-            }
+            },
+            "gradient": true
         },
         "color": {
             "heading": true,
             "text": true,
             "background": false,
-            "__experimentalSkipSerialization": ["gradients"],
-            "enableContrastChecker": false
+            "__experimentalSkipSerialization": [
+                "gradients"
+            ],
+            "enableContrastChecker": false,
+            "gradients": true
         },
         "dimensions": {
             "aspectRatio": true

--- a/resources/js/visual-editor/blocks/cover/edit/index.tsx
+++ b/resources/js/visual-editor/blocks/cover/edit/index.tsx
@@ -17,10 +17,11 @@ import { useEffect, useMemo, useRef } from '@wordpress/element';
 import { Placeholder, Spinner } from '@wordpress/components';
 import {
     withColors,
-    ColorPalette,
     useBlockProps,
     useSettings,
     useInnerBlocksProps,
+    // eslint-disable-next-line camelcase
+    __experimentalColorGradientControl as ColorGradientControl,
     // eslint-disable-next-line camelcase
     __experimentalUseGradient as useGradient,
     store as blockEditorStore,
@@ -249,9 +250,10 @@ function CoverEdit({
             options?: { type?: string }
         ) => void;
     };
-    const { gradientClass, gradientValue } = useGradient() as {
+    const { gradientClass, gradientValue, setGradient } = useGradient() as {
         gradientClass?: string;
         gradientValue?: string;
+        setGradient: (next: string | undefined) => void;
     };
 
     const onSelectMedia = async (
@@ -665,13 +667,22 @@ function CoverEdit({
                         toggleUseFeaturedImage={toggleUseFeaturedImage}
                     >
                         <div className="wp-block-cover__placeholder-background-options">
-                            <ColorPalette
-                                disableCustomColors
-                                value={overlayColor.color}
-                                onChange={onSetOverlayColor}
+                            { /* #490 — surface Color | Gradient tabs here so the
+                                 placeholder matches the full overlay picker
+                                 in `inspector-controls.tsx`. Same control,
+                                 same UX expectation across the editor. */ }
+                            <ColorGradientControl
+                                label={__('Overlay')}
+                                showTitle={false}
+                                colorValue={overlayColor.color}
+                                gradientValue={gradientValue}
+                                onColorChange={onSetOverlayColor}
+                                onGradientChange={setGradient}
                                 clearable={false}
-                                asButtons
-                                aria-label={__('Overlay color')}
+                                enableAlpha={false}
+                                disableCustomColors={true}
+                                disableCustomGradients={false}
+                                __experimentalIsRenderedInSidebar
                             />
                         </div>
                     </CoverPlaceholder>

--- a/resources/js/visual-editor/blocks/details/block.json
+++ b/resources/js/visual-editor/blocks/details/block.json
@@ -49,6 +49,7 @@
         },
         "__experimentalBorder": {
             "color": true,
+            "radius": true,
             "width": true,
             "style": true,
             "gradient": true

--- a/resources/js/visual-editor/blocks/details/block.json
+++ b/resources/js/visual-editor/blocks/details/block.json
@@ -1,95 +1,103 @@
 {
-	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 3,
-	"name": "artisanpack/details",
-	"title": "Details",
-	"category": "text",
-	"description": "Hide and show additional content.",
-	"keywords": [ "summary", "toggle", "disclosure" ],
-	"textdomain": "artisanpack-visual-editor",
-	"attributes": {
-		"showContent": {
-			"type": "boolean",
-			"default": false
-		},
-		"summary": {
-			"type": "rich-text",
-			"source": "rich-text",
-			"selector": "summary",
-			"role": "content"
-		},
-		"name": {
-			"type": "string",
-			"source": "attribute",
-			"attribute": "name",
-			"selector": ".wp-block-details"
-		},
-		"placeholder": {
-			"type": "string"
-		}
-	},
-	"supports": {
-		"__experimentalOnEnter": true,
-		"align": [ "wide", "full" ],
-		"anchor": true,
-		"color": {
-			"gradients": true,
-			"link": true,
-			"__experimentalDefaultControls": {
-				"background": true,
-				"text": true
-			}
-		},
-		"__experimentalBorder": {
-			"color": true,
-			"width": true,
-			"style": true
-		},
-		"html": false,
-		"spacing": {
-			"margin": true,
-			"padding": true,
-			"blockGap": true,
-			"__experimentalDefaultControls": {
-				"margin": false,
-				"padding": false
-			}
-		},
-		"typography": {
-			"fontSize": true,
-			"lineHeight": true,
-			"__experimentalFontFamily": true,
-			"__experimentalFontWeight": true,
-			"__experimentalFontStyle": true,
-			"__experimentalTextTransform": true,
-			"__experimentalTextDecoration": true,
-			"__experimentalLetterSpacing": true,
-			"__experimentalDefaultControls": {
-				"fontSize": true
-			}
-		},
-		"layout": {
-			"allowEditing": false
-		},
-		"interactivity": {
-			"clientNavigation": true
-		},
-		"allowedBlocks": true,
-		"artisanpackStates": {
-			"attributes": [
-				"backgroundColor",
-				"textColor",
-				"color.background",
-				"color.text",
-				"border.color",
-				"border.width",
-				"border.style",
-				"border.radius",
-				"typography.textDecoration",
-				"transition"
-			]
-		}
-	},
-	"editorStyle": "wp-block-details-editor",
-	"style": "wp-block-details"
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "artisanpack/details",
+    "title": "Details",
+    "category": "text",
+    "description": "Hide and show additional content.",
+    "keywords": [
+        "summary",
+        "toggle",
+        "disclosure"
+    ],
+    "textdomain": "artisanpack-visual-editor",
+    "attributes": {
+        "showContent": {
+            "type": "boolean",
+            "default": false
+        },
+        "summary": {
+            "type": "rich-text",
+            "source": "rich-text",
+            "selector": "summary",
+            "role": "content"
+        },
+        "name": {
+            "type": "string",
+            "source": "attribute",
+            "attribute": "name",
+            "selector": ".wp-block-details"
+        },
+        "placeholder": {
+            "type": "string"
+        }
+    },
+    "supports": {
+        "__experimentalOnEnter": true,
+        "align": [
+            "wide",
+            "full"
+        ],
+        "anchor": true,
+        "color": {
+            "gradients": true,
+            "link": true,
+            "__experimentalDefaultControls": {
+                "background": true,
+                "text": true
+            }
+        },
+        "__experimentalBorder": {
+            "color": true,
+            "width": true,
+            "style": true,
+            "gradient": true
+        },
+        "html": false,
+        "spacing": {
+            "margin": true,
+            "padding": true,
+            "blockGap": true,
+            "__experimentalDefaultControls": {
+                "margin": false,
+                "padding": false
+            }
+        },
+        "typography": {
+            "fontSize": true,
+            "lineHeight": true,
+            "__experimentalFontFamily": true,
+            "__experimentalFontWeight": true,
+            "__experimentalFontStyle": true,
+            "__experimentalTextTransform": true,
+            "__experimentalTextDecoration": true,
+            "__experimentalLetterSpacing": true,
+            "__experimentalDefaultControls": {
+                "fontSize": true
+            }
+        },
+        "layout": {
+            "allowEditing": false
+        },
+        "interactivity": {
+            "clientNavigation": true
+        },
+        "allowedBlocks": true,
+        "artisanpackStates": {
+            "attributes": [
+                "backgroundColor",
+                "textColor",
+                "color.background",
+                "color.text",
+                "border.color",
+                "border.width",
+                "border.style",
+                "border.radius",
+                "typography.textDecoration",
+                "transition"
+            ]
+        }
+    },
+    "editorStyle": "wp-block-details-editor",
+    "style": "wp-block-details"
 }

--- a/resources/js/visual-editor/blocks/file/block.json
+++ b/resources/js/visual-editor/blocks/file/block.json
@@ -1,97 +1,102 @@
 {
-	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 3,
-	"name": "artisanpack/file",
-	"title": "File",
-	"category": "media",
-	"description": "Add a link to a downloadable file.",
-	"keywords": [ "document", "pdf", "download" ],
-	"textdomain": "artisanpack-visual-editor",
-	"attributes": {
-		"id": {
-			"type": "number"
-		},
-		"blob": {
-			"type": "string",
-			"role": "local"
-		},
-		"href": {
-			"type": "string",
-			"role": "content"
-		},
-		"fileId": {
-			"type": "string",
-			"source": "attribute",
-			"selector": "a:not([download])",
-			"attribute": "id"
-		},
-		"fileName": {
-			"type": "rich-text",
-			"source": "rich-text",
-			"selector": "a:not([download])",
-			"role": "content"
-		},
-		"textLinkHref": {
-			"type": "string",
-			"source": "attribute",
-			"selector": "a:not([download])",
-			"attribute": "href",
-			"role": "content"
-		},
-		"textLinkTarget": {
-			"type": "string",
-			"source": "attribute",
-			"selector": "a:not([download])",
-			"attribute": "target"
-		},
-		"showDownloadButton": {
-			"type": "boolean",
-			"default": true
-		},
-		"downloadButtonText": {
-			"type": "rich-text",
-			"source": "rich-text",
-			"selector": "a[download]",
-			"role": "content"
-		},
-		"displayPreview": {
-			"type": "boolean"
-		},
-		"previewHeight": {
-			"type": "number",
-			"default": 600
-		}
-	},
-	"supports": {
-		"anchor": true,
-		"align": true,
-		"spacing": {
-			"margin": true,
-			"padding": true
-		},
-		"color": {
-			"gradients": true,
-			"link": true,
-			"text": false,
-			"__experimentalDefaultControls": {
-				"background": true,
-				"link": true
-			}
-		},
-		"__experimentalBorder": {
-			"radius": true,
-			"color": true,
-			"width": true,
-			"style": true,
-			"__experimentalDefaultControls": {
-				"radius": true,
-				"color": true,
-				"width": true,
-				"style": true
-			}
-		},
-		"interactivity": true
-	},
-	"editorStyle": "wp-block-file-editor",
-	"style": "wp-block-file"
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "artisanpack/file",
+    "title": "File",
+    "category": "media",
+    "description": "Add a link to a downloadable file.",
+    "keywords": [
+        "document",
+        "pdf",
+        "download"
+    ],
+    "textdomain": "artisanpack-visual-editor",
+    "attributes": {
+        "id": {
+            "type": "number"
+        },
+        "blob": {
+            "type": "string",
+            "role": "local"
+        },
+        "href": {
+            "type": "string",
+            "role": "content"
+        },
+        "fileId": {
+            "type": "string",
+            "source": "attribute",
+            "selector": "a:not([download])",
+            "attribute": "id"
+        },
+        "fileName": {
+            "type": "rich-text",
+            "source": "rich-text",
+            "selector": "a:not([download])",
+            "role": "content"
+        },
+        "textLinkHref": {
+            "type": "string",
+            "source": "attribute",
+            "selector": "a:not([download])",
+            "attribute": "href",
+            "role": "content"
+        },
+        "textLinkTarget": {
+            "type": "string",
+            "source": "attribute",
+            "selector": "a:not([download])",
+            "attribute": "target"
+        },
+        "showDownloadButton": {
+            "type": "boolean",
+            "default": true
+        },
+        "downloadButtonText": {
+            "type": "rich-text",
+            "source": "rich-text",
+            "selector": "a[download]",
+            "role": "content"
+        },
+        "displayPreview": {
+            "type": "boolean"
+        },
+        "previewHeight": {
+            "type": "number",
+            "default": 600
+        }
+    },
+    "supports": {
+        "anchor": true,
+        "align": true,
+        "spacing": {
+            "margin": true,
+            "padding": true
+        },
+        "color": {
+            "gradients": true,
+            "link": true,
+            "text": false,
+            "__experimentalDefaultControls": {
+                "background": true,
+                "link": true
+            }
+        },
+        "__experimentalBorder": {
+            "radius": true,
+            "color": true,
+            "width": true,
+            "style": true,
+            "__experimentalDefaultControls": {
+                "radius": true,
+                "color": true,
+                "width": true,
+                "style": true
+            },
+            "gradient": true
+        },
+        "interactivity": true
+    },
+    "editorStyle": "wp-block-file-editor",
+    "style": "wp-block-file"
 }

--- a/resources/js/visual-editor/blocks/form/block.json
+++ b/resources/js/visual-editor/blocks/form/block.json
@@ -5,7 +5,12 @@
     "title": "Form",
     "category": "widgets",
     "description": "Embed a form from the artisanpack-ui/forms package.",
-    "keywords": ["form", "contact", "lead", "submission"],
+    "keywords": [
+        "form",
+        "contact",
+        "lead",
+        "submission"
+    ],
     "textdomain": "artisanpack-visual-editor",
     "attributes": {
         "formId": {
@@ -38,7 +43,8 @@
             "color": true,
             "radius": true,
             "style": true,
-            "width": true
+            "width": true,
+            "gradient": true
         },
         "spacing": {
             "padding": true,

--- a/resources/js/visual-editor/blocks/gallery/block.json
+++ b/resources/js/visual-editor/blocks/gallery/block.json
@@ -4,10 +4,17 @@
     "name": "artisanpack/gallery",
     "title": "Gallery",
     "category": "media",
-    "usesContext": [ "galleryId" ],
-    "allowedBlocks": [ "core/image" ],
+    "usesContext": [
+        "galleryId"
+    ],
+    "allowedBlocks": [
+        "core/image"
+    ],
     "description": "Display multiple images in a rich gallery.",
-    "keywords": [ "images", "photos" ],
+    "keywords": [
+        "images",
+        "photos"
+    ],
     "textdomain": "artisanpack-visual-editor",
     "attributes": {
         "images": {
@@ -64,7 +71,11 @@
         "navigationButtonType": {
             "type": "string",
             "default": "icon",
-            "enum": [ "icon", "text", "both" ]
+            "enum": [
+                "icon",
+                "text",
+                "both"
+            ]
         },
         "shortCodeTransforms": {
             "type": "array",
@@ -126,15 +137,27 @@
             "__experimentalDefaultControls": {
                 "color": true,
                 "radius": true
-            }
+            },
+            "gradient": true
         },
         "html": false,
-        "units": [ "px", "em", "rem", "vh", "vw" ],
+        "units": [
+            "px",
+            "em",
+            "rem",
+            "vh",
+            "vw"
+        ],
         "spacing": {
             "margin": true,
             "padding": true,
-            "blockGap": [ "horizontal", "vertical" ],
-            "__experimentalSkipSerialization": [ "blockGap" ],
+            "blockGap": [
+                "horizontal",
+                "vertical"
+            ],
+            "__experimentalSkipSerialization": [
+                "blockGap"
+            ],
             "__experimentalDefaultControls": {
                 "blockGap": true,
                 "margin": false,

--- a/resources/js/visual-editor/blocks/grid-item/block.json
+++ b/resources/js/visual-editor/blocks/grid-item/block.json
@@ -5,14 +5,28 @@
     "title": "Grid Item",
     "category": "design",
     "description": "A single cell inside a grid, with per-breakpoint column/row spans.",
-    "keywords": ["grid", "grid-item", "cell"],
-    "parent": ["artisanpack/grid"],
+    "keywords": [
+        "grid",
+        "grid-item",
+        "cell"
+    ],
+    "parent": [
+        "artisanpack/grid"
+    ],
     "textdomain": "artisanpack-visual-editor",
-    "usesContext": ["numColumns"],
+    "usesContext": [
+        "numColumns"
+    ],
     "attributes": {
         "innerLayout": {
             "type": "string",
-            "enum": ["normal", "equal", "center", "bottom", "last-bottom"],
+            "enum": [
+                "normal",
+                "equal",
+                "center",
+                "bottom",
+                "last-bottom"
+            ],
             "default": "normal"
         },
         "gridColumnSpan": {
@@ -26,12 +40,18 @@
     },
     "supports": {
         "anchor": true,
-        "align": ["wide", "full"],
+        "align": [
+            "wide",
+            "full"
+        ],
         "ariaLabel": true,
         "className": true,
         "html": false,
         "spacing": {
-            "margin": ["top", "bottom"],
+            "margin": [
+                "top",
+                "bottom"
+            ],
             "padding": true,
             "blockGap": true,
             "__experimentalDefaultControls": {
@@ -58,7 +78,8 @@
                 "radius": true,
                 "style": true,
                 "width": true
-            }
+            },
+            "gradient": true
         },
         "typography": {
             "fontSize": true,

--- a/resources/js/visual-editor/blocks/grid/block.json
+++ b/resources/js/visual-editor/blocks/grid/block.json
@@ -5,7 +5,11 @@
     "title": "Grid",
     "category": "design",
     "description": "Add a responsive grid with a custom number of columns per breakpoint.",
-    "keywords": ["grid", "columns", "layout"],
+    "keywords": [
+        "grid",
+        "columns",
+        "layout"
+    ],
     "textdomain": "artisanpack-visual-editor",
     "attributes": {
         "numColumns": {
@@ -18,16 +22,25 @@
     },
     "supports": {
         "anchor": true,
-        "align": ["wide", "full"],
+        "align": [
+            "wide",
+            "full"
+        ],
         "ariaLabel": true,
         "className": true,
         "html": false,
         "spacing": {
             "blockGap": {
                 "__experimentalDefault": "1.5rem",
-                "sides": ["horizontal", "vertical"]
+                "sides": [
+                    "horizontal",
+                    "vertical"
+                ]
             },
-            "margin": ["top", "bottom"],
+            "margin": [
+                "top",
+                "bottom"
+            ],
             "padding": true,
             "__experimentalDefaultControls": {
                 "padding": true,
@@ -53,7 +66,8 @@
                 "radius": true,
                 "style": true,
                 "width": true
-            }
+            },
+            "gradient": true
         },
         "artisanpackResponsive": {
             "attributes": [

--- a/resources/js/visual-editor/blocks/group/block.json
+++ b/resources/js/visual-editor/blocks/group/block.json
@@ -5,7 +5,12 @@
     "title": "Group",
     "category": "design",
     "description": "Gather blocks in a layout container.",
-    "keywords": [ "container", "wrapper", "row", "section" ],
+    "keywords": [
+        "container",
+        "wrapper",
+        "row",
+        "section"
+    ],
     "textdomain": "artisanpack-visual-editor",
     "attributes": {
         "tagName": {
@@ -13,15 +18,26 @@
             "default": "div"
         },
         "templateLock": {
-            "type": [ "string", "boolean" ],
-            "enum": [ "all", "insert", "contentOnly", false ]
+            "type": [
+                "string",
+                "boolean"
+            ],
+            "enum": [
+                "all",
+                "insert",
+                "contentOnly",
+                false
+            ]
         }
     },
     "supports": {
         "__experimentalOnEnter": true,
         "__experimentalOnMerge": true,
         "__experimentalSettings": true,
-        "align": [ "wide", "full" ],
+        "align": [
+            "wide",
+            "full"
+        ],
         "anchor": true,
         "ariaLabel": true,
         "html": false,
@@ -46,7 +62,10 @@
         },
         "shadow": true,
         "spacing": {
-            "margin": [ "top", "bottom" ],
+            "margin": [
+                "top",
+                "bottom"
+            ],
             "padding": true,
             "blockGap": true,
             "__experimentalDefaultControls": {
@@ -67,7 +86,8 @@
                 "radius": true,
                 "style": true,
                 "width": true
-            }
+            },
+            "gradient": true
         },
         "position": {
             "sticky": true

--- a/resources/js/visual-editor/blocks/heading/block.json
+++ b/resources/js/visual-editor/blocks/heading/block.json
@@ -5,7 +5,10 @@
     "title": "Heading",
     "category": "text",
     "description": "Introduce new sections and organize content to help visitors (and search engines) understand the structure of your content.",
-    "keywords": [ "title", "subtitle" ],
+    "keywords": [
+        "title",
+        "subtitle"
+    ],
     "textdomain": "artisanpack-visual-editor",
     "attributes": {
         "content": {
@@ -26,7 +29,10 @@
         }
     },
     "supports": {
-        "align": [ "wide", "full" ],
+        "align": [
+            "wide",
+            "full"
+        ],
         "anchor": true,
         "className": true,
         "splitting": true,
@@ -34,7 +40,8 @@
             "color": true,
             "radius": true,
             "style": true,
-            "width": true
+            "width": true,
+            "gradient": true
         },
         "color": {
             "gradients": true,

--- a/resources/js/visual-editor/blocks/icon/block.json
+++ b/resources/js/visual-editor/blocks/icon/block.json
@@ -5,7 +5,12 @@
     "title": "Icon",
     "category": "design",
     "description": "Insert an SVG icon from a registered set, or paste your own.",
-    "keywords": [ "svg", "icon", "fontawesome", "glyph" ],
+    "keywords": [
+        "svg",
+        "icon",
+        "fontawesome",
+        "glyph"
+    ],
     "textdomain": "artisanpack-visual-editor",
     "attributes": {
         "iconRef": {
@@ -22,25 +27,60 @@
         },
         "sizeUnit": {
             "type": "string",
-            "enum": [ "px", "em", "rem", "%", "vw", "vh" ],
+            "enum": [
+                "px",
+                "em",
+                "rem",
+                "%",
+                "vw",
+                "vh"
+            ],
             "default": "px"
         },
         "width": {
-            "type": [ "number", "null" ],
+            "type": [
+                "number",
+                "null"
+            ],
             "default": null
         },
         "widthUnit": {
-            "type": [ "string", "null" ],
-            "enum": [ "px", "em", "rem", "%", "vw", "vh", null ],
+            "type": [
+                "string",
+                "null"
+            ],
+            "enum": [
+                "px",
+                "em",
+                "rem",
+                "%",
+                "vw",
+                "vh",
+                null
+            ],
             "default": null
         },
         "height": {
-            "type": [ "number", "null" ],
+            "type": [
+                "number",
+                "null"
+            ],
             "default": null
         },
         "heightUnit": {
-            "type": [ "string", "null" ],
-            "enum": [ "px", "em", "rem", "%", "vw", "vh", null ],
+            "type": [
+                "string",
+                "null"
+            ],
+            "enum": [
+                "px",
+                "em",
+                "rem",
+                "%",
+                "vw",
+                "vh",
+                null
+            ],
             "default": null
         },
         "color": {
@@ -54,7 +94,12 @@
         },
         "rotation": {
             "type": "number",
-            "enum": [ 0, 90, 180, 270 ],
+            "enum": [
+                0,
+                90,
+                180,
+                270
+            ],
             "default": 0
         },
         "flipH": {
@@ -92,11 +137,17 @@
     },
     "supports": {
         "anchor": true,
-        "align": [ "left", "center", "right", "wide", "full" ],
+        "align": [
+            "left",
+            "center",
+            "right",
+            "wide",
+            "full"
+        ],
         "color": {
             "text": false,
             "background": true,
-            "gradients": false,
+            "gradients": true,
             "__experimentalDefaultControls": {
                 "background": true
             }
@@ -119,7 +170,8 @@
                 "radius": true,
                 "style": true,
                 "width": true
-            }
+            },
+            "gradient": true
         },
         "interactivity": {
             "clientNavigation": true

--- a/resources/js/visual-editor/blocks/image/block.json
+++ b/resources/js/visual-editor/blocks/image/block.json
@@ -15,7 +15,11 @@
         "galleryId"
     ],
     "description": "Insert an image to make a visual statement.",
-    "keywords": [ "img", "photo", "picture" ],
+    "keywords": [
+        "img",
+        "photo",
+        "picture"
+    ],
     "textdomain": "artisanpack-visual-editor",
     "attributes": {
         "blob": {
@@ -109,7 +113,13 @@
     },
     "supports": {
         "interactivity": true,
-        "align": [ "left", "center", "right", "wide", "full" ],
+        "align": [
+            "left",
+            "center",
+            "right",
+            "wide",
+            "full"
+        ],
         "anchor": true,
         "color": {
             "text": false,
@@ -130,7 +140,8 @@
                 "color": true,
                 "radius": true,
                 "width": true
-            }
+            },
+            "gradient": true
         },
         "shadow": {
             "__experimentalSkipSerialization": true
@@ -160,7 +171,10 @@
             "label": "Default",
             "isDefault": true
         },
-        { "name": "rounded", "label": "Rounded" }
+        {
+            "name": "rounded",
+            "label": "Rounded"
+        }
     ],
     "editorStyle": "wp-block-image-editor",
     "style": "wp-block-image"

--- a/resources/js/visual-editor/blocks/latest-posts/block.json
+++ b/resources/js/visual-editor/blocks/latest-posts/block.json
@@ -5,7 +5,9 @@
     "title": "Latest Posts",
     "category": "widgets",
     "description": "Display a list of your most recent posts.",
-    "keywords": [ "recent posts" ],
+    "keywords": [
+        "recent posts"
+    ],
     "textdomain": "artisanpack-visual-editor",
     "attributes": {
         "categories": {
@@ -63,7 +65,11 @@
         },
         "featuredImageAlign": {
             "type": "string",
-            "enum": [ "left", "center", "right" ]
+            "enum": [
+                "left",
+                "center",
+                "right"
+            ]
         },
         "featuredImageSizeSlug": {
             "type": "string",
@@ -122,7 +128,8 @@
                 "color": true,
                 "width": true,
                 "style": true
-            }
+            },
+            "gradient": true
         },
         "interactivity": {
             "clientNavigation": true

--- a/resources/js/visual-editor/blocks/list-item/block.json
+++ b/resources/js/visual-editor/blocks/list-item/block.json
@@ -4,8 +4,12 @@
     "name": "artisanpack/list-item",
     "title": "List Item",
     "category": "text",
-    "parent": [ "artisanpack/list" ],
-    "allowedBlocks": [ "artisanpack/list" ],
+    "parent": [
+        "artisanpack/list"
+    ],
+    "allowedBlocks": [
+        "artisanpack/list"
+    ],
     "description": "An individual item within a list.",
     "textdomain": "artisanpack-visual-editor",
     "attributes": {
@@ -28,7 +32,8 @@
             "color": true,
             "radius": true,
             "style": true,
-            "width": true
+            "width": true,
+            "gradient": true
         },
         "color": {
             "gradients": true,

--- a/resources/js/visual-editor/blocks/list/block.json
+++ b/resources/js/visual-editor/blocks/list/block.json
@@ -4,9 +4,15 @@
     "name": "artisanpack/list",
     "title": "List",
     "category": "text",
-    "allowedBlocks": [ "artisanpack/list-item" ],
+    "allowedBlocks": [
+        "artisanpack/list-item"
+    ],
     "description": "An organized collection of items displayed in a specific order.",
-    "keywords": [ "bullet list", "ordered list", "numbered list" ],
+    "keywords": [
+        "bullet list",
+        "ordered list",
+        "numbered list"
+    ],
     "textdomain": "artisanpack-visual-editor",
     "attributes": {
         "ordered": {
@@ -42,7 +48,8 @@
             "color": true,
             "radius": true,
             "style": true,
-            "width": true
+            "width": true,
+            "gradient": true
         },
         "typography": {
             "fontSize": true,

--- a/resources/js/visual-editor/blocks/loginout/block.json
+++ b/resources/js/visual-editor/blocks/loginout/block.json
@@ -5,7 +5,11 @@
     "title": "Login/out",
     "category": "theme",
     "description": "Show login & logout links.",
-    "keywords": [ "login", "logout", "form" ],
+    "keywords": [
+        "login",
+        "logout",
+        "form"
+    ],
     "textdomain": "artisanpack-visual-editor",
     "attributes": {
         "displayLoginAsForm": {
@@ -54,7 +58,8 @@
             "radius": true,
             "color": true,
             "width": true,
-            "style": true
+            "style": true,
+            "gradient": true
         },
         "interactivity": {
             "clientNavigation": true

--- a/resources/js/visual-editor/blocks/marquee/block.json
+++ b/resources/js/visual-editor/blocks/marquee/block.json
@@ -5,7 +5,12 @@
     "title": "Marquee",
     "category": "design",
     "description": "Scroll a line of text horizontally across the screen.",
-    "keywords": ["marquee", "scroll", "ticker", "banner"],
+    "keywords": [
+        "marquee",
+        "scroll",
+        "ticker",
+        "banner"
+    ],
     "textdomain": "artisanpack-visual-editor",
     "attributes": {
         "marqueeContent": {
@@ -37,7 +42,10 @@
             }
         },
         "spacing": {
-            "margin": ["top", "bottom"],
+            "margin": [
+                "top",
+                "bottom"
+            ],
             "padding": true,
             "blockGap": true,
             "__experimentalDefaultControls": {
@@ -56,7 +64,8 @@
                 "radius": true,
                 "style": true,
                 "width": true
-            }
+            },
+            "gradient": true
         },
         "typography": {
             "fontSize": true,

--- a/resources/js/visual-editor/blocks/media-text/block.json
+++ b/resources/js/visual-editor/blocks/media-text/block.json
@@ -5,7 +5,10 @@
     "title": "Media & Text",
     "category": "media",
     "description": "Set media and words side-by-side for a richer layout.",
-    "keywords": [ "image", "video" ],
+    "keywords": [
+        "image",
+        "video"
+    ],
     "textdomain": "artisanpack-visual-editor",
     "attributes": {
         "align": {
@@ -95,10 +98,16 @@
             "default": false
         }
     },
-    "usesContext": [ "postId", "postType" ],
+    "usesContext": [
+        "postId",
+        "postType"
+    ],
     "supports": {
         "anchor": true,
-        "align": [ "wide", "full" ],
+        "align": [
+            "wide",
+            "full"
+        ],
         "html": false,
         "__experimentalBorder": {
             "color": true,
@@ -110,7 +119,8 @@
                 "radius": true,
                 "style": true,
                 "width": true
-            }
+            },
+            "gradient": true
         },
         "color": {
             "gradients": true,

--- a/resources/js/visual-editor/blocks/paragraph/block.json
+++ b/resources/js/visual-editor/blocks/paragraph/block.json
@@ -5,7 +5,9 @@
     "title": "Paragraph",
     "category": "text",
     "description": "Start with the basic building block of all narrative.",
-    "keywords": [ "text" ],
+    "keywords": [
+        "text"
+    ],
     "textdomain": "artisanpack-visual-editor",
     "attributes": {
         "content": {
@@ -23,11 +25,17 @@
         },
         "direction": {
             "type": "string",
-            "enum": [ "ltr", "rtl" ]
+            "enum": [
+                "ltr",
+                "rtl"
+            ]
         }
     },
     "supports": {
-        "align": [ "wide", "full" ],
+        "align": [
+            "wide",
+            "full"
+        ],
         "splitting": true,
         "anchor": true,
         "className": false,
@@ -35,7 +43,8 @@
             "color": true,
             "radius": true,
             "style": true,
-            "width": true
+            "width": true,
+            "gradient": true
         },
         "color": {
             "gradients": true,

--- a/resources/js/visual-editor/blocks/post-author-biography/block.json
+++ b/resources/js/visual-editor/blocks/post-author-biography/block.json
@@ -56,7 +56,8 @@
                 "color": true,
                 "width": true,
                 "style": true
-            }
+            },
+            "gradient": true
         }
     },
     "style": "wp-block-post-author-biography"

--- a/resources/js/visual-editor/blocks/post-author-name/block.json
+++ b/resources/js/visual-editor/blocks/post-author-name/block.json
@@ -70,7 +70,8 @@
                 "color": true,
                 "width": true,
                 "style": true
-            }
+            },
+            "gradient": true
         }
     },
     "style": "wp-block-post-author-name"

--- a/resources/js/visual-editor/blocks/post-author/block.json
+++ b/resources/js/visual-editor/blocks/post-author/block.json
@@ -83,7 +83,8 @@
                 "color": true,
                 "width": true,
                 "style": true
-            }
+            },
+            "gradient": true
         },
         "filter": {
             "duotone": true

--- a/resources/js/visual-editor/blocks/post-comments-count/block.json
+++ b/resources/js/visual-editor/blocks/post-comments-count/block.json
@@ -52,7 +52,8 @@
             "radius": true,
             "color": true,
             "width": true,
-            "style": true
+            "style": true,
+            "gradient": true
         }
     }
 }

--- a/resources/js/visual-editor/blocks/post-comments-form/block.json
+++ b/resources/js/visual-editor/blocks/post-comments-form/block.json
@@ -17,7 +17,10 @@
     ],
     "supports": {
         "anchor": true,
-        "align": [ "wide", "full" ],
+        "align": [
+            "wide",
+            "full"
+        ],
         "html": false,
         "color": {
             "gradients": true,
@@ -53,7 +56,8 @@
             "radius": true,
             "color": true,
             "width": true,
-            "style": true
+            "style": true,
+            "gradient": true
         }
     }
 }

--- a/resources/js/visual-editor/blocks/post-comments-link/block.json
+++ b/resources/js/visual-editor/blocks/post-comments-link/block.json
@@ -53,7 +53,8 @@
             "radius": true,
             "color": true,
             "width": true,
-            "style": true
+            "style": true,
+            "gradient": true
         }
     }
 }

--- a/resources/js/visual-editor/blocks/post-comments-title/block.json
+++ b/resources/js/visual-editor/blocks/post-comments-title/block.json
@@ -33,13 +33,17 @@
     ],
     "supports": {
         "anchor": false,
-        "align": [ "wide", "full" ],
+        "align": [
+            "wide",
+            "full"
+        ],
         "html": false,
         "__experimentalBorder": {
             "radius": true,
             "color": true,
             "width": true,
-            "style": true
+            "style": true,
+            "gradient": true
         },
         "color": {
             "gradients": true,

--- a/resources/js/visual-editor/blocks/post-content/block.json
+++ b/resources/js/visual-editor/blocks/post-content/block.json
@@ -82,7 +82,8 @@
                 "color": true,
                 "width": true,
                 "style": true
-            }
+            },
+            "gradient": true
         }
     },
     "style": "wp-block-post-content",

--- a/resources/js/visual-editor/blocks/post-date/block.json
+++ b/resources/js/visual-editor/blocks/post-date/block.json
@@ -72,7 +72,8 @@
                 "color": true,
                 "width": true,
                 "style": true
-            }
+            },
+            "gradient": true
         }
     }
 }

--- a/resources/js/visual-editor/blocks/post-excerpt/block.json
+++ b/resources/js/visual-editor/blocks/post-excerpt/block.json
@@ -73,7 +73,8 @@
                 "color": true,
                 "width": true,
                 "style": true
-            }
+            },
+            "gradient": true
         }
     },
     "editorStyle": "wp-block-post-excerpt-editor",

--- a/resources/js/visual-editor/blocks/post-featured-image/block.json
+++ b/resources/js/visual-editor/blocks/post-featured-image/block.json
@@ -91,7 +91,8 @@
                 "color": true,
                 "radius": true,
                 "width": true
-            }
+            },
+            "gradient": true
         },
         "filter": {
             "duotone": true

--- a/resources/js/visual-editor/blocks/post-navigation-link/block.json
+++ b/resources/js/visual-editor/blocks/post-navigation-link/block.json
@@ -42,7 +42,8 @@
         "reusable": false,
         "html": false,
         "color": {
-            "link": true
+            "link": true,
+            "gradients": true
         },
         "typography": {
             "fontSize": true,

--- a/resources/js/visual-editor/blocks/post-template/block.json
+++ b/resources/js/visual-editor/blocks/post-template/block.json
@@ -4,7 +4,9 @@
     "name": "artisanpack/post-template",
     "title": "Post Template",
     "category": "theme",
-    "ancestor": [ "artisanpack/query" ],
+    "ancestor": [
+        "artisanpack/query"
+    ],
     "description": "Contains the block elements used to render a post, like the title, date, featured image, content or excerpt, and more.",
     "textdomain": "artisanpack-visual-editor",
     "attributes": {
@@ -30,7 +32,10 @@
         "anchor": true,
         "reusable": false,
         "html": false,
-        "align": [ "wide", "full" ],
+        "align": [
+            "wide",
+            "full"
+        ],
         "layout": true,
         "color": {
             "gradients": true,
@@ -72,7 +77,8 @@
             "radius": true,
             "color": true,
             "width": true,
-            "style": true
+            "style": true,
+            "gradient": true
         }
     }
 }

--- a/resources/js/visual-editor/blocks/post-terms/block.json
+++ b/resources/js/visual-editor/blocks/post-terms/block.json
@@ -77,7 +77,8 @@
                 "color": true,
                 "width": true,
                 "style": true
-            }
+            },
+            "gradient": true
         }
     },
     "style": "wp-block-post-terms"

--- a/resources/js/visual-editor/blocks/post-title/block.json
+++ b/resources/js/visual-editor/blocks/post-title/block.json
@@ -90,7 +90,8 @@
                 "color": true,
                 "width": true,
                 "style": true
-            }
+            },
+            "gradient": true
         }
     },
     "style": "wp-block-post-title"

--- a/resources/js/visual-editor/blocks/preformatted/block.json
+++ b/resources/js/visual-editor/blocks/preformatted/block.json
@@ -54,7 +54,8 @@
                 "color": true,
                 "width": true,
                 "style": true
-            }
+            },
+            "gradient": true
         }
     },
     "style": "wp-block-preformatted"

--- a/resources/js/visual-editor/blocks/pullquote/block.json
+++ b/resources/js/visual-editor/blocks/pullquote/block.json
@@ -25,7 +25,12 @@
     },
     "supports": {
         "anchor": true,
-        "align": [ "left", "right", "wide", "full" ],
+        "align": [
+            "left",
+            "right",
+            "wide",
+            "full"
+        ],
         "background": {
             "backgroundImage": true,
             "backgroundSize": true,
@@ -75,7 +80,8 @@
                 "radius": true,
                 "style": true,
                 "width": true
-            }
+            },
+            "gradient": true
         },
         "__experimentalStyle": {
             "typography": {

--- a/resources/js/visual-editor/blocks/query-title/block.json
+++ b/resources/js/visual-editor/blocks/query-title/block.json
@@ -31,10 +31,15 @@
             "type": "search"
         }
     },
-    "usesContext": [ "query" ],
+    "usesContext": [
+        "query"
+    ],
     "supports": {
         "anchor": true,
-        "align": [ "wide", "full" ],
+        "align": [
+            "wide",
+            "full"
+        ],
         "html": false,
         "color": {
             "gradients": true,
@@ -74,7 +79,8 @@
                 "color": true,
                 "width": true,
                 "style": true
-            }
+            },
+            "gradient": true
         }
     }
 }

--- a/resources/js/visual-editor/blocks/quote/block.json
+++ b/resources/js/visual-editor/blocks/quote/block.json
@@ -5,7 +5,10 @@
     "title": "Quote",
     "category": "text",
     "description": "Give quoted text visual emphasis. \"In quoting others, we cite ourselves.\" — Julio Cortázar",
-    "keywords": [ "blockquote", "cite" ],
+    "keywords": [
+        "blockquote",
+        "cite"
+    ],
     "textdomain": "artisanpack-visual-editor",
     "attributes": {
         "value": {
@@ -28,7 +31,12 @@
     },
     "supports": {
         "anchor": true,
-        "align": [ "left", "right", "wide", "full" ],
+        "align": [
+            "left",
+            "right",
+            "wide",
+            "full"
+        ],
         "html": false,
         "background": {
             "backgroundImage": true,
@@ -47,7 +55,8 @@
                 "radius": true,
                 "style": true,
                 "width": true
-            }
+            },
+            "gradient": true
         },
         "dimensions": {
             "minHeight": true,
@@ -98,7 +107,10 @@
             "label": "Default",
             "isDefault": true
         },
-        { "name": "plain", "label": "Plain" }
+        {
+            "name": "plain",
+            "label": "Plain"
+        }
     ],
     "editorStyle": "wp-block-quote-editor",
     "style": "wp-block-quote"

--- a/resources/js/visual-editor/blocks/read-more/block.json
+++ b/resources/js/visual-editor/blocks/read-more/block.json
@@ -43,7 +43,10 @@
             }
         },
         "spacing": {
-            "margin": [ "top", "bottom" ],
+            "margin": [
+                "top",
+                "bottom"
+            ],
             "padding": true,
             "__experimentalDefaultControls": {
                 "padding": true
@@ -55,7 +58,8 @@
             "width": true,
             "__experimentalDefaultControls": {
                 "width": true
-            }
+            },
+            "gradient": true
         },
         "interactivity": {
             "clientNavigation": true

--- a/resources/js/visual-editor/blocks/search-filters/block.json
+++ b/resources/js/visual-editor/blocks/search-filters/block.json
@@ -5,7 +5,11 @@
     "title": "Search Filters",
     "category": "search",
     "description": "Wrap a set of filter controls (search field, taxonomy dropdowns, submit + reset buttons) in a single GET form that posts back to the host site.",
-    "keywords": ["search", "filters", "form"],
+    "keywords": [
+        "search",
+        "filters",
+        "form"
+    ],
     "textdomain": "artisanpack-visual-editor",
     "attributes": {
         "postType": {
@@ -14,12 +18,18 @@
         }
     },
     "supports": {
-        "align": ["wide", "full"],
+        "align": [
+            "wide",
+            "full"
+        ],
         "ariaLabel": true,
         "className": true,
         "html": false,
         "spacing": {
-            "margin": ["top", "bottom"],
+            "margin": [
+                "top",
+                "bottom"
+            ],
             "padding": true,
             "blockGap": true,
             "__experimentalDefaultControls": {
@@ -46,7 +56,8 @@
                 "radius": true,
                 "style": true,
                 "width": true
-            }
+            },
+            "gradient": true
         },
         "typography": {
             "fontSize": true,

--- a/resources/js/visual-editor/blocks/search/block.json
+++ b/resources/js/visual-editor/blocks/search/block.json
@@ -5,7 +5,9 @@
     "title": "Search",
     "category": "widgets",
     "description": "Help visitors find your content.",
-    "keywords": [ "find" ],
+    "keywords": [
+        "find"
+    ],
     "textdomain": "artisanpack-visual-editor",
     "attributes": {
         "label": {
@@ -50,7 +52,11 @@
     },
     "supports": {
         "anchor": true,
-        "align": [ "left", "center", "right" ],
+        "align": [
+            "left",
+            "center",
+            "right"
+        ],
         "color": {
             "gradients": true,
             "__experimentalSkipSerialization": true,
@@ -84,7 +90,8 @@
                 "color": true,
                 "radius": true,
                 "width": true
-            }
+            },
+            "gradient": true
         },
         "spacing": {
             "margin": true

--- a/resources/js/visual-editor/blocks/single-post-types-search-results/block.json
+++ b/resources/js/visual-editor/blocks/single-post-types-search-results/block.json
@@ -5,8 +5,14 @@
     "title": "Single Post Type Search Results",
     "category": "search",
     "description": "Render its inner blocks only when the host page's `?post_type=` query parameter matches the configured post type (or `all` when no parameter is set).",
-    "keywords": ["search", "results", "post type"],
-    "parent": ["artisanpack/post-types-search-results"],
+    "keywords": [
+        "search",
+        "results",
+        "post type"
+    ],
+    "parent": [
+        "artisanpack/post-types-search-results"
+    ],
     "textdomain": "artisanpack-visual-editor",
     "attributes": {
         "postType": {
@@ -19,7 +25,10 @@
         "className": true,
         "html": false,
         "spacing": {
-            "margin": ["top", "bottom"],
+            "margin": [
+                "top",
+                "bottom"
+            ],
             "padding": true,
             "blockGap": true,
             "__experimentalDefaultControls": {
@@ -46,7 +55,8 @@
                 "radius": true,
                 "style": true,
                 "width": true
-            }
+            },
+            "gradient": true
         },
         "typography": {
             "fontSize": true,

--- a/resources/js/visual-editor/blocks/site-tagline/block.json
+++ b/resources/js/visual-editor/blocks/site-tagline/block.json
@@ -82,7 +82,8 @@
             "radius": true,
             "color": true,
             "width": true,
-            "style": true
+            "style": true,
+            "gradient": true
         }
     },
     "editorStyle": "wp-block-site-tagline-editor",

--- a/resources/js/visual-editor/blocks/site-title/block.json
+++ b/resources/js/visual-editor/blocks/site-title/block.json
@@ -83,7 +83,8 @@
             "radius": true,
             "color": true,
             "width": true,
-            "style": true
+            "style": true,
+            "gradient": true
         }
     },
     "editorStyle": "wp-block-site-title-editor",

--- a/resources/js/visual-editor/blocks/tab-section/block.json
+++ b/resources/js/visual-editor/blocks/tab-section/block.json
@@ -5,7 +5,9 @@
     "title": "Tab Section",
     "category": "design",
     "description": "A single tab panel shown when its matching tab is active.",
-    "parent": ["artisanpack/tabs"],
+    "parent": [
+        "artisanpack/tabs"
+    ],
     "textdomain": "artisanpack-visual-editor",
     "attributes": {
         "label": {
@@ -22,7 +24,10 @@
         "className": true,
         "html": false,
         "spacing": {
-            "margin": ["top", "bottom"],
+            "margin": [
+                "top",
+                "bottom"
+            ],
             "padding": true,
             "blockGap": true,
             "__experimentalDefaultControls": {
@@ -41,7 +46,8 @@
                 "radius": true,
                 "style": true,
                 "width": true
-            }
+            },
+            "gradient": true
         }
     }
 }

--- a/resources/js/visual-editor/blocks/table/block.json
+++ b/resources/js/visual-editor/blocks/table/block.json
@@ -197,7 +197,8 @@
                 "color": true,
                 "style": true,
                 "width": true
-            }
+            },
+            "gradient": true
         },
         "interactivity": {
             "clientNavigation": true
@@ -213,7 +214,10 @@
             "label": "Default",
             "isDefault": true
         },
-        { "name": "stripes", "label": "Stripes" }
+        {
+            "name": "stripes",
+            "label": "Stripes"
+        }
     ],
     "editorStyle": "wp-block-table-editor",
     "style": "wp-block-table"

--- a/resources/js/visual-editor/blocks/tabs/block.json
+++ b/resources/js/visual-editor/blocks/tabs/block.json
@@ -5,28 +5,46 @@
     "title": "Tabs",
     "category": "design",
     "description": "Group content into a tabbed interface.",
-    "keywords": ["tabs", "tabbed", "navigation"],
+    "keywords": [
+        "tabs",
+        "tabbed",
+        "navigation"
+    ],
     "textdomain": "artisanpack-visual-editor",
     "attributes": {
         "tabsAlign": {
             "type": "string",
-            "enum": ["horizontal", "vertical"],
+            "enum": [
+                "horizontal",
+                "vertical"
+            ],
             "default": "horizontal"
         },
         "tabsSpacing": {
             "type": "string",
-            "enum": ["start", "end", "center", "equal"],
+            "enum": [
+                "start",
+                "end",
+                "center",
+                "equal"
+            ],
             "default": "start"
         }
     },
     "supports": {
-        "align": ["wide", "full"],
+        "align": [
+            "wide",
+            "full"
+        ],
         "anchor": true,
         "ariaLabel": true,
         "className": true,
         "html": false,
         "spacing": {
-            "margin": ["top", "bottom"],
+            "margin": [
+                "top",
+                "bottom"
+            ],
             "padding": true,
             "blockGap": true,
             "__experimentalDefaultControls": {
@@ -55,7 +73,8 @@
                 "radius": true,
                 "style": true,
                 "width": true
-            }
+            },
+            "gradient": true
         },
         "typography": {
             "fontSize": true,

--- a/resources/js/visual-editor/blocks/tag-cloud/block.json
+++ b/resources/js/visual-editor/blocks/tag-cloud/block.json
@@ -31,8 +31,15 @@
         }
     },
     "styles": [
-        { "name": "default", "label": "Default", "isDefault": true },
-        { "name": "outline", "label": "Outline" }
+        {
+            "name": "default",
+            "label": "Default",
+            "isDefault": true
+        },
+        {
+            "name": "outline",
+            "label": "Outline"
+        }
     ],
     "supports": {
         "anchor": true,
@@ -63,7 +70,8 @@
                 "color": true,
                 "width": true,
                 "style": true
-            }
+            },
+            "gradient": true
         }
     }
 }

--- a/resources/js/visual-editor/blocks/term-description/block.json
+++ b/resources/js/visual-editor/blocks/term-description/block.json
@@ -6,17 +6,24 @@
     "category": "theme",
     "description": "Display the description of categories, tags and custom taxonomies when viewing an archive.",
     "textdomain": "artisanpack-visual-editor",
-    "usesContext": [ "termId", "taxonomy" ],
+    "usesContext": [
+        "termId",
+        "taxonomy"
+    ],
     "supports": {
         "anchor": true,
-        "align": [ "wide", "full" ],
+        "align": [
+            "wide",
+            "full"
+        ],
         "html": false,
         "color": {
             "link": true,
             "__experimentalDefaultControls": {
                 "background": true,
                 "text": true
-            }
+            },
+            "gradients": true
         },
         "spacing": {
             "padding": true,
@@ -49,7 +56,8 @@
                 "color": true,
                 "width": true,
                 "style": true
-            }
+            },
+            "gradient": true
         }
     }
 }

--- a/resources/js/visual-editor/blocks/verse/block.json
+++ b/resources/js/visual-editor/blocks/verse/block.json
@@ -5,7 +5,14 @@
     "title": "Poetry",
     "category": "text",
     "description": "Insert poetry. Use special spacing formats. Or quote song lyrics.",
-    "keywords": [ "poetry", "poem", "verse", "stanza", "song", "lyrics" ],
+    "keywords": [
+        "poetry",
+        "poem",
+        "verse",
+        "stanza",
+        "song",
+        "lyrics"
+    ],
     "textdomain": "artisanpack-visual-editor",
     "attributes": {
         "content": {
@@ -66,7 +73,8 @@
             "radius": true,
             "width": true,
             "color": true,
-            "style": true
+            "style": true,
+            "gradient": true
         },
         "interactivity": {
             "clientNavigation": true

--- a/resources/js/visual-editor/core-blocks/code/block.json
+++ b/resources/js/visual-editor/core-blocks/code/block.json
@@ -5,7 +5,11 @@
     "category": "text",
     "description": "Display code snippets with monospaced formatting.",
     "icon": "code",
-    "keywords": ["pre", "snippet", "syntax"],
+    "keywords": [
+        "pre",
+        "snippet",
+        "syntax"
+    ],
     "textdomain": "artisanpack-visual-editor",
     "attributes": {
         "content": {
@@ -16,9 +20,21 @@
             "type": "string",
             "default": "plaintext",
             "enum": [
-                "plaintext", "html", "css", "javascript", "typescript",
-                "php", "python", "ruby", "go", "rust", "json", "yaml",
-                "bash", "sql", "markdown"
+                "plaintext",
+                "html",
+                "css",
+                "javascript",
+                "typescript",
+                "php",
+                "python",
+                "ruby",
+                "go",
+                "rust",
+                "json",
+                "yaml",
+                "bash",
+                "sql",
+                "markdown"
             ]
         }
     },
@@ -37,7 +53,8 @@
             "color": true,
             "radius": true,
             "style": true,
-            "width": true
+            "width": true,
+            "gradient": true
         }
     }
 }

--- a/resources/js/visual-editor/core-blocks/heading/block.json
+++ b/resources/js/visual-editor/core-blocks/heading/block.json
@@ -5,7 +5,16 @@
     "category": "text",
     "description": "Introduce new sections and organize content to help readers scan.",
     "icon": "heading",
-    "keywords": ["title", "subtitle", "h1", "h2", "h3", "h4", "h5", "h6"],
+    "keywords": [
+        "title",
+        "subtitle",
+        "h1",
+        "h2",
+        "h3",
+        "h4",
+        "h5",
+        "h6"
+    ],
     "textdomain": "artisanpack-visual-editor",
     "attributes": {
         "content": {
@@ -49,7 +58,8 @@
             "color": true,
             "radius": true,
             "style": true,
-            "width": true
+            "width": true,
+            "gradient": true
         }
     }
 }

--- a/resources/js/visual-editor/core-blocks/list/block.json
+++ b/resources/js/visual-editor/core-blocks/list/block.json
@@ -5,7 +5,14 @@
     "category": "text",
     "description": "Create a bulleted or numbered list.",
     "icon": "list",
-    "keywords": ["ul", "ol", "bullet", "numbered", "ordered", "unordered"],
+    "keywords": [
+        "ul",
+        "ol",
+        "bullet",
+        "numbered",
+        "ordered",
+        "unordered"
+    ],
     "textdomain": "artisanpack-visual-editor",
     "attributes": {
         "ordered": {
@@ -26,7 +33,8 @@
         "color": {
             "background": true,
             "text": true,
-            "link": true
+            "link": true,
+            "gradients": true
         },
         "spacing": {
             "margin": true,

--- a/resources/js/visual-editor/core-blocks/preformatted/block.json
+++ b/resources/js/visual-editor/core-blocks/preformatted/block.json
@@ -5,7 +5,11 @@
     "category": "text",
     "description": "Preserve whitespace and line breaks in a monospaced block.",
     "icon": "terminal",
-    "keywords": ["pre", "ascii", "whitespace"],
+    "keywords": [
+        "pre",
+        "ascii",
+        "whitespace"
+    ],
     "textdomain": "artisanpack-visual-editor",
     "attributes": {
         "content": {
@@ -21,7 +25,8 @@
         "className": true,
         "color": {
             "background": true,
-            "text": true
+            "text": true,
+            "gradients": true
         },
         "spacing": {
             "margin": true,

--- a/resources/js/visual-editor/core-blocks/quote/block.json
+++ b/resources/js/visual-editor/core-blocks/quote/block.json
@@ -45,7 +45,8 @@
             "color": true,
             "radius": true,
             "style": true,
-            "width": true
+            "width": true,
+            "gradient": true
         }
     },
     "styles": [

--- a/resources/js/visual-editor/core-blocks/quote/block.json
+++ b/resources/js/visual-editor/core-blocks/quote/block.json
@@ -5,7 +5,11 @@
     "category": "text",
     "description": "Give quoted text visual emphasis.",
     "icon": "quote-left",
-    "keywords": ["blockquote", "citation", "pullquote"],
+    "keywords": [
+        "blockquote",
+        "citation",
+        "pullquote"
+    ],
     "textdomain": "artisanpack-visual-editor",
     "attributes": {
         "content": {
@@ -26,7 +30,8 @@
         "color": {
             "background": true,
             "text": true,
-            "link": true
+            "link": true,
+            "gradients": true
         },
         "spacing": {
             "margin": true,
@@ -44,7 +49,14 @@
         }
     },
     "styles": [
-        { "name": "default", "label": "Default", "isDefault": true },
-        { "name": "plain", "label": "Plain" }
+        {
+            "name": "default",
+            "label": "Default",
+            "isDefault": true
+        },
+        {
+            "name": "plain",
+            "label": "Plain"
+        }
     ]
 }

--- a/resources/js/visual-editor/editor/editor-app.tsx
+++ b/resources/js/visual-editor/editor/editor-app.tsx
@@ -44,6 +44,7 @@ import { registerResponsiveAttribute } from '../responsive/register-attribute';
 import { registerResponsiveAttributesFilter } from '../responsive/with-responsive-attributes';
 import { registerStateAttribute } from '../states/register-attribute';
 import { registerStateAttributesFilter } from '../states/with-state-attributes';
+import { registerGradientBorders } from '../gradient-borders/register';
 import { registerStateStylesFilters } from '../states/with-state-styles';
 import { StateInspectorSync } from '../states/StateInspectorSync';
 import { StateWriteInterceptor } from '../states/state-write-interceptor';
@@ -177,6 +178,12 @@ function registerOnce(): void {
     registerStateAttribute();
     registerStateAttributesFilter();
     registerStateStylesFilters();
+    // #490 — register the gradient-border feature filters BEFORE
+    // blocks load so the supports-extension fires at registration
+    // time (extending opted-in blocks' state/responsive routing lists
+    // automatically) and the BlockEdit HOC wraps every edit component
+    // on first render.
+    registerGradientBorders();
     // I7 (#415): register all artisanpack/* blocks and set the default
     // block to artisanpack/paragraph. Core blocks are no longer loaded.
     registerArtisanPackBlocks();

--- a/resources/js/visual-editor/gradient-borders/__tests__/emitter.test.ts
+++ b/resources/js/visual-editor/gradient-borders/__tests__/emitter.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest'
+
+import { TAILWIND_V4_DEFAULTS, BreakpointRegistry } from '../../responsive/registry'
+import { DEFAULT_STATES, StateRegistry } from '../../states/registry'
+import { emitGradientBorderCss } from '../emitter'
+import type { ResolvedGradientBorder } from '../types'
+
+const states      = new StateRegistry( DEFAULT_STATES )
+const breakpoints = new BreakpointRegistry( TAILWIND_V4_DEFAULTS )
+
+const baseline: ResolvedGradientBorder = {
+	idle:        null,
+	states:      {},
+	breakpoints: {},
+	width:       null,
+	radius:      null,
+}
+
+describe( 'emitGradientBorderCss', () => {
+	it( 'returns empty when scope is blank or payload is null', () => {
+		expect( emitGradientBorderCss( '', baseline, states, breakpoints ) ).toBe( '' )
+		expect( emitGradientBorderCss( '.scope', null, states, breakpoints ) ).toBe( '' )
+	} )
+
+	it( 'returns empty when the payload has no values anywhere', () => {
+		expect( emitGradientBorderCss( '.scope', baseline, states, breakpoints ) ).toBe(
+			'',
+		)
+	} )
+
+	it( 'emits the wrapper + mask ::before for an idle gradient', () => {
+		const css = emitGradientBorderCss(
+			'.scope',
+			{ ...baseline, idle: 'linear-gradient(135deg, #ff0000, #0000ff)', width: '2px' },
+			states,
+			breakpoints,
+		)
+
+		expect( css ).toContain( '.scope{position:relative;border-color:transparent !important}' )
+		expect( css ).toContain( '.scope::before{content:""' )
+		expect( css ).toContain( 'padding:2px' )
+		expect( css ).toContain( 'background:linear-gradient(135deg, #ff0000, #0000ff)' )
+		expect( css ).toContain( 'mask-composite:exclude' )
+		expect( css ).toContain( '-webkit-mask-composite:xor' )
+		expect( css ).toContain( 'pointer-events:none' )
+	} )
+
+	it( 'defaults width to 1px and radius to inherit when absent', () => {
+		const css = emitGradientBorderCss(
+			'.scope',
+			{ ...baseline, idle: 'red' },
+			states,
+			breakpoints,
+		)
+
+		expect( css ).toContain( 'padding:1px' )
+		expect( css ).toContain( 'border-radius:inherit' )
+	} )
+
+	it( 'emits explicit border-radius when supplied', () => {
+		const css = emitGradientBorderCss(
+			'.scope',
+			{ ...baseline, idle: 'red', radius: '8px' },
+			states,
+			breakpoints,
+		)
+
+		expect( css ).toContain( 'border-radius:8px' )
+	} )
+
+	it( 'expands per-corner radius objects to four declarations', () => {
+		const css = emitGradientBorderCss(
+			'.scope',
+			{
+				...baseline,
+				idle:   'red',
+				radius: {
+					topLeft:     '4px',
+					topRight:    '8px',
+					bottomLeft:  '12px',
+					bottomRight: '16px',
+				},
+			},
+			states,
+			breakpoints,
+		)
+
+		expect( css ).toContain( 'border-top-left-radius:4px' )
+		expect( css ).toContain( 'border-top-right-radius:8px' )
+		expect( css ).toContain( 'border-bottom-left-radius:12px' )
+		expect( css ).toContain( 'border-bottom-right-radius:16px' )
+	} )
+
+	it( 'wraps hover under @media (hover: hover) and emits the override', () => {
+		const css = emitGradientBorderCss(
+			'.scope',
+			{ ...baseline, idle: 'red', states: { hover: 'blue' } },
+			states,
+			breakpoints,
+		)
+
+		expect( css ).toContain( '@media (hover: hover){' )
+		expect( css ).toContain( '.scope:hover::before{background:blue}' )
+		expect( css ).toContain( '.scope::before{transition:' )
+	} )
+
+	it( 'emits per-breakpoint overrides under @media (min-width)', () => {
+		const css = emitGradientBorderCss(
+			'.scope',
+			{ ...baseline, idle: 'red', breakpoints: { md: 'blue' } },
+			states,
+			breakpoints,
+		)
+
+		expect( css ).toContain( '@media (min-width:768px){.scope::before{background:blue}}' )
+	} )
+
+	it( 'sanitises gradient and width values to drop context-breaking characters', () => {
+		const css = emitGradientBorderCss(
+			'.scope',
+			{
+				...baseline,
+				idle:  'linear-gradient(<script>red;</script>blue)',
+				width: '2px"; }</style>',
+			},
+			states,
+			breakpoints,
+		)
+
+		// `<`, `>`, `}`, `"`, `;` (in user payload) all stripped from
+		// the unsafe slots. `content:""` legitimately has the `"`
+		// character so we can't assert on a global absence — check the
+		// specific corrupted constructions instead.
+		expect( css ).not.toContain( '<script>' )
+		expect( css ).not.toContain( '</style>' )
+		expect( css ).not.toContain( 'padding:2px";' )
+		expect( css ).not.toContain( '}</' )
+	} )
+} )

--- a/resources/js/visual-editor/gradient-borders/__tests__/resolver.test.ts
+++ b/resources/js/visual-editor/gradient-borders/__tests__/resolver.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest'
+
+import { referencedSlugs, resolveGradientBorder } from '../resolver'
+
+describe( 'resolveGradientBorder', () => {
+	it( 'returns null when no gradient configuration exists', () => {
+		expect( resolveGradientBorder( null ) ).toBeNull()
+		expect( resolveGradientBorder( undefined ) ).toBeNull()
+		expect( resolveGradientBorder( {} ) ).toBeNull()
+		expect(
+			resolveGradientBorder( {
+				style: { border: { width: '2px' } },
+			} ),
+		).toBeNull()
+	} )
+
+	it( 'expands a slug into var(--wp--preset--gradient--{slug})', () => {
+		const resolved = resolveGradientBorder( {
+			style: { border: { gradient: 'primary-glow' } },
+		} )
+
+		expect( resolved ).not.toBeNull()
+		expect( resolved!.idle ).toBe( 'var(--wp--preset--gradient--primary-glow)' )
+	} )
+
+	it( 'passes raw CSS gradient values through unchanged', () => {
+		const raw      = 'linear-gradient(135deg, #ff0000, #0000ff)'
+		const resolved = resolveGradientBorder( {
+			style: { border: { gradient: raw } },
+		} )
+
+		expect( resolved!.idle ).toBe( raw )
+	} )
+
+	it( 'collects per-state and per-breakpoint overrides from the standard bags', () => {
+		const resolved = resolveGradientBorder( {
+			style:      { border: { gradient: 'primary-glow' } },
+			states:     {
+				'style.border.gradient': {
+					hover: 'accent-glow',
+					focus: null,
+				},
+			},
+			responsive: {
+				'style.border.gradient': {
+					md: 'vertical',
+				},
+			},
+		} )
+
+		expect( resolved!.states ).toEqual( {
+			hover: 'var(--wp--preset--gradient--accent-glow)',
+		} )
+		expect( resolved!.breakpoints ).toEqual( {
+			md: 'var(--wp--preset--gradient--vertical)',
+		} )
+	} )
+
+	it( 'accepts the shorthand `border.gradient` path key with canonical winning on conflict', () => {
+		const resolved = resolveGradientBorder( {
+			states: {
+				'border.gradient':       { hover: 'shorthand-loses' },
+				'style.border.gradient': { hover: 'canonical-wins' },
+			},
+		} )
+
+		expect( resolved!.states.hover ).toBe(
+			'var(--wp--preset--gradient--canonical-wins)',
+		)
+	} )
+
+	it( 'preserves border width and radius alongside the gradient', () => {
+		const resolved = resolveGradientBorder( {
+			style: {
+				border: {
+					gradient: 'primary-glow',
+					width:    '4px',
+					radius:   '12px',
+				},
+			},
+		} )
+
+		expect( resolved!.width ).toBe( '4px' )
+		expect( resolved!.radius ).toBe( '12px' )
+	} )
+} )
+
+describe( 'referencedSlugs', () => {
+	it( 'pulls slugs from every cascade slot', () => {
+		const slugs = referencedSlugs( {
+			style:      { border: { gradient: 'primary-glow' } },
+			states:     {
+				'style.border.gradient': { hover: 'primary-glow-bright' },
+			},
+			responsive: {
+				'style.border.gradient': { md: 'vertical' },
+			},
+		} )
+
+		expect( slugs.sort() ).toEqual( [
+			'primary-glow',
+			'primary-glow-bright',
+			'vertical',
+		] )
+	} )
+
+	it( 'deduplicates slugs that appear in multiple cascade slots', () => {
+		const slugs = referencedSlugs( {
+			style:      { border: { gradient: 'primary-glow' } },
+			states:     {
+				'style.border.gradient': { hover: 'primary-glow' },
+			},
+		} )
+
+		expect( slugs ).toEqual( [ 'primary-glow' ] )
+	} )
+
+	it( 'ignores raw CSS values — they cannot become stale', () => {
+		const slugs = referencedSlugs( {
+			style: {
+				border: {
+					gradient: 'radial-gradient(circle, #f00, #00f)',
+				},
+			},
+		} )
+
+		expect( slugs ).toEqual( [] )
+	} )
+} )

--- a/resources/js/visual-editor/gradient-borders/emitter.ts
+++ b/resources/js/visual-editor/gradient-borders/emitter.ts
@@ -104,6 +104,21 @@ function selectorFor( scope: string, selector: string ): string {
 }
 
 /**
+ * Append a pseudo-element suffix to every selector in a
+ * comma-separated list. Mirrors the PHP-side `appendPseudoToList`
+ * — see that docblock for the failure mode this prevents (a naive
+ * `${selector}::before` only suffixes the last selector).
+ */
+function appendPseudoToList( selector: string, pseudo: string ): string {
+	return selector
+		.split( ',' )
+		.map( ( s ) => s.trim() )
+		.filter( ( s ) => '' !== s )
+		.map( ( s ) => s + pseudo )
+		.join( ', ' )
+}
+
+/**
  * Emit the scoped CSS for a single block scope. Empty string when
  * the payload contains no actionable values.
  */
@@ -170,7 +185,7 @@ export function emitGradientBorderCss(
 			continue
 		}
 
-		const rule = `${ selector }::before{background:${ sanitizeGradient( stateMap[ stateKey ] ) }}`
+		const rule = `${ appendPseudoToList( selector, '::before' ) }{background:${ sanitizeGradient( stateMap[ stateKey ] ) }}`
 
 		if ( definition.hoverMediaWrap ) {
 			hoverParts.push( rule )

--- a/resources/js/visual-editor/gradient-borders/emitter.ts
+++ b/resources/js/visual-editor/gradient-borders/emitter.ts
@@ -1,0 +1,204 @@
+/**
+ * Client-side CSS emitter for gradient borders (#490).
+ *
+ * Mirrors the PHP `GradientBorderEmitter` byte-for-byte so the editor
+ * canvas preview matches the rendered front-end. See the PHP file's
+ * docblock for the strategy rationale (single mask-pseudo emission
+ * for all gradient kinds × radius combinations).
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.1.0
+ */
+
+import type { BreakpointRegistry } from '../responsive/registry'
+import type { StateRegistry } from '../states/registry'
+import type { ResolvedGradientBorder } from './types'
+
+export const DEFAULT_TRANSITION =
+	'background 200ms ease, opacity 200ms ease'
+
+const CSS_WHITELIST     = /[^a-zA-Z0-9_+\-*/.,()%#\s]/g
+const GRADIENT_WHITELIST = /[^a-zA-Z0-9_+\-*/.,()%#:\s]/g
+
+function sanitizeCss( value: string ): string {
+	return value.replace( CSS_WHITELIST, '' )
+}
+
+function sanitizeGradient( value: string ): string {
+	return value.replace( GRADIENT_WHITELIST, '' )
+}
+
+function radiusDeclaration( radius: ResolvedGradientBorder[ 'radius' ] ): string {
+	if ( 'string' === typeof radius && '' !== radius.trim() ) {
+		return `border-radius:${ sanitizeCss( radius ) };`
+	}
+
+	if ( radius && 'object' === typeof radius ) {
+		const pieces: string[] = []
+
+		const corners: Array<[string, string]> = [
+			[ 'topLeft', 'top-left' ],
+			[ 'topRight', 'top-right' ],
+			[ 'bottomLeft', 'bottom-left' ],
+			[ 'bottomRight', 'bottom-right' ],
+		]
+
+		for ( const [ key, cssKey ] of corners ) {
+			const value = ( radius as Record<string, unknown> )[ key ]
+
+			if ( 'string' !== typeof value || '' === value.trim() ) {
+				continue
+			}
+
+			pieces.push( `border-${ cssKey }-radius:${ sanitizeCss( value ) }` )
+		}
+
+		if ( 0 < pieces.length ) {
+			return pieces.join( ';' ) + ';'
+		}
+	}
+
+	return 'border-radius:inherit;'
+}
+
+function baseBeforeDeclarations(
+	gradient: string,
+	width: string,
+	radius: ResolvedGradientBorder[ 'radius' ],
+): string {
+	const radiusDecl = radiusDeclaration( radius )
+	const safeWidth  = sanitizeCss( width )
+
+	// `inset: calc(-1 * <width>)` extends the pseudo OUTWARD by the
+	// border-width so its outer edge aligns with the wrapper's
+	// border-box. Combined with `padding: <width>`, the mask cut-out
+	// leaves a `<width>`-wide ring sitting exactly where the wrapper's
+	// native border would render. Mirrors the PHP emitter — see the
+	// docblock there for the visual rationale.
+	return (
+		`content:"";position:absolute;inset:calc(-1 * ${ safeWidth });padding:${ safeWidth };`
+		+ radiusDecl
+		+ `background:${ sanitizeGradient( gradient ) };`
+		+ '-webkit-mask:linear-gradient(#000 0 0) content-box,linear-gradient(#000 0 0);'
+		+ '-webkit-mask-composite:xor;'
+		+ 'mask:linear-gradient(#000 0 0) content-box,linear-gradient(#000 0 0);'
+		+ 'mask-composite:exclude;pointer-events:none'
+	)
+}
+
+function selectorFor( scope: string, selector: string ): string {
+	if ( '' === selector ) {
+		return ''
+	}
+
+	return selector
+		.split( ',' )
+		.map( ( s ) => s.trim() )
+		.filter( ( s ) => '' !== s )
+		.map( ( piece ) =>
+			piece.includes( '&' )
+				? piece.replaceAll( '&', scope )
+				: `${ scope }${ piece }`,
+		)
+		.join( ', ' )
+}
+
+/**
+ * Emit the scoped CSS for a single block scope. Empty string when
+ * the payload contains no actionable values.
+ */
+export function emitGradientBorderCss(
+	scope: string,
+	payload: ResolvedGradientBorder | null | undefined,
+	states: StateRegistry,
+	breakpoints: BreakpointRegistry,
+): string {
+	const trimmedScope = scope.trim()
+
+	if ( '' === trimmedScope || ! payload ) {
+		return ''
+	}
+
+	const idle     = payload.idle
+	const stateMap = payload.states
+	const bpMap    = payload.breakpoints
+	const width    = payload.width ?? '1px'
+
+	const hasNonIdle =
+		0 < Object.keys( stateMap ).length || 0 < Object.keys( bpMap ).length
+
+	if ( null === idle && ! hasNonIdle ) {
+		return ''
+	}
+
+	const rules: string[] = []
+
+	// `border-color: transparent !important` suppresses any stale
+	// `style.border.color` value left over from before the block was
+	// switched to a gradient border (or written by a host that still
+	// has the native color picker enabled). Without it the native
+	// `applyBorder` would paint a solid edge underneath our gradient
+	// `::before` and the user would see two stacked borders.
+	rules.push(
+		`${ trimmedScope }{position:relative;border-color:transparent !important}`,
+	)
+
+	const idleGradient = idle ?? 'transparent'
+	rules.push(
+		`${ trimmedScope }::before{${ baseBeforeDeclarations( idleGradient, width, payload.radius ) }}`,
+	)
+
+	if ( hasNonIdle ) {
+		rules.push(
+			`${ trimmedScope }::before{transition:${ DEFAULT_TRANSITION }}`,
+		)
+	}
+
+	const hoverParts:    string[] = []
+	const nonHoverParts: string[] = []
+
+	for ( const stateKey of Object.keys( stateMap ) ) {
+		const definition = states.get( stateKey )
+
+		if ( ! definition ) {
+			continue
+		}
+
+		const selector = selectorFor( trimmedScope, definition.selector )
+
+		if ( '' === selector ) {
+			continue
+		}
+
+		const rule = `${ selector }::before{background:${ sanitizeGradient( stateMap[ stateKey ] ) }}`
+
+		if ( definition.hoverMediaWrap ) {
+			hoverParts.push( rule )
+			continue
+		}
+
+		nonHoverParts.push( rule )
+	}
+
+	if ( 0 < hoverParts.length ) {
+		rules.push( `@media (hover: hover){${ hoverParts.join( '' ) }}` )
+	}
+
+	for ( const rule of nonHoverParts ) {
+		rules.push( rule )
+	}
+
+	for ( const breakpointKey of Object.keys( bpMap ) ) {
+		const minWidth = breakpoints.get( breakpointKey )
+
+		if ( null === minWidth ) {
+			continue
+		}
+
+		rules.push(
+			`@media (min-width:${ minWidth }px){${ trimmedScope }::before{background:${ sanitizeGradient( bpMap[ breakpointKey ] ) }}}`,
+		)
+	}
+
+	return rules.join( '' )
+}

--- a/resources/js/visual-editor/gradient-borders/extend-supports.ts
+++ b/resources/js/visual-editor/gradient-borders/extend-supports.ts
@@ -1,0 +1,141 @@
+/**
+ * `blocks.registerBlockType` filter — auto-add `border.gradient` to the
+ * `artisanpackStates.attributes` and `artisanpackResponsive.attributes`
+ * routing lists when a block opts into
+ * `supports.__experimentalBorder.gradient: true` (#490).
+ *
+ * Saves every block's `block.json` from having to repeat the
+ * `border.gradient` path in both lists by hand. Without this filter the
+ * generic state/responsive HOCs would treat gradient writes as
+ * non-routable and fall through to the base idle bag — silently
+ * losing the per-state/per-breakpoint cascade the inspector chip
+ * promised.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.1.0
+ */
+
+import { addFilter } from '@wordpress/hooks'
+
+const FILTER_HOOK      = 'blocks.registerBlockType'
+const FILTER_NAMESPACE = 'artisanpack-ui/visual-editor/gradient-border-supports'
+
+const REGISTERED_KEY = Symbol.for(
+	'artisanpack-ui.visual-editor.gradient-border-supports.registered',
+)
+
+interface GlobalSentinelHost {
+	[REGISTERED_KEY]?: boolean
+}
+
+interface BorderSupport {
+	gradient?: boolean
+	[key: string]: unknown
+}
+
+interface RoutingSupport {
+	attributes?: string[]
+	[key: string]: unknown
+}
+
+interface BlockSupports {
+	border?: BorderSupport
+	__experimentalBorder?: BorderSupport
+	artisanpackStates?: RoutingSupport | boolean
+	artisanpackResponsive?: RoutingSupport | boolean
+	[key: string]: unknown
+}
+
+interface BlockSettingsLike {
+	supports?: BlockSupports
+	[key: string]: unknown
+}
+
+const ROUTING_PATH = 'border.gradient'
+
+function gradientEnabled( supports: BlockSupports | undefined ): boolean {
+	if ( ! supports ) {
+		return false
+	}
+
+	const border = supports.__experimentalBorder ?? supports.border
+
+	if ( ! border || 'object' !== typeof border ) {
+		return false
+	}
+
+	return true === border.gradient
+}
+
+function ensureRouted(
+	supports: BlockSupports,
+	key: 'artisanpackStates' | 'artisanpackResponsive',
+): RoutingSupport {
+	const raw = supports[ key ]
+
+	if ( ! raw || 'boolean' === typeof raw ) {
+		return { attributes: [ ROUTING_PATH ] }
+	}
+
+	if ( 'object' !== typeof raw ) {
+		return { attributes: [ ROUTING_PATH ] }
+	}
+
+	const attributes = Array.isArray( raw.attributes ) ? raw.attributes : []
+
+	if ( attributes.includes( ROUTING_PATH ) ) {
+		return raw
+	}
+
+	return {
+		...raw,
+		attributes: [ ...attributes, ROUTING_PATH ],
+	}
+}
+
+function injectGradientBorderSupports(
+	settings: BlockSettingsLike,
+): BlockSettingsLike {
+	if ( ! gradientEnabled( settings.supports ) ) {
+		return settings
+	}
+
+	const supports = settings.supports as BlockSupports
+
+	// IMPORTANT: we deliberately do NOT disable `__experimentalBorder.color`.
+	// Gutenberg's `BorderBoxControl` bundles color + width + style + the
+	// popover into one component — there's no flag to disable the color
+	// slot while keeping style. Flipping `color: false` either removes
+	// the whole BorderBoxControl (when width and style are also off) or
+	// has no effect on the color popover content (the picker is rendered
+	// unconditionally inside `BorderControlDropdown`'s popover regardless
+	// of the supports.color flag). So we leave the native picker as-is;
+	// our gradient picker is a sibling, not a replacement. When BOTH a
+	// solid color and a gradient are set, the gradient wins visually via
+	// `border-color: transparent !important` in `GradientBorderEmitter`.
+	const nextSupports: BlockSupports = {
+		...supports,
+		artisanpackStates:     ensureRouted( supports, 'artisanpackStates' ),
+		artisanpackResponsive: ensureRouted( supports, 'artisanpackResponsive' ),
+	}
+
+	return {
+		...settings,
+		supports: nextSupports,
+	}
+}
+
+/**
+ * Register the filter at most once per page. Idempotent — safe to
+ * call from both the post-editor and site-editor entries.
+ */
+export function registerGradientBorderSupportsExtension(): void {
+	const host = globalThis as unknown as GlobalSentinelHost
+
+	if ( host[ REGISTERED_KEY ] ) {
+		return
+	}
+
+	addFilter( FILTER_HOOK, FILTER_NAMESPACE, injectGradientBorderSupports )
+	host[ REGISTERED_KEY ] = true
+}

--- a/resources/js/visual-editor/gradient-borders/extend-supports.ts
+++ b/resources/js/visual-editor/gradient-borders/extend-supports.ts
@@ -70,10 +70,18 @@ function gradientEnabled( supports: BlockSupports | undefined ): boolean {
 function ensureRouted(
 	supports: BlockSupports,
 	key: 'artisanpackStates' | 'artisanpackResponsive',
-): RoutingSupport {
+): RoutingSupport | false {
 	const raw = supports[ key ]
 
-	if ( ! raw || 'boolean' === typeof raw ) {
+	// Explicit opt-out — a block.json that declares the feature as
+	// `false` is asking for the state/responsive routing to be off
+	// entirely. Flipping that into the default routing list would
+	// reverse a deliberate decision; preserve it instead.
+	if ( false === raw ) {
+		return false
+	}
+
+	if ( raw === undefined || raw === null || true === raw ) {
 		return { attributes: [ ROUTING_PATH ] }
 	}
 

--- a/resources/js/visual-editor/gradient-borders/index.ts
+++ b/resources/js/visual-editor/gradient-borders/index.ts
@@ -1,0 +1,26 @@
+/**
+ * Public entry point for the gradient border feature (#490).
+ *
+ * Mirrors the deliberate split the responsive feature uses: the
+ * HOC + filter registrars (`with-gradient-border-control`,
+ * `extend-supports`) are NOT re-exported here. They import
+ * `@wordpress/blocks`, which trips JSON-import-attribute requirements
+ * when host bundlers (or Vitest) walk this barrel transitively. The
+ * editor bootstrap imports them directly from
+ * `./with-gradient-border-control` and `./extend-supports` (or via
+ * `./register` for the one-shot helper).
+ *
+ * What lives in the barrel: pure data types and the resolver/emitter
+ * helpers that any host can call without booting Gutenberg.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.1.0
+ */
+
+export { resolveGradientBorder, referencedSlugs } from './resolver'
+export { emitGradientBorderCss, DEFAULT_TRANSITION } from './emitter'
+export type {
+	GradientBorderAttributes,
+	BorderSubtree,
+	ResolvedGradientBorder,
+} from './types'

--- a/resources/js/visual-editor/gradient-borders/register.ts
+++ b/resources/js/visual-editor/gradient-borders/register.ts
@@ -1,0 +1,32 @@
+/**
+ * One-shot registrar for the gradient border feature (#490).
+ *
+ * Bootstraps both the BlockEdit HOC (inspector picker + token-missing
+ * warning) and the supports-extension filter (auto-add `border.gradient`
+ * to opted-in blocks' state/responsive routing lists).
+ *
+ * Kept in its own file rather than the package barrel so host bundlers
+ * that walk `./index.ts` transitively don't pull in `@wordpress/blocks`
+ * (which would trip JSON-import-attribute checks). The post-editor and
+ * site-editor bootstraps import this file directly.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.1.0
+ */
+
+import { registerGradientBorderControl } from './with-gradient-border-control'
+import { registerGradientBorderSupportsExtension } from './extend-supports'
+import { registerGradientBorderStylesFilters } from './with-gradient-border-styles'
+
+/**
+ * Install every filter the gradient border feature needs. Idempotent —
+ * each registrar guards itself with a sentinel so calling this from
+ * both post-editor and site-editor entries is safe.
+ *
+ * @since 1.1.0
+ */
+export function registerGradientBorders(): void {
+	registerGradientBorderSupportsExtension()
+	registerGradientBorderControl()
+	registerGradientBorderStylesFilters()
+}

--- a/resources/js/visual-editor/gradient-borders/resolver.ts
+++ b/resources/js/visual-editor/gradient-borders/resolver.ts
@@ -1,0 +1,186 @@
+/**
+ * Resolver — walks a block's attribute tree and normalises the gradient
+ * border payload.
+ *
+ * Mirrors PHP `GradientBorderResolver::resolve` exactly so the editor
+ * preview and server render produce byte-identical CSS:
+ *
+ * - Idle value lives at `style.border.gradient` (string slug or raw CSS).
+ * - Per-state overrides ride `attributes.states['style.border.gradient']`
+ *   (canonical) or `['border.gradient']` (shorthand).
+ * - Per-breakpoint overrides ride `attributes.responsive['style.border.gradient']`.
+ *
+ * Slug values (`primary-glow`) become
+ * `var(--wp--preset--gradient--primary-glow)`. Raw CSS values pass
+ * through. Empty / null / non-string values are stripped.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.1.0
+ */
+
+import type {
+	GradientBorderAttributes,
+	ResolvedGradientBorder,
+} from './types'
+
+const SLUG_RE        = /^[a-z0-9][a-z0-9_-]*$/i
+const GRADIENT_PATHS = [ 'style.border.gradient', 'border.gradient' ]
+
+function expandGradient( value: unknown ): string | null {
+	if ( 'string' !== typeof value ) {
+		return null
+	}
+
+	const trimmed = value.trim()
+
+	if ( '' === trimmed ) {
+		return null
+	}
+
+	if ( SLUG_RE.test( trimmed ) ) {
+		return `var(--wp--preset--gradient--${ trimmed })`
+	}
+
+	return trimmed
+}
+
+function collectOverrides(
+	bag: Record<string, Record<string, string | null>> | null | undefined,
+): Record<string, string> {
+	if ( ! bag || 'object' !== typeof bag ) {
+		return {}
+	}
+
+	const out: Record<string, string> = {}
+
+	// Iterate in reverse-precedence so the canonical path overwrites
+	// the shorthand; last-write-wins on assignment.
+	for ( const path of [ ...GRADIENT_PATHS ].reverse() ) {
+		const overrides = bag[ path ]
+
+		if ( ! overrides || 'object' !== typeof overrides ) {
+			continue
+		}
+
+		for ( const key of Object.keys( overrides ) ) {
+			if ( '' === key ) {
+				continue
+			}
+
+			const expanded = expandGradient( overrides[ key ] )
+
+			if ( null === expanded ) {
+				continue
+			}
+
+			out[ key ] = expanded
+		}
+	}
+
+	return out
+}
+
+/**
+ * Resolve a block's attribute tree into the normalised payload the
+ * emitter consumes. Returns `null` when no gradient configuration
+ * exists at any cascade level — callers should skip emission entirely
+ * in that case.
+ */
+export function resolveGradientBorder(
+	attributes: GradientBorderAttributes | null | undefined,
+): ResolvedGradientBorder | null {
+	if ( ! attributes || 'object' !== typeof attributes ) {
+		return null
+	}
+
+	const border      = attributes.style?.border ?? null
+	const idle        = expandGradient( border?.gradient )
+	const states      = collectOverrides( attributes.states )
+	const breakpoints = collectOverrides( attributes.responsive )
+
+	if (
+		null === idle
+		&& 0 === Object.keys( states ).length
+		&& 0 === Object.keys( breakpoints ).length
+	) {
+		return null
+	}
+
+	const width =
+		border && 'string' === typeof border.width && '' !== border.width.trim()
+			? border.width.trim()
+			: null
+
+	const radius = border
+		? ( 'string' === typeof border.radius
+			? border.radius
+			: ( border.radius && 'object' === typeof border.radius
+				? ( border.radius as Record<string, unknown> )
+				: null ) )
+		: null
+
+	return {
+		idle,
+		states,
+		breakpoints,
+		width,
+		radius,
+	}
+}
+
+/**
+ * Pluck every gradient slug referenced anywhere in a block's attribute
+ * tree (idle + per-state + per-breakpoint). Used by the editor's token-
+ * warning surface to flag references whose theme token was renamed or
+ * removed.
+ */
+export function referencedSlugs(
+	attributes: GradientBorderAttributes | null | undefined,
+): string[] {
+	if ( ! attributes || 'object' !== typeof attributes ) {
+		return []
+	}
+
+	const slugs: string[] = []
+
+	collectSlug( slugs, attributes.style?.border?.gradient )
+	collectSlugsFromBag( slugs, attributes.states )
+	collectSlugsFromBag( slugs, attributes.responsive )
+
+	return Array.from( new Set( slugs ) )
+}
+
+function collectSlug( slugs: string[], value: unknown ): void {
+	if ( 'string' !== typeof value ) {
+		return
+	}
+
+	const trimmed = value.trim()
+
+	if ( '' === trimmed || ! SLUG_RE.test( trimmed ) ) {
+		return
+	}
+
+	slugs.push( trimmed )
+}
+
+function collectSlugsFromBag(
+	slugs: string[],
+	bag: Record<string, Record<string, string | null>> | null | undefined,
+): void {
+	if ( ! bag || 'object' !== typeof bag ) {
+		return
+	}
+
+	for ( const path of GRADIENT_PATHS ) {
+		const overrides = bag[ path ]
+
+		if ( ! overrides || 'object' !== typeof overrides ) {
+			continue
+		}
+
+		for ( const key of Object.keys( overrides ) ) {
+			collectSlug( slugs, overrides[ key ] )
+		}
+	}
+}

--- a/resources/js/visual-editor/gradient-borders/types.ts
+++ b/resources/js/visual-editor/gradient-borders/types.ts
@@ -1,0 +1,43 @@
+/**
+ * Shared types for the gradient border feature (#490).
+ *
+ * Mirrors the PHP-side `GradientBorderResolver` + `GradientBorderEmitter`
+ * shapes so the editor's preview canvas stays in sync with the
+ * server-rendered front-end.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.1.0
+ */
+
+export interface ResolvedGradientBorder {
+	idle: string | null
+	states: Record<string, string>
+	breakpoints: Record<string, string>
+	width: string | null
+	radius: string | Record<string, unknown> | null
+}
+
+/**
+ * Sub-shape of `attributes.style.border` the resolver reads. Only the
+ * fields the gradient pipeline touches are listed — the rest of the
+ * border attribute tree (color, style, per-side) flows through the
+ * standard `BlockSupports::applyBorder` path unchanged.
+ */
+export interface BorderSubtree {
+	gradient?: string | null
+	width?: string | null
+	radius?: string | Record<string, unknown> | null
+	[key: string]: unknown
+}
+
+/**
+ * Block attribute tree as far as the resolver / warning surface is
+ * concerned. The block can carry any other attributes alongside; only
+ * the slots we read are typed.
+ */
+export interface GradientBorderAttributes {
+	style?: { border?: BorderSubtree } | null
+	states?: Record<string, Record<string, string | null>> | null
+	responsive?: Record<string, Record<string, string | null>> | null
+	[key: string]: unknown
+}

--- a/resources/js/visual-editor/gradient-borders/with-gradient-border-control.tsx
+++ b/resources/js/visual-editor/gradient-borders/with-gradient-border-control.tsx
@@ -1,0 +1,470 @@
+/**
+ * `editor.BlockEdit` HOC — inject a unified Border color + gradient
+ * picker into the inspector (#490).
+ *
+ * Uses Gutenberg's `__experimentalColorGradientControl` rendered inline
+ * inside a `ToolsPanelItem` so the user sees the same tabbed Color |
+ * Gradient UX they get for background and text colors — the tabs are
+ * always visible (no popover indirection). Picking a solid color writes
+ * to `attributes.style.border.color`; picking a gradient writes to
+ * `attributes.style.border.gradient`. Choosing a gradient clears the
+ * solid color (and vice versa) — only one value is "active" at a time
+ * since CSS itself can't render both as a border simultaneously.
+ *
+ * Placement: `InspectorControls group="border"` so the dropdown lands
+ * inside the native Border tools panel next to the radius / width
+ * controls.
+ *
+ * State + breakpoint composition is handled by the standard
+ * `withStateAttributes` / `withResponsiveAttributes` HOCs: when the
+ * inspector chip is on `hover` (or `md`, etc.), our write is routed
+ * automatically into `attributes.states['style.border.gradient']` /
+ * `attributes.responsive['style.border.gradient']`.
+ *
+ * A token-missing warning surfaces above the picker when a referenced
+ * gradient slug isn't present in the resolved settings.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.1.0
+ */
+
+import {
+	BaseControl,
+	Button,
+	ColorIndicator,
+	Dropdown,
+	Notice,
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
+	__experimentalToolsPanelItem as ToolsPanelItem,
+} from '@wordpress/components'
+import { createHigherOrderComponent } from '@wordpress/compose'
+import { getBlockType } from '@wordpress/blocks'
+import {
+	InspectorControls,
+	// eslint-disable-next-line camelcase
+	__experimentalColorGradientControl as ColorGradientControl,
+} from '@wordpress/block-editor'
+import { useSelect } from '@wordpress/data'
+import { addFilter } from '@wordpress/hooks'
+import { __, sprintf } from '@wordpress/i18n'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
+import type { ComponentType } from 'react'
+
+import { referencedSlugs } from './resolver'
+import type { GradientBorderAttributes } from './types'
+
+const FILTER_HOOK      = 'editor.BlockEdit'
+const FILTER_NAMESPACE = 'artisanpack-ui/visual-editor/gradient-border-control'
+
+const REGISTERED_KEY = Symbol.for(
+	'artisanpack-ui.visual-editor.gradient-border-control.registered',
+)
+
+interface GlobalSentinelHost {
+	[REGISTERED_KEY]?: boolean
+}
+
+interface BlockEditProps {
+	name: string
+	clientId?: string
+	attributes: GradientBorderAttributes & Record<string, unknown>
+	setAttributes: ( updates: Record<string, unknown> ) => void
+	[key: string]: unknown
+}
+
+interface ThemeGradientEntry {
+	slug?: string
+	name?: string
+	gradient?: string
+}
+
+interface BlockEditorSettings {
+	gradients?: ThemeGradientEntry[]
+	[key: string]: unknown
+}
+
+function blockSupportsGradientBorder( name: string ): boolean {
+	const blockType = getBlockType( name )
+
+	if ( ! blockType ) {
+		return false
+	}
+
+	const support = ( blockType.supports as Record<string, unknown> | undefined )?.[ '__experimentalBorder' ]
+		?? ( blockType.supports as Record<string, unknown> | undefined )?.[ 'border' ]
+
+	if ( ! support || 'object' !== typeof support ) {
+		return false
+	}
+
+	return true === ( support as Record<string, unknown> ).gradient
+}
+
+function readBorder(
+	attributes: GradientBorderAttributes,
+): { color: string | null; gradient: string | null; style: string | null } {
+	const border = attributes.style?.border ?? null
+	const borderStyle = border && 'string' === typeof ( border as Record<string, unknown> ).style
+		? ( ( border as Record<string, unknown> ).style as string )
+		: null
+
+	return {
+		color:    border && 'string' === typeof border.color ? border.color as string : null,
+		gradient: border && 'string' === typeof border.gradient ? border.gradient : null,
+		style:    borderStyle,
+	}
+}
+
+interface BorderPatch {
+	color?: string | null
+	gradient?: string | null
+	style?: string | null
+}
+
+function applyPatchToBorder(
+	border: Record<string, unknown>,
+	patch: BorderPatch,
+): Record<string, unknown> {
+	const next: Record<string, unknown> = { ...border }
+
+	for ( const key of [ 'color', 'gradient', 'style' ] as const ) {
+		if ( ! ( key in patch ) ) {
+			continue
+		}
+
+		const value = patch[ key ]
+
+		if ( null === value || '' === value ) {
+			delete next[ key ]
+		} else {
+			next[ key ] = value
+		}
+	}
+
+	return next
+}
+
+/**
+ * Build a stable border-writer that survives the back-to-back
+ * `onColorChange` + `onGradientChange` calls Gutenberg's
+ * `ColorGradientControl` fires when the user picks a value. Both calls
+ * happen synchronously in the same event handler; using
+ * `attributes.style.border` from the React closure leaves the second
+ * call reading STALE state and overwriting the first call's write
+ * (gradient set, then immediately cleared — the symptom is the
+ * Gradient tab snapping back to Color after a swatch click).
+ *
+ * The fix: track the latest-written border in a ref that updates
+ * synchronously inside `write`. Subsequent calls within the same tick
+ * see the just-written state.
+ */
+function useBorderWriter(
+	attributes: GradientBorderAttributes,
+	setAttributes: ( updates: Record<string, unknown> ) => void,
+): ( patch: BorderPatch ) => void {
+	const borderRef = useRef< Record<string, unknown> >(
+		( attributes.style?.border as Record<string, unknown> | undefined ) ?? {},
+	)
+	const styleRef = useRef< Record<string, unknown> >(
+		( attributes.style as Record<string, unknown> | undefined ) ?? {},
+	)
+
+	// Keep refs in sync with the canonical attributes after each
+	// render so picks on stale data don't overwrite changes made by
+	// other inspectors in the meantime.
+	useEffect( () => {
+		borderRef.current = ( attributes.style?.border as Record<string, unknown> | undefined ) ?? {}
+		styleRef.current  = ( attributes.style as Record<string, unknown> | undefined ) ?? {}
+	}, [ attributes.style, attributes.style?.border ] )
+
+	return useCallback(
+		( patch ) => {
+			const nextBorder = applyPatchToBorder( borderRef.current, patch )
+			// Update the ref BEFORE setAttributes so a follow-up call
+			// inside the same event handler reads the patched state.
+			borderRef.current = nextBorder
+			const nextStyle = { ...styleRef.current, border: nextBorder }
+			styleRef.current = nextStyle
+
+			setAttributes( { style: nextStyle } )
+		},
+		[ setAttributes ],
+	)
+}
+
+/**
+ * Render-inline token-missing warning. Sits above the dropdown's tabs
+ * when one or more referenced slugs no longer resolves to a theme
+ * entry.
+ */
+function MissingTokenWarning(
+	{ missing }: { missing: string[] },
+): JSX.Element | null {
+	if ( 0 === missing.length ) {
+		return null
+	}
+
+	return (
+		<Notice
+			status="warning"
+			isDismissible={ false }
+			className="ap-gradient-border__missing-token-notice"
+		>
+			{ sprintf(
+				/* translators: %s: comma-separated list of slugs. */
+				__( 'Gradient token(s) no longer available: %s. The affected breakpoint or state will render as transparent until restored.', 'artisanpack-visual-editor' ),
+				missing.join( ', ' ),
+			) }
+		</Notice>
+	)
+}
+
+export const withGradientBorderControl = createHigherOrderComponent(
+	( BlockEdit: ComponentType<BlockEditProps> ) => {
+		function GradientBorderBlockEdit( props: BlockEditProps ): JSX.Element {
+			const { name, attributes, setAttributes, clientId } = props
+
+			const enabled = useMemo(
+				() => blockSupportsGradientBorder( name ),
+				[ name ],
+			)
+
+			const { themeGradients, themeColors } = useSelect(
+				( select ) => {
+					const settings = (
+						select( 'core/block-editor' ) as {
+							getSettings: () => BlockEditorSettings & { colors?: unknown[] }
+						}
+					 ).getSettings()
+
+					return {
+						themeGradients: Array.isArray( settings?.gradients ) ? settings.gradients : [],
+						themeColors:    Array.isArray( settings?.colors ) ? settings.colors : [],
+					}
+				},
+				[],
+			)
+
+			// Tab visibility in `ColorGradientControl` requires BOTH:
+			// (a) both onColorChange and onGradientChange, and (b) a
+			// non-empty `gradients` palette. The
+			// `useMultipleOriginColorsAndGradients` hook can return
+			// empty arrays in a dev theme that doesn't ship multi-
+			// origin palettes — so we pass `colors` and `gradients`
+			// explicitly from `getSettings()`, which mirrors what the
+			// editor's own background picker reads.
+
+			const missing = useMemo( () => {
+				if ( ! enabled ) {
+					return []
+				}
+
+				const referenced = referencedSlugs( attributes )
+				const knownSlugs = new Set(
+					themeGradients
+						.map( ( entry ) => ( 'string' === typeof entry?.slug ? entry.slug : null ) )
+						.filter( ( slug ): slug is string => null !== slug && '' !== slug ),
+				)
+
+				return referenced.filter( ( slug ) => ! knownSlugs.has( slug ) )
+			}, [ enabled, attributes, themeGradients ] )
+
+			// Must be declared unconditionally for Rules of Hooks; the
+			// writer only fires when the picker is interacted with, so
+			// the cost on blocks without gradient support is one extra
+			// ref pair per BlockEdit instance.
+			const writeBorder = useBorderWriter( attributes, setAttributes )
+
+			if ( ! enabled ) {
+				return <BlockEdit { ...props } />
+			}
+
+			const { color, gradient, style: borderStyle } = readBorder( attributes )
+
+			return (
+				<>
+					<BlockEdit { ...props } />
+					<InspectorControls group="border">
+						{ /* Replicate the native BorderControlDropdown UX:
+						     - hide the bundled native swatch+popover trigger
+						     - render OUR own swatch+popover with Color | Gradient
+						       tabs inside (matching the background picker's UX)
+						     - reorder via CSS so our swatch lands at the top of
+						       the Border panel where the native one used to sit
+						     The `<style>` MUST live inside `<InspectorControls>`
+						     so it portals into the inspector sidebar's document. */ }
+						<style>{ `
+							button[aria-label*="Border color and style picker"],
+							button[aria-label*="Border color picker"],
+							button[aria-label*="Border style picker"] {
+								display: none !important;
+							}
+							/* Render our picker as the first item in the
+							   Border tools panel so it visually replaces
+							   the native swatch + style trigger. The panel
+							   lays out children in source order; CSS order
+							   shifts ours to the front without touching the
+							   width / radius native items. */
+							.ap-border-picker-item {
+								order: -1;
+							}
+						` }</style>
+						<ToolsPanelItem
+							panelId={ clientId }
+							className="ap-border-picker-item"
+							hasValue={ () =>
+								null !== color || null !== gradient || null !== borderStyle
+							}
+							label={ __( 'Border', 'artisanpack-visual-editor' ) }
+							onDeselect={ () =>
+								writeBorder( { color: null, gradient: null, style: null } )
+							}
+							isShownByDefault
+						>
+							<BaseControl __nextHasNoMarginBottom>
+								<MissingTokenWarning missing={ missing } />
+								<Dropdown
+									contentClassName="ap-border-picker__content"
+									popoverProps={ { placement: 'left-start', offset: 36 } }
+									renderToggle={ ( { onToggle, isOpen }: {
+										onToggle: () => void
+										isOpen:   boolean
+									} ) => (
+										<Button
+											onClick={ onToggle }
+											aria-expanded={ isOpen }
+											aria-haspopup="dialog"
+											aria-label={ __(
+												'Border color, gradient, and style picker',
+												'artisanpack-visual-editor',
+											) }
+											className="ap-border-picker__toggle"
+										>
+											{ /* Mirror the native swatch shape: a
+											     small ColorIndicator + label row.
+											     Showing the gradient as the swatch
+											     fill when one is selected keeps the
+											     UI honest about what's actually
+											     painting. */ }
+											<ColorIndicator
+												colorValue={ gradient ?? color ?? undefined }
+											/>
+											<span style={ { marginLeft: 8 } }>
+												{ __( 'Border', 'artisanpack-visual-editor' ) }
+											</span>
+										</Button>
+									) }
+									renderContent={ () => (
+										<div className="ap-border-picker__popover">
+											<ColorGradientControl
+												label={ __(
+													'Border',
+													'artisanpack-visual-editor',
+												) }
+												showTitle={ false }
+												colorValue={ color ?? undefined }
+												gradientValue={ gradient ?? undefined }
+												onColorChange={ (
+													next: string | undefined,
+												) =>
+													writeBorder( {
+														color: next ?? null,
+													} )
+												}
+												onGradientChange={ (
+													next: string | undefined,
+												) =>
+													writeBorder( {
+														gradient: next ?? null,
+													} )
+												}
+												// ALL FOUR keys must be present or
+												// the control falls back to
+												// `ColorGradientControlSelect`,
+												// which reads from
+												// `useSettings('color.gradients')`
+												// — returning empty in a theme
+												// without origin-grouped gradients
+												// and killing the Gradient tab.
+												colors={ themeColors as never }
+												gradients={ themeGradients as never }
+												disableCustomColors={ false }
+												disableCustomGradients={ false }
+												enableAlpha
+												__experimentalIsRenderedInSidebar
+											/>
+											<div style={ { marginTop: 16 } }>
+												<ToggleGroupControl
+													label={ __(
+														'Style',
+														'artisanpack-visual-editor',
+													) }
+													value={ borderStyle ?? '' }
+													onChange={ ( next ) =>
+														writeBorder( {
+															style:
+																'string' === typeof next
+																	? next
+																	: null,
+														} )
+													}
+													isBlock
+													__nextHasNoMarginBottom
+													__next40pxDefaultSize
+												>
+													<ToggleGroupControlOption
+														label={ __(
+															'Solid',
+															'artisanpack-visual-editor',
+														) }
+														value="solid"
+													/>
+													<ToggleGroupControlOption
+														label={ __(
+															'Dashed',
+															'artisanpack-visual-editor',
+														) }
+														value="dashed"
+													/>
+													<ToggleGroupControlOption
+														label={ __(
+															'Dotted',
+															'artisanpack-visual-editor',
+														) }
+														value="dotted"
+													/>
+												</ToggleGroupControl>
+											</div>
+										</div>
+									) }
+								/>
+							</BaseControl>
+						</ToolsPanelItem>
+					</InspectorControls>
+				</>
+			)
+		}
+
+		GradientBorderBlockEdit.displayName = 'GradientBorderBlockEdit'
+
+		return GradientBorderBlockEdit
+	},
+	'withGradientBorderControl',
+)
+
+/**
+ * Register the BlockEdit filter at most once per page. Idempotent —
+ * safe to call from both the post-editor and site-editor bootstrap
+ * paths.
+ */
+export function registerGradientBorderControl(): void {
+	const host = globalThis as unknown as GlobalSentinelHost
+
+	if ( host[ REGISTERED_KEY ] ) {
+		return
+	}
+
+	addFilter( FILTER_HOOK, FILTER_NAMESPACE, withGradientBorderControl )
+	host[ REGISTERED_KEY ] = true
+}

--- a/resources/js/visual-editor/gradient-borders/with-gradient-border-control.tsx
+++ b/resources/js/visual-editor/gradient-borders/with-gradient-border-control.tsx
@@ -295,9 +295,23 @@ export const withGradientBorderControl = createHigherOrderComponent(
 						     The `<style>` MUST live inside `<InspectorControls>`
 						     so it portals into the inspector sidebar's document. */ }
 						<style>{ `
-							button[aria-label*="Border color and style picker"],
-							button[aria-label*="Border color picker"],
-							button[aria-label*="Border style picker"] {
+							/* Hide Gutenberg's native BorderControlDropdown
+							   trigger via STRUCTURAL selectors — Emotion
+							   hashes the wrapper class names so we can't
+							   target those directly, but \`ColorIndicator\`
+							   ships a stable \`component-color-indicator\`
+							   class. Combined with \`:has()\` we can find
+							   the trigger button without depending on
+							   English aria-label text (which would miss
+							   the native trigger in translated editors). The
+							   scoping rule says "any color-indicator button
+							   that lives in the same ToolsPanel as MY
+							   marker item" — that's exactly the Border
+							   panel and only the Border panel. Our own
+							   trigger carries \`.ap-border-picker__toggle\`
+							   so it's excluded from the hide. */
+							.components-tools-panel:has(.ap-border-picker-item)
+								button:has(.component-color-indicator):not(.ap-border-picker__toggle) {
 								display: none !important;
 							}
 							/* Render our picker as the first item in the

--- a/resources/js/visual-editor/gradient-borders/with-gradient-border-styles.tsx
+++ b/resources/js/visual-editor/gradient-borders/with-gradient-border-styles.tsx
@@ -81,6 +81,17 @@ interface BorderSubtreeWithScope {
 
 const SCOPE_ID_KEY = '_gradientScopeId'
 
+// Whitelist of characters allowed in a persisted scope id. The id is
+// interpolated directly into the wrapper's class attribute AND into
+// emitted CSS rule selectors (`.ve-gb-<id>::before { ... }`), so a
+// crafted block tree carrying selector control characters in
+// `_gradientScopeId` could escape the scope and inject arbitrary CSS.
+// The mint function below produces base-36 (`[a-z0-9]{9}`) ids that
+// trivially pass; anything that fails is treated as hostile /
+// corrupted and re-minted. Mirrors the PHP-side guard in
+// `BlockSupports::resolveGradientBorderScopeClass`.
+const SCOPE_ID_PATTERN = /^[a-z0-9][a-z0-9_-]{0,63}$/i
+
 // Module-level registries — same instances used by the PHP server-side
 // emitter via `fromLayers()` defaults. Eventually these should be
 // hydrated from the editor's themed settings so custom states/
@@ -116,7 +127,12 @@ function readScopeId(
 	const border = attributes?.style?.border as BorderSubtreeWithScope | undefined | null
 	const raw    = border?.[ SCOPE_ID_KEY ]
 
-	return 'string' === typeof raw && '' !== raw ? raw : null
+	if ( 'string' !== typeof raw ) {
+		return null
+	}
+
+	const trimmed = raw.trim()
+	return SCOPE_ID_PATTERN.test( trimmed ) ? trimmed : null
 }
 
 function hasAuthoredAnyGradient(

--- a/resources/js/visual-editor/gradient-borders/with-gradient-border-styles.tsx
+++ b/resources/js/visual-editor/gradient-borders/with-gradient-border-styles.tsx
@@ -1,0 +1,387 @@
+/**
+ * Gradient border CSS emission for the editor canvas + saved markup
+ * (#490).
+ *
+ * Mirrors `withStateStyles` (#488) for the gradient border feature.
+ * Without this HOC, the inspector picker writes the attribute but
+ * nothing paints — the server renderer's `compileGradientBorder()`
+ * only fires at render time, not during editor preview.
+ *
+ * Three filter hooks:
+ *
+ *  1. **`editor.BlockListBlock`** — runs in the canvas. Computes the
+ *     scope class from a stable per-block `_gradientScopeId` and:
+ *     - Injects a `<style>` element with the emitted CSS
+ *     - Adds the scope class to the wrapper props so the rules match
+ *
+ *  2. **`blocks.getSaveContent.extraProps`** — stamps the scope class
+ *     on the saved block root.
+ *
+ *  3. **`blocks.getSaveElement`** — wraps the saved tree with a
+ *     sibling `<style>` element so published markup carries the same
+ *     rules without requiring the Blade renderer.
+ *
+ * The `_gradientScopeId` is minted once per block the first time it
+ * authors any gradient configuration and persisted on
+ * `attributes.style.border._gradientScopeId`. Storing it on the
+ * attributes (rather than regenerating each render) keeps the editor,
+ * saved markup, and Blade-rendered output in lockstep.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.1.0
+ */
+
+import { getBlockType } from '@wordpress/blocks'
+import { createHigherOrderComponent } from '@wordpress/compose'
+import { addFilter } from '@wordpress/hooks'
+import { Fragment, createElement, useEffect, useMemo, useRef } from 'react'
+import type { ComponentType, ReactNode } from 'react'
+
+import { TAILWIND_V4_DEFAULTS, BreakpointRegistry } from '../responsive/registry'
+import { DEFAULT_STATES, StateRegistry } from '../states/registry'
+import { emitGradientBorderCss } from './emitter'
+import { resolveGradientBorder } from './resolver'
+import type { GradientBorderAttributes } from './types'
+
+const BLOCK_FILTER_HOOK = 'editor.BlockListBlock'
+const SAVE_PROPS_HOOK   = 'blocks.getSaveContent.extraProps'
+const SAVE_ELEMENT_HOOK = 'blocks.getSaveElement'
+
+const FILTER_NAMESPACE = 'artisanpack-ui/visual-editor/gradient-border-styles'
+
+const REGISTERED_KEY = Symbol.for(
+	'artisanpack-ui.visual-editor.gradient-border-styles.registered',
+)
+
+interface GlobalSentinelHost {
+	[REGISTERED_KEY]?: boolean
+}
+
+interface BlockListBlockProps {
+	name: string
+	clientId: string
+	attributes: GradientBorderAttributes & Record<string, unknown>
+	setAttributes?: ( updates: Record<string, unknown> ) => void
+	wrapperProps?: Record<string, unknown>
+	[key: string]: unknown
+}
+
+interface BlockSettingsLike {
+	supports?: Record<string, unknown>
+	[key: string]: unknown
+}
+
+interface BorderSubtreeWithScope {
+	gradient?: string | null
+	width?: string | null
+	radius?: string | Record<string, unknown> | null
+	_gradientScopeId?: string
+	[key: string]: unknown
+}
+
+const SCOPE_ID_KEY = '_gradientScopeId'
+
+// Module-level registries — same instances used by the PHP server-side
+// emitter via `fromLayers()` defaults. Eventually these should be
+// hydrated from the editor's themed settings so custom states/
+// breakpoints declared in `theme.json` participate; the v1 surface
+// uses the static defaults so the editor preview matches the renderer
+// when no custom registries are configured.
+const states      = new StateRegistry( DEFAULT_STATES )
+const breakpoints = new BreakpointRegistry( TAILWIND_V4_DEFAULTS )
+
+function blockSupportsGradientBorder( name: string ): boolean {
+	const blockType = getBlockType( name )
+	if ( ! blockType ) {
+		return false
+	}
+
+	const support = ( blockType.supports as Record<string, unknown> | undefined )?.[ '__experimentalBorder' ]
+		?? ( blockType.supports as Record<string, unknown> | undefined )?.[ 'border' ]
+
+	if ( ! support || 'object' !== typeof support ) {
+		return false
+	}
+
+	return true === ( support as Record<string, unknown> ).gradient
+}
+
+function scopeIdToClass( scopeId: string ): string {
+	return `ve-gb-${ scopeId }`
+}
+
+function readScopeId(
+	attributes: GradientBorderAttributes | undefined,
+): string | null {
+	const border = attributes?.style?.border as BorderSubtreeWithScope | undefined | null
+	const raw    = border?.[ SCOPE_ID_KEY ]
+
+	return 'string' === typeof raw && '' !== raw ? raw : null
+}
+
+function hasAuthoredAnyGradient(
+	attributes: GradientBorderAttributes | undefined,
+): boolean {
+	return null !== resolveGradientBorder( attributes )
+}
+
+// `Math.random()` is fine here — collisions only matter within a
+// single page render and the keyspace (~10^14) leaves the
+// birthday-paradox floor well above any realistic block count. Same
+// rationale as `mintScopeId()` in `with-state-styles.tsx`.
+function mintScopeId(): string {
+	return Math.random().toString( 36 ).slice( 2, 11 )
+}
+
+// Tracks which clientId currently owns each scope id so duplicated
+// blocks (which inherit the parent's `_gradientScopeId` via attribute
+// copy) detect the collision and re-mint. Mirrors `scopeIdOwners` in
+// `with-state-styles.tsx`.
+const scopeIdOwners = new Map<string, string>()
+
+function claimScopeId( scopeId: string, clientId: string ): boolean {
+	const owner = scopeIdOwners.get( scopeId )
+	if ( ! owner ) {
+		scopeIdOwners.set( scopeId, clientId )
+		return true
+	}
+
+	return owner === clientId
+}
+
+function releaseScopeId( scopeId: string, clientId: string ): void {
+	if ( scopeIdOwners.get( scopeId ) === clientId ) {
+		scopeIdOwners.delete( scopeId )
+	}
+}
+
+function writeScopeId(
+	attributes: GradientBorderAttributes,
+	setAttributes: ( updates: Record<string, unknown> ) => void,
+	nextId: string,
+): void {
+	const style = ( attributes.style && 'object' === typeof attributes.style )
+		? ( attributes.style as Record<string, unknown> )
+		: {}
+	const border = ( style.border && 'object' === typeof style.border )
+		? ( style.border as Record<string, unknown> )
+		: {}
+
+	setAttributes( {
+		style: {
+			...style,
+			border: {
+				...border,
+				[ SCOPE_ID_KEY ]: nextId,
+			},
+		},
+	} )
+}
+
+export const withGradientBorderStyles = createHigherOrderComponent(
+	( BlockListBlock: ComponentType<BlockListBlockProps> ) => {
+		function GradientBorderStyledBlock( props: BlockListBlockProps ): JSX.Element {
+			const { name, clientId, attributes, setAttributes, wrapperProps } = props
+
+			const supported = blockSupportsGradientBorder( name )
+
+			const scopeId = useMemo(
+				() => readScopeId( attributes ),
+				[ attributes ],
+			)
+
+			const hasOverrides = useMemo(
+				() => hasAuthoredAnyGradient( attributes ),
+				[ attributes ],
+			)
+
+			const persistedRef = useRef( scopeId )
+			useEffect( () => {
+				persistedRef.current = scopeId
+			}, [ scopeId ] )
+
+			useEffect( () => {
+				if ( ! supported || ! setAttributes ) {
+					return
+				}
+
+				const needsMint    = ! scopeId && hasOverrides
+				const hasCollision = scopeId !== null && ! claimScopeId( scopeId, clientId )
+
+				if ( ! needsMint && ! hasCollision ) {
+					return
+				}
+
+				const nextId = mintScopeId()
+				claimScopeId( nextId, clientId )
+				writeScopeId( attributes, setAttributes, nextId )
+			}, [ supported, scopeId, hasOverrides, attributes, setAttributes, clientId ] )
+
+			useEffect( () => {
+				if ( ! scopeId ) {
+					return
+				}
+
+				return () => releaseScopeId( scopeId, clientId )
+			}, [ scopeId, clientId ] )
+
+			const effectiveScopeId = scopeId ?? persistedRef.current
+
+			const css = useMemo( () => {
+				if ( ! supported || ! effectiveScopeId ) {
+					return ''
+				}
+
+				const payload = resolveGradientBorder( attributes )
+				if ( ! payload ) {
+					return ''
+				}
+
+				return emitGradientBorderCss(
+					`.${ scopeIdToClass( effectiveScopeId ) }`,
+					payload,
+					states,
+					breakpoints,
+				)
+			}, [ supported, effectiveScopeId, attributes ] )
+
+			const effectiveWrapperProps: Record<string, unknown> = useMemo( () => {
+				if ( ! supported || ! effectiveScopeId ) {
+					return wrapperProps ?? {}
+				}
+
+				const existingClass = ( wrapperProps?.className as string | undefined ) ?? ''
+				const scopeClass    = scopeIdToClass( effectiveScopeId )
+
+				if ( existingClass.split( ' ' ).includes( scopeClass ) ) {
+					return wrapperProps ?? {}
+				}
+
+				return {
+					...( wrapperProps ?? {} ),
+					className: existingClass ? `${ existingClass } ${ scopeClass }` : scopeClass,
+				}
+			}, [ supported, wrapperProps, effectiveScopeId ] )
+
+			if ( ! supported ) {
+				return <BlockListBlock { ...props } />
+			}
+
+			const wrapped = (
+				<BlockListBlock
+					{ ...props }
+					wrapperProps={ effectiveWrapperProps }
+				/>
+			)
+
+			if ( '' === css ) {
+				return wrapped
+			}
+
+			return (
+				<Fragment>
+					<style data-ap-gradient-border-scope={ effectiveScopeId }>{ css }</style>
+					{ wrapped }
+				</Fragment>
+			)
+		}
+
+		GradientBorderStyledBlock.displayName = 'GradientBorderStyledBlock'
+
+		return GradientBorderStyledBlock
+	},
+	'withGradientBorderStyles',
+)
+
+function blockSupportsConfigOnSettings(
+	blockType: BlockSettingsLike | undefined,
+): boolean {
+	const supports = blockType?.supports as Record<string, unknown> | undefined
+	const border   = ( supports?.[ '__experimentalBorder' ] ?? supports?.[ 'border' ] ) as
+		| Record<string, unknown>
+		| undefined
+
+	return Boolean( border && 'object' === typeof border && true === border.gradient )
+}
+
+function addSaveProps(
+	extraProps: Record<string, unknown>,
+	blockType: BlockSettingsLike,
+	attributes: GradientBorderAttributes & Record<string, unknown>,
+): Record<string, unknown> {
+	if ( ! blockSupportsConfigOnSettings( blockType ) ) {
+		return extraProps
+	}
+
+	const scopeId = readScopeId( attributes )
+	if ( ! scopeId || ! hasAuthoredAnyGradient( attributes ) ) {
+		return extraProps
+	}
+
+	const existingClass = ( extraProps.className as string | undefined ) ?? ''
+	const scopeClass    = scopeIdToClass( scopeId )
+
+	if ( existingClass.split( ' ' ).includes( scopeClass ) ) {
+		return extraProps
+	}
+
+	return {
+		...extraProps,
+		className: existingClass ? `${ existingClass } ${ scopeClass }` : scopeClass,
+	}
+}
+
+function wrapSaveElement(
+	element: unknown,
+	blockType: BlockSettingsLike,
+	attributes: GradientBorderAttributes & Record<string, unknown>,
+): unknown {
+	if ( ! blockSupportsConfigOnSettings( blockType ) ) {
+		return element
+	}
+
+	const scopeId = readScopeId( attributes )
+	if ( ! scopeId ) {
+		return element
+	}
+
+	const payload = resolveGradientBorder( attributes )
+	if ( ! payload ) {
+		return element
+	}
+
+	const css = emitGradientBorderCss(
+		`.${ scopeIdToClass( scopeId ) }`,
+		payload,
+		states,
+		breakpoints,
+	)
+
+	if ( '' === css ) {
+		return element
+	}
+
+	return createElement(
+		Fragment,
+		null,
+		element as ReactNode,
+		createElement( 'style', { 'data-ap-gradient-border-scope': scopeId }, css ),
+	)
+}
+
+/**
+ * Idempotent — safe to call from both the post-editor and site-editor
+ * bootstrap paths. Late callers see the sentinel and no-op.
+ */
+export function registerGradientBorderStylesFilters(): void {
+	const host = globalThis as unknown as GlobalSentinelHost
+
+	if ( host[ REGISTERED_KEY ] ) {
+		return
+	}
+
+	addFilter( BLOCK_FILTER_HOOK, FILTER_NAMESPACE, withGradientBorderStyles )
+	addFilter( SAVE_PROPS_HOOK, FILTER_NAMESPACE, addSaveProps )
+	addFilter( SAVE_ELEMENT_HOOK, FILTER_NAMESPACE, wrapSaveElement )
+	host[ REGISTERED_KEY ] = true
+}

--- a/resources/js/visual-editor/site-editor/__tests__/site-editor-app.test.tsx
+++ b/resources/js/visual-editor/site-editor/__tests__/site-editor-app.test.tsx
@@ -193,6 +193,14 @@ vi.mock('../../editor/synced-pattern-indicator', () => ({
     registerSyncedPatternIndicator: () => undefined,
 }));
 
+// #490: the gradient-border registrars pull in `@wordpress/blocks`
+// through the BlockEdit HOC, which trips the JSON-import-attribute
+// requirement under jsdom. Same rationale as the `../../blocks`
+// stub above — the shell tests don't exercise gradient picker UI.
+vi.mock('../../gradient-borders/register', () => ({
+    registerGradientBorders: (): void => undefined,
+}));
+
 import { SiteEditorApp } from '../site-editor-app';
 
 const ROUTE_BASE = '/visual-editor/site';

--- a/resources/js/visual-editor/site-editor/site-editor-app.tsx
+++ b/resources/js/visual-editor/site-editor/site-editor-app.tsx
@@ -46,6 +46,7 @@ import {
 import { usePersistedToggle } from './use-persisted-toggle';
 import { useSiteEditorRouting } from './use-site-editor-routing';
 import { registerArtisanPackBlocks } from '../blocks';
+import { registerGradientBorders } from '../gradient-borders/register';
 
 import { BlockLibrarySidebar } from '../editor/block-library-sidebar';
 import { TopBar } from '../editor/top-bar';
@@ -158,6 +159,11 @@ function ensureEditorBoot(): void {
     // registration so `artisanpack/block` reference blocks get the badge
     // from the first render. Idempotent across HMR.
     registerSyncedPatternIndicator();
+
+    // #490 — gradient border feature filters; same "before
+    // registerArtisanPackBlocks" placement as the post-editor so opted-in
+    // blocks pick up the routed `border.gradient` path at registration.
+    registerGradientBorders();
 
     // I7 (#415): register all artisanpack/* blocks and set the default
     // block to artisanpack/paragraph. Core blocks are no longer loaded.

--- a/resources/js/visual-editor/use-themed-editor-settings.ts
+++ b/resources/js/visual-editor/use-themed-editor-settings.ts
@@ -300,6 +300,28 @@ export function useThemedEditorSettings(
         const themeSpacingSizes = extractThemeSpacingSizes(themeSettings);
         const themeGradients = extractThemeGradients(themeSettings);
 
+        // #490 — propagate the theme's color-customization booleans so
+        // Gutenberg's `useSettings('color.customGradient')` / `'color.custom'`
+        // hooks return the configured value (used by `ColorGradientControl`
+        // to decide whether to surface the custom-authoring UI inside the
+        // Gradient tab). Without these the auto-injected Background picker
+        // shows only the theme palette with no way to author a fresh
+        // gradient. `?? true` mirrors WP core's defaults so themes that
+        // omit these keys still get the standard authoring affordances.
+        const themeColor = ( themeSettings.color as Record<string, unknown> | undefined ) ?? {};
+        const themeCustomGradient = 'customGradient' in themeColor
+            ? Boolean( themeColor.customGradient )
+            : true;
+        const themeDefaultGradients = 'defaultGradients' in themeColor
+            ? Boolean( themeColor.defaultGradients )
+            : true;
+        const themeCustomColor = 'custom' in themeColor
+            ? Boolean( themeColor.custom )
+            : true;
+        const themeDefaultPalette = 'defaultPalette' in themeColor
+            ? Boolean( themeColor.defaultPalette )
+            : true;
+
         const needsStyles = themeCss !== undefined && themeCss !== '';
         const needsPalette = themePalette !== null;
         const needsFontSizes = themeFontSizes !== null;
@@ -343,6 +365,16 @@ export function useThemedEditorSettings(
                 ...baseFeatures,
                 color: {
                     ...baseColor,
+                    // Authoring affordance flags — see comment above the
+                    // `themeCustomGradient` extraction in this function for
+                    // why these must be forwarded explicitly. WP's
+                    // `useSettings` reads these by dotted path; missing
+                    // keys make `disableCustomGradients` default to true
+                    // and the Gradient tab loses its custom-authoring UI.
+                    custom: themeCustomColor,
+                    customGradient: themeCustomGradient,
+                    defaultPalette: themeDefaultPalette,
+                    defaultGradients: themeDefaultGradients,
                     ...(needsPalette || needsGradients
                         ? {
                               palette: needsPalette

--- a/scripts/opt-in-color-gradients.mjs
+++ b/scripts/opt-in-color-gradients.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+// One-shot — add `gradients: true` to `supports.color` on every block.json
+// that opts into any color slot (`background`, `text`, or `link`) but
+// doesn't yet declare gradient support. Unlocks Gutenberg's auto-
+// injected Color | Gradient tabbed picker for those blocks' backgrounds.
+//
+// Idempotent; re-running leaves blocks that already have `gradients: true`
+// untouched.
+//
+// Run from the package root: `node scripts/opt-in-color-gradients.mjs`.
+// Part of #490 (border gradients PR scope expansion).
+
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
+
+const SCAN_DIRS = [
+	path.resolve( 'resources/js/visual-editor/blocks' ),
+	path.resolve( 'resources/js/visual-editor/core-blocks' ),
+]
+
+async function listBlockJsonFiles( dir ) {
+	try {
+		await fs.access( dir )
+	} catch {
+		return []
+	}
+
+	const entries = await fs.readdir( dir, { withFileTypes: true } )
+	const out     = []
+
+	for ( const entry of entries ) {
+		const full = path.join( dir, entry.name )
+
+		if ( entry.isDirectory() ) {
+			const nested = path.join( full, 'block.json' )
+			try {
+				await fs.access( nested )
+				out.push( nested )
+			} catch {
+				// no block.json in this dir — skip.
+			}
+		}
+	}
+
+	return out
+}
+
+function colorHasAnySlot( color ) {
+	if ( ! color || 'object' !== typeof color ) {
+		return false
+	}
+
+	return true === color.background || true === color.text || true === color.link
+}
+
+async function processOne( file ) {
+	const raw = await fs.readFile( file, 'utf8' )
+	let json
+
+	try {
+		json = JSON.parse( raw )
+	} catch ( err ) {
+		console.warn( `[skip] ${ file }: invalid JSON (${ err.message })` )
+		return false
+	}
+
+	const color = json.supports?.color
+
+	if ( ! colorHasAnySlot( color ) ) {
+		return false
+	}
+
+	if ( true === color.gradients ) {
+		return false
+	}
+
+	json.supports.color = { ...color, gradients: true }
+
+	// Match the project's indentation: 4-space pretty-print.
+	const next = JSON.stringify( json, null, 4 ) + '\n'
+	await fs.writeFile( file, next, 'utf8' )
+
+	return true
+}
+
+async function main() {
+	let touched = 0
+	let total   = 0
+
+	for ( const dir of SCAN_DIRS ) {
+		const files = await listBlockJsonFiles( dir )
+
+		for ( const file of files ) {
+			total++
+			if ( await processOne( file ) ) {
+				touched++
+				console.log( `[updated] ${ path.relative( process.cwd(), file ) }` )
+			}
+		}
+	}
+
+	console.log( `\n${ touched } / ${ total } block.json files updated.` )
+}
+
+main().catch( ( err ) => {
+	console.error( err )
+	process.exit( 1 )
+} )

--- a/scripts/opt-in-gradient-border.mjs
+++ b/scripts/opt-in-gradient-border.mjs
@@ -10,9 +10,18 @@
 import { promises as fs } from 'node:fs'
 import path from 'node:path'
 
-const BLOCKS_DIR = path.resolve( 'resources/js/visual-editor/blocks' )
+const SCAN_DIRS = [
+	path.resolve( 'resources/js/visual-editor/blocks' ),
+	path.resolve( 'resources/js/visual-editor/core-blocks' ),
+]
 
 async function listBlockJsonFiles( dir ) {
+	try {
+		await fs.access( dir )
+	} catch {
+		return []
+	}
+
 	const entries = await fs.readdir( dir, { withFileTypes: true } )
 	const out     = []
 
@@ -97,15 +106,18 @@ async function processOne( file ) {
 }
 
 async function main() {
-	const files   = await listBlockJsonFiles( BLOCKS_DIR )
-	let touched   = 0
-	let total     = 0
+	let touched = 0
+	let total   = 0
 
-	for ( const file of files ) {
-		total++
-		if ( await processOne( file ) ) {
-			touched++
-			console.log( `[updated] ${ path.relative( process.cwd(), file ) }` )
+	for ( const dir of SCAN_DIRS ) {
+		const files = await listBlockJsonFiles( dir )
+
+		for ( const file of files ) {
+			total++
+			if ( await processOne( file ) ) {
+				touched++
+				console.log( `[updated] ${ path.relative( process.cwd(), file ) }` )
+			}
 		}
 	}
 

--- a/scripts/opt-in-gradient-border.mjs
+++ b/scripts/opt-in-gradient-border.mjs
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+// One-shot — flip `supports.__experimentalBorder.gradient` (or
+// `supports.border.gradient` for non-experimental opt-ins) to `true` on
+// every block.json that already opts into border support. Idempotent;
+// re-running leaves blocks already updated alone.
+//
+// Run from the package root: `node scripts/opt-in-gradient-border.mjs`.
+// Part of #490 (border gradients).
+
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
+
+const BLOCKS_DIR = path.resolve( 'resources/js/visual-editor/blocks' )
+
+async function listBlockJsonFiles( dir ) {
+	const entries = await fs.readdir( dir, { withFileTypes: true } )
+	const out     = []
+
+	for ( const entry of entries ) {
+		const full = path.join( dir, entry.name )
+
+		if ( entry.isDirectory() ) {
+			const nested = path.join( full, 'block.json' )
+			try {
+				await fs.access( nested )
+				out.push( nested )
+			} catch {
+				// no block.json in this dir — fine, skip.
+			}
+		}
+	}
+
+	return out
+}
+
+function flipBorderSupport( supportObj ) {
+	if ( ! supportObj || 'object' !== typeof supportObj ) {
+		return { changed: false, value: supportObj }
+	}
+
+	if ( true === supportObj.gradient ) {
+		return { changed: false, value: supportObj }
+	}
+
+	return {
+		changed: true,
+		value:   { ...supportObj, gradient: true },
+	}
+}
+
+async function processOne( file ) {
+	const raw = await fs.readFile( file, 'utf8' )
+	let json
+
+	try {
+		json = JSON.parse( raw )
+	} catch ( err ) {
+		console.warn( `[skip] ${ file }: invalid JSON (${ err.message })` )
+		return false
+	}
+
+	const supports = json.supports
+
+	if ( ! supports || 'object' !== typeof supports ) {
+		return false
+	}
+
+	let changed = false
+
+	if ( supports.__experimentalBorder && 'object' === typeof supports.__experimentalBorder ) {
+		const flipped = flipBorderSupport( supports.__experimentalBorder )
+
+		if ( flipped.changed ) {
+			supports.__experimentalBorder = flipped.value
+			changed                       = true
+		}
+	}
+
+	if ( supports.border && 'object' === typeof supports.border ) {
+		const flipped = flipBorderSupport( supports.border )
+
+		if ( flipped.changed ) {
+			supports.border = flipped.value
+			changed         = true
+		}
+	}
+
+	if ( ! changed ) {
+		return false
+	}
+
+	// Match the project's indentation: 4-space pretty-print.
+	const next = JSON.stringify( json, null, 4 ) + '\n'
+	await fs.writeFile( file, next, 'utf8' )
+
+	return true
+}
+
+async function main() {
+	const files   = await listBlockJsonFiles( BLOCKS_DIR )
+	let touched   = 0
+	let total     = 0
+
+	for ( const file of files ) {
+		total++
+		if ( await processOne( file ) ) {
+			touched++
+			console.log( `[updated] ${ path.relative( process.cwd(), file ) }` )
+		}
+	}
+
+	console.log( `\n${ touched } / ${ total } block.json files updated.` )
+}
+
+main().catch( ( err ) => {
+	console.error( err )
+	process.exit( 1 )
+} )

--- a/src/GradientBorder/GradientBorderEmitter.php
+++ b/src/GradientBorder/GradientBorderEmitter.php
@@ -180,7 +180,7 @@ class GradientBorderEmitter
 				continue;
 			}
 
-			$rule = sprintf( '%s::before{background:%s}', $selector, $gradient );
+			$rule = sprintf( '%s{background:%s}', self::appendPseudoToList( $selector, '::before' ), $gradient );
 
 			if ( ! empty( $definition['hoverMediaWrap'] ) ) {
 				$hoverParts[] = $rule;
@@ -277,6 +277,37 @@ class GradientBorderEmitter
 			$mapped[] = str_contains( $piece, '&' )
 				? str_replace( '&', $scope, $piece )
 				: $scope . $piece;
+		}
+
+		return implode( ', ', $mapped );
+	}
+
+	/**
+	 * Append a pseudo-element suffix (e.g. `::before`) to EVERY
+	 * selector in a comma-separated list.
+	 *
+	 * `selectorFor()` resolves state definitions whose `selector` field
+	 * may itself be a comma-separated list (e.g. the disabled state
+	 * `&:disabled, &[aria-disabled="true"]`). A naive `$selector . '::before'`
+	 * appends the pseudo to the LAST selector only — the earlier
+	 * selectors then target the host element instead of the
+	 * pseudo-element, painting the gradient as a regular background
+	 * underneath the block content. Splitting + re-appending guarantees
+	 * each selector picks up the suffix.
+	 *
+	 * @since 1.1.0
+	 */
+	protected static function appendPseudoToList( string $selector, string $pseudo ): string
+	{
+		$pieces = array_map( 'trim', explode( ',', $selector ) );
+		$mapped = [];
+
+		foreach ( $pieces as $piece ) {
+			if ( '' === $piece ) {
+				continue;
+			}
+
+			$mapped[] = $piece . $pseudo;
 		}
 
 		return implode( ', ', $mapped );

--- a/src/GradientBorder/GradientBorderEmitter.php
+++ b/src/GradientBorder/GradientBorderEmitter.php
@@ -1,0 +1,416 @@
+<?php
+
+/**
+ * Gradient border CSS emitter (#490).
+ *
+ * Turns a block's gradient-border attribute payload into the scoped CSS
+ * the renderer ships with the published page. One emission strategy
+ * handles all three gradient kinds (linear / radial / conic) and all
+ * border-radius values cleanly: a `::before` pseudo-element rendered
+ * over the block, with a `mask-composite: exclude` cut-out that leaves
+ * only the border ring visible.
+ *
+ *     .scope { position: relative; }
+ *     .scope::before {
+ *         content: '';
+ *         position: absolute;
+ *         inset: 0;
+ *         padding: <border-width>;
+ *         border-radius: inherit;
+ *         background: <gradient>;
+ *         -webkit-mask: linear-gradient(#000 0 0) content-box,
+ *                       linear-gradient(#000 0 0);
+ *         -webkit-mask-composite: xor;
+ *         mask: linear-gradient(#000 0 0) content-box,
+ *               linear-gradient(#000 0 0);
+ *         mask-composite: exclude;
+ *         pointer-events: none;
+ *     }
+ *
+ * The single strategy was a deliberate call. `border-image` is simpler
+ * for non-rounded linear gradients but breaks at every `border-radius`
+ * — the gradient renders square and corners fringe. The mask trick is
+ * a touch heavier (one extra paint layer) but produces pixel-correct
+ * output across the matrix of gradient kind × radius × side widths.
+ *
+ * State / breakpoint composition: the emitter consumes a normalized
+ * payload already cascaded by {@see GradientBorderResolver}. Per-state
+ * and per-breakpoint rules are emitted as additional `::before`
+ * declarations under `:hover::before` / `@media (min-width:…) {…}`.
+ * Hover rules are wrapped in `@media (hover: hover)` so touch devices
+ * don't sticky-state on tap.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.1.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\GradientBorder;
+
+use ArtisanPackUI\VisualEditor\Responsive\BreakpointRegistry;
+use ArtisanPackUI\VisualEditor\States\StateRegistry;
+
+class GradientBorderEmitter
+{
+	/**
+	 * Default transition emitted on the wrapper when any non-idle state
+	 * sets a gradient override. Gradients themselves don't smoothly
+	 * interpolate in current browsers, but the surrounding properties
+	 * (opacity, border-width changes, etc.) do — and the rule sets the
+	 * editor up to layer in opacity-cross-fade strategies in a v2
+	 * without changing the public CSS contract.
+	 */
+	public const DEFAULT_TRANSITION = 'background 200ms ease, opacity 200ms ease';
+
+	public function __construct(
+		protected StateRegistry $states,
+		protected BreakpointRegistry $breakpoints,
+	) {}
+
+	/**
+	 * Emit the scoped CSS for a single block's gradient border payload.
+	 *
+	 * `$payload` is the normalized record from
+	 * {@see GradientBorderResolver::resolve} — already preset-expanded,
+	 * with `null` sentinels removed and inheritance cascades applied.
+	 *
+	 *     [
+	 *         'idle'   => 'linear-gradient(135deg, red, blue)',
+	 *         'states' => [
+	 *             'hover' => 'linear-gradient(135deg, blue, red)',
+	 *         ],
+	 *         'breakpoints' => [
+	 *             'md' => 'linear-gradient(180deg, red, blue)',
+	 *         ],
+	 *         'width'  => '2px',
+	 *         'radius' => '8px',
+	 *     ]
+	 *
+	 * Returns an empty string when there's no idle value and no
+	 * non-idle overrides — callers should treat empty as a signal to
+	 * skip the `<style>` push entirely.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param  string  $scope    CSS scope selector, including the leading
+	 *                           `.` (e.g. `.ve-gb-abc123`).
+	 * @param  array{
+	 *     idle?: string|null,
+	 *     states?: array<string, string|null>,
+	 *     breakpoints?: array<string, string|null>,
+	 *     width?: string|null,
+	 *     radius?: string|null,
+	 * }       $payload
+	 */
+	public function emit( string $scope, array $payload ): string
+	{
+		$scope = trim( $scope );
+
+		if ( '' === $scope ) {
+			return '';
+		}
+
+		$idle        = self::stringOrNull( $payload['idle'] ?? null );
+		$states      = self::stringMap( $payload['states'] ?? [] );
+		$breakpoints = self::stringMap( $payload['breakpoints'] ?? [] );
+		$width       = self::stringOrNull( $payload['width'] ?? null ) ?? '1px';
+
+		if ( null === $idle && [] === $states && [] === $breakpoints ) {
+			return '';
+		}
+
+		$rules = [];
+
+		// Position the wrapper so the absolutely-positioned ::before
+		// pseudo aligns to the block box. Authors who want an explicit
+		// non-static position can override via host CSS — this is the
+		// minimum required for the mask layer to render at all.
+		//
+		// `border-color: transparent` suppresses any stale
+		// `style.border.color` value left over from before the block
+		// was switched to a gradient border (or written by a host that
+		// still has the native color picker enabled). Without it the
+		// native `BlockSupports::applyBorder` would paint a solid edge
+		// underneath our gradient `::before` and the user would see
+		// two stacked borders. `!important` matches the inline
+		// `style="border-color:…"` specificity the supports compiler
+		// emits.
+		$rules[] = sprintf( '%s{position:relative;border-color:transparent !important}', $scope );
+
+		// Idle ::before rule. Always emitted when *any* gradient value
+		// exists at any state/breakpoint so the cascade has a base to
+		// override — falling back to `transparent` keeps the cut-out
+		// layer in the DOM without painting anything visible.
+		$idleGradient = $idle ?? 'transparent';
+		$rules[]      = sprintf(
+			'%s::before{%s}',
+			$scope,
+			self::baseBeforeDeclarations( $idleGradient, $width, $payload['radius'] ?? null )
+		);
+
+		$hasNonIdle = [] !== $states || [] !== $breakpoints;
+
+		if ( $hasNonIdle ) {
+			$rules[] = sprintf(
+				'%s::before{transition:%s}',
+				$scope,
+				self::DEFAULT_TRANSITION
+			);
+		}
+
+		// Per-state ::before rules. The state registry's
+		// inheritance-aware traversal lives in `StateValueResolver`;
+		// here we only emit the keys the resolver already trimmed.
+		$hoverParts    = [];
+		$nonHoverParts = [];
+
+		foreach ( $states as $stateKey => $gradient ) {
+			$definition = $this->states->get( $stateKey );
+			if ( null === $definition ) {
+				continue;
+			}
+
+			$selector = self::selectorFor( $scope, $definition['selector'] ?? '' );
+			if ( '' === $selector ) {
+				continue;
+			}
+
+			$rule = sprintf( '%s::before{background:%s}', $selector, $gradient );
+
+			if ( ! empty( $definition['hoverMediaWrap'] ) ) {
+				$hoverParts[] = $rule;
+				continue;
+			}
+
+			$nonHoverParts[] = $rule;
+		}
+
+		if ( [] !== $hoverParts ) {
+			$rules[] = sprintf( '@media (hover: hover){%s}', implode( '', $hoverParts ) );
+		}
+
+		foreach ( $nonHoverParts as $rule ) {
+			$rules[] = $rule;
+		}
+
+		// Per-breakpoint ::before rules. Mobile-first cascade — the
+		// registry's `get()` returns `null` for keys it doesn't know,
+		// which silently drops the override (same behavior as
+		// `compileResponsive` for spacing/border properties).
+		foreach ( $breakpoints as $breakpointKey => $gradient ) {
+			$minWidth = $this->breakpoints->get( $breakpointKey );
+
+			if ( null === $minWidth ) {
+				continue;
+			}
+
+			$rules[] = sprintf(
+				'@media (min-width:%dpx){%s::before{background:%s}}',
+				$minWidth,
+				$scope,
+				$gradient
+			);
+		}
+
+		return implode( '', $rules );
+	}
+
+	/**
+	 * Compose the `::before` declarations shared by every idle rule —
+	 * the cut-out mask, the gradient layer, sizing, and pointer
+	 * fall-through.
+	 *
+	 * @since 1.1.0
+	 */
+	protected static function baseBeforeDeclarations( string $gradient, string $width, mixed $radius ): string
+	{
+		$radiusDecl = self::radiusDeclaration( $radius );
+		$safeWidth  = self::sanitizeCss( $width );
+
+		// `inset: calc(-1 * <width>)` extends the pseudo OUTWARD by the
+		// border-width so its outer edge aligns with the wrapper's
+		// border-box (not the padding-box, which is the default for
+		// `inset: 0` on an absolutely-positioned child). Combined with
+		// `padding: <width>`, the mask cut-out leaves a `<width>`-wide
+		// ring sitting exactly where the wrapper's native border would
+		// render. Without the negative inset the ring sits one
+		// border-width INSIDE the visible block edge, which reads as
+		// "the gradient is floating inside the div" — see #490 follow-up.
+		return sprintf(
+			'content:"";position:absolute;inset:calc(-1 * %1$s);padding:%1$s;%2$sbackground:%3$s;'
+			. '-webkit-mask:linear-gradient(#000 0 0) content-box,linear-gradient(#000 0 0);'
+			. '-webkit-mask-composite:xor;'
+			. 'mask:linear-gradient(#000 0 0) content-box,linear-gradient(#000 0 0);'
+			. 'mask-composite:exclude;pointer-events:none',
+			$safeWidth,
+			$radiusDecl,
+			self::sanitizeGradient( $gradient )
+		);
+	}
+
+	/**
+	 * Resolve the literal selector for a state definition, replacing the
+	 * `&` placeholder with the block scope. Mirrors
+	 * {@see StateCssEmitter::selectorFor}.
+	 *
+	 * @since 1.1.0
+	 */
+	protected static function selectorFor( string $scope, string $selector ): string
+	{
+		if ( '' === $selector ) {
+			return '';
+		}
+
+		$pieces = array_map( 'trim', explode( ',', $selector ) );
+		$mapped = [];
+
+		foreach ( $pieces as $piece ) {
+			if ( '' === $piece ) {
+				continue;
+			}
+
+			$mapped[] = str_contains( $piece, '&' )
+				? str_replace( '&', $scope, $piece )
+				: $scope . $piece;
+		}
+
+		return implode( ', ', $mapped );
+	}
+
+	/**
+	 * Emit the `border-radius` declaration when one is configured.
+	 * Returns an empty string when no radius applies — the wrapper's
+	 * own `border-radius` (or the lack of one) is inherited by the
+	 * pseudo via `border-radius: inherit` only when no explicit value
+	 * is supplied here.
+	 *
+	 * Accepts either a scalar (uniform corner) or a per-corner object
+	 * matching Gutenberg's `{topLeft, topRight, bottomLeft, bottomRight}`
+	 * shape.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param  array<string, mixed>|string|null  $radius
+	 */
+	protected static function radiusDeclaration( mixed $radius ): string
+	{
+		if ( is_string( $radius ) && '' !== trim( $radius ) ) {
+			return 'border-radius:' . self::sanitizeCss( $radius ) . ';';
+		}
+
+		if ( is_array( $radius ) ) {
+			$pieces = [];
+
+			$corners = [
+				'topLeft'     => 'top-left',
+				'topRight'    => 'top-right',
+				'bottomLeft'  => 'bottom-left',
+				'bottomRight' => 'bottom-right',
+			];
+
+			foreach ( $corners as $key => $cssKey ) {
+				$value = $radius[ $key ] ?? null;
+
+				if ( ! is_string( $value ) || '' === trim( $value ) ) {
+					continue;
+				}
+
+				$pieces[] = sprintf( 'border-%s-radius:%s', $cssKey, self::sanitizeCss( $value ) );
+			}
+
+			if ( [] !== $pieces ) {
+				return implode( ';', $pieces ) . ';';
+			}
+		}
+
+		// `inherit` lets the pseudo follow the host wrapper's
+		// `border-radius` when the editor authored one through the
+		// standard border panel.
+		return 'border-radius:inherit;';
+	}
+
+	/**
+	 * Whitelist the characters allowed in a generic CSS value (width,
+	 * radius, calc()). Mirrors {@see BlockSupports::sanitizeCssValue}
+	 * so a corrupted block tree can't break out of the `<style>`
+	 * context.
+	 *
+	 * @since 1.1.0
+	 */
+	protected static function sanitizeCss( string $value ): string
+	{
+		return (string) preg_replace( '/[^a-zA-Z0-9_+\-*\/.,()%#\s]/', '', $value );
+	}
+
+	/**
+	 * Slightly looser whitelist for gradient functions — same as
+	 * `sanitizeCss` plus `:` (for `--var()` references that include
+	 * `var(--wp--preset--gradient--slug)`) and `&` is still disallowed.
+	 * Quote characters are dropped because gradient color stops never
+	 * need them and they'd let an attacker break out of the
+	 * `background: …` declaration.
+	 *
+	 * @since 1.1.0
+	 */
+	protected static function sanitizeGradient( string $value ): string
+	{
+		return (string) preg_replace( '/[^a-zA-Z0-9_+\-*\/.,()%#:\s]/', '', $value );
+	}
+
+	/**
+	 * Coerce an attribute to a non-empty trimmed string, or `null`.
+	 *
+	 * @since 1.1.0
+	 */
+	protected static function stringOrNull( mixed $value ): ?string
+	{
+		if ( ! is_string( $value ) ) {
+			return null;
+		}
+
+		$trimmed = trim( $value );
+
+		return '' === $trimmed ? null : $trimmed;
+	}
+
+	/**
+	 * Coerce a `[ stateKey => value ]` map into a `[ stateKey => string ]`
+	 * map, dropping any non-string / empty entries.
+	 *
+	 * @param  array<mixed, mixed>  $raw
+	 *
+	 * @return array<string, string>
+	 *
+	 * @since 1.1.0
+	 */
+	protected static function stringMap( mixed $raw ): array
+	{
+		if ( ! is_array( $raw ) ) {
+			return [];
+		}
+
+		$out = [];
+
+		foreach ( $raw as $key => $value ) {
+			if ( ! is_string( $key ) || '' === $key ) {
+				continue;
+			}
+
+			$resolved = self::stringOrNull( $value );
+
+			if ( null === $resolved ) {
+				continue;
+			}
+
+			$out[ $key ] = $resolved;
+		}
+
+		return $out;
+	}
+
+}

--- a/src/GradientBorder/GradientBorderResolver.php
+++ b/src/GradientBorder/GradientBorderResolver.php
@@ -1,0 +1,304 @@
+<?php
+
+/**
+ * Gradient border attribute resolver (#490).
+ *
+ * Walks a block's attribute tree and produces the normalized record
+ * {@see GradientBorderEmitter::emit} consumes.
+ *
+ * Composition with the rest of the editor:
+ * - Idle value lives at `style.border.gradient` (string slug or raw CSS).
+ * - Per-state overrides ride the standard `attributes.states` bag keyed
+ *   `style.border.gradient` (or its `border.gradient` shorthand the
+ *   inspector writes for child blocks of `style.*`).
+ * - Per-breakpoint overrides ride `attributes.responsive` keyed
+ *   `style.border.gradient`.
+ *
+ * This deliberate piggybacking means the gradient value composes with
+ * the existing state/responsive HOCs end-to-end — the editor's picker
+ * just writes to `style.border.gradient` and the routing falls out
+ * naturally. The cost is one extra read here per block at compile time;
+ * the alternative (a sibling `gradientStates` bag) duplicated the bag
+ * shape and required two parallel inspector controls.
+ *
+ * Slug values (matched against `^[a-z0-9][a-z0-9_-]*$`) are expanded
+ * into `var(--wp--preset--gradient--{slug})` so the emitted CSS picks
+ * up the runtime token. Raw values pass through.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.1.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\GradientBorder;
+
+class GradientBorderResolver
+{
+	/**
+	 * Path keys the resolver recognizes for gradient overrides in the
+	 * `attributes.states` and `attributes.responsive` bags. The inspector
+	 * panel always writes the canonical `style.border.gradient` form; the
+	 * shorthand `border.gradient` is accepted on read for symmetry with
+	 * the generic state emitter which strips the leading `style.`.
+	 *
+	 * @var array<int, string>
+	 */
+	protected const GRADIENT_PATHS = [
+		'style.border.gradient',
+		'border.gradient',
+	];
+
+	/**
+	 * Resolve a full block attribute tree into the normalized payload
+	 * the emitter consumes.
+	 *
+	 * Returns `null` when no gradient configuration is present at any
+	 * cascade level — callers should treat `null` as a signal to skip
+	 * {@see GradientBorderEmitter} entirely.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param  array<string, mixed>  $attributes  The full block attribute
+	 *                                            payload.
+	 *
+	 * @return array{
+	 *     idle: ?string,
+	 *     states: array<string, string>,
+	 *     breakpoints: array<string, string>,
+	 *     width: ?string,
+	 *     radius: array<string, mixed>|string|null,
+	 * }|null
+	 */
+	public static function resolve( array $attributes ): ?array
+	{
+		$border = $attributes['style']['border'] ?? null;
+		$border = is_array( $border ) ? $border : [];
+
+		$idle        = self::expandGradient( $border['gradient'] ?? null );
+		$states      = self::collectStateOverrides( $attributes['states'] ?? null );
+		$breakpoints = self::collectBreakpointOverrides( $attributes['responsive'] ?? null );
+
+		if ( null === $idle && [] === $states && [] === $breakpoints ) {
+			return null;
+		}
+
+		return [
+			'idle'        => $idle,
+			'states'      => $states,
+			'breakpoints' => $breakpoints,
+			'width'       => self::coerceString( $border['width'] ?? null ),
+			'radius'      => $border['radius'] ?? null,
+		];
+	}
+
+	/**
+	 * Pluck every gradient slug referenced anywhere in a block's
+	 * attribute tree (idle + per-state + per-breakpoint). Used by the
+	 * editor's token-warning surface to flag references whose theme
+	 * token was removed or renamed.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param  array<string, mixed>  $attributes
+	 *
+	 * @return array<int, string>
+	 */
+	public static function referencedSlugs( array $attributes ): array
+	{
+		$slugs = [];
+
+		$border = $attributes['style']['border'] ?? null;
+		if ( is_array( $border ) ) {
+			self::collectSlug( $slugs, $border['gradient'] ?? null );
+		}
+
+		$states = $attributes['states'] ?? null;
+		if ( is_array( $states ) ) {
+			foreach ( self::GRADIENT_PATHS as $path ) {
+				if ( ! isset( $states[ $path ] ) || ! is_array( $states[ $path ] ) ) {
+					continue;
+				}
+
+				foreach ( $states[ $path ] as $value ) {
+					self::collectSlug( $slugs, $value );
+				}
+			}
+		}
+
+		$responsive = $attributes['responsive'] ?? null;
+		if ( is_array( $responsive ) ) {
+			foreach ( self::GRADIENT_PATHS as $path ) {
+				if ( ! isset( $responsive[ $path ] ) || ! is_array( $responsive[ $path ] ) ) {
+					continue;
+				}
+
+				foreach ( $responsive[ $path ] as $value ) {
+					self::collectSlug( $slugs, $value );
+				}
+			}
+		}
+
+		return array_values( array_unique( $slugs ) );
+	}
+
+	/**
+	 * Read every gradient override out of an `attributes.states` bag,
+	 * expanding slugs and dropping null/empty entries. When the same
+	 * state has overrides at both path keys (`style.border.gradient`
+	 * and `border.gradient`), the canonical `style.border.gradient`
+	 * wins — matching the read precedence WP core's `withStateAttributes`
+	 * uses elsewhere.
+	 *
+	 * @param  mixed  $statesBag
+	 *
+	 * @return array<string, string>
+	 */
+	protected static function collectStateOverrides( mixed $statesBag ): array
+	{
+		if ( ! is_array( $statesBag ) ) {
+			return [];
+		}
+
+		$out = [];
+
+		// Iterate paths in reverse-precedence order so the canonical
+		// path overwrites the shorthand. PHP array assignment is "last
+		// write wins" so the loop order is the cascade order.
+		foreach ( array_reverse( self::GRADIENT_PATHS ) as $path ) {
+			$overrides = $statesBag[ $path ] ?? null;
+
+			if ( ! is_array( $overrides ) ) {
+				continue;
+			}
+
+			foreach ( $overrides as $stateKey => $value ) {
+				if ( ! is_string( $stateKey ) || '' === $stateKey ) {
+					continue;
+				}
+
+				$expanded = self::expandGradient( $value );
+
+				if ( null === $expanded ) {
+					continue;
+				}
+
+				$out[ $stateKey ] = $expanded;
+			}
+		}
+
+		return $out;
+	}
+
+	/**
+	 * Read every gradient override out of an `attributes.responsive`
+	 * bag, expanding slugs and dropping null/empty entries.
+	 *
+	 * @param  mixed  $responsiveBag
+	 *
+	 * @return array<string, string>
+	 */
+	protected static function collectBreakpointOverrides( mixed $responsiveBag ): array
+	{
+		if ( ! is_array( $responsiveBag ) ) {
+			return [];
+		}
+
+		$out = [];
+
+		foreach ( array_reverse( self::GRADIENT_PATHS ) as $path ) {
+			$overrides = $responsiveBag[ $path ] ?? null;
+
+			if ( ! is_array( $overrides ) ) {
+				continue;
+			}
+
+			foreach ( $overrides as $bp => $value ) {
+				if ( ! is_string( $bp ) || '' === $bp ) {
+					continue;
+				}
+
+				$expanded = self::expandGradient( $value );
+
+				if ( null === $expanded ) {
+					continue;
+				}
+
+				$out[ $bp ] = $expanded;
+			}
+		}
+
+		return $out;
+	}
+
+	/**
+	 * Expand a single raw value into a CSS gradient. Slugs map to
+	 * `var(--wp--preset--gradient--{slug})`; non-slug strings (already
+	 * raw CSS) pass through; everything else returns `null`.
+	 *
+	 * @since 1.1.0
+	 */
+	protected static function expandGradient( mixed $value ): ?string
+	{
+		if ( ! is_string( $value ) ) {
+			return null;
+		}
+
+		$trimmed = trim( $value );
+
+		if ( '' === $trimmed ) {
+			return null;
+		}
+
+		if ( 1 === preg_match( '/^[a-z0-9][a-z0-9_-]*$/i', $trimmed ) ) {
+			return sprintf( 'var(--wp--preset--gradient--%s)', $trimmed );
+		}
+
+		return $trimmed;
+	}
+
+	/**
+	 * Push the raw slug into `$slugs` if the value is a slug-shaped
+	 * string. Raw CSS values are ignored — only token references can
+	 * become stale.
+	 *
+	 * @param  array<int, string>  &$slugs
+	 */
+	protected static function collectSlug( array &$slugs, mixed $value ): void
+	{
+		if ( ! is_string( $value ) ) {
+			return;
+		}
+
+		$trimmed = trim( $value );
+
+		if ( '' === $trimmed ) {
+			return;
+		}
+
+		if ( 1 !== preg_match( '/^[a-z0-9][a-z0-9_-]*$/i', $trimmed ) ) {
+			return;
+		}
+
+		$slugs[] = $trimmed;
+	}
+
+	/**
+	 * Coerce an arbitrary attribute to a non-empty trimmed string or
+	 * `null`.
+	 */
+	protected static function coerceString( mixed $value ): ?string
+	{
+		if ( ! is_string( $value ) ) {
+			return null;
+		}
+
+		$trimmed = trim( $value );
+
+		return '' === $trimmed ? null : $trimmed;
+	}
+}

--- a/tests/Unit/GradientBorder/GradientBorderEmitterTest.php
+++ b/tests/Unit/GradientBorder/GradientBorderEmitterTest.php
@@ -1,0 +1,178 @@
+<?php
+
+/**
+ * Unit tests for {@see GradientBorderEmitter} (#490).
+ *
+ * Pins the mask-pseudo emission strategy against fixture payloads —
+ * idle-only, per-state, per-breakpoint, with-radius, etc. These tests
+ * are deliberately byte-sensitive on the emitted CSS because the JS
+ * mirror in `gradient-borders/emitter.ts` must produce the same
+ * output (assertion symmetry lives in the Vitest suite).
+ *
+ * @since 1.1.0
+ */
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\GradientBorder\GradientBorderEmitter;
+use ArtisanPackUI\VisualEditor\Responsive\BreakpointRegistry;
+use ArtisanPackUI\VisualEditor\States\StateRegistry;
+
+beforeEach( function (): void {
+	// Explicit empty layer-arrays to skip the `config()` helper lookup
+	// inside `fromLayers()` — these are pure unit tests with no
+	// Laravel container booted.
+	$this->emitter = new GradientBorderEmitter(
+		StateRegistry::fromLayers( [], [] ),
+		BreakpointRegistry::fromLayers( [], [] ),
+	);
+} );
+
+describe( 'GradientBorderEmitter::emit', function (): void {
+	it( 'returns empty when scope is blank or payload has no values', function (): void {
+		expect( $this->emitter->emit( '', [ 'idle' => 'red' ] ) )->toBe( '' );
+
+		expect( $this->emitter->emit( '.scope', [
+			'idle'        => null,
+			'states'      => [],
+			'breakpoints' => [],
+		] ) )->toBe( '' );
+	} );
+
+	it( 'emits the wrapper position + ::before mask layer for an idle gradient', function (): void {
+		$css = $this->emitter->emit( '.scope', [
+			'idle'  => 'linear-gradient(135deg, #ff0000, #0000ff)',
+			'width' => '2px',
+		] );
+
+		expect( $css )->toContain( '.scope{position:relative;border-color:transparent !important}' );
+		expect( $css )->toContain( '.scope::before{content:"";' );
+		expect( $css )->toContain( 'padding:2px;' );
+		expect( $css )->toContain( 'background:linear-gradient(135deg, #ff0000, #0000ff);' );
+		expect( $css )->toContain( 'mask-composite:exclude' );
+		expect( $css )->toContain( '-webkit-mask-composite:xor' );
+		expect( $css )->toContain( 'pointer-events:none' );
+	} );
+
+	it( 'defaults the border width to 1px when none is supplied', function (): void {
+		$css = $this->emitter->emit( '.scope', [ 'idle' => 'red' ] );
+
+		expect( $css )->toContain( 'padding:1px;' );
+	} );
+
+	it( 'inherits border-radius from the wrapper when none is configured', function (): void {
+		$css = $this->emitter->emit( '.scope', [ 'idle' => 'red' ] );
+
+		expect( $css )->toContain( 'border-radius:inherit;' );
+	} );
+
+	it( 'emits an explicit border-radius when supplied as a string', function (): void {
+		$css = $this->emitter->emit( '.scope', [
+			'idle'   => 'red',
+			'radius' => '8px',
+		] );
+
+		expect( $css )->toContain( 'border-radius:8px;' );
+		expect( $css )->not->toContain( 'border-radius:inherit;' );
+	} );
+
+	it( 'expands per-corner radius objects to four declarations', function (): void {
+		$css = $this->emitter->emit( '.scope', [
+			'idle'   => 'red',
+			'radius' => [
+				'topLeft'     => '4px',
+				'topRight'    => '8px',
+				'bottomLeft'  => '12px',
+				'bottomRight' => '16px',
+			],
+		] );
+
+		expect( $css )->toContain( 'border-top-left-radius:4px' );
+		expect( $css )->toContain( 'border-top-right-radius:8px' );
+		expect( $css )->toContain( 'border-bottom-left-radius:12px' );
+		expect( $css )->toContain( 'border-bottom-right-radius:16px' );
+	} );
+
+	it( 'emits a per-state override under the state selector', function (): void {
+		$css = $this->emitter->emit( '.scope', [
+			'idle'   => 'red',
+			'states' => [ 'hover' => 'blue' ],
+		] );
+
+		// Hover wrapped in @media (hover: hover) so touch devices
+		// don't sticky-state. Matches StateCssEmitter's behavior.
+		expect( $css )->toContain( '@media (hover: hover){' );
+		expect( $css )->toContain( '.scope:hover::before{background:blue}' );
+	} );
+
+	it( 'wraps the default transition on ::before when any non-idle override exists', function (): void {
+		$cssWithNonIdle = $this->emitter->emit( '.scope', [
+			'idle'   => 'red',
+			'states' => [ 'hover' => 'blue' ],
+		] );
+
+		expect( $cssWithNonIdle )->toContain( '.scope::before{transition:' );
+
+		$idleOnly = $this->emitter->emit( '.scope', [ 'idle' => 'red' ] );
+
+		expect( $idleOnly )->not->toContain( 'transition:' );
+	} );
+
+	it( 'emits per-breakpoint overrides under @media (min-width:...)', function (): void {
+		$css = $this->emitter->emit( '.scope', [
+			'idle'        => 'red',
+			'breakpoints' => [ 'md' => 'blue' ],
+		] );
+
+		expect( $css )->toContain( '@media (min-width:768px){.scope::before{background:blue}}' );
+	} );
+
+	it( 'silently drops breakpoint overrides for unknown keys', function (): void {
+		$css = $this->emitter->emit( '.scope', [
+			'idle'        => 'red',
+			'breakpoints' => [ 'never-defined' => 'blue' ],
+		] );
+
+		expect( $css )->not->toContain( '@media' );
+	} );
+
+	it( 'silently drops state overrides for unknown keys', function (): void {
+		$css = $this->emitter->emit( '.scope', [
+			'idle'   => 'red',
+			'states' => [ 'never-defined' => 'blue' ],
+		] );
+
+		expect( $css )->not->toContain( 'never-defined' );
+		expect( $css )->not->toContain( 'background:blue' );
+	} );
+
+	it( 'sanitises gradient strings to strip context-breaking characters', function (): void {
+		// `<`, `>`, `;`, and `}` aren't in the gradient whitelist —
+		// stripping them prevents a hostile block tree from breaking
+		// out of the `background:` declaration or the surrounding
+		// `<style>` tag.
+		$css = $this->emitter->emit( '.scope', [
+			'idle' => 'linear-gradient(<script>red;</script>blue)',
+		] );
+
+		expect( $css )->not->toContain( '<' );
+		expect( $css )->not->toContain( '>' );
+		expect( $css )->not->toContain( ';script' );
+	} );
+
+	it( 'sanitises width values to strip context-breaking characters', function (): void {
+		// The `content:""` declaration legitimately includes `"` —
+		// assert the unsafe payload's `"`/`}`/`<` characters are
+		// gone from the width slot. The `/` survives the whitelist
+		// (legal in calc()), but on its own can't break out of a
+		// `padding:` declaration.
+		$css = $this->emitter->emit( '.scope', [
+			'idle'  => 'red',
+			'width' => '2px"; }</style>',
+		] );
+
+		expect( $css )->not->toContain( 'padding:2px";' );
+		expect( $css )->not->toContain( '</style>' );
+		expect( $css )->not->toContain( '}</' );
+	} );
+} );

--- a/tests/Unit/GradientBorder/GradientBorderResolverTest.php
+++ b/tests/Unit/GradientBorder/GradientBorderResolverTest.php
@@ -1,0 +1,195 @@
+<?php
+
+/**
+ * Unit tests for {@see GradientBorderResolver} (#490).
+ *
+ * Covers the three cascade sources the resolver reads from
+ * (`style.border.gradient`, `attributes.states['style.border.gradient']`,
+ * `attributes.responsive['style.border.gradient']`), slug-vs-raw value
+ * expansion, the shorthand path key, and the slug-collection helper
+ * the editor's token-warning surface uses.
+ *
+ * @since 1.1.0
+ */
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\GradientBorder\GradientBorderResolver;
+
+describe( 'GradientBorderResolver::resolve', function (): void {
+	it( 'returns null when no gradient configuration exists anywhere', function (): void {
+		expect( GradientBorderResolver::resolve( [] ) )->toBeNull();
+
+		expect( GradientBorderResolver::resolve( [
+			'style' => [ 'border' => [ 'width' => '2px', 'color' => '#000' ] ],
+		] ) )->toBeNull();
+	} );
+
+	it( 'expands a slug into var(--wp--preset--gradient--{slug})', function (): void {
+		$resolved = GradientBorderResolver::resolve( [
+			'style' => [ 'border' => [ 'gradient' => 'primary-glow' ] ],
+		] );
+
+		expect( $resolved )->not->toBeNull();
+		expect( $resolved['idle'] )->toBe( 'var(--wp--preset--gradient--primary-glow)' );
+	} );
+
+	it( 'passes raw CSS gradient values through unchanged', function (): void {
+		$raw      = 'linear-gradient(135deg, #ff0000, #0000ff)';
+		$resolved = GradientBorderResolver::resolve( [
+			'style' => [ 'border' => [ 'gradient' => $raw ] ],
+		] );
+
+		expect( $resolved['idle'] )->toBe( $raw );
+	} );
+
+	it( 'collects per-state overrides from attributes.states canonical path', function (): void {
+		$resolved = GradientBorderResolver::resolve( [
+			'states' => [
+				'style.border.gradient' => [
+					'hover' => 'primary-glow-bright',
+					'focus' => 'linear-gradient(180deg, red, blue)',
+				],
+			],
+		] );
+
+		expect( $resolved )->not->toBeNull();
+		expect( $resolved['states'] )->toBe( [
+			'hover' => 'var(--wp--preset--gradient--primary-glow-bright)',
+			'focus' => 'linear-gradient(180deg, red, blue)',
+		] );
+	} );
+
+	it( 'accepts the shorthand `border.gradient` path key for state overrides', function (): void {
+		$resolved = GradientBorderResolver::resolve( [
+			'states' => [
+				'border.gradient' => [
+					'hover' => 'primary-glow-bright',
+				],
+			],
+		] );
+
+		expect( $resolved['states'] )->toBe( [
+			'hover' => 'var(--wp--preset--gradient--primary-glow-bright)',
+		] );
+	} );
+
+	it( 'lets the canonical state path overwrite the shorthand when both exist', function (): void {
+		$resolved = GradientBorderResolver::resolve( [
+			'states' => [
+				'border.gradient'       => [ 'hover' => 'shorthand-loses' ],
+				'style.border.gradient' => [ 'hover' => 'canonical-wins' ],
+			],
+		] );
+
+		expect( $resolved['states']['hover'] )->toBe( 'var(--wp--preset--gradient--canonical-wins)' );
+	} );
+
+	it( 'collects per-breakpoint overrides', function (): void {
+		$resolved = GradientBorderResolver::resolve( [
+			'responsive' => [
+				'style.border.gradient' => [
+					'md' => 'primary-vertical',
+					'lg' => 'linear-gradient(45deg, #000, #fff)',
+				],
+			],
+		] );
+
+		expect( $resolved['breakpoints'] )->toBe( [
+			'md' => 'var(--wp--preset--gradient--primary-vertical)',
+			'lg' => 'linear-gradient(45deg, #000, #fff)',
+		] );
+	} );
+
+	it( 'drops null and empty-string overrides', function (): void {
+		$resolved = GradientBorderResolver::resolve( [
+			'states' => [
+				'style.border.gradient' => [
+					'hover'  => null,
+					'focus'  => '',
+					'active' => 'primary-glow',
+				],
+			],
+		] );
+
+		expect( $resolved['states'] )->toBe( [
+			'active' => 'var(--wp--preset--gradient--primary-glow)',
+		] );
+	} );
+
+	it( 'preserves border width and radius alongside the gradient', function (): void {
+		$resolved = GradientBorderResolver::resolve( [
+			'style' => [
+				'border' => [
+					'gradient' => 'primary-glow',
+					'width'    => '4px',
+					'radius'   => '12px',
+				],
+			],
+		] );
+
+		expect( $resolved['width'] )->toBe( '4px' );
+		expect( $resolved['radius'] )->toBe( '12px' );
+	} );
+
+	it( 'preserves a per-corner radius object', function (): void {
+		$resolved = GradientBorderResolver::resolve( [
+			'style' => [
+				'border' => [
+					'gradient' => 'primary-glow',
+					'radius'   => [ 'topLeft' => '4px', 'bottomRight' => '24px' ],
+				],
+			],
+		] );
+
+		expect( $resolved['radius'] )->toBe( [ 'topLeft' => '4px', 'bottomRight' => '24px' ] );
+	} );
+} );
+
+describe( 'GradientBorderResolver::referencedSlugs', function (): void {
+	it( 'returns an empty list when no slugs are referenced', function (): void {
+		expect( GradientBorderResolver::referencedSlugs( [] ) )->toBe( [] );
+
+		expect( GradientBorderResolver::referencedSlugs( [
+			'style' => [ 'border' => [ 'gradient' => 'linear-gradient(red, blue)' ] ],
+		] ) )->toBe( [] );
+	} );
+
+	it( 'pulls slugs from idle + state + responsive bags', function (): void {
+		$slugs = GradientBorderResolver::referencedSlugs( [
+			'style'      => [ 'border' => [ 'gradient' => 'primary-glow' ] ],
+			'states'     => [
+				'style.border.gradient' => [ 'hover' => 'primary-glow-bright' ],
+			],
+			'responsive' => [
+				'style.border.gradient' => [ 'md' => 'vertical' ],
+			],
+		] );
+
+		sort( $slugs );
+
+		expect( $slugs )->toBe( [ 'primary-glow', 'primary-glow-bright', 'vertical' ] );
+	} );
+
+	it( 'deduplicates slugs that appear in multiple cascade slots', function (): void {
+		$slugs = GradientBorderResolver::referencedSlugs( [
+			'style'      => [ 'border' => [ 'gradient' => 'primary-glow' ] ],
+			'states'     => [
+				'style.border.gradient' => [ 'hover' => 'primary-glow' ],
+			],
+			'responsive' => [
+				'style.border.gradient' => [ 'md' => 'primary-glow' ],
+			],
+		] );
+
+		expect( $slugs )->toBe( [ 'primary-glow' ] );
+	} );
+
+	it( 'ignores raw CSS values — they cannot become stale', function (): void {
+		$slugs = GradientBorderResolver::referencedSlugs( [
+			'style' => [ 'border' => [ 'gradient' => 'radial-gradient(circle, #f00, #00f)' ] ],
+		] );
+
+		expect( $slugs )->toBe( [] );
+	} );
+} );

--- a/tests/visual/border-gradients.spec.ts
+++ b/tests/visual/border-gradients.spec.ts
@@ -15,7 +15,7 @@
  * matrix so the implementation here doesn't drift from the contract.
  *
  * When Playwright lands:
- *   - Rename to `border-gradients.spec.ts`, remove the skip guard.
+ *   - Remove the `PLAYWRIGHT_AVAILABLE` skip guard at the bottom.
  *   - Replace `serveBlockFixture` with the real harness call (likely
  *     `await mountBlock(page, 'fixtures/gradient-border.json', vars)`
  *     or similar).

--- a/tests/visual/border-gradients.spec.ts
+++ b/tests/visual/border-gradients.spec.ts
@@ -1,0 +1,96 @@
+/**
+ * Visual regression contract for gradient borders (#490).
+ *
+ * Acceptance criterion AC-8 of #490 calls for Playwright visual
+ * regression coverage at border-radius values 0 / 8 / 12 / 24 / 9999
+ * across all three gradient types (linear, radial, conic). This file
+ * is the test contract those snapshots have to satisfy — every entry
+ * in `MATRIX` becomes one screenshot baseline once Playwright is wired
+ * up.
+ *
+ * The Playwright runner itself is not yet installed in this package
+ * (no `@playwright/test` dependency, no `playwright.config.ts`). Wiring
+ * the runner — config file, baseline screenshots, CI job, fixture
+ * blocks — is tracked separately. Until then this file documents the
+ * matrix so the implementation here doesn't drift from the contract.
+ *
+ * When Playwright lands:
+ *   - Rename to `border-gradients.spec.ts`, remove the skip guard.
+ *   - Replace `serveBlockFixture` with the real harness call (likely
+ *     `await mountBlock(page, 'fixtures/gradient-border.json', vars)`
+ *     or similar).
+ *   - Capture baselines via `--update-snapshots`.
+ *
+ * @since 1.1.0
+ */
+
+interface Fixture {
+	name: string
+	gradient: string
+	radius: string | Record<string, string>
+}
+
+interface MatrixEntry extends Fixture {
+	label: string
+}
+
+// All combinations the snapshot suite must cover. 3 gradient types × 5
+// radius values = 15 baselines; per-corner is a 16th to verify the
+// per-side path holds up under mask clipping.
+const GRADIENT_TYPES: Array<Pick<Fixture, 'name' | 'gradient'>> = [
+	{ name: 'linear',  gradient: 'linear-gradient(135deg, #ff0080, #7928ca)' },
+	{ name: 'radial',  gradient: 'radial-gradient(circle, #ff0080, #7928ca)' },
+	{ name: 'conic',   gradient: 'conic-gradient(from 0deg, #ff0080, #7928ca, #ff0080)' },
+]
+
+const RADII = [ '0', '8px', '12px', '24px', '9999px' ]
+
+const MATRIX: MatrixEntry[] = []
+for ( const gradient of GRADIENT_TYPES ) {
+	for ( const radius of RADII ) {
+		MATRIX.push( {
+			label:    `${ gradient.name } @ radius ${ radius }`,
+			name:     gradient.name,
+			gradient: gradient.gradient,
+			radius,
+		} )
+	}
+}
+
+// Per-corner asymmetry — covers the corner-by-corner emission path
+// the resolver takes for the object-shape radius.
+MATRIX.push( {
+	label:    'linear @ per-corner radius',
+	name:     'linear',
+	gradient: 'linear-gradient(135deg, #ff0080, #7928ca)',
+	radius:   {
+		topLeft:     '4px',
+		topRight:    '8px',
+		bottomLeft:  '12px',
+		bottomRight: '24px',
+	},
+} )
+
+// Sentinel: Playwright not yet wired. The runner / config / fixture
+// harness lands in a follow-up issue; until then the matrix above
+// stays in sync with the resolver + emitter so the snapshot work can
+// pick it up as the contract.
+const PLAYWRIGHT_AVAILABLE = false
+
+if ( PLAYWRIGHT_AVAILABLE ) {
+	// @ts-expect-error — placeholder for the real runner import.
+	const { test, expect } = require( '@playwright/test' )
+
+	for ( const entry of MATRIX ) {
+		test( `gradient border: ${ entry.label }`, async ( { page }: { page: unknown } ): Promise<void> => {
+			void page
+			void entry
+			void expect
+			// const url = await serveBlockFixture( entry )
+			// await page.goto( url )
+			// await expect( page.locator( '[data-test=block]' ) ).toHaveScreenshot( `${ entry.name }-${ entry.radius }.png` )
+		} )
+	}
+}
+
+export { MATRIX }


### PR DESCRIPTION
## Description

Implements [#490](https://github.com/ArtisanPack-UI/visual-editor/issues/490) — block borders can now be painted with linear, radial, or conic gradients. The feature composes with State Design Tools (per-state overrides), Responsive Design Tools (per-breakpoint overrides), honors registered gradient tokens from \`theme.json\`, and clips correctly at any \`border-radius\`.

The PR also includes a color-picker consistency sweep so every per-block color picker (background, text, link, border) offers a Color | Gradient tabbed UX, matching how the WordPress background picker works.

**Closes:** #490

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #490

## Motivation and Context

Block borders shipped with solid color only. Modern design systems lean on gradient borders for emphasis (cards with a hover-glow border, CTAs with a brand-gradient outline). Authors couldn't get there without custom CSS, and the resulting CSS didn't compose with our token system, state composition, or live-preview correctly.

While building this, a related UX gap surfaced: blocks that opted into \`supports.color.background\` weren't consistently exposing a Gradient tab on the auto-injected color picker. That fix is bundled here so the editor-wide color picker UX feels unified after this PR.

## Changes Made

**Core gradient border pipeline**
- \`src/GradientBorder/{Resolver,Emitter}\` — pure resolver + CSS emitter that walk the standard \`attributes.states\` / \`attributes.responsive\` bags and produce scoped CSS. No new storage shape — gradients ride existing cascade bags.
- \`packages/visual-editor-renderer-blade/src/Services/GradientBorderCssAccumulator\` — per-request dedupe, mirroring the responsive + state accumulators.
- \`BlockSupports::compile\` extended with \`compileGradientBorder\` for the static partial path, plus a new public \`applyGradientBorder(\$html, \$attrs)\` helper that post-processes dynamic blocks' HTML (icon, file, gallery, etc.). Without this, dynamic blocks that build their own wrapper HTML never reach the compile pipeline and the gradient border never renders on the front end.
- \`BlockRenderer::renderDynamic\` pipes every dynamic block's output through the helper.

**Editor side**
- \`gradient-borders/\` module mirrors the PHP emitter byte-for-byte; \`withGradientBorderStyles\` HOC injects preview CSS + the scope class into the canvas and saved markup.
- A stable \`_gradientScopeId\` is minted once per block and persisted on \`style.border\` so editor preview and server render target the same scope.

**Border picker UX**
- Gutenberg's \`BorderBoxControl\` native swatch (color + style, no gradient) is hidden via CSS scoped inside \`<InspectorControls>\`. Our own ToolsPanelItem takes its place as the first item in the Border panel via \`order: -1\`.
- Inside the popover: \`ColorGradientControl\` (tabbed Color | Gradient) + \`ToggleGroupControl\` for style (Solid / Dashed / Dotted). Matches the background picker UX.
- All four palette keys (\`colors\`, \`gradients\`, \`disableCustomColors\`, \`disableCustomGradients\`) are passed explicitly. Without all four, \`ColorGradientControl\` falls back to \`ColorGradientControlSelect\`, which reads \`useSettings('color.gradients')\` and returns empty in any theme that doesn't ship origin-grouped gradients — silently dropping the Gradient tab. Documented in \`docs/border-gradients.md\`.

**Color-picker consistency sweep**
- 73 forked blocks opted into \`__experimentalBorder.gradient: true\` via \`scripts/opt-in-gradient-border.mjs\` (covers \`blocks/\` and \`core-blocks/\`).
- 7 blocks (\`icon\`, \`cover\`, \`list\`, \`preformatted\`, \`quote\`, \`term-description\`, \`post-navigation-link\`) gained \`supports.color.gradients: true\` via \`scripts/opt-in-color-gradients.mjs\` so Gutenberg's auto-injected Background picker surfaces tabs there too.
- Cover block's placeholder overlay picker upgraded from color-only \`ColorPalette\` to tabbed \`ColorGradientControl\`.
- \`use-themed-editor-settings\` propagates the theme's \`customGradient\`, \`defaultGradients\`, \`custom\`, and \`defaultPalette\` booleans into \`__experimentalFeatures.color\`. Without these, \`useSettings('color.customGradient')\` reads undefined and the GradientPicker hides its custom-authoring UI (type / angle / color stops). Defaults to \`true\` to match WP core.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS
- Browser: Safari 26
- PHP Version: 8.4
- Project Version: release/1.1

**Tests Performed:**
1. Editor preview — gradient ring renders on the wrapper at the actual border edge for all three gradient types (linear, radial, conic) and at radii 0 / 8 / 12 / 24 / 9999
2. Front-end render via \`<x-ve-blocks>\` — confirmed the scope class \`ve-gb-<id>\` lands on the rendered wrapper for both static partial blocks (Group, Cover) AND dynamic blocks (Icon)
3. State composition — hover override paints under \`@media (hover: hover)\`, default transition applied
4. Breakpoint composition — per-breakpoint override emits the right \`@media (min-width:…)\` rule
5. Picker UX — Color | Gradient tabs render, picking a gradient stays on the Gradient tab (no state-clobber bug), custom-authoring controls (type / angle / stops) appear when the theme defines gradients

## Accessibility Tests Run

- [x] Keyboard navigation tested
- [x] Color contrast verified

**Details:** The new \`ToolsPanelItem\` (swatch trigger) and the Style \`ToggleGroupControl\` both inherit Gutenberg's standard keyboard handling and ARIA attributes (\`aria-haspopup=\"dialog\"\`, \`aria-expanded\`, \`aria-label\`). The token-missing warning uses Gutenberg's \`<Notice status=\"warning\">\` which provides screen-reader semantics. Visible focus is preserved on the swatch button and gradient palette swatches.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:**
- **Pest**: 39 new assertions covering the resolver (cascade, slug expansion, shorthand path, deduplication), the emitter (mask pseudo, radius variants, hover wrap, breakpoint emission, CSS sanitization, transparent border-color suppression), the BlockSupports integration (scope class stability, accumulator push, state + breakpoint composition), and the new \`applyGradientBorder\` helper for dynamic blocks (class injection, idempotence, editor scope-id respect).
- **Vitest**: 18 new tests mirroring the PHP behavior on the JS resolver + emitter.
- **Playwright**: visual-regression contract scaffolded at \`tests/visual/border-gradients.spec.ts\` — the runner itself is a follow-up issue (no \`@playwright/test\` dep is being added in this PR).
- **Full suites**: 2050/2050 Vitest tests pass; 1129/1131 Pest tests pass (the 2 failures are pre-existing icon-package test infrastructure issues unrelated to this work).

## Documentation

- [x] Inline code documentation added
- [x] Wiki updated (\`docs/border-gradients.md\`)

**Documentation details:** \`docs/border-gradients.md\` covers the architecture, the CSS strategy rationale (single mask-pseudo path vs. \`border-image\`), the four-key gotcha for \`ColorGradientControl\`, the theme.json requirement for \`settings.color.gradients\` + \`customGradient\` + \`defaultGradients\`, file map, and what's deferred to v2 (per-side gradients, animated gradients, gradient masks, multi-stack, Playwright runner setup).

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added border gradient support across opted-in blocks in the visual editor, including per-state and responsive overrides.
  * Gradient-border CSS is now emitted consistently for both static and dynamic block rendering.
  * Updated the editor UI to show dedicated Color \| Gradient picker tabs (including cover/overlay cases) and warns when referenced gradient tokens are missing.
* **Documentation**
  * Added/updated the “Border Gradients” guide with authoring and rendering behavior details.
* **Tests**
  * Added unit and visual-regression coverage for gradient border resolution and CSS emission.
* **Chores**
  * Added scripts to opt blocks into color gradients and gradient borders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->