### PR TITLE
feat: block bindings — connect block attrs to parent post/page/CPT data (#504)

### DIFF
--- a/resources/js/visual-editor/bindings/BindingsPanel.tsx
+++ b/resources/js/visual-editor/bindings/BindingsPanel.tsx
@@ -1,0 +1,314 @@
+/**
+ * Per-attribute binding inspector panel (#504).
+ *
+ * Lists the block's scalar attributes; for each one, a toggle reveals
+ * a source select, a field picker (driven by
+ * {@link useBindingFields}), the empty-value policy, and the
+ * "allow incompatible types" override. Mutations flow back through the
+ * `onChange` callback as a complete `BindingsMap` so the HOC can hand
+ * it to `setAttributes( { bindings } )`.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.1.0
+ */
+
+import {
+	PanelBody,
+	PanelRow,
+	SelectControl,
+	TextControl,
+	ToggleControl,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+import {
+	useBindingFields,
+	useBindingSources,
+} from './use-binding-sources';
+import type {
+	BindingDefinition,
+	BindingFieldDefinition,
+	BindingsMap,
+	EmptyValuePolicy,
+} from './types';
+
+export interface BindableAttribute {
+	name: string;
+	label: string;
+	type: string;
+}
+
+export interface BindingsPanelProps {
+	attributes: BindableAttribute[];
+	bindings: BindingsMap;
+	resource: string | null;
+	onChange: ( next: BindingsMap ) => void;
+}
+
+const POLICY_OPTIONS: Array<{ label: string; value: EmptyValuePolicy }> = [
+	{ label: __( 'Fall back to static value', 'visual-editor' ), value: 'fallback' },
+	{ label: __( 'Hide (set to null)', 'visual-editor' ),       value: 'hide' },
+	{ label: __( 'Show placeholder',     'visual-editor' ),     value: 'placeholder' },
+];
+
+const FREE_FORM_SOURCES = new Set( [ 'relation' ] );
+
+function emptyBinding( source: string ): BindingDefinition {
+	return {
+		source,
+		args: {},
+		onEmpty: 'fallback',
+	};
+}
+
+function isCompatibleType(
+	attributeType: string,
+	field: BindingFieldDefinition
+): boolean {
+	if ( ! attributeType ) {
+		return true;
+	}
+
+	if ( attributeType === field.type ) {
+		return true;
+	}
+
+	// `string` / `rich-text` attrs accept anything — non-strings
+	// stringify cleanly, and the RichText component renders a plain
+	// string just as well as a RichTextValue.
+	if ( attributeType === 'string' || attributeType === 'rich-text' ) {
+		return true;
+	}
+
+	// `object` / `array` attrs accept anything — compound shapes vary
+	// per block and the picker can't sniff them any better than the
+	// resolver will at render time. Lets icon-block `iconRef` bind to a
+	// cms-framework image / json custom field without forcing the user
+	// to flip "Show incompatible types".
+	if ( attributeType === 'object' || attributeType === 'array' ) {
+		return true;
+	}
+
+	// Number ↔ integer ↔ number; both sides interchangeable.
+	if (
+		( attributeType === 'integer' || attributeType === 'number' ) &&
+		( field.type === 'number' || field.type === 'integer' )
+	) {
+		return true;
+	}
+
+	// Booleans are strict.
+	if ( attributeType === 'boolean' && field.type === 'boolean' ) {
+		return true;
+	}
+
+	return false;
+}
+
+function AttributeRow( {
+	attribute,
+	binding,
+	resource,
+	sources,
+	sourcesLoading,
+	onChange,
+}: {
+	attribute: BindableAttribute;
+	binding: BindingDefinition | undefined;
+	resource: string | null;
+	sources: ReturnType<typeof useBindingSources>['sources'];
+	sourcesLoading: boolean;
+	onChange: ( next: BindingDefinition | null ) => void;
+} ): JSX.Element {
+	const enabled = !! binding;
+	const sourceName = binding?.source ?? '';
+	const isFreeForm = FREE_FORM_SOURCES.has( sourceName );
+	const argKey = isFreeForm ? 'path' : 'key';
+	const argValue = typeof binding?.args?.[ argKey ] === 'string'
+		? ( binding!.args![ argKey ] as string )
+		: '';
+	const allowIncompatible = binding?.allowIncompatible === true;
+
+	const { fields, loading: fieldsLoading, error: fieldsError } = useBindingFields(
+		enabled ? sourceName : null,
+		resource
+	);
+
+	const filteredFields = allowIncompatible
+		? fields
+		: fields.filter( ( field ) => isCompatibleType( attribute.type, field ) );
+
+	function patchBinding( patch: Partial<BindingDefinition> ): void {
+		if ( ! binding ) {
+			return;
+		}
+
+		const next: BindingDefinition = {
+			...binding,
+			...patch,
+			args: { ...( binding.args ?? {} ), ...( patch.args ?? {} ) },
+		};
+
+		onChange( next );
+	}
+
+	return (
+		<div style={ { borderTop: '1px solid #e0e0e0', paddingTop: 12, marginTop: 12 } }>
+			<ToggleControl
+				label={ `${ attribute.label } (${ attribute.type })` }
+				help={
+					enabled
+						? __( 'This attribute will be replaced with the bound value at render time.', 'visual-editor' )
+						: __( 'Link to data from the parent post / page / CPT.', 'visual-editor' )
+				}
+				checked={ enabled }
+				onChange={ ( checked: boolean ) => {
+					if ( checked ) {
+						const fallbackSource = sources[ 0 ]?.name ?? 'custom_field';
+						onChange( emptyBinding( fallbackSource ) );
+					} else {
+						onChange( null );
+					}
+				} }
+			/>
+
+			{ enabled && (
+				<>
+					<SelectControl
+						label={ __( 'Source', 'visual-editor' ) }
+						value={ sourceName }
+						options={ [
+							{ label: __( '— pick a source —', 'visual-editor' ), value: '' },
+							...sources.map( ( source ) => ( {
+								label: source.name,
+								value: source.name,
+							} ) ),
+						] }
+						disabled={ sourcesLoading }
+						onChange={ ( next: string ) => {
+							onChange( {
+								source: next,
+								args: {},
+								onEmpty: binding!.onEmpty ?? 'fallback',
+							} );
+						} }
+					/>
+
+					{ isFreeForm ? (
+						<TextControl
+							label={ __( 'Path', 'visual-editor' ) }
+							help={ __( 'Dotted path, e.g. author.name', 'visual-editor' ) }
+							value={ argValue }
+							onChange={ ( next: string ) => patchBinding( { args: { path: next } } ) }
+						/>
+					) : (
+						<SelectControl
+							label={ __( 'Field', 'visual-editor' ) }
+							value={ argValue }
+							disabled={ fieldsLoading || ! sourceName }
+							options={ [
+								{ label: __( '— pick a field —', 'visual-editor' ), value: '' },
+								...filteredFields.map( ( field ) => ( {
+									label: `${ field.label } (${ field.type })`,
+									value: field.key,
+								} ) ),
+							] }
+							onChange={ ( next: string ) => patchBinding( { args: { key: next } } ) }
+						/>
+					) }
+
+					{ ! isFreeForm && fields.length > 0 && filteredFields.length === 0 && (
+						<PanelRow>
+							<em>
+								{ __(
+									'No fields match this attribute type. Toggle "Show incompatible types" to widen the picker.',
+									'visual-editor'
+								) }
+							</em>
+						</PanelRow>
+					) }
+
+					{ fieldsError && (
+						<PanelRow>
+							<em style={ { color: '#cc1818' } }>{ fieldsError.message }</em>
+						</PanelRow>
+					) }
+
+					{ ! isFreeForm && (
+						<ToggleControl
+							label={ __( 'Show incompatible types', 'visual-editor' ) }
+							help={ __(
+								'Allow binding to fields whose type does not match the attribute.',
+								'visual-editor'
+							) }
+							checked={ allowIncompatible }
+							onChange={ ( checked: boolean ) => patchBinding( { allowIncompatible: checked } ) }
+						/>
+					) }
+
+					<SelectControl
+						label={ __( 'When the field is empty', 'visual-editor' ) }
+						value={ binding!.onEmpty ?? 'fallback' }
+						options={ POLICY_OPTIONS }
+						onChange={ ( next: string ) => patchBinding( { onEmpty: next as EmptyValuePolicy } ) }
+					/>
+
+					{ binding!.onEmpty === 'placeholder' && (
+						<TextControl
+							label={ __( 'Placeholder', 'visual-editor' ) }
+							value={ binding!.placeholder ?? '' }
+							onChange={ ( next: string ) => patchBinding( { placeholder: next } ) }
+						/>
+					) }
+				</>
+			) }
+		</div>
+	);
+}
+
+export function BindingsPanel( {
+	attributes,
+	bindings,
+	resource,
+	onChange,
+}: BindingsPanelProps ): JSX.Element | null {
+	const { sources, loading: sourcesLoading, error: sourcesError } = useBindingSources();
+
+	if ( attributes.length === 0 ) {
+		return null;
+	}
+
+	function setBinding( name: string, next: BindingDefinition | null ): void {
+		const draft = { ...bindings };
+
+		if ( next === null ) {
+			delete draft[ name ];
+		} else {
+			draft[ name ] = next;
+		}
+
+		onChange( draft );
+	}
+
+	return (
+		<PanelBody title={ __( 'Block bindings', 'visual-editor' ) } initialOpen={ false }>
+			{ sourcesError && (
+				<PanelRow>
+					<em style={ { color: '#cc1818' } }>{ sourcesError.message }</em>
+				</PanelRow>
+			) }
+
+			{ attributes.map( ( attribute ) => (
+				<AttributeRow
+					key={ attribute.name }
+					attribute={ attribute }
+					binding={ bindings[ attribute.name ] }
+					resource={ resource }
+					sources={ sources }
+					sourcesLoading={ sourcesLoading }
+					onChange={ ( next ) => setBinding( attribute.name, next ) }
+				/>
+			) ) }
+		</PanelBody>
+	);
+}

--- a/resources/js/visual-editor/bindings/__tests__/config.test.ts
+++ b/resources/js/visual-editor/bindings/__tests__/config.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import {
+	getBindingsApiConfig,
+	resetBindingsApiConfig,
+	setBindingsApiConfig,
+} from '../config'
+
+beforeEach( () => {
+	resetBindingsApiConfig()
+} )
+
+afterEach( () => {
+	resetBindingsApiConfig()
+} )
+
+describe( 'bindings config', () => {
+	it( 'defaults to the /visual-editor/api base', () => {
+		expect( getBindingsApiConfig().apiBase ).toBe( '/visual-editor/api' )
+	} )
+
+	it( 'lets callers override the apiBase', () => {
+		setBindingsApiConfig( { apiBase: 'https://example.test/ve/api' } )
+
+		expect( getBindingsApiConfig().apiBase ).toBe( 'https://example.test/ve/api' )
+	} )
+
+	it( 'strips trailing slashes from the supplied apiBase', () => {
+		setBindingsApiConfig( { apiBase: 'https://example.test/ve/api/' } )
+
+		expect( getBindingsApiConfig().apiBase ).toBe( 'https://example.test/ve/api' )
+	} )
+
+	it( 'reset returns to the default base', () => {
+		setBindingsApiConfig( { apiBase: 'https://x.test/api' } )
+		resetBindingsApiConfig()
+
+		expect( getBindingsApiConfig().apiBase ).toBe( '/visual-editor/api' )
+	} )
+} )

--- a/resources/js/visual-editor/bindings/__tests__/register-attribute.test.ts
+++ b/resources/js/visual-editor/bindings/__tests__/register-attribute.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const filters = new Map<string, Array<{ namespace: string; callback: ( settings: unknown ) => unknown }>>()
+
+vi.mock( '@wordpress/hooks', () => ( {
+	addFilter: (
+		hook: string,
+		namespace: string,
+		callback: ( settings: unknown ) => unknown,
+	) => {
+		const list = filters.get( hook ) ?? []
+		list.push( { namespace, callback } )
+		filters.set( hook, list )
+	},
+} ) )
+
+import { registerBindingsAttribute } from '../register-attribute'
+
+const REGISTERED_KEY = Symbol.for(
+	'artisanpack-ui.visual-editor.bindings-attribute.registered',
+)
+
+function runFilter( settings: Record<string, unknown> ): Record<string, unknown> {
+	const list = filters.get( 'blocks.registerBlockType' ) ?? []
+	return list.reduce(
+		( acc, { callback } ) => callback( acc ) as Record<string, unknown>,
+		settings,
+	)
+}
+
+beforeEach( () => {
+	filters.clear()
+	delete ( globalThis as Record<symbol, unknown> )[ REGISTERED_KEY ]
+} )
+
+afterEach( () => {
+	filters.clear()
+	delete ( globalThis as Record<symbol, unknown> )[ REGISTERED_KEY ]
+} )
+
+describe( 'registerBindingsAttribute', () => {
+	it( 'registers the filter exactly once even if called twice', () => {
+		registerBindingsAttribute()
+		registerBindingsAttribute()
+
+		expect( ( filters.get( 'blocks.registerBlockType' ) ?? [] ).length ).toBe( 1 )
+	} )
+
+	it( 'adds a bindings object attribute to a block that has no attributes', () => {
+		registerBindingsAttribute()
+
+		const out = runFilter( { name: 'demo/block' } )
+
+		expect( out.attributes ).toMatchObject( {
+			bindings: { type: 'object' },
+		} )
+	} )
+
+	it( 'merges bindings into an existing attributes map without clobbering siblings', () => {
+		registerBindingsAttribute()
+
+		const out = runFilter( {
+			name: 'demo/block',
+			attributes: { icon: { type: 'string' } },
+		} )
+
+		expect( out.attributes ).toMatchObject( {
+			icon:     { type: 'string' },
+			bindings: { type: 'object' },
+		} )
+	} )
+
+	it( 'leaves a block that already declares bindings untouched', () => {
+		registerBindingsAttribute()
+
+		const existing = {
+			name:       'demo/block',
+			attributes: { bindings: { type: 'object', default: { icon: { source: 'x' } } } },
+		}
+
+		const out = runFilter( existing )
+
+		expect( out.attributes ).toBe( existing.attributes )
+	} )
+} )

--- a/resources/js/visual-editor/bindings/__tests__/with-bindings-panel.test.tsx
+++ b/resources/js/visual-editor/bindings/__tests__/with-bindings-panel.test.tsx
@@ -1,0 +1,199 @@
+import { render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const blockTypes = new Map<string, { attributes?: Record<string, unknown> }>()
+
+vi.mock( '@wordpress/blocks', () => ( {
+	getBlockType: ( name: string ) => blockTypes.get( name ),
+	__setBlockType: ( name: string, attributes: Record<string, unknown> ) => {
+		blockTypes.set( name, { attributes } )
+	},
+	__clearBlockTypes: () => {
+		blockTypes.clear()
+	},
+} ) )
+
+vi.mock( '@wordpress/block-editor', () => ( {
+	InspectorControls: ( { children }: { children: React.ReactNode } ) => (
+		<div data-testid="inspector">{ children }</div>
+	),
+} ) )
+
+vi.mock( '@wordpress/i18n', () => ( {
+	__: ( text: string ) => text,
+} ) )
+
+vi.mock( '@wordpress/components', () => ( {
+	PanelBody:     ( { children, title }: { children: React.ReactNode; title: string } ) => (
+		<section data-testid="panel" aria-label={ title }>{ children }</section>
+	),
+	PanelRow:      ( { children }: { children: React.ReactNode } ) => <div>{ children }</div>,
+	ToggleControl: ( { label, checked, onChange }: { label: string; checked: boolean; onChange: ( v: boolean ) => void } ) => (
+		<button
+			type="button"
+			data-testid={ `toggle:${ label }` }
+			data-checked={ checked }
+			onClick={ () => onChange( ! checked ) }
+		>{ label }</button>
+	),
+	SelectControl: ( { label, value, onChange }: { label: string; value: string; onChange: ( v: string ) => void } ) => (
+		<input
+			data-testid={ `select:${ label }` }
+			value={ value }
+			onChange={ ( e ) => onChange( ( e.target as HTMLInputElement ).value ) }
+		/>
+	),
+	TextControl:   ( { label, value, onChange }: { label: string; value: string; onChange: ( v: string ) => void } ) => (
+		<input
+			data-testid={ `text:${ label }` }
+			value={ value }
+			onChange={ ( e ) => onChange( ( e.target as HTMLInputElement ).value ) }
+		/>
+	),
+} ) )
+
+vi.mock( '@wordpress/compose', () => ( {
+	createHigherOrderComponent: ( fn: ( c: unknown ) => unknown ) => fn,
+} ) )
+
+vi.mock( '@wordpress/hooks', () => ( {
+	addFilter: () => undefined,
+} ) )
+
+vi.mock( '../api', () => ( {
+	fetchBindingSources: vi.fn( async () => [
+		{ name: 'custom_field' },
+		{ name: 'post_core' },
+	] ),
+	fetchBindingFields:  vi.fn( async () => [] ),
+	resolveBindings:     vi.fn( async () => ( {} ) ),
+} ) )
+
+import { __setBlockType, __clearBlockTypes } from '@wordpress/blocks'
+
+import { resetBindingSourcesCache } from '../use-binding-sources'
+import { withBindingsPanel } from '../with-bindings-panel'
+
+interface CapturedProps {
+	name: string
+	attributes: Record<string, unknown>
+	setAttributes: ( updates: Record<string, unknown> ) => void
+}
+
+let captured: CapturedProps | null = null
+
+function StubEdit( props: CapturedProps ): JSX.Element {
+	captured = props
+	return <div data-testid="stub">stub</div>
+}
+
+const Wrapped = withBindingsPanel( StubEdit as never ) as React.ComponentType<CapturedProps>
+
+beforeEach( () => {
+	captured = null
+	resetBindingSourcesCache()
+	__clearBlockTypes()
+} )
+
+afterEach( () => {
+	__clearBlockTypes()
+} )
+
+describe( 'withBindingsPanel', () => {
+	it( 'returns the inner edit unchanged when the block has no scalar attributes', () => {
+		__setBlockType( 'demo/empty', {} )
+
+		const setAttributes = vi.fn()
+		const { queryByTestId } = render(
+			<Wrapped
+				name="demo/empty"
+				attributes={ {} }
+				setAttributes={ setAttributes }
+			/>,
+		)
+
+		expect( queryByTestId( 'panel' ) ).toBeNull()
+		expect( queryByTestId( 'stub' ) ).not.toBeNull()
+	} )
+
+	it( 'renders the bindings panel when the block has scalar attributes', () => {
+		__setBlockType( 'demo/box', {
+			icon:  { type: 'string' },
+			count: { type: 'number' },
+		} )
+
+		const { getByTestId } = render(
+			<Wrapped
+				name="demo/box"
+				attributes={ { icon: 'static', count: 0 } }
+				setAttributes={ vi.fn() }
+			/>,
+		)
+
+		expect( getByTestId( 'panel' ) ).toBeTruthy()
+		expect( getByTestId( 'toggle:icon (string)' ) ).toBeTruthy()
+		expect( getByTestId( 'toggle:count (number)' ) ).toBeTruthy()
+	} )
+
+	it( 'exposes rich-text + source-typed attributes (Heading content) as bindable', () => {
+		// Matches the actual shape in heading/block.json + paragraph/block.json
+		__setBlockType( 'core/heading', {
+			content: {
+				type:     'rich-text',
+				source:   'rich-text',
+				selector: 'h1,h2,h3,h4,h5,h6',
+				role:     'content',
+			},
+			level:   { type: 'number' },
+		} )
+
+		const { getByTestId } = render(
+			<Wrapped
+				name="core/heading"
+				attributes={ {} }
+				setAttributes={ vi.fn() }
+			/>,
+		)
+
+		expect( getByTestId( 'toggle:content (rich-text)' ) ).toBeTruthy()
+		expect( getByTestId( 'toggle:level (number)' ) ).toBeTruthy()
+	} )
+
+	it( 'never lists its own bindings sidecar as a bindable attribute', () => {
+		__setBlockType( 'demo/box', {
+			bindings: { type: 'object' },
+			icon:     { type: 'string' },
+		} )
+
+		const { getByTestId, queryByTestId } = render(
+			<Wrapped
+				name="demo/box"
+				attributes={ {} }
+				setAttributes={ vi.fn() }
+			/>,
+		)
+
+		expect( getByTestId( 'toggle:icon (string)' ) ).toBeTruthy()
+		expect( queryByTestId( 'toggle:bindings (object)' ) ).toBeNull()
+	} )
+
+	it( 'exposes object-typed attributes (icon block iconRef) as bindable', () => {
+		__setBlockType( 'artisanpack/icon', {
+			iconRef:   { type: 'object', default: null },
+			customSvg: { type: 'string', default: '' },
+			size:      { type: 'number', default: 32 },
+		} )
+
+		const { getByTestId } = render(
+			<Wrapped
+				name="artisanpack/icon"
+				attributes={ {} }
+				setAttributes={ vi.fn() }
+			/>,
+		)
+
+		expect( getByTestId( 'toggle:iconRef (object)' ) ).toBeTruthy()
+		expect( getByTestId( 'toggle:customSvg (string)' ) ).toBeTruthy()
+		expect( getByTestId( 'toggle:size (number)' ) ).toBeTruthy()
+	} )
+} )

--- a/resources/js/visual-editor/bindings/api.ts
+++ b/resources/js/visual-editor/bindings/api.ts
@@ -1,0 +1,152 @@
+/**
+ * Thin fetch wrappers for the `/visual-editor/api/bindings/*`
+ * endpoints (#504). Mirrors the conventions used by
+ * `editor/api-client.ts`: `same-origin` credentials, the session CSRF
+ * token on mutating calls, normalized error throws.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.1.0
+ */
+
+import { getBindingsApiConfig } from './config';
+import type {
+	BindingFieldDefinition,
+	BindingsMap,
+	BindingSourceSummary,
+} from './types';
+
+function readCsrfToken(): string | null {
+	if ( typeof document === 'undefined' ) {
+		return null;
+	}
+
+	const meta = document.querySelector( 'meta[name="csrf-token"]' );
+	const content = meta?.getAttribute( 'content' );
+
+	return content && content.length > 0 ? content : null;
+}
+
+interface SourcesResponse {
+	sources: BindingSourceSummary[];
+}
+
+interface FieldsResponse {
+	source: string;
+	resource: string;
+	fields: BindingFieldDefinition[];
+}
+
+interface ResolveResponse {
+	values: Record<string, unknown>;
+}
+
+interface ResolveContextPayload {
+	resource: string | null;
+	id: number | string | null;
+	draft?: Record<string, unknown>;
+}
+
+async function jsonOrThrow<T>(
+	response: Response,
+	fallbackMessage: string
+): Promise<T> {
+	if ( ! response.ok ) {
+		throw new Error( `${ fallbackMessage } (HTTP ${ response.status })` );
+	}
+
+	return ( await response.json() ) as T;
+}
+
+export async function fetchBindingSources(
+	signal?: AbortSignal
+): Promise<BindingSourceSummary[]> {
+	const { apiBase } = getBindingsApiConfig();
+
+	const response = await fetch( `${ apiBase }/bindings/sources`, {
+		method: 'GET',
+		credentials: 'same-origin',
+		headers: {
+			Accept: 'application/json',
+			'X-Requested-With': 'XMLHttpRequest',
+		},
+		signal,
+	} );
+
+	const body = await jsonOrThrow<SourcesResponse>(
+		response,
+		'Failed to load binding sources.'
+	);
+
+	return body.sources ?? [];
+}
+
+export async function fetchBindingFields(
+	source: string,
+	resource: string | null | undefined,
+	signal?: AbortSignal
+): Promise<BindingFieldDefinition[]> {
+	const { apiBase } = getBindingsApiConfig();
+
+	const url = new URL(
+		`${ apiBase }/bindings/sources/${ encodeURIComponent( source ) }/fields`,
+		window.location.origin
+	);
+
+	if ( resource ) {
+		url.searchParams.set( 'resource', resource );
+	}
+
+	const response = await fetch( url.toString(), {
+		method: 'GET',
+		credentials: 'same-origin',
+		headers: {
+			Accept: 'application/json',
+			'X-Requested-With': 'XMLHttpRequest',
+		},
+		signal,
+	} );
+
+	const body = await jsonOrThrow<FieldsResponse>(
+		response,
+		`Failed to load fields for source "${ source }".`
+	);
+
+	return body.fields ?? [];
+}
+
+export async function resolveBindings(
+	payload: {
+		attrs: Record<string, unknown>;
+		bindings: BindingsMap;
+		context: ResolveContextPayload;
+	},
+	signal?: AbortSignal
+): Promise<Record<string, unknown>> {
+	const { apiBase } = getBindingsApiConfig();
+	const csrfToken = readCsrfToken();
+
+	const headers: Record<string, string> = {
+		Accept: 'application/json',
+		'Content-Type': 'application/json',
+		'X-Requested-With': 'XMLHttpRequest',
+	};
+
+	if ( csrfToken ) {
+		headers[ 'X-CSRF-TOKEN' ] = csrfToken;
+	}
+
+	const response = await fetch( `${ apiBase }/bindings/resolve`, {
+		method: 'POST',
+		credentials: 'same-origin',
+		headers,
+		body: JSON.stringify( payload ),
+		signal,
+	} );
+
+	const body = await jsonOrThrow<ResolveResponse>(
+		response,
+		'Failed to resolve bindings.'
+	);
+
+	return body.values ?? {};
+}

--- a/resources/js/visual-editor/bindings/config.ts
+++ b/resources/js/visual-editor/bindings/config.ts
@@ -1,0 +1,32 @@
+/**
+ * Module-level configuration for the bindings inspector (#504).
+ *
+ * `registerBindingsPanel(apiBase)` calls into this from the editor
+ * bootstrap so the HOC and its hooks can read the API base without each
+ * block having to thread props through the WordPress filter chain.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.1.0
+ */
+
+import type { BindingsApiConfig } from './types';
+
+const DEFAULT_API_BASE = '/visual-editor/api';
+
+let config: BindingsApiConfig = { apiBase: DEFAULT_API_BASE };
+
+export function setBindingsApiConfig( next: Partial<BindingsApiConfig> ): void {
+	config = {
+		...config,
+		...next,
+		apiBase: next.apiBase?.replace( /\/$/, '' ) ?? config.apiBase,
+	};
+}
+
+export function getBindingsApiConfig(): BindingsApiConfig {
+	return config;
+}
+
+export function resetBindingsApiConfig(): void {
+	config = { apiBase: DEFAULT_API_BASE };
+}

--- a/resources/js/visual-editor/bindings/index.ts
+++ b/resources/js/visual-editor/bindings/index.ts
@@ -1,0 +1,43 @@
+/**
+ * Block bindings public surface (#504).
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.1.0
+ */
+
+export { registerBindingsAttribute } from './register-attribute';
+export {
+	registerBindingsPanel,
+	setBindingsResourceContext,
+	withBindingsPanel,
+} from './with-bindings-panel';
+export type { RegisterBindingsPanelOptions } from './with-bindings-panel';
+export { BindingsPanel } from './BindingsPanel';
+export type {
+	BindableAttribute,
+	BindingsPanelProps,
+} from './BindingsPanel';
+export {
+	getBindingsApiConfig,
+	resetBindingsApiConfig,
+	setBindingsApiConfig,
+} from './config';
+export {
+	fetchBindingFields,
+	fetchBindingSources,
+	resolveBindings,
+} from './api';
+export { useResolvedBindings } from './use-resolved-bindings';
+export {
+	resetBindingSourcesCache,
+	useBindingFields,
+	useBindingSources,
+} from './use-binding-sources';
+export type {
+	BindingDefinition,
+	BindingFieldDefinition,
+	BindingSourceSummary,
+	BindingsApiConfig,
+	BindingsMap,
+	EmptyValuePolicy,
+} from './types';

--- a/resources/js/visual-editor/bindings/register-attribute.ts
+++ b/resources/js/visual-editor/bindings/register-attribute.ts
@@ -1,0 +1,59 @@
+/**
+ * Inject the `bindings` sidecar attribute on every block (#504).
+ *
+ * Unlike opt-in features (animations, states, gradient borders), block
+ * bindings are a universal storage shape — any scalar attribute on any
+ * block can be linked to data. So this `blocks.registerBlockType`
+ * filter unconditionally adds `bindings: { type: 'object', default:
+ * undefined }` to every block's attribute schema so the editor can
+ * `setAttributes( { bindings } )` and Gutenberg round-trips the value
+ * through save/parse identically to today's non-bound blocks.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.1.0
+ */
+
+import { addFilter } from '@wordpress/hooks';
+
+const FILTER_HOOK      = 'blocks.registerBlockType';
+const FILTER_NAMESPACE = 'artisanpack-ui/visual-editor/bindings-attribute';
+
+const REGISTERED_KEY = Symbol.for(
+	'artisanpack-ui.visual-editor.bindings-attribute.registered',
+);
+
+interface GlobalSentinelHost {
+	[ REGISTERED_KEY ]?: boolean;
+}
+
+interface BlockSettingsLike {
+	attributes?: Record<string, unknown>;
+	[ key: string ]: unknown;
+}
+
+function injectBindingsAttribute( settings: BlockSettingsLike ): BlockSettingsLike {
+	if ( settings.attributes && 'bindings' in settings.attributes ) {
+		return settings;
+	}
+
+	return {
+		...settings,
+		attributes: {
+			...( settings.attributes ?? {} ),
+			bindings: {
+				type: 'object',
+			},
+		},
+	};
+}
+
+export function registerBindingsAttribute(): void {
+	const host = globalThis as unknown as GlobalSentinelHost;
+
+	if ( host[ REGISTERED_KEY ] ) {
+		return;
+	}
+
+	addFilter( FILTER_HOOK, FILTER_NAMESPACE, injectBindingsAttribute );
+	host[ REGISTERED_KEY ] = true;
+}

--- a/resources/js/visual-editor/bindings/types.ts
+++ b/resources/js/visual-editor/bindings/types.ts
@@ -1,0 +1,40 @@
+/**
+ * TypeScript shapes for the block binding layer (#504).
+ *
+ * Mirrors the PHP `BindingResolver` storage contract:
+ *
+ *   block.attrs    = static fallback values
+ *   block.bindings = sidecar map (attribute → BindingDefinition)
+ *
+ * Drivers come from {@link BlockBindingSource} on the PHP side; this
+ * file declares only what the editor needs.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.1.0
+ */
+
+export type EmptyValuePolicy = 'fallback' | 'hide' | 'placeholder';
+
+export interface BindingDefinition {
+	source: string;
+	args?: Record<string, unknown>;
+	onEmpty?: EmptyValuePolicy;
+	placeholder?: string;
+	allowIncompatible?: boolean;
+}
+
+export type BindingsMap = Record<string, BindingDefinition>;
+
+export interface BindingSourceSummary {
+	name: string;
+}
+
+export interface BindingFieldDefinition {
+	key: string;
+	label: string;
+	type: string;
+}
+
+export interface BindingsApiConfig {
+	apiBase: string;
+}

--- a/resources/js/visual-editor/bindings/use-binding-sources.ts
+++ b/resources/js/visual-editor/bindings/use-binding-sources.ts
@@ -1,0 +1,166 @@
+/**
+ * Hooks for loading the binding sources catalog + per-source field lists
+ * (#504). One in-memory cache per module — the inspector can be opened
+ * on dozens of blocks per session, and we never want to re-hit the
+ * sources endpoint for each one.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.1.0
+ */
+
+import { useEffect, useState } from 'react';
+
+import { fetchBindingFields, fetchBindingSources } from './api';
+import type {
+	BindingFieldDefinition,
+	BindingSourceSummary,
+} from './types';
+
+interface Cache {
+	sources: BindingSourceSummary[] | null;
+	sourcesPromise: Promise<BindingSourceSummary[]> | null;
+	fields: Map<string, BindingFieldDefinition[]>;
+	fieldsPromises: Map<string, Promise<BindingFieldDefinition[]>>;
+}
+
+const cache: Cache = {
+	sources: null,
+	sourcesPromise: null,
+	fields: new Map(),
+	fieldsPromises: new Map(),
+};
+
+export function resetBindingSourcesCache(): void {
+	cache.sources = null;
+	cache.sourcesPromise = null;
+	cache.fields = new Map();
+	cache.fieldsPromises = new Map();
+}
+
+export interface SourcesState {
+	sources: BindingSourceSummary[];
+	loading: boolean;
+	error: Error | null;
+}
+
+export function useBindingSources(): SourcesState {
+	const [ state, setState ] = useState<SourcesState>( () => ( {
+		sources: cache.sources ?? [],
+		loading: cache.sources === null,
+		error: null,
+	} ) );
+
+	useEffect( () => {
+		if ( cache.sources !== null ) {
+			return;
+		}
+
+		let cancelled = false;
+
+		if ( ! cache.sourcesPromise ) {
+			cache.sourcesPromise = fetchBindingSources()
+				.then( ( sources ) => {
+					cache.sources = sources;
+					return sources;
+				} )
+				.catch( ( error: Error ) => {
+					cache.sourcesPromise = null;
+					throw error;
+				} );
+		}
+
+		cache.sourcesPromise
+			.then( ( sources ) => {
+				if ( ! cancelled ) {
+					setState( { sources, loading: false, error: null } );
+				}
+			} )
+			.catch( ( error: Error ) => {
+				if ( ! cancelled ) {
+					setState( { sources: [], loading: false, error } );
+				}
+			} );
+
+		return () => {
+			cancelled = true;
+		};
+	}, [] );
+
+	return state;
+}
+
+export interface FieldsState {
+	fields: BindingFieldDefinition[];
+	loading: boolean;
+	error: Error | null;
+}
+
+function fieldsKey( source: string, resource: string | null | undefined ): string {
+	return `${ source }::${ resource ?? '' }`;
+}
+
+export function useBindingFields(
+	source: string | null,
+	resource: string | null | undefined
+): FieldsState {
+	const [ state, setState ] = useState<FieldsState>( () => ( {
+		fields: source ? cache.fields.get( fieldsKey( source, resource ) ) ?? [] : [],
+		loading: source !== null && ! cache.fields.has( fieldsKey( source, resource ) ),
+		error: null,
+	} ) );
+
+	useEffect( () => {
+		if ( ! source ) {
+			setState( { fields: [], loading: false, error: null } );
+			return;
+		}
+
+		const key = fieldsKey( source, resource );
+
+		if ( cache.fields.has( key ) ) {
+			setState( {
+				fields: cache.fields.get( key ) ?? [],
+				loading: false,
+				error: null,
+			} );
+			return;
+		}
+
+		let cancelled = false;
+		setState( { fields: [], loading: true, error: null } );
+
+		let promise = cache.fieldsPromises.get( key );
+
+		if ( ! promise ) {
+			promise = fetchBindingFields( source, resource )
+				.then( ( fields ) => {
+					cache.fields.set( key, fields );
+					cache.fieldsPromises.delete( key );
+					return fields;
+				} )
+				.catch( ( error: Error ) => {
+					cache.fieldsPromises.delete( key );
+					throw error;
+				} );
+			cache.fieldsPromises.set( key, promise );
+		}
+
+		promise
+			.then( ( fields ) => {
+				if ( ! cancelled ) {
+					setState( { fields, loading: false, error: null } );
+				}
+			} )
+			.catch( ( error: Error ) => {
+				if ( ! cancelled ) {
+					setState( { fields: [], loading: false, error } );
+				}
+			} );
+
+		return () => {
+			cancelled = true;
+		};
+	}, [ source, resource ] );
+
+	return state;
+}

--- a/resources/js/visual-editor/bindings/use-resolved-bindings.ts
+++ b/resources/js/visual-editor/bindings/use-resolved-bindings.ts
@@ -1,0 +1,124 @@
+/**
+ * Hook that resolves a block's bindings against the editor's current
+ * context (#504). Returns a record of resolved values the HOC overlays
+ * on top of the block's static `attrs` so the canvas shows what the
+ * frontend renderer will show.
+ *
+ * Debounces calls — typing a path / picking a different field fires
+ * setAttributes every keystroke, and we don't want to spam the
+ * `bindings/resolve` endpoint for every intermediate state.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.1.0
+ */
+
+import { useEffect, useRef, useState } from 'react';
+
+import { resolveBindings } from './api';
+import type { BindingsMap } from './types';
+
+const DEBOUNCE_MS = 250;
+
+export interface ResolvedBindingsState {
+	values: Record<string, unknown>;
+	loading: boolean;
+	error: Error | null;
+}
+
+function hasActiveBindings( bindings: BindingsMap | undefined ): boolean {
+	if ( ! bindings ) {
+		return false;
+	}
+
+	for ( const binding of Object.values( bindings ) ) {
+		const source = binding?.source;
+		if ( typeof source === 'string' && source.length > 0 ) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+export function useResolvedBindings(
+	bindings: BindingsMap | undefined,
+	attrs: Record<string, unknown>,
+	resource: string | null,
+	id: number | string | null,
+): ResolvedBindingsState {
+	const [ state, setState ] = useState<ResolvedBindingsState>( {
+		values: {},
+		loading: false,
+		error: null,
+	} );
+
+	const lastSerializedRef = useRef<string | null>( null );
+
+	useEffect( () => {
+		if ( ! hasActiveBindings( bindings ) ) {
+			lastSerializedRef.current = null;
+			setState( { values: {}, loading: false, error: null } );
+			return;
+		}
+
+		if ( ! resource || id === null ) {
+			lastSerializedRef.current = null;
+			setState( { values: {}, loading: false, error: null } );
+			return;
+		}
+
+		// Hash the inputs so re-renders that don't change the binding
+		// payload don't re-fire the request.
+		const serialized = JSON.stringify( { bindings, attrs, resource, id } );
+
+		if ( serialized === lastSerializedRef.current ) {
+			return;
+		}
+
+		lastSerializedRef.current = serialized;
+
+		let cancelled = false;
+		const controller = new AbortController();
+
+		setState( ( prev ) => ( { values: prev.values, loading: true, error: null } ) );
+
+		const handle = setTimeout( () => {
+			resolveBindings(
+				{
+					attrs,
+					bindings: bindings ?? {},
+					context: { resource, id },
+				},
+				controller.signal,
+			)
+				.then( ( values ) => {
+					if ( ! cancelled ) {
+						setState( { values, loading: false, error: null } );
+					}
+				} )
+				.catch( ( error: Error ) => {
+					if ( ! cancelled && error.name !== 'AbortError' ) {
+						setState( { values: {}, loading: false, error } );
+					}
+				} );
+		}, DEBOUNCE_MS );
+
+		return () => {
+			cancelled = true;
+			controller.abort();
+			clearTimeout( handle );
+		};
+	// `bindings` and `attrs` arrive as new object refs on every parent
+	// render — Gutenberg rebuilds the attributes prop frequently, and
+	// the panel renders `current` as a fresh `{}` literal each time
+	// when no bindings exist. Listing the raw refs here causes the
+	// effect to fire on every render; the early-return path then calls
+	// `setState({values: {}, ...})` with a fresh object literal, which
+	// React sees as a state change and re-renders → infinite loop.
+	// Hashing the inputs into a single string deps entry sidesteps
+	// that: string equality is by value, so identical content produces
+	// identical deps and React skips the effect.
+	}, [ JSON.stringify( bindings ), JSON.stringify( attrs ), resource, id ] );
+
+	return state;
+}

--- a/resources/js/visual-editor/bindings/with-bindings-panel.tsx
+++ b/resources/js/visual-editor/bindings/with-bindings-panel.tsx
@@ -1,0 +1,232 @@
+/**
+ * `editor.BlockEdit` HOC — injects the {@link BindingsPanel} into every
+ * block's inspector (#504).
+ *
+ * The panel surfaces every scalar attribute the block declares (string,
+ * number, boolean) and gives the author a "link to data" toggle per
+ * attribute. The bindings map is persisted onto the block via
+ * `setAttributes( { bindings } )` so the server-side
+ * `BindingResolver` can read it at render time.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.1.0
+ */
+
+import { InspectorControls } from '@wordpress/block-editor';
+import { getBlockType } from '@wordpress/blocks';
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { addFilter } from '@wordpress/hooks';
+import type { ComponentType } from 'react';
+
+import { BindingsPanel, type BindableAttribute } from './BindingsPanel';
+import { setBindingsApiConfig } from './config';
+import type { BindingsMap } from './types';
+import { useResolvedBindings } from './use-resolved-bindings';
+
+const FILTER_HOOK      = 'editor.BlockEdit';
+const FILTER_NAMESPACE = 'artisanpack-ui/visual-editor/bindings-panel';
+
+const REGISTERED_KEY = Symbol.for(
+	'artisanpack-ui.visual-editor.bindings-panel.registered',
+);
+
+interface GlobalSentinelHost {
+	[ REGISTERED_KEY ]?: boolean;
+	__artisanpackBindingsResource?: string | null;
+	__artisanpackBindingsRecordId?: number | string | null;
+}
+
+interface BlockEditProps {
+	name: string;
+	attributes: Record<string, unknown> & {
+		bindings?: BindingsMap | null;
+	};
+	setAttributes: ( updates: Record<string, unknown> ) => void;
+	[ key: string ]: unknown;
+}
+
+const BINDABLE_TYPES = new Set( [
+	'string',
+	'number',
+	'integer',
+	'boolean',
+	// Object + array attributes are exposed too — blocks like
+	// `artisanpack/icon` store their primary value as an object
+	// (e.g. `iconRef: { set, name }`). The resolver substitutes whatever
+	// the source returns, and the source/picker is responsible for
+	// matching shape. The `allowIncompatible` flag is the escape hatch
+	// when the picker hides a candidate field on type-strictness alone.
+	'object',
+	'array',
+	// Gutenberg's rich-text type — the heading, paragraph, list-item,
+	// etc. blocks all store their primary content this way. The
+	// RichText component the inner edits use accepts a plain string
+	// (or RichTextValue), so binding to a string-shaped source works
+	// without any extra coercion.
+	'rich-text',
+] );
+
+interface BlockAttributeSchema {
+	type?: string | string[];
+	role?: string;
+	source?: string;
+	__experimentalRole?: string;
+}
+
+function isBindableSchema( schema: BlockAttributeSchema | undefined ): boolean {
+	if ( ! schema ) {
+		return false;
+	}
+
+	const type = Array.isArray( schema.type ) ? schema.type[ 0 ] : schema.type;
+
+	if ( ! type ) {
+		return false;
+	}
+
+	return BINDABLE_TYPES.has( type );
+}
+
+function collectBindableAttributes( blockName: string ): BindableAttribute[] {
+	const blockType = getBlockType( blockName );
+
+	if ( ! blockType || ! blockType.attributes ) {
+		return [];
+	}
+
+	const out: BindableAttribute[] = [];
+
+	for ( const [ name, schema ] of Object.entries( blockType.attributes ) ) {
+		const cast = schema as BlockAttributeSchema;
+
+		// Skip our own sidecar key. Source-typed attributes (e.g. the
+		// Heading block's `content`, extracted from rendered HTML via
+		// `source: 'html'`) are intentionally NOT skipped — they're the
+		// single most common bindable case, and the resolver overrides
+		// `attrs[name]` before the renderer reaches them so the source
+		// extraction never fires.
+		if ( name === 'bindings' ) {
+			continue;
+		}
+
+		if ( ! isBindableSchema( cast ) ) {
+			continue;
+		}
+
+		const type = Array.isArray( cast.type ) ? cast.type[ 0 ] : cast.type;
+
+		out.push( {
+			name,
+			label: name,
+			type: type ?? 'string',
+		} );
+	}
+
+	return out;
+}
+
+function getBindingsResource(): string | null {
+	const host = globalThis as unknown as GlobalSentinelHost;
+	return host.__artisanpackBindingsResource ?? null;
+}
+
+function getBindingsRecordId(): number | string | null {
+	const host = globalThis as unknown as GlobalSentinelHost;
+	return host.__artisanpackBindingsRecordId ?? null;
+}
+
+export function setBindingsResourceContext(
+	resource: string | null,
+	id: number | string | null = null,
+): void {
+	const host = globalThis as unknown as GlobalSentinelHost;
+	host.__artisanpackBindingsResource = resource;
+	host.__artisanpackBindingsRecordId = id;
+}
+
+export const withBindingsPanel = createHigherOrderComponent(
+	( BlockEdit: ComponentType<BlockEditProps> ) => {
+		function BindingsBlockEdit( props: BlockEditProps ): JSX.Element {
+			const attributes = collectBindableAttributes( props.name );
+			const resource   = getBindingsResource();
+			const recordId   = getBindingsRecordId();
+			const current: BindingsMap =
+				( props.attributes.bindings as BindingsMap | undefined ) ?? {};
+
+			// Live-resolve any active bindings against the editor's
+			// current parent record so the canvas reflects the bound
+			// values without waiting for a frontend render.
+			const { values: resolved } = useResolvedBindings(
+				current,
+				props.attributes,
+				resource,
+				recordId,
+			);
+
+			if ( attributes.length === 0 ) {
+				return <BlockEdit { ...props } />;
+			}
+
+			const onChange = ( next: BindingsMap ): void => {
+				props.setAttributes( {
+					bindings: Object.keys( next ).length === 0 ? undefined : next,
+				} );
+			};
+
+			// Overlay resolved values on top of the saved attrs so the
+			// inner edit component sees what the renderer would see.
+			// `setAttributes` still writes through unmodified — the
+			// SAVED attrs are the static fallback, only the EDIT-time
+			// view is overlaid.
+			const overlaid =
+				Object.keys( resolved ).length > 0
+					? { ...props.attributes, ...resolved }
+					: props.attributes;
+
+			return (
+				<>
+					<BlockEdit { ...props } attributes={ overlaid } />
+					<InspectorControls>
+						<BindingsPanel
+							attributes={ attributes }
+							bindings={ current }
+							resource={ resource }
+							onChange={ onChange }
+						/>
+					</InspectorControls>
+				</>
+			);
+		}
+
+		BindingsBlockEdit.displayName = 'BindingsBlockEdit';
+
+		return BindingsBlockEdit;
+	},
+	'withBindingsPanel',
+);
+
+export interface RegisterBindingsPanelOptions {
+	apiBase?: string;
+	resource?: string | null;
+}
+
+export function registerBindingsPanel(
+	options: RegisterBindingsPanelOptions = {}
+): void {
+	const host = globalThis as unknown as GlobalSentinelHost;
+
+	if ( options.apiBase ) {
+		setBindingsApiConfig( { apiBase: options.apiBase } );
+	}
+
+	if ( options.resource !== undefined ) {
+		setBindingsResourceContext( options.resource );
+	}
+
+	if ( host[ REGISTERED_KEY ] ) {
+		return;
+	}
+
+	addFilter( FILTER_HOOK, FILTER_NAMESPACE, withBindingsPanel );
+	host[ REGISTERED_KEY ] = true;
+}

--- a/resources/js/visual-editor/editor/editor-app.tsx
+++ b/resources/js/visual-editor/editor/editor-app.tsx
@@ -48,6 +48,12 @@ import { registerGradientBorders } from '../gradient-borders/register';
 import { registerStateStylesFilters } from '../states/with-state-styles';
 import { registerAnimationsAttribute } from '../animations/register-attribute';
 import { registerAnimationsPanel } from '../animations/with-animations-panel';
+import {
+    setBindingsApiConfig,
+    setBindingsResourceContext,
+} from '../bindings';
+import { registerBindingsAttribute } from '../bindings/register-attribute';
+import { registerBindingsPanel } from '../bindings/with-bindings-panel';
 import { StateInspectorSync } from '../states/StateInspectorSync';
 import { StateWriteInterceptor } from '../states/state-write-interceptor';
 import { ConvertToPatternControl } from './convert-to-pattern-control';
@@ -187,6 +193,12 @@ function registerOnce(): void {
     // first render.
     registerAnimationsAttribute();
     registerAnimationsPanel();
+    // #504 — register the bindings sidecar attribute on every block
+    // and inject the inspector panel. Runs at editor-bootstrap time so
+    // the `bindings` storage key is in every block's schema by the time
+    // `registerArtisanPackBlocks()` runs below.
+    registerBindingsAttribute();
+    registerBindingsPanel();
     // #490 — register the gradient-border feature filters BEFORE
     // blocks load so the supports-extension fires at registration
     // time (extending opted-in blocks' state/responsive routing lists
@@ -272,6 +284,13 @@ const EMPTY_HISTORY: HistoryState = { past: [], future: [] };
 
 export function EditorApp(props: EditorAppProps): JSX.Element {
     registerOnce();
+
+    // #504 — push the current editor's apiBase + resource + record id
+    // into the bindings module so the inspector panel resolves its
+    // API calls, its picker, and the live canvas overlay against the
+    // right parent record.
+    setBindingsApiConfig({ apiBase: props.apiBase });
+    setBindingsResourceContext(props.resource ?? null, props.id ?? null);
 
     return (
         <ToastProvider>

--- a/routes/api.php
+++ b/routes/api.php
@@ -20,6 +20,8 @@ declare( strict_types=1 );
 use ArtisanPackUI\VisualEditor\Http\Controllers\Adapters\CmsFramework\PageController;
 use ArtisanPackUI\VisualEditor\Http\Controllers\Adapters\CmsFramework\PostController;
 use ArtisanPackUI\VisualEditor\Http\Controllers\AttachmentController;
+use ArtisanPackUI\VisualEditor\Http\Controllers\BindingResolveController;
+use ArtisanPackUI\VisualEditor\Http\Controllers\BindingSourcesController;
 use ArtisanPackUI\VisualEditor\Http\Controllers\BlockPreviewController;
 use ArtisanPackUI\VisualEditor\Http\Controllers\EntitySearchController;
 use ArtisanPackUI\VisualEditor\Http\Controllers\Icon\IconSearchController;
@@ -52,6 +54,21 @@ Route::put( '{resource}/{id}/content', [ ResourceContentController::class, 'upda
 
 Route::post( 'blocks/preview', [ BlockPreviewController::class, 'preview' ] )
 	->name( 'visual-editor.api.blocks.preview' );
+
+// #504 — Bindings inspector: list registered sources + their field
+// catalogs so the editor can render the "link to data" picker.
+Route::get( 'bindings/sources', [ BindingSourcesController::class, 'index' ] )
+	->name( 'visual-editor.api.bindings.sources.index' );
+
+Route::get( 'bindings/sources/{source}/fields', [ BindingSourcesController::class, 'fields' ] )
+	->where( 'source', '[a-z][a-z0-9_]*' )
+	->name( 'visual-editor.api.bindings.sources.fields' );
+
+// #504 — Canvas live-preview: resolve a block's bindings into
+// structured values so the editor's `edit` component can overlay them
+// on top of the static attrs without waiting for a server render pass.
+Route::post( 'bindings/resolve', [ BindingResolveController::class, 'resolve' ] )
+	->name( 'visual-editor.api.bindings.resolve' );
 
 // G4c-2 — `core/query` block resolution. Wraps cms-framework's
 // `QueryRuntime` (or any host-bound `QueryResolverContract`

--- a/src/Http/Controllers/BindingResolveController.php
+++ b/src/Http/Controllers/BindingResolveController.php
@@ -1,0 +1,138 @@
+<?php
+
+/**
+ * BindingResolve controller.
+ *
+ * Stateless endpoint the editor calls per block when it needs the
+ * resolved value of an active binding (#504). The HOC overlays the
+ * resolved values on top of the block's static `attrs` so the canvas
+ * reflects the binding in real time instead of waiting for the
+ * frontend renderer to do the substitution.
+ *
+ * Why a separate endpoint and not `blocks/preview`?
+ * - Preview wants the rendered HTML (string). The canvas overlay wants
+ *   the structured value (object / array / scalar) so the block's
+ *   `edit` component can drive its own rendering off it.
+ * - Resolution is cheap (no block rendering, no view layer); making
+ *   the editor pay for a full preview round-trip per binding is wasteful.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.1.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Http\Controllers;
+
+use ArtisanPackUI\VisualEditor\Resources\ResourceResolver;
+use ArtisanPackUI\VisualEditor\Services\Bindings\BindingContext;
+use ArtisanPackUI\VisualEditor\Services\Bindings\BindingResolver;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use InvalidArgumentException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+class BindingResolveController extends Controller
+{
+	public function __construct(
+		protected BindingResolver $resolver,
+		protected ResourceResolver $resourceResolver
+	) {
+	}
+
+	/**
+	 * Resolve a batch of bindings against the request's context.
+	 *
+	 * Request body:
+	 * - `attrs`    array<string, mixed>  Block's static fallback values.
+	 * - `bindings` array<string, array>  Sidecar map (attr → binding).
+	 * - `context`  array  Resource + id + optional draft snapshot.
+	 *
+	 * Response:
+	 * - `values` array<string, mixed>  Resolved values, keyed by attribute.
+	 *   Only attributes that have a binding are present; the client
+	 *   merges them on top of its static attributes.
+	 *
+	 * @since 1.1.0
+	 */
+	public function resolve( Request $request ): JsonResponse
+	{
+		$attrs    = $request->input( 'attrs', [] );
+		$bindings = $request->input( 'bindings', [] );
+
+		if ( ! is_array( $attrs ) || ! is_array( $bindings ) ) {
+			return response()->json( [
+				'error'   => 'invalid_payload',
+				'message' => 'attrs and bindings must be arrays.',
+			], 422 );
+		}
+
+		if ( [] === $bindings ) {
+			return response()->json( [ 'values' => (object) [] ] );
+		}
+
+		$context = $this->buildContext( $request );
+
+		$tree = [ [
+			'name'     => 'editor/preview',
+			'attrs'    => $attrs,
+			'bindings' => $bindings,
+		] ];
+
+		$resolved = $this->resolver->resolve( $tree, $context );
+
+		$resolvedAttrs = is_array( $resolved[0]['attrs'] ?? null ) ? $resolved[0]['attrs'] : [];
+
+		// Only return values for keys that had a binding declared so
+		// the client doesn't accidentally overwrite an unbound attr.
+		$values = [];
+
+		foreach ( $bindings as $attribute => $_ ) {
+			if ( ! is_string( $attribute ) ) {
+				continue;
+			}
+
+			$values[ $attribute ] = $resolvedAttrs[ $attribute ] ?? ( $attrs[ $attribute ] ?? null );
+		}
+
+		return response()->json( [
+			'values' => empty( $values ) ? (object) [] : $values,
+		] );
+	}
+
+	/**
+	 * Resolve the parent model from the request's context payload.
+	 * Mirrors {@see BlockPreviewController::buildContext()} but inline
+	 * so we don't have to share the helper.
+	 *
+	 * @since 1.1.0
+	 */
+	protected function buildContext( Request $request ): BindingContext
+	{
+		$resource = $request->input( 'context.resource' );
+		$id       = $request->input( 'context.id' );
+		$draft    = $request->input( 'context.draft', [] );
+
+		$model = null;
+
+		if ( is_string( $resource ) && '' !== $resource && ( is_string( $id ) || is_int( $id ) ) ) {
+			try {
+				$resolved = $this->resourceResolver->resolve( $resource, $id );
+				$model    = $resolved instanceof Model ? $resolved : null;
+			} catch ( NotFoundHttpException | InvalidArgumentException $e ) {
+				$model = null;
+			}
+		}
+
+		return new BindingContext(
+			$model,
+			is_array( $draft ) ? $draft : [],
+		);
+	}
+}

--- a/src/Http/Controllers/BindingSourcesController.php
+++ b/src/Http/Controllers/BindingSourcesController.php
@@ -1,0 +1,111 @@
+<?php
+
+/**
+ * BindingSources controller.
+ *
+ * Powers the editor's "link to data" inspector (#504): lists the
+ * registered binding source drivers and, per source + resource, the
+ * fields the picker can offer. The editor consumes these to render the
+ * source dropdown, the field dropdown, and the empty-state hint.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.1.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Http\Controllers;
+
+use ArtisanPackUI\VisualEditor\Registries\BlockBindingSourceRegistry;
+use ArtisanPackUI\VisualEditor\Services\Bindings\BlockBindingSource;
+use Illuminate\Contracts\Config\Repository as ConfigRepository;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+
+class BindingSourcesController extends Controller
+{
+	public function __construct(
+		protected BlockBindingSourceRegistry $registry,
+		protected ConfigRepository $config
+	) {
+	}
+
+	/**
+	 * List every registered binding source.
+	 *
+	 * @since 1.1.0
+	 */
+	public function index(): JsonResponse
+	{
+		$sources = array_map(
+			static fn ( BlockBindingSource $source ): array => [
+				'name' => $source->name(),
+			],
+			array_values( $this->registry->all() )
+		);
+
+		return response()->json( [
+			'sources' => $sources,
+		] );
+	}
+
+	/**
+	 * Return the field catalog for one source against a resource slug.
+	 *
+	 * Query params:
+	 *  - `resource` (optional) — slug from
+	 *    `config('artisanpack.visual-editor.resources')`. Falls back to
+	 *    an empty catalog when omitted or unknown.
+	 *
+	 * @since 1.1.0
+	 */
+	public function fields( Request $request, string $source ): JsonResponse
+	{
+		$driver = $this->registry->get( $source );
+
+		if ( null === $driver ) {
+			return response()->json( [
+				'error'  => 'source_not_registered',
+				'source' => $source,
+			], 404 );
+		}
+
+		$resource   = (string) $request->query( 'resource', '' );
+		$modelClass = $this->resolveModelClass( $resource );
+
+		return response()->json( [
+			'source'   => $driver->name(),
+			'resource' => $resource,
+			'fields'   => $driver->availableFields( $resource, $modelClass ),
+		] );
+	}
+
+	/**
+	 * Resolve the model class registered for a resource slug, or null
+	 * when nothing matches. Reads the raw config rather than going
+	 * through `ResourceResolver` so unknown / invalid entries return
+	 * cleanly instead of throwing 404 — the picker treats "no model" as
+	 * "no discoverable fields," not as an error.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return class-string<\Illuminate\Database\Eloquent\Model>|null
+	 */
+	protected function resolveModelClass( string $resource ): ?string
+	{
+		if ( '' === $resource ) {
+			return null;
+		}
+
+		$resources = (array) $this->config->get( 'artisanpack.visual-editor.resources', [] );
+
+		$class = $resources[ $resource ] ?? null;
+
+		return is_string( $class ) && '' !== $class && class_exists( $class ) ? $class : null;
+	}
+}

--- a/src/Http/Controllers/BindingSourcesController.php
+++ b/src/Http/Controllers/BindingSourcesController.php
@@ -23,6 +23,7 @@ namespace ArtisanPackUI\VisualEditor\Http\Controllers;
 use ArtisanPackUI\VisualEditor\Registries\BlockBindingSourceRegistry;
 use ArtisanPackUI\VisualEditor\Services\Bindings\BlockBindingSource;
 use Illuminate\Contracts\Config\Repository as ConfigRepository;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
@@ -106,6 +107,16 @@ class BindingSourcesController extends Controller
 
 		$class = $resources[ $resource ] ?? null;
 
-		return is_string( $class ) && '' !== $class && class_exists( $class ) ? $class : null;
+		// Hard-gate non-Eloquent classes so a misconfigured resource
+		// entry can't leak through to source drivers expecting a
+		// `class-string<Model>`. The picker just returns an empty field
+		// catalog for that resource — surfacing a 500 here would break
+		// the inspector for every block.
+		return is_string( $class )
+			&& '' !== $class
+			&& class_exists( $class )
+			&& is_subclass_of( $class, Model::class )
+				? $class
+				: null;
 	}
 }

--- a/src/Http/Controllers/BlockPreviewController.php
+++ b/src/Http/Controllers/BlockPreviewController.php
@@ -23,17 +23,25 @@ namespace ArtisanPackUI\VisualEditor\Http\Controllers;
 use ArtisanPackUI\VisualEditor\Blocks\DynamicBlock;
 use ArtisanPackUI\VisualEditor\Http\Requests\BlockPreviewRequest;
 use ArtisanPackUI\VisualEditor\Registries\DynamicBlockRegistry;
+use ArtisanPackUI\VisualEditor\Resources\ResourceResolver;
+use ArtisanPackUI\VisualEditor\Services\Bindings\BindingContext;
+use ArtisanPackUI\VisualEditor\Services\Bindings\BindingResolver;
 use Illuminate\Contracts\View\View;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Routing\Controller;
 use InvalidArgumentException;
 use Stringable;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Throwable;
 
 class BlockPreviewController extends Controller
 {
-	public function __construct( protected DynamicBlockRegistry $registry )
-	{
+	public function __construct(
+		protected DynamicBlockRegistry $registry,
+		protected BindingResolver $bindingResolver,
+		protected ResourceResolver $resourceResolver
+	) {
 	}
 
 	/**
@@ -49,6 +57,9 @@ class BlockPreviewController extends Controller
 		/** @var array<string, mixed> $attributes */
 		$attributes = $request->validated( 'attributes' ) ?? [];
 
+		/** @var array<string, mixed> $bindings */
+		$bindings = $request->validated( 'bindings' ) ?? [];
+
 		$block = $this->registry->get( $name );
 
 		if ( null === $block ) {
@@ -56,6 +67,12 @@ class BlockPreviewController extends Controller
 				'error' => 'block_not_registered',
 				'name'  => $name,
 			], 404 );
+		}
+
+		if ( [] !== $bindings ) {
+			$context = $this->buildContext( $request );
+
+			[ $attributes, $bindings ] = $this->applyBindings( $attributes, $bindings, $context );
 		}
 
 		try {
@@ -118,6 +135,72 @@ class BlockPreviewController extends Controller
 
 		throw new InvalidArgumentException(
 			'Dynamic block render() must return a View, Stringable, or string.'
+		);
+	}
+
+	/**
+	 * Run the binding layer (#504) for a single block's attributes.
+	 *
+	 * Wraps the attributes in a one-block tree so the resolver runs its
+	 * usual walk + eager-load preparation, then unpacks the resolved
+	 * `attrs` back out. The shape matches what the renderer-side block
+	 * tree already uses.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param  array<string, mixed>  $attributes
+	 * @param  array<string, mixed>  $bindings
+	 *
+	 * @return array{0: array<string, mixed>, 1: array<string, mixed>}
+	 */
+	protected function applyBindings( array $attributes, array $bindings, BindingContext $context ): array
+	{
+		$resolved = $this->bindingResolver->resolve(
+			[ [
+				'attrs'    => $attributes,
+				'bindings' => $bindings,
+			] ],
+			$context
+		);
+
+		$first    = $resolved[0] ?? [];
+		$newAttrs = is_array( $first['attrs'] ?? null ) ? $first['attrs'] : $attributes;
+
+		return [ $newAttrs, $bindings ];
+	}
+
+	/**
+	 * Build the {@see BindingContext} for the preview request.
+	 *
+	 * Pulls the parent model out of the request's `context.resource` +
+	 * `context.id` pair (via the existing {@see ResourceResolver}) when
+	 * supplied; missing or unknown resources degrade silently to a
+	 * model-less context. The draft snapshot — `context.draft` — is
+	 * forwarded verbatim so the source drivers can prefer unsaved
+	 * editor edits over saved values.
+	 *
+	 * @since 1.1.0
+	 */
+	protected function buildContext( BlockPreviewRequest $request ): BindingContext
+	{
+		$resource = $request->validated( 'context.resource' );
+		$id       = $request->validated( 'context.id' );
+		$draft    = $request->validated( 'context.draft' ) ?? [];
+
+		$model = null;
+
+		if ( is_string( $resource ) && '' !== $resource && ( is_string( $id ) || is_int( $id ) ) ) {
+			try {
+				$resolved = $this->resourceResolver->resolve( $resource, $id );
+				$model    = $resolved instanceof Model ? $resolved : null;
+			} catch ( NotFoundHttpException | InvalidArgumentException $e ) {
+				$model = null;
+			}
+		}
+
+		return new BindingContext(
+			$model,
+			is_array( $draft ) ? $draft : [],
 		);
 	}
 }

--- a/src/Http/Requests/BlockPreviewRequest.php
+++ b/src/Http/Requests/BlockPreviewRequest.php
@@ -34,8 +34,13 @@ class BlockPreviewRequest extends FormRequest
 	public function rules(): array
 	{
 		return [
-			'name'       => [ 'required', 'string', 'regex:/^[a-z][a-z0-9-]*\/[a-z][a-z0-9-]*$/' ],
-			'attributes' => [ 'sometimes', 'array' ],
+			'name'             => [ 'required', 'string', 'regex:/^[a-z][a-z0-9-]*\/[a-z][a-z0-9-]*$/' ],
+			'attributes'       => [ 'sometimes', 'array' ],
+			'bindings'         => [ 'sometimes', 'array' ],
+			'context'          => [ 'sometimes', 'array' ],
+			'context.resource' => [ 'sometimes', 'string' ],
+			'context.id'       => [ 'sometimes' ],
+			'context.draft'    => [ 'sometimes', 'array' ],
 		];
 	}
 }

--- a/src/Registries/BlockBindingSourceRegistry.php
+++ b/src/Registries/BlockBindingSourceRegistry.php
@@ -1,0 +1,109 @@
+<?php
+
+/**
+ * Block binding source registry.
+ *
+ * In-memory store of {@see BlockBindingSource} drivers keyed by their
+ * declared name. Mirrors {@see DynamicBlockRegistry}: third-party
+ * packages register their drivers during a service provider's `boot()`
+ * pass and the resolver pulls them out at render time. Re-registering a
+ * driver under an existing name overwrites the previous binding so a
+ * host application can intentionally replace a built-in driver.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.1.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Registries;
+
+use ArtisanPackUI\VisualEditor\Services\Bindings\BlockBindingSource;
+use InvalidArgumentException;
+
+class BlockBindingSourceRegistry
+{
+	/**
+	 * Canonical source name pattern: lowercase snake_case slug.
+	 *
+	 * Anchored to keep names friendly to JSON storage, JavaScript object
+	 * keys, and the editor's inspector picker. Pattern intentionally
+	 * disallows the `/` namespace separator used by block names so a
+	 * source name can never collide with a block name in mixed contexts.
+	 */
+	public const NAME_PATTERN = '/^[a-z][a-z0-9_]*$/';
+
+	/**
+	 * @var array<string, BlockBindingSource>
+	 */
+	protected array $sources = [];
+
+	/**
+	 * Register a binding source under its declared name.
+	 *
+	 * @since 1.1.0
+	 */
+	public function register( BlockBindingSource $source ): void
+	{
+		$name = trim( $source->name() );
+
+		if ( '' === $name ) {
+			throw new InvalidArgumentException( 'Block binding source name cannot be empty.' );
+		}
+
+		if ( 1 !== preg_match( self::NAME_PATTERN, $name ) ) {
+			throw new InvalidArgumentException( sprintf(
+				'Block binding source name "%s" is invalid. Expected lowercase snake_case (letters, digits, underscores).',
+				$name
+			) );
+		}
+
+		$this->sources[ $name ] = $source;
+	}
+
+	/**
+	 * Resolve a source by name. Returns null when nothing is registered.
+	 *
+	 * @since 1.1.0
+	 */
+	public function get( string $name ): ?BlockBindingSource
+	{
+		return $this->sources[ trim( $name ) ] ?? null;
+	}
+
+	/**
+	 * True when a source is registered under the given name.
+	 *
+	 * @since 1.1.0
+	 */
+	public function has( string $name ): bool
+	{
+		return isset( $this->sources[ trim( $name ) ] );
+	}
+
+	/**
+	 * Remove a registration. No-op when nothing is registered.
+	 *
+	 * @since 1.1.0
+	 */
+	public function unregister( string $name ): void
+	{
+		unset( $this->sources[ trim( $name ) ] );
+	}
+
+	/**
+	 * Return every registered source, keyed by name.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return array<string, BlockBindingSource>
+	 */
+	public function all(): array
+	{
+		return $this->sources;
+	}
+}

--- a/src/Services/Bindings/BindingContext.php
+++ b/src/Services/Bindings/BindingContext.php
@@ -80,6 +80,22 @@ class BindingContext
 	}
 
 	/**
+	 * True when the draft snapshot carries an override for the given key,
+	 * regardless of the override's value (null and empty-string included).
+	 *
+	 * Source drivers consult this to distinguish "the user didn't touch
+	 * this field in the editor" (no draft entry — fall through to the
+	 * saved column) from "the user explicitly cleared this field"
+	 * (entry present, value null/empty — empty-value policy fires).
+	 *
+	 * @since 1.1.0
+	 */
+	public function hasDraftValue( string $key ): bool
+	{
+		return array_key_exists( $key, $this->draft );
+	}
+
+	/**
 	 * The free-form extras bag for custom source drivers.
 	 *
 	 * @since 1.1.0

--- a/src/Services/Bindings/BindingContext.php
+++ b/src/Services/Bindings/BindingContext.php
@@ -1,0 +1,127 @@
+<?php
+
+/**
+ * Context carried through one render pass of the binding resolver.
+ *
+ * Bundles the parent model the bindings should resolve against, optional
+ * draft attribute overrides from the editor (so unsaved custom-field
+ * edits are reflected in the preview), and a free-form `extras` bag for
+ * third-party source drivers that need their own scoped data. The
+ * resolver constructs a context per request:
+ *
+ * - Editor preview: parent model loaded fresh, draft snapshot applied.
+ * - Frontend render: queried/host model passed through, no draft.
+ *
+ * The object is intentionally immutable — every mutator returns a new
+ * instance so a shared resolver pass can safely fork the context for
+ * inner blocks without leaking state.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.1.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Services\Bindings;
+
+use Illuminate\Database\Eloquent\Model;
+
+class BindingContext
+{
+	/**
+	 * @param  Model|null            $model   Parent record bindings resolve against. Null
+	 *                                        means "no context" — every binding falls back.
+	 * @param  array<string, mixed>  $draft   Per-attribute overrides (column → value) the editor
+	 *                                        applies for unsaved field edits.
+	 * @param  array<string, mixed>  $extras  Free-form bag for custom drivers (e.g. site-settings,
+	 *                                        feature-flag identity).
+	 */
+	public function __construct(
+		protected ?Model $model = null,
+		protected array $draft = [],
+		protected array $extras = []
+	) {
+	}
+
+	/**
+	 * The parent model bindings resolve against. Null when no model is in scope.
+	 *
+	 * @since 1.1.0
+	 */
+	public function model(): ?Model
+	{
+		return $this->model;
+	}
+
+	/**
+	 * The draft snapshot — column → value overrides applied by editor previews.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function draft(): array
+	{
+		return $this->draft;
+	}
+
+	/**
+	 * Read a single draft column, or null when no override exists for it.
+	 *
+	 * @since 1.1.0
+	 */
+	public function draftValue( string $key ): mixed
+	{
+		return $this->draft[ $key ] ?? null;
+	}
+
+	/**
+	 * The free-form extras bag for custom source drivers.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function extras(): array
+	{
+		return $this->extras;
+	}
+
+	/**
+	 * Return a clone of this context with the given model.
+	 *
+	 * @since 1.1.0
+	 */
+	public function withModel( ?Model $model ): self
+	{
+		return new self( $model, $this->draft, $this->extras );
+	}
+
+	/**
+	 * Return a clone of this context with the given draft snapshot.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param  array<string, mixed>  $draft
+	 */
+	public function withDraft( array $draft ): self
+	{
+		return new self( $this->model, $draft, $this->extras );
+	}
+
+	/**
+	 * Return a clone of this context with the given extras bag.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param  array<string, mixed>  $extras
+	 */
+	public function withExtras( array $extras ): self
+	{
+		return new self( $this->model, $this->draft, $extras );
+	}
+}

--- a/src/Services/Bindings/BindingException.php
+++ b/src/Services/Bindings/BindingException.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * Soft-failure marker thrown into Laravel's `report()` channel when a
+ * block binding cannot be resolved — e.g. the source driver is not
+ * registered or the bound field is missing.
+ *
+ * The resolver never lets a binding break the surrounding render; this
+ * exception exists so the failure is observable in error tracking
+ * without being raised as an HTTP-visible error.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.1.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Services\Bindings;
+
+use RuntimeException;
+
+class BindingException extends RuntimeException
+{
+}

--- a/src/Services/Bindings/BindingResolver.php
+++ b/src/Services/Bindings/BindingResolver.php
@@ -259,7 +259,17 @@ class BindingResolver
 				continue;
 			}
 
