### PR TITLE
chore: rename ap.visual-editor.* hooks to ap.visualEditor.* camelCase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ resources/js/visual-editor/blocks/**/upstream-diff-report.json
 # Tracking ~2,800 SVGs would bloat the repo for no gain — the script is
 # deterministic and the source is pinned in package.json. See #554.
 resources/icons/font-awesome/
+
+# The renderer-blade sub-package's vendor tree is dev-only — never ships.
+/packages/visual-editor-renderer-blade/vendor/
+/packages/visual-editor-renderer-blade/composer.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,22 +6,47 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
-### Fixed
+## [1.5.0]
 
-- **Site-editor resolvers accept numeric-string map keys (cms-framework #203).**
-  WordPress template hierarchy filenames like `404.html` / `500.html` double
-  as slugs. PHP auto-coerces numeric-string array keys to `int` at insertion
-  time and `array_merge` renumbers int-keyed entries sequentially, so
-  contributors of `ap.visual-editor.{templates,template-parts,patterns,navigation}`
-  cannot preserve the intended string key from upstream. `AbstractMapResolver`
-  now accepts `int` keys and re-keys the normalized output map by each value
-  object's own identifier via a new `identifierOf()` hook (`slug` for
-  templates/parts/patterns, `location` for menus). Empty identifiers and
-  identifier collisions across entries now throw
-  `SiteEditorRegistrationException` at first read instead of silently
-  producing an unaddressable / clobbered entry.
+### Changed (BREAKING)
 
