### PR TITLE
feat: per-post layout overrides on Query Loop (variant system)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,29 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- **Per-post layout overrides on the Query Loop via post-variants
+  (#591).** New `artisanpack/post-variant` block, child of
+  `artisanpack/post-template`, declares an override template that
+  swaps in for posts matching its `matcher` attribute. Four matcher
+  kinds ship in V1: `position` (`first` / `last` / `nth:<n>` /
+  `range:<from>-<to>`), `pattern` (`odd` / `even` /
+  `every-nth:<step>[:start:<offset>]`), `meta` (`sticky`, `featured`,
+  `has-featured-image`, `author:<id>`, `taxonomy:<tax>:<slug>`), and
+  `custom` (`callback:<name>` → `apve_query_variant_match_<name>`
+  filter hook). A new "Post Variants" panel in the query inspector
+  lists, adds, reorders, and deletes variants. Static rules
+  (position / pattern) precompile to a 0-based `position →
+  variantOrder` map stored on the parent post-template as
+  `_compiledVariantMap` for O(1) lookup; dynamic rules (`meta`,
+  `custom`) resolve at render time via the new
+  `ArtisanPackUI\VisualEditor\Resources\VariantResolver`. Precedence
+  is fixed: instance > position > pattern > meta > custom > base,
+  with `priority` ascending as the tie-breaker. All three renderers
+  (Blade, React, Vue) consume the same inlined tree — variants are
+  stripped server-side by `QueryInliner`, so existing query loops
+  with no variants render identically to before. Items rendered via
+  a variant carry an extra `is-variant` class on their
+  `core/post-template-item` wrapper for downstream styling.
 - **Native flex layout panel on group / column / columns / grid-item
   (#595).** New `Flex Layout` + `Flex Item` inspector panels expose
   every CSS flexbox property — direction, wrap, justify, align-items,

--- a/docs/Hooks-and-Events.md
+++ b/docs/Hooks-and-Events.md
@@ -129,6 +129,25 @@ See [[post-editor/Livewire Integration]] for the full Livewire recipe and [[post
 
 ---
 
+### `apve_query_variant_match_<name>`
+
+Resolve a `custom`-kind matcher on an `artisanpack/post-variant` block (see [[blocks/Post Variants]]). The filter name is composed from the variant's `matcher.value` of the form `callback:<name>`.
+
+**Signature:** `bool $matches, object $post, array $context -> bool`
+
+```php
+use function ArtisanPackUI\Hooks\addFilter;
+
+addFilter('apve_query_variant_match_premium', function (bool $matches, object $post, array $context): bool {
+    // $context => ['index' => int (0-based loop position), 'total' => int]
+    return true === ($post->is_premium ?? false);
+}, 10, 3);
+```
+
+Return `true` to make the variant match the current post. Variant precedence is fixed (instance > position > pattern > meta > custom > base) so a callback can be overridden by a higher-tier rule.
+
+---
+
 ## Authorization gates
 
 The site editor's access surface is controlled by a single boot-time contract:

--- a/docs/blocks/Post-Variants.md
+++ b/docs/blocks/Post-Variants.md
@@ -1,0 +1,106 @@
+# Post Variants (Query Loop)
+
+Per-post layout overrides for the Query Loop block. A query can
+declare any number of *variants*; each variant has a matcher rule and
+its own block template. At render time, each post in the loop is
+checked against the variants and rendered with the winning variant —
+falling back to the base Post Template when no variant matches.
+
+## Why
+
+Pre-Gutenberg PHP gave authors full control via `the_loop()` and CSS
+`:nth-child` — make the first post a hero card while the rest render
+as a compact list, alternate odd/even card styles, give sticky posts a
+different layout. Gutenberg's Query Loop renders every post with the
+same Post Template. Variants close that gap.
+
+## Block: `artisanpack/post-variant`
+
+Nested under `artisanpack/post-template`. The variant's `innerBlocks`
+are the override template. Attributes:
+
+| Attribute | Type | Notes |
+|-----------|------|-------|
+| `matcher` | object `{ kind, value }` | The rule. See "Matcher kinds" below. |
+| `priority` | number (default `10`) | Tie-breaker inside a precedence tier. Lower wins. |
+| `label` | string | Optional human label shown in the "Post Variants" panel. |
+
+## Matcher kinds
+
+| Kind | Examples | Where it resolves |
+|------|----------|-------------------|
+| `position` | `first`, `last`, `nth:3`, `range:4-6`, `instance:<n1>` | Compiled to a `position → variantOrder` map at save time. |
+| `pattern` | `odd`, `even`, `every-nth:3`, `every-nth:3:start:2` | Same fast path as `position`. |
+| `meta` | `sticky`, `featured`, `has-featured-image`, `author:42`, `taxonomy:category:news` | Walked at render time — needs the post object. |
+| `custom` | `callback:<name>` | Resolved server-side via `apve_query_variant_match_<name>` filter. |
+
+`every-nth:<step>` follows CSS `:nth-child(<step>n)` semantics — the
+first match is at position `step` (e.g. `every-nth:3` → posts 3, 6,
+9). Add `:start:<offset>` to shift (`every-nth:3:start:2` → posts 2,
+5, 8).
+
+## Precedence
+
+For each post the renderer picks the first match in this fixed order:
+
+1. `instance` — `position` matchers with the `instance:` prefix (canvas click-to-edit)
+2. `position` — `first`, `last`, `nth`, `range`
+3. `pattern` — `odd`, `even`, `every-nth`
+4. `meta` — structural metadata
+5. `custom` — callback hooks
+6. Base `artisanpack/post-template` content
+
+Inside a tier, ties break on `priority` (ascending) then document
+order.
+
+## Editor UX
+
+A "Post Variants" panel in the query block's right-sidebar inspector
+lists every variant. Per-row controls: select-to-edit (focuses the
+variant's InnerBlocks in the canvas), move up/down (re-orders),
+delete. "Add" buttons add a new variant of each kind.
+
+When a variant is selected its own inspector exposes the matcher kind
++ value, an optional label, and the priority.
+
+## Render-side resolution (hybrid)
+
+Save-time compilation walks `position` and `pattern` rules and writes
+a 0-based `index → variantOrder` map to the parent post-template's
+`_compiledVariantMap` attribute. The server-side `QueryInliner` reads
+that map first for O(1) lookup. When the map misses (older saves,
+`meta`, `custom`), the resolver walks variants in precedence order and
+evaluates matchers against the post.
+
+Items rendered via a variant carry an extra `is-variant` class on
+their `core/post-template-item` wrapper for downstream styling.
+
+## Custom matchers (PHP filter)
+
+Register a custom rule by name and resolve it server-side:
+
+```php
+use function ArtisanPackUI\Hooks\addFilter;
+
+addFilter( 'apve_query_variant_match_premium', function ( bool $matches, object $post, array $context ): bool {
+    // $context provides ['index' => int, 'total' => int]
+    return true === ( $post->is_premium ?? false ) && 0 === $context['index'];
+}, 10, 3 );
+```
+
+Then set the variant's matcher to `{ kind: 'custom', value: 'callback:premium' }`.
+
+## Backward compatibility
+
+Purely additive. Query loops with zero variants render identically to
+before — the inliner's variant-detection step is a no-op when no
+`artisanpack/post-variant` children are present, and the precompiled
+map attribute is stripped from the rendered tree.
+
+## Renderer parity
+
+All three renderers register the block (the React/Vue components are
+pass-through; Blade is a recursive render-block include) so the parity
+check stays green, but in practice the server-side `QueryInliner`
+strips variants from the rendered tree — they only ever materialize
+as the per-post template clone.

--- a/packages/renderer-parity.json
+++ b/packages/renderer-parity.json
@@ -106,6 +106,7 @@
         "artisanpack/term-description",
         "artisanpack/query",
         "artisanpack/post-template",
+        "artisanpack/post-variant",
         "artisanpack/comments",
         "artisanpack/comment-template",
         "artisanpack/comment-author-avatar",

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/post-variant.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/post-variant.blade.php
@@ -1,0 +1,15 @@
+{{--
+	artisanpack/post-variant (#591).
+
+	The server-side QueryInliner strips post-variant blocks from the
+	rendered tree before the renderer sees them — variants are
+	template overrides, not blocks that emit markup. This view exists
+	to satisfy the renderer parity check and to provide a safe
+	pass-through if a variant ever reaches the renderer (e.g. a
+	host-side render of an un-inlined tree).
+--}}
+@if ( isset( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) )
+	@foreach ( $block['innerBlocks'] as $innerBlock )
+		@include('visual-editor-renderer-blade::render-block', [ 'block' => $innerBlock ])
+	@endforeach
+@endif

--- a/packages/visual-editor-renderer-react/src/blocks/core/query.tsx
+++ b/packages/visual-editor-renderer-react/src/blocks/core/query.tsx
@@ -72,6 +72,19 @@ export function PostTemplateBlock({ attributes, children }: BlockRendererProps):
     return <ul className={classes}>{children}</ul>;
 }
 
+/**
+ * `artisanpack/post-variant` (#591) is stripped from the inner-block
+ * tree by the server-side `QueryInliner` before the renderer ever
+ * walks it: variant children survive only as the per-iteration
+ * template clone, never as their own block. The renderer still
+ * registers the block so the parity check stays green and so any
+ * client-rendered preview tree (which can include un-inlined variants)
+ * has somewhere to fall through.
+ */
+export function PostVariantBlock({ children }: BlockRendererProps): JSX.Element {
+    return <>{children}</>;
+}
+
 export function PostTemplateItemBlock({ attributes, children }: BlockRendererProps): JSX.Element {
     // Coerce numeric strings ("123") to numbers so the `post-{id}` id stamps
     // regardless of whether the host serialized the attribute as a number or a

--- a/packages/visual-editor-renderer-react/src/blocks/registerCoreBlocks.ts
+++ b/packages/visual-editor-renderer-react/src/blocks/registerCoreBlocks.ts
@@ -117,7 +117,7 @@ import {
     ReadMoreBlock,
     TermDescriptionBlock,
 } from './core/postNavigation';
-import { PostTemplateBlock, PostTemplateItemBlock, QueryBlock } from './core/query';
+import { PostTemplateBlock, PostTemplateItemBlock, PostVariantBlock, QueryBlock } from './core/query';
 import { SiteLogoBlock, SiteTaglineBlock, SiteTitleBlock } from './core/siteContext';
 import { SyncedPatternBlock } from './core/syncedPattern';
 import { TemplatePartBlock } from './core/templatePart';
@@ -207,6 +207,7 @@ const CORE_BLOCKS: Record<string, BlockRenderer> = {
     'core/post-template': PostTemplateBlock,
     'artisanpack/query': QueryBlock,
     'artisanpack/post-template': PostTemplateBlock,
+    'artisanpack/post-variant': PostVariantBlock,
     'core/post-template-item': PostTemplateItemBlock,
     'core/post-title': PostTitleBlock,
     'artisanpack/post-title': PostTitleBlock,

--- a/packages/visual-editor-renderer-vue/src/blocks/core/query.ts
+++ b/packages/visual-editor-renderer-vue/src/blocks/core/query.ts
@@ -79,6 +79,21 @@ export const PostTemplateBlock = defineComponent({
     },
 });
 
+/**
+ * `artisanpack/post-variant` (#591) is stripped from the inner-block
+ * tree by the server-side `QueryInliner` before render — the variant's
+ * children survive only as the per-iteration clone. The renderer
+ * registers the block as a pass-through so the parity check stays
+ * green and so any client-rendered preview tree has a fall-through.
+ */
+export const PostVariantBlock = defineComponent({
+    name: 'PostVariantBlock',
+    props: blockRendererProps,
+    setup(_props, { slots }) {
+        return () => slots.default?.();
+    },
+});
+
 export const PostTemplateItemBlock = defineComponent({
     name: 'PostTemplateItemBlock',
     props: blockRendererProps,

--- a/packages/visual-editor-renderer-vue/src/blocks/registerCoreBlocks.ts
+++ b/packages/visual-editor-renderer-vue/src/blocks/registerCoreBlocks.ts
@@ -117,7 +117,7 @@ import {
     ReadMoreBlock,
     TermDescriptionBlock,
 } from './core/postNavigation';
-import { PostTemplateBlock, PostTemplateItemBlock, QueryBlock } from './core/query';
+import { PostTemplateBlock, PostTemplateItemBlock, PostVariantBlock, QueryBlock } from './core/query';
 import { SiteLogoBlock, SiteTaglineBlock, SiteTitleBlock } from './core/siteContext';
 import { SyncedPatternBlock } from './core/syncedPattern';
 import { TemplatePartBlock } from './core/templatePart';
@@ -206,6 +206,7 @@ const CORE_BLOCKS: Record<string, BlockRenderer> = {
     'core/post-template': PostTemplateBlock,
     'artisanpack/query': QueryBlock,
     'artisanpack/post-template': PostTemplateBlock,
+    'artisanpack/post-variant': PostVariantBlock,
     'core/post-template-item': PostTemplateItemBlock,
     'core/block': SyncedPatternBlock,
     'core/post-title': PostTitleBlock,

--- a/resources/js/visual-editor/blocks/post-template/block.json
+++ b/resources/js/visual-editor/blocks/post-template/block.json
@@ -17,6 +17,10 @@
         "columns": {
             "type": "number",
             "default": 3
+        },
+        "_compiledVariantMap": {
+            "type": "object",
+            "default": {}
         }
     },
     "usesContext": [

--- a/resources/js/visual-editor/blocks/post-variant/block.json
+++ b/resources/js/visual-editor/blocks/post-variant/block.json
@@ -1,0 +1,40 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "artisanpack/post-variant",
+    "title": "Post Variant",
+    "category": "theme",
+    "parent": [
+        "artisanpack/post-template"
+    ],
+    "description": "Per-position override template for the Query Loop. Posts matching the variant's rule render with the variant's inner blocks instead of the base Post Template.",
+    "textdomain": "artisanpack-visual-editor",
+    "attributes": {
+        "matcher": {
+            "type": "object",
+            "default": {
+                "kind": "position",
+                "value": "first"
+            }
+        },
+        "priority": {
+            "type": "number",
+            "default": 10
+        },
+        "label": {
+            "type": "string"
+        }
+    },
+    "usesContext": [
+        "queryId",
+        "query",
+        "displayLayout",
+        "postType"
+    ],
+    "supports": {
+        "html": false,
+        "reusable": false,
+        "layout": false,
+        "inserter": false
+    }
+}

--- a/resources/js/visual-editor/blocks/post-variant/edit.tsx
+++ b/resources/js/visual-editor/blocks/post-variant/edit.tsx
@@ -1,0 +1,229 @@
+/**
+ * Post Variant — edit component (#591).
+ *
+ * Inspector exposes the matcher kind + value, an optional human label,
+ * and a priority for tie-breaking inside a precedence tier. The body
+ * is `<InnerBlocks />` — the variant template that overrides the base
+ * post-template for matching posts.
+ */
+
+import type { ReactElement } from 'react';
+import {
+    InnerBlocks,
+    InspectorControls,
+    useBlockProps,
+} from '@wordpress/block-editor';
+import {
+    Notice,
+    PanelBody,
+    RangeControl,
+    SelectControl,
+    TextControl,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+import { TEXT_DOMAIN } from '../../vendor/i18n';
+import type { Matcher, MatcherKind } from '../../editor/variant-matcher';
+
+interface PostVariantAttributes {
+    readonly matcher?: Matcher;
+    readonly priority?: number;
+    readonly label?: string;
+}
+
+interface PostVariantEditProps {
+    attributes: PostVariantAttributes;
+    setAttributes: ( changes: Partial<PostVariantAttributes> ) => void;
+}
+
+const POSITION_PRESETS: ReadonlyArray<{ value: string; label: string }> = [
+    { value: 'first', label: 'First post' },
+    { value: 'last', label: 'Last post' },
+    { value: 'nth:2', label: '2nd post' },
+    { value: 'nth:3', label: '3rd post' },
+    { value: 'range:1-3', label: 'Posts 1–3' },
+];
+
+const PATTERN_PRESETS: ReadonlyArray<{ value: string; label: string }> = [
+    { value: 'odd', label: 'Odd posts' },
+    { value: 'even', label: 'Even posts' },
+    { value: 'every-nth:3', label: 'Every 3rd post' },
+    { value: 'every-nth:4', label: 'Every 4th post' },
+];
+
+const META_PRESETS: ReadonlyArray<{ value: string; label: string }> = [
+    { value: 'sticky', label: 'Sticky posts' },
+    { value: 'featured', label: 'Featured posts' },
+    { value: 'has-featured-image', label: 'Posts with a featured image' },
+];
+
+function getMatcher( attributes: PostVariantAttributes ): Matcher {
+    if (
+        attributes.matcher &&
+        typeof attributes.matcher.kind === 'string' &&
+        typeof attributes.matcher.value === 'string'
+    ) {
+        return attributes.matcher;
+    }
+    return { kind: 'position', value: 'first' };
+}
+
+function defaultValueForKind( kind: MatcherKind ): string {
+    switch ( kind ) {
+        case 'position':
+            return 'first';
+        case 'pattern':
+            return 'odd';
+        case 'meta':
+            return 'sticky';
+        case 'custom':
+            return 'callback:';
+    }
+}
+
+export default function PostVariantEdit( {
+    attributes,
+    setAttributes,
+}: PostVariantEditProps ): ReactElement {
+    const matcher = getMatcher( attributes );
+    const priority = typeof attributes.priority === 'number' ? attributes.priority : 10;
+    const label = typeof attributes.label === 'string' ? attributes.label : '';
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const blockProps = ( useBlockProps as any )( {
+        className: 'wp-block-artisanpack-post-variant',
+        'data-variant-kind': matcher.kind,
+        'data-variant-value': matcher.value,
+    } );
+
+    const setMatcher = ( next: Matcher ): void => {
+        setAttributes( { matcher: next } );
+    };
+
+    const handleKindChange = ( raw: string ): void => {
+        const kind = raw as MatcherKind;
+        if ( kind === matcher.kind ) {
+            return;
+        }
+        setMatcher( { kind, value: defaultValueForKind( kind ) } as Matcher );
+    };
+
+    const presets =
+        matcher.kind === 'position'
+            ? POSITION_PRESETS
+            : matcher.kind === 'pattern'
+              ? PATTERN_PRESETS
+              : matcher.kind === 'meta'
+                ? META_PRESETS
+                : null;
+
+    const summary = buildSummary( matcher, label );
+
+    return (
+        <div { ...blockProps }>
+            <InspectorControls>
+                <PanelBody title={ __( 'Variant rule', TEXT_DOMAIN ) }>
+                    <TextControl
+                        __next40pxDefaultSize
+                        __nextHasNoMarginBottom
+                        label={ __( 'Label', TEXT_DOMAIN ) }
+                        value={ label }
+                        onChange={ ( value: string ) => setAttributes( { label: value } ) }
+                        help={ __( 'Shown in the parent query block\'s "Post Variants" panel.', TEXT_DOMAIN ) }
+                    />
+                    <SelectControl
+                        __next40pxDefaultSize
+                        __nextHasNoMarginBottom
+                        label={ __( 'Matcher kind', TEXT_DOMAIN ) }
+                        value={ matcher.kind }
+                        options={ [
+                            { value: 'position', label: __( 'Position', TEXT_DOMAIN ) },
+                            { value: 'pattern', label: __( 'Pattern (odd / even / every Nth)', TEXT_DOMAIN ) },
+                            { value: 'meta', label: __( 'Metadata (sticky, featured, taxonomy, author)', TEXT_DOMAIN ) },
+                            { value: 'custom', label: __( 'Custom callback', TEXT_DOMAIN ) },
+                        ] }
+                        onChange={ handleKindChange }
+                    />
+                    { presets !== null && (
+                        <SelectControl
+                            // @ts-expect-error - upstream prop
+                            __next40pxDefaultSize
+                            __nextHasNoMarginBottom
+                            label={ __( 'Preset', TEXT_DOMAIN ) }
+                            value={
+                                presets.some( ( p ) => p.value === matcher.value )
+                                    ? matcher.value
+                                    : ''
+                            }
+                            options={ [
+                                { value: '', label: __( 'Custom value…', TEXT_DOMAIN ) },
+                                ...presets.map( ( preset ) => ( {
+                                    value: preset.value,
+                                    label: __( preset.label, TEXT_DOMAIN ),
+                                } ) ),
+                            ] }
+                            onChange={ ( value: string ) => {
+                                if ( '' === value ) {
+                                    return;
+                                }
+                                setMatcher( { kind: matcher.kind, value } as Matcher );
+                            } }
+                        />
+                    ) }
+                    <TextControl
+                        __next40pxDefaultSize
+                        __nextHasNoMarginBottom
+                        label={ __( 'Matcher value', TEXT_DOMAIN ) }
+                        value={ matcher.value }
+                        onChange={ ( value: string ) =>
+                            setMatcher( { kind: matcher.kind, value } as Matcher )
+                        }
+                        help={ helpFor( matcher.kind ) }
+                    />
+                    <RangeControl
+                        __nextHasNoMarginBottom
+                        __next40pxDefaultSize
+                        label={ __( 'Priority', TEXT_DOMAIN ) }
+                        value={ priority }
+                        onChange={ ( value?: number ) =>
+                            setAttributes( { priority: value ?? 10 } )
+                        }
+                        min={ 0 }
+                        max={ 100 }
+                        help={ __( 'Lower numbers run first when variants share a precedence tier.', TEXT_DOMAIN ) }
+                    />
+                    { matcher.kind === 'custom' && (
+                        <Notice status="info" isDismissible={ false }>
+                            { __( 'Custom matchers are resolved server-side by the apve_query_variant_match_<name> filter hook.', TEXT_DOMAIN ) }
+                        </Notice>
+                    ) }
+                </PanelBody>
+            </InspectorControls>
+            <div className="wp-block-artisanpack-post-variant__summary" aria-hidden="true">
+                <span>{ summary }</span>
+            </div>
+            <InnerBlocks templateLock={ false } />
+        </div>
+    );
+}
+
+function helpFor( kind: MatcherKind ): string {
+    switch ( kind ) {
+        case 'position':
+            return __( 'first | last | nth:<n> | range:<from>-<to>', TEXT_DOMAIN );
+        case 'pattern':
+            return __( 'odd | even | every-nth:<step> | every-nth:<step>:start:<offset>', TEXT_DOMAIN );
+        case 'meta':
+            return __( 'sticky | featured | has-featured-image | author:<id> | taxonomy:<tax>:<slug>', TEXT_DOMAIN );
+        case 'custom':
+            return __( 'callback:<name> — resolved by apve_query_variant_match_<name>.', TEXT_DOMAIN );
+    }
+}
+
+function buildSummary( matcher: Matcher, label: string ): string {
+    const tag = `${ matcher.kind }:${ matcher.value }`;
+    if ( label && '' !== label ) {
+        return `${ label } · ${ tag }`;
+    }
+    return tag;
+}

--- a/resources/js/visual-editor/blocks/post-variant/index.ts
+++ b/resources/js/visual-editor/blocks/post-variant/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Post Variant block entrypoint (#591).
+ *
+ * Auto-discovered by `editor/custom-blocks.ts`. Child block of
+ * `artisanpack/post-template`: declares an override template that the
+ * server-side `QueryInliner` swaps in for posts matching its rule.
+ */
+
+import metadata from './block.json';
+import edit from './edit';
+import save from './save';
+import icon from './inserter-icon';
+
+export { edit, save, metadata, icon };
+
+export default {
+    name: metadata.name,
+    metadata,
+    edit,
+    save,
+    icon,
+};

--- a/resources/js/visual-editor/blocks/post-variant/inserter-icon.tsx
+++ b/resources/js/visual-editor/blocks/post-variant/inserter-icon.tsx
@@ -1,0 +1,20 @@
+/**
+ * Post Variant — inserter icon. Stacked-layers glyph signalling the
+ * override-template nature of the block.
+ */
+
+import type { ReactElement } from 'react';
+
+export default function PostVariantInserterIcon(): ReactElement {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            width={ 24 }
+            height={ 24 }
+            aria-hidden="true"
+        >
+            <path d="M4 8l8-4 8 4-8 4-8-4zm0 4l8 4 8-4M4 16l8 4 8-4" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round" strokeLinecap="round" />
+        </svg>
+    );
+}

--- a/resources/js/visual-editor/blocks/post-variant/save.tsx
+++ b/resources/js/visual-editor/blocks/post-variant/save.tsx
@@ -1,0 +1,20 @@
+/**
+ * Post Variant — save component.
+ *
+ * Dynamic-only: the server-side `QueryInliner` reads the variant's
+ * serialized `innerBlocks` and clones them per matching post. The
+ * client save emits a wrapper so the parent post-template's saved
+ * tree can round-trip the variant's children verbatim.
+ */
+
+import type { ReactElement } from 'react';
+import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
+
+export default function PostVariantSave(): ReactElement {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const blockProps = ( useBlockProps as any ).save();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const innerBlocksProps = ( useInnerBlocksProps as any ).save( blockProps );
+
+    return <div { ...innerBlocksProps } />;
+}

--- a/resources/js/visual-editor/blocks/query/edit.tsx
+++ b/resources/js/visual-editor/blocks/query/edit.tsx
@@ -30,6 +30,7 @@ import { __ } from '@wordpress/i18n';
 
 import { useQueryPreview } from '../../editor/use-query-preview';
 import { TEXT_DOMAIN } from '../../vendor/i18n';
+import PostVariantsPanel from './post-variants-panel';
 
 interface QueryEditProps {
     attributes: Record<string, unknown>;
@@ -190,6 +191,10 @@ export default function QueryEdit( {
                 <PanelBody title={ __( 'Preview', TEXT_DOMAIN ) } initialOpen={ false }>
                     <PreviewStatus preview={ preview } />
                 </PanelBody>
+                <PostVariantsPanel
+                    queryClientId={ clientId }
+                    previewTotal={ preview.status === 'ready' ? preview.total : 0 }
+                />
             </InspectorControls>
             <PreviewBanner preview={ preview } />
             <BlockContextProvider value={ blockContext }>

--- a/resources/js/visual-editor/blocks/query/post-variants-panel.css
+++ b/resources/js/visual-editor/blocks/query/post-variants-panel.css
@@ -1,0 +1,72 @@
+/*
+ * Post Variants panel (#591). Scoped to the inspector so it picks up
+ * the WordPress Components 13px panel base font-size — the canvas
+ * default of 16px otherwise leaks into the panel and oversizes
+ * everything (hint paragraph, action buttons, row labels).
+ */
+
+.ap-post-variants-panel__hint {
+    font-size: 12px;
+    line-height: 1.4;
+    color: rgb(117, 117, 117);
+    margin: 0 0 12px;
+}
+
+.ap-post-variants-panel__list {
+    list-style: none;
+    margin: 0 0 12px;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.ap-post-variants-panel__row {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding: 4px 8px;
+    background: rgb(247, 247, 247);
+    border-radius: 2px;
+    font-size: 12px;
+}
+
+.ap-post-variants-panel__row-label {
+    flex: 1;
+    background: transparent;
+    border: 0;
+    text-align: left;
+    cursor: pointer;
+    padding: 0;
+    font-size: 12px;
+    line-height: 1.3;
+    color: inherit;
+}
+
+.ap-post-variants-panel__row-label:focus-visible {
+    outline: 2px solid var(--wp-admin-theme-color, #007cba);
+    outline-offset: 1px;
+}
+
+.ap-post-variants-panel__row-rule {
+    color: rgb(117, 117, 117);
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 11px;
+}
+
+.ap-post-variants-panel__row-actions {
+    display: flex;
+    gap: 2px;
+    flex: 0 0 auto;
+}
+
+.ap-post-variants-panel__add {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    align-items: stretch;
+}
+
+.ap-post-variants-panel__add .components-button {
+    justify-content: center;
+}

--- a/resources/js/visual-editor/blocks/query/post-variants-panel.tsx
+++ b/resources/js/visual-editor/blocks/query/post-variants-panel.tsx
@@ -153,10 +153,14 @@ export default function PostVariantsPanel( {
     // `variantRows` reference, recompiles the map (identical bytes,
     // new object identity), and the effect fires again forever.
     const { compiledMap, compiledSignature } = useMemo( () => {
-        const total = Math.max( previewTotal, 1 );
+        // `previewTotal` is the count from the editor preview pipeline.
+        // Pass it through verbatim — the static map only carries
+        // `instance:` rules now, so a zero / loading preview just
+        // produces an empty map and the render-time resolver handles
+        // everything else with the live total.
         const map = compileStaticMap(
             variantRows.map( ( row ) => row.descriptor ),
-            total
+            previewTotal
         );
         return { compiledMap: map, compiledSignature: JSON.stringify( map ) };
     }, [ variantRows, previewTotal ] );

--- a/resources/js/visual-editor/blocks/query/post-variants-panel.tsx
+++ b/resources/js/visual-editor/blocks/query/post-variants-panel.tsx
@@ -1,0 +1,299 @@
+/**
+ * "Post Variants" panel for the Query Loop inspector (#591).
+ *
+ * - Lists every `artisanpack/post-variant` block under the query's
+ *   nested `post-template`.
+ * - Add / select / delete / reorder via `core/block-editor` dispatch.
+ * - Side-effect: writes the precompiled `position → variantId` map
+ *   onto the parent `post-template`'s `_compiledVariantMap` attribute
+ *   whenever variants change. The map is consumed by the server-side
+ *   inliner as the O(1) lookup for static (position / pattern) rules.
+ */
+
+import { useEffect, useMemo, type ReactElement } from 'react';
+import { Button, PanelBody } from '@wordpress/components';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { createBlock } from '@wordpress/blocks';
+import { __ } from '@wordpress/i18n';
+
+import { TEXT_DOMAIN } from '../../vendor/i18n';
+import {
+    type Matcher,
+    type VariantDescriptor,
+    compileStaticMap,
+} from '../../editor/variant-matcher';
+
+import './post-variants-panel.css';
+
+interface BlockEditorBlock {
+    clientId: string;
+    name: string;
+    attributes: Record<string, unknown>;
+    innerBlocks?: BlockEditorBlock[];
+}
+
+interface CoreBlockEditorSelect {
+    getBlocks: ( clientId?: string ) => BlockEditorBlock[];
+}
+
+interface CoreBlockEditorDispatch {
+    insertBlock: ( block: unknown, index?: number, rootClientId?: string ) => void;
+    moveBlockToPosition: (
+        clientId: string,
+        fromRootClientId: string,
+        toRootClientId: string,
+        index: number
+    ) => void;
+    removeBlock: ( clientId: string ) => void;
+    selectBlock: ( clientId: string ) => void;
+    updateBlockAttributes: ( clientId: string, attributes: Record<string, unknown> ) => void;
+}
+
+interface PostVariantsPanelProps {
+    readonly queryClientId: string;
+    readonly previewTotal: number;
+}
+
+interface VariantRow {
+    readonly clientId: string;
+    readonly descriptor: VariantDescriptor;
+}
+
+function readMatcher( attrs: Record<string, unknown> ): Matcher {
+    const raw = attrs.matcher;
+    if (
+        raw !== null &&
+        typeof raw === 'object' &&
+        ! Array.isArray( raw ) &&
+        typeof ( raw as { kind?: unknown } ).kind === 'string' &&
+        typeof ( raw as { value?: unknown } ).value === 'string'
+    ) {
+        return raw as Matcher;
+    }
+    return { kind: 'position', value: 'first' };
+}
+
+export default function PostVariantsPanel( {
+    queryClientId,
+    previewTotal,
+}: PostVariantsPanelProps ): ReactElement {
+    // Subscribe via a stable string signature so the panel only
+    // re-renders when something it actually cares about changes — NOT
+    // every time the parent dispatches an unrelated attribute update.
+    // Without this, writing `_compiledVariantMap` back to the
+    // post-template (the effect below) would feed back through the
+    // store, produce a new `variantRows` reference, recompute the map,
+    // and re-run the effect forever (#591 — manual-test infinite loop).
+    const subscription = useSelect(
+        ( select ) => {
+            const store = select( 'core/block-editor' ) as unknown as CoreBlockEditorSelect;
+            const queryChildren = store.getBlocks( queryClientId );
+            const postTemplate = queryChildren.find(
+                ( child ) =>
+                    child.name === 'artisanpack/post-template' ||
+                    child.name === 'core/post-template'
+            );
+            if ( ! postTemplate ) {
+                return {
+                    postTemplateClientId: null as string | null,
+                    variantRows: [] as VariantRow[],
+                    storedMapSignature: '',
+                };
+            }
+            const variantBlocks = ( postTemplate.innerBlocks ?? [] ).filter(
+                ( child ) => child.name === 'artisanpack/post-variant'
+            );
+            const rows: VariantRow[] = variantBlocks.map( ( block, idx ) => {
+                const attrs = block.attributes ?? {};
+                const matcher = readMatcher( attrs );
+                const priority =
+                    typeof attrs.priority === 'number' ? ( attrs.priority as number ) : 10;
+                const label =
+                    typeof attrs.label === 'string' ? ( attrs.label as string ) : undefined;
+                return {
+                    clientId: block.clientId,
+                    descriptor: {
+                        order: idx,
+                        matcher,
+                        priority,
+                        label,
+                    },
+                };
+            } );
+            const storedMap =
+                ( postTemplate.attributes as { _compiledVariantMap?: unknown } )
+                    ._compiledVariantMap;
+            return {
+                postTemplateClientId: postTemplate.clientId,
+                variantRows: rows,
+                storedMapSignature: JSON.stringify( storedMap ?? {} ),
+            };
+        },
+        [ queryClientId ]
+    );
+
+    const { postTemplateClientId, variantRows, storedMapSignature } = subscription;
+
+    const {
+        insertBlock,
+        moveBlockToPosition,
+        removeBlock,
+        selectBlock,
+        updateBlockAttributes,
+    } = useDispatch( 'core/block-editor' ) as unknown as CoreBlockEditorDispatch;
+
+    // Compile static rules into a position → variantOrder map and
+    // write it onto the post-template. Indexed by 0-based loop
+    // position to match the server-side inliner's `foreach (
+    // $results as $index => $post )`.
+    //
+    // We compare the compiled signature to what's already stored on
+    // the post-template before dispatching — otherwise the dispatched
+    // attribute change re-runs `useSelect`, produces a new
+    // `variantRows` reference, recompiles the map (identical bytes,
+    // new object identity), and the effect fires again forever.
+    const { compiledMap, compiledSignature } = useMemo( () => {
+        const total = Math.max( previewTotal, 1 );
+        const map = compileStaticMap(
+            variantRows.map( ( row ) => row.descriptor ),
+            total
+        );
+        return { compiledMap: map, compiledSignature: JSON.stringify( map ) };
+    }, [ variantRows, previewTotal ] );
+
+    useEffect( () => {
+        if ( postTemplateClientId === null ) {
+            return;
+        }
+        if ( compiledSignature === storedMapSignature ) {
+            return;
+        }
+        updateBlockAttributes( postTemplateClientId, {
+            _compiledVariantMap: compiledMap,
+        } );
+    }, [
+        compiledMap,
+        compiledSignature,
+        storedMapSignature,
+        postTemplateClientId,
+        updateBlockAttributes,
+    ] );
+
+    const handleAdd = ( kind: Matcher[ 'kind' ] ): void => {
+        if ( postTemplateClientId === null ) {
+            return;
+        }
+        const block = createBlock( 'artisanpack/post-variant', {
+            matcher: defaultMatcherFor( kind ),
+            priority: 10,
+        } );
+        insertBlock( block, variantRows.length, postTemplateClientId );
+    };
+
+    const handleMove = ( clientId: string, currentIndex: number, delta: number ): void => {
+        if ( postTemplateClientId === null ) {
+            return;
+        }
+        const target = currentIndex + delta;
+        if ( target < 0 || target >= variantRows.length ) {
+            return;
+        }
+        moveBlockToPosition(
+            clientId,
+            postTemplateClientId,
+            postTemplateClientId,
+            target
+        );
+    };
+
+    return (
+        <PanelBody title={ __( 'Post Variants', TEXT_DOMAIN ) } initialOpen={ false }>
+            { variantRows.length === 0 && (
+                <p className="ap-post-variants-panel__hint">
+                    { __(
+                        'Variants let specific posts in the loop render with a different template (e.g. make the first post a hero card while the rest render as a list).',
+                        TEXT_DOMAIN
+                    ) }
+                </p>
+            ) }
+            <ul className="ap-post-variants-panel__list">
+                { variantRows.map( ( row, idx ) => (
+                    <li key={ row.clientId } className="ap-post-variants-panel__row">
+                        <button
+                            type="button"
+                            className="ap-post-variants-panel__row-label"
+                            onClick={ () => selectBlock( row.clientId ) }
+                        >
+                            <strong>
+                                { row.descriptor.label && row.descriptor.label !== ''
+                                    ? row.descriptor.label
+                                    : __( 'Untitled variant', TEXT_DOMAIN ) }
+                            </strong>
+                            <span className="ap-post-variants-panel__row-rule">
+                                { ' · ' }
+                                { row.descriptor.matcher.kind }:
+                                { row.descriptor.matcher.value }
+                            </span>
+                        </button>
+                        <div className="ap-post-variants-panel__row-actions">
+                            <Button
+                                size="small"
+                                variant="tertiary"
+                                onClick={ () => handleMove( row.clientId, idx, -1 ) }
+                                disabled={ idx === 0 }
+                                aria-label={ __( 'Move variant up', TEXT_DOMAIN ) }
+                            >
+                                ↑
+                            </Button>
+                            <Button
+                                size="small"
+                                variant="tertiary"
+                                onClick={ () => handleMove( row.clientId, idx, 1 ) }
+                                disabled={ idx === variantRows.length - 1 }
+                                aria-label={ __( 'Move variant down', TEXT_DOMAIN ) }
+                            >
+                                ↓
+                            </Button>
+                            <Button
+                                size="small"
+                                variant="tertiary"
+                                isDestructive
+                                onClick={ () => removeBlock( row.clientId ) }
+                                aria-label={ __( 'Delete variant', TEXT_DOMAIN ) }
+                            >
+                                ×
+                            </Button>
+                        </div>
+                    </li>
+                ) ) }
+            </ul>
+            <div className="ap-post-variants-panel__add">
+                <Button size="small" variant="secondary" onClick={ () => handleAdd( 'position' ) }>
+                    { __( 'Add position variant', TEXT_DOMAIN ) }
+                </Button>
+                <Button size="small" variant="secondary" onClick={ () => handleAdd( 'pattern' ) }>
+                    { __( 'Add pattern variant', TEXT_DOMAIN ) }
+                </Button>
+                <Button size="small" variant="secondary" onClick={ () => handleAdd( 'meta' ) }>
+                    { __( 'Add metadata variant', TEXT_DOMAIN ) }
+                </Button>
+                <Button size="small" variant="secondary" onClick={ () => handleAdd( 'custom' ) }>
+                    { __( 'Add custom variant', TEXT_DOMAIN ) }
+                </Button>
+            </div>
+        </PanelBody>
+    );
+}
+
+function defaultMatcherFor( kind: Matcher[ 'kind' ] ): Matcher {
+    switch ( kind ) {
+        case 'position':
+            return { kind: 'position', value: 'first' };
+        case 'pattern':
+            return { kind: 'pattern', value: 'odd' };
+        case 'meta':
+            return { kind: 'meta', value: 'sticky' };
+        case 'custom':
+            return { kind: 'custom', value: 'callback:' };
+    }
+}

--- a/resources/js/visual-editor/editor/__tests__/variant-matcher.test.ts
+++ b/resources/js/visual-editor/editor/__tests__/variant-matcher.test.ts
@@ -91,33 +91,32 @@ describe( 'sortVariants precedence', () => {
 } );
 
 describe( 'compileStaticMap', () => {
-    it( 'compiles position + pattern rules into an index → order map', () => {
+    it( 'returns an empty map when total is 0', () => {
+        const variants: VariantDescriptor[] = [
+            { order: 0, priority: 10, matcher: { kind: 'position', value: 'last' } },
+            { order: 1, priority: 10, matcher: { kind: 'pattern', value: 'odd' } },
+            { order: 2, priority: 10, matcher: { kind: 'position', value: 'instance:1' } },
+        ];
+        expect( compileStaticMap( variants, 0 ) ).toEqual( {} );
+    } );
+
+    it( 'only compiles instance:<n1> matchers — position / pattern resolve at render time', () => {
         const variants: VariantDescriptor[] = [
             { order: 0, priority: 10, matcher: { kind: 'position', value: 'first' } },
             { order: 1, priority: 10, matcher: { kind: 'pattern', value: 'odd' } },
+            { order: 2, priority: 10, matcher: { kind: 'position', value: 'last' } },
+            { order: 3, priority: 10, matcher: { kind: 'position', value: 'instance:2' } },
         ];
         const map = compileStaticMap( variants, 4 );
-        // index 0 is "first" AND "odd" — position wins (higher tier).
-        expect( map ).toEqual( { 0: 0, 2: 1 } );
+        expect( map ).toEqual( { 1: 3 } );
     } );
 
     it( 'leaves meta / custom matchers out of the static map', () => {
         const variants: VariantDescriptor[] = [
             { order: 0, priority: 10, matcher: { kind: 'meta', value: 'sticky' } },
             { order: 1, priority: 10, matcher: { kind: 'custom', value: 'callback:x' } },
-            { order: 2, priority: 10, matcher: { kind: 'position', value: 'last' } },
         ];
-        const map = compileStaticMap( variants, 3 );
-        expect( map ).toEqual( { 2: 2 } );
-    } );
-
-    it( 'compiles instance:<n1> as fixed-position match', () => {
-        const variants: VariantDescriptor[] = [
-            { order: 0, priority: 10, matcher: { kind: 'position', value: 'instance:2' } },
-            { order: 1, priority: 10, matcher: { kind: 'position', value: 'first' } },
-        ];
-        const map = compileStaticMap( variants, 3 );
-        expect( map ).toEqual( { 0: 1, 1: 0 } );
+        expect( compileStaticMap( variants, 3 ) ).toEqual( {} );
     } );
 } );
 
@@ -127,12 +126,39 @@ describe( 'resolveVariant', () => {
         expect( resolveVariant( 0, 3, {}, [], map ) ).toBe( 4 );
     } );
 
+    it( 'walks position matchers against the live total when the static map missed', () => {
+        const variants: VariantDescriptor[] = [
+            { order: 0, priority: 10, matcher: { kind: 'position', value: 'last' } },
+        ];
+        // total=3 → "last" matches index 2
+        expect( resolveVariant( 2, 3, {}, variants, {} ) ).toBe( 0 );
+        // total=5 → "last" matches index 4, not 2
+        expect( resolveVariant( 2, 5, {}, variants, {} ) ).toBe( null );
+    } );
+
+    it( 'walks pattern matchers when the static map missed', () => {
+        const variants: VariantDescriptor[] = [
+            { order: 1, priority: 10, matcher: { kind: 'pattern', value: 'odd' } },
+        ];
+        expect( resolveVariant( 0, 5, {}, variants, {} ) ).toBe( 1 );
+        expect( resolveVariant( 1, 5, {}, variants, {} ) ).toBe( null );
+    } );
+
     it( 'walks meta matchers when the static map missed', () => {
         const variants: VariantDescriptor[] = [
             { order: 2, priority: 10, matcher: { kind: 'meta', value: 'sticky' } },
         ];
         expect( resolveVariant( 1, 3, { sticky: true }, variants, {} ) ).toBe( 2 );
         expect( resolveVariant( 1, 3, { sticky: false }, variants, {} ) ).toBe( null );
+    } );
+
+    it( 'honors precedence when multiple matchers would hit at render time', () => {
+        const variants: VariantDescriptor[] = [
+            { order: 0, priority: 10, matcher: { kind: 'meta', value: 'sticky' } },
+            { order: 1, priority: 10, matcher: { kind: 'position', value: 'first' } },
+        ];
+        // First post is sticky AND in position 1 — position wins (higher tier).
+        expect( resolveVariant( 0, 3, { sticky: true }, variants, {} ) ).toBe( 1 );
     } );
 
     it( 'never resolves custom matchers client-side', () => {

--- a/resources/js/visual-editor/editor/__tests__/variant-matcher.test.ts
+++ b/resources/js/visual-editor/editor/__tests__/variant-matcher.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    type VariantDescriptor,
+    compileStaticMap,
+    matchMeta,
+    matchPattern,
+    matchPosition,
+    resolveVariant,
+    sortVariants,
+} from '../variant-matcher';
+
+describe( 'matchPosition', () => {
+    it( 'matches first / last / nth / range', () => {
+        expect( matchPosition( { kind: 'position', value: 'first' }, 0, 5 ) ).toBe( true );
+        expect( matchPosition( { kind: 'position', value: 'first' }, 1, 5 ) ).toBe( false );
+        expect( matchPosition( { kind: 'position', value: 'last' }, 4, 5 ) ).toBe( true );
+        expect( matchPosition( { kind: 'position', value: 'last' }, 3, 5 ) ).toBe( false );
+        expect( matchPosition( { kind: 'position', value: 'nth:3' }, 2, 5 ) ).toBe( true );
+        expect( matchPosition( { kind: 'position', value: 'range:2-4' }, 1, 5 ) ).toBe( true );
+        expect( matchPosition( { kind: 'position', value: 'range:2-4' }, 4, 5 ) ).toBe( false );
+    } );
+
+    it( 'ignores instance: matchers (handled in static-map compile)', () => {
+        expect( matchPosition( { kind: 'position', value: 'instance:abc' }, 0, 5 ) ).toBe( false );
+    } );
+} );
+
+describe( 'matchPattern', () => {
+    it( 'matches odd / even / every-nth', () => {
+        expect( matchPattern( { kind: 'pattern', value: 'odd' }, 0 ) ).toBe( true );
+        expect( matchPattern( { kind: 'pattern', value: 'odd' }, 1 ) ).toBe( false );
+        expect( matchPattern( { kind: 'pattern', value: 'even' }, 1 ) ).toBe( true );
+        expect( matchPattern( { kind: 'pattern', value: 'every-nth:3' }, 2 ) ).toBe( true );
+        expect( matchPattern( { kind: 'pattern', value: 'every-nth:3:start:2' }, 1 ) ).toBe( true );
+        expect( matchPattern( { kind: 'pattern', value: 'every-nth:3:start:2' }, 4 ) ).toBe( true );
+    } );
+} );
+
+describe( 'matchMeta', () => {
+    it( 'matches sticky / featured / has-featured-image / author / taxonomy', () => {
+        expect( matchMeta( { kind: 'meta', value: 'sticky' }, { sticky: true } ) ).toBe( true );
+        expect( matchMeta( { kind: 'meta', value: 'sticky' }, { sticky: false } ) ).toBe( false );
+        expect( matchMeta( { kind: 'meta', value: 'featured' }, { featured: true } ) ).toBe( true );
+        expect( matchMeta( { kind: 'meta', value: 'has-featured-image' }, { hasFeaturedImage: true } ) ).toBe( true );
+        expect( matchMeta( { kind: 'meta', value: 'author:42' }, { authorId: 42 } ) ).toBe( true );
+        expect( matchMeta( { kind: 'meta', value: 'author:42' }, { authorId: 7 } ) ).toBe( false );
+        expect(
+            matchMeta(
+                { kind: 'meta', value: 'taxonomy:category:news' },
+                { taxonomies: { category: [ 'news', 'tech' ] } }
+            )
+        ).toBe( true );
+        expect(
+            matchMeta(
+                { kind: 'meta', value: 'taxonomy:category:news' },
+                { taxonomies: { category: [ 'tech' ] } }
+            )
+        ).toBe( false );
+    } );
+} );
+
+describe( 'sortVariants precedence', () => {
+    it( 'sorts instance > position > pattern > meta > custom', () => {
+        const variants: VariantDescriptor[] = [
+            { order: 0, priority: 10, matcher: { kind: 'meta', value: 'sticky' } },
+            { order: 1, priority: 10, matcher: { kind: 'pattern', value: 'odd' } },
+            { order: 2, priority: 10, matcher: { kind: 'custom', value: 'callback:x' } },
+            { order: 3, priority: 10, matcher: { kind: 'position', value: 'first' } },
+            { order: 4, priority: 10, matcher: { kind: 'position', value: 'instance:1' } },
+        ];
+        const sorted = sortVariants( variants ).map( ( v ) => v.matcher.kind + ':' + v.matcher.value );
+        expect( sorted ).toEqual( [
+            'position:instance:1',
+            'position:first',
+            'pattern:odd',
+            'meta:sticky',
+            'custom:callback:x',
+        ] );
+    } );
+
+    it( 'breaks ties on priority then document order', () => {
+        const variants: VariantDescriptor[] = [
+            { order: 1, priority: 10, matcher: { kind: 'position', value: 'first' } },
+            { order: 2, priority: 5, matcher: { kind: 'position', value: 'first' } },
+            { order: 0, priority: 10, matcher: { kind: 'position', value: 'first' } },
+        ];
+        const sorted = sortVariants( variants ).map( ( v ) => v.order );
+        expect( sorted ).toEqual( [ 2, 0, 1 ] );
+    } );
+} );
+
+describe( 'compileStaticMap', () => {
+    it( 'compiles position + pattern rules into an index → order map', () => {
+        const variants: VariantDescriptor[] = [
+            { order: 0, priority: 10, matcher: { kind: 'position', value: 'first' } },
+            { order: 1, priority: 10, matcher: { kind: 'pattern', value: 'odd' } },
+        ];
+        const map = compileStaticMap( variants, 4 );
+        // index 0 is "first" AND "odd" — position wins (higher tier).
+        expect( map ).toEqual( { 0: 0, 2: 1 } );
+    } );
+
+    it( 'leaves meta / custom matchers out of the static map', () => {
+        const variants: VariantDescriptor[] = [
+            { order: 0, priority: 10, matcher: { kind: 'meta', value: 'sticky' } },
+            { order: 1, priority: 10, matcher: { kind: 'custom', value: 'callback:x' } },
+            { order: 2, priority: 10, matcher: { kind: 'position', value: 'last' } },
+        ];
+        const map = compileStaticMap( variants, 3 );
+        expect( map ).toEqual( { 2: 2 } );
+    } );
+
+    it( 'compiles instance:<n1> as fixed-position match', () => {
+        const variants: VariantDescriptor[] = [
+            { order: 0, priority: 10, matcher: { kind: 'position', value: 'instance:2' } },
+            { order: 1, priority: 10, matcher: { kind: 'position', value: 'first' } },
+        ];
+        const map = compileStaticMap( variants, 3 );
+        expect( map ).toEqual( { 0: 1, 1: 0 } );
+    } );
+} );
+
+describe( 'resolveVariant', () => {
+    it( 'returns the static-map hit when present', () => {
+        const map = { 0: 4 };
+        expect( resolveVariant( 0, 3, {}, [], map ) ).toBe( 4 );
+    } );
+
+    it( 'walks meta matchers when the static map missed', () => {
+        const variants: VariantDescriptor[] = [
+            { order: 2, priority: 10, matcher: { kind: 'meta', value: 'sticky' } },
+        ];
+        expect( resolveVariant( 1, 3, { sticky: true }, variants, {} ) ).toBe( 2 );
+        expect( resolveVariant( 1, 3, { sticky: false }, variants, {} ) ).toBe( null );
+    } );
+
+    it( 'never resolves custom matchers client-side', () => {
+        const variants: VariantDescriptor[] = [
+            { order: 0, priority: 10, matcher: { kind: 'custom', value: 'callback:x' } },
+        ];
+        expect( resolveVariant( 0, 1, {}, variants, {} ) ).toBe( null );
+    } );
+} );

--- a/resources/js/visual-editor/editor/variant-matcher.ts
+++ b/resources/js/visual-editor/editor/variant-matcher.ts
@@ -1,0 +1,329 @@
+/**
+ * Post-variant matcher engine (#591).
+ *
+ * Shared spec consumed by:
+ *   - save-time compilation (writes a `position → variantId` map onto
+ *     the parent `post-template`),
+ *   - canvas preview (applies the matching variant to each preview
+ *     post in the editor),
+ *   - server renderer (`VariantResolver.php` mirrors this logic).
+ *
+ * Precedence (fixed):
+ *   1. instance      (`position.kind === 'instance'`)
+ *   2. position      (first, last, nth, range)
+ *   3. pattern       (odd, even, every-nth)
+ *   4. meta          (sticky, featured, taxonomy, author, has-featured-image)
+ *   5. custom        (callback hooks — server-side only)
+ *   6. base template (no variant matched)
+ *
+ * Ties inside a tier break on `priority` (lower wins), then document
+ * order.
+ */
+
+export type MatcherKind = 'position' | 'pattern' | 'meta' | 'custom';
+
+export interface PositionMatcher {
+    readonly kind: 'position';
+    /**
+     * `first` | `last` | `nth:<n>` | `range:<from>-<to>` | `instance:<uuid>`.
+     * Indices are 1-based to match author intuition ("first" === 1).
+     */
+    readonly value: string;
+}
+
+export interface PatternMatcher {
+    readonly kind: 'pattern';
+    /**
+     * `odd` | `even` | `every-nth:<step>` | `every-nth:<step>:start:<offset>`.
+     * Offset is 1-based (start of loop).
+     */
+    readonly value: string;
+}
+
+export interface MetaMatcher {
+    readonly kind: 'meta';
+    /**
+     * `sticky` | `featured` | `has-featured-image` |
+     * `taxonomy:<tax>:<slug>` | `author:<id>`.
+     */
+    readonly value: string;
+}
+
+export interface CustomMatcher {
+    readonly kind: 'custom';
+    /** `callback:<name>` — resolved by `apve_query_variant_match_<name>`. */
+    readonly value: string;
+}
+
+export type Matcher = PositionMatcher | PatternMatcher | MetaMatcher | CustomMatcher;
+
+export interface VariantDescriptor {
+    /**
+     * 0-based position of the variant within the parent post-template's
+     * inner blocks. Doubles as a stable identifier — clientIds aren't
+     * round-tripped through save/serialize, so the compiled map
+     * references variants by document order.
+     */
+    readonly order: number;
+    readonly matcher: Matcher;
+    readonly priority: number;
+    readonly label?: string;
+}
+
+const TIER_RANK: Record<MatcherKind, number> = {
+    position: 2,
+    pattern: 3,
+    meta: 4,
+    custom: 5,
+};
+
+const INSTANCE_TIER = 1;
+
+function isInstance( matcher: Matcher ): boolean {
+    return matcher.kind === 'position' && matcher.value.startsWith( 'instance:' );
+}
+
+function tierOf( matcher: Matcher ): number {
+    return isInstance( matcher ) ? INSTANCE_TIER : TIER_RANK[ matcher.kind ];
+}
+
+/**
+ * Sort variants by precedence tier → priority → document order.
+ */
+export function sortVariants( variants: ReadonlyArray<VariantDescriptor> ): VariantDescriptor[] {
+    return [ ...variants ].sort( ( a, b ) => {
+        const tierDiff = tierOf( a.matcher ) - tierOf( b.matcher );
+        if ( tierDiff !== 0 ) {
+            return tierDiff;
+        }
+        const priorityDiff = a.priority - b.priority;
+        if ( priorityDiff !== 0 ) {
+            return priorityDiff;
+        }
+        return a.order - b.order;
+    } );
+}
+
+/**
+ * Parse `every-nth:<step>` or `every-nth:<step>:start:<offset>`.
+ */
+function parseEveryNth( value: string ): { step: number; offset: number } | null {
+    const parts = value.split( ':' );
+    if ( parts[ 0 ] !== 'every-nth' ) {
+        return null;
+    }
+    const step = Number.parseInt( parts[ 1 ] ?? '', 10 );
+    if ( ! Number.isFinite( step ) || step < 1 ) {
+        return null;
+    }
+    // Default offset = step so `every-nth:3` matches positions 3, 6, 9
+    // (CSS `:nth-child(3n)` semantics). Explicit `:start:<n>` shifts to
+    // <n>, <n+step>, <n+2*step>, …
+    let offset = step;
+    if ( parts[ 2 ] === 'start' ) {
+        const parsed = Number.parseInt( parts[ 3 ] ?? '', 10 );
+        if ( Number.isFinite( parsed ) && parsed >= 1 ) {
+            offset = parsed;
+        }
+    }
+    return { step, offset };
+}
+
+/**
+ * Parse `nth:<n>` → 1-based position; `range:<from>-<to>` → inclusive
+ * 1-based range; `first` / `last` → fixed positions (last needs the
+ * total count, returned as `last`).
+ */
+function parsePosition( value: string ): { kind: 'first' | 'last' | 'nth' | 'range'; n?: number; from?: number; to?: number } | null {
+    if ( 'first' === value ) {
+        return { kind: 'first' };
+    }
+    if ( 'last' === value ) {
+        return { kind: 'last' };
+    }
+    if ( value.startsWith( 'nth:' ) ) {
+        const n = Number.parseInt( value.slice( 4 ), 10 );
+        if ( Number.isFinite( n ) && n >= 1 ) {
+            return { kind: 'nth', n };
+        }
+        return null;
+    }
+    if ( value.startsWith( 'range:' ) ) {
+        const [ from, to ] = value.slice( 6 ).split( '-' ).map( ( raw ) => Number.parseInt( raw, 10 ) );
+        if ( Number.isFinite( from ) && Number.isFinite( to ) && from >= 1 && to >= from ) {
+            return { kind: 'range', from, to };
+        }
+        return null;
+    }
+    return null;
+}
+
+/**
+ * Does a `position` matcher match the given 0-based loop index?
+ * `total` is required for the `last` keyword.
+ */
+export function matchPosition( matcher: PositionMatcher, index: number, total: number ): boolean {
+    if ( matcher.value.startsWith( 'instance:' ) ) {
+        // `instance:` matchers are looked up by saved index map, not by
+        // walking — see `compileStaticMap`.
+        return false;
+    }
+    const parsed = parsePosition( matcher.value );
+    if ( null === parsed ) {
+        return false;
+    }
+    const position1 = index + 1;
+    switch ( parsed.kind ) {
+        case 'first':
+            return 1 === position1;
+        case 'last':
+            return total >= 1 && position1 === total;
+        case 'nth':
+            return position1 === parsed.n;
+        case 'range':
+            return position1 >= ( parsed.from ?? 0 ) && position1 <= ( parsed.to ?? 0 );
+        default:
+            return false;
+    }
+}
+
+/**
+ * Does a `pattern` matcher match the given 0-based loop index?
+ */
+export function matchPattern( matcher: PatternMatcher, index: number ): boolean {
+    const position1 = index + 1;
+    if ( 'odd' === matcher.value ) {
+        return 1 === position1 % 2;
+    }
+    if ( 'even' === matcher.value ) {
+        return 0 === position1 % 2;
+    }
+    const everyNth = parseEveryNth( matcher.value );
+    if ( null !== everyNth ) {
+        return position1 >= everyNth.offset && 0 === ( position1 - everyNth.offset ) % everyNth.step;
+    }
+    return false;
+}
+
+/**
+ * Loose structural metadata describing a preview post in the editor.
+ * Mirrors what the canvas preview pipeline can derive from the
+ * `useQueryPreview` payload. Server-side meta evaluation lives in
+ * `VariantResolver.php` and reads the same conceptual fields off the
+ * post model.
+ */
+export interface PreviewPostMeta {
+    readonly sticky?: boolean;
+    readonly featured?: boolean;
+    readonly hasFeaturedImage?: boolean;
+    readonly authorId?: number;
+    readonly taxonomies?: Readonly<Record<string, ReadonlyArray<string>>>;
+}
+
+export function matchMeta( matcher: MetaMatcher, post: PreviewPostMeta ): boolean {
+    if ( 'sticky' === matcher.value ) {
+        return true === post.sticky;
+    }
+    if ( 'featured' === matcher.value ) {
+        return true === post.featured;
+    }
+    if ( 'has-featured-image' === matcher.value ) {
+        return true === post.hasFeaturedImage;
+    }
+    if ( matcher.value.startsWith( 'author:' ) ) {
+        const id = Number.parseInt( matcher.value.slice( 7 ), 10 );
+        return Number.isFinite( id ) && post.authorId === id;
+    }
+    if ( matcher.value.startsWith( 'taxonomy:' ) ) {
+        const parts = matcher.value.split( ':' );
+        const tax = parts[ 1 ];
+        const slug = parts[ 2 ];
+        if ( ! tax || ! slug || ! post.taxonomies ) {
+            return false;
+        }
+        const terms = post.taxonomies[ tax ];
+        return Array.isArray( terms ) && terms.includes( slug );
+    }
+    return false;
+}
+
+/**
+ * Compile every `position` / `pattern` variant in `variants` into a
+ * sparse `index → variantId` map for the given loop length. Static
+ * rules cost nothing at render time once compiled. Returns indices
+ * 0-based so the renderer can do a direct array lookup.
+ *
+ * Variants are walked in precedence order (`sortVariants`) and the
+ * FIRST match for each index wins, mirroring the server-side cascade.
+ *
+ * `meta` and `custom` matchers are skipped here — they need post
+ * context only available at render time.
+ */
+export function compileStaticMap(
+    variants: ReadonlyArray<VariantDescriptor>,
+    total: number
+): Record<number, number> {
+    const sorted = sortVariants( variants );
+    const map: Record<number, number> = {};
+
+    for ( const variant of sorted ) {
+        if ( variant.matcher.kind !== 'position' && variant.matcher.kind !== 'pattern' ) {
+            continue;
+        }
+        if ( isInstance( variant.matcher ) ) {
+            // instance:<index1> form — the value is a 1-based loop
+            // position. Treat it as a fixed-position match.
+            const raw = variant.matcher.value.slice( 'instance:'.length );
+            const idx1 = Number.parseInt( raw, 10 );
+            if ( Number.isFinite( idx1 ) && idx1 >= 1 && idx1 <= total ) {
+                const i0 = idx1 - 1;
+                if ( map[ i0 ] === undefined ) {
+                    map[ i0 ] = variant.order;
+                }
+            }
+            continue;
+        }
+
+        for ( let i = 0; i < total; i++ ) {
+            if ( map[ i ] !== undefined ) {
+                continue;
+            }
+            const matches =
+                variant.matcher.kind === 'position'
+                    ? matchPosition( variant.matcher, i, total )
+                    : matchPattern( variant.matcher, i );
+            if ( matches ) {
+                map[ i ] = variant.order;
+            }
+        }
+    }
+
+    return map;
+}
+
+/**
+ * Editor-side runtime resolver: given the precompiled static map and
+ * the full variant list, return the winning variant id (or `null` for
+ * "use the base template") for a single loop iteration. Walks `meta`
+ * matchers when the static map missed; `custom` matchers are
+ * server-only and intentionally not evaluated here.
+ */
+export function resolveVariant(
+    index: number,
+    _total: number,
+    post: PreviewPostMeta,
+    variants: ReadonlyArray<VariantDescriptor>,
+    staticMap: Record<number, number>
+): number | null {
+    const fromStatic = staticMap[ index ];
+    if ( typeof fromStatic === 'number' ) {
+        return fromStatic;
+    }
+    const sorted = sortVariants( variants );
+    for ( const variant of sorted ) {
+        if ( variant.matcher.kind === 'meta' && matchMeta( variant.matcher, post ) ) {
+            return variant.order;
+        }
+    }
+    return null;
+}

--- a/resources/js/visual-editor/editor/variant-matcher.ts
+++ b/resources/js/visual-editor/editor/variant-matcher.ts
@@ -248,16 +248,21 @@ export function matchMeta( matcher: MetaMatcher, post: PreviewPostMeta ): boolea
 }
 
 /**
- * Compile every `position` / `pattern` variant in `variants` into a
- * sparse `index → variantId` map for the given loop length. Static
- * rules cost nothing at render time once compiled. Returns indices
- * 0-based so the renderer can do a direct array lookup.
+ * Compile `instance:` position matchers into a sparse `index →
+ * variantOrder` map.
  *
- * Variants are walked in precedence order (`sortVariants`) and the
- * FIRST match for each index wins, mirroring the server-side cascade.
+ * **Only `instance:<n1>` rules go in the static map.** Earlier
+ * iterations also baked `position` (first/last/nth/range) and
+ * `pattern` (odd/even/every-nth) rules here, but those depend on the
+ * loop's `total` and become stale the moment the live query returns
+ * a different count than what was previewed at save time —
+ * `position:last` would point at the wrong index, etc. So we keep the
+ * map narrowly scoped to the canvas click-to-edit pins (which are
+ * fixed by definition), and `resolveVariant` walks all other matchers
+ * at render time with the actual `total` and `post`.
  *
- * `meta` and `custom` matchers are skipped here — they need post
- * context only available at render time.
+ * Variants are walked in precedence order so `instance:` wins over
+ * any other rule that would also target the same index.
  */
 export function compileStaticMap(
     variants: ReadonlyArray<VariantDescriptor>,
@@ -267,34 +272,18 @@ export function compileStaticMap(
     const map: Record<number, number> = {};
 
     for ( const variant of sorted ) {
-        if ( variant.matcher.kind !== 'position' && variant.matcher.kind !== 'pattern' ) {
+        if ( ! isInstance( variant.matcher ) ) {
             continue;
         }
-        if ( isInstance( variant.matcher ) ) {
-            // instance:<index1> form — the value is a 1-based loop
-            // position. Treat it as a fixed-position match.
-            const raw = variant.matcher.value.slice( 'instance:'.length );
-            const idx1 = Number.parseInt( raw, 10 );
-            if ( Number.isFinite( idx1 ) && idx1 >= 1 && idx1 <= total ) {
-                const i0 = idx1 - 1;
-                if ( map[ i0 ] === undefined ) {
-                    map[ i0 ] = variant.order;
-                }
-            }
+        // instance:<index1> form — value is a 1-based loop position.
+        const raw = variant.matcher.value.slice( 'instance:'.length );
+        const idx1 = Number.parseInt( raw, 10 );
+        if ( ! Number.isFinite( idx1 ) || idx1 < 1 || idx1 > total ) {
             continue;
         }
-
-        for ( let i = 0; i < total; i++ ) {
-            if ( map[ i ] !== undefined ) {
-                continue;
-            }
-            const matches =
-                variant.matcher.kind === 'position'
-                    ? matchPosition( variant.matcher, i, total )
-                    : matchPattern( variant.matcher, i );
-            if ( matches ) {
-                map[ i ] = variant.order;
-            }
+        const i0 = idx1 - 1;
+        if ( map[ i0 ] === undefined ) {
+            map[ i0 ] = variant.order;
         }
     }
 
@@ -310,7 +299,7 @@ export function compileStaticMap(
  */
 export function resolveVariant(
     index: number,
-    _total: number,
+    total: number,
     post: PreviewPostMeta,
     variants: ReadonlyArray<VariantDescriptor>,
     staticMap: Record<number, number>
@@ -321,9 +310,21 @@ export function resolveVariant(
     }
     const sorted = sortVariants( variants );
     for ( const variant of sorted ) {
+        if ( isInstance( variant.matcher ) ) {
+            // instance:<n1> only resolves via the static map; if it
+            // missed there it doesn't match this iteration.
+            continue;
+        }
+        if ( variant.matcher.kind === 'position' && matchPosition( variant.matcher, index, total ) ) {
+            return variant.order;
+        }
+        if ( variant.matcher.kind === 'pattern' && matchPattern( variant.matcher, index ) ) {
+            return variant.order;
+        }
         if ( variant.matcher.kind === 'meta' && matchMeta( variant.matcher, post ) ) {
             return variant.order;
         }
+        // `custom` is server-side only; never resolved in the editor.
     }
     return null;
 }

--- a/src/Resources/QueryInliner.php
+++ b/src/Resources/QueryInliner.php
@@ -68,7 +68,12 @@ class QueryInliner
 	public function __construct(
 		protected Container $container,
 		protected PostResolver $postResolver,
-	) {}
+		protected ?VariantResolver $variantResolver = null,
+	) {
+		if ( null === $this->variantResolver ) {
+			$this->variantResolver = new VariantResolver();
+		}
+	}
 
 	/**
 	 * Host post passed through `inline()` so the related-posts expansion
@@ -603,6 +608,27 @@ class QueryInliner
 			return $this->expandFlat( $block, $attributes, $queryInner, $results, $paginator );
 		}
 
+		// Variants (#591): an `artisanpack/post-variant` child of the
+		// post-template is NOT part of the per-iteration template —
+		// it's a per-post override template. Pull variants out of the
+		// iteration template, prime the resolver, and the loop below
+		// asks the resolver per post which template to use.
+		[ $baseTemplate, $variantBlocks ] = $this->extractVariants( $iterationTemplate );
+
+		$postTemplateAttrs = isset( $queryInner[ $postTemplateIndex ]['attributes'] )
+			&& is_array( $queryInner[ $postTemplateIndex ]['attributes'] )
+				? $queryInner[ $postTemplateIndex ]['attributes']
+				: [];
+
+		$compiledMap = isset( $postTemplateAttrs['_compiledVariantMap'] )
+			&& is_array( $postTemplateAttrs['_compiledVariantMap'] )
+				? $postTemplateAttrs['_compiledVariantMap']
+				: [];
+
+		$resultsList = is_array( $results ) ? array_values( $results ) : iterator_to_array( $results, false );
+
+		$this->variantResolver->prime( $variantBlocks, $compiledMap, count( $resultsList ) );
+
 		// Expand: clone the iteration template once per result, stamp
 		// _resolved* attributes, and wrap each iteration in a synthetic
 		// `core/post-template-item` block. The renderers turn that into
@@ -612,15 +638,20 @@ class QueryInliner
 		// single-item lists.
 		$expandedIterations = [];
 
-		foreach ( $results as $post ) {
+		foreach ( $resultsList as $loopIndex => $post ) {
 			if ( ! is_object( $post ) ) {
 				continue;
 			}
 
-			$postId = isset( $post->id ) ? (int) $post->id : 0;
+			$postId          = isset( $post->id ) ? (int) $post->id : 0;
 			$iterationBlocks = [];
 
-			foreach ( $iterationTemplate as $tmplChild ) {
+			$variantOrder = $this->variantResolver->resolve( $loopIndex, $post );
+			$activeTmpl   = null !== $variantOrder
+				? $this->variantResolver->innerBlocksFor( $variantOrder, $variantBlocks )
+				: $baseTemplate;
+
+			foreach ( $activeTmpl as $tmplChild ) {
 				if ( ! is_array( $tmplChild ) ) {
 					continue;
 				}
@@ -638,6 +669,7 @@ class QueryInliner
 					'postId'    => $postId,
 					'className' => 'post-' . $postId
 					. ' post'
+					. ( null !== $variantOrder ? ' is-variant' : '' )
 					. ' type-' . ( isset( $post->post_type ) ? (string) $post->post_type : ( isset( $post->type ) ? (string) $post->type : 'post' ) )
 					. ' status-' . ( isset( $post->status ) && is_object( $post->status ) && isset( $post->status->value ) ? (string) $post->status->value : ( isset( $post->status ) && is_string( $post->status ) ? $post->status : 'publish' ) ),
 				],
@@ -985,6 +1017,40 @@ class QueryInliner
 				'_resolvedItems' => count( $results ),
 			] ),
 		] );
+	}
+
+	/**
+	 * Split a post-template's inner-block tree into the base iteration
+	 * template (everything that is NOT a `post-variant`) and the list
+	 * of `artisanpack/post-variant` overrides. Variants stay in their
+	 * saved document order so the resolver's `order` index lines up
+	 * with what the editor's `_compiledVariantMap` was built against.
+	 *
+	 * @param  array<int, array<string, mixed>>  $template
+	 *
+	 * @return array{0: array<int, array<string, mixed>>, 1: array<int, array<string, mixed>>}
+	 */
+	protected function extractVariants( array $template ): array
+	{
+		$base     = [];
+		$variants = [];
+
+		foreach ( $template as $child ) {
+			if ( ! is_array( $child ) ) {
+				continue;
+			}
+
+			$childName = isset( $child['name'] ) && is_string( $child['name'] ) ? $child['name'] : '';
+
+			if ( 'artisanpack/post-variant' === $childName ) {
+				$variants[] = $child;
+				continue;
+			}
+
+			$base[] = $child;
+		}
+
+		return [ $base, $variants ];
 	}
 
 	protected function markFailed( array $block, string $reason ): array

--- a/src/Resources/VariantResolver.php
+++ b/src/Resources/VariantResolver.php
@@ -1,0 +1,480 @@
+<?php
+
+/**
+ * VariantResolver — server-side counterpart to the editor's
+ * `variant-matcher.ts`. Given a list of `artisanpack/post-variant`
+ * blocks, a precompiled position→variantId map, and a single post in
+ * the loop, returns the winning variant id (or `null` for "use the
+ * base post-template").
+ *
+ * Precedence cascade mirrors the editor:
+ *
+ *   1. `instance` (canvas click-to-edit overrides)
+ *   2. `position` (first / last / nth / range)
+ *   3. `pattern`  (odd / even / every-nth)
+ *   4. `meta`     (sticky / featured / has-featured-image / author / taxonomy)
+ *   5. `custom`   (`callback:<name>` → `apve_query_variant_match_<name>` filter)
+ *   6. base post-template (no variant matched)
+ *
+ * Ties inside a tier break on `priority` ascending then document order.
+ *
+ * The precompiled map is consulted first for O(1) lookup of static
+ * (position / pattern) rules — saves walking N variants per post. The
+ * map is built editor-side via `compileStaticMap` and stored on the
+ * parent `artisanpack/post-template` as `_compiledVariantMap`. When
+ * the map is absent (older saves, hand-edited content, server-side
+ * pattern expansion), the resolver falls back to walking variants and
+ * evaluating their matchers directly.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.2.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Resources;
+
+class VariantResolver
+{
+	protected const TIER_RANK = [
+		'position' => 2,
+		'pattern'  => 3,
+		'meta'     => 4,
+		'custom'   => 5,
+	];
+
+	protected const INSTANCE_TIER = 1;
+
+	/**
+	 * @var array<int, array<string, mixed>>
+	 */
+	protected array $variants = [];
+
+	/**
+	 * @var array<int, int>
+	 */
+	protected array $compiledMap = [];
+
+	protected int $total = 0;
+
+	/**
+	 * Prime the resolver with the parsed variant blocks, the precompiled
+	 * static map (if any), and the total result count. Called once per
+	 * query expansion.
+	 *
+	 * @param  array<int, array<string, mixed>>  $variants     Raw variant block
+	 *                                                         arrays, in their
+	 *                                                         saved document order.
+	 * @param  array<int|string, mixed>          $compiledMap  Position → variantId map
+	 *                                                         from the post-template
+	 *                                                         attrs.
+	 */
+	public function prime( array $variants, array $compiledMap, int $total ): void
+	{
+		$this->variants    = $this->describeVariants( $variants );
+		$this->compiledMap = $this->normalizeMap( $compiledMap );
+		$this->total       = $total;
+	}
+
+	/**
+	 * Resolve the winning variant index (into the `variants` array
+	 * primed via {@see prime()}) for one loop iteration. Returns
+	 * `null` when no variant matches.
+	 */
+	public function resolve( int $index, object $post ): ?int
+	{
+		// Static map wins first — it's the editor's precompiled
+		// answer for position / pattern rules. The map stores the
+		// variant's document-order index, which the inliner uses to
+		// read the original block array back.
+		if ( isset( $this->compiledMap[ $index ] ) ) {
+			$mapped = $this->compiledMap[ $index ];
+
+			if ( $mapped >= 0 && $mapped < count( $this->variants ) ) {
+				return $mapped;
+			}
+		}
+
+		$sorted = $this->variants;
+
+		usort( $sorted, function ( array $a, array $b ): int {
+			$tierDiff = $a['tier'] - $b['tier'];
+
+			if ( 0 !== $tierDiff ) {
+				return $tierDiff;
+			}
+
+			$priorityDiff = $a['priority'] - $b['priority'];
+
+			if ( 0 !== $priorityDiff ) {
+				return $priorityDiff;
+			}
+
+			return $a['order'] - $b['order'];
+		} );
+
+		foreach ( $sorted as $variant ) {
+			if ( $this->matches( $variant, $index, $post ) ) {
+				return $variant['order'];
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Convenience: read the inner-block tree off the resolved variant
+	 * descriptor. Caller passes the original variant arrays; the
+	 * descriptor remembers them via `order`.
+	 *
+	 * @param  array<int, array<string, mixed>>  $variants
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	public function innerBlocksFor( int $order, array $variants ): array
+	{
+		$block = $variants[ $order ] ?? null;
+
+		if ( ! is_array( $block ) ) {
+			return [];
+		}
+
+		$inner = $block['innerBlocks'] ?? [];
+
+		return is_array( $inner ) ? $inner : [];
+	}
+
+	/**
+	 * @param  array<int, array<string, mixed>>  $variants
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	protected function describeVariants( array $variants ): array
+	{
+		$out = [];
+
+		foreach ( array_values( $variants ) as $order => $variant ) {
+			$attributes = isset( $variant['attributes'] ) && is_array( $variant['attributes'] )
+				? $variant['attributes']
+				: [];
+
+			$matcher = isset( $attributes['matcher'] ) && is_array( $attributes['matcher'] )
+				? $attributes['matcher']
+				: [ 'kind' => 'position', 'value' => 'first' ];
+
+			$kind = isset( $matcher['kind'] ) && is_string( $matcher['kind'] )
+				? $matcher['kind']
+				: 'position';
+
+			$value = isset( $matcher['value'] ) && is_string( $matcher['value'] )
+				? $matcher['value']
+				: 'first';
+
+			$priority = isset( $attributes['priority'] ) && is_numeric( $attributes['priority'] )
+				? (int) $attributes['priority']
+				: 10;
+
+			$out[] = [
+				'order'    => $order,
+				'kind'     => $kind,
+				'value'    => $value,
+				'priority' => $priority,
+				'tier'     => $this->tierFor( $kind, $value ),
+			];
+		}
+
+		return $out;
+	}
+
+	protected function tierFor( string $kind, string $value ): int
+	{
+		if ( 'position' === $kind && str_starts_with( $value, 'instance:' ) ) {
+			return self::INSTANCE_TIER;
+		}
+
+		return self::TIER_RANK[ $kind ] ?? 99;
+	}
+
+	/**
+	 * @param  array<int|string, mixed>  $map
+	 *
+	 * @return array<int, int>
+	 */
+	protected function normalizeMap( array $map ): array
+	{
+		$out = [];
+
+		foreach ( $map as $key => $value ) {
+			if ( ! is_numeric( $key ) ) {
+				continue;
+			}
+
+			if ( ! is_numeric( $value ) ) {
+				continue;
+			}
+
+			$out[ (int) $key ] = (int) $value;
+		}
+
+		return $out;
+	}
+
+	/**
+	 * @param  array<string, mixed>  $variant
+	 */
+	protected function matches( array $variant, int $index, object $post ): bool
+	{
+		$kind  = $variant['kind'];
+		$value = $variant['value'];
+
+		switch ( $kind ) {
+			case 'position':
+				return $this->matchesPosition( $value, $index );
+			case 'pattern':
+				return $this->matchesPattern( $value, $index );
+			case 'meta':
+				return $this->matchesMeta( $value, $post );
+			case 'custom':
+				return $this->matchesCustom( $value, $post, $index );
+		}
+
+		return false;
+	}
+
+	protected function matchesPosition( string $value, int $index ): bool
+	{
+		if ( str_starts_with( $value, 'instance:' ) ) {
+			// `instance:<n1>` is treated as a fixed 1-based position
+			// match when the editor's static map is absent.
+			$raw = (int) substr( $value, strlen( 'instance:' ) );
+
+			return $raw >= 1 && ( $raw - 1 ) === $index;
+		}
+
+		$position1 = $index + 1;
+
+		if ( 'first' === $value ) {
+			return 1 === $position1;
+		}
+
+		if ( 'last' === $value ) {
+			return $this->total >= 1 && $position1 === $this->total;
+		}
+
+		if ( str_starts_with( $value, 'nth:' ) ) {
+			$n = (int) substr( $value, 4 );
+
+			return $n >= 1 && $position1 === $n;
+		}
+
+		if ( str_starts_with( $value, 'range:' ) ) {
+			$range = substr( $value, 6 );
+			$parts = explode( '-', $range );
+
+			if ( 2 !== count( $parts ) ) {
+				return false;
+			}
+
+			$from = (int) $parts[0];
+			$to   = (int) $parts[1];
+
+			return $from >= 1 && $to >= $from && $position1 >= $from && $position1 <= $to;
+		}
+
+		return false;
+	}
+
+	protected function matchesPattern( string $value, int $index ): bool
+	{
+		$position1 = $index + 1;
+
+		if ( 'odd' === $value ) {
+			return 1 === $position1 % 2;
+		}
+
+		if ( 'even' === $value ) {
+			return 0 === $position1 % 2;
+		}
+
+		if ( str_starts_with( $value, 'every-nth:' ) ) {
+			$parts = explode( ':', $value );
+			$step  = isset( $parts[1] ) ? (int) $parts[1] : 0;
+
+			if ( $step < 1 ) {
+				return false;
+			}
+
+			$offset = $step;
+
+			if ( ( $parts[2] ?? null ) === 'start' && isset( $parts[3] ) ) {
+				$parsed = (int) $parts[3];
+
+				if ( $parsed >= 1 ) {
+					$offset = $parsed;
+				}
+			}
+
+			return $position1 >= $offset && 0 === ( $position1 - $offset ) % $step;
+		}
+
+		return false;
+	}
+
+	protected function matchesMeta( string $value, object $post ): bool
+	{
+		if ( 'sticky' === $value ) {
+			return true === ( $post->sticky ?? false ) || true === ( $post->is_sticky ?? false );
+		}
+
+		if ( 'featured' === $value ) {
+			return true === ( $post->featured ?? false ) || true === ( $post->is_featured ?? false );
+		}
+
+		if ( 'has-featured-image' === $value ) {
+			$candidates = [
+				$post->featured_image_id ?? null,
+				$post->featured_image ?? null,
+				$post->thumbnail_id ?? null,
+			];
+
+			foreach ( $candidates as $candidate ) {
+				if ( null === $candidate ) {
+					continue;
+				}
+
+				if ( is_int( $candidate ) && $candidate > 0 ) {
+					return true;
+				}
+
+				if ( is_object( $candidate ) ) {
+					return true;
+				}
+
+				if ( is_string( $candidate ) && '' !== $candidate ) {
+					return true;
+				}
+			}
+
+			return false;
+		}
+
+		if ( str_starts_with( $value, 'author:' ) ) {
+			$expected = (int) substr( $value, 7 );
+
+			if ( $expected < 1 ) {
+				return false;
+			}
+
+			$authorId = null;
+
+			if ( isset( $post->author_id ) && is_numeric( $post->author_id ) ) {
+				$authorId = (int) $post->author_id;
+			} elseif ( isset( $post->user_id ) && is_numeric( $post->user_id ) ) {
+				$authorId = (int) $post->user_id;
+			} elseif ( isset( $post->author ) && is_object( $post->author ) && isset( $post->author->id ) ) {
+				$authorId = (int) $post->author->id;
+			}
+
+			return $authorId === $expected;
+		}
+
+		if ( str_starts_with( $value, 'taxonomy:' ) ) {
+			$parts = explode( ':', $value, 3 );
+
+			if ( 3 !== count( $parts ) ) {
+				return false;
+			}
+
+			[ , $taxonomy, $slug ] = $parts;
+
+			if ( '' === $taxonomy || '' === $slug ) {
+				return false;
+			}
+
+			return $this->postHasTerm( $post, $taxonomy, $slug );
+		}
+
+		return false;
+	}
+
+	protected function matchesCustom( string $value, object $post, int $index ): bool
+	{
+		if ( ! str_starts_with( $value, 'callback:' ) ) {
+			return false;
+		}
+
+		$name = trim( substr( $value, 9 ) );
+
+		if ( '' === $name || ! function_exists( 'ArtisanPackUI\\Hooks\\applyFilters' ) ) {
+			return false;
+		}
+
+		$context = [
+			'index' => $index,
+			'total' => $this->total,
+		];
+
+		$result = \ArtisanPackUI\Hooks\applyFilters(
+			'apve_query_variant_match_' . $name,
+			false,
+			$post,
+			$context
+		);
+
+		return true === $result;
+	}
+
+	protected function postHasTerm( object $post, string $taxonomy, string $slug ): bool
+	{
+		// Map common taxonomy slugs to the loose relations posts expose.
+		$relations = [];
+
+		switch ( $taxonomy ) {
+			case 'category':
+				$relations[] = 'categories';
+				break;
+			case 'post_tag':
+			case 'tag':
+				$relations[] = 'tags';
+				break;
+			default:
+				$relations[] = $taxonomy;
+				$relations[] = $taxonomy . 's';
+				break;
+		}
+
+		$relations[] = 'terms';
+
+		foreach ( $relations as $relation ) {
+			$collection = $post->{$relation} ?? null;
+
+			if ( ! is_iterable( $collection ) ) {
+				continue;
+			}
+
+			foreach ( $collection as $term ) {
+				if ( ! is_object( $term ) ) {
+					continue;
+				}
+
+				$termTaxonomy = $term->taxonomy ?? null;
+
+				if ( null !== $termTaxonomy && $termTaxonomy !== $taxonomy ) {
+					continue;
+				}
+
+				$termSlug = $term->slug ?? null;
+
+				if ( is_string( $termSlug ) && $termSlug === $slug ) {
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+}

--- a/src/Resources/VariantResolver.php
+++ b/src/Resources/VariantResolver.php
@@ -55,6 +55,15 @@ class VariantResolver
 	protected array $variants = [];
 
 	/**
+	 * Variants sorted once in {@see prime()} by precedence tier →
+	 * priority → document order. Reused for every {@see resolve()}
+	 * call on the same primed batch.
+	 *
+	 * @var array<int, array<string, mixed>>
+	 */
+	protected array $sortedVariants = [];
+
+	/**
 	 * @var array<int, int>
 	 */
 	protected array $compiledMap = [];
@@ -78,6 +87,24 @@ class VariantResolver
 		$this->variants    = $this->describeVariants( $variants );
 		$this->compiledMap = $this->normalizeMap( $compiledMap );
 		$this->total       = $total;
+
+		$this->sortedVariants = $this->variants;
+
+		usort( $this->sortedVariants, function ( array $a, array $b ): int {
+			$tierDiff = $a['tier'] - $b['tier'];
+
+			if ( 0 !== $tierDiff ) {
+				return $tierDiff;
+			}
+
+			$priorityDiff = $a['priority'] - $b['priority'];
+
+			if ( 0 !== $priorityDiff ) {
+				return $priorityDiff;
+			}
+
+			return $a['order'] - $b['order'];
+		} );
 	}
 
 	/**
@@ -99,25 +126,7 @@ class VariantResolver
 			}
 		}
 
-		$sorted = $this->variants;
-
-		usort( $sorted, function ( array $a, array $b ): int {
-			$tierDiff = $a['tier'] - $b['tier'];
-
-			if ( 0 !== $tierDiff ) {
-				return $tierDiff;
-			}
-
-			$priorityDiff = $a['priority'] - $b['priority'];
-
-			if ( 0 !== $priorityDiff ) {
-				return $priorityDiff;
-			}
-
-			return $a['order'] - $b['order'];
-		} );
-
-		foreach ( $sorted as $variant ) {
+		foreach ( $this->sortedVariants as $variant ) {
 			if ( $this->matches( $variant, $index, $post ) ) {
 				return $variant['order'];
 			}

--- a/src/VisualEditorServiceProvider.php
+++ b/src/VisualEditorServiceProvider.php
@@ -564,6 +564,7 @@ class VisualEditorServiceProvider extends ServiceProvider
 			'tag-cloud',
 			'query',
 			'post-template',
+			'post-variant',
 		];
 
 		foreach ( $forkedBlocks as $block ) {

--- a/tests/Unit/VisualEditor/Resources/QueryInlinerVariantsTest.php
+++ b/tests/Unit/VisualEditor/Resources/QueryInlinerVariantsTest.php
@@ -1,0 +1,276 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Resources\PostResolver;
+use ArtisanPackUI\VisualEditor\Resources\QueryInliner;
+use ArtisanPackUI\VisualEditor\Services\QueryResolverContract;
+use Tests\Fixtures\FakeQueryResolver;
+
+/**
+ * Issue #591 — post-variant system: per-position template overrides on
+ * the Query Loop. These tests pin the precedence cascade, the
+ * static map fast-path, the meta / custom matcher behavior, and the
+ * backward-compat guarantee (no variants = unchanged output).
+ */
+
+function variantBlock( array $matcher, array $innerBlocks, int $priority = 10 ): array
+{
+	return [
+		'name'        => 'artisanpack/post-variant',
+		'attributes'  => [
+			'matcher'  => $matcher,
+			'priority' => $priority,
+		],
+		'innerBlocks' => $innerBlocks,
+	];
+}
+
+function queryWithVariants( array $baseInner, array $variants, array $compiledMap = [] ): array
+{
+	$postTemplateChildren = array_merge( $baseInner, $variants );
+
+	return [
+		'name'        => 'core/query',
+		'attributes'  => [ 'query' => [ 'postType' => 'post', 'perPage' => 5 ] ],
+		'innerBlocks' => [
+			[
+				'name'        => 'core/post-template',
+				'attributes'  => [ '_compiledVariantMap' => $compiledMap ],
+				'innerBlocks' => $postTemplateChildren,
+			],
+		],
+	];
+}
+
+function variantPostFixture( int $id, string $title, array $extras = [] ): object
+{
+	$post                    = new stdClass();
+	$post->id                = $id;
+	$post->title             = $title;
+	$post->content           = "<p>{$title}</p>";
+	$post->permalink         = "/posts/{$id}";
+	$post->author            = null;
+	$post->published_at      = null;
+	$post->updated_at        = null;
+	$post->featured_image_id = null;
+
+	foreach ( $extras as $key => $value ) {
+		$post->{$key} = $value;
+	}
+
+	return $post;
+}
+
+beforeEach( function (): void {
+	$this->fake = new FakeQueryResolver();
+	$this->app->instance( QueryResolverContract::class, $this->fake );
+
+	$this->inliner = new QueryInliner( $this->app, new PostResolver() );
+} );
+
+it( 'renders identically when no variants are declared (backwards compat)', function () {
+	$this->fake->setItems( [
+		variantPostFixture( 1, 'First' ),
+		variantPostFixture( 2, 'Second' ),
+	] );
+
+	$base = [
+		[ 'name' => 'core/post-title', 'attributes' => [], 'innerBlocks' => [] ],
+	];
+
+	$tree    = [ queryWithVariants( $base, [] ) ];
+	$inlined = $this->inliner->inline( $tree );
+
+	$items = $inlined[0]['innerBlocks'][0]['innerBlocks'];
+
+	expect( count( $items ) )->toBe( 2 )
+		->and( $items[0]['name'] )->toBe( 'core/post-template-item' )
+		->and( count( $items[0]['innerBlocks'] ) )->toBe( 1 )
+		->and( $items[0]['innerBlocks'][0]['name'] )->toBe( 'core/post-title' )
+		// no-variant items must not get the `is-variant` class
+		->and( str_contains( $items[0]['attributes']['className'], 'is-variant' ) )->toBeFalse()
+		->and( str_contains( $items[1]['attributes']['className'], 'is-variant' ) )->toBeFalse();
+} );
+
+it( 'swaps the first post template via a position:first variant', function () {
+	$this->fake->setItems( [
+		variantPostFixture( 1, 'Hero' ),
+		variantPostFixture( 2, 'Listed' ),
+	] );
+
+	$base    = [ [ 'name' => 'core/post-title', 'attributes' => [], 'innerBlocks' => [] ] ];
+	$variant = variantBlock(
+		[ 'kind' => 'position', 'value' => 'first' ],
+		[ [ 'name' => 'core/post-excerpt', 'attributes' => [], 'innerBlocks' => [] ] ]
+	);
+
+	$tree    = [ queryWithVariants( $base, [ $variant ] ) ];
+	$inlined = $this->inliner->inline( $tree );
+
+	$items = $inlined[0]['innerBlocks'][0]['innerBlocks'];
+
+	expect( count( $items ) )->toBe( 2 )
+		// variant template for the first post
+		->and( $items[0]['innerBlocks'][0]['name'] )->toBe( 'core/post-excerpt' )
+		// base template for the rest
+		->and( $items[1]['innerBlocks'][0]['name'] )->toBe( 'core/post-title' )
+		// is-variant class is stamped on the swapped iteration
+		->and( str_contains( $items[0]['attributes']['className'], 'is-variant' ) )->toBeTrue()
+		->and( str_contains( $items[1]['attributes']['className'], 'is-variant' ) )->toBeFalse();
+} );
+
+it( 'matches odd / even pattern variants', function () {
+	$this->fake->setItems( [
+		variantPostFixture( 1, 'A' ),
+		variantPostFixture( 2, 'B' ),
+		variantPostFixture( 3, 'C' ),
+	] );
+
+	$base       = [ [ 'name' => 'core/post-title', 'attributes' => [], 'innerBlocks' => [] ] ];
+	$oddVariant = variantBlock(
+		[ 'kind' => 'pattern', 'value' => 'odd' ],
+		[ [ 'name' => 'core/post-content', 'attributes' => [], 'innerBlocks' => [] ] ]
+	);
+
+	$inlined = $this->inliner->inline( [ queryWithVariants( $base, [ $oddVariant ] ) ] );
+	$items   = $inlined[0]['innerBlocks'][0]['innerBlocks'];
+
+	expect( $items[0]['innerBlocks'][0]['name'] )->toBe( 'core/post-content' ) // pos 1 odd
+		->and( $items[1]['innerBlocks'][0]['name'] )->toBe( 'core/post-title' )  // pos 2 even -> base
+		->and( $items[2]['innerBlocks'][0]['name'] )->toBe( 'core/post-content' ); // pos 3 odd
+} );
+
+it( 'matches meta:sticky variants by walking the variant list at render time', function () {
+	$this->fake->setItems( [
+		variantPostFixture( 1, 'Pinned', [ 'sticky' => true ] ),
+		variantPostFixture( 2, 'Normal' ),
+	] );
+
+	$base    = [ [ 'name' => 'core/post-title', 'attributes' => [], 'innerBlocks' => [] ] ];
+	$variant = variantBlock(
+		[ 'kind' => 'meta', 'value' => 'sticky' ],
+		[ [ 'name' => 'core/post-content', 'attributes' => [], 'innerBlocks' => [] ] ]
+	);
+
+	$inlined = $this->inliner->inline( [ queryWithVariants( $base, [ $variant ] ) ] );
+	$items   = $inlined[0]['innerBlocks'][0]['innerBlocks'];
+
+	expect( $items[0]['innerBlocks'][0]['name'] )->toBe( 'core/post-content' )
+		->and( $items[1]['innerBlocks'][0]['name'] )->toBe( 'core/post-title' );
+} );
+
+it( 'resolves custom matchers via the apve_query_variant_match_<name> filter hook', function () {
+	if ( ! function_exists( 'ArtisanPackUI\\Hooks\\applyFilters' ) ) {
+		test()->markTestSkipped( 'artisanpack-ui/hooks not loaded.' );
+		return;
+	}
+
+	$this->fake->setItems( [
+		variantPostFixture( 1, 'Promo', [ 'is_promo' => true ] ),
+		variantPostFixture( 2, 'Regular' ),
+	] );
+
+	\ArtisanPackUI\Hooks\addFilter(
+		'apve_query_variant_match_premium',
+		fn ( $matches, $post ) => true === ( $post->is_promo ?? false ),
+		10
+	);
+
+	$base    = [ [ 'name' => 'core/post-title', 'attributes' => [], 'innerBlocks' => [] ] ];
+	$variant = variantBlock(
+		[ 'kind' => 'custom', 'value' => 'callback:premium' ],
+		[ [ 'name' => 'core/post-content', 'attributes' => [], 'innerBlocks' => [] ] ]
+	);
+
+	$inlined = $this->inliner->inline( [ queryWithVariants( $base, [ $variant ] ) ] );
+	$items   = $inlined[0]['innerBlocks'][0]['innerBlocks'];
+
+	expect( $items[0]['innerBlocks'][0]['name'] )->toBe( 'core/post-content' )
+		->and( $items[1]['innerBlocks'][0]['name'] )->toBe( 'core/post-title' );
+
+	\ArtisanPackUI\Hooks\removeAllFilters( 'apve_query_variant_match_premium' );
+} );
+
+it( 'honors the precedence cascade: position > pattern > meta > custom', function () {
+	$this->fake->setItems( [
+		variantPostFixture( 1, 'First', [ 'sticky' => true ] ),
+		variantPostFixture( 2, 'Second' ),
+	] );
+
+	$base = [ [ 'name' => 'core/post-title', 'attributes' => [], 'innerBlocks' => [] ] ];
+
+	$positionVariant = variantBlock(
+		[ 'kind' => 'position', 'value' => 'first' ],
+		[ [ 'name' => 'core/post-excerpt', 'attributes' => [], 'innerBlocks' => [] ] ]
+	);
+	$metaVariant = variantBlock(
+		[ 'kind' => 'meta', 'value' => 'sticky' ],
+		[ [ 'name' => 'core/post-content', 'attributes' => [], 'innerBlocks' => [] ] ]
+	);
+
+	// First post matches BOTH position:first AND meta:sticky.
+	// Position must win because it's a higher precedence tier.
+	$inlined = $this->inliner->inline( [
+		queryWithVariants( $base, [ $metaVariant, $positionVariant ] ),
+	] );
+
+	$items = $inlined[0]['innerBlocks'][0]['innerBlocks'];
+
+	expect( $items[0]['innerBlocks'][0]['name'] )->toBe( 'core/post-excerpt' );
+} );
+
+it( 'uses the precompiled _compiledVariantMap as the fast path for static matchers', function () {
+	$this->fake->setItems( [
+		variantPostFixture( 1, 'A' ),
+		variantPostFixture( 2, 'B' ),
+		variantPostFixture( 3, 'C' ),
+	] );
+
+	$base    = [ [ 'name' => 'core/post-title', 'attributes' => [], 'innerBlocks' => [] ] ];
+	$variant = variantBlock(
+		[ 'kind' => 'position', 'value' => 'first' ],
+		[ [ 'name' => 'core/post-content', 'attributes' => [], 'innerBlocks' => [] ] ]
+	);
+
+	// Map says: at loop index 2, use variant #0. Without the map,
+	// position:first would only match index 0, so map presence is
+	// observable in output.
+	$inlined = $this->inliner->inline( [
+		queryWithVariants( $base, [ $variant ], [ 2 => 0 ] ),
+	] );
+
+	$items = $inlined[0]['innerBlocks'][0]['innerBlocks'];
+
+	expect( $items[0]['innerBlocks'][0]['name'] )->toBe( 'core/post-content' ) // matched via walk
+		->and( $items[1]['innerBlocks'][0]['name'] )->toBe( 'core/post-title' )
+		->and( $items[2]['innerBlocks'][0]['name'] )->toBe( 'core/post-content' ); // matched via map
+} );
+
+it( 'breaks ties between same-tier variants on priority ascending then document order', function () {
+	$this->fake->setItems( [
+		variantPostFixture( 1, 'A' ),
+	] );
+
+	$base = [ [ 'name' => 'core/post-title', 'attributes' => [], 'innerBlocks' => [] ] ];
+
+	$higherPriority = variantBlock(
+		[ 'kind' => 'position', 'value' => 'first' ],
+		[ [ 'name' => 'core/post-excerpt', 'attributes' => [], 'innerBlocks' => [] ] ],
+		20
+	);
+	$lowerPriority = variantBlock(
+		[ 'kind' => 'position', 'value' => 'first' ],
+		[ [ 'name' => 'core/post-content', 'attributes' => [], 'innerBlocks' => [] ] ],
+		5
+	);
+
+	// Both match index 0; lowerPriority (priority=5) wins.
+	$inlined = $this->inliner->inline( [
+		queryWithVariants( $base, [ $higherPriority, $lowerPriority ] ),
+	] );
+
+	$items = $inlined[0]['innerBlocks'][0]['innerBlocks'];
+
+	expect( $items[0]['innerBlocks'][0]['name'] )->toBe( 'core/post-content' );
+} );

--- a/tests/Unit/VisualEditor/Resources/QueryInlinerVariantsTest.php
+++ b/tests/Unit/VisualEditor/Resources/QueryInlinerVariantsTest.php
@@ -177,19 +177,21 @@ it( 'resolves custom matchers via the apve_query_variant_match_<name> filter hoo
 		10
 	);
 
-	$base    = [ [ 'name' => 'core/post-title', 'attributes' => [], 'innerBlocks' => [] ] ];
-	$variant = variantBlock(
-		[ 'kind' => 'custom', 'value' => 'callback:premium' ],
-		[ [ 'name' => 'core/post-content', 'attributes' => [], 'innerBlocks' => [] ] ]
-	);
+	try {
+		$base    = [ [ 'name' => 'core/post-title', 'attributes' => [], 'innerBlocks' => [] ] ];
+		$variant = variantBlock(
+			[ 'kind' => 'custom', 'value' => 'callback:premium' ],
+			[ [ 'name' => 'core/post-content', 'attributes' => [], 'innerBlocks' => [] ] ]
+		);
 
-	$inlined = $this->inliner->inline( [ queryWithVariants( $base, [ $variant ] ) ] );
-	$items   = $inlined[0]['innerBlocks'][0]['innerBlocks'];
+		$inlined = $this->inliner->inline( [ queryWithVariants( $base, [ $variant ] ) ] );
+		$items   = $inlined[0]['innerBlocks'][0]['innerBlocks'];
 
-	expect( $items[0]['innerBlocks'][0]['name'] )->toBe( 'core/post-content' )
-		->and( $items[1]['innerBlocks'][0]['name'] )->toBe( 'core/post-title' );
-
-	\ArtisanPackUI\Hooks\removeAllFilters( 'apve_query_variant_match_premium' );
+		expect( $items[0]['innerBlocks'][0]['name'] )->toBe( 'core/post-content' )
+			->and( $items[1]['innerBlocks'][0]['name'] )->toBe( 'core/post-title' );
+	} finally {
+		\ArtisanPackUI\Hooks\removeAllFilters( 'apve_query_variant_match_premium' );
+	}
 } );
 
 it( 'honors the precedence cascade: position > pattern > meta > custom', function () {


### PR DESCRIPTION
## Description

Adds a variant system to the Query Loop block so authors can override the post template for specific posts in the loop — the first post as a hero card, odd / even alternation, sticky posts in a distinct layout, etc. Closes the gap left by Gutenberg's single-template Query Loop without forcing authors back into PHP.

**Closes:** #591

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #591

## Motivation and Context

Pre-Gutenberg PHP gave full control via `the_loop()` + CSS `:nth-child`. Gutenberg's Query Loop renders every post with the same Post Template. This PR closes that gap inside the visual editor.

## Changes Made

- **New block** `artisanpack/post-variant` (parent-locked to `artisanpack/post-template`) with attributes `matcher`, `priority`, `label`. Inspector exposes matcher kind, preset picker, raw value field, priority slider.
- **"Post Variants" panel** in the Query Loop inspector — list / select / reorder / delete plus add buttons for each of the four kinds. Writes a precompiled `position → variantOrder` map onto the parent post-template's new `_compiledVariantMap` attribute.
- **Shared matcher engine** (`resources/js/visual-editor/editor/variant-matcher.ts`) — pure TS spec consumed by save-time compile + canvas. 12 unit tests pass.
- **PHP `VariantResolver`** (`src/Resources/VariantResolver.php`) — server-side counterpart. Precedence: **instance > position > pattern > meta > custom > base**, ties on `priority` ascending then document order. Implements `meta` (sticky / featured / has-featured-image / author / taxonomy) and `custom` (via `apve_query_variant_match_<name>` filter hook).
- **`QueryInliner` integration** — strips variants from the iteration template, primes the resolver, swaps the iteration template per post. Items rendered via a variant carry an `is-variant` class on their `core/post-template-item` wrapper.
- **Renderer parity** — `artisanpack/post-variant` registered in Blade (recursive include), React (`PostVariantBlock`), Vue (`PostVariantBlock`); 152/152 renderer-parity check ✅.
- **Docs**: new `docs/blocks/Post-Variants.md` + `apve_query_variant_match_<name>` entry in `docs/Hooks-and-Events.md`; `CHANGELOG.md` updated.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS
- Browser: Safari (artisanpack-ui-dev Herd site)
- PHP Version: 8.4
- Project Version: 1.2-dev (base branch `release/1.2`)

**Tests Performed:**
1. Manual: insert Query Loop in the dev app → confirm "Post Variants" panel appears, no React crashes (the initial `useEffect` write loop was fixed pre-commit by comparing the compiled map against the stored signature before dispatching).
2. Manual: add position / pattern / meta variants → confirm each renders the right template on the front end; base posts render the base template; `is-variant` class lands on the right `<li>`.
3. Manual: confirmed Query Loops with **no** variants render byte-identical to before (regression check).
4. Automated: new `QueryInlinerVariantsTest` (8 tests, 21 assertions) and `variant-matcher.test.ts` (12 tests). All 15 pre-existing `QueryInlinerTest` cases still pass.

## Accessibility Tests Run

- [x] Keyboard navigation tested
- [ ] Screen reader tested
- [ ] Color contrast verified
- [x] ARIA labels checked

**Details:** Panel action buttons (`↑`, `↓`, `×`) carry `aria-label`s. The select-variant button is a real `<button>` so keyboard activates the canvas selection via `selectBlock`. Block-editor inspector chrome is unchanged.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:**
- `tests/Unit/VisualEditor/Resources/QueryInlinerVariantsTest.php` — backward compat (no variants = unchanged), position swap, pattern (odd / even), meta:sticky walk, custom callback via `apve_query_variant_match_<name>`, precedence cascade, precompiled map fast-path, priority tie-break.
- `resources/js/visual-editor/editor/__tests__/variant-matcher.test.ts` — `matchPosition`, `matchPattern`, `matchMeta`, `sortVariants` precedence + tie-break, `compileStaticMap`, `resolveVariant`.

## Documentation

- [x] Inline code documentation added
- [x] Wiki updated

**Documentation details:** `docs/blocks/Post-Variants.md` covers the block, four matcher kinds, the fixed precedence cascade, editor UX, hybrid resolution, custom matchers, and backward-compat guarantees. `docs/Hooks-and-Events.md` adds the `apve_query_variant_match_<name>` filter section. `CHANGELOG.md` carries the user-facing summary under `[Unreleased]`.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted (CodeRabbit CLI run pre-push against `release/1.2`; all findings addressed)
- [x] Accessibility tests completed (keyboard + ARIA — see above)
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added **per-post layout overrides** in query loops via **post variants**, with fixed precedence and priority-based tie-breaking.
  * Introduced a **Post Variants** inspector panel for creating, reordering, and configuring variants.
  * Added renderer support so variants behave consistently across editor previews and server rendering, including variant styling markers.

* **Documentation**
  * Documented post-variant usage and the `apve_query_variant_match_<name>` custom matcher filter.

* **Tests**
  * Added automated coverage for matcher behavior, precedence, and compiled-map fast paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->