-			foreach ( $source->eagerLoadRelations( $argsList ) as $relation ) {
+			try {
+				$declaredRelations = $source->eagerLoadRelations( $argsList );
+			} catch ( Throwable $e ) {
+				// A misbehaving source driver must not break the wider
+				// render pass — report the failure and treat it as if
+				// the driver declared no eager loads.
+				report( $e );
+				continue;
+			}
+
+			foreach ( $declaredRelations as $relation ) {
 				if ( is_string( $relation ) && '' !== $relation ) {
 					$relations[ $relation ] = true;
 				}
@@ -276,7 +286,14 @@ class BindingResolver
 		);
 
 		if ( [] !== $missing ) {
-			$model->loadMissing( $missing );
+			try {
+				$model->loadMissing( $missing );
+			} catch ( Throwable $e ) {
+				// DB errors / missing relations / etc. — bindings on
+				// dotted paths will degrade to fallback at resolve
+				// time. Don't take the whole render down.
+				report( $e );
+			}
 		}
 	}
 

--- a/src/Services/Bindings/BindingResolver.php
+++ b/src/Services/Bindings/BindingResolver.php
@@ -1,0 +1,337 @@
+<?php
+
+/**
+ * Resolves block bindings against a {@see BindingContext} and rewrites
+ * a block tree's `attrs` so the downstream renderer never sees the
+ * binding layer.
+ *
+ * Walks the tree once per render pass, batches eager-load hints from
+ * every registered source driver, then iterates each block's `bindings`
+ * map and applies the resolved value (or the empty-value policy) on
+ * top of the static `attrs`. Trees without bindings round-trip
+ * byte-identically — the resolver is a strict pass-through when no
+ * `bindings` keys are present.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.1.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Services\Bindings;
+
+use ArtisanPackUI\VisualEditor\Registries\BlockBindingSourceRegistry;
+use Illuminate\Database\Eloquent\Model;
+use Throwable;
+
+class BindingResolver
+{
+	public const POLICY_FALLBACK    = 'fallback';
+	public const POLICY_HIDE        = 'hide';
+	public const POLICY_PLACEHOLDER = 'placeholder';
+
+	/**
+	 * Allowed `onEmpty` policy values. Anything else is treated as `fallback`.
+	 *
+	 * @var array<int, string>
+	 */
+	protected const POLICIES = [
+		self::POLICY_FALLBACK,
+		self::POLICY_HIDE,
+		self::POLICY_PLACEHOLDER,
+	];
+
+	public function __construct( protected BlockBindingSourceRegistry $registry )
+	{
+	}
+
+	/**
+	 * Resolve every binding in the given block tree against the supplied
+	 * context. Returns a new tree — the input is left untouched.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param  array<int, array<string, mixed>>  $blocks
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	public function resolve( array $blocks, ?BindingContext $context = null ): array
+	{
+		if ( [] === $blocks ) {
+			return $blocks;
+		}
+
+		$context ??= new BindingContext();
+
+		$this->prepareEagerLoads( $blocks, $context );
+
+		return array_values( array_map(
+			fn ( $block ) => $this->resolveBlock( $block, $context ),
+			$blocks
+		) );
+	}
+
+	/**
+	 * Walk a single block (and its inner blocks) applying every binding.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param  array<string, mixed>  $block
+	 *
+	 * @return array<string, mixed>
+	 */
+	protected function resolveBlock( array $block, BindingContext $context ): array
+	{
+		$bindings = $block['bindings'] ?? null;
+		$attrs    = is_array( $block['attrs'] ?? null ) ? $block['attrs'] : [];
+
+		if ( is_array( $bindings ) && [] !== $bindings ) {
+			foreach ( $bindings as $attribute => $binding ) {
+				if ( ! is_string( $attribute ) || ! is_array( $binding ) ) {
+					continue;
+				}
+
+				$attrs = $this->applyBinding( $attribute, $binding, $attrs, $context );
+			}
+
+			$block['attrs'] = $attrs;
+		}
+
+		if ( isset( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) && [] !== $block['innerBlocks'] ) {
+			$block['innerBlocks'] = array_values( array_map(
+				fn ( $inner ) => is_array( $inner ) ? $this->resolveBlock( $inner, $context ) : $inner,
+				$block['innerBlocks']
+			) );
+		}
+
+		return $block;
+	}
+
+	/**
+	 * Resolve a single attribute binding and merge the result into `$attrs`.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param  array<string, mixed>  $binding
+	 * @param  array<string, mixed>  $attrs
+	 *
+	 * @return array<string, mixed>
+	 */
+	protected function applyBinding( string $attribute, array $binding, array $attrs, BindingContext $context ): array
+	{
+		$sourceName = is_string( $binding['source'] ?? null ) ? $binding['source'] : '';
+		$args       = is_array( $binding['args'] ?? null ) ? $binding['args'] : [];
+		$policy     = $this->normalizePolicy( $binding['onEmpty'] ?? null );
+
+		$source = '' === $sourceName ? null : $this->registry->get( $sourceName );
+
+		if ( null === $source ) {
+			// Unknown driver — log once per resolve pass via report(), then
+			// fall back so a missing third-party package never breaks a
+			// render.
+			$this->logUnknownSource( $sourceName );
+
+			return $this->applyEmpty( $attribute, $attrs, $policy, $binding );
+		}
+
+		try {
+			$value = $source->resolve( $context, $args );
+		} catch ( Throwable $e ) {
+			report( $e );
+
+			return $this->applyEmpty( $attribute, $attrs, $policy, $binding );
+		}
+
+		if ( $this->isEmpty( $value ) ) {
+			return $this->applyEmpty( $attribute, $attrs, $policy, $binding );
+		}
+
+		$attrs[ $attribute ] = $value;
+
+		return $attrs;
+	}
+
+	/**
+	 * Apply the empty-value policy when a binding resolves to nothing.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param  array<string, mixed>  $attrs
+	 * @param  array<string, mixed>  $binding
+	 *
+	 * @return array<string, mixed>
+	 */
+	protected function applyEmpty( string $attribute, array $attrs, string $policy, array $binding ): array
+	{
+		if ( self::POLICY_FALLBACK === $policy ) {
+			return $attrs;
+		}
+
+		if ( self::POLICY_HIDE === $policy ) {
+			$attrs[ $attribute ] = null;
+
+			return $attrs;
+		}
+
+		// POLICY_PLACEHOLDER
+		$placeholder         = $binding['placeholder'] ?? '';
+		$attrs[ $attribute ] = is_scalar( $placeholder ) ? (string) $placeholder : '';
+
+		return $attrs;
+	}
+
+	/**
+	 * Normalize a user-supplied `onEmpty` value to a known policy constant.
+	 *
+	 * @since 1.1.0
+	 */
+	protected function normalizePolicy( mixed $policy ): string
+	{
+		if ( is_string( $policy ) && in_array( $policy, self::POLICIES, true ) ) {
+			return $policy;
+		}
+
+		return self::POLICY_FALLBACK;
+	}
+
+	/**
+	 * Test whether a resolved value should trigger the empty-value policy.
+	 *
+	 * Empty rules:
+	 * - `null` is always empty.
+	 * - An empty string is empty.
+	 * - An empty array is empty.
+	 * - `0`, `0.0`, and `false` are NOT empty — they're legitimate values.
+	 *
+	 * @since 1.1.0
+	 */
+	protected function isEmpty( mixed $value ): bool
+	{
+		if ( null === $value ) {
+			return true;
+		}
+
+		if ( is_string( $value ) && '' === $value ) {
+			return true;
+		}
+
+		if ( is_array( $value ) && [] === $value ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Pre-eager-load every relation declared by every source driver across
+	 * the entire block tree. Runs once per resolve pass so the parent model
+	 * is hydrated with all relations before any binding is resolved.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param  array<int, array<string, mixed>>  $blocks
+	 */
+	protected function prepareEagerLoads( array $blocks, BindingContext $context ): void
+	{
+		$model = $context->model();
+
+		if ( ! $model instanceof Model ) {
+			return;
+		}
+
+		$bindingArgsBySource = [];
+		$this->collectBindings( $blocks, $bindingArgsBySource );
+
+		if ( [] === $bindingArgsBySource ) {
+			return;
+		}
+
+		$relations = [];
+
+		foreach ( $bindingArgsBySource as $sourceName => $argsList ) {
+			$source = $this->registry->get( $sourceName );
+
+			if ( null === $source ) {
+				continue;
+			}
+
+			foreach ( $source->eagerLoadRelations( $argsList ) as $relation ) {
+				if ( is_string( $relation ) && '' !== $relation ) {
+					$relations[ $relation ] = true;
+				}
+			}
+		}
+
+		if ( [] === $relations ) {
+			return;
+		}
+
+		$missing = array_filter(
+			array_keys( $relations ),
+			static fn ( string $relation ): bool => ! $model->relationLoaded( $relation )
+		);
+
+		if ( [] !== $missing ) {
+			$model->loadMissing( $missing );
+		}
+	}
+
+	/**
+	 * Walk the tree collecting every binding's args, grouped by source name.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param  array<int, array<string, mixed>>     $blocks
+	 * @param  array<string, array<int, array<string, mixed>>>  $collected
+	 */
+	protected function collectBindings( array $blocks, array &$collected ): void
+	{
+		foreach ( $blocks as $block ) {
+			if ( ! is_array( $block ) ) {
+				continue;
+			}
+
+			$bindings = $block['bindings'] ?? null;
+
+			if ( is_array( $bindings ) ) {
+				foreach ( $bindings as $binding ) {
+					if ( ! is_array( $binding ) ) {
+						continue;
+					}
+
+					$sourceName = is_string( $binding['source'] ?? null ) ? $binding['source'] : '';
+
+					if ( '' === $sourceName ) {
+						continue;
+					}
+
+					$args                       = is_array( $binding['args'] ?? null ) ? $binding['args'] : [];
+					$collected[ $sourceName ][] = $args;
+				}
+			}
+
+			if ( isset( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ) {
+				$this->collectBindings( $block['innerBlocks'], $collected );
+			}
+		}
+	}
+
+	/**
+	 * Report an unknown source driver via Laravel's `report()` helper so
+	 * the render keeps going. Inspector UIs surface the warning separately
+	 * during authoring.
+	 *
+	 * @since 1.1.0
+	 */
+	protected function logUnknownSource( string $sourceName ): void
+	{
+		report( new BindingException( sprintf(
+			'Block binding source "%s" is not registered. Falling back.',
+			'' === $sourceName ? '(empty)' : $sourceName
+		) ) );
+	}
+}

--- a/src/Services/Bindings/BlockBindingSource.php
+++ b/src/Services/Bindings/BlockBindingSource.php
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * Contract for a block binding source driver.
+ *
+ * A binding source plugs into the visual-editor's binding layer (#504) and
+ * supplies values for bound block attributes at render time. Built-in
+ * drivers cover the cms-framework custom fields, post core columns, and
+ * dotted-path relation lookups; third-party packages can register their
+ * own sources (site settings, an external API, a feature-flag service)
+ * via {@see \ArtisanPackUI\VisualEditor\Registries\BlockBindingSourceRegistry}.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.1.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Services\Bindings;
+
+interface BlockBindingSource
+{
+	/**
+	 * Unique identifier used in the block's `bindings` map (`source` key).
+	 *
+	 * Must be a lowercase snake_case slug — e.g. `custom_field`, `post_core`,
+	 * `relation`. The registry rejects empty names and prevents collisions.
+	 *
+	 * @since 1.1.0
+	 */
+	public function name(): string;
+
+	/**
+	 * Resolve a single binding to its value.
+	 *
+	 * Implementations should return the raw value associated with the
+	 * binding's arguments — the resolver applies the empty-value policy
+	 * and any coercion afterwards. Return `null` when the bound field is
+	 * empty / missing so the resolver can run the `onEmpty` policy.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param  array<string, mixed>  $args  The binding's `args` map.
+	 */
+	public function resolve( BindingContext $context, array $args ): mixed;
+
+	/**
+	 * Optional eager-load hints for the parent model.
+	 *
+	 * Called once per render pass with every binding's args that targets
+	 * this source. Drivers that read related models (e.g. RelationSource
+	 * walking `author.profile.name`) should return the dotted relation
+	 * paths the resolver should preload to avoid N+1 queries. Drivers
+	 * that read columns on the parent row return an empty array.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param  array<int, array<string, mixed>>  $bindingArgs  Every binding's `args` targeting this source.
+	 *
+	 * @return array<int, string>
+	 */
+	public function eagerLoadRelations( array $bindingArgs ): array;
+
+	/**
+	 * Catalog of fields the inspector picker can offer for a given resource.
+	 *
+	 * The editor's "link to data" toggle calls this through the
+	 * `BindingSourcesController` to populate the source's field dropdown.
+	 * Drivers that resolve free-form paths (e.g. RelationSource) can return
+	 * an empty array — the inspector falls back to a text input.
+	 *
+	 * Each entry must be a map of shape:
+	 *  - `key`   string  — value persisted into `args.key` (or `args.path`)
+	 *  - `label` string  — human-readable label for the picker
+	 *  - `type`  string  — one of `string|number|boolean|url|image|date|datetime|html`
+	 *
+	 * The `$resource` argument is the resource slug (e.g. `posts`,
+	 * `pages`) from `config('artisanpack.visual-editor.resources')`. The
+	 * `$modelClass` argument is the resolved Eloquent class, so drivers
+	 * that introspect (e.g. CustomFieldSource scanning cms-framework
+	 * columns) can build their catalog from the schema rather than the
+	 * slug alone.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param  class-string<\Illuminate\Database\Eloquent\Model>|null  $modelClass
+	 *
+	 * @return array<int, array{ key: string, label: string, type: string }>
+	 */
+	public function availableFields( string $resource, ?string $modelClass = null ): array;
+}

--- a/src/Services/Bindings/Sources/CustomFieldSource.php
+++ b/src/Services/Bindings/Sources/CustomFieldSource.php
@@ -42,10 +42,14 @@ class CustomFieldSource implements BlockBindingSource
 			return null;
 		}
 
-		$draft = $context->draftValue( $key );
-
-		if ( null !== $draft && '' !== $draft ) {
-			return $draft;
+		// Draft presence wins over the saved column: when the editor
+		// hands us a draft entry — even null / empty-string — that's
+		// the unsaved edit the inspector preview should reflect. The
+		// empty-value policy in the resolver runs on the result, so a
+		// user clearing the field gracefully degrades to fallback /
+		// hide / placeholder.
+		if ( $context->hasDraftValue( $key ) ) {
+			return $context->draftValue( $key );
 		}
 
 		$model = $context->model();

--- a/src/Services/Bindings/Sources/CustomFieldSource.php
+++ b/src/Services/Bindings/Sources/CustomFieldSource.php
@@ -1,0 +1,143 @@
+<?php
+
+/**
+ * Binding source that reads a cms-framework custom field off the parent
+ * model.
+ *
+ * cms-framework stores custom-field values as ordinary columns on the
+ * content-type's table (the field's `key` is the column name), so the
+ * resolution is a straight attribute lookup. The class intentionally
+ * does not import cms-framework — it just reads attributes through the
+ * model — so the visual-editor's standalone install keeps working when
+ * cms-framework is not present.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.1.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Services\Bindings\Sources;
+
+use ArtisanPackUI\VisualEditor\Services\Bindings\BindingContext;
+use ArtisanPackUI\VisualEditor\Services\Bindings\BlockBindingSource;
+use Illuminate\Database\Eloquent\Model;
+
+class CustomFieldSource implements BlockBindingSource
+{
+	public function name(): string
+	{
+		return 'custom_field';
+	}
+
+	public function resolve( BindingContext $context, array $args ): mixed
+	{
+		$key = is_string( $args['key'] ?? null ) ? $args['key'] : '';
+
+		if ( '' === $key ) {
+			return null;
+		}
+
+		$draft = $context->draftValue( $key );
+
+		if ( null !== $draft && '' !== $draft ) {
+			return $draft;
+		}
+
+		$model = $context->model();
+
+		if ( ! $model instanceof Model ) {
+			return null;
+		}
+
+		return $model->getAttribute( $key );
+	}
+
+	public function eagerLoadRelations( array $bindingArgs ): array
+	{
+		return [];
+	}
+
+	public function availableFields( string $resource, ?string $modelClass = null ): array
+	{
+		if ( null === $modelClass || ! class_exists( $modelClass ) ) {
+			return [];
+		}
+
+		$cmsField = '\\ArtisanPackUI\\CMSFramework\\Modules\\ContentTypes\\Models\\CustomField';
+
+		if ( ! class_exists( $cmsField ) ) {
+			return [];
+		}
+
+		// Use the model's table name as the cms-framework "content type"
+		// — that mirrors the convention `HasCustomFields::getCustomFieldsForType()`
+		// uses internally so the picker shows whatever cms-framework will
+		// actually resolve at render time.
+		try {
+			/** @var Model $instance */
+			$instance = new $modelClass();
+
+			if ( ! method_exists( $instance, 'getTable' ) ) {
+				return [];
+			}
+
+			$table = $instance->getTable();
+		} catch ( \Throwable $e ) {
+			return [];
+		}
+
+		$rows = $cmsField::query()
+			->orderBy( 'order' )
+			->orderBy( 'id' )
+			->get();
+
+		$fields = [];
+
+		foreach ( $rows as $row ) {
+			$contentTypes = $row->getAttribute( 'content_types' );
+
+			if ( ! is_array( $contentTypes ) || ! in_array( $table, $contentTypes, true ) ) {
+				continue;
+			}
+
+			$key = (string) $row->getAttribute( 'key' );
+
+			if ( '' === $key ) {
+				continue;
+			}
+
+			$fields[] = [
+				'key'   => $key,
+				'label' => (string) ( $row->getAttribute( 'name' ) ?: $key ),
+				'type'  => $this->mapFieldType( $row->getAttribute( 'type' ) ),
+			];
+		}
+
+		return $fields;
+	}
+
+	/**
+	 * Map a cms-framework FieldType enum to the binding-layer type label.
+	 *
+	 * @since 1.1.0
+	 */
+	protected function mapFieldType( mixed $fieldType ): string
+	{
+		$value = $fieldType instanceof \BackedEnum ? $fieldType->value : (string) $fieldType;
+
+		return match ( $value ) {
+			'number'             => 'number',
+			'boolean', 'checkbox' => 'boolean',
+			'date'               => 'date',
+			'datetime'           => 'datetime',
+			'url'                => 'url',
+			'image', 'file'      => 'image',
+			default              => 'string',
+		};
+	}
+}

