### PR TITLE
feat: CSS positioning support for blocks (#640)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,34 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- **CSS positioning support for blocks (#640).** Per-block Position
+  panel in the inspector with a `static / relative / absolute / fixed
+  / sticky` dropdown, per-side offset inputs (`px / % / rem / em /
+  vh / vw / auto`), z-index, and per-breakpoint overrides via the
+  responsive tab pattern from #487. Opt-in per block via
+  `supports.position: true` in `block.json` (Gutenberg's native
+  `{ sticky: true }` object shape also counts). Emits scoped CSS
+  in the editor canvas and inline styles + a `<style
+  data-ve-position>` block on the frontend via the Blade renderer.
+  Inspector shows a warning notice when `position: absolute` is
+  applied but no ancestor is positioned.
+
+### Upgrade notes
+
+- **Hosts that ran `php artisan vendor:publish
+  --tag=visual-editor-blade-views` on a prior version must
+  re-publish with `--force` when upgrading.** The published
+  `blocks.blade.php` and `template.blade.php` files shadow the
+  package source; the pre-1.4 published copies don't include the
+  new `<style data-ve-position>` output block, so the position CSS
+  accumulator will flush its rules but they'll never land in the
+  response body — sticky/absolute blocks render unpositioned on the
+  frontend. Command:
+  `php artisan vendor:publish --tag=visual-editor-blade-views --force`.
+
+
 ## [1.3.0] - 2026-07-07
 
 ### Added

--- a/packages/visual-editor-renderer-blade/resources/views/components/blocks.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/components/blocks.blade.php
@@ -33,6 +33,11 @@
 {!! $boxShadowsCss !!}
 @endif
 @endisset
+@isset( $positionCss )
+@if( '' !== $positionCss )
+{!! $positionCss !!}
+@endif
+@endisset
 {!! $html !!}
 @isset( $animationsRuntimeNeeded )
 @if( $animationsRuntimeNeeded )

--- a/packages/visual-editor-renderer-blade/resources/views/components/template.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/components/template.blade.php
@@ -40,6 +40,11 @@
 {!! $boxShadowsCss !!}
 @endif
 @endisset
+@isset( $positionCss )
+@if( '' !== $positionCss )
+{!! $positionCss !!}
+@endif
+@endisset
 <div class="{{ implode( ' ', $wrapperClasses ) }}" data-ve-template="{{ $slug }}"@if( null !== $matchedSlug && $matchedSlug !== $slug ) data-ve-matched-template="{{ $matchedSlug }}"@endif>
 @if( null !== $resolutionError )
 @if( $inDev )

--- a/packages/visual-editor-renderer-blade/src/Services/PositionCssAccumulator.php
+++ b/packages/visual-editor-renderer-blade/src/Services/PositionCssAccumulator.php
@@ -1,0 +1,111 @@
+<?php
+
+/**
+ * Per-request accumulator for the CSS positioning feature (#640).
+ *
+ * Block partials push their per-scope position rules into this service
+ * while rendering. The `<x-ve-blocks>` / `<x-ve-template>` components
+ * drain it once and emit a single `<style data-ve-position>` block at
+ * the top of the render output — same pattern as
+ * {@see BoxShadowCssAccumulator}.
+ *
+ * Upgrade note: hosts that ran `php artisan vendor:publish
+ * --tag=visual-editor-blade-views` on a pre-1.4 version must republish
+ * with `--force` after upgrading — the published blade files shadow
+ * the package source and pre-1.4 copies don't include the
+ * `<style data-ve-position>` output block, so this accumulator
+ * flushes into the void on the frontend.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditorRendererBlade
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.4.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditorRendererBlade\Services;
+
+class PositionCssAccumulator
+{
+	/**
+	 * Map of scope class → CSS rule string. Keyed so duplicate pushes
+	 * collapse to one entry; PHP arrays preserve insertion order so
+	 * iteration produces deterministic output.
+	 *
+	 * @var array<string, string>
+	 */
+	protected array $rules = [];
+
+	/**
+	 * Adds a rule set for the given scope class. Identical pushes
+	 * (same scope + same rules) dedup — 50 blocks with the same
+	 * position payload emit one rule. When two blocks share a scope
+	 * class but ship DIFFERENT rule bodies (a `_positionScopeId`
+	 * collision from block duplication before the editor's collision
+	 * reclaim runs, or legacy content), keep BOTH entries so neither
+	 * block silently inherits the other's position — CSS cascade
+	 * (last-declaration-wins at equal specificity) picks the winner,
+	 * which beats the previous scope-only dedup that dropped one
+	 * block's rules entirely with no signal.
+	 *
+	 * @since 1.4.0
+	 */
+	public function push( string $scope, string $css ): void
+	{
+		if ( '' === $scope || '' === $css ) {
+			return;
+		}
+
+		$key = $scope . '#' . hash( 'xxh3', $css );
+
+		if ( isset( $this->rules[ $key ] ) ) {
+			return;
+		}
+
+		$this->rules[ $key ] = $css;
+	}
+
+	/**
+	 * Returns the consolidated `<style data-ve-position>` block and
+	 * clears the accumulator.
+	 *
+	 * @since 1.4.0
+	 */
+	public function flush(): string
+	{
+		if ( [] === $this->rules ) {
+			return '';
+		}
+
+		$body        = implode( '', array_values( $this->rules ) );
+		$this->rules = [];
+
+		return '<style data-ve-position>' . $body . '</style>';
+	}
+
+	/**
+	 * Resets the accumulator without emitting. Tests use this to clear
+	 * state between assertions inside a single PHP process.
+	 *
+	 * @since 1.4.0
+	 */
+	public function reset(): void
+	{
+		$this->rules = [];
+	}
+
+	/**
+	 * Inspect what's currently accumulated without draining. Test-only.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @return array<string, string>
+	 */
+	public function all(): array
+	{
+		return $this->rules;
+	}
+}

--- a/packages/visual-editor-renderer-blade/src/Support/BlockSupports.php
+++ b/packages/visual-editor-renderer-blade/src/Support/BlockSupports.php
@@ -51,12 +51,15 @@ use ArtisanPackUI\VisualEditor\BoxShadow\BoxShadowEmitter;
 use ArtisanPackUI\VisualEditor\BoxShadow\BoxShadowResolver;
 use ArtisanPackUI\VisualEditor\GradientBorder\GradientBorderEmitter;
 use ArtisanPackUI\VisualEditor\GradientBorder\GradientBorderResolver;
+use ArtisanPackUI\VisualEditor\Position\PositionEmitter;
+use ArtisanPackUI\VisualEditor\Position\PositionResolver;
 use ArtisanPackUI\VisualEditor\Responsive\BreakpointRegistry;
 use ArtisanPackUI\VisualEditor\States\StateCssEmitter;
 use ArtisanPackUI\VisualEditor\States\StateRegistry;
 use ArtisanPackUI\VisualEditor\States\StateValueResolver;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\BoxShadowCssAccumulator;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\GradientBorderCssAccumulator;
+use ArtisanPackUI\VisualEditorRendererBlade\Services\PositionCssAccumulator;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\ResponsiveCssAccumulator;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\StateCssAccumulator;
 
@@ -92,6 +95,17 @@ class BlockSupports
 	 * arbitrary class names into the wrapper.
 	 */
 	protected const ALIGN_VALUES = [ 'wide', 'full', 'left', 'center', 'right' ];
+
+	/**
+	 * Per-request cache for the position payload produced at the top of
+	 * {@see compile()} so {@see compilePosition()} can reuse it without
+	 * walking the resolver a second time (#640). Not a permanent cache
+	 * — cleared after {@see compilePosition()} reads it so the next
+	 * `compile()` invocation captures its own block's payload.
+	 *
+	 * @var array<string, mixed>|null
+	 */
+	protected static ?array $positionPayloadCache = null;
 
 	/**
 	 * Compile a block's attributes into the wrapper class / style / id
@@ -141,6 +155,23 @@ class BlockSupports
 		// `array_values` flattens the keys for predictable iteration.
 		$classes = array_values( array_unique( array_filter( $classes, static fn ( string $class ): bool => '' !== trim( $class ) ) ) );
 
+		// #640 — resolve the position payload once and thread it through
+		// both the inline-style stamp (below) and compilePosition() (via
+		// self::$positionPayloadCache). The inline stamp runs BEFORE
+		// `$styleString` composition so the base declarations land in
+		// the wrapper's `style` attribute; compilePosition emits the
+		// scoped `<style>` rules for the same payload later. Guard
+		// against `resolve()` returning null so the array offset on
+		// line below doesn't trip a PHP 8 warning for every block that
+		// has no position attributes (the default path).
+		$positionPayload            = PositionResolver::resolve( $attributes );
+		self::$positionPayloadCache = $positionPayload;
+		$positionInlineBase         = self::baseInlinePositionStyle( $positionPayload['base'] ?? null );
+
+		if ( '' !== $positionInlineBase ) {
+			$style[] = $positionInlineBase;
+		}
+
 		$styleString = '' === implode( '', $style ) ? '' : implode( '; ', $style ) . ';';
 
 		$responsive = self::compileResponsive( $attributes );
@@ -180,6 +211,14 @@ class BlockSupports
 			self::pushBoxShadow( $boxShadow['class'], $boxShadow['rules'] );
 		}
 
+		$position = self::compilePosition( $attributes );
+
+		if ( '' !== $position['class'] ) {
+			$classes[] = $position['class'];
+
+			self::pushPosition( $position['class'], $position['rules'] );
+		}
+
 		return [
 			'classes'             => $classes,
 			'style'               => $styleString,
@@ -193,6 +232,8 @@ class BlockSupports
 			'gradientBorderRules' => $gradientBorder['rules'],
 			'boxShadowClass'      => $boxShadow['class'],
 			'boxShadowRules'      => $boxShadow['rules'],
+			'positionClass'       => $position['class'],
+			'positionRules'       => $position['rules'],
 		];
 	}
 
@@ -213,99 +254,119 @@ class BlockSupports
 	}
 
 	/**
-	 * Push a scope's rules into the request-scoped accumulator so the
-	 * consolidated `<style data-ve-responsive>` block at the top of the
-	 * render output picks them up. Called automatically from compile();
-	 * the columns/column partial helpers below call it too for their
-	 * own bespoke rules (columnCount, flex-basis).
+	 * Push a scope's rules into a request-scoped accumulator (#640
+	 * consolidation of the previously copy-pasted per-feature push*
+	 * methods).
+	 *
+	 * Container-not-booted paths (very-early call sites, unit tests
+	 * that exercise BlockSupports without the package service
+	 * provider) silently drop — the call is idempotent and the
+	 * accumulator is a side channel, not the data path.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @param  class-string  $accumulator  Fully-qualified accumulator class.
+	 */
+	/**
+	 * Compose a `ve-<prefix>-<id>` scope class from an
+	 * editor-minted id or a content-derived hash fallback (#640
+	 * consolidation of the previously copy-pasted per-feature
+	 * `resolve*ScopeClass` helpers).
+	 *
+	 * The editor-minted id has to pass a strict allowlist regex + a
+	 * length cap — it lands unescaped in the wrapper's `class`
+	 * attribute, so its content has to be a safe identifier-style
+	 * token.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @param  string                $prefix      Class prefix without the trailing dash (e.g. `ve-bs`).
+	 * @param  string|null           $candidate   Editor-minted id or null.
+	 * @param  array<string, mixed>  $payload     Fallback hash source when the candidate is absent or invalid.
+	 */
+	protected static function composeScopeClass( string $prefix, ?string $candidate, array $payload ): string
+	{
+		if ( is_string( $candidate ) && 1 === preg_match( '/^[a-z0-9][a-z0-9_-]*$/i', $candidate ) && strlen( $candidate ) <= 64 ) {
+			return $prefix . '-' . $candidate;
+		}
+
+		$hash = substr(
+			hash( 'xxh3', (string) json_encode( $payload ) ),
+			0,
+			10
+		);
+
+		return $prefix . '-' . $hash;
+	}
+
+	protected static function pushToAccumulator( string $accumulator, string $scope, string $rules ): void
+	{
+		if ( '' === $scope || '' === $rules ) {
+			return;
+		}
+
+		if ( ! function_exists( 'app' ) ) {
+			return;
+		}
+
+		try {
+			app( $accumulator )->push( $scope, $rules );
+		} catch ( \Throwable $e ) {
+			// Silently drop — see method docblock.
+		}
+	}
+
+	/**
+	 * Push responsive CSS rules into the per-request accumulator.
+	 * Called automatically from {@see compile}; the columns/column
+	 * partial helpers below call it too for their own bespoke rules
+	 * (columnCount, flex-basis).
 	 *
 	 * @since 1.0.0
 	 */
 	public static function pushResponsive( string $scope, string $rules ): void
 	{
-		if ( '' === $scope || '' === $rules ) {
-			return;
-		}
-
-		if ( ! function_exists( 'app' ) ) {
-			return;
-		}
-
-		try {
-			app( ResponsiveCssAccumulator::class )->push( $scope, $rules );
-		} catch ( \Throwable $e ) {
-			// Container not booted (very-early call path or a unit
-			// test that exercises BlockSupports without the package
-			// service provider). Silently drop — the call is
-			// idempotent and the accumulator is the side channel,
-			// not the data path.
-		}
+		self::pushToAccumulator( ResponsiveCssAccumulator::class, $scope, $rules );
 	}
 
 	/**
-	 * Mirror of {@see pushResponsive} for state design tools (#488).
+	 * Push state design tool CSS rules into the per-request accumulator (#488).
 	 *
 	 * @since 1.0.0
 	 */
 	public static function pushStates( string $scope, string $rules ): void
 	{
-		if ( '' === $scope || '' === $rules ) {
-			return;
-		}
-
-		if ( ! function_exists( 'app' ) ) {
-			return;
-		}
-
-		try {
-			app( StateCssAccumulator::class )->push( $scope, $rules );
-		} catch ( \Throwable $e ) {
-			// See pushResponsive() — same drop-silently rationale.
-		}
+		self::pushToAccumulator( StateCssAccumulator::class, $scope, $rules );
 	}
 
 	/**
-	 * Mirror of {@see pushResponsive} for gradient borders (#490).
+	 * Push gradient border CSS rules into the per-request accumulator (#490).
 	 *
 	 * @since 1.1.0
 	 */
 	public static function pushGradientBorder( string $scope, string $rules ): void
 	{
-		if ( '' === $scope || '' === $rules ) {
-			return;
-		}
-
-		if ( ! function_exists( 'app' ) ) {
-			return;
-		}
-
-		try {
-			app( GradientBorderCssAccumulator::class )->push( $scope, $rules );
-		} catch ( \Throwable $e ) {
-			// See pushResponsive() — same drop-silently rationale.
-		}
+		self::pushToAccumulator( GradientBorderCssAccumulator::class, $scope, $rules );
 	}
 
 	/**
-	 * Mirror of {@see pushResponsive} for box shadows (#607).
+	 * Push box shadow CSS rules into the per-request accumulator (#607).
 	 *
 	 * @since 1.2.0
 	 */
 	public static function pushBoxShadow( string $scope, string $rules ): void
 	{
-		if ( '' === $scope || '' === $rules ) {
-			return;
-		}
+		self::pushToAccumulator( BoxShadowCssAccumulator::class, $scope, $rules );
+	}
 
