### PR TITLE
fix: bake dist/editor and dist/lib into the release tag (#678)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,8 +83,155 @@ jobs:
       - name: Build app bundle
         run: npm run build
 
-  release:
+  build-dist:
+    # Rebuilds the editor + library bundles, bakes them into the tag's
+    # release commit, and packages sourcemaps as a separate archive.
+    #
+    # `dist/` is intentionally .gitignored on every working branch so
+    # local builds don't leak into diffs. The release commit is the
+    # ONE place the built assets are supposed to live so consumers
+    # that install via Composer's GitHub-tarball resolution (Keystone
+    # CMS, etc. — see #678) get a `vendor/artisanpack-ui/visual-editor/
+    # dist/editor/` tree without running Node themselves.
     needs: [test-php, test-js]
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    name: Build and bake dist/ into release tag
+
+    permissions:
+      contents: write
+
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      release_sha: ${{ steps.commit-dist.outputs.release_sha }}
+      sourcemap_archive: ${{ steps.package-sourcemaps.outputs.archive }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # We need to push a re-tag from this job, so keep the token.
+          persist-credentials: true
+          fetch-depth: 0
+
+      - name: Extract version from tag
+        id: version
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/v}"
+          case "$VERSION" in
+            ''|*[!0-9A-Za-z.+-]*)
+              echo "Invalid version extracted from tag: $VERSION" >&2
+              exit 1
+              ;;
+          esac
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Build library bundle
+        run: npm run build:lib
+
+      - name: Build editor bundle
+        run: npm run build
+
+      - name: Package sourcemaps and strip them from dist/
+        id: package-sourcemaps
+        env:
+          VERSION_INPUT: ${{ steps.version.outputs.version }}
+        run: |
+          VERSION="$VERSION_INPUT"
+          ARCHIVE="dist-sourcemaps-v${VERSION}.tar.gz"
+
+          mkdir -p release-artifacts
+
+          # Collect every .map under dist/. If any exist, tar them into
+          # a separate archive and delete from the tree — sourcemaps
+          # would ~triple the composer tarball otherwise (#678).
+          find dist -type f -name '*.map' -print0 > sourcemap-files.txt
+          if [ -s sourcemap-files.txt ]; then
+            tar --null -T sourcemap-files.txt -czf "release-artifacts/${ARCHIVE}"
+            xargs -0 rm -f < sourcemap-files.txt
+          else
+            echo "No sourcemaps produced by the build."
+          fi
+          rm -f sourcemap-files.txt
+
+          echo "archive=${ARCHIVE}" >> $GITHUB_OUTPUT
+
+      - name: Verify dist/ contents
+        # Fail loudly if the build ever stops producing the files hosts
+        # depend on. Prevents shipping another `1.5.1`-shaped release
+        # where `dist/editor/` is silently missing.
+        run: |
+          missing=0
+          for f in \
+            dist/editor/visual-editor.js \
+            dist/editor/site-editor.js \
+            dist/editor/sandbox.js \
+            dist/lib/visual-editor.js
+          do
+            if [ ! -f "$f" ]; then
+              echo "Missing required build output: $f" >&2
+              missing=1
+            fi
+          done
+          if [ ! -d dist/editor/chunks ]; then
+            echo "Missing required build output: dist/editor/chunks/" >&2
+            missing=1
+          fi
+          # Sourcemaps must have been split out — leaked .map files
+          # would bloat every composer install by ~30 MB.
+          if find dist -type f -name '*.map' | grep .; then
+            echo "Sourcemaps leaked into dist/ tree after packaging step" >&2
+            missing=1
+          fi
+          if [ "$missing" -ne 0 ]; then
+            exit 1
+          fi
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Commit dist/ and re-point the release tag
+        id: commit-dist
+        env:
+          VERSION_INPUT: ${{ steps.version.outputs.version }}
+        run: |
+          VERSION="$VERSION_INPUT"
+
+          # `.gitignore` still lists `dist/` — that's what keeps local
+          # builds out of every non-release working tree. Force-add
+          # here so this one release commit contains the built assets.
+          git add --force dist/editor dist/lib
+          git commit -m "chore(release): bake dist/ for v${VERSION} (#678)"
+          RELEASE_SHA=$(git rev-parse HEAD)
+
+          # Re-point the tag at the new commit so Composer /
+          # Packagist resolve the built tarball. Force-push because
+          # the tag already exists at the pre-build commit.
+          git tag -f "v${VERSION}" "$RELEASE_SHA"
+          git push --force origin "refs/tags/v${VERSION}"
+
+          echo "release_sha=$RELEASE_SHA" >> $GITHUB_OUTPUT
+
+      - name: Upload sourcemap archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: sourcemaps
+          path: release-artifacts/
+          if-no-files-found: warn
+          retention-days: 7
+
+  release:
+    needs: [build-dist]
     runs-on: ubuntu-latest
     name: Create Release
 
