### PR TITLE
feat: composed-view ribbon and site-editor slug deep links

### DIFF
--- a/docs/site-editor.md
+++ b/docs/site-editor.md
@@ -153,6 +153,56 @@ entity work:
 These are shareable — bookmark or send to a colleague to jump straight
 into editing that entity.
 
+### Deep links by slug
+
+Path routes address entities by database id. Callers outside the SPA
+usually do not have one — the post editor's composed view, for instance,
+knows only the slug of the template it composed against. For those, the
+site editor accepts a query-string deep link on the mount URL:
+
+```text
+/visual-editor/site?entity=template&slug=single
+```
+
+On mount the SPA parses the query string, resolves the slug through the
+templates list endpoint, and navigates to that template's editor view.
+The `pushState` that follows rewrites the address bar to the canonical
+path route (`/visual-editor/site/templates/12`), so the query-string form
+is an entry point rather than a URL the user is left holding.
+
+| Parameter | Required | Notes |
+|-----------|----------|-------|
+| `entity` | yes | Only `template` is supported today. Unknown values are ignored. |
+| `slug` | yes | Entity slug. Blank or whitespace-only values are ignored. |
+| `entity_id` | no | Pre-resolved id. When supplied the slug lookup is skipped. Reserved for entity kinds that have no slug. |
+
+Behaviour worth relying on:
+
+- **Additive.** Mounting with no query string behaves exactly as it did
+  before — no lookup is issued and the SPA lands on its default section.
+- **Unknown entity is a no-op**, not an error. A link written against a
+  future package version lands on the default section rather than
+  throwing.
+- **Unresolvable slug lands on the Templates index** with a toast reading
+  `The template "{slug}" was not found.` A failed lookup does the same.
+- **The access gate is unchanged.** `SiteEditorAccessGate` runs
+  server-side, before the SPA mounts, so a denied request still renders
+  the deny-by-default page and never reaches this parsing.
+
+Build links with `buildTemplateDeepLink()` from
+`site-editor/deep-link.ts` rather than assembling the query string by
+hand, so both sides of the contract move together. The first consumer is
+the post editor's composed-view ribbon, whose **Edit template ↗** button
+opens one of these links in a new tab.
+
+`buildTemplateDeepLink()` defaults to the package's own mount path
+(`/visual-editor/site`) and takes the route base as an optional second
+argument. The composed-view ribbon currently relies on that default: the
+post editor has no way to discover a `data-route-base` the host may have
+overridden on the site-editor mount element. A host that mounts the site
+editor at a non-default path will get a ribbon CTA pointing at the
+default path until that value is threaded through to the post editor.
+
 ---
 
 ## 6. Preview

--- a/resources/js/visual-editor/editor/__tests__/canvas-styles.test.ts
+++ b/resources/js/visual-editor/editor/__tests__/canvas-styles.test.ts
@@ -45,7 +45,7 @@ describe('canvasStyles', () => {
         expect(framingIndex).toBeGreaterThan(defaultsIndex);
     });
 