-### Changed
+- **Renamed every visual-editor hook to camelCase (#664).** The 13 PHP
+  hooks the package fires or subscribes to, plus the
+  `visual_editor.pre_publish_checks` cross-package hook, the
+  `ap.icons.register-icon-sets` bridge hook, and three JS-only hooks
+  (`background-controls`, `canvas-styles`, `document-panels`), now use
+  camelCase — matching the ArtisanPack UI ecosystem's naming convention.
+  Old names remain functional via `deprecateHook()` aliases registered by
+  `ArtisanPackUI\VisualEditor\Support\HookAliases` on the PHP side and a
+  bidirectional `@wordpress/hooks` shim in
+  `resources/js/visual-editor/support/hook-aliases.ts` on the JS side;
+  the JS shim runs at `Number.MIN_SAFE_INTEGER` priority so real
+  subscribers on the paired name are surfaced before priority-sorted
+  dispatch of the applied name's callbacks. A deprecation notice is
+  logged the first time an alias resolves per process. Rename table:
+
+    - `ap.visual-editor.resources` → `ap.visualEditor.resources`
+    - `ap.visual-editor.templates` → `ap.visualEditor.templates`
+    - `ap.visual-editor.template-parts` → `ap.visualEditor.templateParts`
+    - `ap.visual-editor.patterns` → `ap.visualEditor.patterns`
+    - `ap.visual-editor.global-styles` → `ap.visualEditor.globalStyles`
+    - `ap.visual-editor.navigation` → `ap.visualEditor.navigation`
+    - `ap.visual-editor.visibility.register-rules` → `ap.visualEditor.visibility.registerRules`
+    - `ap.visual-editor.visibility.evaluated` → `ap.visualEditor.visibility.evaluated`
+    - `ap.visual-editor.visibility.user-search-results` → `ap.visualEditor.visibility.userSearchResults`
+    - `ap.visual-editor.rendered-block` → `ap.visualEditor.renderedBlock`
+    - `ap.visual-editor.breadcrumbs.trail` → `ap.visualEditor.breadcrumbs.trail`
+    - `ap.visual-editor.loginout.envelope` → `ap.visualEditor.loginout.envelope`
+    - `ap.visual-editor.loginout.login-form` → `ap.visualEditor.loginout.loginForm`
+    - `visual_editor.pre_publish_checks` → `ap.visualEditor.prePublishChecks`
+    - `ap.icons.register-icon-sets` → `ap.icons.registerIconSets`
+    - `ap.visual-editor.background-controls` → `ap.visualEditor.backgroundControls`
+    - `ap.visual-editor.canvas-styles` → `ap.visualEditor.canvasStyles`
+    - `ap.visual-editor.document-panels` → `ap.visualEditor.documentPanels`
+
+  See `src/Support/HookAliases.php` for the full canonical list. Bumps
+  the `artisanpack-ui/hooks` Composer requirement to `^1.2` (v1.3.x in
+  practice) to pick up the `deprecateHook()` helper (v1.3.0).
 
 - **Site-editor map resolvers key by the entry's own identifier, not the
   raw filter key.** Previously, `find( $rawKey )` succeeded when a
@@ -44,6 +69,21 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   preserves the pre-change behavior (style.css only, historical banner
   text) so themes on older cms-framework releases keep the canvas parity
   the endpoint already delivered.
+
+### Fixed
+
+- **Site-editor resolvers accept numeric-string map keys (cms-framework #203).**
+  WordPress template hierarchy filenames like `404.html` / `500.html` double
+  as slugs. PHP auto-coerces numeric-string array keys to `int` at insertion
+  time and `array_merge` renumbers int-keyed entries sequentially, so
+  contributors of `ap.visualEditor.{templates,templateParts,patterns,navigation}`
+  cannot preserve the intended string key from upstream. `AbstractMapResolver`
+  now accepts `int` keys and re-keys the normalized output map by each value
+  object's own identifier via a new `identifierOf()` hook (`slug` for
+  templates/parts/patterns, `location` for menus). Empty identifiers and
+  identifier collisions across entries now throw
+  `SiteEditorRegistrationException` at first read instead of silently
+  producing an unaddressable / clobbered entry.
 
 ## [1.4.0] - 2026-07-16
 

--- a/README.md
+++ b/README.md
@@ -263,7 +263,17 @@ for the site-editor pairing walkthrough.
 
 ## Extensibility
 
-### `ap.visual-editor.resources`
+> **Hook rename (v1.5.0, #664).** Every visual-editor hook now uses
+> camelCase — the old kebab-case names below (`ap.visual-editor.*`,
+> `ap.icons.register-icon-sets`, `visual_editor.pre_publish_checks`)
+> remain functional through `deprecateHook()` aliases and continue to
+> route callbacks to the canonical name, but log a deprecation notice
+> the first time each alias resolves per process. New code should use
+> the camelCase names. See
+> [`src/Support/HookAliases.php`](src/Support/HookAliases.php) for the
+> full rename table.
+
+### `ap.visualEditor.resources`
 
 Register slug → Eloquent model class mappings used by
 `/visual-editor/api/{resource}/{id}/content`. Filter contributions are
@@ -275,7 +285,7 @@ surface as `InvalidArgumentException` on first request rather than at
 boot, so a contributor's standalone install never trips host boot.
 
 ```php
-addFilter('ap.visual-editor.resources', function (array $resources): array {
+addFilter('ap.visualEditor.resources', function (array $resources): array {
     return array_merge([
         'posts' => App\Models\Post::class,
     ], $resources);
@@ -285,7 +295,7 @@ addFilter('ap.visual-editor.resources', function (array $resources): array {
 Full contract: [`docs/content-model.md`](docs/content-model.md#2-the-resource-map) and
 [`docs/Hooks-and-Events.md`](docs/Hooks-and-Events.md#ap-visual-editor-resources).
 
-### `ap.icons.register-icon-sets`
+### `ap.icons.registerIconSets`
 
 Editor chrome icons resolve through `artisanpack-ui/icons`. Register
 additional icon sets in a service provider — see the

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "artisanpack-ui/visual-editor",
   "description": "A Gutenberg-powered visual editor for Laravel — post editor, site editor, and Blade/React/Vue block renderers.",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "type": "library",
   "license": "GPL-3.0-or-later",
   "autoload": {
@@ -30,7 +30,7 @@
     "php": "^8.2",
     "illuminate/support": "^11.0|^12.0|^13.0",
     "artisanpack-ui/core": "^1.0",
-    "artisanpack-ui/hooks": "^1.0"
+    "artisanpack-ui/hooks": "^1.2"
   },
   "require-dev": {
     "pestphp/pest": "^3.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fbfdab56e05f0548e0b91bd4b0e43e3d",
+    "content-hash": "aef967ffa5a1ee1b440ab6cf8295fca0",
     "packages": [
         {
             "name": "artisanpack-ui/core",
@@ -77,20 +77,20 @@
         },
         {
             "name": "artisanpack-ui/hooks",
-            "version": "1.2.0",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ArtisanPack-UI/hooks.git",
-                "reference": "19f4e41737903639afd76e210b58db411b506873"
+                "reference": "2834223f643ee5e12f93edc816a6d2dca66d09aa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ArtisanPack-UI/hooks/zipball/19f4e41737903639afd76e210b58db411b506873",
-                "reference": "19f4e41737903639afd76e210b58db411b506873",
+                "url": "https://api.github.com/repos/ArtisanPack-UI/hooks/zipball/2834223f643ee5e12f93edc816a6d2dca66d09aa",
+                "reference": "2834223f643ee5e12f93edc816a6d2dca66d09aa",
                 "shasum": ""
             },
             "require": {
-                "illuminate/support": ">=5.3",
+                "illuminate/support": "^11.0|^12.0|^13.0",
                 "php": "^8.2"
             },
             "require-dev": {
@@ -137,9 +137,9 @@
             "description": "WordPress-style actions and filters for Laravel, with Blade directives and helper functions.",
             "support": {
                 "issues": "https://github.com/ArtisanPack-UI/hooks/issues",
-                "source": "https://github.com/ArtisanPack-UI/hooks/tree/v1.2.0"
+                "source": "https://github.com/ArtisanPack-UI/hooks/tree/v1.3.0"
             },
-            "time": "2025-11-22T23:15:16+00:00"
+            "time": "2026-07-20T18:37:59+00:00"
         },
         {
             "name": "brick/math",

--- a/config/visual-editor.php
+++ b/config/visual-editor.php
@@ -319,7 +319,7 @@ return [
 	| POST + CSRF — clicking the rendered link will hit a 405 unless the
 	| host either (a) registers a GET-side logout endpoint and points
 	| `logout_route` / `logout_path` at it, or (b) rewrites the resolved
-	| envelope through the `ap.visual-editor.loginout.envelope` filter
+	| envelope through the `ap.visualEditor.loginout.envelope` filter
 	| (e.g. swap in a `URL::signedRoute()` link to a GET handler that
 	| invalidates the session). The default of `logout` is kept because
 	| dropping it would mean `logout_path` shows through as a relative
@@ -328,7 +328,7 @@ return [
 	|
 	| For fully custom URL resolution (per-tenant routes, SSO, etc.)
 	| override the resolved envelope through the
-	| `ap.visual-editor.loginout.envelope` filter hook instead.
+	| `ap.visualEditor.loginout.envelope` filter hook instead.
 	|
 	*/
 
@@ -350,7 +350,7 @@ return [
 	| resolver. The resolver builds a default trail
 	| (`Home → …ancestors → current`) for every breadcrumbs block on
 	| render; hosts customize the trail through the
-	| `ap.visual-editor.breadcrumbs.trail` filter (e.g. to insert a
+	| `ap.visualEditor.breadcrumbs.trail` filter (e.g. to insert a
 	| "Category" hop between Home and a blog post).
 	|
 	| `home_url` overrides the root link target — leave null to fall back
@@ -556,7 +556,7 @@ return [
 	|
 	| Static-config entry points for the five site-editor entity types. Each
 	| key is also a filter slug — packages like cms-framework register their
-	| entities at runtime through `addFilter('ap.visual-editor.{type}', ...)`.
+	| entities at runtime through `addFilter('ap.visualEditor.{type}', ...)`.
 	|
 	| Static config wins on key collision: host-app entries listed here take
 	| precedence over filter-supplied entries with the same key.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@artisanpack-ui/visual-editor",
-    "version": "1.4.0",
+    "version": "1.5.0",
     "private": true,
     "type": "module",
     "exports": {

--- a/packages/visual-editor-renderer-blade/src/BlockRenderer.php
+++ b/packages/visual-editor-renderer-blade/src/BlockRenderer.php
@@ -369,7 +369,7 @@ class BlockRenderer
 			$html = $this->wrapWithScreenSizeCss( $html, $cssHiddenDecision );
 		}
 
-		// `ap.visual-editor.rendered-block` — last-mile hook for packages
+		// `ap.visualEditor.renderedBlock` — last-mile hook for packages
 		// that need to post-process a rendered block. Runs on every block
 		// (static or dynamic) so cross-cutting effects (frosted glass,
 		// motion wrappers, contrast overlays, etc.) can decorate output
@@ -394,7 +394,7 @@ class BlockRenderer
 		// without notice — callbacks should treat them as read-only
 		// side-channel data, not stable public attributes.
 		if ( function_exists( 'applyFilters' ) ) {
-			$filtered = applyFilters( 'ap.visual-editor.rendered-block', $html, $name, $attributes );
+			$filtered = applyFilters( 'ap.visualEditor.renderedBlock', $html, $name, $attributes );
 
 			if ( is_string( $filtered ) ) {
 				$html = $filtered;

--- a/packages/visual-editor-renderer-blade/src/Resolvers/BreadcrumbsResolver.php
+++ b/packages/visual-editor-renderer-blade/src/Resolvers/BreadcrumbsResolver.php
@@ -16,7 +16,7 @@
  * link and emits `aria-current="page"`.
  *
  * Hosts customize the trail through the
- * `ap.visual-editor.breadcrumbs.trail` filter — e.g. to insert a
+ * `ap.visualEditor.breadcrumbs.trail` filter — e.g. to insert a
  * "Category" hop between Home and a blog post — without having to
  * subclass the resolver. The filter receives the resolved trail, the
  * current post (or null), and the block's attributes.
@@ -121,7 +121,7 @@ class BreadcrumbsResolver
 	/**
 	 * Build the resolved trail for a single breadcrumbs block. The default
 	 * shape is `[Home, …ancestors, current]`. Hosts override the result
-	 * through the `ap.visual-editor.breadcrumbs.trail` filter when the
+	 * through the `ap.visualEditor.breadcrumbs.trail` filter when the
 	 * `artisanpack-ui/hooks` helper is available.
 	 *
 	 * @since 1.0.0
@@ -138,7 +138,7 @@ class BreadcrumbsResolver
 		$trail = $this->defaultTrail( $post );
 
 		if ( function_exists( 'applyFilters' ) ) {
-			$filtered = applyFilters( 'ap.visual-editor.breadcrumbs.trail', $trail, $post, $attributes );
+			$filtered = applyFilters( 'ap.visualEditor.breadcrumbs.trail', $trail, $post, $attributes );
 
 			if ( is_array( $filtered ) ) {
 				$trail = $filtered;

--- a/packages/visual-editor-renderer-blade/src/Resolvers/LoginoutResolver.php
+++ b/packages/visual-editor-renderer-blade/src/Resolvers/LoginoutResolver.php
@@ -19,7 +19,7 @@
  *
  * Hosts that need fully custom resolution (per-tenant URLs, third-
  * party SSO, etc.) override the envelope through the
- * `ap.visual-editor.loginout.envelope` filter hook — the resolver
+ * `ap.visualEditor.loginout.envelope` filter hook — the resolver
  * applies the filter against the resolved defaults before returning.
  *
  * @package    ArtisanPack_UI
@@ -106,7 +106,7 @@ class LoginoutResolver
 		];
 
 		if ( function_exists( 'applyFilters' ) ) {
-			$filtered = applyFilters( 'ap.visual-editor.loginout.envelope', $envelope, $attributes );
+			$filtered = applyFilters( 'ap.visualEditor.loginout.envelope', $envelope, $attributes );
 
 			if ( is_array( $filtered ) ) {
 				$envelope = array_merge( $envelope, $filtered );
@@ -200,7 +200,7 @@ class LoginoutResolver
 	 *
 	 * The package ships no login form of its own; hosts return their
 	 * preferred form (typically a Blade view) via the
-	 * `ap.visual-editor.loginout.login-form` filter. The empty string
+	 * `ap.visualEditor.loginout.loginForm` filter. The empty string
 	 * disables the form display and the partial falls back to the
 	 * link variant.
 	 *
@@ -212,7 +212,7 @@ class LoginoutResolver
 			return '';
 		}
 
-		$html = applyFilters( 'ap.visual-editor.loginout.login-form', '', $currentUrl );
+		$html = applyFilters( 'ap.visualEditor.loginout.loginForm', '', $currentUrl );
 
 		return $this->coerceString( $html );
 	}

--- a/packages/visual-editor-renderer-blade/src/View/Components/BlocksComponent.php
+++ b/packages/visual-editor-renderer-blade/src/View/Components/BlocksComponent.php
@@ -146,7 +146,7 @@ class BlocksComponent extends Component
 		// `PostResolver` it tolerates a null `$post` (homepage, 404,
 		// archive without a single record in scope) and still produces a
 		// usable trail (just the "Home" entry, marked current). Hosts
-		// extend the trail through the `ap.visual-editor.breadcrumbs.trail`
+		// extend the trail through the `ap.visualEditor.breadcrumbs.trail`
 		// filter; see `BreadcrumbsResolver::buildTrail()`.
 		$resolved = $resolveBreadcrumbs
 			? $this->breadcrumbsResolver->stampTree( $resolved, is_object( $post ) ? $post : null )

--- a/packages/visual-editor-renderer-blade/tests/Feature/BreadcrumbsResolverTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Feature/BreadcrumbsResolverTest.php
@@ -19,7 +19,7 @@ declare( strict_types=1 );
  * - 404 / no post context still produces a `Home (current)` shell.
  * - The `breadcrumbsSchema` attribute is honored (the resolver is
  *   indifferent; the markup carries Schema.org itemtype attributes).
- * - Host filters through `ap.visual-editor.breadcrumbs.trail` override /
+ * - Host filters through `ap.visualEditor.breadcrumbs.trail` override /
  *   extend the trail without subclassing the resolver.
  * - Pre-stamped `_resolvedTrail` on the saved tree wins over the
  *   resolver fallback so a host that has resolved upstream keeps control.
@@ -62,7 +62,7 @@ function breadcrumbsFakePost( int $id, string $title, string $permalink = '', ?o
 
 beforeEach( function (): void {
 	if ( function_exists( 'removeAllFilters' ) ) {
-		removeAllFilters( 'ap.visual-editor.breadcrumbs.trail' );
+		removeAllFilters( 'ap.visualEditor.breadcrumbs.trail' );
 	}
 
 	config()->set( 'artisanpack.visual-editor.breadcrumbs.home_url', null );
@@ -210,7 +210,7 @@ it( 'allows hosts to override the trail through the filter hook', function () {
 		return;
 	}
 
-	addFilter( 'ap.visual-editor.breadcrumbs.trail', function ( array $trail, ?object $post, array $attributes ): array {
+	addFilter( 'ap.visualEditor.breadcrumbs.trail', function ( array $trail, ?object $post, array $attributes ): array {
 		return [
 			[ 'label' => 'Custom Home', 'url' => 'https://example.test/' ],
 			[ 'label' => 'Category: Travel', 'url' => '/category/travel' ],
@@ -241,7 +241,7 @@ it( 'passes the block attributes to the filter so hosts can branch on them', fun
 
 	$capturedAttrs = null;
 
-	addFilter( 'ap.visual-editor.breadcrumbs.trail', function ( array $trail, ?object $post, array $attributes ) use ( &$capturedAttrs ): array {
+	addFilter( 'ap.visualEditor.breadcrumbs.trail', function ( array $trail, ?object $post, array $attributes ) use ( &$capturedAttrs ): array {
 		$capturedAttrs = $attributes;
 
 		return $trail;
@@ -344,7 +344,7 @@ it( 'drops trail entries with blank labels through the filter', function () {
 		return;
 	}
 
-	addFilter( 'ap.visual-editor.breadcrumbs.trail', function ( array $trail, ?object $post, array $attributes ): array {
+	addFilter( 'ap.visualEditor.breadcrumbs.trail', function ( array $trail, ?object $post, array $attributes ): array {
 		return [
 			[ 'label' => 'Home', 'url' => '/' ],
 			[ 'label' => '', 'url' => '/dropped' ],

--- a/packages/visual-editor-renderer-blade/tests/Feature/LoginoutResolverTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Feature/LoginoutResolverTest.php
@@ -47,8 +47,8 @@ beforeEach( function (): void {
 	// Reset any custom URL filter from a prior case so each test starts
 	// from the same envelope baseline.
 	if ( function_exists( 'removeAllFilters' ) ) {
-		removeAllFilters( 'ap.visual-editor.loginout.envelope' );
-		removeAllFilters( 'ap.visual-editor.loginout.login-form' );
+		removeAllFilters( 'ap.visualEditor.loginout.envelope' );
+		removeAllFilters( 'ap.visualEditor.loginout.loginForm' );
 	}
 } );
 
@@ -123,7 +123,7 @@ it( 'honors a configured named login route over the literal path fallback', func
 
 it( 'shows the host-supplied login form for logged-out viewers when displayLoginAsForm is on', function () {
 	addFilter(
-		'ap.visual-editor.loginout.login-form',
+		'ap.visualEditor.loginout.loginForm',
 		fn ( string $_, string $current ): string => '<form data-test-form data-redirect="' . htmlspecialchars( $current ) . '"></form>'
 	);
 
@@ -142,7 +142,7 @@ it( 'shows the host-supplied login form for logged-out viewers when displayLogin
 
 it( 'keeps the logout link for logged-in viewers even when displayLoginAsForm is on', function () {
 	addFilter(
-		'ap.visual-editor.loginout.login-form',
+		'ap.visualEditor.loginout.loginForm',
 		fn (): string => '<form data-test-form></form>'
 	);
 
@@ -181,9 +181,9 @@ it( 'lets host-stamped resolved attributes win over the resolver fallback', func
 		->toContain( 'custom-class' );
 } );
 
-it( 'lets a host filter rewrite the resolved envelope through ap.visual-editor.loginout.envelope', function () {
+it( 'lets a host filter rewrite the resolved envelope through ap.visualEditor.loginout.envelope', function () {
 	addFilter(
-		'ap.visual-editor.loginout.envelope',
+		'ap.visualEditor.loginout.envelope',
 		fn ( array $envelope ): array => array_merge( $envelope, [
 			'url'   => 'https://sso.example/login',
 			'label' => 'Continue with SSO',
@@ -242,7 +242,7 @@ it( 'omits the has-login-form class when displayLoginAsForm is on but no host fo
 	// Matches the Blade partial's $showForm gate: the modifier class
 	// should only appear when a form will actually render. The resolver
 	// returns an empty loginFormHtml when the host hasn't wired the
-	// `ap.visual-editor.loginout.login-form` filter, so the wrapper
+	// `ap.visualEditor.loginout.loginForm` filter, so the wrapper
 	// must NOT promise a form that isn't there.
 	$rendered = $this->stripGlobalStyles( loginoutRenderTree( [
 		loginoutBlockNode( [

--- a/packages/visual-editor-renderer-blade/tests/Unit/BlockRendererTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Unit/BlockRendererTest.php
@@ -1229,10 +1229,10 @@ it( 'emits nothing for artisanpack/previous-post when no adjacent post is resolv
 	expect( $html )->toBe( '' );
 } );
 
-describe( 'ap.visual-editor.rendered-block filter', function (): void {
+describe( 'ap.visualEditor.renderedBlock filter', function (): void {
 	beforeEach( function (): void {
 		if ( function_exists( 'removeAllFilters' ) ) {
-			removeAllFilters( 'ap.visual-editor.rendered-block' );
+			removeAllFilters( 'ap.visualEditor.renderedBlock' );
 		}
 	} );
 
@@ -1243,7 +1243,7 @@ describe( 'ap.visual-editor.rendered-block filter', function (): void {
 			return;
 		}
 
-		addFilter( 'ap.visual-editor.rendered-block', function ( string $html, string $name ): string {
+		addFilter( 'ap.visualEditor.renderedBlock', function ( string $html, string $name ): string {
 			if ( 'core/paragraph' !== $name ) {
 				return $html;
 			}
@@ -1279,7 +1279,7 @@ describe( 'ap.visual-editor.rendered-block filter', function (): void {
 			}
 		} );
 
-		addFilter( 'ap.visual-editor.rendered-block', function ( string $html, string $name ): string {
+		addFilter( 'ap.visualEditor.renderedBlock', function ( string $html, string $name ): string {
 			if ( 'acme/filter-target' !== $name ) {
 				return $html;
 			}
@@ -1303,7 +1303,7 @@ describe( 'ap.visual-editor.rendered-block filter', function (): void {
 
 		$names = [];
 
-		addFilter( 'ap.visual-editor.rendered-block', function ( string $html, string $name ) use ( &$names ): string {
+		addFilter( 'ap.visualEditor.renderedBlock', function ( string $html, string $name ) use ( &$names ): string {
 			$names[] = $name;
 
 			return $html;
@@ -1331,7 +1331,7 @@ describe( 'ap.visual-editor.rendered-block filter', function (): void {
 			return;
 		}
 
-		addFilter( 'ap.visual-editor.rendered-block', function ( string $html ): array {
+		addFilter( 'ap.visualEditor.renderedBlock', function ( string $html ): array {
 			// A callback that forgets to return a string must not
 			// replace the HTML — otherwise the renderer would emit
 			// something like `Array` on `__toString`.
@@ -1352,7 +1352,7 @@ describe( 'ap.visual-editor.rendered-block filter', function (): void {
 
 		$capturedAttrs = null;
 
-		addFilter( 'ap.visual-editor.rendered-block', function ( string $html, string $name, array $attributes ) use ( &$capturedAttrs ): string {
+		addFilter( 'ap.visualEditor.renderedBlock', function ( string $html, string $name, array $attributes ) use ( &$capturedAttrs ): string {
 			if ( 'core/site-title' === $name ) {
 				$capturedAttrs = $attributes;
 			}

--- a/resources/js/visual-editor/background-controls/__tests__/background-controls.test.ts
+++ b/resources/js/visual-editor/background-controls/__tests__/background-controls.test.ts
@@ -41,8 +41,8 @@ async function loadModule(): Promise<
 }
 
 function registerFilter(callback: FilterCallback): void {
-    filters.set('ap.visual-editor.background-controls', [
-        ...(filters.get('ap.visual-editor.background-controls') ?? []),
+    filters.set('ap.visualEditor.backgroundControls', [
+        ...(filters.get('ap.visualEditor.backgroundControls') ?? []),
         callback,
     ]);
 }
@@ -334,7 +334,7 @@ describe('getFilteredBackgroundControls', () => {
         const { BACKGROUND_CONTROLS_FILTER } = await loadModule();
 
         expect(BACKGROUND_CONTROLS_FILTER).toBe(
-            'ap.visual-editor.background-controls'
+            'ap.visualEditor.backgroundControls'
         );
     });
 });

--- a/resources/js/visual-editor/background-controls/__tests__/with-background-controls.test.tsx
+++ b/resources/js/visual-editor/background-controls/__tests__/with-background-controls.test.tsx
@@ -82,8 +82,8 @@ vi.mock('@wordpress/blocks', () => ({
 }));
 
 function registerFilter(callback: FilterCallback): void {
-    filters.set('ap.visual-editor.background-controls', [
-        ...(filters.get('ap.visual-editor.background-controls') ?? []),
+    filters.set('ap.visualEditor.backgroundControls', [
+        ...(filters.get('ap.visualEditor.backgroundControls') ?? []),
         callback,
     ]);
 }

--- a/resources/js/visual-editor/background-controls/background-controls.ts
+++ b/resources/js/visual-editor/background-controls/background-controls.ts
@@ -6,7 +6,7 @@
  * External packages register their controls via `@wordpress/hooks`:
  *
  *     addFilter(
- *         'ap.visual-editor.background-controls',
+ *         'ap.visualEditor.backgroundControls',
  *         'my-package/glass',
  *         (controls, { attributes, setAttributes, blockSupports }) => {
  *             if ( ! blockSupports.background ) {
@@ -38,7 +38,7 @@ import { applyFilters } from '@wordpress/hooks';
 import type { ReactNode } from 'react';
 
 /** Filter name — exported so hosts can type against a constant. */
-export const BACKGROUND_CONTROLS_FILTER = 'ap.visual-editor.background-controls';
+export const BACKGROUND_CONTROLS_FILTER = 'ap.visualEditor.backgroundControls';
 
 /** Default priority for controls that don't set one. */
 export const DEFAULT_BACKGROUND_CONTROL_PRIORITY = 10;

--- a/resources/js/visual-editor/editor/__tests__/canvas-styles.filter.test.ts
+++ b/resources/js/visual-editor/editor/__tests__/canvas-styles.filter.test.ts
@@ -47,7 +47,7 @@ async function loadCanvasStyles(): Promise<
 }
 
 function registerCanvasStylesFilter(callback: FilterCallback): void {
-    filters.set('ap.visual-editor.canvas-styles', [callback]);
+    filters.set('ap.visualEditor.canvasStyles', [callback]);
 }
 
 describe('ap.visual-editor.canvas-styles filter', () => {

--- a/resources/js/visual-editor/editor/canvas-styles.ts
+++ b/resources/js/visual-editor/editor/canvas-styles.ts
@@ -233,7 +233,7 @@ const baseCanvasStyles: CanvasStyle[] = [
  * TIMING: `applyFilters` runs synchronously at module-load time inside
  * the IIFE below and the resulting `canvasStyles` export is frozen for
  * the rest of the session. Callbacks MUST be registered
- * (`addFilter('ap.visual-editor.canvas-styles', …)`) before this
+ * (`addFilter('ap.visualEditor.canvasStyles', …)`) before this
  * module is first imported — typically from a top-level side-effect
  * import that appears before the editor bundle in the app's entry
  * graph. Filters registered after the first import silently no-op:
@@ -241,7 +241,7 @@ const baseCanvasStyles: CanvasStyle[] = [
  */
 export const canvasStyles: readonly CanvasStyle[] = ( (): CanvasStyle[] => {
     const filtered = applyFilters(
-        'ap.visual-editor.canvas-styles',
+        'ap.visualEditor.canvasStyles',
         [...baseCanvasStyles],
     );
 

--- a/resources/js/visual-editor/editor/main.tsx
+++ b/resources/js/visual-editor/editor/main.tsx
@@ -11,6 +11,14 @@
 import { createElement } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 
+import { registerHookAliases } from '../support/hook-aliases';
+
+// Install #664 hook-name aliases at module load — before any first-party
+// or downstream block registration runs — so subscribers using the old
+// (kebab-case) hook names continue to fire when the editor applies the
+// new (camelCase) canonical names.
+registerHookAliases();
+
 import '../a11y.css';
 
 import type {

--- a/resources/js/visual-editor/editor/plugin-document-setting-panel.tsx
+++ b/resources/js/visual-editor/editor/plugin-document-setting-panel.tsx
@@ -37,7 +37,7 @@ const { Slot, Fill } = createSlotFill(SLOT_NAME);
  * Exported so host code can type-check the filter name against this
  * constant instead of hand-typing the string.
  */
-export const DOCUMENT_PANELS_FILTER = 'ap.visual-editor.document-panels';
+export const DOCUMENT_PANELS_FILTER = 'ap.visualEditor.documentPanels';
 
 export interface DocumentPanelSpec {
     /** Stable identifier; used as the React `key` and `data-panel-name`. */

--- a/resources/js/visual-editor/site-editor/main.tsx
+++ b/resources/js/visual-editor/site-editor/main.tsx
@@ -15,6 +15,13 @@
 import { createElement } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 
+import { registerHookAliases } from '../support/hook-aliases';
+
+// Install #664 hook-name aliases at module load. See editor/main.tsx for
+// the rationale — the site-editor shares the same hook surface as the
+// post editor.
+registerHookAliases();
+
 import '../a11y.css';
 import type { BreakpointRegistrySnapshot } from '../responsive/types';
 

--- a/resources/js/visual-editor/support/__tests__/hook-aliases.test.ts
+++ b/resources/js/visual-editor/support/__tests__/hook-aliases.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Tests for `resources/js/visual-editor/support/hook-aliases.ts` (#664).
+ *
+ * Confirms bidirectional passthrough between renamed hook pairs, no
+ * infinite recursion when both names carry subscribers, and idempotent
+ * registration.
+ */
+
+import { addFilter, applyFilters, removeAllFilters } from '@wordpress/hooks';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+    __resetHookAliasesForTests,
+    registerHookAliases,
+} from '../hook-aliases';
+
+const OLD_RESOURCES = 'ap.visual-editor.resources';
+const NEW_RESOURCES = 'ap.visualEditor.resources';
+const OLD_TEMPLATES = 'ap.visual-editor.templates';
+const NEW_TEMPLATES = 'ap.visualEditor.templates';
+const OLD_RENDERED = 'ap.visual-editor.rendered-block';
+const NEW_RENDERED = 'ap.visualEditor.renderedBlock';
+
+const ALL_PAIRS: ReadonlyArray<readonly [string, string]> = [
+    [OLD_RESOURCES, NEW_RESOURCES],
+    [OLD_TEMPLATES, NEW_TEMPLATES],
+    [OLD_RENDERED, NEW_RENDERED],
+];
+
+function clearAll(): void {
+    for (const [oldName, newName] of ALL_PAIRS) {
+        removeAllFilters(oldName);
+        removeAllFilters(newName);
+    }
+}
+
+describe('registerHookAliases', () => {
+    beforeEach(() => {
+        __resetHookAliasesForTests();
+        clearAll();
+        registerHookAliases();
+    });
+
+    afterEach(() => {
+        __resetHookAliasesForTests();
+        clearAll();
+    });
+
+    it('routes old-name subscribers when new name is applied', () => {
+        let seen: unknown = null;
+        addFilter(
+            OLD_RESOURCES,
+            'test/old-subscriber',
+            (value: unknown) => {
+                seen = value;
+                return value;
+            },
+        );
+
+        const result = applyFilters(NEW_RESOURCES, { key: 'value' });
+
+        expect(seen).toEqual({ key: 'value' });
+        expect(result).toEqual({ key: 'value' });
+    });
+
+    it('routes new-name subscribers when old name is applied', () => {
+        let seen: unknown = null;
+        addFilter(
+            NEW_TEMPLATES,
+            'test/new-subscriber',
+            (value: unknown) => {
+                seen = value;
+                return value;
+            },
+        );
+
+        const result = applyFilters(OLD_TEMPLATES, ['a', 'b']);
+
+        expect(seen).toEqual(['a', 'b']);
+        expect(result).toEqual(['a', 'b']);
+    });
+
+    it('does not recurse infinitely when both names carry subscribers', () => {
+        let oldCalls = 0;
+        let newCalls = 0;
+
+        addFilter(OLD_RENDERED, 'test/count-old', (value: unknown) => {
+            oldCalls += 1;
+            return value;
+        });
+        addFilter(NEW_RENDERED, 'test/count-new', (value: unknown) => {
+            newCalls += 1;
+            return value;
+        });
+
+        // Applying either name should fire each subscriber exactly once.
+        applyFilters(NEW_RENDERED, 'html');
+        expect(oldCalls).toBe(1);
+        expect(newCalls).toBe(1);
+
+        applyFilters(OLD_RENDERED, 'html');
+        expect(oldCalls).toBe(2);
+        expect(newCalls).toBe(2);
+    });
+
+    it('is idempotent — second registerHookAliases() does not double-fire subscribers', () => {
+        let calls = 0;
+        addFilter(OLD_RESOURCES, 'test/idem', (value: unknown) => {
+            calls += 1;
+            return value;
+        });
+
+        registerHookAliases();
+        registerHookAliases();
+
+        applyFilters(NEW_RESOURCES, 'x');
+
+        expect(calls).toBe(1);
+    });
+});

--- a/resources/js/visual-editor/support/hook-aliases.ts
+++ b/resources/js/visual-editor/support/hook-aliases.ts
@@ -1,0 +1,185 @@
+/**
+ * JS hook name deprecation aliases.
+ *
+ * Issue #664 renamed every visual-editor hook from kebab-case to camelCase.
+ * The PHP side installs aliases via `deprecateHook()` from the
+ * `artisanpack-ui/hooks` package. `@wordpress/hooks` has no equivalent
+ * primitive, so this module installs bidirectional passthrough filters that
+ * route:
+ *
+ *   applyFilters(OLD, value, ...args)  →  new-name subscribers fire
+ *   applyFilters(NEW, value, ...args)  →  old-name subscribers still fire
+ *
+ * The alias handlers are registered at `Number.MIN_SAFE_INTEGER` priority
+ * so they always run *before* any real subscribers on the applied hook —
+ * that way real subscribers on the paired name are surfaced first via a
+ * nested `applyFilters(other, ...)` call, and the applied name's real
+ * subscribers then run in their natural priority order relative to the
+ * value that came out of the paired chain. This matches the "collect
+ * callbacks from every alias then dispatch in unified priority order"
+ * behavior of PHP `ManagesHookBuckets` (hooks 1.3) closely enough for the
+ * hook shapes visual-editor exposes.
+ *
+ * To avoid infinite recursion — the old-name filter re-applies the new
+ * name, whose own alias would re-apply the old name — a module-level
+ * re-entry counter guards each hook. A counter (not a Set) is required so
+ * nested `applyFilters` on the same hook name from user callbacks does
+ * not clear a guard the outer invocation set. Registration is idempotent
+ * via a separate `registeredPairs` Set.
+ *
+ * Call {@link registerHookAliases} once at the top of every editor bootstrap
+ * entry (post editor, site editor, sandbox) before any block registration
+ * runs, so subscribers registered by first-party or third-party code fire
+ * regardless of which name they used.
+ */
+
+import { addFilter, applyFilters } from '@wordpress/hooks';
+
+/**
+ * Priority slot for the alias forward/reverse handlers. `MIN_SAFE_INTEGER`
+ * so no realistic host-supplied priority puts a real subscriber ahead of
+ * the alias fan-out. Kept as a named constant so the intent is explicit.
+ */
+const ALIAS_PRIORITY = Number.MIN_SAFE_INTEGER;
+
+/**
+ * The exhaustive old-name → new-name rename table. Kept in lock-step with
+ * `ArtisanPackUI\VisualEditor\Support\HookAliases::RENAMES` on the PHP
+ * side. The three JS-only hooks (background-controls, canvas-styles,
+ * document-panels) live only here — they have no PHP counterpart.
+ */
+const RENAMES: ReadonlyArray<readonly [string, string]> = [
+    ['ap.visual-editor.resources', 'ap.visualEditor.resources'],
+    ['ap.visual-editor.templates', 'ap.visualEditor.templates'],
+    ['ap.visual-editor.template-parts', 'ap.visualEditor.templateParts'],
+    ['ap.visual-editor.patterns', 'ap.visualEditor.patterns'],
+    ['ap.visual-editor.global-styles', 'ap.visualEditor.globalStyles'],
+    ['ap.visual-editor.navigation', 'ap.visualEditor.navigation'],
+    [
+        'ap.visual-editor.visibility.register-rules',
+        'ap.visualEditor.visibility.registerRules',
+    ],
+    [
+        'ap.visual-editor.visibility.evaluated',
+        'ap.visualEditor.visibility.evaluated',
+    ],
+    [
+        'ap.visual-editor.visibility.user-search-results',
+        'ap.visualEditor.visibility.userSearchResults',
+    ],
+    ['ap.visual-editor.rendered-block', 'ap.visualEditor.renderedBlock'],
+    ['ap.visual-editor.breadcrumbs.trail', 'ap.visualEditor.breadcrumbs.trail'],
+    [
+        'ap.visual-editor.loginout.envelope',
+        'ap.visualEditor.loginout.envelope',
+    ],
+    [
+        'ap.visual-editor.loginout.login-form',
+        'ap.visualEditor.loginout.loginForm',
+    ],
+    ['ap.icons.register-icon-sets', 'ap.icons.registerIconSets'],
+    // JS-only hooks (no PHP counterpart) — renamed for surface consistency.
+    [
+        'ap.visual-editor.background-controls',
+        'ap.visualEditor.backgroundControls',
+    ],
+    ['ap.visual-editor.canvas-styles', 'ap.visualEditor.canvasStyles'],
+    ['ap.visual-editor.document-panels', 'ap.visualEditor.documentPanels'],
+];
+
+/**
+ * Pairs already installed this process. Guards `registerHookAliases()`
+ * from double-registering.
+ */
+const registeredPairs = new Set<string>();
+
+/**
+ * Per-hook re-entry counter. Incremented before a nested `applyFilters`
+ * routes to the paired name and decremented in `finally`. A callback that
+ * itself calls `applyFilters(sameHook, ...)` nests safely because each
+ * entry has its own increment/decrement pair.
+ */
+const reentryDepth = new Map<string, number>();
+
+function enter(hook: string): void {
+    reentryDepth.set(hook, (reentryDepth.get(hook) ?? 0) + 1);
+}
+
+function leave(hook: string): void {
+    const current = reentryDepth.get(hook) ?? 0;
+    if (current <= 1) {
+        reentryDepth.delete(hook);
+    } else {
+        reentryDepth.set(hook, current - 1);
+    }
+}
+
+function isReentering(hook: string): boolean {
+    return (reentryDepth.get(hook) ?? 0) > 0;
+}
+
+/**
+ * Install bidirectional aliases for every hook renamed in #664.
+ *
+ * Idempotent — a re-invocation is a no-op.
+ */
+export function registerHookAliases(): void {
+    for (const [oldName, newName] of RENAMES) {
+        const key = `${oldName}=>${newName}`;
+        if (registeredPairs.has(key)) {
+            continue;
+        }
+        registeredPairs.add(key);
+
+        // Old → new: subscribers to `applyFilters(oldName, ...)` still get
+        // to influence the value even though everything now applies under
+        // the new name.
+        addFilter(
+            oldName,
+            'artisanpack-ui/visual-editor/hook-alias-forward',
+            (value: unknown, ...args: unknown[]): unknown => {
+                if (isReentering(oldName)) {
+                    return value;
+                }
+                enter(newName);
+                try {
+                    return applyFilters(newName, value, ...args);
+                } finally {
+                    leave(newName);
+                }
+            },
+            ALIAS_PRIORITY,
+        );
+
+        // New → old: subscribers to `applyFilters(newName, ...)` fire even
+        // when legacy code applies the old name.
+        addFilter(
+            newName,
+            'artisanpack-ui/visual-editor/hook-alias-reverse',
+            (value: unknown, ...args: unknown[]): unknown => {
+                if (isReentering(newName)) {
+                    return value;
+                }
+                enter(oldName);
+                try {
+                    return applyFilters(oldName, value, ...args);
+                } finally {
+                    leave(oldName);
+                }
+            },
+            ALIAS_PRIORITY,
+        );
+    }
+}
+
+/**
+ * Test-only helper — resets the module-level guards so a fresh
+ * `registerHookAliases()` call installs aliases again. Not exported from
+ * the package's public surface.
+ *
+ * @internal
+ */
+export function __resetHookAliasesForTests(): void {
+    registeredPairs.clear();
+    reentryDepth.clear();
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -257,7 +257,7 @@ Route::get( 'search', [ EntitySearchController::class, 'index' ] )
 // #492 — user autocomplete for the "Specific User" visibility rule's
 // InspectorControls picker. Read-only; short-circuits to an empty
 // list when the current session isn't authenticated. Hosts can filter
-// results via `ap.visual-editor.visibility.user-search-results`.
+// results via `ap.visualEditor.visibility.userSearchResults`.
 Route::get( 'users/search', [ UsersSearchController::class, 'index' ] )
 	->name( 'visual-editor.api.visibility.users.search' );
 
@@ -307,7 +307,7 @@ Route::delete( 'admin/icon-sets/{prefix}', [ IconSetsManagementController::class
 // G3 cms-framework Post + Page entity adapters — see plan 12 §4.4.
 // Both controllers resolve their model through `ResourceResolver`, so
 // the host's `posts` / `pages` slugs (registered statically or via
-// the `ap.visual-editor.resources` filter) determine the underlying
+// the `ap.visualEditor.resources` filter) determine the underlying
 // Eloquent class. The legacy `posts/{post}` routes that bound to
 // `VisualEditorPost` were removed at this point in the M3→G3
 // migration — host apps that still reference that model directly

--- a/src/Http/Controllers/Adapters/CmsFramework/PostController.php
+++ b/src/Http/Controllers/Adapters/CmsFramework/PostController.php
@@ -6,7 +6,7 @@
  * Pinned to the `posts` slug; resolves the underlying model class
  * through {@see ResourceResolver} so cms-framework's
  * `Modules\Blog\Models\Post` (registered via the
- * `ap.visual-editor.resources` filter) — or a host-app override — is
+ * `ap.visualEditor.resources` filter) — or a host-app override — is
  * served without this controller importing the class. That keeps the
  * package booting standalone.
  *

--- a/src/Http/Controllers/Adapters/CmsFramework/WpEntityController.php
+++ b/src/Http/Controllers/Adapters/CmsFramework/WpEntityController.php
@@ -5,7 +5,7 @@
  *
  * Generic CRUD scaffolding for any `HasBlockContent` Eloquent model
  * registered in `config('artisanpack.visual-editor.resources')` (or
- * contributed via the `ap.visual-editor.resources` filter from #397).
+ * contributed via the `ap.visualEditor.resources` filter from #397).
  * Handles `index`, `show`, `destroy`, and the shared persistence
  * helpers; concrete subclasses ({@see PostController},
  * {@see PageController}) own their typed `store`/`update` so each

--- a/src/Http/Controllers/SiteEditor/GlobalStylesController.php
+++ b/src/Http/Controllers/SiteEditor/GlobalStylesController.php
@@ -498,7 +498,7 @@ class GlobalStylesController extends Controller
 	{
 		$static = config( 'artisanpack.visual-editor.site-editor.global-styles' );
 		$static = is_array( $static ) ? $static : null;
-		$merged = applyFilters( 'ap.visual-editor.global-styles', $static );
+		$merged = applyFilters( 'ap.visualEditor.globalStyles', $static );
 		$merged = is_array( $merged ) ? $merged : $static;
 
 		$this->resolver = new GlobalStylesResolver( $merged );

--- a/src/Http/Controllers/SiteEditor/PatternController.php
+++ b/src/Http/Controllers/SiteEditor/PatternController.php
@@ -449,7 +449,7 @@ class PatternController extends Controller
 	protected function refreshResolver(): void
 	{
 		$static = (array) config( 'artisanpack.visual-editor.site-editor.patterns', [] );
-		$merged = applyFilters( 'ap.visual-editor.patterns', $static );
+		$merged = applyFilters( 'ap.visualEditor.patterns', $static );
 		$merged = is_array( $merged ) ? $merged : [];
 		$merged = array_merge( $merged, $static );
 

--- a/src/Http/Controllers/SiteEditor/TemplateController.php
+++ b/src/Http/Controllers/SiteEditor/TemplateController.php
@@ -601,7 +601,7 @@ class TemplateController extends Controller
 	protected function refreshResolver(): void
 	{
 		$static = (array) config( 'artisanpack.visual-editor.site-editor.templates', [] );
-		$merged = applyFilters( 'ap.visual-editor.templates', $static );
+		$merged = applyFilters( 'ap.visualEditor.templates', $static );
 		$merged = is_array( $merged ) ? $merged : [];
 		$merged = array_merge( $merged, $static );
 

--- a/src/Http/Controllers/SiteEditor/TemplatePartController.php
+++ b/src/Http/Controllers/SiteEditor/TemplatePartController.php
@@ -589,7 +589,7 @@ class TemplatePartController extends Controller
 	protected function refreshResolver(): void
 	{
 		$static = (array) config( 'artisanpack.visual-editor.site-editor.template-parts', [] );
-		$merged = applyFilters( 'ap.visual-editor.template-parts', $static );
+		$merged = applyFilters( 'ap.visualEditor.templateParts', $static );
 		$merged = is_array( $merged ) ? $merged : [];
 		$merged = array_merge( $merged, $static );
 

--- a/src/Http/Controllers/Visibility/UsersSearchController.php
+++ b/src/Http/Controllers/Visibility/UsersSearchController.php
@@ -10,7 +10,7 @@
  * The lookup is intentionally minimal — hosts with custom user models
  * or additional access constraints can rebind the controller through
  * the container, or filter results via the
- * `ap.visual-editor.visibility.user-search-results` filter.
+ * `ap.visualEditor.visibility.userSearchResults` filter.
  *
  * @package    ArtisanPack_UI
  * @subpackage VisualEditor
@@ -66,7 +66,7 @@ class UsersSearchController
 
 		if ( function_exists( 'applyFilters' ) ) {
 			try {
-				$filtered = applyFilters( 'ap.visual-editor.visibility.user-search-results', $rows, $term, $limit );
+				$filtered = applyFilters( 'ap.visualEditor.visibility.userSearchResults', $rows, $term, $limit );
 				if ( is_array( $filtered ) ) {
 					$rows = $filtered;
 				}

--- a/src/Resources/ResourceResolver.php
+++ b/src/Resources/ResourceResolver.php
@@ -35,7 +35,7 @@ class ResourceResolver
 	 *                                                         from
 	 *                                                         `config('artisanpack.visual-editor.resources')`
 	 *                                                         merged with the
-	 *                                                         `ap.visual-editor.resources` filter result.
+	 *                                                         `ap.visualEditor.resources` filter result.
 	 *                                                         The constructor performs no
 	 *                                                         validation on the entries — invalid
 	 *                                                         classes only surface on the first

--- a/src/Services/Icon/FontAwesomeFreeIconSets.php
+++ b/src/Services/Icon/FontAwesomeFreeIconSets.php
@@ -8,7 +8,7 @@
  * `resources/icons/font-awesome/{fas,far,fab}/` by `scripts/sync-fa-icons.mjs`.
  * This helper turns the on-disk layout into icon-set entries that the
  * `artisanpack-ui/icons` registry consumes via the
- * `ap.icons.register-icon-sets` filter.
+ * `ap.icons.registerIconSets` filter.
  *
  * @package    ArtisanPack_UI
  * @subpackage VisualEditor
@@ -73,7 +73,7 @@ final class FontAwesomeFreeIconSets
 	 * Register each discovered set on the supplied `IconSetRegistration`.
 	 *
 	 * Returns the same registry instance so this method can be used as the
-	 * body of an `ap.icons.register-icon-sets` filter callback. The
+	 * body of an `ap.icons.registerIconSets` filter callback. The
 	 * registry's `addSet()` throws when handed a non-existent path, which
 	 * is exactly why `discover()` filters them first — we want to no-op,
 	 * not blow up, when the FA Free directory is missing.

--- a/src/Services/Icon/IconSetUploader.php
+++ b/src/Services/Icon/IconSetUploader.php
@@ -38,7 +38,7 @@ use ZipArchive;
  *      icon landed — a zip that yields zero stored files is treated as a
  *      failed upload and no metadata is written.
  *
- * The uploader does NOT call into `ap.icons.register-icon-sets` itself —
+ * The uploader does NOT call into `ap.icons.registerIconSets` itself —
  * that happens at app boot, walking whatever the registry persisted.
  * Doing it here would skip the registration on the next process / queue
  * worker until the application rebooted, which would make uploaded

--- a/src/Services/Icon/IconSvgResolver.php
+++ b/src/Services/Icon/IconSvgResolver.php
@@ -5,7 +5,7 @@
  * the rendered Icon Block.
  *
  * The resolver is constructed once per request from the icon-sets
- * registry (`ap.icons.register-icon-sets` filter result) and cached as a
+ * registry (`ap.icons.registerIconSets` filter result) and cached as a
  * singleton. Lookups are file-system reads against the registered set
  * paths — bundled FA Free SVGs live under `resources/icons/font-awesome/`
  * after `scripts/sync-fa-icons.mjs` runs.
@@ -34,7 +34,7 @@ use Closure;
  * The path map can be supplied either eagerly (an `array` for tests +
  * fixtures) or lazily (a `Closure` that returns the array). The lazy
  * form is what production uses: the icon-sets registry is built from
- * the `ap.icons.register-icon-sets` filter, and that filter's
+ * the `ap.icons.registerIconSets` filter, and that filter's
  * callbacks are registered across multiple providers' `boot()` phases.
  * Running the filter at singleton-construction time would race against
  * those registrations — `IconBlock` is constructed early in `boot()`,

--- a/src/Services/Icon/UploadedIconSetRegistry.php
+++ b/src/Services/Icon/UploadedIconSetRegistry.php
@@ -6,7 +6,7 @@
  * Phase 6 (#557) of the Icon Block feature (#494). Persists set
  * metadata to `storage/app/artisanpack/visual-editor/icons/sets.json`
  * so the service provider can re-register uploaded sets against the
- * `ap.icons.register-icon-sets` filter on every boot without re-walking
+ * `ap.icons.registerIconSets` filter on every boot without re-walking
  * directories or re-validating zip uploads.
  *
  * @package    ArtisanPack_UI

--- a/src/SiteEditor/Exceptions/SiteEditorRegistrationException.php
+++ b/src/SiteEditor/Exceptions/SiteEditorRegistrationException.php
@@ -4,8 +4,8 @@
  * Site-editor registration exception.
  *
  * Thrown lazily — on the first {@see TemplateResolver::all()} (or sibling
- * resolver) call, never at boot — when an `ap.visual-editor.{templates,
- * template-parts,patterns,global-styles,navigation}` filter returns a
+ * resolver) call, never at boot — when an `ap.visualEditor.{templates,
+ * templateParts,patterns,globalStyles,navigation}` filter returns a
  * non-conforming shape or an entry is missing a required field.
  *
  * Lazy because `class_exists` registration sites in cms-framework register
@@ -36,7 +36,7 @@ class SiteEditorRegistrationException extends RuntimeException
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param  string  $filterName  The filter slug (e.g. `ap.visual-editor.templates`).
+	 * @param  string  $filterName  The filter slug (e.g. `ap.visualEditor.templates`).
 	 * @param  string  $expected    A short description of the expected shape.
 	 * @param  string  $actual      A short description of the actual shape.
 	 */

--- a/src/SiteEditor/Resolution/GlobalStylesResolver.php
+++ b/src/SiteEditor/Resolution/GlobalStylesResolver.php
@@ -5,7 +5,7 @@
  *
  * Singleton — one resolved object per active theme — distinct from the
  * map-shaped sibling resolvers. cms-framework's H3 GlobalStylesResolver
- * registers via `ap.visual-editor.global-styles`; H6 reads it through
+ * registers via `ap.visualEditor.globalStyles`; H6 reads it through
  * the `__unstableBase` REST adapter.
  *
  * @package    ArtisanPack_UI
@@ -25,7 +25,7 @@ class GlobalStylesResolver
 	/**
 	 * @since 1.0.0
 	 */
-	protected const FILTER_NAME = 'ap.visual-editor.global-styles';
+	protected const FILTER_NAME = 'ap.visualEditor.globalStyles';
 
 	/**
 	 * Raw filter input, deferred until first read.

--- a/src/SiteEditor/Resolution/MenuResolver.php
+++ b/src/SiteEditor/Resolution/MenuResolver.php
@@ -3,7 +3,7 @@
 /**
  * Site-editor menu (navigation) resolver.
  *
- * Consumes the merged `ap.visual-editor.navigation` filter result, keyed by
+ * Consumes the merged `ap.visualEditor.navigation` filter result, keyed by
  * theme-declared menu location.
  *
  * @package    ArtisanPack_UI
@@ -27,7 +27,7 @@ class MenuResolver extends AbstractMapResolver
 	 */
 	protected static function filterName(): string
 	{
-		return 'ap.visual-editor.navigation';
+		return 'ap.visualEditor.navigation';
 	}
 
 	/**

--- a/src/SiteEditor/Resolution/PatternResolver.php
+++ b/src/SiteEditor/Resolution/PatternResolver.php
@@ -3,7 +3,7 @@
 /**
  * Site-editor pattern resolver.
  *
- * Consumes the merged `ap.visual-editor.patterns` filter result. Patterns
+ * Consumes the merged `ap.visualEditor.patterns` filter result. Patterns
  * cover both theme-shipped (`source: 'theme'`, read-only) and user-authored
  * (`source: 'user'`, editable) entries — the value object's `synced` field
  * distinguishes WP `wp_block` (synced) from `wp_block_pattern` (unsynced).
@@ -29,7 +29,7 @@ class PatternResolver extends AbstractMapResolver
 	 */
 	protected static function filterName(): string
 	{
-		return 'ap.visual-editor.patterns';
+		return 'ap.visualEditor.patterns';
 	}
 
 	/**

--- a/src/SiteEditor/Resolution/ResolvedGlobalStyles.php
+++ b/src/SiteEditor/Resolution/ResolvedGlobalStyles.php
@@ -26,7 +26,7 @@ class ResolvedGlobalStyles
 	/**
 	 * @since 1.0.0
 	 */
-	protected const FILTER_NAME = 'ap.visual-editor.global-styles';
+	protected const FILTER_NAME = 'ap.visualEditor.globalStyles';
 
 	/**
 	 * @since 1.0.0

--- a/src/SiteEditor/Resolution/ResolvedMenu.php
+++ b/src/SiteEditor/Resolution/ResolvedMenu.php
@@ -5,7 +5,7 @@
  *
  * Maps a theme-declared location (`primary`, `footer`, etc.) to a menu
  * record + its menu items. cms-framework's `MenuResolver` (H4) populates
- * this through the `ap.visual-editor.navigation` filter; H6's
+ * this through the `ap.visualEditor.navigation` filter; H6's
  * `wp_navigation` REST adapter reads it.
  *
  * @package    ArtisanPack_UI
@@ -27,7 +27,7 @@ class ResolvedMenu
 	/**
 	 * @since 1.0.0
 	 */
-	protected const FILTER_NAME = 'ap.visual-editor.navigation';
+	protected const FILTER_NAME = 'ap.visualEditor.navigation';
 
 	/**
 	 * @since 1.0.0

--- a/src/SiteEditor/Resolution/ResolvedPattern.php
+++ b/src/SiteEditor/Resolution/ResolvedPattern.php
@@ -27,7 +27,7 @@ class ResolvedPattern
 	/**
 	 * @since 1.0.0
 	 */
-	protected const FILTER_NAME = 'ap.visual-editor.patterns';
+	protected const FILTER_NAME = 'ap.visualEditor.patterns';
 
 	/**
 	 * @since 1.0.0

--- a/src/SiteEditor/Resolution/ResolvedTemplate.php
+++ b/src/SiteEditor/Resolution/ResolvedTemplate.php
@@ -29,7 +29,7 @@ class ResolvedTemplate
 	 *
 	 * @since 1.0.0
 	 */
-	protected const FILTER_NAME = 'ap.visual-editor.templates';
+	protected const FILTER_NAME = 'ap.visualEditor.templates';
 
 	/**
 	 * @since 1.0.0

--- a/src/SiteEditor/Resolution/ResolvedTemplatePart.php
+++ b/src/SiteEditor/Resolution/ResolvedTemplatePart.php
@@ -26,7 +26,7 @@ class ResolvedTemplatePart extends ResolvedTemplate
 	/**
 	 * @since 1.0.0
 	 */
-	protected const FILTER_NAME = 'ap.visual-editor.template-parts';
+	protected const FILTER_NAME = 'ap.visualEditor.templateParts';
 
 	/**
 	 * V1 closed list of valid template-part areas. Mirrored from

--- a/src/SiteEditor/Resolution/TemplatePartResolver.php
+++ b/src/SiteEditor/Resolution/TemplatePartResolver.php
@@ -3,7 +3,7 @@
 /**
  * Site-editor template-part resolver.
  *
- * Consumes the merged `ap.visual-editor.template-parts` filter result.
+ * Consumes the merged `ap.visualEditor.templateParts` filter result.
  *
  * @package    ArtisanPack_UI
  * @subpackage VisualEditor
@@ -26,7 +26,7 @@ class TemplatePartResolver extends AbstractMapResolver
 	 */
 	protected static function filterName(): string
 	{
-		return 'ap.visual-editor.template-parts';
+		return 'ap.visualEditor.templateParts';
 	}
 
 	/**

--- a/src/SiteEditor/Resolution/TemplateResolver.php
+++ b/src/SiteEditor/Resolution/TemplateResolver.php
@@ -3,7 +3,7 @@
 /**
  * Site-editor template resolver.
  *
- * Consumes the merged `ap.visual-editor.templates` filter result and exposes
+ * Consumes the merged `ap.visualEditor.templates` filter result and exposes
  * a stable read surface to H6's WP-style REST adapters. Has no awareness of
  * where the data came from — that's cms-framework's H1 resolution job.
  *
@@ -28,7 +28,7 @@ class TemplateResolver extends AbstractMapResolver
 	 */
 	protected static function filterName(): string
 	{
-		return 'ap.visual-editor.templates';
+		return 'ap.visualEditor.templates';
 	}
 
 	/**

--- a/src/Support/HookAliases.php
+++ b/src/Support/HookAliases.php
@@ -1,0 +1,77 @@
+<?php
+
+/**
+ * Hook name deprecation aliases.
+ *
+ * Issue #664 renamed every visual-editor PHP hook (and the JS `ap.icons.*`
+ * bridge hook) from kebab-case to camelCase for consistency with the
+ * ArtisanPack UI ecosystem's naming convention. Existing host apps and
+ * downstream packages continue to subscribe under the old names, so this
+ * class installs alias entries via `deprecateHook()` (shipped by
+ * `artisanpack-ui/hooks` ^1.2) that route old-name subscribers to fire on
+ * the canonical (new) hook. A deprecation notice is logged the first time
+ * an alias resolves per process.
+ *
+ * {@see \deprecateHook()} for the underlying implementation. Called once,
+ * as early as possible, from {@see \ArtisanPackUI\VisualEditor\VisualEditorServiceProvider::boot()}.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.5.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Support;
+
+class HookAliases
+{
+	/**
+	 * The exhaustive old-name → new-name rename table for #664.
+	 *
+	 * The 13 visual-editor PHP hooks plus the `visual_editor.pre_publish_checks`
+	 * cross-package hook (fired by visual-editor, subscribed by seo). The
+	 * `ap.icons.register-icon-sets` alias is included defensively — the
+	 * canonical alias belongs to the `artisanpack-ui/icons` package, but
+	 * declaring it here is idempotent and protects hosts that install
+	 * visual-editor before the icons package publishes its own alias
+	 * registration.
+	 *
+	 * @var array<string, string>
+	 */
+	private const RENAMES = [
+		'ap.visual-editor.resources'                    => 'ap.visualEditor.resources',
+		'ap.visual-editor.templates'                    => 'ap.visualEditor.templates',
+		'ap.visual-editor.template-parts'               => 'ap.visualEditor.templateParts',
+		'ap.visual-editor.patterns'                     => 'ap.visualEditor.patterns',
+		'ap.visual-editor.global-styles'                => 'ap.visualEditor.globalStyles',
+		'ap.visual-editor.navigation'                   => 'ap.visualEditor.navigation',
+		'ap.visual-editor.visibility.register-rules'    => 'ap.visualEditor.visibility.registerRules',
+		'ap.visual-editor.visibility.evaluated'         => 'ap.visualEditor.visibility.evaluated',
+		'ap.visual-editor.visibility.user-search-results' => 'ap.visualEditor.visibility.userSearchResults',
+		'ap.visual-editor.rendered-block'               => 'ap.visualEditor.renderedBlock',
+		'ap.visual-editor.breadcrumbs.trail'            => 'ap.visualEditor.breadcrumbs.trail',
+		'ap.visual-editor.loginout.envelope'            => 'ap.visualEditor.loginout.envelope',
+		'ap.visual-editor.loginout.login-form'          => 'ap.visualEditor.loginout.loginForm',
+		'visual_editor.pre_publish_checks'              => 'ap.visualEditor.prePublishChecks',
+		'ap.icons.register-icon-sets'                   => 'ap.icons.registerIconSets',
+	];
+
+	/**
+	 * Register every deprecation alias in the rename table.
+	 *
+	 * Idempotent — safe to call multiple times. `deprecateHook()` is itself
+	 * idempotent per (old, new) pair.
+	 *
+	 * @since 1.5.0
+	 */
+	public static function registerAll(): void
+	{
+		foreach ( self::RENAMES as $old => $new ) {
+			deprecateHook( $old, $new );
+		}
+	}
+}

--- a/src/Visibility/RuleRegistry.php
+++ b/src/Visibility/RuleRegistry.php
@@ -5,7 +5,7 @@
  *
  * Rules are seeded from the built-in set by
  * {@see \ArtisanPackUI\VisualEditor\VisualEditorServiceProvider} and
- * extended by hosts through the `ap.visual-editor.visibility.register-rules`
+ * extended by hosts through the `ap.visualEditor.visibility.registerRules`
  * filter. The registry is stateless past construction: the evaluator asks
  * it for the full ordered rule list every time it walks a tree.
  *

--- a/src/Visibility/VisibilityDecision.php
+++ b/src/Visibility/VisibilityDecision.php
@@ -16,7 +16,7 @@
  *                        viewport size is a client-only signal.
  *
  * The `reasons` array is opaque and only used by the debug hook
- * (`ap.visual-editor.visibility.evaluated`) so the "why is this hidden?"
+ * (`ap.visualEditor.visibility.evaluated`) so the "why is this hidden?"
  * developer tooling can surface the failing rule name(s) without
  * reserving specific fields on the DTO.
  *

--- a/src/Visibility/VisibilityEvaluator.php
+++ b/src/Visibility/VisibilityEvaluator.php
@@ -17,7 +17,7 @@
  *      `artisanpackVisibility.{rule.key}` slice, combining the returned
  *      {@see VisibilityDecision}s. Any single `hidden()` wins outright.
  *
- * The `ap.visual-editor.visibility.evaluated` action fires once per
+ * The `ap.visualEditor.visibility.evaluated` action fires once per
  * block after evaluation completes, receiving `[decision, blockName,
  * attributes, context]` so a debug listener can answer "why is this
  * block hidden?" without instrumenting each rule.
@@ -267,7 +267,7 @@ class VisibilityEvaluator
 		}
 
 		try {
-			doAction( 'ap.visual-editor.visibility.evaluated', $decision, $name, $attributes, $context );
+			doAction( 'ap.visualEditor.visibility.evaluated', $decision, $name, $attributes, $context );
 		} catch ( Throwable $e ) {
 			report( $e );
 		}

--- a/src/VisualEditorServiceProvider.php
+++ b/src/VisualEditorServiceProvider.php
@@ -56,6 +56,7 @@ use ArtisanPackUI\VisualEditor\States\StateCssEmitter;
 use ArtisanPackUI\VisualEditor\States\StateRegistry;
 use ArtisanPackUI\VisualEditor\States\StateValueResolver;
 use ArtisanPackUI\VisualEditor\Search\BlockTreeSearchExtractor;
+use ArtisanPackUI\VisualEditor\Support\HookAliases;
 use ArtisanPackUI\VisualEditor\SiteEditor\Resolution\GlobalStylesResolver as SiteEditorGlobalStylesResolver;
 use ArtisanPackUI\VisualEditor\SiteEditor\Resolution\MenuResolver as SiteEditorMenuResolver;
 use ArtisanPackUI\VisualEditor\SiteEditor\Resolution\PatternResolver as SiteEditorPatternResolver;
@@ -179,7 +180,7 @@ class VisualEditorServiceProvider extends ServiceProvider
 		// Icon Block Phase 3 (#554): defer the icon-sets-registry walk
 		// until the first `resolve()` call. IconBlock is constructed
 		// inside boot() (via registerReferenceBlocks), which happens
-		// BEFORE every provider's `addFilter('ap.icons.register-icon-sets',
+		// BEFORE every provider's `addFilter('ap.icons.registerIconSets',
 		// …)` has fired. Computing the path map eagerly here would race
 		// against those registrations and produce an empty resolver. The
 		// closure runs at request time, by which point boot is finished
@@ -188,7 +189,7 @@ class VisualEditorServiceProvider extends ServiceProvider
 		// Issue #587: when `owenvoke/blade-fontawesome` is installed,
 		// `FontAwesomeFreeIconSets::register()` defers to it and stops
 		// publishing `fas` / `far` / `fab` through the
-		// `ap.icons.register-icon-sets` filter (so the icons-package
+		// `ap.icons.registerIconSets` filter (so the icons-package
 		// service provider doesn't collide on `BladeUI\Icons\Factory::add()`).
 		// The resolver still needs those paths to inline bundled FA Free
 		// SVGs for the picker and the rendered block, so we always seed
@@ -204,7 +205,7 @@ class VisualEditorServiceProvider extends ServiceProvider
 					return $paths;
 				}
 
-				$registry = applyFilters( 'ap.icons.register-icon-sets', new IconSetRegistration() );
+				$registry = applyFilters( 'ap.icons.registerIconSets', new IconSetRegistration() );
 				if ( ! $registry instanceof IconSetRegistration ) {
 					return $paths;
 				}
@@ -264,7 +265,7 @@ class VisualEditorServiceProvider extends ServiceProvider
 		// Bound here as a placeholder so other providers' register() phases
 		// can typehint ResourceResolver. The boot() phase rebinds with the
 		// final filter-merged map once all providers have registered their
-		// `ap.visual-editor.resources` callbacks.
+		// `ap.visualEditor.resources` callbacks.
 		$this->app->singleton( ResourceResolver::class, function () {
 			return new ResourceResolver();
 		} );
@@ -272,7 +273,7 @@ class VisualEditorServiceProvider extends ServiceProvider
 		// H5 — site-editor resolvers. Same pattern as ResourceResolver
 		// above: empty placeholders here; boot() rebinds with the filter-
 		// merged data once all providers have registered their
-		// `ap.visual-editor.{templates,template-parts,patterns,
+		// `ap.visualEditor.{templates,templateParts,patterns,
 		// global-styles,navigation}` callbacks.
 		$this->app->singleton( SiteEditorTemplateResolver::class, function () {
 			return new SiteEditorTemplateResolver();
@@ -417,7 +418,7 @@ class VisualEditorServiceProvider extends ServiceProvider
 			// Resolve editor-authored keyframes from the same filter-
 			// merged global-styles payload that `SiteEditorGlobalStylesResolver`
 			// consumes, so a host that registers global styles through
-			// the `ap.visual-editor.global-styles` filter (cms-framework
+			// the `ap.visualEditor.globalStyles` filter (cms-framework
 			// being the canonical caller) sees its custom keyframes
 			// reach the editor and renderer. Reading directly from
 			// config would miss the filter contributions.
@@ -453,7 +454,7 @@ class VisualEditorServiceProvider extends ServiceProvider
 		// stateless (safe singleton). `ScheduledBlockCollector` is a
 		// pure walker (safe singleton). The `VisibilityRuleRegistry`
 		// is scoped per request because the built-in rule set is
-		// merged with the `ap.visual-editor.visibility.register-rules`
+		// merged with the `ap.visualEditor.visibility.registerRules`
 		// filter, and third-party rule providers may register with
 		// per-request container state (route parameters, tenant
 		// context, etc.). The `VisibilityEvaluator` is also scoped so
@@ -469,7 +470,7 @@ class VisualEditorServiceProvider extends ServiceProvider
 		} );
 
 		// The scoped closure only assembles the built-in rule set —
-		// the `ap.visual-editor.visibility.register-rules` filter is
+		// the `ap.visualEditor.visibility.registerRules` filter is
 		// applied via `extend()` in `boot()` (see
 		// `applyVisibilityRulesFilter()`). Extending inside the closure
 		// would freeze the filter chain state at first-resolve time,
@@ -576,7 +577,7 @@ class VisualEditorServiceProvider extends ServiceProvider
 	}
 
 	/**
-	 * Layer the `ap.visual-editor.visibility.register-rules` filter
+	 * Layer the `ap.visualEditor.visibility.registerRules` filter
 	 * over every fresh {@see VisibilityRuleRegistry} instance.
 	 *
 	 * Registered in `boot()` via {@see \Illuminate\Container\Container::extend()}
@@ -598,7 +599,7 @@ class VisualEditorServiceProvider extends ServiceProvider
 		$this->app->extend(
 			VisibilityRuleRegistry::class,
 			static function ( VisibilityRuleRegistry $registry ): VisibilityRuleRegistry {
-				$filtered = applyFilters( 'ap.visual-editor.visibility.register-rules', $registry );
+				$filtered = applyFilters( 'ap.visualEditor.visibility.registerRules', $registry );
 				return $filtered instanceof VisibilityRuleRegistry ? $filtered : $registry;
 			},
 		);
@@ -612,6 +613,12 @@ class VisualEditorServiceProvider extends ServiceProvider
 	 */
 	public function boot(): void
 	{
+		// 0. Register hook name aliases (old → new) as early as possible in
+		//    boot() so any subsequent hook fire sites route legacy
+		//    subscribers to the canonical (camelCase) hook name. See
+		//    src/Support/HookAliases.php for the full rename table.
+		HookAliases::registerAll();
+
 		// 1. Merge the configuration correctly.
 		$this->mergeConfiguration();
 
@@ -627,7 +634,7 @@ class VisualEditorServiceProvider extends ServiceProvider
 			$this->registerSiteEditorResolvers();
 		} );
 