-		if ( ! function_exists( 'app' ) ) {
-			return;
-		}
-
-		try {
-			app( BoxShadowCssAccumulator::class )->push( $scope, $rules );
-		} catch ( \Throwable $e ) {
-			// See pushResponsive() — same drop-silently rationale.
-		}
+	/**
+	 * Push CSS position rules into the per-request accumulator (#640).
+	 *
+	 * @since 1.4.0
+	 */
+	public static function pushPosition( string $scope, string $rules ): void
+	{
+		self::pushToAccumulator( PositionCssAccumulator::class, $scope, $rules );
 	}
 
 	/**
@@ -912,23 +973,12 @@ class BlockSupports
 	 */
 	protected static function resolveGradientBorderScopeClass( array $attributes, array $payload ): string
 	{
-		$border = $attributes['style']['border'] ?? null;
+		$border    = $attributes['style']['border'] ?? null;
+		$candidate = is_array( $border ) && isset( $border['_gradientScopeId'] ) && is_string( $border['_gradientScopeId'] )
+			? $border['_gradientScopeId']
+			: null;
 
-		if ( is_array( $border ) && isset( $border['_gradientScopeId'] ) && is_string( $border['_gradientScopeId'] ) ) {
-			$candidate = $border['_gradientScopeId'];
-
-			if ( 1 === preg_match( '/^[a-z0-9][a-z0-9_-]*$/i', $candidate ) && strlen( $candidate ) <= 64 ) {
-				return 've-gb-' . $candidate;
-			}
-		}
-
-		$hash = substr(
-			hash( 'xxh3', (string) json_encode( $payload ) ),
-			0,
-			10
-		);
-
-		return 've-gb-' . $hash;
+		return self::composeScopeClass( 've-gb', $candidate, $payload );
 	}
 
 	/**
@@ -992,23 +1042,135 @@ class BlockSupports
 	 */
 	protected static function resolveBoxShadowScopeClass( array $attributes, array $payload ): string
 	{
-		$shadow = $attributes['style']['shadow'] ?? null;
+		$shadow    = $attributes['style']['shadow'] ?? null;
+		$candidate = is_array( $shadow ) && isset( $shadow['_shadowScopeId'] ) && is_string( $shadow['_shadowScopeId'] )
+			? $shadow['_shadowScopeId']
+			: null;
 
-		if ( is_array( $shadow ) && isset( $shadow['_shadowScopeId'] ) && is_string( $shadow['_shadowScopeId'] ) ) {
-			$candidate = $shadow['_shadowScopeId'];
+		return self::composeScopeClass( 've-bs', $candidate, $payload );
+	}
 
-			if ( 1 === preg_match( '/^[a-z0-9][a-z0-9_-]*$/i', $candidate ) && strlen( $candidate ) <= 64 ) {
-				return 've-bs-' . $candidate;
-			}
+	/**
+	 * Compile the CSS positioning payload into a `{class, rules}` pair
+	 * that {@see compile} merges into the wrapper class list and pushes
+	 * into the per-request {@see PositionCssAccumulator} (#640).
+	 *
+	 * @since 1.4.0
+	 *
+	 * @param  array<string, mixed>  $attributes
+	 *
+	 * @return array{class: string, rules: string}
+	 */
+	protected static function compilePosition( array $attributes ): array
+	{
+		// Prefer the payload cached at the top of compile() (#640) so a
+		// single resolver walk feeds both the inline stamp and the
+		// scoped `<style>` rules. Fall back to a fresh resolve when
+		// called from a code path that didn't seed the cache (tests,
+		// direct callers).
+		$payload = self::$positionPayloadCache ?? PositionResolver::resolve( $attributes );
+		self::$positionPayloadCache = null;
+
+		if ( null === $payload ) {
+			return [ 'class' => '', 'rules' => '' ];
 		}
 
-		$hash = substr(
-			hash( 'xxh3', (string) json_encode( $payload ) ),
-			0,
-			10
-		);
+		try {
+			$breakpoints = function_exists( 'app' )
+				? self::resolveRegistry()
+				: BreakpointRegistry::fromLayers();
 
-		return 've-bs-' . $hash;
+			$emitter = new PositionEmitter( $breakpoints );
+
+			$scopeClass = self::resolvePositionScopeClass( $attributes, $payload );
+			$scope      = '.' . $scopeClass;
+			$css        = $emitter->emit( $scope, $payload );
+
+			if ( '' === $css ) {
+				return [ 'class' => '', 'rules' => '' ];
+			}
+
+			return [
+				'class' => $scopeClass,
+				'rules' => $css,
+			];
+		} catch ( \Throwable $e ) {
+			return [ 'class' => '', 'rules' => '' ];
+		}
+	}
+
+	/**
+	 * Build the semicolon-joined declaration list for the base layer.
+	 * Skips a `static` value (matches emitter semantics — no CSS while
+	 * static). Returns an empty string when the layer contributes
+	 * nothing.
+	 *
+	 * @param  array<string, mixed>|null  $base
+	 */
+	protected static function baseInlinePositionStyle( ?array $base ): string
+	{
+		if ( null === $base ) {
+			return '';
+		}
+
+		$value = $base['value'] ?? null;
+		if ( null === $value || 'static' === $value ) {
+			return '';
+		}
+
+		// `!important` mirrors PositionEmitter's scoped rules so the
+		// inline stamp survives theme resets that use `!important` on
+		// wrapper classes (e.g. `.wp-block-cover { position: relative
+		// !important }`). Without it, the inline fallback loses in
+		// exactly the sanitizer scenario it was added for.
+		$parts = [ 'position: ' . $value . ' !important' ];
+
+		$offsets = $base['offsets'] ?? [];
+		foreach ( [ 'top', 'right', 'bottom', 'left' ] as $side ) {
+			$offset = $offsets[ $side ] ?? null;
+			if ( null === $offset || ! is_array( $offset ) ) {
+				continue;
+			}
+
+			$unit = $offset['unit'] ?? '';
+			if ( 'auto' === $unit ) {
+				$parts[] = $side . ': auto !important';
+				continue;
+			}
+
+			$offsetValue = $offset['value'] ?? null;
+			if ( ! is_int( $offsetValue ) && ! is_float( $offsetValue ) ) {
+				continue;
+			}
+
+			$parts[] = $side . ': ' . $offsetValue . $unit . ' !important';
+		}
+
+		if ( isset( $base['zIndex'] ) && null !== $base['zIndex'] ) {
+			$parts[] = 'z-index: ' . (int) $base['zIndex'] . ' !important';
+		}
+
+		return implode( '; ', $parts );
+	}
+
+	/**
+	 * Prefer the editor-minted `style.position._positionScopeId` so the
+	 * editor preview and the server-rendered output target the same
+	 * scope class. Falls back to a content-derived hash otherwise.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @param  array<string, mixed>  $attributes
+	 * @param  array<string, mixed>  $payload
+	 */
+	protected static function resolvePositionScopeClass( array $attributes, array $payload ): string
+	{
+		$position  = $attributes['style']['position'] ?? null;
+		$candidate = is_array( $position ) && isset( $position['_positionScopeId'] ) && is_string( $position['_positionScopeId'] )
+			? $position['_positionScopeId']
+			: null;
+
+		return self::composeScopeClass( 've-pos', $candidate, $payload );
 	}
 
 	/**

--- a/packages/visual-editor-renderer-blade/src/View/Components/BlocksComponent.php
+++ b/packages/visual-editor-renderer-blade/src/View/Components/BlocksComponent.php
@@ -37,6 +37,7 @@ use ArtisanPackUI\VisualEditorRendererBlade\Services\AnimationCssAccumulator;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\GlobalStylesEmissionResolver;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\BoxShadowCssAccumulator;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\GradientBorderCssAccumulator;
+use ArtisanPackUI\VisualEditorRendererBlade\Services\PositionCssAccumulator;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\ResponsiveCssAccumulator;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\StateCssAccumulator;
 use Illuminate\Contracts\View\View;
@@ -83,9 +84,14 @@ class BlocksComponent extends Component
 		bool $resolveBreadcrumbs = true,
 		bool $resolveNavigation = true,
 		protected ?BoxShadowCssAccumulator $boxShadowAccumulator = null,
+		protected ?PositionCssAccumulator $positionAccumulator = null,
 	) {
 		if ( null === $this->boxShadowAccumulator ) {
 			$this->boxShadowAccumulator = app( BoxShadowCssAccumulator::class );
+		}
+
+		if ( null === $this->positionAccumulator ) {
+			$this->positionAccumulator = app( PositionCssAccumulator::class );
 		}
 
 		$this->defaultTheme = $defaultTheme;
@@ -173,6 +179,7 @@ class BlocksComponent extends Component
 		$animationOutput    = $this->animationAccumulator->flush();
 		$gradientBordersCss = $this->gradientBorderAccumulator->flush();
 		$boxShadowsCss      = $this->boxShadowAccumulator->flush();
+		$positionCss        = $this->positionAccumulator->flush();
 
 		return view( 'visual-editor-renderer-blade::components.blocks', [
 			'html'                    => $html,
@@ -184,6 +191,7 @@ class BlocksComponent extends Component
 			'animationsRuntimeNeeded' => $animationOutput['runtimeNeeded'],
 			'gradientBordersCss'      => $gradientBordersCss,
 			'boxShadowsCss'           => $boxShadowsCss,
+			'positionCss'             => $positionCss,
 		] );
 	}
 

--- a/packages/visual-editor-renderer-blade/src/View/Components/TemplateComponent.php
+++ b/packages/visual-editor-renderer-blade/src/View/Components/TemplateComponent.php
@@ -38,6 +38,7 @@ use ArtisanPackUI\VisualEditorRendererBlade\Services\AnimationCssAccumulator;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\GlobalStylesEmissionResolver;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\BoxShadowCssAccumulator;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\GradientBorderCssAccumulator;
+use ArtisanPackUI\VisualEditorRendererBlade\Services\PositionCssAccumulator;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\ResponsiveCssAccumulator;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\StateCssAccumulator;
 use Illuminate\Contracts\Foundation\Application;
@@ -84,9 +85,14 @@ class TemplateComponent extends Component
 		string $slug,
 		?string $theme = null,
 		protected ?BoxShadowCssAccumulator $boxShadowAccumulator = null,
+		protected ?PositionCssAccumulator $positionAccumulator = null,
 	) {
 		if ( null === $this->boxShadowAccumulator ) {
 			$this->boxShadowAccumulator = $this->app->make( BoxShadowCssAccumulator::class );
+		}
+
+		if ( null === $this->positionAccumulator ) {
+			$this->positionAccumulator = $this->app->make( PositionCssAccumulator::class );
 		}
 
 		$this->slug          = $slug;
@@ -130,6 +136,7 @@ class TemplateComponent extends Component
 		$animationOutput    = $this->animationAccumulator->flush();
 		$gradientBordersCss = $this->gradientBorderAccumulator->flush();
 		$boxShadowsCss      = $this->boxShadowAccumulator->flush();
+		$positionCss        = $this->positionAccumulator->flush();
 
 		return view( 'visual-editor-renderer-blade::components.template', [
 			'slug'                    => $this->slug,
@@ -147,6 +154,7 @@ class TemplateComponent extends Component
 			'animationsRuntimeNeeded' => $animationOutput['runtimeNeeded'],
 			'gradientBordersCss'      => $gradientBordersCss,
 			'boxShadowsCss'           => $boxShadowsCss,
+			'positionCss'             => $positionCss,
 		] );
 	}
 

--- a/packages/visual-editor-renderer-blade/src/VisualEditorRendererBladeServiceProvider.php
+++ b/packages/visual-editor-renderer-blade/src/VisualEditorRendererBladeServiceProvider.php
@@ -34,6 +34,7 @@ use ArtisanPackUI\VisualEditorRendererBlade\Services\AnimationCssAccumulator;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\GlobalStylesEmissionResolver;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\BoxShadowCssAccumulator;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\GradientBorderCssAccumulator;
+use ArtisanPackUI\VisualEditorRendererBlade\Services\PositionCssAccumulator;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\NavigationOverlayTracker;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\ResponsiveCssAccumulator;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\StateCssAccumulator;
@@ -171,6 +172,12 @@ class VisualEditorRendererBladeServiceProvider extends ServiceProvider
 		// shadow installs.
 		$this->app->scoped( BoxShadowCssAccumulator::class, function () {
 			return new BoxShadowCssAccumulator();
+		} );
+
+		// #640 — sibling accumulator for the CSS positioning feature's
+		// `<style data-ve-position>` block.
+		$this->app->scoped( PositionCssAccumulator::class, function () {
+			return new PositionCssAccumulator();
 		} );
 	}
 

--- a/packages/visual-editor-renderer-blade/tests/Unit/BlockSupportsTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Unit/BlockSupportsTest.php
@@ -495,6 +495,8 @@ describe( 'BlockSupports::compile (composition)', function (): void {
 			'gradientBorderRules' => '',
 			'boxShadowClass'      => '',
 			'boxShadowRules'      => '',
+			'positionClass'       => '',
+			'positionRules'       => '',
 		] );
 	} );
 
@@ -598,5 +600,50 @@ describe( 'compile() — state design tools (#488)', function (): void {
 
 		expect( $result['statesRules'] )->toContain( 'background-color: #abc123 !important;' );
 		expect( $result['statesRules'] )->toContain( 'background-color: #fff !important;' );
+	} );
+} );
+
+describe( 'compile() — CSS position (#640)', function (): void {
+	it( 'stamps a ve-pos-* scope class and the base declarations as inline styles', function (): void {
+		$result = BlockSupports::compile( [
+			'style' => [
+				'position' => [
+					'value'   => 'sticky',
+					'offsets' => [ 'top' => [ 'value' => 0, 'unit' => 'px' ] ],
+					'_positionScopeId' => 'abc1234',
+				],
+			],
+		] );
+
+		expect( $result['positionClass'] )->toBe( 've-pos-abc1234' );
+		expect( $result['classes'] )->toContain( 've-pos-abc1234' );
+		expect( $result['positionRules'] )->toContain( 'position:sticky !important' );
+		expect( $result['positionRules'] )->toContain( 'top:0px !important' );
+		// Base layer also stamps as inline style so hosts that strip
+		// the accumulated `<style data-ve-position>` on frontend render
+		// still get the wrapper's sticky behaviour. `!important`
+		// mirrors the emitter's scoped rule so the inline fallback
+		// survives theme resets that use `!important`.
+		expect( $result['style'] )->toContain( 'position: sticky !important' );
+		expect( $result['style'] )->toContain( 'top: 0px !important' );
+	} );
+
+	it( 'emits nothing when the base value is static (offsets preserved but silent)', function (): void {
+		$result = BlockSupports::compile( [
+			'style' => [ 'position' => [ 'value' => 'static' ] ],
+		] );
+
+		expect( $result['positionClass'] )->toBe( '' );
+		expect( $result['positionRules'] )->toBe( '' );
+		expect( $result['style'] )->toBe( '' );
+	} );
+
+	it( 'widens a legacy sticky string to inline styles + scope class', function (): void {
+		$result = BlockSupports::compile( [
+			'style' => [ 'position' => 'sticky' ],
+		] );
+
+		expect( $result['style'] )->toContain( 'position: sticky !important' );
+		expect( $result['positionRules'] )->toContain( 'position:sticky !important' );
 	} );
 } );

--- a/packages/visual-editor-renderer-blade/tests/Unit/PositionCssAccumulatorTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Unit/PositionCssAccumulatorTest.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * Unit tests for {@see PositionCssAccumulator} (#640).
+ *
+ * @since 1.4.0
+ */
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditorRendererBlade\Services\PositionCssAccumulator;
+
+describe( 'PositionCssAccumulator', function (): void {
+	it( 'dedupes identical (scope, rules) pushes', function (): void {
+		$accumulator = new PositionCssAccumulator();
+		$accumulator->push( '.ve-pos-abc', '.ve-pos-abc{position:sticky !important}' );
+		$accumulator->push( '.ve-pos-abc', '.ve-pos-abc{position:sticky !important}' );
+
+		$flushed = $accumulator->flush();
+		// One occurrence of the rule inside a single `<style data-ve-position>` block.
+		expect( substr_count( $flushed, 'position:sticky !important' ) )->toBe( 1 );
+	} );
+
+	it( 'keeps BOTH entries when the same scope arrives with different rules', function (): void {
+		// Regression: prior scope-only keying dropped the second push
+		// entirely, so a `_positionScopeId` collision (paste races,
+		// legacy content) made one block silently inherit the other's
+		// position. Now both entries emit; CSS cascade decides.
+		$accumulator = new PositionCssAccumulator();
+		$accumulator->push( '.ve-pos-abc', '.ve-pos-abc{position:sticky !important}' );
+		$accumulator->push( '.ve-pos-abc', '.ve-pos-abc{position:absolute !important}' );
+
+		$flushed = $accumulator->flush();
+		expect( $flushed )->toContain( 'position:sticky !important' );
+		expect( $flushed )->toContain( 'position:absolute !important' );
+	} );
+
+	it( 'drops empty scope or empty rules silently', function (): void {
+		$accumulator = new PositionCssAccumulator();
+		$accumulator->push( '', 'something' );
+		$accumulator->push( '.ve-pos-x', '' );
+
+		expect( $accumulator->flush() )->toBe( '' );
+	} );
+
+	it( 'clears state on flush', function (): void {
+		$accumulator = new PositionCssAccumulator();
+		$accumulator->push( '.ve-pos-x', '.ve-pos-x{position:sticky}' );
+		expect( $accumulator->flush() )->not->toBe( '' );
+		expect( $accumulator->flush() )->toBe( '' );
+	} );
+} );

--- a/resources/js/visual-editor/editor/editor-app.tsx
+++ b/resources/js/visual-editor/editor/editor-app.tsx
@@ -47,6 +47,7 @@ import { registerStateAttributesFilter } from '../states/with-state-attributes';
 import { registerBackgroundControls } from '../background-controls';
 import { registerBoxShadows } from '../box-shadows/register';
 import { registerGradientBorders } from '../gradient-borders/register';
+import { registerPositioning } from '../positioning/register';
 import { registerStateStylesFilters } from '../states/with-state-styles';
 import { registerAnimationsAttribute } from '../animations/register-attribute';
 import { registerAnimationsPanel } from '../animations/with-animations-panel';
@@ -221,6 +222,7 @@ function registerOnce(): void {
     // on first render.
     registerGradientBorders();
     registerBoxShadows();
+    registerPositioning();
     // I7 (#415): register all artisanpack/* blocks and set the default
     // block to artisanpack/paragraph. Core blocks are no longer loaded.
     registerArtisanPackBlocks();

--- a/resources/js/visual-editor/positioning/__tests__/emitter.test.ts
+++ b/resources/js/visual-editor/positioning/__tests__/emitter.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Emitter tests for the position feature (#643).
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.4.0
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import { BreakpointRegistry, TAILWIND_V4_DEFAULTS } from '../../responsive/registry'
+import {
+	emitPositionCss,
+	layerDeclarations,
+	mergedBreakpointLayers,
+} from '../emitter'
+import { resolvePosition } from '../resolver'
+
+const registry = new BreakpointRegistry( TAILWIND_V4_DEFAULTS )
+
+describe( 'layerDeclarations', () => {
+	it( 'emits nothing for a null layer', () => {
+		expect( layerDeclarations( null ) ).toBe( '' )
+	} )
+
+	it( 'emits nothing when the resolved value is static', () => {
+		expect(
+			layerDeclarations( {
+				value: 'static',
+				offsets: { top: null, right: null, bottom: null, left: null },
+				zIndex: null,
+			} ),
+		).toBe( '' )
+	} )
+
+	it( 'emits nothing when only orphan offsets/zIndex are set with no non-static value', () => {
+		expect(
+			layerDeclarations( {
+				value: null,
+				offsets: {
+					top:    { value: 10, unit: 'px' },
+					right:  null,
+					bottom: null,
+					left:   null,
+				},
+				zIndex: 3,
+			} ),
+		).toBe( '' )
+	} )
+
+	it( 'emits position + offsets + z-index for a non-static value', () => {
+		expect(
+			layerDeclarations( {
+				value: 'absolute',
+				offsets: {
+					top:    { value: 10, unit: 'px' },
+					right:  null,
+					bottom: { value: 5, unit: 'rem' },
+					left:   { value: 0, unit: 'auto' },
+				},
+				zIndex: 2,
+			} ),
+		).toBe( 'position:absolute !important;top:10px !important;bottom:5rem !important;left:auto !important;z-index:2 !important' )
+	} )
+} )
+
+describe( 'emitPositionCss', () => {
+	it( 'returns empty string when the scope is empty', () => {
+		const payload = resolvePosition( { style: { position: { value: 'relative' } } } )!
+		expect( emitPositionCss( '   ', payload, registry, {} ) ).toBe( '' )
+	} )
+
+	it( 'returns empty string when the payload is null', () => {
+		expect( emitPositionCss( '.foo', null, registry, {} ) ).toBe( '' )
+	} )
+
+	it( 'emits the base rule and per-breakpoint media queries in ascending order', () => {
+		const attrs = {
+			style: {
+				position: {
+					value: 'relative',
+					offsets: { top: { value: 10, unit: 'px' } },
+				},
+			},
+			responsive: {
+				'style.position': {
+					lg: { value: 'sticky', offsets: { top: { value: 0, unit: 'px' } } },
+					md: { zIndex: 3 },
+				},
+			},
+		}
+
+		const payload = resolvePosition( attrs )!
+		const merged  = mergedBreakpointLayers( payload, registry )
+		const css     = emitPositionCss( '.wrap', payload, registry, merged )
+
+		expect( css ).toContain( '.wrap{position:relative !important;top:10px !important}' )
+		// md inherits value=relative + top from base, adds z-index.
+		expect( css ).toContain(
+			'@media (min-width:768px){.wrap{position:relative !important;top:10px !important;z-index:3 !important}}',
+		)
+		// lg overrides value to sticky and top to 0px.
+		expect( css ).toContain(
+			'@media (min-width:1024px){.wrap{position:sticky !important;top:0px !important;z-index:3 !important}}',
+		)
+	} )
+
+	it( 'skips media queries when a breakpoint layer resolves to static-only', () => {
+		const attrs = {
+			style: { position: { value: 'relative' } },
+			responsive: {
+				'style.position': {
+					lg: { value: 'static' },
+				},
+			},
+		}
+		const payload = resolvePosition( attrs )!
+		const merged  = mergedBreakpointLayers( payload, registry )
+		const css     = emitPositionCss( '.wrap', payload, registry, merged )
+
+		expect( css ).toContain( '.wrap{position:relative !important}' )
+		expect( css ).not.toContain( '@media' )
+	} )
+
+	it( 'legacy sticky (bare string) round-trips to a single position:sticky rule', () => {
+		const payload = resolvePosition( { style: { position: 'sticky' } } )!
+		const merged  = mergedBreakpointLayers( payload, registry )
+		const css     = emitPositionCss( '.wrap', payload, registry, merged )
+		expect( css ).toBe( '.wrap{position:sticky !important}' )
+	} )
+} )
+
+describe( 'mergedBreakpointLayers', () => {
+	it( 'folds each breakpoint on top of the running merged layer', () => {
+		const attrs = {
+			style: {
+				position: {
+					value: 'absolute',
+					offsets: { top: { value: 5, unit: 'px' } },
+					zIndex: 1,
+				},
+			},
+			responsive: {
+				'style.position': {
+					md: { zIndex: 9 },
+					lg: { value: 'sticky' },
+				},
+			},
+		}
+
+		const payload = resolvePosition( attrs )!
+		const merged  = mergedBreakpointLayers( payload, registry )
+
+		expect( merged.md ).toEqual( {
+			value: 'absolute',
+			offsets: {
+				top:    { value: 5, unit: 'px' },
+				right:  null,
+				bottom: null,
+				left:   null,
+			},
+			zIndex: 9,
+		} )
+		expect( merged.lg ).toEqual( {
+			value: 'sticky',
+			offsets: {
+				top:    { value: 5, unit: 'px' },
+				right:  null,
+				bottom: null,
+				left:   null,
+			},
+			zIndex: 9,
+		} )
+	} )
+} )

--- a/resources/js/visual-editor/positioning/__tests__/extend-supports.test.ts
+++ b/resources/js/visual-editor/positioning/__tests__/extend-supports.test.ts
@@ -1,0 +1,121 @@
+/**
+ * `extend-supports` tests for the position feature (#641).
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.4.0
+ */
+
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock( '@wordpress/hooks', () => ( {
+	addFilter: vi.fn(),
+} ) )
+
+import { addFilter } from '@wordpress/hooks'
+
+import {
+	positionEnabled,
+	registerPositionSupportsExtension,
+} from '../extend-supports'
+
+describe( 'positionEnabled', () => {
+	it( 'returns true for supports.position === true', () => {
+		expect( positionEnabled( { position: true } ) ).toBe( true )
+	} )
+
+	it( 'returns true for an object at supports.position (Gutenberg native shape)', () => {
+		expect( positionEnabled( { position: { sticky: true } } ) ).toBe( true )
+	} )
+
+	it( 'returns false for undefined, false, or missing supports', () => {
+		expect( positionEnabled( undefined ) ).toBe( false )
+		expect( positionEnabled( {} ) ).toBe( false )
+		expect( positionEnabled( { position: false } ) ).toBe( false )
+	} )
+} )
+
+describe( 'registerPositionSupportsExtension', () => {
+	it( 'attaches the blocks.registerBlockType filter that routes style.position', () => {
+		vi.mocked( addFilter ).mockClear()
+		// Clear the sentinel so multiple test runs re-register cleanly.
+		delete ( globalThis as unknown as Record<symbol, unknown> )[
+			Symbol.for( 'artisanpack-ui.visual-editor.position-supports.registered' )
+		]
+
+		registerPositionSupportsExtension()
+
+		expect( addFilter ).toHaveBeenCalledOnce()
+		const [ hook, ns, cb ] = vi.mocked( addFilter ).mock.calls[ 0 ]
+		expect( hook ).toBe( 'blocks.registerBlockType' )
+		expect( ns ).toBe( 'artisanpack-ui/visual-editor/position-supports' )
+
+		const filtered = ( cb as ( s: unknown ) => Record<string, unknown> )( {
+			supports: { position: true },
+		} )
+		const supports = filtered.supports as Record<string, unknown>
+		expect( supports.artisanpackResponsive ).toEqual( {
+			attributes: [ 'style.position' ],
+		} )
+	} )
+
+	it( 'skips blocks that do not opt into position support', () => {
+		vi.mocked( addFilter ).mockClear()
+		delete ( globalThis as unknown as Record<symbol, unknown> )[
+			Symbol.for( 'artisanpack-ui.visual-editor.position-supports.registered' )
+		]
+
+		registerPositionSupportsExtension()
+		const cb = vi.mocked( addFilter ).mock.calls[ 0 ][ 2 ] as ( s: unknown ) => unknown
+
+		const settings = { supports: { color: {} } }
+		expect( cb( settings ) ).toBe( settings )
+	} )
+
+	it( 'preserves an explicit artisanpackResponsive: false opt-out', () => {
+		vi.mocked( addFilter ).mockClear()
+		delete ( globalThis as unknown as Record<symbol, unknown> )[
+			Symbol.for( 'artisanpack-ui.visual-editor.position-supports.registered' )
+		]
+
+		registerPositionSupportsExtension()
+		const cb = vi.mocked( addFilter ).mock.calls[ 0 ][ 2 ] as ( s: unknown ) => Record<string, unknown>
+
+		const filtered = cb( {
+			supports: {
+				position: true,
+				artisanpackResponsive: false,
+			},
+		} )
+		const supports = filtered.supports as Record<string, unknown>
+		expect( supports.artisanpackResponsive ).toBe( false )
+	} )
+
+	it( 'appends style.position to an existing attributes list without duplicating', () => {
+		vi.mocked( addFilter ).mockClear()
+		delete ( globalThis as unknown as Record<symbol, unknown> )[
+			Symbol.for( 'artisanpack-ui.visual-editor.position-supports.registered' )
+		]
+
+		registerPositionSupportsExtension()
+		const cb = vi.mocked( addFilter ).mock.calls[ 0 ][ 2 ] as ( s: unknown ) => Record<string, unknown>
+
+		const filtered = cb( {
+			supports: {
+				position: true,
+				artisanpackResponsive: { attributes: [ 'style.spacing' ] },
+			},
+		} )
+		const supports = filtered.supports as Record<string, unknown>
+		expect( supports.artisanpackResponsive ).toEqual( {
+			attributes: [ 'style.spacing', 'style.position' ],
+		} )
+
+		// Second application must not duplicate.
+		const twice = cb( filtered )
+		expect(
+			( ( twice as Record<string, unknown> ).supports as Record<string, unknown> ).artisanpackResponsive,
+		).toEqual( {
+			attributes: [ 'style.spacing', 'style.position' ],
+		} )
+	} )
+} )

--- a/resources/js/visual-editor/positioning/__tests__/resolver.test.ts
+++ b/resources/js/visual-editor/positioning/__tests__/resolver.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Resolver tests for the position feature (#641).
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.4.0
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import { BreakpointRegistry, TAILWIND_V4_DEFAULTS } from '../../responsive/registry'
+import {
+	coerceSubtree,
+	rawOffsetAt,
+	rawValueAt,
+	rawZIndexAt,
+	resolveAtBreakpoint,
+	resolvePosition,
+} from '../resolver'
+
+const registry = new BreakpointRegistry( TAILWIND_V4_DEFAULTS )
+
+describe( 'coerceSubtree', () => {
+	it( 'widens a legacy sticky string into a structured subtree', () => {
+		expect( coerceSubtree( 'sticky' ) ).toEqual( { value: 'sticky' } )
+	} )
+
+	it( 'rejects strings that are not one of the five supported values', () => {
+		expect( coerceSubtree( 'floaty' ) ).toBeNull()
+	} )
+
+	it( 'returns structured objects unchanged', () => {
+		const input = { value: 'absolute', zIndex: 5 } as const
+		expect( coerceSubtree( input ) ).toBe( input )
+	} )
+
+	it( 'returns null for null / undefined / non-string primitives', () => {
+		expect( coerceSubtree( null ) ).toBeNull()
+		expect( coerceSubtree( undefined ) ).toBeNull()
+		expect( coerceSubtree( 42 ) ).toBeNull()
+	} )
+} )
+
+describe( 'resolvePosition', () => {
+	it( 'returns null when no position data exists', () => {
+		expect( resolvePosition( {} ) ).toBeNull()
+		expect( resolvePosition( { style: {} } ) ).toBeNull()
+		expect( resolvePosition( { style: { position: null } } ) ).toBeNull()
+	} )
+
+	it( 'resolves the base layer from a structured subtree', () => {
+		const attrs = {
+			style: {
+				position: {
+					value: 'absolute',
+					offsets: { top: { value: 10, unit: 'px' } },
+					zIndex: 3,
+				},
+			},
+		}
+
+		expect( resolvePosition( attrs ) ).toEqual( {
+			base: {
+				value: 'absolute',
+				offsets: {
+					top:    { value: 10, unit: 'px' },
+					right:  null,
+					bottom: null,
+					left:   null,
+				},
+				zIndex: 3,
+			},
+			breakpoints: {},
+		} )
+	} )
+
+	it( 'preserves Gutenberg legacy sticky (bare string) at the base layer', () => {
+		const attrs = { style: { position: 'sticky' } }
+
+		expect( resolvePosition( attrs ) ).toEqual( {
+			base: {
+				value: 'sticky',
+				offsets: { top: null, right: null, bottom: null, left: null },
+				zIndex: null,
+			},
+			breakpoints: {},
+		} )
+	} )
+
+	it( 'reads per-breakpoint overrides from the responsive bag', () => {
+		const attrs = {
+			style: { position: { value: 'relative' } },
+			responsive: {
+				'style.position': {
+					md: { value: 'absolute', zIndex: 2 },
+				},
+			},
+		}
+
+		const resolved = resolvePosition( attrs )!
+		expect( resolved.base?.value ).toBe( 'relative' )
+		expect( resolved.breakpoints.md?.value ).toBe( 'absolute' )
+		expect( resolved.breakpoints.md?.zIndex ).toBe( 2 )
+	} )
+
+	it( 'drops entries under the `base` key inside the responsive bag', () => {
+		const attrs = {
+			responsive: {
+				'style.position': {
+					base: { value: 'fixed' },
+					lg:   { value: 'sticky' },
+				},
+			},
+		}
+
+		const resolved = resolvePosition( attrs )!
+		expect( resolved.breakpoints ).toEqual( {
+			lg: {
+				value: 'sticky',
+				offsets: { top: null, right: null, bottom: null, left: null },
+				zIndex: null,
+			},
+		} )
+	} )
+
+	it( 'drops offsets with a missing or invalid unit', () => {
+		const attrs = {
+			style: {
+				position: {
+					value: 'absolute',
+					offsets: {
+						top:    { value: 10 },
+						right:  { value: 5, unit: 'garbage' },
+						bottom: { value: 12, unit: 'rem' },
+					},
+				},
+			},
+		}
+
+		const resolved = resolvePosition( attrs )!
+		expect( resolved.base?.offsets.top ).toBeNull()
+		expect( resolved.base?.offsets.right ).toBeNull()
+		expect( resolved.base?.offsets.bottom ).toEqual( { value: 12, unit: 'rem' } )
+	} )
+
+	it( 'accepts the `auto` unit without a numeric value', () => {
+		const attrs = {
+			style: {
+				position: {
+					value: 'absolute',
+					offsets: { top: { unit: 'auto' } },
+				},
+			},
+		}
+
+		const resolved = resolvePosition( attrs )!
+		expect( resolved.base?.offsets.top ).toEqual( { value: 0, unit: 'auto' } )
+	} )
+} )
+
+describe( 'resolveAtBreakpoint', () => {
+	it( 'returns the base layer for the base key', () => {
+		const attrs = { style: { position: { value: 'relative' } } }
+		const layer = resolveAtBreakpoint( attrs, 'base', registry )
+		expect( layer?.value ).toBe( 'relative' )
+	} )
+
+	it( 'inherits fields from smaller breakpoints when overriding a subset', () => {
+		const attrs = {
+			style: {
+				position: {
+					value: 'absolute',
+					offsets: { top: { value: 5, unit: 'px' } },
+					zIndex: 1,
+				},
+			},
+			responsive: {
+				'style.position': {
+					md: { zIndex: 9 },
+					lg: { value: 'sticky' },
+				},
+			},
+		}
+
+		const md = resolveAtBreakpoint( attrs, 'md', registry )!
+		// Overrides zIndex, inherits value + top offset from base.
+		expect( md.value ).toBe( 'absolute' )
+		expect( md.zIndex ).toBe( 9 )
+		expect( md.offsets.top ).toEqual( { value: 5, unit: 'px' } )
+
+		const lg = resolveAtBreakpoint( attrs, 'lg', registry )!
+		// Overrides value at lg, inherits zIndex from md and top from base.
+		expect( lg.value ).toBe( 'sticky' )
+		expect( lg.zIndex ).toBe( 9 )
+		expect( lg.offsets.top ).toEqual( { value: 5, unit: 'px' } )
+	} )
+
+	it( 'returns null when nothing is defined anywhere', () => {
+		expect( resolveAtBreakpoint( {}, 'md', registry ) ).toBeNull()
+	} )
+} )
+
+describe( 'raw* readers (no inheritance)', () => {
+	const attrs = {
+		style: {
+			position: {
+				value: 'relative',
+				offsets: { top: { value: 4, unit: 'px' } },
+				zIndex: 1,
+			},
+		},
+		responsive: {
+			'style.position': {
+				md: { zIndex: 9 },
+			},
+		},
+	}
+
+	it( 'rawValueAt only returns explicit values at each breakpoint', () => {
+		expect( rawValueAt( attrs, 'base' ) ).toBe( 'relative' )
+		expect( rawValueAt( attrs, 'md' ) ).toBeNull()
+	} )
+
+	it( 'rawZIndexAt returns the explicit z-index at each breakpoint', () => {
+		expect( rawZIndexAt( attrs, 'base' ) ).toBe( 1 )
+		expect( rawZIndexAt( attrs, 'md' ) ).toBe( 9 )
+		expect( rawZIndexAt( attrs, 'lg' ) ).toBeNull()
+	} )
+
+	it( 'rawOffsetAt returns the explicit offset at each breakpoint', () => {
+		expect( rawOffsetAt( attrs, 'base', 'top' ) ).toEqual( {
+			value: 4,
+			unit:  'px',
+		} )
+		expect( rawOffsetAt( attrs, 'md', 'top' ) ).toBeNull()
+	} )
+} )

--- a/resources/js/visual-editor/positioning/emitter.ts
+++ b/resources/js/visual-editor/positioning/emitter.ts
@@ -1,0 +1,178 @@
+/**
+ * CSS emission for position attributes (#643).
+ *
+ * Takes a resolved payload (`resolvePosition` output) and produces the
+ * `<style>` string appended alongside a block's wrapper. Base layer
+ * emits an unscoped rule; per-breakpoint overrides emit inside
+ * `@media (min-width:<n>px)` blocks matching the responsive breakpoint
+ * registry.
+ *
+ * Contracts (per #643 acceptance criteria):
+ *
+ *  - `position: static` emits NOTHING — offsets and z-index are
+ *    preserved in attributes but silent while static.
+ *  - `unit: 'auto'` renders as `top: auto` etc.
+ *  - Legacy Gutenberg sticky is a no-op at the emitter level: the
+ *    resolver already widens the bare string, and static-only base
+ *    layers with no other data resolve to null upstream.
+ *  - Breakpoints inherit from smaller breakpoints; the emitter
+ *    consumes already-merged per-breakpoint layers so the media query
+ *    body carries the fully-resolved position/offset/zIndex set.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.4.0
+ */
+
+import type { BreakpointRegistry } from '../responsive/registry'
+import { BASE_KEY } from '../responsive/types'
+import { mergeLayers } from './resolver'
+import type {
+	OffsetValue,
+	ResolvedPosition,
+	ResolvedPositionLayer,
+} from './types'
+
+function formatOffset( offset: OffsetValue ): string {
+	if ( 'auto' === offset.unit ) {
+		return 'auto'
+	}
+
+	return `${ offset.value }${ offset.unit }`
+}
+
+/**
+ * Emit the declaration list for a single layer. Callers wrap this in
+ * whatever selector / media query they need. Returns an empty string
+ * when the layer effectively contributes nothing (e.g. `static` with
+ * no z-index override).
+ */
+export function layerDeclarations( layer: ResolvedPositionLayer | null ): string {
+	if ( ! layer ) {
+		return ''
+	}
+
+	const parts: string[] = []
+
+	if ( null !== layer.value && 'static' !== layer.value ) {
+		// Every declaration ships `!important`. Gutenberg's editor
+		// canvas emits an internal `.block-editor-block-list__layout
+		// .block-editor-block-list__block { position: relative }` rule
+		// (0,2,0 specificity) that outranks a single `.ve-pos-xyz`
+		// class selector (0,1,0), so an unmarked `position: sticky`
+		// silently loses at author time. Users who pick a value on the
+		// panel explicitly WANT it applied — `!important` matches that
+		// intent and is consistent with how core WordPress overrides
+		// several of its own layout defaults.
+		parts.push( `position:${ layer.value } !important` )
+
+		if ( null !== layer.offsets.top ) {
+			parts.push( `top:${ formatOffset( layer.offsets.top ) } !important` )
+		}
+		if ( null !== layer.offsets.right ) {
+			parts.push( `right:${ formatOffset( layer.offsets.right ) } !important` )
+		}
+		if ( null !== layer.offsets.bottom ) {
+			parts.push( `bottom:${ formatOffset( layer.offsets.bottom ) } !important` )
+		}
+		if ( null !== layer.offsets.left ) {
+			parts.push( `left:${ formatOffset( layer.offsets.left ) } !important` )
+		}
+
+		if ( null !== layer.zIndex ) {
+			parts.push( `z-index:${ layer.zIndex } !important` )
+		}
+	}
+
+	return parts.join( ';' )
+}
+
+/**
+ * Emit scoped CSS for a block. Uses media queries for breakpoint
+ * overrides. Returns an empty string when nothing meaningful renders.
+ *
+ * The per-breakpoint layers passed in must already be merged with the
+ * base layer — the emitter emits the full declaration list for each
+ * breakpoint so the media query body carries a self-contained set of
+ * declarations (no cascade tricks required).
+ */
+export function emitPositionCss(
+	scope: string,
+	payload: ResolvedPosition | null | undefined,
+	breakpoints: BreakpointRegistry,
+	mergedBreakpointLayers: Record<string, ResolvedPositionLayer>,
+): string {
+	const trimmedScope = scope.trim()
+
+	if ( '' === trimmedScope || ! payload ) {
+		return ''
+	}
+
+	const rules: string[] = []
+
+	const baseDecls = layerDeclarations( payload.base )
+	if ( '' !== baseDecls ) {
+		rules.push( `${ trimmedScope }{${ baseDecls }}` )
+	}
+
+	// Emit breakpoints in ascending min-width order so the cascade is
+	// natural — a later, larger breakpoint wins over an earlier one at
+	// the same specificity when both match.
+	const ordered = breakpoints
+		.all()
+		.slice()
+		.sort( ( a, b ) => a.minWidthPx - b.minWidthPx )
+
+	for ( const bp of ordered ) {
+		const key = bp.key
+		if ( BASE_KEY === key ) {
+			continue
+		}
+
+		const layer = mergedBreakpointLayers[ key ]
+		if ( ! layer ) {
+			continue
+		}
+
+		const decls = layerDeclarations( layer )
+		if ( '' === decls ) {
+			continue
+		}
+
+		rules.push(
+			`@media (min-width:${ bp.minWidthPx }px){${ trimmedScope }{${ decls }}}`,
+		)
+	}
+
+	return rules.join( '' )
+}
+
+/**
+ * Convenience: given a resolved payload, produce the merged
+ * per-breakpoint layer map the emitter consumes. Walks each defined
+ * breakpoint override and folds it on top of every smaller layer.
+ * Kept separate from the emitter so the inspector can reuse it when
+ * previewing a specific breakpoint.
+ */
+export function mergedBreakpointLayers(
+	payload: ResolvedPosition,
+	breakpoints: BreakpointRegistry,
+): Record<string, ResolvedPositionLayer> {
+	const out: Record<string, ResolvedPositionLayer> = {}
+
+	const ordered = breakpoints.keysWithBase()
+	let running: ResolvedPositionLayer | null = payload.base
+
+	for ( let i = 1; i < ordered.length; i++ ) {
+		const key     = ordered[ i ]
+		const overlay = payload.breakpoints[ key ]
+
+		if ( overlay ) {
+			running = mergeLayers( running, overlay )
+			if ( null !== running ) {
+				out[ key ] = running
+			}
+		}
+	}
+
+	return out
+}

--- a/resources/js/visual-editor/positioning/extend-supports.ts
+++ b/resources/js/visual-editor/positioning/extend-supports.ts
@@ -1,0 +1,116 @@
+/**
+ * `blocks.registerBlockType` filter — add `style.position` to
+ * `artisanpackResponsive.attributes` routing whenever a block declares
+ * `supports.position` (#641).
+ *
+ * The block-level gate is `supports.position: true` OR any truthy
+ * object at `supports.position` (Gutenberg's own sticky-enabled shape
+ * `{ sticky: true }` counts). Explicit
+ * `artisanpackResponsive: false` opt-out is preserved.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.4.0
+ */
+
+import { addFilter } from '@wordpress/hooks'
+
+import { POSITION_ATTRIBUTE_PATH } from './types'
+
+const FILTER_HOOK      = 'blocks.registerBlockType'
+const FILTER_NAMESPACE = 'artisanpack-ui/visual-editor/position-supports'
+
+const REGISTERED_KEY = Symbol.for(
+	'artisanpack-ui.visual-editor.position-supports.registered',
+)
+
+interface GlobalSentinelHost {
+	[REGISTERED_KEY]?: boolean
+}
+
+interface RoutingSupport {
+	attributes?: string[]
+	[key: string]: unknown
+}
+
+interface BlockSupports {
+	position?: boolean | Record<string, unknown>
+	artisanpackResponsive?: RoutingSupport | boolean
+	[key: string]: unknown
+}
+
+interface BlockSettingsLike {
+	supports?: BlockSupports
+	[key: string]: unknown
+}
+
+export function positionEnabled( supports: BlockSupports | undefined ): boolean {
+	if ( ! supports ) {
+		return false
+	}
+
+	const raw = supports.position
+
+	if ( true === raw ) {
+		return true
+	}
+
+	return Boolean( raw && 'object' === typeof raw )
+}
+
+function ensureRouted( supports: BlockSupports ): RoutingSupport | false {
+	const raw = supports.artisanpackResponsive
+
+	if ( false === raw ) {
+		return false
+	}
+
+	if ( raw === undefined || raw === null || true === raw ) {
+		return { attributes: [ POSITION_ATTRIBUTE_PATH ] }
+	}
+
+	if ( 'object' !== typeof raw ) {
+		return { attributes: [ POSITION_ATTRIBUTE_PATH ] }
+	}
+
+	const attributes = Array.isArray( raw.attributes ) ? raw.attributes : []
+
+	if ( attributes.includes( POSITION_ATTRIBUTE_PATH ) ) {
+		return raw
+	}
+
+	return {
+		...raw,
+		attributes: [ ...attributes, POSITION_ATTRIBUTE_PATH ],
+	}
+}
+
+function injectPositionSupports( settings: BlockSettingsLike ): BlockSettingsLike {
+	if ( ! positionEnabled( settings.supports ) ) {
+		return settings
+	}
+
+	const supports = settings.supports as BlockSupports
+
+	return {
+		...settings,
+		supports: {
+			...supports,
+			artisanpackResponsive: ensureRouted( supports ),
+		},
+	}
+}
+
+/**
+ * Register the filter at most once per page. Idempotent — safe to call
+ * from both the post-editor and site-editor entries.
+ */
+export function registerPositionSupportsExtension(): void {
+	const host = globalThis as unknown as GlobalSentinelHost
+
+	if ( host[ REGISTERED_KEY ] ) {
+		return
+	}
+
+	addFilter( FILTER_HOOK, FILTER_NAMESPACE, injectPositionSupports )
+	host[ REGISTERED_KEY ] = true
+}

--- a/resources/js/visual-editor/positioning/index.ts
+++ b/resources/js/visual-editor/positioning/index.ts
@@ -1,0 +1,45 @@
+/**
+ * Public entry point for the CSS positioning feature (#640).
+ *
+ * Mirrors the split in `box-shadows/index.ts` — the HOC + filter
+ * registrars are NOT re-exported here because they import
+ * `@wordpress/blocks`, which trips JSON-import-attribute requirements
+ * when host bundlers walk this barrel transitively.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.4.0
+ */
+
+export {
+	coerceSubtree,
+	rawOffsetAt,
+	rawValueAt,
+	rawZIndexAt,
+	resolveAtBreakpoint,
+	resolvePosition,
+} from './resolver'
+
+export {
+	emitPositionCss,
+	layerDeclarations,
+	mergedBreakpointLayers,
+} from './emitter'
+
+export type {
+	OffsetSide,
+	OffsetSubtree,
+	OffsetUnit,
+	OffsetValue,
+	PositionAttributes,
+	PositionSubtree,
+	PositionValue,
+	ResolvedPosition,
+	ResolvedPositionLayer,
+} from './types'
+
+export {
+	OFFSET_SIDES,
+	OFFSET_UNITS,
+	POSITION_ATTRIBUTE_PATH,
+	POSITION_VALUES,
+} from './types'

--- a/resources/js/visual-editor/positioning/register.ts
+++ b/resources/js/visual-editor/positioning/register.ts
@@ -1,0 +1,28 @@
+/**
+ * One-shot registrar for the CSS positioning feature (#640).
+ *
+ * Bootstraps the supports-extension filter (auto-add `style.position`
+ * to opted-in blocks' responsive routing), the BlockEdit HOC
+ * (inspector Position panel + ancestor warning) and the style-
+ * emission filters (canvas preview + save markup).
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.4.0
+ */
+
+import { registerPositionControl } from './with-position-control'
+import { registerPositionStylesFilters } from './with-position-styles'
+import { registerPositionSupportsExtension } from './extend-supports'
+
+/**
+ * Install every filter the position feature needs. Idempotent — each
+ * registrar guards itself with a sentinel so calling this from both
+ * the post-editor and site-editor entries is safe.
+ *
+ * @since 1.4.0
+ */
+export function registerPositioning(): void {
+	registerPositionSupportsExtension()
+	registerPositionControl()
+	registerPositionStylesFilters()
+}

--- a/resources/js/visual-editor/positioning/resolver.ts
+++ b/resources/js/visual-editor/positioning/resolver.ts
@@ -1,0 +1,381 @@
+/**
+ * Position attribute resolver (#641).
+ *
+ * Walks a block's attribute tree and produces a normalised payload the
+ * emitter + inspector consume. The idle layer lives at
+ * `attributes.style.position`; per-breakpoint overrides ride
+ * `attributes.responsive['style.position']` following the responsive
+ * routing pattern from #487.
+ *
+ * Backwards compatible with Gutenberg's native sticky path — a plain
+ * string at `style.position` (e.g. `'sticky'`) is widened to
+ * `{ value: 'sticky' }`. Anything else in the string form falls
+ * through unless it matches one of the five supported values.
+ *
+ * Breakpoint inheritance follows the responsive resolver's mobile-
+ * first cascade (larger breakpoints inherit from smaller ones). This
+ * mirrors `resolveResponsiveValue` for scalars but operates on the
+ * full structured layer so partial overrides at a breakpoint inherit
+ * the untouched fields from the next-smaller defined layer.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.4.0
+ */
+
+import type { BreakpointRegistry } from '../responsive/registry'
+import { BASE_KEY } from '../responsive/types'
+import {
+	POSITION_VALUES,
+	OFFSET_UNITS,
+	OFFSET_SIDES,
+	type OffsetSide,
+	type OffsetSubtree,
+	type OffsetValue,
+	type PositionAttributes,
+	type PositionSubtree,
+	type PositionValue,
+	type ResolvedPosition,
+	type ResolvedPositionLayer,
+} from './types'
+
+const POSITION_VALUE_SET = new Set<string>( POSITION_VALUES )
+const OFFSET_UNIT_SET    = new Set<string>( OFFSET_UNITS )
+
+function normalizeValue( raw: unknown ): PositionValue | null {
+	if ( 'string' !== typeof raw ) {
+		return null
+	}
+
+	const trimmed = raw.trim().toLowerCase()
+
+	return POSITION_VALUE_SET.has( trimmed ) ? ( trimmed as PositionValue ) : null
+}
+
+function normalizeOffset( raw: unknown ): OffsetValue | null {
+	if ( ! raw || 'object' !== typeof raw ) {
+		return null
+	}
+
+	const record = raw as Record<string, unknown>
+	const unit   = 'string' === typeof record.unit ? record.unit.trim().toLowerCase() : null
+
+	if ( null === unit || ! OFFSET_UNIT_SET.has( unit ) ) {
+		return null
+	}
+
+	// The `auto` unit has no numeric component. Store as `0` so
+	// consumers can unconditionally read `value` without null checks;
+	// the emitter special-cases `unit === 'auto'` to render `auto`.
+	if ( 'auto' === unit ) {
+		return { value: 0, unit: 'auto' }
+	}
+
+	const numeric = 'number' === typeof record.value
+		? record.value
+		: ( 'string' === typeof record.value && '' !== record.value.trim()
+			? Number( record.value )
+			: NaN )
+
+	if ( ! Number.isFinite( numeric ) ) {
+		return null
+	}
+
+	return { value: numeric, unit: unit as OffsetValue[ 'unit' ] }
+}
+
+function normalizeOffsets( raw: unknown ): ResolvedPositionLayer[ 'offsets' ] {
+	const out: ResolvedPositionLayer[ 'offsets' ] = {
+		top:    null,
+		right:  null,
+		bottom: null,
+		left:   null,
+	}
+
+	if ( ! raw || 'object' !== typeof raw ) {
+		return out
+	}
+
+	const record = raw as Record<string, unknown>
+
+	for ( const side of OFFSET_SIDES ) {
+		out[ side ] = normalizeOffset( record[ side ] )
+	}
+
+	return out
+}
+
+function normalizeZIndex( raw: unknown ): number | null {
+	if ( 'number' === typeof raw && Number.isFinite( raw ) ) {
+		return Math.trunc( raw )
+	}
+
+	if ( 'string' === typeof raw && '' !== raw.trim() ) {
+		const parsed = Number( raw )
+		if ( Number.isFinite( parsed ) ) {
+			return Math.trunc( parsed )
+		}
+	}
+
+	return null
+}
+
+/**
+ * Coerce the raw slot at `attributes.style.position` (or an override
+ * inside `attributes.responsive`) into a structured subtree. A plain
+ * string is treated as the `value` field alone — this is how
+ * Gutenberg's native sticky path stores its data.
+ */
+export function coerceSubtree( raw: unknown ): PositionSubtree | null {
+	if ( null === raw || undefined === raw ) {
+		return null
+	}
+
+	if ( 'string' === typeof raw ) {
+		const value = normalizeValue( raw )
+		return value ? { value } : null
+	}
+
+	if ( 'object' !== typeof raw ) {
+		return null
+	}
+
+	return raw as PositionSubtree
+}
+
+function resolveLayer( subtree: PositionSubtree | null ): ResolvedPositionLayer | null {
+	if ( ! subtree ) {
+		return null
+	}
+
+	const value   = normalizeValue( subtree.value )
+	const offsets = normalizeOffsets( subtree.offsets )
+	const zIndex  = normalizeZIndex( subtree.zIndex )
+
+	const hasAny =
+		null !== value
+		|| null !== offsets.top
+		|| null !== offsets.right
+		|| null !== offsets.bottom
+		|| null !== offsets.left
+		|| null !== zIndex
+
+	if ( ! hasAny ) {
+		return null
+	}
+
+	return {
+		value,
+		offsets,
+		zIndex,
+	}
+}
+
+/**
+ * Fold an overlay layer on top of a base layer — overlay wins per
+ * field, base fills any nulls. Exported so {@see emitter#mergedBreakpointLayers}
+ * and future callers can share the same fallthrough logic (see #640
+ * review finding on triplicated merge code).
+ */
+export function mergeLayers(
+	base: ResolvedPositionLayer | null,
+	overlay: ResolvedPositionLayer | null,
+): ResolvedPositionLayer | null {
+	if ( ! overlay ) {
+		return base
+	}
+
+	if ( ! base ) {
+		return overlay
+	}
+
+	return {
+		value: overlay.value ?? base.value,
+		offsets: {
+			top:    overlay.offsets.top    ?? base.offsets.top,
+			right:  overlay.offsets.right  ?? base.offsets.right,
+			bottom: overlay.offsets.bottom ?? base.offsets.bottom,
+			left:   overlay.offsets.left   ?? base.offsets.left,
+		},
+		zIndex: overlay.zIndex ?? base.zIndex,
+	}
+}
+
+function readIdle( attributes: PositionAttributes ): ResolvedPositionLayer | null {
+	const subtree = coerceSubtree( attributes.style?.position )
+	return resolveLayer( subtree )
+}
+
+function readBreakpointOverrides(
+	attributes: PositionAttributes,
+): Record<string, ResolvedPositionLayer> {
+	const responsive = attributes.responsive
+
+	if ( ! responsive || 'object' !== typeof responsive ) {
+		return {}
+	}
+
+	const bag = responsive[ 'style.position' ]
+
+	if ( ! bag || 'object' !== typeof bag ) {
+		return {}
+	}
+
+	const out: Record<string, ResolvedPositionLayer> = {}
+
+	for ( const [ key, raw ] of Object.entries( bag ) ) {
+		if ( '' === key || BASE_KEY === key ) {
+			continue
+		}
+
+		const subtree = coerceSubtree( raw )
+		const layer   = resolveLayer( subtree )
+
+		if ( null === layer ) {
+			continue
+		}
+
+		out[ key ] = layer
+	}
+
+	return out
+}
+
+/**
+ * Resolve a block's attribute tree into the normalised payload the
+ * emitter consumes. Returns `null` when no position configuration
+ * exists at any cascade level.
+ */
+export function resolvePosition(
+	attributes: PositionAttributes | null | undefined,
+): ResolvedPosition | null {
+	if ( ! attributes || 'object' !== typeof attributes ) {
+		return null
+	}
+
+	const base        = readIdle( attributes )
+	const breakpoints = readBreakpointOverrides( attributes )
+
+	if ( null === base && 0 === Object.keys( breakpoints ).length ) {
+		return null
+	}
+
+	return { base, breakpoints }
+}
+
+/**
+ * Resolve the effective layer for a specific breakpoint. Larger
+ * breakpoints inherit from smaller ones; missing fields at the target
+ * breakpoint fall through to the next-smaller defined layer.
+ *
+ * Pass `BASE_KEY` (or any unknown key) to get the base layer alone.
+ */
+export function resolveAtBreakpoint(
+	attributes: PositionAttributes | null | undefined,
+	breakpointKey: string,
+	registry: BreakpointRegistry,
+): ResolvedPositionLayer | null {
+	const payload = resolvePosition( attributes )
+
+	if ( null === payload ) {
+		return null
+	}
+
+	if ( BASE_KEY === breakpointKey || ! registry.has( breakpointKey ) ) {
+		return payload.base
+	}
+
+	const ordered = registry.keysWithBase()
+	const target  = ordered.indexOf( breakpointKey )
+
+	if ( -1 === target ) {
+		return payload.base
+	}
+
+	let merged: ResolvedPositionLayer | null = payload.base
+
+	for ( let i = 1; i <= target; i++ ) {
+		const key = ordered[ i ]
+		if ( key in payload.breakpoints ) {
+			merged = mergeLayers( merged, payload.breakpoints[ key ] )
+		}
+	}
+
+	return merged
+}
+
+/**
+ * Read a single offset side directly from the attributes without
+ * booting the resolver. Used by the inspector to distinguish "value
+ * inherited from a smaller breakpoint" from "value set at THIS
+ * breakpoint."
+ */
+export function rawOffsetAt(
+	attributes: PositionAttributes | null | undefined,
+	breakpointKey: string,
+	side: OffsetSide,
+): OffsetValue | null {
+	if ( ! attributes ) {
+		return null
+	}
+
+	const subtree = BASE_KEY === breakpointKey
+		? coerceSubtree( attributes.style?.position )
+		: coerceSubtree(
+			attributes.responsive?.[ 'style.position' ]?.[ breakpointKey ],
+		)
+
+	if ( ! subtree ) {
+		return null
+	}
+
+	const offsets = subtree.offsets as OffsetSubtree | null | undefined
+
+	if ( ! offsets ) {
+		return null
+	}
+
+	return normalizeOffset( offsets[ side ] )
+}
+
+/**
+ * Read the raw `value` field at a specific breakpoint without
+ * inheritance. Returns `null` when the block doesn't set position at
+ * that breakpoint (or when only the offsets/zIndex are set).
+ */
+export function rawValueAt(
+	attributes: PositionAttributes | null | undefined,
+	breakpointKey: string,
+): PositionValue | null {
+	if ( ! attributes ) {
+		return null
+	}
+
+	const subtree = BASE_KEY === breakpointKey
+		? coerceSubtree( attributes.style?.position )
+		: coerceSubtree(
+			attributes.responsive?.[ 'style.position' ]?.[ breakpointKey ],
+		)
+
+	return subtree ? normalizeValue( subtree.value ) : null
+}
+
+/**
+ * Read the raw `zIndex` field at a specific breakpoint without
+ * inheritance.
+ */
+export function rawZIndexAt(
+	attributes: PositionAttributes | null | undefined,
+	breakpointKey: string,
+): number | null {
+	if ( ! attributes ) {
+		return null
+	}
+
+	const subtree = BASE_KEY === breakpointKey
+		? coerceSubtree( attributes.style?.position )
+		: coerceSubtree(
+			attributes.responsive?.[ 'style.position' ]?.[ breakpointKey ],
+		)
+
+	return subtree ? normalizeZIndex( subtree.zIndex ) : null
+}

--- a/resources/js/visual-editor/positioning/types.ts
+++ b/resources/js/visual-editor/positioning/types.ts
@@ -1,0 +1,110 @@
+/**
+ * Shared types for CSS positioning support (#640).
+ *
+ * Extends Gutenberg's `supports.position` — the native shape stores
+ * `attributes.style.position` as a plain string (`'sticky'`). We
+ * layer a structured object on top of the same attribute path so the
+ * resolver can read either shape (see `resolver.ts`).
+ *
+ * Per-breakpoint overrides ride `attributes.responsive['style.position']`
+ * following the routing pattern established in #487 and mirrored in
+ * `box-shadows/types.ts` from #607.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.4.0
+ */
+
+export type PositionValue =
+	| 'static'
+	| 'relative'
+	| 'absolute'
+	| 'fixed'
+	| 'sticky'
+
+export type OffsetUnit = 'px' | '%' | 'rem' | 'em' | 'vh' | 'vw' | 'auto'
+
+export type OffsetSide = 'top' | 'right' | 'bottom' | 'left'
+
+export interface OffsetValue {
+	value: number
+	unit: OffsetUnit
+}
+
+export interface OffsetSubtree {
+	top?: OffsetValue | null
+	right?: OffsetValue | null
+	bottom?: OffsetValue | null
+	left?: OffsetValue | null
+}
+
+/**
+ * Structured position payload written by the inspector. When
+ * `attributes.style.position` is a plain string (legacy Gutenberg
+ * sticky), the resolver widens it to `{ value: 'sticky' }`.
+ */
+export interface PositionSubtree {
+	value?: PositionValue | null
+	offsets?: OffsetSubtree | null
+	zIndex?: number | null
+	[key: string]: unknown
+}
+
+/**
+ * Fully resolved layer at a given cascade level (base or breakpoint).
+ * Absent fields collapse to `null` so the emitter can skip them.
+ */
+export interface ResolvedPositionLayer {
+	value: PositionValue | null
+	offsets: {
+		top: OffsetValue | null
+		right: OffsetValue | null
+		bottom: OffsetValue | null
+		left: OffsetValue | null
+	}
+	zIndex: number | null
+}
+
+export interface ResolvedPosition {
+	base: ResolvedPositionLayer | null
+	breakpoints: Record<string, ResolvedPositionLayer>
+}
+
+/**
+ * The subset of block attributes the resolver reads. Blocks carry
+ * plenty of other attributes; only the slots we touch are typed.
+ */
+export interface PositionAttributes {
+	// The tree is defensive — the resolver normalizes anything.
+	// Slots we care about are typed loosely so test-time inline literals
+	// (whose `unit: 'px'` widens to `string`) round-trip without casts.
+	style?: { position?: unknown } | null
+	responsive?: Record<string, Record<string, unknown>> | null
+	[key: string]: unknown
+}
+
+export const POSITION_VALUES: readonly PositionValue[] = [
+	'static',
+	'relative',
+	'absolute',
+	'fixed',
+	'sticky',
+]
+
+export const OFFSET_UNITS: readonly OffsetUnit[] = [
+	'px',
+	'%',
+	'rem',
+	'em',
+	'vh',
+	'vw',
+	'auto',
+]
+
+export const OFFSET_SIDES: readonly OffsetSide[] = [
+	'top',
+	'right',
+	'bottom',
+	'left',
+]
+
+export const POSITION_ATTRIBUTE_PATH = 'style.position'

--- a/resources/js/visual-editor/positioning/with-position-control.tsx
+++ b/resources/js/visual-editor/positioning/with-position-control.tsx
@@ -1,0 +1,596 @@
+/**
+ * `editor.BlockEdit` HOC — Position inspector panel (#642, #644).
+ *
+ * Renders a Position panel in the "styles" InspectorControls group for
+ * every block whose `supports.position` is truthy. The panel houses:
+ *
+ *  - A position dropdown (`static / relative / absolute / fixed / sticky`).
+ *  - When non-`static`: number+unit UnitControls for top/right/bottom/
+ *    left and an integer input for z-index.
+ *  - A breakpoint switcher — clicking a breakpoint tab flips the
+ *    editor's active-breakpoint store so ALL responsive controls
+ *    (spacing, typography, etc.) follow along, mirroring the pattern
+ *    used elsewhere in the package.
+ *  - An "Inherited from smaller breakpoint" affordance when the
+ *    currently-viewed breakpoint doesn't override the field.
+ *  - #644 warning notice when the effective position at the active
+ *    breakpoint is `absolute` and no ancestor block sets a non-static
+ *    position.
+ *
+ * Writes go to `attributes.style.position` (base) or
+ * `attributes.responsive['style.position'][<key>]` (per-breakpoint).
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.4.0
+ */
+
+import {
+	BaseControl,
+	Button,
+	Notice,
+	SelectControl,
+	__experimentalNumberControl as NumberControl,
+	__experimentalToolsPanel as ToolsPanel,
+	__experimentalToolsPanelItem as ToolsPanelItem,
+	__experimentalUnitControl as UnitControl,
+} from '@wordpress/components'
+import { createHigherOrderComponent } from '@wordpress/compose'
+import { getBlockType } from '@wordpress/blocks'
+import { InspectorControls } from '@wordpress/block-editor'
+import { useSelect } from '@wordpress/data'
+import { addFilter } from '@wordpress/hooks'
+import { __ } from '@wordpress/i18n'
+import { useCallback, useMemo, useSyncExternalStore } from 'react'
+import type { ComponentType } from 'react'
+
+import {
+	getActiveBreakpoint,
+	setActiveBreakpoint,
+	subscribeActiveBreakpoint,
+} from '../responsive/active-breakpoint'
+import { BreakpointRegistry, TAILWIND_V4_DEFAULTS } from '../responsive/registry'
+import { BASE_KEY } from '../responsive/types'
+import { positionEnabled } from './extend-supports'
+import {
+	coerceSubtree,
+	rawOffsetAt,
+	rawValueAt,
+	rawZIndexAt,
+	resolveAtBreakpoint,
+} from './resolver'
+import {
+	OFFSET_SIDES,
+	OFFSET_UNITS,
+	POSITION_ATTRIBUTE_PATH,
+	POSITION_VALUES,
+	type OffsetSide,
+	type OffsetValue,
+	type PositionAttributes,
+	type PositionSubtree,
+	type PositionValue,
+} from './types'
+
+const FILTER_HOOK      = 'editor.BlockEdit'
+const FILTER_NAMESPACE = 'artisanpack-ui/visual-editor/position-control'
+
+const REGISTERED_KEY = Symbol.for(
+	'artisanpack-ui.visual-editor.position-control.registered',
+)
+
+interface GlobalSentinelHost {
+	[REGISTERED_KEY]?: boolean
+}
+
+interface BlockEditProps {
+	name: string
+	clientId?: string
+	attributes: PositionAttributes & Record<string, unknown>
+	setAttributes: ( updates: Record<string, unknown> ) => void
+	[key: string]: unknown
+}
+
+const breakpoints = new BreakpointRegistry( TAILWIND_V4_DEFAULTS )
+
+function blockSupportsPosition( name: string ): boolean {
+	const blockType = getBlockType( name )
+	if ( ! blockType ) {
+		return false
+	}
+	return positionEnabled( blockType.supports as Record<string, unknown> | undefined )
+}
+
+function readBaseSubtree( attributes: PositionAttributes ): PositionSubtree {
+	const raw = coerceSubtree( attributes.style?.position )
+	return raw ?? {}
+}
+
+function readBreakpointSubtree(
+	attributes: PositionAttributes,
+	key: string,
+): PositionSubtree {
+	if ( BASE_KEY === key ) {
+		return readBaseSubtree( attributes )
+	}
+
+	const raw = coerceSubtree( attributes.responsive?.[ POSITION_ATTRIBUTE_PATH ]?.[ key ] )
+	return raw ?? {}
+}
+
+/**
+ * Compose a `setAttributes` payload that writes a patched subtree to
+ * the base slot (`style.position`) or the responsive slot (
+ * `responsive['style.position'][key]`) depending on the active
+ * breakpoint. Empty subtrees are collapsed to `null` (base) or the key
+ * is removed (responsive) so downstream consumers don't have to
+ * distinguish "empty object" from "no data".
+ */
+function writeSubtree(
+	attributes: PositionAttributes,
+	setAttributes: ( updates: Record<string, unknown> ) => void,
+	breakpointKey: string,
+	next: PositionSubtree,
+): void {
+	const cleaned = collapseSubtree( next )
+
+	if ( BASE_KEY === breakpointKey ) {
+		const style = ( attributes.style && 'object' === typeof attributes.style )
+			? ( attributes.style as Record<string, unknown> )
+			: {}
+
+		if ( null === cleaned ) {
+			const { position: _drop, ...rest } = style
+			setAttributes( { style: rest } )
+			return
+		}
+
+		// Preserve any private scope-id already on the current subtree
+		// (see `with-position-styles.tsx` for `_positionScopeId`).
+		const existing = style.position && 'object' === typeof style.position
+			? ( style.position as Record<string, unknown> )
+			: {}
+
+		const preserved: Record<string, unknown> = {}
+		if ( 'string' === typeof existing._positionScopeId ) {
+			preserved._positionScopeId = existing._positionScopeId
+		}
+
+		setAttributes( {
+			style: {
+				...style,
+				position: { ...preserved, ...cleaned },
+			},
+		} )
+		return
+	}
+
+	const responsive = ( attributes.responsive && 'object' === typeof attributes.responsive )
+		? ( attributes.responsive as Record<string, Record<string, unknown>> )
+		: {}
+
+	const bag = ( responsive[ POSITION_ATTRIBUTE_PATH ] && 'object' === typeof responsive[ POSITION_ATTRIBUTE_PATH ] )
+		? { ...responsive[ POSITION_ATTRIBUTE_PATH ] }
+		: {}
+
+	if ( null === cleaned ) {
+		delete bag[ breakpointKey ]
+	} else {
+		bag[ breakpointKey ] = cleaned
+	}
+
+	const nextResponsive: Record<string, unknown> = { ...responsive }
+
+	if ( 0 === Object.keys( bag ).length ) {
+		delete nextResponsive[ POSITION_ATTRIBUTE_PATH ]
+	} else {
+		nextResponsive[ POSITION_ATTRIBUTE_PATH ] = bag
+	}
+
+	setAttributes( { responsive: nextResponsive } )
+}
+
+/**
+ * Strip null/undefined leaves and collapse empty objects. Returns
+ * `null` when nothing meaningful remains.
+ */
+function collapseSubtree( subtree: PositionSubtree ): PositionSubtree | null {
+	const out: PositionSubtree = {}
+
+	if ( null !== subtree.value && undefined !== subtree.value ) {
+		out.value = subtree.value
+	}
+
+	if ( subtree.offsets && 'object' === typeof subtree.offsets ) {
+		const offsets: Record<string, OffsetValue> = {}
+		for ( const side of OFFSET_SIDES ) {
+			const val = subtree.offsets[ side ]
+			if ( val && 'object' === typeof val ) {
+				offsets[ side ] = val
+			}
+		}
+		if ( 0 < Object.keys( offsets ).length ) {
+			out.offsets = offsets
+		}
+	}
+
+	if ( null !== subtree.zIndex && undefined !== subtree.zIndex ) {
+		out.zIndex = subtree.zIndex
+	}
+
+	return 0 === Object.keys( out ).length ? null : out
+}
+
+/**
+ * Compute whether any ancestor block sets a non-static position (#644).
+ * Reads the effective position at the currently-viewed breakpoint so
+ * the warning stays in sync with the switcher.
+ */
+function useHasPositionedAncestor(
+	clientId: string | undefined,
+	activeBreakpoint: string,
+): boolean {
+	return useSelect(
+		( select ) => {
+			if ( ! clientId ) {
+				return false
+			}
+
+			const store = select( 'core/block-editor' ) as {
+				getBlockParents: ( id: string ) => string[]
+				getBlockAttributes: ( id: string ) => Record<string, unknown> | undefined
+			}
+
+			const parents = store.getBlockParents( clientId )
+
+			for ( const parentId of parents ) {
+				const attrs = store.getBlockAttributes( parentId )
+				if ( ! attrs ) {
+					continue
+				}
+
+				const layer = resolveAtBreakpoint(
+					attrs as PositionAttributes,
+					activeBreakpoint,
+					breakpoints,
+				)
+
+				if ( layer && null !== layer.value && 'static' !== layer.value ) {
+					return true
+				}
+			}
+
+			return false
+		},
+		[ clientId, activeBreakpoint ],
+	)
+}
+
+function parseUnitControl( raw: string | undefined ): OffsetValue | null {
+	if ( undefined === raw || null === raw ) {
+		return null
+	}
+	const trimmed = raw.trim()
+	if ( '' === trimmed ) {
+		return null
+	}
+	if ( 'auto' === trimmed.toLowerCase() ) {
+		return { value: 0, unit: 'auto' }
+	}
+
+	const match = trimmed.match( /^(-?\d+(?:\.\d+)?)\s*([a-z%]+)$/i )
+	if ( ! match ) {
+		return null
+	}
+
+	const unit = match[ 2 ].toLowerCase()
+	if ( ! ( OFFSET_UNITS as readonly string[] ).includes( unit ) ) {
+		return null
+	}
+
+	const numeric = Number( match[ 1 ] )
+	if ( ! Number.isFinite( numeric ) ) {
+		return null
+	}
+
+	return { value: numeric, unit: unit as OffsetValue[ 'unit' ] }
+}
+
+function formatUnitControl( offset: OffsetValue | null ): string {
+	if ( ! offset ) {
+		return ''
+	}
+	if ( 'auto' === offset.unit ) {
+		return 'auto'
+	}
+	return `${ offset.value }${ offset.unit }`
+}
+
+export const withPositionControl = createHigherOrderComponent(
+	( BlockEdit: ComponentType<BlockEditProps> ) => {
+		function PositionBlockEdit( props: BlockEditProps ): JSX.Element {
+			const { name, attributes, setAttributes, clientId } = props
+
+			const enabled = useMemo( () => blockSupportsPosition( name ), [ name ] )
+
+			const activeBreakpoint = useSyncExternalStore(
+				subscribeActiveBreakpoint,
+				getActiveBreakpoint,
+				getActiveBreakpoint,
+			)
+
+			const effectiveLayer = useMemo(
+				() => resolveAtBreakpoint( attributes, activeBreakpoint, breakpoints ),
+				[ attributes, activeBreakpoint ],
+			)
+
+			const rawValue = useMemo(
+				() => rawValueAt( attributes, activeBreakpoint ),
+				[ attributes, activeBreakpoint ],
+			)
+
+			const rawZ = useMemo(
+				() => rawZIndexAt( attributes, activeBreakpoint ),
+				[ attributes, activeBreakpoint ],
+			)
+
+			const rawOffsets = useMemo(
+				() => ( {
+					top:    rawOffsetAt( attributes, activeBreakpoint, 'top' ),
+					right:  rawOffsetAt( attributes, activeBreakpoint, 'right' ),
+					bottom: rawOffsetAt( attributes, activeBreakpoint, 'bottom' ),
+					left:   rawOffsetAt( attributes, activeBreakpoint, 'left' ),
+				} ),
+				[ attributes, activeBreakpoint ],
+			)
+
+			const hasPositionedAncestor = useHasPositionedAncestor(
+				clientId,
+				activeBreakpoint,
+			)
+
+			const writePatch = useCallback(
+				( patch: Partial<PositionSubtree> ) => {
+					const current = readBreakpointSubtree( attributes, activeBreakpoint )
+					const next: PositionSubtree = { ...current }
+
+					if ( 'value' in patch ) {
+						if ( null === patch.value ) {
+							delete next.value
+						} else {
+							next.value = patch.value
+						}
+					}
+
+					if ( 'zIndex' in patch ) {
+						if ( null === patch.zIndex || undefined === patch.zIndex ) {
+							delete next.zIndex
+						} else {
+							next.zIndex = patch.zIndex
+						}
+					}
+
+					if ( 'offsets' in patch && patch.offsets ) {
+						const nextOffsets = { ...( next.offsets ?? {} ) }
+						for ( const side of OFFSET_SIDES ) {
+							if ( side in patch.offsets ) {
+								const nextVal = patch.offsets[ side ]
+								if ( null === nextVal || undefined === nextVal ) {
+									delete nextOffsets[ side ]
+								} else {
+									nextOffsets[ side ] = nextVal
+								}
+							}
+						}
+						if ( 0 === Object.keys( nextOffsets ).length ) {
+							delete next.offsets
+						} else {
+							next.offsets = nextOffsets
+						}
+					}
+
+					writeSubtree( attributes, setAttributes, activeBreakpoint, next )
+				},
+				[ attributes, setAttributes, activeBreakpoint ],
+			)
+
+			const resetPanel = useCallback( () => {
+				writeSubtree( attributes, setAttributes, activeBreakpoint, {} )
+			}, [ attributes, setAttributes, activeBreakpoint ] )
+
+			if ( ! enabled ) {
+				return <BlockEdit { ...props } />
+			}
+
+			const effectiveValue = effectiveLayer?.value ?? 'static'
+			const showFields     = 'static' !== effectiveValue && null !== effectiveValue
+
+			// #644: warning is shown when the RESOLVED position at this
+			// breakpoint is absolute and no ancestor is positioned.
+			const showAncestorWarning =
+				'absolute' === effectiveValue && ! hasPositionedAncestor
+
+			const positionOptions = [
+				{ label: __( 'Static', 'artisanpack-visual-editor' ),   value: 'static' },
+				{ label: __( 'Relative', 'artisanpack-visual-editor' ), value: 'relative' },
+				{ label: __( 'Absolute', 'artisanpack-visual-editor' ), value: 'absolute' },
+				{ label: __( 'Fixed', 'artisanpack-visual-editor' ),    value: 'fixed' },
+				{ label: __( 'Sticky', 'artisanpack-visual-editor' ),   value: 'sticky' },
+			]
+
+			const breakpointTabs = [ BASE_KEY, ...breakpoints.prefixes() ]
+
+			const hasAnyValue =
+				null !== rawValue
+				|| null !== rawZ
+				|| null !== rawOffsets.top
+				|| null !== rawOffsets.right
+				|| null !== rawOffsets.bottom
+				|| null !== rawOffsets.left
+
+			return (
+				<>
+					<BlockEdit { ...props } />
+					<InspectorControls group="styles">
+						<ToolsPanel
+							label={ __( 'Position', 'artisanpack-visual-editor' ) }
+							resetAll={ resetPanel }
+							panelId={ clientId }
+						>
+							<ToolsPanelItem
+								panelId={ clientId }
+								hasValue={ () => hasAnyValue }
+								label={ __( 'Position', 'artisanpack-visual-editor' ) }
+								onDeselect={ resetPanel }
+								isShownByDefault
+							>
+								<BaseControl __nextHasNoMarginBottom>
+									<div
+										className="ap-position__breakpoint-tabs"
+										role="tablist"
+										aria-label={ __( 'Breakpoint', 'artisanpack-visual-editor' ) }
+										style={ { display: 'flex', gap: 4, marginBottom: 12, flexWrap: 'wrap' } }
+									>
+										{ breakpointTabs.map( ( key ) => {
+											const isActive = key === activeBreakpoint
+											const label    = BASE_KEY === key
+												? __( 'Base', 'artisanpack-visual-editor' )
+												: breakpoints.label( key )
+											return (
+												<Button
+													key={ key }
+													role="tab"
+													aria-selected={ isActive }
+													variant={ isActive ? 'primary' : 'secondary' }
+													size="small"
+													onClick={ () => setActiveBreakpoint( key ) }
+												>
+													{ label }
+												</Button>
+											)
+										} ) }
+									</div>
+
+									<SelectControl
+										label={ __( 'Position', 'artisanpack-visual-editor' ) }
+										value={ effectiveValue }
+										options={ positionOptions }
+										help={ null === rawValue && BASE_KEY !== activeBreakpoint
+											? __(
+												'Inherited from a smaller breakpoint. Change to override.',
+												'artisanpack-visual-editor',
+											)
+											: undefined }
+										onChange={ ( next: string ) => {
+											if ( ! POSITION_VALUES.includes( next as PositionValue ) ) {
+												return
+											}
+											writePatch( { value: next as PositionValue } )
+										} }
+										__nextHasNoMarginBottom
+										__next40pxDefaultSize
+									/>
+
+									{ showAncestorWarning && (
+										<Notice
+											status="warning"
+											isDismissible={ false }
+											className="ap-position__ancestor-warning"
+										>
+											{ __(
+												'This block is set to position: absolute but none of its ancestor blocks is positioned. It will position relative to the nearest positioned ancestor — often the page.',
+												'artisanpack-visual-editor',
+											) }
+										</Notice>
+									) }
+
+									{ showFields && (
+										<>
+											<div style={ { display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8, marginTop: 12 } }>
+												{ OFFSET_SIDES.map( ( side ) => {
+													const raw       = rawOffsets[ side ]
+													const effective = effectiveLayer?.offsets[ side ] ?? null
+													const inherited = null === raw && BASE_KEY !== activeBreakpoint && null !== effective
+
+													return (
+														<UnitControl
+															key={ side }
+															label={ sideLabel( side ) }
+															value={ formatUnitControl( effective ) }
+															units={ OFFSET_UNITS.map( ( unit ) => ( { value: unit, label: unit } ) ) }
+															help={ inherited
+																? __( 'Inherited', 'artisanpack-visual-editor' )
+																: undefined }
+															onChange={ ( next: string | undefined ) => {
+																const parsed = parseUnitControl( next )
+																writePatch( { offsets: { [ side ]: parsed } } )
+															} }
+															__next40pxDefaultSize
+														/>
+													)
+												} ) }
+											</div>
+
+											<div style={ { marginTop: 12 } }>
+												<NumberControl
+													label={ __( 'z-index', 'artisanpack-visual-editor' ) }
+													value={ effectiveLayer?.zIndex ?? '' }
+													onChange={ ( next: string | number | undefined ) => {
+														if ( undefined === next || '' === next ) {
+															writePatch( { zIndex: null } )
+															return
+														}
+														const parsed = Number( next )
+														if ( Number.isFinite( parsed ) ) {
+															writePatch( { zIndex: Math.trunc( parsed ) } )
+														}
+													} }
+													help={ null === rawZ && BASE_KEY !== activeBreakpoint && null !== effectiveLayer?.zIndex
+														? __( 'Inherited', 'artisanpack-visual-editor' )
+														: undefined }
+													__next40pxDefaultSize
+												/>
+											</div>
+										</>
+									) }
+								</BaseControl>
+							</ToolsPanelItem>
+						</ToolsPanel>
+					</InspectorControls>
+				</>
+			)
+		}
+
+		PositionBlockEdit.displayName = 'PositionBlockEdit'
+
+		return PositionBlockEdit
+	},
+	'withPositionControl',
+)
+
+function sideLabel( side: OffsetSide ): string {
+	switch ( side ) {
+		case 'top':
+			return __( 'Top', 'artisanpack-visual-editor' )
+		case 'right':
+			return __( 'Right', 'artisanpack-visual-editor' )
+		case 'bottom':
+			return __( 'Bottom', 'artisanpack-visual-editor' )
+		case 'left':
+			return __( 'Left', 'artisanpack-visual-editor' )
+	}
+}
+
+/**
+ * Register the BlockEdit filter at most once per page. Idempotent —
+ * safe to call from both the post-editor and site-editor bootstrap
+ * paths.
+ */
+export function registerPositionControl(): void {
+	const host = globalThis as unknown as GlobalSentinelHost
+
+	if ( host[ REGISTERED_KEY ] ) {
+		return
+	}
+
+	addFilter( FILTER_HOOK, FILTER_NAMESPACE, withPositionControl )
+	host[ REGISTERED_KEY ] = true
+}

--- a/resources/js/visual-editor/positioning/with-position-styles.tsx
+++ b/resources/js/visual-editor/positioning/with-position-styles.tsx
@@ -1,0 +1,478 @@
+/**
+ * Position CSS emission — editor canvas + saved markup (#643).
+ *
+ * Mirrors `with-box-shadow-styles.tsx` from #607: a mintable scope id
+ * (`_positionScopeId`) lives on the position subtree; the wrapper
+ * carries a `ve-pos-<id>` class; and a `<style>` element scoped by
+ * that class carries the emitted CSS. Both the canvas
+ * (`editor.BlockListBlock`) and the save path
+ * (`blocks.getSaveContent.extraProps` + `blocks.getSaveElement`)
+ * apply the same emission.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.4.0
+ */
+
+import { getBlockType } from '@wordpress/blocks'
+import { createHigherOrderComponent } from '@wordpress/compose'
+import { addFilter } from '@wordpress/hooks'
+import { Fragment, createElement, useEffect, useMemo, useRef } from 'react'
+import type { ComponentType, ReactNode } from 'react'
+
+import { BreakpointRegistry, TAILWIND_V4_DEFAULTS } from '../responsive/registry'
+import { emitPositionCss, mergedBreakpointLayers } from './emitter'
+import { positionEnabled } from './extend-supports'
+import { resolvePosition } from './resolver'
+import type { PositionAttributes, PositionSubtree } from './types'
+
+const BLOCK_FILTER_HOOK = 'editor.BlockListBlock'
+const SAVE_PROPS_HOOK   = 'blocks.getSaveContent.extraProps'
+const SAVE_ELEMENT_HOOK = 'blocks.getSaveElement'
+
+const FILTER_NAMESPACE = 'artisanpack-ui/visual-editor/position-styles'
+
+const REGISTERED_KEY = Symbol.for(
+	'artisanpack-ui.visual-editor.position-styles.registered',
+)
+
+interface GlobalSentinelHost {
+	[REGISTERED_KEY]?: boolean
+}
+
+interface BlockListBlockProps {
+	name: string
+	clientId: string
+	attributes: PositionAttributes & Record<string, unknown>
+	setAttributes?: ( updates: Record<string, unknown> ) => void
+	wrapperProps?: Record<string, unknown>
+	[key: string]: unknown
+}
+
+interface BlockSettingsLike {
+	supports?: Record<string, unknown>
+	[key: string]: unknown
+}
+
+interface PositionSubtreeWithScope extends PositionSubtree {
+	_positionScopeId?: string
+}
+
+const SCOPE_ID_KEY     = '_positionScopeId'
+const SCOPE_ID_PATTERN = /^[a-z0-9][a-z0-9_-]{0,63}$/i
+
+const breakpoints = new BreakpointRegistry( TAILWIND_V4_DEFAULTS )
+
+function blockSupportsPosition( name: string ): boolean {
+	const blockType = getBlockType( name )
+	if ( ! blockType ) {
+		return false
+	}
+
+	return positionEnabled( blockType.supports as Record<string, unknown> | undefined )
+}
+
+function scopeIdToClass( scopeId: string ): string {
+	return `ve-pos-${ scopeId }`
+}
+
+function readScopeId( attributes: PositionAttributes | undefined ): string | null {
+	const raw = attributes?.style?.position
+	if ( ! raw || 'object' !== typeof raw ) {
+		return null
+	}
+
+	const scoped = raw as PositionSubtreeWithScope
+	const value  = scoped[ SCOPE_ID_KEY ]
+
+	if ( 'string' !== typeof value ) {
+		return null
+	}
+
+	const trimmed = value.trim()
+	return SCOPE_ID_PATTERN.test( trimmed ) ? trimmed : null
+}
+
+function hasAuthoredAnyPosition(
+	attributes: PositionAttributes | undefined,
+): boolean {
+	return null !== resolvePosition( attributes )
+}
+
+function mintScopeId(): string {
+	return Math.random().toString( 36 ).slice( 2, 11 )
+}
+
+const scopeIdOwners = new Map<string, string>()
+
+function claimScopeId( scopeId: string, clientId: string ): boolean {
+	const owner = scopeIdOwners.get( scopeId )
+	if ( ! owner ) {
+		scopeIdOwners.set( scopeId, clientId )
+		return true
+	}
+	return owner === clientId
+}
+
+function releaseScopeId( scopeId: string, clientId: string ): void {
+	if ( scopeIdOwners.get( scopeId ) === clientId ) {
+		scopeIdOwners.delete( scopeId )
+	}
+}
+
+function writeScopeId(
+	attributes: PositionAttributes,
+	setAttributes: ( updates: Record<string, unknown> ) => void,
+	nextId: string,
+): void {
+	const style = ( attributes.style && 'object' === typeof attributes.style )
+		? ( attributes.style as Record<string, unknown> )
+		: {}
+	const rawPosition = style.position
+	// `position` may be a bare string (legacy Gutenberg sticky) — widen
+	// it to a structured subtree so we have a slot to write the scope
+	// id onto without clobbering the value.
+	const positionObj =
+		rawPosition && 'object' === typeof rawPosition
+			? ( rawPosition as Record<string, unknown> )
+			: ( 'string' === typeof rawPosition
+				? { value: rawPosition }
+				: {} )
+
+	setAttributes( {
+		style: {
+			...style,
+			position: {
+				...positionObj,
+				[ SCOPE_ID_KEY ]: nextId,
+			},
+		},
+	} )
+}
+
+function emitCssForBlock(
+	scopeId: string,
+	attributes: PositionAttributes,
+): string {
+	const payload = resolvePosition( attributes )
+	if ( ! payload ) {
+		return ''
+	}
+
+	const merged = mergedBreakpointLayers( payload, breakpoints )
+
+	return emitPositionCss(
+		`.${ scopeIdToClass( scopeId ) }`,
+		payload,
+		breakpoints,
+		merged,
+	)
+}
+
+export const withPositionStyles = createHigherOrderComponent(
+	( BlockListBlock: ComponentType<BlockListBlockProps> ) => {
+		function PositionStyledBlock( props: BlockListBlockProps ): JSX.Element {
+			const { name, clientId, attributes, setAttributes, wrapperProps } = props
+
+			const supported = blockSupportsPosition( name )
+
+			const scopeId = useMemo( () => readScopeId( attributes ), [ attributes ] )
+
+			const hasOverrides = useMemo(
+				() => hasAuthoredAnyPosition( attributes ),
+				[ attributes ],
+			)
+
+			const persistedRef = useRef( scopeId )
+			useEffect( () => {
+				persistedRef.current = scopeId
+			}, [ scopeId ] )
+
+			useEffect( () => {
+				if ( ! supported || ! setAttributes ) {
+					return
+				}
+
+				const needsMint    = ! scopeId && hasOverrides
+				const hasCollision = scopeId !== null && ! claimScopeId( scopeId, clientId )
+
+				if ( ! needsMint && ! hasCollision ) {
+					return
+				}
+
+				const nextId = mintScopeId()
+				claimScopeId( nextId, clientId )
+				writeScopeId( attributes, setAttributes, nextId )
+			}, [ supported, scopeId, hasOverrides, attributes, setAttributes, clientId ] )
+
+			useEffect( () => {
+				if ( ! scopeId ) {
+					return
+				}
+				return () => releaseScopeId( scopeId, clientId )
+			}, [ scopeId, clientId ] )
+
+			const effectiveScopeId = scopeId ?? persistedRef.current
+
+			const css = useMemo( () => {
+				if ( ! supported || ! effectiveScopeId ) {
+					return ''
+				}
+				return emitCssForBlock( effectiveScopeId, attributes )
+			}, [ supported, effectiveScopeId, attributes ] )
+
+			const effectiveWrapperProps: Record<string, unknown> = useMemo( () => {
+				if ( ! supported || ! effectiveScopeId ) {
+					return wrapperProps ?? {}
+				}
+
+				const existingClass = ( wrapperProps?.className as string | undefined ) ?? ''
+				const scopeClass    = scopeIdToClass( effectiveScopeId )
+
+				if ( existingClass.split( /\s+/ ).includes( scopeClass ) ) {
+					return wrapperProps ?? {}
+				}
+
+				return {
+					...( wrapperProps ?? {} ),
+					className: existingClass
+						? `${ existingClass } ${ scopeClass }`
+						: scopeClass,
+					// Diagnostic hook — surfaces the scope id in DevTools
+					// so a QA pass can spot the presence/absence at a
+					// glance without opening the block's props panel.
+					'data-ap-position-scope': effectiveScopeId,
+				}
+			}, [ supported, wrapperProps, effectiveScopeId ] )
+
+			if ( ! supported ) {
+				return <BlockListBlock { ...props } />
+			}
+
+			const wrapped = (
+				<BlockListBlock
+					{ ...props }
+					wrapperProps={ effectiveWrapperProps }
+				/>
+			)
+
+			if ( '' === css ) {
+				return wrapped
+			}
+
+			return (
+				<Fragment>
+					<style data-ap-position-scope={ effectiveScopeId }>{ css }</style>
+					{ wrapped }
+				</Fragment>
+			)
+		}
+
+		PositionStyledBlock.displayName = 'PositionStyledBlock'
+
+		return PositionStyledBlock
+	},
+	'withPositionStyles',
+)
+
+function blockSupportsConfigOnSettings( blockType: BlockSettingsLike | undefined ): boolean {
+	return positionEnabled( blockType?.supports as Record<string, unknown> | undefined )
+}
+
+function addSaveProps(
+	extraProps: Record<string, unknown>,
+	blockType: BlockSettingsLike,
+	attributes: PositionAttributes & Record<string, unknown>,
+): Record<string, unknown> {
+	if ( ! blockSupportsConfigOnSettings( blockType ) ) {
+		return extraProps
+	}
+
+	const scopeId = readScopeId( attributes )
+	if ( ! scopeId || ! hasAuthoredAnyPosition( attributes ) ) {
+		return extraProps
+	}
+
+	const css = emitCssForBlock( scopeId, attributes )
+	if ( '' === css ) {
+		return extraProps
+	}
+
+	const existingClass = ( extraProps.className as string | undefined ) ?? ''
+	const scopeClass    = scopeIdToClass( scopeId )
+
+	const nextClass = existingClass.split( /\s+/ ).includes( scopeClass )
+		? existingClass
+		: ( existingClass ? `${ existingClass } ${ scopeClass }` : scopeClass )
+
+	// Also stamp the BASE layer as inline styles on the wrapper. The
+	// `<style>` element `wrapSaveElement` appends below carries the same
+	// declarations for the base rule PLUS every `@media` breakpoint
+	// override, but `<style>` tags inside serialized block markup get
+	// dropped by `wp_kses_post` / the equivalent sanitizer on plenty of
+	// hosts. Inline styles survive that filter path and inherit the
+	// wrapper's inline-style specificity (higher than the `!important`
+	// class rule we emit for the editor canvas). Breakpoint overrides
+	// still need `<style>` — no way to express `@media` inline.
+	const baseStyle = baseInlineStyle( attributes )
+	if ( '' === baseStyle ) {
+		return {
+			...extraProps,
+			className: nextClass,
+		}
+	}
+
+	const existingStyle = ( extraProps.style as Record<string, string> | string | undefined ) ?? undefined
+
+	// Gutenberg's core panels sometimes stamp `style` as an object and
+	// sometimes as a string — merge either into the resulting string
+	// without duplicating declarations we've already stamped for a
+	// prior render pass (same-attribute idempotency).
+	const mergedStyle = mergeStyle( existingStyle, baseStyle )
+
+	return {
+		...extraProps,
+		className: nextClass,
+		style: mergedStyle,
+	}
+}
+
+/**
+ * Build a semicolon-terminated inline declaration string for the base
+ * layer only — media-query overrides continue to ride the `<style>`
+ * element from `wrapSaveElement`.
+ */
+function baseInlineStyle(
+	attributes: PositionAttributes & Record<string, unknown>,
+): string {
+	const payload = resolvePosition( attributes )
+	if ( ! payload ) {
+		return ''
+	}
+
+	const base = payload.base
+	if ( ! base || null === base.value || 'static' === base.value ) {
+		return ''
+	}
+
+	// Mirror the PHP counterpart's `!important` — the inline fallback
+	// only exists for hosts that strip the `<style data-ap-position-scope>`
+	// element, and without `!important` a theme's `!important` reset on
+	// the wrapper class outranks us in that exact scenario.
+	const parts: string[] = [ `position: ${ base.value } !important` ]
+
+	if ( null !== base.offsets.top ) {
+		parts.push( `top: ${ formatInlineOffset( base.offsets.top ) } !important` )
+	}
+	if ( null !== base.offsets.right ) {
+		parts.push( `right: ${ formatInlineOffset( base.offsets.right ) } !important` )
+	}
+	if ( null !== base.offsets.bottom ) {
+		parts.push( `bottom: ${ formatInlineOffset( base.offsets.bottom ) } !important` )
+	}
+	if ( null !== base.offsets.left ) {
+		parts.push( `left: ${ formatInlineOffset( base.offsets.left ) } !important` )
+	}
+	if ( null !== base.zIndex ) {
+		parts.push( `z-index: ${ base.zIndex } !important` )
+	}
+
+	return parts.join( '; ' ) + ';'
+}
+
+function formatInlineOffset( offset: { value: number; unit: string } ): string {
+	if ( 'auto' === offset.unit ) {
+		return 'auto'
+	}
+	return `${ offset.value }${ offset.unit }`
+}
+
+// Anchor `position:` to a declaration boundary (start-of-string or
+// after a semicolon), NOT any substring. `background-position:`,
+// `object-position:`, `transition: position …` would otherwise trip
+// the idempotency guard and silently drop our inline stamp — the
+// wrapper renders unpositioned even though the user configured a value.
+const POSITION_DECL_RE = /(?:^|;)\s*position\s*:/i
+
+function mergeStyle(
+	existing: Record<string, string> | string | undefined,
+	next: string,
+): string {
+	if ( ! existing ) {
+		return next
+	}
+
+	if ( 'string' === typeof existing ) {
+		if ( POSITION_DECL_RE.test( existing ) ) {
+			return existing
+		}
+		const trimmed = existing.trim()
+		if ( '' === trimmed ) {
+			return next
+		}
+		const separator = trimmed.endsWith( ';' ) ? ' ' : '; '
+		return `${ trimmed }${ separator }${ next }`
+	}
+
+	// Object form — convert to string.
+	const stringified = Object.entries( existing )
+		.map( ( [ prop, val ] ) => `${ toKebab( prop ) }: ${ val }` )
+		.join( '; ' )
+
+	if ( '' === stringified ) {
+		return next
+	}
+
+	if ( POSITION_DECL_RE.test( stringified ) ) {
+		return stringified + ';'
+	}
+
+	return `${ stringified }; ${ next }`
+}
+
+function toKebab( value: string ): string {
+	return value.replace( /[A-Z]/g, ( m ) => `-${ m.toLowerCase() }` )
+}
+
+function wrapSaveElement(
+	element: unknown,
+	blockType: BlockSettingsLike,
+	attributes: PositionAttributes & Record<string, unknown>,
+): unknown {
+	if ( ! blockSupportsConfigOnSettings( blockType ) ) {
+		return element
+	}
+
+	const scopeId = readScopeId( attributes )
+	if ( ! scopeId ) {
+		return element
+	}
+
+	const css = emitCssForBlock( scopeId, attributes )
+	if ( '' === css ) {
+		return element
+	}
+
+	return createElement(
+		Fragment,
+		null,
+		element as ReactNode,
+		createElement( 'style', { 'data-ap-position-scope': scopeId }, css ),
+	)
+}
+
+/**
+ * Idempotent — safe to call from both the post-editor and site-editor
+ * bootstrap paths.
+ */
+export function registerPositionStylesFilters(): void {
+	const host = globalThis as unknown as GlobalSentinelHost
+
+	if ( host[ REGISTERED_KEY ] ) {
+		return
+	}
+
+	addFilter( BLOCK_FILTER_HOOK, FILTER_NAMESPACE, withPositionStyles )
+	addFilter( SAVE_PROPS_HOOK, FILTER_NAMESPACE, addSaveProps )
+	addFilter( SAVE_ELEMENT_HOOK, FILTER_NAMESPACE, wrapSaveElement )
+	host[ REGISTERED_KEY ] = true
+}

--- a/resources/js/visual-editor/site-editor/__tests__/site-editor-app.test.tsx
+++ b/resources/js/visual-editor/site-editor/__tests__/site-editor-app.test.tsx
@@ -216,6 +216,11 @@ vi.mock('../../box-shadows/register', () => ({
     registerBoxShadows: (): void => undefined,
 }));
 
+// #640: same JSON-import-attribute trip for the positioning registrar.
+vi.mock('../../positioning/register', () => ({
+    registerPositioning: (): void => undefined,
+}));
+
 import { resetActiveBreakpoint } from '../../responsive/active-breakpoint';
 import { SiteEditorApp } from '../site-editor-app';
 

--- a/resources/js/visual-editor/site-editor/site-editor-app.tsx
+++ b/resources/js/visual-editor/site-editor/site-editor-app.tsx
@@ -49,6 +49,7 @@ import { registerBackgroundControls } from '../background-controls';
 import { registerArtisanPackBlocks } from '../blocks';
 import { registerBoxShadows } from '../box-shadows/register';
 import { registerGradientBorders } from '../gradient-borders/register';
+import { registerPositioning } from '../positioning/register';
 
 import { BlockLibrarySidebar } from '../editor/block-library-sidebar';
 import { TopBar } from '../editor/top-bar';
@@ -187,6 +188,7 @@ function ensureEditorBoot(): void {
     // blocks pick up the routed `border.gradient` path at registration.
     registerGradientBorders();
     registerBoxShadows();
+    registerPositioning();
 
     // I7 (#415): register all artisanpack/* blocks and set the default
     // block to artisanpack/paragraph. Core blocks are no longer loaded.

--- a/src/Position/PositionEmitter.php
+++ b/src/Position/PositionEmitter.php
@@ -1,0 +1,161 @@
+<?php
+
+/**
+ * CSS position emitter (#640).
+ *
+ * PHP mirror of `resources/js/visual-editor/positioning/emitter.ts` —
+ * turns a resolved payload into the scoped CSS the Blade renderer
+ * flushes at the top of the page output.
+ *
+ * Contracts (per #643):
+ *
+ *  - `position: static` emits nothing — orphan offsets / z-index stay
+ *    in attributes but produce no CSS while static.
+ *  - `unit: 'auto'` renders as `top: auto` etc.
+ *  - Breakpoints emit inside `@media (min-width:<n>px)` blocks using
+ *    the request-scoped breakpoint registry.
+ *  - Callers pass in the already-merged per-breakpoint layer map (see
+ *    {@see PositionResolver::mergedBreakpointLayers}) so the emitter
+ *    only walks each breakpoint once.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.4.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Position;
+
+use ArtisanPackUI\VisualEditor\Responsive\BreakpointRegistry;
+
+class PositionEmitter
+{
+	public function __construct(
+		protected BreakpointRegistry $breakpoints,
+	) {}
+
+	/**
+	 * Emit scoped CSS. Returns an empty string when nothing meaningful
+	 * renders.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @param  string  $scope    The selector prefix (e.g. `.ve-pos-abc`).
+	 * @param  array{base: array<string, mixed>|null, breakpoints: array<string, array<string, mixed>>}  $payload
+	 */
+	public function emit( string $scope, array $payload ): string
+	{
+		$trimmedScope = trim( $scope );
+
+		if ( '' === $trimmedScope ) {
+			return '';
+		}
+
+		$rules = [];
+
+		$baseDecls = self::layerDeclarations( $payload['base'] ?? null );
+		if ( '' !== $baseDecls ) {
+			$rules[] = $trimmedScope . '{' . $baseDecls . '}';
+		}
+
+		$orderedKeys = $this->orderedBreakpointKeys();
+		$merged      = PositionResolver::mergedBreakpointLayers( $payload, $orderedKeys );
+
+		foreach ( $orderedKeys as $key ) {
+			$layer = $merged[ $key ] ?? null;
+
+			if ( null === $layer ) {
+				continue;
+			}
+
+			$decls = self::layerDeclarations( $layer );
+			if ( '' === $decls ) {
+				continue;
+			}
+
+			$minWidth = $this->breakpoints->get( $key );
+			if ( null === $minWidth || $minWidth <= 0 ) {
+				continue;
+			}
+
+			$rules[] = '@media (min-width:' . $minWidth . 'px){' . $trimmedScope . '{' . $decls . '}}';
+		}
+
+		return implode( '', $rules );
+	}
+
+	/**
+	 * @param  array<string, mixed>|null  $layer
+	 */
+	public static function layerDeclarations( ?array $layer ): string
+	{
+		if ( null === $layer ) {
+			return '';
+		}
+
+		$value = $layer['value'] ?? null;
+
+		if ( null === $value || 'static' === $value ) {
+			return '';
+		}
+
+		// See `layerDeclarations` in the JS emitter for the `!important`
+		// rationale — same story on the frontend: theme resets and the
+		// occasional utility framework rule can outrank a single scope
+		// class, and the user's panel pick is an explicit override.
+		$parts = [ 'position:' . $value . ' !important' ];
+
+		$offsets = $layer['offsets'] ?? [];
+		foreach ( [ 'top', 'right', 'bottom', 'left' ] as $side ) {
+			$offset = $offsets[ $side ] ?? null;
+			if ( null === $offset || ! is_array( $offset ) ) {
+				continue;
+			}
+			$parts[] = $side . ':' . self::formatOffset( $offset ) . ' !important';
+		}
+
+		if ( isset( $layer['zIndex'] ) && null !== $layer['zIndex'] ) {
+			$parts[] = 'z-index:' . (int) $layer['zIndex'] . ' !important';
+		}
+
+		return implode( ';', $parts );
+	}
+
+	/**
+	 * @param  array{value: float|int, unit: string}  $offset
+	 */
+	protected static function formatOffset( array $offset ): string
+	{
+		if ( 'auto' === $offset['unit'] ) {
+			return 'auto';
+		}
+
+		$value = $offset['value'];
+		// Cast integers back to no-decimal form; keep floats as PHP
+		// formats them (which drops trailing zeros already).
+		return ( is_int( $value ) ? (string) $value : (string) $value ) . $offset['unit'];
+	}
+
+	/**
+	 * Registry keys ordered by ascending min-width. Excludes `base`.
+	 *
+	 * @return array<int, string>
+	 */
+	protected function orderedBreakpointKeys(): array
+	{
+		$keys = [];
+
+		foreach ( $this->breakpoints->all() as $key => $_minWidth ) {
+			if ( ! is_string( $key ) || '' === $key || 'base' === $key ) {
+				continue;
+			}
+			$keys[] = $key;
+		}
+
+		return $keys;
+	}
+}

--- a/src/Position/PositionResolver.php
+++ b/src/Position/PositionResolver.php
@@ -1,0 +1,336 @@
+<?php
+
+/**
+ * CSS position attribute resolver (#640).
+ *
+ * PHP mirror of `resources/js/visual-editor/positioning/resolver.ts` —
+ * walks a block's attribute tree and produces the normalized payload
+ * {@see PositionEmitter::emit} consumes.
+ *
+ * The idle layer lives at `attributes.style.position`; per-breakpoint
+ * overrides ride `attributes.responsive['style.position']` following
+ * the routing pattern from #487. Legacy Gutenberg sticky (a bare
+ * string at `style.position`) is widened to `{ 'value' => 'sticky' }`.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.4.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Position;
+
+class PositionResolver
+{
+	protected const POSITION_VALUES = [ 'static', 'relative', 'absolute', 'fixed', 'sticky' ];
+	protected const OFFSET_UNITS    = [ 'px', '%', 'rem', 'em', 'vh', 'vw', 'auto' ];
+	protected const OFFSET_SIDES    = [ 'top', 'right', 'bottom', 'left' ];
+
+	/**
+	 * Resolve a full block attribute tree into the normalized payload
+	 * the emitter consumes. Returns `null` when no position
+	 * configuration exists at any cascade level.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @param  array<string, mixed>  $attributes
+	 *
+	 * @return array{base: array<string, mixed>|null, breakpoints: array<string, array<string, mixed>>}|null
+	 */
+	public static function resolve( array $attributes ): ?array
+	{
+		$base        = self::resolveLayer( self::coerceSubtree( $attributes['style']['position'] ?? null ) );
+		$breakpoints = self::readBreakpointOverrides( $attributes );
+
+		if ( null === $base && [] === $breakpoints ) {
+			return null;
+		}
+
+		return [
+			'base'        => $base,
+			'breakpoints' => $breakpoints,
+		];
+	}
+
+	/**
+	 * Coerce the raw slot into a structured subtree. A plain string is
+	 * treated as the `value` field alone — Gutenberg's native sticky
+	 * shape.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @return array<string, mixed>|null
+	 */
+	public static function coerceSubtree( mixed $raw ): ?array
+	{
+		if ( null === $raw ) {
+			return null;
+		}
+
+		if ( is_string( $raw ) ) {
+			$value = self::normalizeValue( $raw );
+			return null === $value ? null : [ 'value' => $value ];
+		}
+
+		if ( ! is_array( $raw ) ) {
+			return null;
+		}
+
+		return $raw;
+	}
+
+	/**
+	 * @param  array<string, mixed>|null  $subtree
+	 *
+	 * @return array{value: string|null, offsets: array<string, array<string, mixed>|null>, zIndex: int|null}|null
+	 */
+	protected static function resolveLayer( ?array $subtree ): ?array
+	{
+		if ( null === $subtree ) {
+			return null;
+		}
+
+		$value   = self::normalizeValue( $subtree['value'] ?? null );
+		$offsets = self::normalizeOffsets( $subtree['offsets'] ?? null );
+		$zIndex  = self::normalizeZIndex( $subtree['zIndex'] ?? null );
+
+		$hasAny =
+			null !== $value
+			|| null !== $offsets['top']
+			|| null !== $offsets['right']
+			|| null !== $offsets['bottom']
+			|| null !== $offsets['left']
+			|| null !== $zIndex;
+
+		if ( ! $hasAny ) {
+			return null;
+		}
+
+		return [
+			'value'   => $value,
+			'offsets' => $offsets,
+			'zIndex'  => $zIndex,
+		];
+	}
+
+	protected static function normalizeValue( mixed $raw ): ?string
+	{
+		if ( ! is_string( $raw ) ) {
+			return null;
+		}
+
+		$trimmed = strtolower( trim( $raw ) );
+
+		return in_array( $trimmed, self::POSITION_VALUES, true ) ? $trimmed : null;
+	}
+
+	/**
+	 * @return array<string, array<string, mixed>|null>
+	 */
+	protected static function normalizeOffsets( mixed $raw ): array
+	{
+		$out = [
+			'top'    => null,
+			'right'  => null,
+			'bottom' => null,
+			'left'   => null,
+		];
+
+		if ( ! is_array( $raw ) ) {
+			return $out;
+		}
+
+		foreach ( self::OFFSET_SIDES as $side ) {
+			$out[ $side ] = self::normalizeOffset( $raw[ $side ] ?? null );
+		}
+
+		return $out;
+	}
+
+	/**
+	 * @return array{value: float|int, unit: string}|null
+	 */
+	protected static function normalizeOffset( mixed $raw ): ?array
+	{
+		if ( ! is_array( $raw ) ) {
+			return null;
+		}
+
+		$unit = isset( $raw['unit'] ) && is_string( $raw['unit'] )
+			? strtolower( trim( $raw['unit'] ) )
+			: null;
+
+		if ( null === $unit || ! in_array( $unit, self::OFFSET_UNITS, true ) ) {
+			return null;
+		}
+
+		if ( 'auto' === $unit ) {
+			return [ 'value' => 0, 'unit' => 'auto' ];
+		}
+
+		$value = $raw['value'] ?? null;
+
+		if ( is_string( $value ) ) {
+			$trimmed = trim( $value );
+			if ( '' === $trimmed || ! is_numeric( $trimmed ) ) {
+				return null;
+			}
+			$value = 0 + $trimmed;
+		}
+
+		if ( ! is_int( $value ) && ! is_float( $value ) ) {
+			return null;
+		}
+
+		if ( ! is_finite( (float) $value ) ) {
+			return null;
+		}
+
+		return [ 'value' => $value, 'unit' => $unit ];
+	}
+
+	protected static function normalizeZIndex( mixed $raw ): ?int
+	{
+		if ( is_int( $raw ) ) {
+			return $raw;
+		}
+
+		if ( is_float( $raw ) && is_finite( $raw ) ) {
+			return (int) $raw;
+		}
+
+		if ( is_string( $raw ) ) {
+			$trimmed = trim( $raw );
+			if ( '' === $trimmed ) {
+				return null;
+			}
+			// Reject scientific notation before Number-coercing. PHP's
+			// `is_numeric` accepts `'1e100'` and `0 + '1e100'` overflows
+			// silently to `PHP_INT_MAX`, while the JS side filters it
+			// via `Number.isFinite`. Matching the JS filter keeps preview
+			// (editor) and server render byte-identical for the same
+			// input.
+			if ( 1 === preg_match( '/[eE]/', $trimmed ) ) {
+				return null;
+			}
+			if ( ! is_numeric( $trimmed ) ) {
+				return null;
+			}
+			$value = 0 + $trimmed;
+			if ( ! is_finite( (float) $value ) ) {
+				return null;
+			}
+			return (int) $value;
+		}
+
+		return null;
+	}
+
+	/**
+	 * @param  array<string, mixed>  $attributes
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
+	protected static function readBreakpointOverrides( array $attributes ): array
+	{
+		$responsive = $attributes['responsive'] ?? null;
+
+		if ( ! is_array( $responsive ) ) {
+			return [];
+		}
+
+		$bag = $responsive['style.position'] ?? null;
+
+		if ( ! is_array( $bag ) ) {
+			return [];
+		}
+
+		$out = [];
+
+		foreach ( $bag as $key => $raw ) {
+			if ( ! is_string( $key ) || '' === $key || 'base' === $key ) {
+				continue;
+			}
+
+			$layer = self::resolveLayer( self::coerceSubtree( $raw ) );
+
+			if ( null === $layer ) {
+				continue;
+			}
+
+			$out[ $key ] = $layer;
+		}
+
+		return $out;
+	}
+
+	/**
+	 * Merge each defined breakpoint layer on top of every smaller layer
+	 * (base included). Produces the fully-resolved per-breakpoint layer
+	 * map the emitter consumes for media-query bodies.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @param  array{base: array<string, mixed>|null, breakpoints: array<string, array<string, mixed>>}  $payload
+	 * @param  array<int, string>  $orderedBreakpointKeys  Registry keys, ascending, no `base`.
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
+	public static function mergedBreakpointLayers( array $payload, array $orderedBreakpointKeys ): array
+	{
+		$out     = [];
+		$running = $payload['base'] ?? null;
+
+		foreach ( $orderedBreakpointKeys as $key ) {
+			$overlay = $payload['breakpoints'][ $key ] ?? null;
+
+			if ( null === $overlay ) {
+				continue;
+			}
+
+			$running     = self::mergeLayers( $running, $overlay );
+			$out[ $key ] = $running;
+		}
+
+		return $out;
+	}
+
+	/**
+	 * Fold an overlay layer on top of a base layer — overlay wins per
+	 * field, base fills any nulls. Single source of truth for the
+	 * merge fallthrough logic; the JS mirror lives at
+	 * `resources/js/visual-editor/positioning/resolver.ts::mergeLayers`.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @param  array<string, mixed>|null  $base
+	 * @param  array<string, mixed>|null  $overlay
+	 *
+	 * @return array<string, mixed>|null
+	 */
+	public static function mergeLayers( ?array $base, ?array $overlay ): ?array
+	{
+		if ( null === $overlay ) {
+			return $base;
+		}
+
+		if ( null === $base ) {
+			return $overlay;
+		}
+
+		return [
+			'value'   => $overlay['value'] ?? $base['value'],
+			'offsets' => [
+				'top'    => $overlay['offsets']['top']    ?? $base['offsets']['top'],
+				'right'  => $overlay['offsets']['right']  ?? $base['offsets']['right'],
+				'bottom' => $overlay['offsets']['bottom'] ?? $base['offsets']['bottom'],
+				'left'   => $overlay['offsets']['left']   ?? $base['offsets']['left'],
+			],
+			'zIndex'  => $overlay['zIndex'] ?? $base['zIndex'],
+		];
+	}
+}

--- a/src/VisualEditorServiceProvider.php
+++ b/src/VisualEditorServiceProvider.php
@@ -48,6 +48,7 @@ use ArtisanPackUI\VisualEditor\Responsive\BreakpointRegistry;
 use ArtisanPackUI\VisualEditor\Responsive\ResponsiveValueResolver;
 use ArtisanPackUI\VisualEditor\States\StateAttributeMigrator;
 use ArtisanPackUI\VisualEditor\BoxShadow\BoxShadowEmitter;
+use ArtisanPackUI\VisualEditor\Position\PositionEmitter;
 use ArtisanPackUI\VisualEditor\States\StateCssEmitter;
 use ArtisanPackUI\VisualEditor\States\StateRegistry;
 use ArtisanPackUI\VisualEditor\States\StateValueResolver;
@@ -373,6 +374,16 @@ class VisualEditorServiceProvider extends ServiceProvider
 		$this->app->scoped( BoxShadowEmitter::class, function ( $app ) {
 			return new BoxShadowEmitter(
 				$app->make( StateRegistry::class ),
+				$app->make( BreakpointRegistry::class ),
+			);
+		} );
+
+		// #640: CSS position emitter. Bound here so future
+		// render-pipeline integration can resolve it from the
+		// container; the Blade renderer's BlockSupports already
+		// constructs one directly with the request-scoped registry.
+		$this->app->scoped( PositionEmitter::class, function ( $app ) {
+			return new PositionEmitter(
 				$app->make( BreakpointRegistry::class ),
 			);
 		} );

--- a/tests/Unit/Position/PositionEmitterTest.php
+++ b/tests/Unit/Position/PositionEmitterTest.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * Unit tests for {@see PositionEmitter} (#640).
+ *
+ * @since 1.4.0
+ */
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Position\PositionEmitter;
+use ArtisanPackUI\VisualEditor\Position\PositionResolver;
+use ArtisanPackUI\VisualEditor\Responsive\BreakpointRegistry;
+
+function positionMakeRegistry(): BreakpointRegistry
+{
+	// Pass explicit `[]` for both overrides so `fromLayers()` doesn't
+	// reach for `config()` (unavailable in unit-test isolation).
+	return BreakpointRegistry::fromLayers( [], [] );
+}
+
+describe( 'PositionEmitter::emit', function (): void {
+	it( 'returns empty when the scope is blank', function (): void {
+		$payload = PositionResolver::resolve( [ 'style' => [ 'position' => [ 'value' => 'relative' ] ] ] );
+		$emitter = new PositionEmitter( positionMakeRegistry() );
+
+		expect( $emitter->emit( '   ', $payload ) )->toBe( '' );
+	} );
+
+	it( 'emits nothing for a static-only base layer', function (): void {
+		$payload = PositionResolver::resolve( [ 'style' => [ 'position' => [ 'value' => 'static' ] ] ] );
+		$emitter = new PositionEmitter( positionMakeRegistry() );
+
+		expect( $emitter->emit( '.foo', $payload ) )->toBe( '' );
+	} );
+
+	it( 'emits base position + offsets + z-index in one rule', function (): void {
+		$payload = PositionResolver::resolve( [
+			'style' => [
+				'position' => [
+					'value'   => 'absolute',
+					'offsets' => [
+						'top'    => [ 'value' => 10, 'unit' => 'px' ],
+						'right'  => [ 'unit' => 'auto' ],
+					],
+					'zIndex'  => 2,
+				],
+			],
+		] );
+
+		$emitter = new PositionEmitter( positionMakeRegistry() );
+
+		expect( $emitter->emit( '.wrap', $payload ) )
+			->toBe( '.wrap{position:absolute !important;top:10px !important;right:auto !important;z-index:2 !important}' );
+	} );
+
+	it( 'wraps breakpoint overrides in @media rules with inherited fields', function (): void {
+		$payload = PositionResolver::resolve( [
+			'style' => [
+				'position' => [
+					'value'   => 'relative',
+					'offsets' => [ 'top' => [ 'value' => 10, 'unit' => 'px' ] ],
+				],
+			],
+			'responsive' => [
+				'style.position' => [
+					'md' => [ 'zIndex' => 3 ],
+					'lg' => [ 'value' => 'sticky', 'offsets' => [ 'top' => [ 'value' => 0, 'unit' => 'px' ] ] ],
+				],
+			],
+		] );
+
+		$css = ( new PositionEmitter( positionMakeRegistry() ) )->emit( '.wrap', $payload );
+
+		expect( $css )->toContain( '.wrap{position:relative !important;top:10px !important}' );
+		expect( $css )->toContain( '@media (min-width:768px){.wrap{position:relative !important;top:10px !important;z-index:3 !important}}' );
+		expect( $css )->toContain( '@media (min-width:1024px){.wrap{position:sticky !important;top:0px !important;z-index:3 !important}}' );
+	} );
+
+	it( 'legacy sticky (bare string) round-trips to a single sticky rule', function (): void {
+		$payload = PositionResolver::resolve( [ 'style' => [ 'position' => 'sticky' ] ] );
+
+		expect( ( new PositionEmitter( positionMakeRegistry() ) )->emit( '.wrap', $payload ) )
+			->toBe( '.wrap{position:sticky !important}' );
+	} );
+} );

--- a/tests/Unit/Position/PositionResolverTest.php
+++ b/tests/Unit/Position/PositionResolverTest.php
@@ -1,0 +1,150 @@
+<?php
+
+/**
+ * Unit tests for {@see PositionResolver} (#640).
+ *
+ * @since 1.4.0
+ */
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Position\PositionResolver;
+
+describe( 'PositionResolver::resolve', function (): void {
+	it( 'returns null when no position configuration exists', function (): void {
+		expect( PositionResolver::resolve( [] ) )->toBeNull();
+		expect( PositionResolver::resolve( [ 'style' => [ 'position' => null ] ] ) )->toBeNull();
+	} );
+
+	it( 'widens a legacy sticky string into a structured base layer', function (): void {
+		$resolved = PositionResolver::resolve( [ 'style' => [ 'position' => 'sticky' ] ] );
+
+		expect( $resolved )->not->toBeNull();
+		expect( $resolved[ 'base' ][ 'value' ] )->toBe( 'sticky' );
+	} );
+
+	it( 'resolves offsets + zIndex on the base layer', function (): void {
+		$resolved = PositionResolver::resolve( [
+			'style' => [
+				'position' => [
+					'value'   => 'absolute',
+					'offsets' => [ 'top' => [ 'value' => 10, 'unit' => 'px' ] ],
+					'zIndex'  => 5,
+				],
+			],
+		] );
+
+		expect( $resolved[ 'base' ][ 'value' ] )->toBe( 'absolute' );
+		expect( $resolved[ 'base' ][ 'offsets' ][ 'top' ] )->toBe( [ 'value' => 10, 'unit' => 'px' ] );
+		expect( $resolved[ 'base' ][ 'zIndex' ] )->toBe( 5 );
+	} );
+
+	it( 'reads per-breakpoint overrides from the responsive bag', function (): void {
+		$resolved = PositionResolver::resolve( [
+			'style' => [ 'position' => [ 'value' => 'relative' ] ],
+			'responsive' => [
+				'style.position' => [
+					'md' => [ 'value' => 'absolute', 'zIndex' => 2 ],
+				],
+			],
+		] );
+
+		expect( $resolved[ 'breakpoints' ][ 'md' ][ 'value' ] )->toBe( 'absolute' );
+		expect( $resolved[ 'breakpoints' ][ 'md' ][ 'zIndex' ] )->toBe( 2 );
+	} );
+
+	it( 'drops offsets with an invalid unit', function (): void {
+		$resolved = PositionResolver::resolve( [
+			'style' => [
+				'position' => [
+					'value'   => 'absolute',
+					'offsets' => [
+						'top'   => [ 'value' => 10, 'unit' => 'garbage' ],
+						'right' => [ 'value' => 5, 'unit' => 'rem' ],
+					],
+				],
+			],
+		] );
+
+		expect( $resolved[ 'base' ][ 'offsets' ][ 'top' ] )->toBeNull();
+		expect( $resolved[ 'base' ][ 'offsets' ][ 'right' ] )->toBe( [ 'value' => 5, 'unit' => 'rem' ] );
+	} );
+
+	it( 'accepts the `auto` unit without a numeric value', function (): void {
+		$resolved = PositionResolver::resolve( [
+			'style' => [
+				'position' => [
+					'value'   => 'absolute',
+					'offsets' => [ 'top' => [ 'unit' => 'auto' ] ],
+				],
+			],
+		] );
+
+		expect( $resolved[ 'base' ][ 'offsets' ][ 'top' ] )->toBe( [ 'value' => 0, 'unit' => 'auto' ] );
+	} );
+
+	it( 'drops responsive entries under the `base` key', function (): void {
+		$resolved = PositionResolver::resolve( [
+			'responsive' => [
+				'style.position' => [
+					'base' => [ 'value' => 'fixed' ],
+					'lg'   => [ 'value' => 'sticky' ],
+				],
+			],
+		] );
+
+		expect( $resolved[ 'breakpoints' ] )->toHaveKey( 'lg' );
+		expect( $resolved[ 'breakpoints' ] )->not->toHaveKey( 'base' );
+	} );
+} );
+
+describe( 'PositionResolver::normalizeZIndex (via resolve)', function (): void {
+	it( 'rejects scientific notation strings to stay JS/PHP consistent', function (): void {
+		// PHP `is_numeric` accepts these; `0 + trim($v)` overflows to
+		// PHP_INT_MAX. JS `Number.isFinite` rejects `Infinity`. The
+		// resolver rejects them explicitly to keep preview and server
+		// render byte-identical for the same input.
+		$resolved = PositionResolver::resolve( [
+			'style' => [ 'position' => [ 'value' => 'absolute', 'zIndex' => '1e100' ] ],
+		] );
+
+		expect( $resolved[ 'base' ][ 'zIndex' ] )->toBeNull();
+	} );
+
+	it( 'accepts plain integer strings', function (): void {
+		$resolved = PositionResolver::resolve( [
+			'style' => [ 'position' => [ 'value' => 'absolute', 'zIndex' => '42' ] ],
+		] );
+
+		expect( $resolved[ 'base' ][ 'zIndex' ] )->toBe( 42 );
+	} );
+} );
+
+describe( 'PositionResolver::mergedBreakpointLayers', function (): void {
+	it( 'folds each defined breakpoint on top of every smaller layer', function (): void {
+		$payload = PositionResolver::resolve( [
+			'style' => [
+				'position' => [
+					'value'   => 'absolute',
+					'offsets' => [ 'top' => [ 'value' => 5, 'unit' => 'px' ] ],
+					'zIndex'  => 1,
+				],
+			],
+			'responsive' => [
+				'style.position' => [
+					'md' => [ 'zIndex' => 9 ],
+					'lg' => [ 'value' => 'sticky' ],
+				],
+			],
+		] );
+
+		$merged = PositionResolver::mergedBreakpointLayers( $payload, [ 'sm', 'md', 'lg', 'xl', '2xl' ] );
+
+		expect( $merged[ 'md' ][ 'value' ] )->toBe( 'absolute' );
+		expect( $merged[ 'md' ][ 'zIndex' ] )->toBe( 9 );
+		expect( $merged[ 'md' ][ 'offsets' ][ 'top' ] )->toBe( [ 'value' => 5, 'unit' => 'px' ] );
+
+		expect( $merged[ 'lg' ][ 'value' ] )->toBe( 'sticky' );
+		expect( $merged[ 'lg' ][ 'zIndex' ] )->toBe( 9 );
+	} );
+} );


### PR DESCRIPTION
## Description

Adds a per-block Position inspector panel and scoped CSS emission for the editor canvas and the Blade renderer's frontend output. Users can pick `static / relative / absolute / fixed / sticky`, set per-side offsets (`px / % / rem / em / vh / vw / auto`) and z-index, and override any of those per breakpoint via the responsive tab pattern established in #487.

Opt-in per block via `supports.position: true` in `block.json` (Gutenberg's native `{ sticky: true }` object shape also counts). Legacy `style.position: "sticky"` strings widen into the structured schema at read time — no attribute migration.

**Closes:** #641, #642, #643, #644 (all under the #640 umbrella)

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #640

## Motivation and Context

Blocks in the visual editor had no first-class CSS `position` control. Gutenberg's own `supports.position` exposes only `sticky`; site builders and designers needing overlays, layered decorative elements, or precisely-positioned callouts had to drop into custom CSS.

## Changes Made

- **JS side (`resources/js/visual-editor/positioning/`):** resolver, emitter, supports extension, inspector control (with the #644 positioned-ancestor warning), styles HOC (`_positionScopeId` mint/claim + `ve-pos-<id>` wrapper class + `<style>` element + inline base stamp).
- **PHP side (`src/Position/`, `packages/visual-editor-renderer-blade/`):** `PositionResolver` + `PositionEmitter` mirroring the JS shape; `PositionCssAccumulator`; `BlockSupports::compilePosition()` + `baseInlinePositionStyle()` + `resolvePositionScopeClass()`; `<style data-ve-position>` output in `blocks.blade.php` / `template.blade.php`.
- **Resilience:** base declarations stamp inline on the wrapper (both JS save filter and PHP compile) so hosts that strip `<style>` from block markup still get sticky/absolute applied. Every declaration ships `!important` to beat Gutenberg's canvas `.block-editor-block-list__block { position: relative }` internal rule and theme resets.
- **Consolidation** (carried on top of the feature): `pushToAccumulator()` collapses the five copy-pasted `push*` guards; `composeScopeClass()` collapses the three copy-pasted `resolve*ScopeClass` implementations; `PositionResolver::mergeLayers()` + JS export of `mergeLayers` gives one source of truth for the layer fallthrough logic.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS Darwin 25.5
- Browser: Chrome (via Herd local dev)
- PHP Version: 8.4.3
- Project Version: v1.4 (development)

**Tests Performed:**
1. Manual smoke test in the dev app: sticky group inside a column, verified editor-canvas application and frontend sticky behavior.
2. Full automated suites — see below.

## Accessibility Tests Run

- [x] Keyboard navigation tested (Position panel inputs are reachable via tab; ToolsPanelItem controls follow WP components a11y conventions)
- [ ] Screen reader tested (not exhaustive)
- [x] Color contrast verified (uses standard WP inspector components)
- [x] ARIA labels checked (`role="tablist"` on breakpoint tabs, `aria-selected` per tab, warning notice uses `Notice` component)

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:**

- **JS (34 tests, 0 failures):** `positioning/__tests__/resolver.test.ts`, `emitter.test.ts`, `extend-supports.test.ts`.
- **PHP (13 new + 4 updated, 0 failures):** `tests/Unit/Position/PositionResolverTest.php`, `PositionEmitterTest.php`, `packages/visual-editor-renderer-blade/tests/Unit/PositionCssAccumulatorTest.php`, and new cases in `BlockSupportsTest.php` covering the position compile path.

Full run: `86 PHP passed / 34 JS passed`, all fresh (pre-existing 1330-ish deprecated PDO warnings are unrelated).

## Documentation

- [x] Inline code documentation added (extensive PHPDoc + JSDoc on new modules)
- [ ] README updated
- [ ] Wiki updated (deferred to #648)
- [ ] API documentation updated

**Documentation details:**

- `CHANGELOG.md` [Unreleased] section names the feature and calls out the `vendor:publish --tag=visual-editor-blade-views --force` upgrade step for hosts that previously published the Blade views (documented failure mode: stale published views shadow the package source and drop the `<style data-ve-position>` output).

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [ ] Code has been linted (no repo-wide lint runner wired for this branch — package-level Pint / PHPCS not part of dev harness)
- [x] Accessibility tests completed (see above)
- [x] Code follows project style guide (WordPress-style spacing, Yoda conditions, `!important` scoped to intended overrides, `__()` on all user-facing strings)
- [x] Self-review completed (8-angle recall-biased review; 10 findings surfaced and all addressed in this commit)
- [x] Comments added for complex code
- [x] No new warnings generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CSS positioning controls for supported blocks, including static, relative, absolute, fixed, and sticky positioning.
  * Added per-side offsets, z-index controls, responsive breakpoint overrides, and legacy sticky-value support.
  * Positioning styles now render consistently in the editor and on the frontend.

* **Upgrade Notes**
  * Re-publish the editor Blade views after upgrading to enable positioning styles: `php artisan vendor:publish --tag=visual-editor-blade-views --force`

* **Tests**
  * Added coverage for responsive positioning, CSS output, inheritance, validation, and legacy inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->