### PR TITLE
fix: accept numeric-string map keys in site-editor resolvers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,30 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+- **Site-editor resolvers accept numeric-string map keys (cms-framework #203).**
+  WordPress template hierarchy filenames like `404.html` / `500.html` double
+  as slugs. PHP auto-coerces numeric-string array keys to `int` at insertion
+  time and `array_merge` renumbers int-keyed entries sequentially, so
+  contributors of `ap.visual-editor.{templates,template-parts,patterns,navigation}`
+  cannot preserve the intended string key from upstream. `AbstractMapResolver`
+  now accepts `int` keys and re-keys the normalized output map by each value
+  object's own identifier via a new `identifierOf()` hook (`slug` for
+  templates/parts/patterns, `location` for menus). Empty identifiers and
+  identifier collisions across entries now throw
+  `SiteEditorRegistrationException` at first read instead of silently
+  producing an unaddressable / clobbered entry.
+
 ### Changed
 
+- **Site-editor map resolvers key by the entry's own identifier, not the
+  raw filter key.** Previously, `find( $rawKey )` succeeded when a
+  contributor supplied a filter map whose keys diverged from the entries'
+  own `slug` / `location`. That path is gone: `find()` now only resolves
+  by the value object's identifier. Contributors that already stamp the
+  matching `slug` / `location` on their entries (all first-party
+  contributors, including cms-framework) are unaffected.
 - **Canvas CSS endpoint delegates to cms-framework's `ThemeStylesheetReader`.**
   `GET /visual-editor/api/global-styles/css` now delegates the theme-file
   read to `ArtisanPackUI\CMSFramework\Modules\SiteEditor\Support\ThemeStylesheetReader`

--- a/src/SiteEditor/Exceptions/SiteEditorRegistrationException.php
+++ b/src/SiteEditor/Exceptions/SiteEditorRegistrationException.php
@@ -89,4 +89,41 @@ class SiteEditorRegistrationException extends RuntimeException
 			$expected,
 		) );
 	}
+
+	/**
+	 * Two entries in a filter return map resolved to the same canonical
+	 * identifier (slug / location). One would silently overwrite the other,
+	 * so we surface it as a configuration error.
+	 *
+	 * @since 1.5.0
+	 *
+	 * @param  string  $filterName  The filter slug.
+	 * @param  string  $identifier  The colliding identifier value.
+	 */
+	public static function duplicateIdentifier( string $filterName, string $identifier ): self
+	{
+		return new self( sprintf(
+			'Filter "%s" produced two entries with the same identifier "%s"; one would silently overwrite the other.',
+			$filterName,
+			$identifier,
+		) );
+	}
+
+	/**
+	 * An entry's normalized value object returned an empty-string identifier,
+	 * which would produce an unaddressable `''` map key.
+	 *
+	 * @since 1.5.0
+	 *
+	 * @param  string  $filterName  The filter slug.
+	 * @param  string  $entryKey    The raw map key the entry arrived under.
+	 */
+	public static function emptyIdentifier( string $filterName, string $entryKey ): self
+	{
+		return new self( sprintf(
+			'Filter "%s" entry "%s" resolved to an empty identifier; expected a non-empty slug or location.',
+			$filterName,
+			$entryKey,
+		) );
+	}
 }

--- a/src/SiteEditor/Resolution/AbstractMapResolver.php
+++ b/src/SiteEditor/Resolution/AbstractMapResolver.php
@@ -150,7 +150,27 @@ abstract class AbstractMapResolver
 			// Key by the value object's own identifier so consumers see a
 			// canonical string-keyed map regardless of PHP's coercion or
 			// upstream `array_merge` reindexing at the filter site.
-			$out[ static::identifierOf( $normalized ) ] = $normalized;
+			$identifier = static::identifierOf( $normalized );
+
+			if ( '' === $identifier ) {
+				throw SiteEditorRegistrationException::emptyIdentifier(
+					static::filterName(),
+					$key,
+				);
+			}
+
+			// Re-keying can collapse two distinct raw entries into one when
+			// they claim the same slug / location. That's a configuration
+			// error, not a silent last-wins — surface it so the contributor
+			// knows to disambiguate.
+			if ( array_key_exists( $identifier, $out ) ) {
+				throw SiteEditorRegistrationException::duplicateIdentifier(
+					static::filterName(),
+					$identifier,
+				);
+			}
+
+			$out[ $identifier ] = $normalized;
 		}
 
 		return $out;
