### PR TITLE
fix(site-editor): viewport-anchored shell + theme pattern thumbnails

### DIFF
--- a/resources/js/visual-editor/site-editor/__tests__/site-editor-app-css.test.ts
+++ b/resources/js/visual-editor/site-editor/__tests__/site-editor-app-css.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Regression check for the site-editor shell CSS layout (#666).
+ *
+ * The three-pane shell depends on an unbroken flex chain from `<html>`
+ * through the shell down to each panel's scroll container. When any
+ * link in that chain drops its `flex` / `min-height: 0` / `overflow`
+ * declarations, the sidebar / canvas / inspector collapse to their
+ * intrinsic content size and the whole page starts scrolling instead.
+ * This test asserts the presence of the layout-critical rules so a
+ * regression that removes them fails loudly rather than silently
+ * degrading the editor UX.
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+// `package.json` declares `"type": "module"`, so `__dirname` isn't
+// defined under raw Node ESM. Vitest happens to shim it, but building
+// the path from `import.meta.url` keeps the test portable to other
+// runners and to `node --test`.
+const HERE = dirname(fileURLToPath(import.meta.url));
+const CSS_PATH = resolve(HERE, '..', 'site-editor-app.css');
+
+function readCss(): string {
+    return readFileSync(CSS_PATH, 'utf8');
+}
+
+describe('site-editor-app.css layout chain (#666)', () => {
+    it('anchors html and the SPA body to the viewport', () => {
+        const css = readCss();
+
+        expect(css).toMatch(
+            /html,\s*\n?\s*\.ap-visual-editor-site-editor-body\s*\{[^}]*height:\s*100%/
+        );
+        expect(css).toMatch(
+            /html,\s*\n?\s*\.ap-visual-editor-site-editor-body\s*\{[^}]*overflow:\s*hidden/
+        );
+    });
+
+    it('promotes the mount div into a bounded flex column', () => {
+        const css = readCss();
+        const rule = css.match(
+            /\.ap-visual-editor-site-editor-body\s*>\s*#ap-visual-editor-site-editor\s*\{[^}]*\}/
+        );
+
+        expect(rule).not.toBeNull();
+        expect(rule?.[0]).toContain('height: 100%');
+        expect(rule?.[0]).toContain('display: flex');
+        expect(rule?.[0]).toContain('flex-direction: column');
+        expect(rule?.[0]).toContain('min-height: 0');
+        expect(rule?.[0]).toContain('overflow: hidden');
+    });
+
+    it('makes <main> a flex passthrough so the body flex chain reaches the panels', () => {
+        const css = readCss();
+        const rule = css.match(
+            /\.ap-site-editor__shell\s*>\s*main\s*\{[^}]*\}/
+        );
+
+        expect(rule).not.toBeNull();
+        expect(rule?.[0]).toContain('flex: 1 1 auto');
+        expect(rule?.[0]).toContain('display: flex');
+        expect(rule?.[0]).toContain('flex-direction: column');
+        expect(rule?.[0]).toContain('min-height: 0');
+        expect(rule?.[0]).toContain('overflow: hidden');
+    });
+
+    it('gives the canvas and inspector slots bounded flex heights so their children can scroll', () => {
+        const css = readCss();
+        const rule = css.match(
+            /\.ap-site-editor__canvas-slot,\s*\n?\s*\.ap-site-editor__inspector-slot\s*\{[^}]*\}/
+        );
+
+        expect(rule).not.toBeNull();
+        expect(rule?.[0]).toContain('flex: 1 1 auto');
+        expect(rule?.[0]).toContain('display: flex');
+        expect(rule?.[0]).toContain('flex-direction: column');
+        expect(rule?.[0]).toContain('min-height: 0');
+        expect(rule?.[0]).toContain('overflow: hidden');
+    });
+
+    it('makes the navigator slot a flex column for its own children (parent outlet is block, so fill props are omitted)', () => {
+        const css = readCss();
+        const rule = css.match(
+            /\.ap-site-editor__navigator-slot\s*\{[^}]*\}/
+        );
+
+        expect(rule).not.toBeNull();
+        expect(rule?.[0]).toContain('display: flex');
+        expect(rule?.[0]).toContain('flex-direction: column');
+    });
+});

