### PR TITLE
fix: avoid icon-prefix collision with owenvoke/blade-fontawesome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+- **Icon registration no longer collides with `owenvoke/blade-fontawesome`
+  (#587).** In consumer apps that pull both `artisanpack-ui/visual-editor`
+  and `owenvoke/blade-fontawesome` (the default path via
+  `livewire-ui-components`), the visual-editor's `fas` / `far` / `fab`
+  icon sets collided with the prefixes blade-fontawesome registers,
+  causing `BladeUI\Icons\Exceptions\CannotRegisterIconSet` on every
+  `<x-...>` render and breaking Blade-rendered routes and Livewire tests.
+  `FontAwesomeFreeIconSets::register()` now detects the blade-fontawesome
+  service provider and stops publishing the FA Free sets through
+  `ap.icons.register-icon-sets`, so the icons-package no longer forwards
+  the conflicting prefixes to `BladeUI\Icons\Factory::add()`. The
+  visual-editor's own `IconSvgResolver` seeds its FA Free path map
+  directly from `FontAwesomeFreeIconSets::discover()`, so the icon
+  picker preview and the rendered Icon Block still resolve the bundled
+  SVGs.
+
 ## [1.1.0] — 2026-06-14
 
 The 1.1.0 release ships the full `artisanpack/icon` block (Phases 1–7),

--- a/src/Services/Icon/FontAwesomeFreeIconSets.php
+++ b/src/Services/Icon/FontAwesomeFreeIconSets.php
@@ -40,6 +40,16 @@ final class FontAwesomeFreeIconSets
 	public const SET_PREFIXES = [ 'fas', 'far', 'fab' ];
 
 	/**
+	 * Fully-qualified class name of the `owenvoke/blade-fontawesome`
+	 * service provider. Kept as a literal string so the symbol is never
+	 * imported (and thus never triggers an autoload attempt) just to test
+	 * for the package's presence.
+	 *
+	 * @since 1.1.1
+	 */
+	private const BLADE_FONTAWESOME_PROVIDER = 'OwenVoke\\BladeFontAwesome\\BladeFontAwesomeServiceProvider';
+
+	/**
 	 * Return the absolute path for each FA Free set whose directory exists
 	 * under `$baseDir`. Missing sets are silently skipped so a partial
 	 * sync still surfaces the sets that did land.
@@ -67,9 +77,34 @@ final class FontAwesomeFreeIconSets
 	 * registry's `addSet()` throws when handed a non-existent path, which
 	 * is exactly why `discover()` filters them first — we want to no-op,
 	 * not blow up, when the FA Free directory is missing.
+	 *
+	 * When `owenvoke/blade-fontawesome` is installed, it already claims
+	 * the `fas` / `far` / `fab` prefixes via its own service provider and
+	 * `BladeUI\Icons\Factory::add()` rejects the duplicate registration
+	 * (issue #587). The blade-fontawesome bundle ships the same FA Free
+	 * SVG set, so deferring to it is a no-UX-regression workaround.
+	 *
+	 * `$bladeFontAwesomeProvider` is a test seam: callers can override
+	 * the class name probed by `class_exists()` so the skip path can be
+	 * exercised without loading the real package (or any stub of it) into
+	 * the autoloader.
+	 *
+	 * @param  string|null  $bladeFontAwesomeProvider  FQCN to probe for the
+	 *                                                 blade-fontawesome
+	 *                                                 service provider.
+	 *                                                 Defaults to the real
+	 *                                                 class name when null.
 	 */
-	public static function register( IconSetRegistration $registry, string $baseDir ): IconSetRegistration
-	{
+	public static function register(
+		IconSetRegistration $registry,
+		string $baseDir,
+		?string $bladeFontAwesomeProvider = null,
+	): IconSetRegistration {
+		$providerClass = $bladeFontAwesomeProvider ?? self::BLADE_FONTAWESOME_PROVIDER;
+		if ( class_exists( $providerClass ) ) {
+			return $registry;
+		}
+
 		foreach ( self::discover( $baseDir ) as $prefix => $path ) {
 			$registry->addSet( $path, $prefix );
 		}

--- a/src/VisualEditorServiceProvider.php
+++ b/src/VisualEditorServiceProvider.php
@@ -104,18 +104,31 @@ class VisualEditorServiceProvider extends ServiceProvider
 		// against those registrations and produce an empty resolver. The
 		// closure runs at request time, by which point boot is finished
 		// and the filter chain is complete.
-		$this->app->singleton( IconSvgResolver::class, function (): IconSvgResolver {
-			return new IconSvgResolver( static function (): array {
+		//
+		// Issue #587: when `owenvoke/blade-fontawesome` is installed,
+		// `FontAwesomeFreeIconSets::register()` defers to it and stops
+		// publishing `fas` / `far` / `fab` through the
+		// `ap.icons.register-icon-sets` filter (so the icons-package
+		// service provider doesn't collide on `BladeUI\Icons\Factory::add()`).
+		// The resolver still needs those paths to inline bundled FA Free
+		// SVGs for the picker and the rendered block, so we always seed
+		// it directly from `FontAwesomeFreeIconSets::discover()` — paths
+		// that come back from the filter then layer on top for any
+		// non-FA sets and uploaded sets.
+		$faFreeBaseDir = __DIR__ . '/../resources/icons/font-awesome';
+		$this->app->singleton( IconSvgResolver::class, function () use ( $faFreeBaseDir ): IconSvgResolver {
+			return new IconSvgResolver( static function () use ( $faFreeBaseDir ): array {
+				$paths = FontAwesomeFreeIconSets::discover( $faFreeBaseDir );
+
 				if ( ! class_exists( IconSetRegistration::class ) || ! function_exists( 'applyFilters' ) ) {
-					return [];
+					return $paths;
 				}
 
 				$registry = applyFilters( 'ap.icons.register-icon-sets', new IconSetRegistration() );
 				if ( ! $registry instanceof IconSetRegistration ) {
-					return [];
+					return $paths;
 				}
 
-				$paths = [];
 				foreach ( $registry->getSets() as $prefix => $details ) {
 					$path = $details['path'] ?? null;
 					if ( is_string( $path ) && '' !== $path ) {

--- a/tests/Unit/VisualEditor/Services/Icon/FontAwesomeFreeIconSetsTest.php
+++ b/tests/Unit/VisualEditor/Services/Icon/FontAwesomeFreeIconSetsTest.php
@@ -75,3 +75,35 @@ it( 'does not throw when the base directory is missing', function () {
 
 	expect( $registry->getSets() )->toBe( [] );
 } );
+
+it( 'skips registration when owenvoke/blade-fontawesome is installed (issue #587)', function () {
+	mkdir( test()->fixtureBase . '/fas' );
+	mkdir( test()->fixtureBase . '/far' );
+	mkdir( test()->fixtureBase . '/fab' );
+
+	$registry = new IconSetRegistration();
+	// `stdClass` always exists, so the probe short-circuits to the same
+	// branch that would fire when the real blade-fontawesome provider is
+	// installed alongside visual-editor.
+	$result = FontAwesomeFreeIconSets::register( $registry, test()->fixtureBase, stdClass::class );
+
+	expect( $result )->toBe( $registry )
+		->and( $result->getSets() )->toBe( [] );
+} );
+
+it( 'still registers discovered sets when blade-fontawesome is absent', function () {
+	mkdir( test()->fixtureBase . '/fas' );
+	mkdir( test()->fixtureBase . '/far' );
+	mkdir( test()->fixtureBase . '/fab' );
+
+	$registry = new IconSetRegistration();
+	// Probe a deliberately-missing FQCN so the skip path doesn't fire,
+	// then assert the bundled sets land on the registry as before.
+	$result = FontAwesomeFreeIconSets::register(
+		$registry,
+		test()->fixtureBase,
+		'ArtisanPackUI\\VisualEditor\\__DoesNotExist__',
+	);
+
+	expect( $result->getSets() )->toHaveKeys( [ 'fas', 'far', 'fab' ] );
+} );


### PR DESCRIPTION
## Description

In consumer apps that pull both `artisanpack-ui/visual-editor` and `owenvoke/blade-fontawesome` (the default path via `livewire-ui-components` → `blade-fontawesome`), both packages claim the `fas` / `far` / `fab` prefixes. The icons-package forwards visual-editor's registrations to `BladeUI\Icons\Factory::add()`, which rejects the duplicate and throws `CannotRegisterIconSet` on every Blade render — breaking Blade-rendered routes and Livewire tests in the consumer.

This PR detects the blade-fontawesome service provider at registration time, stops publishing the FA Free sets through the `ap.icons.register-icon-sets` filter, and seeds the visual-editor's `IconSvgResolver` directly from `FontAwesomeFreeIconSets::discover()` so the icon picker preview and the rendered Icon Block keep working.

**Closes:** #587

## Type of Change

- [x] Bug fix (fixes an issue)

## Related Issue

**Issue:** #587

## Motivation and Context

Without this fix, any consumer app that brings in both packages cannot render Blade components at all — `<x-…>` resolution blows up at boot. In `jmwd-keystone-cms` this fails 609 / 618 Unit + Feature tests and every Blade-rendered route. The fix is constrained to visual-editor and preserves all picker / block UX.

## Changes Made

- `FontAwesomeFreeIconSets::register()` short-circuits when `OwenVoke\BladeFontAwesome\BladeFontAwesomeServiceProvider` exists. The FQCN is probed as a literal string so the symbol is never imported just to check presence.
- The method gained an optional `$bladeFontAwesomeProvider` parameter as a test seam — callers can pass an FQCN to force-toggle the skip branch in either direction without polluting the autoloader.
- `IconSvgResolver`'s singleton now seeds its path map from `FontAwesomeFreeIconSets::discover()` first, then layers filter results on top. The resolver always knows where the bundled FA Free SVGs live, even when the filter chain skips them.
- CHANGELOG entry added under `[Unreleased] / Fixed`.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (Darwin 25.5.0)
- PHP Version: 8.4.3
- Project Version: 1.1.0 → 1.1.1

**Tests Performed:**
1. Full Pest suite: 1270 passed (3494 assertions), including two new unit tests covering the skip and non-skip branches via the test seam.
2. Tinker tests in the `artisanpack-ui-dev` app (which has both packages installed):
   - `class_exists('OwenVoke\\BladeFontAwesome\\BladeFontAwesomeServiceProvider')` → `true`
   - `FontAwesomeFreeIconSets::register()` returns an empty registry.
   - `applyFilters('ap.icons.register-icon-sets', …)` yields no fas/far/fab entries.
   - `app(IconSvgResolver::class)->setPaths()` still contains `fas`, `far`, `fab`.
   - `$resolver->resolve('fas', 'star')` returns real Font Awesome SVG markup.
   - `Blade::render('<x-fas-star/>')` renders cleanly — the original `CannotRegisterIconSet` exception is gone.
3. Visual smoke test in the dev app's Icon Block: picker tiles show real SVGs and a placed `fas:star` renders as a star, not a strikethrough text token.

## Accessibility Tests Run

- [x] N/A — fix is internal to icon-set registration; no UI or markup changes.

**Details:** No author-facing surface changes. The picker and rendered output emit the same SVGs as before, sourced from the same bundled FA Free assets.

## Tests Added

- [x] Unit tests added/updated
- [x] All tests passing

**Test details:** Two new tests in `FontAwesomeFreeIconSetsTest.php`:
1. `skips registration when owenvoke/blade-fontawesome is installed (issue #587)` — forces the skip path via `stdClass::class` as the probe FQCN.
2. `still registers discovered sets when blade-fontawesome is absent` — passes a deliberately-missing FQCN to confirm the existing behavior is preserved.

## Documentation

- [x] Inline code documentation added
- [x] N/A — README / Wiki

**Documentation details:** Added PHPDoc on the new optional parameter and on the skip branch. CHANGELOG `[Unreleased] / Fixed` entry explains the consumer-facing behavior.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved icon registration collision between visual-editor and blade-fontawesome packages. The system now detects when blade-fontawesome is present and avoids duplicate Font Awesome Free icon-set registration, preventing `CannotRegisterIconSet` failures during component rendering and Livewire tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->