@@ -180,6 +200,11 @@ abstract class AbstractMapResolver
 	 * re-key the output map so the identifier the entry carries on itself
 	 * (slug, location, etc.) always wins over the raw filter key — which may
 	 * have been coerced to int by PHP or renumbered by `array_merge`.
+	 *
+	 * Must return a non-empty string; an empty value throws
+	 * {@see SiteEditorRegistrationException::emptyIdentifier()} at the call
+	 * site so a misconfigured value object surfaces immediately instead of
+	 * producing an unaddressable `''` map key.
 	 *
 	 * @since 1.5.0
 	 *

--- a/src/SiteEditor/Resolution/AbstractMapResolver.php
+++ b/src/SiteEditor/Resolution/AbstractMapResolver.php
@@ -119,7 +119,17 @@ abstract class AbstractMapResolver
 		$out = [];
 
 		foreach ( $entries as $key => $entry ) {
-			if ( ! is_string( $key ) || '' === $key ) {
+			// PHP auto-coerces numeric-string array keys to `int` when they
+			// enter an array (e.g. WordPress-style `404.html` → int `404`)
+			// and `array_merge` renumbers int-keyed entries sequentially, so
+			// contributors cannot preserve the intended string key at the
+			// language level. Accept `int` keys and cast back to string here
+			// so the raw key remains a legal fallback for entries that omit
+			// the identifier field; the final map is re-keyed below by the
+			// value object's own identifier, which survives both hazards.
+			if ( is_int( $key ) ) {
+				$key = (string) $key;
+			} elseif ( ! is_string( $key ) || '' === $key ) {
 				throw SiteEditorRegistrationException::invalidFilterShape(
 					static::filterName(),
 					'a map keyed by non-empty string',
@@ -135,10 +145,12 @@ abstract class AbstractMapResolver
 				);
 			}
 
-			// Stamp the map key onto the entry under the type-specific key
-			// field so the value object can default to it when the entry
-			// omits the field. The per-type subclass picks the right field.
-			$out[ $key ] = static::normalizeEntry( $key, $entry );
+			$normalized = static::normalizeEntry( $key, $entry );
+
+			// Key by the value object's own identifier so consumers see a
+			// canonical string-keyed map regardless of PHP's coercion or
+			// upstream `array_merge` reindexing at the filter site.
+			$out[ static::identifierOf( $normalized ) ] = $normalized;
 		}
 
 		return $out;
@@ -162,4 +174,16 @@ abstract class AbstractMapResolver
 	 * @return TValue
 	 */
 	abstract protected static function normalizeEntry( string $key, array $entry ): object;
+
+	/**
+	 * Extract the canonical map key from a normalized value object. Used to
+	 * re-key the output map so the identifier the entry carries on itself
+	 * (slug, location, etc.) always wins over the raw filter key — which may
+	 * have been coerced to int by PHP or renumbered by `array_merge`.
+	 *
+	 * @since 1.5.0
+	 *
+	 * @param  TValue  $entry
+	 */
+	abstract protected static function identifierOf( object $entry ): string;
 }

--- a/src/SiteEditor/Resolution/MenuResolver.php
+++ b/src/SiteEditor/Resolution/MenuResolver.php
@@ -42,4 +42,14 @@ class MenuResolver extends AbstractMapResolver
 
 		return ResolvedMenu::fromArray( $entry );
 	}
+
+	/**
+	 * @since 1.5.0
+	 *
+	 * @param  ResolvedMenu  $entry
+	 */
+	protected static function identifierOf( object $entry ): string
+	{
+		return $entry->location;
+	}
 }

--- a/src/SiteEditor/Resolution/PatternResolver.php
+++ b/src/SiteEditor/Resolution/PatternResolver.php
@@ -43,4 +43,14 @@ class PatternResolver extends AbstractMapResolver
 
 		return ResolvedPattern::fromArray( $entry );
 	}
