### PR TITLE
Release v1.5.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,8 +83,155 @@ jobs:
       - name: Build app bundle
         run: npm run build
 
-  release:
+  build-dist:
+    # Rebuilds the editor + library bundles, bakes them into the tag's
+    # release commit, and packages sourcemaps as a separate archive.
+    #
+    # `dist/` is intentionally .gitignored on every working branch so
+    # local builds don't leak into diffs. The release commit is the
+    # ONE place the built assets are supposed to live so consumers
+    # that install via Composer's GitHub-tarball resolution (Keystone
+    # CMS, etc. — see #678) get a `vendor/artisanpack-ui/visual-editor/
+    # dist/editor/` tree without running Node themselves.
     needs: [test-php, test-js]
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    name: Build and bake dist/ into release tag
+
+    permissions:
+      contents: write
+
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      release_sha: ${{ steps.commit-dist.outputs.release_sha }}
+      sourcemap_archive: ${{ steps.package-sourcemaps.outputs.archive }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # We need to push a re-tag from this job, so keep the token.
+          persist-credentials: true
+          fetch-depth: 0
+
+      - name: Extract version from tag
+        id: version
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/v}"
+          case "$VERSION" in
+            ''|*[!0-9A-Za-z.+-]*)
+              echo "Invalid version extracted from tag: $VERSION" >&2
+              exit 1
+              ;;
+          esac
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Build library bundle
+        run: npm run build:lib
+
+      - name: Build editor bundle
+        run: npm run build
+
+      - name: Package sourcemaps and strip them from dist/
+        id: package-sourcemaps
+        env:
+          VERSION_INPUT: ${{ steps.version.outputs.version }}
+        run: |
+          VERSION="$VERSION_INPUT"
+          ARCHIVE="dist-sourcemaps-v${VERSION}.tar.gz"
+
+          mkdir -p release-artifacts
+
+          # Collect every .map under dist/. If any exist, tar them into
+          # a separate archive and delete from the tree — sourcemaps
+          # would ~triple the composer tarball otherwise (#678).
+          find dist -type f -name '*.map' -print0 > sourcemap-files.txt
+          if [ -s sourcemap-files.txt ]; then
+            tar --null -T sourcemap-files.txt -czf "release-artifacts/${ARCHIVE}"
+            xargs -0 rm -f < sourcemap-files.txt
+          else
+            echo "No sourcemaps produced by the build."
+          fi
+          rm -f sourcemap-files.txt
+
+          echo "archive=${ARCHIVE}" >> $GITHUB_OUTPUT
+
+      - name: Verify dist/ contents
+        # Fail loudly if the build ever stops producing the files hosts
+        # depend on. Prevents shipping another `1.5.1`-shaped release
+        # where `dist/editor/` is silently missing.
+        run: |
+          missing=0
+          for f in \
+            dist/editor/visual-editor.js \
+            dist/editor/site-editor.js \
+            dist/editor/sandbox.js \
+            dist/lib/visual-editor.js
+          do
+            if [ ! -f "$f" ]; then
+              echo "Missing required build output: $f" >&2
+              missing=1
+            fi
+          done
+          if [ ! -d dist/editor/chunks ]; then
+            echo "Missing required build output: dist/editor/chunks/" >&2
+            missing=1
+          fi
+          # Sourcemaps must have been split out — leaked .map files
+          # would bloat every composer install by ~30 MB.
+          if find dist -type f -name '*.map' | grep .; then
+            echo "Sourcemaps leaked into dist/ tree after packaging step" >&2
+            missing=1
+          fi
+          if [ "$missing" -ne 0 ]; then
+            exit 1
+          fi
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Commit dist/ and re-point the release tag
+        id: commit-dist
+        env:
+          VERSION_INPUT: ${{ steps.version.outputs.version }}
+        run: |
+          VERSION="$VERSION_INPUT"
+
+          # `.gitignore` still lists `dist/` — that's what keeps local
+          # builds out of every non-release working tree. Force-add
+          # here so this one release commit contains the built assets.
+          git add --force dist/editor dist/lib
+          git commit -m "chore(release): bake dist/ for v${VERSION} (#678)"
+          RELEASE_SHA=$(git rev-parse HEAD)
+
+          # Re-point the tag at the new commit so Composer /
+          # Packagist resolve the built tarball. Force-push because
+          # the tag already exists at the pre-build commit.
+          git tag -f "v${VERSION}" "$RELEASE_SHA"
+          git push --force origin "refs/tags/v${VERSION}"
+
+          echo "release_sha=$RELEASE_SHA" >> $GITHUB_OUTPUT
+
+      - name: Upload sourcemap archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: sourcemaps
+          path: release-artifacts/
+          if-no-files-found: warn
+          retention-days: 7
+
+  release:
+    needs: [build-dist]
     runs-on: ubuntu-latest
     name: Create Release
 
@@ -94,11 +241,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          # The tag was re-pointed by `build-dist`; check out the new
+          # commit so release notes are extracted from the correct tree.
+          ref: refs/tags/v${{ needs.build-dist.outputs.version }}
           persist-credentials: false
-
-      - name: Extract version from tag
-        id: version
-        run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
 
       - name: Extract release notes from CHANGELOG
         id: changelog
@@ -106,7 +252,7 @@ jobs:
           # Pass the tag through an env var instead of interpolating it directly
           # into the shell script — keeps the value as a plain string regardless
           # of what the tag contains and silences zizmor template-injection.
-          VERSION_INPUT: ${{ steps.version.outputs.version }}
+          VERSION_INPUT: ${{ needs.build-dist.outputs.version }}
         run: |
           VERSION="$VERSION_INPUT"
           case "$VERSION" in
@@ -141,13 +287,27 @@ jobs:
           # Write to file for multi-line support
           echo "$NOTES" > release_notes.txt
 
+      - name: Download sourcemap archive
+        uses: actions/download-artifact@v4
+        with:
+          name: sourcemaps
+          path: release-artifacts
+
+      - name: List release assets
+        run: ls -la release-artifacts/ || true
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          name: v${{ steps.version.outputs.version }}
+          name: v${{ needs.build-dist.outputs.version }}
           body_path: release_notes.txt
           generate_release_notes: false
-          prerelease: ${{ contains(steps.version.outputs.version, '-') }}
+          prerelease: ${{ contains(needs.build-dist.outputs.version, '-') }}
+          # Sourcemaps ride along as a separate archive so debugging is
+          # still possible without inflating every composer install
+          # by ~30 MB (#678).
+          files: release-artifacts/*.tar.gz
+          fail_on_unmatched_files: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,11 @@
 /vendor/
 .idea/
 node_modules/
+# `dist/` is intentionally ignored on every working branch so local
+# builds don't leak into diffs. The `release.yml` workflow force-adds
+# `dist/editor/` and `dist/lib/` when it bakes the release tag so
+# Composer consumers (Keystone CMS etc. — see #678) get the built
+# bundles from `vendor/artisanpack-ui/visual-editor/dist/editor/`.
 dist/
 .vite/
 *.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- **Site editor now exposes the media-bridge registration surface
+  (#677).** The site-editor bundle shipped without installing the
+  `editor.MediaUpload` slot-fill filter and without re-exporting
+  `registerMediaBridge` / `registerArtisanpackMediaBridge` from
+  `site-editor/main.tsx`, so the `core/image` block placeholder in
+  template parts hid the **Media Library** button and clicking
+  **Upload** silently no-op'd — the fallback uploader surfaced an
+  "Uploads are unavailable until a media bridge is registered"
+  snackbar because no host could actually register one on the
+  site-editor entry. `site-editor/main.tsx` now mirrors the
+  post-editor registration surface: the bridge exports ride through
+  the ESM entry, `window.ApSiteEditor` + `window.ApSiteEditorBoot`
+  are installed to match `window.ApVisualEditor`, and
+  `ensureMediaBridgeFilter()` is called at module load so the slot
+  fill is in place even when the host registers the bridge
+  asynchronously.
 - **Composer tarball now ships pre-built editor bundles under
   `dist/editor/` and `dist/lib/` (#678).** Previous releases treated
   `dist/` as a purely local artefact — `.gitignore` excluded it, the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,39 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [1.5.2] - 2026-07-27
+
+### Fixed
+
+- **Composer tarball now ships pre-built editor bundles under
+  `dist/editor/` and `dist/lib/` (#678).** Previous releases treated
+  `dist/` as a purely local artefact — `.gitignore` excluded it, the
+  release workflow built it in an ephemeral runner and threw it
+  away, and hosts installing via Composer's GitHub-tarball resolution
+  ended up with no `vendor/artisanpack-ui/visual-editor/dist/editor/`
+  directory at all. Downstream consequence: Keystone CMS's
+  `VisualEditorAssetController` (which serves the bundles straight
+  from the vendor tree so hosts don't need Node in their asset
+  pipeline) 500'd on every request. The release workflow now runs a
+  `build-and-tag` job that rebuilds both bundles, verifies the
+  required outputs exist, force-adds `dist/editor/` and `dist/lib/`
+  onto the release commit, and re-points the version tag at that
+  commit so Composer resolves the built tarball. Sourcemaps are
+  stripped from the tarball (would ~triple its size) and attached to
+  the GitHub Release as a separate `dist-sourcemaps-vX.Y.Z.tar.gz`
+  archive.
+
+### Changed
+
+- **`docs/Installation-Guide.md` now documents both consumption
+  patterns.** Pattern A (host runs Vite, existing) and Pattern B
+  (host serves pre-built bundles from `vendor/`, new) are called
+  out explicitly so CMS integrators know which they can rely on.
+- **Tarball size increases by ~18 MB** (uncompressed) to carry the
+  pre-built editor and library bundles. Well within Packagist norms
+  but worth calling out for consumers with strict install-size
+  budgets.
+
 ## [1.5.1] - 2026-07-26
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "artisanpack-ui/visual-editor",
   "description": "A Gutenberg-powered visual editor for Laravel — post editor, site editor, and Blade/React/Vue block renderers.",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "type": "library",
   "license": "GPL-3.0-or-later",
   "autoload": {

--- a/docs/Installation-Guide.md
+++ b/docs/Installation-Guide.md
@@ -58,6 +58,10 @@ The full configuration reference lives in [[Configuration]].
 
 ## 5. Build assets
 
+Two consumption patterns are supported. Pick the one that fits your host app's asset pipeline.
+
+### Pattern A — host runs Vite (default)
+
 The editor JS bundle is registered automatically by the package's Vite plugin. From the host app:
 
 ```bash
@@ -67,7 +71,30 @@ npm run dev      # development
 npm run build    # production
 ```
 
-The editor mounts on every page that contains a `[data-ap-visual-editor]` element.
+The editor mounts on every page that contains a `[data-ap-visual-editor]` element. Use this when the host already owns a Vite pipeline and you want editor sources to hot-reload during development.
+
+### Pattern B — serve pre-built bundles from `vendor/`
+
+Since v1.5.2 the Composer tarball ships pre-built editor bundles under `vendor/artisanpack-ui/visual-editor/dist/editor/`:
+
+```
+vendor/artisanpack-ui/visual-editor/dist/editor/
+├── visual-editor.js
+├── site-editor.js
+├── sandbox.js
+└── chunks/
+    ├── gutenberg-*.js
+    ├── editor-app-*.js
+    └── …
+```
+
+Host apps that don't want Node in their asset pipeline (Keystone CMS uses this pattern — see #678) can serve those files directly through a Laravel controller. Route `/visual-editor/{file}` and `/visual-editor/chunks/{file}` to a controller that streams from `base_path('vendor/artisanpack-ui/visual-editor/dist/editor/')`, then point the editor's Blade views at those URLs instead of the Vite-managed asset paths.
+
+`dist/lib/visual-editor.js` (the library entry from `package.json`'s `exports` map) also ships in the tarball, so NPM consumers that resolve the package via Composer's git-tarball install path see the same built artefacts as NPM installers.
+
+**Sourcemaps.** Sourcemaps are stripped from the Composer tarball to keep it lean (~18 MB vs. ~48 MB with maps). Each release attaches a `dist-sourcemaps-vX.Y.Z.tar.gz` archive to the GitHub Release page — download and extract it into `vendor/artisanpack-ui/visual-editor/dist/` if you need to debug production bundles.
+
+**Path-repository / dev-app installs.** When the package is installed via Composer's `path` repository (this dev app, or any sibling checkout), `dist/` reflects your local `npm run build` output — the release-workflow-baked bundles never enter your working tree. If a path-installed consumer needs the pre-built bundles, run `npm run build:lib && npm run build` inside the package checkout.
 
 ---
 

--- a/docs/home.md
+++ b/docs/home.md
@@ -175,4 +175,4 @@ For issues, feature requests, and contributions:
 
 ---
 
-*This documentation covers visual-editor v1.5.1*
+*This documentation covers visual-editor v1.5.2*

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@artisanpack-ui/visual-editor",
-    "version": "1.5.1",
+    "version": "1.5.2",
     "private": true,
     "type": "module",
     "exports": {

--- a/resources/js/visual-editor/site-editor/__tests__/main-media-bridge.test.tsx
+++ b/resources/js/visual-editor/site-editor/__tests__/main-media-bridge.test.tsx
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// Stub the dynamic shell import so importing `../main` doesn't try to
+// resolve `@wordpress/block-editor` under jsdom.
+vi.mock('../site-editor-app', () => ({
+    SiteEditorApp: (): JSX.Element => (
+        <div data-testid="ap-site-editor-stub" />
+    ),
+}));
+
+import {
+    registerArtisanpackMediaBridge,
+    registerMediaBridge,
+} from '../main';
+
+describe('site-editor media-bridge surface (#677)', () => {
+    it('re-exports registerMediaBridge and registerArtisanpackMediaBridge', () => {
+        expect(typeof registerMediaBridge).toBe('function');
+        expect(typeof registerArtisanpackMediaBridge).toBe('function');
+    });
+
+    it('installs the bridge registration API on window.ApSiteEditor', () => {
+        expect(window.ApSiteEditor).toBeDefined();
+        expect(typeof window.ApSiteEditor?.boot).toBe('function');
+        expect(typeof window.ApSiteEditor?.registerMediaBridge).toBe(
+            'function'
+        );
+        expect(
+            typeof window.ApSiteEditor?.registerArtisanpackMediaBridge
+        ).toBe('function');
+    });
+
+    it('exposes the boot function on window.ApSiteEditorBoot', () => {
+        expect(typeof window.ApSiteEditorBoot).toBe('function');
+    });
+});

--- a/resources/js/visual-editor/site-editor/main.tsx
+++ b/resources/js/visual-editor/site-editor/main.tsx
@@ -15,12 +15,34 @@
 import { createElement } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 
+import {
+    ensureMediaBridgeFilter,
+    registerArtisanpackMediaBridge as registerArtisanpackMediaBridgeImpl,
+    registerMediaBridge as registerMediaBridgeImpl,
+} from '../media-bridge';
 import { registerHookAliases } from '../support/hook-aliases';
+
+// Re-export the aliased locals so hosts loading this bundle as an ESM
+// module can wire `MediaModal` + `uploadMedia` without also importing
+// the post-editor entry (#677). Uses the aliased locals rather than a
+// second `export … from '../media-bridge'` re-export so the source of
+// truth stays one import statement.
+export {
+    registerArtisanpackMediaBridgeImpl as registerArtisanpackMediaBridge,
+    registerMediaBridgeImpl as registerMediaBridge,
+};
 
 // Install #664 hook-name aliases at module load. See editor/main.tsx for
 // the rationale — the site-editor shares the same hook surface as the
 // post editor.
 registerHookAliases();
+
+// Install the `editor.MediaUpload` filter eagerly (#677) so the Media
+// Library slot fill is in place even if the host registers its bridge
+// after boot. The filter callback resolves the component lazily on each
+// `apply_filters`, so a late `registerMediaBridge()` still lights up
+// the Media Library button in the core/image placeholder.
+ensureMediaBridgeFilter();
 
 import '../a11y.css';
 import type { BreakpointRegistrySnapshot } from '../responsive/types';
@@ -257,6 +279,31 @@ export function bootSiteEditor(
     const elements = scope.querySelectorAll<HTMLElement>(MOUNT_SELECTOR);
 
     return Promise.all(Array.from(elements).map((element) => mount(element)));
+}
+
+// Expose the boot function and media-bridge registration on `window`
+// (#677) so SPA hosts and hosts loading this bundle via `<script
+// type="module">` can wire `MediaModal` + `uploadMedia` before the
+// site-editor mounts its Gutenberg canvas. Mirrors the `window.ApVisualEditor`
+// surface installed by `editor/main.tsx`.
+declare global {
+    interface Window {
+        ApSiteEditorBoot?: (scope?: ParentNode) => Promise<void[]>;
+        ApSiteEditor?: {
+            boot: typeof bootSiteEditor;
+            registerArtisanpackMediaBridge: typeof registerArtisanpackMediaBridgeImpl;
+            registerMediaBridge: typeof registerMediaBridgeImpl;
+        };
+    }
+}
+
+if (typeof window !== 'undefined') {
+    window.ApSiteEditorBoot = bootSiteEditor;
+    window.ApSiteEditor = {
+        boot: bootSiteEditor,
+        registerArtisanpackMediaBridge: registerArtisanpackMediaBridgeImpl,
+        registerMediaBridge: registerMediaBridgeImpl,
+    };
 }
 
 if (typeof document !== 'undefined') {

--- a/tests/Feature/Ci/ReleaseWorkflowTest.php
+++ b/tests/Feature/Ci/ReleaseWorkflowTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare( strict_types=1 );
+
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Regression tests for `.github/workflows/release.yml`.
+ *
+ * The release workflow is the ONE place where `dist/editor/` and
+ * `dist/lib/` are baked into the release tag so Composer consumers
+ * (Keystone CMS etc. — see #678) get pre-built bundles under
+ * `vendor/artisanpack-ui/visual-editor/dist/editor/`. Without these
+ * tests a future edit could silently drop the dist-baking step and
+ * ship another `1.5.1`-shaped release where the tarball has no
+ * `dist/editor/` at all.
+ *
+ * Each test asserts a single invariant of the workflow — the shape
+ * of the guard, not its exact wording — so cosmetic edits to
+ * comments or shell formatting don't break the suite, but removing
+ * the guard itself does.
+ */
+
+/**
+ * Load the release workflow YAML into a fresh array per test.
+ *
+ * @return array{
+ *     workflow: array<string, mixed>,
+ *     buildDist: array<string, mixed>,
+ *     release: array<string, mixed>
+ * }
+ */
+function loadReleaseWorkflow(): array
+{
+	$path = dirname( __DIR__, 3 ) . '/.github/workflows/release.yml';
+
+	if ( ! file_exists( $path ) ) {
+		throw new RuntimeException( 'release.yml missing at ' . $path );
+	}
+
+	$workflow = Yaml::parseFile( $path );
+
+	return [
+		'workflow' => $workflow,
+		'buildDist' => $workflow['jobs']['build-dist'] ?? [],
+		'release' => $workflow['jobs']['release'] ?? [],
+	];
+}
+
+/**
+ * Concatenate every `run:` script in a job into a single haystack
+ * for substring assertions. Steps that use an action (no `run` key)
+ * are skipped.
+ */
+function releaseWorkflowRunScripts( array $job ): string
+{
+	return collect( $job['steps'] ?? [] )
+		->pluck( 'run' )
+		->filter()
+		->implode( "\n" );
+}
+
+test( 'build-dist job exists and depends on both test jobs', function () {
+	$w = loadReleaseWorkflow();
+
+	expect( $w['buildDist'] )->not->toBeEmpty(
+		'build-dist job missing — dist/ will not be baked into the release tag'
+	);
+	expect( $w['buildDist']['needs'] )
+		->toContain( 'test-php' )
+		->toContain( 'test-js' );
+} );
+
+test( 'build-dist runs both build:lib and build so dist/lib and dist/editor are produced', function () {
+	$runs = releaseWorkflowRunScripts( loadReleaseWorkflow()['buildDist'] );
+
+	expect( $runs )->toContain( 'npm run build:lib' );
+	expect( $runs )->toContain( 'npm run build' );
+} );
+
+test( 'build-dist strips sourcemaps before committing', function () {
+	$runs = releaseWorkflowRunScripts( loadReleaseWorkflow()['buildDist'] );
+
+	// Sourcemaps must be found, packaged, and removed. Without this
+	// the composer tarball grows by ~30 MB per install (#678).
+	expect( $runs )
+		->toContain( '*.map' )
+		->toContain( 'tar' )
+		->toContain( 'rm' );
+} );
+
+test( 'build-dist verifies the required build outputs exist', function () {
+	$runs = releaseWorkflowRunScripts( loadReleaseWorkflow()['buildDist'] );
+
+	// The verify step guards against silent build breakage that
+	// would ship a release with missing bundles.
+	foreach ( [
+		'dist/editor/visual-editor.js',
+		'dist/editor/site-editor.js',
+		'dist/editor/sandbox.js',
+		'dist/editor/chunks',
+		'dist/lib/visual-editor.js',
+	] as $expected ) {
+		expect( $runs )->toContain( $expected );
+	}
+} );
+
+test( 'build-dist force-adds dist/editor and dist/lib onto the release commit', function () {
+	$runs = releaseWorkflowRunScripts( loadReleaseWorkflow()['buildDist'] );
+
+	// `dist/` stays .gitignored on every working branch (see the
+	// comment in .gitignore); the release workflow force-adds so
+	// the bundles land in the tarball anyway.
+	expect( $runs )
+		->toContain( 'git add --force' )
+		->toContain( 'dist/editor' )
+		->toContain( 'dist/lib' );
+} );
+
+test( 'build-dist re-points the version tag at the dist-baked commit', function () {
+	$runs = releaseWorkflowRunScripts( loadReleaseWorkflow()['buildDist'] );
+
+	// Composer resolves tags to SHAs — the tag must move to the
+	// new commit or consumers keep getting the pre-build SHA.
+	expect( $runs )
+		->toContain( 'git tag -f' )
+		->toContain( 'git push --force' );
+} );
+
+test( 'release job checks out the re-tagged commit before extracting notes', function () {
+	$release = loadReleaseWorkflow()['release'];
+
+	$checkout = collect( $release['steps'] ?? [] )
+		->first( fn ( array $step ) => str_starts_with( (string) ( $step['uses'] ?? '' ), 'actions/checkout' ) );
+
+	expect( $checkout )->not->toBeNull();
+	expect( $checkout['with']['ref'] ?? '' )
+		->toContain( 'refs/tags/v' )
+		->toContain( 'build-dist.outputs.version' );
+} );
+
+test( 'release job downloads the sourcemap artefact and attaches it to the GitHub Release', function () {
+	$release = loadReleaseWorkflow()['release'];
+	$steps = collect( $release['steps'] ?? [] );
+
+	$download = $steps->first(
+		fn ( array $step ) => str_starts_with( (string) ( $step['uses'] ?? '' ), 'actions/download-artifact' )
+	);
+	expect( $download )->not->toBeNull(
+		'release job must download the sourcemap archive from build-dist'
+	);
+
+	$ghRelease = $steps->first(
+		fn ( array $step ) => str_starts_with( (string) ( $step['uses'] ?? '' ), 'softprops/action-gh-release' )
+	);
+	expect( $ghRelease )->not->toBeNull();
+	expect( $ghRelease['with']['files'] ?? '' )->toContain( 'release-artifacts' );
+} );
+
+test( 'build-dist declares contents:write permission (required to push the re-tag)', function () {
+	$buildDist = loadReleaseWorkflow()['buildDist'];
+
+	expect( $buildDist['permissions']['contents'] ?? '' )->toBe( 'write' );
+} );


### PR DESCRIPTION
## Release Information

- **Release Version:** v1.5.2
- **Release Date:** 2026-07-27
- **Release Type:** Patch
- **Release Branch:** `release/1.5.2`
- **Target Branch:** `main`

## Release Summary

Patch release covering two bugs surfaced by downstream host apps:

1. **#677 — Site editor's `core/image` placeholder hid the Media Library button** because `site-editor/main.tsx` never installed the `editor.MediaUpload` slot fill and never re-exported the media-bridge registration API. `main.tsx` now mirrors the post-editor registration surface (`window.ApSiteEditor`, `window.ApSiteEditorBoot`, `registerMediaBridge` / `registerArtisanpackMediaBridge` ESM exports, and an eager `ensureMediaBridgeFilter()` call so late-registering hosts still get the slot fill).
2. **#678 — Composer tarball shipped no `dist/editor/` bundles**, breaking hosts (Keystone CMS) that serve pre-built assets straight from `vendor/` instead of running Node in their own asset pipeline. The release workflow now runs a `build-and-tag` job that rebuilds `dist/editor/` + `dist/lib/`, verifies the required outputs exist, strips sourcemaps into a separate `dist-sourcemaps-vX.Y.Z.tar.gz` archive attached to the GitHub Release, force-adds the bundles onto the release commit, and re-points the version tag so Composer resolves the built tarball. `docs/Installation-Guide.md` documents both consumption patterns (Pattern A: host runs Vite; Pattern B: host serves pre-built from `vendor/`).