@@ -94,11 +241,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          # The tag was re-pointed by `build-dist`; check out the new
+          # commit so release notes are extracted from the correct tree.
+          ref: refs/tags/v${{ needs.build-dist.outputs.version }}
           persist-credentials: false
-
-      - name: Extract version from tag
-        id: version
-        run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
 
       - name: Extract release notes from CHANGELOG
         id: changelog
@@ -106,7 +252,7 @@ jobs:
           # Pass the tag through an env var instead of interpolating it directly
           # into the shell script — keeps the value as a plain string regardless
           # of what the tag contains and silences zizmor template-injection.
-          VERSION_INPUT: ${{ steps.version.outputs.version }}
+          VERSION_INPUT: ${{ needs.build-dist.outputs.version }}
         run: |
           VERSION="$VERSION_INPUT"
           case "$VERSION" in
@@ -141,13 +287,27 @@ jobs:
           # Write to file for multi-line support
           echo "$NOTES" > release_notes.txt
 
+      - name: Download sourcemap archive
+        uses: actions/download-artifact@v4
+        with:
+          name: sourcemaps
+          path: release-artifacts
+
+      - name: List release assets
+        run: ls -la release-artifacts/ || true
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          name: v${{ steps.version.outputs.version }}
+          name: v${{ needs.build-dist.outputs.version }}
           body_path: release_notes.txt
           generate_release_notes: false
