### PR TITLE
Release v1.5.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,29 @@
 name: Release
 
+# Manual dispatch — do NOT use `on: push: tags` here.
+#
+# Previously the workflow triggered on `push: tags: 'v*'` and used a
+# `build-dist` job to force-update the tag mid-run so the composer
+# tarball would ship `dist/editor/` + `dist/lib/` (#678). Packagist's
+# crawler observes new stable tags within seconds and freezes their
+# SHA permanently under its version-immutability policy — the workflow
+# lost that race on v1.5.2, so Packagist ended up pinned at the
+# source-only commit while GitHub's tag advanced to the dist-baked
+# one. See #683 for the postmortem.
+#
+# The workflow now runs on `workflow_dispatch`: the maintainer merges
+# the release PR into main, then invokes
+# `gh workflow run release.yml -f version=X.Y.Z`. The workflow builds
+# `dist/`, commits it onto a fresh commit, creates the tag on that
+# commit, and pushes the tag ONCE — Packagist observes it exactly
+# once, at the correct SHA.
 on:
-  push:
-    tags:
-      - 'v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release (e.g. 1.5.3 — no leading v)'
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -17,6 +37,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: main
           persist-credentials: false
 
       - name: Setup PHP
@@ -63,6 +84,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: main
           persist-credentials: false
 
       - name: Setup Node.js
@@ -83,47 +105,90 @@ jobs:
       - name: Build app bundle
         run: npm run build
 
-  build-dist:
-    # Rebuilds the editor + library bundles, bakes them into the tag's
-    # release commit, and packages sourcemaps as a separate archive.
+  build-and-tag:
+    # Rebuilds the editor + library bundles, bakes them into a fresh
+    # release commit, creates the version tag, and pushes ONCE.
     #
-    # `dist/` is intentionally .gitignored on every working branch so
-    # local builds don't leak into diffs. The release commit is the
-    # ONE place the built assets are supposed to live so consumers
-    # that install via Composer's GitHub-tarball resolution (Keystone
-    # CMS, etc. — see #678) get a `vendor/artisanpack-ui/visual-editor/
-    # dist/editor/` tree without running Node themselves.
+    # Why a single push? Packagist observes tags within seconds and
+    # freezes stable-version SHAs permanently. #678's earlier design
+    # pushed the tag first and force-updated it after building, losing
+    # the race on v1.5.2. The redesign here (#683) never lets Packagist
+    # see an intermediate SHA: the workflow builds first, then creates
+    # and pushes the tag at the built commit.
     needs: [test-php, test-js]
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    name: Build and bake dist/ into release tag
+    name: Build dist/ and create version tag
 
     permissions:
       contents: write
 
     outputs:
-      version: ${{ steps.version.outputs.version }}
+      version: ${{ inputs.version }}
       release_sha: ${{ steps.commit-dist.outputs.release_sha }}
       sourcemap_archive: ${{ steps.package-sourcemaps.outputs.archive }}
 
     steps:
-      - uses: actions/checkout@v4
-        with:
-          # We need to push a re-tag from this job, so keep the token.
-          persist-credentials: true
-          fetch-depth: 0
-
-      - name: Extract version from tag
-        id: version
+      - name: Validate version input
+        env:
+          VERSION_INPUT: ${{ inputs.version }}
         run: |
-          VERSION="${GITHUB_REF#refs/tags/v}"
+          VERSION="$VERSION_INPUT"
           case "$VERSION" in
