### PR TITLE
Release v1.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,40 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [1.5.4] - 2026-07-28
+
+### Fixed
+
+- **Site editor per-size and per-state style overrides now scope
+  correctly (#700).** The site-editor bootstrap in
+  `site-editor/site-editor-app.tsx` never called the five `register*()`
+  functions that wire the responsive + state pipeline —
+  `registerResponsiveAttribute`, `registerResponsiveAttributesFilter`,
+  `registerStateAttribute`, `registerStateAttributesFilter`, and
+  `registerStateStylesFilters` — so opted-in blocks never got the
+  auto-injected `responsive` / `states` storage keys, the
+  `editor.BlockEdit` HOCs never wrapped `setAttributes` to route writes
+  into `responsive.<bp>.<path>` or `states.<path>.<activeState>`, and
+  the per-state `<style>` scope class was never injected into the
+  canvas. Every panel write landed on the base attribute, so a change
+  on Hover state or Desktop viewport applied to every state / screen
+  size. All five functions are now registered before
+  `registerArtisanPackBlocks()`, mirroring
+  `editor/editor-app.tsx:211-219`. The shared `BlockEditorProvider` in
+  `site-editor/block-editor-boundary.tsx` also mounts
+  `<StateWriteInterceptor />` and `<StateInspectorSync />` (missed when
+  the provider was hoisted in #436) so apiVersion-3 color / border /
+  shadow panels, which dispatch `updateBlockAttributes` directly and
+  bypass the HOC chain, still route through the state bag.
+- **Button block now opts into responsive spacing / dimensions
+  (#700).** The singular `artisanpack/button` block declared
+  `artisanpackStates` but not `artisanpackResponsive`, so
+  per-breakpoint padding / margin writes had no `responsive` storage
+  key to persist into and applied globally. Added
+  `supports.artisanpackResponsive.attributes: ["spacing", "dimensions"]`
+  in `resources/js/visual-editor/blocks/button/block.json`, matching the
+  convention on the `buttons`, `columns`, `group`, and `column` blocks.
+
 ## [1.5.3] - 2026-07-27
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "artisanpack-ui/visual-editor",
   "description": "A Gutenberg-powered visual editor for Laravel — post editor, site editor, and Blade/React/Vue block renderers.",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "type": "library",
   "license": "GPL-3.0-or-later",
   "autoload": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@artisanpack-ui/visual-editor",
-    "version": "1.5.3",
+    "version": "1.5.4",
     "private": true,
     "type": "module",
     "exports": {

--- a/resources/js/visual-editor/blocks/button/block.json
+++ b/resources/js/visual-editor/blocks/button/block.json
@@ -169,6 +169,12 @@
                 "dimensions.transform",
                 "transition"
             ]
+        },
+        "artisanpackResponsive": {
+            "attributes": [
+                "spacing",
+                "dimensions"
+            ]
         }
     },
     "styles": [

--- a/resources/js/visual-editor/site-editor/__tests__/block-editor-boundary.test.tsx
+++ b/resources/js/visual-editor/site-editor/__tests__/block-editor-boundary.test.tsx
@@ -66,6 +66,24 @@ vi.mock('../../editor/convert-to-pattern-control', () => ({
     ConvertToPatternControl: (): null => CONVERT_TO_PATTERN_CONTROL_MOCK(),
 }));
 
+// The boundary mounts StateWriteInterceptor + StateInspectorSync so
+// panel writes route through the state bag the same way the post
+// editor's provider does. Their real implementations transitively pull
+// in `@wordpress/blocks`, which trips a JSON-import-attribute error
+// under jsdom — stub them as no-ops so this structural test stays
+// green.
+vi.mock('../../states/state-write-interceptor', () => ({
+    StateWriteInterceptor: (): JSX.Element => (
+        <div data-testid="ap-stub-state-write-interceptor" />
+    ),
+}));
+
+vi.mock('../../states/StateInspectorSync', () => ({
+    StateInspectorSync: (): JSX.Element => (
+        <div data-testid="ap-stub-state-inspector-sync" />
+    ),
+}));
+
 import { BlockEditorBoundary } from '../block-editor-boundary';
 import { DEFAULT_CANVAS_STYLES } from '../../editor-settings';
 import { resetThemeGlobalStylesCssCache } from '../use-theme-global-styles-css';
@@ -92,6 +110,33 @@ describe('BlockEditorBoundary', () => {
         const provider = providers[0]!;
         expect(within(provider).getByTestId('canvas-slot')).toBeInTheDocument();
         expect(within(provider).getByTestId('inspector-slot')).toBeInTheDocument();
+    });
+
+    it('mounts StateWriteInterceptor and StateInspectorSync inside the shared provider (#700)', () => {
+        // Regression for the site-editor per-size/per-state scoping bug:
+        // WordPress's apiVersion-3 color/border/shadow panels dispatch
+        // `updateBlockAttributes` directly, so writes only route through
+        // the state bag if these two components render inside the same
+        // BlockEditorProvider as the canvas. When #436 hoisted the
+        // provider they were left behind, and every scoped write leaked
+        // to the base attribute.
+        render(
+            <BlockEditorBoundary
+                blocks={[]}
+                onChange={() => undefined}
+                onInput={() => undefined}
+            >
+                <div data-testid="canvas-slot" />
+            </BlockEditorBoundary>
+        );
+
+        const provider = screen.getByTestId('ap-stub-block-editor-provider');
+        expect(
+            within(provider).getByTestId('ap-stub-state-write-interceptor')
+        ).toBeInTheDocument();
+        expect(
+            within(provider).getByTestId('ap-stub-state-inspector-sync')
+        ).toBeInTheDocument();
     });
 
     it('omits the convert-to-pattern control when no apiBase is given', () => {

--- a/resources/js/visual-editor/site-editor/__tests__/site-editor-app.test.tsx
+++ b/resources/js/visual-editor/site-editor/__tests__/site-editor-app.test.tsx
@@ -221,6 +221,30 @@ vi.mock('../../positioning/register', () => ({
     registerPositioning: (): void => undefined,
 }));
 
+// #700: the responsive + state registrars pull in `@wordpress/blocks`
+// through their BlockEdit HOCs — same JSON-import-attribute trip under
+// jsdom. The shell tests don't exercise per-breakpoint or per-state
+// panel wiring; the pipeline is covered by its own unit tests.
+vi.mock('../../responsive/register-attribute', () => ({
+    registerResponsiveAttribute: (): void => undefined,
+}));
+
+vi.mock('../../responsive/with-responsive-attributes', () => ({
+    registerResponsiveAttributesFilter: (): void => undefined,
+}));
+
+vi.mock('../../states/register-attribute', () => ({
+    registerStateAttribute: (): void => undefined,
+}));
+
+vi.mock('../../states/with-state-attributes', () => ({
+    registerStateAttributesFilter: (): void => undefined,
+}));
+
+vi.mock('../../states/with-state-styles', () => ({
+    registerStateStylesFilters: (): void => undefined,
+}));
+
 import { resetActiveBreakpoint } from '../../responsive/active-breakpoint';
 import { SiteEditorApp } from '../site-editor-app';
 

--- a/resources/js/visual-editor/site-editor/block-editor-boundary.tsx
+++ b/resources/js/visual-editor/site-editor/block-editor-boundary.tsx
@@ -37,6 +37,8 @@ import '@wordpress/format-library';
 import { type ReactNode } from 'react';
 
 import { ConvertToPatternControl } from '../editor/convert-to-pattern-control';
+import { StateInspectorSync } from '../states/StateInspectorSync';
+import { StateWriteInterceptor } from '../states/state-write-interceptor';
 import { useThemedEditorSettings } from '../use-themed-editor-settings';
 
 // Gutenberg editor-surface stylesheets. Previously imported by each
@@ -203,6 +205,8 @@ export function BlockEditorBoundary(props: BlockEditorBoundaryProps): JSX.Elemen
                 onInput={onInput}
             >
                 {children}
+                <StateWriteInterceptor />
+                <StateInspectorSync />
                 <Popover.Slot />
                 {apiBase !== undefined && apiBase !== '' ? (
                     <ConvertToPatternControl apiBase={apiBase} />

--- a/resources/js/visual-editor/site-editor/site-editor-app.tsx
+++ b/resources/js/visual-editor/site-editor/site-editor-app.tsx
@@ -50,6 +50,11 @@ import { registerArtisanPackBlocks } from '../blocks';
 import { registerBoxShadows } from '../box-shadows/register';
 import { registerGradientBorders } from '../gradient-borders/register';
 import { registerPositioning } from '../positioning/register';
+import { registerResponsiveAttribute } from '../responsive/register-attribute';
+import { registerResponsiveAttributesFilter } from '../responsive/with-responsive-attributes';
+import { registerStateAttribute } from '../states/register-attribute';
+import { registerStateAttributesFilter } from '../states/with-state-attributes';
+import { registerStateStylesFilters } from '../states/with-state-styles';
 
 import { BlockLibrarySidebar } from '../editor/block-library-sidebar';
 import { TopBar } from '../editor/top-bar';
@@ -182,6 +187,21 @@ function ensureEditorBoot(): void {
     // `ap.visual-editor.background-controls` filter. Idempotent across
     // the post-editor and site-editor bootstrap paths.
     registerBackgroundControls();
+
+    // #700 — responsive + state feature filters. Must be registered
+    // BEFORE `registerArtisanPackBlocks()` below so opted-in blocks
+    // pick up the auto-injected `responsive` / `states` storage keys
+    // at registration time and the `editor.BlockEdit` HOCs wrap every
+    // edit component on first render. Without these, per-breakpoint
+    // and per-state panel writes leak to the base attribute and apply
+    // to every size / state — the site editor was missing the whole
+    // pipeline (the post editor calls the same functions at
+    // `editor/editor-app.tsx:211-219`).
+    registerResponsiveAttribute();
+    registerResponsiveAttributesFilter();
+    registerStateAttribute();
+    registerStateAttributesFilter();
+    registerStateStylesFilters();
 
     // #490 — gradient border feature filters; same "before
     // registerArtisanPackBlocks" placement as the post-editor so opted-in


### PR DESCRIPTION
## Release Information

- **Release Version:** v1.5.4
- **Release Date:** 2026-07-28
- **Release Type:** Patch
- **Release Branch:** `release/1.x`
- **Target Branch:** `main`

## Release Summary

Site-editor per-size and per-state style-override scoping fix. Changes on Hover state or a non-default viewport (Desktop, Tablet, etc.) were leaking into every state / screen size because the site-editor bootstrap never wired the responsive + state pipeline that the post editor has always wired. The shared `BlockEditorProvider` (hoisted in #436) also missed the two interceptor components that route apiVersion-3 color / border / shadow panel writes into the state bag, and the singular `artisanpack/button` block was never opted into `artisanpackResponsive`.

## Changelog

### Added
- (none)

### Changed
- (none)

### Deprecated
- (none)

### Removed
- (none)

### Fixed
- **Site editor per-size and per-state style overrides now scope correctly (#700).** Registered the 5 responsive + state functions (`registerResponsiveAttribute`, `registerResponsiveAttributesFilter`, `registerStateAttribute`, `registerStateAttributesFilter`, `registerStateStylesFilters`) in `site-editor/site-editor-app.tsx` before `registerArtisanPackBlocks()`, mirroring `editor/editor-app.tsx:211-219`. Mounted `<StateWriteInterceptor />` and `<StateInspectorSync />` in the shared `BlockEditorProvider` at `site-editor/block-editor-boundary.tsx`. Opted the `artisanpack/button` block into `artisanpackResponsive.attributes: ["spacing", "dimensions"]`.

### Security
- (none)

## Issues and Pull Requests

**Issues Fixed:**
- Closes #700

**Related PRs:**
- #686 — fix: scope site-editor per-size and per-state style overrides (#700)

## Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes documented below

## Testing Checklist

- [x] All automated tests passing (vitest: 222 site-editor tests + 169 state/responsive tests + 43 button tests pass; the 18 pre-existing `site-editor-app.test.tsx` failures are an unrelated `localStorage --localstorage-file` env issue, baseline unchanged)
- [x] Manual testing completed (site editor: Hover state change reverts on switch back to Idle; Desktop-up padding change stays scoped to Desktop and up)
- [ ] Accessibility tests passing (n/a — internal wiring)
- [ ] Performance tests passing (n/a)
- [x] Security scan completed (dedicated security review — no findings; changes are internal filter registrations, React components, and static block metadata with no user-input surface)
- [ ] Tested in staging environment (n/a — package release)
- [ ] Database migrations tested (n/a)

**Testing notes:** Hard-reload is required after upgrading in a running site editor — the bootstrap `ensureEditorBoot()` guard means HMR alone won't re-run the new registrations.

## Documentation Checklist

- [x] CHANGELOG updated (`[1.5.4] - 2026-07-28` entry)
- [ ] README updated (n/a)
- [ ] API documentation updated (n/a — no consumer-facing API change)
- [ ] Migration guide written (no breaking changes)
- [x] Release notes written (CHANGELOG entry doubles as release notes)

## Follow-up

Code review flagged a site-editor / post-editor parity gap that does NOT affect this bug but is worth its own issue: site-editor bootstrap still doesn't call `ensureMediaBridgeFilter`, `disableContrastCheckerOnBlocks`, `registerContrastWarning`, or the animations / visibility / bindings / dynamic-content registrars. Not blocking this release.

**Release-cutting workflow:** After merging this PR, run `gh workflow run release.yml -f version=1.5.4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)