### PR TITLE
feat: page pattern inserter modal with template selector (#639)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,40 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- **Page pattern inserter modal (#639).** WordPress-style "Choose a
+  pattern" modal that auto-opens when the editor loads a
+  never-saved record with no content, and can be re-opened at any
+  time from a new top-bar button next to the `+` inserter.
+  Patterns are grouped by category in a responsive grid, and — for
+  the `pages` resource — an optional template selector renders
+  site-editor templates (`/visual-editor/api/templates`) alongside
+  the pattern grid; picking one writes through the existing
+  `template` field on the page. Auto-open is gated by a
+  self-contained "never saved" heuristic (empty content plus
+  `created_at === updated_at`), so any save — even a blank canvas
+  — permanently suppresses the auto-open. Zero patterns for the
+  current post-type context suppresses both auto-open and the
+  toolbar button; a Blank starter (`page/blank`) ships as the
+  seed so the modal always has at least one entry. The modal
+  fetches with `?source=theme` so user-created snippet patterns
+  (saved via "Convert to pattern" in the sidebar inserter) don't
+  leak into the whole-page picker — those still surface in the
+  block inserter panel where they belong. Client-side the modal
+  further tightens the fetch to patterns whose `post_types` array
+  explicitly includes the current context (with a carve-out that
+  always keeps the built-in `page/blank` seed) — the whole-page
+  picker is meant for starter layouts a developer or theme
+  deliberately declared, not the general pattern library.
+- **Pattern registration `post_types` scope (#639).** Every
+  contributor entry to the `ap.visual-editor.patterns` filter may
+  now carry an optional `post_types: string[]` array (Gutenberg
+  convention). Patterns without a scope stay available in every
+  post-type context; patterns with a scope surface only when the
+  requested slug matches. The scope reaches the client via the
+  new `post_types` field on `PatternAdapter`'s WP-shape output,
+  and the `PatternController` index accepts a new
+  `?post_type={slug}` query param that applies the scope filter
+  server-side.
 - **CSS positioning support for blocks (#640).** Per-block Position
   panel in the inspector with a `static / relative / absolute / fixed
   / sticky` dropdown, per-side offset inputs (`px / % / rem / em /

--- a/resources/js/visual-editor/editor/__tests__/top-bar.test.tsx
+++ b/resources/js/visual-editor/editor/__tests__/top-bar.test.tsx
@@ -46,6 +46,32 @@ describe('TopBar', () => {
         expect(header.tagName).toBe('HEADER');
     });
 
+    // #639 — the page-pattern-inserter button is opt-in. Absent handler
+    // means "no button" so users aren't invited into an empty modal
+    // when no patterns apply to the current post-type context.
+    it('does not render the pattern-modal button when no handler is supplied (#639)', () => {
+        render(<TopBar {...defaultProps()} />);
+
+        expect(
+            screen.queryByTestId('ap-visual-editor-top-bar-pattern-modal')
+        ).not.toBeInTheDocument();
+    });
+
+    it('renders the pattern-modal button when a handler is supplied and fires it on click (#639)', async () => {
+        const onOpenPatternModal = vi.fn();
+        const user = userEvent.setup();
+
+        render(<TopBar {...defaultProps({ onOpenPatternModal })} />);
+
+        const button = screen.getByTestId('ap-visual-editor-top-bar-pattern-modal');
+
+        expect(button).toBeInTheDocument();
+
+        await user.click(button);
+
+        expect(onOpenPatternModal).toHaveBeenCalledTimes(1);
+    });
+
     it('does not render title, slug, or status inputs (moved to canvas/sidebar)', () => {
         render(<TopBar {...defaultProps()} />);
 

--- a/resources/js/visual-editor/editor/editor-app.tsx
+++ b/resources/js/visual-editor/editor/editor-app.tsx
@@ -64,7 +64,19 @@ import { StateInspectorSync } from '../states/StateInspectorSync';
 import { StateWriteInterceptor } from '../states/state-write-interceptor';
 import { ConvertToPatternControl } from './convert-to-pattern-control';
 import { EditorCanvas } from './editor-canvas';
+import {
+    PagePatternModal,
+    type TemplateOption,
+} from './page-pattern-modal/page-pattern-modal';
+import { useFreshContentDetection } from './page-pattern-modal/use-fresh-content-detection';
+import { filterModalPatterns } from './page-pattern-modal/filter-modal-patterns';
 import { registerSyncedPatternIndicator } from './synced-pattern-indicator';
+import {
+    listPatterns,
+    SiteEditorApiError as PatternsApiError,
+    type PatternRecord,
+} from '../site-editor/patterns/api-client';
+import { listEntities } from '../site-editor/api-client';
 import {
     DocumentPanels,
     type AuthorOption,
@@ -285,6 +297,17 @@ export interface EditorAppProps {
     initialParent?: number | null;
     initialMenuOrder?: number;
     initialTemplate?: string;
+    /**
+     * ISO-8601 timestamp when the record was created (#639). Passed
+     * verbatim to the fresh-content detection hook that gates the
+     * page-pattern modal from auto-opening on already-saved pages.
+     */
+    initialCreatedAt?: string;
+    /**
+     * ISO-8601 timestamp when the record was last updated (#639).
+     * See {@link initialCreatedAt}.
+     */
+    initialUpdatedAt?: string;
     authorOptions?: ReadonlyArray<AuthorOption>;
     supports?: DocumentSupports;
     previewUrl?: string | null;
@@ -499,6 +522,18 @@ function EditorAppShell(props: EditorAppProps): JSX.Element {
     const [inserterOpen, setInserterOpen] = useState<boolean>(false);
     const [inspectorOpen, setInspectorOpen] = useState<boolean>(true);
     const [shortcutsOpen, setShortcutsOpen] = useState<boolean>(false);
+    // #639 — page-pattern modal state. Auto-opens on first-load for
+    // fresh records with no persisted content and at least one
+    // applicable pattern; the user can also open it manually via the
+    // top-bar button. Dismissing clears both `patternModalOpen` and
+    // `patternModalDismissed` so the auto-open path doesn't re-fire
+    // within a single session.
+    const [patternModalOpen, setPatternModalOpen] = useState<boolean>(false);
+    const [patternModalDismissed, setPatternModalDismissed] = useState<boolean>(false);
+    const [pagePatterns, setPagePatterns] = useState<readonly PatternRecord[]>([]);
+    const [pagePatternsLoading, setPagePatternsLoading] = useState<boolean>(true);
+    const [pagePatternsError, setPagePatternsError] = useState<string | null>(null);
+    const [templateOptions, setTemplateOptions] = useState<readonly TemplateOption[]>([]);
     // #617 — viewport preset selection resizes the canvas frame.
     // The shared hook holds the `null | positive-int` slot and the
     // `onViewportChange` callback so post + site editors can't
@@ -796,6 +831,212 @@ function EditorAppShell(props: EditorAppProps): JSX.Element {
         onBlocksChange(next);
     }, [blocks, onBlocksChange]);
 
+    // #639 — fetch page-scope patterns whenever the mounted post-type
+    // context changes. `documentType` is the WP-style singular slug
+    // (`page`, `post`, …); when it's null (custom HasBlockContent
+    // models without a shim registration), we skip the fetch and the
+    // modal stays closed.
+    useEffect(() => {
+        if (documentType === null) {
+            setPagePatterns([]);
+            setPagePatternsLoading(false);
+            return;
+        }
+
+        let cancelled = false;
+
+        setPagePatternsLoading(true);
+        setPagePatternsError(null);
+
+        // Scope the modal fetch to theme-source patterns only. The
+        // page-pattern-inserter is a page-starter picker; user-created
+        // snippet patterns (`source: 'user'`, saved via "Convert to
+        // pattern" in the sidebar) belong to the block inserter panel,
+        // not the whole-page modal. Filtering server-side keeps the
+        // modal grid focused on layouts a developer or theme deliberately
+        // shipped as starters.
+        listPatterns(
+            { apiBase: props.apiBase },
+            { postType: documentType, source: 'theme', perPage: 100 }
+        )
+            .then((records) => {
+                if (cancelled) {
+                    return;
+                }
+
+                // Tighten the server's permissive `?post_type=` filter
+                // client-side so unscoped patterns (which the sidebar
+                // block-inserter treats as "library of everything")
+                // don't leak into the whole-page modal. See the helper
+                // for the seed carve-out.
+                setPagePatterns(filterModalPatterns(records, documentType));
+                setPagePatternsLoading(false);
+            })
+            .catch((error: unknown) => {
+                if (cancelled) {
+                    return;
+                }
+
+                setPagePatterns([]);
+                setPagePatternsLoading(false);
+                setPagePatternsError(
+                    error instanceof PatternsApiError
+                        ? error.message
+                        : __('Failed to load patterns.', TEXT_DOMAIN)
+                );
+            });
+
+        return () => {
+            cancelled = true;
+        };
+    }, [documentType, props.apiBase]);
+
+    // #639 — fetch the site-editor template list once per mount so the
+    // modal's template selector has entries to render. Templates are
+    // free-form theme templates; when the fetch fails or returns nothing,
+    // the selector row is suppressed (falsy `templateOptions`).
+    useEffect(() => {
+        if (documentType !== 'page') {
+            // Only pages carry a `template` field today; skip the fetch
+            // for other post types so we don't ship a selector the caller
+            // has no persistence path for.
+            setTemplateOptions([]);
+            return;
+        }
+
+        let cancelled = false;
+
+        listEntities({ apiBase: props.apiBase }, 'template', { perPage: 100 })
+            .then((records) => {
+                if (cancelled) {
+                    return;
+                }
+
+                const options: TemplateOption[] = [
+                    {
+                        slug: '',
+                        label: __('Default template', TEXT_DOMAIN),
+                    },
+                ];
+
+                for (const record of records) {
+                    options.push({
+                        slug: record.slug,
+                        label:
+                            record.title.rendered && record.title.rendered.trim() !== ''
+                                ? record.title.rendered
+                                : record.slug,
+                        source: __('Theme', TEXT_DOMAIN),
+                    });
+                }
+
+                setTemplateOptions(options);
+            })
+            .catch(() => {
+                if (cancelled) {
+                    return;
+                }
+
+                // A failed template fetch shouldn't block the pattern
+                // grid from rendering — silently drop back to "no
+                // selector" so the modal still works.
+                setTemplateOptions([]);
+            });
+
+        return () => {
+            cancelled = true;
+        };
+    }, [documentType, props.apiBase]);
+
+    // #639 — the auto-open trigger. Fires exactly once when all of the
+    // following hold: the initial load has completed, the record has
+    // never been saved AND has no content, at least one pattern
+    // applies to the current post-type context, and the user hasn't
+    // already dismissed the modal in this session.
+    const isFreshCanvas = useFreshContentDetection({
+        blocks,
+        createdAt: props.initialCreatedAt,
+        updatedAt: props.initialUpdatedAt,
+        loadStatus,
+    });
+
+    useEffect(() => {
+        if (patternModalDismissed) {
+            return;
+        }
+
+        if (!isFreshCanvas) {
+            return;
+        }
+
+        if (pagePatternsLoading) {
+            return;
+        }
+
+        if (pagePatterns.length === 0) {
+            // Zero patterns registered for this post type — the auto-open
+            // path is suppressed so users aren't invited into an empty
+            // modal. Toolbar re-open still works.
+            return;
+        }
+
+        setPatternModalOpen(true);
+    }, [
+        isFreshCanvas,
+        pagePatterns.length,
+        pagePatternsLoading,
+        patternModalDismissed,
+    ]);
+
+    const handleCloseModal = useCallback((): void => {
+        setPatternModalOpen(false);
+        setPatternModalDismissed(true);
+    }, []);
+
+    const handleOpenModal = useCallback((): void => {
+        setPatternModalOpen(true);
+    }, []);
+
+    // Insert the pattern's block tree into the canvas. An empty tree
+    // (e.g. the `Blank` seed) is a no-op — same semantics as WordPress's
+    // "Start blank" affordance.
+    //
+    // Gated on `loadStatus === 'ready'` so users can't drop pattern
+    // blocks into an entity whose initial fetch is still in flight or
+    // has errored — the debounced save would otherwise race the load
+    // and clobber the real content once it lands.
+    const handleInsertPatternBlocks = useCallback(
+        (patternBlocks: readonly BlockInstance[]): void => {
+            if (patternBlocks.length === 0) {
+                return;
+            }
+
+            if (loadStatus !== 'ready') {
+                return;
+            }
+
+            // Push through the same `onChange` path a real edit would
+            // take so history + persistence pick up the insertion.
+            handleChange([...patternBlocks]);
+        },
+        [handleChange, loadStatus]
+    );
+
+    // Expose the manual-open button when the fetch has settled AND
+    // either at least one pattern applies to this post type OR the
+    // fetch itself failed (the modal surfaces the error so users get
+    // a chance to retry / diagnose instead of the feature silently
+    // disappearing). Zero-pattern success case still suppresses the
+    // button, matching the auto-open suppression for zero-pattern
+    // contexts. Also gated on `loadStatus === 'ready'` so users can't
+    // insert pattern blocks into an entity that hasn't loaded — that
+    // would race the persistence loop's initial fetch and clobber the
+    // real content once it lands.
+    const patternModalTriggerAvailable =
+        loadStatus === 'ready'
+        && !pagePatternsLoading
+        && (pagePatterns.length > 0 || pagePatternsError !== null);
+
     const handleToggleInserter = useCallback((): void => {
         setInserterOpen((open) => !open);
     }, []);
@@ -831,10 +1072,14 @@ function EditorAppShell(props: EditorAppProps): JSX.Element {
                 onShowKeyboardShortcuts={handleShowShortcuts}
                 onViewportChange={handleViewportChange}
                 viewportRegistry={viewportRegistry}
+                onOpenPatternModal={
+                    patternModalTriggerAvailable ? handleOpenModal : undefined
+                }
             />
         ),
         [
             flush,
+            handleOpenModal,
             handleRedo,
             handleShowShortcuts,
             handleToggleInserter,
@@ -846,6 +1091,7 @@ function EditorAppShell(props: EditorAppProps): JSX.Element {
             inserterOpen,
             inspectorOpen,
             lastSavedAt,
+            patternModalTriggerAvailable,
             previewUrl,
             saveError,
             saveStatus,
@@ -857,6 +1103,25 @@ function EditorAppShell(props: EditorAppProps): JSX.Element {
         <KeyboardShortcutsModal
             open={shortcutsOpen}
             onClose={handleCloseShortcuts}
+        />
+    );
+
+    // #639 — the page-pattern-inserter modal itself. Rendered at the
+    // shell level so it overlays the whole editor (including the load
+    // / error states below), not just the block-editor tree.
+    const pagePatternModal = (
+        <PagePatternModal
+            open={patternModalOpen}
+            onClose={handleCloseModal}
+            patterns={pagePatterns}
+            onInsertBlocks={handleInsertPatternBlocks}
+            templateOptions={templateOptions.length > 0 ? templateOptions : undefined}
+            initialTemplate={template}
+            onTemplateChange={
+                documentType === 'page' ? handleTemplateChange : undefined
+            }
+            loading={pagePatternsLoading}
+            errorMessage={pagePatternsError}
         />
     );
 
@@ -906,6 +1171,14 @@ function EditorAppShell(props: EditorAppProps): JSX.Element {
                     {__('Loading content…', TEXT_DOMAIN)}
                 </p>
                 {shortcutsModal}
+                {/*
+                 * #639 — pattern modal is intentionally NOT rendered in
+                 * the load-in-progress / load-error branches. The
+                 * insert handler is gated on `loadStatus === 'ready'`,
+                 * but suppressing the whole modal here also removes
+                 * the visual affordance so users don't see a modal
+                 * whose actions silently no-op.
+                 */}
             </div>
         );
     }
@@ -1031,6 +1304,7 @@ function EditorAppShell(props: EditorAppProps): JSX.Element {
                     {wrappedBody}
                 </main>
                 {shortcutsModal}
+                {pagePatternModal}
             </div>
         </SlotFillProvider>
     );

--- a/resources/js/visual-editor/editor/main.tsx
+++ b/resources/js/visual-editor/editor/main.tsx
@@ -109,6 +109,19 @@ export interface MountConfig {
      * Hosts pass via `data-template`.
      */
     initialTemplate?: string;
+    /**
+     * ISO-8601 timestamp when the underlying record was created (#639).
+     * Together with {@link initialUpdatedAt} this drives the "never
+     * saved" heuristic that gates the page-pattern-inserter modal from
+     * auto-opening on already-saved pages. Hosts pass via
+     * `data-created-at`; omit both to leave the modal manual-only.
+     */
+    initialCreatedAt?: string;
+    /**
+     * ISO-8601 timestamp when the underlying record was last updated
+     * (#639). See {@link initialCreatedAt}.
+     */
+    initialUpdatedAt?: string;
     authorOptions?: ReadonlyArray<AuthorOption>;
     supports?: DocumentSupports;
     previewUrl?: string | null;
@@ -179,6 +192,8 @@ function readMountConfig(element: HTMLElement): MountConfig | null {
     const rawParent = element.dataset.parent?.trim();
     const rawMenuOrder = element.dataset.menuOrder?.trim();
     const initialTemplate = element.dataset.template?.trim();
+    const initialCreatedAt = element.dataset.createdAt?.trim();
+    const initialUpdatedAt = element.dataset.updatedAt?.trim();
 
     const initialCategories = parseIdListDataset(
         element.dataset.categories,
@@ -272,6 +287,8 @@ function readMountConfig(element: HTMLElement): MountConfig | null {
             ? { initialMenuOrder }
             : {}),
         ...(initialTemplate ? { initialTemplate } : {}),
+        ...(initialCreatedAt ? { initialCreatedAt } : {}),
+        ...(initialUpdatedAt ? { initialUpdatedAt } : {}),
         ...(breakpoints !== null ? { breakpoints } : {}),
         previewUrl: previewUrl ?? null,
     };

--- a/resources/js/visual-editor/editor/page-pattern-modal/__tests__/filter-modal-patterns.test.ts
+++ b/resources/js/visual-editor/editor/page-pattern-modal/__tests__/filter-modal-patterns.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Vitest for the modal's client-side pattern filter (#639).
+ *
+ * The server's `?post_type=` filter is permissive by design so the
+ * general pattern library (and the sidebar block-inserter) can keep
+ * showing unscoped patterns to every context. The modal tightens
+ * client-side to "explicit scope only, with a seed carve-out."
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import type { PatternRecord } from '../../../site-editor/patterns/api-client';
+import { BUILT_IN_BLANK_SLUG, filterModalPatterns } from '../filter-modal-patterns';
+
+function makePattern(overrides: Partial<PatternRecord> = {}): PatternRecord {
+    return {
+        id: 1,
+        slug: 'x',
+        title: { rendered: 'X', raw: 'X' },
+        content: { raw: '', blocks: [] },
+        synced: false,
+        categories: [],
+        status: 'publish',
+        type: 'wp_block',
+        post_types: null,
+        ...overrides,
+    };
+}
+
+describe('filterModalPatterns', () => {
+    it('keeps a pattern whose post_types explicitly includes the requested post type', () => {
+        const patterns = [
+            makePattern({ id: 1, slug: 'landing-hero', post_types: [ 'page' ] }),
+        ];
+
+        expect(filterModalPatterns(patterns, 'page')).toEqual(patterns);
+    });
+
+    it('drops a pattern that scopes only to a different post type', () => {
+        const patterns = [
+            makePattern({ id: 1, slug: 'recipe-intro', post_types: [ 'post' ] }),
+        ];
+
+        expect(filterModalPatterns(patterns, 'page')).toEqual([]);
+    });
+
+    it('drops unscoped patterns unless they are the built-in Blank seed', () => {
+        const patterns = [
+            makePattern({ id: 1, slug: 'universal-cta', post_types: null }),
+            makePattern({ id: 2, slug: BUILT_IN_BLANK_SLUG, post_types: null }),
+        ];
+
+        const result = filterModalPatterns(patterns, 'page');
+
+        expect(result.map((p) => p.slug)).toEqual([ BUILT_IN_BLANK_SLUG ]);
+    });
+
+    it('drops patterns scoped to an empty array', () => {
+        // A misregistered scope (`post_types: []`) matches nothing —
+        // don't secretly re-include it in every modal.
+        const patterns = [
+            makePattern({ id: 1, slug: 'nowhere', post_types: [] }),
+        ];
+
+        expect(filterModalPatterns(patterns, 'page')).toEqual([]);
+    });
+
+    it('handles a missing post_types field (backward-compat with older backends)', () => {
+        const patterns = [
+            {
+                ...makePattern({ id: 1, slug: 'legacy' }),
+                post_types: undefined,
+            } as unknown as PatternRecord,
+        ];
+
+        expect(filterModalPatterns(patterns, 'page')).toEqual([]);
+    });
+
+    it('keeps only the seed when postType is null (no post-type mapping)', () => {
+        const patterns = [
+            makePattern({ id: 1, slug: 'landing-hero', post_types: [ 'page' ] }),
+            makePattern({ id: 2, slug: BUILT_IN_BLANK_SLUG, post_types: null }),
+        ];
+
+        const result = filterModalPatterns(patterns, null);
+
+        expect(result.map((p) => p.slug)).toEqual([ BUILT_IN_BLANK_SLUG ]);
+    });
+
+    it('produces the exact set for a post editor across a realistic input', () => {
+        const patterns = [
+            makePattern({ id: 1, slug: 'landing-hero', post_types: [ 'page' ] }),
+            makePattern({ id: 2, slug: 'recipe-intro', post_types: [ 'post' ] }),
+            makePattern({ id: 3, slug: 'universal-cta', post_types: null }),
+            makePattern({ id: 4, slug: BUILT_IN_BLANK_SLUG, post_types: null }),
+        ];
+
+        expect(
+            filterModalPatterns(patterns, 'post').map((p) => p.slug).sort()
+        ).toEqual([ BUILT_IN_BLANK_SLUG, 'recipe-intro' ].sort());
+    });
+} );

--- a/resources/js/visual-editor/editor/page-pattern-modal/__tests__/page-pattern-modal.test.tsx
+++ b/resources/js/visual-editor/editor/page-pattern-modal/__tests__/page-pattern-modal.test.tsx
@@ -1,0 +1,353 @@
+/**
+ * Vitest for the page-pattern-inserter modal (#639).
+ *
+ * Exercises the presentational surface: grid rendering, category
+ * grouping, template selector wiring, dismiss (X / Escape / backdrop),
+ * empty-state handling, and pattern selection.
+ */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@wordpress/blocks', () => ({
+    createBlocksFromInnerBlocksTemplate: (template: Array<unknown>) =>
+        template.map((entry) => ({
+            name: (entry as [string])[0],
+            attributes: {},
+            innerBlocks: [],
+        })),
+    parse: (raw: string) => {
+        if (raw.includes('core/paragraph')) {
+            return [{ name: 'core/paragraph', attributes: {}, innerBlocks: [] }];
+        }
+        return [];
+    },
+}));
+
+import type { PatternRecord } from '../../../site-editor/patterns/api-client';
+import { PagePatternModal, type TemplateOption } from '../page-pattern-modal';
+
+function makePattern(overrides: Partial<PatternRecord> = {}): PatternRecord {
+    return {
+        id: 1,
+        slug: 'landing-hero',
+        title: { rendered: 'Landing Hero', raw: 'Landing Hero' },
+        content: { raw: '', blocks: [] },
+        synced: false,
+        categories: [ 'page' ],
+        status: 'publish',
+        type: 'wp_block',
+        post_types: null,
+        ...overrides,
+    };
+}
+
+const NOOP_INSERT = vi.fn();
+const NOOP_CLOSE = vi.fn();
+
+beforeEach(() => {
+    NOOP_INSERT.mockReset();
+    NOOP_CLOSE.mockReset();
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe('<PagePatternModal />', () => {
+    it('does not render when open is false', () => {
+        render(
+            <PagePatternModal
+                open={false}
+                onClose={NOOP_CLOSE}
+                patterns={[]}
+                onInsertBlocks={NOOP_INSERT}
+            />
+        );
+
+        expect(screen.queryByTestId('ap-page-pattern-modal')).not.toBeInTheDocument();
+    });
+
+    it('renders the pattern grid grouped by category when open', () => {
+        render(
+            <PagePatternModal
+                open={true}
+                onClose={NOOP_CLOSE}
+                patterns={[
+                    makePattern({ id: 1, slug: 'a', categories: ['page'] }),
+                    makePattern({ id: 2, slug: 'b', categories: ['post'] }),
+                ]}
+                onInsertBlocks={NOOP_INSERT}
+            />
+        );
+
+        expect(screen.getByTestId('ap-page-pattern-modal-category-page')).toBeInTheDocument();
+        expect(screen.getByTestId('ap-page-pattern-modal-category-post')).toBeInTheDocument();
+        expect(screen.getByTestId('ap-page-pattern-modal-pattern-a')).toBeInTheDocument();
+        expect(screen.getByTestId('ap-page-pattern-modal-pattern-b')).toBeInTheDocument();
+    });
+
+    it('renders a multi-category pattern exactly once, in its primary category', () => {
+        // Modal is a starter picker, not a taxonomy browser — rendering
+        // the same card in every category would duplicate React keys /
+        // `data-testid` and confuse users into thinking the pattern is
+        // multiple different starters.
+        render(
+            <PagePatternModal
+                open={true}
+                onClose={NOOP_CLOSE}
+                patterns={[
+                    makePattern({
+                        id: 42,
+                        slug: 'multi-cat',
+                        categories: [ 'featured', 'page' ],
+                    }),
+                ]}
+                onInsertBlocks={NOOP_INSERT}
+            />
+        );
+
+        expect(screen.getAllByTestId('ap-page-pattern-modal-pattern-multi-cat')).toHaveLength(1);
+        expect(screen.getByTestId('ap-page-pattern-modal-category-featured')).toBeInTheDocument();
+        expect(
+            screen.queryByTestId('ap-page-pattern-modal-category-page')
+        ).not.toBeInTheDocument();
+    });
+
+    it('surfaces the empty-state message when no patterns are provided', () => {
+        render(
+            <PagePatternModal
+                open={true}
+                onClose={NOOP_CLOSE}
+                patterns={[]}
+                onInsertBlocks={NOOP_INSERT}
+            />
+        );
+
+        expect(screen.getByTestId('ap-page-pattern-modal-empty')).toBeInTheDocument();
+    });
+
+    it('renders a loading state when `loading` is true', () => {
+        render(
+            <PagePatternModal
+                open={true}
+                onClose={NOOP_CLOSE}
+                patterns={[]}
+                onInsertBlocks={NOOP_INSERT}
+                loading={true}
+            />
+        );
+
+        expect(screen.getByTestId('ap-page-pattern-modal-loading')).toBeInTheDocument();
+    });
+
+    it('surfaces an error message when provided', () => {
+        render(
+            <PagePatternModal
+                open={true}
+                onClose={NOOP_CLOSE}
+                patterns={[]}
+                onInsertBlocks={NOOP_INSERT}
+                errorMessage="Something went wrong."
+            />
+        );
+
+        expect(screen.getByTestId('ap-page-pattern-modal-error')).toHaveTextContent(
+            'Something went wrong.'
+        );
+    });
+
+    it('fires onClose when the X button is clicked', async () => {
+        const user = userEvent.setup();
+
+        render(
+            <PagePatternModal
+                open={true}
+                onClose={NOOP_CLOSE}
+                patterns={[makePattern()]}
+                onInsertBlocks={NOOP_INSERT}
+            />
+        );
+
+        await user.click(screen.getByTestId('ap-page-pattern-modal-close'));
+
+        expect(NOOP_CLOSE).toHaveBeenCalledTimes(1);
+    });
+
+    it('fires onClose when Escape is pressed', async () => {
+        const user = userEvent.setup();
+
+        render(
+            <PagePatternModal
+                open={true}
+                onClose={NOOP_CLOSE}
+                patterns={[makePattern()]}
+                onInsertBlocks={NOOP_INSERT}
+            />
+        );
+
+        await user.keyboard('{Escape}');
+
+        await waitFor(() => {
+            expect(NOOP_CLOSE).toHaveBeenCalled();
+        });
+    });
+
+    it('fires onClose when the backdrop is clicked', async () => {
+        const user = userEvent.setup();
+
+        render(
+            <PagePatternModal
+                open={true}
+                onClose={NOOP_CLOSE}
+                patterns={[makePattern()]}
+                onInsertBlocks={NOOP_INSERT}
+            />
+        );
+
+        await user.click(screen.getByTestId('ap-page-pattern-modal-backdrop'));
+
+        expect(NOOP_CLOSE).toHaveBeenCalled();
+    });
+
+    it('does not fire onClose when the dialog interior is clicked', async () => {
+        const user = userEvent.setup();
+
+        render(
+            <PagePatternModal
+                open={true}
+                onClose={NOOP_CLOSE}
+                patterns={[makePattern()]}
+                onInsertBlocks={NOOP_INSERT}
+            />
+        );
+
+        // Click the modal container (not the backdrop). Clicks on the
+        // dialog interior must not trigger the dismiss path — otherwise
+        // the user can't interact with the pattern grid.
+        await user.click(screen.getByTestId('ap-page-pattern-modal'));
+
+        expect(NOOP_CLOSE).not.toHaveBeenCalled();
+    });
+
+    it('parses the pattern content and hands the block tree to onInsertBlocks', async () => {
+        const user = userEvent.setup();
+
+        render(
+            <PagePatternModal
+                open={true}
+                onClose={NOOP_CLOSE}
+                patterns={[
+                    makePattern({
+                        slug: 'hero',
+                        content: { raw: '<!-- wp:core/paragraph /-->', blocks: [] },
+                    }),
+                ]}
+                onInsertBlocks={NOOP_INSERT}
+            />
+        );
+
+        await user.click(screen.getByTestId('ap-page-pattern-modal-pattern-hero'));
+
+        expect(NOOP_INSERT).toHaveBeenCalledTimes(1);
+        expect(NOOP_INSERT.mock.calls[0][0]).toEqual([
+            { name: 'core/paragraph', attributes: {}, innerBlocks: [] },
+        ]);
+        // Selecting a pattern also closes the modal so the user lands
+        // back in the canvas.
+        expect(NOOP_CLOSE).toHaveBeenCalled();
+    });
+
+    it('produces an empty block tree for a Blank pattern (no raw, no blocks)', async () => {
+        const user = userEvent.setup();
+
+        render(
+            <PagePatternModal
+                open={true}
+                onClose={NOOP_CLOSE}
+                patterns={[
+                    makePattern({
+                        slug: 'page/blank',
+                        title: { rendered: 'Blank', raw: 'Blank' },
+                        content: { raw: '', blocks: [] },
+                    }),
+                ]}
+                onInsertBlocks={NOOP_INSERT}
+            />
+        );
+
+        await user.click(screen.getByTestId('ap-page-pattern-modal-pattern-page/blank'));
+
+        expect(NOOP_INSERT).toHaveBeenCalledWith([]);
+        expect(NOOP_CLOSE).toHaveBeenCalled();
+    });
+
+    it('renders the template selector when both options and handler are supplied', async () => {
+        const user = userEvent.setup();
+        const onTemplateChange = vi.fn();
+
+        const options: TemplateOption[] = [
+            { slug: '', label: 'Default template' },
+            { slug: 'wide', label: 'Wide', source: 'Theme' },
+        ];
+
+        render(
+            <PagePatternModal
+                open={true}
+                onClose={NOOP_CLOSE}
+                patterns={[makePattern()]}
+                onInsertBlocks={NOOP_INSERT}
+                templateOptions={options}
+                initialTemplate=""
+                onTemplateChange={onTemplateChange}
+            />
+        );
+
+        const select = screen.getByTestId('ap-page-pattern-modal-template-select');
+
+        expect(select).toBeInTheDocument();
+        expect(select).toHaveValue('');
+
+        await user.selectOptions(select, 'wide');
+
+        expect(onTemplateChange).toHaveBeenCalledWith('wide');
+    });
+
+    it('suppresses the template selector when no options are supplied', () => {
+        render(
+            <PagePatternModal
+                open={true}
+                onClose={NOOP_CLOSE}
+                patterns={[makePattern()]}
+                onInsertBlocks={NOOP_INSERT}
+                templateOptions={[]}
+                onTemplateChange={vi.fn()}
+            />
+        );
+
+        expect(
+            screen.queryByTestId('ap-page-pattern-modal-template-select')
+        ).not.toBeInTheDocument();
+    });
+
+    it('suppresses the template selector when no handler is supplied even if options exist', () => {
+        // Options without a setter means the caller has no persistence
+        // path — rendering the select would be a footgun where user
+        // clicks silently vanish. Suppress the row entirely.
+        render(
+            <PagePatternModal
+                open={true}
+                onClose={NOOP_CLOSE}
+                patterns={[makePattern()]}
+                onInsertBlocks={NOOP_INSERT}
+                templateOptions={[{ slug: '', label: 'Default' }]}
+                // onTemplateChange intentionally omitted.
+            />
+        );
+
+        expect(
+            screen.queryByTestId('ap-page-pattern-modal-template-select')
+        ).not.toBeInTheDocument();
+    });
+});

--- a/resources/js/visual-editor/editor/page-pattern-modal/__tests__/use-fresh-content-detection.test.ts
+++ b/resources/js/visual-editor/editor/page-pattern-modal/__tests__/use-fresh-content-detection.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Vitest for the fresh-content detection heuristic (#639).
+ *
+ * The hook itself is a `useMemo` wrapper around `isFreshContent`; we
+ * exercise the pure function directly to keep the cases readable and
+ * avoid a react-hook harness.
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { BlockInstance } from '@wordpress/blocks';
+
+import { isFreshContent } from '../use-fresh-content-detection';
+
+const BLOCK: BlockInstance = {
+    clientId: 'x',
+    name: 'core/paragraph',
+    isValid: true,
+    attributes: {},
+    innerBlocks: [],
+} as unknown as BlockInstance;
+
+describe('isFreshContent', () => {
+    it('returns true when content is empty, load is ready, and created === updated', () => {
+        expect(
+            isFreshContent({
+                blocks: [],
+                createdAt: '2026-01-01T00:00:00Z',
+                updatedAt: '2026-01-01T00:00:00Z',
+                loadStatus: 'ready',
+            })
+        ).toBe(true);
+    });
+
+    it('treats equivalent ISO representations as the same instant', () => {
+        // A backend that emits `+00:00` for `created_at` and `Z` for
+        // `updated_at` (or vice versa) shouldn't defeat the heuristic —
+        // the timestamps refer to the same moment.
+        expect(
+            isFreshContent({
+                blocks: [],
+                createdAt: '2026-01-01T00:00:00+00:00',
+                updatedAt: '2026-01-01T00:00:00Z',
+                loadStatus: 'ready',
+            })
+        ).toBe(true);
+    });
+
+    it('returns false while the initial load is still in flight', () => {
+        // During `loading`, blocks are transiently empty even for saved
+        // pages — the modal would misfire without the guard.
+        expect(
+            isFreshContent({
+                blocks: [],
+                createdAt: '2026-01-01T00:00:00Z',
+                updatedAt: '2026-01-01T00:00:00Z',
+                loadStatus: 'loading',
+            })
+        ).toBe(false);
+    });
+
+    it('returns false when the record has been saved (created !== updated)', () => {
+        expect(
+            isFreshContent({
+                blocks: [],
+                createdAt: '2026-01-01T00:00:00Z',
+                updatedAt: '2026-01-02T00:00:00Z',
+                loadStatus: 'ready',
+            })
+        ).toBe(false);
+    });
+
+    it('returns false when the canvas already has content', () => {
+        expect(
+            isFreshContent({
+                blocks: [BLOCK],
+                createdAt: '2026-01-01T00:00:00Z',
+                updatedAt: '2026-01-01T00:00:00Z',
+                loadStatus: 'ready',
+            })
+        ).toBe(false);
+    });
+
+    it('returns false when either timestamp is missing (backward-compat)', () => {
+        // Hosts that don't stamp `data-created-at` / `data-updated-at`
+        // opt out of the detection entirely. Safe default: no auto-open.
+        expect(
+            isFreshContent({
+                blocks: [],
+                createdAt: undefined,
+                updatedAt: '2026-01-01T00:00:00Z',
+                loadStatus: 'ready',
+            })
+        ).toBe(false);
+
+        expect(
+            isFreshContent({
+                blocks: [],
+                createdAt: '2026-01-01T00:00:00Z',
+                updatedAt: undefined,
+                loadStatus: 'ready',
+            })
+        ).toBe(false);
+
+        expect(
+            isFreshContent({
+                blocks: [],
+                createdAt: undefined,
+                updatedAt: undefined,
+                loadStatus: 'ready',
+            })
+        ).toBe(false);
+    });
+
+    it('returns false when a stamped timestamp is malformed', () => {
+        // A bogus stamp shouldn't be silently coerced to `NaN === NaN
+        // === false` — but Date.parse yields NaN and we normalize to
+        // null, which is compared against null and yields true. Guard
+        // explicitly here so the tests document the behavior.
+        expect(
+            isFreshContent({
+                blocks: [],
+                createdAt: 'not-a-date',
+                updatedAt: 'also-not-a-date',
+                loadStatus: 'ready',
+            })
+        ).toBe(false);
+    });
+});

--- a/resources/js/visual-editor/editor/page-pattern-modal/filter-modal-patterns.ts
+++ b/resources/js/visual-editor/editor/page-pattern-modal/filter-modal-patterns.ts
@@ -1,0 +1,63 @@
+/**
+ * Client-side tightening on top of the server's `?post_type=` filter for
+ * the page-pattern-inserter modal (#639).
+ *
+ * The general pattern index (`PatternController::index`) filters
+ * permissively — unscoped patterns (post_types === null) match every
+ * request so the sidebar block-inserter panel keeps its "library of
+ * everything" behavior. The modal wants stricter semantics: only
+ * patterns that explicitly declare they're for this post type belong
+ * in the whole-page picker. Anything else risks polluting the modal
+ * with what the user thinks of as block-inserter snippets.
+ *
+ * The one exception is the built-in `page/blank` seed — it's
+ * intentionally unscoped so a fresh install always has an "empty
+ * canvas" affordance in the modal regardless of the post type. Special-
+ * casing here keeps the seed available without giving up the stricter
+ * default for every other unscoped pattern.
+ *
+ * @since 1.4.0
+ */
+
+import type { PatternRecord } from '../../site-editor/patterns/api-client';
+
+export const BUILT_IN_BLANK_SLUG = 'page/blank';
+
+/**
+ * @param records    Patterns as returned by `listPatterns`. May include
+ *                   unscoped entries — the server's `?post_type=` is
+ *                   permissive by design.
+ * @param postType   The current editor's post-type slug (`page`,
+ *                   `post`, or a host-registered custom type). When
+ *                   `null`, the modal is running against a resource
+ *                   with no post-type mapping and the caller should
+ *                   already have skipped the fetch — but we handle
+ *                   `null` here defensively by returning the seed only.
+ */
+export function filterModalPatterns(
+    records: readonly PatternRecord[],
+    postType: string | null
+): readonly PatternRecord[] {
+    return records.filter((record) => {
+        if (record.slug === BUILT_IN_BLANK_SLUG) {
+            return true;
+        }
+
+        if (postType === null) {
+            return false;
+        }
+
+        // Unscoped patterns (post_types null / undefined / empty) don't
+        // survive — the general pattern library is what the sidebar
+        // inserter shows, not this modal.
+        if (
+            record.post_types === null ||
+            record.post_types === undefined ||
+            record.post_types.length === 0
+        ) {
+            return false;
+        }
+
+        return record.post_types.includes(postType);
+    });
+}

--- a/resources/js/visual-editor/editor/page-pattern-modal/page-pattern-modal.css
+++ b/resources/js/visual-editor/editor/page-pattern-modal/page-pattern-modal.css
@@ -1,0 +1,146 @@
+/**
+ * Page-pattern-inserter modal styles (#639).
+ *
+ * Uses the `--ap-visual-editor-*` custom-property namespace so M8 (#318)
+ * theming lands here without touching the component.
+ */
+
+.ap-page-pattern-modal__backdrop {
+	position: fixed;
+	inset: 0;
+	z-index: 1000;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	background: color-mix(in oklab, black 55%, transparent);
+	padding: 1.5rem;
+}
+
+.ap-page-pattern-modal__dialog {
+	background: var(--ap-visual-editor-modal-bg, #fff);
+	color: var(--ap-visual-editor-modal-fg, #111);
+	border-radius: 0.5rem;
+	box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
+	width: 100%;
+	max-width: 1024px;
+	max-height: 90vh;
+	display: flex;
+	flex-direction: column;
+	overflow: hidden;
+}
+
+.ap-page-pattern-modal__header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 1rem 1.25rem;
+	border-bottom: 1px solid var(--ap-visual-editor-modal-border, #e5e7eb);
+}
+
+.ap-page-pattern-modal__title {
+	font-size: 1.125rem;
+	font-weight: 600;
+	margin: 0;
+}
+
+.ap-page-pattern-modal__close {
+	background: transparent;
+	border: 0;
+	cursor: pointer;
+	font-size: 1.25rem;
+	line-height: 1;
+	padding: 0.25rem 0.5rem;
+	color: inherit;
+}
+
+.ap-page-pattern-modal__close:hover,
+.ap-page-pattern-modal__close:focus {
+	color: var(--ap-visual-editor-modal-close-hover, #dc2626);
+}
+
+.ap-page-pattern-modal__body {
+	overflow-y: auto;
+	padding: 1.25rem;
+	display: flex;
+	flex-direction: column;
+	gap: 1.25rem;
+}
+
+.ap-page-pattern-modal__template-section {
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+}
+
+.ap-page-pattern-modal__template-label {
+	font-weight: 600;
+	font-size: 0.875rem;
+}
+
+.ap-page-pattern-modal__template-select {
+	padding: 0.5rem 0.75rem;
+	border: 1px solid var(--ap-visual-editor-modal-border, #d1d5db);
+	border-radius: 0.375rem;
+	background: inherit;
+	color: inherit;
+	font-size: 0.875rem;
+}
+
+.ap-page-pattern-modal__grid {
+	display: grid;
+	grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+	gap: 1rem;
+}
+
+.ap-page-pattern-modal__category-heading {
+	font-size: 0.75rem;
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: 0.05em;
+	margin: 0 0 0.5rem;
+	color: var(--ap-visual-editor-modal-muted, #6b7280);
+}
+
+.ap-page-pattern-modal__pattern-card {
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+	border: 1px solid var(--ap-visual-editor-modal-border, #e5e7eb);
+	border-radius: 0.5rem;
+	padding: 0.75rem;
+	background: inherit;
+	color: inherit;
+	text-align: left;
+	cursor: pointer;
+	transition: border-color 100ms ease, transform 100ms ease;
+}
+
+.ap-page-pattern-modal__pattern-card:hover,
+.ap-page-pattern-modal__pattern-card:focus {
+	border-color: var(--ap-visual-editor-modal-accent, #2563eb);
+	transform: translateY(-1px);
+	outline: none;
+}
+
+.ap-page-pattern-modal__pattern-title {
+	font-weight: 600;
+	font-size: 0.875rem;
+	margin: 0;
+}
+
+.ap-page-pattern-modal__pattern-meta {
+	font-size: 0.75rem;
+	color: var(--ap-visual-editor-modal-muted, #6b7280);
+	margin: 0;
+}
+
+.ap-page-pattern-modal__empty,
+.ap-page-pattern-modal__status {
+	text-align: center;
+	color: var(--ap-visual-editor-modal-muted, #6b7280);
+	padding: 2rem 0;
+}
+
+.ap-page-pattern-modal__error {
+	color: var(--ap-visual-editor-modal-error, #b91c1c);
+}

--- a/resources/js/visual-editor/editor/page-pattern-modal/page-pattern-modal.tsx
+++ b/resources/js/visual-editor/editor/page-pattern-modal/page-pattern-modal.tsx
@@ -1,0 +1,417 @@
+/**
+ * Page-pattern-inserter modal (#639).
+ *
+ * Renders a WordPress-style "Choose a pattern" dialog for the current
+ * post-type context. Combines a pattern grid (grouped by category) with
+ * an optional template selector. Selecting a pattern hands its parsed
+ * block tree back to the caller; selecting a template writes through
+ * the caller-provided setter. `Blank` dismisses cleanly with an empty
+ * canvas.
+ *
+ * The modal is purely presentational — the caller (`editor-app.tsx`)
+ * owns the open/close state, the block-insertion side effect, and the
+ * template-change side effect. This keeps the modal reusable for
+ * both the auto-open flow and the toolbar-triggered manual re-open.
+ *
+ * @since 1.4.0
+ */
+
+import {
+    createBlocksFromInnerBlocksTemplate,
+    parse,
+    type BlockInstance,
+} from '@wordpress/blocks';
+import { __, sprintf } from '@wordpress/i18n';
+import {
+    useCallback,
+    useEffect,
+    useId,
+    useMemo,
+    useRef,
+    type ChangeEvent,
+    type KeyboardEvent as ReactKeyboardEvent,
+} from 'react';
+
+import { TEXT_DOMAIN } from '../../vendor/i18n';
+import type { PatternRecord } from '../../site-editor/patterns/api-client';
+
+import './page-pattern-modal.css';
+
+/**
+ * A template option shown in the selector. `source` lets the modal
+ * surface where the template came from ("Theme" for site-editor
+ * `Template` records, "CMS" for cms-framework page templates, or any
+ * host-defined label) without the caller having to render its own
+ * label logic.
+ */
+export interface TemplateOption {
+    /** The slug written to the page's `template` field on selection. */
+    readonly slug: string;
+    /** Human-readable label rendered in the `<option>`. */
+    readonly label: string;
+    /** Optional source tag (e.g. "Theme", "CMS"). */
+    readonly source?: string;
+}
+
+export interface PagePatternModalProps {
+    /** Whether the modal is currently rendered. */
+    readonly open: boolean;
+    /** Fired when the user dismisses via X / Escape / backdrop. */
+    readonly onClose: () => void;
+    /**
+     * All patterns applicable to the current post-type context. The
+     * caller pre-fetches and post-type-filters; the modal only groups
+     * by category and renders. An empty list renders the empty state
+     * (no patterns registered for this post type).
+     */
+    readonly patterns: readonly PatternRecord[];
+    /**
+     * Fired when the user picks a pattern. Receives the parsed block
+     * tree — never the raw `PatternRecord` — so the caller can
+     * `insertBlocks` without another parse pass. `Blank` produces an
+     * empty array, which the caller should treat as "leave the canvas
+     * alone."
+     */
+    readonly onInsertBlocks: (blocks: readonly BlockInstance[]) => void;
+    /**
+     * Template options combining site-editor `Template` records and
+     * cms-framework page templates. Empty means "no selector"; the
+     * modal renders without the template row entirely.
+     */
+    readonly templateOptions?: readonly TemplateOption[];
+    /** Current template slug, driving the `<select>` value. */
+    readonly initialTemplate?: string;
+    /**
+     * Fired when the user picks a template. Optional — omit when the
+     * current post type doesn't support templates.
+     */
+    readonly onTemplateChange?: (slug: string) => void;
+    /** Async loading indicator for the pattern list. */
+    readonly loading?: boolean;
+    /** Error message from a failed pattern fetch. */
+    readonly errorMessage?: string | null;
+    /**
+     * i18n override for the dialog title. Optional so custom post
+     * types can label the modal ("Choose a post pattern",
+     * "Choose a landing-page layout", …).
+     */
+    readonly title?: string;
+}
+
+type TemplateNode = [string, Record<string, unknown>?, TemplateNode[]?];
+
+function patternBlocks(pattern: PatternRecord): BlockInstance[] {
+    const raw = pattern.content?.raw;
+
+    if (typeof raw === 'string' && raw.trim() !== '') {
+        return parse(raw);
+    }
+
+    if (Array.isArray(pattern.content?.blocks)) {
+        return pattern.content.blocks as BlockInstance[];
+    }
+
+    return [];
+}
+
+function blocksToTemplate(blocks: readonly BlockInstance[]): TemplateNode[] {
+    return blocks.map((block): TemplateNode => {
+        const inner = Array.isArray(block.innerBlocks)
+            ? (block.innerBlocks as BlockInstance[])
+            : [];
+
+        return [
+            block.name,
+            block.attributes ?? {},
+            inner.length > 0 ? blocksToTemplate(inner) : [],
+        ];
+    });
+}
+
+/**
+ * Produce a fresh block-tree copy so two inserts of the same pattern
+ * don't collide on clientId. Matches the strategy used by
+ * `inserter-patterns-panel.tsx`.
+ */
+function cloneBlocks(blocks: readonly BlockInstance[]): BlockInstance[] {
+    if (blocks.length === 0) {
+        return [];
+    }
+
+    return createBlocksFromInnerBlocksTemplate(blocksToTemplate(blocks));
+}
+
+function patternTitle(pattern: PatternRecord): string {
+    const raw = pattern.title?.raw?.trim();
+
+    if (raw !== undefined && raw !== '') {
+        return raw;
+    }
+
+    const rendered = pattern.title?.rendered?.trim();
+
+    if (rendered !== undefined && rendered !== '') {
+        return rendered;
+    }
+
+    return pattern.slug;
+}
+
+function groupByCategory(
+    patterns: readonly PatternRecord[]
+): ReadonlyArray<readonly [string, readonly PatternRecord[]]> {
+    const groups = new Map<string, PatternRecord[]>();
+
+    for (const pattern of patterns) {
+        const rawCategories =
+            pattern.categories.length > 0 ? pattern.categories : ['uncategorized'];
+
+        // Assign each pattern to exactly one category — the first entry
+        // in its `categories` array — so a multi-categorized pattern
+        // renders once instead of once per category. Rendering the same
+        // pattern in multiple sections would duplicate the visible card
+        // and collide on `key` / `data-testid`, and the modal is a
+        // pick-one starter picker, not a taxonomy browser.
+        const primary = rawCategories[0] ?? 'uncategorized';
+        const bucket = groups.get(primary);
+
+        if (bucket === undefined) {
+            groups.set(primary, [pattern]);
+        } else if (!bucket.some((existing) => existing.id === pattern.id)) {
+            bucket.push(pattern);
+        }
+    }
+
+    return Array.from(groups.entries()).sort(([a], [b]) => a.localeCompare(b));
+}
+
+export function PagePatternModal(props: PagePatternModalProps): JSX.Element | null {
+    const {
+        open,
+        onClose,
+        patterns,
+        onInsertBlocks,
+        templateOptions,
+        initialTemplate,
+        onTemplateChange,
+        loading = false,
+        errorMessage = null,
+        title,
+    } = props;
+
+    const titleId = useId();
+    const dialogRef = useRef<HTMLDivElement | null>(null);
+
+    useEffect(() => {
+        if (!open) {
+            return;
+        }
+
+        function handleKey(event: KeyboardEvent): void {
+            if (event.key === 'Escape') {
+                event.preventDefault();
+                onClose();
+            }
+        }
+
+        window.addEventListener('keydown', handleKey);
+
+        return () => {
+            window.removeEventListener('keydown', handleKey);
+        };
+    }, [open, onClose]);
+
+    // Move focus into the dialog on open so keyboard users don't have
+    // to tab out of the underlying editor to reach the pattern grid.
+    useEffect(() => {
+        if (!open) {
+            return;
+        }
+
+        dialogRef.current?.focus();
+    }, [open]);
+
+    const grouped = useMemo(() => groupByCategory(patterns), [patterns]);
+
+    const handleBackdropClick = useCallback(() => {
+        onClose();
+    }, [onClose]);
+
+    const handleDialogClick = useCallback(
+        (event: React.MouseEvent<HTMLDivElement>) => {
+            // Prevent the backdrop from closing when the click starts
+            // inside the dialog.
+            event.stopPropagation();
+        },
+        []
+    );
+
+    const handleSelectPattern = useCallback(
+        (pattern: PatternRecord): void => {
+            const blocks = cloneBlocks(patternBlocks(pattern));
+
+            onInsertBlocks(blocks);
+            onClose();
+        },
+        [onClose, onInsertBlocks]
+    );
+
+    const handleTemplateSelect = useCallback(
+        (event: ChangeEvent<HTMLSelectElement>): void => {
+            onTemplateChange?.(event.target.value);
+        },
+        [onTemplateChange]
+    );
+
+    const handleCardKey = useCallback(
+        (event: ReactKeyboardEvent<HTMLButtonElement>, pattern: PatternRecord): void => {
+            if (event.key !== 'Enter' && event.key !== ' ') {
+                return;
+            }
+
+            event.preventDefault();
+            handleSelectPattern(pattern);
+        },
+        [handleSelectPattern]
+    );
+
+    if (!open) {
+        return null;
+    }
+
+    const dialogTitle = title ?? __('Choose a pattern', TEXT_DOMAIN);
+    const shouldRenderTemplateRow =
+        templateOptions !== undefined && templateOptions.length > 0 && onTemplateChange !== undefined;
+
+    return (
+        <div
+            className="ap-page-pattern-modal__backdrop"
+            role="presentation"
+            data-testid="ap-page-pattern-modal-backdrop"
+            onClick={handleBackdropClick}
+        >
+            <div
+                ref={dialogRef}
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby={titleId}
+                tabIndex={-1}
+                className="ap-page-pattern-modal__dialog"
+                data-testid="ap-page-pattern-modal"
+                onClick={handleDialogClick}
+            >
+                <header className="ap-page-pattern-modal__header">
+                    <h2 id={titleId} className="ap-page-pattern-modal__title">
+                        {dialogTitle}
+                    </h2>
+                    <button
+                        type="button"
+                        className="ap-page-pattern-modal__close"
+                        aria-label={__('Close pattern picker', TEXT_DOMAIN)}
+                        data-testid="ap-page-pattern-modal-close"
+                        onClick={onClose}
+                    >
+                        {'×'}
+                    </button>
+                </header>
+                <div className="ap-page-pattern-modal__body">
+                    {shouldRenderTemplateRow ? (
+                        <div className="ap-page-pattern-modal__template-section">
+                            <label
+                                className="ap-page-pattern-modal__template-label"
+                                htmlFor={`${titleId}-template`}
+                            >
+                                {__('Template', TEXT_DOMAIN)}
+                            </label>
+                            <select
+                                id={`${titleId}-template`}
+                                className="ap-page-pattern-modal__template-select"
+                                value={initialTemplate ?? ''}
+                                data-testid="ap-page-pattern-modal-template-select"
+                                onChange={handleTemplateSelect}
+                            >
+                                {templateOptions.map((option) => (
+                                    <option key={option.slug} value={option.slug}>
+                                        {option.source
+                                            ? sprintf(
+                                                  /* translators: 1: template label. 2: source (Theme, CMS, etc). */
+                                                  __('%1$s (%2$s)', TEXT_DOMAIN),
+                                                  option.label,
+                                                  option.source
+                                              )
+                                            : option.label}
+                                    </option>
+                                ))}
+                            </select>
+                        </div>
+                    ) : null}
+
+                    {loading ? (
+                        <p
+                            className="ap-page-pattern-modal__status"
+                            role="status"
+                            aria-live="polite"
+                            data-testid="ap-page-pattern-modal-loading"
+                        >
+                            {__('Loading patterns…', TEXT_DOMAIN)}
+                        </p>
+                    ) : null}
+
+                    {errorMessage !== null && !loading ? (
+                        <p
+                            className="ap-page-pattern-modal__status ap-page-pattern-modal__error"
+                            role="alert"
+                            data-testid="ap-page-pattern-modal-error"
+                        >
+                            {errorMessage}
+                        </p>
+                    ) : null}
+
+                    {!loading && errorMessage === null && grouped.length === 0 ? (
+                        <p
+                            className="ap-page-pattern-modal__empty"
+                            data-testid="ap-page-pattern-modal-empty"
+                        >
+                            {__(
+                                'No patterns registered for this content type yet.',
+                                TEXT_DOMAIN
+                            )}
+                        </p>
+                    ) : null}
+
+                    {!loading && errorMessage === null
+                        ? grouped.map(([category, categoryPatterns]) => (
+                              <section
+                                  key={category}
+                                  data-testid={`ap-page-pattern-modal-category-${category}`}
+                              >
+                                  <h3 className="ap-page-pattern-modal__category-heading">
+                                      {category}
+                                  </h3>
+                                  <div className="ap-page-pattern-modal__grid">
+                                      {categoryPatterns.map((pattern) => (
+                                          <button
+                                              key={pattern.id}
+                                              type="button"
+                                              className="ap-page-pattern-modal__pattern-card"
+                                              data-testid={`ap-page-pattern-modal-pattern-${pattern.slug}`}
+                                              onClick={() => handleSelectPattern(pattern)}
+                                              onKeyDown={(event) => handleCardKey(event, pattern)}
+                                          >
+                                              <p className="ap-page-pattern-modal__pattern-title">
+                                                  {patternTitle(pattern)}
+                                              </p>
+                                              <p className="ap-page-pattern-modal__pattern-meta">
+                                                  <code>{pattern.slug}</code>
+                                              </p>
+                                          </button>
+                                      ))}
+                                  </div>
+                              </section>
+                          ))
+                        : null}
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/resources/js/visual-editor/editor/page-pattern-modal/use-fresh-content-detection.ts
+++ b/resources/js/visual-editor/editor/page-pattern-modal/use-fresh-content-detection.ts
@@ -1,0 +1,110 @@
+/**
+ * Detects a freshly-created record with no persisted content — the trigger
+ * for the #639 page-pattern-inserter modal to auto-open.
+ *
+ * The heuristic mirrors WordPress's "Choose a pattern" flow:
+ *   1. The loaded content payload is empty (no blocks and no non-whitespace
+ *      raw markup).
+ *   2. The underlying record has never been saved (`createdAt === updatedAt`
+ *      or `updatedAt` is missing entirely, so the record still shows its
+ *      creation timestamp only).
+ *
+ * Both conditions must hold at first-load time. Once the user saves — even
+ * a blank canvas — the `updated_at` timestamp advances past `created_at`
+ * and the record no longer looks fresh; the modal never auto-opens again
+ * without a hard reload of a freshly-created record. This is exactly the
+ * "first-save suppression" behavior the acceptance criteria call for
+ * (#639), and it needs no schema change or client-side flag.
+ *
+ * When the host doesn't stamp `data-created-at` / `data-updated-at`
+ * (backward compat), the detection returns `false` and the modal never
+ * auto-opens. The toolbar button still lets users open it manually.
+ *
+ * @since 1.4.0
+ */
+
+import type { BlockInstance } from '@wordpress/blocks';
+import { useMemo } from 'react';
+
+export interface FreshContentInputs {
+    /**
+     * Blocks currently loaded into the editor. Detection ignores anything
+     * queued for save; only the initial payload matters.
+     */
+    readonly blocks: readonly BlockInstance[];
+    /**
+     * ISO-8601 creation timestamp, or `undefined` when the host didn't
+     * stamp `data-created-at` on the mount element.
+     */
+    readonly createdAt: string | undefined;
+    /**
+     * ISO-8601 last-update timestamp, or `undefined` when the host didn't
+     * stamp `data-updated-at`.
+     */
+    readonly updatedAt: string | undefined;
+    /**
+     * The `usePersistence` load-status enum. Detection only returns
+     * `true` once the initial fetch has completed successfully;
+     * otherwise `blocks` may be `[]` transiently while the request is
+     * still in flight and a naïve check would misfire.
+     */
+    readonly loadStatus: 'idle' | 'loading' | 'ready' | 'error';
+}
+
+function normalizeTimestamp(input: string | undefined): string | null {
+    if (input === undefined) {
+        return null;
+    }
+
+    const trimmed = input.trim();
+
+    if (trimmed === '') {
+        return null;
+    }
+
+    // Reduce ISO-8601 timestamps to their millisecond form so a
+    // trailing `Z` vs. `+00:00` offset representation doesn't cause
+    // otherwise-equal timestamps to look different. `Date.parse`
+    // handles both forms and returns NaN for garbage input; we bail
+    // to `null` on NaN so a malformed stamp defaults to "not fresh".
+    const parsed = Date.parse(trimmed);
+
+    return Number.isNaN(parsed) ? null : String(parsed);
+}
+
+export function isFreshContent(inputs: FreshContentInputs): boolean {
+    const { blocks, createdAt, updatedAt, loadStatus } = inputs;
+
+    if (loadStatus !== 'ready') {
+        return false;
+    }
+
+    if (blocks.length > 0) {
+        return false;
+    }
+
+    const created = normalizeTimestamp(createdAt);
+    const updated = normalizeTimestamp(updatedAt);
+
+    // Both timestamps must be present — a host that stamps one but not
+    // the other has (accidentally or otherwise) opted out of the
+    // detection. Returning `false` here is the safe default.
+    if (created === null || updated === null) {
+        return false;
+    }
+
+    return created === updated;
+}
+
+/**
+ * Memoized wrapper so callers can drop this into a React tree without
+ * re-computing on every render.
+ *
+ * @since 1.4.0
+ */
+export function useFreshContentDetection(inputs: FreshContentInputs): boolean {
+    return useMemo(
+        () => isFreshContent(inputs),
+        [inputs.blocks, inputs.createdAt, inputs.updatedAt, inputs.loadStatus]
+    );
+}

--- a/resources/js/visual-editor/editor/top-bar.tsx
+++ b/resources/js/visual-editor/editor/top-bar.tsx
@@ -109,6 +109,16 @@ export interface TopBarProps {
      */
     viewportRegistry?: BreakpointRegistry;
     /**
+     * Optional handler for the #639 page-pattern-inserter button. When
+     * present, the top bar renders a pattern-inserter button next to
+     * the `+` inserter — clicking it re-opens the pattern modal at any
+     * time, including after the "never saved" heuristic has stopped
+     * matching. Omit when no patterns are registered for the current
+     * post type; the button is suppressed rather than rendered inert
+     * so users aren't invited into an always-empty modal.
+     */
+    onOpenPatternModal?: () => void;
+    /**
      * Side-effect fired when the user selects a viewport preset (#617).
      * Receives the breakpoint key and the canvas preview width — `0`
      * for `base` (unconstrained), a positive int for named
@@ -209,6 +219,7 @@ export function TopBar(props: TopBarProps): JSX.Element {
         inspectorToggleAriaLabel,
         viewportRegistry,
         onViewportChange,
+        onOpenPatternModal,
     } = props;
 
     const viewportRegistryValue = viewportRegistry ?? DEFAULT_VIEWPORT_REGISTRY;
@@ -424,6 +435,33 @@ export function TopBar(props: TopBarProps): JSX.Element {
                         />
                     </svg>
                 </button>
+                {onOpenPatternModal !== undefined ? (
+                    <button
+                        type="button"
+                        className="ap-visual-editor-top-bar__icon-button"
+                        aria-label={__('Choose a pattern', TEXT_DOMAIN)}
+                        data-testid="ap-visual-editor-top-bar-pattern-modal"
+                        onClick={onOpenPatternModal}
+                    >
+                        {/*
+                          * #639 — "grid" glyph matches WordPress's
+                          * pattern-modal affordance without pulling in
+                          * an icon-font dep.
+                          */}
+                        <svg
+                            aria-hidden="true"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                            width="20"
+                            height="20"
+                        >
+                            <path
+                                fill="currentColor"
+                                d="M4 4h7v7H4V4zm0 9h7v7H4v-7zm9-9h7v7h-7V4zm0 9h7v7h-7v-7z"
+                            />
+                        </svg>
+                    </button>
+                ) : null}
                 <button
                     type="button"
                     className="ap-visual-editor-top-bar__icon-button"

--- a/resources/js/visual-editor/site-editor/patterns/api-client.ts
+++ b/resources/js/visual-editor/site-editor/patterns/api-client.ts
@@ -44,6 +44,14 @@ export interface PatternRecord {
     categories: readonly string[];
     status: PatternStatus;
     type: 'wp_block';
+    /**
+     * Optional post-type scope (Gutenberg convention — #639). `null` means
+     * the pattern is available in every post-type context. An array means
+     * the pattern is scoped to exactly those post types. The field is
+     * optional on the client type so responses from an older backend
+     * (which never emits the key) still parse.
+     */
+    post_types?: readonly string[] | null;
 }
 
 export interface PatternListParams {
@@ -55,6 +63,21 @@ export interface PatternListParams {
     categories?: readonly string[];
     slug?: string;
     status?: PatternStatus;
+    /**
+     * Restrict to patterns applicable to the given post type (#639).
+     * Patterns registered without a `post_types` scope match every
+     * request; patterns with a scope match only when this slug appears
+     * in that scope. Omit to skip filtering.
+     */
+    postType?: string;
+    /**
+     * Restrict to a specific source. `'theme'` returns developer- /
+     * theme-shipped patterns (the page-pattern-inserter modal uses
+     * this to hide user-created snippet patterns); `'user'` returns
+     * user-authored ones (via `Convert to pattern` in the sidebar).
+     * Omit to return both.
+     */
+    source?: 'theme' | 'user';
 }
 
 export interface PatternCreatePayload {
@@ -211,6 +234,8 @@ export async function listPatterns(
                   : '0',
         slug: params.slug,
         status: params.status,
+        post_type: params.postType,
+        source: params.source,
     });
 
     let withCategories = url;

--- a/resources/views/components/editor.blade.php
+++ b/resources/views/components/editor.blade.php
@@ -14,6 +14,13 @@
 	@isset($authorOptions) data-author-options="{{ json_encode( $authorOptions ) }}" @endisset
 	@isset($supports) data-supports="{{ json_encode( $supports ) }}" @endisset
 	@isset($previewUrl) data-preview-url="{{ $previewUrl }}" @endisset
+	{{-- #639 — created_at/updated_at drive the "never saved" heuristic
+	     that gates the page-pattern-inserter modal from auto-opening on
+	     saved-but-empty pages. Both are optional; when either is missing,
+	     the detection hook falls back to "not fresh" and the modal never
+	     auto-opens. --}}
+	@isset($initialCreatedAt) data-created-at="{{ $initialCreatedAt }}" @endisset
+	@isset($initialUpdatedAt) data-updated-at="{{ $initialUpdatedAt }}" @endisset
 	data-content-types="{{ json_encode( $contentTypes, JSON_HEX_QUOT | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS ) }}"
 	{{-- #617 — merged breakpoint registry (config + theme.json +
 	     defaults) so the viewport switcher's registry hydrates with

--- a/src/Http/Controllers/SiteEditor/PatternController.php
+++ b/src/Http/Controllers/SiteEditor/PatternController.php
@@ -63,6 +63,10 @@ class PatternController extends Controller
 	 * Optional filters:
 	 * - `?source=user|theme`
 	 * - `?synced=1|0`
+	 * - `?post_type={slug}` — restrict to patterns registered for the
+	 *   given post type. Patterns registered without a `post_types`
+	 *   scope match every request (Gutenberg convention); patterns with
+	 *   a scope match only when the requested slug is present.
 	 *
 	 * @since 1.0.0
 	 */
@@ -78,6 +82,14 @@ class PatternController extends Controller
 		if ( $request->has( 'synced' ) ) {
 			$wantSynced = $request->boolean( 'synced' );
 			$patterns   = array_filter( $patterns, static fn ( ResolvedPattern $p ) => $p->synced === $wantSynced );
+		}
+
+		$postType = strtolower( trim( (string) $request->query( 'post_type', '' ) ) );
+		if ( '' !== $postType ) {
+			$patterns = array_filter(
+				$patterns,
+				static fn ( ResolvedPattern $p ) => $p->matchesPostType( $postType ),
+			);
 		}
 
 		return response()->json( ( new PatternAdapter() )->collection( $patterns ) );

--- a/src/Http/Resources/Adapters/CmsFramework/SiteEditor/PatternAdapter.php
+++ b/src/Http/Resources/Adapters/CmsFramework/SiteEditor/PatternAdapter.php
@@ -43,7 +43,8 @@ class PatternAdapter
 	 *     source: string,
 	 *     synced: bool,
 	 *     categories: array<int, string>,
-	 *     block_types: array<int, string>
+	 *     block_types: array<int, string>,
+	 *     post_types: array<int, string>|null
 	 * }
 	 */
 	public function toArray( ResolvedPattern $pattern ): array
@@ -65,6 +66,11 @@ class PatternAdapter
 			'synced'      => $pattern->synced,
 			'categories'  => $pattern->categories,
 			'block_types' => $pattern->blockTypes,
+			// `null` means "available everywhere" (Gutenberg convention);
+			// preserve it verbatim so the editor can distinguish an
+			// unscoped pattern from a pattern that explicitly scoped
+			// itself to zero post types.
+			'post_types'  => $pattern->postTypes,
 		];
 	}
 

--- a/src/SiteEditor/Resolution/ResolvedPattern.php
+++ b/src/SiteEditor/Resolution/ResolvedPattern.php
@@ -42,6 +42,14 @@ class ResolvedPattern
 	 * @param  array<int, string>  $categories  Pattern category slugs.
 	 * @param  array<int, string>  $blockTypes  WP `blockTypes` hint for the inserter.
 	 * @param  int|null  $wpId        DB row id for user-source patterns; null otherwise.
+	 * @param  array<int, string>|null  $postTypes  Post-type slug whitelist (Gutenberg
+	 *                                convention). `null` means the pattern is available
+	 *                                to every post-type context. An empty array means
+	 *                                the pattern was explicitly registered with a scope
+	 *                                that matches nothing — treated the same as an
+	 *                                unmatchable filter, not as "available everywhere",
+	 *                                so a misregistered scope surfaces as "no matches"
+	 *                                instead of leaking into every context.
 	 */
 	public function __construct(
 		public readonly string $slug,
@@ -53,7 +61,33 @@ class ResolvedPattern
 		public readonly array $categories,
 		public readonly array $blockTypes,
 		public readonly ?int $wpId,
+		public readonly ?array $postTypes = null,
 	) {
+	}
+
+	/**
+	 * True when this pattern is available in the given post-type context.
+	 *
+	 * A pattern with a null `postTypes` matches every context (unscoped —
+	 * the default). A pattern with an array `postTypes` matches only when
+	 * the requested slug is present.
+	 *
+	 * Normalizes the input the same way {@see normalizePostTypes()}
+	 * normalizes stored slugs (lower-case, trimmed) so callers that
+	 * pass a mixed-case or padded slug — e.g. `matchesPostType('Page')`
+	 * — don't silently miss a match. The `PatternController` already
+	 * lower-cases the query param, but this keeps the method safe for
+	 * any other consumer that reaches for it directly.
+	 *
+	 * @since 1.4.0
+	 */
+	public function matchesPostType( string $postType ): bool
+	{
+		if ( null === $this->postTypes ) {
+			return true;
+		}
+
+		return in_array( strtolower( trim( $postType ) ), $this->postTypes, true );
 	}
 
 	/**
@@ -124,7 +158,47 @@ class ResolvedPattern
 				'is_string',
 			) ),
 			wpId       : isset( $data['wp_id'] ) ? (int) $data['wp_id'] : null,
+			postTypes  : self::normalizePostTypes( $data['post_types'] ?? null ),
 		);
+	}
+
+	/**
+	 * Normalize the raw `post_types` field into either `null` (omitted /
+	 * unrecognized) or a de-duplicated list of non-empty string slugs.
+	 *
+	 * Any non-array value collapses to `null` so a malformed contributor
+	 * entry defaults to "available everywhere" rather than crashing the
+	 * resolver. Non-string members are filtered out; the remaining slugs
+	 * are lower-cased for stable comparison against the requested
+	 * post-type in {@see matchesPostType()}.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @return array<int, string>|null
+	 */
+	protected static function normalizePostTypes( mixed $raw ): ?array
+	{
+		if ( ! is_array( $raw ) ) {
+			return null;
+		}
+
+		$slugs = [];
+
+		foreach ( $raw as $candidate ) {
+			if ( ! is_string( $candidate ) ) {
+				continue;
+			}
+
+			$slug = strtolower( trim( $candidate ) );
+
+			if ( '' === $slug || in_array( $slug, $slugs, true ) ) {
+				continue;
+			}
+
+			$slugs[] = $slug;
+		}
+
+		return $slugs;
 	}
 
 	/**

--- a/src/View/Components/VisualEditorComponent.php
+++ b/src/View/Components/VisualEditorComponent.php
@@ -65,6 +65,28 @@ class VisualEditorComponent extends Component
 	public ?string $previewUrl;
 
 	/**
+	 * ISO-8601 timestamp when the underlying model was created. Optional.
+	 *
+	 * Together with {@see $initialUpdatedAt}, the React editor uses these
+	 * to derive the "never saved" signal that gates the #639 page-pattern
+	 * inserter modal from auto-opening on already-saved-but-empty pages.
+	 * Hosts that don't pass either can safely omit both — the detection
+	 * hook falls back to "not fresh" and the modal never auto-opens
+	 * (safe default; the toolbar button still works).
+	 *
+	 * @since 1.4.0
+	 */
+	public ?string $initialCreatedAt;
+
+	/**
+	 * ISO-8601 timestamp when the underlying model was last updated. See
+	 * {@see $initialCreatedAt}.
+	 *
+	 * @since 1.4.0
+	 */
+	public ?string $initialUpdatedAt;
+
+	/**
 	 * @var array<int, array{slug: string, label: string}>
 	 */
 	public array $contentTypes;
@@ -115,8 +137,45 @@ class VisualEditorComponent extends Component
 		$this->authorOptions        = $authorOptions;
 		$this->supports             = $supports;
 		$this->previewUrl           = $previewUrl;
+		$this->initialCreatedAt     = $this->resolveTimestamp( $model, 'created_at' );
+		$this->initialUpdatedAt     = $this->resolveTimestamp( $model, 'updated_at' );
 		$this->contentTypes         = $this->resolveContentTypes();
 		$this->breakpoints          = app( BreakpointRegistry::class )->toArray();
+	}
+
+	/**
+	 * Read a timestamp column off the model and normalize to an ISO-8601
+	 * string with microsecond precision, or `null` when the column is
+	 * absent / unparseable.
+	 *
+	 * `created_at` and `updated_at` are the conventional Eloquent
+	 * timestamp columns; hosts with disabled timestamps or custom column
+	 * names simply return `null` and the modal auto-open falls back to
+	 * "not fresh" (safe default).
+	 *
+	 * Microsecond precision is intentional (#639): Carbon's default
+	 * `toIso8601String()` collapses to whole-second `Y-m-d\TH:i:sP` — any
+	 * save that lands in the same integer second as row creation then
+	 * leaves `created_at === updated_at` byte-for-byte identical, and
+	 * the JS-side "never saved" heuristic misfires as a permanent
+	 * auto-open loop. Emitting sub-second precision keeps the first-save
+	 * suppression tight without needing a separate boolean flag.
+	 *
+	 * @since 1.4.0
+	 */
+	protected function resolveTimestamp( Model $model, string $column ): ?string
+	{
+		$value = $model->getAttribute( $column );
+
+		if ( null === $value ) {
+			return null;
+		}
+
+		if ( is_object( $value ) && method_exists( $value, 'format' ) ) {
+			return (string) $value->format( 'Y-m-d\TH:i:s.uP' );
+		}
+
+		return is_string( $value ) ? $value : null;
 	}
 
 	/**

--- a/src/VisualEditorServiceProvider.php
+++ b/src/VisualEditorServiceProvider.php
@@ -535,6 +535,14 @@ class VisualEditorServiceProvider extends ServiceProvider
 		//      sync hasn't run yet, so app boot stays robust.
 		$this->registerFontAwesomeFreeIconSets();
 
+		// 4.1a. #639 — seed the built-in `page` pattern category with a
+		//       single `Blank` starter so the page-pattern-inserter modal
+		//       has at least one entry to render before host apps register
+		//       their own patterns. Registered against the pre-booted
+		//       filter so the boot()-late resolver refresh above picks it
+		//       up alongside third-party contributions.
+		$this->registerBuiltInPatterns();
+
 		// 4.2. Icon Block Phase 6 (#557) — re-register host-uploaded
 		//      icon sets on every boot. Reads the persisted registry
 		//      and hooks the same `ap.icons.register-icon-sets` filter
@@ -722,6 +730,57 @@ class VisualEditorServiceProvider extends ServiceProvider
 			static function ( IconSetRegistration $registry ) use ( $baseDir ): IconSetRegistration {
 				return FontAwesomeFreeIconSets::register( $registry, $baseDir );
 			}
+		);
+	}
+
+	/**
+	 * Seed the built-in `page` pattern category with a `Blank` starter.
+	 *
+	 * The page-pattern-inserter modal (#639) needs at least one entry to
+	 * render even before third-party packages register their own patterns.
+	 * Shipping a `Blank` seed with no blocks gives users the "start from
+	 * scratch" affordance and keeps the modal from rendering an empty
+	 * grid on a fresh install.
+	 *
+	 * Left unscoped (`post_types => null`) so the seed appears in every
+	 * post-type context — the goal is a universally-available empty-canvas
+	 * shortcut, not a page-only entry.
+	 *
+	 * Gated on `addFilter` to keep visual-editor bootable when hooks isn't
+	 * on the classpath.
+	 *
+	 * @since 1.4.0
+	 */
+	protected function registerBuiltInPatterns(): void
+	{
+		if ( ! function_exists( 'addFilter' ) ) {
+			return;
+		}
+
+		addFilter(
+			'ap.visual-editor.patterns',
+			static function ( mixed $patterns ): array {
+				$patterns = is_array( $patterns ) ? $patterns : [];
+
+				// Contributor entries always win — a host that registers
+				// its own `page/blank` (e.g. to swap in a themed skeleton)
+				// takes precedence over the seed. Merge the seed only when
+				// no entry exists for the slug.
+				if ( ! array_key_exists( 'page/blank', $patterns ) ) {
+					$patterns['page/blank'] = [
+						'slug'       => 'page/blank',
+						'title'      => __( 'Blank' ),
+						'source'     => 'theme',
+						'synced'     => false,
+						'categories' => [ 'page' ],
+						'blocks'     => [],
+						'raw_content' => '',
+						'post_types' => null,
+					];
+				}
+
+				return $patterns;
+			},
 		);
 	}
 

--- a/tests/Feature/SiteEditor/PatternControllerStandaloneTest.php
+++ b/tests/Feature/SiteEditor/PatternControllerStandaloneTest.php
@@ -27,12 +27,17 @@ beforeEach( function (): void {
 	$this->actingAs( $user );
 } );
 
-it( 'lists an empty array for patterns when no contributors are registered', function (): void {
+it( 'returns only the built-in `page/blank` seed pattern when no contributors are registered', function (): void {
 	( new VisualEditorServiceProvider( app() ) )->registerSiteEditorResolvers();
 
+	// #639 — the visual-editor ships a `page/blank` starter regardless
+	// of whether cms-framework is integrated, so the modal has an entry
+	// to render even on standalone installs.
 	$this->getJson( '/visual-editor/api/patterns' )
 		->assertOk()
-		->assertExactJson( [] );
+		->assertJsonCount( 1 )
+		->assertJsonPath( '0.slug', 'page/blank' )
+		->assertJsonPath( '0.categories.0', 'page' );
 } );
 
 it( 'returns 404 on POST patterns when cms-framework is not integrated', function (): void {

--- a/tests/Feature/SiteEditor/PatternControllerTest.php
+++ b/tests/Feature/SiteEditor/PatternControllerTest.php
@@ -42,15 +42,23 @@ function rebuildSiteEditorResolversForPatternTest(): void
 }
 
 describe( 'GET /visual-editor/api/patterns', function (): void {
-	it( 'returns an empty list when no patterns exist', function (): void {
+	it( 'returns only the built-in `page/blank` seed pattern when no cms-framework patterns exist', function (): void {
 		rebuildSiteEditorResolversForPatternTest();
 
+		// #639 — visual-editor ships a `page/blank` starter so the
+		// page-pattern-inserter modal has an entry to render out of the
+		// box. Without cms-framework patterns, the index is exactly
+		// that seed.
 		$this->getJson( '/visual-editor/api/patterns' )
 			->assertOk()
-			->assertExactJson( [] );
+			->assertJsonCount( 1 )
+			->assertJsonPath( '0.slug', 'page/blank' )
+			->assertJsonPath( '0.source', 'theme' )
+			->assertJsonPath( '0.categories.0', 'page' )
+			->assertJsonPath( '0.post_types', null );
 	} );
 
-	it( 'lists user-source patterns merged from cms-framework', function (): void {
+	it( 'lists user-source patterns merged from cms-framework alongside the seed', function (): void {
 		BlockPattern::create( [
 			'slug'          => 'cta',
 			'title'         => 'CTA',
@@ -64,13 +72,14 @@ describe( 'GET /visual-editor/api/patterns', function (): void {
 
 		rebuildSiteEditorResolversForPatternTest();
 
-		$this->getJson( '/visual-editor/api/patterns' )
+		$response = $this->getJson( '/visual-editor/api/patterns' )
 			->assertOk()
-			->assertJsonCount( 1 )
-			->assertJsonPath( '0.slug', 'user/cta' )
-			->assertJsonPath( '0.type', 'wp_block' )
-			->assertJsonPath( '0.source', 'user' )
-			->assertJsonPath( '0.synced', true );
+			->assertJsonCount( 2 );
+
+		$slugs = array_column( $response->json(), 'slug' );
+
+		expect( $slugs )->toContain( 'user/cta' )
+			->and( $slugs )->toContain( 'page/blank' );
 	} );
 
 	it( 'filters by source via ?source query parameter', function (): void {
@@ -89,11 +98,78 @@ describe( 'GET /visual-editor/api/patterns', function (): void {
 
 		$this->getJson( '/visual-editor/api/patterns?source=user' )
 			->assertOk()
-			->assertJsonCount( 1 );
+			->assertJsonCount( 1 )
+			->assertJsonPath( '0.slug', 'user/cta' );
 
+		// Only the built-in `page/blank` seed lives under `theme`.
 		$this->getJson( '/visual-editor/api/patterns?source=theme' )
 			->assertOk()
-			->assertJsonCount( 0 );
+			->assertJsonCount( 1 )
+			->assertJsonPath( '0.slug', 'page/blank' );
+	} );
+
+	// #639 — the modal fetches patterns scoped to the current post
+	// type via `?post_type=`. Contributor patterns registered with a
+	// `post_types` whitelist match only when the requested slug is
+	// present; unscoped patterns (post_types null) match everywhere.
+	it( 'filters by ?post_type using each pattern\'s post_types scope (#639)', function (): void {
+		addFilter( 'ap.visual-editor.patterns', function ( mixed $patterns ): array {
+			$patterns = is_array( $patterns ) ? $patterns : [];
+
+			$patterns['landing-hero'] = [
+				'slug'       => 'landing-hero',
+				'title'      => 'Landing hero',
+				'source'     => 'theme',
+				'synced'     => false,
+				'categories' => [ 'page' ],
+				'post_types' => [ 'page' ],
+				'blocks'     => [],
+				'raw_content' => '',
+			];
+
+			$patterns['recipe-intro'] = [
+				'slug'       => 'recipe-intro',
+				'title'      => 'Recipe intro',
+				'source'     => 'theme',
+				'synced'     => false,
+				'categories' => [ 'post' ],
+				'post_types' => [ 'post' ],
+				'blocks'     => [],
+				'raw_content' => '',
+			];
+
+			return $patterns;
+		} );
+
+		rebuildSiteEditorResolversForPatternTest();
+
+		// `page` context: seed (unscoped) + landing-hero, but not recipe-intro.
+		$page = $this->getJson( '/visual-editor/api/patterns?post_type=page' )
+			->assertOk()
+			->assertJsonCount( 2 );
+
+		$pageSlugs = array_column( $page->json(), 'slug' );
+
+		expect( $pageSlugs )->toContain( 'landing-hero' )
+			->and( $pageSlugs )->toContain( 'page/blank' )
+			->and( $pageSlugs )->not->toContain( 'recipe-intro' );
+
+		// `post` context: seed (unscoped) + recipe-intro, but not landing-hero.
+		$post = $this->getJson( '/visual-editor/api/patterns?post_type=post' )
+			->assertOk()
+			->assertJsonCount( 2 );
+
+		$postSlugs = array_column( $post->json(), 'slug' );
+
+		expect( $postSlugs )->toContain( 'recipe-intro' )
+			->and( $postSlugs )->toContain( 'page/blank' )
+			->and( $postSlugs )->not->toContain( 'landing-hero' );
+
+		// `custom` context with no scoped patterns: seed only.
+		$this->getJson( '/visual-editor/api/patterns?post_type=custom' )
+			->assertOk()
+			->assertJsonCount( 1 )
+			->assertJsonPath( '0.slug', 'page/blank' );
 	} );
 
 	it( 'filters by synced flag via ?synced query parameter', function (): void {
@@ -126,10 +202,16 @@ describe( 'GET /visual-editor/api/patterns', function (): void {
 			->assertJsonCount( 1 )
 			->assertJsonPath( '0.slug', 'user/synced-pattern' );
 
-		$this->getJson( '/visual-editor/api/patterns?synced=0' )
+		// `?synced=0` matches both the DB unsynced pattern and the
+		// unsynced built-in seed.
+		$unsynced = $this->getJson( '/visual-editor/api/patterns?synced=0' )
 			->assertOk()
-			->assertJsonCount( 1 )
-			->assertJsonPath( '0.slug', 'user/unsynced-pattern' );
+			->assertJsonCount( 2 );
+
+		$unsyncedSlugs = array_column( $unsynced->json(), 'slug' );
+
+		expect( $unsyncedSlugs )->toContain( 'user/unsynced-pattern' )
+			->and( $unsyncedSlugs )->toContain( 'page/blank' );
 	} );
 } );
 

--- a/tests/Feature/VisualEditor/SiteEditorFiltersTest.php
+++ b/tests/Feature/VisualEditor/SiteEditorFiltersTest.php
@@ -44,9 +44,16 @@ describe( 'standalone install (no contributors, no static config)', function ():
 	it( 'boots cleanly with empty resolvers for every entity type', function (): void {
 		rebuildSiteEditorResolvers();
 
+		// #639 — visual-editor now ships a built-in `page/blank` seed
+		// pattern registered via `ap.visual-editor.patterns` on boot,
+		// so the pattern resolver is no longer strictly empty on a
+		// standalone install. Assert on the shape and the seed's slug
+		// rather than `[]`.
+		$patterns = app( PatternResolver::class )->all();
+
 		expect( app( TemplateResolver::class )->all() )->toBe( [] )
 			->and( app( TemplatePartResolver::class )->all() )->toBe( [] )
-			->and( app( PatternResolver::class )->all() )->toBe( [] )
+			->and( array_keys( $patterns ) )->toBe( [ 'page/blank' ] )
 			->and( app( GlobalStylesResolver::class )->get() )->toBeNull()
 			->and( app( MenuResolver::class )->all() )->toBe( [] );
 	} );

--- a/tests/Unit/VisualEditor/SiteEditor/Adapters/PatternAdapterTest.php
+++ b/tests/Unit/VisualEditor/SiteEditor/Adapters/PatternAdapterTest.php
@@ -17,6 +17,7 @@ function makeResolvedPattern( array $overrides = [] ): ResolvedPattern
 		'categories' => [ 'hero' ],
 		'blockTypes' => [ 'core/cover' ],
 		'wpId'       => null,
+		'postTypes'  => null,
 	];
 
 	$args = array_merge( $defaults, $overrides );
@@ -31,6 +32,7 @@ function makeResolvedPattern( array $overrides = [] ): ResolvedPattern
 		categories : $args['categories'],
 		blockTypes : $args['blockTypes'],
 		wpId       : $args['wpId'],
+		postTypes  : $args['postTypes'],
 	);
 }
 
@@ -86,6 +88,24 @@ describe( 'single-record envelope', function (): void {
 
 		expect( $out['categories'] )->toBe( [] )
 			->and( $out['block_types'] )->toBe( [] );
+	} );
+
+	// #639 — the `post_types` field on the adapter output lets the editor
+	// filter the pattern grid to entries applicable to the current post
+	// type. `null` means "available everywhere" (Gutenberg convention).
+	it( 'emits post_types as null for an unscoped pattern (#639)', function (): void {
+		$out = ( new PatternAdapter() )->toArray( makeResolvedPattern() );
+
+		expect( $out )->toHaveKey( 'post_types' )
+			->and( $out['post_types'] )->toBeNull();
+	} );
+
+	it( 'passes through the post_types whitelist verbatim (#639)', function (): void {
+		$pattern = makeResolvedPattern( [ 'postTypes' => [ 'page', 'landing' ] ] );
+
+		$out = ( new PatternAdapter() )->toArray( $pattern );
+
+		expect( $out['post_types'] )->toBe( [ 'page', 'landing' ] );
 	} );
 } );
 

--- a/tests/Unit/VisualEditor/SiteEditor/Resolution/ResolvedPatternTest.php
+++ b/tests/Unit/VisualEditor/SiteEditor/Resolution/ResolvedPatternTest.php
@@ -1,0 +1,103 @@
+<?php
+
+/**
+ * Tests for {@see \ArtisanPackUI\VisualEditor\SiteEditor\Resolution\ResolvedPattern}.
+ *
+ * Focus is on the `post_types` scoping surface introduced by #639.
+ * General resolution / coercion of the other fields is exercised by
+ * the higher-level adapter and feature tests; these unit cases stay
+ * narrow.
+ *
+ * @since 1.4.0
+ */
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\SiteEditor\Resolution\ResolvedPattern;
+
+it( 'defaults post_types to null when the field is omitted', function (): void {
+	$pattern = ResolvedPattern::fromArray( [
+		'slug'  => 'hero',
+		'title' => 'Hero',
+	] );
+
+	expect( $pattern->postTypes )->toBeNull();
+} );
+
+it( 'normalizes the post_types array to lowercase de-duplicated slugs', function (): void {
+	$pattern = ResolvedPattern::fromArray( [
+		'slug'       => 'landing-hero',
+		'title'      => 'Landing Hero',
+		'post_types' => [ 'Page', 'page', ' LANDING ', 42, null, 'landing' ],
+	] );
+
+	// Duplicates are removed and non-string entries are filtered out.
+	expect( $pattern->postTypes )->toBe( [ 'page', 'landing' ] );
+} );
+
+it( 'collapses a non-array post_types field back to null', function (): void {
+	$pattern = ResolvedPattern::fromArray( [
+		'slug'       => 'hero',
+		'title'      => 'Hero',
+		'post_types' => 'page',
+	] );
+
+	// A misconfigured contributor shouldn't crash; treat malformed
+	// scope as "unscoped" so the pattern remains available.
+	expect( $pattern->postTypes )->toBeNull();
+} );
+
+it( 'matches every post type when postTypes is null (Gutenberg convention)', function (): void {
+	$pattern = ResolvedPattern::fromArray( [
+		'slug'  => 'hero',
+		'title' => 'Hero',
+	] );
+
+	expect( $pattern->matchesPostType( 'page' ) )->toBeTrue()
+		->and( $pattern->matchesPostType( 'post' ) )->toBeTrue()
+		->and( $pattern->matchesPostType( 'anything-goes' ) )->toBeTrue();
+} );
+
+it( 'matches only the whitelisted post types when postTypes is set', function (): void {
+	$pattern = ResolvedPattern::fromArray( [
+		'slug'       => 'landing-hero',
+		'title'      => 'Landing Hero',
+		'post_types' => [ 'page', 'landing' ],
+	] );
+
+	expect( $pattern->matchesPostType( 'page' ) )->toBeTrue()
+		->and( $pattern->matchesPostType( 'landing' ) )->toBeTrue()
+		->and( $pattern->matchesPostType( 'post' ) )->toBeFalse();
+} );
+
+it( 'lowercases and trims the input slug before matching (defensive normalization)', function (): void {
+	$pattern = ResolvedPattern::fromArray( [
+		'slug'       => 'landing-hero',
+		'title'      => 'Landing Hero',
+		'post_types' => [ 'page' ],
+	] );
+
+	// The controller already lower-cases the query param, but the
+	// method has to survive being called directly with a padded /
+	// mixed-case slug — otherwise a future consumer silently misses
+	// a match on `'Page'` or `' page '`.
+	expect( $pattern->matchesPostType( 'Page' ) )->toBeTrue()
+		->and( $pattern->matchesPostType( ' page ' ) )->toBeTrue()
+		->and( $pattern->matchesPostType( 'PAGE' ) )->toBeTrue();
+} );
+
+it( 'matches nothing when postTypes is explicitly the empty list', function (): void {
+	// A contributor that hands us `post_types: []` scoped the pattern
+	// to zero contexts. Treating this as "match everywhere" would
+	// let a misregistered scope leak everywhere — instead, respect
+	// the empty scope and match nothing.
+	$pattern = ResolvedPattern::fromArray( [
+		'slug'       => 'nowhere',
+		'title'      => 'Nowhere',
+		'post_types' => [],
+	] );
+
+	expect( $pattern->postTypes )->toBe( [] )
+		->and( $pattern->matchesPostType( 'page' ) )->toBeFalse()
+		->and( $pattern->matchesPostType( 'post' ) )->toBeFalse();
+} );


### PR DESCRIPTION
## Description

Adds a WordPress-style "Choose a pattern" modal to the visual editor that
auto-opens when the user loads a never-saved record with no persisted
content, and can be re-opened at any time from a new top-bar button next
to the `+` inserter.

**Closes:** #639

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #639

## Motivation and Context

Users creating a new CMS page (or any post-type content) landed on an
empty canvas with no starting point. This PR ships the modal + the
`post_types` pattern-scope contract so developers can register per-post-
type starters and hosts can wire a first-run affordance without editor-
specific coordination.

## Changes Made

- Extends pattern registration with an optional `post_types` scope
  (Gutenberg convention). Patterns without a scope match every context;
  patterns with a scope match only when the requested post-type slug is
  present. Surfaced via new `post_types` field on `PatternAdapter` and a
  new `?post_type=` query param on `PatternController::index`.
- Registers a built-in `page/blank` seed pattern via the
  `ap.visual-editor.patterns` filter so the modal always has an entry
  to render on a fresh install.
- New React module under `resources/js/visual-editor/editor/page-pattern-modal/`:
  - `use-fresh-content-detection` — the "never saved" heuristic (empty
    content + `created_at === updated_at`).
  - `filter-modal-patterns` — client-side tightening on top of the
    permissive server filter, with a seed carve-out so the modal is
    never empty on a fresh install.
  - `page-pattern-modal` — grid grouped by primary category, optional
    template selector, dismiss on X / Escape / backdrop.
- `<x-visual-editor>` now stamps microsecond-precision `data-created-at`
  and `data-updated-at` so the first-save suppression heuristic survives
  records saved within the same integer second as creation.
- Toolbar button + auto-open are both suppressed when zero patterns
  apply or the initial content load hasn't settled — no silent no-op
  modal.
- CHANGELOG entry under `Unreleased`.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS 15.5
- Browser: Chrome
- PHP Version: 8.4.3
- Project Version: 1.4-dev (release/1.4)

**Tests Performed:**
1. Full PHP suite (excluding pre-existing AI test failures unrelated to this PR): 1412 tests passing.
2. Full JS suite: 2415 tests passing.
3. Manual test against a freshly-reseeded Post in the dev-app standalone workbench — modal auto-opens with the expected filtered pattern set.
4. Manual test against a saved Post (#13) — modal does NOT auto-open; toolbar button re-opens on click.

## Accessibility Tests Run

- [x] Keyboard navigation tested (Tab across pattern grid, Enter/Space activates, Escape dismisses)
- [ ] Screen reader tested
- [x] Color contrast verified (dialog uses default theme tokens)
- [x] ARIA labels checked (`role="dialog"`, `aria-modal="true"`, `aria-labelledby`, live-region `role="status"` / `role="alert"` on status messages)

**Details:** The modal traps escape via a global keydown listener, focuses the dialog on open, and exposes descriptive `aria-label` on the close button. Buttons for each pattern have accessible names via their visible titles.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:**

- Pest: new `ResolvedPatternTest` covering `post_types` normalization + `matchesPostType` (including defensive input lowercasing), new `PatternAdapter` cases for the `post_types` field, new integration case in `PatternControllerTest` for the `?post_type=` filter, plus updates to existing standalone / filters tests that assumed an empty pattern index.
- Vitest: `use-fresh-content-detection.test.ts` (7 cases), `filter-modal-patterns.test.ts` (7 cases), `page-pattern-modal.test.tsx` (15 cases including the multi-category dedupe check), and 2 new cases in `top-bar.test.tsx` for the pattern-modal toolbar button.

## Documentation

- [x] Inline code documentation added
- [x] Wiki updated (CHANGELOG entry under `Unreleased`)

**Documentation details:** Every new module carries a file-level docblock explaining the "why" for its shape and the interaction points with the rest of the editor. Both the fresh-content heuristic and the filter carve-out ship with explicit rationale.

## Pre-Submission Checklist

- [x] Code passes all tests
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a page-pattern inserter for new, empty pages, with automatic opening and a top-bar button for reopening.
  * Added support for selecting page templates and inserting patterns directly into the editor.
  * Added post-type scoping for patterns, so only applicable patterns appear in each editing context.
  * Added a built-in Blank page starter pattern.

* **Bug Fixes**
  * Improved pattern filtering and handling of unavailable, empty, or failed pattern results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->