--- a/src/Services/Bindings/Sources/PostCoreSource.php
+++ b/src/Services/Bindings/Sources/PostCoreSource.php
@@ -1,0 +1,163 @@
+<?php
+
+/**
+ * Binding source that reads a core column or accessor off the parent model.
+ *
+ * Targets the conventional "post" surface — title, excerpt, slug, status,
+ * created_at / updated_at, plus author shortcuts. The set of recognized
+ * keys is intentionally narrow so the inspector picker exposes a stable
+ * list across content types; arbitrary column lookups belong in
+ * {@see RelationSource}.
+ *
+ * Each key is resolved via the model's attribute accessor (so casts and
+ * mutators apply), with one fallback for `author.name` so a host that
+ * stores the author behind a `user` relation does not have to register a
+ * custom driver to surface the byline.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.1.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Services\Bindings\Sources;
+
+use ArtisanPackUI\VisualEditor\Services\Bindings\BindingContext;
+use ArtisanPackUI\VisualEditor\Services\Bindings\BlockBindingSource;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class PostCoreSource implements BlockBindingSource
+{
+	/**
+	 * Whitelist of keys this source resolves, paired with the inspector
+	 * picker's labels and types. Hosts that need additional columns can
+	 * register their own source — keeping the whitelist tight prevents
+	 * the inspector from advertising fields that may not exist on every
+	 * model.
+	 *
+	 * @var array<int, array{ key: string, label: string, type: string }>
+	 */
+	public const SUPPORTED_FIELDS = [
+		[ 'key' => 'title',          'label' => 'Title',          'type' => 'string' ],
+		[ 'key' => 'excerpt',        'label' => 'Excerpt',        'type' => 'string' ],
+		[ 'key' => 'slug',           'label' => 'Slug',           'type' => 'string' ],
+		[ 'key' => 'status',         'label' => 'Status',         'type' => 'string' ],
+		[ 'key' => 'created_at',     'label' => 'Created at',     'type' => 'datetime' ],
+		[ 'key' => 'updated_at',     'label' => 'Updated at',     'type' => 'datetime' ],
+		[ 'key' => 'published_at',   'label' => 'Published at',   'type' => 'datetime' ],
+		[ 'key' => 'featured_image', 'label' => 'Featured image', 'type' => 'image' ],
+		[ 'key' => 'author_name',    'label' => 'Author name',    'type' => 'string' ],
+	];
+
+	public function name(): string
+	{
+		return 'post_core';
+	}
+
+	public function resolve( BindingContext $context, array $args ): mixed
+	{
+		$key = is_string( $args['key'] ?? null ) ? $args['key'] : '';
+
+		if ( '' === $key ) {
+			return null;
+		}
+
+		// Guard against arbitrary column reads: keep this source's
+		// surface area aligned with the inspector picker's catalog so
+		// a binding that bypasses the UI cannot exfiltrate, say, a
+		// password hash or a soft-delete timestamp.
+		if ( ! $this->isSupported( $key ) ) {
+			return null;
+		}
+
+		$draft = $context->draftValue( $key );
+
+		if ( null !== $draft && '' !== $draft ) {
+			return $draft;
+		}
+
+		$model = $context->model();
+
+		if ( ! $model instanceof Model ) {
+			return null;
+		}
+
+		if ( 'author_name' === $key ) {
+			return $this->resolveAuthorName( $model );
+		}
+
+		// Defer to the model's accessor so casts and mutators apply.
+		$value = $model->getAttribute( $key );
+
+		return $value;
+	}
+
+	public function eagerLoadRelations( array $bindingArgs ): array
+	{
+		foreach ( $bindingArgs as $args ) {
+			$key = $args['key'] ?? null;
+
+			if ( 'author_name' === $key ) {
+				return [ 'author' ];
+			}
+		}
+
+		return [];
+	}
+
+	public function availableFields( string $resource, ?string $modelClass = null ): array
+	{
+		return self::SUPPORTED_FIELDS;
+	}
+
+	/**
+	 * True when `$key` is one of the source's declared `SUPPORTED_FIELDS`.
+	 *
+	 * @since 1.1.0
+	 */
+	protected function isSupported( string $key ): bool
+	{
+		foreach ( self::SUPPORTED_FIELDS as $field ) {
+			if ( ( $field['key'] ?? null ) === $key ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Resolve the author's display name with a small set of fallbacks so
+	 * the binding works against either a dedicated author relation or a
+	 * direct `author_name` column.
+	 *
+	 * @since 1.1.0
+	 */
+	protected function resolveAuthorName( Model $model ): mixed
+	{
+		$direct = $model->getAttribute( 'author_name' );
+
+		if ( null !== $direct && '' !== $direct ) {
+			return $direct;
+		}
+
+		if ( method_exists( $model, 'author' ) && $model->author() instanceof BelongsTo ) {
+			$author = $model->getAttribute( 'author' );
+
+			if ( $author instanceof Model ) {
+				$name = $author->getAttribute( 'name' );
+
+				if ( null !== $name && '' !== $name ) {
+					return $name;
+				}
+			}
+		}
+
+		return null;
+	}
+}

--- a/src/Services/Bindings/Sources/PostCoreSource.php
+++ b/src/Services/Bindings/Sources/PostCoreSource.php
@@ -75,10 +75,12 @@ class PostCoreSource implements BlockBindingSource
 			return null;
 		}
 
-		$draft = $context->draftValue( $key );
-
-		if ( null !== $draft && '' !== $draft ) {
-			return $draft;
+		// Draft presence wins over the saved column: when the editor
+		// hands us a draft entry — even null / empty-string — that's
+		// the unsaved edit the inspector preview should reflect. The
+		// empty-value policy in the resolver runs on the result.
+		if ( $context->hasDraftValue( $key ) ) {
+			return $context->draftValue( $key );
 		}
 
 		$model = $context->model();

--- a/src/Services/Bindings/Sources/RelationSource.php
+++ b/src/Services/Bindings/Sources/RelationSource.php
@@ -1,0 +1,161 @@
+<?php
+
+/**
+ * Binding source that walks a dotted-path off the parent model and
+ * returns the value at the end of the chain.
+ *
+ * Accepts `args.path` (e.g. `author.profile.display_name`,
+ * `categories.0.name`). Each non-leaf segment must resolve to either
+ * another Eloquent model, a Collection / Arrayable, or an array — the
+ * source bails to `null` (which becomes "empty" for the policy layer)
+ * the moment a segment dead-ends.
+ *
+ * Relations encountered along the path are also returned from
+ * {@see self::eagerLoadRelations()} so the resolver can preload the
+ * full chain on the parent model with a single `loadMissing()` call,
+ * keeping N+1 risk down to "one query per distinct relation chain in
+ * the tree."
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.1.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Services\Bindings\Sources;
+
+use ArtisanPackUI\VisualEditor\Services\Bindings\BindingContext;
+use ArtisanPackUI\VisualEditor\Services\Bindings\BlockBindingSource;
+use ArrayAccess;
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
+
+class RelationSource implements BlockBindingSource
+{
+	public function name(): string
+	{
+		return 'relation';
+	}
+
+	public function resolve( BindingContext $context, array $args ): mixed
+	{
+		$path = is_string( $args['path'] ?? null ) ? trim( $args['path'] ) : '';
+
+		if ( '' === $path ) {
+			return null;
+		}
+
+		$model = $context->model();
+
+		if ( ! $model instanceof Model ) {
+			return null;
+		}
+
+		$segments = explode( '.', $path );
+		$current  = $model;
+
+		foreach ( $segments as $segment ) {
+			$current = $this->walkSegment( $current, $segment );
+
+			if ( null === $current ) {
+				return null;
+			}
+		}
+
+		return $current;
+	}
+
+	public function availableFields( string $resource, ?string $modelClass = null ): array
+	{
+		// Paths are free-form (`author.name`, `categories.0.title`, etc.).
+		// The picker falls back to a free-text input when this is empty.
+		return [];
+	}
+
+	public function eagerLoadRelations( array $bindingArgs ): array
+	{
+		$relations = [];
+
+		foreach ( $bindingArgs as $args ) {
+			$path = is_string( $args['path'] ?? null ) ? trim( $args['path'] ) : '';
+
+			if ( '' === $path ) {
+				continue;
+			}
+
+			$segments = explode( '.', $path );
+
+			// Drop the final segment — the leaf is the resolved value,
+			// not a relation to load. Numeric segments (collection
+			// indices) also can't be eager-loaded.
+			array_pop( $segments );
+
+			$relationParts = [];
+
+			foreach ( $segments as $segment ) {
+				if ( '' === $segment || ctype_digit( $segment ) ) {
+					break;
+				}
+
+				$relationParts[] = $segment;
+			}
+
+			if ( [] === $relationParts ) {
+				continue;
+			}
+
+			$relations[ implode( '.', $relationParts ) ] = true;
+		}
+
+		return array_keys( $relations );
+	}
+
+	/**
+	 * Walk one segment of the dotted path. Returns null when the value at
+	 * the segment is missing.
+	 *
+	 * @since 1.1.0
+	 */
+	protected function walkSegment( mixed $current, string $segment ): mixed
+	{
+		if ( '' === $segment ) {
+			return null;
+		}
+
+		if ( $current instanceof Model ) {
+			return $current->getAttribute( $segment );
+		}
+
+		if ( $current instanceof Collection ) {
+			if ( ctype_digit( $segment ) ) {
+				return $current->get( (int) $segment );
+			}
+
+			return $current->map( fn ( $item ) => $this->walkSegment( $item, $segment ) )
+				->filter( fn ( $v ): bool => null !== $v )
+				->values()
+				->all();
+		}
+
+		if ( is_array( $current ) ) {
+			return $current[ $segment ] ?? null;
+		}
+
+		if ( $current instanceof ArrayAccess ) {
+			return $current[ $segment ] ?? null;
+		}
+
+		if ( $current instanceof Arrayable ) {
+			$asArray = $current->toArray();
+
+			return $asArray[ $segment ] ?? null;
+		}
+
+		return null;
+	}
+}

--- a/src/VisualEditorServiceProvider.php
+++ b/src/VisualEditorServiceProvider.php
@@ -23,8 +23,13 @@ use ArtisanPackUI\VisualEditor\SiteEditor\Gates\DenyByDefaultGate;
 use ArtisanPackUI\VisualEditor\SiteEditor\Gates\SiteEditorAccessGate;
 use ArtisanPackUI\VisualEditor\Models\VisualEditorPost;
 use ArtisanPackUI\VisualEditor\Policies\VisualEditorPostPolicy;
+use ArtisanPackUI\VisualEditor\Registries\BlockBindingSourceRegistry;
 use ArtisanPackUI\VisualEditor\Registries\BlockTypeRegistry;
 use ArtisanPackUI\VisualEditor\Registries\DynamicBlockRegistry;
+use ArtisanPackUI\VisualEditor\Services\Bindings\BindingResolver;
+use ArtisanPackUI\VisualEditor\Services\Bindings\Sources\CustomFieldSource;
+use ArtisanPackUI\VisualEditor\Services\Bindings\Sources\PostCoreSource;
+use ArtisanPackUI\VisualEditor\Services\Bindings\Sources\RelationSource;
 use ArtisanPackUI\VisualEditor\Console\AuditBreakpointsCommand;
 use ArtisanPackUI\VisualEditor\Resources\PostResolver;
 use ArtisanPackUI\VisualEditor\Resources\CommentInliner;
@@ -68,6 +73,20 @@ class VisualEditorServiceProvider extends ServiceProvider
 
 		$this->app->singleton( DynamicBlockRegistry::class, function () {
 			return new DynamicBlockRegistry();
+		} );
+
+		// #504 — Block bindings: a single shared registry of source drivers
+		// (custom_field, post_core, relation, plus host-registered
+		// extensions) and a singleton resolver that the preview controller
+		// and the frontend renderers both call into.
+		$this->app->singleton( BlockBindingSourceRegistry::class, function () {
+			return new BlockBindingSourceRegistry();
+		} );
+
+		$this->app->singleton( BindingResolver::class, function ( $app ) {
+			return new BindingResolver(
+				$app->make( BlockBindingSourceRegistry::class ),
+			);
 		} );
 
 		// Icon Block Phase 1 (#552): the sanitizer is stateless, so bind
@@ -418,6 +437,13 @@ class VisualEditorServiceProvider extends ServiceProvider
 		// 4. Register package-native blocks (artisanpack/callout, etc.).
 		$this->registerReferenceBlocks();
 
+		// 4.0. #504 — Register the built-in block binding sources. Hosts
+		//      and third-party packages register additional sources in
+		//      their own provider's boot() phase; the order of
+		//      registration does not matter because the resolver consults
+		//      the registry per-binding at render time.
+		$this->registerBlockBindingSources();
+
 		// 4.1. Icon Block Phase 3 (#554) — hand the FA Free SVG sets to
 		//      the `artisanpack-ui/icons` registry. The directories are
 		//      mirrored by `scripts/sync-fa-icons.mjs` (runs in `prebuild`)
@@ -455,6 +481,23 @@ class VisualEditorServiceProvider extends ServiceProvider
 				AuditBreakpointsCommand::class,
 			] );
 		}
