### PR TITLE
Release v1.5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,93 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [1.5.5] - 2026-08-02
+
+### Added
+
+- **`BlockMarkupHydrator`** (`Support`) — the supported server-side path
+  from a raw WP block-markup string (a block theme's `templates/*.html`
+  or `parts/*.html`, a `.php` pattern, a persisted `post_content`) to the
+  editor-shape tree the renderers consume. `hydrate( string $markup )`
+  parses the delimiters via cms-framework's `BlockMarkupParser` — resolved
+  by name, so cms-framework stays a non-dependency and the method degrades
+  to an empty tree when it is absent — while `hydrateTree( array $parsed )`
+  takes an already-parsed tree and keeps working either way.
+  `canParseMarkup()` lets hosts that would rather fail loudly gate on
+  parser availability. Carries a `MAX_DEPTH` recursion cap (128, above the
+  parser's own 64) so a hand-built or imported payload cannot blow the PHP
+  stack, and falls back across the `core/` ↔ `artisanpack/` namespace pair
+  so theme files written against WP core's block names resolve against the
+  forks this package registers.
+- **`BlockAttributeSourceResolver`** (`Support`) — server-side port of
+  Gutenberg's save-shape attribute matchers over `DOMDocument` + XPath,
+  covering `attribute`/`property`, `html` (including `multiline`),
+  `rich-text`, `text`, `tag`, `query`, and `raw`. Recovery is driven
+  entirely by the block-type registry's `block.json` definitions rather
+  than a hand-maintained per-block table, so a block that ships a new
+  sourced attribute is picked up with no change here.
+- **`CssSelectorToXPath`** (`Support`) — hand-rolled translator for the
+  narrow CSS subset `block.json` `selector` fields actually use (tag,
+  class, id, attribute presence/equality, `:not()` over a single simple
+  predicate, descendant and child combinators, comma groups), so the
+  package gains no new Composer dependency for this. Selectors outside the
+  subset throw `UnsupportedSelectorException`, which callers degrade to
+  "attribute not recovered" and report once per process rather than
+  silently matching the wrong node.
+- **`BlockRenderer::renderMarkup( string $markup, ?string $defaultTheme )`**
+  (`visual-editor-renderer-blade`) — markup in, HTML out. Hydrates, then
+  inlines `template-part` and synced-pattern references before the walk,
+  so a standalone theme template renders its parts as real content rather
+  than empty wrappers. Blocks that need an entity in scope (`post-*`,
+  `core/query`, comments, breadcrumbs) still require the full
+  `<x-ve-blocks :tree="…" :post="…" />` pipeline.
+
+### Fixed
+
+- **Block-theme markup no longer renders textless server-side (#688).**
+  There was no path from WP-serialized block markup to rendered HTML
+  outside the editor, and the gap was not merely a shape mismatch between
+  cms-framework's `{blockName, attrs, innerHTML}` and the editor's
+  `{name, attributes}`. Gutenberg persists most block text in the **saved
+  HTML**, not in the delimiter JSON — zero of the `artisanpack-ui` theme's
+  130 paragraph/heading blocks serialize a `content` attribute — so a
+  key-rename conversion produced a structurally-correct but completely
+  textless page. Hydration now replays each registered block type's
+  attribute definitions back over the saved HTML, recovering paragraph and
+  heading `content`, button text and href, image `src`/`alt`/`caption`,
+  list values, quote and citation, table cells, and everything else
+  declared with a `source`.
+- **`.html`-sourced template parts now inline with content (#688).**
+  `TemplatePartInliner` resolved a block theme's `parts/header.html` to an
+  entity with `blocks` empty and the raw markup in `rawContent` —
+  cms-framework's resolver does not parse theme files — so the part
+  inlined as an empty wrapper. The inliner now hydrates that raw markup
+  when `blocks` comes back empty, accepting either `rawContent`
+  (visual-editor's `ResolvedTemplatePart`) or `raw` (cms-framework's
+  `ResolvedEntity`) so it works whichever value object a host's resolver
+  hands back. A theme's own parts render without first being opened and
+  re-saved in the site editor.
+- **`TemplatePartInliner` now honors container overrides of the
+  cms-framework resolver.** `RESOLVER_CLASS` carried a leading backslash,
+  which does not match the key Laravel's container stores
+  `TemplatePartResolver::class` under; `app()` treated it as a distinct
+  binding and silently built a fresh instance, ignoring any host- or
+  test-supplied override.
+
+### Security
+
+- `BlockMarkupHydrator` documents an explicit trust boundary. Recovered
+  `rich-text` / `html` attributes are HTML fragments and block partials
+  emit them unescaped (`{!! $content !!}`) — that is what makes a
+  paragraph's `<strong>` survive the round trip. Hydration is therefore
+  only safe over markup you already trust to render: theme files on disk,
+  patterns, and editor-authored content that passed the post editor's
+  authorization. It is **not** a sanitizer, and passing visitor-submitted
+  markup to `hydrate()` turns it into stored XSS. This is the same
+  boundary Gutenberg draws around block markup — neither widened nor
+  narrowed. Hosts rendering untrusted markup should run it through their
+  own sanitizer (e.g. `kses()` from `artisanpack-ui/security`) first.
+
 ## [1.5.4] - 2026-07-28
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "artisanpack-ui/visual-editor",
   "description": "A Gutenberg-powered visual editor for Laravel — post editor, site editor, and Blade/React/Vue block renderers.",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "type": "library",
   "license": "GPL-3.0-or-later",
   "autoload": {

--- a/docs/home.md
+++ b/docs/home.md
@@ -175,4 +175,4 @@ For issues, feature requests, and contributions:
 
 ---
 
-*This documentation covers visual-editor v1.5.3*
+*This documentation covers visual-editor v1.5.5*

--- a/docs/renderers.md
+++ b/docs/renderers.md
@@ -59,6 +59,73 @@ For full-template rendering (with template-part resolution and the
 the fallback chain (theme file → user override → custom), and inlines
 template parts. See [Templates](site-editor/Templates.md) for hierarchy details.
 
+### Rendering raw block markup
+
+*Since v1.5.5 (#688).*
+
+`<x-ve-blocks>` and `<x-ve-template>` both start from a block **tree**. When
+what you have is a raw WP block-markup **string** — a block theme's
+`templates/*.html` or `parts/*.html`, a `.php` pattern, a persisted
+`post_content` column — use `renderMarkup()`:
+
+```php
+use ArtisanPackUI\VisualEditorRendererBlade\BlockRenderer;
+
+$html = app(BlockRenderer::class)->renderMarkup(
+    file_get_contents($theme->path('templates/home.html')),
+    defaultTheme: 'artisanpack-ui',
+);
+```
+
+Markup in, HTML out. The call hydrates the markup into a tree, then inlines
+`template-part` and synced-pattern references before walking it — so a
+standalone theme template renders its parts as real content rather than
+empty wrappers.
+
+The hydration step matters more than it looks. Gutenberg persists most block
+text in the **saved HTML**, not in the delimiter JSON, so a naive
+`{blockName, attrs}` → `{name, attributes}` key-rename yields a
+structurally-correct but completely textless page. Hydration replays each
+registered block type's `block.json` attribute definitions back over the
+saved HTML to recover paragraph and heading `content`, button text and href,
+image `src`/`alt`/`caption`, list values, table cells, and everything else
+declared with a `source`. Recovery is registry-driven, so a block that ships
+a new sourced attribute is picked up with no extra wiring.
+
+To hydrate without rendering — when you need the tree itself, or want to
+pass a `$post` for full-fidelity rendering — use the hydrator directly:
+
+```php
+use ArtisanPackUI\VisualEditor\Support\BlockMarkupHydrator;
+
+$tree = app(BlockMarkupHydrator::class)->hydrate($markup);
+```
+
+```blade
+<x-ve-blocks :tree="$tree" :post="$post" />
+```
+
+**Scope.** `renderMarkup()` cannot resolve blocks that need an entity in
+scope — `post-*`, `core/query` loops, comments, breadcrumbs — because a
+string input carries no post. Hydrate to a tree and hand it to
+`<x-ve-blocks :tree="…" :post="…" />` for those.
+
+**Requires cms-framework.** The markup parser lives in
+`artisanpack-ui/cms-framework`. Without it, `renderMarkup()` returns an empty
+string and `hydrate()` returns an empty tree. Gate on
+`BlockMarkupHydrator::canParseMarkup()` if you would rather fail loudly.
+`hydrateTree()`, which takes an already-parsed `parse_blocks()`-shape array,
+works either way.
+
+> **Security.** `$markup` must already be trusted to render. Block partials
+> emit recovered rich-text unescaped — that is what makes a paragraph's
+> `<strong>` survive the round trip — so hydration is safe over theme files,
+> patterns, and editor-authored content that passed the post editor's
+> authorization, and **not** over visitor-submitted markup, which it would
+> turn into stored XSS. It is not a sanitizer. This is the same trust
+> boundary Gutenberg draws around block markup. Run untrusted markup through
+> your own sanitizer (e.g. `kses()` from `artisanpack-ui/security`) first.
+
 ### Registering a custom block renderer
 
 Static blocks: add the partial. Dynamic blocks: register the `DynamicBlock`

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -217,6 +217,38 @@ debugging the production editor.
 
 ---
 
+## 11. Theme templates render empty (or structure without text)
+
+*Fixed in v1.5.5 (#688).*
+
+**Symptom.** A block theme's `templates/*.html` renders as the right boxes
+and wrappers with no words in them, or a `template-part` reference inlines as
+an empty wrapper.
+
+**Cause.** Gutenberg persists most block text in the block's saved HTML, not
+in the delimiter's JSON — across the `artisanpack-ui` theme, zero of its 130
+paragraph/heading blocks serialize a `content` attribute. Converting the
+parser's `{blockName, attrs, innerHTML}` shape to the renderer's
+`{name, attributes}` shape by renaming keys therefore drops every string on
+the page. Separately, cms-framework's `TemplatePartResolver` does not parse
+theme files, so `.html`-sourced parts arrived with `blocks` empty and their
+markup sitting unread in `rawContent`.
+
+**Fix.** Upgrade to v1.5.5 or later, which hydrates markup through
+`BlockMarkupHydrator` — replaying each block type's `block.json` attribute
+definitions back over the saved HTML — and hydrates `.html`-sourced template
+parts from their raw markup when `blocks` comes back empty. If you are
+starting from a markup string rather than a tree, call
+`BlockRenderer::renderMarkup()`; see
+[Rendering raw block markup](renderers.md#rendering-raw-block-markup).
+
+**Still empty after upgrading?** Hydration needs cms-framework's markup
+parser. Check `BlockMarkupHydrator::canParseMarkup()` — when it returns
+`false`, `artisanpack-ui/cms-framework` is not installed and `renderMarkup()`
+returns an empty string by design.
+
+---
+
 ## See also
 
 - [Quick Start](Quick-Start.md)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@artisanpack-ui/visual-editor",
-    "version": "1.5.4",
+    "version": "1.5.5",
     "private": true,
     "type": "module",
     "exports": {

--- a/packages/visual-editor-renderer-blade/src/BlockRenderer.php
+++ b/packages/visual-editor-renderer-blade/src/BlockRenderer.php
@@ -22,8 +22,11 @@ declare( strict_types=1 );
 namespace ArtisanPackUI\VisualEditorRendererBlade;
 
 use ArtisanPackUI\VisualEditor\Registries\DynamicBlockRegistry;
+use ArtisanPackUI\VisualEditor\Resources\PatternInliner;
+use ArtisanPackUI\VisualEditor\Resources\TemplatePartInliner;
 use ArtisanPackUI\VisualEditor\Services\Bindings\BindingContext;
 use ArtisanPackUI\VisualEditor\Services\Bindings\BindingResolver;
+use ArtisanPackUI\VisualEditor\Support\BlockMarkupHydrator;
 use ArtisanPackUI\VisualEditor\Support\BlockShape;
 use ArtisanPackUI\VisualEditor\Visibility\VisibilityContext;
 use ArtisanPackUI\VisualEditor\Visibility\VisibilityDecision;
@@ -245,6 +248,68 @@ class BlockRenderer
 
 			return $tree;
 		}
+	}
+
+	/**
+	 * Render raw WP block markup to an HTML string.
+	 *
+	 * The server-side counterpart to opening a template in the editor:
+	 * markup goes through {@see BlockMarkupHydrator}, which parses the
+	 * delimiters AND recovers each block's saved-shape attributes from
+	 * its inner HTML, then straight into {@see render()}. Without the
+	 * recovery step a block theme's `templates/*.html` renders as
+	 * structurally-correct but completely textless output, because
+	 * Gutenberg persists paragraph/heading text in the saved HTML
+	 * rather than in the delimiter JSON (#688).
+	 *
+	 * Structural resolution runs too: `template-part` and synced-pattern
+	 * references are inlined before the walk, so a template's
+	 * `parts/header.html` and its patterns render as real content rather
+	 * than empty wrappers. Both passes are entity-independent, which is
+	 * what lets them run from a plain string entry point.
+	 *
+	 * SCOPE: what this canNOT do is resolve blocks that need an entity in
+	 * scope — `post-*`, `core/query` loops, comments, breadcrumbs — because
+	 * a `string` input carries no post. For a full-fidelity render, hydrate
+	 * to a tree with {@see BlockMarkupHydrator::hydrate()} and hand it to
+	 * `<x-ve-blocks :tree="$tree" :post="$post" />`, which runs the complete
+	 * pipeline. This method is the standalone-template shortcut.
+	 *
+	 * Returns an empty string when the markup is blank or when
+	 * cms-framework — which owns the markup parser — is not installed.
+	 *
+	 * SECURITY: `$markup` must already be trusted to render. Block
+	 * partials emit recovered rich-text unescaped, so this method is for
+	 * theme files, patterns, and editor-authored content — never for
+	 * visitor-submitted markup. See {@see BlockMarkupHydrator}'s
+	 * "Trust boundary" note.
+	 *
+	 * @since 1.5.5
+	 *
+	 * @param  string   $markup        Raw block markup, e.g. the contents of a theme `templates/*.html` file.
+	 * @param  ?string  $defaultTheme  Theme assumed for `template-part` blocks that omit a `theme` attribute.
+	 */
+	public function renderMarkup( string $markup, ?string $defaultTheme = null ): string
+	{
+		if ( '' === trim( $markup ) ) {
+			return '';
+		}
+
+		try {
+			$tree = app( BlockMarkupHydrator::class )->hydrate( $markup );
+
+			// Mirrors the ordering in `BlocksComponent`: parts first, so
+			// a part that itself references a synced pattern resolves in
+			// the same pass.
+			$tree = app( TemplatePartInliner::class )->inline( $tree, $defaultTheme );
+			$tree = app( PatternInliner::class )->inline( $tree );
+		} catch ( Throwable $e ) {
+			report( $e );
+
+			return '';
+		}
+
+		return $this->render( $tree );
 	}
 
 	/**

--- a/packages/visual-editor-renderer-blade/tests/Feature/RenderMarkupTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Feature/RenderMarkupTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Resolution\ResolvedEntity;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Resolution\TemplatePartResolver;
+use ArtisanPackUI\VisualEditorRendererBlade\BlockRenderer;
+
+/**
+ * #688 — the end-to-end server-side path a block theme depends on:
+ * raw `templates/*.html` markup in, rendered HTML out. Before the
+ * hydrator existed these same inputs produced structurally-correct but
+ * textless output (or, for the verbatim `parse_blocks()` shape, nothing
+ * at all).
+ */
+
+it( 'renders paragraph text that the markup carries only in its saved HTML', function () {
+	$markup = <<<'HTML'
+	<!-- wp:artisanpack/paragraph {"textColor":"text-muted"} -->
+	<p class="has-text-muted-color has-text-color">Supporting subheading.</p>
+	<!-- /wp:artisanpack/paragraph -->
+	HTML;
+
+	$html = app( BlockRenderer::class )->renderMarkup( $markup );
+
+	expect( $html )->toContain( 'Supporting subheading.' );
+	expect( $html )->toContain( 'wp-block-paragraph' );
+} );
+
+it( 'renders a whole theme-style template including nested blocks', function () {
+	$markup = <<<'HTML'
+	<!-- wp:artisanpack/group -->
+	<div class="wp-block-group">
+	<!-- wp:artisanpack/heading {"level":1} --><h1 class="wp-block-heading">Welcome</h1><!-- /wp:artisanpack/heading -->
+	<!-- wp:artisanpack/paragraph --><p>Body copy.</p><!-- /wp:artisanpack/paragraph -->
+	</div>
+	<!-- /wp:artisanpack/group -->
+	HTML;
+
+	$html = app( BlockRenderer::class )->renderMarkup( $markup );
+
+	expect( $html )->toContain( 'Welcome' );
+	expect( $html )->toContain( 'Body copy.' );
+	expect( $html )->toContain( '<h1' );
+} );
+
+it( 'renders core-namespaced theme markup', function () {
+	$html = app( BlockRenderer::class )->renderMarkup(
+		'<!-- wp:paragraph --><p>HELLO</p><!-- /wp:paragraph -->'
+	);
+
+	expect( $html )->toContain( 'HELLO' );
+} );
+
+it( 'returns an empty string for blank markup', function () {
+	expect( app( BlockRenderer::class )->renderMarkup( '' ) )->toBe( '' );
+	expect( app( BlockRenderer::class )->renderMarkup( "  \n " ) )->toBe( '' );
+} );
+
+it( 'inlines template-part references instead of emitting an empty wrapper', function () {
+	// The `.html`-sourced part is the #688 case: it resolves with
+	// `blocks` empty and only its raw markup populated, so without
+	// both halves of the fix wired together this renders as
+	// `<header></header>`.
+	$resolver = new class extends TemplatePartResolver
+	{
+		public function __construct()
+		{
+		}
+
+		public function resolve( string $slug ): ?ResolvedEntity
+		{
+			return new ResolvedEntity(
+				slug: $slug,
+				theme: 'dev-sample',
+				source: 'theme',
+				raw: '<!-- wp:artisanpack/paragraph --><p>Header content</p><!-- /wp:artisanpack/paragraph -->',
+				blocks: [],
+				title: 'Header',
+				description: '',
+				status: 'publish',
+				hasThemeFile: true,
+				isCustom: false,
+				area: 'header',
+				model: null,
+			);
+		}
+	};
+
+	app()->instance( TemplatePartResolver::class, $resolver );
+
+	$html = app( BlockRenderer::class )->renderMarkup(
+		'<!-- wp:template-part {"slug":"header","tagName":"header"} /-->',
+		'dev-sample',
+	);
+
+	expect( $html )->toContain( 'Header content' );
+} );
+
+it( 'still renders an editor-shape tree passed straight to render()', function () {
+	$html = app( BlockRenderer::class )->render( [
+		[ 'name' => 'artisanpack/paragraph', 'attributes' => [ 'content' => 'HELLO' ], 'innerBlocks' => [] ],
+	] );
+
+	expect( $html )->toContain( 'HELLO' );
+} );

--- a/packages/visual-editor-renderer-blade/tests/Feature/RenderMarkupTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Feature/RenderMarkupTest.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 
 use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Resolution\ResolvedEntity;
 use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Resolution\TemplatePartResolver;
+use ArtisanPackUI\VisualEditor\Support\BlockMarkupHydrator;
 use ArtisanPackUI\VisualEditorRendererBlade\BlockRenderer;
 
 /**
@@ -25,7 +26,7 @@ it( 'renders paragraph text that the markup carries only in its saved HTML', fun
 
 	expect( $html )->toContain( 'Supporting subheading.' );
 	expect( $html )->toContain( 'wp-block-paragraph' );
-} );
+} )->skip( fn () => ! BlockMarkupHydrator::canParseMarkup(), 'requires cms-framework 2.5+ (PHP 8.3+) for BlockMarkupParser' );
 
 it( 'renders a whole theme-style template including nested blocks', function () {
 	$markup = <<<'HTML'
@@ -42,7 +43,7 @@ it( 'renders a whole theme-style template including nested blocks', function () 
 	expect( $html )->toContain( 'Welcome' );
 	expect( $html )->toContain( 'Body copy.' );
 	expect( $html )->toContain( '<h1' );
-} );
+} )->skip( fn () => ! BlockMarkupHydrator::canParseMarkup(), 'requires cms-framework 2.5+ (PHP 8.3+) for BlockMarkupParser' );
 
 it( 'renders core-namespaced theme markup', function () {
 	$html = app( BlockRenderer::class )->renderMarkup(
@@ -50,7 +51,7 @@ it( 'renders core-namespaced theme markup', function () {
 	);
 
 	expect( $html )->toContain( 'HELLO' );
-} );
+} )->skip( fn () => ! BlockMarkupHydrator::canParseMarkup(), 'requires cms-framework 2.5+ (PHP 8.3+) for BlockMarkupParser' );
 
 it( 'returns an empty string for blank markup', function () {
 	expect( app( BlockRenderer::class )->renderMarkup( '' ) )->toBe( '' );
@@ -95,7 +96,7 @@ it( 'inlines template-part references instead of emitting an empty wrapper', fun
 	);
 
 	expect( $html )->toContain( 'Header content' );
-} );
+} )->skip( fn () => ! BlockMarkupHydrator::canParseMarkup(), 'requires cms-framework 2.5+ (PHP 8.3+) for BlockMarkupParser' );
 
 it( 'still renders an editor-shape tree passed straight to render()', function () {
 	$html = app( BlockRenderer::class )->render( [

--- a/src/Resources/TemplatePartInliner.php
+++ b/src/Resources/TemplatePartInliner.php
@@ -28,6 +28,8 @@ declare( strict_types=1 );
 
 namespace ArtisanPackUI\VisualEditor\Resources;
 
+use ArtisanPackUI\VisualEditor\Support\BlockMarkupHydrator;
+
 class TemplatePartInliner
 {
 	/**
@@ -175,8 +177,13 @@ class TemplatePartInliner
 	 * cms-framework's TemplatePartResolver class. Lookups go through it
 	 * when the package is installed; without cms-framework no part
 	 * resolves (Phase H install gate is the user-facing surface).
+	 *
+	 * Written without a leading backslash so it matches the key Laravel's
+	 * container stores `TemplatePartResolver::class` under — with one,
+	 * `app()` treats it as a distinct binding and silently builds a fresh
+	 * instance, ignoring any host- or test-supplied override.
 	 */
-	protected const RESOLVER_CLASS = '\\ArtisanPackUI\\CMSFramework\\Modules\\SiteEditor\\Resolution\\TemplatePartResolver';
+	protected const RESOLVER_CLASS = 'ArtisanPackUI\\CMSFramework\\Modules\\SiteEditor\\Resolution\\TemplatePartResolver';
 
 	/**
 	 * Looks the part up via cms-framework's resolver. Returns the part's
@@ -207,6 +214,30 @@ class TemplatePartInliner
 		}
 
 		$blocks = $resolved->blocks ?? null;
+
+		if ( is_array( $blocks ) && [] !== $blocks ) {
+			return $blocks;
+		}
+
+		// #688 — `.html`-sourced parts (a block theme's `parts/header.html`)
+		// reach us with `blocks` empty but `rawContent` populated:
+		// cms-framework's resolver doesn't parse theme files. Left as-is,
+		// the part inlines as an empty wrapper. Hydrate the raw markup
+		// so a theme's own parts render without first being opened and
+		// re-saved in the site editor.
+		// cms-framework's `ResolvedEntity` names the field `raw`;
+		// visual-editor's own `ResolvedTemplatePart` names it
+		// `rawContent`. Accept either so the fallback works whichever
+		// value object a host's resolver hands back.
+		$raw = $resolved->rawContent ?? $resolved->raw ?? null;
+
+		if ( is_string( $raw ) && '' !== trim( $raw ) ) {
+			$hydrated = app( BlockMarkupHydrator::class )->hydrate( $raw );
+
+			if ( [] !== $hydrated ) {
+				return $hydrated;
+			}
+		}
 
 		return is_array( $blocks ) ? $blocks : null;
 	}

--- a/src/Support/BlockAttributeSourceResolver.php
+++ b/src/Support/BlockAttributeSourceResolver.php
@@ -1,0 +1,449 @@
+<?php
+
+/**
+ * Server-side port of Gutenberg's save-shape attribute matchers.
+ *
+ * Gutenberg persists most block text NOT in the delimiter's JSON but in
+ * the block's saved HTML, recovering it on load by running each
+ * `block.json` attribute definition's `source` matcher over the block's
+ * `innerHTML`. Everything server-side that starts from block markup
+ * (theme `templates/*.html`, `parts/*.html`, `.php` patterns) therefore
+ * needs the same recovery pass or it renders structurally-correct but
+ * textless output — see #688.
+ *
+ * This class implements the matchers Gutenberg's `parseWithAttributeSchema`
+ * supports over `DOMDocument` + XPath:
+ *
+ * | source       | value                                                        |
+ * |--------------|--------------------------------------------------------------|
+ * | `attribute`  | the named HTML attribute of the first match (boolean → presence) |
+ * | `html`       | the first match's inner HTML (`multiline` → matching children)   |
+ * | `rich-text`  | same as `html`, no multiline handling                            |
+ * | `text`       | the first match's text content                                   |
+ * | `tag`        | the matched element's lowercased tag name                        |
+ * | `query`      | a list, one entry per match, of a nested attribute definition set |
+ * | `raw`        | the block's whole inner HTML                                     |
+ *
+ * A definition with no `selector` matches the context node itself,
+ * mirroring hpq's behavior — which is what makes `query` sub-attributes
+ * like the table block's per-cell `content` resolve against their own
+ * cell rather than the whole table.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.5.5
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Support;
+
+use DOMDocument;
+use DOMElement;
+use DOMNode;
+use DOMXPath;
+use Throwable;
+
+class BlockAttributeSourceResolver
+{
+	/**
+	 * `source` values this resolver knows how to evaluate. Definitions
+	 * carrying anything else (or no `source` at all) are left to the
+	 * delimiter's JSON attributes.
+	 *
+	 * @var array<int, string>
+	 *
+	 * @since 1.5.5
+	 */
+	public const SUPPORTED_SOURCES = [
+		'attribute',
+		'property',
+		'html',
+		'rich-text',
+		'text',
+		'tag',
+		'query',
+		'raw',
+	];
+
+	/**
+	 * Selectors already reported as untranslatable, keyed by selector,
+	 * so the log records each offending manifest once per process
+	 * instead of once per rendered block instance.
+	 *
+	 * @var array<string, true>
+	 *
+	 * @since 1.5.5
+	 */
+	protected static array $reportedSelectors = [];
+
+	/**
+	 * Recover every sourced attribute a block type declares from the
+	 * block's saved inner HTML.
+	 *
+	 * Attributes whose matcher finds nothing are omitted entirely (rather
+	 * than emitted as `null`) so the caller can layer the recovered bag
+	 * UNDER the delimiter's own attributes without a miss blanking a
+	 * value the delimiter did persist.
+	 *
+	 * @since 1.5.5
+	 *
+	 * @param  array<string, mixed>  $definitions  The block type's `attributes` map from `block.json`.
+	 * @param  string                $innerHtml    The block's saved inner HTML.
+	 *
+	 * @return array<string, mixed> Recovered attributes, keyed by attribute name.
+	 */
+	public function recover( array $definitions, string $innerHtml ): array
+	{
+		if ( [] === $definitions || '' === trim( $innerHtml ) ) {
+			return [];
+		}
+
+		$root     = $this->parseFragment( $innerHtml );
+		$document = $root?->ownerDocument;
+
+		if ( null === $root || null === $document ) {
+			return [];
+		}
+
+		$xpath     = new DOMXPath( $document );
+		$recovered = [];
+
+		foreach ( $definitions as $name => $definition ) {
+			if ( ! is_string( $name ) || ! is_array( $definition ) ) {
+				continue;
+			}
+
+			$value = $this->resolve( $definition, $root, $xpath, $innerHtml );
+
+			if ( null !== $value ) {
+				$recovered[ $name ] = $value;
+			}
+		}
+
+		return $recovered;
+	}
+
+	/**
+	 * Evaluate a single attribute definition against a context node.
+	 *
+	 * @since 1.5.5
+	 *
+	 * @param  array<string, mixed>  $definition
+	 * @param  ?string               $contextHtml  Verbatim inner HTML of `$context` when the caller has it.
+	 *                                             Only the `raw` source reads it; omitted callers get a
+	 *                                             re-serialized equivalent, computed lazily so a `query`
+	 *                                             with many matches doesn't serialize each one for nothing.
+	 *
+	 * @return mixed The recovered value, or null when nothing matched.
+	 */
+	protected function resolve( array $definition, DOMNode $context, DOMXPath $xpath, ?string $contextHtml = null ): mixed
+	{
+		$source = $definition['source'] ?? null;
+
+		if ( ! is_string( $source ) || ! in_array( $source, self::SUPPORTED_SOURCES, true ) ) {
+			return null;
+		}
+
+		if ( 'raw' === $source ) {
+			return $this->coerce( $contextHtml ?? $this->innerHtml( $context, null ), $definition );
+		}
+
+		$selector = isset( $definition['selector'] ) && is_string( $definition['selector'] )
+			? trim( $definition['selector'] )
+			: '';
+
+		if ( 'query' === $source ) {
+			return $this->resolveQuery( $definition, $context, $xpath, $selector );
+		}
+
+		$node = '' === $selector ? $context : $this->firstMatch( $xpath, $context, $selector );
+
+		if ( null === $node ) {
+			return null;
+		}
+
+		return $this->resolveScalar( $source, $definition, $node );
+	}
+
+	/**
+	 * Evaluate a non-`query`, non-`raw` source against a resolved node.
+	 *
+	 * @since 1.5.5
+	 *
+	 * @param  array<string, mixed>  $definition
+	 */
+	protected function resolveScalar( string $source, array $definition, DOMNode $node ): mixed
+	{
+		switch ( $source ) {
+			case 'attribute':
+			case 'property':
+				$attribute = isset( $definition['attribute'] ) && is_string( $definition['attribute'] )
+					? $definition['attribute']
+					: null;
+
+				if ( null === $attribute || ! $node instanceof DOMElement ) {
+					return null;
+				}
+
+				// HTML boolean attributes are persisted by presence, not
+				// by value — `<video loop>` and `<video loop="">` both
+				// mean true. Gutenberg models this with
+				// `toBooleanAttributeMatcher`; mirror it here so a
+				// re-parsed `<video controls>` doesn't come back false.
+				if ( 'boolean' === ( $definition['type'] ?? null ) ) {
+					return $node->hasAttribute( $attribute );
+				}
+
+				if ( ! $node->hasAttribute( $attribute ) ) {
+					return null;
+				}
+
+				return $this->coerce( $node->getAttribute( $attribute ), $definition );
+
+			case 'html':
+			case 'rich-text':
+				$multiline = 'html' === $source && isset( $definition['multiline'] ) && is_string( $definition['multiline'] )
+					? strtolower( $definition['multiline'] )
+					: null;
+
+				return $this->coerce( $this->innerHtml( $node, $multiline ), $definition );
+
+			case 'text':
+				return $this->coerce( $node->textContent, $definition );
+
+			case 'tag':
+				return $node instanceof DOMElement ? strtolower( $node->tagName ) : null;
+		}
+
+		return null;
+	}
+
+	/**
+	 * Evaluate a `query` source — one entry per selector match, each
+	 * built by resolving the nested definition map against that match.
+	 *
+	 * @since 1.5.5
+	 *
+	 * @param  array<string, mixed>  $definition
+	 *
+	 * @return array<int, array<string, mixed>>|null
+	 */
+	protected function resolveQuery( array $definition, DOMNode $context, DOMXPath $xpath, string $selector ): ?array
+	{
+		$query = $definition['query'] ?? null;
+
+		if ( ! is_array( $query ) || [] === $query ) {
+			return null;
+		}
+
+		$matches = '' === $selector ? [ $context ] : $this->allMatches( $xpath, $context, $selector );
+
+		if ( null === $matches ) {
+			return null;
+		}
+
+		$items = [];
+
+		foreach ( $matches as $match ) {
+			$item = [];
+
+			foreach ( $query as $name => $subDefinition ) {
+				if ( ! is_string( $name ) || ! is_array( $subDefinition ) ) {
+					continue;
+				}
+
+				$value = $this->resolve( $subDefinition, $match, $xpath );
+
+				if ( null === $value && array_key_exists( 'default', $subDefinition ) ) {
+					$value = $subDefinition['default'];
+				}
+
+				if ( null !== $value ) {
+					$item[ $name ] = $value;
+				}
+			}
+
+			$items[] = $item;
+		}
+
+		return $items;
+	}
+
+	/**
+	 * First node matching `$selector` relative to `$context`, or null
+	 * when the selector matches nothing or is outside the supported
+	 * CSS subset.
+	 *
+	 * @since 1.5.5
+	 */
+	protected function firstMatch( DOMXPath $xpath, DOMNode $context, string $selector ): ?DOMNode
+	{
+		$matches = $this->allMatches( $xpath, $context, $selector );
+
+		return null === $matches ? null : ( $matches[0] ?? null );
+	}
+
+	/**
+	 * All nodes matching `$selector` relative to `$context`, in document
+	 * order. Returns null (rather than an empty list) when the selector
+	 * could not be translated, so callers can tell "no match" from
+	 * "cannot evaluate".
+	 *
+	 * @since 1.5.5
+	 *
+	 * @return array<int, DOMNode>|null
+	 */
+	protected function allMatches( DOMXPath $xpath, DOMNode $context, string $selector ): ?array
+	{
+		try {
+			$expression = CssSelectorToXPath::translate( $selector );
+		} catch ( UnsupportedSelectorException $e ) {
+			// Selectors come from a fixed set of registered `block.json`
+			// manifests, so an unsupported one would otherwise be
+			// reported once per block instance on every page render.
+			// Report the first occurrence per process and stay quiet
+			// after that — the signal is "this manifest needs a
+			// translator update", not "this page had N blocks".
+			if ( ! isset( self::$reportedSelectors[ $selector ] ) ) {
+				self::$reportedSelectors[ $selector ] = true;
+
+				report( $e );
+			}
+
+			return null;
+		}
+
+		// A comma group translates to a union of relative paths. XPath
+		// unions bind looser than the implicit context, so each branch
+		// is already anchored by its own axis — no extra parenthesizing
+		// needed. `false` comes back on a malformed expression, which
+		// the translator's grammar should preclude; treat it as
+		// "cannot evaluate" rather than raising mid-render.
+		$nodes = @$xpath->query( $expression, $context );
+
+		if ( false === $nodes ) {
+			return null;
+		}
+
+		$out = [];
+
+		foreach ( $nodes as $node ) {
+			$out[] = $node;
+		}
+
+		return $out;
+	}
+
+	/**
+	 * Serialize a node's children back to an HTML string.
+	 *
+	 * When `$multilineTag` is set, only child ELEMENTS with that tag
+	 * name are kept and each is serialized in full (outer HTML) —
+	 * matching hpq's multiline `html` matcher, which is what turns a
+	 * saved `<ul><li>a</li><li>b</li></ul>` back into the list block's
+	 * `values` attribute.
+	 *
+	 * @since 1.5.5
+	 */
+	protected function innerHtml( DOMNode $node, ?string $multilineTag ): string
+	{
+		$document = $node->ownerDocument;
+
+		if ( null === $document ) {
+			return '';
+		}
+
+		$html = '';
+
+		foreach ( $node->childNodes as $child ) {
+			if ( null !== $multilineTag ) {
+				if ( ! $child instanceof DOMElement || strtolower( $child->tagName ) !== $multilineTag ) {
+					continue;
+				}
+			}
+
+			$html .= (string) $document->saveHTML( $child );
+		}
+
+		return $html;
+	}
+
+	/**
+	 * Cast a matched string to the type the definition declares.
+	 * Non-castable values fall through unchanged — Gutenberg's `asType`
+	 * is equally permissive, preferring a wrong-typed value over a
+	 * dropped one.
+	 *
+	 * @since 1.5.5
+	 *
+	 * @param  array<string, mixed>  $definition
+	 */
+	protected function coerce( string $value, array $definition ): mixed
+	{
+		$type = $definition['type'] ?? null;
+
+		return match ( $type ) {
+			'boolean' => '' !== $value && 'false' !== $value,
+			'number'  => is_numeric( $value ) ? $value + 0 : null,
+			'integer' => is_numeric( $value ) ? (int) $value : null,
+			default   => $value,
+		};
+	}
+
+	/**
+	 * Parse a block's inner HTML into a DOM subtree and return the
+	 * element the matchers should treat as their context node.
+	 *
+	 * The fragment is wrapped in a synthetic container so a multi-root
+	 * fragment (e.g. a figure plus a trailing caption) still has a
+	 * single context, and so `descendant-or-self::` selectors match the
+	 * fragment's own roots — that's the case that recovers a
+	 * paragraph's `content` from its `<p>` root.
+	 *
+	 * @since 1.5.5
+	 */
+	protected function parseFragment( string $html ): ?DOMNode
+	{
+		$document = new DOMDocument();
+
+		$previous = libxml_use_internal_errors( true );
+
+		try {
+			// The XML declaration forces UTF-8 without libxml's legacy
+			// "no charset means ISO-8859-1" fallback mangling multibyte
+			// text. LIBXML_HTML_NOIMPLIED/NODEFDTD keep libxml from
+			// injecting its own <html>/<body> wrappers around ours.
+			$loaded = $document->loadHTML(
+				'<?xml encoding="UTF-8"?><div id="ve-block-fragment">' . $html . '</div>',
+				LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD | LIBXML_NONET,
+			);
+		} catch ( Throwable $e ) {
+			report( $e );
+
+			return null;
+		} finally {
+			libxml_clear_errors();
+			libxml_use_internal_errors( $previous );
+		}
+
+		if ( false === $loaded ) {
+			return null;
+		}
+
+		$root = $document->getElementById( 've-block-fragment' );
+
+		if ( $root instanceof DOMNode ) {
+			return $root;
+		}
+
+		// `getElementById` needs a DTD-declared id to work on some
+		// libxml builds; fall back to a direct XPath lookup.
+		$found = ( new DOMXPath( $document ) )->query( "//*[@id='ve-block-fragment']" );
+
+		return ( false !== $found && $found->length > 0 ) ? $found->item( 0 ) : null;
+	}
+}

--- a/src/Support/BlockMarkupHydrator.php
+++ b/src/Support/BlockMarkupHydrator.php
@@ -1,0 +1,300 @@
+<?php
+
+/**
+ * WP block markup → renderable block tree.
+ *
+ * The public, supported server-side path from a raw block-markup string
+ * (a block theme's `templates/*.html`, `parts/*.html`, a `.php`
+ * pattern, a persisted `post_content`) to the editor-shape tree
+ * {@see \ArtisanPackUI\VisualEditorRendererBlade\BlockRenderer::render()}
+ * consumes.
+ *
+ * Two shapes are in play and, before #688, nothing bridged them:
+ *
+ * | producer                        | shape                                            | text lives in         |
+ * |---------------------------------|--------------------------------------------------|-----------------------|
+ * | cms-framework `BlockMarkupParser` | `{blockName, attrs, innerBlocks, innerHTML, …}` | `innerHTML`           |
+ * | the editor / `BlockRenderer`     | `{name, attributes, innerBlocks}`                 | `attributes.content`  |
+ *
+ * A key-rename alone is not enough: Gutenberg persists most block text
+ * in the SAVED HTML, not in the delimiter's JSON. Across the
+ * `artisanpack-ui` theme, zero of its 130 paragraph/heading blocks
+ * serialize a `content` attribute — renaming keys produces a
+ * structurally-correct, completely textless page. So this hydrator also
+ * runs each registered block type's `block.json` attribute definitions
+ * back over the saved HTML via {@see BlockAttributeSourceResolver},
+ * recovering paragraph/heading `content`, button text + href, image
+ * `src`/`alt`/`caption`, list values, quote + citation, table cells,
+ * and everything else declared with a `source`.
+ *
+ * The recovery is driven entirely by the registry rather than by a
+ * hand-maintained per-block table, so a block that ships a new sourced
+ * attribute is picked up with no change here — which is the whole
+ * reason this lives beside the block manifests and partials rather than
+ * in cms-framework or a host app.
+ *
+ * Blocks with no registered definition pass through untouched: their
+ * delimiter attributes and inner blocks survive, nothing is recovered.
+ *
+ * ## Trust boundary
+ *
+ * Recovered `rich-text` / `html` attributes are HTML FRAGMENTS, and the
+ * block partials emit them unescaped (`{!! $content !!}`) — that is what
+ * makes a paragraph's `<strong>` survive the round trip. The hydrator is
+ * therefore only safe over markup you already trust to render: theme
+ * files on disk, patterns, and editor-authored content that passed
+ * through the same authorization the post editor enforces. It is NOT a
+ * sanitizer, and passing visitor-submitted markup to {@see hydrate()}
+ * turns it into stored XSS. This is the same trust boundary Gutenberg
+ * itself draws around block markup — the hydrator neither widens nor
+ * narrows it. Hosts that must render untrusted markup should run it
+ * through their own sanitizer (e.g. `kses()` from
+ * `artisanpack-ui/security`) BEFORE hydrating.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.5.5
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Support;
+
+use ArtisanPackUI\VisualEditor\Registries\BlockTypeRegistry;
+use RuntimeException;
+
+class BlockMarkupHydrator
+{
+	/**
+	 * cms-framework's markup parser. Resolved by name so visual-editor
+	 * stays installable without cms-framework — {@see hydrate()} then
+	 * degrades to an empty tree while {@see hydrateTree()}, which takes
+	 * an already-parsed tree, keeps working.
+	 */
+	public const PARSER_CLASS = 'ArtisanPackUI\\CMSFramework\\Modules\\SiteEditor\\Support\\BlockMarkupParser';
+
+	/**
+	 * Hard cap on `innerBlocks` recursion. Markup coming through
+	 * {@see hydrate()} is already bounded by the parser's own depth cap,
+	 * but {@see hydrateTree()} is public and accepts a caller-supplied
+	 * array — a hand-built or imported payload nested thousands deep
+	 * would otherwise blow the PHP stack before the tree ever reaches
+	 * the renderer's own {@see \ArtisanPackUI\VisualEditorRendererBlade\BlockRenderer::MAX_INNER_DEPTH}
+	 * guard. Sits above the parser's 64 so hydration never truncates a
+	 * tree the parser was willing to produce.
+	 *
+	 * @since 1.5.5
+	 */
+	public const MAX_DEPTH = 128;
+
+	/**
+	 * The DOM matcher that recovers save-shape attributes. Constructed
+	 * by default so the hydrator can be `new`-ed with just a registry.
+	 *
+	 * @since 1.5.5
+	 */
+	protected BlockAttributeSourceResolver $sources;
+
+	public function __construct(
+		protected BlockTypeRegistry $blockTypes,
+		?BlockAttributeSourceResolver $sources = null,
+	) {
+		$this->sources = $sources ?? new BlockAttributeSourceResolver();
+	}
+
+	/**
+	 * Whether raw-markup hydration is available in this install — i.e.
+	 * whether cms-framework's parser is on the classpath. Hosts that
+	 * want to fail loudly instead of rendering an empty template can
+	 * gate on this.
+	 *
+	 * @since 1.5.5
+	 */
+	public static function canParseMarkup(): bool
+	{
+		return class_exists( self::PARSER_CLASS );
+	}
+
+	/**
+	 * Turn raw WP block markup into a renderable editor-shape tree.
+	 *
+	 * Returns an empty tree when the markup is blank or cms-framework's
+	 * parser is unavailable.
+	 *
+	 * @since 1.5.5
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	public function hydrate( string $markup ): array
+	{
+		if ( '' === trim( $markup ) || ! self::canParseMarkup() ) {
+			return [];
+		}
+
+		/** @var class-string $parser */
+		$parser = self::PARSER_CLASS;
+
+		return $this->hydrateTree( $parser::parse( $markup ) );
+	}
+
+	/**
+	 * Convert an already-parsed `parse_blocks()`-shape tree into the
+	 * editor shape, recovering sourced attributes as it goes.
+	 *
+	 * Accepts the editor shape too — a tree that already uses
+	 * `{name, attributes}` round-trips, gaining only whatever sourced
+	 * attributes its `innerHTML` still carries. That makes the method
+	 * safe to run over a mixed tree without sniffing shape first.
+	 *
+	 * Freeform siblings (`blockName === null`) are dropped: the renderer
+	 * has no partial for them and they would surface as
+	 * `data-ve-unknown-block` wrappers. Matches what the site editor's
+	 * `TemplateAdapter` already does with theme-file content.
+	 *
+	 * @since 1.5.5
+	 *
+	 * @param  array<int, array<string, mixed>>  $tree
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	public function hydrateTree( array $tree, int $depth = 0 ): array
+	{
+		if ( $depth >= self::MAX_DEPTH ) {
+			report( new RuntimeException( sprintf(
+				'BlockMarkupHydrator depth cap (%d) exceeded — dropping the remaining subtree. Likely a malformed or attacker-crafted block payload.',
+				self::MAX_DEPTH,
+			) ) );
+
+			return [];
+		}
+
+		$out = [];
+
+		foreach ( $tree as $block ) {
+			if ( ! is_array( $block ) ) {
+				continue;
+			}
+
+			$hydrated = $this->hydrateBlock( $block, $depth );
+
+			if ( null !== $hydrated ) {
+				$out[] = $hydrated;
+			}
+		}
+
+		return $out;
+	}
+
+	/**
+	 * @since 1.5.5
+	 *
+	 * @param  array<string, mixed>  $block
+	 *
+	 * @return array<string, mixed>|null Null for blocks that carry no usable name (freeform siblings).
+	 */
+	protected function hydrateBlock( array $block, int $depth = 0 ): ?array
+	{
+		$name = $block['blockName'] ?? $block['name'] ?? null;
+
+		if ( ! is_string( $name ) || '' === trim( $name ) ) {
+			return null;
+		}
+
+		$name = trim( $name );
+
+		[ , $attributes ] = BlockShape::readAttrs( $block );
+
+		$innerHtml = isset( $block['innerHTML'] ) && is_string( $block['innerHTML'] ) ? $block['innerHTML'] : '';
+		$recovered = $this->recoverAttributes( $name, $innerHtml );
+
+		$innerBlocks = isset( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] )
+			? $this->hydrateTree( $block['innerBlocks'], $depth + 1 )
+			: [];
+
+		$hydrated = [
+			'name' => $name,
+			// Delimiter attributes win. Gutenberg lets the sourced value
+			// win outright, but a caller may hand us a tree whose text
+			// already lives in `attributes` (an editor-persisted tree, a
+			// dynamic block's seeded content) alongside a stale or empty
+			// `innerHTML`. Layering recovery UNDERNEATH means this
+			// method can never blank a value that was already there —
+			// it only fills gaps.
+			'attributes'  => array_merge( $recovered, $attributes ),
+			'innerBlocks' => $innerBlocks,
+		];
+
+		// Carry the saved HTML through rather than dropping it. A block
+		// whose content lives ONLY in `innerHTML` and which declares no
+		// sourced attributes — `core/html` being the canonical case —
+		// would otherwise hydrate to a node with nothing in it at all,
+		// silently losing the content. The renderer ignores unknown keys,
+		// so this is inert for every block that did recover attributes,
+		// and it leaves the bytes available to partials and to callers
+		// that reserialize the tree.
+		if ( '' !== $innerHtml ) {
+			$hydrated['innerHTML'] = $innerHtml;
+		}
+
+		return $hydrated;
+	}
+
+	/**
+	 * Recover a block's sourced attributes from its saved inner HTML.
+	 *
+	 * Falls back across the `core/` ↔ `artisanpack/` namespace pair:
+	 * themes on disk write WP core's names (`<!-- wp:paragraph -->` →
+	 * `core/paragraph`) while this package registers the
+	 * `artisanpack/*` forks, and the two share their save shape by
+	 * construction — the forks exist so both namespaces render
+	 * identically.
+	 *
+	 * @since 1.5.5
+	 *
+	 * @return array<string, mixed>
+	 */
+	protected function recoverAttributes( string $name, string $innerHtml ): array
+	{
+		if ( '' === trim( $innerHtml ) ) {
+			return [];
+		}
+
+		$definition = $this->blockTypes->get( $name );
+
+		if ( null === $definition ) {
+			$alias = $this->aliasFor( $name );
+
+			$definition = null !== $alias ? $this->blockTypes->get( $alias ) : null;
+		}
+
+		$attributes = $definition['attributes'] ?? null;
+
+		if ( ! is_array( $attributes ) || [] === $attributes ) {
+			return [];
+		}
+
+		return $this->sources->recover( $attributes, $innerHtml );
+	}
+
+	/**
+	 * Map `core/x` ↔ `artisanpack/x`, or null when the name is in
+	 * neither namespace.
+	 *
+	 * @since 1.5.5
+	 */
+	protected function aliasFor( string $name ): ?string
+	{
+		if ( str_starts_with( $name, 'core/' ) ) {
+			return 'artisanpack/' . substr( $name, strlen( 'core/' ) );
+		}
+
+		if ( str_starts_with( $name, 'artisanpack/' ) ) {
+			return 'core/' . substr( $name, strlen( 'artisanpack/' ) );
+		}
+
+		return null;
+	}
+}

--- a/src/Support/CssSelectorToXPath.php
+++ b/src/Support/CssSelectorToXPath.php
@@ -1,0 +1,275 @@
+<?php
+
+/**
+ * Minimal CSS-selector → XPath translator.
+ *
+ * Covers exactly the selector grammar that Gutenberg `block.json`
+ * attribute definitions use in their `selector` field — nothing more.
+ * Written by hand rather than pulled from `symfony/css-selector` so the
+ * package gains no new runtime dependency for a feature this narrow
+ * (the selectors shipped across all 105 bundled manifests are tag
+ * names, class names, attribute presence/equality, `:not()` over a
+ * single simple predicate, descendant and child combinators, and comma
+ * groups).
+ *
+ * Supported grammar, per comma-separated group:
+ *
+ *     compound ( ( ' ' | ' > ' ) compound )*
+ *     compound := tag? ( '.' class | '#' id | '[' attr ( '=' value )? ']' | ':not(' simple ')' )*
+ *
+ * Anything outside that grammar throws {@see UnsupportedSelectorException}
+ * so callers can degrade to "attribute not recovered" rather than
+ * silently matching the wrong node.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.5.5
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Support;
+
+class CssSelectorToXPath
+{
+	/**
+	 * Memoizes translations for the process lifetime. Selectors come
+	 * from a fixed set of registered `block.json` manifests, so the
+	 * cache is bounded by the number of registered sourced attributes.
+	 *
+	 * @var array<string, string>
+	 *
+	 * @since 1.5.5
+	 */
+	protected static array $cache = [];
+
+	/**
+	 * Translate a CSS selector into an XPath expression evaluated
+	 * relative to a context node.
+	 *
+	 * @since 1.5.5
+	 *
+	 * @param  string  $selector  A CSS selector within the supported subset.
+	 *
+	 * @return string XPath expression, relative to the context node.
+	 *
+	 * @throws UnsupportedSelectorException When the selector falls outside the supported subset.
+	 */
+	public static function translate( string $selector ): string
+	{
+		$selector = trim( $selector );
+
+		if ( isset( self::$cache[ $selector ] ) ) {
+			return self::$cache[ $selector ];
+		}
+
+		if ( '' === $selector ) {
+			throw new UnsupportedSelectorException( 'Empty CSS selector.' );
+		}
+
+		$paths = [];
+
+		foreach ( explode( ',', $selector ) as $group ) {
+			$paths[] = self::translateGroup( trim( $group ) );
+		}
+
+		return self::$cache[ $selector ] = implode( ' | ', $paths );
+	}
+
+	/**
+	 * Translate a single (comma-free) selector group.
+	 *
+	 * @since 1.5.5
+	 *
+	 * @throws UnsupportedSelectorException
+	 */
+	protected static function translateGroup( string $group ): string
+	{
+		if ( '' === $group ) {
+			throw new UnsupportedSelectorException( 'Empty CSS selector group.' );
+		}
+
+		// Normalize combinators so a simple whitespace split yields an
+		// alternating compound/combinator token stream.
+		$normalized = (string) preg_replace( '/\s*>\s*/', ' > ', $group );
+		$normalized = (string) preg_replace( '/\s+/', ' ', trim( $normalized ) );
+
+		$tokens = explode( ' ', $normalized );
+		$xpath  = '';
+		$axis   = 'descendant-or-self::';
+
+		foreach ( $tokens as $token ) {
+			if ( '>' === $token ) {
+				$axis = 'child::';
+
+				continue;
+			}
+
+			$xpath .= ( '' === $xpath ? '' : '/' ) . $axis . self::translateCompound( $token );
+			$axis   = 'descendant::';
+		}
+
+		if ( '' === $xpath ) {
+			throw new UnsupportedSelectorException( sprintf( 'Unsupported CSS selector group: "%s".', $group ) );
+		}
+
+		return $xpath;
+	}
+
+	/**
+	 * Translate a compound selector (`tag.class[attr]:not(...)`) into an
+	 * XPath node test plus predicates.
+	 *
+	 * @since 1.5.5
+	 *
+	 * @throws UnsupportedSelectorException
+	 */
+	protected static function translateCompound( string $compound ): string
+	{
+		$tag        = '*';
+		$predicates = [];
+		$cursor     = 0;
+		$length     = strlen( $compound );
+
+		// Leading type selector, if any.
+		if ( preg_match( '/^([a-zA-Z][a-zA-Z0-9_-]*|\*)/', $compound, $match ) ) {
+			$tag    = '*' === $match[1] ? '*' : strtolower( $match[1] );
+			$cursor = strlen( $match[1] );
+		}
+
+		while ( $cursor < $length ) {
+			$rest = substr( $compound, $cursor );
+
+			if ( preg_match( '/^:not\(([^()]+)\)/', $rest, $match ) ) {
+				$predicates[] = sprintf( 'not(%s)', self::translateSimple( $match[1] ) );
+				$cursor      += strlen( $match[0] );
+
+				continue;
+			}
+
+			$simple = self::matchSimple( $rest );
+
+			if ( null === $simple ) {
+				throw new UnsupportedSelectorException( sprintf(
+					'Unsupported CSS selector fragment: "%s".',
+					$rest,
+				) );
+			}
+
+			[ $predicate, $consumed ] = $simple;
+
+			$predicates[] = $predicate;
+			$cursor      += $consumed;
+		}
+
+		return [] === $predicates
+			? $tag
+			: $tag . '[' . implode( ' and ', $predicates ) . ']';
+	}
+
+	/**
+	 * Translate a single simple selector (`.class`, `#id`, `[attr]`,
+	 * `[attr=value]`) into an XPath predicate.
+	 *
+	 * @since 1.5.5
+	 *
+	 * @throws UnsupportedSelectorException
+	 */
+	protected static function translateSimple( string $simple ): string
+	{
+		$simple = trim( $simple );
+		$match  = self::matchSimple( $simple );
+
+		if ( null === $match || $match[1] !== strlen( $simple ) ) {
+			throw new UnsupportedSelectorException( sprintf(
+				'Unsupported simple selector: "%s".',
+				$simple,
+			) );
+		}
+
+		return $match[0];
+	}
+
+	/**
+	 * Match one simple selector at the head of `$input`.
+	 *
+	 * @since 1.5.5
+	 *
+	 * @return array{0: string, 1: int}|null Tuple of `[predicate, bytesConsumed]`, or null when nothing matched.
+	 */
+	protected static function matchSimple( string $input ): ?array
+	{
+		if ( preg_match( '/^\.([a-zA-Z0-9_-]+)/', $input, $match ) ) {
+			return [
+				sprintf(
+					"contains(concat(' ', normalize-space(@class), ' '), %s)",
+					self::quote( ' ' . $match[1] . ' ' ),
+				),
+				strlen( $match[0] ),
+			];
+		}
+
+		if ( preg_match( '/^#([a-zA-Z0-9_-]+)/', $input, $match ) ) {
+			return [ sprintf( '@id = %s', self::quote( $match[1] ) ), strlen( $match[0] ) ];
+		}
+
+		if ( preg_match( '/^\[([a-zA-Z_:][a-zA-Z0-9_:.-]*)\]/', $input, $match ) ) {
+			return [ sprintf( '@%s', $match[1] ), strlen( $match[0] ) ];
+		}
+
+		// One pattern per quoting style rather than a single alternation:
+		// PCRE reports non-participating groups as empty strings when a
+		// LATER group matched, which would make an empty double-quoted
+		// value indistinguishable from an unquoted one.
+		$valuePatterns = [
+			'/^\[([a-zA-Z_:][a-zA-Z0-9_:.-]*)="([^"]*)"\]/',
+			"/^\[([a-zA-Z_:][a-zA-Z0-9_:.-]*)='([^']*)'\]/",
+			'/^\[([a-zA-Z_:][a-zA-Z0-9_:.-]*)=([^\]"\']*)\]/',
+		];
+
+		foreach ( $valuePatterns as $pattern ) {
+			if ( preg_match( $pattern, $input, $match ) ) {
+				return [ sprintf( '@%s = %s', $match[1], self::quote( $match[2] ) ), strlen( $match[0] ) ];
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * XPath 1.0 has no escape syntax for quotes inside string literals,
+	 * so a value containing both quote characters has to be assembled
+	 * with `concat()`. Class and attribute values coming out of
+	 * `block.json` never need it, but the helper keeps a hostile
+	 * selector from producing a malformed expression.
+	 *
+	 * @since 1.5.5
+	 */
+	protected static function quote( string $value ): string
+	{
+		if ( ! str_contains( $value, "'" ) ) {
+			return "'" . $value . "'";
+		}
+
+		if ( ! str_contains( $value, '"' ) ) {
+			return '"' . $value . '"';
+		}
+
+		$parts = [];
+
+		foreach ( explode( "'", $value ) as $index => $chunk ) {
+			if ( $index > 0 ) {
+				$parts[] = '"\'"';
+			}
+
+			if ( '' !== $chunk ) {
+				$parts[] = "'" . $chunk . "'";
+			}
+		}
+
+		return 'concat(' . implode( ', ', $parts ) . ')';
+	}
+}

--- a/src/Support/UnsupportedSelectorException.php
+++ b/src/Support/UnsupportedSelectorException.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * Raised when a `block.json` attribute `selector` falls outside the CSS
+ * subset {@see CssSelectorToXPath} understands. Callers catch it and
+ * degrade to "this attribute was not recovered" rather than risk
+ * matching the wrong node.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditor
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.5.5
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Support;
+
+use InvalidArgumentException;
+
+class UnsupportedSelectorException extends InvalidArgumentException
+{
+}

--- a/src/VisualEditorServiceProvider.php
+++ b/src/VisualEditorServiceProvider.php
@@ -56,6 +56,7 @@ use ArtisanPackUI\VisualEditor\States\StateCssEmitter;
 use ArtisanPackUI\VisualEditor\States\StateRegistry;
 use ArtisanPackUI\VisualEditor\States\StateValueResolver;
 use ArtisanPackUI\VisualEditor\Search\BlockTreeSearchExtractor;
+use ArtisanPackUI\VisualEditor\Support\BlockMarkupHydrator;
 use ArtisanPackUI\VisualEditor\Support\HookAliases;
 use ArtisanPackUI\VisualEditor\SiteEditor\Resolution\GlobalStylesResolver as SiteEditorGlobalStylesResolver;
 use ArtisanPackUI\VisualEditor\SiteEditor\Resolution\MenuResolver as SiteEditorMenuResolver;
@@ -154,6 +155,16 @@ class VisualEditorServiceProvider extends ServiceProvider
 
 		$this->app->singleton( DynamicBlockRegistry::class, function () {
 			return new DynamicBlockRegistry();
+		} );
+
+		// #688 — the server-side bridge from WP block markup to a
+		// renderable tree. Singleton because it carries no request
+		// state: it reads the block-type registry (also a singleton)
+		// and a stateless DOM matcher.
+		$this->app->singleton( BlockMarkupHydrator::class, function ( $app ) {
+			return new BlockMarkupHydrator(
+				$app->make( BlockTypeRegistry::class ),
+			);
 		} );
 
 		// #504 — Block bindings: a single shared registry of source drivers

--- a/tests/Unit/VisualEditor/Resources/TemplatePartInlinerRawContentTest.php
+++ b/tests/Unit/VisualEditor/Resources/TemplatePartInlinerRawContentTest.php
@@ -5,6 +5,7 @@ declare( strict_types=1 );
 use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Resolution\ResolvedEntity;
 use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Resolution\TemplatePartResolver;
 use ArtisanPackUI\VisualEditor\Resources\TemplatePartInliner;
+use ArtisanPackUI\VisualEditor\Support\BlockMarkupHydrator;
 
 /**
  * #688 — a block theme's `parts/header.html` resolves with `blocks`
@@ -64,7 +65,7 @@ it( 'hydrates a theme-file part whose resolved blocks are empty', function () {
 	expect( $tree[0]['innerBlocks'] )->toHaveCount( 1 );
 	expect( $tree[0]['innerBlocks'][0]['name'] )->toBe( 'artisanpack/paragraph' );
 	expect( $tree[0]['innerBlocks'][0]['attributes']['content'] )->toBe( 'Site header' );
-} );
+} )->skip( fn () => ! BlockMarkupHydrator::canParseMarkup(), 'requires cms-framework 2.5+ (PHP 8.3+) for BlockMarkupParser' );
 
 it( 'prefers already-parsed blocks over the raw fallback', function () {
 	bindPartResolver( themeFilePart(

--- a/tests/Unit/VisualEditor/Resources/TemplatePartInlinerRawContentTest.php
+++ b/tests/Unit/VisualEditor/Resources/TemplatePartInlinerRawContentTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Resolution\ResolvedEntity;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Resolution\TemplatePartResolver;
+use ArtisanPackUI\VisualEditor\Resources\TemplatePartInliner;
+
+/**
+ * #688 — a block theme's `parts/header.html` resolves with `blocks`
+ * empty and only its raw markup populated, because cms-framework's
+ * resolver doesn't parse theme files. The inliner used to splice that
+ * in as an empty wrapper; it now hydrates the raw markup instead.
+ */
+
+/**
+ * Bind a stand-in part resolver that returns `$entity` for any slug.
+ */
+function bindPartResolver( ?ResolvedEntity $entity ): void
+{
+	app()->instance( TemplatePartResolver::class, new class( $entity ) extends TemplatePartResolver
+	{
+		public function __construct( private readonly ?ResolvedEntity $entity )
+		{
+		}
+
+		public function resolve( string $slug ): ?ResolvedEntity
+		{
+			return $this->entity;
+		}
+	} );
+}
+
+/**
+ * @param  array<int, array<string, mixed>>  $blocks
+ */
+function themeFilePart( string $raw, array $blocks = [] ): ResolvedEntity
+{
+	return new ResolvedEntity(
+		slug: 'header',
+		theme: 'artisanpack-ui',
+		source: 'theme',
+		raw: $raw,
+		blocks: $blocks,
+		title: 'Header',
+		description: '',
+		status: 'publish',
+		hasThemeFile: true,
+		isCustom: false,
+		area: 'header',
+		model: null,
+	);
+}
+
+it( 'hydrates a theme-file part whose resolved blocks are empty', function () {
+	bindPartResolver( themeFilePart(
+		'<!-- wp:artisanpack/paragraph --><p>Site header</p><!-- /wp:artisanpack/paragraph -->'
+	) );
+
+	$tree = ( new TemplatePartInliner() )->inline( [
+		[ 'name' => 'core/template-part', 'attributes' => [ 'slug' => 'header' ], 'innerBlocks' => [] ],
+	] );
+
+	expect( $tree[0]['innerBlocks'] )->toHaveCount( 1 );
+	expect( $tree[0]['innerBlocks'][0]['name'] )->toBe( 'artisanpack/paragraph' );
+	expect( $tree[0]['innerBlocks'][0]['attributes']['content'] )->toBe( 'Site header' );
+} );
+
+it( 'prefers already-parsed blocks over the raw fallback', function () {
+	bindPartResolver( themeFilePart(
+		'<!-- wp:artisanpack/paragraph --><p>From raw</p><!-- /wp:artisanpack/paragraph -->',
+		[ [ 'name' => 'artisanpack/paragraph', 'attributes' => [ 'content' => 'From blocks' ], 'innerBlocks' => [] ] ],
+	) );
+
+	$tree = ( new TemplatePartInliner() )->inline( [
+		[ 'name' => 'core/template-part', 'attributes' => [ 'slug' => 'header' ], 'innerBlocks' => [] ],
+	] );
+
+	expect( $tree[0]['innerBlocks'][0]['attributes']['content'] )->toBe( 'From blocks' );
+} );
+
+it( 'still marks the part unresolved when nothing resolves at all', function () {
+	bindPartResolver( null );
+
+	$tree = ( new TemplatePartInliner() )->inline( [
+		[ 'name' => 'core/template-part', 'attributes' => [ 'slug' => 'header' ], 'innerBlocks' => [] ],
+	] );
+
+	expect( $tree[0]['attributes']['_resolutionError'] )->toBe( TemplatePartInliner::ERROR_NOT_FOUND );
+} );
+
+it( 'marks the part unresolved when the raw markup hydrates to nothing', function () {
+	bindPartResolver( themeFilePart( '   ' ) );
+
+	$tree = ( new TemplatePartInliner() )->inline( [
+		[ 'name' => 'core/template-part', 'attributes' => [ 'slug' => 'header' ], 'innerBlocks' => [] ],
+	] );
+
+	expect( $tree[0]['innerBlocks'] )->toBe( [] );
+} );

--- a/tests/Unit/VisualEditor/Support/BlockMarkupHydratorTest.php
+++ b/tests/Unit/VisualEditor/Support/BlockMarkupHydratorTest.php
@@ -1,0 +1,261 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Registries\BlockTypeRegistry;
+use ArtisanPackUI\VisualEditor\Support\BlockMarkupHydrator;
+
+beforeEach( function () {
+	$this->hydrator = app( BlockMarkupHydrator::class );
+} );
+
+it( 'recovers paragraph text that lives only in the saved HTML', function () {
+	$markup = <<<'HTML'
+	<!-- wp:artisanpack/paragraph {"textColor":"text-muted"} -->
+	<p class="has-text-muted-color has-text-color">Supporting subheading.</p>
+	<!-- /wp:artisanpack/paragraph -->
+	HTML;
+
+	$tree = $this->hydrator->hydrate( $markup );
+
+	expect( $tree )->toHaveCount( 1 );
+	expect( $tree[0]['name'] )->toBe( 'artisanpack/paragraph' );
+	expect( $tree[0]['attributes']['content'] )->toBe( 'Supporting subheading.' );
+	expect( $tree[0]['attributes']['textColor'] )->toBe( 'text-muted' );
+} );
+
+it( 'recovers text for core-namespaced theme markup via the artisanpack fork', function () {
+	$tree = $this->hydrator->hydrate( '<!-- wp:paragraph --><p>HELLO</p><!-- /wp:paragraph -->' );
+
+	expect( $tree[0]['name'] )->toBe( 'core/paragraph' );
+	expect( $tree[0]['attributes']['content'] )->toBe( 'HELLO' );
+} );
+
+it( 'preserves inline formatting inside recovered rich text', function () {
+	$tree = $this->hydrator->hydrate(
+		'<!-- wp:artisanpack/paragraph --><p>Hello <strong>world</strong>.</p><!-- /wp:artisanpack/paragraph -->'
+	);
+
+	expect( $tree[0]['attributes']['content'] )->toBe( 'Hello <strong>world</strong>.' );
+} );
+
+it( 'recovers heading content regardless of level', function () {
+	$tree = $this->hydrator->hydrate(
+		'<!-- wp:artisanpack/heading {"level":3} --><h3 class="wp-block-heading">Our Story</h3><!-- /wp:artisanpack/heading -->'
+	);
+
+	expect( $tree[0]['attributes']['content'] )->toBe( 'Our Story' );
+	expect( $tree[0]['attributes']['level'] )->toBe( 3 );
+} );
+
+it( 'recovers button text and link attributes', function () {
+	$markup = '<!-- wp:artisanpack/button -->'
+		. '<div class="wp-block-button"><a class="wp-block-button__link" href="/contact" target="_blank" rel="noopener">Get in touch</a></div>'
+		. '<!-- /wp:artisanpack/button -->';
+
+	$attributes = $this->hydrator->hydrate( $markup )[0]['attributes'];
+
+	expect( $attributes['text'] )->toBe( 'Get in touch' );
+	expect( $attributes['url'] )->toBe( '/contact' );
+	expect( $attributes['linkTarget'] )->toBe( '_blank' );
+	expect( $attributes['rel'] )->toBe( 'noopener' );
+} );
+
+it( 'recovers image src, alt and caption from their distinct nodes', function () {
+	$markup = '<!-- wp:artisanpack/image -->'
+		. '<figure class="wp-block-image"><a href="/full"><img src="/cat.jpg" alt="A cat"/></a>'
+		. '<figcaption>Our office cat</figcaption></figure>'
+		. '<!-- /wp:artisanpack/image -->';
+
+	$attributes = $this->hydrator->hydrate( $markup )[0]['attributes'];
+
+	expect( $attributes['url'] )->toBe( '/cat.jpg' );
+	expect( $attributes['alt'] )->toBe( 'A cat' );
+	expect( $attributes['caption'] )->toBe( 'Our office cat' );
+	expect( $attributes['href'] )->toBe( '/full' );
+} );
+
+it( 'recovers multiline list values as whole child elements', function () {
+	$markup = '<!-- wp:artisanpack/list --><ul><li>One</li><li>Two</li></ul><!-- /wp:artisanpack/list -->';
+
+	expect( $this->hydrator->hydrate( $markup )[0]['attributes']['values'] )
+		->toBe( '<li>One</li><li>Two</li>' );
+} );
+
+it( 'leaves a modern list empty so the partial renders its inner blocks', function () {
+	// The list a real theme emits: items are `list-item` INNER BLOCKS,
+	// so the parser leaves only `<ul></ul>` in the list's own innerHTML.
+	// `values` must stay empty — recovering it would double-render every
+	// item, since the partial prefers `$innerBlocksHtml`.
+	$markup = <<<'HTML'
+	<!-- wp:artisanpack/list -->
+	<ul class="wp-block-list">
+	<!-- wp:artisanpack/list-item --><li>One</li><!-- /wp:artisanpack/list-item -->
+	<!-- wp:artisanpack/list-item --><li>Two</li><!-- /wp:artisanpack/list-item -->
+	</ul>
+	<!-- /wp:artisanpack/list -->
+	HTML;
+
+	$list = $this->hydrator->hydrate( $markup )[0];
+
+	expect( $list['attributes']['values'] ?? '' )->toBe( '' );
+	expect( $list['innerBlocks'] )->toHaveCount( 2 );
+	expect( $list['innerBlocks'][0]['attributes']['content'] )->toBe( 'One' );
+	expect( $list['innerBlocks'][1]['attributes']['content'] )->toBe( 'Two' );
+} );
+
+it( 'recovers quote value and citation', function () {
+	$markup = '<!-- wp:artisanpack/quote -->'
+		. '<blockquote class="wp-block-quote"><p>Ship it.</p><cite>A colleague</cite></blockquote>'
+		. '<!-- /wp:artisanpack/quote -->';
+
+	$attributes = $this->hydrator->hydrate( $markup )[0]['attributes'];
+
+	expect( $attributes['value'] )->toBe( '<p>Ship it.</p>' );
+	expect( $attributes['citation'] )->toBe( 'A colleague' );
+} );
+
+it( 'treats boolean attribute sources as presence, not value', function () {
+	$markup = '<!-- wp:artisanpack/video -->'
+		. '<figure><video controls loop src="/clip.mp4"></video></figure>'
+		. '<!-- /wp:artisanpack/video -->';
+
+	$attributes = $this->hydrator->hydrate( $markup )[0]['attributes'];
+
+	expect( $attributes['controls'] )->toBeTrue();
+	expect( $attributes['loop'] )->toBeTrue();
+	expect( $attributes['autoplay'] )->toBeFalse();
+	expect( $attributes['src'] )->toBe( '/clip.mp4' );
+} );
+
+it( 'recovers a query source into one entry per match', function () {
+	$markup = '<!-- wp:artisanpack/table -->'
+		. '<figure class="wp-block-table"><table><tbody>'
+		. '<tr><td>A1</td><td>B1</td></tr><tr><td>A2</td><td>B2</td></tr>'
+		. '</tbody></table></figure>'
+		. '<!-- /wp:artisanpack/table -->';
+
+	$body = $this->hydrator->hydrate( $markup )[0]['attributes']['body'];
+
+	expect( $body )->toHaveCount( 2 );
+	expect( array_column( $body[0]['cells'], 'content' ) )->toBe( [ 'A1', 'B1' ] );
+	expect( $body[1]['cells'][1]['tag'] )->toBe( 'td' );
+} );
+
+it( 'recurses into inner blocks', function () {
+	$markup = <<<'HTML'
+	<!-- wp:artisanpack/group -->
+	<div class="wp-block-group">
+	<!-- wp:artisanpack/paragraph --><p>Nested</p><!-- /wp:artisanpack/paragraph -->
+	</div>
+	<!-- /wp:artisanpack/group -->
+	HTML;
+
+	$tree = $this->hydrator->hydrate( $markup );
+
+	expect( $tree[0]['name'] )->toBe( 'artisanpack/group' );
+	expect( $tree[0]['innerBlocks'] )->toHaveCount( 1 );
+	expect( $tree[0]['innerBlocks'][0]['attributes']['content'] )->toBe( 'Nested' );
+} );
+
+it( 'lets delimiter attributes win over recovered ones', function () {
+	$markup = '<!-- wp:artisanpack/paragraph {"content":"From the delimiter"} -->'
+		. '<p>From the HTML</p>'
+		. '<!-- /wp:artisanpack/paragraph -->';
+
+	expect( $this->hydrator->hydrate( $markup )[0]['attributes']['content'] )
+		->toBe( 'From the delimiter' );
+} );
+
+it( 'passes unregistered blocks through with their delimiter attributes intact', function () {
+	$markup = '<!-- wp:acme/widget {"mode":"compact"} --><div>Body</div><!-- /wp:acme/widget -->';
+
+	$block = $this->hydrator->hydrate( $markup )[0];
+
+	expect( $block['name'] )->toBe( 'acme/widget' );
+	expect( $block['attributes'] )->toBe( [ 'mode' => 'compact' ] );
+	expect( $block['innerBlocks'] )->toBe( [] );
+} );
+
+it( 'keeps the saved HTML of a block whose content lives only in innerHTML', function () {
+	// `core/html` is the canonical case: no sourced attributes, all of
+	// its content in the saved markup. Dropping innerHTML would lose it
+	// outright.
+	$block = $this->hydrator->hydrate( '<!-- wp:html --><div class="x">Raw HTML</div><!-- /wp:html -->' )[0];
+
+	expect( $block['innerHTML'] )->toContain( 'Raw HTML' );
+} );
+
+it( 'omits innerHTML for a self-closing block that saved none', function () {
+	$block = $this->hydrator->hydrate( '<!-- wp:artisanpack/spacer {"height":"40px"} /-->' )[0];
+
+	expect( $block )->not->toHaveKey( 'innerHTML' );
+} );
+
+it( 'returns an empty tree for blank markup', function () {
+	expect( $this->hydrator->hydrate( '' ) )->toBe( [] );
+	expect( $this->hydrator->hydrate( "   \n  " ) )->toBe( [] );
+} );
+
+it( 'drops freeform siblings that carry no block name', function () {
+	$tree = $this->hydrator->hydrateTree( [
+		[ 'blockName' => null, 'attrs' => [], 'innerBlocks' => [], 'innerHTML' => '<p>orphan</p>' ],
+		[ 'blockName' => 'artisanpack/paragraph', 'attrs' => [], 'innerBlocks' => [], 'innerHTML' => '<p>kept</p>' ],
+	] );
+
+	expect( $tree )->toHaveCount( 1 );
+	expect( $tree[0]['attributes']['content'] )->toBe( 'kept' );
+} );
+
+it( 'round-trips a tree that is already in editor shape', function () {
+	$tree = $this->hydrator->hydrateTree( [
+		[
+			'name'        => 'artisanpack/paragraph',
+			'attributes'  => [ 'content' => 'Already here' ],
+			'innerBlocks' => [],
+		],
+	] );
+
+	expect( $tree[0]['attributes']['content'] )->toBe( 'Already here' );
+} );
+
+it( 'preserves multibyte text through the DOM round trip', function () {
+	$markup = '<!-- wp:artisanpack/paragraph --><p>Café — naïve ☕</p><!-- /wp:artisanpack/paragraph -->';
+
+	expect( $this->hydrator->hydrate( $markup )[0]['attributes']['content'] )
+		->toBe( 'Café — naïve ☕' );
+} );
+
+it( 'truncates a pathologically deep tree instead of exhausting the stack', function () {
+	$block = [ 'blockName' => 'artisanpack/paragraph', 'attrs' => [], 'innerBlocks' => [], 'innerHTML' => '<p>deep</p>' ];
+
+	for ( $i = 0; $i < BlockMarkupHydrator::MAX_DEPTH + 20; $i++ ) {
+		$block = [
+			'blockName'   => 'artisanpack/group',
+			'attrs'       => [],
+			'innerHTML'   => '',
+			'innerBlocks' => [ $block ],
+		];
+	}
+
+	$tree  = $this->hydrator->hydrateTree( [ $block ] );
+	$depth = 0;
+	$node  = $tree[0];
+
+	while ( [] !== $node['innerBlocks'] ) {
+		$node = $node['innerBlocks'][0];
+		$depth++;
+	}
+
+	expect( $depth )->toBeLessThan( BlockMarkupHydrator::MAX_DEPTH );
+} );
+
+it( 'recovers nothing when the block type declares no sourced attributes', function () {
+	app( BlockTypeRegistry::class )->register( 'acme/plain', [
+		'attributes' => [ 'label' => [ 'type' => 'string' ] ],
+	] );
+
+	$block = $this->hydrator->hydrate( '<!-- wp:acme/plain --><p>ignored</p><!-- /wp:acme/plain -->' )[0];
+
+	expect( $block['attributes'] )->toBe( [] );
+} );

--- a/tests/Unit/VisualEditor/Support/BlockMarkupHydratorTest.php
+++ b/tests/Unit/VisualEditor/Support/BlockMarkupHydratorTest.php
@@ -22,14 +22,14 @@ it( 'recovers paragraph text that lives only in the saved HTML', function () {
 	expect( $tree[0]['name'] )->toBe( 'artisanpack/paragraph' );
 	expect( $tree[0]['attributes']['content'] )->toBe( 'Supporting subheading.' );
 	expect( $tree[0]['attributes']['textColor'] )->toBe( 'text-muted' );
-} );
+} )->skip( fn () => ! BlockMarkupHydrator::canParseMarkup(), 'requires cms-framework 2.5+ (PHP 8.3+) for BlockMarkupParser' );
 
 it( 'recovers text for core-namespaced theme markup via the artisanpack fork', function () {
 	$tree = $this->hydrator->hydrate( '<!-- wp:paragraph --><p>HELLO</p><!-- /wp:paragraph -->' );
 
 	expect( $tree[0]['name'] )->toBe( 'core/paragraph' );
 	expect( $tree[0]['attributes']['content'] )->toBe( 'HELLO' );
-} );
+} )->skip( fn () => ! BlockMarkupHydrator::canParseMarkup(), 'requires cms-framework 2.5+ (PHP 8.3+) for BlockMarkupParser' );
 
 it( 'preserves inline formatting inside recovered rich text', function () {
 	$tree = $this->hydrator->hydrate(
@@ -37,7 +37,7 @@ it( 'preserves inline formatting inside recovered rich text', function () {
 	);
 
 	expect( $tree[0]['attributes']['content'] )->toBe( 'Hello <strong>world</strong>.' );
-} );
+} )->skip( fn () => ! BlockMarkupHydrator::canParseMarkup(), 'requires cms-framework 2.5+ (PHP 8.3+) for BlockMarkupParser' );
 
 it( 'recovers heading content regardless of level', function () {
 	$tree = $this->hydrator->hydrate(
@@ -46,7 +46,7 @@ it( 'recovers heading content regardless of level', function () {
 
 	expect( $tree[0]['attributes']['content'] )->toBe( 'Our Story' );
 	expect( $tree[0]['attributes']['level'] )->toBe( 3 );
-} );
+} )->skip( fn () => ! BlockMarkupHydrator::canParseMarkup(), 'requires cms-framework 2.5+ (PHP 8.3+) for BlockMarkupParser' );
 
 it( 'recovers button text and link attributes', function () {
 	$markup = '<!-- wp:artisanpack/button -->'
@@ -59,7 +59,7 @@ it( 'recovers button text and link attributes', function () {
 	expect( $attributes['url'] )->toBe( '/contact' );
 	expect( $attributes['linkTarget'] )->toBe( '_blank' );
 	expect( $attributes['rel'] )->toBe( 'noopener' );
-} );
+} )->skip( fn () => ! BlockMarkupHydrator::canParseMarkup(), 'requires cms-framework 2.5+ (PHP 8.3+) for BlockMarkupParser' );
 
 it( 'recovers image src, alt and caption from their distinct nodes', function () {
 	$markup = '<!-- wp:artisanpack/image -->'
@@ -73,14 +73,14 @@ it( 'recovers image src, alt and caption from their distinct nodes', function ()
 	expect( $attributes['alt'] )->toBe( 'A cat' );
 	expect( $attributes['caption'] )->toBe( 'Our office cat' );
 	expect( $attributes['href'] )->toBe( '/full' );
-} );
+} )->skip( fn () => ! BlockMarkupHydrator::canParseMarkup(), 'requires cms-framework 2.5+ (PHP 8.3+) for BlockMarkupParser' );
 
 it( 'recovers multiline list values as whole child elements', function () {
 	$markup = '<!-- wp:artisanpack/list --><ul><li>One</li><li>Two</li></ul><!-- /wp:artisanpack/list -->';
 
 	expect( $this->hydrator->hydrate( $markup )[0]['attributes']['values'] )
 		->toBe( '<li>One</li><li>Two</li>' );
-} );
+} )->skip( fn () => ! BlockMarkupHydrator::canParseMarkup(), 'requires cms-framework 2.5+ (PHP 8.3+) for BlockMarkupParser' );
 
 it( 'leaves a modern list empty so the partial renders its inner blocks', function () {
 	// The list a real theme emits: items are `list-item` INNER BLOCKS,
@@ -102,7 +102,7 @@ it( 'leaves a modern list empty so the partial renders its inner blocks', functi
 	expect( $list['innerBlocks'] )->toHaveCount( 2 );
 	expect( $list['innerBlocks'][0]['attributes']['content'] )->toBe( 'One' );
 	expect( $list['innerBlocks'][1]['attributes']['content'] )->toBe( 'Two' );
-} );
+} )->skip( fn () => ! BlockMarkupHydrator::canParseMarkup(), 'requires cms-framework 2.5+ (PHP 8.3+) for BlockMarkupParser' );
 
 it( 'recovers quote value and citation', function () {
 	$markup = '<!-- wp:artisanpack/quote -->'
@@ -113,7 +113,7 @@ it( 'recovers quote value and citation', function () {
 
 	expect( $attributes['value'] )->toBe( '<p>Ship it.</p>' );
 	expect( $attributes['citation'] )->toBe( 'A colleague' );
-} );
+} )->skip( fn () => ! BlockMarkupHydrator::canParseMarkup(), 'requires cms-framework 2.5+ (PHP 8.3+) for BlockMarkupParser' );
 
 it( 'treats boolean attribute sources as presence, not value', function () {
 	$markup = '<!-- wp:artisanpack/video -->'
@@ -126,7 +126,7 @@ it( 'treats boolean attribute sources as presence, not value', function () {
 	expect( $attributes['loop'] )->toBeTrue();
 	expect( $attributes['autoplay'] )->toBeFalse();
 	expect( $attributes['src'] )->toBe( '/clip.mp4' );
-} );
+} )->skip( fn () => ! BlockMarkupHydrator::canParseMarkup(), 'requires cms-framework 2.5+ (PHP 8.3+) for BlockMarkupParser' );
 
 it( 'recovers a query source into one entry per match', function () {
 	$markup = '<!-- wp:artisanpack/table -->'
@@ -140,7 +140,7 @@ it( 'recovers a query source into one entry per match', function () {
 	expect( $body )->toHaveCount( 2 );
 	expect( array_column( $body[0]['cells'], 'content' ) )->toBe( [ 'A1', 'B1' ] );
 	expect( $body[1]['cells'][1]['tag'] )->toBe( 'td' );
-} );
+} )->skip( fn () => ! BlockMarkupHydrator::canParseMarkup(), 'requires cms-framework 2.5+ (PHP 8.3+) for BlockMarkupParser' );
 
 it( 'recurses into inner blocks', function () {
 	$markup = <<<'HTML'
@@ -156,7 +156,7 @@ it( 'recurses into inner blocks', function () {
 	expect( $tree[0]['name'] )->toBe( 'artisanpack/group' );
 	expect( $tree[0]['innerBlocks'] )->toHaveCount( 1 );
 	expect( $tree[0]['innerBlocks'][0]['attributes']['content'] )->toBe( 'Nested' );
-} );
+} )->skip( fn () => ! BlockMarkupHydrator::canParseMarkup(), 'requires cms-framework 2.5+ (PHP 8.3+) for BlockMarkupParser' );
 
 it( 'lets delimiter attributes win over recovered ones', function () {
 	$markup = '<!-- wp:artisanpack/paragraph {"content":"From the delimiter"} -->'
@@ -165,7 +165,7 @@ it( 'lets delimiter attributes win over recovered ones', function () {
 
 	expect( $this->hydrator->hydrate( $markup )[0]['attributes']['content'] )
 		->toBe( 'From the delimiter' );
-} );
+} )->skip( fn () => ! BlockMarkupHydrator::canParseMarkup(), 'requires cms-framework 2.5+ (PHP 8.3+) for BlockMarkupParser' );
 
 it( 'passes unregistered blocks through with their delimiter attributes intact', function () {
 	$markup = '<!-- wp:acme/widget {"mode":"compact"} --><div>Body</div><!-- /wp:acme/widget -->';
@@ -175,7 +175,7 @@ it( 'passes unregistered blocks through with their delimiter attributes intact',
 	expect( $block['name'] )->toBe( 'acme/widget' );
 	expect( $block['attributes'] )->toBe( [ 'mode' => 'compact' ] );
 	expect( $block['innerBlocks'] )->toBe( [] );
-} );
+} )->skip( fn () => ! BlockMarkupHydrator::canParseMarkup(), 'requires cms-framework 2.5+ (PHP 8.3+) for BlockMarkupParser' );
 
 it( 'keeps the saved HTML of a block whose content lives only in innerHTML', function () {
 	// `core/html` is the canonical case: no sourced attributes, all of
@@ -184,13 +184,13 @@ it( 'keeps the saved HTML of a block whose content lives only in innerHTML', fun
 	$block = $this->hydrator->hydrate( '<!-- wp:html --><div class="x">Raw HTML</div><!-- /wp:html -->' )[0];
 
 	expect( $block['innerHTML'] )->toContain( 'Raw HTML' );
-} );
+} )->skip( fn () => ! BlockMarkupHydrator::canParseMarkup(), 'requires cms-framework 2.5+ (PHP 8.3+) for BlockMarkupParser' );
 
 it( 'omits innerHTML for a self-closing block that saved none', function () {
 	$block = $this->hydrator->hydrate( '<!-- wp:artisanpack/spacer {"height":"40px"} /-->' )[0];
 
 	expect( $block )->not->toHaveKey( 'innerHTML' );
-} );
+} )->skip( fn () => ! BlockMarkupHydrator::canParseMarkup(), 'requires cms-framework 2.5+ (PHP 8.3+) for BlockMarkupParser' );
 
 it( 'returns an empty tree for blank markup', function () {
 	expect( $this->hydrator->hydrate( '' ) )->toBe( [] );
@@ -224,7 +224,7 @@ it( 'preserves multibyte text through the DOM round trip', function () {
 
 	expect( $this->hydrator->hydrate( $markup )[0]['attributes']['content'] )
 		->toBe( 'Café — naïve ☕' );
-} );
+} )->skip( fn () => ! BlockMarkupHydrator::canParseMarkup(), 'requires cms-framework 2.5+ (PHP 8.3+) for BlockMarkupParser' );
 
 it( 'truncates a pathologically deep tree instead of exhausting the stack', function () {
 	$block = [ 'blockName' => 'artisanpack/paragraph', 'attrs' => [], 'innerBlocks' => [], 'innerHTML' => '<p>deep</p>' ];
@@ -258,4 +258,4 @@ it( 'recovers nothing when the block type declares no sourced attributes', funct
 	$block = $this->hydrator->hydrate( '<!-- wp:acme/plain --><p>ignored</p><!-- /wp:acme/plain -->' )[0];
 
 	expect( $block['attributes'] )->toBe( [] );
-} );
+} )->skip( fn () => ! BlockMarkupHydrator::canParseMarkup(), 'requires cms-framework 2.5+ (PHP 8.3+) for BlockMarkupParser' );

