### PR TITLE
feat: render full query loop in editor canvas for true WYSIWYG

### DIFF
--- a/packages/visual-editor-renderer-blade/resources/assets/frontend/query-pagination.css
+++ b/packages/visual-editor-renderer-blade/resources/assets/frontend/query-pagination.css
@@ -1,0 +1,78 @@
+/**
+ * Query Pagination block styles.
+ *
+ * Front-end counterpart of the editor stylesheet at
+ * `resources/js/visual-editor/blocks/query-pagination/query-pagination.css`.
+ * Keep the two in lockstep; the Blade / React / Vue renderers all emit
+ * the same class names so a single rule set serves both surfaces.
+ *
+ * Layout goal: horizontal at every viewport, full width, with the
+ * previous link pinned to the start, the page numbers always
+ * centered, and the next link pinned to the end — *including the
+ * case where previous or next is absent* (inactive prev/next render
+ * nothing on the front end per issue #599). CSS Grid with
+ * `1fr auto 1fr` columns reserves the side slots so the middle column
+ * stays centered even when its sibling slots are empty.
+ *
+ * All visual choices a theme is likely to want to override are
+ * exposed as CSS custom properties.
+ */
+
+.wp-block-query-pagination {
+    --ap-query-pagination-gap: 1rem;
+    --ap-query-pagination-padding-block: 1.25rem;
+    --ap-query-pagination-number-gap: 0.5rem;
+    --ap-query-pagination-number-padding: 0.25rem 0.5rem;
+    --ap-query-pagination-current-weight: 700;
+    --ap-query-pagination-link-decoration: none;
+
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
+    align-items: center;
+    gap: var( --ap-query-pagination-gap );
+    width: 100%;
+    padding-block: var( --ap-query-pagination-padding-block );
+    margin: 0;
+}
+
+/* Previous: column 1, justified to the start. */
+.wp-block-query-pagination > .wp-block-query-pagination-previous {
+    grid-column: 1;
+    justify-self: start;
+    text-decoration: var( --ap-query-pagination-link-decoration );
+}
+
+/* Numbers: column 2 (the always-present `auto` slot), justified to
+   center. The 1fr columns on either side keep the center stable even
+   if previous or next is missing. */
+.wp-block-query-pagination > .wp-block-query-pagination-numbers {
+    grid-column: 2;
+    justify-self: center;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: center;
+    gap: var( --ap-query-pagination-number-gap );
+    text-align: center;
+}
+
+.wp-block-query-pagination .wp-block-query-pagination-numbers .page-numbers {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: var( --ap-query-pagination-number-padding );
+    text-decoration: var( --ap-query-pagination-link-decoration );
+    line-height: 1;
+}
+
+.wp-block-query-pagination .wp-block-query-pagination-numbers .page-numbers.current,
+.wp-block-query-pagination .wp-block-query-pagination-numbers [aria-current="page"] {
+    font-weight: var( --ap-query-pagination-current-weight );
+}
+
+/* Next: column 3, justified to the end. */
+.wp-block-query-pagination > .wp-block-query-pagination-next {
+    grid-column: 3;
+    justify-self: end;
+    text-decoration: var( --ap-query-pagination-link-decoration );
+}

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/query-pagination-next.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/query-pagination-next.blade.php
@@ -7,8 +7,10 @@
 		? $attributes['label']
 		: __( 'Next Page' );
 @endphp