-          prerelease: ${{ contains(steps.version.outputs.version, '-') }}
+          prerelease: ${{ contains(needs.build-dist.outputs.version, '-') }}
+          # Sourcemaps ride along as a separate archive so debugging is
+          # still possible without inflating every composer install
+          # by ~30 MB (#678).
+          files: release-artifacts/*.tar.gz
+          fail_on_unmatched_files: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,11 @@
 /vendor/
 .idea/
 node_modules/
+# `dist/` is intentionally ignored on every working branch so local
+# builds don't leak into diffs. The `release.yml` workflow force-adds
+# `dist/editor/` and `dist/lib/` when it bakes the release tag so
+# Composer consumers (Keystone CMS etc. — see #678) get the built
+# bundles from `vendor/artisanpack-ui/visual-editor/dist/editor/`.
 dist/
 .vite/
 *.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,39 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [1.5.2] - 2026-07-27
+
+### Fixed
+
+- **Composer tarball now ships pre-built editor bundles under
+  `dist/editor/` and `dist/lib/` (#678).** Previous releases treated
+  `dist/` as a purely local artefact — `.gitignore` excluded it, the
+  release workflow built it in an ephemeral runner and threw it
+  away, and hosts installing via Composer's GitHub-tarball resolution
+  ended up with no `vendor/artisanpack-ui/visual-editor/dist/editor/`
+  directory at all. Downstream consequence: Keystone CMS's
+  `VisualEditorAssetController` (which serves the bundles straight
+  from the vendor tree so hosts don't need Node in their asset
+  pipeline) 500'd on every request. The release workflow now runs a
+  `build-and-tag` job that rebuilds both bundles, verifies the
+  required outputs exist, force-adds `dist/editor/` and `dist/lib/`
+  onto the release commit, and re-points the version tag at that
+  commit so Composer resolves the built tarball. Sourcemaps are
+  stripped from the tarball (would ~triple its size) and attached to
+  the GitHub Release as a separate `dist-sourcemaps-vX.Y.Z.tar.gz`
+  archive.
+
+### Changed
+
+- **`docs/Installation-Guide.md` now documents both consumption
+  patterns.** Pattern A (host runs Vite, existing) and Pattern B
+  (host serves pre-built bundles from `vendor/`, new) are called
+  out explicitly so CMS integrators know which they can rely on.
+- **Tarball size increases by ~18 MB** (uncompressed) to carry the
+  pre-built editor and library bundles. Well within Packagist norms
+  but worth calling out for consumers with strict install-size
+  budgets.
+
 ## [1.5.1] - 2026-07-26
 
 ### Fixed

--- a/docs/Installation-Guide.md
+++ b/docs/Installation-Guide.md
@@ -58,6 +58,10 @@ The full configuration reference lives in [[Configuration]].
 
 ## 5. Build assets
 
+Two consumption patterns are supported. Pick the one that fits your host app's asset pipeline.
+
+### Pattern A — host runs Vite (default)
+
 The editor JS bundle is registered automatically by the package's Vite plugin. From the host app:
 
 ```bash
@@ -67,7 +71,30 @@ npm run dev      # development
 npm run build    # production
 ```
 
-The editor mounts on every page that contains a `[data-ap-visual-editor]` element.
+The editor mounts on every page that contains a `[data-ap-visual-editor]` element. Use this when the host already owns a Vite pipeline and you want editor sources to hot-reload during development.
+
+### Pattern B — serve pre-built bundles from `vendor/`
+
+Since v1.5.2 the Composer tarball ships pre-built editor bundles under `vendor/artisanpack-ui/visual-editor/dist/editor/`:
+
+```
+vendor/artisanpack-ui/visual-editor/dist/editor/
+├── visual-editor.js
+├── site-editor.js
+├── sandbox.js
+└── chunks/
+    ├── gutenberg-*.js
+    ├── editor-app-*.js
+    └── …
+```
+
+Host apps that don't want Node in their asset pipeline (Keystone CMS uses this pattern — see #678) can serve those files directly through a Laravel controller. Route `/visual-editor/{file}` and `/visual-editor/chunks/{file}` to a controller that streams from `base_path('vendor/artisanpack-ui/visual-editor/dist/editor/')`, then point the editor's Blade views at those URLs instead of the Vite-managed asset paths.
+
+`dist/lib/visual-editor.js` (the library entry from `package.json`'s `exports` map) also ships in the tarball, so NPM consumers that resolve the package via Composer's git-tarball install path see the same built artefacts as NPM installers.
+
+**Sourcemaps.** Sourcemaps are stripped from the Composer tarball to keep it lean (~18 MB vs. ~48 MB with maps). Each release attaches a `dist-sourcemaps-vX.Y.Z.tar.gz` archive to the GitHub Release page — download and extract it into `vendor/artisanpack-ui/visual-editor/dist/` if you need to debug production bundles.
+
+**Path-repository / dev-app installs.** When the package is installed via Composer's `path` repository (this dev app, or any sibling checkout), `dist/` reflects your local `npm run build` output — the release-workflow-baked bundles never enter your working tree. If a path-installed consumer needs the pre-built bundles, run `npm run build:lib && npm run build` inside the package checkout.
 
 ---
 

--- a/tests/Feature/Ci/ReleaseWorkflowTest.php
+++ b/tests/Feature/Ci/ReleaseWorkflowTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare( strict_types=1 );
+
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Regression tests for `.github/workflows/release.yml`.
+ *
+ * The release workflow is the ONE place where `dist/editor/` and
+ * `dist/lib/` are baked into the release tag so Composer consumers
+ * (Keystone CMS etc. — see #678) get pre-built bundles under
+ * `vendor/artisanpack-ui/visual-editor/dist/editor/`. Without these
+ * tests a future edit could silently drop the dist-baking step and
+ * ship another `1.5.1`-shaped release where the tarball has no
+ * `dist/editor/` at all.
+ *
+ * Each test asserts a single invariant of the workflow — the shape
+ * of the guard, not its exact wording — so cosmetic edits to
+ * comments or shell formatting don't break the suite, but removing
+ * the guard itself does.
+ */
+
+/**
+ * Load the release workflow YAML into a fresh array per test.
+ *
+ * @return array{
+ *     workflow: array<string, mixed>,
+ *     buildDist: array<string, mixed>,
+ *     release: array<string, mixed>
+ * }
+ */
+function loadReleaseWorkflow(): array
+{
+	$path = dirname( __DIR__, 3 ) . '/.github/workflows/release.yml';
+
+	if ( ! file_exists( $path ) ) {
+		throw new RuntimeException( 'release.yml missing at ' . $path );
+	}
+
+	$workflow = Yaml::parseFile( $path );
+
+	return [
+		'workflow' => $workflow,
+		'buildDist' => $workflow['jobs']['build-dist'] ?? [],
+		'release' => $workflow['jobs']['release'] ?? [],
+	];
+}
+
+/**
+ * Concatenate every `run:` script in a job into a single haystack
+ * for substring assertions. Steps that use an action (no `run` key)
+ * are skipped.
+ */
+function releaseWorkflowRunScripts( array $job ): string
+{
+	return collect( $job['steps'] ?? [] )
+		->pluck( 'run' )
+		->filter()
+		->implode( "\n" );
+}
+
+test( 'build-dist job exists and depends on both test jobs', function () {
+	$w = loadReleaseWorkflow();
+
+	expect( $w['buildDist'] )->not->toBeEmpty(
+		'build-dist job missing — dist/ will not be baked into the release tag'
+	);
+	expect( $w['buildDist']['needs'] )
+		->toContain( 'test-php' )
+		->toContain( 'test-js' );
+} );
+
+test( 'build-dist runs both build:lib and build so dist/lib and dist/editor are produced', function () {
+	$runs = releaseWorkflowRunScripts( loadReleaseWorkflow()['buildDist'] );
+
+	expect( $runs )->toContain( 'npm run build:lib' );
+	expect( $runs )->toContain( 'npm run build' );
+} );
+
+test( 'build-dist strips sourcemaps before committing', function () {
+	$runs = releaseWorkflowRunScripts( loadReleaseWorkflow()['buildDist'] );
+
+	// Sourcemaps must be found, packaged, and removed. Without this
+	// the composer tarball grows by ~30 MB per install (#678).
+	expect( $runs )
+		->toContain( '*.map' )
+		->toContain( 'tar' )
+		->toContain( 'rm' );
+} );
+
+test( 'build-dist verifies the required build outputs exist', function () {
+	$runs = releaseWorkflowRunScripts( loadReleaseWorkflow()['buildDist'] );
+
+	// The verify step guards against silent build breakage that
+	// would ship a release with missing bundles.
+	foreach ( [
+		'dist/editor/visual-editor.js',
+		'dist/editor/site-editor.js',
+		'dist/editor/sandbox.js',
+		'dist/editor/chunks',
+		'dist/lib/visual-editor.js',
+	] as $expected ) {
+		expect( $runs )->toContain( $expected );
+	}
+} );
+
+test( 'build-dist force-adds dist/editor and dist/lib onto the release commit', function () {
+	$runs = releaseWorkflowRunScripts( loadReleaseWorkflow()['buildDist'] );
+
+	// `dist/` stays .gitignored on every working branch (see the
+	// comment in .gitignore); the release workflow force-adds so
+	// the bundles land in the tarball anyway.
+	expect( $runs )
+		->toContain( 'git add --force' )
+		->toContain( 'dist/editor' )
+		->toContain( 'dist/lib' );
+} );
+
+test( 'build-dist re-points the version tag at the dist-baked commit', function () {
+	$runs = releaseWorkflowRunScripts( loadReleaseWorkflow()['buildDist'] );
+
+	// Composer resolves tags to SHAs — the tag must move to the
+	// new commit or consumers keep getting the pre-build SHA.
+	expect( $runs )
+		->toContain( 'git tag -f' )
+		->toContain( 'git push --force' );
+} );
+
+test( 'release job checks out the re-tagged commit before extracting notes', function () {
+	$release = loadReleaseWorkflow()['release'];
+
+	$checkout = collect( $release['steps'] ?? [] )
+		->first( fn ( array $step ) => str_starts_with( (string) ( $step['uses'] ?? '' ), 'actions/checkout' ) );
+
+	expect( $checkout )->not->toBeNull();
+	expect( $checkout['with']['ref'] ?? '' )
+		->toContain( 'refs/tags/v' )
+		->toContain( 'build-dist.outputs.version' );
+} );
+
+test( 'release job downloads the sourcemap artefact and attaches it to the GitHub Release', function () {
+	$release = loadReleaseWorkflow()['release'];
+	$steps = collect( $release['steps'] ?? [] );
+
+	$download = $steps->first(
+		fn ( array $step ) => str_starts_with( (string) ( $step['uses'] ?? '' ), 'actions/download-artifact' )
+	);
+	expect( $download )->not->toBeNull(
+		'release job must download the sourcemap archive from build-dist'
+	);
+
+	$ghRelease = $steps->first(
+		fn ( array $step ) => str_starts_with( (string) ( $step['uses'] ?? '' ), 'softprops/action-gh-release' )
+	);
+	expect( $ghRelease )->not->toBeNull();
+	expect( $ghRelease['with']['files'] ?? '' )->toContain( 'release-artifacts' );
+} );
+
+test( 'build-dist declares contents:write permission (required to push the re-tag)', function () {
+	$buildDist = loadReleaseWorkflow()['buildDist'];
+
+	expect( $buildDist['permissions']['contents'] ?? '' )->toBe( 'write' );
+} );


### PR DESCRIPTION
## Description

Composer consumers that install this package via the GitHub-tarball resolution path — Keystone CMS and every other host that serves editor bundles straight from `vendor/` instead of running Node in its own asset pipeline — were landing at 1.5.1 with no `vendor/artisanpack-ui/visual-editor/dist/editor/` directory. `release.yml` built `dist/` inside the `test-js` job, verified it, then discarded it; the `release` job checked out a fresh copy and uploaded nothing.

**Closes:** #678

## Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds new functionality)
- [ ] Enhancement (improves existing functionality)
- [ ] Refactoring (code improvement, no behavior change)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Security fix
- [ ] Breaking change (breaks backward compatibility)

## Related Issue

**Issue:** #678

## Motivation and Context

The Keystone CMS pair adopted a "serve pre-built bundles from `vendor/`" pattern specifically to avoid requiring Node in host asset pipelines. Its `VisualEditorAssetController` reads directly from `base_path('vendor/artisanpack-ui/visual-editor/dist/editor/')` and mounts `GET /visual-editor/site-editor.js` + `GET /visual-editor/chunks/{file}`. Against a clean 1.5.1 install those routes 500 because the tarball has no `dist/editor/` at all — `.gitignore:4` excludes `dist/`, so it never enters the git tree, and the release workflow's build artefacts live inside the ephemeral runner and vanish when the job ends. The Vite-based install pattern still works (that's documented in `docs/Installation-Guide.md#5-build-assets`), but nothing in the current release pipeline supports hosts that legitimately want pre-built bundles.

## Changes Made

- **`.github/workflows/release.yml`** — new `build-dist` job that runs after `test-php` + `test-js`:
  - Rebuilds `dist/editor/` (app) and `dist/lib/` (library) via `npm run build:lib` + `npm run build`.
  - Packages every `.map` file under `dist/` into `release-artifacts/dist-sourcemaps-vX.Y.Z.tar.gz` and deletes the maps from the tree (keeps the composer tarball ~18 MB vs. ~48 MB).
  - Verifies the required build outputs exist (`visual-editor.js`, `site-editor.js`, `sandbox.js`, `chunks/`, `lib/visual-editor.js`) and that no sourcemaps leaked back in.
  - Force-adds `dist/editor` + `dist/lib` onto a release commit and re-points the version tag at that commit via `git tag -f` + `git push --force origin refs/tags/vX.Y.Z`, so Composer resolves the built tarball.
- **`.github/workflows/release.yml`** — the `release` job now checks out the re-pointed tag (via `ref: refs/tags/v${{ needs.build-dist.outputs.version }}`), downloads the sourcemap artefact, and attaches it to the GitHub Release via `softprops/action-gh-release@v2`'s `files:` input.
- **`.gitignore`** — added a comment above the `dist/` line documenting that the workflow force-adds at release time. No functional change; `dist/` stays ignored on every working branch so local builds don't leak into diffs.
- **`docs/Installation-Guide.md`** — Section 5 now documents both consumption patterns explicitly: Pattern A (host runs Vite, existing) and Pattern B (host serves pre-built bundles from `vendor/`, new). Calls out sourcemap handling and the path-repository install caveat.
- **`CHANGELOG.md`** — v1.5.2 entry (`### Fixed` for the workflow change + `### Changed` for the tarball size delta and doc updates).
- **`tests/Feature/Ci/ReleaseWorkflowTest.php`** — new Pest regression suite (9 tests) that parses `release.yml` and locks the load-bearing invariants: build-dist job exists and depends on both test jobs, both build commands run, sourcemaps are stripped, required outputs are verified, `dist/editor` + `dist/lib` are force-added, the tag is re-pointed with force-push, the release job checks out the re-tagged commit, the sourcemap artefact is downloaded + attached, `contents: write` is declared.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS 14 (Darwin 27.0.0)
- Browser (if applicable): n/a — release-workflow change only
- PHP Version: 8.4.3
- Project Version: `release/1.5.2` @ 4ea3928 → `bugfix/678-…`