+
+	/**
+	 * @since 1.5.0
+	 *
+	 * @param  ResolvedPattern  $entry
+	 */
+	protected static function identifierOf( object $entry ): string
+	{
+		return $entry->slug;
+	}
 }

--- a/src/SiteEditor/Resolution/TemplatePartResolver.php
+++ b/src/SiteEditor/Resolution/TemplatePartResolver.php
@@ -40,4 +40,14 @@ class TemplatePartResolver extends AbstractMapResolver
 
 		return ResolvedTemplatePart::fromArray( $entry );
 	}
+
+	/**
+	 * @since 1.5.0
+	 *
+	 * @param  ResolvedTemplatePart  $entry
+	 */
+	protected static function identifierOf( object $entry ): string
+	{
+		return $entry->slug;
+	}
 }

--- a/src/SiteEditor/Resolution/TemplateResolver.php
+++ b/src/SiteEditor/Resolution/TemplateResolver.php
@@ -43,4 +43,14 @@ class TemplateResolver extends AbstractMapResolver
 
 		return ResolvedTemplate::fromArray( $entry );
 	}
+
+	/**
+	 * @since 1.5.0
+	 *
+	 * @param  ResolvedTemplate  $entry
+	 */
+	protected static function identifierOf( object $entry ): string
+	{
+		return $entry->slug;
+	}
 }

--- a/tests/Feature/VisualEditor/SiteEditorFiltersTest.php
+++ b/tests/Feature/VisualEditor/SiteEditorFiltersTest.php
@@ -576,6 +576,56 @@ describe( 'lazy validation on first read', function (): void {
 		expect( app( TemplateResolver::class )->find( '404' )->slug )->toBe( '404' );
 	} );
 
