### PR TITLE
test(composed-view): chrome inertness + toggle-state tripwires, bindings coverage, and Composed-View docs

### DIFF
--- a/docs/home.md
+++ b/docs/home.md
@@ -50,6 +50,7 @@ The block editor for a single resource — a post, page, or any custom Eloquent 
 - [[Post Editor]] — Surface tour and what each region does
 - [[post-editor/Getting Started]] — Mount your first editor in five minutes
 - [[post-editor/Blade Component]] — `<x-visual-editor />` reference
+- [[post-editor/Composed View]] — Editing content inside its resolved template
 - [[post-editor/Livewire Integration]] — Embedding inside Livewire components
 - [[post-editor/Inertia Integration]] — Embedding inside Inertia (React or Vue)
 - [[post-editor/Theming]] — Restyling editor chrome through DaisyUI tokens

--- a/docs/post-editor.md
+++ b/docs/post-editor.md
@@ -56,6 +56,13 @@ on boot and injected into the iframe via the React renderer's
 Block selection, drag-and-drop, undo/redo, and keyboard shortcuts come
 from `@wordpress/block-editor` unchanged.
 
+The topbar's **Content only** / **With template** switch composes the
+resolved template's header and footer around the canvas as a read-only
+preview, so authors can judge their content in context without leaving
+the editor. Template chrome is edited in the site editor, reached from
+the composed canvas's **Edit template ↗** deep link. See
+[Composed view](post-editor/Composed-View.md).
+
 ---
 
 ## 3. Inspector sidebar
@@ -194,6 +201,7 @@ or Inertia. Embedding recipes:
 ## See also
 
 - [Blade component reference](post-editor/Blade-Component.md)
+- [Composed view](post-editor/Composed-View.md) — edit content inside its resolved template
 - [Custom blocks](blocks/Custom-Blocks.md)
 - [Renderers](renderers.md) — get saved content back onto the public site
 - [Theming](post-editor/Theming.md) — restyle editor chrome

--- a/docs/post-editor/Composed-View.md
+++ b/docs/post-editor/Composed-View.md
@@ -1,0 +1,196 @@
+# Composed view
+
+The composed view previews an author's content *inside the template it
+will actually render in* — header, footer, and all — without leaving the
+post editor. Content stays fully editable; the surrounding template
+chrome is a read-only preview.
+
+It answers the question the bare canvas can't: "does this heading still
+work under the site header, and does the page end sensibly above the
+footer?" Before it, the only way to find out was to open Preview in
+another tab and lose the editing context.
+
+---
+
+## 1. When to use it
+
+Use it when the *shape* of the page matters:
+
+- Checking a hero or opening heading against the real site header.
+- Judging spacing and rhythm at the top and bottom of the content.
+- Confirming which template a piece of content actually resolved to.
+
+Keep it off for ordinary writing. The chrome is extra rendering on every
+canvas update, and the content area is narrower on small screens because
+the template's layout constraints apply to it.
+
+The composed view is **not** pixel-parity with the front end. Template
+wrappers that contain the content slot are split in two around it (see
+§3), which the front end does not do. Use **Preview** when you need the
+real thing.
+
+---
+
+## 2. Toggling it
+
+The topbar carries a switch beside the save status, labelled **Content
+only** / **With template** (`role="switch"`, accessible name *View with
+template*).
+
+- Every editor mount starts in **Content only**. The view mode is
+  ephemeral — it is not persisted per user or per document.
+- The first flip to **With template** issues
+  `GET /visual-editor/api/{resource}/{id}/applied-template`, passing the
+  template currently selected in the document panel rather than the one
+  last saved. The switch is disabled while that request is in flight
+  (title: *Loading applied template…*).
+- Results are cached per `(resource, id, template)` for the lifetime of
+  the editor mount, so later flips are instant. Picking a different
+  template in the document panel invalidates that cache and re-resolves.
+
+Toggling is a presentation change only. It records no undo entry, marks
+nothing dirty, and never touches the block tree — selection, undo history
+and unsaved changes are all exactly where you left them when you flip
+back.
+
+---
+
+## 3. What is editable, and what is not
+
+| Region | State |
+|--------|-------|
+| Post title | Editable — the canvas title field, as in bare-content mode |
+| Content blocks | Editable — the live block canvas, unchanged |
+| Template header chrome | Read-only preview |
+| Template footer chrome | Read-only preview |
+| Ribbon at the top of the canvas | Not content — editor chrome (see §5) |
+
+The template's blocks render *above and below* the block canvas, inside
+the same iframe, so they pick up the theme's compiled CSS exactly as the
+content does.
+
+**Why a preview rather than a locked editable.** The chrome is rendered
+through Gutenberg's block-preview provider, which mounts its own isolated
+block-editor store and wraps the subtree in `useDisabled()`. That is what
+makes it genuinely non-selectable and non-editable — not a `lock`
+attribute, which only asks the UI nicely and still leaves an editable
+surface with a live selection. The isolation matters for a second reason:
+the content editor's own block tree is never swapped when you toggle, so
+there is no state to lose and no feedback loop between the two trees.
+
+The practical consequence: clicking the site header in the composed view
+does nothing at all. That is intended, and the standing notice above the
+canvas says so — *Only your content is editable here — the surrounding
+template areas are edited in the site editor.* To change the chrome, use
+the ribbon CTA (§5).
+
+**Where the split happens.** The template is cut at its
+`post-content` slot: everything before becomes header chrome, everything
+after becomes footer chrome. When the slot is nested inside a layout
+wrapper, the wrapper is cloned onto both sides so the surrounding layout
+still reads correctly. If a template declares no content slot at all, the
+whole template renders as header chrome and a warning notice says so —
+*The template "…" has no content area, so your content is shown below the
+whole template.*
+
+**Bindings resolve against the current content.** `post-title`,
+`post-author`, `post-date` and `post-featured-image` blocks inside the
+template chrome resolve their bound values against the post being edited,
+not against the template's sample data. The chrome renders inside the
+same entity block context as the content, so it shows this post's title
+and this post's author.
+
+---
+
+## 4. The fallback template
+
+The composed view always has something to show. When no real template
+resolves, it composes against a built-in **Default template** — a minimal
+tree of post title, featured image, content slot, in that order.
+
+It kicks in for three cases:
+
+| Case | Notice tone | Copy |
+|------|-------------|------|
+| Content has no template selected | warning | *No template is set for this content — previewing on the default template.* |
+| Selected slug resolves to nothing | warning | *The template "{slug}" is unavailable — previewing on the default template.* |
+| The request failed outright | error | *The template could not be loaded — previewing on the default template.* |
+
+Each is announced twice, deliberately: once as a toast when the toggle is
+flipped on, and once as a standing notice above the canvas that is still
+there a minute later when the toast has auto-dismissed.
+
+The default template is a client-side constant, not a database record.
+It is not editable, does not appear in the site editor's template list,
+and has no slug — which is why the ribbon's **Edit template ↗** CTA is
+hidden while composing against it.
+
+---
+
+## 5. The ribbon and the Edit template deep link
+
+A sticky ribbon leads the composed canvas: *Editing content inside
+{template name}*, plus a single **Edit template ↗** link.
+
+It sits *inside* the canvas iframe so it scrolls with the preview and
+reads as a property of the page rather than another editor toolbar.
+Individual template parts get no per-part badge — one statement at the
+top, not five competing controls on a surface whose whole point is to
+read like the finished page.
+
+The CTA opens the site editor in a **new tab**, at a query-string deep
+link:
+
+```text
+/visual-editor/site?entity=template&slug=single
+```
+
+New tab on purpose: the post editor may be holding unsaved content, and
+navigating away from it to edit template chrome would be a data-loss
+trap.
+
+The site editor parses that query string on mount, resolves the slug, and
+lands on that template's editor view — rewriting the address bar to the
+canonical path route as it goes. The full contract, including the
+`entity_id` escape hatch and the unresolvable-slug behaviour, is in
+[Site editor §5](../site-editor.md#deep-links-by-slug).
+
+Build these links with `buildTemplateDeepLink()` from
+`site-editor/deep-link.ts` rather than assembling the query string by
+hand. It defaults to the package's own mount path; a host that mounts the
+site editor elsewhere will get a CTA pointing at the default path until
+that route base is threaded through to the post editor.
+
+---
+
+## 6. Endpoint
+
+```http
+GET /visual-editor/api/{resource}/{id}/applied-template?template={slug}
+```
+
+Returns the resolved template and its referenced template parts, or a
+discriminated miss the client turns into the §4 fallback:
+
+```jsonc
+// hit
+{ "status": "ok", "slug": "single", "name": "Single Post", "source": "db",
+  "blocks": [ /* … */ ], "template_parts": { "header": { /* … */ } } }
+
+// miss
+{ "status": "missing", "reason": "empty" }
+{ "status": "missing", "reason": "unknown-slug", "slug": "does-not-exist" }
+```
+
+The `template` query parameter overrides the slug persisted on the model,
+so a preview taken right after a template change does not race the
+debounced save. A blank `?template=` is meaningful: it says the selection
+was *cleared*, and is answered with `reason: "empty"`.
+
+---
+
+## See also
+
+- [Post editor](../post-editor.md) — the surrounding surface
+- [Site editor §5](../site-editor.md#5-url-routing) — deep-link contract
+- [Templates](../site-editor/Templates.md) — hierarchy, fallback chain, template parts

--- a/docs/site-editor.md
+++ b/docs/site-editor.md
@@ -156,9 +156,10 @@ into editing that entity.
 ### Deep links by slug
 
 Path routes address entities by database id. Callers outside the SPA
-usually do not have one — the post editor's composed view, for instance,
-knows only the slug of the template it composed against. For those, the
-site editor accepts a query-string deep link on the mount URL:
+usually do not have one — the post editor's
+[composed view](post-editor/Composed-View.md), for instance, knows only
+the slug of the template it composed against. For those, the site editor
+accepts a query-string deep link on the mount URL:
 
 ```text
 /visual-editor/site?entity=template&slug=single
@@ -192,8 +193,8 @@ Behaviour worth relying on:
 Build links with `buildTemplateDeepLink()` from
 `site-editor/deep-link.ts` rather than assembling the query string by
 hand, so both sides of the contract move together. The first consumer is
-the post editor's composed-view ribbon, whose **Edit template ↗** button
-opens one of these links in a new tab.
+the post editor's [composed-view ribbon](post-editor/Composed-View.md#5-the-ribbon-and-the-edit-template-deep-link),
+whose **Edit template ↗** button opens one of these links in a new tab.
 
 `buildTemplateDeepLink()` defaults to the package's own mount path
 (`/visual-editor/site`) and takes the route base as an optional second
@@ -268,6 +269,7 @@ chain — user records win on the same slug. See [Templates §4](site-editor/Tem
 
 - [Templates](site-editor/Templates.md) · [Global styles](site-editor/Global-Styles.md) · [Navigation](site-editor/Navigation.md) · [Patterns](site-editor/Patterns.md)
 - [Access Gate](site-editor/Access-Gate.md) — site-editor access gate contract
+- [Composed view](post-editor/Composed-View.md) — the post-editor surface that deep-links here
 - [Content model](content-model.md) — `HasBlockContent` and authorization
 - [Renderers](renderers.md) — render saved entities on the public site
 - [Photo Grid](photo-grid.md) — container-level Photo Grid setting (group / columns / grid). theme.json defaults live under `settings.artisanpack.photoGrid` and ride the same global-styles plumbing.

--- a/resources/js/visual-editor/editor/composed-view/__tests__/bindings.test.ts
+++ b/resources/js/visual-editor/editor/composed-view/__tests__/bindings.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Bindings survive the composed view's block pipeline (#622).
+ *
+ * `core/post-title` and `core/post-author` in the template chrome are
+ * expected to show *this* post's title and author, not the template's
+ * sample data. Two things have to hold for that:
+ *
+ *   1. the resolver has to be pointed at the content being edited — that
+ *      is the `setBindingsResourceContext` / `BlockContextProvider` wiring,
+ *      covered in `toggle-preserves-state.test.tsx`;
+ *   2. the `bindings` map has to still be on the block by the time it
+ *      reaches the preview.
+ *
+ * (2) is what this file pins. The chrome goes through two transforms
+ * between the endpoint and the canvas — `splitTemplateAroundContentSlot`
+ * (which *clones* wrappers onto both sides of the slot) and
+ * `hydrateBlocks` — and either could drop an attribute it doesn't know
+ * about. A binding lost here fails silently: the block renders the
+ * template's placeholder text and looks plausible.
+ *
+ * `@wordpress/blocks` is mocked, per the convention in `hydrate.test.ts` —
+ * the real module cannot be imported under vitest (JSON import attribute).
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { BlockInstance } from '@wordpress/blocks';
+
+let clientIdCounter = 0;
+
+vi.mock('@wordpress/blocks', () => ({
+    createBlock: (
+        name: string,
+        attributes: Record<string, unknown>,
+        innerBlocks: BlockInstance[]
+    ) => {
+        clientIdCounter += 1;
+
+        return {
+            clientId: `cid-${clientIdCounter}`,
+            name,
+            attributes,
+            innerBlocks,
+            isValid: true,
+        };
+    },
+}));
+
+import { hydrateBlocks } from '../hydrate';
+import { splitTemplateAroundContentSlot } from '../split';
+
+const TITLE_BINDING = {
+    content: { source: 'artisanpack/entity-field', args: { field: 'title' } },
+};
+const AUTHOR_BINDING = {
+    content: {
+        source: 'artisanpack/entity-field',
+        args: { field: 'author_name' },
+    },
+};
+
+function block(
+    name: string,
+    attributes: Record<string, unknown> = {},
+    innerBlocks: BlockInstance[] = []
+): BlockInstance {
+    return {
+        clientId: `${name}-${(clientIdCounter += 1)}`,
+        name,
+        isValid: true,
+        attributes,
+        innerBlocks,
+    } as unknown as BlockInstance;
+}
+
+function findByName(
+    blocks: readonly BlockInstance[],
+    name: string
+): BlockInstance | null {
+    for (const candidate of blocks) {
+        if (candidate.name === name) {
+            return candidate;
+        }
+
+        const nested = findByName(candidate.innerBlocks, name);
+
+        if (nested !== null) {
+            return nested;
+        }
+    }
+
+    return null;
+}
+
+beforeEach(() => {
+    clientIdCounter = 0;
+});
+
+describe('composed-view bindings pass-through (#622)', () => {
+    it('keeps the title binding on header chrome through split + hydrate', () => {
+        const split = splitTemplateAroundContentSlot(
+            [
+                block('artisanpack/group', { tagName: 'header' }, [
+                    block('artisanpack/post-title', {
+                        level: 1,
+                        bindings: TITLE_BINDING,
+                    }),
+                ]),
+                block('artisanpack/post-content'),
+            ],
+            'Single Post'
+        );
+
+        const title = findByName(
+            hydrateBlocks(split.header),
+            'artisanpack/post-title'
+        );
+
+        expect(title).not.toBeNull();
+        expect(title?.attributes).toMatchObject({
+            level: 1,
+            bindings: TITLE_BINDING,
+        });
+    });
+
+    it('keeps the author binding on footer chrome through split + hydrate', () => {
+        const split = splitTemplateAroundContentSlot(
+            [
+                block('artisanpack/post-content'),
+                block('artisanpack/group', { tagName: 'footer' }, [
+                    block('artisanpack/post-author', {
+                        bindings: AUTHOR_BINDING,
+                    }),
+                ]),
+            ],
+            'Single Post'
+        );
+
+        const author = findByName(
+            hydrateBlocks(split.footer),
+            'artisanpack/post-author'
+        );
+
+        expect(author).not.toBeNull();
+        expect(author?.attributes).toMatchObject({ bindings: AUTHOR_BINDING });
+    });
+
+    it('keeps bindings on both halves when the slot splits a bound wrapper', () => {
+        // The wrapper is cloned onto both sides of the slot. Its own
+        // attributes — bindings included — have to ride along on both
+        // copies, and the bound children either side have to keep theirs.
+        const wrapperBinding = {
+            style: { source: 'artisanpack/entity-field', args: { field: 'x' } },
+        };
+
+        const split = splitTemplateAroundContentSlot(
+            [
+                block('artisanpack/group', { bindings: wrapperBinding }, [
+                    block('artisanpack/post-title', {
+                        bindings: TITLE_BINDING,
+                    }),
+                    block('artisanpack/post-content'),
+                    block('artisanpack/post-author', {
+                        bindings: AUTHOR_BINDING,
+                    }),
+                ]),
+            ],
+            'Single Post'
+        );
+
+        const header = hydrateBlocks(split.header);
+        const footer = hydrateBlocks(split.footer);
+
+        expect(header[0]?.attributes).toMatchObject({
+            bindings: wrapperBinding,
+        });
+        expect(footer[0]?.attributes).toMatchObject({
+            bindings: wrapperBinding,
+        });
+        expect(
+            findByName(header, 'artisanpack/post-title')?.attributes
+        ).toMatchObject({ bindings: TITLE_BINDING });
+        expect(
+            findByName(footer, 'artisanpack/post-author')?.attributes
+        ).toMatchObject({ bindings: AUTHOR_BINDING });
+    });
+
+    it('leaves an unbound chrome block without a bindings key', () => {
+        // The complement of the assertions above: nothing in the pipeline
+        // invents a binding, so a plain heading still renders its own
+        // static text.
+        const split = splitTemplateAroundContentSlot(
+            [
+                block('artisanpack/heading', { content: 'Static' }),
+                block('artisanpack/post-content'),
+            ],
+            'Single Post'
+        );
+
+        const heading = findByName(
+            hydrateBlocks(split.header),
+            'artisanpack/heading'
+        );
+
+        expect(heading?.attributes).not.toHaveProperty('bindings');
+    });
+});

--- a/resources/js/visual-editor/editor/composed-view/__tests__/chrome-blocks.test.tsx
+++ b/resources/js/visual-editor/editor/composed-view/__tests__/chrome-blocks.test.tsx
@@ -1,0 +1,198 @@
+/**
+ * `ChromeBlocks` renders the applied template's header/footer as *inert*
+ * previews (#655). "Inert" here has a specific meaning, and this file
+ * exists to pin it.
+ *
+ * The abandoned first cut of #621 fed a composed tree to the content
+ * `BlockEditorProvider` and made the chrome read-only by stamping `lock`
+ * attributes onto it. That design froze the editor (`value` → `onChange`
+ * → recompose → `value`, forever) and was replaced by
+ * `__experimentalUseBlockPreview`, which mounts its *own* block-editor
+ * provider, wraps the subtree in `useDisabled()` (genuinely
+ * non-selectable, non-editable), and sets `isPreviewMode`.
+ *
+ * Nothing about that is enforced by types, so a future change could
+ * quietly reintroduce the lock-based shape and pass every other test in
+ * the suite. These assertions fail if it does:
+ *
+ *   - the preview hook must be the render path (a lock-based rewrite
+ *     would go through `BlockEditorProvider` + `BlockList` instead, both
+ *     stubbed here as tripwires);
+ *   - the blocks handed to it must be untouched — no injected `lock`
+ *     attribute, no `templateLock`;
+ *   - whatever inert markers the hook returns (`inert`, `aria-disabled`,
+ *     `contentEditable: false`) must reach the DOM rather than be
+ *     dropped on the floor by the spread.
+ *
+ * `@wordpress/block-editor` is stubbed, matching `editor-canvas.test.tsx`
+ * and `site-editor/__tests__/canvas-frame.test.tsx` — the real module
+ * pulls `@wordpress/blocks`, which vitest cannot import (JSON import
+ * attribute). That scopes this file to *our* contract with the hook.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { BlockInstance } from '@wordpress/blocks';
+
+const useBlockPreview = vi.fn(
+    (options: { props?: Record<string, unknown> }) => ({
+        ...(options.props ?? {}),
+        // Stand-ins for what `useDisabled()` and `isPreviewMode` put on
+        // the node in the real hook.
+        inert: '',
+        'aria-disabled': 'true',
+        contentEditable: false,
+    })
+);
+const blockEditorProviderTripwire = vi.fn();
+const blockListTripwire = vi.fn();
+
+vi.mock('@wordpress/block-editor', () => ({
+    __experimentalUseBlockPreview: (options: unknown) =>
+        (useBlockPreview as unknown as (o: unknown) => unknown)(options),
+    BlockEditorProvider: (props: { children?: unknown }): JSX.Element => {
+        blockEditorProviderTripwire(props);
+
+        return <div data-testid="ap-stub-block-editor-provider" />;
+    },
+    BlockList: (): JSX.Element => {
+        blockListTripwire();
+
+        return <div data-testid="ap-stub-block-list" />;
+    },
+}));
+
+import { ROOT_CANVAS_LAYOUT } from '../../../editor-settings';
+import { ChromeBlocks } from '../ChromeBlocks';
+
+function block(
+    name: string,
+    attributes: Record<string, unknown> = {}
+): BlockInstance {
+    return {
+        clientId: `cid-${name}`,
+        name,
+        isValid: true,
+        attributes,
+        innerBlocks: [],
+    } as unknown as BlockInstance;
+}
+
+const HEADER_LABEL = 'Template header (read-only)';
+
+beforeEach(() => {
+    useBlockPreview.mockClear();
+    blockEditorProviderTripwire.mockClear();
+    blockListTripwire.mockClear();
+});
+
+describe('ChromeBlocks inertness (#655)', () => {
+    it('renders the chrome through the block-preview hook', () => {
+        const blocks = [block('artisanpack/template-part')];
+
+        render(
+            <ChromeBlocks
+                blocks={blocks}
+                label={HEADER_LABEL}
+                region="header"
+            />
+        );
+
+        expect(useBlockPreview).toHaveBeenCalledTimes(1);
+        expect(useBlockPreview.mock.calls[0]?.[0]).toMatchObject({
+            blocks,
+            layout: ROOT_CANVAS_LAYOUT,
+        });
+    });
+
+    it('never mounts an editable block list for the chrome', () => {
+        // The tripwire: a `lock`-attribute reimplementation renders the
+        // chrome through a real provider + block list, both of which are
+        // editable surfaces no matter what `lock` says.
+        render(
+            <ChromeBlocks
+                blocks={[block('artisanpack/site-title')]}
+                label={HEADER_LABEL}
+                region="header"
+            />
+        );
+
+        expect(blockEditorProviderTripwire).not.toHaveBeenCalled();
+        expect(blockListTripwire).not.toHaveBeenCalled();
+        expect(
+            screen.queryByTestId('ap-stub-block-list')
+        ).not.toBeInTheDocument();
+    });
+
+    it('hands the blocks over untouched — no lock attributes injected', () => {
+        const original = block('artisanpack/site-title', { level: 1 });
+
+        render(
+            <ChromeBlocks
+                blocks={[original]}
+                label={HEADER_LABEL}
+                region="header"
+            />
+        );
+
+        const passed = (
+            useBlockPreview.mock.calls[0]?.[0] as {
+                blocks: readonly BlockInstance[];
+            }
+        ).blocks;
+
+        // Same reference: hydration owns the tree, this component only
+        // previews it.
+        expect(passed[0]).toBe(original);
+        expect(passed[0]?.attributes).toEqual({ level: 1 });
+        expect(passed[0]?.attributes).not.toHaveProperty('lock');
+        expect(
+            useBlockPreview.mock.calls[0]?.[0]
+        ).not.toHaveProperty('templateLock');
+    });
+
+    it('spreads the hook props so the inert markers reach the DOM', () => {
+        render(
+            <ChromeBlocks
+                blocks={[block('artisanpack/site-title')]}
+                label={HEADER_LABEL}
+                region="header"
+            />
+        );
+
+        const chrome = screen.getByLabelText(HEADER_LABEL);
+
+        expect(chrome).toHaveAttribute('inert');
+        expect(chrome).toHaveAttribute('aria-disabled', 'true');
+        // React renders `contentEditable: false` as the literal attribute
+        // `contenteditable="false"`; either way the chrome must never be
+        // an editable host.
+        expect(chrome.getAttribute('contenteditable')).not.toBe('true');
+        expect(chrome.querySelector('[contenteditable="true"]')).toBeNull();
+    });
+
+    it('labels the region for assistive tech without announcing it as content', () => {
+        render(
+            <ChromeBlocks
+                blocks={[block('artisanpack/site-title')]}
+                label={HEADER_LABEL}
+                region="footer"
+            />
+        );
+
+        const chrome = screen.getByLabelText(HEADER_LABEL);
+
+        expect(chrome).toHaveAttribute('role', 'presentation');
+        expect(chrome).toHaveAttribute('data-chrome-region', 'footer');
+        expect(chrome).toHaveClass('ap-visual-editor__chrome');
+    });
+
+    it('renders nothing — and calls no hook — for an empty region', () => {
+        const { container } = render(
+            <ChromeBlocks blocks={[]} label={HEADER_LABEL} region="footer" />
+        );
+
+        expect(container).toBeEmptyDOMElement();
+        expect(useBlockPreview).not.toHaveBeenCalled();
+    });
+});

--- a/resources/js/visual-editor/editor/composed-view/__tests__/toggle-preserves-state.test.tsx
+++ b/resources/js/visual-editor/editor/composed-view/__tests__/toggle-preserves-state.test.tsx
@@ -1,0 +1,417 @@
+/**
+ * Flipping the composed-view toggle must not disturb the editor (#618).
+ *
+ * The abandoned first cut of #621 handed the content `BlockEditorProvider`
+ * a *composed* tree — chrome wrapped around a content slot — and swapped
+ * `value` every time the toggle moved. `BlockEditorProvider` is a single,
+ * stateful tree: swapping its `value` discards the block-editor store's
+ * selection and undo stack, and the echo (`value` → `onChange` → extract →
+ * state → new composed tree → new `value`) froze the editor outright.
+ *
+ * The shipped design never touches `value`: chrome renders as sibling
+ * previews inside the canvas, each with its own isolated store. Selection,
+ * undo history and unsaved changes survive a toggle *structurally* — which
+ * is precisely why nothing fails today if someone reintroduces the swap.
+ * This file is that tripwire. It asserts the structural invariants that
+ * the store's state depends on:
+ *
+ *   - the content provider is mounted exactly once across any number of
+ *     toggles (a remount is a store teardown — selection and undo gone);
+ *   - its `value` reference is identical before and after (a swap is a
+ *     `resetBlocks`, which clears selection and pushes undo);
+ *   - the toggle fires neither `onChange` nor `onInput`, so it neither
+ *     records an undo entry nor marks the document dirty;
+ *   - the editor's own undo/redo affordances read the same either side.
+ *
+ * `@wordpress/block-editor` and the heavy editor regions are stubbed, per
+ * the convention in `editor-canvas.test.tsx` and
+ * `site-editor/__tests__/site-editor-app.test.tsx` — the real modules pull
+ * `@wordpress/blocks` (unimportable under vitest) and mount an iframe.
+ * The `EditorCanvas` stub records the `chrome` prop, so the tests can
+ * prove the toggle *did* take effect while the provider stood still.
+ */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import type { RenderResult } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ReactNode } from 'react';
+
+// Side-effect import in `editor-app.tsx`. The real package is a
+// node_modules dependency, so its own `@wordpress/blocks` import is not
+// routed through the mock below and trips vitest's JSON-import-attribute
+// error. Nothing here exercises inline formats.
+vi.mock('@wordpress/format-library', () => ({}));
+
+vi.mock('../../../blocks', () => ({
+    registerArtisanPackBlocks: (): void => undefined,
+}));
+vi.mock('../../../background-controls', () => ({
+    registerBackgroundControls: (): void => undefined,
+}));
+vi.mock('../../../box-shadows/register', () => ({
+    registerBoxShadows: (): void => undefined,
+}));
+vi.mock('../../../gradient-borders/register', () => ({
+    registerGradientBorders: (): void => undefined,
+}));
+vi.mock('../../../positioning/register', () => ({
+    registerPositioning: (): void => undefined,
+}));
+vi.mock('../../../responsive/register-attribute', () => ({
+    registerResponsiveAttribute: (): void => undefined,
+}));
+vi.mock('../../../responsive/with-responsive-attributes', () => ({
+    registerResponsiveAttributesFilter: (): void => undefined,
+}));
+vi.mock('../../../states/register-attribute', () => ({
+    registerStateAttribute: (): void => undefined,
+}));
+vi.mock('../../../states/with-state-attributes', () => ({
+    registerStateAttributesFilter: (): void => undefined,
+}));
+vi.mock('../../../states/with-state-styles', () => ({
+    registerStateStylesFilters: (): void => undefined,
+}));
+vi.mock('../../../states/StateInspectorSync', () => ({
+    StateInspectorSync: (): null => null,
+}));
+vi.mock('../../../states/state-write-interceptor', () => ({
+    StateWriteInterceptor: (): null => null,
+}));
+vi.mock('../../../animations/register-attribute', () => ({
+    registerAnimationsAttribute: (): void => undefined,
+}));
+vi.mock('../../../animations/with-animations-panel', () => ({
+    registerAnimationsPanel: (): void => undefined,
+}));
+vi.mock('../../../visibility/register-attribute', () => ({
+    registerVisibilityAttribute: (): void => undefined,
+}));
+vi.mock('../../../visibility/with-visibility-panel', () => ({
+    registerVisibilityPanel: (): void => undefined,
+    setVisibilityBreakpoints: (): void => undefined,
+    setVisibilityRoles: (): void => undefined,
+}));
+vi.mock('../../../dynamic-content', () => ({
+    registerDynamicContent: (): void => undefined,
+}));
+vi.mock('../../block-library-sidebar', () => ({
+    BlockLibrarySidebar: (): JSX.Element => (
+        <div data-testid="ap-stub-block-library-sidebar" />
+    ),
+}));
+vi.mock('../../inspector-sidebar', () => ({
+    InspectorSidebar: (): JSX.Element => (
+        <div data-testid="ap-stub-inspector-sidebar" />
+    ),
+}));
+vi.mock('../../contrast-warning', () => ({
+    registerContrastWarning: (): void => undefined,
+}));
+vi.mock('../../synced-pattern-indicator', () => ({
+    registerSyncedPatternIndicator: (): void => undefined,
+}));
+vi.mock('../../convert-to-pattern-control', () => ({
+    ConvertToPatternControl: (): null => null,
+}));
+vi.mock('../../page-pattern-modal/page-pattern-modal', () => ({
+    PagePatternModal: (): null => null,
+}));
+vi.mock('../../keyboard-shortcuts-modal', () => ({
+    KeyboardShortcutsModal: (): null => null,
+}));
+
+const canvasProps = vi.fn();
+
+vi.mock('../../editor-canvas', () => ({
+    EditorCanvas: (props: Record<string, unknown>): JSX.Element => {
+        canvasProps(props);
+
+        return (
+            <div
+                data-testid="ap-stub-editor-canvas"
+                data-composed={props.chrome !== null && props.chrome !== undefined}
+            />
+        );
+    },
+}));
+
+/**
+ * The provider stub is the heart of this file: it counts mounts and
+ * records the `value` reference on every render.
+ */
+const providerMounts = vi.fn();
+const providerRenders = vi.fn();
+
+vi.mock('@wordpress/block-editor', async () => {
+    const { useEffect } = await vi.importActual<typeof import('react')>(
+        'react'
+    );
+
+    return {
+        BlockEditorProvider: (props: {
+            value: unknown;
+            children?: ReactNode;
+        }): JSX.Element => {
+            providerRenders(props.value);
+
+            useEffect(() => {
+                providerMounts();
+            }, []);
+
+            return <div data-testid="ap-stub-provider">{props.children}</div>;
+        },
+    };
+});
+
+vi.mock('@wordpress/blocks', () => ({
+    createBlock: (
+        name: string,
+        attributes: Record<string, unknown>,
+        innerBlocks: unknown[]
+    ) => ({
+        clientId: `cid-${name}-${Math.random().toString(36).slice(2)}`,
+        name,
+        attributes,
+        innerBlocks,
+        isValid: true,
+    }),
+}));
+
+const fetchAppliedTemplate = vi.fn();
+
+vi.mock('../api', async () => {
+    const actual = await vi.importActual<typeof import('../api')>('../api');
+
+    return {
+        ...actual,
+        fetchAppliedTemplate: (config: unknown) =>
+            (fetchAppliedTemplate as unknown as (c: unknown) => unknown)(config),
+    };
+});
+
+import { EditorApp } from '../../editor-app';
+
+const APPLIED_TEMPLATE = {
+    status: 'ok' as const,
+    slug: 'single',
+    name: 'Single Post',
+    blocks: [
+        {
+            name: 'artisanpack/template-part',
+            attributes: { slug: 'header' },
+            innerBlocks: [],
+        },
+        {
+            name: 'artisanpack/post-content',
+            attributes: {},
+            innerBlocks: [],
+        },
+        {
+            name: 'artisanpack/template-part',
+            attributes: { slug: 'footer' },
+            innerBlocks: [],
+        },
+    ],
+    template_parts: {},
+};
+
+/**
+ * Mounts the editor and waits for the content GET to settle — the shell
+ * renders a "Loading content…" branch until then, with no provider and no
+ * canvas to assert against.
+ */
+async function renderEditor(): Promise<RenderResult> {
+    const result = render(
+        <EditorApp
+            apiBase="/visual-editor/api"
+            resource="posts"
+            id="7"
+            initialTitle="Hello"
+            initialTemplate="single"
+        />
+    );
+
+    await screen.findByTestId('ap-stub-provider');
+
+    return result;
+}
+
+function viewModeToggle(): HTMLElement {
+    return screen.getByTestId('ap-visual-editor-top-bar-view-mode-toggle');
+}
+
+function lastCanvasChrome(): unknown {
+    const calls = canvasProps.mock.calls;
+
+    return (calls[calls.length - 1]?.[0] as { chrome?: unknown })?.chrome;
+}
+
+beforeEach(() => {
+    canvasProps.mockClear();
+    providerMounts.mockClear();
+    providerRenders.mockClear();
+    fetchAppliedTemplate.mockReset();
+    fetchAppliedTemplate.mockResolvedValue(APPLIED_TEMPLATE);
+    vi.stubGlobal(
+        'fetch',
+        vi.fn(() =>
+            Promise.resolve({
+                ok: true,
+                status: 200,
+                // `api-client.ts` reads bodies via `.text()`.
+                text: () => Promise.resolve(JSON.stringify({ blocks: [] })),
+                json: () => Promise.resolve({ blocks: [] }),
+            } as unknown as Response)
+        )
+    );
+});
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
+
+describe('composed-view toggle preserves editor state (#618)', () => {
+    it('composes the canvas when toggled on, and uncomposes when toggled off', async () => {
+        const user = userEvent.setup();
+        await renderEditor();
+
+        expect(lastCanvasChrome()).toBeNull();
+
+        await user.click(viewModeToggle());
+        await waitFor(() => {
+            expect(lastCanvasChrome()).not.toBeNull();
+        });
+
+        expect(lastCanvasChrome()).toMatchObject({
+            templateName: 'Single Post',
+            templateSlug: 'single',
+        });
+
+        await user.click(viewModeToggle());
+        await waitFor(() => {
+            expect(lastCanvasChrome()).toBeNull();
+        });
+    });
+
+    it('never remounts the content provider across toggles', async () => {
+        const user = userEvent.setup();
+        await renderEditor();
+
+        expect(providerMounts).toHaveBeenCalledTimes(1);
+
+        await user.click(viewModeToggle());
+        await waitFor(() => {
+            expect(lastCanvasChrome()).not.toBeNull();
+        });
+        await user.click(viewModeToggle());
+        await waitFor(() => {
+            expect(lastCanvasChrome()).toBeNull();
+        });
+
+        // A remount tears down the block-editor store: selection gone,
+        // undo stack gone. Once, and only once.
+        expect(providerMounts).toHaveBeenCalledTimes(1);
+    });
+
+    it('never swaps the provider value, so selection and undo survive', async () => {
+        const user = userEvent.setup();
+        await renderEditor();
+
+        const initialValue = providerRenders.mock.calls[0]?.[0];
+
+        await user.click(viewModeToggle());
+        await waitFor(() => {
+            expect(lastCanvasChrome()).not.toBeNull();
+        });
+        await user.click(viewModeToggle());
+        await waitFor(() => {
+            expect(lastCanvasChrome()).toBeNull();
+        });
+
+        // Same reference on every render — not merely deep-equal. A
+        // composed tree would be a fresh array each time, and each swap
+        // is a `resetBlocks` in the store.
+        for (const [value] of providerRenders.mock.calls) {
+            expect(value).toBe(initialValue);
+        }
+    });
+
+    it('records no block change, so the toggle leaves the document clean', async () => {
+        const user = userEvent.setup();
+        await renderEditor();
+
+        const undo = screen.getByTestId('ap-visual-editor-top-bar-undo');
+        const redo = screen.getByTestId('ap-visual-editor-top-bar-redo');
+
+        expect(undo).toBeDisabled();
+        expect(redo).toBeDisabled();
+
+        await user.click(viewModeToggle());
+        await waitFor(() => {
+            expect(lastCanvasChrome()).not.toBeNull();
+        });
+
+        // Composing the view is a presentation change: no undo entry, no
+        // dirty flag, nothing to save.
+        expect(undo).toBeDisabled();
+        expect(redo).toBeDisabled();
+        expect(
+            screen.getByTestId('ap-visual-editor-top-bar-save-status')
+        ).toHaveAttribute('data-save-status', 'idle');
+    });
+});
+
+describe('composed-view bindings context (#622)', () => {
+    it('points the bindings resolver at the content being edited', async () => {
+        await renderEditor();
+
+        const host = globalThis as unknown as {
+            __artisanpackBindingsResource?: string | null;
+            __artisanpackBindingsRecordId?: number | string | null;
+        };
+
+        // `core/post-title` / `core/post-author` in the template chrome
+        // resolve through this context, so the composed view shows *this*
+        // post's title and author rather than the template's sample data.
+        expect(host.__artisanpackBindingsResource).toBe('posts');
+        expect(host.__artisanpackBindingsRecordId).toBe('7');
+    });
+
+    it('clears the context on unmount so the next editor starts clean', async () => {
+        // Let the content GET settle before unmounting: tearing down
+        // mid-flight would leave a pending state update behind and make
+        // the assertion below race the load.
+        const { unmount } = await renderEditor();
+
+        unmount();
+
+        const host = globalThis as unknown as {
+            __artisanpackBindingsResource?: string | null;
+            __artisanpackBindingsRecordId?: number | string | null;
+        };
+
+        expect(host.__artisanpackBindingsResource).toBeNull();
+        expect(host.__artisanpackBindingsRecordId).toBeNull();
+    });
+
+    it('gives the chrome the same entity block context as the content', async () => {
+        const user = userEvent.setup();
+        await renderEditor();
+
+        await user.click(viewModeToggle());
+        await waitFor(() => {
+            expect(lastCanvasChrome()).not.toBeNull();
+        });
+
+        const props = canvasProps.mock.calls[
+            canvasProps.mock.calls.length - 1
+        ]?.[0] as { blockContext?: unknown };
+
+        // Chrome previews mount inside the canvas's `BlockContextProvider`
+        // (see `editor-canvas.tsx`), so `core/post-*` blocks in the
+        // template see the active entity, not a placeholder.
+        expect(props.blockContext).toEqual({ postType: 'post', postId: 7 });
+    });
+});


### PR DESCRIPTION
## Description

Rounds out test coverage for the composed template preview (#618) and adds the user-facing docs page.

**Closes:** #626

## Type of Change

- [x] Enhancement (improves existing functionality)
- [x] Documentation update

## Related Issue

**Issue:** #626

## Motivation and Context

#621's design was rewritten because the original single-composed-tree approach froze the editor — but nothing in the suite fails if someone reintroduces it. The two highest-value items in #626 are exactly those regression tripwires. #654 landed the rest of the composed-view coverage; the rewrite also deleted the old #622 bindings tests, leaving that acceptance criterion uncovered.

## Changes Made

- `composed-view/__tests__/chrome-blocks.test.tsx` (6 tests) — chrome renders through `__experimentalUseBlockPreview` (with `BlockEditorProvider` / `BlockList` stubbed as tripwires), no `lock` attribute is injected, and the hook's inert markers reach the DOM. A `lock`-based reimplementation fails it.
- `composed-view/__tests__/toggle-preserves-state.test.tsx` (7 tests) — mounts the real `EditorApp`: the content provider mounts exactly once across toggles, its `value` is reference-identical on every render, and the toggle records no undo entry and leaves the save status `idle`. Also covers the #622 wiring — bindings resource context set to the edited record and cleared on unmount, chrome sharing the content's entity block context.
- `composed-view/__tests__/bindings.test.ts` (4 tests) — title/author bindings survive `split` + `hydrate`, including when the content slot splits a bound wrapper.
- `docs/post-editor/Composed-View.md` — what the view is and when to use it, how to toggle, editable vs read-only chrome (and why it is a preview rather than a locked editable), the fallback template and when it kicks in, the **Edit template ↗** deep-link contract, and the endpoint shape.
- Cross-links from `docs/post-editor.md` (§2 + See also), `docs/site-editor.md` (§5 deep links + See also), and `docs/home.md`.

Coverage for #623 / #624 / #625 already landed (`composed-view-ribbon.test.tsx`, `fallback.test.ts`, `use-fallback-toast.test.tsx`, `deep-link.test.ts`, `use-deep-link.test.tsx`) and is not duplicated here.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS
- Browser (if applicable): Chrome (manual pass in the dev app)
- PHP Version: 8.4.3
- Project Version: 1.5.5

**Tests Performed:**
1. `npm test` — 3013 passed across 329 files (baseline before this branch: 2996). No pre-existing failures; the `site-editor-app.test.tsx` failures noted in #626 were already fixed upstream in `6afd9d29`.
2. `composer test` — 1654 passed, 1 skipped. No PHP files changed on this branch.
3. `npm run verify:parity` — all 152 blocks registered across react / vue / blade. This feature adds no blocks and does not perturb parity.
4. Mutation-checked the key tripwire: changing `value={blocks}` to `value={[...blocks]}` in `editor-app.tsx` fails the value-identity test, then reverted.
5. Manual pass in the dev app: toggle on/off, chrome inert to clicks, selection + undo intact across toggles, cleared-template fallback (toast + standing notice), **Edit template ↗** opening the site editor at the deep link.

## Accessibility Tests Run

- [x] Keyboard navigation tested
- [x] Screen reader tested
- [ ] Color contrast verified
- [x] ARIA labels checked

**Details:** No new UI. The new tests assert existing a11y contracts on the composed canvas: chrome carries `role="presentation"` plus its region `aria-label` and is non-editable/non-selectable via the preview provider's `useDisabled()`, so it is skipped by keyboard traversal rather than being a focusable dead end. The view-mode toggle's existing `role="switch"` / `aria-checked` behaviour is covered by `top-bar.test.tsx`. No color changes, so contrast is unaffected.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:** 17 new Vitest tests across three files (6 + 7 + 4), co-located per repo convention under `resources/js/visual-editor/editor/composed-view/__tests__/`.

## Documentation

- [ ] Inline code documentation added
- [ ] README updated
- [x] Wiki updated
- [ ] API documentation updated

**Documentation details:** New `docs/post-editor/Composed-View.md`, cross-linked from `docs/post-editor.md`, `docs/site-editor.md`, and the `docs/home.md` index.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [x] Accessibility tests completed
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
