### PR TITLE
feat: responsive preview — device sizes in visual + site editor (#617)

### DIFF
--- a/config/visual-editor.php
+++ b/config/visual-editor.php
@@ -389,7 +389,7 @@ return [
 
 	/*
 	|--------------------------------------------------------------------------
-	| Breakpoints (#487)
+	| Breakpoints (#487 · #617)
 	|--------------------------------------------------------------------------
 	|
 	| Named breakpoints the editor's viewport switcher and the responsive
@@ -397,13 +397,41 @@ return [
 	|
 	|   1. Active theme's `theme.json` → `settings.custom.artisanpack.breakpoints`
 	|   2. This config array (host-app overrides)
-	|   3. `BreakpointRegistry::DEFAULTS` (Tailwind v4 mins)
+	|   3. `BreakpointRegistry::DEFAULTS` (Tailwind v4 mins + Mobile/Tablet/Desktop labels)
 	|
-	| Merging is by key, so an entry here for `sm` resizes the default
-	| `sm` breakpoint without affecting the others; a new key like `3xl`
-	| adds a breakpoint. Values may be integer pixels (`640`) or CSS
-	| length strings (`'640px'`). Validation runs at registry-build time
-	| and throws on bad input — see `BreakpointRegistry::validate()`.
+	| Merging is by key. Two forms are accepted:
+	|
+	|   * Scalar (pre-#617) — a single pixel value or `Npx` string
+	|     that sets `minWidthPx`. `previewWidthPx` defaults to the same
+	|     value; `label` defaults to the key. Existing configs work
+	|     unchanged.
+	|
+	|         'sm' => '640px'
+	|         'md' => 768
+	|
+	|   * Object (#617) — `[ 'minWidthPx' => ..., 'previewWidthPx' => ...,
+	|     'label' => ... ]`. `minWidthPx` is required; `previewWidthPx`
+	|     falls back to `minWidthPx`; `label` falls back to the key.
+	|     Partial objects merge into the default at the same key, so
+	|     `'lg' => [ 'previewWidthPx' => 1440 ]` keeps the default
+	|     `minWidthPx` and `label`.
+	|
+	|         'sm' => [
+	|             'minWidthPx'     => 640,
+	|             'previewWidthPx' => 390,  // canvas iframe width (iPhone-sized preview)
+	|             'label'          => 'iPhone',
+	|         ],
+	|
+	| The `minWidthPx` field feeds Tailwind media-query prefixes and
+	| the mobile-first cascade — no change from #487. The
+	| `previewWidthPx` field is the canvas iframe width the switcher
+	| previews the layout at; it is intentionally decoupled so the
+	| `sm` cascade (activated at 640px) previews on a phone-sized
+	| 375px viewport rather than a physically impossible 640px phone.
+	|
+	| Validation runs at registry-build time and throws on bad input
+	| (unknown fields, non-positive widths, empty labels, duplicate
+	| min-widths) — see `BreakpointRegistry::validate()`.
 	|
 	| The implicit `base` slot (no min-width, applies everywhere) is
 	| reserved and cannot be redefined here.
@@ -411,9 +439,9 @@ return [
 	*/
 
 	'breakpoints' => [
-		// 'sm'  => '640px',
-		// 'md'  => '768px',
-		// 'lg'  => '1024px',
+		// 'sm'  => [ 'minWidthPx' => 640,  'previewWidthPx' => 375,  'label' => 'Mobile' ],
+		// 'md'  => [ 'minWidthPx' => 768,  'previewWidthPx' => 768,  'label' => 'Tablet' ],
+		// 'lg'  => [ 'minWidthPx' => 1024, 'previewWidthPx' => 1440, 'label' => 'Desktop' ],
 		// 'xl'  => '1280px',
 		// '2xl' => '1536px',
 	],

--- a/docs/blocks/Responsive-Design-Tools.md
+++ b/docs/blocks/Responsive-Design-Tools.md
@@ -15,18 +15,22 @@ This document covers both the editor-facing workflow and the developer integrati
 
 ### 1.1 The viewport switcher
 
-The editor toolbar shows one button per registered breakpoint, plus an `All` button on the left for the unprefixed base value:
+The editor toolbar shows one button per registered breakpoint, plus an `All sizes` button on the left for the unprefixed base value:
 
 ```
-[ All ] [ Mobile ] [ Tablet ] [ Desktop ] [ Wide ] [ Full ]
+[ All sizes ] [ Mobile ] [ Tablet ] [ Desktop ] [ xl ] [ 2xl ]
 ```
 
-Selecting a button does two things:
+Selecting a button does two things atomically (#617):
 
-1. **Resizes the canvas** to the breakpoint's min-width so you can preview the layout at that size.
+1. **Resizes the canvas** to the breakpoint's `previewWidthPx` so you can preview the layout at that device size. `All sizes` clears the width constraint and the canvas fills the available editor area.
 2. **Scopes the next style edit** to that breakpoint. Any Inspector control that supports responsive overrides records your change at the active breakpoint.
 
-The `All` button writes to the unprefixed base value — the value that applies everywhere unless a larger breakpoint overrides it.
+The `All sizes` button writes to the unprefixed base value — the value that applies everywhere unless a larger breakpoint overrides it.
+
+The three shipped device presets — `Mobile` (`sm`, 375px canvas), `Tablet` (`md`, 768px canvas), `Desktop` (`lg`, 1440px canvas) — preview at real device viewport widths, not at the CSS `min-width` that activates the breakpoint's cascade. The `sm` cascade activates at Tailwind's default 640px, but you preview it on a phone-sized 375px canvas because that is the device the CSS is authored for.
+
+The same switcher drives the post editor, the site editor (templates, template parts), and the patterns editor.
 
 ### 1.2 Setting a per-breakpoint override
 
@@ -64,15 +68,30 @@ Breakpoints resolve in priority order — highest layer wins on key collision:
 2. **Application config** — `artisanpack.visual-editor.breakpoints`
 3. **Package defaults** — `BreakpointRegistry::DEFAULTS` (Tailwind v4 mins)
 
+Each entry accepts two forms:
+
+- **Scalar** — a single pixel value or `Npx` string. `previewWidthPx` defaults to the same value; `label` defaults to the key. Pre-#617 configs work unchanged.
+- **Object** (#617) — `{ minWidthPx, previewWidthPx, label }`. `minWidthPx` is required; `previewWidthPx` falls back to `minWidthPx`; `label` falls back to the key. Partial objects merge into the default at the same key, so you can override just one field without restating the others.
+
 #### Config example
 
 ```php
 // config/artisanpack/visual-editor.php
 return [
     'breakpoints' => [
-        // Resize the default `lg` breakpoint:
-        'lg'  => '1100px',
-        // Add a new `3xl` breakpoint:
+        // Object form — override the switcher label and preview width:
+        'sm'  => [
+            'minWidthPx'     => 640,
+            'previewWidthPx' => 390,  // canvas iframe width (iPhone-sized preview)
+            'label'          => 'iPhone',
+        ],
+
+        // Partial override — keep the default `Desktop` label + 1440px preview,
+        // just move the media-query threshold:
+        'lg'  => [ 'minWidthPx' => 1100 ],
+
+        // Scalar form — still supported. Resolves to
+        // `{ minWidthPx: 1920, previewWidthPx: 1920, label: '3xl' }`.
         '3xl' => 1920,
     ],
 ];
@@ -86,7 +105,7 @@ return [
         "custom": {
             "artisanpack": {
                 "breakpoints": {
-                    "lg":  "1200px",
+                    "lg":  { "previewWidthPx": 1600 },
                     "3xl": 1920
                 }
             }
@@ -95,9 +114,21 @@ return [
 }
 ```
 
-Values may be integer pixels (`640`) or CSS-length strings (`'640px'`). Other lengths (`rem`, `vw`, …) are rejected at load time with a descriptive error.
+`minWidthPx` and `previewWidthPx` accept integer pixels (`640`) or CSS-length strings (`'640px'`). Other lengths (`rem`, `vw`, …) are rejected at load time with a descriptive error. `label` must be a non-empty string.
 
 The implicit `base` slot (no min-width, applies everywhere) is reserved — using it as a key throws.
+
+#### Ship defaults
+
+| Key   | Label     | `minWidthPx` | `previewWidthPx` |
+| ----- | --------- | ------------ | ---------------- |
+| `sm`  | `Mobile`  | 640          | 375              |
+| `md`  | `Tablet`  | 768          | 768              |
+| `lg`  | `Desktop` | 1024         | 1440             |
+| `xl`  | `xl`      | 1280         | 1280             |
+| `2xl` | `2xl`     | 1536         | 1536             |
+
+The `minWidthPx` / `previewWidthPx` split lets the `sm` media query kick in at Tailwind's default 640px while the canvas previews on a 375px phone — the size the CSS is authored for.
 
 ### 2.2 Opting a block into responsive support
 

--- a/resources/js/visual-editor/editor/__tests__/editor-canvas.test.tsx
+++ b/resources/js/visual-editor/editor/__tests__/editor-canvas.test.tsx
@@ -173,4 +173,78 @@ describe('EditorCanvas', () => {
         ).not.toBeInTheDocument();
         expect(screen.getByTestId('ap-stub-block-list')).toBeInTheDocument();
     });
+
+    /*
+     * #617 — the post editor stamps a preview width onto the canvas
+     * frame when the viewport switcher selects a device preset. These
+     * tests confirm the frame reflects it via inline max-width +
+     * data-attribute so both CSS and the RTL wiring test can react.
+     */
+    describe('#617 preview width prop', () => {
+        it('marks the frame as base when no preview width is provided', () => {
+            render(
+                <EditorCanvas
+                    showTitle
+                    title=""
+                    onTitleChange={() => undefined}
+                    blockContext={null}
+                />
+            );
+
+            const frame = screen.getByTestId('ap-visual-editor-canvas-frame');
+
+            expect(frame).toHaveAttribute('data-preview-width', 'base');
+            expect(frame.style.width).toBe('');
+        });
+
+        it('applies an inline width and data attribute when a preview width is set', () => {
+            render(
+                <EditorCanvas
+                    showTitle
+                    title=""
+                    onTitleChange={() => undefined}
+                    blockContext={null}
+                    previewWidthPx={375}
+                />
+            );
+
+            const frame = screen.getByTestId('ap-visual-editor-canvas-frame');
+
+            // #617 — inline `width` (not `max-width`) so wide presets
+            // scroll horizontally on the parent instead of clamping.
+            expect(frame).toHaveAttribute('data-preview-width', '375');
+            expect(frame.style.width).toBe('375px');
+            expect(frame.style.flexShrink).toBe('0');
+        });
+
+        it('treats null / non-positive previewWidthPx as base', () => {
+            const { rerender } = render(
+                <EditorCanvas
+                    showTitle
+                    title=""
+                    onTitleChange={() => undefined}
+                    blockContext={null}
+                    previewWidthPx={null}
+                />
+            );
+
+            expect(
+                screen.getByTestId('ap-visual-editor-canvas-frame')
+            ).toHaveAttribute('data-preview-width', 'base');
+
+            rerender(
+                <EditorCanvas
+                    showTitle
+                    title=""
+                    onTitleChange={() => undefined}
+                    blockContext={null}
+                    previewWidthPx={0}
+                />
+            );
+
+            const frame = screen.getByTestId('ap-visual-editor-canvas-frame');
+            expect(frame).toHaveAttribute('data-preview-width', 'base');
+            expect(frame.style.width).toBe('');
+        });
+    });
 });

--- a/resources/js/visual-editor/editor/__tests__/top-bar.test.tsx
+++ b/resources/js/visual-editor/editor/__tests__/top-bar.test.tsx
@@ -1,7 +1,9 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { resetActiveBreakpoint } from '../../responsive/active-breakpoint';
+import { BreakpointRegistry } from '../../responsive/registry';
 import { TopBar, type TopBarProps } from '../top-bar';
 
 function defaultProps(overrides: Partial<TopBarProps> = {}): TopBarProps {
@@ -28,6 +30,10 @@ function defaultProps(overrides: Partial<TopBarProps> = {}): TopBarProps {
 
 afterEach(() => {
     vi.restoreAllMocks();
+    // #617 — the viewport switcher owns a module-level active
+    // breakpoint store; without a reset, cross-test residue would
+    // flip a fresh <TopBar>'s aria-pressed on the wrong preset.
+    resetActiveBreakpoint();
 });
 
 describe('TopBar', () => {
@@ -366,5 +372,85 @@ describe('TopBar', () => {
 
         fireEvent.keyDown(window, { key: 'z', metaKey: true });
         expect(onUndo).not.toHaveBeenCalled();
+    });
+
+    /*
+     * #617 — the top-bar hosts the ViewportSwitcher and forwards
+     * `onViewportChange` / `viewportRegistry` down to it. These tests
+     * confirm the wiring reaches the switcher rather than getting lost
+     * in the top-bar shell.
+     */
+    describe('viewport switcher wiring (#617)', () => {
+        it('renders Mobile/Tablet/Desktop labels from the default registry', () => {
+            render(<TopBar {...defaultProps()} />);
+
+            expect(
+                screen.getByRole('button', { name: 'Mobile' })
+            ).toBeInTheDocument();
+            expect(
+                screen.getByRole('button', { name: 'Tablet' })
+            ).toBeInTheDocument();
+            expect(
+                screen.getByRole('button', { name: 'Desktop' })
+            ).toBeInTheDocument();
+        });
+
+        it('forwards a preset selection to onViewportChange with previewWidthPx', () => {
+            const onViewportChange = vi.fn();
+
+            render(
+                <TopBar
+                    {...defaultProps({
+                        onViewportChange,
+                    })}
+                />
+            );
+
+            act(() => {
+                fireEvent.click(screen.getByRole('button', { name: 'Mobile' }));
+            });
+            expect(onViewportChange).toHaveBeenLastCalledWith('sm', 375);
+
+            act(() => {
+                fireEvent.click(screen.getByRole('button', { name: 'Desktop' }));
+            });
+            expect(onViewportChange).toHaveBeenLastCalledWith('lg', 1440);
+
+            act(() => {
+                fireEvent.click(
+                    screen.getByRole('button', { name: 'All sizes' })
+                );
+            });
+            expect(onViewportChange).toHaveBeenLastCalledWith('base', 0);
+        });
+
+        it('uses a host-supplied viewportRegistry when provided', () => {
+            const onViewportChange = vi.fn();
+            const registry = new BreakpointRegistry([
+                { key: 'sm', minWidthPx: 640, previewWidthPx: 390, label: 'iPhone' },
+                { key: 'md', minWidthPx: 900, previewWidthPx: 900, label: 'Slate' },
+            ]);
+
+            render(
+                <TopBar
+                    {...defaultProps({
+                        viewportRegistry: registry,
+                        onViewportChange,
+                    })}
+                />
+            );
+
+            expect(
+                screen.getByRole('button', { name: 'iPhone' })
+            ).toBeInTheDocument();
+            expect(
+                screen.queryByRole('button', { name: 'Mobile' })
+            ).not.toBeInTheDocument();
+
+            act(() => {
+                fireEvent.click(screen.getByRole('button', { name: 'iPhone' }));
+            });
+            expect(onViewportChange).toHaveBeenLastCalledWith('sm', 390);
+        });
     });
 });

--- a/resources/js/visual-editor/editor/editor-app.css
+++ b/resources/js/visual-editor/editor/editor-app.css
@@ -87,7 +87,14 @@
     min-height: 0;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
+    /*
+     * #617 — allow the canvas to scroll horizontally so a wide
+     * preset (Desktop 1440px) in a narrower editor scrolls instead
+     * of being clipped. Y-axis stays hidden because the `BlockCanvas`
+     * iframe handles vertical overflow inside itself.
+     */
+    overflow-x: auto;
+    overflow-y: hidden;
 }
 
 /*
@@ -107,6 +114,17 @@
 .ap-visual-editor__canvas-frame {
     flex: 1 1 auto;
     min-height: 0;
+    /*
+     * #617 — when no device preset is active, the frame fills the
+     * column. When one is active, `editor-canvas.tsx` stamps an
+     * inline `width` (not `max-width`) so wide presets can push past
+     * the editor width and let the parent scroll horizontally;
+     * `margin: 0 auto` still centers the shrunk frame when the
+     * editor is wider than the preset.
+     */
+    width: 100%;
+    margin-left: auto;
+    margin-right: auto;
 }
 
 .ap-visual-editor__sidebar {

--- a/resources/js/visual-editor/editor/editor-app.tsx
+++ b/resources/js/visual-editor/editor/editor-app.tsx
@@ -50,6 +50,9 @@ import { registerGradientBorders } from '../gradient-borders/register';
 import { registerStateStylesFilters } from '../states/with-state-styles';
 import { registerAnimationsAttribute } from '../animations/register-attribute';
 import { registerAnimationsPanel } from '../animations/with-animations-panel';
+import { registryFromSnapshot } from '../responsive/registry';
+import type { BreakpointRegistrySnapshot } from '../responsive/types';
+import { useCanvasPreviewWidth } from '../responsive/use-canvas-preview-width';
 import {
     setBindingsApiConfig,
     setBindingsResourceContext,
@@ -284,6 +287,13 @@ export interface EditorAppProps {
     supports?: DocumentSupports;
     previewUrl?: string | null;
     onMetadataChange?: (change: MetadataChange) => void;
+    /**
+     * Serialised breakpoint registry (#617). When present, hydrated
+     * via `registryFromSnapshot()` and passed to `TopBar` as
+     * `viewportRegistry` so host-configured `label` and
+     * `previewWidthPx` overrides reach the viewport switcher.
+     */
+    breakpoints?: BreakpointRegistrySnapshot | null;
 }
 
 export { entityTypeForResource } from './entity-type';
@@ -487,6 +497,20 @@ function EditorAppShell(props: EditorAppProps): JSX.Element {
     const [inserterOpen, setInserterOpen] = useState<boolean>(false);
     const [inspectorOpen, setInspectorOpen] = useState<boolean>(true);
     const [shortcutsOpen, setShortcutsOpen] = useState<boolean>(false);
+    // #617 — viewport preset selection resizes the canvas frame.
+    // The shared hook holds the `null | positive-int` slot and the
+    // `onViewportChange` callback so post + site editors can't
+    // drift on the base-vs-named-preset contract.
+    const { canvasPreviewWidthPx, handleViewportChange } = useCanvasPreviewWidth();
+    // #617 — hydrate the viewport switcher's registry from the
+    // Blade-stamped `data-breakpoints` payload so host-configured
+    // `label` / `previewWidthPx` overrides reach the UI. When the
+    // host omits the snapshot, `registryFromSnapshot` falls back to
+    // the ship defaults.
+    const viewportRegistry = useMemo(
+        () => registryFromSnapshot(props.breakpoints ?? undefined),
+        [props.breakpoints]
+    );
     const [history, setHistory] = useState<HistoryState>(EMPTY_HISTORY);
     // Mirror history in a ref so undo/redo handlers can read the latest
     // snapshot without taking a dep on `history` (which would re-memoize the
@@ -803,6 +827,8 @@ function EditorAppShell(props: EditorAppProps): JSX.Element {
                 previewUrl={previewUrl}
                 onSave={flush}
                 onShowKeyboardShortcuts={handleShowShortcuts}
+                onViewportChange={handleViewportChange}
+                viewportRegistry={viewportRegistry}
             />
         ),
         [
@@ -812,6 +838,7 @@ function EditorAppShell(props: EditorAppProps): JSX.Element {
             handleToggleInserter,
             handleToggleInspector,
             handleUndo,
+            handleViewportChange,
             history.future.length,
             history.past.length,
             inserterOpen,
@@ -820,6 +847,7 @@ function EditorAppShell(props: EditorAppProps): JSX.Element {
             previewUrl,
             saveError,
             saveStatus,
+            viewportRegistry,
         ]
     );
 
@@ -929,6 +957,7 @@ function EditorAppShell(props: EditorAppProps): JSX.Element {
                 onTitleChange={handleTitleChange}
                 blockContext={blockContextValue}
                 apiBase={props.apiBase}
+                previewWidthPx={canvasPreviewWidthPx}
             />
             {/*
              * #488 — watch the selected block's attributes and re-route

--- a/resources/js/visual-editor/editor/editor-canvas.tsx
+++ b/resources/js/visual-editor/editor/editor-canvas.tsx
@@ -70,6 +70,14 @@ export interface EditorCanvasProps {
      * the canvas on the package-default baseline.
      */
     apiBase?: string;
+    /**
+     * Preview width (px) for the canvas iframe container (#617).
+     * When set to a positive int the canvas frame renders at that
+     * width so the editor can visually preview the layout at a device
+     * breakpoint. `null` leaves the frame unconstrained (fills the
+     * available editor area) — the `base` viewport state.
+     */
+    previewWidthPx?: number | null;
 }
 
 /**
@@ -77,7 +85,14 @@ export interface EditorCanvasProps {
  * `BlockEditorProvider` ancestor (mounted in `editor-app.tsx`).
  */
 export function EditorCanvas(props: EditorCanvasProps): JSX.Element {
-    const { showTitle, title, onTitleChange, blockContext, apiBase } = props;
+    const {
+        showTitle,
+        title,
+        onTitleChange,
+        blockContext,
+        apiBase,
+        previewWidthPx,
+    } = props;
 
     // Keystone #47: pull the compiled theme CSS once per `apiBase` and
     // append it to the iframe's styles array so the canvas surface
@@ -95,6 +110,20 @@ export function EditorCanvas(props: EditorCanvasProps): JSX.Element {
 
     const blockList = <BlockList layout={ROOT_CANVAS_LAYOUT} />;
 
+    // #617 — an inline `width` (rather than `max-width`) means the
+    // frame renders at exactly the requested preview size; wide
+    // presets in a narrow editor scroll horizontally on the parent
+    // (`.ap-visual-editor__canvas`, styled with `overflow-x: auto`)
+    // instead of being clamped. `margin: 0 auto` in the stylesheet
+    // centers the shrunk frame when the editor is wider than the
+    // preset. Emit `data-preview-width` so tests can assert the
+    // applied preset without reading inline style.
+    const hasPreviewWidth =
+        typeof previewWidthPx === 'number' && previewWidthPx > 0;
+    const canvasFrameStyle = hasPreviewWidth
+        ? { width: `${previewWidthPx}px`, maxWidth: 'none', flexShrink: 0 }
+        : undefined;
+
     return (
         <div
             className="ap-visual-editor__canvas"
@@ -103,7 +132,14 @@ export function EditorCanvas(props: EditorCanvasProps): JSX.Element {
             {showTitle ? (
                 <PostTitle value={title} onChange={onTitleChange} />
             ) : null}
-            <div className="ap-visual-editor__canvas-frame">
+            <div
+                className="ap-visual-editor__canvas-frame"
+                data-preview-width={
+                    hasPreviewWidth ? String(previewWidthPx) : 'base'
+                }
+                data-testid="ap-visual-editor-canvas-frame"
+                style={canvasFrameStyle}
+            >
                 <BlockCanvas height="100%" styles={styles}>
                     {blockContext !== null ? (
                         <BlockContextProvider value={blockContext}>

--- a/resources/js/visual-editor/editor/main.tsx
+++ b/resources/js/visual-editor/editor/main.tsx
@@ -18,6 +18,7 @@ import type {
     DocumentSupports,
     FeaturedImageValue,
 } from './document-panels';
+import type { BreakpointRegistrySnapshot } from '../responsive/types';
 
 export {
     registerArtisanpackMediaBridge,
@@ -111,6 +112,16 @@ export interface MountConfig {
     authorOptions?: ReadonlyArray<AuthorOption>;
     supports?: DocumentSupports;
     previewUrl?: string | null;
+    /**
+     * Serialised breakpoint registry (#617) — the merged config +
+     * theme.json + defaults snapshot. Hosts stamp this via
+     * `data-breakpoints` on the mount element; the shell hands it
+     * to `registryFromSnapshot()` and forwards the resulting registry
+     * to `TopBar` so the viewport switcher respects host-configured
+     * `label` / `previewWidthPx` overrides. Omit to fall back to
+     * the ship defaults.
+     */
+    breakpoints?: BreakpointRegistrySnapshot | null;
 }
 
 export interface MountedEditor {
@@ -221,6 +232,15 @@ function readMountConfig(element: HTMLElement): MountConfig | null {
         element.dataset.supports,
         'data-supports'
     );
+    // #617 — the host stamps the merged breakpoint registry as
+    // `data-breakpoints`. Passed through unchanged to the shell,
+    // which hydrates it via `registryFromSnapshot()`.
+    const rawBreakpoints = parseJsonDataset<
+        ReadonlyArray<{ key: string; minWidthPx: number; previewWidthPx?: number; label?: string }>
+    >(element.dataset.breakpoints, 'data-breakpoints');
+    const breakpoints: BreakpointRegistrySnapshot | null = Array.isArray(rawBreakpoints)
+        ? { breakpoints: rawBreakpoints as BreakpointRegistrySnapshot['breakpoints'] }
+        : null;
 
     // Dataset attributes are always strings, but most Laravel hosts store
     // author IDs as integers. Normalize back to the original type so
@@ -252,6 +272,7 @@ function readMountConfig(element: HTMLElement): MountConfig | null {
             ? { initialMenuOrder }
             : {}),
         ...(initialTemplate ? { initialTemplate } : {}),
+        ...(breakpoints !== null ? { breakpoints } : {}),
         previewUrl: previewUrl ?? null,
     };
 }

--- a/resources/js/visual-editor/editor/top-bar.tsx
+++ b/resources/js/visual-editor/editor/top-bar.tsx
@@ -100,6 +100,23 @@ export interface TopBarProps {
      * inspector panel) and the site editor (the section inspector).
      */
     inspectorToggleAriaLabel?: { open: string; close: string };
+    /**
+     * Optional override of the viewport switcher's breakpoint registry
+     * (#617). Falls back to the module-level default (Tailwind v4 +
+     * Mobile/Tablet/Desktop labels). Host shells that hydrate a
+     * registry from the server bootstrap pass it in here so the
+     * switcher renders the same set as the responsive-value resolver.
+     */
+    viewportRegistry?: BreakpointRegistry;
+    /**
+     * Side-effect fired when the user selects a viewport preset (#617).
+     * Receives the breakpoint key and the canvas preview width — `0`
+     * for `base` (unconstrained), a positive int for named
+     * breakpoints. Host shells wire this to their canvas container's
+     * inline width. Omitting it leaves the switcher purely
+     * edit-scoping (the pre-#617 behavior).
+     */
+    onViewportChange?: (breakpoint: string, previewWidthPx: number) => void;
 }
 
 function saveStatusLabel(
@@ -190,7 +207,11 @@ export function TopBar(props: TopBarProps): JSX.Element {
         leadingActions,
         inserterToggleAriaLabel,
         inspectorToggleAriaLabel,
+        viewportRegistry,
+        onViewportChange,
     } = props;
+
+    const viewportRegistryValue = viewportRegistry ?? DEFAULT_VIEWPORT_REGISTRY;
 
     const inserterOpenLabel =
         inserterToggleAriaLabel?.open ?? __('Open block inserter', TEXT_DOMAIN);
@@ -448,7 +469,8 @@ export function TopBar(props: TopBarProps): JSX.Element {
             </div>
             <div className="ap-visual-editor-top-bar__group ap-visual-editor-top-bar__group--center">
                 <ViewportSwitcher
-                    registry={DEFAULT_VIEWPORT_REGISTRY}
+                    registry={viewportRegistryValue}
+                    onChange={onViewportChange}
                     className="ap-visual-editor-viewport-switcher"
                 />
             </div>

--- a/resources/js/visual-editor/responsive/InspectorScopeChip.tsx
+++ b/resources/js/visual-editor/responsive/InspectorScopeChip.tsx
@@ -1,5 +1,5 @@
 /**
- * Inspector scope chip (#487).
+ * Inspector scope chip (#487 · #617).
  *
  * Small banner rendered at the top of the inspector's Block tab. When
  * the editor's active breakpoint is not `base`, it tells the editor
@@ -7,8 +7,16 @@
  * inspector controls would look like they were silently changing the
  * default value when they're actually scoped.
  *
- * Hidden entirely at `base` so the inspector stays uncluttered
- * during normal editing.
+ * Hidden entirely at `base` so the inspector stays uncluttered during
+ * normal editing.
+ *
+ * #617 — labels now come from the same `BreakpointRegistry` the
+ * viewport switcher renders, so the chip and switcher can't disagree
+ * on what to call the active breakpoint. Consumers that don't have a
+ * hydrated registry (dev/test paths, hosts still on the boot-time
+ * defaults) fall through to a module-level fallback registry built
+ * from `TAILWIND_V4_DEFAULTS`, so the chip still reads `Mobile` /
+ * `Tablet` / `Desktop` for the ship keys instead of the raw slug.
  *
  * @package @artisanpack-ui/visual-editor
  * @since 1.0.0
@@ -17,53 +25,61 @@
 import { useSyncExternalStore } from 'react'
 
 import { getActiveBreakpoint, setActiveBreakpoint, subscribeActiveBreakpoint } from './active-breakpoint'
+import { BreakpointRegistry, TAILWIND_V4_DEFAULTS } from './registry'
 import { BASE_KEY } from './types'
 
 import './inspector-scope-chip.css'
 
-// See ViewportSwitcher.tsx for why these are size-keyed rather than
-// device-named.
-const LABELS: Record<string, string> = {
-    [ BASE_KEY ]: 'All sizes',
-    sm:          'sm and up',
-    md:          'md and up',
-    lg:          'lg and up',
-    xl:          'xl and up',
-    '2xl':       '2xl and up',
+// Fallback registry used when the caller doesn't hydrate one from the
+// PHP-side bootstrap payload. Ensures the chip reads a device-friendly
+// label (`Mobile`, `Tablet`, `Desktop`) rather than the raw slug for
+// the shipped keys, and stays consistent with the switcher's ship
+// defaults.
+const FALLBACK_REGISTRY = new BreakpointRegistry( TAILWIND_V4_DEFAULTS )
+
+export interface InspectorScopeChipProps {
+	/**
+	 * Optional breakpoint registry — typically the same instance the
+	 * host passes to `TopBar`'s `viewportRegistry`. When provided, the
+	 * chip renders the registry's label (e.g. an author-configured
+	 * `iPhone`); when omitted, the chip uses the shipped defaults.
+	 */
+	registry?: BreakpointRegistry
 }
 
-export function InspectorScopeChip(): JSX.Element | null {
-    const active = useSyncExternalStore(
-        subscribeActiveBreakpoint,
-        getActiveBreakpoint,
-        getActiveBreakpoint,
-    )
+export function InspectorScopeChip( { registry }: InspectorScopeChipProps = {} ): JSX.Element | null {
+	const active = useSyncExternalStore(
+		subscribeActiveBreakpoint,
+		getActiveBreakpoint,
+		getActiveBreakpoint,
+	)
 
-    if ( BASE_KEY === active ) {
-        return null
-    }
+	if ( BASE_KEY === active ) {
+		return null
+	}
 
-    const label = LABELS[ active ] ?? active
+	const activeRegistry = registry ?? FALLBACK_REGISTRY
+	const label          = activeRegistry.label( active )
 
-    return (
-        <div
-            className="ap-visual-editor-inspector-scope-chip"
-            role="status"
-            aria-live="polite"
-        >
-            <span className="ap-visual-editor-inspector-scope-chip__label">
-                Editing at <strong>{ label }</strong>
-                <span className="ap-visual-editor-inspector-scope-chip__key">
-                    ({ active })
-                </span>
-            </span>
-            <button
-                type="button"
-                className="ap-visual-editor-inspector-scope-chip__reset"
-                onClick={ () => setActiveBreakpoint( BASE_KEY ) }
-            >
-                Switch to All sizes
-            </button>
-        </div>
-    )
+	return (
+		<div
+			className="ap-visual-editor-inspector-scope-chip"
+			role="status"
+			aria-live="polite"
+		>
+			<span className="ap-visual-editor-inspector-scope-chip__label">
+				Editing at <strong>{ label }</strong> and up
+				<span className="ap-visual-editor-inspector-scope-chip__key">
+					({ active })
+				</span>
+			</span>
+			<button
+				type="button"
+				className="ap-visual-editor-inspector-scope-chip__reset"
+				onClick={ () => setActiveBreakpoint( BASE_KEY ) }
+			>
+				Switch to All sizes
+			</button>
+		</div>
+	)
 }

--- a/resources/js/visual-editor/responsive/ViewportSwitcher.tsx
+++ b/resources/js/visual-editor/responsive/ViewportSwitcher.tsx
@@ -1,20 +1,25 @@
 /**
- * Viewport switcher (#487).
+ * Viewport switcher (#487 · #617).
  *
- * Toolbar component that lets the editor preview the canvas at a
- * specific breakpoint AND scope subsequent style edits to that
- * breakpoint.
+ * Unified device-preview + edit-scope toolbar. Selecting a button
+ * atomically:
+ *   1. Resizes the host canvas iframe to the breakpoint's
+ *      `previewWidthPx` (#617 — delegated to the `onChange`
+ *      callback so different host shells resize their own surface).
+ *   2. Scopes subsequent style edits to that breakpoint key
+ *      (#487 — mobile-first cascade semantics preserved).
  *
- * Behavior:
- *  - Renders one button per registered breakpoint plus a `base`
- *    button on the left.
- *  - Selecting a button (a) updates the active-breakpoint store,
- *    (b) sets the canvas iframe's width to the breakpoint's
- *    min-width (or unconstrained for `base`), (c) keeps the
- *    selection visible via aria-pressed.
- *  - The actual canvas-resize side-effect is delegated to an
- *    `onChange` callback so different host shells (admin editor,
- *    sandbox, site-editor) can resize their own surface.
+ * The `base` button previews at full editor width (no width
+ * constraint, callback receives `0`) and scopes edits to the cascade
+ * root.
+ *
+ * Display labels come from the registry entry's `label` field first,
+ * falling back to the switcher's `DEFAULT_LABELS`, then the key itself.
+ * The ship defaults expose `Mobile` / `Tablet` / `Desktop` for
+ * `sm` / `md` / `lg` (#617) to match the WordPress site-editor
+ * convention while keeping the internal keys stable so #487's
+ * cascade language and `docs/responsive-design-tools.md` guidance
+ * continue to work.
  *
  * @package @artisanpack-ui/visual-editor
  * @since 1.0.0
@@ -28,26 +33,28 @@ import { BASE_KEY } from './types'
 
 export interface ViewportSwitcherProps {
 	registry: BreakpointRegistry
-	/** Optional side-effect — typically resizes the canvas iframe. */
-	onChange?: ( breakpoint: string, minWidthPx: number ) => void
+	/**
+	 * Side-effect fired when the user selects a preset. Receives the
+	 * breakpoint key and the canvas preview width — the width is `0`
+	 * for `base` (unconstrained), a positive int for named
+	 * breakpoints. Host shells wire this to their canvas container's
+	 * inline width (#617).
+	 */
+	onChange?: ( breakpoint: string, previewWidthPx: number ) => void
 	className?: string
-	/** Override the visible labels (defaults to the breakpoint key, e.g. "sm"). */
+	/** Override the visible labels (highest priority, wins over registry labels). */
 	labels?: Record<string, string>
 }
 
-// Labels are intentionally size-keyed (`sm+`, `md+`) rather than
-// device-named (`Mobile`, `Tablet`). The editor uses mobile-first
-// cascade semantics — `base` applies everywhere, and each named
-// breakpoint is a progressive override at that min-width and up. A
-// label like "Mobile" for `sm` mis-suggests it scopes to phones only;
-// the `+` suffix makes the "this size and up" semantics obvious.
+// Default labels for keys the ship defaults DO NOT relabel from the
+// registry (`base`, `xl`, `2xl`). `sm`/`md`/`lg` get their
+// `Mobile`/`Tablet`/`Desktop` labels from the registry entry itself
+// (#617), so the switcher falls through to `registry.label(key)` for
+// those. Registry labels are authored, so they take precedence over
+// these fallbacks; the `labels` prop still wins over everything so
+// hosts can override on a per-mount basis.
 const DEFAULT_LABELS: Record<string, string> = {
 	[ BASE_KEY ]: 'All sizes',
-	sm:          'sm+',
-	md:          'md+',
-	lg:          'lg+',
-	xl:          'xl+',
-	'2xl':       '2xl+',
 }
 
 function tooltipFor( key: string, minWidth: number ): string {
@@ -59,15 +66,26 @@ function tooltipFor( key: string, minWidth: number ): string {
 }
 
 export function ViewportSwitcher( { registry, onChange, className, labels }: ViewportSwitcherProps ): JSX.Element {
-	const active  = useSyncExternalStore( subscribeActiveBreakpoint, getActiveBreakpoint, getActiveBreakpoint )
-	const display = { ...DEFAULT_LABELS, ...( labels ?? {} ) }
-	const keys    = registry.keysWithBase()
+	const active = useSyncExternalStore( subscribeActiveBreakpoint, getActiveBreakpoint, getActiveBreakpoint )
+	const keys   = registry.keysWithBase()
+
+	const displayFor = ( key: string ): string => {
+		if ( labels && key in labels ) {
+			return labels[ key ] as string
+		}
+
+		if ( key in DEFAULT_LABELS ) {
+			return DEFAULT_LABELS[ key ] as string
+		}
+
+		return registry.label( key )
+	}
 
 	const handleSelect = ( key: string ): void => {
 		setActiveBreakpoint( key )
 
 		if ( onChange ) {
-			onChange( key, registry.get( key ) ?? 0 )
+			onChange( key, registry.previewWidth( key ) ?? 0 )
 		}
 	}
 
@@ -87,7 +105,7 @@ export function ViewportSwitcher( { registry, onChange, className, labels }: Vie
 						title={ tooltipFor( key, minWidth ) }
 						onClick={ () => handleSelect( key ) }
 					>
-						{ display[ key ] ?? key }
+						{ displayFor( key ) }
 					</button>
 				)
 			} ) }

--- a/resources/js/visual-editor/responsive/__tests__/ViewportSwitcher.test.tsx
+++ b/resources/js/visual-editor/responsive/__tests__/ViewportSwitcher.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * Vitest coverage for the ViewportSwitcher (#617).
+ *
+ * Focuses on the parts #617 changes:
+ *   1. Rendering the registry's `label` (falling back to key).
+ *   2. Emitting `previewWidthPx` (not `minWidthPx`) in the onChange
+ *      payload.
+ *   3. `base` selection reports `0` so host shells can distinguish
+ *      "unconstrained" from a real device width.
+ */
+
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { resetActiveBreakpoint } from '../active-breakpoint'
+import { BreakpointRegistry, TAILWIND_V4_DEFAULTS } from '../registry'
+import { ViewportSwitcher } from '../ViewportSwitcher'
+
+const DEFAULT_REGISTRY = new BreakpointRegistry( TAILWIND_V4_DEFAULTS )
+
+describe( 'ViewportSwitcher (#617)', () => {
+	afterEach( () => {
+		resetActiveBreakpoint()
+	} )
+
+	it( 'renders Mobile/Tablet/Desktop labels for the ship defaults', () => {
+		render( <ViewportSwitcher registry={ DEFAULT_REGISTRY } /> )
+
+		expect( screen.getByRole( 'button', { name: 'All sizes' } ) ).toBeInTheDocument()
+		expect( screen.getByRole( 'button', { name: 'Mobile' } ) ).toBeInTheDocument()
+		expect( screen.getByRole( 'button', { name: 'Tablet' } ) ).toBeInTheDocument()
+		expect( screen.getByRole( 'button', { name: 'Desktop' } ) ).toBeInTheDocument()
+	} )
+
+	it( 'falls back to the key when a breakpoint has no registered label', () => {
+		const registry = new BreakpointRegistry( [
+			{ key: 'zoom', minWidthPx: 900 },
+		] )
+
+		render( <ViewportSwitcher registry={ registry } /> )
+
+		expect( screen.getByRole( 'button', { name: 'zoom' } ) ).toBeInTheDocument()
+	} )
+
+	it( 'lets the `labels` prop override registry labels', () => {
+		render(
+			<ViewportSwitcher
+				registry={ DEFAULT_REGISTRY }
+				labels={ { sm: 'Phone', md: 'Slate', base: 'Full width' } }
+			/>
+		)
+
+		expect( screen.getByRole( 'button', { name: 'Full width' } ) ).toBeInTheDocument()
+		expect( screen.getByRole( 'button', { name: 'Phone' } ) ).toBeInTheDocument()
+		expect( screen.getByRole( 'button', { name: 'Slate' } ) ).toBeInTheDocument()
+		expect( screen.getByRole( 'button', { name: 'Desktop' } ) ).toBeInTheDocument()
+	} )
+
+	it( 'emits the breakpoint key + previewWidthPx when a preset is selected', () => {
+		const onChange = vi.fn()
+
+		render(
+			<ViewportSwitcher registry={ DEFAULT_REGISTRY } onChange={ onChange } />
+		)
+
+		act( () => {
+			fireEvent.click( screen.getByRole( 'button', { name: 'Mobile' } ) )
+		} )
+		expect( onChange ).toHaveBeenLastCalledWith( 'sm', 375 )
+
+		act( () => {
+			fireEvent.click( screen.getByRole( 'button', { name: 'Tablet' } ) )
+		} )
+		expect( onChange ).toHaveBeenLastCalledWith( 'md', 768 )
+
+		act( () => {
+			fireEvent.click( screen.getByRole( 'button', { name: 'Desktop' } ) )
+		} )
+		expect( onChange ).toHaveBeenLastCalledWith( 'lg', 1440 )
+	} )
+
+	it( 'reports previewWidthPx=0 for the base selection so hosts can drop their inline width', () => {
+		const onChange = vi.fn()
+
+		render(
+			<ViewportSwitcher registry={ DEFAULT_REGISTRY } onChange={ onChange } />
+		)
+
+		act( () => {
+			fireEvent.click( screen.getByRole( 'button', { name: 'All sizes' } ) )
+		} )
+		expect( onChange ).toHaveBeenLastCalledWith( 'base', 0 )
+	} )
+
+	it( 'reflects the active selection via aria-pressed', () => {
+		render( <ViewportSwitcher registry={ DEFAULT_REGISTRY } /> )
+
+		const mobile = screen.getByRole( 'button', { name: 'Mobile' } )
+		act( () => {
+			fireEvent.click( mobile )
+		} )
+		expect( mobile ).toHaveAttribute( 'aria-pressed', 'true' )
+
+		const desktop = screen.getByRole( 'button', { name: 'Desktop' } )
+		expect( desktop ).toHaveAttribute( 'aria-pressed', 'false' )
+	} )
+} )

--- a/resources/js/visual-editor/responsive/__tests__/registry.test.ts
+++ b/resources/js/visual-editor/responsive/__tests__/registry.test.ts
@@ -51,4 +51,58 @@ describe( 'BreakpointRegistry', () => {
 	it( 'exports the Tailwind v4 default list as a constant', () => {
 		expect( TAILWIND_V4_DEFAULTS.map( ( bp ) => bp.key ) ).toEqual( [ 'sm', 'md', 'lg', 'xl', '2xl' ] )
 	} )
+
+	// #617 — device labels + preview widths
+	describe( '#617 preview width + label extensions', () => {
+		it( 'ships Mobile/Tablet/Desktop labels and device-sized preview widths by default', () => {
+			const registry = new BreakpointRegistry()
+
+			expect( registry.label( 'sm' ) ).toBe( 'Mobile' )
+			expect( registry.label( 'md' ) ).toBe( 'Tablet' )
+			expect( registry.label( 'lg' ) ).toBe( 'Desktop' )
+
+			expect( registry.previewWidth( 'sm' ) ).toBe( 375 )
+			expect( registry.previewWidth( 'md' ) ).toBe( 768 )
+			expect( registry.previewWidth( 'lg' ) ).toBe( 1440 )
+		} )
+
+		it( 'falls back to minWidthPx when a snapshot entry omits previewWidthPx', () => {
+			const registry = new BreakpointRegistry( [
+				{ key: 'zoom', minWidthPx: 900 },
+			] )
+
+			expect( registry.previewWidth( 'zoom' ) ).toBe( 900 )
+			expect( registry.label( 'zoom' ) ).toBe( 'zoom' )
+		} )
+
+		it( 'returns 0 previewWidth for base and null for unknown keys', () => {
+			const registry = new BreakpointRegistry()
+
+			expect( registry.previewWidth( 'base' ) ).toBe( 0 )
+			expect( registry.previewWidth( 'nope' ) ).toBeNull()
+		} )
+
+		it( 'honours an explicit preview width on hydration', () => {
+			const registry = registryFromSnapshot( {
+				breakpoints: [
+					{ key: 'sm', minWidthPx: 640, previewWidthPx: 390, label: 'iPhone' },
+				],
+			} )
+
+			expect( registry.previewWidth( 'sm' ) ).toBe( 390 )
+			expect( registry.label( 'sm' ) ).toBe( 'iPhone' )
+		} )
+
+		it( 'treats a non-positive previewWidthPx as a fallback to minWidthPx', () => {
+			// A pre-#617 snapshot could serialise with `previewWidthPx: 0`
+			// if the server-side registry accidentally emits it; the JS
+			// registry should still resolve to something sensible rather
+			// than pinning the canvas to 0px.
+			const registry = new BreakpointRegistry( [
+				{ key: 'sm', minWidthPx: 640, previewWidthPx: 0 },
+			] )
+
+			expect( registry.previewWidth( 'sm' ) ).toBe( 640 )
+		} )
+	} )
 } )

--- a/resources/js/visual-editor/responsive/registry.ts
+++ b/resources/js/visual-editor/responsive/registry.ts
@@ -7,6 +7,12 @@
  * which the bootstrap path stamps from the merged PHP config +
  * theme.json.
  *
+ * #617 extends each entry with an optional `label` (display string)
+ * and `previewWidthPx` (canvas iframe width). Both are optional and
+ * fall back to sensible defaults on read (`label → key`,
+ * `previewWidthPx → minWidthPx`), so pre-#617 snapshots that ship
+ * only `{ key, minWidthPx }` continue to work without migration.
+ *
  * @package @artisanpack-ui/visual-editor
  * @since 1.0.0
  */
@@ -14,11 +20,15 @@
 import { BASE_KEY, type Breakpoint, type BreakpointRegistrySnapshot } from './types'
 
 export const TAILWIND_V4_DEFAULTS: Breakpoint[] = [
-	{ key: 'sm', minWidthPx: 640 },
-	{ key: 'md', minWidthPx: 768 },
-	{ key: 'lg', minWidthPx: 1024 },
-	{ key: 'xl', minWidthPx: 1280 },
-	{ key: '2xl', minWidthPx: 1536 },
+	{ key: 'sm',  minWidthPx: 640,  previewWidthPx: 375,  label: 'Mobile' },
+	{ key: 'md',  minWidthPx: 768,  previewWidthPx: 768,  label: 'Tablet' },
+	{ key: 'lg',  minWidthPx: 1024, previewWidthPx: 1440, label: 'Desktop' },
+	// `xl+` / `2xl+` preserve the pre-#617 cascade signal (`this size
+	// and up`) for the two breakpoints without a device-friendly name
+	// — the mobile-first affordance stays visible for developers
+	// auditing which class prefixes emit.
+	{ key: 'xl',  minWidthPx: 1280, previewWidthPx: 1280, label: 'xl+' },
+	{ key: '2xl', minWidthPx: 1536, previewWidthPx: 1536, label: '2xl+' },
 ]
 
 export class BreakpointRegistry {
@@ -47,6 +57,43 @@ export class BreakpointRegistry {
 
 		const found = this.breakpoints.find( ( bp ) => bp.key === key )
 		return found ? found.minWidthPx : null
+	}
+
+	/**
+	 * Returns the canvas preview width for a key (#617). Falls back
+	 * to `minWidthPx` when the entry omits `previewWidthPx`. Returns
+	 * `0` for `base` (no width constraint) and `null` for unknown
+	 * keys, matching the semantics of {@see get()}.
+	 */
+	previewWidth( key: string ): number | null {
+		if ( BASE_KEY === key ) {
+			return 0
+		}
+
+		const found = this.breakpoints.find( ( bp ) => bp.key === key )
+
+		if ( ! found ) {
+			return null
+		}
+
+		return typeof found.previewWidthPx === 'number' && found.previewWidthPx > 0
+			? found.previewWidthPx
+			: found.minWidthPx
+	}
+
+	/**
+	 * Returns the display label for a key (#617). Falls back to the
+	 * key itself when no label is registered. `base` has no entry in
+	 * the registry so callers supply their own base label.
+	 */
+	label( key: string ): string {
+		const found = this.breakpoints.find( ( bp ) => bp.key === key )
+
+		if ( found && typeof found.label === 'string' && found.label !== '' ) {
+			return found.label
+		}
+
+		return key
 	}
 
 	has( key: string ): boolean {

--- a/resources/js/visual-editor/responsive/types.ts
+++ b/resources/js/visual-editor/responsive/types.ts
@@ -15,6 +15,32 @@ export type BreakpointKey = typeof BASE_KEY | string;
 export interface Breakpoint {
 	key: string;
 	minWidthPx: number;
+	/**
+	 * Human-readable label rendered in the viewport switcher (#617).
+	 * When omitted, the UI falls back to the breakpoint key.
+	 */
+	label?: string;
+	/**
+	 * Canvas iframe width, in pixels, used when the switcher previews
+	 * this breakpoint (#617). When omitted, the UI falls back to
+	 * `minWidthPx`. Split from `minWidthPx` because Tailwind's `sm`
+	 * cascade activates at `640px` but you preview it on a phone-sized
+	 * `375px` viewport.
+	 */
+	previewWidthPx?: number;
+}
+
+/**
+ * Wire form used by the PHP → JS bootstrap payload. Mirrors the
+ * `BreakpointRegistry::toArray()` shape so a snapshot round-trips
+ * losslessly between server and client.
+ *
+ * @since 1.0.0
+ */
+export interface BreakpointWireEntry {
+	minWidthPx: number;
+	label?: string;
+	previewWidthPx?: number;
 }
 
 /**

--- a/resources/js/visual-editor/responsive/use-canvas-preview-width.ts
+++ b/resources/js/visual-editor/responsive/use-canvas-preview-width.ts
@@ -1,0 +1,83 @@
+/**
+ * Shared canvas-preview-width state for the two editor shells (#617).
+ *
+ * The post editor (`editor/editor-app.tsx`) and the site editor
+ * (`site-editor/site-editor-app.tsx`) both react to the viewport
+ * switcher by holding a `number | null` slot for the active preview
+ * width and stamping it onto their canvas container as an inline
+ * `max-width` (post editor) or a CSS custom property (site editor).
+ * Before this hook existed the two shells carried byte-identical
+ * copies of the same `useState + handleViewportChange` pair, plus the
+ * subtle invariant that the switcher emits `previewWidthPx === 0` for
+ * `base` (so `<= 0` already subsumes the `key === 'base'` guard).
+ *
+ * Both shells now call this hook and pass `handleViewportChange`
+ * straight into `<TopBar onViewportChange={...} />`; the returned
+ * `canvasPreviewWidthPx` is what they read for the inline style.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.0.0
+ */
+
+import { useCallback, useState } from 'react'
+
+export interface CanvasPreviewWidthApi {
+	/**
+	 * Active preview width in pixels, or `null` when the switcher is
+	 * at `base` (no width constraint — canvas fills the editor).
+	 */
+	canvasPreviewWidthPx: number | null
+	/**
+	 * Direct pass-through for `<TopBar onViewportChange={...} />`. The
+	 * switcher emits `0` for `base` and a positive int for named
+	 * breakpoints; both collapse to `null` / a positive width here so
+	 * downstream JSX only has to check for `null`.
+	 */
+	handleViewportChange: ( key: string, previewWidthPx: number ) => void
+}
+
+export function useCanvasPreviewWidth(): CanvasPreviewWidthApi {
+	const [ canvasPreviewWidthPx, setCanvasPreviewWidthPx ] = useState<number | null>( null )
+
+	const handleViewportChange = useCallback(
+		// The switcher's contract is documented in
+		// `ViewportSwitcher.tsx`: emits `previewWidthPx === 0` for
+		// `base` and a positive int otherwise. `<= 0` covers both
+		// the base case and any host that supplies a weird
+		// registry entry.
+		( _key: string, previewWidthPx: number ): void => {
+			setCanvasPreviewWidthPx( previewWidthPx > 0 ? previewWidthPx : null )
+		},
+		[],
+	)
+
+	return { canvasPreviewWidthPx, handleViewportChange }
+}
+
+/**
+ * Site-editor-shaped JSX props for a canvas container div. Both the
+ * `showEntityEditor` and `isLazySection` branches in
+ * `site-editor-app.tsx` need the same `data-preview-width` +
+ * CSS-custom-property style block; this helper computes it once so
+ * they can't drift on the attribute name or the base sentinel.
+ *
+ * The returned object is intended to be spread onto the container
+ * div. `data-preview-width="base"` is always stamped so CSS selectors
+ * can match `[data-preview-width="base"]` deterministically instead
+ * of testing for attribute absence.
+ */
+export interface SiteEditorCanvasPreviewProps {
+	'data-preview-width': string
+	style?: { [ key: string ]: string }
+}
+
+export function siteEditorCanvasPreviewProps( canvasPreviewWidthPx: number | null ): SiteEditorCanvasPreviewProps {
+	if ( canvasPreviewWidthPx === null ) {
+		return { 'data-preview-width': 'base' }
+	}
+
+	return {
+		'data-preview-width': String( canvasPreviewWidthPx ),
+		style: { '--ap-site-editor-canvas-preview-width': `${ canvasPreviewWidthPx }px` },
+	}
+}

--- a/resources/js/visual-editor/site-editor/__tests__/site-editor-app.test.tsx
+++ b/resources/js/visual-editor/site-editor/__tests__/site-editor-app.test.tsx
@@ -216,6 +216,7 @@ vi.mock('../../box-shadows/register', () => ({
     registerBoxShadows: (): void => undefined,
 }));
 
+import { resetActiveBreakpoint } from '../../responsive/active-breakpoint';
 import { SiteEditorApp } from '../site-editor-app';
 
 const ROUTE_BASE = '/visual-editor/site';
@@ -231,6 +232,12 @@ beforeEach(() => {
 
 afterEach(() => {
     setPath('/');
+    // #617 — the viewport switcher writes to a module-level
+    // active-breakpoint singleton. Without a reset, residue from the
+    // viewport-preset test (or a mid-test early-return) leaks into
+    // subsequent tests in the same worker and cross-contaminates
+    // aria-pressed assertions.
+    resetActiveBreakpoint();
 });
 
 function renderApp(): void {
@@ -468,6 +475,42 @@ describe('SiteEditorApp', () => {
         expect(
             screen.getByTestId('ap-site-editor-mode-indicator')
         ).toHaveAttribute('data-section', 'patterns');
+    });
+
+    /*
+     * #617 — the shell's TopBar hosts the viewport switcher. Clicking
+     * a preset should stamp `data-preview-width` on the site-editor
+     * canvas container so templates/parts/patterns editing surfaces
+     * (which all render into that container) resize.
+     */
+    it('#617: applies the viewport preset width to the site-editor canvas container', async () => {
+        const user = userEvent.setup();
+        renderApp();
+
+        // Land in a section that renders the real canvas div (with
+        // `data-preview-width`) rather than the stubbed `CanvasFrame`
+        // empty state — Styles is a D3 section and takes the lazy
+        // path immediately without needing an entity id.
+        await user.click(screen.getByTestId('ap-site-editor-navigator-styles'));
+
+        const canvas = screen.getByTestId('ap-site-editor-canvas');
+        expect(canvas).toHaveAttribute('data-preview-width', 'base');
+
+        // Pick "Mobile" — matches the shipped `sm` label so tests
+        // don't need to reach into the registry to stay green.
+        await user.click(screen.getByRole('button', { name: 'Mobile' }));
+
+        expect(
+            screen.getByTestId('ap-site-editor-canvas')
+        ).toHaveAttribute('data-preview-width', '375');
+
+        // Switching back to "All sizes" clears the preview width so
+        // the canvas fills the shell area again.
+        await user.click(screen.getByRole('button', { name: 'All sizes' }));
+
+        expect(
+            screen.getByTestId('ap-site-editor-canvas')
+        ).toHaveAttribute('data-preview-width', 'base');
     });
 
     it('marks the body region as the tabpanel and labels it by the active tab', async () => {

--- a/resources/js/visual-editor/site-editor/canvas-frame.css
+++ b/resources/js/visual-editor/site-editor/canvas-frame.css
@@ -12,8 +12,35 @@
     min-height: 0;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
+    /*
+     * #617 — allow the canvas to scroll horizontally so a wide
+     * preset (Desktop 1440px) in a narrower editor scrolls instead
+     * of being clipped. Y-axis stays hidden because the block
+     * canvas' own iframe/scroll region handles vertical overflow.
+     */
+    overflow-x: auto;
+    overflow-y: hidden;
     background: var(--ap-site-editor-canvas-background, var(--color-base-100, #ffffff));
+}
+
+/*
+ * #617 — when a device preset is active `site-editor-app.tsx`
+ * stamps `--ap-site-editor-canvas-preview-width` on the canvas
+ * container and the child (entity canvas / patterns canvas / lazy
+ * section slot) becomes a fixed-width preview. Wider than the
+ * editor area? The parent above scrolls horizontally — matching the
+ * #617 spec ("wide desktop presets will horizontally-scroll in a
+ * narrow editor for v1"). Narrower? `margin-inline: auto` centers
+ * the shrunk preview so it reads as a device viewport.
+ *
+ * `flex-shrink: 0` prevents the flex-column parent from
+ * squeezing the preset back down to the container's width.
+ */
+.ap-site-editor__canvas[data-preview-width]:not([data-preview-width="base"]) > * {
+    width: var(--ap-site-editor-canvas-preview-width, 100%);
+    max-width: none;
+    flex-shrink: 0;
+    margin-inline: auto;
 }
 
 .ap-site-editor__canvas-iframe {

--- a/resources/js/visual-editor/site-editor/canvas-frame.tsx
+++ b/resources/js/visual-editor/site-editor/canvas-frame.tsx
@@ -24,6 +24,7 @@ import { __ } from '@wordpress/i18n';
 import type { BlockInstance } from '@wordpress/blocks';
 
 import { TEXT_DOMAIN } from '../vendor/i18n';
+import { siteEditorCanvasPreviewProps } from '../responsive/use-canvas-preview-width';
 
 import './canvas-frame.css';
 
@@ -44,6 +45,12 @@ export interface CanvasFrameProps {
      * inside the iframe.
      */
     children?: ReactNode;
+    /**
+     * Preview width (px) applied to the canvas container so the empty
+     * state honours the viewport switcher just like the entity + lazy
+     * branches (#617). `null` leaves the canvas at full editor width.
+     */
+    canvasPreviewWidthPx?: number | null;
 }
 
 const EMPTY_BLOCKS: BlockInstance[] = [];
@@ -51,7 +58,7 @@ const EMPTY_BLOCKS: BlockInstance[] = [];
 const EMPTY_SETTINGS = Object.freeze({});
 
 export function CanvasFrame(props: CanvasFrameProps): JSX.Element {
-    const { sectionLabel, hasEntity = false, children } = props;
+    const { sectionLabel, hasEntity = false, children, canvasPreviewWidthPx = null } = props;
 
     const emptyState = useMemo(
         () => (
@@ -80,6 +87,7 @@ export function CanvasFrame(props: CanvasFrameProps): JSX.Element {
             className="ap-site-editor__canvas"
             data-has-entity={hasEntity}
             data-testid="ap-site-editor-canvas"
+            {...siteEditorCanvasPreviewProps(canvasPreviewWidthPx)}
         >
             {hasEntity ? (
                 <SlotFillProvider>

--- a/resources/js/visual-editor/site-editor/main.tsx
+++ b/resources/js/visual-editor/site-editor/main.tsx
@@ -16,6 +16,7 @@ import { createElement } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 
 import '../a11y.css';
+import type { BreakpointRegistrySnapshot } from '../responsive/types';
 
 const MOUNT_SELECTOR = '[data-ap-site-editor]';
 const ROOT_SYMBOL: unique symbol = Symbol('ap-site-editor-root');
@@ -50,6 +51,14 @@ export interface SiteEditorMountConfig {
      */
     exitLabel?: string;
     theme?: string;
+    /**
+     * Serialised breakpoint registry (#617). Hosts stamp this via
+     * `data-breakpoints` on the mount element; the shell hydrates it
+     * via `registryFromSnapshot()` and forwards the resulting
+     * registry to `TopBar` so the viewport switcher respects
+     * host-configured `label` / `previewWidthPx` overrides.
+     */
+    breakpoints?: BreakpointRegistrySnapshot | null;
 }
 
 export interface MountedSiteEditor {
@@ -97,12 +106,31 @@ function readMountConfig(element: HTMLElement): SiteEditorMountConfig | null {
         );
     }
 
+    // #617 — the host stamps the merged breakpoint registry as
+    // `data-breakpoints`. Passed through unchanged to the shell.
+    const rawBreakpoints = element.dataset.breakpoints?.trim();
+    let breakpoints: BreakpointRegistrySnapshot | null = null;
+    if (rawBreakpoints !== undefined && rawBreakpoints !== '') {
+        try {
+            const parsed = JSON.parse(rawBreakpoints);
+            if (Array.isArray(parsed)) {
+                breakpoints = { breakpoints: parsed as BreakpointRegistrySnapshot['breakpoints'] };
+            }
+        } catch (error) {
+            console.warn(
+                'site-editor: could not parse data-breakpoints as JSON.',
+                error
+            );
+        }
+    }
+
     return {
         routeBase,
         apiBase,
         ...(exitUrl !== undefined && exitUrl !== '' ? { exitUrl } : {}),
         ...(exitLabel !== undefined && exitLabel !== '' ? { exitLabel } : {}),
         ...(theme !== undefined && theme !== '' ? { theme } : {}),
+        ...(breakpoints !== null ? { breakpoints } : {}),
     };
 }
 

--- a/resources/js/visual-editor/site-editor/site-editor-app.tsx
+++ b/resources/js/visual-editor/site-editor/site-editor-app.tsx
@@ -53,6 +53,12 @@ import { registerGradientBorders } from '../gradient-borders/register';
 import { BlockLibrarySidebar } from '../editor/block-library-sidebar';
 import { TopBar } from '../editor/top-bar';
 import { registerSyncedPatternIndicator } from '../editor/synced-pattern-indicator';
+import { registryFromSnapshot } from '../responsive/registry';
+import type { BreakpointRegistrySnapshot } from '../responsive/types';
+import {
+    siteEditorCanvasPreviewProps,
+    useCanvasPreviewWidth,
+} from '../responsive/use-canvas-preview-width';
 
 import './site-editor-app.css';
 
@@ -146,6 +152,13 @@ export interface SiteEditorAppProps {
     exitLabel?: string;
     /** Theme slug used when creating new templates / parts. */
     theme?: string;
+    /**
+     * Serialised breakpoint registry (#617). When present, hydrated
+     * via `registryFromSnapshot()` and forwarded to `TopBar` as
+     * `viewportRegistry` so host-configured `label` /
+     * `previewWidthPx` overrides reach the viewport switcher.
+     */
+    breakpoints?: BreakpointRegistrySnapshot | null;
 }
 
 let editorBooted = false;
@@ -244,6 +257,21 @@ export function SiteEditorApp(props: SiteEditorAppProps): JSX.Element {
 
     const [entityState, setEntityState] =
         useState<EntityEditorState>(IDLE_ENTITY_STATE);
+
+    // #617 — viewport preset resizes the site-editor canvas. All three
+    // canvas surfaces (templates/parts, patterns, styles slots) render
+    // into the same `.ap-site-editor__canvas` container so a single
+    // shell-level width slot covers them.
+    const { canvasPreviewWidthPx, handleViewportChange } = useCanvasPreviewWidth();
+    // #617 — hydrate the viewport switcher's registry from the
+    // Blade-stamped `data-breakpoints` payload so host-configured
+    // `label` / `previewWidthPx` overrides reach the UI. When the
+    // host omits the snapshot, `registryFromSnapshot` falls back to
+    // the ship defaults.
+    const viewportRegistry = useMemo(
+        () => registryFromSnapshot(props.breakpoints ?? undefined),
+        [props.breakpoints]
+    );
 
     const handleEntityStateChange = useCallback(
         (state: EntityEditorState): void => {
@@ -655,6 +683,7 @@ export function SiteEditorApp(props: SiteEditorAppProps): JSX.Element {
                     className="ap-site-editor__canvas"
                     data-has-entity="true"
                     data-testid="ap-site-editor-canvas"
+                    {...siteEditorCanvasPreviewProps(canvasPreviewWidthPx)}
                 >
                     {editorViews.canvas}
                 </div>
@@ -667,6 +696,7 @@ export function SiteEditorApp(props: SiteEditorAppProps): JSX.Element {
                         showPatternsEditor
                     }
                     data-testid="ap-site-editor-canvas"
+                    {...siteEditorCanvasPreviewProps(canvasPreviewWidthPx)}
                 >
                     <div
                         className="ap-site-editor__canvas-slot"
@@ -678,6 +708,7 @@ export function SiteEditorApp(props: SiteEditorAppProps): JSX.Element {
                 <CanvasFrame
                     sectionLabel={activeSection.modeLabel}
                     hasEntity={false}
+                    canvasPreviewWidthPx={canvasPreviewWidthPx}
                 />
             )}
             {inspectorOpen ? (
@@ -751,6 +782,8 @@ export function SiteEditorApp(props: SiteEditorAppProps): JSX.Element {
                 inspectorToggleAriaLabel={inspectorToggleAriaLabel}
                 extraActions={extraActions}
                 leadingActions={leadingActions}
+                onViewportChange={handleViewportChange}
+                viewportRegistry={viewportRegistry}
             />
             <main aria-labelledby={mainHeadingId}>
                 <h1 id={mainHeadingId} className="screen-reader-text">

--- a/resources/views/components/editor.blade.php
+++ b/resources/views/components/editor.blade.php
@@ -15,4 +15,8 @@
 	@isset($supports) data-supports="{{ json_encode( $supports ) }}" @endisset
 	@isset($previewUrl) data-preview-url="{{ $previewUrl }}" @endisset
 	data-content-types="{{ json_encode( $contentTypes, JSON_HEX_QUOT | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS ) }}"
+	{{-- #617 — merged breakpoint registry (config + theme.json +
+	     defaults) so the viewport switcher's registry hydrates with
+	     host-configured `label` / `previewWidthPx` overrides. --}}
+	data-breakpoints="{{ json_encode( $breakpoints ) }}"
 ></div>

--- a/resources/views/editor/mount.blade.php
+++ b/resources/views/editor/mount.blade.php
@@ -14,6 +14,11 @@
 		data-id="{{ $modelId }}"
 		data-api-base="{{ $apiBase }}"
 		data-content-types="{{ json_encode( $contentTypes ?? [], JSON_HEX_QUOT | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS ) }}"
+		{{-- #617 — merged breakpoint registry (config + theme.json +
+		     defaults). Reached by the React shell so the viewport
+		     switcher's registry respects host-configured
+		     `label` / `previewWidthPx` overrides. --}}
+		data-breakpoints="{{ json_encode( app( \ArtisanPackUI\VisualEditor\Responsive\BreakpointRegistry::class )->toArray() ) }}"
 	></div>
 </body>
 </html>

--- a/resources/views/site-editor/index.blade.php
+++ b/resources/views/site-editor/index.blade.php
@@ -29,6 +29,11 @@
 		data-exit-label="{{ __('← Post editor') }}"
 		data-api-base="/visual-editor/api"
 		data-theme="{{ config('artisanpack.visual-editor.global_styles.theme', 'default') }}"
+		{{-- #617 — the merged breakpoint registry (config +
+		     theme.json + defaults). The React shell hydrates the
+		     viewport switcher's registry from this so host-configured
+		     `label` / `previewWidthPx` overrides reach the UI. --}}
+		data-breakpoints="{{ json_encode( app( \ArtisanPackUI\VisualEditor\Responsive\BreakpointRegistry::class )->toArray() ) }}"
 	></div>
 </body>
 </html>

--- a/src/Responsive/BreakpointRegistry.php
+++ b/src/Responsive/BreakpointRegistry.php
@@ -24,6 +24,13 @@
  * NEVER stored in the registry itself — the registry only describes
  * the named, prefixed breakpoints.
  *
+ * #617 extends each entry with an optional `label` (viewport switcher
+ * display string) and `previewWidthPx` (canvas iframe width the
+ * switcher previews at). Both are accepted alongside the historical
+ * scalar form (`'sm' => '640px'`) — a scalar entry hydrates to
+ * `{ minWidthPx, previewWidthPx: minWidthPx, label: key }` on load,
+ * so no migration is required.
+ *
  * @package    ArtisanPack_UI
  * @subpackage VisualEditor
  *
@@ -41,17 +48,26 @@ use InvalidArgumentException;
 class BreakpointRegistry
 {
 	/**
-	 * Tailwind v4 defaults, used when nothing higher in the stack
-	 * overrides them.
+	 * Tailwind v4 defaults, extended with #617 preview widths and
+	 * device-friendly labels. Preview widths for `sm`/`md`/`lg` map
+	 * to real device viewports (iPhone / iPad portrait / desktop) —
+	 * they intentionally diverge from `minWidthPx` for `sm` because
+	 * Tailwind's mobile breakpoint kicks in at 640px but the actual
+	 * device is a 375-wide phone.
 	 *
-	 * @var array<string, string>
+	 * @var array<string, array{minWidthPx: int, previewWidthPx: int, label: string}>
 	 */
 	public const DEFAULTS = [
-		'sm'  => '640px',
-		'md'  => '768px',
-		'lg'  => '1024px',
-		'xl'  => '1280px',
-		'2xl' => '1536px',
+		'sm'  => [ 'minWidthPx' => 640,  'previewWidthPx' => 375,  'label' => 'Mobile' ],
+		'md'  => [ 'minWidthPx' => 768,  'previewWidthPx' => 768,  'label' => 'Tablet' ],
+		'lg'  => [ 'minWidthPx' => 1024, 'previewWidthPx' => 1440, 'label' => 'Desktop' ],
+		// `xl+` / `2xl+` preserve the pre-#617 cascade signal
+		// (`this size and up`) for the two breakpoints without a
+		// device-friendly name. `sm` / `md` / `lg` get real device
+		// labels above; `xl` / `2xl` fall back to a decorated key so
+		// hosts don't lose the mobile-first affordance on upgrade.
+		'xl'  => [ 'minWidthPx' => 1280, 'previewWidthPx' => 1280, 'label' => 'xl+' ],
+		'2xl' => [ 'minWidthPx' => 1536, 'previewWidthPx' => 1536, 'label' => '2xl+' ],
 	];
 
 	/**
@@ -64,22 +80,21 @@ class BreakpointRegistry
 	/**
 	 * Resolved, validated, ascending-sorted registry.
 	 *
-	 * @var array<string, int>  Keys are breakpoint slugs; values are the
-	 *                          min-width in pixels.
+	 * @var array<string, array{minWidthPx: int, previewWidthPx: int, label: string}>
 	 */
 	protected array $breakpoints;
 
 	/**
-	 * @param  array<string, int|string>  $raw  Pre-resolved breakpoints.
-	 *                                          Pass the output of
-	 *                                          {@see fromLayers()}
-	 *                                          unless you're constructing
-	 *                                          a one-off registry in a test.
+	 * @param  array<string, int|string|array<string, mixed>>  $raw  Pre-resolved breakpoints.
+	 *                                                               Pass the output of
+	 *                                                               {@see fromLayers()}
+	 *                                                               unless you're constructing
+	 *                                                               a one-off registry in a test.
 	 */
 	public function __construct( array $raw = [] )
 	{
-		$resolved          = $this->validate( $raw );
-		asort( $resolved );
+		$resolved = $this->validate( $raw );
+		uasort( $resolved, static fn ( array $a, array $b ) => $a['minWidthPx'] <=> $b['minWidthPx'] );
 		$this->breakpoints = $resolved;
 	}
 
@@ -90,10 +105,10 @@ class BreakpointRegistry
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param  array<string, int|string>|null  $configOverrides  Defaults to
-	 *                                                           `config('artisanpack.visual-editor.breakpoints')`.
-	 * @param  array<string, int|string>       $themeOverrides   `settings.custom.artisanpack.breakpoints`
-	 *                                                           from the active `theme.json`.
+	 * @param  array<string, int|string|array<string, mixed>>|null  $configOverrides  Defaults to
+	 *                                                                                `config('artisanpack.visual-editor.breakpoints')`.
+	 * @param  array<string, int|string|array<string, mixed>>       $themeOverrides   `settings.custom.artisanpack.breakpoints`
+	 *                                                                                from the active `theme.json`.
 	 */
 	public static function fromLayers( ?array $configOverrides = null, array $themeOverrides = [] ): self
 	{
@@ -101,7 +116,7 @@ class BreakpointRegistry
 			? (array) config( 'artisanpack.visual-editor.breakpoints', [] )
 			: [] );
 
-		$merged = array_replace( self::DEFAULTS, $config, $themeOverrides );
+		$merged = self::mergeByKey( self::DEFAULTS, $config, $themeOverrides );
 
 		$cleaned = array_filter( $merged, static fn ( $value ) => null !== $value && '' !== $value );
 
@@ -112,7 +127,10 @@ class BreakpointRegistry
 	 * Returns every registered breakpoint as `[key => min-width-px]`,
 	 * ascending by pixel value. The implicit `base` slot is NOT
 	 * included — callers that need it can prepend `'base' => 0` to the
-	 * result.
+	 * result. Preserved as `array<string, int>` for callers built
+	 * before #617 (Tailwind class emission, media query building);
+	 * use {@see entries()} for the extended `{ minWidthPx,
+	 * previewWidthPx, label }` shape.
 	 *
 	 * @since 1.0.0
 	 *
@@ -120,13 +138,35 @@ class BreakpointRegistry
 	 */
 	public function all(): array
 	{
+		$out = [];
+
+		foreach ( $this->breakpoints as $key => $spec ) {
+			$out[ $key ] = $spec['minWidthPx'];
+		}
+
+		return $out;
+	}
+
+	/**
+	 * Returns every registered breakpoint as `[key => spec]`, ascending
+	 * by pixel value. Each spec is a `{ minWidthPx, previewWidthPx,
+	 * label }` array (#617). The implicit `base` slot is NOT included —
+	 * callers that need it can prepend their own.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<string, array{minWidthPx: int, previewWidthPx: int, label: string}>
+	 */
+	public function entries(): array
+	{
 		return $this->breakpoints;
 	}
 
 	/**
 	 * Returns the min-width (in px) for a single breakpoint, or `null`
 	 * if the key isn't registered. The implicit `base` slot returns
-	 * `0`.
+	 * `0`. Preserved on the read-side for callers still on the pre-#617
+	 * signature (Tailwind class emission, media query building).
 	 *
 	 * @since 1.0.0
 	 */
@@ -136,7 +176,34 @@ class BreakpointRegistry
 			return 0;
 		}
 
-		return $this->breakpoints[ $key ] ?? null;
+		return $this->breakpoints[ $key ]['minWidthPx'] ?? null;
+	}
+
+	/**
+	 * Returns the canvas preview width (in px) for a single breakpoint,
+	 * or `null` if the key isn't registered (#617). The implicit `base`
+	 * slot returns `0` (no width constraint applied).
+	 *
+	 * @since 1.0.0
+	 */
+	public function previewWidth( string $key ): ?int
+	{
+		if ( self::BASE_KEY === $key ) {
+			return 0;
+		}
+
+		return $this->breakpoints[ $key ]['previewWidthPx'] ?? null;
+	}
+
+	/**
+	 * Returns the display label for a breakpoint, or `null` if the key
+	 * isn't registered (#617).
+	 *
+	 * @since 1.0.0
+	 */
+	public function label( string $key ): ?string
+	{
+		return $this->breakpoints[ $key ]['label'] ?? null;
 	}
 
 	/**
@@ -178,19 +245,49 @@ class BreakpointRegistry
 	}
 
 	/**
-	 * Validates a raw breakpoint map. Accepts integer pixel values and
-	 * CSS-length strings ending in `px`. Rejects empty keys, the
-	 * reserved `base` key, non-positive widths, duplicate widths, and
-	 * anything that doesn't parse to a positive integer pixel value.
+	 * Serializes the registry for the client bootstrap — mirrors the
+	 * TypeScript `Breakpoint[]` shape the JS registry expects. Returns
+	 * an ascending-sorted list of `{ key, minWidthPx, previewWidthPx,
+	 * label }` objects (#617).
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<int, array{key: string, minWidthPx: int, previewWidthPx: int, label: string}>
+	 */
+	public function toArray(): array
+	{
+		$out = [];
+
+		foreach ( $this->breakpoints as $key => $spec ) {
+			$out[] = [
+				'key'            => $key,
+				'minWidthPx'     => $spec['minWidthPx'],
+				'previewWidthPx' => $spec['previewWidthPx'],
+				'label'          => $spec['label'],
+			];
+		}
+
+		return $out;
+	}
+
+	/**
+	 * Validates a raw breakpoint map. Accepts:
+	 *   - integer pixel values (`640`)
+	 *   - CSS-length strings ending in `px` (`'640px'`)
+	 *   - object form `[ 'minWidthPx' => 640, 'previewWidthPx' => 375, 'label' => 'Mobile' ]`
+	 *
+	 * Rejects empty keys, the reserved `base` key, non-positive widths,
+	 * duplicate min-widths, invalid label types, and anything that
+	 * doesn't parse to a positive integer pixel value.
 	 *
 	 * Throws on the first failure with a descriptive message so theme
 	 * authors get actionable feedback when their `theme.json` is bad.
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param  array<string, int|string>  $raw
+	 * @param  array<string, int|string|array<string, mixed>>  $raw
 	 *
-	 * @return array<string, int>  Cleaned `[key => px-int]`.
+	 * @return array<string, array{minWidthPx: int, previewWidthPx: int, label: string}>
 	 */
 	public function validate( array $raw ): array
 	{
@@ -216,21 +313,153 @@ class BreakpointRegistry
 				) );
 			}
 
-			$pixels = $this->parsePixels( $value, $key );
+			$spec = $this->normalizeEntry( $value, $key );
 
-			if ( in_array( $pixels, $seen, true ) ) {
+			if ( in_array( $spec['minWidthPx'], $seen, true ) ) {
 				throw new InvalidArgumentException( sprintf(
 					'Breakpoint key "%s" has the same min-width (%dpx) as another breakpoint.',
 					$key,
-					$pixels
+					$spec['minWidthPx']
 				) );
 			}
 
-			$cleaned[ $key ] = $pixels;
-			$seen[]          = $pixels;
+			$cleaned[ $key ] = $spec;
+			$seen[]          = $spec['minWidthPx'];
 		}
 
 		return $cleaned;
+	}
+
+	/**
+	 * Merges layered breakpoint arrays by key.
+	 *
+	 * Each layer's entry is normalised to an object-shape fragment
+	 * BEFORE merging, so partial overrides survive intact through the
+	 * layer stack:
+	 *
+	 *   - Scalar entry (`'lg' => 1100`)              → `[ 'minWidthPx' => 1100 ]`
+	 *   - Full object                                 → same array, unchanged
+	 *   - Partial object (`[ 'label' => 'iPhone' ]`) → same array, unchanged
+	 *
+	 * Once every layer's entry is a fragment, `array_replace` merges
+	 * fields shallowly: a higher layer's `minWidthPx` wins, but any
+	 * field it omits keeps whatever the lower layer set. This is what
+	 * lets `'lg' => 1100` (scalar) sit on top of the DEFAULTS' `lg`
+	 * object without wiping the `Desktop` label or the `1440px` preview
+	 * width — the scalar contributes only `minWidthPx`. It also fixes
+	 * the reverse: a partial object `[ 'label' => 'Big' ]` layered on
+	 * top of a scalar `1024` no longer throws `missing minWidthPx`,
+	 * because the scalar already normalised to `[ 'minWidthPx' => 1024 ]`
+	 * and its field carries through.
+	 *
+	 * `null` and `''` values still remove any prior entry at that key.
+	 *
+	 * @param  array<string, int|string|array<string, mixed>>  ...$layers  Lowest priority first.
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
+	protected static function mergeByKey( array ...$layers ): array
+	{
+		$merged = [];
+
+		foreach ( $layers as $layer ) {
+			foreach ( $layer as $key => $value ) {
+				if ( null === $value || '' === $value ) {
+					// Explicit removal — drop any prior value.
+					unset( $merged[ $key ] );
+					continue;
+				}
+
+				$fragment = is_array( $value )
+					? $value
+					: [ 'minWidthPx' => $value ];
+
+				$merged[ $key ] = isset( $merged[ $key ] ) && is_array( $merged[ $key ] )
+					? array_replace( $merged[ $key ], $fragment )
+					: $fragment;
+			}
+		}
+
+		return $merged;
+	}
+
+	/**
+	 * Normalizes a single raw entry (scalar or object form) into the
+	 * canonical `{ minWidthPx, previewWidthPx, label }` shape. Scalar
+	 * entries fall back to `previewWidthPx = minWidthPx` and
+	 * `label = key`; object entries fill missing fields from those
+	 * same defaults.
+	 *
+	 * @param  int|string|array<string, mixed>  $value
+	 * @param  string                           $key    Used for error messages only.
+	 *
+	 * @return array{minWidthPx: int, previewWidthPx: int, label: string}
+	 */
+	protected function normalizeEntry( $value, string $key ): array
+	{
+		if ( is_array( $value ) ) {
+			return $this->normalizeObjectEntry( $value, $key );
+		}
+
+		$pixels = $this->parsePixels( $value, $key );
+
+		return [
+			'minWidthPx'     => $pixels,
+			'previewWidthPx' => $pixels,
+			'label'          => $key,
+		];
+	}
+
+	/**
+	 * Normalizes an object-form entry. Requires `minWidthPx`; fills
+	 * `previewWidthPx` from `minWidthPx` and `label` from the key when
+	 * omitted so authors can supply partial objects.
+	 *
+	 * @param  array<string, mixed>  $entry
+	 *
+	 * @return array{minWidthPx: int, previewWidthPx: int, label: string}
+	 */
+	protected function normalizeObjectEntry( array $entry, string $key ): array
+	{
+		if ( ! array_key_exists( 'minWidthPx', $entry ) ) {
+			throw new InvalidArgumentException( sprintf(
+				'Breakpoint "%s" is missing the required `minWidthPx` field.',
+				$key
+			) );
+		}
+
+		$minWidthPx = $this->parsePixels( $entry['minWidthPx'], $key );
+
+		$previewWidthPx = $minWidthPx;
+		if ( array_key_exists( 'previewWidthPx', $entry ) && null !== $entry['previewWidthPx'] ) {
+			$previewWidthPx = $this->parsePreviewPixels( $entry['previewWidthPx'], $key );
+		}
+
+		$label = $key;
+		if ( array_key_exists( 'label', $entry ) && null !== $entry['label'] ) {
+			if ( ! is_string( $entry['label'] ) ) {
+				throw new InvalidArgumentException( sprintf(
+					'Breakpoint "%s" label must be a string.',
+					$key
+				) );
+			}
+
+			$trimmed = trim( $entry['label'] );
+			if ( '' === $trimmed ) {
+				throw new InvalidArgumentException( sprintf(
+					'Breakpoint "%s" label must not be empty.',
+					$key
+				) );
+			}
+
+			$label = $trimmed;
+		}
+
+		return [
+			'minWidthPx'     => $minWidthPx,
+			'previewWidthPx' => $previewWidthPx,
+			'label'          => $label,
+		];
 	}
 
 	/**
@@ -263,6 +492,48 @@ class BreakpointRegistry
 		if ( $pixels <= 0 ) {
 			throw new InvalidArgumentException( sprintf(
 				'Breakpoint "%s" must be a positive pixel value, got %d.',
+				$key,
+				$pixels
+			) );
+		}
+
+		return $pixels;
+	}
+
+	/**
+	 * Like {@see parsePixels()} but for the `previewWidthPx` field —
+	 * error message names the field explicitly so authors know which
+	 * property tripped validation.
+	 *
+	 * @param  mixed   $value
+	 * @param  string  $key
+	 */
+	protected function parsePreviewPixels( $value, string $key ): int
+	{
+		if ( is_int( $value ) ) {
+			$pixels = $value;
+		} elseif ( is_string( $value ) ) {
+			$trimmed = trim( $value );
+
+			if ( 1 !== preg_match( '/^(\d+)(px)?$/i', $trimmed, $matches ) ) {
+				throw new InvalidArgumentException( sprintf(
+					'Breakpoint "%s" `previewWidthPx` has invalid value "%s". Expected an integer or a `Npx` string.',
+					$key,
+					is_scalar( $value ) ? (string) $value : gettype( $value )
+				) );
+			}
+
+			$pixels = (int) $matches[1];
+		} else {
+			throw new InvalidArgumentException( sprintf(
+				'Breakpoint "%s" `previewWidthPx` must be an integer or a `Npx` string.',
+				$key
+			) );
+		}
+
+		if ( $pixels <= 0 ) {
+			throw new InvalidArgumentException( sprintf(
+				'Breakpoint "%s" `previewWidthPx` must be a positive pixel value, got %d.',
 				$key,
 				$pixels
 			) );

--- a/src/View/Components/VisualEditorComponent.php
+++ b/src/View/Components/VisualEditorComponent.php
@@ -20,6 +20,7 @@ declare( strict_types=1 );
 
 namespace ArtisanPackUI\VisualEditor\View\Components;
 
+use ArtisanPackUI\VisualEditor\Responsive\BreakpointRegistry;
 use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
@@ -68,6 +69,15 @@ class VisualEditorComponent extends Component
 	 */
 	public array $contentTypes;
 
+	/**
+	 * Serialised breakpoint registry (#617) — the merged config +
+	 * theme.json + defaults snapshot the React shell hydrates the
+	 * viewport switcher against.
+	 *
+	 * @var array<int, array{key: string, minWidthPx: int, previewWidthPx: int, label: string}>
+	 */
+	public array $breakpoints;
+
 	public function __construct(
 		public Model $model,
 		?string $resource = null,
@@ -106,6 +116,7 @@ class VisualEditorComponent extends Component
 		$this->supports             = $supports;
 		$this->previewUrl           = $previewUrl;
 		$this->contentTypes         = $this->resolveContentTypes();
+		$this->breakpoints          = app( BreakpointRegistry::class )->toArray();
 	}
 
 	/**

--- a/tests/Unit/VisualEditor/Responsive/BreakpointRegistryTest.php
+++ b/tests/Unit/VisualEditor/Responsive/BreakpointRegistryTest.php
@@ -72,3 +72,176 @@ it( 'rejects breakpoints with non-numeric strings', function () {
 it( 'rejects breakpoints with invalid key characters', function () {
 	BreakpointRegistry::fromLayers( [], [ 'big screen!' => 1900 ] );
 } )->throws( InvalidArgumentException::class, 'letters, numbers' );
+
+/*
+|--------------------------------------------------------------------------
+| #617 — device labels + preview widths
+|--------------------------------------------------------------------------
+*/
+
+it( 'ships Mobile/Tablet/Desktop labels and device preview widths by default', function () {
+	$registry = BreakpointRegistry::fromLayers( [], [] );
+
+	expect( $registry->label( 'sm' ) )->toBe( 'Mobile' );
+	expect( $registry->label( 'md' ) )->toBe( 'Tablet' );
+	expect( $registry->label( 'lg' ) )->toBe( 'Desktop' );
+	expect( $registry->previewWidth( 'sm' ) )->toBe( 375 );
+	expect( $registry->previewWidth( 'md' ) )->toBe( 768 );
+	expect( $registry->previewWidth( 'lg' ) )->toBe( 1440 );
+} );
+
+it( 'returns 0 previewWidth for the implicit base slot and null for unknown keys', function () {
+	$registry = BreakpointRegistry::fromLayers( [], [] );
+
+	expect( $registry->previewWidth( 'base' ) )->toBe( 0 );
+	expect( $registry->previewWidth( 'nope' ) )->toBeNull();
+	expect( $registry->label( 'nope' ) )->toBeNull();
+} );
+
+it( 'accepts full object-form config entries', function () {
+	$registry = BreakpointRegistry::fromLayers(
+		[
+			'sm' => [
+				'minWidthPx'     => 640,
+				'previewWidthPx' => 390,
+				'label'          => 'iPhone',
+			],
+		],
+		[]
+	);
+
+	expect( $registry->get( 'sm' ) )->toBe( 640 );
+	expect( $registry->previewWidth( 'sm' ) )->toBe( 390 );
+	expect( $registry->label( 'sm' ) )->toBe( 'iPhone' );
+} );
+
+it( 'lets partial object overrides merge into the default at the same key', function () {
+	$registry = BreakpointRegistry::fromLayers(
+		[ 'lg' => [ 'previewWidthPx' => 1600 ] ],
+		[]
+	);
+
+	// Only previewWidthPx was overridden — minWidthPx + label stay from the default.
+	expect( $registry->get( 'lg' ) )->toBe( 1024 );
+	expect( $registry->previewWidth( 'lg' ) )->toBe( 1600 );
+	expect( $registry->label( 'lg' ) )->toBe( 'Desktop' );
+} );
+
+it( 'normalises a bare scalar override to { minWidthPx, minWidthPx, key } for NEW keys', function () {
+	// A scalar entry that introduces a fresh key (no default to
+	// inherit from) resolves to `{ minWidthPx: value, previewWidthPx:
+	// value, label: key }` — the back-compat guarantee documented in
+	// #617.
+	$registry = BreakpointRegistry::fromLayers( [ 'zoom' => '900px' ], [] );
+
+	expect( $registry->get( 'zoom' ) )->toBe( 900 );
+	expect( $registry->previewWidth( 'zoom' ) )->toBe( 900 );
+	expect( $registry->label( 'zoom' ) )->toBe( 'zoom' );
+} );
+
+it( 'lets a scalar override an existing default without wiping the default label/previewWidthPx', function () {
+	// Regression test for the #617 review finding: a pre-#617 host
+	// with `'lg' => 1100` in config expected to move the min-width
+	// only. Post-#617 the scalar layer contributes only `minWidthPx`
+	// — `previewWidthPx` and `label` still come from the DEFAULTS.
+	$registry = BreakpointRegistry::fromLayers( [ 'lg' => 1100 ], [] );
+
+	expect( $registry->get( 'lg' ) )->toBe( 1100 );
+	expect( $registry->previewWidth( 'lg' ) )->toBe( 1440 );
+	expect( $registry->label( 'lg' ) )->toBe( 'Desktop' );
+} );
+
+it( 'lets a partial-object override merge onto a scalar in a lower layer', function () {
+	// Regression test for the #617 review finding: a config layer
+	// stamps a scalar `'lg' => 1024` (pre-#617 style) and a theme.json
+	// layer wants to tweak just the label. The theme's `[ 'label' =>
+	// 'Big display' ]` merges into the scalar layer's `[ 'minWidthPx'
+	// => 1024 ]` — no `missing minWidthPx` throw, no lost fields.
+	$registry = BreakpointRegistry::fromLayers(
+		[ 'lg' => 1024 ],
+		[ 'lg' => [ 'label' => 'Big display' ] ]
+	);
+
+	expect( $registry->get( 'lg' ) )->toBe( 1024 );
+	expect( $registry->label( 'lg' ) )->toBe( 'Big display' );
+	// `previewWidthPx` still falls through from the DEFAULTS' `lg`
+	// object — 1440px.
+	expect( $registry->previewWidth( 'lg' ) )->toBe( 1440 );
+} );
+
+it( 'lets a theme.json object override win over the config layer', function () {
+	$registry = BreakpointRegistry::fromLayers(
+		[ 'sm' => [ 'previewWidthPx' => 400, 'label' => 'Config phone' ] ],
+		[ 'sm' => [ 'previewWidthPx' => 428, 'label' => 'Theme phone' ] ]
+	);
+
+	expect( $registry->previewWidth( 'sm' ) )->toBe( 428 );
+	expect( $registry->label( 'sm' ) )->toBe( 'Theme phone' );
+} );
+
+it( 'rejects object-form entries missing minWidthPx', function () {
+	BreakpointRegistry::fromLayers(
+		[ '3xl' => [ 'previewWidthPx' => 1920, 'label' => 'Wide' ] ],
+		[]
+	);
+} )->throws( InvalidArgumentException::class, '`minWidthPx`' );
+
+it( 'rejects object-form entries with a non-string label', function () {
+	BreakpointRegistry::fromLayers(
+		[ 'sm' => [ 'minWidthPx' => 640, 'label' => 42 ] ],
+		[]
+	);
+} )->throws( InvalidArgumentException::class, 'label must be a string' );
+
+it( 'rejects object-form entries with an empty label', function () {
+	BreakpointRegistry::fromLayers(
+		[ 'sm' => [ 'minWidthPx' => 640, 'label' => '   ' ] ],
+		[]
+	);
+} )->throws( InvalidArgumentException::class, 'label must not be empty' );
+
+it( 'rejects object-form entries with a non-positive previewWidthPx', function () {
+	BreakpointRegistry::fromLayers(
+		[ 'sm' => [ 'minWidthPx' => 640, 'previewWidthPx' => 0 ] ],
+		[]
+	);
+} )->throws( InvalidArgumentException::class, '`previewWidthPx`' );
+
+it( 'rejects object-form entries with an invalid previewWidthPx string', function () {
+	BreakpointRegistry::fromLayers(
+		[ 'sm' => [ 'minWidthPx' => 640, 'previewWidthPx' => '10rem' ] ],
+		[]
+	);
+} )->throws( InvalidArgumentException::class, '`previewWidthPx`' );
+
+it( 'exposes an entries() view of the extended shape', function () {
+	$registry = BreakpointRegistry::fromLayers( [], [] );
+
+	expect( $registry->entries()['sm'] )->toBe( [
+		'minWidthPx'     => 640,
+		'previewWidthPx' => 375,
+		'label'          => 'Mobile',
+	] );
+} );
+
+it( 'serialises to the JS wire shape via toArray()', function () {
+	$registry = BreakpointRegistry::fromLayers( [], [] );
+
+	$array = $registry->toArray();
+
+	expect( $array )->toHaveCount( 5 );
+	expect( $array[0] )->toBe( [
+		'key'            => 'sm',
+		'minWidthPx'     => 640,
+		'previewWidthPx' => 375,
+		'label'          => 'Mobile',
+	] );
+	expect( array_column( $array, 'key' ) )->toBe( [ 'sm', 'md', 'lg', 'xl', '2xl' ] );
+} );
+
+it( 'lets an explicit null in a higher layer remove a default breakpoint', function () {
+	$registry = BreakpointRegistry::fromLayers( [ 'xl' => null ], [] );
+
+	expect( $registry->has( 'xl' ) )->toBeFalse();
+	expect( $registry->prefixes() )->toBe( [ 'sm', 'md', 'lg', '2xl' ] );
+} );


### PR DESCRIPTION
## Description

Extends `ViewportSwitcher` into a unified device-preview + edit-scope control. Selecting a preset atomically resizes the canvas iframe to the breakpoint's `previewWidthPx` and scopes subsequent style edits to that key (existing #487 behavior). The `base` button previews at full editor width and scopes edits to the cascade root.

**Closes:** #617

## Type of Change

- [ ] Bug fix (fixes an issue)
- [x] New feature (adds new functionality)
- [x] Enhancement (improves existing functionality)
- [ ] Refactoring (code improvement, no behavior change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Security fix
- [ ] Breaking change (breaks backward compatibility)

## Related Issue

**Issue:** #617

## Motivation and Context

Issue #106 originally promised responsive preview as part of the canvas shell and was closed as part of that phase, but the actual canvas-resize behavior was never wired up. The `ViewportSwitcher` shipped for #487 (per-breakpoint style scoping) sat in the top bar but its `onChange` side-effect wasn't connected — clicking `sm+` / `md+` / `lg+` only scoped subsequent style edits, it did not resize the canvas.

This PR closes that gap and ships Mobile / Tablet / Desktop presets end-to-end.

## Changes Made

**Registry shape (both TS and PHP):**
- Each `Breakpoint` gains optional `label` (display string) and `previewWidthPx` (canvas iframe width) alongside `minWidthPx`.
- PHP config accepts scalar and object form. Partial objects merge into the default at the same key. Scalar overrides preserve default `label` / `previewWidthPx` because `mergeByKey` now normalises each layer to a `{minWidthPx: N}` fragment before `array_replace`.

**Ship defaults:** Mobile (`sm` / 375px), Tablet (`md` / 768px), Desktop (`lg` / 1440px), `xl+` (1280px), `2xl+` (1536px). The `+` suffix on `xl` / `2xl` preserves the mobile-first cascade signal from #487.

**Bootstrap bridge:**
- Both Blade templates (post editor's `x-visual-editor` component + site editor's `index.blade.php`) stamp `data-breakpoints` with the merged `BreakpointRegistry` snapshot.
- React shells parse it, hydrate via `registryFromSnapshot()`, and pass the resulting registry to `TopBar` as `viewportRegistry`. Falls back to ship defaults when omitted.

**Wiring:**
- Post editor: shared `useCanvasPreviewWidth()` hook + inline `width` on `.ap-visual-editor__canvas-frame`; parent `.ap-visual-editor__canvas` gets `overflow-x: auto` so wide presets scroll horizontally in narrow editors per the issue spec.
- Site editor: same hook + `siteEditorCanvasPreviewProps()` helper spread on the entity, lazy, and empty-state canvas branches; CSS applies the fixed width to the direct child inside the scrollable canvas container. Patterns editing inherits the resize via the site editor's canvas slot.
- `CanvasFrame` empty state honours the active preset so width stays consistent across all three canvas branches.
- `InspectorScopeChip` reads labels from an optional `registry` prop and falls back to a `TAILWIND_V4_DEFAULTS`-built registry so the chip and switcher never disagree on the shipped labels.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS
- Browser: Safari + Chrome (dev-app workbench)
- PHP Version: 8.4
- Project Version: release/1.x

**Tests Performed:**
1. Manually drove the post editor at `/admin/packages/visual-editor/standalone/editor?stack=react`: clicked Mobile/Tablet/Desktop/All sizes; verified canvas shrinks/centers correctly and edits scope to the active breakpoint.
2. Manually drove the site editor at `/visual-editor/site` across Templates, Template Parts, Patterns, and Styles sections: verified the same behavior in all four surfaces.
3. Ran full Vitest suite (2346 tests) and Pest suite (1380 relevant tests; 17 pre-existing AI-provider failures unrelated to this diff).
4. Verified horizontal scroll in a narrowed editor with the Desktop preset selected.

## Accessibility Tests Run

- [x] Keyboard navigation tested — buttons are focusable and clickable with Enter/Space
- [ ] Screen reader tested — `aria-pressed`, `role='group'`, `aria-label='Preview viewport'`, and tooltip `title` attributes preserved from #487; not exercised in this PR
- [x] Color contrast verified — no color-only signal added
- [x] ARIA labels checked — `aria-pressed` updates on selection; `role='status'` + `aria-live='polite'` preserved on `InspectorScopeChip`

**Details:** The switcher was already a11y-audited under #487; this PR does not change its markup semantics — only the label text (`sm+` → `Mobile`, etc.) and the `onChange` side effect. `InspectorScopeChip` renders the same registry-driven label as the switcher so screen readers announce the same viewport name in both places.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:**
- **Pest (PHP):** `BreakpointRegistryTest.php` — object-form validation, `previewWidth`/`label` accessors, partial-object merges, scalar-preserves-defaults regressions, `toArray()` wire shape, back-compat with scalar entries. 26 tests, 62 assertions.
- **Vitest (TS):** new `ViewportSwitcher.test.tsx` — device-label rendering, `onChange` payload with `previewWidthPx`, `base` reports 0. Extended `registry.test.ts` for object-form hydration + back-compat fallbacks. Extended `top-bar.test.tsx` with the viewport-switcher wiring block. Extended `editor-canvas.test.tsx` for the inline `width` frame. Extended `site-editor-app.test.tsx` for the shell-level preset propagation.

## Documentation

- [x] Inline code documentation added
- [ ] README updated
- [ ] Wiki updated
- [ ] API documentation updated

**Documentation details:** `docs/blocks/Responsive-Design-Tools.md` updated with the new object-form config example, ship-defaults table, and the unified control model. `config/visual-editor.php` docblock updated with the same guidance and a partial-object override example.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted (Pint clean)
- [x] Accessibility tests completed (see notes above)
- [x] Code follows project style guide
- [x] Self-review completed (multi-agent /code-review pass at high effort, all 10 findings applied)
- [x] Comments added for complex code
- [x] No new warnings generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added responsive viewport presets with device-friendly labels across the Visual Editor and Site Editor.
  * Canvas previews now resize to each preset’s configured preview width, with wide previews horizontally scrollable.
  * Added support for customized breakpoint labels and preview widths.
  * Breakpoint settings now support scalar and object formats with layered overrides and validation.

* **Documentation**
  * Updated breakpoint configuration and responsive design guidance with new formats, behavior, defaults, and validation rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->