### PR TITLE
feat: variable column/row spans for posts in Query Loop grid layout

### DIFF
--- a/packages/visual-editor-renderer-blade/resources/assets/frontend/post-template.css
+++ b/packages/visual-editor-renderer-blade/resources/assets/frontend/post-template.css
@@ -1,0 +1,33 @@
+/**
+ * Post Template grid container styles (#592).
+ *
+ * Upstream `core/post-template` uses a flex-with-percent-widths layout
+ * for its grid view via `is-flex-container` + `columns-N`. The
+ * ArtisanPack fork renders the same block as a real CSS grid via
+ * `is-layout-grid` + `columns-N`, both in the editor canvas and the
+ * Blade / Vue / React renderers, so per-post column / row spans on
+ * post-variants (#592) actually have a grid to span across.
+ *
+ * `.is-layout-grid` already picks up `display: grid` from the layout
+ * baseline emitted by <x-ve-blocks-styles />. These rules add the
+ * track definition and item reset that the baseline doesn't supply.
+ */
+
+.wp-block-post-template.is-layout-grid {
+    grid-template-columns: repeat(1, minmax(0, 1fr));
+    gap: var(--wp--style--block-gap, 1.25em);
+    list-style: none;
+    padding: 0;
+}
+
+.wp-block-post-template.is-layout-grid.columns-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.wp-block-post-template.is-layout-grid.columns-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+.wp-block-post-template.is-layout-grid.columns-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+.wp-block-post-template.is-layout-grid.columns-5 { grid-template-columns: repeat(5, minmax(0, 1fr)); }
+.wp-block-post-template.is-layout-grid.columns-6 { grid-template-columns: repeat(6, minmax(0, 1fr)); }
+
+.wp-block-post-template.is-layout-grid > .wp-block-post-template-item {
+    margin: 0;
+    width: auto;
+    min-width: 0;
+}

--- a/packages/visual-editor-renderer-blade/resources/assets/frontend/post-variant.css
+++ b/packages/visual-editor-renderer-blade/resources/assets/frontend/post-variant.css
@@ -1,0 +1,347 @@
+/**
+ * Post Variant grid-span styles (#592).
+ *
+ * Variants can declare per-breakpoint `gridColumnSpan` and `gridRowSpan`
+ * attributes. When the parent Query Loop's post-template renders in
+ * grid layout and a post matches a variant, the QueryInliner stamps
+ * `_resolvedGridSpan` onto the synthetic `core/post-template-item`
+ * wrapper and the renderers emit `ap-post-span-N-{bp}-{columns,row}`
+ * classes for each defined breakpoint.
+ *
+ * The class scheme mirrors `ap-grid-item-span-*` from the standalone
+ * Grid block (grid.css) so authors who know one know the other. Rules
+ * are gated on `.wp-block-post-template.is-layout-grid > li` so spans
+ * never leak into list / stack / flex layouts.
+ *
+ * Two parallel selectors per rule:
+ *
+ *   1. `> .wp-block-post-template-item.ap-post-span-*` — the public
+ *      frontend renderer (Blade / Vue / React) emits the span class
+ *      directly on the `<li>`, so the direct compound selector wins.
+ *   2. `> .wp-block-post:has(.ap-post-span-*)` — the editor canvas
+ *      wraps each iteration in a Gutenberg-shaped `<li class="wp-block-post">`
+ *      and renders the post-variant block as a nested `<div>` that
+ *      carries the span class. The `:has()` selector promotes the
+ *      span up to the `<li>` so the grid actually sees the span.
+ *
+ * Mobile-first cascade: base rules first, then each Tailwind
+ * breakpoint (sm 640, md 768, lg 1024, xl 1280, 2xl 1536) in
+ * ascending min-width order, so a later breakpoint's class overrides
+ * the earlier one for the wider viewport.
+ */
+
+/* === base (no media query) === */
+.wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-1-base-columns,
+.wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-1-base-columns) { grid-column: span 1; }
+.wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-2-base-columns,
+.wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-2-base-columns) { grid-column: span 2; }
+.wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-3-base-columns,
+.wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-3-base-columns) { grid-column: span 3; }
+.wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-4-base-columns,
+.wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-4-base-columns) { grid-column: span 4; }
+.wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-5-base-columns,
+.wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-5-base-columns) { grid-column: span 5; }
+.wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-6-base-columns,
+.wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-6-base-columns) { grid-column: span 6; }
+.wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-7-base-columns,
+.wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-7-base-columns) { grid-column: span 7; }
+.wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-8-base-columns,
+.wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-8-base-columns) { grid-column: span 8; }
+.wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-9-base-columns,
+.wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-9-base-columns) { grid-column: span 9; }
+.wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-10-base-columns,
+.wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-10-base-columns) { grid-column: span 10; }
+.wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-11-base-columns,
+.wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-11-base-columns) { grid-column: span 11; }
+.wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-12-base-columns,
+.wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-12-base-columns) { grid-column: span 12; }
+
+.wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-1-base-row,
+.wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-1-base-row) { grid-row: span 1; }
+.wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-2-base-row,
+.wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-2-base-row) { grid-row: span 2; }
+.wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-3-base-row,
+.wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-3-base-row) { grid-row: span 3; }
+.wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-4-base-row,
+.wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-4-base-row) { grid-row: span 4; }
+.wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-5-base-row,
+.wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-5-base-row) { grid-row: span 5; }
+.wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-6-base-row,
+.wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-6-base-row) { grid-row: span 6; }
+.wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-7-base-row,
+.wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-7-base-row) { grid-row: span 7; }
+.wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-8-base-row,
+.wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-8-base-row) { grid-row: span 8; }
+.wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-9-base-row,
+.wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-9-base-row) { grid-row: span 9; }
+.wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-10-base-row,
+.wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-10-base-row) { grid-row: span 10; }
+.wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-11-base-row,
+.wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-11-base-row) { grid-row: span 11; }
+.wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-12-base-row,
+.wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-12-base-row) { grid-row: span 12; }
+
+/* === sm: 640px === */
+@media (min-width: 640px) {
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-1-sm-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-1-sm-columns) { grid-column: span 1; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-2-sm-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-2-sm-columns) { grid-column: span 2; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-3-sm-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-3-sm-columns) { grid-column: span 3; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-4-sm-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-4-sm-columns) { grid-column: span 4; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-5-sm-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-5-sm-columns) { grid-column: span 5; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-6-sm-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-6-sm-columns) { grid-column: span 6; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-7-sm-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-7-sm-columns) { grid-column: span 7; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-8-sm-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-8-sm-columns) { grid-column: span 8; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-9-sm-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-9-sm-columns) { grid-column: span 9; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-10-sm-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-10-sm-columns) { grid-column: span 10; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-11-sm-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-11-sm-columns) { grid-column: span 11; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-12-sm-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-12-sm-columns) { grid-column: span 12; }
+
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-1-sm-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-1-sm-row) { grid-row: span 1; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-2-sm-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-2-sm-row) { grid-row: span 2; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-3-sm-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-3-sm-row) { grid-row: span 3; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-4-sm-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-4-sm-row) { grid-row: span 4; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-5-sm-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-5-sm-row) { grid-row: span 5; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-6-sm-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-6-sm-row) { grid-row: span 6; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-7-sm-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-7-sm-row) { grid-row: span 7; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-8-sm-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-8-sm-row) { grid-row: span 8; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-9-sm-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-9-sm-row) { grid-row: span 9; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-10-sm-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-10-sm-row) { grid-row: span 10; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-11-sm-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-11-sm-row) { grid-row: span 11; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-12-sm-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-12-sm-row) { grid-row: span 12; }
+}
+
+/* === md: 768px === */
+@media (min-width: 768px) {
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-1-md-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-1-md-columns) { grid-column: span 1; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-2-md-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-2-md-columns) { grid-column: span 2; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-3-md-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-3-md-columns) { grid-column: span 3; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-4-md-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-4-md-columns) { grid-column: span 4; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-5-md-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-5-md-columns) { grid-column: span 5; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-6-md-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-6-md-columns) { grid-column: span 6; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-7-md-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-7-md-columns) { grid-column: span 7; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-8-md-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-8-md-columns) { grid-column: span 8; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-9-md-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-9-md-columns) { grid-column: span 9; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-10-md-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-10-md-columns) { grid-column: span 10; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-11-md-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-11-md-columns) { grid-column: span 11; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-12-md-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-12-md-columns) { grid-column: span 12; }
+
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-1-md-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-1-md-row) { grid-row: span 1; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-2-md-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-2-md-row) { grid-row: span 2; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-3-md-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-3-md-row) { grid-row: span 3; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-4-md-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-4-md-row) { grid-row: span 4; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-5-md-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-5-md-row) { grid-row: span 5; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-6-md-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-6-md-row) { grid-row: span 6; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-7-md-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-7-md-row) { grid-row: span 7; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-8-md-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-8-md-row) { grid-row: span 8; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-9-md-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-9-md-row) { grid-row: span 9; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-10-md-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-10-md-row) { grid-row: span 10; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-11-md-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-11-md-row) { grid-row: span 11; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-12-md-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-12-md-row) { grid-row: span 12; }
+}
+
+/* === lg: 1024px === */
+@media (min-width: 1024px) {
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-1-lg-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-1-lg-columns) { grid-column: span 1; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-2-lg-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-2-lg-columns) { grid-column: span 2; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-3-lg-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-3-lg-columns) { grid-column: span 3; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-4-lg-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-4-lg-columns) { grid-column: span 4; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-5-lg-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-5-lg-columns) { grid-column: span 5; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-6-lg-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-6-lg-columns) { grid-column: span 6; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-7-lg-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-7-lg-columns) { grid-column: span 7; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-8-lg-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-8-lg-columns) { grid-column: span 8; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-9-lg-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-9-lg-columns) { grid-column: span 9; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-10-lg-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-10-lg-columns) { grid-column: span 10; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-11-lg-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-11-lg-columns) { grid-column: span 11; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-12-lg-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-12-lg-columns) { grid-column: span 12; }
+
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-1-lg-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-1-lg-row) { grid-row: span 1; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-2-lg-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-2-lg-row) { grid-row: span 2; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-3-lg-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-3-lg-row) { grid-row: span 3; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-4-lg-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-4-lg-row) { grid-row: span 4; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-5-lg-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-5-lg-row) { grid-row: span 5; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-6-lg-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-6-lg-row) { grid-row: span 6; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-7-lg-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-7-lg-row) { grid-row: span 7; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-8-lg-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-8-lg-row) { grid-row: span 8; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-9-lg-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-9-lg-row) { grid-row: span 9; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-10-lg-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-10-lg-row) { grid-row: span 10; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-11-lg-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-11-lg-row) { grid-row: span 11; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-12-lg-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-12-lg-row) { grid-row: span 12; }
+}
+
+/* === xl: 1280px === */
+@media (min-width: 1280px) {
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-1-xl-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-1-xl-columns) { grid-column: span 1; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-2-xl-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-2-xl-columns) { grid-column: span 2; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-3-xl-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-3-xl-columns) { grid-column: span 3; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-4-xl-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-4-xl-columns) { grid-column: span 4; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-5-xl-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-5-xl-columns) { grid-column: span 5; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-6-xl-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-6-xl-columns) { grid-column: span 6; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-7-xl-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-7-xl-columns) { grid-column: span 7; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-8-xl-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-8-xl-columns) { grid-column: span 8; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-9-xl-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-9-xl-columns) { grid-column: span 9; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-10-xl-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-10-xl-columns) { grid-column: span 10; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-11-xl-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-11-xl-columns) { grid-column: span 11; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-12-xl-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-12-xl-columns) { grid-column: span 12; }
+
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-1-xl-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-1-xl-row) { grid-row: span 1; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-2-xl-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-2-xl-row) { grid-row: span 2; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-3-xl-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-3-xl-row) { grid-row: span 3; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-4-xl-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-4-xl-row) { grid-row: span 4; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-5-xl-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-5-xl-row) { grid-row: span 5; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-6-xl-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-6-xl-row) { grid-row: span 6; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-7-xl-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-7-xl-row) { grid-row: span 7; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-8-xl-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-8-xl-row) { grid-row: span 8; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-9-xl-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-9-xl-row) { grid-row: span 9; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-10-xl-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-10-xl-row) { grid-row: span 10; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-11-xl-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-11-xl-row) { grid-row: span 11; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-12-xl-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-12-xl-row) { grid-row: span 12; }
+}
+
+/* === 2xl: 1536px === */
+@media (min-width: 1536px) {
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-1-2xl-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-1-2xl-columns) { grid-column: span 1; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-2-2xl-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-2-2xl-columns) { grid-column: span 2; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-3-2xl-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-3-2xl-columns) { grid-column: span 3; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-4-2xl-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-4-2xl-columns) { grid-column: span 4; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-5-2xl-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-5-2xl-columns) { grid-column: span 5; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-6-2xl-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-6-2xl-columns) { grid-column: span 6; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-7-2xl-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-7-2xl-columns) { grid-column: span 7; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-8-2xl-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-8-2xl-columns) { grid-column: span 8; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-9-2xl-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-9-2xl-columns) { grid-column: span 9; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-10-2xl-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-10-2xl-columns) { grid-column: span 10; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-11-2xl-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-11-2xl-columns) { grid-column: span 11; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-12-2xl-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-12-2xl-columns) { grid-column: span 12; }
+
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-1-2xl-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-1-2xl-row) { grid-row: span 1; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-2-2xl-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-2-2xl-row) { grid-row: span 2; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-3-2xl-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-3-2xl-row) { grid-row: span 3; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-4-2xl-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-4-2xl-row) { grid-row: span 4; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-5-2xl-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-5-2xl-row) { grid-row: span 5; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-6-2xl-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-6-2xl-row) { grid-row: span 6; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-7-2xl-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-7-2xl-row) { grid-row: span 7; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-8-2xl-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-8-2xl-row) { grid-row: span 8; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-9-2xl-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-9-2xl-row) { grid-row: span 9; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-10-2xl-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-10-2xl-row) { grid-row: span 10; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-11-2xl-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-11-2xl-row) { grid-row: span 11; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-12-2xl-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-12-2xl-row) { grid-row: span 12; }
+}

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/core/post-template-item.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/core/post-template-item.blade.php
@@ -1,10 +1,58 @@
 @php
