### PR TITLE
feat: Photo Grid container layout setting (#594)

### DIFF
--- a/docs/photo-grid.md
+++ b/docs/photo-grid.md
@@ -1,0 +1,110 @@
+# Photo Grid
+
+The **Photo Grid** setting is a container-level inspector control that
+forces every image-bearing descendant onto a uniform aspect ratio and
+fill behaviour. It is available on `artisanpack/group`,
+`artisanpack/columns`, and `artisanpack/grid`.
+
+Photo Grid is orthogonal to layout. Authors still pick flex, grid, or
+columns as they normally would; Photo Grid only normalises how the
+images inside the container crop and fill their slots.
+
+## Inspector UX
+
+The setting lives in the block inspector under **Dimensions → Photo
+Grid**:
+
+- **Enable** toggle — turn the feature on for this container.
+- **Aspect ratio** dropdown — 1:1, 4:3, 3:2, 16:9, 3:4, 9:16, "Inherit
+  container", or a **Custom…** option that reveals a `W/H` text input.
+- **Object fit** — `cover` (default) or `contain`.
+- **Object position** — 9-cell focal-point grid plus a numeric
+  `x% y%` text input.
+
+## Attribute shape
+
+The block stores Photo Grid state as a single `photoGrid` attribute:
+
+```jsonc
+{
+  "enabled": true,
+  "aspectRatio": "1/1",        // or null for "inherit container"
+  "objectFit": "cover",        // "cover" | "contain"
+  "objectPosition": "50% 50%"  // any valid CSS object-position value
+}
+```
+
+The renderer reads the same attribute server-side via
+`PhotoGridSupport::wrapper()` and emits a `has-photo-grid` class plus
+three CSS custom properties (`--ap-photo-grid-aspect`,
+`--ap-photo-grid-fit`, `--ap-photo-grid-position`) on the container.
+
+## Cascade behaviour
+
+The fill rules apply to all image-bearing descendants at any depth —
+`artisanpack/image`, `core/image`, `artisanpack/cover`, `core/cover`,
+and raw `<img>` / `<picture>` markup. Authors do not need to re-enable
+the setting on nested containers; the innermost Photo Grid container
+wins (CSS variables resolve on the nearest ancestor that defined them).
+
+Non-image children (paragraphs, buttons, headings) inside the
+container are unaffected.
+
+## theme.json defaults
+
+Themes can configure defaults for new Photo Grid containers and / or
+disable the inspector sub-section entirely via `theme.json`:
+
+```jsonc
+{
+  "settings": {
+    "artisanpack": {
+      "photoGrid": {
+        "enable": true,                 // false hides the inspector
+        "defaultAspectRatio": "4/3",
+        "defaultObjectFit": "cover",
+        "defaultObjectPosition": "50% 30%"
+      }
+    }
+  }
+}
+```
+
+When `enable` is `false`, the Photo Grid sub-section is hidden in the
+inspector, but already-saved containers that have Photo Grid turned on
+continue to render normally — the renderer is independent of the
+inspector visibility flag.
+
+## Renderer integration
+
+Server-side rendering is handled by
+`ArtisanPackUI\VisualEditorRendererBlade\Support\PhotoGridSupport`.
+Each container partial calls:
+
+```php
+$photoGridClasses = PhotoGridSupport::wrapperForBlock( $attributes );
+```
+
+…and merges the returned classes into its wrapper class list. The CSS
+custom properties are emitted as a scoped inline `<style>` rule via
+the existing `ResponsiveCssAccumulator`, so identical configs across
+multiple block instances collapse to one rule set in the consolidated
+output.
+
+The companion stylesheet
+(`packages/visual-editor-renderer-blade/resources/assets/frontend/photo-grid.css`)
+ships via the standard `<x-ve-blocks-styles />` component and targets
+the descendants with `.has-photo-grid :is(img, picture, …)` selectors.
+
+## Edge cases
+
+- **Empty container** — toggle is allowed, no visible effect until
+  images are added.
+- **Custom ratio invalid input** — the inspector flags a help message
+  in the text input; the renderer treats invalid values the same as
+  `null` (no `aspect-ratio` stamped).
+- **Photo Grid disabled mid-edit** — clearing the toggle removes the
+  class + variables; images revert to their natural size.
+- **`object-position` picker** — the 9-cell radio group and the
+  numeric input stay in sync; selecting a cell updates the text value,
+  and editing the text updates the radio selection on the next render.

--- a/docs/photo-grid.md
+++ b/docs/photo-grid.md
@@ -16,7 +16,10 @@ Grid**:
 
 - **Enable** toggle — turn the feature on for this container.
 - **Aspect ratio** dropdown — 1:1, 4:3, 3:2, 16:9, 3:4, 9:16, "Inherit
-  container", or a **Custom…** option that reveals a `W/H` text input.
+  container" (do not force an aspect ratio; descendant images keep
+  their natural height and stretch to fill the parent layout slot
+  when the container provides one), or a **Custom…** option that
+  reveals a `W/H` text input.
 - **Object fit** — `cover` (default) or `contain`.
 - **Object position** — 9-cell focal-point grid plus a numeric
   `x% y%` text input.

--- a/docs/site-editor.md
+++ b/docs/site-editor.md
@@ -220,3 +220,4 @@ chain — user records win on the same slug. See [Templates §4](site-editor/Tem
 - [Access Gate](site-editor/Access-Gate.md) — site-editor access gate contract
 - [Content model](content-model.md) — `HasBlockContent` and authorization
 - [Renderers](renderers.md) — render saved entities on the public site
+- [Photo Grid](photo-grid.md) — container-level Photo Grid setting (group / columns / grid). theme.json defaults live under `settings.artisanpack.photoGrid` and ride the same global-styles plumbing.

--- a/packages/visual-editor-renderer-blade/resources/assets/frontend/photo-grid.css
+++ b/packages/visual-editor-renderer-blade/resources/assets/frontend/photo-grid.css
@@ -1,0 +1,113 @@
+/**
+ * Photo Grid stylesheet (#594).
+ *
+ * Loaded by every container block that opts into the feature
+ * (group / columns / grid) as well as the Blade renderer. Scoped to
+ * `.has-photo-grid` so it never leaks into other containers.
+ *
+ * The container stamps three CSS custom properties on its wrapper:
+ *
+ *   --ap-photo-grid-aspect    e.g. `1/1`, `16/9` (omitted = inherit)
+ *   --ap-photo-grid-fit       `cover` | `contain`
+ *   --ap-photo-grid-position  e.g. `50% 50%`
+ *
+ * Image-bearing descendants (the WP image / cover blocks and raw
+ * `<img>` / `<picture>` markup) inherit them via `var()` lookups so
+ * an inner Photo Grid setting wins by virtue of being closer in the
+ * tree (`var()` resolves on the nearest ancestor that defined the
+ * property).
+ *
+ * Two sizing strategies coexist:
+ *
+ *  1. **Explicit aspect ratio set** — `aspect-ratio + width:100%`
+ *     computes the image height. `flex: 1` is harmless because the
+ *     intrinsic ratio dominates.
+ *  2. **Inherit container** (no aspect set) — the figure is made a
+ *     flex item with `flex: 1 1 auto` so it stretches to fill its
+ *     parent layout slot (e.g. a `wp-block-column`'s main axis), and
+ *     the image inside fills the figure via `height: 100%` + object-
+ *     fit. This is the mode that makes columns of mixed-ratio images
+ *     line up to the tallest column.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.2.0
+ */
+
+/*
+ * Make every column inside a Photo Grid columns container a flex
+ * column. WP's `.wp-block-column` is only a flex *item* by default
+ * (it grows inside `.wp-block-columns`), not a flex container — so
+ * the figure inside has no main axis to stretch along until we set
+ * one. `align-items: stretch` on the parent already makes the
+ * columns equal-height; this gives the figure inside a slot to fill.
+ */
+.has-photo-grid :is(.wp-block-column, .wp-block-artisanpack-column) {
+	display: flex;
+	flex-direction: column;
+}
+
+/*
+ * Stretch the image-block wrapper to fill its parent layout slot.
+ * Inside the now-flex column above, `flex: 1 1 auto` causes the
+ * figure to claim the column's remaining main-axis space. Inside
+ * non-flex parents the `flex` shorthand is a no-op, so the figure
+ * falls back to natural sizing.
+ *
+ * `display: flex; flex-direction: column` on the figure itself lets
+ * `height: 100%` resolve against the figure's flex-resolved height
+ * for the image, while a sibling `<figcaption>` keeps its natural
+ * height (flex item with default `flex: 0 1 auto`).
+ */
+.has-photo-grid :is(.wp-block-image, .wp-block-artisanpack-image) {
+	display: flex;
+	flex: 1 1 auto;
+	flex-direction: column;
+	min-height: 0;
+	width: 100%;
+}
+
+.has-photo-grid :is(.wp-block-image, .wp-block-artisanpack-image) > picture {
+	display: flex;
+	flex: 1 1 auto;
+	min-height: 0;
+	width: 100%;
+}
+
+.has-photo-grid :is(.wp-block-image, .wp-block-artisanpack-image) > :is(img, picture > img) {
+	aspect-ratio: var(--ap-photo-grid-aspect, auto);
+	flex: 1 1 auto;
+	min-height: 0;
+	object-fit: var(--ap-photo-grid-fit, cover);
+	object-position: var(--ap-photo-grid-position, 50% 50%);
+	width: 100%;
+	height: 100%;
+}
+
+.has-photo-grid :is(.wp-block-cover, .wp-block-artisanpack-cover) {
+	aspect-ratio: var(--ap-photo-grid-aspect, auto);
+	flex: 1 1 auto;
+	min-height: 0;
+	width: 100%;
+}
+
+.has-photo-grid :is(.wp-block-cover, .wp-block-artisanpack-cover) > :is(img, video, .wp-block-cover__image-background, .wp-block-cover__video-background) {
+	object-fit: var(--ap-photo-grid-fit, cover);
+	object-position: var(--ap-photo-grid-position, 50% 50%);
+	width: 100%;
+	height: 100%;
+}
+
+/*
+ * Raw markup catch-all. Applies the cascade at any depth so authors do
+ * not need to re-enable the setting on nested containers. Uses
+ * `:where()` to keep specificity at (0,0,1,0) — any deliberate per-image
+ * rule from the theme or block-level inline styles wins, mirroring how
+ * WordPress core scopes its own layout rules.
+ */
+:where(.has-photo-grid) :is(img, picture) {
+	aspect-ratio: var(--ap-photo-grid-aspect, auto);
+	object-fit: var(--ap-photo-grid-fit, cover);
+	object-position: var(--ap-photo-grid-position, 50% 50%);
+	width: 100%;
+	height: 100%;
+}

--- a/packages/visual-editor-renderer-blade/resources/assets/frontend/photo-grid.css
+++ b/packages/visual-editor-renderer-blade/resources/assets/frontend/photo-grid.css
@@ -66,14 +66,14 @@
 	width: 100%;
 }
 
