### PR TITLE
feat: add block, render, save, editor-config, pattern lifecycle hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,48 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Changed
+
+- **Bumped `artisanpack-ui/hooks` requirement to `^1.3` (#665).** The
+  hook fire sites added in #665 assume the helper globals are always
+  available, so the previous `^1.2` constraint's `function_exists()`
+  guards have been dropped in favour of the newer floor.
+
+### Added
+
+- **Six new lifecycle hooks for editor and block integrations (#665).**
+  Fills in high-value extension points across block registration,
+  rendering, post persistence, editor config assembly, and pattern
+  rendering. All hooks live under the canonical `ap.visualEditor.*`
+  namespace introduced in #664:
+
+    - `ap.visualEditor.blockRegistered` — action, fires at the end of
+      block registration with `(string $name, array $config)`. Fires
+      through `BlockTypeRegistry::register()` so both `block.json`
+      registration and programmatic `registerBlockType()` calls emit.
+    - `ap.visualEditor.beforeRender` — filter on `(array $attributes,
+      string $name)` that runs inside `BlockRenderer::renderBlock()`
+      after site-meta / loginout stamping. Non-array returns are
+      discarded so a misbehaving callback can't blank the block.
+    - `ap.visualEditor.postSaved` — action fired from
+      `WpEntityController` after every POST/PUT persistence with
+      `(int|string $postId, array $blocks)`.
+    - `ap.visualEditor.postPublished` — action fired from the same
+      site whenever the current save transitions status into the
+      WP-canonical `publish` value (create-with-publish or
+      non-publish → publish on update). Same payload as `postSaved`.
+    - `ap.visualEditor.editorConfig` — filter applied by
+      `VisualEditorComponent` on the assembled config array with
+      `(array $config, string $screen)`; `$screen` is `'post'` for
+      the current component. Filtered values are re-hydrated onto
+      the component's typed props, so misbehaving returns can't
+      poison a `?string` prop.
+    - `ap.visualEditor.patternRender` — filter applied by
+      `PatternAdapter::toArray()` on the rendered raw content of a
+      pattern with `(string $html, string $slug, array $context)`.
+      Context carries source, synced flag, categories, block_types,
+      and post_types so callbacks can gate per pattern shape.
+
 ## [1.5.0]
 
 ### Changed (BREAKING)

--- a/README.md
+++ b/README.md
@@ -301,6 +301,22 @@ Editor chrome icons resolve through `artisanpack-ui/icons`. Register
 additional icon sets in a service provider — see the
 [`artisanpack-ui/icons`](https://github.com/ArtisanPack-UI/icons) docs.
 
+### Lifecycle hooks (v1.6.0, #665)
+
+Six additional hooks cover the block-registration, block-render,
+post-persistence, editor-config, and pattern-render lifecycles. The
+tables below summarise each; the full contract is documented in
+[`docs/Hooks-and-Events.md`](docs/Hooks-and-Events.md).
+
+| Hook | Type | Fired at | Payload |
+|---|---|---|---|
+| `ap.visualEditor.blockRegistered` | action | `BlockTypeRegistry::register()` end | `(string $name, array $config)` |
+| `ap.visualEditor.beforeRender` | filter | `BlockRenderer::renderBlock()` pre-render | `(array $attributes, string $name)` |
+| `ap.visualEditor.postSaved` | action | `WpEntityController::persistNew()` / `persistUpdate()` after save | `(int\|string $postId, array $blocks)` |
+| `ap.visualEditor.postPublished` | action | same site, only on non-publish → `publish` transitions | `(int\|string $postId, array $blocks)` |
+| `ap.visualEditor.editorConfig` | filter | `VisualEditorComponent::__construct()` config assembly | `(array $config, string $screen)` |
+| `ap.visualEditor.patternRender` | filter | `PatternAdapter::toArray()` on `content.raw` | `(string $html, string $slug, array $context)` |
+
 ---
 
 ## AI features

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "php": "^8.2",
     "illuminate/support": "^11.0|^12.0|^13.0",
     "artisanpack-ui/core": "^1.0",
-    "artisanpack-ui/hooks": "^1.2"
+    "artisanpack-ui/hooks": "^1.3"
   },
   "require-dev": {
     "pestphp/pest": "^3.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "aef967ffa5a1ee1b440ab6cf8295fca0",
+    "content-hash": "1d3b78cda4f32b8d5b004c07ac3e5581",
     "packages": [
         {
             "name": "artisanpack-ui/core",

--- a/docs/Hooks-and-Events.md
+++ b/docs/Hooks-and-Events.md
@@ -114,6 +114,97 @@ addFilter('ap.visual-editor.rendered-block', function (string $html, string $nam
 
 ---
 
+### `ap.visualEditor.beforeRender`
+
+PHP filter applied inside `BlockRenderer::renderBlock()` **before** a block renders, giving hosts a chance to mutate the block's attributes. Fires after site-meta / loginout stamping so the resolved `_resolved*` keys are already present. Sibling of `rendered-block` (which runs after render).
+
+**Signature:** `array $attributes, string $blockName -> array`
+
+```php
+addFilter('ap.visualEditor.beforeRender', function (array $attributes, string $name): array {
+    if ('core/paragraph' !== $name) {
+        return $attributes;
+    }
+    $attributes['content'] = strtoupper($attributes['content'] ?? '');
+    return $attributes;
+}, 10, 2);
+```
+
+Non-array returns are ignored so a misbehaving callback can't blank the block.
+
+---
+
+### `ap.visualEditor.blockRegistered`
+
+PHP action fired at the end of block-type registration, from `BlockTypeRegistry::register()`. Covers both `block.json`-driven registration and programmatic `VisualEditor::registerBlockType()` calls.
+
+**Signature:** `string $name, array $config -> void`
+
+```php
+addAction('ap.visualEditor.blockRegistered', function (string $name, array $config): void {
+    // e.g. register block variations, per-block binding sources,
+    // per-block category assignment, etc.
+}, 10, 2);
+```
+
+---
+
+### `ap.visualEditor.postSaved` / `ap.visualEditor.postPublished`
+
+PHP actions fired by `WpEntityController` after every POST/PUT persistence (`postSaved`) and additionally when the current save transitions the record's `status` into the WP-canonical `publish` value (`postPublished`). Fire on both create-with-publish and non-publish → publish updates; re-saves of an already-published record fire `postSaved` only.
+
+**Signature:** `int|string $postId, array $blocks -> void`
+
+```php
+addAction('ap.visualEditor.postPublished', function ($postId, array $blocks): void {
+    // e.g. queue a search-index rebuild, send a webhook, purge a CDN, …
+}, 10, 2);
+```
+
+`$blocks` reflects the tree the client submitted in the current request under `content.blocks`; missing / malformed payloads collapse to `[]`.
+
+---
+
+### `ap.visualEditor.editorConfig`
+
+PHP filter applied by `VisualEditorComponent` on the assembled editor config before the Blade template emits its `data-*` attributes. `$screen` identifies the surface — `'post'` for the current component; a future site-editor surface would pass `'site'`.
+
+**Signature:** `array $config, string $screen -> array`
+
+```php
+addFilter('ap.visualEditor.editorConfig', function (array $config, string $screen): array {
+    if ('post' !== $screen) {
+        return $config;
+    }
+    $config['apiBase'] = '/custom/api';
+    return $config;
+}, 10, 2);
+```
+
+Only known keys are re-hydrated back onto the component's typed props — extra keys are ignored and non-array returns leave the assembled config intact.
+
+---
+
+### `ap.visualEditor.patternRender`
+
+PHP filter applied by `PatternAdapter::toArray()` on the rendered raw content of a pattern before it ships to the editor / consumer. Runs on every read.
+
+**Signature:** `string $html, string $slug, array $context -> string`
+
+```php
+addFilter('ap.visualEditor.patternRender', function (string $html, string $slug, array $context): string {
+    // $context carries: source, synced, categories, block_types, post_types
+    if ('user' !== $context['source']) {
+        return $html;
+    }
+    return str_replace('{{year}}', (string) date('Y'), $html);
+}, 10, 3);
+```
+
+Non-string returns are ignored so the underlying `rawContent` survives.
+
+---
+
 ## JavaScript filters
 
 Editor-side filters run through `@wordpress/hooks` inside the browser. Register callbacks with `addFilter(name, namespace, callback)` at editor bootstrap (the moment the app imports your package's entry module is enough — the editor evaluates each filter on every relevant render).

--- a/packages/visual-editor-renderer-blade/src/BlockRenderer.php
+++ b/packages/visual-editor-renderer-blade/src/BlockRenderer.php
@@ -353,6 +353,21 @@ class BlockRenderer
 		$attributes      = $this->normalizeAttributes( $block['attributes'] ?? [] );
 		$attributes      = $this->stampSiteMeta( $name, $attributes );
 		$attributes      = $this->stampLoginout( $name, $attributes );
+
+		// `ap.visualEditor.beforeRender` — last chance for hosts and
+		// extension packages to mutate the attributes a block will render
+		// with. Fires after site-meta / loginout stamping so the resolved
+		// `_resolved*` side-channel keys are already present, giving the
+		// filter access to both the raw attributes and their resolved
+		// values. Callbacks must return an array; non-array returns are
+		// ignored so a mistaken `null` / `false` return doesn't blank the
+		// block.
+		$filteredAttributes = applyFilters( 'ap.visualEditor.beforeRender', $attributes, $name );
+
+		if ( is_array( $filteredAttributes ) ) {
+			$attributes = $filteredAttributes;
+		}
+
 		$innerBlocks     = $this->normalizeInnerBlocks( $block['innerBlocks'] ?? [] );
 		$innerBlocksHtml = $this->renderInner( $innerBlocks );
 
@@ -393,12 +408,10 @@ class BlockRenderer
 		// Those keys are a package-internal contract and may change
 		// without notice — callbacks should treat them as read-only
 		// side-channel data, not stable public attributes.
-		if ( function_exists( 'applyFilters' ) ) {
-			$filtered = applyFilters( 'ap.visualEditor.renderedBlock', $html, $name, $attributes );
+		$filtered = applyFilters( 'ap.visualEditor.renderedBlock', $html, $name, $attributes );
 
-			if ( is_string( $filtered ) ) {
-				$html = $filtered;
-			}
+		if ( is_string( $filtered ) ) {
+			$html = $filtered;
 		}
 
 		return $html;

--- a/packages/visual-editor-renderer-blade/tests/Unit/BlockRendererTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Unit/BlockRendererTest.php
@@ -1483,3 +1483,55 @@ describe( 'Keystone #50 — block-supports compilation on the rendered HTML', fu
 		expect( $good )->toContain( 'is-content-justification-space-between' );
 	} );
 } );
+
+describe( 'ap.visualEditor.beforeRender filter', function (): void {
+	afterEach( function (): void {
+		removeAllFilters( 'ap.visualEditor.beforeRender' );
+	} );
+
+	it( 'lets a callback mutate attributes before the block renders', function (): void {
+		addFilter( 'ap.visualEditor.beforeRender', function ( array $attributes, string $name ): array {
+			if ( 'core/paragraph' !== $name ) {
+				return $attributes;
+			}
+
+			$attributes['content'] = 'Filtered';
+
+			return $attributes;
+		}, 10, 2 );
+
+		$html = makeRenderer()->render( [ makeBlock( 'core/paragraph', [ 'content' => 'Original' ] ) ] );
+
+		expect( $html )->toContain( 'Filtered' )
+			->not->toContain( 'Original' );
+	} );
+
+	it( 'ignores a non-array return so a misbehaving callback cannot corrupt the attributes', function (): void {
+		addFilter( 'ap.visualEditor.beforeRender', function ( array $attributes, string $name ): ?bool {
+			return null;
+		}, 10, 2 );
+
+		$html = makeRenderer()->render( [ makeBlock( 'core/paragraph', [ 'content' => 'Kept' ] ) ] );
+
+		expect( $html )->toContain( 'Kept' );
+	} );
+
+	it( 'receives the block name so callbacks can gate per-type', function (): void {
+		$namesSeen = [];
+
+		addFilter( 'ap.visualEditor.beforeRender', function ( array $attributes, string $name ) use ( &$namesSeen ): array {
+			$namesSeen[] = $name;
+
+			return $attributes;
+		}, 10, 2 );
+
+		makeRenderer()->render( [
+			makeBlock( 'core/group', [], [
+				makeBlock( 'core/paragraph', [ 'content' => 'A' ], [], 'p1' ),
+			] ),
+		] );
+
+		expect( $namesSeen )->toContain( 'core/group' )
+			->toContain( 'core/paragraph' );
+	} );
+} );

--- a/src/Http/Controllers/Adapters/CmsFramework/WpEntityController.php
+++ b/src/Http/Controllers/Adapters/CmsFramework/WpEntityController.php
@@ -155,6 +155,8 @@ abstract class WpEntityController extends Controller
 		$model = $this->setBlockContent( $model, $data );
 		$model->save();
 
+		$this->firePostLifecycleHooks( $model, null );
+
 		return $model;
 	}
 
@@ -173,11 +175,52 @@ abstract class WpEntityController extends Controller
 
 		Gate::authorize( 'update', $model );
 
+		$originalStatus = $model->getOriginal( 'status' );
+		$previousStatus = is_string( $originalStatus ) ? $originalStatus : null;
+
 		$model = $this->fill( $model, $data );
 		$model = $this->setBlockContent( $model, $data );
 		$model->save();
 
+		$this->firePostLifecycleHooks( $model, $previousStatus );
+
 		return $model;
+	}
+
+	/**
+	 * Fires `ap.visualEditor.postSaved` on every persistence, and
+	 * `ap.visualEditor.postPublished` when the current save transitions
+	 * the record into the `publish` status (create-with-publish, or
+	 * update from any non-publish status to `publish`). Subsequent saves
+	 * of an already-published record fire `postSaved` only — republishing
+	 * is not treated as a fresh publish event.
+	 *
+	 * `$blocks` is read from the persisted model via
+	 * {@see \ArtisanPackUI\VisualEditor\Concerns\HasBlockContent::getBlockContent()}
+	 * so subscribers see the tree that actually landed on disk (post any
+	 * model-side mutators / observers) rather than the submitted payload.
+	 *
+	 * @since 1.6.0
+	 *
+	 * @param  Model        $model           The freshly-persisted model.
+	 * @param  string|null  $previousStatus  The pre-save `status` value, or `null`
+	 *                                       on create.
+	 */
+	protected function firePostLifecycleHooks( Model $model, ?string $previousStatus ): void
+	{
+		$postId = $model->getKey();
+
+		if ( null === $postId ) {
+			return;
+		}
+
+		$blocks = method_exists( $model, 'getBlockContent' ) ? $model->getBlockContent() : [];
+
+		doAction( 'ap.visualEditor.postSaved', $postId, $blocks );
+
+		if ( 'publish' === $model->getAttribute( 'status' ) && 'publish' !== $previousStatus ) {
+			doAction( 'ap.visualEditor.postPublished', $postId, $blocks );
+		}
 	}
 
 	/**

--- a/src/Http/Resources/Adapters/CmsFramework/SiteEditor/PatternAdapter.php
+++ b/src/Http/Resources/Adapters/CmsFramework/SiteEditor/PatternAdapter.php
@@ -49,6 +49,30 @@ class PatternAdapter
 	 */
 	public function toArray( ResolvedPattern $pattern ): array
 	{
+		// `ap.visualEditor.patternRender` — filter the rendered raw
+		// content of a pattern before it ships to the editor. Runs on
+		// every read so subscribers can inject dynamic content (shortcode
+		// expansion, per-request personalization tokens, etc.) without
+		// having to mutate the underlying block tree. The context array
+		// carries pattern-level metadata (source, synced flag) so hosts
+		// can gate their transform on theme-vs-user patterns cheaply.
+		// Non-string returns are discarded so a misbehaving callback
+		// can't blank the pattern.
+		$filtered = applyFilters(
+			'ap.visualEditor.patternRender',
+			$pattern->rawContent,
+			$pattern->slug,
+			[
+				'source'      => $pattern->source,
+				'synced'      => $pattern->synced,
+				'categories'  => $pattern->categories,
+				'block_types' => $pattern->blockTypes,
+				'post_types'  => $pattern->postTypes,
+			],
+		);
+
+		$rawContent = is_string( $filtered ) ? $filtered : $pattern->rawContent;
+
 		return [
 			'id'          => $pattern->wpId > 0 ? $pattern->wpId : $pattern->slug,
 			'slug'        => $pattern->slug,
@@ -59,7 +83,7 @@ class PatternAdapter
 				'raw'      => $pattern->title,
 			],
 			'content'     => [
-				'raw'    => $pattern->rawContent,
+				'raw'    => $rawContent,
 				'blocks' => $pattern->blocks,
 			],
 			'source'      => $pattern->source,

--- a/src/Registries/BlockTypeRegistry.php
+++ b/src/Registries/BlockTypeRegistry.php
@@ -58,6 +58,15 @@ class BlockTypeRegistry
 		}
 
 		$this->blocks[ $normalized ] = array_merge( ['name' => $normalized], $definition );
+
+		// `ap.visualEditor.blockRegistered` — fires once per registered block
+		// type, at the end of registration. Payload is the normalized block
+		// name and the merged definition array (block.json plus any
+		// programmatic overrides). Extensions typically use this to attach
+		// server-side runtime concerns (variations, bindings, category
+		// registration) that only make sense once a block has been accepted
+		// by the registry.
+		doAction( 'ap.visualEditor.blockRegistered', $normalized, $this->blocks[ $normalized ] );
 	}
 
 	/**

--- a/src/View/Components/VisualEditorComponent.php
+++ b/src/View/Components/VisualEditorComponent.php
@@ -141,6 +141,102 @@ class VisualEditorComponent extends Component
 		$this->initialUpdatedAt     = $this->resolveTimestamp( $model, 'updated_at' );
 		$this->contentTypes         = $this->resolveContentTypes();
 		$this->breakpoints          = app( BreakpointRegistry::class )->toArray();
+
+		$this->applyEditorConfigFilter();
+	}
+
+	/**
+	 * Identifies the editor surface for the `ap.visualEditor.editorConfig`
+	 * filter. Subclasses (e.g. a future site-editor component) override
+	 * to return `'site'` so callbacks can gate their overrides per screen.
+	 *
+	 * @since 1.6.0
+	 *
+	 * @return string
+	 */
+	protected function screen(): string
+	{
+		return 'post';
+	}
+
+	/**
+	 * Runs the assembled editor config through the
+	 * `ap.visualEditor.editorConfig` filter and re-hydrates the
+	 * component's props from the filtered result.
+	 *
+	 * Each known prop declares a coercer that maps a filter-returned
+	 * value to its declared type or falls back to the current value —
+	 * so an extra key from the filter can't leak into unrelated props,
+	 * and a malformed value can't poison a typed prop. To extend, add a
+	 * new row to {@see configSchema()} rather than a fresh assignment.
+	 *
+	 * @since 1.6.0
+	 *
+	 * @return void
+	 */
+	protected function applyEditorConfigFilter(): void
+	{
+		$schema = $this->configSchema();
+		$config = [];
+
+		foreach ( array_keys( $schema ) as $key ) {
+			$config[ $key ] = $this->{$key};
+		}
+
+		$filtered = applyFilters( 'ap.visualEditor.editorConfig', $config, $this->screen() );
+
+		if ( ! is_array( $filtered ) ) {
+			return;
+		}
+
+		foreach ( $schema as $key => $coercer ) {
+			if ( ! array_key_exists( $key, $filtered ) ) {
+				continue;
+			}
+
+			$this->{$key} = $coercer( $filtered[ $key ], $this->{$key} );
+		}
+	}
+
+	/**
+	 * Prop-name → coercer table for the editor config filter.
+	 *
+	 * Each coercer takes the filter-returned value plus the current prop
+	 * value and returns whatever should land on the prop; returning
+	 * `$current` is the "reject bad shape" fallback.
+	 *
+	 * @since 1.6.0
+	 *
+	 * @return array<string, callable(mixed, mixed): mixed>
+	 */
+	protected function configSchema(): array
+	{
+		$string             = static fn ( mixed $v, mixed $current ) => is_string( $v ) ? $v : $current;
+		$nullableString     = static fn ( mixed $v, mixed $current ) => is_string( $v ) || null === $v ? $v : $current;
+		$nullableArray      = static fn ( mixed $v, mixed $current ) => is_array( $v ) || null === $v ? $v : $current;
+		$nullableBool       = static fn ( mixed $v, mixed $current ) => is_bool( $v ) || null === $v ? $v : $current;
+		$nullableIntOrString = static fn ( mixed $v, mixed $current ) => is_int( $v ) || is_string( $v ) || null === $v ? $v : $current;
+		$array              = static fn ( mixed $v, mixed $current ) => is_array( $v ) ? $v : $current;
+
+		return [
+			'resource'             => $string,
+			'modelId'              => $string,
+			'apiBase'              => $string,
+			'initialTitle'         => $nullableString,
+			'initialSlug'          => $nullableString,
+			'initialStatus'        => $nullableString,
+			'initialExcerpt'       => $nullableString,
+			'initialFeaturedImage' => $nullableArray,
+			'initialAuthorId'      => $nullableIntOrString,
+			'initialCommentsOpen'  => $nullableBool,
+			'authorOptions'        => $nullableArray,
+			'supports'             => $nullableArray,
+			'previewUrl'           => $nullableString,
+			'initialCreatedAt'     => $nullableString,
+			'initialUpdatedAt'     => $nullableString,
+			'contentTypes'         => $array,
+			'breakpoints'          => $array,
+		];
 	}
 
 	/**

--- a/tests/Feature/VisualEditor/Adapters/CmsFramework/PostControllerTest.php
+++ b/tests/Feature/VisualEditor/Adapters/CmsFramework/PostControllerTest.php
@@ -218,3 +218,150 @@ it( 'returns 404 for a missing post', function () {
 
 	$this->getJson( '/visual-editor/api/posts/9999' )->assertNotFound();
 } );
+
+describe( 'lifecycle hooks', function (): void {
+	afterEach( function (): void {
+		removeAllActions( 'ap.visualEditor.postSaved' );
+		removeAllActions( 'ap.visualEditor.postPublished' );
+	} );
+
+	it( 'fires ap.visualEditor.postSaved on POST /posts', function (): void {
+		actor();
+
+		$captured = [];
+		addAction( 'ap.visualEditor.postSaved', function ( $id, $blocks ) use ( &$captured ): void {
+			$captured = [ 'id' => $id, 'blocks' => $blocks ];
+		}, 10, 2 );
+
+		$this->postJson( '/visual-editor/api/posts', [
+			'title'   => 'Fresh',
+			'status'  => 'draft',
+			'content' => [ 'raw' => '', 'blocks' => blockTree() ],
+		] )->assertCreated();
+
+		expect( $captured )->not->toBeEmpty()
+			->and( $captured['id'] )->toBeInt()
+			->and( $captured['blocks'] )->toEqual( blockTree() );
+	} );
+
+	it( 'fires postPublished on create-with-publish-status', function (): void {
+		actor();
+
+		$publishedCalls = 0;
+		addAction( 'ap.visualEditor.postPublished', function ( $id, $blocks ) use ( &$publishedCalls ): void {
+			$publishedCalls++;
+		}, 10, 2 );
+
+		$this->postJson( '/visual-editor/api/posts', [
+			'title'   => 'Live',
+			'status'  => 'publish',
+			'content' => [ 'raw' => '', 'blocks' => blockTree() ],
+		] )->assertCreated();
+
+		expect( $publishedCalls )->toBe( 1 );
+	} );
+
+	it( 'does not fire postPublished when creating with a non-publish status', function (): void {
+		actor();
+
+		$publishedCalls = 0;
+		addAction( 'ap.visualEditor.postPublished', function () use ( &$publishedCalls ): void {
+			$publishedCalls++;
+		} );
+
+		$this->postJson( '/visual-editor/api/posts', [
+			'title'   => 'Draft',
+			'status'  => 'draft',
+			'content' => [ 'raw' => '', 'blocks' => blockTree() ],
+		] )->assertCreated();
+
+		expect( $publishedCalls )->toBe( 0 );
+	} );
+
+	it( 'fires postPublished when the update transitions status into publish', function (): void {
+		actor();
+
+		// The fixture's `forVisualEditor()` scope filters to
+		// `status === 'published'`, so we can only exercise the update
+		// path with rows that pass the scope. Transitioning that row to
+		// the WP-canonical `publish` on update still crosses the
+		// non-publish → publish boundary the hook is meant to catch.
+		$post = TestBlockContentModel::create( [
+			'title'   => 'Was Not Publish',
+			'status'  => 'published',
+			'content' => [],
+		] );
+
+		$publishedPayloads = [];
+		$savedPayloads     = [];
+		addAction( 'ap.visualEditor.postPublished', function ( $id, $blocks ) use ( &$publishedPayloads ): void {
+			$publishedPayloads[] = [ 'id' => $id, 'blocks' => $blocks ];
+		}, 10, 2 );
+		addAction( 'ap.visualEditor.postSaved', function ( $id, $blocks ) use ( &$savedPayloads ): void {
+			$savedPayloads[] = [ 'id' => $id, 'blocks' => $blocks ];
+		}, 10, 2 );
+
+		$this->putJson( "/visual-editor/api/posts/{$post->id}", [
+			'status'  => 'publish',
+			'content' => [ 'raw' => '', 'blocks' => blockTree() ],
+		] )->assertOk();
+
+		expect( $publishedPayloads )->toHaveCount( 1 )
+			->and( $savedPayloads )->toHaveCount( 1 )
+			->and( $publishedPayloads[0]['id'] )->toBe( $post->id )
+			->and( $publishedPayloads[0]['blocks'] )->toEqual( blockTree() )
+			->and( $savedPayloads[0]['id'] )->toBe( $post->id )
+			->and( $savedPayloads[0]['blocks'] )->toEqual( blockTree() );
+	} );
+
+	it( 'fires postSaved without postPublished when an update makes no status transition', function (): void {
+		actor();
+
+		$post = TestBlockContentModel::create( [
+			'title'   => 'Content-only',
+			'status'  => 'published',
+			'content' => [],
+		] );
+
+		$savedCalls     = 0;
+		$publishedCalls = 0;
+		addAction( 'ap.visualEditor.postSaved', function () use ( &$savedCalls ): void {
+			$savedCalls++;
+		} );
+		addAction( 'ap.visualEditor.postPublished', function () use ( &$publishedCalls ): void {
+			$publishedCalls++;
+		} );
+
+		$this->putJson( "/visual-editor/api/posts/{$post->id}", [
+			'title'   => 'Content-only (revised)',
+			'content' => [ 'raw' => '', 'blocks' => blockTree() ],
+		] )->assertOk();
+
+		expect( $savedCalls )->toBe( 1 )
+			->and( $publishedCalls )->toBe( 0 );
+	} );
+
+	it( 'does not re-fire postPublished when status stays at the same publish value', function (): void {
+		actor();
+
+		$post = TestBlockContentModel::create( [
+			'title'   => 'Already',
+			'status'  => 'published',
+			'content' => [],
+		] );
+
+		$publishedCalls = 0;
+		addAction( 'ap.visualEditor.postPublished', function () use ( &$publishedCalls ): void {
+			$publishedCalls++;
+		} );
+
+		// Same status on both sides — no transition — so no publish event.
+		$this->putJson( "/visual-editor/api/posts/{$post->id}", [
+			'title'   => 'Already (revised)',
+			'status'  => 'published',
+			'content' => [ 'raw' => '', 'blocks' => blockTree() ],
+		] )->assertOk();
+
+		expect( $publishedCalls )->toBe( 0 );
+	} );
+} );

--- a/tests/Feature/VisualEditor/VisualEditorComponentTest.php
+++ b/tests/Feature/VisualEditor/VisualEditorComponentTest.php
@@ -173,3 +173,126 @@ it( 'omits optional data attributes when the matching props are not supplied', f
 		->and( $html )->not->toContain( 'data-author-options=' )
 		->and( $html )->not->toContain( 'data-supports=' );
 } );
+
+describe( 'ap.visualEditor.editorConfig filter', function (): void {
+	afterEach( function (): void {
+		removeAllFilters( 'ap.visualEditor.editorConfig' );
+	} );
+
+	it( 'lets a callback rewrite props before render', function (): void {
+		$model = TestBlockContentModel::create( [
+			'title'   => 'Base',
+			'status'  => 'published',
+			'content' => [],
+		] );
+
+		addFilter( 'ap.visualEditor.editorConfig', function ( array $config, string $screen ): array {
+			$config['apiBase']      = '/custom/api';
+			$config['initialTitle'] = 'Filtered';
+
+			return $config;
+		}, 10, 2 );
+
+		$html = Blade::render(
+			'<x-visual-editor :model="$model" :initial-title="\'Base\'" />',
+			[ 'model' => $model ]
+		);
+
+		expect( $html )->toContain( 'data-api-base="/custom/api"' )
+			->and( $html )->toContain( 'data-title="Filtered"' );
+	} );
+
+	it( 'passes the "post" screen identifier so hosts can gate per surface', function (): void {
+		$model = TestBlockContentModel::create( [
+			'title'   => 'Screen',
+			'status'  => 'published',
+			'content' => [],
+		] );
+
+		$screensSeen = [];
+		addFilter( 'ap.visualEditor.editorConfig', function ( array $config, string $screen ) use ( &$screensSeen ): array {
+			$screensSeen[] = $screen;
+
+			return $config;
+		}, 10, 2 );
+
+		Blade::render(
+			'<x-visual-editor :model="$model" />',
+			[ 'model' => $model ]
+		);
+
+		expect( $screensSeen )->toBe( [ 'post' ] );
+	} );
+
+	it( 'ignores a non-array filter return so props survive intact', function (): void {
+		$model = TestBlockContentModel::create( [
+			'title'   => 'Intact',
+			'status'  => 'published',
+			'content' => [],
+		] );
+
+		addFilter( 'ap.visualEditor.editorConfig', function ( array $config, string $screen ): ?bool {
+			return null;
+		}, 10, 2 );
+
+		$html = Blade::render(
+			'<x-visual-editor :model="$model" />',
+			[ 'model' => $model ]
+		);
+
+		expect( $html )->toContain( 'data-resource="posts"' )
+			->and( $html )->toContain( 'data-api-base="/visual-editor/api"' );
+	} );
+
+	it( 'preserves props whose filtered value is a bad shape for the coercer', function (): void {
+		$model = TestBlockContentModel::create( [
+			'title'   => 'Coerce',
+			'status'  => 'published',
+			'content' => [],
+		] );
+
+		addFilter( 'ap.visualEditor.editorConfig', function ( array $config, string $screen ): array {
+			// Malformed values across each coercer type; every one should
+			// be rejected in favour of the current prop value.
+			$config['apiBase']             = 42;              // string coercer
+			$config['initialTitle']        = [ 'not string' ]; // nullableString
+			$config['initialCommentsOpen'] = 'yes';           // nullableBool
+			$config['authorOptions']       = 'oops';          // nullableArray
+			$config['initialAuthorId']     = true;            // nullableIntOrString — must not TypeError
+
+			return $config;
+		}, 10, 2 );
+
+		$html = Blade::render(
+			'<x-visual-editor :model="$model" :initial-title="\'Kept\'" />',
+			[ 'model' => $model ]
+		);
+
+		expect( $html )->toContain( 'data-api-base="/visual-editor/api"' )
+			->and( $html )->toContain( 'data-title="Kept"' )
+			// initialCommentsOpen was null (unset), so no data-comments-open should be emitted.
+			->and( $html )->not->toContain( 'data-comments-open=' )
+			->and( $html )->not->toContain( 'data-author-options=' );
+	} );
+
+	it( 'leaves omitted keys untouched when the filter returns a partial config', function (): void {
+		$model = TestBlockContentModel::create( [
+			'title'   => 'Partial',
+			'status'  => 'published',
+			'content' => [],
+		] );
+
+		addFilter( 'ap.visualEditor.editorConfig', function ( array $config, string $screen ): array {
+			return [ 'apiBase' => '/only-this' ];
+		}, 10, 2 );
+
+		$html = Blade::render(
+			'<x-visual-editor :model="$model" :initial-title="\'Untouched\'" />',
+			[ 'model' => $model ]
+		);
+
+		expect( $html )->toContain( 'data-api-base="/only-this"' )
+			->and( $html )->toContain( 'data-title="Untouched"' )
+			->and( $html )->toContain( 'data-resource="posts"' );
+	} );
+} );

--- a/tests/Unit/VisualEditor/BlockTypeRegistryTest.php
+++ b/tests/Unit/VisualEditor/BlockTypeRegistryTest.php
@@ -55,3 +55,40 @@ it( 'rejects block names missing a namespace', function () {
 
 	$registry->register( 'paragraph', [] );
 } )->throws( InvalidArgumentException::class );
+
+it( 'fires ap.visualEditor.blockRegistered on successful registration', function (): void {
+	$registry = new BlockTypeRegistry();
+	$seen     = [];
+
+	addAction( 'ap.visualEditor.blockRegistered', function ( string $name, array $config ) use ( &$seen ): void {
+		$seen[] = [ 'name' => $name, 'config' => $config ];
+	}, 10, 2 );
+
+	$registry->register( 'acme/hero', [ 'title' => 'Hero', 'category' => 'design' ] );
+
+	removeAllActions( 'ap.visualEditor.blockRegistered' );
+
+	expect( $seen )->toHaveCount( 1 )
+		->and( $seen[0]['name'] )->toBe( 'acme/hero' )
+		->and( $seen[0]['config']['title'] )->toBe( 'Hero' )
+		->and( $seen[0]['config']['name'] )->toBe( 'acme/hero' );
+} );
+
+it( 'does not fire ap.visualEditor.blockRegistered when the name is invalid', function (): void {
+	$registry = new BlockTypeRegistry();
+	$fired    = false;
+
+	addAction( 'ap.visualEditor.blockRegistered', function () use ( &$fired ): void {
+		$fired = true;
+	} );
+
+	try {
+		$registry->register( 'BAD NAME', [] );
+	} catch ( InvalidArgumentException $e ) {
+		// expected
+	}
+
+	removeAllActions( 'ap.visualEditor.blockRegistered' );
+
+	expect( $fired )->toBeFalse();
+} );

--- a/tests/Unit/VisualEditor/SiteEditor/Adapters/PatternAdapterTest.php
+++ b/tests/Unit/VisualEditor/SiteEditor/Adapters/PatternAdapterTest.php
@@ -109,6 +109,56 @@ describe( 'single-record envelope', function (): void {
 	} );
 } );
 
+describe( 'ap.visualEditor.patternRender filter', function (): void {
+	afterEach( function (): void {
+		removeAllFilters( 'ap.visualEditor.patternRender' );
+	} );
+
+	it( 'lets a callback rewrite the rendered raw content', function (): void {
+		addFilter( 'ap.visualEditor.patternRender', function ( string $html, string $slug, array $context ): string {
+			return $html . '<!-- filtered:' . $slug . ' -->';
+		}, 10, 3 );
+
+		$out = ( new PatternAdapter() )->toArray( makeResolvedPattern() );
+
+		expect( $out['content']['raw'] )->toBe( '<!-- wp:cover /--><!-- filtered:hero-banner -->' );
+	} );
+
+	it( 'passes source/synced/categories/block_types/post_types context so callbacks can gate per pattern shape', function (): void {
+		$captured = null;
+		addFilter( 'ap.visualEditor.patternRender', function ( string $html, string $slug, array $context ) use ( &$captured ): string {
+			$captured = $context;
+
+			return $html;
+		}, 10, 3 );
+
+		( new PatternAdapter() )->toArray( makeResolvedPattern( [
+			'source'     => 'user',
+			'synced'     => true,
+			'categories' => [ 'hero', 'promo' ],
+			'blockTypes' => [ 'core/cover', 'core/heading' ],
+			'postTypes'  => [ 'page' ],
+		] ) );
+
+		expect( $captured )->not->toBeNull()
+			->and( $captured['source'] )->toBe( 'user' )
+			->and( $captured['synced'] )->toBeTrue()
+			->and( $captured['categories'] )->toBe( [ 'hero', 'promo' ] )
+			->and( $captured['block_types'] )->toBe( [ 'core/cover', 'core/heading' ] )
+			->and( $captured['post_types'] )->toBe( [ 'page' ] );
+	} );
+
+	it( 'ignores a non-string filter return so the original content survives', function (): void {
+		addFilter( 'ap.visualEditor.patternRender', function ( string $html ): ?array {
+			return [ 'not', 'a', 'string' ];
+		} );
+
+		$out = ( new PatternAdapter() )->toArray( makeResolvedPattern() );
+
+		expect( $out['content']['raw'] )->toBe( '<!-- wp:cover /-->' );
+	} );
+} );
+
 describe( 'collection envelope', function (): void {
 	it( 'returns a flat list in iteration order', function (): void {
 		$patterns = [


### PR DESCRIPTION
## Description

Fills six high-value extension points in the visual-editor package, all under the canonical `ap.visualEditor.*` namespace introduced in #664. Each hook is documented in `docs/Hooks-and-Events.md` with a signature table + example.

**Closes:** #665

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #665

## Motivation and Context

`docs/plans/12-hooks.md` (Wave 5) called for filling in lifecycle-gap extension points across block registration, block rendering, post persistence, editor config assembly, and pattern rendering. visual-editor already had good coverage of the resource / template / global-styles filters; this PR closes the remaining ones.

## Changes Made

- **`blockRegistered`** (action) — fired at the end of `BlockTypeRegistry::register()`, catches both block.json + programmatic registrations. Payload: `(string $name, array $config)`.
- **`beforeRender`** (filter) — attributes filter in `BlockRenderer::renderBlock()`, fires after site-meta/loginout stamping. Non-array returns are discarded. Payload: `(array $attributes, string $name)`.
- **`postSaved` / `postPublished`** (actions) — fired by `WpEntityController::persistNew()` / `persistUpdate()` after every save. `postPublished` only fires on non-publish → `publish` transitions (create-with-publish or PUT that crosses the boundary). `$blocks` is read from the persisted model via `HasBlockContent::getBlockContent()`, so subscribers see the tree that actually landed after any mutators/observers, not the submitted payload. Payload: `(int|string $postId, array $blocks)`.
- **`editorConfig`** (filter) — applied by `VisualEditorComponent` on the assembled prop table. A table-driven coercer schema (`configSchema()`) re-hydrates typed props from the filtered result; extra keys can't leak and malformed values can't poison a typed prop. `screen()` returns `'post'` for the current component; a future site-editor component would override. Payload: `(array $config, string $screen)`.
- **`patternRender`** (filter) — applied by `PatternAdapter::toArray()` on rendered raw content. Context carries source, synced, categories, block_types, post_types. Payload: `(string $html, string $slug, array $context)`.
- Bumps `artisanpack-ui/hooks` to `^1.3` — helper globals are now always available, so `function_exists()` guards around `doAction()`/`applyFilters()` (including the pre-existing `renderedBlock` fire site) have been dropped for a uniform idiom.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS 15.7 (Darwin 25.5.0)
- PHP Version: 8.4.3 (fixture) / package requires ^8.2
- Project Version: `[Unreleased]` (branched from `release/1.5`)

**Tests Performed:**
1. Full suite green: `./vendor/bin/pest` — 4169 assertions, 0 failures.
2. Focused hook suite: 25 tests covering the six new hooks.
3. Adversarial `/code-review` pass across correctness, conventions, test coverage, and security dimensions — one bug caught (`initialAuthorId` coercer allowed non-`int|string|null` values to poison the typed prop) and fixed, plus 10 follow-on cleanups (hook naming consistency, `@since` bumps, missing PHPDoc tags, expanded coverage).

## Accessibility Tests Run

- [x] Keyboard navigation tested — n/a (no UI changes)
- [x] Screen reader tested — n/a
- [x] Color contrast verified — n/a
- [x] ARIA labels checked — n/a

**Details:** This PR only adds server-side hook fire sites and PHPDoc / README updates. No UI or CSS changes.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:**

- `tests/Unit/VisualEditor/BlockTypeRegistryTest.php` — happy-path fire + no-fire-on-invalid-name.
- `packages/visual-editor-renderer-blade/tests/Unit/BlockRendererTest.php` — attributes mutation, non-array-return guard, name passthrough.
- `tests/Feature/VisualEditor/Adapters/CmsFramework/PostControllerTest.php` — POST payload assertion, publish-on-create, no-fire-on-non-publish-create, PUT transition with `id`/`blocks` assertion on both hooks, no-transition PUT firing `postSaved` only, already-published no-op.
- `tests/Feature/VisualEditor/VisualEditorComponentTest.php` — filter rewrites props, `'post'` screen passed, non-array return preserves defaults, coercer rejection preserves typed props on malformed shapes, partial config leaves omitted keys untouched.
- `tests/Unit/VisualEditor/SiteEditor/Adapters/PatternAdapterTest.php` — content rewrite, full context (5 keys) passthrough, non-string return preserves original.

## Documentation

- [x] Inline code documentation added
- [x] README updated
- [ ] Wiki updated
- [ ] API documentation updated

**Documentation details:**

- `CHANGELOG.md` — `[Unreleased]` entry describes the six new hooks + the `^1.3` hooks bump.
- `README.md` — new "Lifecycle hooks" section under Extensibility with a hook / type / fire site / payload table.
- `docs/Hooks-and-Events.md` — full per-hook documentation with signature, example, and behavior notes.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [ ] Code has been linted — package has no linter script; matches existing WordPress-style spacing manually
- [x] Accessibility tests completed (n/a — no UI changes)
- [x] Code follows project style guide
- [x] Self-review completed (`/simplify` + `/code-review` local passes)
- [x] Comments added for complex code
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added six Visual Editor lifecycle hooks for block registration, rendering, post saving and publishing, editor configuration, and pattern rendering.
  * Added configurable editor settings and support for modifying block attributes and pattern HTML through hooks.
  * Post-publish notifications now trigger only when content transitions into a published state.

* **Documentation**
  * Documented the new Visual Editor hooks, including timing, payloads, signatures, and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->