--- a/resources/js/visual-editor/site-editor/patterns/__tests__/pattern-grid.test.tsx
+++ b/resources/js/visual-editor/site-editor/patterns/__tests__/pattern-grid.test.tsx
@@ -2,6 +2,20 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+// #667 — `PatternThumbnail` imports `parse` from `@wordpress/blocks`
+// so the pattern-grid module graph now transitively loads the real
+// package. Under jsdom it trips on a `type: json` import at the top of
+// the build. Stub `parse` so the module chain resolves; the theme-only
+// path we care about in this suite passes it a real Gutenberg comment
+// block and the stub echoes back a single block instance so the
+// thumbnail renders the non-empty summary.
+vi.mock('@wordpress/blocks', () => ({
+    parse: (source: string) =>
+        typeof source === 'string' && source.trim() !== ''
+            ? [{ name: 'core/heading', innerBlocks: [] }]
+            : [],
+}));
+
 import { PatternGrid } from '../pattern-grid';
 import type { PatternRecord } from '../api-client';
 
@@ -158,5 +172,56 @@ describe('<PatternGrid />', () => {
         const empty = await screen.findByTestId('ap-pattern-grid-empty');
 
         expect(empty).toHaveTextContent('No unsynced patterns yet');
+    });
+
+    it('shows the block tree for theme patterns that only ship rawContent (#667)', async () => {
+        // Theme-shipped patterns arrive with `blocks: []` because
+        // cms-framework's `PatternResolver::buildThemePattern()` only
+        // serializes `raw`. `PatternThumbnail` must parse the raw
+        // string client-side rather than falling through to the empty
+        // placeholder — otherwise every theme pattern renders as an
+        // "Empty pattern" card.
+        LIST_MOCK.mockResolvedValue([
+            makePattern({
+                id: 91,
+                slug: 'theme-hero',
+                title: { rendered: 'Theme hero' },
+                synced: false,
+                content: {
+                    raw:
+                        '<!-- wp:heading --><h2>Hi</h2><!-- /wp:heading -->' +
+                        '<!-- wp:paragraph --><p>Body</p><!-- /wp:paragraph -->',
+                    blocks: [],
+                },
+            }),
+        ]);
+
+        render(
+            <PatternGrid
+                apiConfig={API_CONFIG}
+                synced={false}
+                activeEntityId={null}
+                onEdit={() => undefined}
+                onConvertToUnsynced={() => undefined}
+                onDelete={() => undefined}
+                onCreate={() => undefined}
+            />
+        );
+
+        await waitFor(() =>
+            expect(
+                screen.getByTestId('ap-pattern-card-91')
+            ).toBeInTheDocument()
+        );
+
+        expect(screen.queryByTestId('ap-pattern-thumb-empty')).toBeNull();
+        expect(screen.getByTestId('ap-pattern-thumb')).toBeInTheDocument();
+        // The mocked `parse()` at the top of this file returns a
+        // single `core/heading` block for any non-empty source, so a
+        // successful raw-content fallback puts that name into the
+        // thumbnail's block-tree summary. Asserting the text guards
+        // against a regression where the thumbnail renders the
+        // wrapper markup but describeBlocks receives an empty array.
+        expect(screen.getByText('core/heading')).toBeInTheDocument();
     });
 });

