### PR TITLE
Release v1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [1.1.1] — 2026-06-15
+
 ### Fixed
 
 - **Icon registration no longer collides with `owenvoke/blade-fontawesome`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+- **Icon registration no longer collides with `owenvoke/blade-fontawesome`
+  (#587).** In consumer apps that pull both `artisanpack-ui/visual-editor`
+  and `owenvoke/blade-fontawesome` (the default path via
+  `livewire-ui-components`), the visual-editor's `fas` / `far` / `fab`
+  icon sets collided with the prefixes blade-fontawesome registers,
+  causing `BladeUI\Icons\Exceptions\CannotRegisterIconSet` on every
+  `<x-...>` render and breaking Blade-rendered routes and Livewire tests.
+  `FontAwesomeFreeIconSets::register()` now detects the blade-fontawesome
+  service provider and stops publishing the FA Free sets through
+  `ap.icons.register-icon-sets`, so the icons-package no longer forwards
+  the conflicting prefixes to `BladeUI\Icons\Factory::add()`. The
+  visual-editor's own `IconSvgResolver` seeds its FA Free path map
+  directly from `FontAwesomeFreeIconSets::discover()`, so the icon
+  picker preview and the rendered Icon Block still resolve the bundled
+  SVGs.
+
 ## [1.1.0] — 2026-06-14
 
 The 1.1.0 release ships the full `artisanpack/icon` block (Phases 1–7),

--- a/docs/home.md
+++ b/docs/home.md
@@ -171,4 +171,4 @@ For issues, feature requests, and contributions:
 
 ---
 
-*This documentation covers visual-editor v1.1.0*
+*This documentation covers visual-editor v1.1.1*

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@artisanpack-ui/visual-editor",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "private": true,
     "type": "module",
     "exports": {

--- a/src/Services/Icon/FontAwesomeFreeIconSets.php
+++ b/src/Services/Icon/FontAwesomeFreeIconSets.php
@@ -40,6 +40,16 @@ final class FontAwesomeFreeIconSets
 	public const SET_PREFIXES = [ 'fas', 'far', 'fab' ];
 
 	/**
+	 * Fully-qualified class name of the `owenvoke/blade-fontawesome`
+	 * service provider. Kept as a literal string so the symbol is never
+	 * imported (and thus never triggers an autoload attempt) just to test
+	 * for the package's presence.
+	 *
+	 * @since 1.1.1
+	 */
+	private const BLADE_FONTAWESOME_PROVIDER = 'OwenVoke\\BladeFontAwesome\\BladeFontAwesomeServiceProvider';
+
+	/**
 	 * Return the absolute path for each FA Free set whose directory exists
 	 * under `$baseDir`. Missing sets are silently skipped so a partial
 	 * sync still surfaces the sets that did land.
@@ -67,9 +77,34 @@ final class FontAwesomeFreeIconSets
 	 * registry's `addSet()` throws when handed a non-existent path, which
 	 * is exactly why `discover()` filters them first — we want to no-op,
 	 * not blow up, when the FA Free directory is missing.
+	 *
+	 * When `owenvoke/blade-fontawesome` is installed, it already claims
+	 * the `fas` / `far` / `fab` prefixes via its own service provider and
+	 * `BladeUI\Icons\Factory::add()` rejects the duplicate registration
+	 * (issue #587). The blade-fontawesome bundle ships the same FA Free
+	 * SVG set, so deferring to it is a no-UX-regression workaround.
+	 *
+	 * `$bladeFontAwesomeProvider` is a test seam: callers can override
+	 * the class name probed by `class_exists()` so the skip path can be
+	 * exercised without loading the real package (or any stub of it) into
+	 * the autoloader.
+	 *
+	 * @param  string|null  $bladeFontAwesomeProvider  FQCN to probe for the
+	 *                                                 blade-fontawesome
+	 *                                                 service provider.
+	 *                                                 Defaults to the real
+	 *                                                 class name when null.
 	 */
-	public static function register( IconSetRegistration $registry, string $baseDir ): IconSetRegistration
-	{
+	public static function register(
+		IconSetRegistration $registry,
+		string $baseDir,
+		?string $bladeFontAwesomeProvider = null,
+	): IconSetRegistration {
+		$providerClass = $bladeFontAwesomeProvider ?? self::BLADE_FONTAWESOME_PROVIDER;
+		if ( class_exists( $providerClass ) ) {
+			return $registry;
+		}
+
 		foreach ( self::discover( $baseDir ) as $prefix => $path ) {
 			$registry->addSet( $path, $prefix );
 		}

--- a/src/VisualEditorServiceProvider.php
+++ b/src/VisualEditorServiceProvider.php
@@ -104,18 +104,31 @@ class VisualEditorServiceProvider extends ServiceProvider
 		// against those registrations and produce an empty resolver. The
 		// closure runs at request time, by which point boot is finished
 		// and the filter chain is complete.
-		$this->app->singleton( IconSvgResolver::class, function (): IconSvgResolver {
-			return new IconSvgResolver( static function (): array {
+		//
+		// Issue #587: when `owenvoke/blade-fontawesome` is installed,
+		// `FontAwesomeFreeIconSets::register()` defers to it and stops
+		// publishing `fas` / `far` / `fab` through the
+		// `ap.icons.register-icon-sets` filter (so the icons-package
+		// service provider doesn't collide on `BladeUI\Icons\Factory::add()`).
+		// The resolver still needs those paths to inline bundled FA Free
+		// SVGs for the picker and the rendered block, so we always seed
+		// it directly from `FontAwesomeFreeIconSets::discover()` — paths
+		// that come back from the filter then layer on top for any
+		// non-FA sets and uploaded sets.
+		$faFreeBaseDir = __DIR__ . '/../resources/icons/font-awesome';
+		$this->app->singleton( IconSvgResolver::class, function () use ( $faFreeBaseDir ): IconSvgResolver {
+			return new IconSvgResolver( static function () use ( $faFreeBaseDir ): array {
+				$paths = FontAwesomeFreeIconSets::discover( $faFreeBaseDir );
+
 				if ( ! class_exists( IconSetRegistration::class ) || ! function_exists( 'applyFilters' ) ) {
-					return [];
+					return $paths;
 				}
 
 				$registry = applyFilters( 'ap.icons.register-icon-sets', new IconSetRegistration() );
 				if ( ! $registry instanceof IconSetRegistration ) {
-					return [];
+					return $paths;
 				}
 
-				$paths = [];
 				foreach ( $registry->getSets() as $prefix => $details ) {
 					$path = $details['path'] ?? null;
 					if ( is_string( $path ) && '' !== $path ) {

--- a/tests/Unit/VisualEditor/Services/Icon/FontAwesomeFreeIconSetsTest.php
+++ b/tests/Unit/VisualEditor/Services/Icon/FontAwesomeFreeIconSetsTest.php
@@ -75,3 +75,35 @@ it( 'does not throw when the base directory is missing', function () {
 
 	expect( $registry->getSets() )->toBe( [] );
 } );
+
+it( 'skips registration when owenvoke/blade-fontawesome is installed (issue #587)', function () {
+	mkdir( test()->fixtureBase . '/fas' );
+	mkdir( test()->fixtureBase . '/far' );
+	mkdir( test()->fixtureBase . '/fab' );
+
+	$registry = new IconSetRegistration();
+	// `stdClass` always exists, so the probe short-circuits to the same
+	// branch that would fire when the real blade-fontawesome provider is
+	// installed alongside visual-editor.
+	$result = FontAwesomeFreeIconSets::register( $registry, test()->fixtureBase, stdClass::class );
+
+	expect( $result )->toBe( $registry )
+		->and( $result->getSets() )->toBe( [] );
+} );
+
+it( 'still registers discovered sets when blade-fontawesome is absent', function () {
+	mkdir( test()->fixtureBase . '/fas' );
+	mkdir( test()->fixtureBase . '/far' );
+	mkdir( test()->fixtureBase . '/fab' );
+
+	$registry = new IconSetRegistration();
+	// Probe a deliberately-missing FQCN so the skip path doesn't fire,
+	// then assert the bundled sets land on the registry as before.
+	$result = FontAwesomeFreeIconSets::register(
+		$registry,
+		test()->fixtureBase,
+		'ArtisanPackUI\\VisualEditor\\__DoesNotExist__',
+	);
+
+	expect( $result->getSets() )->toHaveKeys( [ 'fas', 'far', 'fab' ] );
+} );


### PR DESCRIPTION
## Release Information

- **Release Version:** v1.1.1
- **Release Date:** 2026-06-15
- **Release Type:** Patch
- **Release Branch:** `release/1.1.1`
- **Target Branch:** `main`

## Release Summary

One-issue patch on top of 1.1.0 (which is already on `main` as `v1.1.0`).

In consumer apps that pull both `artisanpack-ui/visual-editor` and `owenvoke/blade-fontawesome` (the default path via `livewire-ui-components`), the two packages collided on the `fas` / `far` / `fab` BladeUI icon prefixes and threw `CannotRegisterIconSet` on every `<x-…>` render — breaking Blade-rendered routes and Livewire tests in `jmwd-keystone-cms` and any other consumer with the same stack. This release ships the fix.

## Changelog

### Fixed

- **Icon registration no longer collides with `owenvoke/blade-fontawesome` (#587).** `FontAwesomeFreeIconSets::register()` now detects blade-fontawesome's service provider and stops publishing the FA Free sets through the `ap.icons.register-icon-sets` filter, so the icons-package no longer forwards the conflicting prefixes to `BladeUI\Icons\Factory::add()`. The visual-editor's own `IconSvgResolver` seeds its FA Free path map directly from `FontAwesomeFreeIconSets::discover()`, so the icon picker preview and the rendered Icon Block continue to resolve the bundled SVGs.

## Issues and Pull Requests

**Issues fixed:**
- Closes #587

**Related PRs:**
- #588 (merged into `release/1.1.1`)

## Breaking Changes

- [x] No breaking changes

## Testing Checklist

- [x] All automated tests passing
- [x] Manual testing completed
- [ ] Accessibility tests passing (no UI surface change)
- [ ] Performance tests passing (not applicable)
- [x] Security scan completed (see notes below)
- [ ] Tested in staging environment
- [ ] Database migrations tested (no migrations in this release)

**Testing notes:**

- PHP: **1270 tests passing, 3494 assertions** (`./vendor/bin/pest --compact`).
- JS: **2083 tests passing across 248 files** (`npm test`).
- Tinker verification in the `artisanpack-ui-dev` app (with `owenvoke/blade-fontawesome` v2.9.1 installed):
  - `FontAwesomeFreeIconSets::register()` returns an empty registry — collision avoided.
  - `applyFilters('ap.icons.register-icon-sets', …)` yields no fas/far/fab entries — `Factory::add()` no longer collides.
  - `app(IconSvgResolver::class)->setPaths()` still contains `fas` / `far` / `fab` — resolver intact.
  - `$resolver->resolve('fas', 'star')` returns real Font Awesome SVG markup.
  - `Blade::render('<x-fas-star/>')` renders cleanly.
- CodeRabbit review on PR #588: **"No actionable comments were generated."**

## Documentation Checklist

- [x] CHANGELOG updated — new `[1.1.1] — 2026-06-15` section
- [ ] README updated (no API surface change)
- [ ] API documentation updated (no API surface change)
- [ ] Migration guide written (no breaking changes)
- [x] Release notes written (this PR body)
- [x] `docs/home.md` current-version footer bumped to v1.1.1

## Pre-Release Checklist

- [x] Version number updated in all necessary files (`package.json`, `CHANGELOG.md`, `docs/home.md`)
- [x] Git tag prepared: `v1.1.1`
- [x] Release branch created/updated: `release/1.1.1`
- [x] Dependencies tested (lock files in sync)

### Dependency audit notes

- `composer validate --strict`: ✅ valid
- `composer audit`: **2 LOW** advisories on transitive `symfony/yaml` (CVE-2026-45305, CVE-2026-45133 — both DoS-style YAML parser issues). Not exploitable from visual-editor's surface. Not blocking.
- `composer outdated --direct`: 8 packages have patch/minor updates available (`artisanpack-ui/{cms-framework,core,hooks,icons}`, `nesbot/carbon`, `orchestra/testbench`, `pestphp/pest`, `pestphp/pest-plugin-laravel`). None are major-version behind. Held back intentionally — bug-fix release, no dep churn.
- `npm audit`: **17 MODERATE** in `@wordpress/*` (pre-existing). Tracked separately; not introduced by 1.1.1.

## Deployment

**Deployment steps:**
1. Merge this PR into `main`.
2. Tag `v1.1.1` on `main` (`git tag v1.1.1 && git push origin v1.1.1`).
3. Packagist syncs the new tag via the configured webhook.
4. Notify downstream consumers (`jmwd-keystone-cms`, dev-app sandbox) that the FA collision fix is available.

**Rollback plan:**
1. If a regression is reported, revert PR #588 on a `revert/1.1.1` branch and ship `v1.1.2-revert`.
2. Communicate via the CHANGELOG.

## Post-Release Tasks

- [ ] Tag created: `v1.1.1`
- [ ] Release notes published on Packagist / GitHub Releases
- [ ] `dev-app` and `jmwd-keystone-cms` re-pinned to `^1.1.1`
- [ ] Monitoring: watch for any new `CannotRegisterIconSet` reports — none expected

## Notes

This release closes the dependency-collision regression flagged from `jmwd-keystone-cms`'s Laravel 13 upgrade. With it merged, the consumer's Blade/Livewire test suite (609/618 prior failures from this collision) can be re-run cleanly.

---

**Release Manager:** @ViewFromTheBox