### PR TITLE
feat: ap.visual-editor.background-controls filter (#649)

### DIFF
--- a/docs/Hooks-and-Events.md
+++ b/docs/Hooks-and-Events.md
@@ -2,9 +2,9 @@
 
 The visual editor exposes extension points through four mechanisms:
 
-- **PHP filters** — `applyFilters('ap.visual-editor.*', ...)` for value transformation (resource map, site-editor entities, etc.)
+- **PHP filters** — `applyFilters('ap.visual-editor.*', ...)` for value transformation (resource map, site-editor entities, server-rendered block HTML, etc.)
 - **PHP actions** — `doAction('ap.visual-editor.*', ...)` for side effects
-- **JavaScript filters** — `addFilter('ap.visual-editor.*', ...)` via `@wordpress/hooks` for editor-side extension (document panels, background controls, canvas styles, rendered blocks)
+- **JavaScript filters** — `addFilter('ap.visual-editor.*', ...)` via `@wordpress/hooks` for editor-side extension (document panels, background controls, canvas styles)
 - **Browser events** — `CustomEvent` dispatched on `window` for client-side integration (autosave, change, save)
 
 All PHP hooks use the global helpers from [`artisanpack-ui/hooks`](https://github.com/ArtisanPack-UI/hooks). All browser events are plain `CustomEvent` instances dispatched on `window`.
@@ -92,6 +92,28 @@ See the [`artisanpack-ui/icons`](https://github.com/ArtisanPack-UI/icons) docs f
 
 ---
 
+### `ap.visual-editor.rendered-block`
+
+Last-mile PHP filter applied to the rendered HTML of every block (static or dynamic) inside `packages/visual-editor-renderer-blade`'s `BlockRenderer::renderBlock()`. Runs on the server, at render-time, on every request that emits post content — not at save-time and not in JavaScript. Callbacks decorate output without each host having to fork the renderer.
+
+**Signature:** `string $html, string $blockName, array $attributes -> string`
+
+```php
+addFilter('ap.visual-editor.rendered-block', function (string $html, string $name, array $attributes): string {
+    if ('artisanpack/group' !== $name) {
+        return $html;
+    }
+    // …wrap, sanitize, inject data-* attributes, etc.
+    return $html;
+}, 10, 3);
+```
+
+**Recursion:** the renderer walks inner blocks through the same code path, so the filter fires once per block **at every level** of the tree. A callback that wraps a container block will also wrap every descendant unless it gates on `$name` / `$attributes`.
+
+**Attributes shape:** `$attributes` is post-normalization and may already carry package-internal `_resolved*` side-channel keys (site-meta, loginout). Treat those as read-only; they're not stable public attributes.
+
+---
+
 ## JavaScript filters
 
 Editor-side filters run through `@wordpress/hooks` inside the browser. Register callbacks with `addFilter(name, namespace, callback)` at editor bootstrap (the moment the app imports your package's entry module is enough — the editor evaluates each filter on every relevant render).
@@ -111,11 +133,13 @@ type BackgroundControl = {
 }
 
 type BackgroundControlContext = {
-    attributes: Record<string, unknown>
+    // Frozen — call setAttributes to modify.
+    attributes: Readonly<Record<string, unknown>>
     setAttributes: (attrs: Record<string, unknown>) => void
     clientId: string
     blockName: string
-    blockSupports: Record<string, unknown>
+    // Deep-cloned from the block-type registry — treat as read-only.
+    blockSupports: Readonly<Record<string, unknown>>
 }
 ```
 
@@ -128,8 +152,18 @@ addFilter(
     'ap.visual-editor.background-controls',
     'artisanpack-ui/liquid-glass',
     (controls, { attributes, setAttributes, blockSupports }) => {
-        // Only contribute when the block actually has a background support.
-        if (! blockSupports.background) {
+        // The HOC gates on either `supports.background` (image / gradient
+        // background) or `supports.color.background` (color background),
+        // so a block with only text-color support won't fire this filter.
+        // Narrow further to the shape your control cares about:
+        const hasBackground =
+            Boolean(blockSupports.background) ||
+            (typeof blockSupports.color === 'object' &&
+                blockSupports.color !== null &&
+                (blockSupports.color as Record<string, unknown>).background !==
+                    false)
+
+        if (! hasBackground) {
             return controls
         }
 
@@ -151,9 +185,11 @@ addFilter(
 )
 ```
 
-Controls are sorted by `priority` (default `10`, lower first) with ties falling back to registration order. Duplicate ids are deduped last-wins, mirroring how `@wordpress/hooks` composes filters at the same priority.
+Controls are deduped by `id` **before** sorting — a later `addFilter` at the same id overrides an earlier one regardless of priority, mirroring how `@wordpress/hooks` composes filters. Surviving controls are then sorted by `priority` (default `10`, lower first) with ties falling back to registration order.
 
-Attributes are declared the standard Gutenberg way (`blocks.registerBlockType` filter). For static blocks, save-side rendering continues to go through `blocks.getSaveContent.extraProps`; for dynamic blocks, use the block's PHP render or the `ap.visual-editor.rendered-block` filter.
+If a filter callback throws, the exception is caught, logged to `console.error`, and the block renders without any contributed panels for that render — one buggy third-party filter can't trip Gutenberg's per-block crash boundary. Callbacks with a non-numeric `priority` are silently rejected.
+
+Attributes are declared the standard Gutenberg way (`blocks.registerBlockType` filter). For static blocks, save-side rendering continues to go through `blocks.getSaveContent.extraProps`; for dynamic blocks, use the block's PHP render or the `ap.visual-editor.rendered-block` PHP filter (see the PHP filters section above).
 
 ---
 
@@ -184,14 +220,6 @@ Contribute additional stylesheets injected into the block canvas iframe. Applied
 **Signature:** `CanvasStyle[] -> CanvasStyle[]` where `CanvasStyle = { css: string }`.
 
 Entries whose `css` isn't a string are dropped. Non-array return values fall back to the built-in list.
-
----
-
-### `ap.visual-editor.rendered-block`
-
-Transform the HTML the editor emits for each block at save time. Runs after the block's own save function; the return value is the string written to the post content.
-
-**Signature:** `string html, { block, blockName, attributes } -> string`
 
 ---
 

--- a/docs/Hooks-and-Events.md
+++ b/docs/Hooks-and-Events.md
@@ -1,9 +1,10 @@
 # Hooks and Events
 
-The visual editor exposes extension points through three mechanisms:
+The visual editor exposes extension points through four mechanisms:
 
 - **PHP filters** — `applyFilters('ap.visual-editor.*', ...)` for value transformation (resource map, site-editor entities, etc.)
 - **PHP actions** — `doAction('ap.visual-editor.*', ...)` for side effects
+- **JavaScript filters** — `addFilter('ap.visual-editor.*', ...)` via `@wordpress/hooks` for editor-side extension (document panels, background controls, canvas styles, rendered blocks)
 - **Browser events** — `CustomEvent` dispatched on `window` for client-side integration (autosave, change, save)
 
 All PHP hooks use the global helpers from [`artisanpack-ui/hooks`](https://github.com/ArtisanPack-UI/hooks). All browser events are plain `CustomEvent` instances dispatched on `window`.
@@ -88,6 +89,109 @@ addFilter('ap.icons.register-icon-sets', function (IconSetRegistration $registry
 ```
 
 See the [`artisanpack-ui/icons`](https://github.com/ArtisanPack-UI/icons) docs for the full contract.
+
+---
+
+## JavaScript filters
+
+Editor-side filters run through `@wordpress/hooks` inside the browser. Register callbacks with `addFilter(name, namespace, callback)` at editor bootstrap (the moment the app imports your package's entry module is enough — the editor evaluates each filter on every relevant render).
+
+### `ap.visual-editor.background-controls`
+
+Contribute panels to the shared background / appearance area of any block that opts into a background support (`supports.background` for image / gradient backgrounds, or `supports.color.background` for the color background). Applied by the built-in `editor.BlockEdit` HOC so external packages don't have to enumerate target blocks or wrap `BlockEdit` themselves — the target-block decision lives in the editor.
+
+**Signature:** `BackgroundControl[] -> BackgroundControl[]`
+
+```ts
+type BackgroundControl = {
+    id: string           // stable, namespaced (e.g. 'liquid-glass')
+    label: string        // panel heading (translate before returning)
+    priority?: number    // sort key, default 10, lower first
+    render: () => ReactNode
+}
+
+type BackgroundControlContext = {
+    attributes: Record<string, unknown>
+    setAttributes: (attrs: Record<string, unknown>) => void
+    clientId: string
+    blockName: string
+    blockSupports: Record<string, unknown>
+}
+```
+
+**Example:**
+
+```ts
+import { addFilter } from '@wordpress/hooks'
+
+addFilter(
+    'ap.visual-editor.background-controls',
+    'artisanpack-ui/liquid-glass',
+    (controls, { attributes, setAttributes, blockSupports }) => {
+        // Only contribute when the block actually has a background support.
+        if (! blockSupports.background) {
+            return controls
+        }
+
+        return [
+            ...controls,
+            {
+                id: 'liquid-glass',
+                label: 'Liquid Glass',
+                priority: 20,
+                render: () => (
+                    <LiquidGlassPanel
+                        value={attributes.liquidGlass}
+                        onChange={(liquidGlass) => setAttributes({ liquidGlass })}
+                    />
+                ),
+            },
+        ]
+    },
+)
+```
+
+Controls are sorted by `priority` (default `10`, lower first) with ties falling back to registration order. Duplicate ids are deduped last-wins, mirroring how `@wordpress/hooks` composes filters at the same priority.
+
+Attributes are declared the standard Gutenberg way (`blocks.registerBlockType` filter). For static blocks, save-side rendering continues to go through `blocks.getSaveContent.extraProps`; for dynamic blocks, use the block's PHP render or the `ap.visual-editor.rendered-block` filter.
+
+---
+
+### `ap.visual-editor.document-panels`
+
+Contribute panels to the Document tab of the inspector sidebar. Runs against an empty descriptor list at inspector render time; the return value replaces it.
+
+**Signature:** `DocumentPanelSpec[] -> DocumentPanelSpec[]`
+
+```ts
+type DocumentPanelSpec = {
+    id: string
+    title: string
+    initialOpen?: boolean
+    order?: number       // sort key, default 100, lower first
+    render: () => ReactNode
+}
+```
+
+Descriptors are sorted by `order` (default `100`, lower first) with ties falling back to registration order and deduped by `id` (last-wins). The slot-fill companion `<PluginDocumentSettingPanel>` mirrors the WordPress component of the same name for panels rendered as part of the editor tree instead of registered at bootstrap.
+
+---
+
+### `ap.visual-editor.canvas-styles`
+
+Contribute additional stylesheets injected into the block canvas iframe. Applied once at module-load time inside the editor bundle and frozen for the session — register your filter before importing the editor entry module.
+
+**Signature:** `CanvasStyle[] -> CanvasStyle[]` where `CanvasStyle = { css: string }`.
+
+Entries whose `css` isn't a string are dropped. Non-array return values fall back to the built-in list.
+
+---
+
+### `ap.visual-editor.rendered-block`
+
+Transform the HTML the editor emits for each block at save time. Runs after the block's own save function; the return value is the string written to the post content.
+
+**Signature:** `string html, { block, blockName, attributes } -> string`
 
 ---
 

--- a/resources/js/visual-editor/background-controls/__tests__/background-controls.test.ts
+++ b/resources/js/visual-editor/background-controls/__tests__/background-controls.test.ts
@@ -137,7 +137,7 @@ describe('getFilteredBackgroundControls', () => {
         ).toEqual(['a', 'b', 'c']);
     });
 
-    it('dedupes by id, last wins, and keeps the later position', async () => {
+    it('dedupes by id, last-registered wins, then sorts by priority', async () => {
         registerFilter((value) => {
             const list = value as unknown[];
             return [
@@ -170,6 +170,66 @@ describe('getFilteredBackgroundControls', () => {
         expect(result.find((c) => c.id === 'dup')?.label).toBe('Second');
     });
 
+    it('respects registration order over priority for duplicate ids', async () => {
+        // Regression: dedupe must run BEFORE sort so a later-registered
+        // override wins even when the earlier registration has a lower
+        // priority. Otherwise "last-wins mirroring @wordpress/hooks"
+        // becomes "highest-priority-wins".
+        registerFilter((value) => {
+            const list = value as unknown[];
+            return [
+                ...list,
+                {
+                    id: 'glass',
+                    label: 'Package A',
+                    priority: 5,
+                    render: () => null,
+                },
+                {
+                    id: 'glass',
+                    label: 'Package B (override)',
+                    priority: 20,
+                    render: () => null,
+                },
+            ];
+        });
+
+        const { getFilteredBackgroundControls } = await loadModule();
+
+        const result = getFilteredBackgroundControls(CONTEXT);
+        expect(result).toHaveLength(1);
+        expect(result[0]?.label).toBe('Package B (override)');
+    });
+
+    it('respects registration order over priority in the opposite direction', async () => {
+        // Symmetric to the previous test — the docstring promises
+        // last-wins regardless of relative priorities.
+        registerFilter((value) => {
+            const list = value as unknown[];
+            return [
+                ...list,
+                {
+                    id: 'glass',
+                    label: 'Package A',
+                    priority: 20,
+                    render: () => null,
+                },
+                {
+                    id: 'glass',
+                    label: 'Package B (override)',
+                    priority: 5,
+                    render: () => null,
+                },
+            ];
+        });
+
+        const { getFilteredBackgroundControls } = await loadModule();
+
+        const result = getFilteredBackgroundControls(CONTEXT);
+        expect(result).toHaveLength(1);
+        expect(result[0]?.label).toBe('Package B (override)');
+    });
+
     it('drops malformed entries', async () => {
         registerFilter((value) => {
             const list = value as unknown[];
@@ -182,6 +242,7 @@ describe('getFilteredBackgroundControls', () => {
                 { id: 'no-label', render: () => null },
                 { id: 'no-render', label: 'No render' },
                 { label: 'No id', render: () => null },
+                { id: '', label: 'Empty id', render: () => null },
                 {
                     id: 'valid',
                     label: 'Valid',
@@ -195,6 +256,70 @@ describe('getFilteredBackgroundControls', () => {
         expect(
             getFilteredBackgroundControls(CONTEXT).map((c) => c.id)
         ).toEqual(['valid']);
+    });
+
+    it('drops entries whose priority is not a finite number', async () => {
+        // `NaN` / non-numeric priorities produce engine-dependent sort
+        // order because the comparator returns `NaN` for every pair
+        // touching the offender. Reject them at validation time.
+        registerFilter((value) => {
+            const list = value as unknown[];
+            return [
+                ...list,
+                {
+                    id: 'nan',
+                    label: 'NaN priority',
+                    priority: Number.NaN,
+                    render: () => null,
+                },
+                {
+                    id: 'string',
+                    label: 'String priority',
+                    priority: 'high' as unknown as number,
+                    render: () => null,
+                },
+                {
+                    id: 'infinity',
+                    label: 'Infinity priority',
+                    priority: Number.POSITIVE_INFINITY,
+                    render: () => null,
+                },
+                {
+                    id: 'valid-omitted',
+                    label: 'Valid (no priority)',
+                    render: () => null,
+                },
+                {
+                    id: 'valid-explicit',
+                    label: 'Valid (finite)',
+                    priority: 15,
+                    render: () => null,
+                },
+            ];
+        });
+
+        const { getFilteredBackgroundControls } = await loadModule();
+
+        expect(
+            getFilteredBackgroundControls(CONTEXT).map((c) => c.id)
+        ).toEqual(['valid-omitted', 'valid-explicit']);
+    });
+
+    it('swallows a thrown filter callback and logs to console.error', async () => {
+        const errorSpy = vi
+            .spyOn(console, 'error')
+            .mockImplementation(() => undefined);
+
+        registerFilter(() => {
+            throw new Error('boom');
+        });
+
+        const { getFilteredBackgroundControls } = await loadModule();
+
+        expect(getFilteredBackgroundControls(CONTEXT)).toEqual([]);
+        expect(errorSpy).toHaveBeenCalledOnce();
+
+        errorSpy.mockRestore();
     });
 
     it('falls back to an empty list when a callback returns a non-array', async () => {

--- a/resources/js/visual-editor/background-controls/__tests__/background-controls.test.ts
+++ b/resources/js/visual-editor/background-controls/__tests__/background-controls.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Tests for the `ap.visual-editor.background-controls` filter helper
+ * (#649).
+ *
+ * Focuses on the pure list-shaping contract: applies the filter with
+ * the given context, drops malformed descriptors, sorts by `priority`
+ * (default 10, lower first), dedupes by `id` (last-wins).
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type FilterCallback = (value: unknown, ...args: unknown[]) => unknown;
+
+const filters = new Map<string, FilterCallback[]>();
+
+vi.mock('@wordpress/hooks', () => ({
+    addFilter: (hook: string, _id: string, callback: FilterCallback): void => {
+        if (!filters.has(hook)) {
+            filters.set(hook, []);
+        }
+        filters.get(hook)!.push(callback);
+    },
+    applyFilters: (hook: string, value: unknown, ...args: unknown[]): unknown => {
+        const callbacks = filters.get(hook) ?? [];
+        return callbacks.reduce(
+            (acc, callback) => callback(acc, ...args),
+            value
+        );
+    },
+}));
+
+beforeEach(() => {
+    filters.clear();
+    vi.resetModules();
+});
+
+async function loadModule(): Promise<
+    typeof import('../background-controls')
+> {
+    return await import('../background-controls');
+}
+
+function registerFilter(callback: FilterCallback): void {
+    filters.set('ap.visual-editor.background-controls', [
+        ...(filters.get('ap.visual-editor.background-controls') ?? []),
+        callback,
+    ]);
+}
+
+const CONTEXT = {
+    attributes: {},
+    setAttributes: () => undefined,
+    clientId: 'client-1',
+    blockName: 'artisanpack/group',
+    blockSupports: { background: true } as Record<string, unknown>,
+};
+
+describe('getFilteredBackgroundControls', () => {
+    it('returns an empty list when no callbacks are registered', async () => {
+        const { getFilteredBackgroundControls } = await loadModule();
+
+        expect(getFilteredBackgroundControls(CONTEXT)).toEqual([]);
+    });
+
+    it('passes the context to the filter callback verbatim', async () => {
+        let received: unknown = null;
+
+        registerFilter((value, context) => {
+            received = context;
+            return value;
+        });
+
+        const { getFilteredBackgroundControls } = await loadModule();
+
+        getFilteredBackgroundControls(CONTEXT);
+
+        expect(received).toBe(CONTEXT);
+    });
+
+    it('returns controls contributed by the filter', async () => {
+        registerFilter((value) => {
+            const list = value as unknown[];
+            return [
+                ...list,
+                {
+                    id: 'liquid-glass',
+                    label: 'Liquid Glass',
+                    render: () => null,
+                },
+            ];
+        });
+
+        const { getFilteredBackgroundControls } = await loadModule();
+
+        const controls = getFilteredBackgroundControls(CONTEXT);
+        expect(controls.map((c) => c.id)).toEqual(['liquid-glass']);
+    });
+
+    it('sorts by priority (lower first, default 10)', async () => {
+        registerFilter((value) => {
+            const list = value as unknown[];
+            return [
+                ...list,
+                { id: 'late', label: 'Late', priority: 30, render: () => null },
+                { id: 'default', label: 'Default', render: () => null },
+                {
+                    id: 'early',
+                    label: 'Early',
+                    priority: 5,
+                    render: () => null,
+                },
+            ];
+        });
+
+        const { getFilteredBackgroundControls } = await loadModule();
+
+        expect(
+            getFilteredBackgroundControls(CONTEXT).map((c) => c.id)
+        ).toEqual(['early', 'default', 'late']);
+    });
+
+    it('is stable for controls with equal priority', async () => {
+        registerFilter((value) => {
+            const list = value as unknown[];
+            return [
+                ...list,
+                { id: 'a', label: 'A', priority: 10, render: () => null },
+                { id: 'b', label: 'B', priority: 10, render: () => null },
+                { id: 'c', label: 'C', priority: 10, render: () => null },
+            ];
+        });
+
+        const { getFilteredBackgroundControls } = await loadModule();
+
+        expect(
+            getFilteredBackgroundControls(CONTEXT).map((c) => c.id)
+        ).toEqual(['a', 'b', 'c']);
+    });
+
+    it('dedupes by id, last wins, and keeps the later position', async () => {
+        registerFilter((value) => {
+            const list = value as unknown[];
+            return [
+                ...list,
+                {
+                    id: 'dup',
+                    label: 'First',
+                    priority: 10,
+                    render: () => null,
+                },
+                {
+                    id: 'other',
+                    label: 'Other',
+                    priority: 15,
+                    render: () => null,
+                },
+                {
+                    id: 'dup',
+                    label: 'Second',
+                    priority: 20,
+                    render: () => null,
+                },
+            ];
+        });
+
+        const { getFilteredBackgroundControls } = await loadModule();
+
+        const result = getFilteredBackgroundControls(CONTEXT);
+        expect(result.map((c) => c.id)).toEqual(['other', 'dup']);
+        expect(result.find((c) => c.id === 'dup')?.label).toBe('Second');
+    });
+
+    it('drops malformed entries', async () => {
+        registerFilter((value) => {
+            const list = value as unknown[];
+            return [
+                ...list,
+                null,
+                undefined,
+                42,
+                'string',
+                { id: 'no-label', render: () => null },
+                { id: 'no-render', label: 'No render' },
+                { label: 'No id', render: () => null },
+                {
+                    id: 'valid',
+                    label: 'Valid',
+                    render: () => null,
+                },
+            ];
+        });
+
+        const { getFilteredBackgroundControls } = await loadModule();
+
+        expect(
+            getFilteredBackgroundControls(CONTEXT).map((c) => c.id)
+        ).toEqual(['valid']);
+    });
+
+    it('falls back to an empty list when a callback returns a non-array', async () => {
+        registerFilter(() => 'not-an-array');
+
+        const { getFilteredBackgroundControls } = await loadModule();
+
+        expect(getFilteredBackgroundControls(CONTEXT)).toEqual([]);
+    });
+
+    it('exposes the filter name as a constant', async () => {
+        const { BACKGROUND_CONTROLS_FILTER } = await loadModule();
+
+        expect(BACKGROUND_CONTROLS_FILTER).toBe(
+            'ap.visual-editor.background-controls'
+        );
+    });
+});

--- a/resources/js/visual-editor/background-controls/__tests__/with-background-controls.test.tsx
+++ b/resources/js/visual-editor/background-controls/__tests__/with-background-controls.test.tsx
@@ -232,6 +232,133 @@ describe('withBackgroundControls', () => {
         });
     });
 
+    it('freezes context.attributes so filter callbacks cannot mutate them in place', async () => {
+        registeredBlockSupports.set('artisanpack/group', { background: true });
+
+        let mutationError: unknown = null;
+        const attributes = { liquidGlass: { blur: 4 } };
+
+        registerFilter((value, context) => {
+            const ctx = context as { attributes: Record<string, unknown> };
+            try {
+                (ctx.attributes as { liquidGlass?: unknown }).liquidGlass = {
+                    blur: 999,
+                };
+            } catch (error) {
+                mutationError = error;
+            }
+            return value;
+        });
+
+        const { withBackgroundControls } = await loadHOC();
+        const Wrapped = withBackgroundControls(InnerEdit);
+
+        render(
+            <Wrapped
+                name="artisanpack/group"
+                clientId="c-freeze"
+                attributes={attributes}
+                setAttributes={() => undefined}
+            />
+        );
+
+        // In strict mode the assignment throws `TypeError`; in sloppy
+        // mode it silently no-ops. Either way, the source `attributes`
+        // reference the parent handed us must NOT reflect the mutation.
+        expect(attributes.liquidGlass.blur).toBe(4);
+        // If it did throw, it was the expected TypeError from freeze.
+        if (mutationError !== null) {
+            expect(mutationError).toBeInstanceOf(TypeError);
+        }
+    });
+
+    it('deep-clones context.blockSupports so a filter callback cannot corrupt the block registry', async () => {
+        // Live-reference mutation of `getBlockType(name).supports` would
+        // silently break every other block-support gate in the session.
+        const registered = { color: { background: true, text: true } };
+        registeredBlockSupports.set('artisanpack/group', registered);
+
+        registerFilter((value, context) => {
+            const ctx = context as {
+                blockSupports: Record<string, unknown>;
+            };
+            const color = ctx.blockSupports.color as Record<string, unknown>;
+            try {
+                color.background = false;
+            } catch {
+                // frozen — expected
+            }
+            return value;
+        });
+
+        const { withBackgroundControls } = await loadHOC();
+        const Wrapped = withBackgroundControls(InnerEdit);
+
+        render(
+            <Wrapped
+                name="artisanpack/group"
+                clientId="c-clone"
+                attributes={{}}
+                setAttributes={() => undefined}
+            />
+        );
+
+        // The registered object must NOT have been touched.
+        expect(registered.color.background).toBe(true);
+    });
+
+    it('always returns a Fragment so BlockEdit does not remount when the controls list transitions from empty to non-empty', async () => {
+        // React reconciler treats a top-level switch between
+        // `<BlockEdit/>` and `<><BlockEdit/>...</>` as a change in
+        // parent slot type, forcing a remount that discards RichText
+        // cursor, drag state, and child hook state. Verify the HOC
+        // always renders BlockEdit inside a stable Fragment.
+        registeredBlockSupports.set('artisanpack/group', { background: true });
+
+        const { withBackgroundControls } = await loadHOC();
+        const Wrapped = withBackgroundControls(InnerEdit);
+
+        const { rerender, getByTestId, queryByTestId } = render(
+            <Wrapped
+                name="artisanpack/group"
+                clientId="c-stable"
+                attributes={{}}
+                setAttributes={() => undefined}
+            />
+        );
+
+        const innerBefore = getByTestId('inner-edit');
+        expect(queryByTestId('inspector-controls')).toBeNull();
+
+        // Register a filter and force a re-render — controls list
+        // transitions from [] to [glass].
+        registerFilter((value) => {
+            const list = value as unknown[];
+            return [
+                ...list,
+                {
+                    id: 'glass',
+                    label: 'Glass',
+                    render: () => <span data-testid="glass-panel">glass</span>,
+                },
+            ];
+        });
+
+        rerender(
+            <Wrapped
+                name="artisanpack/group"
+                clientId="c-stable"
+                attributes={{}}
+                setAttributes={() => undefined}
+            />
+        );
+
+        // Same DOM node — no remount.
+        expect(getByTestId('inner-edit')).toBe(innerBefore);
+        expect(getByTestId('inspector-controls')).toBeInTheDocument();
+        expect(getByTestId('glass-panel')).toBeInTheDocument();
+    });
+
     it('renders controls in priority order (lower first)', async () => {
         registeredBlockSupports.set('artisanpack/group', { background: true });
 

--- a/resources/js/visual-editor/background-controls/__tests__/with-background-controls.test.tsx
+++ b/resources/js/visual-editor/background-controls/__tests__/with-background-controls.test.tsx
@@ -1,0 +1,316 @@
+/**
+ * Tests for the `editor.BlockEdit` HOC that mounts the
+ * `ap.visual-editor.background-controls` filter (#649).
+ *
+ * The HOC gates on whether the block type declares a background-related
+ * support. These tests exercise the AC "at least one test demonstrating
+ * an external filter adds a control to a supported block and does not
+ * add it to an unsupported block", plus the priority contract.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+
+type FilterCallback = (value: unknown, ...args: unknown[]) => unknown;
+
+const filters = new Map<string, FilterCallback[]>();
+
+vi.mock('@wordpress/hooks', () => ({
+    addFilter: (hook: string, _id: string, callback: FilterCallback): void => {
+        if (!filters.has(hook)) {
+            filters.set(hook, []);
+        }
+        filters.get(hook)!.push(callback);
+    },
+    applyFilters: (hook: string, value: unknown, ...args: unknown[]): unknown => {
+        const callbacks = filters.get(hook) ?? [];
+        return callbacks.reduce(
+            (acc, callback) => callback(acc, ...args),
+            value
+        );
+    },
+}));
+
+// The HOC only uses `InspectorControls` as a pass-through wrapper.
+// Rendering a plain `<div>` is enough for the DOM assertions below and
+// keeps the block-editor stylesheets / slot-fill machinery out of the
+// test environment.
+vi.mock('@wordpress/block-editor', () => ({
+    InspectorControls: ({ children }: { children?: ReactNode }) => (
+        <div data-testid="inspector-controls">{children}</div>
+    ),
+}));
+
+vi.mock('@wordpress/components', () => ({
+    PanelBody: ({
+        title,
+        children,
+    }: {
+        title?: string;
+        initialOpen?: boolean;
+        children?: ReactNode;
+    }) => (
+        <div data-testid="panel-body" data-title={title}>
+            {children}
+        </div>
+    ),
+}));
+
+// `@wordpress/compose`'s real `createHigherOrderComponent` reaches into
+// the `element` package for `Symbol.for( 'react.element' )` lookups
+// that aren't needed here. A minimal HOC wrapper is enough.
+vi.mock('@wordpress/compose', () => ({
+    createHigherOrderComponent:
+        <TProps,>(fn: (Comp: React.ComponentType<TProps>) => React.ComponentType<TProps>) =>
+        (Comp: React.ComponentType<TProps>) =>
+            fn(Comp),
+}));
+
+const registeredBlockSupports = new Map<string, Record<string, unknown>>();
+
+vi.mock('@wordpress/blocks', () => ({
+    getBlockType: (
+        name: string
+    ): { supports?: Record<string, unknown> } | undefined => {
+        const supports = registeredBlockSupports.get(name);
+        if (!supports) {
+            return undefined;
+        }
+        return { supports };
+    },
+}));
+
+function registerFilter(callback: FilterCallback): void {
+    filters.set('ap.visual-editor.background-controls', [
+        ...(filters.get('ap.visual-editor.background-controls') ?? []),
+        callback,
+    ]);
+}
+
+beforeEach(() => {
+    filters.clear();
+    registeredBlockSupports.clear();
+    vi.resetModules();
+});
+
+async function loadHOC(): Promise<
+    typeof import('../with-background-controls')
+> {
+    return await import('../with-background-controls');
+}
+
+const InnerEdit = (props: { name: string }): JSX.Element => (
+    <div data-testid="inner-edit" data-name={props.name}>
+        inner
+    </div>
+);
+
+describe('withBackgroundControls', () => {
+    it('adds a filter-registered control to a block that supports background', async () => {
+        registeredBlockSupports.set('artisanpack/group', { background: true });
+
+        registerFilter((value) => {
+            const list = value as unknown[];
+            return [
+                ...list,
+                {
+                    id: 'liquid-glass',
+                    label: 'Liquid Glass',
+                    render: () => (
+                        <span data-testid="glass-panel">glass</span>
+                    ),
+                },
+            ];
+        });
+
+        const { withBackgroundControls } = await loadHOC();
+        const Wrapped = withBackgroundControls(InnerEdit);
+
+        render(
+            <Wrapped
+                name="artisanpack/group"
+                clientId="c-1"
+                attributes={{}}
+                setAttributes={() => undefined}
+            />
+        );
+
+        expect(screen.getByTestId('inner-edit')).toBeInTheDocument();
+        expect(screen.getByTestId('inspector-controls')).toBeInTheDocument();
+        expect(screen.getByTestId('glass-panel')).toBeInTheDocument();
+        expect(
+            screen.getByTestId('panel-body').getAttribute('data-title')
+        ).toBe('Liquid Glass');
+    });
+
+    it('does not render the inspector wrapper on a block that does not support background', async () => {
+        registeredBlockSupports.set('artisanpack/separator', {
+            color: { background: false },
+        });
+
+        registerFilter((value) => {
+            const list = value as unknown[];
+            return [
+                ...list,
+                {
+                    id: 'liquid-glass',
+                    label: 'Liquid Glass',
+                    render: () => (
+                        <span data-testid="glass-panel">glass</span>
+                    ),
+                },
+            ];
+        });
+
+        const { withBackgroundControls } = await loadHOC();
+        const Wrapped = withBackgroundControls(InnerEdit);
+
+        render(
+            <Wrapped
+                name="artisanpack/separator"
+                clientId="c-2"
+                attributes={{}}
+                setAttributes={() => undefined}
+            />
+        );
+
+        expect(screen.getByTestId('inner-edit')).toBeInTheDocument();
+        expect(screen.queryByTestId('inspector-controls')).toBeNull();
+        expect(screen.queryByTestId('glass-panel')).toBeNull();
+    });
+
+    it('renders nothing extra when no filter callback returns controls', async () => {
+        registeredBlockSupports.set('artisanpack/group', { background: true });
+
+        const { withBackgroundControls } = await loadHOC();
+        const Wrapped = withBackgroundControls(InnerEdit);
+
+        render(
+            <Wrapped
+                name="artisanpack/group"
+                clientId="c-3"
+                attributes={{}}
+                setAttributes={() => undefined}
+            />
+        );
+
+        expect(screen.getByTestId('inner-edit')).toBeInTheDocument();
+        expect(screen.queryByTestId('inspector-controls')).toBeNull();
+    });
+
+    it('passes the block context to filter callbacks', async () => {
+        registeredBlockSupports.set('artisanpack/group', { background: true });
+
+        let received: unknown = null;
+        const setAttributes = (): void => undefined;
+        const attributes = { style: { background: { color: '#fff' } } };
+
+        registerFilter((value, context) => {
+            received = context;
+            return value;
+        });
+
+        const { withBackgroundControls } = await loadHOC();
+        const Wrapped = withBackgroundControls(InnerEdit);
+
+        render(
+            <Wrapped
+                name="artisanpack/group"
+                clientId="c-4"
+                attributes={attributes}
+                setAttributes={setAttributes}
+            />
+        );
+
+        expect(received).toEqual({
+            attributes,
+            setAttributes,
+            clientId: 'c-4',
+            blockName: 'artisanpack/group',
+            blockSupports: { background: true },
+        });
+    });
+
+    it('renders controls in priority order (lower first)', async () => {
+        registeredBlockSupports.set('artisanpack/group', { background: true });
+
+        registerFilter((value) => {
+            const list = value as unknown[];
+            return [
+                ...list,
+                {
+                    id: 'late',
+                    label: 'Late',
+                    priority: 30,
+                    render: () => <span data-testid="control-late">late</span>,
+                },
+                {
+                    id: 'early',
+                    label: 'Early',
+                    priority: 5,
+                    render: () => (
+                        <span data-testid="control-early">early</span>
+                    ),
+                },
+            ];
+        });
+
+        const { withBackgroundControls } = await loadHOC();
+        const Wrapped = withBackgroundControls(InnerEdit);
+
+        render(
+            <Wrapped
+                name="artisanpack/group"
+                clientId="c-5"
+                attributes={{}}
+                setAttributes={() => undefined}
+            />
+        );
+
+        const panels = screen.getAllByTestId('panel-body');
+        expect(panels.map((p) => p.getAttribute('data-title'))).toEqual([
+            'Early',
+            'Late',
+        ]);
+    });
+});
+
+describe('blockSupportsBackground', () => {
+    it('accepts `supports.background: true`', async () => {
+        const { blockSupportsBackground } = await loadHOC();
+        expect(blockSupportsBackground({ background: true })).toBe(true);
+    });
+
+    it('accepts `supports.background` as an object', async () => {
+        const { blockSupportsBackground } = await loadHOC();
+        expect(
+            blockSupportsBackground({ background: { backgroundImage: true } })
+        ).toBe(true);
+    });
+
+    it('accepts `supports.color: true`', async () => {
+        const { blockSupportsBackground } = await loadHOC();
+        expect(blockSupportsBackground({ color: true })).toBe(true);
+    });
+
+    it('accepts `supports.color` as an object without an explicit `background: false`', async () => {
+        const { blockSupportsBackground } = await loadHOC();
+        expect(blockSupportsBackground({ color: {} })).toBe(true);
+        expect(
+            blockSupportsBackground({ color: { text: true } })
+        ).toBe(true);
+    });
+
+    it('rejects `supports.color.background: false`', async () => {
+        const { blockSupportsBackground } = await loadHOC();
+        expect(
+            blockSupportsBackground({ color: { background: false } })
+        ).toBe(false);
+    });
+
+    it('rejects an empty supports object', async () => {
+        const { blockSupportsBackground } = await loadHOC();
+        expect(blockSupportsBackground({})).toBe(false);
+    });
+});

--- a/resources/js/visual-editor/background-controls/background-controls.ts
+++ b/resources/js/visual-editor/background-controls/background-controls.ts
@@ -1,0 +1,155 @@
+/**
+ * `ap.visual-editor.background-controls` — filter that lets external
+ * packages contribute controls to the shared background / appearance
+ * area of any block that opts into a background support (#649).
+ *
+ * External packages register their controls via `@wordpress/hooks`:
+ *
+ *     addFilter(
+ *         'ap.visual-editor.background-controls',
+ *         'my-package/glass',
+ *         (controls, { attributes, setAttributes, blockSupports }) => {
+ *             if ( ! blockSupports.background ) {
+ *                 return controls;
+ *             }
+ *             return [
+ *                 ...controls,
+ *                 {
+ *                     id: 'my-package/glass',
+ *                     label: 'Glass effect',
+ *                     priority: 20,
+ *                     render: () => <GlassPanel ... />,
+ *                 },
+ *             ];
+ *         },
+ *     );
+ *
+ * The editor calls `getFilteredBackgroundControls(context)` from the
+ * `editor.BlockEdit` HOC in `with-background-controls.tsx` on every
+ * render of a supporting block. Sorting, de-duplication, and the
+ * "priority defaults to 10, lower first" contract live here so the HOC
+ * stays about placement only.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.4.0
+ */
+
+import { applyFilters } from '@wordpress/hooks';
+import type { ReactNode } from 'react';
+
+/** Filter name — exported so hosts can type against a constant. */
+export const BACKGROUND_CONTROLS_FILTER = 'ap.visual-editor.background-controls';
+
+/** Default priority for controls that don't set one. */
+export const DEFAULT_BACKGROUND_CONTROL_PRIORITY = 10;
+
+/**
+ * Descriptor a package returns from the filter for each control it wants
+ * to render in the block's background panel.
+ */
+export interface BackgroundControl {
+    /**
+     * Stable, namespaced identifier — used as the React `key` and to
+     * dedupe two packages racing on the same slot (last-wins, mirroring
+     * `@wordpress/hooks`).
+     */
+    id: string;
+    /** Visible section heading. Should already be translated by the caller. */
+    label: string;
+    /**
+     * Sort key. Lower renders earlier. Defaults to
+     * {@link DEFAULT_BACKGROUND_CONTROL_PRIORITY} when omitted.
+     */
+    priority?: number;
+    /** React render callback. Invoked once per render, no arguments. */
+    render: () => ReactNode;
+}
+
+/**
+ * Context passed to filter callbacks so a package can decide whether to
+ * contribute a control (and what to render) based on the currently-
+ * selected block.
+ */
+export interface BackgroundControlContext {
+    /** Live block attributes. Treat as read-only inside the filter. */
+    attributes: Record<string, unknown>;
+    /** Standard Gutenberg attribute setter for the selected block. */
+    setAttributes: (attrs: Record<string, unknown>) => void;
+    /** Selected block's clientId. */
+    clientId: string;
+    /** Selected block's registered name (e.g. `core/group`). */
+    blockName: string;
+    /**
+     * Resolved `supports` object from the block type. Packages use
+     * `blockSupports.background` (or a nested key like
+     * `blockSupports.color?.background`) to gate their contribution.
+     */
+    blockSupports: Record<string, unknown>;
+}
+
+function isBackgroundControl(value: unknown): value is BackgroundControl {
+    return (
+        value !== null &&
+        typeof value === 'object' &&
+        typeof (value as BackgroundControl).id === 'string' &&
+        typeof (value as BackgroundControl).label === 'string' &&
+        typeof (value as BackgroundControl).render === 'function'
+    );
+}
+
+/**
+ * Apply the filter, drop malformed entries, sort by `priority` (stable),
+ * and dedupe by `id` (last-wins). Kept pure so the HOC can call it
+ * inside render without scheduling work.
+ */
+export function getFilteredBackgroundControls(
+    context: BackgroundControlContext
+): BackgroundControl[] {
+    const raw = applyFilters(
+        BACKGROUND_CONTROLS_FILTER,
+        [] as BackgroundControl[],
+        context
+    );
+
+    if (!Array.isArray(raw)) {
+        return [];
+    }
+
+    const valid = raw.filter(isBackgroundControl);
+
+    // Pair with the original index before comparing so we get a stable
+    // sort on engines whose `Array.prototype.sort` isn't stable, and so
+    // ties fall back to registration order.
+    const sorted = valid
+        .map((control, index) => ({ control, index }))
+        .sort((a, b) => {
+            const priorityA =
+                a.control.priority ?? DEFAULT_BACKGROUND_CONTROL_PRIORITY;
+            const priorityB =
+                b.control.priority ?? DEFAULT_BACKGROUND_CONTROL_PRIORITY;
+
+            if (priorityA !== priorityB) {
+                return priorityA - priorityB;
+            }
+
+            return a.index - b.index;
+        })
+        .map(({ control }) => control);
+
+    // Dedupe by id — two packages racing on the same identifier, or a
+    // single package re-registering after HMR, would otherwise render
+    // twice with duplicate React keys. Last-wins policy mirrors
+    // `@wordpress/hooks` filter composition. `Map#set` on an existing
+    // key updates in-place, so delete-then-reinsert to move the later
+    // entry to its later position.
+    const deduped = new Map<string, BackgroundControl>();
+
+    for (const control of sorted) {
+        if (deduped.has(control.id)) {
+            deduped.delete(control.id);
+        }
+        deduped.set(control.id, control);
+    }
+
+    return Array.from(deduped.values());
+}

--- a/resources/js/visual-editor/background-controls/background-controls.ts
+++ b/resources/js/visual-editor/background-controls/background-controls.ts
@@ -69,47 +69,95 @@ export interface BackgroundControl {
  * Context passed to filter callbacks so a package can decide whether to
  * contribute a control (and what to render) based on the currently-
  * selected block.
+ *
+ * All fields except `setAttributes` are **read-only** — the HOC freezes
+ * `attributes` and hands out a defensive clone of `blockSupports`, but
+ * treat every field as immutable regardless. Mutating `attributes`
+ * bypasses React reconciliation and undo history; mutating
+ * `blockSupports` would (if it weren't cloned) corrupt the shared
+ * `@wordpress/blocks` registry that gate-checks every other feature in
+ * the editor.
  */
 export interface BackgroundControlContext {
-    /** Live block attributes. Treat as read-only inside the filter. */
-    attributes: Record<string, unknown>;
+    /**
+     * Frozen block attributes. Treat as read-only. To modify, call
+     * `setAttributes({...})` — the standard Gutenberg pattern.
+     */
+    attributes: Readonly<Record<string, unknown>>;
     /** Standard Gutenberg attribute setter for the selected block. */
     setAttributes: (attrs: Record<string, unknown>) => void;
     /** Selected block's clientId. */
     clientId: string;
-    /** Selected block's registered name (e.g. `core/group`). */
+    /** Selected block's registered name (e.g. `artisanpack/group`). */
     blockName: string;
     /**
-     * Resolved `supports` object from the block type. Packages use
+     * Deep-cloned `supports` object from the block type. Packages use
      * `blockSupports.background` (or a nested key like
      * `blockSupports.color?.background`) to gate their contribution.
+     * Treat as read-only.
      */
-    blockSupports: Record<string, unknown>;
+    blockSupports: Readonly<Record<string, unknown>>;
 }
 
 function isBackgroundControl(value: unknown): value is BackgroundControl {
-    return (
-        value !== null &&
-        typeof value === 'object' &&
-        typeof (value as BackgroundControl).id === 'string' &&
-        typeof (value as BackgroundControl).label === 'string' &&
-        typeof (value as BackgroundControl).render === 'function'
-    );
+    if (
+        value === null ||
+        typeof value !== 'object' ||
+        typeof (value as BackgroundControl).id !== 'string' ||
+        (value as BackgroundControl).id === '' ||
+        typeof (value as BackgroundControl).label !== 'string' ||
+        typeof (value as BackgroundControl).render !== 'function'
+    ) {
+        return false;
+    }
+
+    // `priority` is optional, but if present it must be a finite number.
+    // A `NaN` or string priority would make the sort comparator return
+    // `NaN`, giving engine-dependent order across browsers.
+    const priority = (value as BackgroundControl).priority;
+    if (priority !== undefined && !Number.isFinite(priority)) {
+        return false;
+    }
+
+    return true;
 }
 
 /**
- * Apply the filter, drop malformed entries, sort by `priority` (stable),
- * and dedupe by `id` (last-wins). Kept pure so the HOC can call it
- * inside render without scheduling work.
+ * Apply the filter, drop malformed entries, dedupe by `id` (last-wins),
+ * then sort by `priority` (default `10`, lower first). Dedupe happens
+ * BEFORE sort so "last-wins" tracks registration order, not sort order
+ * — a later `addFilter` with a lower priority still overrides an
+ * earlier registration at the same id.
+ *
+ * If a filter callback throws (a third-party bug), the exception is
+ * caught, logged, and the function returns an empty list. Without the
+ * guard, one bad callback would trip Gutenberg's `BlockCrashBoundary`
+ * on every affected block for the rest of the session.
+ *
+ * Kept pure so the HOC can call it inside render without scheduling
+ * work.
  */
 export function getFilteredBackgroundControls(
     context: BackgroundControlContext
 ): BackgroundControl[] {
-    const raw = applyFilters(
-        BACKGROUND_CONTROLS_FILTER,
-        [] as BackgroundControl[],
-        context
-    );
+    let raw: unknown;
+
+    try {
+        raw = applyFilters(
+            BACKGROUND_CONTROLS_FILTER,
+            [] as BackgroundControl[],
+            context
+        );
+    } catch (error) {
+        // eslint-disable-next-line no-console
+        console.error(
+            '[artisanpack-ui/visual-editor] A ' +
+                `"${BACKGROUND_CONTROLS_FILTER}" filter callback threw. ` +
+                'Skipping background controls for this render.',
+            error
+        );
+        return [];
+    }
 
     if (!Array.isArray(raw)) {
         return [];
@@ -117,39 +165,28 @@ export function getFilteredBackgroundControls(
 
     const valid = raw.filter(isBackgroundControl);
 
-    // Pair with the original index before comparing so we get a stable
-    // sort on engines whose `Array.prototype.sort` isn't stable, and so
-    // ties fall back to registration order.
-    const sorted = valid
-        .map((control, index) => ({ control, index }))
-        .sort((a, b) => {
-            const priorityA =
-                a.control.priority ?? DEFAULT_BACKGROUND_CONTROL_PRIORITY;
-            const priorityB =
-                b.control.priority ?? DEFAULT_BACKGROUND_CONTROL_PRIORITY;
-
-            if (priorityA !== priorityB) {
-                return priorityA - priorityB;
-            }
-
-            return a.index - b.index;
-        })
-        .map(({ control }) => control);
-
     // Dedupe by id — two packages racing on the same identifier, or a
     // single package re-registering after HMR, would otherwise render
-    // twice with duplicate React keys. Last-wins policy mirrors
-    // `@wordpress/hooks` filter composition. `Map#set` on an existing
-    // key updates in-place, so delete-then-reinsert to move the later
-    // entry to its later position.
-    const deduped = new Map<string, BackgroundControl>();
+    // twice with duplicate React keys. Last-wins mirrors how
+    // `@wordpress/hooks` composes filters: a later `addFilter` at the
+    // same namespace/priority overrides an earlier one. Doing the
+    // dedupe here (pre-sort) means the surviving entry is always the
+    // last one the filter chain contributed, regardless of its
+    // priority relative to the earlier duplicate.
+    const dedupedByRegistration = new Map<string, BackgroundControl>();
 
-    for (const control of sorted) {
-        if (deduped.has(control.id)) {
-            deduped.delete(control.id);
+    for (const control of valid) {
+        if (dedupedByRegistration.has(control.id)) {
+            dedupedByRegistration.delete(control.id);
         }
-        deduped.set(control.id, control);
+        dedupedByRegistration.set(control.id, control);
     }
 
-    return Array.from(deduped.values());
+    // ES2019 mandates `Array.prototype.sort` be stable, so ties fall
+    // back to insertion (= registration) order automatically.
+    return Array.from(dedupedByRegistration.values()).sort((a, b) => {
+        const priorityA = a.priority ?? DEFAULT_BACKGROUND_CONTROL_PRIORITY;
+        const priorityB = b.priority ?? DEFAULT_BACKGROUND_CONTROL_PRIORITY;
+        return priorityA - priorityB;
+    });
 }

--- a/resources/js/visual-editor/background-controls/index.ts
+++ b/resources/js/visual-editor/background-controls/index.ts
@@ -1,0 +1,12 @@
+export {
+    BACKGROUND_CONTROLS_FILTER,
+    DEFAULT_BACKGROUND_CONTROL_PRIORITY,
+    getFilteredBackgroundControls,
+    type BackgroundControl,
+    type BackgroundControlContext,
+} from './background-controls';
+export {
+    blockSupportsBackground,
+    registerBackgroundControls,
+    withBackgroundControls,
+} from './with-background-controls';

--- a/resources/js/visual-editor/background-controls/with-background-controls.tsx
+++ b/resources/js/visual-editor/background-controls/with-background-controls.tsx
@@ -57,9 +57,16 @@ interface BlockEditProps {
 }
 
 /**
- * Resolve the block type's `supports` object. Returns an empty object
- * when the block type is unknown so callers can uniformly probe keys
- * without null-guarding first.
+ * Resolve the block type's `supports` object as a defensive deep
+ * clone. Returns an empty object when the block type is unknown so
+ * callers can uniformly probe keys without null-guarding first.
+ *
+ * The clone matters — the raw `supports` object is a live reference to
+ * the `@wordpress/blocks` registry, and this value is handed to every
+ * third-party `ap.visual-editor.background-controls` filter callback
+ * as `context.blockSupports`. A callback that mutates the received
+ * object would (without the clone) silently tamper with the shared
+ * registry entry every other block-support consumer reads from.
  */
 function resolveBlockSupports(name: string): Record<string, unknown> {
     const blockType = getBlockType(name);
@@ -74,7 +81,12 @@ function resolveBlockSupports(name: string): Record<string, unknown> {
         return {};
     }
 
-    return supports as Record<string, unknown>;
+    // `structuredClone` is available in every browser that ships a
+    // modern Gutenberg (Safari 15.4+, Chrome/Edge 98+, Firefox 94+),
+    // matches Node ≥17 for tests, and is the correct primitive here:
+    // block `supports` objects are plain data (no functions, no
+    // symbols) so structuredClone reproduces them losslessly.
+    return structuredClone(supports) as Record<string, unknown>;
 }
 
 /**
@@ -123,36 +135,46 @@ export const withBackgroundControls = createHigherOrderComponent(
                 return <BlockEdit {...props} />;
             }
 
+            // `Object.freeze` on a shallow copy is enough to signal
+            // read-only at the top level and to defend against the most
+            // common footgun (a filter callback assigning to
+            // `context.attributes.foo = ...`). Deep-freezing would
+            // require walking the tree on every render — too expensive
+            // for a hot path; the type is `Readonly<...>` and the
+            // context docstring calls it out.
             const context: BackgroundControlContext = {
-                attributes: props.attributes,
+                attributes: Object.freeze({ ...props.attributes }),
                 setAttributes: props.setAttributes,
                 clientId: props.clientId ?? '',
                 blockName: props.name,
-                blockSupports,
+                blockSupports: Object.freeze(blockSupports),
             };
 
             const controls = getFilteredBackgroundControls(context);
 
-            if (controls.length === 0) {
-                return <BlockEdit {...props} />;
-            }
-
+            // Always return the Fragment shape so the child `BlockEdit`
+            // keeps a stable parent slot type as `controls` transitions
+            // from empty to non-empty (e.g. HMR, lazy-loaded package
+            // bundles, filter callbacks reading external stores). A
+            // top-level switch between `<BlockEdit/>` and a Fragment
+            // would remount BlockEdit and lose RichText cursor, drag,
+            // and child hook state.
             return (
                 <>
                     <BlockEdit {...props} />
-                    <InspectorControls>
-                        {controls.map((control) => (
-                            <PanelBody
-                                key={control.id}
-                                title={control.label}
-                                initialOpen={false}
-                            >
-                                <div data-background-control={control.id}>
+                    {controls.length > 0 && (
+                        <InspectorControls>
+                            {controls.map((control) => (
+                                <PanelBody
+                                    key={control.id}
+                                    title={control.label}
+                                    initialOpen={false}
+                                >
                                     {control.render()}
-                                </div>
-                            </PanelBody>
-                        ))}
-                    </InspectorControls>
+                                </PanelBody>
+                            ))}
+                        </InspectorControls>
+                    )}
                 </>
             );
         }

--- a/resources/js/visual-editor/background-controls/with-background-controls.tsx
+++ b/resources/js/visual-editor/background-controls/with-background-controls.tsx
@@ -1,0 +1,182 @@
+/**
+ * `editor.BlockEdit` HOC — mount the
+ * `ap.visual-editor.background-controls` filter on every block that
+ * opts into a background support (#649).
+ *
+ * Centralizes the target-block decision inside the editor so external
+ * packages contributing a background/appearance control (Liquid Glass,
+ * noise, gradient mesh, etc.) don't have to enumerate blocks and wrap
+ * `editor.BlockEdit` themselves. They just add a filter callback
+ * returning a `BackgroundControl` descriptor; this HOC decides the
+ * gating and the placement.
+ *
+ * Placement: a full-width `PanelBody` per control inside the default
+ * `InspectorControls` group. We considered `group="color"` (which sits
+ * next to the built-in Background color picker) but that slot renders
+ * inside a `ToolsPanel` that either drops non-`ToolsPanelItem` children
+ * or squeezes them into a narrow column — the same trap `liquid-glass`
+ * hit before it moved to a plain `PanelBody`. The default slot gives
+ * every control room to render normally and keeps the API surface
+ * simple (packages return a single `render` — no ToolsPanel wiring
+ * required).
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.4.0
+ */
+
+import { InspectorControls } from '@wordpress/block-editor';
+import { PanelBody } from '@wordpress/components';
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { getBlockType } from '@wordpress/blocks';
+import { addFilter } from '@wordpress/hooks';
+import type { ComponentType } from 'react';
+
+import {
+    getFilteredBackgroundControls,
+    type BackgroundControlContext,
+} from './background-controls';
+
+const FILTER_HOOK = 'editor.BlockEdit';
+const FILTER_NAMESPACE =
+    'artisanpack-ui/visual-editor/background-controls';
+
+const REGISTERED_KEY = Symbol.for(
+    'artisanpack-ui.visual-editor.background-controls.registered'
+);
+
+interface GlobalSentinelHost {
+    [REGISTERED_KEY]?: boolean;
+}
+
+interface BlockEditProps {
+    name: string;
+    clientId?: string;
+    attributes: Record<string, unknown>;
+    setAttributes: (updates: Record<string, unknown>) => void;
+    [key: string]: unknown;
+}
+
+/**
+ * Resolve the block type's `supports` object. Returns an empty object
+ * when the block type is unknown so callers can uniformly probe keys
+ * without null-guarding first.
+ */
+function resolveBlockSupports(name: string): Record<string, unknown> {
+    const blockType = getBlockType(name);
+
+    if (!blockType) {
+        return {};
+    }
+
+    const supports = (blockType as { supports?: unknown }).supports;
+
+    if (supports === null || typeof supports !== 'object') {
+        return {};
+    }
+
+    return supports as Record<string, unknown>;
+}
+
+/**
+ * A block opts into background controls when it declares either
+ * `supports.background` (image / gradient background support) or
+ * `supports.color.background` (color background — the default when
+ * `supports.color` is enabled without an explicit `background: false`
+ * override).
+ *
+ * The check is deliberately permissive: package authors gate their own
+ * contribution inside the filter callback using the resolved
+ * `blockSupports` object, so it's fine for the HOC to run for a
+ * slightly broader set of blocks than any single package cares about.
+ */
+export function blockSupportsBackground(
+    supports: Record<string, unknown>
+): boolean {
+    if (supports.background) {
+        return true;
+    }
+
+    const color = supports.color;
+
+    if (color === true) {
+        return true;
+    }
+
+    if (color !== null && typeof color === 'object') {
+        const colorBackground = (color as Record<string, unknown>).background;
+        // `undefined` means "inherit the default", which for the color
+        // support is `true`. Only an explicit `false` disables it.
+        return colorBackground !== false;
+    }
+
+    return false;
+}
+
+export const withBackgroundControls = createHigherOrderComponent(
+    (BlockEdit: ComponentType<BlockEditProps>) => {
+        function BackgroundControlsBlockEdit(
+            props: BlockEditProps
+        ): JSX.Element {
+            const blockSupports = resolveBlockSupports(props.name);
+
+            if (!blockSupportsBackground(blockSupports)) {
+                return <BlockEdit {...props} />;
+            }
+
+            const context: BackgroundControlContext = {
+                attributes: props.attributes,
+                setAttributes: props.setAttributes,
+                clientId: props.clientId ?? '',
+                blockName: props.name,
+                blockSupports,
+            };
+
+            const controls = getFilteredBackgroundControls(context);
+
+            if (controls.length === 0) {
+                return <BlockEdit {...props} />;
+            }
+
+            return (
+                <>
+                    <BlockEdit {...props} />
+                    <InspectorControls>
+                        {controls.map((control) => (
+                            <PanelBody
+                                key={control.id}
+                                title={control.label}
+                                initialOpen={false}
+                            >
+                                <div data-background-control={control.id}>
+                                    {control.render()}
+                                </div>
+                            </PanelBody>
+                        ))}
+                    </InspectorControls>
+                </>
+            );
+        }
+
+        BackgroundControlsBlockEdit.displayName =
+            'BackgroundControlsBlockEdit';
+
+        return BackgroundControlsBlockEdit;
+    },
+    'withBackgroundControls'
+);
+
+/**
+ * Register the `editor.BlockEdit` HOC at most once per page. Idempotent
+ * — safe to call from both the post-editor and site-editor bootstrap
+ * paths.
+ */
+export function registerBackgroundControls(): void {
+    const host = globalThis as unknown as GlobalSentinelHost;
+
+    if (host[REGISTERED_KEY]) {
+        return;
+    }
+
+    addFilter(FILTER_HOOK, FILTER_NAMESPACE, withBackgroundControls);
+    host[REGISTERED_KEY] = true;
+}

--- a/resources/js/visual-editor/editor/editor-app.tsx
+++ b/resources/js/visual-editor/editor/editor-app.tsx
@@ -44,6 +44,7 @@ import { registerResponsiveAttribute } from '../responsive/register-attribute';
 import { registerResponsiveAttributesFilter } from '../responsive/with-responsive-attributes';
 import { registerStateAttribute } from '../states/register-attribute';
 import { registerStateAttributesFilter } from '../states/with-state-attributes';
+import { registerBackgroundControls } from '../background-controls';
 import { registerBoxShadows } from '../box-shadows/register';
 import { registerGradientBorders } from '../gradient-borders/register';
 import { registerStateStylesFilters } from '../states/with-state-styles';
@@ -207,6 +208,11 @@ function registerOnce(): void {
     // on first render.
     registerGradientBorders();
     registerBoxShadows();
+    // #649 — register the background-controls BlockEdit HOC so external
+    // packages can contribute panels to any block that opts into a
+    // background support via the shared
+    // `ap.visual-editor.background-controls` filter.
+    registerBackgroundControls();
     // I7 (#415): register all artisanpack/* blocks and set the default
     // block to artisanpack/paragraph. Core blocks are no longer loaded.
     registerArtisanPackBlocks();

--- a/resources/js/visual-editor/editor/editor-app.tsx
+++ b/resources/js/visual-editor/editor/editor-app.tsx
@@ -175,6 +175,16 @@ function registerOnce(): void {
     disableContrastCheckerOnBlocks();
     registerContrastWarning();
     registerSyncedPatternIndicator();
+    // #649 — register the background-controls BlockEdit HOC FIRST so
+    // it wraps innermost. `@wordpress/hooks` composes filters in
+    // registration order, so the LAST-registered HOC wraps outermost;
+    // registering background-controls before the responsive + state
+    // HOCs below makes those wrap around it, which means the
+    // `context.attributes` this HOC hands to filter callbacks is the
+    // breakpoint-merged / state-resolved view — not the raw idle
+    // attributes — and `context.setAttributes` routes writes through
+    // the responsive/state wrappers.
+    registerBackgroundControls();
     // #487 — register the responsive feature filters BEFORE blocks load
     // so opted-in blocks pick up the auto-injected `responsive`
     // attribute at registration time and the BlockEdit HOC wraps every
@@ -208,11 +218,6 @@ function registerOnce(): void {
     // on first render.
     registerGradientBorders();
     registerBoxShadows();
-    // #649 — register the background-controls BlockEdit HOC so external
-    // packages can contribute panels to any block that opts into a
-    // background support via the shared
-    // `ap.visual-editor.background-controls` filter.
-    registerBackgroundControls();
     // I7 (#415): register all artisanpack/* blocks and set the default
     // block to artisanpack/paragraph. Core blocks are no longer loaded.
     registerArtisanPackBlocks();

--- a/resources/js/visual-editor/site-editor/__tests__/site-editor-app.test.tsx
+++ b/resources/js/visual-editor/site-editor/__tests__/site-editor-app.test.tsx
@@ -10,6 +10,16 @@ vi.mock('../../blocks', () => ({
     registerArtisanPackBlocks: (): void => undefined,
 }));
 
+// #649 — same reason as the BlockEditorBoundary + BlockLibrarySidebar
+// stubs below: the real background-controls barrel pulls
+// `@wordpress/block-editor` (and its `block-compare` → `diff` subpath)
+// into the graph, which doesn't resolve under jsdom. The shell test
+// only checks that `ensureEditorBoot()` runs the registrars; the HOC
+// itself has its own focused test suite.
+vi.mock('../../background-controls', () => ({
+    registerBackgroundControls: (): void => undefined,
+}));
+
 // #436: the shell now imports `BlockEditorBoundary` directly to wrap
 // the D2 canvas + inspector in one `BlockEditorProvider`. The real
 // boundary pulls `@wordpress/block-editor` (and its `block-compare` →

--- a/resources/js/visual-editor/site-editor/site-editor-app.tsx
+++ b/resources/js/visual-editor/site-editor/site-editor-app.tsx
@@ -45,6 +45,7 @@ import {
 } from './template-parts-section';
 import { usePersistedToggle } from './use-persisted-toggle';
 import { useSiteEditorRouting } from './use-site-editor-routing';
+import { registerBackgroundControls } from '../background-controls';
 import { registerArtisanPackBlocks } from '../blocks';
 import { registerBoxShadows } from '../box-shadows/register';
 import { registerGradientBorders } from '../gradient-borders/register';
@@ -160,6 +161,13 @@ function ensureEditorBoot(): void {
     // registration so `artisanpack/block` reference blocks get the badge
     // from the first render. Idempotent across HMR.
     registerSyncedPatternIndicator();
+
+    // #649 — register the background-controls BlockEdit HOC so external
+    // packages can contribute panels to any block that opts into a
+    // background support via the shared
+    // `ap.visual-editor.background-controls` filter. Idempotent across
+    // the post-editor and site-editor bootstrap paths.
+    registerBackgroundControls();
 
     // #490 — gradient border feature filters; same "before
     // registerArtisanPackBlocks" placement as the post-editor so opted-in


### PR DESCRIPTION
## Summary

- Adds `ap.visual-editor.background-controls` — a JS filter that lets external packages contribute panels to any block that opts into a background support, without each package enumerating target blocks and wrapping `editor.BlockEdit` itself.
- Ships a single built-in `editor.BlockEdit` HOC that gates on `supports.background` / `supports.color.background`, then renders filter-registered controls sorted by `priority` (default 10, lower first) and deduped by `id` (last-wins).
- Documents the filter in `docs/Hooks-and-Events.md` alongside the other JS-side filters (`document-panels`, `canvas-styles`, `rendered-block`).

Downstream `artisanpack-ui/liquid-glass` (and any future "effect" package) can now drop its per-package `editor.BlockEdit` HOC and register a single filter callback instead.

Closes #649.

## API

```ts
type BackgroundControl = {
    id: string           // stable, namespaced
    label: string        // panel heading (already translated)
    priority?: number    // default 10, lower first
    render: () => ReactNode
}

type BackgroundControlContext = {
    attributes: Record<string, unknown>
    setAttributes: (attrs: Record<string, unknown>) => void
    clientId: string
    blockName: string
    blockSupports: Record<string, unknown>
}

applyFilters('ap.visual-editor.background-controls', controls, context)
```

## Test plan

- [x] `vitest run resources/js/visual-editor/background-controls` — 20/20 pass (filter shape + HOC gating + priority ordering + block support detection)
- [x] Full editor suite (`vitest run resources/js/visual-editor`) still green apart from the pre-existing `site-editor-app.test.tsx` failures (verified reproducing on `release/1.x` with my changes stashed)
- [ ] Manual smoke: open the dev app, select `artisanpack/group`, register a stub filter callback in the browser console, confirm a new PanelBody appears in the inspector; select `artisanpack/separator` (or any non-background block), confirm no panel appears
- [ ] Refactor `liquid-glass/resources/js/index.ts` to consume the filter (follow-up PR in that repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added JavaScript filter support for extending visual editor background controls.
  - Blocks with background support can now display contributed appearance controls in the inspector.
  - Controls support configurable ordering, duplicate handling, and contextual block data.
- **Documentation**
  - Documented JavaScript filters, available extension points, contribution formats, and registration requirements.
- **Tests**
  - Added coverage for filtering, ordering, validation, rendering, and background-support behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->