-		// 1b. Layer the `ap.visual-editor.visibility.register-rules`
+		// 1b. Layer the `ap.visualEditor.visibility.registerRules`
 		//     filter over the scoped registry via `extend()`. Runs at
 		//     resolve-time (after the closure builds the default set)
 		//     which means addFilter calls from any other provider's
@@ -683,7 +690,7 @@ class VisualEditorServiceProvider extends ServiceProvider
 
 		// 4.2. Icon Block Phase 6 (#557) — re-register host-uploaded
 		//      icon sets on every boot. Reads the persisted registry
-		//      and hooks the same `ap.icons.register-icon-sets` filter
+		//      and hooks the same `ap.icons.registerIconSets` filter
 		//      the bundled FA sets use, so the picker, the SVG
 		//      resolver, and the catalog all surface uploaded icons
 		//      without any further wiring.
@@ -873,7 +880,7 @@ class VisualEditorServiceProvider extends ServiceProvider
 	}
 
 	/**
-	 * Hook the FA Free SVG sets into the `ap.icons.register-icon-sets`
+	 * Hook the FA Free SVG sets into the `ap.icons.registerIconSets`
 	 * filter.
 	 *
 	 * Gated on the icons package being present so visual-editor still
@@ -893,7 +900,7 @@ class VisualEditorServiceProvider extends ServiceProvider
 		$baseDir = __DIR__ . '/../resources/icons/font-awesome';
 
 		addFilter(
-			'ap.icons.register-icon-sets',
+			'ap.icons.registerIconSets',
 			static function ( IconSetRegistration $registry ) use ( $baseDir ): IconSetRegistration {
 				return FontAwesomeFreeIconSets::register( $registry, $baseDir );
 			}
@@ -925,7 +932,7 @@ class VisualEditorServiceProvider extends ServiceProvider
 		}
 
 		addFilter(
-			'ap.visual-editor.patterns',
+			'ap.visualEditor.patterns',
 			static function ( mixed $patterns ): array {
 				$patterns = is_array( $patterns ) ? $patterns : [];
 
@@ -1060,7 +1067,7 @@ class VisualEditorServiceProvider extends ServiceProvider
 	/**
 	 * Builds the slug → model class map for ResourceResolver.
 	 *
-	 * Pipes the static config through the `ap.visual-editor.resources` filter
+	 * Pipes the static config through the `ap.visualEditor.resources` filter
 	 * (so packages like cms-framework can register their models at runtime),
 	 * then merges static config back on top so host-app entries always win on
 	 * key collision. ResourceResolver itself does not validate at construction
@@ -1076,7 +1083,7 @@ class VisualEditorServiceProvider extends ServiceProvider
 	public function registerResourceResolver(): void
 	{
 		$staticConfig = (array) config( 'artisanpack.visual-editor.resources', [] );
-		$filtered     = applyFilters( 'ap.visual-editor.resources', $staticConfig );
+		$filtered     = applyFilters( 'ap.visualEditor.resources', $staticConfig );
 		$filtered     = is_array( $filtered ) ? $filtered : [];
 
 		// Static config wins on key collision: host app entries take
@@ -1109,7 +1116,7 @@ class VisualEditorServiceProvider extends ServiceProvider
 	{
 		// Templates ─ array<string, array> keyed by slug.
 		$templatesStatic = (array) config( 'artisanpack.visual-editor.site-editor.templates', [] );
-		$templatesMerged = applyFilters( 'ap.visual-editor.templates', $templatesStatic );
+		$templatesMerged = applyFilters( 'ap.visualEditor.templates', $templatesStatic );
 		$templatesMerged = is_array( $templatesMerged ) ? $templatesMerged : [];
 		$templatesMerged = array_merge( $templatesMerged, $templatesStatic );
 
@@ -1120,7 +1127,7 @@ class VisualEditorServiceProvider extends ServiceProvider
 
 		// Template parts ─ array<string, array> keyed by slug.
 		$partsStatic = (array) config( 'artisanpack.visual-editor.site-editor.template-parts', [] );
-		$partsMerged = applyFilters( 'ap.visual-editor.template-parts', $partsStatic );
+		$partsMerged = applyFilters( 'ap.visualEditor.templateParts', $partsStatic );
 		$partsMerged = is_array( $partsMerged ) ? $partsMerged : [];
 		$partsMerged = array_merge( $partsMerged, $partsStatic );
 
@@ -1131,7 +1138,7 @@ class VisualEditorServiceProvider extends ServiceProvider
 
 		// Patterns ─ array<string, array> keyed by slug.
 		$patternsStatic = (array) config( 'artisanpack.visual-editor.site-editor.patterns', [] );
-		$patternsMerged = applyFilters( 'ap.visual-editor.patterns', $patternsStatic );
+		$patternsMerged = applyFilters( 'ap.visualEditor.patterns', $patternsStatic );
 		$patternsMerged = is_array( $patternsMerged ) ? $patternsMerged : [];
 		$patternsMerged = array_merge( $patternsMerged, $patternsStatic );
 
@@ -1145,7 +1152,7 @@ class VisualEditorServiceProvider extends ServiceProvider
 		// static config, the filter result is authoritative.
 		$globalStylesStatic = config( 'artisanpack.visual-editor.site-editor.global-styles', null );
 		$globalStylesStatic = is_array( $globalStylesStatic ) ? $globalStylesStatic : null;
-		$globalStylesMerged = applyFilters( 'ap.visual-editor.global-styles', $globalStylesStatic );
+		$globalStylesMerged = applyFilters( 'ap.visualEditor.globalStyles', $globalStylesStatic );
 		$globalStylesMerged = is_array( $globalStylesMerged ) ? $globalStylesMerged : null;
 		$globalStylesMerged = $globalStylesStatic ?? $globalStylesMerged;
 
@@ -1156,7 +1163,7 @@ class VisualEditorServiceProvider extends ServiceProvider
 
 		// Navigation ─ array<string, array> keyed by location.
 		$menusStatic = (array) config( 'artisanpack.visual-editor.site-editor.navigation', [] );
-		$menusMerged = applyFilters( 'ap.visual-editor.navigation', $menusStatic );
+		$menusMerged = applyFilters( 'ap.visualEditor.navigation', $menusStatic );
 		$menusMerged = is_array( $menusMerged ) ? $menusMerged : [];
 		$menusMerged = array_merge( $menusMerged, $menusStatic );
 
@@ -1192,7 +1199,7 @@ class VisualEditorServiceProvider extends ServiceProvider
 
 	/**
 	 * Hand the persisted uploaded icon sets to the
-	 * `ap.icons.register-icon-sets` filter.
+	 * `ap.icons.registerIconSets` filter.
 	 *
 	 * Phase 6 (#557). The {@see UploadedIconSetRegistry} only carries
 	 * metadata; the directories are managed by {@see IconSetUploader}.
@@ -1218,7 +1225,7 @@ class VisualEditorServiceProvider extends ServiceProvider
 		$app = $this->app;
 
 		addFilter(
-			'ap.icons.register-icon-sets',
+			'ap.icons.registerIconSets',
 			static function ( IconSetRegistration $registry ) use ( $app ): IconSetRegistration {
 				$persisted = $app->make( UploadedIconSetRegistry::class );
 
@@ -1318,10 +1325,10 @@ class VisualEditorServiceProvider extends ServiceProvider
 		// it through `registerUploadedIconSets()` — `IconSvgResolver`
 		// otherwise can't serve the SVG at click time, and the picker
 		// would render a black tile or a 404. Both paths now share one
-		// source of truth: the result of `ap.icons.register-icon-sets`.
+		// source of truth: the result of `ap.icons.registerIconSets`.
 		$registeredPrefixes = [];
 		if ( class_exists( IconSetRegistration::class ) && function_exists( 'applyFilters' ) ) {
-			$registry = applyFilters( 'ap.icons.register-icon-sets', new IconSetRegistration() );
+			$registry = applyFilters( 'ap.icons.registerIconSets', new IconSetRegistration() );
 			if ( $registry instanceof IconSetRegistration ) {
 				$registeredPrefixes = array_flip( array_keys( $registry->getSets() ) );
 			}

--- a/tests/Feature/SiteEditor/PatternControllerTest.php
+++ b/tests/Feature/SiteEditor/PatternControllerTest.php
@@ -113,7 +113,7 @@ describe( 'GET /visual-editor/api/patterns', function (): void {
 	// `post_types` whitelist match only when the requested slug is
 	// present; unscoped patterns (post_types null) match everywhere.
 	it( 'filters by ?post_type using each pattern\'s post_types scope (#639)', function (): void {
-		addFilter( 'ap.visual-editor.patterns', function ( mixed $patterns ): array {
+		addFilter( 'ap.visualEditor.patterns', function ( mixed $patterns ): array {
 			$patterns = is_array( $patterns ) ? $patterns : [];
 
 			$patterns['landing-hero'] = [

--- a/tests/Feature/VisualEditor/HookAliasesTest.php
+++ b/tests/Feature/VisualEditor/HookAliasesTest.php
@@ -1,0 +1,158 @@
+<?php
+
+/**
+ * Feature tests for `ArtisanPackUI\VisualEditor\Support\HookAliases`.
+ *
+ * Confirms every hook renamed in #664 continues to fire old-name
+ * subscribers when the canonical (new-name) hook is applied. Covers
+ * `resources` in depth plus three additional families
+ * (`templates`, `renderedBlock`, `loginout.envelope`) as a spot-check;
+ * exhaustive per-hook coverage lives in the resolver / renderer tests
+ * that already fire each hook.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.5.0
+ */
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Support\HookAliases;
+
+afterEach( function (): void {
+	removeAllFilters( 'ap.visual-editor.resources' );
+	removeAllFilters( 'ap.visualEditor.resources' );
+	removeAllFilters( 'ap.visual-editor.templates' );
+	removeAllFilters( 'ap.visualEditor.templates' );
+	removeAllFilters( 'ap.visual-editor.rendered-block' );
+	removeAllFilters( 'ap.visualEditor.renderedBlock' );
+	removeAllFilters( 'ap.visual-editor.loginout.envelope' );
+	removeAllFilters( 'ap.visualEditor.loginout.envelope' );
+} );
+
+it( 'routes old-name resources subscribers when the new name is applied', function (): void {
+	HookAliases::registerAll();
+
+	addFilter( 'ap.visual-editor.resources', function ( array $resources ): array {
+		return array_merge( [ 'posts' => 'App\\Models\\Post' ], $resources );
+	} );
+
+	$result = applyFilters( 'ap.visualEditor.resources', [] );
+
+	expect( $result )->toHaveKey( 'posts' );
+} );
+
+it( 'routes old-name templates subscribers when the new name is applied', function (): void {
+	HookAliases::registerAll();
+
+	addFilter( 'ap.visual-editor.templates', function ( array $templates ): array {
+		return array_merge( [ 'front-page' => [ 'slug' => 'front-page' ] ], $templates );
+	} );
+
+	$result = applyFilters( 'ap.visualEditor.templates', [] );
+
+	expect( $result )->toHaveKey( 'front-page' );
+} );
+
+it( 'routes old-name renderedBlock subscribers when the new name is applied', function (): void {
+	HookAliases::registerAll();
+
+	addFilter( 'ap.visual-editor.rendered-block', function ( string $html ): string {
+		return $html . '::filtered';
+	} );
+
+	$result = applyFilters( 'ap.visualEditor.renderedBlock', 'html' );
+
+	expect( $result )->toBe( 'html::filtered' );
+} );
+
+it( 'routes old-name loginout envelope subscribers when the new name is applied', function (): void {
+	HookAliases::registerAll();
+
+	addFilter( 'ap.visual-editor.loginout.envelope', function ( array $envelope ): array {
+		$envelope['touched'] = true;
+
+		return $envelope;
+	} );
+
+	$result = applyFilters( 'ap.visualEditor.loginout.envelope', [] );
+
+	expect( $result )->toHaveKey( 'touched' );
+} );
+
+it( 'is idempotent — a second registerAll() does not double-fire subscribers', function (): void {
+	HookAliases::registerAll();
+	HookAliases::registerAll();
+
+	$calls = 0;
+	addFilter( 'ap.visual-editor.resources', function ( array $resources ) use ( &$calls ): array {
+		$calls++;
+
+		return $resources;
+	} );
+
+	applyFilters( 'ap.visualEditor.resources', [] );
+
+	expect( $calls )->toBe( 1 );
+} );
+
+/*
+ * Reverse-direction coverage — a legacy host may still call
+ * applyFilters() against the OLD name (e.g. downstream code compiled
+ * before the rename shipped). Subscribers registered on the canonical
+ * NEW name must still fire so hosts do not lose behavior mid-migration.
+ * These mirror the four OLD→NEW cases above.
+ */
+
+it( 'routes new-name resources subscribers when the old name is applied', function (): void {
+	HookAliases::registerAll();
+
+	addFilter( 'ap.visualEditor.resources', function ( array $resources ): array {
+		return array_merge( [ 'posts' => 'App\\Models\\Post' ], $resources );
+	} );
+
+	$result = applyFilters( 'ap.visual-editor.resources', [] );
+
+	expect( $result )->toHaveKey( 'posts' );
+} );
+
+it( 'routes new-name templates subscribers when the old name is applied', function (): void {
+	HookAliases::registerAll();
+
+	addFilter( 'ap.visualEditor.templates', function ( array $templates ): array {
+		return array_merge( [ 'front-page' => [ 'slug' => 'front-page' ] ], $templates );
+	} );
+
+	$result = applyFilters( 'ap.visual-editor.templates', [] );
+
+	expect( $result )->toHaveKey( 'front-page' );
+} );
+
+it( 'routes new-name renderedBlock subscribers when the old name is applied', function (): void {
+	HookAliases::registerAll();
+
+	addFilter( 'ap.visualEditor.renderedBlock', function ( string $html ): string {
+		return $html . '::filtered';
+	} );
+
+	$result = applyFilters( 'ap.visual-editor.rendered-block', 'html' );
+
+	expect( $result )->toBe( 'html::filtered' );
+} );
+
+it( 'routes new-name loginout envelope subscribers when the old name is applied', function (): void {
+	HookAliases::registerAll();
+
+	addFilter( 'ap.visualEditor.loginout.envelope', function ( array $envelope ): array {
+		$envelope['touched'] = true;
+
+		return $envelope;
+	} );
+
+	$result = applyFilters( 'ap.visual-editor.loginout.envelope', [] );
+
+	expect( $result )->toHaveKey( 'touched' );
+} );

