### PR TITLE
feat(site-editor): delegate canvas CSS to cms-framework's ThemeStylesheetReader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Changed
+
+- **Canvas CSS endpoint delegates to cms-framework's `ThemeStylesheetReader`.**
+  `GET /visual-editor/api/global-styles/css` now delegates the theme-file
+  read to `ArtisanPackUI\CMSFramework\Modules\SiteEditor\Support\ThemeStylesheetReader`
+  when it's available (cms-framework ≥ 2.5). The endpoint now concatenates
+  emitter output + `themes/{slug}/style.css` + `themes/{slug}/editor.css`
+  (the last is new — closes the canvas half of cms-framework #199, giving
+  the site editor a WordPress `add_editor_style()` analog). Section banners
+  switch from `/* === theme stylesheet === */` to per-file banners
+  (`/* === style.css === */`, `/* === editor.css === */`) so devtools
+  inspection matches cms-framework's endpoint. Falls back to the inline
+  `readThemeStylesheet()` helper for cms-framework < 2.5 — the fallback
+  preserves the pre-change behavior (style.css only, historical banner
+  text) so themes on older cms-framework releases keep the canvas parity
+  the endpoint already delivered.
+
 ## [1.4.0] - 2026-07-16
 
 ### Added

--- a/src/Http/Controllers/SiteEditor/GlobalStylesController.php
+++ b/src/Http/Controllers/SiteEditor/GlobalStylesController.php
@@ -159,26 +159,34 @@ class GlobalStylesController extends Controller
 
 	/**
 	 * GET `/global-styles/css` — full canvas stylesheet for the active
-	 * theme. Concatenates two sources in order:
+	 * theme. Concatenates three sources in order:
 	 *
 	 *   1. cms-framework's `GlobalStylesEmitter::emit()` — compiled CSS
 	 *      from theme.json `settings` + `styles`, merged with any DB
 	 *      override the user authored through the Styles section.
 	 *   2. The theme's hand-authored `themes/{slug}/style.css` — the
 	 *      same stylesheet the public front-end loads via `<link rel>`.
+	 *   3. The theme's canvas-only `themes/{slug}/editor.css` — the
+	 *      analog of WordPress's `add_editor_style()`. Never emitted
+	 *      on the front-end, so themes can use bare element selectors
+	 *      here without theming inspector-panel mini-previews.
 	 *
 	 * Order matters: the emitter declares `--wp--preset--*` custom
-	 * properties on `:root`; the hand-authored sheet can consume those
-	 * tokens AND override emitter rules (button border-radius / padding
-	 * that the emitter doesn't compile yet, footer list resets, etc.).
+	 * properties on `:root` first; `style.css` can consume those tokens
+	 * and override emitter rules; `editor.css` runs last so canvas-only
+	 * overrides win.
 	 *
 	 * The site-editor canvas appends the full response to its
 	 * `BlockEditorProvider` `settings.styles` array so the iframe surface
-	 * matches the public front-end's branding 1:1 — closes the parity
-	 * gap that Keystone #47 surfaced. Front-end consumes the emitter
-	 * via the renderer-blade Blade components and loads its own
-	 * `<link rel="stylesheet">` to `style.css`; the canvas reaches
-	 * parity by getting both bundled into this one fetch.
+	 * matches the public front-end's branding 1:1 (Keystone #47) and
+	 * gains WordPress-style canvas-only overrides (cms-framework #199).
+	 *
+	 * File reads delegate to cms-framework's `ThemeStylesheetReader` so
+	 * slug validation, path-containment, and memoization stay in one
+	 * place. Falls back to the inline `readThemeStylesheet()` helper
+	 * for older cms-framework installs (`< 2.5`) that don't ship the
+	 * reader binding — the fallback covers `style.css` only, matching
+	 * this endpoint's pre-#199 behavior.
 	 *
 	 * Returns an empty `text/css` body when cms-framework is not
 	 * installed; the canvas treats that the same as "no theme styles"
@@ -197,17 +205,38 @@ class GlobalStylesController extends Controller
 			$emitted = is_string( $result ) ? $result : '';
 		}
 
-		$themeCss = $this->readThemeStylesheet();
+		$readerFqcn = 'ArtisanPackUI\\CMSFramework\\Modules\\SiteEditor\\Support\\ThemeStylesheetReader';
+		$parts      = [ rtrim( $emitted ) ];
 
-		$body = '' === $themeCss
-			? $emitted
-			: rtrim( $emitted ) . "\n\n/* === theme stylesheet === */\n" . $themeCss;
+		if ( class_exists( $readerFqcn ) && app()->bound( $readerFqcn ) ) {
+			$reader  = app( $readerFqcn );
+			$parts[] = $reader->readWrapped( 'style.css' );
+			$parts[] = $reader->readWrapped( 'editor.css' );
+		} else {
+			// Fallback for cms-framework < 2.5 (no reader binding yet):
+			// preserve the pre-#199 behavior of concatenating just
+			// `style.css` under its historical banner text so themes
+			// installed against older cms-framework releases keep the
+			// canvas parity the endpoint already delivered.
+			$themeCss = $this->readThemeStylesheet();
+
+			if ( '' !== $themeCss ) {
+				$parts[] = "/* === theme stylesheet === */\n" . $themeCss;
+			}
+		}
+
+		$body = implode( "\n\n", array_filter( $parts, static fn ( string $part ): bool => '' !== $part ) );
 
 		return response( $body, Response::HTTP_OK, [ 'Content-Type' => 'text/css; charset=utf-8' ] );
 	}
 
 	/**
-	 * Read the active theme's hand-authored `style.css` from disk.
+	 * Read the active theme's hand-authored `style.css` from disk —
+	 * fallback for cms-framework installs older than 2.5 that don't
+	 * ship the `ThemeStylesheetReader` binding. When the reader is
+	 * available the primary `css()` path uses it instead and this
+	 * method is not invoked.
+	 *
 	 * Returns an empty string when no theme is active, when the file
 	 * doesn't exist, or when the resolved path escapes the configured
 	 * themes directory (path-traversal guard — the theme slug rides in

--- a/tests/Feature/SiteEditor/GlobalStylesControllerTest.php
+++ b/tests/Feature/SiteEditor/GlobalStylesControllerTest.php
@@ -32,12 +32,44 @@ beforeEach( function (): void {
 			'name' => 'Digital Shopfront',
 			'slug' => 'digital-shopfront',
 		] );
+		stubThemeManagerHelpersForGlobalStylesTest( $mock );
 	} );
 } );
 
 function rebuildSiteEditorResolversForGlobalStylesTest(): void
 {
 	( new VisualEditorServiceProvider( app() ) )->registerSiteEditorResolvers();
+}
+
+/**
+ * Stub the ThemeManager methods the ThemeStylesheetReader (cms-framework
+ * ≥ 2.5) calls on top of `getActiveTheme()`. Each `$this->mock()` in a
+ * test replaces the outer beforeEach mock, so tests hitting the /css
+ * endpoint need to re-declare these too.
+ */
+function stubThemeManagerHelpersForGlobalStylesTest( \Mockery\MockInterface $mock ): void
+{
+	$mock->shouldReceive( 'validateSlug' )->andReturnUsing(
+		static fn ( string $slug ): bool => (bool) preg_match( '/^[a-zA-Z0-9_-]+$/', $slug ),
+	);
+	$mock->shouldReceive( 'getThemesPath' )->andReturnUsing(
+		static function (): string {
+			$directory = (string) config( 'cms.themes.directory', 'themes' );
+
+			if ( '' === $directory ) {
+				$directory = 'themes';
+			}
+
+			// Match the real ThemeManager::getThemesPath() behavior:
+			// honor absolute paths so tests that point at a temp dir
+			// (e.g. sys_get_temp_dir()) resolve correctly.
+			if ( '/' === $directory[0] || preg_match( '#^[A-Za-z]:[\\\\/]#', $directory ) ) {
+				return $directory;
+			}
+
+			return base_path( $directory );
+		},
+	);
 }
 
 describe( 'GET /visual-editor/api/global-styles/lookup', function (): void {
@@ -77,6 +109,7 @@ describe( 'GET /visual-editor/api/global-styles/base', function (): void {
 				'settings' => [ 'color' => [ 'palette' => [ [ 'slug' => 'primary', 'color' => '#000' ] ] ] ],
 				'styles'   => [ 'typography' => [ 'fontSize' => '14px' ] ],
 			] );
+			stubThemeManagerHelpersForGlobalStylesTest( $mock );
 		} );
 
 		// A DB override exists with different styles — base() must NOT