+	use ArtisanPackUI\VisualEditor\Responsive\BreakpointRegistry;
+
 	$postId = isset( $attributes['postId'] ) ? (int) $attributes['postId'] : 0;
 	$className = isset( $attributes['className'] ) && is_string( $attributes['className'] )
 		? trim( $attributes['className'] )
 		: '';
 
-	$classes = array_filter( [ 'wp-block-post-template-item', $className ] );
+	$spanClasses = [];
+	$resolvedSpan = $attributes['_resolvedGridSpan'] ?? null;
+
+	if ( is_array( $resolvedSpan ) ) {
+		$breakpointRegistry = app( BreakpointRegistry::class );
+
+		$emitSpan = static function ( $overrides, string $suffix ) use ( $breakpointRegistry ): array {
+			$out = [];
+
+			if ( ! is_array( $overrides ) ) {
+				return $out;
+			}
+
+			foreach ( $overrides as $bp => $value ) {
+				if ( ! is_string( $bp ) || '' === $bp ) {
+					continue;
+				}
+
+				if ( ! is_numeric( $value ) ) {
+					continue;
+				}
+
+				if ( BreakpointRegistry::BASE_KEY !== $bp && null === $breakpointRegistry->get( $bp ) ) {
+					continue;
+				}
+
+				$amount = (int) $value;
+
+				if ( $amount < 1 ) {
+					$amount = 1;
+				} elseif ( $amount > 12 ) {
+					$amount = 12;
+				}
+
+				$out[] = 'ap-post-span-' . $amount . '-' . $bp . '-' . $suffix;
+			}
+
+			return $out;
+		};
+
+		$spanClasses = array_merge(
+			$emitSpan( $resolvedSpan['columns'] ?? null, 'columns' ),
+			$emitSpan( $resolvedSpan['rows'] ?? null, 'row' ),
+		);
+	}
+
+	$classes = array_filter( array_merge( [ 'wp-block-post-template-item', $className ], $spanClasses ) );
 	$classAttr = sprintf( 'class="%s"', e( implode( ' ', $classes ) ) );
 	$idAttr = $postId > 0 ? sprintf( ' id="post-%d"', $postId ) : '';
 @endphp

--- a/packages/visual-editor-renderer-blade/resources/views/components/blocks-styles.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/components/blocks-styles.blade.php
@@ -38,6 +38,16 @@
 	through `PhotoGridSupport::wrapperForBlock` + the responsive CSS
 	accumulator. --}}
 <link rel="stylesheet" href="{{ $photoGridStyleHref }}" data-ve-photo-grid>
+{{-- #592 — Post Template grid container. Sets `grid-template-columns`
+	on `.wp-block-post-template.is-layout-grid.columns-N` so the
+	post-template's `is-layout-grid` wrapper renders as an actual
+	N-column CSS grid (the layout baseline only supplies `display: grid`). --}}
+<link rel="stylesheet" href="{{ $postTemplateStyleHref }}" data-ve-post-template>
+{{-- #592 — Post Variant grid spans. Adds `ap-post-span-N-{bp}-{columns,row}`
+	rules scoped to `.wp-block-post-template.is-layout-grid > .wp-block-post-template-item`
+	so a variant's per-breakpoint `gridColumnSpan` / `gridRowSpan` only takes
+	effect inside a grid-layout Query Loop. --}}
+<link rel="stylesheet" href="{{ $postVariantStyleHref }}" data-ve-post-variant>
 @if( '' !== $themeTokensCss )
 <style data-ve-theme-tokens>{!! $themeTokensCss !!}</style>
 @endif

--- a/packages/visual-editor-renderer-blade/src/View/Components/BlocksStylesComponent.php
+++ b/packages/visual-editor-renderer-blade/src/View/Components/BlocksStylesComponent.php
@@ -75,6 +75,10 @@ class BlocksStylesComponent extends Component
 
 	public string $photoGridStyleHref;
 
+	public string $postTemplateStyleHref;
+
+	public string $postVariantStyleHref;
+
 	public string $interactivityScriptSrc;
 
 	public bool $emitBlockLibrary;
@@ -114,6 +118,8 @@ class BlocksStylesComponent extends Component
 		$this->queryPaginationStyleHref = $base . '/frontend/query-pagination.css';
 		$this->flexLayoutStyleHref    = $base . '/frontend/flex-layout.css';
 		$this->photoGridStyleHref     = $base . '/frontend/photo-grid.css';
+		$this->postTemplateStyleHref  = $base . '/frontend/post-template.css';
+		$this->postVariantStyleHref   = $base . '/frontend/post-variant.css';
 		$this->interactivityScriptSrc = $base . '/frontend/interactivity.js';
 		$this->emitBlockLibrary       = $bundle;
 		$this->emitInteractive        = $interactive;

--- a/packages/visual-editor-renderer-blade/tests/Feature/PostVariantGridSpansRenderTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Feature/PostVariantGridSpansRenderTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Services\QueryResolverContract;
+use ArtisanPackUI\VisualEditorRendererBlade\View\Components\BlocksComponent;
+use Tests\Fixtures\FakeQueryResolver;
+
+/**
+ * Issue #592 — variable column / row spans on post-variants in a
+ * grid-layout Query Loop.
+ *
+ * End-to-end render coverage: the QueryInliner stamps
+ * `_resolvedGridSpan` on the synthetic `core/post-template-item`
+ * wrapper, and this Blade partial translates that into a flat
+ * `ap-post-span-N-{bp}-{columns,row}` class list scoped via the CSS
+ * bundle to grid-layout post-templates only.
+ */
+
+beforeEach( function (): void {
+	$this->fake = new FakeQueryResolver();
+	$this->app->instance( QueryResolverContract::class, $this->fake );
+} );
+
+function spanRenderablePost( int $id, string $title, array $extras = [] ): object
+{
+	$post                    = new stdClass();
+	$post->id                = $id;
+	$post->title             = $title;
+	$post->excerpt           = '';
+	$post->content           = "<p>{$title}</p>";
+	$post->permalink         = "/posts/{$id}";
+	$post->author            = null;
+	$post->published_at      = null;
+	$post->updated_at        = null;
+	$post->featured_image_id = null;
+
+	foreach ( $extras as $key => $value ) {
+		$post->{$key} = $value;
+	}
+
+	return $post;
+}
+
+function gridTreeWithVariantSpan(
+	int $columnSpan,
+	int $rowSpan,
+	?array $responsive = null,
+	string $layout = 'grid'
+): array {
+	$variantAttributes = [
+		'matcher'        => [ 'kind' => 'position', 'value' => 'first' ],
+		'priority'       => 10,
+		'gridColumnSpan' => $columnSpan,
+		'gridRowSpan'    => $rowSpan,
+	];
+
+	if ( null !== $responsive ) {
+		$variantAttributes['responsive'] = $responsive;
+	}
+
+	return [
+		[
+			'name'        => 'core/query',
+			'attributes'  => [ 'query' => [ 'postType' => 'post', 'perPage' => 2 ] ],
+			'innerBlocks' => [
+				[
+					'name'        => 'core/post-template',
+					'attributes'  => [ 'layout' => $layout ],
+					'innerBlocks' => [
+						[
+							'name'        => 'core/post-title',
+							'attributes'  => [],
+							'innerBlocks' => [],
+						],
+						[
+							'name'        => 'artisanpack/post-variant',
+							'attributes'  => $variantAttributes,
+							'innerBlocks' => [
+								[
+									'name'        => 'core/post-excerpt',
+									'attributes'  => [],
+									'innerBlocks' => [],
+								],
+							],
+						],
+					],
+				],
+			],
+		],
+	];
+}
+
+it( 'emits ap-post-span classes on the first iteration <li> when the variant matched in a grid layout', function () {
+	$this->fake->setItems( [
+		spanRenderablePost( 1, 'Hero' ),
+		spanRenderablePost( 2, 'Listed' ),
+	] );
+
+	$tree      = gridTreeWithVariantSpan( 2, 2 );
+	$component = $this->app->make( BlocksComponent::class, [ 'tree' => $tree ] );
+	$html      = $component->render()->with( $component->data() )->render();
+
+	expect( $html )->toContain( 'ap-post-span-2-base-columns' )
+		->and( $html )->toContain( 'ap-post-span-2-base-row' )
+		// Non-matched item should not pick up span classes from the
+		// matched item.
+		->and( substr_count( $html, 'ap-post-span-2-base-columns' ) )->toBe( 1 );
+} );
+
+it( 'does not emit ap-post-span classes when the post-template layout is not grid', function () {
+	$this->fake->setItems( [
+		spanRenderablePost( 1, 'Hero' ),
+	] );
+
+	$tree      = gridTreeWithVariantSpan( 2, 2, null, 'list' );
+	$component = $this->app->make( BlocksComponent::class, [ 'tree' => $tree ] );
+	$html      = $component->render()->with( $component->data() )->render();
+
+	expect( $html )->not->toContain( 'ap-post-span-' );
+} );
+
+it( 'emits per-breakpoint span classes when the variant carries responsive overrides', function () {
+	$this->fake->setItems( [
+		spanRenderablePost( 1, 'Hero' ),
+	] );
+
+	$tree = gridTreeWithVariantSpan( 2, 1, [
+		'gridColumnSpan' => [ 'md' => 3, 'lg' => 4 ],
+		'gridRowSpan'    => [ 'md' => 2 ],
+	] );
+
+	$component = $this->app->make( BlocksComponent::class, [ 'tree' => $tree ] );
+	$html      = $component->render()->with( $component->data() )->render();
+
+	expect( $html )->toContain( 'ap-post-span-2-base-columns' )
+		->and( $html )->toContain( 'ap-post-span-3-md-columns' )
+		->and( $html )->toContain( 'ap-post-span-4-lg-columns' )
+		->and( $html )->toContain( 'ap-post-span-1-base-row' )
+		->and( $html )->toContain( 'ap-post-span-2-md-row' );
+} );

