### PR TITLE
fix(cover): unfreeze editor on overlay color pick + media select

### DIFF
--- a/resources/js/visual-editor/blocks/cover/__tests__/edit.test.tsx
+++ b/resources/js/visual-editor/blocks/cover/__tests__/edit.test.tsx
@@ -359,15 +359,17 @@ describe('CoverEdit', () => {
         expect(setOverlayColor).toHaveBeenNthCalledWith(1, '#ff0000');
         expect(setOverlayColor).toHaveBeenNthCalledWith(2, '#00ff00');
 
-        // Only the second background task should have written isDark —
-        // the first one's captured version was already stale.
+        // Exactly one background task should have written isDark — the
+        // second pick's task. The first pick's captured version was
+        // already stale by the time its `getMediaColor` resolved, so it
+        // must bail out without calling setAttributes.
         const isDarkCalls = setAttributes.mock.calls.filter(
             (args) =>
                 typeof args[0] === 'object' &&
                 args[0] !== null &&
                 'isDark' in (args[0] as Record<string, unknown>)
         );
-        expect(isDarkCalls.length).toBeLessThanOrEqual(1);
+        expect(isDarkCalls).toHaveLength(1);
     });
 
     // #578 — regression: the media-select click must apply the

--- a/resources/js/visual-editor/blocks/cover/__tests__/edit.test.tsx
+++ b/resources/js/visual-editor/blocks/cover/__tests__/edit.test.tsx
@@ -325,6 +325,51 @@ describe('CoverEdit', () => {
         });
     });
 
+    // #578 — race-guard: if the user picks a second overlay color
+    // before the first pick's background `getMediaColor` resolves, the
+    // first task must NOT overwrite the second pick's `isDark`. The
+    // handler bumps a version ref and the background task bails out
+    // when the captured version no longer matches.
+    it('onSetOverlayColor: a superseded background task does not write isDark', async () => {
+        const setAttributes = vi.fn();
+        const setOverlayColor = vi.fn();
+
+        render(
+            <CoverEdit
+                attributes={{ tagName: 'div', dimRatio: 100 }}
+                clientId="abc"
+                isSelected
+                overlayColor={{ color: undefined, class: undefined }}
+                setAttributes={setAttributes}
+                setOverlayColor={setOverlayColor}
+                toggleSelection={() => {}}
+            />
+        );
+
+        // Two picks before any microtask flush — second supersedes first.
+        capturedProps.placeholderColorPaletteOnChange?.('#ff0000');
+        capturedProps.placeholderColorPaletteOnChange?.('#00ff00');
+
+        // Flush microtasks so both background tasks resolve.
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+
+        // Both sync calls happened, in order.
+        expect(setOverlayColor).toHaveBeenNthCalledWith(1, '#ff0000');
+        expect(setOverlayColor).toHaveBeenNthCalledWith(2, '#00ff00');
+
+        // Only the second background task should have written isDark —
+        // the first one's captured version was already stale.
+        const isDarkCalls = setAttributes.mock.calls.filter(
+            (args) =>
+                typeof args[0] === 'object' &&
+                args[0] !== null &&
+                'isDark' in (args[0] as Record<string, unknown>)
+        );
+        expect(isDarkCalls.length).toBeLessThanOrEqual(1);
+    });
+
     // #578 — regression: the media-select click must apply the
     // media-driven attributes (url, backgroundType, id, etc.)
     // synchronously. Anything else lets the modal close while the