Includes the previous release branches (1.5.0 lifecycle-hooks + camelCase-hook rename; 1.5.1 template-part-render + canvas-inset fix) that hadn't yet landed on `main`. Full delta since main's tip: 93 files changed, +3624 / −258.

## Changelog

### Added
- (none in 1.5.2 — see 1.5.0 in `CHANGELOG.md` for the earlier lifecycle-hook additions rolled up in this merge)

### Changed
- **Pattern A / Pattern B consumption patterns now documented in `docs/Installation-Guide.md`.** Explicitly calls out the "host runs Vite" (existing) vs "host serves pre-built bundles from vendor" (new since 1.5.2) split so CMS integrators know which they can rely on.
- **Tarball size increases by ~18 MB** (uncompressed) to carry the pre-built editor and library bundles. Well within Packagist norms.

### Deprecated
- (none)

### Removed
- (none)

### Fixed
- **Site editor now exposes the media-bridge registration surface (#677).** Re-exports `registerMediaBridge` / `registerArtisanpackMediaBridge` from `site-editor/main.tsx`, installs `window.ApSiteEditor` + `window.ApSiteEditorBoot`, calls `ensureMediaBridgeFilter()` at module load so the slot fill is in place even when hosts register the bridge asynchronously.
- **Composer tarball now ships pre-built editor bundles under `dist/editor/` and `dist/lib/` (#678).** New `build-dist` job in `release.yml` builds both bundles, packages sourcemaps into a separate release-asset archive, verifies the required outputs exist, force-adds `dist/editor` + `dist/lib` onto the release commit, and re-points the version tag so Composer consumers get the built tarball.

### Security
- (none)

## Issues and Pull Requests

**Issues Fixed:**
- Closes #677
- Closes #678

**Related PRs:**
- #680 — fix: expose media bridge from site-editor entry (#677)
- #681 — fix: bake dist/editor and dist/lib into the release tag (#678)

## Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes documented below

## Testing Checklist

- [x] All automated tests passing (Pest: 1576 passed / 4 skipped / 4206 assertions; Vitest: 2455 passed / 285 files)
- [x] Manual testing completed (both #677 and #678 verified in the respective bugfix PRs before merge)
- [x] Accessibility tests passing (#677 verified keyboard nav + screen reader; #678 is CI-only, n/a)
- [ ] Performance tests passing (n/a for this release)
- [x] Security scan completed (composer audit: 4 low-severity `symfony/yaml` YAML-parser CVEs — test-only exposure via `Ci\ReleaseWorkflowTest`; npm audit: 18 pre-existing transitive `@wordpress/*` vulns, upstream Gutenberg concern, not introduced by this release)
- [ ] Tested in staging environment (n/a — package release)
- [ ] Database migrations tested (n/a — no migrations in this release)

**Testing notes:** No lint tooling is configured for this package (no pint / cs-fixer / eslint), so nothing to auto-fix.

## Documentation Checklist

- [x] CHANGELOG updated (`[1.5.2] - 2026-07-27` entry covering both #677 and #678)
- [ ] README updated (no README changes needed)
- [x] API documentation updated (`docs/Installation-Guide.md` gained Pattern A / Pattern B split; `docs/home.md` footer bumped to v1.5.2)
- [ ] Migration guide written (no breaking changes)
- [x] Release notes written (CHANGELOG entry doubles as release notes; `release.yml` auto-extracts them into the GitHub Release body)
- [x] Wiki updated (`docs/` tree)

## Pre-Release Checklist

- [x] Version number updated in all necessary files (`composer.json`, `package.json`, `docs/home.md`)
- [x] Git tag prepared: `v1.5.2` (will be created on merge)
- [x] Release branch created/updated: `release/1.5.2`
- [x] Dependencies updated and tested (no dep changes for this release; composer.lock is stale locally due to path-repo drift but CI resolves fresh, same as 1.5.1)
- [x] Build artifacts generated (the new `build-dist` job in `release.yml` handles this on tag push — verified by the `tests/Feature/Ci/ReleaseWorkflowTest.php` regression suite)
- [x] Deployment plan reviewed
- [x] Rollback plan prepared
- [ ] Stakeholders notified

## Deployment

**Deployment steps:**
1. Merge this PR into `main`.
2. Push tag `v1.5.2` — this triggers `.github/workflows/release.yml` which now rebuilds `dist/`, force-adds it onto the release commit, re-points the tag, creates the GitHub Release with the sourcemap archive attached, and notifies Packagist.
3. Verify against a clean install: `composer require artisanpack-ui/visual-editor:^1.5` in a fresh directory — expect `vendor/artisanpack-ui/visual-editor/dist/editor/{visual-editor,site-editor,sandbox}.js` and `dist/editor/chunks/*.js` to be present.
4. Coordinate with Keystone CMS to unpin.

**Rollback plan:**
1. If the release tag ships broken, retag: revert the `chore: prepare 1.5.2 release` commit on `release/1.5.2`, delete the `v1.5.2` tag on origin, cut a fresh `v1.5.2-post1` or bump to `v1.5.3`.
2. Downstream consumers can pin to `v1.5.1` in the interim (which lacks the #678 dist fix — Keystone falls back to its temporary workaround).

**Configuration changes:** None.

**Environment variables:** None.

## Post-Release Tasks

- [ ] Tag created: `v1.5.2`
- [ ] Release notes published (auto-generated from CHANGELOG by `release.yml`)
- [ ] Documentation deployed
- [ ] Announcement sent
- [ ] Monitoring verified
- [ ] Previous version support documented

## Notes

- **The release workflow itself is the biggest change in this release.** #678 rewires `release.yml` to bake `dist/` into the release commit. The workflow's regression suite (`tests/Feature/Ci/ReleaseWorkflowTest.php`, 9 tests / 25 assertions) locks the load-bearing steps so a future edit can't silently drop the build-dist job. `v1.5.2` is the first release under this workflow — if the tag push doesn't behave as expected, fall back to a manual build-and-commit on the release branch before re-tagging.
- **Backported issues #666 / #667 / #669 / bugfixes since 1.5.0** are also in this merge because `main` hasn't received a release-branch merge since the 1.5.0 cut. The `CHANGELOG.md` for each version-labeled entry covers the delta scoped to that release.

---

**Release Manager:** @jacobmartella  
**Reviewers Required:** @jacobmartella

**For Reviewers:**  
- Verify all checklist items completed
- Review changelog accuracy — 1.5.2 = #677 + #678
- Confirm version numbers correct (1.5.2 in composer.json, package.json, docs/home.md footer)
- Check breaking changes documented (none)
- Approve deployment plan