**Tests Performed:**
1. Ran `./vendor/bin/pest tests/Feature/Ci/ReleaseWorkflowTest.php --ci` locally → 9 tests / 25 assertions passing.
2. Parsed `release.yml` with `Symfony\Component\Yaml\Yaml::parseFile()` to confirm the file is valid YAML and produces the expected job / step / output structure (`test-php`, `test-js`, `build-dist`, `release`).
3. Manually traced the shell scripts in the `build-dist` job (find + tar + xargs pipeline, verify step, git tag / push flow) against `bash -eo pipefail` semantics — `find | grep .` inside an `if` correctly handles the "no sourcemaps" case; force-tag + force-push doesn't re-trigger the workflow because GITHUB_TOKEN pushes never do.

**Not tested locally** (requires cutting a live tag and is out of scope for a workflow change): the actual `1.5.2` release publishing. Verifying against Keystone's `VisualEditorAssetTest` happens downstream once `1.5.2` ships.

## Accessibility Tests Run

- [ ] Keyboard navigation tested
- [ ] Screen reader tested
- [ ] Color contrast verified
- [ ] ARIA labels checked

**Details:** n/a — release-workflow / docs change, no UI surface touched.

## Tests Added

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All tests passing

**Test details:** `tests/Feature/Ci/ReleaseWorkflowTest.php` — 9 Pest tests that parse the workflow YAML and assert every load-bearing step of the dist-baking pipeline is present. Locks the invariant so a future edit can't silently drop the build-dist job and ship another `1.5.1`-shaped release. Assertions are shape-based (job name, step content substrings) rather than exact-string, so cosmetic edits to comments or formatting don't break the suite.

## Documentation

- [ ] Inline code documentation added
- [x] README updated
- [x] Wiki updated
- [ ] API documentation updated

**Documentation details:** `docs/Installation-Guide.md` Section 5 rewritten to split Pattern A (Vite pipeline) from Pattern B (serve from vendor). `CHANGELOG.md` v1.5.2 entry.

## Screenshots

n/a

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted (YAML parses via `symfony/yaml`; PHP follows the ArtisanPack UI WordPress-style spacing)
- [ ] Accessibility tests completed (n/a)
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Release packages now include pre-built editor and library bundles for serving directly from vendor assets.
  - Release sourcemaps are provided as a separate downloadable archive.
  - Installation documentation now explains both host-built and pre-built asset workflows.

- **Bug Fixes**
  - Corrected release packaging so required vendor distribution assets are available after installation.

- **Documentation**
  - Added guidance for serving pre-built visual editor bundles and handling Composer development installs.
  - Updated the changelog for version 1.5.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->