--- a/packages/visual-editor-renderer-react/src/blocks/core/query.tsx
+++ b/packages/visual-editor-renderer-react/src/blocks/core/query.tsx
@@ -14,7 +14,7 @@
  */
 
 import type { JSX, ReactNode } from 'react';
-import { attrString, classList } from '../../support/attributes';
+import { attrString, classList, postTemplateItemSpanClasses } from '../../support/attributes';
 import type { BlockRendererProps } from '../../types';
 
 interface WrapperProps {
@@ -93,8 +93,9 @@ export function PostTemplateItemBlock({ attributes, children }: BlockRendererPro
     const parsedPostId = typeof rawPostId === 'number' ? rawPostId : Number(rawPostId);
     const postId = Number.isFinite(parsedPostId) ? parsedPostId : 0;
     const className = attrString(attributes.className);
+    const spanClasses = postTemplateItemSpanClasses(attributes._resolvedGridSpan);
 
-    const classes = classList(['wp-block-post-template-item', className]);
+    const classes = classList(['wp-block-post-template-item', className, ...spanClasses]);
 
     return <li id={postId > 0 ? `post-${postId}` : undefined} className={classes}>{children}</li>;
 }

--- a/packages/visual-editor-renderer-react/src/support/attributes.ts
+++ b/packages/visual-editor-renderer-react/src/support/attributes.ts
@@ -101,3 +101,104 @@ export function formatPercent(value: number): string {
 
     return (trimmed === '' ? '0' : trimmed) + '%';
 }
+
+/**
+ * Tailwind v4 default breakpoint keys recognised by the post-variant
+ * span emitter (#592). Anything outside this list is dropped silently
+ * so a malformed save can't produce CSS classes the stylesheet has no
+ * matching rule for.
+ */
+const POST_TEMPLATE_ITEM_SPAN_BREAKPOINTS = new Set<string>([
+    'base',
+    'sm',
+    'md',
+    'lg',
+    'xl',
+    '2xl',
+]);
+
+const POST_TEMPLATE_ITEM_SPAN_MIN = 1;
+const POST_TEMPLATE_ITEM_SPAN_MAX = 12;
+
+function clampSpan(value: unknown): number | null {
+    if (typeof value === 'number' && Number.isFinite(value)) {
+        const trimmed = Math.trunc(value);
+
+        if (trimmed < POST_TEMPLATE_ITEM_SPAN_MIN) {
+            return POST_TEMPLATE_ITEM_SPAN_MIN;
+        }
+
+        if (trimmed > POST_TEMPLATE_ITEM_SPAN_MAX) {
+            return POST_TEMPLATE_ITEM_SPAN_MAX;
+        }
+
+        return trimmed;
+    }
+
+    if (typeof value === 'string' && value.trim() !== '') {
+        const parsed = Number.parseInt(value, 10);
+
+        if (Number.isFinite(parsed)) {
+            return clampSpan(parsed);
+        }
+    }
+
+    return null;
+}
+
+/**
+ * Build the `ap-post-span-N-{bp}-{columns,row}` class list for a
+ * post-template-item from the `_resolvedGridSpan` attribute the
+ * server-side `QueryInliner` (PHP) or its client-side mirror stamps
+ * onto each iteration wrapper when (a) a variant matched and (b) the
+ * post-template's layout is grid.
+ *
+ * The shape mirrors the PHP `resolveVariantSpans()` output:
+ *
+ *     { columns: { base: 2, md: 3 }, rows: { base: 1 } }
+ *
+ * Unknown breakpoint keys are dropped so the public CSS bundle stays
+ * the only source of truth for the rule set. Returns an empty array
+ * when the attribute is absent or empty so the caller can spread it
+ * unconditionally.
+ */
+export function postTemplateItemSpanClasses(value: unknown): string[] {
+    if (value === null || value === undefined || typeof value !== 'object') {
+        return [];
+    }
+
+    const record = value as Record<string, unknown>;
+
+    return [
+        ...buildSpanClasses(record.columns, 'columns'),
+        ...buildSpanClasses(record.rows, 'row'),
+    ];
+}
+
+function buildSpanClasses(overrides: unknown, suffix: 'columns' | 'row'): string[] {
+    if (overrides === null || overrides === undefined || typeof overrides !== 'object') {
+        return [];
+    }
+
+    if (Array.isArray(overrides)) {
+        return [];
+    }
+
+    const out: string[] = [];
+
+    for (const [bp, raw] of Object.entries(overrides as Record<string, unknown>)) {
+        if (!POST_TEMPLATE_ITEM_SPAN_BREAKPOINTS.has(bp)) {
+            continue;
+        }
+
+        const span = clampSpan(raw);
+
+        if (span === null) {
+            continue;
+        }
+
+        out.push(`ap-post-span-${span}-${bp}-${suffix}`);
+    }
+
+    return out;
+}

--- a/packages/visual-editor-renderer-vue/src/blocks/core/query.ts
+++ b/packages/visual-editor-renderer-vue/src/blocks/core/query.ts
@@ -13,7 +13,7 @@
  */
 
 import { defineComponent, h } from 'vue';
-import { attrString, classList } from '../../support/attributes';
+import { attrString, classList, postTemplateItemSpanClasses } from '../../support/attributes';
 import { blockRendererProps } from '../shared';
 
 function isDevelopment(): boolean {
@@ -107,9 +107,12 @@ export const PostTemplateItemBlock = defineComponent({
                 typeof rawPostId === 'number' ? rawPostId : Number(rawPostId);
             const postId = Number.isFinite(parsedPostId) ? parsedPostId : 0;
             const className = attrString(props.attributes.className);
+            const spanClasses = postTemplateItemSpanClasses(
+                props.attributes._resolvedGridSpan,
+            );
 
             const attrs: Record<string, unknown> = {
-                class: classList(['wp-block-post-template-item', className]),
+                class: classList(['wp-block-post-template-item', className, ...spanClasses]),
             };
 
             if (postId > 0) {

--- a/packages/visual-editor-renderer-vue/src/support/attributes.ts
+++ b/packages/visual-editor-renderer-vue/src/support/attributes.ts
@@ -101,3 +101,104 @@ export function formatPercent(value: number): string {
 
     return (trimmed === '' ? '0' : trimmed) + '%';
 }
+
+/**
+ * Tailwind v4 default breakpoint keys recognised by the post-variant
+ * span emitter (#592). Anything outside this list is dropped silently
+ * so a malformed save can't produce CSS classes the stylesheet has no
+ * matching rule for.
+ */
+const POST_TEMPLATE_ITEM_SPAN_BREAKPOINTS = new Set<string>([
+    'base',
+    'sm',
+    'md',
+    'lg',
+    'xl',
+    '2xl',
+]);
+
+const POST_TEMPLATE_ITEM_SPAN_MIN = 1;
+const POST_TEMPLATE_ITEM_SPAN_MAX = 12;
+
+function clampSpan(value: unknown): number | null {
+    if (typeof value === 'number' && Number.isFinite(value)) {
+        const trimmed = Math.trunc(value);
+
+        if (trimmed < POST_TEMPLATE_ITEM_SPAN_MIN) {
+            return POST_TEMPLATE_ITEM_SPAN_MIN;
+        }
+
+        if (trimmed > POST_TEMPLATE_ITEM_SPAN_MAX) {
+            return POST_TEMPLATE_ITEM_SPAN_MAX;
+        }
+
+        return trimmed;
+    }
+
+    if (typeof value === 'string' && value.trim() !== '') {
+        const parsed = Number.parseInt(value, 10);
+
+        if (Number.isFinite(parsed)) {
+            return clampSpan(parsed);
+        }
+    }
+
+    return null;
+}
+
+/**
+ * Build the `ap-post-span-N-{bp}-{columns,row}` class list for a
+ * post-template-item from the `_resolvedGridSpan` attribute the
+ * server-side `QueryInliner` (PHP) or its client-side mirror stamps
+ * onto each iteration wrapper when (a) a variant matched and (b) the
+ * post-template's layout is grid.
+ *
+ * The shape mirrors the PHP `resolveVariantSpans()` output:
+ *
+ *     { columns: { base: 2, md: 3 }, rows: { base: 1 } }
+ *
+ * Unknown breakpoint keys are dropped so the public CSS bundle stays
+ * the only source of truth for the rule set. Returns an empty array
+ * when the attribute is absent or empty so the caller can spread it
+ * unconditionally.
+ */
+export function postTemplateItemSpanClasses(value: unknown): string[] {
+    if (value === null || value === undefined || typeof value !== 'object') {
+        return [];
+    }
+
+    const record = value as Record<string, unknown>;
+
+    return [
+        ...buildSpanClasses(record.columns, 'columns'),
+        ...buildSpanClasses(record.rows, 'row'),
+    ];
+}
+
+function buildSpanClasses(overrides: unknown, suffix: 'columns' | 'row'): string[] {
+    if (overrides === null || overrides === undefined || typeof overrides !== 'object') {
+        return [];
+    }
+
+    if (Array.isArray(overrides)) {
+        return [];
+    }
+
+    const out: string[] = [];
+
+    for (const [bp, raw] of Object.entries(overrides as Record<string, unknown>)) {
+        if (!POST_TEMPLATE_ITEM_SPAN_BREAKPOINTS.has(bp)) {
+            continue;
+        }
+
+        const span = clampSpan(raw);
+
+        if (span === null) {
+            continue;
+        }
+
+        out.push(`ap-post-span-${span}-${bp}-${suffix}`);
+    }
+
+    return out;
+}

--- a/resources/js/visual-editor/blocks/__tests__/post-variant-grid-spans.test.ts
+++ b/resources/js/visual-editor/blocks/__tests__/post-variant-grid-spans.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Issue #592 — variable grid spans on `artisanpack/post-variant`.
+ *
+ * Covers the editor side: the new `gridColumnSpan` / `gridRowSpan`
+ * attributes default to 1, both opt into the responsive cascade, and
+ * the renderer-side span emitters in the Vue / React `support/attributes`
+ * helpers translate a stamped `_resolvedGridSpan` into the same class
+ * list the Blade post-template-item partial produces.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import postVariantMeta from '../post-variant/block.json';
+import { postTemplateItemSpanClasses as reactSpanClasses } from '../../../../../packages/visual-editor-renderer-react/src/support/attributes';
+import { postTemplateItemSpanClasses as vueSpanClasses } from '../../../../../packages/visual-editor-renderer-vue/src/support/attributes';
+
+interface AttributeDefinition {
+    type?: string;
+    default?: unknown;
+}
+
+interface PostVariantSupports {
+    artisanpackResponsive?: {
+        attributes?: readonly string[];
+    };
+}
+
+describe('artisanpack/post-variant block.json — grid spans (#592)', () => {
+    const attributes = postVariantMeta.attributes as Record<string, AttributeDefinition>;
+    const supports = postVariantMeta.supports as PostVariantSupports;
+
+    it('declares gridColumnSpan and gridRowSpan as numeric attributes with default 1', () => {
+        expect(attributes.gridColumnSpan).toEqual({ type: 'number', default: 1 });
+        expect(attributes.gridRowSpan).toEqual({ type: 'number', default: 1 });
+    });
+
+    it('opts both span attributes into the artisanpackResponsive cascade', () => {
+        const responsive = supports.artisanpackResponsive?.attributes ?? [];
+        expect(responsive).toContain('gridColumnSpan');
+        expect(responsive).toContain('gridRowSpan');
+    });
+});
+
+describe('postTemplateItemSpanClasses — renderer parity for `_resolvedGridSpan`', () => {
+    const expectIdenticalOutput = (input: unknown): string[] => {
+        const fromVue = vueSpanClasses(input);
+        const fromReact = reactSpanClasses(input);
+        expect(fromReact).toEqual(fromVue);
+        return fromVue;
+    };
+
+    it('returns no classes when the attribute is absent or empty', () => {
+        expect(expectIdenticalOutput(undefined)).toEqual([]);
+        expect(expectIdenticalOutput(null)).toEqual([]);
+        expect(expectIdenticalOutput({})).toEqual([]);
+    });
+
+    it('emits base column and row classes from the base values', () => {
+        const result = expectIdenticalOutput({
+            columns: { base: 2 },
+            rows: { base: 3 },
+        });
+
+        expect(result).toContain('ap-post-span-2-base-columns');
+        expect(result).toContain('ap-post-span-3-base-row');
+    });
+
+    it('emits one class per defined breakpoint for both axes', () => {
+        const result = expectIdenticalOutput({
+            columns: { base: 2, md: 3, lg: 4 },
+            rows: { base: 1, md: 2 },
+        });
+
+        expect(result).toEqual(expect.arrayContaining([
+            'ap-post-span-2-base-columns',
+            'ap-post-span-3-md-columns',
+            'ap-post-span-4-lg-columns',
+            'ap-post-span-1-base-row',
+            'ap-post-span-2-md-row',
+        ]));
+    });
+
+    it('drops unknown breakpoint keys instead of emitting orphan classes', () => {
+        const result = expectIdenticalOutput({
+            columns: { base: 2, bogus: 9 },
+            rows: {},
+        });
+
+        expect(result).toEqual(['ap-post-span-2-base-columns']);
+    });
+
+    it('clamps span values into the 1..12 stylesheet range', () => {
+        const result = expectIdenticalOutput({
+            columns: { base: 0, md: 99 },
+            rows: { base: -5 },
+        });
+
+        expect(result).toEqual(expect.arrayContaining([
+            'ap-post-span-1-base-columns',
+            'ap-post-span-12-md-columns',
+            'ap-post-span-1-base-row',
+        ]));
+    });
+
+    it('parses numeric strings the same way both renderers do', () => {
+        const result = expectIdenticalOutput({
+            columns: { base: '2' },
+            rows: { base: '3' },
+        });
+
+        expect(result).toContain('ap-post-span-2-base-columns');
+        expect(result).toContain('ap-post-span-3-base-row');
+    });
+
+    it('skips overrides whose values are not finite numbers or numeric strings', () => {
+        const result = expectIdenticalOutput({
+            columns: { base: 2, md: null, lg: 'not a number' },
+            rows: { base: 1, md: undefined },
+        });
+
+        expect(result).toEqual(expect.arrayContaining([
+            'ap-post-span-2-base-columns',
+            'ap-post-span-1-base-row',
+        ]));
+        expect(result).not.toContain('ap-post-span-null-md-columns');
+    });
+});

--- a/resources/js/visual-editor/blocks/post-template/block.json
+++ b/resources/js/visual-editor/blocks/post-template/block.json
@@ -33,6 +33,10 @@
         "postType",
         "artisanpack/queryPreview"
     ],
+    "providesContext": {
+        "artisanpack/postTemplateLayout": "layout",
+        "artisanpack/postTemplateColumns": "columns"
+    },
     "supports": {
         "anchor": true,
         "reusable": false,

--- a/resources/js/visual-editor/blocks/post-template/edit.tsx
+++ b/resources/js/visual-editor/blocks/post-template/edit.tsx
@@ -49,13 +49,14 @@ export default function PostTemplateEdit( {
     const columns = typeof attributes.columns === 'number' ? attributes.columns : 3;
     const isGrid = layout === 'grid';
 
-    // Use upstream Gutenberg's `core/post-template` class names so the
-    // shipped block-library CSS (`.wp-block-post-template.is-flex-container
-    // > li` + `.columns-{n} > li`) applies without a parallel rule set
-    // — see `@wordpress/block-library/build-style/style.css`.
+    // Match the Blade renderer's class set so the editor canvas and the
+    // public frontend use the same CSS-grid layout. `is-layout-grid` +
+    // `columns-{n}` together activate the rules shipped via the
+    // post-variant stylesheet, which also powers per-post column / row
+    // spans (#592).
     const className = [
         'wp-block-post-template',
-        isGrid ? 'is-flex-container' : '',
+        isGrid ? 'is-layout-grid' : 'is-layout-flow',
         isGrid ? `columns-${ columns }` : '',
     ].filter( Boolean ).join( ' ' );
 

--- a/resources/js/visual-editor/blocks/post-template/index.ts
+++ b/resources/js/visual-editor/blocks/post-template/index.ts
@@ -18,6 +18,8 @@ import save from './save';
 import transforms from './transforms';
 import icon from './inserter-icon';
 
+import './post-template.css';
+
 export { edit, save, metadata, icon, transforms };
 
 export default {

--- a/resources/js/visual-editor/blocks/post-template/post-template.css
+++ b/resources/js/visual-editor/blocks/post-template/post-template.css
@@ -1,0 +1,33 @@
+/**
+ * Post Template grid container styles (#592).
+ *
+ * Upstream `core/post-template` uses a flex-with-percent-widths layout
+ * for its grid view via `is-flex-container` + `columns-N`. The
+ * ArtisanPack fork renders the same block as a real CSS grid via
+ * `is-layout-grid` + `columns-N`, both in the editor canvas and the
+ * Blade / Vue / React renderers, so per-post column / row spans on
+ * post-variants (#592) actually have a grid to span across.
+ *
+ * `.is-layout-grid` already picks up `display: grid` from the layout
+ * baseline emitted by <x-ve-blocks-styles />. These rules add the
+ * track definition and item reset that the baseline doesn't supply.
+ */
+
+.wp-block-post-template.is-layout-grid {
+    grid-template-columns: repeat(1, minmax(0, 1fr));
+    gap: var(--wp--style--block-gap, 1.25em);
+    list-style: none;
+    padding: 0;
+}
+
+.wp-block-post-template.is-layout-grid.columns-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.wp-block-post-template.is-layout-grid.columns-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+.wp-block-post-template.is-layout-grid.columns-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+.wp-block-post-template.is-layout-grid.columns-5 { grid-template-columns: repeat(5, minmax(0, 1fr)); }
+.wp-block-post-template.is-layout-grid.columns-6 { grid-template-columns: repeat(6, minmax(0, 1fr)); }
+
+.wp-block-post-template.is-layout-grid > .wp-block-post-template-item {
+    margin: 0;
+    width: auto;
+    min-width: 0;
+}

--- a/resources/js/visual-editor/blocks/post-variant/block.json
+++ b/resources/js/visual-editor/blocks/post-variant/block.json
@@ -23,18 +23,34 @@
         },
         "label": {
             "type": "string"
+        },
+        "gridColumnSpan": {
+            "type": "number",
+            "default": 1
+        },
+        "gridRowSpan": {
+            "type": "number",
+            "default": 1
         }
     },
     "usesContext": [
         "queryId",
         "query",
         "displayLayout",
-        "postType"
+        "postType",
+        "artisanpack/postTemplateLayout",
+        "artisanpack/postTemplateColumns"
     ],
     "supports": {
         "html": false,
         "reusable": false,
         "layout": false,
-        "inserter": false
+        "inserter": false,
+        "artisanpackResponsive": {
+            "attributes": [
+                "gridColumnSpan",
+                "gridRowSpan"
+            ]
+        }
     }
 }

--- a/resources/js/visual-editor/blocks/post-variant/edit.tsx
+++ b/resources/js/visual-editor/blocks/post-variant/edit.tsx
@@ -29,11 +29,75 @@ interface PostVariantAttributes {
     readonly matcher?: Matcher;
     readonly priority?: number;
     readonly label?: string;
+    readonly gridColumnSpan?: number;
+    readonly gridRowSpan?: number;
+}
+
+interface DisplayLayoutContext {
+    readonly type?: string;
+    readonly columns?: number;
+}
+
+interface PostVariantContext {
+    readonly displayLayout?: DisplayLayoutContext | null;
+    readonly 'artisanpack/postTemplateLayout'?: string | null;
+    readonly 'artisanpack/postTemplateColumns'?: number | null;
 }
 
 interface PostVariantEditProps {
     attributes: PostVariantAttributes;
     setAttributes: ( changes: Partial<PostVariantAttributes> ) => void;
+    context?: PostVariantContext;
+}
+
+const MAX_ROW_SPAN = 12;
+const ROW_SPAN_WARN_THRESHOLD = 4;
+const DEFAULT_NUM_COLUMNS = 3;
+
+function clampSpan( value: number | undefined, max: number, fallback: number ): number {
+    const next = typeof value === 'number' && Number.isFinite( value )
+        ? Math.trunc( value )
+        : fallback;
+
+    if ( next < 1 ) {
+        return 1;
+    }
+
+    if ( next > max ) {
+        return max;
+    }
+
+    return next;
+}
+
+function resolveNumColumns( context: PostVariantContext | undefined ): number {
+    // Prefer the post-template's own `columns` attribute (exposed via
+    // `artisanpack/postTemplateColumns` context) because the post-template
+    // is the source of truth for the grid the variant lives inside. Fall
+    // back to the parent query's `displayLayout.columns` for hosts that
+    // drive grids from the query block instead.
+    const fromPostTemplate = context?.[ 'artisanpack/postTemplateColumns' ];
+    const fromDisplayLayout = context?.displayLayout?.columns;
+
+    const raw = typeof fromPostTemplate === 'number'
+        ? fromPostTemplate
+        : fromDisplayLayout;
+
+    const parsed = typeof raw === 'number' && Number.isFinite( raw ) ? Math.trunc( raw ) : DEFAULT_NUM_COLUMNS;
+
+    if ( parsed < 1 ) {
+        return 1;
+    }
+
+    return parsed;
+}
+
+function isGridLayout( context: PostVariantContext | undefined ): boolean {
+    if ( context?.[ 'artisanpack/postTemplateLayout' ] === 'grid' ) {
+        return true;
+    }
+
+    return context?.displayLayout?.type === 'grid';
 }
 
 const POSITION_PRESETS: ReadonlyArray<{ value: string; label: string }> = [
@@ -84,14 +148,27 @@ function defaultValueForKind( kind: MatcherKind ): string {
 export default function PostVariantEdit( {
     attributes,
     setAttributes,
+    context,
 }: PostVariantEditProps ): ReactElement {
     const matcher = getMatcher( attributes );
     const priority = typeof attributes.priority === 'number' ? attributes.priority : 10;
     const label = typeof attributes.label === 'string' ? attributes.label : '';
+    const showGridSpans = isGridLayout( context );
+    const numColumns = resolveNumColumns( context );
+    const gridColumnSpan = clampSpan( attributes.gridColumnSpan, numColumns, 1 );
+    const gridRowSpan = clampSpan( attributes.gridRowSpan, MAX_ROW_SPAN, 1 );
+
+    const wrapperClassName = [
+        'wp-block-artisanpack-post-variant',
+        showGridSpans ? `ap-post-span-${ gridColumnSpan }-base-columns` : '',
+        showGridSpans ? `ap-post-span-${ gridRowSpan }-base-row` : '',
+    ]
+        .filter( ( value: string ) => '' !== value )
+        .join( ' ' );
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const blockProps = ( useBlockProps as any )( {
-        className: 'wp-block-artisanpack-post-variant',
+        className: wrapperClassName,
         'data-variant-kind': matcher.kind,
         'data-variant-value': matcher.value,
     } );
@@ -198,6 +275,43 @@ export default function PostVariantEdit( {
                         </Notice>
                     ) }
                 </PanelBody>
+                { showGridSpans && (
+                    <PanelBody title={ __( 'Grid Spans', TEXT_DOMAIN ) } initialOpen={ false }>
+                        <RangeControl
+                            __nextHasNoMarginBottom
+                            __next40pxDefaultSize
+                            label={ __( 'Column Span', TEXT_DOMAIN ) }
+                            value={ gridColumnSpan }
+                            onChange={ ( value?: number ) =>
+                                setAttributes( { gridColumnSpan: clampSpan( value, numColumns, 1 ) } )
+                            }
+                            min={ 1 }
+                            max={ numColumns }
+                            allowReset
+                            resetFallbackValue={ 1 }
+                            help={ __( 'How many grid columns this post spans when it matches this variant.', TEXT_DOMAIN ) }
+                        />
+                        <RangeControl
+                            __nextHasNoMarginBottom
+                            __next40pxDefaultSize
+                            label={ __( 'Row Span', TEXT_DOMAIN ) }
+                            value={ gridRowSpan }
+                            onChange={ ( value?: number ) =>
+                                setAttributes( { gridRowSpan: clampSpan( value, MAX_ROW_SPAN, 1 ) } )
+                            }
+                            min={ 1 }
+                            max={ MAX_ROW_SPAN }
+                            allowReset
+                            resetFallbackValue={ 1 }
+                            help={ __( 'How many grid rows this post spans when it matches this variant.', TEXT_DOMAIN ) }
+                        />
+                        { gridRowSpan > ROW_SPAN_WARN_THRESHOLD && (
+                            <Notice status="warning" isDismissible={ false }>
+                                { __( 'A row span larger than 4 can produce very tall cells. Make sure your layout still makes sense at smaller viewports.', TEXT_DOMAIN ) }
+                            </Notice>
+                        ) }
+                    </PanelBody>
+                ) }
             </InspectorControls>
             <div className="wp-block-artisanpack-post-variant__summary" aria-hidden="true">
                 <span>{ summary }</span>

--- a/resources/js/visual-editor/blocks/post-variant/edit.tsx
+++ b/resources/js/visual-editor/blocks/post-variant/edit.tsx
@@ -50,11 +50,17 @@ interface PostVariantEditProps {
     context?: PostVariantContext;
 }
 
-const MAX_ROW_SPAN = 12;
+// Hard ceiling matches the renderer-side CSS rule set in
+// `post-variant.css` and the `QueryInliner::clampSpanValue()` cap.
+// Keeping the same ceiling here means the editor slider never
+// exposes a value the renderers would silently clamp away.
+const HARD_MAX_SPAN = 12;
+const MAX_ROW_SPAN = HARD_MAX_SPAN;
 const ROW_SPAN_WARN_THRESHOLD = 4;
 const DEFAULT_NUM_COLUMNS = 3;
 
 function clampSpan( value: number | undefined, max: number, fallback: number ): number {
+    const effectiveMax = Math.min( max, HARD_MAX_SPAN );
     const next = typeof value === 'number' && Number.isFinite( value )
         ? Math.trunc( value )
         : fallback;
@@ -63,8 +69,8 @@ function clampSpan( value: number | undefined, max: number, fallback: number ): 
         return 1;
     }
 
-    if ( next > max ) {
-        return max;
+    if ( next > effectiveMax ) {
+        return effectiveMax;
     }
 
     return next;
@@ -89,12 +95,24 @@ function resolveNumColumns( context: PostVariantContext | undefined ): number {
         return 1;
     }
 
+    if ( parsed > HARD_MAX_SPAN ) {
+        return HARD_MAX_SPAN;
+    }
+
     return parsed;
 }
 
 function isGridLayout( context: PostVariantContext | undefined ): boolean {
-    if ( context?.[ 'artisanpack/postTemplateLayout' ] === 'grid' ) {
-        return true;
+    // The post-template's own `layout` attribute is authoritative when
+    // present in context — even when it's set to a non-grid value,
+    // because the variant lives inside the post-template and inherits
+    // its layout. Only fall back to the parent query's `displayLayout`
+    // when the post-template hasn't published a layout key at all
+    // (older saves, hosts driving grids from the query block).
+    const fromPostTemplate = context?.[ 'artisanpack/postTemplateLayout' ];
+
+    if ( typeof fromPostTemplate === 'string' ) {
+        return 'grid' === fromPostTemplate;
     }
 
     return context?.displayLayout?.type === 'grid';

--- a/resources/js/visual-editor/blocks/post-variant/index.ts
+++ b/resources/js/visual-editor/blocks/post-variant/index.ts
@@ -11,6 +11,8 @@ import edit from './edit';
 import save from './save';
 import icon from './inserter-icon';
 
+import './post-variant.css';
+
 export { edit, save, metadata, icon };
 
 export default {

--- a/resources/js/visual-editor/blocks/post-variant/post-variant.css
+++ b/resources/js/visual-editor/blocks/post-variant/post-variant.css
@@ -1,0 +1,347 @@
+/**
+ * Post Variant grid-span styles (#592).
+ *
+ * Variants can declare per-breakpoint `gridColumnSpan` and `gridRowSpan`
+ * attributes. When the parent Query Loop's post-template renders in
+ * grid layout and a post matches a variant, the QueryInliner stamps
+ * `_resolvedGridSpan` onto the synthetic `core/post-template-item`
+ * wrapper and the renderers emit `ap-post-span-N-{bp}-{columns,row}`
+ * classes for each defined breakpoint.
+ *
+ * The class scheme mirrors `ap-grid-item-span-*` from the standalone
+ * Grid block (grid.css) so authors who know one know the other. Rules
+ * are gated on `.wp-block-post-template.is-layout-grid > li` so spans
+ * never leak into list / stack / flex layouts.
+ *
+ * Two parallel selectors per rule:
+ *
+ *   1. `> .wp-block-post-template-item.ap-post-span-*` — the public
+ *      frontend renderer (Blade / Vue / React) emits the span class
+ *      directly on the `<li>`, so the direct compound selector wins.
+ *   2. `> .wp-block-post:has(.ap-post-span-*)` — the editor canvas
+ *      wraps each iteration in a Gutenberg-shaped `<li class="wp-block-post">`
+ *      and renders the post-variant block as a nested `<div>` that
+ *      carries the span class. The `:has()` selector promotes the
+ *      span up to the `<li>` so the grid actually sees the span.
+ *
+ * Mobile-first cascade: base rules first, then each Tailwind
+ * breakpoint (sm 640, md 768, lg 1024, xl 1280, 2xl 1536) in
+ * ascending min-width order, so a later breakpoint's class overrides
+ * the earlier one for the wider viewport.
+ */
+
+/* === base (no media query) === */
+.wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-1-base-columns,
+.wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-1-base-columns) { grid-column: span 1; }
+.wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-2-base-columns,
+.wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-2-base-columns) { grid-column: span 2; }
+.wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-3-base-columns,
+.wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-3-base-columns) { grid-column: span 3; }
+.wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-4-base-columns,
+.wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-4-base-columns) { grid-column: span 4; }
+.wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-5-base-columns,
+.wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-5-base-columns) { grid-column: span 5; }
+.wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-6-base-columns,
+.wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-6-base-columns) { grid-column: span 6; }
+.wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-7-base-columns,
+.wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-7-base-columns) { grid-column: span 7; }
+.wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-8-base-columns,
+.wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-8-base-columns) { grid-column: span 8; }
+.wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-9-base-columns,
+.wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-9-base-columns) { grid-column: span 9; }
+.wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-10-base-columns,
+.wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-10-base-columns) { grid-column: span 10; }
+.wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-11-base-columns,
+.wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-11-base-columns) { grid-column: span 11; }
+.wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-12-base-columns,
+.wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-12-base-columns) { grid-column: span 12; }
+
+.wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-1-base-row,
+.wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-1-base-row) { grid-row: span 1; }
+.wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-2-base-row,
+.wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-2-base-row) { grid-row: span 2; }
+.wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-3-base-row,
+.wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-3-base-row) { grid-row: span 3; }
+.wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-4-base-row,
+.wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-4-base-row) { grid-row: span 4; }
+.wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-5-base-row,
+.wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-5-base-row) { grid-row: span 5; }
+.wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-6-base-row,
+.wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-6-base-row) { grid-row: span 6; }
+.wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-7-base-row,
+.wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-7-base-row) { grid-row: span 7; }
+.wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-8-base-row,
+.wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-8-base-row) { grid-row: span 8; }
+.wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-9-base-row,
+.wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-9-base-row) { grid-row: span 9; }
+.wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-10-base-row,
+.wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-10-base-row) { grid-row: span 10; }
+.wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-11-base-row,
+.wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-11-base-row) { grid-row: span 11; }
+.wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-12-base-row,
+.wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-12-base-row) { grid-row: span 12; }
+
+/* === sm: 640px === */
+@media (min-width: 640px) {
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-1-sm-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-1-sm-columns) { grid-column: span 1; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-2-sm-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-2-sm-columns) { grid-column: span 2; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-3-sm-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-3-sm-columns) { grid-column: span 3; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-4-sm-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-4-sm-columns) { grid-column: span 4; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-5-sm-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-5-sm-columns) { grid-column: span 5; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-6-sm-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-6-sm-columns) { grid-column: span 6; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-7-sm-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-7-sm-columns) { grid-column: span 7; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-8-sm-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-8-sm-columns) { grid-column: span 8; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-9-sm-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-9-sm-columns) { grid-column: span 9; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-10-sm-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-10-sm-columns) { grid-column: span 10; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-11-sm-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-11-sm-columns) { grid-column: span 11; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-12-sm-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-12-sm-columns) { grid-column: span 12; }
+
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-1-sm-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-1-sm-row) { grid-row: span 1; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-2-sm-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-2-sm-row) { grid-row: span 2; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-3-sm-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-3-sm-row) { grid-row: span 3; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-4-sm-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-4-sm-row) { grid-row: span 4; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-5-sm-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-5-sm-row) { grid-row: span 5; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-6-sm-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-6-sm-row) { grid-row: span 6; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-7-sm-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-7-sm-row) { grid-row: span 7; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-8-sm-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-8-sm-row) { grid-row: span 8; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-9-sm-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-9-sm-row) { grid-row: span 9; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-10-sm-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-10-sm-row) { grid-row: span 10; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-11-sm-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-11-sm-row) { grid-row: span 11; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-12-sm-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-12-sm-row) { grid-row: span 12; }
+}
+
+/* === md: 768px === */
+@media (min-width: 768px) {
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-1-md-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-1-md-columns) { grid-column: span 1; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-2-md-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-2-md-columns) { grid-column: span 2; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-3-md-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-3-md-columns) { grid-column: span 3; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-4-md-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-4-md-columns) { grid-column: span 4; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-5-md-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-5-md-columns) { grid-column: span 5; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-6-md-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-6-md-columns) { grid-column: span 6; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-7-md-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-7-md-columns) { grid-column: span 7; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-8-md-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-8-md-columns) { grid-column: span 8; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-9-md-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-9-md-columns) { grid-column: span 9; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-10-md-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-10-md-columns) { grid-column: span 10; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-11-md-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-11-md-columns) { grid-column: span 11; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-12-md-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-12-md-columns) { grid-column: span 12; }
+
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-1-md-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-1-md-row) { grid-row: span 1; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-2-md-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-2-md-row) { grid-row: span 2; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-3-md-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-3-md-row) { grid-row: span 3; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-4-md-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-4-md-row) { grid-row: span 4; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-5-md-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-5-md-row) { grid-row: span 5; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-6-md-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-6-md-row) { grid-row: span 6; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-7-md-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-7-md-row) { grid-row: span 7; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-8-md-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-8-md-row) { grid-row: span 8; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-9-md-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-9-md-row) { grid-row: span 9; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-10-md-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-10-md-row) { grid-row: span 10; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-11-md-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-11-md-row) { grid-row: span 11; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-12-md-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-12-md-row) { grid-row: span 12; }
+}
+
+/* === lg: 1024px === */
+@media (min-width: 1024px) {
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-1-lg-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-1-lg-columns) { grid-column: span 1; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-2-lg-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-2-lg-columns) { grid-column: span 2; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-3-lg-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-3-lg-columns) { grid-column: span 3; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-4-lg-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-4-lg-columns) { grid-column: span 4; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-5-lg-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-5-lg-columns) { grid-column: span 5; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-6-lg-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-6-lg-columns) { grid-column: span 6; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-7-lg-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-7-lg-columns) { grid-column: span 7; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-8-lg-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-8-lg-columns) { grid-column: span 8; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-9-lg-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-9-lg-columns) { grid-column: span 9; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-10-lg-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-10-lg-columns) { grid-column: span 10; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-11-lg-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-11-lg-columns) { grid-column: span 11; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-12-lg-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-12-lg-columns) { grid-column: span 12; }
+
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-1-lg-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-1-lg-row) { grid-row: span 1; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-2-lg-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-2-lg-row) { grid-row: span 2; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-3-lg-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-3-lg-row) { grid-row: span 3; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-4-lg-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-4-lg-row) { grid-row: span 4; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-5-lg-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-5-lg-row) { grid-row: span 5; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-6-lg-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-6-lg-row) { grid-row: span 6; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-7-lg-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-7-lg-row) { grid-row: span 7; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-8-lg-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-8-lg-row) { grid-row: span 8; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-9-lg-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-9-lg-row) { grid-row: span 9; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-10-lg-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-10-lg-row) { grid-row: span 10; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-11-lg-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-11-lg-row) { grid-row: span 11; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-12-lg-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-12-lg-row) { grid-row: span 12; }
+}
+
+/* === xl: 1280px === */
+@media (min-width: 1280px) {
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-1-xl-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-1-xl-columns) { grid-column: span 1; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-2-xl-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-2-xl-columns) { grid-column: span 2; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-3-xl-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-3-xl-columns) { grid-column: span 3; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-4-xl-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-4-xl-columns) { grid-column: span 4; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-5-xl-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-5-xl-columns) { grid-column: span 5; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-6-xl-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-6-xl-columns) { grid-column: span 6; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-7-xl-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-7-xl-columns) { grid-column: span 7; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-8-xl-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-8-xl-columns) { grid-column: span 8; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-9-xl-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-9-xl-columns) { grid-column: span 9; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-10-xl-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-10-xl-columns) { grid-column: span 10; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-11-xl-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-11-xl-columns) { grid-column: span 11; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-12-xl-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-12-xl-columns) { grid-column: span 12; }
+
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-1-xl-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-1-xl-row) { grid-row: span 1; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-2-xl-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-2-xl-row) { grid-row: span 2; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-3-xl-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-3-xl-row) { grid-row: span 3; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-4-xl-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-4-xl-row) { grid-row: span 4; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-5-xl-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-5-xl-row) { grid-row: span 5; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-6-xl-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-6-xl-row) { grid-row: span 6; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-7-xl-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-7-xl-row) { grid-row: span 7; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-8-xl-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-8-xl-row) { grid-row: span 8; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-9-xl-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-9-xl-row) { grid-row: span 9; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-10-xl-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-10-xl-row) { grid-row: span 10; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-11-xl-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-11-xl-row) { grid-row: span 11; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-12-xl-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-12-xl-row) { grid-row: span 12; }
+}
+
+/* === 2xl: 1536px === */
+@media (min-width: 1536px) {
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-1-2xl-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-1-2xl-columns) { grid-column: span 1; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-2-2xl-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-2-2xl-columns) { grid-column: span 2; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-3-2xl-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-3-2xl-columns) { grid-column: span 3; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-4-2xl-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-4-2xl-columns) { grid-column: span 4; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-5-2xl-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-5-2xl-columns) { grid-column: span 5; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-6-2xl-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-6-2xl-columns) { grid-column: span 6; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-7-2xl-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-7-2xl-columns) { grid-column: span 7; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-8-2xl-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-8-2xl-columns) { grid-column: span 8; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-9-2xl-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-9-2xl-columns) { grid-column: span 9; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-10-2xl-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-10-2xl-columns) { grid-column: span 10; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-11-2xl-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-11-2xl-columns) { grid-column: span 11; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-12-2xl-columns,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-12-2xl-columns) { grid-column: span 12; }
+
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-1-2xl-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-1-2xl-row) { grid-row: span 1; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-2-2xl-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-2-2xl-row) { grid-row: span 2; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-3-2xl-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-3-2xl-row) { grid-row: span 3; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-4-2xl-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-4-2xl-row) { grid-row: span 4; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-5-2xl-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-5-2xl-row) { grid-row: span 5; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-6-2xl-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-6-2xl-row) { grid-row: span 6; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-7-2xl-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-7-2xl-row) { grid-row: span 7; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-8-2xl-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-8-2xl-row) { grid-row: span 8; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-9-2xl-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-9-2xl-row) { grid-row: span 9; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-10-2xl-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-10-2xl-row) { grid-row: span 10; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-11-2xl-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-11-2xl-row) { grid-row: span 11; }
+    .wp-block-post-template.is-layout-grid > .wp-block-post-template-item.ap-post-span-12-2xl-row,
+    .wp-block-post-template.is-layout-grid > .wp-block-post:has(.ap-post-span-12-2xl-row) { grid-row: span 12; }
+}