--- a/tests/Unit/VisualEditor/Support/CssSelectorToXPathTest.php
+++ b/tests/Unit/VisualEditor/Support/CssSelectorToXPathTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Support\CssSelectorToXPath;
+use ArtisanPackUI\VisualEditor\Support\UnsupportedSelectorException;
+
+/**
+ * Run a selector against a fragment and return the matched tag names,
+ * so the assertions describe behavior rather than XPath syntax.
+ *
+ * @return array<int, string>
+ */
+function veMatchTags( string $html, string $selector ): array
+{
+	$document = new DOMDocument();
+
+	libxml_use_internal_errors( true );
+	$document->loadHTML(
+		'<?xml encoding="UTF-8"?><div id="root">' . $html . '</div>',
+		LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD,
+	);
+	libxml_clear_errors();
+
+	$xpath   = new DOMXPath( $document );
+	$root    = $xpath->query( "//*[@id='root']" )->item( 0 );
+	$matches = $xpath->query( CssSelectorToXPath::translate( $selector ), $root );
+
+	$out = [];
+
+	foreach ( $matches as $node ) {
+		$out[] = strtolower( $node->tagName ) . ( '' !== $node->textContent ? ':' . $node->textContent : '' );
+	}
+
+	return $out;
+}
+
+it( 'matches a fragment root by tag name', function () {
+	expect( veMatchTags( '<p>Hello</p>', 'p' ) )->toBe( [ 'p:Hello' ] );
+} );
+
+it( 'matches any of a comma-separated group', function () {
+	expect( veMatchTags( '<h3>Title</h3>', 'h1,h2,h3,h4,h5,h6' ) )->toBe( [ 'h3:Title' ] );
+} );
+
+it( 'matches a class selector', function () {
+	expect( veMatchTags( '<div class="ap-callout__body other">Body</div>', 'div.ap-callout__body' ) )
+		->toBe( [ 'div:Body' ] );
+} );
+
+it( 'does not match a class that is only a substring of another class', function () {
+	expect( veMatchTags( '<div class="ap-callout__bodyguard">x</div>', '.ap-callout__body' ) )->toBe( [] );
+} );
+
+it( 'honours the child combinator', function () {
+	expect( veMatchTags( '<figure><a href="#">link</a></figure>', 'figure > a' ) )->toBe( [ 'a:link' ] );
+	expect( veMatchTags( '<figure><span><a href="#">link</a></span></figure>', 'figure > a' ) )->toBe( [] );
+} );
+
+it( 'honours the descendant combinator', function () {
+	expect( veMatchTags( '<figure><span><img/></span></figure>', 'figure img' ) )->toBe( [ 'img' ] );
+} );
+
+it( 'matches attribute presence and negation', function () {
+	$html = '<div><a href="#a">plain</a><a download href="#b">dl</a></div>';
+
+	expect( veMatchTags( $html, 'a[download]' ) )->toBe( [ 'a:dl' ] );
+	expect( veMatchTags( $html, 'a:not([download])' ) )->toBe( [ 'a:plain' ] );
+} );
+
+it( 'matches attribute equality across quoting styles', function () {
+	$html = '<div><input type="text"/><input type="hidden"/></div>';
+
+	expect( CssSelectorToXPath::translate( '[type=text]' ) )
+		->toBe( CssSelectorToXPath::translate( '[type="text"]' ) );
+
+	expect( veMatchTags( $html, 'input[type="hidden"]' ) )->toBe( [ 'input' ] );
+} );
+
+it( 'returns matches in document order for a comma group', function () {
+	expect( veMatchTags( '<tr><th>H</th><td>D</td></tr>', 'td,th' ) )->toBe( [ 'th:H', 'td:D' ] );
+} );
+
+it( 'translates every selector used by every bundled block manifest', function () {
+	// The translator supports a deliberate SUBSET of CSS. This guard
+	// makes a manifest that introduces a selector outside that subset
+	// (`~`, `+`, a pseudo-class, a comma inside an attribute value) fail
+	// here rather than silently dropping the attribute at render time.
+	$selectors = [];
+
+	/**
+	 * @param  array<string, mixed>  $definitions
+	 */
+	$collect = function ( array $definitions, string $block ) use ( &$collect, &$selectors ): void {
+		foreach ( $definitions as $definition ) {
+			if ( ! is_array( $definition ) ) {
+				continue;
+			}
+
+			if ( isset( $definition['selector'] ) && is_string( $definition['selector'] ) ) {
+				$selectors[ $definition['selector'] ] = $block;
+			}
+
+			if ( isset( $definition['query'] ) && is_array( $definition['query'] ) ) {
+				$collect( $definition['query'], $block );
+			}
+		}
+	};
+
+	foreach ( glob( __DIR__ . '/../../../../resources/js/visual-editor/blocks/*/block.json' ) as $path ) {
+		$manifest = json_decode( (string) file_get_contents( $path ), true );
+
+		if ( is_array( $manifest['attributes'] ?? null ) ) {
+			$collect( $manifest['attributes'], basename( dirname( $path ) ) );
+		}
+	}
+
+	expect( $selectors )->not->toBeEmpty();
+
+	foreach ( $selectors as $selector => $block ) {
+		expect( fn () => CssSelectorToXPath::translate( (string) $selector ) )
+			->not->toThrow( UnsupportedSelectorException::class, "block: {$block}, selector: {$selector}" );
+	}
+} );
+
+it( 'rejects selectors outside the supported subset', function () {
+	expect( fn () => CssSelectorToXPath::translate( 'p:nth-child(2)' ) )
+		->toThrow( UnsupportedSelectorException::class );
+
+	expect( fn () => CssSelectorToXPath::translate( '' ) )
+		->toThrow( UnsupportedSelectorException::class );
+} );


