### PR TITLE
fix: expose media bridge from site-editor entry (#677)

### DIFF
--- a/resources/js/visual-editor/site-editor/__tests__/main-media-bridge.test.tsx
+++ b/resources/js/visual-editor/site-editor/__tests__/main-media-bridge.test.tsx
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// Stub the dynamic shell import so importing `../main` doesn't try to
+// resolve `@wordpress/block-editor` under jsdom.
+vi.mock('../site-editor-app', () => ({
+    SiteEditorApp: (): JSX.Element => (
+        <div data-testid="ap-site-editor-stub" />
+    ),
+}));
+
+import {
+    registerArtisanpackMediaBridge,
+    registerMediaBridge,
+} from '../main';
+
+describe('site-editor media-bridge surface (#677)', () => {
+    it('re-exports registerMediaBridge and registerArtisanpackMediaBridge', () => {
+        expect(typeof registerMediaBridge).toBe('function');
+        expect(typeof registerArtisanpackMediaBridge).toBe('function');
+    });
+
+    it('installs the bridge registration API on window.ApSiteEditor', () => {
+        expect(window.ApSiteEditor).toBeDefined();
+        expect(typeof window.ApSiteEditor?.boot).toBe('function');
+        expect(typeof window.ApSiteEditor?.registerMediaBridge).toBe(
+            'function'
+        );
+        expect(
+            typeof window.ApSiteEditor?.registerArtisanpackMediaBridge
+        ).toBe('function');
+    });
+
+    it('exposes the boot function on window.ApSiteEditorBoot', () => {
+        expect(typeof window.ApSiteEditorBoot).toBe('function');
+    });
+});

--- a/resources/js/visual-editor/site-editor/main.tsx
+++ b/resources/js/visual-editor/site-editor/main.tsx
@@ -15,12 +15,34 @@
 import { createElement } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 
+import {
+    ensureMediaBridgeFilter,
+    registerArtisanpackMediaBridge as registerArtisanpackMediaBridgeImpl,
+    registerMediaBridge as registerMediaBridgeImpl,
+} from '../media-bridge';
 import { registerHookAliases } from '../support/hook-aliases';
+
+// Re-export the aliased locals so hosts loading this bundle as an ESM
+// module can wire `MediaModal` + `uploadMedia` without also importing
+// the post-editor entry (#677). Uses the aliased locals rather than a
+// second `export … from '../media-bridge'` re-export so the source of
+// truth stays one import statement.
+export {
+    registerArtisanpackMediaBridgeImpl as registerArtisanpackMediaBridge,
+    registerMediaBridgeImpl as registerMediaBridge,
+};
 
 // Install #664 hook-name aliases at module load. See editor/main.tsx for
 // the rationale — the site-editor shares the same hook surface as the
 // post editor.
 registerHookAliases();
+
+// Install the `editor.MediaUpload` filter eagerly (#677) so the Media
+// Library slot fill is in place even if the host registers its bridge
+// after boot. The filter callback resolves the component lazily on each
+// `apply_filters`, so a late `registerMediaBridge()` still lights up
+// the Media Library button in the core/image placeholder.
+ensureMediaBridgeFilter();
 
 import '../a11y.css';
 import type { BreakpointRegistrySnapshot } from '../responsive/types';
@@ -257,6 +279,31 @@ export function bootSiteEditor(
     const elements = scope.querySelectorAll<HTMLElement>(MOUNT_SELECTOR);
 
     return Promise.all(Array.from(elements).map((element) => mount(element)));
+}
+
+// Expose the boot function and media-bridge registration on `window`
+// (#677) so SPA hosts and hosts loading this bundle via `<script
+// type="module">` can wire `MediaModal` + `uploadMedia` before the
+// site-editor mounts its Gutenberg canvas. Mirrors the `window.ApVisualEditor`
+// surface installed by `editor/main.tsx`.
+declare global {
+    interface Window {
+        ApSiteEditorBoot?: (scope?: ParentNode) => Promise<void[]>;
+        ApSiteEditor?: {
+            boot: typeof bootSiteEditor;
+            registerArtisanpackMediaBridge: typeof registerArtisanpackMediaBridgeImpl;
+            registerMediaBridge: typeof registerMediaBridgeImpl;
+        };
+    }
+}
+
+if (typeof window !== 'undefined') {
+    window.ApSiteEditorBoot = bootSiteEditor;
+    window.ApSiteEditor = {
+        boot: bootSiteEditor,
+        registerArtisanpackMediaBridge: registerArtisanpackMediaBridgeImpl,
+        registerMediaBridge: registerMediaBridgeImpl,
+    };
 }
 
 if (typeof document !== 'undefined') {


### PR DESCRIPTION
## Description

The site-editor bundle never installed the `editor.MediaUpload` slot-fill filter and never exposed the media-bridge registration API. As a result the `core/image` block placeholder in template parts hid the **Media Library** button and clicking **Upload** silently no-op'd — the fallback uploader surfaced an *"Uploads are unavailable until a media bridge is registered"* snackbar because no host could actually register one on the site-editor entry.

This PR mirrors the post-editor's registration surface on `site-editor/main.tsx` so hosts can wire `MediaModal` + `uploadMedia` from `artisanpack-ui/media-library` (or a custom picker) into the site editor exactly the way they already wire it into the post editor.

**Closes:** #677

## Type of Change

- [x] Bug fix (fixes an issue)

## Related Issue

**Issue:** #677

## Motivation and Context

The post editor exposes `window.ApVisualEditor.registerArtisanpackMediaBridge` from `editor/main.tsx` and the dev app calls it with `MediaModal` + `uploadMedia` before boot. The site editor shipped without the equivalent surface — `editor/main.tsx`'s bridge exports never reached `site-editor/main.tsx`, so:

1. **No `editor.MediaUpload` slot fill** → Gutenberg falls back to its stock placeholder → **Media Library** button hidden.
2. **`mediaUploadSetting`'s uploader resolves to `null`** → clicking **Upload** surfaces the fallback error message via Gutenberg's snackbar with no network request, no console output.

## Changes Made

- Re-export `registerMediaBridge` / `registerArtisanpackMediaBridge` from `site-editor/main.tsx` (ESM) via the aliased locals — one import statement is the source of truth.
- Install `window.ApSiteEditor` and `window.ApSiteEditorBoot` mirroring the `window.ApVisualEditor` surface installed by `editor/main.tsx`.
- Call `ensureMediaBridgeFilter()` at module load so the slot fill is in place even if the host registers the bridge asynchronously — the filter callback resolves the component lazily on each `apply_filters`.
- Add a Vitest spec asserting the exports and the `window.ApSiteEditor` global (spec is scoped narrowly to bridge surface; existing `main.test.tsx` still covers mount/unmount).

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS Darwin 27
- Browser: Safari (dev)
- PHP Version: 8.4
- Project Version: `release/1.5.2` (branched from `release/1.x` at the tip)

**Tests Performed:**

1. `npx vitest run resources/js/visual-editor/site-editor/__tests__/main-media-bridge.test.tsx resources/js/visual-editor/site-editor/__tests__/main.test.tsx resources/js/visual-editor/media-bridge` → **46 passed** (new spec + pre-existing site-editor / media-bridge suites).
2. Manual (dev app `artisanpack-ui-dev`, `/visual-editor/site/templates/page`):
   - core/image placeholder shows **Upload**, **Media Library**, and **Insert from URL**.
   - **Upload** → picking an image uploads through `uploadMedia` and inserts.
   - **Media Library** → opens `MediaModal`, selection inserts with `id`, `url`, `alt`, and sizes.
   - Drag-and-drop upload onto the canvas works.
   - Without a registered bridge the existing operator-facing alert still surfaces (behavior unchanged).

## Accessibility Tests Run

- [x] Keyboard navigation tested — the Media Library button is reachable via Tab from the placeholder, and Enter opens the modal.
- [x] Screen reader tested — no changes to the block placeholder's ARIA structure; the newly-visible Media Library button uses Gutenberg's stock label.
- [ ] Color contrast verified — n/a, no color changes.
- [ ] ARIA labels checked — n/a, no label changes.

**Details:** The change is purely wiring — it makes the pre-existing Gutenberg slot fill reachable. No new interactive surfaces or labels were introduced.

## Tests Added

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All tests passing

**Test details:** New file `resources/js/visual-editor/site-editor/__tests__/main-media-bridge.test.tsx` asserts:
- `registerMediaBridge` and `registerArtisanpackMediaBridge` are re-exported from `../main`.
- `window.ApSiteEditor.{boot, registerMediaBridge, registerArtisanpackMediaBridge}` are defined after module load.
- `window.ApSiteEditorBoot` is defined.

## Documentation

- [x] Inline code documentation added
- [ ] README updated
- [ ] Wiki updated
- [ ] API documentation updated

**Documentation details:** In-file comments in `site-editor/main.tsx` reference #677 and explain why the filter is installed eagerly and why the aliased-local re-export shape is used.

## Screenshots

N/a — the fix restores the stock Gutenberg placeholder + modal UI. No new visual surface.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted (TS strict, existing conventions in `editor/main.tsx` mirrored)
- [x] Accessibility tests completed
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

## Follow-up

While reviewing, I surfaced an unrelated pre-existing rendering issue in the site editor: `CanvasThemeStyles` injects `:root { padding }` from the theme global-styles emitter, which lands on the outer `<html>` when the site editor mounts inline. It's invisible on hosts with a transparent `<body>` but shows up on any host that paints `<body>` (e.g. the dev app). Filed as **#679** (milestone: Awaiting Review, label: bug) with a full root-cause and fix approach. The dev app carries a temporary `html { padding: 0 !important }` override in `resources/css/site-editor.css` (dev-app change, not in this PR); that override can be removed once #679 lands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added public site editor integration points for booting the editor and registering media functionality.
  * Added media bridge registration exports for module-based integrations.
  * Ensured media upload functionality remains available when the media bridge is registered after editor startup.

* **Tests**
  * Added coverage validating the site editor’s public media bridge and boot interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->