### PR TITLE
Release v1.5.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ resources/js/visual-editor/blocks/**/upstream-diff-report.json
 # Tracking ~2,800 SVGs would bloat the repo for no gain — the script is
 # deterministic and the source is pinned in package.json. See #554.
 resources/icons/font-awesome/
+
+# The renderer-blade sub-package's vendor tree is dev-only — never ships.
+/packages/visual-editor-renderer-blade/vendor/
+/packages/visual-editor-renderer-blade/composer.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,7 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
-### Changed
-
-- **Bumped `artisanpack-ui/hooks` requirement to `^1.3` (#665).** The
-  hook fire sites added in #665 assume the helper globals are always
-  available, so the previous `^1.2` constraint's `function_exists()`
-  guards have been dropped in favour of the newer floor.
+## [1.5.0] - 2026-07-21
 
 ### Added
 
@@ -48,7 +43,12 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
       Context carries source, synced flag, categories, block_types,
       and post_types so callbacks can gate per pattern shape.
 
-## [1.5.0]
+### Changed
+
+- **Bumped `artisanpack-ui/hooks` requirement to `^1.3` (#665).** The
+  hook fire sites added in #665 assume the helper globals are always
+  available, so the previous `^1.2` constraint's `function_exists()`
+  guards have been dropped in favour of the newer floor.
 
 ### Changed (BREAKING)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,30 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+- **Site-editor resolvers accept numeric-string map keys (cms-framework #203).**
+  WordPress template hierarchy filenames like `404.html` / `500.html` double
+  as slugs. PHP auto-coerces numeric-string array keys to `int` at insertion
+  time and `array_merge` renumbers int-keyed entries sequentially, so
+  contributors of `ap.visual-editor.{templates,template-parts,patterns,navigation}`
+  cannot preserve the intended string key from upstream. `AbstractMapResolver`
+  now accepts `int` keys and re-keys the normalized output map by each value
+  object's own identifier via a new `identifierOf()` hook (`slug` for
+  templates/parts/patterns, `location` for menus). Empty identifiers and
+  identifier collisions across entries now throw
+  `SiteEditorRegistrationException` at first read instead of silently
+  producing an unaddressable / clobbered entry.
+
 ### Changed
 
+- **Site-editor map resolvers key by the entry's own identifier, not the
+  raw filter key.** Previously, `find( $rawKey )` succeeded when a
+  contributor supplied a filter map whose keys diverged from the entries'
+  own `slug` / `location`. That path is gone: `find()` now only resolves
+  by the value object's identifier. Contributors that already stamp the
+  matching `slug` / `location` on their entries (all first-party
+  contributors, including cms-framework) are unaffected.
 - **Canvas CSS endpoint delegates to cms-framework's `ThemeStylesheetReader`.**
   `GET /visual-editor/api/global-styles/css` now delegates the theme-file
   read to `ArtisanPackUI\CMSFramework\Modules\SiteEditor\Support\ThemeStylesheetReader`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,22 +6,47 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
-### Fixed
+## [1.5.0]
 
-- **Site-editor resolvers accept numeric-string map keys (cms-framework #203).**
-  WordPress template hierarchy filenames like `404.html` / `500.html` double
-  as slugs. PHP auto-coerces numeric-string array keys to `int` at insertion
-  time and `array_merge` renumbers int-keyed entries sequentially, so
-  contributors of `ap.visual-editor.{templates,template-parts,patterns,navigation}`
-  cannot preserve the intended string key from upstream. `AbstractMapResolver`
-  now accepts `int` keys and re-keys the normalized output map by each value
-  object's own identifier via a new `identifierOf()` hook (`slug` for
-  templates/parts/patterns, `location` for menus). Empty identifiers and
-  identifier collisions across entries now throw
-  `SiteEditorRegistrationException` at first read instead of silently
-  producing an unaddressable / clobbered entry.
+### Changed (BREAKING)
 
-### Changed
+- **Renamed every visual-editor hook to camelCase (#664).** The 13 PHP
+  hooks the package fires or subscribes to, plus the
+  `visual_editor.pre_publish_checks` cross-package hook, the
+  `ap.icons.register-icon-sets` bridge hook, and three JS-only hooks
+  (`background-controls`, `canvas-styles`, `document-panels`), now use
+  camelCase — matching the ArtisanPack UI ecosystem's naming convention.
+  Old names remain functional via `deprecateHook()` aliases registered by
+  `ArtisanPackUI\VisualEditor\Support\HookAliases` on the PHP side and a
+  bidirectional `@wordpress/hooks` shim in
+  `resources/js/visual-editor/support/hook-aliases.ts` on the JS side;
+  the JS shim runs at `Number.MIN_SAFE_INTEGER` priority so real
+  subscribers on the paired name are surfaced before priority-sorted
+  dispatch of the applied name's callbacks. A deprecation notice is
+  logged the first time an alias resolves per process. Rename table:
+
+    - `ap.visual-editor.resources` → `ap.visualEditor.resources`
+    - `ap.visual-editor.templates` → `ap.visualEditor.templates`
+    - `ap.visual-editor.template-parts` → `ap.visualEditor.templateParts`
+    - `ap.visual-editor.patterns` → `ap.visualEditor.patterns`
+    - `ap.visual-editor.global-styles` → `ap.visualEditor.globalStyles`
+    - `ap.visual-editor.navigation` → `ap.visualEditor.navigation`
+    - `ap.visual-editor.visibility.register-rules` → `ap.visualEditor.visibility.registerRules`
+    - `ap.visual-editor.visibility.evaluated` → `ap.visualEditor.visibility.evaluated`
+    - `ap.visual-editor.visibility.user-search-results` → `ap.visualEditor.visibility.userSearchResults`
+    - `ap.visual-editor.rendered-block` → `ap.visualEditor.renderedBlock`
+    - `ap.visual-editor.breadcrumbs.trail` → `ap.visualEditor.breadcrumbs.trail`
+    - `ap.visual-editor.loginout.envelope` → `ap.visualEditor.loginout.envelope`
+    - `ap.visual-editor.loginout.login-form` → `ap.visualEditor.loginout.loginForm`
+    - `visual_editor.pre_publish_checks` → `ap.visualEditor.prePublishChecks`
+    - `ap.icons.register-icon-sets` → `ap.icons.registerIconSets`
+    - `ap.visual-editor.background-controls` → `ap.visualEditor.backgroundControls`
+    - `ap.visual-editor.canvas-styles` → `ap.visualEditor.canvasStyles`
+    - `ap.visual-editor.document-panels` → `ap.visualEditor.documentPanels`
+
+  See `src/Support/HookAliases.php` for the full canonical list. Bumps
+  the `artisanpack-ui/hooks` Composer requirement to `^1.2` (v1.3.x in
+  practice) to pick up the `deprecateHook()` helper (v1.3.0).
 
 - **Site-editor map resolvers key by the entry's own identifier, not the
   raw filter key.** Previously, `find( $rawKey )` succeeded when a
@@ -44,6 +69,21 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   preserves the pre-change behavior (style.css only, historical banner
   text) so themes on older cms-framework releases keep the canvas parity
   the endpoint already delivered.
+
+### Fixed
+
+- **Site-editor resolvers accept numeric-string map keys (cms-framework #203).**
+  WordPress template hierarchy filenames like `404.html` / `500.html` double
+  as slugs. PHP auto-coerces numeric-string array keys to `int` at insertion
+  time and `array_merge` renumbers int-keyed entries sequentially, so
+  contributors of `ap.visualEditor.{templates,templateParts,patterns,navigation}`
+  cannot preserve the intended string key from upstream. `AbstractMapResolver`
+  now accepts `int` keys and re-keys the normalized output map by each value
+  object's own identifier via a new `identifierOf()` hook (`slug` for
+  templates/parts/patterns, `location` for menus). Empty identifiers and
+  identifier collisions across entries now throw
+  `SiteEditorRegistrationException` at first read instead of silently
+  producing an unaddressable / clobbered entry.
 
 ## [1.4.0] - 2026-07-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,48 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Changed
+
+- **Bumped `artisanpack-ui/hooks` requirement to `^1.3` (#665).** The
+  hook fire sites added in #665 assume the helper globals are always
+  available, so the previous `^1.2` constraint's `function_exists()`
+  guards have been dropped in favour of the newer floor.
+
+### Added
+
+- **Six new lifecycle hooks for editor and block integrations (#665).**
+  Fills in high-value extension points across block registration,
+  rendering, post persistence, editor config assembly, and pattern
+  rendering. All hooks live under the canonical `ap.visualEditor.*`
+  namespace introduced in #664:
+
+    - `ap.visualEditor.blockRegistered` — action, fires at the end of
+      block registration with `(string $name, array $config)`. Fires
+      through `BlockTypeRegistry::register()` so both `block.json`
+      registration and programmatic `registerBlockType()` calls emit.
+    - `ap.visualEditor.beforeRender` — filter on `(array $attributes,
+      string $name)` that runs inside `BlockRenderer::renderBlock()`
+      after site-meta / loginout stamping. Non-array returns are
+      discarded so a misbehaving callback can't blank the block.
+    - `ap.visualEditor.postSaved` — action fired from
+      `WpEntityController` after every POST/PUT persistence with
+      `(int|string $postId, array $blocks)`.
+    - `ap.visualEditor.postPublished` — action fired from the same
+      site whenever the current save transitions status into the
+      WP-canonical `publish` value (create-with-publish or
+      non-publish → publish on update). Same payload as `postSaved`.
+    - `ap.visualEditor.editorConfig` — filter applied by
+      `VisualEditorComponent` on the assembled config array with
+      `(array $config, string $screen)`; `$screen` is `'post'` for
+      the current component. Filtered values are re-hydrated onto
+      the component's typed props, so misbehaving returns can't
+      poison a `?string` prop.
+    - `ap.visualEditor.patternRender` — filter applied by
+      `PatternAdapter::toArray()` on the rendered raw content of a
+      pattern with `(string $html, string $slug, array $context)`.
+      Context carries source, synced flag, categories, block_types,
+      and post_types so callbacks can gate per pattern shape.
+
 ## [1.5.0]
 
 ### Changed (BREAKING)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Changed
+
+- **Canvas CSS endpoint delegates to cms-framework's `ThemeStylesheetReader`.**
+  `GET /visual-editor/api/global-styles/css` now delegates the theme-file
+  read to `ArtisanPackUI\CMSFramework\Modules\SiteEditor\Support\ThemeStylesheetReader`
+  when it's available (cms-framework ≥ 2.5). The endpoint now concatenates
+  emitter output + `themes/{slug}/style.css` + `themes/{slug}/editor.css`
+  (the last is new — closes the canvas half of cms-framework #199, giving
+  the site editor a WordPress `add_editor_style()` analog). Section banners
+  switch from `/* === theme stylesheet === */` to per-file banners
+  (`/* === style.css === */`, `/* === editor.css === */`) so devtools
+  inspection matches cms-framework's endpoint. Falls back to the inline
+  `readThemeStylesheet()` helper for cms-framework < 2.5 — the fallback
+  preserves the pre-change behavior (style.css only, historical banner
+  text) so themes on older cms-framework releases keep the canvas parity
+  the endpoint already delivered.
+
 ## [1.4.0] - 2026-07-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -263,7 +263,17 @@ for the site-editor pairing walkthrough.
 
 ## Extensibility
 
-### `ap.visual-editor.resources`
+> **Hook rename (v1.5.0, #664).** Every visual-editor hook now uses
+> camelCase — the old kebab-case names below (`ap.visual-editor.*`,
+> `ap.icons.register-icon-sets`, `visual_editor.pre_publish_checks`)
+> remain functional through `deprecateHook()` aliases and continue to
+> route callbacks to the canonical name, but log a deprecation notice
+> the first time each alias resolves per process. New code should use
+> the camelCase names. See
+> [`src/Support/HookAliases.php`](src/Support/HookAliases.php) for the
+> full rename table.
+
+### `ap.visualEditor.resources`
 
 Register slug → Eloquent model class mappings used by
 `/visual-editor/api/{resource}/{id}/content`. Filter contributions are
@@ -275,7 +285,7 @@ surface as `InvalidArgumentException` on first request rather than at
 boot, so a contributor's standalone install never trips host boot.
 
 ```php
-addFilter('ap.visual-editor.resources', function (array $resources): array {
+addFilter('ap.visualEditor.resources', function (array $resources): array {
     return array_merge([
         'posts' => App\Models\Post::class,
     ], $resources);
@@ -285,7 +295,7 @@ addFilter('ap.visual-editor.resources', function (array $resources): array {
 Full contract: [`docs/content-model.md`](docs/content-model.md#2-the-resource-map) and
 [`docs/Hooks-and-Events.md`](docs/Hooks-and-Events.md#ap-visual-editor-resources).
 
-### `ap.icons.register-icon-sets`
+### `ap.icons.registerIconSets`
 
 Editor chrome icons resolve through `artisanpack-ui/icons`. Register
 additional icon sets in a service provider — see the

--- a/README.md
+++ b/README.md
@@ -301,6 +301,22 @@ Editor chrome icons resolve through `artisanpack-ui/icons`. Register
 additional icon sets in a service provider — see the
 [`artisanpack-ui/icons`](https://github.com/ArtisanPack-UI/icons) docs.
 
+### Lifecycle hooks (v1.6.0, #665)
+
+Six additional hooks cover the block-registration, block-render,
+post-persistence, editor-config, and pattern-render lifecycles. The
+tables below summarise each; the full contract is documented in
+[`docs/Hooks-and-Events.md`](docs/Hooks-and-Events.md).
+
+| Hook | Type | Fired at | Payload |
+|---|---|---|---|
+| `ap.visualEditor.blockRegistered` | action | `BlockTypeRegistry::register()` end | `(string $name, array $config)` |
+| `ap.visualEditor.beforeRender` | filter | `BlockRenderer::renderBlock()` pre-render | `(array $attributes, string $name)` |
+| `ap.visualEditor.postSaved` | action | `WpEntityController::persistNew()` / `persistUpdate()` after save | `(int\|string $postId, array $blocks)` |
+| `ap.visualEditor.postPublished` | action | same site, only on non-publish → `publish` transitions | `(int\|string $postId, array $blocks)` |
+| `ap.visualEditor.editorConfig` | filter | `VisualEditorComponent::__construct()` config assembly | `(array $config, string $screen)` |
+| `ap.visualEditor.patternRender` | filter | `PatternAdapter::toArray()` on `content.raw` | `(string $html, string $slug, array $context)` |
+
 ---
 
 ## AI features

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "php": "^8.2",
     "illuminate/support": "^11.0|^12.0|^13.0",
     "artisanpack-ui/core": "^1.0",
-    "artisanpack-ui/hooks": "^1.2"
+    "artisanpack-ui/hooks": "^1.3"
   },
   "require-dev": {
     "pestphp/pest": "^3.8",

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "artisanpack-ui/visual-editor",
   "description": "A Gutenberg-powered visual editor for Laravel — post editor, site editor, and Blade/React/Vue block renderers.",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "type": "library",
   "license": "GPL-3.0-or-later",
   "autoload": {
@@ -30,7 +30,7 @@
     "php": "^8.2",
     "illuminate/support": "^11.0|^12.0|^13.0",
     "artisanpack-ui/core": "^1.0",
-    "artisanpack-ui/hooks": "^1.0"
+    "artisanpack-ui/hooks": "^1.2"
   },
   "require-dev": {
     "pestphp/pest": "^3.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "aef967ffa5a1ee1b440ab6cf8295fca0",
+    "content-hash": "1d3b78cda4f32b8d5b004c07ac3e5581",
     "packages": [
         {
             "name": "artisanpack-ui/core",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fbfdab56e05f0548e0b91bd4b0e43e3d",
+    "content-hash": "aef967ffa5a1ee1b440ab6cf8295fca0",
     "packages": [
         {
             "name": "artisanpack-ui/core",
@@ -77,20 +77,20 @@
         },
         {
             "name": "artisanpack-ui/hooks",
-            "version": "1.2.0",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ArtisanPack-UI/hooks.git",
-                "reference": "19f4e41737903639afd76e210b58db411b506873"
+                "reference": "2834223f643ee5e12f93edc816a6d2dca66d09aa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ArtisanPack-UI/hooks/zipball/19f4e41737903639afd76e210b58db411b506873",
-                "reference": "19f4e41737903639afd76e210b58db411b506873",
+                "url": "https://api.github.com/repos/ArtisanPack-UI/hooks/zipball/2834223f643ee5e12f93edc816a6d2dca66d09aa",
+                "reference": "2834223f643ee5e12f93edc816a6d2dca66d09aa",
                 "shasum": ""
             },
             "require": {
-                "illuminate/support": ">=5.3",
+                "illuminate/support": "^11.0|^12.0|^13.0",
                 "php": "^8.2"
             },
             "require-dev": {
@@ -137,9 +137,9 @@
             "description": "WordPress-style actions and filters for Laravel, with Blade directives and helper functions.",
             "support": {
                 "issues": "https://github.com/ArtisanPack-UI/hooks/issues",
-                "source": "https://github.com/ArtisanPack-UI/hooks/tree/v1.2.0"
+                "source": "https://github.com/ArtisanPack-UI/hooks/tree/v1.3.0"
             },
-            "time": "2025-11-22T23:15:16+00:00"
+            "time": "2026-07-20T18:37:59+00:00"
         },
         {
             "name": "brick/math",

--- a/config/visual-editor.php
+++ b/config/visual-editor.php
@@ -319,7 +319,7 @@ return [
 	| POST + CSRF — clicking the rendered link will hit a 405 unless the
 	| host either (a) registers a GET-side logout endpoint and points
 	| `logout_route` / `logout_path` at it, or (b) rewrites the resolved
-	| envelope through the `ap.visual-editor.loginout.envelope` filter
+	| envelope through the `ap.visualEditor.loginout.envelope` filter
 	| (e.g. swap in a `URL::signedRoute()` link to a GET handler that
 	| invalidates the session). The default of `logout` is kept because
 	| dropping it would mean `logout_path` shows through as a relative
@@ -328,7 +328,7 @@ return [
 	|
 	| For fully custom URL resolution (per-tenant routes, SSO, etc.)
 	| override the resolved envelope through the
-	| `ap.visual-editor.loginout.envelope` filter hook instead.
+	| `ap.visualEditor.loginout.envelope` filter hook instead.
 	|
 	*/
 
@@ -350,7 +350,7 @@ return [
 	| resolver. The resolver builds a default trail
 	| (`Home → …ancestors → current`) for every breadcrumbs block on
 	| render; hosts customize the trail through the
-	| `ap.visual-editor.breadcrumbs.trail` filter (e.g. to insert a
+	| `ap.visualEditor.breadcrumbs.trail` filter (e.g. to insert a
 	| "Category" hop between Home and a blog post).
 	|
 	| `home_url` overrides the root link target — leave null to fall back
@@ -556,7 +556,7 @@ return [
 	|
 	| Static-config entry points for the five site-editor entity types. Each
 	| key is also a filter slug — packages like cms-framework register their
-	| entities at runtime through `addFilter('ap.visual-editor.{type}', ...)`.
+	| entities at runtime through `addFilter('ap.visualEditor.{type}', ...)`.
 	|
 	| Static config wins on key collision: host-app entries listed here take
 	| precedence over filter-supplied entries with the same key.

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -23,7 +23,7 @@ Maps a URL-friendly slug to the Eloquent model class that backs it. The editor's
 
 Every listed model must use the `ArtisanPackUI\VisualEditor\Concerns\HasBlockContent` trait. Adding a new editable content type is a config change — no per-model controllers required.
 
-The map can also be extended at runtime via the `ap.visual-editor.resources` filter (cms-framework registers `Post` and `Page` this way). Static config wins on key collision.
+The map can also be extended at runtime via the `ap.visualEditor.resources` filter (cms-framework registers `Post` and `Page` this way). Static config wins on key collision.
 
 Full contract: [[Content Model#2-the-resource-map]].
 
@@ -134,9 +134,9 @@ Configures the `artisanpack/loginout` block's server-side renderer. The package 
 ],
 ```
 
-⚠️ **POST-vs-GET caveat for `logout_route`:** the block always emits a plain `<a>`, but Breeze / Jetstream / Fortify register `logout` as POST + CSRF — clicking the rendered link will hit a 405 unless the host either (a) registers a GET-side logout endpoint and points `logout_route` / `logout_path` at it, or (b) rewrites the resolved envelope through the `ap.visual-editor.loginout.envelope` filter.
+⚠️ **POST-vs-GET caveat for `logout_route`:** the block always emits a plain `<a>`, but Breeze / Jetstream / Fortify register `logout` as POST + CSRF — clicking the rendered link will hit a 405 unless the host either (a) registers a GET-side logout endpoint and points `logout_route` / `logout_path` at it, or (b) rewrites the resolved envelope through the `ap.visualEditor.loginout.envelope` filter.
 
-For fully custom URL resolution (per-tenant routes, SSO, etc.) override the resolved envelope through the `ap.visual-editor.loginout.envelope` filter hook.
+For fully custom URL resolution (per-tenant routes, SSO, etc.) override the resolved envelope through the `ap.visualEditor.loginout.envelope` filter hook.
 
 ---
 
@@ -221,7 +221,7 @@ See [[blocks/State Design Tools]] for the editor + developer workflow.
 
 ## `site-editor`
 
-Static-config entry points for the five site-editor entity types. Each key is also a filter slug — packages like cms-framework register their entities at runtime through `addFilter('ap.visual-editor.{type}', ...)`. Static config wins on key collision.
+Static-config entry points for the five site-editor entity types. Each key is also a filter slug — packages like cms-framework register their entities at runtime through `addFilter('ap.visualEditor.{type}', ...)`. Static config wins on key collision.
 
 ```php
 'site-editor' => [
@@ -245,11 +245,11 @@ Several configuration keys can also be extended via filter hooks at runtime — 
 
 | Key | Filter | Behaviour |
 |-----|--------|-----------|
-| `resources` | `ap.visual-editor.resources` | Merge slug → model class entries |
-| `site-editor.templates` | `ap.visual-editor.templates` | Merge template entries |
-| `site-editor.template-parts` | `ap.visual-editor.template-parts` | Merge template-part entries |
-| `site-editor.patterns` | `ap.visual-editor.patterns` | Merge pattern entries |
-| `site-editor.navigation` | `ap.visual-editor.navigation` | Merge menu entries |
+| `resources` | `ap.visualEditor.resources` | Merge slug → model class entries |
+| `site-editor.templates` | `ap.visualEditor.templates` | Merge template entries |
+| `site-editor.template-parts` | `ap.visualEditor.templateParts` | Merge template-part entries |
+| `site-editor.patterns` | `ap.visualEditor.patterns` | Merge pattern entries |
+| `site-editor.navigation` | `ap.visualEditor.navigation` | Merge menu entries |
 | `breakpoints` | (theme.json) | Replace/merge breakpoints from active theme |
 | `states` | (theme.json) | Replace/merge states from active theme |
 

--- a/docs/Hooks-and-Events.md
+++ b/docs/Hooks-and-Events.md
@@ -2,25 +2,35 @@
 
 The visual editor exposes extension points through four mechanisms:
 
-- **PHP filters** — `applyFilters('ap.visual-editor.*', ...)` for value transformation (resource map, site-editor entities, server-rendered block HTML, etc.)
-- **PHP actions** — `doAction('ap.visual-editor.*', ...)` for side effects
-- **JavaScript filters** — `addFilter('ap.visual-editor.*', ...)` via `@wordpress/hooks` for editor-side extension (document panels, background controls, canvas styles)
+- **PHP filters** — `applyFilters('ap.visualEditor.*', ...)` for value transformation (resource map, site-editor entities, server-rendered block HTML, etc.)
+- **PHP actions** — `doAction('ap.visualEditor.*', ...)` for side effects
+- **JavaScript filters** — `addFilter('ap.visualEditor.*', ...)` via `@wordpress/hooks` for editor-side extension (document panels, background controls, canvas styles)
 - **Browser events** — `CustomEvent` dispatched on `window` for client-side integration (autosave, change, save)
 
 All PHP hooks use the global helpers from [`artisanpack-ui/hooks`](https://github.com/ArtisanPack-UI/hooks). All browser events are plain `CustomEvent` instances dispatched on `window`.
+
+> **Hook rename (v1.5.0, #664).** Every visual-editor hook now uses
+> camelCase. The old kebab-case names (`ap.visual-editor.*`,
+> `ap.icons.register-icon-sets`, `visual_editor.pre_publish_checks`)
+> remain functional through `deprecateHook()` aliases that route
+> callbacks to the canonical name, but log a deprecation notice the
+> first time each alias resolves per process. New code should use the
+> camelCase names documented below. See
+> [`src/Support/HookAliases.php`](../src/Support/HookAliases.php) for
+> the full rename table.
 
 ---
 
 ## PHP filters
 
-### `ap.visual-editor.resources`
+### `ap.visualEditor.resources`
 
 Register slug → Eloquent model class mappings used by `/visual-editor/api/{resource}/{id}/content`.
 
 **Signature:** `array $resources -> array`
 
 ```php
-addFilter('ap.visual-editor.resources', function (array $resources): array {
+addFilter('ap.visualEditor.resources', function (array $resources): array {
     return array_merge([
         'posts' => App\Models\Post::class,
     ], $resources);
@@ -35,14 +45,14 @@ See [[Content Model#2-the-resource-map]] for the full contract.
 
 ---
 
-### `ap.visual-editor.templates` / `template-parts` / `patterns` / `navigation`
+### `ap.visualEditor.templates` / `templateParts` / `patterns` / `navigation`
 
 Register site-editor entities at runtime. Each filter slug merges into the matching `config('artisanpack.visual-editor.site-editor.*')` array.
 
 **Signature:** `array $entries -> array`
 
 ```php
-addFilter('ap.visual-editor.templates', function (array $templates): array {
+addFilter('ap.visualEditor.templates', function (array $templates): array {
     return array_merge([
         'single' => [
             'slug'    => 'single',
@@ -60,14 +70,14 @@ Entity shape contracts are documented in `config/visual-editor.php` and [[Config
 
 ---
 
-### `ap.visual-editor.loginout.envelope`
+### `ap.visualEditor.loginout.envelope`
 
 Rewrite the resolved envelope emitted by the `artisanpack/loginout` block before render. Useful for swapping in `URL::signedRoute()`, per-tenant routes, or SSO redirects.
 
 **Signature:** `array $envelope, array $context -> array`
 
 ```php
-addFilter('ap.visual-editor.loginout.envelope', function (array $envelope, array $context): array {
+addFilter('ap.visualEditor.loginout.envelope', function (array $envelope, array $context): array {
     if ($context['action'] === 'logout') {
         $envelope['url'] = URL::signedRoute('logout.get');
     }
@@ -77,12 +87,12 @@ addFilter('ap.visual-editor.loginout.envelope', function (array $envelope, array
 
 ---
 
-### `ap.icons.register-icon-sets`
+### `ap.icons.registerIconSets`
 
 The editor chrome resolves icons through `artisanpack-ui/icons`. Register additional icon sets in a service provider.
 
 ```php
-addFilter('ap.icons.register-icon-sets', function (IconSetRegistration $registry) {
+addFilter('ap.icons.registerIconSets', function (IconSetRegistration $registry) {
     $registry->addSet(__DIR__ . '/../../resources/icons', 'mypackage');
     return $registry;
 });
@@ -92,14 +102,14 @@ See the [`artisanpack-ui/icons`](https://github.com/ArtisanPack-UI/icons) docs f
 
 ---
 
-### `ap.visual-editor.rendered-block`
+### `ap.visualEditor.renderedBlock`
 
 Last-mile PHP filter applied to the rendered HTML of every block (static or dynamic) inside `packages/visual-editor-renderer-blade`'s `BlockRenderer::renderBlock()`. Runs on the server, at render-time, on every request that emits post content — not at save-time and not in JavaScript. Callbacks decorate output without each host having to fork the renderer.
 
 **Signature:** `string $html, string $blockName, array $attributes -> string`
 
 ```php
-addFilter('ap.visual-editor.rendered-block', function (string $html, string $name, array $attributes): string {
+addFilter('ap.visualEditor.renderedBlock', function (string $html, string $name, array $attributes): string {
     if ('artisanpack/group' !== $name) {
         return $html;
     }
@@ -209,7 +219,7 @@ Non-string returns are ignored so the underlying `rawContent` survives.
 
 Editor-side filters run through `@wordpress/hooks` inside the browser. Register callbacks with `addFilter(name, namespace, callback)` at editor bootstrap (the moment the app imports your package's entry module is enough — the editor evaluates each filter on every relevant render).
 
-### `ap.visual-editor.background-controls`
+### `ap.visualEditor.backgroundControls`
 
 Contribute panels to the shared background / appearance area of any block that opts into a background support (`supports.background` for image / gradient backgrounds, or `supports.color.background` for the color background). Applied by the built-in `editor.BlockEdit` HOC so external packages don't have to enumerate target blocks or wrap `BlockEdit` themselves — the target-block decision lives in the editor.
 
@@ -240,7 +250,7 @@ type BackgroundControlContext = {
 import { addFilter } from '@wordpress/hooks'
 
 addFilter(
-    'ap.visual-editor.background-controls',
+    'ap.visualEditor.backgroundControls',
     'artisanpack-ui/liquid-glass',
     (controls, { attributes, setAttributes, blockSupports }) => {
         // The HOC gates on either `supports.background` (image / gradient
@@ -280,11 +290,11 @@ Controls are deduped by `id` **before** sorting — a later `addFilter` at the s
 
 If a filter callback throws, the exception is caught, logged to `console.error`, and the block renders without any contributed panels for that render — one buggy third-party filter can't trip Gutenberg's per-block crash boundary. Callbacks with a non-numeric `priority` are silently rejected.
 
-Attributes are declared the standard Gutenberg way (`blocks.registerBlockType` filter). For static blocks, save-side rendering continues to go through `blocks.getSaveContent.extraProps`; for dynamic blocks, use the block's PHP render or the `ap.visual-editor.rendered-block` PHP filter (see the PHP filters section above).
+Attributes are declared the standard Gutenberg way (`blocks.registerBlockType` filter). For static blocks, save-side rendering continues to go through `blocks.getSaveContent.extraProps`; for dynamic blocks, use the block's PHP render or the `ap.visualEditor.renderedBlock` PHP filter (see the PHP filters section above).
 
 ---
 
-### `ap.visual-editor.document-panels`
+### `ap.visualEditor.documentPanels`
 
 Contribute panels to the Document tab of the inspector sidebar. Runs against an empty descriptor list at inspector render time; the return value replaces it.
 
@@ -304,7 +314,7 @@ Descriptors are sorted by `order` (default `100`, lower first) with ties falling
 
 ---
 
-### `ap.visual-editor.canvas-styles`
+### `ap.visualEditor.canvasStyles`
 
 Contribute additional stylesheets injected into the block canvas iframe. Applied once at module-load time inside the editor bundle and frozen for the session — register your filter before importing the editor entry module.
 

--- a/docs/Hooks-and-Events.md
+++ b/docs/Hooks-and-Events.md
@@ -114,6 +114,97 @@ addFilter('ap.visual-editor.rendered-block', function (string $html, string $nam
 
 ---
 
+### `ap.visualEditor.beforeRender`
+
+PHP filter applied inside `BlockRenderer::renderBlock()` **before** a block renders, giving hosts a chance to mutate the block's attributes. Fires after site-meta / loginout stamping so the resolved `_resolved*` keys are already present. Sibling of `rendered-block` (which runs after render).
+
+**Signature:** `array $attributes, string $blockName -> array`
+
+```php
+addFilter('ap.visualEditor.beforeRender', function (array $attributes, string $name): array {
+    if ('core/paragraph' !== $name) {
+        return $attributes;
+    }
+    $attributes['content'] = strtoupper($attributes['content'] ?? '');
+    return $attributes;
+}, 10, 2);
+```
+
+Non-array returns are ignored so a misbehaving callback can't blank the block.
+
+---
+
+### `ap.visualEditor.blockRegistered`
+
+PHP action fired at the end of block-type registration, from `BlockTypeRegistry::register()`. Covers both `block.json`-driven registration and programmatic `VisualEditor::registerBlockType()` calls.
+
+**Signature:** `string $name, array $config -> void`
+
+```php
+addAction('ap.visualEditor.blockRegistered', function (string $name, array $config): void {
+    // e.g. register block variations, per-block binding sources,
+    // per-block category assignment, etc.
+}, 10, 2);
+```
+
+---
+
+### `ap.visualEditor.postSaved` / `ap.visualEditor.postPublished`
+
+PHP actions fired by `WpEntityController` after every POST/PUT persistence (`postSaved`) and additionally when the current save transitions the record's `status` into the WP-canonical `publish` value (`postPublished`). Fire on both create-with-publish and non-publish → publish updates; re-saves of an already-published record fire `postSaved` only.
+
+**Signature:** `int|string $postId, array $blocks -> void`
+
+```php
+addAction('ap.visualEditor.postPublished', function ($postId, array $blocks): void {
+    // e.g. queue a search-index rebuild, send a webhook, purge a CDN, …
+}, 10, 2);
+```
+
+`$blocks` reflects the tree the client submitted in the current request under `content.blocks`; missing / malformed payloads collapse to `[]`.
+
+---
+
+### `ap.visualEditor.editorConfig`
+
+PHP filter applied by `VisualEditorComponent` on the assembled editor config before the Blade template emits its `data-*` attributes. `$screen` identifies the surface — `'post'` for the current component; a future site-editor surface would pass `'site'`.
+
+**Signature:** `array $config, string $screen -> array`
+
+```php
+addFilter('ap.visualEditor.editorConfig', function (array $config, string $screen): array {
+    if ('post' !== $screen) {
+        return $config;
+    }
+    $config['apiBase'] = '/custom/api';
+    return $config;
+}, 10, 2);
+```
+
+Only known keys are re-hydrated back onto the component's typed props — extra keys are ignored and non-array returns leave the assembled config intact.
+
+---
+
+### `ap.visualEditor.patternRender`
+
+PHP filter applied by `PatternAdapter::toArray()` on the rendered raw content of a pattern before it ships to the editor / consumer. Runs on every read.
+
+**Signature:** `string $html, string $slug, array $context -> string`
+
+```php
+addFilter('ap.visualEditor.patternRender', function (string $html, string $slug, array $context): string {
+    // $context carries: source, synced, categories, block_types, post_types
+    if ('user' !== $context['source']) {
+        return $html;
+    }
+    return str_replace('{{year}}', (string) date('Y'), $html);
+}, 10, 3);
+```
+
+Non-string returns are ignored so the underlying `rawContent` survives.
+
+---
+
 ## JavaScript filters
 
 Editor-side filters run through `@wordpress/hooks` inside the browser. Register callbacks with `addFilter(name, namespace, callback)` at editor bootstrap (the moment the app imports your package's entry module is enough — the editor evaluates each filter on every relevant render).

--- a/docs/blocks/Icon-Block.md
+++ b/docs/blocks/Icon-Block.md
@@ -59,13 +59,13 @@ The Inspector's link controls produce a wrapping `<a>` on the rendered icon. `ta
 
 ## Developer recipe — registering custom sets
 
-Packages register additional icon sets through the existing [`ap.icons.register-icon-sets`](https://github.com/ArtisanPack-UI/icons) filter from `artisanpack-ui/icons`. The Icon Block picks them up automatically — no Icon Block-specific registration is needed.
+Packages register additional icon sets through the existing [`ap.icons.registerIconSets`](https://github.com/ArtisanPack-UI/icons) filter from `artisanpack-ui/icons`. The Icon Block picks them up automatically — no Icon Block-specific registration is needed.
 
 ```php
 use ArtisanPackUI\Icons\Registries\IconSetRegistration;
 
 // In your service provider's boot() method:
-addFilter( 'ap.icons.register-icon-sets', function ( IconSetRegistration $registry ): IconSetRegistration {
+addFilter( 'ap.icons.registerIconSets', function ( IconSetRegistration $registry ): IconSetRegistration {
     $registry->addSet(
         __DIR__ . '/../../resources/icons/myset',
         'myset',
@@ -85,7 +85,7 @@ Admins can also import custom sets directly from the editor UI — useful for sh
 1. Open **Visual Editor → Icon sets** (admin-only; gated by the existing visual-editor management policy).
 2. Click **Upload set**, supply a **prefix**, a human-readable **label**, and a **zip** of SVG files.
 3. The server unpacks the zip, runs each SVG through `SvgSanitizer`, and persists the cleaned files to `storage/app/artisanpack/visual-editor/icons/{prefix}/`.
-4. The set is registered through `ap.icons.register-icon-sets` on the next boot and immediately becomes selectable in the picker.
+4. The set is registered through `ap.icons.registerIconSets` on the next boot and immediately becomes selectable in the picker.
 
 Non-SVG entries are listed in the upload report under `skipped`; SVGs that fail sanitization are listed under `failed`. A prefix collision (an existing bundled or uploaded set already using the same prefix) returns `409 Conflict` with the offending prefix surfaced in the error payload.
 
@@ -130,4 +130,4 @@ If the referenced icon set has been deleted (or never registered), the renderer 
 
 - Parent issue: [#494](https://github.com/ArtisanPack-UI/visual-editor/issues/494)
 - Phase 7 (cross-phase tests + docs): [#558](https://github.com/ArtisanPack-UI/visual-editor/issues/558)
-- Icon Sets API: `artisanpack-ui/icons` ([`ap.icons.register-icon-sets`](https://github.com/ArtisanPack-UI/icons))
+- Icon Sets API: `artisanpack-ui/icons` ([`ap.icons.registerIconSets`](https://github.com/ArtisanPack-UI/icons))

--- a/docs/content-model.md
+++ b/docs/content-model.md
@@ -84,7 +84,7 @@ PUT  /visual-editor/api/{resource}/{id}/content
 
 1. **Static config** — `config('artisanpack.visual-editor.resources')`
    in `config/artisanpack/visual-editor.php`.
-2. **Filter** — `ap.visual-editor.resources`, contributed by packages
+2. **Filter** — `ap.visualEditor.resources`, contributed by packages
    like cms-framework.
 
 ```php
@@ -99,7 +99,7 @@ return [
 
 ```php
 // From a package's service provider
-addFilter('ap.visual-editor.resources', function (array $resources): array {
+addFilter('ap.visualEditor.resources', function (array $resources): array {
     return array_merge([
         'posts' => MyPackage\Models\Post::class,
     ], $resources);

--- a/docs/home.md
+++ b/docs/home.md
@@ -175,4 +175,4 @@ For issues, feature requests, and contributions:
 
 ---
 
-*This documentation covers visual-editor v1.4.0*
+*This documentation covers visual-editor v1.5.0*

--- a/docs/post-editor/Getting-Started.md
+++ b/docs/post-editor/Getting-Started.md
@@ -57,7 +57,7 @@ return [
 
 The map's slug (`posts` here) becomes part of the REST URL: `/visual-editor/api/posts/{id}/content`. Multiple models can register under different slugs — `posts`, `pages`, `products`, anything.
 
-Models can also be registered at runtime via the `ap.visual-editor.resources` filter — see [[Hooks and Events#ap-visual-editor-resources]].
+Models can also be registered at runtime via the `ap.visualEditor.resources` filter — see [[Hooks and Events#ap-visualeditor-resources]].
 
 ---
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -144,7 +144,7 @@ Full theme contract: [Theming](post-editor/Theming.md).
 `PUT /visual-editor/api/{resource}/{id}/content` returns 404 with
 "Unknown resource '{slug}'". The slug isn't in
 `config('artisanpack.visual-editor.resources')` and no
-`ap.visual-editor.resources` filter contributor added it.
+`ap.visualEditor.resources` filter contributor added it.
 
 Check:
 

--- a/docs/visibility.md
+++ b/docs/visibility.md
@@ -98,11 +98,11 @@ return (
 ### Debug hook
 
 Every evaluation fires
-`ap.visual-editor.visibility.evaluated( decision, blockName, attributes, context )`.
+`ap.visualEditor.visibility.evaluated( decision, blockName, attributes, context )`.
 Listen from a service provider to answer "why is this block hidden?":
 
 ```php
-addAction( 'ap.visual-editor.visibility.evaluated', function ( $decision, $name, $attrs, $ctx ) {
+addAction( 'ap.visualEditor.visibility.evaluated', function ( $decision, $name, $attrs, $ctx ) {
     if ( $decision->isHidden() ) {
         \Log::debug( sprintf(
             '%s hidden by %s (viewer: %s)',
@@ -117,12 +117,12 @@ addAction( 'ap.visual-editor.visibility.evaluated', function ( $decision, $name,
 ### Adding a custom rule
 
 Implement the `VisibilityRule` interface and register through the
-`ap.visual-editor.visibility.register-rules` filter:
+`ap.visualEditor.visibility.registerRules` filter:
 
 ```php
 use ArtisanPackUI\VisualEditor\Visibility\RuleRegistry;
 
-addFilter( 'ap.visual-editor.visibility.register-rules', function ( RuleRegistry $registry ) {
+addFilter( 'ap.visualEditor.visibility.registerRules', function ( RuleRegistry $registry ) {
     $registry->register( new \App\Visibility\CookieRule() );
     return $registry;
 } );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@artisanpack-ui/visual-editor",
-    "version": "1.4.0",
+    "version": "1.5.0",
     "private": true,
     "type": "module",
     "exports": {

--- a/packages/visual-editor-renderer-blade/src/BlockRenderer.php
+++ b/packages/visual-editor-renderer-blade/src/BlockRenderer.php
@@ -353,6 +353,21 @@ class BlockRenderer
 		$attributes      = $this->normalizeAttributes( $block['attributes'] ?? [] );
 		$attributes      = $this->stampSiteMeta( $name, $attributes );
 		$attributes      = $this->stampLoginout( $name, $attributes );
+
+		// `ap.visualEditor.beforeRender` — last chance for hosts and
+		// extension packages to mutate the attributes a block will render
+		// with. Fires after site-meta / loginout stamping so the resolved
+		// `_resolved*` side-channel keys are already present, giving the
+		// filter access to both the raw attributes and their resolved
+		// values. Callbacks must return an array; non-array returns are
+		// ignored so a mistaken `null` / `false` return doesn't blank the
+		// block.
+		$filteredAttributes = applyFilters( 'ap.visualEditor.beforeRender', $attributes, $name );
+
+		if ( is_array( $filteredAttributes ) ) {
+			$attributes = $filteredAttributes;
+		}
+
 		$innerBlocks     = $this->normalizeInnerBlocks( $block['innerBlocks'] ?? [] );
 		$innerBlocksHtml = $this->renderInner( $innerBlocks );
 
@@ -393,12 +408,10 @@ class BlockRenderer
 		// Those keys are a package-internal contract and may change
 		// without notice — callbacks should treat them as read-only
 		// side-channel data, not stable public attributes.
-		if ( function_exists( 'applyFilters' ) ) {
-			$filtered = applyFilters( 'ap.visualEditor.renderedBlock', $html, $name, $attributes );
+		$filtered = applyFilters( 'ap.visualEditor.renderedBlock', $html, $name, $attributes );
 
-			if ( is_string( $filtered ) ) {
-				$html = $filtered;
-			}
+		if ( is_string( $filtered ) ) {
+			$html = $filtered;
 		}
 
 		return $html;

--- a/packages/visual-editor-renderer-blade/src/BlockRenderer.php
+++ b/packages/visual-editor-renderer-blade/src/BlockRenderer.php
@@ -369,7 +369,7 @@ class BlockRenderer
 			$html = $this->wrapWithScreenSizeCss( $html, $cssHiddenDecision );
 		}
 
-		// `ap.visual-editor.rendered-block` — last-mile hook for packages
+		// `ap.visualEditor.renderedBlock` — last-mile hook for packages
 		// that need to post-process a rendered block. Runs on every block
 		// (static or dynamic) so cross-cutting effects (frosted glass,
 		// motion wrappers, contrast overlays, etc.) can decorate output
@@ -394,7 +394,7 @@ class BlockRenderer
 		// without notice — callbacks should treat them as read-only
 		// side-channel data, not stable public attributes.
 		if ( function_exists( 'applyFilters' ) ) {
-			$filtered = applyFilters( 'ap.visual-editor.rendered-block', $html, $name, $attributes );
+			$filtered = applyFilters( 'ap.visualEditor.renderedBlock', $html, $name, $attributes );
 
 			if ( is_string( $filtered ) ) {
 				$html = $filtered;

--- a/packages/visual-editor-renderer-blade/src/Resolvers/BreadcrumbsResolver.php
+++ b/packages/visual-editor-renderer-blade/src/Resolvers/BreadcrumbsResolver.php
@@ -16,7 +16,7 @@
  * link and emits `aria-current="page"`.
  *
  * Hosts customize the trail through the
- * `ap.visual-editor.breadcrumbs.trail` filter — e.g. to insert a
+ * `ap.visualEditor.breadcrumbs.trail` filter — e.g. to insert a
  * "Category" hop between Home and a blog post — without having to
  * subclass the resolver. The filter receives the resolved trail, the
  * current post (or null), and the block's attributes.
@@ -121,7 +121,7 @@ class BreadcrumbsResolver
 	/**
 	 * Build the resolved trail for a single breadcrumbs block. The default
 	 * shape is `[Home, …ancestors, current]`. Hosts override the result
-	 * through the `ap.visual-editor.breadcrumbs.trail` filter when the
+	 * through the `ap.visualEditor.breadcrumbs.trail` filter when the
 	 * `artisanpack-ui/hooks` helper is available.
 	 *
 	 * @since 1.0.0
@@ -138,7 +138,7 @@ class BreadcrumbsResolver
 		$trail = $this->defaultTrail( $post );
 
 		if ( function_exists( 'applyFilters' ) ) {
-			$filtered = applyFilters( 'ap.visual-editor.breadcrumbs.trail', $trail, $post, $attributes );
+			$filtered = applyFilters( 'ap.visualEditor.breadcrumbs.trail', $trail, $post, $attributes );
 
 			if ( is_array( $filtered ) ) {
 				$trail = $filtered;

--- a/packages/visual-editor-renderer-blade/src/Resolvers/LoginoutResolver.php
+++ b/packages/visual-editor-renderer-blade/src/Resolvers/LoginoutResolver.php
@@ -19,7 +19,7 @@
  *
  * Hosts that need fully custom resolution (per-tenant URLs, third-
  * party SSO, etc.) override the envelope through the
- * `ap.visual-editor.loginout.envelope` filter hook — the resolver
+ * `ap.visualEditor.loginout.envelope` filter hook — the resolver
  * applies the filter against the resolved defaults before returning.
  *
  * @package    ArtisanPack_UI
@@ -106,7 +106,7 @@ class LoginoutResolver
 		];
 
 		if ( function_exists( 'applyFilters' ) ) {
-			$filtered = applyFilters( 'ap.visual-editor.loginout.envelope', $envelope, $attributes );
+			$filtered = applyFilters( 'ap.visualEditor.loginout.envelope', $envelope, $attributes );
 
 			if ( is_array( $filtered ) ) {
 				$envelope = array_merge( $envelope, $filtered );
@@ -200,7 +200,7 @@ class LoginoutResolver
 	 *
 	 * The package ships no login form of its own; hosts return their
 	 * preferred form (typically a Blade view) via the
-	 * `ap.visual-editor.loginout.login-form` filter. The empty string
+	 * `ap.visualEditor.loginout.loginForm` filter. The empty string
 	 * disables the form display and the partial falls back to the
 	 * link variant.
 	 *
@@ -212,7 +212,7 @@ class LoginoutResolver
 			return '';
 		}
 
-		$html = applyFilters( 'ap.visual-editor.loginout.login-form', '', $currentUrl );
+		$html = applyFilters( 'ap.visualEditor.loginout.loginForm', '', $currentUrl );
 
 		return $this->coerceString( $html );
 	}

--- a/packages/visual-editor-renderer-blade/src/View/Components/BlocksComponent.php
+++ b/packages/visual-editor-renderer-blade/src/View/Components/BlocksComponent.php
@@ -146,7 +146,7 @@ class BlocksComponent extends Component
 		// `PostResolver` it tolerates a null `$post` (homepage, 404,
 		// archive without a single record in scope) and still produces a
 		// usable trail (just the "Home" entry, marked current). Hosts
-		// extend the trail through the `ap.visual-editor.breadcrumbs.trail`
+		// extend the trail through the `ap.visualEditor.breadcrumbs.trail`
 		// filter; see `BreadcrumbsResolver::buildTrail()`.
 		$resolved = $resolveBreadcrumbs
 			? $this->breadcrumbsResolver->stampTree( $resolved, is_object( $post ) ? $post : null )

--- a/packages/visual-editor-renderer-blade/tests/Feature/BreadcrumbsResolverTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Feature/BreadcrumbsResolverTest.php
@@ -19,7 +19,7 @@ declare( strict_types=1 );
  * - 404 / no post context still produces a `Home (current)` shell.
  * - The `breadcrumbsSchema` attribute is honored (the resolver is
  *   indifferent; the markup carries Schema.org itemtype attributes).
- * - Host filters through `ap.visual-editor.breadcrumbs.trail` override /
+ * - Host filters through `ap.visualEditor.breadcrumbs.trail` override /
  *   extend the trail without subclassing the resolver.
  * - Pre-stamped `_resolvedTrail` on the saved tree wins over the
  *   resolver fallback so a host that has resolved upstream keeps control.
@@ -62,7 +62,7 @@ function breadcrumbsFakePost( int $id, string $title, string $permalink = '', ?o
 
 beforeEach( function (): void {
 	if ( function_exists( 'removeAllFilters' ) ) {
-		removeAllFilters( 'ap.visual-editor.breadcrumbs.trail' );
+		removeAllFilters( 'ap.visualEditor.breadcrumbs.trail' );
 	}
 
 	config()->set( 'artisanpack.visual-editor.breadcrumbs.home_url', null );
@@ -210,7 +210,7 @@ it( 'allows hosts to override the trail through the filter hook', function () {
 		return;
 	}
 
-	addFilter( 'ap.visual-editor.breadcrumbs.trail', function ( array $trail, ?object $post, array $attributes ): array {
+	addFilter( 'ap.visualEditor.breadcrumbs.trail', function ( array $trail, ?object $post, array $attributes ): array {
 		return [
 			[ 'label' => 'Custom Home', 'url' => 'https://example.test/' ],
 			[ 'label' => 'Category: Travel', 'url' => '/category/travel' ],
@@ -241,7 +241,7 @@ it( 'passes the block attributes to the filter so hosts can branch on them', fun
 
 	$capturedAttrs = null;
 
-	addFilter( 'ap.visual-editor.breadcrumbs.trail', function ( array $trail, ?object $post, array $attributes ) use ( &$capturedAttrs ): array {
+	addFilter( 'ap.visualEditor.breadcrumbs.trail', function ( array $trail, ?object $post, array $attributes ) use ( &$capturedAttrs ): array {
 		$capturedAttrs = $attributes;
 
 		return $trail;
@@ -344,7 +344,7 @@ it( 'drops trail entries with blank labels through the filter', function () {
 		return;
 	}
 
-	addFilter( 'ap.visual-editor.breadcrumbs.trail', function ( array $trail, ?object $post, array $attributes ): array {
+	addFilter( 'ap.visualEditor.breadcrumbs.trail', function ( array $trail, ?object $post, array $attributes ): array {
 		return [
 			[ 'label' => 'Home', 'url' => '/' ],
 			[ 'label' => '', 'url' => '/dropped' ],

--- a/packages/visual-editor-renderer-blade/tests/Feature/LoginoutResolverTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Feature/LoginoutResolverTest.php
@@ -47,8 +47,8 @@ beforeEach( function (): void {
 	// Reset any custom URL filter from a prior case so each test starts
 	// from the same envelope baseline.
 	if ( function_exists( 'removeAllFilters' ) ) {
-		removeAllFilters( 'ap.visual-editor.loginout.envelope' );
-		removeAllFilters( 'ap.visual-editor.loginout.login-form' );
+		removeAllFilters( 'ap.visualEditor.loginout.envelope' );
+		removeAllFilters( 'ap.visualEditor.loginout.loginForm' );
 	}
 } );
 
@@ -123,7 +123,7 @@ it( 'honors a configured named login route over the literal path fallback', func
 
 it( 'shows the host-supplied login form for logged-out viewers when displayLoginAsForm is on', function () {
 	addFilter(
-		'ap.visual-editor.loginout.login-form',
+		'ap.visualEditor.loginout.loginForm',
 		fn ( string $_, string $current ): string => '<form data-test-form data-redirect="' . htmlspecialchars( $current ) . '"></form>'
 	);
 
@@ -142,7 +142,7 @@ it( 'shows the host-supplied login form for logged-out viewers when displayLogin
 
 it( 'keeps the logout link for logged-in viewers even when displayLoginAsForm is on', function () {
 	addFilter(
-		'ap.visual-editor.loginout.login-form',
+		'ap.visualEditor.loginout.loginForm',
 		fn (): string => '<form data-test-form></form>'
 	);
 
@@ -181,9 +181,9 @@ it( 'lets host-stamped resolved attributes win over the resolver fallback', func
 		->toContain( 'custom-class' );
 } );
 
-it( 'lets a host filter rewrite the resolved envelope through ap.visual-editor.loginout.envelope', function () {
+it( 'lets a host filter rewrite the resolved envelope through ap.visualEditor.loginout.envelope', function () {
 	addFilter(
-		'ap.visual-editor.loginout.envelope',
+		'ap.visualEditor.loginout.envelope',
 		fn ( array $envelope ): array => array_merge( $envelope, [
 			'url'   => 'https://sso.example/login',
 			'label' => 'Continue with SSO',
@@ -242,7 +242,7 @@ it( 'omits the has-login-form class when displayLoginAsForm is on but no host fo
 	// Matches the Blade partial's $showForm gate: the modifier class
 	// should only appear when a form will actually render. The resolver
 	// returns an empty loginFormHtml when the host hasn't wired the
-	// `ap.visual-editor.loginout.login-form` filter, so the wrapper
+	// `ap.visualEditor.loginout.loginForm` filter, so the wrapper
 	// must NOT promise a form that isn't there.
 	$rendered = $this->stripGlobalStyles( loginoutRenderTree( [
 		loginoutBlockNode( [

--- a/packages/visual-editor-renderer-blade/tests/Unit/BlockRendererTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Unit/BlockRendererTest.php
@@ -1483,3 +1483,55 @@ describe( 'Keystone #50 — block-supports compilation on the rendered HTML', fu
 		expect( $good )->toContain( 'is-content-justification-space-between' );
 	} );
 } );
+
+describe( 'ap.visualEditor.beforeRender filter', function (): void {
+	afterEach( function (): void {
+		removeAllFilters( 'ap.visualEditor.beforeRender' );
+	} );
+
+	it( 'lets a callback mutate attributes before the block renders', function (): void {
+		addFilter( 'ap.visualEditor.beforeRender', function ( array $attributes, string $name ): array {
+			if ( 'core/paragraph' !== $name ) {
+				return $attributes;
+			}
+
+			$attributes['content'] = 'Filtered';
+
+			return $attributes;
+		}, 10, 2 );
+
+		$html = makeRenderer()->render( [ makeBlock( 'core/paragraph', [ 'content' => 'Original' ] ) ] );
+
+		expect( $html )->toContain( 'Filtered' )
+			->not->toContain( 'Original' );
+	} );
+
+	it( 'ignores a non-array return so a misbehaving callback cannot corrupt the attributes', function (): void {
+		addFilter( 'ap.visualEditor.beforeRender', function ( array $attributes, string $name ): ?bool {
+			return null;
+		}, 10, 2 );
+
+		$html = makeRenderer()->render( [ makeBlock( 'core/paragraph', [ 'content' => 'Kept' ] ) ] );
+
+		expect( $html )->toContain( 'Kept' );
+	} );
+
+	it( 'receives the block name so callbacks can gate per-type', function (): void {
+		$namesSeen = [];
+
+		addFilter( 'ap.visualEditor.beforeRender', function ( array $attributes, string $name ) use ( &$namesSeen ): array {
+			$namesSeen[] = $name;
+
+			return $attributes;
+		}, 10, 2 );
+
+		makeRenderer()->render( [
+			makeBlock( 'core/group', [], [
+				makeBlock( 'core/paragraph', [ 'content' => 'A' ], [], 'p1' ),
+			] ),
+		] );
+
+		expect( $namesSeen )->toContain( 'core/group' )
+			->toContain( 'core/paragraph' );
+	} );
+} );

--- a/packages/visual-editor-renderer-blade/tests/Unit/BlockRendererTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Unit/BlockRendererTest.php
@@ -1229,10 +1229,10 @@ it( 'emits nothing for artisanpack/previous-post when no adjacent post is resolv
 	expect( $html )->toBe( '' );
 } );
 
-describe( 'ap.visual-editor.rendered-block filter', function (): void {
+describe( 'ap.visualEditor.renderedBlock filter', function (): void {
 	beforeEach( function (): void {
 		if ( function_exists( 'removeAllFilters' ) ) {
-			removeAllFilters( 'ap.visual-editor.rendered-block' );
+			removeAllFilters( 'ap.visualEditor.renderedBlock' );
 		}
 	} );
 
@@ -1243,7 +1243,7 @@ describe( 'ap.visual-editor.rendered-block filter', function (): void {
 			return;
 		}
 
-		addFilter( 'ap.visual-editor.rendered-block', function ( string $html, string $name ): string {
+		addFilter( 'ap.visualEditor.renderedBlock', function ( string $html, string $name ): string {
 			if ( 'core/paragraph' !== $name ) {
 				return $html;
 			}
@@ -1279,7 +1279,7 @@ describe( 'ap.visual-editor.rendered-block filter', function (): void {
 			}
 		} );
 
-		addFilter( 'ap.visual-editor.rendered-block', function ( string $html, string $name ): string {
+		addFilter( 'ap.visualEditor.renderedBlock', function ( string $html, string $name ): string {
 			if ( 'acme/filter-target' !== $name ) {
 				return $html;
 			}
@@ -1303,7 +1303,7 @@ describe( 'ap.visual-editor.rendered-block filter', function (): void {
 
 		$names = [];
 
-		addFilter( 'ap.visual-editor.rendered-block', function ( string $html, string $name ) use ( &$names ): string {
+		addFilter( 'ap.visualEditor.renderedBlock', function ( string $html, string $name ) use ( &$names ): string {
 			$names[] = $name;
 
 			return $html;
@@ -1331,7 +1331,7 @@ describe( 'ap.visual-editor.rendered-block filter', function (): void {
 			return;
 		}
 
-		addFilter( 'ap.visual-editor.rendered-block', function ( string $html ): array {
+		addFilter( 'ap.visualEditor.renderedBlock', function ( string $html ): array {
 			// A callback that forgets to return a string must not
 			// replace the HTML — otherwise the renderer would emit
 			// something like `Array` on `__toString`.
@@ -1352,7 +1352,7 @@ describe( 'ap.visual-editor.rendered-block filter', function (): void {
 
 		$capturedAttrs = null;
 
-		addFilter( 'ap.visual-editor.rendered-block', function ( string $html, string $name, array $attributes ) use ( &$capturedAttrs ): string {
+		addFilter( 'ap.visualEditor.renderedBlock', function ( string $html, string $name, array $attributes ) use ( &$capturedAttrs ): string {
 			if ( 'core/site-title' === $name ) {
 				$capturedAttrs = $attributes;
 			}

--- a/resources/js/visual-editor/background-controls/__tests__/background-controls.test.ts
+++ b/resources/js/visual-editor/background-controls/__tests__/background-controls.test.ts
@@ -41,8 +41,8 @@ async function loadModule(): Promise<
 }
 
 function registerFilter(callback: FilterCallback): void {
-    filters.set('ap.visual-editor.background-controls', [
-        ...(filters.get('ap.visual-editor.background-controls') ?? []),
+    filters.set('ap.visualEditor.backgroundControls', [
+        ...(filters.get('ap.visualEditor.backgroundControls') ?? []),
         callback,
     ]);
 }
@@ -334,7 +334,7 @@ describe('getFilteredBackgroundControls', () => {
         const { BACKGROUND_CONTROLS_FILTER } = await loadModule();
 
         expect(BACKGROUND_CONTROLS_FILTER).toBe(
-            'ap.visual-editor.background-controls'
+            'ap.visualEditor.backgroundControls'
         );
     });
 });

--- a/resources/js/visual-editor/background-controls/__tests__/with-background-controls.test.tsx
+++ b/resources/js/visual-editor/background-controls/__tests__/with-background-controls.test.tsx
@@ -82,8 +82,8 @@ vi.mock('@wordpress/blocks', () => ({
 }));
 
 function registerFilter(callback: FilterCallback): void {
-    filters.set('ap.visual-editor.background-controls', [
-        ...(filters.get('ap.visual-editor.background-controls') ?? []),
+    filters.set('ap.visualEditor.backgroundControls', [
+        ...(filters.get('ap.visualEditor.backgroundControls') ?? []),
         callback,
     ]);
 }

--- a/resources/js/visual-editor/background-controls/background-controls.ts
+++ b/resources/js/visual-editor/background-controls/background-controls.ts
@@ -6,7 +6,7 @@
  * External packages register their controls via `@wordpress/hooks`:
  *
  *     addFilter(
- *         'ap.visual-editor.background-controls',
+ *         'ap.visualEditor.backgroundControls',
  *         'my-package/glass',
  *         (controls, { attributes, setAttributes, blockSupports }) => {
  *             if ( ! blockSupports.background ) {
@@ -38,7 +38,7 @@ import { applyFilters } from '@wordpress/hooks';
 import type { ReactNode } from 'react';
 
 /** Filter name — exported so hosts can type against a constant. */
-export const BACKGROUND_CONTROLS_FILTER = 'ap.visual-editor.background-controls';
+export const BACKGROUND_CONTROLS_FILTER = 'ap.visualEditor.backgroundControls';
 
 /** Default priority for controls that don't set one. */
 export const DEFAULT_BACKGROUND_CONTROL_PRIORITY = 10;

--- a/resources/js/visual-editor/editor/__tests__/canvas-styles.filter.test.ts
+++ b/resources/js/visual-editor/editor/__tests__/canvas-styles.filter.test.ts
@@ -47,7 +47,7 @@ async function loadCanvasStyles(): Promise<
 }
 
 function registerCanvasStylesFilter(callback: FilterCallback): void {
-    filters.set('ap.visual-editor.canvas-styles', [callback]);
+    filters.set('ap.visualEditor.canvasStyles', [callback]);
 }
 
 describe('ap.visual-editor.canvas-styles filter', () => {

--- a/resources/js/visual-editor/editor/canvas-styles.ts
+++ b/resources/js/visual-editor/editor/canvas-styles.ts
@@ -233,7 +233,7 @@ const baseCanvasStyles: CanvasStyle[] = [
  * TIMING: `applyFilters` runs synchronously at module-load time inside
  * the IIFE below and the resulting `canvasStyles` export is frozen for
  * the rest of the session. Callbacks MUST be registered
- * (`addFilter('ap.visual-editor.canvas-styles', …)`) before this
+ * (`addFilter('ap.visualEditor.canvasStyles', …)`) before this
  * module is first imported — typically from a top-level side-effect
  * import that appears before the editor bundle in the app's entry
  * graph. Filters registered after the first import silently no-op:
@@ -241,7 +241,7 @@ const baseCanvasStyles: CanvasStyle[] = [
  */
 export const canvasStyles: readonly CanvasStyle[] = ( (): CanvasStyle[] => {
     const filtered = applyFilters(
-        'ap.visual-editor.canvas-styles',
+        'ap.visualEditor.canvasStyles',
         [...baseCanvasStyles],
     );
 

--- a/resources/js/visual-editor/editor/main.tsx
+++ b/resources/js/visual-editor/editor/main.tsx
@@ -11,6 +11,14 @@
 import { createElement } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 
+import { registerHookAliases } from '../support/hook-aliases';
+
+// Install #664 hook-name aliases at module load — before any first-party
+// or downstream block registration runs — so subscribers using the old
+// (kebab-case) hook names continue to fire when the editor applies the
+// new (camelCase) canonical names.
+registerHookAliases();
+
 import '../a11y.css';
 
 import type {

--- a/resources/js/visual-editor/editor/plugin-document-setting-panel.tsx
+++ b/resources/js/visual-editor/editor/plugin-document-setting-panel.tsx
@@ -37,7 +37,7 @@ const { Slot, Fill } = createSlotFill(SLOT_NAME);
  * Exported so host code can type-check the filter name against this
  * constant instead of hand-typing the string.
  */
-export const DOCUMENT_PANELS_FILTER = 'ap.visual-editor.document-panels';
+export const DOCUMENT_PANELS_FILTER = 'ap.visualEditor.documentPanels';
 
 export interface DocumentPanelSpec {
     /** Stable identifier; used as the React `key` and `data-panel-name`. */

--- a/resources/js/visual-editor/site-editor/__tests__/site-editor-app-css.test.ts
+++ b/resources/js/visual-editor/site-editor/__tests__/site-editor-app-css.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Regression check for the site-editor shell CSS layout (#666).
+ *
+ * The three-pane shell depends on an unbroken flex chain from `<html>`
+ * through the shell down to each panel's scroll container. When any
+ * link in that chain drops its `flex` / `min-height: 0` / `overflow`
+ * declarations, the sidebar / canvas / inspector collapse to their
+ * intrinsic content size and the whole page starts scrolling instead.
+ * This test asserts the presence of the layout-critical rules so a
+ * regression that removes them fails loudly rather than silently
+ * degrading the editor UX.
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+// `package.json` declares `"type": "module"`, so `__dirname` isn't
+// defined under raw Node ESM. Vitest happens to shim it, but building
+// the path from `import.meta.url` keeps the test portable to other
+// runners and to `node --test`.
+const HERE = dirname(fileURLToPath(import.meta.url));
+const CSS_PATH = resolve(HERE, '..', 'site-editor-app.css');
+
+function readCss(): string {
+    return readFileSync(CSS_PATH, 'utf8');
+}
+
+describe('site-editor-app.css layout chain (#666)', () => {
+    it('anchors html and the SPA body to the viewport', () => {
+        const css = readCss();
+
+        expect(css).toMatch(
+            /html,\s*\n?\s*\.ap-visual-editor-site-editor-body\s*\{[^}]*height:\s*100%/
+        );
+        expect(css).toMatch(
+            /html,\s*\n?\s*\.ap-visual-editor-site-editor-body\s*\{[^}]*overflow:\s*hidden/
+        );
+    });
+
+    it('promotes the mount div into a bounded flex column', () => {
+        const css = readCss();
+        const rule = css.match(
+            /\.ap-visual-editor-site-editor-body\s*>\s*#ap-visual-editor-site-editor\s*\{[^}]*\}/
+        );
+
+        expect(rule).not.toBeNull();
+        expect(rule?.[0]).toContain('height: 100%');
+        expect(rule?.[0]).toContain('display: flex');
+        expect(rule?.[0]).toContain('flex-direction: column');
+        expect(rule?.[0]).toContain('min-height: 0');
+        expect(rule?.[0]).toContain('overflow: hidden');
+    });
+
+    it('makes <main> a flex passthrough so the body flex chain reaches the panels', () => {
+        const css = readCss();
+        const rule = css.match(
+            /\.ap-site-editor__shell\s*>\s*main\s*\{[^}]*\}/
+        );
+
+        expect(rule).not.toBeNull();
+        expect(rule?.[0]).toContain('flex: 1 1 auto');
+        expect(rule?.[0]).toContain('display: flex');
+        expect(rule?.[0]).toContain('flex-direction: column');
+        expect(rule?.[0]).toContain('min-height: 0');
+        expect(rule?.[0]).toContain('overflow: hidden');
+    });
+
+    it('gives the canvas and inspector slots bounded flex heights so their children can scroll', () => {
+        const css = readCss();
+        const rule = css.match(
+            /\.ap-site-editor__canvas-slot,\s*\n?\s*\.ap-site-editor__inspector-slot\s*\{[^}]*\}/
+        );
+
+        expect(rule).not.toBeNull();
+        expect(rule?.[0]).toContain('flex: 1 1 auto');
+        expect(rule?.[0]).toContain('display: flex');
+        expect(rule?.[0]).toContain('flex-direction: column');
+        expect(rule?.[0]).toContain('min-height: 0');
+        expect(rule?.[0]).toContain('overflow: hidden');
+    });
+
+    it('makes the navigator slot a flex column for its own children (parent outlet is block, so fill props are omitted)', () => {
+        const css = readCss();
+        const rule = css.match(
+            /\.ap-site-editor__navigator-slot\s*\{[^}]*\}/
+        );
+
+        expect(rule).not.toBeNull();
+        expect(rule?.[0]).toContain('display: flex');
+        expect(rule?.[0]).toContain('flex-direction: column');
+    });
+});

--- a/resources/js/visual-editor/site-editor/main.tsx
+++ b/resources/js/visual-editor/site-editor/main.tsx
@@ -15,6 +15,13 @@
 import { createElement } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 
+import { registerHookAliases } from '../support/hook-aliases';
+
+// Install #664 hook-name aliases at module load. See editor/main.tsx for
+// the rationale — the site-editor shares the same hook surface as the
+// post editor.
+registerHookAliases();
+
 import '../a11y.css';
 import type { BreakpointRegistrySnapshot } from '../responsive/types';
 

--- a/resources/js/visual-editor/site-editor/patterns/__tests__/pattern-grid.test.tsx
+++ b/resources/js/visual-editor/site-editor/patterns/__tests__/pattern-grid.test.tsx
@@ -2,6 +2,20 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+// #667 — `PatternThumbnail` imports `parse` from `@wordpress/blocks`
+// so the pattern-grid module graph now transitively loads the real
+// package. Under jsdom it trips on a `type: json` import at the top of
+// the build. Stub `parse` so the module chain resolves; the theme-only
+// path we care about in this suite passes it a real Gutenberg comment
+// block and the stub echoes back a single block instance so the
+// thumbnail renders the non-empty summary.
+vi.mock('@wordpress/blocks', () => ({
+    parse: (source: string) =>
+        typeof source === 'string' && source.trim() !== ''
+            ? [{ name: 'core/heading', innerBlocks: [] }]
+            : [],
+}));
+
 import { PatternGrid } from '../pattern-grid';
 import type { PatternRecord } from '../api-client';
 
@@ -158,5 +172,56 @@ describe('<PatternGrid />', () => {
         const empty = await screen.findByTestId('ap-pattern-grid-empty');
 
         expect(empty).toHaveTextContent('No unsynced patterns yet');
+    });
+
+    it('shows the block tree for theme patterns that only ship rawContent (#667)', async () => {
+        // Theme-shipped patterns arrive with `blocks: []` because
+        // cms-framework's `PatternResolver::buildThemePattern()` only
+        // serializes `raw`. `PatternThumbnail` must parse the raw
+        // string client-side rather than falling through to the empty
+        // placeholder — otherwise every theme pattern renders as an
+        // "Empty pattern" card.
+        LIST_MOCK.mockResolvedValue([
+            makePattern({
+                id: 91,
+                slug: 'theme-hero',
+                title: { rendered: 'Theme hero' },
+                synced: false,
+                content: {
+                    raw:
+                        '<!-- wp:heading --><h2>Hi</h2><!-- /wp:heading -->' +
+                        '<!-- wp:paragraph --><p>Body</p><!-- /wp:paragraph -->',
+                    blocks: [],
+                },
+            }),
+        ]);
+
+        render(
+            <PatternGrid
+                apiConfig={API_CONFIG}
+                synced={false}
+                activeEntityId={null}
+                onEdit={() => undefined}
+                onConvertToUnsynced={() => undefined}
+                onDelete={() => undefined}
+                onCreate={() => undefined}
+            />
+        );
+
+        await waitFor(() =>
+            expect(
+                screen.getByTestId('ap-pattern-card-91')
+            ).toBeInTheDocument()
+        );
+
+        expect(screen.queryByTestId('ap-pattern-thumb-empty')).toBeNull();
+        expect(screen.getByTestId('ap-pattern-thumb')).toBeInTheDocument();
+        // The mocked `parse()` at the top of this file returns a
+        // single `core/heading` block for any non-empty source, so a
+        // successful raw-content fallback puts that name into the
+        // thumbnail's block-tree summary. Asserting the text guards
+        // against a regression where the thumbnail renders the
+        // wrapper markup but describeBlocks receives an empty array.
+        expect(screen.getByText('core/heading')).toBeInTheDocument();
     });
 });

--- a/resources/js/visual-editor/site-editor/patterns/__tests__/pattern-thumbnail.test.tsx
+++ b/resources/js/visual-editor/site-editor/patterns/__tests__/pattern-thumbnail.test.tsx
@@ -1,0 +1,142 @@
+/**
+ * Tests for `PatternThumbnail`.
+ *
+ * Covers the block-tree summary happy path and the #667 fix where a
+ * theme-shipped pattern arrives with `blocks: []` but a non-empty
+ * `rawContent`. The component parses the raw string client-side so the
+ * card shows the real tree instead of the "Empty pattern" placeholder.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const parseMock = vi.fn();
+
+vi.mock('@wordpress/blocks', () => ({
+    parse: (source: string) => parseMock(source),
+}));
+
+beforeEach(() => {
+    parseMock.mockReset();
+});
+
+// The i18n vendor module imports `@wordpress/i18n`. Its default export
+// covers `__()` — no mocking needed. Import after the mock is declared
+// so the parse override lands before the component's import graph.
+import { PatternThumbnail } from '../pattern-thumbnail';
+
+describe('<PatternThumbnail />', () => {
+    it('renders a block tree summary when blocks is populated', () => {
+        render(
+            <PatternThumbnail
+                blocks={[
+                    { name: 'core/paragraph', innerBlocks: [] },
+                    {
+                        name: 'core/columns',
+                        innerBlocks: [
+                            { name: 'core/column', innerBlocks: [] },
+                        ],
+                    },
+                ]}
+                title="Hero"
+            />
+        );
+
+        expect(screen.getByTestId('ap-pattern-thumb')).toBeInTheDocument();
+        expect(screen.getByText('core/paragraph')).toBeInTheDocument();
+        expect(screen.getByText('core/columns')).toBeInTheDocument();
+        expect(screen.getByText('core/column')).toBeInTheDocument();
+        expect(parseMock).not.toHaveBeenCalled();
+    });
+
+    it('renders the empty placeholder when blocks is empty and no rawContent is supplied', () => {
+        render(<PatternThumbnail blocks={[]} title="Empty" />);
+
+        expect(
+            screen.getByTestId('ap-pattern-thumb-empty')
+        ).toBeInTheDocument();
+        expect(parseMock).not.toHaveBeenCalled();
+    });
+
+    it('renders the empty placeholder when rawContent is present but only whitespace', () => {
+        render(
+            <PatternThumbnail
+                blocks={[]}
+                rawContent={'   \n   '}
+                title="Empty"
+            />
+        );
+
+        expect(
+            screen.getByTestId('ap-pattern-thumb-empty')
+        ).toBeInTheDocument();
+        expect(parseMock).not.toHaveBeenCalled();
+    });
+
+    it('parses rawContent when blocks is empty and shows the parsed tree (#667)', () => {
+        parseMock.mockReturnValueOnce([
+            { name: 'core/heading', innerBlocks: [] },
+            { name: 'core/paragraph', innerBlocks: [] },
+        ]);
+
+        const raw =
+            '<!-- wp:heading --><h2>Hi</h2><!-- /wp:heading -->' +
+            '<!-- wp:paragraph --><p>Body</p><!-- /wp:paragraph -->';
+
+        render(
+            <PatternThumbnail
+                blocks={[]}
+                rawContent={raw}
+                title="Theme pattern"
+            />
+        );
+
+        expect(parseMock).toHaveBeenCalledWith(raw);
+        expect(screen.getByTestId('ap-pattern-thumb')).toBeInTheDocument();
+        expect(screen.getByText('core/heading')).toBeInTheDocument();
+        expect(screen.getByText('core/paragraph')).toBeInTheDocument();
+        expect(
+            screen.queryByTestId('ap-pattern-thumb-empty')
+        ).not.toBeInTheDocument();
+    });
+
+    it('falls back to the empty placeholder and logs a warning when parsing rawContent throws', () => {
+        parseMock.mockImplementationOnce(() => {
+            throw new Error('boom');
+        });
+        const warnSpy = vi
+            .spyOn(console, 'warn')
+            .mockImplementation(() => undefined);
+
+        render(
+            <PatternThumbnail
+                blocks={[]}
+                rawContent="<!-- wp:broken -->"
+                title="Broken"
+            />
+        );
+
+        expect(
+            screen.getByTestId('ap-pattern-thumb-empty')
+        ).toBeInTheDocument();
+        expect(warnSpy).toHaveBeenCalledWith(
+            expect.stringContaining('Failed to parse pattern rawContent'),
+            expect.any(Error)
+        );
+
+        warnSpy.mockRestore();
+    });
+
+    it('prefers server-parsed blocks over rawContent when both are present', () => {
+        render(
+            <PatternThumbnail
+                blocks={[{ name: 'core/paragraph', innerBlocks: [] }]}
+                rawContent="<!-- wp:paragraph --><p>x</p><!-- /wp:paragraph -->"
+                title="Mixed"
+            />
+        );
+
+        expect(parseMock).not.toHaveBeenCalled();
+        expect(screen.getByText('core/paragraph')).toBeInTheDocument();
+    });
+});

--- a/resources/js/visual-editor/site-editor/patterns/pattern-grid.tsx
+++ b/resources/js/visual-editor/site-editor/patterns/pattern-grid.tsx
@@ -287,6 +287,7 @@ export function PatternGrid(props: PatternGridProps): JSX.Element {
                             >
                                 <PatternThumbnail
                                     blocks={pattern.content.blocks}
+                                    rawContent={pattern.content.raw}
                                     title={patternTitle(pattern)}
                                 />
                                 <header className="ap-pattern-card__header">

--- a/resources/js/visual-editor/site-editor/patterns/pattern-thumbnail.css
+++ b/resources/js/visual-editor/site-editor/patterns/pattern-thumbnail.css
@@ -1,4 +1,13 @@
 .ap-pattern-thumb {
+    /*
+     * `content-box` (the default) adds the 12px padding + 1px border on
+     * top of `width: 100%`, so the thumbnail extends ~26px past the
+     * card's inner width and pokes out of the card's rounded corner.
+     * `border-box` keeps the visible box inside the card, and the
+     * aspect-ratio computes from the same border-box so the card
+     * proportions stay stable.
+     */
+    box-sizing: border-box;
     width: 100%;
     aspect-ratio: 16 / 9;
     background: var(--ap-pattern-thumb-bg, #f9fafb);
@@ -30,12 +39,26 @@
     padding: 0;
     display: flex;
     flex-direction: column;
+    /*
+     * Keep the tree inside the thumb's border-box. Without a min-width,
+     * a long block name ("artisanpack/social-share-content") makes the
+     * flex column widen past `100%` and slips out to the right.
+     */
+    min-width: 0;
+    max-width: 100%;
 }
 
 .ap-pattern-thumb__tree li {
+    /*
+     * `white-space: pre` preserves the leading-space indent
+     * `describeBlocks()` emits for nested blocks; `overflow: hidden` +
+     * `text-overflow: ellipsis` clip the rest of a wide name so a
+     * verbose block slug can't spill past the card edge.
+     */
     white-space: pre;
     text-overflow: ellipsis;
     overflow: hidden;
+    max-width: 100%;
 }
 
 .ap-pattern-thumb__more {

--- a/resources/js/visual-editor/site-editor/patterns/pattern-thumbnail.tsx
+++ b/resources/js/visual-editor/site-editor/patterns/pattern-thumbnail.tsx
@@ -15,6 +15,7 @@
  * pattern-preview endpoint ships.
  */
 
+import { parse } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 import { useMemo } from 'react';
 
@@ -30,6 +31,15 @@ type BlockTreeNode = {
 
 export interface PatternThumbnailProps {
     blocks: readonly unknown[];
+    /**
+     * Serialized Gutenberg HTML for the pattern. When `blocks` is empty
+     * but `rawContent` is present — the case for theme-shipped patterns
+     * where cms-framework's `PatternResolver::buildThemePattern()`
+     * hardcodes `blocks: []` (#667) — parse it here so the thumbnail
+     * shows the real block tree instead of the "Empty pattern"
+     * placeholder.
+     */
+    rawContent?: string;
     title: string;
 }
 
@@ -91,11 +101,47 @@ function describeBlocks(
 }
 
 export function PatternThumbnail(props: PatternThumbnailProps): JSX.Element {
-    const { blocks, title } = props;
+    const { blocks, rawContent, title } = props;
 
-    const summary = useMemo(() => describeBlocks(blocks), [blocks]);
+    // #667 — theme-shipped patterns arrive with `blocks: []` because
+    // cms-framework only serializes `rawContent` for them. Parse the
+    // raw string with the same Gutenberg `parse()` helper `hydrateBlocks`
+    // uses so the summary reflects the real tree instead of falling
+    // through to the empty-state placeholder. Wrapped in try/catch so a
+    // malformed pattern doesn't crash the grid — an unparseable pattern
+    // just renders as empty, matching the existing degraded state.
+    const effectiveBlocks = useMemo<readonly unknown[]>(() => {
+        if (blocks.length > 0) {
+            return blocks;
+        }
 
-    if (blocks.length === 0) {
+        if (typeof rawContent === 'string' && rawContent.trim() !== '') {
+            try {
+                return parse(rawContent);
+            } catch (error) {
+                // Surface the failure so a broken theme pattern is
+                // distinguishable from an actually-empty one in
+                // DevTools — the placeholder fallback below looks
+                // identical in either case (#667).
+                // eslint-disable-next-line no-console
+                console.warn(
+                    '[artisanpack/visual-editor] Failed to parse pattern rawContent for thumbnail; rendering empty placeholder.',
+                    error
+                );
+
+                return [];
+            }
+        }
+
+        return [];
+    }, [blocks, rawContent]);
+
+    const summary = useMemo(
+        () => describeBlocks(effectiveBlocks),
+        [effectiveBlocks]
+    );
+
+    if (effectiveBlocks.length === 0) {
         return (
             <div
                 className="ap-pattern-thumb ap-pattern-thumb--empty"

--- a/resources/js/visual-editor/site-editor/site-editor-app.css
+++ b/resources/js/visual-editor/site-editor/site-editor-app.css
@@ -11,11 +11,34 @@
 
 @import '../editor/top-bar.css';
 
+/*
+ * #666 — anchor the SPA to the viewport so the three-pane shell can
+ * scroll its panels independently. Without `height: 100%` + `overflow:
+ * hidden` on the document ancestors, a tall sidebar / canvas / inspector
+ * pushes the whole page below the viewport and the panels' inner
+ * `overflow-y: auto` never engages (there's no bounded parent for
+ * `height: 100%` to resolve against). This stylesheet only ships with
+ * the site-editor bundle, so styling `html` unconditionally is safe.
+ */
+html,
+.ap-visual-editor-site-editor-body {
+    height: 100%;
+    overflow: hidden;
+}
+
 .ap-visual-editor-site-editor-body {
     margin: 0;
     background: var(--ap-site-editor-shell-background, var(--color-base-200, #f9fafb));
     color: var(--ap-site-editor-shell-foreground, var(--color-base-content, #1f2937));
     font-family: var(--ap-site-editor-font-family, system-ui, -apple-system, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif);
+}
+
+.ap-visual-editor-site-editor-body > #ap-visual-editor-site-editor {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    overflow: hidden;
 }
 
 .ap-site-editor__shell {
@@ -43,11 +66,61 @@
     }
 }
 
+/*
+ * #666 — the shell renders `.ap-site-editor__body` inside `<main>`, and
+ * `<main>` is a block-level element with no styling of its own. In a
+ * flex-column parent it collapses to its content, which breaks the
+ * `flex: 1 1 auto` chain below and leaves the body sized by its
+ * children rather than by the viewport. Promoting main to a flex-1
+ * passthrough re-establishes the chain so the sidebar / canvas /
+ * inspector each get a bounded height to constrain their own scroll.
+ */
+.ap-site-editor__shell > main {
+    flex: 1 1 auto;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    overflow: hidden;
+}
+
 .ap-site-editor__body {
     display: flex;
     flex: 1 1 auto;
     min-height: 0;
     overflow: hidden;
+}
+
+/*
+ * #666 — H7 (#432) portal targets for the canvas and inspector. The
+ * lazy sections (styles / navigation / patterns) render their canvas
+ * and inspector content into these slots. Without flex properties the
+ * slots collapse to their intrinsic size, so `height: 100%` inside a
+ * portaled child (e.g. `.ap-pattern-grid`) can't resolve and the child
+ * never scrolls. Both slots live in flex-column parents
+ * (`.ap-site-editor__canvas`, `.ap-site-editor__sidebar--inspector`)
+ * so the flex-1 fill applies.
+ */
+.ap-site-editor__canvas-slot,
+.ap-site-editor__inspector-slot {
+    flex: 1 1 auto;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    min-width: 0;
+    overflow: hidden;
+}
+
+/*
+ * Navigator slot is a sibling case: its parent
+ * `.ap-site-editor__navigator-outlet` uses block layout (with its own
+ * `overflow-y: auto`), so flex/min-* properties on the slot itself are
+ * inert. Only `display: flex; flex-direction: column;` matter — they
+ * let the portaled PatternsBrowser lay out as a flex column inside
+ * the slot. Height stays content-driven and the outlet handles scroll.
+ */
+.ap-site-editor__navigator-slot {
+    display: flex;
+    flex-direction: column;
 }
 
 .ap-site-editor__sidebar {

--- a/resources/js/visual-editor/support/__tests__/hook-aliases.test.ts
+++ b/resources/js/visual-editor/support/__tests__/hook-aliases.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Tests for `resources/js/visual-editor/support/hook-aliases.ts` (#664).
+ *
+ * Confirms bidirectional passthrough between renamed hook pairs, no
+ * infinite recursion when both names carry subscribers, and idempotent
+ * registration.
+ */
+
+import { addFilter, applyFilters, removeAllFilters } from '@wordpress/hooks';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+    __resetHookAliasesForTests,
+    registerHookAliases,
+} from '../hook-aliases';
+
+const OLD_RESOURCES = 'ap.visual-editor.resources';
+const NEW_RESOURCES = 'ap.visualEditor.resources';
+const OLD_TEMPLATES = 'ap.visual-editor.templates';
+const NEW_TEMPLATES = 'ap.visualEditor.templates';
+const OLD_RENDERED = 'ap.visual-editor.rendered-block';
+const NEW_RENDERED = 'ap.visualEditor.renderedBlock';
+
+const ALL_PAIRS: ReadonlyArray<readonly [string, string]> = [
+    [OLD_RESOURCES, NEW_RESOURCES],
+    [OLD_TEMPLATES, NEW_TEMPLATES],
+    [OLD_RENDERED, NEW_RENDERED],
+];
+
+function clearAll(): void {
+    for (const [oldName, newName] of ALL_PAIRS) {
+        removeAllFilters(oldName);
+        removeAllFilters(newName);
+    }
+}
+
+describe('registerHookAliases', () => {
+    beforeEach(() => {
+        __resetHookAliasesForTests();
+        clearAll();
+        registerHookAliases();
+    });
+
+    afterEach(() => {
+        __resetHookAliasesForTests();
+        clearAll();
+    });
+
+    it('routes old-name subscribers when new name is applied', () => {
+        let seen: unknown = null;
+        addFilter(
+            OLD_RESOURCES,
+            'test/old-subscriber',
+            (value: unknown) => {
+                seen = value;
+                return value;
+            },
+        );
+
+        const result = applyFilters(NEW_RESOURCES, { key: 'value' });
+
+        expect(seen).toEqual({ key: 'value' });
+        expect(result).toEqual({ key: 'value' });
+    });
+
+    it('routes new-name subscribers when old name is applied', () => {
+        let seen: unknown = null;
+        addFilter(
+            NEW_TEMPLATES,
+            'test/new-subscriber',
+            (value: unknown) => {
+                seen = value;
+                return value;
+            },
+        );
+
+        const result = applyFilters(OLD_TEMPLATES, ['a', 'b']);
+
+        expect(seen).toEqual(['a', 'b']);
+        expect(result).toEqual(['a', 'b']);
+    });
+
+    it('does not recurse infinitely when both names carry subscribers', () => {
+        let oldCalls = 0;
+        let newCalls = 0;
+
+        addFilter(OLD_RENDERED, 'test/count-old', (value: unknown) => {
+            oldCalls += 1;
+            return value;
+        });
+        addFilter(NEW_RENDERED, 'test/count-new', (value: unknown) => {
+            newCalls += 1;
+            return value;
+        });
+
+        // Applying either name should fire each subscriber exactly once.
+        applyFilters(NEW_RENDERED, 'html');
+        expect(oldCalls).toBe(1);
+        expect(newCalls).toBe(1);
+
+        applyFilters(OLD_RENDERED, 'html');
+        expect(oldCalls).toBe(2);
+        expect(newCalls).toBe(2);
+    });
+
+    it('is idempotent — second registerHookAliases() does not double-fire subscribers', () => {
+        let calls = 0;
+        addFilter(OLD_RESOURCES, 'test/idem', (value: unknown) => {
+            calls += 1;
+            return value;
+        });
+
+        registerHookAliases();
+        registerHookAliases();
+
+        applyFilters(NEW_RESOURCES, 'x');
+
+        expect(calls).toBe(1);
+    });
+});

--- a/resources/js/visual-editor/support/hook-aliases.ts
+++ b/resources/js/visual-editor/support/hook-aliases.ts
@@ -1,0 +1,185 @@
+/**
+ * JS hook name deprecation aliases.
+ *
+ * Issue #664 renamed every visual-editor hook from kebab-case to camelCase.
+ * The PHP side installs aliases via `deprecateHook()` from the
+ * `artisanpack-ui/hooks` package. `@wordpress/hooks` has no equivalent
+ * primitive, so this module installs bidirectional passthrough filters that
+ * route:
+ *
+ *   applyFilters(OLD, value, ...args)  →  new-name subscribers fire
+ *   applyFilters(NEW, value, ...args)  →  old-name subscribers still fire
+ *
+ * The alias handlers are registered at `Number.MIN_SAFE_INTEGER` priority
+ * so they always run *before* any real subscribers on the applied hook —
+ * that way real subscribers on the paired name are surfaced first via a
+ * nested `applyFilters(other, ...)` call, and the applied name's real
+ * subscribers then run in their natural priority order relative to the
+ * value that came out of the paired chain. This matches the "collect
+ * callbacks from every alias then dispatch in unified priority order"
+ * behavior of PHP `ManagesHookBuckets` (hooks 1.3) closely enough for the
+ * hook shapes visual-editor exposes.
+ *
+ * To avoid infinite recursion — the old-name filter re-applies the new
+ * name, whose own alias would re-apply the old name — a module-level
+ * re-entry counter guards each hook. A counter (not a Set) is required so
+ * nested `applyFilters` on the same hook name from user callbacks does
+ * not clear a guard the outer invocation set. Registration is idempotent
+ * via a separate `registeredPairs` Set.
+ *
+ * Call {@link registerHookAliases} once at the top of every editor bootstrap
+ * entry (post editor, site editor, sandbox) before any block registration
+ * runs, so subscribers registered by first-party or third-party code fire
+ * regardless of which name they used.
+ */
+
+import { addFilter, applyFilters } from '@wordpress/hooks';
+
+/**
+ * Priority slot for the alias forward/reverse handlers. `MIN_SAFE_INTEGER`
+ * so no realistic host-supplied priority puts a real subscriber ahead of
+ * the alias fan-out. Kept as a named constant so the intent is explicit.
+ */
+const ALIAS_PRIORITY = Number.MIN_SAFE_INTEGER;
+
+/**
+ * The exhaustive old-name → new-name rename table. Kept in lock-step with
+ * `ArtisanPackUI\VisualEditor\Support\HookAliases::RENAMES` on the PHP
+ * side. The three JS-only hooks (background-controls, canvas-styles,
+ * document-panels) live only here — they have no PHP counterpart.
+ */
+const RENAMES: ReadonlyArray<readonly [string, string]> = [
+    ['ap.visual-editor.resources', 'ap.visualEditor.resources'],
+    ['ap.visual-editor.templates', 'ap.visualEditor.templates'],
+    ['ap.visual-editor.template-parts', 'ap.visualEditor.templateParts'],
+    ['ap.visual-editor.patterns', 'ap.visualEditor.patterns'],
+    ['ap.visual-editor.global-styles', 'ap.visualEditor.globalStyles'],
+    ['ap.visual-editor.navigation', 'ap.visualEditor.navigation'],
+    [
+        'ap.visual-editor.visibility.register-rules',
+        'ap.visualEditor.visibility.registerRules',
+    ],
+    [
+        'ap.visual-editor.visibility.evaluated',
+        'ap.visualEditor.visibility.evaluated',
+    ],
+    [
+        'ap.visual-editor.visibility.user-search-results',
+        'ap.visualEditor.visibility.userSearchResults',
+    ],
+    ['ap.visual-editor.rendered-block', 'ap.visualEditor.renderedBlock'],
+    ['ap.visual-editor.breadcrumbs.trail', 'ap.visualEditor.breadcrumbs.trail'],
+    [
+        'ap.visual-editor.loginout.envelope',
+        'ap.visualEditor.loginout.envelope',
+    ],
+    [
+        'ap.visual-editor.loginout.login-form',
+        'ap.visualEditor.loginout.loginForm',
+    ],
+    ['ap.icons.register-icon-sets', 'ap.icons.registerIconSets'],
+    // JS-only hooks (no PHP counterpart) — renamed for surface consistency.
+    [
+        'ap.visual-editor.background-controls',
+        'ap.visualEditor.backgroundControls',
+    ],
+    ['ap.visual-editor.canvas-styles', 'ap.visualEditor.canvasStyles'],
+    ['ap.visual-editor.document-panels', 'ap.visualEditor.documentPanels'],
+];
+
+/**
+ * Pairs already installed this process. Guards `registerHookAliases()`
+ * from double-registering.
+ */
+const registeredPairs = new Set<string>();
+
+/**
+ * Per-hook re-entry counter. Incremented before a nested `applyFilters`
+ * routes to the paired name and decremented in `finally`. A callback that
+ * itself calls `applyFilters(sameHook, ...)` nests safely because each
+ * entry has its own increment/decrement pair.
+ */
+const reentryDepth = new Map<string, number>();
+
+function enter(hook: string): void {
+    reentryDepth.set(hook, (reentryDepth.get(hook) ?? 0) + 1);
+}
+
+function leave(hook: string): void {
+    const current = reentryDepth.get(hook) ?? 0;
+    if (current <= 1) {
+        reentryDepth.delete(hook);
+    } else {
+        reentryDepth.set(hook, current - 1);
+    }
+}
+
+function isReentering(hook: string): boolean {
+    return (reentryDepth.get(hook) ?? 0) > 0;
+}
+
+/**
+ * Install bidirectional aliases for every hook renamed in #664.
+ *
+ * Idempotent — a re-invocation is a no-op.
+ */
+export function registerHookAliases(): void {
+    for (const [oldName, newName] of RENAMES) {
+        const key = `${oldName}=>${newName}`;
+        if (registeredPairs.has(key)) {
+            continue;
+        }
+        registeredPairs.add(key);
+
+        // Old → new: subscribers to `applyFilters(oldName, ...)` still get
+        // to influence the value even though everything now applies under
+        // the new name.
+        addFilter(
+            oldName,
+            'artisanpack-ui/visual-editor/hook-alias-forward',
+            (value: unknown, ...args: unknown[]): unknown => {
+                if (isReentering(oldName)) {
+                    return value;
+                }
+                enter(newName);
+                try {
+                    return applyFilters(newName, value, ...args);
+                } finally {
+                    leave(newName);
+                }
+            },
+            ALIAS_PRIORITY,
+        );
+
+        // New → old: subscribers to `applyFilters(newName, ...)` fire even
+        // when legacy code applies the old name.
+        addFilter(
+            newName,
+            'artisanpack-ui/visual-editor/hook-alias-reverse',
+            (value: unknown, ...args: unknown[]): unknown => {
+                if (isReentering(newName)) {
+                    return value;
+                }
+                enter(oldName);
+                try {
+                    return applyFilters(oldName, value, ...args);
+                } finally {
+                    leave(oldName);
+                }
+            },
+            ALIAS_PRIORITY,
+        );
+    }
+}
+
+/**
+ * Test-only helper — resets the module-level guards so a fresh
+ * `registerHookAliases()` call installs aliases again. Not exported from
+ * the package's public surface.
+ *
+ * @internal
+ */
+export function __resetHookAliasesForTests(): void {
+    registeredPairs.clear();
+    reentryDepth.clear();
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -257,7 +257,7 @@ Route::get( 'search', [ EntitySearchController::class, 'index' ] )
 // #492 — user autocomplete for the "Specific User" visibility rule's
 // InspectorControls picker. Read-only; short-circuits to an empty
 // list when the current session isn't authenticated. Hosts can filter
-// results via `ap.visual-editor.visibility.user-search-results`.
+// results via `ap.visualEditor.visibility.userSearchResults`.
 Route::get( 'users/search', [ UsersSearchController::class, 'index' ] )
 	->name( 'visual-editor.api.visibility.users.search' );
 
@@ -307,7 +307,7 @@ Route::delete( 'admin/icon-sets/{prefix}', [ IconSetsManagementController::class
 // G3 cms-framework Post + Page entity adapters — see plan 12 §4.4.
 // Both controllers resolve their model through `ResourceResolver`, so
 // the host's `posts` / `pages` slugs (registered statically or via
-// the `ap.visual-editor.resources` filter) determine the underlying
+// the `ap.visualEditor.resources` filter) determine the underlying
 // Eloquent class. The legacy `posts/{post}` routes that bound to
 // `VisualEditorPost` were removed at this point in the M3→G3
 // migration — host apps that still reference that model directly

--- a/src/Http/Controllers/Adapters/CmsFramework/PostController.php
+++ b/src/Http/Controllers/Adapters/CmsFramework/PostController.php
@@ -6,7 +6,7 @@
  * Pinned to the `posts` slug; resolves the underlying model class
  * through {@see ResourceResolver} so cms-framework's
  * `Modules\Blog\Models\Post` (registered via the
- * `ap.visual-editor.resources` filter) — or a host-app override — is
+ * `ap.visualEditor.resources` filter) — or a host-app override — is
  * served without this controller importing the class. That keeps the
  * package booting standalone.
  *

--- a/src/Http/Controllers/Adapters/CmsFramework/WpEntityController.php
+++ b/src/Http/Controllers/Adapters/CmsFramework/WpEntityController.php
@@ -5,7 +5,7 @@
  *
  * Generic CRUD scaffolding for any `HasBlockContent` Eloquent model
  * registered in `config('artisanpack.visual-editor.resources')` (or
- * contributed via the `ap.visual-editor.resources` filter from #397).
+ * contributed via the `ap.visualEditor.resources` filter from #397).
  * Handles `index`, `show`, `destroy`, and the shared persistence
  * helpers; concrete subclasses ({@see PostController},
  * {@see PageController}) own their typed `store`/`update` so each

--- a/src/Http/Controllers/Adapters/CmsFramework/WpEntityController.php
+++ b/src/Http/Controllers/Adapters/CmsFramework/WpEntityController.php
@@ -155,6 +155,8 @@ abstract class WpEntityController extends Controller
 		$model = $this->setBlockContent( $model, $data );
 		$model->save();
 
+		$this->firePostLifecycleHooks( $model, null );
+
 		return $model;
 	}
 
@@ -173,11 +175,52 @@ abstract class WpEntityController extends Controller
 
 		Gate::authorize( 'update', $model );
 
+		$originalStatus = $model->getOriginal( 'status' );
+		$previousStatus = is_string( $originalStatus ) ? $originalStatus : null;
+
 		$model = $this->fill( $model, $data );
 		$model = $this->setBlockContent( $model, $data );
 		$model->save();
 
+		$this->firePostLifecycleHooks( $model, $previousStatus );
+
 		return $model;
+	}
+
+	/**
+	 * Fires `ap.visualEditor.postSaved` on every persistence, and
+	 * `ap.visualEditor.postPublished` when the current save transitions
+	 * the record into the `publish` status (create-with-publish, or
+	 * update from any non-publish status to `publish`). Subsequent saves
+	 * of an already-published record fire `postSaved` only — republishing
+	 * is not treated as a fresh publish event.
+	 *
+	 * `$blocks` is read from the persisted model via
+	 * {@see \ArtisanPackUI\VisualEditor\Concerns\HasBlockContent::getBlockContent()}
+	 * so subscribers see the tree that actually landed on disk (post any
+	 * model-side mutators / observers) rather than the submitted payload.
+	 *
+	 * @since 1.6.0
+	 *
+	 * @param  Model        $model           The freshly-persisted model.
+	 * @param  string|null  $previousStatus  The pre-save `status` value, or `null`
+	 *                                       on create.
+	 */
+	protected function firePostLifecycleHooks( Model $model, ?string $previousStatus ): void
+	{
+		$postId = $model->getKey();
+
+		if ( null === $postId ) {
+			return;
+		}
+
+		$blocks = method_exists( $model, 'getBlockContent' ) ? $model->getBlockContent() : [];
+
+		doAction( 'ap.visualEditor.postSaved', $postId, $blocks );
+
+		if ( 'publish' === $model->getAttribute( 'status' ) && 'publish' !== $previousStatus ) {
+			doAction( 'ap.visualEditor.postPublished', $postId, $blocks );
+		}
 	}
 
 	/**

--- a/src/Http/Controllers/SiteEditor/GlobalStylesController.php
+++ b/src/Http/Controllers/SiteEditor/GlobalStylesController.php
@@ -159,26 +159,34 @@ class GlobalStylesController extends Controller
 
 	/**
 	 * GET `/global-styles/css` — full canvas stylesheet for the active
-	 * theme. Concatenates two sources in order:
+	 * theme. Concatenates three sources in order:
 	 *
 	 *   1. cms-framework's `GlobalStylesEmitter::emit()` — compiled CSS
 	 *      from theme.json `settings` + `styles`, merged with any DB
 	 *      override the user authored through the Styles section.
 	 *   2. The theme's hand-authored `themes/{slug}/style.css` — the
 	 *      same stylesheet the public front-end loads via `<link rel>`.
+	 *   3. The theme's canvas-only `themes/{slug}/editor.css` — the
+	 *      analog of WordPress's `add_editor_style()`. Never emitted
+	 *      on the front-end, so themes can use bare element selectors
+	 *      here without theming inspector-panel mini-previews.
 	 *
 	 * Order matters: the emitter declares `--wp--preset--*` custom
-	 * properties on `:root`; the hand-authored sheet can consume those
-	 * tokens AND override emitter rules (button border-radius / padding
-	 * that the emitter doesn't compile yet, footer list resets, etc.).
+	 * properties on `:root` first; `style.css` can consume those tokens
+	 * and override emitter rules; `editor.css` runs last so canvas-only
+	 * overrides win.
 	 *
 	 * The site-editor canvas appends the full response to its
 	 * `BlockEditorProvider` `settings.styles` array so the iframe surface
-	 * matches the public front-end's branding 1:1 — closes the parity
-	 * gap that Keystone #47 surfaced. Front-end consumes the emitter
-	 * via the renderer-blade Blade components and loads its own
-	 * `<link rel="stylesheet">` to `style.css`; the canvas reaches
-	 * parity by getting both bundled into this one fetch.
+	 * matches the public front-end's branding 1:1 (Keystone #47) and
+	 * gains WordPress-style canvas-only overrides (cms-framework #199).
+	 *
+	 * File reads delegate to cms-framework's `ThemeStylesheetReader` so
+	 * slug validation, path-containment, and memoization stay in one
+	 * place. Falls back to the inline `readThemeStylesheet()` helper
+	 * for older cms-framework installs (`< 2.5`) that don't ship the
+	 * reader binding — the fallback covers `style.css` only, matching
+	 * this endpoint's pre-#199 behavior.
 	 *
 	 * Returns an empty `text/css` body when cms-framework is not
 	 * installed; the canvas treats that the same as "no theme styles"
@@ -197,17 +205,38 @@ class GlobalStylesController extends Controller
 			$emitted = is_string( $result ) ? $result : '';
 		}
 
-		$themeCss = $this->readThemeStylesheet();
+		$readerFqcn = 'ArtisanPackUI\\CMSFramework\\Modules\\SiteEditor\\Support\\ThemeStylesheetReader';
+		$parts      = [ rtrim( $emitted ) ];
 
-		$body = '' === $themeCss
-			? $emitted
-			: rtrim( $emitted ) . "\n\n/* === theme stylesheet === */\n" . $themeCss;
+		if ( class_exists( $readerFqcn ) && app()->bound( $readerFqcn ) ) {
+			$reader  = app( $readerFqcn );
+			$parts[] = $reader->readWrapped( 'style.css' );
+			$parts[] = $reader->readWrapped( 'editor.css' );
+		} else {
+			// Fallback for cms-framework < 2.5 (no reader binding yet):
+			// preserve the pre-#199 behavior of concatenating just
+			// `style.css` under its historical banner text so themes
+			// installed against older cms-framework releases keep the
+			// canvas parity the endpoint already delivered.
+			$themeCss = $this->readThemeStylesheet();
+
+			if ( '' !== $themeCss ) {
+				$parts[] = "/* === theme stylesheet === */\n" . $themeCss;
+			}
+		}
+
+		$body = implode( "\n\n", array_filter( $parts, static fn ( string $part ): bool => '' !== $part ) );
 
 		return response( $body, Response::HTTP_OK, [ 'Content-Type' => 'text/css; charset=utf-8' ] );
 	}
 
 	/**
-	 * Read the active theme's hand-authored `style.css` from disk.
+	 * Read the active theme's hand-authored `style.css` from disk —
+	 * fallback for cms-framework installs older than 2.5 that don't
+	 * ship the `ThemeStylesheetReader` binding. When the reader is
+	 * available the primary `css()` path uses it instead and this
+	 * method is not invoked.
+	 *
 	 * Returns an empty string when no theme is active, when the file
 	 * doesn't exist, or when the resolved path escapes the configured
 	 * themes directory (path-traversal guard — the theme slug rides in

--- a/src/Http/Controllers/SiteEditor/GlobalStylesController.php
+++ b/src/Http/Controllers/SiteEditor/GlobalStylesController.php
@@ -498,7 +498,7 @@ class GlobalStylesController extends Controller
 	{
 		$static = config( 'artisanpack.visual-editor.site-editor.global-styles' );
 		$static = is_array( $static ) ? $static : null;
-		$merged = applyFilters( 'ap.visual-editor.global-styles', $static );
+		$merged = applyFilters( 'ap.visualEditor.globalStyles', $static );
 		$merged = is_array( $merged ) ? $merged : $static;
 
 		$this->resolver = new GlobalStylesResolver( $merged );

--- a/src/Http/Controllers/SiteEditor/PatternController.php
+++ b/src/Http/Controllers/SiteEditor/PatternController.php
@@ -449,7 +449,7 @@ class PatternController extends Controller
 	protected function refreshResolver(): void
 	{
 		$static = (array) config( 'artisanpack.visual-editor.site-editor.patterns', [] );
-		$merged = applyFilters( 'ap.visual-editor.patterns', $static );
+		$merged = applyFilters( 'ap.visualEditor.patterns', $static );
 		$merged = is_array( $merged ) ? $merged : [];
 		$merged = array_merge( $merged, $static );
 

--- a/src/Http/Controllers/SiteEditor/TemplateController.php
+++ b/src/Http/Controllers/SiteEditor/TemplateController.php
@@ -601,7 +601,7 @@ class TemplateController extends Controller
 	protected function refreshResolver(): void
 	{
 		$static = (array) config( 'artisanpack.visual-editor.site-editor.templates', [] );
-		$merged = applyFilters( 'ap.visual-editor.templates', $static );
+		$merged = applyFilters( 'ap.visualEditor.templates', $static );
 		$merged = is_array( $merged ) ? $merged : [];
 		$merged = array_merge( $merged, $static );
 

--- a/src/Http/Controllers/SiteEditor/TemplatePartController.php
+++ b/src/Http/Controllers/SiteEditor/TemplatePartController.php
@@ -589,7 +589,7 @@ class TemplatePartController extends Controller
 	protected function refreshResolver(): void
 	{
 		$static = (array) config( 'artisanpack.visual-editor.site-editor.template-parts', [] );
-		$merged = applyFilters( 'ap.visual-editor.template-parts', $static );
+		$merged = applyFilters( 'ap.visualEditor.templateParts', $static );
 		$merged = is_array( $merged ) ? $merged : [];
 		$merged = array_merge( $merged, $static );
 

--- a/src/Http/Controllers/Visibility/UsersSearchController.php
+++ b/src/Http/Controllers/Visibility/UsersSearchController.php
@@ -10,7 +10,7 @@
  * The lookup is intentionally minimal — hosts with custom user models
  * or additional access constraints can rebind the controller through
  * the container, or filter results via the
- * `ap.visual-editor.visibility.user-search-results` filter.
+ * `ap.visualEditor.visibility.userSearchResults` filter.
  *
  * @package    ArtisanPack_UI
  * @subpackage VisualEditor
@@ -66,7 +66,7 @@ class UsersSearchController
 
 		if ( function_exists( 'applyFilters' ) ) {
 			try {
-				$filtered = applyFilters( 'ap.visual-editor.visibility.user-search-results', $rows, $term, $limit );
+				$filtered = applyFilters( 'ap.visualEditor.visibility.userSearchResults', $rows, $term, $limit );
 				if ( is_array( $filtered ) ) {
 					$rows = $filtered;
 				}

--- a/src/Http/Resources/Adapters/CmsFramework/SiteEditor/PatternAdapter.php
+++ b/src/Http/Resources/Adapters/CmsFramework/SiteEditor/PatternAdapter.php
@@ -49,6 +49,30 @@ class PatternAdapter
 	 */
 	public function toArray( ResolvedPattern $pattern ): array
 	{
+		// `ap.visualEditor.patternRender` — filter the rendered raw
+		// content of a pattern before it ships to the editor. Runs on
+		// every read so subscribers can inject dynamic content (shortcode
+		// expansion, per-request personalization tokens, etc.) without
+		// having to mutate the underlying block tree. The context array
+		// carries pattern-level metadata (source, synced flag) so hosts
+		// can gate their transform on theme-vs-user patterns cheaply.
+		// Non-string returns are discarded so a misbehaving callback
+		// can't blank the pattern.
+		$filtered = applyFilters(
+			'ap.visualEditor.patternRender',
+			$pattern->rawContent,
+			$pattern->slug,
+			[
+				'source'      => $pattern->source,
+				'synced'      => $pattern->synced,
+				'categories'  => $pattern->categories,
+				'block_types' => $pattern->blockTypes,
+				'post_types'  => $pattern->postTypes,
+			],
+		);
+
+		$rawContent = is_string( $filtered ) ? $filtered : $pattern->rawContent;
+
 		return [
 			'id'          => $pattern->wpId > 0 ? $pattern->wpId : $pattern->slug,
 			'slug'        => $pattern->slug,
@@ -59,7 +83,7 @@ class PatternAdapter
 				'raw'      => $pattern->title,
 			],
 			'content'     => [
-				'raw'    => $pattern->rawContent,
+				'raw'    => $rawContent,
 				'blocks' => $pattern->blocks,
 			],
 			'source'      => $pattern->source,

--- a/src/Registries/BlockTypeRegistry.php
+++ b/src/Registries/BlockTypeRegistry.php
@@ -58,6 +58,15 @@ class BlockTypeRegistry
 		}
 
 		$this->blocks[ $normalized ] = array_merge( ['name' => $normalized], $definition );
+
+		// `ap.visualEditor.blockRegistered` — fires once per registered block
+		// type, at the end of registration. Payload is the normalized block
+		// name and the merged definition array (block.json plus any
+		// programmatic overrides). Extensions typically use this to attach
+		// server-side runtime concerns (variations, bindings, category
+		// registration) that only make sense once a block has been accepted
+		// by the registry.
+		doAction( 'ap.visualEditor.blockRegistered', $normalized, $this->blocks[ $normalized ] );
 	}
 
 	/**

--- a/src/Resources/ResourceResolver.php
+++ b/src/Resources/ResourceResolver.php
@@ -35,7 +35,7 @@ class ResourceResolver
 	 *                                                         from
 	 *                                                         `config('artisanpack.visual-editor.resources')`
 	 *                                                         merged with the
-	 *                                                         `ap.visual-editor.resources` filter result.
+	 *                                                         `ap.visualEditor.resources` filter result.
 	 *                                                         The constructor performs no
 	 *                                                         validation on the entries — invalid
 	 *                                                         classes only surface on the first

--- a/src/Services/Icon/FontAwesomeFreeIconSets.php
+++ b/src/Services/Icon/FontAwesomeFreeIconSets.php
@@ -8,7 +8,7 @@
  * `resources/icons/font-awesome/{fas,far,fab}/` by `scripts/sync-fa-icons.mjs`.
  * This helper turns the on-disk layout into icon-set entries that the
  * `artisanpack-ui/icons` registry consumes via the
- * `ap.icons.register-icon-sets` filter.
+ * `ap.icons.registerIconSets` filter.
  *
  * @package    ArtisanPack_UI
  * @subpackage VisualEditor
@@ -73,7 +73,7 @@ final class FontAwesomeFreeIconSets
 	 * Register each discovered set on the supplied `IconSetRegistration`.
 	 *
 	 * Returns the same registry instance so this method can be used as the
-	 * body of an `ap.icons.register-icon-sets` filter callback. The
+	 * body of an `ap.icons.registerIconSets` filter callback. The
 	 * registry's `addSet()` throws when handed a non-existent path, which
 	 * is exactly why `discover()` filters them first — we want to no-op,
 	 * not blow up, when the FA Free directory is missing.

--- a/src/Services/Icon/IconSetUploader.php
+++ b/src/Services/Icon/IconSetUploader.php
@@ -38,7 +38,7 @@ use ZipArchive;
  *      icon landed — a zip that yields zero stored files is treated as a
  *      failed upload and no metadata is written.
  *
- * The uploader does NOT call into `ap.icons.register-icon-sets` itself —
+ * The uploader does NOT call into `ap.icons.registerIconSets` itself —
  * that happens at app boot, walking whatever the registry persisted.
  * Doing it here would skip the registration on the next process / queue
  * worker until the application rebooted, which would make uploaded

--- a/src/Services/Icon/IconSvgResolver.php
+++ b/src/Services/Icon/IconSvgResolver.php
@@ -5,7 +5,7 @@
  * the rendered Icon Block.
  *
  * The resolver is constructed once per request from the icon-sets
- * registry (`ap.icons.register-icon-sets` filter result) and cached as a
+ * registry (`ap.icons.registerIconSets` filter result) and cached as a
  * singleton. Lookups are file-system reads against the registered set
  * paths — bundled FA Free SVGs live under `resources/icons/font-awesome/`
  * after `scripts/sync-fa-icons.mjs` runs.
@@ -34,7 +34,7 @@ use Closure;
  * The path map can be supplied either eagerly (an `array` for tests +
  * fixtures) or lazily (a `Closure` that returns the array). The lazy
  * form is what production uses: the icon-sets registry is built from
- * the `ap.icons.register-icon-sets` filter, and that filter's
+ * the `ap.icons.registerIconSets` filter, and that filter's
  * callbacks are registered across multiple providers' `boot()` phases.
  * Running the filter at singleton-construction time would race against
  * those registrations — `IconBlock` is constructed early in `boot()`,

--- a/src/Services/Icon/UploadedIconSetRegistry.php
+++ b/src/Services/Icon/UploadedIconSetRegistry.php
@@ -6,7 +6,7 @@
  * Phase 6 (#557) of the Icon Block feature (#494). Persists set
  * metadata to `storage/app/artisanpack/visual-editor/icons/sets.json`
  * so the service provider can re-register uploaded sets against the
- * `ap.icons.register-icon-sets` filter on every boot without re-walking
+ * `ap.icons.registerIconSets` filter on every boot without re-walking
  * directories or re-validating zip uploads.
  *
  * @package    ArtisanPack_UI

--- a/src/SiteEditor/Exceptions/SiteEditorRegistrationException.php
+++ b/src/SiteEditor/Exceptions/SiteEditorRegistrationException.php
@@ -4,8 +4,8 @@
  * Site-editor registration exception.
  *
  * Thrown lazily — on the first {@see TemplateResolver::all()} (or sibling
- * resolver) call, never at boot — when an `ap.visual-editor.{templates,
- * template-parts,patterns,global-styles,navigation}` filter returns a
+ * resolver) call, never at boot — when an `ap.visualEditor.{templates,
+ * templateParts,patterns,globalStyles,navigation}` filter returns a
  * non-conforming shape or an entry is missing a required field.
  *
  * Lazy because `class_exists` registration sites in cms-framework register
@@ -36,7 +36,7 @@ class SiteEditorRegistrationException extends RuntimeException
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param  string  $filterName  The filter slug (e.g. `ap.visual-editor.templates`).
+	 * @param  string  $filterName  The filter slug (e.g. `ap.visualEditor.templates`).
 	 * @param  string  $expected    A short description of the expected shape.
 	 * @param  string  $actual      A short description of the actual shape.
 	 */

--- a/src/SiteEditor/Exceptions/SiteEditorRegistrationException.php
+++ b/src/SiteEditor/Exceptions/SiteEditorRegistrationException.php
@@ -89,4 +89,41 @@ class SiteEditorRegistrationException extends RuntimeException
 			$expected,
 		) );
 	}
+
+	/**
+	 * Two entries in a filter return map resolved to the same canonical
+	 * identifier (slug / location). One would silently overwrite the other,
+	 * so we surface it as a configuration error.
+	 *
+	 * @since 1.5.0
+	 *
+	 * @param  string  $filterName  The filter slug.
+	 * @param  string  $identifier  The colliding identifier value.
+	 */
+	public static function duplicateIdentifier( string $filterName, string $identifier ): self
+	{
+		return new self( sprintf(
+			'Filter "%s" produced two entries with the same identifier "%s"; one would silently overwrite the other.',
+			$filterName,
+			$identifier,
+		) );
+	}
+
+	/**
+	 * An entry's normalized value object returned an empty-string identifier,
+	 * which would produce an unaddressable `''` map key.
+	 *
+	 * @since 1.5.0
+	 *
+	 * @param  string  $filterName  The filter slug.
+	 * @param  string  $entryKey    The raw map key the entry arrived under.
+	 */
+	public static function emptyIdentifier( string $filterName, string $entryKey ): self
+	{
+		return new self( sprintf(
+			'Filter "%s" entry "%s" resolved to an empty identifier; expected a non-empty slug or location.',
+			$filterName,
+			$entryKey,
+		) );
+	}
 }

--- a/src/SiteEditor/Resolution/AbstractMapResolver.php
+++ b/src/SiteEditor/Resolution/AbstractMapResolver.php
@@ -150,7 +150,27 @@ abstract class AbstractMapResolver
 			// Key by the value object's own identifier so consumers see a
 			// canonical string-keyed map regardless of PHP's coercion or
 			// upstream `array_merge` reindexing at the filter site.
-			$out[ static::identifierOf( $normalized ) ] = $normalized;
+			$identifier = static::identifierOf( $normalized );
+
+			if ( '' === $identifier ) {
+				throw SiteEditorRegistrationException::emptyIdentifier(
+					static::filterName(),
+					$key,
+				);
+			}
+
+			// Re-keying can collapse two distinct raw entries into one when
+			// they claim the same slug / location. That's a configuration
+			// error, not a silent last-wins — surface it so the contributor
+			// knows to disambiguate.
+			if ( array_key_exists( $identifier, $out ) ) {
+				throw SiteEditorRegistrationException::duplicateIdentifier(
+					static::filterName(),
+					$identifier,
+				);
+			}
+
+			$out[ $identifier ] = $normalized;
 		}
 
 		return $out;
@@ -180,6 +200,11 @@ abstract class AbstractMapResolver
 	 * re-key the output map so the identifier the entry carries on itself
 	 * (slug, location, etc.) always wins over the raw filter key — which may
 	 * have been coerced to int by PHP or renumbered by `array_merge`.
+	 *
+	 * Must return a non-empty string; an empty value throws
+	 * {@see SiteEditorRegistrationException::emptyIdentifier()} at the call
+	 * site so a misconfigured value object surfaces immediately instead of
+	 * producing an unaddressable `''` map key.
 	 *
 	 * @since 1.5.0
 	 *

--- a/src/SiteEditor/Resolution/AbstractMapResolver.php
+++ b/src/SiteEditor/Resolution/AbstractMapResolver.php
@@ -119,7 +119,17 @@ abstract class AbstractMapResolver
 		$out = [];
 
 		foreach ( $entries as $key => $entry ) {
-			if ( ! is_string( $key ) || '' === $key ) {
+			// PHP auto-coerces numeric-string array keys to `int` when they
+			// enter an array (e.g. WordPress-style `404.html` → int `404`)
+			// and `array_merge` renumbers int-keyed entries sequentially, so
+			// contributors cannot preserve the intended string key at the
+			// language level. Accept `int` keys and cast back to string here
+			// so the raw key remains a legal fallback for entries that omit
+			// the identifier field; the final map is re-keyed below by the
+			// value object's own identifier, which survives both hazards.
+			if ( is_int( $key ) ) {
+				$key = (string) $key;
+			} elseif ( ! is_string( $key ) || '' === $key ) {
 				throw SiteEditorRegistrationException::invalidFilterShape(
 					static::filterName(),
 					'a map keyed by non-empty string',
@@ -135,10 +145,12 @@ abstract class AbstractMapResolver
 				);
 			}
 
-			// Stamp the map key onto the entry under the type-specific key
-			// field so the value object can default to it when the entry
-			// omits the field. The per-type subclass picks the right field.
-			$out[ $key ] = static::normalizeEntry( $key, $entry );
+			$normalized = static::normalizeEntry( $key, $entry );
+
+			// Key by the value object's own identifier so consumers see a
+			// canonical string-keyed map regardless of PHP's coercion or
+			// upstream `array_merge` reindexing at the filter site.
+			$out[ static::identifierOf( $normalized ) ] = $normalized;
 		}
 
 		return $out;
@@ -162,4 +174,16 @@ abstract class AbstractMapResolver
 	 * @return TValue
 	 */
 	abstract protected static function normalizeEntry( string $key, array $entry ): object;
+
+	/**
+	 * Extract the canonical map key from a normalized value object. Used to
+	 * re-key the output map so the identifier the entry carries on itself
+	 * (slug, location, etc.) always wins over the raw filter key — which may
+	 * have been coerced to int by PHP or renumbered by `array_merge`.
+	 *
+	 * @since 1.5.0
+	 *
+	 * @param  TValue  $entry
+	 */
+	abstract protected static function identifierOf( object $entry ): string;
 }

--- a/src/SiteEditor/Resolution/GlobalStylesResolver.php
+++ b/src/SiteEditor/Resolution/GlobalStylesResolver.php
@@ -5,7 +5,7 @@
  *
  * Singleton — one resolved object per active theme — distinct from the
  * map-shaped sibling resolvers. cms-framework's H3 GlobalStylesResolver
- * registers via `ap.visual-editor.global-styles`; H6 reads it through
+ * registers via `ap.visualEditor.globalStyles`; H6 reads it through
  * the `__unstableBase` REST adapter.
  *
  * @package    ArtisanPack_UI
@@ -25,7 +25,7 @@ class GlobalStylesResolver
 	/**
 	 * @since 1.0.0
 	 */
-	protected const FILTER_NAME = 'ap.visual-editor.global-styles';
+	protected const FILTER_NAME = 'ap.visualEditor.globalStyles';
 
 	/**
 	 * Raw filter input, deferred until first read.

--- a/src/SiteEditor/Resolution/MenuResolver.php
+++ b/src/SiteEditor/Resolution/MenuResolver.php
@@ -3,7 +3,7 @@
 /**
  * Site-editor menu (navigation) resolver.
  *
- * Consumes the merged `ap.visual-editor.navigation` filter result, keyed by
+ * Consumes the merged `ap.visualEditor.navigation` filter result, keyed by
  * theme-declared menu location.
  *
  * @package    ArtisanPack_UI
@@ -27,7 +27,7 @@ class MenuResolver extends AbstractMapResolver
 	 */
 	protected static function filterName(): string
 	{
-		return 'ap.visual-editor.navigation';
+		return 'ap.visualEditor.navigation';
 	}
 
 	/**

--- a/src/SiteEditor/Resolution/MenuResolver.php
+++ b/src/SiteEditor/Resolution/MenuResolver.php
@@ -42,4 +42,14 @@ class MenuResolver extends AbstractMapResolver
 
 		return ResolvedMenu::fromArray( $entry );
 	}
+
+	/**
+	 * @since 1.5.0
+	 *
+	 * @param  ResolvedMenu  $entry
+	 */
+	protected static function identifierOf( object $entry ): string
+	{
+		return $entry->location;
+	}
 }

--- a/src/SiteEditor/Resolution/PatternResolver.php
+++ b/src/SiteEditor/Resolution/PatternResolver.php
@@ -3,7 +3,7 @@
 /**
  * Site-editor pattern resolver.
  *
- * Consumes the merged `ap.visual-editor.patterns` filter result. Patterns
+ * Consumes the merged `ap.visualEditor.patterns` filter result. Patterns
  * cover both theme-shipped (`source: 'theme'`, read-only) and user-authored
  * (`source: 'user'`, editable) entries — the value object's `synced` field
  * distinguishes WP `wp_block` (synced) from `wp_block_pattern` (unsynced).
@@ -29,7 +29,7 @@ class PatternResolver extends AbstractMapResolver
 	 */
 	protected static function filterName(): string
 	{
-		return 'ap.visual-editor.patterns';
+		return 'ap.visualEditor.patterns';
 	}
 
 	/**

--- a/src/SiteEditor/Resolution/PatternResolver.php
+++ b/src/SiteEditor/Resolution/PatternResolver.php
@@ -43,4 +43,14 @@ class PatternResolver extends AbstractMapResolver
 
 		return ResolvedPattern::fromArray( $entry );
 	}
+
+	/**
+	 * @since 1.5.0
+	 *
+	 * @param  ResolvedPattern  $entry
+	 */
+	protected static function identifierOf( object $entry ): string
+	{
+		return $entry->slug;
+	}
 }

--- a/src/SiteEditor/Resolution/ResolvedGlobalStyles.php
+++ b/src/SiteEditor/Resolution/ResolvedGlobalStyles.php
@@ -26,7 +26,7 @@ class ResolvedGlobalStyles
 	/**
 	 * @since 1.0.0
 	 */
-	protected const FILTER_NAME = 'ap.visual-editor.global-styles';
+	protected const FILTER_NAME = 'ap.visualEditor.globalStyles';
 
 	/**
 	 * @since 1.0.0

--- a/src/SiteEditor/Resolution/ResolvedMenu.php
+++ b/src/SiteEditor/Resolution/ResolvedMenu.php
@@ -5,7 +5,7 @@
  *
  * Maps a theme-declared location (`primary`, `footer`, etc.) to a menu
  * record + its menu items. cms-framework's `MenuResolver` (H4) populates
- * this through the `ap.visual-editor.navigation` filter; H6's
+ * this through the `ap.visualEditor.navigation` filter; H6's
  * `wp_navigation` REST adapter reads it.
  *
  * @package    ArtisanPack_UI
@@ -27,7 +27,7 @@ class ResolvedMenu
 	/**
 	 * @since 1.0.0
 	 */
-	protected const FILTER_NAME = 'ap.visual-editor.navigation';
+	protected const FILTER_NAME = 'ap.visualEditor.navigation';
 
 	/**
 	 * @since 1.0.0

--- a/src/SiteEditor/Resolution/ResolvedPattern.php
+++ b/src/SiteEditor/Resolution/ResolvedPattern.php
@@ -27,7 +27,7 @@ class ResolvedPattern
 	/**
 	 * @since 1.0.0
 	 */
-	protected const FILTER_NAME = 'ap.visual-editor.patterns';
+	protected const FILTER_NAME = 'ap.visualEditor.patterns';
 
 	/**
 	 * @since 1.0.0

--- a/src/SiteEditor/Resolution/ResolvedTemplate.php
+++ b/src/SiteEditor/Resolution/ResolvedTemplate.php
@@ -29,7 +29,7 @@ class ResolvedTemplate
 	 *
 	 * @since 1.0.0
 	 */
-	protected const FILTER_NAME = 'ap.visual-editor.templates';
+	protected const FILTER_NAME = 'ap.visualEditor.templates';
 
 	/**
 	 * @since 1.0.0

--- a/src/SiteEditor/Resolution/ResolvedTemplatePart.php
+++ b/src/SiteEditor/Resolution/ResolvedTemplatePart.php
@@ -26,7 +26,7 @@ class ResolvedTemplatePart extends ResolvedTemplate
 	/**
 	 * @since 1.0.0
 	 */
-	protected const FILTER_NAME = 'ap.visual-editor.template-parts';
+	protected const FILTER_NAME = 'ap.visualEditor.templateParts';
 
 	/**
 	 * V1 closed list of valid template-part areas. Mirrored from

--- a/src/SiteEditor/Resolution/TemplatePartResolver.php
+++ b/src/SiteEditor/Resolution/TemplatePartResolver.php
@@ -3,7 +3,7 @@
 /**
  * Site-editor template-part resolver.
  *
- * Consumes the merged `ap.visual-editor.template-parts` filter result.
+ * Consumes the merged `ap.visualEditor.templateParts` filter result.
  *
  * @package    ArtisanPack_UI
  * @subpackage VisualEditor
@@ -26,7 +26,7 @@ class TemplatePartResolver extends AbstractMapResolver
 	 */
 	protected static function filterName(): string
 	{
-		return 'ap.visual-editor.template-parts';
+		return 'ap.visualEditor.templateParts';
 	}
 
 	/**

--- a/src/SiteEditor/Resolution/TemplatePartResolver.php
+++ b/src/SiteEditor/Resolution/TemplatePartResolver.php
@@ -40,4 +40,14 @@ class TemplatePartResolver extends AbstractMapResolver
 
 		return ResolvedTemplatePart::fromArray( $entry );
 	}
+
+	/**
+	 * @since 1.5.0
+	 *
+	 * @param  ResolvedTemplatePart  $entry
+	 */
+	protected static function identifierOf( object $entry ): string
+	{
+		return $entry->slug;
+	}
 }

--- a/src/SiteEditor/Resolution/TemplateResolver.php
+++ b/src/SiteEditor/Resolution/TemplateResolver.php
@@ -43,4 +43,14 @@ class TemplateResolver extends AbstractMapResolver
 
 		return ResolvedTemplate::fromArray( $entry );
 	}
+
+	/**
+	 * @since 1.5.0
+	 *
+	 * @param  ResolvedTemplate  $entry
+	 */
+	protected static function identifierOf( object $entry ): string
+	{
+		return $entry->slug;
+	}
 }

--- a/src/SiteEditor/Resolution/TemplateResolver.php
+++ b/src/SiteEditor/Resolution/TemplateResolver.php
@@ -3,7 +3,7 @@
 /**
  * Site-editor template resolver.
  *
- * Consumes the merged `ap.visual-editor.templates` filter result and exposes
+ * Consumes the merged `ap.visualEditor.templates` filter result and exposes
  * a stable read surface to H6's WP-style REST adapters. Has no awareness of
  * where the data came from — that's cms-framework's H1 resolution job.
  *
@@ -28,7 +28,7 @@ class TemplateResolver extends AbstractMapResolver
 	 */
 	protected static function filterName(): string
 	{
-		return 'ap.visual-editor.templates';
+		return 'ap.visualEditor.templates';
 	}
 
 	/**

--- a/src/Support/HookAliases.php
+++ b/src/Support/HookAliases.php
@@ -1,0 +1,77 @@
+<?php
+
+/**
+ * Hook name deprecation aliases.
+ *
+ * Issue #664 renamed every visual-editor PHP hook (and the JS `ap.icons.*`
+ * bridge hook) from kebab-case to camelCase for consistency with the
+ * ArtisanPack UI ecosystem's naming convention. Existing host apps and
+ * downstream packages continue to subscribe under the old names, so this
+ * class installs alias entries via `deprecateHook()` (shipped by
+ * `artisanpack-ui/hooks` ^1.2) that route old-name subscribers to fire on
+ * the canonical (new) hook. A deprecation notice is logged the first time
+ * an alias resolves per process.
+ *
+ * {@see \deprecateHook()} for the underlying implementation. Called once,
+ * as early as possible, from {@see \ArtisanPackUI\VisualEditor\VisualEditorServiceProvider::boot()}.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.5.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Support;
+
+class HookAliases
+{
+	/**
+	 * The exhaustive old-name → new-name rename table for #664.
+	 *
+	 * The 13 visual-editor PHP hooks plus the `visual_editor.pre_publish_checks`
+	 * cross-package hook (fired by visual-editor, subscribed by seo). The
+	 * `ap.icons.register-icon-sets` alias is included defensively — the
+	 * canonical alias belongs to the `artisanpack-ui/icons` package, but
+	 * declaring it here is idempotent and protects hosts that install
+	 * visual-editor before the icons package publishes its own alias
+	 * registration.
+	 *
+	 * @var array<string, string>
+	 */
+	private const RENAMES = [
+		'ap.visual-editor.resources'                    => 'ap.visualEditor.resources',
+		'ap.visual-editor.templates'                    => 'ap.visualEditor.templates',
+		'ap.visual-editor.template-parts'               => 'ap.visualEditor.templateParts',
+		'ap.visual-editor.patterns'                     => 'ap.visualEditor.patterns',
+		'ap.visual-editor.global-styles'                => 'ap.visualEditor.globalStyles',
+		'ap.visual-editor.navigation'                   => 'ap.visualEditor.navigation',
+		'ap.visual-editor.visibility.register-rules'    => 'ap.visualEditor.visibility.registerRules',
+		'ap.visual-editor.visibility.evaluated'         => 'ap.visualEditor.visibility.evaluated',
+		'ap.visual-editor.visibility.user-search-results' => 'ap.visualEditor.visibility.userSearchResults',
+		'ap.visual-editor.rendered-block'               => 'ap.visualEditor.renderedBlock',
+		'ap.visual-editor.breadcrumbs.trail'            => 'ap.visualEditor.breadcrumbs.trail',
+		'ap.visual-editor.loginout.envelope'            => 'ap.visualEditor.loginout.envelope',
+		'ap.visual-editor.loginout.login-form'          => 'ap.visualEditor.loginout.loginForm',
+		'visual_editor.pre_publish_checks'              => 'ap.visualEditor.prePublishChecks',
+		'ap.icons.register-icon-sets'                   => 'ap.icons.registerIconSets',
+	];
+
+	/**
+	 * Register every deprecation alias in the rename table.
+	 *
+	 * Idempotent — safe to call multiple times. `deprecateHook()` is itself
+	 * idempotent per (old, new) pair.
+	 *
+	 * @since 1.5.0
+	 */
+	public static function registerAll(): void
+	{
+		foreach ( self::RENAMES as $old => $new ) {
+			deprecateHook( $old, $new );
+		}
+	}
+}

--- a/src/View/Components/VisualEditorComponent.php
+++ b/src/View/Components/VisualEditorComponent.php
@@ -141,6 +141,102 @@ class VisualEditorComponent extends Component
 		$this->initialUpdatedAt     = $this->resolveTimestamp( $model, 'updated_at' );
 		$this->contentTypes         = $this->resolveContentTypes();
 		$this->breakpoints          = app( BreakpointRegistry::class )->toArray();
+
+		$this->applyEditorConfigFilter();
+	}
+
+	/**
+	 * Identifies the editor surface for the `ap.visualEditor.editorConfig`
+	 * filter. Subclasses (e.g. a future site-editor component) override
+	 * to return `'site'` so callbacks can gate their overrides per screen.
+	 *
+	 * @since 1.6.0
+	 *
+	 * @return string
+	 */
+	protected function screen(): string
+	{
+		return 'post';
+	}
+
+	/**
+	 * Runs the assembled editor config through the
+	 * `ap.visualEditor.editorConfig` filter and re-hydrates the
+	 * component's props from the filtered result.
+	 *
+	 * Each known prop declares a coercer that maps a filter-returned
+	 * value to its declared type or falls back to the current value —
+	 * so an extra key from the filter can't leak into unrelated props,
+	 * and a malformed value can't poison a typed prop. To extend, add a
+	 * new row to {@see configSchema()} rather than a fresh assignment.
+	 *
+	 * @since 1.6.0
+	 *
+	 * @return void
+	 */
+	protected function applyEditorConfigFilter(): void
+	{
+		$schema = $this->configSchema();
+		$config = [];
+
+		foreach ( array_keys( $schema ) as $key ) {
+			$config[ $key ] = $this->{$key};
+		}
+
+		$filtered = applyFilters( 'ap.visualEditor.editorConfig', $config, $this->screen() );
+
+		if ( ! is_array( $filtered ) ) {
+			return;
+		}
+
+		foreach ( $schema as $key => $coercer ) {
+			if ( ! array_key_exists( $key, $filtered ) ) {
+				continue;
+			}
+
+			$this->{$key} = $coercer( $filtered[ $key ], $this->{$key} );
+		}
+	}
+
+	/**
+	 * Prop-name → coercer table for the editor config filter.
+	 *
+	 * Each coercer takes the filter-returned value plus the current prop
+	 * value and returns whatever should land on the prop; returning
+	 * `$current` is the "reject bad shape" fallback.
+	 *
+	 * @since 1.6.0
+	 *
+	 * @return array<string, callable(mixed, mixed): mixed>
+	 */
+	protected function configSchema(): array
+	{
+		$string             = static fn ( mixed $v, mixed $current ) => is_string( $v ) ? $v : $current;
+		$nullableString     = static fn ( mixed $v, mixed $current ) => is_string( $v ) || null === $v ? $v : $current;
+		$nullableArray      = static fn ( mixed $v, mixed $current ) => is_array( $v ) || null === $v ? $v : $current;
+		$nullableBool       = static fn ( mixed $v, mixed $current ) => is_bool( $v ) || null === $v ? $v : $current;
+		$nullableIntOrString = static fn ( mixed $v, mixed $current ) => is_int( $v ) || is_string( $v ) || null === $v ? $v : $current;
+		$array              = static fn ( mixed $v, mixed $current ) => is_array( $v ) ? $v : $current;
+
+		return [
+			'resource'             => $string,
+			'modelId'              => $string,
+			'apiBase'              => $string,
+			'initialTitle'         => $nullableString,
+			'initialSlug'          => $nullableString,
+			'initialStatus'        => $nullableString,
+			'initialExcerpt'       => $nullableString,
+			'initialFeaturedImage' => $nullableArray,
+			'initialAuthorId'      => $nullableIntOrString,
+			'initialCommentsOpen'  => $nullableBool,
+			'authorOptions'        => $nullableArray,
+			'supports'             => $nullableArray,
+			'previewUrl'           => $nullableString,
+			'initialCreatedAt'     => $nullableString,
+			'initialUpdatedAt'     => $nullableString,
+			'contentTypes'         => $array,
+			'breakpoints'          => $array,
+		];
 	}
 
 	/**

--- a/src/Visibility/RuleRegistry.php
+++ b/src/Visibility/RuleRegistry.php
@@ -5,7 +5,7 @@
  *
  * Rules are seeded from the built-in set by
  * {@see \ArtisanPackUI\VisualEditor\VisualEditorServiceProvider} and
- * extended by hosts through the `ap.visual-editor.visibility.register-rules`
+ * extended by hosts through the `ap.visualEditor.visibility.registerRules`
  * filter. The registry is stateless past construction: the evaluator asks
  * it for the full ordered rule list every time it walks a tree.
  *

--- a/src/Visibility/VisibilityDecision.php
+++ b/src/Visibility/VisibilityDecision.php
@@ -16,7 +16,7 @@
  *                        viewport size is a client-only signal.
  *
  * The `reasons` array is opaque and only used by the debug hook
- * (`ap.visual-editor.visibility.evaluated`) so the "why is this hidden?"
+ * (`ap.visualEditor.visibility.evaluated`) so the "why is this hidden?"
  * developer tooling can surface the failing rule name(s) without
  * reserving specific fields on the DTO.
  *

--- a/src/Visibility/VisibilityEvaluator.php
+++ b/src/Visibility/VisibilityEvaluator.php
@@ -17,7 +17,7 @@
  *      `artisanpackVisibility.{rule.key}` slice, combining the returned
  *      {@see VisibilityDecision}s. Any single `hidden()` wins outright.
  *
- * The `ap.visual-editor.visibility.evaluated` action fires once per
+ * The `ap.visualEditor.visibility.evaluated` action fires once per
  * block after evaluation completes, receiving `[decision, blockName,
  * attributes, context]` so a debug listener can answer "why is this
  * block hidden?" without instrumenting each rule.
@@ -267,7 +267,7 @@ class VisibilityEvaluator
 		}
 
 		try {
-			doAction( 'ap.visual-editor.visibility.evaluated', $decision, $name, $attributes, $context );
+			doAction( 'ap.visualEditor.visibility.evaluated', $decision, $name, $attributes, $context );
 		} catch ( Throwable $e ) {
 			report( $e );
 		}

--- a/src/VisualEditorServiceProvider.php
+++ b/src/VisualEditorServiceProvider.php
@@ -56,6 +56,7 @@ use ArtisanPackUI\VisualEditor\States\StateCssEmitter;
 use ArtisanPackUI\VisualEditor\States\StateRegistry;
 use ArtisanPackUI\VisualEditor\States\StateValueResolver;
 use ArtisanPackUI\VisualEditor\Search\BlockTreeSearchExtractor;
+use ArtisanPackUI\VisualEditor\Support\HookAliases;
 use ArtisanPackUI\VisualEditor\SiteEditor\Resolution\GlobalStylesResolver as SiteEditorGlobalStylesResolver;
 use ArtisanPackUI\VisualEditor\SiteEditor\Resolution\MenuResolver as SiteEditorMenuResolver;
 use ArtisanPackUI\VisualEditor\SiteEditor\Resolution\PatternResolver as SiteEditorPatternResolver;
@@ -179,7 +180,7 @@ class VisualEditorServiceProvider extends ServiceProvider
 		// Icon Block Phase 3 (#554): defer the icon-sets-registry walk
 		// until the first `resolve()` call. IconBlock is constructed
 		// inside boot() (via registerReferenceBlocks), which happens
-		// BEFORE every provider's `addFilter('ap.icons.register-icon-sets',
+		// BEFORE every provider's `addFilter('ap.icons.registerIconSets',
 		// …)` has fired. Computing the path map eagerly here would race
 		// against those registrations and produce an empty resolver. The
 		// closure runs at request time, by which point boot is finished
@@ -188,7 +189,7 @@ class VisualEditorServiceProvider extends ServiceProvider
 		// Issue #587: when `owenvoke/blade-fontawesome` is installed,
 		// `FontAwesomeFreeIconSets::register()` defers to it and stops
 		// publishing `fas` / `far` / `fab` through the
-		// `ap.icons.register-icon-sets` filter (so the icons-package
+		// `ap.icons.registerIconSets` filter (so the icons-package
 		// service provider doesn't collide on `BladeUI\Icons\Factory::add()`).
 		// The resolver still needs those paths to inline bundled FA Free
 		// SVGs for the picker and the rendered block, so we always seed
@@ -204,7 +205,7 @@ class VisualEditorServiceProvider extends ServiceProvider
 					return $paths;
 				}
 
-				$registry = applyFilters( 'ap.icons.register-icon-sets', new IconSetRegistration() );
+				$registry = applyFilters( 'ap.icons.registerIconSets', new IconSetRegistration() );
 				if ( ! $registry instanceof IconSetRegistration ) {
 					return $paths;
 				}
@@ -264,7 +265,7 @@ class VisualEditorServiceProvider extends ServiceProvider
 		// Bound here as a placeholder so other providers' register() phases
 		// can typehint ResourceResolver. The boot() phase rebinds with the
 		// final filter-merged map once all providers have registered their
-		// `ap.visual-editor.resources` callbacks.
+		// `ap.visualEditor.resources` callbacks.
 		$this->app->singleton( ResourceResolver::class, function () {
 			return new ResourceResolver();
 		} );
@@ -272,7 +273,7 @@ class VisualEditorServiceProvider extends ServiceProvider
 		// H5 — site-editor resolvers. Same pattern as ResourceResolver
 		// above: empty placeholders here; boot() rebinds with the filter-
 		// merged data once all providers have registered their
-		// `ap.visual-editor.{templates,template-parts,patterns,
+		// `ap.visualEditor.{templates,templateParts,patterns,
 		// global-styles,navigation}` callbacks.
 		$this->app->singleton( SiteEditorTemplateResolver::class, function () {
 			return new SiteEditorTemplateResolver();
@@ -417,7 +418,7 @@ class VisualEditorServiceProvider extends ServiceProvider
 			// Resolve editor-authored keyframes from the same filter-
 			// merged global-styles payload that `SiteEditorGlobalStylesResolver`
 			// consumes, so a host that registers global styles through
-			// the `ap.visual-editor.global-styles` filter (cms-framework
+			// the `ap.visualEditor.globalStyles` filter (cms-framework
 			// being the canonical caller) sees its custom keyframes
 			// reach the editor and renderer. Reading directly from
 			// config would miss the filter contributions.
@@ -453,7 +454,7 @@ class VisualEditorServiceProvider extends ServiceProvider
 		// stateless (safe singleton). `ScheduledBlockCollector` is a
 		// pure walker (safe singleton). The `VisibilityRuleRegistry`
 		// is scoped per request because the built-in rule set is
-		// merged with the `ap.visual-editor.visibility.register-rules`
+		// merged with the `ap.visualEditor.visibility.registerRules`
 		// filter, and third-party rule providers may register with
 		// per-request container state (route parameters, tenant
 		// context, etc.). The `VisibilityEvaluator` is also scoped so
@@ -469,7 +470,7 @@ class VisualEditorServiceProvider extends ServiceProvider
 		} );
 
 		// The scoped closure only assembles the built-in rule set —
-		// the `ap.visual-editor.visibility.register-rules` filter is
+		// the `ap.visualEditor.visibility.registerRules` filter is
 		// applied via `extend()` in `boot()` (see
 		// `applyVisibilityRulesFilter()`). Extending inside the closure
 		// would freeze the filter chain state at first-resolve time,
@@ -576,7 +577,7 @@ class VisualEditorServiceProvider extends ServiceProvider
 	}
 
 	/**
-	 * Layer the `ap.visual-editor.visibility.register-rules` filter
+	 * Layer the `ap.visualEditor.visibility.registerRules` filter
 	 * over every fresh {@see VisibilityRuleRegistry} instance.
 	 *
 	 * Registered in `boot()` via {@see \Illuminate\Container\Container::extend()}
@@ -598,7 +599,7 @@ class VisualEditorServiceProvider extends ServiceProvider
 		$this->app->extend(
 			VisibilityRuleRegistry::class,
 			static function ( VisibilityRuleRegistry $registry ): VisibilityRuleRegistry {
-				$filtered = applyFilters( 'ap.visual-editor.visibility.register-rules', $registry );
+				$filtered = applyFilters( 'ap.visualEditor.visibility.registerRules', $registry );
 				return $filtered instanceof VisibilityRuleRegistry ? $filtered : $registry;
 			},
 		);
@@ -612,6 +613,12 @@ class VisualEditorServiceProvider extends ServiceProvider
 	 */
 	public function boot(): void
 	{
+		// 0. Register hook name aliases (old → new) as early as possible in
+		//    boot() so any subsequent hook fire sites route legacy
+		//    subscribers to the canonical (camelCase) hook name. See
+		//    src/Support/HookAliases.php for the full rename table.
+		HookAliases::registerAll();
+
 		// 1. Merge the configuration correctly.
 		$this->mergeConfiguration();
 
@@ -627,7 +634,7 @@ class VisualEditorServiceProvider extends ServiceProvider
 			$this->registerSiteEditorResolvers();
 		} );
 
-		// 1b. Layer the `ap.visual-editor.visibility.register-rules`
+		// 1b. Layer the `ap.visualEditor.visibility.registerRules`
 		//     filter over the scoped registry via `extend()`. Runs at
 		//     resolve-time (after the closure builds the default set)
 		//     which means addFilter calls from any other provider's
@@ -683,7 +690,7 @@ class VisualEditorServiceProvider extends ServiceProvider
 
 		// 4.2. Icon Block Phase 6 (#557) — re-register host-uploaded
 		//      icon sets on every boot. Reads the persisted registry
-		//      and hooks the same `ap.icons.register-icon-sets` filter
+		//      and hooks the same `ap.icons.registerIconSets` filter
 		//      the bundled FA sets use, so the picker, the SVG
 		//      resolver, and the catalog all surface uploaded icons
 		//      without any further wiring.
@@ -873,7 +880,7 @@ class VisualEditorServiceProvider extends ServiceProvider
 	}
 
 	/**
-	 * Hook the FA Free SVG sets into the `ap.icons.register-icon-sets`
+	 * Hook the FA Free SVG sets into the `ap.icons.registerIconSets`
 	 * filter.
 	 *
 	 * Gated on the icons package being present so visual-editor still
@@ -893,7 +900,7 @@ class VisualEditorServiceProvider extends ServiceProvider
 		$baseDir = __DIR__ . '/../resources/icons/font-awesome';
 
 		addFilter(
-			'ap.icons.register-icon-sets',
+			'ap.icons.registerIconSets',
 			static function ( IconSetRegistration $registry ) use ( $baseDir ): IconSetRegistration {
 				return FontAwesomeFreeIconSets::register( $registry, $baseDir );
 			}
@@ -925,7 +932,7 @@ class VisualEditorServiceProvider extends ServiceProvider
 		}
 
 		addFilter(
-			'ap.visual-editor.patterns',
+			'ap.visualEditor.patterns',
 			static function ( mixed $patterns ): array {
 				$patterns = is_array( $patterns ) ? $patterns : [];
 
@@ -1060,7 +1067,7 @@ class VisualEditorServiceProvider extends ServiceProvider
 	/**
 	 * Builds the slug → model class map for ResourceResolver.
 	 *
-	 * Pipes the static config through the `ap.visual-editor.resources` filter
+	 * Pipes the static config through the `ap.visualEditor.resources` filter
 	 * (so packages like cms-framework can register their models at runtime),
 	 * then merges static config back on top so host-app entries always win on
 	 * key collision. ResourceResolver itself does not validate at construction
@@ -1076,7 +1083,7 @@ class VisualEditorServiceProvider extends ServiceProvider
 	public function registerResourceResolver(): void
 	{
 		$staticConfig = (array) config( 'artisanpack.visual-editor.resources', [] );
-		$filtered     = applyFilters( 'ap.visual-editor.resources', $staticConfig );
+		$filtered     = applyFilters( 'ap.visualEditor.resources', $staticConfig );
 		$filtered     = is_array( $filtered ) ? $filtered : [];
 
 		// Static config wins on key collision: host app entries take
@@ -1109,7 +1116,7 @@ class VisualEditorServiceProvider extends ServiceProvider
 	{
 		// Templates ─ array<string, array> keyed by slug.
 		$templatesStatic = (array) config( 'artisanpack.visual-editor.site-editor.templates', [] );
-		$templatesMerged = applyFilters( 'ap.visual-editor.templates', $templatesStatic );
+		$templatesMerged = applyFilters( 'ap.visualEditor.templates', $templatesStatic );
 		$templatesMerged = is_array( $templatesMerged ) ? $templatesMerged : [];
 		$templatesMerged = array_merge( $templatesMerged, $templatesStatic );
 
@@ -1120,7 +1127,7 @@ class VisualEditorServiceProvider extends ServiceProvider
 
 		// Template parts ─ array<string, array> keyed by slug.
 		$partsStatic = (array) config( 'artisanpack.visual-editor.site-editor.template-parts', [] );
-		$partsMerged = applyFilters( 'ap.visual-editor.template-parts', $partsStatic );
+		$partsMerged = applyFilters( 'ap.visualEditor.templateParts', $partsStatic );
 		$partsMerged = is_array( $partsMerged ) ? $partsMerged : [];
 		$partsMerged = array_merge( $partsMerged, $partsStatic );
 
@@ -1131,7 +1138,7 @@ class VisualEditorServiceProvider extends ServiceProvider
 
 		// Patterns ─ array<string, array> keyed by slug.
 		$patternsStatic = (array) config( 'artisanpack.visual-editor.site-editor.patterns', [] );
-		$patternsMerged = applyFilters( 'ap.visual-editor.patterns', $patternsStatic );
+		$patternsMerged = applyFilters( 'ap.visualEditor.patterns', $patternsStatic );
 		$patternsMerged = is_array( $patternsMerged ) ? $patternsMerged : [];
 		$patternsMerged = array_merge( $patternsMerged, $patternsStatic );
 
@@ -1145,7 +1152,7 @@ class VisualEditorServiceProvider extends ServiceProvider
 		// static config, the filter result is authoritative.
 		$globalStylesStatic = config( 'artisanpack.visual-editor.site-editor.global-styles', null );
 		$globalStylesStatic = is_array( $globalStylesStatic ) ? $globalStylesStatic : null;
-		$globalStylesMerged = applyFilters( 'ap.visual-editor.global-styles', $globalStylesStatic );
+		$globalStylesMerged = applyFilters( 'ap.visualEditor.globalStyles', $globalStylesStatic );
 		$globalStylesMerged = is_array( $globalStylesMerged ) ? $globalStylesMerged : null;
 		$globalStylesMerged = $globalStylesStatic ?? $globalStylesMerged;
 
@@ -1156,7 +1163,7 @@ class VisualEditorServiceProvider extends ServiceProvider
 
 		// Navigation ─ array<string, array> keyed by location.
 		$menusStatic = (array) config( 'artisanpack.visual-editor.site-editor.navigation', [] );
-		$menusMerged = applyFilters( 'ap.visual-editor.navigation', $menusStatic );
+		$menusMerged = applyFilters( 'ap.visualEditor.navigation', $menusStatic );
 		$menusMerged = is_array( $menusMerged ) ? $menusMerged : [];
 		$menusMerged = array_merge( $menusMerged, $menusStatic );
 
@@ -1192,7 +1199,7 @@ class VisualEditorServiceProvider extends ServiceProvider
 
 	/**
 	 * Hand the persisted uploaded icon sets to the
-	 * `ap.icons.register-icon-sets` filter.
+	 * `ap.icons.registerIconSets` filter.
 	 *
 	 * Phase 6 (#557). The {@see UploadedIconSetRegistry} only carries
 	 * metadata; the directories are managed by {@see IconSetUploader}.
@@ -1218,7 +1225,7 @@ class VisualEditorServiceProvider extends ServiceProvider
 		$app = $this->app;
 
 		addFilter(
-			'ap.icons.register-icon-sets',
+			'ap.icons.registerIconSets',
 			static function ( IconSetRegistration $registry ) use ( $app ): IconSetRegistration {
 				$persisted = $app->make( UploadedIconSetRegistry::class );
 
@@ -1318,10 +1325,10 @@ class VisualEditorServiceProvider extends ServiceProvider
 		// it through `registerUploadedIconSets()` — `IconSvgResolver`
 		// otherwise can't serve the SVG at click time, and the picker
 		// would render a black tile or a 404. Both paths now share one
-		// source of truth: the result of `ap.icons.register-icon-sets`.
+		// source of truth: the result of `ap.icons.registerIconSets`.
 		$registeredPrefixes = [];
 		if ( class_exists( IconSetRegistration::class ) && function_exists( 'applyFilters' ) ) {
-			$registry = applyFilters( 'ap.icons.register-icon-sets', new IconSetRegistration() );
+			$registry = applyFilters( 'ap.icons.registerIconSets', new IconSetRegistration() );
 			if ( $registry instanceof IconSetRegistration ) {
 				$registeredPrefixes = array_flip( array_keys( $registry->getSets() ) );
 			}

--- a/tests/Feature/SiteEditor/GlobalStylesControllerTest.php
+++ b/tests/Feature/SiteEditor/GlobalStylesControllerTest.php
@@ -32,12 +32,44 @@ beforeEach( function (): void {
 			'name' => 'Digital Shopfront',
 			'slug' => 'digital-shopfront',
 		] );
+		stubThemeManagerHelpersForGlobalStylesTest( $mock );
 	} );
 } );
 
 function rebuildSiteEditorResolversForGlobalStylesTest(): void
 {
 	( new VisualEditorServiceProvider( app() ) )->registerSiteEditorResolvers();
+}
+
+/**
+ * Stub the ThemeManager methods the ThemeStylesheetReader (cms-framework
+ * ≥ 2.5) calls on top of `getActiveTheme()`. Each `$this->mock()` in a
+ * test replaces the outer beforeEach mock, so tests hitting the /css
+ * endpoint need to re-declare these too.
+ */
+function stubThemeManagerHelpersForGlobalStylesTest( \Mockery\MockInterface $mock ): void
+{
+	$mock->shouldReceive( 'validateSlug' )->andReturnUsing(
+		static fn ( string $slug ): bool => (bool) preg_match( '/^[a-zA-Z0-9_-]+$/', $slug ),
+	);
+	$mock->shouldReceive( 'getThemesPath' )->andReturnUsing(
+		static function (): string {
+			$directory = (string) config( 'cms.themes.directory', 'themes' );
+
+			if ( '' === $directory ) {
+				$directory = 'themes';
+			}
+
+			// Match the real ThemeManager::getThemesPath() behavior:
+			// honor absolute paths so tests that point at a temp dir
+			// (e.g. sys_get_temp_dir()) resolve correctly.
+			if ( '/' === $directory[0] || preg_match( '#^[A-Za-z]:[\\\\/]#', $directory ) ) {
+				return $directory;
+			}
+
+			return base_path( $directory );
+		},
+	);
 }
 
 describe( 'GET /visual-editor/api/global-styles/lookup', function (): void {
@@ -77,6 +109,7 @@ describe( 'GET /visual-editor/api/global-styles/base', function (): void {
 				'settings' => [ 'color' => [ 'palette' => [ [ 'slug' => 'primary', 'color' => '#000' ] ] ] ],
 				'styles'   => [ 'typography' => [ 'fontSize' => '14px' ] ],
 			] );
+			stubThemeManagerHelpersForGlobalStylesTest( $mock );
 		} );
 
 		// A DB override exists with different styles — base() must NOT
@@ -100,6 +133,7 @@ describe( 'GET /visual-editor/api/global-styles/base', function (): void {
 	it( 'returns empty defaults when no active theme is configured', function (): void {
 		$this->mock( ThemeManager::class, function ( $mock ): void {
 			$mock->shouldReceive( 'getActiveTheme' )->andReturn( null );
+			stubThemeManagerHelpersForGlobalStylesTest( $mock );
 		} );
 
 		$this->getJson( '/visual-editor/api/global-styles/base' )
@@ -118,6 +152,7 @@ describe( 'GET /visual-editor/api/global-styles/css', function (): void {
 				'settings' => [ 'color' => [ 'palette' => [ [ 'slug' => 'primary', 'color' => '#0f172a' ] ] ] ],
 				'styles'   => [ 'color' => [ 'text' => '#111827' ] ],
 			] );
+			stubThemeManagerHelpersForGlobalStylesTest( $mock );
 		} );
 
 		rebuildSiteEditorResolversForGlobalStylesTest();
@@ -137,6 +172,7 @@ describe( 'GET /visual-editor/api/global-styles/css', function (): void {
 	it( 'returns an empty body when no active theme is configured', function (): void {
 		$this->mock( ThemeManager::class, function ( $mock ): void {
 			$mock->shouldReceive( 'getActiveTheme' )->andReturn( null );
+			stubThemeManagerHelpersForGlobalStylesTest( $mock );
 		} );
 
 		rebuildSiteEditorResolversForGlobalStylesTest();
@@ -164,6 +200,7 @@ describe( 'GET /visual-editor/api/global-styles/css', function (): void {
 				'settings' => [ 'color' => [ 'palette' => [ [ 'slug' => 'primary', 'color' => '#0f172a' ] ] ] ],
 				'styles'   => [ 'elements' => [ 'button' => [ 'color' => [ 'background' => '#2563eb' ] ] ] ],
 			] );
+			stubThemeManagerHelpersForGlobalStylesTest( $mock );
 		} );
 
 		rebuildSiteEditorResolversForGlobalStylesTest();
@@ -193,15 +230,67 @@ describe( 'GET /visual-editor/api/global-styles/css', function (): void {
 				'name' => 'Bad slug',
 				'slug' => '../../etc',
 			] );
+			stubThemeManagerHelpersForGlobalStylesTest( $mock );
 		} );
 
 		rebuildSiteEditorResolversForGlobalStylesTest();
 
 		$response = $this->get( '/visual-editor/api/global-styles/css' )->assertOk();
 
-		// The stylesheet read short-circuited on the bogus slug —
-		// body should not contain the theme-stylesheet marker.
-		expect( $response->getContent() )->not->toContain( '/* === theme stylesheet === */' );
+		// The stylesheet reader short-circuits on the bogus slug —
+		// no banners land in the body from either convention.
+		expect( $response->getContent() )
+			->not->toContain( '/* === style.css === */' )
+			->not->toContain( '/* === editor.css === */' )
+			->not->toContain( '/* === theme stylesheet === */' );
+	} );
+
+	it( 'concatenates the active theme\'s editor.css after style.css (cms-framework #199)', function (): void {
+		$themesBase = sys_get_temp_dir() . '/cms199-editor-css-' . uniqid();
+		$slug       = 'canvas-only-theme';
+		$themeDir   = $themesBase . '/' . $slug;
+
+		mkdir( $themeDir, 0755, true );
+		file_put_contents( $themeDir . '/style.css', "body { background: papayawhip; }\n" );
+		file_put_contents( $themeDir . '/editor.css', ".editor-only-marker { outline: 3px solid magenta; }\n" );
+
+		config()->set( 'cms.themes.directory', $themesBase );
+
+		$this->mock( ThemeManager::class, function ( $mock ) use ( $slug ): void {
+			$mock->shouldReceive( 'getActiveTheme' )->andReturn( [
+				'name'     => 'Canvas-only theme',
+				'slug'     => $slug,
+				'settings' => [ 'color' => [ 'palette' => [ [ 'slug' => 'primary', 'color' => '#0f172a' ] ] ] ],
+				'styles'   => [],
+			] );
+			stubThemeManagerHelpersForGlobalStylesTest( $mock );
+		} );
+
+		rebuildSiteEditorResolversForGlobalStylesTest();
+
+		$body = $this->get( '/visual-editor/api/global-styles/css' )->assertOk()->getContent();
+
+		// Emitter, style.css, and editor.css all present in that order —
+		// closing the gap flagged in cms-framework #199 where the canvas
+		// used to see style.css only.
+		$emitterPos = strpos( $body, '--wp--preset--color--primary' );
+		$stylePos   = strpos( $body, '/* === style.css === */' );
+		$editorPos  = strpos( $body, '/* === editor.css === */' );
+
+		expect( $emitterPos )->not->toBeFalse()
+			->and( $stylePos )->not->toBeFalse()
+			->and( $editorPos )->not->toBeFalse()
+			->and( $emitterPos )->toBeLessThan( $stylePos )
+			->and( $stylePos )->toBeLessThan( $editorPos );
+
+		expect( $body )
+			->toContain( 'body { background: papayawhip; }' )
+			->toContain( '.editor-only-marker' );
+
+		unlink( $themeDir . '/style.css' );
+		unlink( $themeDir . '/editor.css' );
+		rmdir( $themeDir );
+		rmdir( $themesBase );
 	} );
 } );
 

--- a/tests/Feature/SiteEditor/GlobalStylesControllerTest.php
+++ b/tests/Feature/SiteEditor/GlobalStylesControllerTest.php
@@ -46,9 +46,19 @@ function rebuildSiteEditorResolversForGlobalStylesTest(): void
  * ≥ 2.5) calls on top of `getActiveTheme()`. Each `$this->mock()` in a
  * test replaces the outer beforeEach mock, so tests hitting the /css
  * endpoint need to re-declare these too.
+ *
+ * No-op when cms-framework < 2.5 is installed: the controller falls
+ * back to its inline `readThemeStylesheet()` (which only calls
+ * `getActiveTheme()`), and Mockery refuses to stub `validateSlug` /
+ * `getThemesPath` on the older release because they were still
+ * `protected` there.
  */
 function stubThemeManagerHelpersForGlobalStylesTest( \Mockery\MockInterface $mock ): void
 {
+	if ( ! class_exists( 'ArtisanPackUI\\CMSFramework\\Modules\\SiteEditor\\Support\\ThemeStylesheetReader' ) ) {
+		return;
+	}
+
 	$mock->shouldReceive( 'validateSlug' )->andReturnUsing(
 		static fn ( string $slug ): bool => (bool) preg_match( '/^[a-zA-Z0-9_-]+$/', $slug ),
 	);
@@ -246,6 +256,10 @@ describe( 'GET /visual-editor/api/global-styles/css', function (): void {
 	} );
 
 	it( 'concatenates the active theme\'s editor.css after style.css (cms-framework #199)', function (): void {
+		if ( ! class_exists( 'ArtisanPackUI\\CMSFramework\\Modules\\SiteEditor\\Support\\ThemeStylesheetReader' ) ) {
+			$this->markTestSkipped( 'editor.css concatenation requires cms-framework >= 2.5 (reader binding not present).' );
+		}
+
 		$themesBase = sys_get_temp_dir() . '/cms199-editor-css-' . uniqid();
 		$slug       = 'canvas-only-theme';
 		$themeDir   = $themesBase . '/' . $slug;

--- a/tests/Feature/SiteEditor/PatternControllerTest.php
+++ b/tests/Feature/SiteEditor/PatternControllerTest.php
@@ -113,7 +113,7 @@ describe( 'GET /visual-editor/api/patterns', function (): void {
 	// `post_types` whitelist match only when the requested slug is
 	// present; unscoped patterns (post_types null) match everywhere.
 	it( 'filters by ?post_type using each pattern\'s post_types scope (#639)', function (): void {
-		addFilter( 'ap.visual-editor.patterns', function ( mixed $patterns ): array {
+		addFilter( 'ap.visualEditor.patterns', function ( mixed $patterns ): array {
 			$patterns = is_array( $patterns ) ? $patterns : [];
 
 			$patterns['landing-hero'] = [

--- a/tests/Feature/VisualEditor/Adapters/CmsFramework/PostControllerTest.php
+++ b/tests/Feature/VisualEditor/Adapters/CmsFramework/PostControllerTest.php
@@ -218,3 +218,150 @@ it( 'returns 404 for a missing post', function () {
 
 	$this->getJson( '/visual-editor/api/posts/9999' )->assertNotFound();
 } );
+
+describe( 'lifecycle hooks', function (): void {
+	afterEach( function (): void {
+		removeAllActions( 'ap.visualEditor.postSaved' );
+		removeAllActions( 'ap.visualEditor.postPublished' );
+	} );
+
+	it( 'fires ap.visualEditor.postSaved on POST /posts', function (): void {
+		actor();
+
+		$captured = [];
+		addAction( 'ap.visualEditor.postSaved', function ( $id, $blocks ) use ( &$captured ): void {
+			$captured = [ 'id' => $id, 'blocks' => $blocks ];
+		}, 10, 2 );
+
+		$this->postJson( '/visual-editor/api/posts', [
+			'title'   => 'Fresh',
+			'status'  => 'draft',
+			'content' => [ 'raw' => '', 'blocks' => blockTree() ],
+		] )->assertCreated();
+
+		expect( $captured )->not->toBeEmpty()
+			->and( $captured['id'] )->toBeInt()
+			->and( $captured['blocks'] )->toEqual( blockTree() );
+	} );
+
+	it( 'fires postPublished on create-with-publish-status', function (): void {
+		actor();
+
+		$publishedCalls = 0;
+		addAction( 'ap.visualEditor.postPublished', function ( $id, $blocks ) use ( &$publishedCalls ): void {
+			$publishedCalls++;
+		}, 10, 2 );
+
+		$this->postJson( '/visual-editor/api/posts', [
+			'title'   => 'Live',
+			'status'  => 'publish',
+			'content' => [ 'raw' => '', 'blocks' => blockTree() ],
+		] )->assertCreated();
+
+		expect( $publishedCalls )->toBe( 1 );
+	} );
+
+	it( 'does not fire postPublished when creating with a non-publish status', function (): void {
+		actor();
+
+		$publishedCalls = 0;
+		addAction( 'ap.visualEditor.postPublished', function () use ( &$publishedCalls ): void {
+			$publishedCalls++;
+		} );
+
+		$this->postJson( '/visual-editor/api/posts', [
+			'title'   => 'Draft',
+			'status'  => 'draft',
+			'content' => [ 'raw' => '', 'blocks' => blockTree() ],
+		] )->assertCreated();
+
+		expect( $publishedCalls )->toBe( 0 );
+	} );
+
+	it( 'fires postPublished when the update transitions status into publish', function (): void {
+		actor();
+
+		// The fixture's `forVisualEditor()` scope filters to
+		// `status === 'published'`, so we can only exercise the update
+		// path with rows that pass the scope. Transitioning that row to
+		// the WP-canonical `publish` on update still crosses the
+		// non-publish → publish boundary the hook is meant to catch.
+		$post = TestBlockContentModel::create( [
+			'title'   => 'Was Not Publish',
+			'status'  => 'published',
+			'content' => [],
+		] );
+
+		$publishedPayloads = [];
+		$savedPayloads     = [];
+		addAction( 'ap.visualEditor.postPublished', function ( $id, $blocks ) use ( &$publishedPayloads ): void {
+			$publishedPayloads[] = [ 'id' => $id, 'blocks' => $blocks ];
+		}, 10, 2 );
+		addAction( 'ap.visualEditor.postSaved', function ( $id, $blocks ) use ( &$savedPayloads ): void {
+			$savedPayloads[] = [ 'id' => $id, 'blocks' => $blocks ];
+		}, 10, 2 );
+
+		$this->putJson( "/visual-editor/api/posts/{$post->id}", [
+			'status'  => 'publish',
+			'content' => [ 'raw' => '', 'blocks' => blockTree() ],
+		] )->assertOk();
+
+		expect( $publishedPayloads )->toHaveCount( 1 )
+			->and( $savedPayloads )->toHaveCount( 1 )
+			->and( $publishedPayloads[0]['id'] )->toBe( $post->id )
+			->and( $publishedPayloads[0]['blocks'] )->toEqual( blockTree() )
+			->and( $savedPayloads[0]['id'] )->toBe( $post->id )
+			->and( $savedPayloads[0]['blocks'] )->toEqual( blockTree() );
+	} );
+
+	it( 'fires postSaved without postPublished when an update makes no status transition', function (): void {
+		actor();
+
+		$post = TestBlockContentModel::create( [
+			'title'   => 'Content-only',
+			'status'  => 'published',
+			'content' => [],
+		] );
+
+		$savedCalls     = 0;
+		$publishedCalls = 0;
+		addAction( 'ap.visualEditor.postSaved', function () use ( &$savedCalls ): void {
+			$savedCalls++;
+		} );
+		addAction( 'ap.visualEditor.postPublished', function () use ( &$publishedCalls ): void {
+			$publishedCalls++;
+		} );
+
+		$this->putJson( "/visual-editor/api/posts/{$post->id}", [
+			'title'   => 'Content-only (revised)',
+			'content' => [ 'raw' => '', 'blocks' => blockTree() ],
+		] )->assertOk();
+
+		expect( $savedCalls )->toBe( 1 )
+			->and( $publishedCalls )->toBe( 0 );
+	} );
+
+	it( 'does not re-fire postPublished when status stays at the same publish value', function (): void {
+		actor();
+
+		$post = TestBlockContentModel::create( [
+			'title'   => 'Already',
+			'status'  => 'published',
+			'content' => [],
+		] );
+
+		$publishedCalls = 0;
+		addAction( 'ap.visualEditor.postPublished', function () use ( &$publishedCalls ): void {
+			$publishedCalls++;
+		} );
+
+		// Same status on both sides — no transition — so no publish event.
+		$this->putJson( "/visual-editor/api/posts/{$post->id}", [
+			'title'   => 'Already (revised)',
+			'status'  => 'published',
+			'content' => [ 'raw' => '', 'blocks' => blockTree() ],
+		] )->assertOk();
+
+		expect( $publishedCalls )->toBe( 0 );
+	} );
+} );

--- a/tests/Feature/VisualEditor/HookAliasesTest.php
+++ b/tests/Feature/VisualEditor/HookAliasesTest.php
@@ -1,0 +1,158 @@
+<?php
+
+/**
+ * Feature tests for `ArtisanPackUI\VisualEditor\Support\HookAliases`.
+ *
+ * Confirms every hook renamed in #664 continues to fire old-name
+ * subscribers when the canonical (new-name) hook is applied. Covers
+ * `resources` in depth plus three additional families
+ * (`templates`, `renderedBlock`, `loginout.envelope`) as a spot-check;
+ * exhaustive per-hook coverage lives in the resolver / renderer tests
+ * that already fire each hook.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.5.0
+ */
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Support\HookAliases;
+
+afterEach( function (): void {
+	removeAllFilters( 'ap.visual-editor.resources' );
+	removeAllFilters( 'ap.visualEditor.resources' );
+	removeAllFilters( 'ap.visual-editor.templates' );
+	removeAllFilters( 'ap.visualEditor.templates' );
+	removeAllFilters( 'ap.visual-editor.rendered-block' );
+	removeAllFilters( 'ap.visualEditor.renderedBlock' );
+	removeAllFilters( 'ap.visual-editor.loginout.envelope' );
+	removeAllFilters( 'ap.visualEditor.loginout.envelope' );
+} );
+
+it( 'routes old-name resources subscribers when the new name is applied', function (): void {
+	HookAliases::registerAll();
+
+	addFilter( 'ap.visual-editor.resources', function ( array $resources ): array {
+		return array_merge( [ 'posts' => 'App\\Models\\Post' ], $resources );
+	} );
+
+	$result = applyFilters( 'ap.visualEditor.resources', [] );
+
+	expect( $result )->toHaveKey( 'posts' );
+} );
+
+it( 'routes old-name templates subscribers when the new name is applied', function (): void {
+	HookAliases::registerAll();
+
+	addFilter( 'ap.visual-editor.templates', function ( array $templates ): array {
+		return array_merge( [ 'front-page' => [ 'slug' => 'front-page' ] ], $templates );
+	} );
+
+	$result = applyFilters( 'ap.visualEditor.templates', [] );
+
+	expect( $result )->toHaveKey( 'front-page' );
+} );
+
+it( 'routes old-name renderedBlock subscribers when the new name is applied', function (): void {
+	HookAliases::registerAll();
+
+	addFilter( 'ap.visual-editor.rendered-block', function ( string $html ): string {
+		return $html . '::filtered';
+	} );
+
+	$result = applyFilters( 'ap.visualEditor.renderedBlock', 'html' );
+
+	expect( $result )->toBe( 'html::filtered' );
+} );
+
+it( 'routes old-name loginout envelope subscribers when the new name is applied', function (): void {
+	HookAliases::registerAll();
+
+	addFilter( 'ap.visual-editor.loginout.envelope', function ( array $envelope ): array {
+		$envelope['touched'] = true;
+
+		return $envelope;
+	} );
+
+	$result = applyFilters( 'ap.visualEditor.loginout.envelope', [] );
+
+	expect( $result )->toHaveKey( 'touched' );
+} );
+
+it( 'is idempotent — a second registerAll() does not double-fire subscribers', function (): void {
+	HookAliases::registerAll();
+	HookAliases::registerAll();
+
+	$calls = 0;
+	addFilter( 'ap.visual-editor.resources', function ( array $resources ) use ( &$calls ): array {
+		$calls++;
+
+		return $resources;
+	} );
+
+	applyFilters( 'ap.visualEditor.resources', [] );
+
+	expect( $calls )->toBe( 1 );
+} );
+
+/*
+ * Reverse-direction coverage — a legacy host may still call
+ * applyFilters() against the OLD name (e.g. downstream code compiled
+ * before the rename shipped). Subscribers registered on the canonical
+ * NEW name must still fire so hosts do not lose behavior mid-migration.
+ * These mirror the four OLD→NEW cases above.
+ */
+
+it( 'routes new-name resources subscribers when the old name is applied', function (): void {
+	HookAliases::registerAll();
+
+	addFilter( 'ap.visualEditor.resources', function ( array $resources ): array {
+		return array_merge( [ 'posts' => 'App\\Models\\Post' ], $resources );
+	} );
+
+	$result = applyFilters( 'ap.visual-editor.resources', [] );
+
+	expect( $result )->toHaveKey( 'posts' );
+} );
+
+it( 'routes new-name templates subscribers when the old name is applied', function (): void {
+	HookAliases::registerAll();
+
+	addFilter( 'ap.visualEditor.templates', function ( array $templates ): array {
+		return array_merge( [ 'front-page' => [ 'slug' => 'front-page' ] ], $templates );
+	} );
+
+	$result = applyFilters( 'ap.visual-editor.templates', [] );
+
+	expect( $result )->toHaveKey( 'front-page' );
+} );
+
+it( 'routes new-name renderedBlock subscribers when the old name is applied', function (): void {
+	HookAliases::registerAll();
+
+	addFilter( 'ap.visualEditor.renderedBlock', function ( string $html ): string {
+		return $html . '::filtered';
+	} );
+
+	$result = applyFilters( 'ap.visual-editor.rendered-block', 'html' );
+
+	expect( $result )->toBe( 'html::filtered' );
+} );
+
+it( 'routes new-name loginout envelope subscribers when the old name is applied', function (): void {
+	HookAliases::registerAll();
+
+	addFilter( 'ap.visualEditor.loginout.envelope', function ( array $envelope ): array {
+		$envelope['touched'] = true;
+
+		return $envelope;
+	} );
+
+	$result = applyFilters( 'ap.visual-editor.loginout.envelope', [] );
+
+	expect( $result )->toHaveKey( 'touched' );
+} );

--- a/tests/Feature/VisualEditor/IconBlockEndToEndTest.php
+++ b/tests/Feature/VisualEditor/IconBlockEndToEndTest.php
@@ -279,7 +279,7 @@ it( 'uploads an icon set, registers it, and makes it pickable end-to-end', funct
 
 	expect( app( UploadedIconSetRegistry::class )->has( 'uploaded' ) )->toBeTrue();
 
-	// Wire a catalog that mirrors what `ap.icons.register-icon-sets`
+	// Wire a catalog that mirrors what `ap.icons.registerIconSets`
 	// would expose for the newly-uploaded set, then drive the picker
 	// search endpoint and confirm the icon is discoverable.
 	e2eBindCatalogFixture(
@@ -454,10 +454,10 @@ it( 'lets a decorative + linked combo recover when an aria-label is supplied', f
 } );
 
 // -------------------------------------------------------------------
-// `ap.icons.register-icon-sets` filter wires bundled sets at boot
+// `ap.icons.registerIconSets` filter wires bundled sets at boot
 // -------------------------------------------------------------------
 
-it( 'collects bundled FA Free sets via the ap.icons.register-icon-sets filter', function (): void {
+it( 'collects bundled FA Free sets via the ap.icons.registerIconSets filter', function (): void {
 	$registrationClass = 'ArtisanPackUI\\Icons\\Registries\\IconSetRegistration';
 
 	// The icons package is a `suggest`-level dependency. When it's not
@@ -480,7 +480,7 @@ it( 'collects bundled FA Free sets via the ap.icons.register-icon-sets filter', 
 		test()->markTestSkipped( 'FA Free SVGs not synced — run `npm run sync:fa-icons` first' );
 	}
 
-	$registry = applyFilters( 'ap.icons.register-icon-sets', new $registrationClass() );
+	$registry = applyFilters( 'ap.icons.registerIconSets', new $registrationClass() );
 
 	$sets = $registry->getSets();
 

--- a/tests/Feature/VisualEditor/ResourcesFilterTest.php
+++ b/tests/Feature/VisualEditor/ResourcesFilterTest.php
@@ -8,7 +8,7 @@ use Tests\Fixtures\TestBlockContentModel;
 use Tests\Fixtures\TestBlockContentPageModel;
 
 afterEach( function () {
-	removeAllFilters( 'ap.visual-editor.resources' );
+	removeAllFilters( 'ap.visualEditor.resources' );
 } );
 
 function rebuildResourceResolver(): ResourceResolver
@@ -18,8 +18,8 @@ function rebuildResourceResolver(): ResourceResolver
 	return app( ResourceResolver::class );
 }
 
-it( 'registers resources contributed via the ap.visual-editor.resources filter', function () {
-	addFilter( 'ap.visual-editor.resources', function ( array $resources ): array {
+it( 'registers resources contributed via the ap.visualEditor.resources filter', function () {
+	addFilter( 'ap.visualEditor.resources', function ( array $resources ): array {
 		return array_merge( [
 			'posts' => TestBlockContentModel::class,
 		], $resources );
@@ -35,7 +35,7 @@ it( 'lets static config win over filter contributions on key collision', functio
 		'posts' => TestBlockContentPageModel::class, // host override
 	] );
 
-	addFilter( 'ap.visual-editor.resources', function ( array $resources ): array {
+	addFilter( 'ap.visualEditor.resources', function ( array $resources ): array {
 		// Filter contributor naively merges its default; the host config
 		// in the static config map should still win.
 		return array_merge( [
@@ -53,7 +53,7 @@ it( 'merges static config and filter contributions when slugs do not collide', f
 		'pages' => TestBlockContentPageModel::class,
 	] );
 
-	addFilter( 'ap.visual-editor.resources', function ( array $resources ): array {
+	addFilter( 'ap.visualEditor.resources', function ( array $resources ): array {
 		return array_merge( [
 			'posts' => TestBlockContentModel::class,
 		], $resources );
@@ -66,7 +66,7 @@ it( 'merges static config and filter contributions when slugs do not collide', f
 } );
 
 it( 'does not throw at boot when a filter contributes an invalid class — error surfaces on first request', function () {
-	addFilter( 'ap.visual-editor.resources', function ( array $resources ): array {
+	addFilter( 'ap.visualEditor.resources', function ( array $resources ): array {
 		return array_merge( [
 			'invalid' => 'App\\Models\\DoesNotExist',
 		], $resources );

--- a/tests/Feature/VisualEditor/SiteEditorFiltersTest.php
+++ b/tests/Feature/VisualEditor/SiteEditorFiltersTest.php
@@ -17,11 +17,11 @@ use ArtisanPackUI\VisualEditor\VisualEditorServiceProvider;
 
 afterEach( function (): void {
 	foreach ( [
-		'ap.visual-editor.templates',
-		'ap.visual-editor.template-parts',
-		'ap.visual-editor.patterns',
-		'ap.visual-editor.global-styles',
-		'ap.visual-editor.navigation',
+		'ap.visualEditor.templates',
+		'ap.visualEditor.templateParts',
+		'ap.visualEditor.patterns',
+		'ap.visualEditor.globalStyles',
+		'ap.visualEditor.navigation',
 	] as $filter ) {
 		removeAllFilters( $filter );
 	}
@@ -45,7 +45,7 @@ describe( 'standalone install (no contributors, no static config)', function ():
 		rebuildSiteEditorResolvers();
 
 		// #639 — visual-editor now ships a built-in `page/blank` seed
-		// pattern registered via `ap.visual-editor.patterns` on boot,
+		// pattern registered via `ap.visualEditor.patterns` on boot,
 		// so the pattern resolver is no longer strictly empty on a
 		// standalone install. Assert on the shape and the seed's slug
 		// rather than `[]`.
@@ -61,7 +61,7 @@ describe( 'standalone install (no contributors, no static config)', function ():
 
 describe( 'single-source filter contribution', function (): void {
 	it( 'registers a template via the templates filter', function (): void {
-		addFilter( 'ap.visual-editor.templates', function ( array $existing ): array {
+		addFilter( 'ap.visualEditor.templates', function ( array $existing ): array {
 			return array_merge( [
 				'page' => [
 					'slug'   => 'page',
@@ -83,7 +83,7 @@ describe( 'single-source filter contribution', function (): void {
 	} );
 
 	it( 'registers a template-part with area', function (): void {
-		addFilter( 'ap.visual-editor.template-parts', function ( array $existing ): array {
+		addFilter( 'ap.visualEditor.templateParts', function ( array $existing ): array {
 			return array_merge( [
 				'header' => [
 					'slug'   => 'header',
@@ -104,7 +104,7 @@ describe( 'single-source filter contribution', function (): void {
 	} );
 
 	it( 'registers a pattern with source flag', function (): void {
-		addFilter( 'ap.visual-editor.patterns', function ( array $existing ): array {
+		addFilter( 'ap.visualEditor.patterns', function ( array $existing ): array {
 			return array_merge( [
 				'cta' => [
 					'slug'   => 'cta',
@@ -125,7 +125,7 @@ describe( 'single-source filter contribution', function (): void {
 	} );
 
 	it( 'registers global-styles as a singleton', function (): void {
-		addFilter( 'ap.visual-editor.global-styles', function ( $existing ) {
+		addFilter( 'ap.visualEditor.globalStyles', function ( $existing ) {
 			return $existing ?? [
 				'theme'    => 'digital-shopfront',
 				'settings' => [ 'color' => [ 'palette' => [] ] ],
@@ -142,7 +142,7 @@ describe( 'single-source filter contribution', function (): void {
 	} );
 
 	it( 'registers a menu under its location', function (): void {
-		addFilter( 'ap.visual-editor.navigation', function ( array $existing ): array {
+		addFilter( 'ap.visualEditor.navigation', function ( array $existing ): array {
 			return array_merge( [
 				'primary' => [
 					'location' => 'primary',
@@ -173,7 +173,7 @@ describe( 'static config wins on key collision', function (): void {
 			],
 		] );
 
-		addFilter( 'ap.visual-editor.templates', function ( array $existing ): array {
+		addFilter( 'ap.visualEditor.templates', function ( array $existing ): array {
 			return array_merge( [
 				'page' => [
 					'slug'   => 'page',
@@ -202,7 +202,7 @@ describe( 'static config wins on key collision', function (): void {
 			],
 		] );
 
-		addFilter( 'ap.visual-editor.templates', function ( array $existing ): array {
+		addFilter( 'ap.visualEditor.templates', function ( array $existing ): array {
 			return array_merge( [
 				'cms-page' => [
 					'slug'   => 'cms-page',
@@ -228,7 +228,7 @@ describe( 'static config wins on key collision', function (): void {
 			'styles'   => [],
 		] );
 
-		addFilter( 'ap.visual-editor.global-styles', function ( $existing ) {
+		addFilter( 'ap.visualEditor.globalStyles', function ( $existing ) {
 			return $existing ?? [
 				'theme'    => 'cms-theme',
 				'settings' => [ 'cms' => true ],
@@ -247,7 +247,7 @@ describe( 'static config wins on key collision', function (): void {
 
 describe( 'lazy validation on first read', function (): void {
 	it( 'does not throw at boot when a filter returns malformed entries', function (): void {
-		addFilter( 'ap.visual-editor.templates', function ( array $existing ): array {
+		addFilter( 'ap.visualEditor.templates', function ( array $existing ): array {
 			return array_merge( [
 				'broken' => 'this-is-not-an-array',
 			], $existing );
@@ -260,7 +260,7 @@ describe( 'lazy validation on first read', function (): void {
 	} );
 
 	it( 'throws SiteEditorRegistrationException on first all() with a malformed entry', function (): void {
-		addFilter( 'ap.visual-editor.templates', function ( array $existing ): array {
+		addFilter( 'ap.visualEditor.templates', function ( array $existing ): array {
 			return array_merge( [
 				'broken' => 'this-is-not-an-array',
 			], $existing );
@@ -273,7 +273,7 @@ describe( 'lazy validation on first read', function (): void {
 	} );
 
 	it( 'throws when a template entry is missing the required theme field', function (): void {
-		addFilter( 'ap.visual-editor.templates', function ( array $existing ): array {
+		addFilter( 'ap.visualEditor.templates', function ( array $existing ): array {
 			return array_merge( [
 				'no-theme' => [
 					'slug'   => 'no-theme',
@@ -290,7 +290,7 @@ describe( 'lazy validation on first read', function (): void {
 	} );
 
 	it( 'throws when a template-part has an invalid area', function (): void {
-		addFilter( 'ap.visual-editor.template-parts', function ( array $existing ): array {
+		addFilter( 'ap.visualEditor.templateParts', function ( array $existing ): array {
 			return array_merge( [
 				'banner' => [
 					'slug'   => 'banner',
@@ -308,7 +308,7 @@ describe( 'lazy validation on first read', function (): void {
 	} );
 
 	it( 'throws when a pattern has an invalid source value', function (): void {
-		addFilter( 'ap.visual-editor.patterns', function ( array $existing ): array {
+		addFilter( 'ap.visualEditor.patterns', function ( array $existing ): array {
 			return array_merge( [
 				'bad' => [
 					'slug'   => 'bad',
@@ -324,7 +324,7 @@ describe( 'lazy validation on first read', function (): void {
 	} );
 
 	it( 'throws when a pattern is missing the title field', function (): void {
-		addFilter( 'ap.visual-editor.patterns', function ( array $existing ): array {
+		addFilter( 'ap.visualEditor.patterns', function ( array $existing ): array {
 			return array_merge( [
 				'titleless' => [
 					'slug'   => 'titleless',
@@ -343,7 +343,7 @@ describe( 'lazy validation on first read', function (): void {
 		// A misconfigured contributor passes a string in the nested
 		// content.blocks slot — should resolve to an empty blocks array
 		// instead of raising a TypeError on the typed constructor param.
-		addFilter( 'ap.visual-editor.patterns', function ( array $existing ): array {
+		addFilter( 'ap.visualEditor.patterns', function ( array $existing ): array {
 			return array_merge( [
 				'malformed' => [
 					'slug'    => 'malformed',
@@ -365,7 +365,7 @@ describe( 'lazy validation on first read', function (): void {
 		// content is a string instead of an array. Without the defensive
 		// is_array guard, $data['content']['raw'] would index into the
 		// string and silently corrupt rawContent to its first character.
-		addFilter( 'ap.visual-editor.patterns', function ( array $existing ): array {
+		addFilter( 'ap.visualEditor.patterns', function ( array $existing ): array {
 			return array_merge( [
 				'scalar-content' => [
 					'slug'    => 'scalar-content',
@@ -385,7 +385,7 @@ describe( 'lazy validation on first read', function (): void {
 	} );
 
 	it( 'safely handles a scalar content envelope on templates', function (): void {
-		addFilter( 'ap.visual-editor.templates', function ( array $existing ): array {
+		addFilter( 'ap.visualEditor.templates', function ( array $existing ): array {
 			return array_merge( [
 				'scalar-template' => [
 					'slug'    => 'scalar-template',
@@ -405,7 +405,7 @@ describe( 'lazy validation on first read', function (): void {
 	} );
 
 	it( 'safely handles a scalar content envelope on template parts', function (): void {
-		addFilter( 'ap.visual-editor.template-parts', function ( array $existing ): array {
+		addFilter( 'ap.visualEditor.templateParts', function ( array $existing ): array {
 			return array_merge( [
 				'scalar-part' => [
 					'slug'    => 'scalar-part',
@@ -431,7 +431,7 @@ describe( 'lazy validation on first read', function (): void {
 		// `(string) $array` produces the literal `"Array"` and ships
 		// silently — the resolver should fall back to the empty default
 		// instead.
-		addFilter( 'ap.visual-editor.patterns', function ( array $existing ): array {
+		addFilter( 'ap.visualEditor.patterns', function ( array $existing ): array {
 			return array_merge( [
 				'array-raw' => [
 					'slug'        => 'array-raw',
@@ -451,7 +451,7 @@ describe( 'lazy validation on first read', function (): void {
 	} );
 
 	it( 'does not stringify a non-scalar nested content.raw to "Array" on templates', function (): void {
-		addFilter( 'ap.visual-editor.templates', function ( array $existing ): array {
+		addFilter( 'ap.visualEditor.templates', function ( array $existing ): array {
 			return array_merge( [
 				'array-content-raw' => [
 					'slug'    => 'array-content-raw',
@@ -475,7 +475,7 @@ describe( 'lazy validation on first read', function (): void {
 		// is_scalar accepts int, float, bool — these are sensibly stringable
 		// and shouldn't be rejected. Verifies the coercion path exposes the
 		// stringified value rather than dropping it.
-		addFilter( 'ap.visual-editor.patterns', function ( array $existing ): array {
+		addFilter( 'ap.visualEditor.patterns', function ( array $existing ): array {
 			return array_merge( [
 				'numeric-raw' => [
 					'slug'        => 'numeric-raw',
@@ -497,7 +497,7 @@ describe( 'lazy validation on first read', function (): void {
 		// Top-level raw_content + nested content.raw should behave the same
 		// way: a non-string scalar (here, an int) coerces to its string form
 		// rather than being silently dropped.
-		addFilter( 'ap.visual-editor.templates', function ( array $existing ): array {
+		addFilter( 'ap.visualEditor.templates', function ( array $existing ): array {
 			return array_merge( [
 				'numeric-template' => [
 					'slug'        => 'numeric-template',
@@ -516,7 +516,7 @@ describe( 'lazy validation on first read', function (): void {
 	} );
 
 	it( 'coerces scalar non-string raw_content to a string on template parts', function (): void {
-		addFilter( 'ap.visual-editor.template-parts', function ( array $existing ): array {
+		addFilter( 'ap.visualEditor.templateParts', function ( array $existing ): array {
 			return array_merge( [
 				'numeric-part' => [
 					'slug'        => 'numeric-part',
@@ -541,7 +541,7 @@ describe( 'lazy validation on first read', function (): void {
 		// to int(404), which contributors cannot prevent at the language
 		// level. The resolver must accept int keys and cast them back to
 		// string so the filter's string-map contract holds end-to-end.
-		addFilter( 'ap.visual-editor.templates', function ( array $existing ): array {
+		addFilter( 'ap.visualEditor.templates', function ( array $existing ): array {
 			return array_merge( [
 				'404' => [
 					'slug'   => '404',
@@ -581,7 +581,7 @@ describe( 'lazy validation on first read', function (): void {
 		// different raw keys but the same slug would silently overwrite
 		// one another. Surface that as a configuration error instead of
 		// last-wins so contributors know to disambiguate.
-		addFilter( 'ap.visual-editor.templates', function ( array $existing ): array {
+		addFilter( 'ap.visualEditor.templates', function ( array $existing ): array {
 			return array_merge( [
 				'raw-a' => [
 					'slug'   => 'shared',
@@ -609,7 +609,7 @@ describe( 'lazy validation on first read', function (): void {
 		// key. The pre-refactor shape guard rejected empty raw keys; the
 		// post-refactor emptyIdentifier check protects the same
 		// invariant on the re-key path.
-		addFilter( 'ap.visual-editor.templates', function ( array $existing ): array {
+		addFilter( 'ap.visualEditor.templates', function ( array $existing ): array {
 			return array_merge( [
 				'raw-key' => [
 					'slug'   => '',
@@ -627,7 +627,7 @@ describe( 'lazy validation on first read', function (): void {
 	} );
 
 	it( 'throws when global-styles is missing the theme field', function (): void {
-		addFilter( 'ap.visual-editor.global-styles', function ( $existing ) {
+		addFilter( 'ap.visualEditor.globalStyles', function ( $existing ) {
 			return $existing ?? [
 				'settings' => [],
 				'styles'   => [],
@@ -641,7 +641,7 @@ describe( 'lazy validation on first read', function (): void {
 	} );
 
 	it( 'auto-stamps the map key as location when a navigation entry omits the field', function (): void {
-		addFilter( 'ap.visual-editor.navigation', function ( array $existing ): array {
+		addFilter( 'ap.visualEditor.navigation', function ( array $existing ): array {
 			return array_merge( [
 				'primary' => [
 					'name' => 'Primary',
@@ -658,7 +658,7 @@ describe( 'lazy validation on first read', function (): void {
 	} );
 
 	it( 'throws when a non-array filter return value would corrupt the resolver', function (): void {
-		addFilter( 'ap.visual-editor.templates', function ( $existing ) {
+		addFilter( 'ap.visualEditor.templates', function ( $existing ) {
 			// Pathological contributor: returns a string.
 			return 'oops';
 		} );

--- a/tests/Feature/VisualEditor/SiteEditorFiltersTest.php
+++ b/tests/Feature/VisualEditor/SiteEditorFiltersTest.php
@@ -576,6 +576,56 @@ describe( 'lazy validation on first read', function (): void {
 		expect( app( TemplateResolver::class )->find( '404' )->slug )->toBe( '404' );
 	} );
 
+	it( 'throws when two template entries resolve to the same slug', function (): void {
+		// Re-keying by the value object's slug means two entries with
+		// different raw keys but the same slug would silently overwrite
+		// one another. Surface that as a configuration error instead of
+		// last-wins so contributors know to disambiguate.
+		addFilter( 'ap.visual-editor.templates', function ( array $existing ): array {
+			return array_merge( [
+				'raw-a' => [
+					'slug'   => 'shared',
+					'theme'  => 'host',
+					'title'  => 'A',
+					'source' => 'theme',
+				],
+				'raw-b' => [
+					'slug'   => 'shared',
+					'theme'  => 'host',
+					'title'  => 'B',
+					'source' => 'theme',
+				],
+			], $existing );
+		} );
+
+		rebuildSiteEditorResolvers();
+
+		expect( fn () => app( TemplateResolver::class )->all() )
+			->toThrow( SiteEditorRegistrationException::class, 'shared' );
+	} );
+
+	it( 'throws when a template entry resolves to an empty slug', function (): void {
+		// An empty identifier would produce an unaddressable `''` map
+		// key. The pre-refactor shape guard rejected empty raw keys; the
+		// post-refactor emptyIdentifier check protects the same
+		// invariant on the re-key path.
+		addFilter( 'ap.visual-editor.templates', function ( array $existing ): array {
+			return array_merge( [
+				'raw-key' => [
+					'slug'   => '',
+					'theme'  => 'host',
+					'title'  => 'Empty Slug',
+					'source' => 'theme',
+				],
+			], $existing );
+		} );
+
+		rebuildSiteEditorResolvers();
+
+		expect( fn () => app( TemplateResolver::class )->all() )
+			->toThrow( SiteEditorRegistrationException::class, 'empty identifier' );
+	} );
+
 	it( 'throws when global-styles is missing the theme field', function (): void {
 		addFilter( 'ap.visual-editor.global-styles', function ( $existing ) {
 			return $existing ?? [

--- a/tests/Feature/VisualEditor/SiteEditorFiltersTest.php
+++ b/tests/Feature/VisualEditor/SiteEditorFiltersTest.php
@@ -535,6 +535,47 @@ describe( 'lazy validation on first read', function (): void {
 		expect( $part->rawContent )->toBe( '1.5' );
 	} );
 
+	it( 'accepts numeric-string template slugs (404, 500) that PHP coerces to int keys', function (): void {
+		// WordPress template hierarchy uses `404.html` / `500.html`, whose
+		// basenames double as slugs. PHP auto-coerces `'404'` array keys
+		// to int(404), which contributors cannot prevent at the language
+		// level. The resolver must accept int keys and cast them back to
+		// string so the filter's string-map contract holds end-to-end.
+		addFilter( 'ap.visual-editor.templates', function ( array $existing ): array {
+			return array_merge( [
+				'404' => [
+					'slug'   => '404',
+					'theme'  => 'host',
+					'title'  => 'Not Found',
+					'source' => 'theme',
+				],
+				'500' => [
+					'slug'   => '500',
+					'theme'  => 'host',
+					'title'  => 'Server Error',
+					'source' => 'theme',
+				],
+			], $existing );
+		} );
+
+		rebuildSiteEditorResolvers();
+
+		$notFound = app( TemplateResolver::class )->find( '404' );
+		$serverError = app( TemplateResolver::class )->find( '500' );
+
+		expect( $notFound )->not->toBeNull();
+		expect( $notFound->slug )->toBe( '404' );
+		expect( $serverError )->not->toBeNull();
+		expect( $serverError->slug )->toBe( '500' );
+
+		// PHP re-coerces numeric-string map keys back to int on assignment,
+		// so the raw key type in all() is a language-level detail consumers
+		// can't rely on either way — what matters is that find() with the
+		// canonical string identifier resolves to the right value object
+		// and that the entry preserves its slug as a string.
+		expect( app( TemplateResolver::class )->find( '404' )->slug )->toBe( '404' );
+	} );
+
 	it( 'throws when global-styles is missing the theme field', function (): void {
 		addFilter( 'ap.visual-editor.global-styles', function ( $existing ) {
 			return $existing ?? [

--- a/tests/Feature/VisualEditor/VisualEditorComponentTest.php
+++ b/tests/Feature/VisualEditor/VisualEditorComponentTest.php
@@ -173,3 +173,126 @@ it( 'omits optional data attributes when the matching props are not supplied', f
 		->and( $html )->not->toContain( 'data-author-options=' )
 		->and( $html )->not->toContain( 'data-supports=' );
 } );
+
+describe( 'ap.visualEditor.editorConfig filter', function (): void {
+	afterEach( function (): void {
+		removeAllFilters( 'ap.visualEditor.editorConfig' );
+	} );
+
+	it( 'lets a callback rewrite props before render', function (): void {
+		$model = TestBlockContentModel::create( [
+			'title'   => 'Base',
+			'status'  => 'published',
+			'content' => [],
+		] );
+
+		addFilter( 'ap.visualEditor.editorConfig', function ( array $config, string $screen ): array {
+			$config['apiBase']      = '/custom/api';
+			$config['initialTitle'] = 'Filtered';
+
+			return $config;
+		}, 10, 2 );
+
+		$html = Blade::render(
+			'<x-visual-editor :model="$model" :initial-title="\'Base\'" />',
+			[ 'model' => $model ]
+		);
+
+		expect( $html )->toContain( 'data-api-base="/custom/api"' )
+			->and( $html )->toContain( 'data-title="Filtered"' );
+	} );
+
+	it( 'passes the "post" screen identifier so hosts can gate per surface', function (): void {
+		$model = TestBlockContentModel::create( [
+			'title'   => 'Screen',
+			'status'  => 'published',
+			'content' => [],
+		] );
+
+		$screensSeen = [];
+		addFilter( 'ap.visualEditor.editorConfig', function ( array $config, string $screen ) use ( &$screensSeen ): array {
+			$screensSeen[] = $screen;
+
+			return $config;
+		}, 10, 2 );
+
+		Blade::render(
+			'<x-visual-editor :model="$model" />',
+			[ 'model' => $model ]
+		);
+
+		expect( $screensSeen )->toBe( [ 'post' ] );
+	} );
+
+	it( 'ignores a non-array filter return so props survive intact', function (): void {
+		$model = TestBlockContentModel::create( [
+			'title'   => 'Intact',
+			'status'  => 'published',
+			'content' => [],
+		] );
+
+		addFilter( 'ap.visualEditor.editorConfig', function ( array $config, string $screen ): ?bool {
+			return null;
+		}, 10, 2 );
+
+		$html = Blade::render(
+			'<x-visual-editor :model="$model" />',
+			[ 'model' => $model ]
+		);
+
+		expect( $html )->toContain( 'data-resource="posts"' )
+			->and( $html )->toContain( 'data-api-base="/visual-editor/api"' );
+	} );
+
+	it( 'preserves props whose filtered value is a bad shape for the coercer', function (): void {
+		$model = TestBlockContentModel::create( [
+			'title'   => 'Coerce',
+			'status'  => 'published',
+			'content' => [],
+		] );
+
+		addFilter( 'ap.visualEditor.editorConfig', function ( array $config, string $screen ): array {
+			// Malformed values across each coercer type; every one should
+			// be rejected in favour of the current prop value.
+			$config['apiBase']             = 42;              // string coercer
+			$config['initialTitle']        = [ 'not string' ]; // nullableString
+			$config['initialCommentsOpen'] = 'yes';           // nullableBool
+			$config['authorOptions']       = 'oops';          // nullableArray
+			$config['initialAuthorId']     = true;            // nullableIntOrString — must not TypeError
+
+			return $config;
+		}, 10, 2 );
+
+		$html = Blade::render(
+			'<x-visual-editor :model="$model" :initial-title="\'Kept\'" />',
+			[ 'model' => $model ]
+		);
+
+		expect( $html )->toContain( 'data-api-base="/visual-editor/api"' )
+			->and( $html )->toContain( 'data-title="Kept"' )
+			// initialCommentsOpen was null (unset), so no data-comments-open should be emitted.
+			->and( $html )->not->toContain( 'data-comments-open=' )
+			->and( $html )->not->toContain( 'data-author-options=' );
+	} );
+
+	it( 'leaves omitted keys untouched when the filter returns a partial config', function (): void {
+		$model = TestBlockContentModel::create( [
+			'title'   => 'Partial',
+			'status'  => 'published',
+			'content' => [],
+		] );
+
+		addFilter( 'ap.visualEditor.editorConfig', function ( array $config, string $screen ): array {
+			return [ 'apiBase' => '/only-this' ];
+		}, 10, 2 );
+
+		$html = Blade::render(
+			'<x-visual-editor :model="$model" :initial-title="\'Untouched\'" />',
+			[ 'model' => $model ]
+		);
+
+		expect( $html )->toContain( 'data-api-base="/only-this"' )
+			->and( $html )->toContain( 'data-title="Untouched"' )
+			->and( $html )->toContain( 'data-resource="posts"' );
+	} );
+} );

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 
 namespace Tests;
 
+use ArtisanPackUI\Hooks\Providers\HooksServiceProvider;
 use ArtisanPackUI\VisualEditor\VisualEditorServiceProvider;
 use Orchestra\Testbench\TestCase as BaseTestCase;
 
@@ -17,6 +18,7 @@ abstract class TestCase extends BaseTestCase
 	protected function getPackageProviders( $app ): array
 	{
 		return [
+			HooksServiceProvider::class,
 			VisualEditorServiceProvider::class,
 		];
 	}

--- a/tests/Unit/VisualEditor/BlockTypeRegistryTest.php
+++ b/tests/Unit/VisualEditor/BlockTypeRegistryTest.php
@@ -55,3 +55,40 @@ it( 'rejects block names missing a namespace', function () {
 
 	$registry->register( 'paragraph', [] );
 } )->throws( InvalidArgumentException::class );
+
+it( 'fires ap.visualEditor.blockRegistered on successful registration', function (): void {
+	$registry = new BlockTypeRegistry();
+	$seen     = [];
+
+	addAction( 'ap.visualEditor.blockRegistered', function ( string $name, array $config ) use ( &$seen ): void {
+		$seen[] = [ 'name' => $name, 'config' => $config ];
+	}, 10, 2 );
+
+	$registry->register( 'acme/hero', [ 'title' => 'Hero', 'category' => 'design' ] );
+
+	removeAllActions( 'ap.visualEditor.blockRegistered' );
+
+	expect( $seen )->toHaveCount( 1 )
+		->and( $seen[0]['name'] )->toBe( 'acme/hero' )
+		->and( $seen[0]['config']['title'] )->toBe( 'Hero' )
+		->and( $seen[0]['config']['name'] )->toBe( 'acme/hero' );
+} );
+
+it( 'does not fire ap.visualEditor.blockRegistered when the name is invalid', function (): void {
+	$registry = new BlockTypeRegistry();
+	$fired    = false;
+
+	addAction( 'ap.visualEditor.blockRegistered', function () use ( &$fired ): void {
+		$fired = true;
+	} );
+
+	try {
+		$registry->register( 'BAD NAME', [] );
+	} catch ( InvalidArgumentException $e ) {
+		// expected
+	}
+
+	removeAllActions( 'ap.visualEditor.blockRegistered' );
+
+	expect( $fired )->toBeFalse();
+} );

--- a/tests/Unit/VisualEditor/SiteEditor/Adapters/PatternAdapterTest.php
+++ b/tests/Unit/VisualEditor/SiteEditor/Adapters/PatternAdapterTest.php
@@ -109,6 +109,56 @@ describe( 'single-record envelope', function (): void {
 	} );
 } );
 
+describe( 'ap.visualEditor.patternRender filter', function (): void {
+	afterEach( function (): void {
+		removeAllFilters( 'ap.visualEditor.patternRender' );
+	} );
+
+	it( 'lets a callback rewrite the rendered raw content', function (): void {
+		addFilter( 'ap.visualEditor.patternRender', function ( string $html, string $slug, array $context ): string {
+			return $html . '<!-- filtered:' . $slug . ' -->';
+		}, 10, 3 );
+
+		$out = ( new PatternAdapter() )->toArray( makeResolvedPattern() );
+
+		expect( $out['content']['raw'] )->toBe( '<!-- wp:cover /--><!-- filtered:hero-banner -->' );
+	} );
+
+	it( 'passes source/synced/categories/block_types/post_types context so callbacks can gate per pattern shape', function (): void {
+		$captured = null;
+		addFilter( 'ap.visualEditor.patternRender', function ( string $html, string $slug, array $context ) use ( &$captured ): string {
+			$captured = $context;
+
+			return $html;
+		}, 10, 3 );
+
+		( new PatternAdapter() )->toArray( makeResolvedPattern( [
+			'source'     => 'user',
+			'synced'     => true,
+			'categories' => [ 'hero', 'promo' ],
+			'blockTypes' => [ 'core/cover', 'core/heading' ],
+			'postTypes'  => [ 'page' ],
+		] ) );
+
+		expect( $captured )->not->toBeNull()
+			->and( $captured['source'] )->toBe( 'user' )
+			->and( $captured['synced'] )->toBeTrue()
+			->and( $captured['categories'] )->toBe( [ 'hero', 'promo' ] )
+			->and( $captured['block_types'] )->toBe( [ 'core/cover', 'core/heading' ] )
+			->and( $captured['post_types'] )->toBe( [ 'page' ] );
+	} );
+
+	it( 'ignores a non-string filter return so the original content survives', function (): void {
+		addFilter( 'ap.visualEditor.patternRender', function ( string $html ): ?array {
+			return [ 'not', 'a', 'string' ];
+		} );
+
+		$out = ( new PatternAdapter() )->toArray( makeResolvedPattern() );
+
+		expect( $out['content']['raw'] )->toBe( '<!-- wp:cover /-->' );
+	} );
+} );
+
 describe( 'collection envelope', function (): void {
 	it( 'returns a flat list in iteration order', function (): void {
 		$patterns = [


### PR DESCRIPTION
## Release Information

- **Release Version:** v1.5.0
- **Release Date:** 2026-07-21
- **Release Type:** Minor (contains BREAKING renames guarded by deprecation aliases)
- **Release Branch:** `release/1.5`
- **Target Branch:** `main`

## Release Summary

v1.5.0 is a **hooks-focused release** that lands the ecosystem-wide
camelCase hook convention and expands the extension surface with six
new lifecycle hooks. It also ships two site-editor correctness fixes
(numeric-string map keys, identifier-based `find()`) and moves canvas
CSS assembly onto cms-framework's `ThemeStylesheetReader` (with an
editor-stylesheet analog for the site-editor canvas).

## Changelog

### Added

- **Six new lifecycle hooks for editor and block integrations (#665).**
  Fills in high-value extension points across block registration,
  rendering, post persistence, editor config assembly, and pattern
  rendering:
  - `ap.visualEditor.blockRegistered` — action, `(string $name, array $config)`
  - `ap.visualEditor.beforeRender` — filter, `(array $attributes, string $name)` (non-array returns discarded)
  - `ap.visualEditor.postSaved` — action, `(int|string $postId, array $blocks)`
  - `ap.visualEditor.postPublished` — action, same payload; fires on status transition to `publish`
  - `ap.visualEditor.editorConfig` — filter, `(array $config, string $screen)`; re-hydrated onto typed props
  - `ap.visualEditor.patternRender` — filter, `(string $html, string $slug, array $context)`

### Changed

- **Bumped `artisanpack-ui/hooks` requirement to `^1.3` (#665).** The
  hook fire sites added in #665 assume the helper globals are always
  available; the previous `^1.2` `function_exists()` guards were dropped
  in favour of the newer floor.

### Changed (BREAKING)

- **Renamed every visual-editor hook to camelCase (#664).** The 13 PHP
  hooks the package fires or subscribes to, plus `visual_editor.pre_publish_checks`,
  `ap.icons.register-icon-sets`, and three JS-only hooks
  (`background-controls`, `canvas-styles`, `document-panels`), now use
  camelCase. Old names remain functional via `deprecateHook()` aliases
  registered by `ArtisanPackUI\VisualEditor\Support\HookAliases` on the
  PHP side and a bidirectional `@wordpress/hooks` shim on the JS side;
  a deprecation notice is logged the first time an alias resolves per
  process. See `CHANGELOG.md` for the full rename table.
- **Site-editor map resolvers key by the entry's own identifier.**
  `find( $rawKey )` no longer resolves by the raw filter key — only by
  the value object's identifier. First-party contributors (including
  cms-framework) already stamp matching `slug` / `location` and are
  unaffected.
- **Canvas CSS endpoint delegates to cms-framework's `ThemeStylesheetReader`.**
  `GET /visual-editor/api/global-styles/css` now concatenates emitter
  output + `themes/{slug}/style.css` + `themes/{slug}/editor.css`
  (closes the canvas half of cms-framework #199 — a WordPress
  `add_editor_style()` analog). Falls back to the inline
  `readThemeStylesheet()` for cms-framework < 2.5.

### Fixed

- **Site-editor resolvers accept numeric-string map keys (cms-framework #203).**
  Template hierarchy filenames like `404.html` / `500.html` double as
  slugs, but PHP coerces numeric-string keys to `int` and `array_merge`
  renumbers int-keyed entries sequentially. `AbstractMapResolver` now
  accepts `int` keys and re-keys the normalized output map by each
  value object's own identifier via a new `identifierOf()` hook.
  Empty identifiers and collisions now throw
  `SiteEditorRegistrationException` at first read.

## Issues and Pull Requests

**Related PRs merged into `release/1.5`:**
- #668 — site-editor viewport scroll + pattern thumbnails from rawContent
- #669 — delegate canvas CSS to cms-framework's `ThemeStylesheetReader`
- #670 — accept numeric-string map keys in site-editor resolvers
- #671 — camelCase hook rename (#664)
- #672 — six new lifecycle hooks (#665)

## Breaking Changes

- [x] Breaking changes documented below

**Breaking changes:**

1. **Hook renames to camelCase.** All old kebab-case hook names continue
   to work via aliases, but each alias logs a deprecation notice on
   first use per process. Downstream code should switch to the canonical
   camelCase names.
2. **Site-editor `find()` no longer resolves by raw filter key.** Only
   the value object's identifier resolves. Contributors whose entry
   `slug` / `location` diverges from their filter map key must align them.
3. **Site-editor duplicate identifiers now throw.** Empty identifiers and
   collisions raise `SiteEditorRegistrationException` at first read.

**Migration guide:**

- Rename hook subscribers / callers to the camelCase names (see the
  rename table in `CHANGELOG.md` and `docs/Hooks-and-Events.md`).
- Ensure `slug` / `location` on contributed site-editor entries matches
  the filter map key you want addressed by.

## Testing Checklist

- [x] All automated tests passing (PHP: 86 passed / 1479 deprecation warnings only)
- [ ] Manual testing completed
- [x] Accessibility tests passing (as part of PHP suite)
- [ ] Performance tests passing (n/a for this release)
- [x] Security scan completed (no advisories)
- [ ] Tested in staging environment
- [x] Database migrations tested (n/a — no migrations in this release)

**Testing notes:**

- The 18 pre-existing failures in
  `resources/js/visual-editor/site-editor/__tests__/site-editor-app.test.tsx`
  (all attributed to `window.localStorage` being undefined in the shared
  `beforeEach`) reproduce identically on `main` and are unrelated to
  1.5.0. Filing a separate follow-up is recommended.

## Documentation Checklist

- [x] CHANGELOG updated ([Unreleased] entries folded into [1.5.0], dated 2026-07-21)
- [x] README already carries the v1.5.0 rename callout
- [x] API documentation updated (`docs/Hooks-and-Events.md`, `docs/Configuration.md`, `docs/content-model.md`, `docs/troubleshooting.md`, `docs/visibility.md`, `docs/post-editor/Getting-Started.md`, `docs/blocks/Icon-Block.md` — all hook refs renamed; new callout in Hooks-and-Events.md)
- [x] Migration guide written (see rename table in CHANGELOG + Hooks-and-Events callout)
- [x] Release notes written (this description)
- [ ] Wiki updated (post-merge)

## Pre-Release Checklist

- [x] Version number updated in all necessary files (composer.json, package.json — both at 1.5.0)
- [ ] Git tag prepared: `v1.5.0` (post-merge)
- [x] Release branch created/updated: `release/1.5`
- [x] Dependencies updated and tested (composer/npm lock in sync)
- [ ] Build artifacts generated (post-merge)
- [ ] Deployment plan reviewed
- [ ] Rollback plan prepared
- [ ] Stakeholders notified

## Notes

**Known issue (pre-existing, not caused by this release):**
`site-editor-app.test.tsx` has 18 failing tests on both `main` and
`release/1.5` due to a jsdom `window.localStorage` reference in
`beforeEach`. Not a blocker for this release; recommend a follow-up
issue to restore the site-editor shell test suite.

---

**Release Manager:** @jacobmartella  
**Reviewers Required:** @jacobmartella