### PR DESCRIPTION
## Release Information

- **Release Version:** v1.5.5
- **Release Date:** 2026-08-02
- **Release Type:** Patch
- **Release Branch:** `release/1.5.5`
- **Target Branch:** `main`

## Release Summary

A single-issue patch release that closes #688: **there was no server-side path
from WP-serialized block markup to rendered HTML**, which made a block theme's
`templates/*.html` and `parts/*.html` unrenderable outside the editor.

The gap was not merely a shape mismatch between cms-framework's
`{blockName, attrs, innerHTML}` and the renderer's `{name, attributes}`.
Gutenberg persists most block text in the **saved HTML**, not in the delimiter
JSON — zero of the `artisanpack-ui` theme's 130 paragraph/heading blocks
serialize a `content` attribute — so a key-rename conversion yields a
structurally-correct, completely textless page.

`BlockMarkupHydrator` parses the markup *and* replays each registered block
type's `block.json` attribute definitions back over its saved HTML to recover
the content. Recovery is driven by the block-type registry rather than a
hand-maintained per-block table, so a block that ships a new sourced attribute
is picked up with no change — which is why this lives beside the block
manifests rather than in cms-framework or a host app. No new Composer
dependency: the CSS→XPath translation covers only the narrow selector subset
the manifests actually use.