+	it( 'throws when two template entries resolve to the same slug', function (): void {
+		// Re-keying by the value object's slug means two entries with
+		// different raw keys but the same slug would silently overwrite
+		// one another. Surface that as a configuration error instead of
+		// last-wins so contributors know to disambiguate.
+		addFilter( 'ap.visual-editor.templates', function ( array $existing ): array {
+			return array_merge( [
+				'raw-a' => [
+					'slug'   => 'shared',
+					'theme'  => 'host',
+					'title'  => 'A',
+					'source' => 'theme',
+				],
+				'raw-b' => [
+					'slug'   => 'shared',
+					'theme'  => 'host',
+					'title'  => 'B',
+					'source' => 'theme',
+				],
+			], $existing );
+		} );
+
+		rebuildSiteEditorResolvers();
+
+		expect( fn () => app( TemplateResolver::class )->all() )
+			->toThrow( SiteEditorRegistrationException::class, 'shared' );
+	} );
+
+	it( 'throws when a template entry resolves to an empty slug', function (): void {
+		// An empty identifier would produce an unaddressable `''` map
+		// key. The pre-refactor shape guard rejected empty raw keys; the
+		// post-refactor emptyIdentifier check protects the same
+		// invariant on the re-key path.
+		addFilter( 'ap.visual-editor.templates', function ( array $existing ): array {
+			return array_merge( [
+				'raw-key' => [
+					'slug'   => '',
+					'theme'  => 'host',
+					'title'  => 'Empty Slug',
+					'source' => 'theme',
+				],
+			], $existing );
+		} );
+
+		rebuildSiteEditorResolvers();
+
+		expect( fn () => app( TemplateResolver::class )->all() )
+			->toThrow( SiteEditorRegistrationException::class, 'empty identifier' );
+	} );
+
 	it( 'throws when global-styles is missing the theme field', function (): void {
 		addFilter( 'ap.visual-editor.global-styles', function ( $existing ) {
 			return $existing ?? [

--- a/tests/Feature/VisualEditor/SiteEditorFiltersTest.php
+++ b/tests/Feature/VisualEditor/SiteEditorFiltersTest.php
@@ -535,6 +535,47 @@ describe( 'lazy validation on first read', function (): void {
 		expect( $part->rawContent )->toBe( '1.5' );
 	} );
 
+	it( 'accepts numeric-string template slugs (404, 500) that PHP coerces to int keys', function (): void {
+		// WordPress template hierarchy uses `404.html` / `500.html`, whose
+		// basenames double as slugs. PHP auto-coerces `'404'` array keys
+		// to int(404), which contributors cannot prevent at the language
+		// level. The resolver must accept int keys and cast them back to
+		// string so the filter's string-map contract holds end-to-end.
+		addFilter( 'ap.visual-editor.templates', function ( array $existing ): array {
+			return array_merge( [
+				'404' => [
+					'slug'   => '404',
+					'theme'  => 'host',
+					'title'  => 'Not Found',
+					'source' => 'theme',
+				],
+				'500' => [
+					'slug'   => '500',
+					'theme'  => 'host',
+					'title'  => 'Server Error',
+					'source' => 'theme',
+				],
+			], $existing );
+		} );
+
+		rebuildSiteEditorResolvers();
+
+		$notFound = app( TemplateResolver::class )->find( '404' );
+		$serverError = app( TemplateResolver::class )->find( '500' );
+
+		expect( $notFound )->not->toBeNull();
+		expect( $notFound->slug )->toBe( '404' );
+		expect( $serverError )->not->toBeNull();
+		expect( $serverError->slug )->toBe( '500' );
+
+		// PHP re-coerces numeric-string map keys back to int on assignment,
+		// so the raw key type in all() is a language-level detail consumers
+		// can't rely on either way — what matters is that find() with the
+		// canonical string identifier resolves to the right value object
+		// and that the entry preserves its slug as a string.
+		expect( app( TemplateResolver::class )->find( '404' )->slug )->toBe( '404' );
+	} );
+
 	it( 'throws when global-styles is missing the theme field', function (): void {
 		addFilter( 'ap.visual-editor.global-styles', function ( $existing ) {
 			return $existing ?? [


### PR DESCRIPTION
## Description

WordPress template hierarchy uses `404.html` / `500.html`, whose basenames double as template slugs. PHP auto-coerces numeric-string array keys to `int`, and `array_merge` renumbers int-keyed entries sequentially — so contributors of the `ap.visual-editor.templates` (and sibling) filters cannot preserve the intended string key at the language level, no matter how carefully they build the payload upstream.

Before this fix, the site editor's Templates page threw `SiteEditorRegistrationException::invalidFilterShape` ("map keyed by non-empty string … got numeric or empty keys") whenever a theme shipped a `404.html` or `500.html` template.

**Closes:** ArtisanPack-UI/cms-framework#203

## Type of Change

- [x] Bug fix (fixes an issue)

## Related Issue

**Issue:** ArtisanPack-UI/cms-framework#203

## Motivation and Context

The reported fix location (cms-framework) can't solve this in isolation: verified in a `php -r` REPL that `array_combine(array_map('strval', ...), ...)` still yields `int` keys because PHP's auto-coercion happens at insertion time. The only durable fix is on the consumer side.

## Changes Made

- `AbstractMapResolver::normalizeEntries()` now accepts `int` keys, casting them back to `string` for the fallback identifier path (unchanged rejection for empty-string keys).
- Adds an abstract `identifierOf( object $entry ): string` hook implemented by each subclass (`slug` for templates/parts/patterns; `location` for menus). The normalized output map is re-keyed by the value object's own identifier — so PHP's coercion and upstream `array_merge` reindexing can't corrupt the mapping.

## How Has This Been Tested?

**Testing Environment:**
- PHP Version: 8.4.3
- Package: visual-editor `release/1.5`

**Tests Performed:**
1. New Pest test: numeric-string slugs (`404`, `500`) round-trip through the filter → `TemplateResolver::find()` returns the correct entry with `slug` preserved.
2. Full `tests/Unit/VisualEditor/SiteEditor` + `tests/Feature/VisualEditor` + `tests/Feature/SiteEditor` suites: 446 tests, 1429 assertions, all passing.

## Accessibility Tests Run

- [x] N/A — server-side resolver change with no UI surface.

## Tests Added

- [x] Unit tests added/updated
- [x] All tests passing

**Test details:** `tests/Feature/VisualEditor/SiteEditorFiltersTest.php` — `it accepts numeric-string template slugs (404, 500) that PHP coerces to int keys`.

## Documentation

- [x] Inline code documentation added — explains the PHP coercion + `array_merge` interaction that motivates the fix.

## Pre-Submission Checklist

- [x] Code passes all tests
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated