### PR TITLE
fix: switch release workflow to workflow_dispatch (#683)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,29 @@
 name: Release
 
+# Manual dispatch — do NOT use `on: push: tags` here.
+#
+# Previously the workflow triggered on `push: tags: 'v*'` and used a
+# `build-dist` job to force-update the tag mid-run so the composer
+# tarball would ship `dist/editor/` + `dist/lib/` (#678). Packagist's
+# crawler observes new stable tags within seconds and freezes their
+# SHA permanently under its version-immutability policy — the workflow
+# lost that race on v1.5.2, so Packagist ended up pinned at the
+# source-only commit while GitHub's tag advanced to the dist-baked
+# one. See #683 for the postmortem.
+#
+# The workflow now runs on `workflow_dispatch`: the maintainer merges
+# the release PR into main, then invokes
+# `gh workflow run release.yml -f version=X.Y.Z`. The workflow builds
+# `dist/`, commits it onto a fresh commit, creates the tag on that
+# commit, and pushes the tag ONCE — Packagist observes it exactly
+# once, at the correct SHA.
 on:
-  push:
-    tags:
-      - 'v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release (e.g. 1.5.3 — no leading v)'
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -17,6 +37,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: main
           persist-credentials: false
 
       - name: Setup PHP
@@ -63,6 +84,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: main
           persist-credentials: false
 
       - name: Setup Node.js
@@ -83,47 +105,90 @@ jobs:
       - name: Build app bundle
         run: npm run build
 
-  build-dist:
-    # Rebuilds the editor + library bundles, bakes them into the tag's
-    # release commit, and packages sourcemaps as a separate archive.
+  build-and-tag:
+    # Rebuilds the editor + library bundles, bakes them into a fresh
+    # release commit, creates the version tag, and pushes ONCE.
     #
-    # `dist/` is intentionally .gitignored on every working branch so
-    # local builds don't leak into diffs. The release commit is the
-    # ONE place the built assets are supposed to live so consumers
-    # that install via Composer's GitHub-tarball resolution (Keystone
-    # CMS, etc. — see #678) get a `vendor/artisanpack-ui/visual-editor/
-    # dist/editor/` tree without running Node themselves.
+    # Why a single push? Packagist observes tags within seconds and
+    # freezes stable-version SHAs permanently. #678's earlier design
+    # pushed the tag first and force-updated it after building, losing
+    # the race on v1.5.2. The redesign here (#683) never lets Packagist
+    # see an intermediate SHA: the workflow builds first, then creates
+    # and pushes the tag at the built commit.
     needs: [test-php, test-js]
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    name: Build and bake dist/ into release tag
+    name: Build dist/ and create version tag
 
     permissions:
       contents: write
 
     outputs:
-      version: ${{ steps.version.outputs.version }}
+      version: ${{ inputs.version }}
       release_sha: ${{ steps.commit-dist.outputs.release_sha }}
       sourcemap_archive: ${{ steps.package-sourcemaps.outputs.archive }}
 
     steps:
-      - uses: actions/checkout@v4
-        with:
-          # We need to push a re-tag from this job, so keep the token.
-          persist-credentials: true
-          fetch-depth: 0
-
-      - name: Extract version from tag
-        id: version
+      - name: Validate version input
+        env:
+          VERSION_INPUT: ${{ inputs.version }}
         run: |
-          VERSION="${GITHUB_REF#refs/tags/v}"
+          VERSION="$VERSION_INPUT"
           case "$VERSION" in
-            ''|*[!0-9A-Za-z.+-]*)
-              echo "Invalid version extracted from tag: $VERSION" >&2
+            ''|v*|*[!0-9A-Za-z.+-]*)
+              echo "Invalid version input: '$VERSION' (must be bare semver like 1.5.3, no leading v)" >&2
               exit 1
               ;;
           esac
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - uses: actions/checkout@v4
+        with:
+          # Tag off main — the release PR is expected to have merged
+          # before dispatch. `persist-credentials: true` so the tag
+          # push later in this job can authenticate.
+          ref: main
+          persist-credentials: true
+          fetch-depth: 0
+
+      - name: Refuse to overwrite an existing tag
+        # Belt-and-braces guard against re-dispatching for a version
+        # that already shipped. If somebody tries `gh workflow run
+        # release.yml -f version=1.5.2` a second time, this catches
+        # it before we build and would otherwise hit Packagist's
+        # immutability wall again.
+        env:
+          VERSION_INPUT: ${{ inputs.version }}
+        run: |
+          VERSION="$VERSION_INPUT"
+          if git ls-remote --tags --exit-code origin "refs/tags/v${VERSION}" >/dev/null 2>&1; then
+            echo "Tag v${VERSION} already exists on origin — refusing to reship." >&2
+            echo "If you need to reship, cut a new version." >&2
+            exit 1
+          fi
+
+      - name: Verify version input matches composer.json / package.json
+        # Prevents a `-f version=1.5.3` dispatch against a main that
+        # still says 1.5.2 in its manifests — that would produce a tag
+        # inconsistent with the source's stated version.
+        env:
+          VERSION_INPUT: ${{ inputs.version }}
+        run: |
+          VERSION="$VERSION_INPUT"
+          COMPOSER_VERSION=$(jq -r '.version // ""' composer.json)
+          PACKAGE_VERSION=$(jq -r '.version // ""' package.json)
+          fail=0
+          if [ "$COMPOSER_VERSION" != "$VERSION" ]; then
+            echo "composer.json version ($COMPOSER_VERSION) != input ($VERSION)" >&2
+            fail=1
+          fi
+          if [ "$PACKAGE_VERSION" != "$VERSION" ]; then
+            echo "package.json version ($PACKAGE_VERSION) != input ($VERSION)" >&2
+            fail=1
+          fi
+          if [ "$fail" -ne 0 ]; then
+            echo "Bump the manifests on main first (via the release PR) before dispatching." >&2
+            exit 1
+          fi
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -143,7 +208,7 @@ jobs:
       - name: Package sourcemaps and strip them from dist/
         id: package-sourcemaps
         env:
-          VERSION_INPUT: ${{ steps.version.outputs.version }}
+          VERSION_INPUT: ${{ inputs.version }}
         run: |
           VERSION="$VERSION_INPUT"
           ARCHIVE="dist-sourcemaps-v${VERSION}.tar.gz"
@@ -200,10 +265,10 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-      - name: Commit dist/ and re-point the release tag
+      - name: Commit dist/ and create the version tag
         id: commit-dist
         env:
-          VERSION_INPUT: ${{ steps.version.outputs.version }}
+          VERSION_INPUT: ${{ inputs.version }}
         run: |
           VERSION="$VERSION_INPUT"
 
@@ -211,14 +276,14 @@ jobs:
           # builds out of every non-release working tree. Force-add
           # here so this one release commit contains the built assets.
           git add --force dist/editor dist/lib
-          git commit -m "chore(release): bake dist/ for v${VERSION} (#678)"
+          git commit -m "chore(release): bake dist/ for v${VERSION} (#683)"
           RELEASE_SHA=$(git rev-parse HEAD)
 
-          # Re-point the tag at the new commit so Composer /
-          # Packagist resolve the built tarball. Force-push because
-          # the tag already exists at the pre-build commit.
-          git tag -f "v${VERSION}" "$RELEASE_SHA"
-          git push --force origin "refs/tags/v${VERSION}"
+          # Create the tag AT the built commit — this is the first
+          # (and only) time this tag will ever be pushed. No force,
+          # no race with Packagist.
+          git tag -a "v${VERSION}" -m "Release v${VERSION}" "$RELEASE_SHA"
+          git push origin "refs/tags/v${VERSION}"
 
           echo "release_sha=$RELEASE_SHA" >> $GITHUB_OUTPUT
 
