### PR TITLE
fix: emit per-block layout classes and constrain constrained groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,32 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+- **Per-block layout classes in the Blade renderer** (#700) — layout-supporting
+  partials emitted only the shared `is-layout-{type}` modifier, so the shipped
+  block-library rules that key on the per-block compound
+  (`.wp-block-group.wp-block-group-is-layout-constrained`,
+  `.wp-block-post-template-is-layout-flow > li > .aligncenter`, …) never
+  matched. `group`, `row`, `stack`, `columns`, `buttons`, `post-content`, and
+  `post-template` now emit both classes through the new
+  `Support\LayoutSupport` helper. `post-content` additionally honours its
+  stored `layout.type` for the first time — without that class the
+  content-size containment rules `ThemeJsonTokensCompiler` emits for
+  `.wp-block-post-content.is-layout-constrained` could never apply — and
+  `columns` gained the `is-layout-flex` pair it was missing entirely.
+- **Constrained groups now constrain their children** (#700) —
+  `ThemeJsonTokensCompiler` emitted content-size containment only for
+  `.wp-block-post-content`, so a `<article class="wp-block-group
+  is-layout-constrained">` let its title, meta, and featured image run
+  edge-to-edge while its post body behaved. It now also emits the
+  `> :where(:not(.alignwide):not(.alignfull):not(.alignleft):not(.alignright))`
+  cap plus the `alignwide` / `alignfull` overrides for constrained groups,
+  mirroring the per-instance rules WordPress generates. Keyed on the
+  per-block `wp-block-group-is-layout-constrained` compound, so host markup
+  that hand-writes the shared `is-layout-constrained` modifier and styles
+  those children itself is not retroactively constrained.
+
 ## [1.5.5] - 2026-08-02
 
 ### Added

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/core/buttons.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/core/buttons.blade.php
@@ -1,5 +1,6 @@
 @php
 	use ArtisanPackUI\VisualEditorRendererBlade\Support\BlockSupports;
+	use ArtisanPackUI\VisualEditorRendererBlade\Support\LayoutSupport;
 
 	// Whitelist `layout.justifyContent` against WP's known enum so an
 	// authored block can't inject arbitrary class tokens through the
@@ -10,11 +11,11 @@
 	$allowedJustify = [ 'left', 'center', 'right', 'space-between', 'space-around', 'space-evenly', 'stretch' ];
 	$justify        = in_array( $rawJustify, $allowedJustify, true ) ? $rawJustify : 'left';
 
-	$baseClasses = [
-		'wp-block-buttons',
-		'is-layout-flex',
-		'is-content-justification-' . $justify,
-	];
+	$baseClasses = array_merge(
+		[ 'wp-block-buttons' ],
+		LayoutSupport::pair( 'buttons', 'is-layout-flex' ),
+		[ 'is-content-justification-' . $justify ]
+	);
 @endphp
 <div{!! BlockSupports::wrapperAttrs( $attributes, $baseClasses ) !!}>
 	{!! $innerBlocksHtml !!}

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/core/columns.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/core/columns.blade.php
@@ -2,9 +2,16 @@
 	use ArtisanPackUI\VisualEditor\Responsive\BreakpointRegistry;
 	use ArtisanPackUI\VisualEditorRendererBlade\Support\BlockSupports;
 	use ArtisanPackUI\VisualEditorRendererBlade\Support\FlexSupport;
+	use ArtisanPackUI\VisualEditorRendererBlade\Support\LayoutSupport;
 	use ArtisanPackUI\VisualEditorRendererBlade\Support\PhotoGridSupport;
 
-	$baseClasses = [ 'wp-block-columns' ];
+	// #700 — columns is a flex layout upstream and its wrapper carries
+	// both the shared modifier and the per-block compound. Neither was
+	// emitted here, so layout rules keyed on either never applied.
+	$baseClasses = array_merge(
+		[ 'wp-block-columns' ],
+		LayoutSupport::pair( 'columns', 'is-layout-flex' )
+	);
 
 	if ( ! empty( $attributes['isStackedOnMobile'] ) || ! isset( $attributes['isStackedOnMobile'] ) ) {
 		$baseClasses[] = 'is-stacked-on-mobile';

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/core/group.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/core/group.blade.php
@@ -1,23 +1,18 @@
 @php
 	use ArtisanPackUI\VisualEditorRendererBlade\Support\BlockSupports;
 	use ArtisanPackUI\VisualEditorRendererBlade\Support\FlexSupport;
+	use ArtisanPackUI\VisualEditorRendererBlade\Support\LayoutSupport;
 	use ArtisanPackUI\VisualEditorRendererBlade\Support\PhotoGridSupport;
 
 	$tag = isset( $attributes['tagName'] ) && in_array( $attributes['tagName'], [ 'div', 'section', 'article', 'aside', 'header', 'footer', 'main', 'nav' ], true )
 		? $attributes['tagName']
 		: 'div';
 
-	$layoutType = isset( $attributes['layout']['type'] ) ? (string) $attributes['layout']['type'] : '';
+	$layoutType = isset( $attributes['layout']['type'] ) && is_string( $attributes['layout']['type'] )
+		? trim( $attributes['layout']['type'] )
+		: '';
 
-	if ( 'constrained' === $layoutType ) {
-		$layoutClass = 'is-layout-constrained';
-	} elseif ( 'flex' === $layoutType ) {
-		$layoutClass = 'is-layout-flex';
-	} elseif ( 'grid' === $layoutType ) {
-		$layoutClass = 'is-layout-grid';
-	} else {
-		$layoutClass = 'is-layout-flow';
-	}
+	$layoutClass = LayoutSupport::layoutClass( $attributes );
 
 	$flexClasses = FlexSupport::wrapperForBlock( $attributes );
 
@@ -39,7 +34,15 @@
 
 	$photoGridClasses = PhotoGridSupport::wrapperForBlock( $attributes );
 
-	$wrapperBaseClasses = array_merge( [ 'wp-block-group', $layoutClass ], $flexClasses, $photoGridClasses );
+	// #700 — the block-library CSS targets the per-block compound
+	// (`wp-block-group-is-layout-constrained`), so emit it alongside the
+	// shared modifier.
+	$wrapperBaseClasses = array_merge(
+		[ 'wp-block-group' ],
+		LayoutSupport::pair( 'group', $layoutClass ),
+		$flexClasses,
+		$photoGridClasses
+	);
 @endphp
 <{{ $tag }}{!! BlockSupports::wrapperAttrs( $attributes, $wrapperBaseClasses ) !!}>
 	{!! $innerBlocksHtml !!}

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/core/post-content.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/core/post-content.blade.php
@@ -1,6 +1,17 @@
 @php
 	use ArtisanPackUI\VisualEditorRendererBlade\Support\BlockSupports;
+	use ArtisanPackUI\VisualEditorRendererBlade\Support\LayoutSupport;
 
 	$content = isset( $attributes['_resolvedContent'] ) && is_string( $attributes['_resolvedContent'] ) ? $attributes['_resolvedContent'] : '';
+
+	// #700 — the block stores a `layout` attribute like every other
+	// layout-supporting block, but the wrapper never surfaced it. Without
+	// `is-layout-constrained` here the content-size containment rules
+	// `ThemeJsonTokensCompiler` emits for `.wp-block-post-content` can
+	// never match.
+	$baseClasses = array_merge(
+		[ 'entry-content', 'wp-block-post-content' ],
+		LayoutSupport::wrapperForBlock( $attributes, 'post-content' )
+	);
 @endphp
-<div{!! BlockSupports::wrapperAttrs( $attributes, [ 'entry-content', 'wp-block-post-content' ] ) !!}>{!! $content !!}</div>
+<div{!! BlockSupports::wrapperAttrs( $attributes, $baseClasses ) !!}>{!! $content !!}</div>

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/core/post-template.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/core/post-template.blade.php
@@ -1,5 +1,6 @@
 @php
 	use ArtisanPackUI\VisualEditorRendererBlade\Support\BlockSupports;
+	use ArtisanPackUI\VisualEditorRendererBlade\Support\LayoutSupport;
 
 	$layout = isset( $attributes['layout'] ) ? (string) $attributes['layout'] : 'list';
 	if ( ! in_array( $layout, [ 'list', 'grid', 'masonry' ], true ) ) {
@@ -17,12 +18,15 @@
 	// browsers that ship native CSS Grid masonry. Non-supporting
 	// browsers see the columned grid baseline until the JS bootstrap
 	// hydrates and packs the items.
-	$classes = [ 'wp-block-post-template' ];
-	if ( $isGrid || $isMasonry ) {
-		$classes[] = 'is-layout-grid';
-	} else {
-		$classes[] = 'is-layout-flow';
-	}
+	//
+	// #700 — each shared modifier ships with its per-block compound; the
+	// block-library alignment rules key on
+	// `wp-block-post-template-is-layout-flow`. Masonry is an ArtisanPack
+	// extension with no upstream compound, so it stays unpaired.
+	$classes = array_merge(
+		[ 'wp-block-post-template' ],
+		LayoutSupport::pair( 'post-template', $usesColumns ? 'is-layout-grid' : 'is-layout-flow' )
+	);
 	if ( $isMasonry ) {
 		$classes[] = 'is-layout-masonry';
 	}

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/core/row.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/core/row.blade.php
@@ -1,6 +1,15 @@
 @php
 	use ArtisanPackUI\VisualEditorRendererBlade\Support\BlockSupports;
+	use ArtisanPackUI\VisualEditorRendererBlade\Support\LayoutSupport;
+
+	// Renders `wp-block-group` markup, so the per-block layout compound
+	// is keyed on `group` rather than `row` (#700).
+	$baseClasses = array_merge(
+		[ 'wp-block-group' ],
+		LayoutSupport::pair( 'group', 'is-layout-flex' ),
+		[ 'is-horizontal' ]
+	);
 @endphp
-<div{!! BlockSupports::wrapperAttrs( $attributes, [ 'wp-block-group', 'is-layout-flex', 'is-horizontal' ] ) !!}>
+<div{!! BlockSupports::wrapperAttrs( $attributes, $baseClasses ) !!}>
 	{!! $innerBlocksHtml !!}
 </div>

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/core/stack.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/core/stack.blade.php
@@ -1,6 +1,15 @@
 @php
 	use ArtisanPackUI\VisualEditorRendererBlade\Support\BlockSupports;
+	use ArtisanPackUI\VisualEditorRendererBlade\Support\LayoutSupport;
+
+	// Renders `wp-block-group` markup, so the per-block layout compound
+	// is keyed on `group` rather than `stack` (#700).
+	$baseClasses = array_merge(
+		[ 'wp-block-group' ],
+		LayoutSupport::pair( 'group', 'is-layout-flex' ),
+		[ 'is-vertical' ]
+	);
 @endphp
-<div{!! BlockSupports::wrapperAttrs( $attributes, [ 'wp-block-group', 'is-layout-flex', 'is-vertical' ] ) !!}>
+<div{!! BlockSupports::wrapperAttrs( $attributes, $baseClasses ) !!}>
 	{!! $innerBlocksHtml !!}
 </div>

--- a/packages/visual-editor-renderer-blade/src/Services/ThemeJsonTokensCompiler.php
+++ b/packages/visual-editor-renderer-blade/src/Services/ThemeJsonTokensCompiler.php
@@ -565,10 +565,13 @@ class ThemeJsonTokensCompiler
 	 *
 	 * The rules target the constrained group's own classes (not a
 	 * parent-relative selector), so they apply whether the group sits
-	 * at the page root or inside another container. The default case
-	 * (constrained group without an alignment override) is left alone
-	 * so themes that style children-of-constrained directly aren't
-	 * double-constrained.
+	 * at the page root or inside another container.
+	 *
+	 * Child containment for constrained groups (#700) is keyed on the
+	 * per-block `wp-block-group-is-layout-constrained` compound rather
+	 * than the shared modifier, so it reaches wrappers this renderer
+	 * emits without double-constraining host markup that hand-writes
+	 * `is-layout-constrained` and styles those children itself.
 	 *
 	 * @since 1.0.0
 	 *
@@ -637,6 +640,40 @@ class ThemeJsonTokensCompiler
 		}
 
 		$rules[] = ".wp-block-post-content.is-layout-constrained > .alignfull {\n"
+			. "\tmax-width: none;\n"
+			. '}';
+
+		// Rule set C — children of a constrained GROUP (#700). This is
+		// what "constrained" means upstream: WordPress emits a
+		// per-instance `.wp-container-…-is-layout-constrained > :where(…)`
+		// rule that caps every unaligned child at `contentSize`. Without
+		// it a `<article class="wp-block-group is-layout-constrained">`
+		// lets its title / meta / featured image run edge-to-edge even
+		// though the group declares a constrained layout.
+		//
+		// Keyed on the per-block compound rather than the shared
+		// `is-layout-constrained` modifier, which is what keeps the
+		// "double-constrained" hazard in rule set A's note from biting:
+		// only wrappers this renderer emits carry the compound, so
+		// host-authored markup that hand-writes the shared modifier
+		// keeps its existing full-bleed-unless-aligned behavior.
+		if ( $hasContentSize ) {
+			$rules[] = ".wp-block-group.wp-block-group-is-layout-constrained > :where(:not(.alignwide):not(.alignfull):not(.alignleft):not(.alignright)) {\n"
+				. "\tmax-width: var(--wp--style--global--content-size);\n"
+				. "\tmargin-left: auto;\n"
+				. "\tmargin-right: auto;\n"
+				. '}';
+		}
+
+		if ( $hasWideSize ) {
+			$rules[] = ".wp-block-group.wp-block-group-is-layout-constrained > .alignwide {\n"
+				. "\tmax-width: var(--wp--style--global--wide-size);\n"
+				. "\tmargin-left: auto;\n"
+				. "\tmargin-right: auto;\n"
+				. '}';
+		}
+
+		$rules[] = ".wp-block-group.wp-block-group-is-layout-constrained > .alignfull {\n"
 			. "\tmax-width: none;\n"
 			. '}';
 

--- a/packages/visual-editor-renderer-blade/src/Support/LayoutSupport.php
+++ b/packages/visual-editor-renderer-blade/src/Support/LayoutSupport.php
@@ -1,0 +1,118 @@
+<?php
+
+/**
+ * Layout-support class serializer — Blade renderer (#700).
+ *
+ * Blocks that declare a layout carry two classes upstream: the shared
+ * `is-layout-{type}` modifier and the per-block
+ * `wp-block-{slug}-is-layout-{type}` compound. The shipped block-library
+ * stylesheet targets the per-block form exclusively for several rules
+ * (constrained containment on `.wp-block-group`, alignment handling on
+ * `.wp-block-post-template`), so emitting only the shared class leaves
+ * those rules unmatched.
+ *
+ * The block slug is passed in by each partial rather than derived from
+ * the block name because several blocks render as a different wrapper
+ * than their name suggests — `artisanpack/row` and `artisanpack/stack`
+ * both render `wp-block-group` markup and therefore need the
+ * `wp-block-group-is-layout-flex` compound, not `wp-block-row-…`.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditorRendererBlade
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.6.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditorRendererBlade\Support;
+
+class LayoutSupport
+{
+	/**
+	 * Layout types the renderer knows how to serialize. Anything else
+	 * stored on the block falls back to the caller's default so an
+	 * unknown value can't mint an arbitrary class token.
+	 *
+	 * @since 1.6.0
+	 *
+	 * @var array<int, string>
+	 */
+	public const SUPPORTED_TYPES = [ 'constrained', 'flex', 'flow', 'grid' ];
+
+	/**
+	 * Resolve the shared layout class for a block from its saved
+	 * `layout.type` attribute.
+	 *
+	 * @since 1.6.0
+	 *
+	 * @param  array<string, mixed>  $attributes  Raw block attributes.
+	 * @param  string                $default     Type to use when the block
+	 *                                            stores no (or an unknown)
+	 *                                            `layout.type`.
+	 *
+	 * @return string The `is-layout-{type}` class.
+	 */
+	public static function layoutClass( array $attributes, string $default = 'flow' ): string
+	{
+		$type = isset( $attributes[ 'layout' ][ 'type' ] ) && is_string( $attributes[ 'layout' ][ 'type' ] )
+			? trim( $attributes[ 'layout' ][ 'type' ] )
+			: '';
+
+		if ( ! in_array( $type, self::SUPPORTED_TYPES, true ) ) {
+			$type = in_array( $default, self::SUPPORTED_TYPES, true ) ? $default : 'flow';
+		}
+
+		return 'is-layout-' . $type;
+	}
+
+	/**
+	 * Pair each shared layout class with its per-block compound so the
+	 * block-library CSS that targets `wp-block-{slug}-is-layout-{type}`
+	 * matches. Order mirrors upstream: shared class first, compound
+	 * immediately after.
+	 *
+	 * @since 1.6.0
+	 *
+	 * @param  string  $blockSlug       Wrapper slug without the `wp-block-`
+	 *                                  prefix (e.g. `group`, `post-content`).
+	 * @param  string  ...$layoutClasses One or more `is-layout-{type}` classes.
+	 *
+	 * @return array<int, string> Flat class list ready to splice into
+	 *                            `BlockSupports::wrapperAttrs()`.
+	 */
+	public static function pair( string $blockSlug, string ...$layoutClasses ): array
+	{
+		$classes = [];
+
+		foreach ( $layoutClasses as $layoutClass ) {
+			if ( '' === $layoutClass ) {
+				continue;
+			}
+
+			$classes[] = $layoutClass;
+			$classes[] = 'wp-block-' . $blockSlug . '-' . $layoutClass;
+		}
+
+		return $classes;
+	}
+
+	/**
+	 * Shorthand for the common case: resolve the layout class from the
+	 * block's attributes and return it paired with its compound.
+	 *
+	 * @since 1.6.0
+	 *
+	 * @param  array<string, mixed>  $attributes
+	 * @param  string                $blockSlug
+	 * @param  string                $default
+	 *
+	 * @return array<int, string>
+	 */
+	public static function wrapperForBlock( array $attributes, string $blockSlug, string $default = 'flow' ): array
+	{
+		return self::pair( $blockSlug, self::layoutClass( $attributes, $default ) );
+	}
+}

--- a/packages/visual-editor-renderer-blade/tests/Feature/PerBlockLayoutClassesTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Feature/PerBlockLayoutClassesTest.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * Issue #700 — per-block layout classes from the Blade renderer.
+ *
+ * The shipped block-library stylesheet targets the per-block compound
+ * (`wp-block-group-is-layout-constrained`,
+ * `wp-block-post-template-is-layout-flow`, …) rather than the shared
+ * `is-layout-*` modifier alone. These assertions lock in that every
+ * layout-supporting partial emits both.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditorRendererBlade
+ */
+
+declare( strict_types=1 );
+
+/**
+ * @param  array<string, mixed>  $attributes
+ */
+function renderLayoutPartial( string $partial, array $attributes = [] ): string
+{
+	return view( 'visual-editor-renderer-blade::blocks.artisanpack.' . $partial, [
+		'attributes'      => $attributes,
+		'innerBlocksHtml' => '',
+	] )->render();
+}
+
+it( 'pairs the group layout class with its per-block compound', function ( string $type, string $class ) {
+	$html = renderLayoutPartial( 'group', [ 'layout' => [ 'type' => $type ] ] );
+
+	expect( $html )
+		->toContain( 'is-layout-' . $class )
+		->toContain( 'wp-block-group-is-layout-' . $class );
+} )->with( [
+	'constrained' => [ 'constrained', 'constrained' ],
+	'flex'        => [ 'flex', 'flex' ],
+	'grid'        => [ 'grid', 'grid' ],
+	'unset'       => [ '', 'flow' ],
+] );
+
+it( 'keys the row and stack compounds on group, matching their rendered wrapper', function ( string $partial, string $orientation ) {
+	$html = renderLayoutPartial( $partial );
+
+	expect( $html )
+		->toContain( 'wp-block-group is-layout-flex wp-block-group-is-layout-flex ' . $orientation )
+		->not->toContain( 'wp-block-' . $partial . '-is-layout' );
+} )->with( [
+	'row'   => [ 'row', 'is-horizontal' ],
+	'stack' => [ 'stack', 'is-vertical' ],
+] );
+
+it( 'emits the flex layout pair on columns so the flex rules match', function () {
+	$html = renderLayoutPartial( 'columns' );
+
+	expect( $html )->toContain( 'wp-block-columns is-layout-flex wp-block-columns-is-layout-flex' );
+} );
+
+it( 'pairs the buttons flex layout class', function () {
+	$html = renderLayoutPartial( 'buttons' );
+
+	expect( $html )->toContain( 'wp-block-buttons is-layout-flex wp-block-buttons-is-layout-flex' );
+} );
+
+it( 'pairs the post-content layout class resolved from its layout attribute', function () {
+	$html = renderLayoutPartial( 'post-content', [ 'layout' => [ 'type' => 'constrained' ] ] );
+
+	expect( $html )
+		->toContain( 'is-layout-constrained' )
+		->toContain( 'wp-block-post-content-is-layout-constrained' );
+} );
+
+it( 'defaults post-content to the flow pair when no layout is stored', function () {
+	$html = renderLayoutPartial( 'post-content' );
+
+	expect( $html )
+		->toContain( 'is-layout-flow' )
+		->toContain( 'wp-block-post-content-is-layout-flow' );
+} );
+
+it( 'pairs the post-template layout class without pairing the masonry extension', function ( string $layout, string $class ) {
+	$html = view( 'visual-editor-renderer-blade::blocks.artisanpack.post-template', [
+		'attributes'      => [ 'layout' => $layout, 'columns' => 3 ],
+		'innerBlocksHtml' => '',
+	] )->render();
+
+	expect( $html )
+		->toContain( 'wp-block-post-template-is-layout-' . $class )
+		->not->toContain( 'wp-block-post-template-is-layout-masonry' );
+} )->with( [
+	'list'    => [ 'list', 'flow' ],
+	'grid'    => [ 'grid', 'grid' ],
+	'masonry' => [ 'masonry', 'grid' ],
+] );

--- a/packages/visual-editor-renderer-blade/tests/Feature/PostAndSiteContextRenderingTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Feature/PostAndSiteContextRenderingTest.php
@@ -55,7 +55,20 @@ it( 'renders post-content with the resolved HTML body', function () {
 
 	$rendered = $this->stripGlobalStyles( renderTree( $tree ) );
 
-	expect( $this->normalizeHtml( $rendered ) )->toContain( '<div class="entry-content wp-block-post-content"><p>Body</p></div>' );
+	expect( $this->normalizeHtml( $rendered ) )->toContain( '<div class="entry-content wp-block-post-content is-layout-flow wp-block-post-content-is-layout-flow"><p>Body</p></div>' );
+} );
+
+it( 'renders post-content with the layout class pair from its layout attribute (#700)', function () {
+	$tree = [
+		blockNode( 'core/post-content', [
+			'_resolvedContent' => '<p>Body</p>',
+			'layout'           => [ 'type' => 'constrained' ],
+		] ),
+	];
+
+	$rendered = $this->stripGlobalStyles( renderTree( $tree ) );
+
+	expect( $this->normalizeHtml( $rendered ) )->toContain( '<div class="entry-content wp-block-post-content is-layout-constrained wp-block-post-content-is-layout-constrained"><p>Body</p></div>' );
 } );
 
 it( 'renders post-excerpt with a more-text link', function () {

--- a/packages/visual-editor-renderer-blade/tests/Feature/Responsive/ColumnsResponsiveRenderTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Feature/Responsive/ColumnsResponsiveRenderTest.php
@@ -30,7 +30,7 @@ it( 'consolidates spacing overrides into a single <style data-ve-responsive> blo
 	expect( substr_count( $rendered, '<style data-ve-responsive>' ) )->toBe( 1 );
 	expect( $rendered )->toContain( '@media (min-width:768px)' );
 	expect( $rendered )->toContain( '{padding:2rem!important}' );
-	expect( $rendered )->toMatch( '/class="wp-block-columns is-stacked-on-mobile ve-r-[a-f0-9]+"/' );
+	expect( $rendered )->toMatch( '/class="wp-block-columns is-layout-flex wp-block-columns-is-layout-flex is-stacked-on-mobile ve-r-[a-f0-9]+"/' );
 
 	// Style block lives BEFORE the column wrapper, not inside it.
 	$styleEnd      = strpos( $rendered, '</style>' );
@@ -60,7 +60,7 @@ it( 'consolidates columnCount overrides through the same accumulator', function 
 
 	expect( $rendered )->toContain( '<style data-ve-responsive>' );
 	expect( $rendered )->toContain( 'grid-template-columns:repeat(4,minmax(0,1fr))!important' );
-	expect( $rendered )->toMatch( '/class="wp-block-columns is-stacked-on-mobile ve-cols-[a-f0-9]+"/' );
+	expect( $rendered )->toMatch( '/class="wp-block-columns is-layout-flex wp-block-columns-is-layout-flex is-stacked-on-mobile ve-cols-[a-f0-9]+"/' );
 } );
 
 it( 'merges spacing + columnCount + multiple blocks into one style block', function () {

--- a/packages/visual-editor-renderer-blade/tests/Unit/BlockRendererTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Unit/BlockRendererTest.php
@@ -200,7 +200,7 @@ it( 'renders nested inner blocks for a group', function () {
 
 	$html = $this->normalizeHtml( makeRenderer()->render( $tree ) );
 
-	expect( $html )->toContain( '<div class="wp-block-group is-layout-flow">' )
+	expect( $html )->toContain( '<div class="wp-block-group is-layout-flow wp-block-group-is-layout-flow">' )
 		->toContain( '<p class="wp-block-paragraph">Inner</p>' );
 } );
 

--- a/packages/visual-editor-renderer-blade/tests/Unit/LayoutSupportTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Unit/LayoutSupportTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditorRendererBlade\Support\LayoutSupport;
+
+describe( 'LayoutSupport::layoutClass', function (): void {
+	it( 'resolves each supported layout type', function ( string $type ): void {
+		expect( LayoutSupport::layoutClass( [ 'layout' => [ 'type' => $type ] ] ) )
+			->toBe( 'is-layout-' . $type );
+	} )->with( [ 'constrained', 'flex', 'flow', 'grid' ] );
+
+	it( 'trims surrounding whitespace on the stored type', function (): void {
+		expect( LayoutSupport::layoutClass( [ 'layout' => [ 'type' => '  constrained ' ] ] ) )
+			->toBe( 'is-layout-constrained' );
+	} );
+
+	it( 'falls back to flow when no layout is stored', function (): void {
+		expect( LayoutSupport::layoutClass( [] ) )->toBe( 'is-layout-flow' );
+	} );
+
+	it( 'falls back to the caller default when no layout is stored', function (): void {
+		expect( LayoutSupport::layoutClass( [], 'constrained' ) )->toBe( 'is-layout-constrained' );
+	} );
+
+	it( 'refuses to mint a class from an unknown stored type', function ( mixed $type ): void {
+		expect( LayoutSupport::layoutClass( [ 'layout' => [ 'type' => $type ] ] ) )
+			->toBe( 'is-layout-flow' );
+	} )->with( [
+		'unknown string'  => 'sidebar',
+		'injected token'  => 'flow" onload="alert(1)',
+		'non-string type' => 12,
+		'empty string'    => '',
+	] );
+
+	it( 'ignores an unsupported caller default rather than emitting it', function (): void {
+		expect( LayoutSupport::layoutClass( [], 'sidebar' ) )->toBe( 'is-layout-flow' );
+	} );
+} );
+
+describe( 'LayoutSupport::pair', function (): void {
+	it( 'emits the shared modifier followed by the per-block compound', function (): void {
+		expect( LayoutSupport::pair( 'group', 'is-layout-constrained' ) )
+			->toBe( [ 'is-layout-constrained', 'wp-block-group-is-layout-constrained' ] );
+	} );
+
+	it( 'pairs every class it is handed', function (): void {
+		expect( LayoutSupport::pair( 'post-template', 'is-layout-grid', 'is-layout-flow' ) )
+			->toBe( [
+				'is-layout-grid',
+				'wp-block-post-template-is-layout-grid',
+				'is-layout-flow',
+				'wp-block-post-template-is-layout-flow',
+			] );
+	} );
+
+	it( 'skips empty class tokens', function (): void {
+		expect( LayoutSupport::pair( 'group', '' ) )->toBe( [] );
+	} );
+
+	it( 'returns an empty list when handed no classes', function (): void {
+		expect( LayoutSupport::pair( 'group' ) )->toBe( [] );
+	} );
+} );
+
+describe( 'LayoutSupport::wrapperForBlock', function (): void {
+	it( 'resolves the type from attributes and returns the pair', function (): void {
+		expect( LayoutSupport::wrapperForBlock( [ 'layout' => [ 'type' => 'constrained' ] ], 'post-content' ) )
+			->toBe( [ 'is-layout-constrained', 'wp-block-post-content-is-layout-constrained' ] );
+	} );
+
+	it( 'honours the caller default when the block stores no layout', function (): void {
+		expect( LayoutSupport::wrapperForBlock( [], 'group', 'flex' ) )
+			->toBe( [ 'is-layout-flex', 'wp-block-group-is-layout-flex' ] );
+	} );
+} );

--- a/packages/visual-editor-renderer-blade/tests/Unit/ThemeJsonTokensCompilerTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Unit/ThemeJsonTokensCompilerTest.php
@@ -163,6 +163,35 @@ describe( 'Keystone #50 — layout-size custom properties + alignment rules', fu
 			->toContain( '.wp-block-post-content.is-layout-constrained > .alignfull' );
 	} );
 
+	it( 'caps unaligned children of a constrained group at content-size (#700)', function (): void {
+		// A constrained group has to constrain its children — that is
+		// what the layout type means upstream. Keyed on the per-block
+		// compound so host markup that hand-writes the shared
+		// `is-layout-constrained` modifier is not retroactively
+		// constrained.
+		$css = ( new ThemeJsonTokensCompiler() )->compile( [
+			'settings' => [
+				'layout' => [ 'contentSize' => '720px', 'wideSize' => '1200px' ],
+			],
+		] );
+
+		expect( $css )
+			->toContain( '.wp-block-group.wp-block-group-is-layout-constrained > :where(:not(.alignwide):not(.alignfull):not(.alignleft):not(.alignright))' )
+			->toContain( '.wp-block-group.wp-block-group-is-layout-constrained > .alignwide' )
+			->toContain( '.wp-block-group.wp-block-group-is-layout-constrained > .alignfull' );
+	} );
+
+	it( 'omits the constrained-group child cap when no contentSize is configured (#700)', function (): void {
+		$css = ( new ThemeJsonTokensCompiler() )->compile( [
+			'settings' => [ 'layout' => [ 'wideSize' => '1200px' ] ],
+		] );
+
+		expect( $css )
+			->not->toContain( '.wp-block-group.wp-block-group-is-layout-constrained > :where(' )
+			// alignfull stays unconditional, matching the other rule sets.
+			->toContain( '.wp-block-group.wp-block-group-is-layout-constrained > .alignfull' );
+	} );
+
 	it( 'composes root presets with layout rules separated by a blank line', function (): void {
 		$css = ( new ThemeJsonTokensCompiler() )->compile( [
 			'settings' => [


### PR DESCRIPTION
## Description

The Blade renderer emitted only the shared `is-layout-{type}` modifier on layout-supporting wrappers, so the shipped block-library rules that key on the per-block compound (`wp-block-group-is-layout-constrained`, `wp-block-post-template-is-layout-flow`, …) never matched. Fixing the class emission turned out to be necessary but not sufficient — see "Motivation" below.

**Closes:** #700

## Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds new functionality)
- [ ] Enhancement (improves existing functionality)
- [ ] Refactoring (code improvement, no behavior change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Security fix
- [ ] Breaking change (breaks backward compatibility)

## Related Issue

**Issue:** #700

## Motivation and Context

Two defects stacked on top of each other, and the issue only knew about the first.

**1 — missing per-block classes.** Every layout-supporting partial hardcoded its own class tokens; there was no shared layout serializer, and `BlockSupports::compile()` deliberately doesn't walk `layout`. Only `cover` and `gallery` happened to emit the compound. `post-content` never surfaced its stored `layout.type` at all — which left the content-size containment rules keyed on `.wp-block-post-content.is-layout-constrained` permanently unmatched — and `columns` emitted no layout class whatsoever.

**2 — no containment rule for constrained groups.** The issue assumed the bundled CSS already carried `.wp-block-group.wp-block-group-is-layout-constrained > * { max-width: … }` and that only the classes were missing. It doesn't: `style.css:1729` sets only `position: relative` on that compound, and `ThemeJsonTokensCompiler` emitted child containment for `.wp-block-post-content` alone. So after fixing the classes, an `<article class="wp-block-group is-layout-constrained">` still let its title, meta row, and featured image run edge-to-edge while its post body behaved correctly — confirmed in a real app before and after. Upstream, WordPress emits this per-instance as `.wp-container-…-is-layout-constrained > :where(…)`; this PR emits the static equivalent.

Both halves are the same defect from the reporter's point of view, so they ship together.

## Changes Made

- Added `Support\LayoutSupport` — `layoutClass()` resolves `layout.type` against an allowlist (an unknown or non-string value can't mint an arbitrary class token), `pair()` emits the shared modifier plus its `wp-block-{slug}-` compound, `wrapperForBlock()` combines both.
- Wired `group`, `row`, `stack`, `columns`, `buttons`, `post-content`, and `post-template` through it. The compound is keyed on the *rendered wrapper*, not the block name, so `row` / `stack` — which both render `wp-block-group` markup — correctly produce `wp-block-group-is-layout-flex` rather than `wp-block-row-…`.
- `post-content` now honours its stored `layout.type`, defaulting to `flow` (matching `group` and upstream).
- `columns` gained the `is-layout-flex` pair it was missing entirely.
- `post-template` pairs grid/flow; `is-layout-masonry` stays unpaired, being an ArtisanPack extension with no upstream compound.
- `ThemeJsonTokensCompiler::compileLayoutRules()` gained rule set C — the content-size cap for unaligned children of a constrained group, plus `alignwide` / `alignfull` overrides. Keyed on the per-block compound, which is what resolves the "double-constrained" hazard the existing rule-set-A note flagged: only wrappers this renderer emits carry the compound, so host markup that hand-writes the shared modifier keeps its current behavior.
- `cover` and `gallery` already emitted both classes and were left untouched.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (Darwin 27.0.0)
- Browser (if applicable): Safari
- PHP Version: 8.4
- Project Version: visual-editor 1.5.5 (branch `release/1.6`)

**Tests Performed:**
1. Full package suite: 1700 passed, 1 skipped, 4493 assertions.
2. `scripts/verify-renderer-parity.mjs` — clean (152 blocks across all three renderers).
3. Manual verification in a real consuming app against a live post preview: confirmed all wrappers now carry both classes, that the constrained-group containment rules are emitted, and that the post body, title, meta row, and featured image all cap at the theme's 720px `contentSize` instead of running edge-to-edge.

## Accessibility Tests Run

- [ ] Keyboard navigation tested
- [ ] Screen reader tested
- [ ] Color contrast verified
- [ ] ARIA labels checked

**Details:** No interactive surface, ARIA, or color changes — this is layout-class emission and max-width CSS only. The line-length effect is a mild readability *improvement*: body copy now caps at the theme's 720px measure instead of spanning the full viewport.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:**
- `tests/Unit/LayoutSupportTest.php` (new, 18 cases) — type resolution, whitespace trimming, fallback behavior, rejection of unknown / non-string / injection-shaped types, pairing, and empty-token handling.
- `tests/Feature/PerBlockLayoutClassesTest.php` (new, 13 cases) — rendered-output assertions for every touched partial, including that `row` / `stack` do *not* emit `wp-block-row-is-layout-*` and that masonry stays unpaired.
- `tests/Unit/ThemeJsonTokensCompilerTest.php` — two cases for rule set C, covering the `contentSize` gate.
- Updated locked exact-string expectations in `BlockRendererTest`, `PostAndSiteContextRenderingTest`, and `ColumnsResponsiveRenderTest`.

## Documentation

- [x] Inline code documentation added
- [ ] README updated
- [ ] Wiki updated
- [ ] API documentation updated

**Documentation details:** Full PHPDoc on `LayoutSupport` including why the slug is passed in rather than derived from the block name; `compileLayoutRules()`'s docblock updated to explain the compound-keyed scoping. CHANGELOG has entries for both halves.

## Screenshots

Not included — the visual difference is content capping at `contentSize` rather than spanning the viewport.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [ ] Accessibility tests completed
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

---

### Reviewer notes

- **Behavior changes worth a second opinion.** Constrained groups now constrain their children, so wrappers that were previously full-bleed (headers, featured images, full-width sections) will cap at `contentSize` unless marked `alignfull`. That's WP-correct, but it's a visible change for existing content and the right fix for any regression is `align: full` on the block, not reverting the rule. Likewise `post-content` now defaults to `is-layout-flow`, which adds block-gap rhythm to post bodies that previously had none.
- **React/Vue renderers still have the gap.** Their `postContext` / `layout` modules have the same missing compounds, and their `group` implementations are additionally missing the `grid` branch Blade has. Out of scope per the issue's "ships as a patch on renderer-blade", and the React↔Vue parity test still passes since both were left alone — worth a follow-up issue.
- **Linting:** this package ships no php-cs-fixer / phpcs config, so style was matched by hand against the surrounding code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved layout class rendering for groups, columns, buttons, rows, stacks, post content, and templates.
  * Added more reliable constrained-group sizing and alignment behavior.
  * Invalid or missing layout settings now safely fall back to supported defaults.

* **Tests**
  * Added coverage for per-block layout classes, responsive columns, constrained layouts, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->