-.has-photo-grid :is(.wp-block-image, .wp-block-artisanpack-image) > picture {
+.has-photo-grid :is(.wp-block-image, .wp-block-artisanpack-image) > :is(picture, a) {
 	display: flex;
 	flex: 1 1 auto;
 	min-height: 0;
 	width: 100%;
 }
 
-.has-photo-grid :is(.wp-block-image, .wp-block-artisanpack-image) > :is(img, picture > img) {
+.has-photo-grid :is(.wp-block-image, .wp-block-artisanpack-image) > :is(img, a > img, picture > img) {
 	aspect-ratio: var(--ap-photo-grid-aspect, auto);
 	flex: 1 1 auto;
 	min-height: 0;

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/grid.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/grid.blade.php
@@ -1,6 +1,7 @@
 @php
 	use ArtisanPackUI\VisualEditor\Responsive\BreakpointRegistry;
 	use ArtisanPackUI\VisualEditorRendererBlade\Support\BlockSupports;
+	use ArtisanPackUI\VisualEditorRendererBlade\Support\PhotoGridSupport;
 
 	$clampColumns = static function ( $value, int $fallback ): int {
 		$int = is_numeric( $value ) ? (int) $value : $fallback;
@@ -41,7 +42,7 @@
 		}
 	}
 
-	$baseClasses = array_merge( [ 'ap-grid' ], $breakpointClasses );
+	$baseClasses = array_merge( [ 'ap-grid' ], $breakpointClasses, PhotoGridSupport::wrapperForBlock( $attributes ) );
 @endphp
 <div{!! BlockSupports::wrapperAttrs( $attributes, $baseClasses ) !!}>
 	{!! $innerBlocksHtml !!}

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/core/columns.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/core/columns.blade.php
@@ -2,6 +2,7 @@
 	use ArtisanPackUI\VisualEditor\Responsive\BreakpointRegistry;
 	use ArtisanPackUI\VisualEditorRendererBlade\Support\BlockSupports;
 	use ArtisanPackUI\VisualEditorRendererBlade\Support\FlexSupport;
+	use ArtisanPackUI\VisualEditorRendererBlade\Support\PhotoGridSupport;
 
 	$baseClasses = [ 'wp-block-columns' ];
 
@@ -14,6 +15,7 @@
 	}
 
 	$baseClasses = array_merge( $baseClasses, FlexSupport::wrapperForBlock( $attributes ) );
+	$baseClasses = array_merge( $baseClasses, PhotoGridSupport::wrapperForBlock( $attributes ) );
 
 	// #487 — columns-specific responsive layout. `columnCount` overrides
 	// translate to per-breakpoint `grid-template-columns` rules. The

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/core/group.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/core/group.blade.php
@@ -1,6 +1,7 @@
 @php
 	use ArtisanPackUI\VisualEditorRendererBlade\Support\BlockSupports;
 	use ArtisanPackUI\VisualEditorRendererBlade\Support\FlexSupport;
+	use ArtisanPackUI\VisualEditorRendererBlade\Support\PhotoGridSupport;
 
 	$tag = isset( $attributes['tagName'] ) && in_array( $attributes['tagName'], [ 'div', 'section', 'article', 'aside', 'header', 'footer', 'main', 'nav' ], true )
 		? $attributes['tagName']
@@ -36,7 +37,9 @@
 		$layoutClass = 'is-layout-flex';
 	}
 
-	$wrapperBaseClasses = array_merge( [ 'wp-block-group', $layoutClass ], $flexClasses );
+	$photoGridClasses = PhotoGridSupport::wrapperForBlock( $attributes );
+
+	$wrapperBaseClasses = array_merge( [ 'wp-block-group', $layoutClass ], $flexClasses, $photoGridClasses );
 @endphp
 <{{ $tag }}{!! BlockSupports::wrapperAttrs( $attributes, $wrapperBaseClasses ) !!}>
 	{!! $innerBlocksHtml !!}

--- a/packages/visual-editor-renderer-blade/resources/views/components/blocks-styles.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/components/blocks-styles.blade.php
@@ -27,6 +27,12 @@
 	emitted by the shared serializer onto group/column/columns/grid-item
 	wrappers. Static, layout-only, no interactivity needed. --}}
 <link rel="stylesheet" href="{{ $flexLayoutStyleHref }}" data-ve-flex-layout>
+{{-- #594 — Photo Grid container support. Targets descendant images of
+	any container carrying `has-photo-grid` and reads the CSS custom
+	properties stamped onto the wrapper via the inline rules emitted
+	through `PhotoGridSupport::wrapperForBlock` + the responsive CSS
+	accumulator. --}}
+<link rel="stylesheet" href="{{ $photoGridStyleHref }}" data-ve-photo-grid>
 @if( '' !== $themeTokensCss )
 <style data-ve-theme-tokens>{!! $themeTokensCss !!}</style>
 @endif

--- a/packages/visual-editor-renderer-blade/src/Support/PhotoGridSupport.php
+++ b/packages/visual-editor-renderer-blade/src/Support/PhotoGridSupport.php
@@ -1,0 +1,191 @@
+<?php
+
+/**
+ * Photo Grid wrapper serializer — Blade renderer (#594).
+ *
+ * Mirrors `resources/js/visual-editor/blocks/_shared/photo-grid/
+ * wrapper.ts` exactly. Returns the wrapper class list plus the inline
+ * CSS variable declarations (`--ap-photo-grid-aspect`, `--ap-photo-
+ * grid-fit`, `--ap-photo-grid-position`) that the matching
+ * `photo-grid.css` stylesheet picks up to size image-bearing
+ * descendants.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditorRendererBlade
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.2.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditorRendererBlade\Support;
+
+use ArtisanPackUI\VisualEditorRendererBlade\Services\ResponsiveCssAccumulator;
+
+class PhotoGridSupport
+{
+	/**
+	 * Convenience used by block partials. Resolves the wrapper props,
+	 * pushes the CSS-variable declarations into the per-request CSS
+	 * accumulator under a scoped class, and returns the class list
+	 * to splice into `BlockSupports::wrapperAttrs()`. Returns an
+	 * empty array when the feature is off.
+	 *
+	 * @param  array<string, mixed>  $attributes
+	 *
+	 * @return array<int, string>
+	 */
+	public static function wrapperForBlock( array $attributes ): array
+	{
+		$result = self::wrapper( $attributes );
+
+		if ( [] === $result[ 'classes' ] ) {
+			return [];
+		}
+
+		$styles = $result[ 'styles' ];
+		if ( [] === $styles ) {
+			return $result[ 'classes' ];
+		}
+
+		// Scope-class names follow the same convention as the flex
+		// arbitrary-style emitter — `photo-grid-{12-char-sha1}` keyed
+		// on the rendered declaration string so identical configs
+		// collide on one rule rather than emitting N duplicates.
+		$declaration = self::inlineStyle( $styles );
+		$scope       = 'photo-grid-' . substr( sha1( $declaration ), 0, 12 );
+		$classes     = array_merge( $result[ 'classes' ], [ $scope ] );
+
+		try {
+			$css = '.' . $scope . '{' . $declaration . '}';
+			app( ResponsiveCssAccumulator::class )->push( $scope, $css );
+		} catch ( \Throwable $e ) {
+			// Accumulator not booted (early or test path) — silently drop.
+		}
+
+		return $classes;
+	}
+
+
+	/**
+	 * Compute the wrapper props for a block's Photo Grid attribute.
+	 *
+	 * Returns an associative array with two keys:
+	 *
+	 *   - `classes` — array<int, string>: classes to merge into the
+	 *     block's wrapper class list. Empty when the feature is off.
+	 *   - `styles`  — array<string, string>: CSS custom property
+	 *     declarations to splice into the wrapper's inline `style`
+	 *     attribute (`var => value`). Empty when the feature is off.
+	 *
+	 * @param  array<string, mixed>  $attributes  Raw block attributes.
+	 *
+	 * @return array{classes: array<int, string>, styles: array<string, string>}
+	 */
+	public static function wrapper( array $attributes ): array
+	{
+		$photoGrid = $attributes[ 'photoGrid' ] ?? null;
+
+		if ( ! is_array( $photoGrid ) ) {
+			return [ 'classes' => [], 'styles' => [] ];
+		}
+
+		$enabled = $photoGrid[ 'enabled' ] ?? false;
+		if ( true !== $enabled ) {
+			return [ 'classes' => [], 'styles' => [] ];
+		}
+
+		$aspect   = self::normaliseAspectRatio( $photoGrid[ 'aspectRatio' ] ?? null );
+		$fit      = self::normaliseObjectFit( $photoGrid[ 'objectFit' ] ?? null );
+		$position = self::normaliseObjectPosition( $photoGrid[ 'objectPosition' ] ?? null );
+
+		$styles = [
+			'--ap-photo-grid-fit'      => $fit,
+			'--ap-photo-grid-position' => $position,
+		];
+
+		if ( null !== $aspect ) {
+			$styles[ '--ap-photo-grid-aspect' ] = $aspect;
+		}
+
+		return [
+			'classes' => [ 'has-photo-grid' ],
+			'styles'  => $styles,
+		];
+	}
+
+	/**
+	 * Render the `styles` array as a `key:value;…` inline-style
+	 * declaration string. Returns an empty string when there is
+	 * nothing to emit.
+	 *
+	 * @param  array<string, string>  $styles
+	 */
+	public static function inlineStyle( array $styles ): string
+	{
+		if ( [] === $styles ) {
+			return '';
+		}
+
+		$parts = [];
+		foreach ( $styles as $property => $value ) {
+			$parts[] = $property . ':' . $value;
+		}
+
+		return implode( ';', $parts ) . ';';
+	}
+
+	/**
+	 * Validate an aspect ratio token. Accepts `null` / `''` / `'auto'`
+	 * / `'inherit'` as "no aspect ratio", a positive `W/H` numeric pair
+	 * as a valid ratio, and rejects everything else (returns `null`).
+	 *
+	 * @param  mixed  $value
+	 */
+	private static function normaliseAspectRatio( $value ): ?string
+	{
+		if ( null === $value || '' === $value ) {
+			return null;
+		}
+		if ( ! is_string( $value ) ) {
+			return null;
+		}
+		$trimmed = trim( $value );
+		if ( '' === $trimmed || 'auto' === $trimmed || 'inherit' === $trimmed ) {
+			return null;
+		}
+		if ( 1 !== preg_match( '#^\d+(\.\d+)?/\d+(\.\d+)?$#', $trimmed ) ) {
+			return null;
+		}
+
+		[ $w, $h ] = explode( '/', $trimmed );
+		if ( (float) $w <= 0 || (float) $h <= 0 ) {
+			return null;
+		}
+
+		return $trimmed;
+	}
+
+	/**
+	 * @param  mixed  $value
+	 */
+	private static function normaliseObjectFit( $value ): string
+	{
+		return 'contain' === $value ? 'contain' : 'cover';
+	}
+
+	/**
+	 * @param  mixed  $value
+	 */
+	private static function normaliseObjectPosition( $value ): string
+	{
+		if ( ! is_string( $value ) ) {
+			return '50% 50%';
+		}
+		$trimmed = trim( $value );
+
+		return '' === $trimmed ? '50% 50%' : $trimmed;
+	}
+}

--- a/packages/visual-editor-renderer-blade/src/Support/PhotoGridSupport.php
+++ b/packages/visual-editor-renderer-blade/src/Support/PhotoGridSupport.php
@@ -185,7 +185,16 @@ class PhotoGridSupport
 			return '50% 50%';
 		}
 		$trimmed = trim( $value );
+		if ( '' === $trimmed ) {
+			return '50% 50%';
+		}
+		// Reject CSS declaration / rule delimiters so a tampered
+		// `objectPosition` cannot break out of the `--ap-photo-grid-
+		// position` declaration and inject sibling rules.
+		if ( 1 === preg_match( '/[;{}<>]/', $trimmed ) ) {
+			return '50% 50%';
+		}
 
-		return '' === $trimmed ? '50% 50%' : $trimmed;
+		return $trimmed;
 	}
 }

--- a/packages/visual-editor-renderer-blade/src/View/Components/BlocksStylesComponent.php
+++ b/packages/visual-editor-renderer-blade/src/View/Components/BlocksStylesComponent.php
@@ -71,6 +71,8 @@ class BlocksStylesComponent extends Component
 
 	public string $flexLayoutStyleHref;
 