## Changelog

### Added

- **`BlockMarkupHydrator`** (`Support`) — the supported server-side path from a
  raw block-markup string to the editor-shape tree the renderers consume.
  `hydrate( string $markup )` parses delimiters via cms-framework's
  `BlockMarkupParser`, resolved **by name** so cms-framework stays a
  non-dependency; `hydrateTree( array $parsed )` takes an already-parsed tree
  and works either way. `canParseMarkup()` lets hosts gate on parser
  availability. Carries a `MAX_DEPTH` cap (128, above the parser's own 64) and
  falls back across the `core/` ↔ `artisanpack/` namespace pair so theme files
  written against WP core's block names resolve against the forks.
- **`BlockAttributeSourceResolver`** (`Support`) — server-side port of
  Gutenberg's save-shape matchers over `DOMDocument` + XPath: `attribute` /
  `property`, `html` (incl. `multiline`), `rich-text`, `text`, `tag`, `query`,
  `raw`.
- **`CssSelectorToXPath`** (`Support`) — hand-rolled translator for the CSS
  subset `block.json` `selector` fields use, so the package gains **no new
  Composer dependency**. Selectors outside the subset throw
  `UnsupportedSelectorException`, degrade to "attribute not recovered", and are
  reported once per process rather than silently mis-matching.
- **`BlockRenderer::renderMarkup( $markup, $defaultTheme )`**
  (`visual-editor-renderer-blade`) — markup in, HTML out. Inlines
  `template-part` and synced-pattern references before the walk, so a
  standalone theme template renders its parts as real content rather than empty
  wrappers.

### Changed

- Nothing user-facing beyond the fixes below.

### Deprecated

- None.

### Removed

- None.

### Fixed

- **Block-theme markup no longer renders textless server-side (#688).**
  Hydration replays each block type's attribute definitions over the saved HTML,
  recovering paragraph/heading `content`, button text + href, image
  `src`/`alt`/`caption`, list values, quote + citation, table cells, and
  everything else declared with a `source`.
- **`.html`-sourced template parts now inline with content (#688).**
  `TemplatePartInliner` resolved `parts/header.html` to an entity with `blocks`
  empty and the markup unread in `rawContent`, inlining an empty wrapper. It now
  hydrates that raw markup, accepting either `rawContent`
  (`ResolvedTemplatePart`) or `raw` (cms-framework's `ResolvedEntity`).
- **`TemplatePartInliner` now honors container overrides of the cms-framework
  resolver.** `RESOLVER_CLASS` carried a leading backslash, which does not match
  the key Laravel stores `TemplatePartResolver::class` under — `app()` treated it
  as a distinct binding and silently built a fresh instance, ignoring any host-
  or test-supplied override.

### Security

- `BlockMarkupHydrator` documents an explicit **trust boundary**. Recovered
  `rich-text` / `html` attributes are HTML fragments and partials emit them
  unescaped (`{!! $content !!}`) — that is what makes a paragraph's `<strong>`
  survive the round trip. Hydration is safe over theme files, patterns, and
  editor-authored content that passed the post editor's authorization, and is
  **not** a sanitizer: passing visitor-submitted markup to `hydrate()` turns it
  into stored XSS. Same boundary Gutenberg draws — neither widened nor narrowed.
  Untrusted markup should go through `kses()` (from `artisanpack-ui/security`)
  first. Documented in the class docblock, on `renderMarkup()`, and in
  `docs/renderers.md`.

## Issues and Pull Requests

**Issues Fixed:**
- Closes #688

**Related PRs:**
- #689 — fix: add a server-side path from WP block markup to rendered HTML

Companion (not blocking): ArtisanPack-UI/cms-framework#274

## Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes documented below

Purely additive. Existing `<x-ve-blocks>` / `<x-ve-template>` call sites are
untouched; the two `TemplatePartInliner` fixes only affect paths that
previously produced an empty wrapper or ignored a container override.

## Testing Checklist

- [x] All automated tests passing
- [ ] Manual testing completed
- [ ] Accessibility tests passing
- [ ] Performance tests passing (if applicable)
- [x] Security scan completed
- [ ] Tested in staging environment
- [x] Database migrations tested (if applicable) — none in this release

**Testing notes:**

- **CI green on `2ae36e24`** (and on `14779e30` before the release commit).
- **Pest:** 98 passed, 4,347 assertions, 0 failed. The 1,528 "deprecated"
  notices are `PDO::MYSQL_ATTR_SSL_CA` deprecations from
  `orchestra/testbench` under PHP 8.5 — environmental, pre-existing, unrelated
  to this release.
- **Vitest:** 2,881 passed / 2,899 in CI (Node 20). Locally on **Node 26**,
  `site-editor/__tests__/site-editor-app.test.tsx` fails all 18 tests with
  `Cannot read properties of undefined (reading 'clear')` on
  `window.localStorage`. This is a vitest-2 / jsdom-25 global-binding artifact
  on Node 26 (`'localStorage' in window` is `true` but the getter returns
  `undefined`); the release diff is **PHP-only**, and the file is unchanged
  since #700. Pre-existing and not a regression — but worth a follow-up issue
  to bump vitest/jsdom before the toolchain moves to a newer Node.
- New coverage added by #689: `BlockMarkupHydratorTest`,
  `CssSelectorToXPathTest`, `TemplatePartInlinerRawContentTest`,
  `RenderMarkupTest`.

## Documentation Checklist

- [x] CHANGELOG updated
- [ ] README updated (if needed) — not needed
- [x] API documentation updated (if needed)
- [ ] Migration guide written (if breaking changes) — no breaking changes
- [x] Release notes written
- [ ] Wiki updated (if applicable)

**Docs changed in this release commit:**

- `docs/renderers.md` — new **"Rendering raw block markup"** section under the
  Blade renderer: `renderMarkup()` usage, direct `BlockMarkupHydrator` usage
  for when you need the tree (or a `$post` in scope), the entity-scope
  limitation, the cms-framework install gate, and the security callout.
- `docs/troubleshooting.md` — new **§11 "Theme templates render empty (or
  structure without text)"**: symptom, root cause, fix, and what to check if
  it is still empty after upgrading.
- `docs/home.md` — docs version marker restamped `v1.5.3` → `v1.5.5` (it was
  missed during the 1.5.4 prep).

## Pre-Release Checklist

- [x] Version number updated in all necessary files
- [x] Git tag prepared: `v1.5.5`
- [x] Release branch created/updated: `release/1.5.5`
- [x] Dependencies updated and tested
- [ ] Build artifacts generated — produced by `release.yml` on dispatch
- [x] Deployment plan reviewed
- [x] Rollback plan prepared
- [ ] Stakeholders notified

**Version consistency:** `composer.json` and `package.json` both bumped
1.5.4 → 1.5.5. These are the only two files `release.yml`'s version-match guard
checks, and the only two carrying the package's own version. All other `1.5.x`
strings in the tree are historical `@since` tags or dated references (e.g.
`docs/Installation-Guide.md`'s v1.5.3 dist-tarball note) and are correctly left
alone.

## Deployment

**Deployment steps:**
1. Review and merge this PR into `main`.
2. `gh workflow run release.yml -f version=1.5.5`
3. Verify the `v1.5.5` tag carries `dist/editor/` + `dist/lib/`, and that
   Packagist picks up the built commit (the #683 failure mode).

**Rollback plan:**
1. `release.yml` refuses to reship an existing tag, so a bad run cannot
   overwrite `v1.5.5` — cut `v1.5.6` with the revert rather than retagging
   (Packagist freezes a tag's SHA on first crawl).
2. Consumers pin back to `^1.5.4`; nothing in this release changes stored data
   or schema, so downgrade is safe with no migration.

**Configuration changes:**
- None.

**Environment variables:**
- None.

## Post-Release Tasks

- [ ] Tag created: `v1.5.5`
- [ ] Release notes published
- [ ] Documentation deployed
- [ ] Announcement sent
- [ ] Monitoring verified
- [ ] Previous version support documented

## Notes

### Dependency audit

Lock files are the committed ones; **no dependency versions changed in this
release**.

- `composer validate` reports the lock `content-hash` as stale. This is
  expected and pre-existing: Composer includes the `version` field in the hash,
  so every version bump invalidates it, and the 1.5.1 / 1.5.2 / 1.5.3 / 1.5.4
  release commits all left `composer.lock` untouched the same way. It could not
  be resynced here regardless — this checkout's `repositories` path repos
  resolve sibling packages to local working copies (ai 1.1.0, cms-framework
  2.7.2, icons 2.2.0) that do not match the locked constraints, and local PHP
  is 8.5.7 while `brianium/paratest` requires ≤ 8.4. Resyncing the lock on a
  clean CI checkout would be the right follow-up.
- **Composer advisories (all dev-only, via `require-dev`):**
  `phpunit/phpunit` ×1 high, `guzzlehttp/guzzle` ×4 medium, `symfony/yaml` ×3
  low. None reachable from shipped runtime code.
- **npm advisories:** 19 (17 moderate, 2 high) — `vite` and `vitest` are
  `devDependencies`; the rest (`brace-expansion`, `form-data`, `js-cookie`,
  `linkify-it`, `postcss`, `ws`) are transitive through the pinned
  `@wordpress/*` packages, which are deliberately version-locked against
  upstream drift (see `docs/troubleshooting.md` §3). Not addressed here —
  bumping them belongs in a dedicated `@wordpress/*` upgrade audit, not a
  patch release.

### Lint

This package ships no linter configuration — no `pint.json`,
`.php-cs-fixer.dist.php`, `phpcs.xml`, ESLint, or Prettier config, and no
formatter in `require-dev` (only a stale `.php-cs-fixer.cache` at the root).
No auto-fix pass was run because there is nothing configured to run. Adopting
the standard `artisanpack-ui/code-style` + `code-style-pint` setup, and
deleting the orphaned cache file, is worth a follow-up issue.

---

**Release Manager:** @jacobmartella

**For Reviewers:**
- Verify all checklist items completed
- Review changelog accuracy
- Confirm version numbers correct
- Check breaking changes documented
- Approve deployment plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)