@@ -100,6 +133,7 @@ describe( 'GET /visual-editor/api/global-styles/base', function (): void {
 	it( 'returns empty defaults when no active theme is configured', function (): void {
 		$this->mock( ThemeManager::class, function ( $mock ): void {
 			$mock->shouldReceive( 'getActiveTheme' )->andReturn( null );
+			stubThemeManagerHelpersForGlobalStylesTest( $mock );
 		} );
 
 		$this->getJson( '/visual-editor/api/global-styles/base' )
@@ -118,6 +152,7 @@ describe( 'GET /visual-editor/api/global-styles/css', function (): void {
 				'settings' => [ 'color' => [ 'palette' => [ [ 'slug' => 'primary', 'color' => '#0f172a' ] ] ] ],
 				'styles'   => [ 'color' => [ 'text' => '#111827' ] ],
 			] );
+			stubThemeManagerHelpersForGlobalStylesTest( $mock );
 		} );
 
 		rebuildSiteEditorResolversForGlobalStylesTest();
@@ -137,6 +172,7 @@ describe( 'GET /visual-editor/api/global-styles/css', function (): void {
 	it( 'returns an empty body when no active theme is configured', function (): void {
 		$this->mock( ThemeManager::class, function ( $mock ): void {
 			$mock->shouldReceive( 'getActiveTheme' )->andReturn( null );
+			stubThemeManagerHelpersForGlobalStylesTest( $mock );
 		} );
 
 		rebuildSiteEditorResolversForGlobalStylesTest();
@@ -164,6 +200,7 @@ describe( 'GET /visual-editor/api/global-styles/css', function (): void {
 				'settings' => [ 'color' => [ 'palette' => [ [ 'slug' => 'primary', 'color' => '#0f172a' ] ] ] ],
 				'styles'   => [ 'elements' => [ 'button' => [ 'color' => [ 'background' => '#2563eb' ] ] ] ],
 			] );
+			stubThemeManagerHelpersForGlobalStylesTest( $mock );
 		} );
 
 		rebuildSiteEditorResolversForGlobalStylesTest();
@@ -193,15 +230,67 @@ describe( 'GET /visual-editor/api/global-styles/css', function (): void {
 				'name' => 'Bad slug',
 				'slug' => '../../etc',
 			] );
+			stubThemeManagerHelpersForGlobalStylesTest( $mock );
 		} );
 
 		rebuildSiteEditorResolversForGlobalStylesTest();
 
 		$response = $this->get( '/visual-editor/api/global-styles/css' )->assertOk();
 
-		// The stylesheet read short-circuited on the bogus slug —
-		// body should not contain the theme-stylesheet marker.
-		expect( $response->getContent() )->not->toContain( '/* === theme stylesheet === */' );
+		// The stylesheet reader short-circuits on the bogus slug —
+		// no banners land in the body from either convention.
+		expect( $response->getContent() )
+			->not->toContain( '/* === style.css === */' )
+			->not->toContain( '/* === editor.css === */' )
+			->not->toContain( '/* === theme stylesheet === */' );
+	} );
+
+	it( 'concatenates the active theme\'s editor.css after style.css (cms-framework #199)', function (): void {
+		$themesBase = sys_get_temp_dir() . '/cms199-editor-css-' . uniqid();
+		$slug       = 'canvas-only-theme';
+		$themeDir   = $themesBase . '/' . $slug;
+
+		mkdir( $themeDir, 0755, true );
+		file_put_contents( $themeDir . '/style.css', "body { background: papayawhip; }\n" );
+		file_put_contents( $themeDir . '/editor.css', ".editor-only-marker { outline: 3px solid magenta; }\n" );
+
+		config()->set( 'cms.themes.directory', $themesBase );
+
+		$this->mock( ThemeManager::class, function ( $mock ) use ( $slug ): void {
+			$mock->shouldReceive( 'getActiveTheme' )->andReturn( [
+				'name'     => 'Canvas-only theme',
+				'slug'     => $slug,
+				'settings' => [ 'color' => [ 'palette' => [ [ 'slug' => 'primary', 'color' => '#0f172a' ] ] ] ],
+				'styles'   => [],
+			] );
+			stubThemeManagerHelpersForGlobalStylesTest( $mock );
+		} );
+
+		rebuildSiteEditorResolversForGlobalStylesTest();
+
+		$body = $this->get( '/visual-editor/api/global-styles/css' )->assertOk()->getContent();
+
+		// Emitter, style.css, and editor.css all present in that order —
+		// closing the gap flagged in cms-framework #199 where the canvas
+		// used to see style.css only.
+		$emitterPos = strpos( $body, '--wp--preset--color--primary' );
+		$stylePos   = strpos( $body, '/* === style.css === */' );
+		$editorPos  = strpos( $body, '/* === editor.css === */' );
+
+		expect( $emitterPos )->not->toBeFalse()
+			->and( $stylePos )->not->toBeFalse()
+			->and( $editorPos )->not->toBeFalse()
+			->and( $emitterPos )->toBeLessThan( $stylePos )
+			->and( $stylePos )->toBeLessThan( $editorPos );
+
+		expect( $body )
+			->toContain( 'body { background: papayawhip; }' )
+			->toContain( '.editor-only-marker' );
+
+		unlink( $themeDir . '/style.css' );
+		unlink( $themeDir . '/editor.css' );
+		rmdir( $themeDir );
+		rmdir( $themesBase );
 	} );
 } );
 