+	}
+
+	/**
+	 * Registers the built-in block binding source drivers — `custom_field`,
+	 * `post_core`, and `relation`. Host applications and third-party
+	 * packages register their own drivers by resolving the registry out
+	 * of the container in their own provider's boot() phase.
+	 *
+	 * @since 1.1.0
+	 */
+	protected function registerBlockBindingSources(): void
+	{
+		$registry = $this->app->make( BlockBindingSourceRegistry::class );
+
+		$registry->register( new CustomFieldSource() );
+		$registry->register( new PostCoreSource() );
+		$registry->register( new RelationSource() );
 	}
 
 	/**

--- a/tests/Feature/VisualEditor/BindingResolveControllerTest.php
+++ b/tests/Feature/VisualEditor/BindingResolveControllerTest.php
@@ -1,0 +1,171 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\VisualEditorServiceProvider;
+use Tests\Fixtures\TestBindingsModel;
+use Tests\TestUser;
+
+beforeEach( function () {
+	config()->set( 'artisanpack.visual-editor.api.middleware', [ 'auth' ] );
+
+	config()->set( 'artisanpack.visual-editor.resources', [
+		'bindings' => TestBindingsModel::class,
+	] );
+
+	( new VisualEditorServiceProvider( app() ) )->registerResourceResolver();
+
+	$this->actor = TestUser::create( [
+		'name'     => 'Resolve Tester',
+		'email'    => 'resolve+' . uniqid() . '@example.com',
+		'password' => bcrypt( 'secret' ),
+	] );
+
+	$this->actingAs( $this->actor );
+} );
+
+it( 'resolves a binding to the parent model column value', function () {
+	$model = TestBindingsModel::query()->create( [
+		'title'   => 'Bound Title',
+		'status'  => 'published',
+		'content' => [],
+	] );
+
+	$response = $this->postJson( '/visual-editor/api/bindings/resolve', [
+		'attrs'    => [ 'icon' => 'STATIC', 'label' => 'Original' ],
+		'bindings' => [
+			'icon' => [
+				'source' => 'custom_field',
+				'args'   => [ 'key' => 'title' ],
+			],
+		],
+		'context'  => [
+			'resource' => 'bindings',
+			'id'       => $model->getKey(),
+		],
+	] );
+
+	$response->assertOk()
+		->assertJsonPath( 'values.icon', 'Bound Title' );
+} );
+
+it( 'returns the static fallback when the bound field is empty', function () {
+	$model = TestBindingsModel::query()->create( [
+		'title'   => 'Has Title',
+		'status'  => 'published',
+		'excerpt' => null,
+		'content' => [],
+	] );
+
+	$response = $this->postJson( '/visual-editor/api/bindings/resolve', [
+		'attrs'    => [ 'label' => 'Fallback' ],
+		'bindings' => [
+			'label' => [
+				'source' => 'custom_field',
+				'args'   => [ 'key' => 'excerpt' ],
+			],
+		],
+		'context'  => [
+			'resource' => 'bindings',
+			'id'       => $model->getKey(),
+		],
+	] );
+
+	$response->assertOk()
+		->assertJsonPath( 'values.label', 'Fallback' );
+} );
+
+it( 'returns an empty values object when no bindings are supplied', function () {
+	$response = $this->postJson( '/visual-editor/api/bindings/resolve', [
+		'attrs'    => [ 'icon' => 'STATIC' ],
+		'bindings' => [],
+		'context'  => [],
+	] );
+
+	$response->assertOk()
+		->assertJsonPath( 'values', [] );
+} );
+
+it( 'returns the fallback value when no context is supplied', function () {
+	$response = $this->postJson( '/visual-editor/api/bindings/resolve', [
+		'attrs'    => [ 'icon' => 'STATIC' ],
+		'bindings' => [
+			'icon' => [
+				'source' => 'custom_field',
+				'args'   => [ 'key' => 'title' ],
+			],
+		],
+	] );
+
+	$response->assertOk()
+		->assertJsonPath( 'values.icon', 'STATIC' );
+} );
+
+it( 'rejects payloads where attrs or bindings is not an array', function () {
+	$response = $this->postJson( '/visual-editor/api/bindings/resolve', [
+		'attrs'    => 'not-an-array',
+		'bindings' => [],
+	] );
+
+	$response->assertStatus( 422 )
+		->assertJsonPath( 'error', 'invalid_payload' );
+
+	$response = $this->postJson( '/visual-editor/api/bindings/resolve', [
+		'attrs'    => [],
+		'bindings' => 'not-an-array',
+	] );
+
+	$response->assertStatus( 422 )
+		->assertJsonPath( 'error', 'invalid_payload' );
+} );
+
+it( 'reflects draft overrides ahead of saved column values', function () {
+	$model = TestBindingsModel::query()->create( [
+		'title'   => 'Saved Title',
+		'status'  => 'published',
+		'content' => [],
+	] );
+
+	$response = $this->postJson( '/visual-editor/api/bindings/resolve', [
+		'attrs'    => [ 'icon' => 'STATIC' ],
+		'bindings' => [
+			'icon' => [
+				'source' => 'custom_field',
+				'args'   => [ 'key' => 'title' ],
+			],
+		],
+		'context'  => [
+			'resource' => 'bindings',
+			'id'       => $model->getKey(),
+			'draft'    => [ 'title' => 'Live Draft' ],
+		],
+	] );
+
+	$response->assertOk()
+		->assertJsonPath( 'values.icon', 'Live Draft' );
+} );
+
+it( 'resolves multiple bindings on the same block in one round-trip', function () {
+	$model = TestBindingsModel::query()->create( [
+		'title'   => 'My Title',
+		'excerpt' => 'My Excerpt',
+		'status'  => 'published',
+		'content' => [],
+	] );
+
+	$response = $this->postJson( '/visual-editor/api/bindings/resolve', [
+		'attrs'    => [ 'a' => 'a-static', 'b' => 'b-static' ],
+		'bindings' => [
+			'a' => [ 'source' => 'post_core', 'args' => [ 'key' => 'title' ] ],
+			'b' => [ 'source' => 'post_core', 'args' => [ 'key' => 'excerpt' ] ],
+		],
+		'context'  => [
+			'resource' => 'bindings',
+			'id'       => $model->getKey(),
+		],
+	] );
+
+	$response->assertOk()
+		->assertJsonPath( 'values.a', 'My Title' )
+		->assertJsonPath( 'values.b', 'My Excerpt' );
+} );

--- a/tests/Feature/VisualEditor/BindingSourcesControllerTest.php
+++ b/tests/Feature/VisualEditor/BindingSourcesControllerTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Registries\BlockBindingSourceRegistry;
+use ArtisanPackUI\VisualEditor\Services\Bindings\BindingContext;
+use ArtisanPackUI\VisualEditor\Services\Bindings\BlockBindingSource;
+use ArtisanPackUI\VisualEditor\VisualEditorServiceProvider;
+use Tests\Fixtures\TestBindingsModel;
+use Tests\TestUser;
+
+beforeEach( function () {
+	config()->set( 'artisanpack.visual-editor.api.middleware', [ 'auth' ] );
+
+	config()->set( 'artisanpack.visual-editor.resources', [
+		'bindings' => TestBindingsModel::class,
+	] );
+
+	( new VisualEditorServiceProvider( app() ) )->registerResourceResolver();
+
+	$this->actor = TestUser::create( [
+		'name'     => 'Sources Tester',
+		'email'    => 'sources+' . uniqid() . '@example.com',
+		'password' => bcrypt( 'secret' ),
+	] );
+
+	$this->actingAs( $this->actor );
+} );
+
+it( 'lists the built-in registered sources', function () {
+	$response = $this->getJson( '/visual-editor/api/bindings/sources' );
+
+	$response->assertOk();
+
+	$names = collect( $response->json( 'sources' ) )->pluck( 'name' )->all();
+
+	expect( $names )->toContain( 'custom_field', 'post_core', 'relation' );
+} );
+
+it( 'returns the post_core field catalog for a known resource', function () {
+	$response = $this->getJson( '/visual-editor/api/bindings/sources/post_core/fields?resource=bindings' );
+
+	$response->assertOk()
+		->assertJsonPath( 'source', 'post_core' )
+		->assertJsonPath( 'resource', 'bindings' );
+
+	$keys = collect( $response->json( 'fields' ) )->pluck( 'key' )->all();
+
+	expect( $keys )->toContain( 'title', 'excerpt', 'author_name' );
+} );
+
+it( 'returns the post_core catalog even when no resource is supplied', function () {
+	$response = $this->getJson( '/visual-editor/api/bindings/sources/post_core/fields' );
+
+	$response->assertOk();
+
+	$keys = collect( $response->json( 'fields' ) )->pluck( 'key' )->all();
+
+	expect( $keys )->toContain( 'title' );
+} );
+
+it( 'returns an empty field catalog for the relation source', function () {
+	$response = $this->getJson( '/visual-editor/api/bindings/sources/relation/fields?resource=bindings' );
+
+	$response->assertOk()
+		->assertJsonPath( 'fields', [] );
+} );
+
+it( 'returns 404 for an unknown source', function () {
+	$response = $this->getJson( '/visual-editor/api/bindings/sources/imaginary/fields?resource=bindings' );
+
+	$response->assertNotFound()
+		->assertJsonPath( 'error', 'source_not_registered' )
+		->assertJsonPath( 'source', 'imaginary' );
+} );
+
+it( 'rejects a source name that does not match the snake_case pattern at route level', function () {
+	$response = $this->getJson( '/visual-editor/api/bindings/sources/BAD-NAME/fields' );
+
+	$response->assertNotFound();
+} );
+
+it( 'reflects host-registered custom sources in the listing and field endpoints', function () {
+	app( BlockBindingSourceRegistry::class )->register( new class implements BlockBindingSource
+	{
+		public function name(): string
+		{
+			return 'site_settings';
+		}
+
+		public function resolve( BindingContext $context, array $args ): mixed
+		{
+			return null;
+		}
+
+		public function eagerLoadRelations( array $bindingArgs ): array
+		{
+			return [];
+		}
+
+		public function availableFields( string $resource, ?string $modelClass = null ): array
+		{
+			return [
+				[ 'key' => 'site_name', 'label' => 'Site name', 'type' => 'string' ],
+			];
+		}
+	} );
+
+	$list = $this->getJson( '/visual-editor/api/bindings/sources' );
+	$names = collect( $list->json( 'sources' ) )->pluck( 'name' )->all();
+	expect( $names )->toContain( 'site_settings' );
+
+	$fields = $this->getJson( '/visual-editor/api/bindings/sources/site_settings/fields?resource=bindings' );
+	$fields->assertOk()
+		->assertJsonPath( 'fields.0.key', 'site_name' )
+		->assertJsonPath( 'fields.0.type', 'string' );
+} );

--- a/tests/Feature/VisualEditor/BlockPreviewBindingsTest.php
+++ b/tests/Feature/VisualEditor/BlockPreviewBindingsTest.php
@@ -1,0 +1,215 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Facades\VisualEditor;
+use ArtisanPackUI\VisualEditor\Registries\BlockBindingSourceRegistry;
+use ArtisanPackUI\VisualEditor\Services\Bindings\BindingContext;
+use ArtisanPackUI\VisualEditor\Services\Bindings\BlockBindingSource;
+use ArtisanPackUI\VisualEditor\VisualEditorServiceProvider;
+use Tests\Fixtures\TestBindingsModel;
+use Tests\Fixtures\TestDynamicBlock;
+use Tests\TestUser;
+
+beforeEach( function () {
+	config()->set( 'artisanpack.visual-editor.api.middleware', [ 'auth' ] );
+
+	config()->set( 'artisanpack.visual-editor.resources', [
+		'bindings' => TestBindingsModel::class,
+	] );
+
+	( new VisualEditorServiceProvider( app() ) )->registerResourceResolver();
+
+	$this->actor = TestUser::create( [
+		'name'     => 'Binding Tester',
+		'email'    => 'binding+' . uniqid() . '@example.com',
+		'password' => bcrypt( 'secret' ),
+	] );
+
+	$this->actingAs( $this->actor );
+} );
+
+it( 'resolves a bound attribute against the parent model when context is supplied', function () {
+	VisualEditor::registerDynamicBlock( TestDynamicBlock::class );
+
+	$model = TestBindingsModel::query()->create( [
+		'title'   => 'Bound Title',
+		'status'  => 'published',
+		'content' => [],
+	] );
+
+	$response = $this->postJson( '/visual-editor/api/blocks/preview', [
+		'name'       => 'tests/hello',
+		'attributes' => [ 'name' => 'Static', 'greeting' => 'Hi' ],
+		'bindings'   => [
+			'name' => [
+				'source' => 'custom_field',
+				'args'   => [ 'key' => 'title' ],
+			],
+		],
+		'context'    => [
+			'resource' => 'bindings',
+			'id'       => $model->getKey(),
+		],
+	] );
+
+	$response->assertOk()
+		->assertJsonPath( 'html', '<p>Hi, Bound Title!</p>' );
+} );
+
+it( 'falls back to the static value when the bound field is empty', function () {
+	VisualEditor::registerDynamicBlock( TestDynamicBlock::class );
+
+	$model = TestBindingsModel::query()->create( [
+		'title'   => 'Has Title',
+		'status'  => 'published',
+		'excerpt' => null,
+		'content' => [],
+	] );
+
+	$response = $this->postJson( '/visual-editor/api/blocks/preview', [
+		'name'       => 'tests/hello',
+		'attributes' => [ 'name' => 'Fallback', 'greeting' => 'Hi' ],
+		'bindings'   => [
+			'name' => [
+				'source' => 'custom_field',
+				'args'   => [ 'key' => 'excerpt' ],
+			],
+		],
+		'context'    => [
+			'resource' => 'bindings',
+			'id'       => $model->getKey(),
+		],
+	] );
+
+	$response->assertOk()
+		->assertJsonPath( 'html', '<p>Hi, Fallback!</p>' );
+} );
+
+it( 'falls back when no context is supplied', function () {
+	VisualEditor::registerDynamicBlock( TestDynamicBlock::class );
+
+	$response = $this->postJson( '/visual-editor/api/blocks/preview', [
+		'name'       => 'tests/hello',
+		'attributes' => [ 'name' => 'Solo', 'greeting' => 'Hi' ],
+		'bindings'   => [
+			'name' => [
+				'source' => 'custom_field',
+				'args'   => [ 'key' => 'title' ],
+			],
+		],
+	] );
+
+	$response->assertOk()
+		->assertJsonPath( 'html', '<p>Hi, Solo!</p>' );
+} );
+
+it( 'falls back silently when the resource is unknown', function () {
+	VisualEditor::registerDynamicBlock( TestDynamicBlock::class );
+
+	$response = $this->postJson( '/visual-editor/api/blocks/preview', [
+		'name'       => 'tests/hello',
+		'attributes' => [ 'name' => 'Static', 'greeting' => 'Hi' ],
+		'bindings'   => [
+			'name' => [
+				'source' => 'custom_field',
+				'args'   => [ 'key' => 'title' ],
+			],
+		],
+		'context'    => [
+			'resource' => 'not-registered',
+			'id'       => 999,
+		],
+	] );
+
+	$response->assertOk()
+		->assertJsonPath( 'html', '<p>Hi, Static!</p>' );
+} );
+
+it( 'reflects unsaved draft overrides in the bound attribute', function () {
+	VisualEditor::registerDynamicBlock( TestDynamicBlock::class );
+
+	$model = TestBindingsModel::query()->create( [
+		'title'   => 'Saved',
+		'status'  => 'published',
+		'content' => [],
+	] );
+
+	$response = $this->postJson( '/visual-editor/api/blocks/preview', [
+		'name'       => 'tests/hello',
+		'attributes' => [ 'name' => 'Static', 'greeting' => 'Hi' ],
+		'bindings'   => [
+			'name' => [
+				'source' => 'custom_field',
+				'args'   => [ 'key' => 'title' ],
+			],
+		],
+		'context'    => [
+			'resource' => 'bindings',
+			'id'       => $model->getKey(),
+			'draft'    => [ 'title' => 'Editor Draft' ],
+		],
+	] );
+
+	$response->assertOk()
+		->assertJsonPath( 'html', '<p>Hi, Editor Draft!</p>' );
+} );
+
+it( 'lets a host application register a custom source driver', function () {
+	$registry = app( BlockBindingSourceRegistry::class );
+
+	$registry->register( new class implements BlockBindingSource
+	{
+		public function name(): string
+		{
+			return 'site_settings';
+		}
+
+		public function resolve( BindingContext $context, array $args ): mixed
+		{
+			$key = is_string( $args['key'] ?? null ) ? $args['key'] : '';
+
+			$settings = [ 'site_name' => 'Custom Site' ];
+
+			return $settings[ $key ] ?? null;
+		}
+
+		public function eagerLoadRelations( array $bindingArgs ): array
+		{
+			return [];
+		}
+
+		public function availableFields( string $resource, ?string $modelClass = null ): array
+		{
+			return [];
+		}
+	} );
+
+	VisualEditor::registerDynamicBlock( TestDynamicBlock::class );
+
+	$response = $this->postJson( '/visual-editor/api/blocks/preview', [
+		'name'       => 'tests/hello',
+		'attributes' => [ 'name' => 'Static', 'greeting' => 'Hi' ],
+		'bindings'   => [
+			'name' => [
+				'source' => 'site_settings',
+				'args'   => [ 'key' => 'site_name' ],
+			],
+		],
+	] );
+
+	$response->assertOk()
+		->assertJsonPath( 'html', '<p>Hi, Custom Site!</p>' );
+} );
+
+it( 'leaves a preview without a bindings payload unchanged (BC regression)', function () {
+	VisualEditor::registerDynamicBlock( TestDynamicBlock::class );
+
+	$response = $this->postJson( '/visual-editor/api/blocks/preview', [
+		'name'       => 'tests/hello',
+		'attributes' => [ 'name' => 'Original', 'greeting' => 'Hello' ],
+	] );
+
+	$response->assertOk()
+		->assertJsonPath( 'html', '<p>Hello, Original!</p>' );
+} );

--- a/tests/Fixtures/TestBindingsModel.php
+++ b/tests/Fixtures/TestBindingsModel.php
@@ -1,0 +1,38 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace Tests\Fixtures;
+
+use ArtisanPackUI\VisualEditor\Concerns\HasBlockContent;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Tests\TestUser;
+
+/**
+ * Test fixture used by the #504 block-bindings tests. Reuses the
+ * existing `test_block_content_models` table so we do not have to add a
+ * second migration, and layers an `author` relation on top so the
+ * resolver's eager-load path is exercisable.
+ *
+ * @property int $id
+ * @property string $title
+ * @property string|null $slug
+ * @property string|null $excerpt
+ * @property string $status
+ * @property int|null $author_id
+ * @property array<int, array<string, mixed>>|null $content
+ */
+class TestBindingsModel extends Model
+{
+	use HasBlockContent;
+
+	protected $table = 'test_block_content_models';
+
+	protected $guarded = [];
+
+	public function author(): BelongsTo
+	{
+		return $this->belongsTo( TestUser::class, 'author_id' );
+	}
+}