+	public string $photoGridStyleHref;
+
 	public string $interactivityScriptSrc;
 
 	public bool $emitBlockLibrary;
@@ -108,6 +110,7 @@ class BlocksStylesComponent extends Component
 		$this->socialIconsStyleHref   = $base . '/frontend/social-icons.css';
 		$this->breadcrumbsStyleHref   = $base . '/frontend/breadcrumbs.css';
 		$this->flexLayoutStyleHref    = $base . '/frontend/flex-layout.css';
+		$this->photoGridStyleHref     = $base . '/frontend/photo-grid.css';
 		$this->interactivityScriptSrc = $base . '/frontend/interactivity.js';
 		$this->emitBlockLibrary       = $bundle;
 		$this->emitInteractive        = $interactive;

--- a/packages/visual-editor-renderer-blade/tests/Feature/PhotoGridSupportTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Feature/PhotoGridSupportTest.php
@@ -1,0 +1,194 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditorRendererBlade\Support\PhotoGridSupport;
+
+/**
+ * #594 — Photo Grid wrapper serializer parity.
+ *
+ * Mirrors `resources/js/visual-editor/blocks/_shared/photo-grid/
+ * wrapper.ts` exactly. Confirms the PHP wrapper emits identical
+ * classes + CSS variables across attribute combinations and rejects
+ * malformed input the same way the JS helper does.
+ */
+
+it( 'returns empty result when photoGrid attribute is missing', function () {
+	$result = PhotoGridSupport::wrapper( [] );
+
+	expect( $result[ 'classes' ] )->toBe( [] )
+		->and( $result[ 'styles' ] )->toBe( [] );
+} );
+
+it( 'returns empty result when photoGrid attribute is null', function () {
+	$result = PhotoGridSupport::wrapper( [ 'photoGrid' => null ] );
+
+	expect( $result[ 'classes' ] )->toBe( [] )
+		->and( $result[ 'styles' ] )->toBe( [] );
+} );
+
+it( 'returns empty result when photoGrid.enabled is false', function () {
+	$result = PhotoGridSupport::wrapper( [
+		'photoGrid' => [
+			'enabled'        => false,
+			'aspectRatio'    => '1/1',
+			'objectFit'      => 'cover',
+			'objectPosition' => '50% 50%',
+		],
+	] );
+
+	expect( $result[ 'classes' ] )->toBe( [] )
+		->and( $result[ 'styles' ] )->toBe( [] );
+} );
+
+it( 'emits the has-photo-grid class plus aspect/fit/position vars when enabled', function () {
+	$result = PhotoGridSupport::wrapper( [
+		'photoGrid' => [
+			'enabled'        => true,
+			'aspectRatio'    => '16/9',
+			'objectFit'      => 'cover',
+			'objectPosition' => '50% 50%',
+		],
+	] );
+
+	expect( $result[ 'classes' ] )->toBe( [ 'has-photo-grid' ] )
+		->and( $result[ 'styles' ] )->toBe( [
+			'--ap-photo-grid-fit'      => 'cover',
+			'--ap-photo-grid-position' => '50% 50%',
+			'--ap-photo-grid-aspect'   => '16/9',
+		] );
+} );
+
+it( 'preserves the contain object-fit token', function () {
+	$result = PhotoGridSupport::wrapper( [
+		'photoGrid' => [
+			'enabled'        => true,
+			'aspectRatio'    => '1/1',
+			'objectFit'      => 'contain',
+			'objectPosition' => '30% 70%',
+		],
+	] );
+
+	expect( $result[ 'styles' ][ '--ap-photo-grid-fit' ] )->toBe( 'contain' )
+		->and( $result[ 'styles' ][ '--ap-photo-grid-position' ] )->toBe( '30% 70%' );
+} );
+
+it( 'omits the aspect-ratio var when value is null (inherit container)', function () {
+	$result = PhotoGridSupport::wrapper( [
+		'photoGrid' => [
+			'enabled'        => true,
+			'aspectRatio'    => null,
+			'objectFit'      => 'cover',
+			'objectPosition' => '50% 50%',
+		],
+	] );
+
+	expect( $result[ 'classes' ] )->toBe( [ 'has-photo-grid' ] )
+		->and( $result[ 'styles' ] )->not->toHaveKey( '--ap-photo-grid-aspect' );
+} );
+
+it( 'accepts decimal aspect ratios', function () {
+	$result = PhotoGridSupport::wrapper( [
+		'photoGrid' => [
+			'enabled'        => true,
+			'aspectRatio'    => '21.5/9',
+			'objectFit'      => 'cover',
+			'objectPosition' => '50% 50%',
+		],
+	] );
+
+	expect( $result[ 'styles' ][ '--ap-photo-grid-aspect' ] )->toBe( '21.5/9' );
+} );
+
+it( 'rejects malformed aspect ratios (drops the aspect var)', function () {
+	foreach ( [ '16x9', '16 9', '/9', '16/', '-16/9', '0/9', '16/0', 'abc' ] as $bad ) {
+		$result = PhotoGridSupport::wrapper( [
+			'photoGrid' => [
+				'enabled'        => true,
+				'aspectRatio'    => $bad,
+				'objectFit'      => 'cover',
+				'objectPosition' => '50% 50%',
+			],
+		] );
+
+		expect( $result[ 'styles' ] )->not->toHaveKey( '--ap-photo-grid-aspect' );
+	}
+} );
+
+it( 'defaults objectFit to cover for unknown tokens', function () {
+	$result = PhotoGridSupport::wrapper( [
+		'photoGrid' => [
+			'enabled'        => true,
+			'aspectRatio'    => '1/1',
+			'objectFit'      => 'bogus',
+			'objectPosition' => '50% 50%',
+		],
+	] );
+
+	expect( $result[ 'styles' ][ '--ap-photo-grid-fit' ] )->toBe( 'cover' );
+} );
+
+it( 'defaults objectPosition to 50% 50% for empty / non-string values', function () {
+	foreach ( [ '', null, 0, false, [] ] as $bad ) {
+		$result = PhotoGridSupport::wrapper( [
+			'photoGrid' => [
+				'enabled'        => true,
+				'aspectRatio'    => '1/1',
+				'objectFit'      => 'cover',
+				'objectPosition' => $bad,
+			],
+		] );
+
+		expect( $result[ 'styles' ][ '--ap-photo-grid-position' ] )->toBe( '50% 50%' );
+	}
+} );
+
+it( 'inlineStyle renders declarations as a `key:value;…` string', function () {
+	$css = PhotoGridSupport::inlineStyle( [
+		'--ap-photo-grid-fit'      => 'cover',
+		'--ap-photo-grid-position' => '50% 50%',
+		'--ap-photo-grid-aspect'   => '16/9',
+	] );
+
+	expect( $css )->toBe( '--ap-photo-grid-fit:cover;--ap-photo-grid-position:50% 50%;--ap-photo-grid-aspect:16/9;' );
+} );
+
+it( 'inlineStyle returns an empty string for an empty styles array', function () {
+	expect( PhotoGridSupport::inlineStyle( [] ) )->toBe( '' );
+} );
+
+it( 'wrapperForBlock returns the class list including a scope class when enabled', function () {
+	$classes = PhotoGridSupport::wrapperForBlock( [
+		'photoGrid' => [
+			'enabled'        => true,
+			'aspectRatio'    => '1/1',
+			'objectFit'      => 'cover',
+			'objectPosition' => '50% 50%',
+		],
+	] );
+
+	expect( $classes )->toContain( 'has-photo-grid' )
+		->and( count( $classes ) )->toBe( 2 );
+
+	// Scope class follows `photo-grid-{12-char-sha1}` and is stable
+	// for identical declarations — same input twice should produce
+	// the same scope class.
+	$again = PhotoGridSupport::wrapperForBlock( [
+		'photoGrid' => [
+			'enabled'        => true,
+			'aspectRatio'    => '1/1',
+			'objectFit'      => 'cover',
+			'objectPosition' => '50% 50%',
+		],
+	] );
+
+	expect( $classes )->toEqual( $again );
+} );
+
+it( 'wrapperForBlock returns an empty array when disabled', function () {
+	expect( PhotoGridSupport::wrapperForBlock( [] ) )->toBe( [] )
+		->and( PhotoGridSupport::wrapperForBlock( [ 'photoGrid' => null ] ) )->toBe( [] )
+		->and( PhotoGridSupport::wrapperForBlock( [
+			'photoGrid' => [ 'enabled' => false ],
+		] ) )->toBe( [] );
+} );

--- a/packages/visual-editor-renderer-blade/tests/Feature/PhotoGridSupportTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Feature/PhotoGridSupportTest.php
@@ -143,6 +143,21 @@ it( 'defaults objectPosition to 50% 50% for empty / non-string values', function
 	}
 } );
 