@@ -231,7 +296,7 @@ jobs:
           retention-days: 7
 
   release:
-    needs: [build-dist]
+    needs: [build-and-tag]
     runs-on: ubuntu-latest
     name: Create Release
 
@@ -241,23 +306,23 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          # The tag was re-pointed by `build-dist`; check out the new
-          # commit so release notes are extracted from the correct tree.
-          ref: refs/tags/v${{ needs.build-dist.outputs.version }}
+          # The tag was just created by `build-and-tag` at the
+          # dist-baked commit; check that out so release notes are
+          # extracted from the correct tree.
+          ref: refs/tags/v${{ needs.build-and-tag.outputs.version }}
           persist-credentials: false
 
       - name: Extract release notes from CHANGELOG
         id: changelog
         env:
-          # Pass the tag through an env var instead of interpolating it directly
-          # into the shell script — keeps the value as a plain string regardless
-          # of what the tag contains and silences zizmor template-injection.
-          VERSION_INPUT: ${{ needs.build-dist.outputs.version }}
+          # Pass the version through an env var instead of interpolating it
+          # directly into the shell script — silences zizmor template-injection.
+          VERSION_INPUT: ${{ needs.build-and-tag.outputs.version }}
         run: |
           VERSION="$VERSION_INPUT"
           case "$VERSION" in
             ''|*[!0-9A-Za-z.+-]*)
-              echo "Invalid version extracted from tag: $VERSION" >&2
+              echo "Invalid version: $VERSION" >&2
               exit 1
               ;;
           esac
@@ -299,10 +364,11 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          name: v${{ needs.build-dist.outputs.version }}
+          tag_name: v${{ needs.build-and-tag.outputs.version }}
+          name: v${{ needs.build-and-tag.outputs.version }}
           body_path: release_notes.txt
           generate_release_notes: false
-          prerelease: ${{ contains(needs.build-dist.outputs.version, '-') }}
+          prerelease: ${{ contains(needs.build-and-tag.outputs.version, '-') }}
           # Sourcemaps ride along as a separate archive so debugging is
           # still possible without inflating every composer install
           # by ~30 MB (#678).

--- a/docs/Installation-Guide.md
+++ b/docs/Installation-Guide.md
@@ -75,7 +75,7 @@ The editor mounts on every page that contains a `[data-ap-visual-editor]` elemen
 
 ### Pattern B — serve pre-built bundles from `vendor/`
 