--- a/tests/Unit/VisualEditor/Bindings/BindingContextTest.php
+++ b/tests/Unit/VisualEditor/Bindings/BindingContextTest.php
@@ -21,6 +21,21 @@ it( 'returns the supplied draft snapshot verbatim', function () {
 		->and( $context->draftValue( 'missing' ) )->toBeNull();
 } );
 
+it( 'distinguishes "no draft entry" from "draft entry set to null / empty"', function () {
+	$context = new BindingContext( null, [
+		'title'   => null,
+		'excerpt' => '',
+		'slug'    => 'present',
+	] );
+
+	expect( $context->hasDraftValue( 'title' ) )->toBeTrue()
+		->and( $context->hasDraftValue( 'excerpt' ) )->toBeTrue()
+		->and( $context->hasDraftValue( 'slug' ) )->toBeTrue()
+		->and( $context->hasDraftValue( 'missing' ) )->toBeFalse()
+		->and( $context->draftValue( 'title' ) )->toBeNull()
+		->and( $context->draftValue( 'excerpt' ) )->toBe( '' );
+} );
+
 it( 'is immutable — withModel returns a new instance', function () {
 	$original = new BindingContext( null, [ 'a' => 1 ], [ 'b' => 2 ] );
 	$model    = new TestBlockContentModel( [ 'title' => 'X' ] );

--- a/tests/Unit/VisualEditor/Bindings/BindingContextTest.php
+++ b/tests/Unit/VisualEditor/Bindings/BindingContextTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Services\Bindings\BindingContext;
+use Tests\Fixtures\TestBlockContentModel;
+
+it( 'defaults to a model-less, draftless context', function () {
+	$context = new BindingContext();
+
+	expect( $context->model() )->toBeNull()
+		->and( $context->draft() )->toBe( [] )
+		->and( $context->extras() )->toBe( [] );
+} );
+
+it( 'returns the supplied draft snapshot verbatim', function () {
+	$context = new BindingContext( null, [ 'title' => 'Draft Title', 'meta' => [ 'tone' => 'casual' ] ] );
+
+	expect( $context->draft() )->toBe( [ 'title' => 'Draft Title', 'meta' => [ 'tone' => 'casual' ] ] )
+		->and( $context->draftValue( 'title' ) )->toBe( 'Draft Title' )
+		->and( $context->draftValue( 'missing' ) )->toBeNull();
+} );
+
+it( 'is immutable — withModel returns a new instance', function () {
+	$original = new BindingContext( null, [ 'a' => 1 ], [ 'b' => 2 ] );
+	$model    = new TestBlockContentModel( [ 'title' => 'X' ] );
+
+	$next = $original->withModel( $model );
+
+	expect( $next )->not->toBe( $original )
+		->and( $original->model() )->toBeNull()
+		->and( $next->model() )->toBe( $model )
+		->and( $next->draft() )->toBe( [ 'a' => 1 ] )
+		->and( $next->extras() )->toBe( [ 'b' => 2 ] );
+} );
+
+it( 'withDraft replaces only the draft', function () {
+	$model    = new TestBlockContentModel( [ 'title' => 'Y' ] );
+	$original = new BindingContext( $model, [ 'a' => 1 ], [ 'b' => 2 ] );
+
+	$next = $original->withDraft( [ 'c' => 3 ] );
+
+	expect( $next->model() )->toBe( $model )
+		->and( $next->draft() )->toBe( [ 'c' => 3 ] )
+		->and( $next->extras() )->toBe( [ 'b' => 2 ] )
+		->and( $original->draft() )->toBe( [ 'a' => 1 ] );
+} );
+
+it( 'withExtras replaces only the extras bag', function () {
+	$original = new BindingContext( null, [ 'a' => 1 ], [ 'b' => 2 ] );
+
+	$next = $original->withExtras( [ 'siteId' => 4 ] );
+
+	expect( $next->extras() )->toBe( [ 'siteId' => 4 ] )
+		->and( $next->draft() )->toBe( [ 'a' => 1 ] )
+		->and( $original->extras() )->toBe( [ 'b' => 2 ] );
+} );

--- a/tests/Unit/VisualEditor/Bindings/BindingResolverTest.php
+++ b/tests/Unit/VisualEditor/Bindings/BindingResolverTest.php
@@ -1,0 +1,390 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Registries\BlockBindingSourceRegistry;
+use ArtisanPackUI\VisualEditor\Services\Bindings\BindingContext;
+use ArtisanPackUI\VisualEditor\Services\Bindings\BindingResolver;
+use ArtisanPackUI\VisualEditor\Services\Bindings\BlockBindingSource;
+use Illuminate\Support\Facades\DB;
+use Tests\Fixtures\TestBindingsModel;
+use Tests\Fixtures\TestBlockContentModel;
+
+function makeStaticSource( string $name, callable $resolver, array $eagerRelations = [] ): BlockBindingSource
+{
+	return new class( $name, $resolver, $eagerRelations ) implements BlockBindingSource
+	{
+		public function __construct(
+			protected string $sourceName,
+			protected $resolver,
+			protected array $eager
+		) {
+		}
+
+		public function name(): string
+		{
+			return $this->sourceName;
+		}
+
+		public function resolve( BindingContext $context, array $args ): mixed
+		{
+			return ( $this->resolver )( $context, $args );
+		}
+
+		public function eagerLoadRelations( array $bindingArgs ): array
+		{
+			return $this->eager;
+		}
+
+		public function availableFields( string $resource, ?string $modelClass = null ): array
+		{
+			return [];
+		}
+	};
+}
+
+function buildResolver( array $sources = [] ): BindingResolver
+{
+	$registry = new BlockBindingSourceRegistry();
+
+	foreach ( $sources as $source ) {
+		$registry->register( $source );
+	}
+
+	return new BindingResolver( $registry );
+}
+
+it( 'returns an empty tree untouched', function () {
+	$resolver = buildResolver();
+
+	expect( $resolver->resolve( [] ) )->toBe( [] );
+} );
+
+it( 'leaves a tree without bindings byte-identical (BC regression)', function () {
+	$resolver = buildResolver();
+
+	$tree = [
+		[
+			'name'        => 'core/paragraph',
+			'attrs'       => [ 'content' => 'Hello', 'fontSize' => 'large' ],
+			'innerBlocks' => [
+				[
+					'name'  => 'core/heading',
+					'attrs' => [ 'level' => 2, 'content' => 'Sub' ],
+				],
+			],
+		],
+		[
+			'name'  => 'artisanpack/icon',
+			'attrs' => [ 'icon' => 'o-star', 'size' => 'md' ],
+		],
+	];
+
+	expect( $resolver->resolve( $tree ) )->toBe( $tree );
+} );
+
+it( 'overrides a static attribute with the bound value', function () {
+	$resolver = buildResolver( [
+		makeStaticSource( 'custom_field', fn () => 'o-heart' ),
+	] );
+
+	$tree = [
+		[
+			'name'     => 'artisanpack/icon',
+			'attrs'    => [ 'icon' => 'o-star', 'size' => 'md' ],
+			'bindings' => [
+				'icon' => [
+					'source' => 'custom_field',
+					'args'   => [ 'key' => 'featured_icon' ],
+				],
+			],
+		],
+	];
+
+	$resolved = $resolver->resolve( $tree );
+
+	expect( $resolved[0]['attrs']['icon'] )->toBe( 'o-heart' )
+		->and( $resolved[0]['attrs']['size'] )->toBe( 'md' );
+} );
+
+it( 'falls back to the static value by default when the binding is empty', function () {
+	$resolver = buildResolver( [
+		makeStaticSource( 'custom_field', fn () => null ),
+	] );
+
+	$tree = [
+		[
+			'name'     => 'artisanpack/icon',
+			'attrs'    => [ 'icon' => 'o-star' ],
+			'bindings' => [
+				'icon' => [
+					'source' => 'custom_field',
+					'args'   => [ 'key' => 'featured_icon' ],
+				],
+			],
+		],
+	];
+
+	$resolved = $resolver->resolve( $tree );
+
+	expect( $resolved[0]['attrs']['icon'] )->toBe( 'o-star' );
+} );
+
+it( 'nulls the attribute when the empty-value policy is "hide"', function () {
+	$resolver = buildResolver( [
+		makeStaticSource( 'custom_field', fn () => null ),
+	] );
+
+	$tree = [
+		[
+			'name'     => 'artisanpack/icon',
+			'attrs'    => [ 'icon' => 'o-star' ],
+			'bindings' => [
+				'icon' => [
+					'source'  => 'custom_field',
+					'args'    => [ 'key' => 'featured_icon' ],
+					'onEmpty' => BindingResolver::POLICY_HIDE,
+				],
+			],
+		],
+	];
+
+	$resolved = $resolver->resolve( $tree );
+
+	expect( $resolved[0]['attrs'] )->toHaveKey( 'icon' )
+		->and( $resolved[0]['attrs']['icon'] )->toBeNull();
+} );
+
+it( 'writes the placeholder when the empty-value policy is "placeholder"', function () {
+	$resolver = buildResolver( [
+		makeStaticSource( 'custom_field', fn () => null ),
+	] );
+
+	$tree = [
+		[
+			'name'     => 'artisanpack/icon',
+			'attrs'    => [ 'icon' => 'o-star' ],
+			'bindings' => [
+				'icon' => [
+					'source'      => 'custom_field',
+					'args'        => [ 'key' => 'featured_icon' ],
+					'onEmpty'     => BindingResolver::POLICY_PLACEHOLDER,
+					'placeholder' => '— pick one —',
+				],
+			],
+		],
+	];
+
+	$resolved = $resolver->resolve( $tree );
+
+	expect( $resolved[0]['attrs']['icon'] )->toBe( '— pick one —' );
+} );
+
+it( 'falls back when the named source is not registered', function () {
+	$resolver = buildResolver();
+
+	$tree = [
+		[
+			'name'     => 'artisanpack/icon',
+			'attrs'    => [ 'icon' => 'o-star' ],
+			'bindings' => [
+				'icon' => [ 'source' => 'unknown', 'args' => [] ],
+			],
+		],
+	];
+
+	$resolved = $resolver->resolve( $tree );
+
+	expect( $resolved[0]['attrs']['icon'] )->toBe( 'o-star' );
+} );
+
+it( 'falls back when the source throws — does not break the render', function () {
+	$resolver = buildResolver( [
+		makeStaticSource( 'breaks', function () {
+			throw new RuntimeException( 'boom' );
+		} ),
+	] );
+
+	$tree = [
+		[
+			'name'     => 'artisanpack/icon',
+			'attrs'    => [ 'icon' => 'o-star' ],
+			'bindings' => [
+				'icon' => [ 'source' => 'breaks', 'args' => [] ],
+			],
+		],
+	];
+
+	$resolved = $resolver->resolve( $tree );
+
+	expect( $resolved[0]['attrs']['icon'] )->toBe( 'o-star' );
+} );
+
+it( 'treats 0 and false as legitimate (non-empty) bound values', function () {
+	$resolver = buildResolver( [
+		makeStaticSource( 'flag', fn () => false ),
+		makeStaticSource( 'count', fn () => 0 ),
+	] );
+
+	$tree = [
+		[
+			'name'     => 'demo/two',
+			'attrs'    => [ 'enabled' => true, 'count' => 5 ],
+			'bindings' => [
+				'enabled' => [ 'source' => 'flag', 'args' => [] ],
+				'count'   => [ 'source' => 'count', 'args' => [] ],
+			],
+		],
+	];
+
+	$resolved = $resolver->resolve( $tree );
+
+	expect( $resolved[0]['attrs']['enabled'] )->toBeFalse()
+		->and( $resolved[0]['attrs']['count'] )->toBe( 0 );
+} );
+
+it( 'resolves bindings on innerBlocks recursively', function () {
+	$resolver = buildResolver( [
+		makeStaticSource( 'custom_field', fn ( BindingContext $context, array $args ) => 'value-of-' . ( $args['key'] ?? '' ) ),
+	] );
+
+	$tree = [
+		[
+			'name'        => 'core/group',
+			'attrs'       => [],
+			'innerBlocks' => [
+				[
+					'name'     => 'artisanpack/icon',
+					'attrs'    => [ 'icon' => 'o-star' ],
+					'bindings' => [
+						'icon' => [
+							'source' => 'custom_field',
+							'args'   => [ 'key' => 'featured_icon' ],
+						],
+					],
+				],
+			],
+		],
+	];
+
+	$resolved = $resolver->resolve( $tree );
+
+	expect( $resolved[0]['innerBlocks'][0]['attrs']['icon'] )->toBe( 'value-of-featured_icon' );
+} );
+
+it( 'loads the parent model at most once across a tree of 20+ bound blocks', function () {
+	$model = TestBlockContentModel::query()->create( [
+		'title'   => 'Source Of Truth',
+		'status'  => 'published',
+		'content' => [],
+	] );
+
+	$resolver = buildResolver( [
+		makeStaticSource(
+			'custom_field',
+			fn ( BindingContext $context, array $args ) => $context->model()?->getAttribute( $args['key'] ?? 'title' )
+		),
+	] );
+
+	$tree = [];
+
+	for ( $i = 0; $i < 25; $i++ ) {
+		$tree[] = [
+			'name'     => 'artisanpack/icon',
+			'attrs'    => [ 'icon' => 'o-default' ],
+			'bindings' => [
+				'icon' => [
+					'source' => 'custom_field',
+					'args'   => [ 'key' => 'title' ],
+				],
+			],
+		];
+	}
+
+	DB::connection()->enableQueryLog();
+	DB::connection()->flushQueryLog();
+
+	$resolved = $resolver->resolve( $tree, new BindingContext( $model ) );
+
+	$queries = DB::connection()->getQueryLog();
+	DB::connection()->disableQueryLog();
+
+	expect( $queries )->toHaveCount( 0 )
+		->and( $resolved )->toHaveCount( 25 )
+		->and( $resolved[0]['attrs']['icon'] )->toBe( 'Source Of Truth' )
+		->and( $resolved[24]['attrs']['icon'] )->toBe( 'Source Of Truth' );
+} );
+
+it( 'eager-loads relations declared by source drivers exactly once', function () {
+	$author = Tests\TestUser::query()->create( [
+		'name'     => 'Author Name',
+		'email'    => 'author+' . uniqid() . '@example.com',
+		'password' => 'secret',
+	] );
+
+	$model = TestBindingsModel::query()->create( [
+		'title'     => 'Has Author',
+		'status'    => 'published',
+		'author_id' => $author->getKey(),
+		'content'   => [],
+	] );
+
+	$resolver = buildResolver( [
+		makeStaticSource(
+			'post_core',
+			fn ( BindingContext $context, array $args ) => $context->model()?->getAttribute( 'author' )?->getAttribute( 'name' ),
+			[ 'author' ]
+		),
+	] );
+
+	$tree = [];
+
+	for ( $i = 0; $i < 10; $i++ ) {
+		$tree[] = [
+			'name'     => 'artisanpack/byline',
+			'attrs'    => [ 'name' => 'Fallback' ],
+			'bindings' => [
+				'name' => [
+					'source' => 'post_core',
+					'args'   => [ 'key' => 'author_name' ],
+				],
+			],
+		];
+	}
+
+	DB::connection()->enableQueryLog();
+	DB::connection()->flushQueryLog();
+
+	$result = $resolver->resolve( $tree, new BindingContext( $model ) );
+
+	$queries = DB::connection()->getQueryLog();
+	DB::connection()->disableQueryLog();
+
+	// Exactly one query — the eager-load of the `author` relation.
+	expect( $queries )->toHaveCount( 1 )
+		->and( $result[0]['attrs']['name'] )->toBe( 'Author Name' )
+		->and( $result[9]['attrs']['name'] )->toBe( 'Author Name' );
+} );
+
+it( 'ignores malformed binding entries on a block but still rewrites valid ones', function () {
+	$resolver = buildResolver( [
+		makeStaticSource( 'custom_field', fn () => 'GOOD' ),
+	] );
+
+	$tree = [
+		[
+			'name'     => 'artisanpack/icon',
+			'attrs'    => [ 'icon' => 'o-star', 'label' => 'fallback' ],
+			'bindings' => [
+				'icon'  => [ 'source' => 'custom_field', 'args' => [] ],
+				'label' => 'not-an-array',
+				123     => [ 'source' => 'custom_field', 'args' => [] ],
+			],
+		],
+	];
+
+	$resolved = $resolver->resolve( $tree );
+
+	expect( $resolved[0]['attrs']['icon'] )->toBe( 'GOOD' )
+		->and( $resolved[0]['attrs']['label'] )->toBe( 'fallback' );
+} );

--- a/tests/Unit/VisualEditor/Bindings/BlockBindingSourceRegistryTest.php
+++ b/tests/Unit/VisualEditor/Bindings/BlockBindingSourceRegistryTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Registries\BlockBindingSourceRegistry;
+use ArtisanPackUI\VisualEditor\Services\Bindings\BindingContext;
+use ArtisanPackUI\VisualEditor\Services\Bindings\BlockBindingSource;
+
+function makeStubSource( string $name, mixed $value = null, array $eager = [] ): BlockBindingSource
+{
+	return new class( $name, $value, $eager ) implements BlockBindingSource
+	{
+		public function __construct(
+			protected string $sourceName,
+			protected mixed $value,
+			protected array $eager
+		) {
+		}
+
+		public function name(): string
+		{
+			return $this->sourceName;
+		}
+
+		public function resolve( BindingContext $context, array $args ): mixed
+		{
+			return $this->value;
+		}
+
+		public function eagerLoadRelations( array $bindingArgs ): array
+		{
+			return $this->eager;
+		}
+
+		public function availableFields( string $resource, ?string $modelClass = null ): array
+		{
+			return [];
+		}
+	};
+}
+
+it( 'starts empty', function () {
+	$registry = new BlockBindingSourceRegistry();
+
+	expect( $registry->all() )->toBeEmpty();
+} );
+
+it( 'registers a source by its declared name', function () {
+	$registry = new BlockBindingSourceRegistry();
+	$source   = makeStubSource( 'acme_field' );
+
+	$registry->register( $source );
+
+	expect( $registry->has( 'acme_field' ) )->toBeTrue()
+		->and( $registry->get( 'acme_field' ) )->toBe( $source );
+} );
+
+it( 'returns null for unregistered names', function () {
+	$registry = new BlockBindingSourceRegistry();
+
+	expect( $registry->get( 'missing' ) )->toBeNull()
+		->and( $registry->has( 'missing' ) )->toBeFalse();
+} );
+
+it( 'unregisters a source by name', function () {
+	$registry = new BlockBindingSourceRegistry();
+	$registry->register( makeStubSource( 'temp_source' ) );
+
+	$registry->unregister( 'temp_source' );
+
+	expect( $registry->has( 'temp_source' ) )->toBeFalse();
+} );
+
+it( 'overwrites the previous registration when the same name is reused', function () {
+	$registry = new BlockBindingSourceRegistry();
+	$first    = makeStubSource( 'shared' );
+	$second   = makeStubSource( 'shared' );
+
+	$registry->register( $first );
+	$registry->register( $second );
+
+	expect( $registry->get( 'shared' ) )->toBe( $second );
+} );
+
+it( 'rejects an empty source name', function () {
+	$registry = new BlockBindingSourceRegistry();
+
+	$registry->register( makeStubSource( '   ' ) );
+} )->throws( InvalidArgumentException::class, 'cannot be empty' );
+
+it( 'rejects a source name with invalid characters', function () {
+	$registry = new BlockBindingSourceRegistry();
+
+	$registry->register( makeStubSource( 'Bad-Name!' ) );
+} )->throws( InvalidArgumentException::class, 'snake_case' );
+
+it( 'rejects a source name that uses a slash like a block name', function () {
+	$registry = new BlockBindingSourceRegistry();
+
+	$registry->register( makeStubSource( 'acme/source' ) );
+} )->throws( InvalidArgumentException::class, 'snake_case' );

--- a/tests/Unit/VisualEditor/Bindings/Sources/CustomFieldSourceTest.php
+++ b/tests/Unit/VisualEditor/Bindings/Sources/CustomFieldSourceTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Services\Bindings\BindingContext;
+use ArtisanPackUI\VisualEditor\Services\Bindings\Sources\CustomFieldSource;
+use Tests\Fixtures\TestBindingsModel;
+
+it( 'returns null when no model is in context', function () {
+	$source = new CustomFieldSource();
+
+	expect( $source->resolve( new BindingContext(), [ 'key' => 'featured_icon' ] ) )->toBeNull();
+} );
+
+it( 'returns null when the args key is missing or blank', function () {
+	$source = new CustomFieldSource();
+	$model  = new TestBindingsModel( [ 'title' => 'X' ] );
+	$ctx    = new BindingContext( $model );
+
+	expect( $source->resolve( $ctx, [] ) )->toBeNull()
+		->and( $source->resolve( $ctx, [ 'key' => '' ] ) )->toBeNull();
+} );
+
+it( 'reads a column off the parent model', function () {
+	$model = TestBindingsModel::query()->create( [
+		'title'   => 'Hello',
+		'status'  => 'published',
+		'excerpt' => 'Short summary',
+		'content' => [],
+	] );
+
+	$source = new CustomFieldSource();
+
+	expect( $source->resolve( new BindingContext( $model ), [ 'key' => 'excerpt' ] ) )
+		->toBe( 'Short summary' );
+} );
+
+it( 'prefers the draft value over the saved column', function () {
+	$model = TestBindingsModel::query()->create( [
+		'title'   => 'Saved',
+		'status'  => 'published',
+		'content' => [],
+	] );
+
+	$source = new CustomFieldSource();
+
+	$ctx = new BindingContext( $model, [ 'title' => 'Unsaved Draft' ] );
+
+	expect( $source->resolve( $ctx, [ 'key' => 'title' ] ) )->toBe( 'Unsaved Draft' );
+} );
+
+it( 'returns null when the column does not exist on the model', function () {
+	$model = TestBindingsModel::query()->create( [
+		'title'   => 'X',
+		'status'  => 'published',
+		'content' => [],
+	] );
+
+	$source = new CustomFieldSource();
+
+	expect( $source->resolve( new BindingContext( $model ), [ 'key' => 'no_such_column' ] ) )->toBeNull();
+} );
+
+it( 'declares no eager-load relations', function () {
+	expect( ( new CustomFieldSource() )->eagerLoadRelations( [ [ 'key' => 'whatever' ] ] ) )->toBe( [] );
+} );

--- a/tests/Unit/VisualEditor/Bindings/Sources/CustomFieldSourceTest.php
+++ b/tests/Unit/VisualEditor/Bindings/Sources/CustomFieldSourceTest.php
@@ -49,6 +49,23 @@ it( 'prefers the draft value over the saved column', function () {
 	expect( $source->resolve( $ctx, [ 'key' => 'title' ] ) )->toBe( 'Unsaved Draft' );
 } );
 
+it( 'honors an explicit empty draft entry instead of falling through to saved value', function () {
+	$model = TestBindingsModel::query()->create( [
+		'title'   => 'Saved',
+		'status'  => 'published',
+		'content' => [],
+	] );
+
+	$source = new CustomFieldSource();
+
+	// User cleared the field in the editor — draft has an explicit
+	// null entry. The source must return null so the resolver's
+	// empty-value policy fires instead of resurrecting the saved value.
+	$ctx = new BindingContext( $model, [ 'title' => null ] );
+
+	expect( $source->resolve( $ctx, [ 'key' => 'title' ] ) )->toBeNull();
+} );
+
 it( 'returns null when the column does not exist on the model', function () {
 	$model = TestBindingsModel::query()->create( [
 		'title'   => 'X',

--- a/tests/Unit/VisualEditor/Bindings/Sources/PostCoreSourceTest.php
+++ b/tests/Unit/VisualEditor/Bindings/Sources/PostCoreSourceTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Services\Bindings\BindingContext;
+use ArtisanPackUI\VisualEditor\Services\Bindings\Sources\PostCoreSource;
+use Tests\Fixtures\TestBindingsModel;
+use Tests\TestUser;
+
+it( 'returns null when no model is in scope', function () {
+	$source = new PostCoreSource();
+
+	expect( $source->resolve( new BindingContext(), [ 'key' => 'title' ] ) )->toBeNull();
+} );
+
+it( 'reads the title off the parent model', function () {
+	$model = TestBindingsModel::query()->create( [
+		'title'   => 'Welcome',
+		'status'  => 'published',
+		'content' => [],
+	] );
+
+	$source = new PostCoreSource();
+
+	expect( $source->resolve( new BindingContext( $model ), [ 'key' => 'title' ] ) )->toBe( 'Welcome' );
+} );
+
+it( 'prefers a draft value over the saved column', function () {
+	$model = TestBindingsModel::query()->create( [
+		'title'   => 'Saved Title',
+		'status'  => 'published',
+		'content' => [],
+	] );
+
+	$source = new PostCoreSource();
+
+	$ctx = new BindingContext( $model, [ 'title' => 'Editor Draft' ] );
+
+	expect( $source->resolve( $ctx, [ 'key' => 'title' ] ) )->toBe( 'Editor Draft' );
+} );
+
+it( 'resolves the author name via the belongsTo relation', function () {
+	$author = TestUser::query()->create( [
+		'name'     => 'Ada Lovelace',
+		'email'    => 'ada+' . uniqid() . '@example.com',
+		'password' => 'secret',
+	] );
+
+	$model = TestBindingsModel::query()->create( [
+		'title'     => 'X',
+		'status'    => 'published',
+		'author_id' => $author->getKey(),
+		'content'   => [],
+	] );
+
+	$source = new PostCoreSource();
+
+	expect( $source->resolve( new BindingContext( $model ), [ 'key' => 'author_name' ] ) )
+		->toBe( 'Ada Lovelace' );
+} );
+
+it( 'declares the author relation for eager-loading when author_name is bound', function () {
+	$source = new PostCoreSource();
+
+	expect( $source->eagerLoadRelations( [ [ 'key' => 'author_name' ] ] ) )->toBe( [ 'author' ] );
+} );
+
+it( 'declares no relations when only title or excerpt is bound', function () {
+	$source = new PostCoreSource();
+
+	expect( $source->eagerLoadRelations( [ [ 'key' => 'title' ], [ 'key' => 'excerpt' ] ] ) )->toBe( [] );
+} );
+
+it( 'returns null when the key is empty', function () {
+	$source = new PostCoreSource();
+	$model  = new TestBindingsModel( [ 'title' => 'X' ] );
+
+	expect( $source->resolve( new BindingContext( $model ), [] ) )->toBeNull()
+		->and( $source->resolve( new BindingContext( $model ), [ 'key' => '' ] ) )->toBeNull();
+} );
+
+it( 'refuses to resolve a key that is not in the supported whitelist', function () {
+	$model = TestBindingsModel::query()->create( [
+		'title'     => 'X',
+		'status'    => 'published',
+		'author_id' => 999,
+		'content'   => [],
+	] );
+
+	$source = new PostCoreSource();
+
+	// `author_id` is a real column on the model but is not in
+	// SUPPORTED_FIELDS — the source should refuse to expose it via the
+	// binding layer.
+	expect( $source->resolve( new BindingContext( $model ), [ 'key' => 'author_id' ] ) )->toBeNull();
+} );

--- a/tests/Unit/VisualEditor/Bindings/Sources/RelationSourceTest.php
+++ b/tests/Unit/VisualEditor/Bindings/Sources/RelationSourceTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Services\Bindings\BindingContext;
+use ArtisanPackUI\VisualEditor\Services\Bindings\Sources\RelationSource;
+use Tests\Fixtures\TestBindingsModel;
+use Tests\TestUser;
+
+it( 'returns null when no model is in scope', function () {
+	$source = new RelationSource();
+
+	expect( $source->resolve( new BindingContext(), [ 'path' => 'author.name' ] ) )->toBeNull();
+} );
+
+it( 'returns null when path is missing or empty', function () {
+	$source = new RelationSource();
+	$model  = new TestBindingsModel( [ 'title' => 'X' ] );
+
+	expect( $source->resolve( new BindingContext( $model ), [] ) )->toBeNull()
+		->and( $source->resolve( new BindingContext( $model ), [ 'path' => '   ' ] ) )->toBeNull();
+} );
+
+it( 'walks a single-segment path to a column', function () {
+	$model = TestBindingsModel::query()->create( [
+		'title'   => 'Welcome',
+		'status'  => 'published',
+		'content' => [],
+	] );
+
+	$source = new RelationSource();
+
+	expect( $source->resolve( new BindingContext( $model ), [ 'path' => 'title' ] ) )->toBe( 'Welcome' );
+} );
+
+it( 'walks a two-segment path across a belongsTo relation', function () {
+	$author = TestUser::query()->create( [
+		'name'     => 'Grace Hopper',
+		'email'    => 'grace+' . uniqid() . '@example.com',
+		'password' => 'secret',
+	] );
+
+	$model = TestBindingsModel::query()->create( [
+		'title'     => 'X',
+		'status'    => 'published',
+		'author_id' => $author->getKey(),
+		'content'   => [],
+	] );
+
+	$source = new RelationSource();
+
+	expect( $source->resolve( new BindingContext( $model ), [ 'path' => 'author.name' ] ) )
+		->toBe( 'Grace Hopper' );
+} );
+
+it( 'returns null when a non-leaf segment dead-ends', function () {
+	$model = TestBindingsModel::query()->create( [
+		'title'     => 'Orphan',
+		'status'    => 'published',
+		'author_id' => null,
+		'content'   => [],
+	] );
+
+	$source = new RelationSource();
+
+	expect( $source->resolve( new BindingContext( $model ), [ 'path' => 'author.name' ] ) )->toBeNull();
+} );
+
+it( 'declares the relation chain for eager-loading (drops the leaf segment)', function () {
+	$source = new RelationSource();
+
+	expect( $source->eagerLoadRelations( [ [ 'path' => 'author.name' ] ] ) )->toBe( [ 'author' ] );
+} );
+
+it( 'declares the nested relation chain', function () {
+	$source = new RelationSource();
+
+	expect( $source->eagerLoadRelations( [ [ 'path' => 'author.profile.display_name' ] ] ) )
+		->toBe( [ 'author.profile' ] );
+} );
+
+it( 'declares no relation when the path has only one segment', function () {
+	$source = new RelationSource();
+
+	expect( $source->eagerLoadRelations( [ [ 'path' => 'title' ] ] ) )->toBe( [] );
+} );
+
+it( 'stops at a numeric segment when computing eager-loads', function () {
+	$source = new RelationSource();
+
+	expect( $source->eagerLoadRelations( [ [ 'path' => 'categories.0.name' ] ] ) )
+		->toBe( [ 'categories' ] );
+} );
+
+it( 'returns a value from an array on the model', function () {
+	$model = TestBindingsModel::query()->create( [
+		'title'   => 'Y',
+		'status'  => 'published',
+		'content' => [ 'meta' => [ 'tone' => 'casual' ] ],
+	] );
+
+	$source = new RelationSource();
+
+	expect( $source->resolve( new BindingContext( $model ), [ 'path' => 'content.meta' ] ) )
+		->toBe( [ 'tone' => 'casual' ] );
+} );
+
+it( 'deduplicates eager-load entries across many bindings on the same chain', function () {
+	$source = new RelationSource();
+
+	$paths = [
+		[ 'path' => 'author.name' ],
+		[ 'path' => 'author.email' ],
+		[ 'path' => 'author.profile.bio' ],
+	];
+
+	expect( $source->eagerLoadRelations( $paths ) )->toBe( [ 'author', 'author.profile' ] );
+} );


### PR DESCRIPTION
## Description

Server foundation + inspector UI for binding any scalar / `object` / `rich-text` block attribute to data on the parent post, page, or CPT. The block tree without bindings serializes byte-identical to today; bindings live in a sidecar `bindings` map on each block and resolve at render time.

**Closes:** #504

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #504

## Motivation and Context

Until now, every block attribute (icon name, heading string, image URL) was hard-coded into the block instance when the editor saved. There was no way for a block to pull its value from data already attached to the post/page being edited — so authors had to keep block content in sync with the parent record's metadata by hand, and reusable templates couldn't display per-post data. This change introduces a binding layer that closes that gap and is wired against the `cms-framework` custom-field model.

## Changes Made

**Server layer**
- `BlockBindingSource` contract + `BlockBindingSourceRegistry` so hosts and third-party packages can register custom source drivers.
- Built-in drivers: `custom_field` (cms-framework columns), `post_core` (whitelisted columns + author shortcut, validated against `SUPPORTED_FIELDS`), `relation` (dotted-path walker with eager-load hints).
- `BindingResolver`: walks the tree once per render pass, batches the parent-model load + every source's eager-load relations, then rewrites `attrs` before the renderer sees them. Trees without bindings round-trip byte-identically.
- Empty-value policies: `fallback` (default), `hide`, `placeholder`.
- `BlockPreviewController` accepts a binding context (resource + id + draft snapshot) and runs the resolver before delegating to the dynamic block.
- New endpoints: `GET /bindings/sources`, `GET /bindings/sources/{source}/fields`, `POST /bindings/resolve` for the inspector's picker + canvas live preview.

**Editor layer (React, reused by the Inertia+Vue wrapper)**
- `bindings` sidecar attribute auto-injected on every block via a `blocks.registerBlockType` filter.
- `BindingsPanel` rendered into every block's inspector via an `editor.BlockEdit` HOC — per-attribute toggle reveals the source select, field picker, empty-policy controls, and the `allowIncompatible` override.
- Type compatibility tuned for real-world cms-framework field shapes: `string` / `rich-text` / `object` / `array` attributes accept anything by default; numeric and boolean stay strict.
- `useResolvedBindings` hook overlays resolved values onto the block's edit-time attrs so the editor canvas reflects the binding without waiting for a frontend render pass (debounced 250 ms).

**Out of scope (intentional follow-ups)**
- Two-way binding (writing block edits back to custom fields).
- Visual "data inspector" listing every available field.
- Repeater / multi-row custom field bindings.
- Conditional-logic block visibility.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS 25.5.0
- Browser: Safari, Chrome
- PHP Version: 8.4.3
- Project Version: `release/1.1`

**Tests Performed:**
1. Resolver playground page in the dev app (`/test-bindings`) — verified each source driver against a real `Post` model, including the empty-value policies and unknown-source fallback.
2. Full editor round-trip: bound the `iconRef` of an Icon block on Post #1 to the `featured_icon` cms-framework custom field (`{set:"fas",name:"star"}`); confirmed the canvas swapped in the star within ~250 ms.
3. Full editor round-trip: bound a Heading block's `content (rich-text)` to `post_core → Title`; canvas updated to the post title.
4. Confirmed BC: existing blocks without bindings serialize and render identically (regression test).

## Accessibility Tests Run

- [ ] Keyboard navigation tested
- [ ] Screen reader tested
- [ ] Color contrast verified
- [ ] ARIA labels checked

**Details:** Inspector controls use standard `@wordpress/components` (`PanelBody`, `ToggleControl`, `SelectControl`, `TextControl`) which already meet the package's accessibility baseline. Dedicated keyboard / screen-reader verification deferred to a follow-up sweep alongside the broader inspector audit.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:**
- 22 new PHP tests (1257 total passing); 13 new JS tests (2083 total passing).
- Resolver coverage includes the BC-regression case, every empty-value policy, unknown-source fallback, and an N+1 assertion: a 25-block tree loads the parent model 0 times and eager-loaded relations exactly once.
- Feature tests cover preview, sources, resolve endpoints + host-registered custom drivers + draft snapshots.
- The 2 pre-existing `FontAwesomeFreeIconSetsTest` failures are unrelated to this branch (noted in the package's `CLAUDE.md`).

## Documentation

- [x] Inline code documentation added
- [ ] README updated
- [ ] Wiki updated
- [ ] API documentation updated

**Documentation details:** Each new class / function has a PHPDoc or TSDoc block covering shape, lifecycle, and the contract guarantees the resolver makes. A dedicated wiki page on the binding layer (storage shape, extension API, worked third-party-source example) is a follow-up — flagged in the issue's task list and will land as a separate docs PR.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [ ] Accessibility tests completed (see note above)
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a block bindings inspector panel to configure attribute bindings in the visual editor.
  * Introduced built-in binding sources for custom fields, post core fields, and relation path lookups.
  * Enabled editor-time live preview by resolving bindings using the current resource/context, including draft overrides and empty-value behavior.
  * Added API endpoints to list binding sources, fetch available fields per source, and resolve bindings for preview.
* **Tests**
  * Extended automated coverage for the bindings UI, API endpoints, source drivers, resolver behavior, and eager-loading logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->