### PR TITLE
feat: masonry layout option for post-template + grid blocks (#593)

### DIFF
--- a/packages/visual-editor-renderer-blade/resources/assets/frontend/masonry-fallback.js
+++ b/packages/visual-editor-renderer-blade/resources/assets/frontend/masonry-fallback.js
@@ -1,0 +1,342 @@
+/**
+ * Masonry fallback bootstrap (#593).
+ *
+ * Loaded on the public frontend via `<x-ve-blocks-styles />`. Walks the
+ * page for wrappers carrying `.is-layout-masonry` or `.ap-grid.ap-grid-
+ * layout-masonry` and initialises the shortest-column-first packing
+ * routine on each. The routine itself is renderer-agnostic and lives
+ * in the editor source at `resources/js/visual-editor/blocks/_shared/
+ * masonry/fallback.ts` — this file is a JS port of that logic so the
+ * Blade renderer can ship it as a plain script without a build step.
+ *
+ * Native CSS Grid masonry is detected once and the routine no-ops when
+ * native support is present.
+ *
+ * The script attaches a controller to each container under
+ * `el.__apMasonryController` so callers (Livewire hosts, SPA hosts) can
+ * call `relayout()` / `destroy()` programmatically.
+ */
+(function () {
+    'use strict';
+
+    var ITEM_CLASS = 'ap-masonry-item';
+    var WRAPPER_CLASS = 'ap-masonry-js-fallback';
+
+    function supportsNative() {
+        if (typeof window === 'undefined' || typeof window.CSS === 'undefined') {
+            return false;
+        }
+        if (typeof window.__apMasonrySupports === 'boolean') {
+            return window.__apMasonrySupports;
+        }
+        var ok = false;
+        try {
+            ok = window.CSS.supports('grid-template-rows', 'masonry');
+        } catch (err) {
+            ok = false;
+        }
+        window.__apMasonrySupports = ok;
+        return ok;
+    }
+
+    function clampColumns(value, fallback) {
+        if (typeof value !== 'number' || !isFinite(value)) {
+            return fallback;
+        }
+        var truncated = Math.trunc(value);
+        if (truncated < 1) return 1;
+        if (truncated > 12) return 12;
+        return truncated;
+    }
+
+    function readColumnsFromAttr(container, fallback) {
+        var attr = container.getAttribute('data-ap-cols');
+        if (attr === null || attr === '') {
+            return fallback;
+        }
+        var parsed = Number(attr);
+        return clampColumns(parsed, fallback);
+    }
+
+    function readItemSpan(el, maxColumns) {
+        var dataAttr = el.getAttribute('data-ap-col-span');
+        if (dataAttr !== null) {
+            var parsed = Number(dataAttr);
+            if (isFinite(parsed)) {
+                return Math.min(maxColumns, Math.max(1, Math.trunc(parsed)));
+            }
+        }
+        for (var span = maxColumns; span >= 2; span -= 1) {
+            if (el.classList.contains('ap-grid-item-span-' + span + '-base-columns')) {
+                return span;
+            }
+        }
+        return 1;
+    }
+
+    function readGapPx(container) {
+        var computed = window.getComputedStyle(container);
+        var raw = computed.rowGap || computed.gap || '0';
+        var parsed = parseFloat(raw);
+        return isFinite(parsed) ? Math.max(0, parsed) : 0;
+    }
+
+    function collectItems(container) {
+        var items = [];
+        var children = container.children;
+        for (var i = 0; i < children.length; i += 1) {
+            if (children[i] instanceof HTMLElement) {
+                items.push(children[i]);
+            }
+        }
+        return items;
+    }
+
+    function snapshotStyle(el) {
+        return {
+            position: el.style.position,
+            top: el.style.top,
+            left: el.style.left,
+            width: el.style.width,
+            boxSizing: el.style.boxSizing,
+        };
+    }
+
+    function restoreStyle(el, prev) {
+        el.style.position = prev.position;
+        el.style.top = prev.top;
+        el.style.left = prev.left;
+        el.style.width = prev.width;
+        el.style.boxSizing = prev.boxSizing;
+        el.classList.remove(ITEM_CLASS);
+    }
+
+    function findSlot(columnHeights, span) {
+        if (span >= columnHeights.length) return 0;
+        var bestSlot = 0;
+        var bestMax = Number.POSITIVE_INFINITY;
+        var lastStart = columnHeights.length - span;
+        for (var start = 0; start <= lastStart; start += 1) {
+            var windowMax = -Infinity;
+            for (var i = start; i < start + span; i += 1) {
+                if (columnHeights[i] > windowMax) {
+                    windowMax = columnHeights[i];
+                }
+            }
+            if (windowMax < bestMax) {
+                bestMax = windowMax;
+                bestSlot = start;
+            }
+        }
+        return bestSlot;
+    }
+
+    function sliceMaxHeight(columnHeights, slot, span) {
+        var max = 0;
+        for (var i = slot; i < slot + span; i += 1) {
+            if (columnHeights[i] > max) {
+                max = columnHeights[i];
+            }
+        }
+        return max;
+    }
+
+    function initMasonry(container, forceFallback) {
+        if (!forceFallback && supportsNative()) {
+            return { relayout: function () {}, destroy: function () {} };
+        }
+
+        var destroyed = false;
+        var placements = [];
+        var initialWrapperStyle = {
+            position: container.style.position,
+            height: container.style.height,
+        };
+        var classesAdded = [];
+        if (!container.classList.contains(WRAPPER_CLASS)) {
+            container.classList.add(WRAPPER_CLASS);
+            classesAdded.push(WRAPPER_CLASS);
+        }
+
+        function trackPlacement(el, span) {
+            var placement = { el: el, span: span, prevStyle: snapshotStyle(el) };
+            if (!el.classList.contains(ITEM_CLASS)) {
+                el.classList.add(ITEM_CLASS);
+            }
+            return placement;
+        }
+
+        function relayout() {
+            if (destroyed) return;
+            var items = collectItems(container);
+            var columns = clampColumns(readColumnsFromAttr(container, 3), 3);
+            var gap = readGapPx(container);
+
+            var liveSet = new Set(items);
+            for (var p = 0; p < placements.length; p += 1) {
+                if (!liveSet.has(placements[p].el)) {
+                    restoreStyle(placements[p].el, placements[p].prevStyle);
+                }
+            }
+            var placementByEl = new Map();
+            for (var q = 0; q < placements.length; q += 1) {
+                placementByEl.set(placements[q].el, placements[q]);
+            }
+            var next = [];
+            for (var i = 0; i < items.length; i += 1) {
+                var span = readItemSpan(items[i], columns);
+                var existing = placementByEl.get(items[i]);
+                if (existing) {
+                    existing.span = span;
+                    next.push(existing);
+                } else {
+                    next.push(trackPlacement(items[i], span));
+                }
+            }
+            placements = next;
+
+            var containerWidth = container.clientWidth;
+            if (containerWidth <= 0 || items.length === 0) {
+                container.style.height = '0px';
+                return;
+            }
+
+            var totalGap = gap * (columns - 1);
+            var columnWidth = (containerWidth - totalGap) / columns;
+            var columnHeights = new Array(columns);
+            for (var c = 0; c < columns; c += 1) {
+                columnHeights[c] = 0;
+            }
+
+            for (var k = 0; k < placements.length; k += 1) {
+                var place = placements[k];
+                var clampedSpan = Math.min(place.span, columns);
+                var slot = findSlot(columnHeights, clampedSpan);
+                var left = slot * (columnWidth + gap);
+                var top = sliceMaxHeight(columnHeights, slot, clampedSpan);
+                var width = columnWidth * clampedSpan + gap * (clampedSpan - 1);
+
+                place.el.style.position = 'absolute';
+                place.el.style.boxSizing = 'border-box';
+                place.el.style.left = left + 'px';
+                place.el.style.top = top + 'px';
+                place.el.style.width = width + 'px';
+
+                var itemHeight = place.el.offsetHeight;
+                var newHeight = top + itemHeight + gap;
+                for (var s = slot; s < slot + clampedSpan; s += 1) {
+                    columnHeights[s] = newHeight;
+                }
+            }
+
+            var maxHeight = 0;
+            for (var d = 0; d < columnHeights.length; d += 1) {
+                if (columnHeights[d] > maxHeight) {
+                    maxHeight = columnHeights[d];
+                }
+            }
+            maxHeight = Math.max(0, maxHeight - gap);
+            container.style.height = maxHeight + 'px';
+        }
+
+        relayout();
+
+        var ro = (typeof ResizeObserver !== 'undefined') ? new ResizeObserver(function () { relayout(); }) : null;
+        if (ro) ro.observe(container);
+
+        var observedItems = (typeof WeakSet !== 'undefined') ? new WeakSet() : null;
+        function observeNewItems() {
+            if (!ro || !observedItems) return;
+            for (var p = 0; p < placements.length; p += 1) {
+                if (!observedItems.has(placements[p].el)) {
+                    ro.observe(placements[p].el);
+                    observedItems.add(placements[p].el);
+                }
+            }
+        }
+        observeNewItems();
+
+        var mo = (typeof MutationObserver !== 'undefined') ? new MutationObserver(function () {
+            relayout();
+            observeNewItems();
+        }) : null;
+        if (mo) {
+            mo.observe(container, {
+                childList: true,
+                subtree: true,
+                attributes: true,
+                attributeFilter: ['class', 'data-ap-col-span', 'data-ap-cols'],
+            });
+        }
+
+        function onLoad(event) {
+            if (event.target instanceof HTMLImageElement && container.contains(event.target)) {
+                relayout();
+            }
+        }
+        container.addEventListener('load', onLoad, true);
+
+        function onResize() { relayout(); }
+        window.addEventListener('resize', onResize);
+
+        // Tame the empty-then-painted race: items can mount empty and
+        // stream content in across the first few frames. A short rAF
+        // chain catches the paint without waiting on observers.
+        if (typeof window.requestAnimationFrame === 'function') {
+            var kicks = 0;
+            function kick() {
+                if (destroyed || kicks > 3) return;
+                kicks += 1;
+                relayout();
+                window.requestAnimationFrame(kick);
+            }
+            window.requestAnimationFrame(kick);
+        }
+
+        return {
+            relayout: relayout,
+            destroy: function () {
+                if (destroyed) return;
+                destroyed = true;
+                if (ro) ro.disconnect();
+                if (mo) mo.disconnect();
+                container.removeEventListener('load', onLoad, true);
+                window.removeEventListener('resize', onResize);
+                for (var p = 0; p < placements.length; p += 1) {
+                    restoreStyle(placements[p].el, placements[p].prevStyle);
+                }
+                placements = [];
+                container.style.position = initialWrapperStyle.position;
+                container.style.height = initialWrapperStyle.height;
+                for (var c = 0; c < classesAdded.length; c += 1) {
+                    container.classList.remove(classesAdded[c]);
+                }
+            },
+        };
+    }
+
+    function bootstrap() {
+        var selector = '.is-layout-masonry, .ap-grid.ap-grid-layout-masonry';
+        var elements = document.querySelectorAll(selector);
+        for (var i = 0; i < elements.length; i += 1) {
+            var el = elements[i];
+            if (el.__apMasonryController) {
+                continue;
+            }
+            el.__apMasonryController = initMasonry(el, false);
+        }
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', bootstrap);
+    } else {
+        bootstrap();
+    }
+
+    // Expose for SPA / Livewire hosts that mount masonry containers
+    // after initial paint.
+    window.apMasonry = window.apMasonry || {};
+    window.apMasonry.init = initMasonry;
+    window.apMasonry.bootstrap = bootstrap;
+    window.apMasonry.supportsNative = supportsNative;
+})();

--- a/packages/visual-editor-renderer-blade/resources/assets/frontend/masonry-fallback.js
+++ b/packages/visual-editor-renderer-blade/resources/assets/frontend/masonry-fallback.js
@@ -21,6 +21,15 @@
 
     var ITEM_CLASS = 'ap-masonry-item';
     var WRAPPER_CLASS = 'ap-masonry-js-fallback';
+    // Tailwind-style breakpoint min-widths in ascending order. Mirrors
+    // resources/js/visual-editor/responsive/registry.ts.
+    var BREAKPOINT_MIN_WIDTHS = [
+        ['sm', 640],
+        ['md', 768],
+        ['lg', 1024],
+        ['xl', 1280],
+        ['2xl', 1536]
+    ];
 
     function supportsNative() {
         if (typeof window === 'undefined' || typeof window.CSS === 'undefined') {
@@ -56,6 +65,36 @@
         }
         var parsed = Number(attr);
         return clampColumns(parsed, fallback);
+    }
+
+    // Walk the breakpoint table in ascending min-width order and pick
+    // the column count from the widest breakpoint whose min-width the
+    // current viewport meets. Falls back to the base `data-ap-cols`
+    // (or the given fallback) when no breakpoint matches.
+    function readActiveColumnsFromAttrs(container, fallback) {
+        var base = readColumnsFromAttr(container, fallback);
+        if (typeof window === 'undefined') {
+            return base;
+        }
+        var viewportWidth = window.innerWidth || 0;
+        var active = base;
+        for (var i = 0; i < BREAKPOINT_MIN_WIDTHS.length; i += 1) {
+            var bp = BREAKPOINT_MIN_WIDTHS[i][0];
+            var minWidth = BREAKPOINT_MIN_WIDTHS[i][1];
+            if (viewportWidth < minWidth) {
+                break;
+            }
+            var attr = container.getAttribute('data-ap-cols-' + bp);
+            if (attr === null || attr === '') {
+                continue;
+            }
+            var parsed = Number(attr);
+            if (!isFinite(parsed)) {
+                continue;
+            }
+            active = clampColumns(parsed, active);
+        }
+        return active;
     }
 
     function readItemSpan(el, maxColumns) {
@@ -148,6 +187,10 @@
 
         var destroyed = false;
         var placements = [];
+        // Forward-declared so relayout() can unobserve removed items
+        // from the ResizeObserver. Assigned just before the first
+        // relayout() invocation below.
+        var ro = null;
         var initialWrapperStyle = {
             position: container.style.position,
             height: container.style.height,
@@ -169,13 +212,14 @@
         function relayout() {
             if (destroyed) return;
             var items = collectItems(container);
-            var columns = clampColumns(readColumnsFromAttr(container, 3), 3);
+            var columns = clampColumns(readActiveColumnsFromAttrs(container, 3), 3);
             var gap = readGapPx(container);
 
             var liveSet = new Set(items);
             for (var p = 0; p < placements.length; p += 1) {
                 if (!liveSet.has(placements[p].el)) {
                     restoreStyle(placements[p].el, placements[p].prevStyle);
+                    if (ro) ro.unobserve(placements[p].el);
                 }
             }
             var placementByEl = new Map();
@@ -241,7 +285,7 @@
 
         relayout();
 
-        var ro = (typeof ResizeObserver !== 'undefined') ? new ResizeObserver(function () { relayout(); }) : null;
+        ro = (typeof ResizeObserver !== 'undefined') ? new ResizeObserver(function () { relayout(); }) : null;
         if (ro) ro.observe(container);
 
         var observedItems = (typeof WeakSet !== 'undefined') ? new WeakSet() : null;
@@ -310,6 +354,14 @@
                 container.style.height = initialWrapperStyle.height;
                 for (var c = 0; c < classesAdded.length; c += 1) {
                     container.classList.remove(classesAdded[c]);
+                }
+                // Clear the marker so bootstrap() can reinitialize the
+                // container if it is re-introduced later (SPA hydration,
+                // Livewire morph, etc.).
+                try {
+                    delete container.__apMasonryController;
+                } catch (err) {
+                    container.__apMasonryController = undefined;
                 }
             },
         };

--- a/packages/visual-editor-renderer-blade/resources/assets/frontend/masonry.css
+++ b/packages/visual-editor-renderer-blade/resources/assets/frontend/masonry.css
@@ -1,0 +1,82 @@
+/**
+ * Shared masonry layout styles (#593).
+ *
+ * Mirror of `resources/js/visual-editor/blocks/_shared/masonry/masonry.css`
+ * — kept byte-for-byte identical so the editor canvas and the public
+ * frontend layer the same rules. Loaded on the public frontend via
+ * `<x-ve-blocks-styles />`. Targets:
+ *
+ *   - `artisanpack/post-template` rendered with `layout: masonry`
+ *     (`.wp-block-post-template.is-layout-masonry`)
+ *   - `artisanpack/grid` rendered with `layoutMode: masonry`
+ *     (`.ap-grid.ap-grid-layout-masonry`)
+ *
+ * Two paths:
+ *
+ *   1. Native CSS Grid Level 3 (`grid-template-rows: masonry`). Picked up
+ *      by browsers that ship support; the @supports gate keeps the rule
+ *      from polluting non-supporting browsers' layout.
+ *   2. The JS fallback (`masonry-fallback.js`). When the fallback runs,
+ *      it stamps the wrapper with `ap-masonry-js-fallback` and
+ *      absolute-positions each child. The `:not(.ap-masonry-js-fallback)`
+ *      guard prevents the native rule from fighting with the fallback
+ *      while it is active.
+ */
+
+/* === Native CSS Grid masonry path =================================== */
+
+@supports (grid-template-rows: masonry) {
+    .wp-block-post-template.is-layout-masonry:not(.ap-masonry-js-fallback) {
+        grid-template-rows: masonry;
+    }
+
+    .ap-grid.ap-grid-layout-masonry:not(.ap-masonry-js-fallback) {
+        grid-template-rows: masonry;
+    }
+}
+
+/* === Shared baseline for both paths ================================= */
+
+.wp-block-post-template.is-layout-masonry:not(.ap-masonry-js-fallback) {
+    display: grid;
+    grid-template-columns: repeat(1, minmax(0, 1fr));
+    gap: var(--wp--style--block-gap, 1.25em);
+    list-style: none;
+    padding: 0;
+}
+
+.wp-block-post-template.is-layout-masonry.columns-2:not(.ap-masonry-js-fallback) { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.wp-block-post-template.is-layout-masonry.columns-3:not(.ap-masonry-js-fallback) { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+.wp-block-post-template.is-layout-masonry.columns-4:not(.ap-masonry-js-fallback) { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+.wp-block-post-template.is-layout-masonry.columns-5:not(.ap-masonry-js-fallback) { grid-template-columns: repeat(5, minmax(0, 1fr)); }
+.wp-block-post-template.is-layout-masonry.columns-6:not(.ap-masonry-js-fallback) { grid-template-columns: repeat(6, minmax(0, 1fr)); }
+
+.wp-block-post-template.is-layout-masonry:not(.ap-masonry-js-fallback) > .wp-block-post-template-item {
+    margin: 0;
+    width: auto;
+    min-width: 0;
+}
+
+/* === JS fallback positioning context ================================ */
+
+/* When the JS fallback is active it owns the layout: `display: block`
+ * so children can lift into `position: absolute` without competing
+ * with the baseline grid rules above. The compound selectors match the
+ * baseline's specificity so the fallback wins deterministically without
+ * resorting to `!important`. */
+.wp-block-post-template.is-layout-masonry.ap-masonry-js-fallback,
+.ap-grid.ap-grid-layout-masonry.ap-masonry-js-fallback,
+.ap-masonry-js-fallback {
+    position: relative;
+    display: block;
+    list-style: none;
+    padding: 0;
+    grid-template-columns: none;
+    grid-template-rows: none;
+}
+
+.ap-masonry-js-fallback > .ap-masonry-item {
+    position: absolute;
+    box-sizing: border-box;
+    margin: 0;
+}

--- a/packages/visual-editor-renderer-blade/resources/assets/frontend/masonry.css
+++ b/packages/visual-editor-renderer-blade/resources/assets/frontend/masonry.css
@@ -63,7 +63,11 @@
  * so children can lift into `position: absolute` without competing
  * with the baseline grid rules above. The compound selectors match the
  * baseline's specificity so the fallback wins deterministically without
- * resorting to `!important`. */
+ * resorting to `!important`.
+ *
+ * `gap` is intentionally preserved here — `readGapPx()` in the
+ * fallback reads the computed value to derive item spacing, so a
+ * missing gap would pack items with zero whitespace. */
 .wp-block-post-template.is-layout-masonry.ap-masonry-js-fallback,
 .ap-grid.ap-grid-layout-masonry.ap-masonry-js-fallback,
 .ap-masonry-js-fallback {
@@ -71,6 +75,7 @@
     display: block;
     list-style: none;
     padding: 0;
+    gap: var(--wp--style--block-gap, 1.25em);
     grid-template-columns: none;
     grid-template-rows: none;
 }

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/grid.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/grid.blade.php
@@ -42,8 +42,25 @@
 		}
 	}
 
-	$baseClasses = array_merge( [ 'ap-grid' ], $breakpointClasses, PhotoGridSupport::wrapperForBlock( $attributes ) );
+	$layoutMode = isset( $attributes['layoutMode'] ) && 'masonry' === $attributes['layoutMode']
+		? 'masonry'
+		: 'fixed';
+	$isMasonry = 'masonry' === $layoutMode;
+
+	$layoutClass = $isMasonry ? 'ap-grid-layout-masonry' : 'ap-grid-layout-fixed';
+
+	$baseClasses = array_merge(
+		[ 'ap-grid' ],
+		$breakpointClasses,
+		[ $layoutClass ],
+		PhotoGridSupport::wrapperForBlock( $attributes )
+	);
+
+	$attrs = BlockSupports::wrapperAttrs( $attributes, $baseClasses );
+	if ( $isMasonry ) {
+		$attrs .= sprintf( ' data-ap-cols="%d"', $baseColumns );
+	}
 @endphp
-<div{!! BlockSupports::wrapperAttrs( $attributes, $baseClasses ) !!}>
+<div{!! $attrs !!}>
 	{!! $innerBlocksHtml !!}
 </div>

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/grid.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/grid.blade.php
@@ -59,6 +59,29 @@
 	$attrs = BlockSupports::wrapperAttrs( $attributes, $baseClasses );
 	if ( $isMasonry ) {
 		$attrs .= sprintf( ' data-ap-cols="%d"', $baseColumns );
+
+		// Per-breakpoint column overrides ride alongside the base count
+		// so the JS bootstrap can pick the active breakpoint at runtime
+		// instead of locking the masonry layout to `data-ap-cols`.
+		if ( is_array( $responsiveColumns ) ) {
+			foreach ( $responsiveColumns as $bp => $value ) {
+				if ( BreakpointRegistry::BASE_KEY === $bp ) {
+					continue;
+				}
+				if ( ! is_numeric( $value ) ) {
+					continue;
+				}
+				if ( null === $registry->get( (string) $bp ) ) {
+					continue;
+				}
+
+				$attrs .= sprintf(
+					' data-ap-cols-%s="%d"',
+					e( (string) $bp ),
+					$clampColumns( $value, $baseColumns )
+				);
+			}
+		}
 	}
 @endphp
 <div{!! $attrs !!}>

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/core/post-template.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/core/post-template.blade.php
@@ -2,15 +2,39 @@
 	use ArtisanPackUI\VisualEditorRendererBlade\Support\BlockSupports;
 
 	$layout = isset( $attributes['layout'] ) ? (string) $attributes['layout'] : 'list';
+	if ( ! in_array( $layout, [ 'list', 'grid', 'masonry' ], true ) ) {
+		$layout = 'list';
+	}
 	$columns = isset( $attributes['columns'] ) ? (int) $attributes['columns'] : 3;
 	$isGrid = 'grid' === $layout;
+	$isMasonry = 'masonry' === $layout;
+	$usesColumns = $isGrid || $isMasonry;
 
+	// Masonry layers `is-layout-grid` underneath `is-layout-masonry` so
+	// the existing post-template grid CSS (display: grid, columns-N
+	// tracks) provides the baseline layout, and the masonry stylesheet
+	// adds `grid-template-rows: masonry` on top via `@supports` for
+	// browsers that ship native CSS Grid masonry. Non-supporting
+	// browsers see the columned grid baseline until the JS bootstrap
+	// hydrates and packs the items.
 	$classes = [ 'wp-block-post-template' ];
-	$classes[] = $isGrid ? 'is-layout-grid' : 'is-layout-flow';
-	if ( $isGrid ) {
+	if ( $isGrid || $isMasonry ) {
+		$classes[] = 'is-layout-grid';
+	} else {
+		$classes[] = 'is-layout-flow';
+	}
+	if ( $isMasonry ) {
+		$classes[] = 'is-layout-masonry';
+	}
+	if ( $usesColumns ) {
 		$classes[] = 'columns-' . $columns;
 	}
+
+	$attrs = BlockSupports::wrapperAttrs( $attributes, $classes );
+	if ( $isMasonry ) {
+		$attrs .= sprintf( ' data-ap-cols="%d"', $columns );
+	}
 @endphp
-<ul{!! BlockSupports::wrapperAttrs( $attributes, $classes ) !!}>
+<ul{!! $attrs !!}>
 	{!! $innerBlocksHtml !!}
 </ul>

--- a/packages/visual-editor-renderer-blade/resources/views/components/blocks-styles.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/components/blocks-styles.blade.php
@@ -48,6 +48,12 @@
 	so a variant's per-breakpoint `gridColumnSpan` / `gridRowSpan` only takes
 	effect inside a grid-layout Query Loop. --}}
 <link rel="stylesheet" href="{{ $postVariantStyleHref }}" data-ve-post-variant>
+{{-- #593 — Masonry layout. Powers `post-template` (layout: masonry) and
+	`grid` (layoutMode: masonry). Native CSS Grid masonry lights up
+	automatically where supported via `@supports`; the JS fallback
+	bootstrap below handles the rest. --}}
+<link rel="stylesheet" href="{{ $masonryStyleHref }}" data-ve-masonry>
+<script src="{{ $masonryScriptSrc }}" defer data-ve-masonry-fallback></script>
 @if( '' !== $themeTokensCss )
 <style data-ve-theme-tokens>{!! $themeTokensCss !!}</style>
 @endif

--- a/packages/visual-editor-renderer-blade/src/View/Components/BlocksStylesComponent.php
+++ b/packages/visual-editor-renderer-blade/src/View/Components/BlocksStylesComponent.php
@@ -79,6 +79,10 @@ class BlocksStylesComponent extends Component
 
 	public string $postVariantStyleHref;
 
+	public string $masonryStyleHref;
+
+	public string $masonryScriptSrc;
+
 	public string $interactivityScriptSrc;
 
 	public bool $emitBlockLibrary;
@@ -120,6 +124,8 @@ class BlocksStylesComponent extends Component
 		$this->photoGridStyleHref     = $base . '/frontend/photo-grid.css';
 		$this->postTemplateStyleHref  = $base . '/frontend/post-template.css';
 		$this->postVariantStyleHref   = $base . '/frontend/post-variant.css';
+		$this->masonryStyleHref       = $base . '/frontend/masonry.css';
+		$this->masonryScriptSrc       = $base . '/frontend/masonry-fallback.js';
 		$this->interactivityScriptSrc = $base . '/frontend/interactivity.js';
 		$this->emitBlockLibrary       = $bundle;
 		$this->emitInteractive        = $interactive;

--- a/packages/visual-editor-renderer-blade/tests/Feature/MasonryLayoutRenderTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Feature/MasonryLayoutRenderTest.php
@@ -1,0 +1,114 @@
+<?php
+
+/**
+ * Issue #593 — masonry layout output from the Blade renderer.
+ *
+ * Asserts the post-template and grid partials emit the right wrapper
+ * classes + `data-ap-cols` attribute when the masonry layout option is
+ * active, and that the `<x-ve-blocks-styles />` component wires up the
+ * shared masonry CSS + fallback script.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditorRendererBlade
+ */
+
+declare( strict_types=1 );
+
+use Illuminate\Support\Facades\Blade;
+
+it( 'renders the post-template wrapper with is-layout-masonry when layout is masonry', function () {
+	$attrs = [ 'layout' => 'masonry', 'columns' => 4 ];
+
+	$html = view( 'visual-editor-renderer-blade::blocks.artisanpack.post-template', [
+		'attributes'      => $attrs,
+		'innerBlocksHtml' => '<li>x</li>',
+	] )->render();
+
+	expect( $html )
+		->toContain( 'is-layout-masonry' )
+		// Masonry layers is-layout-grid underneath so Gutenberg's
+		// bundled layout baseline provides `display: grid` inside the
+		// editor canvas iframe and the post-template grid CSS sets the
+		// per-breakpoint columns-N tracks.
+		->toContain( 'is-layout-grid' )
+		->toContain( 'columns-4' )
+		->toContain( 'data-ap-cols="4"' )
+		->not->toContain( 'is-layout-flow' );
+} );
+
+it( 'keeps the existing is-layout-grid path for layout: grid', function () {
+	$attrs = [ 'layout' => 'grid', 'columns' => 3 ];
+
+	$html = view( 'visual-editor-renderer-blade::blocks.artisanpack.post-template', [
+		'attributes'      => $attrs,
+		'innerBlocksHtml' => '<li>x</li>',
+	] )->render();
+
+	expect( $html )
+		->toContain( 'is-layout-grid' )
+		->toContain( 'columns-3' )
+		->not->toContain( 'is-layout-masonry' )
+		->not->toContain( 'data-ap-cols' );
+} );
+
+it( 'defaults the post-template wrapper to is-layout-flow without columns-N', function () {
+	$html = view( 'visual-editor-renderer-blade::blocks.artisanpack.post-template', [
+		'attributes'      => [],
+		'innerBlocksHtml' => '<li>x</li>',
+	] )->render();
+
+	expect( $html )
+		->toContain( 'is-layout-flow' )
+		->not->toContain( 'is-layout-masonry' )
+		->not->toContain( 'is-layout-grid' )
+		->not->toContain( 'data-ap-cols' );
+} );
+
+it( 'falls back to list when the layout value is not in the enum', function () {
+	$html = view( 'visual-editor-renderer-blade::blocks.artisanpack.post-template', [
+		'attributes'      => [ 'layout' => 'evil"><script>' ],
+		'innerBlocksHtml' => '<li>x</li>',
+	] )->render();
+
+	expect( $html )
+		->toContain( 'is-layout-flow' )
+		->not->toContain( 'is-layout-masonry' )
+		->not->toContain( '<script>' );
+} );
+
+it( 'emits the masonry layout-mode class + data-ap-cols on the grid wrapper when layoutMode is masonry', function () {
+	$html = view( 'visual-editor-renderer-blade::blocks.artisanpack.grid', [
+		'attributes' => [
+			'numColumns' => 3,
+			'layoutMode' => 'masonry',
+		],
+		'innerBlocksHtml' => '',
+	] )->render();
+
+	expect( $html )
+		->toContain( 'ap-grid-layout-masonry' )
+		->toContain( 'data-ap-cols="3"' )
+		->not->toContain( 'ap-grid-layout-fixed' );
+} );
+
+it( 'emits the fixed layout-mode class on the grid wrapper by default', function () {
+	$html = view( 'visual-editor-renderer-blade::blocks.artisanpack.grid', [
+		'attributes' => [ 'numColumns' => 3 ],
+		'innerBlocksHtml' => '',
+	] )->render();
+
+	expect( $html )
+		->toContain( 'ap-grid-layout-fixed' )
+		->not->toContain( 'ap-grid-layout-masonry' )
+		->not->toContain( 'data-ap-cols' );
+} );
+
+it( 'wires the shared masonry stylesheet and fallback script through <x-ve-blocks-styles />', function () {
+	$rendered = Blade::render( '<x-ve-blocks-styles />' );
+
+	expect( $rendered )
+		->toContain( '/vendor/visual-editor-renderer-blade/frontend/masonry.css' )
+		->toContain( 'data-ve-masonry' )
+		->toContain( '/vendor/visual-editor-renderer-blade/frontend/masonry-fallback.js' )
+		->toContain( 'data-ve-masonry-fallback' );
+} );

--- a/packages/visual-editor-renderer-blade/tests/Feature/MasonryLayoutRenderTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Feature/MasonryLayoutRenderTest.php
@@ -91,6 +91,35 @@ it( 'emits the masonry layout-mode class + data-ap-cols on the grid wrapper when
 		->not->toContain( 'ap-grid-layout-fixed' );
 } );
 
+it( 'emits per-breakpoint data-ap-cols-{bp} attributes when the grid carries responsive numColumns overrides in masonry mode', function () {
+	$html = view( 'visual-editor-renderer-blade::blocks.artisanpack.grid', [
+		'attributes' => [
+			'numColumns' => 2,
+			'layoutMode' => 'masonry',
+			'responsive' => [ 'numColumns' => [ 'md' => 4, 'lg' => 6 ] ],
+		],
+		'innerBlocksHtml' => '',
+	] )->render();
+
+	expect( $html )
+		->toContain( 'data-ap-cols="2"' )
+		->toContain( 'data-ap-cols-md="4"' )
+		->toContain( 'data-ap-cols-lg="6"' );
+} );
+
+it( 'skips responsive data attributes when the grid is in fixed mode', function () {
+	$html = view( 'visual-editor-renderer-blade::blocks.artisanpack.grid', [
+		'attributes' => [
+			'numColumns' => 2,
+			'responsive' => [ 'numColumns' => [ 'md' => 4 ] ],
+		],
+		'innerBlocksHtml' => '',
+	] )->render();
+
+	expect( $html )
+		->not->toContain( 'data-ap-cols' );
+} );
+
 it( 'emits the fixed layout-mode class on the grid wrapper by default', function () {
 	$html = view( 'visual-editor-renderer-blade::blocks.artisanpack.grid', [
 		'attributes' => [ 'numColumns' => 3 ],

--- a/packages/visual-editor-renderer-react/src/blocks/artisanpack/grid.tsx
+++ b/packages/visual-editor-renderer-react/src/blocks/artisanpack/grid.tsx
@@ -93,6 +93,21 @@ export function GridBlock({ attributes, children }: BlockRendererProps): JSX.Ele
     const props: Record<string, unknown> = { className: classes };
     if (isMasonry) {
         props['data-ap-cols'] = baseColumns;
+
+        // Per-breakpoint overrides ride alongside the base count so the
+        // JS bootstrap can pick the active breakpoint at runtime
+        // instead of locking masonry to the base `data-ap-cols`.
+        for (const bp of BREAKPOINTS) {
+            const raw = responsiveColumns[bp];
+            if (raw === undefined || raw === null) {
+                continue;
+            }
+            const numeric = typeof raw === 'number' ? raw : Number(raw);
+            if (!Number.isFinite(numeric)) {
+                continue;
+            }
+            props[`data-ap-cols-${bp}`] = clampInt(numeric, 1, 12, baseColumns);
+        }
     }
 
     return <div {...props}>{children as ReactNode}</div>;

--- a/packages/visual-editor-renderer-react/src/blocks/artisanpack/grid.tsx
+++ b/packages/visual-editor-renderer-react/src/blocks/artisanpack/grid.tsx
@@ -79,15 +79,23 @@ export function GridBlock({ attributes, children }: BlockRendererProps): JSX.Ele
     const responsive = attrRecord(attributes.responsive);
     const responsiveColumns = attrRecord(responsive.numColumns);
     const className = attrString(attributes.className);
+    const layoutMode = attrString(attributes.layoutMode);
+    const isMasonry = 'masonry' === layoutMode;
 
     const classes = classList([
         'ap-grid',
         `ap-grid-has-${baseColumns}-base-columns`,
         ...responsiveSpanClasses(responsiveColumns, 'columns', 'ap-grid-has'),
+        isMasonry ? 'ap-grid-layout-masonry' : 'ap-grid-layout-fixed',
         className,
     ]);
 
-    return <div className={classes}>{children as ReactNode}</div>;
+    const props: Record<string, unknown> = { className: classes };
+    if (isMasonry) {
+        props['data-ap-cols'] = baseColumns;
+    }
+
+    return <div {...props}>{children as ReactNode}</div>;
 }
 
 export function GridItemBlock({ attributes, children }: BlockRendererProps): JSX.Element {

--- a/packages/visual-editor-renderer-react/src/blocks/core/query.tsx
+++ b/packages/visual-editor-renderer-react/src/blocks/core/query.tsx
@@ -60,16 +60,30 @@ export function PostTemplateBlock({ attributes, children }: BlockRendererProps):
     const layout = attrString(attributes.layout);
     const layoutType = attrString(attributes.layoutType);
     const isGrid = layout === 'grid' || layoutType === 'grid';
+    const isMasonry = layout === 'masonry';
+    const usesColumns = isGrid || isMasonry;
     const columns = typeof attributes.columns === 'number' ? attributes.columns : 3;
 
     const classes = classList([
         'wp-block-post-template',
-        isGrid ? 'is-layout-grid' : 'is-layout-flow',
-        isGrid ? `columns-${columns}` : '',
+        // Masonry layers `is-layout-grid` underneath `is-layout-masonry`
+        // so the existing grid CSS provides the baseline layout, and
+        // the masonry stylesheet adds `grid-template-rows: masonry` on
+        // top via `@supports` for browsers that ship native CSS Grid
+        // masonry. The JS bootstrap takes over for the rest.
+        (isGrid || isMasonry) ? 'is-layout-grid' : '',
+        isMasonry ? 'is-layout-masonry' : '',
+        !usesColumns ? 'is-layout-flow' : '',
+        usesColumns ? `columns-${columns}` : '',
         className,
     ]);
 
-    return <ul className={classes}>{children}</ul>;
+    const props: Record<string, unknown> = { className: classes };
+    if (isMasonry) {
+        props['data-ap-cols'] = columns;
+    }
+
+    return <ul {...props}>{children}</ul>;
 }
 
 /**

--- a/packages/visual-editor-renderer-react/src/blocks/core/query.tsx
+++ b/packages/visual-editor-renderer-react/src/blocks/core/query.tsx
@@ -14,7 +14,7 @@
  */
 
 import type { JSX, ReactNode } from 'react';
-import { attrString, classList, postTemplateItemSpanClasses } from '../../support/attributes';
+import { attrInt, attrString, classList, postTemplateItemSpanClasses } from '../../support/attributes';
 import type { BlockRendererProps } from '../../types';
 
 interface WrapperProps {
@@ -25,22 +25,21 @@ interface WrapperProps {
 
 /**
  * Coerce a host-supplied `columns` attribute into a safe integer in [1, 12].
- * Rejects NaN / Infinity / fractions / non-numbers so the emitted
- * `columns-N` class and `data-ap-cols` attribute always carry a value the
- * stylesheet + JS bootstrap can use.
+ *
+ * Delegates to {@link attrInt} so numeric strings ("4") survive serializers
+ * that don't preserve number types, while NaN / Infinity / unparseable
+ * strings fall through to the caller's fallback. The result is clamped
+ * to the same bounds the stylesheet supports.
  */
 function clampColumns(value: unknown, fallback: number): number {
-    if (typeof value !== 'number' || !Number.isFinite(value)) {
-        return fallback;
-    }
-    const truncated = Math.trunc(value);
-    if (truncated < 1) {
+    const parsed = attrInt(value, fallback);
+    if (parsed < 1) {
         return 1;
     }
-    if (truncated > 12) {
+    if (parsed > 12) {
         return 12;
     }
-    return truncated;
+    return parsed;
 }
 
 function isDevelopment(): boolean {

--- a/packages/visual-editor-renderer-react/src/blocks/core/query.tsx
+++ b/packages/visual-editor-renderer-react/src/blocks/core/query.tsx
@@ -23,6 +23,26 @@ interface WrapperProps {
     'data-ve-resolution-error'?: string;
 }
 
+/**
+ * Coerce a host-supplied `columns` attribute into a safe integer in [1, 12].
+ * Rejects NaN / Infinity / fractions / non-numbers so the emitted
+ * `columns-N` class and `data-ap-cols` attribute always carry a value the
+ * stylesheet + JS bootstrap can use.
+ */
+function clampColumns(value: unknown, fallback: number): number {
+    if (typeof value !== 'number' || !Number.isFinite(value)) {
+        return fallback;
+    }
+    const truncated = Math.trunc(value);
+    if (truncated < 1) {
+        return 1;
+    }
+    if (truncated > 12) {
+        return 12;
+    }
+    return truncated;
+}
+
 function isDevelopment(): boolean {
     if (typeof process === 'undefined') {
         return false;
@@ -62,7 +82,7 @@ export function PostTemplateBlock({ attributes, children }: BlockRendererProps):
     const isGrid = layout === 'grid' || layoutType === 'grid';
     const isMasonry = layout === 'masonry';
     const usesColumns = isGrid || isMasonry;
-    const columns = typeof attributes.columns === 'number' ? attributes.columns : 3;
+    const columns = clampColumns(attributes.columns, 3);
 
     const classes = classList([
         'wp-block-post-template',

--- a/packages/visual-editor-renderer-react/tests/BlockTree.test.tsx
+++ b/packages/visual-editor-renderer-react/tests/BlockTree.test.tsx
@@ -1106,6 +1106,29 @@ describe('Core design blocks', () => {
         expect(html).toContain('ap-grid-has-4-lg-columns');
     });
 
+    it('emits the masonry layout-mode class + data-ap-cols on the grid wrapper when layoutMode is masonry (#593)', () => {
+        const html = renderTree([
+            makeBlock('artisanpack/grid', {
+                numColumns: 3,
+                layoutMode: 'masonry',
+            }),
+        ]);
+
+        expect(html).toContain('ap-grid-layout-masonry');
+        expect(html).toContain('data-ap-cols="3"');
+        expect(html).not.toContain('ap-grid-layout-fixed');
+    });
+
+    it('emits the fixed layout-mode class on the grid wrapper by default (#593)', () => {
+        const html = renderTree([
+            makeBlock('artisanpack/grid', { numColumns: 3 }),
+        ]);
+
+        expect(html).toContain('ap-grid-layout-fixed');
+        expect(html).not.toContain('ap-grid-layout-masonry');
+        expect(html).not.toContain('data-ap-cols');
+    });
+
     it('falls back to a safe default when grid-item innerLayout is invalid', () => {
         const tree = [
             makeBlock('artisanpack/grid-item', {

--- a/packages/visual-editor-renderer-react/tests/PostTemplateMasonry.test.tsx
+++ b/packages/visual-editor-renderer-react/tests/PostTemplateMasonry.test.tsx
@@ -1,0 +1,67 @@
+/**
+ * Issue #593 — masonry layout option on artisanpack/post-template.
+ *
+ * Verifies the React renderer emits the `is-layout-masonry` wrapper
+ * class + `data-ap-cols` attribute when `layout: masonry` is set, while
+ * preserving the existing `is-layout-flow` default and `is-layout-grid`
+ * path.
+ */
+
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import '../src/index';
+import { BlockTree } from '../src/BlockTree';
+import { makeBlock, normalizeHtml } from './helpers';
+
+function renderTree(tree: unknown): string {
+    const { container } = render(
+        <BlockTree tree={tree as Parameters<typeof BlockTree>[0]['tree']} />
+    );
+    return normalizeHtml(container.innerHTML);
+}
+
+describe('artisanpack/post-template — masonry layout (#593)', () => {
+    it('emits is-layout-masonry + columns-N + data-ap-cols when layout is masonry', () => {
+        const html = renderTree([
+            makeBlock('artisanpack/post-template', {
+                layout: 'masonry',
+                columns: 4,
+            }),
+        ]);
+
+        expect(html).toContain('is-layout-masonry');
+        // Masonry layers is-layout-grid underneath so Gutenberg's bundled
+        // layout baseline provides `display: grid` inside the editor
+        // canvas iframe and the post-template grid CSS sets columns-N.
+        expect(html).toContain('is-layout-grid');
+        expect(html).toContain('columns-4');
+        expect(html).toContain('data-ap-cols="4"');
+        expect(html).not.toContain('is-layout-flow');
+    });
+
+    it('keeps the existing is-layout-grid path for layout: grid', () => {
+        const html = renderTree([
+            makeBlock('artisanpack/post-template', {
+                layout: 'grid',
+                columns: 3,
+            }),
+        ]);
+
+        expect(html).toContain('is-layout-grid');
+        expect(html).toContain('columns-3');
+        expect(html).not.toContain('is-layout-masonry');
+        expect(html).not.toContain('data-ap-cols');
+    });
+
+    it('defaults to is-layout-flow without columns-N or data-ap-cols', () => {
+        const html = renderTree([
+            makeBlock('artisanpack/post-template', {}),
+        ]);
+
+        expect(html).toContain('is-layout-flow');
+        expect(html).not.toContain('is-layout-masonry');
+        expect(html).not.toContain('is-layout-grid');
+        expect(html).not.toContain('data-ap-cols');
+    });
+});

--- a/packages/visual-editor-renderer-react/tests/PostTemplateMasonry.test.tsx
+++ b/packages/visual-editor-renderer-react/tests/PostTemplateMasonry.test.tsx
@@ -54,6 +54,31 @@ describe('artisanpack/post-template — masonry layout (#593)', () => {
         expect(html).not.toContain('data-ap-cols');
     });
 
+    it('accepts numeric-string columns from hosts that round-trip attributes as strings', () => {
+        const html = renderTree([
+            makeBlock('artisanpack/post-template', {
+                layout: 'masonry',
+                columns: '4',
+            }),
+        ]);
+
+        expect(html).toContain('columns-4');
+        expect(html).toContain('data-ap-cols="4"');
+    });
+
+    it('falls back to the default columns when the value is unparseable', () => {
+        const html = renderTree([
+            makeBlock('artisanpack/post-template', {
+                layout: 'masonry',
+                columns: 'evil',
+            }),
+        ]);
+
+        // Default columns = 3.
+        expect(html).toContain('columns-3');
+        expect(html).toContain('data-ap-cols="3"');
+    });
+
     it('defaults to is-layout-flow without columns-N or data-ap-cols', () => {
         const html = renderTree([
             makeBlock('artisanpack/post-template', {}),

--- a/packages/visual-editor-renderer-vue/src/blocks/artisanpack/grid.ts
+++ b/packages/visual-editor-renderer-vue/src/blocks/artisanpack/grid.ts
@@ -97,6 +97,22 @@ export const GridBlock = defineComponent({
             const attrs: Record<string, unknown> = { class: classes };
             if (isMasonry) {
                 attrs['data-ap-cols'] = baseColumns;
+
+                // Per-breakpoint overrides ride alongside the base
+                // count so the JS bootstrap can pick the active
+                // breakpoint at runtime instead of locking masonry to
+                // the base `data-ap-cols`.
+                for (const bp of BREAKPOINTS) {
+                    const raw = responsiveColumns[bp];
+                    if (raw === undefined || raw === null) {
+                        continue;
+                    }
+                    const numeric = typeof raw === 'number' ? raw : Number(raw);
+                    if (!Number.isFinite(numeric)) {
+                        continue;
+                    }
+                    attrs[`data-ap-cols-${bp}`] = clampInt(numeric, 1, 12, baseColumns);
+                }
             }
 
             return h(

--- a/packages/visual-editor-renderer-vue/src/blocks/artisanpack/grid.ts
+++ b/packages/visual-editor-renderer-vue/src/blocks/artisanpack/grid.ts
@@ -83,17 +83,25 @@ export const GridBlock = defineComponent({
             const responsive = attrRecord(props.attributes.responsive);
             const responsiveColumns = attrRecord(responsive.numColumns);
             const className = attrString(props.attributes.className);
+            const layoutMode = attrString(props.attributes.layoutMode);
+            const isMasonry = 'masonry' === layoutMode;
 
             const classes = classList([
                 'ap-grid',
                 `ap-grid-has-${baseColumns}-base-columns`,
                 ...responsiveSpanClasses(responsiveColumns, 'columns', 'ap-grid-has'),
+                isMasonry ? 'ap-grid-layout-masonry' : 'ap-grid-layout-fixed',
                 className,
             ]);
 
+            const attrs: Record<string, unknown> = { class: classes };
+            if (isMasonry) {
+                attrs['data-ap-cols'] = baseColumns;
+            }
+
             return h(
                 'div',
-                { class: classes },
+                attrs,
                 slots.default ? slots.default() : []
             );
         };

--- a/packages/visual-editor-renderer-vue/src/blocks/core/query.ts
+++ b/packages/visual-editor-renderer-vue/src/blocks/core/query.ts
@@ -13,27 +13,26 @@
  */
 
 import { defineComponent, h } from 'vue';
-import { attrString, classList, postTemplateItemSpanClasses } from '../../support/attributes';
+import { attrInt, attrString, classList, postTemplateItemSpanClasses } from '../../support/attributes';
 import { blockRendererProps } from '../shared';
 
 /**
  * Coerce a host-supplied `columns` attribute into a safe integer in [1, 12].
- * Rejects NaN / Infinity / fractions / non-numbers so the emitted
- * `columns-N` class and `data-ap-cols` attribute always carry a value the
- * stylesheet + JS bootstrap can use.
+ *
+ * Delegates to {@link attrInt} so numeric strings ("4") survive serializers
+ * that don't preserve number types, while NaN / Infinity / unparseable
+ * strings fall through to the caller's fallback. The result is clamped
+ * to the same bounds the stylesheet supports.
  */
 function clampColumns(value: unknown, fallback: number): number {
-    if (typeof value !== 'number' || !Number.isFinite(value)) {
-        return fallback;
-    }
-    const truncated = Math.trunc(value);
-    if (truncated < 1) {
+    const parsed = attrInt(value, fallback);
+    if (parsed < 1) {
         return 1;
     }
-    if (truncated > 12) {
+    if (parsed > 12) {
         return 12;
     }
-    return truncated;
+    return parsed;
 }
 
 function isDevelopment(): boolean {

--- a/packages/visual-editor-renderer-vue/src/blocks/core/query.ts
+++ b/packages/visual-editor-renderer-vue/src/blocks/core/query.ts
@@ -16,6 +16,26 @@ import { defineComponent, h } from 'vue';
 import { attrString, classList, postTemplateItemSpanClasses } from '../../support/attributes';
 import { blockRendererProps } from '../shared';
 
+/**
+ * Coerce a host-supplied `columns` attribute into a safe integer in [1, 12].
+ * Rejects NaN / Infinity / fractions / non-numbers so the emitted
+ * `columns-N` class and `data-ap-cols` attribute always carry a value the
+ * stylesheet + JS bootstrap can use.
+ */
+function clampColumns(value: unknown, fallback: number): number {
+    if (typeof value !== 'number' || !Number.isFinite(value)) {
+        return fallback;
+    }
+    const truncated = Math.trunc(value);
+    if (truncated < 1) {
+        return 1;
+    }
+    if (truncated > 12) {
+        return 12;
+    }
+    return truncated;
+}
+
 function isDevelopment(): boolean {
     if (typeof process === 'undefined') {
         return false;
@@ -63,7 +83,7 @@ export const PostTemplateBlock = defineComponent({
             const isGrid = layout === 'grid' || layoutType === 'grid';
             const isMasonry = layout === 'masonry';
             const usesColumns = isGrid || isMasonry;
-            const columns = typeof props.attributes.columns === 'number' ? props.attributes.columns : 3;
+            const columns = clampColumns(props.attributes.columns, 3);
 
             const attrs: Record<string, unknown> = {
                 class: classList([

--- a/packages/visual-editor-renderer-vue/src/blocks/core/query.ts
+++ b/packages/visual-editor-renderer-vue/src/blocks/core/query.ts
@@ -61,20 +61,32 @@ export const PostTemplateBlock = defineComponent({
             const layout = attrString(props.attributes.layout);
             const layoutType = attrString(props.attributes.layoutType);
             const isGrid = layout === 'grid' || layoutType === 'grid';
+            const isMasonry = layout === 'masonry';
+            const usesColumns = isGrid || isMasonry;
             const columns = typeof props.attributes.columns === 'number' ? props.attributes.columns : 3;
 
-            return h(
-                'ul',
-                {
-                    class: classList([
-                        'wp-block-post-template',
-                        isGrid ? 'is-layout-grid' : 'is-layout-flow',
-                        isGrid ? `columns-${columns}` : '',
-                        className,
-                    ]),
-                },
-                slots.default?.()
-            );
+            const attrs: Record<string, unknown> = {
+                class: classList([
+                    'wp-block-post-template',
+                    // Masonry layers `is-layout-grid` underneath
+                    // `is-layout-masonry` so the existing grid CSS
+                    // provides the baseline layout, and the masonry
+                    // stylesheet adds `grid-template-rows: masonry` on
+                    // top via `@supports` for browsers that ship native
+                    // CSS Grid masonry. The JS bootstrap packs the rest.
+                    (isGrid || isMasonry) ? 'is-layout-grid' : '',
+                    isMasonry ? 'is-layout-masonry' : '',
+                    !usesColumns ? 'is-layout-flow' : '',
+                    usesColumns ? `columns-${columns}` : '',
+                    className,
+                ]),
+            };
+
+            if (isMasonry) {
+                attrs['data-ap-cols'] = columns;
+            }
+
+            return h('ul', attrs, slots.default?.());
         };
     },
 });

--- a/packages/visual-editor-renderer-vue/tests/BlockTree.test.ts
+++ b/packages/visual-editor-renderer-vue/tests/BlockTree.test.ts
@@ -1105,6 +1105,29 @@ describe('Core design blocks', () => {
         expect(html).toContain('ap-grid-has-4-lg-columns');
     });
 
+    it('emits the masonry layout-mode class + data-ap-cols on the grid wrapper when layoutMode is masonry (#593)', () => {
+        const html = renderTree([
+            makeBlock('artisanpack/grid', {
+                numColumns: 3,
+                layoutMode: 'masonry',
+            }),
+        ]);
+
+        expect(html).toContain('ap-grid-layout-masonry');
+        expect(html).toContain('data-ap-cols="3"');
+        expect(html).not.toContain('ap-grid-layout-fixed');
+    });
+
+    it('emits the fixed layout-mode class on the grid wrapper by default (#593)', () => {
+        const html = renderTree([
+            makeBlock('artisanpack/grid', { numColumns: 3 }),
+        ]);
+
+        expect(html).toContain('ap-grid-layout-fixed');
+        expect(html).not.toContain('ap-grid-layout-masonry');
+        expect(html).not.toContain('data-ap-cols');
+    });
+
     it('falls back to a safe default when grid-item innerLayout is invalid', () => {
         const tree = [
             makeBlock('artisanpack/grid-item', {

--- a/packages/visual-editor-renderer-vue/tests/PostTemplateMasonry.test.ts
+++ b/packages/visual-editor-renderer-vue/tests/PostTemplateMasonry.test.ts
@@ -57,6 +57,31 @@ describe('artisanpack/post-template — masonry layout (#593)', () => {
         expect(html).not.toContain('data-ap-cols');
     });
 
+    it('accepts numeric-string columns from hosts that round-trip attributes as strings', () => {
+        const html = renderTree([
+            makeBlock('artisanpack/post-template', {
+                layout: 'masonry',
+                columns: '4',
+            }),
+        ]);
+
+        expect(html).toContain('columns-4');
+        expect(html).toContain('data-ap-cols="4"');
+    });
+
+    it('falls back to the default columns when the value is unparseable', () => {
+        const html = renderTree([
+            makeBlock('artisanpack/post-template', {
+                layout: 'masonry',
+                columns: 'evil',
+            }),
+        ]);
+
+        // Default columns = 3.
+        expect(html).toContain('columns-3');
+        expect(html).toContain('data-ap-cols="3"');
+    });
+
     it('defaults to is-layout-flow without columns-N or data-ap-cols', () => {
         const html = renderTree([
             makeBlock('artisanpack/post-template', {}),

--- a/packages/visual-editor-renderer-vue/tests/PostTemplateMasonry.test.ts
+++ b/packages/visual-editor-renderer-vue/tests/PostTemplateMasonry.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Issue #593 — masonry layout option on artisanpack/post-template.
+ *
+ * Verifies the Vue renderer emits the `is-layout-masonry` wrapper class
+ * + `data-ap-cols` attribute when `layout: masonry` is set, while
+ * preserving the existing `is-layout-flow` default and `is-layout-grid`
+ * path.
+ */
+
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+
+import '../src/index';
+import { BlockTree } from '../src/BlockTree';
+import { makeBlock, normalizeHtml } from './helpers';
+import type { Block } from '../src/types';
+
+function renderTree(tree: unknown): string {
+    const wrapper = mount(BlockTree, {
+        props: {
+            tree: tree as Block[] | string | null | undefined,
+        },
+    });
+    return normalizeHtml(wrapper.html());
+}
+
+describe('artisanpack/post-template — masonry layout (#593)', () => {
+    it('emits is-layout-masonry + columns-N + data-ap-cols when layout is masonry', () => {
+        const html = renderTree([
+            makeBlock('artisanpack/post-template', {
+                layout: 'masonry',
+                columns: 4,
+            }),
+        ]);
+
+        expect(html).toContain('is-layout-masonry');
+        // Masonry layers is-layout-grid underneath so Gutenberg's bundled
+        // layout baseline provides `display: grid` inside the editor
+        // canvas iframe and the post-template grid CSS sets columns-N.
+        expect(html).toContain('is-layout-grid');
+        expect(html).toContain('columns-4');
+        expect(html).toContain('data-ap-cols="4"');
+        expect(html).not.toContain('is-layout-flow');
+    });
+
+    it('keeps the existing is-layout-grid path for layout: grid', () => {
+        const html = renderTree([
+            makeBlock('artisanpack/post-template', {
+                layout: 'grid',
+                columns: 3,
+            }),
+        ]);
+
+        expect(html).toContain('is-layout-grid');
+        expect(html).toContain('columns-3');
+        expect(html).not.toContain('is-layout-masonry');
+        expect(html).not.toContain('data-ap-cols');
+    });
+
+    it('defaults to is-layout-flow without columns-N or data-ap-cols', () => {
+        const html = renderTree([
+            makeBlock('artisanpack/post-template', {}),
+        ]);
+
+        expect(html).toContain('is-layout-flow');
+        expect(html).not.toContain('is-layout-masonry');
+        expect(html).not.toContain('is-layout-grid');
+        expect(html).not.toContain('data-ap-cols');
+    });
+});

--- a/resources/js/visual-editor/blocks/__tests__/masonry-layout.test.ts
+++ b/resources/js/visual-editor/blocks/__tests__/masonry-layout.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Issue #593 — masonry layout option for post-template + grid blocks.
+ *
+ * Covers:
+ *   - block.json shape: post-template adds `masonry` to its layout enum,
+ *     grid adds `layoutMode` (`fixed` | `masonry`)
+ *   - default behavior unchanged: post-template defaults to `list`,
+ *     grid defaults to `layoutMode: fixed`
+ *   - grid passes the layout mode down through `providesContext`
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import postTemplateMeta from '../post-template/block.json';
+import gridMeta from '../grid/block.json';
+import gridItemMeta from '../grid-item/block.json';
+
+interface AttributeDefinition {
+    type?: string;
+    enum?: readonly string[];
+    default?: unknown;
+}
+
+describe('artisanpack/post-template — masonry layout (#593)', () => {
+    const attributes = postTemplateMeta.attributes as Record<string, AttributeDefinition>;
+
+    it('exposes layout as a string enum that includes masonry', () => {
+        expect(attributes.layout.type).toBe('string');
+        expect(attributes.layout.enum).toEqual(['list', 'grid', 'masonry']);
+    });
+
+    it('defaults layout to `list` so existing posts keep their flow-layout rendering', () => {
+        expect(attributes.layout.default).toBe('list');
+    });
+});
+
+describe('artisanpack/grid — layoutMode attribute (#593)', () => {
+    const attributes = gridMeta.attributes as Record<string, AttributeDefinition>;
+    const providesContext = (gridMeta as { providesContext?: Record<string, string> })
+        .providesContext ?? {};
+
+    it('declares layoutMode as a `fixed` | `masonry` string enum', () => {
+        expect(attributes.layoutMode.type).toBe('string');
+        expect(attributes.layoutMode.enum).toEqual(['fixed', 'masonry']);
+    });
+
+    it('defaults layoutMode to `fixed` so existing grids keep their fixed-row rendering', () => {
+        expect(attributes.layoutMode.default).toBe('fixed');
+    });
+
+    it('publishes the layoutMode value to grid-item children via block context', () => {
+        expect(providesContext['artisanpack/gridLayoutMode']).toBe('layoutMode');
+    });
+});
+
+describe('artisanpack/grid-item — masonry-aware row-span control (#593)', () => {
+    it('subscribes to the parent grid layoutMode context so inspectors can disable row-span in masonry mode', () => {
+        const usesContext = (gridItemMeta as { usesContext?: readonly string[] }).usesContext ?? [];
+        expect(usesContext).toContain('artisanpack/gridLayoutMode');
+    });
+});

--- a/resources/js/visual-editor/blocks/_shared/masonry/__tests__/fallback.test.ts
+++ b/resources/js/visual-editor/blocks/_shared/masonry/__tests__/fallback.test.ts
@@ -1,0 +1,342 @@
+/**
+ * Issue #593 — JS fallback for the shared masonry layout.
+ *
+ * Exercises the `initMasonry` controller against a jsdom-backed
+ * container. jsdom returns `0` for layout-derived measurements
+ * (`offsetHeight`, `clientWidth`) by default, so we stub those onto the
+ * elements before each layout pass to assert the shortest-column-first
+ * packing math.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+    initMasonry,
+    supportsNativeMasonry,
+} from '../fallback';
+
+let supportsImpl: ((property: string, value?: string) => boolean) | null = null;
+
+function stubCssSupports(returnValue: boolean | ((property: string, value?: string) => boolean)): void {
+    supportsImpl = typeof returnValue === 'function' ? returnValue : (): boolean => returnValue;
+}
+
+function installCssShim(): void {
+    const cssLike = {
+        supports(property: string, value?: string): boolean {
+            return supportsImpl ? supportsImpl(property, value) : false;
+        },
+    };
+    // jsdom does not implement CSS.supports — install a writable shim so
+    // each test can dictate the answer via stubCssSupports().
+    Object.defineProperty(window, 'CSS', {
+        configurable: true,
+        writable: true,
+        value: cssLike,
+    });
+}
+
+interface MeasuredItem {
+    el: HTMLDivElement;
+    height: number;
+    span?: number;
+}
+
+function makeContainer(
+    items: ReadonlyArray<{ height: number; span?: number }>,
+    containerWidth = 300,
+): { container: HTMLDivElement; measured: MeasuredItem[] } {
+    const container = document.createElement('div');
+    Object.defineProperty(container, 'clientWidth', {
+        configurable: true,
+        value: containerWidth,
+    });
+    const measured: MeasuredItem[] = [];
+    for (const spec of items) {
+        const el = document.createElement('div');
+        Object.defineProperty(el, 'offsetHeight', {
+            configurable: true,
+            value: spec.height,
+        });
+        if (spec.span !== undefined) {
+            el.setAttribute('data-ap-col-span', String(spec.span));
+        }
+        container.appendChild(el);
+        measured.push({ el, height: spec.height, span: spec.span });
+    }
+    document.body.appendChild(container);
+    return { container, measured };
+}
+
+beforeEach(() => {
+    // Reset the cached native-support flag so each test starts from a
+    // clean detection — different tests stub `CSS.supports` differently.
+    delete (window as unknown as { __apMasonrySupports?: boolean }).__apMasonrySupports;
+    document.body.innerHTML = '';
+    supportsImpl = null;
+    installCssShim();
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe('supportsNativeMasonry', () => {
+    it('returns true when CSS.supports reports grid-template-rows: masonry', () => {
+        stubCssSupports(true);
+        expect(supportsNativeMasonry()).toBe(true);
+    });
+
+    it('returns false when CSS.supports rejects the rule', () => {
+        stubCssSupports(false);
+        expect(supportsNativeMasonry()).toBe(false);
+    });
+
+    it('caches the detection result for subsequent calls', () => {
+        let callCount = 0;
+        stubCssSupports(() => {
+            callCount += 1;
+            return true;
+        });
+        expect(supportsNativeMasonry()).toBe(true);
+        expect(supportsNativeMasonry()).toBe(true);
+        expect(callCount).toBe(1);
+    });
+});
+
+describe('initMasonry — native path', () => {
+    it('returns a no-op controller when native masonry is supported and forceFallback is false', () => {
+        stubCssSupports(true);
+
+        const { container } = makeContainer([
+            { height: 100 },
+            { height: 200 },
+        ]);
+
+        const controller = initMasonry(container, { columns: 2 });
+
+        // The fallback class is only stamped on the fallback path.
+        expect(container.classList.contains('ap-masonry-js-fallback')).toBe(false);
+        // Items keep their original positioning (no absolute positioning).
+        expect(container.firstElementChild?.classList.contains('ap-masonry-item')).toBe(false);
+        // The controller is callable but does nothing.
+        expect(() => controller.relayout()).not.toThrow();
+        expect(() => controller.destroy()).not.toThrow();
+    });
+
+    it('runs the fallback path when forceFallback is true even with native support', () => {
+        stubCssSupports(true);
+
+        const { container } = makeContainer([
+            { height: 100 },
+        ]);
+
+        initMasonry(container, { columns: 2, forceFallback: true });
+
+        expect(container.classList.contains('ap-masonry-js-fallback')).toBe(true);
+    });
+});
+
+describe('initMasonry — fallback packing', () => {
+    beforeEach(() => {
+        stubCssSupports(false);
+    });
+
+    it('positions items into the shortest column first', () => {
+        const { container, measured } = makeContainer(
+            [
+                { height: 100 }, // → col 0 (height: 100)
+                { height: 200 }, // → col 1 (height: 200)
+                { height: 50 },  // → col 0 (shorter): top: 100
+                { height: 75 },  // → col 0 still shorter than col 1: top: 150
+            ],
+            300,
+        );
+
+        initMasonry(container, { columns: 2, gap: 0, forceFallback: true });
+
+        // Column 0: items at top 0 and top 100.
+        // Column 1: item at top 0.
+        // 4th item lands in col 0 since col 0 total (150) < col 1 (200).
+        expect(measured[0].el.style.left).toBe('0px');
+        expect(measured[0].el.style.top).toBe('0px');
+
+        expect(measured[1].el.style.left).toBe('150px');
+        expect(measured[1].el.style.top).toBe('0px');
+
+        expect(measured[2].el.style.left).toBe('0px');
+        expect(measured[2].el.style.top).toBe('100px');
+
+        expect(measured[3].el.style.left).toBe('0px');
+        expect(measured[3].el.style.top).toBe('150px');
+    });
+
+    it('honors data-ap-col-span for wider items, skipping under-occupied columns', () => {
+        const { container, measured } = makeContainer(
+            [
+                { height: 50 }, // single-span → col 0 (height 50)
+                { height: 50 }, // single-span → col 1 (height 50)
+                { height: 50 }, // single-span → col 2 (height 50)
+                { height: 100, span: 2 }, // 2-span → starts at col 0 (slot with min max)
+            ],
+            300,
+        );
+
+        initMasonry(container, { columns: 3, gap: 0, forceFallback: true });
+
+        // Each column is 100px wide.
+        expect(measured[0].el.style.width).toBe('100px');
+        expect(measured[3].el.style.width).toBe('200px');
+        // 2-span item lands at column 0 top after the row of three 50px items.
+        expect(measured[3].el.style.left).toBe('0px');
+        expect(measured[3].el.style.top).toBe('50px');
+    });
+
+    it('reads the column count from data-ap-cols when no option is passed', () => {
+        const { container, measured } = makeContainer(
+            [
+                { height: 50 },
+                { height: 50 },
+            ],
+            400,
+        );
+        container.setAttribute('data-ap-cols', '4');
+
+        initMasonry(container, { gap: 0, forceFallback: true });
+
+        // Each of 4 columns is 100px wide.
+        expect(measured[0].el.style.width).toBe('100px');
+        expect(measured[1].el.style.left).toBe('100px');
+    });
+
+    it('clamps column counts outside 1-12 to safe defaults', () => {
+        const { container } = makeContainer(
+            [
+                { height: 10 },
+                { height: 10 },
+                { height: 10 },
+            ],
+            300,
+        );
+
+        const controller = initMasonry(container, {
+            columns: 99,
+            gap: 0,
+            forceFallback: true,
+        });
+
+        // 99 clamps to 12 columns → each column is 25px wide.
+        const firstItem = container.firstElementChild as HTMLElement;
+        expect(firstItem.style.width).toBe('25px');
+
+        controller.destroy();
+    });
+
+    it('updates the container height to the tallest packed column', () => {
+        const { container } = makeContainer(
+            [
+                { height: 100 },
+                { height: 200 },
+            ],
+            300,
+        );
+
+        initMasonry(container, { columns: 2, gap: 0, forceFallback: true });
+
+        expect(container.style.height).toBe('200px');
+    });
+
+    it('relayouts when relayout() is called after a child height changes', () => {
+        const { container, measured } = makeContainer(
+            [
+                { height: 100 },
+                { height: 200 },
+            ],
+            300,
+        );
+
+        const controller = initMasonry(container, {
+            columns: 2,
+            gap: 0,
+            forceFallback: true,
+        });
+
+        // Simulate the second item growing taller.
+        Object.defineProperty(measured[1].el, 'offsetHeight', {
+            configurable: true,
+            value: 400,
+        });
+
+        controller.relayout();
+
+        expect(container.style.height).toBe('400px');
+    });
+
+    it('stamps the wrapper + item classes and restores them on destroy', () => {
+        const { container, measured } = makeContainer(
+            [
+                { height: 100 },
+                { height: 200 },
+            ],
+            300,
+        );
+
+        const controller = initMasonry(container, {
+            columns: 2,
+            gap: 0,
+            forceFallback: true,
+        });
+
+        expect(container.classList.contains('ap-masonry-js-fallback')).toBe(true);
+        for (const item of measured) {
+            expect(item.el.classList.contains('ap-masonry-item')).toBe(true);
+            expect(item.el.style.position).toBe('absolute');
+        }
+
+        controller.destroy();
+
+        expect(container.classList.contains('ap-masonry-js-fallback')).toBe(false);
+        for (const item of measured) {
+            expect(item.el.classList.contains('ap-masonry-item')).toBe(false);
+            expect(item.el.style.position).toBe('');
+        }
+    });
+
+    it('detects and re-applies layout on subsequent calls (idempotent)', () => {
+        const { container, measured } = makeContainer(
+            [
+                { height: 100 },
+                { height: 200 },
+            ],
+            300,
+        );
+
+        const controller = initMasonry(container, {
+            columns: 2,
+            gap: 0,
+            forceFallback: true,
+        });
+
+        const firstTop = measured[0].el.style.top;
+        controller.relayout();
+        expect(measured[0].el.style.top).toBe(firstTop);
+
+        controller.destroy();
+    });
+
+    it('reads gridColumnSpan from grid-item span classes when no data attribute is set', () => {
+        const container = document.createElement('div');
+        Object.defineProperty(container, 'clientWidth', { configurable: true, value: 300 });
+
+        const item = document.createElement('div');
+        item.classList.add('ap-grid-item-span-3-base-columns');
+        Object.defineProperty(item, 'offsetHeight', { configurable: true, value: 100 });
+        container.appendChild(item);
+        document.body.appendChild(container);
+
+        initMasonry(container, { columns: 3, gap: 0, forceFallback: true });
+
+        // 3-span item gets full 300px width.
+        expect(item.style.width).toBe('300px');
+    });
+});

--- a/resources/js/visual-editor/blocks/_shared/masonry/__tests__/fallback.test.ts
+++ b/resources/js/visual-editor/blocks/_shared/masonry/__tests__/fallback.test.ts
@@ -13,6 +13,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
     initMasonry,
     supportsNativeMasonry,
+    type MasonryController,
 } from '../fallback';
 
 let supportsImpl: ((property: string, value?: string) => boolean) | null = null;
@@ -68,6 +69,20 @@ function makeContainer(
     return { container, measured };
 }
 
+// Track every controller spawned during a test so afterEach can tear
+// them down — the controllers attach ResizeObserver / MutationObserver /
+// window resize listeners that survive `document.body.innerHTML = ''`.
+const liveControllers: MasonryController[] = [];
+
+function initMasonryTracked(
+    container: HTMLElement,
+    options: Parameters<typeof initMasonry>[1] = {},
+): MasonryController {
+    const controller = initMasonry(container, options);
+    liveControllers.push(controller);
+    return controller;
+}
+
 beforeEach(() => {
     // Reset the cached native-support flag so each test starts from a
     // clean detection — different tests stub `CSS.supports` differently.
@@ -78,6 +93,9 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+    while (liveControllers.length > 0) {
+        liveControllers.pop()?.destroy();
+    }
     vi.restoreAllMocks();
 });
 
@@ -113,7 +131,7 @@ describe('initMasonry — native path', () => {
             { height: 200 },
         ]);
 
-        const controller = initMasonry(container, { columns: 2 });
+        const controller = initMasonryTracked(container, { columns: 2 });
 
         // The fallback class is only stamped on the fallback path.
         expect(container.classList.contains('ap-masonry-js-fallback')).toBe(false);
@@ -131,7 +149,7 @@ describe('initMasonry — native path', () => {
             { height: 100 },
         ]);
 
-        initMasonry(container, { columns: 2, forceFallback: true });
+        initMasonryTracked(container, { columns: 2, forceFallback: true });
 
         expect(container.classList.contains('ap-masonry-js-fallback')).toBe(true);
     });
@@ -153,7 +171,7 @@ describe('initMasonry — fallback packing', () => {
             300,
         );
 
-        initMasonry(container, { columns: 2, gap: 0, forceFallback: true });
+        initMasonryTracked(container, { columns: 2, gap: 0, forceFallback: true });
 
         // Column 0: items at top 0 and top 100.
         // Column 1: item at top 0.
@@ -182,7 +200,7 @@ describe('initMasonry — fallback packing', () => {
             300,
         );
 
-        initMasonry(container, { columns: 3, gap: 0, forceFallback: true });
+        initMasonryTracked(container, { columns: 3, gap: 0, forceFallback: true });
 
         // Each column is 100px wide.
         expect(measured[0].el.style.width).toBe('100px');
@@ -202,11 +220,56 @@ describe('initMasonry — fallback packing', () => {
         );
         container.setAttribute('data-ap-cols', '4');
 
-        initMasonry(container, { gap: 0, forceFallback: true });
+        initMasonryTracked(container, { gap: 0, forceFallback: true });
 
         // Each of 4 columns is 100px wide.
         expect(measured[0].el.style.width).toBe('100px');
         expect(measured[1].el.style.left).toBe('100px');
+    });
+
+    it('picks the per-breakpoint column count from data-ap-cols-{bp} attributes', () => {
+        const { container, measured } = makeContainer(
+            [
+                { height: 50 },
+                { height: 50 },
+            ],
+            400,
+        );
+        container.setAttribute('data-ap-cols', '1');
+        container.setAttribute('data-ap-cols-md', '4');
+        container.setAttribute('data-ap-cols-lg', '8');
+
+        Object.defineProperty(window, 'innerWidth', {
+            configurable: true,
+            value: 800, // > md (768), < lg (1024) — should pick md = 4 columns
+        });
+
+        initMasonryTracked(container, { gap: 0, forceFallback: true });
+
+        // Container is 400px wide / 4 columns → each item is 100px.
+        expect(measured[0].el.style.width).toBe('100px');
+    });
+
+    it('falls back to the base data-ap-cols when no breakpoint matches the viewport', () => {
+        const { container, measured } = makeContainer(
+            [
+                { height: 50 },
+                { height: 50 },
+            ],
+            400,
+        );
+        container.setAttribute('data-ap-cols', '2');
+        container.setAttribute('data-ap-cols-md', '4');
+
+        Object.defineProperty(window, 'innerWidth', {
+            configurable: true,
+            value: 500, // < md (768) — base 2 columns wins
+        });
+
+        initMasonryTracked(container, { gap: 0, forceFallback: true });
+
+        // Container is 400px / 2 columns → each item is 200px.
+        expect(measured[0].el.style.width).toBe('200px');
     });
 
     it('clamps column counts outside 1-12 to safe defaults', () => {
@@ -219,7 +282,7 @@ describe('initMasonry — fallback packing', () => {
             300,
         );
 
-        const controller = initMasonry(container, {
+        const controller = initMasonryTracked(container, {
             columns: 99,
             gap: 0,
             forceFallback: true,
@@ -241,7 +304,7 @@ describe('initMasonry — fallback packing', () => {
             300,
         );
 
-        initMasonry(container, { columns: 2, gap: 0, forceFallback: true });
+        initMasonryTracked(container, { columns: 2, gap: 0, forceFallback: true });
 
         expect(container.style.height).toBe('200px');
     });
@@ -255,7 +318,7 @@ describe('initMasonry — fallback packing', () => {
             300,
         );
 
-        const controller = initMasonry(container, {
+        const controller = initMasonryTracked(container, {
             columns: 2,
             gap: 0,
             forceFallback: true,
@@ -281,7 +344,7 @@ describe('initMasonry — fallback packing', () => {
             300,
         );
 
-        const controller = initMasonry(container, {
+        const controller = initMasonryTracked(container, {
             columns: 2,
             gap: 0,
             forceFallback: true,
@@ -311,7 +374,7 @@ describe('initMasonry — fallback packing', () => {
             300,
         );
 
-        const controller = initMasonry(container, {
+        const controller = initMasonryTracked(container, {
             columns: 2,
             gap: 0,
             forceFallback: true,
@@ -334,7 +397,7 @@ describe('initMasonry — fallback packing', () => {
         container.appendChild(item);
         document.body.appendChild(container);
 
-        initMasonry(container, { columns: 3, gap: 0, forceFallback: true });
+        initMasonryTracked(container, { columns: 3, gap: 0, forceFallback: true });
 
         // 3-span item gets full 300px width.
         expect(item.style.width).toBe('300px');

--- a/resources/js/visual-editor/blocks/_shared/masonry/fallback.ts
+++ b/resources/js/visual-editor/blocks/_shared/masonry/fallback.ts
@@ -30,6 +30,20 @@ const ITEM_CLASS = 'ap-masonry-item';
 const WRAPPER_CLASS = 'ap-masonry-js-fallback';
 const SUPPORTS_CACHE_KEY = '__apMasonrySupports';
 
+/**
+ * Tailwind-style breakpoint min-widths in ascending order. Mirrors
+ * `resources/js/visual-editor/responsive/registry.ts`. Encoded inline
+ * here because the JS fallback is renderer-agnostic and must stay
+ * decoupled from the editor's responsive registry.
+ */
+const BREAKPOINT_MIN_WIDTHS: ReadonlyArray<readonly [string, number]> = [
+    ['sm', 640],
+    ['md', 768],
+    ['lg', 1024],
+    ['xl', 1280],
+    ['2xl', 1536],
+];
+
 interface SupportsCacheHost {
     [SUPPORTS_CACHE_KEY]?: boolean;
 }
@@ -108,6 +122,36 @@ function readColumnsFromAttr(container: HTMLElement, fallback: number): number {
     }
     const parsed = Number(attr);
     return clampColumns(parsed, fallback);
+}
+
+/**
+ * Walk the breakpoint table in ascending min-width order and pick the
+ * column count from the widest breakpoint whose min-width the current
+ * viewport meets. Falls back to the base `data-ap-cols` (or the given
+ * fallback) when no breakpoint matches.
+ */
+function readActiveColumnsFromAttrs(container: HTMLElement, fallback: number): number {
+    const base = readColumnsFromAttr(container, fallback);
+    if (typeof window === 'undefined') {
+        return base;
+    }
+    const viewportWidth = window.innerWidth ?? 0;
+    let active = base;
+    for (const [bp, minWidth] of BREAKPOINT_MIN_WIDTHS) {
+        if (viewportWidth < minWidth) {
+            break;
+        }
+        const attr = container.getAttribute(`data-ap-cols-${bp}`);
+        if (attr === null || attr === '') {
+            continue;
+        }
+        const parsed = Number(attr);
+        if (!Number.isFinite(parsed)) {
+            continue;
+        }
+        active = clampColumns(parsed, active);
+    }
+    return active;
 }
 
 function readItemSpan(el: HTMLElement, maxColumns: number): number {
@@ -190,6 +234,10 @@ export function initMasonry(container: HTMLElement, options: MasonryOptions = {}
 
     let destroyed = false;
     let placements: ItemPlacement[] = [];
+    // Forward-declared so `relayout()` can call `unobserve()` on items
+    // that disappear between layout passes. Assigned just before the
+    // first `relayout()` invocation below.
+    let resizeObserver: ResizeObserver | null = null;
 
     const initialWrapperStyle = {
         position: container.style.position,
@@ -220,17 +268,20 @@ export function initMasonry(container: HTMLElement, options: MasonryOptions = {}
 
         const items = collectItems(container);
         const columns = clampColumns(
-            options.columns ?? readColumnsFromAttr(container, 3),
+            options.columns ?? readActiveColumnsFromAttrs(container, 3),
             3,
         );
         const gap = readGapPx(container, options.gap);
 
         // Refresh placement tracking so newly added items are styled and
-        // removed items have their styles restored.
+        // removed items have their styles restored. Unobserve removed
+        // items from the ResizeObserver so the observer set doesn't
+        // accumulate detached targets across mutations.
         const liveSet = new Set(items);
         for (const placement of placements) {
             if (!liveSet.has(placement.el)) {
                 restoreStyle(placement.el, placement.prevStyle);
+                resizeObserver?.unobserve(placement.el);
             }
         }
         const placementByEl = new Map(placements.map((p) => [p.el, p] as const));
@@ -289,7 +340,7 @@ export function initMasonry(container: HTMLElement, options: MasonryOptions = {}
     // item's content first paints (editor canvas case) its size jumps
     // from 0 to N, but the container's size doesn't, so the
     // container-only observation misses it.
-    const resizeObserver = typeof ResizeObserver !== 'undefined'
+    resizeObserver = typeof ResizeObserver !== 'undefined'
         ? new ResizeObserver(() => relayout())
         : null;
     resizeObserver?.observe(container);

--- a/resources/js/visual-editor/blocks/_shared/masonry/fallback.ts
+++ b/resources/js/visual-editor/blocks/_shared/masonry/fallback.ts
@@ -1,0 +1,419 @@
+/**
+ * Masonry JS fallback (#593).
+ *
+ * Renderer-agnostic shortest-column-first packing for browsers that do
+ * not ship native CSS Grid Level 3 masonry. Used by:
+ *
+ *   - `artisanpack/post-template` editor preview (always — see #593)
+ *   - `artisanpack/grid` editor preview (always)
+ *   - The Blade / React / Vue renderers on the public frontend, where
+ *     each ships a tiny bootstrap that walks the page for wrappers
+ *     carrying `.is-layout-masonry` / `.ap-grid-layout-masonry` and
+ *     calls {@link initMasonry} on them.
+ *
+ * The fallback:
+ *
+ *   - Reads the configured column count from the container (either passed
+ *     via {@link MasonryOptions} or derived from a `data-ap-cols` /
+ *     `--ap-masonry-cols` custom property when invoked from the renderer
+ *     bootstrap).
+ *   - Honours each direct child's `data-ap-col-span` (or `gridColumnSpan`-
+ *     equivalent class on the item). Wider items skip columns under
+ *     them in the packing pass.
+ *   - Listens for resize, child mutations, and image-load events; relayouts
+ *     idempotently on each.
+ *   - Tears down cleanly via {@link MasonryController#destroy}, restoring
+ *     the original wrapper / child styles.
+ */
+
+const ITEM_CLASS = 'ap-masonry-item';
+const WRAPPER_CLASS = 'ap-masonry-js-fallback';
+const SUPPORTS_CACHE_KEY = '__apMasonrySupports';
+
+interface SupportsCacheHost {
+    [SUPPORTS_CACHE_KEY]?: boolean;
+}
+
+export interface MasonryOptions {
+    /** Number of columns. Falls back to data-ap-cols / 3. */
+    columns?: number;
+    /** Skip the @supports gate and always run the fallback. Editor sets this. */
+    forceFallback?: boolean;
+    /** Override the gap (px). Defaults to the computed `gap` on the wrapper. */
+    gap?: number;
+}
+
+export interface MasonryController {
+    /** Force an immediate relayout. */
+    relayout(): void;
+    /** Remove all observers + restore inline styles. */
+    destroy(): void;
+}
+
+/**
+ * Feature-detect native CSS Grid masonry support. Cached on the global
+ * so subsequent calls reuse the same answer — the spec rule is sticky
+ * for the page lifetime.
+ */
+export function supportsNativeMasonry(): boolean {
+    if (typeof window === 'undefined' || typeof CSS === 'undefined') {
+        return false;
+    }
+    const host = window as SupportsCacheHost;
+    const cached = host[SUPPORTS_CACHE_KEY];
+    if (typeof cached === 'boolean') {
+        return cached;
+    }
+    let result = false;
+    try {
+        result = CSS.supports('grid-template-rows', 'masonry');
+    } catch {
+        result = false;
+    }
+    host[SUPPORTS_CACHE_KEY] = result;
+    return result;
+}
+
+interface ItemPlacement {
+    el: HTMLElement;
+    span: number;
+    /** Pre-stored inline style fragments so destroy() can restore them. */
+    prevStyle: {
+        position: string;
+        top: string;
+        left: string;
+        width: string;
+        boxSizing: string;
+    };
+}
+
+function clampColumns(value: number | undefined, fallback: number): number {
+    if (typeof value !== 'number' || !Number.isFinite(value)) {
+        return fallback;
+    }
+    const truncated = Math.trunc(value);
+    if (truncated < 1) {
+        return 1;
+    }
+    if (truncated > 12) {
+        return 12;
+    }
+    return truncated;
+}
+
+function readColumnsFromAttr(container: HTMLElement, fallback: number): number {
+    const attr = container.getAttribute('data-ap-cols');
+    if (attr === null || attr === '') {
+        return fallback;
+    }
+    const parsed = Number(attr);
+    return clampColumns(parsed, fallback);
+}
+
+function readItemSpan(el: HTMLElement, maxColumns: number): number {
+    // Prefer the explicit data attribute the renderers stamp.
+    const dataAttr = el.getAttribute('data-ap-col-span');
+    if (dataAttr !== null) {
+        const parsed = Number(dataAttr);
+        if (Number.isFinite(parsed)) {
+            return Math.min(maxColumns, Math.max(1, Math.trunc(parsed)));
+        }
+    }
+
+    // Fall back to the grid-item span class so author-set
+    // `gridColumnSpan` keeps applying inside masonry (#593 acceptance).
+    const classNames = el.classList;
+    for (let span = maxColumns; span >= 2; span -= 1) {
+        if (classNames.contains(`ap-grid-item-span-${span}-base-columns`)) {
+            return span;
+        }
+    }
+
+    return 1;
+}
+
+function readGapPx(container: HTMLElement, override?: number): number {
+    if (typeof override === 'number' && Number.isFinite(override)) {
+        return Math.max(0, override);
+    }
+    const computed = typeof window !== 'undefined' ? window.getComputedStyle(container) : null;
+    if (computed === null) {
+        return 0;
+    }
+    const raw = computed.rowGap || computed.gap || '0';
+    const parsed = parseFloat(raw);
+    return Number.isFinite(parsed) ? Math.max(0, parsed) : 0;
+}
+
+function collectItems(container: HTMLElement): HTMLElement[] {
+    const items: HTMLElement[] = [];
+    for (const child of Array.from(container.children)) {
+        if (child instanceof HTMLElement) {
+            items.push(child);
+        }
+    }
+    return items;
+}
+
+function snapshotStyle(el: HTMLElement): ItemPlacement['prevStyle'] {
+    return {
+        position: el.style.position,
+        top: el.style.top,
+        left: el.style.left,
+        width: el.style.width,
+        boxSizing: el.style.boxSizing,
+    };
+}
+
+function restoreStyle(el: HTMLElement, prev: ItemPlacement['prevStyle']): void {
+    el.style.position = prev.position;
+    el.style.top = prev.top;
+    el.style.left = prev.left;
+    el.style.width = prev.width;
+    el.style.boxSizing = prev.boxSizing;
+    el.classList.remove(ITEM_CLASS);
+}
+
+/**
+ * Initialise the masonry fallback on a container. Returns a controller
+ * the caller can use to force a relayout or tear the fallback down.
+ *
+ * If the browser supports native CSS Grid masonry AND `forceFallback`
+ * is not set, this is a no-op and the returned controller's `relayout`
+ * and `destroy` methods do nothing — letting the consumer treat the
+ * call site as unconditional.
+ */
+export function initMasonry(container: HTMLElement, options: MasonryOptions = {}): MasonryController {
+    if (!options.forceFallback && supportsNativeMasonry()) {
+        return { relayout: () => undefined, destroy: () => undefined };
+    }
+
+    let destroyed = false;
+    let placements: ItemPlacement[] = [];
+
+    const initialWrapperStyle = {
+        position: container.style.position,
+        height: container.style.height,
+    };
+    const initialClassesAdded: string[] = [];
+    if (!container.classList.contains(WRAPPER_CLASS)) {
+        container.classList.add(WRAPPER_CLASS);
+        initialClassesAdded.push(WRAPPER_CLASS);
+    }
+
+    const trackPlacement = (el: HTMLElement, span: number): ItemPlacement => {
+        const placement: ItemPlacement = {
+            el,
+            span,
+            prevStyle: snapshotStyle(el),
+        };
+        if (!el.classList.contains(ITEM_CLASS)) {
+            el.classList.add(ITEM_CLASS);
+        }
+        return placement;
+    };
+
+    const relayout = (): void => {
+        if (destroyed) {
+            return;
+        }
+
+        const items = collectItems(container);
+        const columns = clampColumns(
+            options.columns ?? readColumnsFromAttr(container, 3),
+            3,
+        );
+        const gap = readGapPx(container, options.gap);
+
+        // Refresh placement tracking so newly added items are styled and
+        // removed items have their styles restored.
+        const liveSet = new Set(items);
+        for (const placement of placements) {
+            if (!liveSet.has(placement.el)) {
+                restoreStyle(placement.el, placement.prevStyle);
+            }
+        }
+        const placementByEl = new Map(placements.map((p) => [p.el, p] as const));
+        const next: ItemPlacement[] = [];
+        for (const item of items) {
+            const span = readItemSpan(item, columns);
+            const existing = placementByEl.get(item);
+            if (existing !== undefined) {
+                existing.span = span;
+                next.push(existing);
+            } else {
+                next.push(trackPlacement(item, span));
+            }
+        }
+        placements = next;
+
+        const containerWidth = container.clientWidth;
+        if (containerWidth <= 0 || items.length === 0) {
+            container.style.height = '0px';
+            return;
+        }
+
+        const totalGap = gap * (columns - 1);
+        const columnWidth = (containerWidth - totalGap) / columns;
+        const columnHeights = new Array<number>(columns).fill(0);
+
+        for (const placement of placements) {
+            const span = Math.min(placement.span, columns);
+            const slot = findSlot(columnHeights, span);
+            const left = slot * (columnWidth + gap);
+            const top = sliceMaxHeight(columnHeights, slot, span);
+            const width = columnWidth * span + gap * (span - 1);
+
+            placement.el.style.position = 'absolute';
+            placement.el.style.boxSizing = 'border-box';
+            placement.el.style.left = `${left}px`;
+            placement.el.style.top = `${top}px`;
+            placement.el.style.width = `${width}px`;
+
+            const itemHeight = placement.el.offsetHeight;
+            const newColumnHeight = top + itemHeight + gap;
+            for (let i = slot; i < slot + span; i += 1) {
+                columnHeights[i] = newColumnHeight;
+            }
+        }
+
+        const maxHeight = Math.max(0, ...columnHeights) - gap;
+        container.style.height = `${Math.max(0, maxHeight)}px`;
+    };
+
+    // Initial layout. Defer to a microtask so consumers that init() right
+    // after mounting catch the children once they've actually painted.
+    relayout();
+
+    // Observe the container AND each item for size changes — when an
+    // item's content first paints (editor canvas case) its size jumps
+    // from 0 to N, but the container's size doesn't, so the
+    // container-only observation misses it.
+    const resizeObserver = typeof ResizeObserver !== 'undefined'
+        ? new ResizeObserver(() => relayout())
+        : null;
+    resizeObserver?.observe(container);
+
+    const observedItems = new WeakSet<HTMLElement>();
+    const observeNewItems = (): void => {
+        if (!resizeObserver) {
+            return;
+        }
+        for (const placement of placements) {
+            if (!observedItems.has(placement.el)) {
+                resizeObserver.observe(placement.el);
+                observedItems.add(placement.el);
+            }
+        }
+    };
+    observeNewItems();
+
+    const mutationObserver = typeof MutationObserver !== 'undefined'
+        ? new MutationObserver(() => {
+              relayout();
+              observeNewItems();
+          })
+        : null;
+    mutationObserver?.observe(container, {
+        childList: true,
+        subtree: true,
+        attributes: true,
+        attributeFilter: ['class', 'data-ap-col-span', 'data-ap-cols'],
+    });
+
+    const onImgLoad = (event: Event): void => {
+        const target = event.target;
+        if (target instanceof HTMLImageElement && container.contains(target)) {
+            relayout();
+        }
+    };
+    container.addEventListener('load', onImgLoad, true);
+
+    const onWindowResize = (): void => relayout();
+    if (typeof window !== 'undefined') {
+        window.addEventListener('resize', onWindowResize);
+    }
+
+    // Tame the empty-then-painted race: Gutenberg's editor canvas
+    // mounts post-template items as empty `<li>` wrappers and then
+    // streams the inner-block tree into them across several frames.
+    // The MutationObserver above eventually catches it, but a couple
+    // of rAF-paced relayouts let the canvas paint correctly within
+    // the first ~50ms instead of waiting on a mutation we don't
+    // control.
+    if (typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function') {
+        let kicks = 0;
+        const kick = (): void => {
+            if (destroyed || kicks > 3) {
+                return;
+            }
+            kicks += 1;
+            relayout();
+            window.requestAnimationFrame(kick);
+        };
+        window.requestAnimationFrame(kick);
+    }
+
+    return {
+        relayout,
+        destroy(): void {
+            if (destroyed) {
+                return;
+            }
+            destroyed = true;
+            resizeObserver?.disconnect();
+            mutationObserver?.disconnect();
+            container.removeEventListener('load', onImgLoad, true);
+            if (typeof window !== 'undefined') {
+                window.removeEventListener('resize', onWindowResize);
+            }
+            for (const placement of placements) {
+                restoreStyle(placement.el, placement.prevStyle);
+            }
+            placements = [];
+            container.style.position = initialWrapperStyle.position;
+            container.style.height = initialWrapperStyle.height;
+            for (const cls of initialClassesAdded) {
+                container.classList.remove(cls);
+            }
+        },
+    };
+}
+
+/**
+ * Walk the column heights array and return the index where a span-wide
+ * window starts at the shortest max height. For a 1-wide span this is
+ * just the shortest column; for an N-wide span we evaluate every valid
+ * starting slot and pick the one whose window-max is the smallest.
+ */
+function findSlot(columnHeights: ReadonlyArray<number>, span: number): number {
+    if (span >= columnHeights.length) {
+        return 0;
+    }
+    let bestSlot = 0;
+    let bestMax = Number.POSITIVE_INFINITY;
+    const lastStart = columnHeights.length - span;
+    for (let start = 0; start <= lastStart; start += 1) {
+        let windowMax = -Infinity;
+        for (let i = start; i < start + span; i += 1) {
+            if (columnHeights[i] > windowMax) {
+                windowMax = columnHeights[i];
+            }
+        }
+        if (windowMax < bestMax) {
+            bestMax = windowMax;
+            bestSlot = start;
+        }
+    }
+    return bestSlot;
+}
+
+function sliceMaxHeight(columnHeights: ReadonlyArray<number>, slot: number, span: number): number {
+    let max = 0;
+    for (let i = slot; i < slot + span; i += 1) {
+        if (columnHeights[i] > max) {
+            max = columnHeights[i];
+        }
+    }
+    return max;
+}

--- a/resources/js/visual-editor/blocks/_shared/masonry/index.ts
+++ b/resources/js/visual-editor/blocks/_shared/masonry/index.ts
@@ -1,0 +1,16 @@
+/**
+ * Shared masonry layout module (#593).
+ *
+ * Re-exports the JS fallback and the shared CSS so the post-template
+ * and grid block entrypoints can pull from a single path:
+ *
+ *     import { initMasonry } from '../_shared/masonry';
+ *     import '../_shared/masonry/masonry.css';
+ */
+
+export {
+    initMasonry,
+    supportsNativeMasonry,
+    type MasonryController,
+    type MasonryOptions,
+} from './fallback';

--- a/resources/js/visual-editor/blocks/_shared/masonry/masonry.css
+++ b/resources/js/visual-editor/blocks/_shared/masonry/masonry.css
@@ -1,0 +1,91 @@
+/**
+ * Shared masonry layout styles (#593).
+ *
+ * Used by `artisanpack/post-template` (layout: masonry) and
+ * `artisanpack/grid` (layoutMode: masonry). The Blade renderer publishes
+ * an identical copy under `packages/visual-editor-renderer-blade/resources/
+ * assets/frontend/masonry.css` so the public frontend, React, and Vue
+ * renderers all read the same class names.
+ *
+ * Two paths:
+ *
+ *   1. Native CSS Grid Level 3 (`grid-template-rows: masonry`). Picked up
+ *      by browsers that ship support; the @supports gate keeps the rule
+ *      from polluting non-supporting browsers' layout.
+ *   2. The JS fallback (`_shared/masonry/fallback.ts`). When the fallback
+ *      runs, it stamps the wrapper with `ap-masonry-js-fallback` and
+ *      absolute-positions each child. The `:not(.ap-masonry-js-fallback)`
+ *      guard prevents the native rule from fighting with the fallback
+ *      while it is active.
+ *
+ * Class layering:
+ *
+ *   - `.is-layout-masonry`               — post-template wrapper
+ *   - `.ap-grid.ap-grid-layout-masonry`  — grid wrapper
+ *   - `.ap-masonry-js-fallback`          — added by the JS fallback on init
+ *   - `.ap-masonry-item`                 — added by the fallback to each child
+ *                                          for absolute positioning
+ */
+
+/* === Native CSS Grid masonry path =================================== */
+
+@supports (grid-template-rows: masonry) {
+    .wp-block-post-template.is-layout-masonry:not(.ap-masonry-js-fallback) {
+        grid-template-rows: masonry;
+    }
+
+    .ap-grid.ap-grid-layout-masonry:not(.ap-masonry-js-fallback) {
+        grid-template-rows: masonry;
+    }
+}
+
+/* === Shared baseline for both paths ================================= */
+
+/* Mirror the post-template fixed-grid rules so the column count is the
+ * same when the native path is not available and the JS fallback has
+ * not yet hydrated. The `:not(.ap-masonry-js-fallback)` guard keeps
+ * these baseline rules from competing with the fallback once it stamps
+ * the wrapper. */
+.wp-block-post-template.is-layout-masonry:not(.ap-masonry-js-fallback) {
+    display: grid;
+    grid-template-columns: repeat(1, minmax(0, 1fr));
+    gap: var(--wp--style--block-gap, 1.25em);
+    list-style: none;
+    padding: 0;
+}
+
+.wp-block-post-template.is-layout-masonry.columns-2:not(.ap-masonry-js-fallback) { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.wp-block-post-template.is-layout-masonry.columns-3:not(.ap-masonry-js-fallback) { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+.wp-block-post-template.is-layout-masonry.columns-4:not(.ap-masonry-js-fallback) { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+.wp-block-post-template.is-layout-masonry.columns-5:not(.ap-masonry-js-fallback) { grid-template-columns: repeat(5, minmax(0, 1fr)); }
+.wp-block-post-template.is-layout-masonry.columns-6:not(.ap-masonry-js-fallback) { grid-template-columns: repeat(6, minmax(0, 1fr)); }
+
+.wp-block-post-template.is-layout-masonry:not(.ap-masonry-js-fallback) > .wp-block-post-template-item {
+    margin: 0;
+    width: auto;
+    min-width: 0;
+}
+
+/* === JS fallback positioning context ================================ */
+
+/* When the JS fallback is active it owns the layout: `display: block`
+ * so children can lift into `position: absolute` without competing
+ * with the baseline grid rules above. The compound selector below
+ * matches the baseline's specificity so the fallback wins
+ * deterministically without resorting to `!important`. */
+.wp-block-post-template.is-layout-masonry.ap-masonry-js-fallback,
+.ap-grid.ap-grid-layout-masonry.ap-masonry-js-fallback,
+.ap-masonry-js-fallback {
+    position: relative;
+    display: block;
+    list-style: none;
+    padding: 0;
+    grid-template-columns: none;
+    grid-template-rows: none;
+}
+
+.ap-masonry-js-fallback > .ap-masonry-item {
+    position: absolute;
+    box-sizing: border-box;
+    margin: 0;
+}

--- a/resources/js/visual-editor/blocks/_shared/masonry/masonry.css
+++ b/resources/js/visual-editor/blocks/_shared/masonry/masonry.css
@@ -70,9 +70,13 @@
 
 /* When the JS fallback is active it owns the layout: `display: block`
  * so children can lift into `position: absolute` without competing
- * with the baseline grid rules above. The compound selector below
- * matches the baseline's specificity so the fallback wins
- * deterministically without resorting to `!important`. */
+ * with the baseline grid rules above. The compound selectors below
+ * match the baseline's specificity so the fallback wins
+ * deterministically without resorting to `!important`.
+ *
+ * `gap` is intentionally preserved here — `readGapPx()` in the
+ * fallback reads the computed value to derive item spacing, so a
+ * missing gap would pack items with zero whitespace. */
 .wp-block-post-template.is-layout-masonry.ap-masonry-js-fallback,
 .ap-grid.ap-grid-layout-masonry.ap-masonry-js-fallback,
 .ap-masonry-js-fallback {
@@ -80,6 +84,7 @@
     display: block;
     list-style: none;
     padding: 0;
+    gap: var(--wp--style--block-gap, 1.25em);
     grid-template-columns: none;
     grid-template-rows: none;
 }

--- a/resources/js/visual-editor/blocks/grid-item/block.json
+++ b/resources/js/visual-editor/blocks/grid-item/block.json
@@ -15,7 +15,8 @@
     ],
     "textdomain": "artisanpack-visual-editor",
     "usesContext": [
-        "numColumns"
+        "numColumns",
+        "artisanpack/gridLayoutMode"
     ],
     "attributes": {
         "innerLayout": {

--- a/resources/js/visual-editor/blocks/grid-item/edit.tsx
+++ b/resources/js/visual-editor/blocks/grid-item/edit.tsx
@@ -45,6 +45,7 @@ interface GridItemAttributes {
 
 interface GridItemContext {
     readonly numColumns?: number;
+    readonly 'artisanpack/gridLayoutMode'?: string;
 }
 
 interface GridItemEditProps {
@@ -79,6 +80,7 @@ export default function GridItemEdit({
     )
         ? attributes.innerLayout
         : 'normal';
+    const isMasonryParent = 'masonry' === context['artisanpack/gridLayoutMode'];
 
     const flexRegistry = new BreakpointRegistry();
     const flexResult = serializeFlex(
@@ -133,7 +135,14 @@ export default function GridItemEdit({
                     />
                     <RangeControl
                         label={__('Row Span', TEXT_DOMAIN)}
-                        help={__('How many grid rows this item spans.', TEXT_DOMAIN)}
+                        help={
+                            isMasonryParent
+                                ? __(
+                                      "Row span doesn't apply in masonry layouts — rows pack automatically.",
+                                      TEXT_DOMAIN
+                                  )
+                                : __('How many grid rows this item spans.', TEXT_DOMAIN)
+                        }
                         value={gridRowSpan}
                         onChange={(value) =>
                             setAttributes({ gridRowSpan: clampSpan(value, 12, 1) })
@@ -142,6 +151,7 @@ export default function GridItemEdit({
                         max={12}
                         allowReset
                         resetFallbackValue={1}
+                        disabled={isMasonryParent}
                         __nextHasNoMarginBottom
                     />
                 </PanelBody>

--- a/resources/js/visual-editor/blocks/grid/block.json
+++ b/resources/js/visual-editor/blocks/grid/block.json
@@ -16,13 +16,22 @@
             "type": "number",
             "default": 4
         },
+        "layoutMode": {
+            "type": "string",
+            "enum": [
+                "fixed",
+                "masonry"
+            ],
+            "default": "fixed"
+        },
         "photoGrid": {
             "type": "object",
             "default": null
         }
     },
     "providesContext": {
-        "numColumns": "numColumns"
+        "numColumns": "numColumns",
+        "artisanpack/gridLayoutMode": "layoutMode"
     },
     "supports": {
         "artisanpackAnimations": true,

--- a/resources/js/visual-editor/blocks/grid/edit.tsx
+++ b/resources/js/visual-editor/blocks/grid/edit.tsx
@@ -16,7 +16,7 @@
 
 import type { ReactElement } from 'react';
 import { InspectorControls, useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
-import { PanelBody, RangeControl } from '@wordpress/components';
+import { PanelBody, RangeControl, ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 import { TEXT_DOMAIN } from '../../vendor/i18n';
@@ -26,9 +26,16 @@ import {
     type PhotoGridAttribute,
 } from '../_shared/photo-grid';
 
+type GridLayoutMode = 'fixed' | 'masonry';
+
 interface GridAttributes {
     readonly numColumns: number;
+    readonly layoutMode?: GridLayoutMode;
     readonly photoGrid?: PhotoGridAttribute | null;
+}
+
+function normalizeLayoutMode( value: unknown ): GridLayoutMode {
+    return 'masonry' === value ? 'masonry' : 'fixed';
 }
 
 interface GridEditProps {
@@ -58,17 +65,36 @@ function clampColumns(value: number | undefined, fallback: number): number {
 
 export default function GridEdit({ attributes, setAttributes }: GridEditProps): ReactElement {
     const numColumns = clampColumns(attributes.numColumns, 4);
+    const layoutMode = normalizeLayoutMode(attributes.layoutMode);
+    const isMasonry = 'masonry' === layoutMode;
 
     const photoGridWrapper = getPhotoGridWrapperProps(attributes);
     const className = [
         'ap-grid',
         `ap-grid-has-${numColumns}-base-columns`,
+        isMasonry ? 'ap-grid-layout-masonry' : 'ap-grid-layout-fixed',
         photoGridWrapper.className,
     ]
         .filter(Boolean)
         .join(' ');
+
+    // Editor canvas preview path:
+    //   - Browsers that ship native `grid-template-rows: masonry`
+    //     render the canvas with true packed layout via `@supports`.
+    //   - Other browsers see a regular columned grid in the canvas —
+    //     same as the fixed-grid mode. We deliberately do NOT run the
+    //     JS fallback inside Gutenberg's editor canvas: freshly-
+    //     inserted grid-items are empty, so the fallback measures
+    //     their height as 0 and collapses the wrapper. The public
+    //     frontend's masonry-fallback bootstrap packs items at render
+    //     time for both groups, so the published page is always packed.
     const blockProps = useBlockProps({ className, style: photoGridWrapper.style });
-    const innerBlocksProps = useInnerBlocksProps(blockProps, {
+    const outerProps: Record<string, unknown> = { ...blockProps };
+    if (isMasonry) {
+        outerProps['data-ap-cols'] = numColumns;
+    }
+
+    const innerBlocksProps = useInnerBlocksProps(outerProps, {
         allowedBlocks: ALLOWED_BLOCKS,
         template: TEMPLATE,
     });
@@ -87,6 +113,25 @@ export default function GridEdit({ attributes, setAttributes }: GridEditProps): 
                         max={12}
                         allowReset
                         resetFallbackValue={4}
+                        __nextHasNoMarginBottom
+                    />
+                    <ToggleControl
+                        label={__('Masonry layout', TEXT_DOMAIN)}
+                        help={
+                            isMasonry
+                                ? __(
+                                      'Items pack into columns by height. Row spans on grid items are ignored.',
+                                      TEXT_DOMAIN
+                                  )
+                                : __(
+                                      'Toggle on to pack items into columns with variable heights.',
+                                      TEXT_DOMAIN
+                                  )
+                        }
+                        checked={isMasonry}
+                        onChange={(next) =>
+                            setAttributes({ layoutMode: next ? 'masonry' : 'fixed' })
+                        }
                         __nextHasNoMarginBottom
                     />
                 </PanelBody>

--- a/resources/js/visual-editor/blocks/grid/index.ts
+++ b/resources/js/visual-editor/blocks/grid/index.ts
@@ -13,6 +13,7 @@ import icon from './inserter-icon';
 
 import './grid.css';
 import '../_shared/photo-grid/photo-grid.css';
+import '../_shared/masonry/masonry.css';
 
 export { edit, save, metadata, icon };
 

--- a/resources/js/visual-editor/blocks/post-template/block.json
+++ b/resources/js/visual-editor/blocks/post-template/block.json
@@ -12,6 +12,11 @@
     "attributes": {
         "layout": {
             "type": "string",
+            "enum": [
+                "list",
+                "grid",
+                "masonry"
+            ],
             "default": "list"
         },
         "columns": {

--- a/resources/js/visual-editor/blocks/post-template/edit.tsx
+++ b/resources/js/visual-editor/blocks/post-template/edit.tsx
@@ -24,13 +24,22 @@ import {
     ToolbarGroup,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { list, grid } from '@wordpress/icons';
+import { list, grid, layout } from '@wordpress/icons';
 
 import { readQueryPreviewContext } from '../../editor/query-preview-context';
 import { QueryPreviewIterations } from '../../editor/query-preview-iterations';
 import { TEXT_DOMAIN } from '../../vendor/i18n';
 
 const DEFAULT_TEMPLATE: ReadonlyArray<[string]> = [ [ 'artisanpack/post-title' ] ];
+
+type PostTemplateLayout = 'list' | 'grid' | 'masonry';
+
+function normalizeLayout( value: unknown ): PostTemplateLayout {
+    if ( 'grid' === value || 'masonry' === value ) {
+        return value;
+    }
+    return 'list';
+}
 
 interface PostTemplateEditProps {
     attributes: Record<string, unknown>;
@@ -45,23 +54,50 @@ export default function PostTemplateEdit( {
     clientId,
     context,
 }: PostTemplateEditProps ): ReactElement {
-    const layout = typeof attributes.layout === 'string' ? attributes.layout : 'list';
+    const layoutValue = normalizeLayout( attributes.layout );
     const columns = typeof attributes.columns === 'number' ? attributes.columns : 3;
-    const isGrid = layout === 'grid';
+    const isGrid = 'grid' === layoutValue;
+    const isMasonry = 'masonry' === layoutValue;
+    const usesColumns = isGrid || isMasonry;
 
     // Match the Blade renderer's class set so the editor canvas and the
-    // public frontend use the same CSS-grid layout. `is-layout-grid` +
-    // `columns-{n}` together activate the rules shipped via the
-    // post-variant stylesheet, which also powers per-post column / row
-    // spans (#592).
+    // public frontend use the same CSS-grid layout.
+    //
+    // For masonry we layer `is-layout-grid` underneath `is-layout-masonry`
+    // so Gutenberg's bundled layout baseline (which only knows about the
+    // standard `is-layout-grid` class) gives us `display: grid` inside
+    // the editor canvas iframe, and the post-template's existing grid
+    // rules give us `grid-template-columns`. The `is-layout-masonry`
+    // class then layers `grid-template-rows: masonry` on top via
+    // `@supports` for browsers that ship native CSS Grid masonry — non-
+    // supporting browsers see a regular columned grid in the canvas,
+    // which the public frontend's JS fallback packs at render time.
     const className = [
         'wp-block-post-template',
-        isGrid ? 'is-layout-grid' : 'is-layout-flow',
-        isGrid ? `columns-${ columns }` : '',
+        ( isGrid || isMasonry ) ? 'is-layout-grid' : '',
+        isMasonry ? 'is-layout-masonry' : '',
+        ! usesColumns ? 'is-layout-flow' : '',
+        usesColumns ? `columns-${ columns }` : '',
     ].filter( Boolean ).join( ' ' );
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const blockProps = ( useBlockProps as any )( { className } );
+
+    // Editor canvas preview path:
+    //   - Browsers that ship native `grid-template-rows: masonry`
+    //     render the canvas with true packed layout via @supports.
+    //   - Other browsers see a regular columned grid (visually the
+    //     same as `layout: grid`). The public frontend's masonry-
+    //     fallback bootstrap packs items for both groups, so the
+    //     published page is always packed even if the canvas isn't.
+    // We deliberately don't run the JS fallback here: doing so inside
+    // Gutenberg's canvas iframe leaves items absolutely-positioned
+    // before BlockContextProvider streams their content in, so they
+    // measure 0px and collapse the wrapper.
+    const outerProps: Record< string, unknown > = { ...blockProps };
+    if ( isMasonry ) {
+        outerProps[ 'data-ap-cols' ] = columns;
+    }
 
     const previewValue = readQueryPreviewContext( context );
     const postType = typeof context?.postType === 'string' && context.postType !== ''
@@ -75,7 +111,7 @@ export default function PostTemplateEdit( {
                     <ToolbarButton
                         icon={ list }
                         label={ __( 'List view', TEXT_DOMAIN ) }
-                        isPressed={ ! isGrid }
+                        isPressed={ 'list' === layoutValue }
                         onClick={ () => setAttributes( { layout: 'list' } ) }
                     />
                     <ToolbarButton
@@ -84,10 +120,16 @@ export default function PostTemplateEdit( {
                         isPressed={ isGrid }
                         onClick={ () => setAttributes( { layout: 'grid' } ) }
                     />
+                    <ToolbarButton
+                        icon={ layout }
+                        label={ __( 'Masonry view', TEXT_DOMAIN ) }
+                        isPressed={ isMasonry }
+                        onClick={ () => setAttributes( { layout: 'masonry' } ) }
+                    />
                 </ToolbarGroup>
             </BlockControls>
 
-            { isGrid && (
+            { usesColumns && (
                 <InspectorControls>
                     <PanelBody title={ __( 'Layout', TEXT_DOMAIN ) }>
                         <RangeControl
@@ -101,6 +143,12 @@ export default function PostTemplateEdit( {
                             }
                             min={ 2 }
                             max={ 6 }
+                            help={ isMasonry
+                                ? __(
+                                    'Masonry packs items into columns by shortest-column-first; row spans are ignored in this layout.',
+                                    TEXT_DOMAIN
+                                )
+                                : undefined }
                         />
                     </PanelBody>
                 </InspectorControls>
@@ -111,7 +159,7 @@ export default function PostTemplateEdit( {
                 preview={ previewValue }
                 postType={ postType }
                 defaultTemplate={ DEFAULT_TEMPLATE }
-                outerProps={ blockProps as Record<string, unknown> }
+                outerProps={ outerProps }
             />
         </>
     );

--- a/resources/js/visual-editor/blocks/post-template/index.ts
+++ b/resources/js/visual-editor/blocks/post-template/index.ts
@@ -19,6 +19,7 @@ import transforms from './transforms';
 import icon from './inserter-icon';
 
 import './post-template.css';
+import '../_shared/masonry/masonry.css';
 
 export { edit, save, metadata, icon, transforms };
 


### PR DESCRIPTION
## Description

Adds `masonry` as a first-class layout choice on the existing `artisanpack/post-template` and `artisanpack/grid` blocks (no new blocks). Native CSS Grid masonry (`grid-template-rows: masonry`) lights up automatically where the browser supports it via `@supports`; otherwise the public frontend runs a shared JS bootstrap that packs items shortest-column-first, with support for resize, mutation, image load, and `gridColumnSpan` for wider items.

**Closes:** #593

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #593

## Motivation and Context

Both the Query Loop (via post-template) and the standalone Grid block today expose only fixed-row grid as their multi-column layout. There's no native masonry option — the Pinterest-style packed-tile layout where items have variable heights and pack into columns left-to-right without leaving vertical whitespace. Users currently work around this with custom CSS or third-party JS. This change offers masonry as a first-class layout option, sharing the implementation between the two host blocks.

## Changes Made

- **`post-template`**: adds `masonry` to the `layout` enum, plus a Masonry toolbar button alongside List and Grid. Columns control gains a masonry-specific help line.
- **`grid`**: adds a new `layoutMode` attribute (`fixed` | `masonry`) exposed via a `ToggleControl`. Publishes the layout mode to grid-item children via `providesContext`.
- **`grid-item`**: subscribes to the parent grid's layout mode and disables the row-span control with an explanatory hint when the parent is masonry (`gridColumnSpan` still applies per the spec).
- **Shared masonry module** at `resources/js/visual-editor/blocks/_shared/masonry/`:
  - `masonry.css` — native `@supports (grid-template-rows: masonry)` rule + JS-fallback positioning context.
  - `fallback.ts` — `initMasonry(container, options)` controller with renderer-agnostic shortest-column-first packing, native-support feature detection, `data-ap-col-span` honoring, resize/mutation/image-load observers, and clean teardown.
- **Blade renderer** ships `frontend/masonry.css` + `frontend/masonry-fallback.js` (plain-JS port of the controller) and wires both through `<x-ve-blocks-styles />`.
- **React + Vue renderers** emit the same `is-layout-masonry` / `ap-grid-layout-masonry` classes and `data-ap-cols` attribute so the bootstrap can target them.
- Masonry layers `is-layout-grid` underneath `is-layout-masonry` so Gutenberg's bundled layout baseline provides `display: grid` inside the editor canvas iframe and the post-template grid CSS sets the per-breakpoint columns-N tracks.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (Darwin 25.5.0)
- Browser: Safari (no native CSS Grid masonry yet — exercised the non-native code path)
- PHP Version: 8.4.3
- Project Version: 1.2.0 (release/1.2 branch)

**Tests Performed:**

1. Toggled masonry on the post-template and grid blocks in the dev app editor canvas — verified columned grid preview renders correctly (Safari = no native masonry).
2. Saved the page and verified the public frontend HTML emits `is-layout-masonry` + `is-layout-grid` + `columns-N` + `data-ap-cols`, and the masonry-fallback bootstrap packs items into a packed layout.
3. Verified the row-span control on grid-items grays out with the explanatory hint when the parent is masonry, and re-enables when switched back to fixed.
4. Verified column span (`gridColumnSpan`) still applies in masonry mode — items configured with span 2 render twice as wide.

## Accessibility Tests Run

- [x] Keyboard navigation tested (toolbar toggle, ToggleControl, RangeControl all keyboard-operable — inherits Gutenberg's existing accessibility)
- [x] Screen reader tested (toolbar buttons + range controls inherit `__()`-localised labels + help text)
- [ ] Color contrast verified — N/A (no color changes)
- [x] ARIA labels checked (toolbar buttons use `label`; range/toggle inherit Gutenberg defaults)

**Details:** Masonry preview is purely layout — no interactive content was added. All controls use Gutenberg's accessible `ToolbarButton`, `RangeControl`, and `ToggleControl` primitives with localised labels and help text.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:**

- `resources/js/visual-editor/blocks/__tests__/masonry-layout.test.ts` — block.json shape (6 tests).
- `resources/js/visual-editor/blocks/_shared/masonry/__tests__/fallback.test.ts` — JS fallback unit tests (14 tests: feature detection caching, shortest-column-first packing, span handling, column clamping, container height, relayout, destroy + style restoration).
- `packages/visual-editor-renderer-react/tests/PostTemplateMasonry.test.tsx` + `BlockTree.test.tsx` updates — React renderer parity (5 tests).
- `packages/visual-editor-renderer-vue/tests/PostTemplateMasonry.test.ts` + `BlockTree.test.ts` updates — Vue renderer parity (5 tests).
- `packages/visual-editor-renderer-blade/tests/Feature/MasonryLayoutRenderTest.php` — Blade output + `<x-ve-blocks-styles />` wiring (7 tests).

**Totals (full suite run):**
- 2253 / 2253 JS tests passing.
- 1323 / 1323 PHP tests passing (1 pre-existing skip).
- Renderer-parity script clean.

## Documentation

- [x] Inline code documentation added
- [ ] README updated — N/A (no public API changes)
- [ ] Wiki updated — N/A (no public API changes)
- [ ] API documentation updated — N/A (no public API changes)

**Documentation details:** Inline comments on edit components and the masonry CSS / JS fallback explain:
- The class-layering strategy (`is-layout-grid` underneath `is-layout-masonry`).
- Why the JS fallback is deliberately NOT run inside Gutenberg's editor canvas (empty grid-items measure 0; post-template streams content across frames via `BlockContextProvider`).
- Why native `@supports (grid-template-rows: masonry)` is used as the feature gate.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [x] Accessibility tests completed
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

## Trade-off Notes

**Editor canvas preview vs. public frontend:**

- **Chrome 142+** (native CSS Grid masonry): editor canvas + frontend both pack via `@supports`.
- **Safari / Firefox / other non-native browsers**: editor canvas shows a regular columned grid (same as the existing fixed-grid mode would look); the public frontend always packs via the JS bootstrap.

The acceptance criterion "editor canvas uses the JS fallback so preview is consistent" turned out to be unworkable in practice given Gutenberg's canvas behavior — freshly-inserted grid-items are empty (height 0) so the fallback collapses the wrapper, and post-template iterations stream content across frames via `BlockContextProvider` so heights can't be measured reliably. The compromise (column-grid preview + frontend-packed output) is documented in the editor edit components.

Once Safari + Firefox ship native masonry support, the canvas preview will light up automatically via the `@supports` rule — no code change needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added masonry layout support to grid and post-template blocks, including configurable columns and responsive column overrides.
  * Introduced shared masonry styling with an automatic JavaScript fallback that packs items when native masonry isn’t available.
  * Updated the editor UI with a “Masonry layout” toggle, and disabled grid-item row span controls while masonry is active.
* **Tests**
  * Added automated coverage for masonry rendering and the fallback behavior across supported implementations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->