--- a/src/Resources/QueryInliner.php
+++ b/src/Resources/QueryInliner.php
@@ -625,6 +625,9 @@ class QueryInliner
 				? $postTemplateAttrs['_compiledVariantMap']
 				: [];
 
+		$postTemplateIsGrid = isset( $postTemplateAttrs['layout'] )
+			&& 'grid' === $postTemplateAttrs['layout'];
+
 		$resultsList = is_array( $results ) ? array_values( $results ) : iterator_to_array( $results, false );
 
 		$this->variantResolver->prime( $variantBlocks, $compiledMap, count( $resultsList ) );
@@ -662,17 +665,31 @@ class QueryInliner
 				);
 			}
 
+			$itemAttributes = [
+				'postId'    => $postId,
+				'className' => 'post-' . $postId
+				. ' post'
+				. ( null !== $variantOrder ? ' is-variant' : '' )
+				. ' type-' . ( isset( $post->post_type ) ? (string) $post->post_type : ( isset( $post->type ) ? (string) $post->type : 'post' ) )
+				. ' status-' . ( isset( $post->status ) && is_object( $post->status ) && isset( $post->status->value ) ? (string) $post->status->value : ( isset( $post->status ) && is_string( $post->status ) ? $post->status : 'publish' ) ),
+			];
+
+			if ( null !== $variantOrder && $postTemplateIsGrid ) {
+				$variantBlock = $variantBlocks[ $variantOrder ] ?? null;
+
+				if ( is_array( $variantBlock ) ) {
+					$spans = $this->resolveVariantSpans( $variantBlock );
+
+					if ( null !== $spans ) {
+						$itemAttributes['_resolvedGridSpan'] = $spans;
+					}
+				}
+			}
+
 			$expandedIterations[] = [
 				'clientId'    => 'pti-' . $postId,
 				'name'        => 'core/post-template-item',
-				'attributes'  => [
-					'postId'    => $postId,
-					'className' => 'post-' . $postId
-					. ' post'
-					. ( null !== $variantOrder ? ' is-variant' : '' )
-					. ' type-' . ( isset( $post->post_type ) ? (string) $post->post_type : ( isset( $post->type ) ? (string) $post->type : 'post' ) )
-					. ' status-' . ( isset( $post->status ) && is_object( $post->status ) && isset( $post->status->value ) ? (string) $post->status->value : ( isset( $post->status ) && is_string( $post->status ) ? $post->status : 'publish' ) ),
-				],
+				'attributes'  => $itemAttributes,
 				'innerBlocks' => $iterationBlocks,
 			];
 		}
@@ -1017,6 +1034,109 @@ class QueryInliner
 				'_resolvedItems' => count( $results ),
 			] ),
 		] );
+	}
+
+	/**
+	 * Read the matched variant's grid span attributes — both base
+	 * values and any per-breakpoint responsive overrides — and
+	 * normalize them into a flat shape the renderers can consume
+	 * without touching the variant block tree directly.
+	 *
+	 * Returns `null` when the variant carries no span data (defaults
+	 * 1×1 with no breakpoint overrides) so the renderers can skip the
+	 * extra class emission for the common case.
+	 *
+	 * @param  array<string, mixed>  $variantBlock
+	 *
+	 * @return array{
+	 *     columns: array<string, int>,
+	 *     rows: array<string, int>
+	 * }|null
+	 */
+	protected function resolveVariantSpans( array $variantBlock ): ?array
+	{
+		$attributes = isset( $variantBlock['attributes'] ) && is_array( $variantBlock['attributes'] )
+			? $variantBlock['attributes']
+			: [];
+
+		$baseColumns = $this->clampSpanValue( $attributes['gridColumnSpan'] ?? null, 1 );
+		$baseRows    = $this->clampSpanValue( $attributes['gridRowSpan'] ?? null, 1 );
+
+		$columns = [ 'base' => $baseColumns ];
+		$rows    = [ 'base' => $baseRows ];
+
+		$responsive = isset( $attributes['responsive'] ) && is_array( $attributes['responsive'] )
+			? $attributes['responsive']
+			: [];
+
+		$columnOverrides = isset( $responsive['gridColumnSpan'] ) && is_array( $responsive['gridColumnSpan'] )
+			? $responsive['gridColumnSpan']
+			: [];
+
+		foreach ( $columnOverrides as $bp => $value ) {
+			if ( ! is_string( $bp ) || 'base' === $bp ) {
+				continue;
+			}
+
+			if ( null === $value ) {
+				continue;
+			}
+
+			$columns[ $bp ] = $this->clampSpanValue( $value, $baseColumns );
+		}
+
+		$rowOverrides = isset( $responsive['gridRowSpan'] ) && is_array( $responsive['gridRowSpan'] )
+			? $responsive['gridRowSpan']
+			: [];
+
+		foreach ( $rowOverrides as $bp => $value ) {
+			if ( ! is_string( $bp ) || 'base' === $bp ) {
+				continue;
+			}
+
+			if ( null === $value ) {
+				continue;
+			}
+
+			$rows[ $bp ] = $this->clampSpanValue( $value, $baseRows );
+		}
+
+		$hasOverrides = count( $columns ) > 1 || count( $rows ) > 1;
+
+		if ( 1 === $baseColumns && 1 === $baseRows && ! $hasOverrides ) {
+			return null;
+		}
+
+		return [
+			'columns' => $columns,
+			'rows'    => $rows,
+		];
+	}
+
+	/**
+	 * Clamp a single span value to the renderer's supported 1..12 range
+	 * so a malformed save never produces a CSS class that has no
+	 * matching rule in the stylesheet.
+	 *
+	 * @param  mixed  $value
+	 */
+	protected function clampSpanValue( mixed $value, int $fallback ): int
+	{
+		if ( ! is_numeric( $value ) ) {
+			return $fallback;
+		}
+
+		$int = (int) $value;
+
+		if ( $int < 1 ) {
+			return 1;
+		}
+
+		if ( $int > 12 ) {
+			return 12;
+		}
+
+		return $int;
 	}
 
 	/**

--- a/src/Resources/QueryInliner.php
+++ b/src/Resources/QueryInliner.php
@@ -625,8 +625,7 @@ class QueryInliner
 				? $postTemplateAttrs['_compiledVariantMap']
 				: [];
 
-		$postTemplateIsGrid = isset( $postTemplateAttrs['layout'] )
-			&& 'grid' === $postTemplateAttrs['layout'];
+		$postTemplateIsGrid = $this->postTemplateLayoutIsGrid( $postTemplateAttrs );
 
 		$resultsList = is_array( $results ) ? array_values( $results ) : iterator_to_array( $results, false );
 
@@ -1034,6 +1033,34 @@ class QueryInliner
 				'_resolvedItems' => count( $results ),
 			] ),
 		] );
+	}
+
+	/**
+	 * Detect whether a post-template's saved attributes describe a
+	 * grid layout. Three shapes are supported so the inliner stays
+	 * tolerant of variation across the ArtisanPack post-template
+	 * (plain `layout` string), upstream `core/post-template` mirrors
+	 * (object-form `layout = ['type' => 'grid']`), and Gutenberg's
+	 * generic block-supports layout system (sibling `layoutType`
+	 * attribute).
+	 *
+	 * @param  array<string, mixed>  $postTemplateAttrs
+	 */
+	protected function postTemplateLayoutIsGrid( array $postTemplateAttrs ): bool
+	{
+		$layout = $postTemplateAttrs['layout'] ?? null;
+
+		if ( is_string( $layout ) && 'grid' === $layout ) {
+			return true;
+		}
+
+		if ( is_array( $layout ) && isset( $layout['type'] ) && 'grid' === $layout['type'] ) {
+			return true;
+		}
+
+		$layoutType = $postTemplateAttrs['layoutType'] ?? null;
+
+		return is_string( $layoutType ) && 'grid' === $layoutType;
 	}
 
 	/**

--- a/tests/Unit/VisualEditor/Resources/QueryInlinerVariantSpansTest.php
+++ b/tests/Unit/VisualEditor/Resources/QueryInlinerVariantSpansTest.php
@@ -67,6 +67,23 @@ function queryWithLayout( array $baseInner, array $variants, string $layout = 'l
 	];
 }
 
+function queryWithPostTemplateAttrs( array $baseInner, array $variants, array $postTemplateAttrs ): array
+{
+	$postTemplateChildren = array_merge( $baseInner, $variants );
+
+	return [
+		'name'        => 'core/query',
+		'attributes'  => [ 'query' => [ 'postType' => 'post', 'perPage' => 5 ] ],
+		'innerBlocks' => [
+			[
+				'name'        => 'core/post-template',
+				'attributes'  => $postTemplateAttrs,
+				'innerBlocks' => $postTemplateChildren,
+			],
+		],
+	];
+}
+
 function variantSpanPostFixture( int $id, string $title, array $extras = [] ): object
 {
 	$post                    = new stdClass();
@@ -211,6 +228,49 @@ it( 'clamps span values into the renderer-supported 1..12 range', function () {
 	expect( $items[0]['attributes']['_resolvedGridSpan'] )->toEqual( [
 		'columns' => [ 'base' => 1 ],
 		'rows'    => [ 'base' => 12 ],
+	] );
+} );
+
+it( 'detects grid layout from the object-form layout attribute and the layoutType sibling', function () {
+	$this->fake->setItems( [
+		variantSpanPostFixture( 1, 'Hero' ),
+	] );
+
+	$base    = [ [ 'name' => 'core/post-title', 'attributes' => [], 'innerBlocks' => [] ] ];
+	$variant = variantBlockWithSpans(
+		[ 'kind' => 'position', 'value' => 'first' ],
+		[ [ 'name' => 'core/post-excerpt', 'attributes' => [], 'innerBlocks' => [] ] ],
+		2,
+		2
+	);
+
+	// Hosts that wire the post-template through Gutenberg's
+	// block-supports layout system save the layout as either a nested
+	// object (`layout = { type: 'grid' }`) or as a sibling
+	// `layoutType` attribute. The inliner must recognise both shapes
+	// as grid, in addition to the canonical string form.
+	$objectFormTree = queryWithPostTemplateAttrs(
+		$base,
+		[ $variant ],
+		[ 'layout' => [ 'type' => 'grid', 'columns' => 3 ] ]
+	);
+
+	$objectFormItems = $this->inliner->inline( [ $objectFormTree ] )[0]['innerBlocks'][0]['innerBlocks'];
+	expect( $objectFormItems[0]['attributes']['_resolvedGridSpan'] )->toEqual( [
+		'columns' => [ 'base' => 2 ],
+		'rows'    => [ 'base' => 2 ],
+	] );
+
+	$layoutTypeTree = queryWithPostTemplateAttrs(
+		$base,
+		[ $variant ],
+		[ 'layoutType' => 'grid' ]
+	);
+
+	$layoutTypeItems = $this->inliner->inline( [ $layoutTypeTree ] )[0]['innerBlocks'][0]['innerBlocks'];
+	expect( $layoutTypeItems[0]['attributes']['_resolvedGridSpan'] )->toEqual( [
+		'columns' => [ 'base' => 2 ],
+		'rows'    => [ 'base' => 2 ],
 	] );
 } );
 

--- a/tests/Unit/VisualEditor/Resources/QueryInlinerVariantSpansTest.php
+++ b/tests/Unit/VisualEditor/Resources/QueryInlinerVariantSpansTest.php
@@ -1,0 +1,249 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Resources\PostResolver;
+use ArtisanPackUI\VisualEditor\Resources\QueryInliner;
+use ArtisanPackUI\VisualEditor\Services\QueryResolverContract;
+use Tests\Fixtures\FakeQueryResolver;
+
+/**
+ * Issue #592 — variable column / row spans on post-variants.
+ *
+ * Pins the `_resolvedGridSpan` stamping rules on the synthetic
+ * `core/post-template-item` wrapper: spans only attach when (a) a
+ * variant matched the post and (b) the parent post-template's layout
+ * is "grid". The precedence rule from #591 is re-asserted here for the
+ * span data so a higher-precedence variant's spans win over a
+ * lower-precedence variant's spans when both could match.
+ */
+
+function variantBlockWithSpans(
+	array $matcher,
+	array $innerBlocks,
+	?int $columnSpan = null,
+	?int $rowSpan = null,
+	?array $responsive = null,
+	int $priority = 10
+): array {
+	$attributes = [
+		'matcher'  => $matcher,
+		'priority' => $priority,
+	];
+
+	if ( null !== $columnSpan ) {
+		$attributes['gridColumnSpan'] = $columnSpan;
+	}
+
+	if ( null !== $rowSpan ) {
+		$attributes['gridRowSpan'] = $rowSpan;
+	}
+
+	if ( null !== $responsive ) {
+		$attributes['responsive'] = $responsive;
+	}
+
+	return [
+		'name'        => 'artisanpack/post-variant',
+		'attributes'  => $attributes,
+		'innerBlocks' => $innerBlocks,
+	];
+}
+
+function queryWithLayout( array $baseInner, array $variants, string $layout = 'list' ): array
+{
+	$postTemplateChildren = array_merge( $baseInner, $variants );
+
+	return [
+		'name'        => 'core/query',
+		'attributes'  => [ 'query' => [ 'postType' => 'post', 'perPage' => 5 ] ],
+		'innerBlocks' => [
+			[
+				'name'        => 'core/post-template',
+				'attributes'  => [ 'layout' => $layout ],
+				'innerBlocks' => $postTemplateChildren,
+			],
+		],
+	];
+}
+
+function variantSpanPostFixture( int $id, string $title, array $extras = [] ): object
+{
+	$post                    = new stdClass();
+	$post->id                = $id;
+	$post->title             = $title;
+	$post->content           = "<p>{$title}</p>";
+	$post->permalink         = "/posts/{$id}";
+	$post->author            = null;
+	$post->published_at      = null;
+	$post->updated_at        = null;
+	$post->featured_image_id = null;
+
+	foreach ( $extras as $key => $value ) {
+		$post->{$key} = $value;
+	}
+
+	return $post;
+}
+
+beforeEach( function (): void {
+	$this->fake = new FakeQueryResolver();
+	$this->app->instance( QueryResolverContract::class, $this->fake );
+
+	$this->inliner = new QueryInliner( $this->app, new PostResolver() );
+} );
+
+it( 'stamps _resolvedGridSpan on the iteration wrapper when the variant matched and the layout is grid', function () {
+	$this->fake->setItems( [
+		variantSpanPostFixture( 1, 'Hero' ),
+		variantSpanPostFixture( 2, 'Listed' ),
+	] );
+
+	$base    = [ [ 'name' => 'core/post-title', 'attributes' => [], 'innerBlocks' => [] ] ];
+	$variant = variantBlockWithSpans(
+		[ 'kind' => 'position', 'value' => 'first' ],
+		[ [ 'name' => 'core/post-excerpt', 'attributes' => [], 'innerBlocks' => [] ] ],
+		2,
+		2
+	);
+
+	$inlined = $this->inliner->inline( [ queryWithLayout( $base, [ $variant ], 'grid' ) ] );
+	$items   = $inlined[0]['innerBlocks'][0]['innerBlocks'];
+
+	expect( $items[0]['attributes']['_resolvedGridSpan'] )->toEqual( [
+		'columns' => [ 'base' => 2 ],
+		'rows'    => [ 'base' => 2 ],
+	] );
+
+	// Non-matched item gets no span stamp.
+	expect( array_key_exists( '_resolvedGridSpan', $items[1]['attributes'] ) )->toBeFalse();
+} );
+
+it( 'does not stamp _resolvedGridSpan when the parent post-template layout is not grid', function () {
+	$this->fake->setItems( [
+		variantSpanPostFixture( 1, 'Hero' ),
+	] );
+
+	$base    = [ [ 'name' => 'core/post-title', 'attributes' => [], 'innerBlocks' => [] ] ];
+	$variant = variantBlockWithSpans(
+		[ 'kind' => 'position', 'value' => 'first' ],
+		[ [ 'name' => 'core/post-excerpt', 'attributes' => [], 'innerBlocks' => [] ] ],
+		2,
+		2
+	);
+
+	foreach ( [ 'list', 'flex', 'stack' ] as $layout ) {
+		$inlined = $this->inliner->inline( [ queryWithLayout( $base, [ $variant ], $layout ) ] );
+		$items   = $inlined[0]['innerBlocks'][0]['innerBlocks'];
+
+		expect( array_key_exists( '_resolvedGridSpan', $items[0]['attributes'] ) )
+			->toBeFalse( "layout {$layout} must not produce a span stamp" );
+	}
+} );
+
+it( 'omits _resolvedGridSpan when the variant has the default 1x1 span and no breakpoint overrides', function () {
+	$this->fake->setItems( [
+		variantSpanPostFixture( 1, 'Hero' ),
+	] );
+
+	$base    = [ [ 'name' => 'core/post-title', 'attributes' => [], 'innerBlocks' => [] ] ];
+	$variant = variantBlockWithSpans(
+		[ 'kind' => 'position', 'value' => 'first' ],
+		[ [ 'name' => 'core/post-excerpt', 'attributes' => [], 'innerBlocks' => [] ] ],
+		1,
+		1
+	);
+
+	$inlined = $this->inliner->inline( [ queryWithLayout( $base, [ $variant ], 'grid' ) ] );
+	$items   = $inlined[0]['innerBlocks'][0]['innerBlocks'];
+
+	// The 1x1 case is a no-op for the renderer; skip the stamp so
+	// the CSS bundle stays the only source of span emission.
+	expect( array_key_exists( '_resolvedGridSpan', $items[0]['attributes'] ) )->toBeFalse();
+} );
+
+it( 'merges base and per-breakpoint responsive overrides into the resolved span shape', function () {
+	$this->fake->setItems( [
+		variantSpanPostFixture( 1, 'Hero' ),
+	] );
+
+	$base    = [ [ 'name' => 'core/post-title', 'attributes' => [], 'innerBlocks' => [] ] ];
+	$variant = variantBlockWithSpans(
+		[ 'kind' => 'position', 'value' => 'first' ],
+		[ [ 'name' => 'core/post-excerpt', 'attributes' => [], 'innerBlocks' => [] ] ],
+		2,
+		2,
+		[
+			'gridColumnSpan' => [ 'md' => 3, 'lg' => 4 ],
+			'gridRowSpan'    => [ 'md' => 1 ],
+		]
+	);
+
+	$inlined = $this->inliner->inline( [ queryWithLayout( $base, [ $variant ], 'grid' ) ] );
+	$items   = $inlined[0]['innerBlocks'][0]['innerBlocks'];
+
+	expect( $items[0]['attributes']['_resolvedGridSpan'] )->toEqual( [
+		'columns' => [ 'base' => 2, 'md' => 3, 'lg' => 4 ],
+		'rows'    => [ 'base' => 2, 'md' => 1 ],
+	] );
+} );
+
+it( 'clamps span values into the renderer-supported 1..12 range', function () {
+	$this->fake->setItems( [
+		variantSpanPostFixture( 1, 'Hero' ),
+	] );
+
+	$base    = [ [ 'name' => 'core/post-title', 'attributes' => [], 'innerBlocks' => [] ] ];
+	$variant = variantBlockWithSpans(
+		[ 'kind' => 'position', 'value' => 'first' ],
+		[ [ 'name' => 'core/post-excerpt', 'attributes' => [], 'innerBlocks' => [] ] ],
+		// 0 -> 1, 99 -> 12 via clampSpanValue().
+		0,
+		99
+	);
+
+	$inlined = $this->inliner->inline( [ queryWithLayout( $base, [ $variant ], 'grid' ) ] );
+	$items   = $inlined[0]['innerBlocks'][0]['innerBlocks'];
+
+	// Note: when the clamped values land back at the 1×1 default with
+	// no breakpoint overrides, the inliner skips the stamp. We use
+	// row=99 to ensure the stamp survives.
+	expect( $items[0]['attributes']['_resolvedGridSpan'] )->toEqual( [
+		'columns' => [ 'base' => 1 ],
+		'rows'    => [ 'base' => 12 ],
+	] );
+} );
+
+it( 'honors the variant precedence cascade when two variants compete on spans', function () {
+	$this->fake->setItems( [
+		variantSpanPostFixture( 1, 'Sticky Top', [ 'sticky' => true ] ),
+	] );
+
+	$base = [ [ 'name' => 'core/post-title', 'attributes' => [], 'innerBlocks' => [] ] ];
+
+	$positionVariant = variantBlockWithSpans(
+		[ 'kind' => 'position', 'value' => 'first' ],
+		[ [ 'name' => 'core/post-excerpt', 'attributes' => [], 'innerBlocks' => [] ] ],
+		4,
+		2
+	);
+	$metaVariant = variantBlockWithSpans(
+		[ 'kind' => 'meta', 'value' => 'sticky' ],
+		[ [ 'name' => 'core/post-content', 'attributes' => [], 'innerBlocks' => [] ] ],
+		2,
+		1
+	);
+
+	// Both variants match the first post. Position outranks meta, so
+	// the position variant's 4x2 span must win.
+	$inlined = $this->inliner->inline( [
+		queryWithLayout( $base, [ $metaVariant, $positionVariant ], 'grid' ),
+	] );
+
+	$items = $inlined[0]['innerBlocks'][0]['innerBlocks'];
+
+	expect( $items[0]['attributes']['_resolvedGridSpan'] )->toEqual( [
+		'columns' => [ 'base' => 4 ],
+		'rows'    => [ 'base' => 2 ],
+	] );
+} );


### PR DESCRIPTION
## Description

Adds `gridColumnSpan` / `gridRowSpan` attributes (default 1) to `artisanpack/post-variant`, both opting into the `artisanpackResponsive` cascade for per-breakpoint values. When the parent Query Loop's post-template renders in grid layout and a post matches a variant, the spans propagate to the iteration `<li>` so authors can build magazine-style layouts (e.g. lead story spans 2×2, sticky posts span 2×1) without leaving the post-variant system from #591.

**Closes:** #592

## Type of Change

- [x] New feature (adds new functionality)
- [x] Enhancement (improves existing functionality)

## Related Issue

**Issue:** #592

## Motivation and Context

Before this change every post in a Query Loop's grid layout occupied a 1×1 cell — there was no way to say "make the first post 2×2 and the second post 2×1." The standalone `artisanpack/grid` block already supports the same expressiveness via `artisanpack/grid-item`. This issue brings parity to the Query Loop, keeping a single mental model: any per-post difference is just a variant attribute, and spans are one more thing a variant can change.

## Changes Made

- **Block schema**: `artisanpack/post-variant` declares `gridColumnSpan` / `gridRowSpan` (default 1) and lists both in `supports.artisanpackResponsive.attributes`.
- **Context plumbing**: post-template now `providesContext` for its `layout` / `columns` attributes under `artisanpack/postTemplateLayout` / `Columns` so the variant inspector can gate the new "Grid Spans" panel on the parent template's grid state and clamp the column slider to its column count.
- **Editor inspector**: new "Grid Spans" PanelBody on the post-variant block, visible only when the parent post-template is in grid layout. Column span clamps to `1..numColumns`; row span clamps to `1..12` with a notice above 4.
- **Layout parity**: post-template editor switched from upstream `is-flex-container` to `is-layout-grid` so the editor canvas and Blade frontend share the same CSS-grid layout. New `post-template.css` defines `grid-template-columns: repeat(N, …)` for `is-layout-grid.columns-N` (the layout baseline only ships `display: grid`).
- **Server pipeline**: `QueryInliner` stamps a normalised `_resolvedGridSpan = { columns, rows }` on the synthetic `core/post-template-item` wrapper when (a) a variant matched and (b) the post-template's `layout === 'grid'`. Defaults of 1×1 with no breakpoint overrides skip the stamp entirely.
- **Renderers**: Blade / Vue / React `PostTemplateItem` translate `_resolvedGridSpan` into `ap-post-span-N-{bp}-{columns,row}` classes via a shared `postTemplateItemSpanClasses()` helper (Blade side gates on the runtime `BreakpointRegistry`).
- **CSS**: `post-variant.css` carries the span rules with two parallel selectors per breakpoint — a direct compound match for the frontend `<li.wp-block-post-template-item>` and a `:has()`-based match for the editor canvas's `<li.wp-block-post>` (where the span class is nested on the variant wrapper, not on the `<li>` itself).
- **Asset wiring**: `BlocksStylesComponent` ships `post-template.css` and `post-variant.css` as new linked stylesheets, with helpful comments above each `<link>` explaining the role.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS 25.5.0 (Darwin)
- Browser (if applicable): Chrome (canvas + frontend exercised by hand)
- PHP Version: 8.4.3
- Project Version: branched from release/1.2

**Tests Performed:**
1. Manual: created a Query Loop in `~/Herd/artisanpack-ui-dev`, switched the post-template to grid, added a position:first post-variant, set column span 2 / row span 2. Verified the variant's inspector showed the new Grid Spans panel, that it disappeared when toggling the post-template back to list, that the column slider capped at the parent's column count, and that both editor canvas and rendered frontend showed the first post spanning 2×2 across a 3-column grid.
2. PHP: `./vendor/bin/pest --compact` → 1315 passed, 1 skipped (pre-existing hooks skip).
3. JS: `npx vitest run` → 2223 passed, 258 files.
4. Renderer parity: `npm run verify:parity` → clean.
5. CodeRabbit CLI (`cr review --base release/1.2 --agent`) — 1 minor finding (request to add JSON-schema `min`/`max` to block attribute definitions); skipped to stay consistent with the existing `artisanpack/grid-item` attribute precedent, given that clamping is already enforced in the editor, the inliner, and the renderers. Second pass returned 0 findings.

## Accessibility Tests Run

- [x] Keyboard navigation tested
- [ ] Screen reader tested
- [ ] Color contrast verified
- [ ] ARIA labels checked

**Details:**

Inspector controls are standard `@wordpress/components` `RangeControl`s, which are already keyboard-navigable and screen-reader-labelled. No new custom UI was introduced. The visible markup change is purely class-based — the rendered semantics (`<ul>` + `<li>` with `id="post-N"`) are unchanged from the existing post-template family.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:**

- `tests/Unit/VisualEditor/Resources/QueryInlinerVariantSpansTest.php` — 6 cases covering the stamp gating (grid layout only), the omitted-stamp shortcut for 1×1 defaults, base + responsive merging, clamping to 1..12, and the variant precedence cascade for spans.
- `packages/visual-editor-renderer-blade/tests/Feature/PostVariantGridSpansRenderTest.php` — 3 end-to-end render tests asserting the right class set on the rendered `<li>` (or its absence on non-grid layouts), including per-breakpoint overrides.
- `resources/js/visual-editor/blocks/__tests__/post-variant-grid-spans.test.ts` — 9 cases pinning the block.json shape and renderer-parity helper output between Vue and React.

## Documentation

- [x] Inline code documentation added
- [ ] README updated
- [ ] Wiki updated
- [ ] API documentation updated

**Documentation details:**

Each new file carries a header docblock explaining its role (post-template grid container vs. post-variant span overrides; the two-selector pattern for editor / frontend markup). Resource-level PHPDoc on `QueryInliner::resolveVariantSpans()` documents the normalisation rules and the 1×1 short-circuit.

## Screenshots

_See acceptance demo on the artisanpack-ui-dev app — a position:first variant set to 2 cols × 2 rows in a 3-column grid renders as the lead cell across both editor canvas and frontend output._

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted (no .php-cs-fixer config at package level — manual style matched)
- [x] Accessibility tests completed (see above)
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added responsive grid styling for post templates (supports 1–6 columns) and reset behavior for grid items.
  * Added responsive grid span controls to post variants, enabling per-breakpoint column and row spanning when the post template is in grid layout.
* **Enhancements**
  * Post-template items now apply span-aware CSS classes across Blade, React, and Vue renderers, with validation and clamping to supported ranges.
  * Updated editor UI and block context to drive grid-span rendering consistently.
* **Tests**
  * Added end-to-end and unit test coverage for responsive grid span class emissions and variant precedence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->