-    it('places COMPOSED_CHROME_STYLES last so it can undo the framing inside chrome regions', () => {
+    it('places COMPOSED_CHROME_STYLES after the framing so it can undo it inside chrome regions', () => {
         const framingIndex = canvasStyles.findIndex(
             (entry) => entry.css === POST_EDITOR_FRAMING_STYLES
         );
@@ -56,10 +56,15 @@ describe('canvasStyles', () => {
         // The framing entry exists to frame post *content* — 48px padding
         // and a 720px column. Composed-view chrome (#655) renders inside
         // the same canvas but is a site header/footer, so it has to win
-        // against that framing; hence it lands after. Anything added later
-        // would silently outrank the chrome reset.
+        // against that framing; hence it lands after.
+        //
+        // Only the #623 ribbon sheet follows it: the ribbon is editor
+        // chrome that happens to render in the canvas and shares no
+        // selectors with the chrome regions, so it cannot outrank the
+        // reset. Any *other* future entry appended past the chrome reset
+        // would, so this pins the tail to exactly one trailing sheet.
         expect(chromeIndex).toBeGreaterThan(framingIndex);
-        expect(chromeIndex).toBe(canvasStyles.length - 1);
+        expect(chromeIndex).toBe(canvasStyles.length - 2);
     });
 
     it('keeps the alignment overrides between the canvas defaults and the post-editor framing', () => {

--- a/resources/js/visual-editor/editor/__tests__/editor-canvas.test.tsx
+++ b/resources/js/visual-editor/editor/__tests__/editor-canvas.test.tsx
@@ -247,4 +247,78 @@ describe('EditorCanvas', () => {
             expect(frame.style.width).toBe('');
         });
     });
+
+    describe('composed-view ribbon (#623)', () => {
+        it('is absent in bare-content mode', () => {
+            render(
+                <EditorCanvas
+                    showTitle
+                    title=""
+                    onTitleChange={() => undefined}
+                    blockContext={null}
+                    chrome={null}
+                />
+            );
+
+            expect(
+                screen.queryByTestId('ap-composed-view-ribbon')
+            ).not.toBeInTheDocument();
+        });
+
+        it('mounts inside the canvas iframe when chrome is supplied', () => {
+            render(
+                <EditorCanvas
+                    showTitle
+                    title=""
+                    onTitleChange={() => undefined}
+                    blockContext={null}
+                    chrome={{
+                        header: [],
+                        footer: [],
+                        templateName: 'Single Post',
+                        templateSlug: 'single',
+                    }}
+                />
+            );
+
+            const ribbon = screen.getByTestId('ap-composed-view-ribbon');
+
+            // Inside the `BlockCanvas` stub, not beside it — the ribbon
+            // has to scroll with the composed preview rather than sit in
+            // the editor chrome above the frame.
+            expect(
+                screen.getByTestId('ap-stub-block-canvas')
+            ).toContainElement(ribbon);
+            expect(
+                screen.getByTestId('ap-composed-view-ribbon-cta')
+            ).toHaveAttribute(
+                'href',
+                '/visual-editor/site?entity=template&slug=single'
+            );
+        });
+
+        it('drops the CTA when composing against the fallback template', () => {
+            render(
+                <EditorCanvas
+                    showTitle
+                    title=""
+                    onTitleChange={() => undefined}
+                    blockContext={null}
+                    chrome={{
+                        header: [],
+                        footer: [],
+                        templateName: 'Default template',
+                        templateSlug: null,
+                    }}
+                />
+            );
+
+            expect(
+                screen.getByTestId('ap-composed-view-ribbon')
+            ).toBeInTheDocument();
+            expect(
+                screen.queryByTestId('ap-composed-view-ribbon-cta')
+            ).not.toBeInTheDocument();
+        });
+    });
 });

--- a/resources/js/visual-editor/editor/canvas-styles.ts
+++ b/resources/js/visual-editor/editor/canvas-styles.ts
@@ -37,6 +37,7 @@ import {
 } from '../editor-settings';
 
 import canvasThemeTokens from './canvas-theme-tokens.css?inline';
+import composedRibbonStyles from './composed-view/composed-view-ribbon.css?inline';
 import flexLayoutStyles from '../../../css/flex-layout.css?inline';
 import photoGridStyles from '../blocks/_shared/photo-grid/photo-grid.css?inline';
 
@@ -221,6 +222,12 @@ const baseCanvasStyles: CanvasStyle[] = [
     // it exists to undo that framing inside the read-only header/footer
     // regions, which are chrome, not post content.
     { css: COMPOSED_CHROME_STYLES },
+    // Composed-view ribbon (#623). Lives under `composed-view/`, which
+    // the `blocks/*/*.css` glob above does not reach, so it is handed
+    // to the iframe explicitly. Last in the list because it is editor
+    // chrome rendered inside the canvas — nothing downstream should
+    // restyle it.
+    { css: composedRibbonStyles },
 ];
 
 /**

--- a/resources/js/visual-editor/editor/composed-view/__tests__/composed-view-ribbon.test.tsx
+++ b/resources/js/visual-editor/editor/composed-view/__tests__/composed-view-ribbon.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { ComposedViewRibbon } from '../composed-view-ribbon';
+
+describe('ComposedViewRibbon', () => {
+    it('names the resolved template', () => {
+        render(
+            <ComposedViewRibbon templateName="Single Post" templateSlug="single" />
+        );
+
+        expect(
+            screen.getByText('Editing content inside Single Post')
+        ).toBeInTheDocument();
+    });
+
+    it('labels itself as a landmark region for assistive tech', () => {
+        render(
+            <ComposedViewRibbon templateName="Single Post" templateSlug="single" />
+        );
+
+        expect(
+            screen.getByRole('region', { name: 'Composed-view controls' })
+        ).toBeInTheDocument();
+    });
+
+    it('deep-links the CTA at the site editor in a new tab', () => {
+        render(
+            <ComposedViewRibbon templateName="Single Post" templateSlug="single" />
+        );
+
+        const cta = screen.getByTestId('ap-composed-view-ribbon-cta');
+
+        expect(cta).toHaveAttribute(
+            'href',
+            '/visual-editor/site?entity=template&slug=single'
+        );
+        expect(cta).toHaveAttribute('target', '_blank');
+        expect(cta).toHaveAttribute('rel', 'noopener noreferrer');
+    });
+
+    it('encodes reserved characters in the slug', () => {
+        render(
+            <ComposedViewRibbon
+                templateName="Odd"
+                templateSlug="single/post&more"
+            />
+        );
+
+        expect(
+            screen.getByTestId('ap-composed-view-ribbon-cta')
+        ).toHaveAttribute(
+            'href',
+            '/visual-editor/site?entity=template&slug=single%2Fpost%26more'
+        );
+    });
+
+    it('honours a host-supplied site-editor route base', () => {
+        render(
+            <ComposedViewRibbon
+                templateName="Single Post"
+                templateSlug="single"
+                siteEditorRouteBase="/admin/site-editor/"
+            />
+        );
+
+        expect(
+            screen.getByTestId('ap-composed-view-ribbon-cta')
+        ).toHaveAttribute(
+            'href',
+            '/admin/site-editor?entity=template&slug=single'
+        );
+    });
+
+    it('hides the CTA on the fallback template, keeping the name', () => {
+        render(
+            <ComposedViewRibbon
+                templateName="Default template"
+                templateSlug={null}
+            />
+        );
+
+        expect(
+            screen.getByText('Editing content inside Default template')
+        ).toBeInTheDocument();
+        expect(
+            screen.queryByTestId('ap-composed-view-ribbon-cta')
+        ).not.toBeInTheDocument();
+    });
+});

--- a/resources/js/visual-editor/editor/composed-view/composed-view-ribbon.css
+++ b/resources/js/visual-editor/editor/composed-view/composed-view-ribbon.css
@@ -1,0 +1,61 @@
+/**
+ * Composed-view ribbon — #623.
+ *
+ * Injected into the canvas iframe via `canvas-styles.ts` (`?inline`),
+ * NOT imported for side effects by the component: the iframe document
+ * sees none of the parent document's Vite-injected stylesheets.
+ *
+ * Colours resolve from the ArtisanPack UI tokens re-established on the
+ * iframe root by `canvas-theme-tokens.css`, with hex fallbacks so the
+ * ribbon still reads correctly when the editor is mounted outside a
+ * DaisyUI host.
+ */
+
+.ap-visual-editor__composed-ribbon {
+	position: sticky;
+	top: 0;
+	z-index: 20;
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	justify-content: space-between;
+	gap: 0.75rem;
+	padding: 0.5rem 1rem;
+	background-color: var( --color-base-200, #f3f4f6 );
+	border-bottom: 1px solid var( --color-base-300, #e5e7eb );
+	color: var( --color-base-content, #1f2937 );
+	font-size: 0.8125rem;
+	line-height: 1.4;
+
+	/* The ribbon is editor chrome that happens to live in the canvas —
+	   selecting its text on the way to selecting a block is never what
+	   the author meant. */
+	user-select: none;
+}
+
+.ap-visual-editor__composed-ribbon-label {
+	font-weight: 500;
+}
+
+.ap-visual-editor__composed-ribbon-cta {
+	flex-shrink: 0;
+	padding: 0.25rem 0.625rem;
+	border: 1px solid var( --color-base-300, #e5e7eb );
+	border-radius: 0.25rem;
+	background-color: var( --color-base-100, #ffffff );
+	color: var( --color-primary, #2563eb );
+	font-weight: 600;
+	text-decoration: none;
+	white-space: nowrap;
+}
+
+.ap-visual-editor__composed-ribbon-cta:hover,
+.ap-visual-editor__composed-ribbon-cta:focus-visible {
+	text-decoration: underline;
+}
+
+.ap-visual-editor__composed-ribbon-cta:focus-visible {
+	outline: var( --wp-admin-border-width-focus, 2px ) solid
+		var( --color-primary, #2563eb );
+	outline-offset: 1px;
+}

--- a/resources/js/visual-editor/editor/composed-view/composed-view-ribbon.tsx
+++ b/resources/js/visual-editor/editor/composed-view/composed-view-ribbon.tsx
@@ -1,0 +1,95 @@
+/**
+ * Composed-view locked-canvas ribbon (#623).
+ *
+ * A single sticky bar at the top of the composed canvas naming the
+ * template the author's content is being previewed inside, plus one
+ * **Edit template ↗** link into the site editor.
+ *
+ * ## Why one ribbon rather than per-part chrome
+ *
+ * The composed canvas renders the template's header and footer as real,
+ * inert blocks (`ChromeBlocks`). Badging each template part with its own
+ * "edit this part" affordance would put four or five competing controls
+ * on a surface whose whole point is to read like the finished page. One
+ * ribbon at the top says the same thing once: this is a preview, here is
+ * what it is, here is where you go to change it. Per-part chrome is
+ * explicitly out of scope for v1.
+ *
+ * ## Why it lives inside the iframe
+ *
+ * Rendering it in the editor chrome (beside the composed notice) would
+ * pin it above the canvas frame, where it reads as another editor
+ * toolbar. Mounted inside `BlockCanvas` it scrolls with the composed
+ * content and sticks to the top of the *preview*, which is what makes it
+ * read as a property of the page rather than of the editor. The cost is
+ * that `composed-view-ribbon.css` cannot be a side-effect import here —
+ * it is pulled in `?inline` by `canvas-styles.ts` and handed to
+ * `BlockCanvas`, like every other in-iframe sheet.
+ *
+ * The CTA opens in a new tab on purpose: the post editor may hold
+ * unsaved content, and navigating away from it to edit template chrome
+ * would be a data-loss trap.
+ *
+ * @since 1.6.0
+ */
+
+import type { ReactElement } from 'react';
+import { __, sprintf } from '@wordpress/i18n';
+
+import { TEXT_DOMAIN } from '../../vendor/i18n';
+import { buildTemplateDeepLink } from '../../site-editor/deep-link';
+
+export interface ComposedViewRibbonProps {
+    /** Resolved template name — the fallback template's name when composing against it. */
+    templateName: string;
+    /**
+     * Resolved template slug, or `null` when composing against the
+     * built-in default template (#624). `null` hides the CTA: the
+     * fallback template is a client-side constant with no site-editor
+     * record behind it, so there is nothing to link to.
+     */
+    templateSlug: string | null;
+    /**
+     * Route base the site editor is mounted at. Defaults to the
+     * package's own mount path; hosts that mount it elsewhere pass
+     * theirs.
+     */
+    siteEditorRouteBase?: string;
+}
+
+export function ComposedViewRibbon(
+    props: ComposedViewRibbonProps
+): ReactElement {
+    const { templateName, templateSlug, siteEditorRouteBase } = props;
+
+    return (
+        <div
+            className="ap-visual-editor__composed-ribbon"
+            role="region"
+            aria-label={__('Composed-view controls', TEXT_DOMAIN)}
+            data-testid="ap-composed-view-ribbon"
+        >
+            <span className="ap-visual-editor__composed-ribbon-label">
+                {sprintf(
+                    /* translators: %s: template name. */
+                    __('Editing content inside %s', TEXT_DOMAIN),
+                    templateName
+                )}
+            </span>
+            {templateSlug !== null ? (
+                <a
+                    className="ap-visual-editor__composed-ribbon-cta"
+                    href={buildTemplateDeepLink(
+                        templateSlug,
+                        siteEditorRouteBase
+                    )}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    data-testid="ap-composed-view-ribbon-cta"
+                >
+                    {__('Edit template ↗', TEXT_DOMAIN)}
+                </a>
+            ) : null}
+        </div>
+    );
+}

--- a/resources/js/visual-editor/editor/composed-view/index.ts
+++ b/resources/js/visual-editor/editor/composed-view/index.ts
@@ -30,6 +30,10 @@ export {
 } from './split';
 export { ChromeBlocks, type ChromeBlocksProps } from './ChromeBlocks';
 export {
+    ComposedViewRibbon,
+    type ComposedViewRibbonProps,
+} from './composed-view-ribbon';
+export {
     useAppliedTemplate,
     type AppliedTemplateState,
     type UseAppliedTemplateOptions,

--- a/resources/js/visual-editor/editor/editor-app.tsx
+++ b/resources/js/visual-editor/editor/editor-app.tsx
@@ -1474,6 +1474,8 @@ function EditorAppShell(props: EditorAppProps): JSX.Element {
                             : {
                                 header: composedChrome.header,
                                 footer: composedChrome.footer,
+                                templateName: composedChrome.templateName,
+                                templateSlug: composedChrome.templateSlug,
                             }
                     }
                 />

--- a/resources/js/visual-editor/editor/editor-canvas.tsx
+++ b/resources/js/visual-editor/editor/editor-canvas.tsx
@@ -41,6 +41,7 @@ import { useMemo } from 'react';
 
 import { canvasStyles } from './canvas-styles';
 import { ChromeBlocks } from './composed-view/ChromeBlocks';
+import { ComposedViewRibbon } from './composed-view/composed-view-ribbon';
 import { PostTitle } from './post-title';
 import { ROOT_CANVAS_LAYOUT } from '../editor-settings';
 import { TEXT_DOMAIN } from '../vendor/i18n';
@@ -53,6 +54,13 @@ import { useThemeGlobalStylesCss } from '../site-editor/use-theme-global-styles-
 export interface CanvasChrome {
     header: readonly BlockInstance[];
     footer: readonly BlockInstance[];
+    /** Resolved template name, shown in the #623 ribbon. */
+    templateName: string;
+    /**
+     * Resolved template slug, or `null` on the built-in fallback
+     * template. `null` hides the ribbon's **Edit template ↗** CTA.
+     */
+    templateSlug: string | null;
 }
 
 /** Block context value stamped onto the canvas for cms-framework entities. */
@@ -134,11 +142,21 @@ export function EditorCanvas(props: EditorCanvasProps): JSX.Element {
     // previews mount isolated block-editor stores of their own, so the
     // content provider's `value` is untouched and the canvas never
     // remounts across a composed-view toggle.
+    //
+    // The #623 ribbon leads the composed stack. It is the only editing
+    // affordance for template chrome in v1 — individual template parts
+    // get no per-part badge — and it renders in here rather than in the
+    // editor shell so it sticks to the top of the *preview* and scrolls
+    // with it. Bare-content mode (`chrome === null`) never mounts it.
     const blockList =
         chrome === null || chrome === undefined ? (
             <BlockList layout={ROOT_CANVAS_LAYOUT} />
         ) : (
             <>
+                <ComposedViewRibbon
+                    templateName={chrome.templateName}
+                    templateSlug={chrome.templateSlug}
+                />
                 <ChromeBlocks
                     blocks={chrome.header}
                     region="header"

--- a/resources/js/visual-editor/site-editor/__tests__/deep-link.test.ts
+++ b/resources/js/visual-editor/site-editor/__tests__/deep-link.test.ts
@@ -1,0 +1,90 @@
+/**
+ * `deep-link.ts` is the pure half of #625 — the query-string contract
+ * the composed view's **Edit template ↗** CTA writes and the SPA reads.
+ * Parsing is asserted here; the navigation it drives lives in
+ * `use-deep-link.test.tsx`.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { buildTemplateDeepLink, parseDeepLink } from '../deep-link';
+
+describe('parseDeepLink', () => {
+    it('parses a template deep link', () => {
+        expect(parseDeepLink('?entity=template&slug=single')).toEqual({
+            entity: 'template',
+            slug: 'single',
+            entityId: null,
+        });
+    });
+
+    it('accepts a search string without the leading question mark', () => {
+        expect(parseDeepLink('entity=template&slug=single')).toEqual({
+            entity: 'template',
+            slug: 'single',
+            entityId: null,
+        });
+    });
+
+    it('decodes percent-encoded slugs', () => {
+        expect(parseDeepLink('?entity=template&slug=single%2Fpost')).toEqual({
+            entity: 'template',
+            slug: 'single/post',
+            entityId: null,
+        });
+    });
+
+    it('carries entity_id through when present', () => {
+        expect(
+            parseDeepLink('?entity=template&slug=single&entity_id=42')
+        ).toEqual({
+            entity: 'template',
+            slug: 'single',
+            entityId: '42',
+        });
+    });
+
+    it.each([
+        ['empty search', ''],
+        ['no leading params', '?'],
+        ['unrelated params only', '?foo=bar'],
+        ['no slug', '?entity=template'],
+        ['blank slug', '?entity=template&slug='],
+        ['whitespace-only slug', '?entity=template&slug=%20%20'],
+        ['unknown entity', '?entity=navigation&slug=primary'],
+        ['slug without entity', '?slug=single'],
+    ])('returns null for %s', (_label, search) => {
+        expect(parseDeepLink(search)).toBeNull();
+    });
+});
+
+describe('buildTemplateDeepLink', () => {
+    it('builds against the package route base by default', () => {
+        expect(buildTemplateDeepLink('single')).toBe(
+            '/visual-editor/site?entity=template&slug=single'
+        );
+    });
+
+    it('encodes reserved characters in the slug', () => {
+        expect(buildTemplateDeepLink('single/post&more')).toBe(
+            '/visual-editor/site?entity=template&slug=single%2Fpost%26more'
+        );
+    });
+
+    it('strips trailing slashes from a host-supplied route base', () => {
+        expect(buildTemplateDeepLink('single', '/admin/site/')).toBe(
+            '/admin/site?entity=template&slug=single'
+        );
+    });
+
+    it('round-trips through parseDeepLink', () => {
+        const url = buildTemplateDeepLink('single/post&more');
+        const search = url.slice(url.indexOf('?'));
+
+        expect(parseDeepLink(search)).toEqual({
+            entity: 'template',
+            slug: 'single/post&more',
+            entityId: null,
+        });
+    });
+});

--- a/resources/js/visual-editor/site-editor/__tests__/use-deep-link.test.tsx
+++ b/resources/js/visual-editor/site-editor/__tests__/use-deep-link.test.tsx
@@ -1,0 +1,157 @@
+/**
+ * `useSiteEditorDeepLink` (#625) turns a mount-time
+ * `?entity=template&slug=…` into a router navigation. The list endpoint
+ * is stubbed so the suite asserts the resolve → navigate → toast wiring
+ * rather than re-testing `api-client.ts`.
+ */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import { ToastProvider } from '@artisanpack-ui/react/feedback';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const listEntities = vi.fn();
+
+vi.mock('../api-client', () => ({
+    listEntities: (...args: readonly unknown[]) => listEntities(...args),
+}));
+
+import { useSiteEditorDeepLink } from '../use-deep-link';
+
+const apiConfig = { apiBase: '/visual-editor/api' };
+
+function Harness(props: { search: string; navigate: ReturnType<typeof vi.fn> }): JSX.Element {
+    useSiteEditorDeepLink({
+        apiConfig,
+        navigate: props.navigate,
+        search: props.search,
+    });
+
+    return <div data-testid="ap-deep-link-harness" />;
+}
+
+function renderHarness(search: string) {
+    const navigate = vi.fn();
+
+    const result = render(
+        <ToastProvider>
+            <Harness search={search} navigate={navigate} />
+        </ToastProvider>
+    );
+
+    return { ...result, navigate };
+}
+
+describe('useSiteEditorDeepLink', () => {
+    beforeEach(() => {
+        listEntities.mockReset();
+    });
+
+    it('navigates to the resolved template on mount', async () => {
+        listEntities.mockResolvedValue([{ id: 12, slug: 'single' }]);
+
+        const { navigate } = renderHarness('?entity=template&slug=single');
+
+        await waitFor(() => {
+            expect(navigate).toHaveBeenCalledWith('templates', '12');
+        });
+
+        expect(listEntities).toHaveBeenCalledWith(apiConfig, 'template', {
+            slug: 'single',
+        });
+    });
+
+    it('ignores a slug the endpoint returns alongside non-matching rows', async () => {
+        // A host that drops the `slug` filter hands back the whole list;
+        // picking `matches[0]` would open the wrong template.
+        listEntities.mockResolvedValue([
+            { id: 3, slug: 'archive' },
+            { id: 7, slug: 'single' },
+        ]);
+
+        const { navigate } = renderHarness('?entity=template&slug=single');
+
+        await waitFor(() => {
+            expect(navigate).toHaveBeenCalledWith('templates', '7');
+        });
+    });
+
+    it('lands on the templates index with a toast when the slug is unknown', async () => {
+        listEntities.mockResolvedValue([]);
+
+        const { navigate } = renderHarness('?entity=template&slug=nope');
+
+        await waitFor(() => {
+            expect(navigate).toHaveBeenCalledWith('templates', null);
+        });
+
+        expect(
+            await screen.findByText('The template “nope” was not found.')
+        ).toBeInTheDocument();
+    });
+
+    it('lands on the templates index with a toast when the lookup fails', async () => {
+        listEntities.mockRejectedValue(new Error('network down'));
+
+        const { navigate } = renderHarness('?entity=template&slug=single');
+
+        await waitFor(() => {
+            expect(navigate).toHaveBeenCalledWith('templates', null);
+        });
+
+        expect(
+            await screen.findByText('The template “single” was not found.')
+        ).toBeInTheDocument();
+    });
+
+    it('skips the lookup when entity_id is supplied', async () => {
+        const { navigate } = renderHarness(
+            '?entity=template&slug=single&entity_id=42'
+        );
+
+        await waitFor(() => {
+            expect(navigate).toHaveBeenCalledWith('templates', '42');
+        });
+
+        expect(listEntities).not.toHaveBeenCalled();
+    });
+
+    it.each([
+        ['no query string', ''],
+        ['unrelated params', '?foo=bar'],
+        ['unknown entity', '?entity=navigation&slug=primary'],
+        ['entity without slug', '?entity=template'],
+    ])('is a no-op for %s', async (_label, search) => {
+        const { navigate } = renderHarness(search);
+
+        expect(await screen.findByTestId('ap-deep-link-harness')).toBeInTheDocument();
+        expect(navigate).not.toHaveBeenCalled();
+        expect(listEntities).not.toHaveBeenCalled();
+    });
+
+    it('resolves at most once per mount even as the component re-renders', async () => {
+        listEntities.mockResolvedValue([{ id: 12, slug: 'single' }]);
+
+        const navigate = vi.fn();
+        const { rerender } = render(
+            <ToastProvider>
+                <Harness search="?entity=template&slug=single" navigate={navigate} />
+            </ToastProvider>
+        );
+
+        await waitFor(() => {
+            expect(navigate).toHaveBeenCalledTimes(1);
+        });
+
+        rerender(
+            <ToastProvider>
+                <Harness search="?entity=template&slug=single" navigate={navigate} />
+            </ToastProvider>
+        );
+
+        await waitFor(() => {
+            expect(listEntities).toHaveBeenCalledTimes(1);
+        });
+
+        expect(navigate).toHaveBeenCalledTimes(1);
+    });
+});

--- a/resources/js/visual-editor/site-editor/deep-link.ts
+++ b/resources/js/visual-editor/site-editor/deep-link.ts
@@ -1,0 +1,99 @@
+/**
+ * Site-editor deep-link contract (#625).
+ *
+ * The SPA's own routing is pathname-based (`/visual-editor/site/templates/12`
+ * — see `use-site-editor-routing.ts`), which is fine for links the site
+ * editor hands out itself: it knows the entity's database id. Callers
+ * *outside* the SPA do not. The post editor's composed view (#623) knows
+ * only the template slug it composed against, and the applied-template
+ * endpoint never returns an id.
+ *
+ * So the deep-link surface is keyed on `slug`, not id, and is carried in
+ * the query string rather than the path so it stays clearly separate from
+ * the canonical route the SPA rewrites to once it has resolved the slug:
+ *
+ *   /visual-editor/site?entity=template&slug=single
+ *
+ * `entity_id` is accepted alongside `slug` for future entity types that
+ * have no slug of their own; nothing reads it yet, but parsing it here
+ * means the contract does not have to change shape when something does.
+ *
+ * Everything in this module is pure so the parse can be unit-tested
+ * without a router, a DOM, or a network.
+ *
+ * @since 1.6.0
+ */
+
+/** Entity kinds the deep-link surface understands. */
+export type DeepLinkEntity = 'template';
+
+export interface DeepLinkRequest {
+    entity: DeepLinkEntity;
+    /** Entity slug to resolve. Empty slugs are rejected during parsing. */
+    slug: string;
+    /**
+     * Optional pre-resolved id. Reserved for entity kinds that have no
+     * slug; when present the resolver can skip the lookup entirely.
+     */
+    entityId: string | null;
+}
+
+/** Route base the site editor is mounted at by the package's own routes. */
+export const SITE_EDITOR_ROUTE_BASE = '/visual-editor/site';
+
+const SUPPORTED_ENTITIES: ReadonlySet<string> = new Set<DeepLinkEntity>([
+    'template',
+]);
+
+/**
+ * Parse a `location.search` string into a deep-link request.
+ *
+ * Returns `null` for every shape the SPA should treat as "no deep link
+ * requested" — no query string, an unsupported `entity` value, or a
+ * supported entity with no usable `slug`. An unknown entity is a no-op
+ * rather than an error on purpose: the query string is a public URL
+ * surface, and a future package version adding `entity=navigation` must
+ * not make today's build throw when a user pastes tomorrow's link.
+ */
+export function parseDeepLink(search: string): DeepLinkRequest | null {
+    // `URLSearchParams` accepts a leading `?` and an empty string, so no
+    // normalisation is needed beyond handing it the raw value.
+    const params = new URLSearchParams(search);
+    const entity = params.get('entity')?.trim() ?? '';
+
+    if (!SUPPORTED_ENTITIES.has(entity)) {
+        return null;
+    }
+
+    const slug = params.get('slug')?.trim() ?? '';
+
+    if (slug === '') {
+        return null;
+    }
+
+    const entityId = params.get('entity_id')?.trim() ?? '';
+
+    return {
+        entity: entity as DeepLinkEntity,
+        slug,
+        entityId: entityId === '' ? null : entityId,
+    };
+}
+
+/**
+ * Build a deep link to a template's editor view.
+ *
+ * The counterpart to {@link parseDeepLink}: callers outside the SPA use
+ * this rather than hand-assembling the query string, so the two sides of
+ * the contract move together. `routeBase` defaults to the package's own
+ * mount path; hosts that mount the site editor elsewhere pass theirs.
+ */
+export function buildTemplateDeepLink(
+    slug: string,
+    routeBase: string = SITE_EDITOR_ROUTE_BASE
+): string {
+    const normalizedBase = routeBase.replace(/\/+$/, '');
+    const query = new URLSearchParams({ entity: 'template', slug });
+
+    return `${normalizedBase}?${query.toString()}`;
+}

--- a/resources/js/visual-editor/site-editor/site-editor-app.tsx
+++ b/resources/js/visual-editor/site-editor/site-editor-app.tsx
@@ -16,6 +16,7 @@
  */
 
 import { Suspense, lazy, useCallback, useEffect, useId, useMemo, useState } from 'react';
+import { ToastProvider } from '@artisanpack-ui/react/feedback';
 import { __, sprintf } from '@wordpress/i18n';
 
 import { TEXT_DOMAIN, bootI18n } from '../vendor/i18n';
@@ -43,6 +44,7 @@ import {
     TemplatePartCreateDialog,
     TemplatePartsBrowser,
 } from './template-parts-section';
+import { useSiteEditorDeepLink } from './use-deep-link';
 import { usePersistedToggle } from './use-persisted-toggle';
 import { useSiteEditorRouting } from './use-site-editor-routing';
 import { registerBackgroundControls } from '../background-controls';
@@ -229,7 +231,21 @@ function sectionKind(section: SiteEditorSectionId): EntityKind | null {
     return null;
 }
 
+/**
+ * SPA root. The `ToastProvider` wrapper mirrors the post editor
+ * (`editor-app.tsx`): the shell's own hooks — #625's deep-link resolver
+ * for one — announce through `useToast`, which needs a provider ancestor
+ * mounted outside the component that consumes it.
+ */
 export function SiteEditorApp(props: SiteEditorAppProps): JSX.Element {
+    return (
+        <ToastProvider>
+            <SiteEditorAppShell {...props} />
+        </ToastProvider>
+    );
+}
+
+function SiteEditorAppShell(props: SiteEditorAppProps): JSX.Element {
     ensureEditorBoot();
 
     const { routeBase, apiBase, exitUrl, exitLabel, theme = 'default' } = props;
@@ -240,6 +256,13 @@ export function SiteEditorApp(props: SiteEditorAppProps): JSX.Element {
     );
 
     const routing = useSiteEditorRouting({ routeBase });
+
+    // #625 — `?entity=template&slug=…` on the mount URL lands the user on
+    // that template's editor view instead of the default section. No-ops
+    // when the query string carries no deep link, so plain mounts are
+    // unaffected.
+    useSiteEditorDeepLink({ apiConfig, navigate: routing.navigate });
+
     const [navigatorOpen, setNavigatorOpen] = usePersistedToggle(
         NAVIGATOR_STORAGE_KEY,
         true

--- a/resources/js/visual-editor/site-editor/use-deep-link.ts
+++ b/resources/js/visual-editor/site-editor/use-deep-link.ts
@@ -1,0 +1,158 @@
+/**
+ * On-mount deep-link resolution for the site editor (#625).
+ *
+ * Reads `?entity=…&slug=…` off `location.search` once, resolves the slug
+ * to an entity id through the list endpoint, and pushes the SPA's router
+ * at the matching editor view. The whole thing is additive: with no
+ * query string the hook returns before it touches the network and the
+ * SPA lands exactly where it does today.
+ *
+ * ## Why a lookup rather than a slug route
+ *
+ * `useSiteEditorRouting` addresses entities by id, and the applied-template
+ * endpoint the composed view reads (#623) returns a slug and no id. Rather
+ * than teach the router a second addressing mode — and have every entity
+ * view guess which one it was handed — the slug is resolved to an id here,
+ * once, and the router keeps its single id-shaped contract. The pushState
+ * the navigate performs also drops the query string, so the resolved
+ * canonical URL is what the user ends up with in their address bar.
+ *
+ * ## Failure is a landing, not a crash
+ *
+ * An unresolvable slug lands on the Templates index with a toast naming
+ * the slug. A failed lookup does the same: an author who followed an
+ * **Edit template ↗** link wants to be in the site editor either way, and
+ * the templates list is one click from wherever they were headed.
+ *
+ * @since 1.6.0
+ */
+
+import { useEffect, useRef } from 'react';
+import { __, sprintf } from '@wordpress/i18n';
+import { useToast } from '@artisanpack-ui/react/feedback';
+
+import { TEXT_DOMAIN } from '../vendor/i18n';
+
+import { listEntities, type SiteEditorApiConfig } from './api-client';
+import { parseDeepLink } from './deep-link';
+import type { SiteEditorSectionId } from './sections';
+
+export interface UseSiteEditorDeepLinkOptions {
+    apiConfig: SiteEditorApiConfig;
+    /** The routing instance's `navigate` — same signature, same push semantics. */
+    navigate: (section: SiteEditorSectionId, entityId?: string | null) => void;
+    /**
+     * Query string to parse. Defaults to `window.location.search`; tests
+     * (and any SSR host) pass their own rather than mutating `location`.
+     */
+    search?: string;
+}
+
+/**
+ * Resolve the mount-time deep link, if there is one. Fires at most once
+ * per mount.
+ *
+ * Every mutable input is read through a ref so the effect can carry an
+ * empty dependency array: a re-render that changes `navigate`'s identity
+ * must not re-navigate the user away from wherever they have since
+ * browsed. A ref *latch* would do the same job for re-renders but would
+ * turn a double-invoked effect (React StrictMode, or a remount in place)
+ * into a mount that never navigates at all, which is a far worse failure
+ * than navigating twice to the same destination.
+ */
+export function useSiteEditorDeepLink(
+    options: UseSiteEditorDeepLinkOptions
+): void {
+    const { apiConfig, navigate, search } = options;
+    const toast = useToast();
+
+    const navigateRef = useRef(navigate);
+    navigateRef.current = navigate;
+    const toastRef = useRef(toast);
+    toastRef.current = toast;
+    const apiConfigRef = useRef(apiConfig);
+    apiConfigRef.current = apiConfig;
+    const searchRef = useRef(search);
+    searchRef.current = search;
+
+    useEffect(() => {
+        const rawSearch =
+            searchRef.current ??
+            (typeof window === 'undefined' ? '' : window.location.search);
+        const parsed = parseDeepLink(rawSearch);
+
+        if (parsed === null) {
+            return;
+        }
+
+        const request = parsed;
+        let cancelled = false;
+
+        function landOnIndex(): void {
+            if (cancelled) {
+                return;
+            }
+
+            navigateRef.current('templates', null);
+            toastRef.current.warning(
+                sprintf(
+                    /* translators: %s: requested template slug. */
+                    __('The template “%s” was not found.', TEXT_DOMAIN),
+                    request.slug
+                )
+            );
+        }
+
+        function landOnEntity(entityId: string): void {
+            if (cancelled) {
+                return;
+            }
+
+            navigateRef.current('templates', entityId);
+        }
+
+        async function resolve(): Promise<void> {
+            // A caller that already knows the id skips the lookup — the
+            // reserved `entity_id` path (see `deep-link.ts`).
+            if (request.entityId !== null) {
+                landOnEntity(request.entityId);
+
+                return;
+            }
+
+            try {
+                const matches = await listEntities(
+                    apiConfigRef.current,
+                    'template',
+                    { slug: request.slug }
+                );
+
+                // The list endpoint filters server-side, but a host that
+                // ignores the `slug` param would hand back every template.
+                // Match explicitly rather than trusting `matches[0]`.
+                const match = matches.find(
+                    (record) => record.slug === request.slug
+                );
+
+                if (match === undefined) {
+                    landOnIndex();
+
+                    return;
+                }
+
+                landOnEntity(String(match.id));
+            } catch {
+                landOnIndex();
+            }
+        }
+
+        void resolve();
+
+        return (): void => {
+            cancelled = true;
+        };
+        // Mount-only by design — every mutable input is read through the
+        // refs above, so an empty dependency array is correct rather than
+        // a lint workaround.
+    }, []);
+}

--- a/resources/js/visual-editor/test-setup.ts
+++ b/resources/js/visual-editor/test-setup.ts
@@ -1,5 +1,73 @@
 import '@testing-library/jest-dom/vitest';
 
+/**
+ * Restore `localStorage` / `sessionStorage` when the test global has been
+ * left holding an inert stub.
+ *
+ * jsdom implements Web Storage correctly, but vitest never copies it onto
+ * the test global on newer Node. `getWindowKeys()` filters jsdom's window
+ * properties with `if (k in global) return KEYS.includes(k)` — i.e. a key
+ * that already exists on Node's `globalThis` is only copied when it is in
+ * vitest's own allow-list, and `localStorage` is not on that list.
+ *
+ * Node 22+ ships an experimental Web Storage global whose accessor returns
+ * `undefined` unless the process was started with `--localstorage-file`.
+ * So on those versions the key *is* in `globalThis`, vitest skips it, and
+ * jsdom's working implementation is shadowed by Node's inert one:
+ * `'localStorage' in window` is `true` while `window.localStorage` is
+ * `undefined`. On older Node the key is absent, vitest copies jsdom's
+ * version, and everything works — which is why this only appears after a
+ * Node upgrade rather than a code change.
+ *
+ * The shim below is a plain in-memory `Storage`. It deliberately does not
+ * implement the named-property access an index proxy would give you
+ * (`storage.foo = 'bar'`); nothing in this codebase uses that form, and a
+ * Proxy here would buy complexity for no coverage.
+ */
+function createMemoryStorage(): Storage {
+    const entries = new Map<string, string>();
+
+    return {
+        get length(): number {
+            return entries.size;
+        },
+        key(index: number): string | null {
+            return Array.from(entries.keys())[index] ?? null;
+        },
+        getItem(key: string): string | null {
+            return entries.get(String(key)) ?? null;
+        },
+        setItem(key: string, value: string): void {
+            entries.set(String(key), String(value));
+        },
+        removeItem(key: string): void {
+            entries.delete(String(key));
+        },
+        clear(): void {
+            entries.clear();
+        },
+    } as Storage;
+}
+
+if (typeof window !== 'undefined') {
+    for (const area of ['localStorage', 'sessionStorage'] as const) {
+        // Only step in when the global is genuinely unusable. When jsdom's
+        // implementation did survive, leave it alone — it is the real
+        // thing, and it is shared with `document`'s storage events.
+        if (window[area] !== undefined) {
+            continue;
+        }
+
+        // `defineProperty`, not assignment: the property Node leaves behind
+        // is an accessor whose setter would swallow a plain write.
+        Object.defineProperty(window, area, {
+            configurable: true,
+            writable: true,
+            value: createMemoryStorage(),
+        });
+    }
+}
+
 // `@wordpress/components` calls `window.matchMedia` through its responsive
 // helpers (e.g. `PanelBody`, `SelectControl`). jsdom doesn't ship a
 // `matchMedia` implementation so the component import throws. Install a


### PR DESCRIPTION
## Description

Adds the composed view's locked-canvas ribbon (#623) and the site-editor
deep-link surface its CTA targets (#625). Shipped together because the
ribbon's **Edit template ↗** button is the deep link's first consumer —
splitting them would land a button pointing at a route that doesn't
resolve yet.

**Closes:** #623, #625

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #623, #625 (both under parent #618, milestone v1.6)

## Motivation and Context

The composed view renders a template's header and footer as inert blocks
around the author's content. Until now nothing on that surface explained
what the template was or offered a way to go edit it — an author reading
a header they can't click had no next step.

The ribbon is that step, and it is deliberately the *only* one: per-part
chrome would put four or five competing controls on a surface whose whole
point is to read like the finished page.

The CTA needed somewhere to land. Path routes address entities by id, and
the applied-template endpoint returns only a slug, so the site editor
gained a slug-keyed query-string entry point rather than the router
learning a second addressing mode.

## Changes Made

**#623 — composed-view ribbon**

- New `editor/composed-view/composed-view-ribbon.tsx` + `.css` — sticky bar rendered *inside* the canvas iframe so it scrolls with the preview and reads as part of the page, not another editor toolbar
- `editor/canvas-styles.ts` — ribbon CSS injected `?inline` into the iframe (the `blocks/*/*.css` glob doesn't reach `composed-view/`)
- `editor/editor-canvas.tsx` — `CanvasChrome` gained `templateName` / `templateSlug`; the ribbon mounts only when chrome is present, so bare-content mode never renders it
- `editor/editor-app.tsx` — forwards the name/slug it had already resolved
- Fallback template (#624) shows its name with **no CTA** — that tree is a client-side constant with no site-editor record to link to

**#625 — site-editor deep link**

- New `site-editor/deep-link.ts` — `parseDeepLink()` / `buildTemplateDeepLink()`, both pure. The ribbon builds its href with the builder so the two sides of the contract move together
- New `site-editor/use-deep-link.ts` — resolves slug → id via the templates list endpoint on mount, then navigates. Unknown slug or failed lookup lands on the Templates index with a toast
- `site-editor/site-editor-app.tsx` — wrapped in `ToastProvider` (mirrors the post editor) and calls the hook
- `docs/site-editor.md` — new "Deep links by slug" section documenting the parameter table and guarantees

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (Darwin 27.0.0)
- Browser (if applicable): verified in-browser against the ArtisanPack UI dev app
- PHP Version: 8.4.3
- Project Version: v1.6 milestone (branched off `feature/templates-preview`)

**Tests Performed:**
1. Composed view on a post with a template — ribbon renders, sticks to the top of the canvas while scrolling, names the template
2. Toggled back to content mode — ribbon disappears entirely
3. Clicked **Edit template ↗** — new tab, site editor lands directly on that template's editor view, address bar rewrites to the canonical `/visual-editor/site/templates/{id}`
4. Post with no template / unknown slug — ribbon reads "Editing content inside Default template" with no CTA
5. Hand-typed `?entity=template&slug=does-not-exist` — Templates index plus the not-found toast
6. Plain `/visual-editor/site` — unchanged from before

## Accessibility Tests Run

- [x] Keyboard navigation tested
- [ ] Screen reader tested
- [x] Color contrast verified
- [x] ARIA labels checked

**Details:** The ribbon is a `role="region"` landmark labelled
"Composed-view controls", so screen-reader users can reach it by landmark
rather than having to scroll the canvas. The CTA is a real `<a>` — keyboard
focusable in document order, with a visible `:focus-visible` outline drawn
from the theme's focus-width token. Colours resolve from the ArtisanPack UI
`--color-base-*` tokens (with hex fallbacks for non-DaisyUI hosts) so the
ribbon inherits whatever contrast the active theme guarantees. Not yet
verified with an actual screen reader.

## Tests Added

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All tests passing

**Test details:**

- `composed-view-ribbon.test.tsx` (6) — name rendering, landmark labelling, deep-link href, slug encoding, host route-base override, CTA hidden on the fallback
- `editor-canvas.test.tsx` (+3) — ribbon absent in bare-content mode, mounted *inside* the `BlockCanvas` stub rather than beside it, CTA dropped on the fallback
- `deep-link.test.ts` (16) — parse/build round-trip plus every rejected shape (unknown entity, blank slug, no entity, …)
- `use-deep-link.test.tsx` (10) — resolve-and-navigate, explicit slug matching when the host ignores the filter, unknown-slug and lookup-failure toasts, `entity_id` short-circuit, no-op cases, once-per-mount
- `canvas-styles.test.ts` — cascade-order assertion updated for the appended ribbon sheet

`npm test`: **326 files, 2996 tests, all passing.**

This branch also fixes a test-harness break it inherited. All 18 tests in
`site-editor-app.test.tsx` were failing on `window.localStorage.clear()`,
on this branch and on `feature/templates-preview` alike. Root cause was
neither jsdom nor this repo: vitest's `getWindowKeys()` only copies a
jsdom window property onto the test global if the key is absent from
Node's `globalThis` or present in vitest's own allow-list. Node 22+ ships
an experimental Web Storage global that returns `undefined` without
`--localstorage-file`, and `localStorage` is not on vitest's list — so
Node's inert stub shadowed jsdom's working implementation
(`'localStorage' in window` true, `window.localStorage` undefined). It
surfaced on a Node upgrade rather than a code change.

`test-setup.ts` now installs an in-memory `Storage` for `localStorage`
and `sessionStorage`, but only when the global is genuinely unusable, so
a working jsdom implementation is never replaced. That restores real
coverage of `SiteEditorApp` — including this PR's `ToastProvider` wrapper
and the deep-link hook — rather than leaving it silently unexercised.

Also verified with a real `npm run build` that the `?inline` ribbon
stylesheet lands in the editor chunk.

## Documentation

- [x] Inline code documentation added
- [ ] README updated
- [ ] Wiki updated
- [x] API documentation updated

**Documentation details:** `docs/site-editor.md` gained a "Deep links by
slug" section under URL routing — the parameter table, the additive /
unknown-entity-no-op / access-gate-unchanged guarantees, and a pointer at
`buildTemplateDeepLink()` as the supported way to construct links.

It also records a known limitation surfaced during review: the ribbon's
CTA uses the default `/visual-editor/site` base because the post editor
has no way to discover a `data-route-base` a host may have overridden on
the site-editor mount element. `buildTemplateDeepLink()` and the ribbon
both already accept the base as a parameter, so threading the host value
through is the follow-up — left out of scope here rather than guessed at.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [x] Accessibility tests completed
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated
