### PR TITLE
Release v1.3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,13 +53,29 @@ jobs:
           key: ${{ runner.os }}-php${{ matrix.php }}-composer-${{ hashFiles('**/composer.json') }}
           restore-keys: ${{ runner.os }}-php${{ matrix.php }}-composer-
 
+      - name: Remove AI dev deps (PHP 8.2)
+        # `artisanpack-ui/ai` (and by extension the AI trigger surface)
+        # requires PHP 8.3+. Strip both it and livewire (which the ai
+        # package pulls transitively for its admin components) on 8.2 so
+        # `composer update` still resolves; the corresponding tests are
+        # excluded below via `--exclude-testsuite=Ai`.
+        if: matrix.php == '8.2'
+        run: |
+          jq 'del(.["require-dev"]["artisanpack-ui/ai"], .["require-dev"]["livewire/livewire"])' composer.json > composer.json.tmp
+          mv composer.json.tmp composer.json
+
       - name: Install dependencies
         run: composer update --no-interaction --prefer-dist
 
       - name: Run tests
         env:
           XDEBUG_MODE: off
-        run: ./vendor/bin/pest --ci --no-coverage
+        run: |
+          if [ "${{ matrix.php }}" = "8.2" ]; then
+            ./vendor/bin/pest --ci --no-coverage --exclude-testsuite=Ai
+          else
+            ./vendor/bin/pest --ci --no-coverage
+          fi
 
   test-js:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,88 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-07-07
+
+### Added
+
+- **AI-powered authoring affordances (#610–#614).** Five optional
+  AI-assisted authoring features built on top of
+  [`artisanpack-ui/ai`](https://github.com/ArtisanPack-UI/ai). All
+  default to *off* and honor per-feature toggles from the AI package's
+  `FeatureRegistry`; each surfaces suggestions the author must
+  explicitly accept — no automatic mutations. Auto-registered via
+  `VisualEditorServiceProvider::aiFeatures()`, so hosts with the AI
+  package installed pick up every affordance with zero manual wiring.
+
+  Three agents live in this package under `src/Ai/Agents/`:
+
+  - **`ContentBlockSuggestionAgent` (#610)** — `visual_editor.suggest_next_block`.
+    Inline "+ suggest next block" affordance that ranks likely next
+    blocks given the document so far. Ships as
+    `<SuggestNextBlockButton />`.
+  - **`LayoutSuggestionAgent` (#611)** — `visual_editor.suggest_layout`.
+    Given a section's content and your available pattern library,
+    ranks matching section patterns from a whitelist. Ships as
+    `<SuggestLayoutPanel />`.
+  - **`HeadingHierarchyAgent` (#614)** — `visual_editor.heading_hierarchy`.
+    Audits the document for skipped heading levels, duplicate h1s,
+    and ambiguous headings; returns suggested fixes with nested
+    `innerBlocks` traversal. Ships as `<HeadingHierarchyPanel />`.
+
+  Two agents are consumed directly from `artisanpack-ui/ai` so the
+  same prompt + feature toggle powers them across every package that
+  opts in:
+
+  - **`AltTextGenerationAgent` (#612)** — `ai.alt_text`. Suggests
+    accessibility-friendly alt text when an image block is added or
+    its `src` changes and `alt` is empty. Ships as
+    `<AltTextSuggestionCard />`.
+  - **`ContentRewriteAgent` (#613)** — `ai.content_rewrite`.
+    Selection-toolbar / slash-command surface for "make shorter",
+    "more formal", "reading level 6", and similar rewrites. Ships as
+    `<RewriteToolbar />`.
+
+  **Transports.** Every affordance is reachable from any host stack:
+
+  - **HTTP** — six JSON endpoints under `/visual-editor/api/ai/*`:
+    `GET /features`, `POST /suggest-next-block`,
+    `POST /suggest-layout`, `POST /alt-text`, `POST /rewrite`,
+    `POST /heading-hierarchy`. Each endpoint has a dedicated Form
+    Request class in `src/Http/Requests/Ai/` and a consistent error
+    envelope. All routes are guarded on
+    `class_exists(FeatureRegistry)` so hosts without the AI package
+    installed don't 500.
+  - **Livewire** — `artisanpack-visual-editor.ai.tools` component
+    listens for `ap-ve-ai:*` browser events and dispatches shaped
+    `success` / `invalid-input` / `disabled` /
+    `missing-credentials` / `error` events back. Blade/Livewire
+    hosts get the same behavior as the React surface without pulling
+    in a client bundle.
+  - **React** — `resources/js/visual-editor/ai/` ships
+    `createAiApiClient`, `useAiFeatures` gate, per-feature hooks,
+    and 5 UI components. See
+    [`docs/ai-features.md`](docs/ai-features.md) for the full
+    authoring guide.
+
+  **Requirements:** `artisanpack-ui/ai` `^1.0` installed and
+  configured, per-feature toggle enabled in the AI settings surface,
+  and CSRF middleware active on `/visual-editor/api/*` so the shipped
+  JS client's `X-CSRF-TOKEN` header is honored.
+
+### Changed
+
+- `composer.json` now requires PHP 8.2+ and `artisanpack-ui/ai` `^1.0`
+  as an optional-but-recommended companion dependency. Hosts without
+  the AI package installed continue to work — the AI surface simply
+  stays hidden and the routes short-circuit before dispatching an
+  agent.
+
+### CI
+
+- Test suite runs on PHP 8.2 with AI dev deps excluded so hosts still
+  targeting 8.2 have a green matrix even before adopting the AI
+  package.
+
 ## [1.2.0] - 2026-06-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -293,6 +293,89 @@ additional icon sets in a service provider — see the
 
 ---
 
+## AI features
+
+The visual editor ships five optional AI-powered authoring affordances
+that build on top of the [`artisanpack-ui/ai`][ai-pkg] foundation. All
+five default to *off* — hosts opt in by enabling the corresponding
+feature key from the AI package's settings surface, and each affordance
+honors that toggle before rendering.
+
+| Feature key | Agent | What it does |
+|---|---|---|
+| `visual_editor.suggest_next_block` | `ContentBlockSuggestionAgent` | Inline "+ suggest" affordance ranks likely next blocks given the document so far. |
+| `visual_editor.suggest_layout` | `LayoutSuggestionAgent` | Given a section's content + your available pattern library, ranks matching section patterns. |
+| `visual_editor.heading_hierarchy` | `HeadingHierarchyAgent` | Audits the document for skipped levels, duplicate h1s, and ambiguous headings. |
+| `ai.alt_text` | `AltTextGenerationAgent` (from `ai`) | Suggests accessibility-friendly alt text when an image block is added or its `src` changes and `alt` is empty. |
+| `ai.content_rewrite` | `ContentRewriteAgent` (from `ai`) | Selection-toolbar / slash-command surface for "make shorter", "more formal", "reading level 6", etc. |
+
+The first three agents live in this package (`src/Ai/Agents/`); the last
+two are cross-cutting agents consumed directly from `artisanpack-ui/ai`
+so the same prompt + feature toggle powers alt-text and content rewrites
+across every package that opts in.
+
+### Server-side surface
+
+The features are auto-registered with the AI package's `FeatureRegistry`
+via `VisualEditorServiceProvider::aiFeatures()` — no manual wiring
+required. Each has a JSON endpoint under `/visual-editor/api/ai/*` for
+the React editor to hit:
+
+```
+GET  /visual-editor/api/ai/features             # { features: { <key>: bool, ... } }
+POST /visual-editor/api/ai/suggest-next-block
+POST /visual-editor/api/ai/suggest-layout
+POST /visual-editor/api/ai/alt-text
+POST /visual-editor/api/ai/rewrite
+POST /visual-editor/api/ai/heading-hierarchy
+```
+
+Blade / Livewire hosts can consume the same triggers through the shipped
+Livewire component `artisanpack-visual-editor.ai.tools`, which listens
+for `ap-ve-ai:*` browser events and re-dispatches results as
+`ap-ve-ai:{feature}:{status}`.
+
+### React surface
+
+```tsx
+import {
+    createAiApiClient,
+    useAiFeatures,
+    SuggestNextBlockButton,
+    HeadingHierarchyPanel,
+} from '../visual-editor/ai';
+
+const client = createAiApiClient({ apiBase: '/visual-editor/api' });
+const { isEnabled } = useAiFeatures(client);
+
+{isEnabled('visual_editor.suggest_next_block') && (
+    <SuggestNextBlockButton
+        client={client}
+        existingBlocks={blocks}
+        cursorPosition={insertionIndex}
+        onPick={(suggestion) => insertBlock(suggestion.block_type)}
+    />
+)}
+```
+
+Full component list: `resources/js/visual-editor/ai/index.ts`.
+
+### Requirements
+
+- `artisanpack-ui/ai` ^1.0 installed and configured with credentials.
+- The individual feature toggle enabled (default: off) from the AI
+  settings admin surface.
+- CSRF middleware active on the `/visual-editor/api/*` route group so
+  the shipped JS client's `X-CSRF-TOKEN` header is honored.
+
+Every affordance surfaces as a **suggestion** — never an automatic
+mutation. Accepting a suggestion is always explicit user action, per
+the AI RFC.
+
+[ai-pkg]: https://github.com/ArtisanPack-UI/ai
+
+---
+
 ## i18n
 
 Editor strings use `@wordpress/i18n` with the `artisanpack-visual-editor`

--- a/composer.json
+++ b/composer.json
@@ -36,10 +36,19 @@
     "pestphp/pest-plugin-laravel": "^3.1",
     "orchestra/testbench": "^10.2",
     "nesbot/carbon": "^3.8.4 <3.12.0",
+    "artisanpack-ui/ai": "^1.0",
     "artisanpack-ui/cms-framework": "^2.0",
-    "artisanpack-ui/icons": "^2.1"
+    "artisanpack-ui/icons": "^2.1",
+    "livewire/livewire": "^3.6"
   },
   "repositories": [
+    {
+      "type": "path",
+      "url": "../ai",
+      "options": {
+        "symlink": true
+      }
+    },
     {
       "type": "path",
       "url": "../cms-framework",
@@ -56,6 +65,7 @@
     }
   ],
   "suggest": {
+    "artisanpack-ui/ai": "Recommended ^1.0 — enables the visual-editor's AI-assisted authoring features (next-block suggestion, layout suggestion, heading-hierarchy check, plus alt-text + content-rewrite integrations that consume the cross-cutting agents shipped by the ai package). Without it the `aiFeatures()` service-provider hook is a no-op and the editor's AI trigger surfaces stay hidden.",
     "artisanpack-ui/media-library": "Recommended ^1.2 — default media library integration. Wire MediaModal + uploadMedia through registerArtisanpackMediaBridge() in the editor bootstrap to power Gutenberg's media picker and upload flows. Not enforced by Composer; host apps are free to install a different library and register a custom bridge instead.",
     "artisanpack-ui/cms-framework": "Required ^2.0 for the site editor + comments family — the `/visual-editor/site-editor` route is hard-coupled to cms-framework's templates, parts, patterns, global styles, and menus modules (plan 14), and the comments-family forks (#519) consume the Blog module's `Comment` model + `Post::comments` relation introduced in 2.1. Without it, the post-content editor still works but the site editor route returns an install gate and the comments-family blocks render against an empty data set.",
     "artisanpack-ui/icons": "Recommended ^2.1 — bundled FA Free Solid/Regular/Brands sets are registered against the icons package via the `ap.icons.register-icon-sets` filter. Without it, the icon block's `iconRef` paths render as `data-*` carriers (Phase 3, #554) and the picker has no registered icons to surface."

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "artisanpack-ui/visual-editor",
   "description": "A Gutenberg-powered visual editor for Laravel — post editor, site editor, and Blade/React/Vue block renderers.",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "type": "library",
   "license": "GPL-3.0-or-later",
   "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,38 +4,46 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "63998614103cdb4a92e851605e3a24df",
+    "content-hash": "921d251a9b060150da05cb1c42280dbb",
     "packages": [
         {
             "name": "artisanpack-ui/core",
-            "version": "1.1.0",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ArtisanPack-UI/core.git",
-                "reference": "16e91edb542948ee335c618a17fdc60f8593d671"
+                "reference": "bb7055c4b250612d987398f990b5537fbc28865b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ArtisanPack-UI/core/zipball/16e91edb542948ee335c618a17fdc60f8593d671",
-                "reference": "16e91edb542948ee335c618a17fdc60f8593d671",
+                "url": "https://api.github.com/repos/ArtisanPack-UI/core/zipball/bb7055c4b250612d987398f990b5537fbc28865b",
+                "reference": "bb7055c4b250612d987398f990b5537fbc28865b",
                 "shasum": ""
             },
             "require": {
-                "illuminate/support": "^11.0|^12.0",
+                "composer/semver": "^3.0",
+                "illuminate/support": "^11.0|^12.0|^13.0",
                 "laravel/prompts": "^0.3",
                 "php": "^8.2"
             },
             "require-dev": {
+                "artisanpack-ui/code-style": "^1.1",
+                "artisanpack-ui/code-style-pint": "^1.1",
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "friendsofphp/php-cs-fixer": "^3.75",
                 "laravel/pint": "^1.27",
-                "orchestra/testbench": "^10.2",
-                "pestphp/pest": "^3.8",
-                "pestphp/pest-plugin-laravel": "^3.1"
+                "orchestra/testbench": "^9.0|^10.0|^11.0",
+                "pestphp/pest": "^3.8|^4.0",
+                "pestphp/pest-plugin-laravel": "^3.1|^4.0",
+                "squizlabs/php_codesniffer": "3.11.3"
             },
             "type": "library",
             "extra": {
                 "laravel": {
                     "aliases": {
-                        "Core": "ArtisanPackUI\\Core\\Facades\\Core"
+                        "Core": "ArtisanPackUI\\Core\\Facades\\Core",
+                        "ArtisanPackLog": "ArtisanPackUI\\Core\\Facades\\ArtisanPackLog",
+                        "ArtisanPackConfig": "ArtisanPackUI\\Core\\Facades\\ArtisanPackConfig"
                     },
                     "providers": [
                         "ArtisanPackUI\\Core\\CoreServiceProvider"
@@ -63,9 +71,9 @@
             "description": "Supplies the core functionality for ArtisanPack UI that needs to be shared across all packages.",
             "support": {
                 "issues": "https://github.com/ArtisanPack-UI/core/issues",
-                "source": "https://github.com/ArtisanPack-UI/core/tree/v1.1.0"
+                "source": "https://github.com/ArtisanPack-UI/core/tree/v1.2.0"
             },
-            "time": "2026-01-10T02:20:40+00:00"
+            "time": "2026-05-24T02:53:50+00:00"
         },
         {
             "name": "artisanpack-ui/hooks",
@@ -261,6 +269,83 @@
                 }
             ],
             "time": "2024-02-09T16:56:22+00:00"
+        },
+        {
+            "name": "composer/semver",
+            "version": "3.4.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/semver.git",
+                "reference": "198166618906cb2de69b95d7d47e5fa8aa1b2b95"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/semver/zipball/198166618906cb2de69b95d7d47e5fa8aa1b2b95",
+                "reference": "198166618906cb2de69b95d7d47e5fa8aa1b2b95",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.11",
+                "symfony/phpunit-bridge": "^3 || ^7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Semver\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nils Adermann",
+                    "email": "naderman@naderman.de",
+                    "homepage": "http://www.naderman.de"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                },
+                {
+                    "name": "Rob Bast",
+                    "email": "rob.bast@gmail.com",
+                    "homepage": "http://robbast.nl"
+                }
+            ],
+            "description": "Semver library that offers utilities, version constraint parsing and validation.",
+            "keywords": [
+                "semantic",
+                "semver",
+                "validation",
+                "versioning"
+            ],
+            "support": {
+                "irc": "ircs://irc.libera.chat:6697/composer",
+                "issues": "https://github.com/composer/semver/issues",
+                "source": "https://github.com/composer/semver/tree/3.4.4"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-08-20T19:15:30+00:00"
         },
         {
             "name": "dflydev/dot-access-data",
@@ -770,25 +855,26 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.10.0",
+            "version": "7.13.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "b51ac707cfa420b7bfd4e4d5e510ba8008e822b4"
+                "reference": "bcd989ad36c92d42a3715379af91f2defee5b8dd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/b51ac707cfa420b7bfd4e4d5e510ba8008e822b4",
-                "reference": "b51ac707cfa420b7bfd4e4d5e510ba8008e822b4",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/bcd989ad36c92d42a3715379af91f2defee5b8dd",
+                "reference": "bcd989ad36c92d42a3715379af91f2defee5b8dd",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "guzzlehttp/promises": "^2.3",
-                "guzzlehttp/psr7": "^2.8",
+                "guzzlehttp/promises": "^2.5",
+                "guzzlehttp/psr7": "^2.12.3",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
-                "symfony/deprecation-contracts": "^2.2 || ^3.0"
+                "symfony/deprecation-contracts": "^2.5 || ^3.0",
+                "symfony/polyfill-php80": "^1.25"
             },
             "provide": {
                 "psr/http-client-implementation": "1.0"
@@ -796,9 +882,10 @@
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "ext-curl": "*",
-                "guzzle/client-integration-tests": "3.0.2",
+                "guzzle/client-integration-tests": "3.0.3",
+                "guzzlehttp/test-server": "^0.6",
                 "php-http/message-factory": "^1.1",
-                "phpunit/phpunit": "^8.5.39 || ^9.6.20",
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34",
                 "psr/log": "^1.1 || ^2.0 || ^3.0"
             },
             "suggest": {
@@ -876,7 +963,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.10.0"
+                "source": "https://github.com/guzzle/guzzle/tree/7.13.2"
             },
             "funding": [
                 {
@@ -892,28 +979,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-23T22:36:01+00:00"
+            "time": "2026-07-05T19:00:11+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "2.3.0",
+            "version": "2.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "481557b130ef3790cf82b713667b43030dc9c957"
+                "reference": "4360e982f87f5f258bf872d094647791db2f4c8e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/481557b130ef3790cf82b713667b43030dc9c957",
-                "reference": "481557b130ef3790cf82b713667b43030dc9c957",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/4360e982f87f5f258bf872d094647791db2f4c8e",
+                "reference": "4360e982f87f5f258bf872d094647791db2f4c8e",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2.5 || ^8.0"
+                "php": "^7.2.5 || ^8.0",
+                "symfony/deprecation-contracts": "^2.5 || ^3.0"
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "phpunit/phpunit": "^8.5.44 || ^9.6.25"
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34"
             },
             "type": "library",
             "extra": {
@@ -959,7 +1047,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/2.3.0"
+                "source": "https://github.com/guzzle/promises/tree/2.5.0"
             },
             "funding": [
                 {
@@ -975,27 +1063,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-22T14:34:08+00:00"
+            "time": "2026-06-02T12:23:43+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.9.0",
+            "version": "2.12.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "7d0ed42f28e42d61352a7a79de682e5e67fec884"
+                "reference": "7ec62dc3f44aa218487dbed81a9bf9bc647be55d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/7d0ed42f28e42d61352a7a79de682e5e67fec884",
-                "reference": "7d0ed42f28e42d61352a7a79de682e5e67fec884",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/7ec62dc3f44aa218487dbed81a9bf9bc647be55d",
+                "reference": "7ec62dc3f44aa218487dbed81a9bf9bc647be55d",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-factory": "^1.0",
                 "psr/http-message": "^1.1 || ^2.0",
-                "ralouphie/getallheaders": "^3.0"
+                "ralouphie/getallheaders": "^3.0",
+                "symfony/deprecation-contracts": "^2.5 || ^3.0",
+                "symfony/polyfill-php80": "^1.25"
             },
             "provide": {
                 "psr/http-factory-implementation": "1.0",
@@ -1003,9 +1093,9 @@
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "http-interop/http-factory-tests": "0.9.0",
+                "http-interop/http-factory-tests": "1.1.0",
                 "jshttp/mime-db": "1.54.0.1",
-                "phpunit/phpunit": "^8.5.44 || ^9.6.25"
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34"
             },
             "suggest": {
                 "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
@@ -1076,7 +1166,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.9.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.12.3"
             },
             "funding": [
                 {
@@ -1092,29 +1182,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-10T16:41:02+00:00"
+            "time": "2026-06-23T15:21:08+00:00"
         },
         {
             "name": "guzzlehttp/uri-template",
-            "version": "v1.0.5",
+            "version": "v1.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/uri-template.git",
-                "reference": "4f4bbd4e7172148801e76e3decc1e559bdee34e1"
+                "reference": "9c19128923b05a5d7355e5d2318d7808b7e33bbd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/uri-template/zipball/4f4bbd4e7172148801e76e3decc1e559bdee34e1",
-                "reference": "4f4bbd4e7172148801e76e3decc1e559bdee34e1",
+                "url": "https://api.github.com/repos/guzzle/uri-template/zipball/9c19128923b05a5d7355e5d2318d7808b7e33bbd",
+                "reference": "9c19128923b05a5d7355e5d2318d7808b7e33bbd",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2.5 || ^8.0",
-                "symfony/polyfill-php80": "^1.24"
+                "symfony/polyfill-php80": "^1.25"
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "phpunit/phpunit": "^8.5.44 || ^9.6.25",
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34",
                 "uri-template/tests": "1.0.0"
             },
             "type": "library",
@@ -1162,7 +1252,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/uri-template/issues",
-                "source": "https://github.com/guzzle/uri-template/tree/v1.0.5"
+                "source": "https://github.com/guzzle/uri-template/tree/v1.0.8"
             },
             "funding": [
                 {
@@ -1178,20 +1268,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-22T14:27:06+00:00"
+            "time": "2026-06-23T13:02:23+00:00"
         },
         {
             "name": "laravel/framework",
-            "version": "v12.58.0",
+            "version": "v12.63.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "6172ae1f44ba5d89e111057ee4a4e7c27f5a610d"
+                "reference": "7adfddbf4738f2e6cae5419b0e6bc46d4cccfbcf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/6172ae1f44ba5d89e111057ee4a4e7c27f5a610d",
-                "reference": "6172ae1f44ba5d89e111057ee4a4e7c27f5a610d",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/7adfddbf4738f2e6cae5419b0e6bc46d4cccfbcf",
+                "reference": "7adfddbf4738f2e6cae5419b0e6bc46d4cccfbcf",
                 "shasum": ""
             },
             "require": {
@@ -1400,20 +1490,20 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2026-04-26T16:42:04+00:00"
+            "time": "2026-07-07T14:16:35+00:00"
         },
         {
             "name": "laravel/prompts",
-            "version": "v0.3.17",
+            "version": "v0.3.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/prompts.git",
-                "reference": "6a82ac19a28b916ae0885828795dbd4c59d9a818"
+                "reference": "7753c65c281c2550c7c183f14e18062073b7d821"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/prompts/zipball/6a82ac19a28b916ae0885828795dbd4c59d9a818",
-                "reference": "6a82ac19a28b916ae0885828795dbd4c59d9a818",
+                "url": "https://api.github.com/repos/laravel/prompts/zipball/7753c65c281c2550c7c183f14e18062073b7d821",
+                "reference": "7753c65c281c2550c7c183f14e18062073b7d821",
                 "shasum": ""
             },
             "require": {
@@ -1457,9 +1547,9 @@
             "description": "Add beautiful and user-friendly forms to your command-line applications.",
             "support": {
                 "issues": "https://github.com/laravel/prompts/issues",
-                "source": "https://github.com/laravel/prompts/tree/v0.3.17"
+                "source": "https://github.com/laravel/prompts/tree/v0.3.21"
             },
-            "time": "2026-04-20T16:07:33+00:00"
+            "time": "2026-06-26T00:11:25+00:00"
         },
         {
             "name": "laravel/serializable-closure",
@@ -1713,16 +1803,16 @@
         },
         {
             "name": "league/flysystem",
-            "version": "3.33.0",
+            "version": "3.35.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem.git",
-                "reference": "570b8871e0ce693764434b29154c54b434905350"
+                "reference": "b277b5dc3d56650b68904117124e79c851e12376"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/570b8871e0ce693764434b29154c54b434905350",
-                "reference": "570b8871e0ce693764434b29154c54b434905350",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/b277b5dc3d56650b68904117124e79c851e12376",
+                "reference": "b277b5dc3d56650b68904117124e79c851e12376",
                 "shasum": ""
             },
             "require": {
@@ -1790,9 +1880,9 @@
             ],
             "support": {
                 "issues": "https://github.com/thephpleague/flysystem/issues",
-                "source": "https://github.com/thephpleague/flysystem/tree/3.33.0"
+                "source": "https://github.com/thephpleague/flysystem/tree/3.35.2"
             },
-            "time": "2026-03-25T07:59:30+00:00"
+            "time": "2026-07-06T14:42:07+00:00"
         },
         {
             "name": "league/flysystem-local",
@@ -2358,16 +2448,16 @@
         },
         {
             "name": "nette/utils",
-            "version": "v4.1.3",
+            "version": "v4.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/utils.git",
-                "reference": "bb3ea637e3d131d72acc033cfc2746ee893349fe"
+                "reference": "7da6c396d7ebe142bc857c20479d5e70a5e1aac7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/utils/zipball/bb3ea637e3d131d72acc033cfc2746ee893349fe",
-                "reference": "bb3ea637e3d131d72acc033cfc2746ee893349fe",
+                "url": "https://api.github.com/repos/nette/utils/zipball/7da6c396d7ebe142bc857c20479d5e70a5e1aac7",
+                "reference": "7da6c396d7ebe142bc857c20479d5e70a5e1aac7",
                 "shasum": ""
             },
             "require": {
@@ -2443,9 +2533,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nette/utils/issues",
-                "source": "https://github.com/nette/utils/tree/v4.1.3"
+                "source": "https://github.com/nette/utils/tree/v4.1.4"
             },
-            "time": "2026-02-13T03:05:33+00:00"
+            "time": "2026-05-11T20:49:54+00:00"
         },
         {
             "name": "nunomaduro/termwind",
@@ -3143,20 +3233,20 @@
         },
         {
             "name": "ramsey/uuid",
-            "version": "4.9.2",
+            "version": "4.9.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ramsey/uuid.git",
-                "reference": "8429c78ca35a09f27565311b98101e2826affde0"
+                "reference": "1df15849d00943a67d677dc9cfd80795f038c9f8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ramsey/uuid/zipball/8429c78ca35a09f27565311b98101e2826affde0",
-                "reference": "8429c78ca35a09f27565311b98101e2826affde0",
+                "url": "https://api.github.com/repos/ramsey/uuid/zipball/1df15849d00943a67d677dc9cfd80795f038c9f8",
+                "reference": "1df15849d00943a67d677dc9cfd80795f038c9f8",
                 "shasum": ""
             },
             "require": {
-                "brick/math": "^0.8.16 || ^0.9 || ^0.10 || ^0.11 || ^0.12 || ^0.13 || ^0.14",
+                "brick/math": ">=0.8.16 <=0.18",
                 "php": "^8.0",
                 "ramsey/collection": "^1.2 || ^2.0"
             },
@@ -3215,26 +3305,26 @@
             ],
             "support": {
                 "issues": "https://github.com/ramsey/uuid/issues",
-                "source": "https://github.com/ramsey/uuid/tree/4.9.2"
+                "source": "https://github.com/ramsey/uuid/tree/4.9.3"
             },
-            "time": "2025-12-14T04:43:48+00:00"
+            "time": "2026-06-18T03:57:49+00:00"
         },
         {
             "name": "symfony/clock",
-            "version": "v8.0.8",
+            "version": "v8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/clock.git",
-                "reference": "b55a638b189a6faa875e0ccdb00908fb87af95b3"
+                "reference": "701ef4de9705d6c32292ebee5e8044094a09fbf6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/clock/zipball/b55a638b189a6faa875e0ccdb00908fb87af95b3",
-                "reference": "b55a638b189a6faa875e0ccdb00908fb87af95b3",
+                "url": "https://api.github.com/repos/symfony/clock/zipball/701ef4de9705d6c32292ebee5e8044094a09fbf6",
+                "reference": "701ef4de9705d6c32292ebee5e8044094a09fbf6",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4",
+                "php": ">=8.4.1",
                 "psr/clock": "^1.0"
             },
             "provide": {
@@ -3274,7 +3364,7 @@
                 "time"
             ],
             "support": {
-                "source": "https://github.com/symfony/clock/tree/v8.0.8"
+                "source": "https://github.com/symfony/clock/tree/v8.1.0"
             },
             "funding": [
                 {
@@ -3294,20 +3384,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-30T15:14:47+00:00"
+            "time": "2026-05-29T05:06:50+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v7.4.9",
+            "version": "v7.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "d7d2b64a45a89d607865927b176fa51c33ddbb58"
+                "reference": "92f58bc4bf97a92ed1b9f367f0cd44f20bde0e87"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/d7d2b64a45a89d607865927b176fa51c33ddbb58",
-                "reference": "d7d2b64a45a89d607865927b176fa51c33ddbb58",
+                "url": "https://api.github.com/repos/symfony/console/zipball/92f58bc4bf97a92ed1b9f367f0cd44f20bde0e87",
+                "reference": "92f58bc4bf97a92ed1b9f367f0cd44f20bde0e87",
                 "shasum": ""
             },
             "require": {
@@ -3372,7 +3462,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v7.4.9"
+                "source": "https://github.com/symfony/console/tree/v7.4.14"
             },
             "funding": [
                 {
@@ -3392,24 +3482,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-22T15:21:55+00:00"
+            "time": "2026-06-16T11:50:14+00:00"
         },
         {
             "name": "symfony/css-selector",
-            "version": "v8.0.9",
+            "version": "v8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
-                "reference": "3665cfade90565430909b906394c73c8739e57d0"
+                "reference": "dc0e2be45c9b5588c82414f02ac574b4b986abcd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/css-selector/zipball/3665cfade90565430909b906394c73c8739e57d0",
-                "reference": "3665cfade90565430909b906394c73c8739e57d0",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/dc0e2be45c9b5588c82414f02ac574b4b986abcd",
+                "reference": "dc0e2be45c9b5588c82414f02ac574b4b986abcd",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4"
+                "php": ">=8.4.1"
             },
             "type": "library",
             "autoload": {
@@ -3441,7 +3531,7 @@
             "description": "Converts CSS selectors to XPath expressions",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/css-selector/tree/v8.0.9"
+                "source": "https://github.com/symfony/css-selector/tree/v8.1.0"
             },
             "funding": [
                 {
@@ -3461,20 +3551,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-18T13:51:42+00:00"
+            "time": "2026-05-29T05:06:50+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.6.0",
+            "version": "v3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62"
+                "reference": "f3202fa1b5097b0af062dc978b32ecf63404e31d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/63afe740e99a13ba87ec199bb07bbdee937a5b62",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/f3202fa1b5097b0af062dc978b32ecf63404e31d",
+                "reference": "f3202fa1b5097b0af062dc978b32ecf63404e31d",
                 "shasum": ""
             },
             "require": {
@@ -3487,7 +3577,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -3512,7 +3602,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.6.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.1"
             },
             "funding": [
                 {
@@ -3524,24 +3614,28 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:21:43+00:00"
+            "time": "2026-06-05T06:23:12+00:00"
         },
         {
             "name": "symfony/error-handler",
-            "version": "v7.4.8",
+            "version": "v7.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/error-handler.git",
-                "reference": "8dd79d8af777ee6cba2fd4d98da6ffb839f3c0fa"
+                "reference": "4e1a093b481f323e6e326451f9760c3868430673"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/error-handler/zipball/8dd79d8af777ee6cba2fd4d98da6ffb839f3c0fa",
-                "reference": "8dd79d8af777ee6cba2fd4d98da6ffb839f3c0fa",
+                "url": "https://api.github.com/repos/symfony/error-handler/zipball/4e1a093b481f323e6e326451f9760c3868430673",
+                "reference": "4e1a093b481f323e6e326451f9760c3868430673",
                 "shasum": ""
             },
             "require": {
@@ -3590,7 +3684,7 @@
             "description": "Provides tools to manage errors and ease debugging PHP code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/error-handler/tree/v7.4.8"
+                "source": "https://github.com/symfony/error-handler/tree/v7.4.14"
             },
             "funding": [
                 {
@@ -3610,24 +3704,25 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-24T13:12:05+00:00"
+            "time": "2026-06-05T06:22:21+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v8.0.9",
+            "version": "v8.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "0c3c1a17604c4dbbec4b93fe162c538482096e1f"
+                "reference": "abd6c11dc468725d1627302ad10f6cd486e9e3d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/0c3c1a17604c4dbbec4b93fe162c538482096e1f",
-                "reference": "0c3c1a17604c4dbbec4b93fe162c538482096e1f",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/abd6c11dc468725d1627302ad10f6cd486e9e3d0",
+                "reference": "abd6c11dc468725d1627302ad10f6cd486e9e3d0",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4",
+                "php": ">=8.4.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/event-dispatcher-contracts": "^2.5|^3"
             },
             "conflict": {
@@ -3675,7 +3770,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v8.0.9"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v8.1.1"
             },
             "funding": [
                 {
@@ -3695,20 +3790,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-18T13:51:42+00:00"
+            "time": "2026-06-09T12:28:30+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
-            "version": "v3.6.0",
+            "version": "v3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher-contracts.git",
-                "reference": "59eb412e93815df44f05f342958efa9f46b1e586"
+                "reference": "c7de7a00ffb67842132da02ea92988a39ccd9f4e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/59eb412e93815df44f05f342958efa9f46b1e586",
-                "reference": "59eb412e93815df44f05f342958efa9f46b1e586",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/c7de7a00ffb67842132da02ea92988a39ccd9f4e",
+                "reference": "c7de7a00ffb67842132da02ea92988a39ccd9f4e",
                 "shasum": ""
             },
             "require": {
@@ -3722,7 +3817,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -3755,7 +3850,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.6.0"
+                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.7.1"
             },
             "funding": [
                 {
@@ -3767,24 +3862,28 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:21:43+00:00"
+            "time": "2026-06-05T06:23:12+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v7.4.8",
+            "version": "v7.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "e0be088d22278583a82da281886e8c3592fbf149"
+                "reference": "13b38720174286f55d1761152b575a8d1436fc25"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/e0be088d22278583a82da281886e8c3592fbf149",
-                "reference": "e0be088d22278583a82da281886e8c3592fbf149",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/13b38720174286f55d1761152b575a8d1436fc25",
+                "reference": "13b38720174286f55d1761152b575a8d1436fc25",
                 "shasum": ""
             },
             "require": {
@@ -3819,7 +3918,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v7.4.8"
+                "source": "https://github.com/symfony/finder/tree/v7.4.14"
             },
             "funding": [
                 {
@@ -3839,20 +3938,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-24T13:12:05+00:00"
+            "time": "2026-06-27T08:31:18+00:00"
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v7.4.8",
+            "version": "v7.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "9381209597ec66c25be154cbf2289076e64d1eab"
+                "reference": "06db5ae1552177bf8572f8908839f12e3c06aed3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/9381209597ec66c25be154cbf2289076e64d1eab",
-                "reference": "9381209597ec66c25be154cbf2289076e64d1eab",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/06db5ae1552177bf8572f8908839f12e3c06aed3",
+                "reference": "06db5ae1552177bf8572f8908839f12e3c06aed3",
                 "shasum": ""
             },
             "require": {
@@ -3901,7 +4000,7 @@
             "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-foundation/tree/v7.4.8"
+                "source": "https://github.com/symfony/http-foundation/tree/v7.4.14"
             },
             "funding": [
                 {
@@ -3921,20 +4020,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-24T13:12:05+00:00"
+            "time": "2026-06-11T07:31:44+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v7.4.8",
+            "version": "v7.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "017e76ad089bac281553389269e259e155935e1a"
+                "reference": "e99af79b1e776646eda0e1c23b7b45c184ff99be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/017e76ad089bac281553389269e259e155935e1a",
-                "reference": "017e76ad089bac281553389269e259e155935e1a",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/e99af79b1e776646eda0e1c23b7b45c184ff99be",
+                "reference": "e99af79b1e776646eda0e1c23b7b45c184ff99be",
                 "shasum": ""
             },
             "require": {
@@ -4020,7 +4119,7 @@
             "description": "Provides a structured process for converting a Request into a Response",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-kernel/tree/v7.4.8"
+                "source": "https://github.com/symfony/http-kernel/tree/v7.4.14"
             },
             "funding": [
                 {
@@ -4040,20 +4139,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-31T20:57:01+00:00"
+            "time": "2026-06-27T09:14:35+00:00"
         },
         {
             "name": "symfony/mailer",
-            "version": "v7.4.8",
+            "version": "v7.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mailer.git",
-                "reference": "f6ea532250b476bfc1b56699b388a1bdbf168f62"
+                "reference": "f88ce03ae73e3edb5c176ce1f337709996e88495"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mailer/zipball/f6ea532250b476bfc1b56699b388a1bdbf168f62",
-                "reference": "f6ea532250b476bfc1b56699b388a1bdbf168f62",
+                "url": "https://api.github.com/repos/symfony/mailer/zipball/f88ce03ae73e3edb5c176ce1f337709996e88495",
+                "reference": "f88ce03ae73e3edb5c176ce1f337709996e88495",
                 "shasum": ""
             },
             "require": {
@@ -4104,7 +4203,7 @@
             "description": "Helps sending emails",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/mailer/tree/v7.4.8"
+                "source": "https://github.com/symfony/mailer/tree/v7.4.14"
             },
             "funding": [
                 {
@@ -4124,20 +4223,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-24T13:12:05+00:00"
+            "time": "2026-06-13T08:51:35+00:00"
         },
         {
             "name": "symfony/mime",
-            "version": "v7.4.9",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mime.git",
-                "reference": "2d550c4758ba4c47519a6667c36553d535705b0c"
+                "reference": "a845722765c4f6b2ce88beaf4f4479975b186770"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mime/zipball/2d550c4758ba4c47519a6667c36553d535705b0c",
-                "reference": "2d550c4758ba4c47519a6667c36553d535705b0c",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/a845722765c4f6b2ce88beaf4f4479975b186770",
+                "reference": "a845722765c4f6b2ce88beaf4f4479975b186770",
                 "shasum": ""
             },
             "require": {
@@ -4193,7 +4292,7 @@
                 "mime-type"
             ],
             "support": {
-                "source": "https://github.com/symfony/mime/tree/v7.4.9"
+                "source": "https://github.com/symfony/mime/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -4213,7 +4312,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-29T13:21:53+00:00"
+            "time": "2026-05-23T16:22:37+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -4300,16 +4399,16 @@
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.37.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "4864388bfbd3001ce88e234fab652acd91fdc57e"
+                "reference": "e9247d281d694a5120554d9afaf54e070e88a603"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/4864388bfbd3001ce88e234fab652acd91fdc57e",
-                "reference": "4864388bfbd3001ce88e234fab652acd91fdc57e",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/e9247d281d694a5120554d9afaf54e070e88a603",
+                "reference": "e9247d281d694a5120554d9afaf54e070e88a603",
                 "shasum": ""
             },
             "require": {
@@ -4358,7 +4457,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -4378,20 +4477,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-26T13:13:48+00:00"
+            "time": "2026-05-26T05:58:03+00:00"
         },
         {
             "name": "symfony/polyfill-intl-idn",
-            "version": "v1.37.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-idn.git",
-                "reference": "9614ac4d8061dc257ecc64cba1b140873dce8ad3"
+                "reference": "dc21118016c039a66235cf93d96b435ffb282412"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/9614ac4d8061dc257ecc64cba1b140873dce8ad3",
-                "reference": "9614ac4d8061dc257ecc64cba1b140873dce8ad3",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/dc21118016c039a66235cf93d96b435ffb282412",
+                "reference": "dc21118016c039a66235cf93d96b435ffb282412",
                 "shasum": ""
             },
             "require": {
@@ -4445,7 +4544,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -4465,20 +4564,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-10T14:38:51+00:00"
+            "time": "2026-05-25T15:22:23+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.37.0",
+            "version": "v1.38.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "3833d7255cc303546435cb650316bff708a1c75c"
+                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/3833d7255cc303546435cb650316bff708a1c75c",
-                "reference": "3833d7255cc303546435cb650316bff708a1c75c",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/2d446c214bdbe5b71bde5011b060a05fece3ae6b",
+                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b",
                 "shasum": ""
             },
             "require": {
@@ -4530,7 +4629,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.38.0"
             },
             "funding": [
                 {
@@ -4550,20 +4649,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-05-25T13:48:31+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.37.0",
+            "version": "v1.38.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315"
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6a21eb99c6973357967f6ce3708cd55a6bec6315",
-                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
                 "shasum": ""
             },
             "require": {
@@ -4615,7 +4714,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.38.2"
             },
             "funding": [
                 {
@@ -4635,7 +4734,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-10T17:25:58+00:00"
+            "time": "2026-05-27T06:59:30+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
@@ -4723,16 +4822,16 @@
         },
         {
             "name": "symfony/polyfill-php83",
-            "version": "v1.37.0",
+            "version": "v1.38.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php83.git",
-                "reference": "3600c2cb22399e25bb226e4a135ce91eeb2a6149"
+                "reference": "796a26abb75ce49f3a84433cd81bf1009d73d5f8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/3600c2cb22399e25bb226e4a135ce91eeb2a6149",
-                "reference": "3600c2cb22399e25bb226e4a135ce91eeb2a6149",
+                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/796a26abb75ce49f3a84433cd81bf1009d73d5f8",
+                "reference": "796a26abb75ce49f3a84433cd81bf1009d73d5f8",
                 "shasum": ""
             },
             "require": {
@@ -4779,7 +4878,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php83/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-php83/tree/v1.38.2"
             },
             "funding": [
                 {
@@ -4799,20 +4898,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-10T17:25:58+00:00"
+            "time": "2026-05-27T06:51:48+00:00"
         },
         {
             "name": "symfony/polyfill-php84",
-            "version": "v1.37.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php84.git",
-                "reference": "88486db2c389b290bf87ff1de7ebc1e13e42bb06"
+                "reference": "f4e1dfaee5b74aba5964fe1fd4dfc7ba5e3085fa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php84/zipball/88486db2c389b290bf87ff1de7ebc1e13e42bb06",
-                "reference": "88486db2c389b290bf87ff1de7ebc1e13e42bb06",
+                "url": "https://api.github.com/repos/symfony/polyfill-php84/zipball/f4e1dfaee5b74aba5964fe1fd4dfc7ba5e3085fa",
+                "reference": "f4e1dfaee5b74aba5964fe1fd4dfc7ba5e3085fa",
                 "shasum": ""
             },
             "require": {
@@ -4859,7 +4958,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php84/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-php84/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -4879,20 +4978,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-10T18:47:49+00:00"
+            "time": "2026-05-26T12:51:13+00:00"
         },
         {
             "name": "symfony/polyfill-php85",
-            "version": "v1.37.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php85.git",
-                "reference": "fcfa4973a9917cef23f2e38774da74a2b7d115ee"
+                "reference": "ba2ba04f3352cfa2dcbbcb90aee13ed967f505b1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php85/zipball/fcfa4973a9917cef23f2e38774da74a2b7d115ee",
-                "reference": "fcfa4973a9917cef23f2e38774da74a2b7d115ee",
+                "url": "https://api.github.com/repos/symfony/polyfill-php85/zipball/ba2ba04f3352cfa2dcbbcb90aee13ed967f505b1",
+                "reference": "ba2ba04f3352cfa2dcbbcb90aee13ed967f505b1",
                 "shasum": ""
             },
             "require": {
@@ -4939,7 +5038,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php85/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-php85/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -4959,7 +5058,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-26T13:10:57+00:00"
+            "time": "2026-05-26T02:25:22+00:00"
         },
         {
             "name": "symfony/polyfill-uuid",
@@ -5046,16 +5145,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v7.4.8",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "60f19cd3badc8de688421e21e4305eba50f8089a"
+                "reference": "f5804be144caceb570f6747519999636b664f24c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/60f19cd3badc8de688421e21e4305eba50f8089a",
-                "reference": "60f19cd3badc8de688421e21e4305eba50f8089a",
+                "url": "https://api.github.com/repos/symfony/process/zipball/f5804be144caceb570f6747519999636b664f24c",
+                "reference": "f5804be144caceb570f6747519999636b664f24c",
                 "shasum": ""
             },
             "require": {
@@ -5087,7 +5186,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v7.4.8"
+                "source": "https://github.com/symfony/process/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -5107,20 +5206,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-24T13:12:05+00:00"
+            "time": "2026-05-23T16:05:06+00:00"
         },
         {
             "name": "symfony/routing",
-            "version": "v7.4.9",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "287771d8bc86eacb30678dd10eda6c64a859951f"
+                "reference": "3a162171bb008e5e0f15dce6581373a4c0e8390d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/287771d8bc86eacb30678dd10eda6c64a859951f",
-                "reference": "287771d8bc86eacb30678dd10eda6c64a859951f",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/3a162171bb008e5e0f15dce6581373a4c0e8390d",
+                "reference": "3a162171bb008e5e0f15dce6581373a4c0e8390d",
                 "shasum": ""
             },
             "require": {
@@ -5172,7 +5271,7 @@
                 "url"
             ],
             "support": {
-                "source": "https://github.com/symfony/routing/tree/v7.4.9"
+                "source": "https://github.com/symfony/routing/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -5192,20 +5291,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-22T15:21:55+00:00"
+            "time": "2026-05-24T11:20:33+00:00"
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v3.6.1",
+            "version": "v3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "45112560a3ba2d715666a509a0bc9521d10b6c43"
+                "reference": "c0a284bab1ed8aa0417e3d69250ab437739563a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/45112560a3ba2d715666a509a0bc9521d10b6c43",
-                "reference": "45112560a3ba2d715666a509a0bc9521d10b6c43",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/c0a284bab1ed8aa0417e3d69250ab437739563a0",
+                "reference": "c0a284bab1ed8aa0417e3d69250ab437739563a0",
                 "shasum": ""
             },
             "require": {
@@ -5223,7 +5322,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -5259,7 +5358,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.6.1"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.7.1"
             },
             "funding": [
                 {
@@ -5279,24 +5378,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-15T11:30:57+00:00"
+            "time": "2026-06-16T09:55:08+00:00"
         },
         {
             "name": "symfony/string",
-            "version": "v8.0.8",
+            "version": "v8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "ae9488f874d7603f9d2dfbf120203882b645d963"
+                "reference": "afd5944f4005862d961efb85c8bbd5c523c4e3c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/ae9488f874d7603f9d2dfbf120203882b645d963",
-                "reference": "ae9488f874d7603f9d2dfbf120203882b645d963",
+                "url": "https://api.github.com/repos/symfony/string/zipball/afd5944f4005862d961efb85c8bbd5c523c4e3c9",
+                "reference": "afd5944f4005862d961efb85c8bbd5c523c4e3c9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4",
+                "php": ">=8.4.1",
                 "symfony/polyfill-ctype": "^1.8",
                 "symfony/polyfill-intl-grapheme": "^1.33",
                 "symfony/polyfill-intl-normalizer": "^1.0",
@@ -5349,7 +5448,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v8.0.8"
+                "source": "https://github.com/symfony/string/tree/v8.1.0"
             },
             "funding": [
                 {
@@ -5369,24 +5468,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-30T15:14:47+00:00"
+            "time": "2026-05-29T05:06:50+00:00"
         },
         {
             "name": "symfony/translation",
-            "version": "v8.0.8",
+            "version": "v8.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "27c03ae3940de24ba2f71cfdbac824f2aa1fdf2f"
+                "reference": "342b4218630dc2cf284cedcb2080c80b13404014"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/27c03ae3940de24ba2f71cfdbac824f2aa1fdf2f",
-                "reference": "27c03ae3940de24ba2f71cfdbac824f2aa1fdf2f",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/342b4218630dc2cf284cedcb2080c80b13404014",
+                "reference": "342b4218630dc2cf284cedcb2080c80b13404014",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4",
+                "php": ">=8.4.1",
                 "symfony/polyfill-mbstring": "^1.0",
                 "symfony/translation-contracts": "^3.6.1"
             },
@@ -5442,7 +5541,7 @@
             "description": "Provides tools to internationalize your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/translation/tree/v8.0.8"
+                "source": "https://github.com/symfony/translation/tree/v8.1.1"
             },
             "funding": [
                 {
@@ -5462,20 +5561,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-30T15:14:47+00:00"
+            "time": "2026-06-06T11:11:44+00:00"
         },
         {
             "name": "symfony/translation-contracts",
-            "version": "v3.6.1",
+            "version": "v3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation-contracts.git",
-                "reference": "65a8bc82080447fae78373aa10f8d13b38338977"
+                "reference": "ccb206b98faccc511ebae8e5fad50f2dc0b30621"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/65a8bc82080447fae78373aa10f8d13b38338977",
-                "reference": "65a8bc82080447fae78373aa10f8d13b38338977",
+                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/ccb206b98faccc511ebae8e5fad50f2dc0b30621",
+                "reference": "ccb206b98faccc511ebae8e5fad50f2dc0b30621",
                 "shasum": ""
             },
             "require": {
@@ -5488,7 +5587,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -5524,7 +5623,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/translation-contracts/tree/v3.6.1"
+                "source": "https://github.com/symfony/translation-contracts/tree/v3.7.1"
             },
             "funding": [
                 {
@@ -5544,7 +5643,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-15T13:41:35+00:00"
+            "time": "2026-06-05T06:23:12+00:00"
         },
         {
             "name": "symfony/uid",
@@ -5626,16 +5725,16 @@
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v7.4.8",
+            "version": "v7.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "9510c3966f749a1d1ff0059e1eabef6cc621e7fd"
+                "reference": "9a3a56a4a1e65a5cb4f8d13801fe8ab0a170e358"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/9510c3966f749a1d1ff0059e1eabef6cc621e7fd",
-                "reference": "9510c3966f749a1d1ff0059e1eabef6cc621e7fd",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/9a3a56a4a1e65a5cb4f8d13801fe8ab0a170e358",
+                "reference": "9a3a56a4a1e65a5cb4f8d13801fe8ab0a170e358",
                 "shasum": ""
             },
             "require": {
@@ -5689,7 +5788,7 @@
                 "dump"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-dumper/tree/v7.4.8"
+                "source": "https://github.com/symfony/var-dumper/tree/v7.4.14"
             },
             "funding": [
                 {
@@ -5709,7 +5808,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-30T13:44:50+00:00"
+            "time": "2026-06-08T20:24:16+00:00"
         },
         {
             "name": "tijsverkoyen/css-to-inline-styles",
@@ -5768,16 +5867,16 @@
         },
         {
             "name": "vlucas/phpdotenv",
-            "version": "v5.6.3",
+            "version": "v5.6.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vlucas/phpdotenv.git",
-                "reference": "955e7815d677a3eaa7075231212f2110983adecc"
+                "reference": "416df702837983f8d5ff48c9c3fee4f5f57b980b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/955e7815d677a3eaa7075231212f2110983adecc",
-                "reference": "955e7815d677a3eaa7075231212f2110983adecc",
+                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/416df702837983f8d5ff48c9c3fee4f5f57b980b",
+                "reference": "416df702837983f8d5ff48c9c3fee4f5f57b980b",
                 "shasum": ""
             },
             "require": {
@@ -5836,7 +5935,7 @@
             ],
             "support": {
                 "issues": "https://github.com/vlucas/phpdotenv/issues",
-                "source": "https://github.com/vlucas/phpdotenv/tree/v5.6.3"
+                "source": "https://github.com/vlucas/phpdotenv/tree/v5.6.4"
             },
             "funding": [
                 {
@@ -5848,7 +5947,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-27T19:49:13+00:00"
+            "time": "2026-07-06T19:11:50+00:00"
         },
         {
             "name": "voku/portable-ascii",
@@ -6006,6 +6105,93 @@
                 "source": "https://github.com/ArtisanPack-UI/accessibility/tree/v2.1.1"
             },
             "time": "2026-01-09T22:13:00+00:00"
+        },
+        {
+            "name": "artisanpack-ui/ai",
+            "version": "1.0.0",
+            "dist": {
+                "type": "path",
+                "url": "../ai",
+                "reference": "082f1cd337742d34b8035d116c6c5ad8e5453fca"
+            },
+            "require": {
+                "artisanpack-ui/core": "^1.0",
+                "illuminate/support": "^12.0|^13.0",
+                "laravel/ai": "^0.8",
+                "php": "^8.3"
+            },
+            "require-dev": {
+                "artisanpack-ui/code-style": "^1.1",
+                "artisanpack-ui/code-style-pint": "^1.1",
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "friendsofphp/php-cs-fixer": "^3.75",
+                "laravel/pint": "^1.26",
+                "livewire/livewire": "^3.6",
+                "orchestra/testbench": "^10.2|^11.0",
+                "pestphp/pest": "^3.8|^4.0",
+                "pestphp/pest-plugin-laravel": "^3.2|^4.1"
+            },
+            "suggest": {
+                "artisanpack-ui/cms-framework": "Automatically registers AI credentials, features, budget and cache setting groups under the CMS admin surface.",
+                "artisanpack-ui/livewire-ui-components": "Renders the AI Settings and Usage admin surfaces using x-artisanpack-* components.",
+                "livewire/livewire": "Required to mount the AI Settings and Usage dashboard Livewire components under cms-framework's admin nav."
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "ArtisanPackUI\\Ai\\AiServiceProvider"
+                    ],
+                    "aliases": {
+                        "Ai": "ArtisanPackUI\\Ai\\Facades\\Ai"
+                    }
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "ArtisanPackUI\\Ai\\": "src/"
+                },
+                "files": [
+                    "src/helpers.php"
+                ]
+            },
+            "autoload-dev": {
+                "psr-4": {
+                    "Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "lint": [
+                    "./vendor/bin/php-cs-fixer fix --dry-run --diff",
+                    "./vendor/bin/phpcs"
+                ],
+                "fix": [
+                    "./vendor/bin/php-cs-fixer fix"
+                ],
+                "cs": [
+                    "./vendor/bin/phpcs"
+                ],
+                "cs:fix": [
+                    "./vendor/bin/phpcbf"
+                ],
+                "test": [
+                    "./vendor/bin/pest"
+                ]
+            },
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jacob Martella",
+                    "email": "me@jacobmartella.com"
+                }
+            ],
+            "description": "Shared AI foundation for the ArtisanPack UI ecosystem, built on top of laravel/ai.",
+            "transport-options": {
+                "symlink": true,
+                "relative": true
+            }
         },
         {
             "name": "artisanpack-ui/cms-framework",
@@ -6316,6 +6502,157 @@
             "time": "2025-05-14T21:45:20+00:00"
         },
         {
+            "name": "aws/aws-crt-php",
+            "version": "v1.2.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/awslabs/aws-crt-php.git",
+                "reference": "d71d9906c7bb63a28295447ba12e74723bd3730e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/awslabs/aws-crt-php/zipball/d71d9906c7bb63a28295447ba12e74723bd3730e",
+                "reference": "d71d9906c7bb63a28295447ba12e74723bd3730e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35||^5.6.3||^9.5",
+                "yoast/phpunit-polyfills": "^1.0"
+            },
+            "suggest": {
+                "ext-awscrt": "Make sure you install awscrt native extension to use any of the functionality."
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "AWS SDK Common Runtime Team",
+                    "email": "aws-sdk-common-runtime@amazon.com"
+                }
+            ],
+            "description": "AWS Common Runtime for PHP",
+            "homepage": "https://github.com/awslabs/aws-crt-php",
+            "keywords": [
+                "amazon",
+                "aws",
+                "crt",
+                "sdk"
+            ],
+            "support": {
+                "issues": "https://github.com/awslabs/aws-crt-php/issues",
+                "source": "https://github.com/awslabs/aws-crt-php/tree/v1.2.7"
+            },
+            "time": "2024-10-18T22:15:13+00:00"
+        },
+        {
+            "name": "aws/aws-sdk-php",
+            "version": "3.388.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/aws/aws-sdk-php.git",
+                "reference": "6dd9a0674641ef7d302a50cc8f275eb443182dc9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/6dd9a0674641ef7d302a50cc8f275eb443182dc9",
+                "reference": "6dd9a0674641ef7d302a50cc8f275eb443182dc9",
+                "shasum": ""
+            },
+            "require": {
+                "aws/aws-crt-php": "^1.2.3",
+                "ext-json": "*",
+                "ext-pcre": "*",
+                "ext-simplexml": "*",
+                "guzzlehttp/guzzle": "^7.4.5",
+                "guzzlehttp/promises": "^2.0",
+                "guzzlehttp/psr7": "^2.4.5",
+                "mtdowling/jmespath.php": "^2.9.1",
+                "php": ">=8.1",
+                "psr/http-message": "^1.0 || ^2.0",
+                "symfony/filesystem": "^v5.4.45 || ^v6.4.3 || ^v7.1.0 || ^v8.0.0"
+            },
+            "require-dev": {
+                "andrewsville/php-token-reflection": "^1.4",
+                "aws/aws-php-sns-message-validator": "~1.0",
+                "behat/behat": "~3.0",
+                "composer/composer": "^2.7.8",
+                "dms/phpunit-arraysubset-asserts": "^v0.5.0",
+                "doctrine/cache": "~1.4",
+                "ext-dom": "*",
+                "ext-openssl": "*",
+                "ext-sockets": "*",
+                "phpunit/phpunit": "^10.0",
+                "psr/cache": "^2.0 || ^3.0",
+                "psr/simple-cache": "^2.0 || ^3.0",
+                "sebastian/comparator": "^1.2.3 || ^4.0 || ^5.0",
+                "yoast/phpunit-polyfills": "^2.0"
+            },
+            "suggest": {
+                "aws/aws-php-sns-message-validator": "To validate incoming SNS notifications",
+                "doctrine/cache": "To use the DoctrineCacheAdapter",
+                "ext-curl": "To send requests using cURL",
+                "ext-openssl": "Allows working with CloudFront private distributions and verifying received SNS messages",
+                "ext-pcntl": "To use client-side monitoring",
+                "ext-sockets": "To use client-side monitoring"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Aws\\": "src/"
+                },
+                "exclude-from-classmap": [
+                    "src/data/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Amazon Web Services",
+                    "homepage": "https://aws.amazon.com"
+                }
+            ],
+            "description": "AWS SDK for PHP - Use Amazon Web Services in your PHP project",
+            "homepage": "https://aws.amazon.com/sdk-for-php",
+            "keywords": [
+                "amazon",
+                "aws",
+                "cloud",
+                "dynamodb",
+                "ec2",
+                "glacier",
+                "s3",
+                "sdk"
+            ],
+            "support": {
+                "forum": "https://github.com/aws/aws-sdk-php/discussions",
+                "issues": "https://github.com/aws/aws-sdk-php/issues",
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.388.0"
+            },
+            "time": "2026-07-07T18:11:48+00:00"
+        },
+        {
             "name": "blade-ui-kit/blade-icons",
             "version": "1.10.0",
             "source": {
@@ -6488,83 +6825,6 @@
                 }
             ],
             "time": "2025-06-23T06:07:21+00:00"
-        },
-        {
-            "name": "composer/semver",
-            "version": "3.4.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/composer/semver.git",
-                "reference": "198166618906cb2de69b95d7d47e5fa8aa1b2b95"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/composer/semver/zipball/198166618906cb2de69b95d7d47e5fa8aa1b2b95",
-                "reference": "198166618906cb2de69b95d7d47e5fa8aa1b2b95",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.3.2 || ^7.0 || ^8.0"
-            },
-            "require-dev": {
-                "phpstan/phpstan": "^1.11",
-                "symfony/phpunit-bridge": "^3 || ^7"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "3.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Composer\\Semver\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nils Adermann",
-                    "email": "naderman@naderman.de",
-                    "homepage": "http://www.naderman.de"
-                },
-                {
-                    "name": "Jordi Boggiano",
-                    "email": "j.boggiano@seld.be",
-                    "homepage": "http://seld.be"
-                },
-                {
-                    "name": "Rob Bast",
-                    "email": "rob.bast@gmail.com",
-                    "homepage": "http://robbast.nl"
-                }
-            ],
-            "description": "Semver library that offers utilities, version constraint parsing and validation.",
-            "keywords": [
-                "semantic",
-                "semver",
-                "validation",
-                "versioning"
-            ],
-            "support": {
-                "irc": "ircs://irc.libera.chat:6697/composer",
-                "issues": "https://github.com/composer/semver/issues",
-                "source": "https://github.com/composer/semver/tree/3.4.4"
-            },
-            "funding": [
-                {
-                    "url": "https://packagist.com",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/composer",
-                    "type": "github"
-                }
-            ],
-            "time": "2025-08-20T19:15:30+00:00"
         },
         {
             "name": "dedoc/scramble",
@@ -7137,6 +7397,80 @@
             "time": "2025-10-14T18:31:13+00:00"
         },
         {
+            "name": "laravel/ai",
+            "version": "v0.8.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/ai.git",
+                "reference": "b23bc857576d7c4b3bb52ffd8be936ae74005d23"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/ai/zipball/b23bc857576d7c4b3bb52ffd8be936ae74005d23",
+                "reference": "b23bc857576d7c4b3bb52ffd8be936ae74005d23",
+                "shasum": ""
+            },
+            "require": {
+                "aws/aws-sdk-php": "^3.339",
+                "illuminate/console": "^12.0|^13.0",
+                "illuminate/container": "^12.0|^13.0",
+                "illuminate/contracts": "^12.0|^13.0",
+                "illuminate/database": "^12.0|^13.0",
+                "illuminate/filesystem": "^12.0|^13.0",
+                "illuminate/json-schema": "^12.62|^13.15",
+                "illuminate/support": "^12.0|^13.0",
+                "laravel/prompts": "^0.3.6",
+                "laravel/serializable-closure": "^2.0",
+                "php": "^8.3"
+            },
+            "require-dev": {
+                "laravel/mcp": "^0.8",
+                "laravel/pint": "^1.26",
+                "mockery/mockery": "^1.6.12",
+                "orchestra/testbench": "^10.6|^11.0",
+                "pestphp/pest": "^3.0|^4.0",
+                "pestphp/pest-plugin-laravel": "^3.0|^4.0",
+                "phpstan/phpstan": "^2.1"
+            },
+            "suggest": {
+                "laravel/mcp": "Required to use MCP client tools or MCP server tools with Laravel AI agents."
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Laravel\\Ai\\AiServiceProvider"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "functions.php"
+                ],
+                "psr-4": {
+                    "Laravel\\Ai\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "The official AI SDK for Laravel.",
+            "homepage": "https://github.com/laravel/ai",
+            "keywords": [
+                "ai",
+                "laravel"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/ai/issues",
+                "source": "https://github.com/laravel/ai"
+            },
+            "time": "2026-06-10T11:23:35+00:00"
+        },
+        {
             "name": "laravel/pail",
             "version": "v1.2.6",
             "source": {
@@ -7346,6 +7680,82 @@
             "time": "2026-02-06T14:12:35+00:00"
         },
         {
+            "name": "livewire/livewire",
+            "version": "v3.8.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/livewire/livewire.git",
+                "reference": "e77fce60d0615d68dc6b8fafe98a6739d9752a24"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/livewire/livewire/zipball/e77fce60d0615d68dc6b8fafe98a6739d9752a24",
+                "reference": "e77fce60d0615d68dc6b8fafe98a6739d9752a24",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/database": "^10.0|^11.0|^12.0|^13.0",
+                "illuminate/routing": "^10.0|^11.0|^12.0|^13.0",
+                "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
+                "illuminate/validation": "^10.0|^11.0|^12.0|^13.0",
+                "laravel/prompts": "^0.1.24|^0.2|^0.3",
+                "league/mime-type-detection": "^1.9",
+                "php": "^8.1",
+                "symfony/console": "^6.0|^7.0|^8.0",
+                "symfony/http-kernel": "^6.2|^7.0|^8.0"
+            },
+            "require-dev": {
+                "calebporzio/sushi": "^2.1",
+                "laravel/framework": "^10.15.0|^11.0|^12.0|^13.0",
+                "mockery/mockery": "^1.3.1",
+                "orchestra/testbench": "^8.21.0|^9.0|^10.0|^11.0",
+                "orchestra/testbench-dusk": "^8.24|^9.1|^10.0|^11.0",
+                "phpunit/phpunit": "^10.4|^11.5|^12.5",
+                "psy/psysh": "^0.11.22|^0.12"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "Livewire": "Livewire\\Livewire"
+                    },
+                    "providers": [
+                        "Livewire\\LivewireServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "Livewire\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Caleb Porzio",
+                    "email": "calebporzio@gmail.com"
+                }
+            ],
+            "description": "A front-end framework for Laravel.",
+            "support": {
+                "issues": "https://github.com/livewire/livewire/issues",
+                "source": "https://github.com/livewire/livewire/tree/v3.8.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/livewire",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-06-27T03:14:20+00:00"
+        },
+        {
             "name": "marc-mabe/php-enum",
             "version": "v4.7.2",
             "source": {
@@ -7500,6 +7910,72 @@
                 "source": "https://github.com/mockery/mockery"
             },
             "time": "2024-05-16T03:13:13+00:00"
+        },
+        {
+            "name": "mtdowling/jmespath.php",
+            "version": "2.9.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/jmespath/jmespath.php.git",
+                "reference": "2157c5e50e813ec6a96c1eed3be7f64a20fb32a8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/jmespath/jmespath.php/zipball/2157c5e50e813ec6a96c1eed3be7f64a20fb32a8",
+                "reference": "2157c5e50e813ec6a96c1eed3be7f64a20fb32a8",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5 || ^8.0",
+                "symfony/polyfill-mbstring": "^1.17"
+            },
+            "require-dev": {
+                "composer/xdebug-handler": "^3.0.3",
+                "phpunit/phpunit": "^8.5.52"
+            },
+            "bin": [
+                "bin/jp.php"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.9-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/JmesPath.php"
+                ],
+                "psr-4": {
+                    "JmesPath\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Declaratively specify how to extract elements from a JSON document",
+            "keywords": [
+                "json",
+                "jsonpath"
+            ],
+            "support": {
+                "issues": "https://github.com/jmespath/jmespath.php/issues",
+                "source": "https://github.com/jmespath/jmespath.php/tree/2.9.2"
+            },
+            "time": "2026-07-06T18:56:19+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -10494,6 +10970,77 @@
             "time": "2024-10-20T05:08:20+00:00"
         },
         {
+            "name": "symfony/filesystem",
+            "version": "v8.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/filesystem.git",
+                "reference": "99aec13b82b4967ec5088222c4a3ecca955949c2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/99aec13b82b4967ec5088222c4a3ecca955949c2",
+                "reference": "99aec13b82b4967ec5088222c4a3ecca955949c2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-mbstring": "~1.8"
+            },
+            "require-dev": {
+                "symfony/process": "^7.4|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Filesystem\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides basic utilities for the filesystem",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/filesystem/tree/v8.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-29T05:06:50+00:00"
+        },
+        {
             "name": "symfony/yaml",
             "version": "v7.4.8",
             "source": {
@@ -10746,5 +11293,5 @@
         "php": "^8.2"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "921d251a9b060150da05cb1c42280dbb",
+    "content-hash": "c6ad8bd9847164482fa143507014f97d",
     "packages": [
         {
             "name": "artisanpack-ui/core",

--- a/docs/ai-features.md
+++ b/docs/ai-features.md
@@ -1,0 +1,145 @@
+---
+title: AI Features
+---
+
+# AI Features
+
+The visual editor ships five optional AI-powered authoring affordances
+that build on top of the [`artisanpack-ui/ai`](https://github.com/ArtisanPack-UI/ai)
+foundation. All five default to *off* — hosts opt in by enabling the
+corresponding feature key from the AI package's settings surface, and
+each affordance honors that toggle before rendering.
+
+Every affordance surfaces as a **suggestion** — never an automatic
+mutation. Accepting a suggestion is always explicit user action, per
+the AI RFC.
+
+> **Introduced in v1.3.0.**
+
+---
+
+## Features
+
+| Feature key                          | Agent                                | What it does                                                                                                                     |
+|--------------------------------------|--------------------------------------|----------------------------------------------------------------------------------------------------------------------------------|
+| `visual_editor.suggest_next_block`   | `ContentBlockSuggestionAgent`        | Inline "+ suggest" affordance ranks likely next blocks given the document so far.                                                |
+| `visual_editor.suggest_layout`       | `LayoutSuggestionAgent`              | Given a section's content + your available pattern library, ranks matching section patterns.                                     |
+| `visual_editor.heading_hierarchy`    | `HeadingHierarchyAgent`              | Audits the document for skipped levels, duplicate h1s, and ambiguous headings; returns suggested fixes.                          |
+| `ai.alt_text`                        | `AltTextGenerationAgent` (from `ai`) | Suggests accessibility-friendly alt text when an image block is added or its `src` changes and `alt` is empty.                   |
+| `ai.content_rewrite`                 | `ContentRewriteAgent` (from `ai`)    | Selection-toolbar / slash-command surface for "make shorter", "more formal", "reading level 6", and similar rewrites.            |
+
+The first three agents live in this package (`src/Ai/Agents/`); the
+last two are cross-cutting agents consumed directly from
+`artisanpack-ui/ai` so the same prompt and feature toggle power
+alt-text and rewrites across every package that opts in.
+
+---
+
+## Server-side surface
+
+The features are auto-registered with the AI package's
+`FeatureRegistry` via `VisualEditorServiceProvider::aiFeatures()` — no
+manual wiring required. Each has a JSON endpoint under
+`/visual-editor/api/ai/*` for the React editor to hit:
+
+```
+GET  /visual-editor/api/ai/features             # { features: { <key>: bool, ... } }
+POST /visual-editor/api/ai/suggest-next-block
+POST /visual-editor/api/ai/suggest-layout
+POST /visual-editor/api/ai/alt-text
+POST /visual-editor/api/ai/rewrite
+POST /visual-editor/api/ai/heading-hierarchy
+```
+
+Every endpoint is backed by a dedicated Form Request in
+`src/Http/Requests/Ai/` and returns a consistent error envelope. All
+routes are guarded on `class_exists(FeatureRegistry)`, so hosts
+without `artisanpack-ui/ai` installed simply don't expose the surface —
+no 500s.
+
+### Livewire component
+
+Blade / Livewire hosts can consume the same triggers through the
+shipped Livewire component `artisanpack-visual-editor.ai.tools`, which
+listens for `ap-ve-ai:*` browser events and re-dispatches shaped
+results as `ap-ve-ai:{feature}:{status}` events (with statuses
+`success`, `invalid-input`, `disabled`, `missing-credentials`, and
+`error`).
+
+```blade
+<livewire:artisanpack-visual-editor.ai.tools />
+
+<script>
+    document.dispatchEvent(new CustomEvent('ap-ve-ai:suggest-next-block', {
+        detail: { existingBlocks, cursorPosition },
+    }));
+
+    document.addEventListener('ap-ve-ai:suggest-next-block:success', (e) => {
+        const { suggestions } = e.detail;
+    });
+</script>
+```
+
+---
+
+## React surface
+
+```tsx
+import {
+    createAiApiClient,
+    useAiFeatures,
+    SuggestNextBlockButton,
+    SuggestLayoutPanel,
+    AltTextSuggestionCard,
+    RewriteToolbar,
+    HeadingHierarchyPanel,
+} from '../visual-editor/ai';
+
+const client = createAiApiClient({ apiBase: '/visual-editor/api' });
+const { isEnabled } = useAiFeatures(client);
+
+{isEnabled('visual_editor.suggest_next_block') && (
+    <SuggestNextBlockButton
+        client={client}
+        existingBlocks={blocks}
+        cursorPosition={insertionIndex}
+        onPick={(suggestion) => insertBlock(suggestion.block_type)}
+    />
+)}
+```
+
+Full component list and per-feature hooks live in
+`resources/js/visual-editor/ai/index.ts`. Each feature ships:
+
+- A React UI component (`<SuggestNextBlockButton />`,
+  `<SuggestLayoutPanel />`, `<AltTextSuggestionCard />`,
+  `<RewriteToolbar />`, `<HeadingHierarchyPanel />`).
+- A dedicated hook (`useSuggestNextBlock`, `useSuggestLayout`, etc.)
+  for wiring the affordance into your own UI.
+- A shared `useAiFeatures(client)` gate that hides the surface until
+  the host has enabled the corresponding feature key.
+
+---
+
+## Requirements
+
+- `artisanpack-ui/ai` `^1.0` installed and configured with credentials.
+- The individual feature toggle enabled (default: off) from the AI
+  package's settings admin surface.
+- CSRF middleware active on the `/visual-editor/api/*` route group so
+  the shipped JS client's `X-CSRF-TOKEN` header is honored.
+
+If `artisanpack-ui/ai` is not installed, the visual editor continues
+to work as before — the AI feature registration is skipped, no routes
+are registered, and the React affordances stay hidden behind
+`useAiFeatures`.
+
+---
+
+## Related
+
+- [[Hooks and Events]] — `ap-ve-ai:*` browser events and the AI
+  package's `FeatureRegistry` extension points.
+- [`artisanpack-ui/ai`](https://github.com/ArtisanPack-UI/ai) — The
+  foundation package: agents, feature registry, credential
+  management, and provider drivers.

--- a/docs/home.md
+++ b/docs/home.md
@@ -86,6 +86,7 @@ The block library — what ships, how to author your own, and how to wire respon
 - [[Developer Guide]] — Extending and customizing the editor
 - [[Hooks and Events]] — Filters, actions, and browser events for extending functionality
 - [[Renderers]] — Blade, React, and Vue renderers for the public site
+- [[AI Features]] — Optional AI-powered authoring affordances (suggest next block, layout, alt text, rewrite, heading hierarchy) built on `artisanpack-ui/ai` (v1.3)
 
 ---
 
@@ -171,4 +172,4 @@ For issues, feature requests, and contributions:
 
 ---
 
-*This documentation covers visual-editor v1.1.1*
+*This documentation covers visual-editor v1.3.0*

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@artisanpack-ui/visual-editor",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "private": true,
     "type": "module",
     "exports": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -10,6 +10,17 @@
         </testsuite>
         <testsuite name="Feature">
             <directory>tests/Feature</directory>
+            <!--
+                AI suite depends on artisanpack-ui/ai which requires
+                PHP 8.3+. Excluded here and re-registered under a
+                dedicated `Ai` suite so CI on PHP 8.2 can drop it via
+                `exclude-testsuite=Ai` without losing the rest of the
+                Feature coverage.
+            -->
+            <exclude>tests/Feature/Ai</exclude>
+        </testsuite>
+        <testsuite name="Ai">
+            <directory>tests/Feature/Ai</directory>
         </testsuite>
         <testsuite name="RendererBlade">
             <directory>packages/visual-editor-renderer-blade/tests/Unit</directory>

--- a/resources/js/visual-editor/ai/AltTextSuggestionCard.tsx
+++ b/resources/js/visual-editor/ai/AltTextSuggestionCard.tsx
@@ -1,0 +1,122 @@
+/**
+ * Inline accept/dismiss card for AI-generated alt text (#612).
+ *
+ * Fires when an image block is added or its src changes AND the current
+ * alt is empty. Presents the suggested alt + confidence + any warnings,
+ * with explicit Accept / Dismiss actions. Never auto-applies.
+ */
+
+import { useEffect, useMemo, useRef } from 'react';
+import type { AiApiClient, AltTextInput, AltTextOutput } from './ai-api-client';
+import { useAltText } from './hooks';
+
+export interface AltTextSuggestionCardProps {
+    client: AiApiClient;
+    image: AltTextInput;
+    currentAlt: string;
+    onAccept: (suggestion: AltTextOutput) => void;
+    onDismiss: () => void;
+    /** Skip suggestion when currentAlt is already set. Defaults to true. */
+    skipIfAltSet?: boolean;
+}
+
+/**
+ * Stable identity string for an image reference. Cards re-render on
+ * every parent tick and `image` may be a fresh object each time; hashing
+ * it into a primitive lets the effect key on the actual image, not the
+ * object identity, without re-serializing on every render.
+ */
+function imageIdentity(image: AltTextInput): string {
+    if (typeof image === 'string') {
+        return `str:${image}`;
+    }
+    return `${image.source}:${image.value}`;
+}
+
+export function AltTextSuggestionCard(props: AltTextSuggestionCardProps) {
+    const { client, image, currentAlt, onAccept, onDismiss, skipIfAltSet = true } = props;
+    const call = useAltText(client);
+    const shouldRun = !skipIfAltSet || currentAlt.trim() === '';
+    const identity = useMemo(() => imageIdentity(image), [image]);
+    // Track which image identity we've already fetched for, so
+    // clear→retype→clear cycles on the alt input don't re-fire the
+    // agent for the same image (review #5). Only a change in the image
+    // itself resets the guard.
+    const fetchedIdentityRef = useRef<string | null>(null);
+
+    useEffect(() => {
+        if (!shouldRun) {
+            return;
+        }
+        if (fetchedIdentityRef.current === identity) {
+            return;
+        }
+        fetchedIdentityRef.current = identity;
+        void call.run(image);
+        // `identity` is the primitive derived from `image`; running
+        // when that changes gives us one fetch per real image. `call`
+        // and `image` are deliberately not tracked here — `call`
+        // identity churns every render, and `image` is captured through
+        // `identity`.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [shouldRun, identity]);
+
+    if (!shouldRun) {
+        return null;
+    }
+
+    if (call.status === 'loading') {
+        return (
+            <div role="status" className="ap-ve-ai-alt-card ap-ve-ai-alt-card--loading">
+                Generating alt text…
+            </div>
+        );
+    }
+
+    if (call.status === 'error') {
+        return (
+            <div role="alert" className="ap-ve-ai-alt-card ap-ve-ai-alt-card--error">
+                <p>Could not suggest alt text.</p>
+                <button type="button" onClick={onDismiss}>
+                    Dismiss
+                </button>
+            </div>
+        );
+    }
+
+    if (call.status !== 'success' || !call.result) {
+        return null;
+    }
+
+    const suggestion = call.result;
+
+    return (
+        <div className="ap-ve-ai-alt-card" data-testid="ap-ve-ai-alt-card">
+            <p className="ap-ve-ai-alt-card__label">Suggested alt text</p>
+            <p className="ap-ve-ai-alt-card__text">
+                {suggestion.alt_text.trim() === ''
+                    ? '(empty — decorative image)'
+                    : suggestion.alt_text}
+            </p>
+            {suggestion.warnings.length > 0 && (
+                <ul className="ap-ve-ai-alt-card__warnings">
+                    {suggestion.warnings.map((w, i) => (
+                        <li key={i}>{w}</li>
+                    ))}
+                </ul>
+            )}
+            <div className="ap-ve-ai-alt-card__actions">
+                <button
+                    type="button"
+                    onClick={() => onAccept(suggestion)}
+                    data-testid="ap-ve-ai-alt-accept"
+                >
+                    Accept
+                </button>
+                <button type="button" onClick={onDismiss} data-testid="ap-ve-ai-alt-dismiss">
+                    Dismiss
+                </button>
+            </div>
+        </div>
+    );
+}

--- a/resources/js/visual-editor/ai/HeadingHierarchyPanel.tsx
+++ b/resources/js/visual-editor/ai/HeadingHierarchyPanel.tsx
@@ -1,0 +1,67 @@
+/**
+ * Document-inspector panel that lists heading-hierarchy issues (#614).
+ *
+ * Runs on demand (button click) rather than on every keystroke — the
+ * heading-audit prompt is deliberately batchy. Renders `{issues}` inline
+ * with a "focus block" callback so callers can scroll the offending
+ * block into view when the writer clicks an issue.
+ */
+
+import { useCallback } from 'react';
+import type { AiApiClient, HeadingIssue } from './ai-api-client';
+import { useHeadingHierarchy } from './hooks';
+
+export interface HeadingHierarchyPanelProps {
+    client: AiApiClient;
+    blocks: readonly unknown[];
+    onFocusBlock?: (blockId: string) => void;
+    label?: string;
+}
+
+export function HeadingHierarchyPanel(props: HeadingHierarchyPanelProps) {
+    const { client, blocks, onFocusBlock, label } = props;
+    const call = useHeadingHierarchy(client);
+
+    const handleClick = useCallback(() => {
+        void call.run({ blocks });
+    }, [call, blocks]);
+
+    return (
+        <section className="ap-ve-ai-headings" data-testid="ap-ve-ai-headings">
+            <header>
+                <h3>{label ?? 'Heading hierarchy check'}</h3>
+                <button
+                    type="button"
+                    onClick={handleClick}
+                    disabled={call.status === 'loading'}
+                    data-testid="ap-ve-ai-headings-run"
+                >
+                    {call.status === 'loading' ? 'Checking…' : 'Run check'}
+                </button>
+            </header>
+
+            {call.status === 'error' && call.error && (
+                <div role="alert">{call.error.message}</div>
+            )}
+
+            {call.status === 'success' && call.result && (
+                <ul className="ap-ve-ai-headings__list">
+                    {call.result.issues.length === 0 && (
+                        <li className="ap-ve-ai-headings__clean">No heading issues found.</li>
+                    )}
+                    {call.result.issues.map((issue: HeadingIssue) => (
+                        <li key={issue.block_id} className="ap-ve-ai-headings__item">
+                            <button
+                                type="button"
+                                onClick={() => onFocusBlock?.(issue.block_id)}
+                            >
+                                <strong>{issue.issue}</strong>
+                                <div>{issue.suggestion}</div>
+                            </button>
+                        </li>
+                    ))}
+                </ul>
+            )}
+        </section>
+    );
+}

--- a/resources/js/visual-editor/ai/RewriteToolbar.tsx
+++ b/resources/js/visual-editor/ai/RewriteToolbar.tsx
@@ -1,0 +1,111 @@
+/**
+ * Selection-toolbar rewrite affordance (#613).
+ *
+ * Given the currently selected content + a rewrite intent (shorter,
+ * formal, reading level 6, ...), calls the ContentRewriteAgent and shows
+ * an accept/dismiss diff-style preview pane. Never auto-applies — the
+ * caller owns the apply flow so the editor can decide whether to replace
+ * the selection, insert alongside, or open a modal.
+ *
+ * Streaming is deliberately NOT wired here in the initial pass — the
+ * shipped API client returns whole responses. When the ai package's
+ * streaming transport lands for HTTP consumers, this component is where
+ * the incremental preview goes.
+ */
+
+import { useCallback, useState } from 'react';
+import type { AiApiClient, RewriteOutput } from './ai-api-client';
+import { useRewrite } from './hooks';
+
+const PRESET_INTENTS = [
+    { key: 'shorter', label: 'Make shorter' },
+    { key: 'longer', label: 'Expand' },
+    { key: 'formal', label: 'More formal' },
+    { key: 'casual', label: 'More casual' },
+    { key: 'grade-6', label: 'Reading level 6' },
+];
+
+export interface RewriteToolbarProps {
+    client: AiApiClient;
+    content: string;
+    onAccept: (result: RewriteOutput) => void;
+    onCancel: () => void;
+}
+
+export function RewriteToolbar(props: RewriteToolbarProps) {
+    const { client, content, onAccept, onCancel } = props;
+    const [intent, setIntent] = useState<string>('');
+    const call = useRewrite(client);
+
+    const runIntent = useCallback(
+        (nextIntent: string) => {
+            setIntent(nextIntent);
+            void call.run({ content, intent: nextIntent });
+        },
+        [call, content],
+    );
+
+    return (
+        <div className="ap-ve-ai-rewrite" data-testid="ap-ve-ai-rewrite">
+            <div className="ap-ve-ai-rewrite__intents" role="toolbar" aria-label="Rewrite">
+                {PRESET_INTENTS.map((p) => (
+                    <button
+                        key={p.key}
+                        type="button"
+                        onClick={() => runIntent(p.key)}
+                        disabled={call.status === 'loading'}
+                    >
+                        {p.label}
+                    </button>
+                ))}
+                <form
+                    onSubmit={(e) => {
+                        e.preventDefault();
+                        const form = e.currentTarget;
+                        const value = new FormData(form).get('custom-intent');
+                        if (typeof value === 'string' && value.trim() !== '') {
+                            runIntent(value.trim());
+                        }
+                    }}
+                >
+                    <label>
+                        Custom intent
+                        <input name="custom-intent" type="text" placeholder="e.g. more concrete" />
+                    </label>
+                </form>
+            </div>
+
+            {call.status === 'loading' && (
+                <div role="status" aria-live="polite">
+                    Rewriting for &ldquo;{intent}&rdquo;…
+                </div>
+            )}
+
+            {call.status === 'error' && call.error && (
+                <div role="alert">{call.error.message}</div>
+            )}
+
+            {call.status === 'success' && call.result && (
+                <div className="ap-ve-ai-rewrite__preview" data-testid="ap-ve-ai-rewrite-preview">
+                    <p className="ap-ve-ai-rewrite__meta">
+                        {Math.round(call.result.changed_ratio * 100)}% changed —{' '}
+                        <em>{call.result.rationale}</em>
+                    </p>
+                    <pre className="ap-ve-ai-rewrite__text">{call.result.rewrite}</pre>
+                    <div className="ap-ve-ai-rewrite__actions">
+                        <button
+                            type="button"
+                            onClick={() => onAccept(call.result!)}
+                            data-testid="ap-ve-ai-rewrite-accept"
+                        >
+                            Apply rewrite
+                        </button>
+                        <button type="button" onClick={onCancel}>
+                            Cancel
+                        </button>
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/resources/js/visual-editor/ai/SuggestLayoutPanel.tsx
+++ b/resources/js/visual-editor/ai/SuggestLayoutPanel.tsx
@@ -1,0 +1,68 @@
+/**
+ * Layout picker driven by the LayoutSuggestionAgent (#611).
+ *
+ * Renders a "suggest layout" button; on click, submits the current
+ * section's blocks + the available-pattern whitelist to the agent and
+ * shows ranked matches. Never applies a pattern implicitly — the caller
+ * owns the apply flow.
+ */
+
+import { useCallback } from 'react';
+import type { AiApiClient, LayoutMatch } from './ai-api-client';
+import { useSuggestLayout } from './hooks';
+
+export interface SuggestLayoutPanelProps {
+    client: AiApiClient;
+    sectionContent: readonly unknown[];
+    availablePatterns: readonly string[];
+    onPick: (match: LayoutMatch) => void;
+    label?: string;
+}
+
+export function SuggestLayoutPanel(props: SuggestLayoutPanelProps) {
+    const { client, sectionContent, availablePatterns, onPick, label } = props;
+    const call = useSuggestLayout(client);
+
+    const handleClick = useCallback(() => {
+        void call.run({
+            section_content: sectionContent,
+            available_patterns: availablePatterns,
+        });
+    }, [call, sectionContent, availablePatterns]);
+
+    return (
+        <div className="ap-ve-ai-suggest-layout">
+            <button
+                type="button"
+                onClick={handleClick}
+                disabled={call.status === 'loading'}
+                data-testid="ap-ve-ai-suggest-layout-trigger"
+            >
+                {label ?? 'Suggest a layout'}
+            </button>
+
+            {call.status === 'loading' && <span role="status">Matching patterns…</span>}
+
+            {call.status === 'error' && call.error && (
+                <div role="alert">{call.error.message}</div>
+            )}
+
+            {call.status === 'success' && call.result && (
+                <ul className="ap-ve-ai-suggest-layout__list">
+                    {call.result.matches.length === 0 && (
+                        <li>No matching pattern in the current library.</li>
+                    )}
+                    {call.result.matches.map((m) => (
+                        <li key={m.pattern_slug}>
+                            <button type="button" onClick={() => onPick(m)}>
+                                <strong>{m.pattern_slug}</strong>
+                                <span> ({Math.round(m.confidence * 100)}%)</span>
+                                <div>{m.rationale}</div>
+                            </button>
+                        </li>
+                    ))}
+                </ul>
+            )}
+        </div>
+    );
+}

--- a/resources/js/visual-editor/ai/SuggestNextBlockButton.tsx
+++ b/resources/js/visual-editor/ai/SuggestNextBlockButton.tsx
@@ -1,0 +1,81 @@
+/**
+ * Inline "+ suggest" affordance for the block inserter (#610).
+ *
+ * Renders a small button that runs the ContentBlockSuggestionAgent when
+ * clicked and calls back with the chosen suggestion. Always a
+ * *suggestion* — never mutates the editor state itself; callers own the
+ * apply flow per the AI RFC.
+ */
+
+import { useCallback, useState } from 'react';
+import type { AiApiClient, BlockSuggestion } from './ai-api-client';
+import { useSuggestNextBlock } from './hooks';
+
+export interface SuggestNextBlockButtonProps {
+    client: AiApiClient;
+    existingBlocks: readonly unknown[];
+    cursorPosition: number;
+    documentType?: string | null;
+    onPick: (suggestion: BlockSuggestion) => void;
+    label?: string;
+}
+
+export function SuggestNextBlockButton(props: SuggestNextBlockButtonProps) {
+    const { client, existingBlocks, cursorPosition, documentType, onPick, label } = props;
+    const [open, setOpen] = useState(false);
+    const call = useSuggestNextBlock(client);
+
+    const handleClick = useCallback(async () => {
+        setOpen(true);
+        await call.run({
+            existing_blocks: existingBlocks,
+            cursor_position: cursorPosition,
+            document_type: documentType ?? null,
+        });
+    }, [call, existingBlocks, cursorPosition, documentType]);
+
+    return (
+        <div className="ap-ve-ai-suggest-next">
+            <button
+                type="button"
+                onClick={handleClick}
+                disabled={call.status === 'loading'}
+                data-testid="ap-ve-ai-suggest-next-trigger"
+            >
+                {label ?? '+ suggest next block'}
+            </button>
+
+            {open && call.status === 'loading' && (
+                <span role="status" aria-live="polite">
+                    Thinking…
+                </span>
+            )}
+
+            {open && call.status === 'error' && call.error && (
+                <div role="alert" className="ap-ve-ai-suggest-next__error">
+                    {call.error.message}
+                </div>
+            )}
+
+            {open && call.status === 'success' && call.result && (
+                <ul className="ap-ve-ai-suggest-next__list" data-testid="ap-ve-ai-suggest-next-list">
+                    {call.result.suggestions.map((s, i) => (
+                        <li key={`${s.block_type}-${i}`}>
+                            <button
+                                type="button"
+                                onClick={() => {
+                                    onPick(s);
+                                    setOpen(false);
+                                    call.reset();
+                                }}
+                            >
+                                <strong>{s.block_type}</strong>
+                                <span> — {s.why}</span>
+                            </button>
+                        </li>
+                    ))}
+                </ul>
+            )}
+        </div>
+    );
+}

--- a/resources/js/visual-editor/ai/ai-api-client.ts
+++ b/resources/js/visual-editor/ai/ai-api-client.ts
@@ -1,0 +1,224 @@
+/**
+ * REST client for the visual editor's AI trigger endpoints (#610-#614).
+ *
+ * Thin `fetch` wrapper over `/visual-editor/api/ai/*`. Each call maps to
+ * one agent invocation server-side and returns the shaped output verbatim.
+ * The server enforces feature toggles + credentials, so callers should
+ * treat a 403 as "feature disabled" rather than an auth failure.
+ */
+
+/**
+ * The full set of feature keys the visual-editor's AI surface exposes.
+ * This is the JS-side mirror of
+ * `ArtisanPackUI\VisualEditor\VisualEditorServiceProvider::AI_FEATURE_KEYS`;
+ * both are pinned to the same list so the React bundle can't drift out of
+ * sync with the HTTP + Livewire feature-map endpoints. If you add a 6th
+ * key, add it in both places (review #6).
+ */
+export const AI_FEATURE_KEYS = [
+    'visual_editor.suggest_next_block',
+    'visual_editor.suggest_layout',
+    'visual_editor.heading_hierarchy',
+    'ai.alt_text',
+    'ai.content_rewrite',
+] as const;
+
+export type AiFeatureKey = (typeof AI_FEATURE_KEYS)[number];
+
+export type AiFeaturesMap = Record<AiFeatureKey, boolean>;
+
+export interface SuggestNextBlockInput {
+    existing_blocks: readonly unknown[];
+    cursor_position: number;
+    document_type?: string | null;
+}
+
+export interface BlockSuggestion {
+    block_type: string;
+    why: string;
+    starter_content?: string;
+}
+
+export interface SuggestNextBlockOutput {
+    suggestions: BlockSuggestion[];
+}
+
+export interface SuggestLayoutInput {
+    section_content: readonly unknown[];
+    available_patterns: readonly string[];
+}
+
+export interface LayoutMatch {
+    pattern_slug: string;
+    confidence: number;
+    rationale: string;
+}
+
+export interface SuggestLayoutOutput {
+    matches: LayoutMatch[];
+}
+
+export type AltTextInput =
+    | string
+    | { source: 'path' | 'url' | 'base64'; value: string };
+
+export interface AltTextOutput {
+    alt_text: string;
+    confidence: number;
+    warnings: string[];
+}
+
+export interface RewriteInput {
+    content: string;
+    intent: string;
+}
+
+export interface RewriteOutput {
+    rewrite: string;
+    changed_ratio: number;
+    rationale: string;
+}
+
+export interface HeadingHierarchyInput {
+    blocks: readonly unknown[];
+}
+
+export interface HeadingIssue {
+    block_id: string;
+    issue: string;
+    suggestion: string;
+}
+
+export interface HeadingHierarchyOutput {
+    issues: HeadingIssue[];
+}
+
+export class AiApiError extends Error {
+    public readonly status: number;
+
+    public readonly code: string;
+
+    public readonly feature: string | null;
+
+    public constructor(
+        message: string,
+        status: number,
+        code: string,
+        feature: string | null,
+    ) {
+        super(message);
+        this.name = 'AiApiError';
+        this.status = status;
+        this.code = code;
+        this.feature = feature;
+    }
+}
+
+export interface AiApiClientConfig {
+    apiBase: string;
+    /** Optional `fetch` override for tests. */
+    fetchImpl?: typeof fetch;
+    /** Extra headers merged into every request (e.g. `Authorization`). */
+    headers?: Record<string, string>;
+}
+
+function readCsrfToken(): string | null {
+    if (typeof document === 'undefined') {
+        return null;
+    }
+    const meta = document.querySelector<HTMLMetaElement>('meta[name="csrf-token"]');
+    return meta?.content?.trim() || null;
+}
+
+interface AgentEnvelope<T> {
+    feature: string;
+    output: T;
+}
+
+interface AgentErrorEnvelope {
+    feature?: string;
+    error?: string;
+    message?: string;
+}
+
+export function createAiApiClient(config: AiApiClientConfig) {
+    const base = config.apiBase.replace(/\/$/, '');
+    const doFetch = config.fetchImpl ?? globalThis.fetch;
+
+    async function call<TOut>(path: string, method: 'GET' | 'POST', body?: unknown): Promise<TOut> {
+        const csrf = readCsrfToken();
+        const headers: Record<string, string> = {
+            Accept: 'application/json',
+            ...(config.headers ?? {}),
+        };
+        if (method === 'POST') {
+            headers['Content-Type'] = 'application/json';
+        }
+        if (csrf) {
+            headers['X-CSRF-TOKEN'] = csrf;
+        }
+
+        const response = await doFetch(`${base}${path}`, {
+            method,
+            headers,
+            credentials: 'same-origin',
+            body: method === 'POST' && body !== undefined ? JSON.stringify(body) : undefined,
+        });
+
+        const raw = await response.text();
+        let parsed: unknown = null;
+        if (raw.length > 0) {
+            try {
+                parsed = JSON.parse(raw);
+            } catch {
+                parsed = raw;
+            }
+        }
+
+        if (!response.ok) {
+            const envelope = (parsed ?? {}) as AgentErrorEnvelope;
+            throw new AiApiError(
+                envelope.message ?? `AI API responded with ${response.status}`,
+                response.status,
+                envelope.error ?? 'http_error',
+                envelope.feature ?? null,
+            );
+        }
+
+        return parsed as TOut;
+    }
+
+    return {
+        async features(): Promise<AiFeaturesMap> {
+            const data = await call<{ features: AiFeaturesMap }>('/ai/features', 'GET');
+            return data.features;
+        },
+
+        async suggestNextBlock(input: SuggestNextBlockInput): Promise<SuggestNextBlockOutput> {
+            const env = await call<AgentEnvelope<SuggestNextBlockOutput>>('/ai/suggest-next-block', 'POST', input);
+            return env.output;
+        },
+
+        async suggestLayout(input: SuggestLayoutInput): Promise<SuggestLayoutOutput> {
+            const env = await call<AgentEnvelope<SuggestLayoutOutput>>('/ai/suggest-layout', 'POST', input);
+            return env.output;
+        },
+
+        async altText(image: AltTextInput): Promise<AltTextOutput> {
+            const env = await call<AgentEnvelope<AltTextOutput>>('/ai/alt-text', 'POST', { image });
+            return env.output;
+        },
+
+        async rewrite(input: RewriteInput): Promise<RewriteOutput> {
+            const env = await call<AgentEnvelope<RewriteOutput>>('/ai/rewrite', 'POST', input);
+            return env.output;
+        },
+
+        async headingHierarchy(input: HeadingHierarchyInput): Promise<HeadingHierarchyOutput> {
+            const env = await call<AgentEnvelope<HeadingHierarchyOutput>>('/ai/heading-hierarchy', 'POST', input);
+            return env.output;
+        },
+    };
+}
+
+export type AiApiClient = ReturnType<typeof createAiApiClient>;

--- a/resources/js/visual-editor/ai/hooks.ts
+++ b/resources/js/visual-editor/ai/hooks.ts
@@ -1,0 +1,60 @@
+/**
+ * Feature-specific hooks for the five visual-editor AI triggers.
+ * Each thin-wraps `useAgentCall` over one AI client method.
+ */
+
+import { useCallback } from 'react';
+import type {
+    AiApiClient,
+    AltTextInput,
+    AltTextOutput,
+    HeadingHierarchyInput,
+    HeadingHierarchyOutput,
+    RewriteInput,
+    RewriteOutput,
+    SuggestLayoutInput,
+    SuggestLayoutOutput,
+    SuggestNextBlockInput,
+    SuggestNextBlockOutput,
+} from './ai-api-client';
+import { useAgentCall } from './use-agent-call';
+
+export function useSuggestNextBlock(client: AiApiClient) {
+    const invoke = useCallback(
+        (input: SuggestNextBlockInput) => client.suggestNextBlock(input),
+        [client],
+    );
+    return useAgentCall<SuggestNextBlockInput, SuggestNextBlockOutput>(invoke);
+}
+
+export function useSuggestLayout(client: AiApiClient) {
+    const invoke = useCallback(
+        (input: SuggestLayoutInput) => client.suggestLayout(input),
+        [client],
+    );
+    return useAgentCall<SuggestLayoutInput, SuggestLayoutOutput>(invoke);
+}
+
+export function useAltText(client: AiApiClient) {
+    const invoke = useCallback(
+        (image: AltTextInput) => client.altText(image),
+        [client],
+    );
+    return useAgentCall<AltTextInput, AltTextOutput>(invoke);
+}
+
+export function useRewrite(client: AiApiClient) {
+    const invoke = useCallback(
+        (input: RewriteInput) => client.rewrite(input),
+        [client],
+    );
+    return useAgentCall<RewriteInput, RewriteOutput>(invoke);
+}
+
+export function useHeadingHierarchy(client: AiApiClient) {
+    const invoke = useCallback(
+        (input: HeadingHierarchyInput) => client.headingHierarchy(input),
+        [client],
+    );
+    return useAgentCall<HeadingHierarchyInput, HeadingHierarchyOutput>(invoke);
+}

--- a/resources/js/visual-editor/ai/index.ts
+++ b/resources/js/visual-editor/ai/index.ts
@@ -1,0 +1,60 @@
+/**
+ * Public entry point for the visual-editor AI trigger surfaces (#610-#614).
+ *
+ * Import from `../ai` to consume the API client, hooks, and UI components
+ * used by the editor's five AI-powered affordances.
+ */
+
+export { AI_FEATURE_KEYS, AiApiError, createAiApiClient } from './ai-api-client';
+export type {
+    AiApiClient,
+    AiApiClientConfig,
+    AiFeatureKey,
+    AiFeaturesMap,
+    AltTextInput,
+    AltTextOutput,
+    BlockSuggestion,
+    HeadingHierarchyInput,
+    HeadingHierarchyOutput,
+    HeadingIssue,
+    LayoutMatch,
+    RewriteInput,
+    RewriteOutput,
+    SuggestLayoutInput,
+    SuggestLayoutOutput,
+    SuggestNextBlockInput,
+    SuggestNextBlockOutput,
+} from './ai-api-client';
+
+export { useAiFeatures } from './use-ai-features';
+export type { UseAiFeaturesResult } from './use-ai-features';
+
+export { useAgentCall } from './use-agent-call';
+export type {
+    AgentCallState,
+    AgentCallStatus,
+    UseAgentCallReturn,
+} from './use-agent-call';
+
+export {
+    useAltText,
+    useHeadingHierarchy,
+    useRewrite,
+    useSuggestLayout,
+    useSuggestNextBlock,
+} from './hooks';
+
+export { SuggestNextBlockButton } from './SuggestNextBlockButton';
+export type { SuggestNextBlockButtonProps } from './SuggestNextBlockButton';
+
+export { SuggestLayoutPanel } from './SuggestLayoutPanel';
+export type { SuggestLayoutPanelProps } from './SuggestLayoutPanel';
+
+export { AltTextSuggestionCard } from './AltTextSuggestionCard';
+export type { AltTextSuggestionCardProps } from './AltTextSuggestionCard';
+
+export { RewriteToolbar } from './RewriteToolbar';
+export type { RewriteToolbarProps } from './RewriteToolbar';
+
+export { HeadingHierarchyPanel } from './HeadingHierarchyPanel';
+export type { HeadingHierarchyPanelProps } from './HeadingHierarchyPanel';

--- a/resources/js/visual-editor/ai/use-agent-call.ts
+++ b/resources/js/visual-editor/ai/use-agent-call.ts
@@ -1,0 +1,76 @@
+/**
+ * Generic hook that wraps a single AI API method with idle/loading/error/
+ * result state. Each of the five feature-specific hooks in this folder
+ * composes on top of this one so the state machine stays consistent.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { AiApiError } from './ai-api-client';
+
+export type AgentCallStatus = 'idle' | 'loading' | 'success' | 'error';
+
+export interface AgentCallState<TOutput> {
+    status: AgentCallStatus;
+    result: TOutput | null;
+    error: AiApiError | Error | null;
+}
+
+export interface UseAgentCallReturn<TInput, TOutput> extends AgentCallState<TOutput> {
+    run: (input: TInput) => Promise<TOutput | null>;
+    reset: () => void;
+}
+
+export function useAgentCall<TInput, TOutput>(
+    invoke: (input: TInput) => Promise<TOutput>,
+): UseAgentCallReturn<TInput, TOutput> {
+    const [state, setState] = useState<AgentCallState<TOutput>>({
+        status: 'idle',
+        result: null,
+        error: null,
+    });
+    const mountedRef = useRef(true);
+    // Increments on every `run()`. A resolved request only commits to
+    // state when its id still matches `latestRunIdRef` — this drops the
+    // result of an older overlapping request that happens to settle
+    // *after* a newer one (review #3), which would otherwise stomp the
+    // fresher state.
+    const latestRunIdRef = useRef(0);
+
+    useEffect(() => {
+        mountedRef.current = true;
+        return () => {
+            mountedRef.current = false;
+        };
+    }, []);
+
+    const run = useCallback(
+        async (input: TInput) => {
+            const runId = ++latestRunIdRef.current;
+            setState({ status: 'loading', result: null, error: null });
+            try {
+                const result = await invoke(input);
+                if (mountedRef.current && latestRunIdRef.current === runId) {
+                    setState({ status: 'success', result, error: null });
+                }
+                return result;
+            } catch (err) {
+                const normalized =
+                    err instanceof Error ? err : new Error(String(err));
+                if (mountedRef.current && latestRunIdRef.current === runId) {
+                    setState({ status: 'error', result: null, error: normalized });
+                }
+                return null;
+            }
+        },
+        [invoke],
+    );
+
+    const reset = useCallback(() => {
+        // Bump the id so any in-flight request whose promise settles
+        // later can't restore state after a manual reset.
+        latestRunIdRef.current++;
+        setState({ status: 'idle', result: null, error: null });
+    }, []);
+
+    return { ...state, run, reset };
+}

--- a/resources/js/visual-editor/ai/use-ai-features.ts
+++ b/resources/js/visual-editor/ai/use-ai-features.ts
@@ -1,0 +1,66 @@
+/**
+ * React hook that fetches the enabled-features map from the AI API and
+ * caches it for the lifetime of the mount. Used by every trigger surface
+ * to decide whether to render its affordance.
+ */
+
+import { useEffect, useState } from 'react';
+import { AI_FEATURE_KEYS } from './ai-api-client';
+import type { AiApiClient, AiFeatureKey, AiFeaturesMap } from './ai-api-client';
+
+// Derived from the single AI_FEATURE_KEYS list so a future 6th key only
+// needs to land in ai-api-client.ts (review #6).
+const EMPTY_STATE: AiFeaturesMap = AI_FEATURE_KEYS.reduce(
+    (acc, key) => ({ ...acc, [key]: false }),
+    {} as AiFeaturesMap,
+);
+
+export interface UseAiFeaturesResult {
+    features: AiFeaturesMap;
+    loading: boolean;
+    error: Error | null;
+    isEnabled: (key: AiFeatureKey) => boolean;
+}
+
+export function useAiFeatures(client: AiApiClient | null): UseAiFeaturesResult {
+    const [features, setFeatures] = useState<AiFeaturesMap>(EMPTY_STATE);
+    const [loading, setLoading] = useState<boolean>(client !== null);
+    const [error, setError] = useState<Error | null>(null);
+
+    useEffect(() => {
+        if (client === null) {
+            setLoading(false);
+            return;
+        }
+        let cancelled = false;
+        setLoading(true);
+        client
+            .features()
+            .then((next) => {
+                if (!cancelled) {
+                    setFeatures(next);
+                    setError(null);
+                }
+            })
+            .catch((e) => {
+                if (!cancelled) {
+                    setError(e instanceof Error ? e : new Error(String(e)));
+                }
+            })
+            .finally(() => {
+                if (!cancelled) {
+                    setLoading(false);
+                }
+            });
+        return () => {
+            cancelled = true;
+        };
+    }, [client]);
+
+    return {
+        features,
+        loading,
+        error,
+        isEnabled: (key: AiFeatureKey) => features[key] === true,
+    };
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -17,6 +17,7 @@
 
 declare( strict_types=1 );
 
+use ArtisanPackUI\VisualEditor\Http\Controllers\Ai\AiController;
 use ArtisanPackUI\VisualEditor\Http\Controllers\Adapters\CmsFramework\PageController;
 use ArtisanPackUI\VisualEditor\Http\Controllers\Adapters\CmsFramework\PostController;
 use ArtisanPackUI\VisualEditor\Http\Controllers\AttachmentController;
@@ -318,3 +319,27 @@ Route::get( 'attachments/{id}', [ AttachmentController::class, 'show' ] )
 Route::get( 'site/{id}', [ SiteController::class, 'show' ] )
 	->where( 'id', '[A-Za-z0-9_-]+' )
 	->name( 'visual-editor.api.site.show' );
+
+// #610-#614 — AI trigger surface. Each POST runs one agent and returns
+// its shaped output; enforcement of feature toggles + credentials lives
+// inside the ai package's `ArtisanPackAgent`, so this controller is a
+// thin JSON wrapper. Guarded by the same middleware stack as the rest
+// of the visual-editor API. The whole block is gated on the ai package
+// being present because it is a `suggest` (not `require`) dependency —
+// without this guard, `composer install --no-dev` in production would
+// 500 on every /ai/* endpoint the moment the controller tries to
+// resolve `FeatureRegistry` from the container.
+if ( class_exists( \ArtisanPackUI\Ai\Contracts\FeatureRegistry::class ) ) {
+	Route::get( 'ai/features', [ AiController::class, 'features' ] )
+		->name( 'visual-editor.api.ai.features' );
+	Route::post( 'ai/suggest-next-block', [ AiController::class, 'suggestNextBlock' ] )
+		->name( 'visual-editor.api.ai.suggest-next-block' );
+	Route::post( 'ai/suggest-layout', [ AiController::class, 'suggestLayout' ] )
+		->name( 'visual-editor.api.ai.suggest-layout' );
+	Route::post( 'ai/alt-text', [ AiController::class, 'altText' ] )
+		->name( 'visual-editor.api.ai.alt-text' );
+	Route::post( 'ai/rewrite', [ AiController::class, 'rewrite' ] )
+		->name( 'visual-editor.api.ai.rewrite' );
+	Route::post( 'ai/heading-hierarchy', [ AiController::class, 'headingHierarchy' ] )
+		->name( 'visual-editor.api.ai.heading-hierarchy' );
+}

--- a/src/Ai/Agents/ContentBlockSuggestionAgent.php
+++ b/src/Ai/Agents/ContentBlockSuggestionAgent.php
@@ -1,0 +1,270 @@
+<?php
+
+/**
+ * Content block suggestion agent.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @since      1.3.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Ai\Agents;
+
+use ArtisanPackUI\Ai\Agents\ArtisanPackAgent;
+use ArtisanPackUI\Ai\Contracts\AgentPrompter;
+use ArtisanPackUI\Ai\Credentials\Credentials;
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+use JsonException;
+
+/**
+ * Suggests what block type should come next given the blocks already
+ * written and the caret position. Powers the inline "+ suggest"
+ * affordance in the editor (see #610).
+ *
+ * ## Input
+ *
+ * ```
+ * [
+ *   'existing_blocks'  => array,          // required, ordered list of block payloads
+ *   'cursor_position'  => int,            // required, 0-indexed insertion offset
+ *   'document_type'    => string|null,    // optional, e.g. "blog-post", "landing-page"
+ * ]
+ * ```
+ *
+ * Each block payload is expected to expose at minimum a `type` field
+ * (e.g. `core/paragraph`, `core/heading`). Any extra keys (`attrs`,
+ * `content`, `id`) pass through to the model verbatim — the agent does
+ * not read block bodies for privacy-sensitive fields, so callers should
+ * strip anything that shouldn't leave the tenant boundary before invoking.
+ *
+ * ## Output schema
+ *
+ * ```
+ * {
+ *   suggestions: [
+ *     { block_type: string, why: string, starter_content?: string }
+ *   ]
+ * }
+ * ```
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @since      1.3.0
+ */
+class ContentBlockSuggestionAgent extends ArtisanPackAgent
+{
+	/**
+	 * {@inheritDoc}
+	 */
+	public string $featureKey = 'visual_editor.suggest_next_block';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public string $package = 'artisanpack-ui/visual-editor';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public string $defaultModel = 'claude-haiku-4-5';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function instructions(): string
+	{
+		return <<<'PROMPT'
+You suggest the next block a writer should add given the blocks already in the document and the caret's insertion position.
+
+Requirements:
+- Return between 1 and 4 suggestions, ordered by relevance (best first).
+- `block_type` must be a Gutenberg-style slug (e.g. `core/paragraph`, `core/heading`, `core/list`, `core/quote`, `core/image`, `core/columns`). Prefer core blocks; do NOT invent block types that don't exist.
+- `why` is a single sentence explaining why this block fits after the blocks already present.
+- `starter_content` is optional. Include it ONLY when a short concrete example would help the writer (e.g. a heading placeholder like "How it works"). Never fabricate facts, quotes, statistics, or names — leave it out if you would need to guess.
+- If `document_type` is provided, bias suggestions toward that shape (e.g. a landing page benefits from CTA + testimonial blocks; a blog post benefits from heading/subheading/list scaffolding).
+- If the document already ends with a heading, a paragraph almost always comes next.
+- If the document is empty or has only a title, the first suggestion should be a heading or paragraph to open the body — not a rich block like columns.
+
+Return a JSON object with key `suggestions` (array of {block_type, why, starter_content?}).
+PROMPT;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function outputSchema(): array
+	{
+		return [
+			'type'                 => 'object',
+			'additionalProperties' => false,
+			'required'             => [ 'suggestions' ],
+			'properties'           => [
+				'suggestions' => [
+					'type'     => 'array',
+					'minItems' => 1,
+					'maxItems' => 4,
+					'items'    => [
+						'type'                 => 'object',
+						'additionalProperties' => false,
+						'required'             => [ 'block_type', 'why' ],
+						'properties'           => [
+							'block_type'      => [ 'type' => 'string' ],
+							'why'             => [ 'type' => 'string' ],
+							'starter_content' => [ 'type' => 'string' ],
+						],
+					],
+				],
+			],
+		];
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function execute( Credentials $credentials, string $model, string $instructions ): array
+	{
+		$normalized = $this->normalizeInput( $this->input() );
+
+		$prompter = app( AgentPrompter::class );
+
+		$result = $prompter->prompt(
+			credentials: $credentials,
+			model: $model,
+			instructions: $instructions,
+			message: $this->buildMessage( $normalized ),
+			outputSchema: $this->outputSchema(),
+		);
+
+		return [
+			'output'        => $this->validateOutput( $result['output'] ),
+			'input_tokens'  => (int) ( $result['input_tokens'] ?? 0 ),
+			'output_tokens' => (int) ( $result['output_tokens'] ?? 0 ),
+		];
+	}
+
+	/**
+	 * Validate and shape-check the raw agent input.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param  mixed  $input  Raw agent input.
+	 *
+	 * @return array{ existing_blocks: array<int, mixed>, cursor_position: int, document_type: string|null }
+	 */
+	protected function normalizeInput( mixed $input ): array
+	{
+		if ( ! is_array( $input ) ) {
+			throw FeatureError::forFeature(
+				$this->featureKey,
+				'input must be an array with `existing_blocks` and `cursor_position` keys.',
+			);
+		}
+
+		if ( ! isset( $input['existing_blocks'] ) || ! is_array( $input['existing_blocks'] ) ) {
+			throw FeatureError::forFeature( $this->featureKey, '`existing_blocks` must be an array.' );
+		}
+
+		if ( ! array_key_exists( 'cursor_position', $input ) ) {
+			throw FeatureError::forFeature( $this->featureKey, '`cursor_position` is required.' );
+		}
+
+		$cursor = filter_var( $input['cursor_position'], FILTER_VALIDATE_INT, [ 'options' => [ 'min_range' => 0 ] ] );
+		if ( false === $cursor ) {
+			throw FeatureError::forFeature( $this->featureKey, '`cursor_position` must be a non-negative integer.' );
+		}
+
+		$documentType = null;
+		if ( isset( $input['document_type'] ) && is_string( $input['document_type'] ) && '' !== trim( $input['document_type'] ) ) {
+			$documentType = trim( $input['document_type'] );
+		}
+
+		return [
+			'existing_blocks' => array_values( $input['existing_blocks'] ),
+			'cursor_position' => $cursor,
+			'document_type'   => $documentType,
+		];
+	}
+
+	/**
+	 * Build the structured message body for the prompter.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param  array{ existing_blocks: array<int, mixed>, cursor_position: int, document_type: string|null }  $input  Normalized input.
+	 *
+	 * @return array<int, array<string, string>>
+	 */
+	protected function buildMessage( array $input ): array
+	{
+		try {
+			$serialized = json_encode( $input['existing_blocks'], JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
+		} catch ( JsonException $e ) {
+			throw FeatureError::forFeature(
+				$this->featureKey,
+				sprintf( 'existing_blocks are not JSON-encodable: %s', $e->getMessage() ),
+			);
+		}
+
+		$parts = [
+			[ 'type' => 'text', 'text' => sprintf( 'Insertion position (0-indexed): %d', $input['cursor_position'] ) ],
+			[ 'type' => 'text', 'text' => sprintf( 'Existing blocks: %s', $serialized ) ],
+		];
+
+		if ( null !== $input['document_type'] ) {
+			$parts[] = [ 'type' => 'text', 'text' => sprintf( 'Document type: %s', $input['document_type'] ) ];
+		}
+
+		return $parts;
+	}
+
+	/**
+	 * Enforce the output schema shape before returning.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param  array<string, mixed>  $output  Decoded model output.
+	 *
+	 * @return array{ suggestions: array<int, array{ block_type: string, why: string, starter_content?: string }> }
+	 */
+	protected function validateOutput( array $output ): array
+	{
+		$rawSuggestions = isset( $output['suggestions'] ) && is_array( $output['suggestions'] )
+			? $output['suggestions']
+			: [];
+
+		$clean = [];
+		foreach ( $rawSuggestions as $entry ) {
+			if ( ! is_array( $entry ) ) {
+				continue;
+			}
+
+			$blockType = isset( $entry['block_type'] ) ? trim( (string) $entry['block_type'] ) : '';
+			$why       = isset( $entry['why'] ) ? trim( (string) $entry['why'] ) : '';
+
+			if ( '' === $blockType || '' === $why ) {
+				continue;
+			}
+
+			$suggestion = [
+				'block_type' => $blockType,
+				'why'        => $why,
+			];
+
+			if ( isset( $entry['starter_content'] ) && is_string( $entry['starter_content'] ) && '' !== trim( $entry['starter_content'] ) ) {
+				$suggestion['starter_content'] = $entry['starter_content'];
+			}
+
+			$clean[] = $suggestion;
+
+			if ( 4 === count( $clean ) ) {
+				break;
+			}
+		}
+
+		return [ 'suggestions' => $clean ];
+	}
+}

--- a/src/Ai/Agents/HeadingHierarchyAgent.php
+++ b/src/Ai/Agents/HeadingHierarchyAgent.php
@@ -1,0 +1,328 @@
+<?php
+
+/**
+ * Heading hierarchy validation agent.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @since      1.3.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Ai\Agents;
+
+use ArtisanPackUI\Ai\Agents\ArtisanPackAgent;
+use ArtisanPackUI\Ai\Contracts\AgentPrompter;
+use ArtisanPackUI\Ai\Credentials\Credentials;
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+use JsonException;
+
+/**
+ * Reviews the document's heading structure and flags common problems
+ * (skipped levels, multiple h1s, ambiguous headings) alongside concrete
+ * suggested fixes. Also feeds the Accessibility package's document-audit
+ * surface (see #614).
+ *
+ * ## Input
+ *
+ * ```
+ * [
+ *   'blocks' => array,   // required, ordered list of block payloads
+ * ]
+ * ```
+ *
+ * Non-heading blocks are still forwarded — the model uses surrounding
+ * paragraphs and lists to judge whether a heading is "ambiguous" — but
+ * only heading blocks are ever cited in the issues array.
+ *
+ * ## Output schema
+ *
+ * ```
+ * {
+ *   issues: [
+ *     { block_id: string, issue: string, suggestion: string }
+ *   ]
+ * }
+ * ```
+ *
+ * A clean document returns `{ issues: [] }`. Callers should treat an
+ * empty array as "no problems found" rather than as failure.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @since      1.3.0
+ */
+class HeadingHierarchyAgent extends ArtisanPackAgent
+{
+	/**
+	 * {@inheritDoc}
+	 */
+	public string $featureKey = 'visual_editor.heading_hierarchy';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public string $package = 'artisanpack-ui/visual-editor';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public string $defaultModel = 'claude-haiku-4-5';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function instructions(): string
+	{
+		return <<<'PROMPT'
+You review the document's heading structure and flag common accessibility problems.
+
+Categories of issues to report:
+- Skipped heading levels (e.g. an h2 directly followed by an h4 without an intermediate h3).
+- Multiple h1 elements in a single document.
+- Ambiguous or generic headings ("More info", "Details", "Section 2") — call these out with a suggested rewrite based on what the heading actually introduces.
+- Empty or whitespace-only heading text.
+- Heading order that doesn't reflect the document's information architecture (e.g. an h3 introducing a top-level section).
+
+Rules:
+- Only report REAL issues. Do not invent problems in a well-structured document.
+- Every issue must cite the exact `block_id` from the input. Do NOT invent block ids.
+- `issue` is a short label (e.g. "skipped level", "duplicate h1", "ambiguous heading").
+- `suggestion` is a concrete fix the writer can apply — a specific rewrite, a level change, or "merge into previous section".
+- Return `{ "issues": [] }` when the document is clean.
+
+Return a JSON object with key `issues` (array of {block_id, issue, suggestion}).
+PROMPT;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function outputSchema(): array
+	{
+		return [
+			'type'                 => 'object',
+			'additionalProperties' => false,
+			'required'             => [ 'issues' ],
+			'properties'           => [
+				'issues' => [
+					'type'  => 'array',
+					'items' => [
+						'type'                 => 'object',
+						'additionalProperties' => false,
+						'required'             => [ 'block_id', 'issue', 'suggestion' ],
+						'properties'           => [
+							'block_id'   => [ 'type' => 'string' ],
+							'issue'      => [ 'type' => 'string' ],
+							'suggestion' => [ 'type' => 'string' ],
+						],
+					],
+				],
+			],
+		];
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function execute( Credentials $credentials, string $model, string $instructions ): array
+	{
+		$normalized = $this->normalizeInput( $this->input() );
+
+		// If there are literally no headings in the document, short-circuit
+		// to an empty issues array. There's nothing for the model to check,
+		// and running it would waste tokens on a guaranteed-empty output.
+		if ( ! $this->containsHeading( $normalized['blocks'] ) ) {
+			return [
+				'output'        => [ 'issues' => [] ],
+				'input_tokens'  => 0,
+				'output_tokens' => 0,
+			];
+		}
+
+		$prompter = app( AgentPrompter::class );
+
+		$result = $prompter->prompt(
+			credentials: $credentials,
+			model: $model,
+			instructions: $instructions,
+			message: $this->buildMessage( $normalized ),
+			outputSchema: $this->outputSchema(),
+		);
+
+		return [
+			'output'        => $this->validateOutput( $result['output'], $this->collectBlockIds( $normalized['blocks'] ) ),
+			'input_tokens'  => (int) ( $result['input_tokens'] ?? 0 ),
+			'output_tokens' => (int) ( $result['output_tokens'] ?? 0 ),
+		];
+	}
+
+	/**
+	 * Validate and shape-check the raw agent input.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param  mixed  $input  Raw agent input.
+	 *
+	 * @return array{ blocks: array<int, mixed> }
+	 */
+	protected function normalizeInput( mixed $input ): array
+	{
+		if ( ! is_array( $input ) ) {
+			throw FeatureError::forFeature(
+				$this->featureKey,
+				'input must be an array with a `blocks` key.',
+			);
+		}
+
+		if ( ! isset( $input['blocks'] ) || ! is_array( $input['blocks'] ) ) {
+			throw FeatureError::forFeature( $this->featureKey, '`blocks` must be an array.' );
+		}
+
+		return [ 'blocks' => array_values( $input['blocks'] ) ];
+	}
+
+	/**
+	 * Whether any block in the tree is a heading. Recurses into
+	 * `innerBlocks` so headings nested inside a `core/columns`,
+	 * `core/group`, or `core/cover` are still seen (see review #1) —
+	 * without this walk the agent short-circuits to `{issues: []}` on
+	 * documents whose only headings live under a container block, which
+	 * is the exact case the feature is meant to catch.
+	 *
+	 * Uses a permissive check so callers passing normalized Gutenberg
+	 * payloads (`core/heading`) or simplified shapes (`{ type: 'heading' }`)
+	 * both work.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param  array<int, mixed>  $blocks  Normalized block list.
+	 *
+	 * @return bool
+	 */
+	protected function containsHeading( array $blocks ): bool
+	{
+		foreach ( $blocks as $block ) {
+			if ( ! is_array( $block ) ) {
+				continue;
+			}
+			$type = isset( $block['type'] ) ? (string) $block['type'] : ( isset( $block['blockName'] ) ? (string) $block['blockName'] : '' );
+			if ( 'heading' === $type || 'core/heading' === $type ) {
+				return true;
+			}
+			if ( isset( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) && $this->containsHeading( $block['innerBlocks'] ) ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Collect all recognized block ids in the tree so we can drop any
+	 * model-hallucinated ids from the output. Recurses through
+	 * `innerBlocks` for the same reason `containsHeading()` does — the
+	 * model can (and should) cite a nested heading's id, and validation
+	 * must not throw it away as "unknown".
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param  array<int, mixed>  $blocks  Normalized block list.
+	 *
+	 * @return array<int, string>
+	 */
+	protected function collectBlockIds( array $blocks ): array
+	{
+		$ids = [];
+		foreach ( $blocks as $block ) {
+			if ( ! is_array( $block ) ) {
+				continue;
+			}
+			if ( isset( $block['id'] ) && is_string( $block['id'] ) && '' !== $block['id'] ) {
+				$ids[] = $block['id'];
+			} elseif ( isset( $block['clientId'] ) && is_string( $block['clientId'] ) && '' !== $block['clientId'] ) {
+				$ids[] = $block['clientId'];
+			}
+			if ( isset( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ) {
+				$ids = array_merge( $ids, $this->collectBlockIds( $block['innerBlocks'] ) );
+			}
+		}
+		return $ids;
+	}
+
+	/**
+	 * Build the structured message body for the prompter.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param  array{ blocks: array<int, mixed> }  $input  Normalized input.
+	 *
+	 * @return array<int, array<string, string>>
+	 */
+	protected function buildMessage( array $input ): array
+	{
+		try {
+			$serialized = json_encode( $input['blocks'], JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
+		} catch ( JsonException $e ) {
+			throw FeatureError::forFeature(
+				$this->featureKey,
+				sprintf( 'blocks are not JSON-encodable: %s', $e->getMessage() ),
+			);
+		}
+
+		return [
+			[ 'type' => 'text', 'text' => sprintf( 'Document blocks: %s', $serialized ) ],
+		];
+	}
+
+	/**
+	 * Enforce output shape and drop issues referencing ids we didn't send.
+	 * When no block ids were provided at all (input had bare block shapes),
+	 * we keep the model's issues verbatim so callers still get feedback.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param  array<string, mixed>  $output    Decoded model output.
+	 * @param  array<int, string>    $knownIds  Ids present in the input.
+	 *
+	 * @return array{ issues: array<int, array{ block_id: string, issue: string, suggestion: string }> }
+	 */
+	protected function validateOutput( array $output, array $knownIds ): array
+	{
+		$raw = isset( $output['issues'] ) && is_array( $output['issues'] )
+			? $output['issues']
+			: [];
+
+		$known    = array_flip( $knownIds );
+		$hasKnown = [] !== $known;
+		$clean    = [];
+
+		foreach ( $raw as $entry ) {
+			if ( ! is_array( $entry ) ) {
+				continue;
+			}
+
+			$blockId    = isset( $entry['block_id'] ) ? trim( (string) $entry['block_id'] ) : '';
+			$issue      = isset( $entry['issue'] ) ? trim( (string) $entry['issue'] ) : '';
+			$suggestion = isset( $entry['suggestion'] ) ? trim( (string) $entry['suggestion'] ) : '';
+
+			if ( '' === $blockId || '' === $issue || '' === $suggestion ) {
+				continue;
+			}
+
+			if ( $hasKnown && ! isset( $known[ $blockId ] ) ) {
+				continue;
+			}
+
+			$clean[] = [
+				'block_id'   => $blockId,
+				'issue'      => $issue,
+				'suggestion' => $suggestion,
+			];
+		}
+
+		return [ 'issues' => $clean ];
+	}
+}

--- a/src/Ai/Agents/LayoutSuggestionAgent.php
+++ b/src/Ai/Agents/LayoutSuggestionAgent.php
@@ -1,0 +1,266 @@
+<?php
+
+/**
+ * Layout / pattern suggestion agent.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @since      1.3.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Ai\Agents;
+
+use ArtisanPackUI\Ai\Agents\ArtisanPackAgent;
+use ArtisanPackUI\Ai\Contracts\AgentPrompter;
+use ArtisanPackUI\Ai\Credentials\Credentials;
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+use JsonException;
+
+/**
+ * Given the contents of an in-progress section, ranks candidate patterns
+ * from the caller's available pattern library that would fit that
+ * section. Powers the "suggest a layout for this section" affordance
+ * (see #611).
+ *
+ * ## Input
+ *
+ * ```
+ * [
+ *   'section_content'    => array,     // required, ordered list of block payloads inside the section
+ *   'available_patterns' => string[],  // required, non-empty list of pattern slugs
+ * ]
+ * ```
+ *
+ * Pattern slugs are opaque to the agent; the caller is expected to
+ * resolve slugs back to actual pattern definitions when applying the
+ * suggestion. Passing rich pattern descriptions is supported by encoding
+ * them into the slug (`"hero-two-column: side-by-side hero with image"`),
+ * but the shipped format is deliberately slug-only to keep the prompt
+ * small.
+ *
+ * ## Output schema
+ *
+ * ```
+ * {
+ *   matches: [
+ *     { pattern_slug: string, confidence: float, rationale: string }
+ *   ]
+ * }
+ * ```
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @since      1.3.0
+ */
+class LayoutSuggestionAgent extends ArtisanPackAgent
+{
+	/**
+	 * {@inheritDoc}
+	 */
+	public string $featureKey = 'visual_editor.suggest_layout';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public string $package = 'artisanpack-ui/visual-editor';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public string $defaultModel = 'claude-haiku-4-5';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function instructions(): string
+	{
+		return <<<'PROMPT'
+You rank candidate section-layout patterns for the supplied section content.
+
+Requirements:
+- Only return slugs that appear in `available_patterns`. Do NOT invent slugs.
+- Return between 1 and 5 matches, ordered by descending confidence.
+- `confidence` is a float in [0, 1]. Use 0.9+ when the content clearly fits (e.g. a heading + three parallel paragraphs → three-column feature grid); 0.5 for a reasonable fit; below 0.4 for weak matches — omit those entirely rather than including them.
+- `rationale` is a single sentence naming the structural cue that drove the match (e.g. "three parallel paragraphs suggest a three-column grid").
+- If NONE of the available patterns fits, return an empty `matches` array. Do not force a suggestion.
+
+Return a JSON object with key `matches` (array of {pattern_slug, confidence, rationale}).
+PROMPT;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function outputSchema(): array
+	{
+		return [
+			'type'                 => 'object',
+			'additionalProperties' => false,
+			'required'             => [ 'matches' ],
+			'properties'           => [
+				'matches' => [
+					'type'     => 'array',
+					'maxItems' => 5,
+					'items'    => [
+						'type'                 => 'object',
+						'additionalProperties' => false,
+						'required'             => [ 'pattern_slug', 'confidence', 'rationale' ],
+						'properties'           => [
+							'pattern_slug' => [ 'type' => 'string' ],
+							'confidence'   => [ 'type' => 'number', 'minimum' => 0, 'maximum' => 1 ],
+							'rationale'    => [ 'type' => 'string' ],
+						],
+					],
+				],
+			],
+		];
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function execute( Credentials $credentials, string $model, string $instructions ): array
+	{
+		$normalized = $this->normalizeInput( $this->input() );
+
+		$prompter = app( AgentPrompter::class );
+
+		$result = $prompter->prompt(
+			credentials: $credentials,
+			model: $model,
+			instructions: $instructions,
+			message: $this->buildMessage( $normalized ),
+			outputSchema: $this->outputSchema(),
+		);
+
+		return [
+			'output'        => $this->validateOutput( $result['output'], $normalized['available_patterns'] ),
+			'input_tokens'  => (int) ( $result['input_tokens'] ?? 0 ),
+			'output_tokens' => (int) ( $result['output_tokens'] ?? 0 ),
+		];
+	}
+
+	/**
+	 * Validate and shape-check the raw agent input.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param  mixed  $input  Raw agent input.
+	 *
+	 * @return array{ section_content: array<int, mixed>, available_patterns: array<int, string> }
+	 */
+	protected function normalizeInput( mixed $input ): array
+	{
+		if ( ! is_array( $input ) ) {
+			throw FeatureError::forFeature(
+				$this->featureKey,
+				'input must be an array with `section_content` and `available_patterns` keys.',
+			);
+		}
+
+		if ( ! isset( $input['section_content'] ) || ! is_array( $input['section_content'] ) ) {
+			throw FeatureError::forFeature( $this->featureKey, '`section_content` must be an array.' );
+		}
+
+		if ( ! isset( $input['available_patterns'] ) || ! is_array( $input['available_patterns'] ) ) {
+			throw FeatureError::forFeature( $this->featureKey, '`available_patterns` must be an array of pattern slugs.' );
+		}
+
+		$patterns = [];
+		foreach ( $input['available_patterns'] as $slug ) {
+			if ( is_string( $slug ) && '' !== trim( $slug ) ) {
+				$patterns[] = trim( $slug );
+			}
+		}
+
+		if ( [] === $patterns ) {
+			throw FeatureError::forFeature( $this->featureKey, '`available_patterns` must contain at least one non-empty slug.' );
+		}
+
+		return [
+			'section_content'    => array_values( $input['section_content'] ),
+			'available_patterns' => array_values( array_unique( $patterns ) ),
+		];
+	}
+
+	/**
+	 * Build the structured message body for the prompter.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param  array{ section_content: array<int, mixed>, available_patterns: array<int, string> }  $input  Normalized input.
+	 *
+	 * @return array<int, array<string, string>>
+	 */
+	protected function buildMessage( array $input ): array
+	{
+		try {
+			$content = json_encode( $input['section_content'], JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
+		} catch ( JsonException $e ) {
+			throw FeatureError::forFeature(
+				$this->featureKey,
+				sprintf( 'section_content is not JSON-encodable: %s', $e->getMessage() ),
+			);
+		}
+
+		return [
+			[ 'type' => 'text', 'text' => sprintf( 'Section content: %s', $content ) ],
+			[ 'type' => 'text', 'text' => 'Available patterns: ' . implode( ', ', $input['available_patterns'] ) ],
+		];
+	}
+
+	/**
+	 * Enforce the output schema shape and drop matches with unknown slugs.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param  array<string, mixed>  $output      Decoded model output.
+	 * @param  array<int, string>    $whitelisted Known pattern slugs.
+	 *
+	 * @return array{ matches: array<int, array{ pattern_slug: string, confidence: float, rationale: string }> }
+	 */
+	protected function validateOutput( array $output, array $whitelisted ): array
+	{
+		$rawMatches = isset( $output['matches'] ) && is_array( $output['matches'] )
+			? $output['matches']
+			: [];
+
+		$known = array_flip( $whitelisted );
+		$clean = [];
+		foreach ( $rawMatches as $entry ) {
+			if ( ! is_array( $entry ) ) {
+				continue;
+			}
+
+			$slug      = isset( $entry['pattern_slug'] ) ? trim( (string) $entry['pattern_slug'] ) : '';
+			$rationale = isset( $entry['rationale'] ) ? trim( (string) $entry['rationale'] ) : '';
+			$conf      = isset( $entry['confidence'] ) ? (float) $entry['confidence'] : 0.0;
+
+			if ( '' === $slug || ! isset( $known[ $slug ] ) ) {
+				continue;
+			}
+
+			if ( $conf < 0.0 ) {
+				$conf = 0.0;
+			} elseif ( $conf > 1.0 ) {
+				$conf = 1.0;
+			}
+
+			$clean[] = [
+				'pattern_slug' => $slug,
+				'confidence'   => $conf,
+				'rationale'    => $rationale,
+			];
+
+			if ( 5 === count( $clean ) ) {
+				break;
+			}
+		}
+
+		return [ 'matches' => $clean ];
+	}
+}

--- a/src/Http/Controllers/Ai/AiController.php
+++ b/src/Http/Controllers/Ai/AiController.php
@@ -1,0 +1,203 @@
+<?php
+
+/**
+ * JSON API controller for the visual-editor's AI trigger surface.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @since      1.3.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Http\Controllers\Ai;
+
+use ArtisanPackUI\Ai\Agents\AltTextGenerationAgent;
+use ArtisanPackUI\Ai\Agents\ContentRewriteAgent;
+use ArtisanPackUI\Ai\Contracts\FeatureRegistry;
+use ArtisanPackUI\Ai\Exceptions\FeatureDisabledException;
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+use ArtisanPackUI\Ai\Exceptions\MissingCredentialsException;
+use ArtisanPackUI\VisualEditor\Ai\Agents\ContentBlockSuggestionAgent;
+use ArtisanPackUI\VisualEditor\Ai\Agents\HeadingHierarchyAgent;
+use ArtisanPackUI\VisualEditor\Ai\Agents\LayoutSuggestionAgent;
+use ArtisanPackUI\VisualEditor\Http\Requests\Ai\AltTextRequest;
+use ArtisanPackUI\VisualEditor\Http\Requests\Ai\HeadingHierarchyRequest;
+use ArtisanPackUI\VisualEditor\Http\Requests\Ai\RewriteContentRequest;
+use ArtisanPackUI\VisualEditor\Http\Requests\Ai\SuggestLayoutRequest;
+use ArtisanPackUI\VisualEditor\Http\Requests\Ai\SuggestNextBlockRequest;
+use ArtisanPackUI\VisualEditor\VisualEditorServiceProvider;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+/**
+ * REST surface used by the React editor. Each endpoint runs one agent
+ * against a validated body and returns the shaped output, plus token
+ * accounting when present. Feature-toggle enforcement lives inside the
+ * agents themselves — this controller only wraps errors in a consistent
+ * JSON envelope.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @since      1.3.0
+ */
+class AiController
+{
+	/**
+	 * Return the enabled state of the five features the editor cares about.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @return JsonResponse
+	 */
+	public function features(): JsonResponse
+	{
+		/** @var FeatureRegistry $registry */
+		$registry = app( FeatureRegistry::class );
+
+		$state = [];
+		foreach ( VisualEditorServiceProvider::AI_FEATURE_KEYS as $key ) {
+			$state[ $key ] = null !== $registry->get( $key ) && $registry->isToggleOn( $key );
+		}
+
+		return new JsonResponse( [ 'features' => $state ] );
+	}
+
+	/**
+	 * POST /suggest-next-block.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param  SuggestNextBlockRequest  $request  Incoming request.
+	 *
+	 * @return JsonResponse
+	 */
+	public function suggestNextBlock( SuggestNextBlockRequest $request ): JsonResponse
+	{
+		return $this->runAgent(
+			'visual_editor.suggest_next_block',
+			fn () => ContentBlockSuggestionAgent::for( $request->validated() )->run(),
+		);
+	}
+
+	/**
+	 * POST /suggest-layout.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param  SuggestLayoutRequest  $request  Incoming request.
+	 *
+	 * @return JsonResponse
+	 */
+	public function suggestLayout( SuggestLayoutRequest $request ): JsonResponse
+	{
+		return $this->runAgent(
+			'visual_editor.suggest_layout',
+			fn () => LayoutSuggestionAgent::for( $request->validated() )->run(),
+		);
+	}
+
+	/**
+	 * POST /alt-text.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param  AltTextRequest  $request  Incoming request.
+	 *
+	 * @return JsonResponse
+	 */
+	public function altText( AltTextRequest $request ): JsonResponse
+	{
+		return $this->runAgent(
+			'ai.alt_text',
+			fn () => AltTextGenerationAgent::for( $request->validated()['image'] )->run(),
+		);
+	}
+
+	/**
+	 * POST /rewrite.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param  RewriteContentRequest  $request  Incoming request.
+	 *
+	 * @return JsonResponse
+	 */
+	public function rewrite( RewriteContentRequest $request ): JsonResponse
+	{
+		return $this->runAgent(
+			'ai.content_rewrite',
+			fn () => ContentRewriteAgent::for( $request->validated() )->run(),
+		);
+	}
+
+	/**
+	 * POST /heading-hierarchy.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param  HeadingHierarchyRequest  $request  Incoming request.
+	 *
+	 * @return JsonResponse
+	 */
+	public function headingHierarchy( HeadingHierarchyRequest $request ): JsonResponse
+	{
+		return $this->runAgent(
+			'visual_editor.heading_hierarchy',
+			fn () => HeadingHierarchyAgent::for( $request->validated() )->run(),
+		);
+	}
+
+	/**
+	 * Shared wrapper — normalizes the four agent-exception categories into
+	 * consistent status codes + JSON envelopes.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param  string    $featureKey  Feature key (for logging + envelope).
+	 * @param  callable  $callback    Callable returning the agent output.
+	 *
+	 * @return JsonResponse
+	 */
+	private function runAgent( string $featureKey, callable $callback ): JsonResponse
+	{
+		try {
+			$output = $callback();
+			return new JsonResponse( [
+				'feature' => $featureKey,
+				'output'  => $output,
+			] );
+		} catch ( FeatureDisabledException $e ) {
+			return new JsonResponse( [
+				'feature' => $featureKey,
+				'error'   => 'feature_disabled',
+				'message' => $e->getMessage(),
+			], 403 );
+		} catch ( MissingCredentialsException $e ) {
+			return new JsonResponse( [
+				'feature' => $featureKey,
+				'error'   => 'missing_credentials',
+				'message' => $e->getMessage(),
+			], 503 );
+		} catch ( FeatureError $e ) {
+			return new JsonResponse( [
+				'feature' => $featureKey,
+				'error'   => 'invalid_input',
+				'message' => $e->getMessage(),
+			], 422 );
+		} catch ( Throwable $e ) {
+			Log::error( 'visual-editor AI API call failed', [
+				'feature' => $featureKey,
+				'error'   => $e->getMessage(),
+			] );
+			return new JsonResponse( [
+				'feature' => $featureKey,
+				'error'   => 'internal_error',
+				'message' => 'Unexpected error running AI feature.',
+			], 500 );
+		}
+	}
+}

--- a/src/Http/Requests/Ai/AltTextRequest.php
+++ b/src/Http/Requests/Ai/AltTextRequest.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * AltText form request.
+ *
+ * Enforces the string-or-array shape `AltTextGenerationAgent::for()`
+ * accepts — closes the review #4 gap where a bare `required` rule let
+ * arbitrary scalars (integers, booleans) reach the agent and surface as
+ * 500s instead of 422s.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @since      1.3.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Http\Requests\Ai;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class AltTextRequest extends FormRequest
+{
+	public function authorize(): bool
+	{
+		return true;
+	}
+
+	/**
+	 * @return array<string, array<int, mixed>>
+	 */
+	public function rules(): array
+	{
+		return [
+			'image'        => [ 'required', $this->stringOrArrayRule() ],
+			'image.source' => [ 'required_array_keys:source,value', 'string', 'in:path,url,base64' ],
+			'image.value'  => [ 'sometimes', 'string' ],
+		];
+	}
+
+	/**
+	 * `image` must be a string OR an array with source+value keys — the
+	 * two shapes AltTextGenerationAgent normalizes. Laravel's built-in
+	 * rules don't compose "string OR array", so this closure handles it.
+	 *
+	 * @since 1.3.0
+	 */
+	private function stringOrArrayRule(): Closure
+	{
+		return function ( string $attribute, mixed $value, Closure $fail ): void {
+			if ( is_string( $value ) && '' !== $value ) {
+				return;
+			}
+			if ( is_array( $value ) && isset( $value['source'], $value['value'] ) ) {
+				return;
+			}
+			$fail( 'The image must be a non-empty string or an object with `source` and `value` keys.' );
+		};
+	}
+}

--- a/src/Http/Requests/Ai/HeadingHierarchyRequest.php
+++ b/src/Http/Requests/Ai/HeadingHierarchyRequest.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * HeadingHierarchy form request.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @since      1.3.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Http\Requests\Ai;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class HeadingHierarchyRequest extends FormRequest
+{
+	public function authorize(): bool
+	{
+		return true;
+	}
+
+	/**
+	 * @return array<string, array<int, mixed>>
+	 */
+	public function rules(): array
+	{
+		return [
+			'blocks' => [ 'required', 'array' ],
+		];
+	}
+}

--- a/src/Http/Requests/Ai/RewriteContentRequest.php
+++ b/src/Http/Requests/Ai/RewriteContentRequest.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * RewriteContent form request.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @since      1.3.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Http\Requests\Ai;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class RewriteContentRequest extends FormRequest
+{
+	public function authorize(): bool
+	{
+		return true;
+	}
+
+	/**
+	 * @return array<string, array<int, mixed>>
+	 */
+	public function rules(): array
+	{
+		return [
+			'content' => [ 'required', 'string' ],
+			'intent'  => [ 'required', 'string', 'max:256' ],
+		];
+	}
+}

--- a/src/Http/Requests/Ai/SuggestLayoutRequest.php
+++ b/src/Http/Requests/Ai/SuggestLayoutRequest.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * SuggestLayout form request.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @since      1.3.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Http\Requests\Ai;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class SuggestLayoutRequest extends FormRequest
+{
+	public function authorize(): bool
+	{
+		return true;
+	}
+
+	/**
+	 * @return array<string, array<int, mixed>>
+	 */
+	public function rules(): array
+	{
+		return [
+			'section_content'      => [ 'required', 'array' ],
+			'available_patterns'   => [ 'required', 'array', 'min:1' ],
+			'available_patterns.*' => [ 'string', 'max:128' ],
+		];
+	}
+}

--- a/src/Http/Requests/Ai/SuggestNextBlockRequest.php
+++ b/src/Http/Requests/Ai/SuggestNextBlockRequest.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * SuggestNextBlock form request.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @since      1.3.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Http\Requests\Ai;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class SuggestNextBlockRequest extends FormRequest
+{
+	public function authorize(): bool
+	{
+		return true;
+	}
+
+	/**
+	 * @return array<string, array<int, mixed>>
+	 */
+	public function rules(): array
+	{
+		return [
+			'existing_blocks' => [ 'required', 'array' ],
+			'cursor_position' => [ 'required', 'integer', 'min:0' ],
+			'document_type'   => [ 'nullable', 'string', 'max:64' ],
+		];
+	}
+}

--- a/src/Livewire/Ai/AiTools.php
+++ b/src/Livewire/Ai/AiTools.php
@@ -1,0 +1,248 @@
+<?php
+
+/**
+ * Livewire trigger surface for the visual-editor AI features.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @since      1.3.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Livewire\Ai;
+
+use ArtisanPackUI\Ai\Agents\AltTextGenerationAgent;
+use ArtisanPackUI\Ai\Agents\ContentRewriteAgent;
+use ArtisanPackUI\Ai\Contracts\FeatureRegistry;
+use ArtisanPackUI\Ai\Exceptions\FeatureDisabledException;
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+use ArtisanPackUI\Ai\Exceptions\MissingCredentialsException;
+use ArtisanPackUI\VisualEditor\Ai\Agents\ContentBlockSuggestionAgent;
+use ArtisanPackUI\VisualEditor\Ai\Agents\HeadingHierarchyAgent;
+use ArtisanPackUI\VisualEditor\Ai\Agents\LayoutSuggestionAgent;
+use ArtisanPackUI\VisualEditor\VisualEditorServiceProvider;
+use Illuminate\Support\Facades\Log;
+use Livewire\Attributes\On;
+use Livewire\Component;
+use Throwable;
+
+/**
+ * Thin Livewire wrapper that runs any of the five AI features the visual
+ * editor exposes and dispatches the shaped result via a browser event.
+ * Editor React code (or any host Blade view) listens for the event on
+ * `ap-ve-ai:{featureKey}:{status}` and folds the payload into the UI.
+ *
+ * The component intentionally holds no persistent state — a Livewire
+ * class was picked so:
+ *   - CSRF, auth, and rate limiting come "for free" via the standard
+ *     Livewire endpoint
+ *   - Hosts embedding a Blade admin surface can wire the same triggers
+ *     without stamping five bespoke controllers
+ *   - Feature-toggle checks live in one place
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @since      1.3.0
+ */
+class AiTools extends Component
+{
+	/**
+	 * Suggest the next block given the current block list + caret offset.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param  array<int, mixed>  $existingBlocks   Ordered block list.
+	 * @param  int                $cursorPosition   Insertion offset (0-indexed).
+	 * @param  string|null        $documentType     Optional shape hint.
+	 *
+	 * @return void
+	 */
+	#[On( 'ap-ve-ai:suggest-next-block' )]
+	public function suggestNextBlock( array $existingBlocks, int $cursorPosition, ?string $documentType = null ): void
+	{
+		$this->run(
+			'visual_editor.suggest_next_block',
+			fn () => ContentBlockSuggestionAgent::for( [
+				'existing_blocks' => $existingBlocks,
+				'cursor_position' => $cursorPosition,
+				'document_type'   => $documentType,
+			] )->run(),
+		);
+	}
+
+	/**
+	 * Suggest a section layout from the caller's pattern library.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param  array<int, mixed>   $sectionContent      Block payloads inside the section.
+	 * @param  array<int, string>  $availablePatterns   Whitelist of pattern slugs.
+	 *
+	 * @return void
+	 */
+	#[On( 'ap-ve-ai:suggest-layout' )]
+	public function suggestLayout( array $sectionContent, array $availablePatterns ): void
+	{
+		$this->run(
+			'visual_editor.suggest_layout',
+			fn () => LayoutSuggestionAgent::for( [
+				'section_content'    => $sectionContent,
+				'available_patterns' => $availablePatterns,
+			] )->run(),
+		);
+	}
+
+	/**
+	 * Generate alt text for a newly added image block (see #612).
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param  string|array<string, mixed>  $image  Image reference — see AltTextGenerationAgent for accepted shapes.
+	 *
+	 * @return void
+	 */
+	#[On( 'ap-ve-ai:generate-alt-text' )]
+	public function generateAltText( string|array $image ): void
+	{
+		$this->run(
+			'ai.alt_text',
+			fn () => AltTextGenerationAgent::for( $image )->run(),
+		);
+	}
+
+	/**
+	 * Rewrite a piece of content according to an intent (see #613).
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param  string  $content  Original content (Markdown, HTML, or plain text).
+	 * @param  string  $intent   Rewrite intent ("shorter", "more formal", "reading level 6", ...).
+	 *
+	 * @return void
+	 */
+	#[On( 'ap-ve-ai:rewrite-content' )]
+	public function rewriteContent( string $content, string $intent ): void
+	{
+		$this->run(
+			'ai.content_rewrite',
+			fn () => ContentRewriteAgent::for( [
+				'content' => $content,
+				'intent'  => $intent,
+			] )->run(),
+		);
+	}
+
+	/**
+	 * Audit the document's heading hierarchy (see #614).
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param  array<int, mixed>  $blocks  Ordered block payloads.
+	 *
+	 * @return void
+	 */
+	#[On( 'ap-ve-ai:check-headings' )]
+	public function checkHeadings( array $blocks ): void
+	{
+		$this->run(
+			'visual_editor.heading_hierarchy',
+			fn () => HeadingHierarchyAgent::for( [ 'blocks' => $blocks ] )->run(),
+		);
+	}
+
+	/**
+	 * Return the currently-enabled feature toggle map so the front-end
+	 * knows which affordances to render.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @return array<string, bool>
+	 */
+	public function enabledFeatures(): array
+	{
+		/** @var FeatureRegistry $registry */
+		$registry = app( FeatureRegistry::class );
+
+		$state = [];
+		foreach ( VisualEditorServiceProvider::AI_FEATURE_KEYS as $key ) {
+			$state[ $key ] = null !== $registry->get( $key ) && $registry->isToggleOn( $key );
+		}
+		return $state;
+	}
+
+	/**
+	 * Blade shell — hosts can override the view or inline the component
+	 * without body. The default view is intentionally empty; this is a
+	 * transport component, not a UI.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @return string
+	 */
+	public function render(): string
+	{
+		return '<div class="ap-ve-ai-tools" data-testid="ap-ve-ai-tools"></div>';
+	}
+
+	/**
+	 * Shared run-and-emit path. Kept private so callers can only reach
+	 * agents through the five public entry points, each of which
+	 * pre-shapes its input.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param  string   $featureKey  Feature key (for status events).
+	 * @param  callable $callback    Callable that runs the agent and returns its output.
+	 *
+	 * @return void
+	 */
+	private function run( string $featureKey, callable $callback ): void
+	{
+		try {
+			$output = $callback();
+
+			$this->dispatch(
+				sprintf( 'ap-ve-ai:%s:success', $featureKey ),
+				feature: $featureKey,
+				output: $output,
+			);
+		} catch ( FeatureDisabledException $e ) {
+			$this->dispatch(
+				sprintf( 'ap-ve-ai:%s:disabled', $featureKey ),
+				feature: $featureKey,
+				message: $e->getMessage(),
+			);
+		} catch ( MissingCredentialsException $e ) {
+			$this->dispatch(
+				sprintf( 'ap-ve-ai:%s:missing-credentials', $featureKey ),
+				feature: $featureKey,
+				message: $e->getMessage(),
+			);
+		} catch ( FeatureError $e ) {
+			// FeatureError is a user-fixable validation problem (bad
+			// input, empty required field, etc.). Emit under a distinct
+			// event name so front-end listeners can route it to a
+			// form-level warning instead of a generic error toast
+			// (review #7). Mirrors the HTTP surface's 422 status.
+			$this->dispatch(
+				sprintf( 'ap-ve-ai:%s:invalid-input', $featureKey ),
+				feature: $featureKey,
+				message: $e->getMessage(),
+			);
+		} catch ( Throwable $e ) {
+			Log::error( 'visual-editor AI trigger failed', [
+				'feature' => $featureKey,
+				'error'   => $e->getMessage(),
+			] );
+
+			$this->dispatch(
+				sprintf( 'ap-ve-ai:%s:error', $featureKey ),
+				feature: $featureKey,
+				message: 'Unexpected error running AI feature.',
+			);
+		}
+	}
+}

--- a/src/VisualEditorServiceProvider.php
+++ b/src/VisualEditorServiceProvider.php
@@ -36,6 +36,9 @@ use ArtisanPackUI\VisualEditor\Resources\CommentInliner;
 use ArtisanPackUI\VisualEditor\Resources\CommentResolver;
 use ArtisanPackUI\VisualEditor\Resources\QueryInliner;
 use ArtisanPackUI\VisualEditor\Resources\ResourceResolver;
+use ArtisanPackUI\VisualEditor\Ai\Agents\ContentBlockSuggestionAgent;
+use ArtisanPackUI\VisualEditor\Ai\Agents\HeadingHierarchyAgent;
+use ArtisanPackUI\VisualEditor\Ai\Agents\LayoutSuggestionAgent;
 use ArtisanPackUI\VisualEditor\Animations\AnimationAttributeResolver;
 use ArtisanPackUI\VisualEditor\Animations\AnimationCssEmitter;
 use ArtisanPackUI\VisualEditor\Animations\AnimationRegistry;
@@ -65,6 +68,62 @@ use Illuminate\Support\ServiceProvider;
 
 class VisualEditorServiceProvider extends ServiceProvider
 {
+	/**
+	 * The full set of AI feature keys the visual editor exposes in its UI.
+	 *
+	 * Single source of truth: `AiController::features()`, `AiTools::enabledFeatures()`,
+	 * and the JS editor bundle (via `/ai/features`) all read from here so a
+	 * future 6th feature only lands in one place (see review #6). Two of
+	 * the keys (`ai.alt_text`, `ai.content_rewrite`) are cross-cutting —
+	 * the visual editor consumes them but the `artisanpack-ui/ai` package
+	 * owns their registration.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @var array<int, string>
+	 */
+	public const AI_FEATURE_KEYS = [
+		'visual_editor.suggest_next_block',
+		'visual_editor.suggest_layout',
+		'visual_editor.heading_hierarchy',
+		'ai.alt_text',
+		'ai.content_rewrite',
+	];
+
+	/**
+	 * Declare the AI features this package owns.
+	 *
+	 * Auto-discovered by `artisanpack-ui/ai`'s `FeatureRegistry` (see AI RFC).
+	 * When the AI package is absent, this method is simply never called and
+	 * has no effect — the visual-editor still boots without AI wiring.
+	 *
+	 * The three keys below are owned by this package. The cross-cutting
+	 * `ai.alt_text` and `ai.content_rewrite` features are consumed via the
+	 * ai package's registration; visual-editor's UI checks those toggles
+	 * before rendering the corresponding editor affordances (see #612,
+	 * #613).
+	 *
+	 * @since 1.3.0
+	 *
+	 * @return array<string, array{ agent: class-string, package: string }>
+	 */
+	public function aiFeatures(): array
+	{
+		return [
+			'visual_editor.suggest_next_block' => [
+				'agent'   => ContentBlockSuggestionAgent::class,
+				'package' => 'artisanpack-ui/visual-editor',
+			],
+			'visual_editor.suggest_layout'     => [
+				'agent'   => LayoutSuggestionAgent::class,
+				'package' => 'artisanpack-ui/visual-editor',
+			],
+			'visual_editor.heading_hierarchy'  => [
+				'agent'   => HeadingHierarchyAgent::class,
+				'package' => 'artisanpack-ui/visual-editor',
+			],
+		];
+	}
 
 	public function register(): void
 	{
@@ -452,6 +511,7 @@ class VisualEditorServiceProvider extends ServiceProvider
 
 		$this->registerApiRoutes();
 		$this->registerBladeComponents();
+		$this->registerAiLivewireComponents();
 
 		Gate::policy( VisualEditorPost::class, VisualEditorPostPolicy::class );
 
@@ -743,6 +803,31 @@ class VisualEditorServiceProvider extends ServiceProvider
 	protected function registerBladeComponents(): void
 	{
 		Blade::component( VisualEditorComponent::class, 'visual-editor' );
+	}
+
+	/**
+	 * Register the AI trigger Livewire component when both Livewire and
+	 * the artisanpack-ui/ai foundation are present. Guarded so the visual
+	 * editor still boots on hosts that opt out of AI or Livewire.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @return void
+	 */
+	protected function registerAiLivewireComponents(): void
+	{
+		if ( ! class_exists( \Livewire\Livewire::class ) ) {
+			return;
+		}
+
+		if ( ! class_exists( \ArtisanPackUI\Ai\Agents\ArtisanPackAgent::class ) ) {
+			return;
+		}
+
+		\Livewire\Livewire::component(
+			'artisanpack-visual-editor.ai.tools',
+			\ArtisanPackUI\VisualEditor\Livewire\Ai\AiTools::class,
+		);
 	}
 
 

--- a/tests/Feature/Ai/AiAgentTestSetup.php
+++ b/tests/Feature/Ai/AiAgentTestSetup.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * Shared bootstrap for visual-editor AI agent tests.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @since      1.3.0
+ */
+
+declare( strict_types=1 );
+
+namespace Tests\Feature\Ai;
+
+use ArtisanPackUI\Ai\Contracts\AgentPrompter;
+use ArtisanPackUI\Ai\Contracts\CredentialResolver;
+use ArtisanPackUI\Ai\Credentials\ChainedCredentialResolver;
+use ArtisanPackUI\Ai\Credentials\Credentials;
+use Tests\Support\FakeAgentPrompter;
+
+/**
+ * Registers a fake prompter, stub credentials, and enables the five
+ * feature toggles the visual editor cares about.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @since      1.3.0
+ */
+final class AiAgentTestSetup
+{
+	/**
+	 * @since 1.3.0
+	 *
+	 * @param  \Illuminate\Foundation\Application  $app  Application instance.
+	 *
+	 * @return FakeAgentPrompter The bound fake prompter.
+	 */
+	public static function bootstrap( $app ): FakeAgentPrompter
+	{
+		/** @var ChainedCredentialResolver $resolver */
+		$resolver = $app->make( CredentialResolver::class );
+		$resolver->setOverride(
+			new Credentials( provider: 'anthropic', apiKey: 'sk-test', defaultModel: 'claude-haiku-4-5' ),
+		);
+		$resolver->useStore( fn () => null );
+
+		$prompter = new FakeAgentPrompter();
+		$app->instance( AgentPrompter::class, $prompter );
+
+		foreach (
+			[
+				'visual_editor.suggest_next_block',
+				'visual_editor.suggest_layout',
+				'visual_editor.heading_hierarchy',
+				'ai.alt_text',
+				'ai.content_rewrite',
+			] as $key
+		) {
+			$app['config']->set( "artisanpack.ai.features.{$key}.enabled", true );
+		}
+
+		return $prompter;
+	}
+}

--- a/tests/Feature/Ai/AiTestCase.php
+++ b/tests/Feature/Ai/AiTestCase.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * Test-case for visual-editor AI feature tests.
+ *
+ * Boots the ai package's service provider alongside the visual-editor
+ * one so `FeatureRegistry`, `AgentPrompter`, and `CredentialResolver`
+ * are all bindable.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @since      1.3.0
+ */
+
+declare( strict_types=1 );
+
+namespace Tests\Feature\Ai;
+
+use ArtisanPackUI\Ai\AiServiceProvider;
+use ArtisanPackUI\VisualEditor\VisualEditorServiceProvider;
+use Orchestra\Testbench\TestCase as BaseTestCase;
+
+abstract class AiTestCase extends BaseTestCase
+{
+	/**
+	 * @param  \Illuminate\Foundation\Application  $app
+	 *
+	 * @return array<int, class-string>
+	 */
+	protected function getPackageProviders( $app ): array
+	{
+		return [
+			AiServiceProvider::class,
+			VisualEditorServiceProvider::class,
+		];
+	}
+
+	/**
+	 * @param  \Illuminate\Foundation\Application  $app
+	 */
+	protected function defineEnvironment( $app ): void
+	{
+		$app['config']->set( 'app.key', 'base64:' . base64_encode( random_bytes( 32 ) ) );
+		$app['config']->set( 'database.default', 'testbench' );
+		$app['config']->set( 'database.connections.testbench', [
+			'driver'                  => 'sqlite',
+			'database'                => ':memory:',
+			'prefix'                  => '',
+			'foreign_key_constraints' => true,
+		] );
+	}
+}

--- a/tests/Feature/Ai/ContentBlockSuggestionAgentTest.php
+++ b/tests/Feature/Ai/ContentBlockSuggestionAgentTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+use ArtisanPackUI\VisualEditor\Ai\Agents\ContentBlockSuggestionAgent;
+use Tests\Feature\Ai\AiAgentTestSetup;
+
+beforeEach( function (): void {
+	$this->prompter = AiAgentTestSetup::bootstrap( $this->app );
+} );
+
+it( 'returns shaped suggestions when the prompter responds', function (): void {
+	$this->prompter->queue( [
+		'suggestions' => [
+			[ 'block_type' => 'core/heading', 'why' => 'starts a new section' ],
+			[ 'block_type' => 'core/paragraph', 'why' => 'continues the narrative', 'starter_content' => 'To begin,' ],
+		],
+	] );
+
+	$result = ContentBlockSuggestionAgent::for( [
+		'existing_blocks' => [ [ 'type' => 'core/paragraph' ] ],
+		'cursor_position' => 1,
+	] )->run();
+
+	expect( $result['suggestions'] )->toHaveCount( 2 );
+	expect( $result['suggestions'][0]['block_type'] )->toBe( 'core/heading' );
+	expect( $result['suggestions'][1] )->toHaveKey( 'starter_content' );
+} );
+
+it( 'drops suggestions missing required fields', function (): void {
+	$this->prompter->queue( [
+		'suggestions' => [
+			[ 'block_type' => 'core/list', 'why' => 'good for enumerating' ],
+			[ 'block_type' => '', 'why' => 'empty type is invalid' ],
+			[ 'why' => 'no block_type at all' ],
+		],
+	] );
+
+	$result = ContentBlockSuggestionAgent::for( [
+		'existing_blocks' => [],
+		'cursor_position' => 0,
+	] )->run();
+
+	expect( $result['suggestions'] )->toHaveCount( 1 );
+	expect( $result['suggestions'][0]['block_type'] )->toBe( 'core/list' );
+} );
+
+it( 'caps returned suggestions at 4', function (): void {
+	$queued = [ 'suggestions' => [] ];
+	for ( $i = 0; $i < 8; $i++ ) {
+		$queued['suggestions'][] = [ 'block_type' => "core/type-{$i}", 'why' => 'ok' ];
+	}
+	$this->prompter->queue( $queued );
+
+	$result = ContentBlockSuggestionAgent::for( [
+		'existing_blocks' => [],
+		'cursor_position' => 0,
+	] )->run();
+
+	expect( $result['suggestions'] )->toHaveCount( 4 );
+} );
+
+it( 'raises FeatureError on invalid input', function (): void {
+	expect( fn () => ContentBlockSuggestionAgent::for( 'not-an-array' )->run() )
+		->toThrow( FeatureError::class );
+
+	expect( fn () => ContentBlockSuggestionAgent::for( [ 'existing_blocks' => [] ] )->run() )
+		->toThrow( FeatureError::class );
+
+	expect( fn () => ContentBlockSuggestionAgent::for( [ 'existing_blocks' => [], 'cursor_position' => -1 ] )->run() )
+		->toThrow( FeatureError::class );
+} );
+
+it( 'forwards document_type into the prompter message when set', function (): void {
+	$this->prompter->queue( [ 'suggestions' => [ [ 'block_type' => 'core/heading', 'why' => 'ok' ] ] ] );
+
+	ContentBlockSuggestionAgent::for( [
+		'existing_blocks' => [],
+		'cursor_position' => 0,
+		'document_type'   => 'landing-page',
+	] )->run();
+
+	$parts = collect( $this->prompter->calls[0]['message'] )->pluck( 'text' );
+	expect( $parts->contains( fn ( string $t ): bool => str_contains( $t, 'landing-page' ) ) )->toBeTrue();
+} );

--- a/tests/Feature/Ai/FeatureRegistrationTest.php
+++ b/tests/Feature/Ai/FeatureRegistrationTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Ai\Contracts\FeatureRegistry;
+use ArtisanPackUI\VisualEditor\Ai\Agents\ContentBlockSuggestionAgent;
+use ArtisanPackUI\VisualEditor\Ai\Agents\HeadingHierarchyAgent;
+use ArtisanPackUI\VisualEditor\Ai\Agents\LayoutSuggestionAgent;
+use ArtisanPackUI\VisualEditor\VisualEditorServiceProvider;
+
+it( 'declares three visual_editor.* features from the service provider', function (): void {
+	$provider = new VisualEditorServiceProvider( $this->app );
+	$features = $provider->aiFeatures();
+
+	expect( $features )->toHaveKeys( [
+		'visual_editor.suggest_next_block',
+		'visual_editor.suggest_layout',
+		'visual_editor.heading_hierarchy',
+	] );
+
+	expect( $features['visual_editor.suggest_next_block']['agent'] )->toBe( ContentBlockSuggestionAgent::class );
+	expect( $features['visual_editor.suggest_layout']['agent'] )->toBe( LayoutSuggestionAgent::class );
+	expect( $features['visual_editor.heading_hierarchy']['agent'] )->toBe( HeadingHierarchyAgent::class );
+
+	foreach ( $features as $definition ) {
+		expect( $definition['package'] )->toBe( 'artisanpack-ui/visual-editor' );
+	}
+} );
+
+it( 'registers those three features with the ai FeatureRegistry at boot', function (): void {
+	/** @var FeatureRegistry $registry */
+	$registry = $this->app->make( FeatureRegistry::class );
+
+	expect( $registry->get( 'visual_editor.suggest_next_block' ) )->not->toBeNull();
+	expect( $registry->get( 'visual_editor.suggest_layout' ) )->not->toBeNull();
+	expect( $registry->get( 'visual_editor.heading_hierarchy' ) )->not->toBeNull();
+} );

--- a/tests/Feature/Ai/HeadingHierarchyAgentTest.php
+++ b/tests/Feature/Ai/HeadingHierarchyAgentTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+use ArtisanPackUI\VisualEditor\Ai\Agents\HeadingHierarchyAgent;
+use Tests\Feature\Ai\AiAgentTestSetup;
+
+beforeEach( function (): void {
+	$this->prompter = AiAgentTestSetup::bootstrap( $this->app );
+} );
+
+it( 'short-circuits to an empty issues array when no headings are present', function (): void {
+	$result = HeadingHierarchyAgent::for( [
+		'blocks' => [
+			[ 'id' => 'a', 'type' => 'core/paragraph' ],
+			[ 'id' => 'b', 'type' => 'core/list' ],
+		],
+	] )->run();
+
+	expect( $result['issues'] )->toBeArray()->toBeEmpty();
+	expect( $this->prompter->calls )->toBeEmpty();
+} );
+
+it( 'returns issues shaped by the model when headings are present', function (): void {
+	$this->prompter->queue( [
+		'issues' => [
+			[ 'block_id' => 'h1', 'issue' => 'duplicate h1', 'suggestion' => 'demote to h2' ],
+			[ 'block_id' => 'h2', 'issue' => 'skipped level', 'suggestion' => 'insert h2 before' ],
+		],
+	] );
+
+	$result = HeadingHierarchyAgent::for( [
+		'blocks' => [
+			[ 'id' => 'h1', 'type' => 'core/heading' ],
+			[ 'id' => 'h2', 'type' => 'core/heading' ],
+		],
+	] )->run();
+
+	expect( $result['issues'] )->toHaveCount( 2 );
+	expect( $result['issues'][0]['block_id'] )->toBe( 'h1' );
+} );
+
+it( 'drops issues that reference block ids not in the input', function (): void {
+	$this->prompter->queue( [
+		'issues' => [
+			[ 'block_id' => 'h1', 'issue' => 'real', 'suggestion' => 'fix' ],
+			[ 'block_id' => 'ghost', 'issue' => 'hallucinated', 'suggestion' => 'nope' ],
+		],
+	] );
+
+	$result = HeadingHierarchyAgent::for( [
+		'blocks' => [
+			[ 'id' => 'h1', 'type' => 'core/heading' ],
+		],
+	] )->run();
+
+	expect( $result['issues'] )->toHaveCount( 1 );
+	expect( $result['issues'][0]['block_id'] )->toBe( 'h1' );
+} );
+
+it( 'walks innerBlocks when detecting whether headings exist', function (): void {
+	$this->prompter->queue( [
+		'issues' => [
+			[ 'block_id' => 'nested-h4', 'issue' => 'skipped level', 'suggestion' => 'change to h3' ],
+		],
+	] );
+
+	$result = HeadingHierarchyAgent::for( [
+		'blocks' => [
+			[
+				'id'          => 'columns-1',
+				'type'        => 'core/columns',
+				'innerBlocks' => [
+					[
+						'id'          => 'col-a',
+						'type'        => 'core/column',
+						'innerBlocks' => [
+							[ 'id' => 'nested-h4', 'type' => 'core/heading', 'attrs' => [ 'level' => 4 ] ],
+						],
+					],
+				],
+			],
+		],
+	] )->run();
+
+	// Precondition: without recursion the agent would short-circuit and
+	// the prompter would never be called.
+	expect( $this->prompter->calls )->not->toBeEmpty();
+	expect( $result['issues'] )->toHaveCount( 1 );
+	expect( $result['issues'][0]['block_id'] )->toBe( 'nested-h4' );
+} );
+
+it( 'raises FeatureError when input is malformed', function (): void {
+	expect( fn () => HeadingHierarchyAgent::for( 'nope' )->run() )
+		->toThrow( FeatureError::class );
+
+	expect( fn () => HeadingHierarchyAgent::for( [ 'blocks' => 'not-an-array' ] )->run() )
+		->toThrow( FeatureError::class );
+} );

--- a/tests/Feature/Ai/LayoutSuggestionAgentTest.php
+++ b/tests/Feature/Ai/LayoutSuggestionAgentTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+use ArtisanPackUI\VisualEditor\Ai\Agents\LayoutSuggestionAgent;
+use Tests\Feature\Ai\AiAgentTestSetup;
+
+beforeEach( function (): void {
+	$this->prompter = AiAgentTestSetup::bootstrap( $this->app );
+} );
+
+it( 'returns whitelisted matches sorted as provided by the model', function (): void {
+	$this->prompter->queue( [
+		'matches' => [
+			[ 'pattern_slug' => 'hero-two-column', 'confidence' => 0.9, 'rationale' => 'side-by-side' ],
+			[ 'pattern_slug' => 'feature-grid-3', 'confidence' => 0.6, 'rationale' => 'three parallel items' ],
+		],
+	] );
+
+	$result = LayoutSuggestionAgent::for( [
+		'section_content'    => [ [ 'type' => 'core/heading' ] ],
+		'available_patterns' => [ 'hero-two-column', 'feature-grid-3', 'testimonial' ],
+	] )->run();
+
+	expect( $result['matches'] )->toHaveCount( 2 );
+	expect( $result['matches'][0]['pattern_slug'] )->toBe( 'hero-two-column' );
+} );
+
+it( 'drops matches whose slug is not in the whitelist', function (): void {
+	$this->prompter->queue( [
+		'matches' => [
+			[ 'pattern_slug' => 'hero-two-column', 'confidence' => 0.9, 'rationale' => 'ok' ],
+			[ 'pattern_slug' => 'made-up-pattern', 'confidence' => 0.8, 'rationale' => 'hallucinated' ],
+		],
+	] );
+
+	$result = LayoutSuggestionAgent::for( [
+		'section_content'    => [],
+		'available_patterns' => [ 'hero-two-column' ],
+	] )->run();
+
+	expect( $result['matches'] )->toHaveCount( 1 );
+	expect( $result['matches'][0]['pattern_slug'] )->toBe( 'hero-two-column' );
+} );
+
+it( 'clamps confidence values to [0, 1]', function (): void {
+	$this->prompter->queue( [
+		'matches' => [
+			[ 'pattern_slug' => 'p1', 'confidence' => 1.5, 'rationale' => 'over' ],
+			[ 'pattern_slug' => 'p2', 'confidence' => -0.2, 'rationale' => 'under' ],
+		],
+	] );
+
+	$result = LayoutSuggestionAgent::for( [
+		'section_content'    => [],
+		'available_patterns' => [ 'p1', 'p2' ],
+	] )->run();
+
+	expect( $result['matches'][0]['confidence'] )->toBe( 1.0 );
+	expect( $result['matches'][1]['confidence'] )->toBe( 0.0 );
+} );
+
+it( 'raises FeatureError when available_patterns is empty', function (): void {
+	expect( fn () => LayoutSuggestionAgent::for( [
+		'section_content'    => [],
+		'available_patterns' => [],
+	] )->run() )->toThrow( FeatureError::class );
+} );
+
+it( 'raises FeatureError when section_content is not an array', function (): void {
+	expect( fn () => LayoutSuggestionAgent::for( [
+		'section_content'    => 'oops',
+		'available_patterns' => [ 'x' ],
+	] )->run() )->toThrow( FeatureError::class );
+} );

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -15,6 +15,9 @@ pest()->extend(Tests\TestCase::class)
     ->use(Illuminate\Foundation\Testing\RefreshDatabase::class)
     ->in('Feature/VisualEditor');
 
+pest()->extend(Tests\Feature\Ai\AiTestCase::class)
+    ->in('Feature/Ai');
+
 pest()->extend(Tests\TestCase::class)
     ->use(Illuminate\Foundation\Testing\RefreshDatabase::class)
     ->in('Unit/VisualEditor');

--- a/tests/Support/FakeAgentPrompter.php
+++ b/tests/Support/FakeAgentPrompter.php
@@ -1,0 +1,93 @@
+<?php
+
+/**
+ * Test fake for the AgentPrompter contract.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @since      1.3.0
+ */
+
+declare( strict_types=1 );
+
+namespace Tests\Support;
+
+use ArtisanPackUI\Ai\Contracts\AgentPrompter;
+use ArtisanPackUI\Ai\Credentials\Credentials;
+
+/**
+ * Records every prompter call and returns queued responses in order.
+ * Mirrors the dev-app FakeAgentPrompter so the package's own suite does
+ * not depend on the dev app.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @since      1.3.0
+ */
+final class FakeAgentPrompter implements AgentPrompter
+{
+	/**
+	 * Recorded calls, in invocation order.
+	 *
+	 * @var array<int, array<string, mixed>>
+	 */
+	public array $calls = [];
+
+	/**
+	 * Queued responses (FIFO).
+	 *
+	 * @var array<int, array<string, mixed>>
+	 */
+	private array $queue = [];
+
+	/**
+	 * Push a canned response onto the queue.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param  array<string, mixed>  $output        Structured output body.
+	 * @param  int                   $inputTokens   Reported input tokens.
+	 * @param  int                   $outputTokens  Reported output tokens.
+	 *
+	 * @return void
+	 */
+	public function queue( array $output, int $inputTokens = 100, int $outputTokens = 50 ): void
+	{
+		$this->queue[] = [
+			'output'        => $output,
+			'input_tokens'  => $inputTokens,
+			'output_tokens' => $outputTokens,
+		];
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function prompt(
+		Credentials $credentials,
+		string $model,
+		string $instructions,
+		string|array $message,
+		array $outputSchema,
+	): array {
+		$this->calls[] = [
+			'credentials'   => $credentials,
+			'model'         => $model,
+			'instructions'  => $instructions,
+			'message'       => $message,
+			'output_schema' => $outputSchema,
+		];
+
+		if ( [] === $this->queue ) {
+			return [
+				'output'        => [],
+				'input_tokens'  => 0,
+				'output_tokens' => 0,
+			];
+		}
+
+		return array_shift( $this->queue );
+	}
+}


### PR DESCRIPTION
## Release Information

- **Release Version:** v1.3.0
- **Release Date:** 2026-07-07
- **Release Type:** Minor
- **Release Branch:** `release/1.3`
- **Target Branch:** `main`

## Release Summary

v1.3.0 wires the `artisanpack-ui/ai` foundation into the visual editor
with five optional AI-assisted authoring affordances. All five default
to *off* and are gated by the AI package's `FeatureRegistry` toggles;
every affordance surfaces as a suggestion the author must explicitly
accept — no automatic mutations. Hosts without `artisanpack-ui/ai`
installed continue to work unchanged.

## Changelog

### Added

- **AI-powered authoring affordances (#610–#614).** Five optional
  AI-assisted features built on `artisanpack-ui/ai`. Three own agents
  live in `src/Ai/Agents/`:
  - `ContentBlockSuggestionAgent` (#610) — `visual_editor.suggest_next_block`
  - `LayoutSuggestionAgent` (#611) — `visual_editor.suggest_layout`
  - `HeadingHierarchyAgent` (#614) — `visual_editor.heading_hierarchy`

  Two are consumed directly from `artisanpack-ui/ai`:
  - `AltTextGenerationAgent` (#612) — `ai.alt_text`
  - `ContentRewriteAgent` (#613) — `ai.content_rewrite`

- **HTTP transport.** Six JSON endpoints under `/visual-editor/api/ai/*`
  with per-endpoint Form Requests and a consistent error envelope. All
  routes are guarded on `class_exists(FeatureRegistry)` so hosts
  without the AI package don't 500.

- **Livewire transport.** New `artisanpack-visual-editor.ai.tools`
  component listens for `ap-ve-ai:*` browser events and dispatches
  shaped `success` / `invalid-input` / `disabled` /
  `missing-credentials` / `error` events back.

- **React transport.** `resources/js/visual-editor/ai/` ships
  `createAiApiClient`, `useAiFeatures` gate, per-feature hooks, and 5
  UI components: `SuggestNextBlockButton`, `SuggestLayoutPanel`,
  `AltTextSuggestionCard`, `RewriteToolbar`, `HeadingHierarchyPanel`.

- **Docs.** New [`docs/ai-features.md`](docs/ai-features.md) authoring
  guide covering feature toggles, transports, and integration.

### Changed

- `composer.json` now recommends `artisanpack-ui/ai` `^1.0` as an
  optional companion. Hosts without it installed continue to work —
  the AI surface stays hidden and routes short-circuit before
  dispatching an agent.

### CI

- Test suite now runs on PHP 8.2 with AI dev deps excluded so hosts
  still targeting 8.2 have a green matrix even before adopting the AI
  package.

## Issues and Pull Requests

**Issues Fixed:**
- Closes #610
- Closes #611
- Closes #612
- Closes #613
- Closes #614

**Related PRs:**
- #615 (feature/610-614-ai-integrations merge)

## Breaking Changes

- [x] No breaking changes

All AI affordances default to *off* and gracefully no-op when
`artisanpack-ui/ai` is not installed.

## Testing Checklist

- [x] All automated tests passing (71 Pest tests, 3763 assertions)
- [x] Security scan completed (no runtime vulnerabilities)
- [x] Database migrations tested (none required)

**Testing notes:**

Full Pest suite (`./vendor/bin/pest`) passes on the release branch:
17 new AI-specific tests cover agent behavior, feature registration,
and nested `innerBlocks` traversal. Runtime dependency audit
(`composer audit --no-dev`) reports zero vulnerabilities.

## Documentation Checklist

- [x] CHANGELOG updated ([1.3.0] entry with dated release)
- [x] README updated (AI features section already shipped with #615)
- [x] API documentation updated (six new `/visual-editor/api/ai/*` endpoints)
- [x] Release notes written (this PR body + CHANGELOG)
- [x] Wiki updated (docs/ai-features.md added, home.md linked, version footer bumped)

## Pre-Release Checklist

- [x] Version number updated in all necessary files (composer.json, package.json, docs/home.md)
- [x] Release branch created/updated: `release/1.3`
- [x] Dependencies updated and tested (composer.lock synced)

## Deployment

**Deployment steps:**
1. Merge this PR into `main`
2. Tag `v1.3.0` on the merge commit
3. Push tag to trigger Packagist / npm release automation
4. Announce release

**Rollback plan:**
1. Revert the merge commit on `main`
2. Delete the `v1.3.0` tag if published prematurely

**Configuration changes:**
- None required for hosts not adopting AI features
- Hosts adopting AI features: install `artisanpack-ui/ai` `^1.0` and
  enable the desired feature keys in the AI settings surface

## Notes

Additive release — no schema changes, no breaking changes, no
migration required. Existing 1.x hosts pick up v1.3.0 with zero
config changes; AI affordances remain hidden until the host installs
`artisanpack-ui/ai` and toggles the corresponding feature keys.

---

**Release Manager:** @jacobmartella