--- a/resources/js/visual-editor/site-editor/patterns/__tests__/pattern-thumbnail.test.tsx
+++ b/resources/js/visual-editor/site-editor/patterns/__tests__/pattern-thumbnail.test.tsx
@@ -1,0 +1,142 @@
+/**
+ * Tests for `PatternThumbnail`.
+ *
+ * Covers the block-tree summary happy path and the #667 fix where a
+ * theme-shipped pattern arrives with `blocks: []` but a non-empty
+ * `rawContent`. The component parses the raw string client-side so the
+ * card shows the real tree instead of the "Empty pattern" placeholder.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const parseMock = vi.fn();
+
+vi.mock('@wordpress/blocks', () => ({
+    parse: (source: string) => parseMock(source),
+}));
+
+beforeEach(() => {
+    parseMock.mockReset();
+});
+
+// The i18n vendor module imports `@wordpress/i18n`. Its default export
+// covers `__()` — no mocking needed. Import after the mock is declared
+// so the parse override lands before the component's import graph.
+import { PatternThumbnail } from '../pattern-thumbnail';
+
+describe('<PatternThumbnail />', () => {
+    it('renders a block tree summary when blocks is populated', () => {
+        render(
+            <PatternThumbnail
+                blocks={[
+                    { name: 'core/paragraph', innerBlocks: [] },
+                    {
+                        name: 'core/columns',
+                        innerBlocks: [
+                            { name: 'core/column', innerBlocks: [] },
+                        ],
+                    },
+                ]}
+                title="Hero"
+            />
+        );
+
+        expect(screen.getByTestId('ap-pattern-thumb')).toBeInTheDocument();
+        expect(screen.getByText('core/paragraph')).toBeInTheDocument();
+        expect(screen.getByText('core/columns')).toBeInTheDocument();
+        expect(screen.getByText('core/column')).toBeInTheDocument();
+        expect(parseMock).not.toHaveBeenCalled();
+    });
+
+    it('renders the empty placeholder when blocks is empty and no rawContent is supplied', () => {
+        render(<PatternThumbnail blocks={[]} title="Empty" />);
+
+        expect(
+            screen.getByTestId('ap-pattern-thumb-empty')
+        ).toBeInTheDocument();
+        expect(parseMock).not.toHaveBeenCalled();
+    });
+
+    it('renders the empty placeholder when rawContent is present but only whitespace', () => {
+        render(
+            <PatternThumbnail
+                blocks={[]}
+                rawContent={'   \n   '}
+                title="Empty"
+            />
+        );
+
+        expect(
+            screen.getByTestId('ap-pattern-thumb-empty')
+        ).toBeInTheDocument();
+        expect(parseMock).not.toHaveBeenCalled();
+    });
+
+    it('parses rawContent when blocks is empty and shows the parsed tree (#667)', () => {
+        parseMock.mockReturnValueOnce([
+            { name: 'core/heading', innerBlocks: [] },
+            { name: 'core/paragraph', innerBlocks: [] },
+        ]);
+
+        const raw =
+            '<!-- wp:heading --><h2>Hi</h2><!-- /wp:heading -->' +
+            '<!-- wp:paragraph --><p>Body</p><!-- /wp:paragraph -->';
+
+        render(
+            <PatternThumbnail
+                blocks={[]}
+                rawContent={raw}
+                title="Theme pattern"
+            />
+        );
+
+        expect(parseMock).toHaveBeenCalledWith(raw);
+        expect(screen.getByTestId('ap-pattern-thumb')).toBeInTheDocument();
+        expect(screen.getByText('core/heading')).toBeInTheDocument();
+        expect(screen.getByText('core/paragraph')).toBeInTheDocument();
+        expect(
+            screen.queryByTestId('ap-pattern-thumb-empty')
+        ).not.toBeInTheDocument();
+    });
+
+    it('falls back to the empty placeholder and logs a warning when parsing rawContent throws', () => {
+        parseMock.mockImplementationOnce(() => {
+            throw new Error('boom');
+        });
+        const warnSpy = vi
+            .spyOn(console, 'warn')
+            .mockImplementation(() => undefined);
+
+        render(
+            <PatternThumbnail
+                blocks={[]}
+                rawContent="<!-- wp:broken -->"
+                title="Broken"
+            />
+        );
+
+        expect(
+            screen.getByTestId('ap-pattern-thumb-empty')
+        ).toBeInTheDocument();
+        expect(warnSpy).toHaveBeenCalledWith(
+            expect.stringContaining('Failed to parse pattern rawContent'),
+            expect.any(Error)
+        );
+
+        warnSpy.mockRestore();
+    });
+
+    it('prefers server-parsed blocks over rawContent when both are present', () => {
+        render(
+            <PatternThumbnail
+                blocks={[{ name: 'core/paragraph', innerBlocks: [] }]}
+                rawContent="<!-- wp:paragraph --><p>x</p><!-- /wp:paragraph -->"
+                title="Mixed"
+            />
+        );
+
+        expect(parseMock).not.toHaveBeenCalled();
+        expect(screen.getByText('core/paragraph')).toBeInTheDocument();
+    });
+});

--- a/resources/js/visual-editor/site-editor/patterns/pattern-grid.tsx
+++ b/resources/js/visual-editor/site-editor/patterns/pattern-grid.tsx
@@ -287,6 +287,7 @@ export function PatternGrid(props: PatternGridProps): JSX.Element {
                             >
                                 <PatternThumbnail
                                     blocks={pattern.content.blocks}
+                                    rawContent={pattern.content.raw}
                                     title={patternTitle(pattern)}
                                 />
                                 <header className="ap-pattern-card__header">

--- a/resources/js/visual-editor/site-editor/patterns/pattern-thumbnail.css
+++ b/resources/js/visual-editor/site-editor/patterns/pattern-thumbnail.css
@@ -1,4 +1,13 @@
 .ap-pattern-thumb {
+    /*
+     * `content-box` (the default) adds the 12px padding + 1px border on
+     * top of `width: 100%`, so the thumbnail extends ~26px past the
+     * card's inner width and pokes out of the card's rounded corner.
+     * `border-box` keeps the visible box inside the card, and the
+     * aspect-ratio computes from the same border-box so the card
+     * proportions stay stable.
+     */
+    box-sizing: border-box;
     width: 100%;
     aspect-ratio: 16 / 9;
     background: var(--ap-pattern-thumb-bg, #f9fafb);
@@ -30,12 +39,26 @@
     padding: 0;
     display: flex;
     flex-direction: column;
+    /*
+     * Keep the tree inside the thumb's border-box. Without a min-width,
+     * a long block name ("artisanpack/social-share-content") makes the
+     * flex column widen past `100%` and slips out to the right.
+     */
+    min-width: 0;
+    max-width: 100%;
 }
 
 .ap-pattern-thumb__tree li {
+    /*
+     * `white-space: pre` preserves the leading-space indent
+     * `describeBlocks()` emits for nested blocks; `overflow: hidden` +
+     * `text-overflow: ellipsis` clip the rest of a wide name so a
+     * verbose block slug can't spill past the card edge.
+     */
     white-space: pre;
     text-overflow: ellipsis;
     overflow: hidden;
+    max-width: 100%;
 }
 
 .ap-pattern-thumb__more {

--- a/resources/js/visual-editor/site-editor/patterns/pattern-thumbnail.tsx
+++ b/resources/js/visual-editor/site-editor/patterns/pattern-thumbnail.tsx
@@ -15,6 +15,7 @@
  * pattern-preview endpoint ships.
  */
 
+import { parse } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 import { useMemo } from 'react';
 
@@ -30,6 +31,15 @@ type BlockTreeNode = {
 
 export interface PatternThumbnailProps {
     blocks: readonly unknown[];
+    /**
+     * Serialized Gutenberg HTML for the pattern. When `blocks` is empty
+     * but `rawContent` is present — the case for theme-shipped patterns
+     * where cms-framework's `PatternResolver::buildThemePattern()`
+     * hardcodes `blocks: []` (#667) — parse it here so the thumbnail
+     * shows the real block tree instead of the "Empty pattern"
+     * placeholder.
+     */
+    rawContent?: string;
     title: string;
 }
 
@@ -91,11 +101,47 @@ function describeBlocks(
 }
 
 export function PatternThumbnail(props: PatternThumbnailProps): JSX.Element {
-    const { blocks, title } = props;
+    const { blocks, rawContent, title } = props;
 
-    const summary = useMemo(() => describeBlocks(blocks), [blocks]);
+    // #667 — theme-shipped patterns arrive with `blocks: []` because
+    // cms-framework only serializes `rawContent` for them. Parse the
+    // raw string with the same Gutenberg `parse()` helper `hydrateBlocks`
+    // uses so the summary reflects the real tree instead of falling
+    // through to the empty-state placeholder. Wrapped in try/catch so a
+    // malformed pattern doesn't crash the grid — an unparseable pattern
+    // just renders as empty, matching the existing degraded state.
+    const effectiveBlocks = useMemo<readonly unknown[]>(() => {
+        if (blocks.length > 0) {
+            return blocks;
+        }
 
-    if (blocks.length === 0) {
+        if (typeof rawContent === 'string' && rawContent.trim() !== '') {
+            try {
+                return parse(rawContent);
+            } catch (error) {
+                // Surface the failure so a broken theme pattern is
+                // distinguishable from an actually-empty one in
+                // DevTools — the placeholder fallback below looks
+                // identical in either case (#667).
+                // eslint-disable-next-line no-console
+                console.warn(
+                    '[artisanpack/visual-editor] Failed to parse pattern rawContent for thumbnail; rendering empty placeholder.',
+                    error
+                );
+
+                return [];
+            }
+        }
+
+        return [];
+    }, [blocks, rawContent]);
+
+    const summary = useMemo(
+        () => describeBlocks(effectiveBlocks),
+        [effectiveBlocks]
+    );
+
+    if (effectiveBlocks.length === 0) {
         return (
             <div
                 className="ap-pattern-thumb ap-pattern-thumb--empty"

--- a/resources/js/visual-editor/site-editor/site-editor-app.css
+++ b/resources/js/visual-editor/site-editor/site-editor-app.css
@@ -11,11 +11,34 @@
 
 @import '../editor/top-bar.css';
 
+/*
+ * #666 — anchor the SPA to the viewport so the three-pane shell can
+ * scroll its panels independently. Without `height: 100%` + `overflow:
+ * hidden` on the document ancestors, a tall sidebar / canvas / inspector
+ * pushes the whole page below the viewport and the panels' inner
+ * `overflow-y: auto` never engages (there's no bounded parent for
+ * `height: 100%` to resolve against). This stylesheet only ships with
+ * the site-editor bundle, so styling `html` unconditionally is safe.
+ */
+html,
+.ap-visual-editor-site-editor-body {
+    height: 100%;
+    overflow: hidden;
+}
+
 .ap-visual-editor-site-editor-body {
     margin: 0;
     background: var(--ap-site-editor-shell-background, var(--color-base-200, #f9fafb));
     color: var(--ap-site-editor-shell-foreground, var(--color-base-content, #1f2937));
     font-family: var(--ap-site-editor-font-family, system-ui, -apple-system, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif);
+}
+
+.ap-visual-editor-site-editor-body > #ap-visual-editor-site-editor {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    overflow: hidden;
 }
 
 .ap-site-editor__shell {
@@ -43,11 +66,61 @@
     }
 }
 
+/*
+ * #666 — the shell renders `.ap-site-editor__body` inside `<main>`, and
+ * `<main>` is a block-level element with no styling of its own. In a
+ * flex-column parent it collapses to its content, which breaks the
+ * `flex: 1 1 auto` chain below and leaves the body sized by its
+ * children rather than by the viewport. Promoting main to a flex-1
+ * passthrough re-establishes the chain so the sidebar / canvas /
+ * inspector each get a bounded height to constrain their own scroll.
+ */
+.ap-site-editor__shell > main {
+    flex: 1 1 auto;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    overflow: hidden;
+}
+
 .ap-site-editor__body {
     display: flex;
     flex: 1 1 auto;
     min-height: 0;
     overflow: hidden;
+}
+
+/*
+ * #666 — H7 (#432) portal targets for the canvas and inspector. The
+ * lazy sections (styles / navigation / patterns) render their canvas
+ * and inspector content into these slots. Without flex properties the
+ * slots collapse to their intrinsic size, so `height: 100%` inside a
+ * portaled child (e.g. `.ap-pattern-grid`) can't resolve and the child
+ * never scrolls. Both slots live in flex-column parents
+ * (`.ap-site-editor__canvas`, `.ap-site-editor__sidebar--inspector`)
+ * so the flex-1 fill applies.
+ */
+.ap-site-editor__canvas-slot,
+.ap-site-editor__inspector-slot {
+    flex: 1 1 auto;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    min-width: 0;
+    overflow: hidden;
+}
+
+/*
+ * Navigator slot is a sibling case: its parent
+ * `.ap-site-editor__navigator-outlet` uses block layout (with its own
+ * `overflow-y: auto`), so flex/min-* properties on the slot itself are
+ * inert. Only `display: flex; flex-direction: column;` matter — they
+ * let the portaled PatternsBrowser lay out as a flex column inside
+ * the slot. Height stays content-driven and the outlet handles scroll.
+ */
+.ap-site-editor__navigator-slot {
+    display: flex;
+    flex-direction: column;
 }
 
 .ap-site-editor__sidebar {


### PR DESCRIPTION
## Description

Two bug fixes in the site editor's Patterns surface that shipped together because they were discovered on the same walkthrough of a theme with 82 patterns.

**Closes:** #666, #667

## Type of Change

- [x] Bug fix (fixes an issue)

## Related Issues

- **Issue:** #666 — Site editor doesn't fill viewport height, sidebars + canvas not independently scrollable
- **Issue:** #667 — PatternThumbnail renders 'Empty pattern' for theme patterns because `blocks:[]` arrives from server

## Motivation and Context

Under any theme that ships more than a handful of patterns or long templates, the site editor became unusable on the Patterns and Templates surfaces:

- Long pattern lists slid past the fold with no scrollbar because the flex chain from `.ap-site-editor__shell` to the sidebar was broken by the un-styled `<main>` between them. Same for the canvas grid on long templates and the inspector on deep control trees.
- Every theme-shipped pattern rendered as an "Empty pattern" placeholder because `PatternThumbnail` short-circuited on `blocks: []`, but cms-framework's `PatternResolver::buildThemePattern()` only populates `raw` for theme patterns.

## Changes Made

### #666 — layout chain

- Anchor `html` and the SPA body to the viewport (`height: 100%; overflow: hidden`).
- Promote `.ap-site-editor__shell > main` to a bounded flex-1 passthrough so `.ap-site-editor__body` inherits a real height.
- Give the H7 (#432) portal targets (`__canvas-slot`, `__inspector-slot`) the flex-fill they need so `height: 100%` inside portaled children (e.g. `.ap-pattern-grid`) resolves and the child's own `overflow-y: auto` engages. `__navigator-slot` only gets `display: flex` because its outlet parent uses block layout with its own scroll.

### #667 — theme pattern thumbnails

- `PatternThumbnail` accepts an optional `rawContent` prop and, when `blocks` is empty, parses `raw` with the same Gutenberg `parse()` helper `hydrateBlocks` uses. Parse errors log a namespaced `console.warn` and fall back to the empty placeholder so a broken pattern is diagnosable in DevTools.
- `pattern-grid.tsx` forwards `pattern.content.raw`.
- Fixed a latent `content-box` sizing regression the empty state hid: `box-sizing: border-box` on `.ap-pattern-thumb` keeps the visible box inside the card; `min-width: 0` + `max-width: 100%` on the tree ellipsize long block names instead of letting them slip out sideways.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS
- Browser: Chrome (via the dev app at `~/Herd/artisanpack-ui-dev`)
- PHP Version: 8.4.3
- Project Version: release/1.5

**Tests Performed:**
1. Manual walkthrough of the Patterns surface under a theme with 82 patterns — sidebar list scrolls independently, thumbnails render the block tree summary for theme patterns instead of the empty placeholder.
2. Long-template walkthrough on the Templates surface — canvas scrolls independently.
3. Deep inspector controls (Border → Radius → Padding → Shadow) — right rail scrolls independently.
4. `npx vitest run` — 2440 JS tests pass across 282 files.

## Accessibility Tests Run

- [x] Keyboard navigation tested — arrow keys still traverse the pattern list; the fixed scroll containers don't disrupt focus flow.
- [ ] Screen reader tested
- [x] Color contrast verified — no color changes.
- [x] ARIA labels checked — no ARIA changes; landmarks (`<main>`, tablist, etc.) are unchanged.

## Tests Added

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All tests passing

**Test details:**

- New `resources/js/visual-editor/site-editor/__tests__/site-editor-app-css.test.ts` — reads `site-editor-app.css` and asserts the layout-critical rules are present so a refactor that removes them fails loudly.
- New `resources/js/visual-editor/site-editor/patterns/__tests__/pattern-thumbnail.test.tsx` — 6 unit tests covering populated blocks, empty state, whitespace-only rawContent, successful raw parse (#667 happy path), parse-throws fallback + console.warn, and blocks-preferred-over-raw ordering.
- Extended `pattern-grid.test.tsx` — added `@wordpress/blocks` mock at the top (needed now that PatternThumbnail imports `parse`) and a regression test that asserts a theme pattern's thumbnail renders the block tree instead of the empty placeholder.

## Documentation

- [x] Inline code documentation added — each new CSS rule and the `PatternThumbnail` fallback carry comments explaining the WHY (root-cause reference to the issue, invariants the rule maintains).
- [ ] README updated — no user-facing surface change.
- [ ] Wiki updated
- [ ] API documentation updated

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted (per project convention — no lint failures)
- [x] Accessibility tests completed
- [x] Code follows project style guide
- [x] Self-review completed (via `/code-review` skill; five findings surfaced and four applied — the fifth was intentional test-brittleness for regression detection)
- [x] Comments added for complex code
- [x] No new warnings generated