### PR TITLE
fix: route cover block background output to the overlay span (#583)

### DIFF
--- a/packages/visual-editor-renderer-blade/resources/views/blocks/core/cover.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/core/cover.blade.php
@@ -73,9 +73,35 @@
 
 	// Merge cover's own `min-height` declaration with whatever
 	// block-supports style emerges from compile().
-	$compiled = BlockSupports::compile( $attributes );
-	$classes  = array_values( array_unique( array_merge( $baseClasses, $compiled['classes'] ) ) );
-	$style    = '' !== $compiled['style'] ? rtrim( $compiled['style'], ';' ) : '';
+	//
+	// #583 — cover paints its background on the overlay span, not the
+	// outer wrapper. Route palette / gradient / custom background
+	// output (classes + inline declarations) onto the overlay; keep
+	// everything else (layout, alignment, text color, anchor, border,
+	// spacing, typography, animations) on the wrapper. Cover-specific
+	// overlay attributes (`overlayColor`, `customOverlayColor`,
+	// `customGradient`) bypass `compile`'s generic color slots, so
+	// `compileCoverOverlay` re-emits them straight into the overlay
+	// bucket.
+	$compiled     = BlockSupports::compile( $attributes );
+	$split        = BlockSupports::splitBackgroundOutput( $compiled['classes'], $compiled['style'] );
+	$coverOverlay = BlockSupports::compileCoverOverlay( $attributes );
+
+	$overlayBackgroundClasses = array_values( array_unique( array_merge(
+		$split['background']['classes'],
+		$coverOverlay['classes']
+	) ) );
+
+	$overlayBackgroundStyleParts = array_filter(
+		[ rtrim( $split['background']['style'], ';' ), rtrim( $coverOverlay['style'], ';' ) ],
+		static fn ( string $part ): bool => '' !== $part,
+	);
+	$overlayBackgroundStyle      = [] === $overlayBackgroundStyleParts
+		? ''
+		: implode( '; ', $overlayBackgroundStyleParts ) . ';';
+
+	$classes  = array_values( array_unique( array_merge( $baseClasses, $split['wrapper']['classes'] ) ) );
+	$style    = '' !== $split['wrapper']['style'] ? rtrim( $split['wrapper']['style'], ';' ) : '';
 
 	if ( null !== $minHeight ) {
 		$style = ( '' !== $style ? $style . '; ' : '' ) . sprintf( 'min-height: %s%s', (string) $minHeight, $minHeightUnit );
@@ -83,6 +109,27 @@
 
 	$styleAttr = '' !== $style ? sprintf( ' style="%s"', e( $style . ';' ) ) : '';
 	$idAttr    = null !== $compiled['id'] ? sprintf( ' id="%s"', e( $compiled['id'] ) ) : '';
+
+	// #583 — assemble the overlay span's class + style attributes
+	// from the routed background output. `has-background-dim` and
+	// the cover-specific opacity declaration are always present;
+	// palette / gradient / custom background classes append after,
+	// custom background declarations append to the inline style.
+	$overlayClassList = array_values( array_filter(
+		array_merge(
+			[ 'wp-block-cover__background', 'has-background-dim' ],
+			$overlayBackgroundClasses
+		),
+		static fn ( string $token ): bool => '' !== trim( $token ),
+	) );
+
+	$overlayStyleDeclarations = [ sprintf( 'opacity: %s', $dimRatio / 100 ) ];
+
+	if ( '' !== $overlayBackgroundStyle ) {
+		$overlayStyleDeclarations[] = rtrim( $overlayBackgroundStyle, ';' );
+	}
+
+	$overlayStyle = implode( '; ', $overlayStyleDeclarations ) . ';';
 
 	// #489 — resolve any block-animation attribute bag, attach the
 	// wrapper classes + data attributes, and push the per-block CSS
@@ -130,7 +177,7 @@
 	}
 @endphp
 <div class="{{ implode( ' ', $classes ) }}"{!! $styleAttr !!}{!! $idAttr !!}{!! $animationsString !!}>
-	<span aria-hidden="true" class="wp-block-cover__background has-background-dim" style="opacity: {{ $dimRatio / 100 }};"></span>
+	<span aria-hidden="true" class="{{ implode( ' ', $overlayClassList ) }}" style="{{ $overlayStyle }}"></span>
 	@if ( '' !== $url )
 		<img class="wp-block-cover__image-background" alt="{{ $alt }}" src="{{ $url }}"/>
 	@endif

--- a/packages/visual-editor-renderer-blade/src/Support/BlockSupports.php
+++ b/packages/visual-editor-renderer-blade/src/Support/BlockSupports.php
@@ -274,6 +274,229 @@ class BlockSupports
 	}
 
 	/**
+	 * Split {@see compile}'s class / style output into a `background`
+	 * bucket and a `wrapper` bucket (#583).
+	 *
+	 * Most blocks paint their background on the same element that
+	 * carries the wrapper class — so {@see wrapperAttrs} just merges
+	 * everything onto that element and the partial never needs to
+	 * worry about routing. The `core/cover` block is the exception:
+	 * the painted surface is the `wp-block-cover__background` overlay
+	 * span layered on top of the image, not the outer `<div>`. Background
+	 * classes / inline declarations applied to the wrapper sit behind
+	 * the image and never render. This helper carves the
+	 * background-affecting output out of `compile`'s return so the
+	 * cover partial can route it onto the overlay while keeping
+	 * everything else (layout, alignment, text color, anchor, border,
+	 * spacing, typography, animations) on the wrapper.
+	 *
+	 * Classes routed to the `background` bucket:
+	 * - `has-background` marker.
+	 * - `has-{slug}-background-color` (palette background slug).
+	 * - `has-{slug}-gradient-background` (palette gradient slug).
+	 *
+	 * Inline declarations routed to the `background` bucket:
+	 * - `background-color: ...`
+	 * - `background-image: ...`
+	 * - `background: ...` (shorthand / custom gradient).
+	 *
+	 * Every other class / declaration is kept in the `wrapper` bucket
+	 * untouched.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param  array<int, string>  $classes  `compile`'s `classes` return.
+	 * @param  string              $style    `compile`'s `style` return
+	 *                                       (semicolon-separated
+	 *                                       declaration list).
+	 *
+	 * @return array{
+	 *     background: array{classes: array<int, string>, style: string},
+	 *     wrapper:    array{classes: array<int, string>, style: string},
+	 * }
+	 */
+	public static function splitBackgroundOutput( array $classes, string $style ): array
+	{
+		$backgroundClasses = [];
+		$wrapperClasses    = [];
+
+		foreach ( $classes as $class ) {
+			if ( ! is_string( $class ) ) {
+				continue;
+			}
+
+			if ( self::isBackgroundClass( $class ) ) {
+				$backgroundClasses[] = $class;
+
+				continue;
+			}
+
+			$wrapperClasses[] = $class;
+		}
+
+		[ $backgroundStyle, $wrapperStyle ] = self::partitionBackgroundStyle( $style );
+
+		return [
+			'background' => [
+				'classes' => $backgroundClasses,
+				'style'   => $backgroundStyle,
+			],
+			'wrapper'    => [
+				'classes' => $wrapperClasses,
+				'style'   => $wrapperStyle,
+			],
+		];
+	}
+
+	/**
+	 * Compile the cover block's overlay-specific color / gradient
+	 * attributes into a `{classes, style}` bundle the cover partial
+	 * merges into the overlay span (#583).
+	 *
+	 * The cover block stores its overlay color under bespoke top-level
+	 * attribute names (`overlayColor`, `customOverlayColor`,
+	 * `customGradient`) instead of the generic `backgroundColor` /
+	 * `style.color.background` slots that {@see compile} understands.
+	 * Without this helper those values land on neither the wrapper nor
+	 * the overlay — they're silently dropped — because `compile`
+	 * doesn't look at the cover-only attribute names. The `gradient`
+	 * palette slug shares its attribute name with the generic block-
+	 * supports input, so it already flows through `compile` → split →
+	 * overlay and is intentionally NOT re-emitted here.
+	 *
+	 * Precedence (matches WordPress core's `render_block_core_cover`):
+	 * palette `overlayColor` wins over `customOverlayColor`; the
+	 * `customGradient` declaration layers on top of either color
+	 * because `background` shorthand and `background-color` map to
+	 * different cascade slots on the overlay span.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param  array<string, mixed>  $attributes
+	 *
+	 * @return array{classes: array<int, string>, style: string}
+	 */
+	public static function compileCoverOverlay( array $attributes ): array
+	{
+		$classes = [];
+		$style   = [];
+
+		$overlaySlug      = self::stringAttr( $attributes['overlayColor'] ?? null );
+		$customOverlay    = self::stringAttr( $attributes['customOverlayColor'] ?? null );
+		$customGradient   = self::stringAttr( $attributes['customGradient'] ?? null );
+
+		if ( '' !== $overlaySlug ) {
+			$classes[] = 'has-' . self::slugify( $overlaySlug ) . '-background-color';
+			$classes[] = 'has-background';
+		} elseif ( '' !== $customOverlay ) {
+			$style[]   = 'background-color: ' . self::expandPresetReference( $customOverlay );
+			$classes[] = 'has-background';
+		}
+
+		if ( '' !== $customGradient ) {
+			$style[]   = 'background: ' . self::expandPresetReference( $customGradient );
+			$classes[] = 'has-background';
+		}
+
+		return [
+			'classes' => array_values( array_unique( $classes ) ),
+			'style'   => [] === $style ? '' : implode( '; ', $style ) . ';',
+		];
+	}
+
+	/**
+	 * Identify the class tokens emitted by {@see applyColor} that
+	 * correspond to background painting — the `has-background` marker
+	 * and the slug-derived `has-{slug}-background-color` /
+	 * `has-{slug}-gradient-background` classes. Text-color classes
+	 * (`has-text-color`, `has-{slug}-color`) and every non-color class
+	 * fall through to `false` so they stay on the wrapper.
+	 *
+	 * @since 1.1.0
+	 */
+	protected static function isBackgroundClass( string $class ): bool
+	{
+		if ( 'has-background' === $class ) {
+			return true;
+		}
+
+		return 1 === preg_match(
+			'/^has-[a-z0-9](?:[a-z0-9-]*[a-z0-9])?-(?:background-color|gradient-background)$/',
+			$class
+		);
+	}
+
+	/**
+	 * Carve `background-color`, `background-image`, and shorthand
+	 * `background` declarations out of a semicolon-separated style
+	 * string, returning `[backgroundStyle, wrapperStyle]`. Each output
+	 * string is `;`-suffixed iff non-empty so callers can splice them
+	 * back into a wrapper attribute without re-checking emptiness.
+	 *
+	 * Declarations with a leading custom-property name (e.g.
+	 * `--wp--style--block-gap`) are NOT background output and stay on
+	 * the wrapper.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return array{0: string, 1: string}
+	 */
+	protected static function partitionBackgroundStyle( string $style ): array
+	{
+		if ( '' === $style ) {
+			return [ '', '' ];
+		}
+
+		$background = [];
+		$wrapper    = [];
+
+		foreach ( explode( ';', rtrim( $style, ';' ) ) as $declaration ) {
+			$declaration = trim( $declaration );
+
+			if ( '' === $declaration ) {
+				continue;
+			}
+
+			if ( self::isBackgroundDeclaration( $declaration ) ) {
+				$background[] = $declaration;
+
+				continue;
+			}
+
+			$wrapper[] = $declaration;
+		}
+
+		$backgroundString = [] === $background ? '' : implode( '; ', $background ) . ';';
+		$wrapperString    = [] === $wrapper    ? '' : implode( '; ', $wrapper )    . ';';
+
+		return [ $backgroundString, $wrapperString ];
+	}
+
+	/**
+	 * Check a single trimmed CSS declaration for a `background-color`,
+	 * `background-image`, or shorthand `background` property name. The
+	 * match is anchored to the property — declarations with a value
+	 * containing the literal `background` keyword (e.g.
+	 * `transition: background 200ms`) are left on the wrapper.
+	 *
+	 * @since 1.1.0
+	 */
+	protected static function isBackgroundDeclaration( string $declaration ): bool
+	{
+		$colonPosition = strpos( $declaration, ':' );
+
+		if ( false === $colonPosition ) {
+			return false;
+		}
+
+		$property = strtolower( rtrim( substr( $declaration, 0, $colonPosition ) ) );
+
+		return 'background' === $property
+			|| 'background-color' === $property
+			|| 'background-image' === $property;
+	}
+
+	/**
 	 * Apply the gradient border feature to an already-rendered block's
 	 * HTML output (#490).
 	 *

--- a/packages/visual-editor-renderer-blade/tests/Unit/BlockRendererTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Unit/BlockRendererTest.php
@@ -420,6 +420,147 @@ it( 'clamps cover dimRatio to 0-100 and whitelists minHeightUnit', function () {
 		->not->toContain( 'javascript:' );
 } );
 
+it( 'routes cover palette gradient class to the overlay span, not the wrapper', function () {
+	$tree = [
+		makeBlock( 'core/cover', [
+			'gradient' => 'sunset',
+			'dimRatio' => 50,
+		] ),
+	];
+
+	$html = makeRenderer()->render( $tree );
+
+	preg_match( '/<div class="([^"]*wp-block-cover[^"]*)"/', $html, $wrapperMatches );
+	preg_match( '/<span aria-hidden="true" class="([^"]*wp-block-cover__background[^"]*)"/', $html, $overlayMatches );
+
+	$wrapperClasses = $wrapperMatches[1] ?? '';
+	$overlayClasses = $overlayMatches[1] ?? '';
+
+	expect( $overlayClasses )->toContain( 'has-sunset-gradient-background' )
+		->toContain( 'has-background' );
+
+	expect( $wrapperClasses )->not->toContain( 'has-sunset-gradient-background' )
+		->not->toContain( 'has-background' );
+} );
+
+it( 'routes cover custom background-color inline declaration to the overlay span', function () {
+	$tree = [
+		makeBlock( 'core/cover', [
+			'style'    => [ 'color' => [ 'background' => '#bada55' ] ],
+			'dimRatio' => 40,
+		] ),
+	];
+
+	$html = makeRenderer()->render( $tree );
+
+	preg_match( '/<div class="[^"]*wp-block-cover[^"]*"([^>]*)>/', $html, $wrapperMatches );
+	preg_match( '/<span aria-hidden="true"[^>]*style="([^"]*)"/', $html, $overlayMatches );
+
+	$wrapperAttrs = $wrapperMatches[1] ?? '';
+	$overlayStyle = $overlayMatches[1] ?? '';
+
+	expect( $overlayStyle )->toContain( 'background-color: #bada55' )
+		->toContain( 'opacity: 0.4' );
+
+	expect( $wrapperAttrs )->not->toContain( 'background-color' )
+		->not->toContain( '#bada55' );
+} );
+
+it( 'routes cover overlayColor palette slug to the overlay span', function () {
+	$tree = [
+		makeBlock( 'core/cover', [
+			'overlayColor' => 'primary',
+			'dimRatio'     => 60,
+		] ),
+	];
+
+	$html = makeRenderer()->render( $tree );
+
+	preg_match( '/<div class="([^"]*wp-block-cover[^"]*)"/', $html, $wrapperMatches );
+	preg_match( '/<span aria-hidden="true" class="([^"]*wp-block-cover__background[^"]*)"/', $html, $overlayMatches );
+
+	$wrapperClasses = $wrapperMatches[1] ?? '';
+	$overlayClasses = $overlayMatches[1] ?? '';
+
+	expect( $overlayClasses )->toContain( 'has-primary-background-color' )
+		->toContain( 'has-background' );
+
+	expect( $wrapperClasses )->not->toContain( 'has-primary-background-color' )
+		->not->toContain( 'has-background' );
+} );
+
+it( 'routes cover customOverlayColor inline declaration to the overlay span', function () {
+	$tree = [
+		makeBlock( 'core/cover', [
+			'customOverlayColor' => '#eb3824',
+			'dimRatio'           => 50,
+		] ),
+	];
+
+	$html = makeRenderer()->render( $tree );
+
+	preg_match( '/<div class="[^"]*wp-block-cover[^"]*"([^>]*)>/', $html, $wrapperMatches );
+	preg_match( '/<span aria-hidden="true" class="([^"]*wp-block-cover__background[^"]*)"[^>]*style="([^"]*)"/', $html, $overlayMatches );
+
+	$wrapperAttrs   = $wrapperMatches[1] ?? '';
+	$overlayClasses = $overlayMatches[1] ?? '';
+	$overlayStyle   = $overlayMatches[2] ?? '';
+
+	expect( $overlayStyle )->toContain( 'background-color: #eb3824' )
+		->toContain( 'opacity: 0.5' );
+	expect( $overlayClasses )->toContain( 'has-background' );
+
+	expect( $wrapperAttrs )->not->toContain( '#eb3824' )
+		->not->toContain( 'has-background' );
+} );
+
+it( 'routes cover customGradient inline declaration to the overlay span', function () {
+	$tree = [
+		makeBlock( 'core/cover', [
+			'customGradient' => 'linear-gradient(135deg, red, blue)',
+			'dimRatio'       => 50,
+		] ),
+	];
+
+	$html = makeRenderer()->render( $tree );
+
+	preg_match( '/<div class="[^"]*wp-block-cover[^"]*"([^>]*)>/', $html, $wrapperMatches );
+	preg_match( '/<span aria-hidden="true" class="([^"]*wp-block-cover__background[^"]*)"[^>]*style="([^"]*)"/', $html, $overlayMatches );
+
+	$wrapperAttrs   = $wrapperMatches[1] ?? '';
+	$overlayClasses = $overlayMatches[1] ?? '';
+	$overlayStyle   = $overlayMatches[2] ?? '';
+
+	expect( $overlayStyle )->toContain( 'background: linear-gradient(135deg, red, blue)' );
+	expect( $overlayClasses )->toContain( 'has-background' );
+
+	expect( $wrapperAttrs )->not->toContain( 'linear-gradient' )
+		->not->toContain( 'has-background' );
+} );
+
+it( 'keeps cover text-color output on the wrapper, not the overlay span', function () {
+	$tree = [
+		makeBlock( 'core/cover', [
+			'textColor' => 'midnight',
+			'dimRatio'  => 50,
+		] ),
+	];
+
+	$html = makeRenderer()->render( $tree );
+
+	preg_match( '/<div class="([^"]*wp-block-cover[^"]*)"/', $html, $wrapperMatches );
+	preg_match( '/<span aria-hidden="true" class="([^"]*wp-block-cover__background[^"]*)"/', $html, $overlayMatches );
+
+	$wrapperClasses = $wrapperMatches[1] ?? '';
+	$overlayClasses = $overlayMatches[1] ?? '';
+
+	expect( $wrapperClasses )->toContain( 'has-midnight-color' )
+		->toContain( 'has-text-color' );
+
+	expect( $overlayClasses )->not->toContain( 'has-midnight-color' )
+		->not->toContain( 'has-text-color' );
+} );
+
 it( 'validates table cell alignment against an allowlist', function () {
 	$tree = [
 		makeBlock( 'core/table', [


### PR DESCRIPTION
## Description

`core/cover` (and the delegating `artisanpack/cover`) paints its background on the `wp-block-cover__background` overlay span layered over the image — not the outer wrapper. Previously the generic block-supports output (`has-{slug}-background-color`, `has-{slug}-gradient-background`, `has-background`, custom background inline declarations) landed on the wrapper where the image hid it, and the cover-specific overlay attributes (`overlayColor`, `customOverlayColor`, `customGradient`) were silently dropped because `BlockSupports::compile` doesn't read them.

**Closes:** #583

## Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds new functionality)
- [ ] Enhancement (improves existing functionality)
- [ ] Refactoring (code improvement, no behavior change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Security fix
- [ ] Breaking change (breaks backward compatibility)

## Related Issue

**Issue:** #583

## Motivation and Context

When a cover block had a palette gradient, a custom background color, or any other overlay color set, the user-selected background was invisible behind the featured image because the background classes / inline styles were applied to the outer wrapper instead of the overlay span. Moving them onto the span via browser inspector reproduced the correct rendered output, confirming the routing was the bug.

The fix also handles the cover-specific overlay attribute names that the generic block-supports compiler doesn't know about (`overlayColor`, `customOverlayColor`, `customGradient`) — without this, three of the four overlay-color UX paths in the editor produced no visible overlay at all.

## Changes Made

- Add `BlockSupports::splitBackgroundOutput()` — carves background classes / inline declarations out of `compile()`'s return into a `background` bucket vs a `wrapper` bucket. Background classes match `has-background`, `has-{slug}-background-color`, and `has-{slug}-gradient-background`; declarations match `background-color`, `background-image`, and shorthand `background`.
- Add `BlockSupports::compileCoverOverlay()` — translates the cover-only `overlayColor` / `customOverlayColor` / `customGradient` attributes into the same overlay bucket so they appear on the span.
- Rewire `resources/views/blocks/core/cover.blade.php` to merge both buckets onto the overlay span (`wp-block-cover__background has-background-dim …`) while keeping layout / alignment / text color / anchor / border / spacing / typography / animations on the outer wrapper exactly as before. `artisanpack/cover` delegates to the same partial and picks up the fix for free.
- Add four regression tests in `BlockRendererTest`:
  - cover palette gradient lands on the overlay span, not the wrapper
  - cover custom `style.color.background` inline declaration lands on the overlay span
  - cover `overlayColor` palette slug lands on the overlay span
  - cover `customOverlayColor` inline declaration lands on the overlay span
  - cover `customGradient` inline declaration lands on the overlay span
  - cover `textColor` stays on the wrapper (no over-correction)

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS 25.5.0
- Browser: Safari / Chrome
- PHP Version: 8.4.3
- Project Version: `release/1.1`

**Tests Performed:**
1. Ran the full `visual-editor-renderer-blade` Pest suite — 322 passed (892 assertions).
2. Manually exercised the four overlay scenarios on the M9 Blade preview at `/admin/packages/visual-editor/standalone/renderer?stack=livewire&post={id}`:
   - palette `overlayColor` (e.g. `primary`) → overlay carries `has-{slug}-background-color has-background`
   - `customOverlayColor` (e.g. `#eb3824`) → overlay carries `has-background` + inline `background-color`
   - palette `gradient` (e.g. `sunset`) → overlay carries `has-{slug}-gradient-background has-background`
   - `customGradient` → overlay carries `has-background` + inline `background`
3. Verified `textColor` and other non-background block-supports output stays on the outer wrapper.

## Accessibility Tests Run

- [ ] Keyboard navigation tested
- [ ] Screen reader tested
- [x] Color contrast verified
- [ ] ARIA labels checked

**Details:** No interactive surface changed — only the element that carries the background color/gradient. The overlay span is `aria-hidden="true"` (unchanged), so screen-reader output is unaffected. Color-contrast against the inner content is governed by the same `textColor` / theme rules as before.

## Tests Added

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All tests passing

**Test details:** Six new test cases added to `tests/Unit/BlockRendererTest.php` covering every overlay-attribute path the cover block exposes plus a negative case for text color staying on the wrapper. Existing `it clamps cover dimRatio …` test still passes.

## Documentation

- [x] Inline code documentation added
- [ ] README updated
- [ ] Wiki updated
- [ ] API documentation updated

**Documentation details:** PHPDoc blocks on the two new public helpers (`splitBackgroundOutput`, `compileCoverOverlay`) explain the rationale, the precedence rules, and the WP-core parity. Inline comments in the cover partial mark the #583-driven rewiring.

## Screenshots

_None — rendering parity is verified by the new tests + the manual scenarios listed above._

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [x] Accessibility tests completed
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

## Out of Scope

Per #583, the React + Vue renderers don't apply `BlockSupports`-equivalent processing for the cover block at all (they render layout / alignment classes only and skip background classes / styles entirely). That's a broader gap that should get its own issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cover block background and overlay styling to properly separate style application between the wrapper and overlay elements, ensuring styles display on the correct component.

* **Tests**
  * Added unit tests to verify cover block style routing, including palette gradients, custom colors, and overlay color attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->