### PR TITLE
fix: resolve post-variants per iteration in editor canvas

### DIFF
--- a/resources/js/visual-editor/blocks/query/__tests__/post-variants-panel.test.tsx
+++ b/resources/js/visual-editor/blocks/query/__tests__/post-variants-panel.test.tsx
@@ -50,17 +50,15 @@ vi.mock( '@wordpress/blocks', () => ( {
         createBlockCalls.push( { name, attributes, innerBlocks } );
         return block;
     },
-    cloneBlock: ( source: FakeBlock ): FakeBlock => ( {
-        clientId: newClientId(),
-        name: source.name,
-        attributes: { ...source.attributes },
-        innerBlocks: ( source.innerBlocks ?? [] ).map( ( child ) => ( {
+    cloneBlock: ( source: FakeBlock ): FakeBlock => {
+        const cloneDeep = ( block: FakeBlock ): FakeBlock => ( {
             clientId: newClientId(),
-            name: child.name,
-            attributes: { ...child.attributes },
-            innerBlocks: child.innerBlocks ?? [],
-        } ) ),
-    } ),
+            name: block.name,
+            attributes: { ...block.attributes },
+            innerBlocks: ( block.innerBlocks ?? [] ).map( cloneDeep ),
+        } );
+        return cloneDeep( source );
+    },
 } ) );
 
 vi.mock( '@wordpress/data', () => {

--- a/resources/js/visual-editor/blocks/query/__tests__/post-variants-panel.test.tsx
+++ b/resources/js/visual-editor/blocks/query/__tests__/post-variants-panel.test.tsx
@@ -1,0 +1,240 @@
+/**
+ * Tests for the Post Variants panel's `handleAdd` seeding behavior
+ * (#604). When the user clicks "Add … variant", the new variant block
+ * should be seeded with a deep clone of the post-template's current
+ * non-variant inner blocks rather than starting empty.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render } from '@testing-library/react';
+
+interface FakeBlock {
+    clientId: string;
+    name: string;
+    attributes: Record<string, unknown>;
+    innerBlocks?: FakeBlock[];
+}
+
+interface CreateBlockCall {
+    name: string;
+    attributes: Record<string, unknown>;
+    innerBlocks: FakeBlock[];
+}
+
+interface InsertBlockCall {
+    block: FakeBlock;
+    index: number | undefined;
+    rootClientId: string | undefined;
+}
+
+const createBlockCalls: CreateBlockCall[] = [];
+const insertBlockCalls: InsertBlockCall[] = [];
+const selectBlockCalls: string[] = [];
+
+const fakeQueryChildren: FakeBlock[] = [];
+
+let nextClientId = 0;
+function newClientId(): string {
+    nextClientId += 1;
+    return `cid-${ nextClientId }`;
+}
+
+vi.mock( '@wordpress/blocks', () => ( {
+    createBlock: ( name: string, attributes: Record<string, unknown>, innerBlocks: FakeBlock[] = [] ) => {
+        const block: FakeBlock = {
+            clientId: newClientId(),
+            name,
+            attributes,
+            innerBlocks,
+        };
+        createBlockCalls.push( { name, attributes, innerBlocks } );
+        return block;
+    },
+    cloneBlock: ( source: FakeBlock ): FakeBlock => ( {
+        clientId: newClientId(),
+        name: source.name,
+        attributes: { ...source.attributes },
+        innerBlocks: ( source.innerBlocks ?? [] ).map( ( child ) => ( {
+            clientId: newClientId(),
+            name: child.name,
+            attributes: { ...child.attributes },
+            innerBlocks: child.innerBlocks ?? [],
+        } ) ),
+    } ),
+} ) );
+
+vi.mock( '@wordpress/data', () => {
+    const store = {
+        getBlocks: () => fakeQueryChildren,
+        getBlock: ( clientId: string ): FakeBlock | null => {
+            const walk = ( blocks: FakeBlock[] ): FakeBlock | null => {
+                for ( const block of blocks ) {
+                    if ( block.clientId === clientId ) {
+                        return block;
+                    }
+                    const nested = walk( block.innerBlocks ?? [] );
+                    if ( nested !== null ) {
+                        return nested;
+                    }
+                }
+                return null;
+            };
+            return walk( fakeQueryChildren );
+        },
+    };
+    return {
+        select: () => store,
+        useSelect: ( callback: ( selector: ( name: string ) => typeof store ) => unknown ) =>
+            callback( () => store ),
+        useDispatch: () => ( {
+            insertBlock: ( block: FakeBlock, index?: number, rootClientId?: string ) => {
+                insertBlockCalls.push( { block, index, rootClientId } );
+            },
+            moveBlockToPosition: () => undefined,
+            removeBlock: () => undefined,
+            selectBlock: ( clientId: string ) => {
+                selectBlockCalls.push( clientId );
+            },
+            updateBlockAttributes: () => undefined,
+        } ),
+    };
+} );
+
+vi.mock( '@wordpress/components', async () => {
+    const { createElement } = await import( 'react' );
+    return {
+        Button: ( props: Record<string, unknown> ) =>
+            createElement( 'button', {
+                type: 'button',
+                onClick: props.onClick,
+                'aria-label': props[ 'aria-label' ],
+                disabled: props.disabled,
+                children: props.children,
+            } ),
+        PanelBody: ( { children }: { children: React.ReactNode } ) =>
+            createElement( 'section', null, children ),
+    };
+} );
+
+vi.mock( '@wordpress/i18n', () => ( {
+    __: ( text: string ) => text,
+} ) );
+
+import PostVariantsPanel from '../post-variants-panel';
+
+const QUERY_CLIENT_ID = 'query-1';
+const POST_TEMPLATE_CLIENT_ID = 'pt-1';
+
+function setupPostTemplate( children: FakeBlock[] ): void {
+    fakeQueryChildren.length = 0;
+    fakeQueryChildren.push( {
+        clientId: POST_TEMPLATE_CLIENT_ID,
+        name: 'artisanpack/post-template',
+        attributes: {},
+        innerBlocks: children,
+    } );
+}
+
+beforeEach( () => {
+    createBlockCalls.length = 0;
+    insertBlockCalls.length = 0;
+    selectBlockCalls.length = 0;
+    nextClientId = 0;
+} );
+
+describe( 'PostVariantsPanel handleAdd seeding (#604)', () => {
+    it( 'seeds the new variant with a deep clone of the post-template base children', () => {
+        setupPostTemplate( [
+            {
+                clientId: 'title-1',
+                name: 'core/post-title',
+                attributes: { level: 2 },
+            },
+            {
+                clientId: 'cover-1',
+                name: 'core/cover',
+                attributes: { color: 'red' },
+                innerBlocks: [
+                    { clientId: 'inner-1', name: 'core/heading', attributes: { content: 'Hi' } },
+                ],
+            },
+        ] );
+
+        const { getByText } = render(
+            <PostVariantsPanel queryClientId={ QUERY_CLIENT_ID } previewTotal={ 3 } />
+        );
+
+        fireEvent.click( getByText( 'Add position variant' ) );
+
+        expect( createBlockCalls ).toHaveLength( 1 );
+        const created = createBlockCalls[ 0 ];
+        expect( created.name ).toBe( 'artisanpack/post-variant' );
+        expect( created.attributes.matcher ).toEqual( { kind: 'position', value: 'first' } );
+        // Seeded inner blocks deep-equal the base children by shape.
+        expect( created.innerBlocks ).toHaveLength( 2 );
+        expect( created.innerBlocks[ 0 ].name ).toBe( 'core/post-title' );
+        expect( created.innerBlocks[ 0 ].attributes ).toEqual( { level: 2 } );
+        expect( created.innerBlocks[ 1 ].name ).toBe( 'core/cover' );
+        expect( created.innerBlocks[ 1 ].attributes ).toEqual( { color: 'red' } );
+        // Cloned clientIds are independent from the originals.
+        expect( created.innerBlocks[ 0 ].clientId ).not.toBe( 'title-1' );
+        expect( created.innerBlocks[ 1 ].clientId ).not.toBe( 'cover-1' );
+        // Nested innerBlocks are deep-cloned, not shared by reference.
+        const nested = created.innerBlocks[ 1 ].innerBlocks ?? [];
+        expect( nested ).toHaveLength( 1 );
+        expect( nested[ 0 ].name ).toBe( 'core/heading' );
+        expect( nested[ 0 ].attributes ).toEqual( { content: 'Hi' } );
+        expect( nested[ 0 ].clientId ).not.toBe( 'inner-1' );
+    } );
+
+    it( 'excludes existing post-variant blocks from the seed', () => {
+        setupPostTemplate( [
+            { clientId: 'title-1', name: 'core/post-title', attributes: {} },
+            {
+                clientId: 'variant-existing',
+                name: 'artisanpack/post-variant',
+                attributes: { matcher: { kind: 'position', value: 'last' } },
+                innerBlocks: [],
+            },
+        ] );
+
+        const { getByText } = render(
+            <PostVariantsPanel queryClientId={ QUERY_CLIENT_ID } previewTotal={ 3 } />
+        );
+
+        fireEvent.click( getByText( 'Add pattern variant' ) );
+
+        const created = createBlockCalls[ 0 ];
+        expect( created.innerBlocks.map( ( block ) => block.name ) ).toEqual( [
+            'core/post-title',
+        ] );
+    } );
+
+    it( 'selects the newly inserted variant so the inspector opens immediately', () => {
+        setupPostTemplate( [
+            { clientId: 'title-1', name: 'core/post-title', attributes: {} },
+        ] );
+
+        const { getByText } = render(
+            <PostVariantsPanel queryClientId={ QUERY_CLIENT_ID } previewTotal={ 3 } />
+        );
+
+        fireEvent.click( getByText( 'Add metadata variant' ) );
+
+        expect( insertBlockCalls ).toHaveLength( 1 );
+        const insertedClientId = insertBlockCalls[ 0 ].block.clientId;
+        expect( selectBlockCalls ).toContain( insertedClientId );
+    } );
+
+    it( 'seeds an empty variant when the post-template currently has no base children', () => {
+        setupPostTemplate( [] );
+
+        const { getByText } = render(
+            <PostVariantsPanel queryClientId={ QUERY_CLIENT_ID } previewTotal={ 3 } />
+        );
+
+        fireEvent.click( getByText( 'Add position variant' ) );
+
+        expect( createBlockCalls[ 0 ].innerBlocks ).toEqual( [] );
+    } );
+} );

--- a/resources/js/visual-editor/blocks/query/post-variants-panel.tsx
+++ b/resources/js/visual-editor/blocks/query/post-variants-panel.tsx
@@ -197,9 +197,24 @@ export default function PostVariantsPanel( {
         // clientIds recursively so the clones are independent.
         const store = dataSelect( 'core/block-editor' ) as unknown as CoreBlockEditorSelect;
         const postTemplate = store.getBlock( postTemplateClientId );
-        const baseChildren: BlockInstance[] = ( postTemplate?.innerBlocks ?? [] )
+        const templateChildren = postTemplate?.innerBlocks ?? [];
+        const baseChildren: BlockInstance[] = templateChildren
             .filter( ( child ) => child.name !== 'artisanpack/post-variant' )
             .map( ( child ) => cloneBlock( child as unknown as BlockInstance ) );
+
+        // Compute the insertion index from the template's actual child
+        // list — not from the variant count. With non-variant base
+        // children present (the common case), `variantRows.length`
+        // would drop the new variant into the middle of the base
+        // children and shift variant document order, changing
+        // precedence in ways the author can't see.
+        const lastVariantIndex = templateChildren.reduce(
+            ( last, child, index ) =>
+                child.name === 'artisanpack/post-variant' ? index : last,
+            -1
+        );
+        const insertIndex =
+            lastVariantIndex >= 0 ? lastVariantIndex + 1 : templateChildren.length;
 
         const block = createBlock(
             'artisanpack/post-variant',
@@ -209,7 +224,7 @@ export default function PostVariantsPanel( {
             },
             baseChildren
         );
-        insertBlock( block, variantRows.length, postTemplateClientId );
+        insertBlock( block, insertIndex, postTemplateClientId );
         // Focus the new variant so its inspector controls open
         // immediately — auto-jump in the canvas (#604) then surfaces
         // the matching iteration as the editable one.

--- a/resources/js/visual-editor/blocks/query/post-variants-panel.tsx
+++ b/resources/js/visual-editor/blocks/query/post-variants-panel.tsx
@@ -12,8 +12,8 @@
 
 import { useEffect, useMemo, type ReactElement } from 'react';
 import { Button, PanelBody } from '@wordpress/components';
-import { useDispatch, useSelect } from '@wordpress/data';
-import { createBlock } from '@wordpress/blocks';
+import { select as dataSelect, useDispatch, useSelect } from '@wordpress/data';
+import { cloneBlock, createBlock, type BlockInstance } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 
 import { TEXT_DOMAIN } from '../../vendor/i18n';
@@ -34,6 +34,7 @@ interface BlockEditorBlock {
 
 interface CoreBlockEditorSelect {
     getBlocks: ( clientId?: string ) => BlockEditorBlock[];
+    getBlock: ( clientId: string ) => BlockEditorBlock | null;
 }
 
 interface CoreBlockEditorDispatch {
@@ -187,11 +188,32 @@ export default function PostVariantsPanel( {
         if ( postTemplateClientId === null ) {
             return;
         }
-        const block = createBlock( 'artisanpack/post-variant', {
-            matcher: defaultMatcherFor( kind ),
-            priority: 10,
-        } );
+        // Seed the new variant's inner blocks with a deep clone of the
+        // post-template's current non-variant children. Authors almost
+        // always want to start from the base template and tweak rather
+        // than rebuild the title / image / etc. from scratch. Read
+        // through `select` (not the captured `subscription`) so we get
+        // the latest tree at click time — `cloneBlock` regenerates
+        // clientIds recursively so the clones are independent.
+        const store = dataSelect( 'core/block-editor' ) as unknown as CoreBlockEditorSelect;
+        const postTemplate = store.getBlock( postTemplateClientId );
+        const baseChildren: BlockInstance[] = ( postTemplate?.innerBlocks ?? [] )
+            .filter( ( child ) => child.name !== 'artisanpack/post-variant' )
+            .map( ( child ) => cloneBlock( child as unknown as BlockInstance ) );
+
+        const block = createBlock(
+            'artisanpack/post-variant',
+            {
+                matcher: defaultMatcherFor( kind ),
+                priority: 10,
+            },
+            baseChildren
+        );
         insertBlock( block, variantRows.length, postTemplateClientId );
+        // Focus the new variant so its inspector controls open
+        // immediately — auto-jump in the canvas (#604) then surfaces
+        // the matching iteration as the editable one.
+        selectBlock( block.clientId );
     };
 
     const handleMove = ( clientId: string, currentIndex: number, delta: number ): void => {

--- a/resources/js/visual-editor/editor/__tests__/query-preview-iterations.test.tsx
+++ b/resources/js/visual-editor/editor/__tests__/query-preview-iterations.test.tsx
@@ -4,8 +4,32 @@
  * state of non-first iterations, and the zero-result fallback.
  */
 
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render } from '@testing-library/react';
+
+interface FakeStoreState {
+    innerBlocks: Array<{
+        name: string;
+        clientId?: string;
+        attributes?: Record<string, unknown>;
+        innerBlocks?: unknown[];
+    }>;
+    attributes: Record<string, unknown>;
+    selectedClientId?: string | null;
+    blockNames?: Record<string, string>;
+    blockParents?: Record<string, string[]>;
+}
+
+const fakeStoreState: FakeStoreState = {
+    innerBlocks: [
+        { name: 'core/post-title', attributes: {}, innerBlocks: [] },
+        { name: 'core/post-excerpt', attributes: {}, innerBlocks: [] },
+    ],
+    attributes: {},
+    selectedClientId: null,
+    blockNames: {},
+    blockParents: {},
+};
 
 vi.mock( '@wordpress/block-editor', async () => {
     const { createElement } = await import( 'react' );
@@ -43,7 +67,14 @@ vi.mock( '@wordpress/block-editor', async () => {
             className: 'block-editor-block-preview__live-content',
             children: createElement(
                 'div',
-                { 'data-testid': 'ghost-preview-content' },
+                {
+                    'data-testid': 'ghost-preview-content',
+                    'data-ghost-block-names': Array.isArray( opts.blocks )
+                        ? opts.blocks
+                              .map( ( block ) => ( block as { name?: string } ).name ?? '' )
+                              .join( ',' )
+                        : '',
+                },
                 `Preview of ${ Array.isArray( opts.blocks ) ? opts.blocks.length : 0 } block(s)`
             ),
         } ),
@@ -56,11 +87,12 @@ vi.mock( '@wordpress/data', () => ( {
     useSelect: ( callback: ( select: ( storeName: unknown ) => unknown ) => unknown ) => {
         const fakeStore = {
             getBlock: () => ( {
-                innerBlocks: [
-                    { name: 'core/post-title', attributes: {}, innerBlocks: [] },
-                    { name: 'core/post-excerpt', attributes: {}, innerBlocks: [] },
-                ],
+                innerBlocks: fakeStoreState.innerBlocks,
+                attributes: fakeStoreState.attributes,
             } ),
+            getSelectedBlockClientId: () => fakeStoreState.selectedClientId ?? null,
+            getBlockName: ( clientId: string ) => fakeStoreState.blockNames?.[ clientId ],
+            getBlockParents: ( clientId: string ) => fakeStoreState.blockParents?.[ clientId ] ?? [],
         };
         return callback( () => fakeStore );
     },
@@ -97,6 +129,17 @@ function makePreview( overrides: Partial<QueryPreviewContextValue> = {} ): Query
         ...overrides,
     };
 }
+
+beforeEach( () => {
+    fakeStoreState.innerBlocks = [
+        { name: 'core/post-title', attributes: {}, innerBlocks: [] },
+        { name: 'core/post-excerpt', attributes: {}, innerBlocks: [] },
+    ];
+    fakeStoreState.attributes = {};
+    fakeStoreState.selectedClientId = null;
+    fakeStoreState.blockNames = {};
+    fakeStoreState.blockParents = {};
+} );
 
 describe( 'QueryPreviewIterations', () => {
     it( 'renders one editable iteration plus N-1 read-only ghosts for a 3-post query', () => {
@@ -300,5 +343,188 @@ describe( 'QueryPreviewIterations', () => {
         );
 
         expect( getByRole( 'note' ) ).not.toBeNull();
+    } );
+
+    // ---------- Per-iteration variant resolution (#604) ----------
+
+    it( 'renders a position:first variant only on iteration #1; other iterations render base', () => {
+        fakeStoreState.innerBlocks = [
+            { name: 'core/post-title', attributes: {}, innerBlocks: [] },
+            { name: 'core/post-excerpt', attributes: {}, innerBlocks: [] },
+            {
+                name: 'artisanpack/post-variant',
+                clientId: 'variant-1',
+                attributes: { matcher: { kind: 'position', value: 'first' }, priority: 10 },
+                innerBlocks: [
+                    { name: 'core/heading', attributes: { content: 'testing' }, innerBlocks: [] },
+                    { name: 'core/cover', attributes: {}, innerBlocks: [] },
+                ],
+            },
+        ];
+
+        const posts = [ makePost( 1 ), makePost( 2 ), makePost( 3 ) ];
+        const { container } = render(
+            <QueryPreviewIterations
+                clientId="abc"
+                preview={ makePreview( { posts, total: 3, perPage: 3 } ) }
+                postType="post"
+            />
+        );
+
+        // Iteration 1 is editable; iterations 2 and 3 are ghosts.
+        const ghosts = Array.from(
+            container.querySelectorAll( '[data-query-iteration="preview"]' )
+        );
+        expect( ghosts ).toHaveLength( 2 );
+
+        // Ghosts (#2 and #3) should preview the base children, NOT the variant content.
+        for ( const ghost of ghosts ) {
+            const blockNames = ghost
+                .querySelector( '[data-ghost-block-names]' )
+                ?.getAttribute( 'data-ghost-block-names' );
+            expect( blockNames ).toBe( 'core/post-title,core/post-excerpt' );
+            expect( ghost.getAttribute( 'data-resolved-variant-order' ) ).toBe( 'base' );
+        }
+
+        // The editable iteration #1 resolves to the variant.
+        const editable = container.querySelector( '[data-query-iteration="editable"]' );
+        expect( editable?.getAttribute( 'data-resolved-variant-order' ) ).toBe( '0' );
+    } );
+
+    it( 'renders a pattern:odd variant on iterations 1, 3, 5; base on 2, 4', () => {
+        fakeStoreState.innerBlocks = [
+            { name: 'core/post-title', attributes: {}, innerBlocks: [] },
+            {
+                name: 'artisanpack/post-variant',
+                clientId: 'variant-odd',
+                attributes: { matcher: { kind: 'pattern', value: 'odd' }, priority: 10 },
+                innerBlocks: [
+                    { name: 'core/heading', attributes: {}, innerBlocks: [] },
+                ],
+            },
+        ];
+
+        const posts = Array.from( { length: 5 }, ( _v, i ) => makePost( i + 1 ) );
+        const { container } = render(
+            <QueryPreviewIterations
+                clientId="abc"
+                preview={ makePreview( { posts, total: 5, perPage: 5 } ) }
+                postType="post"
+            />
+        );
+
+        const iterations = Array.from(
+            container.querySelectorAll( '[data-query-iteration]' )
+        );
+        const resolved = iterations.map( ( node ) =>
+            node.getAttribute( 'data-resolved-variant-order' )
+        );
+        // Iteration 1 is editable; 2-5 are ghosts. All odd-positioned
+        // iterations (1, 3, 5) resolve to the variant (order 0);
+        // even-positioned (2, 4) resolve to base.
+        expect( resolved ).toEqual( [ '0', 'base', '0', 'base', '0' ] );
+    } );
+
+    it( 'renders a meta:has-featured-image variant only on posts with a featured image', () => {
+        fakeStoreState.innerBlocks = [
+            { name: 'core/post-title', attributes: {}, innerBlocks: [] },
+            {
+                name: 'artisanpack/post-variant',
+                clientId: 'variant-meta',
+                attributes: {
+                    matcher: { kind: 'meta', value: 'has-featured-image' },
+                    priority: 10,
+                },
+                innerBlocks: [
+                    { name: 'core/image', attributes: {}, innerBlocks: [] },
+                ],
+            },
+        ];
+
+        const posts: QueryPreviewPost[] = [
+            { id: 1, title: 'Post 1' },
+            {
+                id: 2,
+                title: 'Post 2',
+                featuredImage: { url: 'https://example.com/img.jpg' },
+            },
+            { id: 3, title: 'Post 3' },
+        ];
+
+        const { container } = render(
+            <QueryPreviewIterations
+                clientId="abc"
+                preview={ makePreview( { posts, total: 3, perPage: 3 } ) }
+                postType="post"
+            />
+        );
+
+        const iterations = Array.from(
+            container.querySelectorAll( '[data-query-iteration]' )
+        );
+        const resolved = iterations.map( ( node ) =>
+            node.getAttribute( 'data-resolved-variant-order' )
+        );
+        // Post 2 has a featured image → variant; 1 and 3 → base.
+        expect( resolved ).toEqual( [ 'base', '0', 'base' ] );
+    } );
+
+    it( 'honors compiled instance map from _compiledVariantMap', () => {
+        fakeStoreState.innerBlocks = [
+            { name: 'core/post-title', attributes: {}, innerBlocks: [] },
+            {
+                name: 'artisanpack/post-variant',
+                clientId: 'variant-instance',
+                attributes: {
+                    matcher: { kind: 'position', value: 'instance:2' },
+                    priority: 10,
+                },
+                innerBlocks: [ { name: 'core/heading', attributes: {}, innerBlocks: [] } ],
+            },
+        ];
+        fakeStoreState.attributes = { _compiledVariantMap: { 1: 0 } };
+
+        const posts = [ makePost( 1 ), makePost( 2 ), makePost( 3 ) ];
+        const { container } = render(
+            <QueryPreviewIterations
+                clientId="abc"
+                preview={ makePreview( { posts, total: 3, perPage: 3 } ) }
+                postType="post"
+            />
+        );
+
+        const resolved = Array.from(
+            container.querySelectorAll( '[data-query-iteration]' )
+        ).map( ( node ) => node.getAttribute( 'data-resolved-variant-order' ) );
+        // Static map pins iteration index 1 (i.e. post #2) to variant order 0.
+        expect( resolved ).toEqual( [ 'base', '0', 'base' ] );
+    } );
+
+    it( 'auto-jumps the editable iteration to the first post matching the selected variant', () => {
+        fakeStoreState.innerBlocks = [
+            { name: 'core/post-title', attributes: {}, innerBlocks: [] },
+            {
+                name: 'artisanpack/post-variant',
+                clientId: 'variant-last',
+                attributes: { matcher: { kind: 'position', value: 'last' }, priority: 10 },
+                innerBlocks: [],
+            },
+        ];
+        fakeStoreState.selectedClientId = 'variant-last';
+        fakeStoreState.blockNames = { 'variant-last': 'artisanpack/post-variant' };
+
+        const posts = [ makePost( 1 ), makePost( 2 ), makePost( 3 ) ];
+        const { container } = render(
+            <QueryPreviewIterations
+                clientId="abc"
+                preview={ makePreview( { posts, total: 3, perPage: 3 } ) }
+                postType="post"
+            />
+        );
+
+        // `position:last` on a 3-post loop matches iteration #3 → post id 3.
+        const editable = container.querySelector( '[data-query-iteration="editable"]' );
+        expect( editable?.closest( '[data-block-context]' )?.getAttribute( 'data-block-context' ) )
+            .toContain( '"postId":3' );
     } );
 } );

--- a/resources/js/visual-editor/editor/query-preview-iterations.tsx
+++ b/resources/js/visual-editor/editor/query-preview-iterations.tsx
@@ -350,6 +350,11 @@ export function QueryPreviewIterations(
     // Computed unconditionally (before the early-return below) so the
     // hook count is stable across renders, regardless of whether the
     // preview has resolved any posts yet.
+    //
+    // The rules are instance-scoped via `data-query-preview-root="<clientId>"`
+    // on the outer wrapper so a second Query Loop block on the same
+    // canvas can't accidentally collapse children in this one.
+    const scopedRootSelector = '[data-query-preview-root="' + clientId + '"]';
     const variantCollapseStyles = useMemo( () => {
         if ( variantBlocks.length === 0 ) {
             return '';
@@ -358,7 +363,8 @@ export function QueryPreviewIterations(
         // When resolved=base: hide every post-variant child of the
         // editable iteration.
         rules.push(
-            'li[data-query-iteration="editable"][data-resolved-variant-order="base"] [data-type="' +
+            scopedRootSelector +
+                ' li[data-query-iteration="editable"][data-resolved-variant-order="base"] [data-type="' +
                 POST_VARIANT_BLOCK_NAME +
                 '"]{display:none!important;}'
         );
@@ -368,7 +374,8 @@ export function QueryPreviewIterations(
         variantBlocks.forEach( ( variant, order ) => {
             const cid = variant.clientId;
             rules.push(
-                'li[data-query-iteration="editable"][data-resolved-variant-order="' +
+                scopedRootSelector +
+                    ' li[data-query-iteration="editable"][data-resolved-variant-order="' +
                     String( order ) +
                     '"] > .block-editor-inner-blocks > .block-editor-block-list__layout > :not([data-block="' +
                     cid +
@@ -376,7 +383,7 @@ export function QueryPreviewIterations(
             );
         } );
         return rules.join( '' );
-    }, [ variantBlocks ] );
+    }, [ variantBlocks, scopedRootSelector ] );
 
     if ( visiblePosts.length === 0 ) {
         const Tag = tag;
@@ -386,7 +393,10 @@ export function QueryPreviewIterations(
         // sibling of the list rather than as a direct child.
         return (
             <>
-                <Tag {...outerProps as Record<string, unknown>}>
+                <Tag
+                    {...outerProps as Record<string, unknown>}
+                    data-query-preview-root={ clientId }
+                >
                     <BlockContextProvider value={{ postType }}>
                         <li className={ itemClassName } data-query-iteration="editable">
                             <InnerBlocks template={ editableTemplate } />

--- a/resources/js/visual-editor/editor/query-preview-iterations.tsx
+++ b/resources/js/visual-editor/editor/query-preview-iterations.tsx
@@ -9,28 +9,28 @@
  * `postType` so descendant `post-*` block edits resolve against the
  * right post (#520 entity-adapter mechanism).
  *
- * The ghosts use `__experimentalUseBlockPreview` from
- * `@wordpress/block-editor` — the same hook upstream Gutenberg's
- * `core/post-template` reaches for. It renders the inner-block tree
- * via a nested `ExperimentalBlockEditorProvider` scope with
- * `useDisabled` applied, so dynamic display blocks (`post-title`,
- * `post-excerpt`, `post-date`, …) run their actual Edit components
- * against the per-iteration block context — no serialization, no
- * iframe, no save-element fallback. The iframe-based `<BlockPreview>`
- * component is explicitly avoided here for the same reason the
- * inserter-patterns panel documents: multiple iframes collide with
- * the M2 CSP shim. `useBlockPreview` is the iframe-free counterpart.
+ * Per-iteration variant resolution (#604): the post-template's
+ * `innerBlocks` are partitioned into base children and
+ * `artisanpack/post-variant` children. Each iteration resolves to
+ * either a specific variant or the base set via the shared
+ * `variant-matcher` engine (parity with server-side `VariantResolver`).
+ * Ghost iterations render the resolved set via `useBlockPreview`. The
+ * editable iteration still renders the post-template's full inner
+ * blocks via `<InnerBlocks />` — variant blocks are kept in the tree so
+ * authors can edit them via the list view / inspector — but the
+ * resolved variant for the active post is signalled via
+ * `data-resolved-variant-order` so styling (and the post-variant
+ * block's own visibility CSS) can collapse the other variants out of
+ * the way.
  *
- * Active-iteration UX: clicking (or pressing Enter / Space on) any
- * ghost iteration promotes it to the editable iteration, matching
- * upstream Gutenberg's `core/post-template` behavior. The shared
- * inner-block tree is what gets edited — `BlockContextProvider`
- * around the active iteration just changes which post's data the
- * descendant `post-*` blocks resolve against.
+ * Auto-jump (#604): selecting a `artisanpack/post-variant` block (or
+ * any descendant thereof) bumps `activeId` to the first preview post
+ * the variant matches, so the canvas WYSIWYGs to the variant the
+ * author is editing.
  */
 
 import type { ReactElement, KeyboardEvent } from 'react';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import {
     BlockContextProvider,
     InnerBlocks,
@@ -49,6 +49,15 @@ import {
     getQueryPreviewIterationCount,
     QUERY_PREVIEW_ITERATION_CAP,
 } from './query-preview-context';
+import type { QueryPreviewPost } from './use-query-preview';
+import {
+    resolveVariant,
+    type Matcher,
+    type PreviewPostMeta,
+    type VariantDescriptor,
+} from './variant-matcher';
+
+const POST_VARIANT_BLOCK_NAME = 'artisanpack/post-variant';
 
 interface UseBlockPreviewOptions {
     readonly blocks: ReadonlyArray<BlockInstance>;
@@ -87,22 +96,127 @@ export interface QueryPreviewIterationsProps {
 }
 
 interface PostTemplateBlockShape {
+    readonly clientId?: string;
     readonly innerBlocks?: ReadonlyArray<BlockInstance>;
+    readonly attributes?: Record<string, unknown>;
 }
 
-function selectInnerBlocks(
+interface BlockEditorStoreShape {
+    readonly getBlock?: ( id: string ) => PostTemplateBlockShape | null;
+    readonly getSelectedBlockClientId?: () => string | null;
+    readonly getBlockParents?: ( clientId: string ) => ReadonlyArray<string>;
+    readonly getBlockName?: ( clientId: string ) => string | undefined;
+}
+
+interface PostTemplateSnapshot {
+    readonly innerBlocks: ReadonlyArray<BlockInstance>;
+    readonly compiledVariantMap: Record<number, number>;
+    readonly selectedVariantClientId: string | null;
+}
+
+function readMatcher( attrs: Record<string, unknown> | undefined ): Matcher {
+    const raw = attrs?.matcher;
+    if (
+        raw !== null &&
+        typeof raw === 'object' &&
+        ! Array.isArray( raw ) &&
+        typeof ( raw as { kind?: unknown } ).kind === 'string' &&
+        typeof ( raw as { value?: unknown } ).value === 'string'
+    ) {
+        return raw as Matcher;
+    }
+    return { kind: 'position', value: 'first' };
+}
+
+function readCompiledMap( attrs: Record<string, unknown> | undefined ): Record<number, number> {
+    const raw = attrs?._compiledVariantMap;
+    if ( raw === null || raw === undefined || typeof raw !== 'object' || Array.isArray( raw ) ) {
+        return {};
+    }
+    const out: Record<number, number> = {};
+    for ( const [ key, value ] of Object.entries( raw as Record<string, unknown> ) ) {
+        const idx = Number.parseInt( key, 10 );
+        if ( Number.isFinite( idx ) && typeof value === 'number' && Number.isFinite( value ) ) {
+            out[ idx ] = value;
+        }
+    }
+    return out;
+}
+
+function buildDescriptors(
+    variantBlocks: ReadonlyArray<BlockInstance>
+): VariantDescriptor[] {
+    return variantBlocks.map( ( block, idx ) => {
+        const attrs = block.attributes ?? {};
+        const matcher = readMatcher( attrs );
+        const priority =
+            typeof attrs.priority === 'number' ? ( attrs.priority as number ) : 10;
+        const label =
+            typeof attrs.label === 'string' ? ( attrs.label as string ) : undefined;
+        return {
+            order: idx,
+            matcher,
+            priority,
+            label,
+        };
+    } );
+}
+
+function toPreviewMeta( post: QueryPreviewPost ): PreviewPostMeta {
+    const taxonomies: Record<string, ReadonlyArray<string>> = {};
+    if ( post.terms ) {
+        for ( const [ tax, terms ] of Object.entries( post.terms ) ) {
+            const slugs = terms
+                .map( ( term ) => term.slug )
+                .filter( ( slug ): slug is string => typeof slug === 'string' && slug !== '' );
+            if ( slugs.length > 0 ) {
+                taxonomies[ tax ] = slugs;
+            }
+        }
+    }
+    return {
+        hasFeaturedImage:
+            post.featuredImage !== null &&
+            post.featuredImage !== undefined &&
+            typeof post.featuredImage.url === 'string' &&
+            post.featuredImage.url !== '',
+        taxonomies,
+    };
+}
+
+function selectPostTemplateSnapshot(
     select: ( storeName: typeof blockEditorStore ) => unknown,
     clientId: string
-): ReadonlyArray<BlockInstance> {
+): PostTemplateSnapshot {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const store = ( select as any )( blockEditorStore ) as { getBlock?: ( id: string ) => PostTemplateBlockShape | null };
+    const store = ( select as any )( blockEditorStore ) as BlockEditorStoreShape;
     const block = store.getBlock?.( clientId ) ?? null;
 
-    if ( block === null || block.innerBlocks === undefined ) {
-        return [];
+    const innerBlocks = block?.innerBlocks ?? [];
+    const compiledVariantMap = readCompiledMap( block?.attributes );
+
+    let selectedVariantClientId: string | null = null;
+    const selectedId = store.getSelectedBlockClientId?.() ?? null;
+    if ( selectedId !== null && selectedId !== undefined ) {
+        const selectedName = store.getBlockName?.( selectedId );
+        if ( selectedName === POST_VARIANT_BLOCK_NAME ) {
+            selectedVariantClientId = selectedId;
+        } else {
+            const parents = store.getBlockParents?.( selectedId ) ?? [];
+            for ( const parentId of parents ) {
+                if ( store.getBlockName?.( parentId ) === POST_VARIANT_BLOCK_NAME ) {
+                    selectedVariantClientId = parentId;
+                    break;
+                }
+            }
+        }
     }
 
-    return block.innerBlocks;
+    return {
+        innerBlocks,
+        compiledVariantMap,
+        selectedVariantClientId,
+    };
 }
 
 /**
@@ -124,21 +238,48 @@ export function QueryPreviewIterations(
         outerProps = {},
     } = props;
 
-    // Subscribe to the post-template's own inner blocks so the ghost
-    // preview stays in sync with edits to the editable iteration.
-    const innerBlocks = useSelect(
-        ( select ) => selectInnerBlocks( select as never, clientId ),
+    const snapshot = useSelect(
+        ( select ) => selectPostTemplateSnapshot( select as never, clientId ),
         [ clientId ]
     );
+    const { innerBlocks, compiledVariantMap, selectedVariantClientId } = snapshot;
 
-    const ghostBlocks = useMemo<ReadonlyArray<BlockInstance>>(
-        () => innerBlocks,
-        [ innerBlocks ]
-    );
+    const { baseChildren, variantBlocks, descriptors } = useMemo( () => {
+        const base: BlockInstance[] = [];
+        const variants: BlockInstance[] = [];
+        for ( const child of innerBlocks ) {
+            if ( child.name === POST_VARIANT_BLOCK_NAME ) {
+                variants.push( child );
+            } else {
+                base.push( child );
+            }
+        }
+        return {
+            baseChildren: base,
+            variantBlocks: variants,
+            descriptors: buildDescriptors( variants ),
+        };
+    }, [ innerBlocks ] );
 
     const posts = preview?.posts ?? [];
     const cap = getQueryPreviewIterationCount( posts, preview?.perPage );
     const visiblePosts = posts.slice( 0, cap );
+    const total = visiblePosts.length;
+
+    // Resolve each visible iteration to a variant order (or null = base).
+    const resolvedOrders = useMemo<ReadonlyArray<number | null>>(
+        () =>
+            visiblePosts.map( ( post, idx ) =>
+                resolveVariant(
+                    idx,
+                    total,
+                    toPreviewMeta( post ),
+                    descriptors,
+                    compiledVariantMap
+                )
+            ),
+        [ visiblePosts, total, descriptors, compiledVariantMap ]
+    );
 
     // Track which iteration is the editable one. Clicking on a ghost
     // promotes it. Defaults to the first post; resets when the posts
@@ -155,7 +296,87 @@ export function QueryPreviewIterations(
         }
     }, [ activeId, activeIdInList ] );
 
+    // Auto-jump to the first iteration that resolves to the selected
+    // variant. Tracked via a ref so re-renders driven by other state
+    // changes (e.g. inner-block edits) don't keep stealing focus from
+    // the user's most recent ghost click.
+    const lastHandledSelectionRef = useRef<string | null>( null );
+    useEffect( () => {
+        if ( selectedVariantClientId === null ) {
+            lastHandledSelectionRef.current = null;
+            return;
+        }
+        if ( lastHandledSelectionRef.current === selectedVariantClientId ) {
+            return;
+        }
+        const variantIdx = variantBlocks.findIndex(
+            ( block ) => block.clientId === selectedVariantClientId
+        );
+        if ( variantIdx === -1 ) {
+            return;
+        }
+        const matchPos = resolvedOrders.findIndex( ( order ) => order === variantIdx );
+        if ( matchPos === -1 ) {
+            // The variant doesn't match any visible iteration — leave
+            // the active iteration alone rather than blanking the canvas.
+            lastHandledSelectionRef.current = selectedVariantClientId;
+            return;
+        }
+        const targetId = visiblePosts[ matchPos ]?.id;
+        if ( targetId !== undefined && targetId !== effectiveActiveId ) {
+            setActiveId( targetId );
+        }
+        lastHandledSelectionRef.current = selectedVariantClientId;
+    }, [
+        selectedVariantClientId,
+        variantBlocks,
+        resolvedOrders,
+        visiblePosts,
+        effectiveActiveId,
+    ] );
+
     const editableTemplate = defaultTemplate !== undefined ? [ ...defaultTemplate ] : undefined;
+
+    // CSS rules that collapse the unmatched children of the editable
+    // iteration. `<InnerBlocks />` always renders every direct child
+    // of the post-template (base + every variant), so without this the
+    // canvas would stack the resolved variant on top of the base
+    // template for the active post. The rules are scoped by the
+    // editable iteration's `data-resolved-variant-order` and by each
+    // variant block's stable `data-block` (clientId), so toggling the
+    // active iteration to a different variant just flips which child
+    // is visible — no React tree churn required.
+    //
+    // Computed unconditionally (before the early-return below) so the
+    // hook count is stable across renders, regardless of whether the
+    // preview has resolved any posts yet.
+    const variantCollapseStyles = useMemo( () => {
+        if ( variantBlocks.length === 0 ) {
+            return '';
+        }
+        const rules: string[] = [];
+        // When resolved=base: hide every post-variant child of the
+        // editable iteration.
+        rules.push(
+            'li[data-query-iteration="editable"][data-resolved-variant-order="base"] [data-type="' +
+                POST_VARIANT_BLOCK_NAME +
+                '"]{display:none!important;}'
+        );
+        // When resolved=<order>: hide every non-matching child of the
+        // editable iteration's inner-blocks layout (both base blocks
+        // and the other variants).
+        variantBlocks.forEach( ( variant, order ) => {
+            const cid = variant.clientId;
+            rules.push(
+                'li[data-query-iteration="editable"][data-resolved-variant-order="' +
+                    String( order ) +
+                    '"] > .block-editor-inner-blocks > .block-editor-block-list__layout > :not([data-block="' +
+                    cid +
+                    '"]){display:none!important;}'
+            );
+        } );
+        return rules.join( '' );
+    }, [ variantBlocks ] );
 
     if ( visiblePosts.length === 0 ) {
         const Tag = tag;
@@ -198,10 +419,21 @@ export function QueryPreviewIterations(
     const Tag = tag;
     return (
         <>
+            { variantCollapseStyles !== '' && (
+                <style data-source="query-preview-iterations-variant-collapse">
+                    { variantCollapseStyles }
+                </style>
+            ) }
             <Tag {...outerProps as Record<string, unknown>}>
-                { visiblePosts.map( ( post ) => {
+                { visiblePosts.map( ( post, idx ) => {
                     const iterationContext = { postType, postId: post.id, 'artisanpack/postPreview': post };
                     const isActive = post.id === effectiveActiveId;
+                    const resolvedOrder = resolvedOrders[ idx ] ?? null;
+                    const resolvedBlocks: ReadonlyArray<BlockInstance> =
+                        resolvedOrder !== null && variantBlocks[ resolvedOrder ] !== undefined
+                            ? variantBlocks[ resolvedOrder ].innerBlocks ?? []
+                            : baseChildren;
+                    const resolvedAttr = resolvedOrder === null ? 'base' : String( resolvedOrder );
 
                     return (
                         <BlockContextProvider key={ post.id } value={ iterationContext }>
@@ -209,11 +441,13 @@ export function QueryPreviewIterations(
                                 <EditableIteration
                                     className={ itemClassName }
                                     template={ editableTemplate }
+                                    resolvedVariantOrder={ resolvedAttr }
                                 />
                             ) : (
                                 <PreviewIteration
                                     className={ itemClassName }
-                                    blocks={ ghostBlocks }
+                                    blocks={ resolvedBlocks }
+                                    resolvedVariantOrder={ resolvedAttr }
                                     onActivate={ () => setActiveId( post.id ) }
                                 />
                             ) }
@@ -232,11 +466,20 @@ export function QueryPreviewIterations(
 interface EditableIterationProps {
     readonly className: string;
     readonly template: ReadonlyArray<[ string ]> | undefined;
+    readonly resolvedVariantOrder: string;
 }
 
-function EditableIteration( { className, template }: EditableIterationProps ): ReactElement {
+function EditableIteration( {
+    className,
+    template,
+    resolvedVariantOrder,
+}: EditableIterationProps ): ReactElement {
     return (
-        <li className={ className } data-query-iteration="editable">
+        <li
+            className={ className }
+            data-query-iteration="editable"
+            data-resolved-variant-order={ resolvedVariantOrder }
+        >
             <InnerBlocks template={ template !== undefined ? [ ...template ] : undefined } />
         </li>
     );
@@ -245,12 +488,14 @@ function EditableIteration( { className, template }: EditableIterationProps ): R
 interface PreviewIterationProps {
     readonly className: string;
     readonly blocks: ReadonlyArray<BlockInstance>;
+    readonly resolvedVariantOrder: string;
     readonly onActivate: () => void;
 }
 
 function PreviewIteration( {
     className,
     blocks,
+    resolvedVariantOrder,
     onActivate,
 }: PreviewIterationProps ): ReactElement {
     // Defensive fallback when the block-editor build doesn't expose
@@ -264,6 +509,7 @@ function PreviewIteration( {
             <li
                 className={ className }
                 data-query-iteration="preview"
+                data-resolved-variant-order={ resolvedVariantOrder }
                 aria-hidden={ true }
             />
         );
@@ -273,6 +519,7 @@ function PreviewIteration( {
         <PreviewIterationLive
             className={ className }
             blocks={ blocks }
+            resolvedVariantOrder={ resolvedVariantOrder }
             onActivate={ onActivate }
         />
     );
@@ -281,6 +528,7 @@ function PreviewIteration( {
 function PreviewIterationLive( {
     className,
     blocks,
+    resolvedVariantOrder,
     onActivate,
 }: PreviewIterationProps ): ReactElement {
     const previewProps = ( useBlockPreview as ( opts: UseBlockPreviewOptions ) => UseBlockPreviewResult )( {
@@ -299,6 +547,7 @@ function PreviewIterationLive( {
         <li
             { ...previewProps as Record<string, unknown> }
             data-query-iteration="preview"
+            data-resolved-variant-order={ resolvedVariantOrder }
             tabIndex={ 0 }
             // eslint-disable-next-line jsx-a11y/no-noninteractive-element-to-interactive-role
             role="button"


### PR DESCRIPTION
## Description

Fixes two distinct bugs in the Query Loop **Post Variants** feature that together made variants unusable in the editor: every variant rendered on every post tile in the canvas, and adding a variant started from a blank slate. The compiled page render was already correct via `QueryInliner` — only the editor preview pipeline was broken.

**Closes:** #604

## Type of Change

- [x] Bug fix (fixes an issue)

## Related Issue

**Issue:** #604

## Motivation and Context

The editor preview misled authors into thinking every post would look identical to the variant, and creating a variant via the "Post Variants" panel inserted an empty `artisanpack/post-variant` block — forcing the user to re-author title/cover/etc. from scratch. Net effect: variants existed but no one would reach for them.

## Changes Made

- `resources/js/visual-editor/editor/query-preview-iterations.tsx`
  - Partition the post-template's `innerBlocks` into base children + `artisanpack/post-variant` children, build a `VariantDescriptor[]`, read `_compiledVariantMap`, and call `resolveVariant` per iteration.
  - Ghost iterations now render the resolved set via `useBlockPreview` (variant `innerBlocks` or base) — so a `position:first` variant only previews on iteration #1.
  - Editable iteration carries `data-resolved-variant-order`; an injected `<style>` collapses non-matching children (base blocks when a variant is resolved, other variants either way) so the active post shows only its resolved content.
  - Subscribe to the block-editor selection store; when a `artisanpack/post-variant` (or descendant) is selected, auto-jump `activeId` to the first iteration that matches that variant. A ref guard prevents overriding the user's most recent manual ghost activation.
- `resources/js/visual-editor/blocks/query/post-variants-panel.tsx`
  - `handleAdd` now deep-clones the post-template's current non-variant inner blocks via `cloneBlock` (independent clientIds, recursive), seeds them into the new variant, and `selectBlock`s the new variant so its inspector opens immediately.
- New vitest specs:
  - `editor/__tests__/query-preview-iterations.test.tsx` — adds 5 cases (`position:first`, `pattern:odd`, `meta:has-featured-image`, instance static map, auto-jump on variant selection).
  - `blocks/query/__tests__/post-variants-panel.test.tsx` — 4 cases covering seed-from-base (including nested `innerBlocks`), excluding existing variants from the seed, and auto-selecting the new variant; also empty-base behavior.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (Darwin 25.5.0)
- Browser: Safari (latest)
- PHP Version: 8.4.3
- Project Version: visual-editor `release/1.2`

**Tests Performed:**
1. `npm test -- --run resources/js/visual-editor/editor/__tests__/query-preview-iterations.test.tsx resources/js/visual-editor/blocks/query/__tests__/post-variants-panel.test.tsx` — 21 passing (17 + 4).
2. Manual canvas test in the dev app — added a `pattern:odd` variant with a custom paragraph + post-title; only odd iterations (1, 3, 5) render the variant; even iterations (2, 4) render the base template; switching the editable iteration via ghost click flips the collapse correctly; adding a new variant pre-seeds with the base template's children; the new variant is auto-selected with its inspector open.
3. Hard-refresh in the canvas iframe — no Rules-of-Hooks regressions, no crashes.

## Accessibility Tests Run

- [x] Keyboard navigation tested — ghost iterations still respond to Enter/Space activation.
- [ ] Screen reader tested — no announce-level changes; `<style>` injection is presentational.
- [x] Color contrast verified — no color changes.
- [x] ARIA labels checked — unchanged from prior implementation.

## Tests Added

- [x] Unit tests added/updated
- [x] All tests passing

**Test details:**
- `query-preview-iterations.test.tsx`: position / pattern / meta / instance-map resolution + auto-jump.
- `post-variants-panel.test.tsx`: seed-from-base deep-clone (incl. nested), exclusion of existing variants, select-after-insert, empty-base edge case.

## Documentation

- [x] Inline code documentation added (file-level docblock updated to call out #604 semantics)

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests (pre-existing site-editor-app localStorage failures unrelated to this change)
- [x] Self-review completed
- [x] Comments added for complex code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Post variants now clone and inherit the non-variant blocks from the parent post template when created, including nested block structure.
- Variant matching now supports position, pattern, and featured-image conditions, and applies the resolved variant per post iteration.
- Editing focus now auto-jumps to the first post matching the currently selected variant, while previews correctly show non-editable “ghost” iterations.

## Tests
- Added and expanded automated coverage for variant seeding and per-iteration variant resolution behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->