### PR TITLE
feat: CSS positioning support for blocks (#640)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,37 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   data-ve-position>` block on the frontend via the Blade renderer.
   Inspector shows a warning notice when `position: absolute` is
   applied but no ancestor is positioned.
+- **Enabled `supports.position: true` on 82 top-level artisanpack
+  blocks (#645).** Every `resources/js/visual-editor/blocks/*/block.json`
+  that doesn't declare a `parent` or `ancestor` restriction now
+  opts in. Child-only blocks (accordion internals, list items,
+  columns, buttons children, query pagination, etc.) are
+  deliberately skipped — positioning a child that a container
+  relies on for layout breaks the container's contract.
+  `artisanpack/group` already carried Gutenberg's
+  `supports.position: { sticky: true }` object shape, which
+  `positionEnabled()` also recognizes; no change needed.
+- **Position support on core containers (#646).** Functionally
+  subsumed by #645 given the I7 (#415) cutover — this repo no
+  longer calls `registerCoreBlocks()`, so no `core/*` block enters
+  the editor. Every container listed in the parent issue
+  (`core/group`, `core/columns`, `core/column`, `core/cover`,
+  `core/row`, `core/stack`, `core/grid`, `core/buttons`,
+  `core/image`) has an `artisanpack/*` fork covered by #645.
+- **Integration + e2e test coverage (#647).** Round-trip
+  integration tests exercising resolver + emitter for a full
+  base + per-breakpoint payload, legacy sticky no-churn, and the
+  static-toggle-preserves-orphan-fields flow. Playwright e2e
+  spec (`tests/e2e/positioning.spec.ts`) documents the runtime
+  contract for sticky groups, absolute covers, ancestor
+  warnings, per-breakpoint viewport switching, and legacy
+  sticky — commented pending the Playwright runner (matches
+  the `animations.spec.ts` precedent).
+- **Docs (#648).** New `docs/position.md` covering opt-in,
+  attribute shape, position values, offset units, per-breakpoint
+  inheritance, the ancestor warning, the two frontend emission
+  channels (inline + `<style data-ve-position>`), and a
+  troubleshooting section. Linked from `docs/home.md`.
 
 ### Upgrade notes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,10 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   in the editor canvas and inline styles + a `<style
   data-ve-position>` block on the frontend via the Blade renderer.
   Inspector shows a warning notice when `position: absolute` is
-  applied but no ancestor is positioned.
+  applied but no ancestor is positioned. Per-breakpoint authoring
+  follows the top-bar viewport switcher (via the shared
+  active-breakpoint store) — no separate control lives in the panel,
+  matching every sibling responsive-aware inspector panel.
 - **Enabled `supports.position: true` on 82 top-level artisanpack
   blocks (#645).** Every `resources/js/visual-editor/blocks/*/block.json`
   that doesn't declare a `parent` or `ancestor` restriction now
@@ -40,7 +43,7 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   integration tests exercising resolver + emitter for a full
   base + per-breakpoint payload, legacy sticky no-churn, and the
   static-toggle-preserves-orphan-fields flow. Playwright e2e
-  spec (`tests/e2e/positioning.spec.ts`) documents the runtime
+  spec (`tests/E2E/positioning.spec.ts`) documents the runtime
   contract for sticky groups, absolute covers, ancestor
   warnings, per-breakpoint viewport switching, and legacy
   sticky — commented pending the Playwright runner (matches

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,34 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- **CSS positioning support for blocks (#640).** Per-block Position
+  panel in the inspector with a `static / relative / absolute / fixed
+  / sticky` dropdown, per-side offset inputs (`px / % / rem / em /
+  vh / vw / auto`), z-index, and per-breakpoint overrides via the
+  responsive tab pattern from #487. Opt-in per block via
+  `supports.position: true` in `block.json` (Gutenberg's native
+  `{ sticky: true }` object shape also counts). Emits scoped CSS
+  in the editor canvas and inline styles + a `<style
+  data-ve-position>` block on the frontend via the Blade renderer.
+  Inspector shows a warning notice when `position: absolute` is
+  applied but no ancestor is positioned.
+
+### Upgrade notes
+
+- **Hosts that ran `php artisan vendor:publish
+  --tag=visual-editor-blade-views` on a prior version must
+  re-publish with `--force` when upgrading.** The published
+  `blocks.blade.php` and `template.blade.php` files shadow the
+  package source; the pre-1.4 published copies don't include the
+  new `<style data-ve-position>` output block, so the position CSS
+  accumulator will flush its rules but they'll never land in the
+  response body — sticky/absolute blocks render unpositioned on the
+  frontend. Command:
+  `php artisan vendor:publish --tag=visual-editor-blade-views --force`.
+
+
 ## [1.3.0] - 2026-07-07
 
 ### Added

--- a/docs/home.md
+++ b/docs/home.md
@@ -78,6 +78,7 @@ The block library — what ships, how to author your own, and how to wire respon
 - [[Animations]] — Block entrance, hover, and continuous animations (v1.1)
 - [[Border Gradients]] — Linear / radial / conic borders + tabbed color/gradient picker (v1.1)
 - [[Block Bindings]] — Bind block attributes to parent post/page/CPT data (v1.1)
+- [[Position]] — CSS positioning (static/relative/absolute/fixed/sticky) with per-side offsets, z-index, and per-breakpoint overrides (v1.4)
 
 ---
 

--- a/docs/home.md
+++ b/docs/home.md
@@ -78,7 +78,7 @@ The block library — what ships, how to author your own, and how to wire respon
 - [[Animations]] — Block entrance, hover, and continuous animations (v1.1)
 - [[Border Gradients]] — Linear / radial / conic borders + tabbed color/gradient picker (v1.1)
 - [[Block Bindings]] — Bind block attributes to parent post/page/CPT data (v1.1)
-- [[Position]] — CSS positioning (static/relative/absolute/fixed/sticky) with per-side offsets, z-index, and per-breakpoint overrides (v1.4)
+- [[Position]] — CSS positioning (static / relative / absolute / fixed / sticky) with per-side offsets, z-index, and per-breakpoint overrides (v1.4)
 
 ---
 

--- a/docs/position.md
+++ b/docs/position.md
@@ -175,6 +175,6 @@ the wrapper's `class` + `style` attributes).
 
 ## Related
 
-- [Animations](animations.md) — same accumulator / scope-class pattern.
-- [Box Shadows](box-shadows.md) — same accumulator pattern.
-- [Border Gradients](border-gradients.md) — same accumulator pattern.
+- [[Animations]] — same accumulator / scope-class pattern.
+- [[Box Shadows]] — same accumulator pattern.
+- [[Border Gradients]] — same accumulator pattern.

--- a/docs/position.md
+++ b/docs/position.md
@@ -1,0 +1,180 @@
+# CSS Position
+
+The Position panel lets editors pin, layer, or precisely place any
+block that opts into `supports.position`. It extends Gutenberg's
+built-in `position` support — the native shape stores a plain
+`"sticky"` string; this system layers a structured object on top of
+the same attribute path so all five CSS `position` values, per-side
+offsets, `z-index`, and per-breakpoint overrides are first-class.
+
+Parent tracking issue: [#640](https://github.com/ArtisanPack-UI/visual-editor/issues/640).
+
+## Attribute shape
+
+Stored on the block as `attributes.style.position`:
+
+```json
+{
+    "value": "sticky",
+    "offsets": {
+        "top":    { "value": 0,  "unit": "px" },
+        "bottom": { "value": 16, "unit": "px" }
+    },
+    "zIndex": 10
+}
+```
+
+- `value`: one of `static | relative | absolute | fixed | sticky`.
+- `offsets.<side>`: `{ value: number, unit: 'px' | '%' | 'rem' | 'em' | 'vh' | 'vw' | 'auto' } | null`.
+  Empty means unset (not `0`).
+- `zIndex`: integer or `null`.
+
+Per-breakpoint overrides ride the standard responsive bag,
+`attributes.responsive['style.position']`, keyed by the breakpoint
+prefix (`sm`, `md`, `lg`, `xl`, `2xl`). Missing fields inherit from
+the next-smaller defined breakpoint, then from `base` — the same
+mobile-first cascade the rest of the responsive system uses (see
+[#487](https://github.com/ArtisanPack-UI/visual-editor/issues/487)).
+
+Legacy content that stored `style.position` as a bare string (Gutenberg's
+native sticky shape) is coerced to `{ "value": "sticky" }` on read
+without touching the persisted attribute — no migration required.
+
+## Opting a custom block in
+
+Set `supports.position: true` in the block's `block.json`:
+
+```json
+{
+    "name": "myplugin/callout",
+    "supports": {
+        "position": true
+    }
+}
+```
+
+Gutenberg's own object shape (`"position": { "sticky": true }`) also
+counts as opted in — both flip the same gate. If a block has neither,
+the Position panel doesn't render for it and no attributes are
+stamped.
+
+Child-only blocks (those with a `parent` or `ancestor` restriction that
+locks them inside a specific container — `column` inside `columns`,
+`accordion-title` inside `accordion`) should be deliberately left off;
+positioning a child that a container relies on for layout will break
+the container's contract.
+
+## Position values
+
+- **static** (default) — normal flow, no CSS emitted. Offsets and
+  `z-index` are preserved on the attribute so a flip back to a
+  positioned value doesn't lose values.
+- **relative** — creates a positioning context for absolute descendants
+  and honors offsets from its natural flow location.
+- **absolute** — takes the block out of flow. Positioned against the
+  nearest positioned ancestor (see the warning notice below).
+- **fixed** — positioned against the viewport. Ignores containing
+  block scroll.
+- **sticky** — behaves as `relative` until the block's containing
+  scroll container reaches the offset, then pins.
+
+## Offset units
+
+`px`, `%`, `rem`, `em`, `vh`, `vw`, `auto`. `auto` is unit-only — no
+numeric value. Emitted as `top: auto` etc., matching CSS semantics.
+
+## Per-breakpoint inheritance
+
+Values are resolved mobile-first. Setting an offset only at `md`
+means: `base` and `sm` inherit whatever was set at `base` (or
+nothing); `md` and larger get the `md` override. The panel follows
+the editor's top-bar viewport switcher — flip to a different
+breakpoint there and the panel re-reads its effective values for
+that breakpoint. The inspector surfaces an **Inherited** hint next
+to any field that isn't explicitly overridden at the currently-viewed
+breakpoint so authors know which value they'd have to change to
+break inheritance.
+
+The three values (position, offsets, `z-index`) inherit
+independently — you can override just `z-index` at `md` and the
+position + offsets keep flowing from `base`.
+
+## Positioned-ancestor warning
+
+When a block is set to `position: absolute` at the currently-viewed
+breakpoint and none of its ancestor blocks is positioned, the
+inspector renders a warning:
+
+> This block is set to `position: absolute` but none of its ancestor
+> blocks is positioned. It will position relative to the nearest
+> positioned ancestor — often the page.
+
+No ancestor is mutated automatically. The block still applies its
+position — the warning is a heads-up that the placement will resolve
+against the page (or whichever ancestor happens to be positioned),
+not necessarily against the block's immediate parent.
+
+To fix, set the parent block's position to any non-static value
+(`relative` is the usual choice — it creates a positioning context
+without changing the parent's own placement).
+
+## Rendered CSS
+
+Two channels emit on the frontend:
+
+- **Wrapper inline style** — the base layer stamps as inline
+  declarations (`style="position: sticky !important; top: 0px !important;"`)
+  so the position survives hosts that strip `<style>` blocks from
+  block markup.
+- **`<style data-ve-position>` block** — the Blade renderer's per-request
+  accumulator emits a single `<style>` element at the top of the
+  response with per-breakpoint rules wrapped in `@media (min-width:...)`
+  queries. Scope class is `.ve-pos-<id>` — same id lands on the
+  wrapper.
+
+Both use `!important` on every declaration. The editor canvas's own
+`.block-editor-block-list__layout .block-editor-block-list__block`
+rule sets `position: relative` at higher specificity than a single
+scope class, and theme resets frequently ship `!important` position
+declarations on wrapper classes. Matching that specificity level is
+the only way to reliably honor the user's explicit pick.
+
+## Troubleshooting
+
+**Sticky doesn't stick.** Sticky needs three things: (1) a non-`auto`
+offset (usually `top`), (2) a scroll context — the block's nearest
+ancestor with a defined height and `overflow: auto | scroll | hidden`,
+and (3) the sticky block cannot fill its scroll container. If the
+container's height exactly matches the sticky block's height, there's
+nowhere to scroll and no sticky travel. Check that the parent column
+has enough content below the sticky block to trigger scrolling.
+
+**Absolute block sits in the wrong place.** The warning notice above
+covers the common cause. If the parent is positioned but the offsets
+still look wrong, check for a Gutenberg layout wrapper (e.g. `.wp-block-group__inner-container`)
+between the block and its declared parent — layout wrappers create
+their own containing block and may shift the coordinate origin.
+
+**Frontend doesn't pick up new rules after an upgrade.** Hosts that
+previously ran `php artisan vendor:publish --tag=visual-editor-blade-views`
+have published copies of the Blade templates that shadow the package
+source. Older published copies don't include the `<style data-ve-position>`
+output block — the accumulator flushes into the void. Republish with:
+
+```bash
+php artisan vendor:publish --tag=visual-editor-blade-views --force
+```
+
+**Editor canvas shows position but the frontend doesn't.** Check the
+page source for a `<style data-ve-position>` element AND a
+`style="position: …"` inline attribute on the wrapper `<div>`. If
+neither is present, the block's parent partial isn't calling
+`BlockSupports::wrapperAttrs()` — verify the block's Blade template
+uses that helper (or an equivalent that pipes `compile()` through
+the wrapper's `class` + `style` attributes).
+
+## Related
+
+- [Animations](animations.md) — same accumulator / scope-class pattern.
+- [Box Shadows](box-shadows.md) — same accumulator pattern.
+- [Border Gradients](border-gradients.md) — same accumulator pattern.

--- a/packages/visual-editor-renderer-blade/resources/views/components/blocks.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/components/blocks.blade.php
@@ -33,6 +33,11 @@
 {!! $boxShadowsCss !!}
 @endif
 @endisset
+@isset( $positionCss )
+@if( '' !== $positionCss )
+{!! $positionCss !!}
+@endif
+@endisset
 {!! $html !!}
 @isset( $animationsRuntimeNeeded )
 @if( $animationsRuntimeNeeded )

--- a/packages/visual-editor-renderer-blade/resources/views/components/template.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/components/template.blade.php
@@ -40,6 +40,11 @@
 {!! $boxShadowsCss !!}
 @endif
 @endisset
+@isset( $positionCss )
+@if( '' !== $positionCss )
+{!! $positionCss !!}
+@endif
+@endisset
 <div class="{{ implode( ' ', $wrapperClasses ) }}" data-ve-template="{{ $slug }}"@if( null !== $matchedSlug && $matchedSlug !== $slug ) data-ve-matched-template="{{ $matchedSlug }}"@endif>
 @if( null !== $resolutionError )
 @if( $inDev )

--- a/packages/visual-editor-renderer-blade/src/Services/PositionCssAccumulator.php
+++ b/packages/visual-editor-renderer-blade/src/Services/PositionCssAccumulator.php
@@ -1,0 +1,111 @@
+<?php
+
+/**
+ * Per-request accumulator for the CSS positioning feature (#640).
+ *
+ * Block partials push their per-scope position rules into this service
+ * while rendering. The `<x-ve-blocks>` / `<x-ve-template>` components
+ * drain it once and emit a single `<style data-ve-position>` block at
+ * the top of the render output — same pattern as
+ * {@see BoxShadowCssAccumulator}.
+ *
+ * Upgrade note: hosts that ran `php artisan vendor:publish
+ * --tag=visual-editor-blade-views` on a pre-1.4 version must republish
+ * with `--force` after upgrading — the published blade files shadow
+ * the package source and pre-1.4 copies don't include the
+ * `<style data-ve-position>` output block, so this accumulator
+ * flushes into the void on the frontend.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditorRendererBlade
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.4.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditorRendererBlade\Services;
+
+class PositionCssAccumulator
+{
+	/**
+	 * Map of scope class → CSS rule string. Keyed so duplicate pushes
+	 * collapse to one entry; PHP arrays preserve insertion order so
+	 * iteration produces deterministic output.
+	 *
+	 * @var array<string, string>
+	 */
+	protected array $rules = [];
+
+	/**
+	 * Adds a rule set for the given scope class. Identical pushes
+	 * (same scope + same rules) dedup — 50 blocks with the same
+	 * position payload emit one rule. When two blocks share a scope
+	 * class but ship DIFFERENT rule bodies (a `_positionScopeId`
+	 * collision from block duplication before the editor's collision
+	 * reclaim runs, or legacy content), keep BOTH entries so neither
+	 * block silently inherits the other's position — CSS cascade
+	 * (last-declaration-wins at equal specificity) picks the winner,
+	 * which beats the previous scope-only dedup that dropped one
+	 * block's rules entirely with no signal.
+	 *
+	 * @since 1.4.0
+	 */
+	public function push( string $scope, string $css ): void
+	{
+		if ( '' === $scope || '' === $css ) {
+			return;
+		}
+
+		$key = $scope . '#' . hash( 'xxh3', $css );
+
+		if ( isset( $this->rules[ $key ] ) ) {
+			return;
+		}
+
+		$this->rules[ $key ] = $css;
+	}
+
+	/**
+	 * Returns the consolidated `<style data-ve-position>` block and
+	 * clears the accumulator.
+	 *
+	 * @since 1.4.0
+	 */
+	public function flush(): string
+	{
+		if ( [] === $this->rules ) {
+			return '';
+		}
+
+		$body        = implode( '', array_values( $this->rules ) );
+		$this->rules = [];
+
+		return '<style data-ve-position>' . $body . '</style>';
+	}
+
+	/**
+	 * Resets the accumulator without emitting. Tests use this to clear
+	 * state between assertions inside a single PHP process.
+	 *
+	 * @since 1.4.0
+	 */
+	public function reset(): void
+	{
+		$this->rules = [];
+	}
+
+	/**
+	 * Inspect what's currently accumulated without draining. Test-only.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @return array<string, string>
+	 */
+	public function all(): array
+	{
+		return $this->rules;
+	}
+}

--- a/packages/visual-editor-renderer-blade/src/Support/BlockSupports.php
+++ b/packages/visual-editor-renderer-blade/src/Support/BlockSupports.php
@@ -51,12 +51,15 @@ use ArtisanPackUI\VisualEditor\BoxShadow\BoxShadowEmitter;
 use ArtisanPackUI\VisualEditor\BoxShadow\BoxShadowResolver;
 use ArtisanPackUI\VisualEditor\GradientBorder\GradientBorderEmitter;
 use ArtisanPackUI\VisualEditor\GradientBorder\GradientBorderResolver;
+use ArtisanPackUI\VisualEditor\Position\PositionEmitter;
+use ArtisanPackUI\VisualEditor\Position\PositionResolver;
 use ArtisanPackUI\VisualEditor\Responsive\BreakpointRegistry;
 use ArtisanPackUI\VisualEditor\States\StateCssEmitter;
 use ArtisanPackUI\VisualEditor\States\StateRegistry;
 use ArtisanPackUI\VisualEditor\States\StateValueResolver;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\BoxShadowCssAccumulator;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\GradientBorderCssAccumulator;
+use ArtisanPackUI\VisualEditorRendererBlade\Services\PositionCssAccumulator;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\ResponsiveCssAccumulator;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\StateCssAccumulator;
 
@@ -92,6 +95,17 @@ class BlockSupports
 	 * arbitrary class names into the wrapper.
 	 */
 	protected const ALIGN_VALUES = [ 'wide', 'full', 'left', 'center', 'right' ];
+
+	/**
+	 * Per-request cache for the position payload produced at the top of
+	 * {@see compile()} so {@see compilePosition()} can reuse it without
+	 * walking the resolver a second time (#640). Not a permanent cache
+	 * — cleared after {@see compilePosition()} reads it so the next
+	 * `compile()` invocation captures its own block's payload.
+	 *
+	 * @var array<string, mixed>|null
+	 */
+	protected static ?array $positionPayloadCache = null;
 
 	/**
 	 * Compile a block's attributes into the wrapper class / style / id
@@ -141,6 +155,23 @@ class BlockSupports
 		// `array_values` flattens the keys for predictable iteration.
 		$classes = array_values( array_unique( array_filter( $classes, static fn ( string $class ): bool => '' !== trim( $class ) ) ) );
 
+		// #640 — resolve the position payload once and thread it through
+		// both the inline-style stamp (below) and compilePosition() (via
+		// self::$positionPayloadCache). The inline stamp runs BEFORE
+		// `$styleString` composition so the base declarations land in
+		// the wrapper's `style` attribute; compilePosition emits the
+		// scoped `<style>` rules for the same payload later. Guard
+		// against `resolve()` returning null so the array offset on
+		// line below doesn't trip a PHP 8 warning for every block that
+		// has no position attributes (the default path).
+		$positionPayload            = PositionResolver::resolve( $attributes );
+		self::$positionPayloadCache = $positionPayload;
+		$positionInlineBase         = self::baseInlinePositionStyle( $positionPayload['base'] ?? null );
+
+		if ( '' !== $positionInlineBase ) {
+			$style[] = $positionInlineBase;
+		}
+
 		$styleString = '' === implode( '', $style ) ? '' : implode( '; ', $style ) . ';';
 
 		$responsive = self::compileResponsive( $attributes );
@@ -180,6 +211,14 @@ class BlockSupports
 			self::pushBoxShadow( $boxShadow['class'], $boxShadow['rules'] );
 		}
 
+		$position = self::compilePosition( $attributes );
+
+		if ( '' !== $position['class'] ) {
+			$classes[] = $position['class'];
+
+			self::pushPosition( $position['class'], $position['rules'] );
+		}
+
 		return [
 			'classes'             => $classes,
 			'style'               => $styleString,
@@ -193,6 +232,8 @@ class BlockSupports
 			'gradientBorderRules' => $gradientBorder['rules'],
 			'boxShadowClass'      => $boxShadow['class'],
 			'boxShadowRules'      => $boxShadow['rules'],
+			'positionClass'       => $position['class'],
+			'positionRules'       => $position['rules'],
 		];
 	}
 
@@ -213,99 +254,119 @@ class BlockSupports
 	}
 
 	/**
-	 * Push a scope's rules into the request-scoped accumulator so the
-	 * consolidated `<style data-ve-responsive>` block at the top of the
-	 * render output picks them up. Called automatically from compile();
-	 * the columns/column partial helpers below call it too for their
-	 * own bespoke rules (columnCount, flex-basis).
+	 * Push a scope's rules into a request-scoped accumulator (#640
+	 * consolidation of the previously copy-pasted per-feature push*
+	 * methods).
+	 *
+	 * Container-not-booted paths (very-early call sites, unit tests
+	 * that exercise BlockSupports without the package service
+	 * provider) silently drop — the call is idempotent and the
+	 * accumulator is a side channel, not the data path.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @param  class-string  $accumulator  Fully-qualified accumulator class.
+	 */
+	/**
+	 * Compose a `ve-<prefix>-<id>` scope class from an
+	 * editor-minted id or a content-derived hash fallback (#640
+	 * consolidation of the previously copy-pasted per-feature
+	 * `resolve*ScopeClass` helpers).
+	 *
+	 * The editor-minted id has to pass a strict allowlist regex + a
+	 * length cap — it lands unescaped in the wrapper's `class`
+	 * attribute, so its content has to be a safe identifier-style
+	 * token.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @param  string                $prefix      Class prefix without the trailing dash (e.g. `ve-bs`).
+	 * @param  string|null           $candidate   Editor-minted id or null.
+	 * @param  array<string, mixed>  $payload     Fallback hash source when the candidate is absent or invalid.
+	 */
+	protected static function composeScopeClass( string $prefix, ?string $candidate, array $payload ): string
+	{
+		if ( is_string( $candidate ) && 1 === preg_match( '/^[a-z0-9][a-z0-9_-]*$/i', $candidate ) && strlen( $candidate ) <= 64 ) {
+			return $prefix . '-' . $candidate;
+		}
+
+		$hash = substr(
+			hash( 'xxh3', (string) json_encode( $payload ) ),
+			0,
+			10
+		);
+
+		return $prefix . '-' . $hash;
+	}
+
+	protected static function pushToAccumulator( string $accumulator, string $scope, string $rules ): void
+	{
+		if ( '' === $scope || '' === $rules ) {
+			return;
+		}
+
+		if ( ! function_exists( 'app' ) ) {
+			return;
+		}
+
+		try {
+			app( $accumulator )->push( $scope, $rules );
+		} catch ( \Throwable $e ) {
+			// Silently drop — see method docblock.
+		}
+	}
+
+	/**
+	 * Push responsive CSS rules into the per-request accumulator.
+	 * Called automatically from {@see compile}; the columns/column
+	 * partial helpers below call it too for their own bespoke rules
+	 * (columnCount, flex-basis).
 	 *
 	 * @since 1.0.0
 	 */
 	public static function pushResponsive( string $scope, string $rules ): void
 	{
-		if ( '' === $scope || '' === $rules ) {
-			return;
-		}
-
-		if ( ! function_exists( 'app' ) ) {
-			return;
-		}
-
-		try {
-			app( ResponsiveCssAccumulator::class )->push( $scope, $rules );
-		} catch ( \Throwable $e ) {
-			// Container not booted (very-early call path or a unit
-			// test that exercises BlockSupports without the package
-			// service provider). Silently drop — the call is
-			// idempotent and the accumulator is the side channel,
-			// not the data path.
-		}
+		self::pushToAccumulator( ResponsiveCssAccumulator::class, $scope, $rules );
 	}
 
 	/**
-	 * Mirror of {@see pushResponsive} for state design tools (#488).
+	 * Push state design tool CSS rules into the per-request accumulator (#488).
 	 *
 	 * @since 1.0.0
 	 */
 	public static function pushStates( string $scope, string $rules ): void
 	{
-		if ( '' === $scope || '' === $rules ) {
-			return;
-		}
-
-		if ( ! function_exists( 'app' ) ) {
-			return;
-		}
-
-		try {
-			app( StateCssAccumulator::class )->push( $scope, $rules );
-		} catch ( \Throwable $e ) {
-			// See pushResponsive() — same drop-silently rationale.
-		}
+		self::pushToAccumulator( StateCssAccumulator::class, $scope, $rules );
 	}
 
 	/**
-	 * Mirror of {@see pushResponsive} for gradient borders (#490).
+	 * Push gradient border CSS rules into the per-request accumulator (#490).
 	 *
 	 * @since 1.1.0
 	 */
 	public static function pushGradientBorder( string $scope, string $rules ): void
 	{
-		if ( '' === $scope || '' === $rules ) {
-			return;
-		}
-
-		if ( ! function_exists( 'app' ) ) {
-			return;
-		}
-
-		try {
-			app( GradientBorderCssAccumulator::class )->push( $scope, $rules );
-		} catch ( \Throwable $e ) {
-			// See pushResponsive() — same drop-silently rationale.
-		}
+		self::pushToAccumulator( GradientBorderCssAccumulator::class, $scope, $rules );
 	}
 
 	/**
-	 * Mirror of {@see pushResponsive} for box shadows (#607).
+	 * Push box shadow CSS rules into the per-request accumulator (#607).
 	 *
 	 * @since 1.2.0
 	 */
 	public static function pushBoxShadow( string $scope, string $rules ): void
 	{
-		if ( '' === $scope || '' === $rules ) {
-			return;
-		}
+		self::pushToAccumulator( BoxShadowCssAccumulator::class, $scope, $rules );
+	}
 
-		if ( ! function_exists( 'app' ) ) {
-			return;
-		}
-
-		try {
-			app( BoxShadowCssAccumulator::class )->push( $scope, $rules );
-		} catch ( \Throwable $e ) {
-			// See pushResponsive() — same drop-silently rationale.
-		}
+	/**
+	 * Push CSS position rules into the per-request accumulator (#640).
+	 *
+	 * @since 1.4.0
+	 */
+	public static function pushPosition( string $scope, string $rules ): void
+	{
+		self::pushToAccumulator( PositionCssAccumulator::class, $scope, $rules );
 	}
 
 	/**
@@ -912,23 +973,12 @@ class BlockSupports
 	 */
 	protected static function resolveGradientBorderScopeClass( array $attributes, array $payload ): string
 	{
-		$border = $attributes['style']['border'] ?? null;
+		$border    = $attributes['style']['border'] ?? null;
+		$candidate = is_array( $border ) && isset( $border['_gradientScopeId'] ) && is_string( $border['_gradientScopeId'] )
+			? $border['_gradientScopeId']
+			: null;
 
-		if ( is_array( $border ) && isset( $border['_gradientScopeId'] ) && is_string( $border['_gradientScopeId'] ) ) {
-			$candidate = $border['_gradientScopeId'];
-
-			if ( 1 === preg_match( '/^[a-z0-9][a-z0-9_-]*$/i', $candidate ) && strlen( $candidate ) <= 64 ) {
-				return 've-gb-' . $candidate;
-			}
-		}
-
-		$hash = substr(
-			hash( 'xxh3', (string) json_encode( $payload ) ),
-			0,
-			10
-		);
-
-		return 've-gb-' . $hash;
+		return self::composeScopeClass( 've-gb', $candidate, $payload );
 	}
 
 	/**
@@ -992,23 +1042,135 @@ class BlockSupports
 	 */
 	protected static function resolveBoxShadowScopeClass( array $attributes, array $payload ): string
 	{
-		$shadow = $attributes['style']['shadow'] ?? null;
+		$shadow    = $attributes['style']['shadow'] ?? null;
+		$candidate = is_array( $shadow ) && isset( $shadow['_shadowScopeId'] ) && is_string( $shadow['_shadowScopeId'] )
+			? $shadow['_shadowScopeId']
+			: null;
 
-		if ( is_array( $shadow ) && isset( $shadow['_shadowScopeId'] ) && is_string( $shadow['_shadowScopeId'] ) ) {
-			$candidate = $shadow['_shadowScopeId'];
+		return self::composeScopeClass( 've-bs', $candidate, $payload );
+	}
 
-			if ( 1 === preg_match( '/^[a-z0-9][a-z0-9_-]*$/i', $candidate ) && strlen( $candidate ) <= 64 ) {
-				return 've-bs-' . $candidate;
-			}
+	/**
+	 * Compile the CSS positioning payload into a `{class, rules}` pair
+	 * that {@see compile} merges into the wrapper class list and pushes
+	 * into the per-request {@see PositionCssAccumulator} (#640).
+	 *
+	 * @since 1.4.0
+	 *
+	 * @param  array<string, mixed>  $attributes
+	 *
+	 * @return array{class: string, rules: string}
+	 */
+	protected static function compilePosition( array $attributes ): array
+	{
+		// Prefer the payload cached at the top of compile() (#640) so a
+		// single resolver walk feeds both the inline stamp and the
+		// scoped `<style>` rules. Fall back to a fresh resolve when
+		// called from a code path that didn't seed the cache (tests,
+		// direct callers).
+		$payload = self::$positionPayloadCache ?? PositionResolver::resolve( $attributes );
+		self::$positionPayloadCache = null;
+
+		if ( null === $payload ) {
+			return [ 'class' => '', 'rules' => '' ];
 		}
 
-		$hash = substr(
-			hash( 'xxh3', (string) json_encode( $payload ) ),
-			0,
-			10
-		);
+		try {
+			$breakpoints = function_exists( 'app' )
+				? self::resolveRegistry()
+				: BreakpointRegistry::fromLayers();
 
-		return 've-bs-' . $hash;
+			$emitter = new PositionEmitter( $breakpoints );
+
+			$scopeClass = self::resolvePositionScopeClass( $attributes, $payload );
+			$scope      = '.' . $scopeClass;
+			$css        = $emitter->emit( $scope, $payload );
+
+			if ( '' === $css ) {
+				return [ 'class' => '', 'rules' => '' ];
+			}
+
+			return [
+				'class' => $scopeClass,
+				'rules' => $css,
+			];
+		} catch ( \Throwable $e ) {
+			return [ 'class' => '', 'rules' => '' ];
+		}
+	}
+
+	/**
+	 * Build the semicolon-joined declaration list for the base layer.
+	 * Skips a `static` value (matches emitter semantics — no CSS while
+	 * static). Returns an empty string when the layer contributes
+	 * nothing.
+	 *
+	 * @param  array<string, mixed>|null  $base
+	 */
+	protected static function baseInlinePositionStyle( ?array $base ): string
+	{
+		if ( null === $base ) {
+			return '';
+		}
+
+		$value = $base['value'] ?? null;
+		if ( null === $value || 'static' === $value ) {
+			return '';
+		}
+
+		// `!important` mirrors PositionEmitter's scoped rules so the
+		// inline stamp survives theme resets that use `!important` on
+		// wrapper classes (e.g. `.wp-block-cover { position: relative
+		// !important }`). Without it, the inline fallback loses in
+		// exactly the sanitizer scenario it was added for.
+		$parts = [ 'position: ' . $value . ' !important' ];
+
+		$offsets = $base['offsets'] ?? [];
+		foreach ( [ 'top', 'right', 'bottom', 'left' ] as $side ) {
+			$offset = $offsets[ $side ] ?? null;
+			if ( null === $offset || ! is_array( $offset ) ) {
+				continue;
+			}
+
+			$unit = $offset['unit'] ?? '';
+			if ( 'auto' === $unit ) {
+				$parts[] = $side . ': auto !important';
+				continue;
+			}
+
+			$offsetValue = $offset['value'] ?? null;
+			if ( ! is_int( $offsetValue ) && ! is_float( $offsetValue ) ) {
+				continue;
+			}
+
+			$parts[] = $side . ': ' . $offsetValue . $unit . ' !important';
+		}
+
+		if ( isset( $base['zIndex'] ) && null !== $base['zIndex'] ) {
+			$parts[] = 'z-index: ' . (int) $base['zIndex'] . ' !important';
+		}
+
+		return implode( '; ', $parts );
+	}
+
+	/**
+	 * Prefer the editor-minted `style.position._positionScopeId` so the
+	 * editor preview and the server-rendered output target the same
+	 * scope class. Falls back to a content-derived hash otherwise.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @param  array<string, mixed>  $attributes
+	 * @param  array<string, mixed>  $payload
+	 */
+	protected static function resolvePositionScopeClass( array $attributes, array $payload ): string
+	{
+		$position  = $attributes['style']['position'] ?? null;
+		$candidate = is_array( $position ) && isset( $position['_positionScopeId'] ) && is_string( $position['_positionScopeId'] )
+			? $position['_positionScopeId']
+			: null;
+
+		return self::composeScopeClass( 've-pos', $candidate, $payload );
 	}
 
 	/**

--- a/packages/visual-editor-renderer-blade/src/View/Components/BlocksComponent.php
+++ b/packages/visual-editor-renderer-blade/src/View/Components/BlocksComponent.php
@@ -37,6 +37,7 @@ use ArtisanPackUI\VisualEditorRendererBlade\Services\AnimationCssAccumulator;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\GlobalStylesEmissionResolver;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\BoxShadowCssAccumulator;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\GradientBorderCssAccumulator;
+use ArtisanPackUI\VisualEditorRendererBlade\Services\PositionCssAccumulator;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\ResponsiveCssAccumulator;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\StateCssAccumulator;
 use Illuminate\Contracts\View\View;
@@ -83,9 +84,14 @@ class BlocksComponent extends Component
 		bool $resolveBreadcrumbs = true,
 		bool $resolveNavigation = true,
 		protected ?BoxShadowCssAccumulator $boxShadowAccumulator = null,
+		protected ?PositionCssAccumulator $positionAccumulator = null,
 	) {
 		if ( null === $this->boxShadowAccumulator ) {
 			$this->boxShadowAccumulator = app( BoxShadowCssAccumulator::class );
+		}
+
+		if ( null === $this->positionAccumulator ) {
+			$this->positionAccumulator = app( PositionCssAccumulator::class );
 		}
 
 		$this->defaultTheme = $defaultTheme;
@@ -173,6 +179,7 @@ class BlocksComponent extends Component
 		$animationOutput    = $this->animationAccumulator->flush();
 		$gradientBordersCss = $this->gradientBorderAccumulator->flush();
 		$boxShadowsCss      = $this->boxShadowAccumulator->flush();
+		$positionCss        = $this->positionAccumulator->flush();
 
 		return view( 'visual-editor-renderer-blade::components.blocks', [
 			'html'                    => $html,
@@ -184,6 +191,7 @@ class BlocksComponent extends Component
 			'animationsRuntimeNeeded' => $animationOutput['runtimeNeeded'],
 			'gradientBordersCss'      => $gradientBordersCss,
 			'boxShadowsCss'           => $boxShadowsCss,
+			'positionCss'             => $positionCss,
 		] );
 	}
 

--- a/packages/visual-editor-renderer-blade/src/View/Components/TemplateComponent.php
+++ b/packages/visual-editor-renderer-blade/src/View/Components/TemplateComponent.php
@@ -38,6 +38,7 @@ use ArtisanPackUI\VisualEditorRendererBlade\Services\AnimationCssAccumulator;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\GlobalStylesEmissionResolver;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\BoxShadowCssAccumulator;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\GradientBorderCssAccumulator;
+use ArtisanPackUI\VisualEditorRendererBlade\Services\PositionCssAccumulator;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\ResponsiveCssAccumulator;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\StateCssAccumulator;
 use Illuminate\Contracts\Foundation\Application;
@@ -84,9 +85,14 @@ class TemplateComponent extends Component
 		string $slug,
 		?string $theme = null,
 		protected ?BoxShadowCssAccumulator $boxShadowAccumulator = null,
+		protected ?PositionCssAccumulator $positionAccumulator = null,
 	) {
 		if ( null === $this->boxShadowAccumulator ) {
 			$this->boxShadowAccumulator = $this->app->make( BoxShadowCssAccumulator::class );
+		}
+
+		if ( null === $this->positionAccumulator ) {
+			$this->positionAccumulator = $this->app->make( PositionCssAccumulator::class );
 		}
 
 		$this->slug          = $slug;
@@ -130,6 +136,7 @@ class TemplateComponent extends Component
 		$animationOutput    = $this->animationAccumulator->flush();
 		$gradientBordersCss = $this->gradientBorderAccumulator->flush();
 		$boxShadowsCss      = $this->boxShadowAccumulator->flush();
+		$positionCss        = $this->positionAccumulator->flush();
 
 		return view( 'visual-editor-renderer-blade::components.template', [
 			'slug'                    => $this->slug,
@@ -147,6 +154,7 @@ class TemplateComponent extends Component
 			'animationsRuntimeNeeded' => $animationOutput['runtimeNeeded'],
 			'gradientBordersCss'      => $gradientBordersCss,
 			'boxShadowsCss'           => $boxShadowsCss,
+			'positionCss'             => $positionCss,
 		] );
 	}
 

--- a/packages/visual-editor-renderer-blade/src/VisualEditorRendererBladeServiceProvider.php
+++ b/packages/visual-editor-renderer-blade/src/VisualEditorRendererBladeServiceProvider.php
@@ -34,6 +34,7 @@ use ArtisanPackUI\VisualEditorRendererBlade\Services\AnimationCssAccumulator;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\GlobalStylesEmissionResolver;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\BoxShadowCssAccumulator;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\GradientBorderCssAccumulator;
+use ArtisanPackUI\VisualEditorRendererBlade\Services\PositionCssAccumulator;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\NavigationOverlayTracker;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\ResponsiveCssAccumulator;
 use ArtisanPackUI\VisualEditorRendererBlade\Services\StateCssAccumulator;
@@ -171,6 +172,12 @@ class VisualEditorRendererBladeServiceProvider extends ServiceProvider
 		// shadow installs.
 		$this->app->scoped( BoxShadowCssAccumulator::class, function () {
 			return new BoxShadowCssAccumulator();
+		} );
+
+		// #640 — sibling accumulator for the CSS positioning feature's
+		// `<style data-ve-position>` block.
+		$this->app->scoped( PositionCssAccumulator::class, function () {
+			return new PositionCssAccumulator();
 		} );
 	}
 

--- a/packages/visual-editor-renderer-blade/tests/Unit/BlockSupportsTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Unit/BlockSupportsTest.php
@@ -495,6 +495,8 @@ describe( 'BlockSupports::compile (composition)', function (): void {
 			'gradientBorderRules' => '',
 			'boxShadowClass'      => '',
 			'boxShadowRules'      => '',
+			'positionClass'       => '',
+			'positionRules'       => '',
 		] );
 	} );
 
@@ -598,5 +600,50 @@ describe( 'compile() — state design tools (#488)', function (): void {
 
 		expect( $result['statesRules'] )->toContain( 'background-color: #abc123 !important;' );
 		expect( $result['statesRules'] )->toContain( 'background-color: #fff !important;' );
+	} );
+} );
+
+describe( 'compile() — CSS position (#640)', function (): void {
+	it( 'stamps a ve-pos-* scope class and the base declarations as inline styles', function (): void {
+		$result = BlockSupports::compile( [
+			'style' => [
+				'position' => [
+					'value'   => 'sticky',
+					'offsets' => [ 'top' => [ 'value' => 0, 'unit' => 'px' ] ],
+					'_positionScopeId' => 'abc1234',
+				],
+			],
+		] );
+
+		expect( $result['positionClass'] )->toBe( 've-pos-abc1234' );
+		expect( $result['classes'] )->toContain( 've-pos-abc1234' );
+		expect( $result['positionRules'] )->toContain( 'position:sticky !important' );
+		expect( $result['positionRules'] )->toContain( 'top:0px !important' );
+		// Base layer also stamps as inline style so hosts that strip
+		// the accumulated `<style data-ve-position>` on frontend render
+		// still get the wrapper's sticky behaviour. `!important`
+		// mirrors the emitter's scoped rule so the inline fallback
+		// survives theme resets that use `!important`.
+		expect( $result['style'] )->toContain( 'position: sticky !important' );
+		expect( $result['style'] )->toContain( 'top: 0px !important' );
+	} );
+
+	it( 'emits nothing when the base value is static (offsets preserved but silent)', function (): void {
+		$result = BlockSupports::compile( [
+			'style' => [ 'position' => [ 'value' => 'static' ] ],
+		] );
+
+		expect( $result['positionClass'] )->toBe( '' );
+		expect( $result['positionRules'] )->toBe( '' );
+		expect( $result['style'] )->toBe( '' );
+	} );
+
+	it( 'widens a legacy sticky string to inline styles + scope class', function (): void {
+		$result = BlockSupports::compile( [
+			'style' => [ 'position' => 'sticky' ],
+		] );
+
+		expect( $result['style'] )->toContain( 'position: sticky !important' );
+		expect( $result['positionRules'] )->toContain( 'position:sticky !important' );
 	} );
 } );

--- a/packages/visual-editor-renderer-blade/tests/Unit/PositionCssAccumulatorTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Unit/PositionCssAccumulatorTest.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * Unit tests for {@see PositionCssAccumulator} (#640).
+ *
+ * @since 1.4.0
+ */
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditorRendererBlade\Services\PositionCssAccumulator;
+
+describe( 'PositionCssAccumulator', function (): void {
+	it( 'dedupes identical (scope, rules) pushes', function (): void {
+		$accumulator = new PositionCssAccumulator();
+		$accumulator->push( '.ve-pos-abc', '.ve-pos-abc{position:sticky !important}' );
+		$accumulator->push( '.ve-pos-abc', '.ve-pos-abc{position:sticky !important}' );
+
+		$flushed = $accumulator->flush();
+		// One occurrence of the rule inside a single `<style data-ve-position>` block.
+		expect( substr_count( $flushed, 'position:sticky !important' ) )->toBe( 1 );
+	} );
+
+	it( 'keeps BOTH entries when the same scope arrives with different rules', function (): void {
+		// Regression: prior scope-only keying dropped the second push
+		// entirely, so a `_positionScopeId` collision (paste races,
+		// legacy content) made one block silently inherit the other's
+		// position. Now both entries emit; CSS cascade decides.
+		$accumulator = new PositionCssAccumulator();
+		$accumulator->push( '.ve-pos-abc', '.ve-pos-abc{position:sticky !important}' );
+		$accumulator->push( '.ve-pos-abc', '.ve-pos-abc{position:absolute !important}' );
+
+		$flushed = $accumulator->flush();
+		expect( $flushed )->toContain( 'position:sticky !important' );
+		expect( $flushed )->toContain( 'position:absolute !important' );
+	} );
+
+	it( 'drops empty scope or empty rules silently', function (): void {
+		$accumulator = new PositionCssAccumulator();
+		$accumulator->push( '', 'something' );
+		$accumulator->push( '.ve-pos-x', '' );
+
+		expect( $accumulator->flush() )->toBe( '' );
+	} );
+
+	it( 'clears state on flush', function (): void {
+		$accumulator = new PositionCssAccumulator();
+		$accumulator->push( '.ve-pos-x', '.ve-pos-x{position:sticky}' );
+		expect( $accumulator->flush() )->not->toBe( '' );
+		expect( $accumulator->flush() )->toBe( '' );
+	} );
+} );

--- a/resources/js/visual-editor/blocks/accordions/block.json
+++ b/resources/js/visual-editor/blocks/accordions/block.json
@@ -14,6 +14,7 @@
     "textdomain": "artisanpack-visual-editor",
     "attributes": {},
     "supports": {
+        "position": true,
         "artisanpackAnimations": true,
         "align": [
             "wide",

--- a/resources/js/visual-editor/blocks/archives/block.json
+++ b/resources/js/visual-editor/blocks/archives/block.json
@@ -25,6 +25,7 @@
         }
     },
     "supports": {
+        "position": true,
         "artisanpackAnimations": true,
         "anchor": true,
         "align": true,

--- a/resources/js/visual-editor/blocks/audio/block.json
+++ b/resources/js/visual-editor/blocks/audio/block.json
@@ -5,7 +5,12 @@
     "title": "Audio",
     "category": "media",
     "description": "Embed a simple audio player.",
-    "keywords": [ "music", "sound", "podcast", "recording" ],
+    "keywords": [
+        "music",
+        "sound",
+        "podcast",
+        "recording"
+    ],
     "textdomain": "artisanpack-visual-editor",
     "attributes": {
         "blob": {
@@ -49,6 +54,7 @@
         }
     },
     "supports": {
+        "position": true,
         "artisanpackAnimations": true,
         "anchor": true,
         "align": true,

--- a/resources/js/visual-editor/blocks/audio/block.json
+++ b/resources/js/visual-editor/blocks/audio/block.json
@@ -5,12 +5,7 @@
     "title": "Audio",
     "category": "media",
     "description": "Embed a simple audio player.",
-    "keywords": [
-        "music",
-        "sound",
-        "podcast",
-        "recording"
-    ],
+    "keywords": [ "music", "sound", "podcast", "recording" ],
     "textdomain": "artisanpack-visual-editor",
     "attributes": {
         "blob": {

--- a/resources/js/visual-editor/blocks/author-social-icons/block.json
+++ b/resources/js/visual-editor/blocks/author-social-icons/block.json
@@ -5,12 +5,7 @@
     "title": "Author Social Icons",
     "category": "theme",
     "description": "Display the author's social media links as icons.",
-    "keywords": [
-        "author",
-        "social",
-        "icons",
-        "links"
-    ],
+    "keywords": ["author", "social", "icons", "links"],
     "textdomain": "artisanpack-visual-editor",
     "attributes": {
         "socialIcons": {
@@ -19,27 +14,17 @@
         },
         "iconStyle": {
             "type": "string",
-            "enum": [
-                "show-label-icon",
-                "show-icon",
-                "show-label"
-            ],
+            "enum": ["show-label-icon", "show-icon", "show-label"],
             "default": "show-label-icon"
         },
         "iconsDirection": {
             "type": "string",
-            "enum": [
-                "horizontal",
-                "vertical"
-            ],
+            "enum": ["horizontal", "vertical"],
             "default": "vertical"
         },
         "iconsStretch": {
             "type": "string",
-            "enum": [
-                "full-width",
-                "auto-width"
-            ],
+            "enum": ["full-width", "auto-width"],
             "default": "full-width"
         },
         "iconsBorderRadius": {
@@ -67,10 +52,7 @@
         "position": true,
         "artisanpackAnimations": true,
         "anchor": true,
-        "align": [
-            "wide",
-            "full"
-        ],
+        "align": ["wide", "full"],
         "ariaLabel": true,
         "className": true,
         "html": false,
@@ -83,10 +65,7 @@
             }
         },
         "spacing": {
-            "margin": [
-                "top",
-                "bottom"
-            ],
+            "margin": ["top", "bottom"],
             "padding": true,
             "blockGap": true,
             "__experimentalDefaultControls": {

--- a/resources/js/visual-editor/blocks/author-social-icons/block.json
+++ b/resources/js/visual-editor/blocks/author-social-icons/block.json
@@ -5,7 +5,12 @@
     "title": "Author Social Icons",
     "category": "theme",
     "description": "Display the author's social media links as icons.",
-    "keywords": ["author", "social", "icons", "links"],
+    "keywords": [
+        "author",
+        "social",
+        "icons",
+        "links"
+    ],
     "textdomain": "artisanpack-visual-editor",
     "attributes": {
         "socialIcons": {
@@ -14,17 +19,27 @@
         },
         "iconStyle": {
             "type": "string",
-            "enum": ["show-label-icon", "show-icon", "show-label"],
+            "enum": [
+                "show-label-icon",
+                "show-icon",
+                "show-label"
+            ],
             "default": "show-label-icon"
         },
         "iconsDirection": {
             "type": "string",
-            "enum": ["horizontal", "vertical"],
+            "enum": [
+                "horizontal",
+                "vertical"
+            ],
             "default": "vertical"
         },
         "iconsStretch": {
             "type": "string",
-            "enum": ["full-width", "auto-width"],
+            "enum": [
+                "full-width",
+                "auto-width"
+            ],
             "default": "full-width"
         },
         "iconsBorderRadius": {
@@ -49,9 +64,13 @@
         }
     },
     "supports": {
+        "position": true,
         "artisanpackAnimations": true,
         "anchor": true,
-        "align": ["wide", "full"],
+        "align": [
+            "wide",
+            "full"
+        ],
         "ariaLabel": true,
         "className": true,
         "html": false,
@@ -64,7 +83,10 @@
             }
         },
         "spacing": {
-            "margin": ["top", "bottom"],
+            "margin": [
+                "top",
+                "bottom"
+            ],
             "padding": true,
             "blockGap": true,
             "__experimentalDefaultControls": {

--- a/resources/js/visual-editor/blocks/avatar/block.json
+++ b/resources/js/visual-editor/blocks/avatar/block.json
@@ -31,6 +31,7 @@
         "artisanpack/postPreview"
     ],
     "supports": {
+        "position": true,
         "artisanpackAnimations": true,
         "anchor": true,
         "html": false,

--- a/resources/js/visual-editor/blocks/breadcrumbs/block.json
+++ b/resources/js/visual-editor/blocks/breadcrumbs/block.json
@@ -28,6 +28,7 @@
         }
     },
     "supports": {
+        "position": true,
         "artisanpackAnimations": true,
         "align": [
             "wide",

--- a/resources/js/visual-editor/blocks/buttons/block.json
+++ b/resources/js/visual-editor/blocks/buttons/block.json
@@ -13,6 +13,7 @@
     ],
     "textdomain": "artisanpack-visual-editor",
     "supports": {
+        "position": true,
         "artisanpackAnimations": true,
         "anchor": true,
         "align": [

--- a/resources/js/visual-editor/blocks/callout/block.json
+++ b/resources/js/visual-editor/blocks/callout/block.json
@@ -5,33 +5,17 @@
     "title": "Callout",
     "category": "design",
     "description": "Highlight a short message with a severity badge and icon.",
-    "keywords": [
-        "callout",
-        "notice",
-        "alert",
-        "tip"
-    ],
+    "keywords": ["callout", "notice", "alert", "tip"],
     "textdomain": "artisanpack-visual-editor",
     "attributes": {
         "severity": {
             "type": "string",
-            "enum": [
-                "info",
-                "success",
-                "warning",
-                "error"
-            ],
+            "enum": ["info", "success", "warning", "error"],
             "default": "info"
         },
         "icon": {
             "type": "string",
-            "enum": [
-                "info",
-                "check",
-                "warning",
-                "error",
-                "lightbulb"
-            ],
+            "enum": ["info", "check", "warning", "error", "lightbulb"],
             "default": "info"
         },
         "content": {

--- a/resources/js/visual-editor/blocks/callout/block.json
+++ b/resources/js/visual-editor/blocks/callout/block.json
@@ -5,17 +5,33 @@
     "title": "Callout",
     "category": "design",
     "description": "Highlight a short message with a severity badge and icon.",
-    "keywords": ["callout", "notice", "alert", "tip"],
+    "keywords": [
+        "callout",
+        "notice",
+        "alert",
+        "tip"
+    ],
     "textdomain": "artisanpack-visual-editor",
     "attributes": {
         "severity": {
             "type": "string",
-            "enum": ["info", "success", "warning", "error"],
+            "enum": [
+                "info",
+                "success",
+                "warning",
+                "error"
+            ],
             "default": "info"
         },
         "icon": {
             "type": "string",
-            "enum": ["info", "check", "warning", "error", "lightbulb"],
+            "enum": [
+                "info",
+                "check",
+                "warning",
+                "error",
+                "lightbulb"
+            ],
             "default": "info"
         },
         "content": {
@@ -26,6 +42,7 @@
         }
     },
     "supports": {
+        "position": true,
         "artisanpackAnimations": true,
         "className": true,
         "html": false

--- a/resources/js/visual-editor/blocks/categories/block.json
+++ b/resources/js/visual-editor/blocks/categories/block.json
@@ -47,6 +47,7 @@
         "enhancedPagination"
     ],
     "supports": {
+        "position": true,
         "artisanpackAnimations": true,
         "anchor": true,
         "align": true,

--- a/resources/js/visual-editor/blocks/code/block.json
+++ b/resources/js/visual-editor/blocks/code/block.json
@@ -16,6 +16,7 @@
         }
     },
     "supports": {
+        "position": true,
         "artisanpackAnimations": true,
         "align": [
             "wide"

--- a/resources/js/visual-editor/blocks/columns/block.json
+++ b/resources/js/visual-editor/blocks/columns/block.json
@@ -42,6 +42,7 @@
         }
     },
     "supports": {
+        "position": true,
         "artisanpackAnimations": true,
         "anchor": true,
         "align": [

--- a/resources/js/visual-editor/blocks/comment-author-avatar/block.json
+++ b/resources/js/visual-editor/blocks/comment-author-avatar/block.json
@@ -20,6 +20,7 @@
         "artisanpack/commentPreview"
     ],
     "supports": {
+        "position": true,
         "html": false,
         "inserter": false,
         "interactivity": {

--- a/resources/js/visual-editor/blocks/comment-author-name/block.json
+++ b/resources/js/visual-editor/blocks/comment-author-name/block.json
@@ -25,6 +25,7 @@
         "viewportWidth": 300
     },
     "supports": {
+        "position": true,
         "html": false,
         "spacing": {
             "margin": true,

--- a/resources/js/visual-editor/blocks/comment-content/block.json
+++ b/resources/js/visual-editor/blocks/comment-content/block.json
@@ -20,6 +20,7 @@
         "viewportWidth": 300
     },
     "supports": {
+        "position": true,
         "html": false,
         "color": {
             "gradients": true,

--- a/resources/js/visual-editor/blocks/comment-date/block.json
+++ b/resources/js/visual-editor/blocks/comment-date/block.json
@@ -24,6 +24,7 @@
         "viewportWidth": 300
     },
     "supports": {
+        "position": true,
         "html": false,
         "color": {
             "gradients": true,

--- a/resources/js/visual-editor/blocks/comment-edit-link/block.json
+++ b/resources/js/visual-editor/blocks/comment-edit-link/block.json
@@ -24,6 +24,7 @@
         "viewportWidth": 300
     },
     "supports": {
+        "position": true,
         "html": false,
         "color": {
             "link": true,

--- a/resources/js/visual-editor/blocks/comment-reply-link/block.json
+++ b/resources/js/visual-editor/blocks/comment-reply-link/block.json
@@ -20,6 +20,7 @@
         "viewportWidth": 300
     },
     "supports": {
+        "position": true,
         "color": {
             "gradients": true,
             "link": true,

--- a/resources/js/visual-editor/blocks/comments-number/block.json
+++ b/resources/js/visual-editor/blocks/comments-number/block.json
@@ -26,6 +26,7 @@
         }
     },
     "supports": {
+        "position": true,
         "artisanpackAnimations": true,
         "align": [
             "wide",

--- a/resources/js/visual-editor/blocks/comments-pagination/block.json
+++ b/resources/js/visual-editor/blocks/comments-pagination/block.json
@@ -16,6 +16,7 @@
         "comments/paginationArrow": "paginationArrow"
     },
     "supports": {
+        "position": true,
         "align": true,
         "reusable": false,
         "html": false,

--- a/resources/js/visual-editor/blocks/comments/block.json
+++ b/resources/js/visual-editor/blocks/comments/block.json
@@ -25,6 +25,7 @@
         "postType"
     ],
     "supports": {
+        "position": true,
         "artisanpackAnimations": true,
         "anchor": true,
         "align": [

--- a/resources/js/visual-editor/blocks/copyright/block.json
+++ b/resources/js/visual-editor/blocks/copyright/block.json
@@ -27,6 +27,7 @@
         }
     },
     "supports": {
+        "position": true,
         "artisanpackAnimations": true,
         "align": [
             "wide",

--- a/resources/js/visual-editor/blocks/cover/block.json
+++ b/resources/js/visual-editor/blocks/cover/block.json
@@ -100,6 +100,7 @@
         "postType"
     ],
     "supports": {
+        "position": true,
         "anchor": true,
         "align": true,
         "html": false,

--- a/resources/js/visual-editor/blocks/details/block.json
+++ b/resources/js/visual-editor/blocks/details/block.json
@@ -33,6 +33,7 @@
         }
     },
     "supports": {
+        "position": true,
         "artisanpackAnimations": true,
         "__experimentalOnEnter": true,
         "align": [

--- a/resources/js/visual-editor/blocks/embed/block.json
+++ b/resources/js/visual-editor/blocks/embed/block.json
@@ -41,6 +41,7 @@
         }
     },
     "supports": {
+        "position": true,
         "artisanpackAnimations": true,
         "anchor": true,
         "align": true,

--- a/resources/js/visual-editor/blocks/file/block.json
+++ b/resources/js/visual-editor/blocks/file/block.json
@@ -67,6 +67,7 @@
         }
     },
     "supports": {
+        "position": true,
         "artisanpackAnimations": true,
         "anchor": true,
         "align": true,

--- a/resources/js/visual-editor/blocks/form/block.json
+++ b/resources/js/visual-editor/blocks/form/block.json
@@ -19,6 +19,7 @@
         }
     },
     "supports": {
+        "position": true,
         "artisanpackAnimations": true,
         "className": true,
         "html": false,

--- a/resources/js/visual-editor/blocks/gallery/block.json
+++ b/resources/js/visual-editor/blocks/gallery/block.json
@@ -127,6 +127,7 @@
         }
     },
     "supports": {
+        "position": true,
         "artisanpackAnimations": true,
         "anchor": true,
         "align": true,

--- a/resources/js/visual-editor/blocks/grid/block.json
+++ b/resources/js/visual-editor/blocks/grid/block.json
@@ -34,6 +34,7 @@
         "artisanpack/gridLayoutMode": "layoutMode"
     },
     "supports": {
+        "position": true,
         "artisanpackAnimations": true,
         "anchor": true,
         "align": [

--- a/resources/js/visual-editor/blocks/heading/block.json
+++ b/resources/js/visual-editor/blocks/heading/block.json
@@ -29,6 +29,7 @@
         }
     },
     "supports": {
+        "position": true,
         "artisanpackAnimations": true,
         "align": [
             "wide",

--- a/resources/js/visual-editor/blocks/icon/block.json
+++ b/resources/js/visual-editor/blocks/icon/block.json
@@ -136,6 +136,7 @@
         }
     },
     "supports": {
+        "position": true,
         "artisanpackAnimations": true,
         "anchor": true,
         "align": [

--- a/resources/js/visual-editor/blocks/image/block.json
+++ b/resources/js/visual-editor/blocks/image/block.json
@@ -112,6 +112,7 @@
         }
     },
     "supports": {
+        "position": true,
         "interactivity": true,
         "align": [
             "left",

--- a/resources/js/visual-editor/blocks/latest-posts/block.json
+++ b/resources/js/visual-editor/blocks/latest-posts/block.json
@@ -89,6 +89,7 @@
         }
     },
     "supports": {
+        "position": true,
         "artisanpackAnimations": true,
         "anchor": true,
         "align": true,

--- a/resources/js/visual-editor/blocks/list/block.json
+++ b/resources/js/visual-editor/blocks/list/block.json
@@ -42,6 +42,7 @@
         }
     },
     "supports": {
+        "position": true,
         "artisanpackAnimations": true,
         "anchor": true,
         "html": false,

--- a/resources/js/visual-editor/blocks/loginout/block.json
+++ b/resources/js/visual-editor/blocks/loginout/block.json
@@ -25,6 +25,7 @@
         "viewportWidth": 350
     },
     "supports": {
+        "position": true,
         "artisanpackAnimations": true,
         "anchor": true,
         "className": true,

--- a/resources/js/visual-editor/blocks/marquee/block.json
+++ b/resources/js/visual-editor/blocks/marquee/block.json
@@ -29,6 +29,7 @@
         }
     },
     "supports": {
+        "position": true,
         "artisanpackAnimations": true,
         "anchor": true,
         "ariaLabel": true,

--- a/resources/js/visual-editor/blocks/media-text/block.json
+++ b/resources/js/visual-editor/blocks/media-text/block.json
@@ -103,6 +103,7 @@
         "postType"
     ],
     "supports": {
+        "position": true,
         "artisanpackAnimations": true,
         "anchor": true,
         "align": [

--- a/resources/js/visual-editor/blocks/navigation/block.json
+++ b/resources/js/visual-editor/blocks/navigation/block.json
@@ -125,6 +125,7 @@
         "maxNestingLevel": "maxNestingLevel"
     },
     "supports": {
+        "position": true,
         "artisanpackAnimations": true,
         "anchor": true,
         "align": [

--- a/resources/js/visual-editor/blocks/next-post/block.json
+++ b/resources/js/visual-editor/blocks/next-post/block.json
@@ -5,7 +5,12 @@
     "title": "Next Post",
     "category": "theme",
     "description": "Wrap inner blocks against the next post in the same post type so post-* children render the newer neighbor's data.",
-    "keywords": ["next", "post", "navigation", "adjacent"],
+    "keywords": [
+        "next",
+        "post",
+        "navigation",
+        "adjacent"
+    ],
     "textdomain": "artisanpack-visual-editor",
     "attributes": {
         "postType": {
@@ -25,9 +30,13 @@
         "queryId": "queryId"
     },
     "supports": {
+        "position": true,
         "artisanpackAnimations": true,
         "anchor": true,
-        "align": ["wide", "full"],
+        "align": [
+            "wide",
+            "full"
+        ],
         "html": false,
         "reusable": false,
         "color": {
@@ -39,7 +48,10 @@
             }
         },
         "spacing": {
-            "margin": ["top", "bottom"],
+            "margin": [
+                "top",
+                "bottom"
+            ],
             "padding": true
         }
     }

--- a/resources/js/visual-editor/blocks/next-post/block.json
+++ b/resources/js/visual-editor/blocks/next-post/block.json
@@ -5,12 +5,7 @@
     "title": "Next Post",
     "category": "theme",
     "description": "Wrap inner blocks against the next post in the same post type so post-* children render the newer neighbor's data.",
-    "keywords": [
-        "next",
-        "post",
-        "navigation",
-        "adjacent"
-    ],
+    "keywords": ["next", "post", "navigation", "adjacent"],
     "textdomain": "artisanpack-visual-editor",
     "attributes": {
         "postType": {
@@ -33,10 +28,7 @@
         "position": true,
         "artisanpackAnimations": true,
         "anchor": true,
-        "align": [
-            "wide",
-            "full"
-        ],
+        "align": ["wide", "full"],
         "html": false,
         "reusable": false,
         "color": {
@@ -48,10 +40,7 @@
             }
         },
         "spacing": {
-            "margin": [
-                "top",
-                "bottom"
-            ],
+            "margin": ["top", "bottom"],
             "padding": true
         }
     }

--- a/resources/js/visual-editor/blocks/paragraph/block.json
+++ b/resources/js/visual-editor/blocks/paragraph/block.json
@@ -32,6 +32,7 @@
         }
     },
     "supports": {
+        "position": true,
         "artisanpackAnimations": true,
         "align": [
             "wide",

--- a/resources/js/visual-editor/blocks/post-author-biography/block.json
+++ b/resources/js/visual-editor/blocks/post-author-biography/block.json
@@ -16,6 +16,7 @@
         "viewportWidth": 350
     },
     "supports": {
+        "position": true,
         "artisanpackAnimations": true,
         "anchor": true,
         "spacing": {

--- a/resources/js/visual-editor/blocks/post-author-name/block.json
+++ b/resources/js/visual-editor/blocks/post-author-name/block.json
@@ -28,6 +28,7 @@
         "viewportWidth": 350
     },
     "supports": {
+        "position": true,
         "artisanpackAnimations": true,
         "anchor": true,
         "html": false,

--- a/resources/js/visual-editor/blocks/post-author/block.json
+++ b/resources/js/visual-editor/blocks/post-author/block.json
@@ -42,6 +42,7 @@
         "artisanpack/postPreview"
     ],
     "supports": {
+        "position": true,
         "artisanpackAnimations": true,
         "inserter": false,
         "anchor": true,

--- a/resources/js/visual-editor/blocks/post-comments-count/block.json
+++ b/resources/js/visual-editor/blocks/post-comments-count/block.json
@@ -20,6 +20,7 @@
         "viewportWidth": 300
     },
     "supports": {
+        "position": true,
         "artisanpackAnimations": true,
         "html": false,
         "color": {

--- a/resources/js/visual-editor/blocks/post-comments-form/block.json
+++ b/resources/js/visual-editor/blocks/post-comments-form/block.json
@@ -16,6 +16,7 @@
         "postType"
     ],
     "supports": {
+        "position": true,
         "artisanpackAnimations": true,
         "anchor": true,
         "align": [

--- a/resources/js/visual-editor/blocks/post-comments-link/block.json
+++ b/resources/js/visual-editor/blocks/post-comments-link/block.json
@@ -20,6 +20,7 @@
         "viewportWidth": 350
     },
     "supports": {
+        "position": true,
         "artisanpackAnimations": true,
         "html": false,
         "color": {

--- a/resources/js/visual-editor/blocks/post-comments-title/block.json
+++ b/resources/js/visual-editor/blocks/post-comments-title/block.json
@@ -32,6 +32,7 @@
         "artisanpack/postPreview"
     ],
     "supports": {
+        "position": true,
         "artisanpackAnimations": true,
         "anchor": false,
         "align": [

--- a/resources/js/visual-editor/blocks/post-content/block.json
+++ b/resources/js/visual-editor/blocks/post-content/block.json
@@ -21,6 +21,7 @@
         "viewportWidth": 350
     },
     "supports": {
+        "position": true,
         "artisanpackAnimations": true,
         "anchor": true,
         "align": [

--- a/resources/js/visual-editor/blocks/post-date/block.json
+++ b/resources/js/visual-editor/blocks/post-date/block.json
@@ -30,6 +30,7 @@
         "viewportWidth": 350
     },
     "supports": {
+        "position": true,
         "artisanpackAnimations": true,
         "anchor": true,
         "html": false,

--- a/resources/js/visual-editor/blocks/post-excerpt/block.json
+++ b/resources/js/visual-editor/blocks/post-excerpt/block.json
@@ -30,6 +30,7 @@
         "viewportWidth": 350
     },
     "supports": {
+        "position": true,
         "artisanpackAnimations": true,
         "anchor": true,
         "html": false,

--- a/resources/js/visual-editor/blocks/post-featured-image/block.json
+++ b/resources/js/visual-editor/blocks/post-featured-image/block.json
@@ -70,6 +70,7 @@
         "viewportWidth": 350
     },
     "supports": {
+        "position": true,
         "artisanpackAnimations": true,
         "anchor": true,
         "align": [

--- a/resources/js/visual-editor/blocks/post-navigation-link/block.json
+++ b/resources/js/visual-editor/blocks/post-navigation-link/block.json
@@ -38,6 +38,7 @@
         "artisanpack/postPreview"
     ],
     "supports": {
+        "position": true,
         "artisanpackAnimations": true,
         "anchor": true,
         "reusable": false,

--- a/resources/js/visual-editor/blocks/post-terms/block.json
+++ b/resources/js/visual-editor/blocks/post-terms/block.json
@@ -35,6 +35,7 @@
         "viewportWidth": 350
     },
     "supports": {
+        "position": true,
         "artisanpackAnimations": true,
         "anchor": true,
         "html": false,

--- a/resources/js/visual-editor/blocks/post-title/block.json
+++ b/resources/js/visual-editor/blocks/post-title/block.json
@@ -44,6 +44,7 @@
         "viewportWidth": 350
     },
     "supports": {
+        "position": true,
         "artisanpackAnimations": true,
         "anchor": true,
         "align": [

--- a/resources/js/visual-editor/blocks/post-types-search-results/block.json
+++ b/resources/js/visual-editor/blocks/post-types-search-results/block.json
@@ -5,16 +5,27 @@
     "title": "Post Types Search Results",
     "category": "search",
     "description": "Wrap a set of post-type-specific result sections that render conditionally based on the searched post type.",
-    "keywords": ["search", "results", "post types"],
+    "keywords": [
+        "search",
+        "results",
+        "post types"
+    ],
     "textdomain": "artisanpack-visual-editor",
     "supports": {
+        "position": true,
         "artisanpackAnimations": true,
-        "align": ["wide", "full"],
+        "align": [
+            "wide",
+            "full"
+        ],
         "ariaLabel": true,
         "className": true,
         "html": false,
         "spacing": {
-            "margin": ["top", "bottom"],
+            "margin": [
+                "top",
+                "bottom"
+            ],
             "padding": true,
             "blockGap": true,
             "__experimentalDefaultControls": {

--- a/resources/js/visual-editor/blocks/post-types-search-results/block.json
+++ b/resources/js/visual-editor/blocks/post-types-search-results/block.json
@@ -5,27 +5,17 @@
     "title": "Post Types Search Results",
     "category": "search",
     "description": "Wrap a set of post-type-specific result sections that render conditionally based on the searched post type.",
-    "keywords": [
-        "search",
-        "results",
-        "post types"
-    ],
+    "keywords": ["search", "results", "post types"],
     "textdomain": "artisanpack-visual-editor",
     "supports": {
         "position": true,
         "artisanpackAnimations": true,
-        "align": [
-            "wide",
-            "full"
-        ],
+        "align": ["wide", "full"],
         "ariaLabel": true,
         "className": true,
         "html": false,
         "spacing": {
-            "margin": [
-                "top",
-                "bottom"
-            ],
+            "margin": ["top", "bottom"],
             "padding": true,
             "blockGap": true,
             "__experimentalDefaultControls": {

--- a/resources/js/visual-editor/blocks/preformatted/block.json
+++ b/resources/js/visual-editor/blocks/preformatted/block.json
@@ -16,6 +16,7 @@
         }
     },
     "supports": {
+        "position": true,
         "artisanpackAnimations": true,
         "anchor": true,
         "color": {

--- a/resources/js/visual-editor/blocks/previous-post/block.json
+++ b/resources/js/visual-editor/blocks/previous-post/block.json
@@ -5,12 +5,7 @@
     "title": "Previous Post",
     "category": "theme",
     "description": "Wrap inner blocks against the previous post in the same post type so post-* children render the older neighbor's data.",
-    "keywords": [
-        "previous",
-        "post",
-        "navigation",
-        "adjacent"
-    ],
+    "keywords": ["previous", "post", "navigation", "adjacent"],
     "textdomain": "artisanpack-visual-editor",
     "attributes": {
         "postType": {
@@ -33,10 +28,7 @@
         "position": true,
         "artisanpackAnimations": true,
         "anchor": true,
-        "align": [
-            "wide",
-            "full"
-        ],
+        "align": ["wide", "full"],
         "html": false,
         "reusable": false,
         "color": {
@@ -48,10 +40,7 @@
             }
         },
         "spacing": {
-            "margin": [
-                "top",
-                "bottom"
-            ],
+            "margin": ["top", "bottom"],
             "padding": true
         }
     }

--- a/resources/js/visual-editor/blocks/previous-post/block.json
+++ b/resources/js/visual-editor/blocks/previous-post/block.json
@@ -5,7 +5,12 @@
     "title": "Previous Post",
     "category": "theme",
     "description": "Wrap inner blocks against the previous post in the same post type so post-* children render the older neighbor's data.",
-    "keywords": ["previous", "post", "navigation", "adjacent"],
+    "keywords": [
+        "previous",
+        "post",
+        "navigation",
+        "adjacent"
+    ],
     "textdomain": "artisanpack-visual-editor",
     "attributes": {
         "postType": {
@@ -25,9 +30,13 @@
         "queryId": "queryId"
     },
     "supports": {
+        "position": true,
         "artisanpackAnimations": true,
         "anchor": true,
-        "align": ["wide", "full"],
+        "align": [
+            "wide",
+            "full"
+        ],
         "html": false,
         "reusable": false,
         "color": {
@@ -39,7 +48,10 @@
             }
         },
         "spacing": {
-            "margin": ["top", "bottom"],
+            "margin": [
+                "top",
+                "bottom"
+            ],
             "padding": true
         }
     }

--- a/resources/js/visual-editor/blocks/pullquote/block.json
+++ b/resources/js/visual-editor/blocks/pullquote/block.json
@@ -24,6 +24,7 @@
         }
     },
     "supports": {
+        "position": true,
         "artisanpackAnimations": true,
         "anchor": true,
         "align": [

--- a/resources/js/visual-editor/blocks/query-title/block.json
+++ b/resources/js/visual-editor/blocks/query-title/block.json
@@ -36,6 +36,7 @@
         "artisanpack/queryPreview"
     ],
     "supports": {
+        "position": true,
         "artisanpackAnimations": true,
         "anchor": true,
         "align": [

--- a/resources/js/visual-editor/blocks/query/block.json
+++ b/resources/js/visual-editor/blocks/query/block.json
@@ -5,7 +5,13 @@
     "title": "Query Loop",
     "category": "theme",
     "description": "An advanced block that allows displaying post types based on different query parameters and visual configurations.",
-    "keywords": [ "posts", "list", "blog", "blogs", "custom post types" ],
+    "keywords": [
+        "posts",
+        "list",
+        "blog",
+        "blogs",
+        "custom post types"
+    ],
     "textdomain": "artisanpack-visual-editor",
     "attributes": {
         "queryId": {
@@ -45,7 +51,9 @@
             "type": "object"
         }
     },
-    "usesContext": [ "templateSlug" ],
+    "usesContext": [
+        "templateSlug"
+    ],
     "providesContext": {
         "queryId": "queryId",
         "query": "query",
@@ -53,8 +61,12 @@
         "enhancedPagination": "enhancedPagination"
     },
     "supports": {
+        "position": true,
         "anchor": true,
-        "align": [ "wide", "full" ],
+        "align": [
+            "wide",
+            "full"
+        ],
         "html": false,
         "layout": true,
         "interactivity": true

--- a/resources/js/visual-editor/blocks/query/block.json
+++ b/resources/js/visual-editor/blocks/query/block.json
@@ -5,13 +5,7 @@
     "title": "Query Loop",
     "category": "theme",
     "description": "An advanced block that allows displaying post types based on different query parameters and visual configurations.",
-    "keywords": [
-        "posts",
-        "list",
-        "blog",
-        "blogs",
-        "custom post types"
-    ],
+    "keywords": [ "posts", "list", "blog", "blogs", "custom post types" ],
     "textdomain": "artisanpack-visual-editor",
     "attributes": {
         "queryId": {
@@ -51,9 +45,7 @@
             "type": "object"
         }
     },
-    "usesContext": [
-        "templateSlug"
-    ],
+    "usesContext": [ "templateSlug" ],
     "providesContext": {
         "queryId": "queryId",
         "query": "query",
@@ -63,10 +55,7 @@
     "supports": {
         "position": true,
         "anchor": true,
-        "align": [
-            "wide",
-            "full"
-        ],
+        "align": [ "wide", "full" ],
         "html": false,
         "layout": true,
         "interactivity": true

--- a/resources/js/visual-editor/blocks/quote/block.json
+++ b/resources/js/visual-editor/blocks/quote/block.json
@@ -30,6 +30,7 @@
         }
     },
     "supports": {
+        "position": true,
         "artisanpackAnimations": true,
         "anchor": true,
         "align": [

--- a/resources/js/visual-editor/blocks/read-more/block.json
+++ b/resources/js/visual-editor/blocks/read-more/block.json
@@ -22,6 +22,7 @@
         "artisanpack/postPreview"
     ],
     "supports": {
+        "position": true,
         "artisanpackAnimations": true,
         "anchor": true,
         "html": false,

--- a/resources/js/visual-editor/blocks/related-posts/block.json
+++ b/resources/js/visual-editor/blocks/related-posts/block.json
@@ -5,7 +5,12 @@
     "title": "Related Posts",
     "category": "theme",
     "description": "Render a query loop of posts related to the host entry so visitors can keep reading.",
-    "keywords": ["related", "posts", "loop", "feed"],
+    "keywords": [
+        "related",
+        "posts",
+        "loop",
+        "feed"
+    ],
     "textdomain": "artisanpack-visual-editor",
     "attributes": {
         "numPosts": {
@@ -43,7 +48,10 @@
             "default": false
         }
     },
-    "usesContext": ["postId", "postType"],
+    "usesContext": [
+        "postId",
+        "postType"
+    ],
     "providesContext": {
         "queryId": "queryId",
         "query": "query",
@@ -51,9 +59,13 @@
         "enhancedPagination": "enhancedPagination"
     },
     "supports": {
+        "position": true,
         "artisanpackAnimations": true,
         "anchor": true,
-        "align": ["wide", "full"],
+        "align": [
+            "wide",
+            "full"
+        ],
         "ariaLabel": true,
         "className": true,
         "html": false,
@@ -67,7 +79,10 @@
             }
         },
         "spacing": {
-            "margin": ["top", "bottom"],
+            "margin": [
+                "top",
+                "bottom"
+            ],
             "padding": true,
             "blockGap": true,
             "__experimentalDefaultControls": {

--- a/resources/js/visual-editor/blocks/related-posts/block.json
+++ b/resources/js/visual-editor/blocks/related-posts/block.json
@@ -5,12 +5,7 @@
     "title": "Related Posts",
     "category": "theme",
     "description": "Render a query loop of posts related to the host entry so visitors can keep reading.",
-    "keywords": [
-        "related",
-        "posts",
-        "loop",
-        "feed"
-    ],
+    "keywords": ["related", "posts", "loop", "feed"],
     "textdomain": "artisanpack-visual-editor",
     "attributes": {
         "numPosts": {
@@ -48,10 +43,7 @@
             "default": false
         }
     },
-    "usesContext": [
-        "postId",
-        "postType"
-    ],
+    "usesContext": ["postId", "postType"],
     "providesContext": {
         "queryId": "queryId",
         "query": "query",
@@ -62,10 +54,7 @@
         "position": true,
         "artisanpackAnimations": true,
         "anchor": true,
-        "align": [
-            "wide",
-            "full"
-        ],
+        "align": ["wide", "full"],
         "ariaLabel": true,
         "className": true,
         "html": false,
@@ -79,10 +68,7 @@
             }
         },
         "spacing": {
-            "margin": [
-                "top",
-                "bottom"
-            ],
+            "margin": ["top", "bottom"],
             "padding": true,
             "blockGap": true,
             "__experimentalDefaultControls": {

--- a/resources/js/visual-editor/blocks/search-field/block.json
+++ b/resources/js/visual-editor/blocks/search-field/block.json
@@ -5,12 +5,7 @@
     "title": "Search Field",
     "category": "search",
     "description": "Render a labelled search input that posts the keyword to the host page as the `s` query parameter.",
-    "keywords": [
-        "search",
-        "keyword",
-        "filter",
-        "input"
-    ],
+    "keywords": ["search", "keyword", "filter", "input"],
     "textdomain": "artisanpack-visual-editor",
     "attributes": {
         "label": {
@@ -28,10 +23,7 @@
         "className": true,
         "html": false,
         "spacing": {
-            "margin": [
-                "top",
-                "bottom"
-            ],
+            "margin": ["top", "bottom"],
             "padding": true,
             "blockGap": true,
             "__experimentalDefaultControls": {

--- a/resources/js/visual-editor/blocks/search-field/block.json
+++ b/resources/js/visual-editor/blocks/search-field/block.json
@@ -5,7 +5,12 @@
     "title": "Search Field",
     "category": "search",
     "description": "Render a labelled search input that posts the keyword to the host page as the `s` query parameter.",
-    "keywords": ["search", "keyword", "filter", "input"],
+    "keywords": [
+        "search",
+        "keyword",
+        "filter",
+        "input"
+    ],
     "textdomain": "artisanpack-visual-editor",
     "attributes": {
         "label": {
@@ -18,11 +23,15 @@
         }
     },
     "supports": {
+        "position": true,
         "ariaLabel": true,
         "className": true,
         "html": false,
         "spacing": {
-            "margin": ["top", "bottom"],
+            "margin": [
+                "top",
+                "bottom"
+            ],
             "padding": true,
             "blockGap": true,
             "__experimentalDefaultControls": {

--- a/resources/js/visual-editor/blocks/search-filters-buttons/block.json
+++ b/resources/js/visual-editor/blocks/search-filters-buttons/block.json
@@ -5,7 +5,12 @@
     "title": "Search Filters Buttons",
     "category": "search",
     "description": "Render the submit + reset buttons that drive the surrounding search filters form.",
-    "keywords": ["search", "filters", "submit", "reset"],
+    "keywords": [
+        "search",
+        "filters",
+        "submit",
+        "reset"
+    ],
     "textdomain": "artisanpack-visual-editor",
     "attributes": {
         "searchLabel": {
@@ -18,6 +23,7 @@
         }
     },
     "supports": {
+        "position": true,
         "ariaLabel": true,
         "className": true,
         "html": false,

--- a/resources/js/visual-editor/blocks/search-filters-buttons/block.json
+++ b/resources/js/visual-editor/blocks/search-filters-buttons/block.json
@@ -5,12 +5,7 @@
     "title": "Search Filters Buttons",
     "category": "search",
     "description": "Render the submit + reset buttons that drive the surrounding search filters form.",
-    "keywords": [
-        "search",
-        "filters",
-        "submit",
-        "reset"
-    ],
+    "keywords": ["search", "filters", "submit", "reset"],
     "textdomain": "artisanpack-visual-editor",
     "attributes": {
         "searchLabel": {

--- a/resources/js/visual-editor/blocks/search-filters-taxonomy/block.json
+++ b/resources/js/visual-editor/blocks/search-filters-taxonomy/block.json
@@ -5,7 +5,12 @@
     "title": "Search Filters Taxonomy",
     "category": "search",
     "description": "Render a labelled `<select>` populated from a taxonomy so visitors can narrow search results by term.",
-    "keywords": ["search", "filters", "taxonomy", "select"],
+    "keywords": [
+        "search",
+        "filters",
+        "taxonomy",
+        "select"
+    ],
     "textdomain": "artisanpack-visual-editor",
     "attributes": {
         "label": {
@@ -22,11 +27,15 @@
         }
     },
     "supports": {
+        "position": true,
         "ariaLabel": true,
         "className": true,
         "html": false,
         "spacing": {
-            "margin": ["top", "bottom"],
+            "margin": [
+                "top",
+                "bottom"
+            ],
             "padding": true,
             "blockGap": true,
             "__experimentalDefaultControls": {

--- a/resources/js/visual-editor/blocks/search-filters-taxonomy/block.json
+++ b/resources/js/visual-editor/blocks/search-filters-taxonomy/block.json
@@ -5,12 +5,7 @@
     "title": "Search Filters Taxonomy",
     "category": "search",
     "description": "Render a labelled `<select>` populated from a taxonomy so visitors can narrow search results by term.",
-    "keywords": [
-        "search",
-        "filters",
-        "taxonomy",
-        "select"
-    ],
+    "keywords": ["search", "filters", "taxonomy", "select"],
     "textdomain": "artisanpack-visual-editor",
     "attributes": {
         "label": {
@@ -32,10 +27,7 @@
         "className": true,
         "html": false,
         "spacing": {
-            "margin": [
-                "top",
-                "bottom"
-            ],
+            "margin": ["top", "bottom"],
             "padding": true,
             "blockGap": true,
             "__experimentalDefaultControls": {

--- a/resources/js/visual-editor/blocks/search-filters/block.json
+++ b/resources/js/visual-editor/blocks/search-filters/block.json
@@ -18,6 +18,7 @@
         }
     },
     "supports": {
+        "position": true,
         "artisanpackAnimations": true,
         "align": [
             "wide",

--- a/resources/js/visual-editor/blocks/search/block.json
+++ b/resources/js/visual-editor/blocks/search/block.json
@@ -51,6 +51,7 @@
         }
     },
     "supports": {
+        "position": true,
         "artisanpackAnimations": true,
         "anchor": true,
         "align": [

--- a/resources/js/visual-editor/blocks/separator/block.json
+++ b/resources/js/visual-editor/blocks/separator/block.json
@@ -5,11 +5,7 @@
     "title": "Separator",
     "category": "design",
     "description": "Create a break between ideas or sections with a horizontal separator.",
-    "keywords": [
-        "horizontal-line",
-        "hr",
-        "divider"
-    ],
+    "keywords": [ "horizontal-line", "hr", "divider" ],
     "textdomain": "artisanpack-visual-editor",
     "attributes": {
         "opacity": {
@@ -18,10 +14,7 @@
         },
         "tagName": {
             "type": "string",
-            "enum": [
-                "hr",
-                "div"
-            ],
+            "enum": [ "hr", "div" ],
             "default": "hr"
         }
     },
@@ -29,11 +22,7 @@
         "position": true,
         "artisanpackAnimations": true,
         "anchor": true,
-        "align": [
-            "center",
-            "wide",
-            "full"
-        ],
+        "align": [ "center", "wide", "full" ],
         "color": {
             "enableContrastChecker": false,
             "__experimentalSkipSerialization": true,
@@ -45,29 +34,16 @@
             }
         },
         "spacing": {
-            "margin": [
-                "top",
-                "bottom"
-            ]
+            "margin": [ "top", "bottom" ]
         },
         "interactivity": {
             "clientNavigation": true
         }
     },
     "styles": [
-        {
-            "name": "default",
-            "label": "Default",
-            "isDefault": true
-        },
-        {
-            "name": "wide",
-            "label": "Wide Line"
-        },
-        {
-            "name": "dots",
-            "label": "Dots"
-        }
+        { "name": "default", "label": "Default", "isDefault": true },
+        { "name": "wide", "label": "Wide Line" },
+        { "name": "dots", "label": "Dots" }
     ],
     "editorStyle": "wp-block-separator-editor",
     "style": "wp-block-separator"

--- a/resources/js/visual-editor/blocks/separator/block.json
+++ b/resources/js/visual-editor/blocks/separator/block.json
@@ -5,7 +5,11 @@
     "title": "Separator",
     "category": "design",
     "description": "Create a break between ideas or sections with a horizontal separator.",
-    "keywords": [ "horizontal-line", "hr", "divider" ],
+    "keywords": [
+        "horizontal-line",
+        "hr",
+        "divider"
+    ],
     "textdomain": "artisanpack-visual-editor",
     "attributes": {
         "opacity": {
@@ -14,14 +18,22 @@
         },
         "tagName": {
             "type": "string",
-            "enum": [ "hr", "div" ],
+            "enum": [
+                "hr",
+                "div"
+            ],
             "default": "hr"
         }
     },
     "supports": {
+        "position": true,
         "artisanpackAnimations": true,
         "anchor": true,
-        "align": [ "center", "wide", "full" ],
+        "align": [
+            "center",
+            "wide",
+            "full"
+        ],
         "color": {
             "enableContrastChecker": false,
             "__experimentalSkipSerialization": true,
@@ -33,16 +45,29 @@
             }
         },
         "spacing": {
-            "margin": [ "top", "bottom" ]
+            "margin": [
+                "top",
+                "bottom"
+            ]
         },
         "interactivity": {
             "clientNavigation": true
         }
     },
     "styles": [
-        { "name": "default", "label": "Default", "isDefault": true },
-        { "name": "wide", "label": "Wide Line" },
-        { "name": "dots", "label": "Dots" }
+        {
+            "name": "default",
+            "label": "Default",
+            "isDefault": true
+        },
+        {
+            "name": "wide",
+            "label": "Wide Line"
+        },
+        {
+            "name": "dots",
+            "label": "Dots"
+        }
     ],
     "editorStyle": "wp-block-separator-editor",
     "style": "wp-block-separator"

--- a/resources/js/visual-editor/blocks/single-content/block.json
+++ b/resources/js/visual-editor/blocks/single-content/block.json
@@ -5,12 +5,7 @@
     "title": "Single Content",
     "category": "theme",
     "description": "Highlight a single post, page, or custom post type with the inner blocks scoped to the chosen entry.",
-    "keywords": [
-        "single",
-        "content",
-        "post",
-        "feature"
-    ],
+    "keywords": ["single", "content", "post", "feature"],
     "textdomain": "artisanpack-visual-editor",
     "attributes": {
         "postId": {
@@ -29,10 +24,7 @@
     "supports": {
         "position": true,
         "anchor": true,
-        "align": [
-            "wide",
-            "full"
-        ],
+        "align": ["wide", "full"],
         "ariaLabel": true,
         "className": true,
         "html": false,
@@ -46,10 +38,7 @@
             }
         },
         "spacing": {
-            "margin": [
-                "top",
-                "bottom"
-            ],
+            "margin": ["top", "bottom"],
             "padding": true,
             "blockGap": true,
             "__experimentalDefaultControls": {

--- a/resources/js/visual-editor/blocks/single-content/block.json
+++ b/resources/js/visual-editor/blocks/single-content/block.json
@@ -5,7 +5,12 @@
     "title": "Single Content",
     "category": "theme",
     "description": "Highlight a single post, page, or custom post type with the inner blocks scoped to the chosen entry.",
-    "keywords": ["single", "content", "post", "feature"],
+    "keywords": [
+        "single",
+        "content",
+        "post",
+        "feature"
+    ],
     "textdomain": "artisanpack-visual-editor",
     "attributes": {
         "postId": {
@@ -22,8 +27,12 @@
         "postType": "postType"
     },
     "supports": {
+        "position": true,
         "anchor": true,
-        "align": ["wide", "full"],
+        "align": [
+            "wide",
+            "full"
+        ],
         "ariaLabel": true,
         "className": true,
         "html": false,
@@ -37,7 +46,10 @@
             }
         },
         "spacing": {
-            "margin": ["top", "bottom"],
+            "margin": [
+                "top",
+                "bottom"
+            ],
             "padding": true,
             "blockGap": true,
             "__experimentalDefaultControls": {

--- a/resources/js/visual-editor/blocks/site-logo/block.json
+++ b/resources/js/visual-editor/blocks/site-logo/block.json
@@ -32,6 +32,7 @@
         }
     },
     "supports": {
+        "position": true,
         "artisanpackAnimations": true,
         "anchor": true,
         "html": false,

--- a/resources/js/visual-editor/blocks/site-tagline/block.json
+++ b/resources/js/visual-editor/blocks/site-tagline/block.json
@@ -38,6 +38,7 @@
         }
     },
     "supports": {
+        "position": true,
         "artisanpackAnimations": true,
         "anchor": true,
         "align": [

--- a/resources/js/visual-editor/blocks/site-title/block.json
+++ b/resources/js/visual-editor/blocks/site-title/block.json
@@ -38,6 +38,7 @@
         "viewportWidth": 500
     },
     "supports": {
+        "position": true,
         "artisanpackAnimations": true,
         "anchor": true,
         "align": [

--- a/resources/js/visual-editor/blocks/skills-slider/block.json
+++ b/resources/js/visual-editor/blocks/skills-slider/block.json
@@ -5,7 +5,13 @@
     "title": "Skills Slider",
     "category": "widgets",
     "description": "Visualise a skill level as a horizontal progress bar.",
-    "keywords": ["skill", "skills", "progress", "bar", "level"],
+    "keywords": [
+        "skill",
+        "skills",
+        "progress",
+        "bar",
+        "level"
+    ],
     "textdomain": "artisanpack-visual-editor",
     "attributes": {
         "skillLevel": {
@@ -30,12 +36,16 @@
         }
     },
     "supports": {
+        "position": true,
         "artisanpackAnimations": true,
         "anchor": true,
         "className": true,
         "html": false,
         "spacing": {
-            "margin": ["top", "bottom"],
+            "margin": [
+                "top",
+                "bottom"
+            ],
             "padding": true,
             "__experimentalDefaultControls": {
                 "padding": true

--- a/resources/js/visual-editor/blocks/skills-slider/block.json
+++ b/resources/js/visual-editor/blocks/skills-slider/block.json
@@ -5,13 +5,7 @@
     "title": "Skills Slider",
     "category": "widgets",
     "description": "Visualise a skill level as a horizontal progress bar.",
-    "keywords": [
-        "skill",
-        "skills",
-        "progress",
-        "bar",
-        "level"
-    ],
+    "keywords": ["skill", "skills", "progress", "bar", "level"],
     "textdomain": "artisanpack-visual-editor",
     "attributes": {
         "skillLevel": {
@@ -42,10 +36,7 @@
         "className": true,
         "html": false,
         "spacing": {
-            "margin": [
-                "top",
-                "bottom"
-            ],
+            "margin": ["top", "bottom"],
             "padding": true,
             "__experimentalDefaultControls": {
                 "padding": true

--- a/resources/js/visual-editor/blocks/social-share-content/block.json
+++ b/resources/js/visual-editor/blocks/social-share-content/block.json
@@ -5,12 +5,7 @@
     "title": "Social Share Content",
     "category": "theme",
     "description": "Render share-to-social buttons for the current entry so visitors can spread the word.",
-    "keywords": [
-        "social",
-        "share",
-        "icons",
-        "links"
-    ],
+    "keywords": ["social", "share", "icons", "links"],
     "textdomain": "artisanpack-visual-editor",
     "attributes": {
         "socialIcons": {
@@ -19,27 +14,17 @@
         },
         "iconStyle": {
             "type": "string",
-            "enum": [
-                "show-label-icon",
-                "show-icon",
-                "show-label"
-            ],
+            "enum": ["show-label-icon", "show-icon", "show-label"],
             "default": "show-label-icon"
         },
         "iconsDirection": {
             "type": "string",
-            "enum": [
-                "horizontal",
-                "vertical"
-            ],
+            "enum": ["horizontal", "vertical"],
             "default": "vertical"
         },
         "iconsStretch": {
             "type": "string",
-            "enum": [
-                "full-width",
-                "auto-width"
-            ],
+            "enum": ["full-width", "auto-width"],
             "default": "full-width"
         },
         "iconsBorderRadius": {
@@ -67,10 +52,7 @@
         "position": true,
         "artisanpackAnimations": true,
         "anchor": true,
-        "align": [
-            "wide",
-            "full"
-        ],
+        "align": ["wide", "full"],
         "ariaLabel": true,
         "className": true,
         "html": false,
@@ -83,10 +65,7 @@
             }
         },
         "spacing": {
-            "margin": [
-                "top",
-                "bottom"
-            ],
+            "margin": ["top", "bottom"],
             "padding": true,
             "blockGap": true,
             "__experimentalDefaultControls": {

--- a/resources/js/visual-editor/blocks/social-share-content/block.json
+++ b/resources/js/visual-editor/blocks/social-share-content/block.json
@@ -5,7 +5,12 @@
     "title": "Social Share Content",
     "category": "theme",
     "description": "Render share-to-social buttons for the current entry so visitors can spread the word.",
-    "keywords": ["social", "share", "icons", "links"],
+    "keywords": [
+        "social",
+        "share",
+        "icons",
+        "links"
+    ],
     "textdomain": "artisanpack-visual-editor",
     "attributes": {
         "socialIcons": {
@@ -14,17 +19,27 @@
         },
         "iconStyle": {
             "type": "string",
-            "enum": ["show-label-icon", "show-icon", "show-label"],
+            "enum": [
+                "show-label-icon",
+                "show-icon",
+                "show-label"
+            ],
             "default": "show-label-icon"
         },
         "iconsDirection": {
             "type": "string",
-            "enum": ["horizontal", "vertical"],
+            "enum": [
+                "horizontal",
+                "vertical"
+            ],
             "default": "vertical"
         },
         "iconsStretch": {
             "type": "string",
-            "enum": ["full-width", "auto-width"],
+            "enum": [
+                "full-width",
+                "auto-width"
+            ],
             "default": "full-width"
         },
         "iconsBorderRadius": {
@@ -49,9 +64,13 @@
         }
     },
     "supports": {
+        "position": true,
         "artisanpackAnimations": true,
         "anchor": true,
-        "align": ["wide", "full"],
+        "align": [
+            "wide",
+            "full"
+        ],
         "ariaLabel": true,
         "className": true,
         "html": false,
@@ -64,7 +83,10 @@
             }
         },
         "spacing": {
-            "margin": ["top", "bottom"],
+            "margin": [
+                "top",
+                "bottom"
+            ],
             "padding": true,
             "blockGap": true,
             "__experimentalDefaultControls": {

--- a/resources/js/visual-editor/blocks/spacer/block.json
+++ b/resources/js/visual-editor/blocks/spacer/block.json
@@ -15,12 +15,18 @@
             "type": "string"
         }
     },
-    "usesContext": [ "orientation" ],
+    "usesContext": [
+        "orientation"
+    ],
     "supports": {
+        "position": true,
         "artisanpackAnimations": true,
         "anchor": true,
         "spacing": {
-            "margin": [ "top", "bottom" ],
+            "margin": [
+                "top",
+                "bottom"
+            ],
             "__experimentalDefaultControls": {
                 "margin": true
             }

--- a/resources/js/visual-editor/blocks/spacer/block.json
+++ b/resources/js/visual-editor/blocks/spacer/block.json
@@ -15,18 +15,13 @@
             "type": "string"
         }
     },
-    "usesContext": [
-        "orientation"
-    ],
+    "usesContext": [ "orientation" ],
     "supports": {
         "position": true,
         "artisanpackAnimations": true,
         "anchor": true,
         "spacing": {
-            "margin": [
-                "top",
-                "bottom"
-            ],
+            "margin": [ "top", "bottom" ],
             "__experimentalDefaultControls": {
                 "margin": true
             }

--- a/resources/js/visual-editor/blocks/table/block.json
+++ b/resources/js/visual-editor/blocks/table/block.json
@@ -157,6 +157,7 @@
         }
     },
     "supports": {
+        "position": true,
         "artisanpackAnimations": true,
         "anchor": true,
         "align": true,

--- a/resources/js/visual-editor/blocks/tabs/block.json
+++ b/resources/js/visual-editor/blocks/tabs/block.json
@@ -32,6 +32,7 @@
         }
     },
     "supports": {
+        "position": true,
         "artisanpackAnimations": true,
         "align": [
             "wide",

--- a/resources/js/visual-editor/blocks/tag-cloud/block.json
+++ b/resources/js/visual-editor/blocks/tag-cloud/block.json
@@ -42,6 +42,7 @@
         }
     ],
     "supports": {
+        "position": true,
         "artisanpackAnimations": true,
         "anchor": true,
         "html": false,

--- a/resources/js/visual-editor/blocks/template-part/block.json
+++ b/resources/js/visual-editor/blocks/template-part/block.json
@@ -21,6 +21,7 @@
         }
     },
     "supports": {
+        "position": true,
         "align": true,
         "html": false,
         "reusable": false,

--- a/resources/js/visual-editor/blocks/term-description/block.json
+++ b/resources/js/visual-editor/blocks/term-description/block.json
@@ -11,6 +11,7 @@
         "taxonomy"
     ],
     "supports": {
+        "position": true,
         "artisanpackAnimations": true,
         "anchor": true,
         "align": [

--- a/resources/js/visual-editor/blocks/verse/block.json
+++ b/resources/js/visual-editor/blocks/verse/block.json
@@ -24,6 +24,7 @@
         }
     },
     "supports": {
+        "position": true,
         "artisanpackAnimations": true,
         "anchor": true,
         "background": {

--- a/resources/js/visual-editor/blocks/video/block.json
+++ b/resources/js/visual-editor/blocks/video/block.json
@@ -5,9 +5,7 @@
 	"title": "Video",
 	"category": "media",
 	"description": "Embed a video from your media library or upload a new one.",
-	"keywords": [
-		"movie"
-	],
+	"keywords": [ "movie" ],
 	"textdomain": "artisanpack-visual-editor",
 	"attributes": {
 		"autoplay": {

--- a/resources/js/visual-editor/blocks/video/block.json
+++ b/resources/js/visual-editor/blocks/video/block.json
@@ -5,7 +5,9 @@
 	"title": "Video",
 	"category": "media",
 	"description": "Embed a video from your media library or upload a new one.",
-	"keywords": [ "movie" ],
+	"keywords": [
+		"movie"
+	],
 	"textdomain": "artisanpack-visual-editor",
 	"attributes": {
 		"autoplay": {
@@ -83,6 +85,7 @@
 		}
 	},
 	"supports": {
+		"position": true,
 		"artisanpackAnimations": true,
 		"anchor": true,
 		"align": true,

--- a/resources/js/visual-editor/editor/editor-app.tsx
+++ b/resources/js/visual-editor/editor/editor-app.tsx
@@ -47,6 +47,7 @@ import { registerStateAttributesFilter } from '../states/with-state-attributes';
 import { registerBackgroundControls } from '../background-controls';
 import { registerBoxShadows } from '../box-shadows/register';
 import { registerGradientBorders } from '../gradient-borders/register';
+import { registerPositioning } from '../positioning/register';
 import { registerStateStylesFilters } from '../states/with-state-styles';
 import { registerAnimationsAttribute } from '../animations/register-attribute';
 import { registerAnimationsPanel } from '../animations/with-animations-panel';
@@ -221,6 +222,7 @@ function registerOnce(): void {
     // on first render.
     registerGradientBorders();
     registerBoxShadows();
+    registerPositioning();
     // I7 (#415): register all artisanpack/* blocks and set the default
     // block to artisanpack/paragraph. Core blocks are no longer loaded.
     registerArtisanPackBlocks();

--- a/resources/js/visual-editor/positioning/__tests__/emitter.test.ts
+++ b/resources/js/visual-editor/positioning/__tests__/emitter.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Emitter tests for the position feature (#643).
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.4.0
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import { BreakpointRegistry, TAILWIND_V4_DEFAULTS } from '../../responsive/registry'
+import {
+	emitPositionCss,
+	layerDeclarations,
+	mergedBreakpointLayers,
+} from '../emitter'
+import { resolvePosition } from '../resolver'
+
+const registry = new BreakpointRegistry( TAILWIND_V4_DEFAULTS )
+
+describe( 'layerDeclarations', () => {
+	it( 'emits nothing for a null layer', () => {
+		expect( layerDeclarations( null ) ).toBe( '' )
+	} )
+
+	it( 'emits nothing when the resolved value is static', () => {
+		expect(
+			layerDeclarations( {
+				value: 'static',
+				offsets: { top: null, right: null, bottom: null, left: null },
+				zIndex: null,
+			} ),
+		).toBe( '' )
+	} )
+
+	it( 'emits nothing when only orphan offsets/zIndex are set with no non-static value', () => {
+		expect(
+			layerDeclarations( {
+				value: null,
+				offsets: {
+					top:    { value: 10, unit: 'px' },
+					right:  null,
+					bottom: null,
+					left:   null,
+				},
+				zIndex: 3,
+			} ),
+		).toBe( '' )
+	} )
+
+	it( 'emits position + offsets + z-index for a non-static value', () => {
+		expect(
+			layerDeclarations( {
+				value: 'absolute',
+				offsets: {
+					top:    { value: 10, unit: 'px' },
+					right:  null,
+					bottom: { value: 5, unit: 'rem' },
+					left:   { value: 0, unit: 'auto' },
+				},
+				zIndex: 2,
+			} ),
+		).toBe( 'position:absolute !important;top:10px !important;bottom:5rem !important;left:auto !important;z-index:2 !important' )
+	} )
+} )
+
+describe( 'emitPositionCss', () => {
+	it( 'returns empty string when the scope is empty', () => {
+		const payload = resolvePosition( { style: { position: { value: 'relative' } } } )!
+		expect( emitPositionCss( '   ', payload, registry, {} ) ).toBe( '' )
+	} )
+
+	it( 'returns empty string when the payload is null', () => {
+		expect( emitPositionCss( '.foo', null, registry, {} ) ).toBe( '' )
+	} )
+
+	it( 'emits the base rule and per-breakpoint media queries in ascending order', () => {
+		const attrs = {
+			style: {
+				position: {
+					value: 'relative',
+					offsets: { top: { value: 10, unit: 'px' } },
+				},
+			},
+			responsive: {
+				'style.position': {
+					lg: { value: 'sticky', offsets: { top: { value: 0, unit: 'px' } } },
+					md: { zIndex: 3 },
+				},
+			},
+		}
+
+		const payload = resolvePosition( attrs )!
+		const merged  = mergedBreakpointLayers( payload, registry )
+		const css     = emitPositionCss( '.wrap', payload, registry, merged )
+
+		expect( css ).toContain( '.wrap{position:relative !important;top:10px !important}' )
+		// md inherits value=relative + top from base, adds z-index.
+		expect( css ).toContain(
+			'@media (min-width:768px){.wrap{position:relative !important;top:10px !important;z-index:3 !important}}',
+		)
+		// lg overrides value to sticky and top to 0px.
+		expect( css ).toContain(
+			'@media (min-width:1024px){.wrap{position:sticky !important;top:0px !important;z-index:3 !important}}',
+		)
+	} )
+
+	it( 'skips media queries when a breakpoint layer resolves to static-only', () => {
+		const attrs = {
+			style: { position: { value: 'relative' } },
+			responsive: {
+				'style.position': {
+					lg: { value: 'static' },
+				},
+			},
+		}
+		const payload = resolvePosition( attrs )!
+		const merged  = mergedBreakpointLayers( payload, registry )
+		const css     = emitPositionCss( '.wrap', payload, registry, merged )
+
+		expect( css ).toContain( '.wrap{position:relative !important}' )
+		expect( css ).not.toContain( '@media' )
+	} )
+
+	it( 'legacy sticky (bare string) round-trips to a single position:sticky rule', () => {
+		const payload = resolvePosition( { style: { position: 'sticky' } } )!
+		const merged  = mergedBreakpointLayers( payload, registry )
+		const css     = emitPositionCss( '.wrap', payload, registry, merged )
+		expect( css ).toBe( '.wrap{position:sticky !important}' )
+	} )
+} )
+
+describe( 'mergedBreakpointLayers', () => {
+	it( 'folds each breakpoint on top of the running merged layer', () => {
+		const attrs = {
+			style: {
+				position: {
+					value: 'absolute',
+					offsets: { top: { value: 5, unit: 'px' } },
+					zIndex: 1,
+				},
+			},
+			responsive: {
+				'style.position': {
+					md: { zIndex: 9 },
+					lg: { value: 'sticky' },
+				},
+			},
+		}
+
+		const payload = resolvePosition( attrs )!
+		const merged  = mergedBreakpointLayers( payload, registry )
+
+		expect( merged.md ).toEqual( {
+			value: 'absolute',
+			offsets: {
+				top:    { value: 5, unit: 'px' },
+				right:  null,
+				bottom: null,
+				left:   null,
+			},
+			zIndex: 9,
+		} )
+		expect( merged.lg ).toEqual( {
+			value: 'sticky',
+			offsets: {
+				top:    { value: 5, unit: 'px' },
+				right:  null,
+				bottom: null,
+				left:   null,
+			},
+			zIndex: 9,
+		} )
+	} )
+} )

--- a/resources/js/visual-editor/positioning/__tests__/extend-supports.test.ts
+++ b/resources/js/visual-editor/positioning/__tests__/extend-supports.test.ts
@@ -1,0 +1,121 @@
+/**
+ * `extend-supports` tests for the position feature (#641).
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.4.0
+ */
+
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock( '@wordpress/hooks', () => ( {
+	addFilter: vi.fn(),
+} ) )
+
+import { addFilter } from '@wordpress/hooks'
+
+import {
+	positionEnabled,
+	registerPositionSupportsExtension,
+} from '../extend-supports'
+
+describe( 'positionEnabled', () => {
+	it( 'returns true for supports.position === true', () => {
+		expect( positionEnabled( { position: true } ) ).toBe( true )
+	} )
+
+	it( 'returns true for an object at supports.position (Gutenberg native shape)', () => {
+		expect( positionEnabled( { position: { sticky: true } } ) ).toBe( true )
+	} )
+
+	it( 'returns false for undefined, false, or missing supports', () => {
+		expect( positionEnabled( undefined ) ).toBe( false )
+		expect( positionEnabled( {} ) ).toBe( false )
+		expect( positionEnabled( { position: false } ) ).toBe( false )
+	} )
+} )
+
+describe( 'registerPositionSupportsExtension', () => {
+	it( 'attaches the blocks.registerBlockType filter that routes style.position', () => {
+		vi.mocked( addFilter ).mockClear()
+		// Clear the sentinel so multiple test runs re-register cleanly.
+		delete ( globalThis as unknown as Record<symbol, unknown> )[
+			Symbol.for( 'artisanpack-ui.visual-editor.position-supports.registered' )
+		]
+
+		registerPositionSupportsExtension()
+
+		expect( addFilter ).toHaveBeenCalledOnce()
+		const [ hook, ns, cb ] = vi.mocked( addFilter ).mock.calls[ 0 ]
+		expect( hook ).toBe( 'blocks.registerBlockType' )
+		expect( ns ).toBe( 'artisanpack-ui/visual-editor/position-supports' )
+
+		const filtered = ( cb as ( s: unknown ) => Record<string, unknown> )( {
+			supports: { position: true },
+		} )
+		const supports = filtered.supports as Record<string, unknown>
+		expect( supports.artisanpackResponsive ).toEqual( {
+			attributes: [ 'style.position' ],
+		} )
+	} )
+
+	it( 'skips blocks that do not opt into position support', () => {
+		vi.mocked( addFilter ).mockClear()
+		delete ( globalThis as unknown as Record<symbol, unknown> )[
+			Symbol.for( 'artisanpack-ui.visual-editor.position-supports.registered' )
+		]
+
+		registerPositionSupportsExtension()
+		const cb = vi.mocked( addFilter ).mock.calls[ 0 ][ 2 ] as ( s: unknown ) => unknown
+
+		const settings = { supports: { color: {} } }
+		expect( cb( settings ) ).toBe( settings )
+	} )
+
+	it( 'preserves an explicit artisanpackResponsive: false opt-out', () => {
+		vi.mocked( addFilter ).mockClear()
+		delete ( globalThis as unknown as Record<symbol, unknown> )[
+			Symbol.for( 'artisanpack-ui.visual-editor.position-supports.registered' )
+		]
+
+		registerPositionSupportsExtension()
+		const cb = vi.mocked( addFilter ).mock.calls[ 0 ][ 2 ] as ( s: unknown ) => Record<string, unknown>
+
+		const filtered = cb( {
+			supports: {
+				position: true,
+				artisanpackResponsive: false,
+			},
+		} )
+		const supports = filtered.supports as Record<string, unknown>
+		expect( supports.artisanpackResponsive ).toBe( false )
+	} )
+
+	it( 'appends style.position to an existing attributes list without duplicating', () => {
+		vi.mocked( addFilter ).mockClear()
+		delete ( globalThis as unknown as Record<symbol, unknown> )[
+			Symbol.for( 'artisanpack-ui.visual-editor.position-supports.registered' )
+		]
+
+		registerPositionSupportsExtension()
+		const cb = vi.mocked( addFilter ).mock.calls[ 0 ][ 2 ] as ( s: unknown ) => Record<string, unknown>
+
+		const filtered = cb( {
+			supports: {
+				position: true,
+				artisanpackResponsive: { attributes: [ 'style.spacing' ] },
+			},
+		} )
+		const supports = filtered.supports as Record<string, unknown>
+		expect( supports.artisanpackResponsive ).toEqual( {
+			attributes: [ 'style.spacing', 'style.position' ],
+		} )
+
+		// Second application must not duplicate.
+		const twice = cb( filtered )
+		expect(
+			( ( twice as Record<string, unknown> ).supports as Record<string, unknown> ).artisanpackResponsive,
+		).toEqual( {
+			attributes: [ 'style.spacing', 'style.position' ],
+		} )
+	} )
+} )

--- a/resources/js/visual-editor/positioning/__tests__/integration.test.ts
+++ b/resources/js/visual-editor/positioning/__tests__/integration.test.ts
@@ -81,7 +81,12 @@ describe( 'position support — full round-trip across breakpoints', () => {
 		const merged  = mergedBreakpointLayers( payload, registry )
 		const css     = emitPositionCss( '.ve-pos-roundtrip1', payload, registry, merged )
 
-		expect( css ).toContain( '.ve-pos-roundtrip1{position:sticky !important;top:0px !important;z-index:10 !important}' )
+		// Assert declarations individually (order/whitespace-agnostic)
+		// so a benign emitter refactor doesn't break the test.
+		expect( css ).toContain( '.ve-pos-roundtrip1{' )
+		expect( css ).toContain( 'position:sticky !important' )
+		expect( css ).toContain( 'top:0px !important' )
+		expect( css ).toContain( 'z-index:10 !important' )
 		expect( css ).toContain( '@media (min-width:768px){' )
 		expect( css ).toContain( 'top:8px !important' )
 		expect( css ).toContain( '@media (min-width:1024px){' )

--- a/resources/js/visual-editor/positioning/__tests__/integration.test.ts
+++ b/resources/js/visual-editor/positioning/__tests__/integration.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Integration tests for position support (#647).
+ *
+ * Round-trip attributes through the resolver + emitter across all
+ * breakpoints so a regression in either side surfaces immediately.
+ * The unit tests exercise the resolver and emitter in isolation; this
+ * file wires them together against realistic block attribute payloads
+ * — the shape saved to post_content, the shape re-hydrated on load,
+ * the CSS emitted for each cascade level.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.4.0
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import { BreakpointRegistry, TAILWIND_V4_DEFAULTS } from '../../responsive/registry'
+import {
+	emitPositionCss,
+	mergedBreakpointLayers,
+} from '../emitter'
+import {
+	rawOffsetAt,
+	rawValueAt,
+	rawZIndexAt,
+	resolveAtBreakpoint,
+	resolvePosition,
+} from '../resolver'
+
+const registry = new BreakpointRegistry( TAILWIND_V4_DEFAULTS )
+
+describe( 'position support — full round-trip across breakpoints', () => {
+	it( 'round-trips base + per-breakpoint values through resolver → emitter', () => {
+		// Simulates a block a user configured with a base sticky
+		// position and progressively broader offsets at md and lg.
+		const attributes = {
+			style: {
+				position: {
+					value:   'sticky',
+					offsets: { top: { value: 0, unit: 'px' } },
+					zIndex:  10,
+					_positionScopeId: 'roundtrip1',
+				},
+			},
+			responsive: {
+				'style.position': {
+					md: { offsets: { top: { value: 8,  unit: 'px' } } },
+					lg: { offsets: { top: { value: 16, unit: 'px' } }, zIndex: 20 },
+				},
+			},
+		}
+
+		// Raw readers (what the inspector uses to draw "inherited" chips).
+		expect( rawValueAt( attributes, 'base' ) ).toBe( 'sticky' )
+		expect( rawValueAt( attributes, 'md' ) ).toBeNull()
+		expect( rawZIndexAt( attributes, 'md' ) ).toBeNull()
+		expect( rawZIndexAt( attributes, 'lg' ) ).toBe( 20 )
+		expect( rawOffsetAt( attributes, 'md', 'top' ) ).toEqual( {
+			value: 8, unit: 'px',
+		} )
+
+		// Effective layers (what the canvas + frontend render).
+		const base = resolveAtBreakpoint( attributes, 'base', registry )!
+		expect( base.value ).toBe( 'sticky' )
+		expect( base.offsets.top ).toEqual( { value: 0, unit: 'px' } )
+		expect( base.zIndex ).toBe( 10 )
+
+		const md = resolveAtBreakpoint( attributes, 'md', registry )!
+		// md inherits sticky + zIndex 10 from base, overrides top.
+		expect( md.value ).toBe( 'sticky' )
+		expect( md.offsets.top ).toEqual( { value: 8, unit: 'px' } )
+		expect( md.zIndex ).toBe( 10 )
+
+		const lg = resolveAtBreakpoint( attributes, 'lg', registry )!
+		expect( lg.value ).toBe( 'sticky' )
+		expect( lg.offsets.top ).toEqual( { value: 16, unit: 'px' } )
+		expect( lg.zIndex ).toBe( 20 )
+
+		// Emitter output — same payload → deterministic CSS.
+		const payload = resolvePosition( attributes )!
+		const merged  = mergedBreakpointLayers( payload, registry )
+		const css     = emitPositionCss( '.ve-pos-roundtrip1', payload, registry, merged )
+
+		expect( css ).toContain( '.ve-pos-roundtrip1{position:sticky !important;top:0px !important;z-index:10 !important}' )
+		expect( css ).toContain( '@media (min-width:768px){' )
+		expect( css ).toContain( 'top:8px !important' )
+		expect( css ).toContain( '@media (min-width:1024px){' )
+		expect( css ).toContain( 'top:16px !important' )
+		expect( css ).toContain( 'z-index:20 !important' )
+	} )
+
+	it( 'emits nothing for a block whose base resolves to static + no breakpoints override', () => {
+		const attributes = {
+			style: { position: { value: 'static' } },
+		}
+		const payload = resolvePosition( attributes )!
+		const merged  = mergedBreakpointLayers( payload, registry )
+		const css     = emitPositionCss( '.ve-pos-x', payload, registry, merged )
+		expect( css ).toBe( '' )
+	} )
+} )
+
+describe( 'position support — legacy Gutenberg sticky no-churn', () => {
+	it( 'loads and re-serializes a bare "sticky" string without attribute migration', () => {
+		// Simulates content saved by Gutenberg's native `supports.position`
+		// before the block opted into artisanpack's structured shape.
+		// The resolver widens the string; the emitter renders the same
+		// sticky rule. No writer needs to touch the attribute — a
+		// no-op re-save preserves it byte-for-byte.
+		const attributes = { style: { position: 'sticky' } }
+
+		const layer = resolveAtBreakpoint( attributes, 'base', registry )!
+		expect( layer.value ).toBe( 'sticky' )
+		expect( layer.offsets ).toEqual( {
+			top: null, right: null, bottom: null, left: null,
+		} )
+		expect( layer.zIndex ).toBeNull()
+
+		const payload = resolvePosition( attributes )!
+		const merged  = mergedBreakpointLayers( payload, registry )
+		expect( emitPositionCss( '.ve-pos-x', payload, registry, merged ) )
+			.toBe( '.ve-pos-x{position:sticky !important}' )
+
+		// Attribute is untouched — the block's style.position is still
+		// the same string reference.
+		expect( attributes.style.position ).toBe( 'sticky' )
+	} )
+} )
+
+describe( 'position support — orphan fields survive a toggle back to static', () => {
+	it( 'preserves offsets and zIndex when value is static, without emitting CSS', () => {
+		// Users often flip value=static to preview un-positioned layout
+		// then flip back — offsets and zIndex must survive that round
+		// trip. The emitter is silent while static (per #643).
+		const attributes = {
+			style: {
+				position: {
+					value:   'static',
+					offsets: { top: { value: 20, unit: 'px' } },
+					zIndex:  5,
+				},
+			},
+		}
+
+		const payload = resolvePosition( attributes )!
+		expect( payload.base?.offsets.top ).toEqual( { value: 20, unit: 'px' } )
+		expect( payload.base?.zIndex ).toBe( 5 )
+
+		const css = emitPositionCss(
+			'.ve-pos-x',
+			payload,
+			registry,
+			mergedBreakpointLayers( payload, registry ),
+		)
+		expect( css ).toBe( '' )
+	} )
+} )

--- a/resources/js/visual-editor/positioning/__tests__/resolver.test.ts
+++ b/resources/js/visual-editor/positioning/__tests__/resolver.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Resolver tests for the position feature (#641).
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.4.0
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import { BreakpointRegistry, TAILWIND_V4_DEFAULTS } from '../../responsive/registry'
+import {
+	coerceSubtree,
+	rawOffsetAt,
+	rawValueAt,
+	rawZIndexAt,
+	resolveAtBreakpoint,
+	resolvePosition,
+} from '../resolver'
+
+const registry = new BreakpointRegistry( TAILWIND_V4_DEFAULTS )
+
+describe( 'coerceSubtree', () => {
+	it( 'widens a legacy sticky string into a structured subtree', () => {
+		expect( coerceSubtree( 'sticky' ) ).toEqual( { value: 'sticky' } )
+	} )
+
+	it( 'rejects strings that are not one of the five supported values', () => {
+		expect( coerceSubtree( 'floaty' ) ).toBeNull()
+	} )
+
+	it( 'returns structured objects unchanged', () => {
+		const input = { value: 'absolute', zIndex: 5 } as const
+		expect( coerceSubtree( input ) ).toBe( input )
+	} )
+
+	it( 'returns null for null / undefined / non-string primitives', () => {
+		expect( coerceSubtree( null ) ).toBeNull()
+		expect( coerceSubtree( undefined ) ).toBeNull()
+		expect( coerceSubtree( 42 ) ).toBeNull()
+	} )
+} )
+
+describe( 'resolvePosition', () => {
+	it( 'returns null when no position data exists', () => {
+		expect( resolvePosition( {} ) ).toBeNull()
+		expect( resolvePosition( { style: {} } ) ).toBeNull()
+		expect( resolvePosition( { style: { position: null } } ) ).toBeNull()
+	} )
+
+	it( 'resolves the base layer from a structured subtree', () => {
+		const attrs = {
+			style: {
+				position: {
+					value: 'absolute',
+					offsets: { top: { value: 10, unit: 'px' } },
+					zIndex: 3,
+				},
+			},
+		}
+
+		expect( resolvePosition( attrs ) ).toEqual( {
+			base: {
+				value: 'absolute',
+				offsets: {
+					top:    { value: 10, unit: 'px' },
+					right:  null,
+					bottom: null,
+					left:   null,
+				},
+				zIndex: 3,
+			},
+			breakpoints: {},
+		} )
+	} )
+
+	it( 'preserves Gutenberg legacy sticky (bare string) at the base layer', () => {
+		const attrs = { style: { position: 'sticky' } }
+
+		expect( resolvePosition( attrs ) ).toEqual( {
+			base: {
+				value: 'sticky',
+				offsets: { top: null, right: null, bottom: null, left: null },
+				zIndex: null,
+			},
+			breakpoints: {},
+		} )
+	} )
+
+	it( 'reads per-breakpoint overrides from the responsive bag', () => {
+		const attrs = {
+			style: { position: { value: 'relative' } },
+			responsive: {
+				'style.position': {
+					md: { value: 'absolute', zIndex: 2 },
+				},
+			},
+		}
+
+		const resolved = resolvePosition( attrs )!
+		expect( resolved.base?.value ).toBe( 'relative' )
+		expect( resolved.breakpoints.md?.value ).toBe( 'absolute' )
+		expect( resolved.breakpoints.md?.zIndex ).toBe( 2 )
+	} )
+
+	it( 'drops entries under the `base` key inside the responsive bag', () => {
+		const attrs = {
+			responsive: {
+				'style.position': {
+					base: { value: 'fixed' },
+					lg:   { value: 'sticky' },
+				},
+			},
+		}
+
+		const resolved = resolvePosition( attrs )!
+		expect( resolved.breakpoints ).toEqual( {
+			lg: {
+				value: 'sticky',
+				offsets: { top: null, right: null, bottom: null, left: null },
+				zIndex: null,
+			},
+		} )
+	} )
+
+	it( 'drops offsets with a missing or invalid unit', () => {
+		const attrs = {
+			style: {
+				position: {
+					value: 'absolute',
+					offsets: {
+						top:    { value: 10 },
+						right:  { value: 5, unit: 'garbage' },
+						bottom: { value: 12, unit: 'rem' },
+					},
+				},
+			},
+		}
+
+		const resolved = resolvePosition( attrs )!
+		expect( resolved.base?.offsets.top ).toBeNull()
+		expect( resolved.base?.offsets.right ).toBeNull()
+		expect( resolved.base?.offsets.bottom ).toEqual( { value: 12, unit: 'rem' } )
+	} )
+
+	it( 'accepts the `auto` unit without a numeric value', () => {
+		const attrs = {
+			style: {
+				position: {
+					value: 'absolute',
+					offsets: { top: { unit: 'auto' } },
+				},
+			},
+		}
+
+		const resolved = resolvePosition( attrs )!
+		expect( resolved.base?.offsets.top ).toEqual( { value: 0, unit: 'auto' } )
+	} )
+} )
+
+describe( 'resolveAtBreakpoint', () => {
+	it( 'returns the base layer for the base key', () => {
+		const attrs = { style: { position: { value: 'relative' } } }
+		const layer = resolveAtBreakpoint( attrs, 'base', registry )
+		expect( layer?.value ).toBe( 'relative' )
+	} )
+
+	it( 'inherits fields from smaller breakpoints when overriding a subset', () => {
+		const attrs = {
+			style: {
+				position: {
+					value: 'absolute',
+					offsets: { top: { value: 5, unit: 'px' } },
+					zIndex: 1,
+				},
+			},
+			responsive: {
+				'style.position': {
+					md: { zIndex: 9 },
+					lg: { value: 'sticky' },
+				},
+			},
+		}
+
+		const md = resolveAtBreakpoint( attrs, 'md', registry )!
+		// Overrides zIndex, inherits value + top offset from base.
+		expect( md.value ).toBe( 'absolute' )
+		expect( md.zIndex ).toBe( 9 )
+		expect( md.offsets.top ).toEqual( { value: 5, unit: 'px' } )
+
+		const lg = resolveAtBreakpoint( attrs, 'lg', registry )!
+		// Overrides value at lg, inherits zIndex from md and top from base.
+		expect( lg.value ).toBe( 'sticky' )
+		expect( lg.zIndex ).toBe( 9 )
+		expect( lg.offsets.top ).toEqual( { value: 5, unit: 'px' } )
+	} )
+
+	it( 'returns null when nothing is defined anywhere', () => {
+		expect( resolveAtBreakpoint( {}, 'md', registry ) ).toBeNull()
+	} )
+} )
+
+describe( 'raw* readers (no inheritance)', () => {
+	const attrs = {
+		style: {
+			position: {
+				value: 'relative',
+				offsets: { top: { value: 4, unit: 'px' } },
+				zIndex: 1,
+			},
+		},
+		responsive: {
+			'style.position': {
+				md: { zIndex: 9 },
+			},
+		},
+	}
+
+	it( 'rawValueAt only returns explicit values at each breakpoint', () => {
+		expect( rawValueAt( attrs, 'base' ) ).toBe( 'relative' )
+		expect( rawValueAt( attrs, 'md' ) ).toBeNull()
+	} )
+
+	it( 'rawZIndexAt returns the explicit z-index at each breakpoint', () => {
+		expect( rawZIndexAt( attrs, 'base' ) ).toBe( 1 )
+		expect( rawZIndexAt( attrs, 'md' ) ).toBe( 9 )
+		expect( rawZIndexAt( attrs, 'lg' ) ).toBeNull()
+	} )
+
+	it( 'rawOffsetAt returns the explicit offset at each breakpoint', () => {
+		expect( rawOffsetAt( attrs, 'base', 'top' ) ).toEqual( {
+			value: 4,
+			unit:  'px',
+		} )
+		expect( rawOffsetAt( attrs, 'md', 'top' ) ).toBeNull()
+	} )
+} )

--- a/resources/js/visual-editor/positioning/emitter.ts
+++ b/resources/js/visual-editor/positioning/emitter.ts
@@ -1,0 +1,178 @@
+/**
+ * CSS emission for position attributes (#643).
+ *
+ * Takes a resolved payload (`resolvePosition` output) and produces the
+ * `<style>` string appended alongside a block's wrapper. Base layer
+ * emits an unscoped rule; per-breakpoint overrides emit inside
+ * `@media (min-width:<n>px)` blocks matching the responsive breakpoint
+ * registry.
+ *
+ * Contracts (per #643 acceptance criteria):
+ *
+ *  - `position: static` emits NOTHING — offsets and z-index are
+ *    preserved in attributes but silent while static.
+ *  - `unit: 'auto'` renders as `top: auto` etc.
+ *  - Legacy Gutenberg sticky is a no-op at the emitter level: the
+ *    resolver already widens the bare string, and static-only base
+ *    layers with no other data resolve to null upstream.
+ *  - Breakpoints inherit from smaller breakpoints; the emitter
+ *    consumes already-merged per-breakpoint layers so the media query
+ *    body carries the fully-resolved position/offset/zIndex set.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.4.0
+ */
+
+import type { BreakpointRegistry } from '../responsive/registry'
+import { BASE_KEY } from '../responsive/types'
+import { mergeLayers } from './resolver'
+import type {
+	OffsetValue,
+	ResolvedPosition,
+	ResolvedPositionLayer,
+} from './types'
+
+function formatOffset( offset: OffsetValue ): string {
+	if ( 'auto' === offset.unit ) {
+		return 'auto'
+	}
+
+	return `${ offset.value }${ offset.unit }`
+}
+
+/**
+ * Emit the declaration list for a single layer. Callers wrap this in
+ * whatever selector / media query they need. Returns an empty string
+ * when the layer effectively contributes nothing (e.g. `static` with
+ * no z-index override).
+ */
+export function layerDeclarations( layer: ResolvedPositionLayer | null ): string {
+	if ( ! layer ) {
+		return ''
+	}
+
+	const parts: string[] = []
+
+	if ( null !== layer.value && 'static' !== layer.value ) {
+		// Every declaration ships `!important`. Gutenberg's editor
+		// canvas emits an internal `.block-editor-block-list__layout
+		// .block-editor-block-list__block { position: relative }` rule
+		// (0,2,0 specificity) that outranks a single `.ve-pos-xyz`
+		// class selector (0,1,0), so an unmarked `position: sticky`
+		// silently loses at author time. Users who pick a value on the
+		// panel explicitly WANT it applied — `!important` matches that
+		// intent and is consistent with how core WordPress overrides
+		// several of its own layout defaults.
+		parts.push( `position:${ layer.value } !important` )
+
+		if ( null !== layer.offsets.top ) {
+			parts.push( `top:${ formatOffset( layer.offsets.top ) } !important` )
+		}
+		if ( null !== layer.offsets.right ) {
+			parts.push( `right:${ formatOffset( layer.offsets.right ) } !important` )
+		}
+		if ( null !== layer.offsets.bottom ) {
+			parts.push( `bottom:${ formatOffset( layer.offsets.bottom ) } !important` )
+		}
+		if ( null !== layer.offsets.left ) {
+			parts.push( `left:${ formatOffset( layer.offsets.left ) } !important` )
+		}
+
+		if ( null !== layer.zIndex ) {
+			parts.push( `z-index:${ layer.zIndex } !important` )
+		}
+	}
+
+	return parts.join( ';' )
+}
+
+/**
+ * Emit scoped CSS for a block. Uses media queries for breakpoint
+ * overrides. Returns an empty string when nothing meaningful renders.
+ *
+ * The per-breakpoint layers passed in must already be merged with the
+ * base layer — the emitter emits the full declaration list for each
+ * breakpoint so the media query body carries a self-contained set of
+ * declarations (no cascade tricks required).
+ */
+export function emitPositionCss(
+	scope: string,
+	payload: ResolvedPosition | null | undefined,
+	breakpoints: BreakpointRegistry,
+	mergedBreakpointLayers: Record<string, ResolvedPositionLayer>,
+): string {
+	const trimmedScope = scope.trim()
+
+	if ( '' === trimmedScope || ! payload ) {
+		return ''
+	}
+
+	const rules: string[] = []
+
+	const baseDecls = layerDeclarations( payload.base )
+	if ( '' !== baseDecls ) {
+		rules.push( `${ trimmedScope }{${ baseDecls }}` )
+	}
+
+	// Emit breakpoints in ascending min-width order so the cascade is
+	// natural — a later, larger breakpoint wins over an earlier one at
+	// the same specificity when both match.
+	const ordered = breakpoints
+		.all()
+		.slice()
+		.sort( ( a, b ) => a.minWidthPx - b.minWidthPx )
+
+	for ( const bp of ordered ) {
+		const key = bp.key
+		if ( BASE_KEY === key ) {
+			continue
+		}
+
+		const layer = mergedBreakpointLayers[ key ]
+		if ( ! layer ) {
+			continue
+		}
+
+		const decls = layerDeclarations( layer )
+		if ( '' === decls ) {
+			continue
+		}
+
+		rules.push(
+			`@media (min-width:${ bp.minWidthPx }px){${ trimmedScope }{${ decls }}}`,
+		)
+	}
+
+	return rules.join( '' )
+}
+
+/**
+ * Convenience: given a resolved payload, produce the merged
+ * per-breakpoint layer map the emitter consumes. Walks each defined
+ * breakpoint override and folds it on top of every smaller layer.
+ * Kept separate from the emitter so the inspector can reuse it when
+ * previewing a specific breakpoint.
+ */
+export function mergedBreakpointLayers(
+	payload: ResolvedPosition,
+	breakpoints: BreakpointRegistry,
+): Record<string, ResolvedPositionLayer> {
+	const out: Record<string, ResolvedPositionLayer> = {}
+
+	const ordered = breakpoints.keysWithBase()
+	let running: ResolvedPositionLayer | null = payload.base
+
+	for ( let i = 1; i < ordered.length; i++ ) {
+		const key     = ordered[ i ]
+		const overlay = payload.breakpoints[ key ]
+
+		if ( overlay ) {
+			running = mergeLayers( running, overlay )
+			if ( null !== running ) {
+				out[ key ] = running
+			}
+		}
+	}
+
+	return out
+}

--- a/resources/js/visual-editor/positioning/extend-supports.ts
+++ b/resources/js/visual-editor/positioning/extend-supports.ts
@@ -1,0 +1,116 @@
+/**
+ * `blocks.registerBlockType` filter — add `style.position` to
+ * `artisanpackResponsive.attributes` routing whenever a block declares
+ * `supports.position` (#641).
+ *
+ * The block-level gate is `supports.position: true` OR any truthy
+ * object at `supports.position` (Gutenberg's own sticky-enabled shape
+ * `{ sticky: true }` counts). Explicit
+ * `artisanpackResponsive: false` opt-out is preserved.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.4.0
+ */
+
+import { addFilter } from '@wordpress/hooks'
+
+import { POSITION_ATTRIBUTE_PATH } from './types'
+
+const FILTER_HOOK      = 'blocks.registerBlockType'
+const FILTER_NAMESPACE = 'artisanpack-ui/visual-editor/position-supports'
+
+const REGISTERED_KEY = Symbol.for(
+	'artisanpack-ui.visual-editor.position-supports.registered',
+)
+
+interface GlobalSentinelHost {
+	[REGISTERED_KEY]?: boolean
+}
+
+interface RoutingSupport {
+	attributes?: string[]
+	[key: string]: unknown
+}
+
+interface BlockSupports {
+	position?: boolean | Record<string, unknown>
+	artisanpackResponsive?: RoutingSupport | boolean
+	[key: string]: unknown
+}
+
+interface BlockSettingsLike {
+	supports?: BlockSupports
+	[key: string]: unknown
+}
+
+export function positionEnabled( supports: BlockSupports | undefined ): boolean {
+	if ( ! supports ) {
+		return false
+	}
+
+	const raw = supports.position
+
+	if ( true === raw ) {
+		return true
+	}
+
+	return Boolean( raw && 'object' === typeof raw )
+}
+
+function ensureRouted( supports: BlockSupports ): RoutingSupport | false {
+	const raw = supports.artisanpackResponsive
+
+	if ( false === raw ) {
+		return false
+	}
+
+	if ( raw === undefined || raw === null || true === raw ) {
+		return { attributes: [ POSITION_ATTRIBUTE_PATH ] }
+	}
+
+	if ( 'object' !== typeof raw ) {
+		return { attributes: [ POSITION_ATTRIBUTE_PATH ] }
+	}
+
+	const attributes = Array.isArray( raw.attributes ) ? raw.attributes : []
+
+	if ( attributes.includes( POSITION_ATTRIBUTE_PATH ) ) {
+		return raw
+	}
+
+	return {
+		...raw,
+		attributes: [ ...attributes, POSITION_ATTRIBUTE_PATH ],
+	}
+}
+
+function injectPositionSupports( settings: BlockSettingsLike ): BlockSettingsLike {
+	if ( ! positionEnabled( settings.supports ) ) {
+		return settings
+	}
+
+	const supports = settings.supports as BlockSupports
+
+	return {
+		...settings,
+		supports: {
+			...supports,
+			artisanpackResponsive: ensureRouted( supports ),
+		},
+	}
+}
+
+/**
+ * Register the filter at most once per page. Idempotent — safe to call
+ * from both the post-editor and site-editor entries.
+ */
+export function registerPositionSupportsExtension(): void {
+	const host = globalThis as unknown as GlobalSentinelHost
+
+	if ( host[ REGISTERED_KEY ] ) {
+		return
+	}
+
+	addFilter( FILTER_HOOK, FILTER_NAMESPACE, injectPositionSupports )
+	host[ REGISTERED_KEY ] = true
+}

--- a/resources/js/visual-editor/positioning/index.ts
+++ b/resources/js/visual-editor/positioning/index.ts
@@ -1,0 +1,45 @@
+/**
+ * Public entry point for the CSS positioning feature (#640).
+ *
+ * Mirrors the split in `box-shadows/index.ts` — the HOC + filter
+ * registrars are NOT re-exported here because they import
+ * `@wordpress/blocks`, which trips JSON-import-attribute requirements
+ * when host bundlers walk this barrel transitively.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.4.0
+ */
+
+export {
+	coerceSubtree,
+	rawOffsetAt,
+	rawValueAt,
+	rawZIndexAt,
+	resolveAtBreakpoint,
+	resolvePosition,
+} from './resolver'
+
+export {
+	emitPositionCss,
+	layerDeclarations,
+	mergedBreakpointLayers,
+} from './emitter'
+
+export type {
+	OffsetSide,
+	OffsetSubtree,
+	OffsetUnit,
+	OffsetValue,
+	PositionAttributes,
+	PositionSubtree,
+	PositionValue,
+	ResolvedPosition,
+	ResolvedPositionLayer,
+} from './types'
+
+export {
+	OFFSET_SIDES,
+	OFFSET_UNITS,
+	POSITION_ATTRIBUTE_PATH,
+	POSITION_VALUES,
+} from './types'

--- a/resources/js/visual-editor/positioning/register.ts
+++ b/resources/js/visual-editor/positioning/register.ts
@@ -1,0 +1,28 @@
+/**
+ * One-shot registrar for the CSS positioning feature (#640).
+ *
+ * Bootstraps the supports-extension filter (auto-add `style.position`
+ * to opted-in blocks' responsive routing), the BlockEdit HOC
+ * (inspector Position panel + ancestor warning) and the style-
+ * emission filters (canvas preview + save markup).
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.4.0
+ */
+
+import { registerPositionControl } from './with-position-control'
+import { registerPositionStylesFilters } from './with-position-styles'
+import { registerPositionSupportsExtension } from './extend-supports'
+
+/**
+ * Install every filter the position feature needs. Idempotent — each
+ * registrar guards itself with a sentinel so calling this from both
+ * the post-editor and site-editor entries is safe.
+ *
+ * @since 1.4.0
+ */
+export function registerPositioning(): void {
+	registerPositionSupportsExtension()
+	registerPositionControl()
+	registerPositionStylesFilters()
+}

--- a/resources/js/visual-editor/positioning/resolver.ts
+++ b/resources/js/visual-editor/positioning/resolver.ts
@@ -1,0 +1,381 @@
+/**
+ * Position attribute resolver (#641).
+ *
+ * Walks a block's attribute tree and produces a normalised payload the
+ * emitter + inspector consume. The idle layer lives at
+ * `attributes.style.position`; per-breakpoint overrides ride
+ * `attributes.responsive['style.position']` following the responsive
+ * routing pattern from #487.
+ *
+ * Backwards compatible with Gutenberg's native sticky path — a plain
+ * string at `style.position` (e.g. `'sticky'`) is widened to
+ * `{ value: 'sticky' }`. Anything else in the string form falls
+ * through unless it matches one of the five supported values.
+ *
+ * Breakpoint inheritance follows the responsive resolver's mobile-
+ * first cascade (larger breakpoints inherit from smaller ones). This
+ * mirrors `resolveResponsiveValue` for scalars but operates on the
+ * full structured layer so partial overrides at a breakpoint inherit
+ * the untouched fields from the next-smaller defined layer.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.4.0
+ */
+
+import type { BreakpointRegistry } from '../responsive/registry'
+import { BASE_KEY } from '../responsive/types'
+import {
+	POSITION_VALUES,
+	OFFSET_UNITS,
+	OFFSET_SIDES,
+	type OffsetSide,
+	type OffsetSubtree,
+	type OffsetValue,
+	type PositionAttributes,
+	type PositionSubtree,
+	type PositionValue,
+	type ResolvedPosition,
+	type ResolvedPositionLayer,
+} from './types'
+
+const POSITION_VALUE_SET = new Set<string>( POSITION_VALUES )
+const OFFSET_UNIT_SET    = new Set<string>( OFFSET_UNITS )
+
+function normalizeValue( raw: unknown ): PositionValue | null {
+	if ( 'string' !== typeof raw ) {
+		return null
+	}
+
+	const trimmed = raw.trim().toLowerCase()
+
+	return POSITION_VALUE_SET.has( trimmed ) ? ( trimmed as PositionValue ) : null
+}
+
+function normalizeOffset( raw: unknown ): OffsetValue | null {
+	if ( ! raw || 'object' !== typeof raw ) {
+		return null
+	}
+
+	const record = raw as Record<string, unknown>
+	const unit   = 'string' === typeof record.unit ? record.unit.trim().toLowerCase() : null
+
+	if ( null === unit || ! OFFSET_UNIT_SET.has( unit ) ) {
+		return null
+	}
+
+	// The `auto` unit has no numeric component. Store as `0` so
+	// consumers can unconditionally read `value` without null checks;
+	// the emitter special-cases `unit === 'auto'` to render `auto`.
+	if ( 'auto' === unit ) {
+		return { value: 0, unit: 'auto' }
+	}
+
+	const numeric = 'number' === typeof record.value
+		? record.value
+		: ( 'string' === typeof record.value && '' !== record.value.trim()
+			? Number( record.value )
+			: NaN )
+
+	if ( ! Number.isFinite( numeric ) ) {
+		return null
+	}
+
+	return { value: numeric, unit: unit as OffsetValue[ 'unit' ] }
+}
+
+function normalizeOffsets( raw: unknown ): ResolvedPositionLayer[ 'offsets' ] {
+	const out: ResolvedPositionLayer[ 'offsets' ] = {
+		top:    null,
+		right:  null,
+		bottom: null,
+		left:   null,
+	}
+
+	if ( ! raw || 'object' !== typeof raw ) {
+		return out
+	}
+
+	const record = raw as Record<string, unknown>
+
+	for ( const side of OFFSET_SIDES ) {
+		out[ side ] = normalizeOffset( record[ side ] )
+	}
+
+	return out
+}
+
+function normalizeZIndex( raw: unknown ): number | null {
+	if ( 'number' === typeof raw && Number.isFinite( raw ) ) {
+		return Math.trunc( raw )
+	}
+
+	if ( 'string' === typeof raw && '' !== raw.trim() ) {
+		const parsed = Number( raw )
+		if ( Number.isFinite( parsed ) ) {
+			return Math.trunc( parsed )
+		}
+	}
+
+	return null
+}
+
+/**
+ * Coerce the raw slot at `attributes.style.position` (or an override
+ * inside `attributes.responsive`) into a structured subtree. A plain
+ * string is treated as the `value` field alone — this is how
+ * Gutenberg's native sticky path stores its data.
+ */
+export function coerceSubtree( raw: unknown ): PositionSubtree | null {
+	if ( null === raw || undefined === raw ) {
+		return null
+	}
+
+	if ( 'string' === typeof raw ) {
+		const value = normalizeValue( raw )
+		return value ? { value } : null
+	}
+
+	if ( 'object' !== typeof raw ) {
+		return null
+	}
+
+	return raw as PositionSubtree
+}
+
+function resolveLayer( subtree: PositionSubtree | null ): ResolvedPositionLayer | null {
+	if ( ! subtree ) {
+		return null
+	}
+
+	const value   = normalizeValue( subtree.value )
+	const offsets = normalizeOffsets( subtree.offsets )
+	const zIndex  = normalizeZIndex( subtree.zIndex )
+
+	const hasAny =
+		null !== value
+		|| null !== offsets.top
+		|| null !== offsets.right
+		|| null !== offsets.bottom
+		|| null !== offsets.left
+		|| null !== zIndex
+
+	if ( ! hasAny ) {
+		return null
+	}
+
+	return {
+		value,
+		offsets,
+		zIndex,
+	}
+}
+
+/**
+ * Fold an overlay layer on top of a base layer — overlay wins per
+ * field, base fills any nulls. Exported so {@see emitter#mergedBreakpointLayers}
+ * and future callers can share the same fallthrough logic (see #640
+ * review finding on triplicated merge code).
+ */
+export function mergeLayers(
+	base: ResolvedPositionLayer | null,
+	overlay: ResolvedPositionLayer | null,
+): ResolvedPositionLayer | null {
+	if ( ! overlay ) {
+		return base
+	}
+
+	if ( ! base ) {
+		return overlay
+	}
+
+	return {
+		value: overlay.value ?? base.value,
+		offsets: {
+			top:    overlay.offsets.top    ?? base.offsets.top,
+			right:  overlay.offsets.right  ?? base.offsets.right,
+			bottom: overlay.offsets.bottom ?? base.offsets.bottom,
+			left:   overlay.offsets.left   ?? base.offsets.left,
+		},
+		zIndex: overlay.zIndex ?? base.zIndex,
+	}
+}
+
+function readIdle( attributes: PositionAttributes ): ResolvedPositionLayer | null {
+	const subtree = coerceSubtree( attributes.style?.position )
+	return resolveLayer( subtree )
+}
+
+function readBreakpointOverrides(
+	attributes: PositionAttributes,
+): Record<string, ResolvedPositionLayer> {
+	const responsive = attributes.responsive
+
+	if ( ! responsive || 'object' !== typeof responsive ) {
+		return {}
+	}
+
+	const bag = responsive[ 'style.position' ]
+
+	if ( ! bag || 'object' !== typeof bag ) {
+		return {}
+	}
+
+	const out: Record<string, ResolvedPositionLayer> = {}
+
+	for ( const [ key, raw ] of Object.entries( bag ) ) {
+		if ( '' === key || BASE_KEY === key ) {
+			continue
+		}
+
+		const subtree = coerceSubtree( raw )
+		const layer   = resolveLayer( subtree )
+
+		if ( null === layer ) {
+			continue
+		}
+
+		out[ key ] = layer
+	}
+
+	return out
+}
+
+/**
+ * Resolve a block's attribute tree into the normalised payload the
+ * emitter consumes. Returns `null` when no position configuration
+ * exists at any cascade level.
+ */
+export function resolvePosition(
+	attributes: PositionAttributes | null | undefined,
+): ResolvedPosition | null {
+	if ( ! attributes || 'object' !== typeof attributes ) {
+		return null
+	}
+
+	const base        = readIdle( attributes )
+	const breakpoints = readBreakpointOverrides( attributes )
+
+	if ( null === base && 0 === Object.keys( breakpoints ).length ) {
+		return null
+	}
+
+	return { base, breakpoints }
+}
+
+/**
+ * Resolve the effective layer for a specific breakpoint. Larger
+ * breakpoints inherit from smaller ones; missing fields at the target
+ * breakpoint fall through to the next-smaller defined layer.
+ *
+ * Pass `BASE_KEY` (or any unknown key) to get the base layer alone.
+ */
+export function resolveAtBreakpoint(
+	attributes: PositionAttributes | null | undefined,
+	breakpointKey: string,
+	registry: BreakpointRegistry,
+): ResolvedPositionLayer | null {
+	const payload = resolvePosition( attributes )
+
+	if ( null === payload ) {
+		return null
+	}
+
+	if ( BASE_KEY === breakpointKey || ! registry.has( breakpointKey ) ) {
+		return payload.base
+	}
+
+	const ordered = registry.keysWithBase()
+	const target  = ordered.indexOf( breakpointKey )
+
+	if ( -1 === target ) {
+		return payload.base
+	}
+
+	let merged: ResolvedPositionLayer | null = payload.base
+
+	for ( let i = 1; i <= target; i++ ) {
+		const key = ordered[ i ]
+		if ( key in payload.breakpoints ) {
+			merged = mergeLayers( merged, payload.breakpoints[ key ] )
+		}
+	}
+
+	return merged
+}
+
+/**
+ * Read a single offset side directly from the attributes without
+ * booting the resolver. Used by the inspector to distinguish "value
+ * inherited from a smaller breakpoint" from "value set at THIS
+ * breakpoint."
+ */
+export function rawOffsetAt(
+	attributes: PositionAttributes | null | undefined,
+	breakpointKey: string,
+	side: OffsetSide,
+): OffsetValue | null {
+	if ( ! attributes ) {
+		return null
+	}
+
+	const subtree = BASE_KEY === breakpointKey
+		? coerceSubtree( attributes.style?.position )
+		: coerceSubtree(
+			attributes.responsive?.[ 'style.position' ]?.[ breakpointKey ],
+		)
+
+	if ( ! subtree ) {
+		return null
+	}
+
+	const offsets = subtree.offsets as OffsetSubtree | null | undefined
+
+	if ( ! offsets ) {
+		return null
+	}
+
+	return normalizeOffset( offsets[ side ] )
+}
+
+/**
+ * Read the raw `value` field at a specific breakpoint without
+ * inheritance. Returns `null` when the block doesn't set position at
+ * that breakpoint (or when only the offsets/zIndex are set).
+ */
+export function rawValueAt(
+	attributes: PositionAttributes | null | undefined,
+	breakpointKey: string,
+): PositionValue | null {
+	if ( ! attributes ) {
+		return null
+	}
+
+	const subtree = BASE_KEY === breakpointKey
+		? coerceSubtree( attributes.style?.position )
+		: coerceSubtree(
+			attributes.responsive?.[ 'style.position' ]?.[ breakpointKey ],
+		)
+
+	return subtree ? normalizeValue( subtree.value ) : null
+}
+
+/**
+ * Read the raw `zIndex` field at a specific breakpoint without
+ * inheritance.
+ */
+export function rawZIndexAt(
+	attributes: PositionAttributes | null | undefined,
+	breakpointKey: string,
+): number | null {
+	if ( ! attributes ) {
+		return null
+	}
+
+	const subtree = BASE_KEY === breakpointKey
+		? coerceSubtree( attributes.style?.position )
+		: coerceSubtree(
+			attributes.responsive?.[ 'style.position' ]?.[ breakpointKey ],
+		)
+
+	return subtree ? normalizeZIndex( subtree.zIndex ) : null
+}

--- a/resources/js/visual-editor/positioning/types.ts
+++ b/resources/js/visual-editor/positioning/types.ts
@@ -1,0 +1,110 @@
+/**
+ * Shared types for CSS positioning support (#640).
+ *
+ * Extends Gutenberg's `supports.position` — the native shape stores
+ * `attributes.style.position` as a plain string (`'sticky'`). We
+ * layer a structured object on top of the same attribute path so the
+ * resolver can read either shape (see `resolver.ts`).
+ *
+ * Per-breakpoint overrides ride `attributes.responsive['style.position']`
+ * following the routing pattern established in #487 and mirrored in
+ * `box-shadows/types.ts` from #607.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.4.0
+ */
+
+export type PositionValue =
+	| 'static'
+	| 'relative'
+	| 'absolute'
+	| 'fixed'
+	| 'sticky'
+
+export type OffsetUnit = 'px' | '%' | 'rem' | 'em' | 'vh' | 'vw' | 'auto'
+
+export type OffsetSide = 'top' | 'right' | 'bottom' | 'left'
+
+export interface OffsetValue {
+	value: number
+	unit: OffsetUnit
+}
+
+export interface OffsetSubtree {
+	top?: OffsetValue | null
+	right?: OffsetValue | null
+	bottom?: OffsetValue | null
+	left?: OffsetValue | null
+}
+
+/**
+ * Structured position payload written by the inspector. When
+ * `attributes.style.position` is a plain string (legacy Gutenberg
+ * sticky), the resolver widens it to `{ value: 'sticky' }`.
+ */
+export interface PositionSubtree {
+	value?: PositionValue | null
+	offsets?: OffsetSubtree | null
+	zIndex?: number | null
+	[key: string]: unknown
+}
+
+/**
+ * Fully resolved layer at a given cascade level (base or breakpoint).
+ * Absent fields collapse to `null` so the emitter can skip them.
+ */
+export interface ResolvedPositionLayer {
+	value: PositionValue | null
+	offsets: {
+		top: OffsetValue | null
+		right: OffsetValue | null
+		bottom: OffsetValue | null
+		left: OffsetValue | null
+	}
+	zIndex: number | null
+}
+
+export interface ResolvedPosition {
+	base: ResolvedPositionLayer | null
+	breakpoints: Record<string, ResolvedPositionLayer>
+}
+
+/**
+ * The subset of block attributes the resolver reads. Blocks carry
+ * plenty of other attributes; only the slots we touch are typed.
+ */
+export interface PositionAttributes {
+	// The tree is defensive — the resolver normalizes anything.
+	// Slots we care about are typed loosely so test-time inline literals
+	// (whose `unit: 'px'` widens to `string`) round-trip without casts.
+	style?: { position?: unknown } | null
+	responsive?: Record<string, Record<string, unknown>> | null
+	[key: string]: unknown
+}
+
+export const POSITION_VALUES: readonly PositionValue[] = [
+	'static',
+	'relative',
+	'absolute',
+	'fixed',
+	'sticky',
+]
+
+export const OFFSET_UNITS: readonly OffsetUnit[] = [
+	'px',
+	'%',
+	'rem',
+	'em',
+	'vh',
+	'vw',
+	'auto',
+]
+
+export const OFFSET_SIDES: readonly OffsetSide[] = [
+	'top',
+	'right',
+	'bottom',
+	'left',
+]
+
+export const POSITION_ATTRIBUTE_PATH = 'style.position'

--- a/resources/js/visual-editor/positioning/with-position-control.tsx
+++ b/resources/js/visual-editor/positioning/with-position-control.tsx
@@ -26,7 +26,6 @@
 
 import {
 	BaseControl,
-	Button,
 	Notice,
 	SelectControl,
 	__experimentalNumberControl as NumberControl,
@@ -45,7 +44,6 @@ import type { ComponentType } from 'react'
 
 import {
 	getActiveBreakpoint,
-	setActiveBreakpoint,
 	subscribeActiveBreakpoint,
 } from '../responsive/active-breakpoint'
 import { BreakpointRegistry, TAILWIND_V4_DEFAULTS } from '../responsive/registry'
@@ -416,8 +414,6 @@ export const withPositionControl = createHigherOrderComponent(
 				{ label: __( 'Sticky', 'artisanpack-visual-editor' ),   value: 'sticky' },
 			]
 
-			const breakpointTabs = [ BASE_KEY, ...breakpoints.prefixes() ]
-
 			const hasAnyValue =
 				null !== rawValue
 				|| null !== rawZ
@@ -443,32 +439,6 @@ export const withPositionControl = createHigherOrderComponent(
 								isShownByDefault
 							>
 								<BaseControl __nextHasNoMarginBottom>
-									<div
-										className="ap-position__breakpoint-tabs"
-										role="tablist"
-										aria-label={ __( 'Breakpoint', 'artisanpack-visual-editor' ) }
-										style={ { display: 'flex', gap: 4, marginBottom: 12, flexWrap: 'wrap' } }
-									>
-										{ breakpointTabs.map( ( key ) => {
-											const isActive = key === activeBreakpoint
-											const label    = BASE_KEY === key
-												? __( 'Base', 'artisanpack-visual-editor' )
-												: breakpoints.label( key )
-											return (
-												<Button
-													key={ key }
-													role="tab"
-													aria-selected={ isActive }
-													variant={ isActive ? 'primary' : 'secondary' }
-													size="small"
-													onClick={ () => setActiveBreakpoint( key ) }
-												>
-													{ label }
-												</Button>
-											)
-										} ) }
-									</div>
-
 									<SelectControl
 										label={ __( 'Position', 'artisanpack-visual-editor' ) }
 										value={ effectiveValue }

--- a/resources/js/visual-editor/positioning/with-position-control.tsx
+++ b/resources/js/visual-editor/positioning/with-position-control.tsx
@@ -1,0 +1,596 @@
+/**
+ * `editor.BlockEdit` HOC — Position inspector panel (#642, #644).
+ *
+ * Renders a Position panel in the "styles" InspectorControls group for
+ * every block whose `supports.position` is truthy. The panel houses:
+ *
+ *  - A position dropdown (`static / relative / absolute / fixed / sticky`).
+ *  - When non-`static`: number+unit UnitControls for top/right/bottom/
+ *    left and an integer input for z-index.
+ *  - A breakpoint switcher — clicking a breakpoint tab flips the
+ *    editor's active-breakpoint store so ALL responsive controls
+ *    (spacing, typography, etc.) follow along, mirroring the pattern
+ *    used elsewhere in the package.
+ *  - An "Inherited from smaller breakpoint" affordance when the
+ *    currently-viewed breakpoint doesn't override the field.
+ *  - #644 warning notice when the effective position at the active
+ *    breakpoint is `absolute` and no ancestor block sets a non-static
+ *    position.
+ *
+ * Writes go to `attributes.style.position` (base) or
+ * `attributes.responsive['style.position'][<key>]` (per-breakpoint).
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.4.0
+ */
+
+import {
+	BaseControl,
+	Button,
+	Notice,
+	SelectControl,
+	__experimentalNumberControl as NumberControl,
+	__experimentalToolsPanel as ToolsPanel,
+	__experimentalToolsPanelItem as ToolsPanelItem,
+	__experimentalUnitControl as UnitControl,
+} from '@wordpress/components'
+import { createHigherOrderComponent } from '@wordpress/compose'
+import { getBlockType } from '@wordpress/blocks'
+import { InspectorControls } from '@wordpress/block-editor'
+import { useSelect } from '@wordpress/data'
+import { addFilter } from '@wordpress/hooks'
+import { __ } from '@wordpress/i18n'
+import { useCallback, useMemo, useSyncExternalStore } from 'react'
+import type { ComponentType } from 'react'
+
+import {
+	getActiveBreakpoint,
+	setActiveBreakpoint,
+	subscribeActiveBreakpoint,
+} from '../responsive/active-breakpoint'
+import { BreakpointRegistry, TAILWIND_V4_DEFAULTS } from '../responsive/registry'
+import { BASE_KEY } from '../responsive/types'
+import { positionEnabled } from './extend-supports'
+import {
+	coerceSubtree,
+	rawOffsetAt,
+	rawValueAt,
+	rawZIndexAt,
+	resolveAtBreakpoint,
+} from './resolver'
+import {
+	OFFSET_SIDES,
+	OFFSET_UNITS,
+	POSITION_ATTRIBUTE_PATH,
+	POSITION_VALUES,
+	type OffsetSide,
+	type OffsetValue,
+	type PositionAttributes,
+	type PositionSubtree,
+	type PositionValue,
+} from './types'
+
+const FILTER_HOOK      = 'editor.BlockEdit'
+const FILTER_NAMESPACE = 'artisanpack-ui/visual-editor/position-control'
+
+const REGISTERED_KEY = Symbol.for(
+	'artisanpack-ui.visual-editor.position-control.registered',
+)
+
+interface GlobalSentinelHost {
+	[REGISTERED_KEY]?: boolean
+}
+
+interface BlockEditProps {
+	name: string
+	clientId?: string
+	attributes: PositionAttributes & Record<string, unknown>
+	setAttributes: ( updates: Record<string, unknown> ) => void
+	[key: string]: unknown
+}
+
+const breakpoints = new BreakpointRegistry( TAILWIND_V4_DEFAULTS )
+
+function blockSupportsPosition( name: string ): boolean {
+	const blockType = getBlockType( name )
+	if ( ! blockType ) {
+		return false
+	}
+	return positionEnabled( blockType.supports as Record<string, unknown> | undefined )
+}
+
+function readBaseSubtree( attributes: PositionAttributes ): PositionSubtree {
+	const raw = coerceSubtree( attributes.style?.position )
+	return raw ?? {}
+}
+
+function readBreakpointSubtree(
+	attributes: PositionAttributes,
+	key: string,
+): PositionSubtree {
+	if ( BASE_KEY === key ) {
+		return readBaseSubtree( attributes )
+	}
+
+	const raw = coerceSubtree( attributes.responsive?.[ POSITION_ATTRIBUTE_PATH ]?.[ key ] )
+	return raw ?? {}
+}
+
+/**
+ * Compose a `setAttributes` payload that writes a patched subtree to
+ * the base slot (`style.position`) or the responsive slot (
+ * `responsive['style.position'][key]`) depending on the active
+ * breakpoint. Empty subtrees are collapsed to `null` (base) or the key
+ * is removed (responsive) so downstream consumers don't have to
+ * distinguish "empty object" from "no data".
+ */
+function writeSubtree(
+	attributes: PositionAttributes,
+	setAttributes: ( updates: Record<string, unknown> ) => void,
+	breakpointKey: string,
+	next: PositionSubtree,
+): void {
+	const cleaned = collapseSubtree( next )
+
+	if ( BASE_KEY === breakpointKey ) {
+		const style = ( attributes.style && 'object' === typeof attributes.style )
+			? ( attributes.style as Record<string, unknown> )
+			: {}
+
+		if ( null === cleaned ) {
+			const { position: _drop, ...rest } = style
+			setAttributes( { style: rest } )
+			return
+		}
+
+		// Preserve any private scope-id already on the current subtree
+		// (see `with-position-styles.tsx` for `_positionScopeId`).
+		const existing = style.position && 'object' === typeof style.position
+			? ( style.position as Record<string, unknown> )
+			: {}
+
+		const preserved: Record<string, unknown> = {}
+		if ( 'string' === typeof existing._positionScopeId ) {
+			preserved._positionScopeId = existing._positionScopeId
+		}
+
+		setAttributes( {
+			style: {
+				...style,
+				position: { ...preserved, ...cleaned },
+			},
+		} )
+		return
+	}
+
+	const responsive = ( attributes.responsive && 'object' === typeof attributes.responsive )
+		? ( attributes.responsive as Record<string, Record<string, unknown>> )
+		: {}
+
+	const bag = ( responsive[ POSITION_ATTRIBUTE_PATH ] && 'object' === typeof responsive[ POSITION_ATTRIBUTE_PATH ] )
+		? { ...responsive[ POSITION_ATTRIBUTE_PATH ] }
+		: {}
+
+	if ( null === cleaned ) {
+		delete bag[ breakpointKey ]
+	} else {
+		bag[ breakpointKey ] = cleaned
+	}
+
+	const nextResponsive: Record<string, unknown> = { ...responsive }
+
+	if ( 0 === Object.keys( bag ).length ) {
+		delete nextResponsive[ POSITION_ATTRIBUTE_PATH ]
+	} else {
+		nextResponsive[ POSITION_ATTRIBUTE_PATH ] = bag
+	}
+
+	setAttributes( { responsive: nextResponsive } )
+}
+
+/**
+ * Strip null/undefined leaves and collapse empty objects. Returns
+ * `null` when nothing meaningful remains.
+ */
+function collapseSubtree( subtree: PositionSubtree ): PositionSubtree | null {
+	const out: PositionSubtree = {}
+
+	if ( null !== subtree.value && undefined !== subtree.value ) {
+		out.value = subtree.value
+	}
+
+	if ( subtree.offsets && 'object' === typeof subtree.offsets ) {
+		const offsets: Record<string, OffsetValue> = {}
+		for ( const side of OFFSET_SIDES ) {
+			const val = subtree.offsets[ side ]
+			if ( val && 'object' === typeof val ) {
+				offsets[ side ] = val
+			}
+		}
+		if ( 0 < Object.keys( offsets ).length ) {
+			out.offsets = offsets
+		}
+	}
+
+	if ( null !== subtree.zIndex && undefined !== subtree.zIndex ) {
+		out.zIndex = subtree.zIndex
+	}
+
+	return 0 === Object.keys( out ).length ? null : out
+}
+
+/**
+ * Compute whether any ancestor block sets a non-static position (#644).
+ * Reads the effective position at the currently-viewed breakpoint so
+ * the warning stays in sync with the switcher.
+ */
+function useHasPositionedAncestor(
+	clientId: string | undefined,
+	activeBreakpoint: string,
+): boolean {
+	return useSelect(
+		( select ) => {
+			if ( ! clientId ) {
+				return false
+			}
+
+			const store = select( 'core/block-editor' ) as {
+				getBlockParents: ( id: string ) => string[]
+				getBlockAttributes: ( id: string ) => Record<string, unknown> | undefined
+			}
+
+			const parents = store.getBlockParents( clientId )
+
+			for ( const parentId of parents ) {
+				const attrs = store.getBlockAttributes( parentId )
+				if ( ! attrs ) {
+					continue
+				}
+
+				const layer = resolveAtBreakpoint(
+					attrs as PositionAttributes,
+					activeBreakpoint,
+					breakpoints,
+				)
+
+				if ( layer && null !== layer.value && 'static' !== layer.value ) {
+					return true
+				}
+			}
+
+			return false
+		},
+		[ clientId, activeBreakpoint ],
+	)
+}
+
+function parseUnitControl( raw: string | undefined ): OffsetValue | null {
+	if ( undefined === raw || null === raw ) {
+		return null
+	}
+	const trimmed = raw.trim()
+	if ( '' === trimmed ) {
+		return null
+	}
+	if ( 'auto' === trimmed.toLowerCase() ) {
+		return { value: 0, unit: 'auto' }
+	}
+
+	const match = trimmed.match( /^(-?\d+(?:\.\d+)?)\s*([a-z%]+)$/i )
+	if ( ! match ) {
+		return null
+	}
+
+	const unit = match[ 2 ].toLowerCase()
+	if ( ! ( OFFSET_UNITS as readonly string[] ).includes( unit ) ) {
+		return null
+	}
+
+	const numeric = Number( match[ 1 ] )
+	if ( ! Number.isFinite( numeric ) ) {
+		return null
+	}
+
+	return { value: numeric, unit: unit as OffsetValue[ 'unit' ] }
+}
+
+function formatUnitControl( offset: OffsetValue | null ): string {
+	if ( ! offset ) {
+		return ''
+	}
+	if ( 'auto' === offset.unit ) {
+		return 'auto'
+	}
+	return `${ offset.value }${ offset.unit }`
+}
+
+export const withPositionControl = createHigherOrderComponent(
+	( BlockEdit: ComponentType<BlockEditProps> ) => {
+		function PositionBlockEdit( props: BlockEditProps ): JSX.Element {
+			const { name, attributes, setAttributes, clientId } = props
+
+			const enabled = useMemo( () => blockSupportsPosition( name ), [ name ] )
+
+			const activeBreakpoint = useSyncExternalStore(
+				subscribeActiveBreakpoint,
+				getActiveBreakpoint,
+				getActiveBreakpoint,
+			)
+
+			const effectiveLayer = useMemo(
+				() => resolveAtBreakpoint( attributes, activeBreakpoint, breakpoints ),
+				[ attributes, activeBreakpoint ],
+			)
+
+			const rawValue = useMemo(
+				() => rawValueAt( attributes, activeBreakpoint ),
+				[ attributes, activeBreakpoint ],
+			)
+
+			const rawZ = useMemo(
+				() => rawZIndexAt( attributes, activeBreakpoint ),
+				[ attributes, activeBreakpoint ],
+			)
+
+			const rawOffsets = useMemo(
+				() => ( {
+					top:    rawOffsetAt( attributes, activeBreakpoint, 'top' ),
+					right:  rawOffsetAt( attributes, activeBreakpoint, 'right' ),
+					bottom: rawOffsetAt( attributes, activeBreakpoint, 'bottom' ),
+					left:   rawOffsetAt( attributes, activeBreakpoint, 'left' ),
+				} ),
+				[ attributes, activeBreakpoint ],
+			)
+
+			const hasPositionedAncestor = useHasPositionedAncestor(
+				clientId,
+				activeBreakpoint,
+			)
+
+			const writePatch = useCallback(
+				( patch: Partial<PositionSubtree> ) => {
+					const current = readBreakpointSubtree( attributes, activeBreakpoint )
+					const next: PositionSubtree = { ...current }
+
+					if ( 'value' in patch ) {
+						if ( null === patch.value ) {
+							delete next.value
+						} else {
+							next.value = patch.value
+						}
+					}
+
+					if ( 'zIndex' in patch ) {
+						if ( null === patch.zIndex || undefined === patch.zIndex ) {
+							delete next.zIndex
+						} else {
+							next.zIndex = patch.zIndex
+						}
+					}
+
+					if ( 'offsets' in patch && patch.offsets ) {
+						const nextOffsets = { ...( next.offsets ?? {} ) }
+						for ( const side of OFFSET_SIDES ) {
+							if ( side in patch.offsets ) {
+								const nextVal = patch.offsets[ side ]
+								if ( null === nextVal || undefined === nextVal ) {
+									delete nextOffsets[ side ]
+								} else {
+									nextOffsets[ side ] = nextVal
+								}
+							}
+						}
+						if ( 0 === Object.keys( nextOffsets ).length ) {
+							delete next.offsets
+						} else {
+							next.offsets = nextOffsets
+						}
+					}
+
+					writeSubtree( attributes, setAttributes, activeBreakpoint, next )
+				},
+				[ attributes, setAttributes, activeBreakpoint ],
+			)
+
+			const resetPanel = useCallback( () => {
+				writeSubtree( attributes, setAttributes, activeBreakpoint, {} )
+			}, [ attributes, setAttributes, activeBreakpoint ] )
+
+			if ( ! enabled ) {
+				return <BlockEdit { ...props } />
+			}
+
+			const effectiveValue = effectiveLayer?.value ?? 'static'
+			const showFields     = 'static' !== effectiveValue && null !== effectiveValue
+
+			// #644: warning is shown when the RESOLVED position at this
+			// breakpoint is absolute and no ancestor is positioned.
+			const showAncestorWarning =
+				'absolute' === effectiveValue && ! hasPositionedAncestor
+
+			const positionOptions = [
+				{ label: __( 'Static', 'artisanpack-visual-editor' ),   value: 'static' },
+				{ label: __( 'Relative', 'artisanpack-visual-editor' ), value: 'relative' },
+				{ label: __( 'Absolute', 'artisanpack-visual-editor' ), value: 'absolute' },
+				{ label: __( 'Fixed', 'artisanpack-visual-editor' ),    value: 'fixed' },
+				{ label: __( 'Sticky', 'artisanpack-visual-editor' ),   value: 'sticky' },
+			]
+
+			const breakpointTabs = [ BASE_KEY, ...breakpoints.prefixes() ]
+
+			const hasAnyValue =
+				null !== rawValue
+				|| null !== rawZ
+				|| null !== rawOffsets.top
+				|| null !== rawOffsets.right
+				|| null !== rawOffsets.bottom
+				|| null !== rawOffsets.left
+
+			return (
+				<>
+					<BlockEdit { ...props } />
+					<InspectorControls group="styles">
+						<ToolsPanel
+							label={ __( 'Position', 'artisanpack-visual-editor' ) }
+							resetAll={ resetPanel }
+							panelId={ clientId }
+						>
+							<ToolsPanelItem
+								panelId={ clientId }
+								hasValue={ () => hasAnyValue }
+								label={ __( 'Position', 'artisanpack-visual-editor' ) }
+								onDeselect={ resetPanel }
+								isShownByDefault
+							>
+								<BaseControl __nextHasNoMarginBottom>
+									<div
+										className="ap-position__breakpoint-tabs"
+										role="tablist"
+										aria-label={ __( 'Breakpoint', 'artisanpack-visual-editor' ) }
+										style={ { display: 'flex', gap: 4, marginBottom: 12, flexWrap: 'wrap' } }
+									>
+										{ breakpointTabs.map( ( key ) => {
+											const isActive = key === activeBreakpoint
+											const label    = BASE_KEY === key
+												? __( 'Base', 'artisanpack-visual-editor' )
+												: breakpoints.label( key )
+											return (
+												<Button
+													key={ key }
+													role="tab"
+													aria-selected={ isActive }
+													variant={ isActive ? 'primary' : 'secondary' }
+													size="small"
+													onClick={ () => setActiveBreakpoint( key ) }
+												>
+													{ label }
+												</Button>
+											)
+										} ) }
+									</div>
+
+									<SelectControl
+										label={ __( 'Position', 'artisanpack-visual-editor' ) }
+										value={ effectiveValue }
+										options={ positionOptions }
+										help={ null === rawValue && BASE_KEY !== activeBreakpoint
+											? __(
+												'Inherited from a smaller breakpoint. Change to override.',
+												'artisanpack-visual-editor',
+											)
+											: undefined }
+										onChange={ ( next: string ) => {
+											if ( ! POSITION_VALUES.includes( next as PositionValue ) ) {
+												return
+											}
+											writePatch( { value: next as PositionValue } )
+										} }
+										__nextHasNoMarginBottom
+										__next40pxDefaultSize
+									/>
+
+									{ showAncestorWarning && (
+										<Notice
+											status="warning"
+											isDismissible={ false }
+											className="ap-position__ancestor-warning"
+										>
+											{ __(
+												'This block is set to position: absolute but none of its ancestor blocks is positioned. It will position relative to the nearest positioned ancestor — often the page.',
+												'artisanpack-visual-editor',
+											) }
+										</Notice>
+									) }
+
+									{ showFields && (
+										<>
+											<div style={ { display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8, marginTop: 12 } }>
+												{ OFFSET_SIDES.map( ( side ) => {
+													const raw       = rawOffsets[ side ]
+													const effective = effectiveLayer?.offsets[ side ] ?? null
+													const inherited = null === raw && BASE_KEY !== activeBreakpoint && null !== effective
+
+													return (
+														<UnitControl
+															key={ side }
+															label={ sideLabel( side ) }
+															value={ formatUnitControl( effective ) }
+															units={ OFFSET_UNITS.map( ( unit ) => ( { value: unit, label: unit } ) ) }
+															help={ inherited
+																? __( 'Inherited', 'artisanpack-visual-editor' )
+																: undefined }
+															onChange={ ( next: string | undefined ) => {
+																const parsed = parseUnitControl( next )
+																writePatch( { offsets: { [ side ]: parsed } } )
+															} }
+															__next40pxDefaultSize
+														/>
+													)
+												} ) }
+											</div>
+
+											<div style={ { marginTop: 12 } }>
+												<NumberControl
+													label={ __( 'z-index', 'artisanpack-visual-editor' ) }
+													value={ effectiveLayer?.zIndex ?? '' }
+													onChange={ ( next: string | number | undefined ) => {
+														if ( undefined === next || '' === next ) {
+															writePatch( { zIndex: null } )
+															return
+														}
+														const parsed = Number( next )
+														if ( Number.isFinite( parsed ) ) {
+															writePatch( { zIndex: Math.trunc( parsed ) } )
+														}
+													} }
+													help={ null === rawZ && BASE_KEY !== activeBreakpoint && null !== effectiveLayer?.zIndex
+														? __( 'Inherited', 'artisanpack-visual-editor' )
+														: undefined }
+													__next40pxDefaultSize
+												/>
+											</div>
+										</>
+									) }
+								</BaseControl>
+							</ToolsPanelItem>
+						</ToolsPanel>
+					</InspectorControls>
+				</>
+			)
+		}
+
+		PositionBlockEdit.displayName = 'PositionBlockEdit'
+
+		return PositionBlockEdit
+	},
+	'withPositionControl',
+)
+
+function sideLabel( side: OffsetSide ): string {
+	switch ( side ) {
+		case 'top':
+			return __( 'Top', 'artisanpack-visual-editor' )
+		case 'right':
+			return __( 'Right', 'artisanpack-visual-editor' )
+		case 'bottom':
+			return __( 'Bottom', 'artisanpack-visual-editor' )
+		case 'left':
+			return __( 'Left', 'artisanpack-visual-editor' )
+	}
+}
+
+/**
+ * Register the BlockEdit filter at most once per page. Idempotent —
+ * safe to call from both the post-editor and site-editor bootstrap
+ * paths.
+ */
+export function registerPositionControl(): void {
+	const host = globalThis as unknown as GlobalSentinelHost
+
+	if ( host[ REGISTERED_KEY ] ) {
+		return
+	}
+
+	addFilter( FILTER_HOOK, FILTER_NAMESPACE, withPositionControl )
+	host[ REGISTERED_KEY ] = true
+}

--- a/resources/js/visual-editor/positioning/with-position-control.tsx
+++ b/resources/js/visual-editor/positioning/with-position-control.tsx
@@ -7,10 +7,12 @@
  *  - A position dropdown (`static / relative / absolute / fixed / sticky`).
  *  - When non-`static`: number+unit UnitControls for top/right/bottom/
  *    left and an integer input for z-index.
- *  - A breakpoint switcher — clicking a breakpoint tab flips the
- *    editor's active-breakpoint store so ALL responsive controls
- *    (spacing, typography, etc.) follow along, mirroring the pattern
- *    used elsewhere in the package.
+ *  - Follows the editor's top-bar `ViewportSwitcher` via the shared
+ *    active-breakpoint store. Every field re-reads its effective
+ *    value when the switcher flips, and surfaces an "Inherited" hint
+ *    on any field not overridden at the currently-viewed breakpoint.
+ *    Matches every sibling responsive-aware panel — no per-panel
+ *    breakpoint control.
  *  - An "Inherited from smaller breakpoint" affordance when the
  *    currently-viewed breakpoint doesn't override the field.
  *  - #644 warning notice when the effective position at the active

--- a/resources/js/visual-editor/positioning/with-position-styles.tsx
+++ b/resources/js/visual-editor/positioning/with-position-styles.tsx
@@ -1,0 +1,478 @@
+/**
+ * Position CSS emission — editor canvas + saved markup (#643).
+ *
+ * Mirrors `with-box-shadow-styles.tsx` from #607: a mintable scope id
+ * (`_positionScopeId`) lives on the position subtree; the wrapper
+ * carries a `ve-pos-<id>` class; and a `<style>` element scoped by
+ * that class carries the emitted CSS. Both the canvas
+ * (`editor.BlockListBlock`) and the save path
+ * (`blocks.getSaveContent.extraProps` + `blocks.getSaveElement`)
+ * apply the same emission.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.4.0
+ */
+
+import { getBlockType } from '@wordpress/blocks'
+import { createHigherOrderComponent } from '@wordpress/compose'
+import { addFilter } from '@wordpress/hooks'
+import { Fragment, createElement, useEffect, useMemo, useRef } from 'react'
+import type { ComponentType, ReactNode } from 'react'
+
+import { BreakpointRegistry, TAILWIND_V4_DEFAULTS } from '../responsive/registry'
+import { emitPositionCss, mergedBreakpointLayers } from './emitter'
+import { positionEnabled } from './extend-supports'
+import { resolvePosition } from './resolver'
+import type { PositionAttributes, PositionSubtree } from './types'
+
+const BLOCK_FILTER_HOOK = 'editor.BlockListBlock'
+const SAVE_PROPS_HOOK   = 'blocks.getSaveContent.extraProps'
+const SAVE_ELEMENT_HOOK = 'blocks.getSaveElement'
+
+const FILTER_NAMESPACE = 'artisanpack-ui/visual-editor/position-styles'
+
+const REGISTERED_KEY = Symbol.for(
+	'artisanpack-ui.visual-editor.position-styles.registered',
+)
+
+interface GlobalSentinelHost {
+	[REGISTERED_KEY]?: boolean
+}
+
+interface BlockListBlockProps {
+	name: string
+	clientId: string
+	attributes: PositionAttributes & Record<string, unknown>
+	setAttributes?: ( updates: Record<string, unknown> ) => void
+	wrapperProps?: Record<string, unknown>
+	[key: string]: unknown
+}
+
+interface BlockSettingsLike {
+	supports?: Record<string, unknown>
+	[key: string]: unknown
+}
+
+interface PositionSubtreeWithScope extends PositionSubtree {
+	_positionScopeId?: string
+}
+
+const SCOPE_ID_KEY     = '_positionScopeId'
+const SCOPE_ID_PATTERN = /^[a-z0-9][a-z0-9_-]{0,63}$/i
+
+const breakpoints = new BreakpointRegistry( TAILWIND_V4_DEFAULTS )
+
+function blockSupportsPosition( name: string ): boolean {
+	const blockType = getBlockType( name )
+	if ( ! blockType ) {
+		return false
+	}
+
+	return positionEnabled( blockType.supports as Record<string, unknown> | undefined )
+}
+
+function scopeIdToClass( scopeId: string ): string {
+	return `ve-pos-${ scopeId }`
+}
+
+function readScopeId( attributes: PositionAttributes | undefined ): string | null {
+	const raw = attributes?.style?.position
+	if ( ! raw || 'object' !== typeof raw ) {
+		return null
+	}
+
+	const scoped = raw as PositionSubtreeWithScope
+	const value  = scoped[ SCOPE_ID_KEY ]
+
+	if ( 'string' !== typeof value ) {
+		return null
+	}
+
+	const trimmed = value.trim()
+	return SCOPE_ID_PATTERN.test( trimmed ) ? trimmed : null
+}
+
+function hasAuthoredAnyPosition(
+	attributes: PositionAttributes | undefined,
+): boolean {
+	return null !== resolvePosition( attributes )
+}
+
+function mintScopeId(): string {
+	return Math.random().toString( 36 ).slice( 2, 11 )
+}
+
+const scopeIdOwners = new Map<string, string>()
+
+function claimScopeId( scopeId: string, clientId: string ): boolean {
+	const owner = scopeIdOwners.get( scopeId )
+	if ( ! owner ) {
+		scopeIdOwners.set( scopeId, clientId )
+		return true
+	}
+	return owner === clientId
+}
+
+function releaseScopeId( scopeId: string, clientId: string ): void {
+	if ( scopeIdOwners.get( scopeId ) === clientId ) {
+		scopeIdOwners.delete( scopeId )
+	}
+}
+
+function writeScopeId(
+	attributes: PositionAttributes,
+	setAttributes: ( updates: Record<string, unknown> ) => void,
+	nextId: string,
+): void {
+	const style = ( attributes.style && 'object' === typeof attributes.style )
+		? ( attributes.style as Record<string, unknown> )
+		: {}
+	const rawPosition = style.position
+	// `position` may be a bare string (legacy Gutenberg sticky) — widen
+	// it to a structured subtree so we have a slot to write the scope
+	// id onto without clobbering the value.
+	const positionObj =
+		rawPosition && 'object' === typeof rawPosition
+			? ( rawPosition as Record<string, unknown> )
+			: ( 'string' === typeof rawPosition
+				? { value: rawPosition }
+				: {} )
+
+	setAttributes( {
+		style: {
+			...style,
+			position: {
+				...positionObj,
+				[ SCOPE_ID_KEY ]: nextId,
+			},
+		},
+	} )
+}
+
+function emitCssForBlock(
+	scopeId: string,
+	attributes: PositionAttributes,
+): string {
+	const payload = resolvePosition( attributes )
+	if ( ! payload ) {
+		return ''
+	}
+
+	const merged = mergedBreakpointLayers( payload, breakpoints )
+
+	return emitPositionCss(
+		`.${ scopeIdToClass( scopeId ) }`,
+		payload,
+		breakpoints,
+		merged,
+	)
+}
+
+export const withPositionStyles = createHigherOrderComponent(
+	( BlockListBlock: ComponentType<BlockListBlockProps> ) => {
+		function PositionStyledBlock( props: BlockListBlockProps ): JSX.Element {
+			const { name, clientId, attributes, setAttributes, wrapperProps } = props
+
+			const supported = blockSupportsPosition( name )
+
+			const scopeId = useMemo( () => readScopeId( attributes ), [ attributes ] )
+
+			const hasOverrides = useMemo(
+				() => hasAuthoredAnyPosition( attributes ),
+				[ attributes ],
+			)
+
+			const persistedRef = useRef( scopeId )
+			useEffect( () => {
+				persistedRef.current = scopeId
+			}, [ scopeId ] )
+
+			useEffect( () => {
+				if ( ! supported || ! setAttributes ) {
+					return
+				}
+
+				const needsMint    = ! scopeId && hasOverrides
+				const hasCollision = scopeId !== null && ! claimScopeId( scopeId, clientId )
+
+				if ( ! needsMint && ! hasCollision ) {
+					return
+				}
+
+				const nextId = mintScopeId()
+				claimScopeId( nextId, clientId )
+				writeScopeId( attributes, setAttributes, nextId )
+			}, [ supported, scopeId, hasOverrides, attributes, setAttributes, clientId ] )
+
+			useEffect( () => {
+				if ( ! scopeId ) {
+					return
+				}
+				return () => releaseScopeId( scopeId, clientId )
+			}, [ scopeId, clientId ] )
+
+			const effectiveScopeId = scopeId ?? persistedRef.current
+
+			const css = useMemo( () => {
+				if ( ! supported || ! effectiveScopeId ) {
+					return ''
+				}
+				return emitCssForBlock( effectiveScopeId, attributes )
+			}, [ supported, effectiveScopeId, attributes ] )
+
+			const effectiveWrapperProps: Record<string, unknown> = useMemo( () => {
+				if ( ! supported || ! effectiveScopeId ) {
+					return wrapperProps ?? {}
+				}
+
+				const existingClass = ( wrapperProps?.className as string | undefined ) ?? ''
+				const scopeClass    = scopeIdToClass( effectiveScopeId )
+
+				if ( existingClass.split( /\s+/ ).includes( scopeClass ) ) {
+					return wrapperProps ?? {}
+				}
+
+				return {
+					...( wrapperProps ?? {} ),
+					className: existingClass
+						? `${ existingClass } ${ scopeClass }`
+						: scopeClass,
+					// Diagnostic hook — surfaces the scope id in DevTools
+					// so a QA pass can spot the presence/absence at a
+					// glance without opening the block's props panel.
+					'data-ap-position-scope': effectiveScopeId,
+				}
+			}, [ supported, wrapperProps, effectiveScopeId ] )
+
+			if ( ! supported ) {
+				return <BlockListBlock { ...props } />
+			}
+
+			const wrapped = (
+				<BlockListBlock
+					{ ...props }
+					wrapperProps={ effectiveWrapperProps }
+				/>
+			)
+
+			if ( '' === css ) {
+				return wrapped
+			}
+
+			return (
+				<Fragment>
+					<style data-ap-position-scope={ effectiveScopeId }>{ css }</style>
+					{ wrapped }
+				</Fragment>
+			)
+		}
+
+		PositionStyledBlock.displayName = 'PositionStyledBlock'
+
+		return PositionStyledBlock
+	},
+	'withPositionStyles',
+)
+
+function blockSupportsConfigOnSettings( blockType: BlockSettingsLike | undefined ): boolean {
+	return positionEnabled( blockType?.supports as Record<string, unknown> | undefined )
+}
+
+function addSaveProps(
+	extraProps: Record<string, unknown>,
+	blockType: BlockSettingsLike,
+	attributes: PositionAttributes & Record<string, unknown>,
+): Record<string, unknown> {
+	if ( ! blockSupportsConfigOnSettings( blockType ) ) {
+		return extraProps
+	}
+
+	const scopeId = readScopeId( attributes )
+	if ( ! scopeId || ! hasAuthoredAnyPosition( attributes ) ) {
+		return extraProps
+	}
+
+	const css = emitCssForBlock( scopeId, attributes )
+	if ( '' === css ) {
+		return extraProps
+	}
+
+	const existingClass = ( extraProps.className as string | undefined ) ?? ''
+	const scopeClass    = scopeIdToClass( scopeId )
+
+	const nextClass = existingClass.split( /\s+/ ).includes( scopeClass )
+		? existingClass
+		: ( existingClass ? `${ existingClass } ${ scopeClass }` : scopeClass )
+
+	// Also stamp the BASE layer as inline styles on the wrapper. The
+	// `<style>` element `wrapSaveElement` appends below carries the same
+	// declarations for the base rule PLUS every `@media` breakpoint
+	// override, but `<style>` tags inside serialized block markup get
+	// dropped by `wp_kses_post` / the equivalent sanitizer on plenty of
+	// hosts. Inline styles survive that filter path and inherit the
+	// wrapper's inline-style specificity (higher than the `!important`
+	// class rule we emit for the editor canvas). Breakpoint overrides
+	// still need `<style>` — no way to express `@media` inline.
+	const baseStyle = baseInlineStyle( attributes )
+	if ( '' === baseStyle ) {
+		return {
+			...extraProps,
+			className: nextClass,
+		}
+	}
+
+	const existingStyle = ( extraProps.style as Record<string, string> | string | undefined ) ?? undefined
+
+	// Gutenberg's core panels sometimes stamp `style` as an object and
+	// sometimes as a string — merge either into the resulting string
+	// without duplicating declarations we've already stamped for a
+	// prior render pass (same-attribute idempotency).
+	const mergedStyle = mergeStyle( existingStyle, baseStyle )
+
+	return {
+		...extraProps,
+		className: nextClass,
+		style: mergedStyle,
+	}
+}
+
+/**
+ * Build a semicolon-terminated inline declaration string for the base
+ * layer only — media-query overrides continue to ride the `<style>`
+ * element from `wrapSaveElement`.
+ */
+function baseInlineStyle(
+	attributes: PositionAttributes & Record<string, unknown>,
+): string {
+	const payload = resolvePosition( attributes )
+	if ( ! payload ) {
+		return ''
+	}
+
+	const base = payload.base
+	if ( ! base || null === base.value || 'static' === base.value ) {
+		return ''
+	}
+
+	// Mirror the PHP counterpart's `!important` — the inline fallback
+	// only exists for hosts that strip the `<style data-ap-position-scope>`
+	// element, and without `!important` a theme's `!important` reset on
+	// the wrapper class outranks us in that exact scenario.
+	const parts: string[] = [ `position: ${ base.value } !important` ]
+
+	if ( null !== base.offsets.top ) {
+		parts.push( `top: ${ formatInlineOffset( base.offsets.top ) } !important` )
+	}
+	if ( null !== base.offsets.right ) {
+		parts.push( `right: ${ formatInlineOffset( base.offsets.right ) } !important` )
+	}
+	if ( null !== base.offsets.bottom ) {
+		parts.push( `bottom: ${ formatInlineOffset( base.offsets.bottom ) } !important` )
+	}
+	if ( null !== base.offsets.left ) {
+		parts.push( `left: ${ formatInlineOffset( base.offsets.left ) } !important` )
+	}
+	if ( null !== base.zIndex ) {
+		parts.push( `z-index: ${ base.zIndex } !important` )
+	}
+
+	return parts.join( '; ' ) + ';'
+}
+
+function formatInlineOffset( offset: { value: number; unit: string } ): string {
+	if ( 'auto' === offset.unit ) {
+		return 'auto'
+	}
+	return `${ offset.value }${ offset.unit }`
+}
+
+// Anchor `position:` to a declaration boundary (start-of-string or
+// after a semicolon), NOT any substring. `background-position:`,
+// `object-position:`, `transition: position …` would otherwise trip
+// the idempotency guard and silently drop our inline stamp — the
+// wrapper renders unpositioned even though the user configured a value.
+const POSITION_DECL_RE = /(?:^|;)\s*position\s*:/i
+
+function mergeStyle(
+	existing: Record<string, string> | string | undefined,
+	next: string,
+): string {
+	if ( ! existing ) {
+		return next
+	}
+
+	if ( 'string' === typeof existing ) {
+		if ( POSITION_DECL_RE.test( existing ) ) {
+			return existing
+		}
+		const trimmed = existing.trim()
+		if ( '' === trimmed ) {
+			return next
+		}
+		const separator = trimmed.endsWith( ';' ) ? ' ' : '; '
+		return `${ trimmed }${ separator }${ next }`
+	}
+
+	// Object form — convert to string.
+	const stringified = Object.entries( existing )
+		.map( ( [ prop, val ] ) => `${ toKebab( prop ) }: ${ val }` )
+		.join( '; ' )
+
+	if ( '' === stringified ) {
+		return next
+	}
+
+	if ( POSITION_DECL_RE.test( stringified ) ) {
+		return stringified + ';'
+	}
+
+	return `${ stringified }; ${ next }`
+}
+
+function toKebab( value: string ): string {
+	return value.replace( /[A-Z]/g, ( m ) => `-${ m.toLowerCase() }` )
+}
+
+function wrapSaveElement(
+	element: unknown,
+	blockType: BlockSettingsLike,
+	attributes: PositionAttributes & Record<string, unknown>,
+): unknown {
+	if ( ! blockSupportsConfigOnSettings( blockType ) ) {
+		return element
+	}
+
+	const scopeId = readScopeId( attributes )
+	if ( ! scopeId ) {
+		return element
+	}
+
+	const css = emitCssForBlock( scopeId, attributes )
+	if ( '' === css ) {
+		return element
+	}
+
+	return createElement(
+		Fragment,
+		null,
+		element as ReactNode,
+		createElement( 'style', { 'data-ap-position-scope': scopeId }, css ),
+	)
+}
+
+/**
+ * Idempotent — safe to call from both the post-editor and site-editor
+ * bootstrap paths.
+ */
+export function registerPositionStylesFilters(): void {
+	const host = globalThis as unknown as GlobalSentinelHost
+
+	if ( host[ REGISTERED_KEY ] ) {
+		return
+	}
+
+	addFilter( BLOCK_FILTER_HOOK, FILTER_NAMESPACE, withPositionStyles )
+	addFilter( SAVE_PROPS_HOOK, FILTER_NAMESPACE, addSaveProps )
+	addFilter( SAVE_ELEMENT_HOOK, FILTER_NAMESPACE, wrapSaveElement )
+	host[ REGISTERED_KEY ] = true
+}

--- a/resources/js/visual-editor/site-editor/__tests__/site-editor-app.test.tsx
+++ b/resources/js/visual-editor/site-editor/__tests__/site-editor-app.test.tsx
@@ -216,6 +216,11 @@ vi.mock('../../box-shadows/register', () => ({
     registerBoxShadows: (): void => undefined,
 }));
 
+// #640: same JSON-import-attribute trip for the positioning registrar.
+vi.mock('../../positioning/register', () => ({
+    registerPositioning: (): void => undefined,
+}));
+
 import { resetActiveBreakpoint } from '../../responsive/active-breakpoint';
 import { SiteEditorApp } from '../site-editor-app';
 

--- a/resources/js/visual-editor/site-editor/site-editor-app.tsx
+++ b/resources/js/visual-editor/site-editor/site-editor-app.tsx
@@ -49,6 +49,7 @@ import { registerBackgroundControls } from '../background-controls';
 import { registerArtisanPackBlocks } from '../blocks';
 import { registerBoxShadows } from '../box-shadows/register';
 import { registerGradientBorders } from '../gradient-borders/register';
+import { registerPositioning } from '../positioning/register';
 
 import { BlockLibrarySidebar } from '../editor/block-library-sidebar';
 import { TopBar } from '../editor/top-bar';
@@ -187,6 +188,7 @@ function ensureEditorBoot(): void {
     // blocks pick up the routed `border.gradient` path at registration.
     registerGradientBorders();
     registerBoxShadows();
+    registerPositioning();
 
     // I7 (#415): register all artisanpack/* blocks and set the default
     // block to artisanpack/paragraph. Core blocks are no longer loaded.

--- a/src/Position/PositionEmitter.php
+++ b/src/Position/PositionEmitter.php
@@ -1,0 +1,161 @@
+<?php
+
+/**
+ * CSS position emitter (#640).
+ *
+ * PHP mirror of `resources/js/visual-editor/positioning/emitter.ts` —
+ * turns a resolved payload into the scoped CSS the Blade renderer
+ * flushes at the top of the page output.
+ *
+ * Contracts (per #643):
+ *
+ *  - `position: static` emits nothing — orphan offsets / z-index stay
+ *    in attributes but produce no CSS while static.
+ *  - `unit: 'auto'` renders as `top: auto` etc.
+ *  - Breakpoints emit inside `@media (min-width:<n>px)` blocks using
+ *    the request-scoped breakpoint registry.
+ *  - Callers pass in the already-merged per-breakpoint layer map (see
+ *    {@see PositionResolver::mergedBreakpointLayers}) so the emitter
+ *    only walks each breakpoint once.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.4.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Position;
+
+use ArtisanPackUI\VisualEditor\Responsive\BreakpointRegistry;
+
+class PositionEmitter
+{
+	public function __construct(
+		protected BreakpointRegistry $breakpoints,
+	) {}
+
+	/**
+	 * Emit scoped CSS. Returns an empty string when nothing meaningful
+	 * renders.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @param  string  $scope    The selector prefix (e.g. `.ve-pos-abc`).
+	 * @param  array{base: array<string, mixed>|null, breakpoints: array<string, array<string, mixed>>}  $payload
+	 */
+	public function emit( string $scope, array $payload ): string
+	{
+		$trimmedScope = trim( $scope );
+
+		if ( '' === $trimmedScope ) {
+			return '';
+		}
+
+		$rules = [];
+
+		$baseDecls = self::layerDeclarations( $payload['base'] ?? null );
+		if ( '' !== $baseDecls ) {
+			$rules[] = $trimmedScope . '{' . $baseDecls . '}';
+		}
+
+		$orderedKeys = $this->orderedBreakpointKeys();
+		$merged      = PositionResolver::mergedBreakpointLayers( $payload, $orderedKeys );
+
+		foreach ( $orderedKeys as $key ) {
+			$layer = $merged[ $key ] ?? null;
+
+			if ( null === $layer ) {
+				continue;
+			}
+
+			$decls = self::layerDeclarations( $layer );
+			if ( '' === $decls ) {
+				continue;
+			}
+
+			$minWidth = $this->breakpoints->get( $key );
+			if ( null === $minWidth || $minWidth <= 0 ) {
+				continue;
+			}
+
+			$rules[] = '@media (min-width:' . $minWidth . 'px){' . $trimmedScope . '{' . $decls . '}}';
+		}
+
+		return implode( '', $rules );
+	}
+
+	/**
+	 * @param  array<string, mixed>|null  $layer
+	 */
+	public static function layerDeclarations( ?array $layer ): string
+	{
+		if ( null === $layer ) {
+			return '';
+		}
+
+		$value = $layer['value'] ?? null;
+
+		if ( null === $value || 'static' === $value ) {
+			return '';
+		}
+
+		// See `layerDeclarations` in the JS emitter for the `!important`
+		// rationale — same story on the frontend: theme resets and the
+		// occasional utility framework rule can outrank a single scope
+		// class, and the user's panel pick is an explicit override.
+		$parts = [ 'position:' . $value . ' !important' ];
+
+		$offsets = $layer['offsets'] ?? [];
+		foreach ( [ 'top', 'right', 'bottom', 'left' ] as $side ) {
+			$offset = $offsets[ $side ] ?? null;
+			if ( null === $offset || ! is_array( $offset ) ) {
+				continue;
+			}
+			$parts[] = $side . ':' . self::formatOffset( $offset ) . ' !important';
+		}
+
+		if ( isset( $layer['zIndex'] ) && null !== $layer['zIndex'] ) {
+			$parts[] = 'z-index:' . (int) $layer['zIndex'] . ' !important';
+		}
+
+		return implode( ';', $parts );
+	}
+
+	/**
+	 * @param  array{value: float|int, unit: string}  $offset
+	 */
+	protected static function formatOffset( array $offset ): string
+	{
+		if ( 'auto' === $offset['unit'] ) {
+			return 'auto';
+		}
+
+		$value = $offset['value'];
+		// Cast integers back to no-decimal form; keep floats as PHP
+		// formats them (which drops trailing zeros already).
+		return ( is_int( $value ) ? (string) $value : (string) $value ) . $offset['unit'];
+	}
+
+	/**
+	 * Registry keys ordered by ascending min-width. Excludes `base`.
+	 *
+	 * @return array<int, string>
+	 */
+	protected function orderedBreakpointKeys(): array
+	{
+		$keys = [];
+
+		foreach ( $this->breakpoints->all() as $key => $_minWidth ) {
+			if ( ! is_string( $key ) || '' === $key || 'base' === $key ) {
+				continue;
+			}
+			$keys[] = $key;
+		}
+
+		return $keys;
+	}
+}

--- a/src/Position/PositionResolver.php
+++ b/src/Position/PositionResolver.php
@@ -1,0 +1,336 @@
+<?php
+
+/**
+ * CSS position attribute resolver (#640).
+ *
+ * PHP mirror of `resources/js/visual-editor/positioning/resolver.ts` —
+ * walks a block's attribute tree and produces the normalized payload
+ * {@see PositionEmitter::emit} consumes.
+ *
+ * The idle layer lives at `attributes.style.position`; per-breakpoint
+ * overrides ride `attributes.responsive['style.position']` following
+ * the routing pattern from #487. Legacy Gutenberg sticky (a bare
+ * string at `style.position`) is widened to `{ 'value' => 'sticky' }`.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.4.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Position;
+
+class PositionResolver
+{
+	protected const POSITION_VALUES = [ 'static', 'relative', 'absolute', 'fixed', 'sticky' ];
+	protected const OFFSET_UNITS    = [ 'px', '%', 'rem', 'em', 'vh', 'vw', 'auto' ];
+	protected const OFFSET_SIDES    = [ 'top', 'right', 'bottom', 'left' ];
+
+	/**
+	 * Resolve a full block attribute tree into the normalized payload
+	 * the emitter consumes. Returns `null` when no position
+	 * configuration exists at any cascade level.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @param  array<string, mixed>  $attributes
+	 *
+	 * @return array{base: array<string, mixed>|null, breakpoints: array<string, array<string, mixed>>}|null
+	 */
+	public static function resolve( array $attributes ): ?array
+	{
+		$base        = self::resolveLayer( self::coerceSubtree( $attributes['style']['position'] ?? null ) );
+		$breakpoints = self::readBreakpointOverrides( $attributes );
+
+		if ( null === $base && [] === $breakpoints ) {
+			return null;
+		}
+
+		return [
+			'base'        => $base,
+			'breakpoints' => $breakpoints,
+		];
+	}
+
+	/**
+	 * Coerce the raw slot into a structured subtree. A plain string is
+	 * treated as the `value` field alone — Gutenberg's native sticky
+	 * shape.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @return array<string, mixed>|null
+	 */
+	public static function coerceSubtree( mixed $raw ): ?array
+	{
+		if ( null === $raw ) {
+			return null;
+		}
+
+		if ( is_string( $raw ) ) {
+			$value = self::normalizeValue( $raw );
+			return null === $value ? null : [ 'value' => $value ];
+		}
+
+		if ( ! is_array( $raw ) ) {
+			return null;
+		}
+
+		return $raw;
+	}
+
+	/**
+	 * @param  array<string, mixed>|null  $subtree
+	 *
+	 * @return array{value: string|null, offsets: array<string, array<string, mixed>|null>, zIndex: int|null}|null
+	 */
+	protected static function resolveLayer( ?array $subtree ): ?array
+	{
+		if ( null === $subtree ) {
+			return null;
+		}
+
+		$value   = self::normalizeValue( $subtree['value'] ?? null );
+		$offsets = self::normalizeOffsets( $subtree['offsets'] ?? null );
+		$zIndex  = self::normalizeZIndex( $subtree['zIndex'] ?? null );
+
+		$hasAny =
+			null !== $value
+			|| null !== $offsets['top']
+			|| null !== $offsets['right']
+			|| null !== $offsets['bottom']
+			|| null !== $offsets['left']
+			|| null !== $zIndex;
+
+		if ( ! $hasAny ) {
+			return null;
+		}
+
+		return [
+			'value'   => $value,
+			'offsets' => $offsets,
+			'zIndex'  => $zIndex,
+		];
+	}
+
+	protected static function normalizeValue( mixed $raw ): ?string
+	{
+		if ( ! is_string( $raw ) ) {
+			return null;
+		}
+
+		$trimmed = strtolower( trim( $raw ) );
+
+		return in_array( $trimmed, self::POSITION_VALUES, true ) ? $trimmed : null;
+	}
+
+	/**
+	 * @return array<string, array<string, mixed>|null>
+	 */
+	protected static function normalizeOffsets( mixed $raw ): array
+	{
+		$out = [
+			'top'    => null,
+			'right'  => null,
+			'bottom' => null,
+			'left'   => null,
+		];
+
+		if ( ! is_array( $raw ) ) {
+			return $out;
+		}
+
+		foreach ( self::OFFSET_SIDES as $side ) {
+			$out[ $side ] = self::normalizeOffset( $raw[ $side ] ?? null );
+		}
+
+		return $out;
+	}
+
+	/**
+	 * @return array{value: float|int, unit: string}|null
+	 */
+	protected static function normalizeOffset( mixed $raw ): ?array
+	{
+		if ( ! is_array( $raw ) ) {
+			return null;
+		}
+
+		$unit = isset( $raw['unit'] ) && is_string( $raw['unit'] )
+			? strtolower( trim( $raw['unit'] ) )
+			: null;
+
+		if ( null === $unit || ! in_array( $unit, self::OFFSET_UNITS, true ) ) {
+			return null;
+		}
+
+		if ( 'auto' === $unit ) {
+			return [ 'value' => 0, 'unit' => 'auto' ];
+		}
+
+		$value = $raw['value'] ?? null;
+
+		if ( is_string( $value ) ) {
+			$trimmed = trim( $value );
+			if ( '' === $trimmed || ! is_numeric( $trimmed ) ) {
+				return null;
+			}
+			$value = 0 + $trimmed;
+		}
+
+		if ( ! is_int( $value ) && ! is_float( $value ) ) {
+			return null;
+		}
+
+		if ( ! is_finite( (float) $value ) ) {
+			return null;
+		}
+
+		return [ 'value' => $value, 'unit' => $unit ];
+	}
+
+	protected static function normalizeZIndex( mixed $raw ): ?int
+	{
+		if ( is_int( $raw ) ) {
+			return $raw;
+		}
+
+		if ( is_float( $raw ) && is_finite( $raw ) ) {
+			return (int) $raw;
+		}
+
+		if ( is_string( $raw ) ) {
+			$trimmed = trim( $raw );
+			if ( '' === $trimmed ) {
+				return null;
+			}
+			// Reject scientific notation before Number-coercing. PHP's
+			// `is_numeric` accepts `'1e100'` and `0 + '1e100'` overflows
+			// silently to `PHP_INT_MAX`, while the JS side filters it
+			// via `Number.isFinite`. Matching the JS filter keeps preview
+			// (editor) and server render byte-identical for the same
+			// input.
+			if ( 1 === preg_match( '/[eE]/', $trimmed ) ) {
+				return null;
+			}
+			if ( ! is_numeric( $trimmed ) ) {
+				return null;
+			}
+			$value = 0 + $trimmed;
+			if ( ! is_finite( (float) $value ) ) {
+				return null;
+			}
+			return (int) $value;
+		}
+
+		return null;
+	}
+
+	/**
+	 * @param  array<string, mixed>  $attributes
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
+	protected static function readBreakpointOverrides( array $attributes ): array
+	{
+		$responsive = $attributes['responsive'] ?? null;
+
+		if ( ! is_array( $responsive ) ) {
+			return [];
+		}
+
+		$bag = $responsive['style.position'] ?? null;
+
+		if ( ! is_array( $bag ) ) {
+			return [];
+		}
+
+		$out = [];
+
+		foreach ( $bag as $key => $raw ) {
+			if ( ! is_string( $key ) || '' === $key || 'base' === $key ) {
+				continue;
+			}
+
+			$layer = self::resolveLayer( self::coerceSubtree( $raw ) );
+
+			if ( null === $layer ) {
+				continue;
+			}
+
+			$out[ $key ] = $layer;
+		}
+
+		return $out;
+	}
+
+	/**
+	 * Merge each defined breakpoint layer on top of every smaller layer
+	 * (base included). Produces the fully-resolved per-breakpoint layer
+	 * map the emitter consumes for media-query bodies.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @param  array{base: array<string, mixed>|null, breakpoints: array<string, array<string, mixed>>}  $payload
+	 * @param  array<int, string>  $orderedBreakpointKeys  Registry keys, ascending, no `base`.
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
+	public static function mergedBreakpointLayers( array $payload, array $orderedBreakpointKeys ): array
+	{
+		$out     = [];
+		$running = $payload['base'] ?? null;
+
+		foreach ( $orderedBreakpointKeys as $key ) {
+			$overlay = $payload['breakpoints'][ $key ] ?? null;
+
+			if ( null === $overlay ) {
+				continue;
+			}
+
+			$running     = self::mergeLayers( $running, $overlay );
+			$out[ $key ] = $running;
+		}
+
+		return $out;
+	}
+
+	/**
+	 * Fold an overlay layer on top of a base layer — overlay wins per
+	 * field, base fills any nulls. Single source of truth for the
+	 * merge fallthrough logic; the JS mirror lives at
+	 * `resources/js/visual-editor/positioning/resolver.ts::mergeLayers`.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @param  array<string, mixed>|null  $base
+	 * @param  array<string, mixed>|null  $overlay
+	 *
+	 * @return array<string, mixed>|null
+	 */
+	public static function mergeLayers( ?array $base, ?array $overlay ): ?array
+	{
+		if ( null === $overlay ) {
+			return $base;
+		}
+
+		if ( null === $base ) {
+			return $overlay;
+		}
+
+		return [
+			'value'   => $overlay['value'] ?? $base['value'],
+			'offsets' => [
+				'top'    => $overlay['offsets']['top']    ?? $base['offsets']['top'],
+				'right'  => $overlay['offsets']['right']  ?? $base['offsets']['right'],
+				'bottom' => $overlay['offsets']['bottom'] ?? $base['offsets']['bottom'],
+				'left'   => $overlay['offsets']['left']   ?? $base['offsets']['left'],
+			],
+			'zIndex'  => $overlay['zIndex'] ?? $base['zIndex'],
+		];
+	}
+}

--- a/src/VisualEditorServiceProvider.php
+++ b/src/VisualEditorServiceProvider.php
@@ -48,6 +48,7 @@ use ArtisanPackUI\VisualEditor\Responsive\BreakpointRegistry;
 use ArtisanPackUI\VisualEditor\Responsive\ResponsiveValueResolver;
 use ArtisanPackUI\VisualEditor\States\StateAttributeMigrator;
 use ArtisanPackUI\VisualEditor\BoxShadow\BoxShadowEmitter;
+use ArtisanPackUI\VisualEditor\Position\PositionEmitter;
 use ArtisanPackUI\VisualEditor\States\StateCssEmitter;
 use ArtisanPackUI\VisualEditor\States\StateRegistry;
 use ArtisanPackUI\VisualEditor\States\StateValueResolver;
@@ -373,6 +374,16 @@ class VisualEditorServiceProvider extends ServiceProvider
 		$this->app->scoped( BoxShadowEmitter::class, function ( $app ) {
 			return new BoxShadowEmitter(
 				$app->make( StateRegistry::class ),
+				$app->make( BreakpointRegistry::class ),
+			);
+		} );
+
+		// #640: CSS position emitter. Bound here so future
+		// render-pipeline integration can resolve it from the
+		// container; the Blade renderer's BlockSupports already
+		// constructs one directly with the request-scoped registry.
+		$this->app->scoped( PositionEmitter::class, function ( $app ) {
+			return new PositionEmitter(
 				$app->make( BreakpointRegistry::class ),
 			);
 		} );

--- a/src/VisualEditorServiceProvider.php
+++ b/src/VisualEditorServiceProvider.php
@@ -48,7 +48,6 @@ use ArtisanPackUI\VisualEditor\Responsive\BreakpointRegistry;
 use ArtisanPackUI\VisualEditor\Responsive\ResponsiveValueResolver;
 use ArtisanPackUI\VisualEditor\States\StateAttributeMigrator;
 use ArtisanPackUI\VisualEditor\BoxShadow\BoxShadowEmitter;
-use ArtisanPackUI\VisualEditor\Position\PositionEmitter;
 use ArtisanPackUI\VisualEditor\States\StateCssEmitter;
 use ArtisanPackUI\VisualEditor\States\StateRegistry;
 use ArtisanPackUI\VisualEditor\States\StateValueResolver;
@@ -374,16 +373,6 @@ class VisualEditorServiceProvider extends ServiceProvider
 		$this->app->scoped( BoxShadowEmitter::class, function ( $app ) {
 			return new BoxShadowEmitter(
 				$app->make( StateRegistry::class ),
-				$app->make( BreakpointRegistry::class ),
-			);
-		} );
-
-		// #640: CSS position emitter. Bound here so future
-		// render-pipeline integration can resolve it from the
-		// container; the Blade renderer's BlockSupports already
-		// constructs one directly with the request-scoped registry.
-		$this->app->scoped( PositionEmitter::class, function ( $app ) {
-			return new PositionEmitter(
 				$app->make( BreakpointRegistry::class ),
 			);
 		} );

--- a/tests/E2E/positioning.spec.ts
+++ b/tests/E2E/positioning.spec.ts
@@ -1,0 +1,119 @@
+/**
+ * E2E specification for CSS position support (#647).
+ *
+ * The package does not yet ship Playwright as a runtime dependency
+ * (it's not wired into the CI matrix in `release/1.x`). This file
+ * documents the test plan in Playwright shape so the suite can be
+ * activated as soon as the runner is added — matches the existing
+ * animations.spec.ts precedent.
+ *
+ * To activate, install `@playwright/test`, add a `playwright.config.ts`
+ * pointing at the dev app, and uncomment the imports at the top of
+ * this file.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since 1.4.0
+ */
+
+// import { expect, test } from '@playwright/test'
+//
+// test.describe( 'CSS position support (#640)', () => {
+// 	test( 'artisanpack/group with position: sticky sticks on canvas scroll', async ( { page } ) => {
+// 		// Renders a group block inside a tall column, with the group
+// 		// configured as position: sticky + top: 0. Scrolling the
+// 		// canvas should pin the group at the top of its scroll
+// 		// container until the container scrolls past.
+// 		await page.goto( '/visual-editor/preview/position-sticky-group' )
+//
+// 		const group   = page.locator( '.wp-block-group.ve-pos-fixture1' )
+// 		const scroll  = page.locator( '[data-scroll-container]' )
+//
+// 		// Baseline: group starts at its natural offset in the column.
+// 		const initialTop = await group.evaluate( ( el ) => el.getBoundingClientRect().top )
+//
+// 		await scroll.evaluate( ( el ) => { el.scrollTop = 400 } )
+//
+// 		const scrolledTop = await group.evaluate( ( el ) => el.getBoundingClientRect().top )
+//
+// 		// Sticky: bounding-rect top stays at (or near) the container's
+// 		// top edge instead of scrolling with the column content.
+// 		expect( scrolledTop ).toBeLessThanOrEqual( initialTop )
+// 		expect( scrolledTop ).toBeGreaterThanOrEqual( -1 )
+// 	} )
+//
+// 	test( 'artisanpack/cover with position: absolute + positioned parent respects offsets', async ( { page } ) => {
+// 		// Renders a cover block inside an explicitly positioned
+// 		// (relative) group. The cover has position: absolute + top:
+// 		// 20px + left: 40px. It should sit at those offsets relative
+// 		// to the group, NOT the viewport.
+// 		await page.goto( '/visual-editor/preview/position-absolute-cover' )
+//
+// 		const parent = page.locator( '.wp-block-group.ve-pos-parent1' )
+// 		const cover  = page.locator( '.wp-block-cover.ve-pos-cover1' )
+//
+// 		const parentBox = await parent.boundingBox()
+// 		const coverBox  = await cover.boundingBox()
+//
+// 		expect( parentBox ).not.toBeNull()
+// 		expect( coverBox ).not.toBeNull()
+//
+// 		// Cover's top edge is 20px below the parent's top edge, its
+// 		// left edge is 40px right of the parent's left edge.
+// 		expect( Math.round( coverBox!.y - parentBox!.y ) ).toBe( 20 )
+// 		expect( Math.round( coverBox!.x - parentBox!.x ) ).toBe( 40 )
+// 	} )
+//
+// 	test( 'artisanpack/cover with position: absolute + STATIC parent surfaces the inspector warning', async ( { page } ) => {
+// 		// Same absolute cover, but the parent group is not positioned.
+// 		// The Position panel should render a warning notice; the
+// 		// block still applies its position (relative to the nearest
+// 		// positioned ancestor, often the page).
+// 		await page.goto( '/visual-editor/edit/position-absolute-no-parent' )
+//
+// 		await page.click( '.wp-block-cover.ve-pos-cover2' )
+//
+// 		const warning = page.locator( '.ap-position__ancestor-warning' )
+// 		await expect( warning ).toBeVisible()
+// 		await expect( warning ).toContainText( /nearest positioned ancestor/i )
+// 	} )
+//
+// 	test( 'per-breakpoint values render distinct CSS at each viewport width', async ( { page, browser } ) => {
+// 		// A `artisanpack/group` with base position: relative + top:
+// 		// 10px, md override to zIndex: 3, lg override to value:
+// 		// sticky + top: 0. Each viewport should surface the merged
+// 		// layer at that breakpoint.
+// 		await page.goto( '/visual-editor/preview/position-per-breakpoint' )
+//
+// 		const group = page.locator( '.wp-block-group.ve-pos-per-bp' )
+//
+// 		// Mobile-first: base rule applies below md.
+// 		await page.setViewportSize( { width: 640, height: 800 } )
+// 		let position = await group.evaluate( ( el ) => getComputedStyle( el ).position )
+// 		let top      = await group.evaluate( ( el ) => getComputedStyle( el ).top )
+// 		expect( position ).toBe( 'relative' )
+// 		expect( top ).toBe( '10px' )
+//
+// 		// md: inherits value=relative + top from base, adds zIndex.
+// 		await page.setViewportSize( { width: 900, height: 800 } )
+// 		const zIndex = await group.evaluate( ( el ) => getComputedStyle( el ).zIndex )
+// 		expect( zIndex ).toBe( '3' )
+//
+// 		// lg: overrides value + top.
+// 		await page.setViewportSize( { width: 1200, height: 800 } )
+// 		position = await group.evaluate( ( el ) => getComputedStyle( el ).position )
+// 		top      = await group.evaluate( ( el ) => getComputedStyle( el ).top )
+// 		expect( position ).toBe( 'sticky' )
+// 		expect( top ).toBe( '0px' )
+// 	} )
+//
+// 	test( 'legacy Gutenberg sticky (bare string) still renders on frontend', async ( { page } ) => {
+// 		// A block whose saved attributes ship style.position="sticky"
+// 		// (Gutenberg native), NOT the structured object. The resolver
+// 		// widens the string; the emitter emits the same sticky rule.
+// 		await page.goto( '/visual-editor/preview/position-legacy-sticky' )
+//
+// 		const group = page.locator( '.wp-block-group.ve-pos-legacy' )
+// 		const position = await group.evaluate( ( el ) => getComputedStyle( el ).position )
+// 		expect( position ).toBe( 'sticky' )
+// 	} )
+// } )

--- a/tests/Unit/Position/PositionEmitterTest.php
+++ b/tests/Unit/Position/PositionEmitterTest.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * Unit tests for {@see PositionEmitter} (#640).
+ *
+ * @since 1.4.0
+ */
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Position\PositionEmitter;
+use ArtisanPackUI\VisualEditor\Position\PositionResolver;
+use ArtisanPackUI\VisualEditor\Responsive\BreakpointRegistry;
+
+function positionMakeRegistry(): BreakpointRegistry
+{
+	// Pass explicit `[]` for both overrides so `fromLayers()` doesn't
+	// reach for `config()` (unavailable in unit-test isolation).
+	return BreakpointRegistry::fromLayers( [], [] );
+}
+
+describe( 'PositionEmitter::emit', function (): void {
+	it( 'returns empty when the scope is blank', function (): void {
+		$payload = PositionResolver::resolve( [ 'style' => [ 'position' => [ 'value' => 'relative' ] ] ] );
+		$emitter = new PositionEmitter( positionMakeRegistry() );
+
+		expect( $emitter->emit( '   ', $payload ) )->toBe( '' );
+	} );
+
+	it( 'emits nothing for a static-only base layer', function (): void {
+		$payload = PositionResolver::resolve( [ 'style' => [ 'position' => [ 'value' => 'static' ] ] ] );
+		$emitter = new PositionEmitter( positionMakeRegistry() );
+
+		expect( $emitter->emit( '.foo', $payload ) )->toBe( '' );
+	} );
+
+	it( 'emits base position + offsets + z-index in one rule', function (): void {
+		$payload = PositionResolver::resolve( [
+			'style' => [
+				'position' => [
+					'value'   => 'absolute',
+					'offsets' => [
+						'top'    => [ 'value' => 10, 'unit' => 'px' ],
+						'right'  => [ 'unit' => 'auto' ],
+					],
+					'zIndex'  => 2,
+				],
+			],
+		] );
+
+		$emitter = new PositionEmitter( positionMakeRegistry() );
+
+		expect( $emitter->emit( '.wrap', $payload ) )
+			->toBe( '.wrap{position:absolute !important;top:10px !important;right:auto !important;z-index:2 !important}' );
+	} );
+
+	it( 'wraps breakpoint overrides in @media rules with inherited fields', function (): void {
+		$payload = PositionResolver::resolve( [
+			'style' => [
+				'position' => [
+					'value'   => 'relative',
+					'offsets' => [ 'top' => [ 'value' => 10, 'unit' => 'px' ] ],
+				],
+			],
+			'responsive' => [
+				'style.position' => [
+					'md' => [ 'zIndex' => 3 ],
+					'lg' => [ 'value' => 'sticky', 'offsets' => [ 'top' => [ 'value' => 0, 'unit' => 'px' ] ] ],
+				],
+			],
+		] );
+
+		$css = ( new PositionEmitter( positionMakeRegistry() ) )->emit( '.wrap', $payload );
+
+		expect( $css )->toContain( '.wrap{position:relative !important;top:10px !important}' );
+		expect( $css )->toContain( '@media (min-width:768px){.wrap{position:relative !important;top:10px !important;z-index:3 !important}}' );
+		expect( $css )->toContain( '@media (min-width:1024px){.wrap{position:sticky !important;top:0px !important;z-index:3 !important}}' );
+	} );
+
+	it( 'legacy sticky (bare string) round-trips to a single sticky rule', function (): void {
+		$payload = PositionResolver::resolve( [ 'style' => [ 'position' => 'sticky' ] ] );
+
+		expect( ( new PositionEmitter( positionMakeRegistry() ) )->emit( '.wrap', $payload ) )
+			->toBe( '.wrap{position:sticky !important}' );
+	} );
+} );

--- a/tests/Unit/Position/PositionResolverTest.php
+++ b/tests/Unit/Position/PositionResolverTest.php
@@ -1,0 +1,150 @@
+<?php
+
+/**
+ * Unit tests for {@see PositionResolver} (#640).
+ *
+ * @since 1.4.0
+ */
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Position\PositionResolver;
+
+describe( 'PositionResolver::resolve', function (): void {
+	it( 'returns null when no position configuration exists', function (): void {
+		expect( PositionResolver::resolve( [] ) )->toBeNull();
+		expect( PositionResolver::resolve( [ 'style' => [ 'position' => null ] ] ) )->toBeNull();
+	} );
+
+	it( 'widens a legacy sticky string into a structured base layer', function (): void {
+		$resolved = PositionResolver::resolve( [ 'style' => [ 'position' => 'sticky' ] ] );
+
+		expect( $resolved )->not->toBeNull();
+		expect( $resolved[ 'base' ][ 'value' ] )->toBe( 'sticky' );
+	} );
+
+	it( 'resolves offsets + zIndex on the base layer', function (): void {
+		$resolved = PositionResolver::resolve( [
+			'style' => [
+				'position' => [
+					'value'   => 'absolute',
+					'offsets' => [ 'top' => [ 'value' => 10, 'unit' => 'px' ] ],
+					'zIndex'  => 5,
+				],
+			],
+		] );
+
+		expect( $resolved[ 'base' ][ 'value' ] )->toBe( 'absolute' );
+		expect( $resolved[ 'base' ][ 'offsets' ][ 'top' ] )->toBe( [ 'value' => 10, 'unit' => 'px' ] );
+		expect( $resolved[ 'base' ][ 'zIndex' ] )->toBe( 5 );
+	} );
+
+	it( 'reads per-breakpoint overrides from the responsive bag', function (): void {
+		$resolved = PositionResolver::resolve( [
+			'style' => [ 'position' => [ 'value' => 'relative' ] ],
+			'responsive' => [
+				'style.position' => [
+					'md' => [ 'value' => 'absolute', 'zIndex' => 2 ],
+				],
+			],
+		] );
+
+		expect( $resolved[ 'breakpoints' ][ 'md' ][ 'value' ] )->toBe( 'absolute' );
+		expect( $resolved[ 'breakpoints' ][ 'md' ][ 'zIndex' ] )->toBe( 2 );
+	} );
+
+	it( 'drops offsets with an invalid unit', function (): void {
+		$resolved = PositionResolver::resolve( [
+			'style' => [
+				'position' => [
+					'value'   => 'absolute',
+					'offsets' => [
+						'top'   => [ 'value' => 10, 'unit' => 'garbage' ],
+						'right' => [ 'value' => 5, 'unit' => 'rem' ],
+					],
+				],
+			],
+		] );
+
+		expect( $resolved[ 'base' ][ 'offsets' ][ 'top' ] )->toBeNull();
+		expect( $resolved[ 'base' ][ 'offsets' ][ 'right' ] )->toBe( [ 'value' => 5, 'unit' => 'rem' ] );
+	} );
+
+	it( 'accepts the `auto` unit without a numeric value', function (): void {
+		$resolved = PositionResolver::resolve( [
+			'style' => [
+				'position' => [
+					'value'   => 'absolute',
+					'offsets' => [ 'top' => [ 'unit' => 'auto' ] ],
+				],
+			],
+		] );
+
+		expect( $resolved[ 'base' ][ 'offsets' ][ 'top' ] )->toBe( [ 'value' => 0, 'unit' => 'auto' ] );
+	} );
+
+	it( 'drops responsive entries under the `base` key', function (): void {
+		$resolved = PositionResolver::resolve( [
+			'responsive' => [
+				'style.position' => [
+					'base' => [ 'value' => 'fixed' ],
+					'lg'   => [ 'value' => 'sticky' ],
+				],
+			],
+		] );
+
+		expect( $resolved[ 'breakpoints' ] )->toHaveKey( 'lg' );
+		expect( $resolved[ 'breakpoints' ] )->not->toHaveKey( 'base' );
+	} );
+} );
+
+describe( 'PositionResolver::normalizeZIndex (via resolve)', function (): void {
+	it( 'rejects scientific notation strings to stay JS/PHP consistent', function (): void {
+		// PHP `is_numeric` accepts these; `0 + trim($v)` overflows to
+		// PHP_INT_MAX. JS `Number.isFinite` rejects `Infinity`. The
+		// resolver rejects them explicitly to keep preview and server
+		// render byte-identical for the same input.
+		$resolved = PositionResolver::resolve( [
+			'style' => [ 'position' => [ 'value' => 'absolute', 'zIndex' => '1e100' ] ],
+		] );
+
+		expect( $resolved[ 'base' ][ 'zIndex' ] )->toBeNull();
+	} );
+
+	it( 'accepts plain integer strings', function (): void {
+		$resolved = PositionResolver::resolve( [
+			'style' => [ 'position' => [ 'value' => 'absolute', 'zIndex' => '42' ] ],
+		] );
+
+		expect( $resolved[ 'base' ][ 'zIndex' ] )->toBe( 42 );
+	} );
+} );
+
+describe( 'PositionResolver::mergedBreakpointLayers', function (): void {
+	it( 'folds each defined breakpoint on top of every smaller layer', function (): void {
+		$payload = PositionResolver::resolve( [
+			'style' => [
+				'position' => [
+					'value'   => 'absolute',
+					'offsets' => [ 'top' => [ 'value' => 5, 'unit' => 'px' ] ],
+					'zIndex'  => 1,
+				],
+			],
+			'responsive' => [
+				'style.position' => [
+					'md' => [ 'zIndex' => 9 ],
+					'lg' => [ 'value' => 'sticky' ],
+				],
+			],
+		] );
+
+		$merged = PositionResolver::mergedBreakpointLayers( $payload, [ 'sm', 'md', 'lg', 'xl', '2xl' ] );
+
+		expect( $merged[ 'md' ][ 'value' ] )->toBe( 'absolute' );
+		expect( $merged[ 'md' ][ 'zIndex' ] )->toBe( 9 );
+		expect( $merged[ 'md' ][ 'offsets' ][ 'top' ] )->toBe( [ 'value' => 5, 'unit' => 'px' ] );
+
+		expect( $merged[ 'lg' ][ 'value' ] )->toBe( 'sticky' );
+		expect( $merged[ 'lg' ][ 'zIndex' ] )->toBe( 9 );
+	} );
+} );


### PR DESCRIPTION
## Description

Integration PR for the #640 umbrella — CSS positioning support for blocks. This branch aggregates two already-merged sub-PRs:

- **#656** ([feature/640-position-support-schema-ui](https://github.com/ArtisanPack-UI/visual-editor/pull/656)) — Schema, resolver, emitter, inspector panel, ancestor warning, save-side style emission, PHP mirror + accumulator. Closed #641/#642/#643/#644.
- **#657** ([feature/640-position-supports-tests-docs](https://github.com/ArtisanPack-UI/visual-editor/pull/657)) — Opt-in on 82 artisanpack blocks, integration + e2e tests, docs page. Closed #645/#646/#647/#648.

Each sub-PR was code-reviewed via the local `/code-review` skill (high effort, 8-angle fan-out on #656, 4-angle on #657) and all surviving findings were addressed before merge.

**Closes:** #640, #641, #642, #643, #644, #645, #646, #647, #648

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #640 (umbrella) and all eight sub-issues.

## Motivation and Context

Blocks in the visual editor had no first-class CSS `position` control. Gutenberg's own `supports.position` exposes only `sticky`; site builders and designers needing overlays, layered decorative elements, sticky sidebars, or precisely-positioned callouts had to drop into custom CSS.

This umbrella brings all five CSS `position` values, per-side offsets (`px / % / rem / em / vh / vw / auto`), z-index, and per-breakpoint overrides to any block that opts in via `supports.position: true` in `block.json`. Legacy Gutenberg sticky (bare `"sticky"` string at `style.position`) is coerced to the structured schema at read time — zero attribute migration.

## Changes Made

- **JS side** (`resources/js/visual-editor/positioning/`): resolver, emitter, supports extension, inspector control (with the #644 positioned-ancestor warning), styles HOC (`_positionScopeId` mint/claim + `ve-pos-<id>` wrapper class + `<style>` element + inline base stamp for sanitizer resilience).
- **PHP side** (`src/Position/`, `packages/visual-editor-renderer-blade/`): `PositionResolver` + `PositionEmitter` mirroring the JS shape; `PositionCssAccumulator` (collision-tolerant, keys by scope + content hash); `BlockSupports::compilePosition()` + inline base stamp + shared `pushToAccumulator()` / `composeScopeClass()` helpers.
- **Opt-in**: 82 top-level artisanpack blocks get `supports.position: true` in their `block.json`. Twenty child-only blocks (accordion internals, list items, `column`, `button`, `post-template`, pagination pieces) are deliberately skipped — positioning a child that a container relies on for layout breaks the container's contract.
- **Resilience**: every declaration ships `!important` (beats Gutenberg's canvas `.block-editor-block-list__block { position: relative }` internal rule and theme resets). Base declarations also stamp inline on the wrapper so hosts that strip `<style>` from block markup still get sticky/absolute applied.
- **Consolidation carried on top**: `pushToAccumulator()` collapses five copy-pasted `push*` guards; `composeScopeClass()` collapses three copy-pasted `resolve*ScopeClass` implementations; `mergeLayers` extracted (once in JS, once in PHP) as the single source of truth for the layer fallthrough logic.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS Darwin 25.5
- Browser: Chrome (via Herd local dev)
- PHP Version: 8.4.3
- Project Version: v1.4 (development)

**Tests Performed:**
1. Manual smoke test across multiple block types (Group, Column, Cover, various artisanpack forks) — Position panel renders, values apply in the canvas, top-bar viewport switcher re-renders the panel's effective values correctly, sticky pins on frontend scroll.
2. Automated suites — 38 positioning JS tests + 86 PHP tests, all green.
3. Two rounds of local `/code-review` at high effort, all surviving findings addressed.

## Accessibility Tests Run

- [x] Keyboard navigation tested (Position panel controls are tab-reachable via standard WP components)
- [x] Screen reader tested via `InspectorScopeChip` at the inspector top (`role="status" aria-live="polite"` announces the active breakpoint)
- [x] Color contrast verified (uses standard WP inspector components)
- [x] ARIA labels checked (SelectControl / UnitControl / NumberControl inherit WP's a11y contracts; warning notice uses `Notice` component)

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:**

- **JS (38 tests):** `resolver.test.ts`, `emitter.test.ts`, `extend-supports.test.ts`, `integration.test.ts` — round-trip across all breakpoints, legacy sticky no-churn, static-toggle preserves orphan fields.
- **PHP (86 total, 15 new for position):** `Position/PositionResolverTest.php`, `PositionEmitterTest.php`, `PositionCssAccumulatorTest.php`, plus new cases in `BlockSupportsTest.php` covering the position compile path.
- **E2E:** `tests/E2E/positioning.spec.ts` documents five runtime scenarios in commented Playwright shape (sticky group, absolute cover, ancestor warning, per-breakpoint viewport switching, legacy sticky) — activated when the Playwright runner lands. Matches the `animations.spec.ts` precedent.

## Documentation

- [x] Inline code documentation added (extensive PHPDoc + JSDoc on new modules)
- [ ] README updated (no README changes needed)
- [x] Wiki updated (`docs/position.md` — opt-in, attribute shape, values, offsets, inheritance, ancestor warning, emission channels, troubleshooting; linked from `docs/home.md`)
- [ ] API documentation updated (attribute shape is documented in `docs/position.md`)

## Upgrade notes (surfaced in `CHANGELOG.md`)

Hosts that ran `php artisan vendor:publish --tag=visual-editor-blade-views` on a prior version must republish with `--force` when upgrading. The published `blocks.blade.php` and `template.blade.php` files shadow the package source; pre-1.4 published copies don't include the new `<style data-ve-position>` output block, so the position CSS accumulator flushes into the void on the frontend for those hosts.

Command:
```bash
php artisan vendor:publish --tag=visual-editor-blade-views --force
```

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Accessibility tests completed
- [x] Code follows project style guide (WordPress-style spacing, Yoda conditions, `__()` on all user-facing strings)
- [x] Self-review completed (two rounds of `/code-review` high-effort, 18 findings total across both PRs, all addressed)
- [x] Comments added for complex code
- [x] No new warnings generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)