-            ''|*[!0-9A-Za-z.+-]*)
-              echo "Invalid version extracted from tag: $VERSION" >&2
+            ''|v*|*[!0-9A-Za-z.+-]*)
+              echo "Invalid version input: '$VERSION' (must be bare semver like 1.5.3, no leading v)" >&2
               exit 1
               ;;
           esac
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - uses: actions/checkout@v4
+        with:
+          # Tag off main — the release PR is expected to have merged
+          # before dispatch. `persist-credentials: true` so the tag
+          # push later in this job can authenticate.
+          ref: main
+          persist-credentials: true
+          fetch-depth: 0
+
+      - name: Refuse to overwrite an existing tag
+        # Belt-and-braces guard against re-dispatching for a version
+        # that already shipped. If somebody tries `gh workflow run
+        # release.yml -f version=1.5.2` a second time, this catches
+        # it before we build and would otherwise hit Packagist's
+        # immutability wall again.
+        env:
+          VERSION_INPUT: ${{ inputs.version }}
+        run: |
+          VERSION="$VERSION_INPUT"
+          if git ls-remote --tags --exit-code origin "refs/tags/v${VERSION}" >/dev/null 2>&1; then
+            echo "Tag v${VERSION} already exists on origin — refusing to reship." >&2
+            echo "If you need to reship, cut a new version." >&2
+            exit 1
+          fi
+
+      - name: Verify version input matches composer.json / package.json
+        # Prevents a `-f version=1.5.3` dispatch against a main that
+        # still says 1.5.2 in its manifests — that would produce a tag
+        # inconsistent with the source's stated version.
+        env:
+          VERSION_INPUT: ${{ inputs.version }}
+        run: |
+          VERSION="$VERSION_INPUT"
+          COMPOSER_VERSION=$(jq -r '.version // ""' composer.json)
+          PACKAGE_VERSION=$(jq -r '.version // ""' package.json)
+          fail=0
+          if [ "$COMPOSER_VERSION" != "$VERSION" ]; then
+            echo "composer.json version ($COMPOSER_VERSION) != input ($VERSION)" >&2
+            fail=1
+          fi
+          if [ "$PACKAGE_VERSION" != "$VERSION" ]; then
+            echo "package.json version ($PACKAGE_VERSION) != input ($VERSION)" >&2
+            fail=1
+          fi
+          if [ "$fail" -ne 0 ]; then
+            echo "Bump the manifests on main first (via the release PR) before dispatching." >&2
+            exit 1
+          fi
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -143,7 +208,7 @@ jobs:
       - name: Package sourcemaps and strip them from dist/
         id: package-sourcemaps
         env:
-          VERSION_INPUT: ${{ steps.version.outputs.version }}
+          VERSION_INPUT: ${{ inputs.version }}
         run: |
           VERSION="$VERSION_INPUT"
           ARCHIVE="dist-sourcemaps-v${VERSION}.tar.gz"
@@ -200,10 +265,10 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-      - name: Commit dist/ and re-point the release tag
+      - name: Commit dist/ and create the version tag
         id: commit-dist
         env:
-          VERSION_INPUT: ${{ steps.version.outputs.version }}
+          VERSION_INPUT: ${{ inputs.version }}
         run: |
           VERSION="$VERSION_INPUT"
 
@@ -211,14 +276,14 @@ jobs:
           # builds out of every non-release working tree. Force-add
           # here so this one release commit contains the built assets.
           git add --force dist/editor dist/lib
-          git commit -m "chore(release): bake dist/ for v${VERSION} (#678)"
+          git commit -m "chore(release): bake dist/ for v${VERSION} (#683)"
           RELEASE_SHA=$(git rev-parse HEAD)
 
-          # Re-point the tag at the new commit so Composer /
-          # Packagist resolve the built tarball. Force-push because
-          # the tag already exists at the pre-build commit.
-          git tag -f "v${VERSION}" "$RELEASE_SHA"
-          git push --force origin "refs/tags/v${VERSION}"
+          # Create the tag AT the built commit — this is the first
+          # (and only) time this tag will ever be pushed. No force,
+          # no race with Packagist.
+          git tag -a "v${VERSION}" -m "Release v${VERSION}" "$RELEASE_SHA"
+          git push origin "refs/tags/v${VERSION}"
 
           echo "release_sha=$RELEASE_SHA" >> $GITHUB_OUTPUT
 
@@ -231,7 +296,7 @@ jobs:
           retention-days: 7
 
   release:
-    needs: [build-dist]
+    needs: [build-and-tag]
     runs-on: ubuntu-latest
     name: Create Release
 
@@ -241,23 +306,23 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          # The tag was re-pointed by `build-dist`; check out the new
-          # commit so release notes are extracted from the correct tree.
-          ref: refs/tags/v${{ needs.build-dist.outputs.version }}
+          # The tag was just created by `build-and-tag` at the
+          # dist-baked commit; check that out so release notes are
+          # extracted from the correct tree.
+          ref: refs/tags/v${{ needs.build-and-tag.outputs.version }}
           persist-credentials: false
 
       - name: Extract release notes from CHANGELOG
         id: changelog
         env:
-          # Pass the tag through an env var instead of interpolating it directly
-          # into the shell script — keeps the value as a plain string regardless
-          # of what the tag contains and silences zizmor template-injection.
-          VERSION_INPUT: ${{ needs.build-dist.outputs.version }}
+          # Pass the version through an env var instead of interpolating it
+          # directly into the shell script — silences zizmor template-injection.
+          VERSION_INPUT: ${{ needs.build-and-tag.outputs.version }}
         run: |
           VERSION="$VERSION_INPUT"
           case "$VERSION" in
             ''|*[!0-9A-Za-z.+-]*)
-              echo "Invalid version extracted from tag: $VERSION" >&2
+              echo "Invalid version: $VERSION" >&2
               exit 1
               ;;
           esac
@@ -299,10 +364,11 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          name: v${{ needs.build-dist.outputs.version }}
+          tag_name: v${{ needs.build-and-tag.outputs.version }}
+          name: v${{ needs.build-and-tag.outputs.version }}
           body_path: release_notes.txt
           generate_release_notes: false
-          prerelease: ${{ contains(needs.build-dist.outputs.version, '-') }}
+          prerelease: ${{ contains(needs.build-and-tag.outputs.version, '-') }}
           # Sourcemaps ride along as a separate archive so debugging is
           # still possible without inflating every composer install
           # by ~30 MB (#678).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,58 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [1.5.3] - 2026-07-27
+
+### Fixed
+
+- **Release workflow no longer races Packagist's version-immutability
+  policy (#683).** The workflow shipped in #678 triggered on
+  `push: tags: 'v*'` and used a `build-dist` job to force-update the
+  tag mid-run so the composer tarball would carry `dist/editor/` +
+  `dist/lib/`. Packagist's crawler observes new stable tags within
+  seconds and freezes their SHA permanently — the workflow lost that
+  race on v1.5.2, so Packagist ended up pinned at the source-only
+  commit while GitHub's tag advanced to the dist-baked one. Composer
+  consumers of v1.5.2 still got the source-only tarball, same broken
+  state as v1.5.1. The workflow now triggers on `workflow_dispatch`
+  with a `version` input. The maintainer merges the release PR into
+  main, then invokes `gh workflow run release.yml -f version=X.Y.Z`.
+  The workflow guards against re-shipping an existing tag, verifies
+  the version input matches `composer.json` / `package.json`, builds
+  `dist/`, commits it onto a fresh commit, creates the tag on that
+  commit with `git tag -a` (annotated, not `-f`), and pushes it
+  exactly ONCE with `git push origin refs/tags/vX.Y.Z` (no
+  `--force`). Packagist observes the tag exactly once, at the
+  correct SHA. `tests/Feature/Ci/ReleaseWorkflowTest.php` was
+  rewritten to lock the new invariants and explicitly banned
+  `git tag -f` / `git push --force` on version tags so the race
+  can't recur silently.
+
+### Notes
+
+- **v1.5.3 is the first release that actually delivers Pattern B
+  from `docs/Installation-Guide.md` end-to-end.** v1.5.2 attempted
+  the same dist-baking contract described in #678 but Packagist
+  froze it at the source-only tarball (see #683 above). Consumers
+  who pinned to v1.5.2 for the pre-built `dist/editor/` tree should
+  upgrade to v1.5.3 — pin `^1.5.3` if you need Pattern B. The
+  `v1.5.2` GitHub tag still points at the dist-baked commit
+  (`49e6728`) for anyone doing `git clone && git checkout v1.5.2`,
+  but Composer consumers get `442ef80` (source-only) from Packagist
+  regardless; this cosmetic tag/Packagist mismatch was left as-is
+  because GitHub's tag-protection rule blocks a CLI restore and the
+  practical impact is zero for Composer installs.
+
 ## [1.5.2] - 2026-07-27
+
+> **This release did not fully ship its promised dist-baking on
+> Packagist.** #678's release-workflow force-push raced Packagist's
+> version-immutability policy and lost — Packagist froze `v1.5.2`
+> at the source-only commit (`442ef80`) while GitHub's tag advanced
+> to the dist-baked commit (`49e6728`). Composer consumers who
+> pinned to `^1.5.2` for Pattern B still get the source-only
+> tarball. Upgrade to v1.5.3 (fixed in #683) for the actual
+> pre-built bundles.
 
 ### Fixed
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "artisanpack-ui/visual-editor",
   "description": "A Gutenberg-powered visual editor for Laravel — post editor, site editor, and Blade/React/Vue block renderers.",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "type": "library",
   "license": "GPL-3.0-or-later",
   "autoload": {

--- a/docs/Installation-Guide.md
+++ b/docs/Installation-Guide.md
@@ -75,7 +75,7 @@ The editor mounts on every page that contains a `[data-ap-visual-editor]` elemen
 
 ### Pattern B — serve pre-built bundles from `vendor/`
 
-Since v1.5.2 the Composer tarball ships pre-built editor bundles under `vendor/artisanpack-ui/visual-editor/dist/editor/`:
+Since v1.5.3 the Composer tarball ships pre-built editor bundles under `vendor/artisanpack-ui/visual-editor/dist/editor/`. (v1.5.2 attempted this too, but a workflow race with Packagist's version-immutability policy left Packagist frozen at a source-only tarball — see #683. Pin `^1.5.3` if you need Pattern B.)
 
 ```
 vendor/artisanpack-ui/visual-editor/dist/editor/

--- a/docs/home.md
+++ b/docs/home.md
@@ -175,4 +175,4 @@ For issues, feature requests, and contributions:
 
 ---
 
-*This documentation covers visual-editor v1.5.2*
+*This documentation covers visual-editor v1.5.3*

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@artisanpack-ui/visual-editor",
-    "version": "1.5.2",
+    "version": "1.5.3",
     "private": true,
     "type": "module",
     "exports": {

--- a/tests/Feature/Ci/ReleaseWorkflowTest.php
+++ b/tests/Feature/Ci/ReleaseWorkflowTest.php
@@ -7,18 +7,22 @@ use Symfony\Component\Yaml\Yaml;
 /**
  * Regression tests for `.github/workflows/release.yml`.
  *
- * The release workflow is the ONE place where `dist/editor/` and
- * `dist/lib/` are baked into the release tag so Composer consumers
- * (Keystone CMS etc. — see #678) get pre-built bundles under
- * `vendor/artisanpack-ui/visual-editor/dist/editor/`. Without these
- * tests a future edit could silently drop the dist-baking step and
- * ship another `1.5.1`-shaped release where the tarball has no
- * `dist/editor/` at all.
+ * The release workflow bakes `dist/editor/` + `dist/lib/` into the
+ * release tag so Composer consumers (Keystone CMS etc. — see #678)
+ * get pre-built bundles under
+ * `vendor/artisanpack-ui/visual-editor/dist/editor/`. #678's original
+ * design triggered on tag push and force-updated the tag mid-run,
+ * which raced Packagist's version-immutability policy and lost
+ * (v1.5.2 shipped without dist/ on Packagist — see #683). The
+ * workflow now triggers on `workflow_dispatch`, builds first, and
+ * pushes the tag exactly ONCE at the built commit.
  *
- * Each test asserts a single invariant of the workflow — the shape
- * of the guard, not its exact wording — so cosmetic edits to
- * comments or shell formatting don't break the suite, but removing
- * the guard itself does.
+ * These tests lock the load-bearing invariants of that design: no
+ * `on: push: tags` trigger, no `git push --force` on a version tag,
+ * a guard that refuses to reship an existing tag, and the
+ * verify/strip/commit/tag pipeline. Each test asserts the shape of
+ * one guard so cosmetic edits to comments or formatting don't break
+ * the suite, but removing the guard itself does.
  */
 
 /**
@@ -26,7 +30,7 @@ use Symfony\Component\Yaml\Yaml;
  *
  * @return array{
  *     workflow: array<string, mixed>,
- *     buildDist: array<string, mixed>,
+ *     buildAndTag: array<string, mixed>,
  *     release: array<string, mixed>
  * }
  */
@@ -42,7 +46,7 @@ function loadReleaseWorkflow(): array
 
 	return [
 		'workflow' => $workflow,
-		'buildDist' => $workflow['jobs']['build-dist'] ?? [],
+		'buildAndTag' => $workflow['jobs']['build-and-tag'] ?? [],
 		'release' => $workflow['jobs']['release'] ?? [],
 	];
 }
@@ -60,26 +64,65 @@ function releaseWorkflowRunScripts( array $job ): string
 		->implode( "\n" );
 }
 
-test( 'build-dist job exists and depends on both test jobs', function () {
+test( 'workflow triggers on workflow_dispatch and NEVER on tag push', function () {
 	$w = loadReleaseWorkflow();
 
-	expect( $w['buildDist'] )->not->toBeEmpty(
-		'build-dist job missing — dist/ will not be baked into the release tag'
+	// The YAML `on:` key is parsed to boolean `true` in PHP — access
+	// the raw value via the special key. Prefer the parsed structure.
+	$on = $w['workflow'][ true ] ?? $w['workflow']['on'] ?? [];
+
+	expect( $on )
+		->toHaveKey( 'workflow_dispatch' )
+		->not->toHaveKey( 'push' );
+
+	// The version input must be required — dispatching without a
+	// version would tag with an empty string.
+	$version = $on['workflow_dispatch']['inputs']['version'] ?? [];
+	expect( $version['required'] ?? null )->toBeTrue();
+} );
+
+test( 'build-and-tag job exists and depends on both test jobs', function () {
+	$w = loadReleaseWorkflow();
+
+	expect( $w['buildAndTag'] )->not->toBeEmpty(
+		'build-and-tag job missing — dist/ will not be baked into the release tag'
 	);
-	expect( $w['buildDist']['needs'] )
+	expect( $w['buildAndTag']['needs'] )
 		->toContain( 'test-php' )
 		->toContain( 'test-js' );
 } );
 
-test( 'build-dist runs both build:lib and build so dist/lib and dist/editor are produced', function () {
-	$runs = releaseWorkflowRunScripts( loadReleaseWorkflow()['buildDist'] );
+test( 'build-and-tag refuses to overwrite an existing tag on origin', function () {
+	$runs = releaseWorkflowRunScripts( loadReleaseWorkflow()['buildAndTag'] );
+
+	// The guard against re-dispatching for an already-shipped
+	// version — without it we could hit Packagist's immutability
+	// wall a second time. See #683.
+	expect( $runs )
+		->toContain( 'git ls-remote --tags --exit-code origin' )
+		->toContain( 'already exists on origin' );
+} );
+
+test( 'build-and-tag verifies the version input matches the manifests', function () {
+	$runs = releaseWorkflowRunScripts( loadReleaseWorkflow()['buildAndTag'] );
+
+	// A `-f version=1.5.3` dispatch against a main that still says
+	// 1.5.2 in the manifests would produce a tag inconsistent with
+	// the source's stated version.
+	expect( $runs )
+		->toContain( 'composer.json' )
+		->toContain( 'package.json' );
+} );
+
+test( 'build-and-tag runs both build:lib and build so dist/lib and dist/editor are produced', function () {
+	$runs = releaseWorkflowRunScripts( loadReleaseWorkflow()['buildAndTag'] );
 
 	expect( $runs )->toContain( 'npm run build:lib' );
 	expect( $runs )->toContain( 'npm run build' );
 } );
 
-test( 'build-dist strips sourcemaps before committing', function () {
-	$runs = releaseWorkflowRunScripts( loadReleaseWorkflow()['buildDist'] );
+test( 'build-and-tag strips sourcemaps before committing', function () {
+	$runs = releaseWorkflowRunScripts( loadReleaseWorkflow()['buildAndTag'] );
 
 	// Sourcemaps must be found, packaged, and removed. Without this
 	// the composer tarball grows by ~30 MB per install (#678).
@@ -89,8 +132,8 @@ test( 'build-dist strips sourcemaps before committing', function () {
 		->toContain( 'rm' );
 } );
 
-test( 'build-dist verifies the required build outputs exist', function () {
-	$runs = releaseWorkflowRunScripts( loadReleaseWorkflow()['buildDist'] );
+test( 'build-and-tag verifies the required build outputs exist', function () {
+	$runs = releaseWorkflowRunScripts( loadReleaseWorkflow()['buildAndTag'] );
 
 	// The verify step guards against silent build breakage that
 	// would ship a release with missing bundles.
@@ -105,8 +148,8 @@ test( 'build-dist verifies the required build outputs exist', function () {
 	}
 } );
 
-test( 'build-dist force-adds dist/editor and dist/lib onto the release commit', function () {
-	$runs = releaseWorkflowRunScripts( loadReleaseWorkflow()['buildDist'] );
+test( 'build-and-tag force-adds dist/editor and dist/lib onto the release commit', function () {
+	$runs = releaseWorkflowRunScripts( loadReleaseWorkflow()['buildAndTag'] );
 
 	// `dist/` stays .gitignored on every working branch (see the
 	// comment in .gitignore); the release workflow force-adds so
@@ -117,17 +160,21 @@ test( 'build-dist force-adds dist/editor and dist/lib onto the release commit', 
 		->toContain( 'dist/lib' );
 } );
 
-test( 'build-dist re-points the version tag at the dist-baked commit', function () {
-	$runs = releaseWorkflowRunScripts( loadReleaseWorkflow()['buildDist'] );
+test( 'build-and-tag pushes the version tag exactly once — no force-push', function () {
+	$runs = releaseWorkflowRunScripts( loadReleaseWorkflow()['buildAndTag'] );
 
-	// Composer resolves tags to SHAs — the tag must move to the
-	// new commit or consumers keep getting the pre-build SHA.
+	// Packagist immutability blocks any subsequent SHA change on a
+	// stable tag — see #683. The workflow must NEVER force-push a
+	// version tag or use `git tag -f`.
 	expect( $runs )
-		->toContain( 'git tag -f' )
-		->toContain( 'git push --force' );
+		->toContain( 'git tag -a' )
+		->toContain( 'git push origin' )
+		->not->toContain( 'git tag -f' )
+		->not->toContain( 'git push --force' )
+		->not->toContain( 'git push -f' );
 } );
 
-test( 'release job checks out the re-tagged commit before extracting notes', function () {
+test( 'release job checks out the tag created by build-and-tag', function () {
 	$release = loadReleaseWorkflow()['release'];
 
 	$checkout = collect( $release['steps'] ?? [] )
@@ -136,7 +183,7 @@ test( 'release job checks out the re-tagged commit before extracting notes', fun
 	expect( $checkout )->not->toBeNull();
 	expect( $checkout['with']['ref'] ?? '' )
 		->toContain( 'refs/tags/v' )
-		->toContain( 'build-dist.outputs.version' );
+		->toContain( 'build-and-tag.outputs.version' );
 } );
 
 test( 'release job downloads the sourcemap artefact and attaches it to the GitHub Release', function () {
@@ -147,7 +194,7 @@ test( 'release job downloads the sourcemap artefact and attaches it to the GitHu
 		fn ( array $step ) => str_starts_with( (string) ( $step['uses'] ?? '' ), 'actions/download-artifact' )
 	);
 	expect( $download )->not->toBeNull(
-		'release job must download the sourcemap archive from build-dist'
+		'release job must download the sourcemap archive from build-and-tag'
 	);
 
 	$ghRelease = $steps->first(
@@ -157,8 +204,8 @@ test( 'release job downloads the sourcemap artefact and attaches it to the GitHu
 	expect( $ghRelease['with']['files'] ?? '' )->toContain( 'release-artifacts' );
 } );
 
-test( 'build-dist declares contents:write permission (required to push the re-tag)', function () {
-	$buildDist = loadReleaseWorkflow()['buildDist'];
+test( 'build-and-tag declares contents:write permission (required to push the tag)', function () {
+	$job = loadReleaseWorkflow()['buildAndTag'];
 
-	expect( $buildDist['permissions']['contents'] ?? '' )->toBe( 'write' );
+	expect( $job['permissions']['contents'] ?? '' )->toBe( 'write' );
 } );


### PR DESCRIPTION
## Release Information

- **Release Version:** v1.5.3
- **Release Date:** 2026-07-27
- **Release Type:** Patch
- **Release Branch:** `release/1.5.3`
- **Target Branch:** `main`

## Release Summary

Recovery patch for v1.5.2: reworks the release workflow so it can actually deliver Pattern B (pre-built `dist/editor/` bundles inside the Composer tarball) end-to-end.

v1.5.2 shipped the source code for the #677 media bridge and the #678 dist-baking, but the release workflow's own design lost a race with Packagist's version-immutability policy — Packagist froze `v1.5.2` at the source-only commit, so Composer consumers still get a tarball with no `dist/editor/`. v1.5.3 rewires `release.yml` to trigger on `workflow_dispatch` with a `version` input (postmortem in #683, implementation in #684). The workflow now builds first, commits `dist/`, creates the tag on the built commit, and pushes it ONCE — Packagist observes it exactly once, at the correct SHA.

**This release is what v1.5.2 was supposed to be.** Consumers who pinned to `^1.5.2` for Pattern B should upgrade to `^1.5.3`.

## Changelog

### Added
- (none in 1.5.3)

### Changed
- (none in 1.5.3; the workflow trigger changed but that's a release-mechanism change, not a consumer-visible change)

### Deprecated
- (none)

### Removed
- (none)

### Fixed
- **Release workflow no longer races Packagist's version-immutability policy (#683 / #684).** `release.yml` triggers on `workflow_dispatch` instead of tag push. The workflow guards against re-shipping an existing tag, verifies the version input matches the manifests, builds `dist/`, commits it onto a fresh commit, and pushes the tag exactly ONCE at the built commit. `tests/Feature/Ci/ReleaseWorkflowTest.php` was rewritten to lock the new invariants and explicitly ban `git tag -f` / `git push --force` on version tags.

### Security
- (none)

### Notes
- **v1.5.3 is the first release that delivers Pattern B on Packagist.** v1.5.2's release did land the source-code changes for #677 (media bridge) and #678 (build code), so those already fixed on the source side — but the pre-built `dist/editor/` never reached Packagist. Consumers on `^1.5.2` for the dist bundles should upgrade to `^1.5.3`.
- **v1.5.2 tag/Packagist mismatch is left as-is.** GitHub tag `v1.5.2` = `49e6728` (dist-baked, orphan-ish); Packagist `v1.5.2` = `442ef80` (source-only). GitHub's tag-protection rule blocks a CLI restore, and Composer consumers get `442ef80` from Packagist regardless. The `[1.5.2]` CHANGELOG entry now carries an inline callout so anyone reading the history sees what happened.

## Issues and Pull Requests

**Issues Fixed:**
- Closes #683

**Related PRs:**
- #684 — fix: switch release workflow to workflow_dispatch (#683)

## Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes documented below

**Note on release-cutting workflow:** `git-release v1.5.3 "..."` no longer cuts the release. The new flow is:
1. Merge this PR into `main`.
2. Run `gh workflow run release.yml -f version=1.5.3` from any authenticated shell.

`git-release` remains fine for any non-release tag.

## Testing Checklist

- [x] All automated tests passing (Pest: 1579 passed / 4 skipped / 4216 assertions; Vitest: 2455 passed / 285 files)
- [x] Manual testing completed (workflow_dispatch shape parsed + tested via the Pest regression suite; #684's PR review pass covered the shell scripts)
- [ ] Accessibility tests passing (n/a — CI/docs change)
- [ ] Performance tests passing (n/a)
- [x] Security scan completed (composer audit: 4 low-severity `symfony/yaml` YAML-parser CVEs — test-only exposure via `Ci\ReleaseWorkflowTest`; npm audit: 18 pre-existing transitive `@wordpress/*` vulns, upstream Gutenberg concern, not introduced by this release)
- [ ] Tested in staging environment (n/a — package release; the workflow dispatch itself is the "staging" run and will happen after this PR merges)
- [ ] Database migrations tested (n/a)

**Testing notes:** The one thing that can only be verified live is the workflow_dispatch → build → tag → Packagist path. That'll happen after this PR merges, when I run `gh workflow run release.yml -f version=1.5.3`. If the tag lands cleanly on Packagist with `dist.reference` matching GitHub's tag SHA, the recovery is complete.

## Documentation Checklist

- [x] CHANGELOG updated (`[1.5.3] - 2026-07-27` entry + inline callout on the `[1.5.2]` entry explaining the miscarriage)
- [ ] README updated (n/a)
- [x] API documentation updated (docs/Installation-Guide.md Pattern B was corrected in #684 to say v1.5.3, not v1.5.2)
- [ ] Migration guide written (no breaking changes)
- [x] Release notes written (CHANGELOG entry doubles as release notes; `release.yml` auto-extracts them into the GitHub Release body)
- [x] Wiki updated (`docs/` tree)

## Pre-Release Checklist

- [x] Version number updated in all necessary files (`composer.json`, `package.json`, `docs/home.md`)
- [x] Git tag prepared: `v1.5.3` (will be created by the workflow_dispatch run, on the dist-baked commit)
- [x] Release branch created/updated: `release/1.5.3`
- [x] Dependencies updated and tested (no dep changes; composer.lock stale locally due to path-repo drift, CI resolves fresh — same pattern as prior releases)
- [x] Build artifacts generated (the new `build-and-tag` job in `release.yml` handles this on dispatch — verified by `tests/Feature/Ci/ReleaseWorkflowTest.php`)
- [x] Deployment plan reviewed
- [x] Rollback plan prepared
- [ ] Stakeholders notified

## Deployment

**Deployment steps:**
1. Merge this PR into `main`.
2. Run `gh workflow run release.yml -f version=1.5.3` (NOT `git-release v1.5.3 "..."` — that's the old flow that lost the Packagist race).
3. Watch the workflow run. `build-and-tag` will: guard the tag doesn't already exist, verify `composer.json` + `package.json` on main say `1.5.3`, run tests, build both bundles, package sourcemaps into `dist-sourcemaps-v1.5.3.tar.gz`, verify outputs, force-add `dist/editor` + `dist/lib`, create the tag at the dist-baked commit, push it once. The `release` job then creates the GitHub Release with the sourcemap archive and notifies Packagist.
4. Verify against a clean install: `composer require artisanpack-ui/visual-editor:^1.5.3` in a fresh directory — expect `vendor/artisanpack-ui/visual-editor/dist/editor/{visual-editor,site-editor,sandbox}.js` and `dist/editor/chunks/*.js` to be present.
5. Verify Packagist's `dist.reference` for `1.5.3` matches GitHub's `v1.5.3` tag SHA (they will, this time).
6. Coordinate with Keystone CMS to unpin from `^1.5.1` and land on `^1.5.3`.

**Rollback plan:**
1. If the workflow_dispatch produces a broken tag, the `Refuse to overwrite an existing tag` guard prevents a second dispatch from clobbering it — cut `v1.5.4` (or `v1.6.0`) with the fix instead.
2. Downstream consumers can pin to `v1.5.1` in the interim (the last release before this recovery arc).

**Configuration changes:** None.

**Environment variables:** None.

## Post-Release Tasks

- [ ] Tag created: `v1.5.3` (by the workflow dispatch, not by hand)
- [ ] Release notes published (auto-generated from CHANGELOG by `release.yml`)
- [ ] Documentation deployed
- [ ] Announcement sent
- [ ] Monitoring verified (check Packagist doesn't email another immutability rejection)
- [ ] Previous version support documented

## Notes

- **Do not run `git-release v1.5.3 "..."`.** The new workflow trigger is `workflow_dispatch`; `git-release` would push a tag off the current HEAD (main after merge), skipping the build-and-tag step entirely and shipping without `dist/`. Use `gh workflow run release.yml -f version=1.5.3` instead.
- **The Ci\ReleaseWorkflowTest suite is a live regression barrier.** If a future PR ever re-introduces `on: push: tags` or `git push --force` on a version tag, the suite fails at CI time. The invariant that #678 got wrong is now enforced.
- **v1.5.2's tag/Packagist mismatch stays.** Restoring the GitHub tag to `442ef80` would require overriding the tag-protection rule and would penalise `git clone && checkout v1.5.2` users (they'd lose `dist/`). The mismatch is cosmetic and the CHANGELOG documents it in-band.

---

**Release Manager:** @jacobmartella  
**Reviewers Required:** @jacobmartella

**For Reviewers:**  
- Verify all checklist items completed
- Review changelog accuracy — 1.5.3 = #683 workflow fix + the delivery of Pattern B that v1.5.2 promised but didn't deliver
- Confirm version numbers correct (1.5.3 in `composer.json`, `package.json`, `docs/home.md` footer)
- Check breaking changes documented (none for consumers; the release-cutting workflow itself changed)
- Approve deployment plan — especially the `gh workflow run` command replacing `git-release`