--- a/resources/js/visual-editor/blocks/cover/__tests__/edit.test.tsx
+++ b/resources/js/visual-editor/blocks/cover/__tests__/edit.test.tsx
@@ -2,8 +2,17 @@
  * Tests for the `artisanpack/cover` edit component.
  */
 
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render } from '@testing-library/react';
+
+// #578 — capture the handlers passed to the placeholder's ColorPalette
+// and MediaPlaceholder so the regression tests below can invoke them
+// directly and assert that the cover-block edit component calls
+// `setAttributes` synchronously (without awaiting `getMediaColor`).
+const capturedProps: {
+    placeholderColorPaletteOnChange?: (color: string | undefined) => void;
+    placeholderMediaOnSelect?: (media: unknown) => void;
+} = {};
 
 vi.mock('@wordpress/i18n', () => ({
     __: (text: string) => text,
@@ -142,9 +151,14 @@ vi.mock('@wordpress/block-editor', () => {
         }) => <div data-testid="inspector">{children}</div>,
         MediaPlaceholder: ({
             children,
+            onSelect,
         }: {
             children?: React.ReactNode;
-        }) => <div data-testid="placeholder">{children}</div>,
+            onSelect?: (media: unknown) => void;
+        }) => {
+            capturedProps.placeholderMediaOnSelect = onSelect;
+            return <div data-testid="placeholder">{children}</div>;
+        },
         MediaReplaceFlow: ({
             children,
         }: {
@@ -155,7 +169,14 @@ vi.mock('@wordpress/block-editor', () => {
         MediaUploadCheck: ({ children }: { children?: React.ReactNode }) => (
             <>{children}</>
         ),
-        ColorPalette: () => null,
+        ColorPalette: ({
+            onChange,
+        }: {
+            onChange?: (color: string | undefined) => void;
+        }) => {
+            capturedProps.placeholderColorPaletteOnChange = onChange;
+            return null;
+        },
         RichText: ({ value }: { value?: string }) => (
             <span dangerouslySetInnerHTML={{ __html: value ?? '' }} />
         ),
@@ -171,9 +192,9 @@ vi.mock('@wordpress/block-editor', () => {
             (Component: React.ComponentType<unknown>) =>
             (props: Record<string, unknown>) => (
                 <Component
-                    {...props}
                     overlayColor={{ color: undefined, class: undefined }}
                     setOverlayColor={() => {}}
+                    {...props}
                 />
             ),
         __experimentalUseGradient: () => ({
@@ -184,15 +205,6 @@ vi.mock('@wordpress/block-editor', () => {
         __experimentalGetGradientClass: (name?: string) =>
             name ? `has-${name}-gradient-background` : undefined,
         __experimentalColorGradientSettingsDropdown: ({
-            children,
-        }: {
-            children?: React.ReactNode;
-        }) => <div>{children}</div>,
-        // #490 — cover placeholder now uses ColorGradientControl
-        // (tabbed Color | Gradient) in place of the color-only
-        // ColorPalette. Mock as a passthrough since the placeholder
-        // tests only assert the surrounding TagName.
-        __experimentalColorGradientControl: ({
             children,
         }: {
             children?: React.ReactNode;
@@ -233,6 +245,11 @@ vi.mock('memize', () => ({
 import CoverEdit from '../edit';
 
 describe('CoverEdit', () => {
+    beforeEach(() => {
+        capturedProps.placeholderColorPaletteOnChange = undefined;
+        capturedProps.placeholderMediaOnSelect = undefined;
+    });
+
     it('renders the placeholder TagName when there is no background and no inner blocks', () => {
         const setAttributes = vi.fn();
         const { container } = render(
@@ -270,5 +287,83 @@ describe('CoverEdit', () => {
         const img = container.querySelector('img.wp-block-cover__image-background');
         expect(img).not.toBeNull();
         expect(img?.getAttribute('src')).toBe('https://example.com/photo.jpg');
+    });
+
+    // #578 — regression: the picker click must apply the overlay color
+    // synchronously. Awaiting `getMediaColor` here piles RAF callbacks
+    // from the upstream contrast checker faster than React can flush,
+    // hangs the editor, and eventually crashes the block via
+    // `BlockCrashBoundary`. The handler now commits the picked color
+    // and `isUserOverlayColor` flag in the same tick, then refines
+    // `isDark` in a background task.
+    it('onSetOverlayColor: commits the overlay color and isUserOverlayColor synchronously', () => {
+        const setAttributes = vi.fn();
+        const setOverlayColor = vi.fn();
+
+        render(
+            <CoverEdit
+                attributes={{ tagName: 'div', dimRatio: 100 }}
+                clientId="abc"
+                isSelected
+                overlayColor={{ color: undefined, class: undefined }}
+                setAttributes={setAttributes}
+                setOverlayColor={setOverlayColor}
+                toggleSelection={() => {}}
+            />
+        );
+
+        expect(capturedProps.placeholderColorPaletteOnChange).toBeDefined();
+
+        capturedProps.placeholderColorPaletteOnChange?.('#ff0000');
+
+        // Both calls must land before the test yields to the
+        // microtask / RAF queue — otherwise the editor render loop
+        // can't settle and the RAF storm reproduces.
+        expect(setOverlayColor).toHaveBeenCalledWith('#ff0000');
+        expect(setAttributes).toHaveBeenCalledWith({
+            isUserOverlayColor: true,
+        });
+    });
+
+    // #578 — regression: the media-select click must apply the
+    // media-driven attributes (url, backgroundType, id, etc.)
+    // synchronously. Anything else lets the modal close while the
+    // block remains in placeholder state — the editor then freezes
+    // during the await and crashes via `BlockCrashBoundary`.
+    it('onSelectMedia: commits the media attributes synchronously', () => {
+        const setAttributes = vi.fn();
+        const setOverlayColor = vi.fn();
+
+        render(
+            <CoverEdit
+                attributes={{ tagName: 'div', dimRatio: 100 }}
+                clientId="abc"
+                isSelected
+                overlayColor={{ color: undefined, class: undefined }}
+                setAttributes={setAttributes}
+                setOverlayColor={setOverlayColor}
+                toggleSelection={() => {}}
+            />
+        );
+
+        expect(capturedProps.placeholderMediaOnSelect).toBeDefined();
+
+        capturedProps.placeholderMediaOnSelect?.({
+            id: 42,
+            url: 'https://example.com/photo.jpg',
+            type: 'image',
+            media_type: 'image',
+            mime: 'image/jpeg',
+        });
+
+        expect(setAttributes).toHaveBeenCalled();
+        const callArgs = setAttributes.mock.calls[0]?.[0] as Record<
+            string,
+            unknown
+        >;
+        expect(callArgs.url).toBe('https://example.com/photo.jpg');
+        expect(callArgs.id).toBe(42);
+        expect(callArgs.focalPoint).toBeUndefined();
+        expect(callArgs.useFeaturedImage).toBeUndefined();
     });
 });

--- a/resources/js/visual-editor/blocks/cover/__tests__/edit.test.tsx
+++ b/resources/js/visual-editor/blocks/cover/__tests__/edit.test.tsx
@@ -323,6 +323,9 @@ describe('CoverEdit', () => {
         expect(setAttributes).toHaveBeenCalledWith({
             isUserOverlayColor: true,
         });
+        // Exactly one synchronous setAttributes call — the `isDark`
+        // refinement must remain deferred to the background task.
+        expect(setAttributes).toHaveBeenCalledTimes(1);
     });
 
     // #578 — race-guard: if the user picks a second overlay color
@@ -403,7 +406,9 @@ describe('CoverEdit', () => {
             mime: 'image/jpeg',
         });
 
-        expect(setAttributes).toHaveBeenCalled();
+        // Exactly one synchronous setAttributes call — the overlay
+        // color / `isDark` refinement must remain deferred.
+        expect(setAttributes).toHaveBeenCalledTimes(1);
         const callArgs = setAttributes.mock.calls[0]?.[0] as Record<
             string,
             unknown

--- a/resources/js/visual-editor/blocks/cover/edit/index.tsx
+++ b/resources/js/visual-editor/blocks/cover/edit/index.tsx
@@ -17,11 +17,10 @@ import { useEffect, useMemo, useRef } from '@wordpress/element';
 import { Placeholder, Spinner } from '@wordpress/components';
 import {
     withColors,
+    ColorPalette,
     useBlockProps,
     useSettings,
     useInnerBlocksProps,
-    // eslint-disable-next-line camelcase
-    __experimentalColorGradientControl as ColorGradientControl,
     // eslint-disable-next-line camelcase
     __experimentalUseGradient as useGradient,
     store as blockEditorStore,
@@ -102,7 +101,12 @@ function getInnerBlocksTemplate(
 ): unknown[][] {
     return [
         [
-            'core/paragraph',
+            // #578 — must reference the forked block name. `core/paragraph`
+            // is not registered in this editor (the paragraph block is
+            // forked at `artisanpack/paragraph`), so the inner-blocks
+            // template insertion fails when the cover transitions out of
+            // its placeholder state, contributing to the editor hang.
+            'artisanpack/paragraph',
             {
                 style: {
                     typography: {
@@ -250,13 +254,17 @@ function CoverEdit({
             options?: { type?: string }
         ) => void;
     };
-    const { gradientClass, gradientValue, setGradient } = useGradient() as {
+    const { gradientClass, gradientValue } = useGradient() as {
         gradientClass?: string;
         gradientValue?: string;
-        setGradient: (next: string | undefined) => void;
     };
 
-    const onSelectMedia = async (
+    // #578 — commit the media-driven attributes (url, backgroundType, etc.)
+    // synchronously so the modal's "Select 1 item" click returns and the
+    // editor render loop settles before any async work resumes. The
+    // overlay-color / `isDark` refinements depend on `getMediaColor`, so
+    // they run in a background task and surface failures via console.error.
+    const onSelectMedia = (
         newMedia:
             | {
                   type?: string;
@@ -269,7 +277,7 @@ function CoverEdit({
                   };
               }
             | undefined
-    ): Promise<void> => {
+    ): void => {
         const mediaAttributes = attributesFromMedia(newMedia);
         if (!mediaAttributes) {
             return;
@@ -278,25 +286,8 @@ function CoverEdit({
             IMAGE_BACKGROUND_TYPE
         );
 
-        const averageBackgroundColor = await getMediaColor(
-            isImage ? newMedia?.url : undefined
-        );
-
-        let newOverlayColor = overlayColor.color;
-        if (!isUserOverlayColor) {
-            newOverlayColor = averageBackgroundColor;
-            setOverlayColor(newOverlayColor);
-            __unstableMarkNextChangeAsNotPersistent();
-        }
-
         const newDimRatio =
             originalUrl === undefined && dimRatio === 100 ? 50 : dimRatio;
-
-        const newIsDark = compositeIsDark(
-            newDimRatio,
-            newOverlayColor,
-            averageBackgroundColor
-        );
 
         if (isImage && mediaAttributes?.id) {
             const { imageDefaultSize } = getSettings() as {
@@ -334,9 +325,42 @@ function CoverEdit({
             focalPoint: undefined,
             useFeaturedImage: undefined,
             dimRatio: newDimRatio,
-            isDark: newIsDark,
             isUserOverlayColor: isUserOverlayColor || false,
         });
+
+        const refinementUrl = isImage
+            ? (mediaAttributes.url as string | undefined)
+            : undefined;
+
+        void (async () => {
+            try {
+                const averageBackgroundColor = await getMediaColor(
+                    refinementUrl
+                );
+
+                let newOverlayColor = overlayColor.color;
+                if (!isUserOverlayColor) {
+                    newOverlayColor = averageBackgroundColor;
+                    __unstableMarkNextChangeAsNotPersistent();
+                    setOverlayColor(newOverlayColor);
+                }
+
+                const newIsDark = compositeIsDark(
+                    newDimRatio,
+                    newOverlayColor,
+                    averageBackgroundColor
+                );
+
+                __unstableMarkNextChangeAsNotPersistent();
+                setAttributes({ isDark: newIsDark });
+            } catch (error) {
+                // eslint-disable-next-line no-console
+                console.error(
+                    '[cover] failed to refine overlay color and isDark after media select',
+                    error
+                );
+            }
+        })();
     };
 
     const onClearMedia = (): void => {
@@ -365,23 +389,44 @@ function CoverEdit({
         });
     };
 
-    const onSetOverlayColor = async (
+    // #578 — apply the user's picked overlay color synchronously so the
+    // picker click returns immediately and React can settle. Awaiting
+    // `getMediaColor` here piles RAF callbacks from the upstream contrast
+    // checker faster than React can flush, tripping its "Maximum update
+    // depth exceeded" guard and crashing the block via `BlockCrashBoundary`.
+    // The `isDark` refinement is deferred to a background task.
+    const onSetOverlayColor = (
         newOverlayColor: string | undefined
-    ): Promise<void> => {
-        const averageBackgroundColor = await getMediaColor(url);
-        const newIsDark = compositeIsDark(
-            dimRatio,
-            newOverlayColor,
-            averageBackgroundColor
-        );
-
+    ): void => {
         setOverlayColor(newOverlayColor);
         __unstableMarkNextChangeAsNotPersistent();
 
         setAttributes({
             isUserOverlayColor: true,
-            isDark: newIsDark,
         });
+
+        void (async () => {
+            try {
+                const averageBackgroundColor = await getMediaColor(url);
+                const newIsDark = compositeIsDark(
+                    dimRatio,
+                    newOverlayColor,
+                    averageBackgroundColor
+                );
+
+                __unstableMarkNextChangeAsNotPersistent();
+                setAttributes({ isDark: newIsDark });
+            } catch (error) {
+                // Surface the swallowed error path so a future regression
+                // of the picker-hang class is visible in the console
+                // instead of a blank tab.
+                // eslint-disable-next-line no-console
+                console.error(
+                    '[cover] failed to refine isDark after overlay color change',
+                    error
+                );
+            }
+        })();
     };
 
     const onUpdateDimRatio = async (newDimRatio: number): Promise<void> => {
@@ -667,22 +712,13 @@ function CoverEdit({
                         toggleUseFeaturedImage={toggleUseFeaturedImage}
                     >
                         <div className="wp-block-cover__placeholder-background-options">
-                            { /* #490 — surface Color | Gradient tabs here so the
-                                 placeholder matches the full overlay picker
-                                 in `inspector-controls.tsx`. Same control,
-                                 same UX expectation across the editor. */ }
-                            <ColorGradientControl
-                                label={__('Overlay')}
-                                showTitle={false}
-                                colorValue={overlayColor.color}
-                                gradientValue={gradientValue}
-                                onColorChange={onSetOverlayColor}
-                                onGradientChange={setGradient}
+                            <ColorPalette
+                                disableCustomColors
+                                value={overlayColor.color}
+                                onChange={onSetOverlayColor}
                                 clearable={false}
-                                enableAlpha={false}
-                                disableCustomColors={true}
-                                disableCustomGradients={false}
-                                __experimentalIsRenderedInSidebar
+                                asButtons
+                                aria-label={__('Overlay color')}
                             />
                         </div>
                     </CoverPlaceholder>

--- a/resources/js/visual-editor/blocks/cover/edit/index.tsx
+++ b/resources/js/visual-editor/blocks/cover/edit/index.tsx
@@ -175,6 +175,14 @@ function CoverEdit({
         __unstableMarkNextChangeAsNotPersistent: () => void;
     };
 
+    // #578 — refinement-task version guard. Each user-triggered handler
+    // (overlay color pick, media select, media clear) bumps this counter
+    // and captures the new value. The background `getMediaColor` task
+    // checks the captured value before applying its result so a newer
+    // user action can't be overwritten by a stale completion — e.g. user
+    // picks color A, then color B, then A's task resolves last.
+    const refinementVersionRef = useRef(0);
+
     const { media } = useSelect(
         (select) => {
             return {
@@ -286,6 +294,8 @@ function CoverEdit({
             IMAGE_BACKGROUND_TYPE
         );
 
+        const version = ++refinementVersionRef.current;
+
         const newDimRatio =
             originalUrl === undefined && dimRatio === 100 ? 50 : dimRatio;
 
@@ -337,6 +347,9 @@ function CoverEdit({
                 const averageBackgroundColor = await getMediaColor(
                     refinementUrl
                 );
+                if (version !== refinementVersionRef.current) {
+                    return;
+                }
 
                 let newOverlayColor = overlayColor.color;
                 if (!isUserOverlayColor) {
@@ -364,6 +377,11 @@ function CoverEdit({
     };
 
     const onClearMedia = (): void => {
+        // #578 — invalidate any in-flight refinement from the previous
+        // media so a late `getMediaColor` resolution can't overwrite the
+        // cleared overlay color / `isDark`.
+        ++refinementVersionRef.current;
+
         let newOverlayColor = overlayColor.color;
         if (!isUserOverlayColor) {
             newOverlayColor = DEFAULT_OVERLAY_COLOR;
@@ -398,6 +416,8 @@ function CoverEdit({
     const onSetOverlayColor = (
         newOverlayColor: string | undefined
     ): void => {
+        const version = ++refinementVersionRef.current;
+
         setOverlayColor(newOverlayColor);
         __unstableMarkNextChangeAsNotPersistent();
 
@@ -408,6 +428,9 @@ function CoverEdit({
         void (async () => {
             try {
                 const averageBackgroundColor = await getMediaColor(url);
+                if (version !== refinementVersionRef.current) {
+                    return;
+                }
                 const newIsDark = compositeIsDark(
                     dimRatio,
                     newOverlayColor,

--- a/resources/js/visual-editor/blocks/cover/edit/index.tsx
+++ b/resources/js/visual-editor/blocks/cover/edit/index.tsx
@@ -221,12 +221,20 @@ function CoverEdit({
         media?.source_url;
 
     useEffect(() => {
+        // #578 — capture the refinement version so a concurrent
+        // `onClearMedia` / `onSelectMedia` / `onSetOverlayColor` can
+        // invalidate this featured-image refinement before its
+        // `getMediaColor` promise resolves.
+        const version = ++refinementVersionRef.current;
         (async () => {
             if (!useFeaturedImage) {
                 return;
             }
 
             const averageBackgroundColor = await getMediaColor(mediaUrl);
+            if (version !== refinementVersionRef.current) {
+                return;
+            }
 
             let newOverlayColor = overlayColor.color;
             if (!isUserOverlayColor) {


### PR DESCRIPTION
## Description

The `artisanpack/cover` block hung the editor whenever the user picked an overlay color or chose media from the modal. The repro: pick a color swatch (or choose a media item and click "Select 1 item") → block doesn't update → editor stops responding → switching tabs and returning shows a blank page. No console output, no network errors — `BlockCrashBoundary` swallowed a "Maximum update depth exceeded" throw.

Two independent regressions stacked on top of each other:

1. **Async handlers**. `onSetOverlayColor` and `onSelectMedia` awaited `getMediaColor(url)` before calling `setAttributes`. During that await the upstream contrast checker's deps-less `useLayoutEffect` piled `requestAnimationFrame` callbacks faster than React could flush. Even though `enableContrastChecker: false` is set on every block via `disableContrastCheckerOnBlocks`, the experimental color/gradient pickers cover uses appear to instantiate the checker through a path the workaround doesn't gate.
2. **Unregistered inner block**. `getInnerBlocksTemplate` referenced `core/paragraph`, but paragraph is forked at `artisanpack/paragraph` in this editor. When the cover transitioned out of placeholder state, the template tried to insert an unknown block on every render, compounding the freeze.

**Closes:** #578

## Type of Change

- [x] Bug fix (fixes an issue)

## Related Issue

**Issue:** #578

## Motivation and Context

Cover is the most-used hero/CTA block, and right now the editor freezes the moment a user tries to pick an overlay color or media — both flows in the issue's "Steps to Reproduce." Manual verification on `release/1.1` confirmed the freeze and the eventual blank tab. The fix restores the same behaviour `artisanpack/image` exhibits today (image's color picker and media select both work).

While in here, also reverted the placeholder back to the original `ColorPalette` color-swatch UI. PR #490 surfaced the tabbed Color | Gradient control inside the placeholder; per discussion the placeholder should stay color-only.

## Changes Made

- `cover/edit/index.tsx`:
  - `onSetOverlayColor` and `onSelectMedia` are now synchronous up-front. They commit the picked overlay color / media-driven attributes (`url`, `id`, `backgroundType`, focal-point reset, `useFeaturedImage` reset, `dimRatio`, `isUserOverlayColor`) in the same tick the picker click fires, so the editor render loop settles before any async work resumes.
  - The `isDark` + average-overlay-color refinement that depends on `getMediaColor` runs in a fire-and-forget background task whose errors surface via `console.error('[cover] …', error)` — addresses the "swallowed-error → blank tab" acceptance criterion.
  - `getInnerBlocksTemplate` now references `artisanpack/paragraph` instead of the unregistered `core/paragraph`.
  - Reverted the placeholder from `__experimentalColorGradientControl` (Color | Gradient tabs) back to `ColorPalette` (color swatches only). Dropped the now-unused `setGradient` destructure and `ColorGradientControl` import.
- `cover/__tests__/edit.test.tsx`:
  - Updated `@wordpress/block-editor` mocks for `ColorPalette` and `MediaPlaceholder` to capture their `onChange` / `onSelect` props.
  - Reordered the `withColors` HOC mock so caller-provided props win (lets the new tests pass `setOverlayColor` as a spy).
  - Removed the obsolete `__experimentalColorGradientControl` mock.
  - Added two regression tests asserting that `setAttributes` (and `setOverlayColor` for the color path) are called synchronously, without yielding to the microtask queue.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (Darwin 25.5.0)
- Browser: Chrome (latest stable as of 2026-06-13)
- PHP Version: 8.4
- Project Version: `release/1.1`

**Tests Performed:**
1. Vitest suite — `npm test` — 2069/2069 passing.
2. Cover-specific Pest filter — `./vendor/bin/pest --filter=Cover` — 8 passing (the one failing test, `FontAwesomeFreeIconSetsTest`, also fails on `release/1.1` and is unrelated to this PR).
3. Manual repro in the dev app: insert `artisanpack/cover`, pick an overlay color from the placeholder swatches, pick media from the library, repeat from the inspector sidebar. All flows now apply the change and keep the editor responsive.
4. Regression-guard manual check: same flows on `artisanpack/image` still work.

## Accessibility Tests Run

- [x] Keyboard navigation tested — overlay color swatches and Media Library button reachable with tab/enter; the placeholder UI is unchanged.
- [ ] Screen reader tested — no markup change in this PR beyond reverting to the prior `ColorPalette`; same a11y profile as `release/1.1` pre-#490.
- [x] Color contrast verified — no visual surface change.
- [x] ARIA labels checked — the reverted `ColorPalette` still passes `aria-label="Overlay color"`.

## Tests Added

- [x] Unit tests added/updated
- [x] All tests passing

**Test details:**

Two new vitest cases in `cover/__tests__/edit.test.tsx`:
- `onSetOverlayColor: commits the overlay color and isUserOverlayColor synchronously` — captures the placeholder's `ColorPalette.onChange`, fires it, and asserts `setOverlayColor('#ff0000')` and `setAttributes({ isUserOverlayColor: true })` both ran in the same tick before any microtask flush.
- `onSelectMedia: commits the media attributes synchronously` — captures the placeholder's `MediaPlaceholder.onSelect`, fires it with a fake image, and asserts the first `setAttributes` call already includes the new `url`, `id`, `focalPoint: undefined`, and `useFeaturedImage: undefined`.

## Documentation

- [x] Inline code documentation added — both handlers now carry a comment explaining why the synchronous-first / async-refine split is necessary (cites #578 and the contrast-checker RAF storm).
- [ ] README updated — not needed; behaviour change is restoring previous semantics.

## Notes for the reviewer

While diagnosing the inner-block name mismatch, I noticed the same `core/*` references in two other places in `cover/`:

- `cover/transforms.ts` — `core/image` (lines 92, 252) and `core/paragraph` (lines 126, 165) in the `from`/`to` transforms.
- `cover/deprecated.tsx` — `core/paragraph` (lines 1293, 1368, 1419) in deprecated migrations.

These don't fire on the overlay-color / media-select paths so they aren't part of #578, but transforms to/from cover and old-content migrations would silently fail. Happy to fold those into this PR if you'd prefer; otherwise I'll file a follow-up.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the cover block’s overlay color control to a streamlined button-style picker with immediate visual and attribute updates.

* **Bug Fixes**
  * Fixed **`#578`** so overlay color and media selection apply reliably and immediately in the cover editor.
  * Prevented stale async color/refinement results from overwriting newer user choices (including dark/contrast state).
  * Improved the cover editor’s inner-block template to avoid placeholder-transition insertion failures.

* **Tests**
  * Added regression tests covering synchronous overlay/media updates and race-guard behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->