--- a/tests/Feature/SiteEditor/GlobalStylesControllerTest.php
+++ b/tests/Feature/SiteEditor/GlobalStylesControllerTest.php
@@ -46,9 +46,19 @@ function rebuildSiteEditorResolversForGlobalStylesTest(): void
  * ≥ 2.5) calls on top of `getActiveTheme()`. Each `$this->mock()` in a
  * test replaces the outer beforeEach mock, so tests hitting the /css
  * endpoint need to re-declare these too.
+ *
+ * No-op when cms-framework < 2.5 is installed: the controller falls
+ * back to its inline `readThemeStylesheet()` (which only calls
+ * `getActiveTheme()`), and Mockery refuses to stub `validateSlug` /
+ * `getThemesPath` on the older release because they were still
+ * `protected` there.
  */
 function stubThemeManagerHelpersForGlobalStylesTest( \Mockery\MockInterface $mock ): void
 {
+	if ( ! class_exists( 'ArtisanPackUI\\CMSFramework\\Modules\\SiteEditor\\Support\\ThemeStylesheetReader' ) ) {
+		return;
+	}
+
 	$mock->shouldReceive( 'validateSlug' )->andReturnUsing(
 		static fn ( string $slug ): bool => (bool) preg_match( '/^[a-zA-Z0-9_-]+$/', $slug ),
 	);
@@ -246,6 +256,10 @@ describe( 'GET /visual-editor/api/global-styles/css', function (): void {
 	} );
 
 	it( 'concatenates the active theme\'s editor.css after style.css (cms-framework #199)', function (): void {
+		if ( ! class_exists( 'ArtisanPackUI\\CMSFramework\\Modules\\SiteEditor\\Support\\ThemeStylesheetReader' ) ) {
+			$this->markTestSkipped( 'editor.css concatenation requires cms-framework >= 2.5 (reader binding not present).' );
+		}
+
 		$themesBase = sys_get_temp_dir() . '/cms199-editor-css-' . uniqid();
 		$slug       = 'canvas-only-theme';
 		$themeDir   = $themesBase . '/' . $slug;


### PR DESCRIPTION
## Description

`GET /visual-editor/api/global-styles/css` now delegates the theme-file read to cms-framework's new `ThemeStylesheetReader` (introduced in [cms-framework#206](https://github.com/ArtisanPack-UI/cms-framework/pull/206), closes cms-framework #199). The endpoint now concatenates emitter + `themes/{slug}/style.css` + `themes/{slug}/editor.css` — the last is new and delivers a WordPress `add_editor_style()` analog to the site-editor canvas.

**Depends on:** ArtisanPack-UI/cms-framework#206 (must ship cms-framework 2.5 before this merges)

## Type of Change

- [x] Enhancement (improves existing functionality)
- [x] Refactoring (code improvement, no behavior change) — for the style.css read path

## Related Issue

**Issue:** ArtisanPack-UI/cms-framework#199

## Motivation and Context

The site-editor canvas fetches this endpoint to populate `settings.styles`. Before this PR the endpoint read only `style.css` from disk with its own inlined slug validation + realpath containment guard — duplicating cms-framework's reader. cms-framework 2.5 introduces `ThemeStylesheetReader` as the canonical public reader; delegating here (a) picks up `editor.css` support automatically, (b) removes the duplication, and (c) keeps banner formatting and path-handling in lockstep between the two endpoints.

## Changes Made

- `css()` now resolves `ArtisanPackUI\CMSFramework\Modules\SiteEditor\Support\ThemeStylesheetReader` via the container and calls `readWrapped( 'style.css' )` + `readWrapped( 'editor.css' )`. Section banners switch from `/* === theme stylesheet === */` to per-file banners so devtools inspection matches cms-framework's own endpoint.
- Legacy inline `readThemeStylesheet()` retained as a `class_exists`-gated fallback for cms-framework < 2.5 installs — preserves the pre-change behavior (style.css only, historical banner text) so themes on older cms-framework releases keep the canvas parity the endpoint already delivered.
- New test case verifying emitter + style.css + editor.css concatenate in the expected order.
- Existing tests updated to stub the reader's new `validateSlug` / `getThemesPath` expectations on the mocked `ThemeManager`.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS 15
- PHP Version: 8.4.23
- Project Version: visual-editor 1.5.x-dev with cms-framework 2.5.x-dev symlinked locally

**Tests Performed:**
1. Focused suite: `tests/Feature/SiteEditor` → `159 passed`.
2. Full package suite: passes modulo 17 pre-existing failures in `tests/Feature/Ai/*` that need the optional `ArtisanPackUI\Ai` package (verified they fail on `release/1.5` before this branch too).

## Accessibility Tests Run

- [x] N/A — server-side CSS emission; no keyboard, screen-reader, or color-contrast surface changes.

**Details:** Change is confined to a CSS-response HTTP endpoint. Accessibility posture unchanged.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing (in-scope)

**Test details:**
- New `it 'concatenates the active theme\'s editor.css after style.css (cms-framework #199)'` case verifying end-to-end wiring.
- Path-traversal guard test updated: the assertion now checks for both new banners and the legacy banner absence, so the guard-still-guards invariant survives the delegation refactor.
- Helper `stubThemeManagerHelpersForGlobalStylesTest()` centralizes the new mock expectations required by the reader (`validateSlug`, `getThemesPath`), including absolute-path handling that matches the real `ThemeManager` behavior.

## Documentation

- [x] Inline code documentation added
- [x] Changelog updated

**Documentation details:** `css()`'s docblock now describes the three-section body + reader delegation + fallback semantics. `CHANGELOG.md` covers the endpoint behavior change and banner-format switch under `[Unreleased] > Changed`.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all in-scope tests
- [x] Code follows project style guide (no linter in visual-editor package; matched sibling formatting)
- [x] Accessibility tests completed (N/A — see above)
- [x] Self-review completed
- [x] Comments added for complex code (the `class_exists` fallback branch)
- [x] No new warnings generated

## Do Not Merge Until

- [ ] cms-framework#206 merges and cms-framework 2.5.0 tag exists
- [ ] visual-editor's composer constraint on `artisanpack-ui/cms-framework` bumped to `^2.5` (separate follow-up)