-Since v1.5.2 the Composer tarball ships pre-built editor bundles under `vendor/artisanpack-ui/visual-editor/dist/editor/`:
+Since v1.5.3 the Composer tarball ships pre-built editor bundles under `vendor/artisanpack-ui/visual-editor/dist/editor/`. (v1.5.2 attempted this too, but a workflow race with Packagist's version-immutability policy left Packagist frozen at a source-only tarball — see #683. Pin `^1.5.3` if you need Pattern B.)
 
 ```
 vendor/artisanpack-ui/visual-editor/dist/editor/

--- a/tests/Feature/Ci/ReleaseWorkflowTest.php
+++ b/tests/Feature/Ci/ReleaseWorkflowTest.php
@@ -7,18 +7,22 @@ use Symfony\Component\Yaml\Yaml;
 /**
  * Regression tests for `.github/workflows/release.yml`.
  *
- * The release workflow is the ONE place where `dist/editor/` and
- * `dist/lib/` are baked into the release tag so Composer consumers
- * (Keystone CMS etc. — see #678) get pre-built bundles under
- * `vendor/artisanpack-ui/visual-editor/dist/editor/`. Without these
- * tests a future edit could silently drop the dist-baking step and
- * ship another `1.5.1`-shaped release where the tarball has no
- * `dist/editor/` at all.
+ * The release workflow bakes `dist/editor/` + `dist/lib/` into the
+ * release tag so Composer consumers (Keystone CMS etc. — see #678)
+ * get pre-built bundles under
+ * `vendor/artisanpack-ui/visual-editor/dist/editor/`. #678's original
+ * design triggered on tag push and force-updated the tag mid-run,
+ * which raced Packagist's version-immutability policy and lost
+ * (v1.5.2 shipped without dist/ on Packagist — see #683). The
+ * workflow now triggers on `workflow_dispatch`, builds first, and
+ * pushes the tag exactly ONCE at the built commit.
  *
- * Each test asserts a single invariant of the workflow — the shape
- * of the guard, not its exact wording — so cosmetic edits to
- * comments or shell formatting don't break the suite, but removing
- * the guard itself does.
+ * These tests lock the load-bearing invariants of that design: no
+ * `on: push: tags` trigger, no `git push --force` on a version tag,
+ * a guard that refuses to reship an existing tag, and the
+ * verify/strip/commit/tag pipeline. Each test asserts the shape of
+ * one guard so cosmetic edits to comments or formatting don't break
+ * the suite, but removing the guard itself does.
  */
 
 /**
@@ -26,7 +30,7 @@ use Symfony\Component\Yaml\Yaml;
  *
  * @return array{
  *     workflow: array<string, mixed>,
- *     buildDist: array<string, mixed>,
+ *     buildAndTag: array<string, mixed>,
  *     release: array<string, mixed>
  * }
  */
@@ -42,7 +46,7 @@ function loadReleaseWorkflow(): array
 
 	return [
 		'workflow' => $workflow,
-		'buildDist' => $workflow['jobs']['build-dist'] ?? [],
+		'buildAndTag' => $workflow['jobs']['build-and-tag'] ?? [],
 		'release' => $workflow['jobs']['release'] ?? [],
 	];
 }
@@ -60,26 +64,65 @@ function releaseWorkflowRunScripts( array $job ): string
 		->implode( "\n" );
 }
 
-test( 'build-dist job exists and depends on both test jobs', function () {
+test( 'workflow triggers on workflow_dispatch and NEVER on tag push', function () {
 	$w = loadReleaseWorkflow();
 
-	expect( $w['buildDist'] )->not->toBeEmpty(
-		'build-dist job missing — dist/ will not be baked into the release tag'
+	// The YAML `on:` key is parsed to boolean `true` in PHP — access
+	// the raw value via the special key. Prefer the parsed structure.
+	$on = $w['workflow'][ true ] ?? $w['workflow']['on'] ?? [];
+
+	expect( $on )
+		->toHaveKey( 'workflow_dispatch' )
+		->not->toHaveKey( 'push' );
+
+	// The version input must be required — dispatching without a
+	// version would tag with an empty string.
+	$version = $on['workflow_dispatch']['inputs']['version'] ?? [];
+	expect( $version['required'] ?? null )->toBeTrue();
+} );
+
+test( 'build-and-tag job exists and depends on both test jobs', function () {
+	$w = loadReleaseWorkflow();
+
+	expect( $w['buildAndTag'] )->not->toBeEmpty(
+		'build-and-tag job missing — dist/ will not be baked into the release tag'
 	);
-	expect( $w['buildDist']['needs'] )
+	expect( $w['buildAndTag']['needs'] )
 		->toContain( 'test-php' )
 		->toContain( 'test-js' );
 } );
 
-test( 'build-dist runs both build:lib and build so dist/lib and dist/editor are produced', function () {
-	$runs = releaseWorkflowRunScripts( loadReleaseWorkflow()['buildDist'] );
+test( 'build-and-tag refuses to overwrite an existing tag on origin', function () {
+	$runs = releaseWorkflowRunScripts( loadReleaseWorkflow()['buildAndTag'] );
+
+	// The guard against re-dispatching for an already-shipped
+	// version — without it we could hit Packagist's immutability
+	// wall a second time. See #683.
+	expect( $runs )
+		->toContain( 'git ls-remote --tags --exit-code origin' )
+		->toContain( 'already exists on origin' );
+} );
+
+test( 'build-and-tag verifies the version input matches the manifests', function () {
+	$runs = releaseWorkflowRunScripts( loadReleaseWorkflow()['buildAndTag'] );
+
+	// A `-f version=1.5.3` dispatch against a main that still says
+	// 1.5.2 in the manifests would produce a tag inconsistent with
+	// the source's stated version.
+	expect( $runs )
+		->toContain( 'composer.json' )
+		->toContain( 'package.json' );
+} );
+
+test( 'build-and-tag runs both build:lib and build so dist/lib and dist/editor are produced', function () {
+	$runs = releaseWorkflowRunScripts( loadReleaseWorkflow()['buildAndTag'] );
 
 	expect( $runs )->toContain( 'npm run build:lib' );
 	expect( $runs )->toContain( 'npm run build' );
 } );
 
-test( 'build-dist strips sourcemaps before committing', function () {
-	$runs = releaseWorkflowRunScripts( loadReleaseWorkflow()['buildDist'] );
+test( 'build-and-tag strips sourcemaps before committing', function () {
+	$runs = releaseWorkflowRunScripts( loadReleaseWorkflow()['buildAndTag'] );
 
 	// Sourcemaps must be found, packaged, and removed. Without this
 	// the composer tarball grows by ~30 MB per install (#678).
@@ -89,8 +132,8 @@ test( 'build-dist strips sourcemaps before committing', function () {
 		->toContain( 'rm' );
 } );
 
-test( 'build-dist verifies the required build outputs exist', function () {
-	$runs = releaseWorkflowRunScripts( loadReleaseWorkflow()['buildDist'] );
+test( 'build-and-tag verifies the required build outputs exist', function () {
+	$runs = releaseWorkflowRunScripts( loadReleaseWorkflow()['buildAndTag'] );
 
 	// The verify step guards against silent build breakage that
 	// would ship a release with missing bundles.
@@ -105,8 +148,8 @@ test( 'build-dist verifies the required build outputs exist', function () {
 	}
 } );
 
-test( 'build-dist force-adds dist/editor and dist/lib onto the release commit', function () {
-	$runs = releaseWorkflowRunScripts( loadReleaseWorkflow()['buildDist'] );
+test( 'build-and-tag force-adds dist/editor and dist/lib onto the release commit', function () {
+	$runs = releaseWorkflowRunScripts( loadReleaseWorkflow()['buildAndTag'] );
 
 	// `dist/` stays .gitignored on every working branch (see the
 	// comment in .gitignore); the release workflow force-adds so
@@ -117,17 +160,21 @@ test( 'build-dist force-adds dist/editor and dist/lib onto the release commit', 
 		->toContain( 'dist/lib' );
 } );
 
-test( 'build-dist re-points the version tag at the dist-baked commit', function () {
-	$runs = releaseWorkflowRunScripts( loadReleaseWorkflow()['buildDist'] );
+test( 'build-and-tag pushes the version tag exactly once — no force-push', function () {
+	$runs = releaseWorkflowRunScripts( loadReleaseWorkflow()['buildAndTag'] );
 
-	// Composer resolves tags to SHAs — the tag must move to the
-	// new commit or consumers keep getting the pre-build SHA.
+	// Packagist immutability blocks any subsequent SHA change on a
+	// stable tag — see #683. The workflow must NEVER force-push a
+	// version tag or use `git tag -f`.
 	expect( $runs )
-		->toContain( 'git tag -f' )
-		->toContain( 'git push --force' );
+		->toContain( 'git tag -a' )
+		->toContain( 'git push origin' )
+		->not->toContain( 'git tag -f' )
+		->not->toContain( 'git push --force' )
+		->not->toContain( 'git push -f' );
 } );
 
-test( 'release job checks out the re-tagged commit before extracting notes', function () {
+test( 'release job checks out the tag created by build-and-tag', function () {
 	$release = loadReleaseWorkflow()['release'];
 
 	$checkout = collect( $release['steps'] ?? [] )
@@ -136,7 +183,7 @@ test( 'release job checks out the re-tagged commit before extracting notes', fun
 	expect( $checkout )->not->toBeNull();
 	expect( $checkout['with']['ref'] ?? '' )
 		->toContain( 'refs/tags/v' )
-		->toContain( 'build-dist.outputs.version' );
+		->toContain( 'build-and-tag.outputs.version' );
 } );
 
 test( 'release job downloads the sourcemap artefact and attaches it to the GitHub Release', function () {
@@ -147,7 +194,7 @@ test( 'release job downloads the sourcemap artefact and attaches it to the GitHu
 		fn ( array $step ) => str_starts_with( (string) ( $step['uses'] ?? '' ), 'actions/download-artifact' )
 	);
 	expect( $download )->not->toBeNull(
-		'release job must download the sourcemap archive from build-dist'
+		'release job must download the sourcemap archive from build-and-tag'
 	);
 
 	$ghRelease = $steps->first(
@@ -157,8 +204,8 @@ test( 'release job downloads the sourcemap artefact and attaches it to the GitHu
 	expect( $ghRelease['with']['files'] ?? '' )->toContain( 'release-artifacts' );
 } );
 
-test( 'build-dist declares contents:write permission (required to push the re-tag)', function () {
-	$buildDist = loadReleaseWorkflow()['buildDist'];
+test( 'build-and-tag declares contents:write permission (required to push the tag)', function () {
+	$job = loadReleaseWorkflow()['buildAndTag'];
 
-	expect( $buildDist['permissions']['contents'] ?? '' )->toBe( 'write' );
+	expect( $job['permissions']['contents'] ?? '' )->toBe( 'write' );
 } );


### PR DESCRIPTION
## Description

Rewires `.github/workflows/release.yml` from `on: push: tags: 'v*'` to `on: workflow_dispatch { inputs: { version } }`, eliminating the Packagist-immutability race that broke v1.5.2 shipping.

**Closes:** #683

## Type of Change

- [x] Bug fix (fixes an issue)

## Related Issue

**Issue:** #683

## Motivation and Context

#678's original workflow shape had a fundamental race with Packagist:

1. Human pushed `v1.5.2` at `442ef80` (main's merge commit, source-only).
2. Packagist's crawler observed the tag within seconds and froze `v1.5.2 → 442ef80` permanently.
3. The workflow's `build-dist` job took ~2 minutes to rebuild, verify, force-add `dist/editor` + `dist/lib`, and force-push the tag to `49e6728`.
4. Packagist rejected the SHA change and emailed the maintainer per its [version immutability policy](https://packagist.org/about/version-immutability).

Result: `git ls-remote origin refs/tags/v1.5.2` shows `49e6728` (dist-baked), Packagist shows `442ef80` (source-only). Composer consumers get the source-only tarball — exactly the state #678 tried to fix. The workflow reported success because the GitHub push succeeded; Packagist's rejection is out-of-band and only surfaces via email.

The race is inherent to any design where the same tag push both triggers the workflow AND is what Packagist crawls. Removing tag-push as the trigger removes the race.

## Changes Made

### `.github/workflows/release.yml`
- **Trigger changed from `push: tags: 'v*'` to `workflow_dispatch` with a required `version` input** (bare semver, no leading `v`).
- **`build-dist` renamed to `build-and-tag`** — its new job scope is: check out `main`, guard against a duplicate tag on origin (belt-and-braces so a re-dispatch of `1.5.2` can't hit Packagist again), verify the version input matches `composer.json` / `package.json` on main, build both bundles, package + strip sourcemaps, verify outputs, force-add `dist/editor` + `dist/lib` onto a fresh commit, create the tag with `git tag -a` (annotated, NOT `-f`), and push once with `git push origin refs/tags/vX.Y.Z` (NOT `--force`).
- `test-php` / `test-js` steps now check out `ref: main` explicitly since there's no tag ref to inherit.
- `release` job unchanged in shape — checks out the just-created tag, extracts CHANGELOG notes, downloads the sourcemap artefact, creates the GitHub Release, notifies Packagist.

### `tests/Feature/Ci/ReleaseWorkflowTest.php`
- **12 tests (35 assertions), all passing.** Replaces the 9 tests that were locking the wrong invariants (force-push, tag-triggered).
- New asserts: `workflow_dispatch` trigger, no `push` trigger, required `version` input, "refuse to overwrite existing tag" guard, "version input matches manifests" guard, and — critically — **`->not->toContain('git tag -f')` + `->not->toContain('git push --force')` + `->not->toContain('git push -f')`** so a future edit can't silently re-introduce the force-push and race Packagist again.

### `docs/Installation-Guide.md`
- Pattern B section now says v1.5.3 (not v1.5.2) is the first release that actually ships pre-built bundles end-to-end, with a callout to #683 explaining why v1.5.2 is stuck at the source-only tarball on Packagist. Advises pinning `^1.5.3` for Pattern B.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS Darwin 27.0.0
- PHP Version: 8.4.3
- Project Version: `release/1.x` @ current tip

**Tests Performed:**
1. `./vendor/bin/pest tests/Feature/Ci/ReleaseWorkflowTest.php --ci` → 12 tests / 35 assertions passing.
2. Parsed `release.yml` with `Symfony\Component\Yaml\Yaml::parseFile()` to confirm the file is valid YAML and produces the expected job / step / output structure — 4 jobs (`test-php`, `test-js`, `build-and-tag`, `release`), 13 steps in `build-and-tag`, correct outputs (`version`, `release_sha`, `sourcemap_archive`).
3. Manually traced the shell scripts against `bash -eo pipefail` semantics — the tag-existence guard uses `git ls-remote --exit-code` correctly; the version-match guard uses `jq -r` against string-only fields.

**Not tested locally** (requires actually dispatching against a live tag and is Phase 3 of the recovery): the actual v1.5.3 release publishing. That happens after this PR merges, in a separate PR that bumps to 1.5.3.

## Accessibility Tests Run

- [ ] Keyboard navigation tested — n/a
- [ ] Screen reader tested — n/a
- [ ] Color contrast verified — n/a
- [ ] ARIA labels checked — n/a

**Details:** n/a — CI/docs change, no UI surface touched.

## Tests Added

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All tests passing

**Test details:** `tests/Feature/Ci/ReleaseWorkflowTest.php` fully rewritten (12 tests / 35 assertions). Explicitly bans `git tag -f` / `git push --force` on version tags — the invariant that #678 got wrong is now enforced.

## Documentation

- [x] Inline code documentation added (workflow header comments explain the Packagist race and reference #683)
- [ ] README updated
- [x] Wiki updated (docs/Installation-Guide.md Pattern B callout)
- [ ] API documentation updated

**Documentation details:** Workflow file's header comment block documents the Packagist race and links to #683's postmortem. Installation-Guide's Pattern B section warns that v1.5.2 doesn't actually deliver Pattern B on Packagist and to pin `^1.5.3`.

## Screenshots

N/a — CI/docs change.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted (YAML parses via `symfony/yaml`; PHP uses ArtisanPack UI spacing)
- [x] Accessibility tests completed (n/a)
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

## Follow-up

- **Phase 3 of the recovery**: cut v1.5.3 to actually ship the dist-baking end-to-end. That'll be a separate release PR that bumps `composer.json` / `package.json` / `docs/home.md`, adds a `[1.5.3]` CHANGELOG entry noting the v1.5.2 miscarriage + this workflow fix + the #677 media bridge + the #678 dist-baking, merges into `main`, and dispatches this new workflow.
- **v1.5.2 tag/Packagist mismatch**: cosmetic; leaving as-is since Packagist immutability is authoritative for Composer consumers and GitHub's tag protection blocks the CLI restore. Anyone doing `git clone && git checkout v1.5.2` will get `dist/` (from 49e6728), but that's a rare access pattern compared to Composer install.