--- a/tests/Feature/VisualEditor/IconBlockEndToEndTest.php
+++ b/tests/Feature/VisualEditor/IconBlockEndToEndTest.php
@@ -279,7 +279,7 @@ it( 'uploads an icon set, registers it, and makes it pickable end-to-end', funct
 
 	expect( app( UploadedIconSetRegistry::class )->has( 'uploaded' ) )->toBeTrue();
 
-	// Wire a catalog that mirrors what `ap.icons.register-icon-sets`
+	// Wire a catalog that mirrors what `ap.icons.registerIconSets`
 	// would expose for the newly-uploaded set, then drive the picker
 	// search endpoint and confirm the icon is discoverable.
 	e2eBindCatalogFixture(
@@ -454,10 +454,10 @@ it( 'lets a decorative + linked combo recover when an aria-label is supplied', f
 } );
 
 // -------------------------------------------------------------------
-// `ap.icons.register-icon-sets` filter wires bundled sets at boot
+// `ap.icons.registerIconSets` filter wires bundled sets at boot
 // -------------------------------------------------------------------
 
-it( 'collects bundled FA Free sets via the ap.icons.register-icon-sets filter', function (): void {
+it( 'collects bundled FA Free sets via the ap.icons.registerIconSets filter', function (): void {
 	$registrationClass = 'ArtisanPackUI\\Icons\\Registries\\IconSetRegistration';
 
 	// The icons package is a `suggest`-level dependency. When it's not
@@ -480,7 +480,7 @@ it( 'collects bundled FA Free sets via the ap.icons.register-icon-sets filter', 
 		test()->markTestSkipped( 'FA Free SVGs not synced — run `npm run sync:fa-icons` first' );
 	}
 
-	$registry = applyFilters( 'ap.icons.register-icon-sets', new $registrationClass() );
+	$registry = applyFilters( 'ap.icons.registerIconSets', new $registrationClass() );
 
 	$sets = $registry->getSets();
 

--- a/tests/Feature/VisualEditor/ResourcesFilterTest.php
+++ b/tests/Feature/VisualEditor/ResourcesFilterTest.php
@@ -8,7 +8,7 @@ use Tests\Fixtures\TestBlockContentModel;
 use Tests\Fixtures\TestBlockContentPageModel;
 
 afterEach( function () {
-	removeAllFilters( 'ap.visual-editor.resources' );
+	removeAllFilters( 'ap.visualEditor.resources' );
 } );
 
 function rebuildResourceResolver(): ResourceResolver
@@ -18,8 +18,8 @@ function rebuildResourceResolver(): ResourceResolver
 	return app( ResourceResolver::class );
 }
 
-it( 'registers resources contributed via the ap.visual-editor.resources filter', function () {
-	addFilter( 'ap.visual-editor.resources', function ( array $resources ): array {
+it( 'registers resources contributed via the ap.visualEditor.resources filter', function () {
+	addFilter( 'ap.visualEditor.resources', function ( array $resources ): array {
 		return array_merge( [
 			'posts' => TestBlockContentModel::class,
 		], $resources );
@@ -35,7 +35,7 @@ it( 'lets static config win over filter contributions on key collision', functio
 		'posts' => TestBlockContentPageModel::class, // host override
 	] );
 
-	addFilter( 'ap.visual-editor.resources', function ( array $resources ): array {
+	addFilter( 'ap.visualEditor.resources', function ( array $resources ): array {
 		// Filter contributor naively merges its default; the host config
 		// in the static config map should still win.
 		return array_merge( [
@@ -53,7 +53,7 @@ it( 'merges static config and filter contributions when slugs do not collide', f
 		'pages' => TestBlockContentPageModel::class,
 	] );
 
-	addFilter( 'ap.visual-editor.resources', function ( array $resources ): array {
+	addFilter( 'ap.visualEditor.resources', function ( array $resources ): array {
 		return array_merge( [
 			'posts' => TestBlockContentModel::class,
 		], $resources );
@@ -66,7 +66,7 @@ it( 'merges static config and filter contributions when slugs do not collide', f
 } );
 
 it( 'does not throw at boot when a filter contributes an invalid class — error surfaces on first request', function () {
-	addFilter( 'ap.visual-editor.resources', function ( array $resources ): array {
+	addFilter( 'ap.visualEditor.resources', function ( array $resources ): array {
 		return array_merge( [
 			'invalid' => 'App\\Models\\DoesNotExist',
 		], $resources );

--- a/tests/Feature/VisualEditor/SiteEditorFiltersTest.php
+++ b/tests/Feature/VisualEditor/SiteEditorFiltersTest.php
@@ -17,11 +17,11 @@ use ArtisanPackUI\VisualEditor\VisualEditorServiceProvider;
 
 afterEach( function (): void {
 	foreach ( [
-		'ap.visual-editor.templates',
-		'ap.visual-editor.template-parts',
-		'ap.visual-editor.patterns',
-		'ap.visual-editor.global-styles',
-		'ap.visual-editor.navigation',
+		'ap.visualEditor.templates',
+		'ap.visualEditor.templateParts',
+		'ap.visualEditor.patterns',
+		'ap.visualEditor.globalStyles',
+		'ap.visualEditor.navigation',
 	] as $filter ) {
 		removeAllFilters( $filter );
 	}
@@ -45,7 +45,7 @@ describe( 'standalone install (no contributors, no static config)', function ():
 		rebuildSiteEditorResolvers();
 
 		// #639 — visual-editor now ships a built-in `page/blank` seed
-		// pattern registered via `ap.visual-editor.patterns` on boot,
+		// pattern registered via `ap.visualEditor.patterns` on boot,
 		// so the pattern resolver is no longer strictly empty on a
 		// standalone install. Assert on the shape and the seed's slug
 		// rather than `[]`.
@@ -61,7 +61,7 @@ describe( 'standalone install (no contributors, no static config)', function ():
 
 describe( 'single-source filter contribution', function (): void {
 	it( 'registers a template via the templates filter', function (): void {
-		addFilter( 'ap.visual-editor.templates', function ( array $existing ): array {
+		addFilter( 'ap.visualEditor.templates', function ( array $existing ): array {
 			return array_merge( [
 				'page' => [
 					'slug'   => 'page',
@@ -83,7 +83,7 @@ describe( 'single-source filter contribution', function (): void {
 	} );
 
 	it( 'registers a template-part with area', function (): void {
-		addFilter( 'ap.visual-editor.template-parts', function ( array $existing ): array {
+		addFilter( 'ap.visualEditor.templateParts', function ( array $existing ): array {
 			return array_merge( [
 				'header' => [
 					'slug'   => 'header',
@@ -104,7 +104,7 @@ describe( 'single-source filter contribution', function (): void {
 	} );
 
 	it( 'registers a pattern with source flag', function (): void {
-		addFilter( 'ap.visual-editor.patterns', function ( array $existing ): array {
+		addFilter( 'ap.visualEditor.patterns', function ( array $existing ): array {
 			return array_merge( [
 				'cta' => [
 					'slug'   => 'cta',
@@ -125,7 +125,7 @@ describe( 'single-source filter contribution', function (): void {
 	} );
 
 	it( 'registers global-styles as a singleton', function (): void {
-		addFilter( 'ap.visual-editor.global-styles', function ( $existing ) {
+		addFilter( 'ap.visualEditor.globalStyles', function ( $existing ) {
 			return $existing ?? [
 				'theme'    => 'digital-shopfront',
 				'settings' => [ 'color' => [ 'palette' => [] ] ],
@@ -142,7 +142,7 @@ describe( 'single-source filter contribution', function (): void {
 	} );
 
 	it( 'registers a menu under its location', function (): void {
-		addFilter( 'ap.visual-editor.navigation', function ( array $existing ): array {
+		addFilter( 'ap.visualEditor.navigation', function ( array $existing ): array {
 			return array_merge( [
 				'primary' => [
 					'location' => 'primary',
@@ -173,7 +173,7 @@ describe( 'static config wins on key collision', function (): void {
 			],
 		] );
 
-		addFilter( 'ap.visual-editor.templates', function ( array $existing ): array {
+		addFilter( 'ap.visualEditor.templates', function ( array $existing ): array {
 			return array_merge( [
 				'page' => [
 					'slug'   => 'page',
@@ -202,7 +202,7 @@ describe( 'static config wins on key collision', function (): void {
 			],
 		] );
 
-		addFilter( 'ap.visual-editor.templates', function ( array $existing ): array {
+		addFilter( 'ap.visualEditor.templates', function ( array $existing ): array {
 			return array_merge( [
 				'cms-page' => [
 					'slug'   => 'cms-page',
@@ -228,7 +228,7 @@ describe( 'static config wins on key collision', function (): void {
 			'styles'   => [],
 		] );
 
-		addFilter( 'ap.visual-editor.global-styles', function ( $existing ) {
+		addFilter( 'ap.visualEditor.globalStyles', function ( $existing ) {
 			return $existing ?? [
 				'theme'    => 'cms-theme',
 				'settings' => [ 'cms' => true ],
@@ -247,7 +247,7 @@ describe( 'static config wins on key collision', function (): void {
 
 describe( 'lazy validation on first read', function (): void {
 	it( 'does not throw at boot when a filter returns malformed entries', function (): void {
-		addFilter( 'ap.visual-editor.templates', function ( array $existing ): array {
+		addFilter( 'ap.visualEditor.templates', function ( array $existing ): array {
 			return array_merge( [
 				'broken' => 'this-is-not-an-array',
 			], $existing );
@@ -260,7 +260,7 @@ describe( 'lazy validation on first read', function (): void {
 	} );
 
 	it( 'throws SiteEditorRegistrationException on first all() with a malformed entry', function (): void {
-		addFilter( 'ap.visual-editor.templates', function ( array $existing ): array {
+		addFilter( 'ap.visualEditor.templates', function ( array $existing ): array {
 			return array_merge( [
 				'broken' => 'this-is-not-an-array',
 			], $existing );
@@ -273,7 +273,7 @@ describe( 'lazy validation on first read', function (): void {
 	} );
 
 	it( 'throws when a template entry is missing the required theme field', function (): void {
-		addFilter( 'ap.visual-editor.templates', function ( array $existing ): array {
+		addFilter( 'ap.visualEditor.templates', function ( array $existing ): array {
 			return array_merge( [
 				'no-theme' => [
 					'slug'   => 'no-theme',
@@ -290,7 +290,7 @@ describe( 'lazy validation on first read', function (): void {
 	} );
 
 	it( 'throws when a template-part has an invalid area', function (): void {
-		addFilter( 'ap.visual-editor.template-parts', function ( array $existing ): array {
+		addFilter( 'ap.visualEditor.templateParts', function ( array $existing ): array {
 			return array_merge( [
 				'banner' => [
 					'slug'   => 'banner',
@@ -308,7 +308,7 @@ describe( 'lazy validation on first read', function (): void {
 	} );
 
 	it( 'throws when a pattern has an invalid source value', function (): void {
-		addFilter( 'ap.visual-editor.patterns', function ( array $existing ): array {
+		addFilter( 'ap.visualEditor.patterns', function ( array $existing ): array {
 			return array_merge( [
 				'bad' => [
 					'slug'   => 'bad',
@@ -324,7 +324,7 @@ describe( 'lazy validation on first read', function (): void {
 	} );
 
 	it( 'throws when a pattern is missing the title field', function (): void {
-		addFilter( 'ap.visual-editor.patterns', function ( array $existing ): array {
+		addFilter( 'ap.visualEditor.patterns', function ( array $existing ): array {
 			return array_merge( [
 				'titleless' => [
 					'slug'   => 'titleless',
@@ -343,7 +343,7 @@ describe( 'lazy validation on first read', function (): void {
 		// A misconfigured contributor passes a string in the nested
 		// content.blocks slot — should resolve to an empty blocks array
 		// instead of raising a TypeError on the typed constructor param.
-		addFilter( 'ap.visual-editor.patterns', function ( array $existing ): array {
+		addFilter( 'ap.visualEditor.patterns', function ( array $existing ): array {
 			return array_merge( [
 				'malformed' => [
 					'slug'    => 'malformed',
@@ -365,7 +365,7 @@ describe( 'lazy validation on first read', function (): void {
 		// content is a string instead of an array. Without the defensive
 		// is_array guard, $data['content']['raw'] would index into the
 		// string and silently corrupt rawContent to its first character.
-		addFilter( 'ap.visual-editor.patterns', function ( array $existing ): array {
+		addFilter( 'ap.visualEditor.patterns', function ( array $existing ): array {
 			return array_merge( [
 				'scalar-content' => [
 					'slug'    => 'scalar-content',
@@ -385,7 +385,7 @@ describe( 'lazy validation on first read', function (): void {
 	} );
 
 	it( 'safely handles a scalar content envelope on templates', function (): void {
-		addFilter( 'ap.visual-editor.templates', function ( array $existing ): array {
+		addFilter( 'ap.visualEditor.templates', function ( array $existing ): array {
 			return array_merge( [
 				'scalar-template' => [
 					'slug'    => 'scalar-template',
@@ -405,7 +405,7 @@ describe( 'lazy validation on first read', function (): void {
 	} );
 
 	it( 'safely handles a scalar content envelope on template parts', function (): void {
-		addFilter( 'ap.visual-editor.template-parts', function ( array $existing ): array {
+		addFilter( 'ap.visualEditor.templateParts', function ( array $existing ): array {
 			return array_merge( [
 				'scalar-part' => [
 					'slug'    => 'scalar-part',
@@ -431,7 +431,7 @@ describe( 'lazy validation on first read', function (): void {
 		// `(string) $array` produces the literal `"Array"` and ships
 		// silently — the resolver should fall back to the empty default
 		// instead.
-		addFilter( 'ap.visual-editor.patterns', function ( array $existing ): array {
+		addFilter( 'ap.visualEditor.patterns', function ( array $existing ): array {
 			return array_merge( [
 				'array-raw' => [
 					'slug'        => 'array-raw',
@@ -451,7 +451,7 @@ describe( 'lazy validation on first read', function (): void {
 	} );
 
 	it( 'does not stringify a non-scalar nested content.raw to "Array" on templates', function (): void {
-		addFilter( 'ap.visual-editor.templates', function ( array $existing ): array {
+		addFilter( 'ap.visualEditor.templates', function ( array $existing ): array {
 			return array_merge( [
 				'array-content-raw' => [
 					'slug'    => 'array-content-raw',
@@ -475,7 +475,7 @@ describe( 'lazy validation on first read', function (): void {
 		// is_scalar accepts int, float, bool — these are sensibly stringable
 		// and shouldn't be rejected. Verifies the coercion path exposes the
 		// stringified value rather than dropping it.
-		addFilter( 'ap.visual-editor.patterns', function ( array $existing ): array {
+		addFilter( 'ap.visualEditor.patterns', function ( array $existing ): array {
 			return array_merge( [
 				'numeric-raw' => [
 					'slug'        => 'numeric-raw',
@@ -497,7 +497,7 @@ describe( 'lazy validation on first read', function (): void {
 		// Top-level raw_content + nested content.raw should behave the same
 		// way: a non-string scalar (here, an int) coerces to its string form
 		// rather than being silently dropped.
-		addFilter( 'ap.visual-editor.templates', function ( array $existing ): array {
+		addFilter( 'ap.visualEditor.templates', function ( array $existing ): array {
 			return array_merge( [
 				'numeric-template' => [
 					'slug'        => 'numeric-template',
@@ -516,7 +516,7 @@ describe( 'lazy validation on first read', function (): void {
 	} );
 
 	it( 'coerces scalar non-string raw_content to a string on template parts', function (): void {
-		addFilter( 'ap.visual-editor.template-parts', function ( array $existing ): array {
+		addFilter( 'ap.visualEditor.templateParts', function ( array $existing ): array {
 			return array_merge( [
 				'numeric-part' => [
 					'slug'        => 'numeric-part',
@@ -541,7 +541,7 @@ describe( 'lazy validation on first read', function (): void {
 		// to int(404), which contributors cannot prevent at the language
 		// level. The resolver must accept int keys and cast them back to
 		// string so the filter's string-map contract holds end-to-end.
-		addFilter( 'ap.visual-editor.templates', function ( array $existing ): array {
+		addFilter( 'ap.visualEditor.templates', function ( array $existing ): array {
 			return array_merge( [
 				'404' => [
 					'slug'   => '404',
@@ -581,7 +581,7 @@ describe( 'lazy validation on first read', function (): void {
 		// different raw keys but the same slug would silently overwrite
 		// one another. Surface that as a configuration error instead of
 		// last-wins so contributors know to disambiguate.
-		addFilter( 'ap.visual-editor.templates', function ( array $existing ): array {
+		addFilter( 'ap.visualEditor.templates', function ( array $existing ): array {
 			return array_merge( [
 				'raw-a' => [
 					'slug'   => 'shared',
@@ -609,7 +609,7 @@ describe( 'lazy validation on first read', function (): void {
 		// key. The pre-refactor shape guard rejected empty raw keys; the
 		// post-refactor emptyIdentifier check protects the same
 		// invariant on the re-key path.
-		addFilter( 'ap.visual-editor.templates', function ( array $existing ): array {
+		addFilter( 'ap.visualEditor.templates', function ( array $existing ): array {
 			return array_merge( [
 				'raw-key' => [
 					'slug'   => '',
@@ -627,7 +627,7 @@ describe( 'lazy validation on first read', function (): void {
 	} );
 
 	it( 'throws when global-styles is missing the theme field', function (): void {
-		addFilter( 'ap.visual-editor.global-styles', function ( $existing ) {
+		addFilter( 'ap.visualEditor.globalStyles', function ( $existing ) {
 			return $existing ?? [
 				'settings' => [],
 				'styles'   => [],
@@ -641,7 +641,7 @@ describe( 'lazy validation on first read', function (): void {
 	} );
 
 	it( 'auto-stamps the map key as location when a navigation entry omits the field', function (): void {
-		addFilter( 'ap.visual-editor.navigation', function ( array $existing ): array {
+		addFilter( 'ap.visualEditor.navigation', function ( array $existing ): array {
 			return array_merge( [
 				'primary' => [
 					'name' => 'Primary',
@@ -658,7 +658,7 @@ describe( 'lazy validation on first read', function (): void {
 	} );
 
 	it( 'throws when a non-array filter return value would corrupt the resolver', function (): void {
-		addFilter( 'ap.visual-editor.templates', function ( $existing ) {
+		addFilter( 'ap.visualEditor.templates', function ( $existing ) {
 			// Pathological contributor: returns a string.
 			return 'oops';
 		} );

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 
 namespace Tests;
 
+use ArtisanPackUI\Hooks\Providers\HooksServiceProvider;
 use ArtisanPackUI\VisualEditor\VisualEditorServiceProvider;
 use Orchestra\Testbench\TestCase as BaseTestCase;
 
@@ -17,6 +18,7 @@ abstract class TestCase extends BaseTestCase
 	protected function getPackageProviders( $app ): array
 	{
 		return [
+			HooksServiceProvider::class,
 			VisualEditorServiceProvider::class,
 		];
 	}


### PR DESCRIPTION
## Description

Renames every visual-editor hook from kebab-case to camelCase for consistency with the ArtisanPack UI ecosystem's naming convention. Old names remain functional via deprecation aliases (PHP: `deprecateHook()` from `artisanpack-ui/hooks ^1.2`; JS: bidirectional `@wordpress/hooks` shim at `Number.MIN_SAFE_INTEGER` priority) so both directions of dispatch — legacy fire → new subscribers and new fire → legacy subscribers — continue to work.

**Closes:** #664

## Type of Change

- [x] Breaking change (breaks backward compatibility)
- [x] Refactoring (code improvement, no behavior change)

## Related Issue

**Issue:** #664 — Wave 3 of the cross-package hooks standardization (umbrella #13).

## Motivation and Context

The visual-editor was the last remaining package still fanning hooks under kebab-case, forcing downstream apps to remember two naming conventions. Wave 3 unifies the surface: `ap.visualEditor.*` everywhere, with aliases keeping every legacy call site working through at least one more minor.

## Changes Made

- **PHP:** New `ArtisanPackUI\VisualEditor\Support\HookAliases::registerAll()` installs `deprecateHook()` aliases for every renamed pair; called from `VisualEditorServiceProvider::boot()` as the first statement so every subsequent hook fire site routes correctly.
- **JS:** New `resources/js/visual-editor/support/hook-aliases.ts` installs bidirectional passthrough filters at `Number.MIN_SAFE_INTEGER` priority with a per-hook `Map<string, number>` re-entry counter (safe under nested `applyFilters` on the same hook). Called from `resources/js/visual-editor/{editor,site-editor}/main.tsx` at module load.
- **Renames applied:** 13 PHP hooks from the issue table + `visual_editor.pre_publish_checks` + `ap.icons.register-icon-sets` + three JS-only hooks (`background-controls`, `canvas-styles`, `document-panels`) for a consistent surface across languages.
- **Composer:** bumped `artisanpack-ui/hooks` constraint to `^1.2`; package version to `1.5.0` (also `package.json`).
- **Testbench wiring:** added `HooksServiceProvider` to `tests/TestCase.php::getPackageProviders()` so the `HookDeprecations` singleton resolves correctly under Orchestra (which does not run composer package discovery). No effect on production apps.
- **Housekeeping:** gitignored `packages/visual-editor-renderer-blade/vendor/` (dev-only sub-package vendor tree); folded the two pre-existing `[Unreleased]` CHANGELOG entries (site-editor resolver identifier re-keying + canvas CSS delegation) into the new `[1.5.0]` section.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (Darwin 25.5)
- Browser: Chrome (dev app manual verification)
- PHP Version: 8.4.3
- Project Version: 1.5.0

**Tests Performed:**

1. `./vendor/bin/pest --compact` — **86 pass** (0 fail). Includes new `HookAliasesTest.php` covering both OLD→NEW and NEW→OLD dispatch for resources / templates / renderedBlock / loginout.envelope + idempotency of `registerAll()`.
2. `npm test` — **2870 pass**. 18 pre-existing failures in `site-editor/__tests__/site-editor-app.test.tsx` (`window.localStorage` undefined in jsdom setup) — confirmed unrelated (also fails on `release/1.5`).
3. Manual verification via the dev app's `/packages/hooks/wave-one-renames` page — all 14 visual-editor alias rows show green success badges for `alias_registered`, `old→new dispatch`, and `new→old dispatch`.

## Accessibility Tests Run

- [x] N/A — hook-name refactor, no user-facing UI changes

**Details:** No rendered output changed; the block editor and site editor render identically to `release/1.5`.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing (relevant to this change)

**Test details:**
- `tests/Feature/VisualEditor/HookAliasesTest.php` — 9 Pest cases (4 OLD→NEW, 4 NEW→OLD, 1 idempotency).
- `resources/js/visual-editor/support/__tests__/hook-aliases.test.ts` — 4 Vitest cases: OLD→NEW routing, NEW→OLD routing, no infinite recursion when both names carry subscribers, idempotency.
- Every existing test file that referenced the old hook names was updated in place.

## Documentation

- [x] Inline code documentation added
- [x] README updated
- [x] Wiki updated — N/A (deferred; wiki lists hook names historically — old names still fire)
- [x] API documentation updated

**Documentation details:**
- `CHANGELOG.md` — new `## [1.5.0]` section with the full rename table + deprecation semantics.
- `README.md` — hook section switched to camelCase + deprecation callout linking to `HookAliases.php`.
- `src/Support/HookAliases.php` + `resources/js/visual-editor/support/hook-aliases.ts` — module-level JSDoc explains the alias mechanism, re-entry counter, and the `MIN_SAFE_INTEGER` priority choice.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted (mirrored existing WordPress-style spacing + tabs; no `php-cs-fixer` installed in package)
- [x] N/A — accessibility not affected
- [x] Code follows project style guide
- [x] Self-review completed (local `/review` pass ran, all 5 findings applied)
- [x] Comments added for complex code (JS alias re-entry counter documented)
- [x] No new warnings generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)