### PR TITLE
feat: box / drop shadow control with solid + gradient color (#607)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,40 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- **Box / drop shadow control with solid + gradient color (#607).**
+  New Shadow tools panel in the inspector's Styles group, auto-enabled
+  on every block with `__experimentalBorder` support (~94 blocks, no
+  block.json changes required). Exposes X/Y offset, blur, spread,
+  solid color, gradient color (with theme palette), inset toggle, and
+  a preset chip row backed by the new `settings.shadow.presets` slot
+  in `theme.json`. Writes route through the standard `artisanpackStates`
+  / `artisanpackResponsive` HOCs so per-state and per-breakpoint
+  shadow overrides land in the right cascade bag automatically. Three
+  emission modes (preset / solid / gradient) share one scoped `<style>`
+  code path; gradient and inset-gradient shadows render through a
+  `::before` / `::after` pseudo-element with `filter: blur()` and a
+  `mask-composite: exclude` ring mask for the inset variant. PHP
+  `BoxShadowResolver` + `BoxShadowEmitter` mirror the TS pair
+  byte-for-byte so editor canvas, saved markup, and Blade-rendered
+  output stay in lockstep. New scope class `ve-bs-<id>` persisted on
+  `attributes.style.shadow._shadowScopeId`. Front-end Blade rendering
+  goes through a new `BoxShadowCssAccumulator` +
+  `BlockSupports::pushBoxShadow()` + auto-stamping in
+  `BlockSupports::compile()`, so every block already routed through
+  the supports compiler picks up shadow rendering with zero
+  per-template changes. The supports-extension filter also strips the
+  native WordPress `supports.shadow` on opted-in blocks to keep the
+  two systems from fighting over the `style.shadow` attribute slot.
+  Mirrors the architecture established by gradient borders (#490).
+  **Known limitation:** outer gradient shadows on blocks with
+  `overflow: hidden` (e.g. Cover) are visually clipped at the wrapper
+  edge — gradient shadows need a `::before` pseudo-element because
+  the native `box-shadow` property doesn't accept gradient fills, and
+  pseudo-elements (unlike box-shadow) are clipped by their host's
+  overflow. Solid shadows and preset shadows are unaffected. See
+  [`docs/box-shadows.md`](docs/box-shadows.md) for the full authoring
+  guide and workarounds.
+
 - **Per-post layout overrides on the Query Loop via post-variants
   (#591).** New `artisanpack/post-variant` block, child of
   `artisanpack/post-template`, declares an override template that

--- a/docs/box-shadows.md
+++ b/docs/box-shadows.md
@@ -1,0 +1,197 @@
+# Box Shadows — Solid + Gradient with State & Breakpoint Cascade
+
+Status: **v1.2.0** — Issue [#607](https://github.com/ArtisanPack-UI/visual-editor/issues/607).
+
+Blocks can be painted with a box shadow (drop shadow) that supports
+solid color, gradient fill, theme presets, the inset variant, and the
+full state + breakpoint cascade — all routed through the same
+inspector chips that the border, color, typography, and spacing
+panels already use.
+
+The feature mirrors the architecture of border gradients (#490) one-
+to-one: same scope-class strategy, same `_…ScopeId` persistence, same
+state/responsive routing piggyback. The genuinely novel piece is the
+CSS emission strategy for gradient-filled (and inset-gradient-filled)
+shadows, which uses a `::before` / `::after` pseudo-element with
+`filter: blur()` rather than the native `box-shadow` property (which
+only accepts solid colors).
+
+## Authoring
+
+In the editor, open any block that supports borders, scroll to the
+**Styles** group in the inspector, and open the **Shadow** panel.
+You'll see:
+
+- A row of preset chips (one per `shadow.presets` entry defined in
+  `theme.json`).
+- Four numeric inputs: **X offset**, **Y offset**, **Blur**, **Spread**.
+- A **Color** picker with Color | Gradient tabs (the same UX used
+  for backgrounds and border gradients).
+- An **Inset** toggle.
+
+Picking a preset short-circuits the custom fields — the shadow
+renders as `var(--wp--preset--shadow--{slug})`. Clicking the active
+chip clears it and reveals the custom controls again.
+
+To set a different shadow for hover (or focus, md+, etc.), switch
+the state or breakpoint chip in the inspector and re-pick. Writes
+land in `attributes.states['style.shadow']` /
+`attributes.responsive['style.shadow']` automatically — no per-
+block.json changes are needed because the supports-extension filter
+auto-injects `style.shadow` into the routing lists for every block
+with any `__experimentalBorder` support.
+
+## Opting a block in
+
+There is **no `supports.shadow` flag**. Per the issue's deliberate
+design call, the panel auto-enables for every block that already
+declares any `__experimentalBorder` (or `border`) support. So a
+block like:
+
+```json
+{
+  "supports": {
+    "__experimentalBorder": {
+      "color":  true,
+      "radius": true,
+      "style":  true,
+      "width":  true
+    }
+  }
+}
+```
+
+automatically picks up the Shadow panel + cascade routing with no
+changes. That's ~94 core ArtisanPack blocks at the time of writing.
+
+To opt OUT of the state/responsive routing (rare — for blocks where
+state-shadow doesn't make sense), set `supports.artisanpackStates:
+false` or `supports.artisanpackResponsive: false` explicitly in
+block.json. The supports-extension filter preserves explicit
+`false` declarations.
+
+## Theme schema
+
+`theme.json` (and your published theme settings) gain a
+`settings.shadow.presets` array:
+
+```php
+'shadow' => [
+    'presets' => [
+        [ 'slug' => 'shadow-sm',       'name' => 'Small',    'shadow' => '0 1px 2px 0 rgba(0,0,0,0.05)' ],
+        [ 'slug' => 'shadow-md',       'name' => 'Medium',   'shadow' => '0 4px 6px -1px rgba(0,0,0,0.1), 0 2px 4px -2px rgba(0,0,0,0.1)' ],
+        [ 'slug' => 'shadow-lg',       'name' => 'Large',    'shadow' => '0 10px 15px -3px rgba(0,0,0,0.1), 0 4px 6px -4px rgba(0,0,0,0.1)' ],
+        [ 'slug' => 'shadow-elevated', 'name' => 'Elevated', 'shadow' => '0 25px 50px -12px rgba(0,0,0,0.25)' ],
+    ],
+],
+```
+
+The `shadow` value is the raw CSS `box-shadow` declaration WITHOUT
+the `inset` keyword — the resolver appends ` inset` when the layer's
+`inset` flag is true.
+
+Themes that ship custom shadow tokens see their entries surface as
+preset chips automatically. Removing a preset that an existing block
+still references surfaces a yellow "Shadow preset(s) no longer
+available: …" notice above the panel until the slug is restored or
+the reference is cleared.
+
+## Attribute shape
+
+The inspector writes a structured subtree at `attributes.style.shadow`:
+
+```json
+{
+  "style": {
+    "shadow": {
+      "offsetX":   "2px",
+      "offsetY":   "4px",
+      "blur":      "8px",
+      "spread":    "0",
+      "color":     "rgba(0,0,0,0.25)",
+      "gradient":  null,
+      "inset":     false,
+      "preset":    null,
+      "_shadowScopeId": "k1f3z9a2p"
+    }
+  }
+}
+```
+
+A state or breakpoint override is the same structured subtree under
+`attributes.states['style.shadow'][stateKey]` or
+`attributes.responsive['style.shadow'][breakpointKey]`. Writes of
+`null` (rather than a subtree) clear the override and let the layer
+fall back to idle.
+
+## CSS emission
+
+Three emission modes, dispatched per resolved layer:
+
+1. **Preset** — `box-shadow: var(--wp--preset--shadow--{slug})`.
+2. **Solid** — stock `box-shadow: [inset] X Y blur spread color`.
+3. **Gradient** — `::before` (outer) or `::after` (inset) pseudo-
+   element painting the gradient, blurred via `filter: blur(<blur>)`,
+   translated by `transform: translate(<X>, <Y>)`. The inset variant
+   additionally applies a `mask-composite: exclude` ring mask so the
+   gradient fills only the inside edge of the wrapper.
+
+All three modes share the same scoped `<style>` block (one code path
+across solid and gradient — no inline `style="box-shadow:…"` on the
+wrapper). The scope class is `ve-bs-<id>` where `<id>` is the
+persisted `_shadowScopeId`.
+
+## Server-side render
+
+The PHP-side `BoxShadowResolver` + `BoxShadowEmitter` produce
+identical CSS to the TS pair, so blocks render the same way whether
+they're hydrated by the editor canvas, served as static save markup,
+or compiled through the Blade renderer.
+
+The resolver and emitter live at:
+
+- `src/BoxShadow/BoxShadowResolver.php`
+- `src/BoxShadow/BoxShadowEmitter.php`
+
+`BoxShadowEmitter` is bound in `VisualEditorServiceProvider` as a
+scoped singleton, resolvable via `app(BoxShadowEmitter::class)`.
+
+## Blade renderer integration
+
+The `visual-editor-renderer-blade` package picks up box shadows
+automatically. `BlockSupports::compile()` reads `attributes.style.shadow`
+on every block, calls `BoxShadowResolver` + `BoxShadowEmitter`,
+stamps the `ve-bs-<id>` scope class onto the wrapper, and pushes the
+emitted CSS into a per-request `BoxShadowCssAccumulator`. The
+`<x-ve-blocks>` and `<x-ve-template>` components drain the
+accumulator once per render and emit a single
+`<style data-ve-box-shadows>` block at the top of the rendered page.
+
+No per-block-template changes are required — any block that already
+goes through `BlockSupports::compile()` (which is every block with
+the standard supports wrapper) gets box-shadow rendering for free.
+
+## Known limitation: outer gradient shadow on `overflow: hidden` blocks
+
+CSS box-shadow paints in a layer outside the element box and is not
+clipped by the element's own `overflow: hidden`. Our **gradient**
+shadow path uses a `::before` (or `::after`) pseudo-element instead,
+because the native `box-shadow` property does not accept gradient
+values — and a pseudo-element IS clipped by the wrapper's
+`overflow: hidden`.
+
+The practical impact: on blocks that clip their content to rounded
+corners (Cover is the prominent example), an **outer gradient shadow**
+will render as a blurred fill that gets clipped at the wrapper edge
+— so the visible "shadow ring" outside the block is missing.
+
+**Workarounds for authors:**
+
+- Use a **solid color shadow** (which paints via stock `box-shadow`
+  and is not clipped) when working with `overflow: hidden` blocks.
+- Use a **shadow preset** (also `box-shadow`) instead of a gradient.
+- Apply gradient shadows on a parent Group block that wraps the
+  clipped block, so the shadow renders on the parent's edge.
+
+Inset gradient shadows are unaffected — they paint inside the wrapper
+where `overflow: hidden` is exactly what we want.

--- a/packages/visual-editor-renderer-blade/resources/views/components/blocks.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/components/blocks.blade.php
@@ -28,6 +28,11 @@
 {!! $gradientBordersCss !!}
 @endif
 @endisset
+@isset( $boxShadowsCss )
+@if( '' !== $boxShadowsCss )
+{!! $boxShadowsCss !!}
+@endif
+@endisset
 {!! $html !!}
 @isset( $animationsRuntimeNeeded )
 @if( $animationsRuntimeNeeded )

--- a/packages/visual-editor-renderer-blade/resources/views/components/template.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/components/template.blade.php
@@ -35,6 +35,11 @@
 {!! $gradientBordersCss !!}
 @endif
 @endisset
+@isset( $boxShadowsCss )
+@if( '' !== $boxShadowsCss )
+{!! $boxShadowsCss !!}
+@endif
+@endisset
 <div class="{{ implode( ' ', $wrapperClasses ) }}" data-ve-template="{{ $slug }}"@if( null !== $matchedSlug && $matchedSlug !== $slug ) data-ve-matched-template="{{ $matchedSlug }}"@endif>
 @if( null !== $resolutionError )
 @if( $inDev )

--- a/packages/visual-editor-renderer-blade/src/Services/BoxShadowCssAccumulator.php
+++ b/packages/visual-editor-renderer-blade/src/Services/BoxShadowCssAccumulator.php
@@ -1,0 +1,102 @@
+<?php
+
+/**
+ * Per-request accumulator for the box-shadow feature's CSS (#607).
+ *
+ * Block partials push their per-scope box-shadow rules into this
+ * service while rendering. The `<x-ve-blocks>` / `<x-ve-template>`
+ * components drain it once and emit a single
+ * `<style data-ve-box-shadows>` block at the top of the render
+ * output — same pattern as {@see GradientBorderCssAccumulator}.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditorRendererBlade
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.2.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditorRendererBlade\Services;
+
+class BoxShadowCssAccumulator
+{
+	/**
+	 * Map of scope class → CSS rule string. Keyed so duplicate pushes
+	 * collapse to one entry; PHP arrays preserve insertion order so
+	 * iteration produces deterministic output.
+	 *
+	 * @var array<string, string>
+	 */
+	protected array $rules = [];
+
+	/**
+	 * Adds a rule set for the given scope class. Subsequent calls with
+	 * the same scope are ignored — block partials are expected to use
+	 * content-derived scope classes so identical payloads land in the
+	 * same bucket.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @param  string  $scope  The scope class (e.g. `ve-bs-abc123`).
+	 * @param  string  $css    The CSS rule string (no surrounding
+	 *                         `<style>` tag).
+	 */
+	public function push( string $scope, string $css ): void
+	{
+		if ( '' === $scope || '' === $css ) {
+			return;
+		}
+
+		if ( isset( $this->rules[ $scope ] ) ) {
+			return;
+		}
+
+		$this->rules[ $scope ] = $css;
+	}
+
+	/**
+	 * Returns the consolidated `<style data-ve-box-shadows>` block
+	 * and clears the accumulator. Called once per render at the top of
+	 * the `<x-ve-blocks>` / `<x-ve-template>` output. Returns an empty
+	 * string when no rules were pushed.
+	 *
+	 * @since 1.2.0
+	 */
+	public function flush(): string
+	{
+		if ( [] === $this->rules ) {
+			return '';
+		}
+
+		$body        = implode( '', array_values( $this->rules ) );
+		$this->rules = [];
+
+		return '<style data-ve-box-shadows>' . $body . '</style>';
+	}
+
+	/**
+	 * Resets the accumulator without emitting. Tests use this to clear
+	 * state between assertions inside a single PHP process.
+	 *
+	 * @since 1.2.0
+	 */
+	public function reset(): void
+	{
+		$this->rules = [];
+	}
+
+	/**
+	 * Inspect what's currently accumulated without draining. Test-only.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @return array<string, string>
+	 */
+	public function all(): array
+	{
+		return $this->rules;
+	}
+}

--- a/packages/visual-editor-renderer-blade/src/Support/BlockSupports.php
+++ b/packages/visual-editor-renderer-blade/src/Support/BlockSupports.php
@@ -47,12 +47,15 @@ declare( strict_types=1 );
 
 namespace ArtisanPackUI\VisualEditorRendererBlade\Support;
 
+use ArtisanPackUI\VisualEditor\BoxShadow\BoxShadowEmitter;
+use ArtisanPackUI\VisualEditor\BoxShadow\BoxShadowResolver;
 use ArtisanPackUI\VisualEditor\GradientBorder\GradientBorderEmitter;
 use ArtisanPackUI\VisualEditor\GradientBorder\GradientBorderResolver;
 use ArtisanPackUI\VisualEditor\Responsive\BreakpointRegistry;
 use ArtisanPackUI\VisualEditor\States\StateCssEmitter;
 use ArtisanPackUI\VisualEditor\States\StateRegistry;
 use ArtisanPackUI\VisualEditor\States\StateValueResolver;
+use ArtisanPackUI\VisualEditorRendererBlade\Services\BoxShadowCssAccumulator;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\GradientBorderCssAccumulator;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\ResponsiveCssAccumulator;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\StateCssAccumulator;
@@ -169,6 +172,14 @@ class BlockSupports
 			self::pushGradientBorder( $gradientBorder['class'], $gradientBorder['rules'] );
 		}
 
+		$boxShadow = self::compileBoxShadow( $attributes );
+
+		if ( '' !== $boxShadow['class'] ) {
+			$classes[] = $boxShadow['class'];
+
+			self::pushBoxShadow( $boxShadow['class'], $boxShadow['rules'] );
+		}
+
 		return [
 			'classes'             => $classes,
 			'style'               => $styleString,
@@ -180,6 +191,8 @@ class BlockSupports
 			'statesRules'         => $states['rules'],
 			'gradientBorderClass' => $gradientBorder['class'],
 			'gradientBorderRules' => $gradientBorder['rules'],
+			'boxShadowClass'      => $boxShadow['class'],
+			'boxShadowRules'      => $boxShadow['rules'],
 		];
 	}
 
@@ -268,6 +281,28 @@ class BlockSupports
 
 		try {
 			app( GradientBorderCssAccumulator::class )->push( $scope, $rules );
+		} catch ( \Throwable $e ) {
+			// See pushResponsive() — same drop-silently rationale.
+		}
+	}
+
+	/**
+	 * Mirror of {@see pushResponsive} for box shadows (#607).
+	 *
+	 * @since 1.2.0
+	 */
+	public static function pushBoxShadow( string $scope, string $rules ): void
+	{
+		if ( '' === $scope || '' === $rules ) {
+			return;
+		}
+
+		if ( ! function_exists( 'app' ) ) {
+			return;
+		}
+
+		try {
+			app( BoxShadowCssAccumulator::class )->push( $scope, $rules );
 		} catch ( \Throwable $e ) {
 			// See pushResponsive() — same drop-silently rationale.
 		}
@@ -894,6 +929,86 @@ class BlockSupports
 		);
 
 		return 've-gb-' . $hash;
+	}
+
+	/**
+	 * Compile the `style.shadow` payload into a `{class, rules}` pair
+	 * the wrapper merges in and the accumulator dedupes (#607).
+	 *
+	 * Returns `{class: '', rules: ''}` when no shadow configuration
+	 * is present at any cascade level — callers should treat empty as
+	 * a signal to skip both wrapper merge and accumulator push.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @param  array<string, mixed>  $attributes
+	 *
+	 * @return array{class: string, rules: string}
+	 */
+	protected static function compileBoxShadow( array $attributes ): array
+	{
+		$payload = BoxShadowResolver::resolve( $attributes );
+
+		if ( null === $payload ) {
+			return [ 'class' => '', 'rules' => '' ];
+		}
+
+		try {
+			$states      = self::resolveStateRegistry();
+			$breakpoints = function_exists( 'app' )
+				? self::resolveRegistry()
+				: BreakpointRegistry::fromLayers();
+
+			$emitter = new BoxShadowEmitter( $states, $breakpoints );
+
+			$scopeClass = self::resolveBoxShadowScopeClass( $attributes, $payload );
+			$scope      = '.' . $scopeClass;
+			$css        = $emitter->emit( $scope, $payload );
+
+			if ( '' === $css ) {
+				return [ 'class' => '', 'rules' => '' ];
+			}
+
+			return [
+				'class' => $scopeClass,
+				'rules' => $css,
+			];
+		} catch ( \Throwable $e ) {
+			return [ 'class' => '', 'rules' => '' ];
+		}
+	}
+
+	/**
+	 * Prefer the editor-minted `style.shadow._shadowScopeId` so the
+	 * editor preview and the server-rendered output target the same
+	 * scope class. Falls back to a content-derived hash when no id was
+	 * stamped (legacy content, hand-authored blocks, server-only
+	 * pipelines).
+	 *
+	 * @since 1.2.0
+	 *
+	 * @param  array<string, mixed>  $attributes
+	 * @param  array<string, mixed>  $payload
+	 */
+	protected static function resolveBoxShadowScopeClass( array $attributes, array $payload ): string
+	{
+		$shadow = $attributes['style']['shadow'] ?? null;
+
+		if ( is_array( $shadow ) && isset( $shadow['_shadowScopeId'] ) && is_string( $shadow['_shadowScopeId'] ) ) {
+			$candidate = $shadow['_shadowScopeId'];
+
+			if ( 1 === preg_match( '/^[a-z0-9][a-z0-9_-]*$/i', $candidate ) && strlen( $candidate ) <= 64 ) {
+				return 've-bs-' . $candidate;
+			}
+		}
+
+		$hash = substr(
+			hash( 'xxh3', (string) json_encode( $payload ) ),
+			0,
+			10
+		);
+
+		return 've-bs-' . $hash;
 	}
 
 	/**

--- a/packages/visual-editor-renderer-blade/src/View/Components/BlocksComponent.php
+++ b/packages/visual-editor-renderer-blade/src/View/Components/BlocksComponent.php
@@ -35,6 +35,7 @@ use ArtisanPackUI\VisualEditorRendererBlade\BlockRenderer;
 use ArtisanPackUI\VisualEditorRendererBlade\Resolvers\BreadcrumbsResolver;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\AnimationCssAccumulator;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\GlobalStylesEmissionResolver;
+use ArtisanPackUI\VisualEditorRendererBlade\Services\BoxShadowCssAccumulator;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\GradientBorderCssAccumulator;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\ResponsiveCssAccumulator;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\StateCssAccumulator;
@@ -71,6 +72,7 @@ class BlocksComponent extends Component
 		protected StateCssAccumulator $stateAccumulator,
 		protected AnimationCssAccumulator $animationAccumulator,
 		protected GradientBorderCssAccumulator $gradientBorderAccumulator,
+		protected BoxShadowCssAccumulator $boxShadowAccumulator,
 		mixed $tree = null,
 		?string $defaultTheme = null,
 		mixed $post = null,
@@ -166,6 +168,7 @@ class BlocksComponent extends Component
 		$statesCss          = $this->stateAccumulator->flush();
 		$animationOutput    = $this->animationAccumulator->flush();
 		$gradientBordersCss = $this->gradientBorderAccumulator->flush();
+		$boxShadowsCss      = $this->boxShadowAccumulator->flush();
 
 		return view( 'visual-editor-renderer-blade::components.blocks', [
 			'html'                    => $html,
@@ -176,6 +179,7 @@ class BlocksComponent extends Component
 			'animationsNoscript'      => $animationOutput['noscriptTag'],
 			'animationsRuntimeNeeded' => $animationOutput['runtimeNeeded'],
 			'gradientBordersCss'      => $gradientBordersCss,
+			'boxShadowsCss'           => $boxShadowsCss,
 		] );
 	}
 

--- a/packages/visual-editor-renderer-blade/src/View/Components/TemplateComponent.php
+++ b/packages/visual-editor-renderer-blade/src/View/Components/TemplateComponent.php
@@ -36,6 +36,7 @@ use ArtisanPackUI\VisualEditor\Services\GlobalStylesEmissionTracker;
 use ArtisanPackUI\VisualEditorRendererBlade\BlockRenderer;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\AnimationCssAccumulator;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\GlobalStylesEmissionResolver;
+use ArtisanPackUI\VisualEditorRendererBlade\Services\BoxShadowCssAccumulator;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\GradientBorderCssAccumulator;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\ResponsiveCssAccumulator;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\StateCssAccumulator;
@@ -80,6 +81,7 @@ class TemplateComponent extends Component
 		protected StateCssAccumulator $stateAccumulator,
 		protected AnimationCssAccumulator $animationAccumulator,
 		protected GradientBorderCssAccumulator $gradientBorderAccumulator,
+		protected BoxShadowCssAccumulator $boxShadowAccumulator,
 		string $slug,
 		?string $theme = null,
 	) {
@@ -123,6 +125,7 @@ class TemplateComponent extends Component
 		$statesCss          = $this->stateAccumulator->flush();
 		$animationOutput    = $this->animationAccumulator->flush();
 		$gradientBordersCss = $this->gradientBorderAccumulator->flush();
+		$boxShadowsCss      = $this->boxShadowAccumulator->flush();
 
 		return view( 'visual-editor-renderer-blade::components.template', [
 			'slug'                    => $this->slug,
@@ -139,6 +142,7 @@ class TemplateComponent extends Component
 			'animationsNoscript'      => $animationOutput['noscriptTag'],
 			'animationsRuntimeNeeded' => $animationOutput['runtimeNeeded'],
 			'gradientBordersCss'      => $gradientBordersCss,
+			'boxShadowsCss'           => $boxShadowsCss,
 		] );
 	}
 

--- a/packages/visual-editor-renderer-blade/src/VisualEditorRendererBladeServiceProvider.php
+++ b/packages/visual-editor-renderer-blade/src/VisualEditorRendererBladeServiceProvider.php
@@ -32,6 +32,7 @@ use ArtisanPackUI\VisualEditorRendererBlade\Animations\AnimationMarkupResolver;
 use ArtisanPackUI\VisualEditorRendererBlade\Responsive\ResponsiveClassResolver;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\AnimationCssAccumulator;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\GlobalStylesEmissionResolver;
+use ArtisanPackUI\VisualEditorRendererBlade\Services\BoxShadowCssAccumulator;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\GradientBorderCssAccumulator;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\NavigationOverlayTracker;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\ResponsiveCssAccumulator;
@@ -161,6 +162,15 @@ class VisualEditorRendererBladeServiceProvider extends ServiceProvider
 		// `::before` mask pseudo a gradient border installs.
 		$this->app->scoped( GradientBorderCssAccumulator::class, function () {
 			return new GradientBorderCssAccumulator();
+		} );
+
+		// #607 — sibling accumulator for the box-shadow feature's
+		// `<style data-ve-box-shadows>` block. Same scoped lifetime
+		// rationale as the others; the rules cover stock `box-shadow`
+		// declarations plus the `::before`/`::after` pseudo a gradient
+		// shadow installs.
+		$this->app->scoped( BoxShadowCssAccumulator::class, function () {
+			return new BoxShadowCssAccumulator();
 		} );
 	}
 

--- a/packages/visual-editor-renderer-blade/tests/Unit/BlockSupportsTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Unit/BlockSupportsTest.php
@@ -441,6 +441,44 @@ describe( 'BlockSupports::compile (composition)', function (): void {
 		expect( substr_count( $result['style'], 'background-color:' ) )->toBe( 1 );
 	} );
 
+	it( 'stamps a ve-bs-* scope class and emits box-shadow rules for a solid shadow (#607)', function (): void {
+		$result = BlockSupports::compile( [
+			'style' => [
+				'shadow' => [
+					'offsetX'        => '2px',
+					'offsetY'        => '4px',
+					'blur'           => '8px',
+					'spread'         => '0',
+					'color'          => '#000',
+					'_shadowScopeId' => 'abc123def',
+				],
+			],
+		] );
+
+		expect( $result['boxShadowClass'] )->toBe( 've-bs-abc123def' );
+		expect( $result['boxShadowRules'] )->toContain( '.ve-bs-abc123def{box-shadow:2px 4px 8px 0 #000}' );
+		expect( $result['classes'] )->toContain( 've-bs-abc123def' );
+	} );
+
+	it( 'stamps a ve-bs-* scope class and emits gradient ::before for a gradient shadow (#607)', function (): void {
+		$result = BlockSupports::compile( [
+			'style' => [
+				'shadow' => [
+					'offsetX'        => '4px',
+					'offsetY'        => '6px',
+					'blur'           => '12px',
+					'spread'         => '2px',
+					'gradient'       => 'linear-gradient(135deg, #ff0000, #0000ff)',
+					'_shadowScopeId' => 'gradblob01',
+				],
+			],
+		] );
+
+		expect( $result['boxShadowClass'] )->toBe( 've-bs-gradblob01' );
+		expect( $result['boxShadowRules'] )->toContain( '.ve-bs-gradblob01::before{' );
+		expect( $result['boxShadowRules'] )->toContain( 'background:linear-gradient(135deg, #ff0000, #0000ff)' );
+	} );
+
 	it( 'returns empty result for a block with no supported attributes', function (): void {
 		$result = BlockSupports::compile( [] );
 
@@ -455,6 +493,8 @@ describe( 'BlockSupports::compile (composition)', function (): void {
 			'statesRules'         => '',
 			'gradientBorderClass' => '',
 			'gradientBorderRules' => '',
+			'boxShadowClass'      => '',
+			'boxShadowRules'      => '',
 		] );
 	} );
 

--- a/resources/js/visual-editor/box-shadows/__tests__/emitter.test.ts
+++ b/resources/js/visual-editor/box-shadows/__tests__/emitter.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from 'vitest'
+
+import { TAILWIND_V4_DEFAULTS, BreakpointRegistry } from '../../responsive/registry'
+import { DEFAULT_STATES, StateRegistry } from '../../states/registry'
+import { emitBoxShadowCss } from '../emitter'
+import type { ResolvedBoxShadow, ResolvedShadowLayer } from '../types'
+
+const states      = new StateRegistry( DEFAULT_STATES )
+const breakpoints = new BreakpointRegistry( TAILWIND_V4_DEFAULTS )
+
+function layer( overrides: Partial<ResolvedShadowLayer> = {} ): ResolvedShadowLayer {
+	return {
+		offsetX:  '0',
+		offsetY:  '0',
+		blur:     '0',
+		spread:   '0',
+		color:    null,
+		gradient: null,
+		inset:    false,
+		preset:   null,
+		...overrides,
+	}
+}
+
+const baseline: ResolvedBoxShadow = {
+	idle:        null,
+	states:      {},
+	breakpoints: {},
+}
+
+describe( 'emitBoxShadowCss', () => {
+	it( 'returns empty when scope is blank or payload is null', () => {
+		expect( emitBoxShadowCss( '', baseline, states, breakpoints ) ).toBe( '' )
+		expect( emitBoxShadowCss( '.scope', null, states, breakpoints ) ).toBe( '' )
+	} )
+
+	it( 'returns empty when the payload has no values anywhere', () => {
+		expect( emitBoxShadowCss( '.scope', baseline, states, breakpoints ) ).toBe( '' )
+	} )
+
+	it( 'emits a stock box-shadow for a solid outer layer', () => {
+		const css = emitBoxShadowCss(
+			'.scope',
+			{ ...baseline, idle: layer( { offsetX: '2px', offsetY: '4px', blur: '8px', color: '#000' } ) },
+			states,
+			breakpoints,
+		)
+
+		expect( css ).toContain( '.scope{box-shadow:2px 4px 8px 0 #000}' )
+		expect( css ).not.toContain( '::before' )
+		expect( css ).not.toContain( 'position:relative' )
+	} )
+
+	it( 'emits inset prefix for a solid inset layer', () => {
+		const css = emitBoxShadowCss(
+			'.scope',
+			{ ...baseline, idle: layer( { blur: '6px', color: '#333', inset: true } ) },
+			states,
+			breakpoints,
+		)
+
+		expect( css ).toContain( '.scope{box-shadow:inset 0 0 6px 0 #333}' )
+	} )
+
+	it( 'emits var() for a preset layer', () => {
+		const css = emitBoxShadowCss(
+			'.scope',
+			{ ...baseline, idle: layer( { preset: 'shadow-md' } ) },
+			states,
+			breakpoints,
+		)
+
+		expect( css ).toContain( '.scope{box-shadow:var(--wp--preset--shadow--shadow-md)}' )
+	} )
+
+	it( 'appends inset suffix on preset layers when inset is true', () => {
+		const css = emitBoxShadowCss(
+			'.scope',
+			{ ...baseline, idle: layer( { preset: 'shadow-lg', inset: true } ) },
+			states,
+			breakpoints,
+		)
+
+		expect( css ).toContain( '.scope{box-shadow:var(--wp--preset--shadow--shadow-lg) inset}' )
+	} )
+
+	it( 'emits the ::before pseudo for an outer gradient layer with position relative on the wrapper', () => {
+		const css = emitBoxShadowCss(
+			'.scope',
+			{ ...baseline, idle: layer( {
+				offsetX:  '4px',
+				offsetY:  '6px',
+				blur:     '12px',
+				spread:   '2px',
+				gradient: 'linear-gradient(135deg, #ff0000, #0000ff)',
+			} ) },
+			states,
+			breakpoints,
+		)
+
+		expect( css ).toContain( '.scope{position:relative;isolation:isolate}' )
+		expect( css ).toContain( '.scope::before{' )
+		expect( css ).toContain( 'background:linear-gradient(135deg, #ff0000, #0000ff)' )
+		expect( css ).toContain( 'filter:blur(12px)' )
+		expect( css ).toContain( 'transform:translate(4px,6px)' )
+		expect( css ).toContain( 'z-index:-1' )
+	} )
+
+	it( 'emits the ::after pseudo with mask-composite for an inset gradient layer', () => {
+		const css = emitBoxShadowCss(
+			'.scope',
+			{ ...baseline, idle: layer( {
+				offsetX:  '4px',
+				offsetY:  '6px',
+				blur:     '8px',
+				spread:   '4px',
+				gradient: 'linear-gradient(180deg, #fff, #000)',
+				inset:    true,
+			} ) },
+			states,
+			breakpoints,
+		)
+
+		expect( css ).toContain( '.scope{position:relative;isolation:isolate}' )
+		expect( css ).toContain( '.scope::after{' )
+		expect( css ).toContain( 'mask-composite:exclude' )
+		expect( css ).toContain( 'transform:translate(calc(-1 * 4px),calc(-1 * 6px))' )
+		expect( css ).toContain( 'padding:4px' )
+	} )
+
+	it( 'wraps hover state rules in @media (hover: hover)', () => {
+		const css = emitBoxShadowCss(
+			'.scope',
+			{
+				...baseline,
+				idle:   layer( { blur: '4px', color: '#000' } ),
+				states: { hover: layer( { blur: '12px', color: '#111' } ) },
+			},
+			states,
+			breakpoints,
+		)
+
+		expect( css ).toContain( '@media (hover: hover){' )
+		expect( css ).toContain( 'transition:' )
+	} )
+
+	it( 'wraps breakpoint rules in a min-width media query', () => {
+		const css = emitBoxShadowCss(
+			'.scope',
+			{
+				...baseline,
+				idle:        layer( { blur: '4px', color: '#000' } ),
+				breakpoints: { md: layer( { blur: '16px', color: '#000' } ) },
+			},
+			states,
+			breakpoints,
+		)
+
+		expect( css ).toMatch( /@media \(min-width:\d+px\)\{\.scope\{box-shadow:0 0 16px 0 #000\}\}/ )
+	} )
+} )

--- a/resources/js/visual-editor/box-shadows/__tests__/extend-supports.test.ts
+++ b/resources/js/visual-editor/box-shadows/__tests__/extend-supports.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Extend-supports filter — verifies that `style.shadow` lands in
+ * `artisanpackStates.attributes` + `artisanpackResponsive.attributes`
+ * for blocks with border support, while explicit `false` opt-outs are
+ * preserved.
+ *
+ * Note: this test imports the filter implementation indirectly by
+ * invoking the registrar against a stubbed @wordpress/hooks. The
+ * registrar itself is sentinel-guarded so we reset the global between
+ * runs.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Stub @wordpress/hooks BEFORE importing the module under test so the
+// registrar's `addFilter` call hits our spy instead of trying to load
+// the real Gutenberg hooks runtime under jsdom.
+let lastFilterCallback: ( ( settings: unknown ) => unknown ) | null = null
+
+vi.mock( '@wordpress/hooks', () => ( {
+	addFilter: ( _hook: string, _ns: string, cb: ( settings: unknown ) => unknown ) => {
+		lastFilterCallback = cb
+	},
+} ) )
+
+import { registerBoxShadowSupportsExtension } from '../extend-supports'
+
+const REGISTERED_KEY = Symbol.for(
+	'artisanpack-ui.visual-editor.box-shadow-supports.registered',
+)
+
+beforeEach( () => {
+	lastFilterCallback = null
+	delete ( globalThis as Record<symbol, unknown> )[ REGISTERED_KEY as unknown as symbol ]
+} )
+
+function applyFilter( settings: Record<string, unknown> ): Record<string, unknown> {
+	registerBoxShadowSupportsExtension()
+	expect( lastFilterCallback ).not.toBeNull()
+	return lastFilterCallback!( settings ) as Record<string, unknown>
+}
+
+describe( 'registerBoxShadowSupportsExtension', () => {
+	it( 'is a no-op for blocks without any border support', () => {
+		const next = applyFilter( { supports: { color: { background: true } } } )
+		expect( next ).toEqual( { supports: { color: { background: true } } } )
+	} )
+
+	it( 'injects style.shadow into the routing lists for blocks with __experimentalBorder', () => {
+		const next = applyFilter( {
+			supports: { __experimentalBorder: { width: true } },
+		} )
+
+		const supports = next.supports as Record<string, unknown>
+		expect( ( supports.artisanpackStates as { attributes: string[] } ).attributes ).toContain( 'style.shadow' )
+		expect( ( supports.artisanpackResponsive as { attributes: string[] } ).attributes ).toContain( 'style.shadow' )
+	} )
+
+	it( 'preserves an explicit `false` opt-out on either routing key', () => {
+		const next = applyFilter( {
+			supports: {
+				__experimentalBorder:   { width: true },
+				artisanpackStates:      false,
+				artisanpackResponsive:  false,
+			},
+		} )
+
+		const supports = next.supports as Record<string, unknown>
+		expect( supports.artisanpackStates ).toBe( false )
+		expect( supports.artisanpackResponsive ).toBe( false )
+	} )
+
+	it( 'preserves existing attribute lists and appends style.shadow', () => {
+		const next = applyFilter( {
+			supports: {
+				__experimentalBorder: { width: true },
+				artisanpackStates:    { attributes: [ 'border.gradient' ] },
+			},
+		} )
+
+		const supports = next.supports as Record<string, unknown>
+		const stateAttrs = ( supports.artisanpackStates as { attributes: string[] } ).attributes
+		expect( stateAttrs ).toEqual( [ 'border.gradient', 'style.shadow' ] )
+	} )
+
+	it( 'strips the native WordPress `supports.shadow` so the two panels do not fight over `style.shadow`', () => {
+		const next = applyFilter( {
+			supports: {
+				__experimentalBorder: { width: true },
+				shadow:               true,
+			},
+		} )
+
+		const supports = next.supports as Record<string, unknown>
+		expect( supports.shadow ).toBe( false )
+	} )
+
+	it( 'is idempotent when style.shadow is already present', () => {
+		const next = applyFilter( {
+			supports: {
+				__experimentalBorder: { width: true },
+				artisanpackStates:    { attributes: [ 'style.shadow' ] },
+			},
+		} )
+
+		const supports = next.supports as Record<string, unknown>
+		const stateAttrs = ( supports.artisanpackStates as { attributes: string[] } ).attributes
+		expect( stateAttrs ).toEqual( [ 'style.shadow' ] )
+	} )
+} )

--- a/resources/js/visual-editor/box-shadows/__tests__/resolver.test.ts
+++ b/resources/js/visual-editor/box-shadows/__tests__/resolver.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest'
+
+import { referencedSlugs, resolveBoxShadow } from '../resolver'
+
+describe( 'resolveBoxShadow', () => {
+	it( 'returns null for missing, null, or empty attributes', () => {
+		expect( resolveBoxShadow( null ) ).toBeNull()
+		expect( resolveBoxShadow( undefined ) ).toBeNull()
+		expect( resolveBoxShadow( {} ) ).toBeNull()
+		expect( resolveBoxShadow( { style: { shadow: {} } } ) ).toBeNull()
+	} )
+
+	it( 'returns a structured idle layer when fields are set', () => {
+		const resolved = resolveBoxShadow( {
+			style: {
+				shadow: {
+					offsetX: '2px',
+					offsetY: '4px',
+					blur:    '8px',
+					spread:  '0',
+					color:   '#000',
+				},
+			},
+		} )
+
+		expect( resolved ).not.toBeNull()
+		expect( resolved!.idle ).toEqual( {
+			offsetX:  '2px',
+			offsetY:  '4px',
+			blur:     '8px',
+			spread:   '0',
+			color:    '#000',
+			gradient: null,
+			inset:    false,
+			preset:   null,
+		} )
+	} )
+
+	it( 'expands a gradient slug into var(--wp--preset--gradient--{slug})', () => {
+		const resolved = resolveBoxShadow( {
+			style: { shadow: { offsetX: '0', gradient: 'primary-glow' } },
+		} )
+
+		expect( resolved!.idle!.gradient ).toBe( 'var(--wp--preset--gradient--primary-glow)' )
+	} )
+
+	it( 'passes raw CSS gradient values through unchanged', () => {
+		const raw      = 'linear-gradient(135deg, #ff0000, #0000ff)'
+		const resolved = resolveBoxShadow( {
+			style: { shadow: { gradient: raw } },
+		} )
+
+		expect( resolved!.idle!.gradient ).toBe( raw )
+	} )
+
+	it( 'captures a preset slug onto the layer', () => {
+		const resolved = resolveBoxShadow( {
+			style: { shadow: { preset: 'shadow-md' } },
+		} )
+
+		expect( resolved!.idle!.preset ).toBe( 'shadow-md' )
+	} )
+
+	it( 'honours the inset flag', () => {
+		const resolved = resolveBoxShadow( {
+			style: { shadow: { offsetX: '0', inset: true } },
+		} )
+
+		expect( resolved!.idle!.inset ).toBe( true )
+	} )
+
+	it( 'collects per-state and per-breakpoint overrides from the standard bags', () => {
+		const resolved = resolveBoxShadow( {
+			style:      { shadow: { offsetX: '2px', blur: '4px', color: '#000' } },
+			states:     {
+				'style.shadow': {
+					hover: { offsetX: '4px', blur: '8px', color: '#111' },
+					focus: null,
+				},
+			},
+			responsive: {
+				'style.shadow': {
+					md: { offsetX: '6px', blur: '12px', color: '#000' },
+				},
+			},
+		} )
+
+		expect( resolved!.states.hover.blur ).toBe( '8px' )
+		expect( resolved!.states.focus ).toBeUndefined()
+		expect( resolved!.breakpoints.md.blur ).toBe( '12px' )
+	} )
+
+	it( 'accepts the shorthand `shadow` path key with canonical winning on conflict', () => {
+		const resolved = resolveBoxShadow( {
+			states: {
+				'shadow':       { hover: { blur: '99px' } },
+				'style.shadow': { hover: { blur: '8px' } },
+			},
+		} )
+
+		expect( resolved!.states.hover.blur ).toBe( '8px' )
+	} )
+} )
+
+describe( 'referencedSlugs', () => {
+	it( 'pulls shadow + gradient slugs from every cascade slot', () => {
+		const slugs = referencedSlugs( {
+			style:      { shadow: { preset: 'shadow-md', gradient: 'brand-glow' } },
+			states:     {
+				'style.shadow': { hover: { preset: 'shadow-elevated' } },
+			},
+			responsive: {
+				'style.shadow': { md: { gradient: 'vertical' } },
+			},
+		} )
+
+		expect( slugs.shadows.sort() ).toEqual( [ 'shadow-elevated', 'shadow-md' ] )
+		expect( slugs.gradients.sort() ).toEqual( [ 'brand-glow', 'vertical' ] )
+	} )
+
+	it( 'deduplicates slugs that appear in multiple cascade slots', () => {
+		const slugs = referencedSlugs( {
+			style:  { shadow: { preset: 'shadow-md' } },
+			states: { 'style.shadow': { hover: { preset: 'shadow-md' } } },
+		} )
+
+		expect( slugs.shadows ).toEqual( [ 'shadow-md' ] )
+	} )
+
+	it( 'ignores raw CSS gradient values — they cannot become stale', () => {
+		const slugs = referencedSlugs( {
+			style: { shadow: { gradient: 'linear-gradient(#f00, #00f)' } },
+		} )
+
+		expect( slugs.gradients ).toEqual( [] )
+	} )
+} )

--- a/resources/js/visual-editor/box-shadows/emitter.ts
+++ b/resources/js/visual-editor/box-shadows/emitter.ts
@@ -1,0 +1,345 @@
+/**
+ * Client-side CSS emitter for box shadows (#607).
+ *
+ * Mirrors the PHP `BoxShadowEmitter` byte-for-byte so the editor
+ * canvas preview matches the rendered front-end. See the PHP file's
+ * docblock for the per-mode CSS strategy rationale.
+ *
+ * Three emission modes, dispatched per resolved layer:
+ *
+ *   1. **Preset** (`layer.preset` set) — `box-shadow: var(--wp--preset--shadow--{slug})`.
+ *      Inset is honored via `var(...) inset` (concatenated by the
+ *      shadow var convention — themes ship the value WITHOUT the
+ *      `inset` keyword).
+ *
+ *   2. **Solid** (`layer.gradient` null) — stock `box-shadow:
+ *      [inset] X Y blur spread color`.
+ *
+ *   3. **Gradient** (`layer.gradient` set) — `::before` (outer) or
+ *      `::after` (inset) pseudo with `background: <gradient>`,
+ *      `filter: blur(<blur>)`, `transform: translate(<X>, <Y>)`, and
+ *      for inset, a `mask-composite: exclude` ring mask to clip the
+ *      fill to the inside of the wrapper.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.2.0
+ */
+
+import type { BreakpointRegistry } from '../responsive/registry'
+import type { StateRegistry } from '../states/registry'
+import type { ResolvedBoxShadow, ResolvedShadowLayer } from './types'
+
+export const DEFAULT_TRANSITION =
+	'box-shadow 200ms ease, background 200ms ease, opacity 200ms ease, transform 200ms ease'
+
+const CSS_WHITELIST      = /[^a-zA-Z0-9_+\-*/.,()%#\s]/g
+const GRADIENT_WHITELIST = /[^a-zA-Z0-9_+\-*/.,()%#:\s]/g
+const SLUG_WHITELIST     = /[^a-z0-9_-]/gi
+
+function sanitizeCss( value: string ): string {
+	return value.replace( CSS_WHITELIST, '' )
+}
+
+function sanitizeGradient( value: string ): string {
+	return value.replace( GRADIENT_WHITELIST, '' )
+}
+
+function sanitizeSlug( value: string ): string {
+	return value.replace( SLUG_WHITELIST, '' )
+}
+
+/**
+ * Compose the `box-shadow` declaration for a solid (non-gradient,
+ * non-preset) layer. Color falls back to `currentColor` if missing
+ * — matches the WP core shadow panel default.
+ */
+function solidBoxShadow( layer: ResolvedShadowLayer ): string {
+	const parts = [
+		sanitizeCss( layer.offsetX ),
+		sanitizeCss( layer.offsetY ),
+		sanitizeCss( layer.blur ),
+		sanitizeCss( layer.spread ),
+		sanitizeCss( layer.color ?? 'currentColor' ),
+	].join( ' ' )
+
+	return layer.inset ? `inset ${ parts }` : parts
+}
+
+function presetBoxShadow( layer: ResolvedShadowLayer ): string {
+	const slug = sanitizeSlug( layer.preset ?? '' )
+
+	if ( '' === slug ) {
+		return ''
+	}
+
+	const value = `var(--wp--preset--shadow--${ slug })`
+
+	return layer.inset ? `${ value } inset` : value
+}
+
+/**
+ * Build the gradient ::before (outer) or ::after (inset) declaration
+ * body. The wrapper itself gets `position: relative` + no native
+ * box-shadow — the pseudo paints the gradient + filter-blur.
+ */
+function gradientPseudoDeclarations( layer: ResolvedShadowLayer ): string {
+	const offsetX = sanitizeCss( layer.offsetX )
+	const offsetY = sanitizeCss( layer.offsetY )
+	const blur    = sanitizeCss( layer.blur )
+	const spread  = sanitizeCss( layer.spread )
+	const fill    = sanitizeGradient( layer.gradient ?? 'transparent' )
+
+	if ( layer.inset ) {
+		// Inset gradient: ::after sits INSIDE the wrapper, padded by
+		// `spread` so the gradient fill is clipped to a ring near
+		// the inside edge via `mask-composite: exclude`. The
+		// translate moves the inner fill OPPOSITE the offset so the
+		// "light source" reads as outside the box. `filter: blur()`
+		// softens the ring. `border-radius: inherit` keeps the mask
+		// curve matched to the wrapper's own corners. Explicit
+		// top/left/width/height (rather than `inset: 0`) for the same
+		// reason the outer path uses them — unambiguous sizing across
+		// containing-block edge cases.
+		return (
+			'content:"";position:absolute;top:0;left:0;width:100%;height:100%;'
+			+ 'border-radius:inherit;'
+			+ `padding:${ spread };`
+			+ `background:${ fill };`
+			+ `filter:blur(${ blur });`
+			+ `transform:translate(calc(-1 * ${ offsetX }),calc(-1 * ${ offsetY }));`
+			+ '-webkit-mask:linear-gradient(#000 0 0) content-box,linear-gradient(#000 0 0);'
+			+ '-webkit-mask-composite:xor;'
+			+ 'mask:linear-gradient(#000 0 0) content-box,linear-gradient(#000 0 0);'
+			+ 'mask-composite:exclude;'
+			+ 'pointer-events:none'
+		)
+	}
+
+	// Outer gradient: ::before extends OUTWARD by `spread` via explicit
+	// top/left + width/height so the fill bleeds past the wrapper edge
+	// before `filter: blur()` softens it into a shadow. The original
+	// shorthand `inset: calc(-1 * spread)` is spec-equivalent but some
+	// browsers / containing-block setups don't resolve a 0-sized
+	// absolutely-positioned element correctly from inset alone — the
+	// pseudo collapses to its (empty) content. Explicit dimensions
+	// make the sizing unambiguous. `z-index: -1` keeps the gradient
+	// behind the wrapper content.
+	return (
+		'content:"";position:absolute;'
+		+ `top:calc(-1 * ${ spread });left:calc(-1 * ${ spread });`
+		+ `width:calc(100% + 2 * ${ spread });height:calc(100% + 2 * ${ spread });`
+		+ 'border-radius:inherit;'
+		+ `background:${ fill };`
+		+ `filter:blur(${ blur });`
+		+ `transform:translate(${ offsetX },${ offsetY });`
+		+ 'z-index:-1;'
+		+ 'pointer-events:none'
+	)
+}
+
+function isGradient( layer: ResolvedShadowLayer ): boolean {
+	return null === layer.preset && null !== layer.gradient
+}
+
+function isPreset( layer: ResolvedShadowLayer ): boolean {
+	return null !== layer.preset
+}
+
+function pseudoForLayer( layer: ResolvedShadowLayer ): '::before' | '::after' {
+	return layer.inset ? '::after' : '::before'
+}
+
+function selectorFor( scope: string, selector: string ): string {
+	if ( '' === selector ) {
+		return ''
+	}
+
+	return selector
+		.split( ',' )
+		.map( ( s ) => s.trim() )
+		.filter( ( s ) => '' !== s )
+		.map( ( piece ) =>
+			piece.includes( '&' )
+				? piece.replaceAll( '&', scope )
+				: `${ scope }${ piece }`,
+		)
+		.join( ', ' )
+}
+
+/**
+ * Append a pseudo-element suffix to every selector in a
+ * comma-separated list. Mirrors gradient-borders' helper of the same
+ * name — see that docblock for the failure mode this prevents.
+ */
+function appendPseudoToList( selector: string, pseudo: string ): string {
+	return selector
+		.split( ',' )
+		.map( ( s ) => s.trim() )
+		.filter( ( s ) => '' !== s )
+		.map( ( s ) => s + pseudo )
+		.join( ', ' )
+}
+
+function layerBoxShadowValue( layer: ResolvedShadowLayer ): string {
+	if ( isPreset( layer ) ) {
+		return presetBoxShadow( layer )
+	}
+
+	return solidBoxShadow( layer )
+}
+
+/**
+ * Emit the scoped CSS for a single block scope. Empty string when
+ * the payload contains no actionable values.
+ */
+export function emitBoxShadowCss(
+	scope: string,
+	payload: ResolvedBoxShadow | null | undefined,
+	states: StateRegistry,
+	breakpoints: BreakpointRegistry,
+): string {
+	const trimmedScope = scope.trim()
+
+	if ( '' === trimmedScope || ! payload ) {
+		return ''
+	}
+
+	const idle     = payload.idle
+	const stateMap = payload.states
+	const bpMap    = payload.breakpoints
+
+	const hasNonIdle =
+		0 < Object.keys( stateMap ).length || 0 < Object.keys( bpMap ).length
+
+	if ( null === idle && ! hasNonIdle ) {
+		return ''
+	}
+
+	const rules: string[] = []
+
+	// Whether any layer at any cascade level uses the gradient
+	// pseudo-element path. If so, the wrapper needs `position:
+	// relative` so the pseudo aligns with the wrapper box.
+	const usesGradient =
+		( null !== idle && isGradient( idle ) )
+		|| Object.values( stateMap ).some( isGradient )
+		|| Object.values( bpMap ).some( isGradient )
+
+	if ( usesGradient ) {
+		// `isolation: isolate` creates a new stacking context on the
+		// wrapper. Without it, the gradient `::before` (which uses
+		// `z-index: -1` to slip BEHIND the wrapper's own children) can
+		// get hidden behind a parent's background, because z-index: -1
+		// in the parent's stacking context puts the pseudo behind that
+		// parent too. With `isolation: isolate` the pseudo's `z-index:
+		// -1` is constrained to THIS wrapper's stacking context — it
+		// goes behind the wrapper's children but stays in front of the
+		// editor canvas / page background. Standard CSS-tricks technique
+		// for gradient drop shadows.
+		rules.push( `${ trimmedScope }{position:relative;isolation:isolate}` )
+	}
+
+	// --- Idle layer ---
+	if ( null !== idle ) {
+		if ( isGradient( idle ) ) {
+			rules.push(
+				`${ trimmedScope }${ pseudoForLayer( idle ) }{${ gradientPseudoDeclarations( idle ) }}`,
+			)
+		} else {
+			const value = layerBoxShadowValue( idle )
+			if ( '' !== value ) {
+				rules.push( `${ trimmedScope }{box-shadow:${ value }}` )
+			}
+		}
+	}
+
+	if ( hasNonIdle ) {
+		rules.push( `${ trimmedScope }{transition:${ DEFAULT_TRANSITION }}` )
+	}
+
+	// --- Per-state layers ---
+	const hoverParts:    string[] = []
+	const nonHoverParts: string[] = []
+
+	for ( const stateKey of Object.keys( stateMap ) ) {
+		const definition = states.get( stateKey )
+
+		if ( ! definition ) {
+			continue
+		}
+
+		const selector = selectorFor( trimmedScope, definition.selector )
+
+		if ( '' === selector ) {
+			continue
+		}
+
+		const layer = stateMap[ stateKey ]
+		const rule  = stateRuleFor( selector, layer )
+
+		if ( '' === rule ) {
+			continue
+		}
+
+		if ( definition.hoverMediaWrap ) {
+			hoverParts.push( rule )
+			continue
+		}
+
+		nonHoverParts.push( rule )
+	}
+
+	if ( 0 < hoverParts.length ) {
+		rules.push( `@media (hover: hover){${ hoverParts.join( '' ) }}` )
+	}
+
+	for ( const rule of nonHoverParts ) {
+		rules.push( rule )
+	}
+
+	// --- Per-breakpoint layers ---
+	for ( const breakpointKey of Object.keys( bpMap ) ) {
+		const minWidth = breakpoints.get( breakpointKey )
+
+		if ( null === minWidth ) {
+			continue
+		}
+
+		const layer = bpMap[ breakpointKey ]
+		const rule  = breakpointRuleFor( trimmedScope, layer )
+
+		if ( '' === rule ) {
+			continue
+		}
+
+		rules.push( `@media (min-width:${ minWidth }px){${ rule }}` )
+	}
+
+	return rules.join( '' )
+}
+
+function stateRuleFor( selector: string, layer: ResolvedShadowLayer ): string {
+	if ( isGradient( layer ) ) {
+		return `${ appendPseudoToList( selector, pseudoForLayer( layer ) ) }{${ gradientPseudoDeclarations( layer ) }}`
+	}
+
+	const value = layerBoxShadowValue( layer )
+	if ( '' === value ) {
+		return ''
+	}
+
+	return `${ selector }{box-shadow:${ value }}`
+}
+
+function breakpointRuleFor( scope: string, layer: ResolvedShadowLayer ): string {
+	if ( isGradient( layer ) ) {
+		return `${ scope }${ pseudoForLayer( layer ) }{${ gradientPseudoDeclarations( layer ) }}`
+	}
+
+	const value = layerBoxShadowValue( layer )
+	if ( '' === value ) {
+		return ''
+	}
+
+	return `${ scope }{box-shadow:${ value }}`
+}

--- a/resources/js/visual-editor/box-shadows/extend-supports.ts
+++ b/resources/js/visual-editor/box-shadows/extend-supports.ts
@@ -1,0 +1,146 @@
+/**
+ * `blocks.registerBlockType` filter — auto-add `style.shadow` to the
+ * `artisanpackStates.attributes` and `artisanpackResponsive.attributes`
+ * routing lists for every block that opts into border support (#607).
+ *
+ * Per #607, the gating reads existing border support directly rather
+ * than a sub-flag — every block with any `__experimentalBorder` (or
+ * `border`) support gets the shadow panel + cascade routing. This
+ * means ~94 blocks pick up shadow controls with NO block.json
+ * changes.
+ *
+ * Explicit `artisanpackStates: false` / `artisanpackResponsive: false`
+ * opt-outs are preserved.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.2.0
+ */
+
+import { addFilter } from '@wordpress/hooks'
+
+const FILTER_HOOK      = 'blocks.registerBlockType'
+const FILTER_NAMESPACE = 'artisanpack-ui/visual-editor/box-shadow-supports'
+
+const REGISTERED_KEY = Symbol.for(
+	'artisanpack-ui.visual-editor.box-shadow-supports.registered',
+)
+
+interface GlobalSentinelHost {
+	[REGISTERED_KEY]?: boolean
+}
+
+interface BorderSupport {
+	[key: string]: unknown
+}
+
+interface RoutingSupport {
+	attributes?: string[]
+	[key: string]: unknown
+}
+
+interface BlockSupports {
+	border?: BorderSupport
+	__experimentalBorder?: BorderSupport
+	artisanpackStates?: RoutingSupport | boolean
+	artisanpackResponsive?: RoutingSupport | boolean
+	shadow?: boolean | Record<string, unknown>
+	[key: string]: unknown
+}
+
+interface BlockSettingsLike {
+	supports?: BlockSupports
+	[key: string]: unknown
+}
+
+const ROUTING_PATH = 'style.shadow'
+
+function shadowEnabled( supports: BlockSupports | undefined ): boolean {
+	if ( ! supports ) {
+		return false
+	}
+
+	const border = supports.__experimentalBorder ?? supports.border
+
+	return Boolean( border && 'object' === typeof border )
+}
+
+function ensureRouted(
+	supports: BlockSupports,
+	key: 'artisanpackStates' | 'artisanpackResponsive',
+): RoutingSupport | false {
+	const raw = supports[ key ]
+
+	// Explicit opt-out — preserve a deliberate `false` declaration in
+	// the block.json.
+	if ( false === raw ) {
+		return false
+	}
+
+	if ( raw === undefined || raw === null || true === raw ) {
+		return { attributes: [ ROUTING_PATH ] }
+	}
+
+	if ( 'object' !== typeof raw ) {
+		return { attributes: [ ROUTING_PATH ] }
+	}
+
+	const attributes = Array.isArray( raw.attributes ) ? raw.attributes : []
+
+	if ( attributes.includes( ROUTING_PATH ) ) {
+		return raw
+	}
+
+	return {
+		...raw,
+		attributes: [ ...attributes, ROUTING_PATH ],
+	}
+}
+
+function injectBoxShadowSupports(
+	settings: BlockSettingsLike,
+): BlockSettingsLike {
+	if ( ! shadowEnabled( settings.supports ) ) {
+		return settings
+	}
+
+	const supports = settings.supports as BlockSupports
+
+	// IMPORTANT: strip the native WordPress `supports.shadow`. Core's
+	// shadow support uses the SAME attribute path (`style.shadow`) we
+	// use, but stores a CSS string (`var(--wp--preset--shadow--{slug})`)
+	// rather than the structured `{offsetX, offsetY, blur, spread,
+	// color, gradient, inset, preset}` object our panel writes. Left
+	// enabled, both panels render in the inspector and they fight over
+	// the attribute — the native compiler treats our object as garbage
+	// and the save filter's `readScopeId` returns null because a string
+	// has no `_shadowScopeId` property. So the saved markup carries
+	// neither rule and the shadow never renders. Removing the native
+	// support hides the native panel and frees `style.shadow` for our
+	// structured shape — ours becomes the single source of truth.
+	const nextSupports: BlockSupports = {
+		...supports,
+		shadow:                false,
+		artisanpackStates:     ensureRouted( supports, 'artisanpackStates' ),
+		artisanpackResponsive: ensureRouted( supports, 'artisanpackResponsive' ),
+	}
+
+	return {
+		...settings,
+		supports: nextSupports,
+	}
+}
+
+/**
+ * Register the filter at most once per page. Idempotent — safe to
+ * call from both the post-editor and site-editor entries.
+ */
+export function registerBoxShadowSupportsExtension(): void {
+	const host = globalThis as unknown as GlobalSentinelHost
+
+	if ( host[ REGISTERED_KEY ] ) {
+		return
+	}
+
+	addFilter( FILTER_HOOK, FILTER_NAMESPACE, injectBoxShadowSupports )
+	host[ REGISTERED_KEY ] = true
+}

--- a/resources/js/visual-editor/box-shadows/index.ts
+++ b/resources/js/visual-editor/box-shadows/index.ts
@@ -1,0 +1,23 @@
+/**
+ * Public entry point for the box-shadow feature (#607).
+ *
+ * Mirrors the deliberate split in `gradient-borders/index.ts`: the
+ * HOC + filter registrars are NOT re-exported here. They import
+ * `@wordpress/blocks`, which trips JSON-import-attribute requirements
+ * when host bundlers (or Vitest) walk this barrel transitively.
+ *
+ * What lives in the barrel: pure data types and the resolver/emitter
+ * helpers any host can call without booting Gutenberg.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.2.0
+ */
+
+export { resolveBoxShadow, referencedSlugs } from './resolver'
+export { emitBoxShadowCss, DEFAULT_TRANSITION } from './emitter'
+export type {
+	BoxShadowAttributes,
+	ShadowSubtree,
+	ResolvedBoxShadow,
+	ResolvedShadowLayer,
+} from './types'

--- a/resources/js/visual-editor/box-shadows/register.ts
+++ b/resources/js/visual-editor/box-shadows/register.ts
@@ -1,0 +1,31 @@
+/**
+ * One-shot registrar for the box-shadow feature (#607).
+ *
+ * Bootstraps the BlockEdit HOC (shadow tools panel + token-missing
+ * warnings), the supports-extension filter (auto-add `style.shadow`
+ * to opted-in blocks' state/responsive routing), and the style-
+ * emission filters (canvas preview + save markup).
+ *
+ * Kept in its own file rather than the package barrel so host bundlers
+ * walking `./index.ts` don't transitively pull in `@wordpress/blocks`.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.2.0
+ */
+
+import { registerBoxShadowControl } from './with-box-shadow-control'
+import { registerBoxShadowSupportsExtension } from './extend-supports'
+import { registerBoxShadowStylesFilters } from './with-box-shadow-styles'
+
+/**
+ * Install every filter the box-shadow feature needs. Idempotent —
+ * each registrar guards itself with a sentinel so calling this from
+ * both post-editor and site-editor entries is safe.
+ *
+ * @since 1.2.0
+ */
+export function registerBoxShadows(): void {
+	registerBoxShadowSupportsExtension()
+	registerBoxShadowControl()
+	registerBoxShadowStylesFilters()
+}

--- a/resources/js/visual-editor/box-shadows/resolver.ts
+++ b/resources/js/visual-editor/box-shadows/resolver.ts
@@ -1,0 +1,262 @@
+/**
+ * Resolver — walks a block's attribute tree and normalises the box-
+ * shadow payload (#607).
+ *
+ * Mirrors PHP `BoxShadowResolver::resolve` exactly so the editor
+ * preview and server render produce byte-identical CSS:
+ *
+ * - Idle value lives at `style.shadow` (a structured subtree).
+ * - Per-state overrides ride `attributes.states['style.shadow']`
+ *   (canonical) or `['shadow']` (shorthand).
+ * - Per-breakpoint overrides ride `attributes.responsive['style.shadow']`.
+ *
+ * A `preset` slug short-circuits everything else — when set, the
+ * resolver returns a layer whose `preset` field carries the slug,
+ * and the emitter renders `box-shadow: var(--wp--preset--shadow--{slug})`.
+ *
+ * The `gradient` field accepts both slugs (expanded to
+ * `var(--wp--preset--gradient--{slug})`) and raw CSS gradient values.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.2.0
+ */
+
+import type {
+	BoxShadowAttributes,
+	ResolvedBoxShadow,
+	ResolvedShadowLayer,
+	ShadowSubtree,
+} from './types'
+
+const SLUG_RE      = /^[a-z0-9][a-z0-9_-]*$/i
+const SHADOW_PATHS = [ 'style.shadow', 'shadow' ]
+
+function expandGradient( value: unknown ): string | null {
+	if ( 'string' !== typeof value ) {
+		return null
+	}
+
+	const trimmed = value.trim()
+
+	if ( '' === trimmed ) {
+		return null
+	}
+
+	if ( SLUG_RE.test( trimmed ) ) {
+		return `var(--wp--preset--gradient--${ trimmed })`
+	}
+
+	return trimmed
+}
+
+function trimmedString( value: unknown ): string | null {
+	if ( 'string' !== typeof value ) {
+		return null
+	}
+
+	const trimmed = value.trim()
+
+	return '' === trimmed ? null : trimmed
+}
+
+function expandPreset( value: unknown ): string | null {
+	const slug = trimmedString( value )
+
+	if ( null === slug || ! SLUG_RE.test( slug ) ) {
+		return null
+	}
+
+	return slug
+}
+
+function resolveLayer( subtree: ShadowSubtree | null | undefined ): ResolvedShadowLayer | null {
+	if ( ! subtree || 'object' !== typeof subtree ) {
+		return null
+	}
+
+	const preset = expandPreset( subtree.preset )
+
+	// Defaults are `0px`, not `0`. Safari (and the CSS spec) require
+	// a unit inside `calc()` — `calc(-1 * 0)` is invalid because `0`
+	// is a `<number>`, not a `<length>`. The unitless form works in
+	// stock `box-shadow` declarations (the property accepts `0` as
+	// a length shorthand) but breaks the gradient pseudo's calc()
+	// sizing.
+	const offsetX  = trimmedString( subtree.offsetX ) ?? '0px'
+	const offsetY  = trimmedString( subtree.offsetY ) ?? '0px'
+	const blur     = trimmedString( subtree.blur ) ?? '0px'
+	const spread   = trimmedString( subtree.spread ) ?? '0px'
+	const color    = trimmedString( subtree.color )
+	const gradient = expandGradient( subtree.gradient )
+	const inset    = true === subtree.inset
+
+	// A layer is meaningful when it carries a preset OR any of the
+	// structured fields. Empty subtrees (all fields null) are dropped
+	// so callers can `null`-check the return value and skip emission.
+	const hasStructured =
+		null !== trimmedString( subtree.offsetX )
+		|| null !== trimmedString( subtree.offsetY )
+		|| null !== trimmedString( subtree.blur )
+		|| null !== trimmedString( subtree.spread )
+		|| null !== color
+		|| null !== gradient
+		|| true === subtree.inset
+
+	if ( null === preset && ! hasStructured ) {
+		return null
+	}
+
+	return {
+		offsetX,
+		offsetY,
+		blur,
+		spread,
+		color,
+		gradient,
+		inset,
+		preset,
+	}
+}
+
+function collectOverrides(
+	bag: Record<string, Record<string, ShadowSubtree | null>> | null | undefined,
+): Record<string, ResolvedShadowLayer> {
+	if ( ! bag || 'object' !== typeof bag ) {
+		return {}
+	}
+
+	const out: Record<string, ResolvedShadowLayer> = {}
+
+	// Iterate in reverse-precedence so the canonical path overwrites
+	// the shorthand; last-write-wins on assignment.
+	for ( const path of [ ...SHADOW_PATHS ].reverse() ) {
+		const overrides = bag[ path ]
+
+		if ( ! overrides || 'object' !== typeof overrides ) {
+			continue
+		}
+
+		for ( const key of Object.keys( overrides ) ) {
+			if ( '' === key ) {
+				continue
+			}
+
+			const layer = resolveLayer( overrides[ key ] )
+
+			if ( null === layer ) {
+				continue
+			}
+
+			out[ key ] = layer
+		}
+	}
+
+	return out
+}
+
+/**
+ * Resolve a block's attribute tree into the normalised payload the
+ * emitter consumes. Returns `null` when no shadow configuration
+ * exists at any cascade level — callers should skip emission entirely
+ * in that case.
+ */
+export function resolveBoxShadow(
+	attributes: BoxShadowAttributes | null | undefined,
+): ResolvedBoxShadow | null {
+	if ( ! attributes || 'object' !== typeof attributes ) {
+		return null
+	}
+
+	const shadow      = attributes.style?.shadow ?? null
+	const idle        = resolveLayer( shadow )
+	const states      = collectOverrides( attributes.states )
+	const breakpoints = collectOverrides( attributes.responsive )
+
+	if (
+		null === idle
+		&& 0 === Object.keys( states ).length
+		&& 0 === Object.keys( breakpoints ).length
+	) {
+		return null
+	}
+
+	return {
+		idle,
+		states,
+		breakpoints,
+	}
+}
+
+/**
+ * Pluck every shadow preset slug AND gradient slug referenced
+ * anywhere in a block's attribute tree (idle + per-state + per-
+ * breakpoint). Used by the editor's token-warning surface to flag
+ * references whose theme token was renamed or removed.
+ *
+ * Returns `{ shadows: string[], gradients: string[] }` so the
+ * inspector can compare each list against its respective theme
+ * settings bucket.
+ */
+export function referencedSlugs(
+	attributes: BoxShadowAttributes | null | undefined,
+): { shadows: string[]; gradients: string[] } {
+	if ( ! attributes || 'object' !== typeof attributes ) {
+		return { shadows: [], gradients: [] }
+	}
+
+	const shadows:   string[] = []
+	const gradients: string[] = []
+
+	collectSubtreeSlugs( shadows, gradients, attributes.style?.shadow )
+	collectSlugsFromBag( shadows, gradients, attributes.states )
+	collectSlugsFromBag( shadows, gradients, attributes.responsive )
+
+	return {
+		shadows:   Array.from( new Set( shadows ) ),
+		gradients: Array.from( new Set( gradients ) ),
+	}
+}
+
+function collectSubtreeSlugs(
+	shadows: string[],
+	gradients: string[],
+	subtree: ShadowSubtree | null | undefined,
+): void {
+	if ( ! subtree || 'object' !== typeof subtree ) {
+		return
+	}
+
+	const preset = expandPreset( subtree.preset )
+	if ( null !== preset ) {
+		shadows.push( preset )
+	}
+
+	if ( 'string' === typeof subtree.gradient ) {
+		const trimmed = subtree.gradient.trim()
+		if ( '' !== trimmed && SLUG_RE.test( trimmed ) ) {
+			gradients.push( trimmed )
+		}
+	}
+}
+
+function collectSlugsFromBag(
+	shadows: string[],
+	gradients: string[],
+	bag: Record<string, Record<string, ShadowSubtree | null>> | null | undefined,
+): void {
+	if ( ! bag || 'object' !== typeof bag ) {
+		return
+	}
+
+	for ( const path of SHADOW_PATHS ) {
+		const overrides = bag[ path ]
+
+		if ( ! overrides || 'object' !== typeof overrides ) {
+			continue
+		}
+
+		for ( const key of Object.keys( overrides ) ) {
+			collectSubtreeSlugs( shadows, gradients, overrides[ key ] )
+		}
+	}
+}

--- a/resources/js/visual-editor/box-shadows/types.ts
+++ b/resources/js/visual-editor/box-shadows/types.ts
@@ -1,0 +1,74 @@
+/**
+ * Shared types for the box-shadow feature (#607).
+ *
+ * Mirrors the PHP-side `BoxShadowResolver` + `BoxShadowEmitter`
+ * shapes so the editor's preview canvas stays in sync with the
+ * server-rendered front-end. Architecture deliberately parallels
+ * `gradient-borders/types.ts` from #490 — see that file's docblock
+ * for the cascade rationale.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.2.0
+ */
+
+/**
+ * Raw shadow subtree the inspector writes. Stored on
+ * `attributes.style.shadow` for the idle slot and as the value of
+ * each entry in `attributes.states['style.shadow']` /
+ * `attributes.responsive['style.shadow']` for the per-state /
+ * per-breakpoint overrides.
+ *
+ * A `preset` slug short-circuits the structured fields — when set,
+ * the renderer emits `box-shadow: var(--wp--preset--shadow--{slug})`
+ * directly and the offset/blur/spread/color/gradient fields are
+ * ignored.
+ */
+export interface ShadowSubtree {
+	offsetX?: string | null
+	offsetY?: string | null
+	blur?: string | null
+	spread?: string | null
+	color?: string | null
+	gradient?: string | null
+	inset?: boolean
+	preset?: string | null
+	[key: string]: unknown
+}
+
+/**
+ * A single fully-resolved shadow layer. The discriminating field is
+ * `gradient` — non-null indicates the gradient ::before/::after
+ * emission path, null indicates the stock `box-shadow` declaration
+ * path.
+ *
+ * Preset references collapse into the `preset` field; the emitter
+ * uses preset over everything else when set.
+ */
+export interface ResolvedShadowLayer {
+	offsetX: string
+	offsetY: string
+	blur: string
+	spread: string
+	color: string | null
+	gradient: string | null
+	inset: boolean
+	preset: string | null
+}
+
+export interface ResolvedBoxShadow {
+	idle: ResolvedShadowLayer | null
+	states: Record<string, ResolvedShadowLayer>
+	breakpoints: Record<string, ResolvedShadowLayer>
+}
+
+/**
+ * Block attribute tree as far as the resolver / warning surface is
+ * concerned. The block can carry any other attributes alongside; only
+ * the slots we read are typed.
+ */
+export interface BoxShadowAttributes {
+	style?: { shadow?: ShadowSubtree } | null
+	states?: Record<string, Record<string, ShadowSubtree | null>> | null
+	responsive?: Record<string, Record<string, ShadowSubtree | null>> | null
+	[key: string]: unknown
+}

--- a/resources/js/visual-editor/box-shadows/with-box-shadow-control.tsx
+++ b/resources/js/visual-editor/box-shadows/with-box-shadow-control.tsx
@@ -1,0 +1,512 @@
+/**
+ * `editor.BlockEdit` HOC — inject the Shadow tools panel into the
+ * inspector for every block with border support (#607).
+ *
+ * Per #607, the panel lives in its own `InspectorControls` group
+ * ("styles" — alongside the native color/typography panels) rather
+ * than piggybacking on the Border tools panel. This leaves room for
+ * a future Effects suite (filters, backdrop-filter) under the same
+ * roof.
+ *
+ * Writes go to `attributes.style.shadow.{offsetX,offsetY,blur,spread,
+ * color,gradient,inset,preset}`. State + breakpoint composition is
+ * handled by the standard routing HOCs once `style.shadow` is in
+ * `artisanpackStates.attributes` / `artisanpackResponsive.attributes`
+ * (see `extend-supports.ts`).
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.2.0
+ */
+
+import {
+	BaseControl,
+	Button,
+	ColorIndicator,
+	Dropdown,
+	ToggleControl,
+	__experimentalUnitControl as UnitControl,
+	__experimentalToolsPanel as ToolsPanel,
+	__experimentalToolsPanelItem as ToolsPanelItem,
+	Notice,
+} from '@wordpress/components'
+import { createHigherOrderComponent } from '@wordpress/compose'
+import { getBlockType } from '@wordpress/blocks'
+import {
+	InspectorControls,
+	// eslint-disable-next-line camelcase
+	__experimentalColorGradientControl as ColorGradientControl,
+} from '@wordpress/block-editor'
+import { useSelect } from '@wordpress/data'
+import { addFilter } from '@wordpress/hooks'
+import { __, sprintf } from '@wordpress/i18n'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
+import type { ComponentType } from 'react'
+
+import { referencedSlugs } from './resolver'
+import type { BoxShadowAttributes, ShadowSubtree } from './types'
+
+const FILTER_HOOK      = 'editor.BlockEdit'
+const FILTER_NAMESPACE = 'artisanpack-ui/visual-editor/box-shadow-control'
+
+const REGISTERED_KEY = Symbol.for(
+	'artisanpack-ui.visual-editor.box-shadow-control.registered',
+)
+
+interface GlobalSentinelHost {
+	[REGISTERED_KEY]?: boolean
+}
+
+interface BlockEditProps {
+	name: string
+	clientId?: string
+	attributes: BoxShadowAttributes & Record<string, unknown>
+	setAttributes: ( updates: Record<string, unknown> ) => void
+	[key: string]: unknown
+}
+
+interface ThemeShadowEntry {
+	slug?: string
+	name?: string
+	shadow?: string
+}
+
+interface ThemeGradientEntry {
+	slug?: string
+	name?: string
+	gradient?: string
+}
+
+interface BlockEditorSettings {
+	gradients?: ThemeGradientEntry[]
+	colors?: unknown[]
+	[key: string]: unknown
+}
+
+function blockSupportsBoxShadow( name: string ): boolean {
+	const blockType = getBlockType( name )
+
+	if ( ! blockType ) {
+		return false
+	}
+
+	const supports = blockType.supports as Record<string, unknown> | undefined
+	const support  = supports?.[ '__experimentalBorder' ] ?? supports?.[ 'border' ]
+
+	return Boolean( support && 'object' === typeof support )
+}
+
+function readShadow( attributes: BoxShadowAttributes ): ShadowSubtree {
+	const shadow = attributes.style?.shadow ?? null
+	return shadow && 'object' === typeof shadow ? shadow : {}
+}
+
+interface ShadowPatch {
+	offsetX?: string | null
+	offsetY?: string | null
+	blur?: string | null
+	spread?: string | null
+	color?: string | null
+	gradient?: string | null
+	inset?: boolean
+	preset?: string | null
+}
+
+function applyPatchToShadow(
+	shadow: Record<string, unknown>,
+	patch: ShadowPatch,
+): Record<string, unknown> {
+	const next: Record<string, unknown> = { ...shadow }
+
+	for ( const key of Object.keys( patch ) as Array<keyof ShadowPatch> ) {
+		const value = patch[ key ]
+
+		if ( null === value || '' === value || undefined === value ) {
+			delete next[ key ]
+			continue
+		}
+
+		next[ key ] = value
+	}
+
+	return next
+}
+
+function MissingTokenWarning(
+	{ missing, kind }: { missing: string[]; kind: 'shadow' | 'gradient' },
+): JSX.Element | null {
+	if ( 0 === missing.length ) {
+		return null
+	}
+
+	const message = 'shadow' === kind
+		? sprintf(
+			/* translators: %s: comma-separated list of slugs. */
+			__( 'Shadow preset(s) no longer available: %s. The affected breakpoint or state will fall back to the idle layer until restored.', 'artisanpack-visual-editor' ),
+			missing.join( ', ' ),
+		)
+		: sprintf(
+			/* translators: %s: comma-separated list of slugs. */
+			__( 'Gradient token(s) no longer available: %s. The affected shadow fill will render as transparent until restored.', 'artisanpack-visual-editor' ),
+			missing.join( ', ' ),
+		)
+
+	return (
+		<Notice
+			status="warning"
+			isDismissible={ false }
+			className="ap-box-shadow__missing-token-notice"
+		>
+			{ message }
+		</Notice>
+	)
+}
+
+export const withBoxShadowControl = createHigherOrderComponent(
+	( BlockEdit: ComponentType<BlockEditProps> ) => {
+		function BoxShadowBlockEdit( props: BlockEditProps ): JSX.Element {
+			const { name, attributes, setAttributes, clientId } = props
+
+			const enabled = useMemo(
+				() => blockSupportsBoxShadow( name ),
+				[ name ],
+			)
+
+			const { themeShadows, themeGradients, themeColors } = useSelect(
+				( select ) => {
+					const settings = (
+						select( 'core/block-editor' ) as {
+							getSettings: () => BlockEditorSettings & {
+								shadow?: { presets?: ThemeShadowEntry[] }
+							}
+						}
+					 ).getSettings()
+
+					const shadowPresets = Array.isArray( settings?.shadow?.presets )
+						? settings.shadow!.presets!
+						: []
+
+					return {
+						themeShadows:   shadowPresets,
+						themeGradients: Array.isArray( settings?.gradients ) ? settings.gradients : [],
+						themeColors:    Array.isArray( settings?.colors ) ? settings.colors : [],
+					}
+				},
+				[],
+			)
+
+			const { missingShadows, missingGradients } = useMemo( () => {
+				if ( ! enabled ) {
+					return { missingShadows: [] as string[], missingGradients: [] as string[] }
+				}
+
+				const referenced = referencedSlugs( attributes )
+
+				const knownShadows = new Set(
+					themeShadows
+						.map( ( entry ) => ( 'string' === typeof entry?.slug ? entry.slug : null ) )
+						.filter( ( slug ): slug is string => null !== slug && '' !== slug ),
+				)
+
+				const knownGradients = new Set(
+					themeGradients
+						.map( ( entry ) => ( 'string' === typeof entry?.slug ? entry.slug : null ) )
+						.filter( ( slug ): slug is string => null !== slug && '' !== slug ),
+				)
+
+				return {
+					missingShadows:   referenced.shadows.filter( ( slug ) => ! knownShadows.has( slug ) ),
+					missingGradients: referenced.gradients.filter( ( slug ) => ! knownGradients.has( slug ) ),
+				}
+			}, [ enabled, attributes, themeShadows, themeGradients ] )
+
+			// Ref-backed writer — survives the back-to-back
+			// `onColorChange` + `onGradientChange` calls that
+			// `__experimentalColorGradientControl` fires synchronously
+			// when the user picks a value. Without the refs both calls
+			// read `attributes.style` from the React closure (same stale
+			// snapshot) and the second `setAttributes` overwrites the
+			// first. Mirrors `useBorderWriter` in gradient-borders/
+			// with-gradient-border-control.tsx.
+			const styleRef  = useRef< Record<string, unknown> >(
+				( attributes.style as Record<string, unknown> | undefined ) ?? {},
+			)
+			const shadowRef = useRef< Record<string, unknown> >(
+				( attributes.style?.shadow as Record<string, unknown> | undefined ) ?? {},
+			)
+
+			useEffect( () => {
+				styleRef.current  = ( attributes.style as Record<string, unknown> | undefined ) ?? {}
+				shadowRef.current = ( attributes.style?.shadow as Record<string, unknown> | undefined ) ?? {}
+			}, [ attributes.style, attributes.style?.shadow ] )
+
+			const writeShadow = useCallback(
+				( patch: ShadowPatch ) => {
+					const nextShadow = applyPatchToShadow( shadowRef.current, patch )
+					shadowRef.current = nextShadow
+
+					const nextStyle: Record<string, unknown> = Object.keys( nextShadow ).length > 0
+						? { ...styleRef.current, shadow: nextShadow }
+						: ( () => {
+							const { shadow: _drop, ...rest } = styleRef.current
+							return rest
+						} )()
+
+					styleRef.current = nextStyle
+
+					setAttributes( { style: nextStyle } )
+				},
+				[ setAttributes ],
+			)
+
+			if ( ! enabled ) {
+				return <BlockEdit { ...props } />
+			}
+
+			const shadow = readShadow( attributes )
+
+			const offsetX = 'string' === typeof shadow.offsetX ? shadow.offsetX : ''
+			const offsetY = 'string' === typeof shadow.offsetY ? shadow.offsetY : ''
+			const blur    = 'string' === typeof shadow.blur ? shadow.blur : ''
+			const spread  = 'string' === typeof shadow.spread ? shadow.spread : ''
+			const color   = 'string' === typeof shadow.color ? shadow.color : undefined
+			const grad    = 'string' === typeof shadow.gradient ? shadow.gradient : undefined
+			const inset   = true === shadow.inset
+			const preset  = 'string' === typeof shadow.preset ? shadow.preset : null
+
+			const hasAnyValue =
+				'' !== offsetX
+				|| '' !== offsetY
+				|| '' !== blur
+				|| '' !== spread
+				|| undefined !== color
+				|| undefined !== grad
+				|| inset
+				|| null !== preset
+
+			return (
+				<>
+					<BlockEdit { ...props } />
+					<InspectorControls group="styles">
+						<ToolsPanel
+							label={ __( 'Shadow', 'artisanpack-visual-editor' ) }
+							resetAll={ () => writeShadow( {
+								offsetX:  null,
+								offsetY:  null,
+								blur:     null,
+								spread:   null,
+								color:    null,
+								gradient: null,
+								inset:    false,
+								preset:   null,
+							} ) }
+							panelId={ clientId }
+						>
+							<ToolsPanelItem
+								panelId={ clientId }
+								hasValue={ () => hasAnyValue }
+								label={ __( 'Shadow', 'artisanpack-visual-editor' ) }
+								onDeselect={ () => writeShadow( {
+									offsetX:  null,
+									offsetY:  null,
+									blur:     null,
+									spread:   null,
+									color:    null,
+									gradient: null,
+									inset:    false,
+									preset:   null,
+								} ) }
+								isShownByDefault
+							>
+								<BaseControl __nextHasNoMarginBottom>
+									<MissingTokenWarning missing={ missingShadows } kind="shadow" />
+									<MissingTokenWarning missing={ missingGradients } kind="gradient" />
+
+									{ themeShadows.length > 0 && (
+										<div className="ap-box-shadow__preset-row" style={ { marginBottom: 12 } }>
+											<BaseControl.VisualLabel>
+												{ __( 'Presets', 'artisanpack-visual-editor' ) }
+											</BaseControl.VisualLabel>
+											<div style={ { display: 'flex', gap: 4, flexWrap: 'wrap' } }>
+												{ themeShadows.map( ( entry ) => {
+													const slug = 'string' === typeof entry?.slug ? entry.slug : ''
+													if ( '' === slug ) {
+														return null
+													}
+													const isActive = slug === preset
+													return (
+														<button
+															key={ slug }
+															type="button"
+															aria-pressed={ isActive }
+															className="ap-box-shadow__preset-chip"
+															onClick={ () =>
+																writeShadow( { preset: isActive ? null : slug } )
+															}
+															style={ {
+																padding: '4px 8px',
+																fontSize: 12,
+																border: isActive ? '2px solid var(--wp-admin-theme-color, #007cba)' : '1px solid #ddd',
+																borderRadius: 4,
+																background: '#fff',
+																cursor: 'pointer',
+															} }
+														>
+															{ entry?.name ?? slug }
+														</button>
+													)
+												} ) }
+											</div>
+										</div>
+									) }
+
+									<div style={ { display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8 } }>
+										<UnitControl
+											label={ __( 'X offset', 'artisanpack-visual-editor' ) }
+											value={ offsetX }
+											onChange={ ( next: string | undefined ) =>
+												writeShadow( { offsetX: next ?? null } )
+											}
+											__next40pxDefaultSize
+										/>
+										<UnitControl
+											label={ __( 'Y offset', 'artisanpack-visual-editor' ) }
+											value={ offsetY }
+											onChange={ ( next: string | undefined ) =>
+												writeShadow( { offsetY: next ?? null } )
+											}
+											__next40pxDefaultSize
+										/>
+										<UnitControl
+											label={ __( 'Blur', 'artisanpack-visual-editor' ) }
+											value={ blur }
+											onChange={ ( next: string | undefined ) =>
+												writeShadow( { blur: next ?? null } )
+											}
+											__next40pxDefaultSize
+										/>
+										<UnitControl
+											label={ __( 'Spread', 'artisanpack-visual-editor' ) }
+											value={ spread }
+											onChange={ ( next: string | undefined ) =>
+												writeShadow( { spread: next ?? null } )
+											}
+											__next40pxDefaultSize
+										/>
+									</div>
+
+									<div style={ { marginTop: 12 } }>
+										<BaseControl.VisualLabel>
+											{ __( 'Color', 'artisanpack-visual-editor' ) }
+										</BaseControl.VisualLabel>
+										<Dropdown
+											contentClassName="ap-box-shadow__color-popover"
+											popoverProps={ { placement: 'left-start', offset: 36 } }
+											renderToggle={ ( { onToggle, isOpen }: {
+												onToggle: () => void
+												isOpen:   boolean
+											} ) => (
+												<Button
+													onClick={ onToggle }
+													aria-expanded={ isOpen }
+													aria-haspopup="dialog"
+													aria-label={ __(
+														'Shadow color and gradient picker',
+														'artisanpack-visual-editor',
+													) }
+													className="ap-box-shadow__color-toggle"
+													style={ { display: 'flex', alignItems: 'center', gap: 8 } }
+												>
+													<ColorIndicator colorValue={ grad ?? color ?? undefined } />
+													<span>
+														{ grad
+															? __( 'Gradient', 'artisanpack-visual-editor' )
+															: ( color
+																? __( 'Color', 'artisanpack-visual-editor' )
+																: __( 'Select color', 'artisanpack-visual-editor' ) ) }
+													</span>
+												</Button>
+											) }
+											renderContent={ () => (
+												<div className="ap-box-shadow__color-popover-content" style={ { minWidth: 260 } }>
+													<ColorGradientControl
+														label={ __( 'Shadow', 'artisanpack-visual-editor' ) }
+														showTitle={ false }
+														colorValue={ color }
+														gradientValue={ grad }
+														// IMPORTANT: only the field the picker
+														// reports a change on is written. We do NOT
+														// proactively clear the other field here —
+														// `__experimentalColorGradientControl` fires
+														// BOTH callbacks synchronously on every pick
+														// (one with the value, one with undefined),
+														// so any "clear the sibling" logic in either
+														// handler races and ends up nuking the value
+														// we just wrote. The ref-backed writer above
+														// keeps them in sync; the mutex below clears
+														// the OTHER field only when this one is set
+														// to a non-empty value, never when it's being
+														// cleared.
+														onColorChange={ ( next: string | undefined ) => {
+															if ( undefined !== next && '' !== next ) {
+																writeShadow( { color: next, gradient: null } )
+															} else {
+																writeShadow( { color: null } )
+															}
+														} }
+														onGradientChange={ ( next: string | undefined ) => {
+															if ( undefined !== next && '' !== next ) {
+																writeShadow( { gradient: next, color: null } )
+															} else {
+																writeShadow( { gradient: null } )
+															}
+														} }
+														colors={ themeColors as never }
+														gradients={ themeGradients as never }
+														disableCustomColors={ false }
+														disableCustomGradients={ false }
+														enableAlpha
+														__experimentalIsRenderedInSidebar
+													/>
+												</div>
+											) }
+										/>
+									</div>
+
+									<div style={ { marginTop: 12 } }>
+										<ToggleControl
+											label={ __( 'Inset', 'artisanpack-visual-editor' ) }
+											checked={ inset }
+											onChange={ ( next: boolean ) => writeShadow( { inset: next } ) }
+											__nextHasNoMarginBottom
+										/>
+									</div>
+								</BaseControl>
+							</ToolsPanelItem>
+						</ToolsPanel>
+					</InspectorControls>
+				</>
+			)
+		}
+
+		BoxShadowBlockEdit.displayName = 'BoxShadowBlockEdit'
+
+		return BoxShadowBlockEdit
+	},
+	'withBoxShadowControl',
+)
+
+/**
+ * Register the BlockEdit filter at most once per page. Idempotent —
+ * safe to call from both the post-editor and site-editor bootstrap
+ * paths.
+ */
+export function registerBoxShadowControl(): void {
+	const host = globalThis as unknown as GlobalSentinelHost
+
+	if ( host[ REGISTERED_KEY ] ) {
+		return
+	}
+
+	addFilter( FILTER_HOOK, FILTER_NAMESPACE, withBoxShadowControl )
+	host[ REGISTERED_KEY ] = true
+}

--- a/resources/js/visual-editor/box-shadows/with-box-shadow-styles.tsx
+++ b/resources/js/visual-editor/box-shadows/with-box-shadow-styles.tsx
@@ -1,0 +1,374 @@
+/**
+ * Box-shadow CSS emission for the editor canvas + saved markup (#607).
+ *
+ * Mirrors `with-gradient-border-styles.tsx` (#490) one-to-one — see
+ * that file's docblock for the three-filter lifecycle (canvas style,
+ * save props, save element wrap) and the `_…ScopeId` rationale.
+ *
+ * The shadow scope id is persisted on
+ * `attributes.style.shadow._shadowScopeId` (matching the gradient-
+ * border `_gradientScopeId` pattern). The scope class is
+ * `ve-bs-<id>`.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.2.0
+ */
+
+import { getBlockType } from '@wordpress/blocks'
+import { createHigherOrderComponent } from '@wordpress/compose'
+import { addFilter } from '@wordpress/hooks'
+import { Fragment, createElement, useEffect, useMemo, useRef } from 'react'
+import type { ComponentType, ReactNode } from 'react'
+
+import { TAILWIND_V4_DEFAULTS, BreakpointRegistry } from '../responsive/registry'
+import { DEFAULT_STATES, StateRegistry } from '../states/registry'
+import { emitBoxShadowCss } from './emitter'
+import { resolveBoxShadow } from './resolver'
+import type { BoxShadowAttributes, ShadowSubtree } from './types'
+
+const BLOCK_FILTER_HOOK = 'editor.BlockListBlock'
+const SAVE_PROPS_HOOK   = 'blocks.getSaveContent.extraProps'
+const SAVE_ELEMENT_HOOK = 'blocks.getSaveElement'
+
+const FILTER_NAMESPACE = 'artisanpack-ui/visual-editor/box-shadow-styles'
+
+const REGISTERED_KEY = Symbol.for(
+	'artisanpack-ui.visual-editor.box-shadow-styles.registered',
+)
+
+interface GlobalSentinelHost {
+	[REGISTERED_KEY]?: boolean
+}
+
+interface BlockListBlockProps {
+	name: string
+	clientId: string
+	attributes: BoxShadowAttributes & Record<string, unknown>
+	setAttributes?: ( updates: Record<string, unknown> ) => void
+	wrapperProps?: Record<string, unknown>
+	[key: string]: unknown
+}
+
+interface BlockSettingsLike {
+	supports?: Record<string, unknown>
+	[key: string]: unknown
+}
+
+interface ShadowSubtreeWithScope extends ShadowSubtree {
+	_shadowScopeId?: string
+}
+
+const SCOPE_ID_KEY     = '_shadowScopeId'
+const SCOPE_ID_PATTERN = /^[a-z0-9][a-z0-9_-]{0,63}$/i
+
+const states      = new StateRegistry( DEFAULT_STATES )
+const breakpoints = new BreakpointRegistry( TAILWIND_V4_DEFAULTS )
+
+function blockSupportsBoxShadow( name: string ): boolean {
+	const blockType = getBlockType( name )
+	if ( ! blockType ) {
+		return false
+	}
+
+	const supports = blockType.supports as Record<string, unknown> | undefined
+	const support  = supports?.[ '__experimentalBorder' ] ?? supports?.[ 'border' ]
+
+	return Boolean( support && 'object' === typeof support )
+}
+
+function scopeIdToClass( scopeId: string ): string {
+	return `ve-bs-${ scopeId }`
+}
+
+function readScopeId(
+	attributes: BoxShadowAttributes | undefined,
+): string | null {
+	const shadow = attributes?.style?.shadow as ShadowSubtreeWithScope | undefined | null
+	const raw    = shadow?.[ SCOPE_ID_KEY ]
+
+	if ( 'string' !== typeof raw ) {
+		return null
+	}
+
+	const trimmed = raw.trim()
+	return SCOPE_ID_PATTERN.test( trimmed ) ? trimmed : null
+}
+
+function hasAuthoredAnyShadow(
+	attributes: BoxShadowAttributes | undefined,
+): boolean {
+	return null !== resolveBoxShadow( attributes )
+}
+
+function mintScopeId(): string {
+	return Math.random().toString( 36 ).slice( 2, 11 )
+}
+
+const scopeIdOwners = new Map<string, string>()
+
+function claimScopeId( scopeId: string, clientId: string ): boolean {
+	const owner = scopeIdOwners.get( scopeId )
+	if ( ! owner ) {
+		scopeIdOwners.set( scopeId, clientId )
+		return true
+	}
+
+	return owner === clientId
+}
+
+function releaseScopeId( scopeId: string, clientId: string ): void {
+	if ( scopeIdOwners.get( scopeId ) === clientId ) {
+		scopeIdOwners.delete( scopeId )
+	}
+}
+
+function writeScopeId(
+	attributes: BoxShadowAttributes,
+	setAttributes: ( updates: Record<string, unknown> ) => void,
+	nextId: string,
+): void {
+	const style = ( attributes.style && 'object' === typeof attributes.style )
+		? ( attributes.style as Record<string, unknown> )
+		: {}
+	const shadow = ( style.shadow && 'object' === typeof style.shadow )
+		? ( style.shadow as Record<string, unknown> )
+		: {}
+
+	setAttributes( {
+		style: {
+			...style,
+			shadow: {
+				...shadow,
+				[ SCOPE_ID_KEY ]: nextId,
+			},
+		},
+	} )
+}
+
+export const withBoxShadowStyles = createHigherOrderComponent(
+	( BlockListBlock: ComponentType<BlockListBlockProps> ) => {
+		function BoxShadowStyledBlock( props: BlockListBlockProps ): JSX.Element {
+			const { name, clientId, attributes, setAttributes, wrapperProps } = props
+
+			const supported = blockSupportsBoxShadow( name )
+
+			const scopeId = useMemo(
+				() => readScopeId( attributes ),
+				[ attributes ],
+			)
+
+			const hasOverrides = useMemo(
+				() => hasAuthoredAnyShadow( attributes ),
+				[ attributes ],
+			)
+
+			const persistedRef = useRef( scopeId )
+			useEffect( () => {
+				persistedRef.current = scopeId
+			}, [ scopeId ] )
+
+			useEffect( () => {
+				if ( ! supported || ! setAttributes ) {
+					return
+				}
+
+				const needsMint    = ! scopeId && hasOverrides
+				const hasCollision = scopeId !== null && ! claimScopeId( scopeId, clientId )
+
+				if ( ! needsMint && ! hasCollision ) {
+					return
+				}
+
+				const nextId = mintScopeId()
+				claimScopeId( nextId, clientId )
+				writeScopeId( attributes, setAttributes, nextId )
+			}, [ supported, scopeId, hasOverrides, attributes, setAttributes, clientId ] )
+
+			useEffect( () => {
+				if ( ! scopeId ) {
+					return
+				}
+
+				return () => releaseScopeId( scopeId, clientId )
+			}, [ scopeId, clientId ] )
+
+			const effectiveScopeId = scopeId ?? persistedRef.current
+
+			const css = useMemo( () => {
+				if ( ! supported || ! effectiveScopeId ) {
+					return ''
+				}
+
+				const payload = resolveBoxShadow( attributes )
+				if ( ! payload ) {
+					return ''
+				}
+
+				return emitBoxShadowCss(
+					`.${ scopeIdToClass( effectiveScopeId ) }`,
+					payload,
+					states,
+					breakpoints,
+				)
+			}, [ supported, effectiveScopeId, attributes ] )
+
+			const effectiveWrapperProps: Record<string, unknown> = useMemo( () => {
+				if ( ! supported || ! effectiveScopeId ) {
+					return wrapperProps ?? {}
+				}
+
+				const existingClass = ( wrapperProps?.className as string | undefined ) ?? ''
+				const scopeClass    = scopeIdToClass( effectiveScopeId )
+
+				if ( existingClass.split( ' ' ).includes( scopeClass ) ) {
+					return wrapperProps ?? {}
+				}
+
+				return {
+					...( wrapperProps ?? {} ),
+					className: existingClass ? `${ existingClass } ${ scopeClass }` : scopeClass,
+				}
+			}, [ supported, wrapperProps, effectiveScopeId ] )
+
+			if ( ! supported ) {
+				return <BlockListBlock { ...props } />
+			}
+
+			const wrapped = (
+				<BlockListBlock
+					{ ...props }
+					wrapperProps={ effectiveWrapperProps }
+				/>
+			)
+
+			if ( '' === css ) {
+				return wrapped
+			}
+
+			return (
+				<Fragment>
+					<style data-ap-box-shadow-scope={ effectiveScopeId }>{ css }</style>
+					{ wrapped }
+				</Fragment>
+			)
+		}
+
+		BoxShadowStyledBlock.displayName = 'BoxShadowStyledBlock'
+
+		return BoxShadowStyledBlock
+	},
+	'withBoxShadowStyles',
+)
+
+function blockSupportsConfigOnSettings(
+	blockType: BlockSettingsLike | undefined,
+): boolean {
+	const supports = blockType?.supports as Record<string, unknown> | undefined
+	const border   = ( supports?.[ '__experimentalBorder' ] ?? supports?.[ 'border' ] ) as
+		| Record<string, unknown>
+		| undefined
+
+	return Boolean( border && 'object' === typeof border )
+}
+
+function addSaveProps(
+	extraProps: Record<string, unknown>,
+	blockType: BlockSettingsLike,
+	attributes: BoxShadowAttributes & Record<string, unknown>,
+): Record<string, unknown> {
+	if ( ! blockSupportsConfigOnSettings( blockType ) ) {
+		return extraProps
+	}
+
+	const scopeId = readScopeId( attributes )
+	if ( ! scopeId || ! hasAuthoredAnyShadow( attributes ) ) {
+		return extraProps
+	}
+
+	// Mirror `wrapSaveElement`'s emit-and-check below: don't stamp
+	// the scope class onto saved markup unless the emitter actually
+	// has rules to ship under that scope. Prevents an orphan class
+	// landing on the wrapper when a resolved layer simplifies to an
+	// empty rule (e.g. preset slug that fails sanitization).
+	const payload = resolveBoxShadow( attributes )
+	if ( ! payload ) {
+		return extraProps
+	}
+
+	const css = emitBoxShadowCss(
+		`.${ scopeIdToClass( scopeId ) }`,
+		payload,
+		states,
+		breakpoints,
+	)
+	if ( '' === css ) {
+		return extraProps
+	}
+
+	const existingClass = ( extraProps.className as string | undefined ) ?? ''
+	const scopeClass    = scopeIdToClass( scopeId )
+
+	if ( existingClass.split( ' ' ).includes( scopeClass ) ) {
+		return extraProps
+	}
+
+	return {
+		...extraProps,
+		className: existingClass ? `${ existingClass } ${ scopeClass }` : scopeClass,
+	}
+}
+
+function wrapSaveElement(
+	element: unknown,
+	blockType: BlockSettingsLike,
+	attributes: BoxShadowAttributes & Record<string, unknown>,
+): unknown {
+	if ( ! blockSupportsConfigOnSettings( blockType ) ) {
+		return element
+	}
+
+	const scopeId = readScopeId( attributes )
+	if ( ! scopeId ) {
+		return element
+	}
+
+	const payload = resolveBoxShadow( attributes )
+	if ( ! payload ) {
+		return element
+	}
+
+	const css = emitBoxShadowCss(
+		`.${ scopeIdToClass( scopeId ) }`,
+		payload,
+		states,
+		breakpoints,
+	)
+
+	if ( '' === css ) {
+		return element
+	}
+
+	return createElement(
+		Fragment,
+		null,
+		element as ReactNode,
+		createElement( 'style', { 'data-ap-box-shadow-scope': scopeId }, css ),
+	)
+}
+
+/**
+ * Idempotent — safe to call from both the post-editor and site-editor
+ * bootstrap paths.
+ */
+export function registerBoxShadowStylesFilters(): void {
+	const host = globalThis as unknown as GlobalSentinelHost
+
+	if ( host[ REGISTERED_KEY ] ) {
+		return
+	}
+
+	addFilter( BLOCK_FILTER_HOOK, FILTER_NAMESPACE, withBoxShadowStyles )
+	addFilter( SAVE_PROPS_HOOK, FILTER_NAMESPACE, addSaveProps )
+	addFilter( SAVE_ELEMENT_HOOK, FILTER_NAMESPACE, wrapSaveElement )
+	host[ REGISTERED_KEY ] = true
+}

--- a/resources/js/visual-editor/editor/editor-app.tsx
+++ b/resources/js/visual-editor/editor/editor-app.tsx
@@ -44,6 +44,7 @@ import { registerResponsiveAttribute } from '../responsive/register-attribute';
 import { registerResponsiveAttributesFilter } from '../responsive/with-responsive-attributes';
 import { registerStateAttribute } from '../states/register-attribute';
 import { registerStateAttributesFilter } from '../states/with-state-attributes';
+import { registerBoxShadows } from '../box-shadows/register';
 import { registerGradientBorders } from '../gradient-borders/register';
 import { registerStateStylesFilters } from '../states/with-state-styles';
 import { registerAnimationsAttribute } from '../animations/register-attribute';
@@ -205,6 +206,7 @@ function registerOnce(): void {
     // automatically) and the BlockEdit HOC wraps every edit component
     // on first render.
     registerGradientBorders();
+    registerBoxShadows();
     // I7 (#415): register all artisanpack/* blocks and set the default
     // block to artisanpack/paragraph. Core blocks are no longer loaded.
     registerArtisanPackBlocks();

--- a/resources/js/visual-editor/site-editor/__tests__/site-editor-app.test.tsx
+++ b/resources/js/visual-editor/site-editor/__tests__/site-editor-app.test.tsx
@@ -201,6 +201,11 @@ vi.mock('../../gradient-borders/register', () => ({
     registerGradientBorders: (): void => undefined,
 }));
 
+// #607: same JSON-import-attribute trip for the box-shadow registrar.
+vi.mock('../../box-shadows/register', () => ({
+    registerBoxShadows: (): void => undefined,
+}));
+
 import { SiteEditorApp } from '../site-editor-app';
 
 const ROUTE_BASE = '/visual-editor/site';

--- a/resources/js/visual-editor/site-editor/site-editor-app.tsx
+++ b/resources/js/visual-editor/site-editor/site-editor-app.tsx
@@ -46,6 +46,7 @@ import {
 import { usePersistedToggle } from './use-persisted-toggle';
 import { useSiteEditorRouting } from './use-site-editor-routing';
 import { registerArtisanPackBlocks } from '../blocks';
+import { registerBoxShadows } from '../box-shadows/register';
 import { registerGradientBorders } from '../gradient-borders/register';
 
 import { BlockLibrarySidebar } from '../editor/block-library-sidebar';
@@ -164,6 +165,7 @@ function ensureEditorBoot(): void {
     // registerArtisanPackBlocks" placement as the post-editor so opted-in
     // blocks pick up the routed `border.gradient` path at registration.
     registerGradientBorders();
+    registerBoxShadows();
 
     // I7 (#415): register all artisanpack/* blocks and set the default
     // block to artisanpack/paragraph. Core blocks are no longer loaded.

--- a/resources/theme-json/default-base.php
+++ b/resources/theme-json/default-base.php
@@ -57,6 +57,19 @@ return [
 			'contentSize' => '720px',
 			'wideSize'    => '1120px',
 		],
+		// #607 — Box shadow presets. Themes can extend, override, or
+		// clear this list; the box-shadow inspector surfaces every entry
+		// as a preset chip and the resolver expands `style.shadow.preset`
+		// slug references to `var(--wp--preset--shadow--{slug})` at
+		// render time.
+		'shadow'     => [
+			'presets' => [
+				[ 'slug' => 'shadow-sm', 'name' => 'Small', 'shadow' => '0 1px 2px 0 rgba(0,0,0,0.05)' ],
+				[ 'slug' => 'shadow-md', 'name' => 'Medium', 'shadow' => '0 4px 6px -1px rgba(0,0,0,0.1), 0 2px 4px -2px rgba(0,0,0,0.1)' ],
+				[ 'slug' => 'shadow-lg', 'name' => 'Large', 'shadow' => '0 10px 15px -3px rgba(0,0,0,0.1), 0 4px 6px -4px rgba(0,0,0,0.1)' ],
+				[ 'slug' => 'shadow-elevated', 'name' => 'Elevated', 'shadow' => '0 25px 50px -12px rgba(0,0,0,0.25)' ],
+			],
+		],
 		// #595 — flex layout panel defaults. Themes can disable the
 		// panel entirely by setting `enable` to false (already-saved
 		// content keeps rendering through the wrapper classes).

--- a/src/BoxShadow/BoxShadowEmitter.php
+++ b/src/BoxShadow/BoxShadowEmitter.php
@@ -1,0 +1,491 @@
+<?php
+
+/**
+ * Box shadow CSS emitter (#607).
+ *
+ * Turns a block's box-shadow attribute payload into the scoped CSS
+ * the renderer ships with the published page. Three emission modes,
+ * dispatched per resolved layer:
+ *
+ *   1. **Preset** (`layer.preset` set) — `box-shadow: var(--wp--preset--shadow--{slug})`.
+ *      Inset is honored via `var(...) inset` (themes ship the value
+ *      WITHOUT the `inset` keyword).
+ *
+ *   2. **Solid** (`layer.gradient` null) — stock `box-shadow:
+ *      [inset] X Y blur spread color`. Color defaults to `currentColor`.
+ *
+ *   3. **Gradient** (`layer.gradient` set) — `::before` (outer) or
+ *      `::after` (inset) pseudo-element with `background: <gradient>`,
+ *      `filter: blur(<blur>)`, `transform: translate(<X>, <Y>)`, and
+ *      for inset, a `mask-composite: exclude` ring mask to clip the
+ *      fill to the inside of the wrapper.
+ *
+ * Architecture deliberately parallels {@see GradientBorderEmitter}.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.2.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\BoxShadow;
+
+use ArtisanPackUI\VisualEditor\Responsive\BreakpointRegistry;
+use ArtisanPackUI\VisualEditor\States\StateRegistry;
+
+class BoxShadowEmitter
+{
+	/**
+	 * Default transition emitted on the wrapper when any non-idle
+	 * state or breakpoint defines a shadow override.
+	 */
+	public const DEFAULT_TRANSITION = 'box-shadow 200ms ease, background 200ms ease, opacity 200ms ease, transform 200ms ease';
+
+	public function __construct(
+		protected StateRegistry $states,
+		protected BreakpointRegistry $breakpoints,
+	) {}
+
+	/**
+	 * Emit the scoped CSS for a single block's box-shadow payload.
+	 *
+	 * Returns an empty string when there's no idle layer and no
+	 * non-idle overrides.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @param  string  $scope    CSS scope selector, including leading
+	 *                           `.` (e.g. `.ve-bs-abc123`).
+	 * @param  array{
+	 *     idle?: array<string, mixed>|null,
+	 *     states?: array<string, array<string, mixed>>,
+	 *     breakpoints?: array<string, array<string, mixed>>,
+	 * }       $payload
+	 */
+	public function emit( string $scope, array $payload ): string
+	{
+		$scope = trim( $scope );
+
+		if ( '' === $scope ) {
+			return '';
+		}
+
+		$idle        = $this->normalizeLayer( $payload['idle'] ?? null );
+		$states      = $this->normalizeLayerMap( $payload['states'] ?? [] );
+		$breakpoints = $this->normalizeLayerMap( $payload['breakpoints'] ?? [] );
+
+		$hasNonIdle = [] !== $states || [] !== $breakpoints;
+
+		if ( null === $idle && ! $hasNonIdle ) {
+			return '';
+		}
+
+		$usesGradient = ( null !== $idle && self::isGradient( $idle ) )
+			|| self::anyGradient( $states )
+			|| self::anyGradient( $breakpoints );
+
+		$rules = [];
+
+		if ( $usesGradient ) {
+			// `isolation: isolate` creates a new stacking context on the
+			// wrapper. Without it, the gradient `::before` (which uses
+			// `z-index: -1` to slip behind the wrapper's own children)
+			// can get hidden behind a parent's background, because
+			// z-index: -1 in the parent's stacking context puts the
+			// pseudo behind that parent too. Mirrors the TS emitter.
+			$rules[] = sprintf( '%s{position:relative;isolation:isolate}', $scope );
+		}
+
+		if ( null !== $idle ) {
+			$rule = $this->ruleForLayer( $scope, $idle );
+
+			if ( '' !== $rule ) {
+				$rules[] = $rule;
+			}
+		}
+
+		if ( $hasNonIdle ) {
+			$rules[] = sprintf( '%s{transition:%s}', $scope, self::DEFAULT_TRANSITION );
+		}
+
+		$hoverParts    = [];
+		$nonHoverParts = [];
+
+		foreach ( $states as $stateKey => $layer ) {
+			$definition = $this->states->get( $stateKey );
+			if ( null === $definition ) {
+				continue;
+			}
+
+			$selector = self::selectorFor( $scope, $definition['selector'] ?? '' );
+			if ( '' === $selector ) {
+				continue;
+			}
+
+			$rule = $this->stateRuleFor( $selector, $layer );
+
+			if ( '' === $rule ) {
+				continue;
+			}
+
+			if ( ! empty( $definition['hoverMediaWrap'] ) ) {
+				$hoverParts[] = $rule;
+				continue;
+			}
+
+			$nonHoverParts[] = $rule;
+		}
+
+		if ( [] !== $hoverParts ) {
+			$rules[] = sprintf( '@media (hover: hover){%s}', implode( '', $hoverParts ) );
+		}
+
+		foreach ( $nonHoverParts as $rule ) {
+			$rules[] = $rule;
+		}
+
+		foreach ( $breakpoints as $bp => $layer ) {
+			$minWidth = $this->breakpoints->get( $bp );
+
+			if ( null === $minWidth ) {
+				continue;
+			}
+
+			$rule = $this->ruleForLayer( $scope, $layer );
+
+			if ( '' === $rule ) {
+				continue;
+			}
+
+			$rules[] = sprintf( '@media (min-width:%dpx){%s}', $minWidth, $rule );
+		}
+
+		return implode( '', $rules );
+	}
+
+	/**
+	 * Build the CSS rule for a layer in idle/breakpoint context where
+	 * the scope itself is the selector.
+	 *
+	 * @param  array<string, mixed>  $layer
+	 */
+	protected function ruleForLayer( string $scope, array $layer ): string
+	{
+		if ( self::isGradient( $layer ) ) {
+			return sprintf(
+				'%s%s{%s}',
+				$scope,
+				self::pseudoForLayer( $layer ),
+				self::gradientPseudoDeclarations( $layer )
+			);
+		}
+
+		$value = self::layerBoxShadowValue( $layer );
+		if ( '' === $value ) {
+			return '';
+		}
+
+		return sprintf( '%s{box-shadow:%s}', $scope, $value );
+	}
+
+	/**
+	 * Build the CSS rule for a layer in per-state context where the
+	 * selector already has the state suffix applied.
+	 *
+	 * @param  array<string, mixed>  $layer
+	 */
+	protected function stateRuleFor( string $selector, array $layer ): string
+	{
+		if ( self::isGradient( $layer ) ) {
+			return sprintf(
+				'%s{%s}',
+				self::appendPseudoToList( $selector, self::pseudoForLayer( $layer ) ),
+				self::gradientPseudoDeclarations( $layer )
+			);
+		}
+
+		$value = self::layerBoxShadowValue( $layer );
+		if ( '' === $value ) {
+			return '';
+		}
+
+		return sprintf( '%s{box-shadow:%s}', $selector, $value );
+	}
+
+	/**
+	 * Compose the box-shadow value for a non-gradient (preset or
+	 * solid) layer. Returns empty string when no value is producible.
+	 *
+	 * @param  array<string, mixed>  $layer
+	 */
+	protected static function layerBoxShadowValue( array $layer ): string
+	{
+		if ( null !== ( $layer['preset'] ?? null ) ) {
+			$slug = self::sanitizeSlug( (string) $layer['preset'] );
+
+			if ( '' === $slug ) {
+				return '';
+			}
+
+			$value = sprintf( 'var(--wp--preset--shadow--%s)', $slug );
+
+			return true === ( $layer['inset'] ?? false ) ? $value . ' inset' : $value;
+		}
+
+		$parts = [
+			self::sanitizeCss( (string) ( $layer['offsetX'] ?? '0px' ) ),
+			self::sanitizeCss( (string) ( $layer['offsetY'] ?? '0px' ) ),
+			self::sanitizeCss( (string) ( $layer['blur'] ?? '0px' ) ),
+			self::sanitizeCss( (string) ( $layer['spread'] ?? '0px' ) ),
+			self::sanitizeCss( (string) ( $layer['color'] ?? 'currentColor' ) ),
+		];
+
+		$value = implode( ' ', $parts );
+
+		return true === ( $layer['inset'] ?? false ) ? 'inset ' . $value : $value;
+	}
+
+	/**
+	 * Compose the `::before`/`::after` declarations for a gradient
+	 * shadow layer. Outer uses negative inset + filter blur + z-index
+	 * -1; inset uses a mask-composite ring with a padding ring.
+	 *
+	 * @param  array<string, mixed>  $layer
+	 */
+	protected static function gradientPseudoDeclarations( array $layer ): string
+	{
+		$offsetX = self::sanitizeCss( (string) ( $layer['offsetX'] ?? '0px' ) );
+		$offsetY = self::sanitizeCss( (string) ( $layer['offsetY'] ?? '0px' ) );
+		$blur    = self::sanitizeCss( (string) ( $layer['blur'] ?? '0px' ) );
+		$spread  = self::sanitizeCss( (string) ( $layer['spread'] ?? '0px' ) );
+		$fill    = self::sanitizeGradient( (string) ( $layer['gradient'] ?? 'transparent' ) );
+
+		if ( true === ( $layer['inset'] ?? false ) ) {
+			// Explicit top/left/width/height (rather than `inset: 0`)
+			// to make the absolutely-positioned pseudo's size
+			// unambiguous across containing-block edge cases. See TS
+			// emitter docblock for the failure mode this guards.
+			return sprintf(
+				'content:"";position:absolute;top:0;left:0;width:100%%;height:100%%;'
+				. 'border-radius:inherit;'
+				. 'padding:%1$s;'
+				. 'background:%2$s;'
+				. 'filter:blur(%3$s);'
+				. 'transform:translate(calc(-1 * %4$s),calc(-1 * %5$s));'
+				. '-webkit-mask:linear-gradient(#000 0 0) content-box,linear-gradient(#000 0 0);'
+				. '-webkit-mask-composite:xor;'
+				. 'mask:linear-gradient(#000 0 0) content-box,linear-gradient(#000 0 0);'
+				. 'mask-composite:exclude;'
+				. 'pointer-events:none',
+				$spread,
+				$fill,
+				$blur,
+				$offsetX,
+				$offsetY
+			);
+		}
+
+		// Outer gradient — explicit top/left/width/height instead of
+		// `inset: calc(-1 * spread)` for unambiguous sizing.
+		return sprintf(
+			'content:"";position:absolute;'
+			. 'top:calc(-1 * %1$s);left:calc(-1 * %1$s);'
+			. 'width:calc(100%% + 2 * %1$s);height:calc(100%% + 2 * %1$s);'
+			. 'border-radius:inherit;'
+			. 'background:%2$s;'
+			. 'filter:blur(%3$s);'
+			. 'transform:translate(%4$s,%5$s);'
+			. 'z-index:-1;'
+			. 'pointer-events:none',
+			$spread,
+			$fill,
+			$blur,
+			$offsetX,
+			$offsetY
+		);
+	}
+
+	/**
+	 * Normalize an incoming layer record — defends against partial /
+	 * malformed payloads from non-trusted resolvers.
+	 *
+	 * @return array<string, mixed>|null
+	 */
+	protected function normalizeLayer( mixed $layer ): ?array
+	{
+		if ( ! is_array( $layer ) ) {
+			return null;
+		}
+
+		$preset = $layer['preset'] ?? null;
+		$preset = is_string( $preset ) && '' !== trim( $preset ) ? trim( $preset ) : null;
+
+		$gradient = $layer['gradient'] ?? null;
+		$gradient = is_string( $gradient ) && '' !== trim( $gradient ) ? trim( $gradient ) : null;
+
+		$hasStructured =
+			self::nonEmptyString( $layer['offsetX'] ?? null )
+			|| self::nonEmptyString( $layer['offsetY'] ?? null )
+			|| self::nonEmptyString( $layer['blur'] ?? null )
+			|| self::nonEmptyString( $layer['spread'] ?? null )
+			|| self::nonEmptyString( $layer['color'] ?? null )
+			|| null !== $gradient
+			|| true === ( $layer['inset'] ?? false );
+
+		if ( null === $preset && ! $hasStructured ) {
+			return null;
+		}
+
+		return [
+			'offsetX'  => self::coerceCss( $layer['offsetX'] ?? null, '0px' ),
+			'offsetY'  => self::coerceCss( $layer['offsetY'] ?? null, '0px' ),
+			'blur'     => self::coerceCss( $layer['blur'] ?? null, '0px' ),
+			'spread'   => self::coerceCss( $layer['spread'] ?? null, '0px' ),
+			'color'    => self::nonEmptyString( $layer['color'] ?? null ) ? trim( (string) $layer['color'] ) : null,
+			'gradient' => $gradient,
+			'inset'    => true === ( $layer['inset'] ?? false ),
+			'preset'   => $preset,
+		];
+	}
+
+	/**
+	 * @param  mixed  $raw
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
+	protected function normalizeLayerMap( mixed $raw ): array
+	{
+		if ( ! is_array( $raw ) ) {
+			return [];
+		}
+
+		$out = [];
+
+		foreach ( $raw as $key => $value ) {
+			if ( ! is_string( $key ) || '' === $key ) {
+				continue;
+			}
+
+			$layer = $this->normalizeLayer( $value );
+
+			if ( null === $layer ) {
+				continue;
+			}
+
+			$out[ $key ] = $layer;
+		}
+
+		return $out;
+	}
+
+	/**
+	 * @param  array<string, mixed>  $layer
+	 */
+	protected static function isGradient( array $layer ): bool
+	{
+		return null === ( $layer['preset'] ?? null ) && null !== ( $layer['gradient'] ?? null );
+	}
+
+	/**
+	 * @param  array<string, array<string, mixed>>  $layers
+	 */
+	protected static function anyGradient( array $layers ): bool
+	{
+		foreach ( $layers as $layer ) {
+			if ( self::isGradient( $layer ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * @param  array<string, mixed>  $layer
+	 */
+	protected static function pseudoForLayer( array $layer ): string
+	{
+		return true === ( $layer['inset'] ?? false ) ? '::after' : '::before';
+	}
+
+	/**
+	 * Resolve the literal selector for a state definition, replacing
+	 * `&` with the block scope.
+	 */
+	protected static function selectorFor( string $scope, string $selector ): string
+	{
+		if ( '' === $selector ) {
+			return '';
+		}
+
+		$pieces = array_map( 'trim', explode( ',', $selector ) );
+		$mapped = [];
+
+		foreach ( $pieces as $piece ) {
+			if ( '' === $piece ) {
+				continue;
+			}
+
+			$mapped[] = str_contains( $piece, '&' )
+				? str_replace( '&', $scope, $piece )
+				: $scope . $piece;
+		}
+
+		return implode( ', ', $mapped );
+	}
+
+	/**
+	 * Append a pseudo-element suffix to EVERY selector in a comma-
+	 * separated list. Mirrors {@see GradientBorderEmitter::appendPseudoToList}.
+	 */
+	protected static function appendPseudoToList( string $selector, string $pseudo ): string
+	{
+		$pieces = array_map( 'trim', explode( ',', $selector ) );
+		$mapped = [];
+
+		foreach ( $pieces as $piece ) {
+			if ( '' === $piece ) {
+				continue;
+			}
+
+			$mapped[] = $piece . $pseudo;
+		}
+
+		return implode( ', ', $mapped );
+	}
+
+	protected static function sanitizeCss( string $value ): string
+	{
+		return (string) preg_replace( '/[^a-zA-Z0-9_+\-*\/.,()%#\s]/', '', $value );
+	}
+
+	protected static function sanitizeGradient( string $value ): string
+	{
+		return (string) preg_replace( '/[^a-zA-Z0-9_+\-*\/.,()%#:\s]/', '', $value );
+	}
+
+	protected static function sanitizeSlug( string $value ): string
+	{
+		return (string) preg_replace( '/[^a-z0-9_-]/i', '', $value );
+	}
+
+	protected static function coerceCss( mixed $value, string $fallback ): string
+	{
+		if ( ! is_string( $value ) ) {
+			return $fallback;
+		}
+
+		$trimmed = trim( $value );
+
+		return '' === $trimmed ? $fallback : $trimmed;
+	}
+
+	protected static function nonEmptyString( mixed $value ): bool
+	{
+		return is_string( $value ) && '' !== trim( $value );
+	}
+}

--- a/src/BoxShadow/BoxShadowResolver.php
+++ b/src/BoxShadow/BoxShadowResolver.php
@@ -1,0 +1,357 @@
+<?php
+
+/**
+ * Box shadow attribute resolver (#607).
+ *
+ * Walks a block's attribute tree and produces the normalized record
+ * {@see BoxShadowEmitter::emit} consumes.
+ *
+ * Composition with the rest of the editor:
+ * - Idle value lives at `style.shadow` (a structured subtree).
+ * - Per-state overrides ride the standard `attributes.states` bag keyed
+ *   `style.shadow` (or its `shadow` shorthand for symmetry).
+ * - Per-breakpoint overrides ride `attributes.responsive` keyed
+ *   `style.shadow`.
+ *
+ * A `preset` slug short-circuits the structured fields — when set,
+ * the emitter renders `box-shadow: var(--wp--preset--shadow--{slug})`.
+ * The `gradient` field accepts both slugs (expanded to
+ * `var(--wp--preset--gradient--{slug})`) and raw CSS gradient values.
+ *
+ * Architecture deliberately parallels {@see GradientBorderResolver}
+ * — see that file's docblock for the cascade rationale.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.2.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\BoxShadow;
+
+class BoxShadowResolver
+{
+	/**
+	 * Path keys the resolver recognizes for shadow overrides in the
+	 * `attributes.states` and `attributes.responsive` bags.
+	 *
+	 * @var array<int, string>
+	 */
+	protected const SHADOW_PATHS = [
+		'style.shadow',
+		'shadow',
+	];
+
+	/**
+	 * Resolve a full block attribute tree into the normalized payload
+	 * the emitter consumes.
+	 *
+	 * Returns `null` when no shadow configuration is present at any
+	 * cascade level — callers should treat `null` as a signal to skip
+	 * {@see BoxShadowEmitter} entirely.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @param  array<string, mixed>  $attributes
+	 *
+	 * @return array{
+	 *     idle: array<string, mixed>|null,
+	 *     states: array<string, array<string, mixed>>,
+	 *     breakpoints: array<string, array<string, mixed>>,
+	 * }|null
+	 */
+	public static function resolve( array $attributes ): ?array
+	{
+		$shadow = $attributes['style']['shadow'] ?? null;
+
+		$idle        = self::resolveLayer( is_array( $shadow ) ? $shadow : null );
+		$states      = self::collectStateOverrides( $attributes['states'] ?? null );
+		$breakpoints = self::collectBreakpointOverrides( $attributes['responsive'] ?? null );
+
+		if ( null === $idle && [] === $states && [] === $breakpoints ) {
+			return null;
+		}
+
+		return [
+			'idle'        => $idle,
+			'states'      => $states,
+			'breakpoints' => $breakpoints,
+		];
+	}
+
+	/**
+	 * Pluck every shadow preset slug AND gradient slug referenced
+	 * anywhere in a block's attribute tree. Used by the editor's
+	 * token-warning surface to flag references whose theme token was
+	 * removed or renamed.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @param  array<string, mixed>  $attributes
+	 *
+	 * @return array{ shadows: array<int, string>, gradients: array<int, string> }
+	 */
+	public static function referencedSlugs( array $attributes ): array
+	{
+		$shadows   = [];
+		$gradients = [];
+
+		$shadow = $attributes['style']['shadow'] ?? null;
+		if ( is_array( $shadow ) ) {
+			self::collectSubtreeSlugs( $shadows, $gradients, $shadow );
+		}
+
+		foreach ( [ $attributes['states'] ?? null, $attributes['responsive'] ?? null ] as $bag ) {
+			if ( ! is_array( $bag ) ) {
+				continue;
+			}
+
+			foreach ( self::SHADOW_PATHS as $path ) {
+				if ( ! isset( $bag[ $path ] ) || ! is_array( $bag[ $path ] ) ) {
+					continue;
+				}
+
+				foreach ( $bag[ $path ] as $value ) {
+					if ( is_array( $value ) ) {
+						self::collectSubtreeSlugs( $shadows, $gradients, $value );
+					}
+				}
+			}
+		}
+
+		return [
+			'shadows'   => array_values( array_unique( $shadows ) ),
+			'gradients' => array_values( array_unique( $gradients ) ),
+		];
+	}
+
+	/**
+	 * Resolve a single shadow subtree into a normalized layer. Returns
+	 * `null` for empty/missing subtrees so callers can short-circuit
+	 * emission.
+	 *
+	 * @param  array<string, mixed>|null  $subtree
+	 *
+	 * @return array{
+	 *     offsetX: string,
+	 *     offsetY: string,
+	 *     blur: string,
+	 *     spread: string,
+	 *     color: string|null,
+	 *     gradient: string|null,
+	 *     inset: bool,
+	 *     preset: string|null,
+	 * }|null
+	 */
+	protected static function resolveLayer( ?array $subtree ): ?array
+	{
+		if ( null === $subtree ) {
+			return null;
+		}
+
+		$preset = self::expandPreset( $subtree['preset'] ?? null );
+
+		$offsetX  = self::coerceString( $subtree['offsetX'] ?? null );
+		$offsetY  = self::coerceString( $subtree['offsetY'] ?? null );
+		$blur     = self::coerceString( $subtree['blur'] ?? null );
+		$spread   = self::coerceString( $subtree['spread'] ?? null );
+		$color    = self::coerceString( $subtree['color'] ?? null );
+		$gradient = self::expandGradient( $subtree['gradient'] ?? null );
+		$inset    = true === ( $subtree['inset'] ?? false );
+
+		$hasStructured =
+			null !== $offsetX
+			|| null !== $offsetY
+			|| null !== $blur
+			|| null !== $spread
+			|| null !== $color
+			|| null !== $gradient
+			|| true === ( $subtree['inset'] ?? false );
+
+		if ( null === $preset && ! $hasStructured ) {
+			return null;
+		}
+
+		// Defaults are `0px`, not `0`. Safari (and the CSS spec) require
+		// a unit inside `calc()` — `calc(-1 * 0)` is invalid because
+		// `0` is a `<number>`, not a `<length>`. Mirrors the TS resolver.
+		return [
+			'offsetX'  => $offsetX ?? '0px',
+			'offsetY'  => $offsetY ?? '0px',
+			'blur'     => $blur ?? '0px',
+			'spread'   => $spread ?? '0px',
+			'color'    => $color,
+			'gradient' => $gradient,
+			'inset'    => $inset,
+			'preset'   => $preset,
+		];
+	}
+
+	/**
+	 * Read every shadow override out of an `attributes.states` bag,
+	 * resolving each into a structured layer. Canonical `style.shadow`
+	 * wins over the `shadow` shorthand on conflict.
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
+	protected static function collectStateOverrides( mixed $statesBag ): array
+	{
+		if ( ! is_array( $statesBag ) ) {
+			return [];
+		}
+
+		$out = [];
+
+		foreach ( array_reverse( self::SHADOW_PATHS ) as $path ) {
+			$overrides = $statesBag[ $path ] ?? null;
+
+			if ( ! is_array( $overrides ) ) {
+				continue;
+			}
+
+			foreach ( $overrides as $stateKey => $value ) {
+				if ( ! is_string( $stateKey ) || '' === $stateKey ) {
+					continue;
+				}
+
+				$layer = self::resolveLayer( is_array( $value ) ? $value : null );
+
+				if ( null === $layer ) {
+					continue;
+				}
+
+				$out[ $stateKey ] = $layer;
+			}
+		}
+
+		return $out;
+	}
+
+	/**
+	 * Read every shadow override out of an `attributes.responsive`
+	 * bag, resolving each into a structured layer.
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
+	protected static function collectBreakpointOverrides( mixed $responsiveBag ): array
+	{
+		if ( ! is_array( $responsiveBag ) ) {
+			return [];
+		}
+
+		$out = [];
+
+		foreach ( array_reverse( self::SHADOW_PATHS ) as $path ) {
+			$overrides = $responsiveBag[ $path ] ?? null;
+
+			if ( ! is_array( $overrides ) ) {
+				continue;
+			}
+
+			foreach ( $overrides as $bp => $value ) {
+				if ( ! is_string( $bp ) || '' === $bp ) {
+					continue;
+				}
+
+				$layer = self::resolveLayer( is_array( $value ) ? $value : null );
+
+				if ( null === $layer ) {
+					continue;
+				}
+
+				$out[ $bp ] = $layer;
+			}
+		}
+
+		return $out;
+	}
+
+	/**
+	 * Expand a gradient value: slugs map to
+	 * `var(--wp--preset--gradient--{slug})`, raw CSS passes through,
+	 * everything else returns `null`.
+	 */
+	protected static function expandGradient( mixed $value ): ?string
+	{
+		if ( ! is_string( $value ) ) {
+			return null;
+		}
+
+		$trimmed = trim( $value );
+
+		if ( '' === $trimmed ) {
+			return null;
+		}
+
+		if ( 1 === preg_match( '/^[a-z0-9][a-z0-9_-]*$/i', $trimmed ) ) {
+			return sprintf( 'var(--wp--preset--gradient--%s)', $trimmed );
+		}
+
+		return $trimmed;
+	}
+
+	/**
+	 * Validate + return a shadow preset slug, or `null` if the value
+	 * isn't slug-shaped.
+	 */
+	protected static function expandPreset( mixed $value ): ?string
+	{
+		if ( ! is_string( $value ) ) {
+			return null;
+		}
+
+		$trimmed = trim( $value );
+
+		if ( '' === $trimmed ) {
+			return null;
+		}
+
+		if ( 1 !== preg_match( '/^[a-z0-9][a-z0-9_-]*$/i', $trimmed ) ) {
+			return null;
+		}
+
+		return $trimmed;
+	}
+
+	/**
+	 * Push the raw slug into either the shadows or gradients list
+	 * depending on which subtree field it came from.
+	 *
+	 * @param  array<int, string>  $shadows
+	 * @param  array<int, string>  $gradients
+	 * @param  array<string, mixed>  $subtree
+	 */
+	protected static function collectSubtreeSlugs( array &$shadows, array &$gradients, array $subtree ): void
+	{
+		$preset = self::expandPreset( $subtree['preset'] ?? null );
+		if ( null !== $preset ) {
+			$shadows[] = $preset;
+		}
+
+		$gradient = $subtree['gradient'] ?? null;
+		if ( is_string( $gradient ) ) {
+			$trimmed = trim( $gradient );
+			if ( '' !== $trimmed && 1 === preg_match( '/^[a-z0-9][a-z0-9_-]*$/i', $trimmed ) ) {
+				$gradients[] = $trimmed;
+			}
+		}
+	}
+
+	/**
+	 * Coerce an attribute to a non-empty trimmed string or `null`.
+	 */
+	protected static function coerceString( mixed $value ): ?string
+	{
+		if ( ! is_string( $value ) ) {
+			return null;
+		}
+
+		$trimmed = trim( $value );
+
+		return '' === $trimmed ? null : $trimmed;
+	}
+}

--- a/src/VisualEditorServiceProvider.php
+++ b/src/VisualEditorServiceProvider.php
@@ -44,6 +44,7 @@ use ArtisanPackUI\VisualEditor\Responsive\AttributeMigrator;
 use ArtisanPackUI\VisualEditor\Responsive\BreakpointRegistry;
 use ArtisanPackUI\VisualEditor\Responsive\ResponsiveValueResolver;
 use ArtisanPackUI\VisualEditor\States\StateAttributeMigrator;
+use ArtisanPackUI\VisualEditor\BoxShadow\BoxShadowEmitter;
 use ArtisanPackUI\VisualEditor\States\StateCssEmitter;
 use ArtisanPackUI\VisualEditor\States\StateRegistry;
 use ArtisanPackUI\VisualEditor\States\StateValueResolver;
@@ -291,6 +292,16 @@ class VisualEditorServiceProvider extends ServiceProvider
 			return new StateCssEmitter(
 				$app->make( StateRegistry::class ),
 				$app->make( StateValueResolver::class ),
+			);
+		} );
+
+		// #607: Box-shadow emitter. Parallels GradientBorderEmitter
+		// (currently unwired) — bound here so future render-pipeline
+		// integration can resolve it from the container.
+		$this->app->scoped( BoxShadowEmitter::class, function ( $app ) {
+			return new BoxShadowEmitter(
+				$app->make( StateRegistry::class ),
+				$app->make( BreakpointRegistry::class ),
 			);
 		} );
 

--- a/tests/Unit/BoxShadow/BoxShadowEmitterTest.php
+++ b/tests/Unit/BoxShadow/BoxShadowEmitterTest.php
@@ -1,0 +1,158 @@
+<?php
+
+/**
+ * Unit tests for {@see BoxShadowEmitter} (#607).
+ *
+ * Pins the three emission modes (preset / solid / gradient) plus the
+ * state and breakpoint cascade behaviors. Byte-sensitive against the
+ * TS mirror in `box-shadows/emitter.ts` — the editor preview and
+ * server render must produce equivalent CSS.
+ *
+ * @since 1.2.0
+ */
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\BoxShadow\BoxShadowEmitter;
+use ArtisanPackUI\VisualEditor\Responsive\BreakpointRegistry;
+use ArtisanPackUI\VisualEditor\States\StateRegistry;
+
+beforeEach( function (): void {
+	$this->emitter = new BoxShadowEmitter(
+		StateRegistry::fromLayers( [], [] ),
+		BreakpointRegistry::fromLayers( [], [] ),
+	);
+} );
+
+/**
+ * @return array<string, mixed>
+ */
+function bsLayer( array $overrides = [] ): array
+{
+	return array_merge( [
+		'offsetX'  => '0',
+		'offsetY'  => '0',
+		'blur'     => '0',
+		'spread'   => '0',
+		'color'    => null,
+		'gradient' => null,
+		'inset'    => false,
+		'preset'   => null,
+	], $overrides );
+}
+
+describe( 'BoxShadowEmitter::emit', function (): void {
+	it( 'returns empty when scope is blank or payload has no values', function (): void {
+		expect( $this->emitter->emit( '', [ 'idle' => bsLayer( [ 'color' => '#000' ] ) ] ) )->toBe( '' );
+
+		expect( $this->emitter->emit( '.scope', [
+			'idle'        => null,
+			'states'      => [],
+			'breakpoints' => [],
+		] ) )->toBe( '' );
+	} );
+
+	it( 'emits a stock box-shadow for a solid outer layer', function (): void {
+		$css = $this->emitter->emit( '.scope', [
+			'idle' => bsLayer( [ 'offsetX' => '2px', 'offsetY' => '4px', 'blur' => '8px', 'color' => '#000' ] ),
+		] );
+
+		expect( $css )->toContain( '.scope{box-shadow:2px 4px 8px 0 #000}' );
+		expect( $css )->not->toContain( '::before' );
+		expect( $css )->not->toContain( 'position:relative' );
+	} );
+
+	it( 'emits inset prefix for a solid inset layer', function (): void {
+		$css = $this->emitter->emit( '.scope', [
+			'idle' => bsLayer( [ 'blur' => '6px', 'color' => '#333', 'inset' => true ] ),
+		] );
+
+		expect( $css )->toContain( '.scope{box-shadow:inset 0 0 6px 0 #333}' );
+	} );
+
+	it( 'emits var() for a preset layer', function (): void {
+		$css = $this->emitter->emit( '.scope', [
+			'idle' => bsLayer( [ 'preset' => 'shadow-md' ] ),
+		] );
+
+		expect( $css )->toContain( '.scope{box-shadow:var(--wp--preset--shadow--shadow-md)}' );
+	} );
+
+	it( 'appends inset suffix on preset layers when inset is true', function (): void {
+		$css = $this->emitter->emit( '.scope', [
+			'idle' => bsLayer( [ 'preset' => 'shadow-lg', 'inset' => true ] ),
+		] );
+
+		expect( $css )->toContain( '.scope{box-shadow:var(--wp--preset--shadow--shadow-lg) inset}' );
+	} );
+
+	it( 'emits a ::before pseudo for an outer gradient layer with position relative on the wrapper', function (): void {
+		$css = $this->emitter->emit( '.scope', [
+			'idle' => bsLayer( [
+				'offsetX'  => '4px',
+				'offsetY'  => '6px',
+				'blur'     => '12px',
+				'spread'   => '2px',
+				'gradient' => 'linear-gradient(135deg, #ff0000, #0000ff)',
+			] ),
+		] );
+
+		expect( $css )->toContain( '.scope{position:relative;isolation:isolate}' );
+		expect( $css )->toContain( '.scope::before{' );
+		expect( $css )->toContain( 'background:linear-gradient(135deg, #ff0000, #0000ff)' );
+		expect( $css )->toContain( 'filter:blur(12px)' );
+		expect( $css )->toContain( 'transform:translate(4px,6px)' );
+		expect( $css )->toContain( 'z-index:-1' );
+	} );
+
+	it( 'emits a ::after pseudo with mask-composite for an inset gradient layer', function (): void {
+		$css = $this->emitter->emit( '.scope', [
+			'idle' => bsLayer( [
+				'offsetX'  => '4px',
+				'offsetY'  => '6px',
+				'blur'     => '8px',
+				'spread'   => '4px',
+				'gradient' => 'linear-gradient(180deg, #fff, #000)',
+				'inset'    => true,
+			] ),
+		] );
+
+		expect( $css )->toContain( '.scope{position:relative;isolation:isolate}' );
+		expect( $css )->toContain( '.scope::after{' );
+		expect( $css )->toContain( 'mask-composite:exclude' );
+		expect( $css )->toContain( 'transform:translate(calc(-1 * 4px),calc(-1 * 6px))' );
+		expect( $css )->toContain( 'padding:4px' );
+	} );
+
+	it( 'emits transition declaration when non-idle layers exist', function (): void {
+		$css = $this->emitter->emit( '.scope', [
+			'idle'   => bsLayer( [ 'blur' => '4px', 'color' => '#000' ] ),
+			'states' => [],
+		] );
+
+		expect( $css )->not->toContain( 'transition:' );
+
+		$css = $this->emitter->emit( '.scope', [
+			'idle'        => bsLayer( [ 'blur' => '4px', 'color' => '#000' ] ),
+			'breakpoints' => [ 'md' => bsLayer( [ 'blur' => '12px', 'color' => '#000' ] ) ],
+		] );
+
+		// The breakpoint registry above has no entries, so the wrap
+		// won't fire, but the transition rule still emits because the
+		// payload reports non-idle entries exist. Both behaviors are
+		// internally consistent.
+		expect( $css )->toContain( 'transition:' );
+	} );
+
+	it( 'sanitises hostile characters in CSS values', function (): void {
+		$css = $this->emitter->emit( '.scope', [
+			'idle' => bsLayer( [
+				'offsetX' => '4px"; }</style><script>alert(1)</script>',
+				'color'   => '#000',
+			] ),
+		] );
+
+		expect( $css )->not->toContain( '<script>' );
+		expect( $css )->not->toContain( '"' );
+	} );
+} );

--- a/tests/Unit/BoxShadow/BoxShadowResolverTest.php
+++ b/tests/Unit/BoxShadow/BoxShadowResolverTest.php
@@ -1,0 +1,158 @@
+<?php
+
+/**
+ * Unit tests for {@see BoxShadowResolver} (#607).
+ *
+ * Covers the three cascade sources the resolver reads from
+ * (`style.shadow`, `attributes.states['style.shadow']`,
+ * `attributes.responsive['style.shadow']`), slug-vs-raw value
+ * expansion, the shorthand path key, preset detection, and the
+ * slug-collection helper the editor's token-warning surface uses.
+ *
+ * @since 1.2.0
+ */
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\BoxShadow\BoxShadowResolver;
+
+describe( 'BoxShadowResolver::resolve', function (): void {
+	it( 'returns null when no shadow configuration exists anywhere', function (): void {
+		expect( BoxShadowResolver::resolve( [] ) )->toBeNull();
+
+		expect( BoxShadowResolver::resolve( [
+			'style' => [ 'shadow' => [] ],
+		] ) )->toBeNull();
+	} );
+
+	it( 'returns a structured idle layer when at least one field is set', function (): void {
+		$resolved = BoxShadowResolver::resolve( [
+			'style' => [
+				'shadow' => [
+					'offsetX' => '2px',
+					'offsetY' => '4px',
+					'blur'    => '8px',
+					'color'   => '#000',
+				],
+			],
+		] );
+
+		expect( $resolved )->not->toBeNull();
+		expect( $resolved['idle']['offsetX'] )->toBe( '2px' );
+		expect( $resolved['idle']['blur'] )->toBe( '8px' );
+		expect( $resolved['idle']['color'] )->toBe( '#000' );
+		expect( $resolved['idle']['inset'] )->toBeFalse();
+		expect( $resolved['idle']['preset'] )->toBeNull();
+	} );
+
+	it( 'expands a gradient slug into var(--wp--preset--gradient--{slug})', function (): void {
+		$resolved = BoxShadowResolver::resolve( [
+			'style' => [ 'shadow' => [ 'gradient' => 'primary-glow' ] ],
+		] );
+
+		expect( $resolved['idle']['gradient'] )->toBe( 'var(--wp--preset--gradient--primary-glow)' );
+	} );
+
+	it( 'passes raw CSS gradient values through unchanged', function (): void {
+		$raw      = 'linear-gradient(135deg, #ff0000, #0000ff)';
+		$resolved = BoxShadowResolver::resolve( [
+			'style' => [ 'shadow' => [ 'gradient' => $raw ] ],
+		] );
+
+		expect( $resolved['idle']['gradient'] )->toBe( $raw );
+	} );
+
+	it( 'captures a preset slug onto the layer', function (): void {
+		$resolved = BoxShadowResolver::resolve( [
+			'style' => [ 'shadow' => [ 'preset' => 'shadow-md' ] ],
+		] );
+
+		expect( $resolved['idle']['preset'] )->toBe( 'shadow-md' );
+	} );
+
+	it( 'honours the inset flag', function (): void {
+		$resolved = BoxShadowResolver::resolve( [
+			'style' => [ 'shadow' => [ 'offsetX' => '0', 'inset' => true ] ],
+		] );
+
+		expect( $resolved['idle']['inset'] )->toBeTrue();
+	} );
+
+	it( 'collects per-state overrides from attributes.states canonical path', function (): void {
+		$resolved = BoxShadowResolver::resolve( [
+			'states' => [
+				'style.shadow' => [
+					'hover' => [ 'offsetX' => '4px', 'blur' => '12px', 'color' => '#111' ],
+					'focus' => null,
+				],
+			],
+		] );
+
+		expect( $resolved )->not->toBeNull();
+		expect( $resolved['states']['hover']['blur'] )->toBe( '12px' );
+		expect( $resolved['states'] )->not->toHaveKey( 'focus' );
+	} );
+
+	it( 'collects per-breakpoint overrides from attributes.responsive', function (): void {
+		$resolved = BoxShadowResolver::resolve( [
+			'responsive' => [
+				'style.shadow' => [
+					'md' => [ 'blur' => '16px', 'color' => '#000' ],
+				],
+			],
+		] );
+
+		expect( $resolved['breakpoints']['md']['blur'] )->toBe( '16px' );
+	} );
+
+	it( 'accepts the shorthand `shadow` path key with canonical winning on conflict', function (): void {
+		$resolved = BoxShadowResolver::resolve( [
+			'states' => [
+				'shadow'       => [ 'hover' => [ 'blur' => '99px' ] ],
+				'style.shadow' => [ 'hover' => [ 'blur' => '8px' ] ],
+			],
+		] );
+
+		expect( $resolved['states']['hover']['blur'] )->toBe( '8px' );
+	} );
+} );
+
+describe( 'BoxShadowResolver::referencedSlugs', function (): void {
+	it( 'pulls shadow + gradient slugs from every cascade slot', function (): void {
+		$slugs = BoxShadowResolver::referencedSlugs( [
+			'style'      => [ 'shadow' => [ 'preset' => 'shadow-md', 'gradient' => 'brand-glow' ] ],
+			'states'     => [
+				'style.shadow' => [
+					'hover' => [ 'preset' => 'shadow-elevated' ],
+				],
+			],
+			'responsive' => [
+				'style.shadow' => [
+					'md' => [ 'gradient' => 'vertical' ],
+				],
+			],
+		] );
+
+		expect( $slugs['shadows'] )->toContain( 'shadow-md' );
+		expect( $slugs['shadows'] )->toContain( 'shadow-elevated' );
+		expect( $slugs['gradients'] )->toContain( 'brand-glow' );
+		expect( $slugs['gradients'] )->toContain( 'vertical' );
+	} );
+
+	it( 'deduplicates slugs that appear in multiple cascade slots', function (): void {
+		$slugs = BoxShadowResolver::referencedSlugs( [
+			'style'  => [ 'shadow' => [ 'preset' => 'shadow-md' ] ],
+			'states' => [ 'style.shadow' => [ 'hover' => [ 'preset' => 'shadow-md' ] ] ],
+		] );
+
+		expect( $slugs['shadows'] )->toBe( [ 'shadow-md' ] );
+	} );
+
+	it( 'ignores raw CSS gradient values — they cannot become stale', function (): void {
+		$slugs = BoxShadowResolver::referencedSlugs( [
+			'style' => [ 'shadow' => [ 'gradient' => 'linear-gradient(#f00, #00f)' ] ],
+		] );
+
+		expect( $slugs['gradients'] )->toBe( [] );
+	} );
+} );

--- a/tests/visual/shadow-gradients.spec.ts
+++ b/tests/visual/shadow-gradients.spec.ts
@@ -1,0 +1,96 @@
+/**
+ * Visual regression contract for box shadows (#607).
+ *
+ * Acceptance criterion AC-7 of #607 calls for Playwright visual
+ * regression coverage spanning the matrix of:
+ *
+ *   {solid, gradient, preset} × {outer, inset} × {idle, hover state, md breakpoint}
+ *
+ * = 18 baselines (3 fill kinds × 2 inset states × 3 cascade slots).
+ * The issue's `Additional Context` note about the inset-mask strategy
+ * being the genuinely novel piece is covered by the gradient × inset
+ * cells, which exercise both Chrome/Safari/Firefox under the same
+ * harness once the runner is wired.
+ *
+ * Mirrors the gated pattern in `border-gradients.spec.ts`: the
+ * Playwright runner is NOT installed in this package today, so this
+ * file documents the matrix the snapshot suite must cover once
+ * Playwright is wired up. The matrix lives at top-level so static
+ * analysis catches drift (e.g. someone removes the inset gradient
+ * code path — the matrix entry stops compiling).
+ *
+ * When Playwright lands:
+ *   - Remove the `PLAYWRIGHT_AVAILABLE` skip guard at the bottom.
+ *   - Replace `serveShadowFixture` with the real harness call.
+ *   - Capture baselines via `--update-snapshots`.
+ *
+ * @since 1.2.0
+ */
+
+interface ShadowFill {
+	name: string
+	color?: string
+	gradient?: string
+	preset?: string
+}
+
+interface MatrixEntry {
+	label: string
+	fill: ShadowFill
+	inset: boolean
+	cascade: 'idle' | 'hover' | 'md'
+}
+
+const FILLS: ShadowFill[] = [
+	{ name: 'solid',    color: 'rgba(0,0,0,0.4)' },
+	{ name: 'gradient', gradient: 'linear-gradient(135deg, #ff0080, #7a00ff)' },
+	{ name: 'preset',   preset: 'shadow-md' },
+]
+
+const INSET   = [ false, true ] as const
+const CASCADE = [ 'idle', 'hover', 'md' ] as const
+
+const MATRIX: MatrixEntry[] = []
+
+for ( const fill of FILLS ) {
+	for ( const inset of INSET ) {
+		for ( const cascade of CASCADE ) {
+			MATRIX.push( {
+				label:   `${ fill.name }-${ inset ? 'inset' : 'outer' }-${ cascade }`,
+				fill,
+				inset,
+				cascade,
+			} )
+		}
+	}
+}
+
+/**
+ * Stub for the real Playwright fixture harness — when the runner is
+ * wired the implementation will render a single block configured per
+ * the matrix entry, capture a screenshot, and diff against the
+ * baseline.
+ */
+async function serveShadowFixture( _entry: MatrixEntry ): Promise<void> {
+	// no-op until Playwright is wired
+}
+
+const PLAYWRIGHT_AVAILABLE = false
+
+if ( PLAYWRIGHT_AVAILABLE ) {
+	// @ts-expect-error — placeholder until @playwright/test is added
+	const { test, expect } = await import( '@playwright/test' )
+
+	for ( const entry of MATRIX ) {
+		test( `shadow ${ entry.label }`, async ( { page }: { page: unknown } ) => {
+			await serveShadowFixture( entry )
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			await expect( page as any ).toHaveScreenshot( `shadow-${ entry.label }.png` )
+		} )
+	}
+}
+
+// Surface the matrix for any tooling that walks this file looking for
+// the snapshot inventory (e.g. CI scripts that diff added/removed
+// baselines).
+export { MATRIX }


### PR DESCRIPTION
## Description

Adds a Shadow tools panel to the inspector for every block with border support, exposing X/Y offset, blur, spread, solid color, gradient color, theme presets, and an inset toggle — composed with the standard state + breakpoint cascade and wired end-to-end through the Blade renderer so the editor canvas and the published front-end emit identical CSS.

**Closes:** #607

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #607

## Motivation and Context

The visual editor had a rich gradient-border subsystem (#490) but no equivalent for box/drop shadows. Authors who wanted a polished elevated UI had to drop down to global theme CSS or use the limited stock Gutenberg shadow panel, which can't do gradient-tinted shadows, can't cascade across states/breakpoints, and isn't routed through our resolver/emitter pipeline. This PR closes that gap with a one-to-one architectural mirror of the gradient-border subsystem.

## Changes Made

- **TS subsystem** under `resources/js/visual-editor/box-shadows/` — `types`, `resolver`, `emitter`, `extend-supports`, two HOCs (control + styles), `register`, `index`. Mirrors `gradient-borders/` one-to-one.
- **PHP subsystem** under `src/BoxShadow/` — `BoxShadowResolver` + `BoxShadowEmitter`, bound in `VisualEditorServiceProvider`.
- **Auto-enable** on every block with any `__experimentalBorder` support — no `block.json` changes anywhere. The supports-extension filter strips the native WordPress `supports.shadow` on opted-in blocks so the two systems don't fight over `style.shadow`.
- **Inspector UX** matches the Border picker — a ColorIndicator + label trigger opens a popover with Color | Gradient tabs inside. Ref-backed `writeShadow` survives the back-to-back `onColorChange`/`onGradientChange` calls `__experimentalColorGradientControl` fires synchronously.
- **CSS emission** dispatches per layer across three modes that share one scoped `<style>` code path: preset (`var(--wp--preset--shadow--{slug})`), solid (stock `box-shadow`), and gradient (`::before` outer / `::after` inset pseudo with `filter: blur()` and `mask-composite: exclude`).
- **Blade renderer integration** in `packages/visual-editor-renderer-blade/` — new `BoxShadowCssAccumulator` + `BlockSupports::pushBoxShadow()` + auto-stamping in `BlockSupports::compile()` + drain in `BlocksComponent`/`TemplateComponent` + emit in templates. Zero per-block-template changes — any block already routed through `BlockSupports::compile()` picks up shadow rendering for free.
- **`theme.json` schema** gains `settings.shadow.presets` with 4 default presets (Small/Medium/Large/Elevated).
- **Scope class** `ve-bs-<id>` persisted on `attributes.style.shadow._shadowScopeId`, mirroring `_gradientScopeId`.
- **Safari calc() fix** — defaults are `0px` (not unitless `0`) so `calc(-1 * spread)` is a valid `<length>` expression in all browsers.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS 25.5.0 (Darwin)
- Browser: Chrome + Safari (Safari `calc()` regression found and fixed mid-review)
- PHP Version: 8.4.3
- Project Version: release/1.2

**Tests Performed:**
1. Vitest box-shadow suite — 27 tests passing (resolver / emitter / extend-supports).
2. Pest `tests/Unit/BoxShadow/` suite — 21 tests / 46 assertions passing.
3. Pest `packages/visual-editor-renderer-blade/` suite — 0 failures (1011 assertions, including 2 new end-to-end Blade integration tests).
4. `npm run build` — clean Vite build.
5. Manual canvas + front-end testing on Cover (solid only, per documented overflow:hidden caveat), Group, Paragraph, Button blocks. Solid + gradient + preset all render correctly in both contexts.

## Accessibility Tests Run

- [x] Keyboard navigation tested
- [ ] Screen reader tested
- [x] Color contrast verified
- [x] ARIA labels checked

**Details:** Inspector panel uses `__experimentalToolsPanel` (native Gutenberg pattern, same a11y baseline as the existing Border/Color panels). Color picker popover trigger carries `aria-expanded` / `aria-haspopup="dialog"` / explicit `aria-label`. Shadow output is decorative; no screen-reader exposure required.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:**
- 3 new vitest files (`resolver`, `emitter`, `extend-supports`) — 27 tests covering preset/solid/gradient emission, slug expansion, cascade routing, scope-id minting, idempotent registration, and the new `supports.shadow` stripping behavior.
- 2 new Pest files (`BoxShadowResolverTest`, `BoxShadowEmitterTest`) — 21 tests mirroring the vitest coverage server-side, plus a CSS sanitization test that asserts hostile characters are stripped.
- 2 new end-to-end Pest tests in `packages/visual-editor-renderer-blade/tests/Unit/BlockSupportsTest.php` that prove `BlockSupports::compile()` stamps `ve-bs-*` and pushes the correct CSS rule for both solid and gradient layers.
- `tests/visual/shadow-gradients.spec.ts` Playwright spec scaffolded against the gated `PLAYWRIGHT_AVAILABLE = false` sentinel pattern used by `border-gradients.spec.ts`. Documents the 18-baseline matrix (3 fill kinds × 2 inset × 3 cascade) the snapshot suite must cover once the runner is wired.

## Documentation

- [x] Inline code documentation added
- [ ] README updated
- [ ] Wiki updated
- [ ] API documentation updated

**Documentation details:** New `docs/box-shadows.md` page covering authoring UI, `theme.json` schema, auto-enable behavior, Blade renderer integration, and the known `overflow: hidden` limitation for outer gradient shadows. CHANGELOG entry added under `[Unreleased]`. All new TS/PHP files carry full file-level docblocks plus per-method `@since 1.2.0` annotations.

## Known limitations (called out in docs + CHANGELOG)

- **Outer gradient shadow on `overflow: hidden` blocks** (Cover is the prime example): clipped at the wrapper edge. Gradient shadows need a `::before` pseudo because native `box-shadow` doesn't accept gradient values, and pseudos (unlike `box-shadow`) ARE clipped by the host's `overflow`. Solid shadows and presets are unaffected. Workaround is to wrap such a block in a Group and put the gradient shadow on the Group.
- **Playwright runner not yet installed in this package** — the visual spec is gated behind the same `PLAYWRIGHT_AVAILABLE = false` sentinel `border-gradients.spec.ts` uses. Wiring the runner + capturing baselines is tracked separately.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [x] Accessibility tests completed
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)