### PR TITLE
fix: scope site-editor per-size and per-state style overrides (#700)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,40 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [1.5.4] - 2026-07-28
+
+### Fixed
+
+- **Site editor per-size and per-state style overrides now scope
+  correctly (#700).** The site-editor bootstrap in
+  `site-editor/site-editor-app.tsx` never called the five `register*()`
+  functions that wire the responsive + state pipeline —
+  `registerResponsiveAttribute`, `registerResponsiveAttributesFilter`,
+  `registerStateAttribute`, `registerStateAttributesFilter`, and
+  `registerStateStylesFilters` — so opted-in blocks never got the
+  auto-injected `responsive` / `states` storage keys, the
+  `editor.BlockEdit` HOCs never wrapped `setAttributes` to route writes
+  into `responsive.<bp>.<path>` or `states.<path>.<activeState>`, and
+  the per-state `<style>` scope class was never injected into the
+  canvas. Every panel write landed on the base attribute, so a change
+  on Hover state or Desktop viewport applied to every state / screen
+  size. All five functions are now registered before
+  `registerArtisanPackBlocks()`, mirroring
+  `editor/editor-app.tsx:211-219`. The shared `BlockEditorProvider` in
+  `site-editor/block-editor-boundary.tsx` also mounts
+  `<StateWriteInterceptor />` and `<StateInspectorSync />` (missed when
+  the provider was hoisted in #436) so apiVersion-3 color / border /
+  shadow panels, which dispatch `updateBlockAttributes` directly and
+  bypass the HOC chain, still route through the state bag.
+- **Button block now opts into responsive spacing / dimensions
+  (#700).** The singular `artisanpack/button` block declared
+  `artisanpackStates` but not `artisanpackResponsive`, so
+  per-breakpoint padding / margin writes had no `responsive` storage
+  key to persist into and applied globally. Added
+  `supports.artisanpackResponsive.attributes: ["spacing", "dimensions"]`
+  in `resources/js/visual-editor/blocks/button/block.json`, matching the
+  convention on the `buttons`, `columns`, `group`, and `column` blocks.
+
 ## [1.5.3] - 2026-07-27
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "artisanpack-ui/visual-editor",
   "description": "A Gutenberg-powered visual editor for Laravel — post editor, site editor, and Blade/React/Vue block renderers.",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "type": "library",
   "license": "GPL-3.0-or-later",
   "autoload": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@artisanpack-ui/visual-editor",
-    "version": "1.5.3",
+    "version": "1.5.4",
     "private": true,
     "type": "module",
     "exports": {

--- a/resources/js/visual-editor/blocks/button/block.json
+++ b/resources/js/visual-editor/blocks/button/block.json
@@ -169,6 +169,12 @@
                 "dimensions.transform",
                 "transition"
             ]
+        },
+        "artisanpackResponsive": {
+            "attributes": [
+                "spacing",
+                "dimensions"
+            ]
         }
     },
     "styles": [

--- a/resources/js/visual-editor/site-editor/__tests__/block-editor-boundary.test.tsx
+++ b/resources/js/visual-editor/site-editor/__tests__/block-editor-boundary.test.tsx
@@ -66,6 +66,24 @@ vi.mock('../../editor/convert-to-pattern-control', () => ({
     ConvertToPatternControl: (): null => CONVERT_TO_PATTERN_CONTROL_MOCK(),
 }));
 
+// The boundary mounts StateWriteInterceptor + StateInspectorSync so
+// panel writes route through the state bag the same way the post
+// editor's provider does. Their real implementations transitively pull
+// in `@wordpress/blocks`, which trips a JSON-import-attribute error
+// under jsdom — stub them as no-ops so this structural test stays
+// green.
+vi.mock('../../states/state-write-interceptor', () => ({
+    StateWriteInterceptor: (): JSX.Element => (
+        <div data-testid="ap-stub-state-write-interceptor" />
+    ),
+}));
+
+vi.mock('../../states/StateInspectorSync', () => ({
+    StateInspectorSync: (): JSX.Element => (
+        <div data-testid="ap-stub-state-inspector-sync" />
+    ),
+}));
+
 import { BlockEditorBoundary } from '../block-editor-boundary';
 import { DEFAULT_CANVAS_STYLES } from '../../editor-settings';
 import { resetThemeGlobalStylesCssCache } from '../use-theme-global-styles-css';
@@ -92,6 +110,33 @@ describe('BlockEditorBoundary', () => {
         const provider = providers[0]!;
         expect(within(provider).getByTestId('canvas-slot')).toBeInTheDocument();
         expect(within(provider).getByTestId('inspector-slot')).toBeInTheDocument();
+    });
+
+    it('mounts StateWriteInterceptor and StateInspectorSync inside the shared provider (#700)', () => {
+        // Regression for the site-editor per-size/per-state scoping bug:
+        // WordPress's apiVersion-3 color/border/shadow panels dispatch
+        // `updateBlockAttributes` directly, so writes only route through
+        // the state bag if these two components render inside the same
+        // BlockEditorProvider as the canvas. When #436 hoisted the
+        // provider they were left behind, and every scoped write leaked
+        // to the base attribute.
+        render(
+            <BlockEditorBoundary
+                blocks={[]}
+                onChange={() => undefined}
+                onInput={() => undefined}
+            >
+                <div data-testid="canvas-slot" />
+            </BlockEditorBoundary>
+        );
+
+        const provider = screen.getByTestId('ap-stub-block-editor-provider');
+        expect(
+            within(provider).getByTestId('ap-stub-state-write-interceptor')
+        ).toBeInTheDocument();
+        expect(
+            within(provider).getByTestId('ap-stub-state-inspector-sync')
+        ).toBeInTheDocument();
     });
 
     it('omits the convert-to-pattern control when no apiBase is given', () => {

--- a/resources/js/visual-editor/site-editor/__tests__/site-editor-app.test.tsx
+++ b/resources/js/visual-editor/site-editor/__tests__/site-editor-app.test.tsx
@@ -221,6 +221,30 @@ vi.mock('../../positioning/register', () => ({
     registerPositioning: (): void => undefined,
 }));
 
+// #700: the responsive + state registrars pull in `@wordpress/blocks`
+// through their BlockEdit HOCs — same JSON-import-attribute trip under
+// jsdom. The shell tests don't exercise per-breakpoint or per-state
+// panel wiring; the pipeline is covered by its own unit tests.
+vi.mock('../../responsive/register-attribute', () => ({
+    registerResponsiveAttribute: (): void => undefined,
+}));
+
+vi.mock('../../responsive/with-responsive-attributes', () => ({
+    registerResponsiveAttributesFilter: (): void => undefined,
+}));
+
+vi.mock('../../states/register-attribute', () => ({
+    registerStateAttribute: (): void => undefined,
+}));
+
+vi.mock('../../states/with-state-attributes', () => ({
+    registerStateAttributesFilter: (): void => undefined,
+}));
+
+vi.mock('../../states/with-state-styles', () => ({
+    registerStateStylesFilters: (): void => undefined,
+}));
+
 import { resetActiveBreakpoint } from '../../responsive/active-breakpoint';
 import { SiteEditorApp } from '../site-editor-app';
 

--- a/resources/js/visual-editor/site-editor/block-editor-boundary.tsx
+++ b/resources/js/visual-editor/site-editor/block-editor-boundary.tsx
@@ -37,6 +37,8 @@ import '@wordpress/format-library';
 import { type ReactNode } from 'react';
 
 import { ConvertToPatternControl } from '../editor/convert-to-pattern-control';
+import { StateInspectorSync } from '../states/StateInspectorSync';
+import { StateWriteInterceptor } from '../states/state-write-interceptor';
 import { useThemedEditorSettings } from '../use-themed-editor-settings';
 
 // Gutenberg editor-surface stylesheets. Previously imported by each
@@ -203,6 +205,8 @@ export function BlockEditorBoundary(props: BlockEditorBoundaryProps): JSX.Elemen
                 onInput={onInput}
             >
                 {children}
+                <StateWriteInterceptor />
+                <StateInspectorSync />
                 <Popover.Slot />
                 {apiBase !== undefined && apiBase !== '' ? (
                     <ConvertToPatternControl apiBase={apiBase} />

--- a/resources/js/visual-editor/site-editor/site-editor-app.tsx
+++ b/resources/js/visual-editor/site-editor/site-editor-app.tsx
@@ -50,6 +50,11 @@ import { registerArtisanPackBlocks } from '../blocks';
 import { registerBoxShadows } from '../box-shadows/register';
 import { registerGradientBorders } from '../gradient-borders/register';
 import { registerPositioning } from '../positioning/register';
+import { registerResponsiveAttribute } from '../responsive/register-attribute';
+import { registerResponsiveAttributesFilter } from '../responsive/with-responsive-attributes';
+import { registerStateAttribute } from '../states/register-attribute';
+import { registerStateAttributesFilter } from '../states/with-state-attributes';
+import { registerStateStylesFilters } from '../states/with-state-styles';
 
 import { BlockLibrarySidebar } from '../editor/block-library-sidebar';
 import { TopBar } from '../editor/top-bar';
@@ -182,6 +187,21 @@ function ensureEditorBoot(): void {
     // `ap.visual-editor.background-controls` filter. Idempotent across
     // the post-editor and site-editor bootstrap paths.
     registerBackgroundControls();
+
+    // #700 — responsive + state feature filters. Must be registered
+    // BEFORE `registerArtisanPackBlocks()` below so opted-in blocks
+    // pick up the auto-injected `responsive` / `states` storage keys
+    // at registration time and the `editor.BlockEdit` HOCs wrap every
+    // edit component on first render. Without these, per-breakpoint
+    // and per-state panel writes leak to the base attribute and apply
+    // to every size / state — the site editor was missing the whole
+    // pipeline (the post editor calls the same functions at
+    // `editor/editor-app.tsx:211-219`).
+    registerResponsiveAttribute();
+    registerResponsiveAttributesFilter();
+    registerStateAttribute();
+    registerStateAttributesFilter();
+    registerStateStylesFilters();
 
     // #490 — gradient border feature filters; same "before
     // registerArtisanPackBlocks" placement as the post-editor so opted-in


### PR DESCRIPTION
## Summary

- Register the 5 responsive + state pipeline functions (`registerResponsiveAttribute`, `registerResponsiveAttributesFilter`, `registerStateAttribute`, `registerStateAttributesFilter`, `registerStateStylesFilters`) in the site-editor bootstrap, mirroring `editor-app.tsx:211-219`. Without them, opted-in blocks never got the auto-injected `responsive` / `states` storage keys, the `editor.BlockEdit` HOCs never wrapped `setAttributes`, and the per-state `<style>` scope class was never emitted — every panel write landed on the base attribute.
- Mount `<StateWriteInterceptor />` and `<StateInspectorSync />` inside the shared `BlockEditorProvider` in `site-editor/block-editor-boundary.tsx`. These route apiVersion-3 color/border/shadow panel writes (which dispatch `updateBlockAttributes` directly and bypass the HOC chain) into the state bag. They were dropped when the provider was hoisted in #436.
- Opt the singular `artisanpack/button` block into `artisanpackResponsive` with `["spacing", "dimensions"]`, matching the convention on `column`, `group`, `columns`, `buttons`. Without this, per-breakpoint padding writes on a single button had no `responsive` storage key to persist into.
- Bump to 1.5.4.

## Test plan

- [x] `npx vitest run resources/js/visual-editor/states resources/js/visual-editor/responsive` — 169 tests pass.
- [x] `npx vitest run resources/js/visual-editor/blocks/button` — 43 tests pass.
- [x] `npx vitest run resources/js/visual-editor/site-editor` — 222 pass, 18 pre-existing failures unrelated (site-editor-app localStorage env issue).
- [x] New regression test in `block-editor-boundary.test.tsx` asserts both interceptors mount inside the shared provider.
- [x] Manual: hard-reload site editor, change background on Hover state — reverts on switch back to Idle. Change padding at Desktop — stays scoped to Desktop and up.

## Out of scope (follow-up)

Code review flagged a parity gap that does not affect this bug: site-editor bootstrap still doesn't call `ensureMediaBridgeFilter`, `disableContrastCheckerOnBlocks`, `registerContrastWarning`, or the animations / visibility / bindings / dynamic-content registrars that the post editor wires. Worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Button blocks now support responsive spacing and dimension settings.
  * Site editor state and responsive styles are applied more consistently across block editing.

* **Bug Fixes**
  * Fixed per-size and per-state style overrides in the site editor.
  * Corrected stateful panel updates so changes are saved to the appropriate responsive and state settings.

* **Chores**
  * Updated the release version to 1.5.4.
  * Added changelog documentation for the fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->