+{{-- When the inliner could not resolve a next-page URL (e.g. on the
+	last page), the leaf renders nothing at all on the front end. The
+	editor still shows the muted placeholder so authors can edit the
+	block; the renderers stay quiet. Issue #599. --}}
 @if ( '' !== $url )
 	<a{!! BlockSupports::wrapperAttrs( $attributes, [ 'wp-block-query-pagination-next' ] ) !!} href="{{ $url }}">{{ $label }} &rarr;</a>
-@else
-	<span{!! BlockSupports::wrapperAttrs( $attributes, [ 'wp-block-query-pagination-next' ] ) !!}>{{ $label }}</span>
 @endif

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/query-pagination-previous.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/query-pagination-previous.blade.php
@@ -7,8 +7,11 @@
 		? $attributes['label']
 		: __( 'Previous Page' );
 @endphp
+{{-- When the inliner could not resolve a previous-page URL (e.g. on
+	page 1), the leaf renders nothing at all on the front end. The
+	editor still shows a muted placeholder so authors can edit the
+	block; the renderers stay quiet so themes don't have to style an
+	always-present-but-sometimes-inactive affordance. Issue #599. --}}
 @if ( '' !== $url )
 	<a{!! BlockSupports::wrapperAttrs( $attributes, [ 'wp-block-query-pagination-previous' ] ) !!} href="{{ $url }}">&larr; {{ $label }}</a>
-@else
-	<span{!! BlockSupports::wrapperAttrs( $attributes, [ 'wp-block-query-pagination-previous' ] ) !!}>{{ $label }}</span>
 @endif

--- a/packages/visual-editor-renderer-blade/resources/views/components/blocks-styles.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/components/blocks-styles.blade.php
@@ -23,6 +23,11 @@
 	server-stamped `<ol>` lays out inline with the chosen separator on
 	the public frontend. --}}
 <link rel="stylesheet" href="{{ $breadcrumbsStyleHref }}" data-ve-breadcrumbs>
+{{-- Query Pagination layout baseline (#599). Matches the rules the
+	editor loads from `blocks/query-pagination/query-pagination.css`
+	so the server-rendered nav lays out horizontally with previous /
+	numbers / next at start / center / end on the public frontend. --}}
+<link rel="stylesheet" href="{{ $queryPaginationStyleHref }}" data-ve-query-pagination>
 {{-- #595 — Flex layout utility classes (ap-flex, ap-flex-row, ap-gap-x-*, …)
 	emitted by the shared serializer onto group/column/columns/grid-item
 	wrappers. Static, layout-only, no interactivity needed. --}}

--- a/packages/visual-editor-renderer-blade/src/View/Components/BlocksStylesComponent.php
+++ b/packages/visual-editor-renderer-blade/src/View/Components/BlocksStylesComponent.php
@@ -69,6 +69,8 @@ class BlocksStylesComponent extends Component
 
 	public string $breadcrumbsStyleHref;
 
+	public string $queryPaginationStyleHref;
+
 	public string $flexLayoutStyleHref;
 
 	public string $photoGridStyleHref;
@@ -109,6 +111,7 @@ class BlocksStylesComponent extends Component
 		$this->marqueeStyleHref       = $base . '/frontend/marquee.css';
 		$this->socialIconsStyleHref   = $base . '/frontend/social-icons.css';
 		$this->breadcrumbsStyleHref   = $base . '/frontend/breadcrumbs.css';
+		$this->queryPaginationStyleHref = $base . '/frontend/query-pagination.css';
 		$this->flexLayoutStyleHref    = $base . '/frontend/flex-layout.css';
 		$this->photoGridStyleHref     = $base . '/frontend/photo-grid.css';
 		$this->interactivityScriptSrc = $base . '/frontend/interactivity.js';

--- a/packages/visual-editor-renderer-blade/tests/Feature/BlocksStylesComponentTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Feature/BlocksStylesComponentTest.php
@@ -41,6 +41,14 @@ it( 'emits the breadcrumbs frontend stylesheet link independently of $emitIntera
 		->toContain( 'data-ve-breadcrumbs' );
 } );
 
+it( 'emits the query-pagination frontend stylesheet link independently of $emitInteractive', function () {
+	$rendered = Blade::render( '<x-ve-blocks-styles :interactive="false" />' );
+
+	expect( $rendered )
+		->toContain( '/vendor/visual-editor-renderer-blade/frontend/query-pagination.css' )
+		->toContain( 'data-ve-query-pagination' );
+} );
+
 it( 'rebases the link href when assetBase is supplied', function () {
 	$rendered = Blade::render(
 		'<x-ve-blocks-styles asset-base="https://cdn.example.com/ve" />'

--- a/packages/visual-editor-renderer-react/src/blocks/artisanpack/queryContext.tsx
+++ b/packages/visual-editor-renderer-react/src/blocks/artisanpack/queryContext.tsx
@@ -34,14 +34,18 @@ export function QueryPaginationBlock({ attributes, children }: BlockRendererProp
     );
 }
 
-export function QueryPaginationNextBlock({ attributes }: BlockRendererProps): JSX.Element {
+// Inactive states render nothing on the front end (issue #599) — the
+// editor still shows a muted placeholder so authors can edit the
+// block; the public renderer stays quiet so themes don't have to
+// style an always-present-but-sometimes-inactive affordance.
+export function QueryPaginationNextBlock({ attributes }: BlockRendererProps): JSX.Element | null {
     const url = safeUrl(attrString(attributes._resolvedNextPageUrl));
     const label = attrString(attributes.label, 'Next Page');
     const className = attrString(attributes.className);
     const classes = classList(['wp-block-query-pagination-next', className]);
 
     if (url === '') {
-        return <span className={classes}>{label}</span>;
+        return null;
     }
     return (
         <a className={classes} href={url}>
@@ -50,14 +54,14 @@ export function QueryPaginationNextBlock({ attributes }: BlockRendererProps): JS
     );
 }
 
-export function QueryPaginationPreviousBlock({ attributes }: BlockRendererProps): JSX.Element {
+export function QueryPaginationPreviousBlock({ attributes }: BlockRendererProps): JSX.Element | null {
     const url = safeUrl(attrString(attributes._resolvedPreviousPageUrl));
     const label = attrString(attributes.label, 'Previous Page');
     const className = attrString(attributes.className);
     const classes = classList(['wp-block-query-pagination-previous', className]);
 
     if (url === '') {
-        return <span className={classes}>{label}</span>;
+        return null;
     }
     return (
         <a className={classes} href={url}>

--- a/packages/visual-editor-renderer-vue/src/blocks/artisanpack/queryContext.ts
+++ b/packages/visual-editor-renderer-vue/src/blocks/artisanpack/queryContext.ts
@@ -45,6 +45,10 @@ export const QueryPaginationBlock = defineComponent({
     },
 });
 
+// Inactive states render nothing on the front end (issue #599) — the
+// editor still shows a muted placeholder so authors can edit the
+// block; the public renderer stays quiet so themes don't have to
+// style an always-present-but-sometimes-inactive affordance.
 export const QueryPaginationNextBlock = defineComponent({
     name: 'QueryPaginationNextBlock',
     props: blockRendererProps,
@@ -55,7 +59,7 @@ export const QueryPaginationNextBlock = defineComponent({
             const className = attrString(props.attributes.className);
             const classes = classList(['wp-block-query-pagination-next', className]);
             if (url === '') {
-                return h('span', { class: classes }, label);
+                return null;
             }
             return h('a', { class: classes, href: url }, `${label} →`);
         };
@@ -72,7 +76,7 @@ export const QueryPaginationPreviousBlock = defineComponent({
             const className = attrString(props.attributes.className);
             const classes = classList(['wp-block-query-pagination-previous', className]);
             if (url === '') {
-                return h('span', { class: classes }, label);
+                return null;
             }
             return h('a', { class: classes, href: url }, `← ${label}`);
         };

--- a/resources/js/visual-editor/blocks/__tests__/query-sibling-context.test.tsx
+++ b/resources/js/visual-editor/blocks/__tests__/query-sibling-context.test.tsx
@@ -1,0 +1,282 @@
+/**
+ * Tests for the query-family sibling blocks reading the
+ * `artisanpack/queryPreview` block context (#599):
+ *
+ *   - query-title shows the resolved title when present.
+ *   - query-pagination-next shows an active state when more pages exist.
+ *   - query-pagination-previous shows the muted state on canvas page 1.
+ *   - query-pagination-numbers computes a plausible page run from
+ *     total + perPage.
+ *   - query-no-results gates the InnerBlocks render on `showInEditor`
+ *     (design-time toggle) — but always renders content when the
+ *     resolver actually returned zero matches (front-end semantics).
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { render } from '@testing-library/react';
+
+vi.mock( '@wordpress/block-editor', async () => {
+    const { createElement } = await import( 'react' );
+    return {
+        InnerBlocks: () => createElement( 'div', { 'data-testid': 'inner-blocks' }, 'Inner blocks' ),
+        InspectorControls: ( { children }: { children: React.ReactNode } ) =>
+            createElement( 'div', { 'data-testid': 'inspector-controls' }, children ),
+        useBlockProps: Object.assign(
+            ( props?: Record<string, unknown> ) => ( {
+                className: typeof props?.className === 'string' ? props.className : 'wp-block',
+            } ),
+            { save: () => ( {} ) }
+        ),
+    };
+} );
+
+vi.mock( '@wordpress/components', async () => {
+    const { createElement } = await import( 'react' );
+    return {
+        PanelBody: ( { children }: { children: React.ReactNode } ) =>
+            createElement( 'div', { 'data-testid': 'panel-body' }, children ),
+        ToggleControl: ( {
+            label,
+            checked,
+            onChange,
+        }: {
+            label: string;
+            checked: boolean;
+            onChange: ( next: boolean ) => void;
+        } ) =>
+            createElement(
+                'label',
+                null,
+                label,
+                createElement( 'input', {
+                    type: 'checkbox',
+                    'data-testid': 'toggle-show-in-editor',
+                    checked,
+                    onChange: ( event: React.ChangeEvent<HTMLInputElement> ) =>
+                        onChange( event.target.checked ),
+                } )
+            ),
+    };
+} );
+
+vi.mock( '@wordpress/i18n', () => ( {
+    __: ( text: string ) => text,
+} ) );
+
+import QueryTitleEdit from '../query-title/edit';
+import QueryPaginationNextEdit from '../query-pagination-next/edit';
+import QueryPaginationPreviousEdit from '../query-pagination-previous/edit';
+import QueryPaginationNumbersEdit from '../query-pagination-numbers/edit';
+import QueryNoResultsEdit from '../query-no-results/edit';
+
+import { QUERY_PREVIEW_CONTEXT_KEY } from '../../editor/query-preview-context';
+import type { QueryPreviewContextValue } from '../../editor/query-preview-context';
+
+function previewContext( overrides: Partial<QueryPreviewContextValue> = {} ): Record<string, unknown> {
+    return {
+        [ QUERY_PREVIEW_CONTEXT_KEY ]: {
+            posts: [],
+            total: 0,
+            currentPage: 1,
+            queryTitle: '',
+            perPage: 0,
+            status: 'ready',
+            ...overrides,
+        },
+    };
+}
+
+describe( 'QueryTitleEdit', () => {
+    it( 'renders the placeholder when no resolved title is available', () => {
+        const { getByText } = render(
+            <QueryTitleEdit attributes={ { type: 'archive', level: 1 } } />
+        );
+        expect( getByText( 'Archive title' ) ).not.toBeNull();
+    } );
+
+    it( 'prefers the stamped _resolvedQueryTitle attribute over the context value', () => {
+        const { getByText, queryByText } = render(
+            <QueryTitleEdit
+                attributes={ {
+                    type: 'archive',
+                    level: 1,
+                    _resolvedQueryTitle: 'Stamped title',
+                } as Record<string, unknown> }
+                context={ previewContext( { queryTitle: 'Context title' } ) }
+            />
+        );
+        expect( getByText( 'Stamped title' ) ).not.toBeNull();
+        expect( queryByText( 'Context title' ) ).toBeNull();
+    } );
+
+    it( 'falls back to the queryPreview context title when the attribute is empty', () => {
+        const { getByText } = render(
+            <QueryTitleEdit
+                attributes={ { type: 'archive', level: 1 } }
+                context={ previewContext( { queryTitle: 'From context' } ) }
+            />
+        );
+        expect( getByText( 'From context' ) ).not.toBeNull();
+    } );
+} );
+
+describe( 'QueryPaginationNextEdit', () => {
+    it( 'renders an active state when the total exceeds perPage on canvas page 1', () => {
+        const { container } = render(
+            <QueryPaginationNextEdit
+                attributes={ {} }
+                context={ previewContext( { total: 10, perPage: 3 } ) }
+            />
+        );
+        // Active state has the arrow glyph appended.
+        expect( container.textContent ).toContain( 'Next Page' );
+        expect( container.textContent ).toContain( '→' ); // →
+    } );
+
+    it( 'renders a muted placeholder when no more pages exist', () => {
+        const { container } = render(
+            <QueryPaginationNextEdit
+                attributes={ {} }
+                context={ previewContext( { total: 2, perPage: 5 } ) }
+            />
+        );
+        expect( container.textContent ).toContain( 'Next Page' );
+        expect( container.textContent ).not.toContain( '→' );
+    } );
+
+    it( 'renders an active state when _resolvedNextPageUrl is stamped on the saved tree', () => {
+        const { container } = render(
+            <QueryPaginationNextEdit
+                attributes={ { _resolvedNextPageUrl: 'https://example.test/page/2' } }
+            />
+        );
+        expect( container.textContent ).toContain( '→' );
+    } );
+} );
+
+describe( 'QueryPaginationPreviousEdit', () => {
+    it( 'renders a muted placeholder by default (canvas always previews page 1)', () => {
+        const { container } = render(
+            <QueryPaginationPreviousEdit attributes={ {} } />
+        );
+        expect( container.textContent ).toContain( 'Previous Page' );
+        expect( container.textContent ).not.toContain( '←' );
+    } );
+
+    it( 'renders an active state when _resolvedPreviousPageUrl is stamped', () => {
+        const { container } = render(
+            <QueryPaginationPreviousEdit
+                attributes={ { _resolvedPreviousPageUrl: 'https://example.test/' } }
+            />
+        );
+        expect( container.textContent ).toContain( '←' );
+    } );
+} );
+
+describe( 'QueryPaginationNumbersEdit', () => {
+    it( 'falls back to the static text when no preview context is present', () => {
+        const { container } = render(
+            <QueryPaginationNumbersEdit attributes={ {} } />
+        );
+        expect( container.textContent ).toContain( '1 2 3' );
+    } );
+
+    it( 'computes a plausible page run from total + perPage', () => {
+        const { container } = render(
+            <QueryPaginationNumbersEdit
+                attributes={ {} }
+                context={ previewContext( { total: 12, perPage: 3 } ) }
+            />
+        );
+        // ceil(12/3) = 4 pages → "1 2 3 4"
+        expect( container.textContent ).toContain( '1' );
+        expect( container.textContent ).toContain( '4' );
+        // Should NOT contain a page number that exceeds the computed count.
+        expect( container.textContent ).not.toContain( '5' );
+    } );
+
+    it( 'caps the displayed numbers to a reasonable preview length', () => {
+        const { container } = render(
+            <QueryPaginationNumbersEdit
+                attributes={ {} }
+                context={ previewContext( { total: 100, perPage: 3 } ) }
+            />
+        );
+        // ceil(100/3) = 34 pages, but preview caps at 5 numbers.
+        expect( container.textContent ).toContain( '1' );
+        expect( container.textContent ).toContain( '5' );
+        expect( container.textContent ).not.toContain( '6' );
+    } );
+
+    it( 'marks page 1 as the current page (canvas always previews page 1)', () => {
+        const { container } = render(
+            <QueryPaginationNumbersEdit
+                attributes={ {} }
+                context={ previewContext( { total: 9, perPage: 3 } ) }
+            />
+        );
+        const current = container.querySelector( '[aria-current="page"]' );
+        expect( current?.textContent ).toBe( '1' );
+    } );
+
+    it( 'prefers a stamped pagination numbers label when present', () => {
+        const { container } = render(
+            <QueryPaginationNumbersEdit
+                attributes={ { _resolvedPaginationNumbersLabel: 'pre-rendered 1 2 3' } }
+                context={ previewContext( { total: 12, perPage: 3 } ) }
+            />
+        );
+        expect( container.textContent ).toBe( 'pre-rendered 1 2 3' );
+    } );
+} );
+
+describe( 'QueryNoResultsEdit', () => {
+    it( 'hides the inner template by default (showInEditor=false and resolver returned matches)', () => {
+        const { queryByTestId, container } = render(
+            <QueryNoResultsEdit
+                attributes={ {} }
+                setAttributes={ () => {} }
+                context={ previewContext( { total: 5, perPage: 5, posts: [
+                    { id: 1, title: 'Hit' },
+                ] as never } ) }
+            />
+        );
+
+        expect( queryByTestId( 'inner-blocks' ) ).toBeNull();
+        expect( container.textContent ).toContain( 'No Results state (hidden — toggle on to style it)' );
+    } );
+
+    it( 'renders the inner template when showInEditor is true (design-time toggle)', () => {
+        const { getByTestId } = render(
+            <QueryNoResultsEdit
+                attributes={ { showInEditor: true } }
+                setAttributes={ () => {} }
+            />
+        );
+
+        expect( getByTestId( 'inner-blocks' ) ).not.toBeNull();
+    } );
+
+    it( 'renders the inner template when the resolver returned zero matches regardless of toggle state', () => {
+        const { getByTestId } = render(
+            <QueryNoResultsEdit
+                attributes={ {} }
+                setAttributes={ () => {} }
+                context={ previewContext( { total: 0, status: 'ready' } ) }
+            />
+        );
+
+        expect( getByTestId( 'inner-blocks' ) ).not.toBeNull();
+    } );
+
+    it( 'exposes the toggle through InspectorControls so users can flip it on', () => {
+        const { getByTestId } = render(
+            <QueryNoResultsEdit
+                attributes={ { showInEditor: false } }
+                setAttributes={ () => {} }
+            />
+        );
+
+        expect( getByTestId( 'toggle-show-in-editor' ) ).not.toBeNull();
+    } );
+} );

--- a/resources/js/visual-editor/blocks/post-template/block.json
+++ b/resources/js/visual-editor/blocks/post-template/block.json
@@ -30,7 +30,8 @@
         "templateSlug",
         "previewPostType",
         "enhancedPagination",
-        "postType"
+        "postType",
+        "artisanpack/queryPreview"
     ],
     "supports": {
         "anchor": true,

--- a/resources/js/visual-editor/blocks/post-template/edit.tsx
+++ b/resources/js/visual-editor/blocks/post-template/edit.tsx
@@ -1,18 +1,19 @@
 /**
  * Post Template — edit component.
  *
- * Renders `<InnerBlocks />` with a default `artisanpack/post-title`
- * template so users can build the per-iteration layout. Provides a
- * toolbar toggle to switch between list and grid display, plus a columns
- * control when grid is active. The wrapping `artisanpack/query`
- * `BlockContextProvider` resolves the inner `artisanpack/post-*` blocks
- * against the right post. Phase I6 loop / feed cluster (#414).
+ * Renders one editable iteration of the per-post template (driven by
+ * `<InnerBlocks />`) plus N read-only ghosts for the rest of the
+ * resolved record set, via the shared `<QueryPreviewIterations>`
+ * renderer. Provides a toolbar toggle to switch between list and grid
+ * display, plus a columns control when grid is active. The wrapping
+ * `artisanpack/query` block pipes the resolved record set down through
+ * `artisanpack/queryPreview` block context (#599). Phase I6 loop /
+ * feed cluster (#414).
  */
 
 import type { ReactElement } from 'react';
 import {
     BlockControls,
-    InnerBlocks,
     InspectorControls,
     useBlockProps,
 } from '@wordpress/block-editor';
@@ -25,6 +26,8 @@ import {
 import { __ } from '@wordpress/i18n';
 import { list, grid } from '@wordpress/icons';
 
+import { readQueryPreviewContext } from '../../editor/query-preview-context';
+import { QueryPreviewIterations } from '../../editor/query-preview-iterations';
 import { TEXT_DOMAIN } from '../../vendor/i18n';
 
 const DEFAULT_TEMPLATE: ReadonlyArray<[string]> = [ [ 'artisanpack/post-title' ] ];
@@ -32,24 +35,37 @@ const DEFAULT_TEMPLATE: ReadonlyArray<[string]> = [ [ 'artisanpack/post-title' ]
 interface PostTemplateEditProps {
     attributes: Record<string, unknown>;
     setAttributes: ( changes: Record<string, unknown> ) => void;
+    clientId: string;
+    context?: Record<string, unknown>;
 }
 
 export default function PostTemplateEdit( {
     attributes,
     setAttributes,
+    clientId,
+    context,
 }: PostTemplateEditProps ): ReactElement {
     const layout = typeof attributes.layout === 'string' ? attributes.layout : 'list';
     const columns = typeof attributes.columns === 'number' ? attributes.columns : 3;
     const isGrid = layout === 'grid';
 
+    // Use upstream Gutenberg's `core/post-template` class names so the
+    // shipped block-library CSS (`.wp-block-post-template.is-flex-container
+    // > li` + `.columns-{n} > li`) applies without a parallel rule set
+    // — see `@wordpress/block-library/build-style/style.css`.
     const className = [
         'wp-block-post-template',
-        isGrid ? 'is-layout-grid' : 'is-layout-flow',
+        isGrid ? 'is-flex-container' : '',
         isGrid ? `columns-${ columns }` : '',
     ].filter( Boolean ).join( ' ' );
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const blockProps = ( useBlockProps as any )( { className } );
+
+    const previewValue = readQueryPreviewContext( context );
+    const postType = typeof context?.postType === 'string' && context.postType !== ''
+        ? context.postType
+        : 'post';
 
     return (
         <>
@@ -89,9 +105,13 @@ export default function PostTemplateEdit( {
                 </InspectorControls>
             ) }
 
-            <div { ...blockProps }>
-                <InnerBlocks template={ [ ...DEFAULT_TEMPLATE ] } />
-            </div>
+            <QueryPreviewIterations
+                clientId={ clientId }
+                preview={ previewValue }
+                postType={ postType }
+                defaultTemplate={ DEFAULT_TEMPLATE }
+                outerProps={ blockProps as Record<string, unknown> }
+            />
         </>
     );
 }

--- a/resources/js/visual-editor/blocks/query-no-results/block.json
+++ b/resources/js/visual-editor/blocks/query-no-results/block.json
@@ -7,7 +7,13 @@
     "description": "Contains the block elements used to render content when a query returns no results.",
     "ancestor": [ "artisanpack/query" ],
     "textdomain": "artisanpack-visual-editor",
-    "usesContext": [ "queryId", "query" ],
+    "attributes": {
+        "showInEditor": {
+            "type": "boolean",
+            "default": false
+        }
+    },
+    "usesContext": [ "queryId", "query", "artisanpack/queryPreview" ],
     "supports": {
         "anchor": true,
         "align": true,

--- a/resources/js/visual-editor/blocks/query-no-results/edit.tsx
+++ b/resources/js/visual-editor/blocks/query-no-results/edit.tsx
@@ -1,18 +1,24 @@
 /**
  * QueryNoResults — edit component.
  *
- * Wrapper block whose inner template is shown when the surrounding
- * `artisanpack/query` resolves to zero results. The editor renders the
- * configured inner blocks as a regular `<InnerBlocks />` tree so authors
- * can style the empty state alongside the rest of the loop; the front
- * end only emits the wrapper when `_resolvedTotal === 0`. Phase I-Block-Fork
+ * Wrapper block whose inner template is shown on the front end when
+ * the surrounding `artisanpack/query` resolves to zero results. In the
+ * editor the empty-state usually wants to be invisible (so authors
+ * editing a populated query see their populated layout, not the
+ * fallback) but is also stylable on demand. Issue #599 introduces a
+ * `showInEditor` design-time toggle on the block so authors can flip
+ * the empty state on while they style it, without forcing the query
+ * to actually return zero results. The front-end render still only
+ * emits the wrapper when `_resolvedTotal === 0`. Phase I-Block-Fork
  * query family (#521).
  */
 
 import type { ReactElement } from 'react';
-import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
+import { InnerBlocks, InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import { PanelBody, ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
+import { readQueryPreviewContext } from '../../editor/query-preview-context';
 import { TEXT_DOMAIN } from '../../vendor/i18n';
 
 const DEFAULT_TEMPLATE: ReadonlyArray<[ string, Record<string, unknown> ]> = [
@@ -27,15 +33,65 @@ const DEFAULT_TEMPLATE: ReadonlyArray<[ string, Record<string, unknown> ]> = [
     ],
 ];
 
-export default function QueryNoResultsEdit(): ReactElement {
+interface QueryNoResultsEditProps {
+    attributes: { showInEditor?: boolean };
+    setAttributes: ( changes: { showInEditor?: boolean } ) => void;
+    context?: Record<string, unknown>;
+}
+
+export default function QueryNoResultsEdit( {
+    attributes,
+    setAttributes,
+    context,
+}: QueryNoResultsEditProps ): ReactElement {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const blockProps = ( useBlockProps as any )();
 
+    const showInEditor = attributes.showInEditor === true;
+    const preview = readQueryPreviewContext( context );
+    // Honour the front-end semantics in the canvas too: when the
+    // resolver returned zero matches, the no-results state is the
+    // active branch regardless of the design-time toggle, because
+    // that's what the user will see on the page. Otherwise it's a
+    // pure design-time affordance gated by the toggle.
+    const isZeroResultBranch = preview !== null && preview.status === 'ready' && preview.total === 0;
+    const shouldRenderContent = showInEditor || isZeroResultBranch;
+
     return (
         <div { ...blockProps }>
-            <InnerBlocks
-                template={ [ ...DEFAULT_TEMPLATE ] }
-            />
+            <InspectorControls>
+                <PanelBody title={ __( 'Empty state', TEXT_DOMAIN ) }>
+                    <ToggleControl
+                        // @ts-expect-error - upstream prop
+                        __nextHasNoMarginBottom
+                        label={ __( 'Show in editor', TEXT_DOMAIN ) }
+                        help={ __(
+                            'Render the empty-state template in the canvas so you can style it without forcing the query to return zero results. Does not affect the front-end render.',
+                            TEXT_DOMAIN
+                        ) }
+                        checked={ showInEditor }
+                        onChange={ ( value ) => setAttributes( { showInEditor: value } ) }
+                    />
+                </PanelBody>
+            </InspectorControls>
+            { shouldRenderContent ? (
+                <InnerBlocks template={ [ ...DEFAULT_TEMPLATE ] } />
+            ) : (
+                <span
+                    contentEditable={ false }
+                    aria-hidden={ true }
+                    style={ {
+                        display: 'inline-block',
+                        padding: '0.25em 0.6em',
+                        border: '1px dashed currentColor',
+                        borderRadius: '4px',
+                        opacity: 0.55,
+                        fontStyle: 'italic',
+                    } }
+                >
+                    { __( 'No Results state (hidden — toggle on to style it)', TEXT_DOMAIN ) }
+                </span>
+            ) }
         </div>
     );
 }

--- a/resources/js/visual-editor/blocks/query-pagination-next/block.json
+++ b/resources/js/visual-editor/blocks/query-pagination-next/block.json
@@ -17,7 +17,8 @@
         "query",
         "paginationArrow",
         "showLabel",
-        "enhancedPagination"
+        "enhancedPagination",
+        "artisanpack/queryPreview"
     ],
     "supports": {
         "anchor": true,

--- a/resources/js/visual-editor/blocks/query-pagination-next/edit.tsx
+++ b/resources/js/visual-editor/blocks/query-pagination-next/edit.tsx
@@ -1,20 +1,63 @@
 /**
  * QueryPaginationNext — edit component.
  *
- * Server-rendered display block. Previews as a labelled placeholder in
- * the canvas; the real next-page link is emitted server-side once the
- * paginator state is known (request-time, after `QueryInliner` stamps
- * `_resolvedNextPageUrl`). Phase I-Block-Fork query family (#521).
+ * Server-rendered display block. The real next-page link is emitted
+ * server-side once the paginator state is known (request-time, after
+ * `QueryInliner` stamps `_resolvedNextPageUrl`). In the canvas the
+ * preview prefers, in order:
+ *
+ *   1. The stamped `_resolvedNextPageUrl` (faithful pre-rendered tree).
+ *   2. A "Next Page" affordance computed from the
+ *      `artisanpack/queryPreview` block context (#599) — the canvas
+ *      always previews page 1 so a next page exists whenever the
+ *      resolved total exceeds `perPage`.
+ *   3. The labelled placeholder.
+ *
+ * Phase I-Block-Fork query family (#521).
  */
 
+import type { ReactElement } from 'react';
+import { useBlockProps } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 
+import { readQueryPreviewContext } from '../../editor/query-preview-context';
 import { TEXT_DOMAIN } from '../../vendor/i18n';
-import { createEntityPlaceholderEdit } from '../_shared/entity-placeholder-edit';
 
-export default createEntityPlaceholderEdit( {
-    label: __( 'Next Page', TEXT_DOMAIN ),
-    resolvedKey: '_resolvedNextPageUrl',
-    kind: 'text',
-    dummyValue: { text: __( 'Next Page →', TEXT_DOMAIN ) },
-} );
+interface QueryPaginationNextEditProps {
+    attributes: Record<string, unknown>;
+    context?: Record<string, unknown>;
+}
+
+export default function QueryPaginationNextEdit( {
+    attributes,
+    context,
+}: QueryPaginationNextEditProps ): ReactElement {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const blockProps = ( useBlockProps as any )();
+
+    const resolvedUrl = typeof attributes._resolvedNextPageUrl === 'string'
+        ? attributes._resolvedNextPageUrl
+        : '';
+    const baseLabel = typeof attributes.label === 'string' && attributes.label !== ''
+        ? attributes.label
+        : __( 'Next Page', TEXT_DOMAIN );
+
+    const preview = readQueryPreviewContext( context );
+    // Canvas always previews page 1. A next page exists whenever the
+    // resolved total exceeds `perPage` and `perPage` is configured.
+    const hasNextPage = preview !== null && preview.perPage > 0 && preview.total > preview.perPage;
+
+    if ( resolvedUrl !== '' || hasNextPage ) {
+        return (
+            <span { ...blockProps }>
+                { baseLabel } &rarr;
+            </span>
+        );
+    }
+
+    return (
+        <span { ...blockProps } style={ { opacity: 0.55, fontStyle: 'italic' } }>
+            { baseLabel }
+        </span>
+    );
+}

--- a/resources/js/visual-editor/blocks/query-pagination-numbers/block.json
+++ b/resources/js/visual-editor/blocks/query-pagination-numbers/block.json
@@ -13,7 +13,7 @@
             "default": 2
         }
     },
-    "usesContext": [ "queryId", "query", "enhancedPagination" ],
+    "usesContext": [ "queryId", "query", "enhancedPagination", "artisanpack/queryPreview" ],
     "supports": {
         "anchor": true,
         "reusable": false,

--- a/resources/js/visual-editor/blocks/query-pagination-numbers/edit.tsx
+++ b/resources/js/visual-editor/blocks/query-pagination-numbers/edit.tsx
@@ -1,21 +1,83 @@
 /**
  * QueryPaginationNumbers — edit component.
  *
- * Server-rendered display block. Previews as a labelled placeholder
- * — the actual numbered links are computed at request time by
- * `QueryInliner` from the resolved paginator and emitted server-side
- * by the Blade / React / Vue renderers. Phase I-Block-Fork query
- * family (#521).
+ * Server-rendered display block. The actual numbered links are
+ * computed at request time by `QueryInliner` from the resolved
+ * paginator and emitted server-side by the Blade / React / Vue
+ * renderers. In the canvas the preview computes a plausible run of
+ * page numbers from `total` + `perPage` carried on the
+ * `artisanpack/queryPreview` block context (#599) so authors can see
+ * the spacing / styling of multi-page navigation without forcing a
+ * server round-trip. Phase I-Block-Fork query family (#521).
  */
 
-import { __ } from '@wordpress/i18n';
+import type { ReactElement } from 'react';
+import { useBlockProps } from '@wordpress/block-editor';
 
-import { TEXT_DOMAIN } from '../../vendor/i18n';
-import { createEntityPlaceholderEdit } from '../_shared/entity-placeholder-edit';
+import {
+    readQueryPreviewContext,
+    type QueryPreviewContextValue,
+} from '../../editor/query-preview-context';
 
-export default createEntityPlaceholderEdit( {
-    label: __( 'Page Numbers', TEXT_DOMAIN ),
-    resolvedKey: '_resolvedPaginationNumbersLabel',
-    kind: 'text',
-    dummyValue: { text: '1 2 3' },
-} );
+const MAX_PREVIEW_NUMBERS = 5;
+const FALLBACK_TEXT = '1 2 3';
+
+interface QueryPaginationNumbersEditProps {
+    attributes: Record<string, unknown>;
+    context?: Record<string, unknown>;
+}
+
+function computePagePreview( preview: QueryPreviewContextValue | null ): number[] {
+    if ( preview === null || preview.perPage <= 0 || preview.total <= 0 ) {
+        return [];
+    }
+    const pageCount = Math.max( 1, Math.ceil( preview.total / preview.perPage ) );
+    const cap = Math.min( pageCount, MAX_PREVIEW_NUMBERS );
+    const pages: number[] = [];
+    for ( let index = 1; index <= cap; index++ ) {
+        pages.push( index );
+    }
+    return pages;
+}
+
+export default function QueryPaginationNumbersEdit( {
+    attributes,
+    context,
+}: QueryPaginationNumbersEditProps ): ReactElement {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const blockProps = ( useBlockProps as any )();
+
+    // Stamped pages from a prior server render take precedence — the
+    // canvas should be byte-faithful when the saved tree already has
+    // them. Otherwise fall back to the live computed preview.
+    const stampedLabel = typeof attributes._resolvedPaginationNumbersLabel === 'string'
+        ? attributes._resolvedPaginationNumbersLabel
+        : '';
+
+    if ( stampedLabel !== '' ) {
+        return <span { ...blockProps }>{ stampedLabel }</span>;
+    }
+
+    const preview = readQueryPreviewContext( context );
+    const pages = computePagePreview( preview );
+
+    if ( pages.length === 0 ) {
+        return <span { ...blockProps }>{ FALLBACK_TEXT }</span>;
+    }
+
+    // Canvas always previews page 1; mark it current to mirror the
+    // front-end output. Other pages render as plain numbers — the
+    // paginator is not interactive in the editor by design.
+    return (
+        <span { ...blockProps }>
+            { pages.map( ( page, index ) => (
+                <span key={ page }>
+                    { index > 0 ? ' ' : '' }
+                    { page === 1
+                        ? ( <span aria-current="page" style={ { fontWeight: 600 } }>{ page }</span> )
+                        : ( <span>{ page }</span> ) }
+                </span>
+            ) ) }
+        </span>
+    );
+}

--- a/resources/js/visual-editor/blocks/query-pagination-previous/edit.tsx
+++ b/resources/js/visual-editor/blocks/query-pagination-previous/edit.tsx
@@ -1,21 +1,52 @@
 /**
  * QueryPaginationPrevious — edit component.
  *
- * Server-rendered display block. Previews as a labelled placeholder in
- * the canvas; the real previous-page link is emitted server-side once
- * the paginator state is known (request-time, after `QueryInliner`
- * stamps `_resolvedPreviousPageUrl`). Phase I-Block-Fork query family
- * (#521).
+ * Server-rendered display block. The real previous-page link is
+ * emitted server-side once the paginator state is known (request-time,
+ * after `QueryInliner` stamps `_resolvedPreviousPageUrl`). The canvas
+ * always previews page 1, so the previous-page affordance is rendered
+ * as a muted placeholder unless the saved tree carries
+ * `_resolvedPreviousPageUrl` from a prior server render. Phase
+ * I-Block-Fork query family (#521).
  */
 
+import type { ReactElement } from 'react';
+import { useBlockProps } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 
 import { TEXT_DOMAIN } from '../../vendor/i18n';
-import { createEntityPlaceholderEdit } from '../_shared/entity-placeholder-edit';
 
-export default createEntityPlaceholderEdit( {
-    label: __( 'Previous Page', TEXT_DOMAIN ),
-    resolvedKey: '_resolvedPreviousPageUrl',
-    kind: 'text',
-    dummyValue: { text: __( '← Previous Page', TEXT_DOMAIN ) },
-} );
+interface QueryPaginationPreviousEditProps {
+    attributes: Record<string, unknown>;
+}
+
+export default function QueryPaginationPreviousEdit( {
+    attributes,
+}: QueryPaginationPreviousEditProps ): ReactElement {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const blockProps = ( useBlockProps as any )();
+
+    const resolvedUrl = typeof attributes._resolvedPreviousPageUrl === 'string'
+        ? attributes._resolvedPreviousPageUrl
+        : '';
+    const baseLabel = typeof attributes.label === 'string' && attributes.label !== ''
+        ? attributes.label
+        : __( 'Previous Page', TEXT_DOMAIN );
+
+    if ( resolvedUrl !== '' ) {
+        return (
+            <span { ...blockProps }>
+                &larr; { baseLabel }
+            </span>
+        );
+    }
+
+    // No previous page exists from canvas page 1 — render muted so
+    // users can tell at a glance that the affordance is inactive in
+    // the preview without obscuring it for styling work.
+    return (
+        <span { ...blockProps } style={ { opacity: 0.55, fontStyle: 'italic' } }>
+            { baseLabel }
+        </span>
+    );
+}

--- a/resources/js/visual-editor/blocks/query-pagination/block.json
+++ b/resources/js/visual-editor/blocks/query-pagination/block.json
@@ -22,7 +22,7 @@
             "default": true
         }
     },
-    "usesContext": [ "queryId", "query" ],
+    "usesContext": [ "queryId", "query", "artisanpack/queryPreview" ],
     "providesContext": {
         "paginationArrow": "paginationArrow",
         "showLabel": "showLabel"

--- a/resources/js/visual-editor/blocks/query-pagination/edit.tsx
+++ b/resources/js/visual-editor/blocks/query-pagination/edit.tsx
@@ -2,13 +2,17 @@
  * QueryPagination — edit component.
  *
  * Wrapper around the pagination children (previous / numbers / next).
- * Renders `<InnerBlocks />` with the upstream default template so the
- * editor experience matches the rendered pagination row out of the box.
- * Phase I-Block-Fork query family (#521).
+ * Uses `useInnerBlocksProps` so the editor doesn't insert an extra
+ * `block-editor-block-list__layout` wrapper between the flex container
+ * (`wp-block-query-pagination`) and its children — without that, the
+ * pagination row collapses into a left-aligned stack in the editor
+ * because the flex children of the wrapper are an unrelated layout
+ * div, not the pagination leaves (#599). Phase I-Block-Fork query
+ * family (#521).
  */
 
 import type { ReactElement } from 'react';
-import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
+import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
 
 const DEFAULT_TEMPLATE: ReadonlyArray<[ string ]> = [
     [ 'artisanpack/query-pagination-previous' ],
@@ -23,15 +27,21 @@ const ALLOWED_BLOCKS: ReadonlyArray<string> = [
 ];
 
 export default function QueryPaginationEdit(): ReactElement {
+    // Add the upstream-compatible `wp-block-query-pagination` class
+    // alongside the auto-generated `wp-block-artisanpack-query-pagination`.
+    // `useBlockProps` only auto-injects the namespaced flavour; the
+    // server-side renderers (Blade / React / Vue) emit the unprefixed
+    // class so the front-end stylesheet targets that. Keeping both on
+    // the editor wrapper lets the same `query-pagination.css`
+    // selectors style the canvas and the public page (#599).
+    const blockProps = ( useBlockProps as unknown as (
+        props?: Record<string, unknown>
+    ) => Record<string, unknown> )( { className: 'wp-block-query-pagination' } );
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const blockProps = ( useBlockProps as any )();
+    const innerBlocksProps = ( useInnerBlocksProps as any )( blockProps, {
+        template: [ ...DEFAULT_TEMPLATE ],
+        allowedBlocks: [ ...ALLOWED_BLOCKS ],
+    } );
 
-    return (
-        <div { ...blockProps }>
-            <InnerBlocks
-                template={ [ ...DEFAULT_TEMPLATE ] }
-                allowedBlocks={ [ ...ALLOWED_BLOCKS ] }
-            />
-        </div>
-    );
+    return <div { ...innerBlocksProps } />;
 }

--- a/resources/js/visual-editor/blocks/query-pagination/index.ts
+++ b/resources/js/visual-editor/blocks/query-pagination/index.ts
@@ -17,6 +17,8 @@ import save from './save';
 import transforms from './transforms';
 import icon from './inserter-icon';
 
+import './query-pagination.css';
+
 export { edit, save, metadata, icon, transforms };
 
 export default {

--- a/resources/js/visual-editor/blocks/query-pagination/query-pagination.css
+++ b/resources/js/visual-editor/blocks/query-pagination/query-pagination.css
@@ -1,0 +1,94 @@
+/**
+ * Query Pagination block styles.
+ *
+ * Loaded in the editor via `blocks/query-pagination/index.ts` and
+ * piped into the canvas iframe by `editor/canvas-styles.ts` (#566
+ * auto-discovery glob). The server-side renderers (Blade / React /
+ * Vue) emit the same class names so a single rule set serves both
+ * surfaces.
+ *
+ * Layout goal: horizontal at every viewport, full width, with the
+ * previous link pinned to the start, the page numbers always
+ * centered, and the next link pinned to the end — *including the
+ * case where previous or next is absent* (front-end issue #599 hides
+ * inactive prev/next entirely). CSS Grid with `1fr auto 1fr` columns
+ * reserves the side slots so the middle column stays centered even
+ * when its sibling slots are empty; auto-margin / flex approaches
+ * leave the numbers at the start because competing auto-margins
+ * share remaining space.
+ *
+ * Editor parity: each leaf selector lists two variants — the
+ * front-end leaf class (e.g. `.wp-block-query-pagination-previous`)
+ * and the editor's `data-type` block wrapper (e.g.
+ * `[data-type="artisanpack/query-pagination-previous"]`). In the
+ * editor the wrapper is the grid child, not the leaf inside it; on
+ * the front end the wrapper isn't emitted, so only the first
+ * selector matches. Both surfaces end up with the same column
+ * assignments.
+ *
+ * All visual choices a theme is likely to want to override (gap,
+ * color, padding, link decoration, current-page emphasis) are exposed
+ * as CSS custom properties.
+ */
+
+.wp-block-query-pagination {
+    --ap-query-pagination-gap: 1rem;
+    --ap-query-pagination-padding-block: 1.25rem;
+    --ap-query-pagination-number-gap: 0.5rem;
+    --ap-query-pagination-number-padding: 0.25rem 0.5rem;
+    --ap-query-pagination-current-weight: 700;
+    --ap-query-pagination-link-decoration: none;
+
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
+    align-items: center;
+    gap: var( --ap-query-pagination-gap );
+    width: 100%;
+    padding-block: var( --ap-query-pagination-padding-block );
+    margin: 0;
+}
+
+/* Previous: column 1, justified to the start. */
+.wp-block-query-pagination > .wp-block-query-pagination-previous,
+.wp-block-query-pagination > [data-type="artisanpack/query-pagination-previous"] {
+    grid-column: 1;
+    justify-self: start;
+    text-decoration: var( --ap-query-pagination-link-decoration );
+}
+
+/* Numbers: column 2 (the always-present `auto` slot), justified to
+   center. The 1fr columns on either side keep the center stable even
+   if previous or next is missing. */
+.wp-block-query-pagination > .wp-block-query-pagination-numbers,
+.wp-block-query-pagination > [data-type="artisanpack/query-pagination-numbers"] {
+    grid-column: 2;
+    justify-self: center;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: center;
+    gap: var( --ap-query-pagination-number-gap );
+    text-align: center;
+}
+
+.wp-block-query-pagination .wp-block-query-pagination-numbers .page-numbers {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: var( --ap-query-pagination-number-padding );
+    text-decoration: var( --ap-query-pagination-link-decoration );
+    line-height: 1;
+}
+
+.wp-block-query-pagination .wp-block-query-pagination-numbers .page-numbers.current,
+.wp-block-query-pagination .wp-block-query-pagination-numbers [aria-current="page"] {
+    font-weight: var( --ap-query-pagination-current-weight );
+}
+
+/* Next: column 3, justified to the end. */
+.wp-block-query-pagination > .wp-block-query-pagination-next,
+.wp-block-query-pagination > [data-type="artisanpack/query-pagination-next"] {
+    grid-column: 3;
+    justify-self: end;
+    text-decoration: var( --ap-query-pagination-link-decoration );
+}

--- a/resources/js/visual-editor/blocks/query-title/block.json
+++ b/resources/js/visual-editor/blocks/query-title/block.json
@@ -32,7 +32,8 @@
         }
     },
     "usesContext": [
-        "query"
+        "query",
+        "artisanpack/queryPreview"
     ],
     "supports": {
         "artisanpackAnimations": true,

--- a/resources/js/visual-editor/blocks/query-title/edit.tsx
+++ b/resources/js/visual-editor/blocks/query-title/edit.tsx
@@ -1,19 +1,21 @@
 /**
  * QueryTitle — edit component.
  *
- * Server-rendered display block. Previews as a heading-shaped
- * placeholder reflecting the configured `type` (archive / search /
- * post-type) and `level`. Upstream's full archive-label / post-type-
- * label lookups depend on `@wordpress/core-data` selectors the post
- * editor's shim does not implement; the real query title is emitted
+ * Server-rendered display block. The real query title is emitted
  * server-side by the Blade / React / Vue renderers from
- * `_resolvedQueryTitle`. Phase I-Block-Fork query family (#521).
+ * `_resolvedQueryTitle` once the front-end paginator settles. In the
+ * canvas the title falls back to the `artisanpack/queryPreview` block
+ * context (#599) — populated by the surrounding query block from the
+ * resolver payload — and then to a heading-shaped placeholder
+ * reflecting the configured `type` (archive / search / post-type) and
+ * `level`. Phase I-Block-Fork query family (#521).
  */
 
 import type { ReactElement } from 'react';
 import { useBlockProps } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 
+import { readQueryPreviewContext } from '../../editor/query-preview-context';
 import { TEXT_DOMAIN } from '../../vendor/i18n';
 
 interface QueryTitleEditProps {
@@ -21,6 +23,7 @@ interface QueryTitleEditProps {
         type?: string;
         level?: number;
     };
+    context?: Record<string, unknown>;
 }
 
 function defaultTitleFor( type: string ): string {
@@ -36,7 +39,12 @@ function defaultTitleFor( type: string ): string {
     }
 }
 
-export default function QueryTitleEdit( { attributes }: QueryTitleEditProps ): ReactElement {
+function readResolvedQueryTitle( context: Record<string, unknown> | undefined ): string {
+    const preview = readQueryPreviewContext( context );
+    return preview?.queryTitle ?? '';
+}
+
+export default function QueryTitleEdit( { attributes, context }: QueryTitleEditProps ): ReactElement {
     const type = typeof attributes.type === 'string' ? attributes.type : '';
     // Clamp `level` to the WP heading range (0 = paragraph, 1-6 = h1-h6)
     // so a malformed saved value never produces an invalid tag like
@@ -51,14 +59,22 @@ export default function QueryTitleEdit( { attributes }: QueryTitleEditProps ): R
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const blockProps = ( useBlockProps as any )();
 
-    // Read the front-end resolved title when present so block previews
-    // that have been server-rendered before opening in the editor stay
-    // faithful. Otherwise fall back to the type-shaped placeholder.
+    // Resolution priority, highest first:
+    //   1. Stamped `_resolvedQueryTitle` attribute (server pre-render path).
+    //   2. `artisanpack/queryPreview` block context (#599 query-loop path).
+    //   3. Type-shaped placeholder.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const resolved = ( attributes as any )._resolvedQueryTitle;
-    const text = typeof resolved === 'string' && '' !== resolved
-        ? resolved
-        : defaultTitleFor( type );
+    const stamped = ( attributes as any )._resolvedQueryTitle;
+    const fromContext = readResolvedQueryTitle( context );
+    let text: string;
+
+    if ( typeof stamped === 'string' && '' !== stamped ) {
+        text = stamped;
+    } else if ( '' !== fromContext ) {
+        text = fromContext;
+    } else {
+        text = defaultTitleFor( type );
+    }
 
     const Tag = tagName;
     return <Tag { ...blockProps }>{ text }</Tag>;

--- a/resources/js/visual-editor/blocks/query/edit.tsx
+++ b/resources/js/visual-editor/blocks/query/edit.tsx
@@ -28,6 +28,10 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
+import {
+    QUERY_PREVIEW_CONTEXT_KEY,
+    type QueryPreviewContextValue,
+} from '../../editor/query-preview-context';
 import { useQueryPreview } from '../../editor/use-query-preview';
 import { TEXT_DOMAIN } from '../../vendor/i18n';
 import PostVariantsPanel from './post-variants-panel';
@@ -101,20 +105,25 @@ export default function QueryEdit( {
 
     const preview = useQueryPreview( query );
 
-    const firstPost = preview.status === 'ready' ? preview.posts[ 0 ] : undefined;
-    // The `artisanpack/postPreview` key piggybacks on the
-    // `BlockContextProvider` `postId` path so inner `post-*` block edits
-    // can render the first matched post's actual data in the canvas
-    // (#483). The value is null when no preview is ready so consumers
-    // fall back to their placeholder.
-    const blockContext =
-        firstPost === undefined
-            ? { postType, 'artisanpack/postPreview': null }
-            : {
-                postType,
-                postId: firstPost.id,
-                'artisanpack/postPreview': firstPost,
-            };
+    // Pipe the resolved record set + paginator state down to
+    // descendants via block context — `post-template` iterates against
+    // `posts`, `query-pagination` consumes `total` / `currentPage` /
+    // `perPage`, `query-title` consumes `queryTitle`. The canvas always
+    // previews page 1 because pagination is not interactive in the
+    // editor (issue #599 scope).
+    const queryPreviewContext: QueryPreviewContextValue = {
+        posts: preview.status === 'ready' ? preview.posts : [],
+        total: preview.total,
+        currentPage: 1,
+        queryTitle: '',
+        perPage,
+        status: preview.status,
+    };
+
+    const blockContext = {
+        postType,
+        [ QUERY_PREVIEW_CONTEXT_KEY ]: queryPreviewContext,
+    };
 
     return (
         <div { ...blockProps }>
@@ -196,7 +205,6 @@ export default function QueryEdit( {
                     previewTotal={ preview.status === 'ready' ? preview.total : 0 }
                 />
             </InspectorControls>
-            <PreviewBanner preview={ preview } />
             <BlockContextProvider value={ blockContext }>
                 <InnerBlocks template={ [ ...DEFAULT_TEMPLATE ] } />
             </BlockContextProvider>
@@ -232,29 +240,3 @@ function PreviewStatus( { preview }: PreviewSummaryProps ): ReactElement {
     return <p>{ __( 'Configure the query to see a preview.', TEXT_DOMAIN ) }</p>;
 }
 
-function PreviewBanner( { preview }: PreviewSummaryProps ): ReactElement | null {
-    if ( preview.status !== 'ready' ) {
-        return null;
-    }
-
-    if ( preview.total === 0 ) {
-        return (
-            <Notice status="warning" isDismissible={ false }>
-                { __( 'No posts matched the current query.', TEXT_DOMAIN ) }
-            </Notice>
-        );
-    }
-
-    if ( preview.total === 1 ) {
-        return null;
-    }
-
-    return (
-        <Notice status="info" isDismissible={ false }>
-            { __(
-                'The canvas previews the first matching post. The saved page renders all matching posts.',
-                TEXT_DOMAIN
-            ) }
-        </Notice>
-    );
-}

--- a/resources/js/visual-editor/editor/__tests__/custom-blocks.test.tsx
+++ b/resources/js/visual-editor/editor/__tests__/custom-blocks.test.tsx
@@ -108,6 +108,7 @@ vi.mock('@wordpress/block-editor', () => ({
     __experimentalImageSizeControl: () => null,
     __experimentalGetElementClassName: (name: string) =>
         `wp-element-${name}`,
+    __experimentalUseBlockPreview: () => ({}),
     __experimentalGetBorderClassesAndStyles: () => ({ className: '', style: {} }),
     __experimentalGetShadowClassesAndStyles: () => ({ className: '', style: {} }),
     __experimentalUseBorderProps: () => ({ className: '', style: {} }),

--- a/resources/js/visual-editor/editor/__tests__/query-preview-context.test.ts
+++ b/resources/js/visual-editor/editor/__tests__/query-preview-context.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Unit tests for the `artisanpack/queryPreview` context helpers (#599).
+ *
+ * Covers the read-side guards (malformed shapes shouldn't crash a
+ * descendant edit), the iteration-count cap math, and the shape of
+ * what a well-formed context produces.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import type { QueryPreviewPost } from '../use-query-preview';
+import {
+    QUERY_PREVIEW_CONTEXT_KEY,
+    QUERY_PREVIEW_ITERATION_CAP,
+    getQueryPreviewIterationCount,
+    readQueryPreviewContext,
+} from '../query-preview-context';
+
+function makePost( id: number, title = `Post ${ id }` ): QueryPreviewPost {
+    return { id, title };
+}
+
+describe( 'readQueryPreviewContext', () => {
+    it( 'returns null when the context is missing or malformed', () => {
+        expect( readQueryPreviewContext( null ) ).toBeNull();
+        expect( readQueryPreviewContext( undefined ) ).toBeNull();
+        expect( readQueryPreviewContext( 'string' ) ).toBeNull();
+        expect( readQueryPreviewContext( {} ) ).toBeNull();
+        expect( readQueryPreviewContext( { [ QUERY_PREVIEW_CONTEXT_KEY ]: 'not-an-object' } ) ).toBeNull();
+    } );
+
+    it( 'extracts a well-formed context with defaults applied to missing fields', () => {
+        const context = {
+            [ QUERY_PREVIEW_CONTEXT_KEY ]: {
+                posts: [ makePost( 1 ), makePost( 2 ) ],
+                total: 5,
+                currentPage: 1,
+                queryTitle: 'Latest',
+                perPage: 3,
+                status: 'ready',
+            },
+        };
+
+        const preview = readQueryPreviewContext( context );
+
+        expect( preview ).not.toBeNull();
+        expect( preview?.posts ).toHaveLength( 2 );
+        expect( preview?.total ).toBe( 5 );
+        expect( preview?.currentPage ).toBe( 1 );
+        expect( preview?.queryTitle ).toBe( 'Latest' );
+        expect( preview?.perPage ).toBe( 3 );
+        expect( preview?.status ).toBe( 'ready' );
+    } );
+
+    it( 'filters posts without a numeric id', () => {
+        const context = {
+            [ QUERY_PREVIEW_CONTEXT_KEY ]: {
+                posts: [ makePost( 1 ), { title: 'No id' }, null, makePost( 2 ) ],
+                total: 4,
+                currentPage: 1,
+                queryTitle: '',
+                perPage: 0,
+                status: 'ready',
+            },
+        };
+
+        const preview = readQueryPreviewContext( context );
+
+        expect( preview?.posts ).toHaveLength( 2 );
+        expect( preview?.posts.map( ( p ) => p.id ) ).toEqual( [ 1, 2 ] );
+    } );
+
+    it( 'clamps malformed numeric values to safe defaults', () => {
+        const context = {
+            [ QUERY_PREVIEW_CONTEXT_KEY ]: {
+                posts: [],
+                total: -5,
+                currentPage: 0,
+                queryTitle: 42,
+                perPage: -3,
+                status: 'bogus',
+            },
+        };
+
+        const preview = readQueryPreviewContext( context );
+
+        expect( preview?.total ).toBe( 0 );
+        expect( preview?.currentPage ).toBe( 1 );
+        expect( preview?.queryTitle ).toBe( '' );
+        expect( preview?.perPage ).toBe( 0 );
+        expect( preview?.status ).toBe( 'idle' );
+    } );
+} );
+
+describe( 'getQueryPreviewIterationCount', () => {
+    it( 'returns posts.length when perPage is undefined or zero', () => {
+        const posts = [ makePost( 1 ), makePost( 2 ), makePost( 3 ) ];
+        expect( getQueryPreviewIterationCount( posts, undefined ) ).toBe( 3 );
+        expect( getQueryPreviewIterationCount( posts, 0 ) ).toBe( 3 );
+    } );
+
+    it( 'caps at perPage when it is smaller than posts.length', () => {
+        const posts = [ makePost( 1 ), makePost( 2 ), makePost( 3 ) ];
+        expect( getQueryPreviewIterationCount( posts, 2 ) ).toBe( 2 );
+    } );
+
+    it( 'caps at posts.length when perPage exceeds it', () => {
+        const posts = [ makePost( 1 ), makePost( 2 ) ];
+        expect( getQueryPreviewIterationCount( posts, 10 ) ).toBe( 2 );
+    } );
+
+    it( `caps at ${ QUERY_PREVIEW_ITERATION_CAP } even when perPage and posts.length are larger`, () => {
+        const posts = Array.from( { length: 50 }, ( _value, index ) => makePost( index + 1 ) );
+        expect( getQueryPreviewIterationCount( posts, 50 ) ).toBe( QUERY_PREVIEW_ITERATION_CAP );
+    } );
+} );

--- a/resources/js/visual-editor/editor/__tests__/query-preview-iterations.test.tsx
+++ b/resources/js/visual-editor/editor/__tests__/query-preview-iterations.test.tsx
@@ -1,0 +1,304 @@
+/**
+ * Tests for the shared `<QueryPreviewIterations>` multi-post renderer
+ * (#599). Covers: multi-post rendering, the perPage cap, the read-only
+ * state of non-first iterations, and the zero-result fallback.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { render } from '@testing-library/react';
+
+vi.mock( '@wordpress/block-editor', async () => {
+    const { createElement } = await import( 'react' );
+    return {
+        BlockContextProvider: ( {
+            value,
+            children,
+        }: {
+            value: Record<string, unknown>;
+            children: React.ReactNode;
+        } ) =>
+            createElement(
+                'div',
+                {
+                    'data-block-context': JSON.stringify( {
+                        postType: value.postType,
+                        postId: value.postId,
+                    } ),
+                },
+                children
+            ),
+        InnerBlocks: () => createElement( 'div', { 'data-testid': 'inner-blocks' }, 'Editable inner blocks' ),
+        useBlockProps: Object.assign(
+            ( props?: Record<string, unknown> ) => ( {
+                className: typeof props?.className === 'string' ? props.className : 'wp-block',
+            } ),
+            { save: () => ( {} ) }
+        ),
+        store: 'block-editor-store',
+        // Stub the live preview hook to return predictable props so we
+        // can assert iterations rendered without spinning up the
+        // nested editor scope the real hook uses.
+        __experimentalUseBlockPreview: ( opts: { blocks: unknown[]; props?: Record<string, unknown> } ) => ( {
+            ...( opts.props ?? {} ),
+            className: 'block-editor-block-preview__live-content',
+            children: createElement(
+                'div',
+                { 'data-testid': 'ghost-preview-content' },
+                `Preview of ${ Array.isArray( opts.blocks ) ? opts.blocks.length : 0 } block(s)`
+            ),
+        } ),
+    };
+} );
+
+vi.mock( '@wordpress/blocks', () => ( {} ) );
+
+vi.mock( '@wordpress/data', () => ( {
+    useSelect: ( callback: ( select: ( storeName: unknown ) => unknown ) => unknown ) => {
+        const fakeStore = {
+            getBlock: () => ( {
+                innerBlocks: [
+                    { name: 'core/post-title', attributes: {}, innerBlocks: [] },
+                    { name: 'core/post-excerpt', attributes: {}, innerBlocks: [] },
+                ],
+            } ),
+        };
+        return callback( () => fakeStore );
+    },
+} ) );
+
+vi.mock( '@wordpress/components', async () => {
+    const { createElement } = await import( 'react' );
+    return {
+        Notice: ( { children }: { children: React.ReactNode } ) =>
+            createElement( 'div', { role: 'note' }, children ),
+    };
+} );
+
+vi.mock( '@wordpress/i18n', () => ( {
+    __: ( text: string ) => text,
+} ) );
+
+import { QueryPreviewIterations } from '../query-preview-iterations';
+import type { QueryPreviewContextValue } from '../query-preview-context';
+import type { QueryPreviewPost } from '../use-query-preview';
+
+function makePost( id: number ): QueryPreviewPost {
+    return { id, title: `Post ${ id }` };
+}
+
+function makePreview( overrides: Partial<QueryPreviewContextValue> = {} ): QueryPreviewContextValue {
+    return {
+        posts: [ makePost( 1 ), makePost( 2 ), makePost( 3 ) ],
+        total: 3,
+        currentPage: 1,
+        queryTitle: '',
+        perPage: 3,
+        status: 'ready',
+        ...overrides,
+    };
+}
+
+describe( 'QueryPreviewIterations', () => {
+    it( 'renders one editable iteration plus N-1 read-only ghosts for a 3-post query', () => {
+        const { container } = render(
+            <QueryPreviewIterations
+                clientId="abc"
+                preview={ makePreview() }
+                postType="post"
+            />
+        );
+
+        const iterations = container.querySelectorAll( '[data-query-iteration]' );
+        expect( iterations ).toHaveLength( 3 );
+
+        const editable = container.querySelectorAll( '[data-query-iteration="editable"]' );
+        const ghosts = container.querySelectorAll( '[data-query-iteration="preview"]' );
+        expect( editable ).toHaveLength( 1 );
+        expect( ghosts ).toHaveLength( 2 );
+    } );
+
+    it( 'wraps each iteration in its own BlockContextProvider keyed by post id', () => {
+        const { container } = render(
+            <QueryPreviewIterations
+                clientId="abc"
+                preview={ makePreview() }
+                postType="page"
+            />
+        );
+
+        const providers = container.querySelectorAll( '[data-block-context]' );
+        expect( providers ).toHaveLength( 3 );
+
+        const postIds = Array.from( providers ).map( ( node ) => {
+            const ctx = JSON.parse( ( node.getAttribute( 'data-block-context' ) ?? '{}' ) ) as {
+                postType: string;
+                postId: number;
+            };
+            return { postType: ctx.postType, postId: ctx.postId };
+        } );
+
+        expect( postIds ).toEqual( [
+            { postType: 'page', postId: 1 },
+            { postType: 'page', postId: 2 },
+            { postType: 'page', postId: 3 },
+        ] );
+    } );
+
+    it( 'renders InnerBlocks only inside the editable iteration', () => {
+        const { container } = render(
+            <QueryPreviewIterations
+                clientId="abc"
+                preview={ makePreview() }
+                postType="post"
+            />
+        );
+
+        const innerBlocks = container.querySelectorAll( '[data-testid="inner-blocks"]' );
+        expect( innerBlocks ).toHaveLength( 1 );
+
+        const editable = container.querySelector( '[data-query-iteration="editable"]' );
+        expect( editable?.querySelector( '[data-testid="inner-blocks"]' ) ).not.toBeNull();
+    } );
+
+    it( 'exposes non-first iterations as clickable buttons that switch the editable iteration', () => {
+        const { container } = render(
+            <QueryPreviewIterations
+                clientId="abc"
+                preview={ makePreview() }
+                postType="post"
+            />
+        );
+
+        const ghosts = container.querySelectorAll( '[data-query-iteration="preview"]' );
+
+        for ( const ghost of Array.from( ghosts ) ) {
+            expect( ghost.getAttribute( 'role' ) ).toBe( 'button' );
+            expect( ghost.getAttribute( 'tabindex' ) ).toBe( '0' );
+            // `useBlockPreview` applies its preview-content class so
+            // CSS targeting the disabled preview surface still works.
+            expect( ghost.getAttribute( 'class' ) ).toContain( 'block-editor-block-preview__live-content' );
+        }
+    } );
+
+    it( 'renders all iterations as <li> elements inside a <ul> by default', () => {
+        const { container } = render(
+            <QueryPreviewIterations
+                clientId="abc"
+                preview={ makePreview() }
+                postType="post"
+            />
+        );
+
+        const list = container.querySelector( 'ul' );
+        expect( list ).not.toBeNull();
+
+        const items = container.querySelectorAll( 'li' );
+        expect( items.length ).toBe( 3 );
+    } );
+
+    it( 'promotes a clicked ghost iteration to the editable iteration', async () => {
+        const { fireEvent } = await import( '@testing-library/react' );
+        const { container } = render(
+            <QueryPreviewIterations
+                clientId="abc"
+                preview={ makePreview() }
+                postType="post"
+            />
+        );
+
+        // Initially the first iteration is editable.
+        let editable = container.querySelector( '[data-query-iteration="editable"]' );
+        expect( editable?.closest( '[data-block-context]' )?.getAttribute( 'data-block-context' ) )
+            .toContain( '"postId":1' );
+
+        // Click the second ghost — it should become editable.
+        const ghosts = container.querySelectorAll( '[data-query-iteration="preview"]' );
+        fireEvent.click( ghosts[ 0 ] );
+
+        editable = container.querySelector( '[data-query-iteration="editable"]' );
+        expect( editable?.closest( '[data-block-context]' )?.getAttribute( 'data-block-context' ) )
+            .toContain( '"postId":2' );
+    } );
+
+    it( 'caps iterations at the lower of perPage or the hard cap (12)', () => {
+        const posts = Array.from( { length: 20 }, ( _value, index ) => makePost( index + 1 ) );
+        const { container } = render(
+            <QueryPreviewIterations
+                clientId="abc"
+                preview={ makePreview( { posts, total: 20, perPage: 20 } ) }
+                postType="post"
+            />
+        );
+
+        const iterations = container.querySelectorAll( '[data-query-iteration]' );
+        expect( iterations.length ).toBe( 12 );
+    } );
+
+    it( 'caps at perPage when perPage is smaller than the resolved post count', () => {
+        const posts = Array.from( { length: 8 }, ( _value, index ) => makePost( index + 1 ) );
+        const { container } = render(
+            <QueryPreviewIterations
+                clientId="abc"
+                preview={ makePreview( { posts, total: 8, perPage: 3 } ) }
+                postType="post"
+            />
+        );
+
+        const iterations = container.querySelectorAll( '[data-query-iteration]' );
+        expect( iterations.length ).toBe( 3 );
+    } );
+
+    it( 'falls back to a single editable iteration + notice when no posts resolved', () => {
+        const { container, getByRole } = render(
+            <QueryPreviewIterations
+                clientId="abc"
+                preview={ makePreview( { posts: [], total: 0 } ) }
+                postType="post"
+            />
+        );
+
+        const innerBlocks = container.querySelectorAll( '[data-testid="inner-blocks"]' );
+        expect( innerBlocks ).toHaveLength( 1 );
+        expect( getByRole( 'note' ) ).not.toBeNull();
+    } );
+
+    it( 'falls back without a notice when the preview is still loading (no resolved data yet)', () => {
+        const { container, queryByRole } = render(
+            <QueryPreviewIterations
+                clientId="abc"
+                preview={ makePreview( { posts: [], total: 0, status: 'loading' } ) }
+                postType="post"
+            />
+        );
+
+        expect( container.querySelectorAll( '[data-testid="inner-blocks"]' ) ).toHaveLength( 1 );
+        // No notice during loading — we don't know yet whether the query
+        // actually resolves to zero.
+        expect( queryByRole( 'note' ) ).toBeNull();
+    } );
+
+    it( 'falls back gracefully when preview is null (block placed outside a query)', () => {
+        const { container } = render(
+            <QueryPreviewIterations
+                clientId="abc"
+                preview={ null }
+                postType="post"
+            />
+        );
+
+        expect( container.querySelectorAll( '[data-testid="inner-blocks"]' ) ).toHaveLength( 1 );
+    } );
+
+    it( 'surfaces a cap notice when perPage exceeds the hard cap', () => {
+        const posts = Array.from( { length: 15 }, ( _value, index ) => makePost( index + 1 ) );
+        const { getByRole } = render(
+            <QueryPreviewIterations
+                clientId="abc"
+                preview={ makePreview( { posts, total: 50, perPage: 50 } ) }
+                postType="post"
+            />
+        );
+
+        expect( getByRole( 'note' ) ).not.toBeNull();
+    } );
+} );

--- a/resources/js/visual-editor/editor/query-block-override.tsx
+++ b/resources/js/visual-editor/editor/query-block-override.tsx
@@ -16,15 +16,18 @@
  * preview, this filter swaps both Edits with thin wrappers:
  *
  *   - `core/query` calls `/visual-editor/api/query/resolve` via the
- *     {@link useQueryPreview} hook, pushes the first result's `postId`
- *     into a `BlockContextProvider`, and renders `<InnerBlocks />` so
- *     the editable `core/post-template` shell renders inside.
- *   - `core/post-template` ignores its upstream entity-records call
- *     and just renders `<InnerBlocks />` with a default
- *     `core/post-title` template, so users can build the per-iteration
- *     layout. The wrapping `BlockContextProvider` from `core/query`
- *     means inner `core/post-*` blocks resolve against the right
- *     post via G3's entity adapter.
+ *     {@link useQueryPreview} hook and pipes the resolved record set
+ *     down through a `BlockContextProvider` keyed by
+ *     `artisanpack/queryPreview`. Descendant blocks
+ *     (`core/post-template`, `core/query-pagination`, `core/query-title`,
+ *     `core/query-no-results`, and the artisanpack mirrors) read this
+ *     context to render against the real resolved data instead of
+ *     placeholder values (#599).
+ *   - `core/post-template` iterates the resolved posts: index 0 is an
+ *     editable `<InnerBlocks />` (with a default `core/post-title`
+ *     template) and indices 1..N are read-only ghosts wrapped in
+ *     their own `BlockContextProvider` so inner `core/post-*` blocks
+ *     resolve per-iteration via G3's entity adapter.
  *
  * Idempotent across HMR via a global Symbol guard.
  */
@@ -42,6 +45,12 @@ import { __ } from '@wordpress/i18n';
 
 import { TEXT_DOMAIN } from '../vendor/i18n';
 
+import {
+    QUERY_PREVIEW_CONTEXT_KEY,
+    readQueryPreviewContext,
+    type QueryPreviewContextValue,
+} from './query-preview-context';
+import { QueryPreviewIterations } from './query-preview-iterations';
 import { useQueryPreview } from './use-query-preview';
 
 const FILTER_HOOK = 'blocks.registerBlockType';
@@ -65,6 +74,7 @@ interface GlobalSentinelHost {
 interface BlockSettings {
     name?: string;
     edit?: unknown;
+    usesContext?: ReadonlyArray<string>;
     [key: string]: unknown;
 }
 
@@ -116,18 +126,33 @@ function QueryEdit({ attributes, setAttributes, clientId }: QueryEditProps): JSX
             ? queryFromAttrs.postType
             : 'post';
 
-    // Only consume `preview.posts` when the resolver has actually
-    // finished — `useQueryPreview` keeps the previous fetch's posts
-    // visible during a new fetch's loading window so the canvas does
-    // not flicker on every inspector tweak. Skipping that read here
-    // means the inner `core/post-*` blocks fall back to their empty
-    // shells while a new query is in flight rather than rendering with
-    // a postId that no longer matches the saved query payload.
-    const firstPost = preview.status === 'ready' ? preview.posts[0] : undefined;
-    const blockContext =
-        firstPost === undefined
-            ? { postType }
-            : { postType, postId: firstPost.id };
+    // Default mirrors the first-party `artisanpack/query` block's
+    // `perPage: 5` so the iteration cap + pagination-numbers preview
+    // get a sensible value when the saved tree omits the attribute.
+    // A zero would skip pagination-numbers computation entirely (the
+    // descendants guard on `perPage <= 0`), but the override is supposed
+    // to behave like a configured query in the canvas.
+    const perPage = typeof queryFromAttrs.perPage === 'number' ? queryFromAttrs.perPage : 5;
+
+    // Pipe the resolved record set + paginator state down to
+    // descendants via block context. `post-template` iterates against
+    // `posts`; `query-pagination` reads `total` + `currentPage` +
+    // `perPage`; `query-title` reads `queryTitle`. The canvas always
+    // previews page 1 — pagination is not interactive in the editor by
+    // design (issue #599 scope).
+    const queryPreviewContext: QueryPreviewContextValue = {
+        posts: preview.status === 'ready' ? preview.posts : [],
+        total: preview.total,
+        currentPage: 1,
+        queryTitle: '',
+        perPage,
+        status: preview.status,
+    };
+
+    const blockContext = {
+        postType,
+        [ QUERY_PREVIEW_CONTEXT_KEY ]: queryPreviewContext,
+    };
 
     return (
         <div {...blockProps}>
@@ -136,7 +161,6 @@ function QueryEdit({ attributes, setAttributes, clientId }: QueryEditProps): JSX
                     <PreviewStatus preview={preview} />
                 </PanelBody>
             </InspectorControls>
-            <PreviewBanner preview={preview} />
             <BlockContextProvider value={blockContext}>
                 <InnerBlocks />
             </BlockContextProvider>
@@ -172,40 +196,27 @@ function PreviewStatus({ preview }: PreviewSummaryProps): JSX.Element {
     return <p>{__('Configure the query to see a preview.', TEXT_DOMAIN)}</p>;
 }
 
-function PreviewBanner({ preview }: PreviewSummaryProps): JSX.Element | null {
-    if (preview.status !== 'ready') {
-        return null;
-    }
-
-    if (preview.total === 0) {
-        return (
-            <Notice status="warning" isDismissible={false}>
-                {__('No posts matched the current query.', TEXT_DOMAIN)}
-            </Notice>
-        );
-    }
-
-    if (preview.total === 1) {
-        return null;
-    }
-
-    return (
-        <Notice status="info" isDismissible={false}>
-            {__(
-                'The canvas previews the first matching post. The saved page renders all matching posts.',
-                TEXT_DOMAIN
-            )}
-        </Notice>
-    );
+interface PostTemplateEditProps {
+    clientId: string;
+    context?: Record<string, unknown>;
 }
 
-function PostTemplateEdit(): JSX.Element {
+function PostTemplateEdit({ clientId, context }: PostTemplateEditProps): JSX.Element {
     const blockProps = useBlockProps({ className: 'wp-block-post-template' });
 
+    const previewValue = readQueryPreviewContext(context);
+    const postType = typeof context?.postType === 'string' && context.postType !== ''
+        ? context.postType
+        : 'post';
+
     return (
-        <div {...blockProps}>
-            <InnerBlocks template={[...POST_TEMPLATE_DEFAULT_TEMPLATE]} />
-        </div>
+        <QueryPreviewIterations
+            clientId={ clientId }
+            preview={ previewValue }
+            postType={ postType }
+            defaultTemplate={ POST_TEMPLATE_DEFAULT_TEMPLATE }
+            outerProps={ blockProps as Record<string, unknown> }
+        />
     );
 }
 
@@ -229,9 +240,22 @@ function overrideEdit(settings: BlockSettings, name: string): BlockSettings {
     }
 
     if (name === POST_TEMPLATE_BLOCK) {
+        // Extend upstream `usesContext` with the `artisanpack/queryPreview`
+        // key so the override Edit receives the resolved record set its
+        // iteration loop needs. `postType` is already on the upstream
+        // declaration; appending guards against future upstream additions
+        // we'd otherwise drop.
+        const upstreamUsesContext = Array.isArray( settings.usesContext )
+            ? settings.usesContext
+            : [];
+        const usesContext = upstreamUsesContext.includes( QUERY_PREVIEW_CONTEXT_KEY )
+            ? upstreamUsesContext
+            : [ ...upstreamUsesContext, QUERY_PREVIEW_CONTEXT_KEY ];
+
         return {
             ...settings,
             edit: PostTemplateEdit,
+            usesContext,
         };
     }
 

--- a/resources/js/visual-editor/editor/query-preview-context.ts
+++ b/resources/js/visual-editor/editor/query-preview-context.ts
@@ -1,0 +1,127 @@
+/**
+ * Shared types + helpers for the `artisanpack/queryPreview` block
+ * context — the editor-side analogue of the `_resolved*` payload the
+ * server-side `QueryInliner` stamps for the front-end renderers.
+ *
+ * The query block (`core/query` override + first-party `artisanpack/query`)
+ * resolves its configured query via `useQueryPreview` and pipes the
+ * resolved record set + paginator state down through a
+ * `BlockContextProvider`. Descendant blocks — `post-template`,
+ * `query-pagination`, `query-pagination-next/previous/numbers`,
+ * `query-title`, `query-no-results` — read this context to render
+ * against the real resolved data instead of placeholder values, giving
+ * the canvas true WYSIWYG fidelity for the loop (#599).
+ *
+ * The context key is intentionally namespaced with `artisanpack/` so
+ * the upstream `core/query` block defaults don't accidentally collide.
+ */
+
+import type { QueryPreviewPost } from './use-query-preview';
+
+export const QUERY_PREVIEW_CONTEXT_KEY = 'artisanpack/queryPreview';
+
+/**
+ * Hard cap on the number of post iterations rendered in the canvas
+ * regardless of the saved `perPage`. Keeps large loops (e.g. perPage
+ * of 50) from tanking canvas perf — the saved attribute is untouched
+ * so the front end still renders the full requested page. Issue #599
+ * settled on 12 as the visual-rhythm break-even point.
+ */
+export const QUERY_PREVIEW_ITERATION_CAP = 12;
+
+export interface QueryPreviewContextValue {
+    /**
+     * Resolved post records returned by
+     * `/visual-editor/api/query/resolve`. Up to the canvas cap; the
+     * saved query may render more on the front end.
+     */
+    readonly posts: ReadonlyArray<QueryPreviewPost>;
+    /** Total matching posts as reported by the resolver, untrimmed. */
+    readonly total: number;
+    /**
+     * Current paginator page used by the resolver — the canvas always
+     * previews page 1 because pagination is not interactive in the
+     * editor (issue #599 scope). Front-end render uses the URL-driven
+     * page number.
+     */
+    readonly currentPage: number;
+    /**
+     * Server-resolved query title (from `_resolvedQueryTitle` once
+     * resolved) — empty string when no title has been resolved yet.
+     * Used by the `artisanpack/query-title` preview.
+     */
+    readonly queryTitle: string;
+    /**
+     * Effective per-page value the canvas is previewing. Mirrors the
+     * saved `query.perPage` once the resolver settles; descendants
+     * use it to compute pagination numbers.
+     */
+    readonly perPage: number;
+    /** Status passthrough — descendants can render loading shells. */
+    readonly status: 'idle' | 'loading' | 'ready' | 'error';
+}
+
+/**
+ * Read the `artisanpack/queryPreview` value out of a block's
+ * `props.context` payload. Returns `null` when the context isn't
+ * present (block sits outside a resolved query loop, or the resolver
+ * has not produced a value yet). Defensively guards against malformed
+ * shapes so a stale saved tree cannot crash a descendant edit.
+ */
+export function readQueryPreviewContext( context: unknown ): QueryPreviewContextValue | null {
+    if ( context === null || typeof context !== 'object' ) {
+        return null;
+    }
+
+    const value = ( context as Record<string, unknown> )[ QUERY_PREVIEW_CONTEXT_KEY ];
+
+    if ( value === null || typeof value !== 'object' ) {
+        return null;
+    }
+
+    const record = value as Record<string, unknown>;
+
+    const rawPosts = Array.isArray( record.posts ) ? record.posts : [];
+    const posts = rawPosts.filter(
+        ( post ): post is QueryPreviewPost =>
+            post !== null && typeof post === 'object' && typeof ( post as { id?: unknown } ).id === 'number'
+    );
+
+    const total = typeof record.total === 'number' && Number.isFinite( record.total )
+        ? Math.max( 0, Math.trunc( record.total ) )
+        : 0;
+
+    const currentPage = typeof record.currentPage === 'number' && Number.isFinite( record.currentPage )
+        ? Math.max( 1, Math.trunc( record.currentPage ) )
+        : 1;
+
+    const queryTitle = typeof record.queryTitle === 'string' ? record.queryTitle : '';
+
+    const perPage = typeof record.perPage === 'number' && Number.isFinite( record.perPage )
+        ? Math.max( 0, Math.trunc( record.perPage ) )
+        : 0;
+
+    const status = record.status === 'idle' || record.status === 'loading' ||
+        record.status === 'ready' || record.status === 'error'
+        ? record.status
+        : 'idle';
+
+    return { posts, total, currentPage, queryTitle, perPage, status };
+}
+
+/**
+ * Compute the visible iteration count for the canvas. Caller still
+ * iterates the post array; this just returns the effective `slice`
+ * length so callers don't sprinkle the `Math.min(perPage, cap)` rule
+ * in three places.
+ *
+ * `perPage` of 0 / undefined falls back to `posts.length` so a zero-
+ * configured query still previews what the resolver returned.
+ */
+export function getQueryPreviewIterationCount(
+    posts: ReadonlyArray<QueryPreviewPost>,
+    perPage: number | undefined
+): number {
+    const upper = typeof perPage === 'number' && perPage > 0 ? perPage : posts.length;
+    return Math.min( upper, QUERY_PREVIEW_ITERATION_CAP, posts.length );
+}

--- a/resources/js/visual-editor/editor/query-preview-iterations.tsx
+++ b/resources/js/visual-editor/editor/query-preview-iterations.tsx
@@ -1,0 +1,295 @@
+/**
+ * Shared multi-post iteration renderer for `post-template` editor
+ * previews (both the `core/post-template` override and the first-party
+ * `artisanpack/post-template`). Issue #599.
+ *
+ * Renders one editable iteration (`<InnerBlocks />`) plus N read-only
+ * "ghost" iterations for the remaining resolved posts. Each iteration
+ * is wrapped in its own `BlockContextProvider` keyed by `postId` +
+ * `postType` so descendant `post-*` block edits resolve against the
+ * right post (#520 entity-adapter mechanism).
+ *
+ * The ghosts use `__experimentalUseBlockPreview` from
+ * `@wordpress/block-editor` — the same hook upstream Gutenberg's
+ * `core/post-template` reaches for. It renders the inner-block tree
+ * via a nested `ExperimentalBlockEditorProvider` scope with
+ * `useDisabled` applied, so dynamic display blocks (`post-title`,
+ * `post-excerpt`, `post-date`, …) run their actual Edit components
+ * against the per-iteration block context — no serialization, no
+ * iframe, no save-element fallback. The iframe-based `<BlockPreview>`
+ * component is explicitly avoided here for the same reason the
+ * inserter-patterns panel documents: multiple iframes collide with
+ * the M2 CSP shim. `useBlockPreview` is the iframe-free counterpart.
+ *
+ * Active-iteration UX: clicking (or pressing Enter / Space on) any
+ * ghost iteration promotes it to the editable iteration, matching
+ * upstream Gutenberg's `core/post-template` behavior. The shared
+ * inner-block tree is what gets edited — `BlockContextProvider`
+ * around the active iteration just changes which post's data the
+ * descendant `post-*` blocks resolve against.
+ */
+
+import type { ReactElement, KeyboardEvent } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import {
+    BlockContextProvider,
+    InnerBlocks,
+    store as blockEditorStore,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    __experimentalUseBlockPreview as rawUseBlockPreview,
+} from '@wordpress/block-editor';
+import type { BlockInstance } from '@wordpress/blocks';
+import { useSelect } from '@wordpress/data';
+import { Notice } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+import { TEXT_DOMAIN } from '../vendor/i18n';
+import type { QueryPreviewContextValue } from './query-preview-context';
+import {
+    getQueryPreviewIterationCount,
+    QUERY_PREVIEW_ITERATION_CAP,
+} from './query-preview-context';
+
+interface UseBlockPreviewOptions {
+    readonly blocks: ReadonlyArray<BlockInstance>;
+    readonly props?: Record<string, unknown>;
+}
+type UseBlockPreviewResult = Record<string, unknown> & { children?: unknown };
+const useBlockPreview = rawUseBlockPreview as
+    ( ( options: UseBlockPreviewOptions ) => UseBlockPreviewResult ) | undefined;
+
+export interface QueryPreviewIterationsProps {
+    /** clientId of the `post-template` block driving the iteration. */
+    readonly clientId: string;
+    /** Query preview state from the surrounding query block. */
+    readonly preview: QueryPreviewContextValue | null;
+    /** Post type for the BlockContextProvider — defaults to `post`. */
+    readonly postType: string;
+    /** Default template applied to the editable iteration's InnerBlocks. */
+    readonly defaultTemplate?: ReadonlyArray<[ string ]>;
+    /**
+     * Wrapper element name. Defaults to `ul` to match upstream
+     * Gutenberg's grid CSS (`.wp-block-post-template.is-flex-container
+     * > li`). Callers can override to `div` etc. if they're styling
+     * with a custom layout.
+     */
+    readonly tag?: 'div' | 'ul' | 'ol';
+    /**
+     * Class name applied to every iteration's wrapper element.
+     * Defaults to `wp-block-post` — the class upstream Gutenberg uses
+     * on each post iteration and the one the grid CSS in
+     * `@wordpress/block-library/build-style/style.css` already targets.
+     */
+    readonly itemClassName?: string;
+    /** Optional extra props (style, className) for the outer wrapper. */
+    readonly outerProps?: Record<string, unknown>;
+}
+
+interface PostTemplateBlockShape {
+    readonly innerBlocks?: ReadonlyArray<BlockInstance>;
+}
+
+function selectInnerBlocks(
+    select: ( storeName: typeof blockEditorStore ) => unknown,
+    clientId: string
+): ReadonlyArray<BlockInstance> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const store = ( select as any )( blockEditorStore ) as { getBlock?: ( id: string ) => PostTemplateBlockShape | null };
+    const block = store.getBlock?.( clientId ) ?? null;
+
+    if ( block === null || block.innerBlocks === undefined ) {
+        return [];
+    }
+
+    return block.innerBlocks;
+}
+
+/**
+ * Render the editable iteration + N read-only ghosts for a resolved
+ * query loop in the editor canvas. Caller is responsible for the
+ * outer wrapper / block props — this component only renders the
+ * iterations themselves.
+ */
+export function QueryPreviewIterations(
+    props: QueryPreviewIterationsProps
+): ReactElement {
+    const {
+        clientId,
+        preview,
+        postType,
+        defaultTemplate,
+        tag = 'ul',
+        itemClassName = 'wp-block-post',
+        outerProps = {},
+    } = props;
+
+    // Subscribe to the post-template's own inner blocks so the ghost
+    // preview stays in sync with edits to the editable iteration.
+    const innerBlocks = useSelect(
+        ( select ) => selectInnerBlocks( select as never, clientId ),
+        [ clientId ]
+    );
+
+    const ghostBlocks = useMemo<ReadonlyArray<BlockInstance>>(
+        () => innerBlocks,
+        [ innerBlocks ]
+    );
+
+    const posts = preview?.posts ?? [];
+    const cap = getQueryPreviewIterationCount( posts, preview?.perPage );
+    const visiblePosts = posts.slice( 0, cap );
+
+    // Track which iteration is the editable one. Clicking on a ghost
+    // promotes it. Defaults to the first post; resets when the posts
+    // array no longer contains the active id (e.g. after a query
+    // attribute change).
+    const [ activeId, setActiveId ] = useState<number | undefined>( undefined );
+    const firstPostId = visiblePosts[ 0 ]?.id;
+    const activeIdInList = activeId !== undefined && visiblePosts.some( ( post ) => post.id === activeId );
+    const effectiveActiveId = activeIdInList ? activeId : firstPostId;
+
+    useEffect( () => {
+        if ( activeId !== undefined && ! activeIdInList ) {
+            setActiveId( undefined );
+        }
+    }, [ activeId, activeIdInList ] );
+
+    const editableTemplate = defaultTemplate !== undefined ? [ ...defaultTemplate ] : undefined;
+
+    if ( visiblePosts.length === 0 ) {
+        const Tag = tag;
+        return (
+            <Tag {...outerProps as Record<string, unknown>}>
+                <BlockContextProvider value={{ postType }}>
+                    <InnerBlocks template={ editableTemplate } />
+                </BlockContextProvider>
+                { preview?.status === 'ready' && (
+                    <Notice status="info" isDismissible={ false }>
+                        { __(
+                            'No posts matched the current query. The template above will render when posts match.',
+                            TEXT_DOMAIN
+                        ) }
+                    </Notice>
+                ) }
+            </Tag>
+        );
+    }
+
+    const ghostNotice = posts.length > cap || ( preview?.perPage ?? 0 ) > QUERY_PREVIEW_ITERATION_CAP
+        ? (
+            <Notice status="info" isDismissible={ false }>
+                { __(
+                    'Canvas previews the first iterations only. The saved page renders the full result set.',
+                    TEXT_DOMAIN
+                ) }
+            </Notice>
+        )
+        : null;
+
+    const Tag = tag;
+    return (
+        <Tag {...outerProps as Record<string, unknown>}>
+            { visiblePosts.map( ( post ) => {
+                const iterationContext = { postType, postId: post.id, 'artisanpack/postPreview': post };
+                const isActive = post.id === effectiveActiveId;
+
+                return (
+                    <BlockContextProvider key={ post.id } value={ iterationContext }>
+                        { isActive ? (
+                            <EditableIteration
+                                className={ itemClassName }
+                                template={ editableTemplate }
+                            />
+                        ) : (
+                            <PreviewIteration
+                                className={ itemClassName }
+                                blocks={ ghostBlocks }
+                                onActivate={ () => setActiveId( post.id ) }
+                            />
+                        ) }
+                    </BlockContextProvider>
+                );
+            } ) }
+            { ghostNotice }
+        </Tag>
+    );
+}
+
+interface EditableIterationProps {
+    readonly className: string;
+    readonly template: ReadonlyArray<[ string ]> | undefined;
+}
+
+function EditableIteration( { className, template }: EditableIterationProps ): ReactElement {
+    return (
+        <li className={ className } data-query-iteration="editable">
+            <InnerBlocks template={ template !== undefined ? [ ...template ] : undefined } />
+        </li>
+    );
+}
+
+interface PreviewIterationProps {
+    readonly className: string;
+    readonly blocks: ReadonlyArray<BlockInstance>;
+    readonly onActivate: () => void;
+}
+
+function PreviewIteration( {
+    className,
+    blocks,
+    onActivate,
+}: PreviewIterationProps ): ReactElement {
+    // Defensive fallback when the block-editor build doesn't expose
+    // the live preview hook (older builds / mocked test envs). The
+    // iteration still takes up grid space and the per-post block
+    // context above still establishes the right scope; descendants
+    // that don't use the preview tree (e.g. server-rendered display
+    // forks reading `_resolved*`) keep working.
+    if ( useBlockPreview === undefined ) {
+        return (
+            <li
+                className={ className }
+                data-query-iteration="preview"
+                aria-hidden={ true }
+            />
+        );
+    }
+
+    return (
+        <PreviewIterationLive
+            className={ className }
+            blocks={ blocks }
+            onActivate={ onActivate }
+        />
+    );
+}
+
+function PreviewIterationLive( {
+    className,
+    blocks,
+    onActivate,
+}: PreviewIterationProps ): ReactElement {
+    const previewProps = ( useBlockPreview as ( opts: UseBlockPreviewOptions ) => UseBlockPreviewResult )( {
+        blocks,
+        props: { className },
+    } );
+
+    const handleKeyDown = ( event: KeyboardEvent<HTMLLIElement> ): void => {
+        if ( event.key === 'Enter' || event.key === ' ' ) {
+            event.preventDefault();
+            onActivate();
+        }
+    };
+
+    return (
+        <li
+            { ...previewProps as Record<string, unknown> }
+            data-query-iteration="preview"
+            tabIndex={ 0 }
+            // eslint-disable-next-line jsx-a11y/no-noninteractive-element-to-interactive-role
+            role="button"
+            onClick={ onActivate }
+            onKeyDown={ handleKeyDown }
+        />
+    );
+}

--- a/resources/js/visual-editor/editor/query-preview-iterations.tsx
+++ b/resources/js/visual-editor/editor/query-preview-iterations.tsx
@@ -70,10 +70,11 @@ export interface QueryPreviewIterationsProps {
     /**
      * Wrapper element name. Defaults to `ul` to match upstream
      * Gutenberg's grid CSS (`.wp-block-post-template.is-flex-container
-     * > li`). Callers can override to `div` etc. if they're styling
-     * with a custom layout.
+     * > li`). Restricted to list-shaped tags because every iteration
+     * renders as a `<li>` — a `<div>` wrapper would produce invalid
+     * HTML (`<div> > <li>`).
      */
-    readonly tag?: 'div' | 'ul' | 'ol';
+    readonly tag?: 'ul' | 'ol';
     /**
      * Class name applied to every iteration's wrapper element.
      * Defaults to `wp-block-post` — the class upstream Gutenberg uses
@@ -158,11 +159,19 @@ export function QueryPreviewIterations(
 
     if ( visiblePosts.length === 0 ) {
         const Tag = tag;
+        // Keep the list-element invariant: the only valid child of
+        // `<ul>` / `<ol>` is `<li>`, so wrap the placeholder iteration
+        // in an `<li>` and render the explanatory `Notice` as a
+        // sibling of the list rather than as a direct child.
         return (
-            <Tag {...outerProps as Record<string, unknown>}>
-                <BlockContextProvider value={{ postType }}>
-                    <InnerBlocks template={ editableTemplate } />
-                </BlockContextProvider>
+            <>
+                <Tag {...outerProps as Record<string, unknown>}>
+                    <BlockContextProvider value={{ postType }}>
+                        <li className={ itemClassName } data-query-iteration="editable">
+                            <InnerBlocks template={ editableTemplate } />
+                        </li>
+                    </BlockContextProvider>
+                </Tag>
                 { preview?.status === 'ready' && (
                     <Notice status="info" isDismissible={ false }>
                         { __(
@@ -171,7 +180,7 @@ export function QueryPreviewIterations(
                         ) }
                     </Notice>
                 ) }
-            </Tag>
+            </>
         );
     }
 
@@ -188,30 +197,35 @@ export function QueryPreviewIterations(
 
     const Tag = tag;
     return (
-        <Tag {...outerProps as Record<string, unknown>}>
-            { visiblePosts.map( ( post ) => {
-                const iterationContext = { postType, postId: post.id, 'artisanpack/postPreview': post };
-                const isActive = post.id === effectiveActiveId;
+        <>
+            <Tag {...outerProps as Record<string, unknown>}>
+                { visiblePosts.map( ( post ) => {
+                    const iterationContext = { postType, postId: post.id, 'artisanpack/postPreview': post };
+                    const isActive = post.id === effectiveActiveId;
 
-                return (
-                    <BlockContextProvider key={ post.id } value={ iterationContext }>
-                        { isActive ? (
-                            <EditableIteration
-                                className={ itemClassName }
-                                template={ editableTemplate }
-                            />
-                        ) : (
-                            <PreviewIteration
-                                className={ itemClassName }
-                                blocks={ ghostBlocks }
-                                onActivate={ () => setActiveId( post.id ) }
-                            />
-                        ) }
-                    </BlockContextProvider>
-                );
-            } ) }
+                    return (
+                        <BlockContextProvider key={ post.id } value={ iterationContext }>
+                            { isActive ? (
+                                <EditableIteration
+                                    className={ itemClassName }
+                                    template={ editableTemplate }
+                                />
+                            ) : (
+                                <PreviewIteration
+                                    className={ itemClassName }
+                                    blocks={ ghostBlocks }
+                                    onActivate={ () => setActiveId( post.id ) }
+                                />
+                            ) }
+                        </BlockContextProvider>
+                    );
+                } ) }
+            </Tag>
+            { /* Notices live outside the list so the ul/ol only
+                 contains `<li>` children — direct text/non-list
+                 nodes in a `<ul>` are invalid markup. */ }
             { ghostNotice }
-        </Tag>
+        </>
     );
 }
 


### PR DESCRIPTION
## Description

The Query Loop block previously resolved the configured query in the editor canvas but only rendered the **first** matching post — the query block pushed one `postId` into a single `BlockContextProvider` and `post-template` rendered one editable iteration. Users saw a representative row rather than the loop they'd get on the front end, and downstream V1.2 features that need cross-post visual differentiation in the canvas (#591 per-post variants, #592 variable grid spans, #593 masonry) had no posts to differentiate against.

**Closes:** #599

## Type of Change

- [x] New feature (adds new functionality)
- [x] Enhancement (improves existing functionality)

## Related Issue

**Issue:** #599

## Motivation and Context

Unblocks #591 (per-post variants), #592 (variable column/row spans), and #593 (masonry layout) — all need the canvas to render multiple posts so per-post differentiation has something to render against. Also addresses long-standing WYSIWYG drift: editors and developers building post archives / blog feeds / related-post sections can now judge spacing, layout, and visual rhythm without leaving the editor.

## Changes Made

### Multi-post iteration

- New `editor/query-preview-context.ts` defines the `artisanpack/queryPreview` block-context shape, the hard iteration cap (12), the read-side guard, and the iteration-count math.
- New `editor/query-preview-iterations.tsx` renders one editable `<InnerBlocks />` plus N read-only ghosts via `__experimentalUseBlockPreview` (the same hook upstream Gutenberg's `core/post-template` uses) — no iframe, no `BlockPreview` collision with the M2 CSP shim. Clicking any ghost promotes it to the editable iteration, matching upstream UX. Iteration cap = `min(perPage, 12)`.
- Each iteration is wrapped in its own `BlockContextProvider` keyed by `postId` + `postType` so descendant `post-*` Edit components resolve against the right post per iteration (#520 mechanism).
- Zero-result fallback: single editable iteration + `Notice` so the Post Template stays editable.
- Updated `editor/query-block-override.tsx` (`core/query` + `core/post-template`), `blocks/query/edit.tsx` (`artisanpack/query`), and `blocks/post-template/edit.tsx` to pipe / consume the context. `post-template` block.json adds `artisanpack/queryPreview` to `usesContext`.

### Sibling blocks consume the resolved data

- `query-pagination-numbers/edit.tsx` computes a plausible page run from `total / perPage`; marks page 1 as current.
- `query-pagination-next/edit.tsx` shows an active state when total exceeds perPage on canvas page 1; otherwise muted placeholder.
- `query-pagination-previous/edit.tsx` always muted in the canvas (page 1 has no previous).
- `query-title/edit.tsx` reads the resolved query title from context when no `_resolvedQueryTitle` attribute is stamped.
- `query-no-results/edit.tsx` gains a `showInEditor` design-time toggle so authors can style the empty state without forcing a zero-result query. Front-end render unchanged.

### Pagination layout baseline

- New stylesheet `blocks/query-pagination/query-pagination.css` (editor) + `packages/visual-editor-renderer-blade/resources/assets/frontend/query-pagination.css` (front end). CSS Grid with `1fr auto 1fr` columns keeps page numbers visually centered even when prev/next are absent. Themes can rebind a single CSS custom property (`--ap-query-pagination-gap`, `--ap-query-pagination-current-weight`, etc.) instead of redeclaring rules.
- `BlocksStylesComponent` + `blocks-styles.blade.php` updated to emit a `<link>` for the front-end stylesheet.
- `query-pagination/edit.tsx` refactored to use `useInnerBlocksProps` (so the editor's intermediate `block-editor-block-list__layout` wrapper doesn't break the grid layout) and to add the upstream-compatible `wp-block-query-pagination` class alongside the auto-generated namespaced flavour so the same CSS targets the editor and the front end.

### Inactive pagination links render nothing

- Front-end `query-pagination-next` / `query-pagination-previous` return `null` when there's no resolved URL (Blade / React / Vue updated symmetrically). The muted placeholder stays in the editor so authors can edit the block.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (Darwin 25.5.0)
- Browser: Safari + Chrome via Laravel Herd
- PHP Version: 8.4.3
- Project Version: 1.2.0 dev

**Tests Performed:**
1. Multi-post canvas rendering with up to 12 iterations; click-to-switch active iteration works.
2. Pagination layout: previous left, numbers centered, next right — verified across page 1 (no prev) and middle pages (all three present) on both editor canvas and front end.
3. Front-end inactive prev/next render nothing; editor still shows muted placeholders.
4. `query-no-results` showInEditor toggle: off → dashed placeholder; on → inner template. Resolver-returned-zero still renders content regardless of toggle.
5. Zero-result fallback: editable iteration mounts; notice surfaces only when `preview.status === 'ready'`.
6. Renderer parity: all 152 blocks registered in React + Vue + Blade; `npm run verify:parity` clean.

## Accessibility Tests Run

- [x] Keyboard navigation tested
- [ ] Screen reader tested
- [ ] Color contrast verified
- [ ] ARIA labels checked

**Details:** Ghost iterations expose `role="button"` + `tabIndex={0}`; Enter/Space promotes the iteration to editable, matching upstream Gutenberg's `core/post-template`. Pagination-numbers current page carries `aria-current="page"` on both surfaces.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:**
- `editor/__tests__/query-preview-context.test.ts` (8 tests) — read-side guards, iteration-count cap math.
- `editor/__tests__/query-preview-iterations.test.tsx` (12 tests) — multi-post rendering, perPage cap, hard cap, ghost states, zero-result fallback, click-to-switch.
- `blocks/__tests__/query-sibling-context.test.tsx` (17 tests) — query-title resolved data, pagination prev/next/numbers states, query-no-results toggle.
- `packages/visual-editor-renderer-blade/tests/Feature/BlocksStylesComponentTest.php` — new front-end stylesheet link.
- All 2214 JS tests + 1306 PHP tests pass; renderer-parity script clean; upstream-diff clean.

## Documentation

- [x] Inline code documentation added

**Documentation details:** Substantial header docblocks on the new modules explain the architecture (why `__experimentalUseBlockPreview` over `<BlockPreview>`, why CSS Grid over flex for centering, why iteration happens in `post-template` rather than `query`). Sibling block edit components carry brief headers describing their resolution priority.

## Screenshots

(Add screenshots from the dev app if needed when promoting to ready-for-review.)

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced editor previews for query loops to render multiple matching results.
  * Added a design-time toggle to show or hide the Query No Results empty state in the editor.

* **Bug Fixes**
  * Pagination “Previous” and “Next” now hide on the front end when they aren’t applicable (first/last pages).
  * Query pagination block/editor states now avoid rendering non-link placeholders when unavailable.

* **Tests**
  * Added/expanded automated coverage for query preview, pagination, and empty-state editor behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->