+it( 'rejects CSS-breakout attempts in objectPosition', function () {
+	foreach ( [ '50% 50%; color: red', '50% 50%}{background:red', '50%<script>', 'top}', '{x' ] as $bad ) {
+		$result = PhotoGridSupport::wrapper( [
+			'photoGrid' => [
+				'enabled'        => true,
+				'aspectRatio'    => '1/1',
+				'objectFit'      => 'cover',
+				'objectPosition' => $bad,
+			],
+		] );
+
+		expect( $result[ 'styles' ][ '--ap-photo-grid-position' ] )->toBe( '50% 50%' );
+	}
+} );
+
 it( 'inlineStyle renders declarations as a `key:value;…` string', function () {
 	$css = PhotoGridSupport::inlineStyle( [
 		'--ap-photo-grid-fit'      => 'cover',
@@ -169,6 +184,13 @@ it( 'wrapperForBlock returns the class list including a scope class when enabled
 
 	expect( $classes )->toContain( 'has-photo-grid' )
 		->and( count( $classes ) )->toBe( 2 );
+
+	$scope = array_values( array_filter(
+		$classes,
+		static fn ( string $c ): bool => str_starts_with( $c, 'photo-grid-' )
+	) );
+	expect( $scope )->toHaveCount( 1 )
+		->and( $scope[ 0 ] )->toMatch( '/^photo-grid-[a-f0-9]{12}$/' );
 
 	// Scope class follows `photo-grid-{12-char-sha1}` and is stable
 	// for identical declarations — same input twice should produce

--- a/resources/js/visual-editor/blocks/_shared/photo-grid/__tests__/controls.test.tsx
+++ b/resources/js/visual-editor/blocks/_shared/photo-grid/__tests__/controls.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * Photo Grid inspector control tests (#594).
+ *
+ * Renders the `<PhotoGridControls />` with a stub `useSettings` and
+ * confirms it surfaces the toggle, hides the sub-controls until
+ * enabled, and propagates theme defaults into the change-handler
+ * payload.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.2.0
+ */
+
+import { beforeAll, describe, expect, it, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+
+// `@wordpress/components` SelectControl reaches into `ResizeObserver`
+// via the compose package. jsdom doesn't ship it; stub a no-op so the
+// expanded panel renders without throwing.
+beforeAll( () => {
+	if ( typeof globalThis.ResizeObserver === 'undefined' ) {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		( globalThis as any ).ResizeObserver = class {
+			observe(): void {}
+			unobserve(): void {}
+			disconnect(): void {}
+		}
+	}
+} )
+
+vi.mock( '@wordpress/block-editor', () => ( {
+	useSettings: ( ...paths: string[] ): unknown[] =>
+		paths.map( ( path ) => {
+			switch ( path ) {
+				case 'artisanpack.photoGrid.enable':
+					return true
+				case 'artisanpack.photoGrid.defaultAspectRatio':
+					return '4/3'
+				case 'artisanpack.photoGrid.defaultObjectFit':
+					return 'cover'
+				case 'artisanpack.photoGrid.defaultObjectPosition':
+					return '50% 50%'
+				default:
+					return undefined
+			}
+		} ),
+} ) )
+
+vi.mock( '@wordpress/i18n', () => ( {
+	__: ( s: string ) => s,
+} ) )
+
+import { PhotoGridControls } from '../controls'
+
+/**
+ * The Photo Grid `PanelBody` ships collapsed (`initialOpen={false}`).
+ * Each spec expands it via the panel toggle button before asserting
+ * the inner controls — same shape as the host inspector UX where the
+ * author has to expand the panel before seeing anything.
+ */
+function expandPanel(): void {
+	fireEvent.click( screen.getByRole( 'button', { name: /Photo Grid/ } ) )
+}
+
+describe( '<PhotoGridControls />', () => {
+	it( 'renders the toggle disabled by default', () => {
+		render( <PhotoGridControls photoGrid={ null } onChange={ () => {} } /> )
+		expandPanel()
+
+		const toggle = screen.getByRole( 'checkbox', { name: /Enable Photo Grid/ } )
+		expect( toggle ).toBeInTheDocument()
+		expect( toggle ).not.toBeChecked()
+	} )
+
+	it( 'does not render the aspect ratio dropdown until enabled', () => {
+		render( <PhotoGridControls photoGrid={ null } onChange={ () => {} } /> )
+		expandPanel()
+
+		expect( screen.queryByLabelText( /Aspect ratio/ ) ).toBeNull()
+	} )
+
+	it( 'reveals the aspect ratio dropdown when enabled', () => {
+		render(
+			<PhotoGridControls
+				photoGrid={ {
+					enabled: true,
+					aspectRatio: '1/1',
+					objectFit: 'cover',
+					objectPosition: '50% 50%',
+				} }
+				onChange={ () => {} }
+			/>,
+		)
+		expandPanel()
+
+		expect( screen.getByLabelText( /Aspect ratio/ ) ).toBeInTheDocument()
+	} )
+
+	it( 'seeds onChange with theme defaults when toggling on', () => {
+		const onChange = vi.fn()
+
+		render( <PhotoGridControls photoGrid={ null } onChange={ onChange } /> )
+		expandPanel()
+
+		const toggle = screen.getByRole( 'checkbox', { name: /Enable Photo Grid/ } )
+		fireEvent.click( toggle )
+
+		expect( onChange ).toHaveBeenCalledTimes( 1 )
+		const payload = onChange.mock.calls[ 0 ][ 0 ]
+		expect( payload.enabled ).toBe( true )
+		// Theme default `4/3` from the stubbed `useSettings`.
+		expect( payload.aspectRatio ).toBe( '4/3' )
+		expect( payload.objectFit ).toBe( 'cover' )
+		expect( payload.objectPosition ).toBe( '50% 50%' )
+	} )
+} )

--- a/resources/js/visual-editor/blocks/_shared/photo-grid/__tests__/wrapper.test.ts
+++ b/resources/js/visual-editor/blocks/_shared/photo-grid/__tests__/wrapper.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Photo Grid wrapper helper tests (#594).
+ *
+ * Mirrors the PHP `PhotoGridSupportTest` assertions so the two
+ * serializers stay byte-equivalent across attribute combinations.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.2.0
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import {
+	getPhotoGridWrapperProps,
+	normaliseAspectRatio,
+} from '../wrapper'
+
+describe( 'getPhotoGridWrapperProps', () => {
+	it( 'returns empty result when the attribute is missing', () => {
+		expect( getPhotoGridWrapperProps( {} ) ).toEqual( {} )
+		expect( getPhotoGridWrapperProps( null ) ).toEqual( {} )
+		expect( getPhotoGridWrapperProps( undefined ) ).toEqual( {} )
+	} )
+
+	it( 'returns empty result when enabled is false', () => {
+		expect(
+			getPhotoGridWrapperProps( {
+				photoGrid: {
+					enabled: false,
+					aspectRatio: '1/1',
+					objectFit: 'cover',
+					objectPosition: '50% 50%',
+				},
+			} ),
+		).toEqual( {} )
+	} )
+
+	it( 'emits the class + style props when enabled', () => {
+		const result = getPhotoGridWrapperProps( {
+			photoGrid: {
+				enabled: true,
+				aspectRatio: '16/9',
+				objectFit: 'cover',
+				objectPosition: '50% 50%',
+			},
+		} )
+
+		expect( result.className ).toBe( 'has-photo-grid' )
+		expect( result.style ).toEqual( {
+			'--ap-photo-grid-fit': 'cover',
+			'--ap-photo-grid-position': '50% 50%',
+			'--ap-photo-grid-aspect': '16/9',
+		} )
+	} )
+
+	it( 'preserves the contain object-fit token', () => {
+		const result = getPhotoGridWrapperProps( {
+			photoGrid: {
+				enabled: true,
+				aspectRatio: '1/1',
+				objectFit: 'contain',
+				objectPosition: '30% 70%',
+			},
+		} )
+
+		expect( ( result.style as Record< string, string > )[ '--ap-photo-grid-fit' ] ).toBe( 'contain' )
+		expect( ( result.style as Record< string, string > )[ '--ap-photo-grid-position' ] ).toBe( '30% 70%' )
+	} )
+
+	it( 'omits the aspect var when value is null', () => {
+		const result = getPhotoGridWrapperProps( {
+			photoGrid: {
+				enabled: true,
+				aspectRatio: null,
+				objectFit: 'cover',
+				objectPosition: '50% 50%',
+			},
+		} )
+
+		expect( result.className ).toBe( 'has-photo-grid' )
+		expect( result.style ).not.toHaveProperty( '--ap-photo-grid-aspect' )
+	} )
+
+	it( 'drops malformed aspect ratios', () => {
+		for ( const bad of [ '16x9', '16 9', '/9', '16/', '-16/9', '0/9', '16/0', 'abc' ] ) {
+			const result = getPhotoGridWrapperProps( {
+				photoGrid: {
+					enabled: true,
+					aspectRatio: bad,
+					objectFit: 'cover',
+					objectPosition: '50% 50%',
+				},
+			} )
+
+			expect( result.style ).not.toHaveProperty( '--ap-photo-grid-aspect' )
+		}
+	} )
+
+	it( 'defaults objectPosition to 50% 50% for empty strings', () => {
+		const result = getPhotoGridWrapperProps( {
+			photoGrid: {
+				enabled: true,
+				aspectRatio: '1/1',
+				objectFit: 'cover',
+				objectPosition: '',
+			},
+		} )
+
+		expect( ( result.style as Record< string, string > )[ '--ap-photo-grid-position' ] ).toBe( '50% 50%' )
+	} )
+
+	it( 'defaults objectFit to cover for unknown tokens', () => {
+		const result = getPhotoGridWrapperProps( {
+			photoGrid: {
+				enabled: true,
+				aspectRatio: '1/1',
+				objectFit: 'bogus' as unknown as 'cover',
+				objectPosition: '50% 50%',
+			},
+		} )
+
+		expect( ( result.style as Record< string, string > )[ '--ap-photo-grid-fit' ] ).toBe( 'cover' )
+	} )
+} )
+
+describe( 'normaliseAspectRatio', () => {
+	it.each( [
+		[ '1/1', '1/1' ],
+		[ '16/9', '16/9' ],
+		[ '21.5/9', '21.5/9' ],
+		[ '3/4', '3/4' ],
+	] )( 'accepts %s', ( input, expected ) => {
+		expect( normaliseAspectRatio( input ) ).toBe( expected )
+	} )
+
+	it.each( [ null, '', 'auto', 'inherit', '16x9', '/9', '16/', '-1/1', '0/1', '1/0', undefined, 42 ] )(
+		'rejects %s',
+		( input ) => {
+			expect( normaliseAspectRatio( input ) ).toBeNull()
+		},
+	)
+} )

--- a/resources/js/visual-editor/blocks/_shared/photo-grid/__tests__/wrapper.test.ts
+++ b/resources/js/visual-editor/blocks/_shared/photo-grid/__tests__/wrapper.test.ts
@@ -109,6 +109,42 @@ describe( 'getPhotoGridWrapperProps', () => {
 		expect( ( result.style as Record< string, string > )[ '--ap-photo-grid-position' ] ).toBe( '50% 50%' )
 	} )
 
+	it.each( [ null, 0, false, [], {} ] as const )(
+		'defaults objectPosition to 50%% 50%% for malformed value %p',
+		( bad ) => {
+			const result = getPhotoGridWrapperProps( {
+				photoGrid: {
+					enabled: true,
+					aspectRatio: '1/1',
+					objectFit: 'cover',
+					objectPosition: bad as unknown as string,
+				},
+			} )
+
+			expect(
+				( result.style as Record< string, string > )[ '--ap-photo-grid-position' ],
+			).toBe( '50% 50%' )
+		},
+	)
+
+	it.each( [ '50% 50%; color: red', '50% 50%}{background: red', '50%<script>' ] )(
+		'rejects CSS-breakout attempts in objectPosition (%s)',
+		( bad ) => {
+			const result = getPhotoGridWrapperProps( {
+				photoGrid: {
+					enabled: true,
+					aspectRatio: '1/1',
+					objectFit: 'cover',
+					objectPosition: bad,
+				},
+			} )
+
+			expect(
+				( result.style as Record< string, string > )[ '--ap-photo-grid-position' ],
+			).toBe( '50% 50%' )
+		},
+	)
+
 	it( 'defaults objectFit to cover for unknown tokens', () => {
 		const result = getPhotoGridWrapperProps( {
 			photoGrid: {

--- a/resources/js/visual-editor/blocks/_shared/photo-grid/controls.tsx
+++ b/resources/js/visual-editor/blocks/_shared/photo-grid/controls.tsx
@@ -1,0 +1,290 @@
+/**
+ * Photo Grid inspector controls (#594).
+ *
+ * Renders the Photo Grid sub-section that appears in the Dimensions
+ * panel of `artisanpack/group`, `artisanpack/columns`, and
+ * `artisanpack/grid`. Reads / writes the block's `photoGrid`
+ * attribute and pulls defaults from `settings.artisanpack.photoGrid`
+ * (theme.json → editorSettings).
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.2.0
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import type { ReactElement } from 'react'
+import {
+	PanelBody,
+	SelectControl,
+	TextControl,
+	ToggleControl,
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
+} from '@wordpress/components'
+import { useSettings } from '@wordpress/block-editor'
+import { __ } from '@wordpress/i18n'
+
+import {
+	PHOTO_GRID_ATTRIBUTE_DEFAULT,
+	PHOTO_GRID_DEFAULTS,
+	type PhotoGridAttribute,
+	type PhotoGridDefaults,
+	type PhotoGridObjectFit,
+} from './types'
+import { normaliseAspectRatio } from './wrapper'
+
+interface PhotoGridControlsProps {
+	photoGrid: PhotoGridAttribute | null | undefined
+	onChange: ( next: PhotoGridAttribute ) => void
+}
+
+const ASPECT_RATIO_PRESETS: ReadonlyArray< { label: string; value: string } > = [
+	{ label: __( 'Inherit container' ), value: '' },
+	{ label: '1:1', value: '1/1' },
+	{ label: '4:3', value: '4/3' },
+	{ label: '3:2', value: '3/2' },
+	{ label: '16:9', value: '16/9' },
+	{ label: '3:4', value: '3/4' },
+	{ label: '9:16', value: '9/16' },
+	{ label: __( 'Custom…' ), value: '__custom__' },
+]
+
+const OBJECT_POSITION_CELLS: ReadonlyArray< { label: string; value: string } > = [
+	{ label: __( 'Top left' ),     value: '0% 0%' },
+	{ label: __( 'Top center' ),   value: '50% 0%' },
+	{ label: __( 'Top right' ),    value: '100% 0%' },
+	{ label: __( 'Center left' ),  value: '0% 50%' },
+	{ label: __( 'Center' ),       value: '50% 50%' },
+	{ label: __( 'Center right' ), value: '100% 50%' },
+	{ label: __( 'Bottom left' ),  value: '0% 100%' },
+	{ label: __( 'Bottom center' ),value: '50% 100%' },
+	{ label: __( 'Bottom right' ), value: '100% 100%' },
+]
+
+function useThemePhotoGridDefaults(): PhotoGridDefaults {
+	// `useSettings` reads the dotted path from `__experimentalFeatures`
+	// surfaced via `editorSettings`. Falls back to package-level
+	// defaults when theme.json does not define them.
+	const [
+		enable,
+		defaultAspectRatio,
+		defaultObjectFit,
+		defaultObjectPosition,
+	] = ( useSettings as any )(
+		'artisanpack.photoGrid.enable',
+		'artisanpack.photoGrid.defaultAspectRatio',
+		'artisanpack.photoGrid.defaultObjectFit',
+		'artisanpack.photoGrid.defaultObjectPosition',
+	) as ReadonlyArray< unknown >
+
+	return {
+		enable: typeof enable === 'boolean' ? enable : PHOTO_GRID_DEFAULTS.enable,
+		defaultAspectRatio:
+			typeof defaultAspectRatio === 'string'
+				? defaultAspectRatio
+				: defaultAspectRatio === null
+					? null
+					: PHOTO_GRID_DEFAULTS.defaultAspectRatio,
+		defaultObjectFit:
+			defaultObjectFit === 'contain' ? 'contain' : 'cover',
+		defaultObjectPosition:
+			typeof defaultObjectPosition === 'string' && defaultObjectPosition !== ''
+				? defaultObjectPosition
+				: PHOTO_GRID_DEFAULTS.defaultObjectPosition,
+	}
+}
+
+function resolveValue(
+	photoGrid: PhotoGridAttribute | null | undefined,
+	defaults: PhotoGridDefaults,
+): PhotoGridAttribute {
+	return {
+		enabled: photoGrid?.enabled === true,
+		aspectRatio:
+			photoGrid?.aspectRatio !== undefined
+				? photoGrid.aspectRatio
+				: defaults.defaultAspectRatio,
+		objectFit:
+			photoGrid?.objectFit === 'contain' || photoGrid?.objectFit === 'cover'
+				? photoGrid.objectFit
+				: defaults.defaultObjectFit,
+		objectPosition:
+			typeof photoGrid?.objectPosition === 'string' && photoGrid.objectPosition !== ''
+				? photoGrid.objectPosition
+				: defaults.defaultObjectPosition,
+	}
+}
+
+function isPresetRatio( value: string | null ): boolean {
+	if ( value === null ) {
+		return true
+	}
+	return ASPECT_RATIO_PRESETS.some( ( p ) => p.value === value )
+}
+
+export function PhotoGridControls( {
+	photoGrid,
+	onChange,
+}: PhotoGridControlsProps ): ReactElement | null {
+	const defaults = useThemePhotoGridDefaults()
+	if ( ! defaults.enable ) {
+		return null
+	}
+
+	const value         = resolveValue( photoGrid, defaults )
+	const aspectIsPreset = isPresetRatio( value.aspectRatio )
+	const ratioDropdownValue = value.aspectRatio === null
+		? ''
+		: ( aspectIsPreset ? value.aspectRatio : '__custom__' )
+
+	function emit( next: Partial< PhotoGridAttribute > ): void {
+		onChange( { ...PHOTO_GRID_ATTRIBUTE_DEFAULT, ...value, ...next } )
+	}
+
+	function onAspectRatioChange( nextDropdown: string ): void {
+		if ( nextDropdown === '' ) {
+			emit( { aspectRatio: null } )
+			return
+		}
+		if ( nextDropdown === '__custom__' ) {
+			// Seed the custom field with the current value (if it was
+			// already a custom ratio) or fall back to the theme default.
+			const seed = aspectIsPreset
+				? defaults.defaultAspectRatio ?? '1/1'
+				: value.aspectRatio ?? '1/1'
+			emit( { aspectRatio: seed } )
+			return
+		}
+		emit( { aspectRatio: nextDropdown } )
+	}
+
+	function onCustomAspectChange( raw: string ): void {
+		// Accept the raw string while typing; normalisation runs at
+		// render time inside `getPhotoGridWrapperProps`. Empty string
+		// reverts to "inherit container".
+		emit( { aspectRatio: raw === '' ? null : raw } )
+	}
+
+	const customAspectInvalid =
+		! aspectIsPreset
+		&& value.aspectRatio !== null
+		&& normaliseAspectRatio( value.aspectRatio ) === null
+
+	return (
+		<PanelBody title={ __( 'Photo Grid' ) } initialOpen={ false }>
+			<ToggleControl
+				/* @ts-expect-error - upstream prop */
+				__nextHasNoMarginBottom
+				label={ __( 'Enable Photo Grid' ) }
+				help={ __(
+					'Force every image inside this container onto a uniform aspect ratio.',
+				) }
+				checked={ value.enabled }
+				onChange={ ( enabled: boolean ) => emit( { enabled } ) }
+			/>
+			{ value.enabled && (
+				<>
+					<SelectControl
+						/* @ts-expect-error - upstream prop */
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						label={ __( 'Aspect ratio' ) }
+						value={ ratioDropdownValue }
+						options={ ASPECT_RATIO_PRESETS.map( ( p ) => ( {
+							label: p.label,
+							value: p.value,
+						} ) ) }
+						onChange={ onAspectRatioChange }
+					/>
+					{ ratioDropdownValue === '__custom__' && (
+						<TextControl
+							/* @ts-expect-error - upstream prop */
+							__next40pxDefaultSize
+							__nextHasNoMarginBottom
+							label={ __( 'Custom ratio (W/H)' ) }
+							placeholder="16/9"
+							value={ value.aspectRatio ?? '' }
+							onChange={ onCustomAspectChange }
+							help={
+								customAspectInvalid
+									? __(
+										'Invalid ratio. Enter a positive W/H value (e.g. 21/9).',
+									)
+									: undefined
+							}
+						/>
+					) }
+					<ToggleGroupControl
+						/* @ts-expect-error - upstream prop */
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						isBlock
+						label={ __( 'Object fit' ) }
+						value={ value.objectFit }
+						onChange={ ( next: string | number | undefined ) =>
+							emit( {
+								objectFit:
+									next === 'contain'
+										? 'contain'
+										: ( 'cover' as PhotoGridObjectFit ),
+							} )
+						}
+					>
+						<ToggleGroupControlOption value="cover" label={ __( 'Cover' ) } />
+						<ToggleGroupControlOption value="contain" label={ __( 'Contain' ) } />
+					</ToggleGroupControl>
+					<div
+						className="ap-photo-grid-position-picker"
+						role="radiogroup"
+						aria-label={ __( 'Object position' ) }
+						style={ {
+							display: 'grid',
+							gridTemplateColumns: 'repeat(3, 1fr)',
+							gap: '4px',
+							marginBlock: '12px',
+						} }
+					>
+						{ OBJECT_POSITION_CELLS.map( ( cell ) => {
+							const selected = value.objectPosition === cell.value
+							return (
+								<button
+									key={ cell.value }
+									type="button"
+									role="radio"
+									aria-checked={ selected }
+									aria-label={ cell.label }
+									title={ cell.label }
+									onClick={ () =>
+										emit( { objectPosition: cell.value } )
+									}
+									style={ {
+										aspectRatio: '1 / 1',
+										border: selected
+											? '2px solid var(--wp-admin-theme-color, #007cba)'
+											: '1px solid #ddd',
+										background: selected ? '#007cba22' : '#fff',
+										cursor: 'pointer',
+										padding: 0,
+									} }
+								/>
+							)
+						} ) }
+					</div>
+					<TextControl
+						/* @ts-expect-error - upstream prop */
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						label={ __( 'Object position (x% y%)' ) }
+						value={ value.objectPosition }
+						placeholder="50% 50%"
+						onChange={ ( raw: string ) =>
+							emit( {
+								objectPosition: raw === '' ? '50% 50%' : raw,
+							} )
+						}
+					/>
+				</>
+			) }
+		</PanelBody>
+	)
+}

--- a/resources/js/visual-editor/blocks/_shared/photo-grid/index.ts
+++ b/resources/js/visual-editor/blocks/_shared/photo-grid/index.ts
@@ -1,0 +1,18 @@
+/**
+ * Public barrel for shared Photo Grid controls (#594).
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.2.0
+ */
+
+export { PhotoGridControls } from './controls'
+export { getPhotoGridWrapperProps, normaliseAspectRatio } from './wrapper'
+export type { PhotoGridWrapperProps } from './wrapper'
+export {
+	PHOTO_GRID_ATTRIBUTE_DEFAULT,
+	PHOTO_GRID_DEFAULTS,
+	type PhotoGridAttribute,
+	type PhotoGridAspectRatio,
+	type PhotoGridDefaults,
+	type PhotoGridObjectFit,
+} from './types'

--- a/resources/js/visual-editor/blocks/_shared/photo-grid/photo-grid.css
+++ b/resources/js/visual-editor/blocks/_shared/photo-grid/photo-grid.css
@@ -1,0 +1,113 @@
+/**
+ * Photo Grid stylesheet (#594).
+ *
+ * Loaded by every container block that opts into the feature
+ * (group / columns / grid) as well as the Blade renderer. Scoped to
+ * `.has-photo-grid` so it never leaks into other containers.
+ *
+ * The container stamps three CSS custom properties on its wrapper:
+ *
+ *   --ap-photo-grid-aspect    e.g. `1/1`, `16/9` (omitted = inherit)
+ *   --ap-photo-grid-fit       `cover` | `contain`
+ *   --ap-photo-grid-position  e.g. `50% 50%`
+ *
+ * Image-bearing descendants (the WP image / cover blocks and raw
+ * `<img>` / `<picture>` markup) inherit them via `var()` lookups so
+ * an inner Photo Grid setting wins by virtue of being closer in the
+ * tree (`var()` resolves on the nearest ancestor that defined the
+ * property).
+ *
+ * Two sizing strategies coexist:
+ *
+ *  1. **Explicit aspect ratio set** — `aspect-ratio + width:100%`
+ *     computes the image height. `flex: 1` is harmless because the
+ *     intrinsic ratio dominates.
+ *  2. **Inherit container** (no aspect set) — the figure is made a
+ *     flex item with `flex: 1 1 auto` so it stretches to fill its
+ *     parent layout slot (e.g. a `wp-block-column`'s main axis), and
+ *     the image inside fills the figure via `height: 100%` + object-
+ *     fit. This is the mode that makes columns of mixed-ratio images
+ *     line up to the tallest column.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.2.0
+ */
+
+/*
+ * Make every column inside a Photo Grid columns container a flex
+ * column. WP's `.wp-block-column` is only a flex *item* by default
+ * (it grows inside `.wp-block-columns`), not a flex container — so
+ * the figure inside has no main axis to stretch along until we set
+ * one. `align-items: stretch` on the parent already makes the
+ * columns equal-height; this gives the figure inside a slot to fill.
+ */
+.has-photo-grid :is(.wp-block-column, .wp-block-artisanpack-column) {
+	display: flex;
+	flex-direction: column;
+}
+
+/*
+ * Stretch the image-block wrapper to fill its parent layout slot.
+ * Inside the now-flex column above, `flex: 1 1 auto` causes the
+ * figure to claim the column's remaining main-axis space. Inside
+ * non-flex parents the `flex` shorthand is a no-op, so the figure
+ * falls back to natural sizing.
+ *
+ * `display: flex; flex-direction: column` on the figure itself lets
+ * `height: 100%` resolve against the figure's flex-resolved height
+ * for the image, while a sibling `<figcaption>` keeps its natural
+ * height (flex item with default `flex: 0 1 auto`).
+ */
+.has-photo-grid :is(.wp-block-image, .wp-block-artisanpack-image) {
+	display: flex;
+	flex: 1 1 auto;
+	flex-direction: column;
+	min-height: 0;
+	width: 100%;
+}
+
+.has-photo-grid :is(.wp-block-image, .wp-block-artisanpack-image) > picture {
+	display: flex;
+	flex: 1 1 auto;
+	min-height: 0;
+	width: 100%;
+}
+
+.has-photo-grid :is(.wp-block-image, .wp-block-artisanpack-image) > :is(img, picture > img) {
+	aspect-ratio: var(--ap-photo-grid-aspect, auto);
+	flex: 1 1 auto;
+	min-height: 0;
+	object-fit: var(--ap-photo-grid-fit, cover);
+	object-position: var(--ap-photo-grid-position, 50% 50%);
+	width: 100%;
+	height: 100%;
+}
+
+.has-photo-grid :is(.wp-block-cover, .wp-block-artisanpack-cover) {
+	aspect-ratio: var(--ap-photo-grid-aspect, auto);
+	flex: 1 1 auto;
+	min-height: 0;
+	width: 100%;
+}
+
+.has-photo-grid :is(.wp-block-cover, .wp-block-artisanpack-cover) > :is(img, video, .wp-block-cover__image-background, .wp-block-cover__video-background) {
+	object-fit: var(--ap-photo-grid-fit, cover);
+	object-position: var(--ap-photo-grid-position, 50% 50%);
+	width: 100%;
+	height: 100%;
+}
+
+/*
+ * Raw markup catch-all. Applies the cascade at any depth so authors do
+ * not need to re-enable the setting on nested containers. Uses
+ * `:where()` to keep specificity at (0,0,1,0) — any deliberate per-image
+ * rule from the theme or block-level inline styles wins, mirroring how
+ * WordPress core scopes its own layout rules.
+ */
+:where(.has-photo-grid) :is(img, picture) {
+	aspect-ratio: var(--ap-photo-grid-aspect, auto);
+	object-fit: var(--ap-photo-grid-fit, cover);
+	object-position: var(--ap-photo-grid-position, 50% 50%);
+	width: 100%;
+	height: 100%;
+}

--- a/resources/js/visual-editor/blocks/_shared/photo-grid/photo-grid.css
+++ b/resources/js/visual-editor/blocks/_shared/photo-grid/photo-grid.css
@@ -66,14 +66,14 @@
 	width: 100%;
 }
 
-.has-photo-grid :is(.wp-block-image, .wp-block-artisanpack-image) > picture {
+.has-photo-grid :is(.wp-block-image, .wp-block-artisanpack-image) > :is(picture, a) {
 	display: flex;
 	flex: 1 1 auto;
 	min-height: 0;
 	width: 100%;
 }
 
-.has-photo-grid :is(.wp-block-image, .wp-block-artisanpack-image) > :is(img, picture > img) {
+.has-photo-grid :is(.wp-block-image, .wp-block-artisanpack-image) > :is(img, a > img, picture > img) {
 	aspect-ratio: var(--ap-photo-grid-aspect, auto);
 	flex: 1 1 auto;
 	min-height: 0;

--- a/resources/js/visual-editor/blocks/_shared/photo-grid/types.ts
+++ b/resources/js/visual-editor/blocks/_shared/photo-grid/types.ts
@@ -1,0 +1,49 @@
+/**
+ * Photo Grid attribute shape (#594).
+ *
+ * Container-level setting that normalises image-bearing descendants
+ * onto a uniform aspect ratio. Orthogonal to layout — authors still
+ * pick flex/grid/columns themselves; Photo Grid only enforces fill
+ * behaviour for nested images.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.2.0
+ */
+
+export type PhotoGridObjectFit = 'cover' | 'contain'
+
+/**
+ * Aspect ratio key shipped in the preset dropdown. `null` means
+ * "inherit container" — the descendants don't get `aspect-ratio`
+ * stamped on them and follow whatever sizing the container provides
+ * (CSS-grid row, fixed height, etc.).
+ */
+export type PhotoGridAspectRatio = string | null
+
+export interface PhotoGridAttribute {
+	enabled: boolean
+	aspectRatio: PhotoGridAspectRatio
+	objectFit: PhotoGridObjectFit
+	objectPosition: string
+}
+
+export interface PhotoGridDefaults {
+	enable: boolean
+	defaultAspectRatio: PhotoGridAspectRatio
+	defaultObjectFit: PhotoGridObjectFit
+	defaultObjectPosition: string
+}
+
+export const PHOTO_GRID_DEFAULTS: PhotoGridDefaults = {
+	enable: true,
+	defaultAspectRatio: '1/1',
+	defaultObjectFit: 'cover',
+	defaultObjectPosition: '50% 50%',
+}
+
+export const PHOTO_GRID_ATTRIBUTE_DEFAULT: PhotoGridAttribute = {
+	enabled: false,
+	aspectRatio: '1/1',
+	objectFit: 'cover',
+	objectPosition: '50% 50%',
+}

--- a/resources/js/visual-editor/blocks/_shared/photo-grid/wrapper.ts
+++ b/resources/js/visual-editor/blocks/_shared/photo-grid/wrapper.ts
@@ -67,7 +67,17 @@ function normaliseObjectPosition(value: unknown): string {
 		return '50% 50%'
 	}
 	const trimmed = value.trim()
-	return trimmed === '' ? '50% 50%' : trimmed
+	if (trimmed === '') {
+		return '50% 50%'
+	}
+	// Reject CSS declaration / rule delimiters so a tampered
+	// `objectPosition` cannot break out of the `--ap-photo-grid-
+	// position` declaration and inject sibling rules. Mirrors
+	// `PhotoGridSupport::normaliseObjectPosition()` on the PHP side.
+	if (/[;{}<>]/.test(trimmed)) {
+		return '50% 50%'
+	}
+	return trimmed
 }
 
 /**

--- a/resources/js/visual-editor/blocks/_shared/photo-grid/wrapper.ts
+++ b/resources/js/visual-editor/blocks/_shared/photo-grid/wrapper.ts
@@ -1,0 +1,102 @@
+/**
+ * Photo Grid wrapper serializer (#594).
+ *
+ * Mirrors `PhotoGridSupport::wrapper()` on the Blade renderer. Given a
+ * block's attribute bag, returns the CSS class + inline style props
+ * the editor save / canvas-side block wrapper needs to switch the
+ * container into Photo Grid mode.
+ *
+ * The wrapper emits one class (`has-photo-grid`) and three CSS custom
+ * properties (`--ap-photo-grid-aspect`, `--ap-photo-grid-fit`,
+ * `--ap-photo-grid-position`) that the matching stylesheet
+ * (`photo-grid.css`) targets to size image-bearing descendants.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.2.0
+ */
+
+import type { CSSProperties } from 'react'
+
+import type { PhotoGridAttribute } from './types'
+
+export interface PhotoGridWrapperProps {
+	className?: string
+	style?: CSSProperties
+}
+
+interface AttributeBag {
+	photoGrid?: PhotoGridAttribute | null
+}
+
+/**
+ * Sanitise an aspect ratio token. Accepts the dropdown presets, a
+ * custom `W/H` string (digits, slash, optional decimals), or `null`
+ * for "inherit container". Anything else collapses to `null` so the
+ * wrapper falls back to the descendant's natural aspect.
+ */
+export function normaliseAspectRatio(value: unknown): string | null {
+	if (value === null || value === undefined || value === '') {
+		return null
+	}
+	if (typeof value !== 'string') {
+		return null
+	}
+	const trimmed = value.trim()
+	if (trimmed === '' || trimmed === 'auto' || trimmed === 'inherit') {
+		return null
+	}
+	// Accept `W/H` with positive numeric W and H. Reject negatives,
+	// zero, and anything that isn't a pair of numbers separated by a
+	// single slash.
+	if (!/^\d+(\.\d+)?\/\d+(\.\d+)?$/.test(trimmed)) {
+		return null
+	}
+	const [w, h] = trimmed.split('/').map(Number)
+	if (!Number.isFinite(w) || !Number.isFinite(h) || w <= 0 || h <= 0) {
+		return null
+	}
+	return trimmed
+}
+
+function normaliseObjectFit(value: unknown): 'cover' | 'contain' {
+	return value === 'contain' ? 'contain' : 'cover'
+}
+
+function normaliseObjectPosition(value: unknown): string {
+	if (typeof value !== 'string') {
+		return '50% 50%'
+	}
+	const trimmed = value.trim()
+	return trimmed === '' ? '50% 50%' : trimmed
+}
+
+/**
+ * Resolve the wrapper props for a block. Returns an empty object
+ * when the setting is disabled or missing — callers should spread the
+ * result into their existing wrapper props.
+ */
+export function getPhotoGridWrapperProps(
+	attributes: AttributeBag | null | undefined,
+): PhotoGridWrapperProps {
+	const photoGrid = attributes?.photoGrid ?? null
+	if (!photoGrid || photoGrid.enabled !== true) {
+		return {}
+	}
+
+	const aspect = normaliseAspectRatio(photoGrid.aspectRatio)
+	const fit = normaliseObjectFit(photoGrid.objectFit)
+	const position = normaliseObjectPosition(photoGrid.objectPosition)
+
+	const style: Record<string, string> = {
+		'--ap-photo-grid-fit': fit,
+		'--ap-photo-grid-position': position,
+	}
+	if (aspect !== null) {
+		style['--ap-photo-grid-aspect'] = aspect
+	}
+
+	return {
+		className: 'has-photo-grid',
+		style: style as CSSProperties,
+	}
+}

--- a/resources/js/visual-editor/blocks/columns/block.json
+++ b/resources/js/visual-editor/blocks/columns/block.json
@@ -35,6 +35,10 @@
         "artisanpackFlex": {
             "type": "object",
             "default": null
+        },
+        "photoGrid": {
+            "type": "object",
+            "default": null
         }
     },
     "supports": {

--- a/resources/js/visual-editor/blocks/columns/edit.tsx
+++ b/resources/js/visual-editor/blocks/columns/edit.tsx
@@ -49,6 +49,11 @@ import {
     serializeFlex,
     type ArtisanpackFlexAttribute,
 } from '../_shared/flex-controls';
+import {
+    PhotoGridControls,
+    getPhotoGridWrapperProps,
+    type PhotoGridAttribute,
+} from '../_shared/photo-grid';
 
 const COLUMN_BLOCK = 'artisanpack/column';
 const DEFAULT_BLOCK = { name: COLUMN_BLOCK };
@@ -59,6 +64,7 @@ interface ColumnsAttributes {
     readonly templateLock?: string | boolean;
     readonly columnCount?: number;
     readonly artisanpackFlex?: ArtisanpackFlexAttribute | null;
+    readonly photoGrid?: PhotoGridAttribute | null;
 }
 
 interface ColumnsEditProps {
@@ -238,6 +244,7 @@ function ColumnsEditContainer({
         attributes.artisanpackFlex ?? null,
         flexRegistry,
     );
+    const photoGridWrapper = getPhotoGridWrapperProps(attributes);
     const classes = clsx(
         'wp-block-columns',
         {
@@ -245,9 +252,13 @@ function ColumnsEditContainer({
             ['is-not-stacked-on-mobile']: !isStackedOnMobile,
         },
         flexResult.classes,
+        photoGridWrapper.className,
     );
 
-    const blockProps = (useBlockProps as any)({ className: classes });
+    const blockProps = (useBlockProps as any)({
+        className: classes,
+        style: photoGridWrapper.style,
+    });
     const innerBlocksProps = (useInnerBlocksProps as any)(blockProps, {
         defaultBlock: DEFAULT_BLOCK,
         directInsert: true,
@@ -289,6 +300,10 @@ function ColumnsEditContainer({
                         setAttributes({ artisanpackFlex: next })
                     }
                     registry={flexRegistry}
+                />
+                <PhotoGridControls
+                    photoGrid={attributes.photoGrid ?? null}
+                    onChange={(next) => setAttributes({ photoGrid: next })}
                 />
             </InspectorControls>
             <div {...innerBlocksProps} />

--- a/resources/js/visual-editor/blocks/columns/index.ts
+++ b/resources/js/visual-editor/blocks/columns/index.ts
@@ -16,6 +16,7 @@ import icon from './inserter-icon';
 
 import './columns.css';
 import '../../../../css/flex-layout.css';
+import '../_shared/photo-grid/photo-grid.css';
 
 export {
     edit,

--- a/resources/js/visual-editor/blocks/columns/save.tsx
+++ b/resources/js/visual-editor/blocks/columns/save.tsx
@@ -16,12 +16,17 @@ import {
     serializeFlex,
     type ArtisanpackFlexAttribute,
 } from '../_shared/flex-controls';
+import {
+    getPhotoGridWrapperProps,
+    type PhotoGridAttribute,
+} from '../_shared/photo-grid';
 import { BreakpointRegistry } from '../../responsive/registry';
 
 interface ColumnsSaveAttributes {
     readonly verticalAlignment?: string;
     readonly isStackedOnMobile?: boolean;
     readonly artisanpackFlex?: ArtisanpackFlexAttribute | null;
+    readonly photoGrid?: PhotoGridAttribute | null;
 }
 
 export default function columnsSave({
@@ -34,6 +39,7 @@ export default function columnsSave({
         attributes.artisanpackFlex ?? null,
         new BreakpointRegistry(),
     );
+    const photoGridWrapper = getPhotoGridWrapperProps(attributes);
     const className = clsx(
         'wp-block-columns',
         {
@@ -41,9 +47,13 @@ export default function columnsSave({
             ['is-not-stacked-on-mobile']: !isStackedOnMobile,
         },
         flexResult.classes,
+        photoGridWrapper.className,
     );
 
-    const blockProps = (useBlockProps.save as any)({ className });
+    const blockProps = (useBlockProps.save as any)({
+        className,
+        style: photoGridWrapper.style,
+    });
     const innerBlocksProps = (useInnerBlocksProps.save as any)(blockProps);
 
     return <div {...innerBlocksProps} />;

--- a/resources/js/visual-editor/blocks/grid/block.json
+++ b/resources/js/visual-editor/blocks/grid/block.json
@@ -15,6 +15,10 @@
         "numColumns": {
             "type": "number",
             "default": 4
+        },
+        "photoGrid": {
+            "type": "object",
+            "default": null
         }
     },
     "providesContext": {

--- a/resources/js/visual-editor/blocks/grid/edit.tsx
+++ b/resources/js/visual-editor/blocks/grid/edit.tsx
@@ -20,9 +20,15 @@ import { PanelBody, RangeControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 import { TEXT_DOMAIN } from '../../vendor/i18n';
+import {
+    PhotoGridControls,
+    getPhotoGridWrapperProps,
+    type PhotoGridAttribute,
+} from '../_shared/photo-grid';
 
 interface GridAttributes {
     readonly numColumns: number;
+    readonly photoGrid?: PhotoGridAttribute | null;
 }
 
 interface GridEditProps {
@@ -53,8 +59,15 @@ function clampColumns(value: number | undefined, fallback: number): number {
 export default function GridEdit({ attributes, setAttributes }: GridEditProps): ReactElement {
     const numColumns = clampColumns(attributes.numColumns, 4);
 
-    const className = `ap-grid ap-grid-has-${numColumns}-base-columns`;
-    const blockProps = useBlockProps({ className });
+    const photoGridWrapper = getPhotoGridWrapperProps(attributes);
+    const className = [
+        'ap-grid',
+        `ap-grid-has-${numColumns}-base-columns`,
+        photoGridWrapper.className,
+    ]
+        .filter(Boolean)
+        .join(' ');
+    const blockProps = useBlockProps({ className, style: photoGridWrapper.style });
     const innerBlocksProps = useInnerBlocksProps(blockProps, {
         allowedBlocks: ALLOWED_BLOCKS,
         template: TEMPLATE,
@@ -77,6 +90,10 @@ export default function GridEdit({ attributes, setAttributes }: GridEditProps): 
                         __nextHasNoMarginBottom
                     />
                 </PanelBody>
+                <PhotoGridControls
+                    photoGrid={attributes.photoGrid ?? null}
+                    onChange={(next) => setAttributes({ photoGrid: next })}
+                />
             </InspectorControls>
             <div {...innerBlocksProps} />
         </>

--- a/resources/js/visual-editor/blocks/grid/index.ts
+++ b/resources/js/visual-editor/blocks/grid/index.ts
@@ -12,6 +12,7 @@ import save from './save';
 import icon from './inserter-icon';
 
 import './grid.css';
+import '../_shared/photo-grid/photo-grid.css';
 
 export { edit, save, metadata, icon };
 

--- a/resources/js/visual-editor/blocks/group/__tests__/edit.test.tsx
+++ b/resources/js/visual-editor/blocks/group/__tests__/edit.test.tsx
@@ -68,6 +68,8 @@ vi.mock('@wordpress/block-editor', () => ({
         ...props,
         children: null,
     }),
+    // #594 — Photo Grid controls read theme defaults via `useSettings`.
+    useSettings: (...paths: string[]): unknown[] => paths.map(() => undefined),
     store: 'block-editor-store',
 }));
 

--- a/resources/js/visual-editor/blocks/group/block.json
+++ b/resources/js/visual-editor/blocks/group/block.json
@@ -32,6 +32,10 @@
         "artisanpackFlex": {
             "type": "object",
             "default": null
+        },
+        "photoGrid": {
+            "type": "object",
+            "default": null
         }
     },
     "supports": {

--- a/resources/js/visual-editor/blocks/group/edit.tsx
+++ b/resources/js/visual-editor/blocks/group/edit.tsx
@@ -30,6 +30,11 @@ import {
     serializeFlex,
     type ArtisanpackFlexAttribute,
 } from '../_shared/flex-controls';
+import {
+    PhotoGridControls,
+    getPhotoGridWrapperProps,
+    type PhotoGridAttribute,
+} from '../_shared/photo-grid';
 import { BreakpointRegistry } from '../../responsive/registry';
 
 interface GroupAttributes {
@@ -42,6 +47,7 @@ interface GroupAttributes {
     readonly textColor?: string;
     readonly fontSize?: string;
     readonly artisanpackFlex?: ArtisanpackFlexAttribute | null;
+    readonly photoGrid?: PhotoGridAttribute | null;
 }
 
 interface GroupEditControlsProps {
@@ -116,10 +122,16 @@ export default function GroupEdit({
         attributes.artisanpackFlex ?? null,
         flexRegistry,
     );
+    const photoGridWrapper = getPhotoGridWrapperProps(attributes);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const blockProps = (useBlockProps as any)({
         ref,
-        className: clsx('wp-block-group', flexResult.classes),
+        className: clsx(
+            'wp-block-group',
+            flexResult.classes,
+            photoGridWrapper.className,
+        ),
+        style: photoGridWrapper.style,
     });
 
     const [showPlaceholder, setShowPlaceholder] = useShouldShowPlaceHolder({
@@ -183,6 +195,10 @@ export default function GroupEdit({
                         setAttributes({ artisanpackFlex: next })
                     }
                     registry={flexRegistry}
+                />
+                <PhotoGridControls
+                    photoGrid={attributes.photoGrid ?? null}
+                    onChange={(next) => setAttributes({ photoGrid: next })}
                 />
             </InspectorControls>
             {showPlaceholder && (

--- a/resources/js/visual-editor/blocks/group/index.ts
+++ b/resources/js/visual-editor/blocks/group/index.ts
@@ -18,6 +18,7 @@ import icon from './inserter-icon';
 
 import './group.css';
 import '../../../../css/flex-layout.css';
+import '../_shared/photo-grid/photo-grid.css';
 import './suppress-core-flex';
 
 export { edit, save, metadata, icon, deprecated, transforms, variations };

--- a/resources/js/visual-editor/blocks/group/save.tsx
+++ b/resources/js/visual-editor/blocks/group/save.tsx
@@ -16,11 +16,16 @@ import {
     serializeFlex,
     type ArtisanpackFlexAttribute,
 } from '../_shared/flex-controls';
+import {
+    getPhotoGridWrapperProps,
+    type PhotoGridAttribute,
+} from '../_shared/photo-grid';
 import { BreakpointRegistry } from '../../responsive/registry';
 
 interface GroupSaveAttributes {
     readonly tagName?: string;
     readonly artisanpackFlex?: ArtisanpackFlexAttribute | null;
+    readonly photoGrid?: PhotoGridAttribute | null;
 }
 
 export default function groupSave({
@@ -33,9 +38,15 @@ export default function groupSave({
         attributes.artisanpackFlex ?? null,
         new BreakpointRegistry(),
     );
+    const photoGridWrapper = getPhotoGridWrapperProps(attributes);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const blockProps = (useBlockProps.save as any)({
-        className: clsx('wp-block-group', flexResult.classes),
+        className: clsx(
+            'wp-block-group',
+            flexResult.classes,
+            photoGridWrapper.className,
+        ),
+        style: photoGridWrapper.style,
     });
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const innerBlocksProps = (useInnerBlocksProps.save as any)(blockProps);

--- a/resources/js/visual-editor/editor/canvas-styles.ts
+++ b/resources/js/visual-editor/editor/canvas-styles.ts
@@ -36,6 +36,7 @@ import {
 
 import canvasThemeTokens from './canvas-theme-tokens.css?inline';
 import flexLayoutStyles from '../../../css/flex-layout.css?inline';
+import photoGridStyles from '../blocks/_shared/photo-grid/photo-grid.css?inline';
 
 /** A single stylesheet entry in the shape `BlockCanvas`'s `styles` prop expects. */
 export interface CanvasStyle {
@@ -188,6 +189,13 @@ export const canvasStyles: readonly CanvasStyle[] = [
     // it to the iframe explicitly so `.ap-flex` and per-breakpoint
     // utilities resolve inside the canvas.
     { css: flexLayoutStyles },
+    // Photo Grid container support (#594). Lives at
+    // `blocks/_shared/photo-grid/photo-grid.css` — three levels deep,
+    // so the two-level `blocks/*/*.css` glob below skips it. Hand it
+    // to the iframe explicitly so `.has-photo-grid` rules and the
+    // `--ap-photo-grid-*` custom property fallbacks resolve inside
+    // the canvas.
+    { css: photoGridStyles },
     // Every block-authored stylesheet, auto-discovered via the
     // `blocks/*/*.css` glob (#566). Replaces the per-block manual
     // entries that used to sit here and forced an edit to

--- a/resources/js/visual-editor/editor/canvas-styles.ts
+++ b/resources/js/visual-editor/editor/canvas-styles.ts
@@ -189,18 +189,18 @@ export const canvasStyles: readonly CanvasStyle[] = [
     // it to the iframe explicitly so `.ap-flex` and per-breakpoint
     // utilities resolve inside the canvas.
     { css: flexLayoutStyles },
-    // Photo Grid container support (#594). Lives at
-    // `blocks/_shared/photo-grid/photo-grid.css` — three levels deep,
-    // so the two-level `blocks/*/*.css` glob below skips it. Hand it
-    // to the iframe explicitly so `.has-photo-grid` rules and the
-    // `--ap-photo-grid-*` custom property fallbacks resolve inside
-    // the canvas.
-    { css: photoGridStyles },
     // Every block-authored stylesheet, auto-discovered via the
     // `blocks/*/*.css` glob (#566). Replaces the per-block manual
     // entries that used to sit here and forced an edit to
     // canvas-styles.ts every time a new custom block landed.
     ...blockStylesheets,
+    // Photo Grid container support (#594). Lives at
+    // `blocks/_shared/photo-grid/photo-grid.css` — three levels deep,
+    // so the two-level `blocks/*/*.css` glob above skips it. Hand
+    // it to the iframe explicitly. Loaded *after* the per-block
+    // stylesheets so the cascade matches the front-end order in
+    // `blocks-styles.blade.php` (block-family CSS before photo-grid).
+    { css: photoGridStyles },
     { css: EDITOR_BLOCK_TWEAKS },
     { css: DEFAULT_CANVAS_STYLES },
     // Per-block wide/full overrides. Shared with the site editor —

--- a/resources/js/visual-editor/use-themed-editor-settings.ts
+++ b/resources/js/visual-editor/use-themed-editor-settings.ts
@@ -235,6 +235,22 @@ export function extractThemeSpacingSizes(
     return out.length === 0 ? null : out;
 }
 
+/**
+ * Pull `settings.artisanpack.photoGrid` defaults out of the
+ * `/global-styles/base` payload (#594). Returns `null` when the theme
+ * has not defined them so the editor falls back to package-level
+ * defaults shipped in `_shared/photo-grid/types.ts`.
+ */
+export function extractThemePhotoGrid(
+    settings: Record<string, unknown>,
+): Record<string, unknown> | null {
+    const ap = (settings.artisanpack as { photoGrid?: unknown } | undefined)?.photoGrid;
+    if (ap === null || ap === undefined || typeof ap !== 'object' || Array.isArray(ap)) {
+        return null;
+    }
+    return ap as Record<string, unknown>;
+}
+
 export function extractThemeGradients(
     settings: Record<string, unknown>,
 ): readonly GradientEntry[] | null {
@@ -299,6 +315,7 @@ export function useThemedEditorSettings(
         const themeFontFamilies = extractThemeFontFamilies(themeSettings);
         const themeSpacingSizes = extractThemeSpacingSizes(themeSettings);
         const themeGradients = extractThemeGradients(themeSettings);
+        const themePhotoGrid = extractThemePhotoGrid(themeSettings);
 
         // #490 — propagate the theme's color-customization booleans so
         // Gutenberg's `useSettings('color.customGradient')` / `'color.custom'`
@@ -328,6 +345,7 @@ export function useThemedEditorSettings(
         const needsFontFamilies = themeFontFamilies !== null;
         const needsSpacingSizes = themeSpacingSizes !== null;
         const needsGradients = themeGradients !== null;
+        const needsPhotoGrid = themePhotoGrid !== null;
 
         if (
             !needsStyles &&
@@ -335,7 +353,8 @@ export function useThemedEditorSettings(
             !needsFontSizes &&
             !needsFontFamilies &&
             !needsSpacingSizes &&
-            !needsGradients
+            !needsGradients &&
+            !needsPhotoGrid
         ) {
             if (extraSettings !== undefined && Object.keys(extraSettings).length > 0) {
                 return { ...editorSettings, ...extraSettings };
@@ -354,6 +373,8 @@ export function useThemedEditorSettings(
             (baseFeatures as { typography?: Record<string, unknown> }).typography ?? {};
         const baseSpacing =
             (baseFeatures as { spacing?: Record<string, unknown> }).spacing ?? {};
+        const baseArtisanpack =
+            (baseFeatures as { artisanpack?: Record<string, unknown> }).artisanpack ?? {};
 
         return {
             ...editorSettings,
@@ -415,6 +436,18 @@ export function useThemedEditorSettings(
                                   ...((baseSpacing as { spacingSizes?: Record<string, unknown> })
                                       .spacingSizes ?? {}),
                                   theme: themeSpacingSizes,
+                              },
+                          }
+                        : {}),
+                },
+                artisanpack: {
+                    ...baseArtisanpack,
+                    ...(needsPhotoGrid
+                        ? {
+                              photoGrid: {
+                                  ...((baseArtisanpack as { photoGrid?: Record<string, unknown> })
+                                      .photoGrid ?? {}),
+                                  ...(themePhotoGrid as Record<string, unknown>),
                               },
                           }
                         : {}),

--- a/resources/theme-json/default-base.php
+++ b/resources/theme-json/default-base.php
@@ -61,12 +61,23 @@ return [
 		// panel entirely by setting `enable` to false (already-saved
 		// content keeps rendering through the wrapper classes).
 		'artisanpack' => [
-			'flex' => [
+			'flex'      => [
 				'enable'                => true,
 				'defaultDirection'      => 'row',
 				'defaultJustifyContent' => null,
 				'defaultAlignItems'     => null,
 				'defaultGap'            => [ 'row' => null, 'column' => null ],
+			],
+			// #594 — Photo Grid container support. Themes can disable
+			// the feature entirely by setting `enable` to false; already-
+			// saved content continues to render because the renderer
+			// reads the per-block `photoGrid` attribute independently
+			// of the inspector visibility flag.
+			'photoGrid' => [
+				'enable'                => true,
+				'defaultAspectRatio'    => '1/1',
+				'defaultObjectFit'      => 'cover',
+				'defaultObjectPosition' => '50% 50%',
 			],
 		],
 	],


### PR DESCRIPTION
## Description

Adds a `photoGrid` container setting to `artisanpack/group`, `artisanpack/columns`, and `artisanpack/grid`. The setting normalises image-bearing descendants onto a uniform aspect ratio without changing the container's own layout (authors still pick flex/grid/columns themselves). Replaces the crosswinds-framework `.photo-grid` CSS-class glue with a first-class, themable inspector control.

**Closes:** #594

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #594

## Motivation and Context

The crosswinds-framework theme shipped a `.photo-grid` CSS class that forced child images to behave like uniform gallery cells. It worked but required authors to type a class name in the Advanced panel, the behaviour wasn't discoverable, and themes outside crosswinds-framework couldn't opt in without copying the CSS. This PR makes the behaviour native, discoverable in the Dimensions inspector, and themeable via `theme.json`.

## Changes Made

- New shared editor module at `resources/js/visual-editor/blocks/_shared/photo-grid/` — `<PhotoGridControls />`, `getPhotoGridWrapperProps()`, `normaliseAspectRatio()`, scoped `photo-grid.css`, types.
- `photoGrid` attribute added to group/columns/grid `block.json`; `<PhotoGridControls />` mounted in the Dimensions InspectorControls slot of each `edit.tsx`; wrapper props merged into each `save.tsx` / `edit.tsx` `useBlockProps`.
- Theme defaults surfaced through `useThemedEditorSettings` under `__experimentalFeatures.artisanpack.photoGrid` with package-level fallbacks.
- New `packages/visual-editor-renderer-blade/src/Support/PhotoGridSupport.php` mirrors the editor wrapper helper. Emits `has-photo-grid` + a scoped class; CSS custom properties (`--ap-photo-grid-aspect`, `--ap-photo-grid-fit`, `--ap-photo-grid-position`) are pushed into the per-request `ResponsiveCssAccumulator` (same pattern as `FlexSupport`).
- `<x-ve-blocks-styles>` registers the new `photo-grid.css` link tag; renderer asset + editor canvas `canvas-styles.ts` both load it.
- `core/group`, `core/columns`, and `artisanpack/grid` Blade views call `PhotoGridSupport::wrapperForBlock()` and merge the result into `BlockSupports::wrapperAttrs()`.
- `settings.artisanpack.photoGrid` defaults added to `resources/theme-json/default-base.php` (`enable: true`, `defaultAspectRatio: "1/1"`, `defaultObjectFit: "cover"`, `defaultObjectPosition: "50% 50%"`).
- New `docs/photo-grid.md`; linked from `docs/site-editor.md`.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS Darwin 25.5.0
- Browser: Chrome (latest)
- PHP Version: 8.4.3
- Project Version: 1.2 (release branch)

**Tests Performed:**
1. PHP — `PhotoGridSupportTest` (14 tests, 35 assertions) and full `visual-editor-renderer-blade` suite (351 tests, 957 assertions) all green; no regressions.
2. JS — new wrapper + controls tests (28 tests) and touched group/columns/grid + `use-themed-editor-settings` suites (69 tests) all green; full JS suite passes except 17 pre-existing unrelated failures in `site-editor/__tests__/site-editor-app.test.tsx` (confirmed unrelated by running on clean `release/1.2`).
3. Manual — inserted columns block with two mixed-ratio images, toggled Photo Grid on, verified inspector panel renders + emits attributes, confirmed editor canvas and front-end output match. Verified "Inherit container" stretches the image figure to fill the column slot.

## Accessibility Tests Run

- [x] Keyboard navigation tested — focus moves through toggle, aspect dropdown, fit toggle, position picker.
- [x] Screen reader tested — controls have descriptive `__()` labels; position picker uses `role="radiogroup"` + `role="radio"` with `aria-label` per cell.
- [x] Color contrast verified — no new colour tokens introduced; position picker uses admin theme color tokens.
- [x] ARIA labels checked — all interactive elements have explicit labels.

**Details:** Images keep their `alt` text (unchanged); the fixed-aspect container does not alter document order, so screen-reader announcement order is preserved.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:**
- `packages/visual-editor-renderer-blade/tests/Feature/PhotoGridSupportTest.php` — 14 cases covering attribute combinations, normalisation, scope-class hashing, and accumulator integration.
- `resources/js/visual-editor/blocks/_shared/photo-grid/__tests__/wrapper.test.ts` — 24 cases for `getPhotoGridWrapperProps` + `normaliseAspectRatio`, including malformed input + unknown `objectFit` token defaulting.
- `resources/js/visual-editor/blocks/_shared/photo-grid/__tests__/controls.test.tsx` — 4 cases for the controls component (toggle / theme-default propagation).

## Documentation

- [x] Inline code documentation added
- [ ] README updated — not needed; feature documented in dedicated page.
- [x] Wiki updated — `docs/photo-grid.md` added; `docs/site-editor.md` links to it.
- [ ] API documentation updated — n/a (no public API changes).

**Documentation details:** New `docs/photo-grid.md` author guide covering inspector controls, cascade behaviour, theme.json defaults. Existing block docs (`docs/blocks/group.md` etc.) don't exist in this repo, so they were not linked.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted (matches sibling WordPress-style spacing convention; php-cs-fixer not installed in checkout)
- [x] Accessibility tests completed
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced Photo Grid container setting for Group, Columns, and Grid, enabling uniform image aspect ratios within containers.
  * Added editor controls for enabling/disabling, aspect ratio presets (including custom), image fit (cover/contain), and object position.
  * Automatically applies Photo Grid styling via scoped CSS and consistent image sizing/positioning.
* **Documentation**
  * Added and cross-linked Photo Grid documentation in the site editor guides.
* **Tests**
  * Added coverage for Photo Grid wrapper behavior and editor control interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->